### PR TITLE
ci: add release-triggered stable publish workflow (#210)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
+  release:
+    types: [published]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -116,3 +118,57 @@ jobs:
 
           npm version "$NEXT_VERSION" --no-git-tag-version
           npm publish --tag next --provenance --access public || true
+
+  publish-latest:
+    if: github.event_name == 'release'
+    needs: [lint, build, test]
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Configure npm registry
+        uses: actions/setup-node@v4
+        with:
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm
+        run: npm install -g "npm@>=11.5.1"
+
+      - name: Validate version matches tag
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $TAG does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test
+        env:
+          REMOTECLAW_TEST_WORKERS: 2
+          REMOTECLAW_TEST_MAX_OLD_SPACE_SIZE_MB: 4096
+
+      - name: Publish
+        run: |
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            npm publish --provenance --tag beta --access public
+          else
+            npm publish --provenance --access public
+          fi


### PR DESCRIPTION
## Summary

- Add `release: types: [published]` trigger to `ci.yml`
- Add `publish-latest` job that validates version matches tag, builds, tests, and publishes to npm with provenance
- Prerelease GitHub Releases publish with `--tag beta` instead of `latest`
- Uses the same `npm-publish` protected environment and OIDC permissions as `publish-next`

Closes #210

## Test plan

- [ ] CI passes (lint, build, test jobs)
- [ ] `publish-latest` job is correctly gated by `if: github.event_name == 'release'` (won't run on push/PR)
- [ ] `publish-next` job continues to work on push to main
- [ ] Creating a GitHub Release triggers the `publish-latest` job
- [ ] Prerelease GitHub Release publishes with `--tag beta`

🤖 Generated with [Claude Code](https://claude.com/claude-code)