### PR TITLE
docs(tools,plugins): clean skills/tools heritage from tools and plugins docs

### DIFF
--- a/docs/plugins/agent-tools.md
+++ b/docs/plugins/agent-tools.md
@@ -88,8 +88,6 @@ Other config knobs that affect tool availability:
 - Allowlists that only name plugin tools are treated as plugin opt-ins; core tools remain
   enabled unless you also include core tools or groups in the allowlist.
 - `tools.profile` / `agents.list[].tools.profile` (base allowlist)
-- `tools.byProvider` / `agents.list[].tools.byProvider` (provider‑specific allow/deny)
-- `tools.sandbox.tools.*` (sandbox tool policy when sandboxed)
 
 ## Rules + tips
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -37,8 +37,6 @@ Optional keys:
 
 - `kind` (string): plugin kind (example: `"memory"`).
 - `channels` (array): channel ids registered by this plugin (example: `["matrix"]`).
-- `providers` (array): provider ids registered by this plugin.
-- `skills` (array): skill directories to load (relative to the plugin root).
 - `name` (string): display name for the plugin.
 - `description` (string): short plugin summary.
 - `uiHints` (object): config field labels/placeholders/sensitive flags for UI rendering.

--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -298,9 +298,10 @@ Inbound policy defaults to `disabled`. To enable inbound calls, set:
 
 Auto-responses use the agent system. Tune with:
 
-- `responseModel`
 - `responseSystemPrompt`
 - `responseTimeoutMs`
+
+Model selection is the CLI agent's responsibility and is not configurable here.
 
 ## CLI
 

--- a/docs/tools/agent-send.md
+++ b/docs/tools/agent-send.md
@@ -8,8 +8,8 @@ title: "Agent Send"
 # `remoteclaw agent` (direct agent runs)
 
 `remoteclaw agent` runs a single agent turn without needing an inbound chat message.
-By default it goes **through the Gateway**; add `--local` to force the embedded
-runtime on the current machine.
+By default it goes **through the Gateway**; add `--local` to run a local CLI
+agent subprocess on the current machine.
 
 ## Behavior
 
@@ -18,7 +18,7 @@ runtime on the current machine.
   - `--to <dest>` derives the session key (group/channel targets preserve isolation; direct chats collapse to `main`), **or**
   - `--session-id <id>` reuses an existing session by id, **or**
   - `--agent <id>` targets a configured agent directly (uses that agent's `main` session key)
-- Runs the same embedded agent runtime as normal inbound replies.
+- Runs the same CLI agent subprocess as normal inbound replies.
 - Thinking/verbose flags persist into the session store.
 - Output:
   - default: prints reply text (plus `MEDIA:<url>` lines)
@@ -26,7 +26,7 @@ runtime on the current machine.
 - Optional delivery back to a channel with `--deliver` + `--channel` (target formats match `remoteclaw message --target`).
 - Use `--reply-channel`/`--reply-to`/`--reply-account` to override delivery without changing the session.
 
-If the Gateway is unreachable, the CLI **falls back** to the embedded local run.
+If the Gateway is unreachable, the CLI **falls back** to a local CLI agent subprocess.
 
 ## Examples
 
@@ -47,7 +47,7 @@ remoteclaw agent --agent ops --message "Generate report" --deliver --reply-chann
 - `--reply-to`: delivery target override
 - `--reply-channel`: delivery channel override
 - `--reply-account`: delivery account id override
-- `--thinking <off|minimal|low|medium|high|xhigh>`: persist thinking level (GPT-5.2 + Codex models only)
+- `--thinking <off|minimal|low|medium|high|xhigh>`: persist thinking level (passed through to the CLI agent)
 - `--verbose <on|full|off>`: persist verbose level
 - `--timeout <seconds>`: override agent timeout
 - `--json`: output structured JSON

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -130,8 +130,9 @@ allowlisted or a safe bin. Chaining (`;`, `&&`, `||`) and redirections are rejec
 allowlist mode unless every top-level segment satisfies the allowlist (including safe bins).
 Redirections remain unsupported.
 
-`autoAllowSkills` is a separate convenience path in exec approvals. It is not the same as
-manual path allowlist entries. For strict explicit trust, keep `autoAllowSkills` disabled.
+`autoAllowSkills` is a separate convenience path in exec approvals that auto-allows
+executables from locally-installed workspace skills. It is not the same as manual path
+allowlist entries. For strict explicit trust, keep `autoAllowSkills` disabled.
 
 Use the two controls for different jobs:
 
@@ -189,7 +190,7 @@ Enable it explicitly:
 {
   tools: {
     exec: {
-      applyPatch: { enabled: true, workspaceOnly: true, allowModels: ["gpt-5.2"] },
+      applyPatch: { enabled: true, workspaceOnly: true },
     },
   },
 }
@@ -197,7 +198,8 @@ Enable it explicitly:
 
 Notes:
 
-- Only available for OpenAI/OpenAI Codex models.
+- Only relevant when using the `codex` runtime (OpenCode/Codex CLI), which natively
+  supports `apply_patch` as a subtool.
 - Tool policy still applies; `allow: ["exec"]` implicitly allows `apply_patch`.
 - Config lives under `tools.exec.applyPatch`.
 - `tools.exec.applyPatch.workspaceOnly` defaults to `true` (workspace-contained). Set it to `false` only if you intentionally want `apply_patch` to write/delete outside the workspace directory.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -15,7 +15,7 @@ and the agent should rely on them directly.
 ## Disabling tools
 
 You can globally allow/deny tools via `tools.allow` / `tools.deny` in `remoteclaw.json`
-(deny wins). This prevents disallowed tools from being sent to model providers.
+(deny wins). This prevents disallowed tools from being presented to the agent.
 
 ```json5
 {
@@ -73,62 +73,6 @@ Example (global coding profile, messaging-only support agent):
       {
         id: "support",
         tools: { profile: "messaging", allow: ["slack"] },
-      },
-    ],
-  },
-}
-```
-
-## Provider-specific tool policy
-
-Use `tools.byProvider` to **further restrict** tools for specific providers
-(or a single `provider/model`) without changing your global defaults.
-Per-agent override: `agents.list[].tools.byProvider`.
-
-This is applied **after** the base tool profile and **before** allow/deny lists,
-so it can only narrow the tool set.
-Provider keys accept either `provider` (e.g. `google-antigravity`) or
-`provider/model` (e.g. `openai/gpt-5.2`).
-
-Example (keep global coding profile, but minimal tools for Google Antigravity):
-
-```json5
-{
-  tools: {
-    profile: "coding",
-    byProvider: {
-      "google-antigravity": { profile: "minimal" },
-    },
-  },
-}
-```
-
-Example (provider/model-specific allowlist for a flaky endpoint):
-
-```json5
-{
-  tools: {
-    allow: ["group:fs", "group:runtime", "sessions_list"],
-    byProvider: {
-      "openai/gpt-5.2": { allow: ["group:fs", "sessions_list"] },
-    },
-  },
-}
-```
-
-Example (agent-specific override for a single provider):
-
-```json5
-{
-  agents: {
-    list: [
-      {
-        id: "support",
-        tools: {
-          byProvider: {
-            "google-antigravity": { allow: ["message", "sessions_list"] },
-          },
-        },
       },
     ],
   },
@@ -382,8 +326,8 @@ Core parameters:
 
 Notes:
 
-- Only available when `agents.defaults.imageModel` is configured (primary or fallbacks), or when an implicit image model can be inferred from your default model + configured auth (best-effort pairing).
-- Uses the image model directly (independent of the main chat model).
+- Requires a configured image model (see agent configuration).
+- Image analysis runs independently of the main chat model.
 
 ### `message`
 
@@ -454,8 +398,8 @@ Core parameters:
 - `sessions_list`: `kinds?`, `limit?`, `activeMinutes?`, `messageLimit?` (0 = none)
 - `sessions_history`: `sessionKey` (or `sessionId`), `limit?`, `includeTools?`
 - `sessions_send`: `sessionKey` (or `sessionId`), `message`, `timeoutSeconds?` (0 = fire-and-forget)
-- `sessions_spawn`: `task`, `label?`, `agentId?`, `model?`, `thinking?`, `runTimeoutSeconds?`, `thread?`, `mode?`, `cleanup?`
-- `session_status`: `sessionKey?` (default current; accepts `sessionId`), `model?` (`default` clears override)
+- `sessions_spawn`: `task`, `label?`, `agentId?`, `model?` (passed through to CLI agent), `thinking?` (passed through to CLI agent), `runTimeoutSeconds?`, `thread?`, `mode?`, `cleanup?`
+- `session_status`: `sessionKey?` (default current; accepts `sessionId`)
 
 Notes:
 
@@ -536,7 +480,7 @@ Node targeting:
 Tools are exposed in two parallel channels:
 
 1. **System prompt text**: a human-readable list + guidance.
-2. **Tool schema**: the structured function definitions sent to the model API.
+2. **Tool schema**: the structured function definitions forwarded to the CLI agent.
 
 That means the agent sees both “what tools exist” and “how to call them.” If a tool
 doesn’t appear in the system prompt or the schema, the model cannot call it.

--- a/docs/tools/llm-task.md
+++ b/docs/tools/llm-task.md
@@ -52,10 +52,7 @@ workflow.
       "llm-task": {
         "enabled": true,
         "config": {
-          "defaultProvider": "openai-codex",
           "defaultModel": "gpt-5.2",
-          "defaultAuthProfileId": "main",
-          "allowedModels": ["openai-codex/gpt-5.3-codex"],
           "maxTokens": 800,
           "timeoutMs": 30000
         }
@@ -65,17 +62,12 @@ workflow.
 }
 ```
 
-`allowedModels` is an allowlist of `provider/model` strings. If set, any request
-outside the list is rejected.
-
 ## Tool parameters
 
 - `prompt` (string, required)
 - `input` (any, optional)
 - `schema` (object, optional JSON Schema)
-- `provider` (string, optional)
 - `model` (string, optional)
-- `authProfileId` (string, optional)
 - `temperature` (number, optional)
 - `maxTokens` (number, optional)
 - `timeoutMs` (number, optional)

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -48,10 +48,7 @@ Looking for third-party listings? See [Community plugins](/plugins/community).
 - [Nostr](/channels/nostr) — `@remoteclaw/nostr`
 - [Zalo](/channels/zalo) — `@remoteclaw/zalo`
 - [Microsoft Teams](/channels/msteams) — `@remoteclaw/msteams`
-- Google Antigravity OAuth (provider auth) — bundled as `google-antigravity-auth` (disabled by default)
-- Gemini CLI OAuth (provider auth) — bundled as `google-gemini-cli-auth` (disabled by default)
-- Qwen OAuth (provider auth) — bundled as `qwen-portal-auth` (disabled by default)
-- Copilot Proxy (provider auth) — local VS Code Copilot Proxy bridge; distinct from built-in `github-copilot` device login (bundled, disabled by default)
+- Gemini CLI OAuth (CLI authentication) — bundled as `google-gemini-cli-auth` (disabled by default)
 
 RemoteClaw plugins are **TypeScript modules** loaded at runtime via jiti. **Config
 validation does not execute plugin code**; it uses the plugin manifest and JSON
@@ -65,7 +62,6 @@ Plugins can register:
 - CLI commands
 - Background services
 - Optional config validation
-- **Skills** (by listing `skills` directories in the plugin manifest)
 - **Auto-reply commands** (execute without invoking the AI agent)
 
 Plugins run **in‑process** with the Gateway, so treat them as trusted code.
@@ -401,8 +397,7 @@ Notes:
 
 ### Write a new messaging channel (step‑by‑step)
 
-Use this when you want a **new chat surface** (a "messaging channel"), not a model provider.
-Model provider docs live under `/providers/*`.
+Use this when you want a **new chat surface** (a "messaging channel").
 
 1. Pick an id + config shape
 
@@ -590,12 +585,6 @@ export default function (api) {
 - Gateway methods: `pluginId.action` (example: `voicecall.status`)
 - Tools: `snake_case` (example: `voice_call`)
 - CLI commands: kebab or camel, but avoid clashing with core commands
-
-## Skills
-
-Plugins can ship a skill in the repo (`skills/<name>/SKILL.md`).
-Enable it with `plugins.entries.<id>.enabled` (or other config gates) and ensure
-it’s present in your workspace/managed skills locations.
 
 ## Distribution (npm)
 

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -70,7 +70,7 @@ Text + native (when enabled):
 - `/help`
 - `/commands`
 - `/remoteclaw` (show RemoteClaw middleware status)
-- `/status` (show current status; includes provider usage/quota for the current model provider when available)
+- `/status` (show current status)
 - `/allowlist` (list/add/remove allowlist entries)
 - `/export-session [path]` (alias: `/export`) (export current session to HTML)
 - `/whoami` (show your sender id; alias: `/id`)
@@ -84,7 +84,7 @@ Text + native (when enabled):
 - `/tell <id|#> <message>` (alias for `/steer`)
 - `/config show|get|set|unset` (persist config to disk, owner-only; requires `commands.config: true`)
 - `/debug show|set|unset|reset` (runtime overrides, owner-only; requires `commands.debug: true`)
-- `/usage off|tokens|full|cost` (per-response usage footer or local cost summary)
+- `/usage off|tokens|full|cost` (per-response usage footer; `/usage cost` relays token counts from session logs)
 - `/tts off|always|inbound|tagged|status|provider|limit|summary|audio` (control TTS; see [/tts](/tts))
   - Discord: native command is `/voice` (Discord reserves `/tts`); text `/tts` still works.
 - `/stop`
@@ -108,7 +108,7 @@ Notes:
 
 - Commands accept an optional `:` between the command and args (e.g. `/send: on`, `/help:`).
 - `/allowlist add|remove` requires `commands.config=true` and honors channel `configWrites`.
-- `/usage` controls the per-response usage footer; `/usage cost` prints a local cost summary from session logs.
+- `/usage` controls the per-response usage footer; `/usage cost` prints a cost summary from session logs (relayed from the CLI agent).
 - `/restart` is enabled by default; set `commands.restart: false` to disable it.
 - Discord-only native command: `/vc join|leave|status` controls voice channels (requires `channels.discord.voice` and native commands; not available as text).
 - Discord thread-binding commands (`/focus`, `/unfocus`, `/agents`, `/session ttl`) require effective thread bindings to be enabled (`session.threadBindings.enabled` and/or `channels.discord.threadBindings.enabled`).
@@ -124,8 +124,8 @@ Notes:
 
 ## Usage surfaces (what shows where)
 
-- **Provider usage/quota** (example: “Claude 80% left”) shows up in `/status` for the current model provider when usage tracking is enabled.
-- **Per-response tokens/cost** is controlled by `/usage off|tokens|full` (appended to normal replies).
+- **Agent usage info** may be surfaced in `/status` when reported by the CLI agent.
+- **Per-response tokens/cost** is controlled by `/usage off|tokens|full` (appended to normal replies; relayed from CLI agent output).
 
 ## Debug overrides
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -21,7 +21,7 @@ Use `/subagents` to inspect or control sub-agent runs for the **current session*
 - `/subagents info <id|#>`
 - `/subagents send <id|#> <message>`
 - `/subagents steer <id|#> <message>`
-- `/subagents spawn <agentId> <task> [--model <model>] [--thinking <level>]`
+- `/subagents spawn <agentId> <task> [--model <model>] [--thinking <level>]` (flags are passed through to the CLI agent)
 
 Thread binding controls:
 
@@ -48,7 +48,7 @@ These commands work on channels that support persistent thread bindings. See **T
   - `Result` (`assistant` reply text, or latest `toolResult` if the assistant reply is empty)
   - `Status` (`completed successfully` / `failed` / `timed out`)
   - compact runtime/token stats
-- `--model` and `--thinking` override defaults for that specific run.
+- `--model` and `--thinking` are passed through to the CLI agent subprocess for that specific run.
 - Use `info`/`log` to inspect details and output after completion.
 - `/subagents spawn` is one-shot mode (`mode: "run"`). For persistent thread-bound sessions, use `sessions_spawn` with `thread: true` and `mode: "session"`.
 
@@ -59,9 +59,9 @@ Primary goals:
 - Keep the tool surface hard to misuse: sub-agents do **not** get session tools by default.
 - Support configurable nesting depth for orchestrator patterns.
 
-Cost note: each sub-agent has its **own** context and token usage. For heavy or repetitive
-tasks, set a cheaper model for sub-agents and keep your main agent on a higher-quality model.
-You can configure this via `agents.defaults.subagents.model` or per-agent overrides.
+Cost note: each sub-agent has its **own** context and token usage. The `model` and
+`thinking` flags are passed through to the CLI agent subprocess — model selection is the
+CLI agent's responsibility, not RemoteClaw's.
 
 ## Tool
 
@@ -69,8 +69,8 @@ Use `sessions_spawn`:
 
 - Starts a sub-agent run (`deliver: false`, global lane: `subagent`)
 - Then runs an announce step and posts the announce reply to the requester chat channel
-- Default model: inherits the caller unless you set `agents.defaults.subagents.model` (or per-agent `agents.list[].subagents.model`); an explicit `sessions_spawn.model` still wins.
-- Default thinking: inherits the caller unless you set `agents.defaults.subagents.thinking` (or per-agent `agents.list[].subagents.thinking`); an explicit `sessions_spawn.thinking` still wins.
+- Default model: inherits the caller; an explicit `sessions_spawn.model` is passed through to the CLI agent subprocess.
+- Default thinking: inherits the caller; an explicit `sessions_spawn.thinking` is passed through to the CLI agent subprocess.
 - Default run timeout: if `sessions_spawn.runTimeoutSeconds` is omitted, RemoteClaw uses `agents.defaults.subagents.runTimeoutSeconds` when set; otherwise it falls back to `0` (no timeout).
 
 Tool params:
@@ -78,8 +78,8 @@ Tool params:
 - `task` (required)
 - `label?` (optional)
 - `agentId?` (optional; spawn under another agent id if allowed)
-- `model?` (optional; overrides the sub-agent model; invalid values are skipped and the sub-agent runs on the default model with a warning in the tool result)
-- `thinking?` (optional; overrides thinking level for the sub-agent run)
+- `model?` (optional; passed through to the CLI agent subprocess)
+- `thinking?` (optional; passed through to the CLI agent subprocess)
 - `runTimeoutSeconds?` (defaults to `agents.defaults.subagents.runTimeoutSeconds` when set, otherwise `0`; when set, the sub-agent run is aborted after N seconds)
 - `thread?` (default `false`; when `true`, requests channel thread binding for this sub-agent session)
 - `mode?` (`run|session`)
@@ -220,7 +220,7 @@ Announce payloads include a stats line at the end (even when wrapped):
 
 - Runtime (e.g., `runtime 5m12s`)
 - Token usage (input/output/total)
-- Estimated cost when model pricing is configured (`models.providers.*.models[].cost`)
+- Estimated cost (when available from the CLI agent)
 - `sessionKey`, `sessionId`, and transcript path (so the main agent can fetch history via `sessions_history` or inspect the file on disk)
 
 ## Tool Policy (sub-agent tools)

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -46,7 +46,6 @@ If no `provider` is explicitly set, RemoteClaw auto-detects which provider to us
 1. **Brave** — `BRAVE_API_KEY` env var or `search.apiKey` config
 2. **Gemini** — `GEMINI_API_KEY` env var or `search.gemini.apiKey` config
 3. **Perplexity** — `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` env var or `search.perplexity.apiKey` config
-4. **Grok** — `XAI_API_KEY` env var or `search.grok.apiKey` config
 
 If no keys are found, it falls back to Brave (you'll get a missing-key error prompting you to configure one).
 


### PR DESCRIPTION
## Summary

Closes #393.

- Remove OpenClaw provider ecosystem references (`byProvider`, model provider names, auth profiles) from 11 docs files across `docs/tools/` and `docs/plugins/`
- Replace "embedded runtime" / "embedded agent runtime" language with CLI agent subprocess terminology
- Reframe `model` and `thinking` flags as CLI agent passthrough (not RemoteClaw-managed model selection)
- Remove dead config keys from examples (`allowModels`, `defaultProvider`, `defaultAuthProfileId`, `allowedModels`, `models.providers.*.models[].cost`)
- Remove skills marketplace heritage (plugin skills registration, manifest `providers`/`skills` fields)
- Remove stale Grok auto-detection entry from web search docs
- Remove `responseModel` from voice-call inbound config (model selection is CLI agent's responsibility)

**Note:** `docs/tools/thinking.md` was already deleted in #383. `docs/tools/browser-login.md` and `docs/tools/chrome-extension.md` were listed in the issue but had no finding descriptions — no heritage content was identified in these files.

### Exit criteria verification

```
grep -ri 'clawhub\|skills.marketplace\|install.gating\|skill.readiness' docs/tools/ docs/plugins/ → CLEAN
grep -ri 'in.process.*tool\|tool.execution.*engine\|pi.tool' docs/tools/ docs/plugins/ → CLEAN
```

## Test plan

- [ ] CI passes (docs-only change, no code impact)
- [ ] Exit criteria grep patterns return CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)