### PR TITLE
gut(bootstrap): remove BOOTSTRAP.md creation from macOS app (#515)

### DIFF
--- a/apps/macos/Sources/RemoteClaw/AgentWorkspace.swift
+++ b/apps/macos/Sources/RemoteClaw/AgentWorkspace.swift
@@ -7,7 +7,6 @@ enum AgentWorkspace {
     static let soulFilename = "SOUL.md"
     static let identityFilename = "IDENTITY.md"
     static let userFilename = "USER.md"
-    static let bootstrapFilename = "BOOTSTRAP.md"
     private static let templateDirname = "templates"
     private static let ignoredEntries: Set<String> = [".DS_Store", ".git", ".gitignore"]
     private static let templateEntries: Set<String> = [
@@ -15,7 +14,6 @@ enum AgentWorkspace {
         AgentWorkspace.soulFilename,
         AgentWorkspace.identityFilename,
         AgentWorkspace.userFilename,
-        AgentWorkspace.bootstrapFilename,
     ]
     struct BootstrapSafety: Equatable {
         let unsafeReason: String?
@@ -92,7 +90,6 @@ enum AgentWorkspace {
     }
 
     static func bootstrap(workspaceURL: URL) throws -> URL {
-        let shouldSeedBootstrap = self.isWorkspaceEmpty(workspaceURL: workspaceURL)
         try FileManager().createDirectory(at: workspaceURL, withIntermediateDirectories: true)
         let agentsURL = self.agentsURL(workspaceURL: workspaceURL)
         if !FileManager().fileExists(atPath: agentsURL.path) {
@@ -114,11 +111,6 @@ enum AgentWorkspace {
             try self.defaultUserTemplate().write(to: userURL, atomically: true, encoding: .utf8)
             self.logger.info("Created USER.md at \(userURL.path, privacy: .public)")
         }
-        let bootstrapURL = workspaceURL.appendingPathComponent(self.bootstrapFilename)
-        if shouldSeedBootstrap, !FileManager().fileExists(atPath: bootstrapURL.path) {
-            try self.defaultBootstrapTemplate().write(to: bootstrapURL, atomically: true, encoding: .utf8)
-            self.logger.info("Created BOOTSTRAP.md at \(bootstrapURL.path, privacy: .public)")
-        }
         return agentsURL
     }
 
@@ -132,8 +124,6 @@ enum AgentWorkspace {
         if self.hasIdentity(workspaceURL: workspaceURL) {
             return false
         }
-        let bootstrapURL = workspaceURL.appendingPathComponent(self.bootstrapFilename)
-        guard fm.fileExists(atPath: bootstrapURL.path) else { return false }
         return self.isTemplateOnlyWorkspace(workspaceURL: workspaceURL)
     }
 
@@ -162,7 +152,6 @@ enum AgentWorkspace {
         This folder is the assistant's working directory.
 
         ## First run (one-time)
-        - If BOOTSTRAP.md exists, follow its ritual and delete it once complete.
         - Your agent identity lives in IDENTITY.md.
         - Your profile lives in USER.md.
 
@@ -230,53 +219,6 @@ enum AgentWorkspace {
         return self.loadTemplate(named: self.userFilename, fallback: fallback)
     }
 
-    static func defaultBootstrapTemplate() -> String {
-        let fallback = """
-        # BOOTSTRAP.md - First Run Ritual (delete after)
-
-        Hello. I was just born.
-
-        ## Your mission
-        Start a short, playful conversation and learn:
-        - Who am I?
-        - What am I?
-        - Who are you?
-        - How should I call you?
-
-        ## How to ask (cute + helpful)
-        Say:
-        "Hello! I was just born. Who am I? What am I? Who are you? How should I call you?"
-
-        Then offer suggestions:
-        - 3-5 name ideas.
-        - 3-5 creature/vibe combos.
-        - 5 emoji ideas.
-
-        ## Write these files
-        After the user chooses, update:
-
-        1) IDENTITY.md
-        - Name
-        - Creature
-        - Vibe
-        - Emoji
-
-        2) USER.md
-        - Name
-        - Preferred address
-        - Pronouns (optional)
-        - Timezone (optional)
-        - Notes
-
-        3) ~/.remoteclaw/remoteclaw.json
-        Set identity.name, identity.theme, identity.emoji to match IDENTITY.md.
-
-        ## Cleanup
-        Delete BOOTSTRAP.md once this is complete.
-        """
-        return self.loadTemplate(named: self.bootstrapFilename, fallback: fallback)
-    }
-
     private static func loadTemplate(named: String, fallback: String) -> String {
         for url in self.templateURLs(named: named) {
             if let content = try? String(contentsOf: url, encoding: .utf8) {
@@ -339,5 +281,5 @@ enum AgentWorkspace {
         return trimmed + "\n"
     }
 
-    // Identity is written by the agent during the bootstrap ritual.
+    // Identity is written by the agent during onboarding.
 }

--- a/apps/macos/Sources/RemoteClaw/OnboardingView+Chat.swift
+++ b/apps/macos/Sources/RemoteClaw/OnboardingView+Chat.swift
@@ -15,10 +15,10 @@ extension OnboardingView {
             guard self.onboardingChatModel.messages.isEmpty else { return }
             let kickoff =
                 "Hi! I just installed RemoteClaw and you’re my brand‑new agent. " +
-                "Please start the first‑run ritual from BOOTSTRAP.md, ask one question at a time, " +
-                "and before we talk about WhatsApp/Telegram, visit soul.md with me to craft SOUL.md: " +
-                "ask what matters to me and how you should be. Then guide me through choosing " +
-                "how we should talk (web‑only, WhatsApp, or Telegram)."
+                "Please help me set up my agent identity — ask one question at a time " +
+                "to fill in IDENTITY.md and USER.md. Then visit SOUL.md with me: " +
+                "ask what matters to me and how you should be. Finally, guide me through " +
+                "choosing how we should talk (web‑only, WhatsApp, or Telegram)."
             self.onboardingChatModel.input = kickoff
             self.onboardingChatModel.send()
         }

--- a/apps/macos/Tests/RemoteClawIPCTests/AgentWorkspaceTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/AgentWorkspaceTests.swift
@@ -40,10 +40,8 @@ struct AgentWorkspaceTests {
 
         let identityURL = tmp.appendingPathComponent(AgentWorkspace.identityFilename)
         let userURL = tmp.appendingPathComponent(AgentWorkspace.userFilename)
-        let bootstrapURL = tmp.appendingPathComponent(AgentWorkspace.bootstrapFilename)
         #expect(FileManager().fileExists(atPath: identityURL.path))
         #expect(FileManager().fileExists(atPath: userURL.path))
-        #expect(FileManager().fileExists(atPath: bootstrapURL.path))
 
         let second = try AgentWorkspace.bootstrap(workspaceURL: tmp)
         #expect(second == agentsURL)
@@ -76,17 +74,14 @@ struct AgentWorkspaceTests {
     }
 
     @Test
-    func bootstrapSkipsBootstrapFileWhenWorkspaceHasContent() throws {
+    func bootstrapDoesNotCreateBootstrapFile() throws {
         let tmp = FileManager().temporaryDirectory
             .appendingPathComponent("remoteclaw-ws-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager().removeItem(at: tmp) }
-        try FileManager().createDirectory(at: tmp, withIntermediateDirectories: true)
-        let marker = tmp.appendingPathComponent("notes.txt")
-        try "hello".write(to: marker, atomically: true, encoding: .utf8)
 
         _ = try AgentWorkspace.bootstrap(workspaceURL: tmp)
 
-        let bootstrapURL = tmp.appendingPathComponent(AgentWorkspace.bootstrapFilename)
+        let bootstrapURL = tmp.appendingPathComponent("BOOTSTRAP.md")
         #expect(!FileManager().fileExists(atPath: bootstrapURL.path))
     }
 
@@ -105,8 +100,6 @@ struct AgentWorkspaceTests {
         - Vibe: Helpful
         - Emoji: crab
         """.write(to: identityURL, atomically: true, encoding: .utf8)
-        let bootstrapURL = tmp.appendingPathComponent(AgentWorkspace.bootstrapFilename)
-        try "bootstrap".write(to: bootstrapURL, atomically: true, encoding: .utf8)
 
         #expect(!AgentWorkspace.needsBootstrap(workspaceURL: tmp))
     }


### PR DESCRIPTION
## Summary
- Remove `bootstrapFilename` constant and `defaultBootstrapTemplate()` function
- Remove BOOTSTRAP.md creation from `bootstrap()` function
- Remove BOOTSTRAP.md ritual reference from AGENTS.md template
- Update onboarding chat kickoff message to remove BOOTSTRAP.md reference
- Update test to remove bootstrap-related assertions

Closes #515

## Test plan
- [x] `grep -ri "BOOTSTRAP" apps/macos/` returns zero hits (excluding launchd)
- [x] macOS test expectations updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>