### PR TITLE
chore: remove phantom README-header.png from files array

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "CHANGELOG.md",
     "LICENSE",
     "remoteclaw.mjs",
-    "README-header.png",
     "README.md",
     "assets/",
     "dist/",


### PR DESCRIPTION
## Summary

- Remove non-existent `README-header.png` from the `files` array in `package.json`
- The file does not exist in the repository and is silently skipped during `npm publish`

Closes #481

## Test plan

- [x] Verified `README-header.png` does not exist in the repo
- [x] Verified no other references to `README-header.png` exist
- [x] Validated `package.json` is valid JSON after edit
- [x] Pre-commit hooks (format) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)