### PR TITLE
feat(auth): add ElevenLabs provider to auth profile system

### DIFF
--- a/src/auth/env-injection.test.ts
+++ b/src/auth/env-injection.test.ts
@@ -43,6 +43,10 @@ describe("resolveProviderEnvVarName", () => {
     expect(resolveProviderEnvVarName("openrouter")).toBe("OPENROUTER_API_KEY");
   });
 
+  it("maps elevenlabs to ELEVENLABS_API_KEY", () => {
+    expect(resolveProviderEnvVarName("elevenlabs")).toBe("ELEVENLABS_API_KEY");
+  });
+
   it("returns undefined for unknown providers", () => {
     expect(resolveProviderEnvVarName("unknown-provider")).toBeUndefined();
   });

--- a/src/auth/env-injection.ts
+++ b/src/auth/env-injection.ts
@@ -62,6 +62,7 @@ export function resolveProviderEnvVarName(provider: string): string | undefined 
     venice: "VENICE_API_KEY",
     qianfan: "QIANFAN_API_KEY",
     kilocode: "KILOCODE_API_KEY",
+    elevenlabs: "ELEVENLABS_API_KEY",
   };
 
   return envMap[normalized];

--- a/src/auth/provider-auth.elevenlabs.test.ts
+++ b/src/auth/provider-auth.elevenlabs.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { captureEnv } from "../test-utils/env.js";
+import { resolveEnvApiKey } from "./provider-auth.js";
+
+describe("resolveEnvApiKey — elevenlabs", () => {
+  it("resolves ELEVENLABS_API_KEY from env", () => {
+    const envSnapshot = captureEnv(["ELEVENLABS_API_KEY", "XI_API_KEY"]);
+    process.env.ELEVENLABS_API_KEY = "test-elevenlabs-key";
+    delete process.env.XI_API_KEY;
+
+    try {
+      const result = resolveEnvApiKey("elevenlabs");
+      expect(result).not.toBeNull();
+      expect(result?.apiKey).toBe("test-elevenlabs-key");
+      expect(result?.source).toContain("ELEVENLABS_API_KEY");
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
+  it("falls back to XI_API_KEY when ELEVENLABS_API_KEY is not set", () => {
+    const envSnapshot = captureEnv(["ELEVENLABS_API_KEY", "XI_API_KEY"]);
+    delete process.env.ELEVENLABS_API_KEY;
+    process.env.XI_API_KEY = "test-xi-key";
+
+    try {
+      const result = resolveEnvApiKey("elevenlabs");
+      expect(result).not.toBeNull();
+      expect(result?.apiKey).toBe("test-xi-key");
+      expect(result?.source).toContain("XI_API_KEY");
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
+  it("prefers ELEVENLABS_API_KEY over XI_API_KEY", () => {
+    const envSnapshot = captureEnv(["ELEVENLABS_API_KEY", "XI_API_KEY"]);
+    process.env.ELEVENLABS_API_KEY = "primary-key";
+    process.env.XI_API_KEY = "legacy-key";
+
+    try {
+      const result = resolveEnvApiKey("elevenlabs");
+      expect(result).not.toBeNull();
+      expect(result?.apiKey).toBe("primary-key");
+      expect(result?.source).toContain("ELEVENLABS_API_KEY");
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
+  it("returns null when neither env var is set", () => {
+    const envSnapshot = captureEnv(["ELEVENLABS_API_KEY", "XI_API_KEY"]);
+    delete process.env.ELEVENLABS_API_KEY;
+    delete process.env.XI_API_KEY;
+
+    try {
+      const result = resolveEnvApiKey("elevenlabs");
+      expect(result).toBeNull();
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+});

--- a/src/auth/provider-auth.ts
+++ b/src/auth/provider-auth.ts
@@ -261,6 +261,10 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     return pick("HUGGINGFACE_HUB_TOKEN") ?? pick("HF_TOKEN");
   }
 
+  if (normalized === "elevenlabs") {
+    return pick("ELEVENLABS_API_KEY") ?? pick("XI_API_KEY");
+  }
+
   const envMap: Record<string, string> = {
     openai: "OPENAI_API_KEY",
     google: "GEMINI_API_KEY",

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -269,3 +269,14 @@ export async function setKilocodeApiKey(key: string) {
     },
   });
 }
+
+export async function setElevenLabsApiKey(key: string) {
+  upsertAuthProfile({
+    profileId: "elevenlabs:default",
+    credential: {
+      type: "api_key",
+      provider: "elevenlabs",
+      key,
+    },
+  });
+}

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -57,6 +57,7 @@ export {
   OPENROUTER_DEFAULT_MODEL_REF,
   setAnthropicApiKey,
   setCloudflareAiGatewayConfig,
+  setElevenLabsApiKey,
   setQianfanApiKey,
   setGeminiApiKey,
   setKilocodeApiKey,


### PR DESCRIPTION
## Summary

- Register ElevenLabs in the auth profile system — env var resolution (`ELEVENLABS_API_KEY` + legacy `XI_API_KEY` fallback), CLI subprocess injection, and onboarding credential setter (`setElevenLabsApiKey`)
- Enables `elevenlabs:default` profile creation and key rotation via the standard auth profile mechanism

Closes #403

## Test plan

- [x] `resolveEnvApiKey("elevenlabs")` resolves `ELEVENLABS_API_KEY`
- [x] Falls back to `XI_API_KEY` when primary env var is unset
- [x] Prefers `ELEVENLABS_API_KEY` over `XI_API_KEY` when both are set
- [x] Returns null when neither env var is set
- [x] `resolveProviderEnvVarName("elevenlabs")` maps to `ELEVENLABS_API_KEY`
- [x] Full test suite passes (876 tests)
- [x] Format, typecheck, lint all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)