### PR TITLE
docs: clean scattered heritage from channels, nodes, platforms and misc docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,13 +173,13 @@ Run `remoteclaw doctor` to surface risky/misconfigured DM policies.
 - [Canvas](https://docs.remoteclaw.org/platforms/mac/canvas): [A2UI](https://docs.remoteclaw.org/platforms/mac/canvas#canvas-a2ui) push/reset, eval, snapshot.
 - [Nodes](https://docs.remoteclaw.org/nodes): camera snap/clip, screen record, [location.get](https://docs.remoteclaw.org/nodes/location-command), notifications.
 - [Cron + wakeups](https://docs.remoteclaw.org/automation/cron-jobs); [webhooks](https://docs.remoteclaw.org/automation/webhook); [Gmail Pub/Sub](https://docs.remoteclaw.org/automation/gmail-pubsub).
-- [Skills platform](https://docs.remoteclaw.org/tools/skills): bundled, managed, and workspace skills with install gating + UI.
+- [Skills platform](https://docs.remoteclaw.org/tools/skills): bundled and workspace skills.
 
 ### Runtime + safety
 
 - [Channel routing](https://docs.remoteclaw.org/channels/channel-routing), [retry policy](https://docs.remoteclaw.org/concepts/retry), and [streaming/chunking](https://docs.remoteclaw.org/concepts/streaming).
 - [Presence](https://docs.remoteclaw.org/concepts/presence), [typing indicators](https://docs.remoteclaw.org/concepts/typing-indicators), and [usage tracking](https://docs.remoteclaw.org/concepts/usage-tracking).
-- [Models](https://docs.remoteclaw.org/concepts/models), [model failover](https://docs.remoteclaw.org/concepts/model-failover), and [session pruning](https://docs.remoteclaw.org/concepts/session-pruning).
+- [Session pruning](https://docs.remoteclaw.org/concepts/session-pruning).
 - [Security](https://docs.remoteclaw.org/gateway/security) and [troubleshooting](https://docs.remoteclaw.org/channels/troubleshooting).
 
 ### Ops + packaging
@@ -255,7 +255,7 @@ The macOS app can run in **node mode** and advertises its capabilities + permiss
 Elevated bash (host permissions) is separate from macOS TCC:
 
 - Use `/elevated on|off` to toggle per‑session elevated access when enabled + allowlisted.
-- Gateway persists the per‑session toggle via `sessions.patch` (WS method) alongside `verboseLevel`, `model`, `sendPolicy`, and `groupActivation`.
+- Gateway persists the per‑session toggle via `sessions.patch` (WS method) alongside `verboseLevel`, `sendPolicy`, and `groupActivation`.
 
 Details: [Nodes](https://docs.remoteclaw.org/nodes) · [macOS app](https://docs.remoteclaw.org/platforms/macos) · [Gateway protocol](https://docs.remoteclaw.org/concepts/architecture)
 
@@ -275,7 +275,7 @@ Send these in WhatsApp/Telegram/Slack/Google Chat/Microsoft Teams/WebChat (group
 - `/status` — compact session status (model + tokens, cost when available)
 - `/new` or `/reset` — reset the session
 - `/compact` — compact session context (summary)
-- `/think <level>` — off|minimal|low|medium|high|xhigh (GPT-5.2 + Codex models only)
+- `/think <level>` — off|minimal|low|medium|high|xhigh (runtimes that support extended thinking)
 - `/verbose on|off`
 - `/usage off|tokens|full` — per-response usage footer
 - `/restart` — restart the gateway (owner-only in groups)
@@ -318,12 +318,14 @@ Runbook: [iOS connect](https://docs.remoteclaw.org/platforms/ios).
 
 ## Configuration
 
-Minimal `~/.remoteclaw/remoteclaw.json` (model + defaults):
+Minimal `~/.remoteclaw/remoteclaw.json`:
 
 ```json5
 {
-  agent: {
-    model: "anthropic/claude-opus-4-6",
+  channels: {
+    telegram: {
+      botToken: "YOUR_BOT_TOKEN",
+    },
   },
 }
 ```

--- a/VISION.md
+++ b/VISION.md
@@ -24,7 +24,7 @@ Priority:
 
 Next priorities:
 
-- Supporting all major model providers
+- Supporting more agent CLI runtimes and messaging channels
 - Improving support for major messaging channels (and adding a few high-demand ones)
 - Performance and test infrastructure
 - Better computer-use and agent harness capabilities
@@ -93,7 +93,7 @@ It is widely known, fast to iterate in, and easy to read, modify, and extend.
 ## What We Will Not Merge (For Now)
 
 - Full-doc translation sets for all docs (deferred; we plan AI-generated translations later)
-- Commercial service integrations that do not clearly fit the model-provider category
+- Commercial service integrations without a clear channel or tool use case
 - Wrapper channels around already supported channels without a clear capability or security gap
 - Agent-hierarchy frameworks (manager-of-managers / nested planner trees) as a default architecture
 - Heavy orchestration layers that duplicate existing agent and tool infrastructure

--- a/docs/brave-search.md
+++ b/docs/brave-search.md
@@ -8,15 +8,17 @@ title: "Brave Search"
 
 # Brave Search API
 
-RemoteClaw uses Brave Search as the default provider for `web_search`.
+Brave Search can be configured as the web search provider when using RemoteClaw's built-in `web_search` tool.
 
 ## Get an API key
 
 1. Create a Brave Search API account at [https://brave.com/search/api/](https://brave.com/search/api/)
 2. In the dashboard, choose the **Data for Search** plan and generate an API key.
-3. Store the key in config (recommended) or set `BRAVE_API_KEY` in the Gateway environment.
+3. Set `BRAVE_API_KEY` in the Gateway environment, or configure it in `tools.web.search`.
 
 ## Config example
+
+> **Note:** The `tools.web.search` configuration applies only when RemoteClaw's built-in web search tool is in use. If your CLI agent provides its own web search capability (e.g., via MCP), configure the API key in the agent's own configuration instead.
 
 ```json5
 {

--- a/docs/channels/bluebubbles.md
+++ b/docs/channels/bluebubbles.md
@@ -188,7 +188,7 @@ Per-group configuration:
 
 ### Command gating
 
-- Control commands (e.g., `/config`, `/model`) require authorization.
+- Control commands (e.g., `/config`) require authorization.
 - Uses `allowFrom` and `groupAllowFrom` to determine command authorization.
 - Authorized senders can run control commands even without mentioning in groups.
 
@@ -289,7 +289,7 @@ Control whether responses are sent as a single message or streamed in blocks:
 
 Full configuration: [Configuration](/gateway/configuration)
 
-Provider options:
+Channel options:
 
 - `channels.bluebubbles.enabled`: Enable/disable the channel.
 - `channels.bluebubbles.serverUrl`: BlueBubbles REST API base URL.

--- a/docs/channels/broadcast-groups.md
+++ b/docs/channels/broadcast-groups.md
@@ -180,8 +180,8 @@ This allows each agent to have:
 
 - Different personalities
 - Different tool access (e.g., read-only vs. read-write)
-- Different models (e.g., opus vs. sonnet)
-- Different skills installed
+- Different CLI configurations (e.g., different system prompts, tool sets)
+- Different MCP tools or capabilities
 
 ### Example: Isolated Sessions
 
@@ -259,7 +259,7 @@ With many agents, consider:
 
 - Using `"strategy": "parallel"` (default) for speed
 - Limiting broadcast groups to 5-10 agents
-- Using faster models for simpler agents
+- Using lighter CLI settings for simpler agents
 
 ### 5. Handle Failures Gracefully
 
@@ -331,7 +331,7 @@ tail -f ~/.remoteclaw/logs/gateway.log | grep broadcast
 **If slow with many agents:**
 
 - Reduce number of agents per group
-- Use lighter models (sonnet instead of opus)
+- Use lighter CLI configurations
 - Check sandbox startup time
 
 ## Examples

--- a/docs/channels/channel-routing.md
+++ b/docs/channels/channel-routing.md
@@ -76,7 +76,7 @@ See: [Broadcast Groups](/channels/broadcast-groups).
 
 ## Config overview
 
-- `agents.list`: named agent definitions (workspace, model, etc.).
+- `agents.list`: named agent definitions (workspace, runtime, etc.).
 - `bindings`: map inbound channels/accounts/peers to agents.
 
 Example:

--- a/docs/channels/discord.mdx
+++ b/docs/channels/discord.mdx
@@ -287,7 +287,7 @@ By default, components are single use. Set `components.reusable=true` to allow b
 
 To restrict who can click a button, set `allowedUsers` on that button (Discord user IDs, tags, or `*`). When configured, unmatched users receive an ephemeral denial.
 
-The `/model` and `/models` slash commands open an interactive model picker with provider and model dropdowns plus a Submit step. The picker reply is ephemeral and only the invoking user can use it.
+The `/model` command forwards a model hint to the CLI agent subprocess. The reply is ephemeral and only the invoking user can see it.
 
 File attachments:
 

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -370,7 +370,6 @@ remoteclaw pairing list feishu
 | --------- | ----------------- |
 | `/status` | Show bot status   |
 | `/reset`  | Reset the session |
-| `/model`  | Show/switch model |
 
 > Note: Feishu does not support native command menus yet, so commands must be sent as text.
 

--- a/docs/channels/group-messages.md
+++ b/docs/channels/group-messages.md
@@ -17,7 +17,7 @@ Note: `agents.list[].groupChat.mentionPatterns` is now used by Telegram/Discord/
 - Group policy: `channels.whatsapp.groupPolicy` controls whether group messages are accepted (`open|disabled|allowlist`). `allowlist` uses `channels.whatsapp.groupAllowFrom` (fallback: explicit `channels.whatsapp.allowFrom`). Default is `allowlist` (blocked until you add senders).
 - Per-group sessions: session keys look like `agent:<agentId>:whatsapp:group:<jid>` so commands such as `/verbose on` or `/think high` (sent as standalone messages) are scoped to that group; personal DM state is untouched. Heartbeats are skipped for group threads.
 - Context injection: **pending-only** group messages (default 50) that _did not_ trigger a run are prefixed under `[Chat messages since your last reply - for context]`, with the triggering line under `[Current message - respond to this]`. Messages already in the session are not re-injected.
-- Sender surfacing: every group batch now ends with `[from: Sender Name (+E164)]` so Pi knows who is speaking.
+- Sender surfacing: every group batch now ends with `[from: Sender Name (+E164)]` so the agent knows who is speaking.
 - Ephemeral/view-once: we unwrap those before extracting text/mentions, so pings inside them still trigger.
 - Group system prompt: on the first turn of a group session (and whenever `/activation` changes the mode) we inject a short blurb into the system prompt like `You are replying inside the WhatsApp group "<subject>". Group members: Alice (+44...), Bob (+43...), … Activation: trigger-only … Address the specific sender noted in the message context.` If metadata isn’t available we still tell the agent it’s a group chat.
 

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -58,66 +58,29 @@ If you want...
 
 Yes — this works well if your “personal” traffic is **DMs** and your “public” traffic is **groups**.
 
-Why: in single-agent mode, DMs typically land in the **main** session key (`agent:main:main`), while groups always use **non-main** session keys (`agent:main:<channel>:group:<id>`). If you enable sandboxing with `mode: "non-main"`, those group sessions run in Docker while your main DM session stays on-host.
+Why: in single-agent mode, DMs typically land in the **main** session key (`agent:main:main`), while groups always use **non-main** session keys (`agent:main:<channel>:group:<id>`). Per-session tool restrictions can be configured to limit what group sessions can do.
 
 This gives you one agent “brain” (shared workspace + memory), but two execution postures:
 
 - **DMs**: full tools (host)
-- **Groups**: sandbox + restricted tools (Docker)
+- **Groups**: restricted tools
+
+Example (DMs on host, groups with restricted tools):
+
+```json5
+{
+  tools: {
+    profiles: {
+      restricted: {
+        allow: [“group:messaging”, “group:sessions”],
+        deny: [“group:runtime”, “group:fs”, “group:ui”, “nodes”, “cron”, “gateway”],
+      },
+    },
+  },
+}
+```
 
 > If you need truly separate workspaces/personas (“personal” and “public” must never mix), use a second agent + bindings. See [Multi-Agent Routing](/concepts/multi-agent).
-
-Example (DMs on host, groups sandboxed + messaging-only tools):
-
-```json5
-{
-  agents: {
-    defaults: {
-      sandbox: {
-        mode: "non-main", // groups/channels are non-main -> sandboxed
-        scope: "session", // strongest isolation (one container per group/channel)
-        workspaceAccess: "none",
-      },
-    },
-  },
-  tools: {
-    sandbox: {
-      tools: {
-        // If allow is non-empty, everything else is blocked (deny still wins).
-        allow: ["group:messaging", "group:sessions"],
-        deny: ["group:runtime", "group:fs", "group:ui", "nodes", "cron", "gateway"],
-      },
-    },
-  },
-}
-```
-
-Want “groups can only see folder X” instead of “no host access”? Keep `workspaceAccess: "none"` and mount only allowlisted paths into the sandbox:
-
-```json5
-{
-  agents: {
-    defaults: {
-      sandbox: {
-        mode: "non-main",
-        scope: "session",
-        workspaceAccess: "none",
-        docker: {
-          binds: [
-            // hostPath:containerPath:mode
-            "/home/user/FriendsShared:/data:ro",
-          ],
-        },
-      },
-    },
-  },
-}
-```
-
-Related:
-
-- Configuration keys and defaults: [Gateway configuration](/gateway/configuration#agentsdefaultssandbox)
-- Debugging why a tool is blocked: [Exec approvals](/tools/exec-approvals)
 
 ## Display labels
 

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -45,4 +45,3 @@ Text is supported everywhere; media and reactions vary by channel.
 - DM pairing and allowlists are enforced for safety; see [Security](/gateway/security).
 - Telegram internals: [grammY notes](/channels/grammy).
 - Troubleshooting: [Channel troubleshooting](/channels/troubleshooting).
-- Model providers are documented separately; see [Model Providers](/providers/models).

--- a/docs/channels/telegram.mdx
+++ b/docs/channels/telegram.mdx
@@ -451,7 +451,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - message sends omit `message_thread_id` (Telegram rejects `sendMessage(...thread_id=1)`)
     - typing actions still include `message_thread_id`
 
-    Topic inheritance: topic entries inherit group settings unless overridden (`requireMention`, `allowFrom`, `skills`, `systemPrompt`, `enabled`, `groupPolicy`).
+    Topic inheritance: topic entries inherit group settings unless overridden (`requireMention`, `allowFrom`, `tools`, `systemPrompt`, `enabled`, `groupPolicy`).
 
     Template context includes:
 
@@ -758,7 +758,7 @@ Primary reference:
 - `channels.telegram.groups`: per-group defaults + allowlist (use `"*"` for global defaults).
   - `channels.telegram.groups.<id>.groupPolicy`: per-group override for groupPolicy (`open | allowlist | disabled`).
   - `channels.telegram.groups.<id>.requireMention`: mention gating default.
-  - `channels.telegram.groups.<id>.skills`: skill filter (omit = all skills, empty = none).
+  - `channels.telegram.groups.<id>.tools`: tool filter (omit = all tools, empty = none).
   - `channels.telegram.groups.<id>.allowFrom`: per-group sender allowlist override.
   - `channels.telegram.groups.<id>.systemPrompt`: extra system prompt for the group.
   - `channels.telegram.groups.<id>.enabled`: disable the group when `false`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,7 +279,7 @@ Every top-level key in `RemoteClawSchema` (from `src/config/zod-schema.ts`):
 | `update`      | object | Auto-update channel (`stable`/`beta`/`dev`) and check settings                                     |
 | `browser`     | object | Chrome DevTools Protocol automation, SSRF policy, browser profiles                                 |
 | `ui`          | object | UI customization: theme color, assistant name and avatar                                           |
-| `auth`        | object | Auth profiles (API key/OAuth/token), provider priority, billing cooldowns                          |
+| `auth`        | object | Auth profiles (API key/OAuth/token) for gateway access control                                     |
 | `nodeHost`    | object | Node host configuration (browser proxy)                                                            |
 | `agents`      | object | Agent defaults and agent list (see [Agent Configuration](#agent-configuration))                    |
 | `tools`       | object | Tool access profiles, allow/deny lists (see [MCP Server Configuration](#mcp-server-configuration)) |
@@ -332,16 +332,15 @@ Configure agent defaults and define multiple agents:
 
 Key agent default options:
 
-| Key                               | Type          | Description                                                 |
-| --------------------------------- | ------------- | ----------------------------------------------------------- |
-| `agents.defaults.runtime`         | string        | Default agent CLI (`claude`, `gemini`, `codex`, `opencode`) |
-| `agents.defaults.model`           | string/object | Default model                                               |
-| `agents.defaults.workspace`       | string        | Workspace root directory                                    |
-| `agents.defaults.contextTokens`   | number        | Context window size                                         |
-| `agents.defaults.timeoutSeconds`  | number        | Agent response timeout                                      |
-| `agents.defaults.maxConcurrent`   | number        | Max concurrent sessions                                     |
-| `agents.defaults.typingMode`      | string        | Typing indicator: `never`, `instant`, `thinking`, `message` |
-| `agents.defaults.humanDelay.mode` | string        | Simulated delay: `off`, `natural`, `custom`                 |
+| Key                               | Type   | Description                                                 |
+| --------------------------------- | ------ | ----------------------------------------------------------- |
+| `agents.defaults.runtime`         | string | Default agent CLI (`claude`, `gemini`, `codex`, `opencode`) |
+| `agents.defaults.workspace`       | string | Workspace root directory                                    |
+| `agents.defaults.contextTokens`   | number | Context window size                                         |
+| `agents.defaults.timeoutSeconds`  | number | Agent response timeout                                      |
+| `agents.defaults.maxConcurrent`   | number | Max concurrent sessions                                     |
+| `agents.defaults.typingMode`      | string | Typing indicator: `never`, `instant`, `thinking`, `message` |
+| `agents.defaults.humanDelay.mode` | string | Simulated delay: `off`, `natural`, `custom`                 |
 
 ## Gateway
 
@@ -418,8 +417,7 @@ centralized skill marketplace. Any `skills` configuration is ignored.
 **Status:** Removed.
 
 The model catalog has been removed. Each agent CLI manages its own model
-selection. Use `agents.defaults.model` or per-agent `model` overrides instead
-of the top-level `models` section. Any `models` configuration is ignored.
+selection. Any `models` configuration is ignored.
 
 ### `plugins` (partially deprecated)
 

--- a/docs/date-time.md
+++ b/docs/date-time.md
@@ -81,7 +81,7 @@ Queued system events inserted into agent context are prefixed with a timestamp u
 same timezone selection as message envelopes (default: host-local).
 
 ```
-System: [2026-01-12 12:19:17 PST] Model switched.
+System: [2026-01-12 12:19:17 PST] Session started.
 ```
 
 ### Configure user timezone + format

--- a/docs/experiments/proposals/model-config.md
+++ b/docs/experiments/proposals/model-config.md
@@ -7,12 +7,15 @@ title: "Model Config Exploration"
 
 # Model Config (Exploration)
 
-This document captures **ideas** for future model configuration. It is not a
-shipping spec. For current behavior, see:
+This document captures **ideas** from the OpenClaw era for model configuration.
+These features were removed in RemoteClaw's middleware rewrite — model selection
+is now the CLI agent's responsibility, not RemoteClaw's.
 
-- [Model failover](/concepts/model-failover)
+This file is kept for historical reference only.
 
 ## Motivation
+
+> **Note:** These requirements described OpenClaw's in-process model management, which was removed.
 
 Operators want:
 
@@ -20,12 +23,16 @@ Operators want:
 - Simple `/model` selection with predictable fallbacks.
 - Clear separation between text models and image-capable models.
 
+> **Note:** These directions proposed re-introducing in-process model management, which contradicts RemoteClaw's middleware architecture.
+
 ## Possible direction (high level)
 
 - Keep model selection simple: `provider/model` with optional aliases.
 - Let providers have multiple auth profiles, with an explicit order.
 - Use a global fallback list so all sessions fail over consistently.
 - Only override image routing when explicitly configured.
+
+> **Note:** These questions assume the in-process model provider ecosystem, which was removed.
 
 ## Open questions
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -165,7 +165,7 @@ diagnostics + the exporter plugin are enabled.
 
 Model usage:
 
-- `model.usage`: tokens, cost, duration, context, provider/model/channel, session ids.
+- `model.usage`: tokens, duration, context, runtime/model/channel, session ids.
 
 Message flow:
 
@@ -270,13 +270,13 @@ Notes:
 Model usage:
 
 - `remoteclaw.tokens` (counter, attrs: `remoteclaw.token`, `remoteclaw.channel`,
-  `remoteclaw.provider`, `remoteclaw.model`)
-- `remoteclaw.cost.usd` (counter, attrs: `remoteclaw.channel`, `remoteclaw.provider`,
+  `remoteclaw.runtime`, `remoteclaw.model`)
+- `remoteclaw.cost.usd` (counter, attrs: `remoteclaw.channel`, `remoteclaw.runtime`,
   `remoteclaw.model`)
 - `remoteclaw.run.duration_ms` (histogram, attrs: `remoteclaw.channel`,
-  `remoteclaw.provider`, `remoteclaw.model`)
+  `remoteclaw.runtime`, `remoteclaw.model`)
 - `remoteclaw.context.tokens` (histogram, attrs: `remoteclaw.context`,
-  `remoteclaw.channel`, `remoteclaw.provider`, `remoteclaw.model`)
+  `remoteclaw.channel`, `remoteclaw.runtime`, `remoteclaw.model`)
 
 Message flow:
 
@@ -308,7 +308,7 @@ Queues + sessions:
 ### Exported spans (names + key attributes)
 
 - `remoteclaw.model.usage`
-  - `remoteclaw.channel`, `remoteclaw.provider`, `remoteclaw.model`
+  - `remoteclaw.channel`, `remoteclaw.runtime`, `remoteclaw.model`
   - `remoteclaw.sessionKey`, `remoteclaw.sessionId`
   - `remoteclaw.tokens.*` (input/output/cache_read/cache_write/total)
 - `remoteclaw.webhook.processed`

--- a/docs/nodes/audio.md
+++ b/docs/nodes/audio.md
@@ -111,7 +111,7 @@ Note: Binary detection is best-effort across macOS/Linux/Windows; ensure the CLI
 
 ## Notes & limits
 
-- Provider auth follows the standard model auth order (auth profiles, env vars, `models.providers.*.apiKey`).
+- Provider auth follows environment variables (e.g. `OPENAI_API_KEY`, `DEEPGRAM_API_KEY`).
 - Deepgram picks up `DEEPGRAM_API_KEY` when `provider: "deepgram"` is used.
 - Deepgram setup details: [Deepgram (audio transcription)](/providers/deepgram).
 - Mistral setup details: [Mistral](/providers/mistral).

--- a/docs/nodes/images.md
+++ b/docs/nodes/images.md
@@ -39,12 +39,11 @@ The WhatsApp channel runs via **Baileys Web**. This document captures the curren
 - When media is present, the web sender resolves local paths or URLs using the same pipeline as `remoteclaw message send`.
 - Multiple media entries are sent sequentially if provided.
 
-## Inbound Media to Commands (Pi)
+## Inbound Media to Commands
 
 - When inbound web messages include media, RemoteClaw downloads to a temp file and exposes templating variables:
   - `{{MediaUrl}}` pseudo-URL for the inbound media.
   - `{{MediaPath}}` local temp path written before running the command.
-- When a per-session Docker sandbox is enabled, inbound media is copied into the sandbox workspace and `MediaPath`/`MediaUrl` are rewritten to a relative path like `media/inbound/<filename>`.
 - Media understanding (if configured via `tools.media.*` or shared `tools.media.models`) runs before templating and can insert `[Image]`, `[Audio]`, and `[Video]` blocks into `Body`.
   - Audio sets `{{Transcript}}` and uses the transcript for command parsing so slash commands still work.
   - Video and image descriptions preserve any caption text for command parsing.

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -45,12 +45,12 @@ Notes:
 ## Remote node host (system.run)
 
 Use a **node host** when your Gateway runs on one machine and you want commands
-to execute on another. The model still talks to the **gateway**; the gateway
+to execute on another. The CLI agent subprocess still communicates with the **gateway**; the gateway
 forwards `exec` calls to the **node host** when `host=node` is selected.
 
 ### What runs where
 
-- **Gateway host**: receives messages, runs the model, routes tool calls.
+- **Gateway host**: receives messages, spawns the CLI agent subprocess, routes tool calls.
 - **Node host**: executes `system.run`/`system.which` on the node machine.
 - **Approvals**: enforced on the node host via `~/.remoteclaw/exec-approvals.json`.
 

--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -72,21 +72,6 @@ Each `models[]` entry can be **provider** or **CLI**:
 
 ```json5
 {
-  type: "provider", // default if omitted
-  provider: "openai",
-  model: "gpt-5.2",
-  prompt: "Describe the image in <= 500 chars.",
-  maxChars: 500,
-  maxBytes: 10485760,
-  timeoutSeconds: 60,
-  capabilities: ["image"], // optional, used for multi‑modal entries
-  profile: "vision-profile",
-  preferredProfile: "vision-fallback",
-}
-```
-
-```json5
-{
   type: "cli",
   command: "gemini",
   args: [
@@ -125,8 +110,8 @@ Rules:
 - If media exceeds `maxBytes`, that model is skipped and the **next model is tried**.
 - If the model returns more than `maxChars`, output is trimmed.
 - `prompt` defaults to simple “Describe the {media}.” plus the `maxChars` guidance (image/video only).
-- If `<capability>.enabled: true` but no models are configured, RemoteClaw tries the
-  **active reply model** when its provider supports the capability.
+- If `<capability>.enabled: true` but no models are configured, RemoteClaw auto-detects
+  available providers and CLIs (see auto-detect section below).
 
 ### Auto-detect media understanding (default)
 
@@ -175,11 +160,11 @@ If you omit `capabilities`, the entry is eligible for the list it appears in.
 
 ## Provider support matrix (RemoteClaw integrations)
 
-| Capability | Provider integration                                                 | Notes                                                     |
-| ---------- | -------------------------------------------------------------------- | --------------------------------------------------------- |
-| Image      | OpenAI / Anthropic / Google / others via RemoteClaw's model registry | Any image-capable model in the registry works.            |
-| Audio      | OpenAI, Groq, Deepgram, Google, Mistral                              | Provider transcription (Whisper/Deepgram/Gemini/Voxtral). |
-| Video      | Google (Gemini API)                                                  | Provider video understanding.                             |
+| Capability | Provider integration                    | Notes                                                     |
+| ---------- | --------------------------------------- | --------------------------------------------------------- |
+| Image      | OpenAI / Anthropic / Google / MiniMax   | Any image-capable provider integration works.             |
+| Audio      | OpenAI, Groq, Deepgram, Google, Mistral | Provider transcription (Whisper/Deepgram/Gemini/Voxtral). |
+| Video      | Google (Gemini API)                     | Provider video understanding.                             |
 
 ## Recommended providers
 

--- a/docs/platforms/digitalocean.md
+++ b/docs/platforms/digitalocean.md
@@ -85,7 +85,6 @@ remoteclaw onboard --install-daemon
 
 The wizard will walk you through:
 
-- Model auth (API keys or OAuth)
 - Channel setup (Telegram, WhatsApp, Discord, etc.)
 - Gateway token (auto-generated)
 - Daemon installation (systemd)
@@ -178,12 +177,12 @@ swapon /swapfile
 echo '/swapfile none swap sw 0 0' >> /etc/fstab
 ```
 
-### Use a lighter model
+### Reduce resource usage
 
 If you're hitting OOMs, consider:
 
-- Using API-based models (Claude, GPT) instead of local models
-- Setting `agents.defaults.model.primary` to a smaller model
+- Reducing the number of concurrent sessions
+- Choosing a lighter CLI agent runtime
 
 ### Monitor memory
 

--- a/docs/platforms/mac/menu-bar.md
+++ b/docs/platforms/mac/menu-bar.md
@@ -12,7 +12,7 @@ title: "Menu Bar"
 - We surface the current agent work state in the menu bar icon and in the first status row of the menu.
 - Health status is hidden while work is active; it returns when all sessions are idle.
 - The “Nodes” block in the menu lists **devices** only (paired nodes via `node.list`), not client/presence entries.
-- A “Usage” section appears under Context when provider usage snapshots are available.
+- A “Usage” section appears under Context when agent usage snapshots are available.
 
 ## State model
 

--- a/docs/platforms/raspberry-pi.md
+++ b/docs/platforms/raspberry-pi.md
@@ -136,9 +136,8 @@ remoteclaw onboard --install-daemon
 Follow the wizard:
 
 1. **Gateway mode:** Local
-2. **Auth:** API keys recommended (OAuth can be finicky on headless Pi)
-3. **Channels:** Telegram is easiest to start with
-4. **Daemon:** Yes (systemd)
+2. **Channels:** Telegram is easiest to start with
+3. **Daemon:** Yes (systemd)
 
 ## 8) Verify Installation
 
@@ -231,7 +230,7 @@ Most RemoteClaw features work on ARM64, but some external binaries may need ARM 
 | gog (Gmail CLI)    | ⚠️           | Check for ARM release               |
 | Chromium (browser) | ✅           | `sudo apt install chromium-browser` |
 
-If a skill fails, check if its binary has an ARM build. Many Go/Rust tools do; some don't.
+If a tool fails, check if its binary has an ARM build. Many Go/Rust tools do; some don't.
 
 ### 32-bit vs 64-bit
 
@@ -244,24 +243,19 @@ uname -m
 
 ---
 
-## Recommended Model Setup
+## Recommended Setup
 
-Since the Pi is just the Gateway (models run in the cloud), use API-based models:
+Since the Pi is just the Gateway (the CLI agent handles model interaction in the cloud), configure your CLI agent's credentials:
 
-```json
-{
-  "agents": {
-    "defaults": {
-      "model": {
-        "primary": "anthropic/claude-sonnet-4-20250514",
-        "fallbacks": ["openai/gpt-4o-mini"]
-      }
-    }
-  }
-}
+```bash
+# For Claude CLI
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# For Gemini CLI
+export GOOGLE_API_KEY=...
 ```
 
-**Don't try to run local LLMs on a Pi** — even small models are too slow. Let Claude/GPT do the heavy lifting.
+**Don't try to run local LLMs on a Pi** — even small models are too slow. Use a cloud-backed CLI agent runtime.
 
 ---
 
@@ -314,7 +308,7 @@ sudo systemctl restart remoteclaw
 
 ### ARM Binary Issues
 
-If a skill fails with "exec format error":
+If a tool fails with "exec format error":
 
 1. Check if the binary has an ARM64 build
 2. Try building from source

--- a/docs/prose.md
+++ b/docs/prose.md
@@ -9,7 +9,7 @@ title: "OpenProse"
 
 # OpenProse
 
-OpenProse is a portable, markdown-first workflow format for orchestrating AI sessions. In RemoteClaw it ships as a plugin that installs an OpenProse skill pack plus a `/prose` slash command. Programs live in `.prose` files and can spawn multiple sub-agents with explicit control flow.
+OpenProse is a portable, markdown-first workflow format for orchestrating AI sessions. In RemoteClaw it ships as a plugin that installs an OpenProse command set plus a `/prose` slash command. Programs live in `.prose` files and can spawn multiple sub-agents with explicit control flow.
 
 Official site: [https://www.prose.md](https://www.prose.md)
 
@@ -57,11 +57,11 @@ Common commands:
 input topic: "What should we research?"
 
 agent researcher:
-  model: sonnet
+  runtime: claude
   prompt: "You research thoroughly and cite sources."
 
 agent writer:
-  model: opus
+  runtime: claude
   prompt: "You write a concise summary."
 
 parallel:

--- a/docs/refactor/clawnet.md
+++ b/docs/refactor/clawnet.md
@@ -46,7 +46,7 @@ Single, rigorous document for:
 
 ### 1) Gateway WebSocket (control plane)
 
-- Full API surface: config, channels, models, sessions, agent runs, logs, nodes, etc.
+- Full API surface: config, channels, sessions, agent runs, logs, nodes, etc.
 - Default bind: loopback. Remote access via SSH/Tailscale.
 - Auth: token/password via `connect`.
 - No TLS pinning (relies on loopback/tunnel).
@@ -119,7 +119,7 @@ Single WS protocol with role + scope.
 - Optional **scope** for operator:
   - `operator.read` (status + viewing)
   - `operator.write` (agent run, sends)
-  - `operator.admin` (config, channels, models)
+  - `operator.admin` (config, channels)
 
 ### Role behaviors
 

--- a/docs/refactor/exec-host.md
+++ b/docs/refactor/exec-host.md
@@ -41,7 +41,7 @@ title: "Exec Host Refactor"
 
 ### Host
 
-- `sandbox`: Docker exec (current behavior).
+- `sandbox`: Docker exec (removed; historical reference).
 - `gateway`: exec on gateway host.
 - `node`: exec on node runner via Bridge (`system.run`).
 
@@ -233,7 +233,7 @@ Option B:
 
 ### Sandbox host
 
-- Existing `exec` behavior (Docker or host when unsandboxed).
+- Existing `exec` behavior (host exec).
 - PTY supported in non-sandbox mode only.
 
 ### Gateway host

--- a/docs/start/hubs.md
+++ b/docs/start/hubs.md
@@ -60,12 +60,10 @@ Use these hubs to discover every page, including deep dives and reference docs t
 - [Channel routing](/channels/channel-routing)
 - [Groups](/channels/groups)
 - [Group messages](/channels/group-messages)
-- [Model failover](/concepts/model-failover)
 
 ## Providers + ingress
 
 - [Chat channels hub](/channels)
-- [Model providers hub](/providers/models)
 - [WhatsApp](/channels/whatsapp)
 - [Telegram](/channels/telegram)
 - [Telegram (grammY notes)](/channels/grammy)
@@ -168,7 +166,7 @@ Use these hubs to discover every page, including deep dives and reference docs t
 ## Experiments (exploratory)
 
 - [Onboarding config protocol](/experiments/onboarding-config-protocol)
-- [Model config exploration](/experiments/proposals/model-config)
+- [Model config (historical)](/experiments/proposals/model-config)
 
 ## Project
 

--- a/docs/start/remoteclaw.md
+++ b/docs/start/remoteclaw.md
@@ -8,13 +8,13 @@ title: "Personal Assistant Setup"
 
 # Building a personal assistant with RemoteClaw
 
-RemoteClaw is a WhatsApp + Telegram + Discord + iMessage gateway for **Pi** agents. Plugins add Mattermost. This guide is the "personal assistant" setup: one dedicated WhatsApp number that behaves like your always-on agent.
+RemoteClaw is a WhatsApp + Telegram + Discord + iMessage gateway for **CLI agents** (Claude, Gemini, Codex, OpenCode). Plugins add Mattermost. This guide is the "personal assistant" setup: one dedicated WhatsApp number that behaves like your always-on agent.
 
 ## ⚠️ Safety first
 
 You’re putting an agent in a position to:
 
-- run commands on your machine (depending on your Pi tool setup)
+- run commands on your machine (depending on the agent's configured tools/MCP servers)
 - read/write files in your workspace
 - send messages back out via WhatsApp/Telegram/Discord/Mattermost (plugin)
 
@@ -119,7 +119,6 @@ Example:
 {
   logging: { level: "info" },
   agent: {
-    model: "anthropic/claude-opus-4-6",
     workspace: "~/.remoteclaw/workspace",
     timeoutSeconds: 1800,
     // Start with 0; enable later.

--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -131,8 +131,7 @@ Use this when debugging auth or deciding what to back up:
 - **Discord bot token**: config/env (token file not yet supported)
 - **Slack tokens**: config/env (`channels.slack.*`)
 - **Pairing allowlists**: `~/.remoteclaw/credentials/<channel>-allowFrom.json`
-- **Model auth profiles**: `~/.remoteclaw/agents/<agentId>/agent/auth-profiles.json`
-- **Legacy OAuth import**: `~/.remoteclaw/credentials/oauth.json`
+- **Agent auth profiles**: `~/.remoteclaw/agents/<agentId>/agent/auth-profiles.json`
   More detail: [Security](/gateway/security#credential-storage-map).
 
 ## Updating (without wrecking your setup)

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -23,12 +23,12 @@ It works anywhere RemoteClaw can send audio; Telegram gets a round voice-note bu
 Edge TTS uses Microsoft Edge's online neural TTS service via the `node-edge-tts`
 library. It's a hosted service (not local), uses Microsoft’s endpoints, and does
 not require an API key. `node-edge-tts` exposes speech configuration options and
-output formats, but not all options are supported by the Edge service. citeturn2search0
+output formats, but not all options are supported by the Edge service.
 
 Because Edge TTS is a public web service without a published SLA or quota, treat it
 as best-effort. If you need guaranteed limits and support, use OpenAI or ElevenLabs.
 Microsoft's Speech REST API documents a 10‑minute audio limit per request; Edge TTS
-does not publish limits, so assume similar or lower limits. citeturn0search3
+does not publish limits, so assume similar or lower limits.
 
 ## Optional keys
 
@@ -41,7 +41,7 @@ Edge TTS does **not** require an API key. If no API keys are found, RemoteClaw d
 to Edge TTS (unless disabled via `messages.tts.edge.enabled=false`).
 
 If multiple providers are configured, the selected provider is used first and the others are fallback options.
-Auto-summary uses the configured `summaryModel` (or `agents.defaults.model.primary`),
+Auto-summary uses the configured `summaryModel`,
 so that provider must also be authenticated if you enable summaries.
 
 ## Service links
@@ -207,7 +207,7 @@ Then run:
 - `provider`: `"elevenlabs"`, `"openai"`, or `"edge"` (fallback is automatic).
 - If `provider` is **unset**, RemoteClaw prefers `openai` (if key), then `elevenlabs` (if key),
   otherwise `edge`.
-- `summaryModel`: optional cheap model for auto-summary; defaults to `agents.defaults.model.primary`.
+- `summaryModel`: optional cheap model for auto-summary (e.g. `openai/gpt-4.1-mini`).
   - Accepts `provider/model` or a configured model alias.
 - `modelOverrides`: allow the model to emit TTS directives (on by default).
   - `allowProvider` defaults to `false` (provider switching is opt-in).
@@ -317,10 +317,10 @@ These override `messages.tts.*` for that host.
   - 44.1kHz / 128kbps is the default balance for speech clarity.
 - **Edge TTS**: uses `edge.outputFormat` (default `audio-24khz-48kbitrate-mono-mp3`).
   - `node-edge-tts` accepts an `outputFormat`, but not all formats are available
-    from the Edge service. citeturn2search0
-  - Output format values follow Microsoft Speech output formats (including Ogg/WebM Opus). citeturn1search0
+    from the Edge service.
+  - Output format values follow Microsoft Speech output formats (including Ogg/WebM Opus).
   - Telegram `sendVoice` accepts OGG/MP3/M4A; use OpenAI/ElevenLabs if you need
-    guaranteed Opus voice notes. citeturn1search1
+    guaranteed Opus voice notes.
   - If the configured Edge output format fails, RemoteClaw retries with MP3.
 
 OpenAI/ElevenLabs formats are fixed; Telegram expects Opus for voice-note UX.
@@ -331,7 +331,7 @@ When enabled, RemoteClaw:
 
 - skips TTS if the reply already contains media or a `MEDIA:` directive.
 - skips very short replies (< 10 chars).
-- summarizes long replies when enabled using `agents.defaults.model.primary` (or `summaryModel`).
+- summarizes long replies when enabled using the configured `summaryModel`.
 - attaches the generated audio to the reply.
 
 If the reply exceeds `maxLength` and summary is off (or no API key for the
@@ -349,7 +349,7 @@ Reply -> TTS enabled?
                    no  -> TTS -> attach audio
                    yes -> summary enabled?
                             no  -> send text
-                            yes -> summarize (summaryModel or agents.defaults.model.primary)
+                            yes -> summarize (summaryModel)
                                       -> TTS -> attach audio
 ```
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -62,7 +62,7 @@ you revoke it with `remoteclaw devices revoke --device <id> --role <role>`. See
 
 ## What it can do (today)
 
-- Chat with the model via Gateway WS (`chat.history`, `chat.send`, `chat.abort`, `chat.inject`)
+- Chat with the agent via Gateway WS (`chat.history`, `chat.send`, `chat.abort`, `chat.inject`)
 - Stream tool calls + live tool output cards in Chat (agent events)
 - Channels: WhatsApp/Telegram/Discord/Slack + plugin channels (Mattermost, etc.) status + QR login + per-channel config (`channels.status`, `web.login.*`, `config.patch`)
 - Instances: presence list + refresh (`system-presence`)
@@ -74,7 +74,7 @@ you revoke it with `remoteclaw devices revoke --device <id> --role <role>`. See
 - Config: apply + restart with validation (`config.apply`) and wake the last active session
 - Config writes include a base-hash guard to prevent clobbering concurrent edits
 - Config schema + form rendering (`config.schema`, including plugin + channel schemas); Raw JSON editor remains available
-- Debug: status/health/models snapshots + event log + manual RPC calls (`status`, `health`, `models.list`)
+- Debug: status/health snapshots + event log + manual RPC calls (`status`, `health`)
 - Logs: live tail of gateway file logs with filter/export (`logs.tail`)
 - Update: run a package/git update + restart (`update.run`) with a restart report
 
@@ -85,7 +85,7 @@ Cron jobs panel notes:
 - Webhook mode uses `delivery.mode = "webhook"` with `delivery.to` set to a valid HTTP(S) webhook URL.
 - For main-session jobs, webhook and none delivery modes are available.
 - Advanced edit controls include delete-after-run, clear agent override, cron exact/stagger options,
-  agent model/thinking overrides, and best-effort delivery toggles.
+  agent thinking overrides, and best-effort delivery toggles.
 - Form validation is inline with field-level errors; invalid values disable the save button until fixed.
 - Set `cron.webhookToken` to send a dedicated bearer token, if omitted the webhook is sent without an auth header.
 - Deprecated fallback: stored legacy jobs with `notify: true` can still use `cron.webhook` until migrated.

--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -37,7 +37,7 @@ Use `--password` if your Gateway uses password auth.
 - Header: connection URL, current agent, current session.
 - Chat log: user messages, assistant replies, system notices, tool cards.
 - Status line: connection/run state (connecting, running, streaming, idle, error).
-- Footer: connection state + agent + session + model + think/verbose/reasoning + token counts + deliver.
+- Footer: connection state + agent + session + runtime + think/verbose/reasoning + token counts + deliver.
 - Input: text editor with autocomplete.
 
 ## Mental model: agents + sessions
@@ -62,7 +62,7 @@ Use `--password` if your Gateway uses password auth.
 
 ## Pickers + overlays
 
-- Model picker: list available models and set the session override.
+- Runtime picker: choose the CLI agent runtime.
 - Agent picker: choose a different agent.
 - Session picker: shows only sessions for the current agent.
 - Settings: toggle deliver, tool output expansion, and thinking visibility.
@@ -87,7 +87,7 @@ Core:
 - `/status`
 - `/agent <id>` (or `/agents`)
 - `/session <key>` (or `/sessions`)
-- `/model <provider/model>` (or `/models`)
+- `/model <hint>` (forward a model hint to the CLI agent)
 
 Session controls:
 
@@ -151,7 +151,7 @@ No output after sending a message:
 
 - Run `/status` in the TUI to confirm the Gateway is connected and idle/busy.
 - Check the Gateway logs: `remoteclaw logs --follow`.
-- Confirm the agent can run: `remoteclaw status` and `remoteclaw models status`.
+- Confirm the agent can run: `remoteclaw status`.
 - If you expect messages in a chat channel, enable delivery (`/deliver on` or `--deliver`).
 - `--history-limit <n>`: History entries to load (default 200)
 

--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -37,7 +37,7 @@ Status: the macOS/iOS SwiftUI chat UI talks directly to the Gateway WebSocket.
   tool as `core` or `plugin:<id>` (plus `optional` for optional plugin tools).
 - If `tools.catalog` is unavailable, the panel falls back to a built-in static list.
 - The panel edits profile and override config, but effective runtime access still follows policy
-  precedence (`allow`/`deny`, per-agent and provider/channel overrides).
+  precedence (`allow`/`deny`, per-agent and per-channel overrides).
 
 ## Remote use
 


### PR DESCRIPTION
## Summary

Closes #395.

- Removes 89 instances of OpenClaw heritage across 33 documentation files
- Cleans model management, Pi execution engine, Docker sandbox, skills marketplace, and provider ecosystem references
- Updates terminology from "provider" to "runtime" where appropriate (OTel metrics, TUI, docs)
- Removes stale citation artifacts (`citeturn` strings) from tts.md
- Adds deprecation notices to historical exploration docs
- Preserves migration docs, fork attribution, and historical lore as specified

### Exit criteria verification

All three grep checks from the issue return CLEAN (remaining matches are in explicitly excluded migration/lore files):

```
grep -ri 'agents\.defaults\.model|model.catalog|model.selection' docs/channels/ docs/nodes/ docs/web/ docs/start/ docs/platforms/ → CLEAN
grep -ri 'clawhub|skills.marketplace|install.gating' docs/channels/ docs/nodes/ docs/web/ docs/start/ docs/platforms/ → CLEAN  
grep -i 'model.provider|supporting.*model.*provider' README.md VISION.md → CLEAN
```

## Test plan

- [ ] Verify CI passes (docs-only, no code changes)
- [ ] Spot-check key files: README.md, docs/nodes/media-understanding.md, docs/channels/groups.md
- [ ] Confirm no legitimate middleware features were removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)