### PR TITLE
docs(start): refine NanoClaw and OpenClaw comparison pages

### DIFF
--- a/docs/start/nanoclaw-or-remoteclaw.mdx
+++ b/docs/start/nanoclaw-or-remoteclaw.mdx
@@ -10,7 +10,7 @@ import { TabItem, Tabs } from "@astrojs/starlight/components";
 
 # NanoClaw or RemoteClaw?
 
-NanoClaw and RemoteClaw both connect AI agents to messaging channels, but they take fundamentally different approaches. NanoClaw builds a new agent using the Anthropic Agent SDK and runs it in containers. RemoteClaw bridges your existing CLI agent as a subprocess.
+[NanoClaw](https://github.com/qwibitai/nanoclaw) and RemoteClaw both connect AI agents to messaging channels, but they take fundamentally different approaches. NanoClaw builds a new agent using the Anthropic Agent SDK and runs it in containers. RemoteClaw bridges your existing CLI agent as a subprocess.
 
 ## Quick decision
 
@@ -29,10 +29,10 @@ Use **NanoClaw**. It provides a purpose-built agent with strong sandboxing out o
 | Middleware-only architecture (no embedded LLM overhead)                                    | **RemoteClaw** |
 | MCP-first tool system (50 tools via MCP server)                                            | **RemoteClaw** |
 | 22+ messaging channels inherited from OpenClaw                                             | **RemoteClaw** |
-| Lightweight Claude agent with container isolation                                          | **NanoClaw**   |
+| Lightweight Claude agent with container-level sandboxing                                   | **NanoClaw**   |
 | Anthropic Agent SDK with built-in tool use                                                 | **NanoClaw**   |
-| Strong sandboxing via Docker/container boundaries                                          | **NanoClaw**   |
 | Minimal setup for a Claude-only workflow                                                   | **NanoClaw**   |
+| Fastest path from zero to a messaging agent (no CLI setup required)                        | **NanoClaw**   |
 
 ## Architecture comparison
 
@@ -67,19 +67,19 @@ Use **NanoClaw**. It provides a purpose-built agent with strong sandboxing out o
 
 ## Key differences
 
-| Dimension                | RemoteClaw                                              | NanoClaw                                       |
-| ------------------------ | ------------------------------------------------------- | ---------------------------------------------- |
-| **Agent model**          | CLI subprocess (your agent, your config)                | Anthropic Agent SDK (new agent instance)       |
-| **Runtime support**      | 4 runtimes (Claude, Gemini, Codex, OpenCode)            | Claude only                                    |
-| **Config preservation**  | Yes — uses your `~/.<agent>` directly                   | No — agent configured within NanoClaw          |
-| **Isolation model**      | Process isolation (subprocess boundary)                 | Container isolation (Docker boundary)          |
-| **Channels**             | 22+ (inherited from OpenClaw)                           | ~5 (WhatsApp, Telegram, Slack, Discord, Gmail) |
-| **MCP tools**            | 50 infrastructure-bound tools                           | Agent SDK built-in tools                       |
-| **Session management**   | File-based, per {channel, user, thread}                 | Built-in                                       |
-| **Subscription support** | Yes — CLI agents use your existing subscription or keys | API keys required (Agent SDK)                  |
+| Dimension               | RemoteClaw                                   | NanoClaw                                      |
+| ----------------------- | -------------------------------------------- | --------------------------------------------- |
+| **Agent model**         | CLI subprocess (your agent, your config)     | Anthropic Agent SDK (new agent instance)      |
+| **Runtime support**     | 4 runtimes (Claude, Gemini, Codex, OpenCode) | Claude only                                   |
+| **Config preservation** | Yes — uses your `~/.<agent>` directly        | No — agent configured within NanoClaw         |
+| **Authentication**      | Your existing CLI subscription or API keys   | API keys (Anthropic policy for Agent SDK)     |
+| **Isolation model**     | Process isolation (subprocess boundary)      | Container isolation (Docker boundary)         |
+| **Channels**            | 22+ (inherited from OpenClaw)                | 5 (WhatsApp, Telegram, Slack, Discord, Gmail) |
+| **MCP tools**           | 50 infrastructure-bound tools                | Agent SDK built-in tools                      |
+| **Session management**  | File-based, per {channel, user, thread}      | Built-in                                      |
 
 :::note
-Anthropic's terms of service restrict Agent SDK usage with Max/Pro subscription OAuth tokens and third-party tools. RemoteClaw spawns the real CLI binary, so your existing Claude subscription works as-is. NanoClaw uses the Agent SDK directly, which requires API keys.
+Anthropic restricts using the Agent SDK with consumer subscription plans (Max/Pro). This affects any project built on the Agent SDK, including NanoClaw. RemoteClaw spawns the CLI binary, which works with your existing subscription or API keys — whichever you have configured.
 :::
 
 ## When NanoClaw is the better fit
@@ -99,5 +99,6 @@ Anthropic's terms of service restrict Agent SDK usage with Max/Pro subscription 
 ## Learn more
 
 - [What is RemoteClaw?](/start/remoteclaw) — full setup guide
+- [Get started with NanoClaw](https://github.com/qwibitai/nanoclaw) — NanoClaw's repository
 - [OpenClaw or RemoteClaw?](/start/openclaw-or-remoteclaw) — comparison with OpenClaw
 - [Middleware Architecture](/concepts/middleware-architecture) — how RemoteClaw's architecture works

--- a/docs/start/openclaw-or-remoteclaw.mdx
+++ b/docs/start/openclaw-or-remoteclaw.mdx
@@ -10,7 +10,7 @@ import { TabItem, Tabs } from "@astrojs/starlight/components";
 
 # OpenClaw or RemoteClaw?
 
-RemoteClaw is a fork of OpenClaw that replaced the embedded AI execution engine with a middleware architecture. Both projects are actively maintained but serve different use cases.
+RemoteClaw is a fork of [OpenClaw](https://openclaw.ai) that replaced the embedded AI execution engine with a middleware architecture. Both projects serve different use cases.
 
 ## Quick decision
 
@@ -49,13 +49,13 @@ Use **OpenClaw**. It includes everything in one process.
     └── MCP server (injected into subprocess for gateway access)
     ```
 
-    The CLI agent owns the agentic loop. RemoteClaw handles session persistence, message delivery, and MCP tool bridging.
+    The CLI agent owns the agentic loop. RemoteClaw handles session persistence, message delivery, and MCP tool bridging. Your `~/.claude`, `~/.gemini`, or other agent config is preserved as-is.
 
   </TabItem>
   <TabItem label="OpenClaw">
     ```
     OpenClaw (single process)
-    ├── Pi execution engine (in-process LLM orchestration)
+    ├── Embedded execution engine (in-process LLM orchestration)
     ├── Model provider ecosystem (OpenAI, Anthropic, Google, etc.)
     ├── Tool execution (in-process)
     ├── Skills marketplace (ClawHub)
@@ -72,3 +72,9 @@ For a deeper architectural comparison, see [Middleware Architecture — How This
 ## Switching from OpenClaw
 
 If you decide to switch, see [Migrate from OpenClaw](/install/from-openclaw) for step-by-step instructions and [Breaking changes](/install/breaking-changes-from-openclaw) for what to expect.
+
+## Learn more
+
+- [What is RemoteClaw?](/start/remoteclaw) — full setup guide
+- [Get started with OpenClaw](https://openclaw.ai) — OpenClaw's official site
+- [Middleware Architecture](/concepts/middleware-architecture) — how RemoteClaw's architecture works


### PR DESCRIPTION
## Summary

- Add hyperlinks to NanoClaw repo and OpenClaw site in page intros
- Consolidate duplicate sandboxing rows and add authentication dimension to NanoClaw comparison table
- Rewrite Agent SDK subscription restriction note for clarity
- Rename internal "Pi execution engine" to "Embedded execution engine"
- Add "Learn more" sections and config preservation notes for consistency across both pages

## Test plan

- [ ] Verify docs build successfully
- [ ] Check links resolve (NanoClaw GitHub repo, OpenClaw site)
- [ ] Review table rendering in both comparison pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)