### PR TITLE
fix(middleware): use CLI runtime name instead of model API provider for ChannelBridge (#361)

### DIFF
--- a/src/agents/defaults.ts
+++ b/src/agents/defaults.ts
@@ -1,6 +1,12 @@
-// Defaults for agent metadata when upstream does not supply them.
-// Model id uses pi-ai's built-in Anthropic catalog.
+// TODO(gut): DEFAULT_PROVIDER and DEFAULT_MODEL are OpenClaw remnants from its
+// model-management system.  RemoteClaw does not control which model a CLI
+// runtime uses — the CLI owns model selection.  These constants (and the
+// `agents.*.model` config fields they back) need to be fully gutted.
+// The only "provider" concept RemoteClaw owns is the CLI runtime name
+// ("claude", "gemini", …), handled by resolveCliRuntimeProvider().
+/** @deprecated OpenClaw remnant — will be removed with model-config gutting. */
 export const DEFAULT_PROVIDER = "anthropic";
+/** @deprecated OpenClaw remnant — will be removed with model-config gutting. */
 export const DEFAULT_MODEL = "claude-opus-4-6";
 // Conservative fallback used when model metadata is unavailable.
 export const DEFAULT_CONTEXT_TOKENS = 200_000;

--- a/src/auto-reply/reply.heartbeat-typing.test.ts
+++ b/src/auto-reply/reply.heartbeat-typing.test.ts
@@ -9,6 +9,18 @@ vi.mock(
   async () => await import("../test-utils/model-fallback.mock.js"),
 );
 
+vi.mock("../middleware/channel-bridge.js", () => ({
+  ChannelBridge: class MockChannelBridge {
+    async handle() {
+      return {
+        payloads: [{ text: "ok" }],
+        run: { text: "ok", durationMs: 10 },
+        mcp: { sentTexts: [], sentMediaUrls: [], sentTargets: [], cronAdds: 0 },
+      };
+    }
+  },
+}));
+
 const webMocks = vi.hoisted(() => ({
   webAuthExists: vi.fn().mockResolvedValue(true),
   getWebAuthAgeMs: vi.fn().mockReturnValue(120_000),

--- a/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.test.ts
@@ -217,7 +217,8 @@ describe("trigger handling", () => {
         await getReplyFromConfig(BASE_MESSAGE, { isHeartbeat: true }, cfg);
 
         const call = runAgentMock.mock.calls[0]?.[0];
-        expect(call?.provider).toBe("anthropic");
+        // ChannelBridge receives the CLI runtime name, not the model API provider.
+        expect(call?.provider).toBe("claude");
       }
       {
         const cfg = makeCfg(home);

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -19,6 +19,7 @@ import { resolveGatewayCredentialsFromConfig } from "../../gateway/credentials.j
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
+import { resolveCliRuntimeProvider } from "../../middleware/runtime-factory.js";
 import type { SessionMap } from "../../middleware/session-map.js";
 import type {
   AgentDeliveryResult,
@@ -279,7 +280,7 @@ export async function runAgentTurnWithFallback(params: {
 
         const cfg = params.followupRun.run.config;
         const bridge = new ChannelBridge({
-          provider,
+          provider: resolveCliRuntimeProvider(cfg),
           sessionMap,
           gatewayUrl: resolveGatewayUrlFromConfig(cfg),
           gatewayToken: resolveGatewayTokenFromConfig(cfg),

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -6,6 +6,7 @@ import type { TypingMode } from "../../config/types.js";
 import { resolveGatewayCredentialsFromConfig } from "../../gateway/credentials.js";
 import { logVerbose } from "../../globals.js";
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
+import { resolveCliRuntimeProvider } from "../../middleware/runtime-factory.js";
 import type { SessionMap } from "../../middleware/session-map.js";
 import type { BridgeCallbacks, ChannelMessage } from "../../middleware/types.js";
 import type { GetReplyOptions } from "../types.js";
@@ -61,7 +62,7 @@ export function createFollowupRunner(params: {
         : "";
 
       const bridge = new ChannelBridge({
-        provider,
+        provider: resolveCliRuntimeProvider(cfg),
         sessionMap,
         gatewayUrl,
         gatewayToken,

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -327,7 +327,7 @@ describe("agentCommand", () => {
     });
   });
 
-  it("uses hardcoded default provider when no session override exists", async () => {
+  it("uses CLI runtime from config for bridge provider", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");
       mockConfig(home, store, {
@@ -340,10 +340,9 @@ describe("agentCommand", () => {
 
       await agentCommand({ message: "hi", to: "+1555" }, runtime);
 
-      // agent.ts uses DEFAULT_PROVIDER ("anthropic") from agents/defaults.ts,
-      // not agents.defaults.model.primary from config. Config-driven model
-      // resolution was removed with model-selection.ts.
-      expect(bridgeConstructorCalls.at(-1)?.provider).toBe("anthropic");
+      // ChannelBridge receives the CLI runtime from agents.defaults.runtime
+      // (falling back to "claude"), NOT the model API provider.
+      expect(bridgeConstructorCalls.at(-1)?.provider).toBe("claude");
     });
   });
 
@@ -376,8 +375,9 @@ describe("agentCommand", () => {
         runtime,
       );
 
-      // ChannelBridge constructed with the stored override provider.
-      expect(bridgeConstructorCalls.at(-1)?.provider).toBe("openai");
+      // ChannelBridge receives the CLI runtime (from config, defaulting to
+      // "claude"), not the model API provider override.
+      expect(bridgeConstructorCalls.at(-1)?.provider).toBe("claude");
 
       const saved = JSON.parse(fs.readFileSync(store, "utf-8")) as Record<
         string,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -39,6 +39,7 @@ import {
   registerAgentRunContext,
 } from "../infra/agent-events.js";
 import { ChannelBridge } from "../middleware/channel-bridge.js";
+import { resolveCliRuntimeProvider } from "../middleware/runtime-factory.js";
 import type { SessionMap } from "../middleware/session-map.js";
 import type { AgentDeliveryResult, ChannelMessage } from "../middleware/types.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -355,7 +356,7 @@ export async function agentCommand(
       });
 
       const bridge = new ChannelBridge({
-        provider,
+        provider: resolveCliRuntimeProvider(cfg),
         sessionMap,
         gatewayUrl: resolveGatewayUrlFromConfig(cfg),
         gatewayToken: resolveGatewayTokenFromConfig(cfg),

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -25,6 +25,7 @@ import { resolveGatewayCredentialsFromConfig } from "../../gateway/credentials.j
 import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { logWarn } from "../../logger.js";
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
+import { resolveCliRuntimeProvider } from "../../middleware/runtime-factory.js";
 import type { SessionMap } from "../../middleware/session-map.js";
 import type { AgentDeliveryResult, ChannelMessage } from "../../middleware/types.js";
 import { buildAgentMainSessionKey, normalizeAgentId } from "../../routing/session-key.js";
@@ -372,7 +373,7 @@ export async function runCronIsolatedAgentTurn(params: {
     });
 
     const bridge = new ChannelBridge({
-      provider,
+      provider: resolveCliRuntimeProvider(cfgWithAgentDefaults),
       sessionMap,
       gatewayUrl: resolveGatewayUrlFromConfig(cfgWithAgentDefaults),
       gatewayToken: resolveGatewayTokenFromConfig(cfgWithAgentDefaults),

--- a/src/middleware/runtime-factory.test.ts
+++ b/src/middleware/runtime-factory.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createCliRuntime, SUPPORTED_PROVIDERS } from "./runtime-factory.js";
+import {
+  createCliRuntime,
+  resolveCliRuntimeProvider,
+  SUPPORTED_PROVIDERS,
+} from "./runtime-factory.js";
 import { ClaudeCliRuntime } from "./runtimes/claude.js";
 import { CodexCliRuntime } from "./runtimes/codex.js";
 import { GeminiCliRuntime } from "./runtimes/gemini.js";
@@ -93,5 +97,31 @@ describe("createCliRuntime", () => {
     it("contains exactly the four supported provider names", () => {
       expect([...SUPPORTED_PROVIDERS]).toEqual(["claude", "gemini", "codex", "opencode"]);
     });
+  });
+});
+
+// ── resolveCliRuntimeProvider ─────────────────────────────────────────────
+
+describe("resolveCliRuntimeProvider", () => {
+  it("returns agents.defaults.runtime when set", () => {
+    expect(resolveCliRuntimeProvider({ agents: { defaults: { runtime: "gemini" } } })).toBe(
+      "gemini",
+    );
+  });
+
+  it("falls back to 'claude' when runtime is undefined", () => {
+    expect(resolveCliRuntimeProvider({ agents: { defaults: {} } })).toBe("claude");
+  });
+
+  it("falls back to 'claude' when defaults is undefined", () => {
+    expect(resolveCliRuntimeProvider({ agents: {} })).toBe("claude");
+  });
+
+  it("falls back to 'claude' when agents is undefined", () => {
+    expect(resolveCliRuntimeProvider({})).toBe("claude");
+  });
+
+  it("falls back to 'claude' when config is undefined", () => {
+    expect(resolveCliRuntimeProvider(undefined)).toBe("claude");
   });
 });

--- a/src/middleware/runtime-factory.ts
+++ b/src/middleware/runtime-factory.ts
@@ -8,6 +8,21 @@ export const SUPPORTED_PROVIDERS = ["claude", "gemini", "codex", "opencode"] as 
 
 export type SupportedProvider = (typeof SUPPORTED_PROVIDERS)[number];
 
+const DEFAULT_CLI_RUNTIME: SupportedProvider = "claude";
+
+/**
+ * Resolve the CLI runtime provider from config.
+ *
+ * Reads `agents.defaults.runtime` (set during onboarding) and falls back to
+ * "claude" when unset.  This is the **CLI runtime** (which binary to spawn),
+ * NOT the model-API provider (e.g. "anthropic").
+ */
+export function resolveCliRuntimeProvider(cfg?: {
+  agents?: { defaults?: { runtime?: string } };
+}): string {
+  return cfg?.agents?.defaults?.runtime ?? DEFAULT_CLI_RUNTIME;
+}
+
 export function createCliRuntime(provider: string): AgentRuntime {
   const normalized = provider.trim().toLowerCase();
 


### PR DESCRIPTION
## Summary

- Add `resolveCliRuntimeProvider(cfg)` that reads `agents.defaults.runtime` from config to determine which CLI binary to spawn
- Wire all four `ChannelBridge` construction sites to use the CLI runtime name ("claude") instead of the model API provider ("anthropic")
- Annotate `DEFAULT_PROVIDER` and `DEFAULT_MODEL` as `@deprecated` OpenClaw remnants pending full removal in #357

Fixes #361

## Problem

After OpenClaw→RemoteClaw config migration, the agent command crashed:
```
Error: Unknown runtime provider "anthropic". Supported providers: claude, gemini, codex, opencode
```

`ChannelBridge` was receiving the **model API provider** name (`"anthropic"`, from `DEFAULT_PROVIDER`) instead of the **CLI runtime** name (`"claude"`). These are two distinct concepts that were conflated in the upstream OpenClaw code.

## Changes

| File | Change |
|------|--------|
| `src/middleware/runtime-factory.ts` | Add `resolveCliRuntimeProvider(cfg)` |
| `src/commands/agent.ts` | Use `resolveCliRuntimeProvider(cfg)` for bridge provider |
| `src/auto-reply/reply/agent-runner-execution.ts` | Same |
| `src/auto-reply/reply/followup-runner.ts` | Same |
| `src/cron/isolated-agent/run.ts` | Same |
| `src/middleware/runtime-factory.test.ts` | Add 5 tests for `resolveCliRuntimeProvider` |
| `src/commands/agent.test.ts` | Update expectations from `"anthropic"`/`"openai"` to `"claude"` |
| `src/agents/defaults.ts` | Annotate constants as `@deprecated` with TODO |

## Test plan

- [x] `pnpm test -- src/middleware/runtime-factory.test.ts` — 18 tests pass
- [x] `pnpm test -- src/commands/agent.test.ts` — 20 tests pass
- [x] `pnpm tsgo` — clean
- [x] `pnpm lint` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)