### PR TITLE
fix(middleware): always close stdin so CLIs get EOF

### DIFF
--- a/src/middleware/cli-runtime-base.test.ts
+++ b/src/middleware/cli-runtime-base.test.ts
@@ -277,11 +277,12 @@ describe("CLIRuntimeBase", () => {
       expect(stdinEnded).toBe(true);
     });
 
-    it("does not write short prompts to stdin", async () => {
+    it("does not write short prompts to stdin but still closes it", async () => {
       const runtime = new TestRuntime("test-cli");
       const shortPrompt = "x".repeat(9_999);
 
       const stdinSpy = vi.spyOn(mockChild.stdin, "write");
+      const endSpy = vi.spyOn(mockChild.stdin, "end");
 
       const promise = collectEvents(runtime.execute({ ...defaultParams, prompt: shortPrompt }));
 
@@ -291,6 +292,7 @@ describe("CLIRuntimeBase", () => {
       await promise;
 
       expect(stdinSpy).not.toHaveBeenCalled();
+      expect(endSpy).toHaveBeenCalled();
     });
   });
 

--- a/src/middleware/cli-runtime-base.ts
+++ b/src/middleware/cli-runtime-base.ts
@@ -138,8 +138,9 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
       child.stdin
     ) {
       child.stdin.write(params.prompt);
-      child.stdin.end();
     }
+    // Always close stdin so CLIs that read from stdin get EOF and don't hang.
+    child.stdin?.end();
 
     // ── Abort signal wiring (after event infrastructure is ready) ────
     const onAbort = () => {


### PR DESCRIPTION
## Summary

- Move `stdin.end()` outside the prompt-length conditional in `CLIRuntimeBase` so stdin is **always** closed after optional prompt delivery
- Previously, CLIs that read from stdin would never see EOF when the prompt was below the threshold, causing them to hang indefinitely
- Updated test to verify `stdin.end()` is called even for short prompts

## Test plan

- [x] Existing unit tests pass (112/112)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)