### PR TITLE
fix: return MCP error responses instead of crashing subprocess

### DIFF
--- a/src/middleware/mcp-tools.test.ts
+++ b/src/middleware/mcp-tools.test.ts
@@ -8,13 +8,24 @@ vi.mock("./mcp-plugin-tools.js", () => ({
   registerPluginTools: vi.fn().mockResolvedValue(undefined),
 }));
 
-// Create a minimal mock McpServer
+// Create a minimal mock McpServer that also captures handler callbacks
 function createMockServer() {
   const registeredTools = new Map<string, { description?: string }>();
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const registeredHandlers = new Map<string, (...args: any[]) => Promise<unknown>>();
   return {
     registeredTools,
-    registerTool: vi.fn((name: string, config: { description?: string }) => {
+    registeredHandlers,
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registerTool: vi.fn((...args: any[]) => {
+      const name = args[0] as string;
+      const config = args[1] as { description?: string };
       registeredTools.set(name, config);
+      // Capture the handler (last argument) if it's a function
+      const last = args[args.length - 1];
+      if (typeof last === "function") {
+        registeredHandlers.set(name, last);
+      }
       return { update: vi.fn(), remove: vi.fn(), disable: vi.fn(), enable: vi.fn() };
     }),
   };
@@ -256,5 +267,38 @@ describe("registerAllTools", () => {
     expect(names).toContain("tts_set_provider");
     expect(names).toContain("tts_enable");
     expect(names).toContain("tts_disable");
+  });
+
+  describe("centralized error handling", () => {
+    it("returns MCP error response instead of throwing when handler fails", async () => {
+      // oxlint-disable-next-line typescript/no-explicit-any
+      await registerAllTools(mockServer as any, ctx);
+
+      // Pick any registered handler and invoke it — the proxy wrapper
+      // calls callMcpGateway which will throw because the gateway mock
+      // isn't wired up. This exercises the catch path.
+      const handler = mockServer.registeredHandlers.get("sessions_list");
+      expect(handler).toBeDefined();
+
+      const result = await handler!({});
+      // Should return an MCP-compliant error instead of throwing
+      expect(result).toMatchObject({
+        isError: true,
+        content: [{ type: "text", text: expect.stringContaining("Tool error (sessions_list):") }],
+      });
+    });
+
+    it("includes error message from Error instances", async () => {
+      // oxlint-disable-next-line typescript/no-explicit-any
+      await registerAllTools(mockServer as any, ctx);
+      const handler = mockServer.registeredHandlers.get("gateway_restart");
+      expect(handler).toBeDefined();
+
+      const result = await handler!({});
+      expect(result).toMatchObject({
+        isError: true,
+        content: [{ type: "text", text: expect.stringMatching(/Tool error \(gateway_restart\):/) }],
+      });
+    });
   });
 });

--- a/src/middleware/mcp-tools.ts
+++ b/src/middleware/mcp-tools.ts
@@ -49,7 +49,15 @@ function wrapWithToolHooks(server: McpServer, ctx: McpHandlerContext): McpServer
                 durationMs: Date.now() - start,
                 error: String(err),
               }).catch(() => {});
-              throw err;
+              return {
+                isError: true,
+                content: [
+                  {
+                    type: "text" as const,
+                    text: `Tool error (${toolName}): ${err instanceof Error ? err.message : String(err)}`,
+                  },
+                ],
+              };
             }
           };
         }


### PR DESCRIPTION
## Summary

Closes #157.

- The `wrapWithToolHooks` proxy in `mcp-tools.ts` caught handler errors but re-threw them, crashing the MCP server subprocess and killing all tool access for the CLI agent
- Now returns MCP-compliant `{ isError: true }` responses with tool name and error message, so the subprocess stays alive and the agent can retry or use other tools
- Added 2 tests verifying that throwing handlers return error responses instead of propagating exceptions

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm tsgo` passes (no type errors)
- [x] `pnpm test` passes (842 tests, 92 files)
- [x] New tests in `mcp-tools.test.ts` verify error containment for `sessions_list` and `gateway_restart` handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)