### PR TITLE
fix(import): allowlist importable root entries during OpenClaw import

### DIFF
--- a/src/commands/import.test.ts
+++ b/src/commands/import.test.ts
@@ -9,6 +9,7 @@ import {
   detectOpenClawInstallation,
   discoverSourceAuthProfileIds,
   importCommand,
+  isImportableRootEntry,
   materializeAuthDefaults,
   materializeWorkspaceDefaults,
   resolveTargetFilename,
@@ -576,6 +577,44 @@ describe("materializeAuthDefaults", () => {
   });
 });
 
+describe("isImportableRootEntry", () => {
+  it("accepts known config files", () => {
+    expect(isImportableRootEntry("openclaw.json")).toBe(true);
+    expect(isImportableRootEntry("remoteclaw.json")).toBe(true);
+    expect(isImportableRootEntry(".env")).toBe(true);
+  });
+
+  it("accepts known directories", () => {
+    expect(isImportableRootEntry("agents")).toBe(true);
+    expect(isImportableRootEntry("agent")).toBe(true);
+    expect(isImportableRootEntry("sessions")).toBe(true);
+    expect(isImportableRootEntry("credentials")).toBe(true);
+    expect(isImportableRootEntry("extensions")).toBe(true);
+    expect(isImportableRootEntry("hooks")).toBe(true);
+    expect(isImportableRootEntry("includes")).toBe(true);
+    expect(isImportableRootEntry("telegram")).toBe(true);
+    expect(isImportableRootEntry("media")).toBe(true);
+    expect(isImportableRootEntry("workspace")).toBe(true);
+  });
+
+  it("accepts workspace-{agentId} directories", () => {
+    expect(isImportableRootEntry("workspace-helper")).toBe(true);
+    expect(isImportableRootEntry("workspace-ops")).toBe(true);
+  });
+
+  it("rejects generated caches and runtime state", () => {
+    expect(isImportableRootEntry("completions")).toBe(false);
+    expect(isImportableRootEntry("restart-sentinel.json")).toBe(false);
+    expect(isImportableRootEntry("delivery-queue")).toBe(false);
+    expect(isImportableRootEntry("sandbox")).toBe(false);
+    expect(isImportableRootEntry("identity")).toBe(false);
+    expect(isImportableRootEntry("logs")).toBe(false);
+    expect(isImportableRootEntry("packs")).toBe(false);
+    expect(isImportableRootEntry("browser")).toBe(false);
+    expect(isImportableRootEntry("canvas")).toBe(false);
+  });
+});
+
 describe("resolveTargetFilename", () => {
   it("renames openclaw.json to remoteclaw.json", () => {
     expect(resolveTargetFilename("openclaw.json")).toBe("remoteclaw.json");
@@ -637,10 +676,10 @@ describe("importCommand", () => {
     await fsp.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("copies files from source to target directory", async () => {
-    await fsp.writeFile(path.join(sourceDir, "data.bin"), "binary data");
-    await fsp.mkdir(path.join(sourceDir, "subdir"));
-    await fsp.writeFile(path.join(sourceDir, "subdir", "nested.txt"), "nested");
+  it("copies known entries from source to target directory", async () => {
+    await fsp.writeFile(path.join(sourceDir, ".env"), "KEY=value");
+    await fsp.mkdir(path.join(sourceDir, "credentials"));
+    await fsp.writeFile(path.join(sourceDir, "credentials", "oauth.json"), '{"token":"fake"}');
 
     // Mock resolveNewStateDir to use our temp target
     const pathsMod = await import("../config/paths.js");
@@ -649,9 +688,58 @@ describe("importCommand", () => {
     const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
 
     expect(result.copiedFiles).toHaveLength(2);
-    expect(fs.existsSync(path.join(targetDir, "data.bin"))).toBe(true);
-    expect(fs.existsSync(path.join(targetDir, "subdir", "nested.txt"))).toBe(true);
-    expect(await fsp.readFile(path.join(targetDir, "data.bin"), "utf-8")).toBe("binary data");
+    expect(fs.existsSync(path.join(targetDir, ".env"))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, "credentials", "oauth.json"))).toBe(true);
+    expect(await fsp.readFile(path.join(targetDir, ".env"), "utf-8")).toBe("KEY=value");
+  });
+
+  it("skips non-importable root-level entries", async () => {
+    await fsp.mkdir(path.join(sourceDir, "completions"));
+    await fsp.writeFile(path.join(sourceDir, "completions", "openclaw.zsh"), "# completions");
+    await fsp.writeFile(path.join(sourceDir, "restart-sentinel.json"), "{}");
+    await fsp.writeFile(path.join(sourceDir, ".env"), "KEY=value");
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    expect(result.copiedFiles).toHaveLength(1);
+    expect(fs.existsSync(path.join(targetDir, ".env"))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, "completions"))).toBe(false);
+    expect(fs.existsSync(path.join(targetDir, "restart-sentinel.json"))).toBe(false);
+    expect(result.skippedEntries).toContain("completions");
+    expect(result.skippedEntries).toContain("restart-sentinel.json");
+  });
+
+  it("copies all contents within allowed directories without filtering", async () => {
+    await fsp.mkdir(path.join(sourceDir, "agents", "main", "agent"), { recursive: true });
+    await fsp.writeFile(path.join(sourceDir, "agents", "main", "agent", "custom-data.bin"), "bin");
+    await fsp.writeFile(path.join(sourceDir, "agents", "main", "agent", "notes.txt"), "notes");
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    expect(result.copiedFiles).toHaveLength(2);
+    expect(fs.existsSync(path.join(targetDir, "agents", "main", "agent", "custom-data.bin"))).toBe(
+      true,
+    );
+    expect(fs.existsSync(path.join(targetDir, "agents", "main", "agent", "notes.txt"))).toBe(true);
+  });
+
+  it("imports workspace-{agentId} directories", async () => {
+    await fsp.mkdir(path.join(sourceDir, "workspace-helper"), { recursive: true });
+    await fsp.writeFile(path.join(sourceDir, "workspace-helper", "project.json"), "{}");
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    expect(result.copiedFiles).toHaveLength(1);
+    expect(fs.existsSync(path.join(targetDir, "workspace-helper", "project.json"))).toBe(true);
   });
 
   it("transforms config files during copy", async () => {
@@ -686,7 +774,7 @@ describe("importCommand", () => {
   });
 
   it("dry-run does not write files", async () => {
-    await fsp.writeFile(path.join(sourceDir, "config.json"), '{"key": "value"}');
+    await fsp.writeFile(path.join(sourceDir, ".env"), "KEY=value");
 
     const pathsMod = await import("../config/paths.js");
     vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
@@ -727,7 +815,7 @@ describe("importCommand", () => {
   });
 
   it("warns and exits in non-interactive mode when target exists without --yes", async () => {
-    await fsp.writeFile(path.join(sourceDir, "data.bin"), "data");
+    await fsp.writeFile(path.join(sourceDir, ".env"), "KEY=value");
     await fsp.mkdir(targetDir, { recursive: true });
 
     const pathsMod = await import("../config/paths.js");
@@ -741,7 +829,7 @@ describe("importCommand", () => {
   });
 
   it("proceeds when target exists and --yes is provided", async () => {
-    await fsp.writeFile(path.join(sourceDir, "data.bin"), "data");
+    await fsp.writeFile(path.join(sourceDir, ".env"), "KEY=value");
     await fsp.mkdir(targetDir, { recursive: true });
 
     const pathsMod = await import("../config/paths.js");
@@ -750,7 +838,7 @@ describe("importCommand", () => {
     const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
 
     expect(result.copiedFiles).toHaveLength(1);
-    expect(fs.existsSync(path.join(targetDir, "data.bin"))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, ".env"))).toBe(true);
   });
 
   it("materializes workspace defaults in main config during import", async () => {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -76,6 +76,7 @@ export type ImportResult = {
   copiedFiles: string[];
   transformedFiles: string[];
   envVarRenames: string[];
+  skippedEntries: string[];
   targetDir: string;
 };
 
@@ -548,6 +549,60 @@ export function resolveTargetFilename(filename: string): string {
 }
 
 /**
+ * Top-level entries in the OpenClaw state directory that should be imported.
+ *
+ * Only entries in this set (plus the `workspace-*` pattern) are copied from
+ * the source root. Everything else — generated caches (`completions/`),
+ * runtime state (`delivery-queue/`, `sandbox/`, `restart-sentinel.json`),
+ * device-specific data (`identity/`), and removed subsystems (`packs/`) —
+ * is intentionally skipped.
+ *
+ * Sub-directories within importable entries are copied recursively without
+ * further filtering.
+ */
+const IMPORTABLE_ROOT_ENTRIES = new Set([
+  // Config files
+  OPENCLAW_CONFIG_FILENAME, // openclaw.json → remoteclaw.json
+  REMOTECLAW_CONFIG_FILENAME, // remoteclaw.json (partially migrated source)
+  ".env",
+
+  // Agent state
+  "agents",
+  "agent", // Legacy root-level agent dir (pre-migration layout)
+  "sessions", // Legacy sessions dir
+
+  // Credentials and auth
+  "credentials",
+
+  // User customizations
+  "extensions",
+  "hooks",
+  "includes",
+
+  // Channel state
+  "telegram",
+
+  // Media and workspaces
+  "media",
+  "workspace",
+]);
+
+/**
+ * Check whether a root-level entry name should be imported.
+ * Matches the static allowlist plus `workspace-{agentId}` directories.
+ */
+export function isImportableRootEntry(name: string): boolean {
+  if (IMPORTABLE_ROOT_ENTRIES.has(name)) {
+    return true;
+  }
+  // Dynamic workspace directories: workspace-{agentId}
+  if (name.startsWith("workspace-") && name.length > "workspace-".length) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Check whether a file is a JSON/JSON5 config file that should be transformed.
  */
 function isConfigFile(filename: string): boolean {
@@ -556,15 +611,20 @@ function isConfigFile(filename: string): boolean {
 
 /**
  * Recursively copy a directory, transforming config files along the way.
+ *
+ * When `filterRoot` is true (used for the top-level source directory),
+ * only entries matching the importable allowlist are processed.
+ * Sub-directories are always copied in full without filtering.
  */
 async function copyDirectory(params: {
   sourceDir: string;
   targetDir: string;
   dryRun: boolean;
+  filterRoot: boolean;
   result: ImportResult;
   discoveredAuthProfileIds: string[];
 }): Promise<void> {
-  const { sourceDir, targetDir, dryRun, result } = params;
+  const { sourceDir, targetDir, dryRun, filterRoot, result } = params;
 
   const entries = await fsp.readdir(sourceDir, { withFileTypes: true });
 
@@ -573,6 +633,11 @@ async function copyDirectory(params: {
   }
 
   for (const entry of entries) {
+    if (filterRoot && !isImportableRootEntry(entry.name)) {
+      result.skippedEntries.push(entry.name);
+      continue;
+    }
+
     const sourcePath = path.join(sourceDir, entry.name);
     const targetFilename = resolveTargetFilename(entry.name);
     const targetPath = path.join(targetDir, targetFilename);
@@ -582,6 +647,7 @@ async function copyDirectory(params: {
         sourceDir: sourcePath,
         targetDir: targetPath,
         dryRun,
+        filterRoot: false,
         result,
         discoveredAuthProfileIds: params.discoveredAuthProfileIds,
       });
@@ -669,6 +735,7 @@ export async function importCommand(
     copiedFiles: [],
     transformedFiles: [],
     envVarRenames: [],
+    skippedEntries: [],
     targetDir,
   };
 
@@ -686,6 +753,7 @@ export async function importCommand(
     sourceDir: sourcePath,
     targetDir,
     dryRun: Boolean(opts.dryRun),
+    filterRoot: true,
     result,
     discoveredAuthProfileIds,
   });
@@ -705,6 +773,13 @@ export async function importCommand(
     runtime.log(`\nEnv var renames:`);
     for (const rename of result.envVarRenames) {
       runtime.log(`  ${rename}`);
+    }
+  }
+
+  if (result.skippedEntries.length > 0) {
+    runtime.log(`\nSkipped ${result.skippedEntries.length} non-importable entry(s):`);
+    for (const entry of result.skippedEntries) {
+      runtime.log(`  ${entry}`);
     }
   }
 


### PR DESCRIPTION
## Summary

- The import command previously copied **all** files/directories from the OpenClaw state directory, causing stale artifacts (shell completion caches, runtime state files) to survive migration
- Switch to an explicit allowlist of known importable root-level entries — only config, agent state, credentials, user customizations, channel state, and workspaces are imported
- Generated caches (`completions/`), runtime state (`delivery-queue/`, `sandbox/`, `restart-sentinel.json`), device-specific data (`identity/`), and removed subsystems (`packs/`) are skipped and reported

## Test plan

- [x] `isImportableRootEntry` unit tests cover static allowlist, `workspace-*` pattern, and rejected entries
- [x] Integration test verifies non-importable root entries are skipped and reported
- [x] Integration test verifies sub-directory contents within allowed entries are copied without filtering
- [x] Integration test verifies `workspace-{agentId}` directories are imported
- [x] All 74 import tests pass
- [x] Existing tests updated to use allowlisted entry names

🤖 Generated with [Claude Code](https://claude.com/claude-code)