### PR TITLE
fix: add SIGKILL escalation for hung CLI subprocesses

### DIFF
--- a/src/middleware/cli-runtime-base.test.ts
+++ b/src/middleware/cli-runtime-base.test.ts
@@ -7,7 +7,7 @@ import type { AgentEvent, AgentExecuteParams } from "./types.js";
 // ── Test harness ─────────────────────────────────────────────────────────
 
 /** Minimal mock ChildProcess with controllable stdio streams. */
-function createMockChild() {
+function createMockChild({ exitOnKill = true }: { exitOnKill?: boolean } = {}) {
   const stdout = new PassThrough();
   const stderr = new PassThrough();
   const stdin = new PassThrough();
@@ -22,10 +22,12 @@ function createMockChild() {
   proc.stderr = stderr;
   proc.stdin = stdin;
   proc.pid = 12345;
-  proc.kill = vi.fn(() => {
-    stdout.end();
-    proc.emit("exit", null, "SIGTERM");
-  });
+  proc.kill = exitOnKill
+    ? vi.fn(() => {
+        stdout.end();
+        proc.emit("exit", null, "SIGTERM");
+      })
+    : vi.fn();
   return proc;
 }
 
@@ -249,6 +251,113 @@ describe("CLIRuntimeBase", () => {
       expect(events).toContainEqual(
         expect.objectContaining({ type: "error", code: "WATCHDOG_TIMEOUT" }),
       );
+    });
+  });
+
+  describe("SIGKILL escalation", () => {
+    it("sends SIGKILL after SIGTERM if process does not exit (watchdog)", async () => {
+      const stubbornChild = createMockChild({ exitOnKill: false });
+      spawnMock.mockReturnValue(stubbornChild);
+
+      const runtime = new TestRuntime("test-cli", 1000);
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      // Advance past watchdog timeout → SIGTERM sent.
+      await vi.advanceTimersByTimeAsync(1001);
+      expect(stubbornChild.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(stubbornChild.kill).not.toHaveBeenCalledWith("SIGKILL");
+
+      // Advance past SIGKILL escalation timeout.
+      await vi.advanceTimersByTimeAsync(1500);
+      expect(stubbornChild.kill).toHaveBeenCalledWith("SIGKILL");
+
+      // Clean up: force process exit.
+      stubbornChild.stdout.end();
+      stubbornChild.emit("exit", null, "SIGKILL");
+
+      const events = await promise;
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: "error", code: "WATCHDOG_TIMEOUT" }),
+      );
+    });
+
+    it("cancels SIGKILL timer if process exits after SIGTERM (watchdog)", async () => {
+      const stubbornChild = createMockChild({ exitOnKill: false });
+      spawnMock.mockReturnValue(stubbornChild);
+
+      const runtime = new TestRuntime("test-cli", 1000);
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      // Advance past watchdog → SIGTERM.
+      await vi.advanceTimersByTimeAsync(1001);
+      expect(stubbornChild.kill).toHaveBeenCalledWith("SIGTERM");
+
+      // Process exits gracefully before escalation.
+      stubbornChild.stdout.end();
+      stubbornChild.emit("exit", 0, "SIGTERM");
+
+      // Advance past when SIGKILL would have fired.
+      await vi.advanceTimersByTimeAsync(2000);
+
+      const events = await promise;
+      expect(stubbornChild.kill).not.toHaveBeenCalledWith("SIGKILL");
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: "error", code: "WATCHDOG_TIMEOUT" }),
+      );
+    });
+
+    it("sends SIGKILL after SIGTERM if process does not exit (abort)", async () => {
+      const stubbornChild = createMockChild({ exitOnKill: false });
+      spawnMock.mockReturnValue(stubbornChild);
+
+      const runtime = new TestRuntime("test-cli");
+      const controller = new AbortController();
+
+      const promise = collectEvents(
+        runtime.execute({ ...defaultParams, abortSignal: controller.signal }),
+      );
+
+      // Abort → SIGTERM sent.
+      controller.abort();
+      expect(stubbornChild.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(stubbornChild.kill).not.toHaveBeenCalledWith("SIGKILL");
+
+      // Advance past SIGKILL escalation timeout.
+      await vi.advanceTimersByTimeAsync(1500);
+      expect(stubbornChild.kill).toHaveBeenCalledWith("SIGKILL");
+
+      // Clean up: force process exit.
+      stubbornChild.stdout.end();
+      stubbornChild.emit("exit", null, "SIGKILL");
+
+      const events = await promise;
+      expect(events).toContainEqual(expect.objectContaining({ type: "error", code: "ABORTED" }));
+    });
+
+    it("cancels SIGKILL timer if process exits after SIGTERM (abort)", async () => {
+      const stubbornChild = createMockChild({ exitOnKill: false });
+      spawnMock.mockReturnValue(stubbornChild);
+
+      const runtime = new TestRuntime("test-cli");
+      const controller = new AbortController();
+
+      const promise = collectEvents(
+        runtime.execute({ ...defaultParams, abortSignal: controller.signal }),
+      );
+
+      // Abort → SIGTERM.
+      controller.abort();
+      expect(stubbornChild.kill).toHaveBeenCalledWith("SIGTERM");
+
+      // Process exits gracefully before escalation.
+      stubbornChild.stdout.end();
+      stubbornChild.emit("exit", 0, "SIGTERM");
+
+      // Advance past when SIGKILL would have fired.
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await promise;
+      expect(stubbornChild.kill).not.toHaveBeenCalledWith("SIGKILL");
     });
   });
 

--- a/src/middleware/cli-runtime-base.ts
+++ b/src/middleware/cli-runtime-base.ts
@@ -62,6 +62,29 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
     const stderrChunks: string[] = [];
     let aborted = false;
 
+    // ── SIGKILL escalation helper ──────────────────────────────────────
+    let escalationTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const killWithEscalation = () => {
+      if (escalationTimer === undefined) {
+        escalationTimer = setTimeout(() => {
+          try {
+            child.kill("SIGKILL");
+          } catch {
+            // Already dead — ignore
+          }
+        }, 1500);
+      }
+      child.kill("SIGTERM");
+    };
+
+    child.on("exit", () => {
+      if (escalationTimer !== undefined) {
+        clearTimeout(escalationTimer);
+        escalationTimer = undefined;
+      }
+    });
+
     // ── Watchdog timer ───────────────────────────────────────────────
     let watchdogTimer: ReturnType<typeof setTimeout> | undefined;
     let watchdogFired = false;
@@ -72,7 +95,7 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
       }
       watchdogTimer = setTimeout(() => {
         watchdogFired = true;
-        child.kill("SIGTERM");
+        killWithEscalation();
       }, this.timeoutMs);
     };
     resetWatchdog();
@@ -145,12 +168,12 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
     // ── Abort signal wiring (after event infrastructure is ready) ────
     const onAbort = () => {
       aborted = true;
-      child.kill("SIGTERM");
+      killWithEscalation();
     };
     if (params.abortSignal) {
       if (params.abortSignal.aborted) {
         aborted = true;
-        child.kill("SIGTERM");
+        killWithEscalation();
       } else {
         params.abortSignal.addEventListener("abort", onAbort, { once: true });
       }
@@ -183,6 +206,9 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
 
     // ── Wait for process to fully exit ───────────────────────────────
     await exitPromise;
+    if (escalationTimer !== undefined) {
+      clearTimeout(escalationTimer);
+    }
     const durationMs = Date.now() - startMs;
 
     // ── Emit terminal events ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #156.

- Add `killWithEscalation()` helper in `cli-runtime-base.ts` that sends SIGTERM then schedules SIGKILL after 1.5s if the process hasn't exited
- Replace all three `child.kill("SIGTERM")` call sites (watchdog timeout, abort handler, already-aborted path) with the escalation helper
- Cancel the SIGKILL timer when the child process exits voluntarily via `child.on("exit")` handler
- Add 4 tests covering both escalation paths (watchdog + abort) and timer cancellation

## Test plan

- [x] Existing 16 tests still pass (no behavioral change for processes that exit after SIGTERM)
- [x] New test: watchdog SIGTERM → 1.5s SIGKILL fires if process doesn't exit
- [x] New test: watchdog SIGTERM → SIGKILL timer cancelled if process exits before escalation
- [x] New test: abort SIGTERM → 1.5s SIGKILL fires if process doesn't exit
- [x] New test: abort SIGTERM → SIGKILL timer cancelled if process exits before escalation
- [x] `pnpm build` passes
- [x] `pnpm test` passes (842 tests)
- [x] `pnpm tsgo` passes
- [x] Lint clean (our files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)