### PR TITLE
perf(ci): shard unit-fast into 2 to halve test wall time (#363)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         run: pnpm test
         env:
           REMOTECLAW_TEST_WORKERS: 1
+          REMOTECLAW_TEST_MAX_OLD_SPACE_SIZE_MB: 1536
 
   publish-next:
     if: github.event_name == 'push'

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -162,6 +162,31 @@ const runs = [
     ],
   },
 ];
+// In CI on Linux, shard unit-fast into parallel lanes to halve wall time.
+// Configurable via REMOTECLAW_TEST_UNIT_FAST_SHARDS; defaults to 2 in Linux CI.
+const unitFastShardCount = (() => {
+  const raw = process.env.REMOTECLAW_TEST_UNIT_FAST_SHARDS;
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  if (isCI && !isWindows && !isMacOS) {
+    return 2;
+  }
+  return 1;
+})();
+const expandedRuns = runs.flatMap((entry) => {
+  if (entry.name !== "unit-fast" || unitFastShardCount <= 1) {
+    return [entry];
+  }
+  return Array.from({ length: unitFastShardCount }, (_, i) => ({
+    ...entry,
+    args: [...entry.args, "--shard", `${i + 1}/${unitFastShardCount}`],
+  }));
+});
+
 const shardOverride = Number.parseInt(process.env.REMOTECLAW_TEST_SHARDS ?? "", 10);
 const shardCount = isWindowsCi
   ? Number.isFinite(shardOverride) && shardOverride > 1
@@ -193,8 +218,12 @@ const keepGatewaySerial =
   process.env.REMOTECLAW_TEST_SERIAL_GATEWAY === "1" ||
   testProfile === "serial" ||
   !parallelGatewayEnabled;
-const parallelRuns = keepGatewaySerial ? runs.filter((entry) => entry.name !== "gateway") : runs;
-const serialRuns = keepGatewaySerial ? runs.filter((entry) => entry.name === "gateway") : [];
+const parallelRuns = keepGatewaySerial
+  ? expandedRuns.filter((entry) => entry.name !== "gateway")
+  : expandedRuns;
+const serialRuns = keepGatewaySerial
+  ? expandedRuns.filter((entry) => entry.name === "gateway")
+  : [];
 const baseLocalWorkers = Math.max(4, Math.min(16, hostCpuCount));
 const loadAwareDisabledRaw = process.env.REMOTECLAW_TEST_LOAD_AWARE?.trim().toLowerCase();
 const loadAwareDisabled = loadAwareDisabledRaw === "0" || loadAwareDisabledRaw === "false";
@@ -347,7 +376,7 @@ function resolveReportPath(entry, extraArgs) {
   if (!reportDir) {
     return null;
   }
-  const shardSuffix = resolveShardSuffix(extraArgs);
+  const shardSuffix = resolveShardSuffix([...entry.args, ...extraArgs]);
   return path.join(reportDir, `vitest-${entry.name}${shardSuffix}.json`);
 }
 


### PR DESCRIPTION
## Summary

- Shard `unit-fast` into 2 parallel vitest shards (`--shard 1/2`, `--shard 2/2`) on Linux CI, running alongside `extensions` and `unit-isolated` — 4 lanes on 4 vCPUs
- Set `REMOTECLAW_TEST_MAX_OLD_SPACE_SIZE_MB=1536` in `ci.yml` as a fixed override to ensure adequate heap per V8 process across 4 lanes
- Fix `resolveReportPath` to detect `--shard` in `entry.args` (not just `extraArgs`), so each shard writes a distinct integrity report file

## Test plan

- [x] Verified shard expansion logic: local stays at 1 shard (no behavior change), Linux CI expands to 2
- [x] Verified report path fix: each shard produces a distinct report file (`vitest-unit-fast-shard1of2.json`, `vitest-unit-fast-shard2of2.json`)
- [x] Format check passes (`oxfmt`)
- [x] Lint passes (pre-commit hook)
- [ ] CI: `build` job passes
- [ ] CI: `test` job passes with sharded unit-fast

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)