### PR TITLE
docs(gateway): clean model/provider heritage from gateway documentation

### DIFF
--- a/docs/gateway/authentication.md
+++ b/docs/gateway/authentication.md
@@ -1,30 +1,27 @@
 ---
-description: "Model authentication: OAuth, API keys, and setup-token"
+description: "CLI agent authentication: API keys and setup-token on the gateway host"
 read_when:
-  - Debugging model auth or OAuth expiry
-  - Documenting authentication or credential storage
+  - Debugging CLI agent auth issues
+  - Documenting authentication or credential setup
 title: "Authentication"
 ---
 
 # Authentication
 
-RemoteClaw supports OAuth and API keys for model providers. For Anthropic
-accounts, we recommend using an **API key**. For Claude subscription access,
-use the long‑lived token created by `claude setup-token`.
-
-See [Model failover](/concepts/model-failover) for auth profile rotation and
-storage layout.
+RemoteClaw is middleware — it spawns CLI agents (Claude, Gemini, Codex, OpenCode)
+as subprocesses. Each CLI agent manages its own credentials. RemoteClaw's job is
+to ensure the gateway host environment exposes the right credentials so the CLI
+agent can authenticate when spawned.
 
 ## Recommended Anthropic setup (API key)
 
-If you’re using Anthropic directly, use an API key.
+If you're using Anthropic directly, use an API key.
 
 1. Create an API key in the Anthropic Console.
 2. Put it on the **gateway host** (the machine running `remoteclaw gateway`).
 
 ```bash
 export ANTHROPIC_API_KEY="..."
-remoteclaw models status
 ```
 
 3. If the Gateway runs under systemd/launchd, prefer putting the key in
@@ -36,39 +33,29 @@ ANTHROPIC_API_KEY=...
 EOF
 ```
 
-Then restart the daemon (or restart your Gateway process) and re-check:
+Then restart the daemon (or restart your Gateway process) and verify the CLI
+agent can authenticate:
 
 ```bash
-remoteclaw models status
+claude --version   # confirm Claude CLI is available
 remoteclaw doctor
 ```
-
-If you’d rather not manage env vars yourself, the onboarding wizard can store
-API keys for daemon use: `remoteclaw onboard`.
 
 See [Help](/help) for details on env inheritance (`env.shellEnv`,
 `~/.remoteclaw/.env`, systemd/launchd).
 
 ## Anthropic: setup-token (subscription auth)
 
-For Anthropic, the recommended path is an **API key**. If you’re using a Claude
+For Anthropic, the recommended path is an **API key**. If you're using a Claude
 subscription, the setup-token flow is also supported. Run it on the **gateway host**:
 
 ```bash
 claude setup-token
 ```
 
-Then paste it into RemoteClaw:
-
-```bash
-remoteclaw models auth setup-token --provider anthropic
-```
-
-If the token was created on another machine, paste it manually:
-
-```bash
-remoteclaw models auth paste-token --provider anthropic
-```
+This stores the token in the Claude CLI's own config. RemoteClaw does not ingest
+or manage CLI agent tokens — the Claude CLI reads its own credential store when
+spawned.
 
 If you see an Anthropic error like:
 
@@ -78,83 +65,33 @@ This credential is only authorized for use with Claude Code and cannot be used f
 
 …use an Anthropic API key instead.
 
-Manual token entry (any provider; writes `auth-profiles.json` + updates config):
-
-```bash
-remoteclaw models auth paste-token --provider anthropic
-remoteclaw models auth paste-token --provider openrouter
-```
-
-Automation-friendly check (exit `1` when expired/missing, `2` when expiring):
-
-```bash
-remoteclaw models status --check
-```
-
-Optional ops scripts (systemd/Termux) are documented here:
-[/automation/auth-monitoring](/automation/auth-monitoring)
-
 > `claude setup-token` requires an interactive TTY.
 
-## Checking model auth status
+## Checking auth status
+
+Verify the CLI agent's own credential state by running the CLI interactively on
+the gateway host:
 
 ```bash
-remoteclaw models status
+claude         # confirm Claude CLI authenticates
 remoteclaw doctor
 ```
 
-## API key rotation behavior (gateway)
-
-Some providers support retrying a request with alternative keys when an API call
-hits a provider rate limit.
-
-- Priority order:
-  - `REMOTECLAW_LIVE_<PROVIDER>_KEY` (single override)
-  - `<PROVIDER>_API_KEYS`
-  - `<PROVIDER>_API_KEY`
-  - `<PROVIDER>_API_KEY_*`
-- Google providers also include `GOOGLE_API_KEY` as an additional fallback.
-- The same key list is deduplicated before use.
-- RemoteClaw retries with the next key only for rate-limit errors (for example
-  `429`, `rate_limit`, `quota`, `resource exhausted`).
-- Non-rate-limit errors are not retried with alternate keys.
-- If all keys fail, the final error from the last attempt is returned.
-
-## Controlling which credential is used
-
-### Per-session (chat command)
-
-Use `/model <alias-or-id>@<profileId>` to pin a specific provider credential for the current session (example profile ids: `anthropic:default`, `anthropic:work`).
-
-Use `/model` (or `/model list`) for a compact picker; use `/model status` for the full view (candidates + next auth profile, plus provider endpoint details when configured).
-
-### Per-agent (CLI override)
-
-Set an explicit auth profile order override for an agent (stored in that agent’s `auth-profiles.json`):
-
-```bash
-remoteclaw models auth order get --provider anthropic
-remoteclaw models auth order set --provider anthropic anthropic:default
-remoteclaw models auth order clear --provider anthropic
-```
-
-Use `--agent <id>` to target a specific agent; omit it to use the configured default agent.
-
 ## Troubleshooting
 
-### “No credentials found”
+### "No credentials found"
 
-If the Anthropic token profile is missing, run `claude setup-token` on the
-**gateway host**, then re-check:
+Run `claude setup-token` on the **gateway host**, or set `ANTHROPIC_API_KEY` in
+the gateway environment, then verify:
 
 ```bash
-remoteclaw models status
+remoteclaw doctor
 ```
 
 ### Token expiring/expired
 
-Run `remoteclaw models status` to confirm which profile is expiring. If the profile
-is missing, rerun `claude setup-token` and paste the token again.
+Rerun `claude setup-token` on the gateway host. The Claude CLI manages its own
+token lifecycle.
 
 ## Requirements
 

--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -35,10 +35,10 @@ When spawning long-running child processes outside the exec/process tools (for e
 
 Environment overrides:
 
-- `PI_BASH_YIELD_MS`: default yield (ms)
-- `PI_BASH_MAX_OUTPUT_CHARS`: in‑memory output cap (chars)
+- `REMOTECLAW_BASH_YIELD_MS`: default yield (ms)
+- `REMOTECLAW_BASH_MAX_OUTPUT_CHARS`: in‑memory output cap (chars)
 - `REMOTECLAW_BASH_PENDING_MAX_OUTPUT_CHARS`: pending stdout/stderr cap per stream (chars)
-- `PI_BASH_JOB_TTL_MS`: TTL for finished sessions (ms, bounded to 1m–3h)
+- `REMOTECLAW_BASH_JOB_TTL_MS`: TTL for finished sessions (ms, bounded to 1m–3h)
 
 Config (preferred):
 

--- a/docs/gateway/bridge-protocol.md
+++ b/docs/gateway/bridge-protocol.md
@@ -52,7 +52,7 @@ authoritative pin without explicit user intent or other out-of-band verification
 
 Client → Gateway:
 
-- `req` / `res`: scoped gateway RPC (chat, sessions, config, health, voicewake, skills.bins)
+- `req` / `res`: scoped gateway RPC (chat, sessions, config, health, voicewake)
 - `event`: node signals (voice transcript, agent request, chat subscribe, exec lifecycle)
 
 Gateway → Client:

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -1,37 +1,36 @@
 ---
-description: "CLI backends: text-only fallback via local AI CLIs"
+description: “CLI backends: text-only path via local AI CLIs”
 read_when:
-  - You want a reliable fallback when API providers fail
-  - You are running Claude Code CLI or other local AI CLIs and want to reuse them
+  - You are configuring CLI backend settings (command path, session handling, image pass-through)
   - You need a text-only, tool-free path that still supports sessions and images
-title: "CLI Backends"
+title: “CLI Backends”
 ---
 
-# CLI backends (fallback runtime)
+# CLI backends
 
-RemoteClaw can run **local AI CLIs** as a **text-only fallback** when API providers are down,
-rate-limited, or temporarily misbehaving. This is intentionally conservative:
+RemoteClaw spawns CLI agents as subprocesses. The **CLI backend** subsystem
+provides a text-only path through these CLIs:
 
 - **Tools are disabled** (no tool calls).
 - **Text in → text out** (reliable).
 - **Sessions are supported** (so follow-up turns stay coherent).
 - **Images can be passed through** if the CLI accepts image paths.
 
-This is designed as a **safety net** rather than a primary path. Use it when you
-want “always works” text responses without relying on external APIs.
+> For the primary CLI agent runtime (with full tool support), see
+> [Configuration Reference → agents.defaults](/gateway/configuration-reference#agentsdefaults).
 
 ## Beginner-friendly quick start
 
 You can use Claude Code CLI **without any config** (RemoteClaw ships a built-in default):
 
 ```bash
-remoteclaw agent --message "hi" --model claude-cli/opus-4.6
+remoteclaw agent --message “hi” --model claude-cli/opus-4.6
 ```
 
 Codex CLI also works out of the box:
 
 ```bash
-remoteclaw agent --message "hi" --model codex-cli/gpt-5.3-codex
+remoteclaw agent --message “hi” --model codex-cli/gpt-5.3-codex
 ```
 
 If your gateway runs under launchd/systemd and PATH is minimal, add just the
@@ -42,8 +41,8 @@ command path:
   agents: {
     defaults: {
       cliBackends: {
-        "claude-cli": {
-          command: "/opt/homebrew/bin/claude",
+        “claude-cli”: {
+          command: “/opt/homebrew/bin/claude”,
         },
       },
     },
@@ -52,34 +51,6 @@ command path:
 ```
 
 That’s it. No keys, no extra auth config needed beyond the CLI itself.
-
-## Using it as a fallback
-
-Add a CLI backend to your fallback list so it only runs when primary models fail:
-
-```json5
-{
-  agents: {
-    defaults: {
-      model: {
-        primary: "anthropic/claude-opus-4-6",
-        fallbacks: ["claude-cli/opus-4.6", "claude-cli/opus-4.5"],
-      },
-      models: {
-        "anthropic/claude-opus-4-6": { alias: "Opus" },
-        "claude-cli/opus-4.6": {},
-        "claude-cli/opus-4.5": {},
-      },
-    },
-  },
-}
-```
-
-Notes:
-
-- If you use `agents.defaults.models` (allowlist), you must include `claude-cli/...`.
-- If the primary provider fails (auth, rate limits, timeouts), RemoteClaw will
-  try the CLI backend next.
 
 ## Configuration overview
 

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -35,7 +35,6 @@ Save to `~/.remoteclaw/remoteclaw.json` and you can DM the bot from that number.
   },
   agent: {
     workspace: "~/.remoteclaw/workspace",
-    model: { primary: "anthropic/claude-sonnet-4-5" },
   },
   channels: {
     whatsapp: {
@@ -61,25 +60,6 @@ Save to `~/.remoteclaw/remoteclaw.json` and you can DM the bot from that number.
     shellEnv: {
       enabled: true,
       timeoutMs: 15000,
-    },
-  },
-
-  // Auth profile metadata (secrets live in auth-profiles.json)
-  auth: {
-    profiles: {
-      "anthropic:me@example.com": {
-        provider: "anthropic",
-        mode: "oauth",
-        email: "me@example.com",
-      },
-      "anthropic:work": { provider: "anthropic", mode: "api_key" },
-      "openai:default": { provider: "openai", mode: "api_key" },
-      "openai-codex:default": { provider: "openai-codex", mode: "oauth" },
-    },
-    order: {
-      anthropic: ["anthropic:me@example.com", "anthropic:work"],
-      openai: ["openai:default"],
-      "openai-codex": ["openai-codex:default"],
     },
   },
 
@@ -136,17 +116,12 @@ Save to `~/.remoteclaw/remoteclaw.json` and you can DM the bot from that number.
       audio: {
         enabled: true,
         maxBytes: 20971520,
-        models: [
-          { provider: "openai", model: "gpt-4o-mini-transcribe" },
-          // Optional CLI fallback (Whisper binary):
-          // { type: "cli", command: "whisper", args: ["--model", "base", "{{MediaPath}}"] }
-        ],
+        models: [{ type: "cli", command: "whisper", args: ["--model", "base", "{{MediaPath}}"] }],
         timeoutSeconds: 120,
       },
       video: {
         enabled: true,
         maxBytes: 52428800,
-        models: [{ provider: "google", model: "gemini-3-flash-preview" }],
       },
     },
   },
@@ -237,18 +212,6 @@ Save to `~/.remoteclaw/remoteclaw.json` and you can DM the bot from that number.
     defaults: {
       workspace: "~/.remoteclaw/workspace",
       userTimezone: "America/Chicago",
-      model: {
-        primary: "anthropic/claude-sonnet-4-5",
-        fallbacks: ["anthropic/claude-opus-4-6", "openai/gpt-5.2"],
-      },
-      imageModel: {
-        primary: "openrouter/anthropic/claude-sonnet-4-5",
-      },
-      models: {
-        "anthropic/claude-opus-4-6": { alias: "opus" },
-        "anthropic/claude-sonnet-4-5": { alias: "sonnet" },
-        "openai/gpt-5.2": { alias: "gpt" },
-      },
       verboseDefault: "off",
       elevatedDefault: "on",
       blockStreamingDefault: "off",
@@ -270,7 +233,6 @@ Save to `~/.remoteclaw/remoteclaw.json` and you can DM the bot from that number.
       maxConcurrent: 3,
       heartbeat: {
         every: "30m",
-        model: "anthropic/claude-sonnet-4-5",
         target: "last",
         to: "+15555550123",
         prompt: "HEARTBEAT",
@@ -312,32 +274,6 @@ Save to `~/.remoteclaw/remoteclaw.json` and you can DM the bot from that number.
         signal: ["+15555550123"],
         imessage: ["user@example.com"],
         webchat: ["session:demo"],
-      },
-    },
-  },
-
-  // Custom model providers
-  models: {
-    mode: "merge",
-    providers: {
-      "custom-proxy": {
-        baseUrl: "http://localhost:4000/v1",
-        apiKey: "LITELLM_KEY",
-        api: "openai-responses",
-        authHeader: true,
-        headers: { "X-Proxy-Region": "us-west" },
-        models: [
-          {
-            id: "llama-3.1-8b",
-            name: "Llama 3.1 8B",
-            api: "openai-responses",
-            reasoning: false,
-            input: ["text"],
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 128000,
-            maxTokens: 32000,
-          },
-        ],
       },
     },
   },
@@ -414,20 +350,10 @@ Save to `~/.remoteclaw/remoteclaw.json` and you can DM the bot from that number.
   },
 
   skills: {
-    allowBundled: ["gemini", "peekaboo"],
     load: {
       extraDirs: ["~/Projects/agent-scripts/skills"],
     },
-    install: {
-      preferBrew: true,
-      nodeManager: "npm",
-    },
     entries: {
-      "nano-banana-pro": {
-        enabled: true,
-        apiKey: "GEMINI_KEY_HERE",
-        env: { GEMINI_API_KEY: "GEMINI_KEY_HERE" },
-      },
       peekaboo: { enabled: true },
     },
   },
@@ -486,75 +412,6 @@ If more than one person can DM your bot (multiple entries in `allowFrom`, pairin
 For Discord/Slack/Google Chat/MS Teams/Mattermost/IRC, sender authorization is ID-first by default.
 Only enable direct mutable name/email/nick matching with each channel's `dangerouslyAllowNameMatching: true` if you explicitly accept that risk.
 
-### OAuth with API key failover
-
-```json5
-{
-  auth: {
-    profiles: {
-      "anthropic:subscription": {
-        provider: "anthropic",
-        mode: "oauth",
-        email: "me@example.com",
-      },
-      "anthropic:api": {
-        provider: "anthropic",
-        mode: "api_key",
-      },
-    },
-    order: {
-      anthropic: ["anthropic:subscription", "anthropic:api"],
-    },
-  },
-  agent: {
-    workspace: "~/.remoteclaw/workspace",
-    model: {
-      primary: "anthropic/claude-sonnet-4-5",
-      fallbacks: ["anthropic/claude-opus-4-6"],
-    },
-  },
-}
-```
-
-### Anthropic subscription + API key, MiniMax fallback
-
-```json5
-{
-  auth: {
-    profiles: {
-      "anthropic:subscription": {
-        provider: "anthropic",
-        mode: "oauth",
-        email: "user@example.com",
-      },
-      "anthropic:api": {
-        provider: "anthropic",
-        mode: "api_key",
-      },
-    },
-    order: {
-      anthropic: ["anthropic:subscription", "anthropic:api"],
-    },
-  },
-  models: {
-    providers: {
-      minimax: {
-        baseUrl: "https://api.minimax.io/anthropic",
-        api: "anthropic-messages",
-        apiKey: "${MINIMAX_API_KEY}",
-      },
-    },
-  },
-  agent: {
-    workspace: "~/.remoteclaw/workspace",
-    model: {
-      primary: "anthropic/claude-opus-4-6",
-      fallbacks: ["minimax/MiniMax-M2.1"],
-    },
-  },
-}
-```
-
 ### Work bot (restricted access)
 
 ```json5
@@ -574,38 +431,6 @@ Only enable direct mutable name/email/nick matching with each channel's `dangero
       channels: {
         "#engineering": { allow: true, requireMention: true },
         "#general": { allow: true, requireMention: true },
-      },
-    },
-  },
-}
-```
-
-### Local models only
-
-```json5
-{
-  agent: {
-    workspace: "~/.remoteclaw/workspace",
-    model: { primary: "lmstudio/minimax-m2.1-gs32" },
-  },
-  models: {
-    mode: "merge",
-    providers: {
-      lmstudio: {
-        baseUrl: "http://127.0.0.1:1234/v1",
-        apiKey: "lmstudio",
-        api: "openai-responses",
-        models: [
-          {
-            id: "minimax-m2.1-gs32",
-            name: "MiniMax M2.1 GS32",
-            reasoning: false,
-            input: ["text"],
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 196608,
-            maxTokens: 8192,
-          },
-        ],
       },
     },
   },

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -41,29 +41,6 @@ Pairing codes expire after 1 hour. Pending DM pairing requests are capped at **3
 If a provider block is missing entirely (`channels.<provider>` absent), runtime group policy falls back to `allowlist` (fail-closed) with a startup warning.
 :::
 
-### Channel model overrides
-
-Use `channels.modelByChannel` to pin specific channel IDs to a model. Values accept `provider/model` or configured model aliases. The channel mapping applies when a session does not already have a model override (for example, set via `/model`).
-
-```json5
-{
-  channels: {
-    modelByChannel: {
-      discord: {
-        "123456789012345678": "anthropic/claude-opus-4-6",
-      },
-      slack: {
-        C1234567890: "openai/gpt-4.1",
-      },
-      telegram: {
-        "-1001234567890": "openai/gpt-4.1-mini",
-        "-1001234567890:topic:99": "anthropic/claude-sonnet-4-6",
-      },
-    },
-  },
-}
-```
-
 ### WhatsApp
 
 WhatsApp runs through the gateway's web channel (Baileys Web). It starts automatically when a linked session exists.
@@ -687,24 +664,12 @@ Time format in system prompt. Default: `auto` (OS preference).
 }
 ```
 
-### `agents.defaults.model`
+### `agents.defaults` (runtime)
 
 ```json5
 {
   agents: {
     defaults: {
-      models: {
-        "anthropic/claude-opus-4-6": { alias: "opus" },
-        "minimax/MiniMax-M2.1": { alias: "minimax" },
-      },
-      model: {
-        primary: "anthropic/claude-opus-4-6",
-        fallbacks: ["minimax/MiniMax-M2.1"],
-      },
-      imageModel: {
-        primary: "openrouter/qwen/qwen-2.5-vl-72b-instruct:free",
-        fallbacks: ["openrouter/google/gemini-2.0-flash-vision:free"],
-      },
       verboseDefault: "off",
       elevatedDefault: "on",
       timeoutSeconds: 600,
@@ -716,36 +681,11 @@ Time format in system prompt. Default: `auto` (OS preference).
 }
 ```
 
-- `model`: accepts either a string (`"provider/model"`) or an object (`{ primary, fallbacks }`).
-  - String form sets only the primary model.
-  - Object form sets primary plus ordered failover models.
-- `imageModel`: accepts either a string (`"provider/model"`) or an object (`{ primary, fallbacks }`).
-  - Used by the `image` tool path as its vision-model config.
-  - Also used as fallback routing when the selected/default model cannot accept image input.
-- `model.primary`: format `provider/model` (e.g. `anthropic/claude-opus-4-6`). If you omit the provider, RemoteClaw assumes `anthropic` (deprecated).
-- `models`: the configured model catalog and allowlist for `/model`. Each entry can include `alias` (shortcut) and `params` (provider-specific, for example `temperature`, `maxTokens`, `cacheRetention`, `context1m`).
-- `params` merge precedence (config): `agents.defaults.models["provider/model"].params` is the base, then `agents.list[].params` (matching agent id) overrides by key.
-- Config writers that mutate these fields (for example `/models set`, `/models set-image`, and fallback add/remove commands) save canonical object form and preserve existing fallback lists when possible.
 - `maxConcurrent`: max parallel agent runs across sessions (each session still serialized). Default: 1.
-
-**Built-in alias shorthands** (only apply when the model is in `agents.defaults.models`):
-
-| Alias          | Model                           |
-| -------------- | ------------------------------- |
-| `opus`         | `anthropic/claude-opus-4-6`     |
-| `sonnet`       | `anthropic/claude-sonnet-4-5`   |
-| `gpt`          | `openai/gpt-5.2`                |
-| `gpt-mini`     | `openai/gpt-5-mini`             |
-| `gemini`       | `google/gemini-3-pro-preview`   |
-| `gemini-flash` | `google/gemini-3-flash-preview` |
-
-Your configured aliases always win over defaults.
-
-Z.AI models enable `tool_stream` by default for tool call streaming. Set `agents.defaults.models["zai/<model>"].params.tool_stream` to `false` to disable it.
 
 ### `agents.defaults.cliBackends`
 
-Optional CLI backends for text-only fallback runs (no tool calls). Useful as a backup when API providers fail.
+Optional CLI backends for text-only runs (no tool calls). See [CLI Backends](/gateway/cli-backends) for details.
 
 ```json5
 {
@@ -787,7 +727,6 @@ Periodic heartbeat runs.
     defaults: {
       heartbeat: {
         every: "30m", // 0m disables
-        model: "openai/gpt-5.2-mini",
         session: "main",
         to: "+15555550123",
         target: "none", // default: none | options: last | whatsapp | telegram | discord | ...
@@ -1050,8 +989,6 @@ scripts/sandbox-browser-setup.sh   # optional browser image
         name: "Main Agent",
         workspace: "~/.remoteclaw/workspace",
         agentDir: "~/.remoteclaw/agents/main/agent",
-        model: "anthropic/claude-opus-4-6", // or { primary, fallbacks }
-        params: { cacheRetention: "none" }, // overrides matching defaults.models params by key
         identity: {
           name: "Samantha",
           theme: "helpful sloth",
@@ -1075,8 +1012,6 @@ scripts/sandbox-browser-setup.sh   # optional browser image
 
 - `id`: stable agent id (required).
 - `default`: when multiple are set, first wins (warning logged). If none set, first list entry is default.
-- `model`: string form overrides `primary` only; object form `{ primary, fallbacks }` overrides both (`[]` disables global fallbacks). Cron jobs that only override `primary` still inherit default fallbacks unless you set `fallbacks: []`.
-- `params`: per-agent stream params merged over the selected model entry in `agents.defaults.models`. Use this for agent-specific overrides like `cacheRetention`, `temperature`, or `maxTokens` without duplicating the whole model catalog.
 - `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
 - `subagents.allowAgents`: allowlist of agent ids for `sessions_spawn` (`["*"]` = any; default: same agent only).
@@ -1334,12 +1269,9 @@ Resolution (most specific wins): account → channel → global. `""` disables a
 
 **Template variables:**
 
-| Variable          | Description           | Example                     |
-| ----------------- | --------------------- | --------------------------- |
-| `{model}`         | Short model name      | `claude-opus-4-6`           |
-| `{modelFull}`     | Full model identifier | `anthropic/claude-opus-4-6` |
-| `{provider}`      | Provider name         | `anthropic`                 |
-| `{identity.name}` | Agent identity name   | (same as `"auto"`)          |
+| Variable          | Description         | Example            |
+| ----------------- | ------------------- | ------------------ |
+| `{identity.name}` | Agent identity name | (same as `"auto"`) |
 
 Variables are case-insensitive.
 
@@ -1364,8 +1296,6 @@ Batches rapid text-only messages from the same sender into a single agent turn. 
       auto: "always", // off | always | inbound | tagged
       mode: "final", // final | all
       provider: "elevenlabs",
-      summaryModel: "openai/gpt-4.1-mini",
-      modelOverrides: { enabled: true },
       maxTextLength: 4000,
       timeoutMs: 30000,
       prefsPath: "~/.remoteclaw/settings/tts.json",
@@ -1396,8 +1326,6 @@ Batches rapid text-only messages from the same sender into a single agent turn. 
 ```
 
 - `auto` controls auto-TTS. `/tts off|always|inbound|tagged` overrides per session.
-- `summaryModel` overrides `agents.defaults.model.primary` for auto-summary.
-- `modelOverrides` is enabled by default; `modelOverrides.allowProvider` defaults to `false` (opt-in).
 - API keys fall back to `ELEVENLABS_API_KEY`/`XI_API_KEY` and `OPENAI_API_KEY`.
 
 ---
@@ -1598,15 +1526,11 @@ Configures inbound media understanding (image/audio/video):
           default: "deny",
           rules: [{ action: "allow", match: { chatType: "direct" } }],
         },
-        models: [
-          { provider: "openai", model: "gpt-4o-mini-transcribe" },
-          { type: "cli", command: "whisper", args: ["--model", "base", "{{MediaPath}}"] },
-        ],
+        models: [{ type: "cli", command: "whisper", args: ["--model", "base", "{{MediaPath}}"] }],
       },
       video: {
         enabled: true,
         maxBytes: 52428800,
-        models: [{ provider: "google", model: "gemini-3-flash-preview" }],
       },
     },
   },
@@ -1616,12 +1540,6 @@ Configures inbound media understanding (image/audio/video):
 <details>
 <summary>Media model entry fields</summary>
 
-**Provider entry** (`type: "provider"` or omitted):
-
-- `provider`: API provider id (`openai`, `anthropic`, `google`/`gemini`, `groq`, etc.)
-- `model`: model id override
-- `profile` / `preferredProfile`: auth profile selection
-
 **CLI entry** (`type: "cli"`):
 
 - `command`: executable to run
@@ -1629,11 +1547,9 @@ Configures inbound media understanding (image/audio/video):
 
 **Common fields:**
 
-- `capabilities`: optional list (`image`, `audio`, `video`). Defaults: `openai`/`anthropic`/`minimax` → image, `google` → image+audio+video, `groq` → audio.
+- `capabilities`: optional list (`image`, `audio`, `video`).
 - `prompt`, `maxChars`, `maxBytes`, `timeoutSeconds`, `language`: per-entry overrides.
 - Failures fall back to the next entry.
-
-Provider auth follows standard order: auth profiles → env vars → `models.providers.*.apiKey`.
 
 </details>
 
@@ -1682,7 +1598,6 @@ Notes:
   agents: {
     defaults: {
       subagents: {
-        model: "minimax/MiniMax-M2.1",
         maxConcurrent: 1,
         runTimeoutSeconds: 900,
         archiveAfterMinutes: 60,
@@ -1692,272 +1607,8 @@ Notes:
 }
 ```
 
-- `model`: default model for spawned sub-agents. If omitted, sub-agents inherit the caller's model.
 - `runTimeoutSeconds`: default timeout (seconds) for `sessions_spawn` when the tool call omits `runTimeoutSeconds`. `0` means no timeout.
 - Per-subagent tool policy: `tools.subagents.tools.allow` / `tools.subagents.tools.deny`.
-
----
-
-## Custom providers and base URLs
-
-RemoteClaw uses the OpenCode Zen model catalog. Add custom providers via `models.providers` in config or `~/.remoteclaw/agents/<agentId>/agent/models.json`.
-
-```json5
-{
-  models: {
-    mode: "merge", // merge (default) | replace
-    providers: {
-      "custom-proxy": {
-        baseUrl: "http://localhost:4000/v1",
-        apiKey: "LITELLM_KEY",
-        api: "openai-completions", // openai-completions | openai-responses | anthropic-messages | google-generative-ai
-        models: [
-          {
-            id: "llama-3.1-8b",
-            name: "Llama 3.1 8B",
-            reasoning: false,
-            input: ["text"],
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 128000,
-            maxTokens: 32000,
-          },
-        ],
-      },
-    },
-  },
-}
-```
-
-- Use `authHeader: true` + `headers` for custom auth needs.
-- Override agent config root with `REMOTECLAW_AGENT_DIR` (or `PI_CODING_AGENT_DIR`).
-
-### Provider examples
-
-<details>
-<summary>Cerebras (GLM 4.6 / 4.7)</summary>
-
-```json5
-{
-  env: { CEREBRAS_API_KEY: "sk-..." },
-  agents: {
-    defaults: {
-      model: {
-        primary: "cerebras/zai-glm-4.7",
-        fallbacks: ["cerebras/zai-glm-4.6"],
-      },
-      models: {
-        "cerebras/zai-glm-4.7": { alias: "GLM 4.7 (Cerebras)" },
-        "cerebras/zai-glm-4.6": { alias: "GLM 4.6 (Cerebras)" },
-      },
-    },
-  },
-  models: {
-    mode: "merge",
-    providers: {
-      cerebras: {
-        baseUrl: "https://api.cerebras.ai/v1",
-        apiKey: "${CEREBRAS_API_KEY}",
-        api: "openai-completions",
-        models: [
-          { id: "zai-glm-4.7", name: "GLM 4.7 (Cerebras)" },
-          { id: "zai-glm-4.6", name: "GLM 4.6 (Cerebras)" },
-        ],
-      },
-    },
-  },
-}
-```
-
-Use `cerebras/zai-glm-4.7` for Cerebras; `zai/glm-4.7` for Z.AI direct.
-
-</details>
-
-<details>
-<summary>OpenCode Zen</summary>
-
-```json5
-{
-  agents: {
-    defaults: {
-      model: { primary: "opencode/claude-opus-4-6" },
-      models: { "opencode/claude-opus-4-6": { alias: "Opus" } },
-    },
-  },
-}
-```
-
-Set `OPENCODE_API_KEY` (or `OPENCODE_ZEN_API_KEY`). Shortcut: `remoteclaw onboard --auth-choice opencode-zen`.
-
-</details>
-
-<details>
-<summary>Z.AI (GLM-4.7)</summary>
-
-```json5
-{
-  agents: {
-    defaults: {
-      model: { primary: "zai/glm-4.7" },
-      models: { "zai/glm-4.7": {} },
-    },
-  },
-}
-```
-
-Set `ZAI_API_KEY`. `z.ai/*` and `z-ai/*` are accepted aliases. Shortcut: `remoteclaw onboard --auth-choice zai-api-key`.
-
-- General endpoint: `https://api.z.ai/api/paas/v4`
-- Coding endpoint (default): `https://api.z.ai/api/coding/paas/v4`
-- For the general endpoint, define a custom provider with the base URL override.
-
-</details>
-
-<details>
-<summary>Moonshot AI (Kimi)</summary>
-
-```json5
-{
-  env: { MOONSHOT_API_KEY: "sk-..." },
-  agents: {
-    defaults: {
-      model: { primary: "moonshot/kimi-k2.5" },
-      models: { "moonshot/kimi-k2.5": { alias: "Kimi K2.5" } },
-    },
-  },
-  models: {
-    mode: "merge",
-    providers: {
-      moonshot: {
-        baseUrl: "https://api.moonshot.ai/v1",
-        apiKey: "${MOONSHOT_API_KEY}",
-        api: "openai-completions",
-        models: [
-          {
-            id: "kimi-k2.5",
-            name: "Kimi K2.5",
-            reasoning: false,
-            input: ["text"],
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 256000,
-            maxTokens: 8192,
-          },
-        ],
-      },
-    },
-  },
-}
-```
-
-For the China endpoint: `baseUrl: "https://api.moonshot.cn/v1"` or `remoteclaw onboard --auth-choice moonshot-api-key-cn`.
-
-</details>
-
-<details>
-<summary>Kimi Coding</summary>
-
-```json5
-{
-  env: { KIMI_API_KEY: "sk-..." },
-  agents: {
-    defaults: {
-      model: { primary: "kimi-coding/k2p5" },
-      models: { "kimi-coding/k2p5": { alias: "Kimi K2.5" } },
-    },
-  },
-}
-```
-
-Anthropic-compatible, built-in provider. Shortcut: `remoteclaw onboard --auth-choice kimi-code-api-key`.
-
-</details>
-
-<details>
-<summary>Synthetic (Anthropic-compatible)</summary>
-
-```json5
-{
-  env: { SYNTHETIC_API_KEY: "sk-..." },
-  agents: {
-    defaults: {
-      model: { primary: "synthetic/hf:MiniMaxAI/MiniMax-M2.1" },
-      models: { "synthetic/hf:MiniMaxAI/MiniMax-M2.1": { alias: "MiniMax M2.1" } },
-    },
-  },
-  models: {
-    mode: "merge",
-    providers: {
-      synthetic: {
-        baseUrl: "https://api.synthetic.new/anthropic",
-        apiKey: "${SYNTHETIC_API_KEY}",
-        api: "anthropic-messages",
-        models: [
-          {
-            id: "hf:MiniMaxAI/MiniMax-M2.1",
-            name: "MiniMax M2.1",
-            reasoning: false,
-            input: ["text"],
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 192000,
-            maxTokens: 65536,
-          },
-        ],
-      },
-    },
-  },
-}
-```
-
-Base URL should omit `/v1` (Anthropic client appends it). Shortcut: `remoteclaw onboard --auth-choice synthetic-api-key`.
-
-</details>
-
-<details>
-<summary>MiniMax M2.1 (direct)</summary>
-
-```json5
-{
-  agents: {
-    defaults: {
-      model: { primary: "minimax/MiniMax-M2.1" },
-      models: {
-        "minimax/MiniMax-M2.1": { alias: "Minimax" },
-      },
-    },
-  },
-  models: {
-    mode: "merge",
-    providers: {
-      minimax: {
-        baseUrl: "https://api.minimax.io/anthropic",
-        apiKey: "${MINIMAX_API_KEY}",
-        api: "anthropic-messages",
-        models: [
-          {
-            id: "MiniMax-M2.1",
-            name: "MiniMax M2.1",
-            reasoning: false,
-            input: ["text"],
-            cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 },
-            contextWindow: 200000,
-            maxTokens: 8192,
-          },
-        ],
-      },
-    },
-  },
-}
-```
-
-Set `MINIMAX_API_KEY`. Shortcut: `remoteclaw onboard --auth-choice minimax-api`.
-
-</details>
-
-<details>
-<summary>Local models (LM Studio)</summary>
-
-See [Local Models](/gateway/local-models). TL;DR: run MiniMax M2.1 via LM Studio Responses API on serious hardware; keep hosted models merged for fallback.
-
-</details>
 
 ---
 
@@ -2371,28 +2022,6 @@ Reference env vars in any config string with `${VAR_NAME}`:
 - Missing/empty vars throw an error at config load.
 - Escape with `$${VAR}` for a literal `${VAR}`.
 - Works with `$include`.
-
----
-
-## Auth storage
-
-```json5
-{
-  auth: {
-    profiles: {
-      "anthropic:me@example.com": { provider: "anthropic", mode: "oauth", email: "me@example.com" },
-      "anthropic:work": { provider: "anthropic", mode: "api_key" },
-    },
-    order: {
-      anthropic: ["anthropic:me@example.com", "anthropic:work"],
-    },
-  },
-}
-```
-
-- Per-agent auth profiles stored at `<agentDir>/auth-profiles.json`.
-- Legacy OAuth imports from `~/.remoteclaw/credentials/oauth.json`.
-- See [Model failover](/concepts/model-failover).
 
 ---
 

--- a/docs/gateway/configuration.mdx
+++ b/docs/gateway/configuration.mdx
@@ -16,7 +16,7 @@ RemoteClaw reads an optional <abbr title="JSON5 supports comments and trailing c
 If the file is missing, RemoteClaw uses safe defaults. Common reasons to add a config:
 
 - Connect channels and control who can message the bot
-- Set models, tools, sandboxing, or automation (cron, hooks)
+- Configure your CLI runtime, tools, sandboxing, or automation (cron, hooks)
 - Tune sessions, media, networking, or UI
 
 See the [full reference](/gateway/configuration-reference) for every available field.
@@ -105,36 +105,6 @@ When validation fails:
       },
     }
     ```
-
-</details>
-
-  <details>
-<summary>Choose and configure models</summary>
-
-    Set the primary model and optional fallbacks:
-
-    ```json5
-    {
-      agents: {
-        defaults: {
-          model: {
-            primary: "anthropic/claude-sonnet-4-5",
-            fallbacks: ["openai/gpt-5.2"],
-          },
-          models: {
-            "anthropic/claude-sonnet-4-5": { alias: "Sonnet" },
-            "openai/gpt-5.2": { alias: "GPT" },
-          },
-        },
-      },
-    }
-    ```
-
-    - `agents.defaults.models` defines the model catalog and acts as the allowlist for `/model`.
-    - Model refs use `provider/model` format (e.g. `anthropic/claude-opus-4-6`).
-    - `agents.defaults.imageMaxDimensionPx` controls transcript/tool image downscaling (default `1200`); lower values usually reduce vision-token usage on screenshot-heavy runs.
-    - See [Model Failover](/concepts/model-failover) for auth rotation and fallback behavior.
-    - For custom/self-hosted providers, see [Custom providers](/gateway/configuration-reference#custom-providers-and-base-urls) in the reference.
 
 </details>
 
@@ -390,7 +360,7 @@ Most fields hot-apply without downtime. In `hybrid` mode, restart-required chang
 | Category            | Fields                                                               | Restart needed? |
 | ------------------- | -------------------------------------------------------------------- | --------------- |
 | Channels            | `channels.*`, `web` (WhatsApp) — all built-in and extension channels | No              |
-| Agent & models      | `agent`, `agents`, `models`, `routing`                               | No              |
+| Agent & routing     | `agent`, `agents`, `routing`                                         | No              |
 | Automation          | `hooks`, `cron`, `agent.heartbeat`                                   | No              |
 | Sessions & messages | `session`, `messages`                                                | No              |
 | Tools & media       | `tools`, `browser`, `skills`, `audio`, `talk`                        | No              |
@@ -508,7 +478,6 @@ Reference env vars in any config string value with `${VAR_NAME}`:
 ```json5
 {
   gateway: { auth: { token: "${REMOTECLAW_GATEWAY_TOKEN}" } },
-  models: { providers: { custom: { apiKey: "${CUSTOM_API_KEY}" } } },
 }
 ```
 

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -23,7 +23,7 @@ remoteclaw doctor
 remoteclaw doctor --yes
 ```
 
-Accept defaults without prompting (including restart/service/sandbox repair steps when applicable).
+Accept defaults without prompting (including restart/service repair steps when applicable).
 
 ```bash
 remoteclaw doctor --repair
@@ -41,7 +41,7 @@ Apply aggressive repairs too (overwrites custom supervisor configs).
 remoteclaw doctor --non-interactive
 ```
 
-Run without prompts and only apply safe migrations (config normalization + on-disk state moves). Skips restart/service/sandbox actions that require human confirmation.
+Run without prompts and only apply safe migrations (config normalization + on-disk state moves). Skips restart/service actions that require human confirmation.
 Legacy state migrations run automatically when detected.
 
 ```bash
@@ -61,15 +61,12 @@ cat ~/.remoteclaw/remoteclaw.json
 - Optional pre-flight update for git installs (interactive only).
 - UI protocol freshness check (rebuilds Control UI when the protocol schema is newer).
 - Health check + restart prompt.
-- Skills status summary (eligible/missing/blocked).
+- Skills status summary.
 - Config normalization for legacy values.
-- OpenCode Zen provider override warnings (`models.providers.opencode`).
 - Legacy on-disk state migration (sessions/agent dir/WhatsApp auth).
 - State integrity and permissions checks (sessions, transcripts, state dir).
 - Config file permission checks (chmod 600) when running locally.
-- Model auth health: checks OAuth expiry, can refresh expiring tokens, and reports auth-profile cooldown/disabled states.
 - Extra workspace dir detection (`~/remoteclaw`).
-- Sandbox image repair when sandboxing is enabled.
 - Legacy service migration and extra gateway detection.
 - Gateway runtime checks (service installed but not running; cached launchd label).
 - Channel status warnings (probed from the running gateway).
@@ -123,16 +120,7 @@ Current migrations:
 - `bindings[].match.accountID` → `bindings[].match.accountId`
 - `identity` → `agents.list[].identity`
 - `agent.*` → `agents.defaults` + `tools.*` (tools/elevated/exec/sandbox/subagents)
-- `agent.model`/`allowedModels`/`modelAliases`/`modelFallbacks`/`imageModelFallbacks`
-  → `agents.defaults.models` + `agents.defaults.model.primary/fallbacks` + `agents.defaults.imageModel.primary/fallbacks`
 - `browser.ssrfPolicy.allowPrivateNetwork` → `browser.ssrfPolicy.dangerouslyAllowPrivateNetwork`
-
-### 2b) OpenCode Zen provider overrides
-
-If you’ve added `models.providers.opencode` (or `opencode-zen`) manually, it
-overrides the built-in OpenCode Zen catalog. That can
-force every model onto a single API or zero out costs. Doctor warns so you can
-remove the override and restore per-model API routing + costs.
 
 ### 3) Legacy state migrations (disk layout)
 
@@ -177,30 +165,7 @@ Doctor checks:
 - **Config file permissions**: warns if `~/.remoteclaw/remoteclaw.json` is
   group/world readable and offers to tighten to `600`.
 
-### 5) Model auth health (OAuth expiry)
-
-Doctor inspects OAuth profiles in the auth store, warns when tokens are
-expiring/expired, and can refresh them when safe. If the Anthropic Claude Code
-profile is stale, it suggests running `claude setup-token` (or pasting a setup-token).
-Refresh prompts only appear when running interactively (TTY); `--non-interactive`
-skips refresh attempts.
-
-Doctor also reports auth profiles that are temporarily unusable due to:
-
-- short cooldowns (rate limits/timeouts/auth failures)
-- longer disables (billing/credit failures)
-
-### 6) Hooks model validation
-
-If `hooks.gmail.model` is set, doctor validates the model reference against the
-catalog and allowlist and warns when it won’t resolve or is disallowed.
-
-### 7) Sandbox image repair
-
-When sandboxing is enabled, doctor checks Docker images and offers to build or
-switch to legacy names if the current image is missing.
-
-### 8) Gateway service migrations and cleanup hints
+### 5) Gateway service migrations and cleanup hints
 
 Doctor detects legacy gateway services (launchd/systemd/schtasks) and
 offers to remove them and install the RemoteClaw service using the current gateway
@@ -208,38 +173,37 @@ port. It can also scan for extra gateway-like services and print cleanup hints.
 Profile-named RemoteClaw gateway services are considered first-class and are not
 flagged as "extra."
 
-### 9) Security warnings
+### 6) Security warnings
 
 Doctor emits warnings when a provider is open to DMs without an allowlist, or
 when a policy is configured in a dangerous way.
 
-### 10) systemd linger (Linux)
+### 7) systemd linger (Linux)
 
 If running as a systemd user service, doctor ensures lingering is enabled so the
 gateway stays alive after logout.
 
-### 11) Skills status
+### 8) Skills status
 
-Doctor prints a quick summary of eligible/missing/blocked skills for the current
-workspace.
+Doctor prints a quick summary of skills present in the current workspace.
 
-### 12) Gateway auth checks (local token)
+### 9) Gateway auth checks (local token)
 
 Doctor warns when `gateway.auth` is missing on a local gateway and offers to
 generate a token. Use `remoteclaw doctor --generate-gateway-token` to force token
 creation in automation.
 
-### 13) Gateway health check + restart
+### 10) Gateway health check + restart
 
 Doctor runs a health check and offers to restart the gateway when it looks
 unhealthy.
 
-### 14) Channel status warnings
+### 11) Channel status warnings
 
 If the gateway is healthy, doctor runs a channel status probe and reports
 warnings with suggested fixes.
 
-### 15) Supervisor config audit + repair
+### 12) Supervisor config audit + repair
 
 Doctor checks the installed supervisor config (launchd/systemd/schtasks) for
 missing or outdated defaults (e.g., systemd network-online dependencies and
@@ -254,14 +218,14 @@ Notes:
 - `remoteclaw doctor --repair --force` overwrites custom supervisor configs.
 - You can always force a full rewrite via `remoteclaw gateway install --force`.
 
-### 16) Gateway runtime + port diagnostics
+### 13) Gateway runtime + port diagnostics
 
 Doctor inspects the service runtime (PID, last exit status) and warns when the
 service is installed but not actually running. It also checks for port collisions
 on the gateway port (default `18789`) and reports likely causes (gateway already
 running, SSH tunnel).
 
-### 17) Gateway runtime best practices
+### 14) Gateway runtime best practices
 
 Doctor warns when the gateway service runs on Bun or a version-managed Node path
 (`nvm`, `fnm`, `volta`, `asdf`, etc.). WhatsApp + Telegram channels require Node,
@@ -269,12 +233,12 @@ and version-manager paths can break after upgrades because the service does not
 load your shell init. Doctor offers to migrate to a system Node install when
 available (Homebrew/apt/choco).
 
-### 18) Config write + wizard metadata
+### 15) Config write + wizard metadata
 
 Doctor persists any config changes and stamps wizard metadata to record the
 doctor run.
 
-### 19) Workspace tips (backup + memory system)
+### 16) Workspace tips (backup + memory system)
 
 Doctor suggests a workspace memory system when missing and prints a backup tip
 if the workspace is not already under git.

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -17,7 +17,7 @@ Troubleshooting: [/automation/troubleshooting](/automation/troubleshooting)
 
 ## Quick start (beginner)
 
-1. Leave heartbeats enabled (default is `30m`, or `1h` for Anthropic OAuth/setup-token) or set your own cadence.
+1. Leave heartbeats enabled (default is `30m`) or set your own cadence.
 2. Create a tiny `HEARTBEAT.md` checklist in the agent workspace (optional but recommended).
 3. Decide where heartbeat messages should go (`target: "none"` is the default; set `target: "last"` to route to the last contact).
 4. Optional: enable heartbeat reasoning delivery for transparency.
@@ -41,7 +41,7 @@ Example config:
 
 ## Defaults
 
-- Interval: `30m` (or `1h` when Anthropic OAuth/setup-token is the detected auth mode). Set `agents.defaults.heartbeat.every` or per-agent `agents.list[].heartbeat.every`; use `0m` to disable.
+- Interval: `30m`. Set `agents.defaults.heartbeat.every` or per-agent `agents.list[].heartbeat.every`; use `0m` to disable.
 - Prompt body (configurable via `agents.defaults.heartbeat.prompt`):
   `Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.`
 - The heartbeat prompt is sent **verbatim** as the user message. The system
@@ -103,7 +103,6 @@ legacy text-based protocol:
     defaults: {
       heartbeat: {
         every: "30m", // default: 30m (0m disables)
-        model: "anthropic/claude-opus-4-6",
         target: "last", // default: none | options: last | none | <channel id> (core or plugin, e.g. "bluebubbles")
         to: "+15551234567", // optional channel-specific override
         accountId: "ops-bot", // optional multi-account channel id
@@ -224,7 +223,6 @@ Use `accountId` to target a specific account on multi-account channels like Tele
 ### Field notes
 
 - `every`: heartbeat interval (duration string; default unit = minutes).
-- `model`: optional model override for heartbeat runs (`provider/model`).
 - `session`: optional session key for heartbeat runs.
   - `main` (default): agent main session.
   - Explicit session key (copy from `remoteclaw sessions --json` or the [sessions CLI](/cli/sessions)).

--- a/docs/gateway/local-models.md
+++ b/docs/gateway/local-models.md
@@ -1,5 +1,5 @@
 ---
-description: "Run RemoteClaw on local LLMs (LM Studio, vLLM, LiteLLM, custom OpenAI endpoints)"
+description: "Run RemoteClaw with local LLMs (LM Studio, vLLM, LiteLLM, custom OpenAI endpoints)"
 read_when:
   - You want to serve models from your own GPU box
   - You are wiring LM Studio or an OpenAI-compatible proxy
@@ -9,142 +9,42 @@ title: "Local Models"
 
 # Local models
 
-Local is doable, but RemoteClaw expects large context + strong defenses against prompt injection. Small cards truncate context and leak safety. Aim high: **≥2 maxed-out Mac Studios or equivalent GPU rig (~$30k+)**. A single **24 GB** GPU works only for lighter prompts with higher latency. Use the **largest / full-size model variant you can run**; aggressively quantized or “small” checkpoints raise prompt-injection risk (see [Security](/gateway/security)).
+Local is doable, but RemoteClaw expects large context + strong defenses against prompt injection. Small cards truncate context and leak safety. Aim high: **≥2 maxed-out Mac Studios or equivalent GPU rig (~$30k+)**. A single **24 GB** GPU works only for lighter prompts with higher latency. Use the **largest / full-size model variant you can run**; aggressively quantized or "small" checkpoints raise prompt-injection risk (see [Security](/gateway/security)).
 
-## Recommended: LM Studio + MiniMax M2.1 (Responses API, full-size)
+## How it works
 
-Best current local stack. Load MiniMax M2.1 in LM Studio, enable the local server (default `http://127.0.0.1:1234`), and use Responses API to keep reasoning separate from final text.
+RemoteClaw is middleware — it spawns CLI agents as subprocesses. To use a local model,
+configure the CLI agent (e.g., Claude CLI, OpenCode) to point at your local
+endpoint. RemoteClaw does not manage model selection or provider routing — that is
+the CLI agent's responsibility.
 
-```json5
-{
-  agents: {
-    defaults: {
-      model: { primary: "lmstudio/minimax-m2.1-gs32" },
-      models: {
-        "anthropic/claude-opus-4-6": { alias: "Opus" },
-        "lmstudio/minimax-m2.1-gs32": { alias: "Minimax" },
-      },
-    },
-  },
-  models: {
-    mode: "merge",
-    providers: {
-      lmstudio: {
-        baseUrl: "http://127.0.0.1:1234/v1",
-        apiKey: "lmstudio",
-        api: "openai-responses",
-        models: [
-          {
-            id: "minimax-m2.1-gs32",
-            name: "MiniMax M2.1 GS32",
-            reasoning: false,
-            input: ["text"],
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 196608,
-            maxTokens: 8192,
-          },
-        ],
-      },
-    },
-  },
-}
-```
+For example, if your CLI agent supports a `--model` flag or an environment variable
+for the API base URL, configure those on the gateway host.
+
+## Recommended: LM Studio + MiniMax M2.1
+
+Best current local stack. Load MiniMax M2.1 in LM Studio, enable the local server (default `http://127.0.0.1:1234`), and configure your CLI agent to use that endpoint.
 
 **Setup checklist**
 
 - Install LM Studio: [https://lmstudio.ai](https://lmstudio.ai)
-- In LM Studio, download the **largest MiniMax M2.1 build available** (avoid “small”/heavily quantized variants), start the server, confirm `http://127.0.0.1:1234/v1/models` lists it.
+- In LM Studio, download the **largest MiniMax M2.1 build available** (avoid "small"/heavily quantized variants), start the server, confirm `http://127.0.0.1:1234/v1/models` lists it.
 - Keep the model loaded; cold-load adds startup latency.
-- Adjust `contextWindow`/`maxTokens` if your LM Studio build differs.
-- For WhatsApp, stick to Responses API so only final text is sent.
-
-Keep hosted models configured even when running local; use `models.mode: "merge"` so fallbacks stay available.
-
-### Hybrid config: hosted primary, local fallback
-
-```json5
-{
-  agents: {
-    defaults: {
-      model: {
-        primary: "anthropic/claude-sonnet-4-5",
-        fallbacks: ["lmstudio/minimax-m2.1-gs32", "anthropic/claude-opus-4-6"],
-      },
-      models: {
-        "anthropic/claude-sonnet-4-5": { alias: "Sonnet" },
-        "lmstudio/minimax-m2.1-gs32": { alias: "MiniMax Local" },
-        "anthropic/claude-opus-4-6": { alias: "Opus" },
-      },
-    },
-  },
-  models: {
-    mode: "merge",
-    providers: {
-      lmstudio: {
-        baseUrl: "http://127.0.0.1:1234/v1",
-        apiKey: "lmstudio",
-        api: "openai-responses",
-        models: [
-          {
-            id: "minimax-m2.1-gs32",
-            name: "MiniMax M2.1 GS32",
-            reasoning: false,
-            input: ["text"],
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 196608,
-            maxTokens: 8192,
-          },
-        ],
-      },
-    },
-  },
-}
-```
-
-### Local-first with hosted safety net
-
-Swap the primary and fallback order; keep the same providers block and `models.mode: "merge"` so you can fall back to Sonnet or Opus when the local box is down.
-
-### Regional hosting / data routing
-
-- Hosted MiniMax/Kimi/GLM variants also exist on OpenRouter with region-pinned endpoints (e.g., US-hosted). Pick the regional variant there to keep traffic in your chosen jurisdiction while still using `models.mode: "merge"` for Anthropic/OpenAI fallbacks.
-- Local-only remains the strongest privacy path; hosted regional routing is the middle ground when you need provider features but want control over data flow.
+- Configure your CLI agent to use the local endpoint (e.g., set `ANTHROPIC_BASE_URL` or equivalent for your runtime).
+- For WhatsApp, use an API mode that returns only final text (not streaming reasoning).
 
 ## Other OpenAI-compatible local proxies
 
-vLLM, LiteLLM, OAI-proxy, or custom gateways work if they expose an OpenAI-style `/v1` endpoint. Replace the provider block above with your endpoint and model ID:
+vLLM, LiteLLM, OAI-proxy, or custom gateways work if they expose an OpenAI-style `/v1` endpoint. Configure your CLI agent to point at the local endpoint.
 
-```json5
-{
-  models: {
-    mode: "merge",
-    providers: {
-      local: {
-        baseUrl: "http://127.0.0.1:8000/v1",
-        apiKey: "sk-local",
-        api: "openai-responses",
-        models: [
-          {
-            id: "my-local-model",
-            name: "Local Model",
-            reasoning: false,
-            input: ["text"],
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 120000,
-            maxTokens: 8192,
-          },
-        ],
-      },
-    },
-  },
-}
-```
+## Regional hosting / data routing
 
-Keep `models.mode: "merge"` so hosted models stay available as fallbacks.
+- Hosted MiniMax/Kimi/GLM variants also exist on OpenRouter with region-pinned endpoints (e.g., US-hosted).
+- Local-only remains the strongest privacy path; hosted regional routing is the middle ground when you need provider features but want control over data flow.
 
 ## Troubleshooting
 
 - Gateway can reach the proxy? `curl http://127.0.0.1:1234/v1/models`.
-- LM Studio model unloaded? Reload; cold start is a common “hanging” cause.
+- LM Studio model unloaded? Reload; cold start is a common "hanging" cause.
 - Context errors? Lower `contextWindow` or raise your server limit.
 - Safety: local models skip provider-side filters; keep agents narrow and compaction on to limit prompt injection blast radius.

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -93,7 +93,7 @@ The request follows the OpenResponses API with item-based input. Current support
 - `tools`: client tool definitions (function tools).
 - `tool_choice`: filter or require client tools.
 - `stream`: enables SSE streaming.
-- `max_output_tokens`: best-effort output limit (provider dependent).
+- `max_output_tokens`: best-effort output limit (CLI runtime dependent).
 - `user`: stable session routing.
 
 Accepted but **currently ignored**:
@@ -287,7 +287,7 @@ Event types currently emitted:
 
 ## Usage
 
-`usage` is populated when the underlying provider reports token counts.
+`usage` is populated when the CLI agent reports token counts.
 
 ## Errors
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -165,18 +165,11 @@ The Gateway treats these as **claims** and enforces server-side allowlists.
 - Presence entries include `deviceId`, `roles`, and `scopes` so UIs can show a single row per device
   even when it connects as both **operator** and **node**.
 
-### Node helper methods
-
-- Nodes may call `skills.bins` to fetch the current list of skill executables
-  for auto-allow checks.
-
 ### Operator helper methods
 
 - Operators may call `tools.catalog` (`operator.read`) to fetch the runtime tool catalog for an
   agent. The response includes grouped tools and provenance metadata:
-  - `source`: `core` or `plugin`
-  - `pluginId`: plugin owner when `source="plugin"`
-  - `optional`: whether a plugin tool is optional
+  - `source`: `core` or `mcp`
 
 ## Exec approvals
 
@@ -224,6 +217,6 @@ The Gateway treats these as **claims** and enforces server-side allowlists.
 
 ## Scope
 
-This protocol exposes the **full gateway API** (status, channels, models, chat,
+This protocol exposes the **full gateway API** (status, channels, chat,
 agent, sessions, nodes, approvals, etc.). The exact surface is defined by the
 TypeBox schemas in `src/gateway/protocol/schema.ts`.

--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -19,7 +19,7 @@ This repo supports “remote over SSH” by keeping a single Gateway (the master
 
 ## Common VPN/tailnet setups (where the agent lives)
 
-Think of the **Gateway host** as “where the agent lives.” It owns sessions, auth profiles, channels, and state.
+Think of the **Gateway host** as “where the agent lives.” It owns sessions, channels, and state.
 Your laptop/desktop (and nodes) connect to that host.
 
 ### 1) Always-on Gateway in your tailnet (VPS or home server)

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -190,7 +190,6 @@ If more than one person can DM your bot:
 - **Plugins** (extensions exist without an explicit allowlist).
 - **Policy drift/misconfig** (sandbox docker settings configured but sandbox mode off; ineffective `gateway.nodes.denyCommands` patterns; dangerous `gateway.nodes.allowCommands` entries; global `tools.profile="minimal"` overridden by per-agent profiles; extension plugin tools reachable under permissive tool policy).
 - **Runtime expectation drift** (for example `tools.exec.host="sandbox"` while sandbox mode is off, which runs directly on the gateway host).
-- **Model hygiene** (warn when configured models look legacy; not a hard block).
 
 If you run `--deep`, RemoteClaw also attempts a best-effort live Gateway probe.
 
@@ -203,8 +202,6 @@ Use this when auditing access or deciding what to back up:
 - **Discord bot token**: config/env (token file not yet supported)
 - **Slack tokens**: config/env (`channels.slack.*`)
 - **Pairing allowlists**: `~/.remoteclaw/credentials/<channel>-allowFrom.json`
-- **Model auth profiles**: `~/.remoteclaw/agents/<agentId>/agent/auth-profiles.json`
-- **Legacy OAuth import**: `~/.remoteclaw/credentials/oauth.json`
 
 ## Security Audit Checklist
 
@@ -215,7 +212,6 @@ When the audit prints findings, treat this as a priority order:
 3. **Browser control remote exposure**: treat it like operator access (tailnet-only, pair nodes deliberately, avoid public exposure).
 4. **Permissions**: make sure state/config/credentials/auth are not group/world-readable.
 5. **Plugins/extensions**: only load what you explicitly trust.
-6. **Model choice**: prefer modern, instruction-hardened models for any bot with tools.
 
 ## Security audit glossary
 
@@ -253,7 +249,6 @@ High-signal `checkId` values you will most likely see in real deployments (not e
 | `security.trust_model.multi_user_heuristic`        | warn          | Config looks multi-user while gateway trust model is personal-assistant            | split trust boundaries, or shared-user hardening (`sandbox.mode`, tool deny/workspace scoping)    | no       |
 | `tools.profile_minimal_overridden`                 | warn          | Agent overrides bypass global minimal profile                                      | `agents.list[].tools.profile`                                                                     | no       |
 | `plugins.tools_reachable_permissive_policy`        | warn          | Extension tools reachable in permissive contexts                                   | `tools.profile` + tool allow/deny                                                                 | no       |
-| `models.small_params`                              | critical/info | Small models + unsafe tool surfaces raise injection risk                           | model choice + sandbox/tool policy                                                                | no       |
 
 ## Control UI over HTTP
 
@@ -512,7 +507,7 @@ Even with strong system prompts, **prompt injection is not solved**. System prom
 - Run sensitive tool execution in a sandbox; keep secrets out of the agent’s reachable filesystem.
 - Note: sandboxing is opt-in. If sandbox mode is off, exec runs on the gateway host even though tools.exec.host defaults to sandbox, and host exec does not require approvals unless you set host=gateway and configure exec approvals.
 - Limit high-risk tools (`exec`, `browser`, `web_fetch`, `web_search`) to trusted agents or explicit allowlists.
-- **Model choice matters:** older/legacy models can be less robust against prompt injection and tool misuse. Prefer modern, instruction-hardened models for any bot with tools. We recommend Anthropic Opus 4.6 (or the latest Opus) because it’s strong at recognizing prompt injections (see [“A step forward on safety”](https://www.anthropic.com/news/claude-opus-4-5)).
+- **Model choice matters:** when configuring your CLI agent, prefer a modern, instruction-hardened model. For Claude, this means Opus-class models (see [“A step forward on safety”](https://www.anthropic.com/news/claude-opus-4-5)). Model selection is managed by your CLI agent, not RemoteClaw.
 
 Red flags to treat as untrusted:
 
@@ -757,8 +752,7 @@ Avoid:
 Assume anything under `~/.remoteclaw/` (or `$REMOTECLAW_STATE_DIR/`) may contain secrets or private data:
 
 - `remoteclaw.json`: config may include tokens (gateway, remote gateway), provider settings, and allowlists.
-- `credentials/**`: channel credentials (example: WhatsApp creds), pairing allowlists, legacy OAuth imports.
-- `agents/<agentId>/agent/auth-profiles.json`: API keys + OAuth tokens (imported from legacy `credentials/oauth.json`).
+- `credentials/**`: channel credentials (example: WhatsApp creds), pairing allowlists.
 - `agents/<agentId>/sessions/**`: session transcripts (`*.jsonl`) + routing metadata (`sessions.json`) that can contain private messages and tool output.
 - `extensions/**`: installed plugins (plus their `node_modules/`).
 - `sandboxes/**`: tool sandbox workspaces; can accumulate copies of files you read/write inside the sandbox.
@@ -1055,7 +1049,7 @@ If your AI does something bad:
 
 1. Rotate Gateway auth (`gateway.auth.token` / `REMOTECLAW_GATEWAY_PASSWORD`) and restart.
 2. Rotate remote client secrets (`gateway.remote.token` / `.password`) on any machine that can call the Gateway.
-3. Rotate provider/API credentials (WhatsApp creds, Slack/Discord tokens, model/API keys in `auth-profiles.json`).
+3. Rotate channel credentials (WhatsApp creds, Slack/Discord tokens).
 
 ### Audit
 


### PR DESCRIPTION
## Summary

- Remove references to removed OpenClaw features (in-process model providers, model catalog/allowlist/failover chains, auth profiles, skills marketplace) from 14 gateway documentation files
- Rewrite `authentication.md` and `local-models.md` to reflect RemoteClaw's middleware architecture — CLI agents manage their own credentials and model selection
- Remove entire "Custom providers and base URLs" section from `configuration-reference.md` (260+ lines of `models.providers` examples)
- Rename legacy `PI_` env vars to `REMOTECLAW_` prefix in `background-process.md`
- Clean model/provider references from config examples, doctor checks, heartbeat, protocol, security audit, and other gateway docs

Closes #390

## Test plan

- [ ] Verify no broken internal doc links (cross-references between gateway docs)
- [ ] Grep exit criteria pass: `grep -ri 'agents\.defaults\.model\|models\.providers\|model.allowlist' docs/gateway/` returns nothing
- [ ] No `auth-profiles.json`, `imageModel`, `summaryModel`, `modelOverrides`, `modelByChannel` references remain
- [ ] Docker sandbox config preserved in examples (not removed as model heritage)
- [ ] CI passes (build + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)