### PR TITLE
CI: fix OIDC publish auth for @next dist-tag (#209)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,6 @@ jobs:
         with:
           install-bun: "false"
 
-      - name: Configure npm registry
-        uses: actions/setup-node@v4
-        with:
-          registry-url: "https://registry.npmjs.org"
-
       - name: Build
         run: pnpm build
 


### PR DESCRIPTION
Fixes the publish-next job from #320 which failed with:
```
npm error 404 Not Found - PUT https://registry.npmjs.org/remoteclaw - Not found
```

## Root cause

The `actions/setup-node` step with `registry-url` created an `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`. With no `NODE_AUTH_TOKEN` set, npm sent an empty credential to the registry instead of falling back to OIDC authentication.

## Fix

Remove the `Configure npm registry` step. The npm CLI uses OIDC natively for both provenance signing and publish auth when `id-token: write` is granted and `--provenance` is specified — no `.npmrc` auth token config needed.

## Test plan

- [ ] CI passes (lint, build, test)
- [ ] After merge, `publish-next` job succeeds on the push-to-main run
- [ ] `npm view remoteclaw@next` shows the published version

🤖 Generated with [Claude Code](https://claude.com/claude-code)