### PR TITLE
CI: upgrade npm >=11.5.1 for OIDC token exchange (#209)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,15 @@ jobs:
         with:
           install-bun: "false"
 
+      - name: Configure npm registry
+        uses: actions/setup-node@v4
+        with:
+          registry-url: "https://registry.npmjs.org"
+
+      # Trusted publishing requires npm >=11.5.1 for OIDC token exchange
+      - name: Upgrade npm
+        run: npm install -g "npm@>=11.5.1"
+
       - name: Build
         run: pnpm build
 


### PR DESCRIPTION
## Root cause

Node 22 ships with npm 10.x. npm's OIDC Trusted Publisher token exchange (secretless publishing) was introduced in **npm 11.5.1**. npm 10.x only supports \`--provenance\` for provenance *signing* but cannot exchange the OIDC token for a publish credential.

Confirmed by comparing with [alexey-pelykh/qontoctl](https://github.com/alexey-pelykh/qontoctl/blob/main/.github/workflows/release.yml) which has a working OIDC publish setup with the same pattern:
\`\`\`yaml
# Trusted publishing requires npm >=11.5.1 for OIDC token exchange
- name: Upgrade npm
  run: npm install -g "npm@>=11.5.1"
\`\`\`

## Changes

1. **Restore \`registry-url\`** — \`actions/setup-node\` with \`registry-url\` creates the \`.npmrc\` registry config
2. **Add npm upgrade step** — installs npm >=11.5.1 which supports OIDC token exchange

## Test plan

- [ ] CI passes
- [ ] After merge, \`publish-next\` job publishes successfully via OIDC
- [ ] \`npm view remoteclaw@next\` shows the published version
- [ ] \`latest\` dist-tag remains \`0.0.0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)