### PR TITLE
Fix checkRemoteClawMigration bug (identical paths) (#293)

### DIFF
--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  checkRemoteClawMigration,
   rewriteUpdateFlagArgv,
   shouldEnsureCliPath,
   shouldRegisterPrimarySubcommand,
@@ -123,5 +125,57 @@ describe("shouldEnsureCliPath", () => {
     expect(shouldEnsureCliPath(["node", "remoteclaw", "message", "send"])).toBe(true);
     expect(shouldEnsureCliPath(["node", "remoteclaw", "voicecall", "status"])).toBe(true);
     expect(shouldEnsureCliPath(["node", "remoteclaw", "acp", "-v"])).toBe(true);
+  });
+});
+
+describe("checkRemoteClawMigration", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("warns when ~/.openclaw exists but ~/.remoteclaw does not", () => {
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+      if (String(p).endsWith("/.remoteclaw")) {
+        return false;
+      }
+      if (String(p).endsWith("/.openclaw")) {
+        return true;
+      }
+      return false;
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    checkRemoteClawMigration({ HOME: "/mock-home" });
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0][0]).toContain("remoteclaw import");
+  });
+
+  it("does not warn when ~/.remoteclaw already exists", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    checkRemoteClawMigration({ HOME: "/mock-home" });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when neither directory exists", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    checkRemoteClawMigration({ HOME: "/mock-home" });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips migration check when REMOTECLAW_STATE_DIR is set", () => {
+    const existsSpy = vi.spyOn(fs, "existsSync");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    checkRemoteClawMigration({ HOME: "/mock-home", REMOTECLAW_STATE_DIR: "/custom/state" });
+
+    expect(existsSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -67,7 +67,7 @@ export function shouldEnsureCliPath(argv: string[]): boolean {
 
 /**
  * Detect an existing RemoteClaw installation and display a one-time migration notice.
- * Only triggers when ~/.remoteclaw is absent but ~/.remoteclaw exists.
+ * Only triggers when ~/.remoteclaw is absent but ~/.openclaw exists.
  * Does not block startup — purely informational.
  */
 export function checkRemoteClawMigration(env: NodeJS.ProcessEnv = process.env): void {
@@ -79,7 +79,7 @@ export function checkRemoteClawMigration(env: NodeJS.ProcessEnv = process.env): 
   try {
     const home = resolveRequiredHomeDir(env, os.homedir);
     const newDir = path.join(home, ".remoteclaw");
-    const oldDir = path.join(home, ".remoteclaw");
+    const oldDir = path.join(home, ".openclaw");
 
     if (!fs.existsSync(newDir) && fs.existsSync(oldDir)) {
       console.warn(


### PR DESCRIPTION
## Summary

- Fix `checkRemoteClawMigration()` where both `newDir` and `oldDir` resolved to `~/.remoteclaw`, making migration detection permanently non-functional
- Correct `oldDir` to `path.join(home, ".openclaw")` so the condition `!existsSync(newDir) && existsSync(oldDir)` can actually trigger
- Fix JSDoc comment that also had the duplicated path
- Add 4 unit tests covering: migration warning fires, both dirs exist, neither exists, env override skip

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm vitest run src/cli/run-main.test.ts` — 18 tests pass (14 existing + 4 new)
- [x] `pnpm test` — all failures are pre-existing (`mcp-tools.test.ts` tool count mismatch, present on main)

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)