### PR TITLE
docs: architecture, AgentRuntime, and ChannelBridge (#201)

### DIFF
--- a/docs/concepts/agent-runtimes.md
+++ b/docs/concepts/agent-runtimes.md
@@ -1,0 +1,221 @@
+# Agent Runtimes
+
+RemoteClaw runs CLI agents as subprocesses. Each agent has a **runtime** that
+handles subprocess lifecycle, parses the CLI's native output format, and
+translates events into a unified stream.
+
+## The AgentRuntime Interface
+
+Every runtime implements a single method:
+
+```typescript
+interface AgentRuntime {
+  execute(params: AgentExecuteParams): AsyncIterable<AgentEvent>;
+}
+```
+
+`execute()` spawns the CLI process and returns an async iterable of events.
+Callers consume events as they arrive — there is no buffering of the full
+response.
+
+### Execute Parameters
+
+| Parameter          | Type                               | Purpose                                    |
+| ------------------ | ---------------------------------- | ------------------------------------------ |
+| `prompt`           | `string`                           | Full prompt text (system + user message)   |
+| `sessionId`        | `string?`                          | CLI session ID for conversation resumption |
+| `mcpServers`       | `Record<string, McpServerConfig>?` | MCP tool servers to expose                 |
+| `abortSignal`      | `AbortSignal?`                     | Cancellation support                       |
+| `workingDirectory` | `string?`                          | Subprocess working directory               |
+| `env`              | `Record<string, string>?`          | Extra environment variables                |
+
+### The Event Stream
+
+Events form a discriminated union. Every execution ends with exactly one
+`done` event:
+
+| Event         | Key Fields                     | Purpose                             |
+| ------------- | ------------------------------ | ----------------------------------- |
+| `text`        | `text`                         | Streaming text delta from the agent |
+| `tool_use`    | `toolName`, `toolId`, `input`  | Agent invoked an MCP tool           |
+| `tool_result` | `toolId`, `output`, `isError?` | Tool returned a result              |
+| `error`       | `message`, `code?`             | Runtime or subprocess error         |
+| `done`        | `result: AgentRunResult`       | Terminal event with run summary     |
+
+The `done` event carries an `AgentRunResult` with accumulated text, the
+session ID for the next invocation, duration, token usage, cost, and stop
+reason.
+
+## CLIRuntimeBase — Subprocess Machinery
+
+All four runtimes extend `CLIRuntimeBase`, which handles subprocess lifecycle
+through a template method pattern. Subclasses implement three methods:
+
+| Method               | Purpose                                    |
+| -------------------- | ------------------------------------------ |
+| `buildArgs(params)`  | Construct CLI command-line arguments       |
+| `buildEnv(params)`   | Construct environment variables            |
+| `extractEvent(line)` | Parse one NDJSON line into an `AgentEvent` |
+
+Two properties control I/O behavior:
+
+| Property              | Default    | Purpose                                         |
+| --------------------- | ---------- | ----------------------------------------------- |
+| `supportsStdinPrompt` | `true`     | Whether to deliver large prompts via stdin      |
+| `ndjsonStream`        | `"stdout"` | Which file descriptor carries structured events |
+
+### Subprocess Lifecycle
+
+When `execute()` is called:
+
+1. **Spawn**: The CLI process starts with full stdio pipes (stdin, stdout,
+   stderr).
+
+2. **Stream selection**: The `ndjsonStream` property determines which file
+   descriptor carries NDJSON events. The other stream is captured as
+   diagnostic output.
+
+3. **NDJSON parsing**: Lines from the selected stream are parsed as JSON.
+   Valid JSON lines are passed to `extractEvent()`, which returns an
+   `AgentEvent` or `null` (to skip the line).
+
+4. **Stdin prompt delivery**: If `supportsStdinPrompt` is true and the prompt
+   exceeds 10 KB, it is written to stdin. `stdin.end()` is always called so
+   CLIs that block on stdin receive EOF.
+
+5. **Event yielding**: Events are pushed into a queue and yielded to the
+   caller via async iteration.
+
+6. **Termination**: After the process exits, any final events (watchdog
+   errors, abort markers) are emitted, followed by the `done` event.
+
+### Watchdog Timer
+
+A 5-minute inactivity watchdog resets on every NDJSON line received. If no
+output arrives within the timeout, the runtime triggers process termination
+and emits an error event with code `WATCHDOG_TIMEOUT`.
+
+### Signal Escalation
+
+Process termination (from watchdog, abort signal, or errors) follows a
+two-step escalation:
+
+1. **SIGTERM** — gives the CLI process a chance to clean up
+2. **SIGKILL** (after 1.5 seconds) — forces termination if SIGTERM is ignored
+
+### Per-Execution State Reset
+
+Each concrete runtime resets its internal state before every `execute()` call.
+This makes runtime instances reusable across multiple invocations without
+reconstruction.
+
+## CLI Runtimes
+
+### Claude
+
+| Aspect             | Detail                                           |
+| ------------------ | ------------------------------------------------ |
+| Command            | `claude --output-format stream-json --verbose`   |
+| Structured output  | Stream JSON events on stdout                     |
+| Session resumption | `--resume <sessionId>`                           |
+| MCP config         | Inline via `--mcp-config '{"mcpServers":{...}}'` |
+| Stdin prompt       | Supported (prompts over 10 KB)                   |
+
+Claude emits a content block streaming protocol. Text arrives as
+`content_block_delta` events with `text_delta` payloads. Tool use is
+assembled across multiple events: `content_block_start` begins a tool buffer,
+`content_block_delta` events with `input_json_delta` accumulate the input
+JSON, and `content_block_stop` triggers parsing and emission of the complete
+`tool_use` event.
+
+Token usage and cost are captured from `result` events at the end of a run.
+
+### Gemini
+
+| Aspect             | Detail                                                 |
+| ------------------ | ------------------------------------------------------ |
+| Command            | `gemini --output-format stream-json --prompt <prompt>` |
+| Structured output  | Flat NDJSON events on stdout                           |
+| Session resumption | `--resume <sessionId>`                                 |
+| MCP config         | File-based merge-restore of `.gemini/settings.json`    |
+| Stdin prompt       | Not supported                                          |
+
+Gemini emits flat events: `message` (with text content), `tool_use`, and
+`tool_result` as complete, self-contained events. No streaming assembly is
+needed.
+
+Since the Gemini CLI lacks a flag for MCP server configuration, the runtime
+uses a merge-restore pattern: it reads the existing `.gemini/settings.json`,
+backs up the original content, merges in the MCP server entries, runs the
+CLI, and restores the original file in a `finally` block.
+
+### Codex
+
+| Aspect             | Detail                                             |
+| ------------------ | -------------------------------------------------- |
+| Command            | `codex exec --json --color never <prompt>`         |
+| Structured output  | Two-level event hierarchy on stdout                |
+| Session resumption | `codex exec resume --json <sessionId> <prompt>`    |
+| MCP config         | File-based merge-restore of `~/.codex/config.toml` |
+| Stdin prompt       | Not supported                                      |
+
+Codex has the most complex event model. Top-level events (`thread.started`,
+`item.started`, `item.updated`, `item.completed`, `turn.completed`) contain
+nested item types (`agent_message`, `command_execution`, `mcp_tool_call`,
+etc.).
+
+Text arrives incrementally: `item.updated` events carry cumulative text, and
+the runtime tracks the last emitted length to compute and yield only the
+delta.
+
+The MCP config merge-restore targets the global `~/.codex/config.toml` file,
+using a custom TOML serializer (no external TOML dependency).
+
+### OpenCode
+
+| Aspect             | Detail                                              |
+| ------------------ | --------------------------------------------------- |
+| Command            | `opencode run --format json <prompt>`               |
+| Structured output  | Envelope events with `part` field on stdout         |
+| Session resumption | `--session <sessionId>`                             |
+| MCP config         | File-based merge-restore of `.opencode/config.json` |
+| Stdin prompt       | Supported (default)                                 |
+
+OpenCode wraps events in an envelope containing `type`, `timestamp`, and
+`sessionID`. The actual event data is in a `part` field.
+
+A notable pattern: OpenCode emits tool use and tool result in the same NDJSON
+line. The runtime yields the `tool_use` event first, then buffers the
+`tool_result` in a pending queue that drains after each base event yield.
+This preserves the expected `tool_use` followed by `tool_result` ordering.
+
+## MCP Configuration Patterns
+
+CLI agents receive MCP server configuration so they can access RemoteClaw's
+gateway tools (messaging, cron, etc.). Each CLI has a different mechanism:
+
+| CLI      | Method        | File Modified                     | Cleanup          |
+| -------- | ------------- | --------------------------------- | ---------------- |
+| Claude   | CLI flag      | None (inline argument)            | None needed      |
+| Gemini   | Merge-restore | `.gemini/settings.json` (workdir) | Restore original |
+| Codex    | Merge-restore | `~/.codex/config.toml` (global)   | Restore original |
+| OpenCode | Merge-restore | `.opencode/config.json` (workdir) | Restore original |
+
+The merge-restore pattern (used by Gemini, Codex, and OpenCode) follows a
+consistent lifecycle:
+
+1. Read the existing config file (if any)
+2. Save the original content
+3. Merge MCP server entries into the config
+4. Write the modified config
+5. Run the CLI
+6. Restore the original content in a `finally` block
+
+Each manager tracks whether it created the file or directory, ensuring
+cleanup does not remove pre-existing user configuration.
+
+## Runtime Selection
+
+`createCliRuntime(provider)` maps a provider string (`"claude"`, `"gemini"`,
+`"codex"`, or `"opencode"`) to the corresponding runtime class. The provider
+is normalized to lowercase before matching.

--- a/docs/concepts/channel-bridge.md
+++ b/docs/concepts/channel-bridge.md
@@ -1,0 +1,222 @@
+# ChannelBridge
+
+The ChannelBridge is the central orchestrator of RemoteClaw's middleware
+layer. It receives a normalized message from a channel adapter, runs it
+through a CLI agent subprocess, and returns deliverable response payloads.
+
+## Overview
+
+```
+Channel Adapter
+      │
+      ▼
+ChannelBridge.handle(message, callbacks?, abortSignal?)
+      │
+      ├── 1. Session lookup
+      ├── 2. System prompt construction
+      ├── 3. MCP server + temp directory setup
+      ├── 4. Pre-spawn hooks
+      ├── 5. Runtime execution (subprocess)
+      ├── 6. Delivery processing (chunking + streaming)
+      ├── 7. Error classification
+      ├── 8. Side effect collection
+      ├── 9. Session state update
+      └── 10. Post-exit hooks
+      │
+      ▼
+AgentDeliveryResult { payloads, run, mcp, error? }
+```
+
+## The handle() Pipeline
+
+### Step 1 — Session Lookup
+
+The bridge builds a session key from `channelId`, `from` (user ID), and
+`replyToId` (thread ID), then queries the `SessionMap` for an existing CLI
+session ID. If found, the session is resumed on the next CLI invocation.
+
+The `SessionMap` is a file-backed store (`remoteclaw-sessions.json`) that
+maps session keys to CLI session IDs with a 7-day TTL. Reads and writes go
+directly to disk (no in-memory cache), and writes use atomic rename for
+POSIX safety.
+
+### Step 2 — System Prompt Construction
+
+`buildSystemPrompt()` assembles a structured markdown prompt with these
+sections:
+
+| Section        | Content                                                              |
+| -------------- | -------------------------------------------------------------------- |
+| Identity       | "You are running inside RemoteClaw..." with channel and user context |
+| Safety         | Human oversight rules, no credential exposure                        |
+| Messaging      | Session routing, cross-session messaging via `sessions_send()`       |
+| Reply tags     | `[[reply_to_current]]` and `[[reply_to:<id>]]` syntax                |
+| Silent replies | `SILENT_REPLY_TOKEN` for when the agent has nothing to say           |
+| Runtime        | Channel name, timezone, agent metadata                               |
+| Workspace      | Working directory and file operations guidance                       |
+
+Conditional sections are included when relevant data is present: message
+formatting hints, authorized sender lists, and emoji reaction guidance.
+
+### Step 3 — MCP Server and Temp Directory
+
+A temporary directory is created for the invocation. Within it, a side
+effects file path is generated for IPC with the MCP server.
+
+The bridge builds an MCP server configuration that injects RemoteClaw's own
+MCP server into the subprocess:
+
+```
+remoteclaw MCP server (injected into every CLI subprocess)
+├── Gateway URL + token (for WebSocket access)
+├── Session key (channelId:userId:threadId)
+├── Side effects file path (for IPC)
+├── Channel metadata (provider, account, sender info)
+└── Tool profile (full/limited)
+```
+
+This MCP server gives the CLI agent access to RemoteClaw-specific tools:
+sending messages to other channels, scheduling cron jobs, and accessing
+gateway resources.
+
+### Step 4 — Pre-Spawn Hooks
+
+If `before_runtime_spawn` hooks are registered, they run before the
+subprocess starts. Extensions can use these hooks to override the working
+directory or inject additional environment variables.
+
+### Step 5 — Runtime Execution
+
+The bridge creates the appropriate runtime via `createCliRuntime(provider)`
+and calls `execute()` with the assembled prompt, session ID, MCP
+configuration, abort signal, working directory, and environment.
+
+The full prompt passed to the runtime concatenates: system prompt + extra
+context (if present) + user message text.
+
+The event stream is wrapped in a `captureResult()` helper that intercepts
+`done` and `error` events to capture their data while passing all events
+through unchanged.
+
+### Step 6 — Delivery Processing
+
+The `DeliveryAdapter` consumes the event stream and produces
+channel-deliverable payloads.
+
+**Text chunking**: Text events accumulate in a buffer. When the buffer
+exceeds the chunk limit (default 4000 characters), it splits at the best
+available boundary:
+
+1. Paragraph break (`\n\n`) — preferred
+2. Line break (`\n`)
+3. Word boundary (space)
+4. Hard split at the limit — last resort
+
+**Code fence awareness**: If a split occurs inside an unclosed markdown code
+fence, the adapter closes the fence in the current chunk and reopens it in
+the next. This prevents broken code blocks in multi-chunk messages.
+
+**Streaming callbacks**: Overflow chunks trigger `onPartialReply` for
+real-time streaming delivery. The final text block triggers `onBlockReply`
+on the `done` event. Tool results trigger `onToolResult`.
+
+### Step 7 — Error Classification
+
+If the runtime throws synchronously, the error message is classified into
+one of five categories:
+
+| Category           | Matches                                                                    |
+| ------------------ | -------------------------------------------------------------------------- |
+| `retryable`        | Rate limits (429), 503, overloaded, network errors (ETIMEDOUT, ECONNRESET) |
+| `context_overflow` | Context length/window exceeded, too many tokens                            |
+| `fatal` (auth)     | 401, 403, unauthorized, forbidden, invalid key                             |
+| `fatal` (other)    | Default for unmatched errors                                               |
+| `timeout`          | Timeout patterns                                                           |
+| `aborted`          | Abort signal triggered                                                     |
+
+Classification uses first-match-wins against pattern arrays.
+
+### Step 8 — Side Effect Collection
+
+After the subprocess exits, the bridge reads the side effects file written by
+the MCP server during execution. Side effects are aggregated into:
+
+- **Sent texts**: Messages the agent sent to other channels
+- **Sent media URLs**: Media delivered through messaging tools
+- **Sent targets**: Destination metadata (tool, provider, account, recipient)
+- **Cron additions**: Scheduled jobs the agent created
+
+The side effects file uses NDJSON format, written by the MCP server process
+and read by the bridge — a clean file-based IPC channel that requires no
+shared memory or sockets.
+
+### Step 9 — Session State Update
+
+If the CLI run produced a session ID (in the `done` event's `AgentRunResult`),
+the bridge persists it to the `SessionMap`. The next message from the same
+user in the same channel/thread will resume this session.
+
+### Step 10 — Post-Exit Hooks
+
+Two hooks fire after the subprocess exits (both fire-and-forget):
+
+- `after_runtime_exit`: receives stdout, stderr, and side effects data
+- `agent_end`: receives run ID, success status, and duration
+
+The temporary directory created in step 3 is cleaned up in a `finally` block.
+
+## The Delivery Result
+
+`handle()` returns an `AgentDeliveryResult` with three parts:
+
+| Field      | Type             | Content                                              |
+| ---------- | ---------------- | ---------------------------------------------------- |
+| `payloads` | `ReplyPayload[]` | Channel-deliverable message chunks                   |
+| `run`      | `AgentRunResult` | CLI subprocess summary (text, usage, cost, duration) |
+| `mcp`      | `McpSideEffects` | Gateway side effects (messages sent, crons added)    |
+| `error`    | `string?`        | Error message if the run failed                      |
+
+## Message Flow
+
+A typical message flows through the system like this:
+
+```
+User sends "Hello" on Telegram
+      │
+      ▼
+Telegram adapter normalizes to ChannelMessage
+      │
+      ▼
+ChannelBridge.handle()
+  ├── SessionMap: no existing session
+  ├── System prompt: builds identity + safety + messaging sections
+  ├── MCP config: injects remoteclaw MCP server
+  ├── Runtime: spawns `claude --output-format stream-json ...`
+  │     ├── stdin: prompt (if >10 KB)
+  │     ├── stdout: NDJSON events streamed back
+  │     │     ├── text "Hi! How can I help?" → DeliveryAdapter buffers
+  │     │     └── done { sessionId: "abc-123", usage: {...} }
+  │     └── process exits
+  ├── Side effects file: empty (no gateway tools used)
+  ├── SessionMap: stores "abc-123" for next message
+  └── Returns AgentDeliveryResult
+      │
+      ▼
+Telegram adapter sends "Hi! How can I help?" to user
+```
+
+## Cross-Channel Routing
+
+The MCP server injected into every subprocess exposes a `sessions_send()`
+tool. This allows the CLI agent to send messages to other channels or users
+through the gateway, enabling cross-channel workflows.
+
+For example, an agent receiving a message on Telegram can send a notification
+to a Slack channel, or forward information to another user on WhatsApp.
+The side effects system tracks all messages sent through this mechanism.
+
+## Followup Handling
+
+When a user sends a new message while the agent is still processing a
+previous one, the message is queued as a followup. The queue mode determines
+behavior — see [Sessions](session.md) for queue mode details.

--- a/docs/concepts/middleware-architecture.md
+++ b/docs/concepts/middleware-architecture.md
@@ -1,0 +1,109 @@
+# Middleware Architecture
+
+RemoteClaw is **middleware**, not an AI runtime. It connects CLI-based AI
+agents to messaging channels without reimplementing the agentic loop.
+
+## The Middleware Model
+
+Traditional AI chat platforms embed the language model, tool execution, and
+conversation management into a single process. RemoteClaw takes a different
+approach: it acts as a **message router** between messaging channels (WhatsApp,
+Telegram, Slack, Discord, etc.) and CLI agent processes that run as
+subprocesses.
+
+```
+┌────────────┐      ┌─────────────────────┐      ┌──────────────┐
+│  Messaging  │ ──▶ │     RemoteClaw       │ ──▶ │  CLI Agent    │
+│  Channel    │ ◀── │  (ChannelBridge)     │ ◀── │  (subprocess) │
+└────────────┘      └─────────────────────┘      └──────────────┘
+                         │          ▲
+                         ▼          │
+                    ┌──────────┐  ┌──────────┐
+                    │ Sessions │  │ MCP Side  │
+                    │  (file)  │  │ Effects   │
+                    └──────────┘  └──────────┘
+```
+
+A channel adapter receives a user message and passes it to the
+[ChannelBridge](channel-bridge.md). The bridge looks up session state, builds a
+system prompt, spawns the appropriate CLI agent as a subprocess, streams events
+back, and delivers the response to the channel.
+
+The agent subprocess is short-lived: it starts, processes one exchange, and
+exits. Conversation continuity is maintained by passing a CLI-specific session
+ID on each invocation.
+
+## Bring Your Own Agent
+
+RemoteClaw supports any CLI agent that communicates over stdin/stdout (or
+stderr) using structured output. Four runtimes ship out of the box:
+
+| Agent    | CLI Command | Structured Output     |
+| -------- | ----------- | --------------------- |
+| Claude   | `claude`    | Stream JSON on stderr |
+| Gemini   | `gemini`    | Stream JSON on stdout |
+| Codex    | `codex`     | JSON on stdout        |
+| OpenCode | `opencode`  | JSON on stdout        |
+
+Each runtime translates the CLI's native event format into RemoteClaw's
+unified `AgentEvent` stream. Adding a new agent means implementing one
+interface — see [Agent Runtimes](agent-runtimes.md) for the contract.
+
+## How This Differs from OpenClaw
+
+OpenClaw ran an embedded execution engine (Pi) inside the main process. The
+model, tool execution, prompt management, and conversation state all lived
+in-process:
+
+```
+OpenClaw (single process)
+├── Pi execution engine (in-process LLM orchestration)
+├── Model provider ecosystem (OpenAI, Anthropic, Google, etc.)
+├── Tool execution (in-process)
+├── Skills marketplace
+└── Session management
+```
+
+RemoteClaw replaces all of this with a subprocess boundary:
+
+```
+RemoteClaw
+├── ChannelBridge (message routing + session tracking)
+├── CLI subprocess (claude, gemini, codex, or opencode)
+│   ├── LLM interaction (handled by the CLI)
+│   ├── Tool execution (handled by the CLI)
+│   └── Conversation management (handled by the CLI)
+└── MCP server (injected into subprocess for gateway access)
+```
+
+The CLI agent owns the agentic loop. RemoteClaw only handles what requires
+its infrastructure: session persistence, message delivery, system prompt
+injection, and MCP tool bridging to the gateway.
+
+## The Middleware Boundary Principle
+
+RemoteClaw documents and provides capabilities that **require RemoteClaw
+infrastructure**:
+
+| RemoteClaw's responsibility         | Agent's responsibility                       |
+| ----------------------------------- | -------------------------------------------- |
+| Session persistence across messages | Conversation memory within a session         |
+| Message delivery to channels        | Deciding what to say                         |
+| System prompt with channel context  | Tool execution (web search, file I/O, shell) |
+| MCP tools bridging to the gateway   | Model selection and inference                |
+| Cron scheduling                     | Code generation and analysis                 |
+| Cross-channel message routing       | Any capability the CLI provides natively     |
+
+This principle governs what belongs in RemoteClaw's codebase and
+documentation. If a capability works without RemoteClaw infrastructure, it
+belongs to the agent CLI, not to RemoteClaw.
+
+## Key Components
+
+| Component                            | Purpose                                         | Documentation |
+| ------------------------------------ | ----------------------------------------------- | ------------- |
+| [ChannelBridge](channel-bridge.md)   | Orchestrates the full message-handling pipeline | Concepts      |
+| [Agent Runtimes](agent-runtimes.md)  | Subprocess management and event translation     | Concepts      |
+| [Gateway](../gateway/)               | WebSocket transport for channel adapters        | Gateway docs  |
+| [Sessions](session.md)               | Conversation state and scoping                  | Concepts      |
+| [Configuration](../configuration.md) | Runtime selection, MCP setup, channel config    | Reference     |


### PR DESCRIPTION
## Summary

- Adds `docs/concepts/middleware-architecture.md` — explains the middleware model, "Bring Your Own Agent" concept, how RemoteClaw differs from OpenClaw's embedded-Pi approach, and the Middleware Boundary Principle
- Adds `docs/concepts/agent-runtimes.md` — documents the AgentRuntime interface contract, CLIRuntimeBase subprocess machinery (spawn, watchdog, signal escalation, NDJSON parsing, stdin prompt delivery), all 4 CLI runtimes (Claude, Gemini, Codex, OpenCode) with their differences, MCP configuration patterns, and runtime factory
- Adds `docs/concepts/channel-bridge.md` — documents the full handle() pipeline (session lookup → system prompt → MCP setup → hooks → runtime execution → delivery → error classification → side effects → session update → post-exit hooks), message flow example, cross-channel routing, and followup handling

All docs follow the Middleware Boundary Principle: only documenting what requires RemoteClaw infrastructure. No overlap with #228 (README Quick Start) or #229 (config reference).

Closes #201

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Cross-check documented interfaces against source code in `src/middleware/`
- [ ] Confirm no duplication with existing concept docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)