### PR TITLE
feat(runtime/codex): multimodal I/O support — accept inbound images (#398)

### DIFF
--- a/src/middleware/__smoke__/codex.live.test.ts
+++ b/src/middleware/__smoke__/codex.live.test.ts
@@ -70,6 +70,25 @@ describe.skipIf(!LIVE)("codex CLI middleware smoke test", () => {
     firstSessionId = result.run.sessionId;
   }, 60_000);
 
+  it("processes an image attachment and describes the content", async () => {
+    // 100x100 solid red PNG (large enough for the API to process)
+    const pngBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/gAIDAAABFUlEQVR4nO3OUQkAIABEsetfWiv4Nx4IC7Cd7XvkByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIReeLesrH9s1agAAAABJRU5ErkJggg==";
+    const testImagePath = join(tempDir, "test-image.png");
+    await writeFile(testImagePath, Buffer.from(pngBase64, "base64"));
+
+    const msg = makeMessage("What color is this image? Reply with just the color name.");
+    msg.mediaUrls = [testImagePath];
+
+    const result = await bridge.handle(msg);
+
+    expect(result.payloads.length).toBeGreaterThan(0);
+    expect(result.run.text).toBeTruthy();
+    expect(result.run.text.toLowerCase()).toContain("red");
+    expect(result.run.aborted).toBe(false);
+    expect(result.run.sessionId).toBeTruthy();
+  }, 60_000);
+
   it("resumes the session on a follow-up message", async () => {
     expect(firstSessionId).toBeTruthy();
 

--- a/src/middleware/runtimes/codex.test.ts
+++ b/src/middleware/runtimes/codex.test.ts
@@ -135,6 +135,97 @@ describe("CodexCliRuntime", () => {
       );
       expect(args).not.toContain("--mcp-config");
     });
+
+    it("appends --image flag for image media with filePath", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          media: [{ mimeType: "image/png", filePath: "/tmp/photo.png" }],
+        }),
+      );
+      const imageIdx = args.indexOf("--image");
+      expect(imageIdx).toBeGreaterThan(-1);
+      expect(args[imageIdx + 1]).toBe("/tmp/photo.png");
+    });
+
+    it("appends multiple --image flags for multiple images", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          media: [
+            { mimeType: "image/png", filePath: "/tmp/a.png" },
+            { mimeType: "image/jpeg", filePath: "/tmp/b.jpg" },
+          ],
+        }),
+      );
+      const imageIndices = args.reduce<number[]>((acc, arg, i) => {
+        if (arg === "--image") {
+          acc.push(i);
+        }
+        return acc;
+      }, []);
+      expect(imageIndices).toHaveLength(2);
+      expect(args[imageIndices[0] + 1]).toBe("/tmp/a.png");
+      expect(args[imageIndices[1] + 1]).toBe("/tmp/b.jpg");
+    });
+
+    it("does not include --image when no media is provided", () => {
+      const args = runtime.testBuildArgs(makeParams());
+      expect(args).not.toContain("--image");
+    });
+
+    it("filters non-image media (no --image for audio/video)", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          media: [
+            { mimeType: "audio/ogg", filePath: "/tmp/audio.ogg" },
+            { mimeType: "video/mp4", filePath: "/tmp/video.mp4" },
+          ],
+        }),
+      );
+      expect(args).not.toContain("--image");
+    });
+
+    it("skips image media without filePath", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          media: [{ mimeType: "image/png", base64: "aW1hZ2U=" }],
+        }),
+      );
+      expect(args).not.toContain("--image");
+    });
+
+    it("does not include --image on session resume", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          sessionId: "thread-abc",
+          media: [{ mimeType: "image/png", filePath: "/tmp/photo.png" }],
+        }),
+      );
+      expect(args).not.toContain("--image");
+    });
+
+    it("places --image flags before the prompt", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          prompt: "Describe this",
+          media: [{ mimeType: "image/jpeg", filePath: "/tmp/img.jpg" }],
+        }),
+      );
+      const imageIdx = args.indexOf("--image");
+      const promptIdx = args.indexOf("Describe this");
+      expect(imageIdx).toBeLessThan(promptIdx);
+    });
+  });
+
+  // ── mediaCapabilities ─────────────────────────────────────────────────
+
+  describe("mediaCapabilities", () => {
+    it("accepts inbound images", () => {
+      expect(runtime.mediaCapabilities.acceptsInbound).toEqual(["image/"]);
+    });
+
+    it("does not emit outbound media", () => {
+      expect(runtime.mediaCapabilities.emitsOutbound).toBe(false);
+    });
   });
 
   // ── extractEvent ──────────────────────────────────────────────────────

--- a/src/middleware/runtimes/codex.ts
+++ b/src/middleware/runtimes/codex.ts
@@ -29,9 +29,9 @@ export class CodexCliRuntime extends CLIRuntimeBase {
   // ── Media capabilities ────────────────────────────────────────────────
 
   readonly mediaCapabilities = {
-    acceptsInbound: [] as string[],
+    acceptsInbound: ["image/"],
     emitsOutbound: false,
-  };
+  } as const;
 
   // ── Per-execution state (reset before each run) ───────────────────────
 
@@ -81,12 +81,25 @@ export class CodexCliRuntime extends CLIRuntimeBase {
   protected buildArgs(params: AgentExecuteParams): string[] {
     if (params.sessionId) {
       // Session resume: codex exec resume --json <id> <prompt>
-      // Note: --color is not supported by the resume subcommand
+      // Note: --color is not supported by the resume subcommand.
+      // Images are skipped on resume — Codex propagates conversation context internally.
       return ["exec", "resume", "--json", params.sessionId, params.prompt];
     }
 
-    // New session: codex exec --json --color never <prompt>
-    return ["exec", "--json", "--color", "never", params.prompt];
+    // New session: codex exec --json --color never [--image ...] <prompt>
+    const args = ["exec", "--json", "--color", "never"];
+
+    // Append --image flags for each image attachment with a file path
+    if (params.media) {
+      for (const attachment of params.media) {
+        if (attachment.mimeType.startsWith("image/") && attachment.filePath) {
+          args.push("--image", attachment.filePath);
+        }
+      }
+    }
+
+    args.push(params.prompt);
+    return args;
   }
 
   protected extractEvent(line: string): AgentEvent | null {


### PR DESCRIPTION
## Summary
- Update `mediaCapabilities` to accept `image/*` inbound media
- Add `--image <path>` flag injection in `buildArgs()` for image attachments
- Add unit tests for `buildArgs()` with image media and `mediaCapabilities` declaration
- Add live smoke test for image input

Closes #398

## Test plan
- [x] Unit tests for `buildArgs()` with image media
- [x] Unit tests for `mediaCapabilities` values
- [x] Live smoke test for image input

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>