### PR TITLE
feat(plugin-sdk): allow extensions to register custom STT providers

### DIFF
--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -69,6 +69,7 @@ const createRegistry = (channels: PluginRegistry["channels"]): PluginRegistry =>
   commands: [],
   channels,
   providers: [],
+  sttProviders: [],
   gatewayHandlers: {},
   httpHandlers: [],
   httpRoutes: [],

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -107,6 +107,9 @@ function formatPluginLine(plugin: PluginRecord, verbose = false): string {
   if (plugin.providerIds.length > 0) {
     parts.push(`  providers: ${plugin.providerIds.join(", ")}`);
   }
+  if (plugin.sttProviderIds.length > 0) {
+    parts.push(`  stt: ${plugin.sttProviderIds.join(", ")}`);
+  }
   if (plugin.error) {
     parts.push(theme.error(`  error: ${plugin.error}`));
   }
@@ -301,6 +304,9 @@ export function registerPluginsCli(program: Command) {
       }
       if (plugin.providerIds.length > 0) {
         lines.push(`${theme.muted("Providers:")} ${plugin.providerIds.join(", ")}`);
+      }
+      if (plugin.sttProviderIds.length > 0) {
+        lines.push(`${theme.muted("STT providers:")} ${plugin.sttProviderIds.join(", ")}`);
       }
       if (plugin.cliCommands.length > 0) {
         lines.push(`${theme.muted("CLI commands:")} ${plugin.cliCommands.join(", ")}`);

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -11,6 +11,7 @@ function makeRegistry(plugins: Array<{ id: string; channels: string[] }>): Plugi
       channels: p.channels,
       providers: [],
       skills: [],
+      stt: [],
       origin: "config" as const,
       rootDir: `/fake/${p.id}`,
       source: `/fake/${p.id}/index.js`,

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -17,6 +17,7 @@ const createRegistry = (diagnostics: PluginDiagnostic[]): PluginRegistry => ({
   channels: [],
   commands: [],
   providers: [],
+  sttProviders: [],
   gatewayHandlers: {},
   httpHandlers: [],
   httpRoutes: [],

--- a/src/gateway/test-helpers.mocks.ts
+++ b/src/gateway/test-helpers.mocks.ts
@@ -145,6 +145,7 @@ const createStubPluginRegistry = (): PluginRegistry => ({
     },
   ],
   providers: [],
+  sttProviders: [],
   gatewayHandlers: {},
   httpHandlers: [],
   httpRoutes: [],

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -14,6 +14,7 @@ import type {
 } from "../config/types.tools.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { resolvePreferredRemoteClawTmpDir } from "../infra/tmp-remoteclaw-dir.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { runExec } from "../process/exec.js";
 import { buildSttProviderRegistry, transcribeAudioWithProvider } from "../stt/stt.js";
 import type { SttProvider } from "../stt/types.js";
@@ -329,7 +330,8 @@ export async function runProviderEntry(params: {
         };
       }
     }
-    const sttRegistry = buildSttProviderRegistry(sttOverrides);
+    const pluginSttProviders = getActivePluginRegistry()?.sttProviders.map((r) => r.provider);
+    const sttRegistry = buildSttProviderRegistry(sttOverrides, pluginSttProviders);
     const result = await transcribeAudioWithProvider({
       buffer: media.buffer,
       fileName: media.fileName,

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -553,6 +553,13 @@ export { loadWebMedia, type WebMediaResult } from "../web/media.js";
 // Security utilities
 export { redactSensitiveText } from "../logging/redact.js";
 
+// STT provider types
+export type {
+  AudioTranscriptionRequest,
+  AudioTranscriptionResult,
+  SttProvider,
+} from "../stt/types.js";
+
 // Voice credential validation
 export {
   checkSttCredentials,

--- a/src/plugins/dead-hooks.test.ts
+++ b/src/plugins/dead-hooks.test.ts
@@ -24,6 +24,7 @@ function makeRecord(overrides?: Partial<PluginRecord>): PluginRecord {
     hookNames: [],
     channelIds: [],
     providerIds: [],
+    sttProviderIds: [],
     gatewayMethods: [],
     cliCommands: [],
     services: [],

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -162,6 +162,7 @@ function createPluginRecord(params: {
     hookNames: [],
     channelIds: [],
     providerIds: [],
+    sttProviderIds: [],
     gatewayMethods: [],
     cliCommands: [],
     services: [],

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -29,6 +29,7 @@ export type PluginManifestRecord = {
   channels: string[];
   providers: string[];
   skills: string[];
+  stt: string[];
   origin: PluginOrigin;
   workspaceDir?: string;
   rootDir: string;
@@ -120,6 +121,7 @@ function buildRecord(params: {
     channels: params.manifest.channels ?? [],
     providers: params.manifest.providers ?? [],
     skills: params.manifest.skills ?? [],
+    stt: params.manifest.stt ?? [],
     origin: params.candidate.origin,
     workspaceDir: params.candidate.workspaceDir,
     rootDir: params.candidate.rootDir,

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -21,6 +21,7 @@ export type PluginManifest = {
   channels?: string[];
   providers?: string[];
   skills?: string[];
+  stt?: string[];
   name?: string;
   description?: string;
   version?: string;
@@ -82,6 +83,7 @@ export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
   const channels = normalizeStringList(raw.channels);
   const providers = normalizeStringList(raw.providers);
   const skills = normalizeStringList(raw.skills);
+  const stt = normalizeStringList(raw.stt);
 
   let uiHints: Record<string, PluginConfigUiHint> | undefined;
   if (isRecord(raw.uiHints)) {
@@ -97,6 +99,7 @@ export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
       channels,
       providers,
       skills,
+      stt,
       name,
       description,
       version,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -8,6 +8,7 @@ import type {
 } from "../gateway/server-methods/types.js";
 import { registerInternalHook } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
+import type { SttProvider } from "../stt/types.js";
 import { resolveUserPath } from "../utils.js";
 import { registerPluginCommand } from "./commands.js";
 import { normalizePluginHttpPath } from "./http-path.js";
@@ -94,6 +95,12 @@ export type PluginCommandRegistration = {
   source: string;
 };
 
+export type PluginSttProviderRegistration = {
+  pluginId: string;
+  provider: SttProvider;
+  source: string;
+};
+
 export type PluginRecord = {
   id: string;
   name: string;
@@ -112,6 +119,7 @@ export type PluginRecord = {
   providerIds: string[];
   gatewayMethods: string[];
   cliCommands: string[];
+  sttProviderIds: string[];
   services: string[];
   commands: string[];
   httpHandlers: number;
@@ -128,6 +136,7 @@ export type PluginRegistry = {
   typedHooks: TypedPluginHookRegistration[];
   channels: PluginChannelRegistration[];
   providers: PluginProviderRegistration[];
+  sttProviders: PluginSttProviderRegistration[];
   gatewayHandlers: GatewayRequestHandlers;
   httpHandlers: PluginHttpRegistration[];
   httpRoutes: PluginHttpRouteRegistration[];
@@ -151,6 +160,7 @@ export function createEmptyPluginRegistry(): PluginRegistry {
     typedHooks: [],
     channels: [],
     providers: [],
+    sttProviders: [],
     gatewayHandlers: {},
     httpHandlers: [],
     httpRoutes: [],
@@ -453,6 +463,34 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     });
   };
 
+  const registerSttProvider = (record: PluginRecord, provider: SttProvider) => {
+    const id = provider.id.trim();
+    if (!id) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: "STT provider registration missing id",
+      });
+      return;
+    }
+    if (registry.sttProviders.some((entry) => entry.provider.id === id)) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `STT provider already registered: ${id}`,
+      });
+      return;
+    }
+    record.sttProviderIds.push(id);
+    registry.sttProviders.push({
+      pluginId: record.id,
+      provider,
+      source: record.source,
+    });
+  };
+
   const registerTypedHook = <K extends PluginHookName>(
     record: PluginRecord,
     hookName: K,
@@ -503,6 +541,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       registerCli: (registrar, opts) => registerCli(record, registrar, opts),
       registerService: (service) => registerService(record, service),
       registerCommand: (command) => registerCommand(record, command),
+      registerSttProvider: (provider) => registerSttProvider(record, provider),
       resolvePath: (input: string) => resolveUserPath(input),
       on: (hookName, handler, opts) => {
         if (DEAD_HOOKS.has(hookName as string)) {
@@ -532,6 +571,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     registerCli,
     registerService,
     registerCommand,
+    registerSttProvider,
     registerHook,
     registerTypedHook,
   };

--- a/src/plugins/stt-providers.test.ts
+++ b/src/plugins/stt-providers.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RemoteClawConfig } from "../config/config.js";
+import { createPluginRegistry, type PluginRecord } from "./registry.js";
+import type { PluginRuntime } from "./runtime/types.js";
+
+const EMPTY_CONFIG = {} as RemoteClawConfig;
+
+function makeRegistryParams() {
+  return {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    runtime: {} as PluginRuntime,
+  };
+}
+
+function makeRecord(overrides?: Partial<PluginRecord>): PluginRecord {
+  return {
+    id: "test-plugin",
+    name: "test-plugin",
+    source: "/tmp/test-plugin.js",
+    origin: "global" as const,
+    enabled: true,
+    status: "loaded" as const,
+    toolNames: [],
+    hookNames: [],
+    channelIds: [],
+    providerIds: [],
+    sttProviderIds: [],
+    gatewayMethods: [],
+    cliCommands: [],
+    services: [],
+    commands: [],
+    httpHandlers: 0,
+    hookCount: 0,
+    configSchema: false,
+    ...overrides,
+  };
+}
+
+describe("registerSttProvider", () => {
+  it("registers a plugin STT provider", () => {
+    const { registry, registerSttProvider } = createPluginRegistry(makeRegistryParams());
+    const record = makeRecord();
+    const provider = {
+      id: "my-custom-stt",
+      transcribeAudio: async () => ({ text: "hello" }),
+    };
+
+    registerSttProvider(record, provider);
+
+    expect(registry.sttProviders).toHaveLength(1);
+    expect(registry.sttProviders[0]).toMatchObject({
+      pluginId: "test-plugin",
+      provider,
+    });
+    expect(record.sttProviderIds).toEqual(["my-custom-stt"]);
+  });
+
+  it("rejects provider with empty id", () => {
+    const { registry, registerSttProvider } = createPluginRegistry(makeRegistryParams());
+    const record = makeRecord();
+    const provider = {
+      id: "  ",
+      transcribeAudio: async () => ({ text: "" }),
+    };
+
+    registerSttProvider(record, provider);
+
+    expect(registry.sttProviders).toHaveLength(0);
+    expect(registry.diagnostics).toHaveLength(1);
+    expect(registry.diagnostics[0]).toMatchObject({
+      level: "error",
+      pluginId: "test-plugin",
+      message: expect.stringContaining("missing id"),
+    });
+  });
+
+  it("rejects duplicate provider id", () => {
+    const { registry, registerSttProvider } = createPluginRegistry(makeRegistryParams());
+    const record = makeRecord();
+    const provider1 = {
+      id: "my-stt",
+      transcribeAudio: async () => ({ text: "one" }),
+    };
+    const provider2 = {
+      id: "my-stt",
+      transcribeAudio: async () => ({ text: "two" }),
+    };
+
+    registerSttProvider(record, provider1);
+    registerSttProvider(record, provider2);
+
+    expect(registry.sttProviders).toHaveLength(1);
+    expect(registry.diagnostics).toHaveLength(1);
+    expect(registry.diagnostics[0]).toMatchObject({
+      level: "error",
+      message: expect.stringContaining("already registered"),
+    });
+  });
+
+  it("is accessible via plugin API", () => {
+    const { registry, createApi } = createPluginRegistry(makeRegistryParams());
+    const record = makeRecord();
+    const api = createApi(record, { config: EMPTY_CONFIG });
+    const provider = {
+      id: "api-stt",
+      transcribeAudio: async () => ({ text: "via api" }),
+    };
+
+    api.registerSttProvider(provider);
+
+    expect(registry.sttProviders).toHaveLength(1);
+    expect(registry.sttProviders[0].provider.id).toBe("api-stt");
+    expect(record.sttProviderIds).toEqual(["api-stt"]);
+  });
+});

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -12,6 +12,7 @@ import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import type { InternalHookHandler } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
 import type { RuntimeEnv } from "../runtime.js";
+import type { SttProvider } from "../stt/types.js";
 import type { AgentMessage } from "../types/agent-types.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import type { PluginRuntime } from "./runtime/types.js";
@@ -274,6 +275,7 @@ export type RemoteClawPluginApi = {
    * Use this for simple state-toggling or status commands that don't need AI reasoning.
    */
   registerCommand: (command: RemoteClawPluginCommandDefinition) => void;
+  registerSttProvider: (provider: SttProvider) => void;
   resolvePath: (input: string) => string;
   /** Register a lifecycle hook handler */
   on: <K extends PluginHookName>(

--- a/src/stt/providers/index.test.ts
+++ b/src/stt/providers/index.test.ts
@@ -30,6 +30,39 @@ describe("buildSttProviderRegistry", () => {
     const registry = buildSttProviderRegistry({ openai: custom });
     expect(registry.get("openai")).toBe(custom);
   });
+
+  it("includes plugin providers", () => {
+    const plugin = {
+      id: "my-custom-stt",
+      transcribeAudio: async () => ({ text: "plugin" }),
+    };
+    const registry = buildSttProviderRegistry(undefined, [plugin]);
+    expect(registry.get("my-custom-stt")).toBe(plugin);
+    // Built-in providers still present
+    expect(registry.has("openai")).toBe(true);
+  });
+
+  it("plugin providers override built-in providers", () => {
+    const plugin = {
+      id: "openai",
+      transcribeAudio: async () => ({ text: "plugin-openai" }),
+    };
+    const registry = buildSttProviderRegistry(undefined, [plugin]);
+    expect(registry.get("openai")).toBe(plugin);
+  });
+
+  it("overrides take precedence over plugin providers", () => {
+    const plugin = {
+      id: "openai",
+      transcribeAudio: async () => ({ text: "plugin-openai" }),
+    };
+    const override = {
+      id: "openai",
+      transcribeAudio: async () => ({ text: "override-openai" }),
+    };
+    const registry = buildSttProviderRegistry({ openai: override }, [plugin]);
+    expect(registry.get("openai")).toBe(override);
+  });
 });
 
 describe("getSttProvider", () => {

--- a/src/stt/providers/index.ts
+++ b/src/stt/providers/index.ts
@@ -24,10 +24,16 @@ export function normalizeSttProviderId(id: string): string {
 
 export function buildSttProviderRegistry(
   overrides?: Record<string, SttProvider>,
+  pluginProviders?: SttProvider[],
 ): Map<string, SttProvider> {
   const registry = new Map<string, SttProvider>();
   for (const provider of STT_PROVIDERS) {
     registry.set(normalizeSttProviderId(provider.id), provider);
+  }
+  if (pluginProviders) {
+    for (const provider of pluginProviders) {
+      registry.set(normalizeSttProviderId(provider.id), provider);
+    }
   }
   if (overrides) {
     for (const [key, provider] of Object.entries(overrides)) {

--- a/src/test-utils/channel-plugins.ts
+++ b/src/test-utils/channel-plugins.ts
@@ -19,6 +19,7 @@ export const createTestRegistry = (channels: TestChannelRegistration[] = []): Pl
   typedHooks: [],
   channels: channels as unknown as PluginRegistry["channels"],
   providers: [],
+  sttProviders: [],
   gatewayHandlers: {},
   httpHandlers: [],
   httpRoutes: [],


### PR DESCRIPTION
## Summary

- Export `SttProvider`, `AudioTranscriptionRequest`, `AudioTranscriptionResult` types from the plugin SDK so extensions can implement custom STT providers
- Add `stt` field to plugin manifest for declaring STT provider IDs at load time
- Add `registerSttProvider()` to `RemoteClawPluginApi` with duplicate/empty-ID validation
- Wire plugin-registered providers into `buildSttProviderRegistry` with correct priority: built-in → plugin → config-specified overrides
- Display registered STT providers in CLI `remoteclaw plugins` output

Closes #497

## Test plan

- [x] New tests for `buildSttProviderRegistry` with plugin providers (3 cases: add, override built-in, override precedence)
- [x] New tests for `registerSttProvider` in plugin registry (4 cases: register, empty ID, duplicate, via API)
- [x] Existing STT provider registry tests still pass
- [x] Existing dead-hooks tests updated and passing
- [x] Full unit suite: 981 files, 8231 tests pass
- [x] Typecheck clean (`tsgo` — 0 errors in src/)
- [x] Lint clean (`oxlint --type-aware` — 0 warnings, 0 errors)
- [x] Format clean (`oxfmt --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)