### PR TITLE
rebrand: update daemon service identifiers to remoteclaw (#193)

### DIFF
--- a/src/cli/daemon-cli.coverage.test.ts
+++ b/src/cli/daemon-cli.coverage.test.ts
@@ -138,7 +138,7 @@ describe("daemon-cli coverage", () => {
         REMOTECLAW_CONFIG_PATH: "/tmp/remoteclaw-daemon-state/remoteclaw.json",
         REMOTECLAW_GATEWAY_PORT: "19001",
       },
-      sourcePath: "/tmp/ai.openclaw.gateway.plist",
+      sourcePath: "/tmp/ai.remoteclaw.gateway.plist",
     });
 
     await runDaemonCommand(["daemon", "status", "--json"]);

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -34,7 +34,7 @@ describe("inspectGatewayRestart", () => {
     inspectPortUsage.mockResolvedValue({
       port: 18789,
       status: "busy",
-      listeners: [{ pid: 7001, ppid: 7000, commandLine: "openclaw-gateway" }],
+      listeners: [{ pid: 7001, ppid: 7000, commandLine: "remoteclaw-gateway" }],
       hints: [],
     });
 
@@ -53,7 +53,7 @@ describe("inspectGatewayRestart", () => {
     inspectPortUsage.mockResolvedValue({
       port: 18789,
       status: "busy",
-      listeners: [{ pid: 9000, ppid: 8999, commandLine: "openclaw-gateway" }],
+      listeners: [{ pid: 9000, ppid: 8999, commandLine: "remoteclaw-gateway" }],
       hints: [],
     });
 

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -326,7 +326,7 @@ describe("update-cli", () => {
     inspectPortUsage.mockResolvedValue({
       port: 18789,
       status: "busy",
-      listeners: [{ pid: 4242, command: "openclaw-gateway" }],
+      listeners: [{ pid: 4242, command: "remoteclaw-gateway" }],
       hints: [],
     });
     classifyPortListener.mockReturnValue("gateway");

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -39,7 +39,7 @@ describe("restart-helper", () => {
       });
       expect(scriptPath.endsWith(".sh")).toBe(true);
       expect(content).toContain("#!/bin/sh");
-      expect(content).toContain("systemctl --user restart 'openclaw-gateway.service'");
+      expect(content).toContain("systemctl --user restart 'remoteclaw-gateway.service'");
       // Script should self-cleanup
       expect(content).toContain('rm -f "$0"');
       await cleanupScript(scriptPath);
@@ -64,7 +64,7 @@ describe("restart-helper", () => {
       });
       expect(scriptPath.endsWith(".sh")).toBe(true);
       expect(content).toContain("#!/bin/sh");
-      expect(content).toContain("launchctl kickstart -k 'gui/501/ai.openclaw.gateway'");
+      expect(content).toContain("launchctl kickstart -k 'gui/501/ai.remoteclaw.gateway'");
       expect(content).toContain('rm -f "$0"');
       await cleanupScript(scriptPath);
     });
@@ -113,7 +113,7 @@ describe("restart-helper", () => {
       const { scriptPath, content } = await prepareAndReadScript({
         REMOTECLAW_PROFILE: "production",
       });
-      expect(content).toContain("openclaw-gateway-production.service");
+      expect(content).toContain("remoteclaw-gateway-production.service");
       await cleanupScript(scriptPath);
     });
 
@@ -124,7 +124,7 @@ describe("restart-helper", () => {
       const { scriptPath, content } = await prepareAndReadScript({
         REMOTECLAW_PROFILE: "staging",
       });
-      expect(content).toContain("gui/502/ai.openclaw.staging");
+      expect(content).toContain("gui/502/ai.remoteclaw.staging");
       await cleanupScript(scriptPath);
     });
 

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -267,7 +267,7 @@ vi.mock("../daemon/service.js", () => ({
     readRuntime: async () => ({ status: "running", pid: 1234 }),
     readCommand: async () => ({
       programArguments: ["node", "dist/entry.js", "gateway"],
-      sourcePath: "/tmp/Library/LaunchAgents/ai.openclaw.gateway.plist",
+      sourcePath: "/tmp/Library/LaunchAgents/ai.remoteclaw.gateway.plist",
     }),
   }),
 }));
@@ -280,7 +280,7 @@ vi.mock("../daemon/node-service.js", () => ({
     readRuntime: async () => ({ status: "running", pid: 4321 }),
     readCommand: async () => ({
       programArguments: ["node", "dist/entry.js", "node-host"],
-      sourcePath: "/tmp/Library/LaunchAgents/ai.openclaw.node.plist",
+      sourcePath: "/tmp/Library/LaunchAgents/ai.remoteclaw.node.plist",
     }),
   }),
 }));

--- a/src/daemon/constants.test.ts
+++ b/src/daemon/constants.test.ts
@@ -32,12 +32,12 @@ describe("resolveGatewayLaunchAgentLabel", () => {
   it("returns default label when no profile is set", () => {
     const result = resolveGatewayLaunchAgentLabel();
     expect(result).toBe(GATEWAY_LAUNCH_AGENT_LABEL);
-    expect(result).toBe("ai.openclaw.gateway");
+    expect(result).toBe("ai.remoteclaw.gateway");
   });
 
   it("returns profile-specific label when profile is set", () => {
     const result = resolveGatewayLaunchAgentLabel("dev");
-    expect(result).toBe("ai.openclaw.dev");
+    expect(result).toBe("ai.remoteclaw.dev");
   });
 });
 
@@ -45,12 +45,12 @@ describe("resolveGatewaySystemdServiceName", () => {
   it("returns default service name when no profile is set", () => {
     const result = resolveGatewaySystemdServiceName();
     expect(result).toBe(GATEWAY_SYSTEMD_SERVICE_NAME);
-    expect(result).toBe("openclaw-gateway");
+    expect(result).toBe("remoteclaw-gateway");
   });
 
   it("returns profile-specific service name when profile is set", () => {
     const result = resolveGatewaySystemdServiceName("dev");
-    expect(result).toBe("openclaw-gateway-dev");
+    expect(result).toBe("remoteclaw-gateway-dev");
   });
 });
 
@@ -131,8 +131,7 @@ describe("resolveGatewayServiceDescription", () => {
 });
 
 describe("LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES", () => {
-  it("includes known pre-rebrand gateway unit names", () => {
-    expect(LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES).toContain("clawdbot-gateway");
-    expect(LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES).toContain("moltbot-gateway");
+  it("is empty (RemoteClaw has no legacy service names)", () => {
+    expect(LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES).toEqual([]);
   });
 });

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -1,20 +1,17 @@
 // Default service labels (canonical + legacy compatibility)
-export const GATEWAY_LAUNCH_AGENT_LABEL = "ai.openclaw.gateway";
-export const GATEWAY_SYSTEMD_SERVICE_NAME = "openclaw-gateway";
+export const GATEWAY_LAUNCH_AGENT_LABEL = "ai.remoteclaw.gateway";
+export const GATEWAY_SYSTEMD_SERVICE_NAME = "remoteclaw-gateway";
 export const GATEWAY_WINDOWS_TASK_NAME = "RemoteClaw Gateway";
-export const GATEWAY_SERVICE_MARKER = "openclaw";
+export const GATEWAY_SERVICE_MARKER = "remoteclaw";
 export const GATEWAY_SERVICE_KIND = "gateway";
-export const NODE_LAUNCH_AGENT_LABEL = "ai.openclaw.node";
-export const NODE_SYSTEMD_SERVICE_NAME = "openclaw-node";
+export const NODE_LAUNCH_AGENT_LABEL = "ai.remoteclaw.node";
+export const NODE_SYSTEMD_SERVICE_NAME = "remoteclaw-node";
 export const NODE_WINDOWS_TASK_NAME = "RemoteClaw Node";
-export const NODE_SERVICE_MARKER = "openclaw";
+export const NODE_SERVICE_MARKER = "remoteclaw";
 export const NODE_SERVICE_KIND = "node";
 export const NODE_WINDOWS_TASK_SCRIPT_NAME = "node.cmd";
 export const LEGACY_GATEWAY_LAUNCH_AGENT_LABELS: string[] = [];
-export const LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES: string[] = [
-  "clawdbot-gateway",
-  "moltbot-gateway",
-];
+export const LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES: string[] = [];
 export const LEGACY_GATEWAY_WINDOWS_TASK_NAMES: string[] = [];
 
 export function normalizeGatewayProfile(profile?: string): string | null {
@@ -35,7 +32,7 @@ export function resolveGatewayLaunchAgentLabel(profile?: string): string {
   if (!normalized) {
     return GATEWAY_LAUNCH_AGENT_LABEL;
   }
-  return `ai.openclaw.${normalized}`;
+  return `ai.remoteclaw.${normalized}`;
 }
 
 export function resolveLegacyGatewayLaunchAgentLabels(profile?: string): string[] {
@@ -48,7 +45,7 @@ export function resolveGatewaySystemdServiceName(profile?: string): string {
   if (!suffix) {
     return GATEWAY_SYSTEMD_SERVICE_NAME;
   }
-  return `openclaw-gateway${suffix}`;
+  return `remoteclaw-gateway${suffix}`;
 }
 
 export function resolveGatewayWindowsTaskName(profile?: string): string {

--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -44,7 +44,7 @@ describe("findExtraGatewayServices (win32)", () => {
     expect(result).toEqual([]);
   });
 
-  it("collects only non-openclaw marker tasks from schtasks output", async () => {
+  it("collects only non-remoteclaw marker tasks from schtasks output", async () => {
     execSchtasksMock.mockResolvedValueOnce({
       code: 0,
       stdout: [

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -14,7 +14,7 @@ export type ExtraGatewayService = {
   label: string;
   detail: string;
   scope: "user" | "system";
-  marker?: "openclaw" | "clawdbot" | "moltbot";
+  marker?: "remoteclaw" | "openclaw" | "clawdbot" | "moltbot";
   legacy?: boolean;
 };
 
@@ -22,7 +22,7 @@ export type FindExtraGatewayServicesOptions = {
   deep?: boolean;
 };
 
-const EXTRA_MARKERS = ["openclaw", "clawdbot", "moltbot"] as const;
+const EXTRA_MARKERS = ["remoteclaw", "openclaw", "clawdbot", "moltbot"] as const;
 
 export function renderGatewayServiceCleanupHints(
   env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
@@ -71,8 +71,8 @@ function detectMarker(content: string): Marker | null {
 
 function hasGatewayServiceMarker(content: string): boolean {
   const lower = content.toLowerCase();
-  const markerKeys = ["openclaw_service_marker"];
-  const kindKeys = ["openclaw_service_kind"];
+  const markerKeys = ["remoteclaw_service_marker"];
+  const kindKeys = ["remoteclaw_service_kind"];
   const markerValues = [GATEWAY_SERVICE_MARKER.toLowerCase()];
   const hasMarkerKey = markerKeys.some((key) => lower.includes(key));
   const hasKindKey = kindKeys.some((key) => lower.includes(key));
@@ -93,14 +93,14 @@ function isRemoteClawGatewayLaunchdService(label: string, contents: string): boo
   if (!lowerContents.includes("gateway")) {
     return false;
   }
-  return label.startsWith("ai.openclaw.");
+  return label.startsWith("ai.remoteclaw.");
 }
 
 function isRemoteClawGatewaySystemdService(name: string, contents: string): boolean {
   if (hasGatewayServiceMarker(contents)) {
     return true;
   }
-  if (!name.startsWith("openclaw-gateway")) {
+  if (!name.startsWith("remoteclaw-gateway")) {
     return false;
   }
   return contents.toLowerCase().includes("gateway");
@@ -112,7 +112,7 @@ function isRemoteClawGatewayTaskName(name: string): boolean {
     return false;
   }
   const defaultName = resolveGatewayWindowsTaskName().toLowerCase();
-  return normalized === defaultName || normalized.startsWith("openclaw gateway");
+  return normalized === defaultName || normalized.startsWith("remoteclaw gateway");
 }
 
 function tryExtractPlistLabel(contents: string): string | null {
@@ -216,7 +216,7 @@ async function scanLaunchdDir(params: {
     if (isIgnoredLaunchdLabel(label)) {
       continue;
     }
-    if (marker === "openclaw" && isRemoteClawGatewayLaunchdService(label, contents)) {
+    if (marker === "remoteclaw" && isRemoteClawGatewayLaunchdService(label, contents)) {
       continue;
     }
     results.push({
@@ -225,7 +225,7 @@ async function scanLaunchdDir(params: {
       detail: `plist: ${fullPath}`,
       scope: params.scope,
       marker,
-      legacy: marker !== "openclaw" || isLegacyLabel(label),
+      legacy: marker !== "remoteclaw" || isLegacyLabel(label),
     });
   }
 
@@ -248,7 +248,7 @@ async function scanSystemdDir(params: {
     if (!marker) {
       continue;
     }
-    if (marker === "openclaw" && isRemoteClawGatewaySystemdService(name, contents)) {
+    if (marker === "remoteclaw" && isRemoteClawGatewaySystemdService(name, contents)) {
       continue;
     }
     results.push({
@@ -257,7 +257,7 @@ async function scanSystemdDir(params: {
       detail: `unit: ${fullPath}`,
       scope: params.scope,
       marker,
-      legacy: marker !== "openclaw",
+      legacy: marker !== "remoteclaw",
     });
   }
 
@@ -422,7 +422,7 @@ export async function findExtraGatewayServices(
         detail: task.taskToRun ? `task: ${name}, run: ${task.taskToRun}` : name,
         scope: "system",
         marker,
-        legacy: marker !== "openclaw",
+        legacy: marker !== "remoteclaw",
       });
     }
     return results;

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -96,7 +96,7 @@ describe("launchd runtime parsing", () => {
 
 describe("launchctl list detection", () => {
   it("detects the resolved label in launchctl list", async () => {
-    state.listOutput = "123 0 ai.openclaw.gateway\n";
+    state.listOutput = "123 0 ai.remoteclaw.gateway\n";
     const listed = await isLaunchAgentListed({
       env: { HOME: "/Users/test", REMOTECLAW_PROFILE: "default" },
     });
@@ -122,7 +122,7 @@ describe("launchd bootstrap repair", () => {
     expect(repair.ok).toBe(true);
 
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-    const label = "ai.openclaw.gateway";
+    const label = "ai.remoteclaw.gateway";
     const plistPath = resolveLaunchAgentPlistPath(env);
 
     expect(state.launchctlCalls).toContainEqual(["bootstrap", domain, plistPath]);
@@ -147,7 +147,7 @@ describe("launchd install", () => {
     });
 
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-    const label = "ai.openclaw.gateway";
+    const label = "ai.remoteclaw.gateway";
     const plistPath = resolveLaunchAgentPlistPath(env);
     const serviceId = `${domain}/${label}`;
 
@@ -216,12 +216,12 @@ describe("resolveLaunchAgentPlistPath", () => {
     {
       name: "uses default label when REMOTECLAW_PROFILE is unset",
       env: { HOME: "/Users/test" },
-      expected: "/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist",
+      expected: "/Users/test/Library/LaunchAgents/ai.remoteclaw.gateway.plist",
     },
     {
       name: "uses profile-specific label when REMOTECLAW_PROFILE is set to a custom value",
       env: { HOME: "/Users/test", REMOTECLAW_PROFILE: "jbphoenix" },
-      expected: "/Users/test/Library/LaunchAgents/ai.openclaw.jbphoenix.plist",
+      expected: "/Users/test/Library/LaunchAgents/ai.remoteclaw.jbphoenix.plist",
     },
     {
       name: "prefers REMOTECLAW_LAUNCHD_LABEL over REMOTECLAW_PROFILE",
@@ -247,7 +247,7 @@ describe("resolveLaunchAgentPlistPath", () => {
         REMOTECLAW_PROFILE: "myprofile",
         REMOTECLAW_LAUNCHD_LABEL: "   ",
       },
-      expected: "/Users/test/Library/LaunchAgents/ai.openclaw.myprofile.plist",
+      expected: "/Users/test/Library/LaunchAgents/ai.remoteclaw.myprofile.plist",
     },
   ])("$name", ({ env, expected }) => {
     expect(resolveLaunchAgentPlistPath(env)).toBe(expected);

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -274,12 +274,12 @@ describe("buildServiceEnvironment", () => {
     }
     expect(env.REMOTECLAW_GATEWAY_PORT).toBe("18789");
     expect(env.REMOTECLAW_GATEWAY_TOKEN).toBe("secret");
-    expect(env.REMOTECLAW_SERVICE_MARKER).toBe("openclaw");
+    expect(env.REMOTECLAW_SERVICE_MARKER).toBe("remoteclaw");
     expect(env.REMOTECLAW_SERVICE_KIND).toBe("gateway");
     expect(typeof env.REMOTECLAW_SERVICE_VERSION).toBe("string");
-    expect(env.REMOTECLAW_SYSTEMD_UNIT).toBe("openclaw-gateway.service");
+    expect(env.REMOTECLAW_SYSTEMD_UNIT).toBe("remoteclaw-gateway.service");
     if (process.platform === "darwin") {
-      expect(env.REMOTECLAW_LAUNCHD_LABEL).toBe("ai.openclaw.gateway");
+      expect(env.REMOTECLAW_LAUNCHD_LABEL).toBe("ai.remoteclaw.gateway");
     }
   });
 
@@ -304,9 +304,9 @@ describe("buildServiceEnvironment", () => {
       env: { HOME: "/home/user", REMOTECLAW_PROFILE: "work" },
       port: 18789,
     });
-    expect(env.REMOTECLAW_SYSTEMD_UNIT).toBe("openclaw-gateway-work.service");
+    expect(env.REMOTECLAW_SYSTEMD_UNIT).toBe("remoteclaw-gateway-work.service");
     if (process.platform === "darwin") {
-      expect(env.REMOTECLAW_LAUNCHD_LABEL).toBe("ai.openclaw.work");
+      expect(env.REMOTECLAW_LAUNCHD_LABEL).toBe("ai.remoteclaw.work");
     }
   });
 });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -65,12 +65,12 @@ describe("resolveSystemdUserUnitPath", () => {
     {
       name: "uses default service name when REMOTECLAW_PROFILE is unset",
       env: { HOME: "/home/test" },
-      expected: "/home/test/.config/systemd/user/openclaw-gateway.service",
+      expected: "/home/test/.config/systemd/user/remoteclaw-gateway.service",
     },
     {
       name: "uses profile-specific service name when REMOTECLAW_PROFILE is set to a custom value",
       env: { HOME: "/home/test", REMOTECLAW_PROFILE: "jbphoenix" },
-      expected: "/home/test/.config/systemd/user/openclaw-gateway-jbphoenix.service",
+      expected: "/home/test/.config/systemd/user/remoteclaw-gateway-jbphoenix.service",
     },
     {
       name: "prefers REMOTECLAW_SYSTEMD_UNIT over REMOTECLAW_PROFILE",
@@ -158,7 +158,7 @@ describe("systemd service control", () => {
     execFileMock
       .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["--user", "stop", "openclaw-gateway.service"]);
+        expect(args).toEqual(["--user", "stop", "remoteclaw-gateway.service"]);
         cb(null, "", "");
       });
     const write = vi.fn();
@@ -174,7 +174,7 @@ describe("systemd service control", () => {
     execFileMock
       .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["--user", "restart", "openclaw-gateway-work.service"]);
+        expect(args).toEqual(["--user", "restart", "remoteclaw-gateway-work.service"]);
         cb(null, "", "");
       });
     const write = vi.fn();

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -106,7 +106,7 @@ function mockSuccessfulWakeConfig(nodeId: string) {
   mocks.loadApnsRegistration.mockResolvedValue({
     nodeId,
     token: "abcd1234abcd1234abcd1234abcd1234",
-    topic: "ai.openclaw.ios",
+    topic: "ai.remoteclaw.ios",
     environment: "sandbox",
     updatedAtMs: 1,
   });
@@ -122,7 +122,7 @@ function mockSuccessfulWakeConfig(nodeId: string) {
     ok: true,
     status: 200,
     tokenSuffix: "1234abcd",
-    topic: "ai.openclaw.ios",
+    topic: "ai.remoteclaw.ios",
     environment: "sandbox",
   });
 }

--- a/src/gateway/server-methods/push.test.ts
+++ b/src/gateway/server-methods/push.test.ts
@@ -69,7 +69,7 @@ describe("push.test handler", () => {
     vi.mocked(loadApnsRegistration).mockResolvedValue({
       nodeId: "ios-node-1",
       token: "abcd",
-      topic: "ai.openclaw.ios",
+      topic: "ai.remoteclaw.ios",
       environment: "sandbox",
       updatedAtMs: 1,
     });
@@ -86,7 +86,7 @@ describe("push.test handler", () => {
       ok: true,
       status: 200,
       tokenSuffix: "1234abcd",
-      topic: "ai.openclaw.ios",
+      topic: "ai.remoteclaw.ios",
       environment: "sandbox",
     });
 

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -37,7 +37,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
   });
 
   it("returns supervised when launchd/systemd hints are present", () => {
-    process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
+    process.env.LAUNCH_JOB_LABEL = "ai.remoteclaw.gateway";
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
     expect(spawnMock).not.toHaveBeenCalled();

--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -38,7 +38,7 @@ describe("push APNs registration store", () => {
     const saved = await registerApnsToken({
       nodeId: "ios-node-1",
       token: "ABCD1234ABCD1234ABCD1234ABCD1234",
-      topic: "ai.openclaw.ios",
+      topic: "ai.remoteclaw.ios",
       environment: "sandbox",
       baseDir,
     });
@@ -47,7 +47,7 @@ describe("push APNs registration store", () => {
     expect(loaded).not.toBeNull();
     expect(loaded?.nodeId).toBe("ios-node-1");
     expect(loaded?.token).toBe("abcd1234abcd1234abcd1234abcd1234");
-    expect(loaded?.topic).toBe("ai.openclaw.ios");
+    expect(loaded?.topic).toBe("ai.remoteclaw.ios");
     expect(loaded?.environment).toBe("sandbox");
     expect(loaded?.updatedAtMs).toBe(saved.updatedAtMs);
   });
@@ -58,7 +58,7 @@ describe("push APNs registration store", () => {
       registerApnsToken({
         nodeId: "ios-node-1",
         token: "not-a-token",
-        topic: "ai.openclaw.ios",
+        topic: "ai.remoteclaw.ios",
         baseDir,
       }),
     ).rejects.toThrow("invalid APNs token");
@@ -116,7 +116,7 @@ describe("push APNs send semantics", () => {
       registration: {
         nodeId: "ios-node-alert",
         token: "ABCD1234ABCD1234ABCD1234ABCD1234",
-        topic: "ai.openclaw.ios",
+        topic: "ai.remoteclaw.ios",
         environment: "sandbox",
         updatedAtMs: 1,
       },
@@ -160,7 +160,7 @@ describe("push APNs send semantics", () => {
       registration: {
         nodeId: "ios-node-wake",
         token: "ABCD1234ABCD1234ABCD1234ABCD1234",
-        topic: "ai.openclaw.ios",
+        topic: "ai.remoteclaw.ios",
         environment: "production",
         updatedAtMs: 1,
       },
@@ -207,7 +207,7 @@ describe("push APNs send semantics", () => {
       registration: {
         nodeId: "ios-node-wake-default-reason",
         token: "ABCD1234ABCD1234ABCD1234ABCD1234",
-        topic: "ai.openclaw.ios",
+        topic: "ai.remoteclaw.ios",
         environment: "sandbox",
         updatedAtMs: 1,
       },

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -55,7 +55,7 @@ async function generateSelfSignedCert(params: {
     "-out",
     params.certPath,
     "-subj",
-    "/CN=openclaw-gateway",
+    "/CN=remoteclaw-gateway",
   ]);
   await fs.chmod(params.keyPath, 0o600).catch(() => {});
   await fs.chmod(params.certPath, 0o600).catch(() => {});


### PR DESCRIPTION
## Summary

- Rename launch agent labels from `ai.openclaw.*` to `ai.remoteclaw.*`
- Rename systemd service names from `openclaw-gateway`/`openclaw-node` to `remoteclaw-gateway`/`remoteclaw-node`
- Update service markers from `"openclaw"` to `"remoteclaw"`
- Empty legacy systemd service name list (RemoteClaw has no legacy service names)
- Update `inspect.ts` detection logic: add `"remoteclaw"` to `EXTRA_MARKERS`, update marker comparisons and detection prefixes
- Update TLS certificate CN from `openclaw-gateway` to `remoteclaw-gateway`
- Update APNs push topics in test fixtures: `ai.openclaw.ios` → `ai.remoteclaw.ios`
- Update ~15 test files with new service identifier assertions

Closes #193

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (93 test files, 854 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)