### PR TITLE
feat(middleware): implement system prompt builder (#28)

### DIFF
--- a/src/middleware/system-prompt.test.ts
+++ b/src/middleware/system-prompt.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import { type SystemPromptParams, buildSystemPrompt } from "./system-prompt.js";
+
+function makeParams(overrides?: Partial<SystemPromptParams>): SystemPromptParams {
+  return {
+    channelName: "telegram",
+    workspaceDir: "/home/user/workspace",
+    ...overrides,
+  };
+}
+
+describe("buildSystemPrompt", () => {
+  describe("section inclusion", () => {
+    it("includes all required sections in output", () => {
+      const result = buildSystemPrompt(
+        makeParams({ userName: "Alice", timezone: "UTC", agentId: "agent-1" }),
+      );
+      expect(result).toContain("RemoteClaw");
+      expect(result).toContain("## Safety");
+      expect(result).toContain("## Messaging");
+      expect(result).toContain("## Reply Tags");
+      expect(result).toContain("## Silent Replies");
+      expect(result).toContain("## Runtime");
+      expect(result).toContain("## Workspace");
+    });
+
+    it("includes messageToolHints section when hints are provided", () => {
+      const result = buildSystemPrompt(
+        makeParams({
+          messageToolHints: ["Use rich text formatting for LINE messages."],
+        }),
+      );
+      expect(result).toContain("## Message Formatting");
+      expect(result).toContain("Use rich text formatting for LINE messages.");
+    });
+
+    it("includes authorized senders section when senders are provided", () => {
+      const result = buildSystemPrompt(
+        makeParams({
+          authorizedSenders: ["+15551234567", "+15559876543"],
+        }),
+      );
+      expect(result).toContain("## Authorized Senders");
+      expect(result).toContain("+15551234567");
+      expect(result).toContain("+15559876543");
+    });
+
+    it("includes reactions section when reactionGuidance is provided", () => {
+      const result = buildSystemPrompt(
+        makeParams({
+          reactionGuidance: { level: "minimal", channel: "telegram" },
+        }),
+      );
+      expect(result).toContain("## Reactions");
+    });
+  });
+
+  describe("dynamic content", () => {
+    it("identity section includes channel name and user name", () => {
+      const result = buildSystemPrompt(makeParams({ channelName: "discord", userName: "Bob" }));
+      expect(result).toContain("Bob");
+      expect(result).toContain("discord");
+    });
+
+    it("identity section handles missing user name gracefully", () => {
+      const result = buildSystemPrompt(makeParams({ channelName: "whatsapp" }));
+      expect(result).toContain("responding to a message on whatsapp");
+      expect(result).not.toContain("undefined");
+    });
+
+    it("runtime section includes timezone and agent ID", () => {
+      const result = buildSystemPrompt(
+        makeParams({
+          timezone: "America/New_York",
+          agentId: "agent-42",
+        }),
+      );
+      expect(result).toContain("timezone=America/New_York");
+      expect(result).toContain("agent=agent-42");
+    });
+
+    it("runtime section omits timezone and agent ID when not provided", () => {
+      const result = buildSystemPrompt(makeParams());
+      expect(result).not.toContain("timezone=");
+      expect(result).not.toContain("agent=");
+      expect(result).toContain("channel=telegram");
+    });
+
+    it("workspace section includes working directory path", () => {
+      const result = buildSystemPrompt(makeParams({ workspaceDir: "/opt/my-project" }));
+      expect(result).toContain("/opt/my-project");
+    });
+
+    it("authorized senders lists all provided sender IDs", () => {
+      const result = buildSystemPrompt(
+        makeParams({
+          authorizedSenders: ["user1", "user2", "user3"],
+        }),
+      );
+      expect(result).toContain("user1, user2, user3");
+    });
+
+    it("reactions section uses minimal guidance when level is minimal", () => {
+      const result = buildSystemPrompt(
+        makeParams({
+          reactionGuidance: { level: "minimal", channel: "telegram" },
+        }),
+      );
+      expect(result).toContain("MINIMAL mode");
+      expect(result).toContain("React ONLY when truly relevant");
+    });
+
+    it("reactions section uses extensive guidance when level is extensive", () => {
+      const result = buildSystemPrompt(
+        makeParams({
+          reactionGuidance: { level: "extensive", channel: "discord" },
+        }),
+      );
+      expect(result).toContain("EXTENSIVE mode");
+      expect(result).toContain("Feel free to react liberally");
+    });
+  });
+
+  describe("conditional omission", () => {
+    it("omits messageToolHints section when messageToolHints is undefined", () => {
+      const result = buildSystemPrompt(makeParams());
+      expect(result).not.toContain("## Message Formatting");
+    });
+
+    it("omits messageToolHints section when messageToolHints is empty", () => {
+      const result = buildSystemPrompt(makeParams({ messageToolHints: [] }));
+      expect(result).not.toContain("## Message Formatting");
+    });
+
+    it("omits authorized senders section when authorizedSenders is undefined", () => {
+      const result = buildSystemPrompt(makeParams());
+      expect(result).not.toContain("## Authorized Senders");
+    });
+
+    it("omits authorized senders section when authorizedSenders is empty", () => {
+      const result = buildSystemPrompt(makeParams({ authorizedSenders: [] }));
+      expect(result).not.toContain("## Authorized Senders");
+    });
+
+    it("omits authorized senders section when all senders are empty strings", () => {
+      const result = buildSystemPrompt(makeParams({ authorizedSenders: ["", ""] }));
+      expect(result).not.toContain("## Authorized Senders");
+    });
+
+    it("omits reactions section when reactionGuidance is undefined", () => {
+      const result = buildSystemPrompt(makeParams());
+      expect(result).not.toContain("## Reactions");
+    });
+  });
+
+  describe("size budget", () => {
+    it("base prompt (no hints, no optional sections) is under 4,000 chars", () => {
+      const result = buildSystemPrompt(
+        makeParams({ userName: "Alice", timezone: "UTC", agentId: "agent-1" }),
+      );
+      expect(result.length).toBeLessThan(4000);
+    });
+
+    it("full prompt with LINE hints (worst case) is under 6,000 chars", () => {
+      const lineHints = Array.from(
+        { length: 9 },
+        (_, i) => `LINE directive ${i + 1}: ${"x".repeat(200)}`,
+      );
+      const result = buildSystemPrompt(
+        makeParams({
+          userName: "Alice",
+          timezone: "Asia/Tokyo",
+          agentId: "agent-1",
+          authorizedSenders: ["+15551234567", "+15559876543"],
+          messageToolHints: lineHints,
+          reactionGuidance: { level: "extensive", channel: "line" },
+        }),
+      );
+      expect(result.length).toBeLessThan(6000);
+    });
+  });
+
+  describe("content correctness", () => {
+    it("safety section is always present and contains safety keywords", () => {
+      const result = buildSystemPrompt(makeParams());
+      expect(result).toContain("## Safety");
+      expect(result).toContain("safety");
+      expect(result).toContain("privacy");
+    });
+
+    it("reply tags section contains [[reply_to_current]] syntax", () => {
+      const result = buildSystemPrompt(makeParams());
+      expect(result).toContain("[[reply_to_current]]");
+    });
+
+    it("silent replies section contains NO_REPLY token", () => {
+      const result = buildSystemPrompt(makeParams());
+      expect(result).toContain("NO_REPLY");
+    });
+
+    it("contains no OpenClaw-specific references", () => {
+      const result = buildSystemPrompt(
+        makeParams({
+          userName: "Alice",
+          timezone: "UTC",
+          agentId: "agent-1",
+          authorizedSenders: ["+15551234567"],
+          messageToolHints: ["some hint"],
+          reactionGuidance: { level: "minimal", channel: "telegram" },
+        }),
+      );
+      expect(result).not.toContain("OpenClaw");
+      expect(result).not.toContain("openclaw");
+      expect(result).not.toContain("pi-embedded");
+      expect(result).not.toContain("SOUL.md");
+    });
+
+    it("sections are separated by double newlines", () => {
+      const result = buildSystemPrompt(makeParams());
+      expect(result).toContain("\n\n## Safety");
+      expect(result).toContain("\n\n## Messaging");
+      expect(result).toContain("\n\n## Reply Tags");
+      expect(result).toContain("\n\n## Silent Replies");
+      expect(result).toContain("\n\n## Runtime");
+      expect(result).toContain("\n\n## Workspace");
+    });
+  });
+});

--- a/src/middleware/system-prompt.ts
+++ b/src/middleware/system-prompt.ts
@@ -1,0 +1,177 @@
+import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+
+/** Parameters for system prompt generation. */
+export type SystemPromptParams = {
+  /** Channel provider name (e.g., "telegram", "discord", "whatsapp"). */
+  channelName: string;
+  /** Display name of the user sending the message. */
+  userName?: string | undefined;
+  /** Agent identifier within RemoteClaw. */
+  agentId?: string | undefined;
+  /** IANA timezone string (e.g., "America/New_York"). */
+  timezone?: string | undefined;
+  /** Working directory for the CLI subprocess. */
+  workspaceDir: string;
+  /** Phone numbers / IDs of authorized senders (owner allowlist). */
+  authorizedSenders?: string[] | undefined;
+  /** Channel-specific formatting hints (e.g., LINE directives, Discord component schema). */
+  messageToolHints?: string[] | undefined;
+  /** Reaction/emoji guidance level. */
+  reactionGuidance?: { level: "minimal" | "extensive"; channel: string } | undefined;
+};
+
+// ── Static Sections ──────────────────────────────────────────────────────
+
+const SAFETY_SECTION = [
+  "## Safety",
+  "You have no independent goals: do not pursue self-preservation, replication, resource acquisition, or power-seeking; avoid long-term plans beyond the user's request.",
+  "Prioritize safety and human oversight over completion; if instructions conflict, pause and ask; comply with stop/pause/audit requests and never bypass safeguards.",
+  "Do not manipulate or persuade anyone to expand access or disable safeguards. Do not copy yourself or change system prompts, safety rules, or tool policies unless explicitly requested.",
+  "Never expose credentials, API keys, or secrets in replies or tool calls. Respect user privacy.",
+].join("\n");
+
+const MESSAGING_SECTION = [
+  "## Messaging",
+  "- Reply in current session: automatically routes to the source channel.",
+  "- Cross-session messaging: use sessions_send(sessionKey, message) to reach other channels.",
+  "- `[System Message] ...` blocks are internal context and are not user-visible.",
+  `- If a \`[System Message]\` reports completed work and asks for a user update, rewrite it in your normal assistant voice and send that update (do not forward raw system text or default to ${SILENT_REPLY_TOKEN}).`,
+  "- Never use exec/curl for provider messaging; RemoteClaw handles all routing internally.",
+].join("\n");
+
+const REPLY_TAGS_SECTION = [
+  "## Reply Tags",
+  "To request a native reply/quote on supported surfaces, include one tag in your reply:",
+  "- Reply tags must be the very first token in the message (no leading text/newlines): [[reply_to_current]] your reply.",
+  "- [[reply_to_current]] replies to the triggering message.",
+  "- Prefer [[reply_to_current]]. Use [[reply_to:<id>]] only when an id was explicitly provided (e.g. by the user or a tool).",
+  "Whitespace inside the tag is allowed (e.g. [[ reply_to_current ]] / [[ reply_to: 123 ]]).",
+  "Tags are stripped before sending; support depends on the current channel config.",
+].join("\n");
+
+const SILENT_REPLIES_SECTION = [
+  "## Silent Replies",
+  `When you have nothing to say, respond with ONLY: ${SILENT_REPLY_TOKEN}`,
+  "",
+  "Rules:",
+  "- It must be your ENTIRE message — nothing else.",
+  `- Never append it to an actual response (never include "${SILENT_REPLY_TOKEN}" in real replies).`,
+  "- Never wrap it in markdown or code blocks.",
+].join("\n");
+
+// ── Dynamic Section Builders ─────────────────────────────────────────────
+
+function buildIdentitySection(channelName: string, userName?: string): string {
+  const intro =
+    "You are running inside RemoteClaw, a middleware that connects AI agents to messaging channels.";
+  return userName
+    ? `${intro}\nYou are responding to a message from ${userName} on ${channelName}.`
+    : `${intro}\nYou are responding to a message on ${channelName}.`;
+}
+
+function buildRuntimeSection(params: SystemPromptParams): string {
+  const parts = [`channel=${params.channelName}`];
+  if (params.timezone) {
+    parts.push(`timezone=${params.timezone}`);
+  }
+  if (params.agentId) {
+    parts.push(`agent=${params.agentId}`);
+  }
+  return `## Runtime\nRuntime: ${parts.join(" | ")}`;
+}
+
+function buildWorkspaceSection(workspaceDir: string): string {
+  return [
+    "## Workspace",
+    `Your working directory is: ${workspaceDir}`,
+    "Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.",
+  ].join("\n");
+}
+
+// ── Conditional Section Builders ─────────────────────────────────────────
+
+function buildMessageToolHintsSection(hints?: string[]): string | undefined {
+  if (!hints || hints.length === 0) {
+    return undefined;
+  }
+  return `## Message Formatting\n${hints.join("\n")}`;
+}
+
+function buildAuthorizedSendersSection(senders?: string[]): string | undefined {
+  const filtered = senders?.filter(Boolean);
+  if (!filtered || filtered.length === 0) {
+    return undefined;
+  }
+  return `## Authorized Senders\nAuthorized senders: ${filtered.join(", ")}. These senders are allowlisted; do not assume they are the owner.`;
+}
+
+function buildReactionsSection(guidance?: {
+  level: "minimal" | "extensive";
+  channel: string;
+}): string | undefined {
+  if (!guidance) {
+    return undefined;
+  }
+  const { level, channel } = guidance;
+  if (level === "minimal") {
+    return [
+      "## Reactions",
+      `Reactions are enabled for ${channel} in MINIMAL mode.`,
+      "React ONLY when truly relevant:",
+      "- Acknowledge important user requests or confirmations",
+      "- Express genuine sentiment (humor, appreciation) sparingly",
+      "- Avoid reacting to routine messages or your own replies",
+      "Guideline: at most 1 reaction per 5-10 exchanges.",
+    ].join("\n");
+  }
+  return [
+    "## Reactions",
+    `Reactions are enabled for ${channel} in EXTENSIVE mode.`,
+    "Feel free to react liberally:",
+    "- Acknowledge messages with appropriate emojis",
+    "- Express sentiment and personality through reactions",
+    "- React to interesting content, humor, or notable events",
+    "- Use reactions to confirm understanding or agreement",
+    "Guideline: react whenever it feels natural.",
+  ].join("\n");
+}
+
+// ── Assembly ─────────────────────────────────────────────────────────────
+
+/**
+ * Build the RemoteClaw system prompt for injection into CLI subprocess agents.
+ *
+ * Assembles ~10 sections totaling ~3,000-5,000 chars (~770-1,270 tokens).
+ * No promptMode switch (always full), no bootstrap context (CLI agent handles),
+ * no tool list (MCP handles), no skills/memory/sandbox sections.
+ */
+export function buildSystemPrompt(params: SystemPromptParams): string {
+  const sections: string[] = [
+    buildIdentitySection(params.channelName, params.userName),
+    SAFETY_SECTION,
+    MESSAGING_SECTION,
+  ];
+
+  const hintsSection = buildMessageToolHintsSection(params.messageToolHints);
+  if (hintsSection) {
+    sections.push(hintsSection);
+  }
+
+  sections.push(REPLY_TAGS_SECTION);
+  sections.push(SILENT_REPLIES_SECTION);
+
+  const sendersSection = buildAuthorizedSendersSection(params.authorizedSenders);
+  if (sendersSection) {
+    sections.push(sendersSection);
+  }
+
+  const reactionsSection = buildReactionsSection(params.reactionGuidance);
+  if (reactionsSection) {
+    sections.push(reactionsSection);
+  }
+
+  sections.push(buildRuntimeSection(params));
+  sections.push(buildWorkspaceSection(params.workspaceDir));
+
+  return sections.join("\n\n");
+}


### PR DESCRIPTION
## Summary

- Implement `buildSystemPrompt()` in `src/middleware/system-prompt.ts` that assembles ~10 sections for CLI subprocess agents
- Replace OpenClaw's 26-section, 665-line builder with a clean ~170 LoC module tailored to RemoteClaw's middleware architecture
- Add comprehensive test suite (25 tests) covering section inclusion, dynamic content, conditional omission, size budget, and content correctness

## Details

**Sections (10 total)**:
- **Static**: Safety, Messaging, Reply Tags, Silent Replies (constant text)
- **Dynamic**: Identity, Runtime, Workspace (parameterized)
- **Conditional**: Message Tool Hints, Authorized Senders, Reactions (only when params provided)

**Design**: No `promptMode` switch (always full), no bootstrap context (CLI agent handles), no tool list (MCP handles), no skills/memory/sandbox sections.

**Budget**: Base prompt <4,000 chars, worst-case with LINE hints <6,000 chars (~770-1,270 tokens).

Closes #28

## Test plan

- [x] All 25 new tests pass: `npx vitest run src/middleware/system-prompt.test.ts`
- [x] Full suite passes: 1,558 test files, 13,136 tests
- [x] Typecheck clean: `pnpm tsgo`
- [x] Lint clean: `pnpm lint`
- [x] Format clean: `pnpm format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)