### PR TITLE
fix(import): add cron, devices, and canvas to importable root entries

### DIFF
--- a/src/commands/import.test.ts
+++ b/src/commands/import.test.ts
@@ -907,6 +907,9 @@ describe("isImportableRootEntry", () => {
     expect(isImportableRootEntry("telegram")).toBe(true);
     expect(isImportableRootEntry("media")).toBe(true);
     expect(isImportableRootEntry("workspace")).toBe(true);
+    expect(isImportableRootEntry("cron")).toBe(true);
+    expect(isImportableRootEntry("devices")).toBe(true);
+    expect(isImportableRootEntry("canvas")).toBe(true);
   });
 
   it("accepts workspace-{agentId} directories", () => {
@@ -923,7 +926,6 @@ describe("isImportableRootEntry", () => {
     expect(isImportableRootEntry("logs")).toBe(false);
     expect(isImportableRootEntry("packs")).toBe(false);
     expect(isImportableRootEntry("browser")).toBe(false);
-    expect(isImportableRootEntry("canvas")).toBe(false);
   });
 });
 
@@ -1085,6 +1087,45 @@ describe("importCommand", () => {
 
     expect(result.copiedFiles).toHaveLength(1);
     expect(fs.existsSync(path.join(targetDir, "workspace-helper", "project.json"))).toBe(true);
+  });
+
+  it("imports cron directory", async () => {
+    await fsp.mkdir(path.join(sourceDir, "cron"), { recursive: true });
+    await fsp.writeFile(path.join(sourceDir, "cron", "jobs.json"), '{"jobs":[]}');
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    expect(result.copiedFiles).toHaveLength(1);
+    expect(fs.existsSync(path.join(targetDir, "cron", "jobs.json"))).toBe(true);
+  });
+
+  it("imports devices directory", async () => {
+    await fsp.mkdir(path.join(sourceDir, "devices"), { recursive: true });
+    await fsp.writeFile(path.join(sourceDir, "devices", "paired.json"), "[]");
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    expect(result.copiedFiles).toHaveLength(1);
+    expect(fs.existsSync(path.join(targetDir, "devices", "paired.json"))).toBe(true);
+  });
+
+  it("imports canvas directory", async () => {
+    await fsp.mkdir(path.join(sourceDir, "canvas"), { recursive: true });
+    await fsp.writeFile(path.join(sourceDir, "canvas", "index.html"), "<html></html>");
+
+    const pathsMod = await import("../config/paths.js");
+    vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
+
+    const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
+
+    expect(result.copiedFiles).toHaveLength(1);
+    expect(fs.existsSync(path.join(targetDir, "canvas", "index.html"))).toBe(true);
   });
 
   it("transforms config files during copy", async () => {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -698,8 +698,8 @@ export function resolveTargetFilename(filename: string): string {
  * Only entries in this set (plus the `workspace-*` pattern) are copied from
  * the source root. Everything else — generated caches (`completions/`),
  * runtime state (`delivery-queue/`, `sandbox/`, `restart-sentinel.json`),
- * device-specific data (`identity/`), and removed subsystems (`packs/`) —
- * is intentionally skipped.
+ * identity data (`identity/`), and removed subsystems (`packs/`) — is
+ * intentionally skipped.
  *
  * Sub-directories within importable entries are copied recursively without
  * further filtering.
@@ -729,6 +729,15 @@ const IMPORTABLE_ROOT_ENTRIES = new Set([
   // Media and workspaces
   "media",
   "workspace",
+
+  // Scheduled jobs
+  "cron",
+
+  // Paired device registry
+  "devices",
+
+  // User-authored canvas content
+  "canvas",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- Add `cron`, `devices`, and `canvas` to the `IMPORTABLE_ROOT_ENTRIES` allowlist so users migrating from OpenClaw retain their scheduled jobs, device pairings, and canvas content
- Update JSDoc comment to reflect that `devices/` is now imported (keep `identity/` as skipped)
- Remove `canvas` from the "rejects non-importable" unit test since it's now importable
- Add 3 integration tests covering import of each new directory

Closes #465

## Test plan

- [x] `isImportableRootEntry` unit tests pass for `cron`, `devices`, `canvas`
- [x] Integration tests verify each directory is copied during import
- [x] Existing "skips non-importable" test updated (canvas removed from rejects)
- [x] All 97 import tests pass
- [x] Format, typecheck, lint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)