### PR TITLE
fix(docs): remove dead Models sidebar section (#492)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -393,34 +393,6 @@ export default defineConfig({
           ],
         },
         {
-          label: "Models",
-          items: [
-            {
-              label: "Overview",
-              items: [{ slug: "providers/index" }, { slug: "providers/models" }],
-            },
-            {
-              label: "Providers",
-              items: [
-                { slug: "providers/anthropic" },
-                { slug: "providers/openai" },
-                { slug: "providers/openrouter" },
-                { slug: "providers/litellm" },
-                { slug: "providers/bedrock" },
-                { slug: "providers/vercel-ai-gateway" },
-                { slug: "providers/moonshot" },
-                { slug: "providers/mistral" },
-                { slug: "providers/minimax" },
-                { slug: "providers/opencode" },
-                { slug: "providers/glm" },
-                { slug: "providers/zai" },
-                { slug: "providers/synthetic" },
-                { slug: "providers/qianfan" },
-              ],
-            },
-          ],
-        },
-        {
           label: "Platforms",
           items: [
             {


### PR DESCRIPTION
## Summary

- Removes the entire "Models" sidebar group from `docs/astro.config.mjs` — all 16 provider slug references (`providers/index`, `providers/models`, `providers/anthropic`, etc.) point to content files that don't exist
- This was causing the Starlight docs build to fail with `AstroUserError: The slug "providers/index" specified in the Starlight sidebar config does not exist` on every push to main
- The only existing provider file (`providers/deepgram`) is already correctly referenced in the "Media and devices" section and is unaffected

Closes #492

## Test plan

- [x] Verified `providers/deepgram.md` is the only file in `docs/providers/` — no other provider content exists
- [x] Verified local docs build no longer fails on the sidebar slug error
- [ ] CI `docs` job passes (previously failing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)