### PR TITLE
feat: thread system prompt context params through ChannelBridge

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -8,6 +8,7 @@ import {
   sanitizeUserFacingText,
 } from "../../agents/agent-helpers.js";
 import { resolveChannelMessageToolHints } from "../../agents/channel-tools.js";
+import { resolveUserTimezone } from "../../agents/date-time.js";
 import { resolveGatewayPort } from "../../config/paths.js";
 import {
   resolveSessionTranscriptPath,
@@ -96,6 +97,29 @@ function resolveGatewayTokenFromConfig(cfg: FollowupRun["run"]["config"]): strin
   return resolveGatewayCredentialsFromConfig({ cfg, env: process.env }).token ?? "";
 }
 
+/**
+ * Resolve reaction guidance for the system prompt from channel config.
+ *
+ * Reads the channel's `reactionLevel` from config and returns guidance
+ * only when the level enables agent-controlled reactions ("minimal" or "extensive").
+ */
+function resolveChannelReactionGuidance(
+  cfg: FollowupRun["run"]["config"],
+  channel: string | undefined,
+): { level: "minimal" | "extensive"; channel: string } | undefined {
+  if (!cfg || !channel) {
+    return undefined;
+  }
+  const channelConfig = (cfg.channels as Record<string, Record<string, unknown>> | undefined)?.[
+    channel
+  ];
+  const level = channelConfig?.reactionLevel;
+  if (level === "minimal" || level === "extensive") {
+    return { level, channel };
+  }
+  return undefined;
+}
+
 /** Build a ChannelMessage from the auto-reply's template context. */
 function buildChannelMessage(params: {
   commandBody: string;
@@ -103,6 +127,11 @@ function buildChannelMessage(params: {
   messageToolHints: string[] | undefined;
   senderIsOwner?: boolean;
   extraSystemPrompt?: string;
+  userName?: string;
+  agentId?: string;
+  timezone?: string;
+  authorizedSenders?: string[];
+  reactionGuidance?: { level: "minimal" | "extensive"; channel: string };
 }): ChannelMessage {
   return {
     id: params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid ?? crypto.randomUUID(),
@@ -115,6 +144,11 @@ function buildChannelMessage(params: {
     messageToolHints: params.messageToolHints?.length ? params.messageToolHints : undefined,
     senderIsOwner: params.senderIsOwner,
     extraContext: params.extraSystemPrompt || undefined,
+    userName: params.userName || undefined,
+    agentId: params.agentId || undefined,
+    timezone: params.timezone || undefined,
+    authorizedSenders: params.authorizedSenders?.length ? params.authorizedSenders : undefined,
+    reactionGuidance: params.reactionGuidance,
   };
 }
 
@@ -272,12 +306,18 @@ export async function runAgentTurnWithFallback(params: {
           accountId: params.sessionCtx.AccountId?.trim(),
         });
 
+        const channel = params.sessionCtx.Provider?.trim();
         const message = buildChannelMessage({
           commandBody: params.commandBody,
           sessionCtx: params.sessionCtx,
           messageToolHints,
           senderIsOwner: params.followupRun.run.senderIsOwner,
           extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+          userName: params.followupRun.run.senderName,
+          agentId: params.followupRun.run.agentId,
+          timezone: resolveUserTimezone(cfg?.agents?.defaults?.userTimezone),
+          authorizedSenders: params.followupRun.run.ownerNumbers,
+          reactionGuidance: resolveChannelReactionGuidance(cfg, channel),
         });
 
         // Build BridgeCallbacks that wrap the existing typing/normalization logic.

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -9,6 +9,7 @@ import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/se
 import { resolveChannelMessageToolHints } from "../../agents/channel-tools.js";
 import { getCliSessionId, setCliSessionId } from "../../agents/cli-session.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
+import { resolveUserTimezone } from "../../agents/date-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { isCliProvider, normalizeModelRef, parseModelRef } from "../../agents/provider-utils.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
@@ -92,6 +93,9 @@ function buildCronChannelMessage(params: {
   resolvedDelivery: { channel?: string; to?: string; accountId?: string };
   timestamp: number;
   messageToolHints: string[] | undefined;
+  agentId?: string;
+  timezone?: string;
+  authorizedSenders?: string[];
 }): ChannelMessage {
   return {
     id: params.job.id ?? crypto.randomUUID(),
@@ -103,6 +107,9 @@ function buildCronChannelMessage(params: {
     timestamp: params.timestamp,
     messageToolHints: params.messageToolHints?.length ? params.messageToolHints : undefined,
     senderIsOwner: false, // Cron agents must not self-modify via owner-only tools
+    agentId: params.agentId || undefined,
+    timezone: params.timezone || undefined,
+    authorizedSenders: params.authorizedSenders?.length ? params.authorizedSenders : undefined,
   };
 }
 
@@ -390,6 +397,8 @@ export async function runCronIsolatedAgentTurn(params: {
       resolvedDelivery,
       timestamp: now,
       messageToolHints,
+      agentId,
+      timezone: resolveUserTimezone(cfgWithAgentDefaults.agents?.defaults?.userTimezone),
     });
 
     runResult = await bridge.handle(message, undefined, abortSignal);

--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -595,6 +595,108 @@ describe("ChannelBridge", () => {
     });
   });
 
+  describe("system prompt context params forwarding", () => {
+    it("passes userName from ChannelMessage to buildSystemPrompt", async () => {
+      mockRuntimeInstance = mockRuntime([makeDone()]);
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage({ userName: "Alice" }));
+
+      expect(mockBuildSystemPrompt).toHaveBeenCalledOnce();
+      const params = mockBuildSystemPrompt.mock.calls[0][0] as Record<string, unknown>;
+      expect(params.userName).toBe("Alice");
+    });
+
+    it("passes agentId from ChannelMessage to buildSystemPrompt", async () => {
+      mockRuntimeInstance = mockRuntime([makeDone()]);
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage({ agentId: "agent-42" }));
+
+      expect(mockBuildSystemPrompt).toHaveBeenCalledOnce();
+      const params = mockBuildSystemPrompt.mock.calls[0][0] as Record<string, unknown>;
+      expect(params.agentId).toBe("agent-42");
+    });
+
+    it("passes timezone from ChannelMessage to buildSystemPrompt", async () => {
+      mockRuntimeInstance = mockRuntime([makeDone()]);
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage({ timezone: "America/New_York" }));
+
+      expect(mockBuildSystemPrompt).toHaveBeenCalledOnce();
+      const params = mockBuildSystemPrompt.mock.calls[0][0] as Record<string, unknown>;
+      expect(params.timezone).toBe("America/New_York");
+    });
+
+    it("passes authorizedSenders from ChannelMessage to buildSystemPrompt", async () => {
+      mockRuntimeInstance = mockRuntime([makeDone()]);
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage({ authorizedSenders: ["+15551234567", "+15559876543"] }));
+
+      expect(mockBuildSystemPrompt).toHaveBeenCalledOnce();
+      const params = mockBuildSystemPrompt.mock.calls[0][0] as Record<string, unknown>;
+      expect(params.authorizedSenders).toEqual(["+15551234567", "+15559876543"]);
+    });
+
+    it("passes reactionGuidance from ChannelMessage to buildSystemPrompt", async () => {
+      mockRuntimeInstance = mockRuntime([makeDone()]);
+
+      const bridge = createBridge();
+      await bridge.handle(
+        makeMessage({ reactionGuidance: { level: "minimal", channel: "telegram" } }),
+      );
+
+      expect(mockBuildSystemPrompt).toHaveBeenCalledOnce();
+      const params = mockBuildSystemPrompt.mock.calls[0][0] as Record<string, unknown>;
+      expect(params.reactionGuidance).toEqual({ level: "minimal", channel: "telegram" });
+    });
+
+    it("passes all 8 params when ChannelMessage is fully populated", async () => {
+      mockRuntimeInstance = mockRuntime([makeDone()]);
+
+      const bridge = createBridge();
+      await bridge.handle(
+        makeMessage({
+          provider: "discord",
+          messageToolHints: ["Use discord components."],
+          userName: "Bob",
+          agentId: "agent-7",
+          timezone: "Europe/Berlin",
+          authorizedSenders: ["+1234"],
+          reactionGuidance: { level: "extensive", channel: "discord" },
+        }),
+      );
+
+      expect(mockBuildSystemPrompt).toHaveBeenCalledOnce();
+      const params = mockBuildSystemPrompt.mock.calls[0][0] as Record<string, unknown>;
+      expect(params.channelName).toBe("discord");
+      expect(params.workspaceDir).toBe("/workspace");
+      expect(params.messageToolHints).toEqual(["Use discord components."]);
+      expect(params.userName).toBe("Bob");
+      expect(params.agentId).toBe("agent-7");
+      expect(params.timezone).toBe("Europe/Berlin");
+      expect(params.authorizedSenders).toEqual(["+1234"]);
+      expect(params.reactionGuidance).toEqual({ level: "extensive", channel: "discord" });
+    });
+
+    it("passes undefined for optional params when not set on ChannelMessage", async () => {
+      mockRuntimeInstance = mockRuntime([makeDone()]);
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage());
+
+      expect(mockBuildSystemPrompt).toHaveBeenCalledOnce();
+      const params = mockBuildSystemPrompt.mock.calls[0][0] as Record<string, unknown>;
+      expect(params.userName).toBeUndefined();
+      expect(params.agentId).toBeUndefined();
+      expect(params.timezone).toBeUndefined();
+      expect(params.authorizedSenders).toBeUndefined();
+      expect(params.reactionGuidance).toBeUndefined();
+    });
+  });
+
   describe("error handling", () => {
     it("classifies runtime errors and sets errorSubtype on result", async () => {
       const executeFn = vi.fn((_p: AgentExecuteParams) => failingStream("rate_limit exceeded"));

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -121,6 +121,11 @@ export class ChannelBridge {
       channelName: message.provider,
       workspaceDir: this.#workspaceDir,
       messageToolHints: message.messageToolHints,
+      userName: message.userName,
+      agentId: message.agentId,
+      timezone: message.timezone,
+      authorizedSenders: message.authorizedSenders,
+      reactionGuidance: message.reactionGuidance,
     });
 
     // 3. MCP config: temp dir for side effects file

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -187,6 +187,16 @@ export type ChannelMessage = {
   senderIsOwner?: boolean | undefined;
   /** Tool profile controlling which tool categories are available. Defaults to `"full"`. */
   toolProfile?: string | undefined;
+  /** Display name of the user sending the message. */
+  userName?: string | undefined;
+  /** Agent identifier within RemoteClaw. */
+  agentId?: string | undefined;
+  /** IANA timezone string (e.g., "America/New_York"). */
+  timezone?: string | undefined;
+  /** Phone numbers / IDs of authorized senders (owner allowlist). */
+  authorizedSenders?: string[] | undefined;
+  /** Reaction/emoji guidance level for the system prompt. */
+  reactionGuidance?: { level: "minimal" | "extensive"; channel: string } | undefined;
 };
 
 // ── Bridge Callbacks ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #146

- Add `userName`, `agentId`, `timezone`, `authorizedSenders`, `reactionGuidance` fields to `ChannelMessage` type
- Wire `ChannelBridge.handle()` to pass all 8 `SystemPromptParams` to `buildSystemPrompt()`
- Populate new fields from `FollowupRun.run` and config in the auto-reply path (`buildChannelMessage`)
- Thread `agentId` and `timezone` through the cron dispatch path (`buildCronChannelMessage`)

## Test plan

- [x] Existing system prompt tests pass (25 tests)
- [x] New channel-bridge tests verify all 8 params forwarding (7 new tests, 52 total)
- [x] Full test suite passes (842 tests)
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)