### PR TITLE
docs(install): fix `--channel dev` → `--channel next` in updating.md

### DIFF
--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -61,7 +61,7 @@ To switch update channels (git + npm installs):
 
 ```bash
 remoteclaw update --channel beta
-remoteclaw update --channel dev
+remoteclaw update --channel next
 remoteclaw update --channel stable
 ```
 
@@ -93,7 +93,7 @@ Behavior:
 
 - `stable`: when a new version is seen, RemoteClaw waits `stableDelayHours` and then applies a deterministic per-install jitter in `stableJitterHours` (spread rollout).
 - `beta`: checks on `betaCheckIntervalHours` cadence (default: hourly) and applies when an update is available.
-- `dev`: no automatic apply; use manual `remoteclaw update`.
+- `next`: no automatic apply; use manual `remoteclaw update`.
 
 Use `remoteclaw update --dry-run` to preview update actions before enabling automation.
 
@@ -122,7 +122,7 @@ It runs a safe-ish update flow:
 
 - Requires a clean worktree.
 - Switches to the selected channel (tag or branch).
-- Fetches + rebases against the configured upstream (dev channel).
+- Fetches + rebases against the configured upstream (next channel).
 - Installs deps, builds, builds the Control UI, and runs `remoteclaw doctor`.
 - Restarts the gateway by default (use `--no-restart` to skip).
 


### PR DESCRIPTION
## Summary

- Replace three occurrences of the non-existent `dev` channel with `next` in `docs/install/updating.md` (lines 64, 96, 125)
- Aligns docs with the valid `stable | beta | next` channel enum defined in `src/cli/update-cli/update-command.ts`

Closes #503

## Test plan

- [ ] Verify no remaining `--channel dev` references in `updating.md`
- [ ] Confirm `next` matches the source-of-truth channel values

🤖 Generated with [Claude Code](https://claude.com/claude-code)