### PR TITLE
feat(canvas): restore gateway-hosted A2UI and canvas content delivery (#469)

### DIFF
--- a/src/gateway/canvas-capability.ts
+++ b/src/gateway/canvas-capability.ts
@@ -1,0 +1,87 @@
+import { randomBytes } from "node:crypto";
+
+export const CANVAS_CAPABILITY_PATH_PREFIX = "/__remoteclaw__/cap";
+export const CANVAS_CAPABILITY_QUERY_PARAM = "rc_cap";
+export const CANVAS_CAPABILITY_TTL_MS = 10 * 60_000;
+
+export type NormalizedCanvasScopedUrl = {
+  pathname: string;
+  capability?: string;
+  rewrittenUrl?: string;
+  scopedPath: boolean;
+  malformedScopedPath: boolean;
+};
+
+function normalizeCapability(raw: string | null | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function mintCanvasCapabilityToken(): string {
+  return randomBytes(18).toString("base64url");
+}
+
+export function buildCanvasScopedHostUrl(baseUrl: string, capability: string): string | undefined {
+  const normalizedCapability = normalizeCapability(capability);
+  if (!normalizedCapability) {
+    return undefined;
+  }
+  try {
+    const url = new URL(baseUrl);
+    const trimmedPath = url.pathname.replace(/\/+$/, "");
+    const prefix = `${CANVAS_CAPABILITY_PATH_PREFIX}/${encodeURIComponent(normalizedCapability)}`;
+    url.pathname = `${trimmedPath}${prefix}`;
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
+export function normalizeCanvasScopedUrl(rawUrl: string): NormalizedCanvasScopedUrl {
+  const url = new URL(rawUrl, "http://localhost");
+  const prefix = `${CANVAS_CAPABILITY_PATH_PREFIX}/`;
+  let scopedPath = false;
+  let malformedScopedPath = false;
+  let capabilityFromPath: string | undefined;
+  let rewrittenUrl: string | undefined;
+
+  if (url.pathname.startsWith(prefix)) {
+    scopedPath = true;
+    const remainder = url.pathname.slice(prefix.length);
+    const slashIndex = remainder.indexOf("/");
+    if (slashIndex <= 0) {
+      malformedScopedPath = true;
+    } else {
+      const encodedCapability = remainder.slice(0, slashIndex);
+      const canonicalPath = remainder.slice(slashIndex) || "/";
+      let decoded: string | undefined;
+      try {
+        decoded = decodeURIComponent(encodedCapability);
+      } catch {
+        malformedScopedPath = true;
+      }
+      capabilityFromPath = normalizeCapability(decoded);
+      if (!capabilityFromPath || !canonicalPath.startsWith("/")) {
+        malformedScopedPath = true;
+      } else {
+        url.pathname = canonicalPath;
+        if (!url.searchParams.has(CANVAS_CAPABILITY_QUERY_PARAM)) {
+          url.searchParams.set(CANVAS_CAPABILITY_QUERY_PARAM, capabilityFromPath);
+        }
+        rewrittenUrl = `${url.pathname}${url.search}`;
+      }
+    }
+  }
+
+  const capability =
+    capabilityFromPath ?? normalizeCapability(url.searchParams.get(CANVAS_CAPABILITY_QUERY_PARAM));
+  return {
+    pathname: url.pathname,
+    capability,
+    rewrittenUrl,
+    scopedPath,
+    malformedScopedPath,
+  };
+}

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -1,5 +1,6 @@
 import type { Server as HttpServer } from "node:http";
 import type { WebSocketServer } from "ws";
+import type { CanvasHostHandler, CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
@@ -8,6 +9,8 @@ import type { PluginServicesHandle } from "../plugins/services.js";
 export function createGatewayCloseHandler(params: {
   bonjourStop: (() => Promise<void>) | null;
   tailscaleCleanup: (() => Promise<void>) | null;
+  canvasHost: CanvasHostHandler | null;
+  canvasHostServer: CanvasHostServer | null;
   stopChannel: (name: ChannelId, accountId?: string) => Promise<void>;
   pluginServices: PluginServicesHandle | null;
   cron: { stop: () => void };
@@ -44,6 +47,20 @@ export function createGatewayCloseHandler(params: {
     }
     if (params.tailscaleCleanup) {
       await params.tailscaleCleanup();
+    }
+    if (params.canvasHost) {
+      try {
+        await params.canvasHost.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    if (params.canvasHostServer) {
+      try {
+        await params.canvasHostServer.close();
+      } catch {
+        /* ignore */
+      }
     }
     for (const plugin of listChannelPlugins()) {
       await params.stopChannel(plugin.id);

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -8,6 +8,13 @@ import { createServer as createHttpsServer } from "node:https";
 import type { TlsOptions } from "node:tls";
 import type { WebSocketServer } from "ws";
 import { resolveAgentAvatar } from "../agents/identity-avatar.js";
+import {
+  A2UI_PATH,
+  CANVAS_HOST_PATH,
+  CANVAS_WS_PATH,
+  handleA2uiHttpRequest,
+} from "../canvas-host/a2ui.js";
+import type { CanvasHostHandler } from "../canvas-host/server.js";
 import { loadConfig } from "../config/config.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
@@ -18,7 +25,13 @@ import {
   normalizeRateLimitClientIp,
   type AuthRateLimiter,
 } from "./auth-rate-limit.js";
-import { authorizeHttpGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
+import {
+  authorizeHttpGatewayConnect,
+  isLocalDirectRequest,
+  type GatewayAuthResult,
+  type ResolvedGatewayAuth,
+} from "./auth.js";
+import { CANVAS_CAPABILITY_TTL_MS, normalizeCanvasScopedUrl } from "./canvas-capability.js";
 import {
   handleControlUiAvatarRequest,
   handleControlUiHttpRequest,
@@ -45,6 +58,8 @@ import { sendGatewayAuthFailure, setDefaultSecurityHeaders } from "./http-common
 import { getBearerToken } from "./http-utils.js";
 import { handleOpenAiHttpRequest } from "./openai-http.js";
 import { handleOpenResponsesHttpRequest } from "./openresponses-http.js";
+import { GATEWAY_CLIENT_MODES, normalizeGatewayClientMode } from "./protocol/client-info.js";
+import type { GatewayWsClient } from "./server/ws-types.js";
 import { handleToolsInvokeHttpRequest } from "./tools-invoke-http.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
@@ -61,6 +76,126 @@ function sendJson(res: ServerResponse, status: number, body: unknown) {
   res.statusCode = status;
   res.setHeader("Content-Type", "application/json; charset=utf-8");
   res.end(JSON.stringify(body));
+}
+
+function isCanvasPath(pathname: string): boolean {
+  return (
+    pathname === A2UI_PATH ||
+    pathname.startsWith(`${A2UI_PATH}/`) ||
+    pathname === CANVAS_HOST_PATH ||
+    pathname.startsWith(`${CANVAS_HOST_PATH}/`) ||
+    pathname === CANVAS_WS_PATH
+  );
+}
+
+function isNodeWsClient(client: GatewayWsClient): boolean {
+  if (client.connect.role === "node") {
+    return true;
+  }
+  return normalizeGatewayClientMode(client.connect.client.mode) === GATEWAY_CLIENT_MODES.NODE;
+}
+
+function hasAuthorizedNodeWsClientForCanvasCapability(
+  clients: Set<GatewayWsClient>,
+  capability: string,
+): boolean {
+  const nowMs = Date.now();
+  for (const client of clients) {
+    if (!isNodeWsClient(client)) {
+      continue;
+    }
+    if (!client.canvasCapability || !client.canvasCapabilityExpiresAtMs) {
+      continue;
+    }
+    if (client.canvasCapabilityExpiresAtMs <= nowMs) {
+      continue;
+    }
+    if (safeEqualSecret(client.canvasCapability, capability)) {
+      // Sliding expiration while the connected node keeps using canvas.
+      client.canvasCapabilityExpiresAtMs = nowMs + CANVAS_CAPABILITY_TTL_MS;
+      return true;
+    }
+  }
+  return false;
+}
+
+async function authorizeCanvasRequest(params: {
+  req: IncomingMessage;
+  auth: ResolvedGatewayAuth;
+  trustedProxies: string[];
+  allowRealIpFallback: boolean;
+  clients: Set<GatewayWsClient>;
+  canvasCapability?: string;
+  malformedScopedPath?: boolean;
+  rateLimiter?: AuthRateLimiter;
+}): Promise<GatewayAuthResult> {
+  const {
+    req,
+    auth,
+    trustedProxies,
+    allowRealIpFallback,
+    clients,
+    canvasCapability,
+    malformedScopedPath,
+    rateLimiter,
+  } = params;
+  if (malformedScopedPath) {
+    return { ok: false, reason: "unauthorized" };
+  }
+  if (isLocalDirectRequest(req, trustedProxies, allowRealIpFallback)) {
+    return { ok: true };
+  }
+
+  let lastAuthFailure: GatewayAuthResult | null = null;
+  const token = getBearerToken(req);
+  if (token) {
+    const authResult = await authorizeHttpGatewayConnect({
+      auth: { ...auth, allowTailscale: false },
+      connectAuth: { token, password: token },
+      req,
+      trustedProxies,
+      allowRealIpFallback,
+      rateLimiter,
+    });
+    if (authResult.ok) {
+      return authResult;
+    }
+    lastAuthFailure = authResult;
+  }
+
+  if (canvasCapability && hasAuthorizedNodeWsClientForCanvasCapability(clients, canvasCapability)) {
+    return { ok: true };
+  }
+  return lastAuthFailure ?? { ok: false, reason: "unauthorized" };
+}
+
+function writeUpgradeAuthFailure(
+  socket: { write: (chunk: string) => void },
+  auth: GatewayAuthResult,
+) {
+  if (auth.rateLimited) {
+    const retryAfterSeconds =
+      auth.retryAfterMs && auth.retryAfterMs > 0 ? Math.ceil(auth.retryAfterMs / 1000) : undefined;
+    socket.write(
+      [
+        "HTTP/1.1 429 Too Many Requests",
+        retryAfterSeconds ? `Retry-After: ${retryAfterSeconds}` : undefined,
+        "Content-Type: application/json; charset=utf-8",
+        "Connection: close",
+        "",
+        JSON.stringify({
+          error: {
+            message: "Too many failed authentication attempts. Please try again later.",
+            type: "rate_limited",
+          },
+        }),
+      ]
+        .filter(Boolean)
+        .join("\r\n"),
+    );
+    return;
+  }
+  socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
 }
 
 export type HooksRequestHandler = (req: IncomingMessage, res: ServerResponse) => Promise<boolean>;
@@ -274,6 +409,8 @@ export function createHooksRequestHandler(
 }
 
 export function createGatewayHttpServer(opts: {
+  canvasHost: CanvasHostHandler | null;
+  clients: Set<GatewayWsClient>;
   controlUiEnabled: boolean;
   controlUiBasePath: string;
   controlUiRoot?: ControlUiRootState;
@@ -289,6 +426,8 @@ export function createGatewayHttpServer(opts: {
   tlsOptions?: TlsOptions;
 }): HttpServer {
   const {
+    canvasHost,
+    clients,
     controlUiEnabled,
     controlUiBasePath,
     controlUiRoot,
@@ -323,6 +462,14 @@ export function createGatewayHttpServer(opts: {
       const configSnapshot = loadConfig();
       const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
       const allowRealIpFallback = configSnapshot.gateway?.allowRealIpFallback === true;
+      const scopedCanvas = normalizeCanvasScopedUrl(req.url ?? "/");
+      if (scopedCanvas.malformedScopedPath) {
+        sendGatewayAuthFailure(res, { ok: false, reason: "unauthorized" });
+        return;
+      }
+      if (scopedCanvas.rewrittenUrl) {
+        req.url = scopedCanvas.rewrittenUrl;
+      }
       const requestPath = new URL(req.url ?? "/", "http://localhost").pathname;
       if (await handleHooksRequest(req, res)) {
         return;
@@ -388,6 +535,30 @@ export function createGatewayHttpServer(opts: {
           return;
         }
       }
+      if (canvasHost) {
+        if (isCanvasPath(requestPath)) {
+          const ok = await authorizeCanvasRequest({
+            req,
+            auth: resolvedAuth,
+            trustedProxies,
+            allowRealIpFallback,
+            clients,
+            canvasCapability: scopedCanvas.capability,
+            malformedScopedPath: scopedCanvas.malformedScopedPath,
+            rateLimiter,
+          });
+          if (!ok.ok) {
+            sendGatewayAuthFailure(res, ok);
+            return;
+          }
+        }
+        if (await handleA2uiHttpRequest(req, res)) {
+          return;
+        }
+        if (await canvasHost.handleHttpRequest(req, res)) {
+          return;
+        }
+      }
       if (controlUiEnabled) {
         if (
           handleControlUiAvatarRequest(req, res, {
@@ -424,10 +595,50 @@ export function createGatewayHttpServer(opts: {
 export function attachGatewayUpgradeHandler(opts: {
   httpServer: HttpServer;
   wss: WebSocketServer;
+  canvasHost: CanvasHostHandler | null;
+  clients: Set<GatewayWsClient>;
+  resolvedAuth: ResolvedGatewayAuth;
+  /** Optional rate limiter for auth brute-force protection. */
+  rateLimiter?: AuthRateLimiter;
 }) {
-  const { httpServer, wss } = opts;
+  const { httpServer, wss, canvasHost, clients, resolvedAuth, rateLimiter } = opts;
   httpServer.on("upgrade", (req, socket, head) => {
     void (async () => {
+      const scopedCanvas = normalizeCanvasScopedUrl(req.url ?? "/");
+      if (scopedCanvas.malformedScopedPath) {
+        writeUpgradeAuthFailure(socket, { ok: false, reason: "unauthorized" });
+        socket.destroy();
+        return;
+      }
+      if (scopedCanvas.rewrittenUrl) {
+        req.url = scopedCanvas.rewrittenUrl;
+      }
+      if (canvasHost) {
+        const url = new URL(req.url ?? "/", "http://localhost");
+        if (url.pathname === CANVAS_WS_PATH) {
+          const configSnapshot = loadConfig();
+          const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
+          const allowRealIpFallback = configSnapshot.gateway?.allowRealIpFallback === true;
+          const ok = await authorizeCanvasRequest({
+            req,
+            auth: resolvedAuth,
+            trustedProxies,
+            allowRealIpFallback,
+            clients,
+            canvasCapability: scopedCanvas.capability,
+            malformedScopedPath: scopedCanvas.malformedScopedPath,
+            rateLimiter,
+          });
+          if (!ok.ok) {
+            writeUpgradeAuthFailure(socket, ok);
+            socket.destroy();
+            return;
+          }
+        }
+        if (canvasHost.handleUpgrade(req, socket, head)) {
+          return;
+        }
+      }
       wss.handleUpgrade(req, socket, head, (ws) => {
         wss.emit("connection", ws, req);
       });

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -33,6 +33,7 @@ export type GatewayRuntimeConfig = {
   tailscaleConfig: GatewayTailscaleConfig;
   tailscaleMode: "off" | "serve" | "funnel";
   hooksConfig: ReturnType<typeof resolveHooksConfig>;
+  canvasHostEnabled: boolean;
 };
 
 export async function resolveGatewayRuntimeConfig(params: {
@@ -110,6 +111,8 @@ export async function resolveGatewayRuntimeConfig(params: {
   const hasSharedSecret =
     (authMode === "token" && hasToken) || (authMode === "password" && hasPassword);
   const hooksConfig = resolveHooksConfig(params.cfg);
+  const canvasHostEnabled =
+    process.env.REMOTECLAW_SKIP_CANVAS_HOST !== "1" && params.cfg.canvasHost?.enabled !== false;
 
   const trustedProxies = params.cfg.gateway?.trustedProxies ?? [];
   const controlUiAllowedOrigins = (params.cfg.gateway?.controlUi?.allowedOrigins ?? [])
@@ -177,5 +180,6 @@ export async function resolveGatewayRuntimeConfig(params: {
     tailscaleConfig,
     tailscaleMode,
     hooksConfig,
+    canvasHostEnabled,
   };
 }

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -1,8 +1,11 @@
 import type { Server as HttpServer } from "node:http";
 import { WebSocketServer } from "ws";
+import { CANVAS_HOST_PATH } from "../canvas-host/a2ui.js";
+import { type CanvasHostHandler, createCanvasHostHandler } from "../canvas-host/server.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginRegistry } from "../plugins/registry.js";
+import type { RuntimeEnv } from "../runtime.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
@@ -46,10 +49,15 @@ export async function createGatewayRuntimeState(params: {
   hooksConfig: () => HooksConfigResolved | null;
   pluginRegistry: PluginRegistry;
   deps: CliDeps;
+  canvasRuntime: RuntimeEnv;
+  canvasHostEnabled: boolean;
+  allowCanvasHostInTests?: boolean;
+  logCanvas: { info: (msg: string) => void; warn: (msg: string) => void };
   log: { info: (msg: string) => void; warn: (msg: string) => void };
   logHooks: ReturnType<typeof createSubsystemLogger>;
   logPlugins: ReturnType<typeof createSubsystemLogger>;
 }): Promise<{
+  canvasHost: CanvasHostHandler | null;
   httpServer: HttpServer;
   httpServers: HttpServer[];
   httpBindHosts: string[];
@@ -71,6 +79,27 @@ export async function createGatewayRuntimeState(params: {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   toolEventRecipients: ReturnType<typeof createToolEventRecipientRegistry>;
 }> {
+  let canvasHost: CanvasHostHandler | null = null;
+  if (params.canvasHostEnabled) {
+    try {
+      const handler = await createCanvasHostHandler({
+        runtime: params.canvasRuntime,
+        rootDir: params.cfg.canvasHost?.root,
+        basePath: CANVAS_HOST_PATH,
+        allowInTests: params.allowCanvasHostInTests,
+        liveReload: params.cfg.canvasHost?.liveReload,
+      });
+      if (handler.rootDir) {
+        canvasHost = handler;
+        params.logCanvas.info(
+          `canvas host mounted at http://${params.bindHost}:${params.port}${CANVAS_HOST_PATH}/ (root ${handler.rootDir})`,
+        );
+      }
+    } catch (err) {
+      params.logCanvas.warn(`canvas host failed to start: ${String(err)}`);
+    }
+  }
+
   const clients = new Set<GatewayWsClient>();
   const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
 
@@ -92,6 +121,8 @@ export async function createGatewayRuntimeState(params: {
   const httpBindHosts: string[] = [];
   for (const host of bindHosts) {
     const httpServer = createGatewayHttpServer({
+      canvasHost,
+      clients,
       controlUiEnabled: params.controlUiEnabled,
       controlUiBasePath: params.controlUiBasePath,
       controlUiRoot: params.controlUiRoot,
@@ -135,6 +166,10 @@ export async function createGatewayRuntimeState(params: {
     attachGatewayUpgradeHandler({
       httpServer: server,
       wss,
+      canvasHost,
+      clients,
+      resolvedAuth: params.resolvedAuth,
+      rateLimiter: params.rateLimiter,
     });
   }
 
@@ -150,6 +185,7 @@ export async function createGatewayRuntimeState(params: {
   const toolEventRecipients = createToolEventRecipientRegistry();
 
   return {
+    canvasHost,
     httpServer,
     httpServers,
     httpBindHosts,

--- a/src/gateway/server-ws-runtime.ts
+++ b/src/gateway/server-ws-runtime.ts
@@ -9,6 +9,10 @@ import type { GatewayWsClient } from "./server/ws-types.js";
 export function attachGatewayWsHandlers(params: {
   wss: WebSocketServer;
   clients: Set<GatewayWsClient>;
+  port: number;
+  gatewayHost?: string;
+  canvasHostEnabled: boolean;
+  canvasHostServerPort?: number;
   resolvedAuth: ResolvedGatewayAuth;
   /** Optional rate limiter for auth brute-force protection. */
   rateLimiter?: AuthRateLimiter;
@@ -31,6 +35,10 @@ export function attachGatewayWsHandlers(params: {
   attachGatewayWsConnectionHandler({
     wss: params.wss,
     clients: params.clients,
+    port: params.port,
+    gatewayHost: params.gatewayHost,
+    canvasHostEnabled: params.canvasHostEnabled,
+    canvasHostServerPort: params.canvasHostServerPort,
     resolvedAuth: params.resolvedAuth,
     rateLimiter: params.rateLimiter,
     gatewayMethods: params.gatewayMethods,

--- a/src/gateway/server.canvas-auth.test.ts
+++ b/src/gateway/server.canvas-auth.test.ts
@@ -1,0 +1,386 @@
+import { describe, expect, test } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import { A2UI_PATH, CANVAS_HOST_PATH, CANVAS_WS_PATH } from "../canvas-host/a2ui.js";
+import type { CanvasHostHandler } from "../canvas-host/server.js";
+import { createAuthRateLimiter } from "./auth-rate-limit.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
+import { CANVAS_CAPABILITY_PATH_PREFIX } from "./canvas-capability.js";
+import { attachGatewayUpgradeHandler, createGatewayHttpServer } from "./server-http.js";
+import type { GatewayWsClient } from "./server/ws-types.js";
+import { withTempConfig } from "./test-temp-config.js";
+
+const WS_REJECT_TIMEOUT_MS = 2_000;
+const WS_CONNECT_TIMEOUT_MS = 2_000;
+
+async function listen(
+  server: ReturnType<typeof createGatewayHttpServer>,
+  host = "127.0.0.1",
+): Promise<{
+  host: string;
+  port: number;
+  close: () => Promise<void>;
+}> {
+  await new Promise<void>((resolve) => server.listen(0, host, resolve));
+  const addr = server.address();
+  const port = typeof addr === "object" && addr ? addr.port : 0;
+  return {
+    host,
+    port,
+    close: async () => {
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      );
+    },
+  };
+}
+
+async function expectWsRejected(
+  url: string,
+  headers: Record<string, string>,
+  expectedStatus = 401,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const ws = new WebSocket(url, { headers });
+    const timer = setTimeout(() => reject(new Error("timeout")), WS_REJECT_TIMEOUT_MS);
+    ws.once("open", () => {
+      clearTimeout(timer);
+      ws.terminate();
+      reject(new Error("expected ws to reject"));
+    });
+    ws.once("unexpected-response", (_req, res) => {
+      clearTimeout(timer);
+      expect(res.statusCode).toBe(expectedStatus);
+      resolve();
+    });
+    ws.once("error", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+async function expectWsConnected(url: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const timer = setTimeout(() => reject(new Error("timeout")), WS_CONNECT_TIMEOUT_MS);
+    ws.once("open", () => {
+      clearTimeout(timer);
+      ws.terminate();
+      resolve();
+    });
+    ws.once("unexpected-response", (_req, res) => {
+      clearTimeout(timer);
+      reject(new Error(`unexpected response ${res.statusCode}`));
+    });
+    ws.once("error", reject);
+  });
+}
+
+function makeWsClient(params: {
+  connId: string;
+  clientIp: string;
+  role: "node" | "operator";
+  mode: "node" | "backend";
+  canvasCapability?: string;
+  canvasCapabilityExpiresAtMs?: number;
+}): GatewayWsClient {
+  return {
+    socket: {} as unknown as WebSocket,
+    connect: {
+      role: params.role,
+      client: {
+        mode: params.mode,
+      },
+    } as GatewayWsClient["connect"],
+    connId: params.connId,
+    clientIp: params.clientIp,
+    canvasCapability: params.canvasCapability,
+    canvasCapabilityExpiresAtMs: params.canvasCapabilityExpiresAtMs,
+  };
+}
+
+function scopedCanvasPath(capability: string, path: string): string {
+  return `${CANVAS_CAPABILITY_PATH_PREFIX}/${encodeURIComponent(capability)}${path}`;
+}
+
+const allowCanvasHostHttp: CanvasHostHandler["handleHttpRequest"] = async (req, res) => {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  if (url.pathname !== CANVAS_HOST_PATH && !url.pathname.startsWith(`${CANVAS_HOST_PATH}/`)) {
+    return false;
+  }
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "text/plain; charset=utf-8");
+  res.end("ok");
+  return true;
+};
+async function withCanvasGatewayHarness(params: {
+  resolvedAuth: ResolvedGatewayAuth;
+  listenHost?: string;
+  rateLimiter?: ReturnType<typeof createAuthRateLimiter>;
+  handleHttpRequest: CanvasHostHandler["handleHttpRequest"];
+  run: (ctx: {
+    listener: Awaited<ReturnType<typeof listen>>;
+    clients: Set<GatewayWsClient>;
+  }) => Promise<void>;
+}) {
+  const clients = new Set<GatewayWsClient>();
+  const canvasWss = new WebSocketServer({ noServer: true });
+  const canvasHost: CanvasHostHandler = {
+    rootDir: "test",
+    basePath: "/canvas",
+    close: async () => {},
+    handleUpgrade: (req, socket, head) => {
+      const url = new URL(req.url ?? "/", "http://localhost");
+      if (url.pathname !== CANVAS_WS_PATH) {
+        return false;
+      }
+      canvasWss.handleUpgrade(req, socket, head, (ws) => ws.close());
+      return true;
+    },
+    handleHttpRequest: params.handleHttpRequest,
+  };
+
+  const httpServer = createGatewayHttpServer({
+    canvasHost,
+    clients,
+    controlUiEnabled: false,
+    controlUiBasePath: "/__control__",
+    openAiChatCompletionsEnabled: false,
+    openResponsesEnabled: false,
+    handleHooksRequest: async () => false,
+    resolvedAuth: params.resolvedAuth,
+    rateLimiter: params.rateLimiter,
+  });
+
+  const wss = new WebSocketServer({ noServer: true });
+  attachGatewayUpgradeHandler({
+    httpServer,
+    wss,
+    canvasHost,
+    clients,
+    resolvedAuth: params.resolvedAuth,
+    rateLimiter: params.rateLimiter,
+  });
+
+  const listener = await listen(httpServer, params.listenHost);
+  try {
+    await params.run({ listener, clients });
+  } finally {
+    await listener.close();
+    params.rateLimiter?.dispose();
+    canvasWss.close();
+    wss.close();
+  }
+}
+
+describe("gateway canvas host auth", () => {
+  const tokenResolvedAuth: ResolvedGatewayAuth = {
+    mode: "token",
+    token: "test-token",
+    password: undefined,
+    allowTailscale: false,
+  };
+
+  const withLoopbackTrustedProxy = async (run: () => Promise<void>, prefix?: string) => {
+    await withTempConfig({
+      cfg: {
+        gateway: {
+          trustedProxies: ["127.0.0.1"],
+        },
+      },
+      ...(prefix ? { prefix } : {}),
+      run,
+    });
+  };
+
+  test("authorizes canvas HTTP/WS via node-scoped capability and rejects misuse", async () => {
+    await withLoopbackTrustedProxy(async () => {
+      await withCanvasGatewayHarness({
+        resolvedAuth: tokenResolvedAuth,
+        handleHttpRequest: allowCanvasHostHttp,
+        run: async ({ listener, clients }) => {
+          const host = "127.0.0.1";
+          const operatorOnlyCapability = "operator-only";
+          const expiredNodeCapability = "expired-node";
+          const activeNodeCapability = "active-node";
+          const activeCanvasPath = scopedCanvasPath(activeNodeCapability, `${CANVAS_HOST_PATH}/`);
+          const activeWsPath = scopedCanvasPath(activeNodeCapability, CANVAS_WS_PATH);
+
+          const unauthCanvas = await fetch(`http://${host}:${listener.port}${CANVAS_HOST_PATH}/`);
+          expect(unauthCanvas.status).toBe(401);
+
+          const malformedScoped = await fetch(
+            `http://${host}:${listener.port}${CANVAS_CAPABILITY_PATH_PREFIX}/broken`,
+          );
+          expect(malformedScoped.status).toBe(401);
+
+          clients.add(
+            makeWsClient({
+              connId: "c-operator",
+              clientIp: "192.168.1.10",
+              role: "operator",
+              mode: "backend",
+              canvasCapability: operatorOnlyCapability,
+              canvasCapabilityExpiresAtMs: Date.now() + 60_000,
+            }),
+          );
+
+          const operatorCapabilityBlocked = await fetch(
+            `http://${host}:${listener.port}${scopedCanvasPath(operatorOnlyCapability, `${CANVAS_HOST_PATH}/`)}`,
+          );
+          expect(operatorCapabilityBlocked.status).toBe(401);
+
+          clients.add(
+            makeWsClient({
+              connId: "c-expired-node",
+              clientIp: "192.168.1.20",
+              role: "node",
+              mode: "node",
+              canvasCapability: expiredNodeCapability,
+              canvasCapabilityExpiresAtMs: Date.now() - 1,
+            }),
+          );
+
+          const expiredCapabilityBlocked = await fetch(
+            `http://${host}:${listener.port}${scopedCanvasPath(expiredNodeCapability, `${CANVAS_HOST_PATH}/`)}`,
+          );
+          expect(expiredCapabilityBlocked.status).toBe(401);
+
+          const activeNodeClient = makeWsClient({
+            connId: "c-active-node",
+            clientIp: "192.168.1.30",
+            role: "node",
+            mode: "node",
+            canvasCapability: activeNodeCapability,
+            canvasCapabilityExpiresAtMs: Date.now() + 60_000,
+          });
+          clients.add(activeNodeClient);
+
+          const scopedCanvas = await fetch(`http://${host}:${listener.port}${activeCanvasPath}`);
+          expect(scopedCanvas.status).toBe(200);
+          expect(await scopedCanvas.text()).toBe("ok");
+
+          const scopedA2ui = await fetch(
+            `http://${host}:${listener.port}${scopedCanvasPath(activeNodeCapability, `${A2UI_PATH}/`)}`,
+          );
+          expect(scopedA2ui.status).toBe(200);
+
+          await expectWsConnected(`ws://${host}:${listener.port}${activeWsPath}`);
+
+          clients.delete(activeNodeClient);
+
+          const disconnectedNodeBlocked = await fetch(
+            `http://${host}:${listener.port}${activeCanvasPath}`,
+          );
+          expect(disconnectedNodeBlocked.status).toBe(401);
+          await expectWsRejected(`ws://${host}:${listener.port}${activeWsPath}`, {});
+        },
+      });
+    }, "remoteclaw-canvas-auth-test-");
+  }, 60_000);
+
+  test("denies canvas auth when trusted proxy omits forwarded client headers", async () => {
+    await withLoopbackTrustedProxy(async () => {
+      await withCanvasGatewayHarness({
+        resolvedAuth: tokenResolvedAuth,
+        handleHttpRequest: allowCanvasHostHttp,
+        run: async ({ listener, clients }) => {
+          clients.add(
+            makeWsClient({
+              connId: "c-loopback-node",
+              clientIp: "127.0.0.1",
+              role: "node",
+              mode: "node",
+              canvasCapability: "unused",
+              canvasCapabilityExpiresAtMs: Date.now() + 60_000,
+            }),
+          );
+
+          const res = await fetch(`http://127.0.0.1:${listener.port}${CANVAS_HOST_PATH}/`);
+          expect(res.status).toBe(401);
+
+          await expectWsRejected(`ws://127.0.0.1:${listener.port}${CANVAS_WS_PATH}`, {});
+        },
+      });
+    });
+  }, 60_000);
+
+  test("accepts capability-scoped paths over IPv6 loopback", async () => {
+    await withTempConfig({
+      cfg: {
+        gateway: {
+          trustedProxies: ["::1"],
+        },
+      },
+      run: async () => {
+        try {
+          await withCanvasGatewayHarness({
+            resolvedAuth: tokenResolvedAuth,
+            listenHost: "::1",
+            handleHttpRequest: allowCanvasHostHttp,
+            run: async ({ listener, clients }) => {
+              const capability = "ipv6-node";
+              clients.add(
+                makeWsClient({
+                  connId: "c-ipv6-node",
+                  clientIp: "fd12:3456:789a::2",
+                  role: "node",
+                  mode: "node",
+                  canvasCapability: capability,
+                  canvasCapabilityExpiresAtMs: Date.now() + 60_000,
+                }),
+              );
+
+              const canvasPath = scopedCanvasPath(capability, `${CANVAS_HOST_PATH}/`);
+              const wsPath = scopedCanvasPath(capability, CANVAS_WS_PATH);
+              const scopedCanvas = await fetch(`http://[::1]:${listener.port}${canvasPath}`);
+              expect(scopedCanvas.status).toBe(200);
+
+              await expectWsConnected(`ws://[::1]:${listener.port}${wsPath}`);
+            },
+          });
+        } catch (err) {
+          const message = String(err);
+          if (message.includes("EAFNOSUPPORT") || message.includes("EADDRNOTAVAIL")) {
+            return;
+          }
+          throw err;
+        }
+      },
+    });
+  }, 60_000);
+
+  test("returns 429 for repeated failed canvas auth attempts (HTTP + WS upgrade)", async () => {
+    await withLoopbackTrustedProxy(async () => {
+      const rateLimiter = createAuthRateLimiter({
+        maxAttempts: 1,
+        windowMs: 60_000,
+        lockoutMs: 60_000,
+        exemptLoopback: false,
+      });
+      await withCanvasGatewayHarness({
+        resolvedAuth: tokenResolvedAuth,
+        rateLimiter,
+        handleHttpRequest: async () => false,
+        run: async ({ listener }) => {
+          const headers = {
+            authorization: "Bearer wrong",
+            "x-forwarded-for": "203.0.113.99",
+          };
+          const first = await fetch(`http://127.0.0.1:${listener.port}${CANVAS_HOST_PATH}/`, {
+            headers,
+          });
+          expect(first.status).toBe(401);
+
+          const second = await fetch(`http://127.0.0.1:${listener.port}${CANVAS_HOST_PATH}/`, {
+            headers,
+          });
+          expect(second.status).toBe(429);
+          expect(second.headers.get("retry-after")).toBeTruthy();
+
+          await expectWsRejected(`ws://127.0.0.1:${listener.port}${CANVAS_WS_PATH}`, headers, 429);
+        },
+      });
+    });
+  }, 60_000);
+});

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
+import type { CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { createDefaultDeps } from "../cli/deps.js";
@@ -82,6 +83,7 @@ import { ensureGatewayStartupAuth } from "./startup-auth.js";
 ensureRemoteClawCliOnPath();
 
 const log = createSubsystemLogger("gateway");
+const logCanvas = log.child("canvas");
 const logDiscovery = log.child("discovery");
 const logTailscale = log.child("tailscale");
 const logChannels = log.child("channels");
@@ -93,6 +95,7 @@ const logHooks = log.child("hooks");
 const logPlugins = log.child("plugins");
 const logWsControl = log.child("ws");
 const gatewayRuntime = runtimeForLogger(log);
+const canvasRuntime = runtimeForLogger(logCanvas);
 
 export type GatewayServer = {
   close: (opts?: { reason?: string; restartExpectedMs?: number | null }) => Promise<void>;
@@ -136,6 +139,10 @@ export type GatewayServerOptions = {
    */
   tailscale?: import("../config/config.js").GatewayTailscaleConfig;
   /**
+   * Test-only: allow canvas host startup even when NODE_ENV/VITEST would disable it.
+   */
+  allowCanvasHostInTests?: boolean;
+  /**
    * Test-only: override the onboarding wizard runner.
    */
   wizardRunner?: (
@@ -152,7 +159,7 @@ export async function startGatewayServer(
   const minimalTestGateway =
     process.env.VITEST === "1" && process.env.REMOTECLAW_TEST_MINIMAL_GATEWAY === "1";
 
-  // Ensure all default port derivations (browser) see the actual runtime port.
+  // Ensure all default port derivations (browser/canvas) see the actual runtime port.
   process.env.REMOTECLAW_GATEWAY_PORT = String(port);
   logAcceptedEnvOption({
     key: "REMOTECLAW_RAW_STREAM",
@@ -287,6 +294,7 @@ export async function startGatewayServer(
     tailscaleMode,
   } = runtimeConfig;
   let hooksConfig = runtimeConfig.hooksConfig;
+  const canvasHostEnabled = runtimeConfig.canvasHostEnabled;
 
   // Create auth rate limiter only when explicitly configured.
   const rateLimitConfig = cfgAtStart.gateway?.auth?.rateLimit;
@@ -330,11 +338,13 @@ export async function startGatewayServer(
   const { wizardSessions, findRunningWizard, purgeWizardSession } = createWizardSessionTracker();
 
   const deps = createDefaultDeps();
+  let canvasHostServer: CanvasHostServer | null = null;
   const gatewayTls = await loadGatewayTlsRuntime(cfgAtStart.gateway?.tls, log.child("tls"));
   if (cfgAtStart.gateway?.tls?.enabled && !gatewayTls.enabled) {
     throw new Error(gatewayTls.error ?? "gateway tls: failed to enable");
   }
   const {
+    canvasHost,
     httpServer,
     httpServers,
     httpBindHosts,
@@ -368,6 +378,10 @@ export async function startGatewayServer(
     hooksConfig: () => hooksConfig,
     pluginRegistry,
     deps,
+    canvasRuntime,
+    canvasHostEnabled,
+    allowCanvasHostInTests: opts.allowCanvasHostInTests,
+    logCanvas,
     log,
     logHooks,
     logPlugins,
@@ -503,9 +517,15 @@ export async function startGatewayServer(
     })().catch((err) => log.error(`Delivery recovery failed: ${String(err)}`));
   }
 
+  const canvasHostServerPort = (canvasHostServer as CanvasHostServer | null)?.port;
+
   attachGatewayWsHandlers({
     wss,
     clients,
+    port,
+    gatewayHost: bindHost ?? undefined,
+    canvasHostEnabled: Boolean(canvasHost),
+    canvasHostServerPort,
     resolvedAuth,
     rateLimiter: authRateLimiter,
     gatewayMethods,
@@ -657,6 +677,8 @@ export async function startGatewayServer(
   const close = createGatewayCloseHandler({
     bonjourStop,
     tailscaleCleanup,
+    canvasHost,
+    canvasHostServer,
     stopChannel,
     pluginServices,
     cron,

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -79,6 +79,8 @@ describe("gateway plugin HTTP auth boundary", () => {
       prefix: "remoteclaw-plugin-http-security-headers-test-",
       run: async () => {
         const withoutHsts = createGatewayHttpServer({
+          canvasHost: null,
+          clients: new Set(),
           controlUiEnabled: false,
           controlUiBasePath: "/__control__",
           openAiChatCompletionsEnabled: false,
@@ -106,6 +108,8 @@ describe("gateway plugin HTTP auth boundary", () => {
         );
 
         const withHsts = createGatewayHttpServer({
+          canvasHost: null,
+          clients: new Set(),
           controlUiEnabled: false,
           controlUiBasePath: "/__control__",
           openAiChatCompletionsEnabled: false,
@@ -160,6 +164,8 @@ describe("gateway plugin HTTP auth boundary", () => {
         });
 
         const server = createGatewayHttpServer({
+          canvasHost: null,
+          clients: new Set(),
           controlUiEnabled: false,
           controlUiBasePath: "/__control__",
           openAiChatCompletionsEnabled: false,

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { WebSocket, WebSocketServer } from "ws";
+import { resolveCanvasHostUrl } from "../../infra/canvas-host-url.js";
 import { upsertPresence } from "../../infra/system-presence.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import { truncateUtf16Safe } from "../../utils.js";
@@ -56,6 +57,10 @@ const sanitizeLogValue = (value: string | undefined): string | undefined => {
 export function attachGatewayWsConnectionHandler(params: {
   wss: WebSocketServer;
   clients: Set<GatewayWsClient>;
+  port: number;
+  gatewayHost?: string;
+  canvasHostEnabled: boolean;
+  canvasHostServerPort?: number;
   resolvedAuth: ResolvedGatewayAuth;
   /** Optional rate limiter for auth brute-force protection. */
   rateLimiter?: AuthRateLimiter;
@@ -78,6 +83,10 @@ export function attachGatewayWsConnectionHandler(params: {
   const {
     wss,
     clients,
+    port,
+    gatewayHost,
+    canvasHostEnabled,
+    canvasHostServerPort,
     resolvedAuth,
     rateLimiter,
     gatewayMethods,
@@ -104,6 +113,17 @@ export function attachGatewayWsConnectionHandler(params: {
     const requestUserAgent = headerValue(upgradeReq.headers["user-agent"]);
     const forwardedFor = headerValue(upgradeReq.headers["x-forwarded-for"]);
     const realIp = headerValue(upgradeReq.headers["x-real-ip"]);
+
+    const canvasHostPortForWs = canvasHostServerPort ?? (canvasHostEnabled ? port : undefined);
+    const canvasHostOverride =
+      gatewayHost && gatewayHost !== "0.0.0.0" && gatewayHost !== "::" ? gatewayHost : undefined;
+    const canvasHostUrl = resolveCanvasHostUrl({
+      canvasPort: canvasHostPortForWs,
+      hostOverride: canvasHostServerPort ? canvasHostOverride : undefined,
+      requestHost: upgradeReq.headers.host,
+      forwardedProto: upgradeReq.headers["x-forwarded-proto"],
+      localAddress: upgradeReq.socket?.localAddress,
+    });
 
     logWs("in", "open", { connId, remoteAddr });
     let handshakeState: "pending" | "connected" | "failed" = "pending";
@@ -252,6 +272,7 @@ export function attachGatewayWsConnectionHandler(params: {
       requestHost,
       requestOrigin,
       requestUserAgent,
+      canvasHostUrl,
       connectNonce,
       resolvedAuth,
       rateLimiter,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -26,6 +26,11 @@ import { resolveRuntimeServiceVersion } from "../../../version.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
 import { isLocalDirectRequest } from "../../auth.js";
+import {
+  buildCanvasScopedHostUrl,
+  CANVAS_CAPABILITY_TTL_MS,
+  mintCanvasCapabilityToken,
+} from "../../canvas-capability.js";
 import { buildDeviceAuthPayload } from "../../device-auth.js";
 import {
   isLocalishHost,
@@ -88,6 +93,7 @@ export function attachGatewayWsMessageHandler(params: {
   requestHost?: string;
   requestOrigin?: string;
   requestUserAgent?: string;
+  canvasHostUrl?: string;
   connectNonce: string;
   resolvedAuth: ResolvedGatewayAuth;
   /** Optional rate limiter for auth brute-force protection. */
@@ -119,6 +125,7 @@ export function attachGatewayWsMessageHandler(params: {
     requestHost,
     requestOrigin,
     requestUserAgent,
+    canvasHostUrl,
     connectNonce,
     resolvedAuth,
     rateLimiter,
@@ -782,6 +789,15 @@ export function attachGatewayWsMessageHandler(params: {
           snapshot.health = cachedHealth;
           snapshot.stateVersion.health = getHealthVersion();
         }
+        const canvasCapability =
+          role === "node" && canvasHostUrl ? mintCanvasCapabilityToken() : undefined;
+        const canvasCapabilityExpiresAtMs = canvasCapability
+          ? Date.now() + CANVAS_CAPABILITY_TTL_MS
+          : undefined;
+        const scopedCanvasHostUrl =
+          canvasHostUrl && canvasCapability
+            ? (buildCanvasScopedHostUrl(canvasHostUrl, canvasCapability) ?? canvasHostUrl)
+            : canvasHostUrl;
         const helloOk = {
           type: "hello-ok",
           protocol: PROTOCOL_VERSION,
@@ -791,6 +807,7 @@ export function attachGatewayWsMessageHandler(params: {
           },
           features: { methods: gatewayMethods, events },
           snapshot,
+          canvasHostUrl: scopedCanvasHostUrl,
           auth: deviceToken
             ? {
                 deviceToken: deviceToken.token,
@@ -813,6 +830,8 @@ export function attachGatewayWsMessageHandler(params: {
           connId,
           presenceKey,
           clientIp: reportedClientIp,
+          canvasCapability,
+          canvasCapabilityExpiresAtMs,
         };
         setClient(nextClient);
         setHandshakeState("connected");

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -7,4 +7,6 @@ export type GatewayWsClient = {
   connId: string;
   presenceKey?: string;
   clientIp?: string;
+  canvasCapability?: string;
+  canvasCapabilityExpiresAtMs?: number;
 };


### PR DESCRIPTION
## Summary

Reverses the gutting from PR #99 (commit `53a966def6`) to re-enable gateway-hosted canvas content delivery and A2UI bundle serving.

- Restore canvas HTTP routing, capability token auth, and WebSocket upgrade handling in the gateway server
- Create `canvas-capability.ts` with remoteclaw-branded naming (`/__remoteclaw__/cap`, `rc_cap` query param)
- Restore `canvasHostUrl` delivery in `hello-ok` to connecting nodes with node-scoped capability tokens
- Restore canvas host handler lifecycle (creation, startup logging, shutdown cleanup)
- Restore `canvasHostEnabled` runtime config flag (`REMOTECLAW_SKIP_CANVAS_HOST` env var)
- Restore canvas auth test suite (4 tests covering capability auth, proxy header denial, IPv6, and rate limiting)

Closes #469

## Test plan

- [x] Type-check passes (`pnpm check`)
- [x] All 876 gateway tests pass (`pnpm test`)
- [x] Canvas auth test suite passes (4 tests)
- [x] Plugin HTTP auth tests pass with canvas params
- [ ] CI build and test jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)