### PR TITLE
fix(import): materialize OpenClaw implicit workspace defaults during config import (#350)

### DIFF
--- a/src/commands/import.test.ts
+++ b/src/commands/import.test.ts
@@ -7,6 +7,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import {
   detectOpenClawInstallation,
   importCommand,
+  materializeWorkspaceDefaults,
   resolveTargetFilename,
   transformConfigContent,
 } from "./import.js";
@@ -83,6 +84,114 @@ describe("transformConfigContent", () => {
     const { content, renames } = transformConfigContent(input);
     expect(content).toBe(input);
     expect(renames).toHaveLength(0);
+  });
+});
+
+describe("materializeWorkspaceDefaults", () => {
+  it("sets workspace on default agent when missing", () => {
+    const input = JSON.stringify({
+      agents: { list: [{ id: "main" }] },
+    });
+    const result = JSON.parse(materializeWorkspaceDefaults(input));
+    expect(result.agents.list[0].workspace).toBe("~/.remoteclaw/workspace");
+  });
+
+  it("sets workspace on non-default agent using id suffix", () => {
+    const input = JSON.stringify({
+      agents: {
+        list: [{ id: "main", default: true, workspace: "~/ws" }, { id: "helper" }],
+      },
+    });
+    const result = JSON.parse(materializeWorkspaceDefaults(input));
+    expect(result.agents.list[0].workspace).toBe("~/ws");
+    expect(result.agents.list[1].workspace).toBe("~/.remoteclaw/workspace-helper");
+  });
+
+  it("uses agents.defaults.workspace as fallback", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: { workspace: "~/custom-ws", model: "x" },
+        list: [{ id: "main" }, { id: "helper" }],
+      },
+    });
+    const result = JSON.parse(materializeWorkspaceDefaults(input));
+    expect(result.agents.list[0].workspace).toBe("~/custom-ws");
+    expect(result.agents.list[1].workspace).toBe("~/custom-ws");
+  });
+
+  it("removes agents.defaults.workspace after consuming", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: { workspace: "~/custom-ws", model: "x" },
+        list: [{ id: "main" }],
+      },
+    });
+    const result = JSON.parse(materializeWorkspaceDefaults(input));
+    expect(result.agents.defaults.workspace).toBeUndefined();
+    expect(result.agents.defaults.model).toBe("x");
+  });
+
+  it("removes agents.defaults entirely when workspace was the only key", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: { workspace: "~/custom-ws" },
+        list: [{ id: "main" }],
+      },
+    });
+    const result = JSON.parse(materializeWorkspaceDefaults(input));
+    expect(result.agents.defaults).toBeUndefined();
+  });
+
+  it("creates default agent when agents.list is empty but config has substantive content", () => {
+    const input = JSON.stringify({
+      gateway: { port: 18789 },
+      channels: { whatsapp: {} },
+    });
+    const result = JSON.parse(materializeWorkspaceDefaults(input));
+    expect(result.agents.list).toHaveLength(1);
+    expect(result.agents.list[0].id).toBe("main");
+    expect(result.agents.list[0].workspace).toBe("~/.remoteclaw/workspace");
+  });
+
+  it("creates default agent when agents key is missing but config has substantive content", () => {
+    const input = JSON.stringify({
+      plugins: { entries: {} },
+    });
+    const result = JSON.parse(materializeWorkspaceDefaults(input));
+    expect(result.agents.list[0].id).toBe("main");
+    expect(result.agents.list[0].workspace).toBe("~/.remoteclaw/workspace");
+  });
+
+  it("does not create agent entry for non-substantive config", () => {
+    const input = JSON.stringify({
+      env: { vars: { FOO: "bar" } },
+    });
+    const output = materializeWorkspaceDefaults(input);
+    expect(output).toBe(input);
+  });
+
+  it("preserves existing workspace values", () => {
+    const input = JSON.stringify({
+      agents: {
+        list: [{ id: "main", workspace: "~/my-workspace" }],
+      },
+    });
+    const output = materializeWorkspaceDefaults(input);
+    // No mutation needed — return original
+    expect(output).toBe(input);
+  });
+
+  it("returns non-JSON content unchanged", () => {
+    const input = "not valid json {{{";
+    expect(materializeWorkspaceDefaults(input)).toBe(input);
+  });
+
+  it("handles sole agent without explicit default flag as default", () => {
+    const input = JSON.stringify({
+      agents: { list: [{ id: "worker" }] },
+    });
+    const result = JSON.parse(materializeWorkspaceDefaults(input));
+    expect(result.agents.list[0].workspace).toBe("~/.remoteclaw/workspace");
   });
 });
 
@@ -261,6 +370,25 @@ describe("importCommand", () => {
 
     expect(result.copiedFiles).toHaveLength(1);
     expect(fs.existsSync(path.join(targetDir, "data.bin"))).toBe(true);
+  });
+
+  it("materializes workspace defaults in main config during import", async () => {
+    const configContent = JSON.stringify({
+      gateway: { port: 18789 },
+      channels: { whatsapp: {} },
+      agents: { list: [{ id: "main" }] },
+    });
+    await fsp.writeFile(path.join(sourceDir, "openclaw.json"), configContent);
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    const written = await fsp.readFile(path.join(targetDir, "remoteclaw.json"), "utf-8");
+    const parsed = JSON.parse(written);
+    expect(parsed.agents.list[0].workspace).toBe("~/.remoteclaw/workspace");
+    expect(result.transformedFiles).toHaveLength(1);
   });
 
   it("handles nested directory structures with mixed file types", async () => {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -21,6 +21,31 @@ const ENV_VAR_PREFIX_NEW = "REMOTECLAW_";
 const OPENCLAW_CONFIG_FILENAME = "openclaw.json";
 const REMOTECLAW_CONFIG_FILENAME = "remoteclaw.json";
 
+/**
+ * Default agent id used by OpenClaw when no explicit id is set.
+ */
+const DEFAULT_AGENT_ID = "main";
+
+/**
+ * Default workspace path for the default agent.
+ */
+const DEFAULT_WORKSPACE = "~/.remoteclaw/workspace";
+
+/**
+ * Keys whose presence indicates the config has substantive content
+ * (i.e. it's a real config, not an empty/skeleton file).
+ */
+const SUBSTANTIVE_CONFIG_KEYS = new Set([
+  "channels",
+  "plugins",
+  "gateway",
+  "bindings",
+  "broadcast",
+  "cron",
+  "hooks",
+  "discovery",
+]);
+
 export type ImportOptions = {
   sourcePath: string;
   yes?: boolean;
@@ -89,6 +114,95 @@ export function transformConfigContent(content: string): {
 }
 
 /**
+ * Materialize implicit OpenClaw workspace defaults into the main config JSON.
+ *
+ * OpenClaw had a three-tier workspace resolution chain that was removed in
+ * #278 and #298. After import, configs that relied on those implicit defaults
+ * fail validation. This function makes those defaults explicit:
+ *
+ * 1. For each agent in agents.list[] without workspace:
+ *    - Use agents.defaults.workspace if set
+ *    - Else default agent → ~/.remoteclaw/workspace
+ *    - Else non-default → ~/.remoteclaw/workspace-{id}
+ * 2. If agents.list is empty/missing but config has substantive content,
+ *    create a default agent entry.
+ * 3. Remove agents.defaults.workspace after consuming it.
+ */
+export function materializeWorkspaceDefaults(jsonContent: string): string {
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(jsonContent);
+  } catch {
+    // Not valid JSON — return as-is (don't break non-JSON configs)
+    return jsonContent;
+  }
+
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    return jsonContent;
+  }
+
+  const agents = config.agents as Record<string, unknown> | undefined;
+  const agentsList = (agents?.list ?? []) as Record<string, unknown>[];
+  const defaultsWorkspace =
+    typeof (agents?.defaults as Record<string, unknown> | undefined)?.workspace === "string"
+      ? ((agents!.defaults as Record<string, unknown>).workspace as string)
+      : undefined;
+
+  const hasSubstantiveContent = Object.keys(config).some((key) => SUBSTANTIVE_CONFIG_KEYS.has(key));
+
+  let mutated = false;
+
+  if (agentsList.length === 0 && hasSubstantiveContent) {
+    // Step 2: Create default agent entry when config has real content
+    const newAgents = agents ?? {};
+    newAgents.list = [{ id: DEFAULT_AGENT_ID, workspace: DEFAULT_WORKSPACE }];
+    config.agents = newAgents;
+    mutated = true;
+  } else {
+    // Step 1: Materialize workspace on existing agents
+    for (const entry of agentsList) {
+      if (typeof entry.workspace === "string" && entry.workspace.trim()) {
+        continue;
+      }
+      if (defaultsWorkspace) {
+        entry.workspace = defaultsWorkspace;
+      } else {
+        const id = typeof entry.id === "string" ? entry.id.trim() : "";
+        const isDefault =
+          entry.default === true || id === DEFAULT_AGENT_ID || agentsList.length === 1;
+        entry.workspace = isDefault
+          ? DEFAULT_WORKSPACE
+          : `~/.remoteclaw/workspace-${id || DEFAULT_AGENT_ID}`;
+      }
+      mutated = true;
+    }
+  }
+
+  // Step 3: Remove agents.defaults.workspace after consuming
+  if (defaultsWorkspace && config.agents) {
+    const defaults = (config.agents as Record<string, unknown>).defaults as
+      | Record<string, unknown>
+      | undefined;
+    if (defaults) {
+      delete defaults.workspace;
+      if (Object.keys(defaults).length === 0) {
+        delete (config.agents as Record<string, unknown>).defaults;
+      }
+      mutated = true;
+    }
+  }
+
+  if (!mutated) {
+    return jsonContent;
+  }
+
+  // Preserve original indentation style
+  const indentMatch = jsonContent.match(/^(\s+)"/m);
+  const indent = indentMatch?.[1] ?? "  ";
+  return JSON.stringify(config, null, indent) + "\n";
+}
+
+/**
  * Determine the target filename for a source file.
  * Renames openclaw.json -> remoteclaw.json at any directory level.
  */
@@ -139,12 +253,15 @@ async function copyDirectory(params: {
       if (isConfigFile(entry.name)) {
         const content = await fsp.readFile(sourcePath, "utf-8");
         const { content: transformed, renames } = transformConfigContent(content);
-        if (renames.length > 0) {
+        // Apply structural config transform to the main config file
+        const isMainConfig = entry.name === OPENCLAW_CONFIG_FILENAME;
+        const final = isMainConfig ? materializeWorkspaceDefaults(transformed) : transformed;
+        if (renames.length > 0 || final !== transformed) {
           result.transformedFiles.push(targetPath);
           result.envVarRenames.push(...renames);
         }
         if (!dryRun) {
-          await fsp.writeFile(targetPath, transformed, "utf-8");
+          await fsp.writeFile(targetPath, final, "utf-8");
         }
         result.copiedFiles.push(targetPath);
       } else {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveAgentWorkspaceDirOrNull, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { CHANNEL_IDS, normalizeChatChannelId } from "../channels/registry.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "../plugins/config-state.js";
 import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
@@ -62,11 +62,11 @@ function validateIdentityAvatar(config: RemoteClawConfig): ConfigValidationIssue
       });
       continue;
     }
-    const workspaceDir = resolveAgentWorkspaceDir(
+    const workspaceDir = resolveAgentWorkspaceDirOrNull(
       config,
       entry.id ?? resolveDefaultAgentId(config),
     );
-    if (!isWorkspaceAvatarPath(avatar, workspaceDir)) {
+    if (workspaceDir != null && !isWorkspaceAvatarPath(avatar, workspaceDir)) {
       issues.push({
         path: `agents.list.${index}.identity.avatar`,
         message: "identity.avatar must stay within the agent workspace.",
@@ -204,7 +204,7 @@ function validateConfigObjectWithPluginsBase(
       return registryInfo;
     }
 
-    const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+    const workspaceDir = resolveAgentWorkspaceDirOrNull(config, resolveDefaultAgentId(config));
     const registry = loadPluginManifestRegistry({
       config,
       workspaceDir: workspaceDir ?? undefined,


### PR DESCRIPTION
## Summary

- Add `materializeWorkspaceDefaults()` structural config transform to the import command that materializes implicit OpenClaw workspace defaults (removed in #278, #298) into explicit per-agent `workspace` fields
- Create a default agent entry when `agents.list` is empty/missing but config has substantive content (channels, plugins, gateway, etc.)
- Remove `agents.defaults.workspace` after consuming it during import
- Harden `src/config/validation.ts` by switching `resolveAgentWorkspaceDir` → `resolveAgentWorkspaceDirOrNull` at two call sites, preventing validation crashes from hand-edited configs missing workspace

Closes #350

## Test plan

- [x] 10 unit tests for `materializeWorkspaceDefaults` covering: default agent, non-default agent suffix, `defaults.workspace` fallback, defaults cleanup, empty defaults removal, substantive vs non-substantive content, preserving existing values, non-JSON passthrough, sole agent handling
- [x] 1 integration test for full import command verifying workspace materialization end-to-end
- [x] Existing test suite passes (no regressions)
- [x] Type-check clean (`tsgo --noEmit` — no errors in `src/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)