### PR TITLE
fix(import): clear stale wizard section during OpenClaw import

### DIFF
--- a/src/commands/import.test.ts
+++ b/src/commands/import.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
 import {
+  clearWizardSection,
   detectOpenClawInstallation,
   discoverSourceAuthProfileIds,
   importCommand,
@@ -301,6 +302,46 @@ describe("stripUnrecognizedConfigKeys", () => {
   it("returns non-JSON content unchanged", () => {
     const input = "not valid json {{{";
     expect(stripUnrecognizedConfigKeys(input)).toBe(input);
+  });
+});
+
+describe("clearWizardSection", () => {
+  it("removes wizard section from config", () => {
+    const input = JSON.stringify({
+      gateway: { port: 18789 },
+      wizard: {
+        lastRunAt: "2025-01-01T00:00:00Z",
+        lastRunVersion: "2026.2.6-3",
+        lastRunCommit: "abc123",
+        lastRunCommand: "openclaw onboard",
+        lastRunMode: "full",
+      },
+    });
+    const result = JSON.parse(clearWizardSection(input));
+    expect(result.wizard).toBeUndefined();
+    expect(result.gateway.port).toBe(18789);
+  });
+
+  it("returns unchanged when no wizard section exists", () => {
+    const input = JSON.stringify({
+      gateway: { port: 18789 },
+    });
+    expect(clearWizardSection(input)).toBe(input);
+  });
+
+  it("returns non-JSON content unchanged", () => {
+    const input = "not valid json {{{";
+    expect(clearWizardSection(input)).toBe(input);
+  });
+
+  it("handles empty wizard section", () => {
+    const input = JSON.stringify({
+      gateway: { port: 18789 },
+      wizard: {},
+    });
+    const result = JSON.parse(clearWizardSection(input));
+    expect(result.wizard).toBeUndefined();
+    expect(result.gateway.port).toBe(18789);
   });
 });
 
@@ -761,6 +802,31 @@ describe("importCommand", () => {
     const written = await fsp.readFile(path.join(targetDir, "remoteclaw.json"), "utf-8");
     const parsed = JSON.parse(written);
     expect(parsed.agents.defaults.auth).toBe("anthropic:default");
+  });
+
+  it("clears wizard section from main config during import", async () => {
+    const configContent = JSON.stringify({
+      gateway: { port: 18789 },
+      agents: { list: [{ id: "main", workspace: "~/ws" }] },
+      wizard: {
+        lastRunAt: "2025-01-01T00:00:00Z",
+        lastRunVersion: "2026.2.6-3",
+        lastRunCommit: "abc123",
+        lastRunCommand: "openclaw onboard",
+        lastRunMode: "full",
+      },
+    });
+    await fsp.writeFile(path.join(sourceDir, "openclaw.json"), configContent);
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    const written = await fsp.readFile(path.join(targetDir, "remoteclaw.json"), "utf-8");
+    const parsed = JSON.parse(written);
+    expect(parsed.wizard).toBeUndefined();
+    expect(parsed.gateway.port).toBe(18789);
   });
 
   it("does not set auth when no auth profiles exist in source", async () => {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -280,6 +280,37 @@ export function stripUnrecognizedConfigKeys(jsonContent: string): string {
 }
 
 /**
+ * Remove the `wizard` section from imported config.
+ *
+ * OpenClaw configs carry wizard state (`wizard.lastRunVersion`,
+ * `wizard.lastRunCommand`, etc.) that reflects OpenClaw's wizard history.
+ * This is misleading after import — RemoteClaw's wizard has never run.
+ * Clearing the section ensures the user gets a fresh wizard experience.
+ */
+export function clearWizardSection(jsonContent: string): string {
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(jsonContent);
+  } catch {
+    return jsonContent;
+  }
+
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    return jsonContent;
+  }
+
+  if (!("wizard" in config)) {
+    return jsonContent;
+  }
+
+  delete config.wizard;
+
+  const indentMatch = jsonContent.match(/^(\s+)"/m);
+  const indent = indentMatch?.[1] ?? "  ";
+  return JSON.stringify(config, null, indent) + "\n";
+}
+
+/**
  * Materialize implicit OpenClaw workspace defaults into the main config JSON.
  *
  * OpenClaw had a three-tier workspace resolution chain that was removed in
@@ -562,7 +593,9 @@ async function copyDirectory(params: {
         const isMainConfig = entry.name === OPENCLAW_CONFIG_FILENAME;
         const final = isMainConfig
           ? materializeAuthDefaults(
-              materializeWorkspaceDefaults(stripUnrecognizedConfigKeys(transformed)),
+              materializeWorkspaceDefaults(
+                clearWizardSection(stripUnrecognizedConfigKeys(transformed)),
+              ),
               params.discoveredAuthProfileIds,
             )
           : transformed;


### PR DESCRIPTION
## Summary

- Add `clearWizardSection` transform to the import pipeline that removes the `wizard` section from imported OpenClaw configs
- OpenClaw wizard state (`lastRunVersion`, `lastRunCommand`, etc.) is misleading after import — RemoteClaw's wizard has never run
- Wired into the transform chain after `stripUnrecognizedConfigKeys` and before `materializeWorkspaceDefaults`

Closes #436

## Test plan

- [x] Unit tests for `clearWizardSection` (removes section, no-op when absent, non-JSON passthrough, empty wizard)
- [x] Integration test verifying full `importCommand` pipeline clears wizard state
- [x] All 67 existing import tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)