### PR TITLE
fix: reconnect followup runner to ChannelBridge (#144)

### DIFF
--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1,12 +1,16 @@
-// Stub: pi-embedded execution engine was gutted (#74).
-// The followup runner previously called `runEmbeddedPiAgent`; with the
-// engine removed, followup runs are no-ops that mark completion.
-
+import crypto from "node:crypto";
+import { resolveChannelMessageToolHints } from "../../agents/channel-tools.js";
+import { resolveGatewayPort } from "../../config/paths.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
+import { resolveGatewayCredentialsFromConfig } from "../../gateway/credentials.js";
 import { logVerbose } from "../../globals.js";
+import { ChannelBridge } from "../../middleware/channel-bridge.js";
+import type { SessionMap } from "../../middleware/session-map.js";
+import type { BridgeCallbacks, ChannelMessage } from "../../middleware/types.js";
 import type { GetReplyOptions } from "../types.js";
 import type { FollowupRun } from "./queue.js";
+import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
 export function createFollowupRunner(params: {
@@ -20,11 +24,80 @@ export function createFollowupRunner(params: {
   defaultModel: string;
   agentCfgContextTokens?: number;
 }): (queued: FollowupRun) => Promise<void> {
-  const { typing } = params;
+  const { opts, typing, typingMode, sessionStore, sessionKey } = params;
 
-  return async (_queued: FollowupRun) => {
+  return async (queued: FollowupRun) => {
+    const typingSignals = createTypingSignaler({
+      typing,
+      mode: typingMode,
+      isHeartbeat: false,
+    });
+
     try {
-      logVerbose("followup queue: embedded engine removed (#74); skipping run");
+      await typingSignals.signalRunStart();
+
+      const provider = queued.run.provider;
+      const cfg = queued.run.config;
+
+      // Session adapter: reads CLI session ID from the auto-reply session store.
+      const sessionMap = {
+        async get() {
+          const entry = sessionKey ? sessionStore?.[sessionKey] : undefined;
+          return entry?.cliSessionIds?.[provider];
+        },
+        async set() {
+          // Session updates handled by caller (persistRunSessionUsage)
+        },
+        async delete() {
+          // Session cleanup handled by caller
+        },
+      } as unknown as SessionMap;
+
+      // Resolve gateway connection from config.
+      const port = resolveGatewayPort(cfg ?? undefined);
+      const gatewayUrl = `ws://127.0.0.1:${port}`;
+      const gatewayToken = cfg
+        ? (resolveGatewayCredentialsFromConfig({ cfg, env: process.env }).token ?? "")
+        : "";
+
+      const bridge = new ChannelBridge({
+        provider,
+        sessionMap,
+        gatewayUrl,
+        gatewayToken,
+        workspaceDir: queued.run.workspaceDir,
+      });
+
+      // Build channel message from followup run fields.
+      const messageToolHints = resolveChannelMessageToolHints({
+        cfg,
+        channel: queued.originatingChannel,
+        accountId: queued.originatingAccountId,
+      });
+
+      const message: ChannelMessage = {
+        id: queued.messageId ?? crypto.randomUUID(),
+        text: queued.prompt,
+        from: queued.originatingAccountId ?? "",
+        channelId: queued.originatingTo ?? "",
+        provider: queued.originatingChannel ?? "",
+        timestamp: Date.now(),
+        replyToId:
+          queued.originatingThreadId != null ? String(queued.originatingThreadId) : undefined,
+        messageToolHints: messageToolHints?.length ? messageToolHints : undefined,
+        senderIsOwner: queued.run.senderIsOwner,
+        extraContext: queued.run.extraSystemPrompt || undefined,
+      };
+
+      // Wire BridgeCallbacks from opts callbacks.
+      const callbacks: BridgeCallbacks = {
+        onPartialReply: opts?.onPartialReply,
+        onBlockReply: opts?.onBlockReply,
+        onToolResult: opts?.onToolResult,
+      };
+
+      await bridge.handle(message, callbacks, opts?.abortSignal);
+      logVerbose("followup queue: bridge.handle() completed");
     } finally {
       typing.markRunComplete();
     }


### PR DESCRIPTION
## Summary

- Replace the no-op followup runner stub (left from #74 Pi engine removal) with a real implementation that builds a `ChannelBridge` and calls `bridge.handle()`
- Build `ChannelMessage` from `FollowupRun` routing fields (`originatingChannel`, `originatingTo`, `originatingAccountId`, `originatingThreadId`)
- Wire session map adapter to read CLI session IDs from `sessionStore[sessionKey].cliSessionIds[provider]`
- Pass through `BridgeCallbacks` and `abortSignal` from `opts`
- Fire typing signals correctly (`signalRunStart` before handle, `markRunComplete` in finally)

Closes #144

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (842 tests, 92 files)
- [ ] Manual: send messages while agent is busy → verify queued messages are processed instead of dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)