### PR TITLE
Clean remaining documentation Pi-era debt (round 2)

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -235,14 +235,7 @@ Once DMs are working, you can set up your Discord server as a full workspace whe
   <Step title="Plan for memory in guild channels">
     By default, long-term memory (MEMORY.md) only loads in DM sessions. Guild channels do not auto-load MEMORY.md.
 
-    <Tabs>
-      <Tab title="Ask your agent">
-        > "When I ask questions in Discord channels, use memory_search or memory_get if you need long-term context from MEMORY.md."
-      </Tab>
-      <Tab title="Manual">
-        If you need shared context in every channel, put the stable instructions in native agent config (e.g. `CLAUDE.md` for Claude Code). Keep long-term notes in `MEMORY.md` and access them on demand with memory tools.
-      </Tab>
-    </Tabs>
+    If you need shared context in every channel, put the stable instructions in native agent config (e.g. `CLAUDE.md` for Claude Code). Keep long-term notes in `MEMORY.md`.
 
   </Step>
 </Steps>

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -69,7 +69,7 @@ remoteclaw plugins uninstall <id> --keep-files
 
 `uninstall` removes plugin records from `plugins.entries`, `plugins.installs`,
 the plugin allowlist, and linked `plugins.load.paths` entries when applicable.
-For active memory plugins, the memory slot resets to `memory-core`.
+For plugins that use exclusive slots, the slot resets to its default.
 
 By default, uninstall also removes the plugin install directory under the active
 state dir extensions root (`$REMOTECLAW_STATE_DIR/extensions/<id>`). Use

--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -7,13 +7,14 @@ title: "Agent Loop"
 
 # Agent Loop (RemoteClaw)
 
-An agentic loop is the full “real” run of an agent: intake → context assembly → model inference →
-tool execution → streaming replies → persistence. It’s the authoritative path that turns a message
-into actions and a final reply, while keeping session state consistent.
+An agentic loop is the full run of an agent: intake, context assembly, CLI
+runtime execution, streaming replies, and persistence. It is the authoritative
+path that turns a message into actions and a final reply while keeping session
+state consistent.
 
-In RemoteClaw, a loop is a single, serialized run per session that emits lifecycle and stream events
-as the model thinks, calls tools, and streams output. This doc explains how that authentic loop is
-wired end-to-end.
+In RemoteClaw, a loop is a single, serialized run per session that emits
+lifecycle and stream events as the CLI runtime thinks, calls tools, and streams
+output. This doc explains how that loop is wired end-to-end.
 
 ## Entry points
 
@@ -26,15 +27,14 @@ wired end-to-end.
 2. `agentCommand` runs the agent:
    - resolves model + thinking/verbose defaults
    - loads skills snapshot
-   - calls `runEmbeddedPiAgent` (pi-agent-core runtime)
-   - emits **lifecycle end/error** if the embedded loop does not emit one
-3. `runEmbeddedPiAgent`:
+   - launches the CLI runtime (Claude, Gemini, Codex, OpenCode) as a subprocess
+   - emits **lifecycle end/error** if the runtime does not emit one
+3. The CLI runtime subprocess:
    - serializes runs via per-session + global queues
-   - resolves model + auth profile and builds the pi session
-   - subscribes to pi events and streams assistant/tool deltas
-   - enforces timeout -> aborts run if exceeded
+   - streams assistant and tool deltas over NDJSON
+   - enforces timeout; aborts run if exceeded
    - returns payloads + usage metadata
-4. `subscribeEmbeddedPiSession` bridges pi-agent-core events to RemoteClaw `agent` stream:
+4. The ChannelBridge adapter bridges CLI runtime events to RemoteClaw `agent` stream:
    - tool events => `stream: "tool"`
    - assistant deltas => `stream: "assistant"`
    - lifecycle events => `stream: "lifecycle"` (`phase: "start" | "end" | "error"`)
@@ -58,7 +58,7 @@ wired end-to-end.
 
 ## Prompt assembly + system prompt
 
-- System prompt is built from RemoteClaw’s base prompt, skills prompt, bootstrap context, and per-run overrides.
+- System prompt is built from RemoteClaw's base prompt, skills prompt, bootstrap context, and per-run overrides.
 - Model-specific limits and compaction reserve tokens are enforced.
 - See [System prompt](/concepts/system-prompt) for what the model sees.
 
@@ -96,7 +96,7 @@ See [Plugins](/tools/plugin#plugin-hooks) for the hook API and registration deta
 
 ## Streaming + partial replies
 
-- Assistant deltas are streamed from pi-agent-core and emitted as `assistant` events.
+- Assistant deltas are streamed from the CLI runtime and emitted as `assistant` events.
 - Block streaming can emit partial replies either on `text_end` or `message_end`.
 - Reasoning streaming can be emitted as a separate stream or as block replies.
 - See [Streaming](/concepts/streaming) for chunking and block reply behavior.
@@ -124,11 +124,11 @@ See [Plugins](/tools/plugin#plugin-hooks) for the hook API and registration deta
 - On retry, in-memory buffers and tool summaries are reset to avoid duplicate output.
 - See [Compaction](/concepts/compaction) for the compaction pipeline.
 
-## Event streams (today)
+## Event streams
 
-- `lifecycle`: emitted by `subscribeEmbeddedPiSession` (and as a fallback by `agentCommand`)
-- `assistant`: streamed deltas from pi-agent-core
-- `tool`: streamed tool events from pi-agent-core
+- `lifecycle`: emitted by the ChannelBridge adapter (and as a fallback by `agentCommand`)
+- `assistant`: streamed deltas from the CLI runtime
+- `tool`: streamed tool events from the CLI runtime
 
 ## Chat channel handling
 
@@ -138,7 +138,7 @@ See [Plugins](/tools/plugin#plugin-hooks) for the hook API and registration deta
 ## Timeouts
 
 - `agent.wait` default: 30s (just the wait). `timeoutMs` param overrides.
-- Agent runtime: `agents.defaults.timeoutSeconds` default 600s; enforced in `runEmbeddedPiAgent` abort timer.
+- Agent runtime: `agents.defaults.timeoutSeconds` default 600s; enforced by the runtime abort timer.
 
 ## Where things can end early
 

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -1,5 +1,5 @@
 ---
-summary: "Agent runtime (embedded pi-mono), workspace contract, and session bootstrap"
+summary: "Agent runtime, workspace contract, and session bootstrap"
 read_when:
   - Changing agent runtime, workspace bootstrap, or session behavior
 title: "Agent Runtime"
@@ -7,7 +7,7 @@ title: "Agent Runtime"
 
 # Agent Runtime 🤖
 
-RemoteClaw runs a single embedded agent runtime derived from **pi-mono**.
+RemoteClaw runs agent CLIs (Claude, Gemini, Codex, OpenCode) as subprocess runtimes.
 
 ## Workspace (required)
 
@@ -40,8 +40,7 @@ See [Agent workspace](/concepts/agent-workspace) for the full layout.
 ## Built-in tools
 
 Core tools (read/exec/edit/write and related system tools) are always available,
-subject to tool policy. `apply_patch` is optional and gated by
-`tools.exec.applyPatch`.
+subject to tool policy.
 
 ## Skills
 
@@ -52,13 +51,6 @@ RemoteClaw loads skills from three locations (workspace wins on name conflict):
 - Workspace: `<workspace>/skills`
 
 Skills can be gated by config/env (see `skills` in [Gateway configuration](/gateway/configuration)).
-
-## pi-mono integration
-
-RemoteClaw reuses pieces of the pi-mono codebase (models/tools), but **session management, discovery, and tool wiring are RemoteClaw-owned**.
-
-- No pi-coding agent runtime.
-- No `~/.pi/agent` or `<workspace>/.pi` settings are consulted.
 
 ## Sessions
 

--- a/docs/concepts/queue.md
+++ b/docs/concepts/queue.md
@@ -17,7 +17,7 @@ We serialize inbound auto-reply runs (all channels) through a tiny in-process qu
 ## How it works
 
 - A lane-aware FIFO queue drains each lane with a configurable concurrency cap (default 1 for unconfigured lanes; main defaults to 4, subagent to 8).
-- `runEmbeddedPiAgent` enqueues by **session key** (lane `session:<key>`) to guarantee only one active run per session.
+- The agent runtime enqueues by **session key** (lane `session:<key>`) to guarantee only one active run per session.
 - Each session run is then queued into a **global lane** (`main` by default) so overall parallelism is capped by `agents.defaults.maxConcurrent`.
 - When verbose logging is enabled, queued runs emit a short notice if they waited more than ~2s before starting.
 - Typing indicators still fire immediately on enqueue (when supported by the channel) so user experience is unchanged while we wait our turn.

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -61,10 +61,6 @@ Files that RemoteClaw may read or write in the workspace:
 - `HEARTBEAT.md` — optional checklist for heartbeat runs
 - `MEMORY.md` and/or `memory.md` — long-term memory (when present)
 
-> **Note:** `memory/*.md` daily files are accessed on demand via the
-> `memory_search` and `memory_get` tools, so they do not count against the
-> context window unless the model explicitly reads them.
-
 To inspect how much each injected file contributes (raw vs injected, truncation, plus tool schema overhead), use `/context list` or `/context detail`. See [Context](/concepts/context).
 
 ## Time handling

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -276,14 +276,6 @@ Save to `~/.remoteclaw/remoteclaw.json` and you can DM the bot from that number.
         to: "+15555550123",
         prompt: "HEARTBEAT",
       },
-      memorySearch: {
-        provider: "gemini",
-        model: "gemini-embedding-001",
-        remote: {
-          apiKey: "${GEMINI_API_KEY}",
-        },
-        extraPaths: ["../team-docs", "/srv/shared-notes"],
-      },
       sandbox: {
         mode: "non-main",
         perSession: true,
@@ -304,7 +296,7 @@ Save to `~/.remoteclaw/remoteclaw.json` and you can DM the bot from that number.
   },
 
   tools: {
-    allow: ["exec", "process", "read", "write", "edit", "apply_patch"],
+    allow: ["exec", "process", "read", "write", "edit"],
     deny: ["browser", "canvas"],
     exec: {
       backgroundMs: 10000,

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1442,9 +1442,8 @@ Defaults for Talk mode (macOS/iOS/Android).
 | Group              | Tools                                                                                    |
 | ------------------ | ---------------------------------------------------------------------------------------- |
 | `group:runtime`    | `exec`, `process` (`bash` is accepted as an alias for `exec`)                            |
-| `group:fs`         | `read`, `write`, `edit`, `apply_patch`                                                   |
+| `group:fs`         | `read`, `write`, `edit`                                                                  |
 | `group:sessions`   | `sessions_list`, `sessions_history`, `sessions_send`, `sessions_spawn`, `session_status` |
-| `group:memory`     | `memory_search`, `memory_get`                                                            |
 | `group:web`        | `web_search`, `web_fetch`                                                                |
 | `group:ui`         | `browser`, `canvas`                                                                      |
 | `group:automation` | `cron`, `gateway`                                                                        |

--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -131,28 +131,6 @@ Default file:
 
 `~/.remoteclaw/logs/raw-stream.jsonl`
 
-## Raw chunk logging (pi-mono)
-
-To capture **raw OpenAI-compat chunks** before they are parsed into blocks,
-pi-mono exposes a separate logger:
-
-```bash
-PI_RAW_STREAM=1
-```
-
-Optional path:
-
-```bash
-PI_RAW_STREAM_PATH=~/.pi-mono/logs/raw-openai-completions.jsonl
-```
-
-Default file:
-
-`~/.pi-mono/logs/raw-openai-completions.jsonl`
-
-> Note: this is only emitted by processes using pi-mono’s
-> `openai-completions` provider.
-
 ## Safety notes
 
 - Raw stream logs can include full prompts, tool output, and user data.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -86,7 +86,6 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   - [How does memory work?](#how-does-memory-work)
   - [Memory keeps forgetting things. How do I make it stick?](#memory-keeps-forgetting-things-how-do-i-make-it-stick)
   - [Does memory persist forever? What are the limits?](#does-memory-persist-forever-what-are-the-limits)
-  - [Does semantic memory search require an OpenAI API key?](#does-semantic-memory-search-require-an-openai-api-key)
 - [Where things live on disk](#where-things-live-on-disk)
   - [Is all data used with RemoteClaw saved locally?](#is-all-data-used-with-remoteclaw-saved-locally)
   - [Where does RemoteClaw store its data?](#where-does-remoteclaw-store-its-data)
@@ -1223,27 +1222,6 @@ workspace on every run.
 
 Docs: Memory, [Agent workspace](/concepts/agent-workspace).
 
-### Does semantic memory search require an OpenAI API key
-
-Only if you use **OpenAI embeddings**. Codex OAuth covers chat/completions and
-does **not** grant embeddings access, so **signing in with Codex (OAuth or the
-Codex CLI login)** does not help for semantic memory search. OpenAI embeddings
-still need a real API key (`OPENAI_API_KEY` or `models.providers.openai.apiKey`).
-
-If you don't set a provider explicitly, RemoteClaw auto-selects a provider when it
-can resolve an API key (auth profiles, `models.providers.*.apiKey`, or env vars).
-It prefers OpenAI if an OpenAI key resolves, otherwise Gemini if a Gemini key
-resolves, then Voyage, then Mistral. If no remote key is available, memory
-search stays disabled until you configure it. If you have a local model path
-configured and present, RemoteClaw
-prefers `local`.
-
-If you'd rather stay local, set `memorySearch.provider = "local"` (and optionally
-`memorySearch.fallback = "none"`). If you want Gemini embeddings, set
-`memorySearch.provider = "gemini"` and provide `GEMINI_API_KEY` (or
-`memorySearch.remote.apiKey`). We support **OpenAI, Gemini, Voyage, Mistral, or local** embedding
-models - see Memory for the setup details.
-
 ### Does memory persist forever What are the limits
 
 Memory files live on disk and persist until you delete them. The limit is your
@@ -1818,7 +1796,6 @@ Notes:
 
 - The onboarding wizard also offers **Reset** if it sees an existing config. See Wizard.
 - If you used profiles (`--profile` / `REMOTECLAW_PROFILE`), reset each state dir (defaults are `~/.remoteclaw-<profile>`).
-- Dev reset: `remoteclaw gateway --dev --reset` (dev-only; wipes dev config + credentials + sessions + workspace).
 
 ### Im getting context too large errors how do I reset or compact
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ RemoteClaw is **AI agent middleware** that connects agent CLIs (Claude, Gemini, 
 - **Self-hosted**: runs on your hardware, your rules
 - **Multi-channel**: one Gateway serves WhatsApp, Telegram, Discord, and more simultaneously
 - **Agent-native**: built for coding agents with tool use, sessions, memory, and multi-agent routing
-- **Open source**: MIT licensed, community-driven
+- **Open source**: AGPL-3.0 licensed, community-driven
 
 **What do you need?** Node 22+, an API key (Anthropic recommended), and 5 minutes.
 
@@ -125,7 +125,7 @@ Open the browser Control UI after the Gateway starts.
 
 Config lives at `~/.remoteclaw/remoteclaw.json`.
 
-- If you **do nothing**, RemoteClaw uses the bundled Pi binary in RPC mode with per-sender sessions.
+- If you **do nothing**, RemoteClaw uses the default CLI agent runtime with per-sender sessions.
 - If you want to lock it down, start with `channels.whatsapp.allowFrom` and (for groups) mention rules.
 
 Example:

--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -10,7 +10,6 @@ title: "Mistral"
 
 RemoteClaw supports Mistral for both text/image model routing (`mistral/...`) and
 audio transcription via Voxtral in media understanding.
-Mistral can also be used for memory embeddings (`memorySearch.provider = "mistral"`).
 
 ## CLI setup
 

--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -38,7 +38,7 @@ RemoteClaw can pick up credentials from:
 - **Auth profiles** (per-agent, stored in `auth-profiles.json`).
 - **Environment variables** (e.g. `OPENAI_API_KEY`, `BRAVE_API_KEY`, `FIRECRAWL_API_KEY`).
 - **Config** (`models.providers.*.apiKey`, `tools.web.search.*`, `tools.web.fetch.firecrawl.*`,
-  `memorySearch.*`, `talk.apiKey`).
+  `talk.apiKey`).
 - **Skills** (`skills.entries.<name>.apiKey`) which may export keys to the skill process env.
 
 ## Features that can spend keys
@@ -60,21 +60,7 @@ Inbound media can be summarized/transcribed before the reply runs. This uses mod
 
 See [Media understanding](/nodes/media-understanding).
 
-### 3) Memory embeddings + semantic search
-
-Semantic memory search uses **embedding APIs** when configured for remote providers:
-
-- `memorySearch.provider = "openai"` → OpenAI embeddings
-- `memorySearch.provider = "gemini"` → Gemini embeddings
-- `memorySearch.provider = "voyage"` → Voyage embeddings
-- `memorySearch.provider = "mistral"` → Mistral embeddings
-- Optional fallback to a remote provider if local embeddings fail
-
-You can keep it local with `memorySearch.provider = "local"` (no API usage).
-
-See [Agent workspace](/concepts/agent-workspace).
-
-### 4) Web search tool (Brave / Perplexity via OpenRouter)
+### 3) Web search tool (Brave / Perplexity via OpenRouter)
 
 `web_search` uses API keys and may incur usage charges:
 
@@ -89,7 +75,7 @@ See [Agent workspace](/concepts/agent-workspace).
 
 See [Web tools](/tools/web).
 
-### 5) Web fetch tool (Firecrawl)
+### 4) Web fetch tool (Firecrawl)
 
 `web_fetch` can call **Firecrawl** when an API key is present:
 
@@ -99,7 +85,7 @@ If Firecrawl isn’t configured, the tool falls back to direct fetch + readabili
 
 See [Web tools](/tools/web).
 
-### 6) Provider usage snapshots (status/health)
+### 5) Provider usage snapshots (status/health)
 
 Some status commands call **provider usage endpoints** to display quota windows or auth health.
 These are typically low-volume calls but still hit provider APIs:
@@ -109,21 +95,21 @@ These are typically low-volume calls but still hit provider APIs:
 
 See [Model providers](/concepts/model-providers).
 
-### 7) Compaction safeguard summarization
+### 6) Compaction safeguard summarization
 
 The compaction safeguard can summarize session history using the **current model**, which
 invokes provider APIs when it runs.
 
 See [Session management + compaction](/reference/session-management-compaction).
 
-### 8) Model scan / probe
+### 7) Model scan / probe
 
 `remoteclaw models scan` can probe OpenRouter models and uses `OPENROUTER_API_KEY` when
 probing is enabled.
 
 See [Model providers](/concepts/model-providers).
 
-### 9) Talk (speech)
+### 8) Talk (speech)
 
 Talk mode can invoke **ElevenLabs** when configured:
 
@@ -131,7 +117,7 @@ Talk mode can invoke **ElevenLabs** when configured:
 
 See [Talk mode](/nodes/talk).
 
-### 10) Skills (third-party APIs)
+### 9) Skills (third-party APIs)
 
 Skills can store `apiKey` in `skills.entries.<name>.apiKey`. If a skill uses that key for external
 APIs, it can incur costs according to the skill’s provider.

--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -137,7 +137,7 @@ agents:
 
 ## Cache diagnostics
 
-RemoteClaw exposes dedicated cache-trace diagnostics for embedded agent runs.
+RemoteClaw exposes dedicated cache-trace diagnostics for agent runs.
 
 ### `diagnostics.cacheTrace` config
 

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -42,8 +42,6 @@ Looking for third-party listings? See [Community plugins](/plugins/community).
 ## Available plugins (official)
 
 - Microsoft Teams is plugin-only as of 2026.1.15; install `@remoteclaw/msteams` if you use Teams.
-- Memory (Core) — bundled memory search plugin (enabled by default via `plugins.slots.memory`)
-- Memory (LanceDB) — bundled long-term memory plugin (auto-recall/capture; set `plugins.slots.memory = "memory-lancedb"`)
 - [Voice Call](/plugins/voice-call) — `@remoteclaw/voice-call`
 - [Zalo Personal](/plugins/zalouser) — `@remoteclaw/zalouser`
 - [Matrix](/channels/matrix) — `@remoteclaw/matrix`
@@ -255,13 +253,13 @@ Some plugin categories are **exclusive** (only one active at a time). Use
 {
   plugins: {
     slots: {
-      memory: "memory-core", // or "none" to disable memory plugins
+      "<category>": "<plugin-id>", // or "none" to disable the slot
     },
   },
 }
 ```
 
-If multiple plugins declare `kind: "memory"`, only the selected one loads. Others
+If multiple plugins declare the same `kind`, only the selected one loads. Others
 are disabled with diagnostics.
 
 ## Control UI (schema + labels)


### PR DESCRIPTION
## Summary

- Removes stale Pi-era references (pi-mono, pi-agent-core, runEmbeddedPiAgent, subscribeEmbeddedPiSession, EmbeddedPiRunResult) from 15 documentation files
- Fixes wrong license claim (MIT → AGPL-3.0) and "bundled Pi binary" description in `docs/index.md`
- Removes gutted memory subsystem references (memory_search, memory_get, memorySearch config, memory-core, memory-lancedb) across all docs
- Removes dead `apply_patch` tool references from config docs
- Rewrites `docs/concepts/agent-loop.md` to describe the current ChannelBridge → CLI runtime → NDJSON stream pipeline

Closes #309

## Acceptance criteria verification

All acceptance criteria greps return zero matches:
- `grep -rn "runEmbeddedPiAgent|subscribeEmbeddedPi|pi-agent-core|pi-mono|EmbeddedPiRunResult" docs/` ✅
- `grep -n "MIT licensed" docs/index.md` ✅
- `grep -n "bundled Pi" docs/index.md` ✅
- `grep -rn "memory_search|memory-core|memory-lancedb|memorySearch" docs/` ✅
- `grep -rn "Docker sandbox" docs/help/faq.md` ✅
- `pnpm build` ✅

## Test plan

- [x] All acceptance criteria greps return zero matches
- [x] `pnpm build` passes
- [ ] CI build and test jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)