### PR TITLE
fix(import): adapt OpenClaw import for relocated auth profiles and auth config field

### DIFF
--- a/src/commands/import.test.ts
+++ b/src/commands/import.test.ts
@@ -6,7 +6,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   detectOpenClawInstallation,
+  discoverSourceAuthProfileIds,
   importCommand,
+  materializeAuthDefaults,
   materializeWorkspaceDefaults,
   resolveTargetFilename,
   stripUnrecognizedConfigKeys,
@@ -302,6 +304,237 @@ describe("stripUnrecognizedConfigKeys", () => {
   });
 });
 
+describe("discoverSourceAuthProfileIds", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "auth-discover-test-"));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("discovers profiles from modern auth-profiles.json", async () => {
+    const agentDir = path.join(tmpDir, "agents", "main", "agent");
+    await fsp.mkdir(agentDir, { recursive: true });
+    await fsp.writeFile(
+      path.join(agentDir, "auth-profiles.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "anthropic:default": { type: "api_key", provider: "anthropic", key: "fake-key" },
+          "google:my-key": { type: "api_key", provider: "google", key: "fake-key" },
+        },
+      }),
+    );
+
+    const ids = discoverSourceAuthProfileIds(tmpDir);
+    expect(ids).toContain("anthropic:default");
+    expect(ids).toContain("google:my-key");
+    expect(ids).toHaveLength(2);
+  });
+
+  it("discovers profiles from legacy auth.json", async () => {
+    const agentDir = path.join(tmpDir, "agents", "main", "agent");
+    await fsp.mkdir(agentDir, { recursive: true });
+    await fsp.writeFile(
+      path.join(agentDir, "auth.json"),
+      JSON.stringify({
+        anthropic: { type: "api_key", provider: "anthropic", key: "fake-key" },
+        google: { type: "api_key", provider: "google", key: "fake-key" },
+      }),
+    );
+
+    const ids = discoverSourceAuthProfileIds(tmpDir);
+    expect(ids).toContain("anthropic:default");
+    expect(ids).toContain("google:default");
+    expect(ids).toHaveLength(2);
+  });
+
+  it("returns empty array when no auth files exist", () => {
+    expect(discoverSourceAuthProfileIds(tmpDir)).toEqual([]);
+  });
+
+  it("returns empty array for malformed auth files", async () => {
+    const agentDir = path.join(tmpDir, "agents", "main", "agent");
+    await fsp.mkdir(agentDir, { recursive: true });
+    await fsp.writeFile(path.join(agentDir, "auth-profiles.json"), "not valid json {{{");
+
+    expect(discoverSourceAuthProfileIds(tmpDir)).toEqual([]);
+  });
+
+  it("deduplicates profile IDs across multiple auth files", async () => {
+    const agent1 = path.join(tmpDir, "agents", "main", "agent");
+    const agent2 = path.join(tmpDir, "agents", "helper", "agent");
+    await fsp.mkdir(agent1, { recursive: true });
+    await fsp.mkdir(agent2, { recursive: true });
+
+    const store = JSON.stringify({
+      version: 1,
+      profiles: { "anthropic:default": { type: "api_key", provider: "anthropic" } },
+    });
+    await fsp.writeFile(path.join(agent1, "auth-profiles.json"), store);
+    await fsp.writeFile(path.join(agent2, "auth-profiles.json"), store);
+
+    const ids = discoverSourceAuthProfileIds(tmpDir);
+    expect(ids).toEqual(["anthropic:default"]);
+  });
+
+  it("skips legacy auth.json that has profiles key (modern format)", async () => {
+    const agentDir = path.join(tmpDir, "agents", "main", "agent");
+    await fsp.mkdir(agentDir, { recursive: true });
+    // A file named auth.json but with modern format should not produce legacy-style IDs
+    await fsp.writeFile(
+      path.join(agentDir, "auth.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: { "anthropic:default": { type: "api_key", provider: "anthropic" } },
+      }),
+    );
+
+    // auth.json with "profiles" key is treated as modern and skipped by legacy collector,
+    // and it's not named auth-profiles.json so modern collector also skips it
+    expect(discoverSourceAuthProfileIds(tmpDir)).toEqual([]);
+  });
+});
+
+describe("materializeAuthDefaults", () => {
+  it("sets auth for claude runtime with anthropic profile", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: { runtime: "claude" },
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    const result = JSON.parse(materializeAuthDefaults(input, ["anthropic:default"]));
+    expect(result.agents.defaults.auth).toBe("anthropic:default");
+  });
+
+  it("sets auth for gemini runtime with google profile", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: { runtime: "gemini" },
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    const result = JSON.parse(materializeAuthDefaults(input, ["google:my-key"]));
+    expect(result.agents.defaults.auth).toBe("google:my-key");
+  });
+
+  it("sets auth for codex runtime with openai-codex profile", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: { runtime: "codex" },
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    const result = JSON.parse(materializeAuthDefaults(input, ["openai-codex:codex-cli"]));
+    expect(result.agents.defaults.auth).toBe("openai-codex:codex-cli");
+  });
+
+  it("sets auth for opencode runtime with anthropic profile", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: { runtime: "opencode" },
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    const result = JSON.parse(materializeAuthDefaults(input, ["anthropic:default"]));
+    expect(result.agents.defaults.auth).toBe("anthropic:default");
+  });
+
+  it("selects first matching profile when multiple exist", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: { runtime: "claude" },
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    const result = JSON.parse(
+      materializeAuthDefaults(input, ["google:key", "anthropic:first", "anthropic:second"]),
+    );
+    expect(result.agents.defaults.auth).toBe("anthropic:first");
+  });
+
+  it("does not set auth when no runtime configured", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: { workspace: "~/ws" },
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    const output = materializeAuthDefaults(input, ["anthropic:default"]);
+    expect(output).toBe(input);
+  });
+
+  it("does not set auth when auth already configured", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: { runtime: "claude", auth: "existing:profile" },
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    const output = materializeAuthDefaults(input, ["anthropic:default"]);
+    expect(output).toBe(input);
+  });
+
+  it("does not set auth when auth is explicitly false", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: { runtime: "claude", auth: false },
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    const output = materializeAuthDefaults(input, ["anthropic:default"]);
+    expect(output).toBe(input);
+  });
+
+  it("does not set auth when no matching profile exists", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: { runtime: "claude" },
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    const output = materializeAuthDefaults(input, ["google:key"]);
+    expect(output).toBe(input);
+  });
+
+  it("returns unchanged for empty profile IDs", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: { runtime: "claude" },
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    const output = materializeAuthDefaults(input, []);
+    expect(output).toBe(input);
+  });
+
+  it("returns non-JSON content unchanged", () => {
+    const input = "not valid json {{{";
+    expect(materializeAuthDefaults(input, ["anthropic:default"])).toBe(input);
+  });
+
+  it("handles config without agents key", () => {
+    const input = JSON.stringify({ gateway: { port: 18789 } });
+    const output = materializeAuthDefaults(input, ["anthropic:default"]);
+    expect(output).toBe(input);
+  });
+
+  it("matches claude provider prefix for claude runtime", () => {
+    const input = JSON.stringify({
+      agents: {
+        defaults: { runtime: "claude" },
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    const result = JSON.parse(materializeAuthDefaults(input, ["claude:custom-profile"]));
+    expect(result.agents.defaults.auth).toBe("claude:custom-profile");
+  });
+});
+
 describe("resolveTargetFilename", () => {
   it("renames openclaw.json to remoteclaw.json", () => {
     expect(resolveTargetFilename("openclaw.json")).toBe("remoteclaw.json");
@@ -496,6 +729,87 @@ describe("importCommand", () => {
     const parsed = JSON.parse(written);
     expect(parsed.agents.list[0].workspace).toBe("~/.remoteclaw/workspace");
     expect(result.transformedFiles).toHaveLength(1);
+  });
+
+  it("materializes auth defaults when auth profiles and runtime exist", async () => {
+    const configContent = JSON.stringify({
+      agents: {
+        defaults: { runtime: "claude" },
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    await fsp.writeFile(path.join(sourceDir, "openclaw.json"), configContent);
+
+    // Create auth profiles in the source
+    const agentDir = path.join(sourceDir, "agents", "main", "agent");
+    await fsp.mkdir(agentDir, { recursive: true });
+    await fsp.writeFile(
+      path.join(agentDir, "auth-profiles.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "anthropic:default": { type: "api_key", provider: "anthropic", key: "fake-key" },
+        },
+      }),
+    );
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    const written = await fsp.readFile(path.join(targetDir, "remoteclaw.json"), "utf-8");
+    const parsed = JSON.parse(written);
+    expect(parsed.agents.defaults.auth).toBe("anthropic:default");
+  });
+
+  it("does not set auth when no auth profiles exist in source", async () => {
+    const configContent = JSON.stringify({
+      agents: {
+        defaults: { runtime: "claude" },
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    await fsp.writeFile(path.join(sourceDir, "openclaw.json"), configContent);
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    const written = await fsp.readFile(path.join(targetDir, "remoteclaw.json"), "utf-8");
+    const parsed = JSON.parse(written);
+    expect(parsed.agents.defaults.auth).toBeUndefined();
+  });
+
+  it("does not set auth when no runtime is configured", async () => {
+    const configContent = JSON.stringify({
+      agents: {
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    await fsp.writeFile(path.join(sourceDir, "openclaw.json"), configContent);
+
+    const agentDir = path.join(sourceDir, "agents", "main", "agent");
+    await fsp.mkdir(agentDir, { recursive: true });
+    await fsp.writeFile(
+      path.join(agentDir, "auth-profiles.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "anthropic:default": { type: "api_key", provider: "anthropic", key: "fake-key" },
+        },
+      }),
+    );
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    const written = await fsp.readFile(path.join(targetDir, "remoteclaw.json"), "utf-8");
+    const parsed = JSON.parse(written);
+    expect(parsed.agents.defaults).toBeUndefined();
   });
 
   it("handles nested directory structures with mixed file types", async () => {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -47,6 +47,24 @@ const SUBSTANTIVE_CONFIG_KEYS = new Set([
   "discovery",
 ]);
 
+/**
+ * Auth profile filenames used for discovery during import.
+ */
+const AUTH_PROFILES_FILENAME = "auth-profiles.json";
+const LEGACY_AUTH_FILENAME = "auth.json";
+
+/**
+ * Runtime-to-provider mapping for auto-detecting auth profiles.
+ * Profile IDs use `{provider}:{name}` format; the provider prefix is matched
+ * against these lists.
+ */
+const RUNTIME_AUTH_PROVIDERS: Record<string, string[]> = {
+  claude: ["anthropic", "claude"],
+  gemini: ["google"],
+  codex: ["codex", "openai", "openai-codex"],
+  opencode: ["openai", "anthropic", "opencode"],
+};
+
 export type ImportOptions = {
   sourcePath: string;
   yes?: boolean;
@@ -351,6 +369,143 @@ export function materializeWorkspaceDefaults(jsonContent: string): string {
 }
 
 /**
+ * Discover auth profile IDs from auth store files in the source directory.
+ *
+ * Walks the directory tree looking for `auth-profiles.json` (v1 format)
+ * and legacy `auth.json` files. Returns deduplicated profile IDs.
+ */
+export function discoverSourceAuthProfileIds(sourceDir: string): string[] {
+  const profileIds: string[] = [];
+
+  const walk = (dir: string) => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile()) {
+        if (entry.name === AUTH_PROFILES_FILENAME) {
+          collectModernStore(fullPath, profileIds);
+        } else if (entry.name === LEGACY_AUTH_FILENAME) {
+          collectLegacyStore(fullPath, profileIds);
+        }
+      }
+    }
+  };
+
+  walk(sourceDir);
+  return [...new Set(profileIds)];
+}
+
+function collectModernStore(filePath: string, out: string[]): void {
+  try {
+    const raw = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    if (raw?.profiles && typeof raw.profiles === "object") {
+      out.push(...Object.keys(raw.profiles));
+    }
+  } catch {
+    /* ignore unreadable/malformed files */
+  }
+}
+
+function collectLegacyStore(filePath: string, out: string[]): void {
+  try {
+    const raw = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    if (typeof raw !== "object" || raw === null || "profiles" in raw) {
+      return;
+    }
+    for (const [key, value] of Object.entries(raw)) {
+      if (
+        value &&
+        typeof value === "object" &&
+        (value as Record<string, unknown>).type === "api_key"
+      ) {
+        out.push(`${key}:default`);
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Materialize the `agents.defaults.auth` field from discovered auth profiles.
+ *
+ * OpenClaw configs don't have the `auth` field. After import, auth profiles
+ * exist on disk but nothing in the config points to them. This function
+ * detects the configured runtime and sets `agents.defaults.auth` to the
+ * first profile whose provider matches the runtime.
+ */
+export function materializeAuthDefaults(
+  jsonContent: string,
+  discoveredProfileIds: string[],
+): string {
+  if (discoveredProfileIds.length === 0) {
+    return jsonContent;
+  }
+
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(jsonContent);
+  } catch {
+    return jsonContent;
+  }
+
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    return jsonContent;
+  }
+
+  const agents = config.agents as Record<string, unknown> | undefined;
+  const defaults = agents?.defaults as Record<string, unknown> | undefined;
+
+  // Skip if auth is already configured
+  if (defaults?.auth !== undefined) {
+    return jsonContent;
+  }
+
+  // Need a runtime to determine which provider to match
+  const runtime = typeof defaults?.runtime === "string" ? defaults.runtime : undefined;
+  if (!runtime) {
+    return jsonContent;
+  }
+
+  const providers = RUNTIME_AUTH_PROVIDERS[runtime];
+  if (!providers) {
+    return jsonContent;
+  }
+
+  // Find first profile whose provider prefix matches the runtime
+  const matchingProfileId = discoveredProfileIds.find((id) => {
+    const colonIdx = id.indexOf(":");
+    const provider = (colonIdx > 0 ? id.slice(0, colonIdx) : id).toLowerCase();
+    return providers.includes(provider);
+  });
+
+  if (!matchingProfileId) {
+    return jsonContent;
+  }
+
+  // Set agents.defaults.auth
+  if (!config.agents) {
+    config.agents = {};
+  }
+  const agentsObj = config.agents as Record<string, unknown>;
+  if (!agentsObj.defaults) {
+    agentsObj.defaults = {};
+  }
+  (agentsObj.defaults as Record<string, unknown>).auth = matchingProfileId;
+
+  const indentMatch = jsonContent.match(/^(\s+)"/m);
+  const indent = indentMatch?.[1] ?? "  ";
+  return JSON.stringify(config, null, indent) + "\n";
+}
+
+/**
  * Determine the target filename for a source file.
  * Renames openclaw.json -> remoteclaw.json at any directory level.
  */
@@ -376,6 +531,7 @@ async function copyDirectory(params: {
   targetDir: string;
   dryRun: boolean;
   result: ImportResult;
+  discoveredAuthProfileIds: string[];
 }): Promise<void> {
   const { sourceDir, targetDir, dryRun, result } = params;
 
@@ -396,6 +552,7 @@ async function copyDirectory(params: {
         targetDir: targetPath,
         dryRun,
         result,
+        discoveredAuthProfileIds: params.discoveredAuthProfileIds,
       });
     } else if (entry.isFile()) {
       if (isConfigFile(entry.name)) {
@@ -404,7 +561,10 @@ async function copyDirectory(params: {
         // Apply structural config transforms to the main config file
         const isMainConfig = entry.name === OPENCLAW_CONFIG_FILENAME;
         const final = isMainConfig
-          ? materializeWorkspaceDefaults(stripUnrecognizedConfigKeys(transformed))
+          ? materializeAuthDefaults(
+              materializeWorkspaceDefaults(stripUnrecognizedConfigKeys(transformed)),
+              params.discoveredAuthProfileIds,
+            )
           : transformed;
         if (renames.length > 0 || final !== transformed) {
           result.transformedFiles.push(targetPath);
@@ -487,11 +647,14 @@ export async function importCommand(
     `Importing from ${shortenHomePath(sourcePath)} to ${shortenHomePath(targetDir)}...\n`,
   );
 
+  const discoveredAuthProfileIds = discoverSourceAuthProfileIds(sourcePath);
+
   await copyDirectory({
     sourceDir: sourcePath,
     targetDir,
     dryRun: Boolean(opts.dryRun),
     result,
+    discoveredAuthProfileIds,
   });
 
   // Deduplicate env var renames for reporting


### PR DESCRIPTION
## Summary

- Add `discoverSourceAuthProfileIds()` to walk the source directory and extract auth profile IDs from `auth-profiles.json` (v1) and legacy `auth.json` files
- Add `materializeAuthDefaults()` to set `agents.defaults.auth` when a discovered profile matches the configured runtime (claude→anthropic, gemini→google, codex→openai, opencode→varies)
- Wire both into the import pipeline so auth profiles imported from OpenClaw are not silently unused

Closes #427

## Test plan

- [x] Unit tests for `discoverSourceAuthProfileIds`: modern store, legacy store, empty, malformed, dedup, legacy-with-profiles-key
- [x] Unit tests for `materializeAuthDefaults`: all four runtimes, first-match selection, no-runtime, auth-already-set, auth-false, no-match, empty profiles, non-JSON, no-agents, claude-prefix
- [x] Integration tests for `importCommand`: auth profiles + runtime → auth set, no profiles → no auth, no runtime → no auth
- [x] Existing tests pass (62/62)
- [x] Format, typecheck, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)