### PR TITLE
fix(import): stamp meta.lastTouchedVersion during OpenClaw import (#435)

### DIFF
--- a/src/commands/import.test.ts
+++ b/src/commands/import.test.ts
@@ -13,6 +13,7 @@ import {
   materializeAuthDefaults,
   materializeWorkspaceDefaults,
   resolveTargetFilename,
+  stampImportedConfigVersion,
   stripUnrecognizedConfigKeys,
   transformConfigContent,
 } from "./import.js";
@@ -615,6 +616,39 @@ describe("isImportableRootEntry", () => {
   });
 });
 
+describe("stampImportedConfigVersion", () => {
+  it("sets meta.lastTouchedVersion and meta.lastTouchedAt", () => {
+    const input = JSON.stringify({ gateway: { port: 18789 } });
+    const result = JSON.parse(stampImportedConfigVersion(input));
+    expect(result.meta.lastTouchedVersion).toEqual(expect.any(String));
+    expect(result.meta.lastTouchedVersion.length).toBeGreaterThan(0);
+    expect(result.meta.lastTouchedAt).toEqual(expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/));
+  });
+
+  it("overwrites existing meta.lastTouchedVersion from OpenClaw", () => {
+    const input = JSON.stringify({
+      gateway: { port: 18789 },
+      meta: { lastTouchedVersion: "2026.2.6-3", lastTouchedAt: "2025-01-01T00:00:00.000Z" },
+    });
+    const result = JSON.parse(stampImportedConfigVersion(input));
+    expect(result.meta.lastTouchedVersion).not.toBe("2026.2.6-3");
+    expect(result.meta.lastTouchedAt).not.toBe("2025-01-01T00:00:00.000Z");
+  });
+
+  it("preserves other meta fields", () => {
+    const input = JSON.stringify({
+      meta: { someOtherField: "keep-me", lastTouchedVersion: "old" },
+    });
+    const result = JSON.parse(stampImportedConfigVersion(input));
+    expect(result.meta.someOtherField).toBe("keep-me");
+  });
+
+  it("returns non-JSON content unchanged", () => {
+    const input = "not valid json {{{";
+    expect(stampImportedConfigVersion(input)).toBe(input);
+  });
+});
+
 describe("resolveTargetFilename", () => {
   it("renames openclaw.json to remoteclaw.json", () => {
     expect(resolveTargetFilename("openclaw.json")).toBe("remoteclaw.json");
@@ -964,6 +998,25 @@ describe("importCommand", () => {
     const written = await fsp.readFile(path.join(targetDir, "remoteclaw.json"), "utf-8");
     const parsed = JSON.parse(written);
     expect(parsed.agents.defaults).toBeUndefined();
+  });
+
+  it("stamps meta.lastTouchedVersion on main config during import", async () => {
+    const configContent = JSON.stringify({
+      gateway: { port: 18789 },
+      meta: { lastTouchedVersion: "2026.2.6-3", lastTouchedAt: "2025-01-01T00:00:00.000Z" },
+    });
+    await fsp.writeFile(path.join(sourceDir, "openclaw.json"), configContent);
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    const written = await fsp.readFile(path.join(targetDir, "remoteclaw.json"), "utf-8");
+    const parsed = JSON.parse(written);
+    expect(parsed.meta.lastTouchedVersion).not.toBe("2026.2.6-3");
+    expect(parsed.meta.lastTouchedVersion).toEqual(expect.any(String));
+    expect(parsed.meta.lastTouchedAt).not.toBe("2025-01-01T00:00:00.000Z");
   });
 
   it("handles nested directory structures with mixed file types", async () => {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -6,6 +6,7 @@ import { RemoteClawSchema } from "../config/zod-schema.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
+import { VERSION } from "../version.js";
 import { createClackPrompter } from "../wizard/clack-prompter.js";
 
 /**
@@ -538,6 +539,36 @@ export function materializeAuthDefaults(
 }
 
 /**
+ * Stamp `meta.lastTouchedVersion` and `meta.lastTouchedAt` on imported config JSON.
+ *
+ * OpenClaw configs carry the OpenClaw version in `meta.lastTouchedVersion`.
+ * After import, RemoteClaw is the last tool that wrote the config, so the
+ * version must be updated to prevent `warnIfConfigFromFuture()` from firing
+ * a spurious "newer RemoteClaw" warning.
+ */
+export function stampImportedConfigVersion(jsonContent: string): string {
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(jsonContent);
+  } catch {
+    return jsonContent;
+  }
+
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    return jsonContent;
+  }
+
+  const meta = (config.meta ?? {}) as Record<string, unknown>;
+  meta.lastTouchedVersion = VERSION;
+  meta.lastTouchedAt = new Date().toISOString();
+  config.meta = meta;
+
+  const indentMatch = jsonContent.match(/^(\s+)"/m);
+  const indent = indentMatch?.[1] ?? "  ";
+  return JSON.stringify(config, null, indent) + "\n";
+}
+
+/**
  * Determine the target filename for a source file.
  * Renames openclaw.json -> remoteclaw.json at any directory level.
  */
@@ -658,11 +689,13 @@ async function copyDirectory(params: {
         // Apply structural config transforms to the main config file
         const isMainConfig = entry.name === OPENCLAW_CONFIG_FILENAME;
         const final = isMainConfig
-          ? materializeAuthDefaults(
-              materializeWorkspaceDefaults(
-                clearWizardSection(stripUnrecognizedConfigKeys(transformed)),
+          ? stampImportedConfigVersion(
+              materializeAuthDefaults(
+                materializeWorkspaceDefaults(
+                  clearWizardSection(stripUnrecognizedConfigKeys(transformed)),
+                ),
+                params.discoveredAuthProfileIds,
               ),
-              params.discoveredAuthProfileIds,
             )
           : transformed;
         if (renames.length > 0 || final !== transformed) {


### PR DESCRIPTION
## Summary

- Add `stampImportedConfigVersion()` transform to the import pipeline that overwrites `meta.lastTouchedVersion` with the current RemoteClaw `VERSION` and `meta.lastTouchedAt` with the current timestamp
- Wire it as the outermost (final) transform in the main-config transform chain in `copyDirectory()`
- Prevents `warnIfConfigFromFuture()` from firing a spurious "newer RemoteClaw" warning after importing an OpenClaw config that carries a high OpenClaw version string (e.g. `2026.2.6-3`)

Closes #435

## Test plan

- [x] Unit tests for `stampImportedConfigVersion()`: sets version/timestamp, overwrites existing OpenClaw version, preserves other meta fields, handles non-JSON gracefully
- [x] Integration test: `importCommand` stamps version on main config during import
- [x] All 67 existing import tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)