### PR TITLE
fix(ci): compute memory-aware V8 heap limit to prevent OOM on CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,6 @@ jobs:
         run: pnpm test
         env:
           REMOTECLAW_TEST_WORKERS: 2
-          REMOTECLAW_TEST_MAX_OLD_SPACE_SIZE_MB: 4096
 
   publish-next:
     if: github.event_name == 'push'

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -282,16 +282,26 @@ const WARNING_SUPPRESSION_FLAGS = [
   "--disable-warning=MaxListenersExceededWarning",
 ];
 
-const DEFAULT_CI_MAX_OLD_SPACE_SIZE_MB = 4096;
 const maxOldSpaceSizeMb = (() => {
-  // CI can hit Node heap limits (especially on large suites). Allow override, default to 4GB.
+  // Allow explicit override via env var.
   const raw = process.env.REMOTECLAW_TEST_MAX_OLD_SPACE_SIZE_MB ?? "";
   const parsed = Number.parseInt(raw, 10);
   if (Number.isFinite(parsed) && parsed > 0) {
     return parsed;
   }
   if (isCI && !isWindows) {
-    return DEFAULT_CI_MAX_OLD_SPACE_SIZE_MB;
+    // Compute memory-aware heap limit from host memory, parallel suite count,
+    // and per-suite worker count to avoid OOM on memory-constrained CI runners.
+    // ubuntu-latest has ~7 GiB RAM; the previous 4096 MB default let 6 workers
+    // claim 24 GB of V8 heap in theory, triggering intermittent OOM crashes.
+    const totalWorkers = parallelRuns.reduce((sum, entry) => {
+      return sum + (maxWorkersForRun(entry.name) ?? 2);
+    }, 0);
+    // Reserve ~25% for OS, Node orchestrator, and Vitest parent processes.
+    const availableMb = hostMemoryGiB * 1024 * 0.75;
+    const computed = Math.floor(availableMb / Math.max(1, totalWorkers));
+    // Clamp to [512, 2048] — avoid starving workers or wasting headroom.
+    return Math.max(512, Math.min(2048, computed));
   }
   return null;
 })();


### PR DESCRIPTION
## Summary

- Replace hardcoded 4096 MB per-worker V8 heap limit with memory-aware computation based on host RAM, parallel suite count, and per-suite worker count
- Remove explicit `REMOTECLAW_TEST_MAX_OLD_SPACE_SIZE_MB=4096` from `ci.yml` — the script auto-computes the right value; env var override still honored
- On ubuntu-latest (~7 GiB), drops theoretical V8 ceiling from 24 GB (6 workers × 4 GB) to ~5.4 GB (6 workers × 896 MB), eliminating intermittent OOM crashes

## How it works

```
perWorkerHeapMb = floor(hostMemoryGiB × 1024 × 0.75 / totalWorkers)
clamped to [512, 2048] MB
```

| Runner | Workers | Per-Worker | Total V8 Max |
|--------|---------|------------|-------------|
| ubuntu-latest (7 GiB) | 6 | 896 MB | 5.4 GB |
| 16 GiB runner | 6 | 2048 MB | 12.3 GB |
| 4 GiB runner | 6 | 512 MB | 3.1 GB |

Closes #18

## Test plan

- [x] `pnpm test` passes locally
- [x] Verified computed values match expected for 7/16/4 GiB scenarios
- [x] Formatting check passes
- [ ] CI passes on this PR (proves the fix works on ubuntu-latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)