### PR TITLE
Fix README logo invisible on npm (light background)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <p align="center">
     <picture>
-        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/docs/assets/remoteclaw-logo-text-dark.png">
-        <img src="https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/docs/assets/remoteclaw-logo-text.png" alt="RemoteClaw" width="500">
+        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/docs/assets/remoteclaw-logo-text.png">
+        <img src="https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/docs/assets/remoteclaw-logo-text-dark.png" alt="RemoteClaw" width="500">
     </picture>
 </p>
 


### PR DESCRIPTION
## Summary

- The `<picture>` element's `<source media>` is ignored by npm's README renderer, so it always falls back to the `<img>` tag
- Previously the fallback was the white-text logo (`remoteclaw-logo-text.png`), making "Remote" invisible on npm's white background — only "Claw" was visible
- Swapped the assignments: `<img>` (default) now uses the dark-text logo; `<source media="(prefers-color-scheme: dark)">` serves the white-text variant for GitHub dark mode

## Test plan

- [ ] Verify logo renders correctly on [npm package page](https://www.npmjs.com/package/remoteclaw)
- [ ] Verify logo renders correctly on GitHub README (both light and dark mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)