### PR TITLE
feat(middleware): communicate multimodal limitations to users when runtime can't handle media

### DIFF
--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -849,6 +849,117 @@ describe("ChannelBridge", () => {
     });
   });
 
+  describe("unsupported media warnings", () => {
+    it("prepends warning payload when runtime does not accept media type", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) =>
+        eventStream([{ type: "text", text: "Reply" }, makeDone({ text: "Reply" })]),
+      );
+      mockRuntimeInstance = {
+        execute: executeFn,
+        mediaCapabilities: { acceptsInbound: ["image/"], emitsOutbound: false },
+      };
+      mockResolveMediaAttachments.mockResolvedValue([
+        { mimeType: "image/jpeg", filePath: "/tmp/photo.jpg" },
+        { mimeType: "audio/ogg", filePath: "/tmp/voice.ogg" },
+      ]);
+
+      const bridge = createBridge();
+      const result = await bridge.handle(
+        makeMessage({
+          mediaUrls: ["https://cdn.example.com/photo.jpg", "https://cdn.example.com/voice.ogg"],
+        }),
+      );
+
+      // Warning should be first payload
+      expect(result.payloads.length).toBeGreaterThanOrEqual(2);
+      expect(result.payloads[0].text).toContain("audio");
+      expect(result.payloads[0].text).toContain("not included");
+      // Agent reply follows
+      expect(result.payloads[1].text).toBe("Reply");
+    });
+
+    it("only passes supported media to runtime.execute()", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = {
+        execute: executeFn,
+        mediaCapabilities: { acceptsInbound: ["image/"], emitsOutbound: false },
+      };
+      mockResolveMediaAttachments.mockResolvedValue([
+        { mimeType: "image/jpeg", filePath: "/tmp/photo.jpg" },
+        { mimeType: "audio/ogg", filePath: "/tmp/voice.ogg" },
+      ]);
+
+      const bridge = createBridge();
+      await bridge.handle(
+        makeMessage({
+          mediaUrls: ["https://cdn.example.com/photo.jpg", "https://cdn.example.com/voice.ogg"],
+        }),
+      );
+
+      const params = executeFn.mock.calls[0][0];
+      expect(params.media).toEqual([{ mimeType: "image/jpeg", filePath: "/tmp/photo.jpg" }]);
+    });
+
+    it("does not add warning when all media is supported", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) =>
+        eventStream([{ type: "text", text: "Reply" }, makeDone({ text: "Reply" })]),
+      );
+      mockRuntimeInstance = {
+        execute: executeFn,
+        mediaCapabilities: { acceptsInbound: ["image/"], emitsOutbound: false },
+      };
+      mockResolveMediaAttachments.mockResolvedValue([
+        { mimeType: "image/jpeg", filePath: "/tmp/photo.jpg" },
+      ]);
+
+      const bridge = createBridge();
+      const result = await bridge.handle(
+        makeMessage({ mediaUrls: ["https://cdn.example.com/photo.jpg"] }),
+      );
+
+      expect(result.payloads).toEqual([{ text: "Reply" }]);
+    });
+
+    it("passes all media through when runtime has no mediaCapabilities", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+      mockResolveMediaAttachments.mockResolvedValue([
+        { mimeType: "audio/ogg", filePath: "/tmp/voice.ogg" },
+      ]);
+
+      const bridge = createBridge();
+      const result = await bridge.handle(
+        makeMessage({ mediaUrls: ["https://cdn.example.com/voice.ogg"] }),
+      );
+
+      const params = executeFn.mock.calls[0][0];
+      expect(params.media).toEqual([{ mimeType: "audio/ogg", filePath: "/tmp/voice.ogg" }]);
+      // No warning
+      expect(result.payloads.every((p) => !p.text?.includes("not included"))).toBe(true);
+    });
+
+    it("passes undefined media when all attachments are unsupported", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = {
+        execute: executeFn,
+        mediaCapabilities: { acceptsInbound: [], emitsOutbound: false },
+      };
+      mockResolveMediaAttachments.mockResolvedValue([
+        { mimeType: "image/jpeg", filePath: "/tmp/photo.jpg" },
+      ]);
+
+      const bridge = createBridge();
+      const result = await bridge.handle(
+        makeMessage({ mediaUrls: ["https://cdn.example.com/photo.jpg"] }),
+      );
+
+      const params = executeFn.mock.calls[0][0];
+      expect(params.media).toBeUndefined();
+      // Warning present
+      expect(result.payloads[0].text).toContain("not included");
+    });
+  });
+
   describe("outbound media delivery", () => {
     it("delivers media events as ReplyPayload with mediaUrl", async () => {
       mockRuntimeInstance = mockRuntime([

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -8,6 +8,7 @@ import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { DeliveryAdapter } from "./delivery-adapter.js";
 import { classifyError } from "./error-classifier.js";
 import { readMcpSideEffects } from "./mcp-side-effects.js";
+import { formatUnsupportedMediaWarning, partitionMedia } from "./media-capability.js";
 import { resolveMediaAttachments } from "./media-resolver.js";
 import { createCliRuntime } from "./runtime-factory.js";
 import type { SessionKey, SessionMap } from "./session-map.js";
@@ -191,12 +192,23 @@ export class ChannelBridge {
       }
 
       // 5. Resolve inbound media attachments (download remote URLs to temp files)
-      const media = message.mediaUrls?.length
+      const resolvedMedia = message.mediaUrls?.length
         ? await resolveMediaAttachments(message.mediaUrls, invocationDir)
         : undefined;
-      if (media?.length) {
+      if (resolvedMedia?.length) {
         logDebug(
-          `[channel-bridge] resolved ${media.length}/${message.mediaUrls!.length} media attachments`,
+          `[channel-bridge] resolved ${resolvedMedia.length}/${message.mediaUrls!.length} media attachments`,
+        );
+      }
+
+      // 5b. Partition media by runtime capability
+      const { supported: supportedMedia, unsupported: unsupportedMedia } = resolvedMedia?.length
+        ? partitionMedia(runtime, resolvedMedia)
+        : { supported: [], unsupported: [] };
+      const mediaWarning = formatUnsupportedMediaWarning(unsupportedMedia, this.#provider);
+      if (unsupportedMedia.length > 0) {
+        logDebug(
+          `[channel-bridge] unsupported media: ${unsupportedMedia.length} attachment(s) not accepted by ${this.#provider}`,
         );
       }
 
@@ -217,7 +229,7 @@ export class ChannelBridge {
               (message.extraContext ? "\n\n" + message.extraContext : "") +
               "\n\n" +
               message.text,
-            media: media?.length ? media : undefined,
+            media: supportedMedia?.length ? supportedMedia : undefined,
             sessionId: existingSessionId,
             mcpServers,
             abortSignal,
@@ -243,6 +255,11 @@ export class ChannelBridge {
           // ErrorClassifier uses "context_overflow"; AgentRunResult uses "context_window"
           errorSubtype: category === "context_overflow" ? "context_window" : category,
         };
+      }
+
+      // 7b. Prepend unsupported-media warning (if any) to payloads
+      if (mediaWarning) {
+        payloads.unshift({ text: mediaWarning });
       }
 
       // 8. Read MCP side effects

--- a/src/middleware/media-capability.test.ts
+++ b/src/middleware/media-capability.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { formatUnsupportedMediaWarning, partitionMedia } from "./media-capability.js";
+import type { AgentRuntime, MediaAttachment } from "./types.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function makeAttachment(mimeType: string, filePath?: string): MediaAttachment {
+  return { mimeType, filePath: filePath ?? `/tmp/file-${mimeType.replace("/", ".")}` };
+}
+
+function makeRuntime(acceptsInbound?: string[]): AgentRuntime {
+  return {
+    execute: async function* () {},
+    mediaCapabilities:
+      acceptsInbound !== undefined ? { acceptsInbound, emitsOutbound: false } : undefined,
+  };
+}
+
+// ── partitionMedia ───────────────────────────────────────────────────────
+
+describe("partitionMedia", () => {
+  it("passes all media through when runtime has no mediaCapabilities", () => {
+    const runtime = makeRuntime(undefined);
+    const media = [makeAttachment("image/jpeg"), makeAttachment("audio/ogg")];
+
+    const result = partitionMedia(runtime, media);
+
+    expect(result.supported).toEqual(media);
+    expect(result.unsupported).toEqual([]);
+  });
+
+  it("partitions media by MIME type prefix matching", () => {
+    const runtime = makeRuntime(["image/"]);
+    const image = makeAttachment("image/jpeg");
+    const audio = makeAttachment("audio/ogg");
+    const video = makeAttachment("video/mp4");
+
+    const result = partitionMedia(runtime, [image, audio, video]);
+
+    expect(result.supported).toEqual([image]);
+    expect(result.unsupported).toEqual([audio, video]);
+  });
+
+  it("supports multiple accepted prefixes", () => {
+    const runtime = makeRuntime(["image/", "audio/", "video/"]);
+    const media = [
+      makeAttachment("image/png"),
+      makeAttachment("audio/wav"),
+      makeAttachment("video/mp4"),
+    ];
+
+    const result = partitionMedia(runtime, media);
+
+    expect(result.supported).toEqual(media);
+    expect(result.unsupported).toEqual([]);
+  });
+
+  it("marks all media as unsupported when acceptsInbound is empty", () => {
+    const runtime = makeRuntime([]);
+    const media = [makeAttachment("image/jpeg"), makeAttachment("audio/ogg")];
+
+    const result = partitionMedia(runtime, media);
+
+    expect(result.supported).toEqual([]);
+    expect(result.unsupported).toEqual(media);
+  });
+
+  it("handles empty media array", () => {
+    const runtime = makeRuntime(["image/"]);
+
+    const result = partitionMedia(runtime, []);
+
+    expect(result.supported).toEqual([]);
+    expect(result.unsupported).toEqual([]);
+  });
+
+  it("matches application/ MIME types correctly", () => {
+    const runtime = makeRuntime(["application/pdf"]);
+    const pdf = makeAttachment("application/pdf");
+    const image = makeAttachment("image/jpeg");
+
+    const result = partitionMedia(runtime, [pdf, image]);
+
+    expect(result.supported).toEqual([pdf]);
+    expect(result.unsupported).toEqual([image]);
+  });
+});
+
+// ── formatUnsupportedMediaWarning ────────────────────────────────────────
+
+describe("formatUnsupportedMediaWarning", () => {
+  it("returns undefined when no unsupported media", () => {
+    expect(formatUnsupportedMediaWarning([], "claude")).toBeUndefined();
+  });
+
+  it("formats a single unsupported image", () => {
+    const warning = formatUnsupportedMediaWarning([makeAttachment("image/jpeg")], "codex");
+
+    expect(warning).toContain("image");
+    expect(warning).toContain("codex");
+    expect(warning).toContain("not included");
+  });
+
+  it("formats a single unsupported audio", () => {
+    const warning = formatUnsupportedMediaWarning([makeAttachment("audio/ogg")], "claude");
+
+    expect(warning).toContain("audio");
+    expect(warning).toContain("claude");
+  });
+
+  it("formats multiple unsupported media of different types", () => {
+    const warning = formatUnsupportedMediaWarning(
+      [makeAttachment("audio/ogg"), makeAttachment("video/mp4")],
+      "claude",
+    );
+
+    expect(warning).toContain("2 media attachments");
+    expect(warning).toContain("audio/video");
+    expect(warning).toContain("claude");
+  });
+
+  it("formats multiple unsupported media of the same type", () => {
+    const warning = formatUnsupportedMediaWarning(
+      [makeAttachment("image/jpeg"), makeAttachment("image/png")],
+      "codex",
+    );
+
+    expect(warning).toContain("2 media attachments");
+    expect(warning).toContain("image");
+    expect(warning).toContain("codex");
+  });
+
+  it("uses lowercase runtime name", () => {
+    const warning = formatUnsupportedMediaWarning([makeAttachment("image/jpeg")], "CLAUDE");
+
+    expect(warning).toContain("claude");
+    expect(warning).not.toContain("CLAUDE");
+  });
+});

--- a/src/middleware/media-capability.ts
+++ b/src/middleware/media-capability.ts
@@ -1,0 +1,96 @@
+import type { AgentRuntime, MediaAttachment } from "./types.js";
+
+/** Result of partitioning media by runtime capability. */
+export type MediaPartition = {
+  /** Media the runtime can handle natively. */
+  supported: MediaAttachment[];
+  /** Media the runtime cannot handle. */
+  unsupported: MediaAttachment[];
+};
+
+/**
+ * Partition media attachments by whether the runtime accepts them.
+ *
+ * If the runtime does not declare `mediaCapabilities` at all, all media is
+ * treated as supported (backwards-compatible — the runtime decides what to do).
+ */
+export function partitionMedia(runtime: AgentRuntime, media: MediaAttachment[]): MediaPartition {
+  const prefixes = runtime.mediaCapabilities?.acceptsInbound;
+
+  // No capability declaration → pass everything through (backwards-compatible)
+  if (prefixes === undefined) {
+    return { supported: media, unsupported: [] };
+  }
+
+  const supported: MediaAttachment[] = [];
+  const unsupported: MediaAttachment[] = [];
+
+  for (const attachment of media) {
+    const accepted = prefixes.some((prefix) => attachment.mimeType.startsWith(prefix));
+    if (accepted) {
+      supported.push(attachment);
+    } else {
+      unsupported.push(attachment);
+    }
+  }
+
+  return { supported, unsupported };
+}
+
+/**
+ * Format a user-facing warning for media the runtime cannot handle.
+ *
+ * Returns `undefined` when there are no unsupported attachments.
+ */
+export function formatUnsupportedMediaWarning(
+  unsupported: MediaAttachment[],
+  runtimeName: string,
+): string | undefined {
+  if (unsupported.length === 0) {
+    return undefined;
+  }
+
+  const typeSummary = summarizeMediaTypes(unsupported);
+  const runtimeLabel = runtimeName.toLowerCase();
+
+  if (unsupported.length === 1) {
+    return (
+      `\u26a0\ufe0f Your ${typeSummary} was received but the current runtime (${runtimeLabel}) ` +
+      `doesn't support ${typeSummary} input. Its content was not included in the conversation.`
+    );
+  }
+
+  return (
+    `\u26a0\ufe0f ${unsupported.length} media attachments were received but the current runtime ` +
+    `(${runtimeLabel}) doesn't support them: ${typeSummary}. ` +
+    `Their content was not included in the conversation.`
+  );
+}
+
+/**
+ * Produce a human-readable summary of MIME type categories.
+ *
+ * Groups by top-level type (image, audio, video) and deduplicates.
+ * Falls back to "media" for unknown types.
+ */
+function summarizeMediaTypes(attachments: MediaAttachment[]): string {
+  const categories = new Set<string>();
+  for (const a of attachments) {
+    const topLevel = a.mimeType.split("/")[0];
+    switch (topLevel) {
+      case "image":
+        categories.add("image");
+        break;
+      case "audio":
+        categories.add("audio");
+        break;
+      case "video":
+        categories.add("video");
+        break;
+      default:
+        categories.add("media");
+        break;
+    }
+  }
+  return [...categories].toSorted().join("/");
+}

--- a/src/middleware/runtimes/claude.ts
+++ b/src/middleware/runtimes/claude.ts
@@ -14,6 +14,13 @@ import type {
  * and maps the streaming NDJSON output to {@link AgentEvent} instances.
  */
 export class ClaudeCliRuntime extends CLIRuntimeBase {
+  // ── Media capabilities ────────────────────────────────────────────────
+
+  readonly mediaCapabilities = {
+    acceptsInbound: ["image/"],
+    emitsOutbound: false,
+  } as const;
+
   // ── Per-execution state (reset before each run) ───────────────────────
 
   private currentSessionId: string | undefined;

--- a/src/middleware/runtimes/codex.ts
+++ b/src/middleware/runtimes/codex.ts
@@ -26,6 +26,13 @@ import type {
  *   reasoning, web_search, error, todo_list
  */
 export class CodexCliRuntime extends CLIRuntimeBase {
+  // ── Media capabilities ────────────────────────────────────────────────
+
+  readonly mediaCapabilities = {
+    acceptsInbound: [] as string[],
+    emitsOutbound: false,
+  };
+
   // ── Per-execution state (reset before each run) ───────────────────────
 
   private currentSessionId: string | undefined;

--- a/src/middleware/runtimes/gemini.ts
+++ b/src/middleware/runtimes/gemini.ts
@@ -18,6 +18,13 @@ import type {
  * and maps the streaming NDJSON output to {@link AgentEvent} instances.
  */
 export class GeminiCliRuntime extends CLIRuntimeBase {
+  // ── Media capabilities ────────────────────────────────────────────────
+
+  readonly mediaCapabilities = {
+    acceptsInbound: ["image/", "audio/", "video/"],
+    emitsOutbound: false,
+  } as const;
+
   // ── Per-execution state (reset before each run) ───────────────────────
 
   private currentSessionId: string | undefined;

--- a/src/middleware/runtimes/opencode.ts
+++ b/src/middleware/runtimes/opencode.ts
@@ -27,6 +27,13 @@ import type {
  * - Usage/cost comes from `step_finish` events
  */
 export class OpenCodeCliRuntime extends CLIRuntimeBase {
+  // ── Media capabilities ────────────────────────────────────────────────
+
+  readonly mediaCapabilities = {
+    acceptsInbound: [] as string[],
+    emitsOutbound: false,
+  };
+
   // ── Per-execution state (reset before each run) ───────────────────────
 
   private currentSessionId: string | undefined;

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -9,7 +9,7 @@ export interface AgentRuntime {
   /** Declare which media types this runtime can handle natively. */
   readonly mediaCapabilities?: {
     /** MIME type prefixes accepted as inbound media (e.g., ["image/", "audio/", "video/"]). */
-    acceptsInbound?: string[];
+    acceptsInbound?: readonly string[];
     /** Whether the runtime can emit media in responses. */
     emitsOutbound?: boolean;
   };


### PR DESCRIPTION
## Summary

- Declare `mediaCapabilities` on all four CLI runtimes — Claude (image/), Gemini (image/, audio/, video/), Codex (none), OpenCode (none)
- Add `partitionMedia()` utility that splits resolved media into supported vs unsupported based on runtime capabilities
- Wire capability check into `ChannelBridge.handle()` so only supported media reaches the runtime; unsupported media generates a user-facing warning prepended to the reply payloads
- Backwards-compatible: runtimes without `mediaCapabilities` pass all media through unchanged

Closes #400

## Test plan

- [x] 12 unit tests for `partitionMedia` and `formatUnsupportedMediaWarning` (media-capability.test.ts)
- [x] 5 integration tests for bridge-level unsupported media warning behavior (channel-bridge.test.ts)
- [x] All 866 existing tests pass
- [x] Type-check (`pnpm tsgo`) clean
- [x] Lint + format (`pnpm check`) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)