### PR TITLE
feat(runtime): wire per-agent auth profile to CLI env injection (#422)

### DIFF
--- a/src/auth/env-injection.test.ts
+++ b/src/auth/env-injection.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { RemoteClawConfig } from "../config/config.js";
+import {
+  _resetRoundRobinState,
+  resolveAuthEnv,
+  resolveProviderEnvVarName,
+} from "./env-injection.js";
+import type { AuthProfileStore } from "./types.js";
+
+afterEach(() => {
+  _resetRoundRobinState();
+});
+
+describe("resolveProviderEnvVarName", () => {
+  it("maps anthropic to ANTHROPIC_API_KEY", () => {
+    expect(resolveProviderEnvVarName("anthropic")).toBe("ANTHROPIC_API_KEY");
+  });
+
+  it("maps google to GEMINI_API_KEY", () => {
+    expect(resolveProviderEnvVarName("google")).toBe("GEMINI_API_KEY");
+  });
+
+  it("maps openai to OPENAI_API_KEY", () => {
+    expect(resolveProviderEnvVarName("openai")).toBe("OPENAI_API_KEY");
+  });
+
+  it("maps openai-codex to OPENAI_API_KEY", () => {
+    expect(resolveProviderEnvVarName("openai-codex")).toBe("OPENAI_API_KEY");
+  });
+
+  it("maps opencode to OPENCODE_API_KEY", () => {
+    expect(resolveProviderEnvVarName("opencode")).toBe("OPENCODE_API_KEY");
+  });
+
+  it("maps general providers via envMap", () => {
+    expect(resolveProviderEnvVarName("groq")).toBe("GROQ_API_KEY");
+    expect(resolveProviderEnvVarName("mistral")).toBe("MISTRAL_API_KEY");
+    expect(resolveProviderEnvVarName("openrouter")).toBe("OPENROUTER_API_KEY");
+  });
+
+  it("returns undefined for unknown providers", () => {
+    expect(resolveProviderEnvVarName("unknown-provider")).toBeUndefined();
+  });
+});
+
+describe("resolveAuthEnv", () => {
+  const makeStore = (
+    profiles: Record<string, { provider: string; key: string }>,
+  ): AuthProfileStore => ({
+    version: 1,
+    profiles: Object.fromEntries(
+      Object.entries(profiles).map(([id, p]) => [
+        id,
+        { type: "api_key" as const, provider: p.provider, key: p.key },
+      ]),
+    ),
+  });
+
+  it("returns undefined when auth is undefined (no config)", async () => {
+    const cfg: RemoteClawConfig = {};
+    const result = await resolveAuthEnv({ cfg, agentId: "main" });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when auth is false", async () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", workspace: "~/w", auth: false }],
+      },
+    };
+    const result = await resolveAuthEnv({ cfg, agentId: "main" });
+    expect(result).toBeUndefined();
+  });
+
+  it("injects correct env var for single anthropic profile", async () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", workspace: "~/w", auth: "anthropic:default" }],
+      },
+    };
+    const store = makeStore({
+      "anthropic:default": { provider: "anthropic", key: "sk-ant-test-key" },
+    });
+
+    const result = await resolveAuthEnv({ cfg, agentId: "main", store });
+    expect(result).toEqual({ ANTHROPIC_API_KEY: "sk-ant-test-key" });
+  });
+
+  it("injects correct env var for google profile", async () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", workspace: "~/w", auth: "google:default" }],
+      },
+    };
+    const store = makeStore({
+      "google:default": { provider: "google", key: "gemini-test-key" },
+    });
+
+    const result = await resolveAuthEnv({ cfg, agentId: "main", store });
+    expect(result).toEqual({ GEMINI_API_KEY: "gemini-test-key" });
+  });
+
+  it("injects correct env var for openai profile", async () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", workspace: "~/w", auth: "openai:default" }],
+      },
+    };
+    const store = makeStore({
+      "openai:default": { provider: "openai", key: "sk-openai-test" },
+    });
+
+    const result = await resolveAuthEnv({ cfg, agentId: "main", store });
+    expect(result).toEqual({ OPENAI_API_KEY: "sk-openai-test" });
+  });
+
+  it("returns undefined for missing profile and logs warning", async () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", workspace: "~/w", auth: "anthropic:nonexistent" }],
+      },
+    };
+    const store = makeStore({});
+
+    const result = await resolveAuthEnv({ cfg, agentId: "main", store });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for profile with unknown provider", async () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", workspace: "~/w", auth: "exotic:p1" }],
+      },
+    };
+    const store = makeStore({
+      "exotic:p1": { provider: "exotic", key: "exotic-key" },
+    });
+
+    const result = await resolveAuthEnv({ cfg, agentId: "main", store });
+    expect(result).toBeUndefined();
+  });
+
+  it("inherits auth from defaults", async () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { auth: "anthropic:shared" },
+        list: [{ id: "main", workspace: "~/w" }],
+      },
+    };
+    const store = makeStore({
+      "anthropic:shared": { provider: "anthropic", key: "sk-shared" },
+    });
+
+    const result = await resolveAuthEnv({ cfg, agentId: "main", store });
+    expect(result).toEqual({ ANTHROPIC_API_KEY: "sk-shared" });
+  });
+
+  describe("round-robin", () => {
+    it("cycles through array entries across calls", async () => {
+      const cfg: RemoteClawConfig = {
+        agents: {
+          list: [
+            {
+              id: "main",
+              workspace: "~/w",
+              auth: ["anthropic:key1", "anthropic:key2", "anthropic:key3"],
+            },
+          ],
+        },
+      };
+      const store = makeStore({
+        "anthropic:key1": { provider: "anthropic", key: "sk-1" },
+        "anthropic:key2": { provider: "anthropic", key: "sk-2" },
+        "anthropic:key3": { provider: "anthropic", key: "sk-3" },
+      });
+
+      const r1 = await resolveAuthEnv({ cfg, agentId: "main", store });
+      expect(r1).toEqual({ ANTHROPIC_API_KEY: "sk-1" });
+
+      const r2 = await resolveAuthEnv({ cfg, agentId: "main", store });
+      expect(r2).toEqual({ ANTHROPIC_API_KEY: "sk-2" });
+
+      const r3 = await resolveAuthEnv({ cfg, agentId: "main", store });
+      expect(r3).toEqual({ ANTHROPIC_API_KEY: "sk-3" });
+
+      // Wraps around
+      const r4 = await resolveAuthEnv({ cfg, agentId: "main", store });
+      expect(r4).toEqual({ ANTHROPIC_API_KEY: "sk-1" });
+    });
+
+    it("tracks rotation independently per agent", async () => {
+      const cfg: RemoteClawConfig = {
+        agents: {
+          list: [
+            { id: "a", workspace: "~/w", auth: ["anthropic:a1", "anthropic:a2"] },
+            { id: "b", workspace: "~/w", auth: ["anthropic:b1", "anthropic:b2"] },
+          ],
+        },
+      };
+      const store = makeStore({
+        "anthropic:a1": { provider: "anthropic", key: "sk-a1" },
+        "anthropic:a2": { provider: "anthropic", key: "sk-a2" },
+        "anthropic:b1": { provider: "anthropic", key: "sk-b1" },
+        "anthropic:b2": { provider: "anthropic", key: "sk-b2" },
+      });
+
+      const ra1 = await resolveAuthEnv({ cfg, agentId: "a", store });
+      expect(ra1).toEqual({ ANTHROPIC_API_KEY: "sk-a1" });
+
+      const rb1 = await resolveAuthEnv({ cfg, agentId: "b", store });
+      expect(rb1).toEqual({ ANTHROPIC_API_KEY: "sk-b1" });
+
+      const ra2 = await resolveAuthEnv({ cfg, agentId: "a", store });
+      expect(ra2).toEqual({ ANTHROPIC_API_KEY: "sk-a2" });
+
+      const rb2 = await resolveAuthEnv({ cfg, agentId: "b", store });
+      expect(rb2).toEqual({ ANTHROPIC_API_KEY: "sk-b2" });
+    });
+
+    it("returns undefined for empty auth array", async () => {
+      const cfg: RemoteClawConfig = {
+        agents: {
+          list: [{ id: "main", workspace: "~/w", auth: [] }],
+        },
+      };
+      const store = makeStore({});
+
+      const result = await resolveAuthEnv({ cfg, agentId: "main", store });
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/auth/env-injection.ts
+++ b/src/auth/env-injection.ts
@@ -1,0 +1,145 @@
+/**
+ * Auth profile → CLI subprocess env var injection.
+ *
+ * Resolves per-agent auth profile references to environment variables
+ * suitable for injecting into CLI subprocess environments.
+ */
+
+import { resolveAgentAuth } from "../agents/agent-scope.js";
+import { normalizeProviderId } from "../agents/provider-utils.js";
+import type { RemoteClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { ensureAuthProfileStore, resolveApiKeyForProfile } from "./index.js";
+import type { AuthProfileStore } from "./types.js";
+
+const log = createSubsystemLogger("auth-env");
+
+/**
+ * Round-robin state: tracks the last-used index per agent ID.
+ * Resets on process restart — rotation is best-effort.
+ */
+const roundRobinState = new Map<string, number>();
+
+/** @internal — exposed for tests only. */
+export function _resetRoundRobinState(): void {
+  roundRobinState.clear();
+}
+
+/**
+ * Map a provider ID to the primary environment variable name used by CLI agents.
+ *
+ * Returns `undefined` for providers with no known env var mapping.
+ */
+export function resolveProviderEnvVarName(provider: string): string | undefined {
+  const normalized = normalizeProviderId(provider);
+
+  switch (normalized) {
+    case "anthropic":
+      return "ANTHROPIC_API_KEY";
+    case "google":
+      return "GEMINI_API_KEY";
+    case "openai":
+    case "openai-codex":
+      return "OPENAI_API_KEY";
+    case "opencode":
+      return "OPENCODE_API_KEY";
+    case "github-copilot":
+      return "GITHUB_TOKEN";
+    default:
+      break;
+  }
+
+  const envMap: Record<string, string> = {
+    voyage: "VOYAGE_API_KEY",
+    groq: "GROQ_API_KEY",
+    deepgram: "DEEPGRAM_API_KEY",
+    cerebras: "CEREBRAS_API_KEY",
+    xai: "XAI_API_KEY",
+    openrouter: "OPENROUTER_API_KEY",
+    litellm: "LITELLM_API_KEY",
+    mistral: "MISTRAL_API_KEY",
+    together: "TOGETHER_API_KEY",
+    moonshot: "MOONSHOT_API_KEY",
+    minimax: "MINIMAX_API_KEY",
+    nvidia: "NVIDIA_API_KEY",
+    xiaomi: "XIAOMI_API_KEY",
+    venice: "VENICE_API_KEY",
+    qianfan: "QIANFAN_API_KEY",
+    kilocode: "KILOCODE_API_KEY",
+  };
+
+  return envMap[normalized];
+}
+
+/**
+ * Pick the next profile ID from an array using round-robin.
+ */
+function pickRoundRobin(agentId: string, profiles: string[]): string | undefined {
+  if (profiles.length === 0) {
+    return undefined;
+  }
+  const lastIndex = roundRobinState.get(agentId) ?? -1;
+  const nextIndex = (lastIndex + 1) % profiles.length;
+  roundRobinState.set(agentId, nextIndex);
+  return profiles[nextIndex];
+}
+
+/**
+ * Resolve per-agent auth profile(s) to env vars for CLI subprocess injection.
+ *
+ * - `auth: false` → no injection (returns `undefined`)
+ * - `auth: "profile-id"` → resolve single profile, inject as env var
+ * - `auth: ["id1", "id2"]` → round-robin rotation, inject selected profile
+ * - `auth: undefined` → no injection (returns `undefined`)
+ *
+ * Missing or invalid profiles log a warning and return `undefined`
+ * (fall-through to next credential precedence level).
+ */
+export async function resolveAuthEnv(params: {
+  cfg: RemoteClawConfig;
+  agentId: string;
+  agentDir?: string;
+  store?: AuthProfileStore;
+}): Promise<Record<string, string> | undefined> {
+  const auth = resolveAgentAuth(params.cfg, params.agentId);
+
+  if (auth === false || auth === undefined) {
+    return undefined;
+  }
+
+  const profileId = Array.isArray(auth) ? pickRoundRobin(params.agentId, auth) : auth;
+
+  if (!profileId) {
+    return undefined;
+  }
+
+  const store = params.store ?? ensureAuthProfileStore(params.agentDir);
+
+  let resolved: { apiKey: string; provider: string; email?: string } | null;
+  try {
+    resolved = await resolveApiKeyForProfile({
+      cfg: params.cfg,
+      store,
+      profileId,
+      agentDir: params.agentDir,
+    });
+  } catch {
+    log.warn(`Failed to resolve auth profile "${profileId}" — skipping env injection`);
+    return undefined;
+  }
+
+  if (!resolved) {
+    log.warn(`Auth profile "${profileId}" not found or has no key — skipping env injection`);
+    return undefined;
+  }
+
+  const envVarName = resolveProviderEnvVarName(resolved.provider);
+  if (!envVarName) {
+    log.warn(
+      `No env var mapping for provider "${resolved.provider}" (profile "${profileId}") — skipping env injection`,
+    );
+    return undefined;
+  }
+
+  return { [envVarName]: resolved.apiKey };
+}

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -9,6 +9,7 @@ import {
 } from "../../agents/agent-helpers.js";
 import { resolveChannelMessageToolHints } from "../../agents/channel-tools.js";
 import { resolveUserTimezone } from "../../agents/date-time.js";
+import { resolveAuthEnv } from "../../auth/env-injection.js";
 import { resolveGatewayPort } from "../../config/paths.js";
 import {
   resolveSessionTranscriptPath,
@@ -281,6 +282,17 @@ export async function runAgentTurnWithFallback(params: {
         });
 
         const cfg = params.followupRun.run.config;
+        const baseRuntimeEnv = resolveCliRuntimeEnv(cfg);
+
+        // Resolve auth profile → env vars for credential injection.
+        // Auth profile takes priority over runtimeEnv (highest precedence).
+        const authEnv = await resolveAuthEnv({
+          cfg,
+          agentId: params.followupRun.run.agentId,
+          agentDir: params.followupRun.run.agentDir,
+        });
+        const runtimeEnv = authEnv ? { ...baseRuntimeEnv, ...authEnv } : baseRuntimeEnv;
+
         const bridge = new ChannelBridge({
           provider: resolveCliRuntimeProvider(cfg),
           sessionMap,
@@ -288,7 +300,7 @@ export async function runAgentTurnWithFallback(params: {
           gatewayToken: resolveGatewayTokenFromConfig(cfg),
           workspaceDir: params.followupRun.run.workspaceDir,
           runtimeArgs: resolveCliRuntimeArgs(cfg),
-          runtimeEnv: resolveCliRuntimeEnv(cfg),
+          runtimeEnv,
         });
 
         const messageToolHints = resolveChannelMessageToolHints({


### PR DESCRIPTION
## Summary

- Add `resolveAuthEnv()` in `src/auth/env-injection.ts` to resolve per-agent auth profile references to CLI subprocess environment variables
- Add `resolveProviderEnvVarName()` mapping providers to their primary env var (anthropic→ANTHROPIC_API_KEY, google→GEMINI_API_KEY, etc.)
- Implement round-robin rotation for `auth: ["id1", "id2"]` array configs with per-agent tracking (resets on process restart)
- Wire into `agent-runner-execution.ts`: auth profile env vars override `runtimeEnv` (highest credential precedence)
- Graceful fallback: missing/invalid profiles log a warning and fall through to next precedence level

## Credential precedence (highest → lowest)

```
agent.auth profile key → runtimeEnv → process.env → CLI-native auth
```

## Test plan

- [x] Auth profile key injected as correct env var for each provider type (18 unit tests)
- [x] `auth: false` results in no profile injection
- [x] `runtimeEnv` is overridden by auth profile when both set same var (spread order)
- [x] Round-robin cycles through array entries across calls
- [x] Missing/invalid profile ID logs warning, falls through (returns undefined)
- [x] Inherits auth from `agents.defaults.auth`
- [x] Unknown provider returns undefined (no env var mapping)
- [x] Empty auth array returns undefined
- [x] Per-agent rotation tracking (independent state per agent ID)

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)