### PR TITLE
feat(channels): enhance Slack setup wizard with manifest customization

### DIFF
--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -5,6 +5,11 @@ import {
   resolveDefaultSlackAccountId,
   resolveSlackAccount,
 } from "../../../slack/accounts.js";
+import {
+  type SlackManifestConfig,
+  buildSlackManifest,
+  defaultManifestConfig,
+} from "../../../slack/manifest.js";
 import { resolveSlackChannelAllowlist } from "../../../slack/resolve-channels.js";
 import { resolveSlackUserAllowlist } from "../../../slack/resolve-users.js";
 import { formatDocsLink } from "../../../terminal/links.js";
@@ -26,91 +31,81 @@ import {
 
 const channel = "slack" as const;
 
-function buildSlackManifest(botName: string) {
-  const safeName = botName.trim() || "RemoteClaw";
-  const manifest = {
-    display_information: {
-      name: safeName,
-      description: `${safeName} connector for RemoteClaw`,
-    },
-    features: {
-      bot_user: {
-        display_name: safeName,
-        always_online: false,
-      },
-      app_home: {
-        messages_tab_enabled: true,
-        messages_tab_read_only_enabled: false,
-      },
-      slash_commands: [
-        {
-          command: "/remoteclaw",
-          description: "Send a message to RemoteClaw",
-          should_escape: false,
-        },
-      ],
-    },
-    oauth_config: {
-      scopes: {
-        bot: [
-          "chat:write",
-          "channels:history",
-          "channels:read",
-          "groups:history",
-          "im:history",
-          "mpim:history",
-          "users:read",
-          "app_mentions:read",
-          "reactions:read",
-          "reactions:write",
-          "pins:read",
-          "pins:write",
-          "emoji:read",
-          "commands",
-          "files:read",
-          "files:write",
-        ],
-      },
-    },
-    settings: {
-      socket_mode_enabled: true,
-      event_subscriptions: {
-        bot_events: [
-          "app_mention",
-          "message.channels",
-          "message.groups",
-          "message.im",
-          "message.mpim",
-          "reaction_added",
-          "reaction_removed",
-          "member_joined_channel",
-          "member_left_channel",
-          "channel_rename",
-          "pin_added",
-          "pin_removed",
-        ],
-      },
-    },
-  };
-  return JSON.stringify(manifest, null, 2);
+async function promptManifestConfig(
+  prompter: WizardPrompter,
+  botName: string,
+): Promise<SlackManifestConfig> {
+  const transport = await prompter.select<"socket" | "http">({
+    message: "Connection mode",
+    options: [
+      { value: "socket", label: "Socket Mode", hint: "recommended" },
+      { value: "http", label: "HTTP Mode", hint: "requires public URL" },
+    ],
+    initialValue: "socket",
+  });
+
+  const includeSlashCommand = await prompter.confirm({
+    message: "Include slash command?",
+    initialValue: true,
+  });
+
+  let slashCommand: string | false = false;
+  if (includeSlashCommand) {
+    slashCommand = String(
+      await prompter.text({
+        message: "Slash command name",
+        initialValue: defaultManifestConfig.slashCommand as string,
+      }),
+    ).trim();
+  }
+
+  const customIdentity = await prompter.confirm({
+    message: "Include custom bot identity? (chat:write.customize)",
+    initialValue: false,
+  });
+
+  const streaming = await prompter.confirm({
+    message: "Include streaming support? (assistant:write)",
+    initialValue: false,
+  });
+
+  return { botName, transport, slashCommand, customIdentity, streaming };
 }
 
-async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Promise<void> {
-  const manifest = buildSlackManifest(botName);
+async function noteSlackTokenHelp(
+  prompter: WizardPrompter,
+  manifestConfig: SlackManifestConfig,
+): Promise<void> {
+  const manifest = buildSlackManifest(manifestConfig);
+  const modeLabel = manifestConfig.transport === "socket" ? "socket mode" : "HTTP mode";
+  const steps =
+    manifestConfig.transport === "socket"
+      ? [
+          "1) Go to api.slack.com/apps → Create New App → From an app manifest",
+          "2) Select your workspace",
+          "3) Paste the manifest above → Create",
+          "4) Socket Mode → Enable → Generate app-level token (xapp-...)",
+          "5) Install App → Install to Workspace → copy bot token (xoxb-...)",
+        ]
+      : [
+          "1) Go to api.slack.com/apps → Create New App → From an app manifest",
+          "2) Select your workspace",
+          "3) Paste the manifest above → Create",
+          "4) Update the request URL to your public endpoint",
+          "5) Install App → Install to Workspace → copy bot token (xoxb-...)",
+        ];
+
   await prompter.note(
     [
-      "1) Slack API → Create App → From scratch",
-      "2) Add Socket Mode + enable it to get the app-level token (xapp-...)",
-      "3) OAuth & Permissions → install app to workspace (xoxb- bot token)",
-      "4) Enable Event Subscriptions (socket) for message events",
-      "5) App Home → enable the Messages tab for DMs",
+      ...steps,
+      "",
       "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
       `Docs: ${formatDocsLink("/slack", "slack")}`,
       "",
       "Manifest (JSON):",
       manifest,
     ].join("\n"),
-    "Slack socket mode tokens",
+    `Slack ${modeLabel} tokens`,
   );
 }
 
@@ -262,8 +257,9 @@ export const slackOnboardingAdapter: ChannelOnboardingAdapter = {
         initialValue: "RemoteClaw",
       }),
     ).trim();
+    const manifestConfig = await promptManifestConfig(prompter, slackBotName);
     if (!accountConfigured) {
-      await noteSlackTokenHelp(prompter, slackBotName);
+      await noteSlackTokenHelp(prompter, manifestConfig);
     }
     if (canUseEnv && (!resolvedAccount.config.botToken || !resolvedAccount.config.appToken)) {
       const keepEnv = await prompter.confirm({

--- a/src/slack/manifest.test.ts
+++ b/src/slack/manifest.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { buildSlackManifest, defaultManifestConfig } from "./manifest.js";
+
+describe("buildSlackManifest", () => {
+  it("produces valid JSON with defaults", () => {
+    const json = buildSlackManifest();
+    const manifest = JSON.parse(json);
+    expect(manifest.display_information.name).toBe("RemoteClaw");
+    expect(manifest.settings.socket_mode_enabled).toBe(true);
+    expect(manifest.features.slash_commands).toHaveLength(1);
+    expect(manifest.features.slash_commands[0].command).toBe("/remoteclaw");
+    expect(manifest.oauth_config.scopes.bot).toContain("commands");
+  });
+
+  it("uses custom bot name", () => {
+    const manifest = JSON.parse(buildSlackManifest({ botName: "MyBot" }));
+    expect(manifest.display_information.name).toBe("MyBot");
+    expect(manifest.features.bot_user.display_name).toBe("MyBot");
+    expect(manifest.display_information.description).toBe("MyBot connector for RemoteClaw");
+  });
+
+  it("falls back to RemoteClaw for empty bot name", () => {
+    const manifest = JSON.parse(buildSlackManifest({ botName: "  " }));
+    expect(manifest.display_information.name).toBe("RemoteClaw");
+  });
+
+  describe("transport modes", () => {
+    it("enables socket mode by default", () => {
+      const manifest = JSON.parse(buildSlackManifest({ transport: "socket" }));
+      expect(manifest.settings.socket_mode_enabled).toBe(true);
+      expect(manifest.settings.event_subscriptions.request_url).toBeUndefined();
+    });
+
+    it("disables socket mode and adds request_url for http", () => {
+      const manifest = JSON.parse(buildSlackManifest({ transport: "http" }));
+      expect(manifest.settings.socket_mode_enabled).toBe(false);
+      expect(manifest.settings.event_subscriptions.request_url).toBe(
+        "https://example.com/slack/events",
+      );
+    });
+  });
+
+  describe("slash command", () => {
+    it("includes slash command and commands scope by default", () => {
+      const manifest = JSON.parse(buildSlackManifest());
+      expect(manifest.features.slash_commands).toBeDefined();
+      expect(manifest.oauth_config.scopes.bot).toContain("commands");
+    });
+
+    it("uses custom slash command name", () => {
+      const manifest = JSON.parse(buildSlackManifest({ slashCommand: "mybot" }));
+      expect(manifest.features.slash_commands[0].command).toBe("/mybot");
+    });
+
+    it("omits slash command and commands scope when false", () => {
+      const manifest = JSON.parse(buildSlackManifest({ slashCommand: false }));
+      expect(manifest.features.slash_commands).toBeUndefined();
+      expect(manifest.oauth_config.scopes.bot).not.toContain("commands");
+    });
+  });
+
+  describe("optional scopes", () => {
+    it("adds chat:write.customize when customIdentity is true", () => {
+      const manifest = JSON.parse(buildSlackManifest({ customIdentity: true }));
+      expect(manifest.oauth_config.scopes.bot).toContain("chat:write.customize");
+    });
+
+    it("omits chat:write.customize by default", () => {
+      const manifest = JSON.parse(buildSlackManifest());
+      expect(manifest.oauth_config.scopes.bot).not.toContain("chat:write.customize");
+    });
+
+    it("adds assistant:write when streaming is true", () => {
+      const manifest = JSON.parse(buildSlackManifest({ streaming: true }));
+      expect(manifest.oauth_config.scopes.bot).toContain("assistant:write");
+    });
+
+    it("omits assistant:write by default", () => {
+      const manifest = JSON.parse(buildSlackManifest());
+      expect(manifest.oauth_config.scopes.bot).not.toContain("assistant:write");
+    });
+  });
+
+  it("combines all options", () => {
+    const manifest = JSON.parse(
+      buildSlackManifest({
+        botName: "CustomBot",
+        transport: "http",
+        slashCommand: "custom",
+        customIdentity: true,
+        streaming: true,
+      }),
+    );
+    expect(manifest.display_information.name).toBe("CustomBot");
+    expect(manifest.settings.socket_mode_enabled).toBe(false);
+    expect(manifest.features.slash_commands[0].command).toBe("/custom");
+    expect(manifest.oauth_config.scopes.bot).toContain("chat:write.customize");
+    expect(manifest.oauth_config.scopes.bot).toContain("assistant:write");
+    expect(manifest.oauth_config.scopes.bot).toContain("commands");
+  });
+
+  it("always includes core bot events", () => {
+    const manifest = JSON.parse(buildSlackManifest());
+    const events = manifest.settings.event_subscriptions.bot_events;
+    expect(events).toContain("app_mention");
+    expect(events).toContain("message.im");
+    expect(events).toContain("reaction_added");
+    expect(events).toContain("pin_added");
+  });
+
+  it("defaultManifestConfig has expected values", () => {
+    expect(defaultManifestConfig).toEqual({
+      botName: "RemoteClaw",
+      transport: "socket",
+      slashCommand: "remoteclaw",
+      customIdentity: false,
+      streaming: false,
+    });
+  });
+});

--- a/src/slack/manifest.ts
+++ b/src/slack/manifest.ts
@@ -1,0 +1,118 @@
+/**
+ * Slack app manifest builder with configurable transport, scopes, and features.
+ */
+
+export type SlackManifestConfig = {
+  /** Bot display name (default: "RemoteClaw") */
+  botName: string;
+  /** Connection mode (default: "socket") */
+  transport: "socket" | "http";
+  /** Slash command name, or false to omit (default: "remoteclaw") */
+  slashCommand: string | false;
+  /** Adds chat:write.customize scope for per-message bot name/avatar */
+  customIdentity: boolean;
+  /** Adds assistant:write scope for Slack native thread streaming */
+  streaming: boolean;
+};
+
+export const defaultManifestConfig: SlackManifestConfig = {
+  botName: "RemoteClaw",
+  transport: "socket",
+  slashCommand: "remoteclaw",
+  customIdentity: false,
+  streaming: false,
+};
+
+export function buildSlackManifest(config: Partial<SlackManifestConfig> = {}): string {
+  const resolved: SlackManifestConfig = { ...defaultManifestConfig, ...config };
+  const safeName = resolved.botName.trim() || "RemoteClaw";
+
+  const botScopes: string[] = [
+    "chat:write",
+    "channels:history",
+    "channels:read",
+    "groups:history",
+    "im:history",
+    "mpim:history",
+    "users:read",
+    "app_mentions:read",
+    "reactions:read",
+    "reactions:write",
+    "pins:read",
+    "pins:write",
+    "emoji:read",
+    "files:read",
+    "files:write",
+  ];
+
+  if (resolved.slashCommand !== false) {
+    botScopes.push("commands");
+  }
+  if (resolved.customIdentity) {
+    botScopes.push("chat:write.customize");
+  }
+  if (resolved.streaming) {
+    botScopes.push("assistant:write");
+  }
+
+  const features: Record<string, unknown> = {
+    bot_user: {
+      display_name: safeName,
+      always_online: false,
+    },
+    app_home: {
+      messages_tab_enabled: true,
+      messages_tab_read_only_enabled: false,
+    },
+  };
+
+  if (resolved.slashCommand !== false) {
+    features.slash_commands = [
+      {
+        command: `/${resolved.slashCommand}`,
+        description: `Send a message to ${safeName}`,
+        should_escape: false,
+      },
+    ];
+  }
+
+  const eventSubscriptions: Record<string, unknown> = {
+    bot_events: [
+      "app_mention",
+      "message.channels",
+      "message.groups",
+      "message.im",
+      "message.mpim",
+      "reaction_added",
+      "reaction_removed",
+      "member_joined_channel",
+      "member_left_channel",
+      "channel_rename",
+      "pin_added",
+      "pin_removed",
+    ],
+  };
+
+  if (resolved.transport === "http") {
+    eventSubscriptions.request_url = "https://example.com/slack/events";
+  }
+
+  const manifest = {
+    display_information: {
+      name: safeName,
+      description: `${safeName} connector for RemoteClaw`,
+    },
+    features,
+    oauth_config: {
+      scopes: {
+        bot: botScopes,
+      },
+    },
+    settings: {
+      socket_mode_enabled: resolved.transport === "socket",
+      event_subscriptions: eventSubscriptions,
+    },
+  };
+
+  return JSON.stringify(manifest, null, 2);
+}


### PR DESCRIPTION
## Summary

- Extract `buildSlackManifest()` from `src/channels/plugins/onboarding/slack.ts` to `src/slack/manifest.ts` with a `SlackManifestConfig` type supporting transport mode (socket/HTTP), optional slash command, custom identity (`chat:write.customize`), and streaming (`assistant:write`)
- Enhance `channels add` wizard to prompt for manifest customization options (connection mode, slash command, optional scopes) before token collection when Slack is selected
- Non-interactive `channels add --channel slack --bot-token ... --app-token ...` path is unchanged

## Test plan

- [x] 15 unit tests for manifest generation covering all option combinations (transport modes, slash command inclusion/exclusion/custom name, optional scopes, combined options)
- [x] `pnpm check` passes (format + typecheck + lint)
- [x] `pnpm test` passes (only pre-existing flaky `server.canvas-auth.test.ts` failure, confirmed on main)

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)