### PR TITLE
fix(cli): onboard command fails on fresh install (#332)

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -13,6 +13,7 @@ import {
   resolveAgentModelPrimary,
   resolveRunModelFallbacksOverride,
   resolveAgentWorkspaceDir,
+  resolveAgentWorkspaceDirOrNull,
 } from "./agent-scope.js";
 
 afterEach(() => {
@@ -423,6 +424,20 @@ describe("resolveAgentConfig", () => {
       },
     };
     const workspace = resolveAgentWorkspaceDir(cfg, "main");
+    expect(workspace).toContain("my-workspace");
+  });
+
+  it("resolveAgentWorkspaceDirOrNull returns null when no workspace is configured", () => {
+    expect(resolveAgentWorkspaceDirOrNull({} as RemoteClawConfig, "main")).toBeNull();
+  });
+
+  it("resolveAgentWorkspaceDirOrNull returns workspace when configured", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", workspace: "~/my-workspace" }],
+      },
+    };
+    const workspace = resolveAgentWorkspaceDirOrNull(cfg, "main");
     expect(workspace).toContain("my-workspace");
   });
 

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -257,6 +257,18 @@ export function resolveAgentWorkspaceDir(cfg: RemoteClawConfig, agentId: string)
   );
 }
 
+export function resolveAgentWorkspaceDirOrNull(
+  cfg: RemoteClawConfig,
+  agentId: string,
+): string | null {
+  const id = normalizeAgentId(agentId);
+  const configured = resolveAgentConfig(cfg, id)?.workspace?.trim();
+  if (configured) {
+    return stripNullBytes(resolveUserPath(configured));
+  }
+  return null;
+}
+
 export function resolveAgentDir(cfg: RemoteClawConfig, agentId: string) {
   const id = normalizeAgentId(agentId);
   const configured = resolveAgentConfig(cfg, id)?.agentDir?.trim();

--- a/src/cli/plugin-registry.ts
+++ b/src/cli/plugin-registry.ts
@@ -1,4 +1,4 @@
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveAgentWorkspaceDirOrNull, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging.js";
 import { loadRemoteClawPlugins } from "../plugins/loader.js";
@@ -23,7 +23,7 @@ export function ensurePluginRegistryLoaded(): void {
     return;
   }
   const config = loadConfig();
-  const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+  const workspaceDir = resolveAgentWorkspaceDirOrNull(config, resolveDefaultAgentId(config));
   const logger: PluginLogger = {
     info: (msg) => log.info(msg),
     warn: (msg) => log.warn(msg),
@@ -32,7 +32,7 @@ export function ensurePluginRegistryLoaded(): void {
   };
   loadRemoteClawPlugins({
     config,
-    workspaceDir,
+    workspaceDir: workspaceDir ?? undefined,
     logger,
   });
   pluginRegistryLoaded = true;


### PR DESCRIPTION
## Summary

- Add `resolveAgentWorkspaceDirOrNull` variant that returns `null` instead of throwing when no workspace is configured
- Use it in `ensurePluginRegistryLoaded()` so the preaction hook no longer crashes during `onboard` and `configure` on a fresh install
- The throwing `resolveAgentWorkspaceDir` is preserved for all other callers that require a workspace

Closes #332

## Test plan

- [x] `resolveAgentWorkspaceDirOrNull` returns `null` when no workspace configured
- [x] `resolveAgentWorkspaceDirOrNull` returns workspace path when configured
- [x] Existing `resolveAgentWorkspaceDir` tests still pass (throwing behavior unchanged)
- [x] All 494 CLI tests pass
- [x] No type errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)