### PR TITLE
fix(test): add agents.list config to E2E/live test harnesses

### DIFF
--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -231,10 +231,16 @@ describeLive("gateway live (cli backend)", () => {
 
     const cfg = loadConfig();
     const existingBackends = cfg.agents?.defaults?.cliBackends ?? {};
+    const workspaceDir = path.join(tempDir, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
     const nextCfg = {
       ...cfg,
       agents: {
         ...cfg.agents,
+        list: [
+          { id: "main", workspace: workspaceDir },
+          { id: "dev", workspace: workspaceDir },
+        ],
         defaults: {
           ...cfg.agents?.defaults,
           model: { primary: modelKey },

--- a/test/helpers/gateway-e2e-harness.ts
+++ b/test/helpers/gateway-e2e-harness.ts
@@ -107,7 +107,10 @@ export async function spawnGatewayInstance(name: string): Promise<GatewayInstanc
   await fs.mkdir(configDir, { recursive: true });
   const configPath = path.join(configDir, "remoteclaw.json");
   const stateDir = path.join(configDir, "state");
+  const workspaceDir = path.join(homeDir, "workspace");
+  await fs.mkdir(workspaceDir, { recursive: true });
   const config = {
+    agents: { list: [{ id: "main", workspace: workspaceDir }] },
     gateway: {
       port,
       auth: { mode: "token", token: gatewayToken },


### PR DESCRIPTION
## Summary

- Adds required `agents.list` with workspace directories to the gateway E2E harness and live CLI backend test
- `resolveAgentWorkspaceDir` throws when agents lack workspace config — these test setups were missing the entries, causing failures on any code path that resolves agent workspaces

## Test plan

- [ ] CI build passes
- [ ] CI tests pass (the fixed harnesses are exercised by E2E/live suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)