### PR TITLE
fix: implement missing gateway methods for sessions_spawn and subagents MCP tools

### DIFF
--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -89,6 +89,8 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "tts.setProvider",
     "voicewake.set",
     "node.invoke",
+    "sessions.spawn",
+    "sessions.subagents",
     "chat.send",
     "chat.abort",
     "browser.request",

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -51,6 +51,8 @@ const BASE_METHODS = [
   "sessions.reset",
   "sessions.delete",
   "sessions.compact",
+  "sessions.spawn",
+  "sessions.subagents",
   "last-heartbeat",
   "set-heartbeats",
   "wake",

--- a/src/gateway/server-methods/sessions-spawn-subagents.test.ts
+++ b/src/gateway/server-methods/sessions-spawn-subagents.test.ts
@@ -1,0 +1,325 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayRequestHandlerOptions, RespondFn } from "./types.js";
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+const spawnSubagentDirectMock = vi.fn();
+vi.mock("../../agents/subagent-spawn.js", () => ({
+  spawnSubagentDirect: (...args: unknown[]) => spawnSubagentDirectMock(...args),
+}));
+
+vi.mock("../../agents/bootstrap-cache.js", () => ({
+  clearBootstrapSnapshot: vi.fn(),
+}));
+
+vi.mock("../../auto-reply/reply/abort.js", () => ({
+  stopSubagentsForRequester: vi.fn(),
+}));
+
+vi.mock("../../auto-reply/reply/queue.js", () => ({
+  clearSessionQueues: vi.fn().mockReturnValue({
+    followupCleared: 0,
+    laneCleared: 0,
+    keys: [],
+  }),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => ({
+    session: { mainKey: "main" },
+  }),
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  loadSessionStore: vi.fn().mockReturnValue({}),
+  snapshotSessionOrigin: vi.fn(),
+  resolveMainSessionKey: vi.fn().mockReturnValue("main"),
+  updateSessionStore: vi.fn(),
+}));
+
+vi.mock("../../discord/monitor/thread-bindings.js", () => ({
+  unbindThreadBindingsBySessionKey: vi.fn(),
+}));
+
+vi.mock("../../hooks/internal-hooks.js", () => ({
+  createInternalHookEvent: vi.fn(),
+  triggerInternalHook: vi.fn(),
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(),
+}));
+
+import {
+  addSubagentRunForTests,
+  resetSubagentRegistryForTests,
+} from "../../agents/subagent-registry.js";
+import { sessionsHandlers } from "./sessions.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function makeOpts(params: Record<string, unknown>): {
+  respond: ReturnType<typeof vi.fn>;
+  opts: GatewayRequestHandlerOptions;
+} {
+  const respond = vi.fn() as unknown as ReturnType<typeof vi.fn> & RespondFn;
+  return {
+    respond,
+    opts: {
+      req: { id: "req-1", type: "req" as const, method: "test" },
+      params,
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as GatewayRequestHandlerOptions["context"],
+    },
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("sessions.spawn gateway method", () => {
+  beforeEach(() => {
+    spawnSubagentDirectMock.mockReset();
+  });
+
+  it("rejects when task is missing", async () => {
+    const { respond, opts } = makeOpts({});
+    await sessionsHandlers["sessions.spawn"](opts);
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: "task is required",
+      }),
+    );
+  });
+
+  it("rejects when task is empty string", async () => {
+    const { respond, opts } = makeOpts({ task: "  " });
+    await sessionsHandlers["sessions.spawn"](opts);
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: "task is required",
+      }),
+    );
+  });
+
+  it("bridges to spawnSubagentDirect with correct params", async () => {
+    spawnSubagentDirectMock.mockResolvedValue({
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:abc",
+      runId: "run-123",
+    });
+
+    const { respond, opts } = makeOpts({
+      task: "investigate auth bug",
+      agentId: "coder",
+      label: "auth-investigator",
+      sessionKey: "agent:main:main",
+    });
+    await sessionsHandlers["sessions.spawn"](opts);
+
+    expect(spawnSubagentDirectMock).toHaveBeenCalledWith(
+      { task: "investigate auth bug", agentId: "coder", label: "auth-investigator" },
+      { agentSessionKey: "agent:main:main" },
+    );
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      {
+        status: "accepted",
+        childSessionKey: "agent:main:subagent:abc",
+        runId: "run-123",
+      },
+      undefined,
+    );
+  });
+
+  it("handles spawn errors gracefully", async () => {
+    spawnSubagentDirectMock.mockRejectedValue(new Error("spawn failed"));
+
+    const { respond, opts } = makeOpts({
+      task: "do stuff",
+      sessionKey: "agent:main:main",
+    });
+    await sessionsHandlers["sessions.spawn"](opts);
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        message: "spawn failed",
+      }),
+    );
+  });
+
+  it("passes optional params as undefined when absent", async () => {
+    spawnSubagentDirectMock.mockResolvedValue({ status: "accepted" });
+
+    const { opts } = makeOpts({ task: "run task" });
+    await sessionsHandlers["sessions.spawn"](opts);
+
+    expect(spawnSubagentDirectMock).toHaveBeenCalledWith(
+      { task: "run task", agentId: undefined, label: undefined },
+      { agentSessionKey: undefined },
+    );
+  });
+});
+
+describe("sessions.subagents gateway method", () => {
+  beforeEach(() => {
+    resetSubagentRegistryForTests();
+  });
+
+  it("rejects when sessionKey is missing", async () => {
+    const { respond, opts } = makeOpts({ action: "list" });
+    await sessionsHandlers["sessions.subagents"](opts);
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: "sessionKey is required",
+      }),
+    );
+  });
+
+  it("lists subagent runs for a session", async () => {
+    const now = Date.now();
+    addSubagentRunForTests({
+      runId: "run-1",
+      childSessionKey: "agent:main:subagent:child-1",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "investigate auth",
+      cleanup: "keep",
+      createdAt: now - 60_000,
+      startedAt: now - 60_000,
+    });
+
+    const { respond, opts } = makeOpts({
+      action: "list",
+      sessionKey: "agent:main:main",
+    });
+    await sessionsHandlers["sessions.subagents"](opts);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        status: "ok",
+        action: "list",
+      }),
+      undefined,
+    );
+    const payload = respond.mock.calls[0][1] as { runs: unknown[] };
+    expect(payload.runs).toHaveLength(1);
+  });
+
+  it("defaults to list when action is missing", async () => {
+    const { respond, opts } = makeOpts({ sessionKey: "agent:main:main" });
+    await sessionsHandlers["sessions.subagents"](opts);
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        status: "ok",
+        action: "list",
+      }),
+      undefined,
+    );
+  });
+
+  it("returns status for a specific run by runId", async () => {
+    const now = Date.now();
+    addSubagentRunForTests({
+      runId: "run-status-1",
+      childSessionKey: "agent:main:subagent:status-child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "check status",
+      cleanup: "keep",
+      createdAt: now,
+      startedAt: now,
+    });
+
+    const { respond, opts } = makeOpts({
+      action: "status",
+      sessionKey: "agent:main:main",
+      runId: "run-status-1",
+    });
+    await sessionsHandlers["sessions.subagents"](opts);
+
+    const payload = respond.mock.calls[0][1] as {
+      status: string;
+      run: { runId: string } | null;
+    };
+    expect(payload.status).toBe("ok");
+    expect(payload.run).not.toBeNull();
+    expect(payload.run?.runId).toBe("run-status-1");
+  });
+
+  it("returns null for unknown runId in status action", async () => {
+    const { respond, opts } = makeOpts({
+      action: "status",
+      sessionKey: "agent:main:main",
+      runId: "nonexistent",
+    });
+    await sessionsHandlers["sessions.subagents"](opts);
+
+    const payload = respond.mock.calls[0][1] as { run: unknown };
+    expect(payload.run).toBeNull();
+  });
+
+  it("cancels a subagent run", async () => {
+    const now = Date.now();
+    addSubagentRunForTests({
+      runId: "run-cancel-1",
+      childSessionKey: "agent:main:subagent:cancel-child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "cancel me",
+      cleanup: "keep",
+      createdAt: now,
+      startedAt: now,
+    });
+
+    const { respond, opts } = makeOpts({
+      action: "cancel",
+      sessionKey: "agent:main:main",
+      runId: "run-cancel-1",
+      reason: "user requested",
+    });
+    await sessionsHandlers["sessions.subagents"](opts);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        status: "ok",
+        action: "cancel",
+        terminated: 1,
+      }),
+      undefined,
+    );
+  });
+
+  it("rejects unsupported actions", async () => {
+    const { respond, opts } = makeOpts({
+      action: "restart",
+      sessionKey: "agent:main:main",
+    });
+    await sessionsHandlers["sessions.subagents"](opts);
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: "unsupported action: restart",
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -2,6 +2,11 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { clearBootstrapSnapshot } from "../../agents/bootstrap-cache.js";
+import {
+  listSubagentRunsForRequester,
+  markSubagentRunTerminated,
+} from "../../agents/subagent-registry.js";
+import { spawnSubagentDirect } from "../../agents/subagent-spawn.js";
 import { stopSubagentsForRequester } from "../../auto-reply/reply/abort.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue.js";
 import { loadConfig } from "../../config/config.js";
@@ -569,6 +574,75 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         kept: keptLines.length,
       },
       undefined,
+    );
+  },
+  "sessions.spawn": async ({ params, respond }) => {
+    const task = typeof params.task === "string" ? params.task.trim() : "";
+    if (!task) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "task is required"));
+      return;
+    }
+    const agentId =
+      typeof params.agentId === "string" ? params.agentId.trim() || undefined : undefined;
+    const label = typeof params.label === "string" ? params.label.trim() || undefined : undefined;
+    const sessionKey =
+      typeof params.sessionKey === "string" ? params.sessionKey.trim() || undefined : undefined;
+
+    try {
+      const result = await spawnSubagentDirect(
+        { task, agentId, label },
+        { agentSessionKey: sessionKey },
+      );
+      respond(true, result, undefined);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, message));
+    }
+  },
+  "sessions.subagents": ({ params, respond }) => {
+    const action = typeof params.action === "string" ? params.action.trim() : "list";
+    const sessionKey = typeof params.sessionKey === "string" ? params.sessionKey.trim() : "";
+    if (!sessionKey) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "sessionKey is required"));
+      return;
+    }
+
+    if (action === "list") {
+      const runs = listSubagentRunsForRequester(sessionKey);
+      respond(true, { status: "ok", action: "list", runs }, undefined);
+      return;
+    }
+
+    if (action === "status") {
+      const runId = typeof params.runId === "string" ? params.runId.trim() : "";
+      const runs = listSubagentRunsForRequester(sessionKey);
+      if (runId) {
+        const run = runs.find((r) => r.runId === runId);
+        respond(true, { status: "ok", action: "status", run: run ?? null }, undefined);
+      } else {
+        respond(true, { status: "ok", action: "status", runs }, undefined);
+      }
+      return;
+    }
+
+    if (action === "cancel") {
+      const runId = typeof params.runId === "string" ? params.runId.trim() : "";
+      const childSessionKey =
+        typeof params.childSessionKey === "string" ? params.childSessionKey.trim() : "";
+      const reason = typeof params.reason === "string" ? params.reason.trim() : "cancelled";
+      const terminated = markSubagentRunTerminated({
+        runId: runId || undefined,
+        childSessionKey: childSessionKey || undefined,
+        reason,
+      });
+      respond(true, { status: "ok", action: "cancel", terminated }, undefined);
+      return;
+    }
+
+    respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.INVALID_REQUEST, `unsupported action: ${action}`),
     );
   },
 };


### PR DESCRIPTION
## Summary

- Add `sessions.spawn` gateway method bridging to `spawnSubagentDirect()` for subagent creation via MCP
- Add `sessions.subagents` gateway method bridging to subagent registry for list/status/cancel actions via MCP
- Register both methods in `BASE_METHODS` (discovery) and `METHOD_SCOPE_GROUPS` (`WRITE_SCOPE`)

Both MCP tools (`sessions_spawn`, `subagents` in `src/middleware/mcp-handlers/session.ts`) were calling `callMcpGateway` with methods that had no server-side handler, causing runtime "unknown method" errors.

## Test plan

- [x] 12 new unit tests covering spawn (param validation, bridging, error handling) and subagents (list, status, cancel, unsupported action)
- [x] All 995 existing test files pass (8135 tests)
- [x] TypeScript compiles cleanly
- [x] Lint passes (0 errors on changed files)

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)