### PR TITLE
feat(middleware): implement CodexCliRuntime concrete class (#12)

### DIFF
--- a/src/middleware/runtimes/codex.test.ts
+++ b/src/middleware/runtimes/codex.test.ts
@@ -1,0 +1,764 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AgentDoneEvent, AgentEvent, AgentExecuteParams, AgentRunResult } from "../types.js";
+import { CodexCliRuntime, CodexMcpConfigManager, serializeMcpServersToToml } from "./codex.js";
+
+// ── Test helper: expose protected methods ───────────────────────────────
+
+class TestableCodexCliRuntime extends CodexCliRuntime {
+  public testBuildArgs(params: AgentExecuteParams): string[] {
+    return this.buildArgs(params);
+  }
+
+  public testExtractEvent(line: string): AgentEvent | null {
+    return this.extractEvent(line);
+  }
+
+  public testBuildEnv(params: AgentExecuteParams): Record<string, string> {
+    return this.buildEnv(params);
+  }
+
+  public get testSupportsStdinPrompt(): boolean {
+    return this.supportsStdinPrompt;
+  }
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+function makeParams(overrides: Partial<AgentExecuteParams> = {}): AgentExecuteParams {
+  return {
+    prompt: "Hello, Codex!",
+    ...overrides,
+  };
+}
+
+function makeDoneResult(overrides: Partial<AgentRunResult> = {}): AgentRunResult {
+  return {
+    text: "",
+    sessionId: undefined,
+    durationMs: 100,
+    usage: undefined,
+    aborted: false,
+    ...overrides,
+  };
+}
+
+function codexEvent(type: string, fields: Record<string, unknown> = {}): string {
+  return JSON.stringify({ type, ...fields });
+}
+
+function itemEvent(
+  eventType: string,
+  itemType: string,
+  itemFields: Record<string, unknown> = {},
+  eventFields: Record<string, unknown> = {},
+): string {
+  return JSON.stringify({
+    type: eventType,
+    item: { type: itemType, ...itemFields },
+    ...eventFields,
+  });
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("CodexCliRuntime", () => {
+  let runtime: TestableCodexCliRuntime;
+
+  beforeEach(() => {
+    runtime = new TestableCodexCliRuntime();
+  });
+
+  // ── supportsStdinPrompt ─────────────────────────────────────────────
+
+  describe("supportsStdinPrompt", () => {
+    it("returns false", () => {
+      expect(runtime.testSupportsStdinPrompt).toBe(false);
+    });
+  });
+
+  // ── buildArgs ─────────────────────────────────────────────────────────
+
+  describe("buildArgs", () => {
+    it("produces exec --json --color never <prompt> for new session", () => {
+      const args = runtime.testBuildArgs(makeParams());
+      expect(args).toEqual(["exec", "--json", "--color", "never", "Hello, Codex!"]);
+    });
+
+    it("produces exec resume <id> --json --color never for session resume", () => {
+      const args = runtime.testBuildArgs(makeParams({ sessionId: "thread-abc-123" }));
+      expect(args).toEqual(["exec", "resume", "thread-abc-123", "--json", "--color", "never"]);
+    });
+
+    it("excludes prompt on session resume", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({ sessionId: "thread-abc-123", prompt: "This should be excluded" }),
+      );
+      expect(args).not.toContain("This should be excluded");
+    });
+
+    it("always starts with exec", () => {
+      const newArgs = runtime.testBuildArgs(makeParams());
+      expect(newArgs[0]).toBe("exec");
+
+      const resumeArgs = runtime.testBuildArgs(makeParams({ sessionId: "sess-1" }));
+      expect(resumeArgs[0]).toBe("exec");
+    });
+
+    it("always includes --color never", () => {
+      const newArgs = runtime.testBuildArgs(makeParams());
+      const colorIdx = newArgs.indexOf("--color");
+      expect(colorIdx).toBeGreaterThan(-1);
+      expect(newArgs[colorIdx + 1]).toBe("never");
+
+      const resumeArgs = runtime.testBuildArgs(makeParams({ sessionId: "s" }));
+      const resumeColorIdx = resumeArgs.indexOf("--color");
+      expect(resumeColorIdx).toBeGreaterThan(-1);
+      expect(resumeArgs[resumeColorIdx + 1]).toBe("never");
+    });
+
+    it("always includes --json", () => {
+      const newArgs = runtime.testBuildArgs(makeParams());
+      expect(newArgs).toContain("--json");
+
+      const resumeArgs = runtime.testBuildArgs(makeParams({ sessionId: "s" }));
+      expect(resumeArgs).toContain("--json");
+    });
+
+    it("does not include --mcp-config flag (MCP handled via config file)", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          mcpServers: { s1: { command: "node" } },
+        }),
+      );
+      expect(args).not.toContain("--mcp-config");
+    });
+  });
+
+  // ── extractEvent ──────────────────────────────────────────────────────
+
+  describe("extractEvent", () => {
+    it("captures thread_id from thread.started and returns null", () => {
+      const event = runtime.testExtractEvent(
+        codexEvent("thread.started", { thread_id: "thread-xyz" }),
+      );
+      expect(event).toBeNull();
+    });
+
+    it("skips turn.started", () => {
+      const event = runtime.testExtractEvent(codexEvent("turn.started"));
+      expect(event).toBeNull();
+    });
+
+    it("maps item.started + command_execution to AgentToolUseEvent", () => {
+      const event = runtime.testExtractEvent(
+        itemEvent("item.started", "command_execution", {
+          id: "cmd-1",
+          command: "ls -la",
+        }),
+      );
+      expect(event).toEqual({
+        type: "tool_use",
+        toolName: "command_execution",
+        toolId: "cmd-1",
+        input: { command: "ls -la" },
+      });
+    });
+
+    it("maps item.started + mcp_tool_call to AgentToolUseEvent with tool name and arguments", () => {
+      const event = runtime.testExtractEvent(
+        itemEvent("item.started", "mcp_tool_call", {
+          id: "mcp-1",
+          name: "read_file",
+          arguments: { path: "/tmp/test.txt" },
+        }),
+      );
+      expect(event).toEqual({
+        type: "tool_use",
+        toolName: "read_file",
+        toolId: "mcp-1",
+        input: { path: "/tmp/test.txt" },
+      });
+    });
+
+    it("skips item.started + agent_message", () => {
+      const event = runtime.testExtractEvent(
+        itemEvent("item.started", "agent_message", { id: "msg-1" }),
+      );
+      expect(event).toBeNull();
+    });
+
+    it("skips item.started + reasoning", () => {
+      const event = runtime.testExtractEvent(itemEvent("item.started", "reasoning", { id: "r-1" }));
+      expect(event).toBeNull();
+    });
+
+    it("maps item.updated + agent_message to AgentTextEvent with delta", () => {
+      // Start a message item to initialize delta tracking
+      runtime.testExtractEvent(itemEvent("item.started", "agent_message", { id: "msg-1" }));
+
+      const event = runtime.testExtractEvent(
+        itemEvent("item.updated", "agent_message", {
+          id: "msg-1",
+          content: [{ type: "output_text", text: "Hello " }],
+        }),
+      );
+      expect(event).toEqual({ type: "text", text: "Hello " });
+    });
+
+    it("computes correct incremental deltas across multiple item.updated events", () => {
+      runtime.testExtractEvent(itemEvent("item.started", "agent_message", { id: "msg-1" }));
+
+      const event1 = runtime.testExtractEvent(
+        itemEvent("item.updated", "agent_message", {
+          id: "msg-1",
+          content: [{ type: "output_text", text: "Hello " }],
+        }),
+      );
+      expect(event1).toEqual({ type: "text", text: "Hello " });
+
+      const event2 = runtime.testExtractEvent(
+        itemEvent("item.updated", "agent_message", {
+          id: "msg-1",
+          content: [{ type: "output_text", text: "Hello World" }],
+        }),
+      );
+      expect(event2).toEqual({ type: "text", text: "World" });
+
+      const event3 = runtime.testExtractEvent(
+        itemEvent("item.updated", "agent_message", {
+          id: "msg-1",
+          content: [{ type: "output_text", text: "Hello World!" }],
+        }),
+      );
+      expect(event3).toEqual({ type: "text", text: "!" });
+    });
+
+    it("skips item.updated for non-agent_message types", () => {
+      const event = runtime.testExtractEvent(
+        itemEvent("item.updated", "command_execution", { id: "cmd-1" }),
+      );
+      expect(event).toBeNull();
+    });
+
+    it("returns null for item.updated with no new delta", () => {
+      runtime.testExtractEvent(itemEvent("item.started", "agent_message", { id: "msg-1" }));
+
+      runtime.testExtractEvent(
+        itemEvent("item.updated", "agent_message", {
+          id: "msg-1",
+          content: [{ type: "output_text", text: "Hello" }],
+        }),
+      );
+
+      // Same text — no delta
+      const event = runtime.testExtractEvent(
+        itemEvent("item.updated", "agent_message", {
+          id: "msg-1",
+          content: [{ type: "output_text", text: "Hello" }],
+        }),
+      );
+      expect(event).toBeNull();
+    });
+
+    it("maps item.completed + agent_message to final delta AgentTextEvent", () => {
+      runtime.testExtractEvent(itemEvent("item.started", "agent_message", { id: "msg-1" }));
+
+      runtime.testExtractEvent(
+        itemEvent("item.updated", "agent_message", {
+          id: "msg-1",
+          content: [{ type: "output_text", text: "Hello" }],
+        }),
+      );
+
+      const event = runtime.testExtractEvent(
+        itemEvent("item.completed", "agent_message", {
+          id: "msg-1",
+          content: [{ type: "output_text", text: "Hello World" }],
+        }),
+      );
+      expect(event).toEqual({ type: "text", text: " World" });
+    });
+
+    it("returns null for item.completed + agent_message with no remaining delta", () => {
+      runtime.testExtractEvent(itemEvent("item.started", "agent_message", { id: "msg-1" }));
+
+      runtime.testExtractEvent(
+        itemEvent("item.updated", "agent_message", {
+          id: "msg-1",
+          content: [{ type: "output_text", text: "Hello" }],
+        }),
+      );
+
+      const event = runtime.testExtractEvent(
+        itemEvent("item.completed", "agent_message", {
+          id: "msg-1",
+          content: [{ type: "output_text", text: "Hello" }],
+        }),
+      );
+      expect(event).toBeNull();
+    });
+
+    it("maps item.completed + command_execution to AgentToolResultEvent", () => {
+      // Start the command first
+      runtime.testExtractEvent(
+        itemEvent("item.started", "command_execution", { id: "cmd-1", command: "ls" }),
+      );
+
+      const event = runtime.testExtractEvent(
+        itemEvent("item.completed", "command_execution", {
+          id: "cmd-1",
+          output: "file1.txt\nfile2.txt",
+          exit_code: 0,
+        }),
+      );
+      expect(event).toEqual({
+        type: "tool_result",
+        toolId: "cmd-1",
+        output: "file1.txt\nfile2.txt",
+        isError: false,
+      });
+    });
+
+    it("marks command_execution as error when exit_code is non-zero", () => {
+      runtime.testExtractEvent(
+        itemEvent("item.started", "command_execution", { id: "cmd-2", command: "false" }),
+      );
+
+      const event = runtime.testExtractEvent(
+        itemEvent("item.completed", "command_execution", {
+          id: "cmd-2",
+          output: "command failed",
+          exit_code: 1,
+        }),
+      );
+      expect(event).toEqual({
+        type: "tool_result",
+        toolId: "cmd-2",
+        output: "command failed",
+        isError: true,
+      });
+    });
+
+    it("maps item.completed + mcp_tool_call to AgentToolResultEvent", () => {
+      runtime.testExtractEvent(
+        itemEvent("item.started", "mcp_tool_call", {
+          id: "mcp-1",
+          name: "read_file",
+          arguments: { path: "/tmp/test.txt" },
+        }),
+      );
+
+      const event = runtime.testExtractEvent(
+        itemEvent("item.completed", "mcp_tool_call", {
+          id: "mcp-1",
+          output: "file contents",
+        }),
+      );
+      expect(event).toEqual({
+        type: "tool_result",
+        toolId: "mcp-1",
+        output: "file contents",
+        isError: false,
+      });
+    });
+
+    it("marks mcp_tool_call as error when error field is present", () => {
+      runtime.testExtractEvent(
+        itemEvent("item.started", "mcp_tool_call", {
+          id: "mcp-2",
+          name: "write_file",
+          arguments: {},
+        }),
+      );
+
+      const event = runtime.testExtractEvent(
+        itemEvent("item.completed", "mcp_tool_call", {
+          id: "mcp-2",
+          output: "",
+          error: "Permission denied",
+        }),
+      );
+      expect(event).toEqual({
+        type: "tool_result",
+        toolId: "mcp-2",
+        output: "",
+        isError: true,
+      });
+    });
+
+    it("maps item.completed + error to AgentErrorEvent", () => {
+      const event = runtime.testExtractEvent(
+        itemEvent("item.completed", "error", {
+          id: "err-1",
+          message: "Rate limit exceeded",
+        }),
+      );
+      expect(event).toEqual({
+        type: "error",
+        message: "Rate limit exceeded",
+      });
+    });
+
+    it("stores usage from turn.completed and returns null", () => {
+      const event = runtime.testExtractEvent(
+        codexEvent("turn.completed", {
+          usage: {
+            input_tokens: 500,
+            output_tokens: 200,
+            cached_input_tokens: 100,
+          },
+        }),
+      );
+      expect(event).toBeNull();
+    });
+
+    it("maps turn.failed to AgentErrorEvent", () => {
+      const event = runtime.testExtractEvent(
+        codexEvent("turn.failed", { message: "Context window exceeded" }),
+      );
+      expect(event).toEqual({
+        type: "error",
+        message: "Context window exceeded",
+        code: "turn_failed",
+      });
+    });
+
+    it("maps stream-level error to AgentErrorEvent", () => {
+      const event = runtime.testExtractEvent(codexEvent("error", { message: "Connection lost" }));
+      expect(event).toEqual({
+        type: "error",
+        message: "Connection lost",
+      });
+    });
+
+    it("skips unknown event types", () => {
+      const event = runtime.testExtractEvent(codexEvent("unknown_type", { data: "foo" }));
+      expect(event).toBeNull();
+    });
+
+    it("generates tool IDs when item.id is missing", () => {
+      const event = runtime.testExtractEvent(
+        itemEvent("item.started", "command_execution", { command: "pwd" }),
+      );
+      expect(event).not.toBeNull();
+      expect((event as { toolId: string }).toolId).toMatch(/^codex-item-\d+$/);
+    });
+
+    it("skips item.completed for file_change", () => {
+      const event = runtime.testExtractEvent(
+        itemEvent("item.completed", "file_change", { id: "fc-1" }),
+      );
+      expect(event).toBeNull();
+    });
+
+    it("handles agent_message with text field fallback", () => {
+      runtime.testExtractEvent(itemEvent("item.started", "agent_message", { id: "msg-1" }));
+
+      const event = runtime.testExtractEvent(
+        itemEvent("item.updated", "agent_message", {
+          id: "msg-1",
+          text: "Fallback text",
+        }),
+      );
+      expect(event).toEqual({ type: "text", text: "Fallback text" });
+    });
+  });
+
+  // ── buildEnv ──────────────────────────────────────────────────────────
+
+  describe("buildEnv", () => {
+    it("strips ANTHROPIC_API_KEY for cross-contamination prevention", () => {
+      const env = runtime.testBuildEnv(makeParams());
+      expect(env).toEqual({ ANTHROPIC_API_KEY: "" });
+    });
+
+    it("does not inject OPENAI_API_KEY (caller responsibility)", () => {
+      const env = runtime.testBuildEnv(makeParams({ env: { OPENAI_API_KEY: "sk-test" } }));
+      expect(env).not.toHaveProperty("OPENAI_API_KEY");
+      expect(env).toEqual({ ANTHROPIC_API_KEY: "" });
+    });
+
+    it("returns same env regardless of params content", () => {
+      const env1 = runtime.testBuildEnv(makeParams());
+      const env2 = runtime.testBuildEnv(makeParams({ sessionId: "s", prompt: "p" }));
+      expect(env1).toEqual(env2);
+    });
+  });
+
+  // ── done event enrichment ─────────────────────────────────────────────
+
+  describe("done event enrichment", () => {
+    it("enriches done event with accumulated text, session ID, and usage", () => {
+      // thread.started → session ID
+      runtime.testExtractEvent(codexEvent("thread.started", { thread_id: "thread-enrich" }));
+
+      // Message deltas → accumulated text
+      runtime.testExtractEvent(itemEvent("item.started", "agent_message", { id: "msg-1" }));
+      runtime.testExtractEvent(
+        itemEvent("item.updated", "agent_message", {
+          id: "msg-1",
+          content: [{ type: "output_text", text: "Hello " }],
+        }),
+      );
+      runtime.testExtractEvent(
+        itemEvent("item.completed", "agent_message", {
+          id: "msg-1",
+          content: [{ type: "output_text", text: "Hello World" }],
+        }),
+      );
+
+      // turn.completed → usage
+      runtime.testExtractEvent(
+        codexEvent("turn.completed", {
+          usage: {
+            input_tokens: 300,
+            output_tokens: 200,
+            cached_input_tokens: 50,
+          },
+        }),
+      );
+
+      const doneEvent: AgentDoneEvent = {
+        type: "done",
+        result: makeDoneResult({ durationMs: 5000 }),
+      };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+
+      expect(doneEvent.result.text).toBe("Hello World");
+      expect(doneEvent.result.sessionId).toBe("thread-enrich");
+      expect(doneEvent.result.usage).toEqual({
+        inputTokens: 300,
+        outputTokens: 200,
+        cacheReadTokens: 50,
+      });
+      expect(doneEvent.result.durationMs).toBe(5000);
+      expect(doneEvent.result.aborted).toBe(false);
+    });
+
+    it("handles missing usage gracefully", () => {
+      runtime.testExtractEvent(codexEvent("thread.started", { thread_id: "thread-no-usage" }));
+
+      runtime.testExtractEvent(itemEvent("item.started", "agent_message", { id: "msg-1" }));
+      runtime.testExtractEvent(
+        itemEvent("item.updated", "agent_message", {
+          id: "msg-1",
+          content: [{ type: "output_text", text: "response" }],
+        }),
+      );
+
+      const doneEvent: AgentDoneEvent = { type: "done", result: makeDoneResult() };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+
+      expect(doneEvent.result.text).toBe("response");
+      expect(doneEvent.result.sessionId).toBe("thread-no-usage");
+      expect(doneEvent.result.usage).toBeUndefined();
+    });
+
+    it("uses last turn's usage when multiple turns occur", () => {
+      // First turn
+      runtime.testExtractEvent(
+        codexEvent("turn.completed", {
+          usage: { input_tokens: 100, output_tokens: 50 },
+        }),
+      );
+
+      // Second turn (should override)
+      runtime.testExtractEvent(
+        codexEvent("turn.completed", {
+          usage: { input_tokens: 400, output_tokens: 250, cached_input_tokens: 75 },
+        }),
+      );
+
+      const doneEvent: AgentDoneEvent = { type: "done", result: makeDoneResult() };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+
+      expect(doneEvent.result.usage).toEqual({
+        inputTokens: 400,
+        outputTokens: 250,
+        cacheReadTokens: 75,
+      });
+    });
+
+    it("does not include cacheReadTokens when cached_input_tokens is 0", () => {
+      runtime.testExtractEvent(
+        codexEvent("turn.completed", {
+          usage: { input_tokens: 100, output_tokens: 50, cached_input_tokens: 0 },
+        }),
+      );
+
+      const doneEvent: AgentDoneEvent = { type: "done", result: makeDoneResult() };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+
+      expect(doneEvent.result.usage).toEqual({
+        inputTokens: 100,
+        outputTokens: 50,
+      });
+      expect(doneEvent.result.usage).not.toHaveProperty("cacheReadTokens");
+    });
+  });
+
+  // ── TOML serialization ────────────────────────────────────────────────
+
+  describe("serializeMcpServersToToml", () => {
+    it("serializes a single server with command only", () => {
+      const toml = serializeMcpServersToToml({
+        myServer: { command: "node" },
+      });
+
+      expect(toml).toBe(`[mcp_servers.myServer]\ntype = "stdio"\ncommand = ["node"]\n`);
+    });
+
+    it("serializes command with args as array", () => {
+      const toml = serializeMcpServersToToml({
+        myServer: { command: "node", args: ["server.js", "--port", "3000"] },
+      });
+
+      expect(toml).toContain(`command = ["node", "server.js", "--port", "3000"]`);
+    });
+
+    it("serializes env vars as sub-table", () => {
+      const toml = serializeMcpServersToToml({
+        myServer: {
+          command: "node",
+          args: ["server.js"],
+          env: { API_KEY: "secret", DEBUG: "true" },
+        },
+      });
+
+      expect(toml).toContain("[mcp_servers.myServer.env]");
+      expect(toml).toContain(`API_KEY = "secret"`);
+      expect(toml).toContain(`DEBUG = "true"`);
+    });
+
+    it("serializes multiple servers", () => {
+      const toml = serializeMcpServersToToml({
+        server1: { command: "node", args: ["s1.js"] },
+        server2: { command: "python", args: ["s2.py"] },
+      });
+
+      expect(toml).toContain("[mcp_servers.server1]");
+      expect(toml).toContain("[mcp_servers.server2]");
+      expect(toml).toContain(`command = ["node", "s1.js"]`);
+      expect(toml).toContain(`command = ["python", "s2.py"]`);
+    });
+
+    it("escapes special characters in TOML strings", () => {
+      const toml = serializeMcpServersToToml({
+        s: { command: "node", args: ['path with "quotes"', "path\\with\\backslashes"] },
+      });
+
+      expect(toml).toContain(`"path with \\"quotes\\""`);
+      expect(toml).toContain(`"path\\\\with\\\\backslashes"`);
+    });
+  });
+
+  // ── MCP config file management ────────────────────────────────────────
+
+  describe("CodexMcpConfigManager", () => {
+    let testDir: string;
+    let codexDir: string;
+    let configPath: string;
+
+    beforeEach(async () => {
+      testDir = join(
+        tmpdir(),
+        `codex-mcp-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      );
+      await mkdir(testDir, { recursive: true });
+      codexDir = join(testDir, "codex-config");
+      configPath = join(codexDir, "config.toml");
+    });
+
+    afterEach(async () => {
+      await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("creates TOML config file when mcpServers has entries", async () => {
+      const manager = new CodexMcpConfigManager(
+        { myServer: { command: "node", args: ["server.js"] } },
+        codexDir,
+      );
+
+      await manager.setup();
+
+      const content = await readFile(configPath, "utf-8");
+      expect(content).toContain("[mcp_servers.myServer]");
+      expect(content).toContain('type = "stdio"');
+      expect(content).toContain('command = ["node", "server.js"]');
+
+      await manager.teardown();
+    });
+
+    it("cleans up created file on teardown", async () => {
+      const manager = new CodexMcpConfigManager({ s: { command: "cmd" } }, codexDir);
+
+      await manager.setup();
+
+      // File exists
+      await expect(readFile(configPath, "utf-8")).resolves.toBeTruthy();
+
+      await manager.teardown();
+
+      // File should be removed
+      await expect(readFile(configPath, "utf-8")).rejects.toThrow();
+    });
+
+    it("preserves existing config and restores on teardown", async () => {
+      // Create existing config
+      await mkdir(codexDir, { recursive: true });
+      const originalContent = '[settings]\nmodel = "o3"\n';
+      await writeFile(configPath, originalContent, "utf-8");
+
+      const manager = new CodexMcpConfigManager(
+        { newServer: { command: "python", args: ["serve.py"] } },
+        codexDir,
+      );
+
+      await manager.setup();
+
+      // Should have merged content
+      const merged = await readFile(configPath, "utf-8");
+      expect(merged).toContain("[settings]");
+      expect(merged).toContain("[mcp_servers.newServer]");
+
+      await manager.teardown();
+
+      // Should restore original
+      const restored = await readFile(configPath, "utf-8");
+      expect(restored).toBe(originalContent);
+    });
+
+    it("writes correct TOML structure with command array from McpServerConfig", async () => {
+      const manager = new CodexMcpConfigManager(
+        {
+          server1: { command: "node", args: ["s1.js"] },
+          server2: { command: "python", args: ["s2.py"], env: { KEY: "val" } },
+        },
+        codexDir,
+      );
+
+      await manager.setup();
+
+      const content = await readFile(configPath, "utf-8");
+      expect(content).toContain("[mcp_servers.server1]");
+      expect(content).toContain("[mcp_servers.server2]");
+      expect(content).toContain('command = ["node", "s1.js"]');
+      expect(content).toContain('command = ["python", "s2.py"]');
+      expect(content).toContain("[mcp_servers.server2.env]");
+      expect(content).toContain('KEY = "val"');
+
+      await manager.teardown();
+    });
+  });
+});

--- a/src/middleware/runtimes/codex.ts
+++ b/src/middleware/runtimes/codex.ts
@@ -1,0 +1,518 @@
+import { mkdir, readFile, readdir, rm, rmdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { CLIRuntimeBase } from "../cli-runtime-base.js";
+import type {
+  AgentDoneEvent,
+  AgentErrorEvent,
+  AgentEvent,
+  AgentExecuteParams,
+  AgentTextEvent,
+  AgentToolResultEvent,
+  AgentToolUseEvent,
+  AgentUsage,
+  McpServerConfig,
+} from "../types.js";
+
+/**
+ * Codex CLI runtime — invokes `codex exec --json`
+ * and maps the streaming NDJSON output to {@link AgentEvent} instances.
+ *
+ * The Codex CLI uses a two-level event model:
+ * - Top-level events: thread.started, turn.started, item.started, item.updated,
+ *   item.completed, turn.completed, turn.failed, error
+ * - Item types: agent_message, command_execution, mcp_tool_call, file_change,
+ *   reasoning, web_search, error, todo_list
+ */
+export class CodexCliRuntime extends CLIRuntimeBase {
+  // ── Per-execution state (reset before each run) ───────────────────────
+
+  private currentSessionId: string | undefined;
+  private accumulatedText = "";
+  private lastEmittedTextLength = 0;
+  private lastUsage: AgentUsage | undefined;
+  private currentToolId: string | undefined;
+  private itemCounter = 0;
+
+  constructor() {
+    super("codex");
+  }
+
+  // ── stdin prompt delivery override ────────────────────────────────────
+
+  protected override get supportsStdinPrompt(): boolean {
+    return false;
+  }
+
+  // ── execute() override: state reset + MCP config + done enrichment ────
+
+  async *execute(params: AgentExecuteParams): AsyncIterable<AgentEvent> {
+    this.resetState();
+
+    const mcpConfigManager =
+      params.mcpServers && Object.keys(params.mcpServers).length > 0
+        ? new CodexMcpConfigManager(params.mcpServers)
+        : null;
+
+    try {
+      await mcpConfigManager?.setup();
+
+      for await (const event of super.execute(params)) {
+        if (event.type === "done") {
+          this.enrichDoneEvent(event);
+        }
+        yield event;
+      }
+    } finally {
+      await mcpConfigManager?.teardown();
+    }
+  }
+
+  // ── CLIRuntimeBase abstract method implementations ────────────────────
+
+  protected buildArgs(params: AgentExecuteParams): string[] {
+    if (params.sessionId) {
+      // Session resume: codex exec resume <id> --json --color never
+      return ["exec", "resume", params.sessionId, "--json", "--color", "never"];
+    }
+
+    // New session: codex exec --json --color never <prompt>
+    return ["exec", "--json", "--color", "never", params.prompt];
+  }
+
+  protected extractEvent(line: string): AgentEvent | null {
+    const parsed: unknown = JSON.parse(line);
+    if (!isObject(parsed) || typeof parsed.type !== "string") {
+      return null;
+    }
+
+    switch (parsed.type) {
+      case "thread.started":
+        return this.handleThreadStarted(parsed);
+      case "item.started":
+        return this.handleItemStarted(parsed);
+      case "item.updated":
+        return this.handleItemUpdated(parsed);
+      case "item.completed":
+        return this.handleItemCompleted(parsed);
+      case "turn.completed":
+        return this.handleTurnCompleted(parsed);
+      case "turn.failed":
+        return this.handleTurnFailed(parsed);
+      case "error":
+        return this.handleError(parsed);
+      // turn.started — skip (lifecycle boundary)
+      default:
+        return null;
+    }
+  }
+
+  protected buildEnv(_params: AgentExecuteParams): Record<string, string> {
+    return {
+      ANTHROPIC_API_KEY: "", // Prevent cross-provider leakage
+    };
+  }
+
+  // ── Event handlers ────────────────────────────────────────────────────
+
+  private handleThreadStarted(parsed: Record<string, unknown>): null {
+    if (typeof parsed.thread_id === "string") {
+      this.currentSessionId = parsed.thread_id;
+    }
+    return null;
+  }
+
+  private handleItemStarted(parsed: Record<string, unknown>): AgentEvent | null {
+    const item = isObject(parsed.item) ? parsed.item : null;
+    if (!item || typeof item.type !== "string") {
+      return null;
+    }
+
+    const toolId = this.extractToolId(item);
+
+    switch (item.type) {
+      case "command_execution": {
+        this.currentToolId = toolId;
+        const command = typeof item.command === "string" ? item.command : "";
+        return {
+          type: "tool_use",
+          toolName: "command_execution",
+          toolId,
+          input: { command },
+        } satisfies AgentToolUseEvent;
+      }
+      case "mcp_tool_call": {
+        this.currentToolId = toolId;
+        const toolName = typeof item.name === "string" ? item.name : "";
+        const args = isObject(item.arguments) ? item.arguments : {};
+        return {
+          type: "tool_use",
+          toolName,
+          toolId,
+          input: args,
+        } satisfies AgentToolUseEvent;
+      }
+      case "agent_message":
+        // Reset delta tracking for new message item
+        this.lastEmittedTextLength = 0;
+        return null;
+      default:
+        return null;
+    }
+  }
+
+  private handleItemUpdated(parsed: Record<string, unknown>): AgentEvent | null {
+    const item = isObject(parsed.item) ? parsed.item : null;
+    if (!item || item.type !== "agent_message") {
+      return null;
+    }
+
+    const fullText = this.extractMessageText(item);
+    if (fullText === undefined) {
+      return null;
+    }
+
+    const delta = fullText.substring(this.lastEmittedTextLength);
+    this.lastEmittedTextLength = fullText.length;
+
+    if (delta) {
+      this.accumulatedText += delta;
+      return { type: "text", text: delta } satisfies AgentTextEvent;
+    }
+
+    return null;
+  }
+
+  private handleItemCompleted(parsed: Record<string, unknown>): AgentEvent | null {
+    const item = isObject(parsed.item) ? parsed.item : null;
+    if (!item || typeof item.type !== "string") {
+      return null;
+    }
+
+    switch (item.type) {
+      case "agent_message": {
+        // Emit final delta if any remains
+        const fullText = this.extractMessageText(item);
+        if (fullText !== undefined) {
+          const delta = fullText.substring(this.lastEmittedTextLength);
+          this.lastEmittedTextLength = fullText.length;
+          if (delta) {
+            this.accumulatedText += delta;
+            return { type: "text", text: delta } satisfies AgentTextEvent;
+          }
+        }
+        return null;
+      }
+      case "command_execution": {
+        const toolId = this.currentToolId ?? this.extractToolId(item);
+        this.currentToolId = undefined;
+        const output = typeof item.output === "string" ? item.output : "";
+        const exitCode = typeof item.exit_code === "number" ? item.exit_code : 0;
+        return {
+          type: "tool_result",
+          toolId,
+          output,
+          isError: exitCode !== 0,
+        } satisfies AgentToolResultEvent;
+      }
+      case "mcp_tool_call": {
+        const toolId = this.currentToolId ?? this.extractToolId(item);
+        this.currentToolId = undefined;
+        const output = typeof item.output === "string" ? item.output : "";
+        const hasError = typeof item.error === "string" && item.error.length > 0;
+        return {
+          type: "tool_result",
+          toolId,
+          output,
+          isError: hasError,
+        } satisfies AgentToolResultEvent;
+      }
+      case "error": {
+        const message = typeof item.message === "string" ? item.message : "Unknown error";
+        return {
+          type: "error",
+          message,
+        } satisfies AgentErrorEvent;
+      }
+      default:
+        return null;
+    }
+  }
+
+  private handleTurnCompleted(parsed: Record<string, unknown>): null {
+    if (isObject(parsed.usage)) {
+      const usage = parsed.usage;
+      this.lastUsage = {
+        inputTokens: typeof usage.input_tokens === "number" ? usage.input_tokens : 0,
+        outputTokens: typeof usage.output_tokens === "number" ? usage.output_tokens : 0,
+        ...(typeof usage.cached_input_tokens === "number" && usage.cached_input_tokens > 0
+          ? { cacheReadTokens: usage.cached_input_tokens }
+          : {}),
+      };
+    }
+    return null;
+  }
+
+  private handleTurnFailed(parsed: Record<string, unknown>): AgentEvent {
+    const message = typeof parsed.message === "string" ? parsed.message : "Turn failed";
+    return {
+      type: "error",
+      message,
+      code: "turn_failed",
+    } satisfies AgentErrorEvent;
+  }
+
+  private handleError(parsed: Record<string, unknown>): AgentEvent {
+    const message = typeof parsed.message === "string" ? parsed.message : "Unknown error";
+    return {
+      type: "error",
+      message,
+    } satisfies AgentErrorEvent;
+  }
+
+  // ── Done event enrichment ─────────────────────────────────────────────
+
+  private enrichDoneEvent(event: AgentDoneEvent): void {
+    const { result } = event;
+
+    result.text = this.accumulatedText;
+    result.sessionId = this.currentSessionId;
+
+    if (this.lastUsage) {
+      result.usage = this.lastUsage;
+    }
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────
+
+  private extractToolId(item: Record<string, unknown>): string {
+    if (typeof item.id === "string") {
+      return item.id;
+    }
+    return `codex-item-${this.itemCounter++}`;
+  }
+
+  private extractMessageText(item: Record<string, unknown>): string | undefined {
+    // Codex agent_message items have a content array with text parts
+    if (Array.isArray(item.content)) {
+      const textParts: string[] = [];
+      for (const part of item.content) {
+        if (isObject(part) && part.type === "output_text" && typeof part.text === "string") {
+          textParts.push(part.text);
+        }
+      }
+      if (textParts.length > 0) {
+        return textParts.join("");
+      }
+    }
+
+    // Fallback: direct text field
+    if (typeof item.text === "string") {
+      return item.text;
+    }
+
+    return undefined;
+  }
+
+  // ── State reset ───────────────────────────────────────────────────────
+
+  private resetState(): void {
+    this.currentSessionId = undefined;
+    this.accumulatedText = "";
+    this.lastEmittedTextLength = 0;
+    this.lastUsage = undefined;
+    this.currentToolId = undefined;
+    this.itemCounter = 0;
+  }
+}
+
+// ── MCP Config Manager ────────────────────────────────────────────────────
+
+/**
+ * Manages the `~/.codex/config.toml` lifecycle for MCP server configuration.
+ *
+ * The Codex CLI reads MCP config from `~/.codex/config.toml`. The config uses
+ * TOML format with `[mcp_servers.<name>]` sections.
+ *
+ * Uses a merge-restore pattern:
+ * - **Setup**: read existing config (if any), save a copy, append `mcp_servers`
+ *   sections, write back.
+ * - **Teardown** (always, via `finally`): restore original or delete created file.
+ */
+export class CodexMcpConfigManager {
+  private readonly configDir: string;
+  private readonly configPath: string;
+
+  private originalContent: string | null = null;
+  private createdFile = false;
+  private createdDir = false;
+
+  constructor(
+    private readonly mcpServers: Record<string, McpServerConfig>,
+    configDir?: string,
+  ) {
+    this.configDir = configDir ?? join(homedir(), ".codex");
+    this.configPath = join(this.configDir, "config.toml");
+  }
+
+  async setup(): Promise<void> {
+    // Ensure ~/.codex/ directory exists
+    try {
+      await mkdir(this.configDir, { recursive: true });
+    } catch {
+      // Directory already exists or cannot be created
+    }
+
+    // Check for existing config file
+    let existingContent: string | null = null;
+    try {
+      const content = await readFile(this.configPath, "utf-8");
+      this.originalContent = content;
+      existingContent = content;
+    } catch {
+      // File doesn't exist — we'll create a new one
+      this.createdFile = true;
+
+      // Check if we created the directory
+      try {
+        const entries = await readdir(this.configDir);
+        if (entries.length === 0) {
+          this.createdDir = true;
+        }
+      } catch {
+        // Ignore
+      }
+    }
+
+    // Build merged config: preserve existing content + append MCP sections
+    const mcpToml = serializeMcpServersToToml(this.mcpServers);
+
+    if (existingContent) {
+      // Strip any existing [mcp_servers.*] sections to avoid duplication,
+      // then append our sections
+      const stripped = stripMcpServersSections(existingContent);
+      const separator = stripped.endsWith("\n") ? "\n" : "\n\n";
+      await writeFile(this.configPath, stripped + separator + mcpToml, "utf-8");
+    } else {
+      await writeFile(this.configPath, mcpToml, "utf-8");
+    }
+  }
+
+  async teardown(): Promise<void> {
+    try {
+      if (this.originalContent !== null) {
+        // Restore original file
+        await writeFile(this.configPath, this.originalContent, "utf-8");
+      } else if (this.createdFile) {
+        // Remove file we created
+        await rm(this.configPath, { force: true });
+
+        // Remove directory if we created it
+        if (this.createdDir) {
+          try {
+            await rmdir(this.configDir);
+          } catch {
+            // Directory not empty or already removed — ignore
+          }
+        }
+      }
+    } catch {
+      // Best-effort cleanup — don't throw during teardown
+    }
+  }
+}
+
+// ── TOML Serialization ──────────────────────────────────────────────────
+
+/**
+ * Serialize MCP server configs to TOML format for Codex config.
+ *
+ * Output format:
+ * ```toml
+ * [mcp_servers.server_name]
+ * type = "stdio"
+ * command = ["node", "server.js"]
+ *
+ * [mcp_servers.server_name.env]
+ * KEY = "VALUE"
+ * ```
+ */
+export function serializeMcpServersToToml(mcpServers: Record<string, McpServerConfig>): string {
+  const sections: string[] = [];
+
+  for (const [name, config] of Object.entries(mcpServers)) {
+    const lines: string[] = [];
+    lines.push(`[mcp_servers.${name}]`);
+    lines.push(`type = "stdio"`);
+
+    // command is an array: [config.command, ...(config.args ?? [])]
+    const commandArray = [config.command, ...(config.args ?? [])];
+    lines.push(`command = [${commandArray.map((s) => toTomlString(s)).join(", ")}]`);
+
+    sections.push(lines.join("\n"));
+
+    // Environment variables as a sub-table
+    if (config.env && Object.keys(config.env).length > 0) {
+      const envLines: string[] = [];
+      envLines.push(`[mcp_servers.${name}.env]`);
+      for (const [key, value] of Object.entries(config.env)) {
+        envLines.push(`${key} = ${toTomlString(value)}`);
+      }
+      sections.push(envLines.join("\n"));
+    }
+  }
+
+  return sections.join("\n\n") + "\n";
+}
+
+/**
+ * Strip existing `[mcp_servers.*]` sections from TOML content.
+ * This is a simple line-based approach that removes lines belonging to
+ * mcp_servers sections (from header to next non-mcp_servers section).
+ */
+function stripMcpServersSections(content: string): string {
+  const lines = content.split("\n");
+  const result: string[] = [];
+  let inMcpSection = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Check if this is a section header
+    if (trimmed.startsWith("[")) {
+      if (trimmed.startsWith("[mcp_servers.") || trimmed === "[mcp_servers]") {
+        inMcpSection = true;
+        continue;
+      }
+      inMcpSection = false;
+    }
+
+    if (!inMcpSection) {
+      result.push(line);
+    }
+  }
+
+  // Remove trailing blank lines
+  while (result.length > 0 && result[result.length - 1].trim() === "") {
+    result.pop();
+  }
+
+  return result.join("\n") + "\n";
+}
+
+/** Escape a string for TOML (basic string with double quotes). */
+function toTomlString(value: string): string {
+  const escaped = value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+  return `"${escaped}"`;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

- Implement `CodexCliRuntime` extending `CLIRuntimeBase` for OpenAI's `codex` CLI (`src/middleware/runtimes/codex.ts`)
- Handle the two-level Codex event model: 8 top-level event types (thread/turn/item lifecycle) × 8 item sub-types (agent_message, command_execution, mcp_tool_call, etc.)
- Implement `CodexMcpConfigManager` with merge-restore pattern for `~/.codex/config.toml` TOML config lifecycle
- Delta text computation from progressive `item.updated` events (Codex sends accumulated text, not incremental deltas)
- Cross-provider contamination prevention: strips `ANTHROPIC_API_KEY` from subprocess environment
- 48 unit tests covering argument construction, all event types, environment setup, TOML serialization, MCP config management, and done event enrichment

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` (format + typecheck + lint) passes clean
- [x] 48 unit tests pass covering all acceptance criteria
- [x] Full test suite (10,691 tests) passes — 1 pre-existing flaky failure in `supervisor.test.ts` unrelated to changes

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)