### PR TITLE
feat(middleware): implement LIVE=1 smoke test for Codex CLI runtime (#37)

### DIFF
--- a/src/middleware/__smoke__/codex.live.test.ts
+++ b/src/middleware/__smoke__/codex.live.test.ts
@@ -1,0 +1,85 @@
+import { execFileSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { isTruthyEnvValue } from "../../infra/env.js";
+import { ChannelBridge } from "../channel-bridge.js";
+import { SessionMap } from "../session-map.js";
+import type { ChannelMessage } from "../types.js";
+
+const LIVE = isTruthyEnvValue(process.env.LIVE);
+
+describe.skipIf(!LIVE)("codex CLI middleware smoke test", () => {
+  let bridge: ChannelBridge;
+  let tempDir: string;
+  let firstSessionId: string | undefined;
+
+  const channelId = "smoke-test";
+  const userId = "smoke-user";
+
+  function makeMessage(text: string): ChannelMessage {
+    return {
+      id: randomBytes(4).toString("hex"),
+      text,
+      from: userId,
+      channelId,
+      provider: "test",
+      timestamp: Date.now(),
+    };
+  }
+
+  beforeAll(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "rc-smoke-"));
+
+    // Codex CLI requires a trusted git directory
+    execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+
+    // Write a no-op MCP server script so the ChannelBridge MCP config points to a valid file
+    const noopMcpServer = join(tempDir, "noop-mcp-server.js");
+    await writeFile(noopMcpServer, "// no-op MCP server for smoke test\n");
+
+    const sessionMap = new SessionMap(tempDir);
+    bridge = new ChannelBridge({
+      provider: "codex",
+      sessionMap,
+      gatewayUrl: "",
+      gatewayToken: "",
+      workspaceDir: tempDir,
+      mcpServerPath: noopMcpServer,
+    });
+  });
+
+  afterAll(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it("receives a coherent single-turn response", async () => {
+    const result = await bridge.handle(makeMessage("What is 2+2? Reply with just the number."));
+
+    expect(result.payloads.length).toBeGreaterThan(0);
+    expect(result.run.text).toBeTruthy();
+    expect(result.run.text).toContain("4");
+    expect(result.run.sessionId).toBeTruthy();
+    expect(result.run.aborted).toBe(false);
+    expect(result.run.durationMs).toBeGreaterThan(0);
+
+    firstSessionId = result.run.sessionId;
+  }, 60_000);
+
+  it("resumes the session on a follow-up message", async () => {
+    expect(firstSessionId).toBeTruthy();
+
+    const result = await bridge.handle(
+      makeMessage("What was the number I just asked about? Reply with just the number."),
+    );
+
+    expect(result.payloads.length).toBeGreaterThan(0);
+    expect(result.run.text).toBeTruthy();
+    expect(result.run.sessionId).toBe(firstSessionId);
+    expect(result.run.aborted).toBe(false);
+  }, 60_000);
+});

--- a/src/middleware/runtimes/codex.test.ts
+++ b/src/middleware/runtimes/codex.test.ts
@@ -87,16 +87,16 @@ describe("CodexCliRuntime", () => {
       expect(args).toEqual(["exec", "--json", "--color", "never", "Hello, Codex!"]);
     });
 
-    it("produces exec resume <id> --json --color never for session resume", () => {
+    it("produces exec resume --json <id> <prompt> for session resume", () => {
       const args = runtime.testBuildArgs(makeParams({ sessionId: "thread-abc-123" }));
-      expect(args).toEqual(["exec", "resume", "thread-abc-123", "--json", "--color", "never"]);
+      expect(args).toEqual(["exec", "resume", "--json", "thread-abc-123", "Hello, Codex!"]);
     });
 
-    it("excludes prompt on session resume", () => {
+    it("includes prompt on session resume", () => {
       const args = runtime.testBuildArgs(
-        makeParams({ sessionId: "thread-abc-123", prompt: "This should be excluded" }),
+        makeParams({ sessionId: "thread-abc-123", prompt: "Follow-up message" }),
       );
-      expect(args).not.toContain("This should be excluded");
+      expect(args).toContain("Follow-up message");
     });
 
     it("always starts with exec", () => {
@@ -107,16 +107,16 @@ describe("CodexCliRuntime", () => {
       expect(resumeArgs[0]).toBe("exec");
     });
 
-    it("always includes --color never", () => {
+    it("includes --color never for new sessions", () => {
       const newArgs = runtime.testBuildArgs(makeParams());
       const colorIdx = newArgs.indexOf("--color");
       expect(colorIdx).toBeGreaterThan(-1);
       expect(newArgs[colorIdx + 1]).toBe("never");
+    });
 
+    it("does not include --color for resume (unsupported by resume subcommand)", () => {
       const resumeArgs = runtime.testBuildArgs(makeParams({ sessionId: "s" }));
-      const resumeColorIdx = resumeArgs.indexOf("--color");
-      expect(resumeColorIdx).toBeGreaterThan(-1);
-      expect(resumeArgs[resumeColorIdx + 1]).toBe("never");
+      expect(resumeArgs).not.toContain("--color");
     });
 
     it("always includes --json", () => {
@@ -610,15 +610,16 @@ describe("CodexCliRuntime", () => {
         myServer: { command: "node" },
       });
 
-      expect(toml).toBe(`[mcp_servers.myServer]\ntype = "stdio"\ncommand = ["node"]\n`);
+      expect(toml).toBe(`[mcp_servers.myServer]\ntype = "stdio"\ncommand = "node"\n`);
     });
 
-    it("serializes command with args as array", () => {
+    it("serializes command as string and args as separate array", () => {
       const toml = serializeMcpServersToToml({
         myServer: { command: "node", args: ["server.js", "--port", "3000"] },
       });
 
-      expect(toml).toContain(`command = ["node", "server.js", "--port", "3000"]`);
+      expect(toml).toContain(`command = "node"`);
+      expect(toml).toContain(`args = ["server.js", "--port", "3000"]`);
     });
 
     it("serializes env vars as sub-table", () => {
@@ -643,8 +644,10 @@ describe("CodexCliRuntime", () => {
 
       expect(toml).toContain("[mcp_servers.server1]");
       expect(toml).toContain("[mcp_servers.server2]");
-      expect(toml).toContain(`command = ["node", "s1.js"]`);
-      expect(toml).toContain(`command = ["python", "s2.py"]`);
+      expect(toml).toContain(`command = "node"`);
+      expect(toml).toContain(`args = ["s1.js"]`);
+      expect(toml).toContain(`command = "python"`);
+      expect(toml).toContain(`args = ["s2.py"]`);
     });
 
     it("escapes special characters in TOML strings", () => {
@@ -652,6 +655,7 @@ describe("CodexCliRuntime", () => {
         s: { command: "node", args: ['path with "quotes"', "path\\with\\backslashes"] },
       });
 
+      expect(toml).toContain(`command = "node"`);
       expect(toml).toContain(`"path with \\"quotes\\""`);
       expect(toml).toContain(`"path\\\\with\\\\backslashes"`);
     });
@@ -689,7 +693,8 @@ describe("CodexCliRuntime", () => {
       const content = await readFile(configPath, "utf-8");
       expect(content).toContain("[mcp_servers.myServer]");
       expect(content).toContain('type = "stdio"');
-      expect(content).toContain('command = ["node", "server.js"]');
+      expect(content).toContain('command = "node"');
+      expect(content).toContain('args = ["server.js"]');
 
       await manager.teardown();
     });
@@ -747,8 +752,10 @@ describe("CodexCliRuntime", () => {
       const content = await readFile(configPath, "utf-8");
       expect(content).toContain("[mcp_servers.server1]");
       expect(content).toContain("[mcp_servers.server2]");
-      expect(content).toContain('command = ["node", "s1.js"]');
-      expect(content).toContain('command = ["python", "s2.py"]');
+      expect(content).toContain('command = "node"');
+      expect(content).toContain('args = ["s1.js"]');
+      expect(content).toContain('command = "python"');
+      expect(content).toContain('args = ["s2.py"]');
       expect(content).toContain("[mcp_servers.server2.env]");
       expect(content).toContain('KEY = "val"');
 

--- a/src/middleware/runtimes/codex.ts
+++ b/src/middleware/runtimes/codex.ts
@@ -72,8 +72,9 @@ export class CodexCliRuntime extends CLIRuntimeBase {
 
   protected buildArgs(params: AgentExecuteParams): string[] {
     if (params.sessionId) {
-      // Session resume: codex exec resume <id> --json --color never
-      return ["exec", "resume", params.sessionId, "--json", "--color", "never"];
+      // Session resume: codex exec resume --json <id> <prompt>
+      // Note: --color is not supported by the resume subcommand
+      return ["exec", "resume", "--json", params.sessionId, params.prompt];
     }
 
     // New session: codex exec --json --color never <prompt>
@@ -429,7 +430,8 @@ export class CodexMcpConfigManager {
  * ```toml
  * [mcp_servers.server_name]
  * type = "stdio"
- * command = ["node", "server.js"]
+ * command = "node"
+ * args = ["server.js"]
  *
  * [mcp_servers.server_name.env]
  * KEY = "VALUE"
@@ -443,9 +445,12 @@ export function serializeMcpServersToToml(mcpServers: Record<string, McpServerCo
     lines.push(`[mcp_servers.${name}]`);
     lines.push(`type = "stdio"`);
 
-    // command is an array: [config.command, ...(config.args ?? [])]
-    const commandArray = [config.command, ...(config.args ?? [])];
-    lines.push(`command = [${commandArray.map((s) => toTomlString(s)).join(", ")}]`);
+    // command is a string; args is a separate array
+    lines.push(`command = ${toTomlString(config.command)}`);
+    const args = config.args ?? [];
+    if (args.length > 0) {
+      lines.push(`args = [${args.map((s) => toTomlString(s)).join(", ")}]`);
+    }
 
     sections.push(lines.join("\n"));
 

--- a/src/middleware/runtimes/opencode.test.ts
+++ b/src/middleware/runtimes/opencode.test.ts
@@ -95,7 +95,7 @@ describe("OpenCodeCliRuntime", () => {
       ]);
     });
 
-    it("includes prompt on session resume (unlike Codex)", () => {
+    it("includes prompt on session resume", () => {
       const args = runtime.testBuildArgs(
         makeParams({ sessionId: "sess-123", prompt: "Follow up prompt" }),
       );


### PR DESCRIPTION
## Summary

- Add `src/middleware/__smoke__/codex.live.test.ts` — end-to-end smoke test for the Codex CLI runtime
- Mirrors the Gemini smoke test pattern: `ChannelBridge` → `CodexCliRuntime` → `codex` CLI → NDJSON streaming → assertion
- Gated behind `LIVE=1` environment variable (skipped in CI)
- Tests single-turn response (payloads, text, sessionId, aborted=false) and session resumption
- Adds `git init` in temp dir setup (codex requires a trusted git directory)
- Fixes two pre-existing `CodexCliRuntime` bugs discovered during live testing:
  - `serializeMcpServersToToml`: emit `command` as TOML string with separate `args` array (codex expects string, not array)
  - `buildArgs` for resume: include prompt and drop unsupported `--color` flag

## Test plan

- [x] Test skips correctly without `LIVE=1` (verified: 2 tests skipped)
- [x] `LIVE=1` smoke test passes (single-turn: 11s, resume: 1.8s)
- [x] Codex unit tests pass (48/48)
- [x] Full test suite passes (861/861)
- [x] Formatting clean (`pnpm format`)
- [x] Linting clean (`pnpm lint`)
- [x] Type-check clean (`pnpm tsgo`)

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)