### PR TITLE
feat: relocate before_tool_call and after_tool_call hooks to MCP server

### DIFF
--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -92,6 +92,8 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "chat.abort",
     "browser.request",
     "push.test",
+    "hooks.tool.before",
+    "hooks.tool.after",
   ],
   [ADMIN_SCOPE]: [
     "channels.logout",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -21,6 +21,7 @@ import { sendHandlers } from "./server-methods/send.js";
 import { sessionsHandlers } from "./server-methods/sessions.js";
 import { systemHandlers } from "./server-methods/system.js";
 import { talkHandlers } from "./server-methods/talk.js";
+import { toolHooksHandlers } from "./server-methods/tool-hooks.js";
 import { toolsCatalogHandlers } from "./server-methods/tools-catalog.js";
 import { ttsHandlers } from "./server-methods/tts.js";
 import type { GatewayRequestHandlers, GatewayRequestOptions } from "./server-methods/types.js";
@@ -86,6 +87,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...agentHandlers,
   ...agentsHandlers,
   ...browserHandlers,
+  ...toolHooksHandlers,
 };
 
 export async function handleGatewayRequest(

--- a/src/gateway/server-methods/tool-hooks.ts
+++ b/src/gateway/server-methods/tool-hooks.ts
@@ -1,0 +1,36 @@
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+export const toolHooksHandlers: GatewayRequestHandlers = {
+  "hooks.tool.before": async ({ params, respond }) => {
+    const hookRunner = getGlobalHookRunner();
+    if (!hookRunner) {
+      respond(true, {});
+      return;
+    }
+    const toolName = typeof params.toolName === "string" ? params.toolName : "";
+    const toolParams = (params.params ?? {}) as Record<string, unknown>;
+    const result = await hookRunner.runBeforeToolCall(
+      { toolName, params: toolParams },
+      { toolName },
+    );
+    respond(true, result ?? {});
+  },
+
+  "hooks.tool.after": async ({ params, respond }) => {
+    const hookRunner = getGlobalHookRunner();
+    if (!hookRunner) {
+      respond(true, {});
+      return;
+    }
+    const toolName = typeof params.toolName === "string" ? params.toolName : "";
+    const toolParams = (params.params ?? {}) as Record<string, unknown>;
+    const durationMs = typeof params.durationMs === "number" ? params.durationMs : undefined;
+    const error = typeof params.error === "string" ? params.error : undefined;
+    await hookRunner.runAfterToolCall(
+      { toolName, params: toolParams, durationMs, error },
+      { toolName },
+    );
+    respond(true, {});
+  },
+};

--- a/src/middleware/mcp-tools.before-tool-call.test.ts
+++ b/src/middleware/mcp-tools.before-tool-call.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { McpHandlerContext } from "./mcp-handlers/context.js";
+import { McpSideEffectsWriter } from "./mcp-side-effects.js";
+import { registerAllTools } from "./mcp-tools.js";
+
+// Mock callGateway — all callMcpGateway calls delegate here
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn().mockResolvedValue({}),
+}));
+
+// Import after mock setup so the mock is in place
+const { callGateway } = await import("../gateway/call.js");
+const mockCallGateway = vi.mocked(callGateway);
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function createMockServer() {
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const registeredTools = new Map<string, { handler: (...args: any[]) => any }>();
+  return {
+    registeredTools,
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerTool: vi.fn((name: string, _config: any, handler?: (...args: any[]) => any) => {
+      if (handler) {
+        registeredTools.set(name, { handler });
+      }
+      return { update: vi.fn(), remove: vi.fn(), disable: vi.fn(), enable: vi.fn() };
+    }),
+  };
+}
+
+function createMockContext(overrides?: Partial<McpHandlerContext>): McpHandlerContext {
+  return {
+    gatewayUrl: "ws://127.0.0.1:18789",
+    gatewayToken: "test-token",
+    sessionKey: "test-session",
+    sideEffects: new McpSideEffectsWriter("/dev/null"),
+    channel: "telegram",
+    accountId: "test-account",
+    to: "test-target",
+    threadId: "test-thread",
+    senderIsOwner: true,
+    toolProfile: "full",
+    ...overrides,
+  };
+}
+
+// oxlint-disable-next-line typescript/no-explicit-any
+function getCallMethods(): string[] {
+  // oxlint-disable-next-line typescript/no-explicit-any
+  return mockCallGateway.mock.calls.map((c: any[]) => c[0]?.method as string);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("tool hook wrapping", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let ctx: McpHandlerContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockServer = createMockServer();
+    ctx = createMockContext();
+  });
+
+  it("fires hooks.tool.before when an MCP tool is invoked", async () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerAllTools(mockServer as any, ctx);
+
+    const { handler } = mockServer.registeredTools.get("sessions_list")!;
+    await handler({ limit: 10 });
+
+    expect(getCallMethods()).toContain("hooks.tool.before");
+
+    const beforeCall = mockCallGateway.mock.calls.find(
+      // oxlint-disable-next-line typescript/no-explicit-any
+      (c: any[]) => c[0]?.method === "hooks.tool.before",
+    );
+    expect(beforeCall).toBeDefined();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect((beforeCall![0] as any).params).toEqual(
+      expect.objectContaining({ toolName: "sessions_list" }),
+    );
+  });
+
+  it("fires hooks.tool.after with durationMs after tool execution", async () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerAllTools(mockServer as any, ctx);
+
+    const { handler } = mockServer.registeredTools.get("sessions_list")!;
+    await handler({ limit: 10 });
+
+    const afterCall = mockCallGateway.mock.calls.find(
+      // oxlint-disable-next-line typescript/no-explicit-any
+      (c: any[]) => c[0]?.method === "hooks.tool.after",
+    );
+    expect(afterCall).toBeDefined();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const afterParams = (afterCall![0] as any).params;
+    expect(afterParams.toolName).toBe("sessions_list");
+    expect(typeof afterParams.durationMs).toBe("number");
+    expect(afterParams.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("fires hooks in order: before, tool, after", async () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerAllTools(mockServer as any, ctx);
+
+    const { handler } = mockServer.registeredTools.get("sessions_list")!;
+    await handler({ limit: 10 });
+
+    const methods = getCallMethods();
+    const beforeIdx = methods.indexOf("hooks.tool.before");
+    const toolIdx = methods.indexOf("sessions.list");
+    const afterIdx = methods.indexOf("hooks.tool.after");
+
+    expect(beforeIdx).toBeLessThan(toolIdx);
+    expect(toolIdx).toBeLessThan(afterIdx);
+  });
+
+  it("hook failures do not block tool execution", async () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    mockCallGateway.mockImplementation(async (opts: any) => {
+      if (opts.method === "hooks.tool.before" || opts.method === "hooks.tool.after") {
+        throw new Error("hook gateway error");
+      }
+      return {};
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerAllTools(mockServer as any, ctx);
+
+    const { handler } = mockServer.registeredTools.get("sessions_list")!;
+    const result = await handler({ limit: 10 });
+
+    expect(result).toBeDefined();
+    expect(result.content).toBeDefined();
+  });
+});

--- a/src/middleware/mcp-tools.ts
+++ b/src/middleware/mcp-tools.ts
@@ -3,7 +3,57 @@ import type { McpHandlerContext } from "./mcp-handlers/context.js";
 import { registerCronTools } from "./mcp-handlers/cron.js";
 import { registerGatewayTools } from "./mcp-handlers/gateway.js";
 import { registerMessageTools } from "./mcp-handlers/message.js";
-import { registerSessionTools } from "./mcp-handlers/session.js";
+import { callMcpGateway, registerSessionTools } from "./mcp-handlers/session.js";
+
+/**
+ * Wraps an MCP server so every registered tool fires `before_tool_call` /
+ * `after_tool_call` plugin hooks via gateway RPC. Both hook calls are
+ * fire-and-forget (`.catch(() => {})`) so they never block tool execution.
+ */
+function wrapWithToolHooks(server: McpServer, ctx: McpHandlerContext): McpServer {
+  const orig = server.registerTool.bind(server);
+  return new Proxy(server, {
+    get(target, prop, receiver) {
+      if (prop !== "registerTool") {
+        return Reflect.get(target, prop, receiver);
+      }
+      // oxlint-disable-next-line typescript/no-explicit-any
+      return (...registerArgs: any[]) => {
+        const toolName = registerArgs[0] as string;
+        const lastIdx = registerArgs.length - 1;
+        const handler = registerArgs[lastIdx];
+        if (typeof handler === "function") {
+          // oxlint-disable-next-line typescript/no-explicit-any
+          registerArgs[lastIdx] = async (...handlerArgs: any[]) => {
+            const start = Date.now();
+            const params = handlerArgs[0] as Record<string, unknown>;
+            callMcpGateway(ctx, "hooks.tool.before", { toolName, params }).catch(() => {});
+            try {
+              // oxlint-disable-next-line typescript/no-explicit-any
+              const result = await (handler as (...a: any[]) => Promise<unknown>)(...handlerArgs);
+              callMcpGateway(ctx, "hooks.tool.after", {
+                toolName,
+                params,
+                durationMs: Date.now() - start,
+              }).catch(() => {});
+              return result;
+            } catch (err) {
+              callMcpGateway(ctx, "hooks.tool.after", {
+                toolName,
+                params,
+                durationMs: Date.now() - start,
+                error: String(err),
+              }).catch(() => {});
+              throw err;
+            }
+          };
+        }
+        // oxlint-disable-next-line typescript/no-explicit-any
+        return (orig as (...a: any[]) => unknown)(...registerArgs);
+      };
+    },
+  });
+}
 
 /**
  * Registers RemoteClaw-specific MCP tools on the given server.
@@ -17,12 +67,16 @@ import { registerSessionTools } from "./mcp-handlers/session.js";
  * Owner-only tools (cron, gateway) are only registered when
  * `ctx.senderIsOwner` is `true`, preventing non-owner channel
  * users from accessing privileged operations.
+ *
+ * All tools are wrapped with before_tool_call / after_tool_call
+ * hook firing via gateway RPC.
  */
 export function registerAllTools(server: McpServer, ctx: McpHandlerContext): void {
-  registerSessionTools(server, ctx);
-  registerMessageTools(server, ctx);
+  const hooked = wrapWithToolHooks(server, ctx);
+  registerSessionTools(hooked, ctx);
+  registerMessageTools(hooked, ctx);
   if (ctx.senderIsOwner) {
-    registerCronTools(server, ctx);
-    registerGatewayTools(server, ctx);
+    registerCronTools(hooked, ctx);
+    registerGatewayTools(hooked, ctx);
   }
 }


### PR DESCRIPTION
## Summary

Closes #95.

- Adds `hooks.tool.before` and `hooks.tool.after` gateway RPC methods that fire `HookRunner.runBeforeToolCall()` / `runAfterToolCall()` in the gateway process
- Registers both methods in `coreGatewayHandlers` with `WRITE_SCOPE` access so the MCP server can call them
- Wraps all MCP tool handlers (via `Proxy` on `registerAllTools()`) to fire both hooks around tool execution as fire-and-forget (`.catch(() => {})`)
- Observe-only for v0.1.0: the before hook result (block/modify) is not propagated back to the MCP server

## Test plan

- [x] New test: `mcp-tools.before-tool-call.test.ts` (4 tests) — verifies before/after hooks fire, order is correct, durationMs is present, and hook failures don't block tool execution
- [x] Existing `mcp-tools.test.ts` (12 tests) — passes unchanged (tool count, gating, descriptions)
- [x] Existing `server-methods.test.ts` (26 tests) — passes with new handlers
- [x] Existing `method-scopes.test.ts` (7 tests) — passes with new scope entries
- [x] Full test suite: 833 passed, 0 failed
- [x] `pnpm build` passes
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format:check` — all files formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)