### PR TITLE
Delete ackMaxChars heartbeat config (#262)

### DIFF
--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -275,7 +275,6 @@ Save to `~/.remoteclaw/remoteclaw.json` and you can DM the bot from that number.
         target: "last",
         to: "+15555550123",
         prompt: "HEARTBEAT",
-        ackMaxChars: 300,
       },
       memorySearch: {
         provider: "gemini",

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -802,7 +802,6 @@ Periodic heartbeat runs.
         to: "+15555550123",
         target: "none", // default: none | options: last | whatsapp | telegram | discord | ...
         prompt: "Read HEARTBEAT.md if it exists...",
-        ackMaxChars: 300,
         suppressToolErrorWarnings: false,
       },
     },

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -69,7 +69,7 @@ stats” or “verify gateway health”), set `agents.defaults.heartbeat.prompt`
 - If nothing needs attention, reply with **`HEARTBEAT_OK`**.
 - During heartbeat runs, RemoteClaw treats `HEARTBEAT_OK` as an ack when it appears
   at the **start or end** of the reply. The token is stripped and the reply is
-  dropped if the remaining content is **≤ `ackMaxChars`** (default: 300).
+  dropped.
 - If `HEARTBEAT_OK` appears in the **middle** of a reply, it is not treated
   specially.
 - For alerts, **do not** include `HEARTBEAT_OK`; return only the alert text.
@@ -91,7 +91,6 @@ and logged; a message that is only `HEARTBEAT_OK` is dropped.
         to: "+15551234567", // optional channel-specific override
         accountId: "ops-bot", // optional multi-account channel id
         prompt: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.",
-        ackMaxChars: 300, // max chars allowed after HEARTBEAT_OK
       },
     },
   },
@@ -219,7 +218,6 @@ Use `accountId` to target a specific account on multi-account channels like Tele
 - `to`: optional recipient override (channel-specific id, e.g. E.164 for WhatsApp or a Telegram chat id). For Telegram topics/threads, use `<chatId>:topic:<messageThreadId>`.
 - `accountId`: optional account id for multi-account channels. When `target: "last"`, the account id applies to the resolved last channel if it supports accounts; otherwise it is ignored. If the account id does not match a configured account for the resolved channel, delivery is skipped.
 - `prompt`: overrides the default prompt body (not merged).
-- `ackMaxChars`: max chars allowed after `HEARTBEAT_OK` before delivery.
 - `suppressToolErrorWarnings`: when true, suppresses tool error warning payloads during heartbeat runs.
 - `activeHours`: restricts heartbeat runs to a time window. Object with `start` (HH:MM, inclusive; use `00:00` for start-of-day), `end` (HH:MM exclusive; `24:00` allowed for end-of-day), and optional `timezone`.
   - Omitted or `"user"`: uses your `agents.defaults.userTimezone` if set, otherwise falls back to the host system timezone.

--- a/docs/start/remoteclaw.md
+++ b/docs/start/remoteclaw.md
@@ -163,7 +163,7 @@ Set `agents.defaults.heartbeat.every: "0m"` to disable.
 
 - If `HEARTBEAT.md` exists but is effectively empty (only blank lines and markdown headers like `# Heading`), RemoteClaw skips the heartbeat run to save API calls.
 - If the file is missing, the heartbeat still runs and the model decides what to do.
-- If the agent replies with `HEARTBEAT_OK` (optionally with short padding; see `agents.defaults.heartbeat.ackMaxChars`), RemoteClaw suppresses outbound delivery for that heartbeat.
+- If the agent replies with `HEARTBEAT_OK`, RemoteClaw suppresses outbound delivery for that heartbeat.
 - Heartbeat delivery to DM-style `user:<id>` targets is blocked; those runs still execute but skip outbound delivery.
 - Heartbeats run full agent turns — shorter intervals burn more tokens.
 


### PR DESCRIPTION
## Summary

- Remove all documentation references to the `ackMaxChars` heartbeat config key
- Source-level code (zod schema, types, constant, helper function, test file) was already removed in #261 (heartbeat_report MCP tool)
- With the structured `heartbeat_report` tool, agents explicitly signal `anything_done: true/false` — the text-length heuristic is no longer needed

## Files changed

- `docs/gateway/heartbeat.md` — removed config example line, response contract length clause, field notes entry
- `docs/gateway/configuration-reference.md` — removed config example line
- `docs/gateway/configuration-examples.md` — removed config example line
- `docs/start/remoteclaw.md` — removed parenthetical `ackMaxChars` reference

## Verification

- `grep -ri "ackMaxChars\|ACK_MAX_CHARS"` returns zero hits across entire repo
- Build passes

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)