### PR TITLE
fix: remove dead edit tool infrastructure

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -353,7 +353,7 @@ describe("resolveAgentConfig", () => {
             workspace: "~/openclaw-restricted",
             tools: {
               allow: ["read"],
-              deny: ["exec", "write", "edit"],
+              deny: ["exec", "write"],
               elevated: {
                 enabled: false,
                 allowFrom: { whatsapp: ["+15555550123"] },
@@ -366,7 +366,7 @@ describe("resolveAgentConfig", () => {
     const result = resolveAgentConfig(cfg, "restricted");
     expect(result?.tools).toEqual({
       allow: ["read"],
-      deny: ["exec", "write", "edit"],
+      deny: ["exec", "write"],
       elevated: {
         enabled: false,
         allowFrom: { whatsapp: ["+15555550123"] },

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -25,7 +25,6 @@ type CoreToolDefinition = {
 };
 
 const CORE_TOOL_SECTION_ORDER: Array<{ id: string; label: string }> = [
-  { id: "fs", label: "Files" },
   { id: "web", label: "Web" },
   { id: "sessions", label: "Sessions" },
   { id: "ui", label: "UI" },
@@ -37,13 +36,6 @@ const CORE_TOOL_SECTION_ORDER: Array<{ id: string; label: string }> = [
 ];
 
 const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
-  {
-    id: "edit",
-    label: "edit",
-    description: "Make precise edits",
-    sectionId: "fs",
-    profiles: ["coding"],
-  },
   {
     id: "sessions_list",
     label: "sessions_list",

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -166,21 +166,7 @@ export function resolveWriteDetail(toolKey: string, args: unknown): string | und
     return `from ${path}`;
   }
 
-  const destinationPrefix = "in";
-  const content =
-    typeof record.content === "string"
-      ? record.content
-      : typeof record.newText === "string"
-        ? record.newText
-        : typeof record.new_string === "string"
-          ? record.new_string
-          : undefined;
-
-  if (content && content.length > 0) {
-    return `${destinationPrefix} ${path} (${content.length} chars)`;
-  }
-
-  return `${destinationPrefix} ${path}`;
+  return undefined;
 }
 
 export function resolveActionSpec(

--- a/src/agents/tool-display.json
+++ b/src/agents/tool-display.json
@@ -25,11 +25,6 @@
     ]
   },
   "tools": {
-    "edit": {
-      "emoji": "📝",
-      "title": "Edit",
-      "detailKeys": ["path"]
-    },
     "attach": {
       "emoji": "📎",
       "title": "Attach",

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -51,15 +51,4 @@ describe("tool display details", () => {
     expect(detail).toContain("limit 20");
     expect(detail).toContain("tools true");
   });
-
-  it("formats edit with intent-first file detail", () => {
-    const editDetail = formatToolDetail(
-      resolveToolDisplay({
-        name: "edit",
-        args: { path: "/tmp/a.txt", newText: "abcd" },
-      }),
-    );
-
-    expect(editDetail).toBe("in /tmp/a.txt (4 chars)");
-  });
 });

--- a/src/agents/tool-display.ts
+++ b/src/agents/tool-display.ts
@@ -75,7 +75,7 @@ export function resolveToolDisplay(params: {
   const verb = normalizeVerb(actionSpec?.label ?? action ?? fallbackVerb);
 
   let detail: string | undefined;
-  if (key === "edit" || key === "attach") {
+  if (key === "attach") {
     detail = resolveWriteDetail(key, params.args);
   }
 

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -39,15 +39,14 @@ function createOwnerPolicyTools() {
 
 describe("tool-policy", () => {
   it("expands groups and normalizes names", () => {
-    const expanded = expandToolGroups(["BASH", "group:fs"]);
+    const expanded = expandToolGroups(["BASH", "group:sessions"]);
     const set = new Set(expanded);
     expect(set.has("bash")).toBe(true);
-    expect(set.has("edit")).toBe(true);
+    expect(set.has("sessions_list")).toBe(true);
   });
 
   it("resolves known profiles and ignores unknown ones", () => {
     const coding = resolveToolProfilePolicy("coding");
-    expect(coding?.allow).toContain("edit");
     expect(coding?.allow).toContain("cron");
     expect(coding?.allow).not.toContain("gateway");
     expect(resolveToolProfilePolicy("nope")).toBeUndefined();

--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -634,8 +634,6 @@
         }
         return `[read: ${display}]`;
       }
-      case "edit":
-        return `[edit: ${shortenPath(String(args.path || args.file_path || ""))}]`;
       case "bash": {
         const rawCmd = String(args.command || "");
         const cmd = rawCmd
@@ -1099,30 +1097,6 @@
           const lang = filePath ? getLanguageFromPath(filePath) : null;
           if (output) {
             html += formatExpandableOutput(output, 10, lang);
-          }
-        }
-        break;
-      }
-      case "edit": {
-        const filePath = str(args.file_path ?? args.path);
-        html += `<div class="tool-header"><span class="tool-name">edit</span> <span class="tool-path">${filePath === null ? invalidArg : escapeHtml(shortenPath(filePath || ""))}</span></div>`;
-
-        if (result?.details?.diff) {
-          const diffLines = result.details.diff.split("\n");
-          html += '<div class="tool-diff">';
-          for (const line of diffLines) {
-            const cls = line.match(/^\+/)
-              ? "diff-added"
-              : line.match(/^-/)
-                ? "diff-removed"
-                : "diff-context";
-            html += `<div class="${cls}">${escapeHtml(replaceTabs(line))}</div>`;
-          }
-          html += "</div>";
-        } else if (result) {
-          const output = getResultText().trim();
-          if (output) {
-            html += `<div class="tool-output"><pre>${escapeHtml(output)}</pre></div>`;
           }
         }
         break;

--- a/src/channels/status-reactions.test.ts
+++ b/src/channels/status-reactions.test.ts
@@ -66,7 +66,7 @@ describe("resolveToolEmoji", () => {
     tool: string | undefined;
     expected: string;
   }> = [
-    { name: "returns coding emoji for exec tool", tool: "exec", expected: DEFAULT_EMOJIS.coding },
+    { name: "returns coding emoji for bash tool", tool: "bash", expected: DEFAULT_EMOJIS.coding },
     { name: "returns web emoji for browser tool", tool: "browser", expected: DEFAULT_EMOJIS.web },
     {
       name: "returns tool emoji for unknown tool",
@@ -75,10 +75,10 @@ describe("resolveToolEmoji", () => {
     },
     { name: "returns tool emoji for empty string", tool: "", expected: DEFAULT_EMOJIS.tool },
     { name: "returns tool emoji for undefined", tool: undefined, expected: DEFAULT_EMOJIS.tool },
-    { name: "is case-insensitive", tool: "EXEC", expected: DEFAULT_EMOJIS.coding },
+    { name: "is case-insensitive", tool: "BASH", expected: DEFAULT_EMOJIS.coding },
     {
       name: "matches tokens within tool names",
-      tool: "my_exec_wrapper",
+      tool: "my_bash_wrapper",
       expected: DEFAULT_EMOJIS.coding,
     },
   ];
@@ -141,7 +141,7 @@ describe("createStatusReactionController", () => {
   it("should classify tool name and debounce", async () => {
     const { calls, controller } = createEnabledController();
 
-    void controller.setTool("exec");
+    void controller.setTool("bash");
     await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
 
     expect(calls).toContainEqual({ method: "set", emoji: DEFAULT_EMOJIS.coding });
@@ -185,7 +185,7 @@ describe("createStatusReactionController", () => {
       terminal: (controller: ReturnType<typeof createStatusReactionController>) =>
         controller.setError(),
       followup: (controller: ReturnType<typeof createStatusReactionController>) => {
-        void controller.setTool("exec");
+        void controller.setTool("bash");
       },
     },
   ] as const;
@@ -212,10 +212,10 @@ describe("createStatusReactionController", () => {
     void controller.setTool("web_fetch");
     await vi.advanceTimersByTimeAsync(100);
 
-    void controller.setTool("exec");
+    void controller.setTool("bash");
     await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
 
-    // Should only have the last one (exec → coding)
+    // Should only have the last one (bash → coding)
     const setEmojis = calls.filter((c) => c.method === "set").map((c) => c.emoji);
     expect(setEmojis).toEqual([DEFAULT_EMOJIS.coding]);
   });
@@ -367,7 +367,7 @@ describe("createStatusReactionController", () => {
     {
       name: "phase change",
       runUpdate: (controller: ReturnType<typeof createStatusReactionController>) => {
-        void controller.setTool("exec");
+        void controller.setTool("bash");
         return vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
       },
     },
@@ -421,7 +421,7 @@ describe("createStatusReactionController", () => {
 
 describe("constants", () => {
   it("should export CODING_TOOL_TOKENS", () => {
-    for (const token of ["exec", "edit"]) {
+    for (const token of ["session_status", "bash"]) {
       expect(CODING_TOOL_TOKENS).toContain(token);
     }
   });

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -68,7 +68,7 @@ export const DEFAULT_TIMING: Required<StatusReactionTiming> = {
   errorHoldMs: 2500,
 };
 
-export const CODING_TOOL_TOKENS: string[] = ["edit", "session_status", "bash"];
+export const CODING_TOOL_TOKENS: string[] = ["session_status", "bash"];
 
 export const WEB_TOOL_TOKENS: string[] = ["browser"];
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -525,7 +525,7 @@ export const FIELD_HELP: Record<string, string> = {
   "approvals.exec.targets[].threadId":
     "Optional thread/topic target for channels that support threaded delivery of forwarded approvals. Use this to keep approval traffic contained in operational threads instead of main channels.",
   "tools.fs.workspaceOnly":
-    "Restrict filesystem tools (read/write/edit) to the workspace directory (default: false).",
+    "Restrict filesystem tools to the workspace directory (default: false).",
   "tools.sessions.visibility":
     'Controls which sessions can be targeted by sessions_list/sessions_history/sessions_send. ("tree" default = current session + spawned subagent sessions; "self" = only current; "agent" = any session in the current agent id; "all" = any session; cross-agent still requires tools.agentToAgent).',
   "tools.message.allowCrossContextSend":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -233,7 +233,7 @@ export type ExecToolConfig = {
 
 export type FsToolsConfig = {
   /**
-   * Restrict filesystem tools (read/write/edit) to the agent workspace directory.
+   * Restrict filesystem tools to the agent workspace directory.
    * Default: false (unrestricted, matches legacy behavior).
    */
   workspaceOnly?: boolean;

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -444,27 +444,14 @@ function collectRiskyToolExposureContexts(cfg: OpenClawConfig): {
   let hasRuntimeRisk = false;
   for (const context of contexts) {
     const sandboxMode = resolveSandboxConfigForAgent(cfg, context.agentId).mode;
-    const policies = resolveToolPolicies({
-      cfg,
-      agentTools: context.tools,
-      sandboxMode,
-      agentId: context.agentId ?? null,
-    });
     const runtimeTools: string[] = [];
-    const fsTools = ["edit"].filter((tool) => isToolAllowedByPolicies(tool, policies));
-    const fsWorkspaceOnly = context.tools?.fs?.workspaceOnly ?? cfg.tools?.fs?.workspaceOnly;
     const runtimeUnguarded = runtimeTools.length > 0 && sandboxMode !== "all";
-    const fsUnguarded = fsTools.length > 0 && sandboxMode !== "all" && fsWorkspaceOnly !== true;
-    if (!runtimeUnguarded && !fsUnguarded) {
+    if (!runtimeUnguarded) {
       continue;
     }
-    if (runtimeUnguarded) {
-      hasRuntimeRisk = true;
-    }
+    hasRuntimeRisk = true;
     riskyContexts.push(
-      `${context.label} (sandbox=${sandboxMode}; runtime=[${runtimeTools.join(", ") || "off"}]; fs=[${fsTools.join(", ") || "off"}]; fs.workspaceOnly=${
-        fsWorkspaceOnly === true ? "true" : "false"
-      })`,
+      `${context.label} (sandbox=${sandboxMode}; runtime=[${runtimeTools.join(", ") || "off"}])`,
     );
   }
 

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -2082,24 +2082,6 @@ describe("security audit", () => {
     );
   });
 
-  it("flags open groupPolicy when filesystem tools are exposed without guards", async () => {
-    const cfg: OpenClawConfig = {
-      channels: { whatsapp: { groupPolicy: "open" } },
-      tools: { elevated: { enabled: false } },
-    };
-
-    const res = await audit(cfg);
-
-    expect(res.findings).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          checkId: "security.exposure.open_groups_with_runtime_or_fs",
-          severity: "warn",
-        }),
-      ]),
-    );
-  });
-
   it("does not flag runtime/filesystem exposure for open groups when runtime is denied and fs is workspace-only", async () => {
     const cfg: OpenClawConfig = {
       channels: { whatsapp: { groupPolicy: "open" } },

--- a/ui/src/ui/tool-display.json
+++ b/ui/src/ui/tool-display.json
@@ -40,11 +40,6 @@
       "title": "Write",
       "detailKeys": ["path"]
     },
-    "edit": {
-      "icon": "penLine",
-      "title": "Edit",
-      "detailKeys": ["path"]
-    },
     "attach": {
       "icon": "paperclip",
       "title": "Attach",


### PR DESCRIPTION
## Summary

Closes #172.

- Remove `edit` from `CORE_TOOL_DEFINITIONS` and empty `fs` section from `CORE_TOOL_SECTION_ORDER`
- Remove file-edit entry from `tool-display.json` (server + UI); keep `message:edit` action intact
- Remove `edit` path from `resolveWriteDetail()` call site and clean up dead code path (only `attach` remains)
- Remove `edit` from `CODING_TOOL_TOKENS` in status reactions
- Remove dead `fsTools` check from security audit (`audit-extra.sync.ts`)
- Remove `edit` cases from HTML export template
- Update doc comments in `types.tools.ts` and `schema.help.ts`
- Remove obsolete test for fs-tool exposure in open groups (no embedded fs tools remain)
- Fix pre-existing `exec` references in `status-reactions.test.ts` (broken since #184)

## Test plan

- [x] `pnpm build` passes
- [x] All affected test files pass (tool-policy, tool-display, status-reactions, agent-scope, security/audit)
- [x] Full test suite passes (854 tests, 93 files)
- [x] Pre-existing lint error in `plugins/manifest.ts` is unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)