### PR TITLE
Remove dead tool-display entries in native apps (bash, process) (#297)

### DIFF
--- a/apps/shared/RemoteClawKit/Sources/RemoteClawKit/Resources/tool-display.json
+++ b/apps/shared/RemoteClawKit/Sources/RemoteClawKit/Resources/tool-display.json
@@ -25,16 +25,6 @@
     ]
   },
   "tools": {
-    "bash": {
-      "emoji": "🛠️",
-      "title": "Bash",
-      "detailKeys": ["command"]
-    },
-    "process": {
-      "emoji": "🧰",
-      "title": "Process",
-      "detailKeys": ["sessionId"]
-    },
     "read": {
       "emoji": "📖",
       "title": "Read",

--- a/apps/shared/RemoteClawKit/Sources/RemoteClawKit/ToolDisplay.swift
+++ b/apps/shared/RemoteClawKit/Sources/RemoteClawKit/ToolDisplay.swift
@@ -131,12 +131,6 @@ public enum ToolDisplayRegistry {
                 ],
                 actions: nil),
             tools: [
-                "bash": ToolDisplaySpec(
-                    emoji: "🛠️",
-                    title: "Bash",
-                    label: nil,
-                    detailKeys: ["command"],
-                    actions: nil),
                 "read": ToolDisplaySpec(
                     emoji: "📖",
                     title: "Read",
@@ -160,12 +154,6 @@ public enum ToolDisplayRegistry {
                     title: "Attach",
                     label: nil,
                     detailKeys: ["path", "url", "fileName"],
-                    actions: nil),
-                "process": ToolDisplaySpec(
-                    emoji: "🧰",
-                    title: "Process",
-                    label: nil,
-                    detailKeys: ["sessionId"],
                     actions: nil),
             ])
     }

--- a/apps/shared/RemoteClawKit/Tests/RemoteClawKitTests/ToolDisplayRegistryTests.swift
+++ b/apps/shared/RemoteClawKit/Tests/RemoteClawKitTests/ToolDisplayRegistryTests.swift
@@ -9,8 +9,8 @@ import Testing
     }
 
     @Test func resolvesKnownToolFromConfig() {
-        let summary = ToolDisplayRegistry.resolve(name: "bash", args: nil)
-        #expect(summary.emoji == "🛠️")
-        #expect(summary.title == "Bash")
+        let summary = ToolDisplayRegistry.resolve(name: "read", args: nil)
+        #expect(summary.emoji == "📖")
+        #expect(summary.title == "Read")
     }
 }


### PR DESCRIPTION
## Summary

- Remove dead `bash` and `process` entries from `apps/shared/RemoteClawKit/Sources/RemoteClawKit/Resources/tool-display.json`
- Remove matching entries from the compiled-in `defaultConfig()` fallback in `ToolDisplay.swift`
- Update `ToolDisplayRegistryTests` to assert against a live tool (`read`) instead of the removed `bash`

Neither tool will ever match an active tool call — bash execution is handled natively by CLI agents, and the process tool was removed from the MCP catalog. The native app gracefully handles unknown tools with a fallback display.

Closes #297

## Test plan

- [x] JSON validates correctly
- [x] `pnpm check` passes (format, typecheck, lint)
- [x] `pnpm test` — no new failures (pre-existing failures unrelated to this change)
- [ ] CI build + test jobs pass
- [ ] Native app builds pass (Swift compilation verifies `defaultConfig()` and test changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)