### PR TITLE
gut(config): remove dead auto-migration test (#545)

### DIFF
--- a/src/config/config.legacy-config-detection.accepts-imessage-dmpolicy.test.ts
+++ b/src/config/config.legacy-config-detection.accepts-imessage-dmpolicy.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
-const { loadConfig, readConfigFileSnapshot, validateConfigObject } =
+const { readConfigFileSnapshot, validateConfigObject } =
   await vi.importActual<typeof import("./config.js")>("./config.js");
 import { withTempHome } from "./test-helpers.js";
 
@@ -185,36 +185,6 @@ describe("legacy config detection", () => {
   ])("$name", ({ config }) => {
     const res = validateConfigObject(config);
     expect(res.ok).toBe(true);
-  });
-  it("does not auto-migrate claude-cli auth profile mode on load", async () => {
-    await withTempHome(async (home) => {
-      const configPath = path.join(home, ".remoteclaw", "remoteclaw.json");
-      await fs.mkdir(path.dirname(configPath), { recursive: true });
-      await fs.writeFile(
-        configPath,
-        JSON.stringify(
-          {
-            auth: {
-              profiles: {
-                "anthropic:claude-cli": { provider: "anthropic", mode: "token" },
-              },
-            },
-          },
-          null,
-          2,
-        ),
-        "utf-8",
-      );
-
-      const cfg = loadConfig();
-      expect(cfg.auth?.profiles?.["anthropic:claude-cli"]?.mode).toBe("token");
-
-      const raw = await fs.readFile(configPath, "utf-8");
-      const parsed = JSON.parse(raw) as {
-        auth?: { profiles?: Record<string, { mode?: string }> };
-      };
-      expect(parsed.auth?.profiles?.["anthropic:claude-cli"]?.mode).toBe("token");
-    });
   });
   it("rejects bindings[].match.provider on load", async () => {
     await expectLoadRejectionPreservesField({


### PR DESCRIPTION
## Summary

- Removed the `does not auto-migrate claude-cli auth profile mode on load` test from `config.legacy-config-detection.accepts-imessage-dmpolicy.test.ts` — this tested migration behavior that no longer exists (migrations array is empty)
- Removed unused `loadConfig` import
- Completes the legacy migration cleanup started in #549, which missed this test

**20 schema validation tests retained, 1 dead migration test removed.**

## Test plan

- [x] `pnpm check` passes (format + typecheck + lint)
- [x] `pnpm test` passes — all 871 gateway tests green
- [x] Modified test file runs: 20 tests pass

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)