### PR TITLE
feat: warn extensions that register dead LLM pipeline hooks

### DIFF
--- a/src/plugins/dead-hooks.test.ts
+++ b/src/plugins/dead-hooks.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPluginRegistry, type PluginRecord } from "./registry.js";
+import type { PluginRuntime } from "./runtime/types.js";
+
+function makeRegistryParams() {
+  return {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    runtime: {} as PluginRuntime,
+  };
+}
+
+function makeRecord(overrides?: Partial<PluginRecord>): PluginRecord {
+  return {
+    id: "test-plugin",
+    name: "test-plugin",
+    source: "/tmp/test-plugin.js",
+    origin: "global" as const,
+    enabled: true,
+    status: "loaded" as const,
+    toolNames: [],
+    hookNames: [],
+    channelIds: [],
+    providerIds: [],
+    gatewayMethods: [],
+    cliCommands: [],
+    services: [],
+    commands: [],
+    httpHandlers: 0,
+    hookCount: 0,
+    configSchema: false,
+    ...overrides,
+  };
+}
+
+const DEAD_HOOK_NAMES = [
+  "before_model_resolve",
+  "before_prompt_build",
+  "before_agent_start",
+  "llm_input",
+  "llm_output",
+  "agent_end",
+  "before_compaction",
+  "after_compaction",
+  "tool_result_persist",
+] as const;
+
+describe("dead hook guards", () => {
+  describe("registerHook (legacy string-based)", () => {
+    it.each(DEAD_HOOK_NAMES)("warns and skips dead hook: %s", (hookName) => {
+      const { registry, registerHook } = createPluginRegistry(makeRegistryParams());
+      const record = makeRecord();
+      const handler = vi.fn();
+
+      registerHook(record, hookName, handler, { name: "test-hook" }, undefined);
+
+      // Hook should NOT be registered
+      expect(registry.hooks).toHaveLength(0);
+
+      // Diagnostic warning should be pushed
+      expect(registry.diagnostics).toHaveLength(1);
+      expect(registry.diagnostics[0]).toMatchObject({
+        level: "warn",
+        pluginId: "test-plugin",
+        message: expect.stringContaining(hookName),
+      });
+      expect(registry.diagnostics[0].message).toContain("CLI-only mode");
+    });
+
+    it("allows live hooks through without warnings", () => {
+      const { registry, registerHook } = createPluginRegistry(makeRegistryParams());
+      const record = makeRecord();
+      const handler = vi.fn();
+
+      registerHook(record, "message_received", handler, { name: "test-hook" }, undefined);
+
+      expect(registry.hooks).toHaveLength(1);
+      expect(registry.diagnostics).toHaveLength(0);
+    });
+
+    it("filters dead hooks from a mixed array, keeping live ones", () => {
+      const { registry, registerHook } = createPluginRegistry(makeRegistryParams());
+      const record = makeRecord();
+      const handler = vi.fn();
+
+      registerHook(
+        record,
+        ["llm_input", "message_received", "agent_end"],
+        handler,
+        { name: "test-hook" },
+        undefined,
+      );
+
+      // Only the live hook should be registered
+      expect(registry.hooks).toHaveLength(1);
+      expect(registry.hooks[0].events).toEqual(["message_received"]);
+
+      // Two dead hooks should produce two warnings
+      expect(registry.diagnostics).toHaveLength(2);
+      expect(registry.diagnostics[0].message).toContain("llm_input");
+      expect(registry.diagnostics[1].message).toContain("agent_end");
+    });
+
+    it("returns early when all events in array are dead", () => {
+      const { registry, registerHook } = createPluginRegistry(makeRegistryParams());
+      const record = makeRecord();
+      const handler = vi.fn();
+
+      registerHook(record, ["llm_input", "llm_output"], handler, { name: "test-hook" }, undefined);
+
+      expect(registry.hooks).toHaveLength(0);
+      expect(registry.diagnostics).toHaveLength(2);
+    });
+  });
+
+  describe("api.on() (typed hook)", () => {
+    it("warns and skips dead hook via api.on()", () => {
+      const { registry, createApi } = createPluginRegistry(makeRegistryParams());
+      const record = makeRecord();
+      const api = createApi(record, { config: undefined });
+
+      // Cast to bypass TypeScript — simulates JS extension or old type defs
+      (api.on as (name: string, handler: () => void) => void)("llm_input", vi.fn());
+
+      // Typed hook should NOT be registered
+      expect(registry.typedHooks).toHaveLength(0);
+
+      // Diagnostic warning should be pushed
+      expect(registry.diagnostics).toHaveLength(1);
+      expect(registry.diagnostics[0]).toMatchObject({
+        level: "warn",
+        pluginId: "test-plugin",
+        message: expect.stringContaining("llm_input"),
+      });
+      expect(registry.diagnostics[0].message).toContain("CLI-only mode");
+    });
+
+    it("allows live hooks through api.on() without warnings", () => {
+      const { registry, createApi } = createPluginRegistry(makeRegistryParams());
+      const record = makeRecord();
+      const api = createApi(record, { config: undefined });
+
+      api.on("message_received", vi.fn());
+
+      expect(registry.typedHooks).toHaveLength(1);
+      expect(registry.diagnostics).toHaveLength(0);
+    });
+  });
+});

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -161,6 +161,23 @@ export function createEmptyPluginRegistry(): PluginRegistry {
   };
 }
 
+/**
+ * Hooks that belonged to the in-process LLM execution pipeline.
+ * Their trigger points no longer exist in CLI-only mode — registrations
+ * are silently dropped with a diagnostic warning.
+ */
+const DEAD_HOOKS: ReadonlySet<string> = new Set([
+  "before_model_resolve",
+  "before_prompt_build",
+  "before_agent_start",
+  "llm_input",
+  "llm_output",
+  "agent_end",
+  "before_compaction",
+  "after_compaction",
+  "tool_result_persist",
+]);
+
 export function createPluginRegistry(registryParams: PluginRegistryParams) {
   const registry = createEmptyPluginRegistry();
   const coreGatewayMethods = new Set(Object.keys(registryParams.coreGatewayHandlers ?? {}));
@@ -204,7 +221,29 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     config: OpenClawPluginApi["config"],
   ) => {
     const eventList = Array.isArray(events) ? events : [events];
-    const normalizedEvents = eventList.map((event) => event.trim()).filter(Boolean);
+    const trimmedEvents = eventList.map((event) => event.trim()).filter(Boolean);
+
+    // Filter out dead hooks with warnings
+    const normalizedEvents: string[] = [];
+    for (const event of trimmedEvents) {
+      if (DEAD_HOOKS.has(event)) {
+        pushDiagnostic({
+          level: "warn",
+          pluginId: record.id,
+          source: record.source,
+          message:
+            `Hook "${event}" is not available in CLI-only mode. ` +
+            "LLM pipeline hooks are managed by the CLI agent runtime. " +
+            "This hook will not fire.",
+        });
+        continue;
+      }
+      normalizedEvents.push(event);
+    }
+    if (normalizedEvents.length === 0) {
+      return;
+    }
+
     const entry = opts?.entry ?? null;
     const name = entry?.hook.name ?? opts?.name?.trim();
     if (!name) {
@@ -468,7 +507,21 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       registerService: (service) => registerService(record, service),
       registerCommand: (command) => registerCommand(record, command),
       resolvePath: (input: string) => resolveUserPath(input),
-      on: (hookName, handler, opts) => registerTypedHook(record, hookName, handler, opts),
+      on: (hookName, handler, opts) => {
+        if (DEAD_HOOKS.has(hookName as string)) {
+          pushDiagnostic({
+            level: "warn",
+            pluginId: record.id,
+            source: record.source,
+            message:
+              `Hook "${hookName}" is not available in CLI-only mode. ` +
+              "LLM pipeline hooks are managed by the CLI agent runtime. " +
+              "This hook will not fire.",
+          });
+          return;
+        }
+        registerTypedHook(record, hookName, handler, opts);
+      },
     };
   };
 


### PR DESCRIPTION
## Summary

- Add `DEAD_HOOKS` constant listing 9 hooks whose trigger points no longer exist in CLI-only mode
- Guard `registerHook()` to filter dead hooks from event arrays, emitting diagnostic warnings per dead hook
- Guard `api.on()` to warn and skip dead hooks registered via the typed hook API
- Extensions continue to load normally — warn, don't fail

Closes #88

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (833 tests, 93 files)
- [x] New test file `src/plugins/dead-hooks.test.ts` (14 tests) covers:
  - Each of the 9 dead hooks via `registerHook()` produces a warning and is skipped
  - Live hooks pass through `registerHook()` without warnings
  - Mixed arrays (dead + live) keep only live hooks
  - All-dead arrays return early
  - Dead hooks via `api.on()` produce a warning and are skipped
  - Live hooks via `api.on()` pass through without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)