### PR TITLE
gut(config): remove dead commands.bash config flag (#518)

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -556,8 +556,6 @@ Include your own number in `allowFrom` to enable self-chat mode (ignores native 
   commands: {
     native: "auto", // register native commands when supported
     text: true, // parse /commands in chat messages
-    bash: false, // allow ! (alias: /bash)
-    bashForegroundMs: 2000,
     config: false, // allow /config
     debug: false, // allow /debug
     restart: false, // allow /restart + gateway restart tool
@@ -577,7 +575,6 @@ Include your own number in `allowFrom` to enable self-chat mode (ignores native 
 - `native: "auto"` turns on native commands for Discord/Telegram, leaves Slack off.
 - Override per channel: `channels.discord.commands.native` (bool or `"auto"`). `false` clears previously registered commands.
 - `channels.telegram.customCommands` adds extra Telegram bot menu entries.
-- `bash: true` enables `! <cmd>` for host shell. Requires `tools.elevated.enabled` and sender in `tools.elevated.allowFrom.<channel>`.
 - `config: true` enables `/config` (reads/writes `remoteclaw.json`).
 - `channels.<provider>.configWrites` gates config mutations per channel (default: true).
 - `allowFrom` is per-provider. When set, it is the **only** authorization source (channel allowlists/pairing and `useAccessGroups` are ignored).

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -9,7 +9,6 @@ title: "Slash Commands"
 # Slash commands
 
 Commands are handled by the Gateway. Most commands must be sent as a **standalone** message that starts with `/`.
-The host-only bash chat command uses `! <cmd>` (with `/bash <cmd>` as an alias).
 
 There are two related systems:
 
@@ -33,8 +32,6 @@ They run immediately, are stripped before the model sees the message, and the re
     native: "auto",
 
     text: true,
-    bash: false,
-    bashForegroundMs: 2000,
     config: false,
     debug: false,
     restart: false,
@@ -54,8 +51,6 @@ They run immediately, are stripped before the model sees the message, and the re
   - Set `channels.discord.commands.native`, `channels.telegram.commands.native`, or `channels.slack.commands.native` to override per provider (bool or `"auto"`).
   - `false` clears previously registered commands on Discord/Telegram at startup. Slack commands are managed in the Slack app and are not removed automatically.
 
-- `commands.bash` (default `false`) enables `! <cmd>` to run host shell commands (`/bash <cmd>` is an alias; requires `tools.elevated` allowlists).
-- `commands.bashForegroundMs` (default `2000`) controls how long bash waits before switching to background mode (`0` backgrounds immediately).
 - `commands.config` (default `false`) enables `/config` (reads/writes `remoteclaw.json`).
 - `commands.debug` (default `false`) enables `/debug` (runtime-only overrides).
 - `commands.allowFrom` (optional) sets a per-provider allowlist for command authorization. When configured, it is the
@@ -97,12 +92,6 @@ Text + native (when enabled):
 - `/reset` or `/new` (remainder is passed through)
 - `/verbose on|full|off` (alias: `/v`)
 - `/queue <mode>` (plus options like `debounce:2s cap:25 drop:summarize`; send `/queue` to see current settings)
-
-Text-only:
-
-- `! <command>` (host-only; one at a time; use `!poll` + `!stop` for long-running jobs)
-- `!poll` (check output / status; accepts optional `sessionId`; `/bash poll` also works)
-- `!stop` (stop the running bash job; accepts optional `sessionId`; `/bash stop` also works)
 
 Notes:
 

--- a/src/acp/commands.ts
+++ b/src/acp/commands.ts
@@ -34,7 +34,6 @@ export function getAvailableCommands(): AvailableCommand[] {
     { name: "elevated", description: "Toggle elevated mode (on|off)." },
     { name: "model", description: "Select a model (list|status|<name>)." },
     { name: "queue", description: "Adjust queue mode and options." },
-    { name: "bash", description: "Run a host command (if enabled)." },
     { name: "compact", description: "Compact the session history." },
   ];
 }

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -64,14 +64,12 @@ describe("commands registry", () => {
     const inheritedCommands = Object.create({
       config: true,
       debug: true,
-      bash: true,
     }) as Record<string, unknown>;
     const commands = listChatCommandsForConfig({
       commands: inheritedCommands as never,
     });
     expect(commands.find((spec) => spec.key === "config")).toBeFalsy();
     expect(commands.find((spec) => spec.key === "debug")).toBeFalsy();
-    expect(commands.find((spec) => spec.key === "bash")).toBeFalsy();
   });
 
   it("applies provider-specific native names", () => {

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -78,9 +78,6 @@ export function isCommandEnabled(cfg: RemoteClawConfig, commandKey: string): boo
   if (commandKey === "debug") {
     return isCommandFlagEnabled(cfg, "debug");
   }
-  if (commandKey === "bash") {
-    return isCommandFlagEnabled(cfg, "bash");
-  }
   return true;
 }
 

--- a/src/config/commands.test.ts
+++ b/src/config/commands.test.ts
@@ -73,14 +73,14 @@ describe("isRestartEnabled", () => {
 
 describe("isCommandFlagEnabled", () => {
   it("requires own boolean true", () => {
-    expect(isCommandFlagEnabled({ commands: { bash: true } }, "bash")).toBe(true);
-    expect(isCommandFlagEnabled({ commands: { bash: false } }, "bash")).toBe(false);
+    expect(isCommandFlagEnabled({ commands: { config: true } }, "config")).toBe(true);
+    expect(isCommandFlagEnabled({ commands: { config: false } }, "config")).toBe(false);
     expect(
       isCommandFlagEnabled(
         {
-          commands: Object.create({ bash: true }) as Record<string, unknown>,
+          commands: Object.create({ config: true }) as Record<string, unknown>,
         },
-        "bash",
+        "config",
       ),
     ).toBe(false);
   });

--- a/src/config/legacy.rules.ts
+++ b/src/config/legacy.rules.ts
@@ -86,10 +86,6 @@ export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
       "agent.* was moved; use agents.defaults (and tools.* for tool/elevated/exec settings) instead (auto-migrated on load).",
   },
   {
-    path: ["tools", "bash"],
-    message: "tools.bash was removed; use tools.exec instead (auto-migrated on load).",
-  },
-  {
     path: ["agent", "model"],
     message:
       "agent.model string was replaced by agents.defaults.model.primary/fallbacks and agents.defaults.models (auto-migrated on load).",

--- a/src/config/runtime-overrides.test.ts
+++ b/src/config/runtime-overrides.test.ts
@@ -51,28 +51,28 @@ describe("runtime overrides", () => {
 
   it("blocks __proto__ keys inside override object values", () => {
     const cfg = { commands: {} } as RemoteClawConfig;
-    setConfigOverride("commands", JSON.parse('{"__proto__":{"bash":true}}'));
+    setConfigOverride("commands", JSON.parse('{"__proto__":{"debug":true}}'));
 
     const next = applyConfigOverrides(cfg);
-    expect(next.commands?.bash).toBeUndefined();
-    expect(Object.prototype.hasOwnProperty.call(next.commands ?? {}, "bash")).toBe(false);
+    expect(next.commands?.debug).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(next.commands ?? {}, "debug")).toBe(false);
   });
 
   it("blocks constructor/prototype keys inside override object values", () => {
     const cfg = { commands: {} } as RemoteClawConfig;
-    setConfigOverride("commands", JSON.parse('{"constructor":{"prototype":{"bash":true}}}'));
+    setConfigOverride("commands", JSON.parse('{"constructor":{"prototype":{"debug":true}}}'));
 
     const next = applyConfigOverrides(cfg);
-    expect(next.commands?.bash).toBeUndefined();
-    expect(Object.prototype.hasOwnProperty.call(next.commands ?? {}, "bash")).toBe(false);
+    expect(next.commands?.debug).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(next.commands ?? {}, "debug")).toBe(false);
   });
 
   it("sanitizes blocked object keys when writing overrides", () => {
-    setConfigOverride("commands", JSON.parse('{"__proto__":{"bash":true},"debug":true}'));
+    setConfigOverride("commands", JSON.parse('{"__proto__":{"debug":true},"config":true}'));
 
     expect(getConfigOverrides()).toEqual({
       commands: {
-        debug: true,
+        config: true,
       },
     });
   });

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -649,10 +649,6 @@ export const FIELD_HELP: Record<string, string> = {
 
   "commands.text":
     "Enables text-command parsing in chat input in addition to native command surfaces where available. Keep this enabled for compatibility across channels that do not support native command registration.",
-  "commands.bash":
-    "Allow bash chat command (`!`; `/bash` alias) to run host shell commands (default: false; requires tools.elevated).",
-  "commands.bashForegroundMs":
-    "How long bash waits before backgrounding (default: 2000; 0 backgrounds immediately).",
   "commands.config": "Allow /config chat command to read/write config on disk (default: false).",
   "commands.debug": "Allow /debug chat command for runtime-only overrides (default: false).",
   "commands.restart": "Allow /restart and gateway restart tool actions (default: true).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -264,8 +264,6 @@ export const FIELD_LABELS: Record<string, string> = {
   "commands.native": "Native Commands",
 
   "commands.text": "Text Commands",
-  "commands.bash": "Allow Bash Chat Command",
-  "commands.bashForegroundMs": "Bash Foreground Window (ms)",
   "commands.config": "Allow /config",
   "commands.debug": "Allow /debug",
   "commands.restart": "Allow Restart",

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -138,10 +138,6 @@ export type CommandsConfig = {
   native?: NativeCommandsSetting;
   /** Enable text command parsing (default: true). */
   text?: boolean;
-  /** Allow bash chat command (`!`; `/bash` alias) (default: false). */
-  bash?: boolean;
-  /** How long bash waits before backgrounding (default: 2000; 0 backgrounds immediately). */
-  bashForegroundMs?: number;
   /** Allow /config command (default: false). */
   config?: boolean;
   /** Allow /debug command (default: false). */

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -192,8 +192,6 @@ export const CommandsSchema = z
     native: NativeCommandsSettingSchema.optional().default("auto"),
 
     text: z.boolean().optional(),
-    bash: z.boolean().optional(),
-    bashForegroundMs: z.number().int().min(0).max(30_000).optional(),
     config: z.boolean().optional(),
     debug: z.boolean().optional(),
     restart: z.boolean().optional().default(true),


### PR DESCRIPTION
## Summary
- Remove `commands.bash` and `commands.bashForegroundMs` from config types and Zod schema
- Remove bash-specific check from `isCommandEnabled()` in commands registry
- Remove `tools.bash` → `tools.exec` legacy migration rule
- Remove documentation for bash command, `!` syntax, `!poll`, `!stop`
- Remove `commands.bash`/`commands.bashForegroundMs` from gateway config reference
- Update tests to reflect removed config fields

Closes #518

## Test plan
- [x] Config fields removed from types, schema, help text, and labels
- [x] Legacy migration rule removed
- [x] Commands registry no longer references bash
- [x] Documentation cleaned up
- [x] Tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>