### PR TITLE
ci(docs): add docs to branch protection required checks (#493)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,8 +6,6 @@ on:
     paths:
       - "docs/**"
   pull_request:
-    paths:
-      - "docs/**"
   workflow_dispatch:
 
 concurrency:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ GitHub Actions (`.github/workflows/ci.yml`):
 - **build** job: checkout, setup Node env, `pnpm build`
 - **test** job: checkout, setup Node env, canvas bundle, `pnpm test`
 - Both run on `ubuntu-latest` with Node 22 and pnpm 10.23.0
-- Branch protection requires both `build` and `test` to pass
+- Branch protection requires `build`, `test`, `lint`, and `docs` to pass
 
 ## Security
 


### PR DESCRIPTION
## Summary

- Remove `paths` filter from the `pull_request` trigger in the docs workflow so the `docs` check runs on all PRs (not just those touching `docs/`)
- Add `docs` to branch protection required status checks (via API, post-merge)

Without removing the paths filter, PRs that don't touch `docs/` never produce a `docs` check — blocking merge when `docs` is required.

The `push` trigger retains its `paths` filter so deployments only happen when docs actually change on main.

**Note**: The `docs` check will fail on this PR due to a pre-existing MDX build error on main — that's being fixed separately. The current required checks (build, test, lint) are unaffected.

Closes #493

## Test plan

- [ ] Verify `docs` workflow triggers on this PR (even though it doesn't touch `docs/`)
- [ ] After merge, add `docs` to required status checks via GitHub API

🤖 Generated with [Claude Code](https://claude.com/claude-code)