### PR TITLE
feat(middleware): implement SessionMap with file-backed session store (#24)

### DIFF
--- a/src/middleware/session-map.test.ts
+++ b/src/middleware/session-map.test.ts
@@ -1,0 +1,222 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type SessionEntry, type SessionKey, SessionMap } from "./session-map.js";
+
+describe("SessionMap", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "session-map-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  // ── CRUD Operations ─────────────────────────────────────────────────
+
+  describe("CRUD operations", () => {
+    it("get() returns undefined for unknown key", async () => {
+      const map = new SessionMap(dir);
+      const result = await map.get({ channelId: "c1", userId: "u1" });
+      expect(result).toBeUndefined();
+    });
+
+    it("set() + get() round-trip stores and retrieves a session ID", async () => {
+      const map = new SessionMap(dir);
+      const key: SessionKey = {
+        channelId: "telegram-123",
+        userId: "user-42",
+        threadId: "thread-99",
+      };
+      await map.set(key, "sess_abc123");
+      const result = await map.get(key);
+      expect(result).toBe("sess_abc123");
+    });
+
+    it("set() overwrites an existing entry", async () => {
+      const map = new SessionMap(dir);
+      const key: SessionKey = { channelId: "c1", userId: "u1" };
+      await map.set(key, "sess_old");
+      await map.set(key, "sess_new");
+      expect(await map.get(key)).toBe("sess_new");
+    });
+
+    it("thread isolation: same channelId + userId but different threadId → different sessions", async () => {
+      const map = new SessionMap(dir);
+      const key1: SessionKey = { channelId: "c1", userId: "u1", threadId: "t1" };
+      const key2: SessionKey = { channelId: "c1", userId: "u1", threadId: "t2" };
+      await map.set(key1, "sess_thread1");
+      await map.set(key2, "sess_thread2");
+      expect(await map.get(key1)).toBe("sess_thread1");
+      expect(await map.get(key2)).toBe("sess_thread2");
+    });
+
+    it("delete() removes an entry", async () => {
+      const map = new SessionMap(dir);
+      const key: SessionKey = { channelId: "c1", userId: "u1" };
+      await map.set(key, "sess_123");
+      await map.delete(key);
+      expect(await map.get(key)).toBeUndefined();
+    });
+
+    it("delete() is a no-op for missing key", async () => {
+      const map = new SessionMap(dir);
+      // Should not throw
+      await expect(map.delete({ channelId: "c1", userId: "u1" })).resolves.toBeUndefined();
+    });
+  });
+
+  // ── Persistence ─────────────────────────────────────────────────────
+
+  describe("persistence", () => {
+    it("data survives across SessionMap instances using the same directory", async () => {
+      const mapA = new SessionMap(dir);
+      const key: SessionKey = { channelId: "c1", userId: "u1", threadId: "t1" };
+      await mapA.set(key, "sess_persistent");
+
+      const mapB = new SessionMap(dir);
+      expect(await mapB.get(key)).toBe("sess_persistent");
+    });
+  });
+
+  // ── TTL Expiration ──────────────────────────────────────────────────
+
+  describe("TTL expiration", () => {
+    it("get() returns undefined for an expired entry", async () => {
+      const map = new SessionMap(dir, 1); // 1ms TTL
+      const key: SessionKey = { channelId: "c1", userId: "u1" };
+      await map.set(key, "sess_expired");
+
+      // Wait for TTL to elapse
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(await map.get(key)).toBeUndefined();
+    });
+
+    it("expired entries are evicted on the next set() call", async () => {
+      const map = new SessionMap(dir, 1); // 1ms TTL
+      const expiredKey: SessionKey = { channelId: "c1", userId: "u1" };
+      await map.set(expiredKey, "sess_old");
+
+      // Wait for TTL to elapse
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // set() with a different key should evict the expired entry
+      const freshKey: SessionKey = { channelId: "c2", userId: "u2" };
+      await map.set(freshKey, "sess_fresh");
+
+      // Read the raw file to verify the expired entry was removed
+      const raw = readFileSync(join(dir, "remoteclaw-sessions.json"), "utf-8");
+      const store = JSON.parse(raw) as Record<string, SessionEntry>;
+      expect(store["c1:u1:_"]).toBeUndefined();
+      expect(store["c2:u2:_"]).toBeDefined();
+    });
+
+    it("uses 7-day default TTL when none specified", async () => {
+      const now = Date.now();
+      vi.spyOn(Date, "now").mockReturnValue(now);
+
+      const map = new SessionMap(dir);
+      const key: SessionKey = { channelId: "c1", userId: "u1" };
+      await map.set(key, "sess_default_ttl");
+
+      // Just before expiration: should still be valid
+      vi.spyOn(Date, "now").mockReturnValue(now + 604_800_000 - 1);
+      expect(await map.get(key)).toBe("sess_default_ttl");
+
+      // Past expiration: should be expired
+      vi.spyOn(Date, "now").mockReturnValue(now + 604_800_000 + 1);
+      expect(await map.get(key)).toBeUndefined();
+    });
+  });
+
+  // ── Resilience ──────────────────────────────────────────────────────
+
+  describe("resilience", () => {
+    it("get() returns undefined when JSON file is corrupted", async () => {
+      writeFileSync(join(dir, "remoteclaw-sessions.json"), "NOT VALID JSON{{{");
+      const map = new SessionMap(dir);
+      expect(await map.get({ channelId: "c1", userId: "u1" })).toBeUndefined();
+    });
+
+    it("set() recovers from corrupted JSON file and writes new data", async () => {
+      writeFileSync(join(dir, "remoteclaw-sessions.json"), "CORRUPT");
+      const map = new SessionMap(dir);
+      const key: SessionKey = { channelId: "c1", userId: "u1" };
+      await map.set(key, "sess_recovered");
+      expect(await map.get(key)).toBe("sess_recovered");
+    });
+
+    it("set() creates missing directory", async () => {
+      const nested = join(dir, "deep", "nested", "dir");
+      const map = new SessionMap(nested);
+      const key: SessionKey = { channelId: "c1", userId: "u1" };
+      await map.set(key, "sess_nested");
+      expect(await map.get(key)).toBe("sess_nested");
+    });
+
+    it.each(["null", "42", '"hello"', "[]", "true"])(
+      "get() returns undefined when file contains valid but non-object JSON: %s",
+      async (content) => {
+        writeFileSync(join(dir, "remoteclaw-sessions.json"), content);
+        const map = new SessionMap(dir);
+        expect(await map.get({ channelId: "c1", userId: "u1" })).toBeUndefined();
+      },
+    );
+
+    it("set() recovers from valid but non-object JSON and writes new data", async () => {
+      writeFileSync(join(dir, "remoteclaw-sessions.json"), "null");
+      const map = new SessionMap(dir);
+      const key: SessionKey = { channelId: "c1", userId: "u1" };
+      await map.set(key, "sess_from_null");
+      expect(await map.get(key)).toBe("sess_from_null");
+    });
+
+    it("get() returns undefined when file does not exist", async () => {
+      const empty = join(dir, "empty-subdir");
+      const map = new SessionMap(empty);
+      expect(await map.get({ channelId: "c1", userId: "u1" })).toBeUndefined();
+    });
+  });
+
+  // ── Key Composition ─────────────────────────────────────────────────
+
+  describe("key composition", () => {
+    it("composes key as channelId:userId:threadId", async () => {
+      const map = new SessionMap(dir);
+      const key: SessionKey = {
+        channelId: "telegram-12345",
+        userId: "user-42",
+        threadId: "thread-99",
+      };
+      await map.set(key, "sess_threaded");
+
+      const raw = readFileSync(join(dir, "remoteclaw-sessions.json"), "utf-8");
+      const store = JSON.parse(raw) as Record<string, SessionEntry>;
+      expect(store["telegram-12345:user-42:thread-99"]).toBeDefined();
+      expect(store["telegram-12345:user-42:thread-99"].sessionId).toBe("sess_threaded");
+    });
+
+    it("composes threadless key as channelId:userId:_ when threadId is undefined", async () => {
+      const map = new SessionMap(dir);
+      const key: SessionKey = { channelId: "discord-67890", userId: "user-7" };
+      await map.set(key, "sess_threadless");
+
+      const raw = readFileSync(join(dir, "remoteclaw-sessions.json"), "utf-8");
+      const store = JSON.parse(raw) as Record<string, SessionEntry>;
+      expect(store["discord-67890:user-7:_"]).toBeDefined();
+      expect(store["discord-67890:user-7:_"].sessionId).toBe("sess_threadless");
+    });
+
+    it("treats explicit undefined threadId the same as omitted threadId", async () => {
+      const map = new SessionMap(dir);
+      const key1: SessionKey = { channelId: "c1", userId: "u1", threadId: undefined };
+      const key2: SessionKey = { channelId: "c1", userId: "u1" };
+      await map.set(key1, "sess_explicit_undef");
+      expect(await map.get(key2)).toBe("sess_explicit_undef");
+    });
+  });
+});

--- a/src/middleware/session-map.ts
+++ b/src/middleware/session-map.ts
@@ -1,0 +1,112 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/** Composite key for session lookup. */
+export type SessionKey = {
+  channelId: string;
+  userId: string;
+  threadId?: string | undefined;
+};
+
+/** Stored session entry. */
+export type SessionEntry = {
+  /** CLI runtime session ID (e.g., Claude session UUID, Codex thread ID). */
+  sessionId: string;
+  /** Epoch milliseconds of last access (set/get). */
+  lastAccessMs: number;
+};
+
+const SESSION_FILE = "remoteclaw-sessions.json";
+const DEFAULT_TTL_MS = 604_800_000; // 7 days
+
+/**
+ * File-backed session store mapping channel conversations to CLI runtime session IDs.
+ *
+ * Design decisions:
+ * - No in-memory cache: every get/set/delete reads from and writes to disk
+ * - Correctness over performance for the expected low-frequency session lookup pattern
+ * - Lazy TTL eviction: expired entries are invisible on get(), evicted on next set()
+ * - Atomic writes via write-to-temp + rename pattern
+ */
+export class SessionMap {
+  readonly #directory: string;
+  readonly #ttlMs: number;
+  readonly #filePath: string;
+  readonly #tmpPath: string;
+
+  /**
+   * @param directory - Directory where the session file is stored
+   * @param ttlMs - Time-to-live in milliseconds (default: 7 days = 604_800_000)
+   */
+  constructor(directory: string, ttlMs?: number) {
+    this.#directory = directory;
+    this.#ttlMs = ttlMs ?? DEFAULT_TTL_MS;
+    this.#filePath = join(directory, SESSION_FILE);
+    this.#tmpPath = join(directory, `${SESSION_FILE}.tmp`);
+  }
+
+  /** Get session ID for a channel conversation. Returns undefined if not found or expired. */
+  async get(key: SessionKey): Promise<string | undefined> {
+    const store = await this.#readStore();
+    const compositeKey = formatKey(key);
+    const entry = store[compositeKey];
+    if (!entry) {
+      return undefined;
+    }
+    if (entry.lastAccessMs + this.#ttlMs < Date.now()) {
+      return undefined;
+    }
+    return entry.sessionId;
+  }
+
+  /** Store or update a session ID for a channel conversation. Updates lastAccessMs. */
+  async set(key: SessionKey, sessionId: string): Promise<void> {
+    const store = await this.#readStore();
+    const now = Date.now();
+
+    // Evict all expired entries
+    for (const k of Object.keys(store)) {
+      if (store[k].lastAccessMs + this.#ttlMs < now) {
+        delete store[k];
+      }
+    }
+
+    store[formatKey(key)] = { sessionId, lastAccessMs: now };
+    await this.#writeStore(store);
+  }
+
+  /** Delete a session entry. No-op if key doesn't exist. */
+  async delete(key: SessionKey): Promise<void> {
+    const store = await this.#readStore();
+    const compositeKey = formatKey(key);
+    if (!(compositeKey in store)) {
+      return;
+    }
+    delete store[compositeKey];
+    await this.#writeStore(store);
+  }
+
+  async #readStore(): Promise<Record<string, SessionEntry>> {
+    try {
+      const data = await readFile(this.#filePath, "utf-8");
+      const parsed: unknown = JSON.parse(data);
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return {};
+      }
+      return parsed as Record<string, SessionEntry>;
+    } catch {
+      return {};
+    }
+  }
+
+  async #writeStore(store: Record<string, SessionEntry>): Promise<void> {
+    await mkdir(this.#directory, { recursive: true });
+    await writeFile(this.#tmpPath, JSON.stringify(store), "utf-8");
+    await rename(this.#tmpPath, this.#filePath);
+  }
+}
+
+/** Compose a flat string key from a SessionKey. */
+function formatKey(key: SessionKey): string {
+  return `${key.channelId}:${key.userId}:${key.threadId ?? "_"}`;
+}


### PR DESCRIPTION
## Summary

Implements `SessionMap` class that maps channel conversations to CLI runtime session IDs, enabling session continuity across messaging channels.

- Exports `SessionMap` class, `SessionKey` type, `SessionEntry` type from `src/middleware/session-map.ts`
- Composite key format: `{channelId}:{userId}:{threadId ?? "_"}`
- 7-day default TTL with configurable override
- `get()` returns `undefined` for unknown, expired, or corrupted entries
- `set()` evicts all expired entries, writes atomically (temp + rename)
- `delete()` removes entry, no-op for missing key
- Corrupted JSON file → graceful recovery (no throw)
- Missing directory → created on `set()`
- No in-memory cache — every operation hits disk
- 17 tests covering CRUD, persistence, TTL expiration, resilience, and key composition

Closes #24

## Test plan

- [x] `npx vitest run src/middleware/session-map.test.ts` — all 17 tests pass
- [x] `npx vitest run` — full suite passes (pre-existing flaky `server.auth` timeout unrelated)
- [x] `pnpm check` — format, typecheck, lint all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)