### PR TITLE
Rebrand canvas host openclaw references (a2ui/index.html + window.__openclaw) (#310)

### DIFF
--- a/src/canvas-host/a2ui/index.html
+++ b/src/canvas-host/a2ui/index.html
@@ -81,7 +81,7 @@
         backface-visibility: hidden;
         opacity: 0.45;
         pointer-events: none;
-        animation: openclaw-grid-drift 140s ease-in-out infinite alternate;
+        animation: remoteclaw-grid-drift 140s ease-in-out infinite alternate;
       }
       :root[data-platform="android"] body::before {
         opacity: 0.8;
@@ -101,7 +101,7 @@
         backface-visibility: hidden;
         transform: translate3d(0, 0, 0);
         pointer-events: none;
-        animation: openclaw-glow-drift 110s ease-in-out infinite alternate;
+        animation: remoteclaw-glow-drift 110s ease-in-out infinite alternate;
       }
       :root[data-platform="android"] body::after {
         opacity: 0.85;
@@ -116,7 +116,7 @@
           opacity: 0.7;
         }
       }
-      @keyframes openclaw-grid-drift {
+      @keyframes remoteclaw-grid-drift {
         0% {
           transform: translate3d(-12px, 8px, 0) rotate(-7deg);
           opacity: 0.4;
@@ -130,7 +130,7 @@
           opacity: 0.42;
         }
       }
-      @keyframes openclaw-glow-drift {
+      @keyframes remoteclaw-glow-drift {
         0% {
           transform: translate3d(-18px, 12px, 0) scale(1.02);
           opacity: 0.4;
@@ -153,14 +153,14 @@
         touch-action: none;
         z-index: 1;
       }
-      :root[data-platform="android"] #openclaw-canvas {
+      :root[data-platform="android"] #remoteclaw-canvas {
         background:
           radial-gradient(1100px 800px at 20% 15%, rgba(42, 113, 255, 0.78), rgba(0, 0, 0, 0) 58%),
           radial-gradient(900px 650px at 82% 28%, rgba(255, 0, 138, 0.66), rgba(0, 0, 0, 0) 62%),
           radial-gradient(1000px 900px at 60% 88%, rgba(0, 209, 255, 0.58), rgba(0, 0, 0, 0) 62%),
           #141c33;
       }
-      #openclaw-status {
+      #remoteclaw-status {
         position: fixed;
         inset: 0;
         display: none;
@@ -172,7 +172,7 @@
         pointer-events: none;
         z-index: 3;
       }
-      #openclaw-status .card {
+      #remoteclaw-status .card {
         width: min(560px, 88vw);
         text-align: left;
         padding: 14px 16px 12px;
@@ -185,7 +185,7 @@
         -webkit-backdrop-filter: blur(18px) saturate(140%);
         backdrop-filter: blur(18px) saturate(140%);
       }
-      #openclaw-status .title {
+      #remoteclaw-status .title {
         font:
           600 12px/1.2 -apple-system,
           BlinkMacSystemFont,
@@ -196,7 +196,7 @@
         text-transform: uppercase;
         color: rgba(255, 255, 255, 0.7);
       }
-      #openclaw-status .subtitle {
+      #remoteclaw-status .subtitle {
         margin-top: 8px;
         font:
           500 13px/1.45 -apple-system,
@@ -208,39 +208,39 @@
         white-space: pre-wrap;
         overflow-wrap: anywhere;
       }
-      openclaw-a2ui-host {
+      remoteclaw-a2ui-host {
         display: block;
         height: 100%;
         position: fixed;
         inset: 0;
         z-index: 4;
-        --openclaw-a2ui-inset-top: 28px;
-        --openclaw-a2ui-inset-right: 0px;
-        --openclaw-a2ui-inset-bottom: 0px;
-        --openclaw-a2ui-inset-left: 0px;
-        --openclaw-a2ui-scroll-pad-bottom: 0px;
-        --openclaw-a2ui-status-top: calc(50% - 18px);
-        --openclaw-a2ui-empty-top: 18px;
+        --remoteclaw-a2ui-inset-top: 28px;
+        --remoteclaw-a2ui-inset-right: 0px;
+        --remoteclaw-a2ui-inset-bottom: 0px;
+        --remoteclaw-a2ui-inset-left: 0px;
+        --remoteclaw-a2ui-scroll-pad-bottom: 0px;
+        --remoteclaw-a2ui-status-top: calc(50% - 18px);
+        --remoteclaw-a2ui-empty-top: 18px;
       }
     </style>
   </head>
   <body>
-    <canvas id="openclaw-canvas"></canvas>
-    <div id="openclaw-status">
+    <canvas id="remoteclaw-canvas"></canvas>
+    <div id="remoteclaw-status">
       <div class="card">
-        <div class="title" id="openclaw-status-title">Ready</div>
-        <div class="subtitle" id="openclaw-status-subtitle">Waiting for agent</div>
+        <div class="title" id="remoteclaw-status-title">Ready</div>
+        <div class="subtitle" id="remoteclaw-status-subtitle">Waiting for agent</div>
       </div>
     </div>
-    <openclaw-a2ui-host></openclaw-a2ui-host>
+    <remoteclaw-a2ui-host></remoteclaw-a2ui-host>
     <script src="a2ui.bundle.js"></script>
     <script>
       (() => {
-        const canvas = document.getElementById("openclaw-canvas");
+        const canvas = document.getElementById("remoteclaw-canvas");
         const ctx = canvas.getContext("2d");
-        const statusEl = document.getElementById("openclaw-status");
-        const titleEl = document.getElementById("openclaw-status-title");
-        const subtitleEl = document.getElementById("openclaw-status-subtitle");
+        const statusEl = document.getElementById("remoteclaw-status");
+        const titleEl = document.getElementById("remoteclaw-status-title");
+        const subtitleEl = document.getElementById("remoteclaw-status-subtitle");
         const debugStatusEnabledByQuery = (() => {
           try {
             const params = new URLSearchParams(window.location.search);
@@ -278,7 +278,7 @@
           statusEl.style.display = "none";
         }
 
-        window.__openclaw = {
+        window.__remoteclaw = {
           canvas,
           ctx,
           setDebugStatusEnabled,


### PR DESCRIPTION
## Summary

- Renames all 27 `openclaw` → `remoteclaw` occurrences in `src/canvas-host/a2ui/index.html`: CSS animation names, element IDs, CSS custom properties, custom element tag (`<remoteclaw-a2ui-host>`), and `window.__remoteclaw` JS global
- Fixes tag mismatch: HTML previously declared `<openclaw-a2ui-host>` while the A2UI bundle registers `remoteclaw-a2ui-host`
- No native app changes needed — `apps/` has zero `__openclaw` references

## Test plan

- [x] `grep -rn "openclaw" src/canvas-host/a2ui/index.html` returns zero matches
- [x] `grep -rn "__openclaw" src/ apps/` returns zero matches
- [x] Custom element tag in HTML matches what A2UI bundle registers
- [x] `pnpm build` passes
- [x] Canvas host tests pass (7/7)

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)