### PR TITLE
feat(runtime): add runtimeEnv config for CLI process environment variables (#375)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -21,6 +21,7 @@ import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-event
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
 import {
   resolveCliRuntimeArgs,
+  resolveCliRuntimeEnv,
   resolveCliRuntimeProvider,
 } from "../../middleware/runtime-factory.js";
 import type { SessionMap } from "../../middleware/session-map.js";
@@ -289,6 +290,7 @@ export async function runAgentTurnWithFallback(params: {
           gatewayToken: resolveGatewayTokenFromConfig(cfg),
           workspaceDir: params.followupRun.run.workspaceDir,
           runtimeArgs: resolveCliRuntimeArgs(cfg),
+          runtimeEnv: resolveCliRuntimeEnv(cfg),
         });
 
         const messageToolHints = resolveChannelMessageToolHints({

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -8,6 +8,7 @@ import { logVerbose } from "../../globals.js";
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
 import {
   resolveCliRuntimeArgs,
+  resolveCliRuntimeEnv,
   resolveCliRuntimeProvider,
 } from "../../middleware/runtime-factory.js";
 import type { SessionMap } from "../../middleware/session-map.js";
@@ -71,6 +72,7 @@ export function createFollowupRunner(params: {
         gatewayToken,
         workspaceDir: queued.run.workspaceDir,
         runtimeArgs: resolveCliRuntimeArgs(cfg),
+        runtimeEnv: resolveCliRuntimeEnv(cfg),
       });
 
       // Build channel message from followup run fields.

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -39,7 +39,11 @@ import {
   registerAgentRunContext,
 } from "../infra/agent-events.js";
 import { ChannelBridge } from "../middleware/channel-bridge.js";
-import { resolveCliRuntimeArgs, resolveCliRuntimeProvider } from "../middleware/runtime-factory.js";
+import {
+  resolveCliRuntimeArgs,
+  resolveCliRuntimeEnv,
+  resolveCliRuntimeProvider,
+} from "../middleware/runtime-factory.js";
 import type { SessionMap } from "../middleware/session-map.js";
 import type { AgentDeliveryResult, ChannelMessage } from "../middleware/types.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -362,6 +366,7 @@ export async function agentCommand(
         gatewayToken: resolveGatewayTokenFromConfig(cfg),
         workspaceDir,
         runtimeArgs: resolveCliRuntimeArgs(cfg),
+        runtimeEnv: resolveCliRuntimeEnv(cfg),
       });
 
       const messageToolHints = resolveChannelMessageToolHints({

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -193,6 +193,8 @@ export type AgentDefaultsConfig = {
   runtime?: "claude" | "gemini" | "codex" | "opencode";
   /** Extra CLI arguments appended to every runtime invocation. */
   runtimeArgs?: string[];
+  /** Extra environment variables injected into every runtime invocation. */
+  runtimeEnv?: Record<string, string>;
 };
 
 export type AgentCompactionMode = "default" | "safeguard";

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -129,6 +129,7 @@ export const AgentDefaultsSchema = z
       .union([z.literal("claude"), z.literal("gemini"), z.literal("codex"), z.literal("opencode")])
       .optional(),
     runtimeArgs: z.array(z.string()).optional(),
+    runtimeEnv: z.record(z.string(), z.string()).optional(),
   })
   .strict()
   .optional();

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -27,6 +27,7 @@ import { logWarn } from "../../logger.js";
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
 import {
   resolveCliRuntimeArgs,
+  resolveCliRuntimeEnv,
   resolveCliRuntimeProvider,
 } from "../../middleware/runtime-factory.js";
 import type { SessionMap } from "../../middleware/session-map.js";
@@ -382,6 +383,7 @@ export async function runCronIsolatedAgentTurn(params: {
       gatewayToken: resolveGatewayTokenFromConfig(cfgWithAgentDefaults),
       workspaceDir,
       runtimeArgs: resolveCliRuntimeArgs(cfgWithAgentDefaults),
+      runtimeEnv: resolveCliRuntimeEnv(cfgWithAgentDefaults),
     });
 
     const messageToolHints = resolveChannelMessageToolHints({

--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -839,6 +839,39 @@ describe("ChannelBridge", () => {
       const params = executeFn.mock.calls[0][0];
       expect(params.extraArgs).toBeUndefined();
     });
+
+    it("passes runtimeEnv as env to runtime.execute()", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = new ChannelBridge({
+        provider: "claude",
+        sessionMap,
+        gatewayUrl: "wss://gw.test.com",
+        gatewayToken: "tok",
+        runtimeEnv: { ANTHROPIC_API_KEY: "sk-ant-test" },
+      });
+      await bridge.handle(makeMessage());
+
+      const params = executeFn.mock.calls[0][0];
+      expect(params.env).toEqual({ ANTHROPIC_API_KEY: "sk-ant-test" });
+    });
+
+    it("leaves env undefined when runtimeEnv is not specified", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = new ChannelBridge({
+        provider: "claude",
+        sessionMap,
+        gatewayUrl: "wss://gw.test.com",
+        gatewayToken: "tok",
+      });
+      await bridge.handle(makeMessage());
+
+      const params = executeFn.mock.calls[0][0];
+      expect(params.env).toBeUndefined();
+    });
   });
 });
 

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -38,6 +38,8 @@ export type ChannelBridgeOptions = {
   mcpServerPath?: string | undefined;
   /** Extra CLI arguments appended to every runtime invocation. */
   runtimeArgs?: string[] | undefined;
+  /** Extra environment variables injected into every runtime invocation. */
+  runtimeEnv?: Record<string, string> | undefined;
 };
 
 const DEFAULT_WORKSPACE_DIR = ".";
@@ -74,6 +76,7 @@ export class ChannelBridge {
   readonly #chunkLimit: number | undefined;
   readonly #mcpServerPath: string;
   readonly #runtimeArgs: string[] | undefined;
+  readonly #runtimeEnv: Record<string, string> | undefined;
 
   constructor(options: ChannelBridgeOptions) {
     this.#provider = options.provider;
@@ -84,6 +87,7 @@ export class ChannelBridge {
     this.#chunkLimit = options.chunkLimit;
     this.#mcpServerPath = options.mcpServerPath ?? DEFAULT_MCP_SERVER_PATH;
     this.#runtimeArgs = options.runtimeArgs;
+    this.#runtimeEnv = options.runtimeEnv;
   }
 
   /**
@@ -142,7 +146,7 @@ export class ChannelBridge {
       // 4. Runtime params
       const runtime = createCliRuntime(this.#provider);
       let workspaceDir = this.#workspaceDir;
-      let extraEnv: Record<string, string> | undefined;
+      let hookEnv: Record<string, string> | undefined;
       const runId = randomUUID();
 
       // Hook: before_runtime_spawn — extensions can modify env and workspaceDir
@@ -167,7 +171,7 @@ export class ChannelBridge {
           workspaceDir = spawnResult.workspaceDir;
         }
         if (spawnResult?.env) {
-          extraEnv = spawnResult.env;
+          hookEnv = spawnResult.env;
         }
       }
 
@@ -192,7 +196,7 @@ export class ChannelBridge {
             mcpServers,
             abortSignal,
             workingDirectory: workspaceDir,
-            env: extraEnv,
+            env: this.#runtimeEnv || hookEnv ? { ...this.#runtimeEnv, ...hookEnv } : undefined,
             extraArgs: this.#runtimeArgs,
           }),
         );

--- a/src/middleware/runtime-factory.test.ts
+++ b/src/middleware/runtime-factory.test.ts
@@ -4,6 +4,7 @@ import {
   _resetValidationCache,
   createCliRuntime,
   resolveCliRuntimeArgs,
+  resolveCliRuntimeEnv,
   resolveCliRuntimeProvider,
   SUPPORTED_PROVIDERS,
 } from "./runtime-factory.js";
@@ -229,5 +230,37 @@ describe("resolveCliRuntimeArgs", () => {
 
   it("returns empty array when set to empty array", () => {
     expect(resolveCliRuntimeArgs({ agents: { defaults: { runtimeArgs: [] } } })).toEqual([]);
+  });
+});
+
+// ── resolveCliRuntimeEnv ────────────────────────────────────────────────
+
+describe("resolveCliRuntimeEnv", () => {
+  it("returns agents.defaults.runtimeEnv when set", () => {
+    expect(
+      resolveCliRuntimeEnv({
+        agents: { defaults: { runtimeEnv: { ANTHROPIC_API_KEY: "sk-ant-test" } } },
+      }),
+    ).toEqual({ ANTHROPIC_API_KEY: "sk-ant-test" });
+  });
+
+  it("returns undefined when runtimeEnv is not set", () => {
+    expect(resolveCliRuntimeEnv({ agents: { defaults: {} } })).toBeUndefined();
+  });
+
+  it("returns undefined when defaults is undefined", () => {
+    expect(resolveCliRuntimeEnv({ agents: {} })).toBeUndefined();
+  });
+
+  it("returns undefined when agents is undefined", () => {
+    expect(resolveCliRuntimeEnv({})).toBeUndefined();
+  });
+
+  it("returns undefined when config is undefined", () => {
+    expect(resolveCliRuntimeEnv(undefined)).toBeUndefined();
+  });
+
+  it("returns empty object when set to empty object", () => {
+    expect(resolveCliRuntimeEnv({ agents: { defaults: { runtimeEnv: {} } } })).toEqual({});
   });
 });

--- a/src/middleware/runtime-factory.ts
+++ b/src/middleware/runtime-factory.ts
@@ -70,6 +70,18 @@ export function resolveCliRuntimeArgs(cfg?: {
   return cfg?.agents?.defaults?.runtimeArgs;
 }
 
+/**
+ * Resolve extra CLI runtime env vars from config.
+ *
+ * Reads `agents.defaults.runtimeEnv` — environment variables injected into
+ * every runtime invocation (e.g. `{ "ANTHROPIC_API_KEY": "sk-ant-..." }`).
+ */
+export function resolveCliRuntimeEnv(cfg?: {
+  agents?: { defaults?: { runtimeEnv?: Record<string, string> } };
+}): Record<string, string> | undefined {
+  return cfg?.agents?.defaults?.runtimeEnv;
+}
+
 export function createCliRuntime(provider: string): AgentRuntime {
   const normalized = provider.trim().toLowerCase();
 


### PR DESCRIPTION
## Summary

- Adds `runtimeEnv?: Record<string, string>` to `AgentDefaultsConfig` as a sibling to `runtime` and `runtimeArgs`
- Adds `resolveCliRuntimeEnv()` in `runtime-factory.ts` (parallel to `resolveCliRuntimeArgs()`)
- Threads `runtimeEnv` through `ChannelBridge` → `AgentExecuteParams.env` across all 4 dispatch sites (agent command, auto-reply, cron, followup)
- Hook-provided env from `before_runtime_spawn` takes precedence over config env (hooks are more specific/dynamic)
- `CLIRuntimeBase.execute()` already merges `params.env` into the spawn environment — no changes needed there

Closes #375

## Test plan

- [x] `resolveCliRuntimeEnv()` unit tests — all config path permutations (set, empty, missing at each nesting level)
- [x] `ChannelBridge` unit tests — `runtimeEnv` passed as `env` to `runtime.execute()`, `env` left `undefined` when unset
- [x] Full test suite passes (868 tests, 93 files)
- [x] Type-check clean, lint clean, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)