### PR TITLE
fix: remove dead sandbox remnants (#148)

### DIFF
--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -276,13 +276,6 @@ async function hydrateAttachmentPayload(params: {
   }
 }
 
-export async function normalizeSandboxMediaParams(_params: {
-  args: Record<string, unknown>;
-  mediaPolicy: AttachmentMediaPolicy;
-}): Promise<void> {
-  // Sandbox infrastructure has been removed; this is now a no-op.
-}
-
 export async function normalizeSandboxMediaList(params: {
   values: string[];
   sandboxRoot?: string;

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -30,7 +30,6 @@ import type { OutboundSendDeps } from "./deliver.js";
 import {
   hydrateAttachmentParamsForAction,
   normalizeSandboxMediaList,
-  normalizeSandboxMediaParams,
   parseButtonsParam,
   parseCardParam,
   parseComponentsParam,
@@ -760,11 +759,6 @@ export async function runMessageAction(
   const mediaPolicy = resolveAttachmentMediaPolicy({
     sandboxRoot: input.sandboxRoot,
     mediaLocalRoots,
-  });
-
-  await normalizeSandboxMediaParams({
-    args: params,
-    mediaPolicy,
   });
 
   await hydrateAttachmentParamsForAction({

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -13,11 +13,8 @@ const resolveSandboxConfigForAgent = (_cfg: unknown, _agentId?: string) => ({
 });
 const resolveSandboxToolPolicyForAgent = (_cfg: unknown, _agentId?: string) =>
   undefined as SandboxToolPolicy | undefined;
-const SANDBOX_BROWSER_SECURITY_HASH_EPOCH = "";
-type ExecDockerRawResult = { code: number; stdout: Buffer; stderr: Buffer };
 type SandboxToolPolicy = { allow?: string[]; deny?: string[] };
 import { resolveToolProfilePolicy } from "../agents/tool-policy.js";
-import { formatCliCommand } from "../cli/command-format.js";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import type { OpenClawConfig, ConfigFileSnapshot } from "../config/config.js";
 import { createConfigIO } from "../config/config.js";
@@ -57,18 +54,6 @@ export type SecurityAuditFinding = {
   detail: string;
   remediation?: string;
 };
-
-type ExecDockerRawFn = (
-  args: string[],
-  opts?: { allowFailure?: boolean; input?: Buffer | string; signal?: AbortSignal },
-) => Promise<ExecDockerRawResult>;
-
-// Sandbox infrastructure removed (#68)
-const execDockerRaw: ExecDockerRawFn = async () => ({
-  code: 1,
-  stdout: Buffer.from(""),
-  stderr: Buffer.from("sandbox removed"),
-});
 
 // --------------------------------------------------------------------------
 // Helpers
@@ -253,187 +238,6 @@ async function readInstalledPackageVersion(dir: string): Promise<string | undefi
 // --------------------------------------------------------------------------
 // Exported collectors
 // --------------------------------------------------------------------------
-
-function normalizeDockerLabelValue(raw: string | undefined): string | null {
-  const trimmed = raw?.trim() ?? "";
-  if (!trimmed || trimmed === "<no value>") {
-    return null;
-  }
-  return trimmed;
-}
-
-async function listSandboxBrowserContainers(
-  execDockerRawFn: ExecDockerRawFn,
-): Promise<string[] | null> {
-  try {
-    const result = await execDockerRawFn(
-      ["ps", "-a", "--filter", "label=openclaw.sandboxBrowser=1", "--format", "{{.Names}}"],
-      { allowFailure: true },
-    );
-    if (result.code !== 0) {
-      return null;
-    }
-    return result.stdout
-      .toString("utf8")
-      .split(/\r?\n/)
-      .map((entry) => entry.trim())
-      .filter(Boolean);
-  } catch {
-    return null;
-  }
-}
-
-async function readSandboxBrowserHashLabels(params: {
-  containerName: string;
-  execDockerRawFn: ExecDockerRawFn;
-}): Promise<{ configHash: string | null; epoch: string | null } | null> {
-  try {
-    const result = await params.execDockerRawFn(
-      [
-        "inspect",
-        "-f",
-        '{{ index .Config.Labels "openclaw.configHash" }}\t{{ index .Config.Labels "openclaw.browserConfigEpoch" }}',
-        params.containerName,
-      ],
-      { allowFailure: true },
-    );
-    if (result.code !== 0) {
-      return null;
-    }
-    const [hashRaw, epochRaw] = result.stdout.toString("utf8").split("\t");
-    return {
-      configHash: normalizeDockerLabelValue(hashRaw),
-      epoch: normalizeDockerLabelValue(epochRaw),
-    };
-  } catch {
-    return null;
-  }
-}
-
-function parsePublishedHostFromDockerPortLine(line: string): string | null {
-  const trimmed = line.trim();
-  const rhs = trimmed.includes("->") ? (trimmed.split("->").at(-1)?.trim() ?? "") : trimmed;
-  if (!rhs) {
-    return null;
-  }
-  const bracketHost = rhs.match(/^\[([^\]]+)\]:\d+$/);
-  if (bracketHost?.[1]) {
-    return bracketHost[1];
-  }
-  const hostPort = rhs.match(/^([^:]+):\d+$/);
-  if (hostPort?.[1]) {
-    return hostPort[1];
-  }
-  return null;
-}
-
-function isLoopbackPublishHost(host: string): boolean {
-  const normalized = host.trim().toLowerCase();
-  return normalized === "127.0.0.1" || normalized === "::1" || normalized === "localhost";
-}
-
-async function readSandboxBrowserPortMappings(params: {
-  containerName: string;
-  execDockerRawFn: ExecDockerRawFn;
-}): Promise<string[] | null> {
-  try {
-    const result = await params.execDockerRawFn(["port", params.containerName], {
-      allowFailure: true,
-    });
-    if (result.code !== 0) {
-      return null;
-    }
-    return result.stdout
-      .toString("utf8")
-      .split(/\r?\n/)
-      .map((entry) => entry.trim())
-      .filter(Boolean);
-  } catch {
-    return null;
-  }
-}
-
-export async function collectSandboxBrowserHashLabelFindings(params?: {
-  execDockerRawFn?: ExecDockerRawFn;
-}): Promise<SecurityAuditFinding[]> {
-  const findings: SecurityAuditFinding[] = [];
-  const execFn = params?.execDockerRawFn ?? execDockerRaw;
-  const containers = await listSandboxBrowserContainers(execFn);
-  if (!containers || containers.length === 0) {
-    return findings;
-  }
-
-  const missingHash: string[] = [];
-  const staleEpoch: string[] = [];
-  const nonLoopbackPublished: string[] = [];
-
-  for (const containerName of containers) {
-    const labels = await readSandboxBrowserHashLabels({ containerName, execDockerRawFn: execFn });
-    if (!labels) {
-      continue;
-    }
-    if (!labels.configHash) {
-      missingHash.push(containerName);
-    }
-    if (labels.epoch !== SANDBOX_BROWSER_SECURITY_HASH_EPOCH) {
-      staleEpoch.push(containerName);
-    }
-    const portMappings = await readSandboxBrowserPortMappings({
-      containerName,
-      execDockerRawFn: execFn,
-    });
-    if (!portMappings?.length) {
-      continue;
-    }
-    const exposedMappings = portMappings.filter((line) => {
-      const host = parsePublishedHostFromDockerPortLine(line);
-      return Boolean(host && !isLoopbackPublishHost(host));
-    });
-    if (exposedMappings.length > 0) {
-      nonLoopbackPublished.push(`${containerName} (${exposedMappings.join("; ")})`);
-    }
-  }
-
-  if (missingHash.length > 0) {
-    findings.push({
-      checkId: "sandbox.browser_container.hash_label_missing",
-      severity: "warn",
-      title: "Sandbox browser container missing config hash label",
-      detail:
-        `Containers: ${missingHash.join(", ")}. ` +
-        "These browser containers predate hash-based drift checks and may miss security remediations until recreated.",
-      remediation: `${formatCliCommand("openclaw sandbox recreate --browser --all")} (add --force to skip prompt).`,
-    });
-  }
-
-  if (staleEpoch.length > 0) {
-    findings.push({
-      checkId: "sandbox.browser_container.hash_epoch_stale",
-      severity: "warn",
-      title: "Sandbox browser container hash epoch is stale",
-      detail:
-        `Containers: ${staleEpoch.join(", ")}. ` +
-        `Expected openclaw.browserConfigEpoch=${SANDBOX_BROWSER_SECURITY_HASH_EPOCH}.`,
-      remediation: `${formatCliCommand("openclaw sandbox recreate --browser --all")} (add --force to skip prompt).`,
-    });
-  }
-
-  if (nonLoopbackPublished.length > 0) {
-    findings.push({
-      checkId: "sandbox.browser_container.non_loopback_publish",
-      severity: "critical",
-      title: "Sandbox browser container publishes ports on non-loopback interfaces",
-      detail:
-        `Containers: ${nonLoopbackPublished.join(", ")}. ` +
-        "Sandbox browser observer/control ports should stay loopback-only to avoid unintended remote access.",
-      remediation:
-        `${formatCliCommand("openclaw sandbox recreate --browser --all")} (add --force to skip prompt), ` +
-        "then verify published ports are bound to 127.0.0.1.",
-    });
-  }
-
-  return findings;
-}
 
 export async function collectPluginsTrustFindings(params: {
   cfg: OpenClawConfig;

--- a/src/security/audit-extra.ts
+++ b/src/security/audit-extra.ts
@@ -29,7 +29,6 @@ export {
 
 // Async collectors
 export {
-  collectSandboxBrowserHashLabelFindings,
   collectIncludeFilePermFindings,
   collectPluginsCodeSafetyFindings,
   collectPluginsTrustFindings,

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -18,7 +18,6 @@ import {
   collectHooksHardeningFindings,
   collectIncludeFilePermFindings,
   collectLikelyMultiUserSetupFindings,
-  collectSandboxBrowserHashLabelFindings,
   collectMinimalProfileOverrideFindings,
   collectModelHygieneFindings,
   collectNodeDangerousAllowCommandFindings,
@@ -775,7 +774,6 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
     findings.push(
       ...(await collectStateDeepFilesystemFindings({ cfg, env, stateDir, platform, execIcacls })),
     );
-    findings.push(...(await collectSandboxBrowserHashLabelFindings({})));
     findings.push(...(await collectPluginsTrustFindings({ cfg, stateDir })));
     if (opts.deep === true) {
       findings.push(...(await collectPluginsCodeSafetyFindings({ stateDir })));


### PR DESCRIPTION
## Summary

- Delete ~210 lines of dead code left behind when the Docker sandbox was gutted (PR #68)
- Remove dead Docker container audit pipeline (`collectSandboxBrowserHashLabelFindings` and all private helpers) from `audit-extra.async.ts`
- Remove dead `normalizeSandboxMediaParams` no-op from `message-action-params.ts` and its call site in `message-action-runner.ts`
- Clean up corresponding barrel re-exports and import references

Live sandbox stubs (`resolveSandboxConfigForAgent`, `resolveSandboxToolPolicyForAgent`, `SandboxToolPolicy`) and live utilities (`normalizeSandboxMediaList`) are preserved.

Closes #148

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (92 files, 842 tests)
- [x] `grep -r` for all deleted symbols returns zero matches in `src/`
- [x] No test files reference any of the deleted code

🤖 Generated with [Claude Code](https://claude.com/claude-code)