### PR TITLE
Remove dead describeImageWithModel stub and provider-based image path (#294)

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -670,24 +670,21 @@ describe("applyMediaUnderstanding", () => {
     );
   });
 
-  it("orders mixed media outputs as image, audio, video", async () => {
+  it("orders mixed media outputs as audio, video", async () => {
     const dir = await createTempMediaDir();
-    const imagePath = path.join(dir, "photo.jpg");
     const audioPath = path.join(dir, "note.ogg");
     const videoPath = path.join(dir, "clip.mp4");
-    await fs.writeFile(imagePath, "image-bytes");
     await fs.writeFile(audioPath, Buffer.from([200, 201, 202, 203, 204, 205, 206, 207, 208]));
     await fs.writeFile(videoPath, "video-bytes");
 
     const ctx: MsgContext = {
       Body: "<media:mixed>",
-      MediaPaths: [imagePath, audioPath, videoPath],
-      MediaTypes: ["image/jpeg", "audio/ogg", "video/mp4"],
+      MediaPaths: [audioPath, videoPath],
+      MediaTypes: ["audio/ogg", "video/mp4"],
     };
     const cfg: RemoteClawConfig = {
       tools: {
         media: {
-          image: { enabled: true, models: [{ provider: "openai", model: "gpt-5.2" }] },
           audio: { enabled: true, models: [{ provider: "groq" }] },
           video: { enabled: true, models: [{ provider: "google", model: "gemini-3" }] },
         },
@@ -699,10 +696,6 @@ describe("applyMediaUnderstanding", () => {
       cfg,
       agentDir: dir,
       providers: {
-        openai: {
-          id: "openai",
-          describeImage: async () => ({ text: "image ok" }),
-        },
         groq: {
           id: "groq",
           transcribeAudio: async () => ({ text: "audio ok" }),
@@ -714,15 +707,10 @@ describe("applyMediaUnderstanding", () => {
       },
     });
 
-    expect(result.appliedImage).toBe(true);
     expect(result.appliedAudio).toBe(true);
     expect(result.appliedVideo).toBe(true);
     expect(ctx.Body).toBe(
-      [
-        "[Image]\nDescription:\nimage ok",
-        "[Audio]\nTranscript:\naudio ok",
-        "[Video]\nDescription:\nvideo ok",
-      ].join("\n\n"),
+      ["[Audio]\nTranscript:\naudio ok", "[Video]\nDescription:\nvideo ok"].join("\n\n"),
     );
     expect(ctx.Transcript).toBe("audio ok");
     expect(ctx.CommandBody).toBe("audio ok");

--- a/src/media-understanding/defaults.ts
+++ b/src/media-understanding/defaults.ts
@@ -41,20 +41,6 @@ export const AUTO_AUDIO_KEY_PROVIDERS = [
   "google",
   "mistral",
 ] as const;
-export const AUTO_IMAGE_KEY_PROVIDERS = [
-  "openai",
-  "anthropic",
-  "google",
-  "minimax",
-  "zai",
-] as const;
 export const AUTO_VIDEO_KEY_PROVIDERS = ["google", "moonshot"] as const;
-export const DEFAULT_IMAGE_MODELS: Record<string, string> = {
-  openai: "gpt-5-mini",
-  anthropic: "claude-opus-4-6",
-  google: "gemini-3-flash-preview",
-  minimax: "MiniMax-VL-01",
-  zai: "glm-4.6v",
-};
 export const CLI_OUTPUT_MAX_BUFFER = 5 * MB;
 export const DEFAULT_MEDIA_CONCURRENCY = 2;

--- a/src/media-understanding/providers/anthropic/index.ts
+++ b/src/media-understanding/providers/anthropic/index.ts
@@ -1,8 +1,5 @@
 import type { MediaUnderstandingProvider } from "../../types.js";
-import { describeImageWithModel } from "../image.js";
 
 export const anthropicProvider: MediaUnderstandingProvider = {
   id: "anthropic",
-  capabilities: ["image"],
-  describeImage: describeImageWithModel,
 };

--- a/src/media-understanding/providers/google/index.ts
+++ b/src/media-understanding/providers/google/index.ts
@@ -1,12 +1,10 @@
 import type { MediaUnderstandingProvider } from "../../types.js";
-import { describeImageWithModel } from "../image.js";
 import { transcribeGeminiAudio } from "./audio.js";
 import { describeGeminiVideo } from "./video.js";
 
 export const googleProvider: MediaUnderstandingProvider = {
   id: "google",
-  capabilities: ["image", "audio", "video"],
-  describeImage: describeImageWithModel,
+  capabilities: ["audio", "video"],
   transcribeAudio: transcribeGeminiAudio,
   describeVideo: describeGeminiVideo,
 };

--- a/src/media-understanding/providers/image.ts
+++ b/src/media-understanding/providers/image.ts
@@ -1,9 +1,0 @@
-import type { ImageDescriptionRequest, ImageDescriptionResult } from "../types.js";
-
-export async function describeImageWithModel(
-  params: ImageDescriptionRequest,
-): Promise<ImageDescriptionResult> {
-  throw new Error(
-    `describeImageWithModel is not available: model discovery has been removed (${params.provider}/${params.model})`,
-  );
-}

--- a/src/media-understanding/providers/index.test.ts
+++ b/src/media-understanding/providers/index.test.ts
@@ -22,6 +22,6 @@ describe("media-understanding provider registry", () => {
     const provider = getMediaUnderstandingProvider("moonshot", registry);
 
     expect(provider?.id).toBe("moonshot");
-    expect(provider?.capabilities).toEqual(["image", "video"]);
+    expect(provider?.capabilities).toEqual(["video"]);
   });
 });

--- a/src/media-understanding/providers/minimax/index.ts
+++ b/src/media-understanding/providers/minimax/index.ts
@@ -1,8 +1,5 @@
 import type { MediaUnderstandingProvider } from "../../types.js";
-import { describeImageWithModel } from "../image.js";
 
 export const minimaxProvider: MediaUnderstandingProvider = {
   id: "minimax",
-  capabilities: ["image"],
-  describeImage: describeImageWithModel,
 };

--- a/src/media-understanding/providers/moonshot/index.ts
+++ b/src/media-understanding/providers/moonshot/index.ts
@@ -1,10 +1,8 @@
 import type { MediaUnderstandingProvider } from "../../types.js";
-import { describeImageWithModel } from "../image.js";
 import { describeMoonshotVideo } from "./video.js";
 
 export const moonshotProvider: MediaUnderstandingProvider = {
   id: "moonshot",
-  capabilities: ["image", "video"],
-  describeImage: describeImageWithModel,
+  capabilities: ["video"],
   describeVideo: describeMoonshotVideo,
 };

--- a/src/media-understanding/providers/openai/index.ts
+++ b/src/media-understanding/providers/openai/index.ts
@@ -1,10 +1,7 @@
 import type { MediaUnderstandingProvider } from "../../types.js";
-import { describeImageWithModel } from "../image.js";
 import { transcribeOpenAiCompatibleAudio } from "./audio.js";
 
 export const openaiProvider: MediaUnderstandingProvider = {
   id: "openai",
-  capabilities: ["image"],
-  describeImage: describeImageWithModel,
   transcribeAudio: transcribeOpenAiCompatibleAudio,
 };

--- a/src/media-understanding/providers/zai/index.ts
+++ b/src/media-understanding/providers/zai/index.ts
@@ -1,8 +1,5 @@
 import type { MediaUnderstandingProvider } from "../../types.js";
-import { describeImageWithModel } from "../image.js";
 
 export const zaiProvider: MediaUnderstandingProvider = {
   id: "zai",
-  capabilities: ["image"],
-  describeImage: describeImageWithModel,
 };

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -24,7 +24,6 @@ import {
 import { MediaUnderstandingSkipError } from "./errors.js";
 import { fileExists } from "./fs.js";
 import { extractGeminiResponse } from "./output-extract.js";
-import { describeImageWithModel } from "./providers/image.js";
 import { getMediaUnderstandingProvider, normalizeMediaProviderId } from "./providers/index.js";
 import { resolveMaxBytes, resolveMaxChars, resolvePrompt, resolveTimeoutMs } from "./resolve.js";
 import type {
@@ -383,56 +382,6 @@ export async function runProviderEntry(params: {
     cfg,
     config: params.config,
   });
-
-  if (capability === "image") {
-    if (!params.agentDir) {
-      throw new Error("Image understanding requires agentDir");
-    }
-    const modelId = entry.model?.trim();
-    if (!modelId) {
-      throw new Error("Image understanding requires model id");
-    }
-    const media = await params.cache.getBuffer({
-      attachmentIndex: params.attachmentIndex,
-      maxBytes,
-      timeoutMs,
-    });
-    const provider = getMediaUnderstandingProvider(providerId, params.providerRegistry);
-    const result = provider?.describeImage
-      ? await provider.describeImage({
-          buffer: media.buffer,
-          fileName: media.fileName,
-          mime: media.mime,
-          model: modelId,
-          provider: providerId,
-          prompt,
-          timeoutMs,
-          profile: entry.profile,
-          preferredProfile: entry.preferredProfile,
-          agentDir: params.agentDir,
-          cfg: params.cfg,
-        })
-      : await describeImageWithModel({
-          buffer: media.buffer,
-          fileName: media.fileName,
-          mime: media.mime,
-          model: modelId,
-          provider: providerId,
-          prompt,
-          timeoutMs,
-          profile: entry.profile,
-          preferredProfile: entry.preferredProfile,
-          agentDir: params.agentDir,
-          cfg: params.cfg,
-        });
-    return {
-      kind: "image.description",
-      attachmentIndex: params.attachmentIndex,
-      text: trimOutput(result.text, maxChars),
-      provider: providerId,
-      model: result.model ?? modelId,
-    };
-  }
 
   const provider = getMediaUnderstandingProvider(providerId, params.providerRegistry);
   if (!provider) {

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -5,10 +5,6 @@ import path from "node:path";
 import { resolveApiKeyForProvider } from "../agents/provider-auth.js";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { RemoteClawConfig } from "../config/config.js";
-import {
-  resolveAgentModelFallbackValues,
-  resolveAgentModelPrimaryValue,
-} from "../config/model-input.js";
 import type {
   MediaUnderstandingConfig,
   MediaUnderstandingModelConfig,
@@ -26,12 +22,7 @@ import {
   normalizeAttachments,
   selectAttachments,
 } from "./attachments.js";
-import {
-  AUTO_AUDIO_KEY_PROVIDERS,
-  AUTO_IMAGE_KEY_PROVIDERS,
-  AUTO_VIDEO_KEY_PROVIDERS,
-  DEFAULT_IMAGE_MODELS,
-} from "./defaults.js";
+import { AUTO_AUDIO_KEY_PROVIDERS, AUTO_VIDEO_KEY_PROVIDERS } from "./defaults.js";
 import { isMediaUnderstandingSkipError } from "./errors.js";
 import { fileExists } from "./fs.js";
 import { extractGeminiResponse } from "./output-extract.js";
@@ -351,9 +342,6 @@ async function resolveKeyEntry(params: {
     if (capability === "audio" && !provider.transcribeAudio) {
       return null;
     }
-    if (capability === "image" && !provider.describeImage) {
-      return null;
-    }
     if (capability === "video" && !provider.describeVideo) {
       return null;
     }
@@ -364,24 +352,6 @@ async function resolveKeyEntry(params: {
       return null;
     }
   };
-
-  if (capability === "image") {
-    const activeProvider = params.activeModel?.provider?.trim();
-    if (activeProvider) {
-      const activeEntry = await checkProvider(activeProvider, params.activeModel?.model);
-      if (activeEntry) {
-        return activeEntry;
-      }
-    }
-    for (const providerId of AUTO_IMAGE_KEY_PROVIDERS) {
-      const model = DEFAULT_IMAGE_MODELS[providerId];
-      const entry = await checkProvider(providerId, model);
-      if (entry) {
-        return entry;
-      }
-    }
-    return null;
-  }
 
   if (capability === "video") {
     const activeProvider = params.activeModel?.provider?.trim();
@@ -416,37 +386,6 @@ async function resolveKeyEntry(params: {
   return null;
 }
 
-function resolveImageModelFromAgentDefaults(
-  cfg: RemoteClawConfig,
-): MediaUnderstandingModelConfig[] {
-  const refs: string[] = [];
-  const primary = resolveAgentModelPrimaryValue(cfg.agents?.defaults?.imageModel);
-  if (primary?.trim()) {
-    refs.push(primary.trim());
-  }
-  for (const fb of resolveAgentModelFallbackValues(cfg.agents?.defaults?.imageModel)) {
-    if (fb?.trim()) {
-      refs.push(fb.trim());
-    }
-  }
-  if (refs.length === 0) {
-    return [];
-  }
-  const entries: MediaUnderstandingModelConfig[] = [];
-  for (const ref of refs) {
-    const slashIdx = ref.indexOf("/");
-    if (slashIdx <= 0 || slashIdx >= ref.length - 1) {
-      continue;
-    }
-    entries.push({
-      type: "provider",
-      provider: ref.slice(0, slashIdx),
-      model: ref.slice(slashIdx + 1),
-    });
-  }
-  return entries;
-}
-
 async function resolveAutoEntries(params: {
   cfg: RemoteClawConfig;
   agentDir?: string;
@@ -464,12 +403,6 @@ async function resolveAutoEntries(params: {
       return [localAudio];
     }
   }
-  if (params.capability === "image") {
-    const imageModelEntries = resolveImageModelFromAgentDefaults(params.cfg);
-    if (imageModelEntries.length > 0) {
-      return imageModelEntries;
-    }
-  }
   const gemini = await resolveGeminiCliEntry(params.capability);
   if (gemini) {
     return [gemini];
@@ -479,47 +412,6 @@ async function resolveAutoEntries(params: {
     return [keys];
   }
   return [];
-}
-
-export async function resolveAutoImageModel(params: {
-  cfg: RemoteClawConfig;
-  agentDir?: string;
-  activeModel?: ActiveMediaModel;
-}): Promise<ActiveMediaModel | null> {
-  const providerRegistry = buildProviderRegistry();
-  const toActive = (entry: MediaUnderstandingModelConfig | null): ActiveMediaModel | null => {
-    if (!entry || entry.type === "cli") {
-      return null;
-    }
-    const provider = entry.provider;
-    if (!provider) {
-      return null;
-    }
-    const model = entry.model ?? DEFAULT_IMAGE_MODELS[provider];
-    if (!model) {
-      return null;
-    }
-    return { provider, model };
-  };
-  const activeEntry = await resolveActiveModelEntry({
-    cfg: params.cfg,
-    agentDir: params.agentDir,
-    providerRegistry,
-    capability: "image",
-    activeModel: params.activeModel,
-  });
-  const resolvedActive = toActive(activeEntry);
-  if (resolvedActive) {
-    return resolvedActive;
-  }
-  const keyEntry = await resolveKeyEntry({
-    cfg: params.cfg,
-    agentDir: params.agentDir,
-    providerRegistry,
-    capability: "image",
-    activeModel: params.activeModel,
-  });
-  return toActive(keyEntry);
 }
 
 async function resolveActiveModelEntry(params: {
@@ -542,9 +434,6 @@ async function resolveActiveModelEntry(params: {
     return null;
   }
   if (params.capability === "audio" && !provider.transcribeAudio) {
-    return null;
-  }
-  if (params.capability === "image" && !provider.describeImage) {
     return null;
   }
   if (params.capability === "video" && !provider.describeVideo) {

--- a/src/media-understanding/types.ts
+++ b/src/media-understanding/types.ts
@@ -86,30 +86,9 @@ export type VideoDescriptionResult = {
   model?: string;
 };
 
-export type ImageDescriptionRequest = {
-  buffer: Buffer;
-  fileName: string;
-  mime?: string;
-  model: string;
-  provider: string;
-  prompt?: string;
-  maxTokens?: number;
-  timeoutMs: number;
-  profile?: string;
-  preferredProfile?: string;
-  agentDir: string;
-  cfg: import("../config/config.js").RemoteClawConfig;
-};
-
-export type ImageDescriptionResult = {
-  text: string;
-  model?: string;
-};
-
 export type MediaUnderstandingProvider = {
   id: string;
   capabilities?: MediaUnderstandingCapability[];
   transcribeAudio?: (req: AudioTranscriptionRequest) => Promise<AudioTranscriptionResult>;
   describeVideo?: (req: VideoDescriptionRequest) => Promise<VideoDescriptionResult>;
-  describeImage?: (req: ImageDescriptionRequest) => Promise<ImageDescriptionResult>;
 };

--- a/src/telegram/sticker-cache.ts
+++ b/src/telegram/sticker-cache.ts
@@ -1,10 +1,8 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import type { RemoteClawConfig } from "../config/config.js";
 import { STATE_DIR } from "../config/paths.js";
 import { logVerbose } from "../globals.js";
 import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
-import { resolveAutoImageModel } from "../media-understanding/runner.js";
 
 const CACHE_FILE = path.join(STATE_DIR, "telegram", "sticker-cache.json");
 const CACHE_VERSION = 1;
@@ -132,9 +130,6 @@ export function getCacheStats(): { count: number; oldestAt?: string; newestAt?: 
   };
 }
 
-const STICKER_DESCRIPTION_PROMPT =
-  "Describe this sticker image in 1-2 sentences. Focus on what the sticker depicts (character, object, action, emotion). Be concise and objective.";
-
 export interface DescribeStickerParams {
   imagePath: string;
   cfg: RemoteClawConfig;
@@ -144,47 +139,11 @@ export interface DescribeStickerParams {
 
 /**
  * Describe a sticker image using vision API.
- * Auto-detects an available vision provider based on configured API keys.
- * Returns null if no vision provider is available.
+ * Currently returns null — provider-based image description was removed
+ * (the Pi-era model catalog was gutted). Will be restored when image
+ * understanding routes through CLI agent multimodal capabilities.
  */
-export async function describeStickerImage(params: DescribeStickerParams): Promise<string | null> {
-  const { imagePath, cfg, agentDir } = params;
-
-  // Model catalog gutted in RemoteClaw — use resolveAutoImageModel directly
-  // to find a vision-capable provider from available API keys.
-  const resolved = await resolveAutoImageModel({
-    cfg,
-    agentDir,
-    activeModel: undefined,
-  });
-
-  if (!resolved?.model) {
-    logVerbose("telegram: no vision provider available for sticker description");
-    return null;
-  }
-
-  const { provider, model } = resolved;
-  logVerbose(`telegram: describing sticker with ${provider}/${model}`);
-
-  try {
-    const buffer = await fs.readFile(imagePath);
-    // Dynamic import to avoid circular dependency
-    const { describeImageWithModel } = await import("../media-understanding/providers/image.js");
-    const result = await describeImageWithModel({
-      buffer,
-      fileName: "sticker.webp",
-      mime: "image/webp",
-      prompt: STICKER_DESCRIPTION_PROMPT,
-      cfg,
-      agentDir: agentDir ?? "",
-      provider,
-      model,
-      maxTokens: 150,
-      timeoutMs: 30000,
-    });
-    return result.text;
-  } catch (err) {
-    logVerbose(`telegram: failed to describe sticker: ${String(err)}`);
-    return null;
-  }
+export async function describeStickerImage(_params: DescribeStickerParams): Promise<string | null> {
+  logVerbose("telegram: sticker image description not available (provider-based image removed)");
+  return null;
 }


### PR DESCRIPTION
## Summary

- Delete `describeImageWithModel()` — the always-throwing stub in `src/media-understanding/providers/image.ts` that broke image description across all channels since the Pi-era model catalog was gutted
- Remove `describeImage` from all 6 provider registrations (anthropic, google, minimax, moonshot, openai, zai) and strip `"image"` from their capabilities
- Remove `ImageDescriptionRequest`, `ImageDescriptionResult` types and `describeImage` from `MediaUnderstandingProvider`
- Remove dead image provider auto-resolution code: `resolveAutoImageModel`, `resolveImageModelFromAgentDefaults`, `AUTO_IMAGE_KEY_PROVIDERS`, `DEFAULT_IMAGE_MODELS`
- Clean up `runProviderEntry` image branch, `resolveKeyEntry`/`resolveActiveModelEntry` image checks
- Simplify `describeStickerImage` in `sticker-cache.ts` to return null (was calling the dead stub)
- CLI-based image understanding (e.g. Gemini CLI) continues to work unchanged

Closes #294

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm tsgo` (type-check) passes clean
- [x] All 89 media-understanding + sticker-cache tests pass (15 test files)
- [x] No remaining references to `describeImageWithModel`, `ImageDescriptionRequest`, `ImageDescriptionResult`, `AUTO_IMAGE_KEY_PROVIDERS`, or `DEFAULT_IMAGE_MODELS` in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)