### PR TITLE
docs(start): reframe comparison pages as "coming from" guides

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -186,8 +186,8 @@ export default defineConfig({
               label: "Guides",
               items: [
                 { slug: "start/remoteclaw" },
-                { slug: "start/openclaw-or-remoteclaw" },
-                { slug: "start/nanoclaw-or-remoteclaw" },
+                { slug: "start/openclaw-or-remoteclaw", label: "Coming from OpenClaw" },
+                { slug: "start/nanoclaw-or-remoteclaw", label: "Coming from NanoClaw" },
               ],
             },
           ],

--- a/docs/start/nanoclaw-or-remoteclaw.mdx
+++ b/docs/start/nanoclaw-or-remoteclaw.mdx
@@ -1,40 +1,35 @@
 ---
-description: "Compare NanoClaw and RemoteClaw: Anthropic Agent SDK vs CLI subprocess middleware, container isolation vs process isolation, and when each is the right choice."
+description: "What changes when you switch from NanoClaw to RemoteClaw: CLI subprocess replaces Anthropic Agent SDK, process isolation replaces container isolation, and what you gain."
 read_when:
-  - You are evaluating whether to use NanoClaw or RemoteClaw
-  - You want to understand the trade-offs between the two projects
-title: "NanoClaw or RemoteClaw? Decision Guide for AI Agent Middleware"
+  - You are coming from NanoClaw and want to understand what RemoteClaw does differently
+  - You want to know what to expect when switching from NanoClaw
+title: "Coming from NanoClaw"
 ---
 
 import { TabItem, Tabs } from "@astrojs/starlight/components";
 
-# NanoClaw or RemoteClaw?
+# Coming from NanoClaw
 
-[NanoClaw](https://github.com/qwibitai/nanoclaw) and RemoteClaw both connect AI agents to messaging channels, but they take fundamentally different approaches. NanoClaw builds a new agent using the Anthropic Agent SDK and runs it in containers. RemoteClaw bridges your existing CLI agent as a subprocess.
+[NanoClaw](https://github.com/qwibitai/nanoclaw) and RemoteClaw both connect AI agents to messaging channels, but they take fundamentally different approaches. If you're coming from NanoClaw, here's what changes.
 
-## Quick decision
+## The key difference
 
-**Already using Claude Code, Gemini CLI, Codex CLI, or OpenCode with your own config?**
-Use **RemoteClaw**. It connects your existing agent to messaging channels without replacing it.
+NanoClaw builds a new agent using the Anthropic Agent SDK and runs it in containers. RemoteClaw bridges your **existing** CLI agent as a subprocess — your `~/.claude`, `~/.gemini`, or other agent config is preserved as-is.
 
-**Want a lightweight, security-hardened Claude agent with container isolation?**
-Use **NanoClaw**. It provides a purpose-built agent with strong sandboxing out of the box.
+## What you gain
 
-## Decision tree
+- **Multi-runtime support.** NanoClaw is Claude-only via the Anthropic Agent SDK. RemoteClaw supports 4 CLI runtimes: Claude Code, Gemini CLI, Codex CLI, and OpenCode. Switch runtimes via config, no rebuild needed.
+- **20+ messaging channels.** NanoClaw supports WhatsApp, Telegram, Slack, Discord, and Gmail. RemoteClaw inherits OpenClaw's full adapter library.
+- **Your existing config.** RemoteClaw uses your `~/.<agent>` directly. No need to reconfigure your agent inside a new framework.
+- **Subscription compatibility.** RemoteClaw spawns the CLI binary, so your existing Claude subscription or API keys work as-is.
+- **50+ MCP tools.** Infrastructure-bound tools for sessions, messaging, cron, gateway, and more.
 
-| If you want…                                                                               | Choose         |
-| ------------------------------------------------------------------------------------------ | -------------- |
-| Connect an existing CLI agent (Claude, Gemini, Codex, OpenCode) to WhatsApp/Telegram/Slack | **RemoteClaw** |
-| Switch between multiple agent runtimes via config                                          | **RemoteClaw** |
-| Middleware-only architecture (no embedded LLM overhead)                                    | **RemoteClaw** |
-| MCP-first tool system (50 tools via MCP server)                                            | **RemoteClaw** |
-| 22+ messaging channels inherited from OpenClaw                                             | **RemoteClaw** |
-| Lightweight Claude agent with container-level sandboxing                                   | **NanoClaw**   |
-| Anthropic Agent SDK with built-in tool use                                                 | **NanoClaw**   |
-| Minimal setup for a Claude-only workflow                                                   | **NanoClaw**   |
-| Fastest path from zero to a messaging agent (no CLI setup required)                        | **NanoClaw**   |
+## What you trade off
 
-## Architecture comparison
+- **Container isolation.** NanoClaw runs agents in containers with strong sandbox boundaries. RemoteClaw uses process isolation — the agent runs as a subprocess on your host. If container-level sandboxing is a hard requirement, NanoClaw may be the better fit.
+- **Bring-your-own-agent not required.** NanoClaw provides a pre-configured Claude agent. RemoteClaw requires you to have a CLI agent installed and configured first.
+
+## Architecture side by side
 
 <Tabs>
   <TabItem label="RemoteClaw">
@@ -48,14 +43,14 @@ Use **NanoClaw**. It provides a purpose-built agent with strong sandboxing out o
     └── MCP server (injected into subprocess for gateway access)
     ```
 
-    The CLI agent owns the agentic loop. RemoteClaw handles session persistence, message delivery, and MCP tool bridging. Your `~/.claude`, `~/.gemini`, or other agent config is preserved as-is.
+    The CLI agent owns the agentic loop. RemoteClaw handles session persistence, message delivery, and MCP tool bridging.
 
   </TabItem>
   <TabItem label="NanoClaw">
     ```
     NanoClaw (containerized agent)
     ├── Anthropic Agent SDK (Claude-only orchestration)
-    ├── Container isolation (Docker-based sandboxing)
+    ├── Container isolation (container-based sandboxing)
     ├── Built-in tool use (via Agent SDK)
     └── Channel adapters (WhatsApp, Telegram, Slack, Discord, Gmail)
     ```
@@ -65,40 +60,26 @@ Use **NanoClaw**. It provides a purpose-built agent with strong sandboxing out o
   </TabItem>
 </Tabs>
 
-## Key differences
+## Key differences at a glance
 
-| Dimension               | RemoteClaw                                   | NanoClaw                                      |
-| ----------------------- | -------------------------------------------- | --------------------------------------------- |
-| **Agent model**         | CLI subprocess (your agent, your config)     | Anthropic Agent SDK (new agent instance)      |
-| **Runtime support**     | 4 runtimes (Claude, Gemini, Codex, OpenCode) | Claude only                                   |
-| **Config preservation** | Yes — uses your `~/.<agent>` directly        | No — agent configured within NanoClaw         |
-| **Authentication**      | Your existing CLI subscription or API keys   | API keys (Anthropic policy for Agent SDK)     |
-| **Isolation model**     | Process isolation (subprocess boundary)      | Container isolation (Docker boundary)         |
-| **Channels**            | 22+ (inherited from OpenClaw)                | 5 (WhatsApp, Telegram, Slack, Discord, Gmail) |
-| **MCP tools**           | 50 infrastructure-bound tools                | Agent SDK built-in tools                      |
-| **Session management**  | File-based, per {channel, user, thread}      | Built-in                                      |
+| Dimension           | RemoteClaw                                   | NanoClaw                                  |
+| ------------------- | -------------------------------------------- | ----------------------------------------- |
+| **Agent model**     | CLI subprocess (your agent, your config)     | Anthropic Agent SDK (new agent instance)  |
+| **Runtime support** | 4 runtimes (Claude, Gemini, Codex, OpenCode) | Claude only                               |
+| **Config**          | Uses your `~/.<agent>` directly              | Agent configured within NanoClaw          |
+| **Authentication**  | Your existing CLI subscription or API keys   | API keys (Anthropic policy for Agent SDK) |
+| **Isolation**       | Process isolation (subprocess boundary)      | Container isolation (container boundary)  |
+| **Channels**        | 20+ (inherited from OpenClaw)                | WhatsApp, Telegram, Slack, Discord, Gmail |
+| **MCP tools**       | 50+ infrastructure-bound tools               | Agent SDK built-in tools                  |
 
 :::note
 Anthropic restricts using the Agent SDK with consumer subscription plans (Max/Pro). This affects any project built on the Agent SDK, including NanoClaw. RemoteClaw spawns the CLI binary, which works with your existing subscription or API keys — whichever you have configured.
 :::
 
-## When NanoClaw is the better fit
+## Next steps
 
-- You only need Claude and want the simplest possible setup
-- Container-level isolation is a hard requirement for your deployment
-- You don't have an existing CLI agent config you want to preserve
-- You prefer the Anthropic Agent SDK's built-in tool system
-
-## When RemoteClaw is the better fit
-
-- You already have a configured CLI agent (`~/.claude`, `~/.gemini`, etc.)
-- You want to switch between multiple agent runtimes without rebuilding
-- You need more than 5 messaging channels
-- You want middleware that stays out of the agent's way — no LLM layer between you and your agent
-
-## Learn more
-
-- [What is RemoteClaw?](/start/remoteclaw) — full setup guide
-- [Get started with NanoClaw](https://github.com/qwibitai/nanoclaw) — NanoClaw's repository
-- [OpenClaw or RemoteClaw?](/start/openclaw-or-remoteclaw) — comparison with OpenClaw
+- [Get started with RemoteClaw](/start/getting-started) — install and configure
+- [Personal Assistant Setup](/start/remoteclaw) — full setup guide
 - [Middleware Architecture](/concepts/middleware-architecture) — how RemoteClaw's architecture works
+
+If RemoteClaw isn't the right fit, [NanoClaw](https://github.com/qwibitai/nanoclaw) is a great choice if you want a lightweight, security-hardened Claude agent with container isolation and minimal setup.

--- a/docs/start/openclaw-or-remoteclaw.mdx
+++ b/docs/start/openclaw-or-remoteclaw.mdx
@@ -1,41 +1,34 @@
 ---
-description: "Compare OpenClaw and RemoteClaw: middleware architecture vs embedded engine, CLI subprocess vs in-process, and when each is the right choice."
+description: "What changes when you switch from OpenClaw to RemoteClaw: middleware architecture replaces the embedded engine, CLI subprocess replaces in-process execution, and what you keep."
 read_when:
-  - You are evaluating whether to use OpenClaw or RemoteClaw
-  - You want to understand the trade-offs between the two projects
-title: "OpenClaw or RemoteClaw? Decision Guide for AI Agent Middleware"
+  - You are coming from OpenClaw and want to understand what RemoteClaw changes
+  - You want to know what to expect when switching from OpenClaw
+title: "Coming from OpenClaw"
 ---
 
 import { TabItem, Tabs } from "@astrojs/starlight/components";
 
-# OpenClaw or RemoteClaw?
+# Coming from OpenClaw
 
-RemoteClaw is a fork of [OpenClaw](https://openclaw.ai) that replaced the embedded AI execution engine with a middleware architecture. Both projects serve different use cases.
+RemoteClaw is a fork of [OpenClaw](https://openclaw.ai) that replaced the embedded AI execution engine with a middleware architecture. If you're coming from OpenClaw, here's what changes and what stays the same.
 
-## Quick decision
+## What stays
 
-**Already using Claude Code, Gemini CLI, Codex CLI, or OpenCode?**
-Use **RemoteClaw**. It connects your existing agent to messaging channels without adding another LLM layer.
+RemoteClaw inherits OpenClaw's channel infrastructure. The 20+ messaging adapters (WhatsApp, Telegram, Discord, Slack, iMessage, and more), the gateway, the plugin system, and the native apps all carry over. Your channel configurations import directly.
 
-**Want a self-contained platform with built-in model providers and a skills marketplace?**
-Use **OpenClaw**. It includes everything in one process.
+## What changes
 
-## Decision tree
+RemoteClaw gutted OpenClaw's embedded execution engine and replaced it with a CLI subprocess bridge. Instead of running an LLM inside its own process, RemoteClaw launches your existing CLI agent (Claude Code, Gemini CLI, Codex CLI, or OpenCode) as a subprocess.
 
-| If you want…                                                                               | Choose         |
-| ------------------------------------------------------------------------------------------ | -------------- |
-| Connect an existing CLI agent (Claude, Gemini, Codex, OpenCode) to WhatsApp/Telegram/Slack | **RemoteClaw** |
-| Switch between multiple agent runtimes via config                                          | **RemoteClaw** |
-| Middleware-only architecture (no embedded LLM overhead)                                    | **RemoteClaw** |
-| MCP-first tool system (50 tools via MCP server)                                            | **RemoteClaw** |
-| Subprocess isolation (agent crashes don't crash the gateway)                               | **RemoteClaw** |
-| Consumer onboarding wizard with 30+ LLM provider picker                                    | **OpenClaw**   |
-| Built-in skills marketplace (ClawHub)                                                      | **OpenClaw**   |
-| In-process model catalog (switch between OpenAI, Anthropic, Google, etc.)                  | **OpenClaw**   |
-| Docker sandbox for code execution                                                          | **OpenClaw**   |
-| Centralized OAuth for all providers                                                        | **OpenClaw**   |
+This means:
 
-## Architecture comparison
+- **Your agent config is preserved.** Your `~/.claude`, `~/.gemini`, or other agent setup works as-is — no reconfiguration inside RemoteClaw.
+- **No built-in model catalog.** OpenClaw ships many LLM providers with a picker wizard. RemoteClaw delegates model selection entirely to your CLI agent.
+- **No skills marketplace.** ClawHub and the skills system are removed. Agents bring their own capabilities via MCP or built-in tools.
+- **No Docker sandbox.** Agents manage their own sandboxing. RemoteClaw provides process isolation via the subprocess boundary.
+- **No provider auth management.** Agents use their own API keys or subscriptions via environment variables.
+
+## Architecture side by side
 
 <Tabs>
   <TabItem label="RemoteClaw">
@@ -49,7 +42,7 @@ Use **OpenClaw**. It includes everything in one process.
     └── MCP server (injected into subprocess for gateway access)
     ```
 
-    The CLI agent owns the agentic loop. RemoteClaw handles session persistence, message delivery, and MCP tool bridging. Your `~/.claude`, `~/.gemini`, or other agent config is preserved as-is.
+    The CLI agent owns the agentic loop. RemoteClaw handles session persistence, message delivery, and MCP tool bridging.
 
   </TabItem>
   <TabItem label="OpenClaw">
@@ -69,12 +62,8 @@ Use **OpenClaw**. It includes everything in one process.
 
 For a deeper architectural comparison, see [Middleware Architecture — How This Differs from OpenClaw](/concepts/middleware-architecture#how-this-differs-from-openclaw).
 
-## Switching from OpenClaw
+## Ready to switch?
 
-If you decide to switch, see [Migrate from OpenClaw](/install/from-openclaw) for step-by-step instructions and [Breaking changes](/install/breaking-changes-from-openclaw) for what to expect.
+See [Migrate from OpenClaw](/install/from-openclaw) for step-by-step instructions and [Breaking changes](/install/breaking-changes-from-openclaw) for the full list of what's removed and what's new.
 
-## Learn more
-
-- [What is RemoteClaw?](/start/remoteclaw) — full setup guide
-- [Get started with OpenClaw](https://openclaw.ai) — OpenClaw's official site
-- [Middleware Architecture](/concepts/middleware-architecture) — how RemoteClaw's architecture works
+If RemoteClaw isn't the right fit, [OpenClaw](https://openclaw.ai) remains a great choice for anyone who wants a self-contained platform with built-in model providers and a skills marketplace.


### PR DESCRIPTION
## Summary

- Reframes NanoClaw and OpenClaw comparison pages from neutral "decision guide" format to onboarding-oriented "Coming from X" pages
- Restructures content around what you gain, what you trade off, and what stays — instead of symmetric feature tables
- Adds explicit sidebar labels ("Coming from OpenClaw", "Coming from NanoClaw") for clarity

## Test plan

- [ ] Verify docs build passes in CI
- [ ] Check sidebar labels render correctly in Starlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)