### PR TITLE
docs(install): fix OpenCode link to point to active repo

### DIFF
--- a/docs/install/from-openclaw.mdx
+++ b/docs/install/from-openclaw.mdx
@@ -111,7 +111,7 @@ Read [Breaking changes from OpenClaw](/install/breaking-changes-from-openclaw) t
     | `claude` (default) | [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) | `ANTHROPIC_API_KEY`                  |
     | `gemini`           | [Gemini CLI](https://github.com/google-gemini/gemini-cli)                               | `GEMINI_API_KEY` or `GOOGLE_API_KEY` |
     | `codex`            | [Codex CLI](https://github.com/openai/codex)                                            | `OPENAI_API_KEY`                     |
-    | `opencode`         | [OpenCode](https://github.com/opencode-ai/opencode)                                     | Provider-specific                    |
+    | `opencode`         | [OpenCode](https://github.com/anomalyco/opencode)                                       | Provider-specific                    |
 
     Set the runtime in your config:
 


### PR DESCRIPTION
## Summary

- Replace archived `opencode-ai/opencode` URL with active `anomalyco/opencode` in the migration guide runtime table

Closes #520

## Test plan

- [ ] Verify the link resolves to the active OpenCode repository
- [ ] Docs build passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)