### PR TITLE
ci(docs): rename docs-build job to docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  docs-build:
+  docs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,7 +44,7 @@ jobs:
 
   deploy:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    needs: docs-build
+    needs: docs
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary

- Renames the `docs-build` job to `docs` in `.github/workflows/docs.yml` for consistency with other CI job names (`build`, `test`, `lint`)
- Updates the `needs` reference in the `deploy` job accordingly
- Branch protection update (adding `docs` to required checks) will be applied via API after PR creation

**Note:** The Docs workflow uses `paths: ["docs/**"]` filtering, so the `docs` check will only run on PRs that touch files under `docs/`. For PRs that don't touch docs, the check won't trigger. This is a known consideration — a follow-up may be needed to handle path-filtered required checks (e.g., repository rulesets or a skip mechanism).

Closes #489

## Test plan

- [ ] Verify `docs` job name appears correctly in GitHub Actions
- [ ] Verify `deploy` job still depends on `docs` (was `docs-build`)
- [ ] Verify branch protection includes `docs` in required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)