### PR TITLE
feat(runtime/claude): multimodal I/O support — accept inbound images (#396)

### DIFF
--- a/src/middleware/__smoke__/claude.live.test.ts
+++ b/src/middleware/__smoke__/claude.live.test.ts
@@ -90,6 +90,25 @@ describe.skipIf(!LIVE)("claude CLI middleware smoke test", () => {
     firstSessionId = result.run.sessionId;
   }, 60_000);
 
+  it("processes an image attachment and describes the content", async () => {
+    // 100x100 solid red PNG (large enough for the API to process)
+    const pngBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/gAIDAAABFUlEQVR4nO3OUQkAIABEsetfWiv4Nx4IC7Cd7XvkByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIReeLesrH9s1agAAAABJRU5ErkJggg==";
+    const testImagePath = join(tempDir, "test-image.png");
+    await writeFile(testImagePath, Buffer.from(pngBase64, "base64"));
+
+    const msg = makeMessage("What color is this image? Reply with just the color name.");
+    msg.mediaUrls = [testImagePath];
+
+    const result = await bridge.handle(msg);
+
+    expect(result.payloads.length).toBeGreaterThan(0);
+    expect(result.run.text).toBeTruthy();
+    expect(result.run.text.toLowerCase()).toContain("red");
+    expect(result.run.aborted).toBe(false);
+    expect(result.run.sessionId).toBeTruthy();
+  }, 60_000);
+
   it("resumes the session on a follow-up message", async () => {
     expect(firstSessionId).toBeTruthy();
 

--- a/src/middleware/cli-runtime-base.ts
+++ b/src/middleware/cli-runtime-base.ts
@@ -36,6 +36,15 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
   /** Construct provider-specific environment variables. */
   protected abstract buildEnv(params: AgentExecuteParams): Record<string, string>;
 
+  /**
+   * Construct a custom stdin payload for the subprocess.
+   * When this returns a string, it is written to stdin instead of
+   * the default large-prompt fallback.  Subclasses may override.
+   */
+  protected buildStdinPayload(_params: AgentExecuteParams): string | undefined {
+    return undefined;
+  }
+
   /** Whether this CLI accepts prompts via stdin. Subclasses may override. */
   protected get supportsStdinPrompt(): boolean {
     return true;
@@ -177,7 +186,13 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
     );
 
     // ── Stdin prompt delivery ────────────────────────────────────────
-    if (
+    const customStdin = this.buildStdinPayload(params);
+    if (customStdin !== undefined && child.stdin) {
+      logDebug(
+        `[agent-runtime] pid=${child.pid}: delivering custom stdin payload (${customStdin.length} chars)`,
+      );
+      child.stdin.write(customStdin);
+    } else if (
       this.supportsStdinPrompt &&
       params.prompt.length > CLIRuntimeBase.STDIN_PROMPT_THRESHOLD &&
       child.stdin

--- a/src/middleware/runtimes/claude.test.ts
+++ b/src/middleware/runtimes/claude.test.ts
@@ -16,6 +16,10 @@ class TestableClaudeCliRuntime extends ClaudeCliRuntime {
   public testBuildEnv(params: AgentExecuteParams): Record<string, string> {
     return this.buildEnv(params);
   }
+
+  public testBuildStdinPayload(params: AgentExecuteParams): string | undefined {
+    return this.buildStdinPayload(params);
+  }
 }
 
 // ── Fixtures ────────────────────────────────────────────────────────────
@@ -159,6 +163,56 @@ describe("ClaudeCliRuntime", () => {
       const args = runtime.testBuildArgs(makeParams({ prompt: "test prompt" }));
       expect(args[args.length - 2]).toBe("--print");
       expect(args[args.length - 1]).toBe("test prompt");
+    });
+
+    it("uses -p --input-format stream-json when image media with base64 is present", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          media: [{ mimeType: "image/jpeg", base64: "dGVzdA==" }],
+        }),
+      );
+      expect(args).toContain("-p");
+      expect(args).toContain("--input-format");
+      expect(args).toContain("stream-json");
+      expect(args).not.toContain("--print");
+    });
+
+    it("uses --print when media has no base64 populated", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          media: [{ mimeType: "image/jpeg", filePath: "/tmp/img.jpg" }],
+        }),
+      );
+      expect(args).toContain("--print");
+      expect(args).not.toContain("--input-format");
+    });
+
+    it("uses --print when media is non-image (audio/video)", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          media: [
+            { mimeType: "audio/ogg", base64: "dGVzdA==" },
+            { mimeType: "video/mp4", base64: "dGVzdA==" },
+          ],
+        }),
+      );
+      expect(args).toContain("--print");
+      expect(args).not.toContain("--input-format");
+    });
+
+    it("uses -p --input-format stream-json when mixed media includes images with base64", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          media: [
+            { mimeType: "audio/ogg", base64: "dGVzdA==" },
+            { mimeType: "image/png", base64: "aW1hZ2U=" },
+          ],
+        }),
+      );
+      expect(args).toContain("-p");
+      expect(args).toContain("--input-format");
+      expect(args).toContain("stream-json");
+      expect(args).not.toContain("--print");
     });
   });
 
@@ -498,6 +552,119 @@ describe("ClaudeCliRuntime", () => {
       expect(parsed).toEqual({
         mcpServers: { s: { command: "node" } },
       });
+    });
+  });
+
+  // ── buildStdinPayload ────────────────────────────────────────────────
+
+  describe("buildStdinPayload", () => {
+    it("returns undefined when no media is present", () => {
+      const payload = runtime.testBuildStdinPayload(makeParams());
+      expect(payload).toBeUndefined();
+    });
+
+    it("returns undefined when media has no base64", () => {
+      const payload = runtime.testBuildStdinPayload(
+        makeParams({ media: [{ mimeType: "image/jpeg", filePath: "/tmp/img.jpg" }] }),
+      );
+      expect(payload).toBeUndefined();
+    });
+
+    it("returns undefined for non-image media", () => {
+      const payload = runtime.testBuildStdinPayload(
+        makeParams({ media: [{ mimeType: "audio/ogg", base64: "dGVzdA==" }] }),
+      );
+      expect(payload).toBeUndefined();
+    });
+
+    it("constructs correct stream-json envelope for a single image", () => {
+      const payload = runtime.testBuildStdinPayload(
+        makeParams({
+          prompt: "Describe this image",
+          media: [{ mimeType: "image/jpeg", base64: "aW1hZ2VkYXRh" }],
+        }),
+      );
+
+      expect(payload).toBeDefined();
+      const parsed = JSON.parse(payload!.trimEnd());
+      expect(parsed).toEqual({
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/jpeg",
+                data: "aW1hZ2VkYXRh",
+              },
+            },
+            { type: "text", text: "Describe this image" },
+          ],
+        },
+      });
+    });
+
+    it("constructs correct envelope for multiple images", () => {
+      const payload = runtime.testBuildStdinPayload(
+        makeParams({
+          prompt: "Compare these",
+          media: [
+            { mimeType: "image/jpeg", base64: "aW1nMQ==" },
+            { mimeType: "image/png", base64: "aW1nMg==" },
+          ],
+        }),
+      );
+
+      const parsed = JSON.parse(payload!.trimEnd());
+      expect(parsed.type).toBe("user");
+      const { content } = parsed.message;
+      expect(content).toHaveLength(3); // 2 images + 1 text
+      expect(content[0].type).toBe("image");
+      expect(content[0].source.media_type).toBe("image/jpeg");
+      expect(content[1].type).toBe("image");
+      expect(content[1].source.media_type).toBe("image/png");
+      expect(content[2]).toEqual({ type: "text", text: "Compare these" });
+    });
+
+    it("filters out non-image media from payload", () => {
+      const payload = runtime.testBuildStdinPayload(
+        makeParams({
+          prompt: "Describe",
+          media: [
+            { mimeType: "audio/ogg", base64: "YXVkaW8=" },
+            { mimeType: "image/jpeg", base64: "aW1hZ2U=" },
+            { mimeType: "video/mp4", base64: "dmlkZW8=" },
+          ],
+        }),
+      );
+
+      const parsed = JSON.parse(payload!.trimEnd());
+      const { content } = parsed.message;
+      expect(content).toHaveLength(2); // 1 image + 1 text
+      expect(content[0].source.media_type).toBe("image/jpeg");
+    });
+
+    it("ends payload with newline", () => {
+      const payload = runtime.testBuildStdinPayload(
+        makeParams({
+          media: [{ mimeType: "image/jpeg", base64: "dGVzdA==" }],
+        }),
+      );
+      expect(payload).toMatch(/\n$/);
+    });
+  });
+
+  // ── mediaCapabilities ──────────────────────────────────────────────────
+
+  describe("mediaCapabilities", () => {
+    it("accepts inbound images", () => {
+      expect(runtime.mediaCapabilities.acceptsInbound).toEqual(["image/"]);
+    });
+
+    it("does not emit outbound media", () => {
+      expect(runtime.mediaCapabilities.emitsOutbound).toBe(false);
     });
   });
 

--- a/src/middleware/runtimes/claude.ts
+++ b/src/middleware/runtimes/claude.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+import { logDebug } from "../../logger.js";
 import { CLIRuntimeBase } from "../cli-runtime-base.js";
 import type {
   AgentDoneEvent,
@@ -7,6 +9,7 @@ import type {
   AgentThinkingEvent,
   AgentToolUseEvent,
   AgentUsage,
+  MediaAttachment,
 } from "../types.js";
 
 /**
@@ -38,7 +41,8 @@ export class ClaudeCliRuntime extends CLIRuntimeBase {
 
   async *execute(params: AgentExecuteParams): AsyncIterable<AgentEvent> {
     this.resetState();
-    for await (const event of super.execute(params)) {
+    const prepared = await this.prepareMedia(params);
+    for await (const event of super.execute(prepared)) {
       if (event.type === "done") {
         this.enrichDoneEvent(event);
       }
@@ -64,10 +68,43 @@ export class ClaudeCliRuntime extends CLIRuntimeBase {
       args.push("--mcp-config", JSON.stringify({ mcpServers: params.mcpServers }));
     }
 
-    // --print <prompt> comes last so it doesn't interfere with other flags.
-    args.push("--print", params.prompt);
+    // When image media is present (with base64 populated), use stream-json stdin
+    // delivery instead of --print so content blocks can carry inline images.
+    // -p activates print mode (required for --input-format / --output-format).
+    const hasImages = params.media?.some((m) => m.mimeType.startsWith("image/") && m.base64);
+    if (hasImages) {
+      args.push("-p", "--input-format", "stream-json");
+    } else {
+      // --print <prompt> comes last so it doesn't interfere with other flags.
+      args.push("--print", params.prompt);
+    }
 
     return args;
+  }
+
+  protected buildStdinPayload(params: AgentExecuteParams): string | undefined {
+    const images = params.media?.filter((m) => m.mimeType.startsWith("image/") && m.base64);
+    if (!images?.length) {
+      return undefined;
+    }
+
+    const content: unknown[] = images.map((img) => ({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: img.mimeType,
+        data: img.base64,
+      },
+    }));
+    content.push({ type: "text", text: params.prompt });
+
+    // Claude CLI --input-format stream-json expects each line to be a
+    // { type: "user", message: { role: "user", content: [...] } } envelope.
+    const envelope = {
+      type: "user",
+      message: { role: "user", content },
+    };
+    return JSON.stringify(envelope) + "\n";
   }
 
   protected extractEvent(line: string): AgentEvent | null {
@@ -247,6 +284,45 @@ export class ClaudeCliRuntime extends CLIRuntimeBase {
     if (this.resultData?.numTurns !== undefined) {
       result.numTurns = this.resultData.numTurns;
     }
+  }
+
+  // ── Media preparation ────────────────────────────────────────────────
+
+  /**
+   * Read image files referenced by media attachments and populate their base64 field.
+   * Non-image media types are filtered out (audio/video are not supported natively).
+   */
+  private async prepareMedia(params: AgentExecuteParams): Promise<AgentExecuteParams> {
+    if (!params.media?.length) {
+      return params;
+    }
+
+    const prepared: MediaAttachment[] = [];
+    for (const attachment of params.media) {
+      if (!attachment.mimeType.startsWith("image/")) {
+        continue;
+      }
+
+      if (attachment.base64) {
+        prepared.push(attachment);
+        continue;
+      }
+
+      if (attachment.filePath) {
+        try {
+          const buffer = await readFile(attachment.filePath);
+          prepared.push({ ...attachment, base64: buffer.toString("base64") });
+        } catch {
+          logDebug(`[claude-runtime] failed to read media file: ${attachment.filePath}`);
+        }
+        continue;
+      }
+    }
+
+    return {
+      ...params,
+      media: prepared.length > 0 ? prepared : undefined,
+    };
   }
 
   // ── State reset ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add inbound image support to Claude CLI runtime via `--input-format stream-json` stdin mode
- Add `buildStdinPayload()` hook to `CLIRuntimeBase` for custom stdin delivery
- `prepareMedia()` reads image files from disk and populates base64 fields
- Non-image media (audio/video) is filtered out; only `image/*` is accepted
- `mediaCapabilities` declares `acceptsInbound: ["image/"]`, `emitsOutbound: false`

## Test plan

- [x] Unit tests: `buildArgs` with image media → `-p --input-format stream-json` (no `--print`)
- [x] Unit tests: `buildArgs` without media → `--print` (backwards compat)
- [x] Unit tests: `buildArgs` with non-image media → `--print` (ignores audio/video)
- [x] Unit tests: `buildStdinPayload` constructs correct `{ type: "user", message: {...} }` envelope
- [x] Unit tests: `buildStdinPayload` returns undefined for non-image/missing media
- [x] Unit tests: `mediaCapabilities` reports correct values
- [x] Live smoke test: send 100x100 red PNG → Claude responds "Red"
- [x] Live smoke test: text-only prompt still works (existing test)
- [x] Live smoke test: session resumption still works (existing test)
- [x] All 47 unit tests pass, all 3 live smoke tests pass
- [x] Typecheck, lint, format all clean

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)