### PR TITLE
gut(gateway): remove dead models.list method references

### DIFF
--- a/apps/macos/Sources/RemoteClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/RemoteClaw/GatewayConnection.swift
@@ -73,7 +73,6 @@ actor GatewayConnection {
         case webLoginStart = "web.login.start"
         case webLoginWait = "web.login.wait"
         case channelsLogout = "channels.logout"
-        case modelsList = "models.list"
         case chatHistory = "chat.history"
         case sessionsPreview = "sessions.preview"
         case chatSend = "chat.send"

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -50,7 +50,6 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "usage.cost",
     "tts.status",
     "tts.providers",
-    "models.list",
     "tools.catalog",
     "plugin:tools:list",
     "agents.list",

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -33,7 +33,6 @@ const BASE_METHODS = [
   "wizard.status",
   "talk.config",
   "talk.mode",
-  "models.list",
   "tools.catalog",
   "agents.list",
   "agents.create",

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -59,11 +59,7 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
     { name: "agents", description: "Open agent picker" },
     { name: "session", description: "Switch session (or open picker)" },
     { name: "sessions", description: "Open session picker" },
-    {
-      name: "model",
-      description: "Set model (or open picker)",
-    },
-    { name: "models", description: "Open model picker" },
+    { name: "model", description: "Set model" },
     {
       name: "verbose",
       description: "Set verbose on/off",
@@ -122,7 +118,7 @@ export function helpText(_options: SlashCommandOptions = {}): string {
     "/status",
     "/agent <id> (or /agents)",
     "/session <key> (or /sessions)",
-    "/model <provider/model> (or /models)",
+    "/model <provider/model>",
     "/verbose <on|off>",
     "/usage <off|tokens|full>",
     "/elevated <on|off|ask|full>",

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -90,14 +90,6 @@ export type GatewayAgentsList = {
   }>;
 };
 
-export type GatewayModelChoice = {
-  id: string;
-  name: string;
-  provider: string;
-  contextWindow?: number;
-  reasoning?: boolean;
-};
-
 export class GatewayChatClient {
   private client: GatewayClient;
   private readyPromise: Promise<void>;
@@ -224,11 +216,6 @@ export class GatewayChatClient {
 
   async getStatus() {
     return await this.client.request("status");
-  }
-
-  async listModels(): Promise<GatewayModelChoice[]> {
-    const res = await this.client.request<{ models?: GatewayModelChoice[] }>("models.list");
-    return Array.isArray(res?.models) ? res.models : [];
   }
 }
 

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -93,39 +93,6 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     tui.requestRender();
   };
 
-  const openModelSelector = async () => {
-    try {
-      const models = await client.listModels();
-      if (models.length === 0) {
-        chatLog.addSystem("no models available");
-        tui.requestRender();
-        return;
-      }
-      const items = models.map((model) => ({
-        value: `${model.provider}/${model.id}`,
-        label: `${model.provider}/${model.id}`,
-        description: model.name && model.name !== model.id ? model.name : "",
-      }));
-      const selector = createSearchableSelectList(items, 9);
-      openSelector(selector, async (value) => {
-        try {
-          const result = await client.patchSession({
-            key: state.currentSessionKey,
-            model: value,
-          });
-          chatLog.addSystem(`model set to ${value}`);
-          applySessionInfoFromPatch(result);
-          await refreshSessionInfo();
-        } catch (err) {
-          chatLog.addSystem(`model set failed: ${String(err)}`);
-        }
-      });
-    } catch (err) {
-      chatLog.addSystem(`model list failed: ${String(err)}`);
-      tui.requestRender();
-    }
-  };
-
   const openAgentSelector = async () => {
     await refreshAgents();
     if (state.agents.length === 0) {
@@ -273,7 +240,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         break;
       case "model":
         if (!args) {
-          await openModelSelector();
+          chatLog.addSystem("usage: /model <provider/model>");
         } else {
           try {
             const result = await client.patchSession({
@@ -287,9 +254,6 @@ export function createCommandHandlers(context: CommandHandlerContext) {
             chatLog.addSystem(`model set failed: ${String(err)}`);
           }
         }
-        break;
-      case "models":
-        await openModelSelector();
         break;
       case "verbose":
         if (!args) {
@@ -441,7 +405,6 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   return {
     handleCommand,
     sendMessage,
-    openModelSelector,
     openAgentSelector,
     openSessionSelector,
     openSettings,

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -768,7 +768,7 @@ export async function runTui(opts: TuiOptions) {
     process.exit(0);
   };
 
-  const { handleCommand, sendMessage, openModelSelector, openAgentSelector, openSessionSelector } =
+  const { handleCommand, sendMessage, openAgentSelector, openSessionSelector } =
     createCommandHandlers({
       client,
       chatLog,
@@ -844,9 +844,6 @@ export async function runTui(opts: TuiOptions) {
     chatLog.setToolsExpanded(toolsExpanded);
     setActivityStatus(toolsExpanded ? "tools expanded" : "tools collapsed");
     tui.requestRender();
-  };
-  editor.onCtrlL = () => {
-    void openModelSelector();
   };
   editor.onCtrlG = () => {
     void openAgentSelector();

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -163,30 +163,9 @@ export async function loadCronStatus(state: CronState) {
   }
 }
 
-export async function loadCronModelSuggestions(state: CronModelSuggestionsState) {
-  if (!state.client || !state.connected) {
-    return;
-  }
-  try {
-    const res = await state.client.request("models.list", {});
-    const models = (res as { models?: unknown[] } | null)?.models;
-    if (!Array.isArray(models)) {
-      state.cronModelSuggestions = [];
-      return;
-    }
-    const ids = models
-      .map((entry) => {
-        if (!entry || typeof entry !== "object") {
-          return "";
-        }
-        const id = (entry as { id?: unknown }).id;
-        return typeof id === "string" ? id.trim() : "";
-      })
-      .filter(Boolean);
-    state.cronModelSuggestions = Array.from(new Set(ids)).toSorted((a, b) => a.localeCompare(b));
-  } catch {
-    state.cronModelSuggestions = [];
-  }
+export function loadCronModelSuggestions(state: CronModelSuggestionsState) {
+  // models.list gateway method was removed — no provider-sourced suggestions available.
+  state.cronModelSuggestions = [];
 }
 
 export async function loadCronJobs(state: CronState) {


### PR DESCRIPTION
## Summary

- Remove `models.list` from gateway method list and `operator.read` scope map — the handler was already gutted, but these registrations caused `INVALID_REQUEST` errors on any call
- Delete `listModels()` client method, `GatewayModelChoice` type, `openModelSelector` TUI picker, `/models` command, and Ctrl+L keybinding
- Stub `loadCronModelSuggestions` to return empty array (no provider-sourced models available)
- Drop `modelsList` case from macOS Swift `Method` enum

Closes #416

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` (format + typecheck + lint) passes
- [x] `pnpm test` — all 866 tests pass
- [x] No remaining `models.list` references in codebase (verified via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)