### PR TITLE
docs(tools): add missing directives to slash-commands.md

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -14,7 +14,7 @@ The host-only bash chat command uses `! <cmd>` (with `/bash <cmd>` as an alias).
 There are two related systems:
 
 - **Commands**: standalone `/...` messages.
-- **Directives**: `/verbose`, `/queue`.
+- **Directives**: `/verbose`, `/queue`, `/elevated` (`/elev`), `/notice` (`/notices`), `/model`.
   - Directives are stripped from the message before the model sees it.
   - In normal chat messages (not directive-only), they are treated as “inline hints” and do **not** persist session settings.
   - In directive-only messages (the message contains only directives), they persist to the session and reply with an acknowledgement.
@@ -97,6 +97,9 @@ Text + native (when enabled):
 - `/reset` or `/new` (remainder is passed through)
 - `/verbose on|full|off` (alias: `/v`)
 - `/queue <mode>` (plus options like `debounce:2s cap:25 drop:summarize`; send `/queue` to see current settings)
+- `/elevated off|on|ask|full` (alias: `/elev`) (toggle elevated bash permissions; tracked for removal in #517)
+- `/notice off|on|full` (alias: `/notices`) (toggle system notice level)
+- `/model [provider/model[@profile]]` (switch model mid-session; `/model status` or `/model list` to show current; supports config-defined aliases)
 
 Text-only:
 


### PR DESCRIPTION
## Summary

- Add `/elevated` (`/elev`), `/notice` (`/notices`), and `/model` directives to `docs/tools/slash-commands.md`
- Update the directives summary list to include all functional directives
- Each entry documents accepted values, aliases, and behavior

Closes #505

## Test plan

- [ ] Verify the documented values match the source in `src/auto-reply/reply/directives.ts` and `src/auto-reply/model.ts`
- [ ] Confirm no formatting issues in the rendered markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)