### PR TITLE
Replace hardcoded gateway file whitelist with configurable globs (#259)

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -18,14 +18,8 @@ export function resolveDefaultAgentWorkspaceDir(
 }
 
 export const DEFAULT_AGENT_WORKSPACE_DIR = resolveDefaultAgentWorkspaceDir();
-export const DEFAULT_AGENTS_FILENAME = "AGENTS.md";
-export const DEFAULT_SOUL_FILENAME = "SOUL.md";
-export const DEFAULT_TOOLS_FILENAME = "TOOLS.md";
 export const DEFAULT_IDENTITY_FILENAME = "IDENTITY.md";
-export const DEFAULT_USER_FILENAME = "USER.md";
 export const DEFAULT_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
-export const DEFAULT_MEMORY_FILENAME = "MEMORY.md";
-export const DEFAULT_MEMORY_ALT_FILENAME = "memory.md";
 let gitAvailabilityPromise: Promise<boolean> | null = null;
 
 async function hasGitRepo(dir: string): Promise<boolean> {
@@ -73,37 +67,14 @@ export async function ensureAgentWorkspace(params?: {
   ensureBootstrapFiles?: boolean;
 }): Promise<{
   dir: string;
-  agentsPath?: string;
-  soulPath?: string;
-  toolsPath?: string;
-  identityPath?: string;
-  userPath?: string;
-  bootstrapPath?: string;
 }> {
   const rawDir = params?.dir?.trim() ? params.dir.trim() : DEFAULT_AGENT_WORKSPACE_DIR;
   const dir = resolveUserPath(rawDir);
   await fs.mkdir(dir, { recursive: true });
 
-  if (!params?.ensureBootstrapFiles) {
-    return { dir };
+  if (params?.ensureBootstrapFiles) {
+    await ensureGitRepo(dir);
   }
 
-  const agentsPath = path.join(dir, DEFAULT_AGENTS_FILENAME);
-  const soulPath = path.join(dir, DEFAULT_SOUL_FILENAME);
-  const toolsPath = path.join(dir, DEFAULT_TOOLS_FILENAME);
-  const identityPath = path.join(dir, DEFAULT_IDENTITY_FILENAME);
-  const userPath = path.join(dir, DEFAULT_USER_FILENAME);
-  const bootstrapPath = path.join(dir, DEFAULT_BOOTSTRAP_FILENAME);
-
-  await ensureGitRepo(dir);
-
-  return {
-    dir,
-    agentsPath,
-    soulPath,
-    toolsPath,
-    identityPath,
-    userPath,
-    bootstrapPath,
-  };
+  return { dir };
 }

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -256,6 +256,8 @@ export type AgentDefaultsConfig = {
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 60000). */
     announceTimeoutMs?: number;
   };
+  /** Glob patterns for files exposed via agents.files.list/get/set (default: []). */
+  editableFiles?: string[];
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;
   /** Selected agent runtime (claude, gemini, codex, opencode). */

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -32,6 +32,8 @@ export type AgentConfig = {
   sandbox?: AgentSandboxConfig;
   /** Optional per-agent stream params (e.g. cacheRetention, temperature). */
   params?: Record<string, unknown>;
+  /** Glob patterns for files exposed via agents.files.list/get/set. Per-agent overrides defaults. */
+  editableFiles?: string[];
   tools?: AgentToolsConfig;
 };
 

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -137,6 +137,7 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
+    editableFiles: z.array(z.string()).optional(),
     sandbox: z.unknown().optional(),
     runtime: z
       .union([z.literal("claude"), z.literal("gemini"), z.literal("codex"), z.literal("opencode")])

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -262,6 +262,7 @@ export const AgentEntrySchema = z
       })
       .strict()
       .optional(),
+    editableFiles: z.array(z.string()).optional(),
     tools: AgentToolsSchema,
   })
   .strict();

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -26,7 +26,11 @@ const mocks = vi.hoisted(() => ({
   fsMkdir: vi.fn(async () => undefined),
   fsAppendFile: vi.fn(async () => {}),
   fsReadFile: vi.fn(async () => ""),
-  fsStat: vi.fn(async () => null),
+  fsWriteFile: vi.fn(async () => {}),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fsStat: vi.fn(async () => null) as any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fsReaddir: vi.fn(async () => []) as any,
 }));
 
 vi.mock("../../config/config.js", () => ({
@@ -84,7 +88,9 @@ vi.mock("node:fs/promises", async () => {
     mkdir: mocks.fsMkdir,
     appendFile: mocks.fsAppendFile,
     readFile: mocks.fsReadFile,
+    writeFile: mocks.fsWriteFile,
     stat: mocks.fsStat,
+    readdir: mocks.fsReaddir,
   };
   return { ...patched, default: patched };
 });
@@ -117,15 +123,6 @@ function createEnoentError() {
   const err = new Error("ENOENT") as NodeJS.ErrnoException;
   err.code = "ENOENT";
   return err;
-}
-
-async function listAgentFileNames(agentId = "main") {
-  const { respond, promise } = makeCall("agents.files.list", { agentId });
-  await promise;
-
-  const [, result] = respond.mock.calls[0] ?? [];
-  const files = (result as { files: Array<{ name: string }> }).files;
-  return files.map((file) => file.name);
 }
 
 function expectNotFoundResponseAndNoWrite(respond: ReturnType<typeof vi.fn>) {
@@ -405,8 +402,193 @@ describe("agents.files.list", () => {
     mocks.loadConfigReturn = {};
   });
 
-  it("always includes BOOTSTRAP.md in the file list", async () => {
-    const names = await listAgentFileNames();
-    expect(names).toContain("BOOTSTRAP.md");
+  it("returns empty list with hint when editableFiles is empty", async () => {
+    const { respond, promise } = makeCall("agents.files.list", { agentId: "main" });
+    await promise;
+
+    const [ok, result] = respond.mock.calls[0] ?? [];
+    expect(ok).toBe(true);
+    expect((result as { files: unknown[] }).files).toEqual([]);
+    expect((result as { hint: string }).hint).toMatch(/editableFiles/);
+  });
+
+  it("lists only files matching configured globs", async () => {
+    mocks.loadConfigReturn = {
+      agents: { defaults: { editableFiles: ["*.md"] } },
+    };
+    mocks.fsReaddir.mockImplementation(async () => [
+      { name: "CLAUDE.md", isFile: () => true, isDirectory: () => false },
+      { name: "secret.key", isFile: () => true, isDirectory: () => false },
+    ]);
+    mocks.fsStat.mockImplementation(async () => ({
+      isFile: () => true,
+      size: 42,
+      mtimeMs: 1000,
+    }));
+
+    const { respond, promise } = makeCall("agents.files.list", { agentId: "main" });
+    await promise;
+
+    const [ok, result] = respond.mock.calls[0] ?? [];
+    expect(ok).toBe(true);
+    const files = (result as { files: Array<{ name: string }> }).files;
+    expect(files.map((f) => f.name)).toEqual(["CLAUDE.md"]);
+  });
+
+  it("per-agent editableFiles override defaults", async () => {
+    mocks.loadConfigReturn = {
+      agents: {
+        defaults: { editableFiles: ["*.txt"] },
+        list: [{ id: "main", editableFiles: ["*.md"] }],
+      },
+    };
+    mocks.fsReaddir.mockImplementation(async () => [
+      { name: "README.md", isFile: () => true, isDirectory: () => false },
+      { name: "notes.txt", isFile: () => true, isDirectory: () => false },
+    ]);
+    mocks.fsStat.mockImplementation(async () => ({
+      isFile: () => true,
+      size: 10,
+      mtimeMs: 2000,
+    }));
+
+    const { respond, promise } = makeCall("agents.files.list", { agentId: "main" });
+    await promise;
+
+    const [ok, result] = respond.mock.calls[0] ?? [];
+    expect(ok).toBe(true);
+    const files = (result as { files: Array<{ name: string }> }).files;
+    expect(files.map((f) => f.name)).toEqual(["README.md"]);
+  });
+
+  it("rejects unsafe glob patterns with path traversal", async () => {
+    mocks.loadConfigReturn = {
+      agents: { defaults: { editableFiles: ["../etc/passwd"] } },
+    };
+
+    const { respond, promise } = makeCall("agents.files.list", { agentId: "main" });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("unsafe") }),
+    );
+  });
+});
+
+describe("agents.files.get", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadConfigReturn = {
+      agents: { defaults: { editableFiles: ["*.md"] } },
+    };
+  });
+
+  it("rejects files not matching any glob", async () => {
+    const { respond, promise } = makeCall("agents.files.get", {
+      agentId: "main",
+      name: "secret.key",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("not in editableFiles") }),
+    );
+  });
+
+  it("returns file content for matching glob", async () => {
+    mocks.fsStat.mockImplementation(async () => ({
+      isFile: () => true,
+      size: 5,
+      mtimeMs: 3000,
+    }));
+    mocks.fsReadFile.mockImplementation(async () => "hello");
+
+    const { respond, promise } = makeCall("agents.files.get", {
+      agentId: "main",
+      name: "README.md",
+    });
+    await promise;
+
+    const [ok, result] = respond.mock.calls[0] ?? [];
+    expect(ok).toBe(true);
+    const file = (result as { file: { content: string } }).file;
+    expect(file.content).toBe("hello");
+  });
+
+  it("returns missing:true for non-existent matching file", async () => {
+    const { respond, promise } = makeCall("agents.files.get", {
+      agentId: "main",
+      name: "MISSING.md",
+    });
+    await promise;
+
+    const [ok, result] = respond.mock.calls[0] ?? [];
+    expect(ok).toBe(true);
+    expect((result as { file: { missing: boolean } }).file.missing).toBe(true);
+  });
+});
+
+describe("agents.files.set", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadConfigReturn = {
+      agents: { defaults: { editableFiles: ["*.md"] } },
+    };
+  });
+
+  it("rejects files not matching any glob", async () => {
+    const { respond, promise } = makeCall("agents.files.set", {
+      agentId: "main",
+      name: "secret.key",
+      content: "bad",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("not in editableFiles") }),
+    );
+    expect(mocks.fsWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("writes file content for matching glob", async () => {
+    mocks.fsStat.mockImplementation(async () => ({
+      isFile: () => true,
+      size: 11,
+      mtimeMs: 4000,
+    }));
+
+    const { respond, promise } = makeCall("agents.files.set", {
+      agentId: "main",
+      name: "CLAUDE.md",
+      content: "hello world",
+    });
+    await promise;
+
+    expect(mocks.fsWriteFile).toHaveBeenCalled();
+    const [ok, result] = respond.mock.calls[0] ?? [];
+    expect(ok).toBe(true);
+    expect((result as { ok: boolean }).ok).toBe(true);
+  });
+
+  it("rejects file names with path traversal", async () => {
+    const { respond, promise } = makeCall("agents.files.set", {
+      agentId: "main",
+      name: "../etc/passwd",
+      content: "bad",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("unsafe") }),
+    );
+    expect(mocks.fsWriteFile).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -5,17 +5,7 @@ import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
 } from "../../agents/agent-scope.js";
-import {
-  DEFAULT_AGENTS_FILENAME,
-  DEFAULT_BOOTSTRAP_FILENAME,
-  DEFAULT_IDENTITY_FILENAME,
-  DEFAULT_MEMORY_ALT_FILENAME,
-  DEFAULT_MEMORY_FILENAME,
-  DEFAULT_SOUL_FILENAME,
-  DEFAULT_TOOLS_FILENAME,
-  DEFAULT_USER_FILENAME,
-  ensureAgentWorkspace,
-} from "../../agents/workspace.js";
+import { ensureAgentWorkspace } from "../../agents/workspace.js";
 import { movePathToTrash } from "../../browser/trash.js";
 import {
   applyAgentConfig,
@@ -24,6 +14,7 @@ import {
   pruneAgentConfig,
 } from "../../commands/agents.config.js";
 import { loadConfig, writeConfigFile } from "../../config/config.js";
+import type { RemoteClawConfig } from "../../config/config.js";
 import { resolveSessionTranscriptsDirForAgent } from "../../config/sessions/paths.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
 import { resolveUserPath } from "../../utils.js";
@@ -40,49 +31,35 @@ import {
   validateAgentsUpdateParams,
 } from "../protocol/index.js";
 import { listAgentsForGateway } from "../session-utils.js";
-import type { GatewayRequestHandlers, RespondFn } from "./types.js";
+import type { GatewayRequestHandlers } from "./types.js";
 
-const BOOTSTRAP_FILE_NAMES = [
-  DEFAULT_AGENTS_FILENAME,
-  DEFAULT_SOUL_FILENAME,
-  DEFAULT_TOOLS_FILENAME,
-  DEFAULT_IDENTITY_FILENAME,
-  DEFAULT_USER_FILENAME,
-  DEFAULT_BOOTSTRAP_FILENAME,
-] as const;
-const MEMORY_FILE_NAMES = [DEFAULT_MEMORY_FILENAME, DEFAULT_MEMORY_ALT_FILENAME] as const;
+const IDENTITY_FILENAME = "IDENTITY.md";
 
-const ALLOWED_FILE_NAMES = new Set<string>([...BOOTSTRAP_FILE_NAMES, ...MEMORY_FILE_NAMES]);
-
-function resolveAgentWorkspaceFileOrRespondError(
-  params: Record<string, unknown>,
-  respond: RespondFn,
-): {
-  cfg: ReturnType<typeof loadConfig>;
-  agentId: string;
-  workspaceDir: string;
-  name: string;
-} | null {
-  const cfg = loadConfig();
-  const rawAgentId = params.agentId;
-  const agentId = resolveAgentIdOrError(
-    typeof rawAgentId === "string" || typeof rawAgentId === "number" ? String(rawAgentId) : "",
-    cfg,
+/**
+ * Resolve the editableFiles glob list for a given agent.
+ * Per-agent editableFiles override the defaults; if neither is set, returns [].
+ */
+function resolveEditableFiles(cfg: RemoteClawConfig, agentId: string): string[] {
+  const agentEntry = (cfg.agents?.list ?? []).find(
+    (e) => normalizeAgentId(e.id) === normalizeAgentId(agentId),
   );
-  if (!agentId) {
-    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown agent id"));
-    return null;
+  if (agentEntry?.editableFiles) {
+    return agentEntry.editableFiles;
   }
-  const rawName = params.name;
-  const name = (
-    typeof rawName === "string" || typeof rawName === "number" ? String(rawName) : ""
-  ).trim();
-  if (!ALLOWED_FILE_NAMES.has(name)) {
-    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, `unsupported file "${name}"`));
-    return null;
+  return cfg.agents?.defaults?.editableFiles ?? [];
+}
+
+/** Reject glob patterns with path traversal or absolute paths. */
+function isUnsafePattern(pattern: string): boolean {
+  return pattern.includes("..") || path.isAbsolute(pattern);
+}
+
+/** Check if a workspace-relative filename matches any of the allowed glob patterns. */
+function matchesEditableGlobs(name: string, globs: string[]): boolean {
+  if (globs.length === 0) {
+    return false;
   }
-  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-  return { cfg, agentId, workspaceDir, name };
+  return globs.some((glob) => path.matchesGlob(name, glob));
 }
 
 type FileMeta = {
@@ -105,54 +82,77 @@ async function statFile(filePath: string): Promise<FileMeta | null> {
   }
 }
 
-async function listAgentFiles(workspaceDir: string) {
+/**
+ * Recursively list all files under `dir`, returning workspace-relative paths.
+ * Limits depth to avoid unbounded traversal.
+ */
+async function walkDir(dir: string, base: string, maxDepth: number, depth = 0): Promise<string[]> {
+  if (depth > maxDepth) {
+    return [];
+  }
+  let entries: Array<{ name: string; isFile(): boolean; isDirectory(): boolean }>;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const result: string[] = [];
+  for (const entry of entries) {
+    const name = String(entry.name);
+    const relPath = base ? `${base}/${name}` : name;
+    if (entry.isFile()) {
+      result.push(relPath);
+    } else if (entry.isDirectory() && !name.startsWith(".")) {
+      const sub = await walkDir(path.join(dir, name), relPath, maxDepth, depth + 1);
+      result.push(...sub);
+    }
+  }
+  return result;
+}
+
+/** Compute the max directory depth implied by glob patterns. */
+function maxGlobDepth(globs: string[]): number {
+  let max = 0;
+  for (const g of globs) {
+    if (g.includes("**")) {
+      return 10; // cap for safety
+    }
+    const depth = g.split("/").length - 1;
+    if (depth > max) {
+      max = depth;
+    }
+  }
+  return Math.max(max, 0);
+}
+
+async function listAgentFiles(workspaceDir: string, globs: string[]) {
   const files: Array<{
     name: string;
     path: string;
-    missing: boolean;
-    size?: number;
-    updatedAtMs?: number;
+    size: number;
+    updatedAtMs: number;
   }> = [];
 
-  for (const name of BOOTSTRAP_FILE_NAMES) {
-    const filePath = path.join(workspaceDir, name);
+  if (globs.length === 0) {
+    return files;
+  }
+
+  const depth = maxGlobDepth(globs);
+  const allFiles = await walkDir(workspaceDir, "", depth);
+
+  for (const relPath of allFiles) {
+    if (!matchesEditableGlobs(relPath, globs)) {
+      continue;
+    }
+    const filePath = path.join(workspaceDir, relPath);
     const meta = await statFile(filePath);
     if (meta) {
       files.push({
-        name,
+        name: relPath,
         path: filePath,
-        missing: false,
         size: meta.size,
         updatedAtMs: meta.updatedAtMs,
       });
-    } else {
-      files.push({ name, path: filePath, missing: true });
-    }
-  }
-
-  const primaryMemoryPath = path.join(workspaceDir, DEFAULT_MEMORY_FILENAME);
-  const primaryMeta = await statFile(primaryMemoryPath);
-  if (primaryMeta) {
-    files.push({
-      name: DEFAULT_MEMORY_FILENAME,
-      path: primaryMemoryPath,
-      missing: false,
-      size: primaryMeta.size,
-      updatedAtMs: primaryMeta.updatedAtMs,
-    });
-  } else {
-    const altMemoryPath = path.join(workspaceDir, DEFAULT_MEMORY_ALT_FILENAME);
-    const altMeta = await statFile(altMemoryPath);
-    if (altMeta) {
-      files.push({
-        name: DEFAULT_MEMORY_ALT_FILENAME,
-        path: altMemoryPath,
-        missing: false,
-        size: altMeta.size,
-        updatedAtMs: altMeta.updatedAtMs,
-      });
-    } else {
-      files.push({ name: DEFAULT_MEMORY_FILENAME, path: primaryMemoryPath, missing: true });
     }
   }
 
@@ -270,7 +270,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     const safeName = sanitizeIdentityLine(rawName);
     const emoji = resolveOptionalStringParam(params.emoji);
     const avatar = resolveOptionalStringParam(params.avatar);
-    const identityPath = path.join(workspaceDir, DEFAULT_IDENTITY_FILENAME);
+    const identityPath = path.join(workspaceDir, IDENTITY_FILENAME);
     const lines = [
       "",
       `- Name: ${safeName}`,
@@ -335,7 +335,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     if (avatar) {
       const workspace = workspaceDir ?? resolveAgentWorkspaceDir(nextConfig, agentId);
       await fs.mkdir(workspace, { recursive: true });
-      const identityPath = path.join(workspace, DEFAULT_IDENTITY_FILENAME);
+      const identityPath = path.join(workspace, IDENTITY_FILENAME);
       await fs.appendFile(identityPath, `\n- Avatar: ${sanitizeIdentityLine(avatar)}\n`, "utf-8");
     }
 
@@ -414,8 +414,34 @@ export const agentsHandlers: GatewayRequestHandlers = {
       return;
     }
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-    const files = await listAgentFiles(workspaceDir);
-    respond(true, { agentId, workspace: workspaceDir, files }, undefined);
+    const globs = resolveEditableFiles(cfg, agentId);
+    const unsafeGlob = globs.find(isUnsafePattern);
+    if (unsafeGlob) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `editableFiles pattern "${unsafeGlob}" is unsafe (no ".." or absolute paths)`,
+        ),
+      );
+      return;
+    }
+    const files = await listAgentFiles(workspaceDir, globs);
+    respond(
+      true,
+      {
+        agentId,
+        workspace: workspaceDir,
+        files,
+        ...(globs.length === 0
+          ? {
+              hint: "configure agents.defaults.editableFiles or per-agent editableFiles to manage workspace files here",
+            }
+          : {}),
+      },
+      undefined,
+    );
   },
   "agents.files.get": async ({ params, respond }) => {
     if (!validateAgentsFilesGetParams(params)) {
@@ -431,11 +457,42 @@ export const agentsHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const resolved = resolveAgentWorkspaceFileOrRespondError(params, respond);
-    if (!resolved) {
+    const cfg = loadConfig();
+    const rawAgentId = params.agentId;
+    const agentId = resolveAgentIdOrError(
+      typeof rawAgentId === "string" || typeof rawAgentId === "number" ? String(rawAgentId) : "",
+      cfg,
+    );
+    if (!agentId) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown agent id"));
       return;
     }
-    const { agentId, workspaceDir, name } = resolved;
+    const rawName = params.name;
+    const name = (
+      typeof rawName === "string" || typeof rawName === "number" ? String(rawName) : ""
+    ).trim();
+    if (!name) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "file name is required"));
+      return;
+    }
+    if (isUnsafePattern(name)) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `unsafe file name "${name}"`),
+      );
+      return;
+    }
+    const globs = resolveEditableFiles(cfg, agentId);
+    if (!matchesEditableGlobs(name, globs)) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `file "${name}" is not in editableFiles`),
+      );
+      return;
+    }
+    const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
     const filePath = path.join(workspaceDir, name);
     const meta = await statFile(filePath);
     if (!meta) {
@@ -482,13 +539,48 @@ export const agentsHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const resolved = resolveAgentWorkspaceFileOrRespondError(params, respond);
-    if (!resolved) {
+    const cfg = loadConfig();
+    const rawAgentId = params.agentId;
+    const agentId = resolveAgentIdOrError(
+      typeof rawAgentId === "string" || typeof rawAgentId === "number" ? String(rawAgentId) : "",
+      cfg,
+    );
+    if (!agentId) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown agent id"));
       return;
     }
-    const { agentId, workspaceDir, name } = resolved;
+    const rawName = params.name;
+    const name = (
+      typeof rawName === "string" || typeof rawName === "number" ? String(rawName) : ""
+    ).trim();
+    if (!name) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "file name is required"));
+      return;
+    }
+    if (isUnsafePattern(name)) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `unsafe file name "${name}"`),
+      );
+      return;
+    }
+    const globs = resolveEditableFiles(cfg, agentId);
+    if (!matchesEditableGlobs(name, globs)) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `file "${name}" is not in editableFiles`),
+      );
+      return;
+    }
+    const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
     await fs.mkdir(workspaceDir, { recursive: true });
     const filePath = path.join(workspaceDir, name);
+    const parentDir = path.dirname(filePath);
+    if (parentDir !== workspaceDir) {
+      await fs.mkdir(parentDir, { recursive: true });
+    }
     const content = String(params.content ?? "");
     await fs.writeFile(filePath, content, "utf-8");
     const meta = await statFile(filePath);


### PR DESCRIPTION
## Summary

- Replace hardcoded 9-file whitelist (`ALLOWED_FILE_NAMES`, `BOOTSTRAP_FILE_NAMES`, `MEMORY_FILE_NAMES`) in gateway `agents.files.list/get/set` with configurable `editableFiles` glob patterns
- Add `editableFiles: string[]` config key at `agents.defaults.editableFiles` (global) and per-agent `agents.list[].editableFiles`
- Per-agent `editableFiles` overrides defaults; empty by default (no files exposed until opted in)
- Glob matching uses Node.js built-in `path.matchesGlob` (no new dependencies)
- Safety: reject patterns with `..` sequences or absolute paths
- When `editableFiles` is empty, `agents.files.list` returns empty list with config hint
- Delete 7 dead `DEFAULT_*_FILENAME` constants from `workspace.ts`; keep `DEFAULT_IDENTITY_FILENAME` and `DEFAULT_BOOTSTRAP_FILENAME` (still used by other modules)
- Simplify `ensureAgentWorkspace` (remove unused path return values)

Closes #259

## Test plan

- [x] `agents.files.list` returns empty list with hint when `editableFiles` is `[]`
- [x] `agents.files.list` returns only files matching configured globs
- [x] Per-agent `editableFiles` overrides defaults
- [x] `agents.files.list` rejects unsafe glob patterns (`..`, absolute paths)
- [x] `agents.files.get` rejects files not matching any glob
- [x] `agents.files.get` returns content for matching files
- [x] `agents.files.get` returns `missing: true` for non-existent matching files
- [x] `agents.files.set` rejects files not matching any glob
- [x] `agents.files.set` writes content for matching files
- [x] `agents.files.set` rejects file names with path traversal
- [x] `grep -ri "ALLOWED_FILE_NAMES\|BOOTSTRAP_FILE_NAMES\|MEMORY_FILE_NAMES" src/` returns zero hits
- [x] Build passes, type-check clean, lint clean
- [x] All existing tests pass (pre-existing cron test flake unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)