### PR TITLE
fix: remove dead MemorySchema and pass sessions_list filter

### DIFF
--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -9,12 +9,7 @@ import { HookMappingSchema, HooksGmailSchema, InternalHooksSchema } from "./zod-
 import { InstallRecordShape } from "./zod-schema.installs.js";
 import { ChannelsSchema } from "./zod-schema.providers.js";
 import { sensitive } from "./zod-schema.sensitive.js";
-import {
-  CommandsSchema,
-  MessagesSchema,
-  SessionSchema,
-  SessionSendPolicySchema,
-} from "./zod-schema.session.js";
+import { CommandsSchema, MessagesSchema, SessionSchema } from "./zod-schema.session.js";
 
 const BrowserSnapshotDefaultsSchema = z
   .object({
@@ -36,52 +31,6 @@ const NodeHostSchema = z
   .strict()
   .optional();
 
-const MemoryQmdPathSchema = z
-  .object({
-    path: z.string(),
-    name: z.string().optional(),
-    pattern: z.string().optional(),
-  })
-  .strict();
-
-const MemoryQmdSessionSchema = z
-  .object({
-    enabled: z.boolean().optional(),
-    exportDir: z.string().optional(),
-    retentionDays: z.number().int().nonnegative().optional(),
-  })
-  .strict();
-
-const MemoryQmdUpdateSchema = z
-  .object({
-    interval: z.string().optional(),
-    debounceMs: z.number().int().nonnegative().optional(),
-    onBoot: z.boolean().optional(),
-    waitForBootSync: z.boolean().optional(),
-    embedInterval: z.string().optional(),
-    commandTimeoutMs: z.number().int().nonnegative().optional(),
-    updateTimeoutMs: z.number().int().nonnegative().optional(),
-    embedTimeoutMs: z.number().int().nonnegative().optional(),
-  })
-  .strict();
-
-const MemoryQmdLimitsSchema = z
-  .object({
-    maxResults: z.number().int().positive().optional(),
-    maxSnippetChars: z.number().int().positive().optional(),
-    maxInjectedChars: z.number().int().positive().optional(),
-    timeoutMs: z.number().int().nonnegative().optional(),
-  })
-  .strict();
-
-const MemoryQmdMcporterSchema = z
-  .object({
-    enabled: z.boolean().optional(),
-    serverName: z.string().optional(),
-    startDaemon: z.boolean().optional(),
-  })
-  .strict();
-
 const LoggingLevelSchema = z.union([
   z.literal("silent"),
   z.literal("fatal"),
@@ -91,29 +40,6 @@ const LoggingLevelSchema = z.union([
   z.literal("debug"),
   z.literal("trace"),
 ]);
-
-const MemoryQmdSchema = z
-  .object({
-    command: z.string().optional(),
-    mcporter: MemoryQmdMcporterSchema.optional(),
-    searchMode: z.union([z.literal("query"), z.literal("search"), z.literal("vsearch")]).optional(),
-    includeDefaultMemory: z.boolean().optional(),
-    paths: z.array(MemoryQmdPathSchema).optional(),
-    sessions: MemoryQmdSessionSchema.optional(),
-    update: MemoryQmdUpdateSchema.optional(),
-    limits: MemoryQmdLimitsSchema.optional(),
-    scope: SessionSendPolicySchema.optional(),
-  })
-  .strict();
-
-const MemorySchema = z
-  .object({
-    backend: z.union([z.literal("builtin"), z.literal("qmd")]).optional(),
-    citations: z.union([z.literal("auto"), z.literal("on"), z.literal("off")]).optional(),
-    qmd: MemoryQmdSchema.optional(),
-  })
-  .strict()
-  .optional();
 
 const HttpUrlSchema = z
   .string()
@@ -653,7 +579,7 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
-    memory: MemorySchema,
+    memory: z.unknown().optional(),
     plugins: z
       .object({
         enabled: z.boolean().optional(),

--- a/src/middleware/mcp-handlers/session.ts
+++ b/src/middleware/mcp-handlers/session.ts
@@ -50,6 +50,7 @@ export function registerSessionTools(server: McpServer, ctx: McpHandlerContext):
     async (args) => {
       const result = await callMcpGateway(ctx, "sessions.list", {
         limit: args.filter !== undefined ? undefined : args.limit,
+        search: args.filter,
         includeGlobal: true,
         includeUnknown: true,
       });


### PR DESCRIPTION
## Summary

Closes #160.

- **Remove dead `MemorySchema`** (~75 lines) from `src/config/zod-schema.ts` — the memory subsystem was gutted and the parsed config was silently discarded at the Zod-to-TypeScript boundary. Replaced with `z.unknown().optional()` so old config files still parse without errors.
- **Pass `sessions_list` filter** as `search` parameter to the gateway API in `src/middleware/mcp-handlers/session.ts`, so CLI agents can actually filter sessions instead of having the filter silently dropped.

## Test plan

- [x] `grep -r "MemorySchema" src/` returns zero matches
- [x] `pnpm build` passes
- [x] `pnpm test` passes (842 tests, 92 files)
- [x] Config files with `memory` section still accepted (via `z.unknown().optional()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)