### PR TITLE
feat(gateway): propagate thinking events through event bus to WebSocket clients (#441)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -328,6 +328,13 @@ export async function runAgentTurnWithFallback(params: {
                 directlySentBlockKeys,
               })
             : undefined,
+          onThinking: (payload) => {
+            emitAgentEvent({
+              runId,
+              stream: "thinking",
+              data: { text: payload.text },
+            });
+          },
           onToolResult: onToolResult
             ? (() => {
                 // Serialize tool result delivery to preserve message ordering.

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -440,6 +440,83 @@ describe("agent event handler", () => {
     resetAgentRunContextForTest();
   });
 
+  it("broadcasts thinking events to WS clients when verbose is on", () => {
+    const { broadcast, nodeSendToSession, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-1",
+    });
+
+    registerAgentRunContext("run-thinking", { sessionKey: "session-1", verboseLevel: "on" });
+
+    handler({
+      runId: "run-thinking",
+      seq: 1,
+      stream: "thinking",
+      ts: Date.now(),
+      data: { text: "Let me think about this..." },
+    });
+
+    // Thinking events should be broadcast to WS clients
+    const agentCalls = broadcast.mock.calls.filter(([event]) => event === "agent");
+    expect(agentCalls).toHaveLength(1);
+    const payload = agentCalls[0]?.[1] as { stream?: string; data?: Record<string, unknown> };
+    expect(payload.stream).toBe("thinking");
+    expect(payload.data?.text).toBe("Let me think about this...");
+
+    // Thinking events should NOT be sent to node/channel subscribers
+    const nodeCalls = nodeSendToSession.mock.calls.filter(([, event]) => event === "agent");
+    expect(nodeCalls).toHaveLength(0);
+    resetAgentRunContextForTest();
+  });
+
+  it("suppresses thinking events when verbose is off", () => {
+    const { broadcast, nodeSendToSession, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-1",
+    });
+
+    registerAgentRunContext("run-thinking-off", { sessionKey: "session-1", verboseLevel: "off" });
+
+    handler({
+      runId: "run-thinking-off",
+      seq: 1,
+      stream: "thinking",
+      ts: Date.now(),
+      data: { text: "Secret thoughts..." },
+    });
+
+    // Should NOT broadcast to WS clients when verbose is off
+    const agentCalls = broadcast.mock.calls.filter(([event]) => event === "agent");
+    expect(agentCalls).toHaveLength(0);
+
+    // Should NOT be sent to node/channel subscribers
+    const nodeCalls = nodeSendToSession.mock.calls.filter(([, event]) => event === "agent");
+    expect(nodeCalls).toHaveLength(0);
+    resetAgentRunContextForTest();
+  });
+
+  it("broadcasts thinking events when verbose is full", () => {
+    const { broadcast, nodeSendToSession, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-1",
+    });
+
+    registerAgentRunContext("run-thinking-full", { sessionKey: "session-1", verboseLevel: "full" });
+
+    handler({
+      runId: "run-thinking-full",
+      seq: 1,
+      stream: "thinking",
+      ts: Date.now(),
+      data: { text: "Deep thinking..." },
+    });
+
+    const agentCalls = broadcast.mock.calls.filter(([event]) => event === "agent");
+    expect(agentCalls).toHaveLength(1);
+
+    // Even at full verbose, thinking events should NOT go to node/channel
+    const nodeCalls = nodeSendToSession.mock.calls.filter(([, event]) => event === "agent");
+    expect(nodeCalls).toHaveLength(0);
+    resetAgentRunContextForTest();
+  });
+
   it("passes heartbeat text through to chat output without filtering", () => {
     const { broadcast, chatRunState, handler } = createHarness({ now: 3_000 });
     chatRunState.registry.add("run-heartbeat-alert", {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -324,7 +324,9 @@ export function createAgentEventHandler({
     const agentPayload = sessionKey ? { ...eventForClients, sessionKey } : eventForClients;
     const last = agentRunSeq.get(evt.runId) ?? 0;
     const isToolEvent = evt.stream === "tool";
-    const toolVerbose = isToolEvent ? resolveToolVerboseLevel(evt.runId, sessionKey) : "off";
+    const isThinkingEvent = evt.stream === "thinking";
+    const toolVerbose =
+      isToolEvent || isThinkingEvent ? resolveToolVerboseLevel(evt.runId, sessionKey) : "off";
     // Build tool payload: strip result/partialResult unless verbose=full
     const toolPayload =
       isToolEvent && toolVerbose !== "full"
@@ -360,6 +362,12 @@ export function createAgentEventHandler({
       if (recipients && recipients.size > 0) {
         broadcastToConnIds("agent", toolPayload, recipients);
       }
+    } else if (isThinkingEvent) {
+      // Thinking events: broadcast to WS clients only when verbose is enabled.
+      // Never sent to node/channel subscribers (thinking is for interactive clients only).
+      if (toolVerbose !== "off") {
+        broadcast("agent", agentPayload);
+      }
     } else {
       broadcast("agent", agentPayload);
     }
@@ -368,9 +376,9 @@ export function createAgentEventHandler({
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : null;
 
     if (sessionKey) {
-      // Send tool events to node/channel subscribers only when verbose is enabled;
-      // WS clients already received the event above via broadcastToConnIds.
-      if (!isToolEvent || toolVerbose !== "off") {
+      // Thinking events are for interactive WS clients only — never sent to
+      // node/channel subscribers. Tool events only when verbose is enabled.
+      if (!isThinkingEvent && (!isToolEvent || toolVerbose !== "off")) {
         nodeSendToSession(sessionKey, "agent", isToolEvent ? toolPayload : agentPayload);
       }
       if (!isAborted && evt.stream === "assistant" && typeof evt.data?.text === "string") {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -1,6 +1,12 @@
 import type { VerboseLevel } from "../auto-reply/thinking.js";
 
-export type AgentEventStream = "lifecycle" | "tool" | "assistant" | "error" | (string & {});
+export type AgentEventStream =
+  | "lifecycle"
+  | "tool"
+  | "assistant"
+  | "thinking"
+  | "error"
+  | (string & {});
 
 export type AgentEventPayload = {
   runId: string;

--- a/src/middleware/delivery-adapter.test.ts
+++ b/src/middleware/delivery-adapter.test.ts
@@ -210,6 +210,38 @@ describe("DeliveryAdapter", () => {
   });
 
   describe("event types", () => {
+    it("thinking events invoke onThinking callback", async () => {
+      const onThinking = vi.fn();
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        { type: "thinking", text: "Let me consider..." },
+        { type: "text", text: "Here is my answer." },
+        makeDone(),
+      ]);
+      const payloads = await adapter.process(events, { onThinking });
+      expect(onThinking).toHaveBeenCalledWith({ text: "Let me consider..." });
+      // Thinking events should NOT produce delivery payloads
+      expect(payloads).toEqual([{ text: "Here is my answer." }]);
+    });
+
+    it("thinking events with empty text are skipped", async () => {
+      const onThinking = vi.fn();
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([{ type: "thinking", text: "" }, makeDone()]);
+      await adapter.process(events, { onThinking });
+      expect(onThinking).not.toHaveBeenCalled();
+    });
+
+    it("thinking events do not error when onThinking callback is omitted", async () => {
+      const adapter = new DeliveryAdapter();
+      const events = eventStream([
+        { type: "thinking", text: "Thinking without a listener" },
+        makeDone(),
+      ]);
+      const payloads = await adapter.process(events);
+      expect(payloads).toEqual([]);
+    });
+
     it("tool_use events produce no output", async () => {
       const adapter = new DeliveryAdapter();
       const events = eventStream([

--- a/src/middleware/delivery-adapter.ts
+++ b/src/middleware/delivery-adapter.ts
@@ -85,6 +85,12 @@ export class DeliveryAdapter {
           }
           break;
         }
+        case "thinking": {
+          if (event.text) {
+            callbacks?.onThinking?.({ text: event.text });
+          }
+          break;
+        }
         case "tool_use":
           break;
         case "tool_result": {

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -265,4 +265,6 @@ export type BridgeCallbacks = {
   onBlockReply?: ((payload: ReplyPayload) => Promise<void> | void) | undefined;
   /** Called when a tool result is available. */
   onToolResult?: ((payload: ReplyPayload) => Promise<void> | void) | undefined;
+  /** Called when the agent emits thinking content. */
+  onThinking?: ((payload: { text: string }) => void) | undefined;
 };

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -245,6 +245,18 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (!isKnownRun) {
       return;
     }
+    if (evt.stream === "thinking") {
+      const verbose = state.sessionInfo.verboseLevel ?? "off";
+      if (verbose === "off") {
+        return;
+      }
+      const text = typeof evt.data?.text === "string" ? evt.data.text : "";
+      if (text) {
+        chatLog.addSystem(text);
+      }
+      tui.requestRender();
+      return;
+    }
     if (evt.stream === "tool") {
       const verbose = state.sessionInfo.verboseLevel ?? "off";
       const allowToolEvents = verbose !== "off";


### PR DESCRIPTION
## Summary

- Wire `AgentThinkingEvent` through the agent event bus and gateway WebSocket broadcast so thinking content reaches connected clients (Control UI, TUI)
- Add `"thinking"` to `AgentEventStream` union type and `onThinking` callback to `BridgeCallbacks`
- Gateway forwards thinking events to WS clients gated by `verboseLevel`; thinking events are never sent to node/channel subscribers
- TUI handles `"thinking"` stream events when verbose is enabled
- Unit tests covering all three `verboseLevel` behaviors (`on`, `off`, `full`)

## Test plan

- [x] `pnpm check` passes (format, typecheck, lint)
- [x] All 64 relevant unit tests pass (agent-events, delivery-adapter, server-chat agent-events)
- [x] Full test suite passes (8,947 tests across 1,064 files)
- [ ] Thinking events broadcast to WS clients when verbose is `on` or `full`
- [ ] Thinking events suppressed when verbose is `off`
- [ ] Thinking events never forwarded to node/channel subscribers

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)