### PR TITLE
feat(auth): restore persistent cooldown-aware round-robin from upstream (#455)

### DIFF
--- a/src/auth/env-injection.test.ts
+++ b/src/auth/env-injection.test.ts
@@ -1,15 +1,19 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { RemoteClawConfig } from "../config/config.js";
 import {
-  _resetRoundRobinState,
   resolveAuthEnv,
   resolveAuthProfileCount,
   resolveProviderEnvVarName,
 } from "./env-injection.js";
 import type { AuthProfileStore } from "./types.js";
 
-afterEach(() => {
-  _resetRoundRobinState();
+vi.mock("./store.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./store.js")>();
+  return {
+    ...original,
+    updateAuthProfileStoreWithLock: vi.fn().mockResolvedValue(null),
+    saveAuthProfileStore: vi.fn(),
+  };
 });
 
 describe("resolveProviderEnvVarName", () => {
@@ -47,6 +51,7 @@ describe("resolveProviderEnvVarName", () => {
 describe("resolveAuthEnv", () => {
   const makeStore = (
     profiles: Record<string, { provider: string; key: string }>,
+    usageStats?: AuthProfileStore["usageStats"],
   ): AuthProfileStore => ({
     version: 1,
     profiles: Object.fromEntries(
@@ -55,6 +60,7 @@ describe("resolveAuthEnv", () => {
         { type: "api_key" as const, provider: p.provider, key: p.key },
       ]),
     ),
+    usageStats,
   });
 
   it("returns undefined when auth is undefined (no config)", async () => {
@@ -199,7 +205,7 @@ describe("resolveAuthEnv", () => {
   });
 
   describe("round-robin", () => {
-    it("cycles through array entries across calls", async () => {
+    it("picks least-recently-used profile from array", async () => {
       const cfg: RemoteClawConfig = {
         agents: {
           list: [
@@ -211,53 +217,69 @@ describe("resolveAuthEnv", () => {
           ],
         },
       };
-      const store = makeStore({
-        "anthropic:key1": { provider: "anthropic", key: "sk-1" },
-        "anthropic:key2": { provider: "anthropic", key: "sk-2" },
-        "anthropic:key3": { provider: "anthropic", key: "sk-3" },
-      });
+      // key2 was used least recently (lastUsed: 100), so it should be picked
+      const store = makeStore(
+        {
+          "anthropic:key1": { provider: "anthropic", key: "sk-1" },
+          "anthropic:key2": { provider: "anthropic", key: "sk-2" },
+          "anthropic:key3": { provider: "anthropic", key: "sk-3" },
+        },
+        {
+          "anthropic:key1": { lastUsed: 200 },
+          "anthropic:key2": { lastUsed: 100 },
+          "anthropic:key3": { lastUsed: 300 },
+        },
+      );
 
       const r1 = await resolveAuthEnv({ cfg, agentId: "main", store });
-      expect(r1).toEqual({ ANTHROPIC_API_KEY: "sk-1" });
-
-      const r2 = await resolveAuthEnv({ cfg, agentId: "main", store });
-      expect(r2).toEqual({ ANTHROPIC_API_KEY: "sk-2" });
-
-      const r3 = await resolveAuthEnv({ cfg, agentId: "main", store });
-      expect(r3).toEqual({ ANTHROPIC_API_KEY: "sk-3" });
-
-      // Wraps around
-      const r4 = await resolveAuthEnv({ cfg, agentId: "main", store });
-      expect(r4).toEqual({ ANTHROPIC_API_KEY: "sk-1" });
+      expect(r1).toEqual({ ANTHROPIC_API_KEY: "sk-2" });
     });
 
-    it("tracks rotation independently per agent", async () => {
+    it("picks first profile when no usage stats exist", async () => {
       const cfg: RemoteClawConfig = {
         agents: {
           list: [
-            { id: "a", workspace: "~/w", auth: ["anthropic:a1", "anthropic:a2"] },
-            { id: "b", workspace: "~/w", auth: ["anthropic:b1", "anthropic:b2"] },
+            {
+              id: "main",
+              workspace: "~/w",
+              auth: ["anthropic:key1", "anthropic:key2"],
+            },
           ],
         },
       };
       const store = makeStore({
-        "anthropic:a1": { provider: "anthropic", key: "sk-a1" },
-        "anthropic:a2": { provider: "anthropic", key: "sk-a2" },
-        "anthropic:b1": { provider: "anthropic", key: "sk-b1" },
-        "anthropic:b2": { provider: "anthropic", key: "sk-b2" },
+        "anthropic:key1": { provider: "anthropic", key: "sk-1" },
+        "anthropic:key2": { provider: "anthropic", key: "sk-2" },
       });
 
-      const ra1 = await resolveAuthEnv({ cfg, agentId: "a", store });
-      expect(ra1).toEqual({ ANTHROPIC_API_KEY: "sk-a1" });
+      const result = await resolveAuthEnv({ cfg, agentId: "main", store });
+      expect(result).toEqual({ ANTHROPIC_API_KEY: "sk-1" });
+    });
 
-      const rb1 = await resolveAuthEnv({ cfg, agentId: "b", store });
-      expect(rb1).toEqual({ ANTHROPIC_API_KEY: "sk-b1" });
+    it("skips profiles in cooldown", async () => {
+      const cfg: RemoteClawConfig = {
+        agents: {
+          list: [
+            {
+              id: "main",
+              workspace: "~/w",
+              auth: ["anthropic:key1", "anthropic:key2"],
+            },
+          ],
+        },
+      };
+      const store = makeStore(
+        {
+          "anthropic:key1": { provider: "anthropic", key: "sk-1" },
+          "anthropic:key2": { provider: "anthropic", key: "sk-2" },
+        },
+        {
+          "anthropic:key1": { cooldownUntil: Date.now() + 60_000 },
+        },
+      );
 
-      const ra2 = await resolveAuthEnv({ cfg, agentId: "a", store });
-      expect(ra2).toEqual({ ANTHROPIC_API_KEY: "sk-a2" });
-
-      const rb2 = await resolveAuthEnv({ cfg, agentId: "b", store });
-      expect(rb2).toEqual({ ANTHROPIC_API_KEY: "sk-b2" });
+      const result = await resolveAuthEnv({ cfg, agentId: "main", store });
+      expect(result).toEqual({ ANTHROPIC_API_KEY: "sk-2" });
     });
 
     it("returns undefined for empty auth array", async () => {

--- a/src/auth/env-injection.ts
+++ b/src/auth/env-injection.ts
@@ -1,5 +1,5 @@
 /**
- * Auth profile → CLI subprocess env var injection.
+ * Auth profile -> CLI subprocess env var injection.
  *
  * Resolves per-agent auth profile references to environment variables
  * suitable for injecting into CLI subprocess environments.
@@ -9,21 +9,17 @@ import { resolveAgentAuth } from "../agents/agent-scope.js";
 import { normalizeProviderId } from "../agents/provider-utils.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { ensureAuthProfileStore, resolveApiKeyForProfile } from "./index.js";
+import { resolveApiKeyForProfile } from "./oauth.js";
+import { ensureAuthProfileStore } from "./store.js";
 import type { AuthProfileStore } from "./types.js";
+import {
+  clearExpiredCooldowns,
+  isProfileInCooldown,
+  markAuthProfileUsed,
+  resolveProfileUnusableUntil,
+} from "./usage.js";
 
 const log = createSubsystemLogger("auth-env");
-
-/**
- * Round-robin state: tracks the last-used index per agent ID.
- * Resets on process restart — rotation is best-effort.
- */
-const roundRobinState = new Map<string, number>();
-
-/** @internal — exposed for tests only. */
-export function _resetRoundRobinState(): void {
-  roundRobinState.clear();
-}
 
 /**
  * Map a provider ID to the primary environment variable name used by CLI agents.
@@ -72,24 +68,69 @@ export function resolveProviderEnvVarName(provider: string): string | undefined 
 }
 
 /**
- * Pick the next profile ID from an array using round-robin.
+ * Pick the next profile ID from an array using persistent, cooldown-aware
+ * round-robin. Profiles are ordered by lastUsed (oldest first) with
+ * cooldown profiles pushed to the end. The selected profile is marked as
+ * used so subsequent calls rotate to the next one.
  */
-function pickRoundRobin(agentId: string, profiles: string[]): string | undefined {
+async function pickNextProfile(
+  store: AuthProfileStore,
+  profiles: string[],
+): Promise<string | undefined> {
   if (profiles.length === 0) {
     return undefined;
   }
-  const lastIndex = roundRobinState.get(agentId) ?? -1;
-  const nextIndex = (lastIndex + 1) % profiles.length;
-  roundRobinState.set(agentId, nextIndex);
-  return profiles[nextIndex];
+
+  // Clear expired cooldowns so recovered profiles are available again
+  clearExpiredCooldowns(store);
+
+  // Partition into available and in-cooldown
+  const available: string[] = [];
+  const inCooldown: Array<{ profileId: string; cooldownUntil: number }> = [];
+  const now = Date.now();
+
+  for (const profileId of profiles) {
+    if (!store.profiles[profileId]) {
+      continue;
+    }
+    if (isProfileInCooldown(store, profileId)) {
+      const cooldownUntil = resolveProfileUnusableUntil(store.usageStats?.[profileId] ?? {}) ?? now;
+      inCooldown.push({ profileId, cooldownUntil });
+    } else {
+      available.push(profileId);
+    }
+  }
+
+  // Sort available by lastUsed (oldest first = round-robin)
+  const sorted = available.toSorted((a, b) => {
+    const aUsed = store.usageStats?.[a]?.lastUsed ?? 0;
+    const bUsed = store.usageStats?.[b]?.lastUsed ?? 0;
+    return aUsed - bUsed;
+  });
+
+  // Append cooldown profiles sorted by soonest expiry
+  const cooldownSorted = inCooldown
+    .toSorted((a, b) => a.cooldownUntil - b.cooldownUntil)
+    .map((entry) => entry.profileId);
+
+  const ordered = [...sorted, ...cooldownSorted];
+  const selected = ordered[0];
+  if (!selected) {
+    return undefined;
+  }
+
+  // Mark as used to advance the round-robin for the next call
+  await markAuthProfileUsed({ store, profileId: selected });
+
+  return selected;
 }
 
 /**
  * Return the number of auth profiles configured for an agent.
  *
- * - `auth: false` or `undefined` → 0
- * - `auth: "profile-id"` → 1
- * - `auth: ["id1", "id2"]` → N
+ * - `auth: false` or `undefined` -> 0
+ * - `auth: "profile-id"` -> 1
+ * - `auth: ["id1", "id2"]` -> N
  */
 export function resolveAuthProfileCount(cfg: RemoteClawConfig, agentId: string): number {
   const auth = resolveAgentAuth(cfg, agentId);
@@ -105,10 +146,10 @@ export function resolveAuthProfileCount(cfg: RemoteClawConfig, agentId: string):
 /**
  * Resolve per-agent auth profile(s) to env vars for CLI subprocess injection.
  *
- * - `auth: false` → no injection (returns `undefined`)
- * - `auth: "profile-id"` → resolve single profile, inject as env var
- * - `auth: ["id1", "id2"]` → round-robin rotation, inject selected profile
- * - `auth: undefined` → no injection (returns `undefined`)
+ * - `auth: false` -> no injection (returns `undefined`)
+ * - `auth: "profile-id"` -> resolve single profile, inject as env var
+ * - `auth: ["id1", "id2"]` -> persistent cooldown-aware round-robin, inject selected profile
+ * - `auth: undefined` -> no injection (returns `undefined`)
  *
  * Missing or invalid profiles log a warning and return `undefined`
  * (fall-through to next credential precedence level).
@@ -124,13 +165,13 @@ export async function resolveAuthEnv(params: {
     return undefined;
   }
 
-  const profileId = Array.isArray(auth) ? pickRoundRobin(params.agentId, auth) : auth;
+  const store = params.store ?? ensureAuthProfileStore();
+
+  const profileId = Array.isArray(auth) ? await pickNextProfile(store, auth) : auth;
 
   if (!profileId) {
     return undefined;
   }
-
-  const store = params.store ?? ensureAuthProfileStore();
 
   let resolved: { apiKey: string; provider: string; email?: string } | null;
   try {

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -2,11 +2,32 @@ export { CLAUDE_CLI_PROFILE_ID, CODEX_CLI_PROFILE_ID } from "./constants.js";
 export { resolveAuthProfileDisplayLabel } from "./display.js";
 export { formatAuthDoctorHint } from "./doctor.js";
 export { resolveApiKeyForProfile } from "./oauth.js";
+export { resolveAuthProfileOrder } from "./order.js";
 export { resolveAuthStorePathForDisplay } from "./paths.js";
 export {
+  dedupeProfileIds,
   listProfilesForProvider,
   upsertAuthProfile,
   upsertAuthProfileWithLock,
 } from "./profiles.js";
 export { ensureAuthProfileStore, loadAuthProfileStore, saveAuthProfileStore } from "./store.js";
-export type { ApiKeyCredential, AuthProfileCredential, AuthProfileStore } from "./types.js";
+export type {
+  ApiKeyCredential,
+  AuthProfileCredential,
+  AuthProfileFailureReason,
+  AuthProfileStore,
+  ProfileUsageStats,
+} from "./types.js";
+export {
+  calculateAuthProfileCooldownMs,
+  clearAuthProfileCooldown,
+  clearExpiredCooldowns,
+  getSoonestCooldownExpiry,
+  isProfileInCooldown,
+  markAuthProfileCooldown,
+  markAuthProfileFailure,
+  markAuthProfileUsed,
+  resolveProfilesUnavailableReason,
+  resolveProfileUnusableUntil,
+  resolveProfileUnusableUntilForDisplay,
+} from "./usage.js";

--- a/src/auth/order.test.ts
+++ b/src/auth/order.test.ts
@@ -1,0 +1,645 @@
+import { describe, expect, it } from "vitest";
+import type { RemoteClawConfig } from "../config/config.js";
+import { resolveAuthProfileOrder } from "./order.js";
+import type { AuthProfileStore } from "./types.js";
+import { isProfileInCooldown } from "./usage.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_STORE: AuthProfileStore = {
+  version: 1,
+  profiles: {
+    "anthropic:default": {
+      type: "api_key",
+      provider: "anthropic",
+      key: "sk-default",
+    },
+    "anthropic:work": {
+      type: "api_key",
+      provider: "anthropic",
+      key: "sk-work",
+    },
+  },
+};
+
+const ANTHROPIC_CFG: RemoteClawConfig = {
+  auth: {
+    profiles: {
+      "anthropic:default": { provider: "anthropic", mode: "api_key" },
+      "anthropic:work": { provider: "anthropic", mode: "api_key" },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// resolveAuthProfileOrder — basic ordering
+// ---------------------------------------------------------------------------
+
+describe("resolveAuthProfileOrder", () => {
+  const store = ANTHROPIC_STORE;
+  const cfg = ANTHROPIC_CFG;
+
+  function resolveWithAnthropicOrderAndUsage(params: {
+    orderSource: "store" | "config";
+    usageStats: NonNullable<AuthProfileStore["usageStats"]>;
+  }) {
+    const configuredOrder = { anthropic: ["anthropic:default", "anthropic:work"] };
+    return resolveAuthProfileOrder({
+      cfg:
+        params.orderSource === "config"
+          ? {
+              auth: {
+                order: configuredOrder,
+                profiles: cfg.auth?.profiles,
+              },
+            }
+          : undefined,
+      store:
+        params.orderSource === "store"
+          ? { ...store, order: configuredOrder, usageStats: params.usageStats }
+          : { ...store, usageStats: params.usageStats },
+      provider: "anthropic",
+    });
+  }
+
+  it("does not prioritize lastGood over round-robin ordering", () => {
+    const order = resolveAuthProfileOrder({
+      cfg,
+      store: {
+        ...store,
+        lastGood: { anthropic: "anthropic:work" },
+        usageStats: {
+          "anthropic:default": { lastUsed: 100 },
+          "anthropic:work": { lastUsed: 200 },
+        },
+      },
+      provider: "anthropic",
+    });
+    expect(order[0]).toBe("anthropic:default");
+  });
+
+  it("uses explicit profiles when order is missing", () => {
+    const order = resolveAuthProfileOrder({
+      cfg,
+      store,
+      provider: "anthropic",
+    });
+    expect(order).toEqual(["anthropic:default", "anthropic:work"]);
+  });
+
+  it("uses configured order when provided", () => {
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          order: { anthropic: ["anthropic:work", "anthropic:default"] },
+          profiles: cfg.auth?.profiles,
+        },
+      },
+      store,
+      provider: "anthropic",
+    });
+    expect(order).toEqual(["anthropic:work", "anthropic:default"]);
+  });
+
+  it("prefers store order over config order", () => {
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          order: { anthropic: ["anthropic:default", "anthropic:work"] },
+          profiles: cfg.auth?.profiles,
+        },
+      },
+      store: {
+        ...store,
+        order: { anthropic: ["anthropic:work", "anthropic:default"] },
+      },
+      provider: "anthropic",
+    });
+    expect(order).toEqual(["anthropic:work", "anthropic:default"]);
+  });
+
+  it.each(["store", "config"] as const)(
+    "pushes cooldown profiles to the end even with %s order",
+    (orderSource) => {
+      const now = Date.now();
+      const order = resolveWithAnthropicOrderAndUsage({
+        orderSource,
+        usageStats: {
+          "anthropic:default": { cooldownUntil: now + 60_000 },
+          "anthropic:work": { lastUsed: 1 },
+        },
+      });
+      expect(order).toEqual(["anthropic:work", "anthropic:default"]);
+    },
+  );
+
+  it.each(["store", "config"] as const)(
+    "pushes disabled profiles to the end even with %s order",
+    (orderSource) => {
+      const now = Date.now();
+      const order = resolveWithAnthropicOrderAndUsage({
+        orderSource,
+        usageStats: {
+          "anthropic:default": {
+            disabledUntil: now + 60_000,
+            disabledReason: "billing",
+          },
+          "anthropic:work": { lastUsed: 1 },
+        },
+      });
+      expect(order).toEqual(["anthropic:work", "anthropic:default"]);
+    },
+  );
+
+  it.each(["store", "config"] as const)(
+    "keeps OpenRouter explicit order even when cooldown fields exist (%s)",
+    (orderSource) => {
+      const now = Date.now();
+      const explicitOrder = ["openrouter:default", "openrouter:work"];
+      const order = resolveAuthProfileOrder({
+        cfg:
+          orderSource === "config"
+            ? {
+                auth: {
+                  order: { openrouter: explicitOrder },
+                },
+              }
+            : undefined,
+        store: {
+          version: 1,
+          ...(orderSource === "store" ? { order: { openrouter: explicitOrder } } : {}),
+          profiles: {
+            "openrouter:default": {
+              type: "api_key",
+              provider: "openrouter",
+              key: "sk-or-default",
+            },
+            "openrouter:work": {
+              type: "api_key",
+              provider: "openrouter",
+              key: "sk-or-work",
+            },
+          },
+          usageStats: {
+            "openrouter:default": {
+              cooldownUntil: now + 60_000,
+              disabledUntil: now + 120_000,
+              disabledReason: "billing",
+            },
+          },
+        },
+        provider: "openrouter",
+      });
+
+      expect(order).toEqual(explicitOrder);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// resolveAuthProfileOrder — stored profiles fallback
+// ---------------------------------------------------------------------------
+
+describe("resolveAuthProfileOrder — stored profiles", () => {
+  const store = ANTHROPIC_STORE;
+  const cfg = ANTHROPIC_CFG;
+
+  it("uses stored profiles when no config exists", () => {
+    const order = resolveAuthProfileOrder({
+      store,
+      provider: "anthropic",
+    });
+    expect(order).toEqual(["anthropic:default", "anthropic:work"]);
+  });
+
+  it("prioritizes preferred profiles", () => {
+    const order = resolveAuthProfileOrder({
+      cfg,
+      store,
+      provider: "anthropic",
+      preferredProfile: "anthropic:work",
+    });
+    expect(order[0]).toBe("anthropic:work");
+    expect(order).toContain("anthropic:default");
+  });
+
+  it("drops explicit order entries that are missing from the store", () => {
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          order: {
+            minimax: ["minimax:default", "minimax:prod"],
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "minimax:prod": {
+            type: "api_key",
+            provider: "minimax",
+            key: "sk-prod",
+          },
+        },
+      },
+      provider: "minimax",
+    });
+    expect(order).toEqual(["minimax:prod"]);
+  });
+
+  it("falls back to stored provider profiles when config profile ids drift", () => {
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          profiles: {
+            "openai-codex:default": {
+              provider: "openai-codex",
+              mode: "token",
+            },
+          },
+          order: {
+            "openai-codex": ["openai-codex:default"],
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "openai-codex:user@example.com": {
+            type: "token",
+            provider: "openai-codex",
+            token: "access-token",
+            expires: Date.now() + 60_000,
+          },
+        },
+      },
+      provider: "openai-codex",
+    });
+    expect(order).toEqual(["openai-codex:user@example.com"]);
+  });
+
+  it("does not bypass explicit ids when the configured profile exists but is invalid", () => {
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          profiles: {
+            "openai-codex:default": {
+              provider: "openai-codex",
+              mode: "token",
+            },
+          },
+          order: {
+            "openai-codex": ["openai-codex:default"],
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "openai-codex:default": {
+            type: "token",
+            provider: "openai-codex",
+            token: "expired-token",
+            expires: Date.now() - 1_000,
+          },
+          "openai-codex:user@example.com": {
+            type: "token",
+            provider: "openai-codex",
+            token: "access-token",
+            expires: Date.now() + 60_000,
+          },
+        },
+      },
+      provider: "openai-codex",
+    });
+    expect(order).toEqual([]);
+  });
+
+  it("drops explicit order entries that belong to another provider", () => {
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          order: {
+            minimax: ["openai:default", "minimax:prod"],
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-openai",
+          },
+          "minimax:prod": {
+            type: "api_key",
+            provider: "minimax",
+            key: "sk-mini",
+          },
+        },
+      },
+      provider: "minimax",
+    });
+    expect(order).toEqual(["minimax:prod"]);
+  });
+
+  it.each([
+    {
+      caseName: "drops token profiles with empty credentials",
+      profile: {
+        type: "token" as const,
+        provider: "minimax" as const,
+        token: "   ",
+      },
+    },
+    {
+      caseName: "drops token profiles that are already expired",
+      profile: {
+        type: "token" as const,
+        provider: "minimax" as const,
+        token: "sk-minimax",
+        expires: Date.now() - 1000,
+      },
+    },
+  ])("$caseName", ({ profile }) => {
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          order: {
+            minimax: ["minimax:default"],
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "minimax:default": profile,
+        },
+      },
+      provider: "minimax",
+    });
+    expect(order).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAuthProfileOrder — lastUsed ordering
+// ---------------------------------------------------------------------------
+
+describe("resolveAuthProfileOrder — lastUsed ordering", () => {
+  it("orders by lastUsed when no explicit order exists", () => {
+    const order = resolveAuthProfileOrder({
+      store: {
+        version: 1,
+        profiles: {
+          "anthropic:a": {
+            type: "token",
+            provider: "anthropic",
+            token: "access-token",
+            expires: Date.now() + 60_000,
+          },
+          "anthropic:b": {
+            type: "api_key",
+            provider: "anthropic",
+            key: "sk-b",
+          },
+          "anthropic:c": {
+            type: "api_key",
+            provider: "anthropic",
+            key: "sk-c",
+          },
+        },
+        usageStats: {
+          "anthropic:a": { lastUsed: 200 },
+          "anthropic:b": { lastUsed: 100 },
+          "anthropic:c": { lastUsed: 300 },
+        },
+      },
+      provider: "anthropic",
+    });
+    // token type has higher priority, then sorted by lastUsed within type
+    expect(order).toEqual(["anthropic:a", "anthropic:b", "anthropic:c"]);
+  });
+
+  it("pushes cooldown profiles to the end, ordered by cooldown expiry", () => {
+    const now = Date.now();
+    const order = resolveAuthProfileOrder({
+      store: {
+        version: 1,
+        profiles: {
+          "anthropic:ready": {
+            type: "api_key",
+            provider: "anthropic",
+            key: "sk-ready",
+          },
+          "anthropic:cool1": {
+            type: "token",
+            provider: "anthropic",
+            token: "access-token",
+            expires: now + 60_000,
+          },
+          "anthropic:cool2": {
+            type: "api_key",
+            provider: "anthropic",
+            key: "sk-cool",
+          },
+        },
+        usageStats: {
+          "anthropic:ready": { lastUsed: 50 },
+          "anthropic:cool1": { cooldownUntil: now + 5_000 },
+          "anthropic:cool2": { cooldownUntil: now + 1_000 },
+        },
+      },
+      provider: "anthropic",
+    });
+    expect(order).toEqual(["anthropic:ready", "anthropic:cool2", "anthropic:cool1"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAuthProfileOrder — alias normalization
+// ---------------------------------------------------------------------------
+
+describe("resolveAuthProfileOrder — alias normalization", () => {
+  function makeApiKeyStore(provider: string, profileIds: string[]): AuthProfileStore {
+    return {
+      version: 1,
+      profiles: Object.fromEntries(
+        profileIds.map((profileId) => [
+          profileId,
+          {
+            type: "api_key" as const,
+            provider,
+            key: profileId.endsWith(":work") ? "sk-work" : "sk-default",
+          },
+        ]),
+      ),
+    };
+  }
+
+  function makeApiKeyProfilesByProvider(
+    providerByProfileId: Record<string, string>,
+  ): Record<string, { provider: string; mode: "api_key" }> {
+    return Object.fromEntries(
+      Object.entries(providerByProfileId).map(([profileId, provider]) => [
+        profileId,
+        { provider, mode: "api_key" as const },
+      ]),
+    );
+  }
+
+  it("normalizes provider casing in auth.order keys", () => {
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          order: { OpenAI: ["openai:work", "openai:default"] },
+          profiles: makeApiKeyProfilesByProvider({
+            "openai:default": "openai",
+            "openai:work": "openai",
+          }),
+        },
+      },
+      store: makeApiKeyStore("openai", ["openai:default", "openai:work"]),
+      provider: "openai",
+    });
+    expect(order).toEqual(["openai:work", "openai:default"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAuthProfileOrder — cooldown auto-expiry
+// ---------------------------------------------------------------------------
+
+describe("resolveAuthProfileOrder — cooldown auto-expiry", () => {
+  function makeStoreWithProfiles(): AuthProfileStore {
+    return {
+      version: 1,
+      profiles: {
+        "anthropic:default": { type: "api_key", provider: "anthropic", key: "sk-1" },
+        "anthropic:secondary": { type: "api_key", provider: "anthropic", key: "sk-2" },
+        "openai:default": { type: "api_key", provider: "openai", key: "sk-oi" },
+      },
+      usageStats: {},
+    };
+  }
+
+  it("places profile with expired cooldown in available list (round-robin path)", () => {
+    const store = makeStoreWithProfiles();
+    store.usageStats = {
+      "anthropic:default": {
+        cooldownUntil: Date.now() - 10_000,
+        errorCount: 4,
+        failureCounts: { rate_limit: 4 },
+        lastFailureAt: Date.now() - 70_000,
+      },
+    };
+
+    const order = resolveAuthProfileOrder({ store, provider: "anthropic" });
+
+    expect(order).toContain("anthropic:default");
+    expect(isProfileInCooldown(store, "anthropic:default")).toBe(false);
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(0);
+    expect(store.usageStats?.["anthropic:default"]?.cooldownUntil).toBeUndefined();
+  });
+
+  it("places profile with expired cooldown in available list (explicit-order path)", () => {
+    const store = makeStoreWithProfiles();
+    store.order = { anthropic: ["anthropic:secondary", "anthropic:default"] };
+    store.usageStats = {
+      "anthropic:default": {
+        cooldownUntil: Date.now() - 5_000,
+        errorCount: 3,
+      },
+    };
+
+    const order = resolveAuthProfileOrder({ store, provider: "anthropic" });
+
+    expect(order[0]).toBe("anthropic:secondary");
+    expect(order).toContain("anthropic:default");
+    expect(store.usageStats?.["anthropic:default"]?.cooldownUntil).toBeUndefined();
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(0);
+  });
+
+  it("keeps profile with active cooldown in cooldown list", () => {
+    const futureMs = Date.now() + 300_000;
+    const store = makeStoreWithProfiles();
+    store.usageStats = {
+      "anthropic:default": {
+        cooldownUntil: futureMs,
+        errorCount: 3,
+      },
+    };
+
+    const order = resolveAuthProfileOrder({ store, provider: "anthropic" });
+
+    expect(order).toContain("anthropic:default");
+    expect(isProfileInCooldown(store, "anthropic:default")).toBe(true);
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(3);
+  });
+
+  it("expired cooldown resets error count — prevents escalation on next failure", () => {
+    const store = makeStoreWithProfiles();
+    store.usageStats = {
+      "anthropic:default": {
+        cooldownUntil: Date.now() - 1_000,
+        errorCount: 4,
+        failureCounts: { rate_limit: 4 },
+        lastFailureAt: Date.now() - 3_700_000,
+      },
+    };
+
+    resolveAuthProfileOrder({ store, provider: "anthropic" });
+
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(0);
+    expect(store.usageStats?.["anthropic:default"]?.failureCounts).toBeUndefined();
+  });
+
+  it("mixed active and expired cooldowns across profiles", () => {
+    const store = makeStoreWithProfiles();
+    store.usageStats = {
+      "anthropic:default": {
+        cooldownUntil: Date.now() - 1_000,
+        errorCount: 3,
+      },
+      "anthropic:secondary": {
+        cooldownUntil: Date.now() + 300_000,
+        errorCount: 2,
+      },
+    };
+
+    const order = resolveAuthProfileOrder({ store, provider: "anthropic" });
+
+    expect(store.usageStats?.["anthropic:default"]?.cooldownUntil).toBeUndefined();
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(0);
+
+    expect(store.usageStats?.["anthropic:secondary"]?.cooldownUntil).toBeGreaterThan(Date.now());
+    expect(store.usageStats?.["anthropic:secondary"]?.errorCount).toBe(2);
+
+    expect(order[0]).toBe("anthropic:default");
+  });
+
+  it("does not affect profiles from other providers", () => {
+    const store = makeStoreWithProfiles();
+    store.usageStats = {
+      "anthropic:default": {
+        cooldownUntil: Date.now() - 1_000,
+        errorCount: 4,
+      },
+      "openai:default": {
+        cooldownUntil: Date.now() - 1_000,
+        errorCount: 3,
+      },
+    };
+
+    // Resolve only anthropic
+    resolveAuthProfileOrder({ store, provider: "anthropic" });
+
+    // Both should be cleared since clearExpiredCooldowns sweeps all profiles
+    // in the store — this is intentional for correctness.
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(0);
+    expect(store.usageStats?.["openai:default"]?.errorCount).toBe(0);
+  });
+});

--- a/src/auth/order.ts
+++ b/src/auth/order.ts
@@ -1,0 +1,175 @@
+import { findNormalizedProviderValue, normalizeProviderId } from "../agents/provider-utils.js";
+import type { RemoteClawConfig } from "../config/config.js";
+import { dedupeProfileIds, listProfilesForProvider } from "./profiles.js";
+import type { AuthProfileStore } from "./types.js";
+import {
+  clearExpiredCooldowns,
+  isProfileInCooldown,
+  resolveProfileUnusableUntil,
+} from "./usage.js";
+
+export function resolveAuthProfileOrder(params: {
+  cfg?: RemoteClawConfig;
+  store: AuthProfileStore;
+  provider: string;
+  preferredProfile?: string;
+}): string[] {
+  const { cfg, store, provider, preferredProfile } = params;
+  const providerKey = normalizeProviderId(provider);
+  const now = Date.now();
+
+  // Clear any cooldowns that have expired since the last check so profiles
+  // get a fresh error count and are not immediately re-penalized on the
+  // next transient failure.
+  clearExpiredCooldowns(store, now);
+  const storedOrder = findNormalizedProviderValue(store.order, providerKey);
+  const configuredOrder = findNormalizedProviderValue(cfg?.auth?.order, providerKey);
+  const explicitOrder = storedOrder ?? configuredOrder;
+  const explicitProfiles = cfg?.auth?.profiles
+    ? Object.entries(cfg.auth.profiles)
+        .filter(([, profile]) => normalizeProviderId(profile.provider) === providerKey)
+        .map(([profileId]) => profileId)
+    : [];
+  const baseOrder =
+    explicitOrder ??
+    (explicitProfiles.length > 0 ? explicitProfiles : listProfilesForProvider(store, providerKey));
+  if (baseOrder.length === 0) {
+    return [];
+  }
+
+  const isValidProfile = (profileId: string): boolean => {
+    const cred = store.profiles[profileId];
+    if (!cred) {
+      return false;
+    }
+    if (normalizeProviderId(cred.provider) !== providerKey) {
+      return false;
+    }
+    const profileConfig = cfg?.auth?.profiles?.[profileId];
+    if (profileConfig) {
+      if (normalizeProviderId(profileConfig.provider) !== providerKey) {
+        return false;
+      }
+      if (profileConfig.mode !== cred.type) {
+        return false;
+      }
+    }
+    if (cred.type === "api_key") {
+      return Boolean(cred.key?.trim());
+    }
+    if (cred.type === "token") {
+      if (!cred.token?.trim()) {
+        return false;
+      }
+      if (
+        typeof cred.expires === "number" &&
+        Number.isFinite(cred.expires) &&
+        cred.expires > 0 &&
+        now >= cred.expires
+      ) {
+        return false;
+      }
+      return true;
+    }
+    return false;
+  };
+  let filtered = baseOrder.filter(isValidProfile);
+
+  // Repair config/store profile-id drift from older onboarding flows:
+  // if configured profile ids no longer exist in auth-profiles.json, scan the
+  // provider's stored credentials and use any valid entries.
+  const allBaseProfilesMissing = baseOrder.every((profileId) => !store.profiles[profileId]);
+  if (filtered.length === 0 && explicitProfiles.length > 0 && allBaseProfilesMissing) {
+    const storeProfiles = listProfilesForProvider(store, providerKey);
+    filtered = storeProfiles.filter(isValidProfile);
+  }
+
+  const deduped = dedupeProfileIds(filtered);
+
+  // If user specified explicit order (store override or config), respect it
+  // exactly, but still apply cooldown sorting to avoid repeatedly selecting
+  // known-bad/rate-limited keys as the first candidate.
+  if (explicitOrder && explicitOrder.length > 0) {
+    const available: string[] = [];
+    const inCooldown: Array<{ profileId: string; cooldownUntil: number }> = [];
+
+    for (const profileId of deduped) {
+      if (isProfileInCooldown(store, profileId)) {
+        const cooldownUntil =
+          resolveProfileUnusableUntil(store.usageStats?.[profileId] ?? {}) ?? now;
+        inCooldown.push({ profileId, cooldownUntil });
+      } else {
+        available.push(profileId);
+      }
+    }
+
+    const cooldownSorted = inCooldown
+      .toSorted((a, b) => a.cooldownUntil - b.cooldownUntil)
+      .map((entry) => entry.profileId);
+
+    const ordered = [...available, ...cooldownSorted];
+
+    // Still put preferredProfile first if specified
+    if (preferredProfile && ordered.includes(preferredProfile)) {
+      return [preferredProfile, ...ordered.filter((e) => e !== preferredProfile)];
+    }
+    return ordered;
+  }
+
+  // Otherwise, use round-robin: sort by lastUsed (oldest first)
+  // preferredProfile goes first if specified (for explicit user choice)
+  // lastGood is NOT prioritized — that would defeat round-robin
+  const sorted = orderProfilesByMode(deduped, store);
+
+  if (preferredProfile && sorted.includes(preferredProfile)) {
+    return [preferredProfile, ...sorted.filter((e) => e !== preferredProfile)];
+  }
+
+  return sorted;
+}
+
+function orderProfilesByMode(order: string[], store: AuthProfileStore): string[] {
+  const now = Date.now();
+
+  // Partition into available and in-cooldown
+  const available: string[] = [];
+  const inCooldown: string[] = [];
+
+  for (const profileId of order) {
+    if (isProfileInCooldown(store, profileId)) {
+      inCooldown.push(profileId);
+    } else {
+      available.push(profileId);
+    }
+  }
+
+  // Sort available profiles by type preference, then by lastUsed (oldest first = round-robin within type)
+  const scored = available.map((profileId) => {
+    const type = store.profiles[profileId]?.type;
+    const typeScore = type === "token" ? 0 : type === "api_key" ? 1 : 2;
+    const lastUsed = store.usageStats?.[profileId]?.lastUsed ?? 0;
+    return { profileId, typeScore, lastUsed };
+  });
+
+  // Primary sort: type preference (token > api_key).
+  // Secondary sort: lastUsed (oldest first for round-robin within type).
+  const sorted = scored
+    .toSorted((a, b) => {
+      if (a.typeScore !== b.typeScore) {
+        return a.typeScore - b.typeScore;
+      }
+      return a.lastUsed - b.lastUsed;
+    })
+    .map((entry) => entry.profileId);
+
+  // Append cooldown profiles at the end (sorted by cooldown expiry, soonest first)
+  const cooldownSorted = inCooldown
+    .map((profileId) => ({
+      profileId,
+      cooldownUntil: resolveProfileUnusableUntil(store.usageStats?.[profileId] ?? {}) ?? now,
+    }))
+    .toSorted((a, b) => a.cooldownUntil - b.cooldownUntil)
+    .map((entry) => entry.profileId);
+
+  return [...sorted, ...cooldownSorted];
+}

--- a/src/auth/profiles.ts
+++ b/src/auth/profiles.ts
@@ -7,6 +7,10 @@ import {
 } from "./store.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
 
+export function dedupeProfileIds(profileIds: string[]): string[] {
+  return [...new Set(profileIds)];
+}
+
 export function upsertAuthProfile(params: {
   profileId: string;
   credential: AuthProfileCredential;

--- a/src/auth/store.ts
+++ b/src/auth/store.ts
@@ -2,7 +2,7 @@ import { withFileLock } from "../infra/file-lock.js";
 import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
 import { AUTH_STORE_LOCK_OPTIONS, AUTH_STORE_VERSION } from "./constants.js";
 import { ensureAuthStoreFile, resolveAuthStorePath } from "./paths.js";
-import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
+import type { AuthProfileCredential, AuthProfileStore, ProfileUsageStats } from "./types.js";
 
 export async function updateAuthProfileStoreWithLock(params: {
   updater: (store: AuthProfileStore) => boolean;
@@ -50,9 +50,38 @@ function coerceAuthStore(raw: unknown): AuthProfileStore | null {
       provider,
     } as AuthProfileCredential;
   }
+  const order =
+    record.order && typeof record.order === "object"
+      ? Object.entries(record.order as Record<string, unknown>).reduce(
+          (acc, [provider, value]) => {
+            if (!Array.isArray(value)) {
+              return acc;
+            }
+            const list = value
+              .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+              .filter(Boolean);
+            if (list.length === 0) {
+              return acc;
+            }
+            acc[provider] = list;
+            return acc;
+          },
+          {} as Record<string, string[]>,
+        )
+      : undefined;
+
   return {
     version: Number(record.version ?? AUTH_STORE_VERSION),
     profiles: normalized,
+    order,
+    lastGood:
+      record.lastGood && typeof record.lastGood === "object"
+        ? (record.lastGood as Record<string, string>)
+        : undefined,
+    usageStats:
+      record.usageStats && typeof record.usageStats === "object"
+        ? (record.usageStats as Record<string, ProfileUsageStats>)
+        : undefined,
   };
 }
 
@@ -76,6 +105,9 @@ export function saveAuthProfileStore(store: AuthProfileStore): void {
   const payload = {
     version: AUTH_STORE_VERSION,
     profiles: store.profiles,
+    order: store.order ?? undefined,
+    lastGood: store.lastGood ?? undefined,
+    usageStats: store.usageStats ?? undefined,
   } satisfies AuthProfileStore;
   saveJsonFile(authPath, payload);
 }

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -22,7 +22,36 @@ export type TokenCredential = {
 
 export type AuthProfileCredential = ApiKeyCredential | TokenCredential;
 
+export type AuthProfileFailureReason =
+  | "auth"
+  | "format"
+  | "rate_limit"
+  | "billing"
+  | "timeout"
+  | "model_not_found"
+  | "unknown";
+
+/** Per-profile usage statistics for round-robin and cooldown tracking */
+export type ProfileUsageStats = {
+  lastUsed?: number;
+  cooldownUntil?: number;
+  disabledUntil?: number;
+  disabledReason?: AuthProfileFailureReason;
+  errorCount?: number;
+  failureCounts?: Partial<Record<AuthProfileFailureReason, number>>;
+  lastFailureAt?: number;
+};
+
 export type AuthProfileStore = {
   version: number;
   profiles: Record<string, AuthProfileCredential>;
+  /**
+   * Optional per-agent preferred profile order overrides.
+   * This lets you lock/override auth rotation for a specific agent without
+   * changing the global config.
+   */
+  order?: Record<string, string[]>;
+  lastGood?: Record<string, string>;
+  /** Usage statistics per profile for round-robin rotation */
+  usageStats?: Record<string, ProfileUsageStats>;
 };

--- a/src/auth/usage.test.ts
+++ b/src/auth/usage.test.ts
@@ -1,0 +1,678 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
+import {
+  calculateAuthProfileCooldownMs,
+  clearAuthProfileCooldown,
+  clearExpiredCooldowns,
+  getSoonestCooldownExpiry,
+  isProfileInCooldown,
+  markAuthProfileFailure,
+  resolveProfilesUnavailableReason,
+  resolveProfileUnusableUntil,
+  resolveProfileUnusableUntilForDisplay,
+} from "./usage.js";
+
+vi.mock("./store.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./store.js")>();
+  return {
+    ...original,
+    updateAuthProfileStoreWithLock: vi.fn().mockResolvedValue(null),
+    saveAuthProfileStore: vi.fn(),
+  };
+});
+
+function makeStore(usageStats: AuthProfileStore["usageStats"]): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {
+      "anthropic:default": { type: "api_key", provider: "anthropic", key: "sk-test" },
+      "openai:default": { type: "api_key", provider: "openai", key: "sk-test-2" },
+      "openrouter:default": { type: "api_key", provider: "openrouter", key: "sk-or-test" },
+    },
+    usageStats,
+  };
+}
+
+function expectProfileErrorStateCleared(
+  stats: NonNullable<AuthProfileStore["usageStats"]>[string] | undefined,
+) {
+  expect(stats?.cooldownUntil).toBeUndefined();
+  expect(stats?.disabledUntil).toBeUndefined();
+  expect(stats?.disabledReason).toBeUndefined();
+  expect(stats?.errorCount).toBe(0);
+  expect(stats?.failureCounts).toBeUndefined();
+}
+
+describe("resolveProfileUnusableUntil", () => {
+  it("returns null when both values are missing or invalid", () => {
+    expect(resolveProfileUnusableUntil({})).toBeNull();
+    expect(resolveProfileUnusableUntil({ cooldownUntil: 0, disabledUntil: Number.NaN })).toBeNull();
+  });
+
+  it("returns the latest active timestamp", () => {
+    expect(resolveProfileUnusableUntil({ cooldownUntil: 100, disabledUntil: 200 })).toBe(200);
+    expect(resolveProfileUnusableUntil({ cooldownUntil: 300 })).toBe(300);
+  });
+});
+
+describe("resolveProfileUnusableUntilForDisplay", () => {
+  it("hides cooldown markers for OpenRouter profiles", () => {
+    const store = makeStore({
+      "openrouter:default": {
+        cooldownUntil: Date.now() + 60_000,
+      },
+    });
+
+    expect(resolveProfileUnusableUntilForDisplay(store, "openrouter:default")).toBeNull();
+  });
+
+  it("keeps cooldown markers visible for other providers", () => {
+    const until = Date.now() + 60_000;
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: until,
+      },
+    });
+
+    expect(resolveProfileUnusableUntilForDisplay(store, "anthropic:default")).toBe(until);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isProfileInCooldown
+// ---------------------------------------------------------------------------
+
+describe("isProfileInCooldown", () => {
+  it("returns false when profile has no usage stats", () => {
+    const store = makeStore(undefined);
+    expect(isProfileInCooldown(store, "anthropic:default")).toBe(false);
+  });
+
+  it("returns true when cooldownUntil is in the future", () => {
+    const store = makeStore({
+      "anthropic:default": { cooldownUntil: Date.now() + 60_000 },
+    });
+    expect(isProfileInCooldown(store, "anthropic:default")).toBe(true);
+  });
+
+  it("returns false when cooldownUntil has passed", () => {
+    const store = makeStore({
+      "anthropic:default": { cooldownUntil: Date.now() - 1_000 },
+    });
+    expect(isProfileInCooldown(store, "anthropic:default")).toBe(false);
+  });
+
+  it("returns true when disabledUntil is in the future (even if cooldownUntil expired)", () => {
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: Date.now() - 1_000,
+        disabledUntil: Date.now() + 60_000,
+      },
+    });
+    expect(isProfileInCooldown(store, "anthropic:default")).toBe(true);
+  });
+
+  it("returns false for OpenRouter even when cooldown fields exist", () => {
+    const store = makeStore({
+      "openrouter:default": {
+        cooldownUntil: Date.now() + 60_000,
+        disabledUntil: Date.now() + 60_000,
+        disabledReason: "billing",
+      },
+    });
+    expect(isProfileInCooldown(store, "openrouter:default")).toBe(false);
+  });
+});
+
+describe("resolveProfilesUnavailableReason", () => {
+  it("prefers active disabledReason when profiles are disabled", () => {
+    const now = Date.now();
+    const store = makeStore({
+      "anthropic:default": {
+        disabledUntil: now + 60_000,
+        disabledReason: "billing",
+      },
+    });
+
+    expect(
+      resolveProfilesUnavailableReason({
+        store,
+        profileIds: ["anthropic:default"],
+        now,
+      }),
+    ).toBe("billing");
+  });
+
+  it("uses recorded non-rate-limit failure counts for active cooldown windows", () => {
+    const now = Date.now();
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: now + 60_000,
+        failureCounts: { auth: 3, rate_limit: 1 },
+      },
+    });
+
+    expect(
+      resolveProfilesUnavailableReason({
+        store,
+        profileIds: ["anthropic:default"],
+        now,
+      }),
+    ).toBe("auth");
+  });
+
+  it("falls back to rate_limit when active cooldown has no reason history", () => {
+    const now = Date.now();
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: now + 60_000,
+      },
+    });
+
+    expect(
+      resolveProfilesUnavailableReason({
+        store,
+        profileIds: ["anthropic:default"],
+        now,
+      }),
+    ).toBe("rate_limit");
+  });
+
+  it("ignores expired windows and returns null when no profile is actively unavailable", () => {
+    const now = Date.now();
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: now - 1_000,
+        failureCounts: { auth: 5 },
+      },
+      "anthropic:backup": {
+        disabledUntil: now - 500,
+        disabledReason: "billing",
+      },
+    });
+
+    expect(
+      resolveProfilesUnavailableReason({
+        store,
+        profileIds: ["anthropic:default", "anthropic:backup"],
+        now,
+      }),
+    ).toBeNull();
+  });
+
+  it("breaks ties by reason priority for equal active failure counts", () => {
+    const now = Date.now();
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: now + 60_000,
+        failureCounts: { timeout: 2, auth: 2 },
+      },
+    });
+
+    expect(
+      resolveProfilesUnavailableReason({
+        store,
+        profileIds: ["anthropic:default"],
+        now,
+      }),
+    ).toBe("auth");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clearExpiredCooldowns
+// ---------------------------------------------------------------------------
+
+describe("clearExpiredCooldowns", () => {
+  it("returns false on empty usageStats", () => {
+    const store = makeStore(undefined);
+    expect(clearExpiredCooldowns(store)).toBe(false);
+  });
+
+  it("returns false when no profiles have cooldowns", () => {
+    const store = makeStore({
+      "anthropic:default": { lastUsed: Date.now() },
+    });
+    expect(clearExpiredCooldowns(store)).toBe(false);
+  });
+
+  it("returns false when cooldown is still active", () => {
+    const future = Date.now() + 300_000;
+    const store = makeStore({
+      "anthropic:default": { cooldownUntil: future, errorCount: 3 },
+    });
+
+    expect(clearExpiredCooldowns(store)).toBe(false);
+    expect(store.usageStats?.["anthropic:default"]?.cooldownUntil).toBe(future);
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(3);
+  });
+
+  it("clears expired cooldownUntil and resets errorCount", () => {
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: Date.now() - 1_000,
+        errorCount: 4,
+        failureCounts: { rate_limit: 3, timeout: 1 },
+        lastFailureAt: Date.now() - 120_000,
+      },
+    });
+
+    expect(clearExpiredCooldowns(store)).toBe(true);
+
+    const stats = store.usageStats?.["anthropic:default"];
+    expect(stats?.cooldownUntil).toBeUndefined();
+    expect(stats?.errorCount).toBe(0);
+    expect(stats?.failureCounts).toBeUndefined();
+    // lastFailureAt preserved for failureWindowMs decay
+    expect(stats?.lastFailureAt).toBeDefined();
+  });
+
+  it("clears expired disabledUntil and disabledReason", () => {
+    const store = makeStore({
+      "anthropic:default": {
+        disabledUntil: Date.now() - 1_000,
+        disabledReason: "billing",
+        errorCount: 2,
+        failureCounts: { billing: 2 },
+      },
+    });
+
+    expect(clearExpiredCooldowns(store)).toBe(true);
+
+    const stats = store.usageStats?.["anthropic:default"];
+    expect(stats?.disabledUntil).toBeUndefined();
+    expect(stats?.disabledReason).toBeUndefined();
+    expect(stats?.errorCount).toBe(0);
+    expect(stats?.failureCounts).toBeUndefined();
+  });
+
+  it("handles independent expiry: cooldown expired but disabled still active", () => {
+    const future = Date.now() + 3_600_000;
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: Date.now() - 1_000,
+        disabledUntil: future,
+        disabledReason: "billing",
+        errorCount: 5,
+        failureCounts: { rate_limit: 3, billing: 2 },
+      },
+    });
+
+    expect(clearExpiredCooldowns(store)).toBe(true);
+
+    const stats = store.usageStats?.["anthropic:default"];
+    // cooldownUntil cleared
+    expect(stats?.cooldownUntil).toBeUndefined();
+    // disabledUntil still active — not touched
+    expect(stats?.disabledUntil).toBe(future);
+    expect(stats?.disabledReason).toBe("billing");
+    // errorCount NOT reset because profile still has an active unusable window
+    expect(stats?.errorCount).toBe(5);
+    expect(stats?.failureCounts).toEqual({ rate_limit: 3, billing: 2 });
+  });
+
+  it("handles independent expiry: disabled expired but cooldown still active", () => {
+    const future = Date.now() + 300_000;
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: future,
+        disabledUntil: Date.now() - 1_000,
+        disabledReason: "billing",
+        errorCount: 3,
+      },
+    });
+
+    expect(clearExpiredCooldowns(store)).toBe(true);
+
+    const stats = store.usageStats?.["anthropic:default"];
+    expect(stats?.cooldownUntil).toBe(future);
+    expect(stats?.disabledUntil).toBeUndefined();
+    expect(stats?.disabledReason).toBeUndefined();
+    // errorCount NOT reset because cooldown is still active
+    expect(stats?.errorCount).toBe(3);
+  });
+
+  it("resets errorCount only when both cooldown and disabled have expired", () => {
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: Date.now() - 2_000,
+        disabledUntil: Date.now() - 1_000,
+        disabledReason: "billing",
+        errorCount: 4,
+        failureCounts: { rate_limit: 2, billing: 2 },
+      },
+    });
+
+    expect(clearExpiredCooldowns(store)).toBe(true);
+
+    const stats = store.usageStats?.["anthropic:default"];
+    expectProfileErrorStateCleared(stats);
+  });
+
+  it("processes multiple profiles independently", () => {
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: Date.now() - 1_000,
+        errorCount: 3,
+      },
+      "openai:default": {
+        cooldownUntil: Date.now() + 300_000,
+        errorCount: 2,
+      },
+    });
+
+    expect(clearExpiredCooldowns(store)).toBe(true);
+
+    // Anthropic: expired -> cleared
+    expect(store.usageStats?.["anthropic:default"]?.cooldownUntil).toBeUndefined();
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(0);
+
+    // OpenAI: still active -> untouched
+    expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBeGreaterThan(Date.now());
+    expect(store.usageStats?.["openai:default"]?.errorCount).toBe(2);
+  });
+
+  it("accepts an explicit `now` timestamp for deterministic testing", () => {
+    const fixedNow = 1_700_000_000_000;
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: fixedNow - 1,
+        errorCount: 2,
+      },
+    });
+
+    expect(clearExpiredCooldowns(store, fixedNow)).toBe(true);
+    expect(store.usageStats?.["anthropic:default"]?.cooldownUntil).toBeUndefined();
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(0);
+  });
+
+  it("clears cooldownUntil that equals exactly `now`", () => {
+    const fixedNow = 1_700_000_000_000;
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: fixedNow,
+        errorCount: 2,
+      },
+    });
+
+    // ts >= cooldownUntil -> should clear (cooldown "until" means the instant
+    // at cooldownUntil the profile becomes available again).
+    expect(clearExpiredCooldowns(store, fixedNow)).toBe(true);
+    expect(store.usageStats?.["anthropic:default"]?.cooldownUntil).toBeUndefined();
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(0);
+  });
+
+  it("ignores NaN and Infinity cooldown values", () => {
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: NaN,
+        errorCount: 2,
+      },
+      "openai:default": {
+        cooldownUntil: Infinity,
+        errorCount: 3,
+      },
+    });
+
+    expect(clearExpiredCooldowns(store)).toBe(false);
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(2);
+    expect(store.usageStats?.["openai:default"]?.errorCount).toBe(3);
+  });
+
+  it("ignores zero and negative cooldown values", () => {
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: 0,
+        errorCount: 1,
+      },
+      "openai:default": {
+        cooldownUntil: -1,
+        errorCount: 1,
+      },
+    });
+
+    expect(clearExpiredCooldowns(store)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clearAuthProfileCooldown
+// ---------------------------------------------------------------------------
+
+describe("clearAuthProfileCooldown", () => {
+  it("clears all error state fields including disabledUntil and failureCounts", async () => {
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: Date.now() + 60_000,
+        disabledUntil: Date.now() + 3_600_000,
+        disabledReason: "billing",
+        errorCount: 5,
+        failureCounts: { billing: 3, rate_limit: 2 },
+      },
+    });
+
+    await clearAuthProfileCooldown({ store, profileId: "anthropic:default" });
+
+    const stats = store.usageStats?.["anthropic:default"];
+    expectProfileErrorStateCleared(stats);
+  });
+
+  it("preserves lastUsed and lastFailureAt timestamps", async () => {
+    const lastUsed = Date.now() - 10_000;
+    const lastFailureAt = Date.now() - 5_000;
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: Date.now() + 60_000,
+        errorCount: 3,
+        lastUsed,
+        lastFailureAt,
+      },
+    });
+
+    await clearAuthProfileCooldown({ store, profileId: "anthropic:default" });
+
+    const stats = store.usageStats?.["anthropic:default"];
+    expect(stats?.lastUsed).toBe(lastUsed);
+    expect(stats?.lastFailureAt).toBe(lastFailureAt);
+  });
+
+  it("no-ops for unknown profile id", async () => {
+    const store = makeStore(undefined);
+    await clearAuthProfileCooldown({ store, profileId: "nonexistent" });
+    expect(store.usageStats).toBeUndefined();
+  });
+});
+
+describe("markAuthProfileFailure — active windows do not extend on retry", () => {
+  type WindowStats = ProfileUsageStats;
+
+  async function markFailureAt(params: {
+    store: ReturnType<typeof makeStore>;
+    now: number;
+    reason: "rate_limit" | "billing";
+  }): Promise<void> {
+    vi.useFakeTimers();
+    vi.setSystemTime(params.now);
+    try {
+      await markAuthProfileFailure({
+        store: params.store,
+        profileId: "anthropic:default",
+        reason: params.reason,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  }
+
+  const activeWindowCases = [
+    {
+      label: "cooldownUntil",
+      reason: "rate_limit" as const,
+      buildUsageStats: (now: number): WindowStats => ({
+        cooldownUntil: now + 50 * 60 * 1000,
+        errorCount: 3,
+        lastFailureAt: now - 10 * 60 * 1000,
+      }),
+      readUntil: (stats: WindowStats | undefined) => stats?.cooldownUntil,
+    },
+    {
+      label: "disabledUntil",
+      reason: "billing" as const,
+      buildUsageStats: (now: number): WindowStats => ({
+        disabledUntil: now + 20 * 60 * 60 * 1000,
+        disabledReason: "billing",
+        errorCount: 5,
+        failureCounts: { billing: 5 },
+        lastFailureAt: now - 60_000,
+      }),
+      readUntil: (stats: WindowStats | undefined) => stats?.disabledUntil,
+    },
+  ];
+
+  for (const testCase of activeWindowCases) {
+    it(`keeps active ${testCase.label} unchanged on retry`, async () => {
+      const now = 1_000_000;
+      const existingStats = testCase.buildUsageStats(now);
+      const existingUntil = testCase.readUntil(existingStats);
+      const store = makeStore({ "anthropic:default": existingStats });
+
+      await markFailureAt({
+        store,
+        now,
+        reason: testCase.reason,
+      });
+
+      const stats = store.usageStats?.["anthropic:default"];
+      expect(testCase.readUntil(stats)).toBe(existingUntil);
+    });
+  }
+
+  const expiredWindowCases = [
+    {
+      label: "cooldownUntil",
+      reason: "rate_limit" as const,
+      buildUsageStats: (now: number): WindowStats => ({
+        cooldownUntil: now - 60_000,
+        errorCount: 3,
+        lastFailureAt: now - 60_000,
+      }),
+      expectedUntil: (now: number) => now + 60 * 60 * 1000,
+      readUntil: (stats: WindowStats | undefined) => stats?.cooldownUntil,
+    },
+    {
+      label: "disabledUntil",
+      reason: "billing" as const,
+      buildUsageStats: (now: number): WindowStats => ({
+        disabledUntil: now - 60_000,
+        disabledReason: "billing",
+        errorCount: 5,
+        failureCounts: { billing: 2 },
+        lastFailureAt: now - 60_000,
+      }),
+      expectedUntil: (now: number) => now + 20 * 60 * 60 * 1000,
+      readUntil: (stats: WindowStats | undefined) => stats?.disabledUntil,
+    },
+  ];
+
+  for (const testCase of expiredWindowCases) {
+    it(`recomputes ${testCase.label} after the previous window expires`, async () => {
+      const now = 1_000_000;
+      const store = makeStore({
+        "anthropic:default": testCase.buildUsageStats(now),
+      });
+
+      await markFailureAt({
+        store,
+        now,
+        reason: testCase.reason,
+      });
+
+      const stats = store.usageStats?.["anthropic:default"];
+      expect(testCase.readUntil(stats)).toBe(testCase.expectedUntil(now));
+    });
+  }
+});
+
+describe("getSoonestCooldownExpiry", () => {
+  function makeStoreForExpiry(usageStats?: AuthProfileStore["usageStats"]): AuthProfileStore {
+    return {
+      version: 1,
+      profiles: {},
+      usageStats,
+    };
+  }
+
+  it("returns null when no cooldown timestamps exist", () => {
+    const store = makeStoreForExpiry();
+    expect(getSoonestCooldownExpiry(store, ["openai:p1"])).toBeNull();
+  });
+
+  it("returns earliest unusable time across profiles", () => {
+    const store = makeStoreForExpiry({
+      "openai:p1": {
+        cooldownUntil: 1_700_000_002_000,
+        disabledUntil: 1_700_000_004_000,
+      },
+      "openai:p2": {
+        cooldownUntil: 1_700_000_003_000,
+      },
+      "openai:p3": {
+        disabledUntil: 1_700_000_001_000,
+      },
+    });
+
+    expect(getSoonestCooldownExpiry(store, ["openai:p1", "openai:p2", "openai:p3"])).toBe(
+      1_700_000_001_000,
+    );
+  });
+
+  it("ignores unknown profiles and invalid cooldown values", () => {
+    const store = makeStoreForExpiry({
+      "openai:p1": {
+        cooldownUntil: -1,
+      },
+      "openai:p2": {
+        cooldownUntil: Infinity,
+      },
+      "openai:p3": {
+        disabledUntil: NaN,
+      },
+      "openai:p4": {
+        cooldownUntil: 1_700_000_005_000,
+      },
+    });
+
+    expect(
+      getSoonestCooldownExpiry(store, [
+        "missing",
+        "openai:p1",
+        "openai:p2",
+        "openai:p3",
+        "openai:p4",
+      ]),
+    ).toBe(1_700_000_005_000);
+  });
+
+  it("returns past timestamps when cooldown already expired", () => {
+    const store = makeStoreForExpiry({
+      "openai:p1": {
+        cooldownUntil: 1_700_000_000_000,
+      },
+      "openai:p2": {
+        disabledUntil: 1_700_000_010_000,
+      },
+    });
+
+    expect(getSoonestCooldownExpiry(store, ["openai:p1", "openai:p2"])).toBe(1_700_000_000_000);
+  });
+});
+
+describe("calculateAuthProfileCooldownMs", () => {
+  it("applies exponential backoff with a 1h cap", () => {
+    expect(calculateAuthProfileCooldownMs(1)).toBe(60_000);
+    expect(calculateAuthProfileCooldownMs(2)).toBe(5 * 60_000);
+    expect(calculateAuthProfileCooldownMs(3)).toBe(25 * 60_000);
+    expect(calculateAuthProfileCooldownMs(4)).toBe(60 * 60_000);
+    expect(calculateAuthProfileCooldownMs(5)).toBe(60 * 60_000);
+  });
+});

--- a/src/auth/usage.ts
+++ b/src/auth/usage.ts
@@ -1,0 +1,549 @@
+import { normalizeProviderId } from "../agents/provider-utils.js";
+import type { RemoteClawConfig } from "../config/config.js";
+import { saveAuthProfileStore, updateAuthProfileStoreWithLock } from "./store.js";
+import type { AuthProfileFailureReason, AuthProfileStore, ProfileUsageStats } from "./types.js";
+
+const FAILURE_REASON_PRIORITY: AuthProfileFailureReason[] = [
+  "auth",
+  "billing",
+  "format",
+  "model_not_found",
+  "timeout",
+  "rate_limit",
+  "unknown",
+];
+const FAILURE_REASON_SET = new Set<AuthProfileFailureReason>(FAILURE_REASON_PRIORITY);
+const FAILURE_REASON_ORDER = new Map<AuthProfileFailureReason, number>(
+  FAILURE_REASON_PRIORITY.map((reason, index) => [reason, index]),
+);
+
+function isAuthCooldownBypassedForProvider(provider: string | undefined): boolean {
+  return normalizeProviderId(provider ?? "") === "openrouter";
+}
+
+export function resolveProfileUnusableUntil(
+  stats: Pick<ProfileUsageStats, "cooldownUntil" | "disabledUntil">,
+): number | null {
+  const values = [stats.cooldownUntil, stats.disabledUntil]
+    .filter((value): value is number => typeof value === "number")
+    .filter((value) => Number.isFinite(value) && value > 0);
+  if (values.length === 0) {
+    return null;
+  }
+  return Math.max(...values);
+}
+
+/**
+ * Check if a profile is currently in cooldown (due to rate limiting or errors).
+ */
+export function isProfileInCooldown(store: AuthProfileStore, profileId: string): boolean {
+  if (isAuthCooldownBypassedForProvider(store.profiles[profileId]?.provider)) {
+    return false;
+  }
+  const stats = store.usageStats?.[profileId];
+  if (!stats) {
+    return false;
+  }
+  const unusableUntil = resolveProfileUnusableUntil(stats);
+  return unusableUntil ? Date.now() < unusableUntil : false;
+}
+
+function isActiveUnusableWindow(until: number | undefined, now: number): boolean {
+  return typeof until === "number" && Number.isFinite(until) && until > 0 && now < until;
+}
+
+/**
+ * Infer the most likely reason all candidate profiles are currently unavailable.
+ *
+ * We prefer explicit active `disabledReason` values (for example billing/auth)
+ * over generic cooldown buckets, then fall back to failure-count signals.
+ */
+export function resolveProfilesUnavailableReason(params: {
+  store: AuthProfileStore;
+  profileIds: string[];
+  now?: number;
+}): AuthProfileFailureReason | null {
+  const now = params.now ?? Date.now();
+  const scores = new Map<AuthProfileFailureReason, number>();
+  const addScore = (reason: AuthProfileFailureReason, value: number) => {
+    if (!FAILURE_REASON_SET.has(reason) || value <= 0 || !Number.isFinite(value)) {
+      return;
+    }
+    scores.set(reason, (scores.get(reason) ?? 0) + value);
+  };
+
+  for (const profileId of params.profileIds) {
+    const stats = params.store.usageStats?.[profileId];
+    if (!stats) {
+      continue;
+    }
+
+    const disabledActive = isActiveUnusableWindow(stats.disabledUntil, now);
+    if (disabledActive && stats.disabledReason && FAILURE_REASON_SET.has(stats.disabledReason)) {
+      // Disabled reasons are explicit and high-signal; weight heavily.
+      addScore(stats.disabledReason, 1_000);
+      continue;
+    }
+
+    const cooldownActive = isActiveUnusableWindow(stats.cooldownUntil, now);
+    if (!cooldownActive) {
+      continue;
+    }
+
+    let recordedReason = false;
+    for (const [rawReason, rawCount] of Object.entries(stats.failureCounts ?? {})) {
+      const reason = rawReason as AuthProfileFailureReason;
+      const count = typeof rawCount === "number" ? rawCount : 0;
+      if (!FAILURE_REASON_SET.has(reason) || count <= 0) {
+        continue;
+      }
+      addScore(reason, count);
+      recordedReason = true;
+    }
+    if (!recordedReason) {
+      addScore("rate_limit", 1);
+    }
+  }
+
+  if (scores.size === 0) {
+    return null;
+  }
+
+  let best: AuthProfileFailureReason | null = null;
+  let bestScore = -1;
+  let bestPriority = Number.MAX_SAFE_INTEGER;
+  for (const reason of FAILURE_REASON_PRIORITY) {
+    const score = scores.get(reason);
+    if (typeof score !== "number") {
+      continue;
+    }
+    const priority = FAILURE_REASON_ORDER.get(reason) ?? Number.MAX_SAFE_INTEGER;
+    if (score > bestScore || (score === bestScore && priority < bestPriority)) {
+      best = reason;
+      bestScore = score;
+      bestPriority = priority;
+    }
+  }
+  return best;
+}
+
+/**
+ * Return the soonest `unusableUntil` timestamp (ms epoch) among the given
+ * profiles, or `null` when no profile has a recorded cooldown. Note: the
+ * returned timestamp may be in the past if the cooldown has already expired.
+ */
+export function getSoonestCooldownExpiry(
+  store: AuthProfileStore,
+  profileIds: string[],
+): number | null {
+  let soonest: number | null = null;
+  for (const id of profileIds) {
+    const stats = store.usageStats?.[id];
+    if (!stats) {
+      continue;
+    }
+    const until = resolveProfileUnusableUntil(stats);
+    if (typeof until !== "number" || !Number.isFinite(until) || until <= 0) {
+      continue;
+    }
+    if (soonest === null || until < soonest) {
+      soonest = until;
+    }
+  }
+  return soonest;
+}
+
+/**
+ * Clear expired cooldowns from all profiles in the store.
+ *
+ * When `cooldownUntil` or `disabledUntil` has passed, the corresponding fields
+ * are removed and error counters are reset so the profile gets a fresh start
+ * (circuit-breaker half-open -> closed). Without this, a stale `errorCount`
+ * causes the *next* transient failure to immediately escalate to a much longer
+ * cooldown -- the root cause of profiles appearing "stuck" after rate limits.
+ *
+ * `cooldownUntil` and `disabledUntil` are handled independently: if a profile
+ * has both and only one has expired, only that field is cleared.
+ *
+ * Mutates the in-memory store; disk persistence happens lazily on the next
+ * store write (e.g. `markAuthProfileUsed` / `markAuthProfileFailure`), which
+ * matches the existing save pattern throughout the auth-profiles module.
+ *
+ * @returns `true` if any profile was modified.
+ */
+export function clearExpiredCooldowns(store: AuthProfileStore, now?: number): boolean {
+  const usageStats = store.usageStats;
+  if (!usageStats) {
+    return false;
+  }
+
+  const ts = now ?? Date.now();
+  let mutated = false;
+
+  for (const [profileId, stats] of Object.entries(usageStats)) {
+    if (!stats) {
+      continue;
+    }
+
+    let profileMutated = false;
+    const cooldownExpired =
+      typeof stats.cooldownUntil === "number" &&
+      Number.isFinite(stats.cooldownUntil) &&
+      stats.cooldownUntil > 0 &&
+      ts >= stats.cooldownUntil;
+    const disabledExpired =
+      typeof stats.disabledUntil === "number" &&
+      Number.isFinite(stats.disabledUntil) &&
+      stats.disabledUntil > 0 &&
+      ts >= stats.disabledUntil;
+
+    if (cooldownExpired) {
+      stats.cooldownUntil = undefined;
+      profileMutated = true;
+    }
+    if (disabledExpired) {
+      stats.disabledUntil = undefined;
+      stats.disabledReason = undefined;
+      profileMutated = true;
+    }
+
+    // Reset error counters when ALL cooldowns have expired so the profile gets
+    // a fair retry window. Preserves lastFailureAt for the failureWindowMs
+    // decay check in computeNextProfileUsageStats.
+    if (profileMutated && !resolveProfileUnusableUntil(stats)) {
+      stats.errorCount = 0;
+      stats.failureCounts = undefined;
+    }
+
+    if (profileMutated) {
+      usageStats[profileId] = stats;
+      mutated = true;
+    }
+  }
+
+  return mutated;
+}
+
+/**
+ * Mark a profile as successfully used. Resets error count and updates lastUsed.
+ * Uses store lock to avoid overwriting concurrent usage updates.
+ */
+export async function markAuthProfileUsed(params: {
+  store: AuthProfileStore;
+  profileId: string;
+}): Promise<void> {
+  const { store, profileId } = params;
+  const updated = await updateAuthProfileStoreWithLock({
+    updater: (freshStore) => {
+      if (!freshStore.profiles[profileId]) {
+        return false;
+      }
+      freshStore.usageStats = freshStore.usageStats ?? {};
+      freshStore.usageStats[profileId] = {
+        ...freshStore.usageStats[profileId],
+        lastUsed: Date.now(),
+        errorCount: 0,
+        cooldownUntil: undefined,
+        disabledUntil: undefined,
+        disabledReason: undefined,
+        failureCounts: undefined,
+      };
+      return true;
+    },
+  });
+  if (updated) {
+    store.usageStats = updated.usageStats;
+    return;
+  }
+  if (!store.profiles[profileId]) {
+    return;
+  }
+
+  store.usageStats = store.usageStats ?? {};
+  store.usageStats[profileId] = {
+    ...store.usageStats[profileId],
+    lastUsed: Date.now(),
+    errorCount: 0,
+    cooldownUntil: undefined,
+    disabledUntil: undefined,
+    disabledReason: undefined,
+    failureCounts: undefined,
+  };
+  saveAuthProfileStore(store);
+}
+
+export function calculateAuthProfileCooldownMs(errorCount: number): number {
+  const normalized = Math.max(1, errorCount);
+  return Math.min(
+    60 * 60 * 1000, // 1 hour max
+    60 * 1000 * 5 ** Math.min(normalized - 1, 3),
+  );
+}
+
+type ResolvedAuthCooldownConfig = {
+  billingBackoffMs: number;
+  billingMaxMs: number;
+  failureWindowMs: number;
+};
+
+function resolveAuthCooldownConfig(params: {
+  cfg?: RemoteClawConfig;
+  providerId: string;
+}): ResolvedAuthCooldownConfig {
+  const defaults = {
+    billingBackoffHours: 5,
+    billingMaxHours: 24,
+    failureWindowHours: 24,
+  } as const;
+
+  const resolveHours = (value: unknown, fallback: number) =>
+    typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+
+  const cooldowns = params.cfg?.auth?.cooldowns;
+  const billingOverride = (() => {
+    const map = cooldowns?.billingBackoffHoursByProvider;
+    if (!map) {
+      return undefined;
+    }
+    for (const [key, value] of Object.entries(map)) {
+      if (normalizeProviderId(key) === params.providerId) {
+        return value;
+      }
+    }
+    return undefined;
+  })();
+
+  const billingBackoffHours = resolveHours(
+    billingOverride ?? cooldowns?.billingBackoffHours,
+    defaults.billingBackoffHours,
+  );
+  const billingMaxHours = resolveHours(cooldowns?.billingMaxHours, defaults.billingMaxHours);
+  const failureWindowHours = resolveHours(
+    cooldowns?.failureWindowHours,
+    defaults.failureWindowHours,
+  );
+
+  return {
+    billingBackoffMs: billingBackoffHours * 60 * 60 * 1000,
+    billingMaxMs: billingMaxHours * 60 * 60 * 1000,
+    failureWindowMs: failureWindowHours * 60 * 60 * 1000,
+  };
+}
+
+function calculateAuthProfileBillingDisableMsWithConfig(params: {
+  errorCount: number;
+  baseMs: number;
+  maxMs: number;
+}): number {
+  const normalized = Math.max(1, params.errorCount);
+  const baseMs = Math.max(60_000, params.baseMs);
+  const maxMs = Math.max(baseMs, params.maxMs);
+  const exponent = Math.min(normalized - 1, 10);
+  const raw = baseMs * 2 ** exponent;
+  return Math.min(maxMs, raw);
+}
+
+export function resolveProfileUnusableUntilForDisplay(
+  store: AuthProfileStore,
+  profileId: string,
+): number | null {
+  if (isAuthCooldownBypassedForProvider(store.profiles[profileId]?.provider)) {
+    return null;
+  }
+  const stats = store.usageStats?.[profileId];
+  if (!stats) {
+    return null;
+  }
+  return resolveProfileUnusableUntil(stats);
+}
+
+function keepActiveWindowOrRecompute(params: {
+  existingUntil: number | undefined;
+  now: number;
+  recomputedUntil: number;
+}): number {
+  const { existingUntil, now, recomputedUntil } = params;
+  const hasActiveWindow =
+    typeof existingUntil === "number" && Number.isFinite(existingUntil) && existingUntil > now;
+  return hasActiveWindow ? existingUntil : recomputedUntil;
+}
+
+function computeNextProfileUsageStats(params: {
+  existing: ProfileUsageStats;
+  now: number;
+  reason: AuthProfileFailureReason;
+  cfgResolved: ResolvedAuthCooldownConfig;
+}): ProfileUsageStats {
+  const windowMs = params.cfgResolved.failureWindowMs;
+  const windowExpired =
+    typeof params.existing.lastFailureAt === "number" &&
+    params.existing.lastFailureAt > 0 &&
+    params.now - params.existing.lastFailureAt > windowMs;
+
+  const baseErrorCount = windowExpired ? 0 : (params.existing.errorCount ?? 0);
+  const nextErrorCount = baseErrorCount + 1;
+  const failureCounts = windowExpired ? {} : { ...params.existing.failureCounts };
+  failureCounts[params.reason] = (failureCounts[params.reason] ?? 0) + 1;
+
+  const updatedStats: ProfileUsageStats = {
+    ...params.existing,
+    errorCount: nextErrorCount,
+    failureCounts,
+    lastFailureAt: params.now,
+  };
+
+  if (params.reason === "billing") {
+    const billingCount = failureCounts.billing ?? 1;
+    const backoffMs = calculateAuthProfileBillingDisableMsWithConfig({
+      errorCount: billingCount,
+      baseMs: params.cfgResolved.billingBackoffMs,
+      maxMs: params.cfgResolved.billingMaxMs,
+    });
+    // Keep active disable windows immutable so retries within the window cannot
+    // extend recovery time indefinitely.
+    updatedStats.disabledUntil = keepActiveWindowOrRecompute({
+      existingUntil: params.existing.disabledUntil,
+      now: params.now,
+      recomputedUntil: params.now + backoffMs,
+    });
+    updatedStats.disabledReason = "billing";
+  } else {
+    const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount);
+    // Keep active cooldown windows immutable so retries within the window
+    // cannot push recovery further out.
+    updatedStats.cooldownUntil = keepActiveWindowOrRecompute({
+      existingUntil: params.existing.cooldownUntil,
+      now: params.now,
+      recomputedUntil: params.now + backoffMs,
+    });
+  }
+
+  return updatedStats;
+}
+
+/**
+ * Mark a profile as failed for a specific reason. Billing failures are treated
+ * as "disabled" (longer backoff) vs the regular cooldown window.
+ */
+export async function markAuthProfileFailure(params: {
+  store: AuthProfileStore;
+  profileId: string;
+  reason: AuthProfileFailureReason;
+  cfg?: RemoteClawConfig;
+}): Promise<void> {
+  const { store, profileId, reason, cfg } = params;
+  const profile = store.profiles[profileId];
+  if (!profile || isAuthCooldownBypassedForProvider(profile.provider)) {
+    return;
+  }
+  const updated = await updateAuthProfileStoreWithLock({
+    updater: (freshStore) => {
+      const profile = freshStore.profiles[profileId];
+      if (!profile || isAuthCooldownBypassedForProvider(profile.provider)) {
+        return false;
+      }
+      freshStore.usageStats = freshStore.usageStats ?? {};
+      const existing = freshStore.usageStats[profileId] ?? {};
+
+      const now = Date.now();
+      const providerKey = normalizeProviderId(profile.provider);
+      const cfgResolved = resolveAuthCooldownConfig({
+        cfg,
+        providerId: providerKey,
+      });
+
+      freshStore.usageStats[profileId] = computeNextProfileUsageStats({
+        existing,
+        now,
+        reason,
+        cfgResolved,
+      });
+      return true;
+    },
+  });
+  if (updated) {
+    store.usageStats = updated.usageStats;
+    return;
+  }
+  if (!store.profiles[profileId]) {
+    return;
+  }
+
+  store.usageStats = store.usageStats ?? {};
+  const existing = store.usageStats[profileId] ?? {};
+  const now = Date.now();
+  const providerKey = normalizeProviderId(store.profiles[profileId]?.provider ?? "");
+  const cfgResolved = resolveAuthCooldownConfig({
+    cfg,
+    providerId: providerKey,
+  });
+
+  store.usageStats[profileId] = computeNextProfileUsageStats({
+    existing,
+    now,
+    reason,
+    cfgResolved,
+  });
+  saveAuthProfileStore(store);
+}
+
+/**
+ * Mark a profile as failed/rate-limited. Applies exponential backoff cooldown.
+ * Cooldown times: 1min, 5min, 25min, max 1 hour.
+ * Uses store lock to avoid overwriting concurrent usage updates.
+ */
+export async function markAuthProfileCooldown(params: {
+  store: AuthProfileStore;
+  profileId: string;
+}): Promise<void> {
+  await markAuthProfileFailure({
+    store: params.store,
+    profileId: params.profileId,
+    reason: "unknown",
+  });
+}
+
+/**
+ * Clear cooldown for a profile (e.g., manual reset).
+ * Uses store lock to avoid overwriting concurrent usage updates.
+ */
+export async function clearAuthProfileCooldown(params: {
+  store: AuthProfileStore;
+  profileId: string;
+}): Promise<void> {
+  const { store, profileId } = params;
+  const updated = await updateAuthProfileStoreWithLock({
+    updater: (freshStore) => {
+      if (!freshStore.usageStats?.[profileId]) {
+        return false;
+      }
+
+      freshStore.usageStats[profileId] = {
+        ...freshStore.usageStats[profileId],
+        errorCount: 0,
+        cooldownUntil: undefined,
+        disabledUntil: undefined,
+        disabledReason: undefined,
+        failureCounts: undefined,
+      };
+      return true;
+    },
+  });
+  if (updated) {
+    store.usageStats = updated.usageStats;
+    return;
+  }
+  if (!store.usageStats?.[profileId]) {
+    return;
+  }
+
+  store.usageStats[profileId] = {
+    ...store.usageStats[profileId],
+    errorCount: 0,
+    cooldownUntil: undefined,
+    disabledUntil: undefined,
+    disabledReason: undefined,
+    failureCounts: undefined,
+  };
+  saveAuthProfileStore(store);
+}

--- a/src/middleware/auth-key-retry.test.ts
+++ b/src/middleware/auth-key-retry.test.ts
@@ -1,11 +1,15 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { _resetRoundRobinState } from "../auth/env-injection.js";
+import { describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore } from "../auth/types.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { withAuthKeyRetry } from "./auth-key-retry.js";
 
-afterEach(() => {
-  _resetRoundRobinState();
+vi.mock("../auth/store.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../auth/store.js")>();
+  return {
+    ...original,
+    updateAuthProfileStoreWithLock: vi.fn().mockResolvedValue(null),
+    saveAuthProfileStore: vi.fn(),
+  };
 });
 
 // ── Helpers ──────────────────────────────────────────────────────────────
@@ -36,11 +40,13 @@ const multiKeyCfg: RemoteClawConfig = {
   },
 };
 
-const multiKeyStore = makeStore({
-  "anthropic:key1": { provider: "anthropic", key: "sk-1" },
-  "anthropic:key2": { provider: "anthropic", key: "sk-2" },
-  "anthropic:key3": { provider: "anthropic", key: "sk-3" },
-});
+function freshMultiKeyStore(): AuthProfileStore {
+  return makeStore({
+    "anthropic:key1": { provider: "anthropic", key: "sk-1" },
+    "anthropic:key2": { provider: "anthropic", key: "sk-2" },
+    "anthropic:key3": { provider: "anthropic", key: "sk-3" },
+  });
+}
 
 // ── Tests ────────────────────────────────────────────────────────────────
 
@@ -48,9 +54,10 @@ describe("withAuthKeyRetry", () => {
   it("rate-limit error with multi-key config triggers retry with next key", async () => {
     const envsSeen: Record<string, string>[] = [];
     let callCount = 0;
+    const store = freshMultiKeyStore();
 
     const result = await withAuthKeyRetry<FakeResult>(
-      { cfg: multiKeyCfg, agentId: "main", baseEnv: {}, store: multiKeyStore },
+      { cfg: multiKeyCfg, agentId: "main", baseEnv: {}, store },
       async (env) => {
         envsSeen.push({ ...env });
         callCount++;
@@ -64,16 +71,17 @@ describe("withAuthKeyRetry", () => {
 
     expect(callCount).toBe(2);
     expect(result.text).toBe("ok");
-    // First call uses key1, second uses key2 (round-robin)
+    // First call uses key1, second uses key2 (round-robin via lastUsed ordering)
     expect(envsSeen[0]).toEqual({ ANTHROPIC_API_KEY: "sk-1" });
     expect(envsSeen[1]).toEqual({ ANTHROPIC_API_KEY: "sk-2" });
   });
 
   it("retry succeeds with second key — normal response returned", async () => {
     let callCount = 0;
+    const store = freshMultiKeyStore();
 
     const result = await withAuthKeyRetry<FakeResult>(
-      { cfg: multiKeyCfg, agentId: "main", baseEnv: {}, store: multiKeyStore },
+      { cfg: multiKeyCfg, agentId: "main", baseEnv: {}, store },
       async () => {
         callCount++;
         if (callCount === 1) {
@@ -91,9 +99,10 @@ describe("withAuthKeyRetry", () => {
 
   it("all keys fail — error surfaced to user", async () => {
     let callCount = 0;
+    const store = freshMultiKeyStore();
 
     const result = await withAuthKeyRetry<FakeResult>(
-      { cfg: multiKeyCfg, agentId: "main", baseEnv: {}, store: multiKeyStore },
+      { cfg: multiKeyCfg, agentId: "main", baseEnv: {}, store },
       async () => {
         callCount++;
         return { text: "", error: "rate limit exceeded" };
@@ -108,10 +117,11 @@ describe("withAuthKeyRetry", () => {
 
   it("all keys fail with thrown errors — last error re-thrown", async () => {
     let callCount = 0;
+    const store = freshMultiKeyStore();
 
     await expect(
       withAuthKeyRetry<FakeResult>(
-        { cfg: multiKeyCfg, agentId: "main", baseEnv: {}, store: multiKeyStore },
+        { cfg: multiKeyCfg, agentId: "main", baseEnv: {}, store },
         async () => {
           callCount++;
           throw new Error("HTTP 401 Unauthorized");
@@ -129,11 +139,12 @@ describe("withAuthKeyRetry", () => {
         list: [{ id: "main", workspace: "~/w", auth: "anthropic:key1" }],
       },
     };
+    const store = freshMultiKeyStore();
     let callCount = 0;
 
     await expect(
       withAuthKeyRetry<FakeResult>(
-        { cfg: singleKeyCfg, agentId: "main", baseEnv: {}, store: multiKeyStore },
+        { cfg: singleKeyCfg, agentId: "main", baseEnv: {}, store },
         async () => {
           callCount++;
           throw new Error("rate limit exceeded");
@@ -151,11 +162,12 @@ describe("withAuthKeyRetry", () => {
         list: [{ id: "main", workspace: "~/w", auth: false }],
       },
     };
+    const store = freshMultiKeyStore();
     let callCount = 0;
 
     await expect(
       withAuthKeyRetry<FakeResult>(
-        { cfg: noAuthCfg, agentId: "main", baseEnv: {}, store: multiKeyStore },
+        { cfg: noAuthCfg, agentId: "main", baseEnv: {}, store },
         async () => {
           callCount++;
           throw new Error("rate limit exceeded");
@@ -195,10 +207,11 @@ describe("withAuthKeyRetry", () => {
 
   it("non-rotatable errors are not retried", async () => {
     let callCount = 0;
+    const store = freshMultiKeyStore();
 
     await expect(
       withAuthKeyRetry<FakeResult>(
-        { cfg: multiKeyCfg, agentId: "main", baseEnv: {}, store: multiKeyStore },
+        { cfg: multiKeyCfg, agentId: "main", baseEnv: {}, store },
         async () => {
           callCount++;
           throw new Error("context length exceeded");
@@ -213,13 +226,14 @@ describe("withAuthKeyRetry", () => {
 
   it("merges auth env with base env", async () => {
     let capturedEnv: Record<string, string> | undefined;
+    const store = freshMultiKeyStore();
 
     await withAuthKeyRetry<FakeResult>(
       {
         cfg: multiKeyCfg,
         agentId: "main",
         baseEnv: { NODE_ENV: "test", EXISTING: "value" },
-        store: multiKeyStore,
+        store,
       },
       async (env) => {
         capturedEnv = env;


### PR DESCRIPTION
## Summary

- Restore upstream round-robin infrastructure removed in `3d697e9a` (gut centralized OAuth and auth profiles)
- Replace in-memory round-robin counter with persistent, cooldown-aware profile ordering backed by `usageStats` in `auth-profiles.json`
- Add `usage.ts` module: `ProfileUsageStats` tracking (`lastUsed`, `cooldownUntil`, `disabledUntil`, `errorCount`, `failureCounts`), failure marking with exponential backoff, cooldown auto-expiry
- Add `order.ts` module: `resolveAuthProfileOrder()` with config overrides, cooldown-aware filtering, `lastUsed`-based round-robin
- Restore `AuthProfileFailureReason`, `ProfileUsageStats` types and `AuthProfileStore.order`, `.lastGood`, `.usageStats` fields
- Wire `resolveAuthEnv` to use persistent ordering (`pickNextProfile`) instead of modulo-based `pickRoundRobin`
- ~103 new/adapted tests across 4 test files

Closes #455

## Test plan

- [x] All 103 auth/middleware tests pass (`usage.test.ts`, `order.test.ts`, `env-injection.test.ts`, `auth-key-retry.test.ts`)
- [x] Full test suite passes (866 tests, 93 files)
- [x] Type-check clean (`tsc --noEmit` — no errors in `src/`)
- [x] Lint clean (`oxlint --type-aware` — 0 warnings, 0 errors)
- [x] Format clean (`oxfmt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)