### PR TITLE
rebrand: rename npm package and CLI binary to remoteclaw (#130)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,5 +61,5 @@ USER node
 #
 # For container platforms requiring external health checks:
 #   1. Set REMOTECLAW_GATEWAY_TOKEN or REMOTECLAW_GATEWAY_PASSWORD env var
-#   2. Override CMD: ["node","openclaw.mjs","gateway","--allow-unconfigured","--bind","lan"]
-CMD ["node", "openclaw.mjs", "gateway", "--allow-unconfigured"]
+#   2. Override CMD: ["node","remoteclaw.mjs","gateway","--allow-unconfigured","--bind","lan"]
+CMD ["node", "remoteclaw.mjs", "gateway", "--allow-unconfigured"]

--- a/apps/macos/Sources/OpenClaw/CommandResolver.swift
+++ b/apps/macos/Sources/OpenClaw/CommandResolver.swift
@@ -2,12 +2,12 @@ import Foundation
 
 enum CommandResolver {
     private static let projectRootDefaultsKey = "openclaw.gatewayProjectRootPath"
-    private static let helperName = "openclaw"
+    private static let helperName = "remoteclaw"
 
     static func gatewayEntrypoint(in root: URL) -> String? {
         let distEntry = root.appendingPathComponent("dist/index.js").path
         if FileManager().isReadableFile(atPath: distEntry) { return distEntry }
-        let openclawEntry = root.appendingPathComponent("openclaw.mjs").path
+        let openclawEntry = root.appendingPathComponent("remoteclaw.mjs").path
         if FileManager().isReadableFile(atPath: openclawEntry) { return openclawEntry }
         let binEntry = root.appendingPathComponent("bin/openclaw.js").path
         if FileManager().isReadableFile(atPath: binEntry) { return binEntry }
@@ -210,7 +210,7 @@ enum CommandResolver {
     static func nodeCliPath() -> String? {
         let root = self.projectRoot()
         let candidates = [
-            root.appendingPathComponent("openclaw.mjs").path,
+            root.appendingPathComponent("remoteclaw.mjs").path,
             root.appendingPathComponent("bin/openclaw.js").path,
         ]
         for candidate in candidates where FileManager().isReadableFile(atPath: candidate) {
@@ -270,13 +270,13 @@ enum CommandResolver {
 
         if let pnpm = self.findExecutable(named: "pnpm", searchPaths: searchPaths) {
             // Use --silent to avoid pnpm lifecycle banners that would corrupt JSON outputs.
-            return [pnpm, "--silent", "openclaw", subcommand] + extraArgs
+            return [pnpm, "--silent", "remoteclaw", subcommand] + extraArgs
         }
 
         switch runtimeResult {
         case .success:
             let missingEntry = """
-            openclaw entrypoint missing (looked for dist/index.js or openclaw.mjs); run pnpm build.
+            openclaw entrypoint missing (looked for dist/index.js or remoteclaw.mjs); run pnpm build.
             """
             return self.errorCommand(with: missingEntry)
         case let .failure(error):
@@ -371,10 +371,10 @@ enum CommandResolver {
           else
             echo "Node >=22 required on remote host"; exit 127;
           fi
-        elif [ -n "${PRJ:-}" ] && [ -f "$PRJ/openclaw.mjs" ]; then
+        elif [ -n "${PRJ:-}" ] && [ -f "$PRJ/remoteclaw.mjs" ]; then
           if command -v node >/dev/null 2>&1; then
-            CLI="node $PRJ/openclaw.mjs"
-            node "$PRJ/openclaw.mjs" \(quotedArgs);
+            CLI="node $PRJ/remoteclaw.mjs"
+            node "$PRJ/remoteclaw.mjs" \(quotedArgs);
           else
             echo "Node >=22 required on remote host"; exit 127;
           fi

--- a/docs/cli/acp.md
+++ b/docs/cli/acp.md
@@ -46,7 +46,7 @@ openclaw acp client
 openclaw acp client --server-args --url wss://gateway-host:18789 --token-file ~/.openclaw/gateway.token
 
 # Override the server command (default: openclaw)
-openclaw acp client --server "node" --server-args openclaw.mjs acp --url ws://127.0.0.1:19001
+openclaw acp client --server "node" --server-args remoteclaw.mjs acp --url ws://127.0.0.1:19001
 ```
 
 Permission model (client debug mode):

--- a/docs/debug/node-issue.md
+++ b/docs/debug/node-issue.md
@@ -65,10 +65,10 @@ node --import tsx scripts/repro/tsx-name-repro.ts
 
   ```bash
   pnpm exec tsc --watch --preserveWatchOutput
-  node --watch openclaw.mjs status
+  node --watch remoteclaw.mjs status
   ```
 
-- Confirmed locally: `pnpm exec tsc -p tsconfig.json` + `node openclaw.mjs status` works on Node 25.
+- Confirmed locally: `pnpm exec tsc -p tsconfig.json` + `node remoteclaw.mjs status` works on Node 25.
 - Disable esbuild keepNames in the TS loader if possible (prevents `__name` helper insertion); tsx does not currently expose this.
 - Test Node LTS (22/24) with `tsx` to see if the issue is Node 25–specific.
 

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -161,7 +161,7 @@ openclaw health
 
 Notes:
 
-- `pnpm build` matters when you run the packaged `openclaw` binary ([`openclaw.mjs`](https://github.com/openclaw/openclaw/blob/main/openclaw.mjs)) or use Node to run `dist/`.
+- `pnpm build` matters when you run the packaged `remoteclaw` binary ([`remoteclaw.mjs`](https://github.com/remoteclaw/remoteclaw/blob/main/remoteclaw.mjs)) or use Node to run `dist/`.
 - If you run from a repo checkout without a global install, use `pnpm openclaw ...` for CLI commands.
 - If you run directly from TypeScript (`pnpm openclaw ...`), a rebuild is usually unnecessary, but **config migrations still apply** → run doctor.
 - Switching between global and git installs is easy: install the other flavor, then run `openclaw doctor` so the gateway service entrypoint is rewritten to the current install.

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -24,7 +24,7 @@ When the operator says “release”, immediately do this preflight (no extra qu
 - [ ] Bump `package.json` version (e.g., `2026.1.29`).
 - [ ] Run `pnpm plugins:sync` to align extension package versions + changelogs.
 - [ ] Update CLI/version strings in [`src/version.ts`](https://github.com/openclaw/openclaw/blob/main/src/version.ts) and the Baileys user agent in [`src/web/session.ts`](https://github.com/openclaw/openclaw/blob/main/src/web/session.ts).
-- [ ] Confirm package metadata (name, description, repository, keywords, license) and `bin` map points to [`openclaw.mjs`](https://github.com/openclaw/openclaw/blob/main/openclaw.mjs) for `openclaw`.
+- [ ] Confirm package metadata (name, description, repository, keywords, license) and `bin` map points to [`remoteclaw.mjs`](https://github.com/remoteclaw/remoteclaw/blob/main/remoteclaw.mjs) for `remoteclaw`.
 - [ ] If dependencies changed, run `pnpm install` so `pnpm-lock.yaml` is current.
 
 2. **Build & artifacts**

--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -53,7 +53,7 @@ If you don’t have a global install yet, run it via `pnpm openclaw setup`.
 After `pnpm build`, you can run the packaged CLI directly:
 
 ```bash
-node openclaw.mjs gateway --port 18789 --verbose
+node remoteclaw.mjs gateway --port 18789 --verbose
 ```
 
 ## Stable workflow (macOS app first)

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
-  "name": "openclaw",
+  "name": "remoteclaw",
   "version": "2026.2.25",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
-  "homepage": "https://github.com/openclaw/openclaw#readme",
+  "homepage": "https://github.com/remoteclaw/remoteclaw#readme",
   "bugs": {
-    "url": "https://github.com/openclaw/openclaw/issues"
+    "url": "https://github.com/remoteclaw/remoteclaw/issues"
   },
   "license": "MIT",
   "author": "",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openclaw/openclaw.git"
+    "url": "git+https://github.com/remoteclaw/remoteclaw.git"
   },
   "bin": {
-    "openclaw": "openclaw.mjs"
+    "remoteclaw": "remoteclaw.mjs"
   },
   "directories": {
     "doc": "docs",
@@ -23,7 +23,7 @@
   "files": [
     "CHANGELOG.md",
     "LICENSE",
-    "openclaw.mjs",
+    "remoteclaw.mjs",
     "README-header.png",
     "README.md",
     "assets/",
@@ -44,7 +44,7 @@
       "types": "./dist/plugin-sdk/account-id.d.ts",
       "default": "./dist/plugin-sdk/account-id.js"
     },
-    "./cli-entry": "./openclaw.mjs"
+    "./cli-entry": "./remoteclaw.mjs"
   },
   "scripts": {
     "android:assemble": "cd apps/android && ./gradlew :app:assembleDebug",
@@ -99,14 +99,14 @@
     "mac:package": "bash scripts/package-mac-app.sh",
     "mac:restart": "bash scripts/restart-mac.sh",
     "moltbot:rpc": "node scripts/run-node.mjs agent --mode rpc --json",
-    "openclaw": "node scripts/run-node.mjs",
-    "openclaw:rpc": "node scripts/run-node.mjs agent --mode rpc --json",
     "prepack": "pnpm build && pnpm ui:build",
     "prepare": "command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath git-hooks || exit 0",
     "protocol:check": "pnpm protocol:gen && pnpm protocol:gen:swift && git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift",
     "protocol:gen": "node --import tsx scripts/protocol-gen.ts",
     "protocol:gen:swift": "node --import tsx scripts/protocol-gen-swift.ts",
     "release:check": "node --import tsx scripts/release-check.ts",
+    "remoteclaw": "node scripts/run-node.mjs",
+    "remoteclaw:rpc": "node scripts/run-node.mjs agent --mode rpc --json",
     "start": "node scripts/run-node.mjs",
     "test": "node scripts/test-parallel.mjs",
     "test:all": "pnpm lint && pnpm build && pnpm test && pnpm test:e2e && pnpm test:live && pnpm test:docker:all",

--- a/remoteclaw.mjs
+++ b/remoteclaw.mjs
@@ -52,5 +52,5 @@ if (await tryImport("./dist/entry.js")) {
 } else if (await tryImport("./dist/entry.mjs")) {
   // OK
 } else {
-  throw new Error("openclaw: missing dist/entry.(m)js (build output).");
+  throw new Error("remoteclaw: missing dist/entry.(m)js (build output).");
 }

--- a/scripts/e2e/Dockerfile
+++ b/scripts/e2e/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 ENV NODE_OPTIONS="--disable-warning=ExperimentalWarning"
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json tsconfig.plugin-sdk.dts.json tsdown.config.ts vitest.config.ts vitest.e2e.config.ts openclaw.mjs ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json tsconfig.plugin-sdk.dts.json tsdown.config.ts vitest.config.ts vitest.e2e.config.ts remoteclaw.mjs ./
 COPY src ./src
 COPY test ./test
 COPY scripts ./scripts

--- a/scripts/e2e/doctor-install-switch-docker.sh
+++ b/scripts/e2e/doctor-install-switch-docker.sh
@@ -93,7 +93,7 @@ LOGINCTL
 	  else
 	    git_entry="/app/dist/index.js"
 	  fi
-	  git_cli="/app/openclaw.mjs"
+	  git_cli="/app/remoteclaw.mjs"
 
   assert_entrypoint() {
     local unit_path="$1"

--- a/scripts/restart-mac.sh
+++ b/scripts/restart-mac.sh
@@ -96,8 +96,8 @@ for arg in "$@"; do
       log "  REMOTECLAW_GATEWAY_WAIT_SECONDS=0  Wait time before gateway port check (unsigned only)"
       log ""
       log "Unsigned recovery:"
-      log "  node openclaw.mjs daemon install --force --runtime node"
-      log "  node openclaw.mjs daemon restart"
+      log "  node remoteclaw.mjs daemon install --force --runtime node"
+      log "  node remoteclaw.mjs daemon restart"
       log ""
       log "Reset unsigned overrides:"
       log "  rm ~/.openclaw/disable-launchagent"
@@ -217,8 +217,8 @@ fi
 # When unsigned, ensure the gateway LaunchAgent targets the repo CLI (before the app launches).
 # This reduces noisy "could not connect" errors during app startup.
 if [ "$NO_SIGN" -eq 1 ] && [ "$ATTACH_ONLY" -ne 1 ]; then
-  run_step "install gateway launch agent (unsigned)" bash -lc "cd '${ROOT_DIR}' && node openclaw.mjs daemon install --force --runtime node"
-  run_step "restart gateway daemon (unsigned)" bash -lc "cd '${ROOT_DIR}' && node openclaw.mjs daemon restart"
+  run_step "install gateway launch agent (unsigned)" bash -lc "cd '${ROOT_DIR}' && node remoteclaw.mjs daemon install --force --runtime node"
+  run_step "restart gateway daemon (unsigned)" bash -lc "cd '${ROOT_DIR}' && node remoteclaw.mjs daemon restart"
   if [[ "${GATEWAY_WAIT_SECONDS}" -gt 0 ]]; then
     run_step "wait for gateway (unsigned)" sleep "${GATEWAY_WAIT_SECONDS}"
   fi

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -177,7 +177,7 @@ const logRunner = (message, deps) => {
 };
 
 const runOpenClaw = async (deps) => {
-  const nodeProcess = deps.spawn(deps.execPath, ["openclaw.mjs", ...deps.args], {
+  const nodeProcess = deps.spawn(deps.execPath, ["remoteclaw.mjs", ...deps.args], {
     cwd: deps.cwd,
     env: deps.env,
     stdio: "inherit",

--- a/scripts/shell-helpers/clawdock-helpers.sh
+++ b/scripts/shell-helpers/clawdock-helpers.sh
@@ -194,7 +194,7 @@ clawdock-workspace() {
 # Container Access
 clawdock-shell() {
   _clawdock_compose exec openclaw-gateway \
-    bash -c 'echo "alias openclaw=\"./openclaw.mjs\"" > /tmp/.bashrc_openclaw && bash --rcfile /tmp/.bashrc_openclaw'
+    bash -c 'echo "alias remoteclaw=\"./remoteclaw.mjs\"" > /tmp/.bashrc_remoteclaw && bash --rcfile /tmp/.bashrc_remoteclaw'
 }
 
 clawdock-exec() {
@@ -249,12 +249,12 @@ clawdock-fix-token() {
   echo "📝 Setting token: ${token:0:20}..."
 
   _clawdock_compose exec -e "TOKEN=$token" openclaw-gateway \
-    bash -c './openclaw.mjs config set gateway.remote.token "$TOKEN" && ./openclaw.mjs config set gateway.auth.token "$TOKEN"' 2>&1 | _clawdock_filter_warnings
+    bash -c './remoteclaw.mjs config set gateway.remote.token "$TOKEN" && ./remoteclaw.mjs config set gateway.auth.token "$TOKEN"' 2>&1 | _clawdock_filter_warnings
 
   echo "🔍 Verifying token was saved..."
   local saved_token
   saved_token=$(_clawdock_compose exec openclaw-gateway \
-    bash -c "./openclaw.mjs config get gateway.remote.token 2>/dev/null" 2>&1 | _clawdock_filter_warnings | tr -d '\r\n' | head -c 64)
+    bash -c "./remoteclaw.mjs config get gateway.remote.token 2>/dev/null" 2>&1 | _clawdock_filter_warnings | tr -d '\r\n' | head -c 64)
 
   if [[ "$saved_token" == "$token" ]]; then
     echo "✅ Token saved correctly!"

--- a/src/agents/workspace-templates.test.ts
+++ b/src/agents/workspace-templates.test.ts
@@ -11,7 +11,7 @@ import {
 const tempDirs: string[] = [];
 
 async function makeTempRoot(): Promise<string> {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-templates-"));
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-templates-"));
   tempDirs.push(root);
   return root;
 }
@@ -26,7 +26,7 @@ describe("resolveWorkspaceTemplateDir", () => {
 
   it("resolves templates from package root when module url is dist-rooted", async () => {
     const root = await makeTempRoot();
-    await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
+    await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "remoteclaw" }));
 
     const templatesDir = path.join(root, "docs", "reference", "templates");
     await fs.mkdir(templatesDir, { recursive: true });
@@ -42,7 +42,7 @@ describe("resolveWorkspaceTemplateDir", () => {
 
   it("falls back to package-root docs path when templates directory is missing", async () => {
     const root = await makeTempRoot();
-    await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
+    await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "remoteclaw" }));
 
     const distDir = path.join(root, "dist");
     await fs.mkdir(distDir, { recursive: true });

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -256,7 +256,7 @@ export async function resolveGlobalManager(params: {
 }
 
 export async function tryWriteCompletionCache(root: string, jsonMode: boolean): Promise<void> {
-  const binPath = path.join(root, "openclaw.mjs");
+  const binPath = path.join(root, "remoteclaw.mjs");
   if (!(await pathExists(binPath))) {
     return;
   }

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -27,7 +27,7 @@ async function generateCompletionCache(): Promise<boolean> {
     return false;
   }
 
-  const binPath = path.join(root, "openclaw.mjs");
+  const binPath = path.join(root, "remoteclaw.mjs");
   const result = spawnSync(process.execPath, [binPath, "completion", "--write-state"], {
     cwd: root,
     env: process.env,

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -11,8 +11,8 @@ import { installProcessWarningFilter } from "./infra/warning-filter.js";
 import { attachChildProcessBridge } from "./process/child-process-bridge.js";
 
 const ENTRY_WRAPPER_PAIRS = [
-  { wrapperBasename: "openclaw.mjs", entryBasename: "entry.js" },
-  { wrapperBasename: "openclaw.js", entryBasename: "entry.js" },
+  { wrapperBasename: "remoteclaw.mjs", entryBasename: "entry.js" },
+  { wrapperBasename: "remoteclaw.js", entryBasename: "entry.js" },
 ] as const;
 
 // Guard: only run entry-point logic when this file is the main module.

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -136,10 +136,10 @@ describe("control UI assets helpers (fs-mocked)", () => {
 
   it("falls back to package.json name matching when root resolution fails", async () => {
     const root = abs("fixtures/fallback");
-    setFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
+    setFile(path.join(root, "package.json"), JSON.stringify({ name: "remoteclaw" }));
     setFile(path.join(root, "dist", "control-ui", "index.html"), "<html></html>\n");
 
-    await expect(resolveControlUiDistIndexPath(path.join(root, "openclaw.mjs"))).resolves.toBe(
+    await expect(resolveControlUiDistIndexPath(path.join(root, "remoteclaw.mjs"))).resolves.toBe(
       path.join(root, "dist", "control-ui", "index.html"),
     );
   });

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -91,7 +91,7 @@ export async function resolveControlUiDistIndexPath(
     return path.join(packageRoot, "dist", "control-ui", "index.html");
   }
 
-  // Fallback: traverse up and find package.json with name "openclaw" + dist/control-ui/index.html
+  // Fallback: traverse up and find package.json with name "remoteclaw" + dist/control-ui/index.html
   // This handles global installs where path-based resolution might fail.
   let dir = path.dirname(normalized);
   for (let i = 0; i < 8; i++) {
@@ -101,7 +101,7 @@ export async function resolveControlUiDistIndexPath(
       try {
         const raw = fs.readFileSync(pkgJsonPath, "utf-8");
         const parsed = JSON.parse(raw) as { name?: unknown };
-        if (parsed.name === "openclaw") {
+        if (parsed.name === "remoteclaw") {
           return fs.existsSync(indexPath) ? indexPath : null;
         }
         // Stop at the first package boundary to avoid resolving through unrelated ancestors.
@@ -183,7 +183,7 @@ export function resolveControlUiRootSync(opts: ControlUiRootResolveOptions = {})
     addCandidate(candidates, path.join(moduleDir, "../../dist/control-ui"));
   }
   if (argv1Dir) {
-    // openclaw.mjs or dist/<bundle>.js
+    // remoteclaw.mjs or dist/<bundle>.js
     addCandidate(candidates, path.join(argv1Dir, "dist", "control-ui"));
     addCandidate(candidates, path.join(argv1Dir, "control-ui"));
   }

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -66,7 +66,7 @@ function isGatewayArgv(args: string[]): boolean {
   const entryCandidates = [
     "dist/index.js",
     "dist/entry.js",
-    "openclaw.mjs",
+    "remoteclaw.mjs",
     "scripts/run-node.mjs",
     "src/index.ts",
   ];
@@ -75,7 +75,7 @@ function isGatewayArgv(args: string[]): boolean {
   }
 
   const exe = normalized[0] ?? "";
-  return exe.endsWith("/openclaw") || exe === "openclaw";
+  return exe.endsWith("/remoteclaw") || exe === "remoteclaw";
 }
 
 function readLinuxCmdline(pid: number): string[] | null {

--- a/src/infra/infra-parsing.test.ts
+++ b/src/infra/infra-parsing.test.ts
@@ -56,14 +56,14 @@ describe("infra parsing", () => {
       ).toBe(true);
     });
 
-    it("returns true for dist/entry.js when launched via openclaw.mjs wrapper", () => {
+    it("returns true for dist/entry.js when launched via remoteclaw.mjs wrapper", () => {
       expect(
         isMainModule({
           currentFile: "/repo/dist/entry.js",
-          argv: ["node", "/repo/openclaw.mjs"],
+          argv: ["node", "/repo/remoteclaw.mjs"],
           cwd: "/repo",
           env: {},
-          wrapperEntryPairs: [{ wrapperBasename: "openclaw.mjs", entryBasename: "entry.js" }],
+          wrapperEntryPairs: [{ wrapperBasename: "remoteclaw.mjs", entryBasename: "entry.js" }],
         }),
       ).toBe(true);
     });
@@ -72,7 +72,7 @@ describe("infra parsing", () => {
       expect(
         isMainModule({
           currentFile: "/repo/dist/entry.js",
-          argv: ["node", "/repo/openclaw.mjs"],
+          argv: ["node", "/repo/remoteclaw.mjs"],
           cwd: "/repo",
           env: {},
         }),
@@ -83,10 +83,10 @@ describe("infra parsing", () => {
       expect(
         isMainModule({
           currentFile: "/repo/dist/index.js",
-          argv: ["node", "/repo/openclaw.mjs"],
+          argv: ["node", "/repo/remoteclaw.mjs"],
           cwd: "/repo",
           env: {},
-          wrapperEntryPairs: [{ wrapperBasename: "openclaw.mjs", entryBasename: "entry.js" }],
+          wrapperEntryPairs: [{ wrapperBasename: "remoteclaw.mjs", entryBasename: "entry.js" }],
         }),
       ).toBe(false);
     });

--- a/src/infra/openclaw-root.test.ts
+++ b/src/infra/openclaw-root.test.ts
@@ -106,36 +106,36 @@ describe("resolveRemoteClawPackageRoot", () => {
 
   it("resolves package root from .bin argv1", async () => {
     const project = fx("bin-scenario");
-    const argv1 = path.join(project, "node_modules", ".bin", "openclaw");
-    const pkgRoot = path.join(project, "node_modules", "openclaw");
-    setFile(path.join(pkgRoot, "package.json"), JSON.stringify({ name: "openclaw" }));
+    const argv1 = path.join(project, "node_modules", ".bin", "remoteclaw");
+    const pkgRoot = path.join(project, "node_modules", "remoteclaw");
+    setFile(path.join(pkgRoot, "package.json"), JSON.stringify({ name: "remoteclaw" }));
 
     expect(resolveRemoteClawPackageRootSync({ argv1 })).toBe(pkgRoot);
   });
 
   it("resolves package root via symlinked argv1", async () => {
     const project = fx("symlink-scenario");
-    const bin = path.join(project, "bin", "openclaw");
+    const bin = path.join(project, "bin", "remoteclaw");
     const realPkg = path.join(project, "real-pkg");
-    state.realpaths.set(abs(bin), abs(path.join(realPkg, "openclaw.mjs")));
-    setFile(path.join(realPkg, "package.json"), JSON.stringify({ name: "openclaw" }));
+    state.realpaths.set(abs(bin), abs(path.join(realPkg, "remoteclaw.mjs")));
+    setFile(path.join(realPkg, "package.json"), JSON.stringify({ name: "remoteclaw" }));
 
     expect(resolveRemoteClawPackageRootSync({ argv1: bin })).toBe(realPkg);
   });
 
   it("falls back when argv1 realpath throws", async () => {
     const project = fx("realpath-throw-scenario");
-    const argv1 = path.join(project, "node_modules", ".bin", "openclaw");
-    const pkgRoot = path.join(project, "node_modules", "openclaw");
+    const argv1 = path.join(project, "node_modules", ".bin", "remoteclaw");
+    const pkgRoot = path.join(project, "node_modules", "remoteclaw");
     state.realpathErrors.add(abs(argv1));
-    setFile(path.join(pkgRoot, "package.json"), JSON.stringify({ name: "openclaw" }));
+    setFile(path.join(pkgRoot, "package.json"), JSON.stringify({ name: "remoteclaw" }));
 
     expect(resolveRemoteClawPackageRootSync({ argv1 })).toBe(pkgRoot);
   });
 
   it("prefers moduleUrl candidates", async () => {
     const pkgRoot = fx("moduleurl");
-    setFile(path.join(pkgRoot, "package.json"), JSON.stringify({ name: "openclaw" }));
+    setFile(path.join(pkgRoot, "package.json"), JSON.stringify({ name: "remoteclaw" }));
     const moduleUrl = pathToFileURL(path.join(pkgRoot, "dist", "index.js")).toString();
 
     expect(resolveRemoteClawPackageRootSync({ moduleUrl })).toBe(pkgRoot);
@@ -150,7 +150,7 @@ describe("resolveRemoteClawPackageRoot", () => {
 
   it("async resolver matches sync behavior", async () => {
     const pkgRoot = fx("async");
-    setFile(path.join(pkgRoot, "package.json"), JSON.stringify({ name: "openclaw" }));
+    setFile(path.join(pkgRoot, "package.json"), JSON.stringify({ name: "remoteclaw" }));
 
     await expect(resolveRemoteClawPackageRoot({ cwd: pkgRoot })).resolves.toBe(pkgRoot);
   });

--- a/src/infra/openclaw-root.ts
+++ b/src/infra/openclaw-root.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const CORE_PACKAGE_NAMES = new Set(["openclaw"]);
+const CORE_PACKAGE_NAMES = new Set(["remoteclaw"]);
 
 async function readPackageName(dir: string): Promise<string | null> {
   try {

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -62,7 +62,7 @@ describe("run-node script", () => {
         expect(exitCode).toBe(0);
         await expect(fs.readFile(argsPath, "utf-8")).resolves.toContain("exec tsdown --no-clean");
         await expect(fs.readFile(indexPath, "utf-8")).resolves.toContain("sentinel");
-        expect(nodeCalls).toEqual([[process.execPath, "openclaw.mjs", "--version"]]);
+        expect(nodeCalls).toEqual([[process.execPath, "remoteclaw.mjs", "--version"]]);
       });
     },
   );

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -42,7 +42,7 @@ describe("runGatewayUpdate", () => {
   beforeEach(async () => {
     tempDir = path.join(fixtureRoot, `case-${caseId++}`);
     await fs.mkdir(tempDir, { recursive: true });
-    await fs.writeFile(path.join(tempDir, "openclaw.mjs"), "export {};\n", "utf-8");
+    await fs.writeFile(path.join(tempDir, "remoteclaw.mjs"), "export {};\n", "utf-8");
   });
 
   afterEach(async () => {
@@ -57,7 +57,7 @@ describe("runGatewayUpdate", () => {
   }) {
     const calls: string[] = [];
     let uiBuildCount = 0;
-    const doctorKey = `${process.execPath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
+    const doctorKey = `${process.execPath} ${path.join(tempDir, "remoteclaw.mjs")} doctor --non-interactive --fix`;
 
     const runCommand = async (argv: string[]) => {
       const key = argv.join(" ");
@@ -259,7 +259,7 @@ describe("runGatewayUpdate", () => {
       "pnpm install": { stdout: "" },
       "pnpm build": { stdout: "" },
       "pnpm ui:build": { stdout: "" },
-      [`${process.execPath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`]:
+      [`${process.execPath} ${path.join(tempDir, "remoteclaw.mjs")} doctor --non-interactive --fix`]:
         {
           stdout: "",
         },
@@ -458,13 +458,13 @@ describe("runGatewayUpdate", () => {
     cwdSpy.mockRestore();
 
     expect(result.status).toBe("error");
-    expect(result.reason).toBe("not-openclaw-root");
+    expect(result.reason).toBe("not-remoteclaw-root");
     expect(calls.some((call) => call.includes("status --porcelain"))).toBe(false);
   });
 
-  it("fails with a clear reason when openclaw.mjs is missing", async () => {
+  it("fails with a clear reason when remoteclaw.mjs is missing", async () => {
     await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
-    await fs.rm(path.join(tempDir, "openclaw.mjs"), { force: true });
+    await fs.rm(path.join(tempDir, "remoteclaw.mjs"), { force: true });
 
     const stableTag = "v1.0.1-1";
     const { runner } = createRunner({
@@ -478,7 +478,7 @@ describe("runGatewayUpdate", () => {
 
     expect(result.status).toBe("error");
     expect(result.reason).toBe("doctor-entry-missing");
-    expect(result.steps.at(-1)?.name).toBe("openclaw doctor entry");
+    expect(result.steps.at(-1)?.name).toBe("remoteclaw doctor entry");
   });
 
   it("repairs UI assets when doctor run removes control-ui files", async () => {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -373,7 +373,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       status: "error",
       mode: "unknown",
       root: gitRoot,
-      reason: "not-openclaw-root",
+      reason: "not-remoteclaw-root",
       steps: [],
       durationMs: Date.now() - startedAt,
     };
@@ -747,14 +747,14 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       };
     }
 
-    const doctorEntry = path.join(gitRoot, "openclaw.mjs");
+    const doctorEntry = path.join(gitRoot, "remoteclaw.mjs");
     const doctorEntryExists = await fs
       .stat(doctorEntry)
       .then(() => true)
       .catch(() => false);
     if (!doctorEntryExists) {
       steps.push({
-        name: "openclaw doctor entry",
+        name: "remoteclaw doctor entry",
         command: `verify ${doctorEntry}`,
         cwd: gitRoot,
         durationMs: 0,


### PR DESCRIPTION
## Summary

- Rename `openclaw.mjs` → `remoteclaw.mjs` (CLI binary entry point)
- Update `package.json` identity fields: `name`, `bin`, `homepage`, `bugs`, `repository`
- Update `package.json` packaging fields: `files`, `exports["./cli-entry"]`
- Rename `openclaw`/`openclaw:rpc` npm scripts to `remoteclaw`/`remoteclaw:rpc`
- Update all 27 files referencing `openclaw.mjs` across source, tests, scripts, docs, Swift, and Docker configs
- Update `CORE_PACKAGE_NAMES` and fallback package name checks from `openclaw` to `remoteclaw`

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (985 test files, 8027 tests, 0 failures)
- [x] No remaining `openclaw.mjs` references outside `node_modules`

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)