### PR TITLE
fix: suppress lint errors from empty legacy-names arrays

### DIFF
--- a/src/hooks/install.ts
+++ b/src/hooks/install.ts
@@ -33,6 +33,7 @@ type HookPackageManifest = {
   version?: string;
   dependencies?: Record<string, string>;
 } & Partial<
+  // oxlint-disable-next-line typescript-eslint/no-redundant-type-constituents -- legacy keys empty during rebrand
   Record<typeof MANIFEST_KEY | (typeof LEGACY_MANIFEST_KEYS)[number], { hooks?: string[] }>
 >;
 

--- a/src/hooks/workspace.ts
+++ b/src/hooks/workspace.ts
@@ -24,6 +24,7 @@ import type {
 type HookPackageManifest = {
   name?: string;
 } & Partial<
+  // oxlint-disable-next-line typescript-eslint/no-redundant-type-constituents -- legacy keys empty during rebrand
   Record<typeof MANIFEST_KEY | (typeof LEGACY_MANIFEST_KEYS)[number], { hooks?: string[] }>
 >;
 const log = createSubsystemLogger("hooks/workspace");

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -37,7 +37,7 @@ type PackageManifest = {
   name?: string;
   version?: string;
   dependencies?: Record<string, string>;
-} & Partial<Record<typeof MANIFEST_KEY | (typeof LEGACY_MANIFEST_KEYS)[number], ManifestMeta>>;
+} & Partial<Record<typeof MANIFEST_KEY | (typeof LEGACY_MANIFEST_KEYS)[number], ManifestMeta>>; // oxlint-disable-line typescript-eslint/no-redundant-type-constituents -- legacy keys empty during rebrand
 
 export type InstallPluginResult =
   | {

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -147,7 +147,7 @@ export type PackageManifest = {
   name?: string;
   version?: string;
   description?: string;
-} & Partial<Record<ManifestKey | LegacyManifestKey, RemoteClawPackageManifest>>;
+} & Partial<Record<ManifestKey | LegacyManifestKey, RemoteClawPackageManifest>>; // oxlint-disable-line typescript-eslint/no-redundant-type-constituents -- legacy keys empty during rebrand
 
 export function getPackageManifestMetadata(
   manifest: PackageManifest | undefined,


### PR DESCRIPTION
## Summary
- Adds targeted `oxlint-disable-line` / `oxlint-disable-next-line` suppressions for `no-redundant-type-constituents` at 4 type definition sites
- The empty `LEGACY_MANIFEST_KEYS` (`readonly string[]`) makes the union `ManifestKey | LegacyManifestKey` redundant (`"remoteclaw" | string` = `string`), triggering the lint rule
- Suppressions keep code structure identical to upstream — when legacy names are re-populated, just remove the comments

## Context
CI on main broke in #233 (empty legacy-names arrays). Alternative approaches (`as const` narrowing, removing legacy union members, type-level workarounds) all require more consumer-file changes and diverge further from upstream.

## Test plan
- [x] `pnpm check` passes (format + typecheck + lint)
- [x] 4 pre-existing test failures in `workspace.test.ts` and `server.test.ts` are unrelated (missing template file + HTML fixture mismatch from prior rebrand commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)