### PR TITLE
fix: thread per-channel extraSystemPrompt through ChannelBridge

### DIFF
--- a/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
+++ b/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
@@ -25,13 +25,7 @@ export function registerGroupIntroPromptCases(params: {
     };
     const groupParticipationNote =
       "Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Don't type literal \\n sequences; use real line breaks sparingly.";
-    // Skipped: extraSystemPrompt is built by get-reply-run.ts and stored in FollowupRun.run,
-    // but agent-runner-execution.ts does not forward it through the ChannelBridge. The bridge
-    // only receives ChannelMessage (text, from, channelId, provider) and BridgeCallbacks.
-    // This test asserts on extraSystemPrompt passed to runAgent, which is no longer
-    // the dispatch path for the main agent turn. Re-enable once extraSystemPrompt is threaded
-    // through the bridge (e.g. via ChannelMessage.metadata or a dedicated bridge option).
-    it.skip("labels group chats using channel-specific metadata", async () => {
+    it("labels group chats using channel-specific metadata", async () => {
       await withTempHome(async (home) => {
         const cases: GroupIntroCase[] = [
           {

--- a/src/auto-reply/reply.triggers.trigger-handling.test-harness.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.test-harness.ts
@@ -36,6 +36,7 @@ vi.mock("../middleware/channel-bridge.js", () => ({
     ): Promise<AgentDeliveryResult> {
       const embeddedParams = {
         prompt: message.text,
+        extraSystemPrompt: message.extraContext,
         provider: this.#provider,
         onBlockReply: callbacks?.onBlockReply,
         onPartialReply: callbacks?.onPartialReply,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -102,6 +102,7 @@ function buildChannelMessage(params: {
   sessionCtx: TemplateContext;
   messageToolHints: string[] | undefined;
   senderIsOwner?: boolean;
+  extraSystemPrompt?: string;
 }): ChannelMessage {
   return {
     id: params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid ?? crypto.randomUUID(),
@@ -113,6 +114,7 @@ function buildChannelMessage(params: {
     replyToId: params.sessionCtx.ReplyToId?.trim() || undefined,
     messageToolHints: params.messageToolHints?.length ? params.messageToolHints : undefined,
     senderIsOwner: params.senderIsOwner,
+    extraContext: params.extraSystemPrompt || undefined,
   };
 }
 
@@ -275,6 +277,7 @@ export async function runAgentTurnWithFallback(params: {
           sessionCtx: params.sessionCtx,
           messageToolHints,
           senderIsOwner: params.followupRun.run.senderIsOwner,
+          extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
         });
 
         // Build BridgeCallbacks that wrap the existing typing/normalization logic.

--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -176,6 +176,30 @@ describe("ChannelBridge", () => {
       expect(params.prompt).toBe("SYSTEM_PROMPT\n\nWhat is 2+2?");
     });
 
+    it("prepends extraContext between system prompt and user text", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage({ text: "What is 2+2?", extraContext: "Answer in French" }));
+
+      expect(executeFn).toHaveBeenCalledOnce();
+      const params = executeFn.mock.calls[0][0];
+      expect(params.prompt).toBe("SYSTEM_PROMPT\n\nAnswer in French\n\nWhat is 2+2?");
+    });
+
+    it("omits extraContext section when not provided", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage({ text: "What is 2+2?" }));
+
+      expect(executeFn).toHaveBeenCalledOnce();
+      const params = executeFn.mock.calls[0][0];
+      expect(params.prompt).toBe("SYSTEM_PROMPT\n\nWhat is 2+2?");
+    });
+
     it("passes workingDirectory to runtime", async () => {
       const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
       mockRuntimeInstance = { execute: executeFn };

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -174,7 +174,11 @@ export class ChannelBridge {
       try {
         const captured = captureResult(
           runtime.execute({
-            prompt: systemPrompt + "\n\n" + message.text,
+            prompt:
+              systemPrompt +
+              (message.extraContext ? "\n\n" + message.extraContext : "") +
+              "\n\n" +
+              message.text,
             sessionId: existingSessionId,
             mcpServers,
             abortSignal,

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -179,6 +179,8 @@ export type ChannelMessage = {
   mediaUrls?: string[] | undefined;
   /** Channel-specific formatting hints (e.g., LINE directives, Discord component schema). */
   messageToolHints?: string[] | undefined;
+  /** Extra context to prepend between the system prompt and user text (e.g. per-channel instructions). */
+  extraContext?: string | undefined;
   /** Provider-specific metadata. */
   metadata?: Record<string, unknown> | undefined;
   /** Whether the message sender is the bot owner. Defaults to `false`. */


### PR DESCRIPTION
## Summary

Closes #142.

- Added `extraContext` field to `ChannelMessage` type for carrying per-channel instructions
- `buildChannelMessage()` in `agent-runner-execution.ts` now populates `extraContext` from `followupRun.run.extraSystemPrompt`
- `ChannelBridge.handle()` prepends `extraContext` between the middleware system prompt and the user message text
- Un-skipped the `group-intro-prompts` test that documented this gap
- Added bridge-level unit tests for `extraContext` prepending

## Test plan

- [x] `pnpm tsgo` — no new type errors in modified files
- [x] `channel-bridge.test.ts` — 45 tests pass (2 new: extraContext prepended, extraContext omitted when absent)
- [x] `reply.triggers.trigger-handling.targets-active-session-native-stop.test.ts` — 3 tests pass (previously skipped "labels group chats using channel-specific metadata" now passes)
- [x] Full `pnpm test` — 8138 passed, 1 skipped, 1 pre-existing flaky failure (unrelated Slack media test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)