### PR TITLE
CLI: implement remoteclaw import migration command (#134)

### DIFF
--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -41,6 +41,19 @@ const coreEntries: CoreCliEntry[] = [
   {
     commands: [
       {
+        name: "import",
+        description: "Import an existing OpenClaw installation into RemoteClaw",
+        hasSubcommands: false,
+      },
+    ],
+    register: async ({ program }) => {
+      const mod = await import("./register.import.js");
+      mod.registerImportCommand(program);
+    },
+  },
+  {
+    commands: [
+      {
         name: "setup",
         description: "Initialize local config and agent workspace",
         hasSubcommands: false,

--- a/src/cli/program/register.import.ts
+++ b/src/cli/program/register.import.ts
@@ -1,0 +1,27 @@
+import type { Command } from "commander";
+import { importCommand } from "../../commands/import.js";
+import { defaultRuntime } from "../../runtime.js";
+import { runCommandWithRuntime } from "../cli-utils.js";
+
+export function registerImportCommand(program: Command) {
+  program
+    .command("import <path>")
+    .description("Import an existing OpenClaw installation into RemoteClaw")
+    .option("--yes", "Skip confirmation prompts", false)
+    .option("--dry-run", "Preview import without writing files", false)
+    .option("--non-interactive", "Run without prompts (requires --yes if target exists)", false)
+    .action(async (sourcePath: string, opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await importCommand(
+          {
+            sourcePath,
+            yes: Boolean(opts.yes),
+            dryRun: Boolean(opts.dryRun),
+            nonInteractive: Boolean(opts.nonInteractive),
+          },
+          defaultRuntime,
+        );
+        defaultRuntime.exit(0);
+      });
+    });
+}

--- a/src/commands/import.test.ts
+++ b/src/commands/import.test.ts
@@ -1,0 +1,300 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import {
+  detectOpenClawInstallation,
+  importCommand,
+  resolveTargetFilename,
+  transformConfigContent,
+} from "./import.js";
+import { createTestRuntime, type TestRuntime } from "./test-runtime-config-helpers.js";
+
+describe("transformConfigContent", () => {
+  it("replaces ${OPENCLAW_*} template references with ${REMOTECLAW_*}", () => {
+    const input = `{
+  "env": {
+    "vars": {
+      "token": "\${OPENCLAW_GATEWAY_TOKEN}",
+      "password": "\${OPENCLAW_GATEWAY_PASSWORD}"
+    }
+  }
+}`;
+    const { content, renames } = transformConfigContent(input);
+    expect(content).toContain("${REMOTECLAW_GATEWAY_TOKEN}");
+    expect(content).toContain("${REMOTECLAW_GATEWAY_PASSWORD}");
+    expect(content).not.toContain("${OPENCLAW_");
+    expect(renames).toContain("${OPENCLAW_GATEWAY_TOKEN} -> ${REMOTECLAW_GATEWAY_TOKEN}");
+    expect(renames).toContain("${OPENCLAW_GATEWAY_PASSWORD} -> ${REMOTECLAW_GATEWAY_PASSWORD}");
+  });
+
+  it("replaces bare OPENCLAW_* string values in JSON", () => {
+    const input = `{
+  "envVar": "OPENCLAW_STATE_DIR",
+  "other": "OPENCLAW_CONFIG_PATH"
+}`;
+    const { content, renames } = transformConfigContent(input);
+    expect(content).toContain('"REMOTECLAW_STATE_DIR"');
+    expect(content).toContain('"REMOTECLAW_CONFIG_PATH"');
+    expect(renames).toContain("OPENCLAW_STATE_DIR -> REMOTECLAW_STATE_DIR");
+    expect(renames).toContain("OPENCLAW_CONFIG_PATH -> REMOTECLAW_CONFIG_PATH");
+  });
+
+  it("replaces .openclaw path references with .remoteclaw", () => {
+    const input = `{
+  "workspace": "/home/user/.openclaw/workspace",
+  "sessions": "/home/user/.openclaw/sessions"
+}`;
+    const { content } = transformConfigContent(input);
+    expect(content).toContain("/.remoteclaw/workspace");
+    expect(content).toContain("/.remoteclaw/sessions");
+    expect(content).not.toContain("/.openclaw/");
+  });
+
+  it("returns empty renames when no OPENCLAW_ references exist", () => {
+    const input = `{
+  "gateway": {
+    "port": 18789
+  }
+}`;
+    const { content, renames } = transformConfigContent(input);
+    expect(content).toBe(input);
+    expect(renames).toHaveLength(0);
+  });
+
+  it("deduplicates renames", () => {
+    const input = `{
+  "a": "\${OPENCLAW_TOKEN}",
+  "b": "\${OPENCLAW_TOKEN}"
+}`;
+    const { renames } = transformConfigContent(input);
+    const tokenRenames = renames.filter((r) => r.includes("OPENCLAW_TOKEN"));
+    expect(tokenRenames).toHaveLength(1);
+  });
+
+  it("does not modify non-string JSON content", () => {
+    const input = `{
+  "port": 18789,
+  "enabled": true,
+  "items": [1, 2, 3]
+}`;
+    const { content, renames } = transformConfigContent(input);
+    expect(content).toBe(input);
+    expect(renames).toHaveLength(0);
+  });
+});
+
+describe("resolveTargetFilename", () => {
+  it("renames openclaw.json to remoteclaw.json", () => {
+    expect(resolveTargetFilename("openclaw.json")).toBe("remoteclaw.json");
+  });
+
+  it("keeps other filenames unchanged", () => {
+    expect(resolveTargetFilename("sessions.json")).toBe("sessions.json");
+    expect(resolveTargetFilename("config.json5")).toBe("config.json5");
+    expect(resolveTargetFilename("data.bin")).toBe("data.bin");
+  });
+});
+
+describe("detectOpenClawInstallation", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "import-test-"));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns path when .openclaw directory exists", async () => {
+    await fsp.mkdir(path.join(tmpDir, ".openclaw"));
+    expect(detectOpenClawInstallation(tmpDir)).toBe(path.join(tmpDir, ".openclaw"));
+  });
+
+  it("returns null when .openclaw does not exist", () => {
+    expect(detectOpenClawInstallation(tmpDir)).toBeNull();
+  });
+
+  it("returns null when .openclaw is a file not a directory", async () => {
+    await fsp.writeFile(path.join(tmpDir, ".openclaw"), "not a dir");
+    expect(detectOpenClawInstallation(tmpDir)).toBeNull();
+  });
+});
+
+describe("importCommand", () => {
+  let tmpDir: string;
+  let sourceDir: string;
+  let targetDir: string;
+  let runtime: TestRuntime;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "import-cmd-test-"));
+    sourceDir = path.join(tmpDir, "source");
+    targetDir = path.join(tmpDir, "target");
+    await fsp.mkdir(sourceDir, { recursive: true });
+
+    runtime = createTestRuntime();
+    runtime.exit.mockImplementation((_code: number) => {
+      throw new Error("exit");
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("copies files from source to target directory", async () => {
+    await fsp.writeFile(path.join(sourceDir, "data.bin"), "binary data");
+    await fsp.mkdir(path.join(sourceDir, "subdir"));
+    await fsp.writeFile(path.join(sourceDir, "subdir", "nested.txt"), "nested");
+
+    // Mock resolveNewStateDir to use our temp target
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    expect(result.copiedFiles).toHaveLength(2);
+    expect(fs.existsSync(path.join(targetDir, "data.bin"))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, "subdir", "nested.txt"))).toBe(true);
+    expect(await fsp.readFile(path.join(targetDir, "data.bin"), "utf-8")).toBe("binary data");
+  });
+
+  it("transforms config files during copy", async () => {
+    const configContent = `{
+  "env": {
+    "vars": {
+      "token": "\${OPENCLAW_GATEWAY_TOKEN}"
+    }
+  },
+  "workspace": "/home/user/.openclaw/workspace"
+}`;
+    await fsp.writeFile(path.join(sourceDir, "openclaw.json"), configContent);
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    // File should be renamed
+    expect(fs.existsSync(path.join(targetDir, "remoteclaw.json"))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, "openclaw.json"))).toBe(false);
+
+    // Content should be transformed
+    const written = await fsp.readFile(path.join(targetDir, "remoteclaw.json"), "utf-8");
+    expect(written).toContain("${REMOTECLAW_GATEWAY_TOKEN}");
+    expect(written).toContain("/.remoteclaw/workspace");
+    expect(written).not.toContain("OPENCLAW_");
+    expect(written).not.toContain("/.openclaw/");
+
+    expect(result.transformedFiles).toHaveLength(1);
+    expect(result.envVarRenames.length).toBeGreaterThan(0);
+  });
+
+  it("dry-run does not write files", async () => {
+    await fsp.writeFile(path.join(sourceDir, "config.json"), '{"key": "value"}');
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    const result = await importCommand(
+      { sourcePath: sourceDir, dryRun: true },
+      runtime as RuntimeEnv,
+    );
+
+    expect(result.copiedFiles).toHaveLength(1);
+    expect(fs.existsSync(targetDir)).toBe(false);
+  });
+
+  it("exits with error when source path does not exist", async () => {
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    await expect(
+      importCommand({ sourcePath: path.join(tmpDir, "nonexistent") }, runtime as RuntimeEnv),
+    ).rejects.toThrow("exit");
+
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("does not exist"));
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("exits with error when source path is not a directory", async () => {
+    const filePath = path.join(tmpDir, "afile");
+    await fsp.writeFile(filePath, "not a dir");
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    await expect(importCommand({ sourcePath: filePath }, runtime as RuntimeEnv)).rejects.toThrow(
+      "exit",
+    );
+
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("not a directory"));
+  });
+
+  it("warns and exits in non-interactive mode when target exists without --yes", async () => {
+    await fsp.writeFile(path.join(sourceDir, "data.bin"), "data");
+    await fsp.mkdir(targetDir, { recursive: true });
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    await expect(
+      importCommand({ sourcePath: sourceDir, nonInteractive: true }, runtime as RuntimeEnv),
+    ).rejects.toThrow("exit");
+
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("already exists"));
+  });
+
+  it("proceeds when target exists and --yes is provided", async () => {
+    await fsp.writeFile(path.join(sourceDir, "data.bin"), "data");
+    await fsp.mkdir(targetDir, { recursive: true });
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    expect(result.copiedFiles).toHaveLength(1);
+    expect(fs.existsSync(path.join(targetDir, "data.bin"))).toBe(true);
+  });
+
+  it("handles nested directory structures with mixed file types", async () => {
+    // Create a realistic OpenClaw directory structure
+    await fsp.mkdir(path.join(sourceDir, "agents", "default", "sessions"), { recursive: true });
+    await fsp.mkdir(path.join(sourceDir, "credentials"), { recursive: true });
+
+    await fsp.writeFile(
+      path.join(sourceDir, "openclaw.json"),
+      '{"gateway": {"port": 18789}, "env": {"vars": {"token": "${OPENCLAW_GATEWAY_TOKEN}"}}}',
+    );
+    await fsp.writeFile(
+      path.join(sourceDir, "agents", "default", "sessions", "sessions.json"),
+      '{"sessions": []}',
+    );
+    await fsp.writeFile(
+      path.join(sourceDir, "credentials", "oauth.json"),
+      '{"token": "fake-token"}',
+    );
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    expect(result.copiedFiles.length).toBeGreaterThanOrEqual(3);
+    expect(fs.existsSync(path.join(targetDir, "remoteclaw.json"))).toBe(true);
+    expect(
+      fs.existsSync(path.join(targetDir, "agents", "default", "sessions", "sessions.json")),
+    ).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, "credentials", "oauth.json"))).toBe(true);
+
+    // Verify main config was transformed
+    const mainConfig = await fsp.readFile(path.join(targetDir, "remoteclaw.json"), "utf-8");
+    expect(mainConfig).toContain("${REMOTECLAW_GATEWAY_TOKEN}");
+  });
+});

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,0 +1,276 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { resolveNewStateDir } from "../config/paths.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { defaultRuntime } from "../runtime.js";
+import { shortenHomePath } from "../utils.js";
+import { createClackPrompter } from "../wizard/clack-prompter.js";
+
+/**
+ * Config key prefixes that need rewriting during import.
+ * The import rewrites env var references from the OpenClaw namespace
+ * to the RemoteClaw namespace.
+ */
+const ENV_VAR_PREFIX_OLD = "OPENCLAW_";
+const ENV_VAR_PREFIX_NEW = "REMOTECLAW_";
+
+/**
+ * OpenClaw config filename that gets renamed during import.
+ */
+const OPENCLAW_CONFIG_FILENAME = "openclaw.json";
+const REMOTECLAW_CONFIG_FILENAME = "remoteclaw.json";
+
+export type ImportOptions = {
+  sourcePath: string;
+  yes?: boolean;
+  dryRun?: boolean;
+  nonInteractive?: boolean;
+};
+
+export type ImportResult = {
+  copiedFiles: string[];
+  transformedFiles: string[];
+  envVarRenames: string[];
+  targetDir: string;
+};
+
+/**
+ * Transform config content by replacing OPENCLAW_* env var references
+ * with REMOTECLAW_* equivalents.
+ *
+ * Handles both `${OPENCLAW_*}` template references and bare `OPENCLAW_*` string values.
+ */
+export function transformConfigContent(content: string): {
+  content: string;
+  renames: string[];
+} {
+  const renames: string[] = [];
+
+  // Replace ${OPENCLAW_*} env var template references
+  const templatePattern = /\$\{(OPENCLAW_\w+)\}/g;
+  let transformed = content.replace(templatePattern, (_match, varName: string) => {
+    const newVarName = varName.replace(ENV_VAR_PREFIX_OLD, ENV_VAR_PREFIX_NEW);
+    renames.push(`\${${varName}} -> \${${newVarName}}`);
+    return `\${${newVarName}}`;
+  });
+
+  // Replace bare "OPENCLAW_*" string values (in JSON string values)
+  // This catches cases like: "envVar": "OPENCLAW_GATEWAY_TOKEN"
+  const barePattern = /("(?:[^"\\]|\\.)*")/g;
+  transformed = transformed.replace(barePattern, (match) => {
+    if (match.includes(ENV_VAR_PREFIX_OLD)) {
+      const updated = match.replace(
+        new RegExp(`${ENV_VAR_PREFIX_OLD}(\\w+)`, "g"),
+        (_m, suffix: string) => {
+          const oldName = `${ENV_VAR_PREFIX_OLD}${suffix}`;
+          const newName = `${ENV_VAR_PREFIX_NEW}${suffix}`;
+          renames.push(`${oldName} -> ${newName}`);
+          return newName;
+        },
+      );
+      return updated;
+    }
+    return match;
+  });
+
+  // Replace path references from .openclaw to .remoteclaw in string values
+  const pathPattern = /("(?:[^"\\]|\\.)*")/g;
+  transformed = transformed.replace(pathPattern, (match) => {
+    if (match.includes("/.openclaw/") || match.includes("\\.openclaw\\")) {
+      return match
+        .replace(/\/\.openclaw\//g, "/.remoteclaw/")
+        .replace(/\\\.openclaw\\/g, "\\.remoteclaw\\");
+    }
+    return match;
+  });
+
+  return { content: transformed, renames: [...new Set(renames)] };
+}
+
+/**
+ * Determine the target filename for a source file.
+ * Renames openclaw.json -> remoteclaw.json at any directory level.
+ */
+export function resolveTargetFilename(filename: string): string {
+  if (filename === OPENCLAW_CONFIG_FILENAME) {
+    return REMOTECLAW_CONFIG_FILENAME;
+  }
+  return filename;
+}
+
+/**
+ * Check whether a file is a JSON/JSON5 config file that should be transformed.
+ */
+function isConfigFile(filename: string): boolean {
+  return filename.endsWith(".json") || filename.endsWith(".json5");
+}
+
+/**
+ * Recursively copy a directory, transforming config files along the way.
+ */
+async function copyDirectory(params: {
+  sourceDir: string;
+  targetDir: string;
+  dryRun: boolean;
+  result: ImportResult;
+}): Promise<void> {
+  const { sourceDir, targetDir, dryRun, result } = params;
+
+  const entries = await fsp.readdir(sourceDir, { withFileTypes: true });
+
+  if (!dryRun) {
+    await fsp.mkdir(targetDir, { recursive: true });
+  }
+
+  for (const entry of entries) {
+    const sourcePath = path.join(sourceDir, entry.name);
+    const targetFilename = resolveTargetFilename(entry.name);
+    const targetPath = path.join(targetDir, targetFilename);
+
+    if (entry.isDirectory()) {
+      await copyDirectory({
+        sourceDir: sourcePath,
+        targetDir: targetPath,
+        dryRun,
+        result,
+      });
+    } else if (entry.isFile()) {
+      if (isConfigFile(entry.name)) {
+        const content = await fsp.readFile(sourcePath, "utf-8");
+        const { content: transformed, renames } = transformConfigContent(content);
+        if (renames.length > 0) {
+          result.transformedFiles.push(targetPath);
+          result.envVarRenames.push(...renames);
+        }
+        if (!dryRun) {
+          await fsp.writeFile(targetPath, transformed, "utf-8");
+        }
+        result.copiedFiles.push(targetPath);
+      } else {
+        if (!dryRun) {
+          await fsp.copyFile(sourcePath, targetPath);
+        }
+        result.copiedFiles.push(targetPath);
+      }
+    }
+  }
+}
+
+/**
+ * Execute the import migration from an OpenClaw installation to RemoteClaw.
+ */
+export async function importCommand(
+  opts: ImportOptions,
+  runtime: RuntimeEnv = defaultRuntime,
+): Promise<ImportResult> {
+  const sourcePath = path.resolve(opts.sourcePath.replace(/^~/, process.env.HOME ?? "~"));
+  const targetDir = resolveNewStateDir();
+
+  // Validate source path exists
+  if (!fs.existsSync(sourcePath)) {
+    runtime.error(`Source path does not exist: ${shortenHomePath(sourcePath)}`);
+    runtime.exit(1);
+    return null as never;
+  }
+
+  const sourceStat = await fsp.stat(sourcePath);
+  if (!sourceStat.isDirectory()) {
+    runtime.error(`Source path is not a directory: ${shortenHomePath(sourcePath)}`);
+    runtime.exit(1);
+    return null as never;
+  }
+
+  // Check if target already exists
+  const targetExists = fs.existsSync(targetDir);
+  if (targetExists && !opts.yes && !opts.dryRun) {
+    if (opts.nonInteractive) {
+      runtime.error(
+        `Target directory already exists: ${shortenHomePath(targetDir)}\nUse --yes to overwrite.`,
+      );
+      runtime.exit(1);
+      return null as never;
+    }
+
+    const prompter = createClackPrompter();
+    const shouldContinue = await prompter.confirm({
+      message: `Target directory ${shortenHomePath(targetDir)} already exists. Merge imported files into it?`,
+      initialValue: false,
+    });
+
+    if (!shouldContinue) {
+      runtime.log("Import cancelled.");
+      runtime.exit(0);
+      return null as never;
+    }
+  }
+
+  const result: ImportResult = {
+    copiedFiles: [],
+    transformedFiles: [],
+    envVarRenames: [],
+    targetDir,
+  };
+
+  if (opts.dryRun) {
+    runtime.log("Dry run — no files will be written.\n");
+  }
+
+  runtime.log(
+    `Importing from ${shortenHomePath(sourcePath)} to ${shortenHomePath(targetDir)}...\n`,
+  );
+
+  await copyDirectory({
+    sourceDir: sourcePath,
+    targetDir,
+    dryRun: Boolean(opts.dryRun),
+    result,
+  });
+
+  // Deduplicate env var renames for reporting
+  result.envVarRenames = [...new Set(result.envVarRenames)];
+
+  // Report results
+  runtime.log(`Copied ${result.copiedFiles.length} file(s).`);
+  if (result.transformedFiles.length > 0) {
+    runtime.log(`Transformed ${result.transformedFiles.length} config file(s):`);
+    for (const file of result.transformedFiles) {
+      runtime.log(`  ${shortenHomePath(file)}`);
+    }
+  }
+  if (result.envVarRenames.length > 0) {
+    runtime.log(`\nEnv var renames:`);
+    for (const rename of result.envVarRenames) {
+      runtime.log(`  ${rename}`);
+    }
+  }
+
+  if (opts.dryRun) {
+    runtime.log("\nDry run complete — no changes were made.");
+  } else {
+    runtime.log("\nImport complete.");
+  }
+
+  return result;
+}
+
+/**
+ * Detect whether an OpenClaw installation exists at the default location.
+ * Used by the onboarding wizard to offer migration.
+ */
+export function detectOpenClawInstallation(
+  homedir: string = process.env.HOME ?? "",
+): string | null {
+  const openclawDir = path.join(homedir, ".openclaw");
+  if (fs.existsSync(openclawDir)) {
+    try {
+      const stat = fs.statSync(openclawDir);
+      if (stat.isDirectory()) {
+        return openclawDir;
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return null;
+}

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -1,4 +1,5 @@
 import { formatCliCommand } from "../cli/command-format.js";
+import { detectOpenClawInstallation, importCommand } from "../commands/import.js";
 import type {
   AgentRuntime,
   GatewayAuthChoice,
@@ -15,7 +16,7 @@ import {
 } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
-import { resolveUserPath } from "../utils.js";
+import { resolveUserPath, shortenHomePath } from "../utils.js";
 import type { QuickstartGatewayDefaults, WizardFlow } from "./onboarding.types.js";
 import { WizardCancelledError, type WizardPrompter } from "./prompts.js";
 
@@ -278,6 +279,30 @@ export async function runOnboardingWizard(
   onboardHelpers.printWizardHeader(runtime);
   await prompter.intro("RemoteClaw onboarding");
   await requireRiskAcknowledgement({ opts, prompter });
+
+  // Detect existing OpenClaw installation and offer migration before proceeding.
+  const openclawDir = detectOpenClawInstallation();
+  if (openclawDir) {
+    const preCheck = await readConfigFileSnapshot();
+    if (!preCheck.exists) {
+      await prompter.note(
+        [
+          `Existing OpenClaw installation found at ${shortenHomePath(openclawDir)}.`,
+          "",
+          "RemoteClaw can import your config, sessions, and channel settings.",
+        ].join("\n"),
+        "OpenClaw detected",
+      );
+      const shouldImport = await prompter.confirm({
+        message: `Import from ${shortenHomePath(openclawDir)}?`,
+        initialValue: true,
+      });
+      if (shouldImport) {
+        await importCommand({ sourcePath: openclawDir }, runtime);
+        await prompter.note("OpenClaw config imported. Continuing with setup.", "Import complete");
+      }
+    }
+  }
 
   const snapshot = await readConfigFileSnapshot();
   let baseConfig: RemoteClawConfig = snapshot.valid ? snapshot.config : {};


### PR DESCRIPTION
## Summary

- Adds `remoteclaw import <path>` CLI command that migrates an existing OpenClaw installation to RemoteClaw
- Copies config, sessions, and channel settings from source path to `~/.remoteclaw`
- Transforms `OPENCLAW_*` env var references to `REMOTECLAW_*` and rewrites `.openclaw` path references to `.remoteclaw`
- Renames `openclaw.json` to `remoteclaw.json` during import
- Onboarding wizard now detects `~/.openclaw` and offers migration during first-run setup
- Supports `--dry-run`, `--yes`, and `--non-interactive` flags

Closes #134

## Test plan

- [x] 19 unit tests covering config transformation, directory copying, overwrite protection, dry-run mode, nested structures, and OpenClaw detection
- [x] Full test suite passes (854 tests)
- [x] Type-check clean
- [x] Lint clean
- [ ] CI build + test

🤖 Generated with [Claude Code](https://claude.com/claude-code)