### PR TITLE
feat(middleware): implement OpenCodeCliRuntime concrete class (#16)

### DIFF
--- a/src/middleware/runtimes/opencode.test.ts
+++ b/src/middleware/runtimes/opencode.test.ts
@@ -1,0 +1,572 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AgentDoneEvent, AgentEvent, AgentExecuteParams, AgentRunResult } from "../types.js";
+import { OpenCodeCliRuntime, OpenCodeMcpConfigManager } from "./opencode.js";
+
+// ── Test helper: expose protected methods ───────────────────────────────
+
+class TestableOpenCodeCliRuntime extends OpenCodeCliRuntime {
+  public testBuildArgs(params: AgentExecuteParams): string[] {
+    return this.buildArgs(params);
+  }
+
+  public testExtractEvent(line: string): AgentEvent | null {
+    return this.extractEvent(line);
+  }
+
+  public testBuildEnv(params: AgentExecuteParams): Record<string, string> {
+    return this.buildEnv(params);
+  }
+
+  public get testSupportsStdinPrompt(): boolean {
+    return this.supportsStdinPrompt;
+  }
+
+  public get testPendingEvents(): AgentEvent[] {
+    return (this as unknown as { pendingEvents: AgentEvent[] }).pendingEvents;
+  }
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+function makeParams(overrides: Partial<AgentExecuteParams> = {}): AgentExecuteParams {
+  return {
+    prompt: "Hello, OpenCode!",
+    ...overrides,
+  };
+}
+
+function makeDoneResult(overrides: Partial<AgentRunResult> = {}): AgentRunResult {
+  return {
+    text: "",
+    sessionId: undefined,
+    durationMs: 100,
+    usage: undefined,
+    aborted: false,
+    ...overrides,
+  };
+}
+
+function openCodeEvent(type: string, fields: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    type,
+    timestamp: "2026-02-25T10:00:00Z",
+    sessionID: "sess-abc",
+    ...fields,
+  });
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("OpenCodeCliRuntime", () => {
+  let runtime: TestableOpenCodeCliRuntime;
+
+  beforeEach(() => {
+    runtime = new TestableOpenCodeCliRuntime();
+  });
+
+  // ── supportsStdinPrompt ─────────────────────────────────────────────
+
+  describe("supportsStdinPrompt", () => {
+    it("returns true (default from base class)", () => {
+      expect(runtime.testSupportsStdinPrompt).toBe(true);
+    });
+  });
+
+  // ── buildArgs ─────────────────────────────────────────────────────────
+
+  describe("buildArgs", () => {
+    it("produces run --format json <prompt> for new session", () => {
+      const args = runtime.testBuildArgs(makeParams());
+      expect(args).toEqual(["run", "--format", "json", "Hello, OpenCode!"]);
+    });
+
+    it("produces run --format json --session <id> <prompt> for session resume", () => {
+      const args = runtime.testBuildArgs(makeParams({ sessionId: "sess-123" }));
+      expect(args).toEqual([
+        "run",
+        "--format",
+        "json",
+        "--session",
+        "sess-123",
+        "Hello, OpenCode!",
+      ]);
+    });
+
+    it("includes prompt on session resume (unlike Codex)", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({ sessionId: "sess-123", prompt: "Follow up prompt" }),
+      );
+      expect(args).toContain("Follow up prompt");
+    });
+
+    it("always starts with run", () => {
+      const newArgs = runtime.testBuildArgs(makeParams());
+      expect(newArgs[0]).toBe("run");
+
+      const resumeArgs = runtime.testBuildArgs(makeParams({ sessionId: "sess-1" }));
+      expect(resumeArgs[0]).toBe("run");
+    });
+
+    it("always includes --format json", () => {
+      const newArgs = runtime.testBuildArgs(makeParams());
+      const formatIdx = newArgs.indexOf("--format");
+      expect(formatIdx).toBeGreaterThan(-1);
+      expect(newArgs[formatIdx + 1]).toBe("json");
+
+      const resumeArgs = runtime.testBuildArgs(makeParams({ sessionId: "s" }));
+      const resumeFormatIdx = resumeArgs.indexOf("--format");
+      expect(resumeFormatIdx).toBeGreaterThan(-1);
+      expect(resumeArgs[resumeFormatIdx + 1]).toBe("json");
+    });
+
+    it("does not include --mcp-config flag (MCP handled via config file)", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          mcpServers: { s1: { command: "node" } },
+        }),
+      );
+      expect(args).not.toContain("--mcp-config");
+    });
+  });
+
+  // ── extractEvent ──────────────────────────────────────────────────────
+
+  describe("extractEvent", () => {
+    it("extracts sessionID from envelope and returns appropriate event", () => {
+      const event = runtime.testExtractEvent(
+        openCodeEvent("text", { content: "Hello", sessionID: "sess-xyz" }),
+      );
+      expect(event).toEqual({ type: "text", text: "Hello" });
+    });
+
+    it("maps text event to AgentTextEvent with complete text chunk", () => {
+      const event = runtime.testExtractEvent(openCodeEvent("text", { content: "Hello there!" }));
+      expect(event).toEqual({ type: "text", text: "Hello there!" });
+    });
+
+    it("accumulates text across multiple text events", () => {
+      runtime.testExtractEvent(openCodeEvent("text", { content: "Hello " }));
+      runtime.testExtractEvent(openCodeEvent("text", { content: "World" }));
+
+      const doneEvent: AgentDoneEvent = { type: "done", result: makeDoneResult() };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+      expect(doneEvent.result.text).toBe("Hello World");
+    });
+
+    it("maps tool_use event to AgentToolUseEvent and buffers AgentToolResultEvent", () => {
+      const event = runtime.testExtractEvent(
+        openCodeEvent("tool_use", {
+          name: "read_file",
+          callID: "call-123",
+          input: { path: "/tmp/test.txt" },
+          state: { output: "file contents", error: "" },
+        }),
+      );
+
+      expect(event).toEqual({
+        type: "tool_use",
+        toolName: "read_file",
+        toolId: "call-123",
+        input: { path: "/tmp/test.txt" },
+      });
+
+      // Check buffered tool_result
+      expect(runtime.testPendingEvents).toHaveLength(1);
+      expect(runtime.testPendingEvents[0]).toEqual({
+        type: "tool_result",
+        toolId: "call-123",
+        output: "file contents",
+        isError: false,
+      });
+    });
+
+    it("uses callID as toolId when present", () => {
+      const event = runtime.testExtractEvent(
+        openCodeEvent("tool_use", {
+          name: "write_file",
+          callID: "call-456",
+          input: {},
+          state: { output: "", error: "" },
+        }),
+      );
+      expect((event as { toolId: string }).toolId).toBe("call-456");
+    });
+
+    it("generates fallback opencode-tool-N IDs when callID is missing", () => {
+      const event1 = runtime.testExtractEvent(
+        openCodeEvent("tool_use", {
+          name: "tool1",
+          input: {},
+          state: { output: "", error: "" },
+        }),
+      );
+      expect((event1 as { toolId: string }).toolId).toBe("opencode-tool-0");
+
+      const event2 = runtime.testExtractEvent(
+        openCodeEvent("tool_use", {
+          name: "tool2",
+          input: {},
+          state: { output: "", error: "" },
+        }),
+      );
+      expect((event2 as { toolId: string }).toolId).toBe("opencode-tool-1");
+    });
+
+    it("marks tool_result as error when state.error is non-empty", () => {
+      runtime.testExtractEvent(
+        openCodeEvent("tool_use", {
+          name: "read_file",
+          callID: "call-err",
+          input: { path: "/nonexistent" },
+          state: { output: "", error: "File not found" },
+        }),
+      );
+
+      expect(runtime.testPendingEvents).toHaveLength(1);
+      expect(runtime.testPendingEvents[0]).toEqual({
+        type: "tool_result",
+        toolId: "call-err",
+        output: "",
+        isError: true,
+      });
+    });
+
+    it("stores usage from step_finish and returns null", () => {
+      const event = runtime.testExtractEvent(
+        openCodeEvent("step_finish", {
+          tokens: {
+            input: 500,
+            output: 200,
+            reasoning: 50,
+            total: 750,
+            cache: { read: 100, write: 25 },
+          },
+          cost: 0.0042,
+          reason: "end_turn",
+        }),
+      );
+      expect(event).toBeNull();
+    });
+
+    it("stores cost from step_finish and returns null", () => {
+      runtime.testExtractEvent(
+        openCodeEvent("step_finish", {
+          tokens: { input: 100, output: 50 },
+          cost: 0.0015,
+          reason: "end_turn",
+        }),
+      );
+
+      const doneEvent: AgentDoneEvent = { type: "done", result: makeDoneResult() };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+      expect(doneEvent.result.totalCostUsd).toBe(0.0015);
+    });
+
+    it("stores stop reason from step_finish and returns null", () => {
+      runtime.testExtractEvent(
+        openCodeEvent("step_finish", {
+          tokens: { input: 100, output: 50 },
+          cost: 0.001,
+          reason: "max_tokens",
+        }),
+      );
+
+      const doneEvent: AgentDoneEvent = { type: "done", result: makeDoneResult() };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+      expect(doneEvent.result.stopReason).toBe("max_tokens");
+    });
+
+    it("skips step_start events", () => {
+      const event = runtime.testExtractEvent(openCodeEvent("step_start"));
+      expect(event).toBeNull();
+    });
+
+    it("skips reasoning events", () => {
+      const event = runtime.testExtractEvent(
+        openCodeEvent("reasoning", { content: "thinking..." }),
+      );
+      expect(event).toBeNull();
+    });
+
+    it("maps error event to AgentErrorEvent", () => {
+      const event = runtime.testExtractEvent(
+        openCodeEvent("error", { message: "Rate limit exceeded" }),
+      );
+      expect(event).toEqual({
+        type: "error",
+        message: "Rate limit exceeded",
+      });
+    });
+
+    it("skips unknown event types", () => {
+      const event = runtime.testExtractEvent(openCodeEvent("unknown_type", { data: "foo" }));
+      expect(event).toBeNull();
+    });
+
+    it("handles missing/malformed fields gracefully", () => {
+      // text with no content field
+      const textEvent = runtime.testExtractEvent(openCodeEvent("text"));
+      expect(textEvent).toEqual({ type: "text", text: "" });
+
+      // tool_use with no name, callID, input, or state
+      const toolEvent = runtime.testExtractEvent(openCodeEvent("tool_use"));
+      expect(toolEvent).toEqual({
+        type: "tool_use",
+        toolName: "",
+        toolId: "opencode-tool-0",
+        input: {},
+      });
+
+      // error with no message
+      const errorEvent = runtime.testExtractEvent(openCodeEvent("error"));
+      expect(errorEvent).toEqual({
+        type: "error",
+        message: "Unknown error",
+      });
+    });
+  });
+
+  // ── buildEnv ──────────────────────────────────────────────────────────
+
+  describe("buildEnv", () => {
+    it("returns empty record", () => {
+      const env = runtime.testBuildEnv(makeParams());
+      expect(env).toEqual({});
+    });
+
+    it("does not inject auth vars regardless of params", () => {
+      const env = runtime.testBuildEnv(makeParams({ env: { OPENCODE_API_KEY: "test-key" } }));
+      expect(env).toEqual({});
+      expect(env).not.toHaveProperty("OPENCODE_API_KEY");
+    });
+  });
+
+  // ── done event enrichment ─────────────────────────────────────────────
+
+  describe("done event enrichment", () => {
+    it("enriches done event with accumulated text, session ID, and usage", () => {
+      // text events → accumulated text + sessionID capture
+      runtime.testExtractEvent(
+        openCodeEvent("text", { content: "Hello ", sessionID: "sess-enrich" }),
+      );
+      runtime.testExtractEvent(openCodeEvent("text", { content: "World" }));
+
+      // step_finish → usage
+      runtime.testExtractEvent(
+        openCodeEvent("step_finish", {
+          tokens: { input: 300, output: 200, cache: { read: 50, write: 10 } },
+          cost: 0.005,
+          reason: "end_turn",
+        }),
+      );
+
+      const doneEvent: AgentDoneEvent = {
+        type: "done",
+        result: makeDoneResult({ durationMs: 5000 }),
+      };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+
+      expect(doneEvent.result.text).toBe("Hello World");
+      expect(doneEvent.result.sessionId).toBe("sess-enrich");
+      expect(doneEvent.result.usage).toEqual({
+        inputTokens: 300,
+        outputTokens: 200,
+        cacheReadTokens: 50,
+        cacheWriteTokens: 10,
+      });
+      expect(doneEvent.result.totalCostUsd).toBe(0.005);
+      expect(doneEvent.result.stopReason).toBe("end_turn");
+      expect(doneEvent.result.durationMs).toBe(5000);
+      expect(doneEvent.result.aborted).toBe(false);
+    });
+
+    it("includes cacheReadTokens and cacheWriteTokens when present", () => {
+      runtime.testExtractEvent(
+        openCodeEvent("step_finish", {
+          tokens: { input: 100, output: 50, cache: { read: 30, write: 15 } },
+          cost: 0.001,
+        }),
+      );
+
+      const doneEvent: AgentDoneEvent = { type: "done", result: makeDoneResult() };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+
+      expect(doneEvent.result.usage).toEqual({
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 30,
+        cacheWriteTokens: 15,
+      });
+    });
+
+    it("omits cache tokens when zero", () => {
+      runtime.testExtractEvent(
+        openCodeEvent("step_finish", {
+          tokens: { input: 100, output: 50, cache: { read: 0, write: 0 } },
+          cost: 0.001,
+        }),
+      );
+
+      const doneEvent: AgentDoneEvent = { type: "done", result: makeDoneResult() };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+
+      expect(doneEvent.result.usage).toEqual({
+        inputTokens: 100,
+        outputTokens: 50,
+      });
+      expect(doneEvent.result.usage).not.toHaveProperty("cacheReadTokens");
+      expect(doneEvent.result.usage).not.toHaveProperty("cacheWriteTokens");
+    });
+
+    it("sets totalCostUsd and stopReason from step_finish", () => {
+      runtime.testExtractEvent(
+        openCodeEvent("step_finish", {
+          tokens: { input: 100, output: 50 },
+          cost: 0.0042,
+          reason: "end_turn",
+        }),
+      );
+
+      const doneEvent: AgentDoneEvent = { type: "done", result: makeDoneResult() };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+
+      expect(doneEvent.result.totalCostUsd).toBe(0.0042);
+      expect(doneEvent.result.stopReason).toBe("end_turn");
+    });
+
+    it("handles missing step_finish gracefully (no usage, no cost)", () => {
+      runtime.testExtractEvent(
+        openCodeEvent("text", { content: "response", sessionID: "sess-no-finish" }),
+      );
+
+      const doneEvent: AgentDoneEvent = { type: "done", result: makeDoneResult() };
+      (runtime as unknown as { enrichDoneEvent: (e: AgentDoneEvent) => void }).enrichDoneEvent(
+        doneEvent,
+      );
+
+      expect(doneEvent.result.text).toBe("response");
+      expect(doneEvent.result.sessionId).toBe("sess-no-finish");
+      expect(doneEvent.result.usage).toBeUndefined();
+      expect(doneEvent.result.totalCostUsd).toBeUndefined();
+      expect(doneEvent.result.stopReason).toBeUndefined();
+    });
+  });
+
+  // ── MCP config file management ────────────────────────────────────────
+
+  describe("OpenCodeMcpConfigManager", () => {
+    let testDir: string;
+    let openCodeDir: string;
+    let configPath: string;
+
+    beforeEach(async () => {
+      testDir = join(
+        tmpdir(),
+        `opencode-mcp-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      );
+      await mkdir(testDir, { recursive: true });
+      openCodeDir = join(testDir, ".opencode");
+      configPath = join(openCodeDir, "config.json");
+    });
+
+    afterEach(async () => {
+      await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("creates JSON config file when mcpServers has entries", async () => {
+      const manager = new OpenCodeMcpConfigManager(testDir, {
+        myServer: { command: "node", args: ["server.js"] },
+      });
+
+      await manager.setup();
+
+      const content = JSON.parse(await readFile(configPath, "utf-8"));
+      expect(content).toEqual({
+        mcpServers: {
+          myServer: { command: "node", args: ["server.js"] },
+        },
+      });
+
+      await manager.teardown();
+    });
+
+    it("cleans up created file on teardown", async () => {
+      const manager = new OpenCodeMcpConfigManager(testDir, {
+        s: { command: "cmd" },
+      });
+
+      await manager.setup();
+
+      // File exists
+      await expect(readFile(configPath, "utf-8")).resolves.toBeTruthy();
+
+      await manager.teardown();
+
+      // File should be removed
+      await expect(readFile(configPath, "utf-8")).rejects.toThrow();
+    });
+
+    it("preserves existing config and restores on teardown", async () => {
+      // Create existing config
+      await mkdir(openCodeDir, { recursive: true });
+      const originalConfig = { theme: "dark", otherKey: "value" };
+      await writeFile(configPath, JSON.stringify(originalConfig), "utf-8");
+
+      const manager = new OpenCodeMcpConfigManager(testDir, {
+        newServer: { command: "python", args: ["serve.py"] },
+      });
+
+      await manager.setup();
+
+      // Should have merged config
+      const merged = JSON.parse(await readFile(configPath, "utf-8"));
+      expect(merged.theme).toBe("dark");
+      expect(merged.otherKey).toBe("value");
+      expect(merged.mcpServers).toEqual({
+        newServer: { command: "python", args: ["serve.py"] },
+      });
+
+      await manager.teardown();
+
+      // Should restore original
+      const restored = JSON.parse(await readFile(configPath, "utf-8"));
+      expect(restored).toEqual(originalConfig);
+    });
+
+    it("writes correct JSON structure with mcpServers key", async () => {
+      const manager = new OpenCodeMcpConfigManager(testDir, {
+        server1: { command: "node", args: ["s1.js"] },
+        server2: { command: "python", args: ["s2.py"], env: { KEY: "val" } },
+      });
+
+      await manager.setup();
+
+      const content = JSON.parse(await readFile(configPath, "utf-8"));
+      expect(content).toEqual({
+        mcpServers: {
+          server1: { command: "node", args: ["s1.js"] },
+          server2: { command: "python", args: ["s2.py"], env: { KEY: "val" } },
+        },
+      });
+
+      await manager.teardown();
+    });
+  });
+});

--- a/src/middleware/runtimes/opencode.ts
+++ b/src/middleware/runtimes/opencode.ts
@@ -1,0 +1,318 @@
+import { mkdir, readFile, readdir, rm, rmdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { CLIRuntimeBase } from "../cli-runtime-base.js";
+import type {
+  AgentDoneEvent,
+  AgentErrorEvent,
+  AgentEvent,
+  AgentExecuteParams,
+  AgentTextEvent,
+  AgentToolResultEvent,
+  AgentToolUseEvent,
+  AgentUsage,
+  McpServerConfig,
+} from "../types.js";
+
+/**
+ * OpenCode CLI runtime — invokes `opencode run --format json`
+ * and maps the streaming NDJSON output to {@link AgentEvent} instances.
+ *
+ * OpenCode uses a per-line envelope model where every NDJSON line has:
+ * `{ type, timestamp, sessionID, ...data }`
+ *
+ * Key differences from other runtimes:
+ * - Text events are complete parts (no delta tracking needed)
+ * - Tool events combine use + result in a single line (buffered drain pattern)
+ * - Usage/cost comes from `step_finish` events
+ */
+export class OpenCodeCliRuntime extends CLIRuntimeBase {
+  // ── Per-execution state (reset before each run) ───────────────────────
+
+  private currentSessionId: string | undefined;
+  private accumulatedText = "";
+  private lastStepFinish: StepFinishData | undefined;
+  private pendingEvents: AgentEvent[] = [];
+  private toolCounter = 0;
+
+  constructor() {
+    super("opencode");
+  }
+
+  // ── execute() override: state reset + MCP config + pending drain + done enrichment ──
+
+  async *execute(params: AgentExecuteParams): AsyncIterable<AgentEvent> {
+    this.resetState();
+
+    const mcpConfigManager =
+      params.mcpServers && Object.keys(params.mcpServers).length > 0
+        ? new OpenCodeMcpConfigManager(params.workingDirectory, params.mcpServers)
+        : null;
+
+    try {
+      await mcpConfigManager?.setup();
+
+      for await (const event of super.execute(params)) {
+        if (event.type === "done") {
+          this.enrichDoneEvent(event);
+        }
+        yield event;
+
+        // Drain buffered events (from tool_use → tool_result pairs)
+        while (this.pendingEvents.length > 0) {
+          yield this.pendingEvents.shift()!;
+        }
+      }
+    } finally {
+      await mcpConfigManager?.teardown();
+    }
+  }
+
+  // ── CLIRuntimeBase abstract method implementations ────────────────────
+
+  protected buildArgs(params: AgentExecuteParams): string[] {
+    const args: string[] = ["run", "--format", "json"];
+
+    if (params.sessionId) {
+      args.push("--session", params.sessionId);
+    }
+
+    args.push(params.prompt);
+    return args;
+  }
+
+  protected extractEvent(line: string): AgentEvent | null {
+    const parsed: unknown = JSON.parse(line);
+    if (!isObject(parsed) || typeof parsed.type !== "string") {
+      return null;
+    }
+
+    // Extract sessionID from envelope (every event carries it)
+    if (typeof parsed.sessionID === "string" && this.currentSessionId === undefined) {
+      this.currentSessionId = parsed.sessionID;
+    }
+
+    switch (parsed.type) {
+      case "text":
+        return this.handleText(parsed);
+      case "tool_use":
+        return this.handleToolUse(parsed);
+      case "step_start":
+        return null;
+      case "step_finish":
+        return this.handleStepFinish(parsed);
+      case "reasoning":
+        return null;
+      case "error":
+        return this.handleError(parsed);
+      default:
+        return null;
+    }
+  }
+
+  protected buildEnv(_params: AgentExecuteParams): Record<string, string> {
+    return {};
+  }
+
+  // ── Event handlers ────────────────────────────────────────────────────
+
+  private handleText(parsed: Record<string, unknown>): AgentEvent | null {
+    const content = typeof parsed.content === "string" ? parsed.content : "";
+    this.accumulatedText += content;
+    return { type: "text", text: content } satisfies AgentTextEvent;
+  }
+
+  private handleToolUse(parsed: Record<string, unknown>): AgentEvent | null {
+    const toolId =
+      typeof parsed.callID === "string" ? parsed.callID : `opencode-tool-${this.toolCounter++}`;
+
+    // Buffer the tool_result event for drain after yield
+    const state = isObject(parsed.state) ? parsed.state : undefined;
+    this.pendingEvents.push({
+      type: "tool_result",
+      toolId,
+      output: typeof state?.output === "string" ? state.output : "",
+      isError: typeof state?.error === "string" && state.error.length > 0,
+    } satisfies AgentToolResultEvent);
+
+    return {
+      type: "tool_use",
+      toolName: typeof parsed.name === "string" ? parsed.name : "",
+      toolId,
+      input: isObject(parsed.input) ? parsed.input : {},
+    } satisfies AgentToolUseEvent;
+  }
+
+  private handleStepFinish(parsed: Record<string, unknown>): null {
+    this.lastStepFinish = {
+      tokens: isObject(parsed.tokens) ? (parsed.tokens as StepFinishData["tokens"]) : undefined,
+      cost: typeof parsed.cost === "number" ? parsed.cost : undefined,
+      reason: typeof parsed.reason === "string" ? parsed.reason : undefined,
+    };
+    return null;
+  }
+
+  private handleError(parsed: Record<string, unknown>): AgentEvent {
+    return {
+      type: "error",
+      message: typeof parsed.message === "string" ? parsed.message : "Unknown error",
+    } satisfies AgentErrorEvent;
+  }
+
+  // ── Done event enrichment ─────────────────────────────────────────────
+
+  private enrichDoneEvent(event: AgentDoneEvent): void {
+    const { result } = event;
+
+    result.text = this.accumulatedText;
+    result.sessionId = this.currentSessionId;
+
+    if (this.lastStepFinish) {
+      const { tokens, cost, reason } = this.lastStepFinish;
+
+      if (tokens) {
+        const input = typeof tokens.input === "number" ? tokens.input : 0;
+        const output = typeof tokens.output === "number" ? tokens.output : 0;
+        const cache = isObject(tokens.cache) ? tokens.cache : undefined;
+        const cacheRead = typeof cache?.read === "number" ? cache.read : 0;
+        const cacheWrite = typeof cache?.write === "number" ? cache.write : 0;
+
+        const usage: AgentUsage = {
+          inputTokens: input,
+          outputTokens: output,
+          ...(cacheRead > 0 ? { cacheReadTokens: cacheRead } : {}),
+          ...(cacheWrite > 0 ? { cacheWriteTokens: cacheWrite } : {}),
+        };
+        result.usage = usage;
+      }
+
+      if (cost !== undefined) {
+        result.totalCostUsd = cost;
+      }
+      if (reason !== undefined) {
+        result.stopReason = reason;
+      }
+    }
+  }
+
+  // ── State reset ───────────────────────────────────────────────────────
+
+  private resetState(): void {
+    this.currentSessionId = undefined;
+    this.accumulatedText = "";
+    this.lastStepFinish = undefined;
+    this.pendingEvents = [];
+    this.toolCounter = 0;
+  }
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+type StepFinishData = {
+  tokens:
+    | {
+        input?: number;
+        output?: number;
+        reasoning?: number;
+        total?: number;
+        cache?: { read?: number; write?: number };
+      }
+    | undefined;
+  cost: number | undefined;
+  reason: string | undefined;
+};
+
+// ── MCP Config Manager ────────────────────────────────────────────────────
+
+/**
+ * Manages the `.opencode/config.json` lifecycle for MCP server configuration.
+ *
+ * OpenCode reads MCP config from its project-level settings file. Uses a
+ * merge-restore pattern (same as Gemini and Codex):
+ *
+ * - **Setup**: read existing `.opencode/config.json` (if any), save a copy,
+ *   merge `mcpServers` into it, write back.
+ * - **Teardown** (always, via `finally`): restore the original file, or remove
+ *   the file/directory we created.
+ */
+export class OpenCodeMcpConfigManager {
+  private readonly configDir: string;
+  private readonly configPath: string;
+
+  private originalContent: string | null = null;
+  private createdFile = false;
+  private createdDir = false;
+
+  constructor(
+    workingDirectory: string | undefined,
+    private readonly mcpServers: Record<string, McpServerConfig>,
+  ) {
+    const baseDir = workingDirectory ?? process.cwd();
+    this.configDir = join(baseDir, ".opencode");
+    this.configPath = join(this.configDir, "config.json");
+  }
+
+  async setup(): Promise<void> {
+    // Ensure .opencode/ directory exists
+    try {
+      await mkdir(this.configDir, { recursive: true });
+    } catch {
+      // Directory already exists or cannot be created
+    }
+
+    // Check for existing config file
+    let existingConfig: Record<string, unknown> | null = null;
+    try {
+      const content = await readFile(this.configPath, "utf-8");
+      this.originalContent = content;
+      existingConfig = JSON.parse(content) as Record<string, unknown>;
+    } catch {
+      // File doesn't exist or is invalid — we'll create a new one
+      this.createdFile = true;
+
+      // Check if we created the directory
+      try {
+        const entries = await readdir(this.configDir);
+        if (entries.length === 0) {
+          this.createdDir = true;
+        }
+      } catch {
+        // Ignore
+      }
+    }
+
+    // Build merged config
+    const mergedConfig: Record<string, unknown> = existingConfig ?? {};
+    mergedConfig.mcpServers = this.mcpServers;
+
+    await writeFile(this.configPath, JSON.stringify(mergedConfig, null, 2), "utf-8");
+  }
+
+  async teardown(): Promise<void> {
+    try {
+      if (this.originalContent !== null) {
+        // Restore original file
+        await writeFile(this.configPath, this.originalContent, "utf-8");
+      } else if (this.createdFile) {
+        // Remove file we created
+        await rm(this.configPath, { force: true });
+
+        // Remove directory if we created it
+        if (this.createdDir) {
+          try {
+            await rmdir(this.configDir);
+          } catch {
+            // Directory not empty or already removed — ignore
+          }
+        }
+      }
+    } catch {
+      // Best-effort cleanup — don't throw during teardown
+    }
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

- Implement `OpenCodeCliRuntime` extending `CLIRuntimeBase` — spawns `opencode run --format json` and maps per-line envelope NDJSON output to `AgentEvent` instances
- Implement `OpenCodeMcpConfigManager` with merge-restore pattern on `.opencode/config.json` (same approach as Gemini/Codex)
- Add comprehensive test suite with 33 tests covering all specified categories (buildArgs, extractEvent, buildEnv, done enrichment, MCP config)

Key design decisions:
- Text events are complete parts (no delta tracking needed, simpler than Codex)
- Tool events combine use + result in a single NDJSON line; uses pending events buffer drain in `execute()` override
- Usage, cost, and stop reason captured from `step_finish` events
- `supportsStdinPrompt` defaults to `true` (not overridden)
- Prompt included on session resume (unlike Codex)

## Test plan

- [x] All 33 unit tests pass (`npx vitest run src/middleware/runtimes/opencode.test.ts`)
- [x] Format check passes (`pnpm format:check`)
- [x] Type check passes (`pnpm tsgo`)
- [x] Lint passes (`pnpm lint`)
- [ ] CI build + test jobs pass

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)