### PR TITLE
fix(tts): resolve TTS API keys through auth profile store

### DIFF
--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -334,7 +334,7 @@ export function createSessionStatusTool(opts?: {
         typeof rawModel === "object" && rawModel
           ? { ...rawModel, primary: defaultLabel }
           : { primary: defaultLabel };
-      const statusText = buildStatusMessage({
+      const statusText = await buildStatusMessage({
         config: cfg,
         agent: {
           ...agentDefaults,

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -143,7 +143,7 @@ export async function buildStatusReply(params: {
       })
     : selectedModelAuth;
   const agentDefaults = cfg.agents?.defaults ?? {};
-  const statusText = buildStatusMessage({
+  const statusText = await buildStatusMessage({
     config: cfg,
     agent: {
       ...agentDefaults,

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -157,11 +157,11 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
   }
 
   if (action === "provider") {
-    const currentProvider = getTtsProvider(config, prefsPath);
+    const currentProvider = await getTtsProvider(config, prefsPath);
     if (!args.trim()) {
-      const hasOpenAI = Boolean(resolveTtsApiKey(config, "openai"));
-      const hasElevenLabs = Boolean(resolveTtsApiKey(config, "elevenlabs"));
-      const hasEdge = isTtsProviderConfigured(config, "edge");
+      const hasOpenAI = Boolean(await resolveTtsApiKey(config, "openai"));
+      const hasElevenLabs = Boolean(await resolveTtsApiKey(config, "elevenlabs"));
+      const hasEdge = await isTtsProviderConfigured(config, "edge");
       return {
         shouldContinue: false,
         reply: {
@@ -248,8 +248,8 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
 
   if (action === "status") {
     const enabled = isTtsEnabled(config, prefsPath);
-    const provider = getTtsProvider(config, prefsPath);
-    const hasKey = isTtsProviderConfigured(config, provider);
+    const provider = await getTtsProvider(config, prefsPath);
+    const hasKey = await isTtsProviderConfigured(config, provider);
     const maxLength = getTtsMaxLength(prefsPath);
     const summarize = isSummarizationEnabled(prefsPath);
     const last = getLastTtsAttempt();

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -27,8 +27,8 @@ afterEach(() => {
 });
 
 describe("buildStatusMessage", () => {
-  it("summarizes agent readiness and context usage", () => {
-    const text = buildStatusMessage({
+  it("summarizes agent readiness and context usage", async () => {
+    const text = await buildStatusMessage({
       config: {} as unknown as RemoteClawConfig,
       agent: {
         contextTokens: 32_000,
@@ -69,8 +69,8 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Queue: collect");
   });
 
-  it("notes channel model overrides in status output", () => {
-    const text = buildStatusMessage({
+  it("notes channel model overrides in status output", async () => {
+    const text = await buildStatusMessage({
       config: {
         channels: {
           modelByChannel: {
@@ -100,8 +100,8 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("channel override");
   });
 
-  it("shows 1M context window when contextTokens is set to 1M", () => {
-    const text = buildStatusMessage({
+  it("shows 1M context window when contextTokens is set to 1M", async () => {
+    const text = await buildStatusMessage({
       config: {} as unknown as RemoteClawConfig,
       agent: {
         contextTokens: 1_000_000,
@@ -119,8 +119,8 @@ describe("buildStatusMessage", () => {
     expect(normalizeTestText(text)).toContain("Context: 200k/1.0m");
   });
 
-  it("shows verbose/elevated labels only when enabled", () => {
-    const text = buildStatusMessage({
+  it("shows verbose/elevated labels only when enabled", async () => {
+    const text = await buildStatusMessage({
       agent: { model: "anthropic/claude-opus-4-5" },
       sessionEntry: { sessionId: "v1", updatedAt: 0 },
       sessionKey: "agent:main:main",
@@ -135,8 +135,8 @@ describe("buildStatusMessage", () => {
     expect(text).toContain("elevated");
   });
 
-  it("includes media understanding decisions when present", () => {
-    const text = buildStatusMessage({
+  it("includes media understanding decisions when present", async () => {
+    const text = await buildStatusMessage({
       agent: { model: "anthropic/claude-opus-4-5" },
       sessionEntry: { sessionId: "media", updatedAt: 0 },
       sessionKey: "agent:main:main",
@@ -168,8 +168,8 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Media: image ok (openai/gpt-5.2) · audio skipped (maxBytes)");
   });
 
-  it("omits media line when all decisions are none", () => {
-    const text = buildStatusMessage({
+  it("omits media line when all decisions are none", async () => {
+    const text = await buildStatusMessage({
       agent: { model: "anthropic/claude-opus-4-5" },
       sessionEntry: { sessionId: "media-none", updatedAt: 0 },
       sessionKey: "agent:main:main",
@@ -184,8 +184,8 @@ describe("buildStatusMessage", () => {
     expect(normalizeTestText(text)).not.toContain("Media:");
   });
 
-  it("does not show elevated label when session explicitly disables it", () => {
-    const text = buildStatusMessage({
+  it("does not show elevated label when session explicitly disables it", async () => {
+    const text = await buildStatusMessage({
       agent: { model: "anthropic/claude-opus-4-5", elevatedDefault: "on" },
       sessionEntry: { sessionId: "v1", updatedAt: 0, elevatedLevel: "off" },
       sessionKey: "agent:main:main",
@@ -200,8 +200,8 @@ describe("buildStatusMessage", () => {
     expect(optionsLine).not.toContain("elevated");
   });
 
-  it("shows selected model and active runtime model when they differ", () => {
-    const text = buildStatusMessage({
+  it("shows selected model and active runtime model when they differ", async () => {
+    const text = await buildStatusMessage({
       agent: {
         model: "anthropic/claude-opus-4-5",
         contextTokens: 32_000,
@@ -234,8 +234,8 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("di_123...abc");
   });
 
-  it("omits active fallback details when runtime drift does not match fallback state", () => {
-    const text = buildStatusMessage({
+  it("omits active fallback details when runtime drift does not match fallback state", async () => {
+    const text = await buildStatusMessage({
       agent: {
         contextTokens: 32_000,
       },
@@ -263,8 +263,8 @@ describe("buildStatusMessage", () => {
     expect(normalized).not.toContain("(rate limit)");
   });
 
-  it("omits active lines when runtime matches selected model", () => {
-    const text = buildStatusMessage({
+  it("omits active lines when runtime matches selected model", async () => {
+    const text = await buildStatusMessage({
       agent: {
         model: "openai/gpt-4.1-mini",
         contextTokens: 32_000,
@@ -286,8 +286,8 @@ describe("buildStatusMessage", () => {
     expect(normalized).not.toContain("Fallback:");
   });
 
-  it("keeps provider prefix from session override model", () => {
-    const text = buildStatusMessage({
+  it("keeps provider prefix from session override model", async () => {
+    const text = await buildStatusMessage({
       agent: {},
       sessionEntry: {
         sessionId: "prefix-test",
@@ -303,8 +303,8 @@ describe("buildStatusMessage", () => {
     expect(normalizeTestText(text)).toContain("Model: google-antigravity/claude-sonnet-4-5");
   });
 
-  it("handles missing agent config gracefully", () => {
-    const text = buildStatusMessage({
+  it("handles missing agent config gracefully", async () => {
+    const text = await buildStatusMessage({
       agent: {},
       sessionScope: "per-sender",
       queue: { mode: "collect", depth: 0 },
@@ -317,8 +317,8 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Queue: collect");
   });
 
-  it("includes group activation for group sessions", () => {
-    const text = buildStatusMessage({
+  it("includes group activation for group sessions", async () => {
+    const text = await buildStatusMessage({
       agent: {},
       sessionEntry: {
         sessionId: "g1",
@@ -335,8 +335,8 @@ describe("buildStatusMessage", () => {
     expect(text).toContain("Activation: always");
   });
 
-  it("shows queue details when overridden", () => {
-    const text = buildStatusMessage({
+  it("shows queue details when overridden", async () => {
+    const text = await buildStatusMessage({
       agent: {},
       sessionEntry: { sessionId: "q1", updatedAt: 0 },
       sessionKey: "agent:main:main",
@@ -355,8 +355,8 @@ describe("buildStatusMessage", () => {
     expect(text).toContain("Queue: collect (depth 3 · debounce 2s · cap 5 · drop old)");
   });
 
-  it("inserts usage summary beneath context line", () => {
-    const text = buildStatusMessage({
+  it("inserts usage summary beneath context line", async () => {
+    const text = await buildStatusMessage({
       agent: { model: "anthropic/claude-opus-4-5", contextTokens: 32_000 },
       sessionEntry: { sessionId: "u1", updatedAt: 0, totalTokens: 1000 },
       sessionKey: "agent:main:main",
@@ -372,8 +372,8 @@ describe("buildStatusMessage", () => {
     expect(lines[contextIndex + 1]).toContain("Usage: Claude 80% left (5h)");
   });
 
-  it("hides cost when not using an API key", () => {
-    const text = buildStatusMessage({
+  it("hides cost when not using an API key", async () => {
+    const text = await buildStatusMessage({
       config: {} as unknown as RemoteClawConfig,
       agent: { model: "anthropic/claude-opus-4-5" },
       sessionEntry: { sessionId: "c1", updatedAt: 0, inputTokens: 10 },
@@ -442,8 +442,8 @@ describe("buildStatusMessage", () => {
     });
   }
 
-  function buildTranscriptStatusText(params: { sessionId: string; sessionKey: string }) {
-    return buildStatusMessage({
+  async function buildTranscriptStatusText(params: { sessionId: string; sessionKey: string }) {
+    return await buildStatusMessage({
       agent: {
         model: "anthropic/claude-opus-4-5",
         contextTokens: 32_000,
@@ -472,7 +472,7 @@ describe("buildStatusMessage", () => {
           sessionId,
         });
 
-        const text = buildTranscriptStatusText({
+        const text = await buildTranscriptStatusText({
           sessionId,
           sessionKey: "agent:main:main",
         });
@@ -493,7 +493,7 @@ describe("buildStatusMessage", () => {
           sessionId,
         });
 
-        const text = buildTranscriptStatusText({
+        const text = await buildTranscriptStatusText({
           sessionId,
           sessionKey: "agent:worker1:telegram:12345",
         });
@@ -521,7 +521,7 @@ describe("buildStatusMessage", () => {
           },
         });
 
-        const text = buildStatusMessage({
+        const text = await buildStatusMessage({
           agent: {
             model: "anthropic/claude-opus-4-5",
             contextTokens: 32_000,

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -332,10 +332,10 @@ const formatMediaUnderstandingLine = (decisions?: ReadonlyArray<MediaUnderstandi
   return `📎 Media: ${parts.join(" · ")}`;
 };
 
-const formatVoiceModeLine = (
+const formatVoiceModeLine = async (
   config?: RemoteClawConfig,
   sessionEntry?: SessionEntry,
-): string | null => {
+): Promise<string | null> => {
   if (!config) {
     return null;
   }
@@ -349,13 +349,13 @@ const formatVoiceModeLine = (
   if (autoMode === "off") {
     return null;
   }
-  const provider = getTtsProvider(ttsConfig, prefsPath);
+  const provider = await getTtsProvider(ttsConfig, prefsPath);
   const maxLength = getTtsMaxLength(prefsPath);
   const summarize = isSummarizationEnabled(prefsPath) ? "on" : "off";
   return `🔊 Voice: ${autoMode} · provider=${provider} · limit=${maxLength} · summary=${summarize}`;
 };
 
-export function buildStatusMessage(args: StatusArgs): string {
+export async function buildStatusMessage(args: StatusArgs): Promise<string> {
   const now = args.now ?? Date.now();
   const entry = args.sessionEntry;
   // Model selection gutted in RemoteClaw — CLI runtimes own model selection.
@@ -560,7 +560,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   const usageCostLine =
     usagePair && costLine ? `${usagePair} · ${costLine}` : (usagePair ?? costLine);
   const mediaLine = formatMediaUnderstandingLine(args.mediaDecisions);
-  const voiceLine = formatVoiceModeLine(args.config, args.sessionEntry);
+  const voiceLine = await formatVoiceModeLine(args.config, args.sessionEntry);
 
   return [
     versionLine,

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -24,11 +24,15 @@ export const ttsHandlers: GatewayRequestHandlers = {
       const cfg = loadConfig();
       const config = resolveTtsConfig(cfg);
       const prefsPath = resolveTtsPrefsPath(config);
-      const provider = getTtsProvider(config, prefsPath);
+      const provider = await getTtsProvider(config, prefsPath);
       const autoMode = resolveTtsAutoMode({ config, prefsPath });
-      const fallbackProviders = resolveTtsProviderOrder(provider)
-        .slice(1)
-        .filter((candidate) => isTtsProviderConfigured(config, candidate));
+      const candidates = resolveTtsProviderOrder(provider).slice(1);
+      const fallbackProviders: string[] = [];
+      for (const candidate of candidates) {
+        if (await isTtsProviderConfigured(config, candidate)) {
+          fallbackProviders.push(candidate);
+        }
+      }
       respond(true, {
         enabled: isTtsEnabled(config, prefsPath),
         auto: autoMode,
@@ -36,9 +40,9 @@ export const ttsHandlers: GatewayRequestHandlers = {
         fallbackProvider: fallbackProviders[0] ?? null,
         fallbackProviders,
         prefsPath,
-        hasOpenAIKey: Boolean(resolveTtsApiKey(config, "openai")),
-        hasElevenLabsKey: Boolean(resolveTtsApiKey(config, "elevenlabs")),
-        edgeEnabled: isTtsProviderConfigured(config, "edge"),
+        hasOpenAIKey: Boolean(await resolveTtsApiKey(config, "openai")),
+        hasElevenLabsKey: Boolean(await resolveTtsApiKey(config, "elevenlabs")),
+        edgeEnabled: await isTtsProviderConfigured(config, "edge"),
       });
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
@@ -131,24 +135,24 @@ export const ttsHandlers: GatewayRequestHandlers = {
           {
             id: "openai",
             name: "OpenAI",
-            configured: Boolean(resolveTtsApiKey(config, "openai")),
+            configured: Boolean(await resolveTtsApiKey(config, "openai")),
             models: [...OPENAI_TTS_MODELS],
             voices: [...OPENAI_TTS_VOICES],
           },
           {
             id: "elevenlabs",
             name: "ElevenLabs",
-            configured: Boolean(resolveTtsApiKey(config, "elevenlabs")),
+            configured: Boolean(await resolveTtsApiKey(config, "elevenlabs")),
             models: ["eleven_multilingual_v2", "eleven_turbo_v2_5", "eleven_monolingual_v1"],
           },
           {
             id: "edge",
             name: "Edge TTS",
-            configured: isTtsProviderConfigured(config, "edge"),
+            configured: await isTtsProviderConfigured(config, "edge"),
             models: [],
           },
         ],
-        active: getTtsProvider(config, prefsPath),
+        active: await getTtsProvider(config, prefsPath),
       });
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { RemoteClawConfig } from "../config/config.js";
-import { withEnv } from "../test-utils/env.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import * as tts from "./tts.js";
 
 const { _test, resolveTtsConfig, maybeApplyTtsToPayload, getTtsProvider } = tts;
@@ -198,7 +198,7 @@ describe("tts", () => {
       messages: { tts: {} },
     };
 
-    it("selects provider based on available API keys", () => {
+    it("selects provider based on available API keys", async () => {
       const cases = [
         {
           env: {
@@ -230,11 +230,11 @@ describe("tts", () => {
       ] as const;
 
       for (const testCase of cases) {
-        withEnv(testCase.env, () => {
+        const provider = await withEnvAsync(testCase.env, async () => {
           const config = resolveTtsConfig(baseCfg);
-          const provider = getTtsProvider(config, testCase.prefsPath);
-          expect(provider).toBe(testCase.expected);
+          return getTtsProvider(config, testCase.prefsPath);
         });
+        expect(provider).toBe(testCase.expected);
       }
     });
   });

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -10,6 +10,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import path from "node:path";
+import { resolveApiKeyForProvider } from "../auth/provider-auth.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.js";
@@ -400,7 +401,10 @@ export function setTtsEnabled(prefsPath: string, enabled: boolean): void {
   setTtsAutoMode(prefsPath, enabled ? "always" : "off");
 }
 
-export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): TtsProvider {
+export async function getTtsProvider(
+  config: ResolvedTtsConfig,
+  prefsPath: string,
+): Promise<TtsProvider> {
   const prefs = readPrefs(prefsPath);
   if (prefs.tts?.provider) {
     return prefs.tts.provider;
@@ -409,10 +413,10 @@ export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): Tt
     return config.provider;
   }
 
-  if (resolveTtsApiKey(config, "openai")) {
+  if (await resolveTtsApiKey(config, "openai")) {
     return "openai";
   }
-  if (resolveTtsApiKey(config, "elevenlabs")) {
+  if (await resolveTtsApiKey(config, "elevenlabs")) {
     return "elevenlabs";
   }
   return "edge";
@@ -469,15 +473,41 @@ function resolveEdgeOutputFormat(config: ResolvedTtsConfig): string {
   return config.edge.outputFormat;
 }
 
-export function resolveTtsApiKey(
+function ttsProviderToAuthProvider(provider: TtsProvider): string {
+  switch (provider) {
+    case "openai":
+      return "openai";
+    case "elevenlabs":
+      return "elevenlabs";
+    default:
+      return provider;
+  }
+}
+
+export async function resolveTtsApiKey(
   config: ResolvedTtsConfig,
   provider: TtsProvider,
-): string | undefined {
+): Promise<string | undefined> {
+  // 1. Auth profile store (unified credential system)
+  if (provider !== "edge") {
+    try {
+      const auth = await resolveApiKeyForProvider({
+        provider: ttsProviderToAuthProvider(provider),
+      });
+      if (auth.apiKey) {
+        return auth.apiKey;
+      }
+    } catch {
+      // no profile or env var found — fall through to config
+    }
+  }
+
+  // 2. TTS-specific config fallback (backwards compat)
   if (provider === "elevenlabs") {
-    return config.elevenlabs.apiKey || process.env.ELEVENLABS_API_KEY || process.env.XI_API_KEY;
+    return config.elevenlabs.apiKey || undefined;
   }
   if (provider === "openai") {
-    return config.openai.apiKey || process.env.OPENAI_API_KEY;
+    return config.openai.apiKey || undefined;
   }
   return undefined;
 }
@@ -488,11 +518,14 @@ export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
   return [primary, ...TTS_PROVIDERS.filter((provider) => provider !== primary)];
 }
 
-export function isTtsProviderConfigured(config: ResolvedTtsConfig, provider: TtsProvider): boolean {
+export async function isTtsProviderConfigured(
+  config: ResolvedTtsConfig,
+  provider: TtsProvider,
+): Promise<boolean> {
   if (provider === "edge") {
     return config.edge.enabled;
   }
-  return Boolean(resolveTtsApiKey(config, provider));
+  return Boolean(await resolveTtsApiKey(config, provider));
 }
 
 function formatTtsProviderError(provider: TtsProvider, err: unknown): string {
@@ -522,7 +555,7 @@ export async function textToSpeech(params: {
     };
   }
 
-  const userProvider = getTtsProvider(config, prefsPath);
+  const userProvider = await getTtsProvider(config, prefsPath);
   const overrideProvider = params.overrides?.provider;
   const provider = overrideProvider ?? userProvider;
   const providers = resolveTtsProviderOrder(provider);
@@ -602,7 +635,7 @@ export async function textToSpeech(params: {
         };
       }
 
-      const apiKey = resolveTtsApiKey(config, provider);
+      const apiKey = await resolveTtsApiKey(config, provider);
       if (!apiKey) {
         errors.push(`${provider}: no API key`);
         continue;
@@ -688,7 +721,7 @@ export async function textToSpeechTelephony(params: {
     };
   }
 
-  const userProvider = getTtsProvider(config, prefsPath);
+  const userProvider = await getTtsProvider(config, prefsPath);
   const providers = resolveTtsProviderOrder(userProvider);
 
   const errors: string[] = [];
@@ -701,7 +734,7 @@ export async function textToSpeechTelephony(params: {
         continue;
       }
 
-      const apiKey = resolveTtsApiKey(config, provider);
+      const apiKey = await resolveTtsApiKey(config, provider);
       if (!apiKey) {
         errors.push(`${provider}: no API key`);
         continue;


### PR DESCRIPTION
## Summary

- Wires `resolveTtsApiKey` through `resolveApiKeyForProvider` so TTS providers (openai, elevenlabs) use the unified auth profile store as the primary credential source
- TTS-specific config (`messages.tts.{provider}.apiKey`) remains as a backwards-compatible fallback
- `resolveTtsApiKey` becomes async, cascading to `getTtsProvider`, `isTtsProviderConfigured`, `buildStatusMessage`, and their callers in gateway, commands, and status display

Closes #402

## Test plan

- [x] Typecheck passes (`tsgo` — 0 errors in src/)
- [x] Lint passes (`oxlint` — 0 errors)
- [x] All 876 tests pass across 95 test files
- [x] `getTtsProvider` test updated to async with `withEnvAsync`
- [x] `buildStatusMessage` tests updated to async (19 call sites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)