### PR TITLE
ci: add lint job for format and lint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,28 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Format check
+        run: pnpm format:check
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Lint no-random-messaging
+        run: pnpm lint:tmp:no-random-messaging
+
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Adds a new `lint` job to the CI workflow that runs `format:check`, `oxlint`, and `no-random-messaging` checks
- These were previously local-only (`pnpm check`) — now they gate PRs alongside `build` and `test`
- All three checks pass cleanly on main today

## Test plan
- [ ] CI `lint` job passes on this PR
- [ ] CI `build` and `test` jobs still pass unchanged
- [ ] After merge, add `lint` to branch protection required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)