### PR TITLE
feat(middleware): propagate senderIsOwner security context to MCP server

### DIFF
--- a/extensions/voice-call/src/core-bridge.ts
+++ b/extensions/voice-call/src/core-bridge.ts
@@ -23,6 +23,8 @@ type ChannelMessage = {
   timestamp: number;
   replyToId?: string;
   messageToolHints?: string[];
+  senderIsOwner?: boolean;
+  toolProfile?: string;
 };
 
 /** Minimal AgentDeliveryResult shape returned by ChannelBridge.handle(). */

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -133,6 +133,7 @@ export async function generateVoiceResponse(
     channelId: "voice",
     provider: "voice",
     timestamp: now,
+    senderIsOwner: true, // Voice callers have direct phone access → treated as owner
   };
 
   // Execute with timeout (voice calls have real-time constraints)

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -104,6 +104,7 @@ function buildChannelMessage(params: {
   commandBody: string;
   sessionCtx: TemplateContext;
   messageToolHints: string[] | undefined;
+  senderIsOwner?: boolean;
 }): ChannelMessage {
   return {
     id: params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid ?? crypto.randomUUID(),
@@ -114,6 +115,7 @@ function buildChannelMessage(params: {
     timestamp: Date.now(),
     replyToId: params.sessionCtx.ReplyToId?.trim() || undefined,
     messageToolHints: params.messageToolHints?.length ? params.messageToolHints : undefined,
+    senderIsOwner: params.senderIsOwner,
   };
 }
 
@@ -328,6 +330,7 @@ export async function runAgentTurnWithFallback(params: {
                 commandBody: params.commandBody,
                 sessionCtx: params.sessionCtx,
                 messageToolHints,
+                senderIsOwner: params.followupRun.run.senderIsOwner,
               });
 
               // Build BridgeCallbacks that wrap the existing typing/normalization logic.

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -145,6 +145,7 @@ function buildCliChannelMessage(params: {
     timestamp: params.timestamp,
     replyToId: params.threadId,
     messageToolHints: params.messageToolHints?.length ? params.messageToolHints : undefined,
+    senderIsOwner: true, // CLI user is always the bot owner
   };
 }
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -114,6 +114,7 @@ function buildCronChannelMessage(params: {
     provider: params.resolvedDelivery.channel ?? "cron",
     timestamp: params.timestamp,
     messageToolHints: params.messageToolHints?.length ? params.messageToolHints : undefined,
+    senderIsOwner: false, // Cron agents must not self-modify via owner-only tools
   };
 }
 

--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -443,6 +443,61 @@ describe("ChannelBridge", () => {
       const mcpEnv = executeFn.mock.calls[0][0].mcpServers!.remoteclaw.env!;
       expect(mcpEnv.REMOTECLAW_SIDE_EFFECTS_FILE).toMatch(/side-effects\.ndjson$/);
     });
+
+    it("sets REMOTECLAW_SENDER_IS_OWNER=true when senderIsOwner is true", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage({ senderIsOwner: true }));
+
+      const mcpEnv = executeFn.mock.calls[0][0].mcpServers!.remoteclaw.env!;
+      expect(mcpEnv.REMOTECLAW_SENDER_IS_OWNER).toBe("true");
+    });
+
+    it("sets REMOTECLAW_SENDER_IS_OWNER=false when senderIsOwner is false", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage({ senderIsOwner: false }));
+
+      const mcpEnv = executeFn.mock.calls[0][0].mcpServers!.remoteclaw.env!;
+      expect(mcpEnv.REMOTECLAW_SENDER_IS_OWNER).toBe("false");
+    });
+
+    it("defaults REMOTECLAW_SENDER_IS_OWNER to false when not set", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage());
+
+      const mcpEnv = executeFn.mock.calls[0][0].mcpServers!.remoteclaw.env!;
+      expect(mcpEnv.REMOTECLAW_SENDER_IS_OWNER).toBe("false");
+    });
+
+    it("sets REMOTECLAW_TOOL_PROFILE from message", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage({ toolProfile: "messaging" }));
+
+      const mcpEnv = executeFn.mock.calls[0][0].mcpServers!.remoteclaw.env!;
+      expect(mcpEnv.REMOTECLAW_TOOL_PROFILE).toBe("messaging");
+    });
+
+    it("defaults REMOTECLAW_TOOL_PROFILE to full when not set", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage());
+
+      const mcpEnv = executeFn.mock.calls[0][0].mcpServers!.remoteclaw.env!;
+      expect(mcpEnv.REMOTECLAW_TOOL_PROFILE).toBe("full");
+    });
   });
 
   describe("messageToolHints forwarding", () => {

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -192,6 +192,8 @@ export class ChannelBridge {
           REMOTECLAW_ACCOUNT_ID: message.from,
           REMOTECLAW_TO: message.channelId,
           ...(message.replyToId ? { REMOTECLAW_THREAD_ID: message.replyToId } : {}),
+          REMOTECLAW_SENDER_IS_OWNER: String(message.senderIsOwner ?? false),
+          REMOTECLAW_TOOL_PROFILE: message.toolProfile ?? "full",
         },
       },
     };

--- a/src/middleware/mcp-handlers/context.ts
+++ b/src/middleware/mcp-handlers/context.ts
@@ -23,4 +23,8 @@ export type McpHandlerContext = {
   to: string;
   /** Originating thread/topic ID. */
   threadId: string;
+  /** Whether the message sender is the bot owner. */
+  senderIsOwner: boolean;
+  /** Tool profile controlling which tool categories are available. */
+  toolProfile: string;
 };

--- a/src/middleware/mcp-handlers/cron.test.ts
+++ b/src/middleware/mcp-handlers/cron.test.ts
@@ -51,6 +51,8 @@ describe("registerCronTools", () => {
       accountId: "acc-1",
       to: "chat-123",
       threadId: "",
+      senderIsOwner: true,
+      toolProfile: "full",
     };
     // oxlint-disable-next-line typescript/no-explicit-any
     registerCronTools(mockServer as any, ctx);

--- a/src/middleware/mcp-handlers/message.test.ts
+++ b/src/middleware/mcp-handlers/message.test.ts
@@ -51,6 +51,8 @@ describe("registerMessageTools", () => {
       accountId: "acc-1",
       to: "chat-123",
       threadId: "",
+      senderIsOwner: true,
+      toolProfile: "full",
     };
     // oxlint-disable-next-line typescript/no-explicit-any
     registerMessageTools(mockServer as any, ctx);

--- a/src/middleware/mcp-handlers/session.test.ts
+++ b/src/middleware/mcp-handlers/session.test.ts
@@ -29,6 +29,8 @@ function createMockContext(): McpHandlerContext {
     accountId: "test-account",
     to: "test-target",
     threadId: "",
+    senderIsOwner: true,
+    toolProfile: "full",
   };
 }
 

--- a/src/middleware/mcp-server.ts
+++ b/src/middleware/mcp-server.ts
@@ -22,6 +22,8 @@ function createContext(): McpHandlerContext {
     accountId: process.env.REMOTECLAW_ACCOUNT_ID ?? "",
     to: process.env.REMOTECLAW_TO ?? "",
     threadId: process.env.REMOTECLAW_THREAD_ID ?? "",
+    senderIsOwner: process.env.REMOTECLAW_SENDER_IS_OWNER === "true",
+    toolProfile: process.env.REMOTECLAW_TOOL_PROFILE || "full",
   };
 }
 

--- a/src/middleware/mcp-tools.test.ts
+++ b/src/middleware/mcp-tools.test.ts
@@ -15,7 +15,7 @@ function createMockServer() {
   };
 }
 
-function createMockContext(): McpHandlerContext {
+function createMockContext(overrides?: Partial<McpHandlerContext>): McpHandlerContext {
   return {
     gatewayUrl: "ws://127.0.0.1:18789",
     gatewayToken: "test-token",
@@ -25,6 +25,9 @@ function createMockContext(): McpHandlerContext {
     accountId: "test-account",
     to: "test-target",
     threadId: "test-thread",
+    senderIsOwner: true,
+    toolProfile: "full",
+    ...overrides,
   };
 }
 
@@ -110,5 +113,63 @@ describe("registerAllTools", () => {
     for (const [name, config] of mockServer.registeredTools) {
       expect(config.description, `tool "${name}" should have a description`).toBeTruthy();
     }
+  });
+
+  describe("owner-only tool gating", () => {
+    it("registers only 17 tools for non-owner senders", () => {
+      ctx = createMockContext({ senderIsOwner: false });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerAllTools(mockServer as any, ctx);
+      // 7 session + 10 message = 17 (no cron or gateway)
+      expect(mockServer.registerTool).toHaveBeenCalledTimes(17);
+    });
+
+    it("does NOT register cron tools for non-owner senders", () => {
+      ctx = createMockContext({ senderIsOwner: false });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerAllTools(mockServer as any, ctx);
+      const names = [...mockServer.registeredTools.keys()];
+      expect(names).not.toContain("cron_status");
+      expect(names).not.toContain("cron_list");
+      expect(names).not.toContain("cron_add");
+      expect(names).not.toContain("cron_update");
+      expect(names).not.toContain("cron_remove");
+      expect(names).not.toContain("cron_run");
+      expect(names).not.toContain("cron_runs");
+    });
+
+    it("does NOT register gateway tools for non-owner senders", () => {
+      ctx = createMockContext({ senderIsOwner: false });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerAllTools(mockServer as any, ctx);
+      const names = [...mockServer.registeredTools.keys()];
+      expect(names).not.toContain("gateway_restart");
+      expect(names).not.toContain("gateway_config_get");
+      expect(names).not.toContain("gateway_config_apply");
+      expect(names).not.toContain("gateway_config_patch");
+      expect(names).not.toContain("gateway_config_schema");
+    });
+
+    it("still registers session and message tools for non-owner senders", () => {
+      ctx = createMockContext({ senderIsOwner: false });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerAllTools(mockServer as any, ctx);
+      const names = [...mockServer.registeredTools.keys()];
+      // Session tools
+      expect(names).toContain("sessions_list");
+      expect(names).toContain("sessions_history");
+      expect(names).toContain("sessions_send");
+      // Message tools
+      expect(names).toContain("message_send");
+      expect(names).toContain("message_reply");
+      expect(names).toContain("message_broadcast");
+    });
+
+    it("registers all 29 tools for owner senders", () => {
+      ctx = createMockContext({ senderIsOwner: true });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerAllTools(mockServer as any, ctx);
+      expect(mockServer.registerTool).toHaveBeenCalledTimes(29);
+    });
   });
 });

--- a/src/middleware/mcp-tools.ts
+++ b/src/middleware/mcp-tools.ts
@@ -6,17 +6,23 @@ import { registerMessageTools } from "./mcp-handlers/message.js";
 import { registerSessionTools } from "./mcp-handlers/session.js";
 
 /**
- * Registers all 29 RemoteClaw-specific MCP tools on the given server.
+ * Registers RemoteClaw-specific MCP tools on the given server.
  *
  * Tool categories:
- * - Session management (7 tools)
- * - Channel messaging (10 tools)
- * - Cron scheduling (7 tools)
- * - Gateway admin (5 tools)
+ * - Session management (7 tools) — always registered
+ * - Channel messaging (10 tools) — always registered
+ * - Cron scheduling (7 tools) — owner-only
+ * - Gateway admin (5 tools) — owner-only
+ *
+ * Owner-only tools (cron, gateway) are only registered when
+ * `ctx.senderIsOwner` is `true`, preventing non-owner channel
+ * users from accessing privileged operations.
  */
 export function registerAllTools(server: McpServer, ctx: McpHandlerContext): void {
   registerSessionTools(server, ctx);
   registerMessageTools(server, ctx);
-  registerCronTools(server, ctx);
-  registerGatewayTools(server, ctx);
+  if (ctx.senderIsOwner) {
+    registerCronTools(server, ctx);
+    registerGatewayTools(server, ctx);
+  }
 }

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -181,6 +181,10 @@ export type ChannelMessage = {
   messageToolHints?: string[] | undefined;
   /** Provider-specific metadata. */
   metadata?: Record<string, unknown> | undefined;
+  /** Whether the message sender is the bot owner. Defaults to `false`. */
+  senderIsOwner?: boolean | undefined;
+  /** Tool profile controlling which tool categories are available. Defaults to `"full"`. */
+  toolProfile?: string | undefined;
 };
 
 // ── Bridge Callbacks ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Gate owner-only MCP tools (cron scheduling, gateway admin) behind `senderIsOwner` flag resolved from command authorization
- Propagate `senderIsOwner` and `toolProfile` end-to-end: dispatch site → `ChannelMessage` → ChannelBridge env var → MCP server context → tool registration gate
- Non-owner channel users can no longer instruct the agent to modify cron schedules or restart the gateway via MCP tools
- Secure defaults: `senderIsOwner` defaults to `false` at every boundary (defense-in-depth)

## Changes

| File | Change |
|------|--------|
| `src/middleware/mcp-handlers/context.ts` | Add `senderIsOwner` and `toolProfile` fields |
| `src/middleware/mcp-server.ts` | Read `REMOTECLAW_SENDER_IS_OWNER` and `REMOTECLAW_TOOL_PROFILE` env vars |
| `src/middleware/mcp-tools.ts` | Gate cron/gateway tool registration on `ctx.senderIsOwner` |
| `src/middleware/channel-bridge.ts` | Pass security context as env vars in `#buildMcpConfig()` |
| `src/middleware/types.ts` | Add `senderIsOwner` and `toolProfile` to `ChannelMessage` |
| `src/auto-reply/reply/agent-runner-execution.ts` | Propagate `senderIsOwner` from `resolveCommandAuthorization()` |
| `src/commands/agent.ts` | Set `senderIsOwner: true` (CLI user is always owner) |
| `src/cron/isolated-agent/run.ts` | Set `senderIsOwner: false` (cron agents must not self-modify) |
| `extensions/voice-call/src/core-bridge.ts` | Add fields to duck-typed `ChannelMessage` |
| `extensions/voice-call/src/response-generator.ts` | Set `senderIsOwner: true` (voice callers have direct access) |

## Test plan

- [x] `registerAllTools` with `senderIsOwner: false` registers only 17 tools (no cron/gateway)
- [x] `registerAllTools` with `senderIsOwner: true` registers all 29 tools
- [x] `ChannelBridge.#buildMcpConfig()` includes `REMOTECLAW_SENDER_IS_OWNER` env var
- [x] Default `senderIsOwner` is `false` when not set on message
- [x] `REMOTECLAW_TOOL_PROFILE` defaults to `"full"` when not set
- [x] All existing middleware tests pass (71 tests)
- [x] `pnpm build` passes
- [x] `pnpm format` and `pnpm lint` clean

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)