### PR TITLE
Remove pi-ai model catalog from macOS app bundle script (#312)

### DIFF
--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -207,15 +207,6 @@ echo "📦 Copying device model resources"
 rm -rf "$APP_ROOT/Contents/Resources/DeviceModels"
 cp -R "$ROOT_DIR/apps/macos/Sources/RemoteClaw/Resources/DeviceModels" "$APP_ROOT/Contents/Resources/DeviceModels"
 
-echo "📦 Copying model catalog"
-MODEL_CATALOG_SRC="$ROOT_DIR/node_modules/@mariozechner/pi-ai/dist/models.generated.js"
-MODEL_CATALOG_DEST="$APP_ROOT/Contents/Resources/models.generated.js"
-if [ -f "$MODEL_CATALOG_SRC" ]; then
-  cp "$MODEL_CATALOG_SRC" "$MODEL_CATALOG_DEST"
-else
-  echo "WARN: model catalog missing at $MODEL_CATALOG_SRC (continuing)" >&2
-fi
-
 echo "📦 Copying RemoteClawKit resources"
 REMOTECLAWKIT_BUNDLE="$(build_path_for_arch "$PRIMARY_ARCH")/$BUILD_CONFIG/RemoteClawKit_RemoteClawKit.bundle"
 if [ -d "$REMOTECLAWKIT_BUNDLE" ]; then


### PR DESCRIPTION
## Summary

- Remove the dead "Copying model catalog" block (lines 210–217) from `scripts/package-mac-app.sh` that copied `@mariozechner/pi-ai/dist/models.generated.js` into the app bundle
- No Swift code in `apps/macos/` or `apps/shared/` references `models.generated.js` — zero consumers
- `@mariozechner/pi-ai` is not in `package.json` — no dependency to clean up

Closes #312

## Verification

- `grep -n 'model.catalog\|models.generated\|pi-ai' scripts/package-mac-app.sh` → zero matches
- `pnpm build` passes
- No Swift consumers found (`grep -rn "models.generated" apps/macos/ apps/shared/` → empty)

## Test plan

- [x] `pnpm build` passes
- [x] Acceptance criteria grep returns zero matches
- [x] No Swift consumer code needs updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)