### PR TITLE
fix(docs): use Starlight built-in classes for hero logo dark/light toggle

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -14,13 +14,13 @@ import { Card, CardGrid, Steps } from "@astrojs/starlight/components";
     src="/assets/remoteclaw-logo-text-dark.png"
     alt="RemoteClaw"
     width="500"
-    class="dark:hidden"
+    class="dark:sl-hidden"
   />
   <img
     src="/assets/remoteclaw-logo-text.png"
     alt="RemoteClaw"
     width="500"
-    class="hidden dark:block"
+    class="light:sl-hidden"
   />
 </p>
 


### PR DESCRIPTION
## Summary

- Hero logo on docs site rendered twice (duplicate crab emoji + text) because the images used Tailwind CSS classes (`dark:hidden`, `hidden dark:block`) that don't exist in Starlight
- Replaced with Starlight's built-in `dark:sl-hidden` and `light:sl-hidden` utility classes from `@astrojs/starlight/style/util.css`

## Test plan

- [ ] Verify docs site shows single logo in light mode (`remoteclaw-logo-text-dark.png`)
- [ ] Verify docs site shows single logo in dark mode (`remoteclaw-logo-text.png`)
- [ ] Verify on mobile viewport (original bug report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)