### PR TITLE
fix(config): add missing `workspace` field to AgentDefaultsSchema (#346)

### DIFF
--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -26,6 +26,7 @@ export const AgentDefaultsSchema = z
           .strict(),
       )
       .optional(),
+    workspace: z.string().optional(),
     repoRoot: z.string().optional(),
     skipBootstrap: z.boolean().optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary

- Add `workspace: z.string().optional()` to `AgentDefaultsSchema` Zod schema to match the existing `AgentDefaultsConfig` TypeScript type

## Problem

When importing an OpenClaw config (`~/.openclaw` → `~/.remoteclaw`) during `remoteclaw onboard`, the wizard rejects the imported config because `agents.defaults.workspace` is not recognized by the Zod schema (which uses `.strict()` mode). This blocks onboarding with a confusing "No key settings detected" + "Unrecognized key: workspace" error.

## Root Cause

Type/schema mismatch: `AgentDefaultsConfig` in `types.agent-defaults.ts` declares `workspace?: string`, but `AgentDefaultsSchema` in `zod-schema.agent-defaults.ts` omitted it.

## Test plan

- [x] All 524 config tests pass (`npx vitest run src/config/`)
- [x] Onboarding wizard tests pass (`npx vitest run src/wizard/onboarding.test.ts`)
- [x] Format, typecheck, and lint clean (`pnpm check` on changed file)

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)