### PR TITLE
docs: add migration guide and OpenClaw comparison docs (#241)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -758,7 +758,7 @@
               },
               {
                 "group": "Guides",
-                "pages": ["start/remoteclaw"]
+                "pages": ["start/remoteclaw", "start/openclaw-or-remoteclaw"]
               }
             ]
           },
@@ -781,7 +781,13 @@
               },
               {
                 "group": "Maintenance",
-                "pages": ["install/updating", "install/migrating", "install/uninstall"]
+                "pages": [
+                  "install/updating",
+                  "install/migrating",
+                  "install/from-openclaw",
+                  "install/breaking-changes-from-openclaw",
+                  "install/uninstall"
+                ]
               },
               {
                 "group": "Hosting and deployment",

--- a/docs/install/breaking-changes-from-openclaw.md
+++ b/docs/install/breaking-changes-from-openclaw.md
@@ -1,0 +1,63 @@
+---
+summary: "What OpenClaw users lose and gain when switching to RemoteClaw"
+read_when:
+  - You are switching from OpenClaw to RemoteClaw
+  - You want to know what features were removed or replaced
+title: "Breaking Changes from OpenClaw"
+---
+
+# Breaking Changes from OpenClaw
+
+RemoteClaw is a fork of OpenClaw that replaced the embedded Pi execution engine with a middleware architecture. This page lists everything that changed, was removed, or was added.
+
+## What you lose
+
+These OpenClaw features do not exist in RemoteClaw:
+
+| Feature                                     | Why it was removed                                                                                   |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **Skills system and ClawHub marketplace**   | Agents bring their own capabilities via MCP or built-in tools. There is no skills marketplace.       |
+| **Model catalog (30+ LLM providers)**       | One CLI agent = one provider. Model selection is the agent's responsibility, not the gateway's.      |
+| **Embedded Pi execution engine**            | Replaced by subprocess CLI agents (Claude Code, Gemini CLI, Codex CLI, OpenCode).                    |
+| **Docker sandbox**                          | Agents manage their own sandboxing. RemoteClaw does not run containers for code execution.           |
+| **Centralized OAuth**                       | Agents use their own API keys via environment variables. No shared OAuth flow.                       |
+| **Wizard onboarding (model picker)**        | RemoteClaw's onboarding sets up channels and agent runtime — no model catalog to browse.             |
+| **Web/browser/image/TTS as built-in tools** | These capabilities are either agent-native or available via MCP servers, not built into the gateway. |
+| **In-process tool execution**               | Tools run inside the agent subprocess, not inside the gateway process.                               |
+
+## What you gain
+
+| Feature                       | What it means                                                                                                                     |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **Multi-runtime support**     | Switch between Claude Code, Gemini CLI, Codex CLI, and OpenCode via a single config key (`agentRuntime`).                         |
+| **Middleware architecture**   | Lighter footprint — RemoteClaw routes messages and manages sessions; the agent does everything else.                              |
+| **MCP-first tool system**     | 50 tools exposed via an MCP server injected into the agent subprocess.                                                            |
+| **Subprocess isolation**      | Agent crashes don't crash the gateway. Each session runs in its own process.                                                      |
+| **Agent-native capabilities** | Your CLI agent's full feature set (web search, file I/O, code execution, etc.) works without RemoteClaw needing to know about it. |
+
+## What changed
+
+| Area                | OpenClaw                          | RemoteClaw                                    |
+| ------------------- | --------------------------------- | --------------------------------------------- |
+| **State directory** | `~/.openclaw`                     | `~/.remoteclaw`                               |
+| **Config file**     | `openclaw.json`                   | `remoteclaw.json`                             |
+| **Env var prefix**  | `OPENCLAW_*`                      | `REMOTECLAW_*`                                |
+| **CLI binary**      | `openclaw`                        | `remoteclaw`                                  |
+| **Execution model** | In-process Pi engine              | CLI subprocess (claude/gemini/codex/opencode) |
+| **Tool system**     | Built-in tool registry            | MCP server injected into subprocess           |
+| **Model selection** | Gateway config (provider + model) | Agent config (agent chooses its own model)    |
+
+## What stays the same
+
+These OpenClaw features work identically in RemoteClaw:
+
+- Channel adapters (WhatsApp, Telegram, Slack, Discord, iMessage, and 30+ more)
+- Gateway WebSocket transport
+- Session management and scoping
+- Cron job scheduling
+- Message routing and delivery
+- Channel-specific formatting
+
+## Migration
+
+To migrate your OpenClaw installation, see [Migrate from OpenClaw](/install/from-openclaw). The `remoteclaw import` command handles config file renaming and env var rewriting automatically.

--- a/docs/install/from-openclaw.md
+++ b/docs/install/from-openclaw.md
@@ -1,0 +1,189 @@
+---
+summary: "Migrate an existing OpenClaw installation to RemoteClaw"
+read_when:
+  - You are running OpenClaw and want to switch to RemoteClaw
+  - You need to understand what the import command does
+  - You want to know what migrates and what does not
+title: "Migrate from OpenClaw"
+---
+
+# Migrate from OpenClaw
+
+RemoteClaw can import your existing OpenClaw config, session history, cron jobs, and channel settings. This guide walks through the full migration.
+
+<Note>
+RemoteClaw does **not** silently fall back to reading `~/.openclaw`. Migration is explicit — you run `remoteclaw import` once, then everything lives under `~/.remoteclaw`.
+</Note>
+
+## Before you start
+
+Read [Breaking changes from OpenClaw](/install/breaking-changes-from-openclaw) to understand what features no longer exist in RemoteClaw. If you rely heavily on the skills marketplace, embedded model catalog, or Docker sandbox, RemoteClaw may not be the right fit — see [OpenClaw or RemoteClaw?](/start/openclaw-or-remoteclaw) for a decision guide.
+
+## Migration steps
+
+<Steps>
+  <Step title="Back up your OpenClaw config">
+    Copy your existing OpenClaw state directory before making changes:
+
+    ```bash
+    cp -r ~/.openclaw ~/.openclaw-backup
+    ```
+
+  </Step>
+
+  <Step title="Install RemoteClaw">
+    Install RemoteClaw globally. If you already have Node 22+:
+
+    ```bash
+    npm install -g remoteclaw@latest
+    ```
+
+    Or use the installer script, which handles Node detection automatically:
+
+    ```bash
+    curl -fsSL https://remoteclaw.org/install.sh | bash -s -- --no-onboard
+    ```
+
+    Pass `--no-onboard` since you'll import your existing config instead of running the onboarding wizard from scratch.
+
+    See [Install](/install/index) for all install methods.
+
+  </Step>
+
+  <Step title="Run the import command">
+    Import your OpenClaw config into RemoteClaw:
+
+    ```bash
+    remoteclaw import ~/.openclaw
+    ```
+
+    This command:
+
+    - Copies all files from `~/.openclaw` into `~/.remoteclaw`
+    - Renames `openclaw.json` config files to `remoteclaw.json`
+    - Rewrites `${OPENCLAW_*}` template variables to `${REMOTECLAW_*}` in JSON and JSON5 files
+    - Rewrites `OPENCLAW_*` string values (e.g. env var references) to `REMOTECLAW_*`
+    - Rewrites `/.openclaw/` path strings to `/.remoteclaw/`
+
+    <Tip>
+    Preview what will happen without writing any files:
+
+    ```bash
+    remoteclaw import ~/.openclaw --dry-run
+    ```
+
+    For CI or scripted migrations, use `--non-interactive --yes` to suppress all prompts and auto-confirm:
+
+    ```bash
+    remoteclaw import ~/.openclaw --non-interactive --yes
+    ```
+    </Tip>
+
+    <Note>
+    Only JSON and JSON5 files are transformed. Other file types (credentials, session files, binary data) are copied as-is.
+    </Note>
+
+  </Step>
+
+  <Step title="Update environment variables">
+    The import command transforms config files but does **not** touch your shell profile. If you have `OPENCLAW_*` env vars in your `~/.zshrc`, `~/.bashrc`, or `.env` files, rename them manually:
+
+    | Old variable | New variable |
+    | --- | --- |
+    | `OPENCLAW_GATEWAY_TOKEN` | `REMOTECLAW_GATEWAY_TOKEN` |
+    | `OPENCLAW_HOME` | `REMOTECLAW_HOME` |
+    | `OPENCLAW_STATE_DIR` | `REMOTECLAW_STATE_DIR` |
+    | `OPENCLAW_CONFIG_PATH` | `REMOTECLAW_CONFIG_PATH` |
+
+    After editing, reload your shell (`source ~/.zshrc` or open a new terminal).
+
+  </Step>
+
+  <Step title="Configure an agent runtime">
+    OpenClaw used an embedded execution engine (Pi) with a built-in model catalog. RemoteClaw does not — it launches a CLI agent as a subprocess instead.
+
+    You need one of these CLI agents installed and configured:
+
+    | Runtime | CLI | API key env var |
+    | --- | --- | --- |
+    | `claude` (default) | [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) | `ANTHROPIC_API_KEY` |
+    | `gemini` | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `GEMINI_API_KEY` or `GOOGLE_API_KEY` |
+    | `codex` | [Codex CLI](https://github.com/openai/codex) | `OPENAI_API_KEY` |
+    | `opencode` | [OpenCode](https://github.com/opencode-ai/opencode) | Provider-specific |
+
+    Set the runtime in your config:
+
+    ```json5
+    // ~/.remoteclaw/remoteclaw.json
+    {
+      "agentRuntime": "claude"  // or "gemini", "codex", "opencode"
+    }
+    ```
+
+    See [Configuration](/configuration) for all runtime options.
+
+  </Step>
+
+  <Step title="Verify the migration">
+    Run the doctor command to check for issues:
+
+    ```bash
+    remoteclaw doctor
+    ```
+
+    Then start the gateway and send a test message through one of your channels:
+
+    ```bash
+    remoteclaw start
+    ```
+
+  </Step>
+
+  <Step title="Uninstall OpenClaw (optional)">
+    Once you've confirmed RemoteClaw is working:
+
+    ```bash
+    npm uninstall -g openclaw
+    ```
+
+    You can remove `~/.openclaw` once you're confident the migration is complete (keep `~/.openclaw-backup` a bit longer just in case).
+
+  </Step>
+</Steps>
+
+## What gets migrated
+
+| Category                       | Migrated? | Notes                                                                      |
+| ------------------------------ | --------- | -------------------------------------------------------------------------- |
+| Config files (`openclaw.json`) | Yes       | Renamed to `remoteclaw.json`, env vars rewritten                           |
+| Session history                | Yes       | Copied as-is                                                               |
+| Cron job definitions           | Yes       | Copied as-is                                                               |
+| Channel settings               | Yes       | Copied as-is                                                               |
+| Custom extensions              | Yes       | Copied as-is, but extensions using Pi APIs need manual updates (see below) |
+
+## What does NOT migrate
+
+These OpenClaw features have been removed in RemoteClaw. Config referencing them is still copied but will have no effect.
+
+- **Skills system and ClawHub marketplace** — agents bring their own capabilities (via MCP or built-in tools)
+- **Model catalog and 30+ LLM provider configs** — one CLI agent = one provider; no in-process model switching
+- **Embedded Pi execution engine** — replaced by subprocess CLI agents
+- **Docker sandbox** — agents manage their own sandboxing
+- **Centralized OAuth** — agents use their own API keys via env vars
+- **Wizard onboarding** — replaced with direct config file editing (or `remoteclaw onboard`)
+
+See [Breaking changes from OpenClaw](/install/breaking-changes-from-openclaw) for the full list of what's removed and what's new.
+
+## Edge cases
+
+### Custom extensions using Pi APIs
+
+If you wrote custom extensions that called OpenClaw's Pi execution engine directly, those calls will fail in RemoteClaw. You'll need to update them to work with the subprocess-based agent runtime or use MCP tools instead. See [Middleware Architecture](/concepts/middleware-architecture) for how the new architecture works.
+
+### Multiple OpenClaw installations
+
+The import command takes a single source path. If you have multiple OpenClaw installations (e.g. different machines synced to the same host), import the primary one first, verify, then manually merge any unique config from the others.
+
+### Existing `~/.remoteclaw` directory
+
+If `~/.remoteclaw` already exists, the import command will prompt before merging. Use `--yes` to skip the prompt, `--dry-run` to preview the merge first, or `--non-interactive --yes` for unattended runs.

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -203,7 +203,7 @@ On Windows, add the output of `npm prefix -g` to your PATH.
 Then open a new terminal (or `rehash` in zsh / `hash -r` in bash).
 </Accordion>
 
-## Update / uninstall
+## Update / migrate / uninstall
 
 <CardGroup cols={3}>
   <Card title="Updating" href="/install/updating" icon="refresh-cw">
@@ -211,6 +211,12 @@ Then open a new terminal (or `rehash` in zsh / `hash -r` in bash).
   </Card>
   <Card title="Migrating" href="/install/migrating" icon="arrow-right">
     Move to a new machine.
+  </Card>
+  <Card title="From OpenClaw" href="/install/from-openclaw" icon="arrow-right-left">
+    Migrate an OpenClaw installation to RemoteClaw.
+  </Card>
+  <Card title="Breaking changes" href="/install/breaking-changes-from-openclaw" icon="triangle-alert">
+    What changed from OpenClaw.
   </Card>
   <Card title="Uninstall" href="/install/uninstall" icon="trash-2">
     Remove RemoteClaw completely.

--- a/docs/start/openclaw-or-remoteclaw.md
+++ b/docs/start/openclaw-or-remoteclaw.md
@@ -1,0 +1,72 @@
+---
+summary: "Decision guide for choosing between OpenClaw and RemoteClaw"
+read_when:
+  - You are evaluating whether to use OpenClaw or RemoteClaw
+  - You want to understand the trade-offs between the two projects
+title: "OpenClaw or RemoteClaw?"
+---
+
+# OpenClaw or RemoteClaw?
+
+RemoteClaw is a fork of OpenClaw that replaced the embedded AI execution engine with a middleware architecture. Both projects are actively maintained but serve different use cases.
+
+## Quick decision
+
+**Already using Claude Code, Gemini CLI, Codex CLI, or OpenCode?**
+Use **RemoteClaw**. It connects your existing agent to messaging channels without adding another LLM layer.
+
+**Want a self-contained platform with built-in model providers and a skills marketplace?**
+Use **OpenClaw**. It includes everything in one process.
+
+## Decision tree
+
+| If you want…                                                                               | Choose         |
+| ------------------------------------------------------------------------------------------ | -------------- |
+| Connect an existing CLI agent (Claude, Gemini, Codex, OpenCode) to WhatsApp/Telegram/Slack | **RemoteClaw** |
+| Switch between multiple agent runtimes via config                                          | **RemoteClaw** |
+| Middleware-only architecture (no embedded LLM overhead)                                    | **RemoteClaw** |
+| MCP-first tool system (50 tools via MCP server)                                            | **RemoteClaw** |
+| Subprocess isolation (agent crashes don't crash the gateway)                               | **RemoteClaw** |
+| Consumer onboarding wizard with 30+ LLM provider picker                                    | **OpenClaw**   |
+| Built-in skills marketplace (ClawHub)                                                      | **OpenClaw**   |
+| In-process model catalog (switch between OpenAI, Anthropic, Google, etc.)                  | **OpenClaw**   |
+| Docker sandbox for code execution                                                          | **OpenClaw**   |
+| Centralized OAuth for all providers                                                        | **OpenClaw**   |
+
+## Architecture comparison
+
+<Tabs>
+  <Tab title="RemoteClaw">
+    ```
+    RemoteClaw (middleware)
+    ├── ChannelBridge (message routing + session tracking)
+    ├── CLI subprocess (claude, gemini, codex, or opencode)
+    │   ├── LLM interaction (handled by the CLI)
+    │   ├── Tool execution (handled by the CLI)
+    │   └── Conversation management (handled by the CLI)
+    └── MCP server (injected into subprocess for gateway access)
+    ```
+
+    The CLI agent owns the agentic loop. RemoteClaw handles session persistence, message delivery, and MCP tool bridging.
+
+  </Tab>
+  <Tab title="OpenClaw">
+    ```
+    OpenClaw (single process)
+    ├── Pi execution engine (in-process LLM orchestration)
+    ├── Model provider ecosystem (OpenAI, Anthropic, Google, etc.)
+    ├── Tool execution (in-process)
+    ├── Skills marketplace (ClawHub)
+    └── Session management
+    ```
+
+    Everything runs in one process. OpenClaw manages the model, tools, and conversation directly.
+
+  </Tab>
+</Tabs>
+
+For a deeper architectural comparison, see [Middleware Architecture — How This Differs from OpenClaw](/concepts/middleware-architecture#how-this-differs-from-openclaw).
+
+## Switching from OpenClaw
+
+If you decide to switch, see [Migrate from OpenClaw](/install/from-openclaw) for step-by-step instructions and [Breaking changes](/install/breaking-changes-from-openclaw) for what to expect.


### PR DESCRIPTION
## Summary

- **Migration guide** (`docs/install/from-openclaw.md`): Step-by-step walkthrough of `remoteclaw import`, what gets migrated (config, sessions, cron, channels), what does NOT migrate (skills, model catalog, Pi engine, Docker sandbox, OAuth, wizard), env var manual rename, agent runtime setup, and edge cases
- **Decision page** (`docs/start/openclaw-or-remoteclaw.md`): Quick decision guide and feature comparison table helping users choose between OpenClaw and RemoteClaw based on their use case
- **Breaking changes** (`docs/install/breaking-changes-from-openclaw.md`): What OpenClaw users lose (8 features), gain (5 features), what changed (7 areas), and what stays the same
- Navigation (`docs.json`) and install index card links updated to include all three new pages

Closes #241

## Test plan

- [ ] Verify `pnpm build` passes (docs are static, no code changes)
- [ ] Verify all cross-links between the three new docs resolve correctly in Mintlify
- [ ] Verify navigation shows the new pages in correct locations (Start > Guides, Install > Maintenance)
- [ ] Spot-check `remoteclaw import` flags against `src/commands/import.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)