### PR TITLE
Remove HEARTBEAT_PROMPT fallback — heartbeat must be explicitly configured (#281)

### DIFF
--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -1,11 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-// Default heartbeat prompt (used when config.agents.defaults.heartbeat.prompt is unset).
-// Keep it tight and avoid encouraging the model to invent/rehash "open loops" from prior chat context.
-export const HEARTBEAT_PROMPT =
-  "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats.";
-
 /** Non-configurable suffix appended by the middleware to every heartbeat prompt. */
 export const HEARTBEAT_TOOL_SUFFIX = " Report the result using the heartbeat_report tool.";
 

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -25,8 +25,7 @@ export async function prependSystemEvents(params: {
     if (lower.includes("reason periodic")) {
       return null;
     }
-    // Filter out the actual heartbeat prompt, but not cron jobs that mention "heartbeat"
-    // The heartbeat prompt starts with "Read HEARTBEAT.md" - cron payloads won't match this
+    // Filter out legacy heartbeat prompts that started with "Read HEARTBEAT.md"
     if (lower.startsWith("read heartbeat.md")) {
       return null;
     }

--- a/src/channel-web.ts
+++ b/src/channel-web.ts
@@ -2,7 +2,6 @@
 // module keeps responsibilities small and testable.
 export {
   DEFAULT_WEB_MEDIA_BYTES,
-  HEARTBEAT_PROMPT,
   monitorWebChannel,
   resolveHeartbeatRecipients,
   runWebHeartbeatOnce,

--- a/src/web/auto-reply.impl.ts
+++ b/src/web/auto-reply.impl.ts
@@ -1,4 +1,3 @@
-export { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
 export { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 
 export { DEFAULT_WEB_MEDIA_BYTES } from "./auto-reply/constants.js";


### PR DESCRIPTION
## Summary

- Delete the `HEARTBEAT_PROMPT` constant from `src/auto-reply/heartbeat.ts` and its dead re-export chain (`auto-reply.impl.ts`, `channel-web.ts`)
- Update stale comment in `session-updates.ts` that referenced the old Pi-era "Read HEARTBEAT.md" prompt
- No behavioral change: `resolveHeartbeatPrompt()` already returns `""` when neither `prompt` nor `file` is configured, causing heartbeat to be skipped

Closes #281

## Test plan

- [x] Type-check passes (`npx tsgo` — no errors in `src/`)
- [x] `src/auto-reply/heartbeat.test.ts` — all 7 tests pass, including "returns empty string when neither prompt nor file is set"
- [x] No remaining references to `HEARTBEAT_PROMPT` in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)