### PR TITLE
feat(middleware): implement MCP server with 29 tools (#30)

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "@mariozechner/pi-ai": "0.55.0",
     "@mariozechner/pi-coding-agent": "0.55.0",
     "@mariozechner/pi-tui": "0.55.0",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "@mozilla/readability": "^0.6.0",
     "@sinclair/typebox": "0.34.48",
     "@slack/bolt": "^4.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,16 +55,19 @@ importers:
         version: 1.2.0-beta.3
       '@mariozechner/pi-agent-core':
         specifier: 0.55.0
-        version: 0.55.0(ws@8.19.0)(zod@4.3.6)
+        version: 0.55.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
         specifier: 0.55.0
-        version: 0.55.0(ws@8.19.0)(zod@4.3.6)
+        version: 0.55.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.55.0
-        version: 0.55.0(ws@8.19.0)(zod@4.3.6)
+        version: 0.55.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
         specifier: 0.55.0
         version: 0.55.0
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.27.1
+        version: 1.27.1(zod@4.3.6)
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0
@@ -314,7 +317,7 @@ importers:
         version: 10.6.1
       openclaw:
         specifier: '>=2026.1.26'
-        version: 2026.2.23(@napi-rs/canvas@0.1.94)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3))
+        version: 2026.2.23(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(@napi-rs/canvas@0.1.94)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3))
 
   extensions/imessage: {}
 
@@ -350,7 +353,7 @@ importers:
     dependencies:
       openclaw:
         specifier: '>=2026.1.26'
-        version: 2026.2.23(@napi-rs/canvas@0.1.94)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3))
+        version: 2026.2.23(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(@napi-rs/canvas@0.1.94)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3))
 
   extensions/memory-lancedb:
     dependencies:
@@ -1542,6 +1545,16 @@ packages:
 
   '@mistralai/mistralai@1.10.0':
     resolution: {integrity: sha512-tdIgWs4Le8vpvPiUEWne6tK0qbVc+jMenujnvTqOjogrJUsCSQhus0tHTU1avDDh5//Rq2dFgP9mWRAdIEoBqg==}
+
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mozilla/readability@0.6.0':
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
@@ -3793,6 +3806,10 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   croner@10.0.1:
     resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
     engines: {node: '>=18.0'}
@@ -4031,9 +4048,23 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.2.1:
+    resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
@@ -4181,10 +4212,6 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
-
-  get-east-asian-width@1.4.0:
-    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
-    engines: {node: '>=18'}
 
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
@@ -4364,6 +4391,10 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  ip-address@10.0.1:
+    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+    engines: {node: '>= 12'}
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
@@ -4459,6 +4490,9 @@ packages:
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
 
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -4483,6 +4517,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -5190,6 +5227,10 @@ packages:
   pixelmatch@7.1.0:
     resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   playwright-core@1.58.2:
     resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
@@ -7368,12 +7409,14 @@ snapshots:
   '@eshaz/web-worker@1.2.2':
     optional: true
 
-  '@google/genai@1.42.0':
+  '@google/genai@1.42.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))':
     dependencies:
       google-auth-library: 10.6.1
       p-retry: 4.6.2
       protobufjs: 7.5.4
       ws: 8.19.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -7421,7 +7464,6 @@ snapshots:
   '@hono/node-server@1.19.9(hono@4.11.10)':
     dependencies:
       hono: 4.11.10
-    optional: true
 
   '@huggingface/jinja@0.5.5': {}
 
@@ -7602,7 +7644,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -7618,7 +7660,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7713,9 +7755,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.54.1(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-agent-core@0.54.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.54.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.54.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -7725,9 +7767,9 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-agent-core@0.55.0(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-agent-core@0.55.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -7737,11 +7779,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.54.1(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.54.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.995.0
-      '@google/genai': 1.42.0
+      '@google/genai': 1.42.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))
       '@mistralai/mistralai': 1.10.0
       '@sinclair/typebox': 0.34.48
       ajv: 8.18.0
@@ -7761,11 +7803,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.55.0(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.55.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.997.0
-      '@google/genai': 1.42.0
+      '@google/genai': 1.42.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))
       '@mistralai/mistralai': 1.10.0
       '@sinclair/typebox': 0.34.48
       ajv: 8.18.0
@@ -7785,11 +7827,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.54.1(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.54.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.54.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.54.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-agent-core': 0.54.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.54.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.54.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -7814,11 +7856,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.55.0(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.55.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-agent-core': 0.55.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.55.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -7881,7 +7923,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 5.0.4
       '@microsoft/agents-activity': 1.3.1
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7894,6 +7936,28 @@ snapshots:
     dependencies:
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
+
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.11.10)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.11.10
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@mozilla/readability@0.6.0': {}
 
@@ -8782,7 +8846,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8828,7 +8892,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.3.0
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -10071,14 +10135,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -10305,6 +10361,11 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   croner@10.0.1: {}
 
   cross-spawn@7.0.6:
@@ -10510,7 +10571,18 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.2.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.0.1
 
   express@4.22.1:
     dependencies:
@@ -10648,8 +10720,6 @@ snapshots:
 
   flatbuffers@24.12.23: {}
 
-  follow-redirects@1.15.11: {}
-
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3
@@ -10739,8 +10809,6 @@ snapshots:
       - supports-color
 
   get-caller-file@2.0.5: {}
-
-  get-east-asian-width@1.4.0: {}
 
   get-east-asian-width@1.5.0: {}
 
@@ -10859,8 +10927,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.11.10:
-    optional: true
+  hono@4.11.10: {}
 
   hookable@6.0.1: {}
 
@@ -10967,6 +11034,8 @@ snapshots:
 
   ini@1.3.8: {}
 
+  ip-address@10.0.1: {}
+
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
@@ -11016,7 +11085,7 @@ snapshots:
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
-      get-east-asian-width: 1.4.0
+      get-east-asian-width: 1.5.0
 
   is-interactive@2.0.0: {}
 
@@ -11065,6 +11134,8 @@ snapshots:
 
   jose@4.15.9: {}
 
+  jose@6.1.3: {}
+
   js-tokens@10.0.0: {}
 
   jsbn@0.1.1: {}
@@ -11083,6 +11154,8 @@ snapshots:
       ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -11628,7 +11701,7 @@ snapshots:
       ws: 8.19.0
       zod: 4.3.6
 
-  openclaw@2026.2.23(@napi-rs/canvas@0.1.94)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3)):
+  openclaw@2026.2.23(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(@napi-rs/canvas@0.1.94)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3)):
     dependencies:
       '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
       '@aws-sdk/client-bedrock': 3.995.0
@@ -11641,9 +11714,9 @@ snapshots:
       '@larksuiteoapi/node-sdk': 1.59.0
       '@line/bot-sdk': 10.6.0
       '@lydell/node-pty': 1.2.0-beta.3
-      '@mariozechner/pi-agent-core': 0.54.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.54.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-coding-agent': 0.54.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-agent-core': 0.54.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.54.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent': 0.54.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.54.1
       '@mozilla/readability': 0.6.0
       '@napi-rs/canvas': 0.1.94
@@ -11910,6 +11983,8 @@ snapshots:
   pixelmatch@7.1.0:
     dependencies:
       pngjs: 7.0.0
+
+  pkce-challenge@5.0.1: {}
 
   playwright-core@1.58.2: {}
 
@@ -12505,7 +12580,7 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
-      get-east-asian-width: 1.4.0
+      get-east-asian-width: 1.5.0
       strip-ansi: 7.1.2
 
   string_decoder@1.1.1:

--- a/src/middleware/mcp-handlers/context.ts
+++ b/src/middleware/mcp-handlers/context.ts
@@ -1,0 +1,26 @@
+import type { McpSideEffectsWriter } from "../mcp-side-effects.js";
+
+// ── MCP Handler Context ────────────────────────────────────────────────
+
+/**
+ * Shared context passed to all MCP tool handlers.
+ * Populated from environment variables set by ChannelBridge.
+ */
+export type McpHandlerContext = {
+  /** Gateway WebSocket URL (e.g., `ws://127.0.0.1:18789`). */
+  gatewayUrl: string;
+  /** Gateway auth token. */
+  gatewayToken: string;
+  /** Current session key. */
+  sessionKey: string;
+  /** Side effects NDJSON writer. */
+  sideEffects: McpSideEffectsWriter;
+  /** Originating channel (e.g., `telegram`). */
+  channel: string;
+  /** Originating account ID. */
+  accountId: string;
+  /** Originating delivery target. */
+  to: string;
+  /** Originating thread/topic ID. */
+  threadId: string;
+};

--- a/src/middleware/mcp-handlers/cron.test.ts
+++ b/src/middleware/mcp-handlers/cron.test.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { McpSideEffectsWriter } from "../mcp-side-effects.js";
+import { readMcpSideEffects } from "../mcp-side-effects.js";
+import type { McpHandlerContext } from "./context.js";
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: vi.fn(),
+}));
+vi.mock("../../gateway/method-scopes.js", () => ({
+  resolveLeastPrivilegeOperatorScopesForMethod: vi.fn().mockReturnValue(["operator.write"]),
+}));
+vi.mock("../../utils/message-channel.js", () => ({
+  GATEWAY_CLIENT_NAMES: { GATEWAY_CLIENT: "agent-client" },
+  GATEWAY_CLIENT_MODES: { BACKEND: "backend" },
+}));
+
+import { callGateway } from "../../gateway/call.js";
+import { registerCronTools } from "./cron.js";
+
+const mockCallGateway = vi.mocked(callGateway);
+
+function createMockServer() {
+  const tools = new Map<string, { handler: Function; config: Record<string, unknown> }>();
+  return {
+    tools,
+    registerTool: vi.fn((name: string, config: Record<string, unknown>, handler: Function) => {
+      tools.set(name, { handler, config });
+      return { update: vi.fn(), remove: vi.fn(), disable: vi.fn(), enable: vi.fn() };
+    }),
+  };
+}
+
+describe("registerCronTools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let ctx: McpHandlerContext;
+  let dir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dir = mkdtempSync(join(tmpdir(), "mcp-cron-"));
+    mockServer = createMockServer();
+    ctx = {
+      gatewayUrl: "ws://127.0.0.1:18789",
+      gatewayToken: "test-token",
+      sessionKey: "agent:default:main",
+      sideEffects: new McpSideEffectsWriter(join(dir, "effects.ndjson")),
+      channel: "telegram",
+      accountId: "acc-1",
+      to: "chat-123",
+      threadId: "",
+    };
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerCronTools(mockServer as any, ctx);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("registers 7 cron tools", () => {
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(7);
+  });
+
+  it("cron_status calls cron.status", async () => {
+    mockCallGateway.mockResolvedValueOnce({ running: true });
+
+    const tool = mockServer.tools.get("cron_status");
+    await tool!.handler({});
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "cron.status" }),
+    );
+  });
+
+  it("cron_add calls cron.add and records side effect", async () => {
+    mockCallGateway.mockResolvedValueOnce({ id: "job-123" });
+
+    const tool = mockServer.tools.get("cron_add");
+    await tool!.handler({ job: { name: "test", schedule: { kind: "cron", expr: "0 * * * *" } } });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(expect.objectContaining({ method: "cron.add" }));
+
+    const effects = await readMcpSideEffects(join(dir, "effects.ndjson"));
+    expect(effects.cronAdds).toBe(1);
+  });
+
+  it("cron_remove calls cron.remove with correct id", async () => {
+    mockCallGateway.mockResolvedValueOnce({ ok: true });
+
+    const tool = mockServer.tools.get("cron_remove");
+    await tool!.handler({ jobId: "job-123" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "cron.remove",
+        params: { id: "job-123" },
+      }),
+    );
+  });
+
+  it("cron_run calls cron.run with force mode", async () => {
+    mockCallGateway.mockResolvedValueOnce({ triggered: true });
+
+    const tool = mockServer.tools.get("cron_run");
+    await tool!.handler({ jobId: "job-456" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "cron.run",
+        params: { id: "job-456", mode: "force" },
+      }),
+    );
+  });
+});

--- a/src/middleware/mcp-handlers/cron.ts
+++ b/src/middleware/mcp-handlers/cron.ts
@@ -1,0 +1,130 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { McpHandlerContext } from "./context.js";
+import { callMcpGateway } from "./session.js";
+
+// ── Cron Tool Handlers ───────────────────────────────────────────────
+
+/**
+ * Registers all cron scheduling MCP tools on the given server.
+ */
+export function registerCronTools(server: McpServer, ctx: McpHandlerContext): void {
+  // 1. cron_status — Check cron scheduler status
+  server.registerTool(
+    "cron_status",
+    {
+      description: "Check cron scheduler status.",
+      inputSchema: z.object({}),
+    },
+    async () => {
+      const result = await callMcpGateway(ctx, "cron.status", {});
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // 2. cron_list — List cron jobs
+  server.registerTool(
+    "cron_list",
+    {
+      description: "List cron jobs.",
+      inputSchema: z.object({
+        filter: z.string().optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "cron.list", {
+        includeDisabled: true,
+        ...(args.filter !== undefined ? { filter: args.filter } : {}),
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // 3. cron_add — Add a cron job (SIDE EFFECT)
+  server.registerTool(
+    "cron_add",
+    {
+      description: "Create a new cron job.",
+      inputSchema: z.object({
+        job: z.record(z.string(), z.unknown()),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway<Record<string, unknown>>(ctx, "cron.add", args.job);
+      const jobId = typeof result?.id === "string" ? result.id : undefined;
+      await ctx.sideEffects.recordCronAdd(jobId);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // 4. cron_update — Update a cron job
+  server.registerTool(
+    "cron_update",
+    {
+      description: "Update a cron job.",
+      inputSchema: z.object({
+        jobId: z.string(),
+        patch: z.record(z.string(), z.unknown()),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "cron.update", {
+        id: args.jobId,
+        patch: args.patch,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // 5. cron_remove — Remove a cron job
+  server.registerTool(
+    "cron_remove",
+    {
+      description: "Remove a cron job.",
+      inputSchema: z.object({
+        jobId: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "cron.remove", { id: args.jobId });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // 6. cron_run — Trigger a cron job immediately
+  server.registerTool(
+    "cron_run",
+    {
+      description: "Trigger a cron job immediately.",
+      inputSchema: z.object({
+        jobId: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "cron.run", {
+        id: args.jobId,
+        mode: "force",
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // 7. cron_runs — Get run history for a cron job
+  server.registerTool(
+    "cron_runs",
+    {
+      description: "Get run history for a cron job.",
+      inputSchema: z.object({
+        jobId: z.string(),
+        limit: z.number().optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "cron.runs", {
+        id: args.jobId,
+        ...(args.limit !== undefined ? { limit: args.limit } : {}),
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/src/middleware/mcp-handlers/gateway.ts
+++ b/src/middleware/mcp-handlers/gateway.ts
@@ -1,0 +1,87 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { McpHandlerContext } from "./context.js";
+import { callMcpGateway } from "./session.js";
+
+// ── Gateway Admin Tools ──────────────────────────────────────────────
+
+/**
+ * Registers gateway administration MCP tools on the given server.
+ *
+ * Tools: gateway_restart, gateway_config_get, gateway_config_apply,
+ *        gateway_config_patch, gateway_config_schema.
+ */
+export function registerGatewayTools(server: McpServer, ctx: McpHandlerContext): void {
+  server.registerTool(
+    "gateway_restart",
+    {
+      description: "Restart the gateway process.",
+      inputSchema: z.object({}),
+    },
+    async () => {
+      const result = await callMcpGateway(ctx, "gateway:restart", {});
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "gateway_config_get",
+    {
+      description: "Get gateway configuration. Optionally filter by key.",
+      inputSchema: z.object({
+        key: z.string().optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "gateway:config.get", {
+        key: args.key,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "gateway_config_apply",
+    {
+      description:
+        "Apply a full gateway configuration object, replacing the current configuration.",
+      inputSchema: z.object({
+        config: z.object({}).passthrough(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "gateway:config.apply", {
+        config: args.config,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "gateway_config_patch",
+    {
+      description: "Patch the gateway configuration with a partial update.",
+      inputSchema: z.object({
+        patches: z.object({}).passthrough(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "gateway:config.patch", {
+        patches: args.patches,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "gateway_config_schema",
+    {
+      description: "Get the JSON schema for gateway configuration.",
+      inputSchema: z.object({}),
+    },
+    async () => {
+      const result = await callMcpGateway(ctx, "gateway:config.schema", {});
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/src/middleware/mcp-handlers/message.test.ts
+++ b/src/middleware/mcp-handlers/message.test.ts
@@ -1,0 +1,131 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { McpSideEffectsWriter } from "../mcp-side-effects.js";
+import { readMcpSideEffects } from "../mcp-side-effects.js";
+import type { McpHandlerContext } from "./context.js";
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: vi.fn(),
+}));
+vi.mock("../../gateway/method-scopes.js", () => ({
+  resolveLeastPrivilegeOperatorScopesForMethod: vi.fn().mockReturnValue(["operator.write"]),
+}));
+vi.mock("../../utils/message-channel.js", () => ({
+  GATEWAY_CLIENT_NAMES: { GATEWAY_CLIENT: "agent-client" },
+  GATEWAY_CLIENT_MODES: { BACKEND: "backend" },
+}));
+
+import { callGateway } from "../../gateway/call.js";
+import { registerMessageTools } from "./message.js";
+
+const mockCallGateway = vi.mocked(callGateway);
+
+function createMockServer() {
+  const tools = new Map<string, { handler: Function; config: Record<string, unknown> }>();
+  return {
+    tools,
+    registerTool: vi.fn((name: string, config: Record<string, unknown>, handler: Function) => {
+      tools.set(name, { handler, config });
+      return { update: vi.fn(), remove: vi.fn(), disable: vi.fn(), enable: vi.fn() };
+    }),
+  };
+}
+
+describe("registerMessageTools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let ctx: McpHandlerContext;
+  let dir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dir = mkdtempSync(join(tmpdir(), "mcp-msg-"));
+    mockServer = createMockServer();
+    ctx = {
+      gatewayUrl: "ws://127.0.0.1:18789",
+      gatewayToken: "test-token",
+      sessionKey: "agent:default:main",
+      sideEffects: new McpSideEffectsWriter(join(dir, "effects.ndjson")),
+      channel: "telegram",
+      accountId: "acc-1",
+      to: "chat-123",
+      threadId: "",
+    };
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerMessageTools(mockServer as any, ctx);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("registers 10 message tools", () => {
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(10);
+  });
+
+  it("message_send calls message:send and records side effect", async () => {
+    mockCallGateway.mockResolvedValueOnce({ ok: true });
+
+    const tool = mockServer.tools.get("message_send");
+    await tool!.handler({ target: "user-1", message: "Hello" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "message:send",
+        params: expect.objectContaining({ target: "user-1", message: "Hello" }),
+      }),
+    );
+
+    const effects = await readMcpSideEffects(join(dir, "effects.ndjson"));
+    expect(effects.sentTexts).toEqual(["Hello"]);
+    expect(effects.sentTargets[0]).toEqual(
+      expect.objectContaining({ tool: "message_send", provider: "telegram", to: "user-1" }),
+    );
+  });
+
+  it("message_reply calls message:reply and records side effect", async () => {
+    mockCallGateway.mockResolvedValueOnce({ ok: true });
+
+    const tool = mockServer.tools.get("message_reply");
+    await tool!.handler({ message: "Reply text" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "message:reply",
+        params: expect.objectContaining({ message: "Reply text", to: "chat-123" }),
+      }),
+    );
+
+    const effects = await readMcpSideEffects(join(dir, "effects.ndjson"));
+    expect(effects.sentTexts).toEqual(["Reply text"]);
+  });
+
+  it("message_react does not record side effect", async () => {
+    mockCallGateway.mockResolvedValueOnce({ ok: true });
+
+    const tool = mockServer.tools.get("message_react");
+    await tool!.handler({ emoji: "\u{1F44D}", messageId: "msg-1" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "message:react" }),
+    );
+
+    const effects = await readMcpSideEffects(join(dir, "effects.ndjson"));
+    expect(effects.sentTexts).toEqual([]);
+  });
+
+  it("message_read calls message:readMessages", async () => {
+    mockCallGateway.mockResolvedValueOnce({ messages: [] });
+
+    const tool = mockServer.tools.get("message_read");
+    await tool!.handler({ limit: 10 });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "message:readMessages",
+        params: expect.objectContaining({ channelId: "chat-123", limit: 10 }),
+      }),
+    );
+  });
+});

--- a/src/middleware/mcp-handlers/message.ts
+++ b/src/middleware/mcp-handlers/message.ts
@@ -1,0 +1,284 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { McpHandlerContext } from "./context.js";
+import { callMcpGateway } from "./session.js";
+
+// ── Message Tool Handlers ────────────────────────────────────────────────
+
+/**
+ * Registers channel messaging MCP tools on the given server.
+ *
+ * Each tool delegates to a `message:*` gateway method and, for tools that
+ * send messages, records a side effect via {@link McpHandlerContext.sideEffects}.
+ */
+export function registerMessageTools(server: McpServer, ctx: McpHandlerContext): void {
+  // ── message_send ─────────────────────────────────────────────────────
+
+  server.registerTool(
+    "message_send",
+    {
+      description: "Send a message to a target channel or user.",
+      inputSchema: z.object({
+        target: z.string(),
+        message: z.string(),
+        media: z.string().optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "message:send", {
+        target: args.target,
+        message: args.message,
+        media: args.media,
+        channel: ctx.channel,
+        accountId: ctx.accountId,
+      });
+      await ctx.sideEffects.recordMessageSent({
+        tool: "message_send",
+        provider: ctx.channel,
+        accountId: ctx.accountId,
+        to: args.target,
+        text: args.message,
+        mediaUrl: args.media,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ── message_reply ────────────────────────────────────────────────────
+
+  server.registerTool(
+    "message_reply",
+    {
+      description: "Reply to a message in the current conversation.",
+      inputSchema: z.object({
+        message: z.string(),
+        replyToId: z.string().optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "message:reply", {
+        message: args.message,
+        replyToId: args.replyToId,
+        channel: ctx.channel,
+        accountId: ctx.accountId,
+        to: ctx.to,
+      });
+      await ctx.sideEffects.recordMessageSent({
+        tool: "message_reply",
+        provider: ctx.channel,
+        accountId: ctx.accountId,
+        to: ctx.to,
+        text: args.message,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ── message_thread_reply ─────────────────────────────────────────────
+
+  server.registerTool(
+    "message_thread_reply",
+    {
+      description: "Reply to a message within a specific thread.",
+      inputSchema: z.object({
+        message: z.string(),
+        threadId: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "message:thread-reply", {
+        message: args.message,
+        threadId: args.threadId,
+        channel: ctx.channel,
+        accountId: ctx.accountId,
+        to: ctx.to,
+      });
+      await ctx.sideEffects.recordMessageSent({
+        tool: "message_thread_reply",
+        provider: ctx.channel,
+        accountId: ctx.accountId,
+        to: ctx.to,
+        text: args.message,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ── message_broadcast ────────────────────────────────────────────────
+
+  server.registerTool(
+    "message_broadcast",
+    {
+      description: "Broadcast a message to multiple targets.",
+      inputSchema: z.object({
+        targets: z.array(z.string()),
+        message: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "message:broadcast", {
+        targets: args.targets,
+        message: args.message,
+        channel: ctx.channel,
+        accountId: ctx.accountId,
+      });
+      await ctx.sideEffects.recordMessageSent({
+        tool: "message_broadcast",
+        provider: ctx.channel,
+        accountId: ctx.accountId,
+        text: args.message,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ── message_react ────────────────────────────────────────────────────
+
+  server.registerTool(
+    "message_react",
+    {
+      description: "React to a message with an emoji.",
+      inputSchema: z.object({
+        emoji: z.string(),
+        messageId: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "message:react", {
+        emoji: args.emoji,
+        messageId: args.messageId,
+        channel: ctx.channel,
+        accountId: ctx.accountId,
+        to: ctx.to,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ── message_delete ───────────────────────────────────────────────────
+
+  server.registerTool(
+    "message_delete",
+    {
+      description: "Delete a message.",
+      inputSchema: z.object({
+        messageId: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "message:delete", {
+        messageId: args.messageId,
+        channel: ctx.channel,
+        accountId: ctx.accountId,
+        to: ctx.to,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ── message_send_attachment ──────────────────────────────────────────
+
+  server.registerTool(
+    "message_send_attachment",
+    {
+      description: "Send a file attachment to a target.",
+      inputSchema: z.object({
+        target: z.string(),
+        file: z.string(),
+        caption: z.string().optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "message:sendAttachment", {
+        target: args.target,
+        file: args.file,
+        caption: args.caption,
+        channel: ctx.channel,
+        accountId: ctx.accountId,
+      });
+      await ctx.sideEffects.recordMessageSent({
+        tool: "message_send_attachment",
+        provider: ctx.channel,
+        accountId: ctx.accountId,
+        to: args.target,
+        text: args.caption ?? "",
+        mediaUrl: args.file,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ── message_send_with_effect ─────────────────────────────────────────
+
+  server.registerTool(
+    "message_send_with_effect",
+    {
+      description: "Send a message with a visual effect.",
+      inputSchema: z.object({
+        target: z.string(),
+        message: z.string(),
+        effectId: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "message:sendWithEffect", {
+        target: args.target,
+        message: args.message,
+        effectId: args.effectId,
+        channel: ctx.channel,
+        accountId: ctx.accountId,
+      });
+      await ctx.sideEffects.recordMessageSent({
+        tool: "message_send_with_effect",
+        provider: ctx.channel,
+        accountId: ctx.accountId,
+        to: args.target,
+        text: args.message,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ── message_pin ──────────────────────────────────────────────────────
+
+  server.registerTool(
+    "message_pin",
+    {
+      description: "Pin a message in a channel.",
+      inputSchema: z.object({
+        messageId: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "message:pin", {
+        messageId: args.messageId,
+        channel: ctx.channel,
+        accountId: ctx.accountId,
+        to: ctx.to,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ── message_read ─────────────────────────────────────────────────────
+
+  server.registerTool(
+    "message_read",
+    {
+      description: "Read messages from a channel.",
+      inputSchema: z.object({
+        channelId: z.string().optional(),
+        limit: z.number().optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "message:readMessages", {
+        channelId: args.channelId ?? ctx.to,
+        limit: args.limit,
+        channel: ctx.channel,
+        accountId: ctx.accountId,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/src/middleware/mcp-handlers/session.test.ts
+++ b/src/middleware/mcp-handlers/session.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { McpSideEffectsWriter } from "../mcp-side-effects.js";
+import type { McpHandlerContext } from "./context.js";
+
+// Mock gateway modules
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: vi.fn(),
+}));
+vi.mock("../../gateway/method-scopes.js", () => ({
+  resolveLeastPrivilegeOperatorScopesForMethod: vi.fn().mockReturnValue(["operator.read"]),
+}));
+vi.mock("../../utils/message-channel.js", () => ({
+  GATEWAY_CLIENT_NAMES: { GATEWAY_CLIENT: "agent-client" },
+  GATEWAY_CLIENT_MODES: { BACKEND: "backend" },
+}));
+
+import { callGateway } from "../../gateway/call.js";
+import { callMcpGateway, registerSessionTools } from "./session.js";
+
+const mockCallGateway = vi.mocked(callGateway);
+
+function createMockContext(): McpHandlerContext {
+  return {
+    gatewayUrl: "ws://127.0.0.1:18789",
+    gatewayToken: "test-token",
+    sessionKey: "agent:default:main",
+    sideEffects: new McpSideEffectsWriter("/dev/null"),
+    channel: "telegram",
+    accountId: "test-account",
+    to: "test-target",
+    threadId: "",
+  };
+}
+
+function createMockServer() {
+  const tools = new Map<string, { handler: Function; config: Record<string, unknown> }>();
+  return {
+    tools,
+    registerTool: vi.fn((name: string, config: Record<string, unknown>, handler: Function) => {
+      tools.set(name, { handler, config });
+      return { update: vi.fn(), remove: vi.fn(), disable: vi.fn(), enable: vi.fn() };
+    }),
+  };
+}
+
+describe("callMcpGateway", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls gateway with correct parameters", async () => {
+    const ctx = createMockContext();
+    mockCallGateway.mockResolvedValueOnce({ sessions: [] });
+
+    const result = await callMcpGateway(ctx, "sessions.list", { limit: 10 });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "ws://127.0.0.1:18789",
+        token: "test-token",
+        method: "sessions.list",
+        params: { limit: 10 },
+        timeoutMs: 30_000,
+      }),
+    );
+    expect(result).toEqual({ sessions: [] });
+  });
+});
+
+describe("registerSessionTools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let ctx: McpHandlerContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockServer = createMockServer();
+    ctx = createMockContext();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerSessionTools(mockServer as any, ctx);
+  });
+
+  it("registers 7 session tools", () => {
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(7);
+  });
+
+  it("sessions_list calls sessions.list gateway method", async () => {
+    mockCallGateway.mockResolvedValueOnce({ sessions: [{ key: "main" }] });
+
+    const tool = mockServer.tools.get("sessions_list");
+    const result = await tool!.handler({ limit: 5 });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "sessions.list" }),
+    );
+    expect(result.content[0].type).toBe("text");
+  });
+
+  it("sessions_history calls chat.history gateway method", async () => {
+    mockCallGateway.mockResolvedValueOnce({ messages: [] });
+
+    const tool = mockServer.tools.get("sessions_history");
+    await tool!.handler({ sessionKey: "agent:default:main", limit: 10 });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "chat.history",
+        params: { sessionKey: "agent:default:main", limit: 10 },
+      }),
+    );
+  });
+
+  it("agents_list calls agents.list gateway method", async () => {
+    mockCallGateway.mockResolvedValueOnce({ agents: [] });
+
+    const tool = mockServer.tools.get("agents_list");
+    await tool!.handler({});
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "agents.list" }),
+    );
+  });
+
+  it("session_status defaults to current session key", async () => {
+    mockCallGateway.mockResolvedValueOnce({ status: "active" });
+
+    const tool = mockServer.tools.get("session_status");
+    await tool!.handler({});
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "status",
+        params: { sessionKey: "agent:default:main" },
+      }),
+    );
+  });
+});

--- a/src/middleware/mcp-handlers/session.ts
+++ b/src/middleware/mcp-handlers/session.ts
@@ -1,0 +1,250 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { callGateway } from "../../gateway/call.js";
+import { resolveLeastPrivilegeOperatorScopesForMethod } from "../../gateway/method-scopes.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
+import type { McpHandlerContext } from "./context.js";
+
+// ── Gateway helper ───────────────────────────────────────────────────
+
+/**
+ * Call the gateway with least-privilege scopes for the given method.
+ * Shared by all session MCP handlers (and exported for other handler modules).
+ */
+export async function callMcpGateway<T>(
+  ctx: McpHandlerContext,
+  method: string,
+  params?: unknown,
+): Promise<T> {
+  const scopes = resolveLeastPrivilegeOperatorScopesForMethod(method);
+  const result = await callGateway<T>({
+    url: ctx.gatewayUrl,
+    token: ctx.gatewayToken,
+    method,
+    params,
+    timeoutMs: 30_000,
+    clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+    clientDisplayName: "mcp-server",
+    mode: GATEWAY_CLIENT_MODES.BACKEND,
+    scopes,
+  });
+  return result as T;
+}
+
+// ── Session tool registration ────────────────────────────────────────
+
+/**
+ * Register all session-management MCP tools on the given server.
+ */
+export function registerSessionTools(server: McpServer, ctx: McpHandlerContext): void {
+  // 1. sessions_list ───────────────────────────────────────────────────
+  server.registerTool(
+    "sessions_list",
+    {
+      description: "List active sessions with optional filters.",
+      inputSchema: z.object({
+        filter: z.string().optional(),
+        limit: z.number().optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "sessions.list", {
+        limit: args.filter !== undefined ? undefined : args.limit,
+        includeGlobal: true,
+        includeUnknown: true,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // 2. sessions_history ────────────────────────────────────────────────
+  server.registerTool(
+    "sessions_history",
+    {
+      description: "Get chat history for a session.",
+      inputSchema: z.object({
+        sessionKey: z.string(),
+        limit: z.number().optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "chat.history", {
+        sessionKey: args.sessionKey,
+        limit: args.limit,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // 3. sessions_send ───────────────────────────────────────────────────
+  server.registerTool(
+    "sessions_send",
+    {
+      description:
+        "Send a message to another session. Use sessionKey or label to identify the target.",
+      inputSchema: z.object({
+        sessionKey: z.string().optional(),
+        label: z.string().optional(),
+        message: z.string(),
+        timeout: z.number().optional(),
+      }),
+    },
+    async (args) => {
+      const sessionKey = args.sessionKey ?? args.label;
+      const timeoutMs = (args.timeout ?? 30) * 1000;
+
+      // Send message
+      const sendResult = await callMcpGateway<{ runId?: string }>(ctx, "agent", {
+        message: args.message,
+        sessionKey,
+        deliver: false,
+        channel: "internal",
+      });
+      const runId = sendResult?.runId;
+
+      // Record side effect
+      await ctx.sideEffects.recordMessageSent({
+        tool: "sessions_send",
+        provider: ctx.channel,
+        accountId: ctx.accountId,
+        to: sessionKey ?? "",
+        text: args.message,
+      });
+
+      // If timeout is 0, return immediately
+      if (args.timeout === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ runId, status: "accepted" }, null, 2),
+            },
+          ],
+        };
+      }
+
+      // Wait for reply
+      try {
+        const waitResult = await callMcpGateway<{ status?: string; error?: string }>(
+          ctx,
+          "agent.wait",
+          {
+            runId,
+            timeoutMs,
+          },
+        );
+
+        // Get the reply from history
+        const history = await callMcpGateway<{ messages?: unknown[] }>(ctx, "chat.history", {
+          sessionKey,
+          limit: 5,
+        });
+        const messages = Array.isArray(history?.messages) ? history.messages : [];
+        const last = messages[messages.length - 1];
+        const reply =
+          last && typeof last === "object" && "content" in (last as Record<string, unknown>)
+            ? String((last as Record<string, unknown>).content)
+            : undefined;
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  runId,
+                  status: waitResult?.status ?? "ok",
+                  reply,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ runId, status: "error", error: message }, null, 2),
+            },
+          ],
+        };
+      }
+    },
+  );
+
+  // 4. sessions_spawn ──────────────────────────────────────────────────
+  server.registerTool(
+    "sessions_spawn",
+    {
+      description: "Spawn a sub-agent session to handle a delegated task.",
+      inputSchema: z.object({
+        task: z.string(),
+        agentId: z.string().optional(),
+        label: z.string().optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "sessions.spawn", {
+        task: args.task,
+        agentId: args.agentId,
+        label: args.label,
+        sessionKey: ctx.sessionKey,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // 5. session_status ──────────────────────────────────────────────────
+  server.registerTool(
+    "session_status",
+    {
+      description: "Get the current status of a session.",
+      inputSchema: z.object({
+        sessionKey: z.string().optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "status", {
+        sessionKey: args.sessionKey ?? ctx.sessionKey,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // 6. agents_list ─────────────────────────────────────────────────────
+  server.registerTool(
+    "agents_list",
+    {
+      description: "List all configured agents.",
+      inputSchema: z.object({}),
+    },
+    async () => {
+      const result = await callMcpGateway(ctx, "agents.list");
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // 7. subagents ───────────────────────────────────────────────────────
+  server.registerTool(
+    "subagents",
+    {
+      description: "Manage sub-agents (list, status, cancel, etc.).",
+      inputSchema: z.object({
+        action: z.string(),
+        params: z.record(z.string(), z.unknown()).optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "sessions.subagents", {
+        action: args.action,
+        ...args.params,
+        sessionKey: ctx.sessionKey,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/src/middleware/mcp-server.ts
+++ b/src/middleware/mcp-server.ts
@@ -1,0 +1,45 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { McpHandlerContext } from "./mcp-handlers/context.js";
+import { McpSideEffectsWriter } from "./mcp-side-effects.js";
+import { registerAllTools } from "./mcp-tools.js";
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function createContext(): McpHandlerContext {
+  return {
+    gatewayUrl: requiredEnv("REMOTECLAW_GATEWAY_URL"),
+    gatewayToken: requiredEnv("REMOTECLAW_GATEWAY_TOKEN"),
+    sessionKey: requiredEnv("REMOTECLAW_SESSION_KEY"),
+    sideEffects: new McpSideEffectsWriter(requiredEnv("REMOTECLAW_SIDE_EFFECTS_FILE")),
+    channel: process.env.REMOTECLAW_CHANNEL ?? "",
+    accountId: process.env.REMOTECLAW_ACCOUNT_ID ?? "",
+    to: process.env.REMOTECLAW_TO ?? "",
+    threadId: process.env.REMOTECLAW_THREAD_ID ?? "",
+  };
+}
+
+async function main(): Promise<void> {
+  const ctx = createContext();
+
+  const server = new McpServer({
+    name: "remoteclaw",
+    version: "1.0.0",
+  });
+
+  registerAllTools(server, ctx);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`remoteclaw-mcp-server fatal: ${err}\n`);
+  process.exit(1);
+});

--- a/src/middleware/mcp-side-effects.test.ts
+++ b/src/middleware/mcp-side-effects.test.ts
@@ -1,0 +1,156 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { McpSideEffectsWriter, readMcpSideEffects } from "./mcp-side-effects.js";
+
+describe("McpSideEffectsWriter", () => {
+  let dir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mcp-se-"));
+    filePath = join(dir, "side-effects.ndjson");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("records a message_sent side effect", async () => {
+    const writer = new McpSideEffectsWriter(filePath);
+    await writer.recordMessageSent({
+      tool: "message",
+      provider: "telegram",
+      to: "group:123",
+      text: "Hello",
+    });
+
+    const result = await readMcpSideEffects(filePath);
+    expect(result.sentTexts).toEqual(["Hello"]);
+    expect(result.sentTargets).toEqual([
+      { tool: "message", provider: "telegram", to: "group:123" },
+    ]);
+    expect(result.sentMediaUrls).toEqual([]);
+    expect(result.cronAdds).toBe(0);
+  });
+
+  it("records a message_sent with media URL", async () => {
+    const writer = new McpSideEffectsWriter(filePath);
+    await writer.recordMessageSent({
+      tool: "message_send_attachment",
+      provider: "discord",
+      to: "channel:456",
+      text: "Check this out",
+      mediaUrl: "https://example.com/image.png",
+    });
+
+    const result = await readMcpSideEffects(filePath);
+    expect(result.sentTexts).toEqual(["Check this out"]);
+    expect(result.sentMediaUrls).toEqual(["https://example.com/image.png"]);
+    expect(result.sentTargets).toEqual([
+      { tool: "message_send_attachment", provider: "discord", to: "channel:456" },
+    ]);
+  });
+
+  it("records a cron_added side effect", async () => {
+    const writer = new McpSideEffectsWriter(filePath);
+    await writer.recordCronAdd("job-xyz");
+
+    const result = await readMcpSideEffects(filePath);
+    expect(result.cronAdds).toBe(1);
+    expect(result.sentTexts).toEqual([]);
+  });
+
+  it("records multiple side effects", async () => {
+    const writer = new McpSideEffectsWriter(filePath);
+    await writer.recordMessageSent({
+      tool: "message",
+      provider: "telegram",
+      to: "group:1",
+      text: "First",
+    });
+    await writer.recordMessageSent({
+      tool: "message",
+      provider: "telegram",
+      to: "group:2",
+      text: "Second",
+      mediaUrl: "https://example.com/file.pdf",
+    });
+    await writer.recordCronAdd("job-1");
+    await writer.recordCronAdd();
+
+    const result = await readMcpSideEffects(filePath);
+    expect(result.sentTexts).toEqual(["First", "Second"]);
+    expect(result.sentMediaUrls).toEqual(["https://example.com/file.pdf"]);
+    expect(result.sentTargets).toHaveLength(2);
+    expect(result.cronAdds).toBe(2);
+  });
+
+  it("records message_sent with accountId", async () => {
+    const writer = new McpSideEffectsWriter(filePath);
+    await writer.recordMessageSent({
+      tool: "message",
+      provider: "slack",
+      accountId: "T12345",
+      to: "C67890",
+      text: "Hello Slack",
+    });
+
+    const result = await readMcpSideEffects(filePath);
+    expect(result.sentTargets).toEqual([
+      { tool: "message", provider: "slack", accountId: "T12345", to: "C67890" },
+    ]);
+  });
+});
+
+describe("readMcpSideEffects", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mcp-se-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns empty result for non-existent file", async () => {
+    const result = await readMcpSideEffects(join(dir, "nonexistent.ndjson"));
+    expect(result).toEqual({
+      sentTexts: [],
+      sentMediaUrls: [],
+      sentTargets: [],
+      cronAdds: 0,
+    });
+  });
+
+  it("skips malformed lines", async () => {
+    const filePath = join(dir, "effects.ndjson");
+    await writeFile(
+      filePath,
+      '{"type":"message_sent","tool":"m","provider":"t","to":"1","text":"ok","mediaUrl":null,"ts":1}\n' +
+        "not-json\n" +
+        '{"type":"cron_added","ts":2}\n',
+      "utf-8",
+    );
+
+    const result = await readMcpSideEffects(filePath);
+    expect(result.sentTexts).toEqual(["ok"]);
+    expect(result.cronAdds).toBe(1);
+  });
+
+  it("handles empty file", async () => {
+    const filePath = join(dir, "empty.ndjson");
+    await writeFile(filePath, "", "utf-8");
+
+    const result = await readMcpSideEffects(filePath);
+    expect(result).toEqual({
+      sentTexts: [],
+      sentMediaUrls: [],
+      sentTargets: [],
+      cronAdds: 0,
+    });
+  });
+});

--- a/src/middleware/mcp-side-effects.ts
+++ b/src/middleware/mcp-side-effects.ts
@@ -1,0 +1,104 @@
+import { appendFile, readFile } from "node:fs/promises";
+import type { McpMessageTarget, McpSideEffects } from "./types.js";
+
+// NDJSON side effect record types
+type MessageSentRecord = {
+  type: "message_sent";
+  tool: string;
+  provider: string;
+  accountId?: string;
+  to?: string;
+  text: string;
+  mediaUrl: string | null;
+  ts: number;
+};
+
+type CronAddedRecord = {
+  type: "cron_added";
+  jobId?: string;
+  ts: number;
+};
+
+type SideEffectRecord = MessageSentRecord | CronAddedRecord;
+
+export class McpSideEffectsWriter {
+  constructor(private readonly filePath: string) {}
+
+  async recordMessageSent(params: {
+    tool: string;
+    provider: string;
+    accountId?: string;
+    to?: string;
+    text: string;
+    mediaUrl?: string;
+  }): Promise<void> {
+    const record: MessageSentRecord = {
+      type: "message_sent",
+      tool: params.tool,
+      provider: params.provider,
+      ...(params.accountId ? { accountId: params.accountId } : {}),
+      ...(params.to ? { to: params.to } : {}),
+      text: params.text,
+      mediaUrl: params.mediaUrl ?? null,
+      ts: Date.now(),
+    };
+    await this.appendRecord(record);
+  }
+
+  async recordCronAdd(jobId?: string): Promise<void> {
+    const record: CronAddedRecord = {
+      type: "cron_added",
+      ...(jobId ? { jobId } : {}),
+      ts: Date.now(),
+    };
+    await this.appendRecord(record);
+  }
+
+  private async appendRecord(record: SideEffectRecord): Promise<void> {
+    await appendFile(this.filePath, JSON.stringify(record) + "\n", "utf-8");
+  }
+}
+
+export async function readMcpSideEffects(filePath: string): Promise<McpSideEffects> {
+  const result: McpSideEffects = {
+    sentTexts: [],
+    sentMediaUrls: [],
+    sentTargets: [],
+    cronAdds: 0,
+  };
+
+  let content: string;
+  try {
+    content = await readFile(filePath, "utf-8");
+  } catch {
+    return result;
+  }
+
+  const lines = content.split("\n").filter(Boolean);
+  for (const line of lines) {
+    let record: SideEffectRecord;
+    try {
+      record = JSON.parse(line) as SideEffectRecord;
+    } catch {
+      continue; // skip malformed lines
+    }
+
+    if (record.type === "message_sent") {
+      result.sentTexts.push(record.text);
+      if (record.mediaUrl) {
+        result.sentMediaUrls.push(record.mediaUrl);
+      }
+      const target: McpMessageTarget = {
+        tool: record.tool,
+        provider: record.provider,
+        ...(record.accountId ? { accountId: record.accountId } : {}),
+        ...(record.to ? { to: record.to } : {}),
+      };
+      result.sentTargets.push(target);
+    } else if (record.type === "cron_added") {
+      result.cronAdds += 1;
+    }
+  }
+
+  return result;
+}

--- a/src/middleware/mcp-tools.test.ts
+++ b/src/middleware/mcp-tools.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { McpHandlerContext } from "./mcp-handlers/context.js";
+import { McpSideEffectsWriter } from "./mcp-side-effects.js";
+import { registerAllTools } from "./mcp-tools.js";
+
+// Create a minimal mock McpServer
+function createMockServer() {
+  const registeredTools = new Map<string, { description?: string }>();
+  return {
+    registeredTools,
+    registerTool: vi.fn((name: string, config: { description?: string }) => {
+      registeredTools.set(name, config);
+      return { update: vi.fn(), remove: vi.fn(), disable: vi.fn(), enable: vi.fn() };
+    }),
+  };
+}
+
+function createMockContext(): McpHandlerContext {
+  return {
+    gatewayUrl: "ws://127.0.0.1:18789",
+    gatewayToken: "test-token",
+    sessionKey: "test-session",
+    sideEffects: new McpSideEffectsWriter("/dev/null"),
+    channel: "telegram",
+    accountId: "test-account",
+    to: "test-target",
+    threadId: "test-thread",
+  };
+}
+
+describe("registerAllTools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let ctx: McpHandlerContext;
+
+  beforeEach(() => {
+    mockServer = createMockServer();
+    ctx = createMockContext();
+  });
+
+  it("registers exactly 29 tools", () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerAllTools(mockServer as any, ctx);
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(29);
+  });
+
+  it("registers all session management tools", () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerAllTools(mockServer as any, ctx);
+    const names = [...mockServer.registeredTools.keys()];
+    expect(names).toContain("sessions_list");
+    expect(names).toContain("sessions_history");
+    expect(names).toContain("sessions_send");
+    expect(names).toContain("sessions_spawn");
+    expect(names).toContain("session_status");
+    expect(names).toContain("agents_list");
+    expect(names).toContain("subagents");
+  });
+
+  it("registers all channel messaging tools", () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerAllTools(mockServer as any, ctx);
+    const names = [...mockServer.registeredTools.keys()];
+    expect(names).toContain("message_send");
+    expect(names).toContain("message_reply");
+    expect(names).toContain("message_thread_reply");
+    expect(names).toContain("message_broadcast");
+    expect(names).toContain("message_react");
+    expect(names).toContain("message_delete");
+    expect(names).toContain("message_send_attachment");
+    expect(names).toContain("message_send_with_effect");
+    expect(names).toContain("message_pin");
+    expect(names).toContain("message_read");
+  });
+
+  it("registers all cron scheduling tools", () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerAllTools(mockServer as any, ctx);
+    const names = [...mockServer.registeredTools.keys()];
+    expect(names).toContain("cron_status");
+    expect(names).toContain("cron_list");
+    expect(names).toContain("cron_add");
+    expect(names).toContain("cron_update");
+    expect(names).toContain("cron_remove");
+    expect(names).toContain("cron_run");
+    expect(names).toContain("cron_runs");
+  });
+
+  it("registers all gateway admin tools", () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerAllTools(mockServer as any, ctx);
+    const names = [...mockServer.registeredTools.keys()];
+    expect(names).toContain("gateway_restart");
+    expect(names).toContain("gateway_config_get");
+    expect(names).toContain("gateway_config_apply");
+    expect(names).toContain("gateway_config_patch");
+    expect(names).toContain("gateway_config_schema");
+  });
+
+  it("registers no duplicate tool names", () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerAllTools(mockServer as any, ctx);
+    const names = mockServer.registerTool.mock.calls.map((call: unknown[]) => call[0]);
+    const uniqueNames = new Set(names);
+    expect(uniqueNames.size).toBe(names.length);
+  });
+
+  it("every tool has a description", () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerAllTools(mockServer as any, ctx);
+    for (const [name, config] of mockServer.registeredTools) {
+      expect(config.description, `tool "${name}" should have a description`).toBeTruthy();
+    }
+  });
+});

--- a/src/middleware/mcp-tools.ts
+++ b/src/middleware/mcp-tools.ts
@@ -1,0 +1,22 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpHandlerContext } from "./mcp-handlers/context.js";
+import { registerCronTools } from "./mcp-handlers/cron.js";
+import { registerGatewayTools } from "./mcp-handlers/gateway.js";
+import { registerMessageTools } from "./mcp-handlers/message.js";
+import { registerSessionTools } from "./mcp-handlers/session.js";
+
+/**
+ * Registers all 29 RemoteClaw-specific MCP tools on the given server.
+ *
+ * Tool categories:
+ * - Session management (7 tools)
+ * - Channel messaging (10 tools)
+ * - Cron scheduling (7 tools)
+ * - Gateway admin (5 tools)
+ */
+export function registerAllTools(server: McpServer, ctx: McpHandlerContext): void {
+  registerSessionTools(server, ctx);
+  registerMessageTools(server, ctx);
+  registerCronTools(server, ctx);
+  registerGatewayTools(server, ctx);
+}


### PR DESCRIPTION
## Summary

- Implement standalone MCP server exposing 29 RemoteClaw-specific tools to CLI subprocess agents via stdio transport
- Tools organized into 4 categories: session management (7), channel messaging (10), cron scheduling (7), gateway admin (5)
- NDJSON-based side effects tracking for sent messages and cron additions
- Environment variable-based configuration with `McpHandlerContext` shared across all handlers

## New Files

| File | Purpose |
|------|---------|
| `src/middleware/mcp-server.ts` | Entry point with env-based config + StdioServerTransport |
| `src/middleware/mcp-tools.ts` | Registration orchestrator for all 29 tools |
| `src/middleware/mcp-handlers/context.ts` | Shared `McpHandlerContext` type |
| `src/middleware/mcp-handlers/session.ts` | 7 session tools + `callMcpGateway` helper |
| `src/middleware/mcp-handlers/message.ts` | 10 channel messaging tools |
| `src/middleware/mcp-handlers/cron.ts` | 7 cron scheduling tools |
| `src/middleware/mcp-handlers/gateway.ts` | 5 gateway admin tools |
| `src/middleware/mcp-side-effects.ts` | NDJSON writer/reader for side effects |

## Test plan

- [x] 31 tests across 5 test files all pass
- [x] Type-check (`pnpm tsgo`) passes clean
- [x] Lint (`pnpm lint`) passes clean (0 warnings, 0 errors)
- [x] Format (`pnpm format`) passes clean
- [ ] CI build and test jobs pass

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)