### PR TITLE
feat(voice-call): wire dispatch site to ChannelBridge (#48)

### DIFF
--- a/extensions/voice-call/src/core-bridge.ts
+++ b/extensions/voice-call/src/core-bridge.ts
@@ -13,49 +13,59 @@ export type CoreConfig = {
   [key: string]: unknown;
 };
 
+/** Minimal ChannelMessage shape for building voice dispatch messages. */
+type ChannelMessage = {
+  id: string;
+  text: string;
+  from: string;
+  channelId: string;
+  provider: string;
+  timestamp: number;
+  replyToId?: string;
+};
+
+/** Minimal AgentDeliveryResult shape returned by ChannelBridge.handle(). */
+type AgentDeliveryResult = {
+  payloads: Array<{ text?: string; isError?: boolean }>;
+  run: { sessionId?: string; aborted?: boolean };
+  mcp: unknown;
+  error?: string;
+};
+
+/** Duck-typed SessionMap interface for the no-op adapter pattern. */
+type SessionMapLike = {
+  get(key: unknown): Promise<string | undefined>;
+  set(key: unknown, sessionId: string): Promise<void>;
+  delete(key: unknown): Promise<void>;
+};
+
 type CoreAgentDeps = {
-  resolveAgentDir: (cfg: CoreConfig, agentId: string) => string;
+  ChannelBridge: new (options: {
+    provider: string;
+    sessionMap: SessionMapLike;
+    gatewayUrl: string;
+    gatewayToken: string;
+    workspaceDir?: string;
+  }) => {
+    handle(
+      message: ChannelMessage,
+      callbacks?: unknown,
+      abortSignal?: AbortSignal,
+    ): Promise<AgentDeliveryResult>;
+  };
+  resolveGatewayPort: (cfg?: CoreConfig) => number;
+  resolveGatewayCredentialsFromConfig: (params: { cfg: CoreConfig; env?: NodeJS.ProcessEnv }) => {
+    token?: string;
+  };
   resolveAgentWorkspaceDir: (cfg: CoreConfig, agentId: string) => string;
   resolveAgentIdentity: (
     cfg: CoreConfig,
     agentId: string,
   ) => { name?: string | null } | null | undefined;
-  resolveThinkingDefault: (params: {
-    cfg: CoreConfig;
-    provider?: string;
-    model?: string;
-  }) => string;
-  runEmbeddedPiAgent: (params: {
-    sessionId: string;
-    sessionKey?: string;
-    messageProvider?: string;
-    sessionFile: string;
-    workspaceDir: string;
-    config?: CoreConfig;
-    prompt: string;
-    provider?: string;
-    model?: string;
-    thinkLevel?: string;
-    verboseLevel?: string;
-    timeoutMs: number;
-    runId: string;
-    lane?: string;
-    extraSystemPrompt?: string;
-    agentDir?: string;
-  }) => Promise<{
-    payloads?: Array<{ text?: string; isError?: boolean }>;
-    meta?: { aborted?: boolean };
-  }>;
-  resolveAgentTimeoutMs: (opts: { cfg: CoreConfig }) => number;
   ensureAgentWorkspace: (params?: { dir: string }) => Promise<void>;
   resolveStorePath: (store?: string, opts?: { agentId?: string }) => string;
   loadSessionStore: (storePath: string) => Record<string, unknown>;
   saveSessionStore: (storePath: string, store: Record<string, unknown>) => Promise<void>;
-  resolveSessionFilePath: (
-    sessionId: string,
-    entry: unknown,
-    opts?: { agentId?: string },
-  ) => string;
   DEFAULT_MODEL: string;
   DEFAULT_PROVIDER: string;
 };
@@ -122,19 +132,17 @@ function resolveOpenClawRoot(): string {
 }
 
 async function importCoreExtensionAPI(): Promise<{
-  resolveAgentDir: CoreAgentDeps["resolveAgentDir"];
+  ChannelBridge: CoreAgentDeps["ChannelBridge"];
+  resolveGatewayPort: CoreAgentDeps["resolveGatewayPort"];
+  resolveGatewayCredentialsFromConfig: CoreAgentDeps["resolveGatewayCredentialsFromConfig"];
   resolveAgentWorkspaceDir: CoreAgentDeps["resolveAgentWorkspaceDir"];
-  DEFAULT_MODEL: string;
-  DEFAULT_PROVIDER: string;
   resolveAgentIdentity: CoreAgentDeps["resolveAgentIdentity"];
-  resolveThinkingDefault: CoreAgentDeps["resolveThinkingDefault"];
-  runEmbeddedPiAgent: CoreAgentDeps["runEmbeddedPiAgent"];
-  resolveAgentTimeoutMs: CoreAgentDeps["resolveAgentTimeoutMs"];
   ensureAgentWorkspace: CoreAgentDeps["ensureAgentWorkspace"];
   resolveStorePath: CoreAgentDeps["resolveStorePath"];
   loadSessionStore: CoreAgentDeps["loadSessionStore"];
   saveSessionStore: CoreAgentDeps["saveSessionStore"];
-  resolveSessionFilePath: CoreAgentDeps["resolveSessionFilePath"];
+  DEFAULT_MODEL: string;
+  DEFAULT_PROVIDER: string;
 }> {
   // Do not import any other module. You can't touch this or you will be fired.
   const distPath = path.join(resolveOpenClawRoot(), "dist", "extensionAPI.js");

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -1,6 +1,6 @@
 /**
- * Voice call response generator - uses the embedded Pi agent for tool support.
- * Routes voice responses through the same agent infrastructure as messaging.
+ * Voice call response generator - routes voice responses through ChannelBridge.
+ * Uses the same middleware infrastructure as all other dispatch sites.
  */
 
 import crypto from "node:crypto";
@@ -33,8 +33,8 @@ type SessionEntry = {
 };
 
 /**
- * Generate a voice response using the embedded Pi agent with full tool support.
- * Uses the same agent infrastructure as messaging for consistent behavior.
+ * Generate a voice response by routing through ChannelBridge.
+ * Uses the same middleware pipeline as messaging, cron, and CLI dispatch sites.
  */
 export async function generateVoiceResponse(
   params: VoiceResponseParams,
@@ -56,20 +56,20 @@ export async function generateVoiceResponse(
   }
   const cfg = coreConfig;
 
-  // Build voice-specific session key based on phone number
-  const normalizedPhone = from.replace(/\D/g, "");
-  const sessionKey = `voice:${normalizedPhone}`;
+  // Resolve provider from config (e.g., "claude/claude-sonnet-4" → "claude")
+  const modelRef = voiceConfig.responseModel || `${deps.DEFAULT_PROVIDER}/${deps.DEFAULT_MODEL}`;
+  const slashIndex = modelRef.indexOf("/");
+  const provider = slashIndex === -1 ? deps.DEFAULT_PROVIDER : modelRef.slice(0, slashIndex);
+
+  // Resolve workspace
   const agentId = "main";
-
-  // Resolve paths
-  const storePath = deps.resolveStorePath(cfg.session?.store, { agentId });
-  const agentDir = deps.resolveAgentDir(cfg, agentId);
   const workspaceDir = deps.resolveAgentWorkspaceDir(cfg, agentId);
-
-  // Ensure workspace exists
   await deps.ensureAgentWorkspace({ dir: workspaceDir });
 
-  // Load or create session entry
+  // Load or create session entry (legacy store for backward compatibility)
+  const normalizedPhone = from.replace(/\D/g, "");
+  const sessionKey = `voice:${normalizedPhone}`;
+  const storePath = deps.resolveStorePath(cfg.session?.store, { agentId });
   const sessionStore = deps.loadSessionStore(storePath);
   const now = Date.now();
   let sessionEntry = sessionStore[sessionKey] as SessionEntry | undefined;
@@ -83,75 +83,90 @@ export async function generateVoiceResponse(
     await deps.saveSessionStore(storePath, sessionStore);
   }
 
-  const sessionId = sessionEntry.sessionId;
-  const sessionFile = deps.resolveSessionFilePath(sessionId, sessionEntry, {
-    agentId,
+  // Session map adapter: read-only, matching the pattern used by all dispatch sites.
+  // set()/delete() are no-ops — session persistence is handled after the run.
+  const sessionMap = {
+    async get() {
+      return sessionEntry.sessionId;
+    },
+    async set() {},
+    async delete() {},
+  };
+
+  // Gateway credentials
+  const gatewayPort = deps.resolveGatewayPort(cfg);
+  const gatewayUrl = `ws://127.0.0.1:${gatewayPort}`;
+  const gatewayToken =
+    deps.resolveGatewayCredentialsFromConfig({ cfg, env: process.env }).token ?? "";
+
+  // Create ChannelBridge
+  const bridge = new deps.ChannelBridge({
+    provider,
+    sessionMap,
+    gatewayUrl,
+    gatewayToken,
+    workspaceDir,
   });
 
-  // Resolve model from config
-  const modelRef = voiceConfig.responseModel || `${deps.DEFAULT_PROVIDER}/${deps.DEFAULT_MODEL}`;
-  const slashIndex = modelRef.indexOf("/");
-  const provider = slashIndex === -1 ? deps.DEFAULT_PROVIDER : modelRef.slice(0, slashIndex);
-  const model = slashIndex === -1 ? modelRef : modelRef.slice(slashIndex + 1);
-
-  // Resolve thinking level
-  const thinkLevel = deps.resolveThinkingDefault({ cfg, provider, model });
-
-  // Resolve agent identity for personalized prompt
+  // Build voice-specific system prompt with conversation history
   const identity = deps.resolveAgentIdentity(cfg, agentId);
   const agentName = identity?.name?.trim() || "assistant";
 
-  // Build system prompt with conversation history
   const basePrompt =
     voiceConfig.responseSystemPrompt ??
     `You are ${agentName}, a helpful voice assistant on a phone call. Keep responses brief and conversational (1-2 sentences max). Be natural and friendly. The caller's phone number is ${from}. You have access to tools - use them when helpful.`;
 
-  let extraSystemPrompt = basePrompt;
+  let voiceContext = basePrompt;
   if (transcript.length > 0) {
     const history = transcript
       .map((entry) => `${entry.speaker === "bot" ? "You" : "Caller"}: ${entry.text}`)
       .join("\n");
-    extraSystemPrompt = `${basePrompt}\n\nConversation so far:\n${history}`;
+    voiceContext = `${basePrompt}\n\nConversation so far:\n${history}`;
   }
 
-  // Resolve timeout
-  const timeoutMs = voiceConfig.responseTimeoutMs ?? deps.resolveAgentTimeoutMs({ cfg });
-  const runId = `voice:${callId}:${Date.now()}`;
+  // Build ChannelMessage for voice dispatch
+  const runId = `voice:${callId}:${now}`;
+  const message = {
+    id: runId,
+    text: `${voiceContext}\n\nCaller: ${userMessage}`,
+    from: normalizedPhone,
+    channelId: "voice",
+    provider: "voice",
+    timestamp: now,
+  };
+
+  // Execute with timeout (voice calls have real-time constraints)
+  const timeoutMs = voiceConfig.responseTimeoutMs ?? 30_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const result = await deps.runEmbeddedPiAgent({
-      sessionId,
-      sessionKey,
-      messageProvider: "voice",
-      sessionFile,
-      workspaceDir,
-      config: cfg,
-      prompt: userMessage,
-      provider,
-      model,
-      thinkLevel,
-      verboseLevel: "off",
-      timeoutMs,
-      runId,
-      lane: "voice",
-      extraSystemPrompt,
-      agentDir,
-    });
+    const delivery = await bridge.handle(message, undefined, controller.signal);
+    clearTimeout(timer);
+
+    // Update session with new CLI session ID for conversation continuity
+    if (delivery.run.sessionId) {
+      sessionEntry.sessionId = delivery.run.sessionId;
+      sessionEntry.updatedAt = Date.now();
+      sessionStore[sessionKey] = sessionEntry;
+      await deps.saveSessionStore(storePath, sessionStore);
+    }
 
     // Extract text from payloads
-    const texts = (result.payloads ?? [])
+    const texts = (delivery.payloads ?? [])
       .filter((p) => p.text && !p.isError)
       .map((p) => p.text?.trim())
       .filter(Boolean);
 
     const text = texts.join(" ") || null;
 
-    if (!text && result.meta?.aborted) {
+    if (!text && delivery.run.aborted) {
       return { text: null, error: "Response generation was aborted" };
     }
 
     return { text };
   } catch (err) {
+    clearTimeout(timer);
     console.error(`[voice-call] Response generation failed:`, err);
     return { text: null, error: String(err) };
   }

--- a/src/extensionAPI.ts
+++ b/src/extensionAPI.ts
@@ -12,3 +12,7 @@ export {
   saveSessionStore,
   resolveSessionFilePath,
 } from "./config/sessions.ts";
+
+export { ChannelBridge } from "./middleware/channel-bridge.ts";
+export { resolveGatewayPort } from "./config/paths.ts";
+export { resolveGatewayCredentialsFromConfig } from "./gateway/credentials.ts";


### PR DESCRIPTION
## Summary
- Export `ChannelBridge`, `resolveGatewayPort`, and `resolveGatewayCredentialsFromConfig` from `extensionAPI` so extensions can access the middleware
- Update `CoreAgentDeps` in the voice-call extension to expose the ChannelBridge constructor and gateway helpers instead of `runEmbeddedPiAgent`
- Rewrite `response-generator.ts` to use the same session map adapter + ChannelBridge pattern used by commands (#54), cron (#53), and auto-reply (#52) dispatch sites
- Use `AbortController`-based timeout instead of `resolveAgentTimeoutMs` for voice call real-time constraints

Closes #48

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] Extension tests pass (146 files, 1408 tests)
- [x] ChannelBridge tests pass (34 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)