### PR TITLE
feat: implement ChannelBridge runtime lifecycle hooks (#101)

### DIFF
--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -1,7 +1,9 @@
+import { randomUUID } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ReplyPayload } from "../auto-reply/types.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { DeliveryAdapter } from "./delivery-adapter.js";
 import { classifyError } from "./error-classifier.js";
 import { readMcpSideEffects } from "./mcp-side-effects.js";
@@ -94,6 +96,25 @@ export class ChannelBridge {
     // 1. Session lookup
     const sessionKey = buildSessionKey(message);
     const existingSessionId = await this.#sessionMap.get(sessionKey);
+    const hookRunner = getGlobalHookRunner();
+
+    // Hook: session_resumed — fires when reusing an existing session
+    if (existingSessionId && hookRunner?.hasHooks("session_resumed")) {
+      await hookRunner.runSessionResumed(
+        {
+          sessionId: existingSessionId,
+          runtimeName: this.#provider,
+          channelId: message.channelId,
+          userId: message.from,
+          resumeMethod: "session_map",
+        },
+        {
+          sessionId: existingSessionId,
+          channelId: message.channelId,
+          runtimeName: this.#provider,
+        },
+      );
+    }
 
     // 2. System prompt
     const systemPrompt = buildSystemPrompt({
@@ -111,6 +132,35 @@ export class ChannelBridge {
 
       // 4. Runtime params
       const runtime = createCliRuntime(this.#provider);
+      let workspaceDir = this.#workspaceDir;
+      let extraEnv: Record<string, string> | undefined;
+      const runId = randomUUID();
+
+      // Hook: before_runtime_spawn — extensions can modify env and workspaceDir
+      if (hookRunner?.hasHooks("before_runtime_spawn")) {
+        const spawnResult = await hookRunner.runBeforeRuntimeSpawn(
+          {
+            runtimeName: this.#provider,
+            sessionId: existingSessionId,
+            command: "node",
+            args: [this.#mcpServerPath],
+            env: mcpServers.remoteclaw?.env ?? {},
+            workspaceDir,
+            channelId: message.channelId,
+          },
+          {
+            sessionId: existingSessionId,
+            channelId: message.channelId,
+            runtimeName: this.#provider,
+          },
+        );
+        if (spawnResult?.workspaceDir) {
+          workspaceDir = spawnResult.workspaceDir;
+        }
+        if (spawnResult?.env) {
+          extraEnv = spawnResult.env;
+        }
+      }
 
       // 5-6. Execute + stream events through DeliveryAdapter
       const adapter = new DeliveryAdapter(
@@ -128,7 +178,8 @@ export class ChannelBridge {
             sessionId: existingSessionId,
             mcpServers,
             abortSignal,
-            workingDirectory: this.#workspaceDir,
+            workingDirectory: workspaceDir,
+            env: extraEnv,
           }),
         );
         payloads = await adapter.process(captured.events, callbacks);
@@ -160,10 +211,51 @@ export class ChannelBridge {
         await this.#sessionMap.set(sessionKey, runResult.sessionId);
       }
 
+      // Hooks: after_runtime_exit + agent_end — fire after session update
+      const finalResult = runResult ?? { ...DEFAULT_RUN_RESULT };
+      if (hookRunner) {
+        const runtimeCtx = {
+          sessionId: finalResult.sessionId,
+          channelId: message.channelId,
+          runtimeName: this.#provider,
+        };
+
+        if (hookRunner.hasHooks("after_runtime_exit")) {
+          void hookRunner.runAfterRuntimeExit(
+            {
+              runtimeName: this.#provider,
+              sessionId: finalResult.sessionId,
+              exitCode: finalResult.errorSubtype ? 1 : 0,
+              durationMs: finalResult.durationMs,
+              stdout: finalResult.text,
+              stderr: lastError,
+              mcpSideEffects: {
+                sentTexts: mcp.sentTexts,
+                sentMediaUrls: mcp.sentMediaUrls,
+                cronAdds: mcp.cronAdds,
+              },
+            },
+            runtimeCtx,
+          );
+        }
+
+        if (hookRunner.hasHooks("agent_end")) {
+          void hookRunner.runAgentEnd(
+            {
+              runId,
+              sessionId: finalResult.sessionId,
+              success: !finalResult.errorSubtype && !lastError,
+              durationMs: finalResult.durationMs,
+            },
+            runtimeCtx,
+          );
+        }
+      }
+
       // 10. Return result
       return {
         payloads,
-        run: runResult ?? { ...DEFAULT_RUN_RESULT },
+        run: finalResult,
         mcp,
         error: lastError,
       };

--- a/src/plugins/dead-hooks.test.ts
+++ b/src/plugins/dead-hooks.test.ts
@@ -38,7 +38,6 @@ const DEAD_HOOK_NAMES = [
   "before_agent_start",
   "llm_input",
   "llm_output",
-  "agent_end",
   "before_compaction",
   "after_compaction",
   "tool_result_persist",
@@ -84,7 +83,7 @@ describe("dead hook guards", () => {
 
       registerHook(
         record,
-        ["llm_input", "message_received", "agent_end"],
+        ["llm_input", "message_received", "llm_output"],
         handler,
         { name: "test-hook" },
         undefined,
@@ -97,7 +96,7 @@ describe("dead hook guards", () => {
       // Two dead hooks should produce two warnings
       expect(registry.diagnostics).toHaveLength(2);
       expect(registry.diagnostics[0].message).toContain("llm_input");
-      expect(registry.diagnostics[1].message).toContain("agent_end");
+      expect(registry.diagnostics[1].message).toContain("llm_output");
     });
 
     it("returns early when all events in array are dead", () => {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -9,7 +9,11 @@ import type { PluginRegistry } from "./registry.js";
 import type {
   PluginHookAfterToolCallEvent,
   PluginHookAgentContext,
+  PluginHookAgentEndEvent,
+  PluginHookAfterRuntimeExitEvent,
   PluginHookBeforeResetEvent,
+  PluginHookBeforeRuntimeSpawnEvent,
+  PluginHookBeforeRuntimeSpawnResult,
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
   PluginHookGatewayContext,
@@ -22,8 +26,10 @@ import type {
   PluginHookMessageSentEvent,
   PluginHookName,
   PluginHookRegistration,
+  PluginHookRuntimeContext,
   PluginHookSessionContext,
   PluginHookSessionEndEvent,
+  PluginHookSessionResumedEvent,
   PluginHookSessionStartEvent,
   PluginHookSubagentContext,
   PluginHookSubagentDeliveryTargetEvent,
@@ -40,7 +46,11 @@ import type {
 // Re-export types for consumers
 export type {
   PluginHookAgentContext,
+  PluginHookAgentEndEvent,
+  PluginHookAfterRuntimeExitEvent,
   PluginHookBeforeResetEvent,
+  PluginHookBeforeRuntimeSpawnEvent,
+  PluginHookBeforeRuntimeSpawnResult,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
   PluginHookMessageSendingEvent,
@@ -52,9 +62,11 @@ export type {
   PluginHookAfterToolCallEvent,
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
+  PluginHookRuntimeContext,
   PluginHookSessionContext,
-  PluginHookSessionStartEvent,
   PluginHookSessionEndEvent,
+  PluginHookSessionResumedEvent,
+  PluginHookSessionStartEvent,
   PluginHookSubagentContext,
   PluginHookSubagentDeliveryTargetEvent,
   PluginHookSubagentDeliveryTargetResult,
@@ -488,6 +500,66 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   }
 
   // =========================================================================
+  // ChannelBridge Runtime Hooks
+  // =========================================================================
+
+  /**
+   * Run before_runtime_spawn hook.
+   * Fired before the CLI subprocess starts. Extensions can modify env, args, workspaceDir.
+   * Runs sequentially (modifiable).
+   */
+  async function runBeforeRuntimeSpawn(
+    event: PluginHookBeforeRuntimeSpawnEvent,
+    ctx: PluginHookRuntimeContext,
+  ): Promise<PluginHookBeforeRuntimeSpawnResult | undefined> {
+    return runModifyingHook<"before_runtime_spawn", PluginHookBeforeRuntimeSpawnResult>(
+      "before_runtime_spawn",
+      event,
+      ctx,
+      (acc, next) => ({
+        env: next.env ?? acc?.env,
+        workspaceDir: next.workspaceDir ?? acc?.workspaceDir,
+      }),
+    );
+  }
+
+  /**
+   * Run after_runtime_exit hook.
+   * Fired after the CLI subprocess exits. Observe-only.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runAfterRuntimeExit(
+    event: PluginHookAfterRuntimeExitEvent,
+    ctx: PluginHookRuntimeContext,
+  ): Promise<void> {
+    return runVoidHook("after_runtime_exit", event, ctx);
+  }
+
+  /**
+   * Run session_resumed hook.
+   * Fired when an existing session ID is found for the channel conversation.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runSessionResumed(
+    event: PluginHookSessionResumedEvent,
+    ctx: PluginHookRuntimeContext,
+  ): Promise<void> {
+    return runVoidHook("session_resumed", event, ctx);
+  }
+
+  /**
+   * Run agent_end hook.
+   * Reconstructed from CLI subprocess exit data. Observe-only.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runAgentEnd(
+    event: PluginHookAgentEndEvent,
+    ctx: PluginHookRuntimeContext,
+  ): Promise<void> {
+    return runVoidHook("agent_end", event, ctx);
+  }
+
+  // =========================================================================
   // Utility
   // =========================================================================
 
@@ -527,6 +599,11 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     // Gateway hooks
     runGatewayStart,
     runGatewayStop,
+    // ChannelBridge runtime hooks
+    runBeforeRuntimeSpawn,
+    runAfterRuntimeExit,
+    runSessionResumed,
+    runAgentEnd,
     // Utility
     hasHooks,
     getHookCount,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -172,7 +172,6 @@ const DEAD_HOOKS: ReadonlySet<string> = new Set([
   "before_agent_start",
   "llm_input",
   "llm_output",
-  "agent_end",
   "before_compaction",
   "after_compaction",
   "tool_result_persist",

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -309,7 +309,11 @@ export type PluginHookName =
   | "subagent_spawned"
   | "subagent_ended"
   | "gateway_start"
-  | "gateway_stop";
+  | "gateway_stop"
+  | "before_runtime_spawn"
+  | "after_runtime_exit"
+  | "session_resumed"
+  | "agent_end";
 
 // Agent context shared across agent hooks
 export type PluginHookAgentContext = {
@@ -523,6 +527,63 @@ export type PluginHookGatewayStopEvent = {
   reason?: string;
 };
 
+// ── ChannelBridge Runtime Hooks ──────────────────────────────────────────
+
+// before_runtime_spawn hook — fired before CLI subprocess starts (modifiable)
+export type PluginHookBeforeRuntimeSpawnEvent = {
+  runtimeName: string;
+  sessionId: string | undefined;
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+  workspaceDir: string;
+  channelId: string;
+};
+
+export type PluginHookBeforeRuntimeSpawnResult = {
+  env?: Record<string, string>;
+  workspaceDir?: string;
+};
+
+// after_runtime_exit hook — fired after CLI subprocess exits (observe-only)
+export type PluginHookAfterRuntimeExitEvent = {
+  runtimeName: string;
+  sessionId: string | undefined;
+  exitCode: number | undefined;
+  durationMs: number;
+  stdout: string;
+  stderr: string | undefined;
+  mcpSideEffects: {
+    sentTexts: string[];
+    sentMediaUrls: string[];
+    cronAdds: number;
+  };
+};
+
+// session_resumed hook — fired when an existing session is reused
+export type PluginHookSessionResumedEvent = {
+  sessionId: string;
+  runtimeName: string;
+  channelId: string;
+  userId: string;
+  resumeMethod: "session_map";
+};
+
+// agent_end hook — reconstructed from CLI subprocess exit
+export type PluginHookAgentEndEvent = {
+  runId: string;
+  sessionId: string | undefined;
+  success: boolean;
+  durationMs: number;
+};
+
+// Runtime hook context (shared across before_runtime_spawn / after_runtime_exit)
+export type PluginHookRuntimeContext = {
+  sessionId?: string;
+  channelId: string;
+  runtimeName: string;
+};
+
 // Hook handler types mapped by hook name
 export type PluginHookHandlerMap = {
   before_reset: (
@@ -587,6 +648,25 @@ export type PluginHookHandlerMap = {
   gateway_stop: (
     event: PluginHookGatewayStopEvent,
     ctx: PluginHookGatewayContext,
+  ) => Promise<void> | void;
+  before_runtime_spawn: (
+    event: PluginHookBeforeRuntimeSpawnEvent,
+    ctx: PluginHookRuntimeContext,
+  ) =>
+    | Promise<PluginHookBeforeRuntimeSpawnResult | void>
+    | PluginHookBeforeRuntimeSpawnResult
+    | void;
+  after_runtime_exit: (
+    event: PluginHookAfterRuntimeExitEvent,
+    ctx: PluginHookRuntimeContext,
+  ) => Promise<void> | void;
+  session_resumed: (
+    event: PluginHookSessionResumedEvent,
+    ctx: PluginHookRuntimeContext,
+  ) => Promise<void> | void;
+  agent_end: (
+    event: PluginHookAgentEndEvent,
+    ctx: PluginHookRuntimeContext,
   ) => Promise<void> | void;
 };
 


### PR DESCRIPTION
## Summary

- Add 3 new hooks (`before_runtime_spawn`, `after_runtime_exit`, `session_resumed`) and reconstruct 1 dead hook (`agent_end`) in `ChannelBridge.handle()`
- Register hook types in `src/plugins/types.ts` and runner methods in `src/plugins/hooks.ts`
- Remove `agent_end` from `DEAD_HOOKS` set in `src/plugins/registry.ts`
- `before_runtime_spawn` is modifiable (env vars, workspaceDir); the other three are observe-only

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes (0 warnings, 0 errors)
- [x] `pnpm format:check` passes
- [x] Dead hooks test updated and passing (13 tests)
- [x] Channel bridge tests passing (43 tests)
- [x] Full test suite passing (10,772 tests, 0 failures)

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)