### PR TITLE
fix(middleware): surface stderr when CLI exits with error (#374)

### DIFF
--- a/src/middleware/cli-runtime-base.test.ts
+++ b/src/middleware/cli-runtime-base.test.ts
@@ -505,7 +505,7 @@ describe("CLIRuntimeBase", () => {
   });
 
   describe("stderr capture", () => {
-    it("captures stderr without failing", async () => {
+    it("captures stderr without error event on success exit with output", async () => {
       const runtime = new TestRuntime("test-cli");
 
       const promise = collectEvents(runtime.execute(defaultParams));
@@ -518,10 +518,86 @@ describe("CLIRuntimeBase", () => {
 
       const events = await promise;
 
-      // Stderr should not produce error events — it's just captured.
+      // Stderr should not produce error events when exit 0 + events yielded.
       const errorEvents = events.filter((e) => e.type === "error");
       expect(errorEvents).toHaveLength(0);
       expect(events[0]).toEqual({ type: "text", text: "ok" });
+    });
+
+    it("includes stderr in done result when present", async () => {
+      const runtime = new TestRuntime("test-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      mockChild.stderr.write("some warning\n");
+      mockChild.stdout.write('{"type":"text","text":"ok"}\n');
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      const events = await promise;
+      const done = events.find((e) => e.type === "done");
+
+      expect(done).toBeDefined();
+      expect(done!.type === "done" && done!.result.stderr).toBe("some warning\n");
+    });
+
+    it("emits error event when CLI exits non-zero with stderr", async () => {
+      const runtime = new TestRuntime("test-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      mockChild.stderr.write("Not logged in · Please run /login\n");
+      mockChild.stdout.end();
+      mockChild.emit("exit", 1, null);
+
+      const events = await promise;
+
+      const errorEvents = events.filter((e) => e.type === "error");
+      expect(errorEvents).toContainEqual({
+        type: "error",
+        message: "Not logged in · Please run /login",
+        code: "CLI_STDERR",
+      });
+
+      const done = events.find((e) => e.type === "done");
+      expect(done!.type === "done" && done!.result.stderr).toBe(
+        "Not logged in · Please run /login\n",
+      );
+    });
+
+    it("emits error event when CLI exits zero with stderr but no NDJSON output", async () => {
+      const runtime = new TestRuntime("test-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      mockChild.stderr.write("Unexpected error occurred\n");
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      const events = await promise;
+
+      const errorEvents = events.filter((e) => e.type === "error");
+      expect(errorEvents).toContainEqual({
+        type: "error",
+        message: "Unexpected error occurred",
+        code: "CLI_STDERR",
+      });
+    });
+
+    it("does not emit CLI_STDERR error when no stderr content on non-zero exit", async () => {
+      const runtime = new TestRuntime("test-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      mockChild.stdout.end();
+      mockChild.emit("exit", 1, null);
+
+      const events = await promise;
+
+      const stderrErrors = events.filter(
+        (e) => e.type === "error" && "code" in e && e.code === "CLI_STDERR",
+      );
+      expect(stderrErrors).toHaveLength(0);
     });
   });
 

--- a/src/middleware/cli-runtime-base.ts
+++ b/src/middleware/cli-runtime-base.ts
@@ -64,6 +64,7 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
     const startMs = Date.now();
     const stderrChunks: string[] = [];
     let aborted = false;
+    let yieldedEvents = false;
 
     // ── SIGKILL escalation helper ──────────────────────────────────────
     let escalationTimer: ReturnType<typeof setTimeout> | undefined;
@@ -197,6 +198,7 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
             // Sentinel or empty — stdout closed.
             break;
           }
+          yieldedEvents = true;
           yield event;
         }
       }
@@ -208,11 +210,21 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
     }
 
     // ── Wait for process to fully exit ───────────────────────────────
-    await exitPromise;
+    const { code: exitCode } = await exitPromise;
     if (escalationTimer !== undefined) {
       clearTimeout(escalationTimer);
     }
     const durationMs = Date.now() - startMs;
+
+    // ── Surface stderr when CLI exits with error ─────────────────────
+    const stderr = stderrChunks.join("");
+    if (stderr && (exitCode !== 0 || !yieldedEvents)) {
+      yield {
+        type: "error",
+        message: stderr.trim(),
+        code: "CLI_STDERR",
+      } satisfies AgentErrorEvent;
+    }
 
     // ── Emit terminal events ─────────────────────────────────────────
     if (watchdogFired) {
@@ -237,6 +249,7 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
       durationMs,
       usage: undefined,
       aborted,
+      stderr: stderr || undefined,
     };
 
     yield { type: "done", result } satisfies AgentDoneEvent;

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -86,6 +86,8 @@ export type AgentRunResult = {
   usage: AgentUsage | undefined;
   /** Whether the run was aborted via the abort signal. */
   aborted: boolean;
+  /** Captured stderr output from the CLI subprocess (if any). */
+  stderr?: string | undefined;
   /** Estimated total cost in USD (if reported by the CLI). */
   totalCostUsd?: number | undefined;
   /** Duration spent in API calls in milliseconds (if reported). */


### PR DESCRIPTION
## Summary

- When a CLI agent runtime exits with a non-zero exit code (or zero with no NDJSON output) and stderr has content, the runtime now emits a `CLI_STDERR` error event with the stderr message
- Adds `stderr` optional field to `AgentRunResult` so captured stderr is available for logging/diagnostics downstream
- Previously, stderr was captured into `stderrChunks` but never used — messages sent via channels would silently "disappear" with no error

Closes #374

## Test plan

- [x] Existing test updated: stderr on success exit with output still produces no error event
- [x] New test: stderr included in done result when present
- [x] New test: non-zero exit + stderr → emits `CLI_STDERR` error event
- [x] New test: zero exit + no NDJSON output + stderr → emits `CLI_STDERR` error event
- [x] New test: non-zero exit without stderr → no `CLI_STDERR` event
- [x] Full test suite passes (868 tests across 93 files)
- [x] Type-check, lint, format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)