### PR TITLE
feat(middleware): implement createCliRuntime factory function (#19)

### DIFF
--- a/src/middleware/runtime-factory.test.ts
+++ b/src/middleware/runtime-factory.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { createCliRuntime, SUPPORTED_PROVIDERS } from "./runtime-factory.js";
+import { ClaudeCliRuntime } from "./runtimes/claude.js";
+import { CodexCliRuntime } from "./runtimes/codex.js";
+import { GeminiCliRuntime } from "./runtimes/gemini.js";
+import { OpenCodeCliRuntime } from "./runtimes/opencode.js";
+
+// ── Provider mapping ──────────────────────────────────────────────────────
+
+describe("createCliRuntime", () => {
+  describe("provider mapping", () => {
+    it("returns ClaudeCliRuntime for 'claude'", () => {
+      const runtime = createCliRuntime("claude");
+      expect(runtime).toBeInstanceOf(ClaudeCliRuntime);
+    });
+
+    it("returns GeminiCliRuntime for 'gemini'", () => {
+      const runtime = createCliRuntime("gemini");
+      expect(runtime).toBeInstanceOf(GeminiCliRuntime);
+    });
+
+    it("returns CodexCliRuntime for 'codex'", () => {
+      const runtime = createCliRuntime("codex");
+      expect(runtime).toBeInstanceOf(CodexCliRuntime);
+    });
+
+    it("returns OpenCodeCliRuntime for 'opencode'", () => {
+      const runtime = createCliRuntime("opencode");
+      expect(runtime).toBeInstanceOf(OpenCodeCliRuntime);
+    });
+
+    it("returns instances that satisfy AgentRuntime interface", () => {
+      for (const provider of SUPPORTED_PROVIDERS) {
+        const runtime = createCliRuntime(provider);
+        expect(runtime).toHaveProperty("execute");
+        expect(typeof runtime.execute).toBe("function");
+      }
+    });
+  });
+
+  // ── Input normalization ───────────────────────────────────────────────
+
+  describe("input normalization", () => {
+    it("handles case-insensitive input", () => {
+      expect(createCliRuntime("Claude")).toBeInstanceOf(ClaudeCliRuntime);
+      expect(createCliRuntime("GEMINI")).toBeInstanceOf(GeminiCliRuntime);
+      expect(createCliRuntime("Codex")).toBeInstanceOf(CodexCliRuntime);
+    });
+
+    it("trims whitespace", () => {
+      expect(createCliRuntime(" claude ")).toBeInstanceOf(ClaudeCliRuntime);
+    });
+
+    it("handles mixed case and whitespace", () => {
+      expect(createCliRuntime(" OpenCode ")).toBeInstanceOf(OpenCodeCliRuntime);
+    });
+  });
+
+  // ── Error handling ────────────────────────────────────────────────────
+
+  describe("error handling", () => {
+    it("throws Error with descriptive message for unknown provider", () => {
+      expect(() => createCliRuntime("foo")).toThrow('Unknown runtime provider "foo"');
+    });
+
+    it("includes all supported providers in error message", () => {
+      expect.assertions(4);
+      try {
+        createCliRuntime("unknown");
+      } catch (error) {
+        const message = (error as Error).message;
+        expect(message).toContain("claude");
+        expect(message).toContain("gemini");
+        expect(message).toContain("codex");
+        expect(message).toContain("opencode");
+      }
+    });
+  });
+
+  // ── Instance freshness ────────────────────────────────────────────────
+
+  describe("instance freshness", () => {
+    it("returns distinct instances for consecutive calls", () => {
+      const a = createCliRuntime("claude");
+      const b = createCliRuntime("claude");
+      expect(a).not.toBe(b);
+    });
+  });
+
+  // ── SUPPORTED_PROVIDERS export ────────────────────────────────────────
+
+  describe("SUPPORTED_PROVIDERS", () => {
+    it("contains exactly the four supported provider names", () => {
+      expect([...SUPPORTED_PROVIDERS]).toEqual(["claude", "gemini", "codex", "opencode"]);
+    });
+  });
+});

--- a/src/middleware/runtime-factory.ts
+++ b/src/middleware/runtime-factory.ts
@@ -1,0 +1,28 @@
+import { ClaudeCliRuntime } from "./runtimes/claude.js";
+import { CodexCliRuntime } from "./runtimes/codex.js";
+import { GeminiCliRuntime } from "./runtimes/gemini.js";
+import { OpenCodeCliRuntime } from "./runtimes/opencode.js";
+import type { AgentRuntime } from "./types.js";
+
+export const SUPPORTED_PROVIDERS = ["claude", "gemini", "codex", "opencode"] as const;
+
+export type SupportedProvider = (typeof SUPPORTED_PROVIDERS)[number];
+
+export function createCliRuntime(provider: string): AgentRuntime {
+  const normalized = provider.trim().toLowerCase();
+
+  switch (normalized) {
+    case "claude":
+      return new ClaudeCliRuntime();
+    case "gemini":
+      return new GeminiCliRuntime();
+    case "codex":
+      return new CodexCliRuntime();
+    case "opencode":
+      return new OpenCodeCliRuntime();
+    default:
+      throw new Error(
+        `Unknown runtime provider "${provider}". Supported providers: ${SUPPORTED_PROVIDERS.join(", ")}`,
+      );
+  }
+}


### PR DESCRIPTION
## Summary
- Add `createCliRuntime(provider)` factory function that maps provider name strings to `AgentRuntime` instances
- Export `SUPPORTED_PROVIDERS` array and `SupportedProvider` type for validation and help text
- Input normalized (case-insensitive, whitespace-trimmed); unknown providers throw descriptive Error

## Test plan
- [x] 12 tests in `src/middleware/runtime-factory.test.ts` covering:
  - Provider mapping (4 providers + interface check)
  - Input normalization (case, whitespace, mixed)
  - Error handling (descriptive message, lists supported providers)
  - Instance freshness (distinct instances per call)
  - SUPPORTED_PROVIDERS export validation
- [x] `npx vitest run src/middleware/runtime-factory.test.ts` — 12 passed
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format` — clean

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)