### PR TITLE
feat(middleware): update runtime CLI flags and event parsing

### DIFF
--- a/src/middleware/runtimes/claude.test.ts
+++ b/src/middleware/runtimes/claude.test.ts
@@ -82,9 +82,16 @@ describe("ClaudeCliRuntime", () => {
   // ── buildArgs ─────────────────────────────────────────────────────────
 
   describe("buildArgs", () => {
-    it("produces base flags with prompt as positional arg", () => {
+    it("produces base flags with --print prompt at the end", () => {
       const args = runtime.testBuildArgs(makeParams());
-      expect(args).toEqual(["-p", "--output-format", "stream-json", "--verbose", "Hello, Claude!"]);
+      expect(args).toEqual([
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--include-partial-messages",
+        "--print",
+        "Hello, Claude!",
+      ]);
     });
 
     it("adds --resume when sessionId is provided", () => {
@@ -137,19 +144,20 @@ describe("ClaudeCliRuntime", () => {
         }),
       );
 
-      expect(args).toContain("-p");
       expect(args).toContain("--output-format");
       expect(args).toContain("stream-json");
       expect(args).toContain("--verbose");
       expect(args).toContain("--resume");
       expect(args).toContain("sess-456");
       expect(args).toContain("--mcp-config");
-      // Prompt is always last
+      // --print prompt comes last
+      expect(args[args.length - 2]).toBe("--print");
       expect(args[args.length - 1]).toBe("Hello, Claude!");
     });
 
-    it("always includes prompt as last argument", () => {
+    it("places --print prompt at the end", () => {
       const args = runtime.testBuildArgs(makeParams({ prompt: "test prompt" }));
+      expect(args[args.length - 2]).toBe("--print");
       expect(args[args.length - 1]).toBe("test prompt");
     });
   });

--- a/src/middleware/runtimes/claude.ts
+++ b/src/middleware/runtimes/claude.ts
@@ -9,7 +9,7 @@ import type {
 } from "../types.js";
 
 /**
- * Claude CLI runtime — invokes `claude -p --output-format stream-json`
+ * Claude CLI runtime — invokes `claude --print --output-format stream-json`
  * and maps the streaming NDJSON output to {@link AgentEvent} instances.
  */
 export class ClaudeCliRuntime extends CLIRuntimeBase {
@@ -40,13 +40,13 @@ export class ClaudeCliRuntime extends CLIRuntimeBase {
 
   // ── CLIRuntimeBase overrides ──────────────────────────────────────────
 
-  /** Claude CLI emits stream-json NDJSON on stderr, not stdout. */
-  protected override get ndjsonStream(): "stdout" | "stderr" {
-    return "stderr";
-  }
-
   protected buildArgs(params: AgentExecuteParams): string[] {
-    const args: string[] = ["-p", "--output-format", "stream-json", "--verbose"];
+    const args: string[] = [
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--include-partial-messages",
+    ];
 
     if (params.sessionId) {
       args.push("--resume", params.sessionId);
@@ -56,7 +56,8 @@ export class ClaudeCliRuntime extends CLIRuntimeBase {
       args.push("--mcp-config", JSON.stringify({ mcpServers: params.mcpServers }));
     }
 
-    args.push(params.prompt);
+    // --print <prompt> comes last so it doesn't interfere with other flags.
+    args.push("--print", params.prompt);
 
     return args;
   }
@@ -64,6 +65,14 @@ export class ClaudeCliRuntime extends CLIRuntimeBase {
   protected extractEvent(line: string): AgentEvent | null {
     const parsed: unknown = JSON.parse(line);
     if (!isObject(parsed)) {
+      return null;
+    }
+
+    // system init event — capture session_id
+    if (parsed.type === "system") {
+      if (typeof parsed.session_id === "string" && !this.currentSessionId) {
+        this.currentSessionId = parsed.session_id;
+      }
       return null;
     }
 
@@ -82,6 +91,8 @@ export class ClaudeCliRuntime extends CLIRuntimeBase {
       return null;
     }
 
+    // assistant, rate_limit_event, and other types are skipped
+    // (text and tool data come via stream_event when --include-partial-messages is set)
     return null;
   }
 

--- a/src/middleware/runtimes/gemini.test.ts
+++ b/src/middleware/runtimes/gemini.test.ts
@@ -73,26 +73,26 @@ describe("GeminiCliRuntime", () => {
   // ── buildArgs ─────────────────────────────────────────────────────────
 
   describe("buildArgs", () => {
-    it("produces base flags with prompt via -p flag", () => {
+    it("produces base flags with prompt via --prompt flag", () => {
       const args = runtime.testBuildArgs(makeParams());
-      expect(args).toEqual(["--output-format", "stream-json", "-p", "Hello, Gemini!"]);
+      expect(args).toEqual(["--output-format", "stream-json", "--prompt", "Hello, Gemini!"]);
     });
 
-    it("adds -r when sessionId is provided", () => {
+    it("adds --resume when sessionId is provided", () => {
       const args = runtime.testBuildArgs(makeParams({ sessionId: "sess-123" }));
-      expect(args).toContain("-r");
+      expect(args).toContain("--resume");
       expect(args).toContain("sess-123");
-      expect(args.indexOf("-r")).toBeLessThan(args.indexOf("sess-123"));
+      expect(args.indexOf("--resume")).toBeLessThan(args.indexOf("sess-123"));
     });
 
-    it("does not add -r when sessionId is absent", () => {
+    it("does not add --resume when sessionId is absent", () => {
       const args = runtime.testBuildArgs(makeParams());
-      expect(args).not.toContain("-r");
+      expect(args).not.toContain("--resume");
     });
 
-    it("delivers prompt via -p flag, not positional", () => {
+    it("delivers prompt via --prompt flag, not positional", () => {
       const args = runtime.testBuildArgs(makeParams({ prompt: "test prompt" }));
-      const pIdx = args.indexOf("-p");
+      const pIdx = args.indexOf("--prompt");
       expect(pIdx).toBeGreaterThan(-1);
       expect(args[pIdx + 1]).toBe("test prompt");
     });
@@ -106,9 +106,9 @@ describe("GeminiCliRuntime", () => {
 
       expect(args).toContain("--output-format");
       expect(args).toContain("stream-json");
-      expect(args).toContain("-p");
+      expect(args).toContain("--prompt");
       expect(args).toContain("Hello, Gemini!");
-      expect(args).toContain("-r");
+      expect(args).toContain("--resume");
       expect(args).toContain("sess-456");
     });
 

--- a/src/middleware/runtimes/gemini.ts
+++ b/src/middleware/runtimes/gemini.ts
@@ -61,10 +61,10 @@ export class GeminiCliRuntime extends CLIRuntimeBase {
   // ── CLIRuntimeBase abstract method implementations ────────────────────
 
   protected buildArgs(params: AgentExecuteParams): string[] {
-    const args: string[] = ["--output-format", "stream-json", "-p", params.prompt];
+    const args: string[] = ["--output-format", "stream-json", "--prompt", params.prompt];
 
     if (params.sessionId) {
-      args.push("-r", params.sessionId);
+      args.push("--resume", params.sessionId);
     }
 
     return args;

--- a/src/middleware/runtimes/opencode.ts
+++ b/src/middleware/runtimes/opencode.ts
@@ -91,19 +91,22 @@ export class OpenCodeCliRuntime extends CLIRuntimeBase {
       this.currentSessionId = parsed.sessionID;
     }
 
+    // OpenCode wraps event data in a `part` field; unwrap for handlers.
+    const data = isObject(parsed.part) ? parsed.part : parsed;
+
     switch (parsed.type) {
       case "text":
-        return this.handleText(parsed);
+        return this.handleText(data);
       case "tool_use":
-        return this.handleToolUse(parsed);
+        return this.handleToolUse(data);
       case "step_start":
         return null;
       case "step_finish":
-        return this.handleStepFinish(parsed);
+        return this.handleStepFinish(data);
       case "reasoning":
         return null;
       case "error":
-        return this.handleError(parsed);
+        return this.handleError(data);
       default:
         return null;
     }
@@ -116,7 +119,13 @@ export class OpenCodeCliRuntime extends CLIRuntimeBase {
   // ── Event handlers ────────────────────────────────────────────────────
 
   private handleText(parsed: Record<string, unknown>): AgentEvent | null {
-    const content = typeof parsed.content === "string" ? parsed.content : "";
+    // Text is in `text` field (from `part.text`) or legacy `content` field.
+    const content =
+      typeof parsed.text === "string"
+        ? parsed.text
+        : typeof parsed.content === "string"
+          ? parsed.content
+          : "";
     this.accumulatedText += content;
     return { type: "text", text: content } satisfies AgentTextEvent;
   }


### PR DESCRIPTION
## Summary

- **Claude**: Switch from `-p` (piped mode) to `--print` for non-interactive execution, add `--include-partial-messages` for real-time streaming, handle `system` init events for session ID capture, read NDJSON from stdout (not stderr)
- **Gemini**: Use long flags (`--prompt`, `--resume`) instead of short (`-p`, `-r`) for clarity
- **OpenCode**: Unwrap `part` field from event envelope so handlers receive inner data structure, with backward-compatible fallback to `content` field

## Test plan

- [x] All 112 unit tests pass
- [x] Format + lint clean
- [ ] CI green
- [ ] LIVE=1 smoke tests (if available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)