### PR TITLE
docs(seo): optimize comparison docs SEO metadata (#329)

### DIFF
--- a/docs/install/breaking-changes-from-openclaw.md
+++ b/docs/install/breaking-changes-from-openclaw.md
@@ -1,12 +1,12 @@
 ---
-description: "What OpenClaw users lose and gain when switching to RemoteClaw"
+description: "Complete list of RemoteClaw breaking changes from OpenClaw: removed features, new capabilities, renamed config, and what stays the same."
 read_when:
   - You are switching from OpenClaw to RemoteClaw
   - You want to know what features were removed or replaced
-title: "Breaking Changes from OpenClaw"
+title: "RemoteClaw Breaking Changes from OpenClaw — What's Removed, Added, and Changed"
 ---
 
-# Breaking Changes from OpenClaw
+# What Are the Breaking Changes from OpenClaw to RemoteClaw?
 
 RemoteClaw is a fork of OpenClaw that replaced the embedded Pi execution engine with a middleware architecture. This page lists everything that changed, was removed, or was added.
 

--- a/docs/install/from-openclaw.mdx
+++ b/docs/install/from-openclaw.mdx
@@ -1,15 +1,15 @@
 ---
-description: "Migrate an existing OpenClaw installation to RemoteClaw"
+description: "Step-by-step guide to migrate from OpenClaw to RemoteClaw: import config, sessions, cron jobs, and channel settings with a single command."
 read_when:
   - You are running OpenClaw and want to switch to RemoteClaw
   - You need to understand what the import command does
   - You want to know what migrates and what does not
-title: "Migrate from OpenClaw"
+title: "Migrate from OpenClaw to RemoteClaw — Step-by-Step Guide"
 ---
 
 import { Steps } from "@astrojs/starlight/components";
 
-# Migrate from OpenClaw
+# How Do I Migrate from OpenClaw to RemoteClaw?
 
 RemoteClaw can import your existing OpenClaw config, session history, cron jobs, and channel settings. This guide walks through the full migration.
 

--- a/docs/start/openclaw-or-remoteclaw.mdx
+++ b/docs/start/openclaw-or-remoteclaw.mdx
@@ -1,9 +1,9 @@
 ---
-description: "Decision guide for choosing between OpenClaw and RemoteClaw"
+description: "Compare OpenClaw and RemoteClaw: middleware architecture vs embedded engine, CLI subprocess vs in-process, and when each is the right choice."
 read_when:
   - You are evaluating whether to use OpenClaw or RemoteClaw
   - You want to understand the trade-offs between the two projects
-title: "OpenClaw or RemoteClaw?"
+title: "OpenClaw or RemoteClaw? Decision Guide for AI Agent Middleware"
 ---
 
 import { TabItem, Tabs } from "@astrojs/starlight/components";


### PR DESCRIPTION
## Summary

- Optimized frontmatter `title` and `description` on the three OpenClaw comparison docs pages to capture search traffic for key queries
- Updated H1 headings to question format for featured snippet eligibility

### Pages updated

| Page | Target queries |
|------|---------------|
| `docs/start/openclaw-or-remoteclaw.mdx` | "OpenClaw vs RemoteClaw", "OpenClaw alternative" |
| `docs/install/from-openclaw.mdx` | "migrate from OpenClaw" |
| `docs/install/breaking-changes-from-openclaw.md` | "RemoteClaw breaking changes" |

Closes #329

## Test plan

- [ ] Verify Starlight renders the updated titles and descriptions correctly
- [ ] Confirm H1 headings display properly on each page
- [ ] Check that sidebar navigation still works (Starlight uses `title` for sidebar labels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)