### PR TITLE
Bump version from CalVer to semver 0.1.0

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
     applicationId = "ai.remoteclaw.android"
     minSdk = 31
     targetSdk = 36
-    versionCode = 202602250
-    versionName = "2026.2.25"
+    versionCode = 1
+    versionName = "0.1.0"
     ndk {
       // Support all major ABIs — native libs are tiny (~47 KB per ABI)
       abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.2.25</string>
+	<string>0.1.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20260225</string>
+	<string>1</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoadsInWebContent</key>

--- a/apps/ios/Tests/Info.plist
+++ b/apps/ios/Tests/Info.plist
@@ -17,8 +17,8 @@
 	<key>CFBundlePackageType</key>
 			<string>BNDL</string>
 			<key>CFBundleShortVersionString</key>
-			<string>2026.2.25</string>
+			<string>0.1.0</string>
 			<key>CFBundleVersion</key>
-			<string>20260225</string>
+			<string>1</string>
 		</dict>
 	</plist>

--- a/apps/macos/Sources/RemoteClaw/Resources/Info.plist
+++ b/apps/macos/Sources/RemoteClaw/Resources/Info.plist
@@ -15,9 +15,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>2026.2.25</string>
+    <string>0.1.0</string>
     <key>CFBundleVersion</key>
-    <string>202602250</string>
+    <string>1</string>
     <key>CFBundleIconFile</key>
     <string>RemoteClaw</string>
     <key>CFBundleURLTypes</key>

--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -34,17 +34,17 @@ Notes:
 # From repo root; set release IDs so Sparkle feed is enabled.
 # APP_BUILD must be numeric + monotonic for Sparkle compare.
 BUNDLE_ID=ai.remoteclaw.mac \
-APP_VERSION=2026.2.25 \
+APP_VERSION=0.1.0 \
 APP_BUILD="$(git rev-list --count HEAD)" \
 BUILD_CONFIG=release \
 SIGN_IDENTITY="Developer ID Application: <Developer Name> (<TEAMID>)" \
 scripts/package-mac-app.sh
 
 # Zip for distribution (includes resource forks for Sparkle delta support)
-ditto -c -k --sequesterRsrc --keepParent dist/RemoteClaw.app dist/RemoteClaw-2026.2.25.zip
+ditto -c -k --sequesterRsrc --keepParent dist/RemoteClaw.app dist/RemoteClaw-0.1.0.zip
 
 # Optional: also build a styled DMG for humans (drag to /Applications)
-scripts/create-dmg.sh dist/RemoteClaw.app dist/RemoteClaw-2026.2.25.dmg
+scripts/create-dmg.sh dist/RemoteClaw.app dist/RemoteClaw-0.1.0.dmg
 
 # Recommended: build + notarize/staple zip + DMG
 # First, create a keychain profile once:
@@ -52,14 +52,14 @@ scripts/create-dmg.sh dist/RemoteClaw.app dist/RemoteClaw-2026.2.25.dmg
 #     --apple-id "<apple-id>" --team-id "<team-id>" --password "<app-specific-password>"
 NOTARIZE=1 NOTARYTOOL_PROFILE=remoteclaw-notary \
 BUNDLE_ID=ai.remoteclaw.mac \
-APP_VERSION=2026.2.25 \
+APP_VERSION=0.1.0 \
 APP_BUILD="$(git rev-list --count HEAD)" \
 BUILD_CONFIG=release \
 SIGN_IDENTITY="Developer ID Application: <Developer Name> (<TEAMID>)" \
 scripts/package-mac-dist.sh
 
 # Optional: ship dSYM alongside the release
-ditto -c -k --keepParent apps/macos/.build/release/RemoteClaw.app.dSYM dist/RemoteClaw-2026.2.25.dSYM.zip
+ditto -c -k --keepParent apps/macos/.build/release/RemoteClaw.app.dSYM dist/RemoteClaw-0.1.0.dSYM.zip
 ```
 
 ## Appcast entry
@@ -67,7 +67,7 @@ ditto -c -k --keepParent apps/macos/.build/release/RemoteClaw.app.dSYM dist/Remo
 Use the release note generator so Sparkle renders formatted HTML notes:
 
 ```bash
-SPARKLE_PRIVATE_KEY_FILE=/path/to/ed25519-private-key scripts/make_appcast.sh dist/RemoteClaw-2026.2.25.zip https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/appcast.xml
+SPARKLE_PRIVATE_KEY_FILE=/path/to/ed25519-private-key scripts/make_appcast.sh dist/RemoteClaw-0.1.0.zip https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/appcast.xml
 ```
 
 Generates HTML release notes from `CHANGELOG.md` (via [`scripts/changelog-to-html.sh`](https://github.com/remoteclaw/remoteclaw/blob/main/scripts/changelog-to-html.sh)) and embeds them in the appcast entry.
@@ -75,7 +75,7 @@ Commit the updated `appcast.xml` alongside the release assets (zip + dSYM) when 
 
 ## Publish & verify
 
-- Upload `RemoteClaw-2026.2.25.zip` (and `RemoteClaw-2026.2.25.dSYM.zip`) to the GitHub release for tag `v2026.2.25`.
+- Upload `RemoteClaw-0.1.0.zip` (and `RemoteClaw-0.1.0.dSYM.zip`) to the GitHub release for tag `v0.1.0`.
 - Ensure the raw appcast URL matches the baked feed: `https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/appcast.xml`.
 - Sanity checks:
   - `curl -I https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/appcast.xml` returns 200.

--- a/extensions/bluebubbles/package.json
+++ b/extensions/bluebubbles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/bluebubbles",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "RemoteClaw BlueBubbles channel plugin",
   "type": "module",
   "remoteclaw": {

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/diagnostics-otel",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "RemoteClaw diagnostics OpenTelemetry exporter",
   "type": "module",
   "dependencies": {

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/discord",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "RemoteClaw Discord channel plugin",
   "type": "module",
   "remoteclaw": {

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/feishu",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "RemoteClaw Feishu/Lark channel plugin (community maintained by @m1heng)",
   "type": "module",
   "dependencies": {

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/googlechat",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "private": true,
   "description": "RemoteClaw Google Chat channel plugin",
   "type": "module",

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/imessage",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "private": true,
   "description": "RemoteClaw iMessage channel plugin",
   "type": "module",

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/irc",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "RemoteClaw IRC channel plugin",
   "type": "module",
   "remoteclaw": {

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/line",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "private": true,
   "description": "RemoteClaw LINE channel plugin",
   "type": "module",

--- a/extensions/matrix/CHANGELOG.md
+++ b/extensions/matrix/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2026.2.25
+## 0.1.0
 
 ### Changes
 

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/matrix",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "RemoteClaw Matrix channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/mattermost",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "RemoteClaw Mattermost channel plugin",
   "type": "module",
   "remoteclaw": {

--- a/extensions/msteams/CHANGELOG.md
+++ b/extensions/msteams/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2026.2.25
+## 0.1.0
 
 ### Changes
 

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/msteams",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "RemoteClaw Microsoft Teams channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/nextcloud-talk",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "RemoteClaw Nextcloud Talk channel plugin",
   "type": "module",
   "remoteclaw": {

--- a/extensions/nostr/CHANGELOG.md
+++ b/extensions/nostr/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2026.2.25
+## 0.1.0
 
 ### Changes
 

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/nostr",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "RemoteClaw Nostr channel plugin for NIP-04 encrypted DMs",
   "type": "module",
   "dependencies": {

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/signal",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "private": true,
   "description": "RemoteClaw Signal channel plugin",
   "type": "module",

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/slack",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "private": true,
   "description": "RemoteClaw Slack channel plugin",
   "type": "module",

--- a/extensions/synology-chat/package.json
+++ b/extensions/synology-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/synology-chat",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "Synology Chat channel plugin for RemoteClaw",
   "type": "module",
   "dependencies": {

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/telegram",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "private": true,
   "description": "RemoteClaw Telegram channel plugin",
   "type": "module",

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/tlon",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "RemoteClaw Tlon/Urbit channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/twitch/CHANGELOG.md
+++ b/extensions/twitch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2026.2.25
+## 0.1.0
 
 ### Changes
 

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/twitch",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "RemoteClaw Twitch channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/voice-call/CHANGELOG.md
+++ b/extensions/voice-call/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2026.2.25
+## 0.1.0
 
 ### Changes
 

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/voice-call",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "RemoteClaw voice-call plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/whatsapp",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "private": true,
   "description": "RemoteClaw WhatsApp channel plugin",
   "type": "module",

--- a/extensions/zalo/CHANGELOG.md
+++ b/extensions/zalo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2026.2.25
+## 0.1.0
 
 ### Changes
 

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/zalo",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "RemoteClaw Zalo channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/zalouser/CHANGELOG.md
+++ b/extensions/zalouser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2026.2.25
+## 0.1.0
 
 ### Changes
 

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/zalouser",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "RemoteClaw Zalo Personal Account plugin via zca-cli",
   "type": "module",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteclaw",
-  "version": "2026.2.25",
+  "version": "0.1.0",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [
     "agent",


### PR DESCRIPTION
## Summary

- Replace legacy CalVer `2026.2.25` (inherited from OpenClaw) with semver `0.1.0` across all 36 files: root and extension `package.json` files, native app configs (Android `build.gradle.kts`, iOS/macOS `Info.plist`), extension changelogs, and release docs
- Reset CalVer-derived build numbers (`versionCode`, `CFBundleVersion`) to `1`
- Prerequisite for #209 (`next` dist-tag auto-publish), which reads `package.json` version to construct `{pkg.version}-next.{sha}` prerelease identifiers

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (5 pre-existing failures on main, unrelated)
- [x] No remaining `2026.2.25` references in source files
- [x] Verified build numbers updated (Android versionCode, iOS/macOS CFBundleVersion)

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)