### PR TITLE
fix(import): strip $schema field during OpenClaw import (#437)

### DIFF
--- a/src/commands/import.test.ts
+++ b/src/commands/import.test.ts
@@ -14,6 +14,7 @@ import {
   materializeWorkspaceDefaults,
   resolveTargetFilename,
   stampImportedConfigVersion,
+  stripSchemaField,
   stripUnrecognizedConfigKeys,
   transformConfigContent,
 } from "./import.js";
@@ -344,6 +345,40 @@ describe("clearWizardSection", () => {
     const result = JSON.parse(clearWizardSection(input));
     expect(result.wizard).toBeUndefined();
     expect(result.gateway.port).toBe(18789);
+  });
+});
+
+describe("stripSchemaField", () => {
+  it("strips $schema field from config JSON", () => {
+    const input = JSON.stringify({
+      $schema: "https://openclaw.org/config.json",
+      gateway: { port: 18789 },
+    });
+    const result = JSON.parse(stripSchemaField(input));
+    expect(result.$schema).toBeUndefined();
+    expect(result.gateway.port).toBe(18789);
+  });
+
+  it("returns content unchanged when no $schema field exists", () => {
+    const input = JSON.stringify({
+      gateway: { port: 18789 },
+    });
+    expect(stripSchemaField(input)).toBe(input);
+  });
+
+  it("returns non-JSON content unchanged", () => {
+    const input = "not valid json {{{";
+    expect(stripSchemaField(input)).toBe(input);
+  });
+
+  it("strips $schema regardless of URL value", () => {
+    const input = JSON.stringify({
+      $schema: "https://example.com/any-schema.json",
+      agents: { list: [] },
+    });
+    const result = JSON.parse(stripSchemaField(input));
+    expect(result.$schema).toBeUndefined();
+    expect(result.agents.list).toEqual([]);
   });
 });
 
@@ -1017,6 +1052,25 @@ describe("importCommand", () => {
     expect(parsed.meta.lastTouchedVersion).not.toBe("2026.2.6-3");
     expect(parsed.meta.lastTouchedVersion).toEqual(expect.any(String));
     expect(parsed.meta.lastTouchedAt).not.toBe("2025-01-01T00:00:00.000Z");
+  });
+
+  it("strips $schema field from main config during import", async () => {
+    const configContent = JSON.stringify({
+      $schema: "https://openclaw.org/config.json",
+      gateway: { port: 18789 },
+      agents: { list: [{ id: "main", workspace: "~/ws" }] },
+    });
+    await fsp.writeFile(path.join(sourceDir, "openclaw.json"), configContent);
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    const written = await fsp.readFile(path.join(targetDir, "remoteclaw.json"), "utf-8");
+    const parsed = JSON.parse(written);
+    expect(parsed.$schema).toBeUndefined();
+    expect(parsed.gateway.port).toBe(18789);
   });
 
   it("handles nested directory structures with mixed file types", async () => {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -313,6 +313,37 @@ export function clearWizardSection(jsonContent: string): string {
 }
 
 /**
+ * Strip the `$schema` field from config JSON.
+ *
+ * OpenClaw configs may contain `"$schema": "https://openclaw.org/..."` pointing
+ * to an OpenClaw schema URL. Rather than rewriting to a RemoteClaw URL (which
+ * may have a different format), we strip the field entirely — RemoteClaw will
+ * write its own `$schema` on the next config save if needed.
+ */
+export function stripSchemaField(jsonContent: string): string {
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(jsonContent);
+  } catch {
+    return jsonContent;
+  }
+
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    return jsonContent;
+  }
+
+  if (!("$schema" in config)) {
+    return jsonContent;
+  }
+
+  delete config.$schema;
+
+  const indentMatch = jsonContent.match(/^(\s+)"/m);
+  const indent = indentMatch?.[1] ?? "  ";
+  return JSON.stringify(config, null, indent) + "\n";
+}
+
+/**
  * Materialize implicit OpenClaw workspace defaults into the main config JSON.
  *
  * OpenClaw had a three-tier workspace resolution chain that was removed in
@@ -692,7 +723,7 @@ async function copyDirectory(params: {
           ? stampImportedConfigVersion(
               materializeAuthDefaults(
                 materializeWorkspaceDefaults(
-                  clearWizardSection(stripUnrecognizedConfigKeys(transformed)),
+                  clearWizardSection(stripUnrecognizedConfigKeys(stripSchemaField(transformed))),
                 ),
                 params.discoveredAuthProfileIds,
               ),


### PR DESCRIPTION
## Summary

- Adds `stripSchemaField()` to remove the `$schema` field from OpenClaw config JSON during import
- Wires it into the main config transform chain before `stripUnrecognizedConfigKeys()`
- Stripping is preferred over URL rewriting since schema URL formats may differ between OpenClaw and RemoteClaw

Closes #437

## Test plan

- [x] Unit tests for `stripSchemaField()`: strips present `$schema`, no-op when absent, non-JSON passthrough, arbitrary URL values
- [x] Integration test: full import pipeline strips `$schema` from main config
- [x] All 67 tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)