### PR TITLE
fix: reject delivery to unconfigured plugin channels

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { listAgentIds } from "../../agents/agent-scope.js";
 import { BARE_SESSION_RESET_PROMPT } from "../../auto-reply/reply/session-reset-prompt.js";
+import { CHANNEL_IDS, type ChatChannelId } from "../../channels/registry.js";
 import { agentCommand } from "../../commands/agent.js";
 import { loadConfig } from "../../config/config.js";
 import {
@@ -15,7 +16,10 @@ import {
   resolveAgentDeliveryPlan,
   resolveAgentOutboundTarget,
 } from "../../infra/outbound/agent-delivery.js";
-import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
+import {
+  listConfiguredMessageChannels,
+  resolveMessageChannelSelection,
+} from "../../infra/outbound/channel-selection.js";
 import { classifySessionKeyShape, normalizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
@@ -514,6 +518,24 @@ export const agentHandlers: GatewayRequestHandlers = {
     let resolvedAccountId = deliveryPlan.resolvedAccountId;
     let resolvedTo = deliveryPlan.resolvedTo;
     let effectivePlan = deliveryPlan;
+
+    // A plugin channel may be registered but have no configured accounts,
+    // making it unusable for delivery.  Fall back to the
+    // INTERNAL_MESSAGE_CHANNEL path so the existing channel-selection
+    // logic can surface a proper error.  Built-in channels (in
+    // CHANNEL_IDS) are always considered available.
+    if (
+      wantsDelivery &&
+      resolvedChannel !== INTERNAL_MESSAGE_CHANNEL &&
+      isDeliverableMessageChannel(resolvedChannel) &&
+      !CHANNEL_IDS.includes(resolvedChannel as ChatChannelId)
+    ) {
+      const cfgResolved = cfgForAgent ?? cfg;
+      const configured = await listConfiguredMessageChannels(cfgResolved);
+      if (!configured.includes(resolvedChannel)) {
+        resolvedChannel = INTERNAL_MESSAGE_CHANNEL;
+      }
+    }
 
     if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
       const cfgResolved = cfgForAgent ?? cfg;


### PR DESCRIPTION
## Summary

When a session's `lastChannel` points to a plugin channel (e.g. msteams) that
has no configured accounts, the agent handler now falls back to the
`INTERNAL_MESSAGE_CHANNEL` path instead of silently accepting the delivery
request. This surfaces a proper "Channel is required" error.

Built-in channels (telegram, whatsapp, etc.) are always considered available
and skip this check.

**Root cause**: `isDeliverableMessageChannel()` only checks plugin registry
presence, not whether the plugin has configured accounts. The existing
`isPluginConfigured()` / `listConfiguredMessageChannels()` logic in
`channel-selection.ts` was only invoked in the webchat fallback path, never
for explicitly resolved plugin channels.

**Impact**: The bug was masked by test ordering — the gateway test
"agent errors when deliver=true and last-channel plugin is unavailable"
passed on `main` only due to favorable global state from preceding tests.

This fix is upstream-portable to OpenClaw (same code, same bug).

## Test plan

- [x] `server.agent.gateway-server-agent-b.test.ts` — all 10 tests pass (including the previously-masked failure)
- [x] `server-methods/agent.test.ts` — all 9 tests pass (no regression for built-in channel delivery)
- [x] Full gateway suite — 830 passed, 1 skipped
- [x] Full `pnpm test` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)