### PR TITLE
feat(middleware): implement LIVE=1 smoke test for Claude CLI runtime

### DIFF
--- a/src/middleware/__smoke__/claude.live.test.ts
+++ b/src/middleware/__smoke__/claude.live.test.ts
@@ -1,0 +1,105 @@
+import { randomBytes } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { isTruthyEnvValue } from "../../infra/env.js";
+import { ChannelBridge } from "../channel-bridge.js";
+import { SessionMap } from "../session-map.js";
+import type { ChannelMessage } from "../types.js";
+
+const LIVE = isTruthyEnvValue(process.env.LIVE);
+
+/** Env vars that Claude Code sets and that cause nesting rejection in `claude -p`. */
+const CLAUDE_CODE_ENV_KEYS = [
+  "CLAUDECODE",
+  "CLAUDE_CODE_ENTRYPOINT",
+  "CLAUDE_CODE_MAX_OUTPUT_TOKENS",
+];
+
+describe.skipIf(!LIVE)("claude CLI middleware smoke test", () => {
+  let bridge: ChannelBridge;
+  let tempDir: string;
+  const savedEnv: Record<string, string | undefined> = {};
+  let firstSessionId: string | undefined;
+
+  const channelId = "smoke-test";
+  const userId = "smoke-user";
+
+  function makeMessage(text: string): ChannelMessage {
+    return {
+      id: randomBytes(4).toString("hex"),
+      text,
+      from: userId,
+      channelId,
+      provider: "test",
+      timestamp: Date.now(),
+    };
+  }
+
+  beforeAll(async () => {
+    // Unset Claude Code env vars to prevent nesting rejection
+    for (const key of CLAUDE_CODE_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+
+    tempDir = await mkdtemp(join(tmpdir(), "rc-smoke-"));
+
+    // Write a no-op MCP server script so the ChannelBridge MCP config points to a valid file
+    const noopMcpServer = join(tempDir, "noop-mcp-server.js");
+    await writeFile(noopMcpServer, "// no-op MCP server for smoke test\n");
+
+    const sessionMap = new SessionMap(tempDir);
+    bridge = new ChannelBridge({
+      provider: "claude",
+      sessionMap,
+      gatewayUrl: "",
+      gatewayToken: "",
+      workspaceDir: tempDir,
+      mcpServerPath: noopMcpServer,
+    });
+  });
+
+  afterAll(async () => {
+    // Restore Claude Code env vars
+    for (const key of CLAUDE_CODE_ENV_KEYS) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+
+    // Cleanup temp directory
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it("receives a coherent single-turn response", async () => {
+    const result = await bridge.handle(makeMessage("What is 2+2? Reply with just the number."));
+
+    expect(result.payloads.length).toBeGreaterThan(0);
+    expect(result.run.text).toBeTruthy();
+    expect(result.run.text).toContain("4");
+    expect(result.run.sessionId).toBeTruthy();
+    expect(result.run.aborted).toBe(false);
+    expect(result.run.durationMs).toBeGreaterThan(0);
+
+    firstSessionId = result.run.sessionId;
+  }, 60_000);
+
+  it("resumes the session on a follow-up message", async () => {
+    expect(firstSessionId).toBeTruthy();
+
+    const result = await bridge.handle(
+      makeMessage("What was the number I just asked about? Reply with just the number."),
+    );
+
+    expect(result.payloads.length).toBeGreaterThan(0);
+    expect(result.run.text).toBeTruthy();
+    expect(result.run.sessionId).toBe(firstSessionId);
+    expect(result.run.aborted).toBe(false);
+  }, 60_000);
+});

--- a/src/middleware/cli-runtime-base.ts
+++ b/src/middleware/cli-runtime-base.ts
@@ -40,6 +40,15 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
     return true;
   }
 
+  /**
+   * Which subprocess stream carries NDJSON output.
+   * Defaults to `"stdout"`. Override to `"stderr"` for CLIs (like Claude)
+   * that emit structured output on stderr.
+   */
+  protected get ndjsonStream(): "stdout" | "stderr" {
+    return "stdout";
+  }
+
   async *execute(params: AgentExecuteParams): AsyncIterable<AgentEvent> {
     const args = this.buildArgs(params);
     const env = { ...process.env, ...this.buildEnv(params), ...params.env };
@@ -68,13 +77,16 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
     };
     resetWatchdog();
 
-    // ── Stderr capture ───────────────────────────────────────────────
-    child.stderr?.on("data", (chunk: Buffer) => {
+    // ── Stream selection: NDJSON source + diagnostic capture ─────────
+    const ndjsonSource = this.ndjsonStream === "stderr" ? child.stderr : child.stdout;
+    const diagnosticStream = this.ndjsonStream === "stderr" ? child.stdout : child.stderr;
+
+    diagnosticStream?.on("data", (chunk: Buffer) => {
       stderrChunks.push(chunk.toString());
     });
 
-    // ── NDJSON stdout parsing ────────────────────────────────────────
-    const rl = createInterface({ input: child.stdout });
+    // ── NDJSON parsing ─────────────────────────────────────────────
+    const rl = createInterface({ input: ndjsonSource });
 
     // Buffer events from readline so the async generator can yield them.
     const eventQueue: (AgentEvent | null)[] = [];

--- a/src/middleware/runtimes/claude.ts
+++ b/src/middleware/runtimes/claude.ts
@@ -38,7 +38,12 @@ export class ClaudeCliRuntime extends CLIRuntimeBase {
     }
   }
 
-  // ── CLIRuntimeBase abstract method implementations ────────────────────
+  // ── CLIRuntimeBase overrides ──────────────────────────────────────────
+
+  /** Claude CLI emits stream-json NDJSON on stderr, not stdout. */
+  protected override get ndjsonStream(): "stdout" | "stderr" {
+    return "stderr";
+  }
 
   protected buildArgs(params: AgentExecuteParams): string[] {
     const args: string[] = ["-p", "--output-format", "stream-json", "--verbose"];


### PR DESCRIPTION
## Summary

- End-to-end smoke test validating the full middleware pipeline with a real Claude CLI subprocess
- Exercises: message → ChannelBridge → ClaudeCliRuntime → `claude -p --output-format stream-json` → NDJSON streaming → AgentDeliveryResult
- Gated behind `LIVE=1` environment variable so CI skips it by default
- Validates single-turn response (payloads, text, sessionId, aborted, durationMs) and session resumption
- Clears all Claude Code env vars (`CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_MAX_OUTPUT_TOKENS`) in `beforeAll` to prevent nesting rejection

### Bug fix: Claude CLI NDJSON stream source

During smoke test development, discovered that `claude -p --output-format stream-json` emits NDJSON to **stderr**, not stdout. Added a configurable `ndjsonStream` getter to `CLIRuntimeBase` (defaults to `"stdout"`) and overrode to `"stderr"` in `ClaudeCliRuntime`. The non-NDJSON stream is captured as diagnostics.

Closes #34

## Test plan

- [x] `pnpm check` passes (format + typecheck + lint)
- [x] `pnpm vitest run src/middleware/` — all 367 unit tests pass
- [x] `pnpm vitest run --config vitest.live.config.ts` finds the test and skips it without `LIVE=1`
- [ ] `LIVE=1 pnpm vitest run --config vitest.live.config.ts src/middleware/__smoke__/claude.live.test.ts` runs both tests with a real Claude CLI (must be run from a **normal terminal**, not from within Claude Code due to nesting restrictions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)