### PR TITLE
Fix migration warning message text (says ~/.remoteclaw instead of ~/.openclaw) (#307)

### DIFF
--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -148,7 +148,7 @@ describe("checkRemoteClawMigration", () => {
     checkRemoteClawMigration({ HOME: "/mock-home" });
 
     expect(warnSpy).toHaveBeenCalledOnce();
-    expect(warnSpy.mock.calls[0][0]).toContain("remoteclaw import");
+    expect(warnSpy.mock.calls[0][0]).toContain("remoteclaw import ~/.openclaw");
   });
 
   it("does not warn when ~/.remoteclaw already exists", () => {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -83,7 +83,7 @@ export function checkRemoteClawMigration(env: NodeJS.ProcessEnv = process.env): 
 
     if (!fs.existsSync(newDir) && fs.existsSync(oldDir)) {
       console.warn(
-        "Existing RemoteClaw installation detected. Run `remoteclaw import ~/.remoteclaw` to migrate.",
+        "Existing RemoteClaw installation detected. Run `remoteclaw import ~/.openclaw` to migrate.",
       );
     }
   } catch {


### PR DESCRIPTION
## Summary

- Fixed the `checkRemoteClawMigration()` warning message in `src/cli/run-main.ts` to say `remoteclaw import ~/.openclaw` (the old directory) instead of `remoteclaw import ~/.remoteclaw` (the new directory)
- Tightened the unit test assertion to verify the correct `~/.openclaw` path appears in the message

## Test plan

- [x] `grep -n 'import.*~\/\.remoteclaw' src/cli/run-main.ts` returns zero matches
- [x] Unit test asserts the warning contains `remoteclaw import ~/.openclaw`
- [x] All 18 tests in `src/cli/run-main.test.ts` pass

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)