### PR TITLE
fix(auth): use token credential type in writeOAuthCredentials (#457)

### DIFF
--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -14,9 +14,9 @@ export async function writeOAuthCredentials(
 
   const credEmail = email !== "default" ? email : undefined;
   const credential = {
-    type: "api_key" as const,
+    type: "token" as const,
     provider,
-    key: creds.access,
+    token: creds.access,
     ...(credEmail ? { email: credEmail } : {}),
   };
 

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -133,12 +133,12 @@ describe("writeOAuthCredentials", () => {
     const globalPath = path.join(env.stateDir, "auth-profiles.json");
     const raw = await fs.readFile(globalPath, "utf8");
     const parsed = JSON.parse(raw) as {
-      profiles?: Record<string, { type?: string; key?: string; provider?: string }>;
+      profiles?: Record<string, { type?: string; token?: string; provider?: string }>;
     };
     expect(parsed.profiles?.["openai-codex:default"]).toMatchObject({
-      type: "api_key",
+      type: "token",
       provider: "openai-codex",
-      key: "access-token",
+      token: "access-token",
     });
   });
 });


### PR DESCRIPTION
## Summary

- `writeOAuthCredentials` hardcoded `type: "api_key"` for all OAuth credential flows due to the gutting commit `3d697e9a57`
- Changed to `type: "token"` with `token: creds.access` to match the `TokenCredential` shape restored in #452
- Updated test assertion to match the corrected credential shape

Closes #457

## Test plan

- [x] Existing `writeOAuthCredentials` test updated and passing (23/23 tests green)
- [x] Type-check passes
- [x] Credential shape matches `TokenCredential` type definition in `src/auth/types.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)