### PR TITLE
Implement CLIRuntimeBase abstract class

### DIFF
--- a/src/middleware/cli-runtime-base.test.ts
+++ b/src/middleware/cli-runtime-base.test.ts
@@ -1,0 +1,405 @@
+import EventEmitter from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CLIRuntimeBase } from "./cli-runtime-base.js";
+import type { AgentEvent, AgentExecuteParams } from "./types.js";
+
+// ── Test harness ─────────────────────────────────────────────────────────
+
+/** Minimal mock ChildProcess with controllable stdio streams. */
+function createMockChild() {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdin = new PassThrough();
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: PassThrough;
+    stderr: PassThrough;
+    stdin: PassThrough;
+    pid: number;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  proc.stdout = stdout;
+  proc.stderr = stderr;
+  proc.stdin = stdin;
+  proc.pid = 12345;
+  proc.kill = vi.fn(() => {
+    stdout.end();
+    proc.emit("exit", null, "SIGTERM");
+  });
+  return proc;
+}
+
+/** Concrete test subclass of CLIRuntimeBase. */
+class TestRuntime extends CLIRuntimeBase {
+  protected buildArgs(_params: AgentExecuteParams): string[] {
+    return ["--test"];
+  }
+
+  protected extractEvent(line: string): AgentEvent | null {
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    if (parsed["type"] === "text" && typeof parsed["text"] === "string") {
+      return { type: "text", text: parsed["text"] };
+    }
+    if (parsed["type"] === "error" && typeof parsed["message"] === "string") {
+      return {
+        type: "error",
+        message: parsed["message"],
+        code: typeof parsed["code"] === "string" ? parsed["code"] : undefined,
+      };
+    }
+    return null;
+  }
+
+  protected buildEnv(_params: AgentExecuteParams): Record<string, string> {
+    return { TEST_VAR: "1" };
+  }
+}
+
+/** Collect all events from the async iterable. */
+async function collectEvents(iterable: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+const defaultParams: AgentExecuteParams = {
+  prompt: "hello",
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+let mockChild: ReturnType<typeof createMockChild>;
+let spawnMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockChild = createMockChild();
+  spawnMock = vi.fn().mockReturnValue(mockChild);
+  vi.mock("node:child_process", () => ({
+    spawn: (...args: unknown[]) => (spawnMock as (...a: unknown[]) => unknown)(...args),
+  }));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("CLIRuntimeBase", () => {
+  describe("NDJSON parsing", () => {
+    it("yields events from valid NDJSON lines", async () => {
+      const runtime = new TestRuntime("test-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      // Emit NDJSON lines and close.
+      mockChild.stdout.write('{"type":"text","text":"hello"}\n');
+      mockChild.stdout.write('{"type":"text","text":"world"}\n');
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      const events = await promise;
+
+      expect(events).toEqual([
+        { type: "text", text: "hello" },
+        { type: "text", text: "world" },
+        { type: "done", result: expect.objectContaining({ aborted: false }) },
+      ]);
+    });
+
+    it("skips malformed JSON lines without failing", async () => {
+      const runtime = new TestRuntime("test-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      mockChild.stdout.write("not valid json\n");
+      mockChild.stdout.write('{"type":"text","text":"ok"}\n');
+      mockChild.stdout.write("another bad line\n");
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      const events = await promise;
+
+      expect(events).toEqual([
+        { type: "text", text: "ok" },
+        { type: "done", result: expect.objectContaining({ aborted: false }) },
+      ]);
+    });
+
+    it("skips empty lines", async () => {
+      const runtime = new TestRuntime("test-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      mockChild.stdout.write("\n");
+      mockChild.stdout.write("   \n");
+      mockChild.stdout.write('{"type":"text","text":"x"}\n');
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      const events = await promise;
+
+      expect(events).toEqual([
+        { type: "text", text: "x" },
+        { type: "done", result: expect.objectContaining({ aborted: false }) },
+      ]);
+    });
+
+    it("skips lines where extractEvent returns null", async () => {
+      const runtime = new TestRuntime("test-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      // Valid JSON but extractEvent returns null for unknown types.
+      mockChild.stdout.write('{"type":"unknown","data":123}\n');
+      mockChild.stdout.write('{"type":"text","text":"ok"}\n');
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      const events = await promise;
+
+      expect(events).toEqual([
+        { type: "text", text: "ok" },
+        { type: "done", result: expect.objectContaining({ aborted: false }) },
+      ]);
+    });
+  });
+
+  describe("abort signal propagation", () => {
+    it("kills child process when abort signal fires", async () => {
+      const runtime = new TestRuntime("test-cli");
+      const controller = new AbortController();
+
+      const promise = collectEvents(
+        runtime.execute({ ...defaultParams, abortSignal: controller.signal }),
+      );
+
+      // Abort after some output.
+      mockChild.stdout.write('{"type":"text","text":"before"}\n');
+      controller.abort();
+
+      const events = await promise;
+
+      expect(mockChild.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(events).toContainEqual(expect.objectContaining({ type: "error", code: "ABORTED" }));
+      expect(events[events.length - 1]).toEqual(
+        expect.objectContaining({
+          type: "done",
+          result: expect.objectContaining({ aborted: true }),
+        }),
+      );
+    });
+
+    it("kills immediately if signal already aborted", async () => {
+      const runtime = new TestRuntime("test-cli");
+      const controller = new AbortController();
+      controller.abort();
+
+      const promise = collectEvents(
+        runtime.execute({ ...defaultParams, abortSignal: controller.signal }),
+      );
+
+      const events = await promise;
+
+      expect(mockChild.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(events).toContainEqual(expect.objectContaining({ type: "error", code: "ABORTED" }));
+    });
+  });
+
+  describe("watchdog timer", () => {
+    it("kills child process after inactivity timeout", async () => {
+      const runtime = new TestRuntime("test-cli", 1000);
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      // Advance past the watchdog timeout with no output.
+      await vi.advanceTimersByTimeAsync(1001);
+
+      const events = await promise;
+
+      expect(mockChild.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: "error", code: "WATCHDOG_TIMEOUT" }),
+      );
+    });
+
+    it("resets on each NDJSON line", async () => {
+      const runtime = new TestRuntime("test-cli", 1000);
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      // Emit a line at 800ms — should reset the watchdog.
+      await vi.advanceTimersByTimeAsync(800);
+      mockChild.stdout.write('{"type":"text","text":"alive"}\n');
+
+      // Advance another 800ms (total 1600ms, but only 800ms since last line).
+      await vi.advanceTimersByTimeAsync(800);
+      // Watchdog should NOT have fired yet.
+      expect(mockChild.kill).not.toHaveBeenCalled();
+
+      // Now advance past the remaining 200ms of the watchdog.
+      await vi.advanceTimersByTimeAsync(201);
+
+      const events = await promise;
+
+      // We should have the text event, then the watchdog error, then done.
+      expect(events[0]).toEqual({ type: "text", text: "alive" });
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: "error", code: "WATCHDOG_TIMEOUT" }),
+      );
+    });
+  });
+
+  describe("stdin prompt delivery", () => {
+    it("writes long prompts to stdin", async () => {
+      const runtime = new TestRuntime("test-cli");
+      const longPrompt = "x".repeat(10_001);
+
+      const stdinChunks: string[] = [];
+      let stdinEnded = false;
+      mockChild.stdin.on("data", (chunk: Buffer) => {
+        stdinChunks.push(chunk.toString());
+      });
+      mockChild.stdin.on("end", () => {
+        stdinEnded = true;
+      });
+
+      const promise = collectEvents(runtime.execute({ ...defaultParams, prompt: longPrompt }));
+
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      await promise;
+
+      expect(stdinChunks.join("")).toBe(longPrompt);
+      expect(stdinEnded).toBe(true);
+    });
+
+    it("does not write short prompts to stdin", async () => {
+      const runtime = new TestRuntime("test-cli");
+      const shortPrompt = "x".repeat(9_999);
+
+      const stdinSpy = vi.spyOn(mockChild.stdin, "write");
+
+      const promise = collectEvents(runtime.execute({ ...defaultParams, prompt: shortPrompt }));
+
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      await promise;
+
+      expect(stdinSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("subprocess spawning", () => {
+    it("passes command and args to spawn", async () => {
+      const runtime = new TestRuntime("my-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      await promise;
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        "my-cli",
+        ["--test"],
+        expect.objectContaining({
+          stdio: ["pipe", "pipe", "pipe"],
+        }),
+      );
+    });
+
+    it("sets working directory from params", async () => {
+      const runtime = new TestRuntime("my-cli");
+
+      const promise = collectEvents(
+        runtime.execute({ ...defaultParams, workingDirectory: "/some/dir" }),
+      );
+
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      await promise;
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        "my-cli",
+        expect.any(Array),
+        expect.objectContaining({ cwd: "/some/dir" }),
+      );
+    });
+
+    it("merges buildEnv and params.env into spawn environment", async () => {
+      const runtime = new TestRuntime("my-cli");
+
+      const promise = collectEvents(runtime.execute({ ...defaultParams, env: { EXTRA: "yes" } }));
+
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      await promise;
+
+      const spawnEnv = spawnMock.mock.calls[0]?.[2]?.env as Record<string, string>;
+      expect(spawnEnv).toMatchObject({ TEST_VAR: "1", EXTRA: "yes" });
+    });
+  });
+
+  describe("stderr capture", () => {
+    it("captures stderr without failing", async () => {
+      const runtime = new TestRuntime("test-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      mockChild.stderr.write("some warning\n");
+      mockChild.stderr.write("another warning\n");
+      mockChild.stdout.write('{"type":"text","text":"ok"}\n');
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      const events = await promise;
+
+      // Stderr should not produce error events — it's just captured.
+      const errorEvents = events.filter((e) => e.type === "error");
+      expect(errorEvents).toHaveLength(0);
+      expect(events[0]).toEqual({ type: "text", text: "ok" });
+    });
+  });
+
+  describe("done event", () => {
+    it("includes duration in result", async () => {
+      const runtime = new TestRuntime("test-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      // Advance time to simulate duration.
+      await vi.advanceTimersByTimeAsync(500);
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      const events = await promise;
+      const done = events.find((e) => e.type === "done");
+
+      expect(done).toBeDefined();
+      expect(done!.type === "done" && done!.result.durationMs).toBeGreaterThanOrEqual(500);
+    });
+
+    it("always emits done as the final event", async () => {
+      const runtime = new TestRuntime("test-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      mockChild.stdout.write('{"type":"text","text":"a"}\n');
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      const events = await promise;
+      const last = events[events.length - 1];
+
+      expect(last.type).toBe("done");
+    });
+  });
+});

--- a/src/middleware/cli-runtime-base.ts
+++ b/src/middleware/cli-runtime-base.ts
@@ -1,0 +1,202 @@
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import type {
+  AgentDoneEvent,
+  AgentErrorEvent,
+  AgentEvent,
+  AgentExecuteParams,
+  AgentRunResult,
+  AgentRuntime,
+} from "./types.js";
+
+/**
+ * Abstract base class encapsulating shared subprocess machinery for CLI-based agent runtimes.
+ *
+ * Concrete runtimes (Claude, Gemini, Codex, OpenCode) extend this and implement only
+ * the CLI-specific parts: argument construction, event extraction, and environment setup.
+ */
+export abstract class CLIRuntimeBase implements AgentRuntime {
+  /** Threshold above which prompts are delivered via stdin instead of CLI argument. */
+  private static readonly STDIN_PROMPT_THRESHOLD = 10_000;
+
+  constructor(
+    /** CLI command name (e.g., "claude", "gemini", "codex", "opencode"). */
+    protected readonly command: string,
+    /** Subprocess timeout in milliseconds (default: 5 minutes). */
+    protected readonly timeoutMs: number = 300_000,
+  ) {}
+
+  /** Construct CLI-specific command-line arguments. */
+  protected abstract buildArgs(params: AgentExecuteParams): string[];
+
+  /** Parse a single NDJSON line into an AgentEvent (or null to skip). */
+  protected abstract extractEvent(line: string): AgentEvent | null;
+
+  /** Construct provider-specific environment variables. */
+  protected abstract buildEnv(params: AgentExecuteParams): Record<string, string>;
+
+  /** Whether this CLI accepts prompts via stdin. Subclasses may override. */
+  protected get supportsStdinPrompt(): boolean {
+    return true;
+  }
+
+  async *execute(params: AgentExecuteParams): AsyncIterable<AgentEvent> {
+    const args = this.buildArgs(params);
+    const env = { ...process.env, ...this.buildEnv(params), ...params.env };
+    const child = spawn(this.command, args, {
+      cwd: params.workingDirectory,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const startMs = Date.now();
+    const stderrChunks: string[] = [];
+    let aborted = false;
+
+    // ── Watchdog timer ───────────────────────────────────────────────
+    let watchdogTimer: ReturnType<typeof setTimeout> | undefined;
+    let watchdogFired = false;
+
+    const resetWatchdog = () => {
+      if (watchdogTimer !== undefined) {
+        clearTimeout(watchdogTimer);
+      }
+      watchdogTimer = setTimeout(() => {
+        watchdogFired = true;
+        child.kill("SIGTERM");
+      }, this.timeoutMs);
+    };
+    resetWatchdog();
+
+    // ── Stderr capture ───────────────────────────────────────────────
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderrChunks.push(chunk.toString());
+    });
+
+    // ── NDJSON stdout parsing ────────────────────────────────────────
+    const rl = createInterface({ input: child.stdout });
+
+    // Buffer events from readline so the async generator can yield them.
+    const eventQueue: (AgentEvent | null)[] = [];
+    let resolveNext: (() => void) | undefined;
+    let streamDone = false;
+
+    const enqueue = (event: AgentEvent | null) => {
+      eventQueue.push(event);
+      resolveNext?.();
+    };
+
+    rl.on("line", (line) => {
+      resetWatchdog();
+      if (!line.trim()) {
+        return;
+      }
+
+      try {
+        JSON.parse(line);
+      } catch {
+        // Malformed line — skip (not fatal).
+        return;
+      }
+
+      const event = this.extractEvent(line);
+      if (event) {
+        enqueue(event);
+      }
+    });
+
+    rl.on("close", () => {
+      streamDone = true;
+      enqueue(null);
+    });
+
+    // ── Wait for subprocess exit (in parallel with event yielding) ───
+    const exitPromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+      (resolve) => {
+        child.on("exit", (code, signal) => {
+          resolve({ code, signal });
+        });
+      },
+    );
+
+    // ── Stdin prompt delivery ────────────────────────────────────────
+    if (
+      this.supportsStdinPrompt &&
+      params.prompt.length > CLIRuntimeBase.STDIN_PROMPT_THRESHOLD &&
+      child.stdin
+    ) {
+      child.stdin.write(params.prompt);
+      child.stdin.end();
+    }
+
+    // ── Abort signal wiring (after event infrastructure is ready) ────
+    const onAbort = () => {
+      aborted = true;
+      child.kill("SIGTERM");
+    };
+    if (params.abortSignal) {
+      if (params.abortSignal.aborted) {
+        aborted = true;
+        child.kill("SIGTERM");
+      } else {
+        params.abortSignal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
+    // ── Yield events as they arrive ──────────────────────────────────
+    try {
+      while (!streamDone) {
+        if (eventQueue.length === 0) {
+          await new Promise<void>((resolve) => {
+            resolveNext = resolve;
+          });
+        }
+
+        while (eventQueue.length > 0) {
+          const event = eventQueue.shift();
+          if (event === null || event === undefined) {
+            // Sentinel or empty — stdout closed.
+            break;
+          }
+          yield event;
+        }
+      }
+    } finally {
+      if (watchdogTimer !== undefined) {
+        clearTimeout(watchdogTimer);
+      }
+      params.abortSignal?.removeEventListener("abort", onAbort);
+    }
+
+    // ── Wait for process to fully exit ───────────────────────────────
+    await exitPromise;
+    const durationMs = Date.now() - startMs;
+
+    // ── Emit terminal events ─────────────────────────────────────────
+    if (watchdogFired) {
+      yield {
+        type: "error",
+        message: `Watchdog timeout: no output for ${this.timeoutMs}ms`,
+        code: "WATCHDOG_TIMEOUT",
+      } satisfies AgentErrorEvent;
+    }
+
+    if (aborted) {
+      yield {
+        type: "error",
+        message: "Execution aborted",
+        code: "ABORTED",
+      } satisfies AgentErrorEvent;
+    }
+
+    const result: AgentRunResult = {
+      text: "",
+      sessionId: undefined,
+      durationMs,
+      usage: undefined,
+      aborted,
+    };
+
+    yield { type: "done", result } satisfies AgentDoneEvent;
+  }
+}


### PR DESCRIPTION
## Summary

- Implements `CLIRuntimeBase` abstract class in `src/middleware/cli-runtime-base.ts` (~200 lines)
- Implements `AgentRuntime` interface with an async generator `execute()` method
- Provides shared subprocess machinery: NDJSON parsing, watchdog timer, abort signal propagation, stderr capture, stdin prompt delivery for long prompts (>10K chars)
- Defines three abstract methods for concrete runtimes: `buildArgs()`, `extractEvent()`, `buildEnv()`
- Adds 16 unit tests covering all acceptance criteria in `src/middleware/cli-runtime-base.test.ts`

Closes #5

## Test plan

- [x] NDJSON parsing: valid lines, malformed lines, empty lines, null extractEvent results
- [x] Abort signal: fires mid-execution, already-aborted signal
- [x] Watchdog timer: kills on inactivity, resets on output
- [x] Stdin prompt delivery: long prompts written to stdin, short prompts not written
- [x] Subprocess spawning: command/args, working directory, environment merging
- [x] Stderr capture: captured without producing error events
- [x] Done event: includes duration, always emitted last
- [x] `pnpm check` passes (format + typecheck + lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)