### PR TITLE
feat(channels): require STT/TTS auth credentials for voice-only channels

### DIFF
--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -1,5 +1,9 @@
 import { Type } from "@sinclair/typebox";
-import type { GatewayRequestHandlerOptions, RemoteClawPluginApi } from "remoteclaw/plugin-sdk";
+import {
+  validateVoiceCredentials,
+  type GatewayRequestHandlerOptions,
+  type RemoteClawPluginApi,
+} from "remoteclaw/plugin-sdk";
 import { registerVoiceCallCli } from "./src/cli.js";
 import {
   VoiceCallConfigSchema,
@@ -483,6 +487,19 @@ const voiceCallPlugin = {
         if (!config.enabled) {
           return;
         }
+
+        const credentials = await validateVoiceCredentials(api.config);
+        if (!credentials.stt.available) {
+          api.logger.warn(
+            "[voice-call] No STT credentials found. Voice calls require a speech-to-text provider (openai, groq, deepgram, google, or mistral).",
+          );
+        }
+        if (!credentials.tts.available) {
+          api.logger.warn(
+            "[voice-call] No TTS credentials found. Voice calls require a text-to-speech provider (openai, elevenlabs, or edge).",
+          );
+        }
+
         try {
           await ensureRuntime();
         } catch (err) {

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -170,6 +170,7 @@ export type ChannelGroupContext = {
 
 export type ChannelCapabilities = {
   chatTypes: Array<ChatType | "thread">;
+  voiceOnly?: boolean;
   polls?: boolean;
   reactions?: boolean;
   edit?: boolean;

--- a/src/channels/voice-credentials.test.ts
+++ b/src/channels/voice-credentials.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../auth/provider-auth.js", () => ({
+  resolveApiKeyForProvider: vi.fn(),
+}));
+
+vi.mock("../tts/tts.js", () => ({
+  resolveTtsConfig: vi.fn(() => ({
+    edge: { enabled: true },
+  })),
+  isTtsProviderConfigured: vi.fn(),
+  TTS_PROVIDERS: ["openai", "elevenlabs", "edge"],
+}));
+
+import { resolveApiKeyForProvider } from "../auth/provider-auth.js";
+import type { RemoteClawConfig } from "../config/config.js";
+import { isTtsProviderConfigured } from "../tts/tts.js";
+import {
+  checkSttCredentials,
+  checkTtsCredentials,
+  validateVoiceCredentials,
+} from "./voice-credentials.js";
+
+const mockResolveApiKey = vi.mocked(resolveApiKeyForProvider);
+const mockIsTtsConfigured = vi.mocked(isTtsProviderConfigured);
+
+const emptyCfg = {} as RemoteClawConfig;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("checkSttCredentials", () => {
+  it("returns available when a provider has a valid API key", async () => {
+    mockResolveApiKey.mockRejectedValueOnce(new Error("no key")); // openai
+    mockResolveApiKey.mockResolvedValueOnce({
+      apiKey: "gsk-test",
+      source: "profile:groq",
+      mode: "api-key",
+    }); // groq
+
+    const result = await checkSttCredentials();
+    expect(result.available).toBe(true);
+    expect(result.provider).toBe("groq");
+  });
+
+  it("returns unavailable when no provider has credentials", async () => {
+    mockResolveApiKey.mockRejectedValue(new Error("no key"));
+
+    const result = await checkSttCredentials();
+    expect(result.available).toBe(false);
+    expect(result.provider).toBeUndefined();
+  });
+
+  it("returns first available provider", async () => {
+    mockResolveApiKey.mockResolvedValueOnce({
+      apiKey: "sk-test",
+      source: "env:OPENAI_API_KEY",
+      mode: "api-key",
+    }); // openai
+
+    const result = await checkSttCredentials();
+    expect(result.available).toBe(true);
+    expect(result.provider).toBe("openai");
+  });
+
+  it("skips providers that return no apiKey", async () => {
+    mockResolveApiKey.mockResolvedValueOnce({
+      apiKey: undefined,
+      source: "env",
+      mode: "api-key",
+    }); // openai
+    mockResolveApiKey.mockRejectedValueOnce(new Error("no key")); // groq
+    mockResolveApiKey.mockResolvedValueOnce({
+      apiKey: "dg-test",
+      source: "profile:deepgram",
+      mode: "api-key",
+    }); // deepgram
+
+    const result = await checkSttCredentials();
+    expect(result.available).toBe(true);
+    expect(result.provider).toBe("deepgram");
+  });
+});
+
+describe("checkTtsCredentials", () => {
+  it("returns available when edge TTS is enabled", async () => {
+    mockIsTtsConfigured.mockResolvedValueOnce(false); // openai
+    mockIsTtsConfigured.mockResolvedValueOnce(false); // elevenlabs
+    mockIsTtsConfigured.mockResolvedValueOnce(true); // edge
+
+    const result = await checkTtsCredentials(emptyCfg);
+    expect(result.available).toBe(true);
+    expect(result.provider).toBe("edge");
+  });
+
+  it("returns available when openai has credentials", async () => {
+    mockIsTtsConfigured.mockResolvedValueOnce(true); // openai
+
+    const result = await checkTtsCredentials(emptyCfg);
+    expect(result.available).toBe(true);
+    expect(result.provider).toBe("openai");
+  });
+
+  it("returns unavailable when no TTS provider is configured", async () => {
+    mockIsTtsConfigured.mockResolvedValue(false);
+
+    const result = await checkTtsCredentials(emptyCfg);
+    expect(result.available).toBe(false);
+    expect(result.provider).toBeUndefined();
+  });
+});
+
+describe("validateVoiceCredentials", () => {
+  it("reports both STT and TTS status", async () => {
+    mockResolveApiKey.mockRejectedValue(new Error("no key"));
+    mockIsTtsConfigured.mockResolvedValueOnce(true); // openai
+
+    const report = await validateVoiceCredentials(emptyCfg);
+    expect(report.stt.available).toBe(false);
+    expect(report.tts.available).toBe(true);
+    expect(report.tts.provider).toBe("openai");
+  });
+});

--- a/src/channels/voice-credentials.ts
+++ b/src/channels/voice-credentials.ts
@@ -1,0 +1,59 @@
+import { resolveApiKeyForProvider } from "../auth/provider-auth.js";
+import type { RemoteClawConfig } from "../config/config.js";
+import { AUTO_AUDIO_KEY_PROVIDERS } from "../stt/defaults.js";
+import { isTtsProviderConfigured, resolveTtsConfig, TTS_PROVIDERS } from "../tts/tts.js";
+
+export type VoiceCredentialStatus = {
+  available: boolean;
+  provider?: string;
+};
+
+export type VoiceCredentialReport = {
+  tts: VoiceCredentialStatus;
+  stt: VoiceCredentialStatus;
+};
+
+/**
+ * Check whether at least one STT provider has valid auth credentials.
+ *
+ * STT has no free fallback — at least one provider must be configured
+ * with a valid API key.
+ */
+export async function checkSttCredentials(): Promise<VoiceCredentialStatus> {
+  for (const provider of AUTO_AUDIO_KEY_PROVIDERS) {
+    try {
+      const auth = await resolveApiKeyForProvider({ provider });
+      if (auth.apiKey) {
+        return { available: true, provider };
+      }
+    } catch {
+      // no credentials for this provider — try next
+    }
+  }
+  return { available: false };
+}
+
+/**
+ * Check whether at least one TTS provider has valid auth credentials.
+ *
+ * Edge TTS is free (no API key needed) and counts as a valid provider.
+ */
+export async function checkTtsCredentials(cfg: RemoteClawConfig): Promise<VoiceCredentialStatus> {
+  const ttsConfig = resolveTtsConfig(cfg);
+  for (const provider of TTS_PROVIDERS) {
+    if (await isTtsProviderConfigured(ttsConfig, provider)) {
+      return { available: true, provider };
+    }
+  }
+  return { available: false };
+}
+
+/**
+ * Validate that both STT and TTS credentials are available for voice channels.
+ */
+export async function validateVoiceCredentials(
+  cfg: RemoteClawConfig,
+): Promise<VoiceCredentialReport> {
+  const [tts, stt] = await Promise.all([checkTtsCredentials(cfg), checkSttCredentials()]);
+  return { tts, stt };
+}

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -2,6 +2,7 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/ag
 import { listChannelPluginCatalogEntries } from "../../channels/plugins/catalog.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import type { ChannelId, ChannelSetupInput } from "../../channels/plugins/types.js";
+import { validateVoiceCredentials } from "../../channels/voice-credentials.js";
 import { writeConfigFile, type RemoteClawConfig } from "../../config/config.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
@@ -233,4 +234,23 @@ export async function channelsAddCommand(
 
   await writeConfigFile(nextConfig);
   runtime.log(`Added ${channelLabel(channel)} account "${accountId}".`);
+
+  const addedPlugin = getChannelPlugin(channel);
+  if (addedPlugin?.capabilities.voiceOnly) {
+    const report = await validateVoiceCredentials(nextConfig);
+    const warnings: string[] = [];
+    if (!report.stt.available) {
+      warnings.push(
+        "Warning: no STT credentials found. Voice channels require a speech-to-text provider.",
+      );
+    }
+    if (!report.tts.available) {
+      warnings.push(
+        "Warning: no TTS credentials found. Voice channels require a text-to-speech provider.",
+      );
+    }
+    for (const warning of warnings) {
+      runtime.log(warning);
+    }
+  }
 }

--- a/src/commands/channels/capabilities.ts
+++ b/src/commands/channels/capabilities.ts
@@ -81,6 +81,9 @@ function formatSupport(capabilities?: ChannelCapabilities) {
   if (capabilities.chatTypes?.length) {
     bits.push(`chatTypes=${capabilities.chatTypes.join(",")}`);
   }
+  if (capabilities.voiceOnly) {
+    bits.push("voiceOnly");
+  }
   if (capabilities.polls) {
     bits.push("polls");
   }

--- a/src/commands/doctor-voice.test.ts
+++ b/src/commands/doctor-voice.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../channels/voice-credentials.js", () => ({
+  validateVoiceCredentials: vi.fn(),
+}));
+
+vi.mock("../terminal/note.js", () => ({
+  note: vi.fn(),
+}));
+
+import { validateVoiceCredentials } from "../channels/voice-credentials.js";
+import type { RemoteClawConfig } from "../config/config.js";
+import { note } from "../terminal/note.js";
+import { noteVoiceChannelHealth } from "./doctor-voice.js";
+
+const mockValidate = vi.mocked(validateVoiceCredentials);
+const mockNote = vi.mocked(note);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function cfgWithVoiceCall(enabled?: boolean): RemoteClawConfig {
+  return {
+    plugins: {
+      entries: {
+        "voice-call": { enabled: enabled ?? true },
+      },
+    },
+  } as unknown as RemoteClawConfig;
+}
+
+describe("noteVoiceChannelHealth", () => {
+  it("skips when voice-call plugin is not configured", async () => {
+    await noteVoiceChannelHealth({} as RemoteClawConfig);
+    expect(mockValidate).not.toHaveBeenCalled();
+    expect(mockNote).not.toHaveBeenCalled();
+  });
+
+  it("skips when voice-call plugin is disabled", async () => {
+    await noteVoiceChannelHealth(cfgWithVoiceCall(false));
+    expect(mockValidate).not.toHaveBeenCalled();
+    expect(mockNote).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when both STT and TTS are available", async () => {
+    mockValidate.mockResolvedValue({
+      stt: { available: true, provider: "openai" },
+      tts: { available: true, provider: "edge" },
+    });
+
+    await noteVoiceChannelHealth(cfgWithVoiceCall());
+    expect(mockValidate).toHaveBeenCalled();
+    expect(mockNote).not.toHaveBeenCalled();
+  });
+
+  it("warns when STT credentials are missing", async () => {
+    mockValidate.mockResolvedValue({
+      stt: { available: false },
+      tts: { available: true, provider: "edge" },
+    });
+
+    await noteVoiceChannelHealth(cfgWithVoiceCall());
+    expect(mockNote).toHaveBeenCalledOnce();
+    const message = mockNote.mock.calls[0][0];
+    expect(message).toContain("STT");
+    expect(message).not.toContain("TTS: no credentials");
+  });
+
+  it("warns when TTS credentials are missing", async () => {
+    mockValidate.mockResolvedValue({
+      stt: { available: true, provider: "openai" },
+      tts: { available: false },
+    });
+
+    await noteVoiceChannelHealth(cfgWithVoiceCall());
+    expect(mockNote).toHaveBeenCalledOnce();
+    const message = mockNote.mock.calls[0][0];
+    expect(message).toContain("TTS");
+    expect(message).not.toContain("STT: no credentials");
+  });
+
+  it("warns when both STT and TTS credentials are missing", async () => {
+    mockValidate.mockResolvedValue({
+      stt: { available: false },
+      tts: { available: false },
+    });
+
+    await noteVoiceChannelHealth(cfgWithVoiceCall());
+    expect(mockNote).toHaveBeenCalledOnce();
+    const message = mockNote.mock.calls[0][0];
+    expect(message).toContain("STT");
+    expect(message).toContain("TTS");
+  });
+
+  it("uses 'Voice channel' as the note title", async () => {
+    mockValidate.mockResolvedValue({
+      stt: { available: false },
+      tts: { available: false },
+    });
+
+    await noteVoiceChannelHealth(cfgWithVoiceCall());
+    expect(mockNote).toHaveBeenCalledWith(expect.any(String), "Voice channel");
+  });
+});

--- a/src/commands/doctor-voice.ts
+++ b/src/commands/doctor-voice.ts
@@ -1,0 +1,40 @@
+import { validateVoiceCredentials } from "../channels/voice-credentials.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import type { RemoteClawConfig } from "../config/config.js";
+import { note } from "../terminal/note.js";
+
+function isVoiceCallPluginEnabled(cfg: RemoteClawConfig): boolean {
+  const entry = cfg.plugins?.entries?.["voice-call"];
+  if (!entry) {
+    return false;
+  }
+  return entry.enabled !== false;
+}
+
+export async function noteVoiceChannelHealth(cfg: RemoteClawConfig): Promise<void> {
+  if (!isVoiceCallPluginEnabled(cfg)) {
+    return;
+  }
+
+  const report = await validateVoiceCredentials(cfg);
+  const issues: string[] = [];
+
+  if (!report.stt.available) {
+    issues.push(
+      `- STT: no credentials found. Voice channels require a speech-to-text provider (openai, groq, deepgram, google, or mistral).`,
+    );
+  }
+
+  if (!report.tts.available) {
+    issues.push(
+      `- TTS: no credentials found. Voice channels require a text-to-speech provider (openai, elevenlabs, or edge).`,
+    );
+  }
+
+  if (issues.length > 0) {
+    issues.push(
+      `Configure auth via ${formatCliCommand("remoteclaw configure")} or set provider API keys.`,
+    );
+    note(issues.join("\n"), "Voice channel");
+  }
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -43,6 +43,7 @@ import {
 } from "./doctor-state-migrations.js";
 import { maybeRepairUiProtocolFreshness } from "./doctor-ui.js";
 import { maybeOfferUpdateBeforeDoctor } from "./doctor-update.js";
+import { noteVoiceChannelHealth } from "./doctor-voice.js";
 import { noteWorkspaceStatus } from "./doctor-workspace-status.js";
 import { applyWizardMetadata, printWizardHeader, randomToken } from "./onboard-helpers.js";
 import { ensureSystemdUserLingerInteractive } from "./systemd-linger.js";
@@ -111,6 +112,7 @@ export async function doctorCommand(
     prompter,
     allowKeychainPrompt: options.nonInteractive !== true && Boolean(process.stdin.isTTY),
   });
+  await noteVoiceChannelHealth(cfg);
   const gatewayDetails = buildGatewayConnectionDetails({ config: cfg });
   if (gatewayDetails.remoteFallbackNote) {
     note(gatewayDetails.remoteFallbackNote, "Gateway");

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -552,3 +552,14 @@ export { loadWebMedia, type WebMediaResult } from "../web/media.js";
 
 // Security utilities
 export { redactSensitiveText } from "../logging/redact.js";
+
+// Voice credential validation
+export {
+  checkSttCredentials,
+  checkTtsCredentials,
+  validateVoiceCredentials,
+} from "../channels/voice-credentials.js";
+export type {
+  VoiceCredentialReport,
+  VoiceCredentialStatus,
+} from "../channels/voice-credentials.js";


### PR DESCRIPTION
## Summary

- Add `voiceOnly` flag to `ChannelCapabilities` type and display it in capabilities output
- Create shared voice credential validation utilities (`checkSttCredentials`, `checkTtsCredentials`, `validateVoiceCredentials`) with plugin-sdk exports
- Validate credentials at three points: `remoteclaw channels add` (warns after adding voice-only channel), voice-call plugin service start (runtime warnings via logger), and `remoteclaw doctor` (health check note)
- Edge TTS counts as a valid free provider; STT has no free fallback and requires a configured provider key

Closes #471

## Test plan

- [x] Unit tests for `checkSttCredentials` — verifies provider iteration, error handling, first-available selection
- [x] Unit tests for `checkTtsCredentials` — verifies edge TTS counts as valid, provider iteration
- [x] Unit tests for `validateVoiceCredentials` — combined report
- [x] Unit tests for `noteVoiceChannelHealth` — skip when plugin absent/disabled, warn on missing STT/TTS/both
- [ ] Manual: `remoteclaw channels add voice-call` without STT credentials → warning printed
- [ ] Manual: `remoteclaw doctor` with voice-call enabled but missing credentials → note displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)