### PR TITLE
fix(import): strip unrecognized config keys during OpenClaw import

### DIFF
--- a/src/commands/import.test.ts
+++ b/src/commands/import.test.ts
@@ -9,6 +9,7 @@ import {
   importCommand,
   materializeWorkspaceDefaults,
   resolveTargetFilename,
+  stripUnrecognizedConfigKeys,
   transformConfigContent,
 } from "./import.js";
 import { createTestRuntime, type TestRuntime } from "./test-runtime-config-helpers.js";
@@ -195,6 +196,112 @@ describe("materializeWorkspaceDefaults", () => {
   });
 });
 
+describe("stripUnrecognizedConfigKeys", () => {
+  it("strips unknown top-level keys", () => {
+    const input = JSON.stringify({
+      gateway: { port: 18789 },
+      deadTopLevel: true,
+    });
+    const result = JSON.parse(stripUnrecognizedConfigKeys(input));
+    expect(result.gateway.port).toBe(18789);
+    expect(result.deadTopLevel).toBeUndefined();
+  });
+
+  it("strips unknown keys from agents.defaults", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: { compaction: { mode: "default" }, workspace: "~/ws" },
+        list: [{ id: "main" }],
+      },
+    });
+    const result = JSON.parse(stripUnrecognizedConfigKeys(input));
+    expect(result.agents.defaults.workspace).toBe("~/ws");
+    expect(result.agents.defaults.compaction).toBeUndefined();
+  });
+
+  it("strips unknown nested keys from agents.defaults.heartbeat", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: {
+          heartbeat: { every: "30m", includeReasoning: true },
+        },
+        list: [{ id: "main" }],
+      },
+    });
+    const result = JSON.parse(stripUnrecognizedConfigKeys(input));
+    expect(result.agents.defaults.heartbeat.every).toBe("30m");
+    expect(result.agents.defaults.heartbeat.includeReasoning).toBeUndefined();
+  });
+
+  it("strips unknown nested keys from agents.defaults.subagents", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: {
+          subagents: { maxConcurrent: 2, thinking: "high" },
+        },
+        list: [{ id: "main" }],
+      },
+    });
+    const result = JSON.parse(stripUnrecognizedConfigKeys(input));
+    expect(result.agents.defaults.subagents.maxConcurrent).toBe(2);
+    expect(result.agents.defaults.subagents.thinking).toBeUndefined();
+  });
+
+  it("strips unknown keys from nested gateway sub-objects", () => {
+    const input = JSON.stringify({
+      gateway: {
+        port: 18789,
+        auth: { mode: "token", legacyField: true },
+      },
+    });
+    const result = JSON.parse(stripUnrecognizedConfigKeys(input));
+    expect(result.gateway.auth.mode).toBe("token");
+    expect(result.gateway.auth.legacyField).toBeUndefined();
+  });
+
+  it("returns content unchanged when all keys are recognized", () => {
+    const input = JSON.stringify({
+      gateway: { port: 18789 },
+      agents: {
+        defaults: { workspace: "~/ws", timeoutSeconds: 60 },
+        list: [{ id: "main" }],
+      },
+    });
+    expect(stripUnrecognizedConfigKeys(input)).toBe(input);
+  });
+
+  it("preserves dynamic keys in catchall objects like broadcast", () => {
+    const input = JSON.stringify({
+      broadcast: {
+        strategy: "parallel",
+        "whatsapp-main": ["main", "helper"],
+        "telegram-ops": ["ops"],
+      },
+    });
+    const result = JSON.parse(stripUnrecognizedConfigKeys(input));
+    expect(result.broadcast.strategy).toBe("parallel");
+    expect(result.broadcast["whatsapp-main"]).toEqual(["main", "helper"]);
+    expect(result.broadcast["telegram-ops"]).toEqual(["ops"]);
+  });
+
+  it("preserves dynamic keys in env catchall", () => {
+    const input = JSON.stringify({
+      env: {
+        vars: { FOO: "bar" },
+        CUSTOM_KEY: "custom-value",
+      },
+    });
+    const result = JSON.parse(stripUnrecognizedConfigKeys(input));
+    expect(result.env.vars.FOO).toBe("bar");
+    expect(result.env.CUSTOM_KEY).toBe("custom-value");
+  });
+
+  it("returns non-JSON content unchanged", () => {
+    const input = "not valid json {{{";
+    expect(stripUnrecognizedConfigKeys(input)).toBe(input);
+  });
+});
+
 describe("resolveTargetFilename", () => {
   it("renames openclaw.json to remoteclaw.json", () => {
     expect(resolveTargetFilename("openclaw.json")).toBe("remoteclaw.json");
@@ -277,10 +384,10 @@ describe("importCommand", () => {
     const configContent = `{
   "env": {
     "vars": {
-      "token": "\${OPENCLAW_GATEWAY_TOKEN}"
+      "token": "\${OPENCLAW_GATEWAY_TOKEN}",
+      "workspace": "/home/user/.openclaw/workspace"
     }
-  },
-  "workspace": "/home/user/.openclaw/workspace"
+  }
 }`;
     await fsp.writeFile(path.join(sourceDir, "openclaw.json"), configContent);
 

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { resolveNewStateDir } from "../config/paths.js";
+import { RemoteClawSchema } from "../config/zod-schema.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
@@ -111,6 +112,153 @@ export function transformConfigContent(content: string): {
   });
 
   return { content: transformed, renames: [...new Set(renames)] };
+}
+
+/**
+ * Recursive key-tree node describing an object schema's known keys.
+ *
+ * - `children`: declared shape keys → their sub-trees (`null` = leaf)
+ * - `catchall`: when `true`, undeclared keys are preserved as-is
+ *   (the schema uses `.catchall()` to accept arbitrary extra keys)
+ */
+type KeyTreeNode = {
+  children: Map<string, KeyTreeNode | null>;
+  catchall: boolean;
+};
+
+/**
+ * Build a recursive key-tree from a Zod schema by walking `.shape` properties.
+ * Unwraps optional/nullable/default wrappers via `.unwrap()` to reach the
+ * underlying object shape. Returns `null` for non-object schemas (leaves).
+ */
+function buildKeyTree(schema: unknown): KeyTreeNode | null {
+  // Unwrap optional / nullable / default wrappers (.unwrap())
+  let current = schema;
+  while (
+    current &&
+    typeof current === "object" &&
+    "unwrap" in current &&
+    typeof current.unwrap === "function"
+  ) {
+    current = current.unwrap();
+  }
+
+  // Check for object shape
+  if (
+    !current ||
+    typeof current !== "object" ||
+    !("shape" in current) ||
+    !current.shape ||
+    typeof current.shape !== "object"
+  ) {
+    return null;
+  }
+
+  // Detect .catchall() — schema allows arbitrary extra keys.
+  // In Zod v4, .strict() sets catchall to ZodNever (type "never"),
+  // while a real .catchall() sets it to the accepting type.
+  const def =
+    "_zod" in current &&
+    current._zod &&
+    typeof current._zod === "object" &&
+    "def" in current._zod &&
+    current._zod.def &&
+    typeof current._zod.def === "object"
+      ? (current._zod.def as Record<string, unknown>)
+      : null;
+  const catchallSchema = def !== null && "catchall" in def ? def.catchall : null;
+  const hasCatchall = Boolean(
+    catchallSchema != null &&
+    typeof catchallSchema === "object" &&
+    "_zod" in catchallSchema &&
+    catchallSchema._zod &&
+    typeof catchallSchema._zod === "object" &&
+    "def" in catchallSchema._zod &&
+    catchallSchema._zod.def &&
+    typeof catchallSchema._zod.def === "object" &&
+    "type" in catchallSchema._zod.def &&
+    catchallSchema._zod.def.type !== "never",
+  );
+
+  const shape = current.shape as Record<string, unknown>;
+  const children = new Map<string, KeyTreeNode | null>();
+
+  for (const [key, fieldSchema] of Object.entries(shape)) {
+    children.set(key, buildKeyTree(fieldSchema));
+  }
+
+  return { children, catchall: hasCatchall };
+}
+
+/** Pre-built key tree from the root config schema, computed once at module load. */
+const CONFIG_KEY_TREE = buildKeyTree(RemoteClawSchema)!;
+
+/**
+ * Recursively filter an object to only keep keys present in the key tree.
+ * Keys in catchall objects are always preserved.
+ */
+function filterByKeyTree(
+  obj: Record<string, unknown>,
+  node: KeyTreeNode,
+): { result: Record<string, unknown>; changed: boolean } {
+  let changed = false;
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (!node.children.has(key)) {
+      if (node.catchall) {
+        // Schema accepts arbitrary extra keys — preserve as-is
+        result[key] = value;
+      } else {
+        changed = true;
+      }
+      continue;
+    }
+
+    const childNode = node.children.get(key);
+    if (childNode && value !== null && typeof value === "object" && !Array.isArray(value)) {
+      const nested = filterByKeyTree(value as Record<string, unknown>, childNode);
+      result[key] = nested.result;
+      if (nested.changed) {
+        changed = true;
+      }
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return { result, changed };
+}
+
+/**
+ * Strip unrecognized keys from the entire config JSON by filtering against
+ * the current RemoteClawSchema shape tree.
+ *
+ * OpenClaw configs may contain keys that RemoteClaw's schema no longer accepts.
+ * Instead of maintaining a denylist of dead keys, this function keeps only keys
+ * the current schema recognizes — any key we don't know about is dropped.
+ * Recurses into nested strict objects so sub-keys are filtered too.
+ */
+export function stripUnrecognizedConfigKeys(jsonContent: string): string {
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(jsonContent);
+  } catch {
+    return jsonContent;
+  }
+
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    return jsonContent;
+  }
+
+  const { result, changed } = filterByKeyTree(config, CONFIG_KEY_TREE);
+  if (!changed) {
+    return jsonContent;
+  }
+
+  const indentMatch = jsonContent.match(/^(\s+)"/m);
+  const indent = indentMatch?.[1] ?? "  ";
+  return JSON.stringify(result, null, indent) + "\n";
 }
 
 /**
@@ -253,9 +401,11 @@ async function copyDirectory(params: {
       if (isConfigFile(entry.name)) {
         const content = await fsp.readFile(sourcePath, "utf-8");
         const { content: transformed, renames } = transformConfigContent(content);
-        // Apply structural config transform to the main config file
+        // Apply structural config transforms to the main config file
         const isMainConfig = entry.name === OPENCLAW_CONFIG_FILENAME;
-        const final = isMainConfig ? materializeWorkspaceDefaults(transformed) : transformed;
+        const final = isMainConfig
+          ? materializeWorkspaceDefaults(stripUnrecognizedConfigKeys(transformed))
+          : transformed;
         if (renames.length > 0 || final !== transformed) {
           result.transformedFiles.push(targetPath);
           result.envVarRenames.push(...renames);


### PR DESCRIPTION
## Summary

- OpenClaw configs may contain keys that RemoteClaw's schema no longer accepts (e.g. `compaction`, `thinkingDefault`), causing strict Zod validation errors on import
- Instead of maintaining a denylist of dead keys, builds a recursive key-tree from `RemoteClawSchema` at module load and filters the entire config tree against it — any key the schema doesn't recognize is dropped
- Schemas with `.catchall()` (`broadcast`, `env`, `talk.providers`) correctly preserve their dynamic keys

## Test plan

- [x] 9 new unit tests for `stripUnrecognizedConfigKeys` covering top-level, nested, deep-nested stripping, catchall preservation, and non-JSON passthrough
- [x] Updated existing test fixture that had an invalid top-level key
- [x] All 40 import tests pass
- [x] `tsgo` type-check passes
- [x] `oxlint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)