### PR TITLE
CI: fix OIDC publish — add environment + registry-url (#209)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
     if: github.event_name == 'push'
     needs: [lint, build, test]
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write
@@ -90,6 +91,11 @@ jobs:
         uses: ./.github/actions/setup-node-env
         with:
           install-bun: "false"
+
+      - name: Configure npm registry
+        uses: actions/setup-node@v4
+        with:
+          registry-url: "https://registry.npmjs.org"
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
Fixes the publish-next OIDC auth. Two issues from previous attempts:

| Attempt | Error | Root Cause |
|---------|-------|------------|
| #320 | E404 | Missing \`environment: npm-publish\` — OIDC token didn't match npm Trusted Publisher config |
| #321 | ENEEDAUTH | Removed \`registry-url\` — npm had no \`.npmrc\` auth scaffolding at all |

## Fix

1. **Add \`environment: npm-publish\`** — matches the npm Trusted Publisher config, so the OIDC token includes the correct environment claim
2. **Restore \`registry-url\`** — \`actions/setup-node\` creates \`.npmrc\` with auth scaffolding that npm needs for OIDC token exchange

## Prerequisite (npm side)

The npm Trusted Publisher config currently specifies workflow filename \`publish.yml\`. This must be updated to \`ci.yml\` to match the actual workflow file.

## Test plan

- [ ] CI passes (lint, build, test)
- [ ] npm Trusted Publisher config updated: \`publish.yml\` → \`ci.yml\`
- [ ] After merge, \`publish-next\` job succeeds
- [ ] \`npm view remoteclaw@next\` shows published version

🤖 Generated with [Claude Code](https://claude.com/claude-code)