### PR TITLE
fix: remove dead write tool infrastructure (#171)

### DIFF
--- a/src/acp/event-mapper.ts
+++ b/src/acp/event-mapper.ts
@@ -132,7 +132,7 @@ export function inferToolKind(name?: string): ToolKind {
   if (normalized.includes("read")) {
     return "read";
   }
-  if (normalized.includes("write") || normalized.includes("edit")) {
+  if (normalized.includes("edit")) {
     return "edit";
   }
   if (normalized.includes("delete") || normalized.includes("remove")) {

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -39,13 +39,6 @@ const CORE_TOOL_SECTION_ORDER: Array<{ id: string; label: string }> = [
 
 const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   {
-    id: "write",
-    label: "write",
-    description: "Create or overwrite files",
-    sectionId: "fs",
-    profiles: ["coding"],
-  },
-  {
     id: "edit",
     label: "edit",
     description: "Make precise edits",

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -166,7 +166,7 @@ export function resolveWriteDetail(toolKey: string, args: unknown): string | und
     return `from ${path}`;
   }
 
-  const destinationPrefix = toolKey === "edit" ? "in" : "to";
+  const destinationPrefix = "in";
   const content =
     typeof record.content === "string"
       ? record.content

--- a/src/agents/tool-display.json
+++ b/src/agents/tool-display.json
@@ -30,11 +30,6 @@
       "title": "Exec",
       "detailKeys": ["command"]
     },
-    "write": {
-      "emoji": "✍️",
-      "title": "Write",
-      "detailKeys": ["path"]
-    },
     "edit": {
       "emoji": "📝",
       "title": "Edit",

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -52,13 +52,7 @@ describe("tool display details", () => {
     expect(detail).toContain("tools true");
   });
 
-  it("formats write/edit with intent-first file detail", () => {
-    const writeDetail = formatToolDetail(
-      resolveToolDisplay({
-        name: "write",
-        args: { file_path: "/tmp/a.txt", content: "abc" },
-      }),
-    );
+  it("formats edit with intent-first file detail", () => {
     const editDetail = formatToolDetail(
       resolveToolDisplay({
         name: "edit",
@@ -66,7 +60,6 @@ describe("tool display details", () => {
       }),
     );
 
-    expect(writeDetail).toBe("to /tmp/a.txt (3 chars)");
     expect(editDetail).toBe("in /tmp/a.txt (4 chars)");
   });
 

--- a/src/agents/tool-display.ts
+++ b/src/agents/tool-display.ts
@@ -79,7 +79,7 @@ export function resolveToolDisplay(params: {
   if (key === "exec") {
     detail = resolveExecDetail(params.args);
   }
-  if (!detail && (key === "write" || key === "edit" || key === "attach")) {
+  if (!detail && (key === "edit" || key === "attach")) {
     detail = resolveWriteDetail(key, params.args);
   }
 

--- a/src/agents/tool-policy.plugin-only-allowlist.test.ts
+++ b/src/agents/tool-policy.plugin-only-allowlist.test.ts
@@ -5,7 +5,7 @@ const pluginGroups: PluginToolGroups = {
   all: ["lobster", "workflow_tool"],
   byPlugin: new Map([["lobster", ["lobster", "workflow_tool"]]]),
 };
-const coreTools = new Set(["read", "write", "exec", "session_status"]);
+const coreTools = new Set(["exec", "session_status"]);
 
 describe("stripPluginOnlyAllowlist", () => {
   it("strips allowlist when it only targets plugin tools", () => {
@@ -28,11 +28,11 @@ describe("stripPluginOnlyAllowlist", () => {
 
   it("keeps allowlist when it mixes plugin and core entries", () => {
     const policy = stripPluginOnlyAllowlist(
-      { allow: ["lobster", "read"] },
+      { allow: ["lobster", "exec"] },
       pluginGroups,
       coreTools,
     );
-    expect(policy.policy?.allow).toEqual(["lobster", "read"]);
+    expect(policy.policy?.allow).toEqual(["lobster", "exec"]);
     expect(policy.unknownAllowlist).toEqual([]);
   });
 
@@ -46,11 +46,11 @@ describe("stripPluginOnlyAllowlist", () => {
   it("keeps allowlist with core tools and reports unknown entries", () => {
     const emptyPlugins: PluginToolGroups = { all: [], byPlugin: new Map() };
     const policy = stripPluginOnlyAllowlist(
-      { allow: ["read", "lobster"] },
+      { allow: ["exec", "lobster"] },
       emptyPlugins,
       coreTools,
     );
-    expect(policy.policy?.allow).toEqual(["read", "lobster"]);
+    expect(policy.policy?.allow).toEqual(["exec", "lobster"]);
     expect(policy.unknownAllowlist).toEqual(["lobster"]);
   });
 });

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -43,14 +43,12 @@ describe("tool-policy", () => {
     const set = new Set(expanded);
     expect(set.has("exec")).toBe(true);
     expect(set.has("bash")).toBe(false);
-    expect(set.has("read")).toBe(true);
-    expect(set.has("write")).toBe(true);
     expect(set.has("edit")).toBe(true);
   });
 
   it("resolves known profiles and ignores unknown ones", () => {
     const coding = resolveToolProfilePolicy("coding");
-    expect(coding?.allow).toContain("read");
+    expect(coding?.allow).toContain("edit");
     expect(coding?.allow).toContain("cron");
     expect(coding?.allow).not.toContain("gateway");
     expect(resolveToolProfilePolicy("nope")).toBeUndefined();

--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -634,8 +634,6 @@
         }
         return `[read: ${display}]`;
       }
-      case "write":
-        return `[write: ${shortenPath(String(args.path || args.file_path || ""))}]`;
       case "edit":
         return `[edit: ${shortenPath(String(args.path || args.file_path || ""))}]`;
       case "bash": {
@@ -1101,33 +1099,6 @@
           const lang = filePath ? getLanguageFromPath(filePath) : null;
           if (output) {
             html += formatExpandableOutput(output, 10, lang);
-          }
-        }
-        break;
-      }
-      case "write": {
-        const filePath = str(args.file_path ?? args.path);
-        const content = str(args.content);
-
-        html += `<div class="tool-header"><span class="tool-name">write</span> <span class="tool-path">${filePath === null ? invalidArg : escapeHtml(shortenPath(filePath || ""))}</span>`;
-        if (content !== null && content) {
-          const lines = content.split("\n");
-          if (lines.length > 10) {
-            html += ` <span class="line-count">(${lines.length} lines)</span>`;
-          }
-        }
-        html += "</div>";
-
-        if (content === null) {
-          html += `<div class="tool-error">[invalid content arg - expected string]</div>`;
-        } else if (content) {
-          const lang = filePath ? getLanguageFromPath(filePath) : null;
-          html += formatExpandableOutput(content, 10, lang);
-        }
-        if (result) {
-          const output = getResultText().trim();
-          if (output) {
-            html += `<div class="tool-output"><div>${escapeHtml(output)}</div></div>`;
           }
         }
         break;

--- a/src/channels/status-reactions.test.ts
+++ b/src/channels/status-reactions.test.ts
@@ -421,13 +421,13 @@ describe("createStatusReactionController", () => {
 
 describe("constants", () => {
   it("should export CODING_TOOL_TOKENS", () => {
-    for (const token of ["exec", "write"]) {
+    for (const token of ["exec", "edit"]) {
       expect(CODING_TOOL_TOKENS).toContain(token);
     }
   });
 
   it("should export WEB_TOOL_TOKENS", () => {
-    for (const token of ["web_fetch", "browser"]) {
+    for (const token of ["browser"]) {
       expect(WEB_TOOL_TOKENS).toContain(token);
     }
   });

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -68,7 +68,7 @@ export const DEFAULT_TIMING: Required<StatusReactionTiming> = {
   errorHoldMs: 2500,
 };
 
-export const CODING_TOOL_TOKENS: string[] = ["exec", "write", "edit", "session_status", "bash"];
+export const CODING_TOOL_TOKENS: string[] = ["exec", "edit", "session_status", "bash"];
 
 export const WEB_TOOL_TOKENS: string[] = ["browser"];
 

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -451,7 +451,7 @@ function collectRiskyToolExposureContexts(cfg: OpenClawConfig): {
       agentId: context.agentId ?? null,
     });
     const runtimeTools = ["exec"].filter((tool) => isToolAllowedByPolicies(tool, policies));
-    const fsTools = ["write", "edit"].filter((tool) => isToolAllowedByPolicies(tool, policies));
+    const fsTools = ["edit"].filter((tool) => isToolAllowedByPolicies(tool, policies));
     const fsWorkspaceOnly = context.tools?.fs?.workspaceOnly ?? cfg.tools?.fs?.workspaceOnly;
     const runtimeUnguarded = runtimeTools.length > 0 && sandboxMode !== "all";
     const fsUnguarded = fsTools.length > 0 && sandboxMode !== "all" && fsWorkspaceOnly !== true;

--- a/src/security/dangerous-tools.ts
+++ b/src/security/dangerous-tools.ts
@@ -25,7 +25,6 @@ export const DEFAULT_GATEWAY_HTTP_TOOL_DENY = [
  */
 export const DANGEROUS_ACP_TOOL_NAMES = [
   "exec",
-  "write",
   "sessions_spawn",
   "sessions_send",
   "gateway",


### PR DESCRIPTION
## Summary

- Remove all remnants of the gutted `write` tool across 10 source files: catalog entry, display config (JSON + call site + resolver write-path), ACP dangerous classification, ACP event mapper, security audit, status reactions, and HTML export template handlers
- Keep shared `resolveWriteDetail()` function for `edit`/`attach` — #172 handles edit removal
- Mutation tracking ACs skipped (file already deleted by #177)
- Fix pre-existing broken test assertions left by #170 (read) and #175 (web_fetch)

Closes #171

## Test plan

- [x] `pnpm build` passes
- [x] Targeted test suite passes (66/66 tests in affected files)
- [x] Pre-existing lint error in `plugins/manifest.ts` confirmed unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)