### PR TITLE
fix: remove dead sandbox config schema and tool params

### DIFF
--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -4,18 +4,7 @@ import { Type } from "@sinclair/typebox";
 import { applyUpdateHunk } from "./apply-patch-update.js";
 import type { AgentTool } from "./pi-types.js";
 
-// Sandbox infrastructure removed (#68); inline the types and helpers that survived the gut.
-type SandboxFsBridge = {
-  readFile(params: { filePath: string; cwd: string }): Promise<Buffer>;
-  writeFile(params: { filePath: string; cwd: string; data: string }): Promise<void>;
-  remove(params: { filePath: string; cwd: string; force: boolean }): Promise<void>;
-  mkdirp(params: { filePath: string; cwd: string }): Promise<void>;
-  resolvePath(params: { filePath: string; cwd: string }): {
-    hostPath: string;
-    relativePath: string;
-  };
-};
-async function assertSandboxPath(opts: {
+async function assertWorkspacePath(opts: {
   filePath: string;
   cwd: string;
   root: string;
@@ -29,7 +18,7 @@ async function assertSandboxPath(opts: {
   const relative = path.relative(normalizedRoot, resolved);
   return { resolved, relative };
 }
-function resolveSandboxInputPath(filePath: string, cwd: string): string {
+function resolveInputPath(filePath: string, cwd: string): string {
   return path.resolve(cwd, filePath);
 }
 
@@ -85,14 +74,8 @@ export type ApplyPatchToolDetails = {
   summary: ApplyPatchSummary;
 };
 
-type SandboxApplyPatchConfig = {
-  root: string;
-  bridge: SandboxFsBridge;
-};
-
 type ApplyPatchOptions = {
   cwd: string;
-  sandbox?: SandboxApplyPatchConfig;
   /** Restrict patch paths to the workspace root (cwd). Default: true. Set false to opt out. */
   workspaceOnly?: boolean;
   signal?: AbortSignal;
@@ -105,10 +88,9 @@ const applyPatchSchema = Type.Object({
 });
 
 export function createApplyPatchTool(
-  options: { cwd?: string; sandbox?: SandboxApplyPatchConfig; workspaceOnly?: boolean } = {},
+  options: { cwd?: string; workspaceOnly?: boolean } = {},
 ): AgentTool<typeof applyPatchSchema, ApplyPatchToolDetails> {
   const cwd = options.cwd ?? process.cwd();
-  const sandbox = options.sandbox;
   const workspaceOnly = options.workspaceOnly !== false;
 
   return {
@@ -131,7 +113,6 @@ export function createApplyPatchTool(
 
       const result = await applyPatch(input, {
         cwd,
-        sandbox,
         workspaceOnly,
         signal,
       });
@@ -163,7 +144,7 @@ export async function applyPatch(
     modified: new Set<string>(),
     deleted: new Set<string>(),
   };
-  const fileOps = resolvePatchFileOps(options);
+  const fileOps = resolvePatchFileOps();
 
   for (const hunk of parsed.hunks) {
     if (options.signal?.aborted) {
@@ -248,19 +229,7 @@ type PatchFileOps = {
   mkdirp: (dir: string) => Promise<void>;
 };
 
-function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
-  if (options.sandbox) {
-    const { root, bridge } = options.sandbox;
-    return {
-      readFile: async (filePath) => {
-        const buf = await bridge.readFile({ filePath, cwd: root });
-        return buf.toString("utf8");
-      },
-      writeFile: (filePath, content) => bridge.writeFile({ filePath, cwd: root, data: content }),
-      remove: (filePath) => bridge.remove({ filePath, cwd: root, force: false }),
-      mkdirp: (dir) => bridge.mkdirp({ filePath: dir, cwd: root }),
-    };
-  }
+function resolvePatchFileOps(): PatchFileOps {
   return {
     readFile: (filePath) => fs.readFile(filePath, "utf8"),
     writeFile: (filePath, content) => fs.writeFile(filePath, content, "utf8"),
@@ -282,29 +251,10 @@ async function resolvePatchPath(
   options: ApplyPatchOptions,
   purpose: "readWrite" | "unlink" = "readWrite",
 ): Promise<{ resolved: string; display: string }> {
-  if (options.sandbox) {
-    const resolved = options.sandbox.bridge.resolvePath({
-      filePath,
-      cwd: options.cwd,
-    });
-    if (options.workspaceOnly !== false) {
-      await assertSandboxPath({
-        filePath: resolved.hostPath,
-        cwd: options.cwd,
-        root: options.cwd,
-        allowFinalSymlink: purpose === "unlink",
-      });
-    }
-    return {
-      resolved: resolved.hostPath,
-      display: resolved.relativePath || resolved.hostPath,
-    };
-  }
-
   const workspaceOnly = options.workspaceOnly !== false;
   const resolved = workspaceOnly
     ? (
-        await assertSandboxPath({
+        await assertWorkspacePath({
           filePath,
           cwd: options.cwd,
           root: options.cwd,
@@ -319,7 +269,7 @@ async function resolvePatchPath(
 }
 
 function resolvePathFromCwd(filePath: string, cwd: string): string {
-  return path.normalize(resolveSandboxInputPath(filePath, cwd));
+  return path.normalize(resolveInputPath(filePath, cwd));
 }
 
 function toDisplayPath(resolved: string, cwd: string): string {

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -2,21 +2,6 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolvePluginTools } from "../plugins/tools.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveSessionAgentId } from "./agent-scope.js";
-// Sandbox infrastructure removed (#68)
-type SandboxFsBridge = {
-  readFile(params: { filePath: string; cwd: string }): Promise<Buffer>;
-  writeFile(params: { filePath: string; cwd: string; data: string }): Promise<void>;
-  stat(params: {
-    filePath: string;
-    cwd: string;
-  }): Promise<{ isFile(): boolean; size: number } | null>;
-  mkdirp(params: { filePath: string; cwd: string }): Promise<void>;
-  remove(params: { filePath: string; cwd: string; force: boolean }): Promise<void>;
-  resolvePath(params: { filePath: string; cwd: string }): {
-    hostPath: string;
-    relativePath: string;
-  };
-};
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
 import { createAgentsListTool } from "./tools/agents-list-tool.js";
 import { createCanvasTool } from "./tools/canvas-tool.js";
@@ -34,8 +19,6 @@ import { createSubagentsTool } from "./tools/subagents-tool.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
 export function createOpenClawTools(options?: {
-  sandboxBrowserBridgeUrl?: string;
-  allowHostBrowserControl?: boolean;
   agentSessionKey?: string;
   agentChannel?: GatewayMessageChannel;
   agentAccountId?: string;
@@ -50,8 +33,6 @@ export function createOpenClawTools(options?: {
   /** Group space label for channel-level tool policy inheritance. */
   agentGroupSpace?: string | null;
   agentDir?: string;
-  sandboxRoot?: string;
-  sandboxFsBridge?: SandboxFsBridge;
   fsPolicy?: ToolFsPolicy;
   workspaceDir?: string;
   sandboxed?: boolean;
@@ -93,7 +74,6 @@ export function createOpenClawTools(options?: {
         currentMessageId: options?.currentMessageId,
         replyToMode: options?.replyToMode,
         hasRepliedRef: options?.hasRepliedRef,
-        sandboxRoot: options?.sandboxRoot,
         requireExplicitTarget: options?.requireExplicitMessageTarget,
         requesterSenderId: options?.requesterSenderId ?? undefined,
       });

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -1,21 +1,5 @@
 import { z } from "zod";
 import { HeartbeatSchema, AgentModelSchema } from "./zod-schema.agent-runtime.js";
-
-// Sandbox infrastructure removed (#68)
-const AgentSandboxSchema = z
-  .object({
-    mode: z.union([z.literal("off"), z.literal("non-main"), z.literal("all")]).optional(),
-    workspaceAccess: z.union([z.literal("none"), z.literal("ro"), z.literal("rw")]).optional(),
-    sessionToolsVisibility: z.union([z.literal("spawned"), z.literal("all")]).optional(),
-    scope: z.union([z.literal("session"), z.literal("agent"), z.literal("shared")]).optional(),
-    perSession: z.boolean().optional(),
-    workspaceRoot: z.string().optional(),
-    docker: z.record(z.string(), z.unknown()).optional(),
-    browser: z.record(z.string(), z.unknown()).optional(),
-    prune: z.record(z.string(), z.unknown()).optional(),
-  })
-  .strict()
-  .optional();
 import {
   BlockStreamingChunkSchema,
   BlockStreamingCoalesceSchema,
@@ -152,7 +136,7 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
-    sandbox: AgentSandboxSchema,
+    sandbox: z.unknown().optional(),
     runtime: z
       .union([z.literal("claude"), z.literal("gemini"), z.literal("codex"), z.literal("opencode")])
       .optional(),


### PR DESCRIPTION
## Summary

Closes #158.

- Removed `AgentSandboxSchema` from config, replaced with `z.unknown().optional()` pass-through so existing configs with a `sandbox` key are silently accepted
- Deleted `SandboxFsBridge` type and 4 dead sandbox parameters (`sandboxBrowserBridgeUrl`, `allowHostBrowserControl`, `sandboxRoot`, `sandboxFsBridge`) from `createOpenClawTools`
- Cleaned up sandbox infrastructure from `apply-patch.ts`: removed `SandboxFsBridge` type, `SandboxApplyPatchConfig`, dead sandbox code paths in `resolvePatchFileOps` and `resolvePatchPath`; renamed `assertSandboxPath` → `assertWorkspacePath` and `resolveSandboxInputPath` → `resolveInputPath`

**~86 lines deleted** across 3 files. No behavioral changes — all removed code was dead.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (842 tests, 0 failures)
- [x] `grep -r "SandboxFsBridge" src/` returns zero matches
- [x] `grep -r "AgentSandboxSchema" src/` returns zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)