### PR TITLE
Bootstrap npm package and configure OIDC trusted publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,6 @@
   "bin": {
     "remoteclaw": "remoteclaw.mjs"
   },
-  "directories": {
-    "doc": "docs",
-    "test": "test"
-  },
   "files": [
     "CHANGELOG.md",
     "LICENSE",
@@ -42,9 +38,10 @@
     "README.md",
     "assets/",
     "dist/",
-    "docs/",
     "extensions/",
-    "skills/"
+    "!extensions/**/*.test.ts",
+    "!extensions/**/fixtures/",
+    "!extensions/**/test/"
   ],
   "type": "module",
   "main": "dist/index.js",
@@ -59,6 +56,9 @@
       "default": "./dist/plugin-sdk/account-id.js"
     },
     "./cli-entry": "./remoteclaw.mjs"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "android:assemble": "cd apps/android && ./gradlew :app:assembleDebug",


### PR DESCRIPTION
## Summary

- Add `publishConfig: { access: "public" }` to `package.json`
- Tighten `files` field: remove `docs/`, `skills/`, exclude `*.test.ts` and fixture/test dirs from extensions
- Remove stale `directories` field (referenced `docs/` and `test/` which aren't shipped)
- Package size: 28.3 MB → 23.1 MB unpacked, 2584 → 2120 files

## Manual steps required after merge

These cannot be automated in the PR and require human action:

- [ ] **First publish**: `npm login && npm publish --access public` (publishes `remoteclaw@0.0.1`)
- [ ] **Verify**: `npm info remoteclaw` shows correct metadata
- [ ] **Create org**: npmjs.com → Create Organization → `remoteclaw` (free tier, reserves `@remoteclaw/` scope)
- [ ] **OIDC trusted publisher**: npmjs.com → Package Settings → Publishing access → Add trusted publisher (repo: `remoteclaw/remoteclaw`, workflow: `publish.yml`, env: `npm-publish`)
- [ ] **GitHub environment**: Repo Settings → Environments → Create `npm-publish` with required reviewers

## Test plan

- [x] `npm pack --dry-run` shows 0 test files, no docs/, no skills/
- [x] Package size 23.1 MB unpacked / 5.4 MB compressed (well under 50 MB threshold)
- [x] `package.json` is valid JSON
- [x] `pnpm format:check` passes

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)