### PR TITLE
fix(docs): correct README logo image paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <p align="center">
     <picture>
-        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/docs/assets/remoteclaw-logo-text.png">
-        <img src="https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/docs/assets/remoteclaw-logo-text-dark.png" alt="RemoteClaw" width="500">
+        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/docs/public/assets/remoteclaw-logo-text.png">
+        <img src="https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/docs/public/assets/remoteclaw-logo-text-dark.png" alt="RemoteClaw" width="500">
     </picture>
 </p>
 


### PR DESCRIPTION
## Summary
- Fix broken logo images in README by correcting paths from `docs/assets/` to `docs/public/assets/` where the files actually reside

Closes #480

## Test plan
- [ ] Verify logo images render on the PR's README preview on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)