### PR TITLE
docs: document Conventional Commits convention in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,18 @@ must run before tests (CI does this automatically).
 
 ### Commit Messages
 
-- Concise, action-oriented (e.g., `CLI: add verbose flag to send`)
+Follow **Conventional Commits** with optional scope:
+
+```
+type(scope): imperative description (#issue)
+```
+
+- **Types**: `feat`, `fix`, `refactor`, `docs`, `test`, `ci`, `chore`, `perf`
+- **Project-specific types**: `rebrand` (openclaw→remoteclaw renaming), `gut` (removing dead upstream subsystems)
+- **Scope**: optional, lowercase — e.g., `middleware`, `cron`, `app:macos`
+- **Subject**: imperative mood, lowercase start, no trailing period
+- **Rationale clause**: use em-dash for context when helpful — e.g., `fix(middleware): close stdin on spawn — prevents CLI hang`
+- **Issue refs**: append `(#N)` when a GitHub issue exists
 - Group related changes; avoid bundling unrelated refactors
 
 ## Testing


### PR DESCRIPTION
## Summary

- Replace the vague commit message guidance with a formal Conventional Commits convention
- Document standard types (`feat`, `fix`, `refactor`, `docs`, `test`, `ci`, `chore`, `perf`) and project-specific types (`rebrand`, `gut`)
- Add rules for scope, subject style, em-dash rationale clauses, and issue refs
- Based on analysis of all 158 fork commits showing a drift from prefixed to unprefixed style

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)