### PR TITLE
docs(install): clean provider setup heritage from 13 install docs

### DIFF
--- a/docs/install/ansible.md
+++ b/docs/install/ansible.md
@@ -27,7 +27,7 @@ curl -fsSL https://raw.githubusercontent.com/remoteclaw/remoteclaw-ansible/main/
 
 - 🔒 **Firewall-first security**: UFW + Docker isolation (only SSH + Tailscale accessible)
 - 🔐 **Tailscale VPN**: Secure remote access without exposing services publicly
-- 🐳 **Docker**: Isolated sandbox containers, localhost-only bindings
+- 🐳 **Docker**: Network isolation, localhost-only bindings
 - 🛡️ **Defense in depth**: 4-layer security architecture
 - 🚀 **One-command setup**: Complete deployment in minutes
 - 🔧 **Systemd integration**: Auto-start on boot with hardening
@@ -45,12 +45,12 @@ The Ansible playbook installs and configures:
 
 1. **Tailscale** (mesh VPN for secure remote access)
 2. **UFW firewall** (SSH + Tailscale ports only)
-3. **Docker CE + Compose V2** (for agent sandboxes)
+3. **Docker CE + Compose V2** (for network isolation and optional sandboxing)
 4. **Node.js 22.x + pnpm** (runtime dependencies)
 5. **RemoteClaw** (host-based, not containerized)
 6. **Systemd service** (auto-start with security hardening)
 
-Note: The gateway runs **directly on the host** (not in Docker), but agent sandboxes use Docker for isolation. See [Gateway configuration](/gateway/configuration#agentsdefaultssandbox) for details.
+Note: The gateway runs **directly on the host** (not in Docker). Docker is used for network isolation (firewall rules). See [Gateway configuration](/gateway/configuration) for details.
 
 ## Post-Install Setup
 
@@ -63,7 +63,7 @@ sudo -i -u remoteclaw
 The post-install script will guide you through:
 
 1. **Onboarding wizard**: Configure RemoteClaw settings
-2. **Provider login**: Connect WhatsApp/Telegram/Discord/Signal
+2. **Channel login**: Connect WhatsApp/Telegram/Discord/Signal
 3. **Gateway testing**: Verify the installation
 4. **Tailscale setup**: Connect to your VPN mesh
 
@@ -79,7 +79,7 @@ sudo journalctl -u remoteclaw -f
 # Restart gateway
 sudo systemctl restart remoteclaw
 
-# Provider login (run as remoteclaw user)
+# Channel login (run as remoteclaw user)
 sudo -i -u remoteclaw
 remoteclaw channels login
 ```
@@ -105,9 +105,9 @@ Should show **only port 22** (SSH) open. All other services (gateway, Docker) ar
 
 ### Docker Availability
 
-Docker is installed for **agent sandboxes** (isolated tool execution), not for running the gateway itself. The gateway binds to localhost only and is accessible via Tailscale VPN.
+Docker is installed for **network isolation** (firewall rules via DOCKER-USER iptables chain), not for running the gateway itself. The gateway binds to localhost only and is accessible via Tailscale VPN.
 
-See [Multi-Agent Routing](/concepts/multi-agent) for sandbox configuration.
+See [Multi-Agent Routing](/concepts/multi-agent) for agent configuration.
 
 ## Manual Installation
 
@@ -183,7 +183,7 @@ cd /opt/remoteclaw/remoteclaw
 sudo -u remoteclaw ./scripts/sandbox-setup.sh
 ```
 
-### Provider login fails
+### Channel login fails
 
 Make sure you're running as the `remoteclaw` user:
 
@@ -204,5 +204,5 @@ For detailed security architecture and troubleshooting:
 
 - [remoteclaw-ansible](https://github.com/remoteclaw/remoteclaw-ansible) — full deployment guide
 - [Docker](/install/docker) — containerized gateway setup
-- [Gateway configuration](/gateway/configuration#agentsdefaultssandbox) — agent sandbox configuration
+- [Gateway configuration](/gateway/configuration) — gateway configuration
 - [Multi-Agent Routing](/concepts/multi-agent) — per-agent isolation

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -42,7 +42,7 @@ This script:
 
 - builds the gateway image
 - runs the onboarding wizard
-- prints optional provider setup hints
+- prints optional channel setup hints
 - starts the gateway via Docker Compose
 - generates a gateway token and writes it to `.env`
 
@@ -296,12 +296,12 @@ docker compose run --rm remoteclaw-cli channels add --channel discord --token "<
 
 Docs: [WhatsApp](/channels/whatsapp), [Telegram](/channels/telegram), [Discord](/channels/discord)
 
-### OpenAI Codex OAuth (headless Docker)
+### CLI agent OAuth (headless Docker)
 
-If you pick OpenAI Codex OAuth in the wizard, it opens a browser URL and tries
-to capture a callback on `http://127.0.0.1:1455/auth/callback`. In Docker or
-headless setups that callback can show a browser error. Copy the full redirect
-URL you land on and paste it back into the wizard to finish auth.
+Some CLI agents (e.g. Codex) use OAuth flows that open a browser URL and try
+to capture a callback on a local port. In Docker or headless setups that
+callback can show a browser error. Copy the full redirect URL you land on and
+paste it back into the CLI agent's auth flow to finish auth.
 
 ### Health check
 

--- a/docs/install/fly.md
+++ b/docs/install/fly.md
@@ -14,7 +14,7 @@ read_when:
 
 - [flyctl CLI](https://fly.io/docs/hands-on/install-flyctl/) installed
 - Fly.io account (free tier works)
-- Model auth: Anthropic API key (or other provider keys)
+- CLI agent credentials: Anthropic API key (for Claude runtime), or keys for other CLI agents
 - Channel credentials: Discord bot token, Telegram token, etc.
 
 ## Beginner quick path
@@ -95,10 +95,10 @@ primary_region = "iad"
 # Required: Gateway token (for non-loopback binding)
 fly secrets set REMOTECLAW_GATEWAY_TOKEN=$(openssl rand -hex 32)
 
-# Model provider API keys
+# CLI agent API keys (consumed by the agent subprocess, not RemoteClaw)
 fly secrets set ANTHROPIC_API_KEY=sk-ant-...
 
-# Optional: Other providers
+# Optional: other CLI agent keys
 fly secrets set OPENAI_API_KEY=sk-...
 fly secrets set GOOGLE_API_KEY=...
 
@@ -150,10 +150,7 @@ cat > /data/remoteclaw.json << 'EOF'
 {
   "agents": {
     "defaults": {
-      "model": {
-        "primary": "anthropic/claude-opus-4-6",
-        "fallbacks": ["anthropic/claude-sonnet-4-5", "openai/gpt-4o"]
-      },
+      "runtime": "claude",
       "maxConcurrent": 4
     },
     "list": [
@@ -162,12 +159,6 @@ cat > /data/remoteclaw.json << 'EOF'
         "default": true
       }
     ]
-  },
-  "auth": {
-    "profiles": {
-      "anthropic:default": { "mode": "token", "provider": "anthropic" },
-      "openai:default": { "mode": "token", "provider": "openai" }
-    }
   },
   "bindings": [
     {

--- a/docs/install/gcp.md
+++ b/docs/install/gcp.md
@@ -57,8 +57,8 @@ For the generic Docker flow, see [Docker](/install/docker).
 - Basic comfort with SSH + copy/paste
 - ~20-30 minutes
 - Docker and Docker Compose
-- Model auth credentials
-- Optional provider credentials
+- CLI agent credentials (e.g., Anthropic API key for Claude runtime)
+- Optional channel credentials
   - WhatsApp QR
   - Telegram bot token
   - Gmail OAuth
@@ -285,7 +285,7 @@ services:
 Installing binaries inside a running container is a trap.
 Anything installed at runtime will be lost on restart.
 
-All external binaries required by skills must be installed at image build time.
+All external binaries required by MCP tools or extensions must be installed at image build time.
 
 The examples below show three common binaries only:
 
@@ -296,7 +296,7 @@ The examples below show three common binaries only:
 These are examples, not a complete list.
 You may install as many binaries as needed using the same pattern.
 
-If you add new skills later that depend on additional binaries, you must:
+If you add new MCP tools or extensions later that depend on additional binaries, you must:
 
 1. Update the Dockerfile
 2. Rebuild the image
@@ -403,18 +403,18 @@ Paste your gateway token.
 RemoteClaw runs in Docker, but Docker is not the source of truth.
 All long-lived state must survive restarts, rebuilds, and reboots.
 
-| Component           | Location                            | Persistence mechanism  | Notes                              |
-| ------------------- | ----------------------------------- | ---------------------- | ---------------------------------- |
-| Gateway config      | `/home/node/.remoteclaw/`           | Host volume mount      | Includes `remoteclaw.json`, tokens |
-| Model auth profiles | `/home/node/.remoteclaw/`           | Host volume mount      | OAuth tokens, API keys             |
-| Skill configs       | `/home/node/.remoteclaw/skills/`    | Host volume mount      | Skill-level state                  |
-| Agent workspace     | `/home/node/.remoteclaw/workspace/` | Host volume mount      | Code and agent artifacts           |
-| WhatsApp session    | `/home/node/.remoteclaw/`           | Host volume mount      | Preserves QR login                 |
-| Gmail keyring       | `/home/node/.remoteclaw/`           | Host volume + password | Requires `GOG_KEYRING_PASSWORD`    |
-| External binaries   | `/usr/local/bin/`                   | Docker image           | Must be baked at build time        |
-| Node runtime        | Container filesystem                | Docker image           | Rebuilt every image build          |
-| OS packages         | Container filesystem                | Docker image           | Do not install at runtime          |
-| Docker container    | Ephemeral                           | Restartable            | Safe to destroy                    |
+| Component           | Location                             | Persistence mechanism  | Notes                              |
+| ------------------- | ------------------------------------ | ---------------------- | ---------------------------------- |
+| Gateway config      | `/home/node/.remoteclaw/`            | Host volume mount      | Includes `remoteclaw.json`, tokens |
+| Channel credentials | `/home/node/.remoteclaw/`            | Host volume mount      | Channel tokens, session state      |
+| Extension configs   | `/home/node/.remoteclaw/extensions/` | Host volume mount      | Extension-level state              |
+| Agent workspace     | `/home/node/.remoteclaw/workspace/`  | Host volume mount      | Code and agent artifacts           |
+| WhatsApp session    | `/home/node/.remoteclaw/`            | Host volume mount      | Preserves QR login                 |
+| Gmail keyring       | `/home/node/.remoteclaw/`            | Host volume + password | Requires `GOG_KEYRING_PASSWORD`    |
+| External binaries   | `/usr/local/bin/`                    | Docker image           | Must be baked at build time        |
+| Node runtime        | Container filesystem                 | Docker image           | Rebuilt every image build          |
+| OS packages         | Container filesystem                 | Docker image           | Do not install at runtime          |
+| Docker container    | Ephemeral                            | Restartable            | Safe to destroy                    |
 
 ---
 

--- a/docs/install/hetzner.md
+++ b/docs/install/hetzner.md
@@ -64,8 +64,8 @@ For the generic Docker flow, see [Docker](/install/docker).
 - Basic comfort with SSH + copy/paste
 - ~20 minutes
 - Docker and Docker Compose
-- Model auth credentials
-- Optional provider credentials
+- CLI agent credentials (e.g., Anthropic API key for Claude runtime)
+- Optional channel credentials
   - WhatsApp QR
   - Telegram bot token
   - Gmail OAuth
@@ -207,7 +207,7 @@ services:
 Installing binaries inside a running container is a trap.
 Anything installed at runtime will be lost on restart.
 
-All external binaries required by skills must be installed at image build time.
+All external binaries required by MCP tools or extensions must be installed at image build time.
 
 The examples below show three common binaries only:
 
@@ -218,7 +218,7 @@ The examples below show three common binaries only:
 These are examples, not a complete list.
 You may install as many binaries as needed using the same pattern.
 
-If you add new skills later that depend on additional binaries, you must:
+If you add new MCP tools or extensions later that depend on additional binaries, you must:
 
 1. Update the Dockerfile
 2. Rebuild the image
@@ -321,18 +321,18 @@ Paste your gateway token.
 RemoteClaw runs in Docker, but Docker is not the source of truth.
 All long-lived state must survive restarts, rebuilds, and reboots.
 
-| Component           | Location                            | Persistence mechanism  | Notes                              |
-| ------------------- | ----------------------------------- | ---------------------- | ---------------------------------- |
-| Gateway config      | `/home/node/.remoteclaw/`           | Host volume mount      | Includes `remoteclaw.json`, tokens |
-| Model auth profiles | `/home/node/.remoteclaw/`           | Host volume mount      | OAuth tokens, API keys             |
-| Skill configs       | `/home/node/.remoteclaw/skills/`    | Host volume mount      | Skill-level state                  |
-| Agent workspace     | `/home/node/.remoteclaw/workspace/` | Host volume mount      | Code and agent artifacts           |
-| WhatsApp session    | `/home/node/.remoteclaw/`           | Host volume mount      | Preserves QR login                 |
-| Gmail keyring       | `/home/node/.remoteclaw/`           | Host volume + password | Requires `GOG_KEYRING_PASSWORD`    |
-| External binaries   | `/usr/local/bin/`                   | Docker image           | Must be baked at build time        |
-| Node runtime        | Container filesystem                | Docker image           | Rebuilt every image build          |
-| OS packages         | Container filesystem                | Docker image           | Do not install at runtime          |
-| Docker container    | Ephemeral                           | Restartable            | Safe to destroy                    |
+| Component           | Location                             | Persistence mechanism  | Notes                              |
+| ------------------- | ------------------------------------ | ---------------------- | ---------------------------------- |
+| Gateway config      | `/home/node/.remoteclaw/`            | Host volume mount      | Includes `remoteclaw.json`, tokens |
+| Channel credentials | `/home/node/.remoteclaw/`            | Host volume mount      | Channel tokens, session state      |
+| Extension configs   | `/home/node/.remoteclaw/extensions/` | Host volume mount      | Extension-level state              |
+| Agent workspace     | `/home/node/.remoteclaw/workspace/`  | Host volume mount      | Code and agent artifacts           |
+| WhatsApp session    | `/home/node/.remoteclaw/`            | Host volume mount      | Preserves QR login                 |
+| Gmail keyring       | `/home/node/.remoteclaw/`            | Host volume + password | Requires `GOG_KEYRING_PASSWORD`    |
+| External binaries   | `/usr/local/bin/`                    | Docker image           | Must be baked at build time        |
+| Node runtime        | Container filesystem                 | Docker image           | Rebuilt every image build          |
+| OS packages         | Container filesystem                 | Docker image           | Do not install at runtime          |
+| Docker container    | Ephemeral                            | Restartable            | Safe to destroy                    |
 
 ---
 

--- a/docs/install/installer.mdx
+++ b/docs/install/installer.mdx
@@ -246,7 +246,7 @@ Designed for environments where you want everything under a local prefix (defaul
 | `REMOTECLAW_NODE_VERSION=<ver>`               | Node version                                                                      |
 | `REMOTECLAW_NO_ONBOARD=1`                     | Skip onboarding                                                                   |
 | `REMOTECLAW_NPM_LOGLEVEL=error\|warn\|notice` | npm log level                                                                     |
-| `REMOTECLAW_GIT_DIR=<path>`                   | Legacy cleanup lookup path (used when removing old `Peekaboo` submodule checkout) |
+| `REMOTECLAW_GIT_DIR=<path>`                   | Legacy cleanup lookup path (used when removing old submodule checkouts) |
 | `SHARP_IGNORE_GLOBAL_LIBVIPS=0\|1`            | Control sharp/libvips behavior (default: `1`)                                     |
 
 </details>

--- a/docs/install/macos-vm.md
+++ b/docs/install/macos-vm.md
@@ -141,7 +141,7 @@ npm install -g remoteclaw@latest
 remoteclaw onboard --install-daemon
 ```
 
-Follow the onboarding prompts to set up your model provider (Anthropic, OpenAI, etc.).
+Follow the onboarding prompts to select an agent runtime and configure channels.
 
 ---
 

--- a/docs/install/migrating.md
+++ b/docs/install/migrating.md
@@ -55,7 +55,7 @@ Your workspace is where files like `MEMORY.md` and `memory/*.md` live.
 If you copy **both** the state dir and workspace, you keep:
 
 - Gateway configuration (`remoteclaw.json`)
-- Auth profiles / API keys / OAuth tokens
+- Channel credentials and tokens
 - Session history + agent state
 - Channel state (e.g. WhatsApp login/session)
 - Your workspace files (memory, skills notes, etc.)

--- a/docs/install/northflank.mdx
+++ b/docs/install/northflank.mdx
@@ -27,8 +27,8 @@ and you configure everything via the `/setup` web wizard.
 ## Setup flow
 
 1. Visit `https://<your-northflank-domain>/setup` and enter your `SETUP_PASSWORD`.
-2. Choose a model/auth provider and paste your key.
-3. (Optional) Add Telegram/Discord/Slack tokens.
+2. Select a CLI agent runtime and configure its API key.
+3. (Optional) Add channel tokens (Telegram, Discord, Slack).
 4. Click **Run setup**.
 5. Open the Control UI at `https://<your-northflank-domain>/remoteclaw`
 

--- a/docs/install/podman.md
+++ b/docs/install/podman.md
@@ -22,7 +22,7 @@ Run the RemoteClaw gateway in a **rootless** Podman container. Uses the same ima
 ./setup-podman.sh
 ```
 
-This also creates a minimal `~remoteclaw/.remoteclaw/remoteclaw.json` (sets `gateway.mode="local"`) so the gateway can start without running the wizard.
+This also creates a minimal `~remoteclaw/.remoteclaw/remoteclaw.json` (sets `gateway.mode="local"`) so the gateway can start without additional setup.
 
 By default the container is **not** installed as a systemd service, you start it manually (see below). For a production-style setup with auto-start and restarts, install it as a systemd Quadlet user service instead:
 
@@ -38,7 +38,7 @@ By default the container is **not** installed as a systemd service, you start it
 ./scripts/run-remoteclaw-podman.sh launch
 ```
 
-**3. Onboarding wizard** (e.g. to add channels or providers):
+**3. Onboarding wizard** (e.g. to add channels):
 
 ```bash
 ./scripts/run-remoteclaw-podman.sh launch setup
@@ -83,7 +83,7 @@ To add quadlet **after** an initial setup that did not use it, re-run: `./setup-
 ## Environment and config
 
 - **Token:** Stored in `~remoteclaw/.remoteclaw/.env` as `REMOTECLAW_GATEWAY_TOKEN`. `setup-podman.sh` and `run-remoteclaw-podman.sh` generate it if missing (uses `openssl`, `python3`, or `od`).
-- **Optional:** In that `.env` you can set provider keys (e.g. `GROQ_API_KEY`, `OLLAMA_API_KEY`) and other RemoteClaw env vars.
+- **Optional:** In that `.env` you can set CLI agent API keys (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) and other RemoteClaw env vars.
 - **Host ports:** By default the script maps `18789` (gateway) and `18790` (bridge). Override the **host** port mapping with `REMOTECLAW_PODMAN_GATEWAY_HOST_PORT` and `REMOTECLAW_PODMAN_BRIDGE_HOST_PORT` when launching.
 - **Paths:** Host config and workspace default to `~remoteclaw/.remoteclaw` and `~remoteclaw/.remoteclaw/workspace`. Override the host paths used by the launch script with `REMOTECLAW_CONFIG_DIR` and `REMOTECLAW_WORKSPACE_DIR`.
 
@@ -97,7 +97,7 @@ To add quadlet **after** an initial setup that did not use it, re-run: `./setup-
 ## Troubleshooting
 
 - **Permission denied (EACCES) on config or auth-profiles:** The container defaults to `--userns=keep-id` and runs as the same uid/gid as the host user running the script. Ensure your host `REMOTECLAW_CONFIG_DIR` and `REMOTECLAW_WORKSPACE_DIR` are owned by that user.
-- **Gateway start blocked (missing `gateway.mode=local`):** Ensure `~remoteclaw/.remoteclaw/remoteclaw.json` exists and sets `gateway.mode="local"`. `setup-podman.sh` creates this file if missing.
+- **Gateway start blocked (missing `gateway.mode=local`):** Ensure `~remoteclaw/.remoteclaw/remoteclaw.json` exists and sets `gateway.mode="local"`. `setup-podman.sh` creates this file if missing. This setting controls the gateway's network mode, not an onboarding wizard.
 - **Rootless Podman fails for user remoteclaw:** Check `/etc/subuid` and `/etc/subgid` contain a line for `remoteclaw` (e.g. `remoteclaw:100000:65536`). Add it if missing and restart.
 - **Container name in use:** The launch script uses `podman run --replace`, so the existing container is replaced when you start again. To clean up manually: `podman rm -f remoteclaw`.
 - **Script not found when running as remoteclaw:** Ensure `setup-podman.sh` was run so that `run-remoteclaw-podman.sh` is copied to remoteclaw’s home (e.g. `/home/remoteclaw/run-remoteclaw-podman.sh`).

--- a/docs/install/railway.mdx
+++ b/docs/install/railway.mdx
@@ -66,8 +66,8 @@ Set these variables on the service:
 ## Setup flow
 
 1. Visit `https://<your-railway-domain>/setup` and enter your `SETUP_PASSWORD`.
-2. Choose a model/auth provider and paste your key.
-3. (Optional) Add Telegram/Discord/Slack tokens.
+2. Select a CLI agent runtime and configure its API key.
+3. (Optional) Add channel tokens (Telegram, Discord, Slack).
 4. Click **Run setup**.
 
 If Telegram DMs are set to pairing, the setup wizard can approve the pairing code.

--- a/docs/install/render.mdx
+++ b/docs/install/render.mdx
@@ -7,7 +7,7 @@ Deploy RemoteClaw on Render using Infrastructure as Code. The included `render.y
 ## Prerequisites
 
 - A [Render account](https://render.com) (free tier available)
-- An API key from your preferred [model provider](/providers)
+- An API key for your CLI agent runtime (e.g. Anthropic API key for Claude)
 
 ## Deploy with a Render Blueprint
 
@@ -77,7 +77,7 @@ The Blueprint defaults to `starter`. To use free tier, change `plan: free` in yo
 
 1. Navigate to `https://<your-service>.onrender.com/setup`
 2. Enter your `SETUP_PASSWORD`
-3. Select a model provider and paste your API key
+3. Select a CLI agent runtime and paste its API key
 4. Optionally configure messaging channels (Telegram, Discord, Slack)
 5. Click **Run setup**
 

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -22,7 +22,7 @@ curl -fsSL https://remoteclaw.org/install.sh | bash
 
 Notes:
 
-- Add `--no-onboard` if you don’t want the onboarding wizard to run again.
+- Add `--no-onboard` to skip the post-install setup prompts.
 - For **source installs**, use:
 
   ```bash
@@ -32,7 +32,7 @@ Notes:
   The installer will `git pull --rebase` **only** if the repo is clean.
 
 - For **global installs**, the script uses `npm install -g remoteclaw@latest` under the hood.
-- Legacy note: `clawdbot` remains available as a compatibility shim.
+- Legacy note: `clawdbot` may still be available as a compatibility shim on older installs.
 
 ## Before you update
 


### PR DESCRIPTION
## Summary

- Remove OpenClaw model provider setup steps, model config examples, provider API key framing, sandbox references, skills marketplace language, and stale onboarding wizard references from 13 install/deployment docs
- Replace with RemoteClaw middleware-accurate terminology: CLI agent runtimes, channel credentials, MCP tools, and extensions
- Remove `agents.defaults.model` block and `auth.profiles` section from fly.md config example, replace with `runtime: "claude"`

Closes #394

## Changes by file

| File | Changes |
|------|---------|
| `ansible.md` | Remove sandbox framing, fix Docker role description, rename provider→channel login, remove dead `#agentsdefaultssandbox` anchor |
| `docker.md` | Rename provider→channel setup hints, rewrite Codex OAuth section as generic CLI agent OAuth |
| `fly.md` | Fix API key comments, remove `model` block and `auth.profiles` from config, rename prerequisites |
| `gcp.md` | Rename model auth→CLI agent credentials, replace skills→MCP tools/extensions, fix persistence table |
| `hetzner.md` | Same pattern as gcp.md: credentials, skills→MCP tools, persistence table |
| `installer.mdx` | Remove Peekaboo internal name from env var description |
| `macos-vm.md` | Replace "set up your model provider" with "select an agent runtime and configure channels" |
| `migrating.md` | Replace "Auth profiles / API keys / OAuth tokens" with "Channel credentials and tokens" |
| `northflank.mdx` | Replace "model/auth provider" with "CLI agent runtime" in setup flow |
| `podman.md` | Remove "or providers", replace Groq/Ollama env vars with Anthropic/OpenAI, clarify gateway.mode |
| `railway.mdx` | Same as northflank: model/auth provider → CLI agent runtime |
| `render.mdx` | Remove `/providers` link, replace model provider → CLI agent runtime |
| `updating.md` | Clarify `--no-onboard` description, soften `clawdbot` shim claim |

## Exit criteria verification

```
grep -ri 'agents\.defaults\.model|model.provider|models\.providers' docs/install/ → CLEAN
grep -ri 'remoteclaw onboard.*auth-choice|remoteclaw onboard.*api-key' docs/install/ → CLEAN
grep -ri 'openai-api-key|anthropic-api-key|mistral-api-key' docs/install/ | grep -v 'CLI agent' → CLEAN
```

## Test plan

- [x] All three exit criteria grep checks pass (CLEAN)
- [ ] CI build passes
- [ ] CI test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)