### PR TITLE
fix(middleware): surface Claude CLI structured errors as AgentErrorEvent

### DIFF
--- a/src/middleware/runtimes/claude.test.ts
+++ b/src/middleware/runtimes/claude.test.ts
@@ -276,8 +276,29 @@ describe("ClaudeCliRuntime", () => {
       expect(event).toBeNull();
     });
 
-    it("stores result line data and returns null", () => {
+    it("stores result line data and returns null for successful results", () => {
       const event = runtime.testExtractEvent(resultLine());
+      expect(event).toBeNull();
+    });
+
+    it("emits error event when result line has is_error=true", () => {
+      const event = runtime.testExtractEvent(
+        resultLine({ is_error: true, result: "Not logged in · Please run /login" }),
+      );
+      expect(event).toEqual({
+        type: "error",
+        message: "Not logged in · Please run /login",
+        code: "CLI_ERROR",
+      });
+    });
+
+    it("returns null for is_error result with no result text", () => {
+      const event = runtime.testExtractEvent(resultLine({ is_error: true, result: "" }));
+      expect(event).toBeNull();
+    });
+
+    it("returns null for is_error result with non-string result", () => {
+      const event = runtime.testExtractEvent(resultLine({ is_error: true, result: 42 }));
       expect(event).toBeNull();
     });
 

--- a/src/middleware/runtimes/claude.ts
+++ b/src/middleware/runtimes/claude.ts
@@ -88,6 +88,9 @@ export class ClaudeCliRuntime extends CLIRuntimeBase {
 
     if (parsed.type === "result") {
       this.storeResultData(parsed);
+      if (parsed.is_error === true && typeof parsed.result === "string" && parsed.result) {
+        return { type: "error", message: parsed.result, code: "CLI_ERROR" };
+      }
       return null;
     }
 


### PR DESCRIPTION
## Summary

- When Claude CLI fails (auth error, etc.), it outputs errors as structured JSON on stdout with `is_error: true` — **not** as plain text on stderr
- The existing `CLIRuntimeBase` stderr propagation never fires because stderr is empty
- `ClaudeCliRuntime.extractEvent()` processed the result line but ignored `is_error`, silently swallowing the error
- Now emits `AgentErrorEvent` from the result line so errors flow through `DeliveryAdapter` to the user

## Test plan

- [x] Unit tests: `is_error=true` with error text emits error event
- [x] Unit tests: `is_error=true` with empty/non-string result returns null (no false positive)
- [x] Unit tests: successful result lines still return null
- [x] All 94 middleware tests pass (`claude.test.ts`, `cli-runtime-base.test.ts`, `delivery-adapter.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)