### PR TITLE
feat(middleware): add AgentThinkingEvent and emit from all runtimes

### DIFF
--- a/src/middleware/runtimes/claude.test.ts
+++ b/src/middleware/runtimes/claude.test.ts
@@ -265,7 +265,7 @@ describe("ClaudeCliRuntime", () => {
       expect(event).toBeNull(); // message_delta is consumed as state, not emitted
     });
 
-    it("skips thinking_delta", () => {
+    it("maps thinking_delta to AgentThinkingEvent", () => {
       const event = runtime.testExtractEvent(
         streamEventLine({
           type: "content_block_delta",
@@ -273,7 +273,7 @@ describe("ClaudeCliRuntime", () => {
           delta: { type: "thinking_delta", thinking: "Let me think..." },
         }),
       );
-      expect(event).toBeNull();
+      expect(event).toEqual({ type: "thinking", text: "Let me think..." });
     });
 
     it("stores result line data and returns null for successful results", () => {

--- a/src/middleware/runtimes/claude.ts
+++ b/src/middleware/runtimes/claude.ts
@@ -4,6 +4,7 @@ import type {
   AgentEvent,
   AgentExecuteParams,
   AgentTextEvent,
+  AgentThinkingEvent,
   AgentToolUseEvent,
   AgentUsage,
 } from "../types.js";
@@ -157,7 +158,11 @@ export class ClaudeCliRuntime extends CLIRuntimeBase {
       return null;
     }
 
-    // thinking_delta and other delta types are skipped
+    if (delta.type === "thinking_delta" && typeof delta.thinking === "string") {
+      return { type: "thinking", text: delta.thinking } satisfies AgentThinkingEvent;
+    }
+
+    // other delta types are skipped
     return null;
   }
 

--- a/src/middleware/runtimes/codex.test.ts
+++ b/src/middleware/runtimes/codex.test.ts
@@ -190,9 +190,39 @@ describe("CodexCliRuntime", () => {
       expect(event).toBeNull();
     });
 
-    it("skips item.started + reasoning", () => {
+    it("skips item.started + reasoning (no content yet)", () => {
       const event = runtime.testExtractEvent(itemEvent("item.started", "reasoning", { id: "r-1" }));
       expect(event).toBeNull();
+    });
+
+    it("maps item.completed + reasoning to AgentThinkingEvent", () => {
+      const event = runtime.testExtractEvent(
+        itemEvent("item.completed", "reasoning", {
+          id: "r-1",
+          summary: [{ type: "summary_text", text: "Let me reason..." }],
+        }),
+      );
+      expect(event).toEqual({ type: "thinking", text: "Let me reason..." });
+    });
+
+    it("maps item.completed + reasoning with text fallback to AgentThinkingEvent", () => {
+      const event = runtime.testExtractEvent(
+        itemEvent("item.completed", "reasoning", {
+          id: "r-2",
+          text: "Thinking through this...",
+        }),
+      );
+      expect(event).toEqual({ type: "thinking", text: "Thinking through this..." });
+    });
+
+    it("maps item.updated + reasoning to AgentThinkingEvent", () => {
+      const event = runtime.testExtractEvent(
+        itemEvent("item.updated", "reasoning", {
+          id: "r-3",
+          text: "Partial reasoning",
+        }),
+      );
+      expect(event).toEqual({ type: "thinking", text: "Partial reasoning" });
     });
 
     it("maps item.updated + agent_message to AgentTextEvent with delta", () => {

--- a/src/middleware/runtimes/codex.ts
+++ b/src/middleware/runtimes/codex.ts
@@ -8,6 +8,7 @@ import type {
   AgentEvent,
   AgentExecuteParams,
   AgentTextEvent,
+  AgentThinkingEvent,
   AgentToolResultEvent,
   AgentToolUseEvent,
   AgentUsage,
@@ -155,6 +156,8 @@ export class CodexCliRuntime extends CLIRuntimeBase {
         // Reset delta tracking for new message item
         this.lastEmittedTextLength = 0;
         return null;
+      case "reasoning":
+        return null;
       default:
         return null;
     }
@@ -162,7 +165,19 @@ export class CodexCliRuntime extends CLIRuntimeBase {
 
   private handleItemUpdated(parsed: Record<string, unknown>): AgentEvent | null {
     const item = isObject(parsed.item) ? parsed.item : null;
-    if (!item || item.type !== "agent_message") {
+    if (!item) {
+      return null;
+    }
+
+    if (item.type === "reasoning") {
+      const text = this.extractReasoningText(item);
+      if (text) {
+        return { type: "thinking", text } satisfies AgentThinkingEvent;
+      }
+      return null;
+    }
+
+    if (item.type !== "agent_message") {
       return null;
     }
 
@@ -199,6 +214,13 @@ export class CodexCliRuntime extends CLIRuntimeBase {
             this.accumulatedText += delta;
             return { type: "text", text: delta } satisfies AgentTextEvent;
           }
+        }
+        return null;
+      }
+      case "reasoning": {
+        const text = this.extractReasoningText(item);
+        if (text) {
+          return { type: "thinking", text } satisfies AgentThinkingEvent;
         }
         return null;
       }
@@ -297,6 +319,28 @@ export class CodexCliRuntime extends CLIRuntimeBase {
       const textParts: string[] = [];
       for (const part of item.content) {
         if (isObject(part) && part.type === "output_text" && typeof part.text === "string") {
+          textParts.push(part.text);
+        }
+      }
+      if (textParts.length > 0) {
+        return textParts.join("");
+      }
+    }
+
+    // Fallback: direct text field
+    if (typeof item.text === "string") {
+      return item.text;
+    }
+
+    return undefined;
+  }
+
+  private extractReasoningText(item: Record<string, unknown>): string | undefined {
+    // Codex reasoning items carry text in a `summary` array of text parts
+    if (Array.isArray(item.summary)) {
+      const textParts: string[] = [];
+      for (const part of item.summary) {
+        if (isObject(part) && part.type === "summary_text" && typeof part.text === "string") {
           textParts.push(part.text);
         }
       }

--- a/src/middleware/runtimes/opencode.test.ts
+++ b/src/middleware/runtimes/opencode.test.ts
@@ -290,10 +290,22 @@ describe("OpenCodeCliRuntime", () => {
       expect(event).toBeNull();
     });
 
-    it("skips reasoning events", () => {
+    it("maps reasoning event to AgentThinkingEvent", () => {
       const event = runtime.testExtractEvent(
         openCodeEvent("reasoning", { content: "thinking..." }),
       );
+      expect(event).toEqual({ type: "thinking", text: "thinking..." });
+    });
+
+    it("maps reasoning event with text field to AgentThinkingEvent", () => {
+      const event = runtime.testExtractEvent(
+        openCodeEvent("reasoning", { part: { text: "reasoning text" } }),
+      );
+      expect(event).toEqual({ type: "thinking", text: "reasoning text" });
+    });
+
+    it("returns null for reasoning event with empty content", () => {
+      const event = runtime.testExtractEvent(openCodeEvent("reasoning", { content: "" }));
       expect(event).toBeNull();
     });
 

--- a/src/middleware/runtimes/opencode.ts
+++ b/src/middleware/runtimes/opencode.ts
@@ -7,6 +7,7 @@ import type {
   AgentEvent,
   AgentExecuteParams,
   AgentTextEvent,
+  AgentThinkingEvent,
   AgentToolResultEvent,
   AgentToolUseEvent,
   AgentUsage,
@@ -104,7 +105,7 @@ export class OpenCodeCliRuntime extends CLIRuntimeBase {
       case "step_finish":
         return this.handleStepFinish(data);
       case "reasoning":
-        return null;
+        return this.handleReasoning(data);
       case "error":
         return this.handleError(data);
       default:
@@ -165,6 +166,19 @@ export class OpenCodeCliRuntime extends CLIRuntimeBase {
       type: "error",
       message: typeof parsed.message === "string" ? parsed.message : "Unknown error",
     } satisfies AgentErrorEvent;
+  }
+
+  private handleReasoning(parsed: Record<string, unknown>): AgentEvent | null {
+    const content =
+      typeof parsed.text === "string"
+        ? parsed.text
+        : typeof parsed.content === "string"
+          ? parsed.content
+          : "";
+    if (!content) {
+      return null;
+    }
+    return { type: "thinking", text: content } satisfies AgentThinkingEvent;
   }
 
   // ── Done event enrichment ─────────────────────────────────────────────

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -66,6 +66,7 @@ export type McpServerConfig = {
 export type AgentEvent =
   | AgentTextEvent
   | AgentMediaEvent
+  | AgentThinkingEvent
   | AgentToolUseEvent
   | AgentToolResultEvent
   | AgentErrorEvent
@@ -79,6 +80,11 @@ export type AgentTextEvent = {
 export type AgentMediaEvent = {
   type: "media";
   media: MediaAttachment;
+};
+
+export type AgentThinkingEvent = {
+  type: "thinking";
+  text: string;
 };
 
 export type AgentToolUseEvent = {


### PR DESCRIPTION
## Summary

- Add `AgentThinkingEvent` type (`{ type: "thinking"; text: string }`) to the `AgentEvent` discriminated union in `src/middleware/types.ts`
- Wire Claude runtime to emit thinking events for `thinking_delta` deltas instead of discarding them
- Wire Codex runtime to emit thinking events for `reasoning` item types (started/updated/completed)
- Wire OpenCode runtime to emit thinking events for `reasoning` events instead of discarding them
- Update existing "skips thinking/reasoning" tests to assert events ARE emitted; add new coverage for edge cases

Closes #440

## Test plan

- [x] All 3 runtime test files pass (120 tests)
- [x] Full unit test suite passes (8059 tests across 971 files)
- [x] No type errors in middleware code
- [x] Lint passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)