### PR TITLE
fix(agents): wizard crashes before workspace prompt when adding new agent

### DIFF
--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -8,6 +8,9 @@ const wizardMocks = vi.hoisted(() => ({
   createClackPrompter: vi.fn(),
 }));
 
+const setupChannelsMock = vi.hoisted(() => vi.fn());
+const ensureWorkspaceAndSessionsMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
 vi.mock("../config/config.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../config/config.js")>()),
   readConfigFileSnapshot: readConfigFileSnapshotMock,
@@ -16,6 +19,16 @@ vi.mock("../config/config.js", async (importOriginal) => ({
 
 vi.mock("../wizard/clack-prompter.js", () => ({
   createClackPrompter: wizardMocks.createClackPrompter,
+}));
+
+vi.mock("./onboard-channels.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./onboard-channels.js")>()),
+  setupChannels: setupChannelsMock,
+}));
+
+vi.mock("./onboard-helpers.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./onboard-helpers.js")>()),
+  ensureWorkspaceAndSessions: ensureWorkspaceAndSessionsMock,
 }));
 
 import { WizardCancelledError } from "../wizard/prompts.js";
@@ -28,6 +41,8 @@ describe("agents add command", () => {
     readConfigFileSnapshotMock.mockClear();
     writeConfigFileMock.mockClear();
     wizardMocks.createClackPrompter.mockClear();
+    setupChannelsMock.mockClear();
+    ensureWorkspaceAndSessionsMock.mockClear();
     runtime.log.mockClear();
     runtime.error.mockClear();
     runtime.exit.mockClear();
@@ -69,5 +84,38 @@ describe("agents add command", () => {
 
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(writeConfigFileMock).not.toHaveBeenCalled();
+  });
+
+  it("completes interactive wizard for a new agent without crashing", async () => {
+    const cfg = { ...baseConfigSnapshot };
+    readConfigFileSnapshotMock.mockResolvedValue(cfg);
+    setupChannelsMock.mockImplementation((c: unknown) => Promise.resolve(c));
+
+    const textMock = vi
+      .fn()
+      .mockResolvedValueOnce("My Agent") // agent name
+      .mockResolvedValueOnce("/tmp/workspace"); // workspace directory
+    const confirmMock = vi.fn().mockResolvedValue(false);
+    const outroMock = vi.fn();
+
+    wizardMocks.createClackPrompter.mockReturnValue({
+      intro: vi.fn(),
+      text: textMock,
+      confirm: confirmMock,
+      select: vi.fn(),
+      note: vi.fn(),
+      outro: outroMock,
+    });
+
+    await agentsAddCommand({}, runtime);
+
+    expect(textMock).toHaveBeenCalledTimes(2);
+    expect(textMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ message: "Workspace directory" }),
+    );
+    expect(writeConfigFileMock).toHaveBeenCalled();
+    expect(outroMock).toHaveBeenCalledWith(expect.stringContaining("my-agent"));
+    expect(runtime.exit).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -1,4 +1,4 @@
-import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { resolveAgentDir, resolveAgentWorkspaceDirOrNull } from "../agents/agent-scope.js";
 import { upsertAuthProfile } from "../auth/index.js";
 import { writeConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
@@ -195,7 +195,7 @@ export async function agentsAddCommand(
       }
     }
 
-    const workspaceDefault = resolveAgentWorkspaceDir(cfg, agentId);
+    const workspaceDefault = resolveAgentWorkspaceDirOrNull(cfg, agentId) ?? process.cwd();
     const workspaceInput = await prompter.text({
       message: "Workspace directory",
       initialValue: workspaceDefault,


### PR DESCRIPTION
## Summary

- Replace `resolveAgentWorkspaceDir` (throws when no workspace configured) with
  `resolveAgentWorkspaceDirOrNull` + `process.cwd()` fallback in the interactive
  `agents add` wizard so new-agent creation reaches the workspace prompt
- Add test covering the full interactive wizard path for a new agent

Closes #558

## Test plan

- [x] New test: interactive wizard completes for a new agent without crashing
- [x] Existing tests pass (4/4 in `agents.add.test.ts`)
- [x] No type errors in changed files
- [x] oxlint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)