### PR TITLE
fix(docs): replace curly quotes in cli-backends.md frontmatter (#488)

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -1,9 +1,9 @@
 ---
-description: “CLI backends: text-only path via local AI CLIs”
+description: "CLI backends: text-only path via local AI CLIs"
 read_when:
   - You are configuring CLI backend settings (command path, session handling, image pass-through)
   - You need a text-only, tool-free path that still supports sessions and images
-title: “CLI Backends”
+title: "CLI Backends"
 ---
 
 # CLI backends
@@ -24,13 +24,13 @@ provides a text-only path through these CLIs:
 You can use Claude Code CLI **without any config** (RemoteClaw ships a built-in default):
 
 ```bash
-remoteclaw agent --message “hi” --model claude-cli/opus-4.6
+remoteclaw agent --message "hi" --model claude-cli/opus-4.6
 ```
 
 Codex CLI also works out of the box:
 
 ```bash
-remoteclaw agent --message “hi” --model codex-cli/gpt-5.3-codex
+remoteclaw agent --message "hi" --model codex-cli/gpt-5.3-codex
 ```
 
 If your gateway runs under launchd/systemd and PATH is minimal, add just the
@@ -41,8 +41,8 @@ command path:
   agents: {
     defaults: {
       cliBackends: {
-        “claude-cli”: {
-          command: “/opt/homebrew/bin/claude”,
+        "claude-cli": {
+          command: "/opt/homebrew/bin/claude",
         },
       },
     },


### PR DESCRIPTION
## Summary

- Replace Unicode curly quotes (U+201C / U+201D) with ASCII straight quotes in `docs/gateway/cli-backends.md`
- The curly quotes in the YAML frontmatter `description` and `title` fields caused the YAML parser to misinterpret colons as mapping separators, breaking docs-build CI on main

Closes #488

## Test plan

- [ ] `docs-build` CI job passes (the frontmatter YAML parses correctly)
- [ ] `build` and `test` CI jobs pass (no source changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)