### PR TITLE
rebrand: clean up redundant regex alternations from #231

### DIFF
--- a/src/commands/channels.adds-non-default-telegram-account.test.ts
+++ b/src/commands/channels.adds-non-default-telegram-account.test.ts
@@ -330,7 +330,7 @@ describe("channels command", () => {
     });
     expect(lines.join("\n")).toMatch(/Warnings:/);
     expect(lines.join("\n")).toMatch(/Message Content Intent is disabled/i);
-    expect(lines.join("\n")).toMatch(/Run: (?:remoteclaw|remoteclaw)( --profile isolated)? doctor/);
+    expect(lines.join("\n")).toMatch(/Run: remoteclaw( --profile isolated)? doctor/);
   });
 
   it("surfaces Discord permission audit issues in channels status output", () => {

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -238,7 +238,7 @@ describe("gatewayInstallErrorHint", () => {
   it("returns platform-specific hints", () => {
     expect(gatewayInstallErrorHint("win32")).toContain("Run as administrator");
     expect(gatewayInstallErrorHint("linux")).toMatch(
-      /(?:remoteclaw|remoteclaw)( --profile isolated)? gateway install/,
+      /remoteclaw( --profile isolated)? gateway install/,
     );
   });
 });

--- a/src/pairing/pairing-messages.test.ts
+++ b/src/pairing/pairing-messages.test.ts
@@ -54,7 +54,7 @@ describe("buildPairingReply", () => {
       expect(text).toContain(`Pairing code: ${testCase.code}`);
       // CLI commands should respect REMOTECLAW_PROFILE when set (most tests run with isolated profile)
       const commandRe = new RegExp(
-        `(?:remoteclaw|remoteclaw) --profile isolated pairing approve ${testCase.channel} ${testCase.code}`,
+        `remoteclaw --profile isolated pairing approve ${testCase.channel} ${testCase.code}`,
       );
       expect(text).toMatch(commandRe);
     });


### PR DESCRIPTION
## Summary

Follow-up to #231. The bulk `openclaw→remoteclaw` replacement turned `(?:openclaw|remoteclaw)` alternations into `(?:remoteclaw|remoteclaw)`. Simplifies to plain strings.

3 files, 3 lines changed.

## Test plan

- [x] Trivial change — removes redundant regex alternatives, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)