### PR TITLE
fix: remove dead read tool infrastructure

### DIFF
--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -11,7 +11,7 @@ function makePermissionRequest(
     sessionId: "session-1",
     toolCall: {
       toolCallId: "tool-1",
-      title: "read: src/index.ts",
+      title: "search: foo",
       status: "pending",
     },
     options: [
@@ -49,7 +49,7 @@ describe("resolvePermissionRequest", () => {
     expect(res).toEqual({ outcome: { outcome: "selected", optionId: "allow" } });
   });
 
-  it("prompts for non-read/search tools (write)", async () => {
+  it("prompts for non-search tools (write)", async () => {
     const prompt = vi.fn(async () => true);
     const res = await resolvePermissionRequest(
       makePermissionRequest({
@@ -74,98 +74,16 @@ describe("resolvePermissionRequest", () => {
     expect(prompt).not.toHaveBeenCalled();
   });
 
-  it("prompts for read outside cwd scope", async () => {
+  it("prompts for read tool (no longer auto-approved)", async () => {
     const prompt = vi.fn(async () => false);
     const res = await resolvePermissionRequest(
       makePermissionRequest({
-        toolCall: { toolCallId: "tool-r", title: "read: ~/.ssh/id_rsa", status: "pending" },
+        toolCall: { toolCallId: "tool-r", title: "read: src/index.ts", status: "pending" },
       }),
       { prompt, log: () => {} },
     );
     expect(prompt).toHaveBeenCalledTimes(1);
-    expect(prompt).toHaveBeenCalledWith("read", "read: ~/.ssh/id_rsa");
-    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "reject" } });
-  });
-
-  it("auto-approves read when rawInput path resolves inside cwd", async () => {
-    const prompt = vi.fn(async () => true);
-    const res = await resolvePermissionRequest(
-      makePermissionRequest({
-        toolCall: {
-          toolCallId: "tool-read-inside-cwd",
-          title: "read: ignored-by-raw-input",
-          status: "pending",
-          rawInput: { path: "docs/security.md" },
-        },
-      }),
-      { prompt, log: () => {}, cwd: "/tmp/openclaw-acp-cwd" },
-    );
-    expect(prompt).not.toHaveBeenCalled();
-    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "allow" } });
-  });
-
-  it("auto-approves read when rawInput file URL resolves inside cwd", async () => {
-    const prompt = vi.fn(async () => true);
-    const res = await resolvePermissionRequest(
-      makePermissionRequest({
-        toolCall: {
-          toolCallId: "tool-read-inside-cwd-file-url",
-          title: "read: ignored-by-raw-input",
-          status: "pending",
-          rawInput: { path: "file:///tmp/openclaw-acp-cwd/docs/security.md" },
-        },
-      }),
-      { prompt, log: () => {}, cwd: "/tmp/openclaw-acp-cwd" },
-    );
-    expect(prompt).not.toHaveBeenCalled();
-    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "allow" } });
-  });
-
-  it("prompts for read when rawInput path escapes cwd via traversal", async () => {
-    const prompt = vi.fn(async () => false);
-    const res = await resolvePermissionRequest(
-      makePermissionRequest({
-        toolCall: {
-          toolCallId: "tool-read-escape-cwd",
-          title: "read: ignored-by-raw-input",
-          status: "pending",
-          rawInput: { path: "../.ssh/id_rsa" },
-        },
-      }),
-      { prompt, log: () => {}, cwd: "/tmp/openclaw-acp-cwd/workspace" },
-    );
-    expect(prompt).toHaveBeenCalledTimes(1);
-    expect(prompt).toHaveBeenCalledWith("read", "read: ignored-by-raw-input");
-    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "reject" } });
-  });
-
-  it("prompts for read when scoped path is missing", async () => {
-    const prompt = vi.fn(async () => false);
-    const res = await resolvePermissionRequest(
-      makePermissionRequest({
-        toolCall: {
-          toolCallId: "tool-read-no-path",
-          title: "read",
-          status: "pending",
-        },
-      }),
-      { prompt, log: () => {} },
-    );
-    expect(prompt).toHaveBeenCalledTimes(1);
-    expect(prompt).toHaveBeenCalledWith("read", "read");
-    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "reject" } });
-  });
-
-  it("prompts for non-core read-like tool names", async () => {
-    const prompt = vi.fn(async () => false);
-    const res = await resolvePermissionRequest(
-      makePermissionRequest({
-        toolCall: { toolCallId: "tool-fr", title: "fs_read: ~/.ssh/id_rsa", status: "pending" },
-      }),
-      { prompt, log: () => {} },
-    );
-    expect(prompt).toHaveBeenCalledTimes(1);
-    expect(prompt).toHaveBeenCalledWith("fs_read", "fs_read: ~/.ssh/id_rsa");
+    expect(prompt).toHaveBeenCalledWith("read", "read: src/index.ts");
     expect(res).toEqual({ outcome: { outcome: "selected", optionId: "reject" } });
   });
 

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -1,6 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
-import { homedir } from "node:os";
 import path from "node:path";
 import * as readline from "node:readline";
 import { Readable, Writable } from "node:stream";
@@ -17,13 +16,11 @@ import { isKnownCoreToolId } from "../agents/tool-catalog.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { DANGEROUS_ACP_TOOLS } from "../security/dangerous-tools.js";
 
-const SAFE_AUTO_APPROVE_TOOL_IDS = new Set(["read", "search", "web_search"]);
+const SAFE_AUTO_APPROVE_TOOL_IDS = new Set(["search", "web_search"]);
 const TRUSTED_SAFE_TOOL_ALIASES = new Set(["search"]);
-const READ_TOOL_PATH_KEYS = ["path", "file_path", "filePath"];
 const TOOL_NAME_MAX_LENGTH = 128;
 const TOOL_NAME_PATTERN = /^[a-z0-9._-]+$/;
 const TOOL_KIND_BY_ID = new Map<string, string>([
-  ["read", "read"],
   ["search", "search"],
   ["web_search", "search"],
 ]);
@@ -98,105 +95,12 @@ function resolveToolNameForPermission(params: RequestPermissionRequest): string 
   return normalizeToolName(fromMeta ?? fromRawInput ?? fromTitle ?? "");
 }
 
-function extractPathFromToolTitle(
-  toolTitle: string | undefined,
-  toolName: string | undefined,
-): string | undefined {
-  if (!toolTitle) {
-    return undefined;
-  }
-  const separator = toolTitle.indexOf(":");
-  if (separator < 0) {
-    return undefined;
-  }
-  const tail = toolTitle.slice(separator + 1).trim();
-  if (!tail) {
-    return undefined;
-  }
-  const keyedMatch = tail.match(/(?:^|,\s*)(?:path|file_path|filePath)\s*:\s*([^,]+)/);
-  if (keyedMatch?.[1]) {
-    return keyedMatch[1].trim();
-  }
-  if (toolName === "read") {
-    return tail;
-  }
-  return undefined;
-}
-
-function resolveToolPathCandidate(
-  params: RequestPermissionRequest,
-  toolName: string | undefined,
-  toolTitle: string | undefined,
-): string | undefined {
-  const rawInput = asRecord(params.toolCall?.rawInput);
-  const fromRawInput = readFirstStringValue(rawInput, READ_TOOL_PATH_KEYS);
-  const fromTitle = extractPathFromToolTitle(toolTitle, toolName);
-  return fromRawInput ?? fromTitle;
-}
-
-function resolveAbsoluteScopedPath(value: string, cwd: string): string | undefined {
-  let candidate = value.trim();
-  if (!candidate) {
-    return undefined;
-  }
-  if (candidate.startsWith("file://")) {
-    try {
-      const parsed = new URL(candidate);
-      candidate = decodeURIComponent(parsed.pathname || "");
-    } catch {
-      return undefined;
-    }
-  }
-  if (candidate === "~") {
-    candidate = homedir();
-  } else if (candidate.startsWith("~/")) {
-    candidate = path.join(homedir(), candidate.slice(2));
-  }
-  const absolute = path.isAbsolute(candidate)
-    ? path.normalize(candidate)
-    : path.resolve(cwd, candidate);
-  return absolute;
-}
-
-function isPathWithinRoot(candidatePath: string, root: string): boolean {
-  const relative = path.relative(root, candidatePath);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-}
-
-function isReadToolCallScopedToCwd(
-  params: RequestPermissionRequest,
-  toolName: string | undefined,
-  toolTitle: string | undefined,
-  cwd: string,
-): boolean {
-  if (toolName !== "read") {
-    return false;
-  }
-  const rawPath = resolveToolPathCandidate(params, toolName, toolTitle);
-  if (!rawPath) {
-    return false;
-  }
-  const absolutePath = resolveAbsoluteScopedPath(rawPath, cwd);
-  if (!absolutePath) {
-    return false;
-  }
-  return isPathWithinRoot(absolutePath, path.resolve(cwd));
-}
-
-function shouldAutoApproveToolCall(
-  params: RequestPermissionRequest,
-  toolName: string | undefined,
-  toolTitle: string | undefined,
-  cwd: string,
-): boolean {
+function shouldAutoApproveToolCall(toolName: string | undefined): boolean {
   const isTrustedToolId =
     typeof toolName === "string" &&
     (isKnownCoreToolId(toolName) || TRUSTED_SAFE_TOOL_ALIASES.has(toolName));
   if (!toolName || !isTrustedToolId || !SAFE_AUTO_APPROVE_TOOL_IDS.has(toolName)) {
     return false;
-  }
-  if (toolName === "read") {
-    return isReadToolCallScopedToCwd(params, toolName, toolTitle, cwd);
   }
   return true;
 }
@@ -268,7 +172,6 @@ export async function resolvePermissionRequest(
 ): Promise<RequestPermissionResponse> {
   const log = deps.log ?? ((line: string) => console.error(line));
   const prompt = deps.prompt ?? promptUserPermission;
-  const cwd = deps.cwd ?? process.cwd();
   const options = params.options ?? [];
   const toolTitle = params.toolCall?.title ?? "tool";
   const toolName = resolveToolNameForPermission(params);
@@ -281,7 +184,7 @@ export async function resolvePermissionRequest(
 
   const allowOption = pickOption(options, ["allow_once", "allow_always"]);
   const rejectOption = pickOption(options, ["reject_once", "reject_always"]);
-  const autoApproveAllowed = shouldAutoApproveToolCall(params, toolName, toolTitle, cwd);
+  const autoApproveAllowed = shouldAutoApproveToolCall(toolName);
   const promptRequired = !toolName || !autoApproveAllowed || DANGEROUS_ACP_TOOLS.has(toolName);
 
   if (!promptRequired) {

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -39,13 +39,6 @@ const CORE_TOOL_SECTION_ORDER: Array<{ id: string; label: string }> = [
 
 const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   {
-    id: "read",
-    label: "read",
-    description: "Read file contents",
-    sectionId: "fs",
-    profiles: ["coding"],
-  },
-  {
     id: "write",
     label: "write",
     description: "Create or overwrite files",

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -150,43 +150,6 @@ export function resolvePathArg(args: unknown): string | undefined {
   return undefined;
 }
 
-export function resolveReadDetail(args: unknown): string | undefined {
-  const record = asRecord(args);
-  if (!record) {
-    return undefined;
-  }
-
-  const path = resolvePathArg(record);
-  if (!path) {
-    return undefined;
-  }
-
-  const offsetRaw =
-    typeof record.offset === "number" && Number.isFinite(record.offset)
-      ? Math.floor(record.offset)
-      : undefined;
-  const limitRaw =
-    typeof record.limit === "number" && Number.isFinite(record.limit)
-      ? Math.floor(record.limit)
-      : undefined;
-
-  const offset = offsetRaw !== undefined ? Math.max(1, offsetRaw) : undefined;
-  const limit = limitRaw !== undefined ? Math.max(1, limitRaw) : undefined;
-
-  if (offset !== undefined && limit !== undefined) {
-    const unit = limit === 1 ? "line" : "lines";
-    return `${unit} ${offset}-${offset + limit - 1} from ${path}`;
-  }
-  if (offset !== undefined) {
-    return `from line ${offset} in ${path}`;
-  }
-  if (limit !== undefined) {
-    const unit = limit === 1 ? "line" : "lines";
-    return `first ${limit} ${unit} of ${path}`;
-  }
-  return `from ${path}`;
-}
-
 export function resolveWriteDetail(toolKey: string, args: unknown): string | undefined {
   const record = asRecord(args);
   if (!record) {

--- a/src/agents/tool-display.json
+++ b/src/agents/tool-display.json
@@ -30,11 +30,6 @@
       "title": "Exec",
       "detailKeys": ["command"]
     },
-    "read": {
-      "emoji": "📖",
-      "title": "Read",
-      "detailKeys": ["path"]
-    },
     "write": {
       "emoji": "✍️",
       "title": "Write",

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -52,13 +52,7 @@ describe("tool display details", () => {
     expect(detail).toContain("tools true");
   });
 
-  it("formats read/write/edit with intent-first file detail", () => {
-    const readDetail = formatToolDetail(
-      resolveToolDisplay({
-        name: "read",
-        args: { file_path: "/tmp/a.txt", offset: 2, limit: 2 },
-      }),
-    );
+  it("formats write/edit with intent-first file detail", () => {
     const writeDetail = formatToolDetail(
       resolveToolDisplay({
         name: "write",
@@ -72,7 +66,6 @@ describe("tool display details", () => {
       }),
     );
 
-    expect(readDetail).toBe("lines 2-3 from /tmp/a.txt");
     expect(writeDetail).toBe("to /tmp/a.txt (3 chars)");
     expect(editDetail).toBe("in /tmp/a.txt (4 chars)");
   });

--- a/src/agents/tool-display.ts
+++ b/src/agents/tool-display.ts
@@ -8,7 +8,6 @@ import {
   resolveActionSpec,
   resolveDetailFromKeys,
   resolveExecDetail,
-  resolveReadDetail,
   resolveWebFetchDetail,
   resolveWebSearchDetail,
   resolveWriteDetail,
@@ -86,9 +85,6 @@ export function resolveToolDisplay(params: {
   let detail: string | undefined;
   if (key === "exec") {
     detail = resolveExecDetail(params.args);
-  }
-  if (!detail && key === "read") {
-    detail = resolveReadDetail(params.args);
   }
   if (!detail && (key === "write" || key === "edit" || key === "attach")) {
     detail = resolveWriteDetail(key, params.args);

--- a/src/channels/status-reactions.test.ts
+++ b/src/channels/status-reactions.test.ts
@@ -426,7 +426,7 @@ describe("createStatusReactionController", () => {
 
 describe("constants", () => {
   it("should export CODING_TOOL_TOKENS", () => {
-    for (const token of ["exec", "read", "write"]) {
+    for (const token of ["exec", "write"]) {
       expect(CODING_TOOL_TOKENS).toContain(token);
     }
   });

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -68,14 +68,7 @@ export const DEFAULT_TIMING: Required<StatusReactionTiming> = {
   errorHoldMs: 2500,
 };
 
-export const CODING_TOOL_TOKENS: string[] = [
-  "exec",
-  "read",
-  "write",
-  "edit",
-  "session_status",
-  "bash",
-];
+export const CODING_TOOL_TOKENS: string[] = ["exec", "write", "edit", "session_status", "bash"];
 
 export const WEB_TOOL_TOKENS: string[] = [
   "web_search",

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -451,9 +451,7 @@ function collectRiskyToolExposureContexts(cfg: OpenClawConfig): {
       agentId: context.agentId ?? null,
     });
     const runtimeTools = ["exec"].filter((tool) => isToolAllowedByPolicies(tool, policies));
-    const fsTools = ["read", "write", "edit"].filter((tool) =>
-      isToolAllowedByPolicies(tool, policies),
-    );
+    const fsTools = ["write", "edit"].filter((tool) => isToolAllowedByPolicies(tool, policies));
     const fsWorkspaceOnly = context.tools?.fs?.workspaceOnly ?? cfg.tools?.fs?.workspaceOnly;
     const runtimeUnguarded = runtimeTools.length > 0 && sandboxMode !== "all";
     const fsUnguarded = fsTools.length > 0 && sandboxMode !== "all" && fsWorkspaceOnly !== true;

--- a/ui/src/ui/tool-display.json
+++ b/ui/src/ui/tool-display.json
@@ -35,11 +35,6 @@
       "title": "Process",
       "detailKeys": ["sessionId"]
     },
-    "read": {
-      "icon": "fileText",
-      "title": "Read",
-      "detailKeys": ["path"]
-    },
     "write": {
       "icon": "edit",
       "title": "Write",

--- a/ui/src/ui/tool-display.ts
+++ b/ui/src/ui/tool-display.ts
@@ -5,7 +5,6 @@ import {
   resolveActionSpec,
   resolveDetailFromKeys,
   resolveExecDetail,
-  resolveReadDetail,
   resolveWebFetchDetail,
   resolveWebSearchDetail,
   resolveWriteDetail,
@@ -86,9 +85,6 @@ export function resolveToolDisplay(params: {
   let detail: string | undefined;
   if (key === "exec") {
     detail = resolveExecDetail(params.args);
-  }
-  if (!detail && key === "read") {
-    detail = resolveReadDetail(params.args);
   }
   if (!detail && (key === "write" || key === "edit" || key === "attach")) {
     detail = resolveWriteDetail(key, params.args);


### PR DESCRIPTION
## Summary

- Remove `read` from `CORE_TOOL_DEFINITIONS` in tool catalog
- Remove `read` display entries from server and UI `tool-display.json`
- Remove `resolveReadDetail()` function (~36 lines) and its call sites in both server and UI `tool-display.ts`
- Remove `read` from ACP auto-approve set, tool-kind map, and delete the entire cwd-scoped path resolution infrastructure (`extractPathFromToolTitle`, `resolveToolPathCandidate`, `resolveAbsoluteScopedPath`, `isPathWithinRoot`, `isReadToolCallScopedToCwd` — ~90 lines)
- Remove `read` from `fsTools` in security audit
- Remove `read` from `CODING_TOOL_TOKENS` in status reactions
- Update tests: remove read-specific ACP scope tests, update assertions

~257 lines removed across 12 files.

Closes #170

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm tsgo` passes (typecheck clean)
- [x] `pnpm format` passes
- [x] All 4 changed test files pass (82 tests): `tool-display.test.ts`, `client.test.ts`, `status-reactions.test.ts`, `audit-extra.sync.test.ts`
- [x] Full `pnpm test` passes (991/992 files; 1 failure is pre-existing worker timeout in unrelated `slack.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)