### PR TITLE
feat: register node, canvas, browser, and TTS MCP tools (21 new tools)

### DIFF
--- a/src/middleware/mcp-handlers/browser.test.ts
+++ b/src/middleware/mcp-handlers/browser.test.ts
@@ -1,0 +1,110 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { McpSideEffectsWriter } from "../mcp-side-effects.js";
+import type { McpHandlerContext } from "./context.js";
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: vi.fn(),
+}));
+vi.mock("../../gateway/method-scopes.js", () => ({
+  resolveLeastPrivilegeOperatorScopesForMethod: vi.fn().mockReturnValue(["operator.write"]),
+}));
+vi.mock("../../utils/message-channel.js", () => ({
+  GATEWAY_CLIENT_NAMES: { GATEWAY_CLIENT: "agent-client" },
+  GATEWAY_CLIENT_MODES: { BACKEND: "backend" },
+}));
+
+import { callGateway } from "../../gateway/call.js";
+import { registerBrowserTools } from "./browser.js";
+
+const mockCallGateway = vi.mocked(callGateway);
+
+function createMockServer() {
+  const tools = new Map<string, { handler: Function; config: Record<string, unknown> }>();
+  return {
+    tools,
+    registerTool: vi.fn((name: string, config: Record<string, unknown>, handler: Function) => {
+      tools.set(name, { handler, config });
+      return { update: vi.fn(), remove: vi.fn(), disable: vi.fn(), enable: vi.fn() };
+    }),
+  };
+}
+
+describe("registerBrowserTools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let ctx: McpHandlerContext;
+  let dir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dir = mkdtempSync(join(tmpdir(), "mcp-browser-"));
+    mockServer = createMockServer();
+    ctx = {
+      gatewayUrl: "ws://127.0.0.1:18789",
+      gatewayToken: "test-token",
+      sessionKey: "agent:default:main",
+      sideEffects: new McpSideEffectsWriter(join(dir, "effects.ndjson")),
+      channel: "telegram",
+      accountId: "acc-1",
+      to: "chat-123",
+      threadId: "",
+      senderIsOwner: true,
+      toolProfile: "full",
+    };
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerBrowserTools(mockServer as any, ctx);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("registers 1 browser tool", () => {
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("browser_request calls browser.request with method and path", async () => {
+    mockCallGateway.mockResolvedValueOnce({ status: 200, body: {} });
+
+    const tool = mockServer.tools.get("browser_request");
+    await tool!.handler({ method: "GET", path: "/api/tabs" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "browser.request",
+        params: expect.objectContaining({
+          method: "GET",
+          path: "/api/tabs",
+        }),
+      }),
+    );
+  });
+
+  it("browser_request passes query, body, and timeoutMs", async () => {
+    mockCallGateway.mockResolvedValueOnce({ status: 200 });
+
+    const tool = mockServer.tools.get("browser_request");
+    await tool!.handler({
+      method: "POST",
+      path: "/api/action",
+      query: { tab: "1" },
+      body: { action: "click" },
+      timeoutMs: 5000,
+    });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "browser.request",
+        params: {
+          method: "POST",
+          path: "/api/action",
+          query: { tab: "1" },
+          body: { action: "click" },
+          timeoutMs: 5000,
+        },
+      }),
+    );
+  });
+});

--- a/src/middleware/mcp-handlers/browser.ts
+++ b/src/middleware/mcp-handlers/browser.ts
@@ -1,0 +1,37 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { McpHandlerContext } from "./context.js";
+import { callMcpGateway } from "./session.js";
+
+// ── Browser Tools ───────────────────────────────────────────────────
+
+/**
+ * Registers browser automation MCP tools on the given server.
+ *
+ * Tools: browser_request.
+ */
+export function registerBrowserTools(server: McpServer, ctx: McpHandlerContext): void {
+  server.registerTool(
+    "browser_request",
+    {
+      description: "Proxy an HTTP request through a browser-capable node.",
+      inputSchema: z.object({
+        method: z.enum(["GET", "POST", "DELETE"]),
+        path: z.string(),
+        query: z.record(z.string(), z.unknown()).optional(),
+        body: z.unknown().optional(),
+        timeoutMs: z.number().optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "browser.request", {
+        method: args.method,
+        path: args.path,
+        ...(args.query !== undefined ? { query: args.query } : {}),
+        ...(args.body !== undefined ? { body: args.body } : {}),
+        ...(args.timeoutMs !== undefined ? { timeoutMs: args.timeoutMs } : {}),
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/src/middleware/mcp-handlers/canvas.test.ts
+++ b/src/middleware/mcp-handlers/canvas.test.ts
@@ -1,0 +1,200 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { McpSideEffectsWriter } from "../mcp-side-effects.js";
+import type { McpHandlerContext } from "./context.js";
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: vi.fn(),
+}));
+vi.mock("../../gateway/method-scopes.js", () => ({
+  resolveLeastPrivilegeOperatorScopesForMethod: vi.fn().mockReturnValue(["operator.write"]),
+}));
+vi.mock("../../utils/message-channel.js", () => ({
+  GATEWAY_CLIENT_NAMES: { GATEWAY_CLIENT: "agent-client" },
+  GATEWAY_CLIENT_MODES: { BACKEND: "backend" },
+}));
+
+import { callGateway } from "../../gateway/call.js";
+import { registerCanvasTools } from "./canvas.js";
+
+const mockCallGateway = vi.mocked(callGateway);
+
+function createMockServer() {
+  const tools = new Map<string, { handler: Function; config: Record<string, unknown> }>();
+  return {
+    tools,
+    registerTool: vi.fn((name: string, config: Record<string, unknown>, handler: Function) => {
+      tools.set(name, { handler, config });
+      return { update: vi.fn(), remove: vi.fn(), disable: vi.fn(), enable: vi.fn() };
+    }),
+  };
+}
+
+describe("registerCanvasTools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let ctx: McpHandlerContext;
+  let dir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dir = mkdtempSync(join(tmpdir(), "mcp-canvas-"));
+    mockServer = createMockServer();
+    ctx = {
+      gatewayUrl: "ws://127.0.0.1:18789",
+      gatewayToken: "test-token",
+      sessionKey: "agent:default:main",
+      sideEffects: new McpSideEffectsWriter(join(dir, "effects.ndjson")),
+      channel: "telegram",
+      accountId: "acc-1",
+      to: "chat-123",
+      threadId: "",
+      senderIsOwner: true,
+      toolProfile: "full",
+    };
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerCanvasTools(mockServer as any, ctx);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("registers 7 canvas tools", () => {
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(7);
+  });
+
+  it("canvas_present calls node.invoke with canvas.present command", async () => {
+    mockCallGateway.mockResolvedValueOnce({ ok: true });
+
+    const tool = mockServer.tools.get("canvas_present");
+    await tool!.handler({ nodeId: "node-1", url: "https://example.com" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "node.invoke",
+        params: expect.objectContaining({
+          nodeId: "node-1",
+          command: "canvas.present",
+          params: { url: "https://example.com" },
+          idempotencyKey: expect.any(String),
+        }),
+      }),
+    );
+  });
+
+  it("canvas_present includes placement when coordinates are provided", async () => {
+    mockCallGateway.mockResolvedValueOnce({ ok: true });
+
+    const tool = mockServer.tools.get("canvas_present");
+    await tool!.handler({ nodeId: "node-1", x: 0, y: 0, width: 800, height: 600 });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          command: "canvas.present",
+          params: {
+            placement: { x: 0, y: 0, width: 800, height: 600 },
+          },
+        }),
+      }),
+    );
+  });
+
+  it("canvas_hide calls node.invoke with canvas.hide command", async () => {
+    mockCallGateway.mockResolvedValueOnce({ ok: true });
+
+    const tool = mockServer.tools.get("canvas_hide");
+    await tool!.handler({ nodeId: "node-1" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "node.invoke",
+        params: expect.objectContaining({
+          nodeId: "node-1",
+          command: "canvas.hide",
+        }),
+      }),
+    );
+  });
+
+  it("canvas_navigate calls node.invoke with canvas.navigate and url", async () => {
+    mockCallGateway.mockResolvedValueOnce({ ok: true });
+
+    const tool = mockServer.tools.get("canvas_navigate");
+    await tool!.handler({ nodeId: "node-1", url: "https://example.com/page" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          command: "canvas.navigate",
+          params: { url: "https://example.com/page" },
+        }),
+      }),
+    );
+  });
+
+  it("canvas_eval calls node.invoke with canvas.eval and javaScript", async () => {
+    mockCallGateway.mockResolvedValueOnce({ ok: true });
+
+    const tool = mockServer.tools.get("canvas_eval");
+    await tool!.handler({ nodeId: "node-1", javaScript: "document.title" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          command: "canvas.eval",
+          params: { javaScript: "document.title" },
+        }),
+      }),
+    );
+  });
+
+  it("canvas_snapshot calls node.invoke with canvas.snapshot and format options", async () => {
+    mockCallGateway.mockResolvedValueOnce({ ok: true });
+
+    const tool = mockServer.tools.get("canvas_snapshot");
+    await tool!.handler({ nodeId: "node-1", format: "png", maxWidth: 1024 });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          command: "canvas.snapshot",
+          params: { format: "png", maxWidth: 1024, quality: undefined },
+        }),
+      }),
+    );
+  });
+
+  it("canvas_a2ui_push calls node.invoke with canvas.a2ui.pushJSONL", async () => {
+    mockCallGateway.mockResolvedValueOnce({ ok: true });
+
+    const tool = mockServer.tools.get("canvas_a2ui_push");
+    await tool!.handler({ nodeId: "node-1", jsonl: '{"type":"text","text":"hello"}' });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          command: "canvas.a2ui.pushJSONL",
+          params: { jsonl: '{"type":"text","text":"hello"}' },
+        }),
+      }),
+    );
+  });
+
+  it("canvas_a2ui_reset calls node.invoke with canvas.a2ui.reset", async () => {
+    mockCallGateway.mockResolvedValueOnce({ ok: true });
+
+    const tool = mockServer.tools.get("canvas_a2ui_reset");
+    await tool!.handler({ nodeId: "node-1" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          command: "canvas.a2ui.reset",
+        }),
+      }),
+    );
+  });
+});

--- a/src/middleware/mcp-handlers/canvas.ts
+++ b/src/middleware/mcp-handlers/canvas.ts
@@ -1,0 +1,182 @@
+import crypto from "node:crypto";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { McpHandlerContext } from "./context.js";
+import { callMcpGateway } from "./session.js";
+
+// ── Canvas Tools ────────────────────────────────────────────────────
+
+/**
+ * Registers canvas MCP tools on the given server.
+ *
+ * All canvas tools are thin wrappers around `node.invoke` with
+ * pre-filled canvas-specific commands.
+ *
+ * Tools: canvas_present, canvas_hide, canvas_navigate, canvas_eval,
+ *        canvas_snapshot, canvas_a2ui_push, canvas_a2ui_reset.
+ */
+export function registerCanvasTools(server: McpServer, ctx: McpHandlerContext): void {
+  server.registerTool(
+    "canvas_present",
+    {
+      description: "Show the canvas on a node, optionally with a target URL and placement.",
+      inputSchema: z.object({
+        nodeId: z.string(),
+        url: z.string().optional(),
+        x: z.number().optional(),
+        y: z.number().optional(),
+        width: z.number().optional(),
+        height: z.number().optional(),
+      }),
+    },
+    async (args) => {
+      const params: Record<string, unknown> = {};
+      if (args.url !== undefined) {
+        params.url = args.url;
+      }
+      const placement = {
+        x: args.x,
+        y: args.y,
+        width: args.width,
+        height: args.height,
+      };
+      if (
+        Number.isFinite(placement.x) ||
+        Number.isFinite(placement.y) ||
+        Number.isFinite(placement.width) ||
+        Number.isFinite(placement.height)
+      ) {
+        params.placement = placement;
+      }
+      const result = await callMcpGateway(ctx, "node.invoke", {
+        nodeId: args.nodeId,
+        command: "canvas.present",
+        params,
+        idempotencyKey: crypto.randomUUID(),
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "canvas_hide",
+    {
+      description: "Hide the canvas on a node.",
+      inputSchema: z.object({
+        nodeId: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "node.invoke", {
+        nodeId: args.nodeId,
+        command: "canvas.hide",
+        idempotencyKey: crypto.randomUUID(),
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "canvas_navigate",
+    {
+      description: "Navigate the canvas to a URL.",
+      inputSchema: z.object({
+        nodeId: z.string(),
+        url: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "node.invoke", {
+        nodeId: args.nodeId,
+        command: "canvas.navigate",
+        params: { url: args.url },
+        idempotencyKey: crypto.randomUUID(),
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "canvas_eval",
+    {
+      description: "Evaluate JavaScript in the canvas.",
+      inputSchema: z.object({
+        nodeId: z.string(),
+        javaScript: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "node.invoke", {
+        nodeId: args.nodeId,
+        command: "canvas.eval",
+        params: { javaScript: args.javaScript },
+        idempotencyKey: crypto.randomUUID(),
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "canvas_snapshot",
+    {
+      description: "Capture a snapshot of the canvas.",
+      inputSchema: z.object({
+        nodeId: z.string(),
+        format: z.enum(["png", "jpg", "jpeg"]).optional(),
+        maxWidth: z.number().optional(),
+        quality: z.number().optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "node.invoke", {
+        nodeId: args.nodeId,
+        command: "canvas.snapshot",
+        params: {
+          format: args.format,
+          maxWidth: args.maxWidth,
+          quality: args.quality,
+        },
+        idempotencyKey: crypto.randomUUID(),
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "canvas_a2ui_push",
+    {
+      description: "Push A2UI JSONL content to the canvas.",
+      inputSchema: z.object({
+        nodeId: z.string(),
+        jsonl: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "node.invoke", {
+        nodeId: args.nodeId,
+        command: "canvas.a2ui.pushJSONL",
+        params: { jsonl: args.jsonl },
+        idempotencyKey: crypto.randomUUID(),
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "canvas_a2ui_reset",
+    {
+      description: "Reset the A2UI renderer state on a node.",
+      inputSchema: z.object({
+        nodeId: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "node.invoke", {
+        nodeId: args.nodeId,
+        command: "canvas.a2ui.reset",
+        idempotencyKey: crypto.randomUUID(),
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/src/middleware/mcp-handlers/nodes.test.ts
+++ b/src/middleware/mcp-handlers/nodes.test.ts
@@ -1,0 +1,162 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { McpSideEffectsWriter } from "../mcp-side-effects.js";
+import type { McpHandlerContext } from "./context.js";
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: vi.fn(),
+}));
+vi.mock("../../gateway/method-scopes.js", () => ({
+  resolveLeastPrivilegeOperatorScopesForMethod: vi.fn().mockReturnValue(["operator.write"]),
+}));
+vi.mock("../../utils/message-channel.js", () => ({
+  GATEWAY_CLIENT_NAMES: { GATEWAY_CLIENT: "agent-client" },
+  GATEWAY_CLIENT_MODES: { BACKEND: "backend" },
+}));
+
+import { callGateway } from "../../gateway/call.js";
+import { registerNodeTools } from "./nodes.js";
+
+const mockCallGateway = vi.mocked(callGateway);
+
+function createMockServer() {
+  const tools = new Map<string, { handler: Function; config: Record<string, unknown> }>();
+  return {
+    tools,
+    registerTool: vi.fn((name: string, config: Record<string, unknown>, handler: Function) => {
+      tools.set(name, { handler, config });
+      return { update: vi.fn(), remove: vi.fn(), disable: vi.fn(), enable: vi.fn() };
+    }),
+  };
+}
+
+describe("registerNodeTools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let ctx: McpHandlerContext;
+  let dir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dir = mkdtempSync(join(tmpdir(), "mcp-nodes-"));
+    mockServer = createMockServer();
+    ctx = {
+      gatewayUrl: "ws://127.0.0.1:18789",
+      gatewayToken: "test-token",
+      sessionKey: "agent:default:main",
+      sideEffects: new McpSideEffectsWriter(join(dir, "effects.ndjson")),
+      channel: "telegram",
+      accountId: "acc-1",
+      to: "chat-123",
+      threadId: "",
+      senderIsOwner: true,
+      toolProfile: "full",
+    };
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerNodeTools(mockServer as any, ctx);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("registers 7 node tools", () => {
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(7);
+  });
+
+  it("node_list calls node.list", async () => {
+    mockCallGateway.mockResolvedValueOnce({ nodes: [] });
+
+    const tool = mockServer.tools.get("node_list");
+    await tool!.handler({});
+
+    expect(mockCallGateway).toHaveBeenCalledWith(expect.objectContaining({ method: "node.list" }));
+  });
+
+  it("node_describe calls node.describe with nodeId", async () => {
+    mockCallGateway.mockResolvedValueOnce({ nodeId: "node-1" });
+
+    const tool = mockServer.tools.get("node_describe");
+    await tool!.handler({ nodeId: "node-1" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "node.describe",
+        params: { nodeId: "node-1" },
+      }),
+    );
+  });
+
+  it("node_invoke calls node.invoke with command and params", async () => {
+    mockCallGateway.mockResolvedValueOnce({ ok: true });
+
+    const tool = mockServer.tools.get("node_invoke");
+    await tool!.handler({ nodeId: "node-1", command: "system.run", params: { cmd: "ls" } });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "node.invoke",
+        params: expect.objectContaining({
+          nodeId: "node-1",
+          command: "system.run",
+          params: { cmd: "ls" },
+          idempotencyKey: expect.any(String),
+        }),
+      }),
+    );
+  });
+
+  it("node_rename calls node.rename with nodeId and displayName", async () => {
+    mockCallGateway.mockResolvedValueOnce({ nodeId: "node-1", displayName: "My Node" });
+
+    const tool = mockServer.tools.get("node_rename");
+    await tool!.handler({ nodeId: "node-1", displayName: "My Node" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "node.rename",
+        params: { nodeId: "node-1", displayName: "My Node" },
+      }),
+    );
+  });
+
+  it("node_pair_list calls node.pair.list", async () => {
+    mockCallGateway.mockResolvedValueOnce({ requests: [] });
+
+    const tool = mockServer.tools.get("node_pair_list");
+    await tool!.handler({});
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "node.pair.list" }),
+    );
+  });
+
+  it("node_pair_approve calls node.pair.approve with requestId", async () => {
+    mockCallGateway.mockResolvedValueOnce({ approved: true });
+
+    const tool = mockServer.tools.get("node_pair_approve");
+    await tool!.handler({ requestId: "req-123" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "node.pair.approve",
+        params: { requestId: "req-123" },
+      }),
+    );
+  });
+
+  it("node_pair_reject calls node.pair.reject with requestId", async () => {
+    mockCallGateway.mockResolvedValueOnce({ rejected: true });
+
+    const tool = mockServer.tools.get("node_pair_reject");
+    await tool!.handler({ requestId: "req-456" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "node.pair.reject",
+        params: { requestId: "req-456" },
+      }),
+    );
+  });
+});

--- a/src/middleware/mcp-handlers/nodes.ts
+++ b/src/middleware/mcp-handlers/nodes.ts
@@ -1,0 +1,128 @@
+import crypto from "node:crypto";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { McpHandlerContext } from "./context.js";
+import { callMcpGateway } from "./session.js";
+
+// ── Node Tools ──────────────────────────────────────────────────────
+
+/**
+ * Registers node management MCP tools on the given server.
+ *
+ * Tools: node_list, node_describe, node_invoke, node_rename,
+ *        node_pair_list, node_pair_approve, node_pair_reject.
+ */
+export function registerNodeTools(server: McpServer, ctx: McpHandlerContext): void {
+  server.registerTool(
+    "node_list",
+    {
+      description: "List connected and paired nodes.",
+      inputSchema: z.object({}),
+    },
+    async () => {
+      const result = await callMcpGateway(ctx, "node.list", {});
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "node_describe",
+    {
+      description: "Get detailed information about a specific node.",
+      inputSchema: z.object({
+        nodeId: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "node.describe", {
+        nodeId: args.nodeId,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "node_invoke",
+    {
+      description: "Execute a command on a connected node.",
+      inputSchema: z.object({
+        nodeId: z.string(),
+        command: z.string(),
+        params: z.unknown().optional(),
+        timeoutMs: z.number().optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "node.invoke", {
+        nodeId: args.nodeId,
+        command: args.command,
+        params: args.params,
+        timeoutMs: args.timeoutMs,
+        idempotencyKey: crypto.randomUUID(),
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "node_rename",
+    {
+      description: "Rename a paired node.",
+      inputSchema: z.object({
+        nodeId: z.string(),
+        displayName: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "node.rename", {
+        nodeId: args.nodeId,
+        displayName: args.displayName,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "node_pair_list",
+    {
+      description: "List pending and completed node pairing requests.",
+      inputSchema: z.object({}),
+    },
+    async () => {
+      const result = await callMcpGateway(ctx, "node.pair.list", {});
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "node_pair_approve",
+    {
+      description: "Approve a pending node pairing request.",
+      inputSchema: z.object({
+        requestId: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "node.pair.approve", {
+        requestId: args.requestId,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "node_pair_reject",
+    {
+      description: "Reject a pending node pairing request.",
+      inputSchema: z.object({
+        requestId: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "node.pair.reject", {
+        requestId: args.requestId,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/src/middleware/mcp-handlers/tts.test.ts
+++ b/src/middleware/mcp-handlers/tts.test.ts
@@ -1,0 +1,149 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { McpSideEffectsWriter } from "../mcp-side-effects.js";
+import type { McpHandlerContext } from "./context.js";
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: vi.fn(),
+}));
+vi.mock("../../gateway/method-scopes.js", () => ({
+  resolveLeastPrivilegeOperatorScopesForMethod: vi.fn().mockReturnValue(["operator.write"]),
+}));
+vi.mock("../../utils/message-channel.js", () => ({
+  GATEWAY_CLIENT_NAMES: { GATEWAY_CLIENT: "agent-client" },
+  GATEWAY_CLIENT_MODES: { BACKEND: "backend" },
+}));
+
+import { callGateway } from "../../gateway/call.js";
+import { registerTtsTools } from "./tts.js";
+
+const mockCallGateway = vi.mocked(callGateway);
+
+function createMockServer() {
+  const tools = new Map<string, { handler: Function; config: Record<string, unknown> }>();
+  return {
+    tools,
+    registerTool: vi.fn((name: string, config: Record<string, unknown>, handler: Function) => {
+      tools.set(name, { handler, config });
+      return { update: vi.fn(), remove: vi.fn(), disable: vi.fn(), enable: vi.fn() };
+    }),
+  };
+}
+
+describe("registerTtsTools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let ctx: McpHandlerContext;
+  let dir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dir = mkdtempSync(join(tmpdir(), "mcp-tts-"));
+    mockServer = createMockServer();
+    ctx = {
+      gatewayUrl: "ws://127.0.0.1:18789",
+      gatewayToken: "test-token",
+      sessionKey: "agent:default:main",
+      sideEffects: new McpSideEffectsWriter(join(dir, "effects.ndjson")),
+      channel: "telegram",
+      accountId: "acc-1",
+      to: "chat-123",
+      threadId: "",
+      senderIsOwner: true,
+      toolProfile: "full",
+    };
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerTtsTools(mockServer as any, ctx);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("registers 6 TTS tools", () => {
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(6);
+  });
+
+  it("tts_status calls tts.status", async () => {
+    mockCallGateway.mockResolvedValueOnce({ enabled: true, provider: "openai" });
+
+    const tool = mockServer.tools.get("tts_status");
+    await tool!.handler({});
+
+    expect(mockCallGateway).toHaveBeenCalledWith(expect.objectContaining({ method: "tts.status" }));
+  });
+
+  it("tts_convert calls tts.convert with text", async () => {
+    mockCallGateway.mockResolvedValueOnce({ audioPath: "/tmp/audio.mp3" });
+
+    const tool = mockServer.tools.get("tts_convert");
+    await tool!.handler({ text: "Hello world" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "tts.convert",
+        params: { text: "Hello world" },
+      }),
+    );
+  });
+
+  it("tts_convert passes channel when provided", async () => {
+    mockCallGateway.mockResolvedValueOnce({ audioPath: "/tmp/audio.mp3" });
+
+    const tool = mockServer.tools.get("tts_convert");
+    await tool!.handler({ text: "Hello", channel: "telegram" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "tts.convert",
+        params: { text: "Hello", channel: "telegram" },
+      }),
+    );
+  });
+
+  it("tts_providers calls tts.providers", async () => {
+    mockCallGateway.mockResolvedValueOnce({ providers: [] });
+
+    const tool = mockServer.tools.get("tts_providers");
+    await tool!.handler({});
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "tts.providers" }),
+    );
+  });
+
+  it("tts_set_provider calls tts.setProvider with provider", async () => {
+    mockCallGateway.mockResolvedValueOnce({ provider: "elevenlabs" });
+
+    const tool = mockServer.tools.get("tts_set_provider");
+    await tool!.handler({ provider: "elevenlabs" });
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "tts.setProvider",
+        params: { provider: "elevenlabs" },
+      }),
+    );
+  });
+
+  it("tts_enable calls tts.enable", async () => {
+    mockCallGateway.mockResolvedValueOnce({ enabled: true });
+
+    const tool = mockServer.tools.get("tts_enable");
+    await tool!.handler({});
+
+    expect(mockCallGateway).toHaveBeenCalledWith(expect.objectContaining({ method: "tts.enable" }));
+  });
+
+  it("tts_disable calls tts.disable", async () => {
+    mockCallGateway.mockResolvedValueOnce({ enabled: false });
+
+    const tool = mockServer.tools.get("tts_disable");
+    await tool!.handler({});
+
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "tts.disable" }),
+    );
+  });
+});

--- a/src/middleware/mcp-handlers/tts.ts
+++ b/src/middleware/mcp-handlers/tts.ts
@@ -1,0 +1,96 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { McpHandlerContext } from "./context.js";
+import { callMcpGateway } from "./session.js";
+
+// ── TTS Tools ───────────────────────────────────────────────────────
+
+/**
+ * Registers text-to-speech MCP tools on the given server.
+ *
+ * Tools: tts_status, tts_convert, tts_providers,
+ *        tts_set_provider, tts_enable, tts_disable.
+ */
+export function registerTtsTools(server: McpServer, ctx: McpHandlerContext): void {
+  server.registerTool(
+    "tts_status",
+    {
+      description: "Get current TTS status (enabled, provider, fallbacks).",
+      inputSchema: z.object({}),
+    },
+    async () => {
+      const result = await callMcpGateway(ctx, "tts.status", {});
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "tts_convert",
+    {
+      description: "Convert text to speech audio.",
+      inputSchema: z.object({
+        text: z.string(),
+        channel: z.string().optional(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "tts.convert", {
+        text: args.text,
+        ...(args.channel !== undefined ? { channel: args.channel } : {}),
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "tts_providers",
+    {
+      description: "List available TTS providers and their configuration.",
+      inputSchema: z.object({}),
+    },
+    async () => {
+      const result = await callMcpGateway(ctx, "tts.providers", {});
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "tts_set_provider",
+    {
+      description: "Set the active TTS provider (openai, elevenlabs, or edge).",
+      inputSchema: z.object({
+        provider: z.string(),
+      }),
+    },
+    async (args) => {
+      const result = await callMcpGateway(ctx, "tts.setProvider", {
+        provider: args.provider,
+      });
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "tts_enable",
+    {
+      description: "Enable text-to-speech.",
+      inputSchema: z.object({}),
+    },
+    async () => {
+      const result = await callMcpGateway(ctx, "tts.enable", {});
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "tts_disable",
+    {
+      description: "Disable text-to-speech.",
+      inputSchema: z.object({}),
+    },
+    async () => {
+      const result = await callMcpGateway(ctx, "tts.disable", {});
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/src/middleware/mcp-tools.test.ts
+++ b/src/middleware/mcp-tools.test.ts
@@ -45,10 +45,10 @@ describe("registerAllTools", () => {
     ctx = createMockContext();
   });
 
-  it("registers exactly 29 core tools", async () => {
+  it("registers exactly 50 core tools", async () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     await registerAllTools(mockServer as any, ctx);
-    expect(mockServer.registerTool).toHaveBeenCalledTimes(29);
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(50);
   });
 
   it("registers all session management tools", async () => {
@@ -170,11 +170,91 @@ describe("registerAllTools", () => {
       expect(names).toContain("message_broadcast");
     });
 
-    it("registers all 29 core tools for owner senders", async () => {
+    it("registers all 50 core tools for owner senders", async () => {
       ctx = createMockContext({ senderIsOwner: true });
       // oxlint-disable-next-line typescript/no-explicit-any
       await registerAllTools(mockServer as any, ctx);
-      expect(mockServer.registerTool).toHaveBeenCalledTimes(29);
+      expect(mockServer.registerTool).toHaveBeenCalledTimes(50);
     });
+
+    it("does NOT register node tools for non-owner senders", async () => {
+      ctx = createMockContext({ senderIsOwner: false });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      await registerAllTools(mockServer as any, ctx);
+      const names = [...mockServer.registeredTools.keys()];
+      expect(names).not.toContain("node_list");
+      expect(names).not.toContain("node_invoke");
+    });
+
+    it("does NOT register canvas tools for non-owner senders", async () => {
+      ctx = createMockContext({ senderIsOwner: false });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      await registerAllTools(mockServer as any, ctx);
+      const names = [...mockServer.registeredTools.keys()];
+      expect(names).not.toContain("canvas_present");
+      expect(names).not.toContain("canvas_snapshot");
+    });
+
+    it("does NOT register browser tools for non-owner senders", async () => {
+      ctx = createMockContext({ senderIsOwner: false });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      await registerAllTools(mockServer as any, ctx);
+      const names = [...mockServer.registeredTools.keys()];
+      expect(names).not.toContain("browser_request");
+    });
+
+    it("does NOT register TTS tools for non-owner senders", async () => {
+      ctx = createMockContext({ senderIsOwner: false });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      await registerAllTools(mockServer as any, ctx);
+      const names = [...mockServer.registeredTools.keys()];
+      expect(names).not.toContain("tts_status");
+      expect(names).not.toContain("tts_convert");
+    });
+  });
+
+  it("registers all node management tools", async () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await registerAllTools(mockServer as any, ctx);
+    const names = [...mockServer.registeredTools.keys()];
+    expect(names).toContain("node_list");
+    expect(names).toContain("node_describe");
+    expect(names).toContain("node_invoke");
+    expect(names).toContain("node_rename");
+    expect(names).toContain("node_pair_list");
+    expect(names).toContain("node_pair_approve");
+    expect(names).toContain("node_pair_reject");
+  });
+
+  it("registers all canvas tools", async () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await registerAllTools(mockServer as any, ctx);
+    const names = [...mockServer.registeredTools.keys()];
+    expect(names).toContain("canvas_present");
+    expect(names).toContain("canvas_hide");
+    expect(names).toContain("canvas_navigate");
+    expect(names).toContain("canvas_eval");
+    expect(names).toContain("canvas_snapshot");
+    expect(names).toContain("canvas_a2ui_push");
+    expect(names).toContain("canvas_a2ui_reset");
+  });
+
+  it("registers browser request tool", async () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await registerAllTools(mockServer as any, ctx);
+    const names = [...mockServer.registeredTools.keys()];
+    expect(names).toContain("browser_request");
+  });
+
+  it("registers all TTS tools", async () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await registerAllTools(mockServer as any, ctx);
+    const names = [...mockServer.registeredTools.keys()];
+    expect(names).toContain("tts_status");
+    expect(names).toContain("tts_convert");
+    expect(names).toContain("tts_providers");
+    expect(names).toContain("tts_set_provider");
+    expect(names).toContain("tts_enable");
+    expect(names).toContain("tts_disable");
   });
 });

--- a/src/middleware/mcp-tools.ts
+++ b/src/middleware/mcp-tools.ts
@@ -1,9 +1,13 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerBrowserTools } from "./mcp-handlers/browser.js";
+import { registerCanvasTools } from "./mcp-handlers/canvas.js";
 import type { McpHandlerContext } from "./mcp-handlers/context.js";
 import { registerCronTools } from "./mcp-handlers/cron.js";
 import { registerGatewayTools } from "./mcp-handlers/gateway.js";
 import { registerMessageTools } from "./mcp-handlers/message.js";
+import { registerNodeTools } from "./mcp-handlers/nodes.js";
 import { callMcpGateway, registerSessionTools } from "./mcp-handlers/session.js";
+import { registerTtsTools } from "./mcp-handlers/tts.js";
 import { registerPluginTools } from "./mcp-plugin-tools.js";
 
 /**
@@ -64,10 +68,14 @@ function wrapWithToolHooks(server: McpServer, ctx: McpHandlerContext): McpServer
  * - Channel messaging (10 tools) — always registered
  * - Cron scheduling (7 tools) — owner-only
  * - Gateway admin (5 tools) — owner-only
+ * - Node management (7 tools) — owner-only
+ * - Canvas (7 tools) — owner-only
+ * - Browser proxy (1 tool) — owner-only
+ * - TTS (6 tools) — owner-only
  *
- * Owner-only tools (cron, gateway) are only registered when
- * `ctx.senderIsOwner` is `true`, preventing non-owner channel
- * users from accessing privileged operations.
+ * Owner-only tools are only registered when `ctx.senderIsOwner`
+ * is `true`, preventing non-owner channel users from accessing
+ * privileged operations.
  *
  * All tools are wrapped with before_tool_call / after_tool_call
  * hook firing via gateway RPC.
@@ -79,6 +87,10 @@ export async function registerAllTools(server: McpServer, ctx: McpHandlerContext
   if (ctx.senderIsOwner) {
     registerCronTools(hooked, ctx);
     registerGatewayTools(hooked, ctx);
+    registerNodeTools(hooked, ctx);
+    registerCanvasTools(hooked, ctx);
+    registerBrowserTools(hooked, ctx);
+    registerTtsTools(hooked, ctx);
   }
   await registerPluginTools(hooked, ctx);
 }


### PR DESCRIPTION
## Summary

- Add 4 new MCP handler files exposing gateway infrastructure features as MCP tools for CLI agents
- **Node tools** (7): `node_list`, `node_describe`, `node_invoke`, `node_rename`, `node_pair_list`, `node_pair_approve`, `node_pair_reject`
- **Canvas tools** (7): `canvas_present`, `canvas_hide`, `canvas_navigate`, `canvas_eval`, `canvas_snapshot`, `canvas_a2ui_push`, `canvas_a2ui_reset` (thin wrappers around `node.invoke`)
- **Browser tool** (1): `browser_request` (HTTP proxy through browser-capable nodes)
- **TTS tools** (6): `tts_status`, `tts_convert`, `tts_providers`, `tts_set_provider`, `tts_enable`, `tts_disable`
- All 21 new tools are owner-only, following the existing `callMcpGateway()` pattern
- Total MCP tool count: 50 (29 existing + 21 new)

## Test plan

- [x] All 4 new handler test files pass (28 tests)
- [x] Updated `mcp-tools.test.ts` passes (20 tests, tool count 29→50)
- [x] `pnpm build` passes
- [x] `pnpm lint` passes (0 warnings, 0 errors)
- [x] Full test suite passes (837 tests, 0 failures)

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)