### PR TITLE
fix(ui): rename Claude Code label from "claude --print" to "claude" (#356)

### DIFF
--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -259,7 +259,7 @@ export async function agentsAddCommand(
       const selectedRuntime: AgentRuntime = await prompter.select({
         message: "Which agent runtime?",
         options: [
-          { value: "claude", label: "Claude Code (claude --print)" },
+          { value: "claude", label: "Claude Code (claude)" },
           { value: "gemini", label: "Gemini CLI (gemini)" },
           { value: "codex", label: "Codex CLI (codex exec)" },
           { value: "opencode", label: "OpenCode (opencode)" },

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -61,7 +61,7 @@ export async function promptAuthConfig(
   const selectedRuntime: AgentRuntime = await prompter.select({
     message: "Which agent runtime?",
     options: [
-      { value: "claude", label: "Claude Code (claude --print)" },
+      { value: "claude", label: "Claude Code (claude)" },
       { value: "gemini", label: "Gemini CLI (gemini)" },
       { value: "codex", label: "Codex CLI (codex exec)" },
       { value: "opencode", label: "OpenCode (opencode)" },

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -586,7 +586,7 @@ export async function runOnboardingWizard(
     (await prompter.select({
       message: "Which agent runtime?",
       options: [
-        { value: "claude", label: "Claude Code (claude --print)" },
+        { value: "claude", label: "Claude Code (claude)" },
         { value: "gemini", label: "Gemini CLI (gemini)" },
         { value: "codex", label: "Codex CLI (codex exec)" },
         { value: "opencode", label: "OpenCode (opencode)" },


### PR DESCRIPTION
## Summary

- Remove the `--print` flag from the Claude Code agent runtime label in all three prompt locations — it's an implementation detail, not a user-facing concept

Closes #356

## Test plan

- [x] `pnpm tsgo` passes
- [x] `pnpm format` passes
- [x] Grep confirms no remaining `claude --print` in UI labels (only in runtime comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)