### PR TITLE
refactor(auth): relocate auth store from per-agent to global path

### DIFF
--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -22,7 +22,6 @@ import {
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
 // Model override infrastructure gutted in RemoteClaw — inline override logic.
-import { resolveAgentDir } from "../agent-scope.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 // Model management defaults gutted in RemoteClaw — CLI runtimes own model selection.
 import { parseModelRef } from "../provider-utils.js";
@@ -276,7 +275,6 @@ export function createSessionStatusTool(opts?: {
         }
       }
 
-      const agentDir = resolveAgentDir(cfg, agentId);
       const providerForCard = resolved.entry.providerOverride?.trim() || configured.provider;
       const usageProvider = resolveUsageProviderId(providerForCard);
       let usageLine: string | undefined;
@@ -285,7 +283,6 @@ export function createSessionStatusTool(opts?: {
           const usageSummary = await loadProviderUsageSummary({
             timeoutMs: 3500,
             providers: [usageProvider],
-            agentDir,
           });
           const snapshot = usageSummary.providers.find((entry) => entry.provider === usageProvider);
           if (snapshot) {

--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -2,7 +2,6 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 
 export const AUTH_STORE_VERSION = 1;
 export const AUTH_PROFILE_FILENAME = "auth-profiles.json";
-export const LEGACY_AUTH_FILENAME = "auth.json";
 
 export const CLAUDE_CLI_PROFILE_ID = "anthropic:claude-cli";
 export const CODEX_CLI_PROFILE_ID = "openai-codex:codex-cli";

--- a/src/auth/env-injection.ts
+++ b/src/auth/env-injection.ts
@@ -116,7 +116,6 @@ export function resolveAuthProfileCount(cfg: RemoteClawConfig, agentId: string):
 export async function resolveAuthEnv(params: {
   cfg: RemoteClawConfig;
   agentId: string;
-  agentDir?: string;
   store?: AuthProfileStore;
 }): Promise<Record<string, string> | undefined> {
   const auth = resolveAgentAuth(params.cfg, params.agentId);
@@ -131,7 +130,7 @@ export async function resolveAuthEnv(params: {
     return undefined;
   }
 
-  const store = params.store ?? ensureAuthProfileStore(params.agentDir);
+  const store = params.store ?? ensureAuthProfileStore();
 
   let resolved: { apiKey: string; provider: string; email?: string } | null;
   try {
@@ -139,7 +138,6 @@ export async function resolveAuthEnv(params: {
       cfg: params.cfg,
       store,
       profileId,
-      agentDir: params.agentDir,
     });
   } catch {
     log.warn(`Failed to resolve auth profile "${profileId}" — skipping env injection`);

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -25,7 +25,6 @@ type ResolveApiKeyForProfileParams = {
   cfg?: RemoteClawConfig;
   store: AuthProfileStore;
   profileId: string;
-  agentDir?: string;
 };
 
 export async function resolveApiKeyForProfile(

--- a/src/auth/paths.ts
+++ b/src/auth/paths.ts
@@ -1,24 +1,16 @@
 import fs from "node:fs";
 import path from "node:path";
-import { resolveRemoteClawAgentDir } from "../agents/agent-paths.js";
+import { resolveStateDir } from "../config/paths.js";
 import { saveJsonFile } from "../infra/json-file.js";
-import { resolveUserPath } from "../utils.js";
-import { AUTH_PROFILE_FILENAME, AUTH_STORE_VERSION, LEGACY_AUTH_FILENAME } from "./constants.js";
+import { AUTH_PROFILE_FILENAME, AUTH_STORE_VERSION } from "./constants.js";
 import type { AuthProfileStore } from "./types.js";
 
-export function resolveAuthStorePath(agentDir?: string): string {
-  const resolved = resolveUserPath(agentDir ?? resolveRemoteClawAgentDir());
-  return path.join(resolved, AUTH_PROFILE_FILENAME);
+export function resolveAuthStorePath(): string {
+  return path.join(resolveStateDir(), AUTH_PROFILE_FILENAME);
 }
 
-export function resolveLegacyAuthStorePath(agentDir?: string): string {
-  const resolved = resolveUserPath(agentDir ?? resolveRemoteClawAgentDir());
-  return path.join(resolved, LEGACY_AUTH_FILENAME);
-}
-
-export function resolveAuthStorePathForDisplay(agentDir?: string): string {
-  const pathname = resolveAuthStorePath(agentDir);
-  return pathname.startsWith("~") ? pathname : resolveUserPath(pathname);
+export function resolveAuthStorePathForDisplay(): string {
+  return resolveAuthStorePath();
 }
 
 export function ensureAuthStoreFile(pathname: string) {

--- a/src/auth/profiles.ts
+++ b/src/auth/profiles.ts
@@ -10,7 +10,6 @@ import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
 export function upsertAuthProfile(params: {
   profileId: string;
   credential: AuthProfileCredential;
-  agentDir?: string;
 }): void {
   const credential = {
     ...params.credential,
@@ -18,18 +17,16 @@ export function upsertAuthProfile(params: {
       ? { key: normalizeSecretInput(params.credential.key) }
       : {}),
   };
-  const store = ensureAuthProfileStore(params.agentDir);
+  const store = ensureAuthProfileStore();
   store.profiles[params.profileId] = credential;
-  saveAuthProfileStore(store, params.agentDir);
+  saveAuthProfileStore(store);
 }
 
 export async function upsertAuthProfileWithLock(params: {
   profileId: string;
   credential: AuthProfileCredential;
-  agentDir?: string;
 }): Promise<AuthProfileStore | null> {
   return await updateAuthProfileStoreWithLock({
-    agentDir: params.agentDir,
     updater: (store) => {
       store.profiles[params.profileId] = params.credential;
       return true;

--- a/src/auth/provider-auth.ts
+++ b/src/auth/provider-auth.ts
@@ -8,7 +8,7 @@
 
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import path, { join } from "node:path";
+import { join } from "node:path";
 import { normalizeProviderId } from "../agents/provider-utils.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { RemoteClawConfig } from "../config/config.js";
@@ -113,17 +113,15 @@ export async function resolveApiKeyForProvider(params: {
   profileId?: string;
   preferredProfile?: string;
   store?: AuthProfileStore;
-  agentDir?: string;
 }): Promise<ResolvedProviderAuth> {
   const { provider, cfg, profileId } = params;
-  const store = params.store ?? ensureAuthProfileStore(params.agentDir);
+  const store = params.store ?? ensureAuthProfileStore();
 
   if (profileId) {
     const resolved = await resolveApiKeyForProfile({
       cfg,
       store,
       profileId,
-      agentDir: params.agentDir,
     });
     if (!resolved) {
       throw new Error(`No credentials found for profile "${profileId}".`);
@@ -150,7 +148,6 @@ export async function resolveApiKeyForProvider(params: {
         cfg,
         store,
         profileId: candidate,
-        agentDir: params.agentDir,
       });
       if (resolved) {
         return {
@@ -186,13 +183,12 @@ export async function resolveApiKeyForProvider(params: {
     }
   }
 
-  const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);
-  const resolvedAgentDir = path.dirname(authStorePath);
+  const authStorePath = resolveAuthStorePathForDisplay();
   throw new Error(
     [
       `No API key found for provider "${provider}".`,
-      `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
-      `Configure auth for this agent (${formatCliCommand("remoteclaw agents add <id>")}) or copy auth-profiles.json from the main agentDir.`,
+      `Auth store: ${authStorePath}.`,
+      `Configure auth via ${formatCliCommand("remoteclaw configure")} or ${formatCliCommand("remoteclaw onboard")}.`,
     ].join(" "),
   );
 }
@@ -349,7 +345,6 @@ export function resolveModelAuthLabel(params: {
   provider?: string;
   cfg?: RemoteClawConfig;
   sessionEntry?: SessionEntry;
-  agentDir?: string;
 }): string | undefined {
   const resolvedProvider = params.provider?.trim();
   if (!resolvedProvider) {
@@ -357,9 +352,7 @@ export function resolveModelAuthLabel(params: {
   }
 
   const providerKey = normalizeProviderId(resolvedProvider);
-  const store = ensureAuthProfileStore(params.agentDir, {
-    allowKeychainPrompt: false,
-  });
+  const store = ensureAuthProfileStore();
   const profileOverride = params.sessionEntry?.authProfileOverride?.trim();
   const profiles = listProfilesForProvider(store, providerKey);
   const candidates = [profileOverride, ...profiles].filter(Boolean) as string[];

--- a/src/auth/session-override.ts
+++ b/src/auth/session-override.ts
@@ -37,19 +37,18 @@ export async function clearSessionAuthProfileOverride(params: {
 export async function resolveSessionAuthProfileOverride(params: {
   cfg: RemoteClawConfig;
   provider: string;
-  agentDir: string;
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
   storePath?: string;
   isNewSession: boolean;
 }): Promise<string | undefined> {
-  const { provider, agentDir, sessionEntry, sessionStore, sessionKey, storePath } = params;
+  const { provider, sessionEntry, sessionStore, sessionKey, storePath } = params;
   if (!sessionEntry || !sessionStore || !sessionKey) {
     return sessionEntry?.authProfileOverride;
   }
 
-  const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  const store = ensureAuthProfileStore();
   const profiles = listProfilesForProvider(store, provider);
   let current = sessionEntry.authProfileOverride?.trim();
 

--- a/src/auth/store.ensureauthprofilestore.test.ts
+++ b/src/auth/store.ensureauthprofilestore.test.ts
@@ -1,123 +1,59 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { AUTH_STORE_VERSION } from "./constants.js";
 import { ensureAuthProfileStore } from "./index.js";
 
 describe("ensureAuthProfileStore", () => {
-  it("migrates legacy auth.json and deletes it (PR #368)", () => {
-    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-auth-profiles-"));
-    try {
-      const legacyPath = path.join(agentDir, "auth.json");
-      fs.writeFileSync(
-        legacyPath,
-        `${JSON.stringify(
-          {
-            anthropic: {
-              type: "api_key",
-              provider: "anthropic",
-              key: "sk-ant-legacy-key",
-            },
-          },
-          null,
-          2,
-        )}\n`,
-        "utf8",
-      );
+  let prevStateDir: string | undefined;
+  let tempDir: string;
 
-      const store = ensureAuthProfileStore(agentDir);
-      expect(store.profiles["anthropic:default"]).toMatchObject({
-        type: "api_key",
-        provider: "anthropic",
-      });
-
-      const migratedPath = path.join(agentDir, "auth-profiles.json");
-      expect(fs.existsSync(migratedPath)).toBe(true);
-      expect(fs.existsSync(legacyPath)).toBe(false);
-
-      // idempotent
-      const store2 = ensureAuthProfileStore(agentDir);
-      expect(store2.profiles["anthropic:default"]).toBeDefined();
-      expect(fs.existsSync(legacyPath)).toBe(false);
-    } finally {
-      fs.rmSync(agentDir, { recursive: true, force: true });
+  afterEach(() => {
+    if (prevStateDir === undefined) {
+      delete process.env.REMOTECLAW_STATE_DIR;
+    } else {
+      process.env.REMOTECLAW_STATE_DIR = prevStateDir;
     }
+    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("merges main auth profiles into agent store and keeps agent overrides", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-auth-merge-"));
-    const previousAgentDir = process.env.REMOTECLAW_AGENT_DIR;
-    const previousPiAgentDir = process.env.PI_CODING_AGENT_DIR;
-    try {
-      const mainDir = path.join(root, "main-agent");
-      const agentDir = path.join(root, "agent-x");
-      fs.mkdirSync(mainDir, { recursive: true });
-      fs.mkdirSync(agentDir, { recursive: true });
+  it("returns an empty store when no auth-profiles.json exists", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-auth-empty-"));
+    prevStateDir = process.env.REMOTECLAW_STATE_DIR;
+    process.env.REMOTECLAW_STATE_DIR = tempDir;
 
-      process.env.REMOTECLAW_AGENT_DIR = mainDir;
-      process.env.PI_CODING_AGENT_DIR = mainDir;
+    const store = ensureAuthProfileStore();
+    expect(store.version).toBe(AUTH_STORE_VERSION);
+    expect(Object.keys(store.profiles)).toHaveLength(0);
+  });
 
-      const mainStore = {
-        version: AUTH_STORE_VERSION,
-        profiles: {
-          "openai:default": {
-            type: "api_key",
-            provider: "openai",
-            key: "main-key",
-          },
-          "anthropic:default": {
-            type: "api_key",
-            provider: "anthropic",
-            key: "main-anthropic-key",
-          },
+  it("loads profiles from global auth-profiles.json", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-auth-global-"));
+    prevStateDir = process.env.REMOTECLAW_STATE_DIR;
+    process.env.REMOTECLAW_STATE_DIR = tempDir;
+
+    const globalStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        "anthropic:default": {
+          type: "api_key",
+          provider: "anthropic",
+          key: "sk-ant-global-key",
         },
-      };
-      fs.writeFileSync(
-        path.join(mainDir, "auth-profiles.json"),
-        `${JSON.stringify(mainStore, null, 2)}\n`,
-        "utf8",
-      );
+      },
+    };
+    fs.writeFileSync(
+      path.join(tempDir, "auth-profiles.json"),
+      `${JSON.stringify(globalStore, null, 2)}\n`,
+      "utf8",
+    );
 
-      const agentStore = {
-        version: AUTH_STORE_VERSION,
-        profiles: {
-          "openai:default": {
-            type: "api_key",
-            provider: "openai",
-            key: "agent-key",
-          },
-        },
-      };
-      fs.writeFileSync(
-        path.join(agentDir, "auth-profiles.json"),
-        `${JSON.stringify(agentStore, null, 2)}\n`,
-        "utf8",
-      );
-
-      const store = ensureAuthProfileStore(agentDir);
-      expect(store.profiles["anthropic:default"]).toMatchObject({
-        type: "api_key",
-        provider: "anthropic",
-        key: "main-anthropic-key",
-      });
-      expect(store.profiles["openai:default"]).toMatchObject({
-        type: "api_key",
-        provider: "openai",
-        key: "agent-key",
-      });
-    } finally {
-      if (previousAgentDir === undefined) {
-        delete process.env.REMOTECLAW_AGENT_DIR;
-      } else {
-        process.env.REMOTECLAW_AGENT_DIR = previousAgentDir;
-      }
-      if (previousPiAgentDir === undefined) {
-        delete process.env.PI_CODING_AGENT_DIR;
-      } else {
-        process.env.PI_CODING_AGENT_DIR = previousPiAgentDir;
-      }
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+    const store = ensureAuthProfileStore();
+    expect(store.profiles["anthropic:default"]).toMatchObject({
+      type: "api_key",
+      provider: "anthropic",
+      key: "sk-ant-global-key",
+    });
   });
 });

--- a/src/auth/store.ts
+++ b/src/auth/store.ts
@@ -1,56 +1,27 @@
-import fs from "node:fs";
 import { withFileLock } from "../infra/file-lock.js";
 import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
-import { AUTH_STORE_LOCK_OPTIONS, AUTH_STORE_VERSION, log } from "./constants.js";
-import { ensureAuthStoreFile, resolveAuthStorePath, resolveLegacyAuthStorePath } from "./paths.js";
+import { AUTH_STORE_LOCK_OPTIONS, AUTH_STORE_VERSION } from "./constants.js";
+import { ensureAuthStoreFile, resolveAuthStorePath } from "./paths.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
 
-type LegacyAuthStore = Record<string, AuthProfileCredential>;
-
 export async function updateAuthProfileStoreWithLock(params: {
-  agentDir?: string;
   updater: (store: AuthProfileStore) => boolean;
 }): Promise<AuthProfileStore | null> {
-  const authPath = resolveAuthStorePath(params.agentDir);
+  const authPath = resolveAuthStorePath();
   ensureAuthStoreFile(authPath);
 
   try {
     return await withFileLock(authPath, AUTH_STORE_LOCK_OPTIONS, async () => {
-      const store = ensureAuthProfileStore(params.agentDir);
+      const store = ensureAuthProfileStore();
       const shouldSave = params.updater(store);
       if (shouldSave) {
-        saveAuthProfileStore(store, params.agentDir);
+        saveAuthProfileStore(store);
       }
       return store;
     });
   } catch {
     return null;
   }
-}
-
-function coerceLegacyStore(raw: unknown): LegacyAuthStore | null {
-  if (!raw || typeof raw !== "object") {
-    return null;
-  }
-  const record = raw as Record<string, unknown>;
-  if ("profiles" in record) {
-    return null;
-  }
-  const entries: LegacyAuthStore = {};
-  for (const [key, value] of Object.entries(record)) {
-    if (!value || typeof value !== "object") {
-      continue;
-    }
-    const typed = value as Partial<AuthProfileCredential>;
-    if (typed.type !== "api_key") {
-      continue;
-    }
-    entries[key] = {
-      ...typed,
-      provider: String(typed.provider ?? key),
-    } as AuthProfileCredential;
-  }
-  return Object.keys(entries).length > 0 ? entries : null;
 }
 
 function coerceAuthStore(raw: unknown): AuthProfileStore | null {
@@ -86,33 +57,6 @@ function coerceAuthStore(raw: unknown): AuthProfileStore | null {
   };
 }
 
-function mergeAuthProfileStores(
-  base: AuthProfileStore,
-  override: AuthProfileStore,
-): AuthProfileStore {
-  if (Object.keys(override.profiles).length === 0) {
-    return base;
-  }
-  return {
-    version: Math.max(base.version, override.version ?? base.version),
-    profiles: { ...base.profiles, ...override.profiles },
-  };
-}
-
-function applyLegacyStore(store: AuthProfileStore, legacy: LegacyAuthStore): void {
-  for (const [provider, cred] of Object.entries(legacy)) {
-    const profileId = `${provider}:default`;
-    if (cred.type === "api_key") {
-      store.profiles[profileId] = {
-        type: "api_key",
-        provider: String(cred.provider ?? provider),
-        key: cred.key,
-        ...(cred.email ? { email: cred.email } : {}),
-      };
-    }
-  }
-}
-
 export function loadAuthProfileStore(): AuthProfileStore {
   const authPath = resolveAuthStorePath();
   const raw = loadJsonFile(authPath);
@@ -121,96 +65,15 @@ export function loadAuthProfileStore(): AuthProfileStore {
     return asStore;
   }
 
-  const legacyRaw = loadJsonFile(resolveLegacyAuthStorePath());
-  const legacy = coerceLegacyStore(legacyRaw);
-  if (legacy) {
-    const store: AuthProfileStore = {
-      version: AUTH_STORE_VERSION,
-      profiles: {},
-    };
-    applyLegacyStore(store, legacy);
-    return store;
-  }
-
   return { version: AUTH_STORE_VERSION, profiles: {} };
 }
 
-function loadAuthProfileStoreForAgent(
-  agentDir?: string,
-  _options?: { allowKeychainPrompt?: boolean },
-): AuthProfileStore {
-  const authPath = resolveAuthStorePath(agentDir);
-  const raw = loadJsonFile(authPath);
-  const asStore = coerceAuthStore(raw);
-  if (asStore) {
-    return asStore;
-  }
-
-  // Fallback: inherit auth-profiles from main agent if subagent has none
-  if (agentDir) {
-    const mainAuthPath = resolveAuthStorePath(); // without agentDir = main
-    const mainRaw = loadJsonFile(mainAuthPath);
-    const mainStore = coerceAuthStore(mainRaw);
-    if (mainStore && Object.keys(mainStore.profiles).length > 0) {
-      // Clone main store to subagent directory for auth inheritance
-      saveJsonFile(authPath, mainStore);
-      log.info("inherited auth-profiles from main agent", { agentDir });
-      return mainStore;
-    }
-  }
-
-  const legacyRaw = loadJsonFile(resolveLegacyAuthStorePath(agentDir));
-  const legacy = coerceLegacyStore(legacyRaw);
-  const store: AuthProfileStore = {
-    version: AUTH_STORE_VERSION,
-    profiles: {},
-  };
-  if (legacy) {
-    applyLegacyStore(store, legacy);
-  }
-
-  const shouldWrite = legacy !== null;
-  if (shouldWrite) {
-    saveJsonFile(authPath, store);
-  }
-
-  // Delete legacy auth.json after successful migration.
-  if (shouldWrite && legacy !== null) {
-    const legacyPath = resolveLegacyAuthStorePath(agentDir);
-    try {
-      fs.unlinkSync(legacyPath);
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
-        log.warn("failed to delete legacy auth.json after migration", {
-          err,
-          legacyPath,
-        });
-      }
-    }
-  }
-
-  return store;
+export function ensureAuthProfileStore(): AuthProfileStore {
+  return loadAuthProfileStore();
 }
 
-export function ensureAuthProfileStore(
-  agentDir?: string,
-  options?: { allowKeychainPrompt?: boolean },
-): AuthProfileStore {
-  const store = loadAuthProfileStoreForAgent(agentDir, options);
-  const authPath = resolveAuthStorePath(agentDir);
-  const mainAuthPath = resolveAuthStorePath();
-  if (!agentDir || authPath === mainAuthPath) {
-    return store;
-  }
-
-  const mainStore = loadAuthProfileStoreForAgent(undefined, options);
-  const merged = mergeAuthProfileStores(mainStore, store);
-
-  return merged;
-}
-
-export function saveAuthProfileStore(store: AuthProfileStore, agentDir?: string): void {
-  const authPath = resolveAuthStorePath(agentDir);
+export function saveAuthProfileStore(store: AuthProfileStore): void {
+  const authPath = resolveAuthStorePath();
   const payload = {
     version: AUTH_STORE_VERSION,
     profiles: store.profiles,

--- a/src/auto-reply/reply.triggers.trigger-handling.filters-usage-summary-current-model-provider.cases.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.filters-usage-summary-current-model-provider.cases.ts
@@ -156,10 +156,10 @@ export function registerTriggerHandlingUsageSummaryCases(params: {
           runAgentMock.mockClear();
           const cfg = makeCfg(home);
           cfg.session = { ...cfg.session, store: join(home, "auth-profile-status.sessions.json") };
-          const agentDir = join(home, ".remoteclaw", "agents", "main", "agent");
-          await mkdir(agentDir, { recursive: true });
+          const stateDir = join(home, ".remoteclaw");
+          await mkdir(stateDir, { recursive: true });
           await writeFile(
-            join(agentDir, "auth-profiles.json"),
+            join(stateDir, "auth-profiles.json"),
             JSON.stringify(
               {
                 version: 1,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -366,7 +366,6 @@ export async function runAgentTurnWithFallback(params: {
           {
             cfg,
             agentId: params.followupRun.run.agentId,
-            agentDir: params.followupRun.run.agentDir,
             baseEnv: baseRuntimeEnv,
           },
           async (runtimeEnv) => {

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -1,8 +1,4 @@
-import {
-  resolveAgentDir,
-  resolveDefaultAgentId,
-  resolveSessionAgentId,
-} from "../../agents/agent-scope.js";
+import { resolveDefaultAgentId, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { listSubagentRunsForRequester } from "../../agents/subagent-registry.js";
 import {
   resolveInternalSessionKey,
@@ -66,7 +62,6 @@ export async function buildStatusReply(params: {
   const statusAgentId = sessionKey
     ? resolveSessionAgentId({ sessionKey, config: cfg })
     : resolveDefaultAgentId(cfg);
-  const statusAgentDir = resolveAgentDir(cfg, statusAgentId);
   const currentUsageProvider = (() => {
     try {
       return resolveUsageProviderId(provider);
@@ -80,7 +75,6 @@ export async function buildStatusReply(params: {
       const usageSummary = await loadProviderUsageSummary({
         timeoutMs: 3500,
         providers: [currentUsageProvider],
-        agentDir: statusAgentDir,
       });
       const usageEntry = usageSummary.providers[0];
       if (usageEntry && !usageEntry.error && usageEntry.windows.length > 0) {
@@ -136,7 +130,6 @@ export async function buildStatusReply(params: {
     provider,
     cfg,
     sessionEntry,
-    agentDir: statusAgentDir,
   });
   // Resolve active model from session fallback notice fields.
   const activeProvider = sessionEntry?.modelProvider?.trim() || provider;
@@ -147,7 +140,6 @@ export async function buildStatusReply(params: {
         provider: activeProvider,
         cfg,
         sessionEntry,
-        agentDir: statusAgentDir,
       })
     : selectedModelAuth;
   const agentDefaults = cfg.agents?.defaults ?? {};

--- a/src/auto-reply/reply/directive-handling.auth.ts
+++ b/src/auto-reply/reply/directive-handling.auth.ts
@@ -11,13 +11,11 @@ export const resolveAuthLabel = async (
   provider: string,
   cfg: RemoteClawConfig,
   modelsPath: string,
-  agentDir?: string,
+  _agentDir?: string,
   mode: ModelAuthDetailMode = "compact",
 ): Promise<{ label: string; source: string }> => {
   const formatPath = (value: string) => shortenHomePath(value);
-  const store = ensureAuthProfileStore(agentDir, {
-    allowKeychainPrompt: false,
-  });
+  const store = ensureAuthProfileStore();
   const profiles = listProfilesForProvider(store, provider);
   const nextProfileId = profiles[0];
 
@@ -60,7 +58,7 @@ export const resolveAuthLabel = async (
     });
     return {
       label: labels.join(", "),
-      source: `auth-profiles.json: ${formatPath(resolveAuthStorePathForDisplay(agentDir))}`,
+      source: `auth-profiles.json: ${formatPath(resolveAuthStorePathForDisplay())}`,
     };
   }
 
@@ -83,15 +81,12 @@ export const resolveProfileOverride = (params: {
   rawProfile?: string;
   provider: string;
   cfg: RemoteClawConfig;
-  agentDir?: string;
 }): { profileId?: string; error?: string } => {
   const raw = params.rawProfile?.trim();
   if (!raw) {
     return {};
   }
-  const store = ensureAuthProfileStore(params.agentDir, {
-    allowKeychainPrompt: false,
-  });
+  const store = ensureAuthProfileStore();
   const profile = store.profiles[raw];
   if (!profile) {
     return { error: `Auth profile "${raw}" not found.` };

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -1,8 +1,3 @@
-import {
-  resolveAgentDir,
-  resolveDefaultAgentId,
-  resolveSessionAgentId,
-} from "../../agents/agent-scope.js";
 import { modelKey, parseModelRef } from "../../agents/provider-utils.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import { type SessionEntry, updateSessionStore } from "../../config/sessions.js";
@@ -17,7 +12,6 @@ export async function persistInlineDirectives(params: {
   directives: InlineDirectives;
   effectiveModelDirective?: string;
   cfg: RemoteClawConfig;
-  agentDir?: string;
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
@@ -52,11 +46,6 @@ export async function persistInlineDirectives(params: {
     agentCfg,
   } = params;
   let { provider, model } = params;
-  const activeAgentId = sessionKey
-    ? resolveSessionAgentId({ sessionKey, config: cfg })
-    : resolveDefaultAgentId(cfg);
-  const agentDir = resolveAgentDir(cfg, activeAgentId);
-
   if (sessionEntry && sessionStore && sessionKey) {
     const prevElevatedLevel =
       (sessionEntry.elevatedLevel as ElevatedLevel | undefined) ??
@@ -121,7 +110,6 @@ export async function persistInlineDirectives(params: {
               rawProfile: directives.rawModelProfile,
               provider: resolved.provider,
               cfg,
-              agentDir,
             });
             if (profileResolved.error) {
               throw new Error(profileResolved.error);

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -39,7 +39,6 @@ export async function applyInlineDirectiveOverrides(params: {
   ctx: MsgContext;
   cfg: RemoteClawConfig;
   agentId: string;
-  agentDir: string;
   agentCfg: AgentDefaults;
   sessionEntry: SessionEntry;
   sessionStore: Record<string, SessionEntry>;
@@ -74,7 +73,6 @@ export async function applyInlineDirectiveOverrides(params: {
     ctx,
     cfg,
     agentId,
-    agentDir,
     agentCfg,
     sessionEntry,
     sessionStore,
@@ -233,7 +231,6 @@ export async function applyInlineDirectiveOverrides(params: {
     directives,
     effectiveModelDirective,
     cfg,
-    agentDir,
     sessionEntry,
     sessionStore,
     sessionKey,

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -119,7 +119,6 @@ export async function resolveReplyDirectives(params: {
   ctx: MsgContext;
   cfg: RemoteClawConfig;
   agentId: string;
-  agentDir: string;
   workspaceDir: string;
   agentCfg: AgentDefaults;
   sessionCtx: TemplateContext;
@@ -146,7 +145,6 @@ export async function resolveReplyDirectives(params: {
     cfg,
     agentId,
     agentCfg,
-    agentDir,
     workspaceDir: _workspaceDir,
     sessionCtx,
     sessionEntry,
@@ -410,7 +408,6 @@ export async function resolveReplyDirectives(params: {
     ctx,
     cfg,
     agentId,
-    agentDir,
     agentCfg,
     sessionEntry,
     sessionStore,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -362,7 +362,6 @@ export async function runPreparedReply(
   const authProfileId = await resolveSessionAuthProfileOverride({
     cfg,
     provider,
-    agentDir,
     sessionEntry,
     sessionStore,
     sessionKey,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -153,7 +153,6 @@ export async function getReplyFromConfig(
     ctx: finalized,
     cfg,
     agentId,
-    agentDir,
     workspaceDir,
     agentCfg,
     sessionCtx,

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -1,12 +1,5 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-import {
-  resolveAgentDir,
-  resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
-} from "../agents/agent-scope.js";
+import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { upsertAuthProfile } from "../auth/index.js";
-import { resolveAuthStorePath } from "../auth/paths.js";
 import { writeConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
@@ -36,15 +29,6 @@ type AgentsAddOptions = {
   nonInteractive?: boolean;
   json?: boolean;
 };
-
-async function fileExists(pathname: string): Promise<boolean> {
-  try {
-    await fs.stat(pathname);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 export async function agentsAddCommand(
   opts: AgentsAddOptions,
@@ -228,29 +212,6 @@ export async function agentsAddCommand(
       agentDir,
     });
 
-    const defaultAgentId = resolveDefaultAgentId(cfg);
-    if (defaultAgentId !== agentId) {
-      const sourceAuthPath = resolveAuthStorePath(resolveAgentDir(cfg, defaultAgentId));
-      const destAuthPath = resolveAuthStorePath(agentDir);
-      const sameAuthPath =
-        path.resolve(sourceAuthPath).toLowerCase() === path.resolve(destAuthPath).toLowerCase();
-      if (
-        !sameAuthPath &&
-        (await fileExists(sourceAuthPath)) &&
-        !(await fileExists(destAuthPath))
-      ) {
-        const shouldCopy = await prompter.confirm({
-          message: `Copy auth profiles from "${defaultAgentId}"?`,
-          initialValue: false,
-        });
-        if (shouldCopy) {
-          await fs.mkdir(path.dirname(destAuthPath), { recursive: true });
-          await fs.copyFile(sourceAuthPath, destAuthPath);
-          await prompter.note(`Copied auth profiles from "${defaultAgentId}".`, "Auth profiles");
-        }
-      }
-    }
-
     const wantsAuth = await prompter.confirm({
       message: "Configure model/auth for this agent now?",
       initialValue: false,
@@ -278,7 +239,6 @@ export async function agentsAddCommand(
           upsertAuthProfile({
             profileId: "anthropic:default",
             credential: { type: "api_key", provider: "anthropic", key },
-            agentDir,
           });
         }
       } else if (selectedRuntime === "gemini") {
@@ -287,7 +247,6 @@ export async function agentsAddCommand(
           upsertAuthProfile({
             profileId: "google:default",
             credential: { type: "api_key", provider: "google", key },
-            agentDir,
           });
         }
       } else if (selectedRuntime === "codex") {
@@ -296,7 +255,6 @@ export async function agentsAddCommand(
           upsertAuthProfile({
             profileId: "codex:default",
             credential: { type: "api_key", provider: "codex", key },
-            agentDir,
           });
         }
       } else if (selectedRuntime === "opencode") {
@@ -305,7 +263,6 @@ export async function agentsAddCommand(
           upsertAuthProfile({
             profileId: "opencode:default",
             credential: { type: "api_key", provider: "opencode", key },
-            agentDir,
           });
         }
       }

--- a/src/commands/doctor-auth.deprecated-cli-profiles.test.ts
+++ b/src/commands/doctor-auth.deprecated-cli-profiles.test.ts
@@ -8,7 +8,7 @@ import { maybeRemoveDeprecatedCliAuthProfiles } from "./doctor-auth.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
 let envSnapshot: ReturnType<typeof captureEnv>;
-let tempAgentDir: string | undefined;
+let tempStateDir: string | undefined;
 
 function makePrompter(confirmValue: boolean): DoctorPrompter {
   return {
@@ -23,26 +23,25 @@ function makePrompter(confirmValue: boolean): DoctorPrompter {
 }
 
 beforeEach(() => {
-  envSnapshot = captureEnv(["REMOTECLAW_AGENT_DIR", "PI_CODING_AGENT_DIR"]);
-  tempAgentDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-auth-"));
-  process.env.REMOTECLAW_AGENT_DIR = tempAgentDir;
-  process.env.PI_CODING_AGENT_DIR = tempAgentDir;
+  envSnapshot = captureEnv(["REMOTECLAW_STATE_DIR", "REMOTECLAW_AGENT_DIR", "PI_CODING_AGENT_DIR"]);
+  tempStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-auth-"));
+  process.env.REMOTECLAW_STATE_DIR = tempStateDir;
 });
 
 afterEach(() => {
   envSnapshot.restore();
-  if (tempAgentDir) {
-    fs.rmSync(tempAgentDir, { recursive: true, force: true });
-    tempAgentDir = undefined;
+  if (tempStateDir) {
+    fs.rmSync(tempStateDir, { recursive: true, force: true });
+    tempStateDir = undefined;
   }
 });
 
 describe("maybeRemoveDeprecatedCliAuthProfiles", () => {
   it("removes deprecated CLI auth profiles from store + config", async () => {
-    if (!tempAgentDir) {
-      throw new Error("Missing temp agent dir");
+    if (!tempStateDir) {
+      throw new Error("Missing temp state dir");
     }
-    const authPath = path.join(tempAgentDir, "auth-profiles.json");
+    const authPath = path.join(tempStateDir, "auth-profiles.json");
     fs.writeFileSync(
       authPath,
       `${JSON.stringify(

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -59,7 +59,7 @@ export async function maybeRemoveDeprecatedCliAuthProfiles(
   cfg: RemoteClawConfig,
   prompter: DoctorPrompter,
 ): Promise<RemoteClawConfig> {
-  const store = ensureAuthProfileStore(undefined, { allowKeychainPrompt: false });
+  const store = ensureAuthProfileStore();
   const deprecated = new Set<string>();
   if (store.profiles[CLAUDE_CLI_PROFILE_ID] || cfg.auth?.profiles?.[CLAUDE_CLI_PROFILE_ID]) {
     deprecated.add(CLAUDE_CLI_PROFILE_ID);
@@ -144,9 +144,7 @@ export async function noteAuthProfileHealth(params: {
   prompter: DoctorPrompter;
   allowKeychainPrompt: boolean;
 }): Promise<void> {
-  const store = ensureAuthProfileStore(undefined, {
-    allowKeychainPrompt: params.allowKeychainPrompt,
-  });
+  const store = ensureAuthProfileStore();
 
   const summary = buildAuthHealthSummary({
     store,

--- a/src/commands/onboard-auth.config-core.kilocode.test.ts
+++ b/src/commands/onboard-auth.config-core.kilocode.test.ts
@@ -1,6 +1,3 @@
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveApiKeyForProvider, resolveEnvApiKey } from "../auth/provider-auth.js";
 import type { RemoteClawConfig } from "../config/config.js";
@@ -143,14 +140,12 @@ describe("Kilo Gateway provider config", () => {
     });
 
     it("resolves the kilocode api key via resolveApiKeyForProvider", async () => {
-      const agentDir = mkdtempSync(join(tmpdir(), "remoteclaw-test-"));
       const envSnapshot = captureEnv(["KILOCODE_API_KEY"]);
       process.env.KILOCODE_API_KEY = "kilo-provider-test-key";
 
       try {
         const auth = await resolveApiKeyForProvider({
           provider: "kilocode",
-          agentDir,
         });
 
         expect(auth.apiKey).toBe("kilo-provider-test-key");

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -1,80 +1,16 @@
-import fs from "node:fs";
-import path from "node:path";
-import { resolveRemoteClawAgentDir } from "../agents/agent-paths.js";
 import { upsertAuthProfile } from "../auth/index.js";
-import { resolveStateDir } from "../config/paths.js";
 import { KILOCODE_DEFAULT_MODEL_REF } from "../providers/kilocode-shared.js";
 import type { OAuthCredentials } from "../types/agent-types.js";
 export { MISTRAL_DEFAULT_MODEL_REF, XAI_DEFAULT_MODEL_REF } from "./onboard-auth.models.js";
 export { KILOCODE_DEFAULT_MODEL_REF };
 
-const resolveAuthAgentDir = (agentDir?: string) => agentDir ?? resolveRemoteClawAgentDir();
-
-export type WriteOAuthCredentialsOptions = {
-  syncSiblingAgents?: boolean;
-};
-
-/** Resolve real path, returning null if the target doesn't exist. */
-function safeRealpathSync(dir: string): string | null {
-  try {
-    return fs.realpathSync(path.resolve(dir));
-  } catch {
-    return null;
-  }
-}
-
-function resolveSiblingAgentDirs(primaryAgentDir: string): string[] {
-  const normalized = path.resolve(primaryAgentDir);
-
-  // Derive agentsRoot from primaryAgentDir when it matches the standard
-  // layout (.../agents/<name>/agent). Falls back to global state dir.
-  const parentOfAgent = path.dirname(normalized);
-  const candidateAgentsRoot = path.dirname(parentOfAgent);
-  const looksLikeStandardLayout =
-    path.basename(normalized) === "agent" && path.basename(candidateAgentsRoot) === "agents";
-
-  const agentsRoot = looksLikeStandardLayout
-    ? candidateAgentsRoot
-    : path.join(resolveStateDir(), "agents");
-
-  const entries = (() => {
-    try {
-      return fs.readdirSync(agentsRoot, { withFileTypes: true });
-    } catch {
-      return [];
-    }
-  })();
-  // Include both directories and symlinks-to-directories.
-  const discovered = entries
-    .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
-    .map((entry) => path.join(agentsRoot, entry.name, "agent"));
-
-  // Deduplicate via realpath to handle symlinks and path normalization.
-  const seen = new Set<string>();
-  const result: string[] = [];
-  for (const dir of [normalized, ...discovered]) {
-    const real = safeRealpathSync(dir);
-    if (real && !seen.has(real)) {
-      seen.add(real);
-      result.push(real);
-    }
-  }
-  return result;
-}
-
 export async function writeOAuthCredentials(
   provider: string,
   creds: OAuthCredentials,
-  agentDir?: string,
-  options?: WriteOAuthCredentialsOptions,
 ): Promise<string> {
   const email =
     typeof creds.email === "string" && creds.email.trim() ? creds.email.trim() : "default";
   const profileId = `${provider}:${email}`;
-  const resolvedAgentDir = path.resolve(resolveAuthAgentDir(agentDir));
-  const targetAgentDirs = options?.syncSiblingAgents
-    ? resolveSiblingAgentDirs(resolvedAgentDir)
-    : [resolvedAgentDir];
 
   const credEmail = email !== "default" ? email : undefined;
   const credential = {
@@ -84,37 +20,15 @@ export async function writeOAuthCredentials(
     ...(credEmail ? { email: credEmail } : {}),
   };
 
-  // Primary write must succeed — let it throw on failure.
   upsertAuthProfile({
     profileId,
     credential,
-    agentDir: resolvedAgentDir,
   });
 
-  // Sibling sync is best-effort — log and ignore individual failures.
-  if (options?.syncSiblingAgents) {
-    const primaryReal = safeRealpathSync(resolvedAgentDir);
-    for (const targetAgentDir of targetAgentDirs) {
-      const targetReal = safeRealpathSync(targetAgentDir);
-      if (targetReal && primaryReal && targetReal === primaryReal) {
-        continue;
-      }
-      try {
-        upsertAuthProfile({
-          profileId,
-          credential,
-          agentDir: targetAgentDir,
-        });
-      } catch {
-        // Best-effort: sibling sync failure must not block primary onboarding.
-      }
-    }
-  }
   return profileId;
 }
 
-export async function setAnthropicApiKey(key: string, agentDir?: string) {
-  // Write to resolved agent dir so gateway finds credentials on startup.
+export async function setAnthropicApiKey(key: string) {
   upsertAuthProfile({
     profileId: "anthropic:default",
     credential: {
@@ -122,12 +36,10 @@ export async function setAnthropicApiKey(key: string, agentDir?: string) {
       provider: "anthropic",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setGeminiApiKey(key: string, agentDir?: string) {
-  // Write to resolved agent dir so gateway finds credentials on startup.
+export async function setGeminiApiKey(key: string) {
   upsertAuthProfile({
     profileId: "google:default",
     credential: {
@@ -135,17 +47,11 @@ export async function setGeminiApiKey(key: string, agentDir?: string) {
       provider: "google",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setMinimaxApiKey(
-  key: string,
-  agentDir?: string,
-  profileId: string = "minimax:default",
-) {
+export async function setMinimaxApiKey(key: string, profileId: string = "minimax:default") {
   const provider = profileId.split(":")[0] ?? "minimax";
-  // Write to resolved agent dir so gateway finds credentials on startup.
   upsertAuthProfile({
     profileId,
     credential: {
@@ -153,12 +59,10 @@ export async function setMinimaxApiKey(
       provider,
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setMoonshotApiKey(key: string, agentDir?: string) {
-  // Write to resolved agent dir so gateway finds credentials on startup.
+export async function setMoonshotApiKey(key: string) {
   upsertAuthProfile({
     profileId: "moonshot:default",
     credential: {
@@ -166,12 +70,10 @@ export async function setMoonshotApiKey(key: string, agentDir?: string) {
       provider: "moonshot",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setKimiCodingApiKey(key: string, agentDir?: string) {
-  // Write to resolved agent dir so gateway finds credentials on startup.
+export async function setKimiCodingApiKey(key: string) {
   upsertAuthProfile({
     profileId: "kimi-coding:default",
     credential: {
@@ -179,12 +81,10 @@ export async function setKimiCodingApiKey(key: string, agentDir?: string) {
       provider: "kimi-coding",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setSyntheticApiKey(key: string, agentDir?: string) {
-  // Write to resolved agent dir so gateway finds credentials on startup.
+export async function setSyntheticApiKey(key: string) {
   upsertAuthProfile({
     profileId: "synthetic:default",
     credential: {
@@ -192,12 +92,10 @@ export async function setSyntheticApiKey(key: string, agentDir?: string) {
       provider: "synthetic",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setVeniceApiKey(key: string, agentDir?: string) {
-  // Write to resolved agent dir so gateway finds credentials on startup.
+export async function setVeniceApiKey(key: string) {
   upsertAuthProfile({
     profileId: "venice:default",
     credential: {
@@ -205,7 +103,6 @@ export async function setVeniceApiKey(key: string, agentDir?: string) {
       provider: "venice",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
@@ -217,8 +114,7 @@ export const TOGETHER_DEFAULT_MODEL_REF = "together/moonshotai/Kimi-K2.5";
 export const LITELLM_DEFAULT_MODEL_REF = "litellm/claude-opus-4-6";
 export const VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF = "vercel-ai-gateway/anthropic/claude-opus-4.6";
 
-export async function setZaiApiKey(key: string, agentDir?: string) {
-  // Write to resolved agent dir so gateway finds credentials on startup.
+export async function setZaiApiKey(key: string) {
   upsertAuthProfile({
     profileId: "zai:default",
     credential: {
@@ -226,11 +122,10 @@ export async function setZaiApiKey(key: string, agentDir?: string) {
       provider: "zai",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setXiaomiApiKey(key: string, agentDir?: string) {
+export async function setXiaomiApiKey(key: string) {
   upsertAuthProfile({
     profileId: "xiaomi:default",
     credential: {
@@ -238,11 +133,10 @@ export async function setXiaomiApiKey(key: string, agentDir?: string) {
       provider: "xiaomi",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setOpenrouterApiKey(key: string, agentDir?: string) {
+export async function setOpenrouterApiKey(key: string) {
   // Never persist the literal "undefined" (e.g. when prompt returns undefined and caller used String(key)).
   const safeKey = key === "undefined" ? "" : key;
   upsertAuthProfile({
@@ -252,7 +146,6 @@ export async function setOpenrouterApiKey(key: string, agentDir?: string) {
       provider: "openrouter",
       key: safeKey,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
@@ -260,7 +153,6 @@ export async function setCloudflareAiGatewayConfig(
   accountId: string,
   gatewayId: string,
   apiKey: string,
-  agentDir?: string,
 ) {
   const normalizedAccountId = accountId.trim();
   const normalizedGatewayId = gatewayId.trim();
@@ -276,11 +168,10 @@ export async function setCloudflareAiGatewayConfig(
         gatewayId: normalizedGatewayId,
       },
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setLitellmApiKey(key: string, agentDir?: string) {
+export async function setLitellmApiKey(key: string) {
   upsertAuthProfile({
     profileId: "litellm:default",
     credential: {
@@ -288,11 +179,10 @@ export async function setLitellmApiKey(key: string, agentDir?: string) {
       provider: "litellm",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setVercelAiGatewayApiKey(key: string, agentDir?: string) {
+export async function setVercelAiGatewayApiKey(key: string) {
   upsertAuthProfile({
     profileId: "vercel-ai-gateway:default",
     credential: {
@@ -300,11 +190,10 @@ export async function setVercelAiGatewayApiKey(key: string, agentDir?: string) {
       provider: "vercel-ai-gateway",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setOpencodeZenApiKey(key: string, agentDir?: string) {
+export async function setOpencodeZenApiKey(key: string) {
   upsertAuthProfile({
     profileId: "opencode:default",
     credential: {
@@ -312,11 +201,10 @@ export async function setOpencodeZenApiKey(key: string, agentDir?: string) {
       provider: "opencode",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setTogetherApiKey(key: string, agentDir?: string) {
+export async function setTogetherApiKey(key: string) {
   upsertAuthProfile({
     profileId: "together:default",
     credential: {
@@ -324,11 +212,10 @@ export async function setTogetherApiKey(key: string, agentDir?: string) {
       provider: "together",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setHuggingfaceApiKey(key: string, agentDir?: string) {
+export async function setHuggingfaceApiKey(key: string) {
   upsertAuthProfile({
     profileId: "huggingface:default",
     credential: {
@@ -336,11 +223,10 @@ export async function setHuggingfaceApiKey(key: string, agentDir?: string) {
       provider: "huggingface",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export function setQianfanApiKey(key: string, agentDir?: string) {
+export function setQianfanApiKey(key: string) {
   upsertAuthProfile({
     profileId: "qianfan:default",
     credential: {
@@ -348,11 +234,10 @@ export function setQianfanApiKey(key: string, agentDir?: string) {
       provider: "qianfan",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export function setXaiApiKey(key: string, agentDir?: string) {
+export function setXaiApiKey(key: string) {
   upsertAuthProfile({
     profileId: "xai:default",
     credential: {
@@ -360,11 +245,10 @@ export function setXaiApiKey(key: string, agentDir?: string) {
       provider: "xai",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setMistralApiKey(key: string, agentDir?: string) {
+export async function setMistralApiKey(key: string) {
   upsertAuthProfile({
     profileId: "mistral:default",
     credential: {
@@ -372,11 +256,10 @@ export async function setMistralApiKey(key: string, agentDir?: string) {
       provider: "mistral",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setKilocodeApiKey(key: string, agentDir?: string) {
+export async function setKilocodeApiKey(key: string) {
   upsertAuthProfile({
     profileId: "kilocode:default",
     credential: {
@@ -384,6 +267,5 @@ export async function setKilocodeApiKey(key: string, agentDir?: string) {
       provider: "kilocode",
       key,
     },
-    agentDir: resolveAuthAgentDir(agentDir),
   });
 }

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { RemoteClawConfig } from "../config/config.js";
@@ -54,11 +53,7 @@ import {
   setMinimaxApiKey,
   writeOAuthCredentials,
 } from "./onboard-auth.js";
-import {
-  createAuthTestLifecycle,
-  readAuthProfilesForAgent,
-  setupAuthTestEnv,
-} from "./test-wizard-helpers.js";
+import { createAuthTestLifecycle, setupAuthTestEnv } from "./test-wizard-helpers.js";
 
 function createLegacyProviderConfig(_params: {
   providerId: string;
@@ -119,14 +114,11 @@ describe("writeOAuthCredentials", () => {
     "REMOTECLAW_OAUTH_DIR",
   ]);
 
-  let tempStateDir: string;
-  const authProfilePathFor = (dir: string) => path.join(dir, "auth-profiles.json");
-
   afterEach(async () => {
     await lifecycle.cleanup();
   });
 
-  it("writes auth-profiles.json under REMOTECLAW_AGENT_DIR when set", async () => {
+  it("writes auth-profiles.json to global state dir", async () => {
     const env = await setupAuthTestEnv("remoteclaw-oauth-");
     lifecycle.setStateDir(env.stateDir);
 
@@ -138,129 +130,16 @@ describe("writeOAuthCredentials", () => {
 
     await writeOAuthCredentials("openai-codex", creds);
 
-    const parsed = await readAuthProfilesForAgent<{
+    const globalPath = path.join(env.stateDir, "auth-profiles.json");
+    const raw = await fs.readFile(globalPath, "utf8");
+    const parsed = JSON.parse(raw) as {
       profiles?: Record<string, { type?: string; key?: string; provider?: string }>;
-    }>(env.agentDir);
+    };
     expect(parsed.profiles?.["openai-codex:default"]).toMatchObject({
       type: "api_key",
       provider: "openai-codex",
       key: "access-token",
     });
-
-    await expect(
-      fs.readFile(path.join(env.stateDir, "agents", "main", "agent", "auth-profiles.json"), "utf8"),
-    ).rejects.toThrow();
-  });
-
-  it("writes OAuth credentials to all sibling agent dirs when syncSiblingAgents=true", async () => {
-    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-oauth-sync-"));
-    process.env.REMOTECLAW_STATE_DIR = tempStateDir;
-
-    const mainAgentDir = path.join(tempStateDir, "agents", "main", "agent");
-    const kidAgentDir = path.join(tempStateDir, "agents", "kid", "agent");
-    const workerAgentDir = path.join(tempStateDir, "agents", "worker", "agent");
-    await fs.mkdir(mainAgentDir, { recursive: true });
-    await fs.mkdir(kidAgentDir, { recursive: true });
-    await fs.mkdir(workerAgentDir, { recursive: true });
-
-    process.env.REMOTECLAW_AGENT_DIR = kidAgentDir;
-    process.env.PI_CODING_AGENT_DIR = kidAgentDir;
-
-    const creds = {
-      refresh: "refresh-sync",
-      access: "access-sync",
-      expires: Date.now() + 60_000,
-    } satisfies OAuthCredentials;
-
-    await writeOAuthCredentials("openai-codex", creds, undefined, {
-      syncSiblingAgents: true,
-    });
-
-    for (const dir of [mainAgentDir, kidAgentDir, workerAgentDir]) {
-      const raw = await fs.readFile(authProfilePathFor(dir), "utf8");
-      const parsed = JSON.parse(raw) as {
-        profiles?: Record<string, { type?: string; key?: string; provider?: string }>;
-      };
-      expect(parsed.profiles?.["openai-codex:default"]).toMatchObject({
-        type: "api_key",
-        provider: "openai-codex",
-        key: "access-sync",
-      });
-    }
-  });
-
-  it("writes OAuth credentials only to target dir by default", async () => {
-    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-oauth-nosync-"));
-    process.env.REMOTECLAW_STATE_DIR = tempStateDir;
-
-    const mainAgentDir = path.join(tempStateDir, "agents", "main", "agent");
-    const kidAgentDir = path.join(tempStateDir, "agents", "kid", "agent");
-    await fs.mkdir(mainAgentDir, { recursive: true });
-    await fs.mkdir(kidAgentDir, { recursive: true });
-
-    process.env.REMOTECLAW_AGENT_DIR = kidAgentDir;
-    process.env.PI_CODING_AGENT_DIR = kidAgentDir;
-
-    const creds = {
-      refresh: "refresh-kid",
-      access: "access-kid",
-      expires: Date.now() + 60_000,
-    } satisfies OAuthCredentials;
-
-    await writeOAuthCredentials("openai-codex", creds, kidAgentDir);
-
-    const kidRaw = await fs.readFile(authProfilePathFor(kidAgentDir), "utf8");
-    const kidParsed = JSON.parse(kidRaw) as {
-      profiles?: Record<string, { type?: string; key?: string; provider?: string }>;
-    };
-    expect(kidParsed.profiles?.["openai-codex:default"]).toMatchObject({
-      type: "api_key",
-      provider: "openai-codex",
-      key: "access-kid",
-    });
-
-    await expect(fs.readFile(authProfilePathFor(mainAgentDir), "utf8")).rejects.toThrow();
-  });
-
-  it("syncs siblings from explicit agentDir outside REMOTECLAW_STATE_DIR", async () => {
-    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-oauth-external-"));
-    process.env.REMOTECLAW_STATE_DIR = tempStateDir;
-
-    // Create standard-layout agents tree *outside* REMOTECLAW_STATE_DIR
-    const externalRoot = path.join(tempStateDir, "external", "agents");
-    const extMain = path.join(externalRoot, "main", "agent");
-    const extKid = path.join(externalRoot, "kid", "agent");
-    const extWorker = path.join(externalRoot, "worker", "agent");
-    await fs.mkdir(extMain, { recursive: true });
-    await fs.mkdir(extKid, { recursive: true });
-    await fs.mkdir(extWorker, { recursive: true });
-
-    const creds = {
-      refresh: "refresh-ext",
-      access: "access-ext",
-      expires: Date.now() + 60_000,
-    } satisfies OAuthCredentials;
-
-    await writeOAuthCredentials("openai-codex", creds, extKid, {
-      syncSiblingAgents: true,
-    });
-
-    // All siblings under the external root should have credentials
-    for (const dir of [extMain, extKid, extWorker]) {
-      const raw = await fs.readFile(authProfilePathFor(dir), "utf8");
-      const parsed = JSON.parse(raw) as {
-        profiles?: Record<string, { type?: string; key?: string; provider?: string }>;
-      };
-      expect(parsed.profiles?.["openai-codex:default"]).toMatchObject({
-        type: "api_key",
-        provider: "openai-codex",
-        key: "access-ext",
-      });
-    }
-
-    // Global state dir should NOT have credentials written
-    const globalMain = path.join(tempStateDir, "agents", "main", "agent");
-    await expect(fs.readFile(authProfilePathFor(globalMain), "utf8")).rejects.toThrow();
   });
 });
 
@@ -275,24 +154,22 @@ describe("setMinimaxApiKey", () => {
     await lifecycle.cleanup();
   });
 
-  it("writes to REMOTECLAW_AGENT_DIR when set", async () => {
+  it("writes to global state dir", async () => {
     const env = await setupAuthTestEnv("remoteclaw-minimax-", { agentSubdir: "custom-agent" });
     lifecycle.setStateDir(env.stateDir);
 
     await setMinimaxApiKey("sk-minimax-test");
 
-    const parsed = await readAuthProfilesForAgent<{
+    const globalPath = path.join(env.stateDir, "auth-profiles.json");
+    const raw = await fs.readFile(globalPath, "utf8");
+    const parsed = JSON.parse(raw) as {
       profiles?: Record<string, { type?: string; provider?: string; key?: string }>;
-    }>(env.agentDir);
+    };
     expect(parsed.profiles?.["minimax:default"]).toMatchObject({
       type: "api_key",
       provider: "minimax",
       key: "sk-minimax-test",
     });
-
-    await expect(
-      fs.readFile(path.join(env.stateDir, "agents", "main", "agent", "auth-profiles.json"), "utf8"),
-    ).rejects.toThrow();
   });
 });
 

--- a/src/config/agent-dirs.ts
+++ b/src/config/agent-dirs.ts
@@ -100,13 +100,12 @@ export function findDuplicateAgentDirs(
 export function formatDuplicateAgentDirError(dups: DuplicateAgentDir[]): string {
   const lines: string[] = [
     "Duplicate agentDir detected (multi-agent config).",
-    "Each agent must have a unique agentDir; sharing it causes auth/session state collisions and token invalidation.",
+    "Each agent must have a unique agentDir; sharing it causes session state collisions.",
     "",
     "Conflicts:",
     ...dups.map((d) => `- ${d.agentDir}: ${d.agentIds.map((id) => `"${id}"`).join(", ")}`),
     "",
     "Fix: remove the shared agents.list[].agentDir override (or give each agent its own directory).",
-    "If you want to share credentials, copy auth-profiles.json instead of sharing the entire agentDir.",
   ];
   return lines.join("\n");
 }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,7 +1,6 @@
 import crypto from "node:crypto";
 import {
   resolveAgentConfig,
-  resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../../agents/agent-scope.js";
@@ -194,7 +193,6 @@ export async function runCronIsolatedAgentTurn(params: {
   });
 
   const workspaceDirRaw = resolveAgentWorkspaceDir(params.cfg, agentId);
-  const agentDir = resolveAgentDir(params.cfg, agentId);
   const workspaceDir = await ensureAgentWorkspace(workspaceDirRaw);
 
   const resolvedDefault = normalizeModelRef("unknown", "unknown");
@@ -345,7 +343,6 @@ export async function runCronIsolatedAgentTurn(params: {
   await resolveSessionAuthProfileOverride({
     cfg: cfgWithAgentDefaults,
     provider,
-    agentDir,
     sessionEntry: cronSession.sessionEntry,
     sessionStore: cronSession.store,
     sessionKey: agentSessionKey,

--- a/src/infra/provider-usage.auth.normalizes-keys.test.ts
+++ b/src/infra/provider-usage.auth.normalizes-keys.test.ts
@@ -67,10 +67,10 @@ describe("resolveProviderAuths key normalization", () => {
   }
 
   async function writeAuthProfiles(home: string, profiles: Record<string, unknown>) {
-    const agentDir = path.join(home, ".remoteclaw", "agents", "main", "agent");
-    await fs.mkdir(agentDir, { recursive: true });
+    const stateDir = path.join(home, ".remoteclaw");
+    await fs.mkdir(stateDir, { recursive: true });
     await fs.writeFile(
-      path.join(agentDir, "auth-profiles.json"),
+      path.join(stateDir, "auth-profiles.json"),
       `${JSON.stringify({ version: 1, profiles }, null, 2)}\n`,
       "utf8",
     );

--- a/src/infra/provider-usage.auth.ts
+++ b/src/infra/provider-usage.auth.ts
@@ -93,11 +93,8 @@ function resolveProviderApiKeyFromConfigAndStore(params: {
 
 async function resolveProfileToken(params: {
   provider: UsageProviderId;
-  agentDir?: string;
 }): Promise<ProviderAuth | null> {
-  const store = ensureAuthProfileStore(params.agentDir, {
-    allowKeychainPrompt: false,
-  });
+  const store = ensureAuthProfileStore();
   const profiles = listProfilesForProvider(store, params.provider);
 
   for (const profileId of profiles) {
@@ -106,7 +103,6 @@ async function resolveProfileToken(params: {
         cfg: undefined,
         store,
         profileId,
-        agentDir: params.agentDir,
       });
       if (resolved) {
         return {
@@ -122,10 +118,8 @@ async function resolveProfileToken(params: {
   return null;
 }
 
-function resolveProviderCandidates(agentDir?: string): UsageProviderId[] {
-  const store = ensureAuthProfileStore(agentDir, {
-    allowKeychainPrompt: false,
-  });
+function resolveProviderCandidates(): UsageProviderId[] {
+  const store = ensureAuthProfileStore();
   const providers = [
     "anthropic",
     "github-copilot",
@@ -141,13 +135,12 @@ function resolveProviderCandidates(agentDir?: string): UsageProviderId[] {
 export async function resolveProviderAuths(params: {
   providers: UsageProviderId[];
   auth?: ProviderAuth[];
-  agentDir?: string;
 }): Promise<ProviderAuth[]> {
   if (params.auth) {
     return params.auth;
   }
 
-  const candidates = resolveProviderCandidates(params.agentDir);
+  const candidates = resolveProviderCandidates();
   const auths: ProviderAuth[] = [];
 
   for (const provider of params.providers) {
@@ -178,7 +171,6 @@ export async function resolveProviderAuths(params: {
     }
     const auth = await resolveProfileToken({
       provider,
-      agentDir: params.agentDir,
     });
     if (auth) {
       auths.push(auth);

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -26,7 +26,6 @@ type UsageSummaryOptions = {
   timeoutMs?: number;
   providers?: UsageProviderId[];
   auth?: ProviderAuth[];
-  agentDir?: string;
   fetch?: typeof fetch;
 };
 
@@ -43,7 +42,6 @@ export async function loadProviderUsageSummary(
   const auths = await resolveProviderAuths({
     providers: opts.providers ?? usageProviders,
     auth: opts.auth,
-    agentDir: opts.agentDir,
   });
   if (auths.length === 0) {
     return { updatedAt: now, providers: [] };

--- a/src/infra/provider-usage.test.ts
+++ b/src/infra/provider-usage.test.ts
@@ -236,15 +236,10 @@ describe("provider usage loading", () => {
   it("discovers Claude usage from api_key auth profiles", async () => {
     await withTempHome(
       async (tempHome) => {
-        const agentDir = path.join(
-          process.env.REMOTECLAW_STATE_DIR ?? path.join(tempHome, ".remoteclaw"),
-          "agents",
-          "main",
-          "agent",
-        );
-        fs.mkdirSync(agentDir, { recursive: true, mode: 0o700 });
+        const stateDir = process.env.REMOTECLAW_STATE_DIR ?? path.join(tempHome, ".remoteclaw");
+        fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
         fs.writeFileSync(
-          path.join(agentDir, "auth-profiles.json"),
+          path.join(stateDir, "auth-profiles.json"),
           `${JSON.stringify(
             {
               version: 1,
@@ -261,9 +256,7 @@ describe("provider usage loading", () => {
           )}\n`,
           "utf8",
         );
-        const store = ensureAuthProfileStore(agentDir, {
-          allowKeychainPrompt: false,
-        });
+        const store = ensureAuthProfileStore();
         expect(listProfilesForProvider(store, "anthropic")).toContain("anthropic:default");
 
         const mockFetch = createProviderUsageFetch(async (url, init) => {
@@ -283,7 +276,6 @@ describe("provider usage loading", () => {
         const summary = await loadProviderUsageSummary({
           now: usageNow,
           providers: ["anthropic"],
-          agentDir,
           fetch: mockFetch as unknown as typeof fetch,
         });
 

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -308,7 +308,6 @@ async function resolveProviderExecutionAuth(params: {
     cfg: params.cfg,
     profileId: params.entry.profile,
     preferredProfile: params.entry.preferredProfile,
-    agentDir: params.agentDir,
   });
   return {
     apiKeys: collectProviderApiKeysForExecution({

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -330,7 +330,7 @@ async function resolveKeyEntry(params: {
   capability: MediaUnderstandingCapability;
   activeModel?: ActiveMediaModel;
 }): Promise<MediaUnderstandingModelConfig | null> {
-  const { cfg, agentDir, providerRegistry, capability } = params;
+  const { cfg, providerRegistry, capability } = params;
   const checkProvider = async (
     providerId: string,
     model?: string,
@@ -346,7 +346,7 @@ async function resolveKeyEntry(params: {
       return null;
     }
     try {
-      await resolveApiKeyForProvider({ provider: providerId, cfg, agentDir });
+      await resolveApiKeyForProvider({ provider: providerId, cfg });
       return { type: "provider" as const, provider: providerId, model };
     } catch {
       return null;
@@ -443,7 +443,6 @@ async function resolveActiveModelEntry(params: {
     await resolveApiKeyForProvider({
       provider: providerId,
       cfg: params.cfg,
-      agentDir: params.agentDir,
     });
   } catch {
     return null;

--- a/src/middleware/auth-key-retry.ts
+++ b/src/middleware/auth-key-retry.ts
@@ -17,7 +17,6 @@ const log = createSubsystemLogger("auth-retry");
 export type AuthKeyRetryOptions = {
   cfg: RemoteClawConfig;
   agentId: string;
-  agentDir?: string;
   baseEnv?: Record<string, string>;
   store?: AuthProfileStore;
 };
@@ -52,7 +51,6 @@ export async function withAuthKeyRetry<T>(
     const authEnv = await resolveAuthEnv({
       cfg: options.cfg,
       agentId: options.agentId,
-      agentDir: options.agentDir,
       store: options.store,
     });
     const env = authEnv


### PR DESCRIPTION
## Summary

- Relocates auth profile store from per-agent (`~/.remoteclaw/agents/{agentId}/agent/auth-profiles.json`) to global (`~/.remoteclaw/auth-profiles.json`)
- Removes `agentDir` parameter threading from all auth function signatures and call sites (34 files, -714 lines)
- Removes auth store inheritance/merge logic, sibling agent sync, and legacy `auth.json` migration (OpenClaw dead code)
- Per-agent credential selection now handled by config `auth` field instead of per-agent store files

Closes #438

## Test plan

- [x] Type-check passes (`npx tsc --noEmit` — zero errors in `src/`)
- [x] Lint passes (`pnpm lint` — zero errors)
- [x] Full test suite passes (971 + 141 + 93 test files, 10,279 tests)
- [x] Updated tests for global store path (`store.ensureauthprofilestore.test.ts`, `onboard-auth.test.ts`, `provider-usage.test.ts`, `doctor-auth.deprecated-cli-profiles.test.ts`, `provider-usage.auth.normalizes-keys.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)