### PR TITLE
fix(middleware): remove asymmetric ANTHROPIC_API_KEY stripping from CodexCliRuntime (#14)

### DIFF
--- a/src/middleware/runtimes/codex.test.ts
+++ b/src/middleware/runtimes/codex.test.ts
@@ -470,21 +470,15 @@ describe("CodexCliRuntime", () => {
   // ── buildEnv ──────────────────────────────────────────────────────────
 
   describe("buildEnv", () => {
-    it("strips ANTHROPIC_API_KEY for cross-contamination prevention", () => {
+    it("returns empty record", () => {
       const env = runtime.testBuildEnv(makeParams());
-      expect(env).toEqual({ ANTHROPIC_API_KEY: "" });
+      expect(env).toEqual({});
     });
 
-    it("does not inject OPENAI_API_KEY (caller responsibility)", () => {
+    it("does not inject auth vars regardless of params", () => {
       const env = runtime.testBuildEnv(makeParams({ env: { OPENAI_API_KEY: "sk-test" } }));
+      expect(env).toEqual({});
       expect(env).not.toHaveProperty("OPENAI_API_KEY");
-      expect(env).toEqual({ ANTHROPIC_API_KEY: "" });
-    });
-
-    it("returns same env regardless of params content", () => {
-      const env1 = runtime.testBuildEnv(makeParams());
-      const env2 = runtime.testBuildEnv(makeParams({ sessionId: "s", prompt: "p" }));
-      expect(env1).toEqual(env2);
     });
   });
 

--- a/src/middleware/runtimes/codex.ts
+++ b/src/middleware/runtimes/codex.ts
@@ -108,9 +108,7 @@ export class CodexCliRuntime extends CLIRuntimeBase {
   }
 
   protected buildEnv(_params: AgentExecuteParams): Record<string, string> {
-    return {
-      ANTHROPIC_API_KEY: "", // Prevent cross-provider leakage
-    };
+    return {};
   }
 
   // ── Event handlers ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Removed asymmetric `ANTHROPIC_API_KEY` stripping from `CodexCliRuntime.buildEnv()` — now returns `{}` consistent with Claude and Gemini runtimes
- Updated tests to match the simplified pattern (3 env-stripping tests replaced with 2 generic empty-record tests)

Closes #14

## Test plan
- [x] `buildEnv()` returns empty record
- [x] No auth vars injected regardless of params
- [x] All 47 existing tests pass
- [x] Build passes
- [x] `pnpm check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)