### PR TITLE
docs: fix stale content from M5 workspace cleanup

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -19,19 +19,9 @@ Related:
 ```bash
 remoteclaw agents list
 remoteclaw agents add work --workspace ~/.remoteclaw/workspace-work
-remoteclaw agents set-identity --workspace ~/.remoteclaw/workspace --from-identity
 remoteclaw agents set-identity --agent main --avatar avatars/remoteclaw.png
 remoteclaw agents delete work
 ```
-
-## Identity files
-
-Each agent workspace can include an `IDENTITY.md` at the workspace root:
-
-- Example path: `~/.remoteclaw/workspace/IDENTITY.md`
-- `set-identity --from-identity` reads from the workspace root (or an explicit `--identity-file`)
-
-Avatar paths resolve relative to the workspace root.
 
 ## Set identity
 
@@ -41,12 +31,6 @@ Avatar paths resolve relative to the workspace root.
 - `theme`
 - `emoji`
 - `avatar` (workspace-relative path, http(s) URL, or data URI)
-
-Load from `IDENTITY.md`:
-
-```bash
-remoteclaw agents set-identity --workspace ~/.remoteclaw/workspace --from-identity
-```
 
 Override fields explicitly:
 

--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -24,8 +24,8 @@ inside a sandbox workspace under `~/.remoteclaw/sandboxes`, not your host worksp
 ## Configuration
 
 There is no built-in workspace path — you must explicitly configure one.
-Set a shared default via `agents.defaults.workspace` or override per-agent
-via `agents.list[].workspace`:
+Set a default via `agents.defaults.workspace` (applied per-agent, not a shared
+directory) or override per-agent via `agents.list[].workspace`:
 
 ```json5
 {
@@ -46,10 +46,6 @@ configuration (e.g., `CLAUDE.md` for Claude Code, `.gemini/` for Gemini CLI).
 RemoteClaw does not seed or manage template files in the workspace.
 
 Files that RemoteClaw may read or write:
-
-- `IDENTITY.md`
-  - The agent's name, vibe, and emoji.
-  - Managed via the control UI or `agents.create`/`agents.update` RPC.
 
 - `HEARTBEAT.md`
   - Optional tiny checklist for heartbeat runs.
@@ -85,7 +81,7 @@ patterns. Set `agents.defaults.editableFiles` (or per-agent
 {
   agents: {
     defaults: {
-      editableFiles: ["IDENTITY.md", "HEARTBEAT.md", "memory/**/*.md"],
+      editableFiles: ["HEARTBEAT.md", "memory/**/*.md"],
     },
   },
 }
@@ -116,7 +112,7 @@ workspace lives).
 ```bash
 cd ~/projects  # your workspace path
 git init
-git add IDENTITY.md HEARTBEAT.md memory/
+git add HEARTBEAT.md memory/
 git commit -m "Add agent workspace"
 ```
 

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -29,7 +29,6 @@ not seed or manage template files in the workspace.
 
 Files that RemoteClaw may read or write:
 
-- `IDENTITY.md` — agent name/vibe/emoji (managed via control UI or RPC)
 - `HEARTBEAT.md` — optional tiny checklist for heartbeat runs
 - Boot prompt file — configurable path via `agents.defaults.boot.file`
 - `memory/YYYY-MM-DD.md` — daily memory log

--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -43,7 +43,6 @@ Sandbox: mode=non-main sandboxed=false
 System prompt (run): 38,412 chars (~9,603 tok) (Project Context 23,901 chars (~5,976 tok))
 
 Workspace files:
-- IDENTITY.md: OK | raw 211 chars (~53 tok) | injected 211 chars (~53 tok)
 - HEARTBEAT.md: MISSING | raw 0 | injected 0
 
 Skills list (system prompt text): 2,184 chars (~546 tok) (12 skills)
@@ -91,13 +90,13 @@ The system prompt is **RemoteClaw-owned** and rebuilt each run. It includes:
 - Workspace location.
 - Time (UTC + converted user time if configured).
 - Runtime metadata (host/OS/model/thinking).
-- Workspace context files (`IDENTITY.md`, `HEARTBEAT.md`).
+- Workspace context files (`HEARTBEAT.md`).
 
 Full breakdown: [System Prompt](/concepts/system-prompt).
 
 ## Workspace files
 
-RemoteClaw reads workspace files (`IDENTITY.md`, `HEARTBEAT.md`) when present.
+RemoteClaw reads workspace files (`HEARTBEAT.md`) when present.
 Agent CLIs load their own config files (e.g. `CLAUDE.md` for Claude Code).
 See [Agent workspace](/concepts/agent-workspace) for the full layout.
 

--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -71,7 +71,7 @@ remoteclaw models status
 
 ## OAuth exchange (how login works)
 
-RemoteClaw’s interactive login flows are implemented in `@mariozechner/pi-ai` and wired into the wizards/commands.
+RemoteClaw’s interactive login flows are implemented in the auth module and wired into the wizards/commands.
 
 ### Anthropic (Claude Pro/Max) setup-token
 

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -2,13 +2,13 @@
 description: "What the RemoteClaw system prompt contains and how it is assembled"
 read_when:
   - Editing system prompt text, tools list, or time/heartbeat sections
-  - Changing workspace bootstrap or skills injection behavior
+  - Changing workspace context or skills injection behavior
 title: "System Prompt"
 ---
 
 # System Prompt
 
-RemoteClaw builds a custom system prompt for every agent run. The prompt is **RemoteClaw-owned** and does not use the pi-coding-agent default prompt.
+RemoteClaw builds a custom system prompt for every agent run. The prompt is **RemoteClaw-owned**.
 
 The prompt is assembled by RemoteClaw and injected into each agent run.
 
@@ -22,7 +22,7 @@ The prompt is intentionally compact and uses fixed sections:
 - **RemoteClaw Self-Update**: how to run `config.apply` and `update.run`.
 - **Workspace**: working directory (`agents.defaults.workspace`).
 - **Documentation**: local path to RemoteClaw docs (repo or npm package) and when to read them.
-- **Workspace Files (injected)**: indicates bootstrap files are included below.
+- **Workspace Files (injected)**: indicates workspace context files are included below.
 - **Sandbox** (when enabled): indicates sandboxed runtime, sandbox paths, and whether elevated exec is available.
 - **Current Date & Time**: user-local time, timezone, and time format.
 - **Reply Tags**: optional reply tag syntax for supported providers.
@@ -57,7 +57,6 @@ own context loading.
 
 Files that RemoteClaw may read or write in the workspace:
 
-- `IDENTITY.md` — agent name/vibe/emoji
 - `HEARTBEAT.md` — optional checklist for heartbeat runs
 - `MEMORY.md` and/or `memory.md` — long-term memory (when present)
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -649,7 +649,7 @@ Per-agent override: `agents.list[].editableFiles`.
 
 ```json5
 {
-  agents: { defaults: { editableFiles: ["IDENTITY.md", "HEARTBEAT.md", "memory/**/*.md"] } },
+  agents: { defaults: { editableFiles: ["HEARTBEAT.md", "memory/**/*.md"] } },
 }
 ```
 
@@ -1704,7 +1704,7 @@ Notes:
 
 ## Custom providers and base URLs
 
-RemoteClaw uses the pi-coding-agent model catalog. Add custom providers via `models.providers` in config or `~/.remoteclaw/agents/<agentId>/agent/models.json`.
+RemoteClaw uses the OpenCode Zen model catalog. Add custom providers via `models.providers` in config or `~/.remoteclaw/agents/<agentId>/agent/models.json`.
 
 ```json5
 {

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -130,7 +130,7 @@ Current migrations:
 ### 2b) OpenCode Zen provider overrides
 
 If you’ve added `models.providers.opencode` (or `opencode-zen`) manually, it
-overrides the built-in OpenCode Zen catalog from `@mariozechner/pi-ai`. That can
+overrides the built-in OpenCode Zen catalog. That can
 force every model onto a single API or zero out costs. Doctor warns so you can
 remove the override and restore per-model API routing + costs.
 

--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -46,17 +46,15 @@ node --watch-path src --watch-path tsconfig.json --watch-path package.json --wat
 Add any gateway CLI flags after `gateway:watch` and they will be passed through
 on each restart.
 
-## Dev profile + dev gateway (--dev)
+## Dev profile
 
 Use the dev profile to isolate state and spin up a safe, disposable setup for
-debugging. There are **two** `--dev` flags:
+debugging:
 
 - **Global `--dev` (profile):** isolates state under `~/.remoteclaw-dev` and
   defaults the gateway port to `19001` (derived ports shift with it).
-- **`gateway --dev`: tells the Gateway to auto-create a default config +
-  workspace** when missing.
 
-Recommended flow (dev profile + dev bootstrap):
+Recommended flow:
 
 ```bash
 pnpm gateway:dev
@@ -73,11 +71,8 @@ What this does:
    - `REMOTECLAW_CONFIG_PATH=~/.remoteclaw-dev/remoteclaw.json`
    - `REMOTECLAW_GATEWAY_PORT=19001` (browser/canvas shift accordingly)
 
-2. **Dev bootstrap** (`gateway --dev`)
-   - Writes a minimal config if missing (`gateway.mode=local`, bind loopback).
-   - Sets `agent.workspace` to the dev workspace.
+2. **Workspace setup**
    - Creates the workspace directory if missing.
-   - Default identity: **C3‑PO** (protocol droid).
    - Skips channel providers in dev mode (`REMOTECLAW_SKIP_CHANNELS=1`).
 
 Reset flow (fresh start):
@@ -90,7 +85,7 @@ Note: `--dev` is a **global** profile flag and gets eaten by some runners.
 If you need to spell it out, use the env var form:
 
 ```bash
-REMOTECLAW_PROFILE=dev remoteclaw gateway --dev --reset
+REMOTECLAW_PROFILE=dev remoteclaw gateway --reset
 ```
 
 `--reset` wipes config, credentials, sessions, and the dev workspace (using

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -718,7 +718,7 @@ See [OAuth](/concepts/oauth).
 
 ### Is AWS Bedrock supported
 
-Yes - via pi-ai's **Amazon Bedrock (Converse)** provider with **manual config**. You must supply AWS credentials/region on the gateway host and add a Bedrock provider entry in your models config. See [Amazon Bedrock](/providers/bedrock) and [Model providers](/providers/models). If you prefer a managed key flow, an OpenAI-compatible proxy in front of Bedrock is still a valid option.
+Yes - via RemoteClaw's **Amazon Bedrock (Converse)** provider with **manual config**. You must supply AWS credentials/region on the gateway host and add a Bedrock provider entry in your models config. See [Amazon Bedrock](/providers/bedrock) and [Model providers](/providers/models). If you prefer a managed key flow, an OpenAI-compatible proxy in front of Bedrock is still a valid option.
 
 ### How does Codex auth work
 
@@ -1270,7 +1270,7 @@ Your **workspace** is separate and configured via `agents.defaults.workspace` (n
 
 Workspace files live in the **agent workspace**, not `~/.remoteclaw`.
 
-- **Workspace (per agent)**: `IDENTITY.md`, `HEARTBEAT.md`,
+- **Workspace (per agent)**: `HEARTBEAT.md`,
   `MEMORY.md` (or `memory.md`), `memory/YYYY-MM-DD.md`, plus native agent config
   (e.g. `CLAUDE.md` for Claude Code).
 - **State dir (`~/.remoteclaw`)**: config, credentials, auth profiles, sessions, logs,

--- a/docs/install/migrating.md
+++ b/docs/install/migrating.md
@@ -43,7 +43,7 @@ Look for mentions of `REMOTECLAW_STATE_DIR` / profile in the output. If you run 
 There is no built-in default workspace path — check your `agents.defaults.workspace`
 (or per-agent `agents.list[].workspace`) in `remoteclaw.json`.
 
-Your workspace is where files like `MEMORY.md`, `IDENTITY.md`, and `memory/*.md` live.
+Your workspace is where files like `MEMORY.md` and `memory/*.md` live.
 
 > **Note:** RemoteClaw no longer seeds template files (`SOUL.md`, `AGENTS.md`,
 > `USER.md`, `TOOLS.md`, `BOOTSTRAP.md`) in the workspace. Agents bring their

--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -175,11 +175,11 @@ If you omit `capabilities`, the entry is eligible for the list it appears in.
 
 ## Provider support matrix (RemoteClaw integrations)
 
-| Capability | Provider integration                             | Notes                                                     |
-| ---------- | ------------------------------------------------ | --------------------------------------------------------- |
-| Image      | OpenAI / Anthropic / Google / others via `pi-ai` | Any image-capable model in the registry works.            |
-| Audio      | OpenAI, Groq, Deepgram, Google, Mistral          | Provider transcription (Whisper/Deepgram/Gemini/Voxtral). |
-| Video      | Google (Gemini API)                              | Provider video understanding.                             |
+| Capability | Provider integration                                                 | Notes                                                     |
+| ---------- | -------------------------------------------------------------------- | --------------------------------------------------------- |
+| Image      | OpenAI / Anthropic / Google / others via RemoteClaw's model registry | Any image-capable model in the registry works.            |
+| Audio      | OpenAI, Groq, Deepgram, Google, Mistral                              | Provider transcription (Whisper/Deepgram/Gemini/Voxtral). |
+| Video      | Google (Gemini API)                                                  | Provider video understanding.                             |
 
 ## Recommended providers
 

--- a/docs/platforms/digitalocean.md
+++ b/docs/platforms/digitalocean.md
@@ -199,7 +199,7 @@ htop
 All state lives in:
 
 - `~/.remoteclaw/` — config, credentials, session data
-- `<configured workspace>` — workspace (IDENTITY.md, memory, etc.)
+- `<configured workspace>` — workspace (memory, etc.)
 
 These survive reboots. Back them up periodically:
 

--- a/docs/platforms/oracle.md
+++ b/docs/platforms/oracle.md
@@ -284,7 +284,7 @@ Most npm packages work fine. For binaries, look for `linux-arm64` or `aarch64` r
 All state lives in:
 
 - `~/.remoteclaw/` — config, credentials, session data
-- `<configured workspace>` — workspace (IDENTITY.md, memory, artifacts)
+- `<configured workspace>` — workspace (memory, artifacts)
 
 Back up periodically:
 

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -161,7 +161,7 @@ The store is safe to edit, but the Gateway is the authority: it may rewrite or r
 
 ## Transcript structure (`*.jsonl`)
 
-Transcripts are managed by `@mariozechner/pi-coding-agent`’s `SessionManager`.
+Transcripts are managed by RemoteClaw’s `SessionManager`.
 
 The file is JSONL:
 

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -18,7 +18,7 @@ RemoteClaw assembles its own system prompt on every run. It includes:
 - Tool list + short descriptions
 - Skills list (only metadata; instructions are loaded on demand with `read`)
 - Self-update instructions
-- Workspace context files (`IDENTITY.md`, `HEARTBEAT.md`, `MEMORY.md` when present). Agent CLIs load their own config files (e.g. `CLAUDE.md`). `memory/*.md` files are on-demand via memory tools and are not auto-injected.
+- Workspace context files (`HEARTBEAT.md`, `MEMORY.md` when present). Agent CLIs load their own config files (e.g. `CLAUDE.md`). `memory/*.md` files are on-demand via memory tools and are not auto-injected.
 - Time (UTC + user timezone)
 - Reply tags + heartbeat behavior
 - Runtime metadata (host/OS/model/thinking)

--- a/docs/start/bootstrapping.md
+++ b/docs/start/bootstrapping.md
@@ -1,9 +1,9 @@
 ---
-description: "Agent bootstrapping ritual that seeds the workspace and identity files"
+description: "Agent bootstrapping: workspace setup on first run"
 read_when:
   - Understanding what happens on the first agent run
-  - Explaining where bootstrapping files live
-  - Debugging onboarding identity setup
+  - Explaining where workspace files live
+  - Debugging onboarding workspace setup
 title: "Agent Bootstrapping"
 
 sidebar:
@@ -12,9 +12,8 @@ sidebar:
 
 # Agent Bootstrapping
 
-Bootstrapping is the **first‑run** ritual that prepares an agent workspace and
-collects identity details. It happens after onboarding, when the agent starts
-for the first time.
+Bootstrapping is the **first‑run** ritual that prepares an agent workspace. It
+happens after onboarding, when the agent starts for the first time.
 
 ## What bootstrapping does
 
@@ -26,7 +25,7 @@ seeds template files in the workspace.
 ## Where it runs
 
 Bootstrapping always runs on the **gateway host**. If the macOS app connects to
-a remote Gateway, the workspace and bootstrapping files live on that remote
+a remote Gateway, the workspace files live on that remote
 machine.
 
 :::note


### PR DESCRIPTION
## Summary

Closes #330.

- Remove all `IDENTITY.md` references across 17 doc files (identity file concept gutted in #285; identity is now config-driven only)
- Remove `gateway --dev` auto-config behavior from debugging docs (the `--dev` flag was removed in #237)
- Update stale `pi-ai` / `pi-coding-agent` package references to RemoteClaw equivalents
- Fix workspace bootstrap wording: remove "seeds" contradiction, clarify `agents.defaults.workspace` is per-agent config (not a shared fallback, per #282)

### Exit criteria verified

- `grep -ri "gateway --dev" docs/` → zero results ✅
- `grep -ri "IDENTITY\.md" docs/` → zero results ✅
- `grep -ri "\-\-from-identity\|\-\-identity-file" docs/` → zero results ✅
- `grep -ri "pi-ai\|pi-coding-agent" docs/` → zero results ✅
- `grep -ri "seeds.*workspace\|workspace.*seeding\|template seeding" docs/` → only correctly-marked historical references ✅

## Test plan

- [ ] Docs build passes (no broken internal links from removed content)
- [ ] Grep exit criteria all pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)