### PR TITLE
Fix cross-boundary extension imports (use plugin-sdk instead of ../../../src/) (#311)

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { resolvePreferredRemoteClawTmpDir } from "remoteclaw/plugin-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolvePreferredRemoteClawTmpDir } from "../../../src/infra/tmp-remoteclaw-dir.js";
 
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 const resolveFeishuAccountMock = vi.hoisted(() => vi.fn());

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -1,8 +1,7 @@
 import { EventEmitter } from "node:events";
-import type { IncomingMessage } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { RemoteClawConfig, PluginRuntime } from "remoteclaw/plugin-sdk";
 import { describe, expect, it, vi } from "vitest";
-import { createMockServerResponse } from "../../../src/test-utils/mock-http-response.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import { verifyGoogleChatRequest } from "./auth.js";
 import { handleGoogleChatWebhookRequest, registerGoogleChatWebhookTarget } from "./monitor.js";
@@ -10,6 +9,30 @@ import { handleGoogleChatWebhookRequest, registerGoogleChatWebhookTarget } from 
 vi.mock("./auth.js", () => ({
   verifyGoogleChatRequest: vi.fn(),
 }));
+
+function createMockServerResponse(): ServerResponse & { body?: string } {
+  const headers: Record<string, string> = {};
+  const res: {
+    headersSent: boolean;
+    statusCode: number;
+    body?: string;
+    setHeader: (key: string, value: string) => unknown;
+    end: (body?: string) => unknown;
+  } = {
+    headersSent: false,
+    statusCode: 200,
+    setHeader: (key: string, value: string) => {
+      headers[key.toLowerCase()] = value;
+      return res;
+    },
+    end: (body?: string) => {
+      res.headersSent = true;
+      res.body = body;
+      return res;
+    },
+  };
+  return res as unknown as ServerResponse & { body?: string };
+}
 
 function createWebhookRequest(params: {
   authorization?: string;

--- a/extensions/irc/src/policy.test.ts
+++ b/extensions/irc/src/policy.test.ts
@@ -1,5 +1,5 @@
+import { resolveChannelGroupPolicy } from "remoteclaw/plugin-sdk";
 import { describe, expect, it } from "vitest";
-import { resolveChannelGroupPolicy } from "../../../src/config/group-policy.js";
 import {
   resolveIrcGroupAccessGate,
   resolveIrcGroupMatch,

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -4,8 +4,8 @@ import {
   readNumberParam,
   readReactionParams,
   readStringParam,
+  type AgentToolResult,
 } from "remoteclaw/plugin-sdk";
-import type { AgentToolResult } from "../../../src/types/agent-types.js";
 import {
   deleteMatrixMessage,
   editMatrixMessage,

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -16,7 +16,7 @@ vi.mock("./graph-upload.js", async () => {
   };
 });
 
-import { resolvePreferredRemoteClawTmpDir } from "../../../src/infra/tmp-remoteclaw-dir.js";
+import { resolvePreferredRemoteClawTmpDir } from "remoteclaw/plugin-sdk";
 import {
   type MSTeamsAdapter,
   renderReplyPayloadsToMessages,

--- a/extensions/twitch/src/token.ts
+++ b/extensions/twitch/src/token.ts
@@ -9,8 +9,11 @@
  * 2. Environment variable: REMOTECLAW_TWITCH_ACCESS_TOKEN (default account only)
  */
 
-import type { RemoteClawConfig } from "../../../src/config/config.js";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../../src/routing/session-key.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+  type RemoteClawConfig,
+} from "remoteclaw/plugin-sdk";
 
 export type TwitchTokenSource = "env" | "config" | "none";
 

--- a/extensions/twitch/src/types.ts
+++ b/extensions/twitch/src/types.ts
@@ -6,25 +6,23 @@
  */
 
 import type {
-  ChannelGatewayContext,
-  ChannelOutboundAdapter,
-  ChannelOutboundContext,
-  ChannelResolveKind,
-  ChannelResolveResult,
-  ChannelStatusAdapter,
-} from "../../../src/channels/plugins/types.adapters.js";
-import type {
   ChannelAccountSnapshot,
   ChannelCapabilities,
+  ChannelGatewayContext,
   ChannelLogSink,
   ChannelMessageActionAdapter,
   ChannelMessageActionContext,
   ChannelMeta,
-} from "../../../src/channels/plugins/types.core.js";
-import type { ChannelPlugin } from "../../../src/channels/plugins/types.plugin.js";
-import type { RemoteClawConfig } from "../../../src/config/config.js";
-import type { OutboundDeliveryResult } from "../../../src/infra/outbound/deliver.js";
-import type { RuntimeEnv } from "../../../src/runtime.js";
+  ChannelOutboundAdapter,
+  ChannelOutboundContext,
+  ChannelPlugin,
+  ChannelResolveKind,
+  ChannelResolveResult,
+  ChannelStatusAdapter,
+  OutboundDeliveryResult,
+  RemoteClawConfig,
+  RuntimeEnv,
+} from "remoteclaw/plugin-sdk";
 
 // ============================================================================
 // Twitch-Specific Types

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -225,7 +225,9 @@ export type { ChatType } from "../channels/chat-type.js";
 /** @deprecated Use ChatType instead */
 export type { RoutePeerKind } from "../routing/resolve-route.js";
 export { resolveAckReaction } from "../agents/identity.js";
+export type { AgentToolResult } from "../types/agent-types.js";
 export type { ReplyPayload } from "../auto-reply/types.js";
+export type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
 export type { ChunkMode } from "../auto-reply/chunk.js";
 export { SILENT_REPLY_TOKEN, isSilentReplyText } from "../auto-reply/tokens.js";
 export { formatInboundFromLabel } from "../auto-reply/envelope.js";
@@ -265,7 +267,7 @@ export type { LookupFn, SsrFPolicy } from "../infra/net/ssrf.js";
 export { rawDataToString } from "../infra/ws.js";
 export { isWSLSync, isWSL2Sync, isWSLEnv } from "../infra/wsl.js";
 export { isTruthyEnvValue } from "../infra/env.js";
-export { resolveToolsBySender } from "../config/group-policy.js";
+export { resolveChannelGroupPolicy, resolveToolsBySender } from "../config/group-policy.js";
 export {
   buildPendingHistoryContextFromMap,
   clearHistoryEntries,


### PR DESCRIPTION
## Summary

- Replace all 13 relative `../../../src/` imports across 5 extensions (twitch, matrix, feishu, irc, msteams, googlechat) with `remoteclaw/plugin-sdk` imports
- Add 3 missing exports to `src/plugin-sdk/index.ts`: `AgentToolResult`, `OutboundDeliveryResult`, `resolveChannelGroupPolicy`
- Inline `createMockServerResponse` test helper in googlechat extension (avoids adding test utilities to production SDK)

## Test plan

- [x] `grep -rn 'from ["'"'"']../../../src/' extensions/` returns zero matches
- [x] `pnpm build` passes
- [x] `pnpm check` (format + typecheck + lint) passes
- [x] Extension tests pass: 141 files, 1367 tests all green

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)