### PR TITLE
feat(ui): render thinking/reasoning output in Control UI chat view (#442)

### DIFF
--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -4,7 +4,7 @@
 
 .chat-thinking {
   margin-bottom: 10px;
-  padding: 10px 12px;
+  padding: 0;
   border-radius: 10px;
   border: 1px dashed rgba(255, 255, 255, 0.18);
   background: rgba(255, 255, 255, 0.04);
@@ -16,6 +16,27 @@
 :root[data-theme="light"] .chat-thinking {
   border-color: rgba(16, 24, 40, 0.25);
   background: rgba(16, 24, 40, 0.04);
+}
+
+.chat-thinking__summary {
+  padding: 8px 12px;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-style: italic;
+  opacity: 0.85;
+}
+
+.chat-thinking__summary:hover {
+  opacity: 1;
+}
+
+.chat-thinking__content {
+  padding: 0 12px 10px;
+  max-height: 400px;
+  overflow-y: auto;
 }
 
 .chat-text {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -10,7 +10,12 @@ import {
   refreshActiveTab,
   setLastActiveSessionKey,
 } from "./app-settings.ts";
-import { handleAgentEvent, resetToolStream, type AgentEventPayload } from "./app-tool-stream.ts";
+import {
+  consumeThinkingStream,
+  handleAgentEvent,
+  resetToolStream,
+  type AgentEventPayload,
+} from "./app-tool-stream.ts";
 import type { RemoteClawApp } from "./app.ts";
 import { shouldReloadHistoryForFinalEvent } from "./chat-event-reload.ts";
 import { loadAgents, loadToolsCatalog } from "./controllers/agents.ts";
@@ -228,6 +233,25 @@ function handleTerminalChatEvent(
 ) {
   if (state !== "final" && state !== "error" && state !== "aborted") {
     return;
+  }
+  // Inject accumulated thinking into the last assistant message before resetting.
+  const thinkingText = consumeThinkingStream(
+    host as unknown as Parameters<typeof consumeThinkingStream>[0],
+  );
+  if (thinkingText && state === "final") {
+    const app = host as unknown as RemoteClawApp;
+    const messages = app.chatMessages;
+    if (messages.length > 0) {
+      const last = messages[messages.length - 1] as Record<string, unknown>;
+      if (typeof last.role === "string" && last.role.toLowerCase() === "assistant") {
+        const content = Array.isArray(last.content) ? last.content : [];
+        const enriched = {
+          ...last,
+          content: [{ type: "thinking", thinking: thinkingText }, ...content],
+        };
+        app.chatMessages = [...messages.slice(0, -1), enriched];
+      }
+    }
   }
   resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
   void flushChatQueueForEvent(host as unknown as Parameters<typeof flushChatQueueForEvent>[0]);

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -871,6 +871,7 @@ export function renderApp(state: AppViewState) {
                 assistantAvatarUrl: chatAvatarUrl,
                 messages: state.chatMessages,
                 toolMessages: state.chatToolMessages,
+                thinkingStream: showThinking ? state.chatThinkingStream : null,
                 stream: state.chatStream,
                 streamStartedAt: state.chatStreamStartedAt,
                 draft: state.chatMessage,

--- a/ui/src/ui/app-tool-stream.node.test.ts
+++ b/ui/src/ui/app-tool-stream.node.test.ts
@@ -1,5 +1,11 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { handleAgentEvent, type FallbackStatus, type ToolStreamEntry } from "./app-tool-stream.ts";
+import {
+  consumeThinkingStream,
+  handleAgentEvent,
+  resetToolStream,
+  type FallbackStatus,
+  type ToolStreamEntry,
+} from "./app-tool-stream.ts";
 
 type ToolStreamHost = Parameters<typeof handleAgentEvent>[0];
 type MutableHost = ToolStreamHost & {
@@ -17,6 +23,7 @@ function createHost(overrides?: Partial<MutableHost>): MutableHost {
     toolStreamOrder: [],
     chatToolMessages: [],
     toolStreamSyncTimer: null,
+    chatThinkingStream: null,
     compactionStatus: null,
     compactionClearTimer: null,
     fallbackStatus: null,
@@ -135,5 +142,117 @@ describe("app-tool-stream fallback lifecycle handling", () => {
     expect(host.fallbackStatus?.phase).toBe("cleared");
     expect(host.fallbackStatus?.previous).toBe("deepinfra/moonshotai/Kimi-K2.5");
     vi.useRealTimers();
+  });
+});
+
+describe("app-tool-stream thinking event handling", () => {
+  beforeAll(() => {
+    const globalWithWindow = globalThis as typeof globalThis & {
+      window?: Window & typeof globalThis;
+    };
+    if (!globalWithWindow.window) {
+      globalWithWindow.window = globalThis as unknown as Window & typeof globalThis;
+    }
+  });
+
+  it("accumulates thinking text from thinking stream events", () => {
+    const host = createHost({ chatRunId: "run-1" });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "thinking",
+      ts: Date.now(),
+      data: { text: "Let me think about this..." },
+    });
+
+    expect(host.chatThinkingStream).toBe("Let me think about this...");
+  });
+
+  it("concatenates multiple thinking events with newlines", () => {
+    const host = createHost({ chatRunId: "run-1" });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "thinking",
+      ts: Date.now(),
+      data: { text: "First thought" },
+    });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 2,
+      stream: "thinking",
+      ts: Date.now(),
+      data: { text: "Second thought" },
+    });
+
+    expect(host.chatThinkingStream).toBe("First thought\nSecond thought");
+  });
+
+  it("ignores thinking events with empty text", () => {
+    const host = createHost({ chatRunId: "run-1" });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "thinking",
+      ts: Date.now(),
+      data: { text: "" },
+    });
+
+    expect(host.chatThinkingStream).toBeNull();
+  });
+
+  it("ignores thinking events for different runs", () => {
+    const host = createHost({ chatRunId: "run-1" });
+
+    handleAgentEvent(host, {
+      runId: "run-other",
+      seq: 1,
+      stream: "thinking",
+      ts: Date.now(),
+      data: { text: "Wrong run thinking" },
+    });
+
+    expect(host.chatThinkingStream).toBeNull();
+  });
+
+  it("consumeThinkingStream returns and clears accumulated text", () => {
+    const host = createHost({ chatRunId: "run-1" });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "thinking",
+      ts: Date.now(),
+      data: { text: "Some thinking" },
+    });
+
+    const result = consumeThinkingStream(host);
+    expect(result).toBe("Some thinking");
+    expect(host.chatThinkingStream).toBeNull();
+  });
+
+  it("consumeThinkingStream returns null when no thinking accumulated", () => {
+    const host = createHost();
+    expect(consumeThinkingStream(host)).toBeNull();
+  });
+
+  it("resetToolStream clears thinking stream", () => {
+    const host = createHost({ chatRunId: "run-1" });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "thinking",
+      ts: Date.now(),
+      data: { text: "Some thinking" },
+    });
+
+    expect(host.chatThinkingStream).toBe("Some thinking");
+    resetToolStream(host);
+    expect(host.chatThinkingStream).toBeNull();
   });
 });

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -32,6 +32,7 @@ type ToolStreamHost = {
   toolStreamOrder: string[];
   chatToolMessages: Record<string, unknown>[];
   toolStreamSyncTimer: number | null;
+  chatThinkingStream: string | null;
 };
 
 function toTrimmedString(value: unknown): string | null {
@@ -208,6 +209,12 @@ function syncToolStreamMessages(host: ToolStreamHost) {
     .filter((msg): msg is Record<string, unknown> => Boolean(msg));
 }
 
+export function consumeThinkingStream(host: ToolStreamHost): string | null {
+  const text = host.chatThinkingStream;
+  host.chatThinkingStream = null;
+  return text;
+}
+
 export function flushToolStreamSync(host: ToolStreamHost) {
   if (host.toolStreamSyncTimer != null) {
     clearTimeout(host.toolStreamSyncTimer);
@@ -234,6 +241,7 @@ export function resetToolStream(host: ToolStreamHost) {
   host.toolStreamById.clear();
   host.toolStreamOrder = [];
   host.chatToolMessages = [];
+  host.chatThinkingStream = null;
   flushToolStreamSync(host);
 }
 
@@ -382,6 +390,20 @@ function handleLifecycleFallbackEvent(host: CompactionHost, payload: AgentEventP
   }, FALLBACK_TOAST_DURATION_MS);
 }
 
+function handleThinkingEvent(host: ToolStreamHost, payload: AgentEventPayload) {
+  const accepted = resolveAcceptedSession(host, payload);
+  if (!accepted.accepted) {
+    return;
+  }
+  const data = payload.data ?? {};
+  const text = typeof data.text === "string" ? data.text : "";
+  if (!text) {
+    return;
+  }
+  const current = host.chatThinkingStream ?? "";
+  host.chatThinkingStream = current ? `${current}\n${text}` : text;
+}
+
 export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPayload) {
   if (!payload) {
     return;
@@ -395,6 +417,11 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
 
   if (payload.stream === "lifecycle" || payload.stream === "fallback") {
     handleLifecycleFallbackEvent(host as CompactionHost, payload);
+    return;
+  }
+
+  if (payload.stream === "thinking") {
+    handleThinkingEvent(host, payload);
     return;
   }
 

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -65,6 +65,7 @@ export type AppViewState = {
   chatAttachments: ChatAttachment[];
   chatMessages: unknown[];
   chatToolMessages: unknown[];
+  chatThinkingStream: string | null;
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   chatRunId: string | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -140,6 +140,7 @@ export class RemoteClawApp extends LitElement {
   @state() chatMessage = "";
   @state() chatMessages: unknown[] = [];
   @state() chatToolMessages: unknown[] = [];
+  @state() chatThinkingStream: string | null = null;
   @state() chatStream: string | null = null;
   @state() chatStreamStartedAt: number | null = null;
   @state() chatRunId: string | null = null;

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -76,12 +76,18 @@ export function renderStreamingGroup(
   startedAt: number,
   onOpenSidebar?: (content: string) => void,
   assistant?: AssistantIdentity,
+  thinkingText?: string | null,
 ) {
   const timestamp = new Date(startedAt).toLocaleTimeString([], {
     hour: "numeric",
     minute: "2-digit",
   });
   const name = assistant?.name ?? "Assistant";
+  const contentBlocks: Array<Record<string, unknown>> = [];
+  if (thinkingText) {
+    contentBlocks.push({ type: "thinking", thinking: thinkingText });
+  }
+  contentBlocks.push({ type: "text", text });
 
   return html`
     <div class="chat-group assistant">
@@ -90,10 +96,10 @@ export function renderStreamingGroup(
         ${renderGroupedMessage(
           {
             role: "assistant",
-            content: [{ type: "text", text }],
+            content: contentBlocks,
             timestamp: startedAt,
           },
-          { isStreaming: true, showReasoning: false },
+          { isStreaming: true, showReasoning: Boolean(thinkingText) },
           onOpenSidebar,
         )}
         <div class="chat-group-footer">
@@ -221,6 +227,31 @@ function renderMessageImages(images: ImageBlock[]) {
   `;
 }
 
+const THINKING_SUMMARY_PREVIEW_CHARS = 120;
+
+function renderThinkingBlock(reasoningMarkdown: string, isStreaming: boolean) {
+  const thinkingHtml = toSanitizedMarkdownHtml(reasoningMarkdown);
+  if (isStreaming) {
+    return html`<details class="chat-thinking" open>
+      <summary class="chat-thinking__summary">Thinking…</summary>
+      <div class="chat-thinking__content">${unsafeHTML(thinkingHtml)}</div>
+    </details>`;
+  }
+  // Extract a short preview for the collapsed summary
+  const plainPreview = reasoningMarkdown
+    .replace(/_Reasoning:_\n?/, "")
+    .replace(/_/g, "")
+    .slice(0, THINKING_SUMMARY_PREVIEW_CHARS)
+    .trim();
+  const summaryText = plainPreview
+    ? `Thinking: ${plainPreview}${reasoningMarkdown.length > THINKING_SUMMARY_PREVIEW_CHARS ? "…" : ""}`
+    : "Thinking";
+  return html`<details class="chat-thinking">
+    <summary class="chat-thinking__summary">${summaryText}</summary>
+    <div class="chat-thinking__content">${unsafeHTML(thinkingHtml)}</div>
+  </details>`;
+}
+
 function renderGroupedMessage(
   message: unknown,
   opts: { isStreaming: boolean; showReasoning: boolean },
@@ -269,13 +300,7 @@ function renderGroupedMessage(
     <div class="${bubbleClasses}">
       ${canCopyMarkdown ? renderCopyAsMarkdownButton(markdown!) : nothing}
       ${renderMessageImages(images)}
-      ${
-        reasoningMarkdown
-          ? html`<div class="chat-thinking">${unsafeHTML(
-              toSanitizedMarkdownHtml(reasoningMarkdown),
-            )}</div>`
-          : nothing
-      }
+      ${reasoningMarkdown ? renderThinkingBlock(reasoningMarkdown, opts.isStreaming) : nothing}
       ${
         markdown
           ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -25,6 +25,7 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     fallbackStatus: null,
     messages: [],
     toolMessages: [],
+    thinkingStream: null,
     stream: null,
     streamStartedAt: null,
     assistantAvatarUrl: null,

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -42,6 +42,7 @@ export type ChatProps = {
   fallbackStatus?: FallbackIndicatorStatus | null;
   messages: unknown[];
   toolMessages: unknown[];
+  thinkingStream: string | null;
   stream: string | null;
   streamStartedAt: number | null;
   assistantAvatarUrl?: string | null;
@@ -292,13 +293,14 @@ export function renderChat(props: ChatProps) {
               item.startedAt,
               props.onOpenSidebar,
               assistantIdentity,
+              props.thinkingStream,
             );
           }
 
           if (item.kind === "group") {
             return renderMessageGroup(item, {
               onOpenSidebar: props.onOpenSidebar,
-              showReasoning: false,
+              showReasoning: props.showThinking,
               assistantName: props.assistantName,
               assistantAvatar: assistantIdentity.avatar,
             });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
       "ui/src/ui/views/agents-utils.test.ts",
       "ui/src/ui/views/usage-render-details.test.ts",
       "ui/src/ui/controllers/agents.test.ts",
+      "ui/src/ui/app-tool-stream.node.test.ts",
     ],
     setupFiles: ["test/setup.ts"],
     exclude: [


### PR DESCRIPTION
## Summary

- Wire thinking events from WebSocket agent stream (`stream: "thinking"`) into the chat view, accumulating text in `chatThinkingStream` state
- Inject accumulated thinking into the final assistant message as a `{ type: "thinking", thinking: "..." }` content block so it persists in chat history
- Render thinking blocks as collapsible `<details>` elements — open during streaming with "Thinking…" label, collapsed in history with a text preview summary
- Style with dashed border, muted colors, and light theme support via `.chat-thinking` CSS classes
- Add 7 unit tests covering stream accumulation, concatenation, session filtering, consume/reset lifecycle

Closes #442

## Test plan

- [x] `pnpm check` passes (format + typecheck + lint)
- [x] `pnpm test` passes (866+ tests including 7 new thinking stream tests)
- [ ] CI build and test jobs pass
- [ ] Manual: send a message to an agent with extended thinking enabled, verify thinking block appears during streaming (open) and collapses after completion (with preview text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)