### PR TITLE
fix(cli): correct migration hint wording (#333)

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -83,7 +83,7 @@ export function checkRemoteClawMigration(env: NodeJS.ProcessEnv = process.env): 
 
     if (!fs.existsSync(newDir) && fs.existsSync(oldDir)) {
       console.warn(
-        "Existing RemoteClaw installation detected. Run `remoteclaw import ~/.openclaw` to migrate.",
+        "Existing OpenClaw configuration detected. Run `remoteclaw import ~/.openclaw` to migrate.",
       );
     }
   } catch {


### PR DESCRIPTION
## Summary

- Fixes the migration hint message in `checkRemoteClawMigration` to say "OpenClaw configuration" instead of "RemoteClaw installation"
- The detected directory is `~/.openclaw` (an OpenClaw artifact), and it's a configuration directory, not an installation

Closes #333

## Test plan

- [x] Existing `run-main.test.ts` tests pass (18/18) — assertions check for `remoteclaw import ~/.openclaw` substring which is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)