### PR TITLE
rebrand: cascade-update test infrastructure for openclaw→remoteclaw rename (#216)

### DIFF
--- a/src/agents/agent-paths.test.ts
+++ b/src/agents/agent-paths.test.ts
@@ -7,7 +7,7 @@ import { resolveRemoteClawAgentDir } from "./agent-paths.js";
 
 describe("resolveRemoteClawAgentDir", () => {
   const withTempStateDir = async (run: (stateDir: string) => void) => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-agent-"));
     try {
       run(stateDir);
     } finally {

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -29,7 +29,7 @@ describe("resolveAgentConfig", () => {
   it("should return undefined when agent id does not exist", () => {
     const cfg: RemoteClawConfig = {
       agents: {
-        list: [{ id: "main", workspace: "~/openclaw" }],
+        list: [{ id: "main", workspace: "~/remoteclaw" }],
       },
     };
     const result = resolveAgentConfig(cfg, "nonexistent");
@@ -43,7 +43,7 @@ describe("resolveAgentConfig", () => {
           {
             id: "main",
             name: "Main Agent",
-            workspace: "~/openclaw",
+            workspace: "~/remoteclaw",
             agentDir: "~/.remoteclaw/agents/main",
             model: "anthropic/claude-opus-4",
           },
@@ -53,7 +53,7 @@ describe("resolveAgentConfig", () => {
     const result = resolveAgentConfig(cfg, "main");
     expect(result).toEqual({
       name: "Main Agent",
-      workspace: "~/openclaw",
+      workspace: "~/remoteclaw",
       agentDir: "~/.remoteclaw/agents/main",
       model: "anthropic/claude-opus-4",
       identity: undefined,
@@ -322,7 +322,7 @@ describe("resolveAgentConfig", () => {
         list: [
           {
             id: "work",
-            workspace: "~/openclaw-work",
+            workspace: "~/remoteclaw-work",
             sandbox: {
               mode: "all",
               scope: "agent",
@@ -401,13 +401,13 @@ describe("resolveAgentConfig", () => {
   it("should normalize agent id", () => {
     const cfg: RemoteClawConfig = {
       agents: {
-        list: [{ id: "main", workspace: "~/openclaw" }],
+        list: [{ id: "main", workspace: "~/remoteclaw" }],
       },
     };
     // Should normalize to "main" (default)
     const result = resolveAgentConfig(cfg, "");
     expect(result).toBeDefined();
-    expect(result?.workspace).toBe("~/openclaw");
+    expect(result?.workspace).toBe("~/remoteclaw");
   });
 
   it("uses REMOTECLAW_HOME for default agent workspace", () => {

--- a/src/agents/auth-profiles.ensureauthprofilestore.test.ts
+++ b/src/agents/auth-profiles.ensureauthprofilestore.test.ts
@@ -7,7 +7,7 @@ import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
 
 describe("ensureAuthProfileStore", () => {
   it("migrates legacy auth.json and deletes it (PR #368)", () => {
-    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-profiles-"));
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-auth-profiles-"));
     try {
       const legacyPath = path.join(agentDir, "auth.json");
       fs.writeFileSync(
@@ -46,7 +46,7 @@ describe("ensureAuthProfileStore", () => {
   });
 
   it("merges main auth profiles into agent store and keeps agent overrides", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-merge-"));
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-auth-merge-"));
     const previousAgentDir = process.env.REMOTECLAW_AGENT_DIR;
     const previousPiAgentDir = process.env.PI_CODING_AGENT_DIR;
     try {

--- a/src/agents/identity-avatar.test.ts
+++ b/src/agents/identity-avatar.test.ts
@@ -28,7 +28,7 @@ async function expectLocalAvatarPath(
 const tempRoots: string[] = [];
 
 async function createTempAvatarRoot() {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-avatar-"));
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-avatar-"));
   tempRoots.push(root);
   return root;
 }

--- a/src/agents/openclaw-gateway-tool.test.ts
+++ b/src/agents/openclaw-gateway-tool.test.ts
@@ -59,7 +59,7 @@ describe("gateway tool", () => {
   it("schedules SIGUSR1 restart", async () => {
     vi.useFakeTimers();
     const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-test-"));
 
     try {
       await withEnvAsync(
@@ -105,7 +105,7 @@ describe("gateway tool", () => {
     const sessionKey = "agent:main:whatsapp:dm:+15555550123";
     const tool = requireGatewayTool(sessionKey);
 
-    const raw = '{\n  agents: { defaults: { workspace: "~/openclaw" } }\n}\n';
+    const raw = '{\n  agents: { defaults: { workspace: "~/remoteclaw" } }\n}\n';
     await tool.execute("call2", {
       action: "config.apply",
       raw,

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -25,7 +25,7 @@ function buildSessionHeaderAndMessage() {
 const tempDirs: string[] = [];
 
 async function createTempSessionPath() {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-repair-"));
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-session-repair-"));
   tempDirs.push(dir);
   return { dir, file: path.join(dir, "session.jsonl") };
 }

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -28,7 +28,7 @@ describe("acquireSessionWriteLock", () => {
       return;
     }
 
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-lock-"));
     try {
       const realDir = path.join(root, "real");
       const linkDir = path.join(root, "link");
@@ -49,7 +49,7 @@ describe("acquireSessionWriteLock", () => {
   });
 
   it("keeps the lock file until the last release", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-lock-"));
     try {
       const sessionFile = path.join(root, "sessions.json");
       const lockPath = `${sessionFile}.lock`;
@@ -68,7 +68,7 @@ describe("acquireSessionWriteLock", () => {
   });
 
   it("reclaims stale lock files", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-lock-"));
     try {
       const sessionFile = path.join(root, "sessions.json");
       const lockPath = `${sessionFile}.lock`;
@@ -90,7 +90,7 @@ describe("acquireSessionWriteLock", () => {
   });
 
   it("does not reclaim fresh malformed lock files during contention", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-lock-"));
     try {
       const sessionFile = path.join(root, "sessions.json");
       const lockPath = `${sessionFile}.lock`;
@@ -106,7 +106,7 @@ describe("acquireSessionWriteLock", () => {
   });
 
   it("reclaims malformed lock files once they are old enough", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-lock-"));
     try {
       const sessionFile = path.join(root, "sessions.json");
       const lockPath = `${sessionFile}.lock`;
@@ -123,7 +123,7 @@ describe("acquireSessionWriteLock", () => {
   });
 
   it("watchdog releases stale in-process locks", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-lock-"));
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
       const sessionFile = path.join(root, "session.jsonl");
@@ -167,7 +167,7 @@ describe("acquireSessionWriteLock", () => {
   });
 
   it("cleans stale .jsonl lock files in sessions directories", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-lock-"));
     const sessionsDir = path.join(root, "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
 
@@ -230,7 +230,7 @@ describe("acquireSessionWriteLock", () => {
     process.kill = ((_pid: number, _signal?: NodeJS.Signals) => true) as typeof process.kill;
     try {
       for (const signal of signals) {
-        const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-cleanup-"));
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-lock-cleanup-"));
         try {
           const sessionFile = path.join(root, "sessions.json");
           const lockPath = `${sessionFile}.lock`;
@@ -260,7 +260,7 @@ describe("acquireSessionWriteLock", () => {
     expect(__testing.cleanupSignals).toContain("SIGABRT");
   });
   it("cleans up locks on SIGINT without removing other handlers", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-lock-"));
     const originalKill = process.kill.bind(process);
     const killCalls: Array<NodeJS.Signals | undefined> = [];
     let otherHandlerCalled = false;
@@ -294,7 +294,7 @@ describe("acquireSessionWriteLock", () => {
   });
 
   it("cleans up locks on exit", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-lock-"));
     try {
       const sessionFile = path.join(root, "sessions.json");
       const lockPath = `${sessionFile}.lock`;

--- a/src/agents/subagent-depth.test.ts
+++ b/src/agents/subagent-depth.test.ts
@@ -45,7 +45,7 @@ describe("getSubagentDepthFromSessionStore", () => {
   });
 
   it("resolves prefixed store keys when caller key omits the agent prefix", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-subagent-depth-"));
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-subagent-depth-"));
     const storeTemplate = path.join(tmpDir, "sessions-{agentId}.json");
     const prefixedKey = "agent:main:subagent:flat";
     const storePath = storeTemplate.replaceAll("{agentId}", "main");

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -104,7 +104,7 @@ describe("subagent registry persistence", () => {
     persisted: Record<string, unknown>,
     opts?: { seedChildSessions?: boolean },
   ) => {
-    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-subagent-"));
     process.env.REMOTECLAW_STATE_DIR = tempStateDir;
     const registryPath = path.join(tempStateDir, "subagents", "runs.json");
     await fs.mkdir(path.dirname(registryPath), { recursive: true });
@@ -162,7 +162,7 @@ describe("subagent registry persistence", () => {
   });
 
   it("persists runs to disk and resumes after restart", async () => {
-    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-subagent-"));
     process.env.REMOTECLAW_STATE_DIR = tempStateDir;
 
     registerSubagentRun({
@@ -227,7 +227,7 @@ describe("subagent registry persistence", () => {
   });
 
   it("skips cleanup when cleanupHandled was persisted", async () => {
-    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-subagent-"));
     process.env.REMOTECLAW_STATE_DIR = tempStateDir;
 
     const registryPath = path.join(tempStateDir, "subagents", "runs.json");
@@ -382,7 +382,7 @@ describe("subagent registry persistence", () => {
   });
 
   it("resume guard prunes orphan runs before announce retry", async () => {
-    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-subagent-"));
     process.env.REMOTECLAW_STATE_DIR = tempStateDir;
     const runId = "run-orphan-resume-guard";
     const childSessionKey = "agent:main:subagent:ghost-resume";

--- a/src/agents/workspace.load-extra-bootstrap-files.test.ts
+++ b/src/agents/workspace.load-extra-bootstrap-files.test.ts
@@ -15,7 +15,7 @@ describe("loadExtraBootstrapFiles", () => {
   };
 
   beforeAll(async () => {
-    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-extra-bootstrap-"));
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-extra-bootstrap-"));
   });
 
   afterAll(async () => {

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -20,11 +20,11 @@ import {
 describe("resolveDefaultAgentWorkspaceDir", () => {
   it("uses REMOTECLAW_HOME for default workspace resolution", () => {
     const dir = resolveDefaultAgentWorkspaceDir({
-      REMOTECLAW_HOME: "/srv/openclaw-home",
+      REMOTECLAW_HOME: "/srv/remoteclaw-home",
       HOME: "/home/other",
     } as NodeJS.ProcessEnv);
 
-    expect(dir).toBe(path.join(path.resolve("/srv/openclaw-home"), ".remoteclaw", "workspace"));
+    expect(dir).toBe(path.join(path.resolve("/srv/remoteclaw-home"), ".remoteclaw", "workspace"));
   });
 });
 

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -283,7 +283,7 @@ describe("createInboundDebouncer", () => {
 
 describe("initSessionState BodyStripped", () => {
   it("prefers BodyForAgent over Body for group chats", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sender-meta-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-sender-meta-"));
     const storePath = path.join(root, "sessions.json");
     const cfg = { session: { store: storePath } } as RemoteClawConfig;
 
@@ -305,7 +305,7 @@ describe("initSessionState BodyStripped", () => {
   });
 
   it("prefers BodyForAgent over Body for direct chats", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sender-meta-direct-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-sender-meta-direct-"));
     const storePath = path.join(root, "sessions.json");
     const cfg = { session: { store: storePath } } as RemoteClawConfig;
 

--- a/src/auto-reply/reply.block-streaming.test.ts
+++ b/src/auto-reply/reply.block-streaming.test.ts
@@ -115,7 +115,7 @@ function createReplyConfig(home: string, streamMode?: "block"): RemoteClawConfig
     agents: {
       defaults: {
         model: { primary: "anthropic/claude-opus-4-5" },
-        workspace: path.join(home, "openclaw"),
+        workspace: path.join(home, "remoteclaw"),
       },
     },
     channels: { telegram: { allowFrom: ["*"], streamMode } },

--- a/src/auto-reply/reply.directive.directive-behavior.e2e-harness.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.e2e-harness.ts
@@ -75,7 +75,7 @@ export function makeWhatsAppDirectiveConfig(
   return {
     agents: {
       defaults: {
-        workspace: path.join(home, "openclaw"),
+        workspace: path.join(home, "remoteclaw"),
         ...defaults,
       },
     },
@@ -145,7 +145,7 @@ export function makeRestrictedElevatedDisabledConfig(home: string) {
     agents: {
       defaults: {
         model: "anthropic/claude-opus-4-5",
-        workspace: path.join(home, "openclaw"),
+        workspace: path.join(home, "remoteclaw"),
       },
       list: [
         {

--- a/src/auto-reply/reply.media-note.test.ts
+++ b/src/auto-reply/reply.media-note.test.ts
@@ -35,7 +35,7 @@ function makeCfg(home: string) {
     agents: {
       defaults: {
         model: "anthropic/claude-opus-4-5",
-        workspace: path.join(home, "openclaw"),
+        workspace: path.join(home, "remoteclaw"),
       },
     },
     channels: { whatsapp: { allowFrom: ["*"] } },

--- a/src/auto-reply/reply.raw-body.test.ts
+++ b/src/auto-reply/reply.raw-body.test.ts
@@ -65,7 +65,7 @@ vi.mock("../gateway/credentials.js", () => ({
 
 import { getReplyFromConfig } from "./reply.js";
 
-const { withTempHome } = createTempHomeHarness({ prefix: "openclaw-rawbody-" });
+const { withTempHome } = createTempHomeHarness({ prefix: "remoteclaw-rawbody-" });
 
 describe("RawBody directive parsing", () => {
   beforeEach(() => {

--- a/src/auto-reply/reply.test-harness.ts
+++ b/src/auto-reply/reply.test-harness.ts
@@ -86,7 +86,7 @@ export function makeReplyConfig(home: string) {
     agents: {
       defaults: {
         model: "anthropic/claude-opus-4-5",
-        workspace: path.join(home, "openclaw"),
+        workspace: path.join(home, "remoteclaw"),
       },
     },
     channels: {

--- a/src/auto-reply/reply.triggers.trigger-handling.test-harness.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.test-harness.ts
@@ -228,7 +228,7 @@ export function makeCfg(home: string): RemoteClawConfig {
     agents: {
       defaults: {
         model: { primary: "anthropic/claude-opus-4-5" },
-        workspace: join(home, "openclaw"),
+        workspace: join(home, "remoteclaw"),
         // Test harness: avoid 1s coalescer idle sleeps that dominate trigger suites.
         blockStreamingCoalesce: { idleMs: 1 },
         // Trigger tests assert routing/authorization behavior, not delivery pacing.

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -56,7 +56,7 @@ describe("abort detection", () => {
     sessionIdsByKey?: Record<string, string>;
     nowMs?: number;
   }) {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-abort-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-abort-"));
     const storePath = path.join(root, "sessions.json");
     const cfg = {
       session: { store: storePath },
@@ -96,7 +96,7 @@ describe("abort detection", () => {
   });
 
   it("triggerBodyNormalized extracts /stop from RawBody for abort detection", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-abort-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-abort-"));
     const storePath = path.join(root, "sessions.json");
     const cfg = { session: { store: storePath } } as RemoteClawConfig;
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -385,7 +385,7 @@ describe("runReplyAgent auto-compaction token update", () => {
   }
 
   it("persists usage from bridge result", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compact-tokens-"));
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-compact-tokens-"));
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
     const sessionEntry = {
@@ -445,7 +445,7 @@ describe("runReplyAgent auto-compaction token update", () => {
   });
 
   it("persists usage tokens from bridge result without compaction", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-usage-last-"));
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-usage-last-"));
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
     const sessionEntry = {
@@ -900,7 +900,7 @@ describe("runReplyAgent messaging tool suppression", () => {
 
   it("persists usage fields even when replies are suppressed", async () => {
     const storePath = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-store-")),
+      await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-session-store-")),
       "sessions.json",
     );
     const sessionKey = "main";
@@ -931,7 +931,7 @@ describe("runReplyAgent messaging tool suppression", () => {
 
   it("persists usage when bridge provides token data", async () => {
     const storePath = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-store-")),
+      await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-session-store-")),
       "sessions.json",
     );
     const sessionKey = "main";
@@ -960,7 +960,7 @@ describe("runReplyAgent messaging tool suppression", () => {
 
   it("preserves existing token data when bridge omits usage", async () => {
     const storePath = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-store-")),
+      await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-session-store-")),
       "sessions.json",
     );
     const sessionKey = "main";

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -1053,7 +1053,7 @@ describe("runReplyAgent memory flush", () => {
   }
 
   beforeAll(async () => {
-    fixtureRoot = await fs.mkdtemp(path.join(tmpdir(), "openclaw-memory-flush-"));
+    fixtureRoot = await fs.mkdtemp(path.join(tmpdir(), "remoteclaw-memory-flush-"));
   });
 
   afterAll(async () => {

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -90,7 +90,7 @@ import { buildCommandContext, handleCommands } from "./commands.js";
 let testWorkspaceDir = os.tmpdir();
 
 beforeAll(async () => {
-  testWorkspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-commands-"));
+  testWorkspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-commands-"));
   await fs.writeFile(path.join(testWorkspaceDir, "AGENTS.md"), "# Agents\n", "utf-8");
 });
 

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -36,7 +36,7 @@ async function seedSessionStore(params: {
 }
 
 async function createCompactionSessionFixture(entry: SessionEntry) {
-  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compact-"));
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-compact-"));
   tempDirs.push(tmp);
   const storePath = path.join(tmp, "sessions.json");
   const sessionKey = "main";

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -26,7 +26,7 @@ let suiteRoot = "";
 let suiteCase = 0;
 
 beforeAll(async () => {
-  suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-suite-"));
+  suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-session-suite-"));
 });
 
 afterAll(async () => {

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -486,7 +486,7 @@ describe("buildStatusMessage", () => {
 
         expect(normalizeTestText(text)).toContain("Context: 1.0k/32k");
       },
-      { prefix: "openclaw-status-" },
+      { prefix: "remoteclaw-status-" },
     );
   });
 
@@ -507,7 +507,7 @@ describe("buildStatusMessage", () => {
 
         expect(normalizeTestText(text)).toContain("Context: 1.0k/32k");
       },
-      { prefix: "openclaw-status-" },
+      { prefix: "remoteclaw-status-" },
     );
   });
 
@@ -549,7 +549,7 @@ describe("buildStatusMessage", () => {
 
         expect(normalizeTestText(text)).toContain("Context: 1.2k/32k");
       },
-      { prefix: "openclaw-status-" },
+      { prefix: "remoteclaw-status-" },
     );
   });
 });

--- a/src/browser/chrome-user-data-dir.test-harness.ts
+++ b/src/browser/chrome-user-data-dir.test-harness.ts
@@ -9,7 +9,9 @@ type ChromeUserDataDirRef = {
 
 export function installChromeUserDataDirHooks(chromeUserDataDir: ChromeUserDataDirRef): void {
   beforeAll(async () => {
-    chromeUserDataDir.dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-chrome-user-data-"));
+    chromeUserDataDir.dir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "remoteclaw-chrome-user-data-"),
+    );
   });
 
   afterAll(async () => {

--- a/src/browser/chrome.test.ts
+++ b/src/browser/chrome.test.ts
@@ -42,7 +42,7 @@ describe("browser chrome profile decoration", () => {
   };
 
   beforeAll(async () => {
-    fixtureRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-chrome-suite-"));
+    fixtureRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "remoteclaw-chrome-suite-"));
   });
 
   afterAll(async () => {

--- a/src/browser/paths.test.ts
+++ b/src/browser/paths.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./paths.js";
 
 async function createFixtureRoot(): Promise<{ baseDir: string; uploadsDir: string }> {
-  const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-browser-paths-"));
+  const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-browser-paths-"));
   const uploadsDir = path.join(baseDir, "uploads");
   await fs.mkdir(uploadsDir, { recursive: true });
   return { baseDir, uploadsDir };

--- a/src/browser/profiles-service.test.ts
+++ b/src/browser/profiles-service.test.ts
@@ -19,7 +19,7 @@ vi.mock("./trash.js", () => ({
 }));
 
 vi.mock("./chrome.js", () => ({
-  resolveRemoteClawUserDataDir: vi.fn(() => "/tmp/openclaw-test/openclaw/user-data"),
+  resolveRemoteClawUserDataDir: vi.fn(() => "/tmp/remoteclaw-test/openclaw/user-data"),
 }));
 
 import { loadConfig, writeConfigFile } from "../config/config.js";
@@ -133,7 +133,7 @@ describe("BrowserProfilesService", () => {
       },
     });
 
-    const tempDir = fs.mkdtempSync(path.join("/tmp", "openclaw-profile-"));
+    const tempDir = fs.mkdtempSync(path.join("/tmp", "remoteclaw-profile-"));
     const userDataDir = path.join(tempDir, "work", "user-data");
     fs.mkdirSync(path.dirname(userDataDir), { recursive: true });
     vi.mocked(resolveRemoteClawUserDataDir).mockReturnValue(userDataDir);

--- a/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
+++ b/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
@@ -126,7 +126,7 @@ describe("pw-tools-core", () => {
     expect(res.path).toBe(targetPath);
   });
   it("uses preferred tmp dir when waiting for download without explicit path", async () => {
-    tmpDirMocks.resolvePreferredRemoteClawTmpDir.mockReturnValue("/tmp/openclaw-preferred");
+    tmpDirMocks.resolvePreferredRemoteClawTmpDir.mockReturnValue("/tmp/remoteclaw-preferred");
     const { res, outPath } = await waitForImplicitDownloadOutput({
       downloadUrl: "https://example.com/file.bin",
       suggestedFilename: "file.bin",
@@ -135,10 +135,10 @@ describe("pw-tools-core", () => {
     const expectedRootedDownloadsDir = path.join(
       path.sep,
       "tmp",
-      "openclaw-preferred",
+      "remoteclaw-preferred",
       "downloads",
     );
-    const expectedDownloadsTail = `${path.join("tmp", "openclaw-preferred", "downloads")}${path.sep}`;
+    const expectedDownloadsTail = `${path.join("tmp", "remoteclaw-preferred", "downloads")}${path.sep}`;
     expect(path.dirname(String(outPath))).toBe(expectedRootedDownloadsDir);
     expect(path.basename(String(outPath))).toMatch(/-file\.bin$/);
     expect(path.normalize(res.path)).toContain(path.normalize(expectedDownloadsTail));
@@ -146,18 +146,18 @@ describe("pw-tools-core", () => {
   });
 
   it("sanitizes suggested download filenames to prevent traversal escapes", async () => {
-    tmpDirMocks.resolvePreferredRemoteClawTmpDir.mockReturnValue("/tmp/openclaw-preferred");
+    tmpDirMocks.resolvePreferredRemoteClawTmpDir.mockReturnValue("/tmp/remoteclaw-preferred");
     const { res, outPath } = await waitForImplicitDownloadOutput({
       downloadUrl: "https://example.com/evil",
       suggestedFilename: "../../../../etc/passwd",
     });
     expect(typeof outPath).toBe("string");
     expect(path.dirname(String(outPath))).toBe(
-      path.join(path.sep, "tmp", "openclaw-preferred", "downloads"),
+      path.join(path.sep, "tmp", "remoteclaw-preferred", "downloads"),
     );
     expect(path.basename(String(outPath))).toMatch(/-passwd$/);
     expect(path.normalize(res.path)).toContain(
-      path.normalize(`${path.join("tmp", "openclaw-preferred", "downloads")}${path.sep}`),
+      path.normalize(`${path.join("tmp", "remoteclaw-preferred", "downloads")}${path.sep}`),
     );
   });
   it("waits for a matching response and returns its body", async () => {

--- a/src/canvas-host/server.test.ts
+++ b/src/canvas-host/server.test.ts
@@ -66,7 +66,7 @@ describe("canvas host", () => {
   };
 
   beforeAll(async () => {
-    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-canvas-fixtures-"));
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-canvas-fixtures-"));
   });
 
   afterAll(async () => {

--- a/src/channels/plugins/onboarding/telegram.ts
+++ b/src/channels/plugins/onboarding/telegram.ts
@@ -32,7 +32,7 @@ async function noteTelegramTokenHelp(prompter: WizardPrompter): Promise<void> {
       "3) Copy the token (looks like 123456:ABC...)",
       "Tip: you can also set TELEGRAM_BOT_TOKEN in your env.",
       `Docs: ${formatDocsLink("/telegram")}`,
-      "Website: https://openclaw.ai",
+      "Website: https://remoteclaw.ai",
     ].join("\n"),
     "Telegram bot token",
   );
@@ -45,7 +45,7 @@ async function noteTelegramUserIdHelp(prompter: WizardPrompter): Promise<void> {
       "2) Or call https://api.telegram.org/bot<bot_token>/getUpdates and read message.from.id",
       "3) Third-party: DM @userinfobot or @getidsbot",
       `Docs: ${formatDocsLink("/telegram")}`,
-      "Website: https://openclaw.ai",
+      "Website: https://remoteclaw.ai",
     ].join("\n"),
     "Telegram user id",
   );

--- a/src/channels/plugins/onboarding/whatsapp.test.ts
+++ b/src/channels/plugins/onboarding/whatsapp.test.ts
@@ -10,7 +10,7 @@ const listWhatsAppAccountIdsMock = vi.hoisted(() => vi.fn(() => [] as string[]))
 const resolveDefaultWhatsAppAccountIdMock = vi.hoisted(() => vi.fn(() => DEFAULT_ACCOUNT_ID));
 const resolveWhatsAppAuthDirMock = vi.hoisted(() =>
   vi.fn(() => ({
-    authDir: "/tmp/openclaw-whatsapp-test",
+    authDir: "/tmp/remoteclaw-whatsapp-test",
   })),
 );
 
@@ -127,7 +127,7 @@ describe("whatsappOnboardingAdapter.configure", () => {
     pathExistsMock.mockResolvedValue(false);
     listWhatsAppAccountIdsMock.mockReturnValue([]);
     resolveDefaultWhatsAppAccountIdMock.mockReturnValue(DEFAULT_ACCOUNT_ID);
-    resolveWhatsAppAuthDirMock.mockReturnValue({ authDir: "/tmp/openclaw-whatsapp-test" });
+    resolveWhatsAppAuthDirMock.mockReturnValue({ authDir: "/tmp/remoteclaw-whatsapp-test" });
   });
 
   it("applies owner allowlist when forceAllowFrom is enabled", async () => {

--- a/src/channels/registry.helpers.test.ts
+++ b/src/channels/registry.helpers.test.ts
@@ -37,6 +37,6 @@ describe("channel registry helpers", () => {
     );
     expect(line).not.toContain("Docs:");
     expect(line).toContain("/channels/telegram");
-    expect(line).toContain("https://openclaw.ai");
+    expect(line).toContain("https://remoteclaw.ai");
   });
 });

--- a/src/channels/session.test.ts
+++ b/src/channels/session.test.ts
@@ -26,7 +26,7 @@ describe("recordInboundSession", () => {
     const { recordInboundSession } = await import("./session.js");
 
     await recordInboundSession({
-      storePath: "/tmp/openclaw-session-store.json",
+      storePath: "/tmp/remoteclaw-session-store.json",
       sessionKey: "agent:main:telegram:1234:thread:42",
       ctx,
       updateLastRoute: {
@@ -53,7 +53,7 @@ describe("recordInboundSession", () => {
     const { recordInboundSession } = await import("./session.js");
 
     await recordInboundSession({
-      storePath: "/tmp/openclaw-session-store.json",
+      storePath: "/tmp/remoteclaw-session-store.json",
       sessionKey: "agent:main:telegram:1234:thread:42",
       ctx,
       updateLastRoute: {
@@ -80,7 +80,7 @@ describe("recordInboundSession", () => {
     const { recordInboundSession } = await import("./session.js");
 
     await recordInboundSession({
-      storePath: "/tmp/openclaw-session-store.json",
+      storePath: "/tmp/remoteclaw-session-store.json",
       sessionKey: "Agent:Main:Telegram:1234:Thread:42",
       ctx,
       updateLastRoute: {

--- a/src/cli/acp-cli.option-collisions.test.ts
+++ b/src/cli/acp-cli.option-collisions.test.ts
@@ -32,7 +32,7 @@ describe("acp cli option collisions", () => {
     secrets: { token?: string; password?: string },
     run: (files: { tokenFile?: string; passwordFile?: string }) => Promise<T>,
   ): Promise<T> {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-cli-"));
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-acp-cli-"));
     try {
       const files: { tokenFile?: string; passwordFile?: string } = {};
       if (secrets.token !== undefined) {
@@ -148,7 +148,7 @@ describe("acp cli option collisions", () => {
   });
 
   it("reports missing token-file read errors", async () => {
-    await parseAcp(["--token-file", "/tmp/openclaw-acp-missing-token.txt"]);
+    await parseAcp(["--token-file", "/tmp/remoteclaw-acp-missing-token.txt"]);
     expectCliError(/Failed to read Gateway token file/);
   });
 });

--- a/src/cli/acp-cli.ts
+++ b/src/cli/acp-cli.ts
@@ -48,7 +48,8 @@ export function registerAcpCli(program: Command) {
     .option("-v, --verbose", "Verbose logging to stderr", false)
     .addHelpText(
       "after",
-      () => `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/acp", "docs.openclaw.ai/cli/acp")}\n`,
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/acp", "docs.remoteclaw.ai/cli/acp")}\n`,
     )
     .action(async (opts) => {
       try {

--- a/src/cli/browser-cli-extension.test.ts
+++ b/src/cli/browser-cli-extension.test.ts
@@ -129,7 +129,7 @@ function writeManifest(dir: string) {
 
 describe("bundled extension resolver (fs-mocked)", () => {
   it("walks up to find the assets directory", () => {
-    const root = abs("/tmp/openclaw-ext-root");
+    const root = abs("/tmp/remoteclaw-ext-root");
     const here = path.join(root, "dist", "cli");
     const assets = path.join(root, "assets", "chrome-extension");
 
@@ -140,7 +140,7 @@ describe("bundled extension resolver (fs-mocked)", () => {
   });
 
   it("prefers the nearest assets directory", () => {
-    const root = abs("/tmp/openclaw-ext-root-nearest");
+    const root = abs("/tmp/remoteclaw-ext-root-nearest");
     const here = path.join(root, "dist", "cli");
     const distAssets = path.join(root, "dist", "assets", "chrome-extension");
     const rootAssets = path.join(root, "assets", "chrome-extension");
@@ -155,7 +155,7 @@ describe("bundled extension resolver (fs-mocked)", () => {
 
 describe("browser extension install (fs-mocked)", () => {
   it("installs into the state dir (never node_modules)", async () => {
-    const tmp = abs("/tmp/openclaw-ext-install");
+    const tmp = abs("/tmp/remoteclaw-ext-install");
     const sourceDir = path.join(tmp, "source-ext");
     writeManifest(sourceDir);
     setFile(path.join(sourceDir, "test.txt"), "ok");
@@ -169,7 +169,7 @@ describe("browser extension install (fs-mocked)", () => {
   });
 
   it("copies extension path to clipboard", async () => {
-    const tmp = abs("/tmp/openclaw-ext-path");
+    const tmp = abs("/tmp/remoteclaw-ext-path");
     await withEnvAsync({ REMOTECLAW_STATE_DIR: tmp }, async () => {
       copyToClipboard.mockResolvedValue(true);
 

--- a/src/cli/browser-cli-extension.ts
+++ b/src/cli/browser-cli-extension.ts
@@ -103,7 +103,7 @@ export function registerBrowserExtensionCommands(
             `- “Load unpacked” → select: ${displayPath}`,
             `- Pin “RemoteClaw Browser Relay”, then click it on the tab (badge shows ON)`,
             "",
-            `${theme.muted("Docs:")} ${formatDocsLink("/tools/chrome-extension", "docs.openclaw.ai/tools/chrome-extension")}`,
+            `${theme.muted("Docs:")} ${formatDocsLink("/tools/chrome-extension", "docs.remoteclaw.ai/tools/chrome-extension")}`,
           ].join("\n"),
         ),
       );
@@ -120,7 +120,7 @@ export function registerBrowserExtensionCommands(
           danger(
             [
               `Chrome extension is not installed. Run: "${formatCliCommand("openclaw browser extension install")}"`,
-              `Docs: ${formatDocsLink("/tools/chrome-extension", "docs.openclaw.ai/tools/chrome-extension")}`,
+              `Docs: ${formatDocsLink("/tools/chrome-extension", "docs.remoteclaw.ai/tools/chrome-extension")}`,
             ].join("\n"),
           ),
         );

--- a/src/cli/browser-cli.ts
+++ b/src/cli/browser-cli.ts
@@ -30,7 +30,7 @@ export function registerBrowserCli(program: Command) {
           true,
         )}\n\n${theme.muted("Docs:")} ${formatDocsLink(
           "/cli/browser",
-          "docs.openclaw.ai/cli/browser",
+          "docs.remoteclaw.ai/cli/browser",
         )}\n`,
     )
     .action(() => {

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -85,7 +85,7 @@ export function registerChannelsCli(program: Command) {
           ["openclaw channels login --channel whatsapp", "Link a WhatsApp Web account."],
         ])}\n\n${theme.muted("Docs:")} ${formatDocsLink(
           "/cli/channels",
-          "docs.openclaw.ai/cli/channels",
+          "docs.remoteclaw.ai/cli/channels",
         )}\n`,
     );
 

--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -55,10 +55,12 @@ describe("dns cli", () => {
     try {
       const program = new Command();
       registerDnsCli(program);
-      await program.parseAsync(["dns", "setup", "--domain", "openclaw.internal"], { from: "user" });
+      await program.parseAsync(["dns", "setup", "--domain", "remoteclaw.internal"], {
+        from: "user",
+      });
       const output = log.mock.calls.map((call) => call.join(" ")).join("\\n");
       expect(output).toContain("DNS setup");
-      expect(output).toContain("openclaw.internal");
+      expect(output).toContain("remoteclaw.internal");
     } finally {
       log.mockRestore();
     }

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -305,7 +305,7 @@ export function registerConfigCli(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/config", "docs.openclaw.ai/cli/config")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/config", "docs.remoteclaw.ai/cli/config")}\n`,
     )
     .option(
       "--section <section>",

--- a/src/cli/cron-cli/register.ts
+++ b/src/cli/cron-cli/register.ts
@@ -16,7 +16,7 @@ export function registerCronCli(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/cron", "docs.openclaw.ai/cli/cron")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/cron", "docs.remoteclaw.ai/cli/cron")}\n`,
     );
 
   registerCronStatusCommand(cron);

--- a/src/cli/daemon-cli/register.ts
+++ b/src/cli/daemon-cli/register.ts
@@ -10,7 +10,7 @@ export function registerDaemonCli(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/gateway", "docs.openclaw.ai/cli/gateway")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/gateway", "docs.remoteclaw.ai/cli/gateway")}\n`,
     );
 
   addGatewayServiceCommands(daemon, {

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -306,5 +306,5 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
   }
 
   defaultRuntime.log(`${label("Troubles:")} run ${formatCliCommand("openclaw status")}`);
-  defaultRuntime.log(`${label("Troubleshooting:")} https://docs.openclaw.ai/troubleshooting`);
+  defaultRuntime.log(`${label("Troubleshooting:")} https://docs.remoteclaw.ai/troubleshooting`);
 }

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -82,7 +82,7 @@ export function registerDirectoryCli(program: Command) {
           ],
         ])}\n\n${theme.muted("Docs:")} ${formatDocsLink(
           "/cli/directory",
-          "docs.openclaw.ai/cli/directory",
+          "docs.remoteclaw.ai/cli/directory",
         )}\n`,
     )
     .action(() => {

--- a/src/cli/dns-cli.ts
+++ b/src/cli/dns-cli.ts
@@ -105,7 +105,8 @@ export function registerDnsCli(program: Command) {
     .description("DNS helpers for wide-area discovery (Tailscale + CoreDNS)")
     .addHelpText(
       "after",
-      () => `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/dns", "docs.openclaw.ai/cli/dns")}\n`,
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/dns", "docs.remoteclaw.ai/cli/dns")}\n`,
     );
 
   dns

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -130,7 +130,7 @@ describe("gateway-cli coverage", () => {
       {
         instanceName: "Studio (RemoteClaw)",
         displayName: "Studio",
-        domain: "openclaw.internal.",
+        domain: "remoteclaw.internal.",
         host: "studio.openclaw.internal",
         lanHost: "studio.local",
         tailnetDns: "studio.tailnet.ts.net",

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -77,7 +77,7 @@ vi.mock("../../terminal/health-style.js", () => ({
 }));
 
 vi.mock("../../terminal/links.js", () => ({
-  formatDocsLink: () => "docs.openclaw.ai/cli/gateway",
+  formatDocsLink: () => "docs.remoteclaw.ai/cli/gateway",
 }));
 
 vi.mock("../../terminal/theme.js", () => ({

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -99,7 +99,7 @@ export function registerGatewayCli(program: Command) {
             ["openclaw gateway status", "Show service status and probe reachability."],
             ["openclaw gateway discover", "Find local and wide-area gateway beacons."],
             ["openclaw gateway call health", "Call a gateway RPC method directly."],
-          ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/gateway", "docs.openclaw.ai/cli/gateway")}\n`,
+          ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/gateway", "docs.remoteclaw.ai/cli/gateway")}\n`,
       ),
   );
 

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -21,7 +21,7 @@ const runGatewayLoop = vi.fn(async ({ start }: { start: () => Promise<unknown> }
 const { defaultRuntime, resetRuntimeCapture } = createCliRuntimeCapture();
 
 vi.mock("../../config/config.js", () => ({
-  getConfigPath: () => "/tmp/openclaw-test-missing-config.json",
+  getConfigPath: () => "/tmp/remoteclaw-test-missing-config.json",
   loadConfig: () => ({}),
   readConfigFileSnapshot: async () => ({ exists: false }),
   resolveStateDir: () => "/tmp",

--- a/src/cli/hooks-cli.test.ts
+++ b/src/cli/hooks-cli.test.ts
@@ -17,7 +17,7 @@ const report: HookStatusReport = {
       handlerPath: "/tmp/hooks/session-memory/handler.js",
       hookKey: "session-memory",
       emoji: "💾",
-      homepage: "https://docs.openclaw.ai/automation/hooks#session-memory",
+      homepage: "https://docs.remoteclaw.ai/automation/hooks#session-memory",
       events: ["command:new"],
       always: false,
       disabled: false,
@@ -48,7 +48,7 @@ describe("hooks cli formatting", () => {
         {
           name: "plugin-hook",
           description: "Hook from plugin",
-          source: "openclaw-plugin",
+          source: "remoteclaw-plugin",
           pluginId: "voice-call",
           filePath: "/tmp/hooks/plugin-hook/HOOK.md",
           baseDir: "/tmp/hooks/plugin-hook",

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -513,7 +513,7 @@ export function registerHooksCli(program: Command): void {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/hooks", "docs.openclaw.ai/cli/hooks")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/hooks", "docs.remoteclaw.ai/cli/hooks")}\n`,
     );
 
   hooks

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -210,7 +210,7 @@ export function registerLogsCli(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/logs", "docs.openclaw.ai/cli/logs")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/logs", "docs.remoteclaw.ai/cli/logs")}\n`,
     );
 
   addGatewayClientOptions(logs);

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -13,7 +13,7 @@ import {
 import { parseScreenRecordPayload, screenRecordTempPath } from "./nodes-screen.js";
 
 async function withCameraTempDir<T>(run: (dir: string) => Promise<T>): Promise<T> {
-  return await withTempDir("openclaw-test-", run);
+  return await withTempDir("remoteclaw-test-", run);
 }
 
 describe("nodes camera helpers", () => {

--- a/src/cli/nodes-cli/register.ts
+++ b/src/cli/nodes-cli/register.ts
@@ -24,7 +24,7 @@ export function registerNodesCli(program: Command) {
           ["openclaw nodes pairing pending", "Show pending node pairing requests."],
           ['openclaw nodes run --node <id> --raw "uname -a"', "Run a shell command on a node."],
           ["openclaw nodes camera snap --node <id>", "Capture a photo from a node camera."],
-        ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/nodes", "docs.openclaw.ai/cli/nodes")}\n`,
+        ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/nodes", "docs.remoteclaw.ai/cli/nodes")}\n`,
     );
 
   registerNodesStatusCommands(nodes);

--- a/src/cli/pairing-cli.ts
+++ b/src/cli/pairing-cli.ts
@@ -57,7 +57,7 @@ export function registerPairingCli(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/pairing", "docs.openclaw.ai/cli/pairing")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/pairing", "docs.remoteclaw.ai/cli/pairing")}\n`,
     );
 
   pairing

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -154,7 +154,7 @@ export function registerPluginsCli(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/plugins", "docs.openclaw.ai/cli/plugins")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/plugins", "docs.remoteclaw.ai/cli/plugins")}\n`,
     );
 
   plugins
@@ -731,7 +731,7 @@ export function registerPluginsCli(program: Command) {
           lines.push(`- ${target}${diag.message}`);
         }
       }
-      const docs = formatDocsLink("/plugin", "docs.openclaw.ai/plugin");
+      const docs = formatDocsLink("/plugin", "docs.remoteclaw.ai/plugin");
       lines.push("");
       lines.push(`${theme.muted("Docs:")} ${docs}`);
       defaultRuntime.log(lines.join("\n"));

--- a/src/cli/profile.test.ts
+++ b/src/cli/profile.test.ts
@@ -83,7 +83,7 @@ describe("applyCliProfileEnv", () => {
 
   it("uses REMOTECLAW_HOME when deriving profile state dir", () => {
     const env: Record<string, string | undefined> = {
-      REMOTECLAW_HOME: "/srv/openclaw-home",
+      REMOTECLAW_HOME: "/srv/remoteclaw-home",
       HOME: "/home/other",
     };
     applyCliProfileEnv({
@@ -92,7 +92,7 @@ describe("applyCliProfileEnv", () => {
       homedir: () => "/home/fallback",
     });
 
-    const resolvedHome = path.resolve("/srv/openclaw-home");
+    const resolvedHome = path.resolve("/srv/remoteclaw-home");
     expect(env.REMOTECLAW_STATE_DIR).toBe(path.join(resolvedHome, ".remoteclaw-work"));
     expect(env.REMOTECLAW_CONFIG_PATH).toBe(
       path.join(resolvedHome, ".remoteclaw-work", "remoteclaw.json"),

--- a/src/cli/program/help.test.ts
+++ b/src/cli/program/help.test.ts
@@ -104,7 +104,7 @@ describe("configureProgramHelp", () => {
     const help = captureHelpOutput(program);
     expect(help).toContain("BANNER-LINE");
     expect(help).toContain("Examples:");
-    expect(help).toContain("https://docs.openclaw.ai/cli");
+    expect(help).toContain("https://docs.remoteclaw.ai/cli");
   });
 
   it("prints version and exits immediately when version flags are present", () => {

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -133,7 +133,7 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     if (command !== program) {
       return "";
     }
-    const docs = formatDocsLink("/cli", "docs.openclaw.ai/cli");
+    const docs = formatDocsLink("/cli", "docs.remoteclaw.ai/cli");
     return `\n${theme.heading("Examples:")}\n${fmtExamples}\n\n${theme.muted("Docs:")} ${docs}\n`;
   });
 }

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -73,7 +73,7 @@ afterEach(() => {
 
 describe("registerPreActionHooks", () => {
   function buildProgram() {
-    const program = new Command().name("openclaw");
+    const program = new Command().name("remoteclaw");
     program.command("status").action(async () => {});
     program.command("doctor").action(async () => {});
     program.command("completion").action(async () => {});

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -67,7 +67,7 @@ ${formatHelpExamples([
   ],
 ])}
 
-${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/agent")}`,
+${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.remoteclaw.ai/cli/agent")}`,
     )
     .action(async (opts) => {
       const verboseLevel = typeof opts.verbose === "string" ? opts.verbose.toLowerCase() : "";
@@ -85,7 +85,7 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/agents", "docs.openclaw.ai/cli/agents")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/agents", "docs.remoteclaw.ai/cli/agents")}\n`,
     );
 
   agents

--- a/src/cli/program/register.configure.ts
+++ b/src/cli/program/register.configure.ts
@@ -15,7 +15,7 @@ export function registerConfigureCommand(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/configure", "docs.openclaw.ai/cli/configure")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/configure", "docs.remoteclaw.ai/cli/configure")}\n`,
     )
     .option(
       "--section <section>",

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -15,7 +15,7 @@ export function registerMaintenanceCommands(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/doctor", "docs.openclaw.ai/cli/doctor")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/doctor", "docs.remoteclaw.ai/cli/doctor")}\n`,
     )
     .option("--no-workspace-suggestions", "Disable workspace memory system suggestions", false)
     .option("--yes", "Accept defaults without prompting", false)
@@ -46,7 +46,7 @@ export function registerMaintenanceCommands(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/dashboard", "docs.openclaw.ai/cli/dashboard")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/dashboard", "docs.remoteclaw.ai/cli/dashboard")}\n`,
     )
     .option("--no-open", "Print URL but do not launch a browser")
     .action(async (opts) => {
@@ -63,7 +63,7 @@ export function registerMaintenanceCommands(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/reset", "docs.openclaw.ai/cli/reset")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/reset", "docs.remoteclaw.ai/cli/reset")}\n`,
     )
     .option("--scope <scope>", "config|config+creds+sessions|full (default: interactive prompt)")
     .option("--yes", "Skip confirmation prompts", false)
@@ -86,7 +86,7 @@ export function registerMaintenanceCommands(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/uninstall", "docs.openclaw.ai/cli/uninstall")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/uninstall", "docs.remoteclaw.ai/cli/uninstall")}\n`,
     )
     .option("--service", "Remove the gateway service", false)
     .option("--state", "Remove state + config", false)

--- a/src/cli/program/register.message.ts
+++ b/src/cli/program/register.message.ts
@@ -46,7 +46,7 @@ ${formatHelpExamples([
   ],
 ])}
 
-${theme.muted("Docs:")} ${formatDocsLink("/cli/message", "docs.openclaw.ai/cli/message")}`,
+${theme.muted("Docs:")} ${formatDocsLink("/cli/message", "docs.remoteclaw.ai/cli/message")}`,
     )
     .action(() => {
       message.help({ error: true });

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -45,7 +45,7 @@ export function registerOnboardCommand(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/onboard", "docs.openclaw.ai/cli/onboard")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/onboard", "docs.remoteclaw.ai/cli/onboard")}\n`,
     )
     .option("--workspace <dir>", "Agent workspace directory (default: ~/.remoteclaw/workspace)")
     .option("--reset", "Reset config + credentials + sessions + workspace before running wizard")

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -14,7 +14,7 @@ export function registerSetupCommand(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/setup", "docs.openclaw.ai/cli/setup")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/setup", "docs.remoteclaw.ai/cli/setup")}\n`,
     )
     .option(
       "--workspace <dir>",

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -69,7 +69,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/status", "docs.openclaw.ai/cli/status")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/status", "docs.remoteclaw.ai/cli/status")}\n`,
     )
     .action(async (opts) => {
       await runWithVerboseAndTimeout(opts, async ({ verbose, timeoutMs }) => {
@@ -97,7 +97,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/health", "docs.openclaw.ai/cli/health")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/health", "docs.remoteclaw.ai/cli/health")}\n`,
     )
     .action(async (opts) => {
       await runWithVerboseAndTimeout(opts, async ({ verbose, timeoutMs }) => {
@@ -138,7 +138,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/sessions", "docs.openclaw.ai/cli/sessions")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/sessions", "docs.remoteclaw.ai/cli/sessions")}\n`,
     )
     .action(async (opts) => {
       setVerbose(Boolean(opts.verbose));

--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -81,7 +81,7 @@ describe("registerSubCliCommands", () => {
   });
 
   it("re-parses argv for lazy subcommands", async () => {
-    const program = createRegisteredProgram(["node", "openclaw", "nodes", "list"], "openclaw");
+    const program = createRegisteredProgram(["node", "openclaw", "nodes", "list"], "remoteclaw");
 
     expect(program.commands.map((cmd) => cmd.name())).toEqual(["nodes"]);
 
@@ -92,7 +92,7 @@ describe("registerSubCliCommands", () => {
   });
 
   it("replaces placeholder when registering a subcommand by name", async () => {
-    const program = createRegisteredProgram(["node", "openclaw", "acp", "--help"], "openclaw");
+    const program = createRegisteredProgram(["node", "openclaw", "acp", "--help"], "remoteclaw");
 
     await registerSubCliByName(program, "acp");
 

--- a/src/cli/qr-cli.ts
+++ b/src/cli/qr-cli.ts
@@ -41,7 +41,7 @@ export function registerQrCli(program: Command) {
     .description("Generate an iOS pairing QR code and setup code")
     .addHelpText(
       "after",
-      () => `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/qr", "docs.openclaw.ai/cli/qr")}\n`,
+      () => `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/qr", "docs.remoteclaw.ai/cli/qr")}\n`,
     )
     .option(
       "--remote",

--- a/src/cli/security-cli.ts
+++ b/src/cli/security-cli.ts
@@ -39,7 +39,7 @@ export function registerSecurityCli(program: Command) {
           ["openclaw security audit --deep", "Include best-effort live Gateway probe checks."],
           ["openclaw security audit --fix", "Apply safe remediations and file-permission fixes."],
           ["openclaw security audit --json", "Output machine-readable JSON."],
-        ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/security", "docs.openclaw.ai/cli/security")}\n`,
+        ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/security", "docs.remoteclaw.ai/cli/security")}\n`,
     );
 
   security

--- a/src/cli/system-cli.ts
+++ b/src/cli/system-cli.ts
@@ -45,7 +45,7 @@ export function registerSystemCli(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/system", "docs.openclaw.ai/cli/system")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/system", "docs.remoteclaw.ai/cli/system")}\n`,
     );
 
   addGatewayClientOptions(

--- a/src/cli/tui-cli.ts
+++ b/src/cli/tui-cli.ts
@@ -20,7 +20,8 @@ export function registerTuiCli(program: Command) {
     .option("--history-limit <n>", "History entries to load", "200")
     .addHelpText(
       "after",
-      () => `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/tui", "docs.openclaw.ai/cli/tui")}\n`,
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/tui", "docs.remoteclaw.ai/cli/tui")}\n`,
     )
     .action(async (opts) => {
       try {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -133,7 +133,7 @@ const { updateCommand, registerUpdateCli, updateStatusCommand, updateWizardComma
   await import("./update-cli.js");
 
 describe("update-cli", () => {
-  const fixtureRoot = "/tmp/openclaw-update-tests";
+  const fixtureRoot = "/tmp/remoteclaw-update-tests";
   let fixtureCount = 0;
 
   const createCaseDir = (prefix: string) => {
@@ -144,7 +144,7 @@ describe("update-cli", () => {
 
   const baseConfig = {} as RemoteClawConfig;
   const baseSnapshot: ConfigFileSnapshot = {
-    path: "/tmp/openclaw-config.json",
+    path: "/tmp/remoteclaw-config.json",
     exists: true,
     raw: "{}",
     parsed: {},
@@ -221,7 +221,7 @@ describe("update-cli", () => {
   };
 
   const setupNonInteractiveDowngrade = async () => {
-    const tempDir = createCaseDir("openclaw-update");
+    const tempDir = createCaseDir("remoteclaw-update");
     setTty(false);
     readPackageVersion.mockResolvedValue("2.0.0");
 
@@ -312,7 +312,7 @@ describe("update-cli", () => {
       killed: false,
       termination: "exit",
     });
-    readPackageName.mockResolvedValue("openclaw");
+    readPackageName.mockResolvedValue("remoteclaw");
     readPackageVersion.mockResolvedValue("1.0.0");
     resolveGlobalManager.mockResolvedValue("npm");
     serviceLoaded.mockResolvedValue(false);
@@ -321,7 +321,7 @@ describe("update-cli", () => {
       pid: 4242,
       state: "running",
     });
-    prepareRestartScript.mockResolvedValue("/tmp/openclaw-restart-test.sh");
+    prepareRestartScript.mockResolvedValue("/tmp/remoteclaw-restart-test.sh");
     runRestartScript.mockResolvedValue(undefined);
     inspectPortUsage.mockResolvedValue({
       port: 18789,
@@ -421,7 +421,7 @@ describe("update-cli", () => {
       mode: "npm" as const,
       options: { yes: true },
       prepare: async () => {
-        const tempDir = createCaseDir("openclaw-update");
+        const tempDir = createCaseDir("remoteclaw-update");
         mockPackageInstallStatus(tempDir);
       },
       expectedChannel: "stable" as const,
@@ -453,7 +453,7 @@ describe("update-cli", () => {
   });
 
   it("falls back to latest when beta tag is older than release", async () => {
-    const tempDir = createCaseDir("openclaw-update");
+    const tempDir = createCaseDir("remoteclaw-update");
 
     mockPackageInstallStatus(tempDir);
     vi.mocked(readConfigFileSnapshot).mockResolvedValue({
@@ -477,7 +477,7 @@ describe("update-cli", () => {
   });
 
   it("honors --tag override", async () => {
-    const tempDir = createCaseDir("openclaw-update");
+    const tempDir = createCaseDir("remoteclaw-update");
 
     vi.mocked(resolveRemoteClawPackageRoot).mockResolvedValue(tempDir);
     vi.mocked(runGatewayUpdate).mockResolvedValue(
@@ -559,7 +559,7 @@ describe("update-cli", () => {
   });
 
   it("updateCommand refreshes service env from updated install root when available", async () => {
-    const root = createCaseDir("openclaw-updated-root");
+    const root = createCaseDir("remoteclaw-updated-root");
     await fs.mkdir(path.join(root, "dist"), { recursive: true });
     await fs.writeFile(path.join(root, "dist", "entry.js"), "console.log('ok');\n", "utf8");
 
@@ -737,7 +737,7 @@ describe("update-cli", () => {
   });
 
   it("updateWizardCommand offers dev checkout and forwards selections", async () => {
-    const tempDir = createCaseDir("openclaw-update-wizard");
+    const tempDir = createCaseDir("remoteclaw-update-wizard");
     await withEnvAsync({ REMOTECLAW_GIT_DIR: tempDir }, async () => {
       setTty(true);
 

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -82,7 +82,7 @@ ${theme.heading("Notes:")}
   - Downgrades require confirmation (can break configuration)
   - Skips update if the working directory has uncommitted changes
 
-${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/update")}`;
+${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.remoteclaw.ai/cli/update")}`;
     })
     .action(async (opts) => {
       try {
@@ -107,7 +107,7 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/up
     .option("--timeout <seconds>", "Timeout for each update step in seconds (default: 1200)")
     .addHelpText(
       "after",
-      `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/update")}\n`,
+      `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.remoteclaw.ai/cli/update")}\n`,
     )
     .action(async (opts, command) => {
       try {
@@ -136,7 +136,7 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/up
           "- Shows current update channel (stable/beta/dev) and source",
         )}\n${theme.muted("- Includes git tag/branch/SHA for source checkouts")}\n\n${theme.muted(
           "Docs:",
-        )} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/update")}`,
+        )} ${formatDocsLink("/cli/update", "docs.remoteclaw.ai/cli/update")}`,
     )
     .action(async (opts, command) => {
       try {

--- a/src/cli/update-cli/shared.command-runner.test.ts
+++ b/src/cli/update-cli/shared.command-runner.test.ts
@@ -34,13 +34,13 @@ describe("createGlobalCommandRunner", () => {
 
     const result = await runCommand(["npm", "root", "-g"], {
       timeoutMs: 1200,
-      cwd: "/tmp/openclaw",
+      cwd: "/tmp/remoteclaw",
       env: { REMOTECLAW_TEST: "1" },
     });
 
     expect(runCommandWithTimeout).toHaveBeenCalledWith(["npm", "root", "-g"], {
       timeoutMs: 1200,
-      cwd: "/tmp/openclaw",
+      cwd: "/tmp/remoteclaw",
       env: { REMOTECLAW_TEST: "1" },
     });
     expect(result).toEqual({

--- a/src/cli/webhooks-cli.ts
+++ b/src/cli/webhooks-cli.ts
@@ -27,7 +27,7 @@ export function registerWebhooksCli(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/webhooks", "docs.openclaw.ai/cli/webhooks")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/webhooks", "docs.remoteclaw.ai/cli/webhooks")}\n`,
     );
 
   const gmail = webhooks.command("gmail").description("Gmail Pub/Sub hooks (via gogcli)");

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -47,7 +47,7 @@ async function withTempStore(
   fn: (ctx: { dir: string; store: string }) => Promise<void>,
   overrides?: Partial<RemoteClawConfig>,
 ) {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-cli-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-agent-cli-"));
   const store = path.join(dir, "sessions.json");
   mockConfig(store, overrides);
   try {

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -120,7 +120,7 @@ const runtime: RuntimeEnv = {
 const configSpy = vi.spyOn(configModule, "loadConfig");
 
 async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
-  return withTempHomeBase(fn, { prefix: "openclaw-agent-" });
+  return withTempHomeBase(fn, { prefix: "remoteclaw-agent-" });
 }
 
 function mockConfig(
@@ -135,7 +135,7 @@ function mockConfig(
       defaults: {
         model: { primary: "anthropic/claude-opus-4-5" },
         models: { "anthropic/claude-opus-4-5": {} },
-        workspace: path.join(home, "openclaw"),
+        workspace: path.join(home, "remoteclaw"),
         ...agentOverrides,
       },
       list: agentsList,

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -359,7 +359,7 @@ export async function agentsAddCommand(
         await prompter.note(
           [
             "Routing unchanged. Add bindings when you're ready.",
-            "Docs: https://docs.openclaw.ai/concepts/multi-agent",
+            "Docs: https://docs.remoteclaw.ai/concepts/multi-agent",
           ].join("\n"),
           "Routing",
         );

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -48,7 +48,7 @@ describe("cleanup path removals", () => {
 
   it("removes state and only linked paths outside state", async () => {
     const runtime = createRuntimeMock();
-    const tmpRoot = path.join(path.parse(process.cwd()).root, "tmp", "openclaw-cleanup");
+    const tmpRoot = path.join(path.parse(process.cwd()).root, "tmp", "remoteclaw-cleanup");
     await removeStateAndLinkedPaths(
       {
         stateDir: path.join(tmpRoot, "state"),
@@ -64,19 +64,19 @@ describe("cleanup path removals", () => {
     const joinedLogs = runtime.log.mock.calls
       .map(([line]) => line.replaceAll("\\", "/"))
       .join("\n");
-    expect(joinedLogs).toContain("/tmp/openclaw-cleanup/state");
-    expect(joinedLogs).toContain("/tmp/openclaw-cleanup/oauth");
+    expect(joinedLogs).toContain("/tmp/remoteclaw-cleanup/state");
+    expect(joinedLogs).toContain("/tmp/remoteclaw-cleanup/oauth");
     expect(joinedLogs).not.toContain("remoteclaw.json");
   });
 
   it("removes every workspace directory", async () => {
     const runtime = createRuntimeMock();
-    const workspaces = ["/tmp/openclaw-workspace-1", "/tmp/openclaw-workspace-2"];
+    const workspaces = ["/tmp/remoteclaw-workspace-1", "/tmp/remoteclaw-workspace-2"];
 
     await removeWorkspaceDirs(workspaces, runtime, { dryRun: true });
 
     const logs = runtime.log.mock.calls.map(([line]) => line);
-    expect(logs).toContain("[dry-run] remove /tmp/openclaw-workspace-1");
-    expect(logs).toContain("[dry-run] remove /tmp/openclaw-workspace-2");
+    expect(logs).toContain("[dry-run] remove /tmp/remoteclaw-workspace-1");
+    expect(logs).toContain("[dry-run] remove /tmp/remoteclaw-workspace-2");
   });
 });

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -191,7 +191,7 @@ export async function promptGatewayConfig(
         "Only requests from specified proxy IPs will be trusted.",
         "",
         "Common use cases: Pomerium, Caddy + OAuth, Traefik + forward auth",
-        "Docs: https://docs.openclaw.ai/gateway/trusted-proxy-auth",
+        "Docs: https://docs.remoteclaw.ai/gateway/trusted-proxy-auth",
       ].join("\n"),
       "Trusted Proxy Auth",
     );

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -67,8 +67,8 @@ async function runGatewayHealthCheck(params: {
     note(
       [
         "Docs:",
-        "https://docs.openclaw.ai/gateway/health",
-        "https://docs.openclaw.ai/gateway/troubleshooting",
+        "https://docs.remoteclaw.ai/gateway/health",
+        "https://docs.remoteclaw.ai/gateway/troubleshooting",
       ].join("\n"),
       "Health check help",
     );
@@ -138,7 +138,7 @@ export async function runConfigureWizard(
           [
             ...snapshot.issues.map((iss) => `- ${iss.path}: ${iss.message}`),
             "",
-            "Docs: https://docs.openclaw.ai/gateway/configuration",
+            "Docs: https://docs.remoteclaw.ai/gateway/configuration",
           ].join("\n"),
           "Config issues",
         );
@@ -425,7 +425,7 @@ export async function runConfigureWizard(
         `Web UI: ${links.httpUrl}`,
         `Gateway WS: ${links.wsUrl}`,
         gatewayStatusLine,
-        "Docs: https://docs.openclaw.ai/web/control-ui",
+        "Docs: https://docs.remoteclaw.ai/web/control-ui",
       ].join("\n"),
       "Control UI",
     );

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -5,7 +5,7 @@ import { hasBinary } from "../shared/config-eval.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { isRich, theme } from "../terminal/theme.js";
 
-const SEARCH_TOOL = "https://docs.openclaw.ai/mcp.SearchRemoteClaw";
+const SEARCH_TOOL = "https://docs.remoteclaw.ai/mcp.SearchRemoteClaw";
 const SEARCH_TIMEOUT_MS = 30_000;
 const DEFAULT_SNIPPET_MAX = 220;
 
@@ -160,12 +160,12 @@ async function renderMarkdown(markdown: string, runtime: RuntimeEnv) {
 export async function docsSearchCommand(queryParts: string[], runtime: RuntimeEnv) {
   const query = queryParts.join(" ").trim();
   if (!query) {
-    const docs = formatDocsLink("/", "docs.openclaw.ai");
+    const docs = formatDocsLink("/", "docs.remoteclaw.ai");
     if (isRich()) {
       runtime.log(`${theme.muted("Docs:")} ${docs}`);
       runtime.log(`${theme.muted("Search:")} ${formatCliCommand('openclaw docs "your query"')}`);
     } else {
-      runtime.log("Docs: https://docs.openclaw.ai/");
+      runtime.log("Docs: https://docs.remoteclaw.ai/");
       runtime.log(`Search: ${formatCliCommand('openclaw docs "your query"')}`);
     }
     return;

--- a/src/commands/doctor-auth.deprecated-cli-profiles.test.ts
+++ b/src/commands/doctor-auth.deprecated-cli-profiles.test.ts
@@ -24,7 +24,7 @@ function makePrompter(confirmValue: boolean): DoctorPrompter {
 
 beforeEach(() => {
   envSnapshot = captureEnv(["REMOTECLAW_AGENT_DIR", "PI_CODING_AGENT_DIR"]);
-  tempAgentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+  tempAgentDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-auth-"));
   process.env.REMOTECLAW_AGENT_DIR = tempAgentDir;
   process.env.PI_CODING_AGENT_DIR = tempAgentDir;
 });

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -24,7 +24,7 @@ describe("normalizeLegacyConfigValues", () => {
 
   beforeEach(() => {
     previousOauthDir = process.env.REMOTECLAW_OAUTH_DIR;
-    tempOauthDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-oauth-"));
+    tempOauthDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-oauth-"));
     process.env.REMOTECLAW_OAUTH_DIR = tempOauthDir;
   });
 
@@ -87,7 +87,7 @@ describe("normalizeLegacyConfigValues", () => {
   });
 
   it("copies legacy ack reaction when authDir override exists", () => {
-    const customDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wa-auth-"));
+    const customDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-wa-auth-"));
     try {
       writeCreds(customDir);
 

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -45,7 +45,7 @@ export async function noteSecurityWarnings(cfg: RemoteClawConfig) {
   const saferRemoteAccessLines = [
     "  Safer remote access: keep bind loopback and use Tailscale Serve/Funnel or an SSH tunnel.",
     "  Example tunnel: ssh -N -L 18789:127.0.0.1:18789 user@gateway-host",
-    "  Docs: https://docs.openclaw.ai/gateway/remote",
+    "  Docs: https://docs.remoteclaw.ai/gateway/remote",
   ];
 
   if (isExposed) {

--- a/src/commands/doctor-session-locks.test.ts
+++ b/src/commands/doctor-session-locks.test.ts
@@ -19,7 +19,7 @@ describe("noteSessionLockHealth", () => {
   beforeEach(async () => {
     note.mockClear();
     envSnapshot = captureEnv(["REMOTECLAW_STATE_DIR"]);
-    root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-locks-"));
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-doctor-locks-"));
     process.env.REMOTECLAW_STATE_DIR = root;
   });
 

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -71,7 +71,7 @@ describe("doctor state integrity oauth dir checks", () => {
 
   beforeEach(() => {
     envSnapshot = captureEnv();
-    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-state-integrity-"));
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-doctor-state-integrity-"));
     process.env.HOME = tempHome;
     process.env.REMOTECLAW_HOME = tempHome;
     process.env.REMOTECLAW_STATE_DIR = path.join(tempHome, ".remoteclaw");

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -15,7 +15,7 @@ import {
 let tempRoot: string | null = null;
 
 async function makeTempRoot() {
-  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-"));
+  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "remoteclaw-doctor-"));
   tempRoot = root;
   return root;
 }

--- a/src/commands/doctor.e2e-harness.ts
+++ b/src/commands/doctor.e2e-harness.ts
@@ -395,7 +395,7 @@ beforeEach(() => {
   originalStateDir = process.env.REMOTECLAW_STATE_DIR;
   originalUpdateInProgress = process.env.REMOTECLAW_UPDATE_IN_PROGRESS;
   process.env.REMOTECLAW_UPDATE_IN_PROGRESS = "1";
-  tempStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-state-"));
+  tempStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-doctor-state-"));
   process.env.REMOTECLAW_STATE_DIR = tempStateDir;
   fs.mkdirSync(path.join(tempStateDir, "agents", "main", "sessions"), {
     recursive: true,

--- a/src/commands/doctor.warns-state-directory-is-missing.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.test.ts
@@ -17,7 +17,7 @@ describe("doctor command", () => {
   it("warns when the state directory is missing", async () => {
     mockDoctorConfigSnapshot();
 
-    const missingDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-missing-state-"));
+    const missingDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-missing-state-"));
     fs.rmSync(missingDir, { recursive: true, force: true });
     process.env.REMOTECLAW_STATE_DIR = missingDir;
     note.mockClear();

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -157,7 +157,7 @@ describe("getHealthSnapshot", () => {
   });
 
   it("treats telegram.tokenFile as configured", async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-health-"));
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-health-"));
     const tokenFile = path.join(tmpDir, "telegram-token");
     fs.writeFileSync(tokenFile, "t-file\n", "utf-8");
     const { calls, telegram } = await runSuccessfulTelegramProbe(

--- a/src/commands/onboard-auth.config-core.kilocode.test.ts
+++ b/src/commands/onboard-auth.config-core.kilocode.test.ts
@@ -127,7 +127,7 @@ describe("Kilo Gateway provider config", () => {
     });
 
     it("resolves the kilocode api key via resolveApiKeyForProvider", async () => {
-      const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+      const agentDir = mkdtempSync(join(tmpdir(), "remoteclaw-test-"));
       const envSnapshot = captureEnv(["KILOCODE_API_KEY"]);
       process.env.KILOCODE_API_KEY = "kilo-provider-test-key";
 

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -130,7 +130,7 @@ describe("writeOAuthCredentials", () => {
   });
 
   it("writes OAuth credentials to all sibling agent dirs when syncSiblingAgents=true", async () => {
-    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-oauth-sync-"));
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-oauth-sync-"));
     process.env.REMOTECLAW_STATE_DIR = tempStateDir;
 
     const mainAgentDir = path.join(tempStateDir, "agents", "main", "agent");
@@ -167,7 +167,7 @@ describe("writeOAuthCredentials", () => {
   });
 
   it("writes OAuth credentials only to target dir by default", async () => {
-    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-oauth-nosync-"));
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-oauth-nosync-"));
     process.env.REMOTECLAW_STATE_DIR = tempStateDir;
 
     const mainAgentDir = path.join(tempStateDir, "agents", "main", "agent");
@@ -200,7 +200,7 @@ describe("writeOAuthCredentials", () => {
   });
 
   it("syncs siblings from explicit agentDir outside REMOTECLAW_STATE_DIR", async () => {
-    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-oauth-external-"));
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-oauth-external-"));
     process.env.REMOTECLAW_STATE_DIR = tempStateDir;
 
     // Create standard-layout agents tree *outside* REMOTECLAW_STATE_DIR

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -218,8 +218,8 @@ export function formatControlUiSshHint(params: {
     localUrl,
     authedUrl,
     "Docs:",
-    "https://docs.openclaw.ai/gateway/remote",
-    "https://docs.openclaw.ai/web/control-ui",
+    "https://docs.remoteclaw.ai/gateway/remote",
+    "https://docs.remoteclaw.ai/web/control-ui",
   ]
     .filter(Boolean)
     .join("\n");

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -119,7 +119,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
   it("writes gateway token auth into config", async () => {
     await withStateDir("state-noninteractive-", async (stateDir) => {
       const token = "tok_test_123";
-      const workspace = path.join(stateDir, "openclaw");
+      const workspace = path.join(stateDir, "remoteclaw");
 
       await runNonInteractiveOnboarding(
         {
@@ -190,7 +190,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       process.env.REMOTECLAW_CONFIG_PATH = path.join(stateDir, "remoteclaw.json");
 
       const port = getPseudoPort(40_000);
-      const workspace = path.join(stateDir, "openclaw");
+      const workspace = path.join(stateDir, "remoteclaw");
 
       await runNonInteractiveOnboarding(
         {

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -195,7 +195,7 @@ export async function runNonInteractiveOnboardingLocal(params: {
 
   if (!opts.json) {
     runtime.log(
-      `Tip: run \`${formatCliCommand("remoteclaw configure")}\` to customize your setup. Docs: https://docs.openclaw.ai`,
+      `Tip: run \`${formatCliCommand("remoteclaw configure")}\` to customize your setup. Docs: https://docs.remoteclaw.ai`,
     );
   }
 }

--- a/src/commands/onboard-non-interactive/remote.ts
+++ b/src/commands/onboard-non-interactive/remote.ts
@@ -47,7 +47,7 @@ export async function runNonInteractiveOnboardingRemote(params: {
     runtime.log(`Remote gateway: ${remoteUrl}`);
     runtime.log(`Auth: ${payload.auth}`);
     runtime.log(
-      `Tip: run \`${formatCliCommand("remoteclaw configure")}\` to customize your setup. Docs: https://docs.openclaw.ai`,
+      `Tip: run \`${formatCliCommand("remoteclaw configure")}\` to customize your setup. Docs: https://docs.remoteclaw.ai`,
     );
   }
 }

--- a/src/commands/onboard-remote.ts
+++ b/src/commands/onboard-remote.ts
@@ -60,7 +60,7 @@ export async function promptRemoteGatewayConfig(
     await prompter.note(
       [
         "Bonjour discovery requires dns-sd (macOS) or avahi-browse (Linux).",
-        "Docs: https://docs.openclaw.ai/gateway/discovery",
+        "Docs: https://docs.remoteclaw.ai/gateway/discovery",
       ].join("\n"),
       "Discovery",
     );
@@ -124,7 +124,7 @@ export async function promptRemoteGatewayConfig(
             `ssh -N -L 18789:127.0.0.1:18789 <user>@${host}${
               selectedBeacon.sshPort ? ` -p ${selectedBeacon.sshPort}` : ""
             }`,
-            "Docs: https://docs.openclaw.ai/gateway/remote",
+            "Docs: https://docs.remoteclaw.ai/gateway/remote",
           ].join("\n"),
           "SSH tunnel",
         );

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -18,7 +18,7 @@ export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv =
     runtime.error(
       [
         "Non-interactive onboarding requires explicit risk acknowledgement.",
-        "Read: https://docs.openclaw.ai/security",
+        "Read: https://docs.remoteclaw.ai/security",
         `Re-run with: ${formatCliCommand("openclaw onboard --non-interactive --accept-risk ...")}`,
       ].join("\n"),
     );
@@ -40,7 +40,7 @@ export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv =
         "Windows detected — RemoteClaw runs great on WSL2!",
         "Native Windows might be trickier.",
         "Quick setup: wsl --install (one command, one reboot)",
-        "Guide: https://docs.openclaw.ai/windows",
+        "Guide: https://docs.remoteclaw.ai/windows",
       ].join("\n"),
     );
   }

--- a/src/commands/onboarding/plugin-install.test.ts
+++ b/src/commands/onboarding/plugin-install.test.ts
@@ -34,7 +34,7 @@ const baseEntry: ChannelPluginCatalogEntry = {
     blurb: "Test",
   },
   install: {
-    npmSpec: "@openclaw/zalo",
+    npmSpec: "@remoteclaw/zalo",
     localPath: "extensions/zalo",
   },
 };
@@ -102,10 +102,10 @@ describe("ensureOnboardingPluginInstalled", () => {
     expect(result.cfg.plugins?.entries?.zalo?.enabled).toBe(true);
     expect(result.cfg.plugins?.allow).toContain("zalo");
     expect(result.cfg.plugins?.installs?.zalo?.source).toBe("npm");
-    expect(result.cfg.plugins?.installs?.zalo?.spec).toBe("@openclaw/zalo");
+    expect(result.cfg.plugins?.installs?.zalo?.spec).toBe("@remoteclaw/zalo");
     expect(result.cfg.plugins?.installs?.zalo?.installPath).toBe("/tmp/zalo");
     expect(installPluginFromNpmSpec).toHaveBeenCalledWith(
-      expect.objectContaining({ spec: "@openclaw/zalo" }),
+      expect.objectContaining({ spec: "@remoteclaw/zalo" }),
     );
   });
 

--- a/src/commands/signal-install.test.ts
+++ b/src/commands/signal-install.test.ts
@@ -134,7 +134,7 @@ describe("pickAsset", () => {
 
 describe("extractSignalCliArchive", () => {
   async function withArchiveWorkspace(run: (workDir: string) => Promise<void>) {
-    const workDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-signal-install-"));
+    const workDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-signal-install-"));
     try {
       await run(workDir);
     } finally {

--- a/src/commands/signal-install.ts
+++ b/src/commands/signal-install.ts
@@ -242,7 +242,7 @@ async function installSignalCliFromRelease(runtime: RuntimeEnv): Promise<SignalI
     };
   }
 
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-signal-"));
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-signal-"));
   const archivePath = path.join(tmpDir, asset.name);
 
   runtime.log(`Downloading signal-cli ${version} (${asset.name})…`);

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -242,6 +242,6 @@ export async function appendStatusAllDiagnosis(params: {
 
   lines.push("");
   lines.push(muted("Pasteable debug report. Auth tokens redacted."));
-  lines.push("Troubleshooting: https://docs.openclaw.ai/troubleshooting");
+  lines.push("Troubleshooting: https://docs.remoteclaw.ai/troubleshooting");
   lines.push("");
 }

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -597,8 +597,8 @@ export async function statusCommand(
   }
 
   runtime.log("");
-  runtime.log("FAQ: https://docs.openclaw.ai/faq");
-  runtime.log("Troubleshooting: https://docs.openclaw.ai/troubleshooting");
+  runtime.log("FAQ: https://docs.remoteclaw.ai/faq");
+  runtime.log("Troubleshooting: https://docs.remoteclaw.ai/troubleshooting");
   runtime.log("");
   const updateHint = formatUpdateAvailableHint(update);
   if (updateHint) {

--- a/src/config/agent-dirs.test.ts
+++ b/src/config/agent-dirs.test.ts
@@ -22,7 +22,7 @@ describe("resolveEffectiveAgentDir via findDuplicateAgentDirs", () => {
     };
 
     const env = {
-      REMOTECLAW_HOME: "/srv/openclaw-home",
+      REMOTECLAW_HOME: "/srv/remoteclaw-home",
       HOME: "/home/other",
     } as NodeJS.ProcessEnv;
 
@@ -37,7 +37,7 @@ describe("resolveEffectiveAgentDir via findDuplicateAgentDirs", () => {
     const cfg: RemoteClawConfig = {};
 
     const env = {
-      REMOTECLAW_HOME: "/srv/openclaw-home",
+      REMOTECLAW_HOME: "/srv/remoteclaw-home",
     } as NodeJS.ProcessEnv;
 
     // No duplicates for a single default agent

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -14,11 +14,11 @@ import { RemoteClawSchema } from "./zod-schema.js";
 describe("$schema key in config (#14998)", () => {
   it("accepts config with $schema string", () => {
     const result = RemoteClawSchema.safeParse({
-      $schema: "https://openclaw.ai/config.json",
+      $schema: "https://remoteclaw.ai/config.json",
     });
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.$schema).toBe("https://openclaw.ai/config.json");
+      expect(result.data.$schema).toBe("https://remoteclaw.ai/config.json");
     }
   });
 

--- a/src/config/config.discord-presence.test.ts
+++ b/src/config/config.discord-presence.test.ts
@@ -57,7 +57,7 @@ describe("config discord presence", () => {
       channels: {
         discord: {
           activity: "Live",
-          activityUrl: "https://twitch.tv/openclaw",
+          activityUrl: "https://twitch.tv/remoteclaw",
         },
       },
     });

--- a/src/config/config.discord.test.ts
+++ b/src/config/config.discord.test.ts
@@ -23,7 +23,7 @@ describe("config discord", () => {
               enabled: true,
               allowFrom: ["steipete"],
               groupEnabled: true,
-              groupChannels: ["openclaw-dm"],
+              groupChannels: ["remoteclaw-dm"],
             },
             actions: {
               emojiUploads: true,
@@ -32,7 +32,7 @@ describe("config discord", () => {
             },
             guilds: {
               "123": {
-                slug: "friends-of-openclaw",
+                slug: "friends-of-remoteclaw",
                 requireMention: false,
                 users: ["steipete"],
                 channels: {
@@ -48,11 +48,11 @@ describe("config discord", () => {
 
         expect(cfg.channels?.discord?.enabled).toBe(true);
         expect(cfg.channels?.discord?.dm?.groupEnabled).toBe(true);
-        expect(cfg.channels?.discord?.dm?.groupChannels).toEqual(["openclaw-dm"]);
+        expect(cfg.channels?.discord?.dm?.groupChannels).toEqual(["remoteclaw-dm"]);
         expect(cfg.channels?.discord?.actions?.emojiUploads).toBe(true);
         expect(cfg.channels?.discord?.actions?.stickerUploads).toBe(false);
         expect(cfg.channels?.discord?.actions?.channels).toBe(true);
-        expect(cfg.channels?.discord?.guilds?.["123"]?.slug).toBe("friends-of-openclaw");
+        expect(cfg.channels?.discord?.guilds?.["123"]?.slug).toBe("friends-of-remoteclaw");
         expect(cfg.channels?.discord?.guilds?.["123"]?.channels?.general?.allow).toBe(true);
       },
     );

--- a/src/config/config.identity-avatar.test.ts
+++ b/src/config/config.identity-avatar.test.ts
@@ -6,10 +6,10 @@ import { withTempHome } from "./test-helpers.js";
 describe("identity avatar validation", () => {
   it("accepts workspace-relative avatar paths", async () => {
     await withTempHome(async (home) => {
-      const workspace = path.join(home, "openclaw");
+      const workspace = path.join(home, "remoteclaw");
       const res = validateConfigObject({
         agents: {
-          list: [{ id: "main", workspace, identity: { avatar: "avatars/openclaw.png" } }],
+          list: [{ id: "main", workspace, identity: { avatar: "avatars/remoteclaw.png" } }],
         },
       });
       expect(res.ok).toBe(true);
@@ -18,7 +18,7 @@ describe("identity avatar validation", () => {
 
   it("accepts http(s) and data avatars", async () => {
     await withTempHome(async (home) => {
-      const workspace = path.join(home, "openclaw");
+      const workspace = path.join(home, "remoteclaw");
       const httpRes = validateConfigObject({
         agents: {
           list: [{ id: "main", workspace, identity: { avatar: "https://example.com/avatar.png" } }],
@@ -37,7 +37,7 @@ describe("identity avatar validation", () => {
 
   it("rejects avatar paths outside workspace", async () => {
     await withTempHome(async (home) => {
-      const workspace = path.join(home, "openclaw");
+      const workspace = path.join(home, "remoteclaw");
       const res = validateConfigObject({
         agents: {
           list: [{ id: "main", workspace, identity: { avatar: "../oops.png" } }],

--- a/src/config/config.identity-defaults.test.ts
+++ b/src/config/config.identity-defaults.test.ts
@@ -36,7 +36,7 @@ describe("config identity defaults", () => {
   };
 
   it("does not derive mention defaults and only sets ackReactionScope when identity is present", async () => {
-    await withTempHome("openclaw-config-identity-", async (home) => {
+    await withTempHome("remoteclaw-config-identity-", async (home) => {
       const cfg = await writeAndLoadConfig(home, configWithDefaultIdentity({}));
 
       expect(cfg.messages?.responsePrefix).toBeUndefined();
@@ -47,7 +47,7 @@ describe("config identity defaults", () => {
   });
 
   it("keeps ackReaction unset and does not synthesize agent/session defaults when identity is missing", async () => {
-    await withTempHome("openclaw-config-identity-", async (home) => {
+    await withTempHome("remoteclaw-config-identity-", async (home) => {
       const cfg = await writeAndLoadConfig(home, { messages: {} });
 
       expect(cfg.messages?.ackReaction).toBeUndefined();
@@ -62,7 +62,7 @@ describe("config identity defaults", () => {
   });
 
   it("does not override explicit values", async () => {
-    await withTempHome("openclaw-config-identity-", async (home) => {
+    await withTempHome("remoteclaw-config-identity-", async (home) => {
       const cfg = await writeAndLoadConfig(home, {
         agents: {
           list: [
@@ -88,7 +88,7 @@ describe("config identity defaults", () => {
   });
 
   it("supports provider textChunkLimit config", async () => {
-    await withTempHome("openclaw-config-identity-", async (home) => {
+    await withTempHome("remoteclaw-config-identity-", async (home) => {
       const cfg = await writeAndLoadConfig(home, {
         messages: {
           messagePrefix: "[openclaw]",
@@ -120,7 +120,7 @@ describe("config identity defaults", () => {
   });
 
   it("respects empty responsePrefix to disable identity defaults", async () => {
-    await withTempHome("openclaw-config-identity-", async (home) => {
+    await withTempHome("remoteclaw-config-identity-", async (home) => {
       const cfg = await writeAndLoadConfig(home, configWithDefaultIdentity({ responsePrefix: "" }));
 
       expect(cfg.messages?.responsePrefix).toBe("");

--- a/src/config/config.irc.test.ts
+++ b/src/config/config.irc.test.ts
@@ -23,15 +23,15 @@ describe("config irc", () => {
       channels: {
         irc: {
           host: "irc.libera.chat",
-          nick: "openclaw-bot",
-          channels: ["#openclaw"],
+          nick: "remoteclaw-bot",
+          channels: ["#remoteclaw"],
         },
       },
     });
 
     const config = expectValidConfig(res);
     expect(config.channels?.irc?.host).toBe("irc.libera.chat");
-    expect(config.channels?.irc?.nick).toBe("openclaw-bot");
+    expect(config.channels?.irc?.nick).toBe("remoteclaw-bot");
   });
 
   it('rejects irc.dmPolicy="open" without allowFrom "*"', () => {

--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
@@ -238,7 +238,7 @@ describe("legacy config detection", () => {
         list: [
           {
             id: "work",
-            workspace: "~/openclaw-work",
+            workspace: "~/remoteclaw-work",
             tools: {
               elevated: {
                 enabled: false,

--- a/src/config/config.multi-agent-agentdir-validation.test.ts
+++ b/src/config/config.multi-agent-agentdir-validation.test.ts
@@ -6,7 +6,7 @@ import { withTempHomeConfig } from "./test-helpers.js";
 
 describe("multi-agent agentDir validation", () => {
   it("rejects shared agents.list agentDir", async () => {
-    const shared = path.join(tmpdir(), "openclaw-shared-agentdir");
+    const shared = path.join(tmpdir(), "remoteclaw-shared-agentdir");
     const res = validateConfigObject({
       agents: {
         list: [

--- a/src/config/env-preserve-io.test.ts
+++ b/src/config/env-preserve-io.test.ts
@@ -12,7 +12,7 @@ async function withTempConfig(
   configContent: string,
   run: (configPath: string) => Promise<void>,
 ): Promise<void> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-env-io-"));
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-env-io-"));
   const configPath = path.join(dir, "remoteclaw.json");
   await fs.writeFile(configPath, configContent);
   try {

--- a/src/config/includes.test.ts
+++ b/src/config/includes.test.ts
@@ -12,7 +12,7 @@ import {
 
 const ROOT_DIR = path.parse(process.cwd()).root;
 const CONFIG_DIR = path.join(ROOT_DIR, "config");
-const ETC_REMOTECLAW_DIR = path.join(ROOT_DIR, "etc", "openclaw");
+const ETC_REMOTECLAW_DIR = path.join(ROOT_DIR, "etc", "remoteclaw");
 const SHARED_DIR = path.join(ROOT_DIR, "shared");
 
 const DEFAULT_BASE_PATH = path.join(CONFIG_DIR, "remoteclaw.json");
@@ -619,7 +619,7 @@ describe("security: path traversal protection (CWE-22)", () => {
     });
 
     it("allows include files when the config root path is a symlink", async () => {
-      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-includes-symlink-"));
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-includes-symlink-"));
       try {
         const realRoot = path.join(tempRoot, "real");
         const linkRoot = path.join(tempRoot, "link");

--- a/src/config/io.compat.test.ts
+++ b/src/config/io.compat.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import { createConfigIO } from "./io.js";
 
 async function withTempHome(run: (home: string) => Promise<void>): Promise<void> {
-  const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-config-"));
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-config-"));
   try {
     await run(home);
   } finally {

--- a/src/config/io.owner-display-secret.test.ts
+++ b/src/config/io.owner-display-secret.test.ts
@@ -21,7 +21,7 @@ async function waitForPersistedSecret(configPath: string, expectedSecret: string
 
 describe("config io owner display secret autofill", () => {
   it("auto-generates and persists commands.ownerDisplaySecret in hash mode", async () => {
-    await withTempHome("openclaw-owner-display-secret-", async (home) => {
+    await withTempHome("remoteclaw-owner-display-secret-", async (home) => {
       const configPath = path.join(home, ".remoteclaw", "remoteclaw.json");
       await fs.mkdir(path.dirname(configPath), { recursive: true });
       await fs.writeFile(

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -110,7 +110,7 @@ describe("config io write", () => {
   }
 
   it("persists caller changes onto resolved config without leaking runtime defaults", async () => {
-    await withTempHome("openclaw-config-io-", async (home) => {
+    await withTempHome("remoteclaw-config-io-", async (home) => {
       const { configPath, io, snapshot } = await writeConfigAndCreateIo({
         home,
         initialConfig: { gateway: { port: 18789 } },
@@ -127,7 +127,7 @@ describe("config io write", () => {
   });
 
   it('shows actionable guidance for dmPolicy="open" without wildcard allowFrom', async () => {
-    await withTempHome("openclaw-config-io-", async (home) => {
+    await withTempHome("remoteclaw-config-io-", async (home) => {
       const io = createConfigIO({
         env: {} as NodeJS.ProcessEnv,
         homedir: () => home,
@@ -153,7 +153,7 @@ describe("config io write", () => {
   });
 
   it("honors explicit unset paths when schema defaults would otherwise reappear", async () => {
-    await withTempHome("openclaw-config-io-", async (home) => {
+    await withTempHome("remoteclaw-config-io-", async (home) => {
       const { configPath, io, snapshot } = await writeConfigAndCreateIo({
         home,
         initialConfig: {
@@ -181,7 +181,7 @@ describe("config io write", () => {
   });
 
   it("does not mutate caller config when unsetPaths is applied on first write", async () => {
-    await withTempHome("openclaw-config-io-", async (home) => {
+    await withTempHome("remoteclaw-config-io-", async (home) => {
       const configPath = path.join(home, ".remoteclaw", "remoteclaw.json");
       const io = createConfigIO({
         env: {} as NodeJS.ProcessEnv,
@@ -206,7 +206,7 @@ describe("config io write", () => {
   });
 
   it("does not mutate caller config when unsetPaths is applied on existing files", async () => {
-    await withTempHome("openclaw-config-io-", async (home) => {
+    await withTempHome("remoteclaw-config-io-", async (home) => {
       const { configPath, io, snapshot } = await writeConfigAndCreateIo({
         home,
         initialConfig: {
@@ -224,7 +224,7 @@ describe("config io write", () => {
   });
 
   it("keeps caller arrays immutable when unsetting array entries", async () => {
-    await withTempHome("openclaw-config-io-", async (home) => {
+    await withTempHome("remoteclaw-config-io-", async (home) => {
       const { configPath, io, snapshot } = await writeConfigAndCreateIo({
         home,
         initialConfig: {
@@ -245,7 +245,7 @@ describe("config io write", () => {
   });
 
   it("treats missing unset paths as no-op without mutating caller config", async () => {
-    await withTempHome("openclaw-config-io-", async (home) => {
+    await withTempHome("remoteclaw-config-io-", async (home) => {
       await runUnsetNoopCase({
         home,
         unsetPaths: [["commands", "missingKey"]],
@@ -254,7 +254,7 @@ describe("config io write", () => {
   });
 
   it("ignores blocked prototype-key unset path segments", async () => {
-    await withTempHome("openclaw-config-io-", async (home) => {
+    await withTempHome("remoteclaw-config-io-", async (home) => {
       await runUnsetNoopCase({
         home,
         unsetPaths: [
@@ -267,7 +267,7 @@ describe("config io write", () => {
   });
 
   it("preserves env var references when writing", async () => {
-    await withTempHome("openclaw-config-io-", async (home) => {
+    await withTempHome("remoteclaw-config-io-", async (home) => {
       const { configPath, io, snapshot } = await writeConfigAndCreateIo({
         home,
         env: { OPENAI_API_KEY: "sk-secret" } as NodeJS.ProcessEnv,
@@ -302,7 +302,7 @@ describe("config io write", () => {
   });
 
   it("does not reintroduce Slack/Discord legacy dm.policy defaults when writing", async () => {
-    await withTempHome("openclaw-config-io-", async (home) => {
+    await withTempHome("remoteclaw-config-io-", async (home) => {
       const { configPath, io, snapshot } = await writeConfigAndCreateIo({
         home,
         initialConfig: {
@@ -348,7 +348,7 @@ describe("config io write", () => {
   });
 
   it("keeps env refs in arrays when appending entries", async () => {
-    await withTempHome("openclaw-config-io-", async (home) => {
+    await withTempHome("remoteclaw-config-io-", async (home) => {
       const configPath = path.join(home, ".remoteclaw", "remoteclaw.json");
       await fs.mkdir(path.dirname(configPath), { recursive: true });
       await fs.writeFile(
@@ -421,7 +421,7 @@ describe("config io write", () => {
   });
 
   it("logs an overwrite audit entry when replacing an existing config file", async () => {
-    await withTempHome("openclaw-config-io-", async (home) => {
+    await withTempHome("remoteclaw-config-io-", async (home) => {
       const warn = vi.fn();
       const { configPath, io, snapshot } = await writeConfigAndCreateIo({
         home,
@@ -451,7 +451,7 @@ describe("config io write", () => {
   });
 
   it("does not log an overwrite audit entry when creating config for the first time", async () => {
-    await withTempHome("openclaw-config-io-", async (home) => {
+    await withTempHome("remoteclaw-config-io-", async (home) => {
       const warn = vi.fn();
       const io = createConfigIO({
         env: {} as NodeJS.ProcessEnv,
@@ -474,7 +474,7 @@ describe("config io write", () => {
   });
 
   it("appends config write audit JSONL entries with forensic metadata", async () => {
-    await withTempHome("openclaw-config-io-", async (home) => {
+    await withTempHome("remoteclaw-config-io-", async (home) => {
       const { configPath, lines, last } = await writeGatewayPatchAndReadLastAuditEntry({
         home,
         initialConfig: { gateway: { port: 18789 } },
@@ -494,7 +494,7 @@ describe("config io write", () => {
   });
 
   it("records gateway watch session markers in config audit entries", async () => {
-    await withTempHome("openclaw-config-io-", async (home) => {
+    await withTempHome("remoteclaw-config-io-", async (home) => {
       const { last } = await writeGatewayPatchAndReadLastAuditEntry({
         home,
         initialConfig: { gateway: { mode: "local" } },

--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -68,14 +68,14 @@ describe("state + config path candidates", () => {
 
   it("uses REMOTECLAW_HOME for default state/config locations", () => {
     const env = {
-      REMOTECLAW_HOME: "/srv/openclaw-home",
+      REMOTECLAW_HOME: "/srv/remoteclaw-home",
     } as NodeJS.ProcessEnv;
     expectRemoteClawHomeDefaults(env);
   });
 
   it("prefers REMOTECLAW_HOME over HOME for default state/config locations", () => {
     const env = {
-      REMOTECLAW_HOME: "/srv/openclaw-home",
+      REMOTECLAW_HOME: "/srv/remoteclaw-home",
       HOME: "/home/other",
     } as NodeJS.ProcessEnv;
     expectRemoteClawHomeDefaults(env);

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -115,7 +115,7 @@ describe("applyPluginAutoEnable", () => {
       config: {},
       env: {
         IRC_HOST: "irc.libera.chat",
-        IRC_NICK: "openclaw-bot",
+        IRC_NICK: "remoteclaw-bot",
       },
     });
 

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -27,7 +27,7 @@ describe("sessions", () => {
   };
 
   beforeAll(async () => {
-    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-suite-"));
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-sessions-suite-"));
   });
 
   afterAll(async () => {
@@ -91,11 +91,11 @@ describe("sessions", () => {
       buildGroupDisplayName({
         provider: "discord",
         groupChannel: "#general",
-        space: "friends-of-openclaw",
+        space: "friends-of-remoteclaw",
         id: "123",
         key: "discord:group:123",
       }),
-    ).toBe("discord:friends-of-openclaw#general");
+    ).toBe("discord:friends-of-remoteclaw#general");
   });
 
   const resolveSessionKeyCases = [

--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -21,7 +21,7 @@ afterEach(async () => {
 
 describe("enforceSessionDiskBudget", () => {
   it("does not treat referenced transcripts with marker-like session IDs as archived artifacts", async () => {
-    const dir = await createCaseDir("openclaw-disk-budget-");
+    const dir = await createCaseDir("remoteclaw-disk-budget-");
     const storePath = path.join(dir, "sessions.json");
     const sessionId = "keep.deleted.keep";
     const activeKey = "agent:main:main";
@@ -55,7 +55,7 @@ describe("enforceSessionDiskBudget", () => {
   });
 
   it("removes true archived transcript artifacts while preserving referenced primary transcripts", async () => {
-    const dir = await createCaseDir("openclaw-disk-budget-");
+    const dir = await createCaseDir("remoteclaw-disk-budget-");
     const storePath = path.join(dir, "sessions.json");
     const sessionId = "keep";
     const transcriptPath = path.join(dir, `${sessionId}.jsonl`);

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -72,7 +72,7 @@ describe("session path safety", () => {
     if (process.platform === "win32") {
       return;
     }
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-symlink-session-"));
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-symlink-session-"));
     const realRoot = path.join(tmpDir, "real-state");
     const aliasRoot = path.join(tmpDir, "alias-state");
     try {
@@ -94,7 +94,7 @@ describe("session path safety", () => {
     if (process.platform === "win32") {
       return;
     }
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-symlink-escape-"));
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-symlink-escape-"));
     const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
     const outsideDir = path.join(tmpDir, "outside");
     try {
@@ -156,7 +156,7 @@ describe("session store lock (Promise chain mutex)", () => {
   }
 
   beforeAll(async () => {
-    lockFixtureRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-test-"));
+    lockFixtureRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), "remoteclaw-lock-test-"));
   });
 
   afterAll(async () => {

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -56,7 +56,7 @@ describe("Integration: saveSessionStore with pruning", () => {
   let savedCacheTtl: string | undefined;
 
   beforeAll(async () => {
-    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pruning-integ-"));
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-pruning-integ-"));
   });
 
   afterAll(async () => {
@@ -263,7 +263,7 @@ describe("Integration: saveSessionStore with pruning", () => {
     });
 
     const now = Date.now();
-    const externalDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-external-cap-"));
+    const externalDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-external-cap-"));
     const externalTranscript = path.join(externalDir, "outside.jsonl");
     await fs.writeFile(externalTranscript, "external", "utf-8");
     const store: Record<string, SessionEntry> = {
@@ -367,7 +367,7 @@ describe("Integration: saveSessionStore with pruning", () => {
     });
 
     const now = Date.now();
-    const externalDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-external-session-"));
+    const externalDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-external-session-"));
     const externalTranscript = path.join(externalDir, "outside.jsonl");
     await fs.writeFile(externalTranscript, "z".repeat(400), "utf-8");
 

--- a/src/config/sessions/store.session-key-normalization.test.ts
+++ b/src/config/sessions/store.session-key-normalization.test.ts
@@ -30,7 +30,7 @@ describe("session store key normalization", () => {
   let storePath = "";
 
   beforeEach(async () => {
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-key-normalize-"));
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-session-key-normalize-"));
     storePath = path.join(tempDir, "sessions.json");
     await fs.writeFile(storePath, "{}", "utf-8");
   });

--- a/src/config/talk.normalize.test.ts
+++ b/src/config/talk.normalize.test.ts
@@ -9,7 +9,7 @@ async function withTempConfig(
   config: unknown,
   run: (configPath: string) => Promise<void>,
 ): Promise<void> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-talk-"));
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-talk-"));
   const configPath = path.join(dir, "remoteclaw.json");
   await fs.writeFile(configPath, JSON.stringify(config, null, 2));
   try {

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -15,7 +15,7 @@ export type GatewayTlsConfig = {
 
 export type WideAreaDiscoveryConfig = {
   enabled?: boolean;
-  /** Optional unicast DNS-SD domain (e.g. "openclaw.internal"). */
+  /** Optional unicast DNS-SD domain (e.g. "remoteclaw.internal"). */
   domain?: string;
 };
 

--- a/src/cron/service.delivery-plan.test.ts
+++ b/src/cron/service.delivery-plan.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./service.test-harness.js";
 
 const noopLogger = createNoopLogger();
-const { makeStorePath } = createCronStoreHarness({ prefix: "openclaw-cron-delivery-" });
+const { makeStorePath } = createCronStoreHarness({ prefix: "remoteclaw-cron-delivery-" });
 
 type DeliveryMode = "none" | "announce";
 

--- a/src/cron/service.get-job.test.ts
+++ b/src/cron/service.get-job.test.ts
@@ -7,7 +7,7 @@ import {
 } from "./service.test-harness.js";
 
 const logger = createNoopLogger();
-const { makeStorePath } = createCronStoreHarness({ prefix: "openclaw-cron-get-job-" });
+const { makeStorePath } = createCronStoreHarness({ prefix: "remoteclaw-cron-get-job-" });
 installCronTestHooks({ logger });
 
 function createCronService(storePath: string) {

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1030,7 +1030,7 @@ describe("Cron issue regressions", () => {
     };
     const state = createCronServiceState({
       cronEnabled: true,
-      storePath: "/tmp/openclaw-cron-abort-test/jobs.json",
+      storePath: "/tmp/remoteclaw-cron-abort-test/jobs.json",
       log: noopLogger,
       nowMs: () => Date.now(),
       enqueueSystemEvent,

--- a/src/cron/service.prevents-duplicate-timers.test.ts
+++ b/src/cron/service.prevents-duplicate-timers.test.ts
@@ -7,7 +7,7 @@ import {
 } from "./service.test-harness.js";
 
 const noopLogger = createNoopLogger();
-const { makeStorePath } = createCronStoreHarness({ prefix: "openclaw-cron-" });
+const { makeStorePath } = createCronStoreHarness({ prefix: "remoteclaw-cron-" });
 installCronTestHooks({
   logger: noopLogger,
   baseTimeIso: "2025-12-13T00:00:00.000Z",

--- a/src/cron/service.read-ops-nonblocking.test.ts
+++ b/src/cron/service.read-ops-nonblocking.test.ts
@@ -35,7 +35,7 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: str
 }
 
 async function makeStorePath() {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-"));
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-cron-"));
   return {
     storePath: path.join(dir, "cron", "jobs.json"),
     cleanup: async () => {

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -19,7 +19,7 @@ const fsState = vi.hoisted(() => ({
 }));
 
 const abs = (p: string) => path.resolve(p);
-const fixturesRoot = abs(path.join("__openclaw_vitest__", "cron", "runs-one-shot"));
+const fixturesRoot = abs(path.join("__remoteclaw_vitest__", "cron", "runs-one-shot"));
 const isFixturePath = (p: string) => {
   const resolved = abs(p);
   const rootPrefix = `${fixturesRoot}${path.sep}`;

--- a/src/cron/service.store.migration.test.ts
+++ b/src/cron/service.store.migration.test.ts
@@ -7,7 +7,7 @@ import { DEFAULT_TOP_OF_HOUR_STAGGER_MS } from "./stagger.js";
 import { loadCronStore } from "./store.js";
 
 const noopLogger = createNoopLogger();
-const { makeStorePath } = createCronStoreHarness({ prefix: "openclaw-cron-migrate-" });
+const { makeStorePath } = createCronStoreHarness({ prefix: "remoteclaw-cron-migrate-" });
 
 async function writeLegacyStore(storePath: string, legacyJob: Record<string, unknown>) {
   await fs.mkdir(path.dirname(storePath), { recursive: true });

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -29,7 +29,7 @@ export function createCronStoreHarness(options?: { prefix?: string }) {
   let caseId = 0;
 
   beforeAll(async () => {
-    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), options?.prefix ?? "openclaw-cron-"));
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), options?.prefix ?? "remoteclaw-cron-"));
   });
 
   afterAll(async () => {

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadCronStore, resolveCronStorePath } from "./store.js";
 
 async function makeStorePath() {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-store-"));
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-cron-store-"));
   return {
     dir,
     storePath: path.join(dir, "jobs.json"),
@@ -21,11 +21,11 @@ describe("resolveCronStorePath", () => {
   });
 
   it("uses REMOTECLAW_HOME for tilde expansion", () => {
-    vi.stubEnv("REMOTECLAW_HOME", "/srv/openclaw-home");
+    vi.stubEnv("REMOTECLAW_HOME", "/srv/remoteclaw-home");
     vi.stubEnv("HOME", "/home/other");
 
     const result = resolveCronStorePath("~/cron/jobs.json");
-    expect(result).toBe(path.resolve("/srv/openclaw-home", "cron", "jobs.json"));
+    expect(result).toBe(path.resolve("/srv/remoteclaw-home", "cron", "jobs.json"));
   });
 });
 

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -194,7 +194,7 @@ describe("launchd install", () => {
     }
     expect(message).toContain("logged-in macOS GUI session");
     expect(message).toContain("wrong user (including sudo)");
-    expect(message).toContain("https://docs.openclaw.ai/gateway");
+    expect(message).toContain("https://docs.remoteclaw.ai/gateway");
   });
 
   it("surfaces generic bootstrap failures without GUI-specific guidance", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -394,7 +394,7 @@ export async function installLaunchAgent({
           `LaunchAgent install requires a logged-in macOS GUI session for this user (${domain}).`,
           "This usually means you are running from SSH/headless context or as the wrong user (including sudo).",
           "Fix: sign in to the macOS desktop as the target user and rerun `openclaw gateway install --force`.",
-          "Headless deployments should use a dedicated logged-in user session or a custom LaunchDaemon (not shipped): https://docs.openclaw.ai/gateway",
+          "Headless deployments should use a dedicated logged-in user session or a custom LaunchDaemon (not shipped): https://docs.remoteclaw.ai/gateway",
         ].join("\n"),
       );
     }

--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -22,7 +22,7 @@ describe("installScheduledTask", () => {
   async function withUserProfileDir(
     run: (tmpDir: string, env: Record<string, string>) => Promise<void>,
   ) {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-schtasks-install-"));
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-schtasks-install-"));
     const env = {
       USERPROFILE: tmpDir,
       REMOTECLAW_PROFILE: "default",

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -61,7 +61,7 @@ describe("readScheduledTaskCommand", () => {
     },
     run: (env: Record<string, string | undefined>) => Promise<void>,
   ) {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-schtasks-test-"));
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-schtasks-test-"));
     try {
       const extraEnv = typeof options.env === "function" ? options.env(tmpDir) : options.env;
       const env = {

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -592,15 +592,15 @@ describe("discord group DM gating", () => {
   it("matches group DM allowlist", () => {
     expect(
       resolveGroupDmAllow({
-        channels: ["openclaw-dm"],
+        channels: ["remoteclaw-dm"],
         channelId: "1",
         channelName: "RemoteClaw DM",
-        channelSlug: "openclaw-dm",
+        channelSlug: "remoteclaw-dm",
       }),
     ).toBe(true);
     expect(
       resolveGroupDmAllow({
-        channels: ["openclaw-dm"],
+        channels: ["remoteclaw-dm"],
         channelId: "1",
         channelName: "Other",
         channelSlug: "other",

--- a/src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.test.ts
+++ b/src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.test.ts
@@ -138,7 +138,7 @@ function createDefaultThreadConfig(): LoadedConfig {
         workspace: "/tmp/openclaw",
       },
     },
-    session: { store: "/tmp/openclaw-sessions.json" },
+    session: { store: "/tmp/remoteclaw-sessions.json" },
     messages: { responsePrefix: "PFX" },
     channels: {
       discord: {
@@ -162,7 +162,7 @@ function createMentionRequiredGuildConfig(
         workspace: "/tmp/openclaw",
       },
     },
-    session: { store: "/tmp/openclaw-sessions.json" },
+    session: { store: "/tmp/remoteclaw-sessions.json" },
     channels: {
       discord: {
         dm: { enabled: true, policy: "open" },
@@ -316,7 +316,7 @@ describe("discord tool result dispatch", () => {
             workspace: "/tmp/openclaw",
           },
         },
-        session: { store: "/tmp/openclaw-sessions.json" },
+        session: { store: "/tmp/remoteclaw-sessions.json" },
         channels: {
           discord: { dm: { enabled: true, policy: "open" } },
         },
@@ -462,7 +462,7 @@ describe("discord tool result dispatch", () => {
 
     const cfg = {
       agent: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" },
-      session: { store: "/tmp/openclaw-sessions.json" },
+      session: { store: "/tmp/remoteclaw-sessions.json" },
       channels: {
         discord: {
           dm: { enabled: true, policy: "open" },

--- a/src/discord/monitor.tool-result.sends-status-replies-responseprefix.test.ts
+++ b/src/discord/monitor.tool-result.sends-status-replies-responseprefix.test.ts
@@ -33,7 +33,7 @@ const BASE_CFG: Config = {
       workspace: "/tmp/openclaw",
     },
   },
-  session: { store: "/tmp/openclaw-sessions.json" },
+  session: { store: "/tmp/remoteclaw-sessions.json" },
 };
 
 const CATEGORY_GUILD_CFG = {

--- a/src/discord/monitor.tool-result.test-harness.ts
+++ b/src/discord/monitor.tool-result.test-harness.ts
@@ -34,7 +34,7 @@ vi.mock("../config/sessions.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/sessions.js")>();
   return {
     ...actual,
-    resolveStorePath: vi.fn(() => "/tmp/openclaw-sessions.json"),
+    resolveStorePath: vi.fn(() => "/tmp/remoteclaw-sessions.json"),
     updateLastRoute: (...args: unknown[]) => updateLastRouteMock(...args),
     resolveSessionKey: vi.fn(),
   };

--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -112,7 +112,7 @@ describe("preflightDiscordMessage", () => {
       accountId: "default",
       token: "token",
       runtime: {} as import("../../runtime.js").RuntimeEnv,
-      botUserId: "openclaw-bot",
+      botUserId: "remoteclaw-bot",
       guildHistories: new Map(),
       historyLimit: 0,
       mediaMaxBytes: 1_000_000,

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -54,7 +54,7 @@ const dispatchInboundMessage = vi.fn(async (_params?: DispatchInboundParams) => 
 }));
 const recordInboundSession = vi.fn(async () => {});
 const readSessionUpdatedAt = vi.fn(() => undefined);
-const resolveStorePath = vi.fn(() => "/tmp/openclaw-discord-process-test-sessions.json");
+const resolveStorePath = vi.fn(() => "/tmp/remoteclaw-discord-process-test-sessions.json");
 
 vi.mock("../send.js", () => ({
   reactMessageDiscord: sendMocks.reactMessageDiscord,
@@ -130,7 +130,7 @@ beforeEach(() => {
   });
   recordInboundSession.mockResolvedValue(undefined);
   readSessionUpdatedAt.mockReturnValue(undefined);
-  resolveStorePath.mockReturnValue("/tmp/openclaw-discord-process-test-sessions.json");
+  resolveStorePath.mockReturnValue("/tmp/remoteclaw-discord-process-test-sessions.json");
   threadBindingTesting.resetThreadBindingsForTests();
 });
 
@@ -273,7 +273,7 @@ describe("processDiscordMessage ack reactions", () => {
             timing: { debounceMs: 0 },
           },
         },
-        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+        session: { store: "/tmp/remoteclaw-discord-process-test-sessions.json" },
       },
     });
 
@@ -420,7 +420,7 @@ describe("processDiscordMessage draft streaming", () => {
     return await createBaseContext({
       cfg: {
         messages: { ackReaction: "👀" },
-        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+        session: { store: "/tmp/remoteclaw-discord-process-test-sessions.json" },
         channels: {
           discord: {
             draftChunk: { minChars: 1, maxChars: 5, breakPreference: "newline" },

--- a/src/discord/monitor/message-handler.test-harness.ts
+++ b/src/discord/monitor/message-handler.test-harness.ts
@@ -7,7 +7,7 @@ import { createNoopThreadBindingManager } from "./thread-bindings.js";
 export async function createBaseDiscordMessageContext(
   overrides: Record<string, unknown> = {},
 ): Promise<DiscordMessagePreflightContext> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-"));
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-discord-"));
   const storePath = path.join(dir, "sessions.json");
   return {
     cfg: { messages: { ackReaction: "👀" }, session: { store: storePath } },

--- a/src/discord/monitor/monitor.test.ts
+++ b/src/discord/monitor/monitor.test.ts
@@ -302,7 +302,7 @@ describe("discord component interactions", () => {
     deliverDiscordReplyMock.mockClear();
     recordInboundSessionMock.mockClear().mockResolvedValue(undefined);
     readSessionUpdatedAtMock.mockClear().mockReturnValue(undefined);
-    resolveStorePathMock.mockClear().mockReturnValue("/tmp/openclaw-sessions-test.json");
+    resolveStorePathMock.mockClear().mockReturnValue("/tmp/remoteclaw-sessions-test.json");
   });
 
   it("routes button clicks with reply references", async () => {
@@ -700,14 +700,14 @@ describe("resolveDiscordPresenceUpdate", () => {
     const presence = resolveDiscordPresenceUpdate({
       activity: "Live",
       activityType: 1,
-      activityUrl: "https://twitch.tv/openclaw",
+      activityUrl: "https://twitch.tv/remoteclaw",
     });
     expect(presence).not.toBeNull();
     expect(presence?.activities).toHaveLength(1);
     expect(presence?.activities[0]).toMatchObject({
       type: 1,
       name: "Live",
-      url: "https://twitch.tv/openclaw",
+      url: "https://twitch.tv/remoteclaw",
     });
   });
 });

--- a/src/discord/monitor/thread-bindings.ttl.test.ts
+++ b/src/discord/monitor/thread-bindings.ttl.test.ts
@@ -481,7 +481,7 @@ describe("thread binding ttl", () => {
 
   it("persists unbinds even when no manager is active", () => {
     const previousStateDir = process.env.REMOTECLAW_STATE_DIR;
-    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-thread-bindings-"));
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-thread-bindings-"));
     process.env.REMOTECLAW_STATE_DIR = stateDir;
     try {
       __testing.resetThreadBindingsForTests();

--- a/src/gateway/assistant-identity.test.ts
+++ b/src/gateway/assistant-identity.test.ts
@@ -33,11 +33,13 @@ describe("resolveAssistantIdentity avatar normalization", () => {
     const cfg: RemoteClawConfig = {
       ui: {
         assistant: {
-          avatar: "avatars/openclaw.png",
+          avatar: "avatars/remoteclaw.png",
         },
       },
     };
 
-    expect(resolveAssistantIdentity({ cfg, workspaceDir: "" }).avatar).toBe("avatars/openclaw.png");
+    expect(resolveAssistantIdentity({ cfg, workspaceDir: "" }).avatar).toBe(
+      "avatars/remoteclaw.png",
+    );
   });
 });

--- a/src/gateway/boot.test.ts
+++ b/src/gateway/boot.test.ts
@@ -51,7 +51,7 @@ describe("runBootOnce", () => {
     options: BootWorkspaceOptions,
     run: (workspaceDir: string) => Promise<void>,
   ) => {
-    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-boot-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-boot-"));
     try {
       const bootPath = path.join(workspaceDir, "BOOT.md");
       if (options.bootAsDirectory) {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -155,7 +155,7 @@ export function buildGatewayConnectionDetails(
         "- keep gateway.bind=loopback and use an SSH tunnel (ssh -N -L 18789:127.0.0.1:18789 user@gateway-host)",
         "- or use Tailscale Serve/Funnel for HTTPS remote access",
         "Doctor: openclaw doctor --fix",
-        "Docs: https://docs.openclaw.ai/gateway/remote",
+        "Docs: https://docs.remoteclaw.ai/gateway/remote",
       ].join("\n"),
     );
   }

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -12,7 +12,7 @@ describe("handleControlUiHttpRequest", () => {
     indexHtml?: string;
     fn: (tmp: string) => Promise<T>;
   }) {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-"));
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-ui-"));
     try {
       await fs.writeFile(path.join(tmp, "index.html"), params.indexHtml ?? "<html></html>\n");
       return await params.fn(tmp);
@@ -88,7 +88,7 @@ describe("handleControlUiHttpRequest", () => {
     siblingDir: string;
     fn: (paths: { root: string; sibling: string }) => Promise<T>;
   }) {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-root-"));
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-ui-root-"));
     try {
       const root = path.join(tmp, "ui");
       const sibling = path.join(tmp, params.siblingDir);
@@ -198,7 +198,7 @@ describe("handleControlUiHttpRequest", () => {
   });
 
   it("serves local avatar bytes through hardened avatar handler", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-avatar-http-"));
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-avatar-http-"));
     try {
       const avatarPath = path.join(tmp, "main.png");
       await fs.writeFile(avatarPath, "avatar-bytes\n");
@@ -218,8 +218,8 @@ describe("handleControlUiHttpRequest", () => {
   });
 
   it("rejects avatar symlink paths from resolver", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-avatar-http-link-"));
-    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-avatar-http-outside-"));
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-avatar-http-link-"));
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-avatar-http-outside-"));
     try {
       const outsideFile = path.join(outside, "secret.txt");
       await fs.writeFile(outsideFile, "outside-secret\n");
@@ -243,7 +243,7 @@ describe("handleControlUiHttpRequest", () => {
     await withControlUiRoot({
       fn: async (tmp) => {
         const assetsDir = path.join(tmp, "assets");
-        const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-outside-"));
+        const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-ui-outside-"));
         try {
           const outsideFile = path.join(outsideDir, "secret.txt");
           await fs.mkdir(assetsDir, { recursive: true });
@@ -306,7 +306,7 @@ describe("handleControlUiHttpRequest", () => {
   it("rejects symlinked SPA fallback index.html outside control-ui root", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-index-outside-"));
+        const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-ui-index-outside-"));
         try {
           const outsideIndex = path.join(outsideDir, "index.html");
           await fs.writeFile(outsideIndex, "<html>outside</html>\n");

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -220,7 +220,7 @@ describeLive("gateway live (cli backend)", () => {
       );
     }
 
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-live-cli-"));
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-live-cli-"));
     const disableMcpConfig = process.env.REMOTECLAW_LIVE_CLI_BACKEND_DISABLE_MCP_CONFIG !== "0";
     let cliArgs = baseCliArgs;
     if (providerId === "claude-cli" && disableMcpConfig) {

--- a/src/gateway/gateway-config-prompts.shared.ts
+++ b/src/gateway/gateway-config-prompts.shared.ts
@@ -22,6 +22,6 @@ export const TAILSCALE_MISSING_BIN_NOTE_LINES = [
 
 export const TAILSCALE_DOCS_LINES = [
   "Docs:",
-  "https://docs.openclaw.ai/gateway/tailscale",
-  "https://docs.openclaw.ai/web",
+  "https://docs.remoteclaw.ai/gateway/tailscale",
+  "https://docs.remoteclaw.ai/web",
 ] as const;

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -50,7 +50,7 @@ describe("GatewayClient", () => {
     params: { faviconSvg?: string; indexHtml?: string },
     run: (tmp: string) => Promise<void>,
   ) {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-"));
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-ui-"));
     try {
       await fs.writeFile(path.join(tmp, "index.html"), params.indexHtml ?? "<html></html>\n");
       if (typeof params.faviconSvg === "string") {

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -43,7 +43,7 @@ describe("gateway e2e", () => {
       process.env.REMOTECLAW_SKIP_BROWSER_CONTROL_SERVER = "1";
       delete process.env.REMOTECLAW_GATEWAY_TOKEN;
 
-      const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wizard-home-"));
+      const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-wizard-home-"));
       process.env.HOME = tempHome;
       delete process.env.REMOTECLAW_STATE_DIR;
       delete process.env.REMOTECLAW_CONFIG_PATH;

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -145,7 +145,7 @@ describe("hooks mapping", () => {
   });
 
   it("runs transform module", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-"));
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-config-"));
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "transform.mjs");
@@ -183,7 +183,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transform module traversal outside transformsDir", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-traversal-"));
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-config-traversal-"));
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -203,7 +203,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects absolute transform module path outside transformsDir", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-abs-"));
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-config-abs-"));
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const outside = path.join(os.tmpdir(), "evil.mjs");
@@ -224,7 +224,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transformsDir traversal outside the transforms root", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xformdir-trav-"));
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-config-xformdir-trav-"));
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -245,7 +245,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transformsDir absolute path outside the transforms root", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xformdir-abs-"));
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-config-xformdir-abs-"));
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -266,7 +266,7 @@ describe("hooks mapping", () => {
   });
 
   it("accepts transformsDir subdirectory within the transforms root", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xformdir-ok-"));
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-config-xformdir-ok-"));
     const result = await applyNullTransformFromTempConfig({ configDir, transformsDir: "subdir" });
     expectSkippedTransformResult(result);
   });
@@ -274,10 +274,10 @@ describe("hooks mapping", () => {
   it.runIf(process.platform !== "win32")(
     "rejects transform module symlink escape outside transformsDir",
     () => {
-      const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-symlink-module-"));
+      const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-config-symlink-module-"));
       const transformsRoot = path.join(configDir, "hooks", "transforms");
       fs.mkdirSync(transformsRoot, { recursive: true });
-      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-outside-module-"));
+      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-outside-module-"));
       const outsideModule = path.join(outsideDir, "evil.mjs");
       fs.writeFileSync(outsideModule, 'export default () => ({ kind: "wake", text: "owned" });');
       fs.symlinkSync(outsideModule, path.join(transformsRoot, "linked.mjs"));
@@ -301,10 +301,10 @@ describe("hooks mapping", () => {
   it.runIf(process.platform !== "win32")(
     "rejects transformsDir symlink escape outside transforms root",
     () => {
-      const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-symlink-dir-"));
+      const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-config-symlink-dir-"));
       const transformsRoot = path.join(configDir, "hooks", "transforms");
       fs.mkdirSync(transformsRoot, { recursive: true });
-      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-outside-dir-"));
+      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-outside-dir-"));
       fs.writeFileSync(path.join(outsideDir, "transform.mjs"), "export default () => null;");
       fs.symlinkSync(outsideDir, path.join(transformsRoot, "escape"), "dir");
       expect(() =>
@@ -326,7 +326,7 @@ describe("hooks mapping", () => {
   );
 
   it.runIf(process.platform !== "win32")("accepts in-root transform module symlink", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-symlink-ok-"));
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-config-symlink-ok-"));
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     const nestedDir = path.join(transformsRoot, "nested");
     fs.mkdirSync(nestedDir, { recursive: true });
@@ -357,7 +357,7 @@ describe("hooks mapping", () => {
   });
 
   it("treats null transform as a handled skip", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-skip-"));
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-config-skip-"));
     const result = await applyNullTransformFromTempConfig({ configDir });
     expectSkippedTransformResult(result);
   });
@@ -407,7 +407,7 @@ describe("hooks mapping", () => {
   });
 
   it("caches transform functions by module path and export name", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-export-"));
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-hooks-export-"));
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "multi-export.mjs");

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -286,7 +286,7 @@ describe("logs.tail", () => {
   });
 
   it("falls back to latest rolling log file when today is missing", async () => {
-    const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-logs-"));
+    const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "remoteclaw-logs-"));
     const older = path.join(tempDir, "openclaw-2026-01-20.log");
     const newer = path.join(tempDir, "openclaw-2026-01-21.log");
 

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -151,7 +151,7 @@ describe("sessions.usage", () => {
 
   it("resolves store entries by sessionId when queried via discovered agent-prefixed key", async () => {
     const storeKey = "agent:opus:slack:dm:u123";
-    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-usage-test-"));
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-usage-test-"));
 
     try {
       await withEnvAsync({ REMOTECLAW_STATE_DIR: stateDir }, async () => {

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -35,7 +35,7 @@ vi.mock("../commands/agent.js", () => ({
 }));
 vi.mock("../config/config.js", () => ({
   loadConfig: vi.fn(() => ({ session: { mainKey: "agent:main:main" } })),
-  STATE_DIR: "/tmp/openclaw-state",
+  STATE_DIR: "/tmp/remoteclaw-state",
 }));
 vi.mock("../config/sessions.js", () => ({
   updateSessionStore: vi.fn(),

--- a/src/gateway/server.agent.gateway-server-agent-a.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-a.test.ts
@@ -28,7 +28,7 @@ beforeAll(async () => {
   server = started.server;
   ws = started.ws;
   await connectOk(ws);
-  sharedSessionStoreDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-session-"));
+  sharedSessionStoreDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-gw-session-"));
   sharedSessionStorePath = path.join(sharedSessionStoreDir, "sessions.json");
 });
 

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -142,7 +142,7 @@ async function sendAgentWsRequestAndWaitFinal(
 }
 
 async function useTempSessionStorePath() {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-gw-"));
   testState.sessionStorePath = path.join(dir, "sessions.json");
 }
 

--- a/src/gateway/server.auth.test.ts
+++ b/src/gateway/server.auth.test.ts
@@ -1074,7 +1074,7 @@ describe("gateway server auth/connect", () => {
       await import("../infra/device-identity.js");
     const { getPairedDevice, listDevicePairing } = await import("../infra/device-pairing.js");
     const { server, ws, port, prevToken } = await startServerWithClient("secret");
-    const identityDir = await mkdtemp(join(tmpdir(), "openclaw-device-scope-"));
+    const identityDir = await mkdtemp(join(tmpdir(), "remoteclaw-device-scope-"));
     const identity = loadOrCreateDeviceIdentity(join(identityDir, "device.json"));
     const client = {
       id: GATEWAY_CLIENT_NAMES.TEST,
@@ -1143,7 +1143,7 @@ describe("gateway server auth/connect", () => {
     const { approveDevicePairing, getPairedDevice, listDevicePairing, requestDevicePairing } =
       await import("../infra/device-pairing.js");
     const { server, ws, port, prevToken } = await startServerWithClient("secret");
-    const identityDir = await mkdtemp(join(tmpdir(), "openclaw-device-token-scope-"));
+    const identityDir = await mkdtemp(join(tmpdir(), "remoteclaw-device-token-scope-"));
     const identity = loadOrCreateDeviceIdentity(join(identityDir, "device.json"));
     const devicePublicKey = publicKeyRawBase64UrlFromPem(identity.publicKeyPem);
     const buildDevice = (scopes: string[], nonce: string) => {
@@ -1209,7 +1209,7 @@ describe("gateway server auth/connect", () => {
       await import("../infra/device-pairing.js");
     const { server, ws, port, prevToken } = await startServerWithClient("secret");
     ws.close();
-    const identityDir = await mkdtemp(join(tmpdir(), "openclaw-device-scope-"));
+    const identityDir = await mkdtemp(join(tmpdir(), "remoteclaw-device-scope-"));
     const identity = loadOrCreateDeviceIdentity(join(identityDir, "device.json"));
     const client = {
       id: GATEWAY_CLIENT_NAMES.TEST,
@@ -1304,7 +1304,7 @@ describe("gateway server auth/connect", () => {
       await import("../infra/device-identity.js");
     const { listDevicePairing } = await import("../infra/device-pairing.js");
     const { server, ws, port, prevToken } = await startServerWithClient("secret");
-    const identityDir = await mkdtemp(join(tmpdir(), "openclaw-device-scope-"));
+    const identityDir = await mkdtemp(join(tmpdir(), "remoteclaw-device-scope-"));
     const identity = loadOrCreateDeviceIdentity(join(identityDir, "device.json"));
     const client = {
       id: GATEWAY_CLIENT_NAMES.TEST,
@@ -1375,7 +1375,7 @@ describe("gateway server auth/connect", () => {
     const { writeJsonAtomic } = await import("../infra/json-files.js");
     const { approveDevicePairing, getPairedDevice, listDevicePairing, requestDevicePairing } =
       await import("../infra/device-pairing.js");
-    const identityDir = await mkdtemp(join(tmpdir(), "openclaw-device-legacy-meta-"));
+    const identityDir = await mkdtemp(join(tmpdir(), "remoteclaw-device-legacy-meta-"));
     const identity = loadOrCreateDeviceIdentity(join(identityDir, "device.json"));
     const deviceId = identity.deviceId;
     const publicKey = publicKeyRawBase64UrlFromPem(identity.publicKeyPem);
@@ -1463,7 +1463,7 @@ describe("gateway server auth/connect", () => {
       await import("../infra/device-pairing.js");
     const { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } =
       await import("../utils/message-channel.js");
-    const identityDir = await mkdtemp(join(tmpdir(), "openclaw-device-legacy-"));
+    const identityDir = await mkdtemp(join(tmpdir(), "remoteclaw-device-legacy-"));
     const identity = loadOrCreateDeviceIdentity(join(identityDir, "device.json"));
     const devicePublicKey = publicKeyRawBase64UrlFromPem(identity.publicKeyPem);
     const seeded = await requestDevicePairing({

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -43,7 +43,7 @@ async function withGatewayChatHarness(
   const tempDirs: string[] = [];
   const { server, ws } = await startServerWithClient();
   const createSessionDir = async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-gw-"));
     tempDirs.push(sessionDir);
     testState.sessionStorePath = path.join(sessionDir, "sessions.json");
     return sessionDir;

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -126,7 +126,7 @@ describe("gateway server chat", () => {
       expect(sessionRes.ok).toBe(true);
       expect(sessionRes.payload?.runId).toBe("idem-session-key-1");
 
-      const sendPolicyDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+      const sendPolicyDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-gw-"));
       tempDirs.push(sendPolicyDir);
       testState.sessionStorePath = path.join(sendPolicyDir, "sessions.json");
       testState.sessionConfig = {
@@ -165,7 +165,7 @@ describe("gateway server chat", () => {
       testState.sessionStorePath = undefined;
       testState.sessionConfig = undefined;
 
-      const agentBlockedDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+      const agentBlockedDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-gw-"));
       tempDirs.push(agentBlockedDir);
       testState.sessionStorePath = path.join(agentBlockedDir, "sessions.json");
       testState.sessionConfig = {
@@ -259,7 +259,7 @@ describe("gateway server chat", () => {
       expect(imgOnlyRes.ok).toBe(true);
       expect(imgOnlyRes.payload?.runId).toBeDefined();
 
-      const historyDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+      const historyDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-gw-"));
       tempDirs.push(historyDir);
       testState.sessionStorePath = path.join(historyDir, "sessions.json");
       await writeSessionStore({
@@ -319,7 +319,7 @@ describe("gateway server chat", () => {
   });
 
   test("routes chat.send slash commands without agent runs", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-gw-"));
     try {
       testState.sessionStorePath = path.join(dir, "sessions.json");
       await writeSessionStore({
@@ -357,7 +357,7 @@ describe("gateway server chat", () => {
   });
 
   test("agent events include sessionKey and agent.wait covers lifecycle flows", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-gw-"));
     testState.sessionStorePath = path.join(dir, "sessions.json");
     await writeSessionStore({
       entries: {

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -24,7 +24,7 @@ function requireWs(): Awaited<ReturnType<typeof startServerWithClient>>["ws"] {
 }
 
 beforeAll(async () => {
-  sharedTempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-config-"));
+  sharedTempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-sessions-config-"));
   startedServer = await startServerWithClient(undefined, { controlUiEnabled: true });
   await connectOk(requireWs());
 });

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -82,7 +82,7 @@ const emptyRegistry = createRegistry([]);
 
 describe("gateway server voicewake", () => {
   const withTempHome = async <T>(fn: (homeDir: string) => Promise<T>): Promise<T> => {
-    const tempHome = await createTempHomeEnv("openclaw-home-");
+    const tempHome = await createTempHomeEnv("remoteclaw-home-");
     try {
       return await fn(tempHome.home);
     } finally {

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -76,7 +76,7 @@ describe("gateway plugin HTTP auth boundary", () => {
 
     await withTempConfig({
       cfg: { gateway: { trustedProxies: [] } },
-      prefix: "openclaw-plugin-http-security-headers-test-",
+      prefix: "remoteclaw-plugin-http-security-headers-test-",
       run: async () => {
         const withoutHsts = createGatewayHttpServer({
           controlUiEnabled: false,
@@ -134,7 +134,7 @@ describe("gateway plugin HTTP auth boundary", () => {
 
     await withTempConfig({
       cfg: { gateway: { trustedProxies: [] } },
-      prefix: "openclaw-plugin-http-auth-test-",
+      prefix: "remoteclaw-plugin-http-auth-test-",
       run: async () => {
         const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
           const pathname = new URL(req.url ?? "/", "http://localhost").pathname;

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -97,7 +97,7 @@ let sharedSessionStorePath: string;
 
 beforeAll(async () => {
   harness = await startGatewayServerHarness();
-  sharedSessionStoreDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-"));
+  sharedSessionStoreDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-sessions-"));
   sharedSessionStorePath = path.join(sharedSessionStoreDir, "sessions.json");
 });
 

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -654,13 +654,13 @@ describe("resolveSessionTranscriptCandidates", () => {
   });
 
   test("fallback candidate uses REMOTECLAW_HOME instead of os.homedir()", () => {
-    vi.stubEnv("REMOTECLAW_HOME", "/srv/openclaw-home");
+    vi.stubEnv("REMOTECLAW_HOME", "/srv/remoteclaw-home");
     vi.stubEnv("HOME", "/home/other");
 
     const candidates = resolveSessionTranscriptCandidates("sess-1", undefined);
     const fallback = candidates[candidates.length - 1];
     expect(fallback).toBe(
-      path.join(path.resolve("/srv/openclaw-home"), ".remoteclaw", "sessions", "sess-1.jsonl"),
+      path.join(path.resolve("/srv/remoteclaw-home"), ".remoteclaw", "sessions", "sess-1.jsonl"),
     );
   });
 });

--- a/src/hooks/frontmatter.test.ts
+++ b/src/hooks/frontmatter.test.ts
@@ -201,7 +201,7 @@ describe("resolveRemoteClawMetadata", () => {
           events: ["command"],
           install: [
             { id: "bundled", kind: "bundled", label: "Bundled with RemoteClaw" },
-            { id: "npm", kind: "npm", package: "@openclaw/hook" },
+            { id: "npm", kind: "npm", package: "@remoteclaw/hook" },
           ],
         },
       }),
@@ -211,7 +211,7 @@ describe("resolveRemoteClawMetadata", () => {
     expect(result?.install).toHaveLength(2);
     expect(result?.install?.[0].kind).toBe("bundled");
     expect(result?.install?.[1].kind).toBe("npm");
-    expect(result?.install?.[1].package).toBe("@openclaw/hook");
+    expect(result?.install?.[1].package).toBe("@remoteclaw/hook");
   });
 
   it("handles os restrictions", () => {
@@ -233,7 +233,7 @@ describe("resolveRemoteClawMetadata", () => {
     const content = `---
 name: session-memory
 description: "Save session context to memory when /new or /reset command is issued"
-homepage: https://docs.openclaw.ai/automation/hooks#session-memory
+homepage: https://docs.remoteclaw.ai/automation/hooks#session-memory
 metadata:
   {
     "openclaw":

--- a/src/hooks/gmail-setup-utils.test.ts
+++ b/src/hooks/gmail-setup-utils.test.ts
@@ -25,7 +25,7 @@ describe("resolvePythonExecutablePath", () => {
   itUnix(
     "resolves a working python path and caches the result",
     async () => {
-      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-python-"));
+      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-python-"));
       try {
         const realPython = path.join(tmp, "python-real");
         await fs.writeFile(realPython, "#!/bin/sh\nexit 0\n", "utf-8");

--- a/src/hooks/hooks-install.test.ts
+++ b/src/hooks/hooks-install.test.ts
@@ -13,7 +13,7 @@ import { loadInternalHooks } from "./loader.js";
 const tempDirs: string[] = [];
 
 async function makeTempDir() {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hooks-e2e-"));
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-hooks-e2e-"));
   tempDirs.push(dir);
   return dir;
 }

--- a/src/hooks/import-url.test.ts
+++ b/src/hooks/import-url.test.ts
@@ -39,7 +39,7 @@ describe("buildImportUrl", () => {
   });
 
   it("appends mtime-based cache buster for plugin hooks", () => {
-    const url = buildImportUrl(tmpFile, "remoteclaw-plugin");
+    const url = buildImportUrl(tmpFile, "openclaw-plugin");
     expect(url).toMatch(/\?t=[\d.]+&s=\d+/);
   });
 

--- a/src/hooks/import-url.test.ts
+++ b/src/hooks/import-url.test.ts
@@ -39,7 +39,7 @@ describe("buildImportUrl", () => {
   });
 
   it("appends mtime-based cache buster for plugin hooks", () => {
-    const url = buildImportUrl(tmpFile, "openclaw-plugin");
+    const url = buildImportUrl(tmpFile, "remoteclaw-plugin");
     expect(url).toMatch(/\?t=[\d.]+&s=\d+/);
   });
 

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -19,7 +19,7 @@ describe("loader", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
 
   beforeAll(async () => {
-    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hooks-loader-"));
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-hooks-loader-"));
   });
 
   beforeEach(async () => {

--- a/src/hooks/workspace.test.ts
+++ b/src/hooks/workspace.test.ts
@@ -7,7 +7,7 @@ import { loadHookEntriesFromDir } from "./workspace.js";
 
 describe("hooks workspace", () => {
   it("ignores package.json hook paths that traverse outside package directory", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-workspace-"));
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-hooks-workspace-"));
     const hooksRoot = path.join(root, "hooks");
     fs.mkdirSync(hooksRoot, { recursive: true });
 
@@ -38,7 +38,7 @@ describe("hooks workspace", () => {
   });
 
   it("accepts package.json hook paths within package directory", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-workspace-ok-"));
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-hooks-workspace-ok-"));
     const hooksRoot = path.join(root, "hooks");
     fs.mkdirSync(hooksRoot, { recursive: true });
 
@@ -68,7 +68,7 @@ describe("hooks workspace", () => {
   });
 
   it("ignores package.json hook paths that escape via symlink", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-workspace-link-"));
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-hooks-workspace-link-"));
     const hooksRoot = path.join(root, "hooks");
     fs.mkdirSync(hooksRoot, { recursive: true });
 

--- a/src/infra/archive.test.ts
+++ b/src/infra/archive.test.ts
@@ -64,7 +64,7 @@ async function expectExtractedSizeBudgetExceeded(params: {
 }
 
 beforeAll(async () => {
-  fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-archive-"));
+  fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-archive-"));
 });
 
 afterAll(async () => {

--- a/src/infra/bonjour-discovery.test.ts
+++ b/src/infra/bonjour-discovery.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { runCommandWithTimeout } from "../process/exec.js";
 import { discoverGatewayBeacons } from "./bonjour-discovery.js";
 
-const WIDE_AREA_DOMAIN = "openclaw.internal.";
+const WIDE_AREA_DOMAIN = "remoteclaw.internal.";
 
 describe("bonjour-discovery", () => {
   it("discovers beacons on darwin across local + wide-area domains", async () => {
@@ -289,12 +289,12 @@ describe("bonjour-discovery", () => {
     await discoverGatewayBeacons({
       platform: "darwin",
       timeoutMs: 1,
-      domains: ["local", "openclaw.internal"],
+      domains: ["local", "remoteclaw.internal"],
       run: run as unknown as typeof runCommandWithTimeout,
     });
 
     expect(calls.filter((c) => c[1] === "-B").map((c) => c[3])).toEqual(
-      expect.arrayContaining(["local.", "openclaw.internal."]),
+      expect.arrayContaining(["local.", "remoteclaw.internal."]),
     );
 
     calls.length = 0;

--- a/src/infra/brew.test.ts
+++ b/src/infra/brew.test.ts
@@ -6,7 +6,7 @@ import { resolveBrewExecutable, resolveBrewPathDirs } from "./brew.js";
 
 describe("brew helpers", () => {
   async function withBrewRoot(run: (tmp: string) => Promise<void>) {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-brew-"));
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-brew-"));
     try {
       await run(tmp);
     } finally {

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -78,7 +78,7 @@ let resolveControlUiDistIndexPath: typeof import("./control-ui-assets.js").resol
 let resolveControlUiDistIndexHealth: typeof import("./control-ui-assets.js").resolveControlUiDistIndexHealth;
 let resolveControlUiRootOverrideSync: typeof import("./control-ui-assets.js").resolveControlUiRootOverrideSync;
 let resolveControlUiRootSync: typeof import("./control-ui-assets.js").resolveControlUiRootSync;
-let openclawRoot: typeof import("./remoteclaw-root.js");
+let remoteClawRoot: typeof import("./remoteclaw-root.js");
 
 describe("control UI assets helpers (fs-mocked)", () => {
   beforeAll(async () => {
@@ -89,7 +89,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
       resolveControlUiRootOverrideSync,
       resolveControlUiRootSync,
     } = await import("./control-ui-assets.js"));
-    openclawRoot = await import("./remoteclaw-root.js");
+    remoteClawRoot = await import("./remoteclaw-root.js");
   });
 
   beforeEach(() => {
@@ -124,12 +124,12 @@ describe("control UI assets helpers (fs-mocked)", () => {
   });
 
   it("uses resolveRemoteClawPackageRoot when available", async () => {
-    const pkgRoot = abs("fixtures/openclaw");
+    const pkgRoot = abs("fixtures/remoteclaw");
     (
-      openclawRoot.resolveRemoteClawPackageRoot as unknown as ReturnType<typeof vi.fn>
+      remoteClawRoot.resolveRemoteClawPackageRoot as unknown as ReturnType<typeof vi.fn>
     ).mockResolvedValueOnce(pkgRoot);
 
-    await expect(resolveControlUiDistIndexPath(abs("fixtures/bin/openclaw"))).resolves.toBe(
+    await expect(resolveControlUiDistIndexPath(abs("fixtures/bin/remoteclaw"))).resolves.toBe(
       path.join(pkgRoot, "dist", "control-ui", "index.html"),
     );
   });
@@ -145,7 +145,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
   });
 
   it("returns null when fallback package name does not match", async () => {
-    const root = abs("fixtures/not-openclaw");
+    const root = abs("fixtures/not-remoteclaw");
     setFile(path.join(root, "package.json"), JSON.stringify({ name: "malicious-pkg" }));
     setFile(path.join(root, "dist", "control-ui", "index.html"), "<html></html>\n");
 
@@ -182,9 +182,9 @@ describe("control UI assets helpers (fs-mocked)", () => {
   });
 
   it("resolves control-ui root for dist bundle argv1 and moduleUrl candidates", async () => {
-    const pkgRoot = abs("fixtures/openclaw-bundle");
+    const pkgRoot = abs("fixtures/remoteclaw-bundle");
     (
-      openclawRoot.resolveRemoteClawPackageRootSync as unknown as ReturnType<typeof vi.fn>
+      remoteClawRoot.resolveRemoteClawPackageRootSync as unknown as ReturnType<typeof vi.fn>
     ).mockReturnValueOnce(pkgRoot);
 
     const uiDir = path.join(pkgRoot, "dist", "control-ui");

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -26,7 +26,7 @@ async function setupPairedOperatorDevice(baseDir: string, scopes: string[]) {
 }
 
 async function setupOperatorToken(scopes: string[]) {
-  const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+  const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-device-pairing-"));
   await setupPairedOperatorDevice(baseDir, scopes);
   const paired = await getPairedDevice("device-1", baseDir);
   const token = requireToken(paired?.tokens?.operator?.token);
@@ -53,7 +53,7 @@ function requireToken(token: string | undefined): string {
 
 describe("device pairing tokens", () => {
   test("reuses existing pending requests for the same device", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-device-pairing-"));
     const first = await requestDevicePairing(
       {
         deviceId: "device-1",
@@ -75,7 +75,7 @@ describe("device pairing tokens", () => {
   });
 
   test("merges pending roles/scopes for the same device before approval", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-device-pairing-"));
     const first = await requestDevicePairing(
       {
         deviceId: "device-1",
@@ -107,7 +107,7 @@ describe("device pairing tokens", () => {
   });
 
   test("generates base64url device tokens with 256-bit entropy output length", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-device-pairing-"));
     await setupPairedOperatorDevice(baseDir, ["operator.admin"]);
 
     const paired = await getPairedDevice("device-1", baseDir);
@@ -117,7 +117,7 @@ describe("device pairing tokens", () => {
   });
 
   test("allows down-scoping from admin and preserves approved scope baseline", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-device-pairing-"));
     await setupPairedOperatorDevice(baseDir, ["operator.admin"]);
 
     await rotateDeviceToken({
@@ -141,7 +141,7 @@ describe("device pairing tokens", () => {
   });
 
   test("preserves existing token scopes when approving a repair without requested scopes", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-device-pairing-"));
     await setupPairedOperatorDevice(baseDir, ["operator.admin"]);
 
     const repair = await requestDevicePairing(
@@ -161,7 +161,7 @@ describe("device pairing tokens", () => {
   });
 
   test("rejects scope escalation when rotating a token and leaves state unchanged", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-device-pairing-"));
     await setupPairedOperatorDevice(baseDir, ["operator.read"]);
     const before = await getPairedDevice("device-1", baseDir);
 
@@ -232,7 +232,7 @@ describe("device pairing tokens", () => {
   });
 
   test("removes paired devices by device id", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-device-pairing-"));
     await setupPairedOperatorDevice(baseDir, ["operator.read"]);
 
     const removed = await removePairedDevice("device-1", baseDir);
@@ -243,7 +243,7 @@ describe("device pairing tokens", () => {
   });
 
   test("clears paired device state by device id", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-device-pairing-"));
     await setupPairedOperatorDevice(baseDir, ["operator.read"]);
 
     await expect(clearDevicePairing("device-1", baseDir)).resolves.toBe(true);

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -38,7 +38,7 @@ type DotEnvFixture = {
 };
 
 async function withDotEnvFixture(run: (fixture: DotEnvFixture) => Promise<void>) {
-  const base = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dotenv-test-"));
+  const base = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-dotenv-test-"));
   const cwdDir = path.join(base, "cwd");
   const stateDir = path.join(base, "state");
   process.env.REMOTECLAW_STATE_DIR = stateDir;

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -12,7 +12,7 @@ afterEach(async () => {
 
 describe("fs-safe", () => {
   it("reads a local file safely", async () => {
-    const dir = await tempDirs.make("openclaw-fs-safe-");
+    const dir = await tempDirs.make("remoteclaw-fs-safe-");
     const file = path.join(dir, "payload.txt");
     await fs.writeFile(file, "hello");
 
@@ -23,14 +23,14 @@ describe("fs-safe", () => {
   });
 
   it("rejects directories", async () => {
-    const dir = await tempDirs.make("openclaw-fs-safe-");
+    const dir = await tempDirs.make("remoteclaw-fs-safe-");
     await expect(readLocalFileSafely({ filePath: dir })).rejects.toMatchObject({
       code: "not-file",
     });
   });
 
   it("enforces maxBytes", async () => {
-    const dir = await tempDirs.make("openclaw-fs-safe-");
+    const dir = await tempDirs.make("remoteclaw-fs-safe-");
     const file = path.join(dir, "big.bin");
     await fs.writeFile(file, Buffer.alloc(8));
 
@@ -40,7 +40,7 @@ describe("fs-safe", () => {
   });
 
   it.runIf(process.platform !== "win32")("rejects symlinks", async () => {
-    const dir = await tempDirs.make("openclaw-fs-safe-");
+    const dir = await tempDirs.make("remoteclaw-fs-safe-");
     const target = path.join(dir, "target.txt");
     const link = path.join(dir, "link.txt");
     await fs.writeFile(target, "target");
@@ -52,8 +52,8 @@ describe("fs-safe", () => {
   });
 
   it("blocks traversal outside root", async () => {
-    const root = await tempDirs.make("openclaw-fs-safe-root-");
-    const outside = await tempDirs.make("openclaw-fs-safe-outside-");
+    const root = await tempDirs.make("remoteclaw-fs-safe-root-");
+    const outside = await tempDirs.make("remoteclaw-fs-safe-outside-");
     const file = path.join(outside, "outside.txt");
     await fs.writeFile(file, "outside");
 
@@ -66,8 +66,8 @@ describe("fs-safe", () => {
   });
 
   it.runIf(process.platform !== "win32")("blocks symlink escapes under root", async () => {
-    const root = await tempDirs.make("openclaw-fs-safe-root-");
-    const outside = await tempDirs.make("openclaw-fs-safe-outside-");
+    const root = await tempDirs.make("remoteclaw-fs-safe-root-");
+    const outside = await tempDirs.make("remoteclaw-fs-safe-outside-");
     const target = path.join(outside, "outside.txt");
     const link = path.join(root, "link.txt");
     await fs.writeFile(target, "outside");
@@ -82,7 +82,7 @@ describe("fs-safe", () => {
   });
 
   it("returns not-found for missing files", async () => {
-    const dir = await tempDirs.make("openclaw-fs-safe-");
+    const dir = await tempDirs.make("remoteclaw-fs-safe-");
     const missing = path.join(dir, "missing.txt");
 
     await expect(readLocalFileSafely({ filePath: missing })).rejects.toBeInstanceOf(SafeOpenError);

--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -139,7 +139,7 @@ async function writeRecentLockFile(env: NodeJS.ProcessEnv, startTime = 111) {
 
 describe("gateway lock", () => {
   beforeAll(async () => {
-    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-lock-"));
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-gateway-lock-"));
   });
 
   beforeEach(() => {

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -138,7 +138,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
 
   it("does not use CRON_EVENT_PROMPT when only a HEARTBEAT_OK event is present", async () => {
     const { result, sendTelegram, calledCtx, replyCallCount } = await runHeartbeatCase({
-      tmpPrefix: "openclaw-ghost-",
+      tmpPrefix: "remoteclaw-ghost-",
       replyText: "Heartbeat check-in",
       reason: "cron:test-job",
       enqueue: (sessionKey) => {
@@ -180,7 +180,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
 
   it("uses CRON_EVENT_PROMPT for tagged cron events on interval wake", async () => {
     const { result, sendTelegram, calledCtx, replyCallCount } = await runHeartbeatCase({
-      tmpPrefix: "openclaw-cron-interval-",
+      tmpPrefix: "remoteclaw-cron-interval-",
       replyText: "Relay this cron update now",
       reason: "interval",
       enqueue: (sessionKey) => {
@@ -201,7 +201,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
 
   it("uses an internal-only cron prompt when delivery target is none", async () => {
     const { result, sendTelegram, calledCtx } = await runHeartbeatCase({
-      tmpPrefix: "openclaw-cron-internal-",
+      tmpPrefix: "remoteclaw-cron-internal-",
       replyText: "Handled internally",
       reason: "cron:reminder-job",
       target: "none",
@@ -218,7 +218,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
 
   it("uses an internal-only exec prompt when delivery target is none", async () => {
     const { result, sendTelegram, calledCtx } = await runHeartbeatCase({
-      tmpPrefix: "openclaw-exec-internal-",
+      tmpPrefix: "remoteclaw-exec-internal-",
       replyText: "Handled internally",
       reason: "exec-event",
       target: "none",

--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -40,7 +40,7 @@ async function withHeartbeatFixture(
       };
       return run({ tmpDir, storePath, seedSession });
     },
-    { prefix: "openclaw-hb-model-" },
+    { prefix: "remoteclaw-hb-model-" },
   );
 }
 

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -103,7 +103,7 @@ beforeAll(async () => {
   ]);
   setActivePluginRegistry(testRegistry);
 
-  fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-suite-"));
+  fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-heartbeat-suite-"));
 });
 
 beforeEach(() => {
@@ -938,7 +938,7 @@ describe("runHeartbeatOnce", () => {
   });
 
   it("loads the default agent session from templated stores", async () => {
-    const tmpDir = await createCaseDir("openclaw-hb");
+    const tmpDir = await createCaseDir("remoteclaw-hb");
     const storeTemplate = path.join(tmpDir, "agents", "{agentId}", "sessions.json");
     const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
     try {
@@ -998,7 +998,7 @@ describe("runHeartbeatOnce", () => {
     queueCronEvent?: boolean;
     replyText?: string;
   }) {
-    const tmpDir = await createCaseDir("openclaw-hb");
+    const tmpDir = await createCaseDir("remoteclaw-hb");
     const storePath = path.join(tmpDir, "sessions.json");
     const workspaceDir = path.join(tmpDir, "workspace");
     await fs.mkdir(workspaceDir, { recursive: true });

--- a/src/infra/heartbeat-runner.sender-prefers-delivery-target.test.ts
+++ b/src/infra/heartbeat-runner.sender-prefers-delivery-target.test.ts
@@ -55,7 +55,7 @@ describe("runHeartbeatOnce", () => {
 
         expect(sendSlack).toHaveBeenCalled();
       },
-      { prefix: "openclaw-hb-" },
+      { prefix: "remoteclaw-hb-" },
     );
   });
 });

--- a/src/infra/heartbeat-runner.test-utils.ts
+++ b/src/infra/heartbeat-runner.test-utils.ts
@@ -57,7 +57,7 @@ export async function withTempHeartbeatSandbox<T>(
     unsetEnvVars?: string[];
   },
 ): Promise<T> {
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), options?.prefix ?? "openclaw-hb-"));
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), options?.prefix ?? "remoteclaw-hb-"));
   await fs.writeFile(path.join(tmpDir, "HEARTBEAT.md"), "- Check status\n", "utf-8");
   const storePath = path.join(tmpDir, "sessions.json");
   const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");

--- a/src/infra/heartbeat-runner.transcript-prune.test.ts
+++ b/src/infra/heartbeat-runner.transcript-prune.test.ts
@@ -85,7 +85,7 @@ describe("heartbeat transcript pruning", () => {
         }
         expect(finalSize).toBeGreaterThanOrEqual(originalSize);
       },
-      { prefix: "openclaw-hb-prune-" },
+      { prefix: "remoteclaw-hb-prune-" },
     );
   }
 

--- a/src/infra/home-dir.test.ts
+++ b/src/infra/home-dir.test.ts
@@ -5,13 +5,13 @@ import { expandHomePrefix, resolveEffectiveHomeDir, resolveRequiredHomeDir } fro
 describe("resolveEffectiveHomeDir", () => {
   it("prefers REMOTECLAW_HOME over HOME and USERPROFILE", () => {
     const env = {
-      REMOTECLAW_HOME: "/srv/openclaw-home",
+      REMOTECLAW_HOME: "/srv/remoteclaw-home",
       HOME: "/home/other",
       USERPROFILE: "C:/Users/other",
     } as NodeJS.ProcessEnv;
 
     expect(resolveEffectiveHomeDir(env, () => "/fallback")).toBe(
-      path.resolve("/srv/openclaw-home"),
+      path.resolve("/srv/remoteclaw-home"),
     );
   });
 
@@ -66,9 +66,9 @@ describe("resolveRequiredHomeDir", () => {
 describe("expandHomePrefix", () => {
   it("expands tilde using effective home", () => {
     const value = expandHomePrefix("~/x", {
-      env: { REMOTECLAW_HOME: "/srv/openclaw-home" } as NodeJS.ProcessEnv,
+      env: { REMOTECLAW_HOME: "/srv/remoteclaw-home" } as NodeJS.ProcessEnv,
     });
-    expect(value).toBe(`${path.resolve("/srv/openclaw-home")}/x`);
+    expect(value).toBe(`${path.resolve("/srv/remoteclaw-home")}/x`);
   });
 
   it("keeps non-tilde values unchanged", () => {

--- a/src/infra/host-env-security.test.ts
+++ b/src/infra/host-env-security.test.ts
@@ -160,7 +160,7 @@ describe("shell wrapper exploit regression", () => {
     if (process.platform === "win32" || !fs.existsSync(bashPath)) {
       return;
     }
-    const marker = path.join(os.tmpdir(), `openclaw-ps4-marker-${process.pid}-${Date.now()}`);
+    const marker = path.join(os.tmpdir(), `remoteclaw-ps4-marker-${process.pid}-${Date.now()}`);
     try {
       fs.unlinkSync(marker);
     } catch {

--- a/src/infra/infra-store.test.ts
+++ b/src/infra/infra-store.test.ts
@@ -23,7 +23,7 @@ import {
 describe("infra store", () => {
   describe("state migrations fs", () => {
     it("treats array session stores as invalid", async () => {
-      await withTempDir("openclaw-session-store-", async (dir) => {
+      await withTempDir("remoteclaw-session-store-", async (dir) => {
         const storePath = path.join(dir, "sessions.json");
         await fs.writeFile(storePath, "[]", "utf-8");
 
@@ -34,7 +34,7 @@ describe("infra store", () => {
     });
 
     it("parses JSON5 object session stores", async () => {
-      await withTempDir("openclaw-session-store-", async (dir) => {
+      await withTempDir("remoteclaw-session-store-", async (dir) => {
         const storePath = path.join(dir, "sessions.json");
         await fs.writeFile(
           storePath,
@@ -52,7 +52,7 @@ describe("infra store", () => {
 
   describe("voicewake store", () => {
     it("returns defaults when missing", async () => {
-      await withTempDir("openclaw-voicewake-", async (baseDir) => {
+      await withTempDir("remoteclaw-voicewake-", async (baseDir) => {
         const cfg = await loadVoiceWakeConfig(baseDir);
         expect(cfg.triggers).toEqual(defaultVoiceWakeTriggers());
         expect(cfg.updatedAtMs).toBe(0);
@@ -60,7 +60,7 @@ describe("infra store", () => {
     });
 
     it("sanitizes and persists triggers", async () => {
-      await withTempDir("openclaw-voicewake-", async (baseDir) => {
+      await withTempDir("remoteclaw-voicewake-", async (baseDir) => {
         const saved = await setVoiceWakeTriggers(["  hi  ", "", "  there "], baseDir);
         expect(saved.triggers).toEqual(["hi", "there"]);
         expect(saved.updatedAtMs).toBeGreaterThan(0);
@@ -72,14 +72,14 @@ describe("infra store", () => {
     });
 
     it("falls back to defaults when triggers empty", async () => {
-      await withTempDir("openclaw-voicewake-", async (baseDir) => {
+      await withTempDir("remoteclaw-voicewake-", async (baseDir) => {
         const saved = await setVoiceWakeTriggers(["", "   "], baseDir);
         expect(saved.triggers).toEqual(defaultVoiceWakeTriggers());
       });
     });
 
     it("sanitizes malformed persisted config values", async () => {
-      await withTempDir("openclaw-voicewake-", async (baseDir) => {
+      await withTempDir("remoteclaw-voicewake-", async (baseDir) => {
         await fs.mkdir(path.join(baseDir, "settings"), { recursive: true });
         await fs.writeFile(
           path.join(baseDir, "settings", "voicewake.json"),

--- a/src/infra/install-flow.test.ts
+++ b/src/infra/install-flow.test.ts
@@ -10,7 +10,7 @@ describe("resolveExistingInstallPath", () => {
   let fixtureRoot = "";
 
   beforeEach(async () => {
-    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-install-flow-"));
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-install-flow-"));
   });
 
   afterEach(async () => {
@@ -51,7 +51,7 @@ describe("withExtractedArchiveRoot", () => {
   });
 
   it("extracts archive and passes root directory to callback", async () => {
-    const tmpRoot = path.join(path.sep, "tmp", "openclaw-install-flow");
+    const tmpRoot = path.join(path.sep, "tmp", "remoteclaw-install-flow");
     const archivePath = path.join(path.sep, "tmp", "plugin.tgz");
     const extractDir = path.join(tmpRoot, "extract");
     const packageRoot = path.join(extractDir, "package");
@@ -64,12 +64,12 @@ describe("withExtractedArchiveRoot", () => {
     const onExtracted = vi.fn(async (rootDir: string) => ({ ok: true as const, rootDir }));
     const result = await withExtractedArchiveRoot({
       archivePath,
-      tempDirPrefix: "openclaw-plugin-",
+      tempDirPrefix: "remoteclaw-plugin-",
       timeoutMs: 1000,
       onExtracted,
     });
 
-    expect(withTempDirSpy).toHaveBeenCalledWith("openclaw-plugin-", expect.any(Function));
+    expect(withTempDirSpy).toHaveBeenCalledWith("remoteclaw-plugin-", expect.any(Function));
     expect(extractSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         archivePath,
@@ -85,13 +85,13 @@ describe("withExtractedArchiveRoot", () => {
 
   it("returns extract failure when extraction throws", async () => {
     vi.spyOn(installSource, "withTempDir").mockImplementation(
-      async (_prefix, fn) => await fn("/tmp/openclaw-install-flow"),
+      async (_prefix, fn) => await fn("/tmp/remoteclaw-install-flow"),
     );
     vi.spyOn(archive, "extractArchive").mockRejectedValue(new Error("boom"));
 
     const result = await withExtractedArchiveRoot({
       archivePath: "/tmp/plugin.tgz",
-      tempDirPrefix: "openclaw-plugin-",
+      tempDirPrefix: "remoteclaw-plugin-",
       timeoutMs: 1000,
       onExtracted: async () => ({ ok: true as const }),
     });
@@ -104,14 +104,14 @@ describe("withExtractedArchiveRoot", () => {
 
   it("returns root-resolution failure when archive layout is invalid", async () => {
     vi.spyOn(installSource, "withTempDir").mockImplementation(
-      async (_prefix, fn) => await fn("/tmp/openclaw-install-flow"),
+      async (_prefix, fn) => await fn("/tmp/remoteclaw-install-flow"),
     );
     vi.spyOn(archive, "extractArchive").mockResolvedValue(undefined);
     vi.spyOn(archive, "resolvePackedRootDir").mockRejectedValue(new Error("invalid layout"));
 
     const result = await withExtractedArchiveRoot({
       archivePath: "/tmp/plugin.tgz",
-      tempDirPrefix: "openclaw-plugin-",
+      tempDirPrefix: "remoteclaw-plugin-",
       timeoutMs: 1000,
       onExtracted: async () => ({ ok: true as const }),
     });

--- a/src/infra/install-source-utils.test.ts
+++ b/src/infra/install-source-utils.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./install-source-utils.js";
 
 const runCommandWithTimeoutMock = vi.fn();
-const TEMP_DIR_PREFIX = "openclaw-install-source-utils-";
+const TEMP_DIR_PREFIX = "remoteclaw-install-source-utils-";
 
 vi.mock("../process/exec.js", () => ({
   runCommandWithTimeout: (...args: unknown[]) => runCommandWithTimeoutMock(...args),
@@ -75,7 +75,7 @@ describe("withTempDir", () => {
     let observedDir = "";
     const markerFile = "marker.txt";
 
-    const value = await withTempDir("openclaw-install-source-utils-", async (tmpDir) => {
+    const value = await withTempDir("remoteclaw-install-source-utils-", async (tmpDir) => {
       observedDir = tmpDir;
       await fs.writeFile(path.join(tmpDir, markerFile), "ok", "utf-8");
       await expect(fs.stat(path.join(tmpDir, markerFile))).resolves.toBeDefined();
@@ -89,7 +89,7 @@ describe("withTempDir", () => {
 
 describe("resolveArchiveSourcePath", () => {
   it("returns not found error for missing archive paths", async () => {
-    const result = await resolveArchiveSourcePath("/tmp/does-not-exist-openclaw-archive.tgz");
+    const result = await resolveArchiveSourcePath("/tmp/does-not-exist-remoteclaw-archive.tgz");
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain("archive not found");
@@ -126,31 +126,31 @@ describe("packNpmSpecToArchive", () => {
     mockPackCommandResult({
       stdout: JSON.stringify([
         {
-          id: "openclaw-plugin@1.2.3",
-          name: "openclaw-plugin",
+          id: "remoteclaw-plugin@1.2.3",
+          name: "remoteclaw-plugin",
           version: "1.2.3",
-          filename: "openclaw-plugin-1.2.3.tgz",
+          filename: "remoteclaw-plugin-1.2.3.tgz",
           integrity: "sha512-test-integrity",
           shasum: "abc123",
         },
       ]),
     });
 
-    const result = await runPack("openclaw-plugin@1.2.3", cwd);
+    const result = await runPack("remoteclaw-plugin@1.2.3", cwd);
 
     expect(result).toEqual({
       ok: true,
-      archivePath: path.join(cwd, "openclaw-plugin-1.2.3.tgz"),
+      archivePath: path.join(cwd, "remoteclaw-plugin-1.2.3.tgz"),
       metadata: {
-        name: "openclaw-plugin",
+        name: "remoteclaw-plugin",
         version: "1.2.3",
-        resolvedSpec: "openclaw-plugin@1.2.3",
+        resolvedSpec: "remoteclaw-plugin@1.2.3",
         integrity: "sha512-test-integrity",
         shasum: "abc123",
       },
     });
     expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(
-      ["npm", "pack", "openclaw-plugin@1.2.3", "--ignore-scripts", "--json"],
+      ["npm", "pack", "remoteclaw-plugin@1.2.3", "--ignore-scripts", "--json"],
       expect.objectContaining({
         cwd,
         timeoutMs: 300_000,
@@ -161,14 +161,14 @@ describe("packNpmSpecToArchive", () => {
   it("falls back to parsing final stdout line when npm json output is unavailable", async () => {
     const cwd = await createFixtureDir();
     mockPackCommandResult({
-      stdout: "npm notice created package\nopenclaw-plugin-1.2.3.tgz\n",
+      stdout: "npm notice created package\nremoteclaw-plugin-1.2.3.tgz\n",
     });
 
-    const result = await runPack("openclaw-plugin@1.2.3", cwd);
+    const result = await runPack("remoteclaw-plugin@1.2.3", cwd);
 
     expect(result).toEqual({
       ok: true,
-      archivePath: path.join(cwd, "openclaw-plugin-1.2.3.tgz"),
+      archivePath: path.join(cwd, "remoteclaw-plugin-1.2.3.tgz"),
       metadata: {},
     });
   });
@@ -196,7 +196,7 @@ describe("packNpmSpecToArchive", () => {
       stdout: " \n\n",
     });
 
-    const result = await runPack("openclaw-plugin@1.2.3", cwd, 5000);
+    const result = await runPack("remoteclaw-plugin@1.2.3", cwd, 5000);
 
     expect(result).toEqual({
       ok: false,
@@ -211,18 +211,18 @@ describe("packNpmSpecToArchive", () => {
         "npm notice creating package\n" +
         JSON.stringify([
           {
-            id: "@openclaw/plugin-demo@2.0.0",
-            filename: "openclaw-plugin-demo-2.0.0.tgz",
+            id: "@remoteclaw/plugin-demo@2.0.0",
+            filename: "remoteclaw-plugin-demo-2.0.0.tgz",
           },
         ]),
     });
 
-    const result = await runPack("@openclaw/plugin-demo@2.0.0", cwd);
+    const result = await runPack("@remoteclaw/plugin-demo@2.0.0", cwd);
     expect(result).toEqual({
       ok: true,
-      archivePath: path.join(cwd, "openclaw-plugin-demo-2.0.0.tgz"),
+      archivePath: path.join(cwd, "remoteclaw-plugin-demo-2.0.0.tgz"),
       metadata: {
-        resolvedSpec: "@openclaw/plugin-demo@2.0.0",
+        resolvedSpec: "@remoteclaw/plugin-demo@2.0.0",
       },
     });
   });

--- a/src/infra/node-pairing.test.ts
+++ b/src/infra/node-pairing.test.ts
@@ -29,7 +29,7 @@ async function setupPairedNode(baseDir: string): Promise<string> {
 
 describe("node pairing tokens", () => {
   test("reuses existing pending requests for the same node", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-node-pairing-"));
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
     const first = await requestNodePairing(
       {
         nodeId: "node-1",
@@ -51,14 +51,14 @@ describe("node pairing tokens", () => {
   });
 
   test("generates base64url node tokens with 256-bit entropy output length", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-node-pairing-"));
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
     const token = await setupPairedNode(baseDir);
     expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
     expect(Buffer.from(token, "base64url")).toHaveLength(32);
   });
 
   test("verifies token and rejects mismatches", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-node-pairing-"));
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
     const token = await setupPairedNode(baseDir);
     await expect(verifyNodeToken("node-1", token, baseDir)).resolves.toEqual({
       ok: true,
@@ -70,7 +70,7 @@ describe("node pairing tokens", () => {
   });
 
   test("treats multibyte same-length token input as mismatch without throwing", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-node-pairing-"));
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
     const token = await setupPairedNode(baseDir);
     const multibyteToken = "é".repeat(token.length);
     expect(Buffer.from(multibyteToken).length).not.toBe(Buffer.from(token).length);

--- a/src/infra/npm-integrity.test.ts
+++ b/src/infra/npm-integrity.test.ts
@@ -8,7 +8,7 @@ describe("resolveNpmIntegrityDrift", () => {
   it("returns proceed=true when integrity is missing or unchanged", async () => {
     await expect(
       resolveNpmIntegrityDrift({
-        spec: "@openclaw/test@1.0.0",
+        spec: "@remoteclaw/test@1.0.0",
         expectedIntegrity: "sha512-same",
         resolution: { integrity: "sha512-same", resolvedAt: "2026-01-01T00:00:00.000Z" },
         createPayload: () => "unused",
@@ -17,7 +17,7 @@ describe("resolveNpmIntegrityDrift", () => {
 
     await expect(
       resolveNpmIntegrityDrift({
-        spec: "@openclaw/test@1.0.0",
+        spec: "@remoteclaw/test@1.0.0",
         expectedIntegrity: "sha512-same",
         resolution: { resolvedAt: "2026-01-01T00:00:00.000Z" },
         createPayload: () => "unused",
@@ -28,7 +28,7 @@ describe("resolveNpmIntegrityDrift", () => {
   it("uses callback on integrity drift", async () => {
     const onIntegrityDrift = vi.fn(async () => false);
     const result = await resolveNpmIntegrityDrift({
-      spec: "@openclaw/test@1.0.0",
+      spec: "@remoteclaw/test@1.0.0",
       expectedIntegrity: "sha512-old",
       resolution: {
         integrity: "sha512-new",
@@ -55,7 +55,7 @@ describe("resolveNpmIntegrityDrift", () => {
   it("warns by default when no callback is provided", async () => {
     const warn = vi.fn();
     const result = await resolveNpmIntegrityDrift({
-      spec: "@openclaw/test@1.0.0",
+      spec: "@remoteclaw/test@1.0.0",
       expectedIntegrity: "sha512-old",
       resolution: {
         integrity: "sha512-new",
@@ -65,39 +65,39 @@ describe("resolveNpmIntegrityDrift", () => {
       warn,
     });
 
-    expect(warn).toHaveBeenCalledWith({ spec: "@openclaw/test@1.0.0" });
+    expect(warn).toHaveBeenCalledWith({ spec: "@remoteclaw/test@1.0.0" });
     expect(result.proceed).toBe(true);
   });
 
   it("formats default warning and abort error messages", async () => {
     const warn = vi.fn();
     const warningResult = await resolveNpmIntegrityDriftWithDefaultMessage({
-      spec: "@openclaw/test@1.0.0",
+      spec: "@remoteclaw/test@1.0.0",
       expectedIntegrity: "sha512-old",
       resolution: {
         integrity: "sha512-new",
-        resolvedSpec: "@openclaw/test@1.0.0",
+        resolvedSpec: "@remoteclaw/test@1.0.0",
         resolvedAt: "2026-01-01T00:00:00.000Z",
       },
       warn,
     });
     expect(warningResult.error).toBeUndefined();
     expect(warn).toHaveBeenCalledWith(
-      "Integrity drift detected for @openclaw/test@1.0.0: expected sha512-old, got sha512-new",
+      "Integrity drift detected for @remoteclaw/test@1.0.0: expected sha512-old, got sha512-new",
     );
 
     const abortResult = await resolveNpmIntegrityDriftWithDefaultMessage({
-      spec: "@openclaw/test@1.0.0",
+      spec: "@remoteclaw/test@1.0.0",
       expectedIntegrity: "sha512-old",
       resolution: {
         integrity: "sha512-new",
-        resolvedSpec: "@openclaw/test@1.0.0",
+        resolvedSpec: "@remoteclaw/test@1.0.0",
         resolvedAt: "2026-01-01T00:00:00.000Z",
       },
       onIntegrityDrift: async () => false,
     });
     expect(abortResult.error).toBe(
-      "aborted: npm package integrity drift detected for @openclaw/test@1.0.0",
+      "aborted: npm package integrity drift detected for @remoteclaw/test@1.0.0",
     );
   });
 });

--- a/src/infra/npm-pack-install.test.ts
+++ b/src/infra/npm-pack-install.test.ts
@@ -12,15 +12,15 @@ vi.mock("./install-source-utils.js", async (importOriginal) => {
   return {
     ...actual,
     withTempDir: vi.fn(async (_prefix: string, fn: (tmpDir: string) => Promise<unknown>) => {
-      return await fn("/tmp/openclaw-npm-pack-install-test");
+      return await fn("/tmp/remoteclaw-npm-pack-install-test");
     }),
     packNpmSpecToArchive: vi.fn(),
   };
 });
 
 describe("installFromNpmSpecArchive", () => {
-  const baseSpec = "@openclaw/test@1.0.0";
-  const baseArchivePath = "/tmp/openclaw-test.tgz";
+  const baseSpec = "@remoteclaw/test@1.0.0";
+  const baseArchivePath = "/tmp/remoteclaw-test.tgz";
 
   const mockPackedSuccess = (overrides?: {
     resolvedSpec?: string;
@@ -49,7 +49,7 @@ describe("installFromNpmSpecArchive", () => {
     }) => Promise<{ ok: boolean; [k: string]: unknown }>;
   }) =>
     await installFromNpmSpecArchive({
-      tempDirPrefix: "openclaw-test-",
+      tempDirPrefix: "remoteclaw-test-",
       spec: baseSpec,
       timeoutMs: 1000,
       expectedIntegrity: overrides.expectedIntegrity,
@@ -80,19 +80,19 @@ describe("installFromNpmSpecArchive", () => {
     const installFromArchive = vi.fn(async () => ({ ok: true as const }));
 
     const result = await installFromNpmSpecArchive({
-      tempDirPrefix: "openclaw-test-",
-      spec: "@openclaw/test@1.0.0",
+      tempDirPrefix: "remoteclaw-test-",
+      spec: "@remoteclaw/test@1.0.0",
       timeoutMs: 1000,
       installFromArchive,
     });
 
     expect(result).toEqual({ ok: false, error: "pack failed" });
     expect(installFromArchive).not.toHaveBeenCalled();
-    expect(withTempDir).toHaveBeenCalledWith("openclaw-test-", expect.any(Function));
+    expect(withTempDir).toHaveBeenCalledWith("remoteclaw-test-", expect.any(Function));
   });
 
   it("returns resolution metadata and installer result on success", async () => {
-    mockPackedSuccess({ name: "@openclaw/test", version: "1.0.0" });
+    mockPackedSuccess({ name: "@remoteclaw/test", version: "1.0.0" });
     const installFromArchive = vi.fn(async () => ({ ok: true as const, target: "done" }));
 
     const result = await runInstall({
@@ -102,9 +102,9 @@ describe("installFromNpmSpecArchive", () => {
 
     const okResult = expectWrappedOkResult(result, { ok: true, target: "done" });
     expect(okResult.integrityDrift).toBeUndefined();
-    expect(okResult.npmResolution.resolvedSpec).toBe("@openclaw/test@1.0.0");
+    expect(okResult.npmResolution.resolvedSpec).toBe("@remoteclaw/test@1.0.0");
     expect(okResult.npmResolution.resolvedAt).toBeTruthy();
-    expect(installFromArchive).toHaveBeenCalledWith({ archivePath: "/tmp/openclaw-test.tgz" });
+    expect(installFromArchive).toHaveBeenCalledWith({ archivePath: "/tmp/remoteclaw-test.tgz" });
   });
 
   it("proceeds when integrity drift callback accepts drift", async () => {
@@ -138,7 +138,7 @@ describe("installFromNpmSpecArchive", () => {
 
     expect(result).toEqual({
       ok: false,
-      error: "aborted: npm package integrity drift detected for @openclaw/test@1.0.0",
+      error: "aborted: npm package integrity drift detected for @remoteclaw/test@1.0.0",
     });
     expect(installFromArchive).not.toHaveBeenCalled();
   });
@@ -160,7 +160,7 @@ describe("installFromNpmSpecArchive", () => {
       actualIntegrity: "sha512-new",
     });
     expect(warn).toHaveBeenCalledWith(
-      "Integrity drift detected for @openclaw/test@1.0.0: expected sha512-old, got sha512-new",
+      "Integrity drift detected for @remoteclaw/test@1.0.0: expected sha512-old, got sha512-new",
     );
   });
 
@@ -186,9 +186,9 @@ describe("installFromNpmSpecArchiveWithInstaller", () => {
   it("passes archive path and installer params to installFromArchive", async () => {
     vi.mocked(packNpmSpecToArchive).mockResolvedValue({
       ok: true,
-      archivePath: "/tmp/openclaw-plugin.tgz",
+      archivePath: "/tmp/remoteclaw-plugin.tgz",
       metadata: {
-        resolvedSpec: "@openclaw/voice-call@1.0.0",
+        resolvedSpec: "@remoteclaw/voice-call@1.0.0",
         integrity: "sha512-same",
       },
     });
@@ -198,8 +198,8 @@ describe("installFromNpmSpecArchiveWithInstaller", () => {
     );
 
     const result = await installFromNpmSpecArchiveWithInstaller({
-      tempDirPrefix: "openclaw-test-",
-      spec: "@openclaw/voice-call@1.0.0",
+      tempDirPrefix: "remoteclaw-test-",
+      spec: "@remoteclaw/voice-call@1.0.0",
       timeoutMs: 1000,
       installFromArchive,
       archiveInstallParams: { pluginId: "voice-call" },
@@ -210,7 +210,7 @@ describe("installFromNpmSpecArchiveWithInstaller", () => {
       return;
     }
     expect(installFromArchive).toHaveBeenCalledWith({
-      archivePath: "/tmp/openclaw-plugin.tgz",
+      archivePath: "/tmp/remoteclaw-plugin.tgz",
       pluginId: "voice-call",
     });
     expect(result.installResult).toEqual({ ok: true, pluginId: "voice-call" });
@@ -232,7 +232,7 @@ describe("finalizeNpmSpecArchiveInstall", () => {
       ok: true,
       installResult: { ok: false, error: "install failed" },
       npmResolution: {
-        resolvedSpec: "@openclaw/test@1.0.0",
+        resolvedSpec: "@remoteclaw/test@1.0.0",
         integrity: "sha512-same",
         resolvedAt: "2026-01-01T00:00:00.000Z",
       },
@@ -248,7 +248,7 @@ describe("finalizeNpmSpecArchiveInstall", () => {
       ok: true,
       installResult: { ok: true, pluginId: "voice-call" },
       npmResolution: {
-        resolvedSpec: "@openclaw/voice-call@1.0.0",
+        resolvedSpec: "@remoteclaw/voice-call@1.0.0",
         integrity: "sha512-same",
         resolvedAt: "2026-01-01T00:00:00.000Z",
       },
@@ -262,7 +262,7 @@ describe("finalizeNpmSpecArchiveInstall", () => {
       ok: true,
       pluginId: "voice-call",
       npmResolution: {
-        resolvedSpec: "@openclaw/voice-call@1.0.0",
+        resolvedSpec: "@remoteclaw/voice-call@1.0.0",
         integrity: "sha512-same",
         resolvedAt: "2026-01-01T00:00:00.000Z",
       },

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -42,7 +42,7 @@ describe("delivery-queue", () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-dq-test-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-dq-test-"));
   });
 
   afterEach(() => {

--- a/src/infra/provider-usage.auth.normalizes-keys.test.ts
+++ b/src/infra/provider-usage.auth.normalizes-keys.test.ts
@@ -9,7 +9,7 @@ describe("resolveProviderAuths key normalization", () => {
   let suiteCase = 0;
 
   beforeAll(async () => {
-    suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-provider-auth-suite-"));
+    suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-provider-auth-suite-"));
   });
 
   afterAll(async () => {

--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -18,7 +18,7 @@ const testAuthPrivateKey = generateKeyPairSync("ec", { namedCurve: "prime256v1" 
   .toString();
 
 async function makeTempDir(): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-push-apns-test-"));
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-push-apns-test-"));
   tempDirs.push(dir);
   return dir;
 }

--- a/src/infra/remoteclaw-root.test.ts
+++ b/src/infra/remoteclaw-root.test.ts
@@ -4,7 +4,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 type FakeFsEntry = { kind: "file"; content: string } | { kind: "dir" };
 
-const VITEST_FS_BASE = path.join(path.parse(process.cwd()).root, "__openclaw_vitest__");
+const VITEST_FS_BASE = path.join(path.parse(process.cwd()).root, "__remoteclaw_vitest__");
 const FIXTURE_BASE = path.join(VITEST_FS_BASE, "remoteclaw-root");
 
 const state = vi.hoisted(() => ({
@@ -141,9 +141,9 @@ describe("resolveRemoteClawPackageRoot", () => {
     expect(resolveRemoteClawPackageRootSync({ moduleUrl })).toBe(pkgRoot);
   });
 
-  it("returns null for non-openclaw package roots", async () => {
-    const pkgRoot = fx("not-openclaw");
-    setFile(path.join(pkgRoot, "package.json"), JSON.stringify({ name: "not-openclaw" }));
+  it("returns null for non-remoteclaw package roots", async () => {
+    const pkgRoot = fx("not-remoteclaw");
+    setFile(path.join(pkgRoot, "package.json"), JSON.stringify({ name: "not-remoteclaw" }));
 
     expect(resolveRemoteClawPackageRootSync({ cwd: pkgRoot })).toBeNull();
   });

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -18,7 +18,7 @@ describe("restart sentinel", () => {
 
   beforeEach(async () => {
     envSnapshot = captureEnv(["REMOTECLAW_STATE_DIR"]);
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sentinel-"));
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-sentinel-"));
     process.env.REMOTECLAW_STATE_DIR = tempDir;
   });
 

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 async function withTempDir<T>(run: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-run-node-"));
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-run-node-"));
   try {
     return await run(dir);
   } finally {

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -17,7 +17,7 @@ describe("session cost usage", () => {
     await withEnvAsync({ REMOTECLAW_STATE_DIR: stateDir }, fn);
 
   it("aggregates daily totals with log cost and pricing fallback", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-cost-"));
     const sessionsDir = path.join(root, "agents", "main", "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
     const sessionFile = path.join(sessionsDir, "sess-1.jsonl");
@@ -95,7 +95,7 @@ describe("session cost usage", () => {
   });
 
   it("summarizes a single session file", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-session-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-cost-session-"));
     const sessionFile = path.join(root, "session.jsonl");
     const now = new Date();
 
@@ -128,7 +128,7 @@ describe("session cost usage", () => {
   });
 
   it("captures message counts, tool usage, and model usage", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-session-meta-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-cost-session-meta-"));
     const sessionFile = path.join(root, "session.jsonl");
     const start = new Date("2026-02-01T10:00:00.000Z");
     const end = new Date("2026-02-01T10:05:00.000Z");
@@ -196,7 +196,7 @@ describe("session cost usage", () => {
   });
 
   it("does not exclude sessions with mtime after endMs during discovery", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-discover-"));
     const sessionsDir = path.join(root, "agents", "main", "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
     const sessionFile = path.join(sessionsDir, "sess-late.jsonl");
@@ -216,7 +216,7 @@ describe("session cost usage", () => {
   });
 
   it("resolves non-main absolute sessionFile using explicit agentId for cost summary", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-agent-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-cost-agent-"));
     const workerSessionsDir = path.join(root, "agents", "worker1", "sessions");
     await fs.mkdir(workerSessionsDir, { recursive: true });
     const workerSessionFile = path.join(workerSessionsDir, "sess-worker-1.jsonl");
@@ -258,7 +258,7 @@ describe("session cost usage", () => {
   });
 
   it("resolves non-main absolute sessionFile using explicit agentId for timeseries", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-timeseries-agent-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-timeseries-agent-"));
     const workerSessionsDir = path.join(root, "agents", "worker2", "sessions");
     await fs.mkdir(workerSessionsDir, { recursive: true });
     const workerSessionFile = path.join(workerSessionsDir, "sess-worker-2.jsonl");
@@ -296,7 +296,7 @@ describe("session cost usage", () => {
   });
 
   it("resolves non-main absolute sessionFile using explicit agentId for logs", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-logs-agent-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-logs-agent-"));
     const workerSessionsDir = path.join(root, "agents", "worker3", "sessions");
     await fs.mkdir(workerSessionsDir, { recursive: true });
     const workerSessionFile = path.join(workerSessionsDir, "sess-worker-3.jsonl");
@@ -333,7 +333,7 @@ describe("session cost usage", () => {
   });
 
   it("strips inbound and untrusted metadata blocks from session usage logs", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-logs-sanitize-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-logs-sanitize-"));
     const sessionsDir = path.join(root, "agents", "main", "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
     const sessionFile = path.join(sessionsDir, "sess-sanitize.jsonl");
@@ -375,7 +375,7 @@ example
   });
 
   it("preserves totals and cumulative values when downsampling timeseries", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-timeseries-downsample-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-timeseries-downsample-"));
     const sessionsDir = path.join(root, "agents", "main", "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
     const sessionFile = path.join(sessionsDir, "sess-downsample.jsonl");

--- a/src/infra/state-migrations.state-dir.test.ts
+++ b/src/infra/state-migrations.state-dir.test.ts
@@ -10,7 +10,7 @@ import {
 let tempRoot: string | null = null;
 
 async function makeTempRoot() {
-  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-state-dir-"));
+  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "remoteclaw-state-dir-"));
   tempRoot = root;
   return root;
 }

--- a/src/infra/system-presence.test.ts
+++ b/src/infra/system-presence.test.ts
@@ -12,7 +12,7 @@ describe("system-presence", () => {
     const instanceIdLower = instanceIdUpper.toLowerCase();
 
     upsertPresence(instanceIdUpper, {
-      host: "openclaw",
+      host: "remoteclaw",
       mode: "ui",
       instanceId: instanceIdUpper,
       reason: "connect",
@@ -43,7 +43,7 @@ describe("system-presence", () => {
 
     upsertPresence(deviceId, {
       deviceId,
-      host: "openclaw",
+      host: "remoteclaw",
       roles: ["operator"],
       scopes: ["operator.admin"],
       reason: "connect",

--- a/src/infra/tmp-remoteclaw-dir.test.ts
+++ b/src/infra/tmp-remoteclaw-dir.test.ts
@@ -8,7 +8,7 @@ import {
 type TmpDirOptions = NonNullable<Parameters<typeof resolvePreferredRemoteClawTmpDir>[0]>;
 
 function fallbackTmp(uid = 501) {
-  return path.join("/var/fallback", `openclaw-${uid}`);
+  return path.join("/var/fallback", `remoteclaw-${uid}`);
 }
 
 function resolveWithMocks(params: {
@@ -32,7 +32,7 @@ function resolveWithMocks(params: {
 }
 
 describe("resolvePreferredRemoteClawTmpDir", () => {
-  it("prefers /tmp/openclaw when it already exists and is writable", () => {
+  it("prefers /tmp/remoteclaw when it already exists and is writable", () => {
     const lstatSync: NonNullable<TmpDirOptions["lstatSync"]> = vi.fn(() => ({
       isDirectory: () => true,
       isSymbolicLink: () => false,
@@ -47,7 +47,7 @@ describe("resolvePreferredRemoteClawTmpDir", () => {
     expect(tmpdir).not.toHaveBeenCalled();
   });
 
-  it("prefers /tmp/openclaw when it does not exist but /tmp is writable", () => {
+  it("prefers /tmp/remoteclaw when it does not exist but /tmp is writable", () => {
     const lstatSyncMock = vi.fn<NonNullable<TmpDirOptions["lstatSync"]>>(() => {
       const err = new Error("missing") as Error & { code?: string };
       err.code = "ENOENT";
@@ -77,7 +77,7 @@ describe("resolvePreferredRemoteClawTmpDir", () => {
     expect(tmpdir).not.toHaveBeenCalled();
   });
 
-  it("falls back to os.tmpdir()/openclaw when /tmp/openclaw is not a directory", () => {
+  it("falls back to os.tmpdir()/remoteclaw when /tmp/remoteclaw is not a directory", () => {
     const lstatSync = vi.fn(() => ({
       isDirectory: () => false,
       isSymbolicLink: () => false,
@@ -90,7 +90,7 @@ describe("resolvePreferredRemoteClawTmpDir", () => {
     expect(tmpdir).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to os.tmpdir()/openclaw when /tmp is not writable", () => {
+  it("falls back to os.tmpdir()/remoteclaw when /tmp is not writable", () => {
     const accessSync = vi.fn((target: string) => {
       if (target === "/tmp") {
         throw new Error("read-only");
@@ -110,7 +110,7 @@ describe("resolvePreferredRemoteClawTmpDir", () => {
     expect(tmpdir).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back when /tmp/openclaw is a symlink", () => {
+  it("falls back when /tmp/remoteclaw is a symlink", () => {
     const lstatSync = vi.fn(() => ({
       isDirectory: () => true,
       isSymbolicLink: () => true,
@@ -124,7 +124,7 @@ describe("resolvePreferredRemoteClawTmpDir", () => {
     expect(tmpdir).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back when /tmp/openclaw is not owned by the current user", () => {
+  it("falls back when /tmp/remoteclaw is not owned by the current user", () => {
     const lstatSync = vi.fn(() => ({
       isDirectory: () => true,
       isSymbolicLink: () => false,
@@ -138,7 +138,7 @@ describe("resolvePreferredRemoteClawTmpDir", () => {
     expect(tmpdir).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back when /tmp/openclaw is group/other writable", () => {
+  it("falls back when /tmp/remoteclaw is group/other writable", () => {
     const lstatSync = vi.fn(() => ({
       isDirectory: () => true,
       isSymbolicLink: () => false,

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -56,7 +56,7 @@ describe("update-startup", () => {
   let loaded = false;
 
   beforeAll(async () => {
-    suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-check-suite-"));
+    suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-update-check-suite-"));
   });
 
   beforeEach(async () => {
@@ -107,9 +107,9 @@ describe("update-startup", () => {
   });
 
   function mockPackageUpdateStatus(tag = "latest", version = "2.0.0") {
-    vi.mocked(resolveRemoteClawPackageRoot).mockResolvedValue("/opt/openclaw");
+    vi.mocked(resolveRemoteClawPackageRoot).mockResolvedValue("/opt/remoteclaw");
     vi.mocked(checkUpdateStatus).mockResolvedValue({
-      root: "/opt/openclaw",
+      root: "/opt/remoteclaw",
       installKind: "package",
       packageManager: "npm",
     } satisfies UpdateCheckResult);
@@ -206,9 +206,9 @@ describe("update-startup", () => {
   });
 
   it("emits update change callback when update state clears", async () => {
-    vi.mocked(resolveRemoteClawPackageRoot).mockResolvedValue("/opt/openclaw");
+    vi.mocked(resolveRemoteClawPackageRoot).mockResolvedValue("/opt/remoteclaw");
     vi.mocked(checkUpdateStatus).mockResolvedValue({
-      root: "/opt/openclaw",
+      root: "/opt/remoteclaw",
       installKind: "package",
       packageManager: "npm",
     } satisfies UpdateCheckResult);
@@ -302,7 +302,7 @@ describe("update-startup", () => {
     expect(runAutoUpdate).toHaveBeenCalledWith({
       channel: "stable",
       timeoutMs: 45 * 60 * 1000,
-      root: "/opt/openclaw",
+      root: "/opt/remoteclaw",
     });
   });
 
@@ -330,7 +330,7 @@ describe("update-startup", () => {
     expect(runAutoUpdate).toHaveBeenCalledWith({
       channel: "beta",
       timeoutMs: 45 * 60 * 1000,
-      root: "/opt/openclaw",
+      root: "/opt/remoteclaw",
     });
   });
 
@@ -359,9 +359,9 @@ describe("update-startup", () => {
   });
 
   it("uses current runtime + entrypoint for default auto-update command execution", async () => {
-    vi.mocked(resolveRemoteClawPackageRoot).mockResolvedValue("/opt/openclaw");
+    vi.mocked(resolveRemoteClawPackageRoot).mockResolvedValue("/opt/remoteclaw");
     vi.mocked(checkUpdateStatus).mockResolvedValue({
-      root: "/opt/openclaw",
+      root: "/opt/remoteclaw",
       installKind: "package",
       packageManager: "npm",
     } satisfies UpdateCheckResult);
@@ -379,7 +379,7 @@ describe("update-startup", () => {
     });
 
     const originalArgv = process.argv.slice();
-    process.argv = [process.execPath, "/opt/openclaw/dist/entry.js"];
+    process.argv = [process.execPath, "/opt/remoteclaw/dist/entry.js"];
     try {
       await runGatewayUpdateCheck({
         cfg: {
@@ -402,7 +402,7 @@ describe("update-startup", () => {
     expect(runCommandWithTimeout).toHaveBeenCalledWith(
       [
         process.execPath,
-        "/opt/openclaw/dist/entry.js",
+        "/opt/remoteclaw/dist/entry.js",
         "update",
         "--yes",
         "--channel",

--- a/src/infra/watch-node.test.ts
+++ b/src/infra/watch-node.test.ts
@@ -24,7 +24,7 @@ describe("watch-node script", () => {
 
     const runPromise = runWatchMain({
       args: ["gateway", "--force"],
-      cwd: "/tmp/openclaw",
+      cwd: "/tmp/remoteclaw",
       env: { PATH: "/usr/bin" },
       now: () => 1700000000000,
       process: fakeProcess,
@@ -46,7 +46,7 @@ describe("watch-node script", () => {
         "--force",
       ],
       expect.objectContaining({
-        cwd: "/tmp/openclaw",
+        cwd: "/tmp/remoteclaw",
         stdio: "inherit",
         env: expect.objectContaining({
           PATH: "/usr/bin",

--- a/src/infra/widearea-dns.test.ts
+++ b/src/infra/widearea-dns.test.ts
@@ -4,7 +4,7 @@ import { renderWideAreaGatewayZoneText } from "./widearea-dns.js";
 describe("wide-area DNS-SD zone rendering", () => {
   it("renders a zone with gateway PTR/SRV/TXT records", () => {
     const txt = renderWideAreaGatewayZoneText({
-      domain: "openclaw.internal.",
+      domain: "remoteclaw.internal.",
       serial: 2025121701,
       gatewayPort: 18789,
       displayName: "Mac Studio (RemoteClaw)",
@@ -16,7 +16,7 @@ describe("wide-area DNS-SD zone rendering", () => {
       cliPath: "/opt/homebrew/bin/openclaw",
     });
 
-    expect(txt).toContain(`$ORIGIN openclaw.internal.`);
+    expect(txt).toContain(`$ORIGIN remoteclaw.internal.`);
     expect(txt).toContain(`studio-london IN A 100.123.224.76`);
     expect(txt).toContain(`studio-london IN AAAA fd7a:115c:a1e0::8801:e04c`);
     expect(txt).toContain(`_openclaw-gw._tcp IN PTR studio-london._openclaw-gw._tcp`);
@@ -29,7 +29,7 @@ describe("wide-area DNS-SD zone rendering", () => {
 
   it("includes tailnetDns when provided", () => {
     const txt = renderWideAreaGatewayZoneText({
-      domain: "openclaw.internal.",
+      domain: "remoteclaw.internal.",
       serial: 2025121701,
       gatewayPort: 18789,
       displayName: "Mac Studio (RemoteClaw)",

--- a/src/line/bot-message-context.test.ts
+++ b/src/line/bot-message-context.test.ts
@@ -53,7 +53,7 @@ describe("buildLineMessageContext", () => {
     }) as PostbackEvent;
 
   beforeEach(async () => {
-    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-line-context-"));
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-line-context-"));
     storePath = path.join(tmpDir, "sessions.json");
     cfg = { session: { store: storePath } };
   });

--- a/src/media/image-ops.ts
+++ b/src/media/image-ops.ts
@@ -134,7 +134,7 @@ function readJpegExifOrientation(buffer: Buffer): number | null {
 }
 
 async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-img-"));
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-img-"));
   try {
     return await fn(dir);
   } finally {

--- a/src/media/server.test.ts
+++ b/src/media/server.test.ts
@@ -46,7 +46,7 @@ describe("media server", () => {
   }
 
   beforeAll(async () => {
-    MEDIA_DIR = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-test-"));
+    MEDIA_DIR = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-media-test-"));
     server = await startMediaServer(0, 1_000);
     port = (server.address() as AddressInfo).port;
   });

--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -12,7 +12,7 @@ describe("media store", () => {
   let tempHome: TempHomeEnv;
 
   beforeAll(async () => {
-    tempHome = await createTempHomeEnv("openclaw-test-home-");
+    tempHome = await createTempHomeEnv("remoteclaw-test-home-");
     home = tempHome.home;
     store = await import("./store.js");
   });

--- a/src/middleware/system-prompt.test.ts
+++ b/src/middleware/system-prompt.test.ts
@@ -210,7 +210,7 @@ describe("buildSystemPrompt", () => {
         }),
       );
       expect(result).not.toContain("OpenClaw");
-      expect(result).not.toContain("openclaw");
+      expect(result).not.toContain("remoteclaw");
       expect(result).not.toContain("pi-embedded");
       expect(result).not.toContain("SOUL.md");
     });

--- a/src/pairing/pairing-store.test.ts
+++ b/src/pairing/pairing-store.test.ts
@@ -19,7 +19,7 @@ let fixtureRoot = "";
 let caseId = 0;
 
 beforeAll(async () => {
-  fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pairing-"));
+  fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-pairing-"));
 });
 
 afterAll(async () => {

--- a/src/plugin-sdk/persistent-dedupe.test.ts
+++ b/src/plugin-sdk/persistent-dedupe.test.ts
@@ -7,7 +7,7 @@ import { createPersistentDedupe } from "./persistent-dedupe.js";
 const tmpRoots: string[] = [];
 
 async function makeTmpRoot(): Promise<string> {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dedupe-"));
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-dedupe-"));
   tmpRoots.push(root);
   return root;
 }

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -131,7 +131,7 @@ describe("discoverRemoteClawPlugins", () => {
     fs.writeFileSync(
       path.join(globalExt, "package.json"),
       JSON.stringify({
-        name: "@openclaw/voice-call",
+        name: "@remoteclaw/voice-call",
         openclaw: { extensions: ["./src/index.ts"] },
       }),
       "utf-8",
@@ -158,7 +158,7 @@ describe("discoverRemoteClawPlugins", () => {
     fs.writeFileSync(
       path.join(packDir, "package.json"),
       JSON.stringify({
-        name: "@openclaw/demo-plugin-dir",
+        name: "@remoteclaw/demo-plugin-dir",
         openclaw: { extensions: ["./index.js"] },
       }),
       "utf-8",
@@ -181,7 +181,7 @@ describe("discoverRemoteClawPlugins", () => {
     fs.writeFileSync(
       path.join(globalExt, "package.json"),
       JSON.stringify({
-        name: "@openclaw/escape-pack",
+        name: "@remoteclaw/escape-pack",
         openclaw: { extensions: ["../../outside.js"] },
       }),
       "utf-8",
@@ -215,7 +215,7 @@ describe("discoverRemoteClawPlugins", () => {
     fs.writeFileSync(
       path.join(globalExt, "package.json"),
       JSON.stringify({
-        name: "@openclaw/pack",
+        name: "@remoteclaw/pack",
         openclaw: { extensions: ["./linked/escape.ts"] },
       }),
       "utf-8",

--- a/src/scripts/canvas-a2ui-copy.test.ts
+++ b/src/scripts/canvas-a2ui-copy.test.ts
@@ -6,7 +6,7 @@ import { copyA2uiAssets } from "../../scripts/canvas-a2ui-copy.js";
 
 describe("canvas a2ui copy", () => {
   async function withA2uiFixture(run: (dir: string) => Promise<void>) {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-a2ui-"));
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-a2ui-"));
     try {
       await run(dir);
     } finally {

--- a/src/security/fix.test.ts
+++ b/src/security/fix.test.ts
@@ -66,7 +66,7 @@ describe("security fix", () => {
   };
 
   beforeAll(async () => {
-    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-security-fix-suite-"));
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-security-fix-suite-"));
   });
 
   afterAll(async () => {

--- a/src/shared/avatar-policy.test.ts
+++ b/src/shared/avatar-policy.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe("avatar policy", () => {
   it("accepts workspace-relative avatar paths and rejects URI schemes", () => {
-    expect(isWorkspaceRelativeAvatarPath("avatars/openclaw.png")).toBe(true);
+    expect(isWorkspaceRelativeAvatarPath("avatars/remoteclaw.png")).toBe(true);
     expect(isWorkspaceRelativeAvatarPath("C:\\\\avatars\\\\openclaw.png")).toBe(true);
     expect(isWorkspaceRelativeAvatarPath("https://example.com/avatar.png")).toBe(false);
     expect(isWorkspaceRelativeAvatarPath("data:image/png;base64,AAAA")).toBe(false);
@@ -24,8 +24,8 @@ describe("avatar policy", () => {
   });
 
   it("detects avatar-like path strings", () => {
-    expect(looksLikeAvatarPath("avatars/openclaw.svg")).toBe(true);
-    expect(looksLikeAvatarPath("openclaw.webp")).toBe(true);
+    expect(looksLikeAvatarPath("avatars/remoteclaw.svg")).toBe(true);
+    expect(looksLikeAvatarPath("remoteclaw.webp")).toBe(true);
     expect(looksLikeAvatarPath("A")).toBe(false);
   });
 

--- a/src/signal/monitor.tool-result.test-harness.ts
+++ b/src/signal/monitor.tool-result.test-harness.ts
@@ -92,7 +92,7 @@ vi.mock("../pairing/pairing-store.js", () => ({
 }));
 
 vi.mock("../config/sessions.js", () => ({
-  resolveStorePath: vi.fn(() => "/tmp/openclaw-sessions.json"),
+  resolveStorePath: vi.fn(() => "/tmp/remoteclaw-sessions.json"),
   updateLastRoute: (...args: unknown[]) => updateLastRouteMock(...args),
   readSessionUpdatedAt: vi.fn(() => undefined),
   recordSessionMetaFromInbound: vi.fn().mockResolvedValue(undefined),

--- a/src/slack/monitor.test-helpers.ts
+++ b/src/slack/monitor.test-helpers.ts
@@ -181,7 +181,7 @@ vi.mock("../pairing/pairing-store.js", () => ({
 }));
 
 vi.mock("../config/sessions.js", () => ({
-  resolveStorePath: vi.fn(() => "/tmp/openclaw-sessions.json"),
+  resolveStorePath: vi.fn(() => "/tmp/remoteclaw-sessions.json"),
   updateLastRoute: (...args: unknown[]) => slackTestState.updateLastRouteMock(...args),
   resolveSessionKey: vi.fn(),
   readSessionUpdatedAt: vi.fn(() => undefined),

--- a/src/slack/monitor/events/interactions.test.ts
+++ b/src/slack/monitor/events/interactions.test.ts
@@ -860,13 +860,13 @@ describe("registerSlackInteractionEvents", () => {
               email_block: {
                 email_input: {
                   type: "email_text_input",
-                  value: "team@openclaw.ai",
+                  value: "team@remoteclaw.ai",
                 },
               },
               url_block: {
                 url_input: {
                   type: "url_text_input",
-                  value: "https://docs.openclaw.ai",
+                  value: "https://docs.remoteclaw.ai",
                 },
               },
               richtext_block: {
@@ -957,12 +957,12 @@ describe("registerSlackInteractionEvents", () => {
         expect.objectContaining({
           actionId: "email_input",
           inputKind: "email",
-          inputEmail: "team@openclaw.ai",
+          inputEmail: "team@remoteclaw.ai",
         }),
         expect.objectContaining({
           actionId: "url_input",
           inputKind: "url",
-          inputUrl: "https://docs.openclaw.ai/",
+          inputUrl: "https://docs.remoteclaw.ai/",
         }),
         expect.objectContaining({
           actionId: "richtext_input",

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -28,7 +28,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
   }
 
   beforeAll(() => {
-    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-slack-thread-"));
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-slack-thread-"));
   });
 
   afterAll(() => {

--- a/src/slack/monitor/slash.test-harness.ts
+++ b/src/slack/monitor/slash.test-harness.ts
@@ -72,5 +72,5 @@ export function resetSlackSlashMocks() {
   mocks.resolveConversationLabelMock.mockReset().mockReturnValue(undefined);
   mocks.createReplyPrefixOptionsMock.mockReset().mockReturnValue({ onModelSelected: () => {} });
   mocks.recordSessionMetaFromInboundMock.mockReset().mockResolvedValue(undefined);
-  mocks.resolveStorePathMock.mockReset().mockReturnValue("/tmp/openclaw-sessions.json");
+  mocks.resolveStorePathMock.mockReset().mockReturnValue("/tmp/remoteclaw-sessions.json");
 }

--- a/src/telegram/bot-native-commands.session-meta.test.ts
+++ b/src/telegram/bot-native-commands.session-meta.test.ts
@@ -86,7 +86,7 @@ function registerAndResolveStatusHandler(cfg: RemoteClawConfig): TelegramCommand
 describe("registerTelegramNativeCommands — session metadata", () => {
   beforeEach(() => {
     sessionMocks.recordSessionMetaFromInbound.mockClear().mockResolvedValue(undefined);
-    sessionMocks.resolveStorePath.mockClear().mockReturnValue("/tmp/openclaw-sessions.json");
+    sessionMocks.resolveStorePath.mockClear().mockReturnValue("/tmp/remoteclaw-sessions.json");
     replyMocks.dispatchReplyWithBufferedBlockDispatcher.mockClear().mockResolvedValue(undefined);
   });
 

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -1726,7 +1726,7 @@ describe("createTelegramBot", () => {
     }
   });
   it("honors routed group activation from session store", async () => {
-    const storeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-telegram-"));
+    const storeDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-telegram-"));
     const storePath = path.join(storeDir, "sessions.json");
     fs.writeFileSync(
       storePath,

--- a/src/telegram/sticker-cache.test.ts
+++ b/src/telegram/sticker-cache.test.ts
@@ -14,11 +14,11 @@ vi.mock("../config/paths.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/paths.js")>();
   return {
     ...actual,
-    STATE_DIR: "/tmp/openclaw-test-sticker-cache",
+    STATE_DIR: "/tmp/remoteclaw-test-sticker-cache",
   };
 });
 
-const TEST_CACHE_DIR = "/tmp/openclaw-test-sticker-cache/telegram";
+const TEST_CACHE_DIR = "/tmp/remoteclaw-test-sticker-cache/telegram";
 const TEST_CACHE_FILE = path.join(TEST_CACHE_DIR, "sticker-cache.json");
 
 describe("sticker-cache", () => {

--- a/src/telegram/token.test.ts
+++ b/src/telegram/token.test.ts
@@ -8,7 +8,7 @@ import { resolveTelegramToken } from "./token.js";
 import { readTelegramUpdateOffset, writeTelegramUpdateOffset } from "./update-offset-store.js";
 
 function withTempDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-telegram-token-"));
+  return fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-telegram-token-"));
 }
 
 describe("resolveTelegramToken", () => {

--- a/src/test-helpers/state-dir-env.test.ts
+++ b/src/test-helpers/state-dir-env.test.ts
@@ -44,8 +44,8 @@ describe("state-dir-env helpers", () => {
     const prev = snapshotCurrentStateDirVars();
     const snapshot = snapshotStateDirEnv();
 
-    setStateDirEnv("/tmp/openclaw-state-dir-test");
-    expect(process.env.REMOTECLAW_STATE_DIR).toBe("/tmp/openclaw-state-dir-test");
+    setStateDirEnv("/tmp/remoteclaw-state-dir-test");
+    expect(process.env.REMOTECLAW_STATE_DIR).toBe("/tmp/remoteclaw-state-dir-test");
     expect(process.env.CLAWDBOT_STATE_DIR).toBeUndefined();
 
     restoreStateDirEnv(snapshot);

--- a/src/test-utils/temp-home.test.ts
+++ b/src/test-utils/temp-home.test.ts
@@ -9,7 +9,7 @@ describe("createTempHomeEnv", () => {
     const previousUserProfile = process.env.USERPROFILE;
     const previousStateDir = process.env.REMOTECLAW_STATE_DIR;
 
-    const tempHome = await createTempHomeEnv("openclaw-temp-home-");
+    const tempHome = await createTempHomeEnv("remoteclaw-temp-home-");
     expect(process.env.HOME).toBe(tempHome.home);
     expect(process.env.USERPROFILE).toBe(tempHome.home);
     expect(process.env.REMOTECLAW_STATE_DIR).toBe(path.join(tempHome.home, ".remoteclaw"));

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -51,7 +51,7 @@ describe("withWhatsAppPrefix", () => {
 
 describe("ensureDir", () => {
   it("creates nested directory", async () => {
-    await withTempDirSync("openclaw-test-", async (tmp) => {
+    await withTempDirSync("remoteclaw-test-", async (tmp) => {
       const target = path.join(tmp, "nested", "dir");
       await ensureDir(target);
       expect(fs.existsSync(target)).toBe(true);
@@ -107,7 +107,7 @@ describe("jidToE164", () => {
   });
 
   it("maps @lid from authDir mapping files", () => {
-    withTempDirSync("openclaw-auth-", (authDir) => {
+    withTempDirSync("remoteclaw-auth-", (authDir) => {
       const mappingPath = path.join(authDir, "lid-mapping-456_reverse.json");
       fs.writeFileSync(mappingPath, JSON.stringify("5559876"));
       expect(jidToE164("456@lid", { authDir })).toBe("+5559876");
@@ -115,7 +115,7 @@ describe("jidToE164", () => {
   });
 
   it("maps @hosted.lid from authDir mapping files", () => {
-    withTempDirSync("openclaw-auth-", (authDir) => {
+    withTempDirSync("remoteclaw-auth-", (authDir) => {
       const mappingPath = path.join(authDir, "lid-mapping-789_reverse.json");
       fs.writeFileSync(mappingPath, JSON.stringify(4440001));
       expect(jidToE164("789@hosted.lid", { authDir })).toBe("+4440001");
@@ -127,8 +127,8 @@ describe("jidToE164", () => {
   });
 
   it("falls back through lidMappingDirs in order", () => {
-    withTempDirSync("openclaw-lid-a-", (first) => {
-      withTempDirSync("openclaw-lid-b-", (second) => {
+    withTempDirSync("remoteclaw-lid-a-", (first) => {
+      withTempDirSync("remoteclaw-lid-b-", (second) => {
         const mappingPath = path.join(second, "lid-mapping-321_reverse.json");
         fs.writeFileSync(mappingPath, JSON.stringify("123321"));
         expect(jidToE164("321@lid", { lidMappingDirs: [first, second] })).toBe("+123321");
@@ -153,10 +153,10 @@ describe("resolveConfigDir", () => {
 
 describe("resolveHomeDir", () => {
   it("prefers REMOTECLAW_HOME over HOME", () => {
-    vi.stubEnv("REMOTECLAW_HOME", "/srv/openclaw-home");
+    vi.stubEnv("REMOTECLAW_HOME", "/srv/remoteclaw-home");
     vi.stubEnv("HOME", "/home/other");
 
-    expect(resolveHomeDir()).toBe(path.resolve("/srv/openclaw-home"));
+    expect(resolveHomeDir()).toBe(path.resolve("/srv/remoteclaw-home"));
 
     vi.unstubAllEnvs();
   });
@@ -164,11 +164,11 @@ describe("resolveHomeDir", () => {
 
 describe("shortenHomePath", () => {
   it("uses $REMOTECLAW_HOME prefix when REMOTECLAW_HOME is set", () => {
-    vi.stubEnv("REMOTECLAW_HOME", "/srv/openclaw-home");
+    vi.stubEnv("REMOTECLAW_HOME", "/srv/remoteclaw-home");
     vi.stubEnv("HOME", "/home/other");
 
     expect(
-      shortenHomePath(`${path.resolve("/srv/openclaw-home")}/.remoteclaw/remoteclaw.json`),
+      shortenHomePath(`${path.resolve("/srv/remoteclaw-home")}/.remoteclaw/remoteclaw.json`),
     ).toBe("$REMOTECLAW_HOME/.remoteclaw/remoteclaw.json");
 
     vi.unstubAllEnvs();
@@ -177,12 +177,12 @@ describe("shortenHomePath", () => {
 
 describe("shortenHomeInString", () => {
   it("uses $REMOTECLAW_HOME replacement when REMOTECLAW_HOME is set", () => {
-    vi.stubEnv("REMOTECLAW_HOME", "/srv/openclaw-home");
+    vi.stubEnv("REMOTECLAW_HOME", "/srv/remoteclaw-home");
     vi.stubEnv("HOME", "/home/other");
 
     expect(
       shortenHomeInString(
-        `config: ${path.resolve("/srv/openclaw-home")}/.remoteclaw/remoteclaw.json`,
+        `config: ${path.resolve("/srv/remoteclaw-home")}/.remoteclaw/remoteclaw.json`,
       ),
     ).toBe("config: $REMOTECLAW_HOME/.remoteclaw/remoteclaw.json");
 
@@ -222,7 +222,7 @@ describe("resolveUserPath", () => {
   });
 
   it("expands ~/ to home dir", () => {
-    expect(resolveUserPath("~/openclaw")).toBe(path.resolve(os.homedir(), "openclaw"));
+    expect(resolveUserPath("~/remoteclaw")).toBe(path.resolve(os.homedir(), "remoteclaw"));
   });
 
   it("resolves relative paths", () => {
@@ -230,10 +230,12 @@ describe("resolveUserPath", () => {
   });
 
   it("prefers REMOTECLAW_HOME for tilde expansion", () => {
-    vi.stubEnv("REMOTECLAW_HOME", "/srv/openclaw-home");
+    vi.stubEnv("REMOTECLAW_HOME", "/srv/remoteclaw-home");
     vi.stubEnv("HOME", "/home/other");
 
-    expect(resolveUserPath("~/openclaw")).toBe(path.resolve("/srv/openclaw-home", "openclaw"));
+    expect(resolveUserPath("~/remoteclaw")).toBe(
+      path.resolve("/srv/remoteclaw-home", "remoteclaw"),
+    );
 
     vi.unstubAllEnvs();
   });

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -11,7 +11,7 @@ import {
 } from "./version.js";
 
 async function withTempDir<T>(run: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-version-"));
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-version-"));
   try {
     return await run(dir);
   } finally {

--- a/src/web/accounts.whatsapp-auth.test.ts
+++ b/src/web/accounts.whatsapp-auth.test.ts
@@ -16,7 +16,7 @@ describe("hasAnyWhatsAppAuth", () => {
 
   beforeEach(() => {
     envSnapshot = captureEnv(["REMOTECLAW_OAUTH_DIR"]);
-    tempOauthDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-oauth-"));
+    tempOauthDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-oauth-"));
     process.env.REMOTECLAW_OAUTH_DIR = tempOauthDir;
   });
 
@@ -43,7 +43,7 @@ describe("hasAnyWhatsAppAuth", () => {
   });
 
   it("includes authDir overrides", () => {
-    const customDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wa-auth-"));
+    const customDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-wa-auth-"));
     try {
       writeCreds(customDir);
       const cfg = {

--- a/src/web/auto-reply.test-harness.ts
+++ b/src/web/auto-reply.test-harness.ts
@@ -75,7 +75,7 @@ let tempHomeId = 0;
 
 export function installWebAutoReplyTestHomeHooks() {
   beforeAll(async () => {
-    tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-web-home-suite-"));
+    tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-web-home-suite-"));
   });
 
   beforeEach(async () => {
@@ -103,7 +103,7 @@ export function installWebAutoReplyTestHomeHooks() {
 export async function makeSessionStore(
   entries: Record<string, unknown> = {},
 ): Promise<{ storePath: string; cleanup: () => Promise<void> }> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-"));
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-session-"));
   const storePath = path.join(dir, "sessions.json");
   await fs.writeFile(storePath, JSON.stringify(entries));
   const cleanup = async () => {

--- a/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
+++ b/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
@@ -93,7 +93,7 @@ describe("web processMessage inbound contract", () => {
     capturedDispatchParams = undefined;
     backgroundTasks = new Set();
     deliverWebReplyMock.mockClear();
-    sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-process-message-"));
+    sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-process-message-"));
     sessionStorePath = path.join(sessionDir, "sessions.json");
   });
 

--- a/src/web/auto-reply/web-auto-reply-monitor.test.ts
+++ b/src/web/auto-reply/web-auto-reply-monitor.test.ts
@@ -11,7 +11,7 @@ let sessionDir: string | undefined;
 let sessionStorePath: string;
 
 beforeEach(async () => {
-  sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-group-gating-"));
+  sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-group-gating-"));
   sessionStorePath = path.join(sessionDir, "sessions.json");
   await fs.writeFile(sessionStorePath, "{}");
 });

--- a/src/web/auto-reply/web-auto-reply-utils.test.ts
+++ b/src/web/auto-reply/web-auto-reply-utils.test.ts
@@ -100,7 +100,7 @@ describe("isBotMentionedFromTargets", () => {
 
 describe("resolveMentionTargets with @lid mapping", () => {
   it("uses @lid reverse mapping for mentions and self identity", async () => {
-    await withTempDir("openclaw-lid-mapping-", async (authDir) => {
+    await withTempDir("remoteclaw-lid-mapping-", async (authDir) => {
       await fs.writeFile(
         path.join(authDir, "lid-mapping-777_reverse.json"),
         JSON.stringify("+1777"),
@@ -134,7 +134,7 @@ describe("getSessionSnapshot", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
     try {
-      await withTempDir("openclaw-snapshot-", async (root) => {
+      await withTempDir("remoteclaw-snapshot-", async (root) => {
         const storePath = path.join(root, "sessions.json");
         const sessionKey = "agent:main:whatsapp:dm:s1";
 

--- a/src/web/login.test.ts
+++ b/src/web/login.test.ts
@@ -55,7 +55,7 @@ describe("web login", () => {
 
 describe("renderQrPngBase64", () => {
   it("renders a PNG data payload", async () => {
-    const b64 = await renderQrPngBase64("openclaw");
+    const b64 = await renderQrPngBase64("remoteclaw");
     const buf = Buffer.from(b64, "base64");
     expect(buf.subarray(0, 8).toString("hex")).toBe("89504e470d0a1a0a");
   });

--- a/src/web/logout.test.ts
+++ b/src/web/logout.test.ts
@@ -17,7 +17,7 @@ describe("web logout", () => {
   let logoutWeb: typeof import("./auth-store.js").logoutWeb;
 
   beforeAll(async () => {
-    fixtureRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-test-web-logout-"));
+    fixtureRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), "remoteclaw-test-web-logout-"));
     ({ logoutWeb } = await import("./auth-store.js"));
   });
 

--- a/src/web/monitor-inbox.test-harness.ts
+++ b/src/web/monitor-inbox.test-harness.ts
@@ -123,7 +123,7 @@ export function installWebMonitorInboxUnitTestHooks(opts?: { authDir?: boolean }
     const { resetWebInboundDedupe } = await import("./inbound.js");
     resetWebInboundDedupe();
     if (createAuthDir) {
-      authDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+      authDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-auth-"));
     } else {
       authDir = undefined;
     }

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -215,8 +215,8 @@ export async function finalizeOnboardingWizard(
       await prompter.note(
         [
           "Docs:",
-          "https://docs.openclaw.ai/gateway/health",
-          "https://docs.openclaw.ai/gateway/troubleshooting",
+          "https://docs.remoteclaw.ai/gateway/health",
+          "https://docs.remoteclaw.ai/gateway/troubleshooting",
         ].join("\n"),
         "Health check help",
       );
@@ -279,7 +279,7 @@ export async function finalizeOnboardingWizard(
         : undefined,
       `Gateway WS: ${links.wsUrl}`,
       gatewayStatusLine,
-      "Docs: https://docs.openclaw.ai/web/control-ui",
+      "Docs: https://docs.remoteclaw.ai/web/control-ui",
     ]
       .filter(Boolean)
       .join("\n"),
@@ -382,13 +382,13 @@ export async function finalizeOnboardingWizard(
   await prompter.note(
     [
       "Back up your agent workspace.",
-      "Docs: https://docs.openclaw.ai/concepts/agent-workspace",
+      "Docs: https://docs.remoteclaw.ai/concepts/agent-workspace",
     ].join("\n"),
     "Workspace backup",
   );
 
   await prompter.note(
-    "Running agents on your computer is risky — harden your setup: https://docs.openclaw.ai/security",
+    "Running agents on your computer is risky — harden your setup: https://docs.remoteclaw.ai/security",
     "Security",
   );
 
@@ -433,7 +433,7 @@ export async function finalizeOnboardingWizard(
   }
 
   await prompter.note(
-    'What now: https://openclaw.ai/showcase ("What People Are Building").',
+    'What now: https://remoteclaw.ai/showcase ("What People Are Building").',
     "What now",
   );
 

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -98,7 +98,7 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("../commands/onboard-helpers.js", () => ({
-  DEFAULT_WORKSPACE: "/tmp/openclaw-workspace",
+  DEFAULT_WORKSPACE: "/tmp/remoteclaw-workspace",
   applyWizardMetadata: (cfg: unknown) => cfg,
   summarizeExistingConfig: () => "summary",
   handleReset: async () => {},
@@ -181,7 +181,7 @@ describe("runOnboardingWizard", () => {
   let suiteCase = 0;
 
   beforeAll(async () => {
-    suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-onboard-suite-"));
+    suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-onboard-suite-"));
   });
 
   afterAll(async () => {

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -256,7 +256,7 @@ async function requireRiskAcknowledgement(params: {
       "remoteclaw security audit --deep",
       "remoteclaw security audit --fix",
       "",
-      "Must read: https://docs.openclaw.ai/gateway/security",
+      "Must read: https://docs.remoteclaw.ai/gateway/security",
     ].join("\n"),
     "Security",
   );
@@ -287,7 +287,7 @@ export async function runOnboardingWizard(
     if (!preCheck.exists) {
       await prompter.note(
         [
-          `Existing OpenClaw installation found at ${shortenHomePath(openclawDir)}.`,
+          `Existing RemoteClaw installation found at ${shortenHomePath(openclawDir)}.`,
           "",
           "RemoteClaw can import your config, sessions, and channel settings.",
         ].join("\n"),
@@ -314,7 +314,7 @@ export async function runOnboardingWizard(
         [
           ...snapshot.issues.map((iss) => `- ${iss.path}: ${iss.message}`),
           "",
-          "Docs: https://docs.openclaw.ai/gateway/configuration",
+          "Docs: https://docs.remoteclaw.ai/gateway/configuration",
         ].join("\n"),
         "Config issues",
       );

--- a/test/fixtures/exec-allowlist-shell-parser-parity.json
+++ b/test/fixtures/exec-allowlist-shell-parser-parity.json
@@ -8,7 +8,7 @@
     },
     {
       "id": "chained-commands",
-      "command": "ls && rm -rf /tmp/openclaw-allowlist",
+      "command": "ls && rm -rf /tmp/remoteclaw-allowlist",
       "ok": true,
       "executables": ["ls", "rm"]
     },

--- a/test/git-hooks-pre-commit.test.ts
+++ b/test/git-hooks-pre-commit.test.ts
@@ -11,7 +11,7 @@ const run = (cwd: string, cmd: string, args: string[] = []) => {
 
 describe("git-hooks/pre-commit (integration)", () => {
   it("does not treat staged filenames as git-add flags (e.g. --all)", async () => {
-    const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-pre-commit-"));
+    const dir = await mkdtemp(path.join(os.tmpdir(), "remoteclaw-pre-commit-"));
     run(dir, "git", ["init", "-q"]);
 
     // Copy the hook + helpers so the test exercises real on-disk wiring.

--- a/test/helpers/gateway-e2e-harness.ts
+++ b/test/helpers/gateway-e2e-harness.ts
@@ -102,7 +102,7 @@ export async function spawnGatewayInstance(name: string): Promise<GatewayInstanc
   const port = await getFreePort();
   const hookToken = `token-${name}-${randomUUID()}`;
   const gatewayToken = `gateway-${name}-${randomUUID()}`;
-  const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), `openclaw-e2e-${name}-`));
+  const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), `remoteclaw-e2e-${name}-`));
   const configDir = path.join(homeDir, ".remoteclaw");
   await fs.mkdir(configDir, { recursive: true });
   const configPath = path.join(configDir, "remoteclaw.json");

--- a/test/helpers/temp-home.ts
+++ b/test/helpers/temp-home.ts
@@ -80,7 +80,7 @@ export async function withTempHome<T>(
   fn: (home: string) => Promise<T>,
   opts: { env?: Record<string, EnvValue>; prefix?: string } = {},
 ): Promise<T> {
-  const base = await fs.mkdtemp(path.join(os.tmpdir(), opts.prefix ?? "openclaw-test-home-"));
+  const base = await fs.mkdtemp(path.join(os.tmpdir(), opts.prefix ?? "remoteclaw-test-home-"));
   const snapshot = snapshotEnv();
   const envKeys = Object.keys(opts.env ?? {});
   for (const key of envKeys) {

--- a/test/scripts/check-no-raw-window-open.test.ts
+++ b/test/scripts/check-no-raw-window-open.test.ts
@@ -5,7 +5,7 @@ describe("check-no-raw-window-open", () => {
   it("finds direct window.open calls", () => {
     const source = `
       function openDocs() {
-        window.open("https://docs.openclaw.ai");
+        window.open("https://docs.remoteclaw.ai");
       }
     `;
     expect(findRawWindowOpenLines(source)).toEqual([3]);
@@ -14,7 +14,7 @@ describe("check-no-raw-window-open", () => {
   it("finds globalThis.open calls", () => {
     const source = `
       function openDocs() {
-        globalThis.open("https://docs.openclaw.ai");
+        globalThis.open("https://docs.remoteclaw.ai");
       }
     `;
     expect(findRawWindowOpenLines(source)).toEqual([3]);

--- a/test/scripts/ios-team-id.test.ts
+++ b/test/scripts/ios-team-id.test.ts
@@ -47,7 +47,7 @@ function runScript(
 
 describe("scripts/ios-team-id.sh", () => {
   it("falls back to Xcode-managed provisioning profiles when preference teams are empty", async () => {
-    const homeDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-ios-team-id-"));
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "remoteclaw-ios-team-id-"));
     const binDir = path.join(homeDir, "bin");
     await mkdir(binDir, { recursive: true });
     await mkdir(path.join(homeDir, "Library", "Preferences"), { recursive: true });
@@ -101,7 +101,7 @@ exit 0`,
   });
 
   it("prints actionable guidance when Xcode account exists but no Team ID is resolvable", async () => {
-    const homeDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-ios-team-id-"));
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "remoteclaw-ios-team-id-"));
     const binDir = path.join(homeDir, "bin");
     await mkdir(binDir, { recursive: true });
     await mkdir(path.join(homeDir, "Library", "Preferences"), { recursive: true });
@@ -135,7 +135,7 @@ exit 1`,
   });
 
   it("honors IOS_PREFERRED_TEAM_ID when multiple profile teams are available", async () => {
-    const homeDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-ios-team-id-"));
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "remoteclaw-ios-team-id-"));
     const binDir = path.join(homeDir, "bin");
     await mkdir(binDir, { recursive: true });
     await mkdir(path.join(homeDir, "Library", "Preferences"), { recursive: true });
@@ -194,7 +194,7 @@ exit 0`,
   });
 
   it("matches preferred team IDs even when parser output uses CRLF line endings", async () => {
-    const homeDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-ios-team-id-"));
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "remoteclaw-ios-team-id-"));
     const binDir = path.join(homeDir, "bin");
     await mkdir(binDir, { recursive: true });
     await mkdir(path.join(homeDir, "Library", "Preferences"), { recursive: true });

--- a/test/scripts/ui.test.ts
+++ b/test/scripts/ui.test.ts
@@ -16,7 +16,7 @@ describe("scripts/ui windows spawn behavior", () => {
 
   it("allows safe forwarded args when shell mode is required on Windows", () => {
     expect(() =>
-      assertSafeWindowsShellArgs(["run", "build", "--filter", "@openclaw/ui"], "win32"),
+      assertSafeWindowsShellArgs(["run", "build", "--filter", "@remoteclaw/ui"], "win32"),
     ).not.toThrow();
   });
 

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -91,7 +91,7 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
     { key: "NODE_OPTIONS", value: process.env.NODE_OPTIONS },
   ];
 
-  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-test-home-"));
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-test-home-"));
 
   process.env.HOME = tempHome;
   process.env.USERPROFILE = tempHome;


### PR DESCRIPTION
## Summary

- Update mkdtemp prefixes in tests and production code (`openclaw-` → `remoteclaw-`)
- Update docs URL display labels (`docs.openclaw.ai` → `docs.remoteclaw.ai`)
- Update website URLs (`openclaw.ai` → `remoteclaw.ai`)
- Update test fixture data (env vars, paths, domain names) across 259 files

Production runtime values that still use `openclaw` (CLI binary name, hook source enums, DNS labels, HTTP headers) are intentionally preserved — they match the current production code and will be updated in a separate rebrand pass.

Closes #216

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (3 pre-existing failures in `workspace.test.ts` due to missing `BOOTSTRAP.md` template — unrelated to this PR)
- [x] `pnpm lint` clean
- [x] `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)