### PR TITLE
feat(runtime): add configurable runtimeArgs for CLI runtime invocation

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -19,7 +19,10 @@ import { resolveGatewayCredentialsFromConfig } from "../../gateway/credentials.j
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
-import { resolveCliRuntimeProvider } from "../../middleware/runtime-factory.js";
+import {
+  resolveCliRuntimeArgs,
+  resolveCliRuntimeProvider,
+} from "../../middleware/runtime-factory.js";
 import type { SessionMap } from "../../middleware/session-map.js";
 import type {
   AgentDeliveryResult,
@@ -285,6 +288,7 @@ export async function runAgentTurnWithFallback(params: {
           gatewayUrl: resolveGatewayUrlFromConfig(cfg),
           gatewayToken: resolveGatewayTokenFromConfig(cfg),
           workspaceDir: params.followupRun.run.workspaceDir,
+          runtimeArgs: resolveCliRuntimeArgs(cfg),
         });
 
         const messageToolHints = resolveChannelMessageToolHints({

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -6,7 +6,10 @@ import type { TypingMode } from "../../config/types.js";
 import { resolveGatewayCredentialsFromConfig } from "../../gateway/credentials.js";
 import { logVerbose } from "../../globals.js";
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
-import { resolveCliRuntimeProvider } from "../../middleware/runtime-factory.js";
+import {
+  resolveCliRuntimeArgs,
+  resolveCliRuntimeProvider,
+} from "../../middleware/runtime-factory.js";
 import type { SessionMap } from "../../middleware/session-map.js";
 import type { BridgeCallbacks, ChannelMessage } from "../../middleware/types.js";
 import type { GetReplyOptions } from "../types.js";
@@ -67,6 +70,7 @@ export function createFollowupRunner(params: {
         gatewayUrl,
         gatewayToken,
         workspaceDir: queued.run.workspaceDir,
+        runtimeArgs: resolveCliRuntimeArgs(cfg),
       });
 
       // Build channel message from followup run fields.

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -39,7 +39,7 @@ import {
   registerAgentRunContext,
 } from "../infra/agent-events.js";
 import { ChannelBridge } from "../middleware/channel-bridge.js";
-import { resolveCliRuntimeProvider } from "../middleware/runtime-factory.js";
+import { resolveCliRuntimeArgs, resolveCliRuntimeProvider } from "../middleware/runtime-factory.js";
 import type { SessionMap } from "../middleware/session-map.js";
 import type { AgentDeliveryResult, ChannelMessage } from "../middleware/types.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -361,6 +361,7 @@ export async function agentCommand(
         gatewayUrl: resolveGatewayUrlFromConfig(cfg),
         gatewayToken: resolveGatewayTokenFromConfig(cfg),
         workspaceDir,
+        runtimeArgs: resolveCliRuntimeArgs(cfg),
       });
 
       const messageToolHints = resolveChannelMessageToolHints({

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -262,6 +262,8 @@ export type AgentDefaultsConfig = {
   sandbox?: AgentSandboxConfig;
   /** Selected agent runtime (claude, gemini, codex, opencode). */
   runtime?: "claude" | "gemini" | "codex" | "opencode";
+  /** Extra CLI arguments appended to every runtime invocation. */
+  runtimeArgs?: string[];
 };
 
 export type AgentCompactionMode = "default" | "safeguard";

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -142,6 +142,7 @@ export const AgentDefaultsSchema = z
     runtime: z
       .union([z.literal("claude"), z.literal("gemini"), z.literal("codex"), z.literal("opencode")])
       .optional(),
+    runtimeArgs: z.array(z.string()).optional(),
   })
   .strict()
   .optional();

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -25,7 +25,10 @@ import { resolveGatewayCredentialsFromConfig } from "../../gateway/credentials.j
 import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { logWarn } from "../../logger.js";
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
-import { resolveCliRuntimeProvider } from "../../middleware/runtime-factory.js";
+import {
+  resolveCliRuntimeArgs,
+  resolveCliRuntimeProvider,
+} from "../../middleware/runtime-factory.js";
 import type { SessionMap } from "../../middleware/session-map.js";
 import type { AgentDeliveryResult, ChannelMessage } from "../../middleware/types.js";
 import { buildAgentMainSessionKey, normalizeAgentId } from "../../routing/session-key.js";
@@ -378,6 +381,7 @@ export async function runCronIsolatedAgentTurn(params: {
       gatewayUrl: resolveGatewayUrlFromConfig(cfgWithAgentDefaults),
       gatewayToken: resolveGatewayTokenFromConfig(cfgWithAgentDefaults),
       workspaceDir,
+      runtimeArgs: resolveCliRuntimeArgs(cfgWithAgentDefaults),
     });
 
     const messageToolHints = resolveChannelMessageToolHints({

--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -806,6 +806,39 @@ describe("ChannelBridge", () => {
       const mcpArgs = executeFn.mock.calls[0][0].mcpServers!.remoteclaw.args!;
       expect(mcpArgs[0]).toContain("mcp-server.js");
     });
+
+    it("passes runtimeArgs as extraArgs to runtime.execute()", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = new ChannelBridge({
+        provider: "claude",
+        sessionMap,
+        gatewayUrl: "wss://gw.test.com",
+        gatewayToken: "tok",
+        runtimeArgs: ["--dangerously-skip-permissions"],
+      });
+      await bridge.handle(makeMessage());
+
+      const params = executeFn.mock.calls[0][0];
+      expect(params.extraArgs).toEqual(["--dangerously-skip-permissions"]);
+    });
+
+    it("leaves extraArgs undefined when runtimeArgs is not specified", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = new ChannelBridge({
+        provider: "claude",
+        sessionMap,
+        gatewayUrl: "wss://gw.test.com",
+        gatewayToken: "tok",
+      });
+      await bridge.handle(makeMessage());
+
+      const params = executeFn.mock.calls[0][0];
+      expect(params.extraArgs).toBeUndefined();
+    });
   });
 });
 

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -36,6 +36,8 @@ export type ChannelBridgeOptions = {
   chunkLimit?: number | undefined;
   /** MCP server entry point path. */
   mcpServerPath?: string | undefined;
+  /** Extra CLI arguments appended to every runtime invocation. */
+  runtimeArgs?: string[] | undefined;
 };
 
 const DEFAULT_WORKSPACE_DIR = ".";
@@ -71,6 +73,7 @@ export class ChannelBridge {
   readonly #workspaceDir: string;
   readonly #chunkLimit: number | undefined;
   readonly #mcpServerPath: string;
+  readonly #runtimeArgs: string[] | undefined;
 
   constructor(options: ChannelBridgeOptions) {
     this.#provider = options.provider;
@@ -80,6 +83,7 @@ export class ChannelBridge {
     this.#workspaceDir = options.workspaceDir ?? DEFAULT_WORKSPACE_DIR;
     this.#chunkLimit = options.chunkLimit;
     this.#mcpServerPath = options.mcpServerPath ?? DEFAULT_MCP_SERVER_PATH;
+    this.#runtimeArgs = options.runtimeArgs;
   }
 
   /**
@@ -189,6 +193,7 @@ export class ChannelBridge {
             abortSignal,
             workingDirectory: workspaceDir,
             env: extraEnv,
+            extraArgs: this.#runtimeArgs,
           }),
         );
         payloads = await adapter.process(captured.events, callbacks);

--- a/src/middleware/cli-runtime-base.test.ts
+++ b/src/middleware/cli-runtime-base.test.ts
@@ -444,6 +444,51 @@ describe("CLIRuntimeBase", () => {
       );
     });
 
+    it("appends extraArgs after buildArgs output", async () => {
+      const runtime = new TestRuntime("my-cli");
+
+      const promise = collectEvents(
+        runtime.execute({ ...defaultParams, extraArgs: ["--extra-flag", "--another"] }),
+      );
+
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      await promise;
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        "my-cli",
+        ["--test", "--extra-flag", "--another"],
+        expect.any(Object),
+      );
+    });
+
+    it("does not modify args when extraArgs is undefined", async () => {
+      const runtime = new TestRuntime("my-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      await promise;
+
+      expect(spawnMock).toHaveBeenCalledWith("my-cli", ["--test"], expect.any(Object));
+    });
+
+    it("does not modify args when extraArgs is empty", async () => {
+      const runtime = new TestRuntime("my-cli");
+
+      const promise = collectEvents(runtime.execute({ ...defaultParams, extraArgs: [] }));
+
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      await promise;
+
+      expect(spawnMock).toHaveBeenCalledWith("my-cli", ["--test"], expect.any(Object));
+    });
+
     it("merges buildEnv and params.env into spawn environment", async () => {
       const runtime = new TestRuntime("my-cli");
 

--- a/src/middleware/cli-runtime-base.ts
+++ b/src/middleware/cli-runtime-base.ts
@@ -51,6 +51,9 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
 
   async *execute(params: AgentExecuteParams): AsyncIterable<AgentEvent> {
     const args = this.buildArgs(params);
+    if (params.extraArgs && params.extraArgs.length > 0) {
+      args.push(...params.extraArgs);
+    }
     const env = { ...process.env, ...this.buildEnv(params), ...params.env };
     const child = spawn(this.command, args, {
       cwd: params.workingDirectory,

--- a/src/middleware/runtime-factory.test.ts
+++ b/src/middleware/runtime-factory.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   createCliRuntime,
+  resolveCliRuntimeArgs,
   resolveCliRuntimeProvider,
   SUPPORTED_PROVIDERS,
 } from "./runtime-factory.js";
@@ -123,5 +124,37 @@ describe("resolveCliRuntimeProvider", () => {
 
   it("falls back to 'claude' when config is undefined", () => {
     expect(resolveCliRuntimeProvider(undefined)).toBe("claude");
+  });
+});
+
+// ── resolveCliRuntimeArgs ───────────────────────────────────────────────
+
+describe("resolveCliRuntimeArgs", () => {
+  it("returns agents.defaults.runtimeArgs when set", () => {
+    expect(
+      resolveCliRuntimeArgs({
+        agents: { defaults: { runtimeArgs: ["--dangerously-skip-permissions"] } },
+      }),
+    ).toEqual(["--dangerously-skip-permissions"]);
+  });
+
+  it("returns undefined when runtimeArgs is not set", () => {
+    expect(resolveCliRuntimeArgs({ agents: { defaults: {} } })).toBeUndefined();
+  });
+
+  it("returns undefined when defaults is undefined", () => {
+    expect(resolveCliRuntimeArgs({ agents: {} })).toBeUndefined();
+  });
+
+  it("returns undefined when agents is undefined", () => {
+    expect(resolveCliRuntimeArgs({})).toBeUndefined();
+  });
+
+  it("returns undefined when config is undefined", () => {
+    expect(resolveCliRuntimeArgs(undefined)).toBeUndefined();
+  });
+
+  it("returns empty array when set to empty array", () => {
+    expect(resolveCliRuntimeArgs({ agents: { defaults: { runtimeArgs: [] } } })).toEqual([]);
   });
 });

--- a/src/middleware/runtime-factory.ts
+++ b/src/middleware/runtime-factory.ts
@@ -23,6 +23,18 @@ export function resolveCliRuntimeProvider(cfg?: {
   return cfg?.agents?.defaults?.runtime ?? DEFAULT_CLI_RUNTIME;
 }
 
+/**
+ * Resolve extra CLI runtime args from config.
+ *
+ * Reads `agents.defaults.runtimeArgs` — extra CLI flags appended to every
+ * runtime invocation (e.g. `["--dangerously-skip-permissions"]`).
+ */
+export function resolveCliRuntimeArgs(cfg?: {
+  agents?: { defaults?: { runtimeArgs?: string[] } };
+}): string[] | undefined {
+  return cfg?.agents?.defaults?.runtimeArgs;
+}
+
 export function createCliRuntime(provider: string): AgentRuntime {
   const normalized = provider.trim().toLowerCase();
 

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -21,6 +21,8 @@ export type AgentExecuteParams = {
   workingDirectory?: string | undefined;
   /** Additional environment variables for the CLI subprocess. */
   env?: Record<string, string> | undefined;
+  /** Extra CLI arguments appended after the runtime's own args. */
+  extraArgs?: string[] | undefined;
 };
 
 /** MCP server configuration passed to agent CLI subprocesses. */


### PR DESCRIPTION
## Summary

Closes #358

- Adds `agents.defaults.runtimeArgs` config field — a string array of extra CLI args appended to every runtime invocation (e.g. `["--dangerously-skip-permissions"]`)
- Threads the config through `ChannelBridge` → `CLIRuntimeBase.execute()` via a new `extraArgs` field on `AgentExecuteParams`
- All 4 ChannelBridge construction sites wired: agent command, cron, auto-reply agent-runner, followup-runner

## Test plan

- [x] `resolveCliRuntimeArgs()` returns config value when set, `undefined` when absent
- [x] `CLIRuntimeBase.execute()` appends `extraArgs` after `buildArgs()` output; no-ops when undefined or empty
- [x] `ChannelBridge` passes `runtimeArgs` as `extraArgs` to `runtime.execute()`; leaves it undefined when not configured
- [x] `AgentDefaultsSchema` accepts `runtimeArgs` field (schema is `.strict()`)
- [x] `pnpm check` passes (format + typecheck + lint)
- [x] `pnpm test` passes (868 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)