### PR TITLE
docs(start): update channel list to reflect 20+ integrations (#502)

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -26,10 +26,11 @@ import { Card, CardGrid, Steps } from "@astrojs/starlight/components";
 
 <p align="center">
   <strong>
-    Any OS gateway for AI agents across WhatsApp, Telegram, Discord, iMessage, and more.
+    Any OS gateway for AI agents across 20+ channels — WhatsApp, Telegram, Discord, iMessage,
+    Signal, Slack, Matrix, and more.
   </strong>
   <br />
-  Send a message, get an agent response from your pocket. Plugins add Mattermost and more.
+  Send a message, get an agent response from your pocket.
 </p>
 
 <CardGrid>

--- a/docs/start/remoteclaw.md
+++ b/docs/start/remoteclaw.md
@@ -8,7 +8,7 @@ title: "Personal Assistant Setup"
 
 # Building a personal assistant with RemoteClaw
 
-RemoteClaw is a WhatsApp + Telegram + Discord + iMessage gateway for **CLI agents** (Claude, Gemini, Codex, OpenCode). Plugins add Mattermost. This guide is the "personal assistant" setup: one dedicated WhatsApp number that behaves like your always-on agent.
+RemoteClaw is a gateway for **CLI agents** (Claude, Gemini, Codex, OpenCode) with 20+ channel integrations — WhatsApp, Telegram, Discord, iMessage, Signal, Slack, Matrix, Microsoft Teams, Google Chat, LINE, and more. This guide is the "personal assistant" setup: one dedicated WhatsApp number that behaves like your always-on agent.
 
 ## ⚠️ Safety first
 
@@ -16,7 +16,7 @@ You’re putting an agent in a position to:
 
 - run commands on your machine (depending on the agent's configured tools/MCP servers)
 - read/write files in your workspace
-- send messages back out via WhatsApp/Telegram/Discord/Mattermost (plugin)
+- send messages back out via any connected channel (WhatsApp, Telegram, Slack, etc.)
 
 Start conservative:
 


### PR DESCRIPTION
## Summary

- Updated `docs/start/remoteclaw.md` intro to list 20+ channels (was only WhatsApp/Telegram/Discord/iMessage + "Plugins add Mattermost")
- Updated `docs/index.mdx` hero tagline to match — removed outdated "Plugins add Mattermost" phrasing
- Both now reference representative channels (WhatsApp, Telegram, Discord, iMessage, Signal, Slack, Matrix, etc.) with a "20+" count

Closes #502

## Test plan

- [ ] Verify docs site renders correctly with updated text
- [ ] Confirm no other docs reference the old 4-channel short list

🤖 Generated with [Claude Code](https://claude.com/claude-code)