### PR TITLE
feat(runtime): validate CLI executable exists when runtime is configured (#360)

### DIFF
--- a/src/middleware/runtime-factory.test.ts
+++ b/src/middleware/runtime-factory.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  _resetValidationCache,
   createCliRuntime,
   resolveCliRuntimeArgs,
   resolveCliRuntimeProvider,
@@ -9,6 +11,17 @@ import { ClaudeCliRuntime } from "./runtimes/claude.js";
 import { CodexCliRuntime } from "./runtimes/codex.js";
 import { GeminiCliRuntime } from "./runtimes/gemini.js";
 import { OpenCodeCliRuntime } from "./runtimes/opencode.js";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+const mockedExecFileSync = vi.mocked(execFileSync);
+
+beforeEach(() => {
+  _resetValidationCache();
+  mockedExecFileSync.mockReset();
+});
 
 // ── Provider mapping ──────────────────────────────────────────────────────
 
@@ -97,6 +110,60 @@ describe("createCliRuntime", () => {
   describe("SUPPORTED_PROVIDERS", () => {
     it("contains exactly the four supported provider names", () => {
       expect([...SUPPORTED_PROVIDERS]).toEqual(["claude", "gemini", "codex", "opencode"]);
+    });
+  });
+
+  // ── Executable validation ─────────────────────────────────────────────
+
+  describe("executable validation", () => {
+    it("calls which to validate the binary exists on PATH", () => {
+      createCliRuntime("claude");
+      expect(mockedExecFileSync).toHaveBeenCalledWith("which", ["claude"], { stdio: "ignore" });
+    });
+
+    it("throws a clear error when binary is not found", () => {
+      mockedExecFileSync.mockImplementation(() => {
+        throw new Error("not found");
+      });
+      expect(() => createCliRuntime("claude")).toThrow(
+        "Runtime 'claude' is configured but the 'claude' binary was not found on PATH",
+      );
+    });
+
+    it("includes alternative suggestion in error message", () => {
+      mockedExecFileSync.mockImplementation(() => {
+        throw new Error("not found");
+      });
+      expect(() => createCliRuntime("gemini")).toThrow(
+        "set agents.defaults.runtime to a different provider",
+      );
+    });
+
+    it("caches validation per command — which is called only once", () => {
+      createCliRuntime("claude");
+      createCliRuntime("claude");
+      createCliRuntime("claude");
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+    });
+
+    it("validates each provider independently", () => {
+      createCliRuntime("claude");
+      createCliRuntime("gemini");
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
+      expect(mockedExecFileSync).toHaveBeenCalledWith("which", ["claude"], { stdio: "ignore" });
+      expect(mockedExecFileSync).toHaveBeenCalledWith("which", ["gemini"], { stdio: "ignore" });
+    });
+
+    it("does not call which for unknown providers", () => {
+      expect(() => createCliRuntime("foo")).toThrow("Unknown runtime provider");
+      expect(mockedExecFileSync).not.toHaveBeenCalled();
+    });
+
+    it("validates all four supported providers", () => {
+      for (const provider of SUPPORTED_PROVIDERS) {
+        createCliRuntime(provider);
+      }
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/src/middleware/runtime-factory.ts
+++ b/src/middleware/runtime-factory.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { ClaudeCliRuntime } from "./runtimes/claude.js";
 import { CodexCliRuntime } from "./runtimes/codex.js";
 import { GeminiCliRuntime } from "./runtimes/gemini.js";
@@ -7,6 +8,36 @@ import type { AgentRuntime } from "./types.js";
 export const SUPPORTED_PROVIDERS = ["claude", "gemini", "codex", "opencode"] as const;
 
 export type SupportedProvider = (typeof SUPPORTED_PROVIDERS)[number];
+
+// ── Executable validation ─────────────────────────────────────────────────
+
+const validatedCommands = new Set<string>();
+
+/**
+ * Verify that a CLI binary exists on PATH.
+ *
+ * Results are cached per process lifetime so the `which` lookup runs at most
+ * once per command.
+ */
+function validateExecutable(command: string): void {
+  if (validatedCommands.has(command)) {
+    return;
+  }
+  try {
+    execFileSync("which", [command], { stdio: "ignore" });
+    validatedCommands.add(command);
+  } catch {
+    throw new Error(
+      `Runtime '${command}' is configured but the '${command}' binary was not found on PATH. ` +
+        `Install it or set agents.defaults.runtime to a different provider.`,
+    );
+  }
+}
+
+/** @internal — exposed for tests only. */
+export function _resetValidationCache(): void {
+  validatedCommands.clear();
+}
 
 /**
  * Resolve the CLI runtime provider from config.
@@ -44,12 +75,16 @@ export function createCliRuntime(provider: string): AgentRuntime {
 
   switch (normalized) {
     case "claude":
+      validateExecutable(normalized);
       return new ClaudeCliRuntime();
     case "gemini":
+      validateExecutable(normalized);
       return new GeminiCliRuntime();
     case "codex":
+      validateExecutable(normalized);
       return new CodexCliRuntime();
     case "opencode":
+      validateExecutable(normalized);
       return new OpenCodeCliRuntime();
     default:
       throw new Error(


### PR DESCRIPTION
## Summary

- Adds early PATH validation in `createCliRuntime()` via `which` so a missing CLI binary produces a clear, actionable error instead of a generic `ENOENT` from `child_process.spawn()`
- Caches validation results per process lifetime — `which` runs at most once per command
- Error message names the missing binary and suggests setting `agents.defaults.runtime` to a different provider

Closes #360

## Test plan

- [x] New `executable validation` describe block with 7 tests covering: PATH lookup, missing binary error, error message content, caching, per-provider independence, unknown provider bypass, all-providers validation
- [x] All 31 `runtime-factory.test.ts` tests pass
- [x] All 868 tests across the full suite pass
- [x] Typecheck (`pnpm tsgo`) clean
- [x] Lint (`pnpm lint`) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)