### PR TITLE
CI: remove registry-url to let npm use OIDC natively (#209)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,11 +92,6 @@ jobs:
         with:
           install-bun: "false"
 
-      - name: Configure npm registry
-        uses: actions/setup-node@v4
-        with:
-          registry-url: "https://registry.npmjs.org"
-
       - name: Build
         run: pnpm build
 


### PR DESCRIPTION
Testing the final untried combination for OIDC publish auth.

| \`registry-url\` | \`environment\` | Result |
|:-:|:-:|:-:|
| yes | no | E404 (PR #320) |
| no | no | ENEEDAUTH (PR #321) |
| yes | yes | E404 (PR #322) |
| **no** | **yes** | **this PR** |

The hypothesis: \`actions/setup-node\` with \`registry-url\` writes \`\${NODE_AUTH_TOKEN}\` into \`.npmrc\`. npm CLI finds this empty token and uses it instead of falling back to OIDC token exchange. Removing it lets npm detect the OIDC environment natively.

## Test plan

- [ ] CI passes
- [ ] After merge, \`publish-next\` publishes successfully
- [ ] \`npm view remoteclaw@next\` shows version

🤖 Generated with [Claude Code](https://claude.com/claude-code)