### PR TITLE
feat: bridge extension registerTool() to MCP server for CLI agents

### DIFF
--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -53,6 +53,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "tts.providers",
     "models.list",
     "tools.catalog",
+    "plugin:tools:list",
     "agents.list",
     "agent.identity.get",
     "voicewake.get",
@@ -94,6 +95,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "push.test",
     "hooks.tool.before",
     "hooks.tool.after",
+    "plugin:tools:invoke",
   ],
   [ADMIN_SCOPE]: [
     "channels.logout",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -16,6 +16,7 @@ import { doctorHandlers } from "./server-methods/doctor.js";
 import { healthHandlers } from "./server-methods/health.js";
 import { logsHandlers } from "./server-methods/logs.js";
 import { nodeHandlers } from "./server-methods/nodes.js";
+import { pluginToolsHandlers } from "./server-methods/plugin-tools.js";
 import { pushHandlers } from "./server-methods/push.js";
 import { sendHandlers } from "./server-methods/send.js";
 import { sessionsHandlers } from "./server-methods/sessions.js";
@@ -87,6 +88,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...agentHandlers,
   ...agentsHandlers,
   ...browserHandlers,
+  ...pluginToolsHandlers,
   ...toolHooksHandlers,
 };
 

--- a/src/gateway/server-methods/plugin-tools.test.ts
+++ b/src/gateway/server-methods/plugin-tools.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi } from "vitest";
+import { pluginToolsHandlers } from "./plugin-tools.js";
+import type { RespondFn } from "./types.js";
+
+// Mock dependencies
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentDir: () => "/mock/agent",
+  resolveAgentWorkspaceDir: () => "/mock/workspace",
+  resolveDefaultAgentId: () => "default",
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => ({}),
+}));
+
+const mockResolvePluginTools = vi.fn();
+vi.mock("../../plugins/tools.js", () => ({
+  resolvePluginTools: (...args: unknown[]) => mockResolvePluginTools(...args),
+}));
+
+function createHandlerArgs(method: string, params: Record<string, unknown> = {}) {
+  const respond = vi.fn() as unknown as RespondFn & ReturnType<typeof vi.fn>;
+  return {
+    opts: {
+      req: { method, params },
+      params,
+      client: undefined,
+      isWebchatConnect: false,
+      respond,
+      context: { logGateway: { warn: vi.fn(), error: vi.fn(), info: vi.fn() } },
+    },
+    respond,
+  };
+}
+
+describe("plugin:tools:list", () => {
+  it("returns tool names, descriptions, and schemas", () => {
+    const mockTool = {
+      name: "memory_search",
+      description: "Search vector memory",
+      parameters: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+      },
+    };
+    mockResolvePluginTools.mockReturnValue([mockTool]);
+
+    const { opts, respond } = createHandlerArgs("plugin:tools:list");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    void pluginToolsHandlers["plugin:tools:list"](opts as any);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        agentId: "default",
+        tools: [
+          {
+            name: "memory_search",
+            description: "Search vector memory",
+            inputSchema: {
+              type: "object",
+              properties: { query: { type: "string" } },
+              required: ["query"],
+            },
+          },
+        ],
+      }),
+    );
+  });
+
+  it("returns empty array when no plugins registered", () => {
+    mockResolvePluginTools.mockReturnValue([]);
+
+    const { opts, respond } = createHandlerArgs("plugin:tools:list");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    void pluginToolsHandlers["plugin:tools:list"](opts as any);
+
+    expect(respond).toHaveBeenCalledWith(true, expect.objectContaining({ tools: [] }));
+  });
+
+  it("provides fallback description for tools without one", () => {
+    const mockTool = {
+      name: "bare_tool",
+      description: "",
+      parameters: { type: "object" },
+    };
+    mockResolvePluginTools.mockReturnValue([mockTool]);
+
+    const { opts, respond } = createHandlerArgs("plugin:tools:list");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    void pluginToolsHandlers["plugin:tools:list"](opts as any);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        tools: [expect.objectContaining({ description: "Plugin tool" })],
+      }),
+    );
+  });
+
+  it("provides fallback schema for tools without parameters", () => {
+    const mockTool = {
+      name: "no_schema_tool",
+      description: "Tool without schema",
+      parameters: undefined,
+    };
+    mockResolvePluginTools.mockReturnValue([mockTool]);
+
+    const { opts, respond } = createHandlerArgs("plugin:tools:list");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    void pluginToolsHandlers["plugin:tools:list"](opts as any);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        tools: [
+          expect.objectContaining({
+            inputSchema: { type: "object", properties: {} },
+          }),
+        ],
+      }),
+    );
+  });
+});
+
+describe("plugin:tools:invoke", () => {
+  it("executes a plugin tool and returns result", async () => {
+    const mockExecute = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "result data" }],
+      details: { found: 3 },
+    });
+    mockResolvePluginTools.mockReturnValue([{ name: "memory_search", execute: mockExecute }]);
+
+    const { opts, respond } = createHandlerArgs("plugin:tools:invoke", {
+      toolName: "memory_search",
+      params: { query: "test" },
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await pluginToolsHandlers["plugin:tools:invoke"](opts as any);
+
+    expect(mockExecute).toHaveBeenCalledWith(
+      expect.any(String), // toolCallId (UUID)
+      { query: "test" },
+    );
+    expect(respond).toHaveBeenCalledWith(true, {
+      content: [{ type: "text", text: "result data" }],
+      details: { found: 3 },
+    });
+  });
+
+  it("returns error when toolName is missing", async () => {
+    const { opts, respond } = createHandlerArgs("plugin:tools:invoke", {});
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await pluginToolsHandlers["plugin:tools:invoke"](opts as any);
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "toolName required" }),
+    );
+  });
+
+  it("returns error when tool is not found", async () => {
+    mockResolvePluginTools.mockReturnValue([]);
+
+    const { opts, respond } = createHandlerArgs("plugin:tools:invoke", {
+      toolName: "nonexistent",
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await pluginToolsHandlers["plugin:tools:invoke"](opts as any);
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "plugin tool not found: nonexistent" }),
+    );
+  });
+
+  it("returns error when tool execution fails", async () => {
+    mockResolvePluginTools.mockReturnValue([
+      {
+        name: "failing_tool",
+        execute: vi.fn().mockRejectedValue(new Error("execution failed")),
+      },
+    ]);
+
+    const { opts, respond } = createHandlerArgs("plugin:tools:invoke", {
+      toolName: "failing_tool",
+      params: {},
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await pluginToolsHandlers["plugin:tools:invoke"](opts as any);
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("execution failed") }),
+    );
+  });
+});

--- a/src/gateway/server-methods/plugin-tools.ts
+++ b/src/gateway/server-methods/plugin-tools.ts
@@ -1,0 +1,87 @@
+import crypto from "node:crypto";
+import {
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../../agents/agent-scope.js";
+import { loadConfig } from "../../config/config.js";
+import { resolvePluginTools } from "../../plugins/tools.js";
+import { ErrorCodes, errorShape } from "../protocol/index.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+function resolveToolContext(rawAgentId: unknown) {
+  const cfg = loadConfig();
+  const agentId =
+    typeof rawAgentId === "string" && rawAgentId.trim()
+      ? rawAgentId.trim()
+      : resolveDefaultAgentId(cfg);
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+  const agentDir = resolveAgentDir(cfg, agentId);
+  return { cfg, agentId, workspaceDir, agentDir };
+}
+
+export const pluginToolsHandlers: GatewayRequestHandlers = {
+  "plugin:tools:list": ({ params, respond }) => {
+    try {
+      const { cfg, agentId, workspaceDir, agentDir } = resolveToolContext(params.agentId);
+      const tools = resolvePluginTools({
+        context: { config: cfg, workspaceDir, agentDir, agentId },
+        suppressNameConflicts: true,
+      });
+      const entries = tools.map((tool) => ({
+        name: tool.name,
+        description:
+          typeof tool.description === "string" && tool.description.trim()
+            ? tool.description.trim()
+            : "Plugin tool",
+        inputSchema:
+          tool.parameters && typeof tool.parameters === "object"
+            ? (tool.parameters as Record<string, unknown>)
+            : { type: "object", properties: {} },
+      }));
+      respond(true, { agentId, tools: entries });
+    } catch (err) {
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));
+    }
+  },
+
+  "plugin:tools:invoke": async ({ params, respond }) => {
+    const toolName = typeof params.toolName === "string" ? params.toolName.trim() : "";
+    if (!toolName) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "toolName required"));
+      return;
+    }
+    try {
+      const { cfg, agentId, workspaceDir, agentDir } = resolveToolContext(params.agentId);
+      const sessionKey = typeof params.sessionKey === "string" ? params.sessionKey : undefined;
+      const tools = resolvePluginTools({
+        context: {
+          config: cfg,
+          workspaceDir,
+          agentDir,
+          agentId,
+          sessionKey,
+        },
+        suppressNameConflicts: true,
+      });
+      const tool = tools.find((t) => t.name === toolName);
+      if (!tool) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, `plugin tool not found: ${toolName}`),
+        );
+        return;
+      }
+      const toolCallId = crypto.randomUUID();
+      const toolParams = (params.params ?? {}) as Record<string, unknown>;
+      const result = await tool.execute(toolCallId, toolParams);
+      respond(true, {
+        content: result.content,
+        details: result.details,
+      });
+    } catch (err) {
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));
+    }
+  },
+};

--- a/src/middleware/mcp-plugin-tools.test.ts
+++ b/src/middleware/mcp-plugin-tools.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from "vitest";
+import type { McpHandlerContext } from "./mcp-handlers/context.js";
+import { registerPluginTools } from "./mcp-plugin-tools.js";
+import { McpSideEffectsWriter } from "./mcp-side-effects.js";
+
+// Mock callMcpGateway to simulate gateway responses
+vi.mock("./mcp-handlers/session.js", () => ({
+  callMcpGateway: vi.fn(),
+}));
+import { callMcpGateway } from "./mcp-handlers/session.js";
+const mockCallMcpGateway = vi.mocked(callMcpGateway);
+
+function createMockServer() {
+  const registeredTools = new Map<
+    string,
+    { description?: string; inputSchema?: unknown; handler?: unknown }
+  >();
+  return {
+    registeredTools,
+    registerTool: vi.fn(
+      (name: string, config: { description?: string; inputSchema?: unknown }, handler: unknown) => {
+        registeredTools.set(name, { ...config, handler });
+        return { update: vi.fn(), remove: vi.fn(), disable: vi.fn(), enable: vi.fn() };
+      },
+    ),
+  };
+}
+
+function createMockContext(overrides?: Partial<McpHandlerContext>): McpHandlerContext {
+  return {
+    gatewayUrl: "ws://127.0.0.1:18789",
+    gatewayToken: "test-token",
+    sessionKey: "test-session",
+    sideEffects: new McpSideEffectsWriter("/dev/null"),
+    channel: "telegram",
+    accountId: "test-account",
+    to: "test-target",
+    threadId: "test-thread",
+    senderIsOwner: true,
+    toolProfile: "full",
+    ...overrides,
+  };
+}
+
+describe("registerPluginTools", () => {
+  it("registers plugin tools returned by gateway", async () => {
+    mockCallMcpGateway.mockImplementation(async (_ctx, method) => {
+      if (method === "plugin:tools:list") {
+        return {
+          agentId: "default",
+          tools: [
+            {
+              name: "memory_search",
+              description: "Search vector memory",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  query: { type: "string" },
+                  limit: { type: "number" },
+                },
+                required: ["query"],
+              },
+            },
+            {
+              name: "voice_call",
+              description: "Initiate a voice call",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  number: { type: "string" },
+                },
+                required: ["number"],
+              },
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const server = createMockServer();
+    const ctx = createMockContext();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await registerPluginTools(server as any, ctx);
+
+    expect(server.registerTool).toHaveBeenCalledTimes(2);
+    const names = [...server.registeredTools.keys()];
+    expect(names).toContain("memory_search");
+    expect(names).toContain("voice_call");
+  });
+
+  it("skips registration when gateway returns no tools", async () => {
+    mockCallMcpGateway.mockResolvedValue({ agentId: "default", tools: [] });
+
+    const server = createMockServer();
+    const ctx = createMockContext();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await registerPluginTools(server as any, ctx);
+
+    expect(server.registerTool).not.toHaveBeenCalled();
+  });
+
+  it("silently skips when gateway call fails", async () => {
+    mockCallMcpGateway.mockRejectedValue(new Error("connection refused"));
+
+    const server = createMockServer();
+    const ctx = createMockContext();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await registerPluginTools(server as any, ctx);
+
+    expect(server.registerTool).not.toHaveBeenCalled();
+  });
+
+  it("tool handler delegates to plugin:tools:invoke", async () => {
+    mockCallMcpGateway.mockImplementation(async (_ctx, method, params) => {
+      if (method === "plugin:tools:list") {
+        return {
+          agentId: "default",
+          tools: [
+            {
+              name: "test_tool",
+              description: "A test tool",
+              inputSchema: {
+                type: "object",
+                properties: { input: { type: "string" } },
+                required: ["input"],
+              },
+            },
+          ],
+        };
+      }
+      if (method === "plugin:tools:invoke") {
+        const p = params as { toolName: string; params: Record<string, unknown> };
+        return {
+          content: [
+            { type: "text", text: `invoked ${p.toolName} with ${JSON.stringify(p.params)}` },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const server = createMockServer();
+    const ctx = createMockContext();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await registerPluginTools(server as any, ctx);
+
+    // Call the registered handler
+    const toolEntry = server.registeredTools.get("test_tool");
+    expect(toolEntry?.handler).toBeDefined();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const handler = toolEntry!.handler as (args: Record<string, unknown>) => Promise<any>;
+    const result = await handler({ input: "hello" });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+    expect(result.content[0].text).toContain("invoked test_tool");
+
+    // Verify the invoke call was made with correct params
+    expect(mockCallMcpGateway).toHaveBeenCalledWith(
+      ctx,
+      "plugin:tools:invoke",
+      expect.objectContaining({
+        toolName: "test_tool",
+        params: { input: "hello" },
+        sessionKey: "test-session",
+      }),
+    );
+  });
+
+  it("registered tools have correct descriptions", async () => {
+    mockCallMcpGateway.mockResolvedValue({
+      agentId: "default",
+      tools: [
+        {
+          name: "custom_tool",
+          description: "Custom tool description",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ],
+    });
+
+    const server = createMockServer();
+    const ctx = createMockContext();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await registerPluginTools(server as any, ctx);
+
+    expect(server.registerTool).toHaveBeenCalledWith(
+      "custom_tool",
+      expect.objectContaining({ description: "Custom tool description" }),
+      expect.any(Function),
+    );
+  });
+});

--- a/src/middleware/mcp-plugin-tools.ts
+++ b/src/middleware/mcp-plugin-tools.ts
@@ -1,0 +1,127 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { McpHandlerContext } from "./mcp-handlers/context.js";
+import { callMcpGateway } from "./mcp-handlers/session.js";
+
+// ── JSON Schema → Zod conversion ────────────────────────────────────
+
+/**
+ * Converts a JSON Schema (as produced by TypeBox) into a Zod schema so the
+ * MCP SDK can expose correct parameter definitions and validate input.
+ *
+ * Handles the common types that TypeBox produces. Anything unrecognised is
+ * treated as `z.unknown()` so tool calls still work even if the schema uses
+ * advanced features.
+ */
+function jsonSchemaPropertyToZod(schema: Record<string, unknown>): z.ZodTypeAny {
+  if (Array.isArray(schema.enum)) {
+    const values = schema.enum as [string, ...string[]];
+    if (values.length > 0 && values.every((v) => typeof v === "string")) {
+      return z.enum(values);
+    }
+    return z.any();
+  }
+
+  const type = schema.type;
+
+  if (type === "string") {
+    return z.string();
+  }
+  if (type === "number" || type === "integer") {
+    return z.number();
+  }
+  if (type === "boolean") {
+    return z.boolean();
+  }
+  if (type === "array") {
+    const items = schema.items;
+    if (items && typeof items === "object" && !Array.isArray(items)) {
+      return z.array(jsonSchemaPropertyToZod(items as Record<string, unknown>));
+    }
+    return z.array(z.unknown());
+  }
+  if (type === "object") {
+    return jsonSchemaToZodObject(schema);
+  }
+
+  // Fallback: accept anything so the tool remains callable.
+  return z.any();
+}
+
+function jsonSchemaToZodObject(schema: Record<string, unknown>) {
+  const properties = (schema.properties ?? {}) as Record<string, Record<string, unknown>>;
+  const required = new Set(Array.isArray(schema.required) ? (schema.required as string[]) : []);
+  const shape: Record<string, z.ZodTypeAny> = {};
+  for (const [key, propSchema] of Object.entries(properties)) {
+    const zodType = jsonSchemaPropertyToZod(propSchema);
+    shape[key] = required.has(key) ? zodType : zodType.optional();
+  }
+  return z.object(shape).passthrough();
+}
+
+// ── MCP tool registration ────────────────────────────────────────────
+
+type PluginToolEntry = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+};
+
+type PluginToolListResult = {
+  agentId: string;
+  tools: PluginToolEntry[];
+};
+
+/**
+ * Fetches plugin-registered tools from the gateway and registers each one
+ * as an MCP tool. Handlers delegate execution back to the gateway via
+ * `plugin:tools:invoke`, keeping plugin closures intact.
+ */
+export async function registerPluginTools(
+  server: McpServer,
+  ctx: McpHandlerContext,
+): Promise<void> {
+  let result: PluginToolListResult;
+  try {
+    result = await callMcpGateway<PluginToolListResult>(ctx, "plugin:tools:list");
+  } catch {
+    // Gateway may not have plugins enabled — silently skip.
+    return;
+  }
+  if (!result?.tools || !Array.isArray(result.tools)) {
+    return;
+  }
+  for (const entry of result.tools) {
+    const inputSchema = jsonSchemaToZodObject(entry.inputSchema);
+    server.registerTool(
+      entry.name,
+      {
+        description: entry.description,
+        inputSchema,
+      },
+      async (args: Record<string, unknown>) => {
+        const invokeResult = await callMcpGateway<{
+          content?: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+          details?: unknown;
+        }>(ctx, "plugin:tools:invoke", {
+          toolName: entry.name,
+          params: args,
+          sessionKey: ctx.sessionKey,
+        });
+        const content = Array.isArray(invokeResult?.content) ? invokeResult.content : [];
+        return {
+          content: content.map((c) => {
+            if (c.type === "image" && typeof c.data === "string") {
+              return {
+                type: "image" as const,
+                data: c.data,
+                mimeType: c.mimeType ?? "image/png",
+              };
+            }
+            return { type: "text" as const, text: typeof c.text === "string" ? c.text : "" };
+          }),
+        };
+      },
+    );
+  }
+}

--- a/src/middleware/mcp-server.ts
+++ b/src/middleware/mcp-server.ts
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
     version: "1.0.0",
   });
 
-  registerAllTools(server, ctx);
+  await registerAllTools(server, ctx);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/middleware/mcp-tools.before-tool-call.test.ts
+++ b/src/middleware/mcp-tools.before-tool-call.test.ts
@@ -65,7 +65,7 @@ describe("tool hook wrapping", () => {
 
   it("fires hooks.tool.before when an MCP tool is invoked", async () => {
     // oxlint-disable-next-line typescript/no-explicit-any
-    registerAllTools(mockServer as any, ctx);
+    await registerAllTools(mockServer as any, ctx);
 
     const { handler } = mockServer.registeredTools.get("sessions_list")!;
     await handler({ limit: 10 });
@@ -85,7 +85,7 @@ describe("tool hook wrapping", () => {
 
   it("fires hooks.tool.after with durationMs after tool execution", async () => {
     // oxlint-disable-next-line typescript/no-explicit-any
-    registerAllTools(mockServer as any, ctx);
+    await registerAllTools(mockServer as any, ctx);
 
     const { handler } = mockServer.registeredTools.get("sessions_list")!;
     await handler({ limit: 10 });
@@ -104,7 +104,7 @@ describe("tool hook wrapping", () => {
 
   it("fires hooks in order: before, tool, after", async () => {
     // oxlint-disable-next-line typescript/no-explicit-any
-    registerAllTools(mockServer as any, ctx);
+    await registerAllTools(mockServer as any, ctx);
 
     const { handler } = mockServer.registeredTools.get("sessions_list")!;
     await handler({ limit: 10 });
@@ -128,7 +128,7 @@ describe("tool hook wrapping", () => {
     });
 
     // oxlint-disable-next-line typescript/no-explicit-any
-    registerAllTools(mockServer as any, ctx);
+    await registerAllTools(mockServer as any, ctx);
 
     const { handler } = mockServer.registeredTools.get("sessions_list")!;
     const result = await handler({ limit: 10 });

--- a/src/middleware/mcp-tools.test.ts
+++ b/src/middleware/mcp-tools.test.ts
@@ -3,6 +3,11 @@ import type { McpHandlerContext } from "./mcp-handlers/context.js";
 import { McpSideEffectsWriter } from "./mcp-side-effects.js";
 import { registerAllTools } from "./mcp-tools.js";
 
+// Mock registerPluginTools so it doesn't call the real gateway
+vi.mock("./mcp-plugin-tools.js", () => ({
+  registerPluginTools: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Create a minimal mock McpServer
 function createMockServer() {
   const registeredTools = new Map<string, { description?: string }>();
@@ -40,15 +45,15 @@ describe("registerAllTools", () => {
     ctx = createMockContext();
   });
 
-  it("registers exactly 29 tools", () => {
+  it("registers exactly 29 core tools", async () => {
     // oxlint-disable-next-line typescript/no-explicit-any
-    registerAllTools(mockServer as any, ctx);
+    await registerAllTools(mockServer as any, ctx);
     expect(mockServer.registerTool).toHaveBeenCalledTimes(29);
   });
 
-  it("registers all session management tools", () => {
+  it("registers all session management tools", async () => {
     // oxlint-disable-next-line typescript/no-explicit-any
-    registerAllTools(mockServer as any, ctx);
+    await registerAllTools(mockServer as any, ctx);
     const names = [...mockServer.registeredTools.keys()];
     expect(names).toContain("sessions_list");
     expect(names).toContain("sessions_history");
@@ -59,9 +64,9 @@ describe("registerAllTools", () => {
     expect(names).toContain("subagents");
   });
 
-  it("registers all channel messaging tools", () => {
+  it("registers all channel messaging tools", async () => {
     // oxlint-disable-next-line typescript/no-explicit-any
-    registerAllTools(mockServer as any, ctx);
+    await registerAllTools(mockServer as any, ctx);
     const names = [...mockServer.registeredTools.keys()];
     expect(names).toContain("message_send");
     expect(names).toContain("message_reply");
@@ -75,9 +80,9 @@ describe("registerAllTools", () => {
     expect(names).toContain("message_read");
   });
 
-  it("registers all cron scheduling tools", () => {
+  it("registers all cron scheduling tools", async () => {
     // oxlint-disable-next-line typescript/no-explicit-any
-    registerAllTools(mockServer as any, ctx);
+    await registerAllTools(mockServer as any, ctx);
     const names = [...mockServer.registeredTools.keys()];
     expect(names).toContain("cron_status");
     expect(names).toContain("cron_list");
@@ -88,9 +93,9 @@ describe("registerAllTools", () => {
     expect(names).toContain("cron_runs");
   });
 
-  it("registers all gateway admin tools", () => {
+  it("registers all gateway admin tools", async () => {
     // oxlint-disable-next-line typescript/no-explicit-any
-    registerAllTools(mockServer as any, ctx);
+    await registerAllTools(mockServer as any, ctx);
     const names = [...mockServer.registeredTools.keys()];
     expect(names).toContain("gateway_restart");
     expect(names).toContain("gateway_config_get");
@@ -99,35 +104,35 @@ describe("registerAllTools", () => {
     expect(names).toContain("gateway_config_schema");
   });
 
-  it("registers no duplicate tool names", () => {
+  it("registers no duplicate tool names", async () => {
     // oxlint-disable-next-line typescript/no-explicit-any
-    registerAllTools(mockServer as any, ctx);
+    await registerAllTools(mockServer as any, ctx);
     const names = mockServer.registerTool.mock.calls.map((call: unknown[]) => call[0]);
     const uniqueNames = new Set(names);
     expect(uniqueNames.size).toBe(names.length);
   });
 
-  it("every tool has a description", () => {
+  it("every tool has a description", async () => {
     // oxlint-disable-next-line typescript/no-explicit-any
-    registerAllTools(mockServer as any, ctx);
+    await registerAllTools(mockServer as any, ctx);
     for (const [name, config] of mockServer.registeredTools) {
       expect(config.description, `tool "${name}" should have a description`).toBeTruthy();
     }
   });
 
   describe("owner-only tool gating", () => {
-    it("registers only 17 tools for non-owner senders", () => {
+    it("registers only 17 tools for non-owner senders", async () => {
       ctx = createMockContext({ senderIsOwner: false });
       // oxlint-disable-next-line typescript/no-explicit-any
-      registerAllTools(mockServer as any, ctx);
+      await registerAllTools(mockServer as any, ctx);
       // 7 session + 10 message = 17 (no cron or gateway)
       expect(mockServer.registerTool).toHaveBeenCalledTimes(17);
     });
 
-    it("does NOT register cron tools for non-owner senders", () => {
+    it("does NOT register cron tools for non-owner senders", async () => {
       ctx = createMockContext({ senderIsOwner: false });
       // oxlint-disable-next-line typescript/no-explicit-any
-      registerAllTools(mockServer as any, ctx);
+      await registerAllTools(mockServer as any, ctx);
       const names = [...mockServer.registeredTools.keys()];
       expect(names).not.toContain("cron_status");
       expect(names).not.toContain("cron_list");
@@ -138,10 +143,10 @@ describe("registerAllTools", () => {
       expect(names).not.toContain("cron_runs");
     });
 
-    it("does NOT register gateway tools for non-owner senders", () => {
+    it("does NOT register gateway tools for non-owner senders", async () => {
       ctx = createMockContext({ senderIsOwner: false });
       // oxlint-disable-next-line typescript/no-explicit-any
-      registerAllTools(mockServer as any, ctx);
+      await registerAllTools(mockServer as any, ctx);
       const names = [...mockServer.registeredTools.keys()];
       expect(names).not.toContain("gateway_restart");
       expect(names).not.toContain("gateway_config_get");
@@ -150,10 +155,10 @@ describe("registerAllTools", () => {
       expect(names).not.toContain("gateway_config_schema");
     });
 
-    it("still registers session and message tools for non-owner senders", () => {
+    it("still registers session and message tools for non-owner senders", async () => {
       ctx = createMockContext({ senderIsOwner: false });
       // oxlint-disable-next-line typescript/no-explicit-any
-      registerAllTools(mockServer as any, ctx);
+      await registerAllTools(mockServer as any, ctx);
       const names = [...mockServer.registeredTools.keys()];
       // Session tools
       expect(names).toContain("sessions_list");
@@ -165,10 +170,10 @@ describe("registerAllTools", () => {
       expect(names).toContain("message_broadcast");
     });
 
-    it("registers all 29 tools for owner senders", () => {
+    it("registers all 29 core tools for owner senders", async () => {
       ctx = createMockContext({ senderIsOwner: true });
       // oxlint-disable-next-line typescript/no-explicit-any
-      registerAllTools(mockServer as any, ctx);
+      await registerAllTools(mockServer as any, ctx);
       expect(mockServer.registerTool).toHaveBeenCalledTimes(29);
     });
   });

--- a/src/middleware/mcp-tools.ts
+++ b/src/middleware/mcp-tools.ts
@@ -4,6 +4,7 @@ import { registerCronTools } from "./mcp-handlers/cron.js";
 import { registerGatewayTools } from "./mcp-handlers/gateway.js";
 import { registerMessageTools } from "./mcp-handlers/message.js";
 import { callMcpGateway, registerSessionTools } from "./mcp-handlers/session.js";
+import { registerPluginTools } from "./mcp-plugin-tools.js";
 
 /**
  * Wraps an MCP server so every registered tool fires `before_tool_call` /
@@ -71,7 +72,7 @@ function wrapWithToolHooks(server: McpServer, ctx: McpHandlerContext): McpServer
  * All tools are wrapped with before_tool_call / after_tool_call
  * hook firing via gateway RPC.
  */
-export function registerAllTools(server: McpServer, ctx: McpHandlerContext): void {
+export async function registerAllTools(server: McpServer, ctx: McpHandlerContext): Promise<void> {
   const hooked = wrapWithToolHooks(server, ctx);
   registerSessionTools(hooked, ctx);
   registerMessageTools(hooked, ctx);
@@ -79,4 +80,5 @@ export function registerAllTools(server: McpServer, ctx: McpHandlerContext): voi
     registerCronTools(hooked, ctx);
     registerGatewayTools(hooked, ctx);
   }
+  await registerPluginTools(hooked, ctx);
 }


### PR DESCRIPTION
## Summary
- Add `plugin:tools:list` and `plugin:tools:invoke` gateway RPC methods that resolve extension-registered tools via `resolvePluginTools()`
- Add MCP dynamic registration in `registerPluginTools()` that fetches plugin tools at startup and registers them with JSON Schema → Zod converted schemas
- Plugin tool invocations delegate back to the gateway, keeping plugin closures intact on the gateway side
- Plugin tools get `before_tool_call`/`after_tool_call` hook treatment via the existing `wrapWithToolHooks` proxy

## Test plan
- [x] 8 gateway handler tests (list returns tools/empty/fallback description/fallback schema, invoke executes/missing toolName/not found/execution failure)
- [x] 5 MCP registration tests (registers tools/skips empty/skips on failure/delegates to invoke/correct descriptions)
- [x] Existing `mcp-tools.test.ts` (12 tests) and `mcp-tools.before-tool-call.test.ts` (4 tests) updated for async `registerAllTools`
- [x] Full test suite: 837 passed, 1 skipped (pre-existing)
- [x] Build passes
- [x] Lint clean (0 errors, 0 warnings)

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)