### PR TITLE
feat(middleware): propagate multimodal media through ChannelBridge and auto-reply

### DIFF
--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -96,6 +96,12 @@ vi.mock("./mcp-side-effects.js", () => ({
   McpSideEffectsWriter: vi.fn(),
 }));
 
+// Mock media-resolver to return controllable attachments
+const mockResolveMediaAttachments = vi.fn().mockResolvedValue([]);
+vi.mock("./media-resolver.js", () => ({
+  resolveMediaAttachments: (...args: unknown[]) => mockResolveMediaAttachments(...args),
+}));
+
 // ── Session Map (real-ish, file-backed in temp dir) ─────────────────────
 
 let sessionDir: string;
@@ -117,6 +123,8 @@ beforeEach(async () => {
     sentTargets: [],
     cronAdds: 0,
   });
+  mockResolveMediaAttachments.mockClear();
+  mockResolveMediaAttachments.mockResolvedValue([]);
 });
 
 afterEach(async () => {
@@ -752,6 +760,128 @@ describe("ChannelBridge", () => {
       await bridge.handle(makeMessage());
 
       expect(mockReadSideEffects).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("inbound media forwarding", () => {
+    it("resolves mediaUrls and passes media to runtime.execute()", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+      mockResolveMediaAttachments.mockResolvedValue([
+        {
+          mimeType: "image/jpeg",
+          filePath: "/tmp/photo.jpg",
+          sourceUrl: "https://cdn.example.com/photo.jpg",
+        },
+      ]);
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage({ mediaUrls: ["https://cdn.example.com/photo.jpg"] }));
+
+      expect(mockResolveMediaAttachments).toHaveBeenCalledOnce();
+      expect(mockResolveMediaAttachments.mock.calls[0][0]).toEqual([
+        "https://cdn.example.com/photo.jpg",
+      ]);
+      const params = executeFn.mock.calls[0][0];
+      expect(params.media).toEqual([
+        {
+          mimeType: "image/jpeg",
+          filePath: "/tmp/photo.jpg",
+          sourceUrl: "https://cdn.example.com/photo.jpg",
+        },
+      ]);
+    });
+
+    it("does not resolve media when mediaUrls is empty", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage({ mediaUrls: [] }));
+
+      expect(mockResolveMediaAttachments).not.toHaveBeenCalled();
+      const params = executeFn.mock.calls[0][0];
+      expect(params.media).toBeUndefined();
+    });
+
+    it("does not resolve media when mediaUrls is undefined", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage());
+
+      expect(mockResolveMediaAttachments).not.toHaveBeenCalled();
+      const params = executeFn.mock.calls[0][0];
+      expect(params.media).toBeUndefined();
+    });
+
+    it("passes undefined media when resolver returns empty array", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+      mockResolveMediaAttachments.mockResolvedValue([]);
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage({ mediaUrls: ["https://cdn.example.com/bad"] }));
+
+      expect(mockResolveMediaAttachments).toHaveBeenCalledOnce();
+      const params = executeFn.mock.calls[0][0];
+      expect(params.media).toBeUndefined();
+    });
+
+    it("passes multiple resolved media attachments", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+      mockResolveMediaAttachments.mockResolvedValue([
+        { mimeType: "image/jpeg", filePath: "/tmp/a.jpg" },
+        { mimeType: "audio/ogg", filePath: "/tmp/b.ogg" },
+      ]);
+
+      const bridge = createBridge();
+      await bridge.handle(
+        makeMessage({
+          mediaUrls: ["https://cdn.example.com/a.jpg", "https://cdn.example.com/b.ogg"],
+        }),
+      );
+
+      const params = executeFn.mock.calls[0][0];
+      expect(params.media).toHaveLength(2);
+    });
+  });
+
+  describe("outbound media delivery", () => {
+    it("delivers media events as ReplyPayload with mediaUrl", async () => {
+      mockRuntimeInstance = mockRuntime([
+        {
+          type: "media" as const,
+          media: { mimeType: "image/png", filePath: "/workspace/output.png" },
+        },
+        makeDone(),
+      ]);
+
+      const bridge = createBridge();
+      const result = await bridge.handle(makeMessage());
+
+      expect(result.payloads).toEqual([{ mediaUrl: "/workspace/output.png" }]);
+    });
+
+    it("delivers interleaved text and media payloads", async () => {
+      mockRuntimeInstance = mockRuntime([
+        { type: "text", text: "Here is the chart:" },
+        {
+          type: "media" as const,
+          media: { mimeType: "image/png", filePath: "/workspace/chart.png" },
+        },
+        makeDone({ text: "Here is the chart:" }),
+      ]);
+
+      const bridge = createBridge();
+      const result = await bridge.handle(makeMessage());
+
+      expect(result.payloads).toEqual([
+        { text: "Here is the chart:" },
+        { mediaUrl: "/workspace/chart.png" },
+      ]);
     });
   });
 

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -7,6 +7,7 @@ import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { DeliveryAdapter } from "./delivery-adapter.js";
 import { classifyError } from "./error-classifier.js";
 import { readMcpSideEffects } from "./mcp-side-effects.js";
+import { resolveMediaAttachments } from "./media-resolver.js";
 import { createCliRuntime } from "./runtime-factory.js";
 import type { SessionKey, SessionMap } from "./session-map.js";
 import { buildSystemPrompt } from "./system-prompt.js";
@@ -175,7 +176,12 @@ export class ChannelBridge {
         }
       }
 
-      // 5-6. Execute + stream events through DeliveryAdapter
+      // 5. Resolve inbound media attachments (download remote URLs to temp files)
+      const media = message.mediaUrls?.length
+        ? await resolveMediaAttachments(message.mediaUrls, invocationDir)
+        : undefined;
+
+      // 6-7. Execute + stream events through DeliveryAdapter
       const adapter = new DeliveryAdapter(
         this.#chunkLimit !== undefined ? { chunkLimit: this.#chunkLimit } : undefined,
       );
@@ -192,6 +198,7 @@ export class ChannelBridge {
               (message.extraContext ? "\n\n" + message.extraContext : "") +
               "\n\n" +
               message.text,
+            media: media?.length ? media : undefined,
             sessionId: existingSessionId,
             mcpServers,
             abortSignal,

--- a/src/middleware/delivery-adapter.test.ts
+++ b/src/middleware/delivery-adapter.test.ts
@@ -290,6 +290,148 @@ describe("DeliveryAdapter", () => {
     });
   });
 
+  describe("media events", () => {
+    it("media event with filePath produces mediaUrl payload", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        {
+          type: "media" as const,
+          media: { mimeType: "image/png", filePath: "/tmp/screenshot.png" },
+        },
+        makeDone(),
+      ]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([{ mediaUrl: "/tmp/screenshot.png" }]);
+    });
+
+    it("media event with sourceUrl produces mediaUrl payload when no filePath", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        {
+          type: "media" as const,
+          media: { mimeType: "image/jpeg", sourceUrl: "https://example.com/photo.jpg" },
+        },
+        makeDone(),
+      ]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([{ mediaUrl: "https://example.com/photo.jpg" }]);
+    });
+
+    it("media event prefers filePath over sourceUrl", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        {
+          type: "media" as const,
+          media: {
+            mimeType: "image/png",
+            filePath: "/tmp/local.png",
+            sourceUrl: "https://example.com/remote.png",
+          },
+        },
+        makeDone(),
+      ]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([{ mediaUrl: "/tmp/local.png" }]);
+    });
+
+    it("media event with neither filePath nor sourceUrl is skipped", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        {
+          type: "media" as const,
+          media: { mimeType: "image/png", base64: "aW1hZ2VkYXRh" },
+        },
+        makeDone(),
+      ]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([]);
+    });
+
+    it("media event invokes onBlockReply callback", async () => {
+      const onBlockReply = vi.fn();
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        {
+          type: "media" as const,
+          media: { mimeType: "audio/ogg", filePath: "/tmp/voice.ogg" },
+        },
+        makeDone(),
+      ]);
+      await adapter.process(events, { onBlockReply });
+      expect(onBlockReply).toHaveBeenCalledWith({ mediaUrl: "/tmp/voice.ogg" });
+    });
+
+    it("interleaves text and media payloads in order", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        { type: "text", text: "Here is the file:" },
+        {
+          type: "media" as const,
+          media: { mimeType: "image/png", filePath: "/tmp/chart.png" },
+        },
+        makeDone(),
+      ]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([{ text: "Here is the file:" }, { mediaUrl: "/tmp/chart.png" }]);
+    });
+
+    it("delivers result.media from done event when not already streamed", async () => {
+      const adapter = new DeliveryAdapter();
+      const doneEvent: AgentEvent = {
+        type: "done",
+        result: {
+          text: "Done",
+          sessionId: undefined,
+          durationMs: 100,
+          usage: undefined,
+          aborted: false,
+          media: [
+            { mimeType: "image/png", filePath: "/tmp/result.png" },
+            { mimeType: "audio/mp3", sourceUrl: "https://example.com/audio.mp3" },
+          ],
+        },
+      };
+      const events = eventStream([{ type: "text", text: "Done" }, doneEvent]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([
+        { text: "Done" },
+        { mediaUrl: "/tmp/result.png" },
+        { mediaUrl: "https://example.com/audio.mp3" },
+      ]);
+    });
+
+    it("deduplicates streamed media vs result.media", async () => {
+      const adapter = new DeliveryAdapter();
+      const doneEvent: AgentEvent = {
+        type: "done",
+        result: {
+          text: "",
+          sessionId: undefined,
+          durationMs: 100,
+          usage: undefined,
+          aborted: false,
+          media: [
+            { mimeType: "image/png", filePath: "/tmp/already-sent.png" },
+            { mimeType: "image/jpeg", filePath: "/tmp/new.jpg" },
+          ],
+        },
+      };
+      const events = eventStream([
+        {
+          type: "media" as const,
+          media: { mimeType: "image/png", filePath: "/tmp/already-sent.png" },
+        },
+        doneEvent,
+      ]);
+      const payloads = await adapter.process(events);
+      // /tmp/already-sent.png should appear only once (from streaming), /tmp/new.jpg from result
+      expect(payloads).toEqual([
+        { mediaUrl: "/tmp/already-sent.png" },
+        { mediaUrl: "/tmp/new.jpg" },
+      ]);
+    });
+  });
+
   describe("code fence preservation", () => {
     it("does not split inside a code fence when text before fence exists", async () => {
       const adapter = new DeliveryAdapter({ chunkLimit: 30 });

--- a/src/middleware/delivery-adapter.ts
+++ b/src/middleware/delivery-adapter.ts
@@ -46,6 +46,8 @@ export class DeliveryAdapter {
   ): Promise<ReplyPayload[]> {
     let textBuffer = "";
     const payloads: ReplyPayload[] = [];
+    /** Track media delivered via streaming events to avoid duplicates from result.media. */
+    const deliveredMediaKeys = new Set<string>();
 
     for await (const event of events) {
       switch (event.type) {
@@ -60,6 +62,23 @@ export class DeliveryAdapter {
             const payload: ReplyPayload = { text: chunk };
             payloads.push(payload);
             await callbacks?.onPartialReply?.(payload);
+          }
+          break;
+        }
+        case "media": {
+          const mediaUrl = event.media.filePath ?? event.media.sourceUrl;
+          if (mediaUrl) {
+            // Flush any buffered text before the media so ordering is preserved.
+            if (textBuffer.length > 0) {
+              const textPayload: ReplyPayload = { text: textBuffer };
+              payloads.push(textPayload);
+              await callbacks?.onBlockReply?.(textPayload);
+              textBuffer = "";
+            }
+            deliveredMediaKeys.add(mediaUrl);
+            const payload: ReplyPayload = { mediaUrl };
+            payloads.push(payload);
+            await callbacks?.onBlockReply?.(payload);
           }
           break;
         }
@@ -84,6 +103,17 @@ export class DeliveryAdapter {
             payloads.push(payload);
             await callbacks?.onBlockReply?.(payload);
             textBuffer = "";
+          }
+          // Deliver result media not already delivered via streaming events.
+          if (event.result.media?.length) {
+            for (const media of event.result.media) {
+              const url = media.filePath ?? media.sourceUrl;
+              if (url && !deliveredMediaKeys.has(url)) {
+                const payload: ReplyPayload = { mediaUrl: url };
+                payloads.push(payload);
+                await callbacks?.onBlockReply?.(payload);
+              }
+            }
           }
           break;
         }

--- a/src/middleware/media-resolver.test.ts
+++ b/src/middleware/media-resolver.test.ts
@@ -1,0 +1,207 @@
+import { mkdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveMediaAttachments } from "./media-resolver.js";
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+const mockFetchRemoteMedia = vi.fn();
+vi.mock("../media/fetch.js", () => ({
+  fetchRemoteMedia: (...args: unknown[]) => mockFetchRemoteMedia(...args),
+}));
+
+const mockDetectMime = vi.fn();
+vi.mock("../media/mime.js", () => ({
+  detectMime: (...args: unknown[]) => mockDetectMime(...args),
+  extensionForMime: (mime?: string) => {
+    const map: Record<string, string> = {
+      "image/jpeg": ".jpg",
+      "image/png": ".png",
+      "audio/ogg": ".ogg",
+      "video/mp4": ".mp4",
+    };
+    return mime ? (map[mime] ?? "") : "";
+  },
+}));
+
+// ── Setup / Teardown ─────────────────────────────────────────────────────
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = join(tmpdir(), `rc-test-media-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+  await mkdir(tempDir, { recursive: true });
+  mockFetchRemoteMedia.mockReset();
+  mockDetectMime.mockReset();
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("resolveMediaAttachments", () => {
+  describe("remote URLs", () => {
+    it("downloads HTTP URL and saves to temp file", async () => {
+      const imageBuffer = Buffer.from("fake-jpeg-data");
+      mockFetchRemoteMedia.mockResolvedValue({
+        buffer: imageBuffer,
+        contentType: "image/jpeg",
+        fileName: "photo.jpg",
+      });
+
+      const result = await resolveMediaAttachments(["https://cdn.example.com/photo.jpg"], tempDir);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].mimeType).toBe("image/jpeg");
+      expect(result[0].filePath).toMatch(/inbound-media-0\.jpg$/);
+      expect(result[0].sourceUrl).toBe("https://cdn.example.com/photo.jpg");
+      expect(result[0].fileName).toBe("photo.jpg");
+
+      // Verify file was written
+      const written = await readFile(result[0].filePath!);
+      expect(written).toEqual(imageBuffer);
+    });
+
+    it("downloads HTTPS URL", async () => {
+      mockFetchRemoteMedia.mockResolvedValue({
+        buffer: Buffer.from("audio-data"),
+        contentType: "audio/ogg",
+        fileName: "voice.ogg",
+      });
+
+      const result = await resolveMediaAttachments(["https://cdn.telegram.org/voice.ogg"], tempDir);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].mimeType).toBe("audio/ogg");
+      expect(result[0].filePath).toMatch(/inbound-media-0\.ogg$/);
+    });
+
+    it("handles multiple remote URLs", async () => {
+      mockFetchRemoteMedia
+        .mockResolvedValueOnce({
+          buffer: Buffer.from("img1"),
+          contentType: "image/jpeg",
+          fileName: "a.jpg",
+        })
+        .mockResolvedValueOnce({
+          buffer: Buffer.from("img2"),
+          contentType: "image/png",
+          fileName: "b.png",
+        });
+
+      const result = await resolveMediaAttachments(
+        ["https://example.com/a.jpg", "https://example.com/b.png"],
+        tempDir,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0].filePath).toMatch(/inbound-media-0\.jpg$/);
+      expect(result[1].filePath).toMatch(/inbound-media-1\.png$/);
+    });
+
+    it("uses generic extension when MIME type has no mapping", async () => {
+      mockFetchRemoteMedia.mockResolvedValue({
+        buffer: Buffer.from("data"),
+        contentType: "application/octet-stream",
+      });
+
+      const result = await resolveMediaAttachments(["https://example.com/file"], tempDir);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].filePath).toMatch(/inbound-media-0$/);
+      expect(result[0].fileName).toBe("inbound-media-0");
+    });
+
+    it("falls back to application/octet-stream when no content type returned", async () => {
+      mockFetchRemoteMedia.mockResolvedValue({
+        buffer: Buffer.from("unknown"),
+        contentType: undefined,
+      });
+
+      const result = await resolveMediaAttachments(["https://example.com/blob"], tempDir);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].mimeType).toBe("application/octet-stream");
+    });
+  });
+
+  describe("local file paths", () => {
+    it("resolves local file with detected MIME type", async () => {
+      mockDetectMime.mockResolvedValue("image/png");
+
+      const result = await resolveMediaAttachments(["/tmp/screenshot.png"], tempDir);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].mimeType).toBe("image/png");
+      expect(result[0].filePath).toBe("/tmp/screenshot.png");
+      expect(result[0].sourceUrl).toBeUndefined();
+    });
+
+    it("uses application/octet-stream when MIME detection returns undefined", async () => {
+      mockDetectMime.mockResolvedValue(undefined);
+
+      const result = await resolveMediaAttachments(["/tmp/unknown.bin"], tempDir);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].mimeType).toBe("application/octet-stream");
+    });
+  });
+
+  describe("error handling", () => {
+    it("skips URLs that fail to resolve", async () => {
+      mockFetchRemoteMedia.mockRejectedValueOnce(new Error("network error")).mockResolvedValueOnce({
+        buffer: Buffer.from("ok"),
+        contentType: "image/png",
+        fileName: "ok.png",
+      });
+
+      const result = await resolveMediaAttachments(
+        ["https://example.com/bad", "https://example.com/ok.png"],
+        tempDir,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].sourceUrl).toBe("https://example.com/ok.png");
+    });
+
+    it("returns empty array when all URLs fail", async () => {
+      mockFetchRemoteMedia.mockRejectedValue(new Error("fail"));
+
+      const result = await resolveMediaAttachments(
+        ["https://example.com/a", "https://example.com/b"],
+        tempDir,
+      );
+
+      expect(result).toHaveLength(0);
+    });
+
+    it("returns empty array for empty input", async () => {
+      const result = await resolveMediaAttachments([], tempDir);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("mixed URLs", () => {
+    it("handles mix of remote and local URLs", async () => {
+      mockFetchRemoteMedia.mockResolvedValue({
+        buffer: Buffer.from("remote"),
+        contentType: "video/mp4",
+        fileName: "clip.mp4",
+      });
+      mockDetectMime.mockResolvedValue("image/jpeg");
+
+      const result = await resolveMediaAttachments(
+        ["https://cdn.example.com/clip.mp4", "/local/photo.jpg"],
+        tempDir,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0].sourceUrl).toBe("https://cdn.example.com/clip.mp4");
+      expect(result[0].filePath).toMatch(/inbound-media-0\.mp4$/);
+      expect(result[1].filePath).toBe("/local/photo.jpg");
+    });
+  });
+});

--- a/src/middleware/media-resolver.ts
+++ b/src/middleware/media-resolver.ts
@@ -1,0 +1,75 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fetchRemoteMedia } from "../media/fetch.js";
+import { detectMime, extensionForMime } from "../media/mime.js";
+import type { MediaAttachment } from "./types.js";
+
+/** Max download size for inbound channel media (100 MB). */
+const MAX_INBOUND_MEDIA_BYTES = 100 * 1024 * 1024;
+
+/**
+ * Resolve an array of media URLs (HTTP or local paths) into MediaAttachment
+ * objects suitable for passing to {@link AgentRuntime.execute}.
+ *
+ * Remote URLs are downloaded into `tempDir` so that CLI runtimes can access
+ * them as local files.  Local paths are validated for MIME type only.
+ *
+ * Individual resolution failures are silently skipped — a single bad URL
+ * should not prevent the rest of the message from being processed.
+ */
+export async function resolveMediaAttachments(
+  mediaUrls: string[],
+  tempDir: string,
+): Promise<MediaAttachment[]> {
+  const results: MediaAttachment[] = [];
+  for (const [index, url] of mediaUrls.entries()) {
+    try {
+      const attachment = await resolveOne(url, tempDir, index);
+      if (attachment) {
+        results.push(attachment);
+      }
+    } catch {
+      // Skip unresolvable media; don't block the entire message.
+    }
+  }
+  return results;
+}
+
+async function resolveOne(
+  url: string,
+  tempDir: string,
+  index: number,
+): Promise<MediaAttachment | undefined> {
+  if (/^https?:\/\//i.test(url)) {
+    return downloadRemote(url, tempDir, index);
+  }
+  // Local file path — detect MIME from extension, keep original path.
+  return resolveLocal(url);
+}
+
+async function downloadRemote(
+  url: string,
+  tempDir: string,
+  index: number,
+): Promise<MediaAttachment> {
+  const fetched = await fetchRemoteMedia({ url, maxBytes: MAX_INBOUND_MEDIA_BYTES });
+  const mimeType = fetched.contentType ?? "application/octet-stream";
+  const ext = extensionForMime(mimeType) ?? "";
+  const fileName = `inbound-media-${index}${ext}`;
+  const filePath = join(tempDir, fileName);
+  await writeFile(filePath, fetched.buffer);
+  return {
+    mimeType,
+    filePath,
+    sourceUrl: url,
+    fileName: fetched.fileName ?? fileName,
+  };
+}
+
+async function resolveLocal(filePath: string): Promise<MediaAttachment> {
+  const mimeType = (await detectMime({ filePath })) ?? "application/octet-stream";
+  return {
+    mimeType,
+    filePath,
+  };
+}


### PR DESCRIPTION
## Summary

- Add `media-resolver` module to download remote media URLs and detect MIME types for local files, producing `MediaAttachment[]` for CLI runtimes
- Handle `AgentMediaEvent` in `DeliveryAdapter` — flushes text buffer before media to preserve interleaving order, deduplicates streaming events against `AgentRunResult.media`
- Integrate media resolution into `ChannelBridge.handle()` between hook processing and `runtime.execute()`, passing resolved attachments as the `media` parameter

Closes #387

## Test plan

- [x] 11 unit tests for `media-resolver` (remote download, local paths, error handling, mixed URLs)
- [x] 8 unit tests for `DeliveryAdapter` media handling (filePath/sourceUrl, deduplication, interleaving, callbacks)
- [x] 7 unit tests for `ChannelBridge` media forwarding (inbound resolution, outbound delivery, edge cases)
- [x] All 7948 existing tests pass
- [x] TypeScript strict mode — no errors
- [x] oxlint + oxfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)