### PR TITLE
feat(middleware): implement GeminiCliRuntime concrete class

### DIFF
--- a/src/middleware/runtimes/gemini.test.ts
+++ b/src/middleware/runtimes/gemini.test.ts
@@ -1,0 +1,538 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AgentDoneEvent, AgentEvent, AgentExecuteParams, AgentRunResult } from "../types.js";
+import { GeminiCliRuntime, GeminiMcpConfigManager } from "./gemini.js";
+
+// ── Test helper: expose protected methods ───────────────────────────────
+
+class TestableGeminiCliRuntime extends GeminiCliRuntime {
+  public testBuildArgs(params: AgentExecuteParams): string[] {
+    return this.buildArgs(params);
+  }
+
+  public testExtractEvent(line: string): AgentEvent | null {
+    return this.extractEvent(line);
+  }
+
+  public testBuildEnv(params: AgentExecuteParams): Record<string, string> {
+    return this.buildEnv(params);
+  }
+
+  public get testSupportsStdinPrompt(): boolean {
+    return this.supportsStdinPrompt;
+  }
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+function makeParams(overrides: Partial<AgentExecuteParams> = {}): AgentExecuteParams {
+  return {
+    prompt: "Hello, Gemini!",
+    ...overrides,
+  };
+}
+
+function makeDoneResult(overrides: Partial<AgentRunResult> = {}): AgentRunResult {
+  return {
+    text: "",
+    sessionId: undefined,
+    durationMs: 100,
+    usage: undefined,
+    aborted: false,
+    ...overrides,
+  };
+}
+
+function geminiEvent(type: string, fields: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    type,
+    timestamp: "2026-01-15T10:00:00Z",
+    ...fields,
+  });
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("GeminiCliRuntime", () => {
+  let runtime: TestableGeminiCliRuntime;
+
+  beforeEach(() => {
+    runtime = new TestableGeminiCliRuntime();
+  });
+
+  // ── supportsStdinPrompt ─────────────────────────────────────────────
+
+  describe("supportsStdinPrompt", () => {
+    it("returns false", () => {
+      expect(runtime.testSupportsStdinPrompt).toBe(false);
+    });
+  });
+
+  // ── buildArgs ─────────────────────────────────────────────────────────
+
+  describe("buildArgs", () => {
+    it("produces base flags with prompt via -p flag", () => {
+      const args = runtime.testBuildArgs(makeParams());
+      expect(args).toEqual(["--output-format", "stream-json", "-p", "Hello, Gemini!"]);
+    });
+
+    it("adds -r when sessionId is provided", () => {
+      const args = runtime.testBuildArgs(makeParams({ sessionId: "sess-123" }));
+      expect(args).toContain("-r");
+      expect(args).toContain("sess-123");
+      expect(args.indexOf("-r")).toBeLessThan(args.indexOf("sess-123"));
+    });
+
+    it("does not add -r when sessionId is absent", () => {
+      const args = runtime.testBuildArgs(makeParams());
+      expect(args).not.toContain("-r");
+    });
+
+    it("delivers prompt via -p flag, not positional", () => {
+      const args = runtime.testBuildArgs(makeParams({ prompt: "test prompt" }));
+      const pIdx = args.indexOf("-p");
+      expect(pIdx).toBeGreaterThan(-1);
+      expect(args[pIdx + 1]).toBe("test prompt");
+    });
+
+    it("combines all flags: session + prompt", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          sessionId: "sess-456",
+        }),
+      );
+
+      expect(args).toContain("--output-format");
+      expect(args).toContain("stream-json");
+      expect(args).toContain("-p");
+      expect(args).toContain("Hello, Gemini!");
+      expect(args).toContain("-r");
+      expect(args).toContain("sess-456");
+    });
+
+    it("does not include --verbose flag", () => {
+      const args = runtime.testBuildArgs(makeParams());
+      expect(args).not.toContain("--verbose");
+    });
+
+    it("does not include --mcp-config flag (MCP handled via settings file)", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          mcpServers: { s1: { command: "node" } },
+        }),
+      );
+      expect(args).not.toContain("--mcp-config");
+    });
+  });
+
+  // ── extractEvent ──────────────────────────────────────────────────────
+
+  describe("extractEvent", () => {
+    it("captures session_id from init event and returns null", () => {
+      const event = runtime.testExtractEvent(geminiEvent("init", { session_id: "gemini-sess-1" }));
+      expect(event).toBeNull();
+    });
+
+    it("maps assistant delta message to AgentTextEvent", () => {
+      const event = runtime.testExtractEvent(
+        geminiEvent("message", {
+          delta: true,
+          role: "assistant",
+          content: "Hello there!",
+        }),
+      );
+      expect(event).toEqual({ type: "text", text: "Hello there!" });
+    });
+
+    it("skips non-delta message (final echo)", () => {
+      const event = runtime.testExtractEvent(
+        geminiEvent("message", {
+          delta: false,
+          role: "assistant",
+          content: "Full response",
+        }),
+      );
+      expect(event).toBeNull();
+    });
+
+    it("skips user role message", () => {
+      const event = runtime.testExtractEvent(
+        geminiEvent("message", {
+          delta: true,
+          role: "user",
+          content: "User message",
+        }),
+      );
+      expect(event).toBeNull();
+    });
+
+    it("maps tool_use to AgentToolUseEvent", () => {
+      const event = runtime.testExtractEvent(
+        geminiEvent("tool_use", {
+          tool_name: "read_file",
+          tool_id: "tool-1",
+          parameters: { path: "/tmp/foo.txt" },
+        }),
+      );
+      expect(event).toEqual({
+        type: "tool_use",
+        toolName: "read_file",
+        toolId: "tool-1",
+        input: { path: "/tmp/foo.txt" },
+      });
+    });
+
+    it("maps tool_result with success status to AgentToolResultEvent", () => {
+      const event = runtime.testExtractEvent(
+        geminiEvent("tool_result", {
+          tool_id: "tool-1",
+          output: "file contents here",
+          status: "success",
+        }),
+      );
+      expect(event).toEqual({
+        type: "tool_result",
+        toolId: "tool-1",
+        output: "file contents here",
+        isError: false,
+      });
+    });
+
+    it("maps tool_result with error status to AgentToolResultEvent with isError", () => {
+      const event = runtime.testExtractEvent(
+        geminiEvent("tool_result", {
+          tool_id: "tool-2",
+          output: "File not found",
+          status: "error",
+        }),
+      );
+      expect(event).toEqual({
+        type: "tool_result",
+        toolId: "tool-2",
+        output: "File not found",
+        isError: true,
+      });
+    });
+
+    it("maps error to AgentErrorEvent with message and severity as code", () => {
+      const event = runtime.testExtractEvent(
+        geminiEvent("error", {
+          message: "Rate limit exceeded",
+          severity: "fatal",
+        }),
+      );
+      expect(event).toEqual({
+        type: "error",
+        message: "Rate limit exceeded",
+        code: "fatal",
+      });
+    });
+
+    it("stores result stats and returns null", () => {
+      const event = runtime.testExtractEvent(
+        geminiEvent("result", {
+          stats: {
+            total_tokens: 500,
+            input_tokens: 300,
+            output_tokens: 200,
+            cached: 50,
+            duration_ms: 1500,
+            tool_calls: 3,
+          },
+        }),
+      );
+      expect(event).toBeNull();
+    });
+
+    it("skips unknown event types", () => {
+      const event = runtime.testExtractEvent(geminiEvent("unknown_type", { data: "foo" }));
+      expect(event).toBeNull();
+    });
+
+    it("accumulates text across multiple message deltas", () => {
+      runtime.testExtractEvent(
+        geminiEvent("message", { delta: true, role: "assistant", content: "Hello " }),
+      );
+      runtime.testExtractEvent(
+        geminiEvent("message", { delta: true, role: "assistant", content: "World" }),
+      );
+
+      const doneEvent: AgentDoneEvent = { type: "done", result: makeDoneResult() };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+      expect(doneEvent.result.text).toBe("Hello World");
+    });
+
+    it("skips message with missing content", () => {
+      const event = runtime.testExtractEvent(
+        geminiEvent("message", { delta: true, role: "assistant" }),
+      );
+      expect(event).toBeNull();
+    });
+
+    it("handles tool_use with empty parameters", () => {
+      const event = runtime.testExtractEvent(
+        geminiEvent("tool_use", {
+          tool_name: "list_files",
+          tool_id: "tool-3",
+        }),
+      );
+      expect(event).toEqual({
+        type: "tool_use",
+        toolName: "list_files",
+        toolId: "tool-3",
+        input: {},
+      });
+    });
+
+    it("handles error without severity", () => {
+      const event = runtime.testExtractEvent(
+        geminiEvent("error", { message: "Something went wrong" }),
+      );
+      expect(event).toEqual({
+        type: "error",
+        message: "Something went wrong",
+        code: undefined,
+      });
+    });
+  });
+
+  // ── buildEnv ──────────────────────────────────────────────────────────
+
+  describe("buildEnv", () => {
+    it("returns empty record", () => {
+      const env = runtime.testBuildEnv(makeParams());
+      expect(env).toEqual({});
+    });
+
+    it("does not inject auth vars regardless of params", () => {
+      const env = runtime.testBuildEnv(makeParams({ env: { GEMINI_API_KEY: "test-key" } }));
+      expect(env).toEqual({});
+      expect(env).not.toHaveProperty("GEMINI_API_KEY");
+    });
+  });
+
+  // ── done event enrichment ─────────────────────────────────────────────
+
+  describe("done event enrichment", () => {
+    it("enriches done event with accumulated text, session ID, and usage from stats", () => {
+      // init → session ID
+      runtime.testExtractEvent(geminiEvent("init", { session_id: "sess-enrich" }));
+
+      // message deltas → accumulated text
+      runtime.testExtractEvent(
+        geminiEvent("message", { delta: true, role: "assistant", content: "Hello " }),
+      );
+      runtime.testExtractEvent(
+        geminiEvent("message", { delta: true, role: "assistant", content: "World" }),
+      );
+
+      // result → stats
+      runtime.testExtractEvent(
+        geminiEvent("result", {
+          stats: {
+            total_tokens: 500,
+            input_tokens: 300,
+            output_tokens: 200,
+            cached: 50,
+            duration_ms: 2000,
+            tool_calls: 4,
+          },
+        }),
+      );
+
+      const doneEvent: AgentDoneEvent = {
+        type: "done",
+        result: makeDoneResult({ durationMs: 5000 }),
+      };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+
+      expect(doneEvent.result.text).toBe("Hello World");
+      expect(doneEvent.result.sessionId).toBe("sess-enrich");
+      expect(doneEvent.result.usage).toEqual({
+        inputTokens: 300,
+        outputTokens: 200,
+        cacheReadTokens: 50,
+      });
+      expect(doneEvent.result.apiDurationMs).toBe(2000);
+      expect(doneEvent.result.numTurns).toBe(4);
+      expect(doneEvent.result.durationMs).toBe(5000);
+      expect(doneEvent.result.aborted).toBe(false);
+    });
+
+    it("maps duration_ms to apiDurationMs and tool_calls to numTurns", () => {
+      runtime.testExtractEvent(
+        geminiEvent("result", {
+          stats: {
+            input_tokens: 100,
+            output_tokens: 50,
+            cached: 0,
+            duration_ms: 1234,
+            tool_calls: 7,
+          },
+        }),
+      );
+
+      const doneEvent: AgentDoneEvent = { type: "done", result: makeDoneResult() };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+
+      expect(doneEvent.result.apiDurationMs).toBe(1234);
+      expect(doneEvent.result.numTurns).toBe(7);
+    });
+
+    it("handles missing stats gracefully", () => {
+      runtime.testExtractEvent(geminiEvent("init", { session_id: "sess-no-stats" }));
+
+      runtime.testExtractEvent(
+        geminiEvent("message", { delta: true, role: "assistant", content: "response" }),
+      );
+
+      // result without stats
+      runtime.testExtractEvent(geminiEvent("result", {}));
+
+      const doneEvent: AgentDoneEvent = { type: "done", result: makeDoneResult() };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+
+      expect(doneEvent.result.text).toBe("response");
+      expect(doneEvent.result.sessionId).toBe("sess-no-stats");
+      expect(doneEvent.result.usage).toBeUndefined();
+      expect(doneEvent.result.apiDurationMs).toBeUndefined();
+      expect(doneEvent.result.numTurns).toBeUndefined();
+    });
+
+    it("does not include cacheReadTokens when cached is 0", () => {
+      runtime.testExtractEvent(
+        geminiEvent("result", {
+          stats: {
+            input_tokens: 100,
+            output_tokens: 50,
+            cached: 0,
+            duration_ms: 500,
+            tool_calls: 1,
+          },
+        }),
+      );
+
+      const doneEvent: AgentDoneEvent = { type: "done", result: makeDoneResult() };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+
+      expect(doneEvent.result.usage).toEqual({
+        inputTokens: 100,
+        outputTokens: 50,
+      });
+      expect(doneEvent.result.usage).not.toHaveProperty("cacheReadTokens");
+    });
+  });
+
+  // ── MCP config file management ────────────────────────────────────────
+
+  describe("GeminiMcpConfigManager", () => {
+    let testDir: string;
+    let geminiDir: string;
+    let settingsPath: string;
+
+    beforeEach(async () => {
+      testDir = join(
+        tmpdir(),
+        `gemini-mcp-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      );
+      await mkdir(testDir, { recursive: true });
+      geminiDir = join(testDir, ".gemini");
+      settingsPath = join(geminiDir, "settings.json");
+    });
+
+    afterEach(async () => {
+      await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("creates settings file when mcpServers has entries", async () => {
+      const manager = new GeminiMcpConfigManager(testDir, {
+        myServer: { command: "node", args: ["server.js"] },
+      });
+
+      await manager.setup();
+
+      const content = JSON.parse(await readFile(settingsPath, "utf-8"));
+      expect(content).toEqual({
+        mcpServers: {
+          myServer: { command: "node", args: ["server.js"] },
+        },
+      });
+
+      await manager.teardown();
+    });
+
+    it("cleans up created file and directory on teardown", async () => {
+      const manager = new GeminiMcpConfigManager(testDir, {
+        s: { command: "cmd" },
+      });
+
+      await manager.setup();
+
+      // File exists
+      await expect(readFile(settingsPath, "utf-8")).resolves.toBeTruthy();
+
+      await manager.teardown();
+
+      // File should be removed
+      await expect(readFile(settingsPath, "utf-8")).rejects.toThrow();
+    });
+
+    it("merges mcpServers into existing settings and restores on teardown", async () => {
+      // Create existing settings
+      await mkdir(geminiDir, { recursive: true });
+      const originalSettings = { theme: "dark", otherKey: "value" };
+      await writeFile(settingsPath, JSON.stringify(originalSettings), "utf-8");
+
+      const manager = new GeminiMcpConfigManager(testDir, {
+        newServer: { command: "python", args: ["serve.py"] },
+      });
+
+      await manager.setup();
+
+      // Should have merged settings
+      const merged = JSON.parse(await readFile(settingsPath, "utf-8"));
+      expect(merged.theme).toBe("dark");
+      expect(merged.otherKey).toBe("value");
+      expect(merged.mcpServers).toEqual({
+        newServer: { command: "python", args: ["serve.py"] },
+      });
+
+      await manager.teardown();
+
+      // Should restore original
+      const restored = JSON.parse(await readFile(settingsPath, "utf-8"));
+      expect(restored).toEqual(originalSettings);
+    });
+
+    it("writes correct JSON structure with multiple servers", async () => {
+      const manager = new GeminiMcpConfigManager(testDir, {
+        server1: { command: "node", args: ["s1.js"] },
+        server2: { command: "python", args: ["s2.py"], env: { KEY: "val" } },
+      });
+
+      await manager.setup();
+
+      const content = JSON.parse(await readFile(settingsPath, "utf-8"));
+      expect(content).toEqual({
+        mcpServers: {
+          server1: { command: "node", args: ["s1.js"] },
+          server2: { command: "python", args: ["s2.py"], env: { KEY: "val" } },
+        },
+      });
+
+      await manager.teardown();
+    });
+  });
+});

--- a/src/middleware/runtimes/gemini.ts
+++ b/src/middleware/runtimes/gemini.ts
@@ -1,0 +1,312 @@
+import { mkdir, readFile, readdir, rm, rmdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { CLIRuntimeBase } from "../cli-runtime-base.js";
+import type {
+  AgentDoneEvent,
+  AgentErrorEvent,
+  AgentEvent,
+  AgentExecuteParams,
+  AgentTextEvent,
+  AgentToolResultEvent,
+  AgentToolUseEvent,
+  AgentUsage,
+  McpServerConfig,
+} from "../types.js";
+
+/**
+ * Gemini CLI runtime — invokes `gemini --output-format stream-json`
+ * and maps the streaming NDJSON output to {@link AgentEvent} instances.
+ */
+export class GeminiCliRuntime extends CLIRuntimeBase {
+  // ── Per-execution state (reset before each run) ───────────────────────
+
+  private currentSessionId: string | undefined;
+  private accumulatedText = "";
+  private resultStats: GeminiResultStats | undefined;
+
+  constructor() {
+    super("gemini");
+  }
+
+  // ── stdin prompt delivery override ────────────────────────────────────
+
+  protected override get supportsStdinPrompt(): boolean {
+    return false;
+  }
+
+  // ── execute() override: state reset + MCP config + done enrichment ────
+
+  async *execute(params: AgentExecuteParams): AsyncIterable<AgentEvent> {
+    this.resetState();
+
+    const mcpConfigManager =
+      params.mcpServers && Object.keys(params.mcpServers).length > 0
+        ? new GeminiMcpConfigManager(params.workingDirectory, params.mcpServers)
+        : null;
+
+    try {
+      await mcpConfigManager?.setup();
+
+      for await (const event of super.execute(params)) {
+        if (event.type === "done") {
+          this.enrichDoneEvent(event);
+        }
+        yield event;
+      }
+    } finally {
+      await mcpConfigManager?.teardown();
+    }
+  }
+
+  // ── CLIRuntimeBase abstract method implementations ────────────────────
+
+  protected buildArgs(params: AgentExecuteParams): string[] {
+    const args: string[] = ["--output-format", "stream-json", "-p", params.prompt];
+
+    if (params.sessionId) {
+      args.push("-r", params.sessionId);
+    }
+
+    return args;
+  }
+
+  protected extractEvent(line: string): AgentEvent | null {
+    const parsed: unknown = JSON.parse(line);
+    if (!isObject(parsed) || typeof parsed.type !== "string") {
+      return null;
+    }
+
+    switch (parsed.type) {
+      case "init":
+        return this.handleInit(parsed);
+      case "message":
+        return this.handleMessage(parsed);
+      case "tool_use":
+        return this.handleToolUse(parsed);
+      case "tool_result":
+        return this.handleToolResult(parsed);
+      case "error":
+        return this.handleError(parsed);
+      case "result":
+        return this.handleResult(parsed);
+      default:
+        return null;
+    }
+  }
+
+  protected buildEnv(_params: AgentExecuteParams): Record<string, string> {
+    return {};
+  }
+
+  // ── Event handlers ────────────────────────────────────────────────────
+
+  private handleInit(parsed: Record<string, unknown>): null {
+    if (typeof parsed.session_id === "string") {
+      this.currentSessionId = parsed.session_id;
+    }
+    return null;
+  }
+
+  private handleMessage(parsed: Record<string, unknown>): AgentEvent | null {
+    if (parsed.delta !== true || parsed.role !== "assistant") {
+      return null;
+    }
+
+    const content = typeof parsed.content === "string" ? parsed.content : undefined;
+    if (content === undefined) {
+      return null;
+    }
+
+    this.accumulatedText += content;
+    return { type: "text", text: content } satisfies AgentTextEvent;
+  }
+
+  private handleToolUse(parsed: Record<string, unknown>): AgentEvent | null {
+    return {
+      type: "tool_use",
+      toolName: typeof parsed.tool_name === "string" ? parsed.tool_name : "",
+      toolId: typeof parsed.tool_id === "string" ? parsed.tool_id : "",
+      input: isObject(parsed.parameters) ? parsed.parameters : {},
+    } satisfies AgentToolUseEvent;
+  }
+
+  private handleToolResult(parsed: Record<string, unknown>): AgentEvent | null {
+    return {
+      type: "tool_result",
+      toolId: typeof parsed.tool_id === "string" ? parsed.tool_id : "",
+      output: typeof parsed.output === "string" ? parsed.output : "",
+      isError: parsed.status === "error",
+    } satisfies AgentToolResultEvent;
+  }
+
+  private handleError(parsed: Record<string, unknown>): AgentEvent | null {
+    return {
+      type: "error",
+      message: typeof parsed.message === "string" ? parsed.message : "Unknown error",
+      code: typeof parsed.severity === "string" ? parsed.severity : undefined,
+    } satisfies AgentErrorEvent;
+  }
+
+  private handleResult(parsed: Record<string, unknown>): null {
+    if (isObject(parsed.stats)) {
+      this.resultStats = {
+        inputTokens:
+          typeof parsed.stats.input_tokens === "number" ? parsed.stats.input_tokens : undefined,
+        outputTokens:
+          typeof parsed.stats.output_tokens === "number" ? parsed.stats.output_tokens : undefined,
+        cached: typeof parsed.stats.cached === "number" ? parsed.stats.cached : undefined,
+        durationMs:
+          typeof parsed.stats.duration_ms === "number" ? parsed.stats.duration_ms : undefined,
+        toolCalls:
+          typeof parsed.stats.tool_calls === "number" ? parsed.stats.tool_calls : undefined,
+      };
+    }
+    return null;
+  }
+
+  // ── Done event enrichment ─────────────────────────────────────────────
+
+  private enrichDoneEvent(event: AgentDoneEvent): void {
+    const { result } = event;
+
+    result.text = this.accumulatedText;
+    result.sessionId = this.currentSessionId;
+
+    if (this.resultStats) {
+      const usage: AgentUsage = {
+        inputTokens: this.resultStats.inputTokens ?? 0,
+        outputTokens: this.resultStats.outputTokens ?? 0,
+        ...(this.resultStats.cached != null && this.resultStats.cached > 0
+          ? { cacheReadTokens: this.resultStats.cached }
+          : {}),
+      };
+      result.usage = usage;
+
+      if (this.resultStats.durationMs !== undefined) {
+        result.apiDurationMs = this.resultStats.durationMs;
+      }
+      if (this.resultStats.toolCalls !== undefined) {
+        result.numTurns = this.resultStats.toolCalls;
+      }
+    }
+  }
+
+  // ── State reset ───────────────────────────────────────────────────────
+
+  private resetState(): void {
+    this.currentSessionId = undefined;
+    this.accumulatedText = "";
+    this.resultStats = undefined;
+  }
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+type GeminiResultStats = {
+  inputTokens: number | undefined;
+  outputTokens: number | undefined;
+  cached: number | undefined;
+  durationMs: number | undefined;
+  toolCalls: number | undefined;
+};
+
+// ── MCP Config Manager ────────────────────────────────────────────────────
+
+/**
+ * Manages the `.gemini/settings.json` lifecycle for MCP server configuration.
+ *
+ * The Gemini CLI reads MCP config from a fixed settings file hierarchy — there
+ * is no `--mcp-config`, `--settings-dir`, or `--config` CLI flag. Project-level
+ * settings live in `.gemini/settings.json` within the working directory.
+ *
+ * A `GEMINI_CONFIG_DIR` env var was requested (google-gemini/gemini-cli#2815)
+ * but redirected to XDG spec compliance (#1825), which hasn't shipped as of
+ * v0.11.x. Until a flag or env var exists, we use a merge-restore pattern:
+ *
+ * - **Setup**: read existing `.gemini/settings.json` (if any), save a copy,
+ *   merge `mcpServers` into it, write back.
+ * - **Teardown** (always, via `finally`): restore the original file, or remove
+ *   the file/directory we created.
+ */
+export class GeminiMcpConfigManager {
+  private readonly settingsDir: string;
+  private readonly settingsPath: string;
+
+  private originalContent: string | null = null;
+  private createdFile = false;
+  private createdDir = false;
+
+  constructor(
+    workingDirectory: string | undefined,
+    private readonly mcpServers: Record<string, McpServerConfig>,
+  ) {
+    const baseDir = workingDirectory ?? process.cwd();
+    this.settingsDir = join(baseDir, ".gemini");
+    this.settingsPath = join(this.settingsDir, "settings.json");
+  }
+
+  async setup(): Promise<void> {
+    // Ensure .gemini/ directory exists
+    try {
+      await mkdir(this.settingsDir, { recursive: true });
+    } catch {
+      // Directory already exists or cannot be created
+    }
+
+    // Check for existing settings file
+    let existingSettings: Record<string, unknown> | null = null;
+    try {
+      const content = await readFile(this.settingsPath, "utf-8");
+      this.originalContent = content;
+      existingSettings = JSON.parse(content) as Record<string, unknown>;
+    } catch {
+      // File doesn't exist or is invalid — we'll create a new one
+      this.createdFile = true;
+
+      // Check if we created the directory
+      try {
+        const entries = await readdir(this.settingsDir);
+        if (entries.length === 0) {
+          this.createdDir = true;
+        }
+      } catch {
+        // Ignore
+      }
+    }
+
+    // Build merged settings
+    const mergedSettings: Record<string, unknown> = existingSettings ?? {};
+    mergedSettings.mcpServers = this.mcpServers;
+
+    await writeFile(this.settingsPath, JSON.stringify(mergedSettings, null, 2), "utf-8");
+  }
+
+  async teardown(): Promise<void> {
+    try {
+      if (this.originalContent !== null) {
+        // Restore original file
+        await writeFile(this.settingsPath, this.originalContent, "utf-8");
+      } else if (this.createdFile) {
+        // Remove file we created
+        await rm(this.settingsPath, { force: true });
+
+        // Remove directory if we created it
+        if (this.createdDir) {
+          try {
+            await rmdir(this.settingsDir);
+          } catch {
+            // Directory not empty or already removed — ignore
+          }
+        }
+      }
+    } catch {
+      // Best-effort cleanup — don't throw during teardown
+    }
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

- Implements `GeminiCliRuntime` extending `CLIRuntimeBase` — the second concrete runtime, targeting Google's `gemini` CLI (`google-gemini/gemini-cli`)
- Maps all 6 Gemini `stream-json` NDJSON event types (`init`, `message`, `tool_use`, `tool_result`, `error`, `result`) to `AgentEvent` instances
- Manages MCP server config via `.gemini/settings.json` merge-restore lifecycle (no `--mcp-config` CLI flag exists; `GEMINI_CONFIG_DIR` env var requested in google-gemini/gemini-cli#2815 but redirected to XDG compliance #1825, not yet shipped)

## Test plan

- [x] 32 unit tests covering argument construction, event extraction, environment setup, MCP config lifecycle, stdin prompt override, and done event enrichment
- [x] `pnpm check` passes (format + typecheck + lint)
- [x] `pnpm test` passes (861 tests across 97 files)
- [x] `pnpm build` passes

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)