### PR TITLE
feat(middleware): add debug logging across middleware layer

### DIFF
--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ReplyPayload } from "../auto-reply/types.js";
+import { logDebug } from "../logger.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { DeliveryAdapter } from "./delivery-adapter.js";
 import { classifyError } from "./error-classifier.js";
@@ -104,7 +105,13 @@ export class ChannelBridge {
   ): Promise<AgentDeliveryResult> {
     // 1. Session lookup
     const sessionKey = buildSessionKey(message);
+    logDebug(
+      `[channel-bridge] handle: channel=${message.provider} from=${message.from} channelId=${message.channelId} threadId=${message.replyToId ?? "none"} agentId=${message.agentId ?? "default"} media=${message.mediaUrls?.length ?? 0}`,
+    );
     const existingSessionId = await this.#sessionMap.get(sessionKey);
+    logDebug(
+      `[channel-bridge] session lookup: key=${formatSessionKeyString(sessionKey)} ${existingSessionId ? `hit=${existingSessionId}` : "miss"}`,
+    );
     const hookRunner = getGlobalHookRunner();
 
     // Hook: session_resumed — fires when reusing an existing session
@@ -145,6 +152,7 @@ export class ChannelBridge {
       const mcpServers = this.#buildMcpConfig(message, sessionKey, sideEffectsFile);
 
       // 4. Runtime params
+      logDebug(`[channel-bridge] creating runtime: provider=${this.#provider}`);
       const runtime = createCliRuntime(this.#provider);
       let workspaceDir = this.#workspaceDir;
       let hookEnv: Record<string, string> | undefined;
@@ -169,9 +177,15 @@ export class ChannelBridge {
           },
         );
         if (spawnResult?.workspaceDir) {
+          logDebug(
+            `[channel-bridge] hook overrode workspaceDir: ${this.#workspaceDir} -> ${spawnResult.workspaceDir}`,
+          );
           workspaceDir = spawnResult.workspaceDir;
         }
         if (spawnResult?.env) {
+          logDebug(
+            `[channel-bridge] hook injected env keys: ${Object.keys(spawnResult.env).join(", ")}`,
+          );
           hookEnv = spawnResult.env;
         }
       }
@@ -180,6 +194,11 @@ export class ChannelBridge {
       const media = message.mediaUrls?.length
         ? await resolveMediaAttachments(message.mediaUrls, invocationDir)
         : undefined;
+      if (media?.length) {
+        logDebug(
+          `[channel-bridge] resolved ${media.length}/${message.mediaUrls!.length} media attachments`,
+        );
+      }
 
       // 6-7. Execute + stream events through DeliveryAdapter
       const adapter = new DeliveryAdapter(
@@ -214,6 +233,9 @@ export class ChannelBridge {
         // 7. Error classification
         const errMsg = String(err);
         const category = classifyError(errMsg);
+        logDebug(
+          `[channel-bridge] runtime threw: category=${category} error=${errMsg.slice(0, 500)}`,
+        );
         lastError = errMsg;
         payloads = [];
         runResult = {
@@ -230,9 +252,15 @@ export class ChannelBridge {
       } catch {
         mcp = { ...EMPTY_SIDE_EFFECTS };
       }
+      logDebug(
+        `[channel-bridge] side effects: sentTexts=${mcp.sentTexts.length} sentMedia=${mcp.sentMediaUrls.length} cronAdds=${mcp.cronAdds}`,
+      );
 
       // 9. Session update
       if (runResult?.sessionId) {
+        logDebug(
+          `[channel-bridge] session update: key=${formatSessionKeyString(sessionKey)} sessionId=${runResult.sessionId}`,
+        );
         await this.#sessionMap.set(sessionKey, runResult.sessionId);
       }
 
@@ -278,6 +306,9 @@ export class ChannelBridge {
       }
 
       // 10. Return result
+      logDebug(
+        `[channel-bridge] complete: runId=${runId} duration=${finalResult.durationMs}ms payloads=${payloads.length} error=${lastError ?? "none"}`,
+      );
       return {
         payloads,
         run: finalResult,

--- a/src/middleware/cli-runtime-base.ts
+++ b/src/middleware/cli-runtime-base.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
+import { logDebug } from "../logger.js";
 import type {
   AgentDoneEvent,
   AgentErrorEvent,
@@ -54,12 +55,28 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
     if (params.extraArgs && params.extraArgs.length > 0) {
       args.push(...params.extraArgs);
     }
-    const env = { ...process.env, ...this.buildEnv(params), ...params.env };
+    const runtimeEnv = this.buildEnv(params);
+    const callerEnv = params.env ?? {};
+    const env = { ...process.env, ...runtimeEnv, ...callerEnv };
+
+    logDebug(
+      `[agent-runtime] spawn: ${this.command} ${args.map((a) => JSON.stringify(a)).join(" ")}`,
+    );
+    logDebug(`[agent-runtime] cwd: ${params.workingDirectory ?? process.cwd()}`);
+    if (Object.keys(runtimeEnv).length > 0) {
+      logDebug(`[agent-runtime] runtime env keys: ${Object.keys(runtimeEnv).join(", ")}`);
+    }
+    if (Object.keys(callerEnv).length > 0) {
+      logDebug(`[agent-runtime] caller env keys: ${Object.keys(callerEnv).join(", ")}`);
+    }
+
     const child = spawn(this.command, args, {
       cwd: params.workingDirectory,
       env,
       stdio: ["pipe", "pipe", "pipe"],
     });
+
+    logDebug(`[agent-runtime] spawned pid=${child.pid}`);
 
     const startMs = Date.now();
     const stderrChunks: string[] = [];
@@ -99,6 +116,7 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
       }
       watchdogTimer = setTimeout(() => {
         watchdogFired = true;
+        logDebug(`[agent-runtime] pid=${child.pid}: watchdog timeout after ${this.timeoutMs}ms`);
         killWithEscalation();
       }, this.timeoutMs);
     };
@@ -164,6 +182,9 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
       params.prompt.length > CLIRuntimeBase.STDIN_PROMPT_THRESHOLD &&
       child.stdin
     ) {
+      logDebug(
+        `[agent-runtime] pid=${child.pid}: delivering prompt via stdin (${params.prompt.length} chars)`,
+      );
       child.stdin.write(params.prompt);
     }
     // Always close stdin so CLIs that read from stdin get EOF and don't hang.
@@ -172,6 +193,7 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
     // ── Abort signal wiring (after event infrastructure is ready) ────
     const onAbort = () => {
       aborted = true;
+      logDebug(`[agent-runtime] pid=${child.pid}: abort signal received`);
       killWithEscalation();
     };
     if (params.abortSignal) {
@@ -210,11 +232,15 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
     }
 
     // ── Wait for process to fully exit ───────────────────────────────
-    const { code: exitCode } = await exitPromise;
+    const { code: exitCode, signal: exitSignal } = await exitPromise;
     if (escalationTimer !== undefined) {
       clearTimeout(escalationTimer);
     }
     const durationMs = Date.now() - startMs;
+
+    logDebug(
+      `[agent-runtime] pid=${child.pid}: exited code=${exitCode} signal=${exitSignal} duration=${durationMs}ms`,
+    );
 
     // ── Surface stderr when CLI exits with error ─────────────────────
     const stderr = stderrChunks.join("");

--- a/src/middleware/delivery-adapter.ts
+++ b/src/middleware/delivery-adapter.ts
@@ -1,4 +1,5 @@
 import type { ReplyPayload } from "../auto-reply/types.js";
+import { logDebug } from "../logger.js";
 import type { AgentEvent, BridgeCallbacks } from "./types.js";
 
 /** Options for the delivery adapter. */
@@ -48,8 +49,10 @@ export class DeliveryAdapter {
     const payloads: ReplyPayload[] = [];
     /** Track media delivered via streaming events to avoid duplicates from result.media. */
     const deliveredMediaKeys = new Set<string>();
+    let eventCount = 0;
 
     for await (const event of events) {
+      eventCount++;
       switch (event.type) {
         case "text": {
           if (event.text === "") {
@@ -126,6 +129,9 @@ export class DeliveryAdapter {
       payloads.push(payload);
     }
 
+    logDebug(
+      `[delivery-adapter] processed ${eventCount} events into ${payloads.length} payloads (chunkLimit=${this.chunkLimit})`,
+    );
     return payloads;
   }
 }

--- a/src/middleware/error-classifier.ts
+++ b/src/middleware/error-classifier.ts
@@ -1,3 +1,5 @@
+import { logDebug } from "../logger.js";
+
 /** Error categories for CLI subprocess failures. */
 export type ErrorCategory = "retryable" | "fatal" | "context_overflow" | "timeout" | "aborted";
 
@@ -71,18 +73,22 @@ export function isAuthRotatableError(message: string): boolean {
 export function classifyError(message: string): ErrorCategory {
   for (const pattern of retryablePatterns) {
     if (pattern.test(message)) {
+      logDebug(`[error-classifier] classified as retryable: ${message.slice(0, 200)}`);
       return "retryable";
     }
   }
   for (const pattern of contextOverflowPatterns) {
     if (pattern.test(message)) {
+      logDebug(`[error-classifier] classified as context_overflow: ${message.slice(0, 200)}`);
       return "context_overflow";
     }
   }
   for (const pattern of fatalAuthPatterns) {
     if (pattern.test(message)) {
+      logDebug(`[error-classifier] classified as fatal (auth): ${message.slice(0, 200)}`);
       return "fatal";
     }
   }
+  logDebug(`[error-classifier] classified as fatal (unmatched): ${message.slice(0, 200)}`);
   return "fatal";
 }

--- a/src/middleware/mcp-side-effects.ts
+++ b/src/middleware/mcp-side-effects.ts
@@ -1,4 +1,5 @@
 import { appendFile, readFile } from "node:fs/promises";
+import { logDebug } from "../logger.js";
 import type { McpMessageTarget, McpSideEffects } from "./types.js";
 
 // NDJSON side effect record types
@@ -75,6 +76,7 @@ export class McpSideEffectsWriter {
   }
 
   private async appendRecord(record: SideEffectRecord): Promise<void> {
+    logDebug(`[mcp-side-effects] recording: type=${record.type}`);
     await appendFile(this.filePath, JSON.stringify(record) + "\n", "utf-8");
   }
 }

--- a/src/middleware/media-resolver.ts
+++ b/src/middleware/media-resolver.ts
@@ -1,5 +1,6 @@
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { logDebug } from "../logger.js";
 import { fetchRemoteMedia } from "../media/fetch.js";
 import { detectMime, extensionForMime } from "../media/mime.js";
 import type { MediaAttachment } from "./types.js";
@@ -26,9 +27,13 @@ export async function resolveMediaAttachments(
     try {
       const attachment = await resolveOne(url, tempDir, index);
       if (attachment) {
+        logDebug(
+          `[media-resolver] resolved: url=${url} mime=${attachment.mimeType} path=${attachment.filePath}`,
+        );
         results.push(attachment);
       }
-    } catch {
+    } catch (err) {
+      logDebug(`[media-resolver] failed: url=${url} error=${String(err)}`);
       // Skip unresolvable media; don't block the entire message.
     }
   }

--- a/src/middleware/runtime-factory.ts
+++ b/src/middleware/runtime-factory.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { logDebug } from "../logger.js";
 import { ClaudeCliRuntime } from "./runtimes/claude.js";
 import { CodexCliRuntime } from "./runtimes/codex.js";
 import { GeminiCliRuntime } from "./runtimes/gemini.js";
@@ -21,10 +22,12 @@ const validatedCommands = new Set<string>();
  */
 function validateExecutable(command: string): void {
   if (validatedCommands.has(command)) {
+    logDebug(`[runtime-factory] executable already validated: ${command}`);
     return;
   }
   try {
     execFileSync("which", [command], { stdio: "ignore" });
+    logDebug(`[runtime-factory] executable validated: ${command}`);
     validatedCommands.add(command);
   } catch {
     throw new Error(
@@ -84,6 +87,7 @@ export function resolveCliRuntimeEnv(cfg?: {
 
 export function createCliRuntime(provider: string): AgentRuntime {
   const normalized = provider.trim().toLowerCase();
+  logDebug(`[runtime-factory] creating runtime: provider=${normalized}`);
 
   switch (normalized) {
     case "claude":

--- a/src/middleware/session-map.ts
+++ b/src/middleware/session-map.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { logDebug } from "../logger.js";
 
 /** Composite key for session lookup. */
 export type SessionKey = {
@@ -51,11 +52,16 @@ export class SessionMap {
     const compositeKey = formatKey(key);
     const entry = store[compositeKey];
     if (!entry) {
+      logDebug(`[session-map] get: key=${compositeKey} miss`);
       return undefined;
     }
     if (entry.lastAccessMs + this.#ttlMs < Date.now()) {
+      logDebug(
+        `[session-map] get: key=${compositeKey} expired (age=${Date.now() - entry.lastAccessMs}ms)`,
+      );
       return undefined;
     }
+    logDebug(`[session-map] get: key=${compositeKey} hit=${entry.sessionId}`);
     return entry.sessionId;
   }
 
@@ -65,13 +71,20 @@ export class SessionMap {
     const now = Date.now();
 
     // Evict all expired entries
+    let evicted = 0;
     for (const k of Object.keys(store)) {
       if (store[k].lastAccessMs + this.#ttlMs < now) {
         delete store[k];
+        evicted++;
       }
     }
+    if (evicted > 0) {
+      logDebug(`[session-map] evicted ${evicted} expired entries`);
+    }
 
-    store[formatKey(key)] = { sessionId, lastAccessMs: now };
+    const compositeKey = formatKey(key);
+    logDebug(`[session-map] set: key=${compositeKey} sessionId=${sessionId}`);
+    store[compositeKey] = { sessionId, lastAccessMs: now };
     await this.#writeStore(store);
   }
 
@@ -80,8 +93,10 @@ export class SessionMap {
     const store = await this.#readStore();
     const compositeKey = formatKey(key);
     if (!(compositeKey in store)) {
+      logDebug(`[session-map] delete: key=${compositeKey} not found`);
       return;
     }
+    logDebug(`[session-map] delete: key=${compositeKey}`);
     delete store[compositeKey];
     await this.#writeStore(store);
   }


### PR DESCRIPTION
## Summary

- Add `logDebug` calls across all middleware components (`cli-runtime-base`, `channel-bridge`, `runtime-factory`, `session-map`, `delivery-adapter`, `error-classifier`, `media-resolver`, `mcp-side-effects`) so that `REMOTECLAW_LOG_LEVEL=debug` surfaces the full request lifecycle
- Log spawn command/args/pid/cwd, session lookups (hit/miss/expired), media resolution, error classification, delivery stats, MCP side effects, watchdog/abort events, and exit codes
- Env vars logged by key name only (not values) to prevent leaking API keys and tokens

## Test plan

- [x] Type-check passes (`tsc --noEmit`)
- [x] All 558 middleware tests pass (`vitest run src/middleware/`)
- [ ] CI build + test jobs pass
- [ ] Manual: run with `REMOTECLAW_LOG_LEVEL=debug` and verify log output covers spawn → exit lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)