### PR TITLE
Remove TTS dead code: summarizeText stub, unwired hint, stale mock (#295)

### DIFF
--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -1,6 +1,5 @@
 import { rmSync } from "node:fs";
 import { EdgeTTS } from "node-edge-tts";
-import type { RemoteClawConfig } from "../config/config.js";
 import type {
   ResolvedTtsConfig,
   ResolvedTtsModelOverrides,
@@ -368,28 +367,6 @@ export function isValidOpenAIVoice(voice: string): voice is OpenAiTtsVoice {
     return true;
   }
   return OPENAI_TTS_VOICES.includes(voice as OpenAiTtsVoice);
-}
-
-type SummarizeResult = {
-  summary: string;
-  latencyMs: number;
-  inputLength: number;
-  outputLength: number;
-};
-
-/**
- * Stub: embedded model resolver was removed (#74).
- * TTS summarisation requires `completeSimple` from pi-ai with a resolved
- * model object, which is no longer available.
- */
-export async function summarizeText(_params: {
-  text: string;
-  targetLength: number;
-  cfg: RemoteClawConfig;
-  config: ResolvedTtsConfig;
-  timeoutMs: number;
-}): Promise<SummarizeResult> {
-  throw new Error("TTS summarisation unavailable: embedded model resolver removed (#74).");
 }
 
 export function scheduleCleanup(

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -1,16 +1,7 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { RemoteClawConfig } from "../config/config.js";
 import { withEnv } from "../test-utils/env.js";
 import * as tts from "./tts.js";
-
-vi.mock("../agents/model-auth.js", () => ({
-  getApiKeyForModel: vi.fn(async () => ({
-    apiKey: "test-api-key",
-    source: "test",
-    mode: "api-key",
-  })),
-  requireApiKey: vi.fn((auth: { apiKey?: string }) => auth.apiKey ?? ""),
-}));
 
 const { _test, resolveTtsConfig, maybeApplyTtsToPayload, getTtsProvider } = tts;
 
@@ -22,16 +13,11 @@ const {
   OPENAI_TTS_VOICES,
   parseTtsDirectives,
   resolveModelOverridePolicy,
-  summarizeText,
   resolveOutputFormat,
   resolveEdgeOutputFormat,
 } = _test;
 
 describe("tts", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   describe("isValidVoiceId", () => {
     it("validates ElevenLabs voice ID length and character rules", () => {
       const cases = [
@@ -203,26 +189,6 @@ describe("tts", () => {
 
       expect(result.cleanedText).toBe(input);
       expect(result.overrides.provider).toBeUndefined();
-    });
-  });
-
-  describe("summarizeText", () => {
-    const baseCfg: RemoteClawConfig = {
-      agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
-      messages: { tts: {} },
-    };
-    const baseConfig = resolveTtsConfig(baseCfg);
-
-    it("throws because embedded model resolver was removed", async () => {
-      await expect(
-        summarizeText({
-          text: "A".repeat(2000),
-          targetLength: 1500,
-          cfg: baseCfg,
-          config: baseConfig,
-          timeoutMs: 30_000,
-        }),
-      ).rejects.toThrow("TTS summarisation unavailable: embedded model resolver removed (#74).");
     });
   });
 

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -38,7 +38,6 @@ import {
   openaiTTS,
   parseTtsDirectives,
   scheduleCleanup,
-  summarizeText,
 } from "./tts-core.js";
 export { OPENAI_TTS_MODELS, OPENAI_TTS_VOICES } from "./tts-core.js";
 
@@ -345,31 +344,6 @@ export function resolveTtsAutoMode(params: {
     return prefsAuto;
   }
   return params.config.auto;
-}
-
-export function buildTtsSystemPromptHint(cfg: RemoteClawConfig): string | undefined {
-  const config = resolveTtsConfig(cfg);
-  const prefsPath = resolveTtsPrefsPath(config);
-  const autoMode = resolveTtsAutoMode({ config, prefsPath });
-  if (autoMode === "off") {
-    return undefined;
-  }
-  const maxLength = getTtsMaxLength(prefsPath);
-  const summarize = isSummarizationEnabled(prefsPath) ? "on" : "off";
-  const autoHint =
-    autoMode === "inbound"
-      ? "Only use TTS when the user's last message includes audio/voice."
-      : autoMode === "tagged"
-        ? "Only use TTS when you include [[tts]] or [[tts:text]] tags."
-        : undefined;
-  return [
-    "Voice (TTS) is enabled.",
-    autoHint,
-    `Keep spoken text ≤${maxLength} chars to avoid auto-summary (summary ${summarize}).`,
-    "Use [[tts:...]] and optional [[tts:text]]...[[/tts:text]] to control voice/expressiveness.",
-  ]
-    .filter(Boolean)
-    .join("\n");
 }
 
 function readPrefs(prefsPath: string): TtsUserPrefs {
@@ -853,37 +827,10 @@ export async function maybeApplyTtsToPayload(params: {
 
   const maxLength = getTtsMaxLength(prefsPath);
   let textForAudio = ttsText.trim();
-  let wasSummarized = false;
 
   if (textForAudio.length > maxLength) {
-    if (!isSummarizationEnabled(prefsPath)) {
-      logVerbose(
-        `TTS: truncating long text (${textForAudio.length} > ${maxLength}), summarization disabled.`,
-      );
-      textForAudio = `${textForAudio.slice(0, maxLength - 3)}...`;
-    } else {
-      try {
-        const summary = await summarizeText({
-          text: textForAudio,
-          targetLength: maxLength,
-          cfg: params.cfg,
-          config,
-          timeoutMs: config.timeoutMs,
-        });
-        textForAudio = summary.summary;
-        wasSummarized = true;
-        if (textForAudio.length > config.maxTextLength) {
-          logVerbose(
-            `TTS: summary exceeded hard limit (${textForAudio.length} > ${config.maxTextLength}); truncating.`,
-          );
-          textForAudio = `${textForAudio.slice(0, config.maxTextLength - 3)}...`;
-        }
-      } catch (err) {
-        const error = err as Error;
-        logVerbose(`TTS: summarization failed, truncating instead: ${error.message}`);
-        textForAudio = `${textForAudio.slice(0, maxLength - 3)}...`;
-      }
-    }
+    logVerbose(`TTS: truncating long text (${textForAudio.length} > ${maxLength}).`);
+    textForAudio = `${textForAudio.slice(0, maxLength - 3)}...`;
   }
 
   textForAudio = stripMarkdown(textForAudio).trim(); // strip markdown for TTS (### → "hashtag" etc.)
@@ -905,7 +852,7 @@ export async function maybeApplyTtsToPayload(params: {
       timestamp: Date.now(),
       success: true,
       textLength: text.length,
-      summarized: wasSummarized,
+      summarized: false,
       provider: result.provider,
       latencyMs: result.latencyMs,
     };
@@ -924,7 +871,7 @@ export async function maybeApplyTtsToPayload(params: {
     timestamp: Date.now(),
     success: false,
     textLength: text.length,
-    summarized: wasSummarized,
+    summarized: false,
     error: result.error,
   };
 
@@ -941,7 +888,6 @@ export const _test = {
   OPENAI_TTS_VOICES,
   parseTtsDirectives,
   resolveModelOverridePolicy,
-  summarizeText,
   resolveOutputFormat,
   resolveEdgeOutputFormat,
 };


### PR DESCRIPTION
## Summary

- Delete `summarizeText()` always-throw stub from `tts-core.ts` and its unused `SummarizeResult` type
- Simplify `maybeApplyTtsToPayload()` to truncation-only (was try-summarize → catch-truncate)
- Delete `buildTtsSystemPromptHint()` — exported but zero callers
- Remove inert `model-auth.js` mock from `tts.test.ts` (module was renamed to `provider-auth.ts`)

Closes #295

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` (format + typecheck + lint) passes
- [x] `pnpm vitest run src/tts/tts.test.ts` — all 14 tests pass
- [x] Full `pnpm test` — TTS tests green; pre-existing `mcp-tools.test.ts` failures unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)