### PR TITLE
ci: rename docs workflow build job to avoid collision with required CI check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
+  docs-build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,7 +44,7 @@ jobs:
 
   deploy:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    needs: build
+    needs: docs-build
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary

- Renames the `build` job in `.github/workflows/docs.yml` to `docs-build` to avoid collision with the required CI `build` check
- Updates the `deploy` job's `needs` reference accordingly

Fixes #428

## Test plan

- [ ] CI passes (the docs workflow's job no longer shadows the required `build` check)
- [ ] Docs workflow still triggers correctly on `docs/**` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)