### PR TITLE
Simplify ensureAgentWorkspace() to mkdir wrapper (#263)

### DIFF
--- a/extensions/voice-call/src/core-bridge.ts
+++ b/extensions/voice-call/src/core-bridge.ts
@@ -65,7 +65,7 @@ type CoreAgentDeps = {
     cfg: CoreConfig,
     agentId: string,
   ) => { name?: string | null } | null | undefined;
-  ensureAgentWorkspace: (params?: { dir: string }) => Promise<void>;
+  ensureAgentWorkspace: (dir: string) => Promise<string>;
   resolveStorePath: (store?: string, opts?: { agentId?: string }) => string;
   loadSessionStore: (storePath: string) => Record<string, unknown>;
   saveSessionStore: (storePath: string, store: Record<string, unknown>) => Promise<void>;

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -64,7 +64,7 @@ export async function generateVoiceResponse(
   // Resolve workspace
   const agentId = "main";
   const workspaceDir = deps.resolveAgentWorkspaceDir(cfg, agentId);
-  await deps.ensureAgentWorkspace({ dir: workspaceDir });
+  await deps.ensureAgentWorkspace(workspaceDir);
 
   // Load or create session entry (legacy store for backward compatibility)
   const normalizedPhone = from.replace(/\D/g, "");

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -1,8 +1,5 @@
 import fs from "node:fs/promises";
 
-export const DEFAULT_AGENTS_FILENAME = "AGENTS.md";
-export const DEFAULT_SOUL_FILENAME = "SOUL.md";
-export const DEFAULT_TOOLS_FILENAME = "TOOLS.md";
 export const DEFAULT_IDENTITY_FILENAME = "IDENTITY.md";
 export const DEFAULT_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
 

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
   applyAgentConfig: vi.fn((_cfg: unknown, _opts: unknown) => ({})),
   pruneAgentConfig: vi.fn(() => ({ config: {}, removedBindings: 0 })),
   writeConfigFile: vi.fn(async () => {}),
-  ensureAgentWorkspace: vi.fn(async () => {}),
+  ensureAgentWorkspace: vi.fn(async (dir: string) => dir),
   resolveAgentDir: vi.fn(() => "/agents/test-agent"),
   resolveAgentWorkspaceDir: vi.fn(() => "/workspace/test-agent"),
   resolveSessionTranscriptsDirForAgent: vi.fn(() => "/transcripts/test-agent"),
@@ -177,8 +177,9 @@ describe("agents.create", () => {
 
   it("ensures workspace is set up before writing config", async () => {
     const callOrder: string[] = [];
-    mocks.ensureAgentWorkspace.mockImplementation(async () => {
+    mocks.ensureAgentWorkspace.mockImplementation(async (dir: string) => {
       callOrder.push("ensureAgentWorkspace");
+      return dir;
     });
     mocks.writeConfigFile.mockImplementation(async () => {
       callOrder.push("writeConfigFile");


### PR DESCRIPTION
## Summary

Closes #263. The blocking issues (#255, #256, #257, #258) are all resolved — `ensureAgentWorkspace()` was already simplified to `(dir: string) => Promise<string>` and all 6 internal callers updated. This PR cleans up the remaining artifacts:

- **Remove dead constants** from `workspace.ts`: `DEFAULT_AGENTS_FILENAME`, `DEFAULT_SOUL_FILENAME`, `DEFAULT_TOOLS_FILENAME` (unused since template/seeding removal)
- **Update voice-call extension** type and call site to match the new signature (`(dir: string) => Promise<string>` instead of `(params?: { dir: string }) => Promise<void>`)
- **Fix test mock** return types in `agents-mutate.test.ts` to return `dir` string instead of void

The still-used constants (`DEFAULT_IDENTITY_FILENAME`, `DEFAULT_BOOTSTRAP_FILENAME`) are preserved.

## Test plan

- [x] `pnpm check` passes (format + typecheck + lint)
- [x] `pnpm build` succeeds
- [x] `workspace.test.ts` passes (1 test)
- [x] `agents-mutate.test.ts` passes (26 tests)
- [x] Pre-existing `mcp-tools.test.ts` failures confirmed on main (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)