### PR TITLE
fix(test): add missing setSessionRuntimeModel mock

### DIFF
--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -112,6 +112,7 @@ vi.mock("../../cli/outbound-send-deps.js", () => ({
 vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
+  setSessionRuntimeModel: vi.fn().mockReturnValue(true),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
 }));
 


### PR DESCRIPTION
## Summary
- Upstream commit `177386e` added `setSessionRuntimeModel` to `src/cron/isolated-agent/run.ts` but didn't update the test mock in `run.skill-filter.test.ts`
- All 8 skill-filter tests were failing with: `No "setSessionRuntimeModel" export is defined on the "../../config/sessions.js" mock`
- Added the missing mock entry to unblock CI

## Test plan
- [x] All 8 skill-filter tests now pass locally
- [x] All 28 tests in `src/cron/isolated-agent/` pass
- [x] Format, typecheck, and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)