### PR TITLE
fix(onboard): write workspace to agents.list during onboarding (#351)

### DIFF
--- a/src/commands/onboard-config.ts
+++ b/src/commands/onboard-config.ts
@@ -5,8 +5,9 @@ export const ONBOARDING_DEFAULT_DM_SCOPE: DmScope = "per-channel-peer";
 
 export function applyOnboardingLocalWorkspaceConfig(
   baseConfig: RemoteClawConfig,
+  workspace?: string,
 ): RemoteClawConfig {
-  return {
+  const result: RemoteClawConfig = {
     ...baseConfig,
     gateway: {
       ...baseConfig.gateway,
@@ -17,4 +18,19 @@ export function applyOnboardingLocalWorkspaceConfig(
       dmScope: baseConfig.session?.dmScope ?? ONBOARDING_DEFAULT_DM_SCOPE,
     },
   };
+
+  if (workspace) {
+    const existingList = Array.isArray(result.agents?.list) ? result.agents.list : [];
+    const list = existingList.map((entry) =>
+      entry && typeof entry === "object" && !("workspace" in entry && entry.workspace)
+        ? { ...entry, workspace }
+        : entry,
+    );
+    if (list.length === 0) {
+      list.push({ id: "main", workspace });
+    }
+    result.agents = { ...result.agents, list };
+  }
+
+  return result;
 }

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -122,7 +122,10 @@ export async function runNonInteractiveOnboardingLocal(params: {
     defaultWorkspaceDir: workspaceRaw,
   });
 
-  let nextConfig: RemoteClawConfig = applyOnboardingLocalWorkspaceConfig(baseConfig);
+  let nextConfig: RemoteClawConfig = applyOnboardingLocalWorkspaceConfig(
+    baseConfig,
+    workspaceRaw.trim(),
+  );
 
   const selectedRuntime = inferRuntimeFromFlags(opts);
   if (selectedRuntime) {

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -65,7 +65,7 @@ const readConfigFileSnapshot = vi.hoisted(() =>
     parsed: {},
     resolved: {},
     valid: true,
-    config: { agents: { list: [{ id: "main", workspace: "/tmp/test-workspace" }] } },
+    config: {},
     issues: [] as Array<{ path: string; message: string }>,
     warnings: [] as Array<{ path: string; message: string }>,
     legacyIssues: [] as Array<{ path: string; message: string }>,
@@ -202,7 +202,7 @@ describe("runOnboardingWizard", () => {
       parsed: {},
       resolved: {},
       valid: false,
-      config: { agents: { list: [{ id: "main", workspace: "/tmp/test-workspace" }] } },
+      config: {},
       issues: [{ path: "routing.allowFrom", message: "Legacy key" }],
       warnings: [],
       legacyIssues: [{ path: "routing.allowFrom", message: "Legacy key" }],
@@ -252,11 +252,13 @@ describe("runOnboardingWizard", () => {
     const prompter = buildWizardPrompter({ select, multiselect });
     const runtime = createRuntime({ throwsOnExit: true });
 
+    const workspaceDir = await makeCaseDir("workspace-");
     await runOnboardingWizard(
       {
         acceptRisk: true,
         flow: "quickstart",
         runtime: "claude",
+        workspace: workspaceDir,
         installDaemon: false,
         skipProviders: true,
         skipSkills: true,
@@ -270,6 +272,51 @@ describe("runOnboardingWizard", () => {
     expect(setupChannels).not.toHaveBeenCalled();
     expect(healthCommand).not.toHaveBeenCalled();
     expect(runTui).not.toHaveBeenCalled();
+  });
+
+  it("writes workspace to agents.list in config", async () => {
+    writeConfigFile.mockClear();
+
+    const workspaceDir = await makeCaseDir("workspace-");
+
+    const select = vi.fn(async (params: WizardSelectParams<unknown>) => {
+      if (
+        params.message === "Authentication for Claude Code" ||
+        params.message === "Authentication for Gemini CLI" ||
+        params.message === "Authentication for Codex CLI" ||
+        params.message === "Authentication for OpenCode"
+      ) {
+        return "skip";
+      }
+      return "quickstart";
+    }) as unknown as WizardPrompter["select"];
+    const prompter = buildWizardPrompter({ select });
+    const runtime = createRuntime({ throwsOnExit: true });
+
+    await runOnboardingWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        runtime: "claude",
+        workspace: workspaceDir,
+        installDaemon: false,
+        skipProviders: true,
+        skipSkills: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      runtime,
+      prompter,
+    );
+
+    type WrittenConfig = { agents?: { list?: Array<{ id?: string; workspace?: string }> } };
+    const writtenConfigs = writeConfigFile.mock.calls.map(
+      (call) => (call as unknown[])[0] as WrittenConfig,
+    );
+    const hasWorkspaceInList = writtenConfigs.some((cfg) =>
+      cfg.agents?.list?.some((entry) => entry.workspace === workspaceDir),
+    );
+    expect(hasWorkspaceInList).toBe(true);
   });
 
   async function runTuiHatchTest(params: {
@@ -338,6 +385,7 @@ describe("runOnboardingWizard", () => {
     delete process.env.BRAVE_API_KEY;
 
     try {
+      const workspaceDir = await makeCaseDir("workspace-");
       const select = vi.fn(async (params: WizardSelectParams<unknown>) => {
         if (
           params.message === "Authentication for Claude Code" ||
@@ -358,6 +406,7 @@ describe("runOnboardingWizard", () => {
           acceptRisk: true,
           flow: "quickstart",
           runtime: "claude",
+          workspace: workspaceDir,
           installDaemon: false,
           skipProviders: true,
           skipSkills: true,

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -573,7 +573,10 @@ export async function runOnboardingWizard(
   const workspaceDir = resolveUserPath(trimmedWorkspace);
 
   const { applyOnboardingLocalWorkspaceConfig } = await import("../commands/onboard-config.js");
-  let nextConfig: RemoteClawConfig = applyOnboardingLocalWorkspaceConfig(baseConfig);
+  let nextConfig: RemoteClawConfig = applyOnboardingLocalWorkspaceConfig(
+    baseConfig,
+    trimmedWorkspace,
+  );
 
   const { upsertAuthProfile } = await import("../agents/auth-profiles.js");
 


### PR DESCRIPTION
## Summary

- Onboarding wizard collected workspace path but never wrote it to `agents.list[]` in config, causing `resolveAgentWorkspaceDir` to throw at runtime
- Extended `applyOnboardingLocalWorkspaceConfig` to accept workspace and populate `agents.list` — fixes both interactive and non-interactive paths
- Test mock no longer pre-seeds `agents.list`, so tests exercise the actual code path; added test verifying workspace appears in written config

Closes #351

## Test plan

- [x] Existing onboarding tests pass (6/6)
- [x] `onboard-config` tests pass (3/3)
- [x] New test verifies `writeConfigFile` receives config with `agents.list[].workspace` set
- [x] Full test suite: 9899 passed (18 pre-existing extension dep failures unrelated)
- [x] TypeScript type-check clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)