### PR TITLE
test(cli): add coverage for ensurePluginRegistryLoaded fresh install path

### DIFF
--- a/src/cli/plugin-registry.test.ts
+++ b/src/cli/plugin-registry.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getActivePluginRegistryMock = vi.fn();
+const loadConfigMock = vi.fn();
+const resolveAgentWorkspaceDirOrNullMock = vi.fn();
+const resolveDefaultAgentIdMock = vi.fn();
+const loadRemoteClawPluginsMock = vi.fn();
+
+vi.mock("../plugins/runtime.js", () => ({
+  getActivePluginRegistry: getActivePluginRegistryMock,
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: loadConfigMock,
+}));
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDirOrNull: resolveAgentWorkspaceDirOrNullMock,
+  resolveDefaultAgentId: resolveDefaultAgentIdMock,
+}));
+
+vi.mock("../plugins/loader.js", () => ({
+  loadRemoteClawPlugins: loadRemoteClawPluginsMock,
+}));
+
+vi.mock("../logging.js", () => ({
+  createSubsystemLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+describe("ensurePluginRegistryLoaded", () => {
+  let ensurePluginRegistryLoaded: typeof import("./plugin-registry.js").ensurePluginRegistryLoaded;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    ({ ensurePluginRegistryLoaded } = await import("./plugin-registry.js"));
+    getActivePluginRegistryMock.mockReturnValue(null);
+    loadConfigMock.mockReturnValue({});
+    resolveDefaultAgentIdMock.mockReturnValue("main");
+  });
+
+  it("does not throw when no workspace is configured (fresh install)", () => {
+    resolveAgentWorkspaceDirOrNullMock.mockReturnValue(null);
+
+    expect(() => ensurePluginRegistryLoaded()).not.toThrow();
+    expect(loadRemoteClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: undefined }),
+    );
+  });
+
+  it("passes resolved workspace to plugin loader", () => {
+    resolveAgentWorkspaceDirOrNullMock.mockReturnValue("/home/user/workspace");
+
+    ensurePluginRegistryLoaded();
+
+    expect(loadRemoteClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: "/home/user/workspace" }),
+    );
+  });
+
+  it("skips loading when a pre-seeded registry with plugins exists", () => {
+    getActivePluginRegistryMock.mockReturnValue({
+      plugins: [{ id: "test" }],
+      channels: [],
+      tools: [],
+    });
+
+    ensurePluginRegistryLoaded();
+
+    expect(loadConfigMock).not.toHaveBeenCalled();
+    expect(loadRemoteClawPluginsMock).not.toHaveBeenCalled();
+  });
+
+  it("loads plugins when active registry is empty", () => {
+    getActivePluginRegistryMock.mockReturnValue({
+      plugins: [],
+      channels: [],
+      tools: [],
+    });
+    resolveAgentWorkspaceDirOrNullMock.mockReturnValue(null);
+
+    ensurePluginRegistryLoaded();
+
+    expect(loadRemoteClawPluginsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload on subsequent calls", () => {
+    resolveAgentWorkspaceDirOrNullMock.mockReturnValue(null);
+
+    ensurePluginRegistryLoaded();
+    ensurePluginRegistryLoaded();
+
+    expect(loadRemoteClawPluginsMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/cli/plugin-registry.test.ts` — the module had zero test coverage
- Covers the fresh-install scenario (#332) where no workspace is configured and `ensurePluginRegistryLoaded` must not throw
- Also covers: workspace passthrough, pre-seeded registry skip, empty registry loading, and call idempotency

## Context

The fix in #336 (`2abd2fa`) switched `ensurePluginRegistryLoaded` from `resolveAgentWorkspaceDir` (throws) to `resolveAgentWorkspaceDirOrNull` (returns null), but no test verified this. The bug was invisible to existing tests because `preaction.test.ts` mocks `ensurePluginRegistryLoaded` entirely — it verifies the function is *called* for `onboard`, but never tests the function's *behavior*.

## Test plan

- [x] `npx vitest run src/cli/plugin-registry.test.ts` — 5/5 pass
- [x] `pnpm test` — no new failures (5 pre-existing failures in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)