### PR TITLE
feat(middleware): add AgentRuntime interface and type contracts

### DIFF
--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -1,0 +1,194 @@
+import type { ReplyPayload } from "../auto-reply/types.js";
+
+// ── Agent Runtime ───────────────────────────────────────────────────────
+
+/** Core interface that all CLI runtime implementations (Claude, Gemini, Codex, OpenCode) implement. */
+export interface AgentRuntime {
+  execute(params: AgentExecuteParams): AsyncIterable<AgentEvent>;
+}
+
+/** Input to {@link AgentRuntime.execute}. */
+export type AgentExecuteParams = {
+  /** The user prompt to send to the agent. */
+  prompt: string;
+  /** Resume an existing session (CLI-specific session identifier). */
+  sessionId?: string | undefined;
+  /** MCP server configurations to expose to the agent. */
+  mcpServers?: Record<string, McpServerConfig> | undefined;
+  /** Abort signal for cancelling the execution. */
+  abortSignal?: AbortSignal | undefined;
+  /** Working directory for the CLI subprocess. */
+  workingDirectory?: string | undefined;
+  /** Additional environment variables for the CLI subprocess. */
+  env?: Record<string, string> | undefined;
+};
+
+/** MCP server configuration passed to agent CLI subprocesses. */
+export type McpServerConfig = {
+  command: string;
+  args?: string[] | undefined;
+  env?: Record<string, string> | undefined;
+};
+
+// ── Agent Events ────────────────────────────────────────────────────────
+
+/** Discriminated union of events emitted during CLI subprocess execution. */
+export type AgentEvent =
+  | AgentTextEvent
+  | AgentToolUseEvent
+  | AgentToolResultEvent
+  | AgentErrorEvent
+  | AgentDoneEvent;
+
+export type AgentTextEvent = {
+  type: "text";
+  text: string;
+};
+
+export type AgentToolUseEvent = {
+  type: "tool_use";
+  toolName: string;
+  toolId: string;
+  input: Record<string, unknown>;
+};
+
+export type AgentToolResultEvent = {
+  type: "tool_result";
+  toolId: string;
+  output: string;
+  isError?: boolean | undefined;
+};
+
+export type AgentErrorEvent = {
+  type: "error";
+  message: string;
+  code?: string | undefined;
+};
+
+export type AgentDoneEvent = {
+  type: "done";
+  result: AgentRunResult;
+};
+
+// ── Agent Run Result ────────────────────────────────────────────────────
+
+/** Final CLI output summary produced when execution completes. */
+export type AgentRunResult = {
+  /** Accumulated text output from the agent. */
+  text: string;
+  /** CLI-specific session identifier for resumption. */
+  sessionId: string | undefined;
+  /** Wall-clock duration of the entire run in milliseconds. */
+  durationMs: number;
+  /** Token usage breakdown (if reported by the CLI). */
+  usage: AgentUsage | undefined;
+  /** Whether the run was aborted via the abort signal. */
+  aborted: boolean;
+  /** Estimated total cost in USD (if reported by the CLI). */
+  totalCostUsd?: number | undefined;
+  /** Duration spent in API calls in milliseconds (if reported). */
+  apiDurationMs?: number | undefined;
+  /** Number of agentic turns taken (if reported). */
+  numTurns?: number | undefined;
+  /** Why the agent stopped (e.g., "end_turn", "max_tokens"). */
+  stopReason?: string | undefined;
+  /** Error subtype for classification (e.g., "rate_limit", "context_window"). */
+  errorSubtype?: string | undefined;
+  /** Permission denials encountered during the run. */
+  permissionDenials?: PermissionDenial[] | undefined;
+};
+
+/** Token usage breakdown. */
+export type AgentUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number | undefined;
+  cacheWriteTokens?: number | undefined;
+};
+
+/** A permission denial encountered during an agent run. */
+export type PermissionDenial = {
+  tool: string;
+  reason?: string | undefined;
+};
+
+// ── MCP Side Effects ────────────────────────────────────────────────────
+
+/** Target of a message sent via an MCP tool during the agent run. */
+export type McpMessageTarget = {
+  /** MCP tool name (e.g., "message", "sessions_send", "telegram_send"). */
+  tool: string;
+  /** Channel provider (e.g., "telegram", "discord", "slack"). */
+  provider: string;
+  /** Account identifier within the provider. */
+  accountId?: string | undefined;
+  /** Target identifier (chat ID, channel ID, etc.). */
+  to?: string | undefined;
+};
+
+/** Gateway-side MCP server tracking of side effects during agent execution. */
+export type McpSideEffects = {
+  /** Texts sent via MCP messaging tools. */
+  sentTexts: string[];
+  /** Media URLs sent via MCP messaging tools. */
+  sentMediaUrls: string[];
+  /** Targets of messages sent via MCP messaging tools. */
+  sentTargets: McpMessageTarget[];
+  /** Number of cron jobs added via MCP tools. */
+  cronAdds: number;
+};
+
+// ── Agent Delivery Result ───────────────────────────────────────────────
+
+/**
+ * The three-type delivery contract:
+ * `AgentRunResult` (CLI output) + `McpSideEffects` (gateway tracking) = `AgentDeliveryResult`.
+ *
+ * This is what the delivery pipeline consumers receive.
+ */
+export type AgentDeliveryResult = {
+  /** Reply payloads for delivery to the channel. */
+  payloads: ReplyPayload[];
+  /** CLI subprocess output summary. */
+  run: AgentRunResult;
+  /** Gateway-side MCP server side effects. */
+  mcp: McpSideEffects;
+  /** Top-level error message, if the run failed. */
+  error?: string | undefined;
+};
+
+// ── Channel Message ─────────────────────────────────────────────────────
+
+/** Incoming message from a channel, normalized across providers. */
+export type ChannelMessage = {
+  /** Provider-assigned message identifier. */
+  id: string;
+  /** Message text body. */
+  text: string;
+  /** Sender identifier (provider-specific). */
+  from: string;
+  /** Channel or chat identifier. */
+  channelId: string;
+  /** Channel provider name (e.g., "telegram", "discord", "whatsapp"). */
+  provider: string;
+  /** Message timestamp (epoch milliseconds). */
+  timestamp: number;
+  /** ID of the message being replied to, if any. */
+  replyToId?: string | undefined;
+  /** Media URLs attached to the message. */
+  mediaUrls?: string[] | undefined;
+  /** Provider-specific metadata. */
+  metadata?: Record<string, unknown> | undefined;
+};
+
+// ── Bridge Callbacks ────────────────────────────────────────────────────
+
+/** Streaming callbacks used by ChannelBridge during agent execution. */
+export type BridgeCallbacks = {
+  /** Called when a partial (streaming) text chunk is available. */
+  onPartialReply?: ((payload: ReplyPayload) => Promise<void> | void) | undefined;
+  /** Called when a complete reply block is available. */
+  onBlockReply?: ((payload: ReplyPayload) => Promise<void> | void) | undefined;
+  /** Called when a tool result is available. */
+  onToolResult?: ((payload: ReplyPayload) => Promise<void> | void) | undefined;
+};


### PR DESCRIPTION
## Summary

- Add `src/middleware/types.ts` with foundational type contracts for the middleware layer
- Define `AgentRuntime` interface with `execute(params) -> AsyncIterable<AgentEvent>` contract
- Define `AgentEvent` discriminated union (text, tool_use, tool_result, error, done)
- Define three-type delivery contract: `AgentRunResult` + `McpSideEffects` = `AgentDeliveryResult`
- Add supporting types: `AgentUsage`, `PermissionDenial`, `ChannelMessage`, `BridgeCallbacks`

Closes #3

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes (format + typecheck + lint)
- [ ] CI build and test jobs pass
- Types-only file — no runtime code to test

🤖 Generated with [Claude Code](https://claude.com/claude-code)