### PR TITLE
feat(middleware): implement DeliveryAdapter with streaming and chunk splitting

### DIFF
--- a/src/middleware/delivery-adapter.test.ts
+++ b/src/middleware/delivery-adapter.test.ts
@@ -1,0 +1,431 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ReplyPayload } from "../auto-reply/types.js";
+import { DeliveryAdapter } from "./delivery-adapter.js";
+import type { AgentEvent, BridgeCallbacks } from "./types.js";
+
+/** Create an async iterable from an array of events. */
+async function* eventStream(events: AgentEvent[]): AsyncIterable<AgentEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+/** Create a done event with minimal defaults. */
+function makeDone(): AgentEvent {
+  return {
+    type: "done",
+    result: {
+      text: "",
+      sessionId: undefined,
+      durationMs: 0,
+      usage: undefined,
+      aborted: false,
+    },
+  };
+}
+
+describe("DeliveryAdapter", () => {
+  describe("text accumulation", () => {
+    it("produces single payload from single text event", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([{ type: "text", text: "Hello world" }, makeDone()]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([{ text: "Hello world" }]);
+    });
+
+    it("accumulates multiple text events into one payload", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        { type: "text", text: "Hello " },
+        { type: "text", text: "world" },
+        makeDone(),
+      ]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([{ text: "Hello world" }]);
+    });
+
+    it("skips empty text events", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        { type: "text", text: "Hello" },
+        { type: "text", text: "" },
+        { type: "text", text: " world" },
+        makeDone(),
+      ]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([{ text: "Hello world" }]);
+    });
+
+    it("returns empty array when no text events", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([makeDone()]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([]);
+    });
+  });
+
+  describe("message splitting", () => {
+    it("splits text exceeding chunkLimit into multiple chunks", async () => {
+      const adapter = new DeliveryAdapter({ chunkLimit: 20 });
+      const events = eventStream([
+        { type: "text", text: "Hello world. This is a longer message that exceeds the limit." },
+        makeDone(),
+      ]);
+      const payloads = await adapter.process(events);
+      expect(payloads.length).toBeGreaterThan(1);
+      for (const p of payloads) {
+        expect(p.text).toBeDefined();
+      }
+    });
+
+    it("splits at paragraph boundary when possible", async () => {
+      const adapter = new DeliveryAdapter({ chunkLimit: 30 });
+      const text = "First paragraph.\n\nSecond paragraph here.";
+      const events = eventStream([{ type: "text", text }, makeDone()]);
+      const payloads = await adapter.process(events);
+      expect(payloads.length).toBe(2);
+      expect(payloads[0].text).toBe("First paragraph.\n\n");
+      expect(payloads[1].text).toBe("Second paragraph here.");
+    });
+
+    it("splits at line boundary as fallback", async () => {
+      const adapter = new DeliveryAdapter({ chunkLimit: 20 });
+      const text = "First line here.\nSecond line here.";
+      const events = eventStream([{ type: "text", text }, makeDone()]);
+      const payloads = await adapter.process(events);
+      expect(payloads.length).toBe(2);
+      expect(payloads[0].text).toBe("First line here.\n");
+      expect(payloads[1].text).toBe("Second line here.");
+    });
+
+    it("splits at word boundary as last resort before hard split", async () => {
+      const adapter = new DeliveryAdapter({ chunkLimit: 10 });
+      const text = "Hello beautiful world";
+      const events = eventStream([{ type: "text", text }, makeDone()]);
+      const payloads = await adapter.process(events);
+      expect(payloads.length).toBeGreaterThanOrEqual(2);
+      // First chunk should break at a space
+      expect(payloads[0].text).toMatch(/ $/);
+    });
+
+    it("hard splits when no natural boundary exists", async () => {
+      const adapter = new DeliveryAdapter({ chunkLimit: 5 });
+      const text = "abcdefghij";
+      const events = eventStream([{ type: "text", text }, makeDone()]);
+      const payloads = await adapter.process(events);
+      expect(payloads.length).toBe(2);
+      expect(payloads[0].text).toBe("abcde");
+      expect(payloads[1].text).toBe("fghij");
+    });
+
+    it("does not split text exactly at chunk limit", async () => {
+      const adapter = new DeliveryAdapter({ chunkLimit: 11 });
+      const events = eventStream([{ type: "text", text: "Hello world" }, makeDone()]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([{ text: "Hello world" }]);
+    });
+
+    it("preserves all text content when splitting", async () => {
+      const adapter = new DeliveryAdapter({ chunkLimit: 15 });
+      const original = "The quick brown fox jumps over the lazy dog.";
+      const events = eventStream([{ type: "text", text: original }, makeDone()]);
+      const payloads = await adapter.process(events);
+      const reassembled = payloads.map((p) => p.text).join("");
+      expect(reassembled).toBe(original);
+    });
+  });
+
+  describe("streaming callbacks", () => {
+    it("calls onPartialReply when buffer flushed mid-stream", async () => {
+      const onPartialReply = vi.fn();
+      const adapter = new DeliveryAdapter({ chunkLimit: 10 });
+      const events = eventStream([
+        { type: "text", text: "Hello world, this is a long message" },
+        makeDone(),
+      ]);
+      await adapter.process(events, { onPartialReply });
+      expect(onPartialReply).toHaveBeenCalled();
+      for (const call of onPartialReply.mock.calls) {
+        expect(call[0]).toHaveProperty("text");
+      }
+    });
+
+    it("calls onBlockReply for error events", async () => {
+      const onBlockReply = vi.fn();
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([{ type: "error", message: "Something failed" }, makeDone()]);
+      await adapter.process(events, { onBlockReply });
+      expect(onBlockReply).toHaveBeenCalledWith({ text: "Something failed", isError: true });
+    });
+
+    it("calls onBlockReply for final text flush on done", async () => {
+      const onBlockReply = vi.fn();
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([{ type: "text", text: "Final text" }, makeDone()]);
+      await adapter.process(events, { onBlockReply });
+      expect(onBlockReply).toHaveBeenCalledWith({ text: "Final text" });
+    });
+
+    it("calls onToolResult for tool result events", async () => {
+      const onToolResult = vi.fn();
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        { type: "tool_result", toolId: "t1", output: "result data" },
+        makeDone(),
+      ]);
+      await adapter.process(events, { onToolResult });
+      expect(onToolResult).toHaveBeenCalledWith({ text: "Tool t1 result: result data" });
+    });
+
+    it("does not error when callbacks are omitted", async () => {
+      const adapter = new DeliveryAdapter({ chunkLimit: 10 });
+      const events = eventStream([
+        { type: "text", text: "Hello world, this is a long message" },
+        { type: "tool_result", toolId: "t1", output: "data" },
+        { type: "error", message: "oops" },
+        makeDone(),
+      ]);
+      const payloads = await adapter.process(events);
+      expect(payloads.length).toBeGreaterThan(0);
+    });
+
+    it("handles async callbacks", async () => {
+      const calls: string[] = [];
+      const callbacks: BridgeCallbacks = {
+        onPartialReply: async (p) => {
+          await new Promise((r) => setTimeout(r, 1));
+          calls.push(`partial:${p.text}`);
+        },
+        onBlockReply: async (p) => {
+          await new Promise((r) => setTimeout(r, 1));
+          calls.push(`block:${p.text}`);
+        },
+      };
+      const adapter = new DeliveryAdapter({ chunkLimit: 10 });
+      const events = eventStream([{ type: "text", text: "Hello world, done" }, makeDone()]);
+      await adapter.process(events, callbacks);
+      expect(calls.some((c) => c.startsWith("partial:"))).toBe(true);
+      expect(calls.some((c) => c.startsWith("block:"))).toBe(true);
+    });
+  });
+
+  describe("event types", () => {
+    it("tool_use events produce no output", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        {
+          type: "tool_use",
+          toolName: "read_file",
+          toolId: "t1",
+          input: { path: "/tmp/test" },
+        },
+        makeDone(),
+      ]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([]);
+    });
+
+    it("tool_result events produce formatted payload via onToolResult", async () => {
+      const onToolResult = vi.fn();
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        { type: "tool_result", toolId: "t1", output: "file contents here" },
+        makeDone(),
+      ]);
+      await adapter.process(events, { onToolResult });
+      expect(onToolResult).toHaveBeenCalledWith({
+        text: "Tool t1 result: file contents here",
+      });
+    });
+
+    it("tool_result with isError formats as error", async () => {
+      const onToolResult = vi.fn();
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        { type: "tool_result", toolId: "t1", output: "permission denied", isError: true },
+        makeDone(),
+      ]);
+      await adapter.process(events, { onToolResult });
+      expect(onToolResult).toHaveBeenCalledWith({
+        text: "Tool t1 error: permission denied",
+      });
+    });
+
+    it("error events produce error payload with isError true", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([{ type: "error", message: "Critical failure" }, makeDone()]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([{ text: "Critical failure", isError: true }]);
+    });
+
+    it("error events with code include code in message", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        { type: "error", message: "Rate limit exceeded", code: "RATE_LIMIT" },
+        makeDone(),
+      ]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([{ text: "[RATE_LIMIT] Rate limit exceeded", isError: true }]);
+    });
+
+    it("done event flushes remaining buffer", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([{ type: "text", text: "buffered text" }, makeDone()]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([{ text: "buffered text" }]);
+    });
+
+    it("only error events when no text → returns error payloads", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        { type: "error", message: "error one" },
+        { type: "error", message: "error two" },
+        makeDone(),
+      ]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([
+        { text: "error one", isError: true },
+        { text: "error two", isError: true },
+      ]);
+    });
+  });
+
+  describe("code fence preservation", () => {
+    it("does not split inside a code fence when text before fence exists", async () => {
+      const adapter = new DeliveryAdapter({ chunkLimit: 30 });
+      const text = "Some text here.\n\n```\ncode line\n```";
+      const events = eventStream([{ type: "text", text }, makeDone()]);
+      const payloads = await adapter.process(events);
+      // The code fence should not be split
+      const allText = payloads.map((p) => p.text).join("");
+      // Verify all code content is preserved
+      expect(allText).toContain("code line");
+      expect(allText).toContain("```");
+    });
+
+    it("closes and reopens fence when split is necessary inside code block", async () => {
+      const adapter = new DeliveryAdapter({ chunkLimit: 25 });
+      const text = "```\nline one\nline two\nline three\nline four\n```";
+      const events = eventStream([{ type: "text", text }, makeDone()]);
+      const payloads = await adapter.process(events);
+      expect(payloads.length).toBeGreaterThan(1);
+      // First chunk should end with closing fence
+      expect(payloads[0].text).toMatch(/```\s*$/);
+      // Second chunk should start with opening fence
+      expect(payloads[1].text).toMatch(/^```/);
+    });
+
+    it("handles tilde fences", async () => {
+      const adapter = new DeliveryAdapter({ chunkLimit: 25 });
+      const text = "~~~\nline one\nline two\nline three\nline four\n~~~";
+      const events = eventStream([{ type: "text", text }, makeDone()]);
+      const payloads = await adapter.process(events);
+      expect(payloads.length).toBeGreaterThan(1);
+      expect(payloads[0].text).toMatch(/~~~\s*$/);
+      expect(payloads[1].text).toMatch(/^~~~/);
+    });
+
+    it("does not treat closed code fences as open", async () => {
+      const adapter = new DeliveryAdapter({ chunkLimit: 40 });
+      const text = "```\nshort\n```\n\nNormal text that goes on for a while after the fence.";
+      const events = eventStream([{ type: "text", text }, makeDone()]);
+      const payloads = await adapter.process(events);
+      // The closed fence should not affect splitting behavior
+      expect(payloads.length).toBeGreaterThanOrEqual(1);
+      const allText = payloads.map((p) => p.text).join("");
+      expect(allText).toContain("short");
+      expect(allText).toContain("Normal text");
+    });
+  });
+
+  describe("integration pattern", () => {
+    it("processes a realistic event sequence", async () => {
+      const partialReplies: ReplyPayload[] = [];
+      const blockReplies: ReplyPayload[] = [];
+      const toolResults: ReplyPayload[] = [];
+
+      const callbacks: BridgeCallbacks = {
+        onPartialReply: (p) => {
+          partialReplies.push(p);
+        },
+        onBlockReply: (p) => {
+          blockReplies.push(p);
+        },
+        onToolResult: (p) => {
+          toolResults.push(p);
+        },
+      };
+
+      const adapter = new DeliveryAdapter({ chunkLimit: 50 });
+      const events = eventStream([
+        { type: "text", text: "I'll read the file for you.\n\n" },
+        {
+          type: "tool_use",
+          toolName: "read_file",
+          toolId: "tool_1",
+          input: { path: "test.ts" },
+        },
+        { type: "tool_result", toolId: "tool_1", output: "file contents" },
+        { type: "text", text: "Here is the file content. " },
+        { type: "text", text: "The file contains test code that verifies the behavior." },
+        makeDone(),
+      ]);
+
+      const payloads = await adapter.process(events, callbacks);
+
+      // Tool result callback fired
+      expect(toolResults).toHaveLength(1);
+      expect(toolResults[0].text).toBe("Tool tool_1 result: file contents");
+
+      // Text was accumulated and delivered
+      expect(payloads.length).toBeGreaterThanOrEqual(1);
+      const allText = payloads.map((p) => p.text).join("");
+      expect(allText).toContain("I'll read the file for you.");
+      expect(allText).toContain("The file contains test code");
+
+      // Block reply called at least for final flush
+      expect(blockReplies.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("handles stream ending without done event", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        { type: "text", text: "Some text" },
+        // No done event
+      ]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([{ text: "Some text" }]);
+    });
+
+    it("handles very long single text event", async () => {
+      const adapter = new DeliveryAdapter({ chunkLimit: 20 });
+      const longText = "a".repeat(100);
+      const events = eventStream([{ type: "text", text: longText }, makeDone()]);
+      const payloads = await adapter.process(events);
+      expect(payloads.length).toBe(5);
+      for (const p of payloads) {
+        expect(p.text!.length).toBeLessThanOrEqual(20);
+      }
+      const reassembled = payloads.map((p) => p.text).join("");
+      expect(reassembled).toBe(longText);
+    });
+  });
+
+  describe("default chunk limit", () => {
+    it("uses 4000 as default chunk limit", async () => {
+      const adapter = new DeliveryAdapter();
+      const text = "a".repeat(4000);
+      const events = eventStream([{ type: "text", text }, makeDone()]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([{ text }]);
+    });
+
+    it("splits text exceeding 4000 chars with default limit", async () => {
+      const adapter = new DeliveryAdapter();
+      const text = "a".repeat(4001);
+      const events = eventStream([{ type: "text", text }, makeDone()]);
+      const payloads = await adapter.process(events);
+      expect(payloads.length).toBe(2);
+    });
+  });
+});

--- a/src/middleware/delivery-adapter.ts
+++ b/src/middleware/delivery-adapter.ts
@@ -1,0 +1,209 @@
+import type { ReplyPayload } from "../auto-reply/types.js";
+import type { AgentEvent, BridgeCallbacks } from "./types.js";
+
+/** Options for the delivery adapter. */
+export type DeliveryAdapterOptions = {
+  /**
+   * Maximum characters per message chunk.
+   * Different channels have different limits:
+   * - Discord: 2000 chars
+   * - Telegram: 4096 chars
+   * - Slack: ~40000 chars (block-based)
+   * Default: 4000 (safe default for most channels)
+   */
+  chunkLimit?: number | undefined;
+};
+
+const DEFAULT_CHUNK_LIMIT = 4000;
+
+/**
+ * Converts AgentEvent async iterable into channel-deliverable ReplyPayload chunks.
+ *
+ * Handles:
+ * - Text accumulation and chunking at channel limits
+ * - Progressive streaming via BridgeCallbacks
+ * - Tool result formatting
+ * - Error event formatting
+ */
+export class DeliveryAdapter {
+  private readonly chunkLimit: number;
+
+  constructor(options?: DeliveryAdapterOptions) {
+    this.chunkLimit = options?.chunkLimit ?? DEFAULT_CHUNK_LIMIT;
+  }
+
+  /**
+   * Process an event stream, invoking callbacks for real-time delivery
+   * and returning final payloads for post-execution delivery.
+   *
+   * @param events - AgentEvent async iterable from runtime.execute()
+   * @param callbacks - Optional streaming callbacks for real-time delivery
+   * @returns Final ReplyPayload array for post-execution delivery
+   */
+  async process(
+    events: AsyncIterable<AgentEvent>,
+    callbacks?: BridgeCallbacks,
+  ): Promise<ReplyPayload[]> {
+    let textBuffer = "";
+    const payloads: ReplyPayload[] = [];
+
+    for await (const event of events) {
+      switch (event.type) {
+        case "text": {
+          if (event.text === "") {
+            break;
+          }
+          textBuffer += event.text;
+          while (textBuffer.length > this.chunkLimit) {
+            const { chunk, rest } = splitAtBoundary(textBuffer, this.chunkLimit);
+            textBuffer = rest;
+            const payload: ReplyPayload = { text: chunk };
+            payloads.push(payload);
+            await callbacks?.onPartialReply?.(payload);
+          }
+          break;
+        }
+        case "tool_use":
+          break;
+        case "tool_result": {
+          const formatted = formatToolResult(event.toolId, event.output, event.isError);
+          const payload: ReplyPayload = { text: formatted };
+          await callbacks?.onToolResult?.(payload);
+          break;
+        }
+        case "error": {
+          const errorMsg = event.code ? `[${event.code}] ${event.message}` : event.message;
+          const payload: ReplyPayload = { text: errorMsg, isError: true };
+          payloads.push(payload);
+          await callbacks?.onBlockReply?.(payload);
+          break;
+        }
+        case "done": {
+          if (textBuffer.length > 0) {
+            const payload: ReplyPayload = { text: textBuffer };
+            payloads.push(payload);
+            await callbacks?.onBlockReply?.(payload);
+            textBuffer = "";
+          }
+          break;
+        }
+      }
+    }
+
+    // Flush any remaining text if stream ends without a done event
+    if (textBuffer.length > 0) {
+      const payload: ReplyPayload = { text: textBuffer };
+      payloads.push(payload);
+    }
+
+    return payloads;
+  }
+}
+
+/** Format a tool result for display. */
+function formatToolResult(toolId: string, output: string, isError?: boolean): string {
+  const prefix = isError ? `Tool ${toolId} error` : `Tool ${toolId} result`;
+  return `${prefix}: ${output}`;
+}
+
+/**
+ * Split text at the nearest safe boundary before the limit.
+ *
+ * Preference order:
+ * 1. Paragraph break (\n\n)
+ * 2. Line break (\n)
+ * 3. Word boundary (space)
+ * 4. Hard split at limit
+ *
+ * Markdown-aware: preserves code fence boundaries by closing/reopening
+ * fences at split points when a split occurs inside a fenced code block.
+ */
+function splitAtBoundary(text: string, limit: number): { chunk: string; rest: string } {
+  // Check if we're inside a code fence at the split region
+  const fenceInfo = findOpenCodeFence(text, limit);
+
+  if (fenceInfo !== undefined) {
+    // Split before the code fence starts if possible
+    const beforeFence = text.substring(0, fenceInfo.fenceStart);
+    if (beforeFence.trimEnd().length > 0) {
+      const trimmed = beforeFence.trimEnd();
+      return { chunk: trimmed, rest: text.substring(trimmed.length).trimStart() };
+    }
+    // Code fence starts at the beginning — close fence at limit and reopen in next chunk
+    const closingFence = `\n${fenceInfo.fence}`;
+    const openingFence = `${fenceInfo.fence}\n`;
+    const splitPoint = findSplitPoint(text, limit - closingFence.length);
+    return {
+      chunk: text.substring(0, splitPoint) + closingFence,
+      rest: openingFence + text.substring(splitPoint),
+    };
+  }
+
+  const splitPoint = findSplitPoint(text, limit);
+  return {
+    chunk: text.substring(0, splitPoint),
+    rest: text.substring(splitPoint),
+  };
+}
+
+/** Find the best split point within the text up to the given limit. */
+function findSplitPoint(text: string, limit: number): number {
+  if (limit <= 0) {
+    return Math.min(1, text.length);
+  }
+
+  const searchRegion = text.substring(0, limit);
+
+  // 1. Paragraph break (\n\n)
+  const paragraphIdx = searchRegion.lastIndexOf("\n\n");
+  if (paragraphIdx > 0) {
+    return paragraphIdx + 2;
+  }
+
+  // 2. Line break (\n)
+  const lineIdx = searchRegion.lastIndexOf("\n");
+  if (lineIdx > 0) {
+    return lineIdx + 1;
+  }
+
+  // 3. Word boundary (space)
+  const spaceIdx = searchRegion.lastIndexOf(" ");
+  if (spaceIdx > 0) {
+    return spaceIdx + 1;
+  }
+
+  // 4. Hard split at limit
+  return limit;
+}
+
+/**
+ * Detect if the text has an unclosed code fence at or before the limit position.
+ * Returns info about the open fence, or undefined if no open fence.
+ */
+function findOpenCodeFence(
+  text: string,
+  limit: number,
+): { fenceStart: number; fence: string } | undefined {
+  const fenceRegex = /^(`{3,}|~{3,})/gm;
+  let openFence: { fenceStart: number; fence: string } | undefined;
+
+  let match: RegExpExecArray | null;
+  while ((match = fenceRegex.exec(text)) !== null) {
+    if (match.index >= limit) {
+      break;
+    }
+    if (openFence === undefined) {
+      openFence = { fenceStart: match.index, fence: match[1] };
+    } else {
+      // Closing fence found — only if fence marker matches
+      if (
+        match[1].charAt(0) === openFence.fence.charAt(0) &&
+        match[1].length >= openFence.fence.length
+      ) {
+        openFence = undefined;
+      }
+    }
+  }
+
+  return openFence;
+}


### PR DESCRIPTION
## Summary

Implements the `DeliveryAdapter` class that converts `AgentEvent` async iterables from CLI runtimes into channel-deliverable `ReplyPayload` chunks.

- **Text accumulation**: Buffers incremental text events into coherent chunks
- **Smart splitting**: Splits at `chunkLimit` (default 4000) with boundary preference: paragraph (`\n\n`) > line (`\n`) > word (space) > hard split
- **Code fence preservation**: Detects open markdown fences and either splits before them or closes/reopens at split points
- **Streaming callbacks**: Invokes `BridgeCallbacks` (`onPartialReply`, `onBlockReply`, `onToolResult`) for real-time channel delivery
- **Error formatting**: Formats error events with `isError: true` and optional error codes
- **Tool result formatting**: Formats tool results via `onToolResult` callback

## Test plan

- [x] 33 tests covering all acceptance criteria
- [x] Text accumulation (single, multiple, empty, none)
- [x] Message splitting (paragraph, line, word, hard boundaries)
- [x] Streaming callbacks (partial, block, tool result, async, optional)
- [x] Event types (tool_use no-op, tool_result, error, done flush)
- [x] Code fence preservation (backtick, tilde, closed fences)
- [x] Integration pattern (realistic sequence, no-done fallback, very long text)
- [x] Default chunk limit verification
- [x] Full test suite passes (861 tests)
- [x] `pnpm check` passes (format + typecheck + lint)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)