### PR TITLE
feat(plugin-sdk): allow extensions to register custom TTS providers

### DIFF
--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -70,6 +70,7 @@ const createRegistry = (channels: PluginRegistry["channels"]): PluginRegistry =>
   channels,
   providers: [],
   sttProviders: [],
+  ttsProviders: [],
   gatewayHandlers: {},
   httpHandlers: [],
   httpRoutes: [],

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -110,6 +110,9 @@ function formatPluginLine(plugin: PluginRecord, verbose = false): string {
   if (plugin.sttProviderIds.length > 0) {
     parts.push(`  stt: ${plugin.sttProviderIds.join(", ")}`);
   }
+  if (plugin.ttsProviderIds.length > 0) {
+    parts.push(`  tts: ${plugin.ttsProviderIds.join(", ")}`);
+  }
   if (plugin.error) {
     parts.push(theme.error(`  error: ${plugin.error}`));
   }
@@ -307,6 +310,9 @@ export function registerPluginsCli(program: Command) {
       }
       if (plugin.sttProviderIds.length > 0) {
         lines.push(`${theme.muted("STT providers:")} ${plugin.sttProviderIds.join(", ")}`);
+      }
+      if (plugin.ttsProviderIds.length > 0) {
+        lines.push(`${theme.muted("TTS providers:")} ${plugin.ttsProviderIds.join(", ")}`);
       }
       if (plugin.cliCommands.length > 0) {
         lines.push(`${theme.muted("CLI commands:")} ${plugin.cliCommands.join(", ")}`);

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -12,6 +12,7 @@ function makeRegistry(plugins: Array<{ id: string; channels: string[] }>): Plugi
       providers: [],
       skills: [],
       stt: [],
+      tts: [],
       origin: "config" as const,
       rootDir: `/fake/${p.id}`,
       source: `/fake/${p.id}/index.js`,

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,4 +1,5 @@
-export type TtsProvider = "elevenlabs" | "openai" | "edge";
+export type BuiltinTtsProvider = "elevenlabs" | "openai" | "edge";
+export type TtsProvider = BuiltinTtsProvider | (string & {});
 
 export type TtsMode = "final" | "all";
 

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -95,7 +95,7 @@ export const MarkdownConfigSchema = z
   .strict()
   .optional();
 
-export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge"]);
+export const TtsProviderSchema = z.string().min(1);
 export const TtsModeSchema = z.enum(["final", "all"]);
 export const TtsAutoSchema = z.enum(["off", "always", "inbound", "tagged"]);
 export const TtsConfigSchema = z

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -18,6 +18,7 @@ const createRegistry = (diagnostics: PluginDiagnostic[]): PluginRegistry => ({
   commands: [],
   providers: [],
   sttProviders: [],
+  ttsProviders: [],
   gatewayHandlers: {},
   httpHandlers: [],
   httpRoutes: [],

--- a/src/gateway/test-helpers.mocks.ts
+++ b/src/gateway/test-helpers.mocks.ts
@@ -146,6 +146,7 @@ const createStubPluginRegistry = (): PluginRegistry => ({
   ],
   providers: [],
   sttProviders: [],
+  ttsProviders: [],
   gatewayHandlers: {},
   httpHandlers: [],
   httpRoutes: [],

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -560,6 +560,9 @@ export type {
   SttProvider,
 } from "../stt/types.js";
 
+// TTS provider types
+export type { TtsProviderImpl, TtsSynthesisRequest, TtsSynthesisResult } from "../tts/types.js";
+
 // Voice credential validation
 export {
   checkSttCredentials,

--- a/src/plugins/dead-hooks.test.ts
+++ b/src/plugins/dead-hooks.test.ts
@@ -25,6 +25,7 @@ function makeRecord(overrides?: Partial<PluginRecord>): PluginRecord {
     channelIds: [],
     providerIds: [],
     sttProviderIds: [],
+    ttsProviderIds: [],
     gatewayMethods: [],
     cliCommands: [],
     services: [],

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -163,6 +163,7 @@ function createPluginRecord(params: {
     channelIds: [],
     providerIds: [],
     sttProviderIds: [],
+    ttsProviderIds: [],
     gatewayMethods: [],
     cliCommands: [],
     services: [],

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -30,6 +30,7 @@ export type PluginManifestRecord = {
   providers: string[];
   skills: string[];
   stt: string[];
+  tts: string[];
   origin: PluginOrigin;
   workspaceDir?: string;
   rootDir: string;
@@ -122,6 +123,7 @@ function buildRecord(params: {
     providers: params.manifest.providers ?? [],
     skills: params.manifest.skills ?? [],
     stt: params.manifest.stt ?? [],
+    tts: params.manifest.tts ?? [],
     origin: params.candidate.origin,
     workspaceDir: params.candidate.workspaceDir,
     rootDir: params.candidate.rootDir,

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -22,6 +22,7 @@ export type PluginManifest = {
   providers?: string[];
   skills?: string[];
   stt?: string[];
+  tts?: string[];
   name?: string;
   description?: string;
   version?: string;
@@ -84,6 +85,7 @@ export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
   const providers = normalizeStringList(raw.providers);
   const skills = normalizeStringList(raw.skills);
   const stt = normalizeStringList(raw.stt);
+  const tts = normalizeStringList(raw.tts);
 
   let uiHints: Record<string, PluginConfigUiHint> | undefined;
   if (isRecord(raw.uiHints)) {
@@ -100,6 +102,7 @@ export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
       providers,
       skills,
       stt,
+      tts,
       name,
       description,
       version,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -9,6 +9,7 @@ import type {
 import { registerInternalHook } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
 import type { SttProvider } from "../stt/types.js";
+import type { TtsProviderImpl } from "../tts/types.js";
 import { resolveUserPath } from "../utils.js";
 import { registerPluginCommand } from "./commands.js";
 import { normalizePluginHttpPath } from "./http-path.js";
@@ -101,6 +102,12 @@ export type PluginSttProviderRegistration = {
   source: string;
 };
 
+export type PluginTtsProviderRegistration = {
+  pluginId: string;
+  provider: TtsProviderImpl;
+  source: string;
+};
+
 export type PluginRecord = {
   id: string;
   name: string;
@@ -120,6 +127,7 @@ export type PluginRecord = {
   gatewayMethods: string[];
   cliCommands: string[];
   sttProviderIds: string[];
+  ttsProviderIds: string[];
   services: string[];
   commands: string[];
   httpHandlers: number;
@@ -137,6 +145,7 @@ export type PluginRegistry = {
   channels: PluginChannelRegistration[];
   providers: PluginProviderRegistration[];
   sttProviders: PluginSttProviderRegistration[];
+  ttsProviders: PluginTtsProviderRegistration[];
   gatewayHandlers: GatewayRequestHandlers;
   httpHandlers: PluginHttpRegistration[];
   httpRoutes: PluginHttpRouteRegistration[];
@@ -161,6 +170,7 @@ export function createEmptyPluginRegistry(): PluginRegistry {
     channels: [],
     providers: [],
     sttProviders: [],
+    ttsProviders: [],
     gatewayHandlers: {},
     httpHandlers: [],
     httpRoutes: [],
@@ -491,6 +501,34 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     });
   };
 
+  const registerTtsProvider = (record: PluginRecord, provider: TtsProviderImpl) => {
+    const id = provider.id.trim();
+    if (!id) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: "TTS provider registration missing id",
+      });
+      return;
+    }
+    if (registry.ttsProviders.some((entry) => entry.provider.id === id)) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `TTS provider already registered: ${id}`,
+      });
+      return;
+    }
+    record.ttsProviderIds.push(id);
+    registry.ttsProviders.push({
+      pluginId: record.id,
+      provider,
+      source: record.source,
+    });
+  };
+
   const registerTypedHook = <K extends PluginHookName>(
     record: PluginRecord,
     hookName: K,
@@ -542,6 +580,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       registerService: (service) => registerService(record, service),
       registerCommand: (command) => registerCommand(record, command),
       registerSttProvider: (provider) => registerSttProvider(record, provider),
+      registerTtsProvider: (provider) => registerTtsProvider(record, provider),
       resolvePath: (input: string) => resolveUserPath(input),
       on: (hookName, handler, opts) => {
         if (DEAD_HOOKS.has(hookName as string)) {
@@ -572,6 +611,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     registerService,
     registerCommand,
     registerSttProvider,
+    registerTtsProvider,
     registerHook,
     registerTypedHook,
   };

--- a/src/plugins/tts-providers.test.ts
+++ b/src/plugins/tts-providers.test.ts
@@ -37,36 +37,38 @@ function makeRecord(overrides?: Partial<PluginRecord>): PluginRecord {
   };
 }
 
-describe("registerSttProvider", () => {
-  it("registers a plugin STT provider", () => {
-    const { registry, registerSttProvider } = createPluginRegistry(makeRegistryParams());
+describe("registerTtsProvider", () => {
+  it("registers a plugin TTS provider", () => {
+    const { registry, registerTtsProvider } = createPluginRegistry(makeRegistryParams());
     const record = makeRecord();
     const provider = {
-      id: "my-custom-stt",
-      transcribeAudio: async () => ({ text: "hello" }),
+      id: "my-custom-tts",
+      requiresApiKey: true as const,
+      synthesize: async () => ({ audioBuffer: Buffer.from("audio"), format: "mp3" }),
     };
 
-    registerSttProvider(record, provider);
+    registerTtsProvider(record, provider);
 
-    expect(registry.sttProviders).toHaveLength(1);
-    expect(registry.sttProviders[0]).toMatchObject({
+    expect(registry.ttsProviders).toHaveLength(1);
+    expect(registry.ttsProviders[0]).toMatchObject({
       pluginId: "test-plugin",
       provider,
     });
-    expect(record.sttProviderIds).toEqual(["my-custom-stt"]);
+    expect(record.ttsProviderIds).toEqual(["my-custom-tts"]);
   });
 
   it("rejects provider with empty id", () => {
-    const { registry, registerSttProvider } = createPluginRegistry(makeRegistryParams());
+    const { registry, registerTtsProvider } = createPluginRegistry(makeRegistryParams());
     const record = makeRecord();
     const provider = {
       id: "  ",
-      transcribeAudio: async () => ({ text: "" }),
+      requiresApiKey: false as const,
+      synthesize: async () => ({ audioBuffer: Buffer.from(""), format: "mp3" }),
     };
 
-    registerSttProvider(record, provider);
+    registerTtsProvider(record, provider);
 
-    expect(registry.sttProviders).toHaveLength(0);
+    expect(registry.ttsProviders).toHaveLength(0);
     expect(registry.diagnostics).toHaveLength(1);
     expect(registry.diagnostics[0]).toMatchObject({
       level: "error",
@@ -76,21 +78,23 @@ describe("registerSttProvider", () => {
   });
 
   it("rejects duplicate provider id", () => {
-    const { registry, registerSttProvider } = createPluginRegistry(makeRegistryParams());
+    const { registry, registerTtsProvider } = createPluginRegistry(makeRegistryParams());
     const record = makeRecord();
     const provider1 = {
-      id: "my-stt",
-      transcribeAudio: async () => ({ text: "one" }),
+      id: "my-tts",
+      requiresApiKey: true as const,
+      synthesize: async () => ({ audioBuffer: Buffer.from("one"), format: "mp3" }),
     };
     const provider2 = {
-      id: "my-stt",
-      transcribeAudio: async () => ({ text: "two" }),
+      id: "my-tts",
+      requiresApiKey: true as const,
+      synthesize: async () => ({ audioBuffer: Buffer.from("two"), format: "mp3" }),
     };
 
-    registerSttProvider(record, provider1);
-    registerSttProvider(record, provider2);
+    registerTtsProvider(record, provider1);
+    registerTtsProvider(record, provider2);
 
-    expect(registry.sttProviders).toHaveLength(1);
+    expect(registry.ttsProviders).toHaveLength(1);
     expect(registry.diagnostics).toHaveLength(1);
     expect(registry.diagnostics[0]).toMatchObject({
       level: "error",
@@ -103,14 +107,15 @@ describe("registerSttProvider", () => {
     const record = makeRecord();
     const api = createApi(record, { config: EMPTY_CONFIG });
     const provider = {
-      id: "api-stt",
-      transcribeAudio: async () => ({ text: "via api" }),
+      id: "api-tts",
+      requiresApiKey: false as const,
+      synthesize: async () => ({ audioBuffer: Buffer.from("via api"), format: "opus" }),
     };
 
-    api.registerSttProvider(provider);
+    api.registerTtsProvider(provider);
 
-    expect(registry.sttProviders).toHaveLength(1);
-    expect(registry.sttProviders[0].provider.id).toBe("api-stt");
-    expect(record.sttProviderIds).toEqual(["api-stt"]);
+    expect(registry.ttsProviders).toHaveLength(1);
+    expect(registry.ttsProviders[0].provider.id).toBe("api-tts");
+    expect(record.ttsProviderIds).toEqual(["api-tts"]);
   });
 });

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -13,6 +13,7 @@ import type { InternalHookHandler } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { SttProvider } from "../stt/types.js";
+import type { TtsProviderImpl } from "../tts/types.js";
 import type { AgentMessage } from "../types/agent-types.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import type { PluginRuntime } from "./runtime/types.js";
@@ -276,6 +277,7 @@ export type RemoteClawPluginApi = {
    */
   registerCommand: (command: RemoteClawPluginCommandDefinition) => void;
   registerSttProvider: (provider: SttProvider) => void;
+  registerTtsProvider: (provider: TtsProviderImpl) => void;
   resolvePath: (input: string) => string;
   /** Register a lifecycle hook handler */
   on: <K extends PluginHookName>(

--- a/src/test-utils/channel-plugins.ts
+++ b/src/test-utils/channel-plugins.ts
@@ -20,6 +20,7 @@ export const createTestRegistry = (channels: TestChannelRegistration[] = []): Pl
   channels: channels as unknown as PluginRegistry["channels"],
   providers: [],
   sttProviders: [],
+  ttsProviders: [],
   gatewayHandlers: {},
   httpHandlers: [],
   httpRoutes: [],

--- a/src/tts/providers/edge.ts
+++ b/src/tts/providers/edge.ts
@@ -1,0 +1,58 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import { resolvePreferredRemoteClawTmpDir } from "../../infra/tmp-remoteclaw-dir.js";
+import { edgeTTS, inferEdgeExtension } from "../tts-core.js";
+import type { TtsProviderImpl } from "../types.js";
+
+type EdgeExtras = {
+  voice?: string;
+  lang?: string;
+  outputFormat?: string;
+  pitch?: string;
+  rate?: string;
+  volume?: string;
+  saveSubtitles?: boolean;
+  proxy?: string;
+};
+
+export const edgeTtsProvider: TtsProviderImpl = {
+  id: "edge",
+  requiresApiKey: false,
+  synthesize: async (req) => {
+    const extras = (req.extras ?? {}) as EdgeExtras;
+    const outputFormat = extras.outputFormat ?? "audio-24khz-48kbitrate-mono-mp3";
+    const tempRoot = resolvePreferredRemoteClawTmpDir();
+    mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
+    const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
+    const extension = inferEdgeExtension(outputFormat);
+    const audioPath = path.join(tempDir, `voice-${Date.now()}${extension}`);
+
+    try {
+      await edgeTTS({
+        text: req.text,
+        outputPath: audioPath,
+        config: {
+          voice: extras.voice ?? "en-US-MichelleNeural",
+          lang: extras.lang ?? "en-US",
+          outputFormat,
+          outputFormatConfigured: false,
+          saveSubtitles: extras.saveSubtitles ?? false,
+          proxy: extras.proxy,
+          pitch: extras.pitch,
+          rate: extras.rate,
+          volume: extras.volume,
+          enabled: true,
+        },
+        timeoutMs: req.timeoutMs,
+      });
+      const audioBuffer = readFileSync(audioPath);
+      return { audioBuffer, format: outputFormat };
+    } finally {
+      try {
+        rmSync(tempDir, { recursive: true, force: true });
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+  },
+};

--- a/src/tts/providers/elevenlabs.ts
+++ b/src/tts/providers/elevenlabs.ts
@@ -1,0 +1,55 @@
+import { elevenLabsTTS } from "../tts-core.js";
+import type { TtsProviderImpl } from "../types.js";
+
+const DEFAULT_BASE_URL = "https://api.elevenlabs.io";
+const DEFAULT_VOICE_ID = "pMsXgVXv3BLzUgSXRplE";
+const DEFAULT_MODEL_ID = "eleven_multilingual_v2";
+
+const DEFAULT_VOICE_SETTINGS = {
+  stability: 0.5,
+  similarityBoost: 0.75,
+  style: 0.0,
+  useSpeakerBoost: true,
+  speed: 1.0,
+};
+
+type ElevenLabsExtras = {
+  baseUrl?: string;
+  voiceId?: string;
+  seed?: number;
+  applyTextNormalization?: "auto" | "on" | "off";
+  languageCode?: string;
+  voiceSettings?: {
+    stability: number;
+    similarityBoost: number;
+    style: number;
+    useSpeakerBoost: boolean;
+    speed: number;
+  };
+};
+
+export const elevenLabsTtsProvider: TtsProviderImpl = {
+  id: "elevenlabs",
+  requiresApiKey: true,
+  synthesize: async (req) => {
+    const extras = (req.extras ?? {}) as ElevenLabsExtras;
+    const outputFormat = req.outputFormat ?? "mp3_44100_128";
+    const buffer = await elevenLabsTTS({
+      text: req.text,
+      apiKey: req.apiKey!,
+      baseUrl: extras.baseUrl ?? DEFAULT_BASE_URL,
+      voiceId: extras.voiceId ?? DEFAULT_VOICE_ID,
+      modelId: req.model ?? DEFAULT_MODEL_ID,
+      outputFormat,
+      seed: extras.seed,
+      applyTextNormalization: extras.applyTextNormalization,
+      languageCode: extras.languageCode,
+      voiceSettings: extras.voiceSettings ?? DEFAULT_VOICE_SETTINGS,
+      timeoutMs: req.timeoutMs,
+    });
+    const sampleRate = outputFormat.startsWith("pcm_")
+      ? Number.parseInt(outputFormat.split("_")[1], 10)
+      : undefined;
+    return { audioBuffer: buffer, format: outputFormat, sampleRate };
+  },
+};

--- a/src/tts/providers/index.ts
+++ b/src/tts/providers/index.ts
@@ -1,0 +1,37 @@
+import { normalizeProviderId } from "../../agents/provider-utils.js";
+import type { TtsProviderImpl } from "../types.js";
+import { edgeTtsProvider } from "./edge.js";
+import { elevenLabsTtsProvider } from "./elevenlabs.js";
+import { openaiTtsProvider } from "./openai.js";
+
+const TTS_PROVIDERS: TtsProviderImpl[] = [
+  openaiTtsProvider,
+  elevenLabsTtsProvider,
+  edgeTtsProvider,
+];
+
+export function normalizeTtsProviderId(id: string): string {
+  return normalizeProviderId(id);
+}
+
+export function buildTtsProviderRegistry(
+  pluginProviders?: TtsProviderImpl[],
+): Map<string, TtsProviderImpl> {
+  const registry = new Map<string, TtsProviderImpl>();
+  for (const provider of TTS_PROVIDERS) {
+    registry.set(normalizeTtsProviderId(provider.id), provider);
+  }
+  if (pluginProviders) {
+    for (const provider of pluginProviders) {
+      registry.set(normalizeTtsProviderId(provider.id), provider);
+    }
+  }
+  return registry;
+}
+
+export function getTtsProvider(
+  id: string,
+  registry: Map<string, TtsProviderImpl>,
+): TtsProviderImpl | undefined {
+  return registry.get(normalizeTtsProviderId(id));
+}

--- a/src/tts/providers/openai.ts
+++ b/src/tts/providers/openai.ts
@@ -1,0 +1,20 @@
+import { openaiTTS } from "../tts-core.js";
+import type { TtsProviderImpl } from "../types.js";
+
+export const openaiTtsProvider: TtsProviderImpl = {
+  id: "openai",
+  requiresApiKey: true,
+  synthesize: async (req) => {
+    const format = (req.outputFormat ?? "mp3") as "mp3" | "opus" | "pcm";
+    const buffer = await openaiTTS({
+      text: req.text,
+      apiKey: req.apiKey!,
+      model: req.model ?? "gpt-4o-mini-tts",
+      voice: req.voice ?? "alloy",
+      responseFormat: format,
+      timeoutMs: req.timeoutMs,
+    });
+    const sampleRate = format === "pcm" ? 24000 : undefined;
+    return { audioBuffer: buffer, format, sampleRate };
+  },
+};

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -129,10 +129,10 @@ export function parseTtsDirectives(
             if (!policy.allowProvider) {
               break;
             }
-            if (rawValue === "openai" || rawValue === "elevenlabs" || rawValue === "edge") {
-              overrides.provider = rawValue;
+            if (rawValue.trim()) {
+              overrides.provider = rawValue.trim();
             } else {
-              warnings.push(`unsupported provider "${rawValue}"`);
+              warnings.push(`empty provider value`);
             }
             break;
           case "voice":

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -28,6 +28,10 @@ import { stripMarkdown } from "../line/markdown-to-line.js";
 import { isVoiceCompatibleAudio } from "../media/audio.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import {
+  buildTtsProviderRegistry,
+  getTtsProvider as lookupTtsProvider,
+} from "./providers/index.js";
+import {
   edgeTTS,
   elevenLabsTTS,
   inferEdgeExtension,
@@ -40,6 +44,7 @@ import {
   parseTtsDirectives,
   scheduleCleanup,
 } from "./tts-core.js";
+import type { TtsProviderImpl } from "./types.js";
 export { OPENAI_TTS_MODELS, OPENAI_TTS_VOICES } from "./tts-core.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -156,7 +161,7 @@ export type ResolvedTtsModelOverrides = {
 
 export type TtsDirectiveOverrides = {
   ttsText?: string;
-  provider?: TtsProvider;
+  provider?: string;
   openai?: {
     voice?: string;
     model?: string;
@@ -401,7 +406,7 @@ export function setTtsEnabled(prefsPath: string, enabled: boolean): void {
   setTtsAutoMode(prefsPath, enabled ? "always" : "off");
 }
 
-export async function getTtsProvider(
+export async function resolveConfiguredTtsProvider(
   config: ResolvedTtsConfig,
   prefsPath: string,
 ): Promise<TtsProvider> {
@@ -421,6 +426,9 @@ export async function getTtsProvider(
   }
   return "edge";
 }
+
+/** @deprecated Use resolveConfiguredTtsProvider instead. */
+export const getTtsProvider = resolveConfiguredTtsProvider;
 
 export function setTtsProvider(prefsPath: string, provider: TtsProvider): void {
   updatePrefs(prefsPath, (prefs) => {
@@ -473,7 +481,7 @@ function resolveEdgeOutputFormat(config: ResolvedTtsConfig): string {
   return config.edge.outputFormat;
 }
 
-function ttsProviderToAuthProvider(provider: TtsProvider): string {
+function ttsProviderToAuthProvider(provider: string): string {
   switch (provider) {
     case "openai":
       return "openai";
@@ -486,7 +494,7 @@ function ttsProviderToAuthProvider(provider: TtsProvider): string {
 
 export async function resolveTtsApiKey(
   config: ResolvedTtsConfig,
-  provider: TtsProvider,
+  provider: string,
 ): Promise<string | undefined> {
   // 1. Auth profile store (unified credential system)
   if (provider !== "edge") {
@@ -512,15 +520,18 @@ export async function resolveTtsApiKey(
   return undefined;
 }
 
-export const TTS_PROVIDERS = ["openai", "elevenlabs", "edge"] as const;
+export const BUILTIN_TTS_PROVIDER_IDS = ["openai", "elevenlabs", "edge"] as const;
 
-export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
-  return [primary, ...TTS_PROVIDERS.filter((provider) => provider !== primary)];
+/** @deprecated Use BUILTIN_TTS_PROVIDER_IDS instead. */
+export const TTS_PROVIDERS = BUILTIN_TTS_PROVIDER_IDS;
+
+export function resolveTtsProviderOrder(primary: string): string[] {
+  return [primary, ...BUILTIN_TTS_PROVIDER_IDS.filter((id) => id !== primary)];
 }
 
 export async function isTtsProviderConfigured(
   config: ResolvedTtsConfig,
-  provider: TtsProvider,
+  provider: string,
 ): Promise<boolean> {
   if (provider === "edge") {
     return config.edge.enabled;
@@ -528,7 +539,7 @@ export async function isTtsProviderConfigured(
   return Boolean(await resolveTtsApiKey(config, provider));
 }
 
-function formatTtsProviderError(provider: TtsProvider, err: unknown): string {
+function formatTtsProviderError(provider: string, err: unknown): string {
   const error = err instanceof Error ? err : new Error(String(err));
   if (error.name === "AbortError") {
     return `${provider}: request timed out`;
@@ -542,6 +553,7 @@ export async function textToSpeech(params: {
   prefsPath?: string;
   channel?: string;
   overrides?: TtsDirectiveOverrides;
+  ttsProviders?: TtsProviderImpl[];
 }): Promise<TtsResult> {
   const config = resolveTtsConfig(params.cfg);
   const prefsPath = params.prefsPath ?? resolveTtsPrefsPath(config);
@@ -555,7 +567,8 @@ export async function textToSpeech(params: {
     };
   }
 
-  const userProvider = await getTtsProvider(config, prefsPath);
+  const providerRegistry = buildTtsProviderRegistry(params.ttsProviders);
+  const userProvider = await resolveConfiguredTtsProvider(config, prefsPath);
   const overrideProvider = params.overrides?.provider;
   const provider = overrideProvider ?? userProvider;
   const providers = resolveTtsProviderOrder(provider);
@@ -565,6 +578,7 @@ export async function textToSpeech(params: {
   for (const provider of providers) {
     const providerStart = Date.now();
     try {
+      // ── Built-in: Edge ──────────────────────────────────────────────
       if (provider === "edge") {
         if (!config.edge.enabled) {
           errors.push("edge: disabled");
@@ -635,56 +649,101 @@ export async function textToSpeech(params: {
         };
       }
 
-      const apiKey = await resolveTtsApiKey(config, provider);
-      if (!apiKey) {
-        errors.push(`${provider}: no API key`);
+      // ── Built-in: ElevenLabs / OpenAI ───────────────────────────────
+      if (provider === "elevenlabs" || provider === "openai") {
+        const apiKey = await resolveTtsApiKey(config, provider);
+        if (!apiKey) {
+          errors.push(`${provider}: no API key`);
+          continue;
+        }
+
+        let audioBuffer: Buffer;
+        if (provider === "elevenlabs") {
+          const voiceIdOverride = params.overrides?.elevenlabs?.voiceId;
+          const modelIdOverride = params.overrides?.elevenlabs?.modelId;
+          const voiceSettings = {
+            ...config.elevenlabs.voiceSettings,
+            ...params.overrides?.elevenlabs?.voiceSettings,
+          };
+          const seedOverride = params.overrides?.elevenlabs?.seed;
+          const normalizationOverride = params.overrides?.elevenlabs?.applyTextNormalization;
+          const languageOverride = params.overrides?.elevenlabs?.languageCode;
+          audioBuffer = await elevenLabsTTS({
+            text: params.text,
+            apiKey,
+            baseUrl: config.elevenlabs.baseUrl,
+            voiceId: voiceIdOverride ?? config.elevenlabs.voiceId,
+            modelId: modelIdOverride ?? config.elevenlabs.modelId,
+            outputFormat: output.elevenlabs,
+            seed: seedOverride ?? config.elevenlabs.seed,
+            applyTextNormalization:
+              normalizationOverride ?? config.elevenlabs.applyTextNormalization,
+            languageCode: languageOverride ?? config.elevenlabs.languageCode,
+            voiceSettings,
+            timeoutMs: config.timeoutMs,
+          });
+        } else {
+          const openaiModelOverride = params.overrides?.openai?.model;
+          const openaiVoiceOverride = params.overrides?.openai?.voice;
+          audioBuffer = await openaiTTS({
+            text: params.text,
+            apiKey,
+            model: openaiModelOverride ?? config.openai.model,
+            voice: openaiVoiceOverride ?? config.openai.voice,
+            responseFormat: output.openai,
+            timeoutMs: config.timeoutMs,
+          });
+        }
+
+        const latencyMs = Date.now() - providerStart;
+
+        const tempRoot = resolvePreferredRemoteClawTmpDir();
+        mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
+        const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
+        const audioPath = path.join(tempDir, `voice-${Date.now()}${output.extension}`);
+        writeFileSync(audioPath, audioBuffer);
+        scheduleCleanup(tempDir);
+
+        return {
+          success: true,
+          audioPath,
+          latencyMs,
+          provider,
+          outputFormat: provider === "openai" ? output.openai : output.elevenlabs,
+          voiceCompatible: output.voiceCompatible,
+        };
+      }
+
+      // ── Plugin provider ─────────────────────────────────────────────
+      const pluginProvider = lookupTtsProvider(provider, providerRegistry);
+      if (!pluginProvider) {
+        errors.push(`${provider}: unknown provider`);
         continue;
       }
 
-      let audioBuffer: Buffer;
-      if (provider === "elevenlabs") {
-        const voiceIdOverride = params.overrides?.elevenlabs?.voiceId;
-        const modelIdOverride = params.overrides?.elevenlabs?.modelId;
-        const voiceSettings = {
-          ...config.elevenlabs.voiceSettings,
-          ...params.overrides?.elevenlabs?.voiceSettings,
-        };
-        const seedOverride = params.overrides?.elevenlabs?.seed;
-        const normalizationOverride = params.overrides?.elevenlabs?.applyTextNormalization;
-        const languageOverride = params.overrides?.elevenlabs?.languageCode;
-        audioBuffer = await elevenLabsTTS({
-          text: params.text,
-          apiKey,
-          baseUrl: config.elevenlabs.baseUrl,
-          voiceId: voiceIdOverride ?? config.elevenlabs.voiceId,
-          modelId: modelIdOverride ?? config.elevenlabs.modelId,
-          outputFormat: output.elevenlabs,
-          seed: seedOverride ?? config.elevenlabs.seed,
-          applyTextNormalization: normalizationOverride ?? config.elevenlabs.applyTextNormalization,
-          languageCode: languageOverride ?? config.elevenlabs.languageCode,
-          voiceSettings,
-          timeoutMs: config.timeoutMs,
-        });
-      } else {
-        const openaiModelOverride = params.overrides?.openai?.model;
-        const openaiVoiceOverride = params.overrides?.openai?.voice;
-        audioBuffer = await openaiTTS({
-          text: params.text,
-          apiKey,
-          model: openaiModelOverride ?? config.openai.model,
-          voice: openaiVoiceOverride ?? config.openai.voice,
-          responseFormat: output.openai,
-          timeoutMs: config.timeoutMs,
-        });
+      let apiKey: string | undefined;
+      if (pluginProvider.requiresApiKey) {
+        apiKey = await resolveTtsApiKey(config, provider);
+        if (!apiKey) {
+          errors.push(`${provider}: no API key`);
+          continue;
+        }
       }
 
-      const latencyMs = Date.now() - providerStart;
+      const result = await pluginProvider.synthesize({
+        text: params.text,
+        apiKey,
+        outputFormat: output.openai,
+        timeoutMs: config.timeoutMs,
+      });
 
+      const latencyMs = Date.now() - providerStart;
       const tempRoot = resolvePreferredRemoteClawTmpDir();
       mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
       const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
-      const audioPath = path.join(tempDir, `voice-${Date.now()}${output.extension}`);
-      writeFileSync(audioPath, audioBuffer);
+      const ext = resolveExtensionForFormat(result.format);
+      const audioPath = path.join(tempDir, `voice-${Date.now()}${ext}`);
+      writeFileSync(audioPath, result.audioBuffer);
       scheduleCleanup(tempDir);
 
       return {
@@ -692,8 +751,8 @@ export async function textToSpeech(params: {
         audioPath,
         latencyMs,
         provider,
-        outputFormat: provider === "openai" ? output.openai : output.elevenlabs,
-        voiceCompatible: output.voiceCompatible,
+        outputFormat: result.format,
+        voiceCompatible: isVoiceCompatibleAudio({ fileName: audioPath }),
       };
     } catch (err) {
       errors.push(formatTtsProviderError(provider, err));
@@ -706,10 +765,28 @@ export async function textToSpeech(params: {
   };
 }
 
+function resolveExtensionForFormat(format: string): string {
+  const normalized = format.toLowerCase();
+  if (normalized.includes("opus")) {
+    return ".opus";
+  }
+  if (normalized.includes("ogg")) {
+    return ".ogg";
+  }
+  if (normalized.includes("wav") || normalized.includes("pcm")) {
+    return ".wav";
+  }
+  if (normalized.includes("webm")) {
+    return ".webm";
+  }
+  return ".mp3";
+}
+
 export async function textToSpeechTelephony(params: {
   text: string;
   cfg: RemoteClawConfig;
   prefsPath?: string;
+  ttsProviders?: TtsProviderImpl[];
 }): Promise<TtsTelephonyResult> {
   const config = resolveTtsConfig(params.cfg);
   const prefsPath = params.prefsPath ?? resolveTtsPrefsPath(config);
@@ -721,7 +798,8 @@ export async function textToSpeechTelephony(params: {
     };
   }
 
-  const userProvider = await getTtsProvider(config, prefsPath);
+  const providerRegistry = buildTtsProviderRegistry(params.ttsProviders);
+  const userProvider = await resolveConfiguredTtsProvider(config, prefsPath);
   const providers = resolveTtsProviderOrder(userProvider);
 
   const errors: string[] = [];
@@ -734,25 +812,47 @@ export async function textToSpeechTelephony(params: {
         continue;
       }
 
-      const apiKey = await resolveTtsApiKey(config, provider);
-      if (!apiKey) {
-        errors.push(`${provider}: no API key`);
-        continue;
-      }
+      // ── Built-in: ElevenLabs / OpenAI ───────────────────────────────
+      if (provider === "elevenlabs" || provider === "openai") {
+        const apiKey = await resolveTtsApiKey(config, provider);
+        if (!apiKey) {
+          errors.push(`${provider}: no API key`);
+          continue;
+        }
 
-      if (provider === "elevenlabs") {
-        const output = TELEPHONY_OUTPUT.elevenlabs;
-        const audioBuffer = await elevenLabsTTS({
+        if (provider === "elevenlabs") {
+          const output = TELEPHONY_OUTPUT.elevenlabs;
+          const audioBuffer = await elevenLabsTTS({
+            text: params.text,
+            apiKey,
+            baseUrl: config.elevenlabs.baseUrl,
+            voiceId: config.elevenlabs.voiceId,
+            modelId: config.elevenlabs.modelId,
+            outputFormat: output.format,
+            seed: config.elevenlabs.seed,
+            applyTextNormalization: config.elevenlabs.applyTextNormalization,
+            languageCode: config.elevenlabs.languageCode,
+            voiceSettings: config.elevenlabs.voiceSettings,
+            timeoutMs: config.timeoutMs,
+          });
+
+          return {
+            success: true,
+            audioBuffer,
+            latencyMs: Date.now() - providerStart,
+            provider,
+            outputFormat: output.format,
+            sampleRate: output.sampleRate,
+          };
+        }
+
+        const output = TELEPHONY_OUTPUT.openai;
+        const audioBuffer = await openaiTTS({
           text: params.text,
           apiKey,
-          baseUrl: config.elevenlabs.baseUrl,
-          voiceId: config.elevenlabs.voiceId,
-          modelId: config.elevenlabs.modelId,
-          outputFormat: output.format,
-          seed: config.elevenlabs.seed,
-          applyTextNormalization: config.elevenlabs.applyTextNormalization,
-          languageCode: config.elevenlabs.languageCode,
-          voiceSettings: config.elevenlabs.voiceSettings,
+          model: config.openai.model,
+          voice: config.openai.voice,
+          responseFormat: output.format,
           timeoutMs: config.timeoutMs,
         });
 
@@ -766,23 +866,36 @@ export async function textToSpeechTelephony(params: {
         };
       }
 
-      const output = TELEPHONY_OUTPUT.openai;
-      const audioBuffer = await openaiTTS({
+      // ── Plugin provider ─────────────────────────────────────────────
+      const pluginProvider = lookupTtsProvider(provider, providerRegistry);
+      if (!pluginProvider) {
+        errors.push(`${provider}: unknown provider`);
+        continue;
+      }
+
+      let apiKey: string | undefined;
+      if (pluginProvider.requiresApiKey) {
+        apiKey = await resolveTtsApiKey(config, provider);
+        if (!apiKey) {
+          errors.push(`${provider}: no API key`);
+          continue;
+        }
+      }
+
+      const result = await pluginProvider.synthesize({
         text: params.text,
         apiKey,
-        model: config.openai.model,
-        voice: config.openai.voice,
-        responseFormat: output.format,
+        outputFormat: "pcm",
         timeoutMs: config.timeoutMs,
       });
 
       return {
         success: true,
-        audioBuffer,
+        audioBuffer: result.audioBuffer,
         latencyMs: Date.now() - providerStart,
         provider,
-        outputFormat: output.format,
-        sampleRate: output.sampleRate,
+        outputFormat: result.format,
+        sampleRate: result.sampleRate,
       };
     } catch (err) {
       errors.push(formatTtsProviderError(provider, err));
@@ -802,6 +915,7 @@ export async function maybeApplyTtsToPayload(params: {
   kind?: "tool" | "block" | "final";
   inboundAudio?: boolean;
   ttsAuto?: string;
+  ttsProviders?: TtsProviderImpl[];
 }): Promise<ReplyPayload> {
   const config = resolveTtsConfig(params.cfg);
   const prefsPath = resolveTtsPrefsPath(config);
@@ -878,6 +992,7 @@ export async function maybeApplyTtsToPayload(params: {
     prefsPath,
     channel: params.channel,
     overrides: directives.overrides,
+    ttsProviders: params.ttsProviders,
   });
 
   if (result.success && result.audioPath) {

--- a/src/tts/types.ts
+++ b/src/tts/types.ts
@@ -1,0 +1,23 @@
+export type TtsSynthesisRequest = {
+  text: string;
+  voice?: string;
+  model?: string;
+  apiKey?: string;
+  outputFormat?: string;
+  speed?: number;
+  timeoutMs: number;
+  /** Provider-specific options. */
+  extras?: Record<string, unknown>;
+};
+
+export type TtsSynthesisResult = {
+  audioBuffer: Buffer;
+  format: string;
+  sampleRate?: number;
+};
+
+export type TtsProviderImpl = {
+  id: string;
+  synthesize: (req: TtsSynthesisRequest) => Promise<TtsSynthesisResult>;
+  readonly requiresApiKey: boolean;
+};


### PR DESCRIPTION
## Summary

- Define `TtsProviderImpl` interface (with `TtsSynthesisRequest`/`TtsSynthesisResult`) and export from plugin-sdk
- Wrap built-in TTS providers (OpenAI, ElevenLabs, Edge) as `TtsProviderImpl` implementations behind a registry (`buildTtsProviderRegistry`)
- Add `registerTtsProvider` to plugin runtime API, manifest `tts` field, and CLI display
- Widen `TtsProvider` type and `TtsProviderSchema` to accept plugin provider IDs
- Add plugin provider dispatch path in `textToSpeech()` and `textToSpeechTelephony()` after built-in provider checks

Closes #498

## Test plan

- [x] New `tts-providers.test.ts` — registers provider, rejects empty id, rejects duplicate, accessible via API
- [x] All 876 existing tests pass
- [x] TypeScript type-check clean (`src/`)
- [x] Lint clean (0 errors)
- [x] Format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)