### PR TITLE
Delete dead workspace constants and phantom gateway method entry (#283)

### DIFF
--- a/src/agents/identity-file.ts
+++ b/src/agents/identity-file.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import path from "node:path";
-import { DEFAULT_IDENTITY_FILENAME } from "./workspace.js";
 
 export type AgentIdentityFile = {
   name?: string;
@@ -102,6 +101,6 @@ export function loadIdentityFromFile(identityPath: string): AgentIdentityFile | 
 }
 
 export function loadAgentIdentityFromWorkspace(workspace: string): AgentIdentityFile | null {
-  const identityPath = path.join(workspace, DEFAULT_IDENTITY_FILENAME);
+  const identityPath = path.join(workspace, "IDENTITY.md");
   return loadIdentityFromFile(identityPath);
 }

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -1,8 +1,5 @@
 import fs from "node:fs/promises";
 
-export const DEFAULT_IDENTITY_FILENAME = "IDENTITY.md";
-export const DEFAULT_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
-
 export async function ensureAgentWorkspace(dir: string): Promise<string> {
   await fs.mkdir(dir, { recursive: true });
   return dir;

--- a/src/commands/agents.commands.identity.ts
+++ b/src/commands/agents.commands.identity.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { identityHasValues, parseIdentityMarkdown } from "../agents/identity-file.js";
-import { DEFAULT_IDENTITY_FILENAME } from "../agents/workspace.js";
 import { writeConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import type { IdentityConfig } from "../config/types.js";
@@ -131,8 +130,7 @@ export async function agentsSetIdentityCommand(
     }
     if (!identityFromFile) {
       const targetPath =
-        identityFilePath ??
-        (workspaceDir ? path.join(workspaceDir, DEFAULT_IDENTITY_FILENAME) : "IDENTITY.md");
+        identityFilePath ?? (workspaceDir ? path.join(workspaceDir, "IDENTITY.md") : "IDENTITY.md");
       runtime.error(`No identity data found in ${shortenHomePath(targetPath)}.`);
       runtime.exit(1);
       return;

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -43,7 +43,6 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
   ],
   [READ_SCOPE]: [
     "health",
-    "doctor.memory.status",
     "logs.tail",
     "channels.status",
     "status",

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createWizardPrompter as buildWizardPrompter } from "../../test/helpers/wizard-prompter.js";
-import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { runOnboardingWizard } from "./onboarding.js";
 import type { WizardPrompter, WizardSelectParams } from "./prompts.js";
@@ -42,7 +41,7 @@ const finalizeOnboardingWizard = vi.hoisted(() =>
 
     let message: string | undefined;
     try {
-      await fs.stat(path.join(options.workspaceDir, DEFAULT_BOOTSTRAP_FILENAME));
+      await fs.stat(path.join(options.workspaceDir, "BOOTSTRAP.md"));
       message = "Wake up, my friend!";
     } catch {
       message = undefined;
@@ -281,7 +280,7 @@ describe("runOnboardingWizard", () => {
 
     const workspaceDir = await makeCaseDir("workspace-");
     if (params.writeBootstrapFile) {
-      await fs.writeFile(path.join(workspaceDir, DEFAULT_BOOTSTRAP_FILENAME), "{}");
+      await fs.writeFile(path.join(workspaceDir, "BOOTSTRAP.md"), "{}");
     }
 
     const select = vi.fn(async (opts: WizardSelectParams<unknown>) => {


### PR DESCRIPTION
## Summary

- Delete `DEFAULT_IDENTITY_FILENAME` and `DEFAULT_BOOTSTRAP_FILENAME` from `src/agents/workspace.ts`, inlining string literals at all call sites (`identity-file.ts`, `agents.commands.identity.ts`, `onboarding.test.ts`)
- Remove phantom `"doctor.memory.status"` entry from `src/gateway/method-scopes.ts` (implementation was deleted when memory subsystem was gutted)

Closes #283

## Test plan

- [x] `pnpm tsgo` — type-check passes
- [x] `vitest --run src/wizard/onboarding.test.ts` — 5/5 pass
- [x] `vitest --run src/gateway/method-scopes.test.ts` — 7/7 pass
- [x] Pre-commit hooks pass (oxfmt, oxlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)