### PR TITLE
CI: add publish-next job for @next dist-tag auto-publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,43 @@ jobs:
         env:
           REMOTECLAW_TEST_WORKERS: 2
           REMOTECLAW_TEST_MAX_OLD_SPACE_SIZE_MB: 4096
+
+  publish-next:
+    if: github.event_name == 'push'
+    needs: [lint, build, test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Configure npm registry
+        uses: actions/setup-node@v4
+        with:
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish next
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          NEXT_VERSION="${PKG_VERSION}-next.${SHORT_SHA}"
+
+          if npm view "remoteclaw@${NEXT_VERSION}" version &>/dev/null; then
+            echo "Version ${NEXT_VERSION} already published, skipping"
+            exit 0
+          fi
+
+          npm version "$NEXT_VERSION" --no-git-tag-version
+          npm publish --tag next --provenance --access public || true


### PR DESCRIPTION
Closes #209

## Summary

- Adds `publish-next` job to CI workflow that auto-publishes `remoteclaw@next` on every successful push to `main`
- Version format: `{pkg.version}-next.{short-sha}` (e.g. `0.1.0-next.a1b2c3d`)
- Uses OIDC provenance attestation (`--provenance`) with `id-token: write` — zero stored npm secrets
- Idempotent: skips publish if the version already exists on npm
- Non-blocking: publish failures don't fail the CI workflow (`|| true`)
- Only runs on push to `main`, after `lint`, `build`, and `test` jobs pass

## Test plan

- [ ] CI passes on this PR (lint, build, test — publish-next is skipped on PRs via `if: github.event_name == 'push'`)
- [ ] After merge, verify `publish-next` job runs on the push-to-main CI
- [ ] Verify `npm view remoteclaw@next` shows the published version
- [ ] Verify `latest` dist-tag is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)