### PR TITLE
fix(gateway): clear stale resolvedTo/resolvedAccountId on plugin channel fallback

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -532,6 +532,8 @@ export const agentHandlers: GatewayRequestHandlers = {
       const configured = await listConfiguredMessageChannels(cfgResolved);
       if (!configured.includes(resolvedChannel)) {
         resolvedChannel = INTERNAL_MESSAGE_CHANNEL;
+        resolvedTo = undefined;
+        resolvedAccountId = undefined;
       }
     }
 


### PR DESCRIPTION
## Summary

- Clears `resolvedTo` and `resolvedAccountId` alongside `resolvedChannel` when falling back from an unconfigured plugin channel to `INTERNAL_MESSAGE_CHANNEL`
- Prevents delivery with a stale recipient ID when `resolveMessageChannelSelection` subsequently picks a different channel (e.g. Telegram vs Teams)

Closes #459

## Test plan

- [x] All 866 gateway tests pass
- [x] Type-check clean (no new errors)
- [x] Lint and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)