### PR TITLE
fix(gateway): propagate agent error payloads to webchat UI

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -816,6 +816,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         channel: INTERNAL_MESSAGE_CHANNEL,
       });
       const finalReplyParts: string[] = [];
+      let hasErrorPayload = false;
       const dispatcher = createReplyDispatcher({
         ...prefixOptions,
         onError: (err) => {
@@ -828,6 +829,9 @@ export const chatHandlers: GatewayRequestHandlers = {
           const text = payload.text?.trim() ?? "";
           if (!text) {
             return;
+          }
+          if (payload.isError) {
+            hasErrorPayload = true;
           }
           finalReplyParts.push(text);
         },
@@ -908,6 +912,23 @@ export const chatHandlers: GatewayRequestHandlers = {
               sessionKey: rawSessionKey,
               message,
             });
+          } else if (hasErrorPayload && finalReplyParts.length > 0) {
+            // When the agent run started but produced only error payloads
+            // (e.g. auth failure, CLI crash), the lifecycle events carry no
+            // assistant text. Surface the error to the UI/TUI explicitly.
+            const combinedError = finalReplyParts
+              .map((part) => part.trim())
+              .filter(Boolean)
+              .join("\n\n")
+              .trim();
+            if (combinedError) {
+              broadcastChatError({
+                context,
+                runId: clientRunId,
+                sessionKey: rawSessionKey,
+                errorMessage: combinedError,
+              });
+            }
           }
           context.dedupe.set(`chat:${clientRunId}`, {
             ts: Date.now(),


### PR DESCRIPTION
## Summary

- When the agent run starts but produces only error payloads (e.g. auth failure, CLI crash), the webchat handler's `.then()` skipped `broadcastChatFinal` (since `agentRunStarted` was true) but had no fallback — errors were silently swallowed
- Tracks `hasErrorPayload` flag and surfaces errors through `broadcastChatError` when the run completes with errors but no assistant text

## Test plan

- [x] All 863 gateway tests pass
- [x] Type-check clean (`tsgo --noEmit`)
- [ ] Manual: trigger auth failure → verify error appears in UI/TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)