### PR TITLE
feat(middleware): retry with rotated auth key on rate-limit errors (#423)

### DIFF
--- a/src/auth/env-injection.test.ts
+++ b/src/auth/env-injection.test.ts
@@ -3,6 +3,7 @@ import type { RemoteClawConfig } from "../config/config.js";
 import {
   _resetRoundRobinState,
   resolveAuthEnv,
+  resolveAuthProfileCount,
   resolveProviderEnvVarName,
 } from "./env-injection.js";
 import type { AuthProfileStore } from "./types.js";
@@ -228,5 +229,53 @@ describe("resolveAuthEnv", () => {
       const result = await resolveAuthEnv({ cfg, agentId: "main", store });
       expect(result).toBeUndefined();
     });
+  });
+});
+
+describe("resolveAuthProfileCount", () => {
+  it("returns 0 when auth is undefined (no config)", () => {
+    expect(resolveAuthProfileCount({}, "main")).toBe(0);
+  });
+
+  it("returns 0 when auth is false", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "main", workspace: "~/w", auth: false }] },
+    };
+    expect(resolveAuthProfileCount(cfg, "main")).toBe(0);
+  });
+
+  it("returns 1 for single string profile", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "main", workspace: "~/w", auth: "anthropic:default" }] },
+    };
+    expect(resolveAuthProfileCount(cfg, "main")).toBe(1);
+  });
+
+  it("returns array length for multiple profiles", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "main", workspace: "~/w", auth: ["anthropic:k1", "anthropic:k2", "anthropic:k3"] },
+        ],
+      },
+    };
+    expect(resolveAuthProfileCount(cfg, "main")).toBe(3);
+  });
+
+  it("returns 0 for empty array", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "main", workspace: "~/w", auth: [] }] },
+    };
+    expect(resolveAuthProfileCount(cfg, "main")).toBe(0);
+  });
+
+  it("resolves from defaults when agent has no auth", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { auth: ["anthropic:d1", "anthropic:d2"] },
+        list: [{ id: "main", workspace: "~/w" }],
+      },
+    };
+    expect(resolveAuthProfileCount(cfg, "main")).toBe(2);
   });
 });

--- a/src/auth/env-injection.ts
+++ b/src/auth/env-injection.ts
@@ -85,6 +85,24 @@ function pickRoundRobin(agentId: string, profiles: string[]): string | undefined
 }
 
 /**
+ * Return the number of auth profiles configured for an agent.
+ *
+ * - `auth: false` or `undefined` → 0
+ * - `auth: "profile-id"` → 1
+ * - `auth: ["id1", "id2"]` → N
+ */
+export function resolveAuthProfileCount(cfg: RemoteClawConfig, agentId: string): number {
+  const auth = resolveAgentAuth(cfg, agentId);
+  if (auth === false || auth === undefined) {
+    return 0;
+  }
+  if (typeof auth === "string") {
+    return 1;
+  }
+  return auth.length;
+}
+
+/**
  * Resolve per-agent auth profile(s) to env vars for CLI subprocess injection.
  *
  * - `auth: false` → no injection (returns `undefined`)

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -9,7 +9,6 @@ import {
 } from "../../agents/agent-helpers.js";
 import { resolveChannelMessageToolHints } from "../../agents/channel-tools.js";
 import { resolveUserTimezone } from "../../agents/date-time.js";
-import { resolveAuthEnv } from "../../auth/env-injection.js";
 import { resolveGatewayPort } from "../../config/paths.js";
 import {
   resolveSessionTranscriptPath,
@@ -19,6 +18,7 @@ import {
 import { resolveGatewayCredentialsFromConfig } from "../../gateway/credentials.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
+import { withAuthKeyRetry } from "../../middleware/auth-key-retry.js";
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
 import {
   resolveCliRuntimeArgs,
@@ -284,25 +284,6 @@ export async function runAgentTurnWithFallback(params: {
         const cfg = params.followupRun.run.config;
         const baseRuntimeEnv = resolveCliRuntimeEnv(cfg);
 
-        // Resolve auth profile → env vars for credential injection.
-        // Auth profile takes priority over runtimeEnv (highest precedence).
-        const authEnv = await resolveAuthEnv({
-          cfg,
-          agentId: params.followupRun.run.agentId,
-          agentDir: params.followupRun.run.agentDir,
-        });
-        const runtimeEnv = authEnv ? { ...baseRuntimeEnv, ...authEnv } : baseRuntimeEnv;
-
-        const bridge = new ChannelBridge({
-          provider: resolveCliRuntimeProvider(cfg),
-          sessionMap,
-          gatewayUrl: resolveGatewayUrlFromConfig(cfg),
-          gatewayToken: resolveGatewayTokenFromConfig(cfg),
-          workspaceDir: params.followupRun.run.workspaceDir,
-          runtimeArgs: resolveCliRuntimeArgs(cfg),
-          runtimeEnv,
-        });
-
         const messageToolHints = resolveChannelMessageToolHints({
           cfg,
           channel: params.sessionCtx.Provider?.trim(),
@@ -380,12 +361,36 @@ export async function runAgentTurnWithFallback(params: {
             : undefined,
         };
 
-        const delivery = await bridge.handle(message, callbacks, params.opts?.abortSignal);
+        // Execute with auth key retry — rotates to next profile on rate-limit/auth errors.
+        const delivery = await withAuthKeyRetry<AgentDeliveryResult>(
+          {
+            cfg,
+            agentId: params.followupRun.run.agentId,
+            agentDir: params.followupRun.run.agentDir,
+            baseEnv: baseRuntimeEnv,
+          },
+          async (runtimeEnv) => {
+            const bridge = new ChannelBridge({
+              provider: resolveCliRuntimeProvider(cfg),
+              sessionMap,
+              gatewayUrl: resolveGatewayUrlFromConfig(cfg),
+              gatewayToken: resolveGatewayTokenFromConfig(cfg),
+              workspaceDir: params.followupRun.run.workspaceDir,
+              runtimeArgs: resolveCliRuntimeArgs(cfg),
+              runtimeEnv,
+            });
 
-        // Complete runtime failure: throw so the catch block can handle it.
-        if (delivery.error && delivery.payloads.length === 0) {
-          throw new Error(delivery.error);
-        }
+            const result = await bridge.handle(message, callbacks, params.opts?.abortSignal);
+
+            // Complete runtime failure: re-throw for retry or outer catch handling.
+            if (result.error && result.payloads.length === 0) {
+              throw new Error(result.error);
+            }
+
+            return result;
+          },
+          (result) => result.error,
+        );
 
         // Emit assistant text event for TUI/WebSocket clients (CLI backends don't
         // stream assistant events, so we emit one with the final text).

--- a/src/middleware/auth-key-retry.test.ts
+++ b/src/middleware/auth-key-retry.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { _resetRoundRobinState } from "../auth/env-injection.js";
+import type { AuthProfileStore } from "../auth/types.js";
+import type { RemoteClawConfig } from "../config/config.js";
+import { withAuthKeyRetry } from "./auth-key-retry.js";
+
+afterEach(() => {
+  _resetRoundRobinState();
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+type FakeResult = { text: string; error?: string };
+
+const makeStore = (
+  profiles: Record<string, { provider: string; key: string }>,
+): AuthProfileStore => ({
+  version: 1,
+  profiles: Object.fromEntries(
+    Object.entries(profiles).map(([id, p]) => [
+      id,
+      { type: "api_key" as const, provider: p.provider, key: p.key },
+    ]),
+  ),
+});
+
+const multiKeyCfg: RemoteClawConfig = {
+  agents: {
+    list: [
+      {
+        id: "main",
+        workspace: "~/w",
+        auth: ["anthropic:key1", "anthropic:key2", "anthropic:key3"],
+      },
+    ],
+  },
+};
+
+const multiKeyStore = makeStore({
+  "anthropic:key1": { provider: "anthropic", key: "sk-1" },
+  "anthropic:key2": { provider: "anthropic", key: "sk-2" },
+  "anthropic:key3": { provider: "anthropic", key: "sk-3" },
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("withAuthKeyRetry", () => {
+  it("rate-limit error with multi-key config triggers retry with next key", async () => {
+    const envsSeen: Record<string, string>[] = [];
+    let callCount = 0;
+
+    const result = await withAuthKeyRetry<FakeResult>(
+      { cfg: multiKeyCfg, agentId: "main", baseEnv: {}, store: multiKeyStore },
+      async (env) => {
+        envsSeen.push({ ...env });
+        callCount++;
+        if (callCount === 1) {
+          throw new Error("rate limit exceeded");
+        }
+        return { text: "ok" };
+      },
+      (r) => r.error,
+    );
+
+    expect(callCount).toBe(2);
+    expect(result.text).toBe("ok");
+    // First call uses key1, second uses key2 (round-robin)
+    expect(envsSeen[0]).toEqual({ ANTHROPIC_API_KEY: "sk-1" });
+    expect(envsSeen[1]).toEqual({ ANTHROPIC_API_KEY: "sk-2" });
+  });
+
+  it("retry succeeds with second key — normal response returned", async () => {
+    let callCount = 0;
+
+    const result = await withAuthKeyRetry<FakeResult>(
+      { cfg: multiKeyCfg, agentId: "main", baseEnv: {}, store: multiKeyStore },
+      async () => {
+        callCount++;
+        if (callCount === 1) {
+          // Return result with error (not thrown) — e.g. partial failure
+          return { text: "", error: "429 Too Many Requests" };
+        }
+        return { text: "success from key2" };
+      },
+      (r) => r.error,
+    );
+
+    expect(result.text).toBe("success from key2");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("all keys fail — error surfaced to user", async () => {
+    let callCount = 0;
+
+    const result = await withAuthKeyRetry<FakeResult>(
+      { cfg: multiKeyCfg, agentId: "main", baseEnv: {}, store: multiKeyStore },
+      async () => {
+        callCount++;
+        return { text: "", error: "rate limit exceeded" };
+      },
+      (r) => r.error,
+    );
+
+    // All 3 keys attempted, last error result returned
+    expect(callCount).toBe(3);
+    expect(result.error).toBe("rate limit exceeded");
+  });
+
+  it("all keys fail with thrown errors — last error re-thrown", async () => {
+    let callCount = 0;
+
+    await expect(
+      withAuthKeyRetry<FakeResult>(
+        { cfg: multiKeyCfg, agentId: "main", baseEnv: {}, store: multiKeyStore },
+        async () => {
+          callCount++;
+          throw new Error("HTTP 401 Unauthorized");
+        },
+        (r) => r.error,
+      ),
+    ).rejects.toThrow("HTTP 401 Unauthorized");
+
+    expect(callCount).toBe(3);
+  });
+
+  it("single key config — no retry attempted", async () => {
+    const singleKeyCfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", workspace: "~/w", auth: "anthropic:key1" }],
+      },
+    };
+    let callCount = 0;
+
+    await expect(
+      withAuthKeyRetry<FakeResult>(
+        { cfg: singleKeyCfg, agentId: "main", baseEnv: {}, store: multiKeyStore },
+        async () => {
+          callCount++;
+          throw new Error("rate limit exceeded");
+        },
+        (r) => r.error,
+      ),
+    ).rejects.toThrow("rate limit exceeded");
+
+    expect(callCount).toBe(1);
+  });
+
+  it("auth: false — no retry attempted", async () => {
+    const noAuthCfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", workspace: "~/w", auth: false }],
+      },
+    };
+    let callCount = 0;
+
+    await expect(
+      withAuthKeyRetry<FakeResult>(
+        { cfg: noAuthCfg, agentId: "main", baseEnv: {}, store: multiKeyStore },
+        async () => {
+          callCount++;
+          throw new Error("rate limit exceeded");
+        },
+        (r) => r.error,
+      ),
+    ).rejects.toThrow("rate limit exceeded");
+
+    expect(callCount).toBe(1);
+  });
+
+  it("retry count never exceeds number of configured keys", async () => {
+    const twoKeyCfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", workspace: "~/w", auth: ["anthropic:key1", "anthropic:key2"] }],
+      },
+    };
+    const twoKeyStore = makeStore({
+      "anthropic:key1": { provider: "anthropic", key: "sk-1" },
+      "anthropic:key2": { provider: "anthropic", key: "sk-2" },
+    });
+    let callCount = 0;
+
+    const result = await withAuthKeyRetry<FakeResult>(
+      { cfg: twoKeyCfg, agentId: "main", baseEnv: {}, store: twoKeyStore },
+      async () => {
+        callCount++;
+        return { text: "", error: "quota exceeded" };
+      },
+      (r) => r.error,
+    );
+
+    // Exactly 2 attempts (one per key), not more
+    expect(callCount).toBe(2);
+    expect(result.error).toBe("quota exceeded");
+  });
+
+  it("non-rotatable errors are not retried", async () => {
+    let callCount = 0;
+
+    await expect(
+      withAuthKeyRetry<FakeResult>(
+        { cfg: multiKeyCfg, agentId: "main", baseEnv: {}, store: multiKeyStore },
+        async () => {
+          callCount++;
+          throw new Error("context length exceeded");
+        },
+        (r) => r.error,
+      ),
+    ).rejects.toThrow("context length exceeded");
+
+    // Only one attempt — context overflow is not auth-rotatable
+    expect(callCount).toBe(1);
+  });
+
+  it("merges auth env with base env", async () => {
+    let capturedEnv: Record<string, string> | undefined;
+
+    await withAuthKeyRetry<FakeResult>(
+      {
+        cfg: multiKeyCfg,
+        agentId: "main",
+        baseEnv: { NODE_ENV: "test", EXISTING: "value" },
+        store: multiKeyStore,
+      },
+      async (env) => {
+        capturedEnv = env;
+        return { text: "ok" };
+      },
+      (r) => r.error,
+    );
+
+    expect(capturedEnv).toEqual({
+      NODE_ENV: "test",
+      EXISTING: "value",
+      ANTHROPIC_API_KEY: "sk-1",
+    });
+  });
+
+  it("passes base env when no auth is configured", async () => {
+    const noAuthCfg: RemoteClawConfig = {};
+    let capturedEnv: Record<string, string> | undefined;
+
+    await withAuthKeyRetry<FakeResult>(
+      { cfg: noAuthCfg, agentId: "main", baseEnv: { BASE: "env" } },
+      async (env) => {
+        capturedEnv = env;
+        return { text: "ok" };
+      },
+      (r) => r.error,
+    );
+
+    expect(capturedEnv).toEqual({ BASE: "env" });
+  });
+});

--- a/src/middleware/auth-key-retry.ts
+++ b/src/middleware/auth-key-retry.ts
@@ -1,0 +1,96 @@
+/**
+ * Auth key retry — rotates to the next auth profile on rate-limit / auth errors.
+ *
+ * When an agent has multiple auth profiles configured (`auth: ["k1", "k2"]`),
+ * a rate-limit or auth failure triggers a retry with the next key in the
+ * rotation. Each key is tried at most once per invocation.
+ */
+
+import { resolveAuthEnv, resolveAuthProfileCount } from "../auth/env-injection.js";
+import type { AuthProfileStore } from "../auth/types.js";
+import type { RemoteClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { isAuthRotatableError } from "./error-classifier.js";
+
+const log = createSubsystemLogger("auth-retry");
+
+export type AuthKeyRetryOptions = {
+  cfg: RemoteClawConfig;
+  agentId: string;
+  agentDir?: string;
+  baseEnv?: Record<string, string>;
+  store?: AuthProfileStore;
+};
+
+/**
+ * Execute a callback with automatic auth key retry on rate-limit / auth errors.
+ *
+ * - `auth: false` / `undefined` / single key → one attempt, no retry.
+ * - `auth: ["k1", "k2", ...]` → up to `N` attempts (one per key).
+ *
+ * The `execute` callback receives a merged env (base + auth). On a rate-limit
+ * or auth error (thrown or returned in the result), the next profile is
+ * selected via round-robin and the callback is retried.
+ *
+ * @param options  Auth config and base env.
+ * @param execute  Callback that runs the agent with the given env.
+ * @param getErrorMessage  Extracts an error string from a non-thrown result
+ *                         (e.g. `result.error`). Return `undefined` if no error.
+ */
+export async function withAuthKeyRetry<T>(
+  options: AuthKeyRetryOptions,
+  execute: (env: Record<string, string>) => Promise<T>,
+  getErrorMessage: (result: T) => string | undefined,
+): Promise<T> {
+  const profileCount = resolveAuthProfileCount(options.cfg, options.agentId);
+  const maxAttempts = Math.max(1, profileCount);
+
+  let lastResult: T | undefined;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const authEnv = await resolveAuthEnv({
+      cfg: options.cfg,
+      agentId: options.agentId,
+      agentDir: options.agentDir,
+      store: options.store,
+    });
+    const env = authEnv
+      ? { ...options.baseEnv, ...authEnv }
+      : options.baseEnv
+        ? { ...options.baseEnv }
+        : {};
+
+    try {
+      const result = await execute(env);
+
+      // Check for rate-limit / auth errors returned in the result (not thrown).
+      const errorMsg = getErrorMessage(result);
+      if (errorMsg && isAuthRotatableError(errorMsg) && attempt + 1 < maxAttempts) {
+        log.info(
+          `Auth key rate-limited (attempt ${attempt + 1}/${maxAttempts}), rotating to next profile`,
+        );
+        lastResult = result;
+        continue;
+      }
+
+      return result;
+    } catch (err) {
+      lastError = err;
+      const errMsg = err instanceof Error ? err.message : String(err);
+      if (isAuthRotatableError(errMsg) && attempt + 1 < maxAttempts) {
+        log.info(
+          `Auth key rate-limited (attempt ${attempt + 1}/${maxAttempts}), rotating to next profile`,
+        );
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  // All keys exhausted — return the last result or re-throw the last error.
+  if (lastResult !== undefined) {
+    return lastResult;
+  }
+  throw lastError;
+}

--- a/src/middleware/error-classifier.test.ts
+++ b/src/middleware/error-classifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { type ErrorCategory, classifyError } from "./error-classifier.js";
+import { type ErrorCategory, classifyError, isAuthRotatableError } from "./error-classifier.js";
 
 describe("classifyError", () => {
   describe("retryable classification", () => {
@@ -172,6 +172,87 @@ describe("classifyError", () => {
         expect(result).not.toBe("timeout");
         expect(result).not.toBe("aborted");
       }
+    });
+  });
+});
+
+describe("isAuthRotatableError", () => {
+  describe("rate-limit patterns", () => {
+    it.each([
+      ["rate limit", "rate limit exceeded"],
+      ["rate_limit", "rate_limit exceeded"],
+      ["Rate Limit", "Rate Limit Error"],
+      ["ratelimit", "ratelimit hit"],
+    ])("detects rate-limit variant %s", (_label, message) => {
+      expect(isAuthRotatableError(message)).toBe(true);
+    });
+
+    it("detects HTTP 429", () => {
+      expect(isAuthRotatableError("HTTP 429 Too Many Requests")).toBe(true);
+    });
+
+    it("does not match 429 embedded in other numbers", () => {
+      expect(isAuthRotatableError("error code 14291")).toBe(false);
+    });
+
+    it.each([
+      ["quota exceeded", "quota exceeded for today"],
+      ["quota_exceeded", "quota_exceeded: try again later"],
+    ])("detects quota pattern %s", (_label, message) => {
+      expect(isAuthRotatableError(message)).toBe(true);
+    });
+
+    it.each([
+      ["resource exhausted", "resource exhausted: billing limit"],
+      ["resource_exhausted", "resource_exhausted error"],
+    ])("detects resource exhausted pattern %s", (_label, message) => {
+      expect(isAuthRotatableError(message)).toBe(true);
+    });
+
+    it("detects too many requests", () => {
+      expect(isAuthRotatableError("too many requests")).toBe(true);
+    });
+  });
+
+  describe("auth failure patterns", () => {
+    it("detects HTTP 401", () => {
+      expect(isAuthRotatableError("HTTP 401 Unauthorized")).toBe(true);
+    });
+
+    it("does not match 401 embedded in other numbers", () => {
+      expect(isAuthRotatableError("error code 14011")).toBe(false);
+    });
+
+    it.each([
+      ["unauthorized", "unauthorized access denied"],
+      ["Unauthorized", "Unauthorized request"],
+    ])("detects %s", (_label, message) => {
+      expect(isAuthRotatableError(message)).toBe(true);
+    });
+
+    it.each([
+      ["invalid key", "invalid key provided"],
+      ["invalid_key", "invalid_key: check your API key"],
+    ])("detects %s", (_label, message) => {
+      expect(isAuthRotatableError(message)).toBe(true);
+    });
+  });
+
+  describe("non-rotatable errors", () => {
+    it("does not match generic errors", () => {
+      expect(isAuthRotatableError("something went wrong")).toBe(false);
+    });
+
+    it("does not match context overflow", () => {
+      expect(isAuthRotatableError("context length exceeded")).toBe(false);
+    });
+
+    it("does not match network errors", () => {
+      expect(isAuthRotatableError("ECONNRESET")).toBe(false);
+    });
+
+    it("does not match empty string", () => {
+      expect(isAuthRotatableError("")).toBe(false);
     });
   });
 });

--- a/src/middleware/error-classifier.ts
+++ b/src/middleware/error-classifier.ts
@@ -31,6 +31,33 @@ const fatalAuthPatterns: readonly RegExp[] = [
 ];
 
 /**
+ * Rate-limit and auth failure patterns that may benefit from key rotation.
+ *
+ * Includes rate-limit indicators (429, quota) and auth failures
+ * (401, invalid key) — a different API key might succeed in either case.
+ */
+const authRotatablePatterns: readonly RegExp[] = [
+  // Rate-limit patterns
+  /rate.?limit/i,
+  /\b429\b/,
+  /quota.?exceeded/i,
+  /resource.?exhausted/i,
+  /too many requests/i,
+  // Auth failure patterns (a different key might work)
+  /\b401\b/,
+  /unauthorized/i,
+  /invalid.?key/i,
+];
+
+/**
+ * Test whether an error message indicates a rate-limit or auth failure
+ * that could be resolved by rotating to a different API key.
+ */
+export function isAuthRotatableError(message: string): boolean {
+  return authRotatablePatterns.some((pattern) => pattern.test(message));
+}
+
+/**
  * Classify an error message string into an actionable category.
  *
  * Uses first-match-wins semantics across ordered pattern arrays:


### PR DESCRIPTION
## Summary

- When an agent has multiple auth profiles (`auth: ["key1", "key2"]`), rate-limit or auth errors now trigger automatic retry with the next key in the rotation
- Each key is tried at most once per message — retry budget equals number of configured keys
- Single-key or `auth: false` agents execute once with no retry (existing behavior preserved)

## Changes

- **`src/middleware/error-classifier.ts`** — Add `isAuthRotatableError()` detecting rate-limit (429, quota exceeded, resource exhausted, too many requests) and auth failures (401, unauthorized, invalid key)
- **`src/auth/env-injection.ts`** — Add `resolveAuthProfileCount()` returning the number of configured auth profiles for an agent
- **`src/middleware/auth-key-retry.ts`** *(new)* — `withAuthKeyRetry()` orchestrator wrapping execute callbacks with automatic retry on rotatable errors, capped at one attempt per key
- **`src/auto-reply/reply/agent-runner-execution.ts`** — Replace direct `resolveAuthEnv` + bridge creation with `withAuthKeyRetry` wrapper

## Test plan

- [x] Rate-limit error with multi-key config triggers retry with next key
- [x] Retry succeeds with second key → normal response returned
- [x] All keys fail → error surfaced to user
- [x] Single key config → no retry attempted
- [x] `auth: false` → no retry attempted
- [x] Retry count never exceeds number of configured keys
- [x] Non-rotatable errors (context overflow, network) are not retried
- [x] Auth env correctly merged with base env
- [x] All 8054 existing unit tests pass (no regressions)

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)