### PR TITLE
feat(wizard): set agents.defaults.auth during onboarding (#417)

### DIFF
--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -83,7 +83,7 @@ async function withOnboardEnv(
 }
 
 type RuntimeConfigSnapshot = {
-  agents?: { defaults?: { runtime?: string } };
+  agents?: { defaults?: { runtime?: string; auth?: false | string | string[] } };
 };
 
 async function runNonInteractiveOnboardingWithDefaults(
@@ -108,10 +108,12 @@ describe("onboard (non-interactive): runtime auth", () => {
       });
       const config = await readJsonFile<RuntimeConfigSnapshot>(configPath);
       expect(config.agents?.defaults?.runtime).toBe("claude");
+      // No key provided — auth defaults to false (CLI-native auth).
+      expect(config.agents?.defaults?.auth).toBe(false);
     });
   });
 
-  it("infers claude runtime from --anthropic-api-key", async () => {
+  it("infers claude runtime from --anthropic-api-key and sets auth profile", async () => {
     await withOnboardEnv("remoteclaw-onboard-infer-claude-", async ({ configPath, runtime }) => {
       await runNonInteractiveOnboardingWithDefaults(runtime, {
         anthropicApiKey: "sk-ant-test-key",
@@ -119,10 +121,11 @@ describe("onboard (non-interactive): runtime auth", () => {
       });
       const config = await readJsonFile<RuntimeConfigSnapshot>(configPath);
       expect(config.agents?.defaults?.runtime).toBe("claude");
+      expect(config.agents?.defaults?.auth).toBe("anthropic:default");
     });
   });
 
-  it("infers gemini runtime from --gemini-api-key", async () => {
+  it("infers gemini runtime from --gemini-api-key and sets auth profile", async () => {
     await withOnboardEnv("remoteclaw-onboard-infer-gemini-", async ({ configPath, runtime }) => {
       await runNonInteractiveOnboardingWithDefaults(runtime, {
         geminiApiKey: "gemini-test-key",
@@ -130,10 +133,11 @@ describe("onboard (non-interactive): runtime auth", () => {
       });
       const config = await readJsonFile<RuntimeConfigSnapshot>(configPath);
       expect(config.agents?.defaults?.runtime).toBe("gemini");
+      expect(config.agents?.defaults?.auth).toBe("google:default");
     });
   });
 
-  it("infers codex runtime from --codex-api-key", async () => {
+  it("infers codex runtime from --codex-api-key and sets auth profile", async () => {
     await withOnboardEnv("remoteclaw-onboard-infer-codex-", async ({ configPath, runtime }) => {
       await runNonInteractiveOnboardingWithDefaults(runtime, {
         codexApiKey: "codex-test-key",
@@ -141,10 +145,11 @@ describe("onboard (non-interactive): runtime auth", () => {
       });
       const config = await readJsonFile<RuntimeConfigSnapshot>(configPath);
       expect(config.agents?.defaults?.runtime).toBe("codex");
+      expect(config.agents?.defaults?.auth).toBe("codex:default");
     });
   });
 
-  it("infers opencode runtime from --openai-api-key", async () => {
+  it("infers opencode runtime from --openai-api-key and sets auth profile", async () => {
     await withOnboardEnv("remoteclaw-onboard-infer-opencode-", async ({ configPath, runtime }) => {
       await runNonInteractiveOnboardingWithDefaults(runtime, {
         openaiApiKey: "sk-openai-test-key",
@@ -152,10 +157,11 @@ describe("onboard (non-interactive): runtime auth", () => {
       });
       const config = await readJsonFile<RuntimeConfigSnapshot>(configPath);
       expect(config.agents?.defaults?.runtime).toBe("opencode");
+      expect(config.agents?.defaults?.auth).toBe("openai:default");
     });
   });
 
-  it("infers claude runtime from --auth-token", async () => {
+  it("infers claude runtime from --auth-token and sets auth profile", async () => {
     await withOnboardEnv("remoteclaw-onboard-auth-token-", async ({ configPath, runtime }) => {
       await runNonInteractiveOnboardingWithDefaults(runtime, {
         authToken: "my-oauth-token",
@@ -163,6 +169,7 @@ describe("onboard (non-interactive): runtime auth", () => {
       });
       const config = await readJsonFile<RuntimeConfigSnapshot>(configPath);
       expect(config.agents?.defaults?.runtime).toBe("claude");
+      expect(config.agents?.defaults?.auth).toBe("claude:oauth-token");
     });
   });
 
@@ -174,6 +181,8 @@ describe("onboard (non-interactive): runtime auth", () => {
       const config = await readJsonFile<RuntimeConfigSnapshot>(configPath);
       // No runtime set when none specified.
       expect(config.agents?.defaults?.runtime).toBeUndefined();
+      // No auth field set when no runtime inferred.
+      expect(config.agents?.defaults?.auth).toBeUndefined();
     });
   });
 });

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -56,47 +56,71 @@ async function applyNonInteractiveRuntimeAuth(params: {
     },
   };
 
+  /** Set `agents.defaults.auth` on the config being built. */
+  function setAuthDefault(auth: false | string): void {
+    config = {
+      ...config,
+      agents: {
+        ...config.agents,
+        defaults: {
+          ...config.agents?.defaults,
+          auth,
+        },
+      },
+    };
+  }
+
   const { upsertAuthProfile } = await import("../../auth/index.js");
+
+  let profileId: string | undefined;
 
   if (runtime === "claude") {
     if (opts.authToken) {
+      profileId = "claude:oauth-token";
       upsertAuthProfile({
-        profileId: "claude:oauth-token",
+        profileId,
         credential: { type: "api_key", provider: "anthropic", key: opts.authToken },
       });
     } else if (opts.anthropicApiKey) {
+      profileId = "anthropic:default";
       upsertAuthProfile({
-        profileId: "anthropic:default",
+        profileId,
         credential: { type: "api_key", provider: "anthropic", key: opts.anthropicApiKey },
       });
     }
   } else if (runtime === "gemini") {
     if (opts.geminiApiKey) {
+      profileId = "google:default";
       upsertAuthProfile({
-        profileId: "google:default",
+        profileId,
         credential: { type: "api_key", provider: "google", key: opts.geminiApiKey },
       });
     }
   } else if (runtime === "codex") {
     if (opts.codexApiKey) {
+      profileId = "codex:default";
       upsertAuthProfile({
-        profileId: "codex:default",
+        profileId,
         credential: { type: "api_key", provider: "codex", key: opts.codexApiKey },
       });
     }
   } else if (runtime === "opencode") {
     if (opts.anthropicApiKey) {
+      profileId = "anthropic:default";
       upsertAuthProfile({
-        profileId: "anthropic:default",
+        profileId,
         credential: { type: "api_key", provider: "anthropic", key: opts.anthropicApiKey },
       });
     } else if (opts.openaiApiKey) {
+      profileId = "openai:default";
       upsertAuthProfile({
-        profileId: "openai:default",
+        profileId,
         credential: { type: "api_key", provider: "openai", key: opts.openaiApiKey },
       });
     }
   }
+
+  setAuthDefault(profileId ?? false);
 
   return config;
 }

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -319,6 +319,137 @@ describe("runOnboardingWizard", () => {
     expect(hasWorkspaceInList).toBe(true);
   });
 
+  it("sets agents.defaults.auth to false when user skips credential", async () => {
+    writeConfigFile.mockClear();
+
+    const workspaceDir = await makeCaseDir("workspace-");
+
+    const select = vi.fn(async (params: WizardSelectParams<unknown>) => {
+      if (params.message === "Authentication for Claude Code") {
+        return "skip";
+      }
+      return "quickstart";
+    }) as unknown as WizardPrompter["select"];
+    const prompter = buildWizardPrompter({ select });
+    const runtime = createRuntime({ throwsOnExit: true });
+
+    await runOnboardingWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        runtime: "claude",
+        workspace: workspaceDir,
+        installDaemon: false,
+        skipProviders: true,
+        skipSkills: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      runtime,
+      prompter,
+    );
+
+    type WrittenConfig = {
+      agents?: { defaults?: { auth?: false | string | string[] } };
+    };
+    const writtenConfigs = writeConfigFile.mock.calls.map(
+      (call) => (call as unknown[])[0] as WrittenConfig,
+    );
+    const hasAuthFalse = writtenConfigs.some((cfg) => cfg.agents?.defaults?.auth === false);
+    expect(hasAuthFalse).toBe(true);
+  });
+
+  it("sets agents.defaults.auth to profile id when user provides API key", async () => {
+    writeConfigFile.mockClear();
+    upsertAuthProfile.mockClear();
+
+    const workspaceDir = await makeCaseDir("workspace-");
+
+    const select = vi.fn(async (params: WizardSelectParams<unknown>) => {
+      if (params.message === "Authentication for Claude Code") {
+        return "api-key";
+      }
+      return "quickstart";
+    }) as unknown as WizardPrompter["select"];
+    const text: WizardPrompter["text"] = vi.fn(async () => "sk-ant-test-key");
+    const prompter = buildWizardPrompter({ select, text });
+    const runtime = createRuntime({ throwsOnExit: true });
+
+    await runOnboardingWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        runtime: "claude",
+        workspace: workspaceDir,
+        installDaemon: false,
+        skipProviders: true,
+        skipSkills: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      runtime,
+      prompter,
+    );
+
+    type WrittenConfig = {
+      agents?: { defaults?: { auth?: false | string | string[] } };
+    };
+    const writtenConfigs = writeConfigFile.mock.calls.map(
+      (call) => (call as unknown[])[0] as WrittenConfig,
+    );
+    const hasAuthProfile = writtenConfigs.some(
+      (cfg) => cfg.agents?.defaults?.auth === "anthropic:default",
+    );
+    expect(hasAuthProfile).toBe(true);
+    expect(upsertAuthProfile).toHaveBeenCalledWith(
+      expect.objectContaining({ profileId: "anthropic:default" }),
+    );
+  });
+
+  it("sets agents.defaults.auth to claude:oauth-token when user provides auth token", async () => {
+    writeConfigFile.mockClear();
+    upsertAuthProfile.mockClear();
+
+    const workspaceDir = await makeCaseDir("workspace-");
+
+    const select = vi.fn(async (params: WizardSelectParams<unknown>) => {
+      if (params.message === "Authentication for Claude Code") {
+        return "auth-token";
+      }
+      return "quickstart";
+    }) as unknown as WizardPrompter["select"];
+    const text: WizardPrompter["text"] = vi.fn(async () => "my-oauth-token");
+    const prompter = buildWizardPrompter({ select, text });
+    const runtime = createRuntime({ throwsOnExit: true });
+
+    await runOnboardingWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        runtime: "claude",
+        workspace: workspaceDir,
+        installDaemon: false,
+        skipProviders: true,
+        skipSkills: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      runtime,
+      prompter,
+    );
+
+    type WrittenConfig = {
+      agents?: { defaults?: { auth?: false | string | string[] } };
+    };
+    const writtenConfigs = writeConfigFile.mock.calls.map(
+      (call) => (call as unknown[])[0] as WrittenConfig,
+    );
+    const hasAuthProfile = writtenConfigs.some(
+      (cfg) => cfg.agents?.defaults?.auth === "claude:oauth-token",
+    );
+    expect(hasAuthProfile).toBe(true);
+  });
+
   async function runTuiHatchTest(params: {
     writeBootstrapFile: boolean;
     expectedMessage: string | undefined;

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -22,22 +22,27 @@ import type { QuickstartGatewayDefaults, WizardFlow } from "./onboarding.types.j
 import { WizardCancelledError, type WizardPrompter } from "./prompts.js";
 
 // Skip guidance messages shown when user chooses "Skip" for credential.
+// Skipping sets `agents.defaults.auth: false` — the CLI handles its own authentication.
 const SKIP_GUIDANCE: Record<AgentRuntime, string> = {
   claude: [
+    "CLI handles its own authentication (auth: false).",
     "Make sure Claude Code can authenticate. Options: run `claude login`,",
     "set `ANTHROPIC_API_KEY`, or configure AWS Bedrock (`CLAUDE_CODE_USE_BEDROCK=1`)",
     "or Google Vertex AI (`CLAUDE_CODE_USE_VERTEX=1`).",
   ].join(" "),
   gemini: [
+    "CLI handles its own authentication (auth: false).",
     "Make sure Gemini CLI can authenticate. Options: run `gemini` and select",
     "'Login with Google', set `GEMINI_API_KEY`, or configure",
     "`gcloud auth application-default login` for Vertex AI.",
   ].join(" "),
   codex: [
+    "CLI handles its own authentication (auth: false).",
     "Make sure Codex CLI can authenticate. Options: run `codex login`,",
     "or set `CODEX_API_KEY` in your environment.",
   ].join(" "),
   opencode: [
+    "CLI handles its own authentication (auth: false).",
     "Make sure OpenCode can authenticate. Options: run `opencode` and use `/connect`,",
     "configure `opencode.json`, or set the appropriate provider env var",
     "(e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`).",
@@ -59,6 +64,20 @@ async function promptRuntimeCredential(params: {
   const { runtime, prompter, upsertAuthProfile, opts } = params;
   let config = params.config;
 
+  /** Set `agents.defaults.auth` on the config being built. */
+  function setAuthDefault(auth: false | string): void {
+    config = {
+      ...config,
+      agents: {
+        ...config.agents,
+        defaults: {
+          ...config.agents?.defaults,
+          auth,
+        },
+      },
+    };
+  }
+
   if (runtime === "claude") {
     const choice = await prompter.select({
       message: "Authentication for Claude Code",
@@ -76,7 +95,7 @@ async function promptRuntimeCredential(params: {
         {
           value: "skip",
           label: "Skip",
-          hint: "Claude CLI is already authorized",
+          hint: "CLI handles its own authentication",
         },
       ],
       initialValue: "skip",
@@ -91,6 +110,7 @@ async function promptRuntimeCredential(params: {
           profileId: "anthropic:default",
           credential: { type: "api_key", provider: "anthropic", key: key.trim() },
         });
+        setAuthDefault("anthropic:default");
       }
     } else if (choice === "auth-token") {
       const token =
@@ -100,9 +120,11 @@ async function promptRuntimeCredential(params: {
           profileId: "claude:oauth-token",
           credential: { type: "api_key", provider: "anthropic", key: token.trim() },
         });
+        setAuthDefault("claude:oauth-token");
       }
     } else {
       await prompter.note(SKIP_GUIDANCE.claude, "Authentication");
+      setAuthDefault(false);
     }
   } else if (runtime === "gemini") {
     const choice = await prompter.select({
@@ -112,7 +134,7 @@ async function promptRuntimeCredential(params: {
         {
           value: "skip",
           label: "Skip",
-          hint: "Already authorized",
+          hint: "CLI handles its own authentication",
         },
       ],
       initialValue: "skip",
@@ -126,9 +148,11 @@ async function promptRuntimeCredential(params: {
           profileId: "google:default",
           credential: { type: "api_key", provider: "google", key: key.trim() },
         });
+        setAuthDefault("google:default");
       }
     } else {
       await prompter.note(SKIP_GUIDANCE.gemini, "Authentication");
+      setAuthDefault(false);
     }
   } else if (runtime === "codex") {
     const choice = await prompter.select({
@@ -138,7 +162,7 @@ async function promptRuntimeCredential(params: {
         {
           value: "skip",
           label: "Skip",
-          hint: "Already authorized",
+          hint: "CLI handles its own authentication",
         },
       ],
       initialValue: "skip",
@@ -152,9 +176,11 @@ async function promptRuntimeCredential(params: {
           profileId: "codex:default",
           credential: { type: "api_key", provider: "codex", key: key.trim() },
         });
+        setAuthDefault("codex:default");
       }
     } else {
       await prompter.note(SKIP_GUIDANCE.codex, "Authentication");
+      setAuthDefault(false);
     }
   } else if (runtime === "opencode") {
     const choice = await prompter.select({
@@ -164,7 +190,7 @@ async function promptRuntimeCredential(params: {
         {
           value: "skip",
           label: "Skip",
-          hint: "Already authorized",
+          hint: "CLI handles its own authentication",
         },
       ],
       initialValue: "skip",
@@ -189,6 +215,7 @@ async function promptRuntimeCredential(params: {
             profileId: "anthropic:default",
             credential: { type: "api_key", provider: "anthropic", key: key.trim() },
           });
+          setAuthDefault("anthropic:default");
         }
       } else if (provider === "openai") {
         const key =
@@ -199,6 +226,7 @@ async function promptRuntimeCredential(params: {
             profileId: "openai:default",
             credential: { type: "api_key", provider: "openai", key: key.trim() },
           });
+          setAuthDefault("openai:default");
         }
       } else {
         const envVarName = await prompter.text({
@@ -210,18 +238,21 @@ async function promptRuntimeCredential(params: {
           initialValue: "",
         });
         if (envVarName.trim() && envVarValue.trim()) {
+          const profileId = `opencode:${envVarName.trim().toLowerCase()}`;
           upsertAuthProfile({
-            profileId: `opencode:${envVarName.trim().toLowerCase()}`,
+            profileId,
             credential: {
               type: "api_key",
               provider: "opencode",
               key: envVarValue.trim(),
             },
           });
+          setAuthDefault(profileId);
         }
       }
     } else {
       await prompter.note(SKIP_GUIDANCE.opencode, "Authentication");
+      setAuthDefault(false);
     }
   }
 


### PR DESCRIPTION
## Summary

- Wire `agents.defaults.auth` into onboarding wizard — credential choices now set the auth config field
- API key / auth token provided → `auth: "{profile-id}"` (e.g., `"anthropic:default"`, `"claude:oauth-token"`)
- Credential skipped → `auth: false` (CLI handles its own authentication)
- Applies to both interactive (`promptRuntimeCredential`) and non-interactive (`applyNonInteractiveRuntimeAuth`) flows
- Update skip hint text to say "CLI handles its own authentication" and prepend guidance messages with `auth: false` explanation

Closes #417

## Test plan

- [x] Interactive wizard: skip → `agents.defaults.auth: false` in written config
- [x] Interactive wizard: API key → `agents.defaults.auth: "anthropic:default"` in written config
- [x] Interactive wizard: auth token → `agents.defaults.auth: "claude:oauth-token"` in written config
- [x] Non-interactive: `--anthropic-api-key` → `auth: "anthropic:default"`
- [x] Non-interactive: `--gemini-api-key` → `auth: "google:default"`
- [x] Non-interactive: `--codex-api-key` → `auth: "codex:default"`
- [x] Non-interactive: `--openai-api-key` → `auth: "openai:default"`
- [x] Non-interactive: `--auth-token` → `auth: "claude:oauth-token"`
- [x] Non-interactive: `--runtime claude` (no key) → `auth: false`
- [x] Non-interactive: no runtime/key → `auth: undefined`
- [x] All 107 onboarding tests pass
- [x] Type-check, lint, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)