### PR TITLE
fix(import): consolidate per-agent auth profiles into global store (#439)

### DIFF
--- a/src/commands/import.test.ts
+++ b/src/commands/import.test.ts
@@ -6,8 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   clearWizardSection,
+  consolidateAuthProfiles,
   detectOpenClawInstallation,
   discoverSourceAuthProfileIds,
+  discoverSourceAuthProfiles,
   importCommand,
   isImportableRootEntry,
   materializeAuthDefaults,
@@ -474,6 +476,280 @@ describe("discoverSourceAuthProfileIds", () => {
     // auth.json with "profiles" key is treated as modern and skipped by legacy collector,
     // and it's not named auth-profiles.json so modern collector also skips it
     expect(discoverSourceAuthProfileIds(tmpDir)).toEqual([]);
+  });
+});
+
+describe("discoverSourceAuthProfiles", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "auth-profiles-test-"));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns full profile credentials from modern auth-profiles.json", async () => {
+    const agentDir = path.join(tmpDir, "agents", "main", "agent");
+    await fsp.mkdir(agentDir, { recursive: true });
+    await fsp.writeFile(
+      path.join(agentDir, "auth-profiles.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "anthropic:default": { type: "api_key", provider: "anthropic", key: "sk-ant-fake" },
+        },
+      }),
+    );
+
+    const profiles = discoverSourceAuthProfiles(tmpDir);
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0].id).toBe("anthropic:default");
+    expect(profiles[0].credential.key).toBe("sk-ant-fake");
+    expect(profiles[0].sourceFile).toContain("auth-profiles.json");
+  });
+
+  it("returns full profile credentials from legacy auth.json", async () => {
+    const agentDir = path.join(tmpDir, "agents", "main", "agent");
+    await fsp.mkdir(agentDir, { recursive: true });
+    await fsp.writeFile(
+      path.join(agentDir, "auth.json"),
+      JSON.stringify({
+        anthropic: { type: "api_key", provider: "anthropic", key: "sk-ant-fake" },
+      }),
+    );
+
+    const profiles = discoverSourceAuthProfiles(tmpDir);
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0].id).toBe("anthropic:default");
+    expect(profiles[0].credential.key).toBe("sk-ant-fake");
+  });
+
+  it("returns profiles from multiple agent directories", async () => {
+    const agent1 = path.join(tmpDir, "agents", "main", "agent");
+    const agent2 = path.join(tmpDir, "agents", "helper", "agent");
+    await fsp.mkdir(agent1, { recursive: true });
+    await fsp.mkdir(agent2, { recursive: true });
+
+    await fsp.writeFile(
+      path.join(agent1, "auth-profiles.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "anthropic:default": { type: "api_key", provider: "anthropic", key: "key-1" },
+        },
+      }),
+    );
+    await fsp.writeFile(
+      path.join(agent2, "auth-profiles.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "google:my-key": { type: "api_key", provider: "google", key: "key-2" },
+        },
+      }),
+    );
+
+    const profiles = discoverSourceAuthProfiles(tmpDir);
+    expect(profiles).toHaveLength(2);
+    const ids = profiles.map((p) => p.id);
+    expect(ids).toContain("anthropic:default");
+    expect(ids).toContain("google:my-key");
+  });
+});
+
+describe("consolidateAuthProfiles", () => {
+  let tmpDir: string;
+  let targetDir: string;
+  let runtime: TestRuntime;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "consolidate-test-"));
+    targetDir = path.join(tmpDir, "target");
+    runtime = createTestRuntime();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes consolidated profiles to global auth-profiles.json", async () => {
+    const result = {
+      copiedFiles: [],
+      transformedFiles: [],
+      envVarRenames: [],
+      skippedEntries: [],
+      targetDir,
+      consolidatedAuthProfiles: [],
+      authProfileConflicts: [],
+    };
+
+    await consolidateAuthProfiles({
+      profiles: [
+        {
+          id: "anthropic:default",
+          credential: { type: "api_key", provider: "anthropic", key: "sk-ant-fake" },
+          sourceFile: "/src/agents/main/agent/auth-profiles.json",
+        },
+        {
+          id: "google:my-key",
+          credential: { type: "api_key", provider: "google", key: "goog-fake" },
+          sourceFile: "/src/agents/helper/agent/auth-profiles.json",
+        },
+      ],
+      targetDir,
+      sourceDir: "/src",
+      dryRun: false,
+      result,
+      runtime: runtime as RuntimeEnv,
+    });
+
+    const storePath = path.join(targetDir, "auth-profiles.json");
+    expect(fs.existsSync(storePath)).toBe(true);
+    const store = JSON.parse(await fsp.readFile(storePath, "utf-8"));
+    expect(store.version).toBe(1);
+    expect(store.profiles["anthropic:default"].key).toBe("sk-ant-fake");
+    expect(store.profiles["google:my-key"].key).toBe("goog-fake");
+    expect(result.consolidatedAuthProfiles).toEqual(["anthropic:default", "google:my-key"]);
+    expect(result.authProfileConflicts).toHaveLength(0);
+  });
+
+  it("warns on profile ID conflict with different keys", async () => {
+    const sourceDir = path.join(tmpDir, "source");
+    const result = {
+      copiedFiles: [],
+      transformedFiles: [],
+      envVarRenames: [],
+      skippedEntries: [],
+      targetDir,
+      consolidatedAuthProfiles: [],
+      authProfileConflicts: [],
+    };
+
+    await consolidateAuthProfiles({
+      profiles: [
+        {
+          id: "anthropic:default",
+          credential: { type: "api_key", provider: "anthropic", key: "key-first" },
+          sourceFile: path.join(sourceDir, "agents", "main", "agent", "auth-profiles.json"),
+        },
+        {
+          id: "anthropic:default",
+          credential: { type: "api_key", provider: "anthropic", key: "key-second" },
+          sourceFile: path.join(sourceDir, "agents", "helper", "agent", "auth-profiles.json"),
+        },
+      ],
+      targetDir,
+      sourceDir,
+      dryRun: false,
+      result,
+      runtime: runtime as RuntimeEnv,
+    });
+
+    // First occurrence wins
+    const store = JSON.parse(
+      await fsp.readFile(path.join(targetDir, "auth-profiles.json"), "utf-8"),
+    );
+    expect(store.profiles["anthropic:default"].key).toBe("key-first");
+
+    // Only one profile consolidated (deduped)
+    expect(result.consolidatedAuthProfiles).toEqual(["anthropic:default"]);
+
+    // Conflict warning emitted
+    expect(result.authProfileConflicts).toHaveLength(1);
+    expect(result.authProfileConflicts[0]).toContain("anthropic:default");
+    expect(result.authProfileConflicts[0]).toContain("conflicts");
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Warning"));
+  });
+
+  it("does not warn on duplicate with same key", async () => {
+    const sourceDir = path.join(tmpDir, "source");
+    const result = {
+      copiedFiles: [],
+      transformedFiles: [],
+      envVarRenames: [],
+      skippedEntries: [],
+      targetDir,
+      consolidatedAuthProfiles: [],
+      authProfileConflicts: [],
+    };
+
+    await consolidateAuthProfiles({
+      profiles: [
+        {
+          id: "anthropic:default",
+          credential: { type: "api_key", provider: "anthropic", key: "same-key" },
+          sourceFile: path.join(sourceDir, "agents", "main", "agent", "auth-profiles.json"),
+        },
+        {
+          id: "anthropic:default",
+          credential: { type: "api_key", provider: "anthropic", key: "same-key" },
+          sourceFile: path.join(sourceDir, "agents", "helper", "agent", "auth-profiles.json"),
+        },
+      ],
+      targetDir,
+      sourceDir,
+      dryRun: false,
+      result,
+      runtime: runtime as RuntimeEnv,
+    });
+
+    expect(result.authProfileConflicts).toHaveLength(0);
+  });
+
+  it("does nothing when no profiles discovered", async () => {
+    const result = {
+      copiedFiles: [],
+      transformedFiles: [],
+      envVarRenames: [],
+      skippedEntries: [],
+      targetDir,
+      consolidatedAuthProfiles: [],
+      authProfileConflicts: [],
+    };
+
+    await consolidateAuthProfiles({
+      profiles: [],
+      targetDir,
+      sourceDir: "/src",
+      dryRun: false,
+      result,
+      runtime: runtime as RuntimeEnv,
+    });
+
+    expect(fs.existsSync(path.join(targetDir, "auth-profiles.json"))).toBe(false);
+    expect(result.consolidatedAuthProfiles).toHaveLength(0);
+  });
+
+  it("dry run does not write file", async () => {
+    const result = {
+      copiedFiles: [],
+      transformedFiles: [],
+      envVarRenames: [],
+      skippedEntries: [],
+      targetDir,
+      consolidatedAuthProfiles: [],
+      authProfileConflicts: [],
+    };
+
+    await consolidateAuthProfiles({
+      profiles: [
+        {
+          id: "anthropic:default",
+          credential: { type: "api_key", provider: "anthropic", key: "sk-fake" },
+          sourceFile: "/src/auth-profiles.json",
+        },
+      ],
+      targetDir,
+      sourceDir: "/src",
+      dryRun: true,
+      result,
+      runtime: runtime as RuntimeEnv,
+    });
+
+    expect(fs.existsSync(path.join(targetDir, "auth-profiles.json"))).toBe(false);
+    expect(result.consolidatedAuthProfiles).toEqual(["anthropic:default"]);
   });
 });
 
@@ -1071,6 +1347,115 @@ describe("importCommand", () => {
     const parsed = JSON.parse(written);
     expect(parsed.$schema).toBeUndefined();
     expect(parsed.gateway.port).toBe(18789);
+  });
+
+  it("consolidates per-agent auth profiles into global store", async () => {
+    const configContent = JSON.stringify({
+      agents: {
+        defaults: { runtime: "claude" },
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    await fsp.writeFile(path.join(sourceDir, "openclaw.json"), configContent);
+
+    // Create auth profiles in two agent directories
+    const agent1 = path.join(sourceDir, "agents", "main", "agent");
+    const agent2 = path.join(sourceDir, "agents", "helper", "agent");
+    await fsp.mkdir(agent1, { recursive: true });
+    await fsp.mkdir(agent2, { recursive: true });
+
+    await fsp.writeFile(
+      path.join(agent1, "auth-profiles.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "anthropic:default": { type: "api_key", provider: "anthropic", key: "key-1" },
+        },
+      }),
+    );
+    await fsp.writeFile(
+      path.join(agent2, "auth-profiles.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "google:my-key": { type: "api_key", provider: "google", key: "key-2" },
+        },
+      }),
+    );
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    // Global store should exist with both profiles
+    const globalStore = JSON.parse(
+      await fsp.readFile(path.join(targetDir, "auth-profiles.json"), "utf-8"),
+    );
+    expect(globalStore.version).toBe(1);
+    expect(globalStore.profiles["anthropic:default"].key).toBe("key-1");
+    expect(globalStore.profiles["google:my-key"].key).toBe("key-2");
+
+    // Per-agent auth-profiles.json should NOT be copied
+    expect(
+      fs.existsSync(path.join(targetDir, "agents", "main", "agent", "auth-profiles.json")),
+    ).toBe(false);
+    expect(
+      fs.existsSync(path.join(targetDir, "agents", "helper", "agent", "auth-profiles.json")),
+    ).toBe(false);
+
+    expect(result.consolidatedAuthProfiles).toContain("anthropic:default");
+    expect(result.consolidatedAuthProfiles).toContain("google:my-key");
+  });
+
+  it("warns on auth profile conflict during import", async () => {
+    const configContent = JSON.stringify({
+      agents: {
+        defaults: { runtime: "claude" },
+        list: [{ id: "main", workspace: "~/ws" }],
+      },
+    });
+    await fsp.writeFile(path.join(sourceDir, "openclaw.json"), configContent);
+
+    // Same profile ID in two agents with different keys
+    const agent1 = path.join(sourceDir, "agents", "main", "agent");
+    const agent2 = path.join(sourceDir, "agents", "helper", "agent");
+    await fsp.mkdir(agent1, { recursive: true });
+    await fsp.mkdir(agent2, { recursive: true });
+
+    await fsp.writeFile(
+      path.join(agent1, "auth-profiles.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "anthropic:default": { type: "api_key", provider: "anthropic", key: "key-main" },
+        },
+      }),
+    );
+    await fsp.writeFile(
+      path.join(agent2, "auth-profiles.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "anthropic:default": { type: "api_key", provider: "anthropic", key: "key-helper" },
+        },
+      }),
+    );
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    // One of the two keys wins (walk order is OS-dependent)
+    const globalStore = JSON.parse(
+      await fsp.readFile(path.join(targetDir, "auth-profiles.json"), "utf-8"),
+    );
+    expect(["key-main", "key-helper"]).toContain(globalStore.profiles["anthropic:default"].key);
+
+    // Conflict reported
+    expect(result.authProfileConflicts).toHaveLength(1);
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Warning"));
   });
 
   it("handles nested directory structures with mixed file types", async () => {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -79,6 +79,8 @@ export type ImportResult = {
   envVarRenames: string[];
   skippedEntries: string[];
   targetDir: string;
+  consolidatedAuthProfiles: string[];
+  authProfileConflicts: string[];
 };
 
 /**
@@ -433,13 +435,35 @@ export function materializeWorkspaceDefaults(jsonContent: string): string {
 }
 
 /**
+ * A single auth profile credential discovered during import, tagged
+ * with the source file path for conflict reporting.
+ */
+type DiscoveredAuthProfile = {
+  id: string;
+  credential: Record<string, unknown>;
+  sourceFile: string;
+};
+
+/**
  * Discover auth profile IDs from auth store files in the source directory.
  *
  * Walks the directory tree looking for `auth-profiles.json` (v1 format)
  * and legacy `auth.json` files. Returns deduplicated profile IDs.
  */
 export function discoverSourceAuthProfileIds(sourceDir: string): string[] {
-  const profileIds: string[] = [];
+  return [...new Set(discoverSourceAuthProfiles(sourceDir).map((p) => p.id))];
+}
+
+/**
+ * Discover full auth profile credentials from auth store files in the
+ * source directory.
+ *
+ * Walks the directory tree looking for `auth-profiles.json` (v1 format)
+ * and legacy `auth.json` files. Returns all discovered profiles with
+ * their credentials and source paths for conflict detection.
+ */
+export function discoverSourceAuthProfiles(sourceDir: string): DiscoveredAuthProfile[] {
+  const profiles: DiscoveredAuthProfile[] = [];
 
   const walk = (dir: string) => {
     let entries: fs.Dirent[];
@@ -454,30 +478,34 @@ export function discoverSourceAuthProfileIds(sourceDir: string): string[] {
         walk(fullPath);
       } else if (entry.isFile()) {
         if (entry.name === AUTH_PROFILES_FILENAME) {
-          collectModernStore(fullPath, profileIds);
+          collectModernStore(fullPath, profiles);
         } else if (entry.name === LEGACY_AUTH_FILENAME) {
-          collectLegacyStore(fullPath, profileIds);
+          collectLegacyStore(fullPath, profiles);
         }
       }
     }
   };
 
   walk(sourceDir);
-  return [...new Set(profileIds)];
+  return profiles;
 }
 
-function collectModernStore(filePath: string, out: string[]): void {
+function collectModernStore(filePath: string, out: DiscoveredAuthProfile[]): void {
   try {
     const raw = JSON.parse(fs.readFileSync(filePath, "utf-8"));
     if (raw?.profiles && typeof raw.profiles === "object") {
-      out.push(...Object.keys(raw.profiles));
+      for (const [id, credential] of Object.entries(raw.profiles)) {
+        if (credential && typeof credential === "object") {
+          out.push({ id, credential: credential as Record<string, unknown>, sourceFile: filePath });
+        }
+      }
     }
   } catch {
     /* ignore unreadable/malformed files */
   }
 }
 
-function collectLegacyStore(filePath: string, out: string[]): void {
+function collectLegacyStore(filePath: string, out: DiscoveredAuthProfile[]): void {
   try {
     const raw = JSON.parse(fs.readFileSync(filePath, "utf-8"));
     if (typeof raw !== "object" || raw === null || "profiles" in raw) {
@@ -489,7 +517,11 @@ function collectLegacyStore(filePath: string, out: string[]): void {
         typeof value === "object" &&
         (value as Record<string, unknown>).type === "api_key"
       ) {
-        out.push(`${key}:default`);
+        out.push({
+          id: `${key}:default`,
+          credential: value as Record<string, unknown>,
+          sourceFile: filePath,
+        });
       }
     }
   } catch {
@@ -567,6 +599,55 @@ export function materializeAuthDefaults(
   const indentMatch = jsonContent.match(/^(\s+)"/m);
   const indent = indentMatch?.[1] ?? "  ";
   return JSON.stringify(config, null, indent) + "\n";
+}
+
+/**
+ * Consolidate discovered auth profiles into a single global auth store.
+ *
+ * Merges all profiles into one store, writing it to `targetDir/auth-profiles.json`.
+ * When the same profile ID appears in multiple source files with different keys,
+ * a warning is emitted and the first occurrence wins.
+ */
+export async function consolidateAuthProfiles(params: {
+  profiles: DiscoveredAuthProfile[];
+  targetDir: string;
+  sourceDir: string;
+  dryRun: boolean;
+  result: ImportResult;
+  runtime: RuntimeEnv;
+}): Promise<void> {
+  const { profiles, targetDir, sourceDir, dryRun, result, runtime } = params;
+  if (profiles.length === 0) {
+    return;
+  }
+
+  const merged: Record<string, Record<string, unknown>> = {};
+
+  for (const { id, credential, sourceFile } of profiles) {
+    if (id in merged) {
+      // Check for conflict: same profile ID but different key value
+      const existing = merged[id];
+      if (existing.key !== credential.key) {
+        const relPath = path.relative(sourceDir, sourceFile);
+        const warning = `Auth profile "${id}" found in ${relPath} conflicts with earlier occurrence — keeping first`;
+        result.authProfileConflicts.push(warning);
+        runtime.log(`Warning: ${warning}`);
+      }
+      continue;
+    }
+    merged[id] = credential;
+    result.consolidatedAuthProfiles.push(id);
+  }
+
+  if (!dryRun) {
+    const store = {
+      version: 1,
+      profiles: merged,
+    };
+    const storePath = path.join(targetDir, AUTH_PROFILES_FILENAME);
+    await fsp.mkdir(targetDir, { recursive: true });
+    await fsp.writeFile(storePath, JSON.stringify(store, null, 2) + "\n", "utf-8");
+  }
 }
 
 /**
@@ -714,6 +795,11 @@ async function copyDirectory(params: {
         discoveredAuthProfileIds: params.discoveredAuthProfileIds,
       });
     } else if (entry.isFile()) {
+      // Skip auth-profiles.json files — they are consolidated into the
+      // global auth store separately, not copied per-agent.
+      if (entry.name === AUTH_PROFILES_FILENAME) {
+        continue;
+      }
       if (isConfigFile(entry.name)) {
         const content = await fsp.readFile(sourcePath, "utf-8");
         const { content: transformed, renames } = transformConfigContent(content);
@@ -801,6 +887,8 @@ export async function importCommand(
     envVarRenames: [],
     skippedEntries: [],
     targetDir,
+    consolidatedAuthProfiles: [],
+    authProfileConflicts: [],
   };
 
   if (opts.dryRun) {
@@ -811,7 +899,8 @@ export async function importCommand(
     `Importing from ${shortenHomePath(sourcePath)} to ${shortenHomePath(targetDir)}...\n`,
   );
 
-  const discoveredAuthProfileIds = discoverSourceAuthProfileIds(sourcePath);
+  const discoveredAuthProfiles = discoverSourceAuthProfiles(sourcePath);
+  const discoveredAuthProfileIds = [...new Set(discoveredAuthProfiles.map((p) => p.id))];
 
   await copyDirectory({
     sourceDir: sourcePath,
@@ -820,6 +909,15 @@ export async function importCommand(
     filterRoot: true,
     result,
     discoveredAuthProfileIds,
+  });
+
+  await consolidateAuthProfiles({
+    profiles: discoveredAuthProfiles,
+    targetDir,
+    sourceDir: sourcePath,
+    dryRun: Boolean(opts.dryRun),
+    result,
+    runtime,
   });
 
   // Deduplicate env var renames for reporting
@@ -837,6 +935,15 @@ export async function importCommand(
     runtime.log(`\nEnv var renames:`);
     for (const rename of result.envVarRenames) {
       runtime.log(`  ${rename}`);
+    }
+  }
+
+  if (result.consolidatedAuthProfiles.length > 0) {
+    runtime.log(
+      `\nConsolidated ${result.consolidatedAuthProfiles.length} auth profile(s) into global store:`,
+    );
+    for (const id of result.consolidatedAuthProfiles) {
+      runtime.log(`  ${id}`);
     }
   }
 


### PR DESCRIPTION
## Summary

- During OpenClaw import, per-agent `auth-profiles.json` files are now **consolidated into a single global store** at the target root instead of being copied into per-agent directories where they'd be silently unused after #438's auth store relocation
- Auth profile files are **skipped during recursive directory copy** to prevent stale per-agent copies
- **Conflict detection**: warns when the same profile ID appears with different API keys across agent directories (first occurrence wins)

## Test plan

- [x] Import with per-agent auth profiles → consolidated into single global `auth-profiles.json`
- [x] Import with auth profiles in multiple agent dirs → merged correctly
- [x] Profile ID conflict across agents → warning logged, first occurrence kept
- [x] Auth profiles NOT copied to per-agent directories
- [x] Existing import tests continue to pass (94 tests, all green)
- [x] Full test suite passes (8088 tests)

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)