### PR TITLE
fix(runtime): remove DEFAULT_CLI_RUNTIME fallback — require explicit runtime config

### DIFF
--- a/src/auto-reply/reply.block-streaming.test.ts
+++ b/src/auto-reply/reply.block-streaming.test.ts
@@ -114,6 +114,7 @@ function createReplyConfig(home: string, streamMode?: "block"): RemoteClawConfig
   return {
     agents: {
       defaults: {
+        runtime: "claude",
         model: { primary: "anthropic/claude-opus-4-5" },
       },
       list: [{ id: "main", workspace: path.join(home, "remoteclaw") }],

--- a/src/auto-reply/reply.directive.directive-behavior.e2e-harness.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.e2e-harness.ts
@@ -75,6 +75,7 @@ export function makeWhatsAppDirectiveConfig(
   return {
     agents: {
       defaults: {
+        runtime: "claude" as const,
         ...defaults,
       },
       list: [{ id: "main", workspace: path.join(home, "remoteclaw") }],

--- a/src/auto-reply/reply.media-note.test.ts
+++ b/src/auto-reply/reply.media-note.test.ts
@@ -34,6 +34,7 @@ function makeCfg(home: string) {
   return {
     agents: {
       defaults: {
+        runtime: "claude",
         model: "anthropic/claude-opus-4-5",
       },
       list: [{ id: "main", workspace: path.join(home, "remoteclaw") }],

--- a/src/auto-reply/reply.test-harness.ts
+++ b/src/auto-reply/reply.test-harness.ts
@@ -85,6 +85,7 @@ export function makeReplyConfig(home: string) {
   return {
     agents: {
       defaults: {
+        runtime: "claude",
         model: "anthropic/claude-opus-4-5",
       },
       list: [{ id: "main", workspace: path.join(home, "remoteclaw") }],

--- a/src/auto-reply/reply.triggers.trigger-handling.test-harness.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.test-harness.ts
@@ -227,6 +227,7 @@ export function makeCfg(home: string): RemoteClawConfig {
   return {
     agents: {
       defaults: {
+        runtime: "claude",
         model: { primary: "anthropic/claude-opus-4-5" },
         // Test harness: avoid 1s coalescer idle sleeps that dominate trigger suites.
         blockStreamingCoalesce: { idleMs: 1 },

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -168,7 +168,7 @@ describe("runReplyAgent onAgentRunStart", () => {
         messageProvider: "webchat",
         sessionFile: "/tmp/session.jsonl",
         workspaceDir: "/tmp",
-        config: {},
+        config: { agents: { defaults: { runtime: "claude" } } },
         provider,
         model,
         thinkLevel: "low",
@@ -275,7 +275,7 @@ describe("runReplyAgent authProfileId fallback scoping", () => {
         messageProvider: "telegram",
         sessionFile: "/tmp/session.jsonl",
         workspaceDir: "/tmp",
-        config: {},
+        config: { agents: { defaults: { runtime: "claude" } } },
         provider: "anthropic",
         model: "claude-opus",
         authProfileId: "anthropic:remoteclaw",
@@ -370,7 +370,7 @@ describe("runReplyAgent auto-compaction token update", () => {
         messageProvider: "whatsapp",
         sessionFile: "/tmp/session.jsonl",
         workspaceDir: "/tmp",
-        config: params.config ?? {},
+        config: params.config ?? { agents: { defaults: { runtime: "claude" } } },
         provider: "anthropic",
         model: "claude",
         thinkLevel: "low",
@@ -408,7 +408,7 @@ describe("runReplyAgent auto-compaction token update", () => {
 
     // Disable memory flush so we isolate the usage persistence path
     const config = {
-      agents: { defaults: { compaction: { memoryFlush: { enabled: false } } } },
+      agents: { defaults: { runtime: "claude", compaction: { memoryFlush: { enabled: false } } } },
     };
     const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
       storePath,
@@ -529,6 +529,7 @@ describe("runReplyAgent block streaming", () => {
         config: {
           agents: {
             defaults: {
+              runtime: "claude",
               blockStreamingCoalesce: {
                 minChars: 1,
                 maxChars: 200,
@@ -626,6 +627,7 @@ describe("runReplyAgent block streaming", () => {
         config: {
           agents: {
             defaults: {
+              runtime: "claude",
               blockStreamingCoalesce: {
                 minChars: 1,
                 maxChars: 200,
@@ -701,7 +703,7 @@ describe("runReplyAgent claude-cli routing", () => {
         messageProvider: "webchat",
         sessionFile: "/tmp/session.jsonl",
         workspaceDir: "/tmp",
-        config: {},
+        config: { agents: { defaults: { runtime: "claude" } } },
         provider: "claude-cli",
         model: "opus-4.5",
         thinkLevel: "low",
@@ -790,7 +792,7 @@ describe("runReplyAgent messaging tool suppression", () => {
         messageProvider,
         sessionFile: "/tmp/session.jsonl",
         workspaceDir: "/tmp",
-        config: {},
+        config: { agents: { defaults: { runtime: "claude" } } },
         provider: "anthropic",
         model: "claude",
         thinkLevel: "low",
@@ -1012,7 +1014,7 @@ describe("runReplyAgent reminder commitment guard", () => {
         messageProvider: "telegram",
         sessionFile: "/tmp/session.jsonl",
         workspaceDir: "/tmp",
-        config: {},
+        config: { agents: { defaults: { runtime: "claude" } } },
         provider: "anthropic",
         model: "claude",
         thinkLevel: "low",
@@ -1104,7 +1106,7 @@ describe("runReplyAgent fallback provider routing", () => {
         messageProvider: "whatsapp",
         sessionFile: "/tmp/session.jsonl",
         workspaceDir: "/tmp",
-        config: {},
+        config: { agents: { defaults: { runtime: "claude" } } },
         provider: "anthropic",
         model: "claude",
         thinkLevel: "low",
@@ -1212,7 +1214,7 @@ describe("runReplyAgent response usage footer", () => {
         messageProvider: "whatsapp",
         sessionFile: "/tmp/session.jsonl",
         workspaceDir: "/tmp",
-        config: {},
+        config: { agents: { defaults: { runtime: "claude" } } },
         provider: "anthropic",
         model: "claude",
         thinkLevel: "low",
@@ -1307,7 +1309,7 @@ describe("runReplyAgent transient HTTP retry", () => {
         messageProvider: "telegram",
         sessionFile: "/tmp/session.jsonl",
         workspaceDir: "/tmp",
-        config: {},
+        config: { agents: { defaults: { runtime: "claude" } } },
         provider: "anthropic",
         model: "claude",
         thinkLevel: "low",

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -146,7 +146,7 @@ function createMinimalRun(params?: {
       messageProvider: "whatsapp",
       sessionFile: "/tmp/session.jsonl",
       workspaceDir: "/tmp",
-      config: {},
+      config: { agents: { defaults: { runtime: "claude" } } },
       provider: "anthropic",
       model: "claude",
       thinkLevel: "low",
@@ -233,7 +233,7 @@ function createBaseRun(params: {
       messageProvider: "whatsapp",
       sessionFile: "/tmp/session.jsonl",
       workspaceDir: "/tmp",
-      config: params.config ?? {},
+      config: params.config ?? { agents: { defaults: { runtime: "claude" } } },
       provider: "anthropic",
       model: "claude",
       thinkLevel: "low",
@@ -1170,7 +1170,11 @@ describe("runReplyAgent memory flush", () => {
       const baseRun = createBaseRun({
         storePath,
         sessionEntry,
-        config: { agents: { defaults: { compaction: { memoryFlush: { enabled: false } } } } },
+        config: {
+          agents: {
+            defaults: { runtime: "claude", compaction: { memoryFlush: { enabled: false } } },
+          },
+        },
       });
 
       await runReplyAgentWithBase({

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -133,6 +133,7 @@ function mockConfig(
   configSpy.mockReturnValue({
     agents: {
       defaults: {
+        runtime: "claude",
         model: { primary: "anthropic/claude-opus-4-5" },
         models: { "anthropic/claude-opus-4-5": {} },
         ...agentOverrides,
@@ -340,8 +341,8 @@ describe("agentCommand", () => {
 
       await agentCommand({ message: "hi", to: "+1555" }, runtime);
 
-      // ChannelBridge receives the CLI runtime from agents.defaults.runtime
-      // (falling back to "claude"), NOT the model API provider.
+      // ChannelBridge receives the CLI runtime from agents.defaults.runtime,
+      // NOT the model API provider.
       expect(bridgeConstructorCalls.at(-1)?.provider).toBe("claude");
     });
   });

--- a/src/cron/isolated-agent/run.channel-bridge.test.ts
+++ b/src/cron/isolated-agent/run.channel-bridge.test.ts
@@ -199,7 +199,7 @@ function makeJob(overrides?: Record<string, unknown>) {
 
 function makeParams(overrides?: Record<string, unknown>) {
   return {
-    cfg: {},
+    cfg: { agents: { defaults: { runtime: "claude" as const } } },
     deps: {} as never,
     job: makeJob(),
     message: "generate daily summary",

--- a/src/middleware/runtime-factory.test.ts
+++ b/src/middleware/runtime-factory.test.ts
@@ -109,19 +109,25 @@ describe("resolveCliRuntimeProvider", () => {
     );
   });
 
-  it("falls back to 'claude' when runtime is undefined", () => {
-    expect(resolveCliRuntimeProvider({ agents: { defaults: {} } })).toBe("claude");
+  it("throws when runtime is undefined", () => {
+    expect(() => resolveCliRuntimeProvider({ agents: { defaults: {} } })).toThrow(
+      "No runtime configured",
+    );
   });
 
-  it("falls back to 'claude' when defaults is undefined", () => {
-    expect(resolveCliRuntimeProvider({ agents: {} })).toBe("claude");
+  it("throws when defaults is undefined", () => {
+    expect(() => resolveCliRuntimeProvider({ agents: {} })).toThrow("No runtime configured");
   });
 
-  it("falls back to 'claude' when agents is undefined", () => {
-    expect(resolveCliRuntimeProvider({})).toBe("claude");
+  it("throws when agents is undefined", () => {
+    expect(() => resolveCliRuntimeProvider({})).toThrow("No runtime configured");
   });
 
-  it("falls back to 'claude' when config is undefined", () => {
-    expect(resolveCliRuntimeProvider(undefined)).toBe("claude");
+  it("throws when config is undefined", () => {
+    expect(() => resolveCliRuntimeProvider(undefined)).toThrow("No runtime configured");
+  });
+
+  it("includes supported providers in error message", () => {
+    expect(() => resolveCliRuntimeProvider({})).toThrow("claude, gemini, codex, opencode");
   });
 });

--- a/src/middleware/runtime-factory.ts
+++ b/src/middleware/runtime-factory.ts
@@ -8,19 +8,23 @@ export const SUPPORTED_PROVIDERS = ["claude", "gemini", "codex", "opencode"] as 
 
 export type SupportedProvider = (typeof SUPPORTED_PROVIDERS)[number];
 
-const DEFAULT_CLI_RUNTIME: SupportedProvider = "claude";
-
 /**
  * Resolve the CLI runtime provider from config.
  *
- * Reads `agents.defaults.runtime` (set during onboarding) and falls back to
- * "claude" when unset.  This is the **CLI runtime** (which binary to spawn),
- * NOT the model-API provider (e.g. "anthropic").
+ * Reads `agents.defaults.runtime` (set during onboarding) and throws when
+ * unset.  This is the **CLI runtime** (which binary to spawn), NOT the
+ * model-API provider (e.g. "anthropic").
  */
 export function resolveCliRuntimeProvider(cfg?: {
   agents?: { defaults?: { runtime?: string } };
 }): string {
-  return cfg?.agents?.defaults?.runtime ?? DEFAULT_CLI_RUNTIME;
+  const runtime = cfg?.agents?.defaults?.runtime;
+  if (!runtime) {
+    throw new Error(
+      `No runtime configured. Set agents.defaults.runtime to one of: ${SUPPORTED_PROVIDERS.join(", ")}`,
+    );
+  }
+  return runtime;
 }
 
 export function createCliRuntime(provider: string): AgentRuntime {


### PR DESCRIPTION
## Summary

- Remove the silent `"claude"` fallback from `resolveCliRuntimeProvider()` — a missing `agents.defaults.runtime` now throws a clear, actionable error instead of failing at spawn time with a confusing message
- Delete `DEFAULT_CLI_RUNTIME` constant
- Update 11 test files to provide explicit `runtime: "claude"` in config fixtures

Closes #359

## Test plan

- [x] `pnpm check` passes (format + typecheck + lint)
- [x] `pnpm test` passes (all 971 test files, 7948 tests)
- [x] `resolveCliRuntimeProvider()` returns runtime when set
- [x] `resolveCliRuntimeProvider()` throws descriptive error when runtime missing
- [x] Error message includes all supported providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)