### PR TITLE
fix(auth): restore token credential type for OAuth env injection

### DIFF
--- a/src/auth/auth-health.ts
+++ b/src/auth/auth-health.ts
@@ -12,7 +12,7 @@ export type AuthProfileHealthStatus = "ok" | "missing" | "static";
 export type AuthProfileHealth = {
   profileId: string;
   provider: string;
-  type: "api_key";
+  type: "api_key" | "token";
   status: AuthProfileHealthStatus;
   source: AuthProfileSource;
   label: string;
@@ -80,7 +80,7 @@ function buildProfileHealth(params: {
   return {
     profileId,
     provider: credential.provider,
-    type: "api_key",
+    type: credential.type,
     status: "static",
     source,
     label,

--- a/src/auth/env-injection.test.ts
+++ b/src/auth/env-injection.test.ts
@@ -85,7 +85,7 @@ describe("resolveAuthEnv", () => {
         "claude:oauth-token": {
           type: "token",
           provider: "anthropic",
-          key: "sk-ant-oat01-test-oauth-token",
+          token: "sk-ant-oat01-test-oauth-token",
         },
       },
     };

--- a/src/auth/env-injection.test.ts
+++ b/src/auth/env-injection.test.ts
@@ -73,6 +73,48 @@ describe("resolveAuthEnv", () => {
     expect(result).toBeUndefined();
   });
 
+  it("injects CLAUDE_CODE_OAUTH_TOKEN for anthropic token credential", async () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", workspace: "~/w", auth: "claude:oauth-token" }],
+      },
+    };
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "claude:oauth-token": {
+          type: "token",
+          provider: "anthropic",
+          key: "sk-ant-oat01-test-oauth-token",
+        },
+      },
+    };
+
+    const result = await resolveAuthEnv({ cfg, agentId: "main", store });
+    expect(result).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-test-oauth-token" });
+  });
+
+  it("injects ANTHROPIC_API_KEY for anthropic api_key credential", async () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", workspace: "~/w", auth: "anthropic:default" }],
+      },
+    };
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "anthropic:default": {
+          type: "api_key",
+          provider: "anthropic",
+          key: "sk-ant-api03-regular-api-key",
+        },
+      },
+    };
+
+    const result = await resolveAuthEnv({ cfg, agentId: "main", store });
+    expect(result).toEqual({ ANTHROPIC_API_KEY: "sk-ant-api03-regular-api-key" });
+  });
+
   it("injects correct env var for single anthropic profile", async () => {
     const cfg: RemoteClawConfig = {
       agents: {

--- a/src/auth/env-injection.ts
+++ b/src/auth/env-injection.ts
@@ -157,5 +157,14 @@ export async function resolveAuthEnv(params: {
     return undefined;
   }
 
-  return { [envVarName]: resolved.apiKey };
+  // Token credentials for anthropic must be injected as CLAUDE_CODE_OAUTH_TOKEN,
+  // not ANTHROPIC_API_KEY — the SDK treats them as different auth mechanisms
+  // (Bearer token vs x-api-key header).
+  const credType = store.profiles[profileId]?.type;
+  const effectiveEnvVar =
+    envVarName === "ANTHROPIC_API_KEY" && credType === "token"
+      ? "CLAUDE_CODE_OAUTH_TOKEN"
+      : envVarName;
+
+  return { [effectiveEnvVar]: resolved.apiKey };
 }

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -45,7 +45,7 @@ export async function resolveApiKeyForProfile(
     return null;
   }
 
-  const key = cred.key?.trim();
+  const key = (cred.type === "token" ? cred.token : cred.key)?.trim();
   if (!key) {
     return null;
   }

--- a/src/auth/profiles.ts
+++ b/src/auth/profiles.ts
@@ -11,12 +11,15 @@ export function upsertAuthProfile(params: {
   profileId: string;
   credential: AuthProfileCredential;
 }): void {
-  const credential = {
-    ...params.credential,
-    ...(typeof params.credential.key === "string"
-      ? { key: normalizeSecretInput(params.credential.key) }
-      : {}),
-  };
+  const credential =
+    params.credential.type === "token"
+      ? { ...params.credential, token: normalizeSecretInput(params.credential.token) ?? "" }
+      : {
+          ...params.credential,
+          ...(typeof params.credential.key === "string"
+            ? { key: normalizeSecretInput(params.credential.key) }
+            : {}),
+        };
   const store = ensureAuthProfileStore();
   store.profiles[params.profileId] = credential;
   saveAuthProfileStore(store);

--- a/src/auth/provider-auth.ts
+++ b/src/auth/provider-auth.ts
@@ -367,7 +367,8 @@ export function resolveModelAuthLabel(params: {
       store,
       profileId,
     });
-    return `api-key ${formatApiKeySnippet(profile.key ?? "")}${label ? ` (${label})` : ""}`;
+    const keyValue = profile.type === "token" ? profile.token : (profile.key ?? "");
+    return `api-key ${formatApiKeySnippet(keyValue)}${label ? ` (${label})` : ""}`;
   }
 
   const envKey = resolveEnvApiKey(providerKey);

--- a/src/auth/store.ts
+++ b/src/auth/store.ts
@@ -43,11 +43,10 @@ function coerceAuthStore(raw: unknown): AuthProfileStore | null {
     if (!provider) {
       continue;
     }
-    // Accept any credential type from disk — coerce to api_key since
-    // OAuth/token types have been removed.
+    const type = typed.type === "token" ? "token" : "api_key";
     normalized[key] = {
       ...typed,
-      type: "api_key",
+      type,
       provider,
     } as AuthProfileCredential;
   }

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -7,17 +7,17 @@ export type ApiKeyCredential = {
   metadata?: Record<string, string>;
 };
 
-/**
- * Static bearer-style token (e.g., OAuth access token / PAT).
- * Stored with `type: "token"` so env-injection can map to the correct
- * env var (e.g., CLAUDE_CODE_OAUTH_TOKEN instead of ANTHROPIC_API_KEY).
- */
 export type TokenCredential = {
+  /**
+   * Static bearer-style token (often OAuth access token / PAT).
+   * Not refreshable by RemoteClaw.
+   */
   type: "token";
   provider: string;
-  key?: string;
+  token: string;
+  /** Optional expiry timestamp (ms since epoch). */
+  expires?: number;
   email?: string;
-  metadata?: Record<string, string>;
 };
 
 export type AuthProfileCredential = ApiKeyCredential | TokenCredential;

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -7,7 +7,20 @@ export type ApiKeyCredential = {
   metadata?: Record<string, string>;
 };
 
-export type AuthProfileCredential = ApiKeyCredential;
+/**
+ * Static bearer-style token (e.g., OAuth access token / PAT).
+ * Stored with `type: "token"` so env-injection can map to the correct
+ * env var (e.g., CLAUDE_CODE_OAUTH_TOKEN instead of ANTHROPIC_API_KEY).
+ */
+export type TokenCredential = {
+  type: "token";
+  provider: string;
+  key?: string;
+  email?: string;
+  metadata?: Record<string, string>;
+};
+
+export type AuthProfileCredential = ApiKeyCredential | TokenCredential;
 
 export type AuthProfileStore = {
   version: number;

--- a/src/auto-reply/reply/directive-handling.auth.ts
+++ b/src/auto-reply/reply/directive-handling.auth.ts
@@ -36,7 +36,7 @@ export const resolveAuthLabel = async (
       }
 
       return {
-        label: `${profileId} api-key ${maskApiKey(profile.key ?? "")}${more}`,
+        label: `${profileId} api-key ${maskApiKey(profile.type === "token" ? profile.token : (profile.key ?? ""))}${more}`,
         source: "",
       };
     }
@@ -54,7 +54,7 @@ export const resolveAuthLabel = async (
         return `${profileId}=missing${suffix}`;
       }
       const suffix = flags.length > 0 ? ` (${flags.join(", ")})` : "";
-      return `${profileId}=${maskApiKey(profile.key ?? "")}${suffix}`;
+      return `${profileId}=${maskApiKey(profile.type === "token" ? profile.token : (profile.key ?? ""))}${suffix}`;
     });
     return {
       label: labels.join(", "),

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -515,7 +515,8 @@ function collectLegacyStore(filePath: string, out: DiscoveredAuthProfile[]): voi
       if (
         value &&
         typeof value === "object" &&
-        (value as Record<string, unknown>).type === "api_key"
+        ((value as Record<string, unknown>).type === "api_key" ||
+          (value as Record<string, unknown>).type === "token")
       ) {
         out.push({
           id: `${key}:default`,

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -79,7 +79,7 @@ async function applyNonInteractiveRuntimeAuth(params: {
       profileId = "claude:oauth-token";
       upsertAuthProfile({
         profileId,
-        credential: { type: "api_key", provider: "anthropic", key: opts.authToken },
+        credential: { type: "token", provider: "anthropic", key: opts.authToken },
       });
     } else if (opts.anthropicApiKey) {
       profileId = "anthropic:default";

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -79,7 +79,7 @@ async function applyNonInteractiveRuntimeAuth(params: {
       profileId = "claude:oauth-token";
       upsertAuthProfile({
         profileId,
-        credential: { type: "token", provider: "anthropic", key: opts.authToken },
+        credential: { type: "token", provider: "anthropic", token: opts.authToken },
       });
     } else if (opts.anthropicApiKey) {
       profileId = "anthropic:default";

--- a/src/infra/provider-usage.auth.ts
+++ b/src/infra/provider-usage.auth.ts
@@ -27,10 +27,13 @@ function resolveZaiApiKey(): string | undefined {
   const apiProfile = [
     ...listProfilesForProvider(store, "zai"),
     ...listProfilesForProvider(store, "z-ai"),
-  ].find((id) => store.profiles[id]?.type === "api_key");
+  ].find((id) => {
+    const t = store.profiles[id]?.type;
+    return t === "api_key" || t === "token";
+  });
   if (apiProfile) {
     const cred = store.profiles[apiProfile];
-    if (cred?.type === "api_key" && normalizeSecretInput(cred.key)) {
+    if ((cred?.type === "api_key" || cred?.type === "token") && normalizeSecretInput(cred.key)) {
       return normalizeSecretInput(cred.key);
     }
   }
@@ -82,8 +85,8 @@ function resolveProviderApiKeyFromConfigAndStore(params: {
   const cred = listProfilesForProvider(store, params.providerId)
     .map((id) => store.profiles[id])
     .find(
-      (profile): profile is { type: "api_key"; provider: string; key: string } =>
-        profile?.type === "api_key",
+      (profile): profile is { type: "api_key" | "token"; provider: string; key: string } =>
+        profile?.type === "api_key" || profile?.type === "token",
     );
   if (!cred) {
     return undefined;

--- a/src/infra/provider-usage.auth.ts
+++ b/src/infra/provider-usage.auth.ts
@@ -33,8 +33,9 @@ function resolveZaiApiKey(): string | undefined {
   });
   if (apiProfile) {
     const cred = store.profiles[apiProfile];
-    if ((cred?.type === "api_key" || cred?.type === "token") && normalizeSecretInput(cred.key)) {
-      return normalizeSecretInput(cred.key);
+    const credKey = cred?.type === "token" ? cred.token : cred?.key;
+    if (credKey && normalizeSecretInput(credKey)) {
+      return normalizeSecretInput(credKey);
     }
   }
 
@@ -84,14 +85,12 @@ function resolveProviderApiKeyFromConfigAndStore(params: {
   const store = ensureAuthProfileStore();
   const cred = listProfilesForProvider(store, params.providerId)
     .map((id) => store.profiles[id])
-    .find(
-      (profile): profile is { type: "api_key" | "token"; provider: string; key: string } =>
-        profile?.type === "api_key" || profile?.type === "token",
-    );
+    .find((profile) => profile?.type === "api_key" || profile?.type === "token");
   if (!cred) {
     return undefined;
   }
-  return normalizeSecretInput(cred.key);
+  const credKey = cred.type === "token" ? cred.token : cred.key;
+  return normalizeSecretInput(credKey);
 }
 
 async function resolveProfileToken(params: {

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -51,7 +51,7 @@ const SKIP_GUIDANCE: Record<AgentRuntime, string> = {
 
 type UpsertAuthProfileFn = (params: {
   profileId: string;
-  credential: { type: "api_key"; provider: string; key: string };
+  credential: { type: "api_key" | "token"; provider: string; key: string };
 }) => void;
 
 async function promptRuntimeCredential(params: {
@@ -118,7 +118,7 @@ async function promptRuntimeCredential(params: {
       if (token.trim()) {
         upsertAuthProfile({
           profileId: "claude:oauth-token",
-          credential: { type: "api_key", provider: "anthropic", key: token.trim() },
+          credential: { type: "token", provider: "anthropic", key: token.trim() },
         });
         setAuthDefault("claude:oauth-token");
       }

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -51,7 +51,9 @@ const SKIP_GUIDANCE: Record<AgentRuntime, string> = {
 
 type UpsertAuthProfileFn = (params: {
   profileId: string;
-  credential: { type: "api_key" | "token"; provider: string; key: string };
+  credential:
+    | { type: "api_key"; provider: string; key: string }
+    | { type: "token"; provider: string; token: string };
 }) => void;
 
 async function promptRuntimeCredential(params: {
@@ -118,7 +120,7 @@ async function promptRuntimeCredential(params: {
       if (token.trim()) {
         upsertAuthProfile({
           profileId: "claude:oauth-token",
-          credential: { type: "token", provider: "anthropic", key: token.trim() },
+          credential: { type: "token", provider: "anthropic", token: token.trim() },
         });
         setAuthDefault("claude:oauth-token");
       }


### PR DESCRIPTION
## Summary

- Restores `TokenCredential` (`type: "token"`) that was removed in the OAuth gutting commit (3d697e9a), causing OAuth tokens to be injected as `ANTHROPIC_API_KEY` instead of `CLAUDE_CODE_OAUTH_TOKEN` — resulting in 401 auth failures
- Auth store preserves `type: "token"` from disk instead of coercing all credentials to `api_key`
- Wizard and non-interactive onboarding now save OAuth tokens as `type: "token"`
- Env-injection uses the stored credential type (not key prefix) to select the correct env var

## Test plan

- [x] `src/auth/env-injection.test.ts` — 2 new tests: token → `CLAUDE_CODE_OAUTH_TOKEN`, api_key → `ANTHROPIC_API_KEY`
- [x] All 152 affected tests pass (auth, import, onboard-auth, provider-usage, auth-key-retry)
- [x] Type-check passes clean (`tsgo --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)