### PR TITLE
refactor(import): switch to glob-based file discovery

### DIFF
--- a/src/commands/import.test.ts
+++ b/src/commands/import.test.ts
@@ -8,6 +8,7 @@ import {
   clearWizardSection,
   consolidateAuthProfiles,
   detectOpenClawInstallation,
+  discoverImportableFiles,
   discoverSourceAuthProfileIds,
   discoverSourceAuthProfiles,
   importCommand,
@@ -929,6 +930,86 @@ describe("isImportableRootEntry", () => {
   });
 });
 
+describe("discoverImportableFiles", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "discover-import-test-"));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("discovers files matching glob patterns", async () => {
+    await fsp.mkdir(path.join(tmpDir, "agents", "main", "sessions"), { recursive: true });
+    await fsp.writeFile(path.join(tmpDir, "agents", "main", "sessions", "data.bin"), "bin");
+    await fsp.writeFile(path.join(tmpDir, ".env"), "KEY=value");
+    await fsp.writeFile(path.join(tmpDir, "openclaw.json"), "{}");
+
+    const files = await discoverImportableFiles(tmpDir);
+
+    expect(files).toContain(".env");
+    expect(files).toContain("openclaw.json");
+    expect(files).toContain(path.join("agents", "main", "sessions", "data.bin"));
+  });
+
+  it("excludes agent working directories (only sessions are imported)", async () => {
+    await fsp.mkdir(path.join(tmpDir, "agents", "main", "agent"), { recursive: true });
+    await fsp.mkdir(path.join(tmpDir, "agents", "main", "sessions"), { recursive: true });
+    await fsp.writeFile(
+      path.join(tmpDir, "agents", "main", "agent", "auth-profiles.json"),
+      '{"profiles":{}}',
+    );
+    await fsp.writeFile(path.join(tmpDir, "agents", "main", "agent", "auth.json"), "{}");
+    await fsp.writeFile(path.join(tmpDir, "agents", "main", "agent", "data.bin"), "bin");
+    await fsp.writeFile(path.join(tmpDir, "agents", "main", "sessions", "log.json"), "{}");
+
+    const files = await discoverImportableFiles(tmpDir);
+
+    expect(files).toContain(path.join("agents", "main", "sessions", "log.json"));
+    expect(files).not.toContain(path.join("agents", "main", "agent", "auth-profiles.json"));
+    expect(files).not.toContain(path.join("agents", "main", "agent", "auth.json"));
+    expect(files).not.toContain(path.join("agents", "main", "agent", "data.bin"));
+  });
+
+  it("excludes files outside importable patterns", async () => {
+    await fsp.mkdir(path.join(tmpDir, "completions"));
+    await fsp.writeFile(path.join(tmpDir, "completions", "openclaw.zsh"), "# completions");
+    await fsp.writeFile(path.join(tmpDir, "restart-sentinel.json"), "{}");
+    await fsp.writeFile(path.join(tmpDir, ".env"), "KEY=value");
+
+    const files = await discoverImportableFiles(tmpDir);
+
+    expect(files).toContain(".env");
+    expect(files).not.toContain(path.join("completions", "openclaw.zsh"));
+    expect(files).not.toContain("restart-sentinel.json");
+  });
+
+  it("discovers workspace-{agentId} files", async () => {
+    await fsp.mkdir(path.join(tmpDir, "workspace-helper"), { recursive: true });
+    await fsp.writeFile(path.join(tmpDir, "workspace-helper", "project.json"), "{}");
+
+    const files = await discoverImportableFiles(tmpDir);
+
+    expect(files).toContain(path.join("workspace-helper", "project.json"));
+  });
+
+  it("does not include directories as entries", async () => {
+    await fsp.mkdir(path.join(tmpDir, "agents", "main", "sessions"), { recursive: true });
+    await fsp.writeFile(path.join(tmpDir, "agents", "main", "sessions", "data.txt"), "data");
+
+    const files = await discoverImportableFiles(tmpDir);
+
+    // Should contain the file but not the intermediate directory
+    expect(files).toContain(path.join("agents", "main", "sessions", "data.txt"));
+    for (const f of files) {
+      const stat = await fsp.stat(path.join(tmpDir, f));
+      expect(stat.isFile()).toBe(true);
+    }
+  });
+});
+
 describe("stampImportedConfigVersion", () => {
   it("sets meta.lastTouchedVersion and meta.lastTouchedAt", () => {
     const input = JSON.stringify({ gateway: { port: 18789 } });
@@ -1059,10 +1140,13 @@ describe("importCommand", () => {
     expect(result.skippedEntries).toContain("restart-sentinel.json");
   });
 
-  it("copies all contents within allowed directories without filtering", async () => {
-    await fsp.mkdir(path.join(sourceDir, "agents", "main", "agent"), { recursive: true });
-    await fsp.writeFile(path.join(sourceDir, "agents", "main", "agent", "custom-data.bin"), "bin");
-    await fsp.writeFile(path.join(sourceDir, "agents", "main", "agent", "notes.txt"), "notes");
+  it("copies files matching glob patterns within allowed directories", async () => {
+    await fsp.mkdir(path.join(sourceDir, "agents", "main", "sessions"), { recursive: true });
+    await fsp.writeFile(
+      path.join(sourceDir, "agents", "main", "sessions", "custom-data.bin"),
+      "bin",
+    );
+    await fsp.writeFile(path.join(sourceDir, "agents", "main", "sessions", "notes.txt"), "notes");
 
     const pathsMod = await import("../config/paths.js");
     vi.spyOn(pathsMod, "resolveNewStateDir").mockReturnValue(targetDir);
@@ -1070,10 +1154,12 @@ describe("importCommand", () => {
     const result = await importCommand({ sourcePath: sourceDir, yes: true }, runtime as RuntimeEnv);
 
     expect(result.copiedFiles).toHaveLength(2);
-    expect(fs.existsSync(path.join(targetDir, "agents", "main", "agent", "custom-data.bin"))).toBe(
+    expect(
+      fs.existsSync(path.join(targetDir, "agents", "main", "sessions", "custom-data.bin")),
+    ).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, "agents", "main", "sessions", "notes.txt"))).toBe(
       true,
     );
-    expect(fs.existsSync(path.join(targetDir, "agents", "main", "agent", "notes.txt"))).toBe(true);
   });
 
   it("imports workspace-{agentId} directories", async () => {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -693,64 +693,88 @@ export function resolveTargetFilename(filename: string): string {
 }
 
 /**
- * Top-level entries in the OpenClaw state directory that should be imported.
+ * Glob patterns that define which files are importable from an OpenClaw
+ * state directory.
  *
- * Only entries in this set (plus the `workspace-*` pattern) are copied from
- * the source root. Everything else — generated caches (`completions/`),
- * runtime state (`delivery-queue/`, `sandbox/`, `restart-sentinel.json`),
- * identity data (`identity/`), and removed subsystems (`packs/`) — is
- * intentionally skipped.
+ * Every file that gets copied must explicitly match a pattern — there is
+ * no implicit recursion. Patterns use `**​/*` for explicit recursive
+ * matching within allowed directories.
  *
- * Sub-directories within importable entries are copied recursively without
- * further filtering.
+ * Everything else — generated caches (`completions/`), runtime state
+ * (`delivery-queue/`, `sandbox/`, `restart-sentinel.json`), identity data
+ * (`identity/`), and removed subsystems (`packs/`) — is intentionally
+ * not matched.
+ *
+ * Auth store files (`auth-profiles.json`, `auth.json`) inside agent dirs
+ * are NOT matched here — they are handled separately by
+ * {@link discoverSourceAuthProfiles} + {@link consolidateAuthProfiles}.
  */
-const IMPORTABLE_ROOT_ENTRIES = new Set([
-  // Config files
+const IMPORTABLE_GLOB_PATTERNS: string[] = [
+  // Config files (root level)
   OPENCLAW_CONFIG_FILENAME, // openclaw.json → remoteclaw.json
   REMOTECLAW_CONFIG_FILENAME, // remoteclaw.json (partially migrated source)
   ".env",
 
-  // Agent state
-  "agents",
-  "agent", // Legacy root-level agent dir (pre-migration layout)
-  "sessions", // Legacy sessions dir
+  // Agent sessions (transcripts, metadata)
+  "agents/*/sessions/**/*",
+
+  // Legacy root-level session dirs
+  "agent/sessions/**/*",
+  "sessions/**/*",
 
   // Credentials and auth
-  "credentials",
+  "credentials/**/*",
 
   // User customizations
-  "extensions",
-  "hooks",
-  "includes",
+  "extensions/**/*",
+  "hooks/**/*",
+  "includes/**/*",
 
   // Channel state
-  "telegram",
+  "telegram/**/*",
 
   // Media and workspaces
-  "media",
-  "workspace",
+  "media/**/*",
+  "workspace/**/*",
+
+  // Dynamic workspace directories: workspace-{agentId}
+  "workspace-*/**/*",
 
   // Scheduled jobs
-  "cron",
+  "cron/**/*",
 
   // Paired device registry
-  "devices",
+  "devices/**/*",
 
   // User-authored canvas content
-  "canvas",
-]);
+  "canvas/**/*",
+];
 
 /**
  * Check whether a root-level entry name should be imported.
- * Matches the static allowlist plus `workspace-{agentId}` directories.
+ * Derived from {@link IMPORTABLE_GLOB_PATTERNS} to keep a single source of truth.
  */
 export function isImportableRootEntry(name: string): boolean {
-  if (IMPORTABLE_ROOT_ENTRIES.has(name)) {
-    return true;
-  }
-  // Dynamic workspace directories: workspace-{agentId}
-  if (name.startsWith("workspace-") && name.length > "workspace-".length) {
-    return true;
+  for (const pattern of IMPORTABLE_GLOB_PATTERNS) {
+    const slashIdx = pattern.indexOf("/");
+    if (slashIdx === -1) {
+      // Root-level file pattern (no slash) — exact match
+      if (pattern === name) {
+        return true;
+      }
+    } else {
+      // Directory pattern — match the first segment
+      const firstSegment = pattern.slice(0, slashIdx);
+      if (firstSegment.includes("*")) {
+        // Dynamic pattern like "workspace-*/**/*" — prefix match
+        const prefix = firstSegment.slice(0, firstSegment.indexOf("*"));
+        if (name.startsWith(prefix) && name.length > prefix.length) {
+          return true;
+        }
+      } else if (name === firstSegment) {
+        return true;
+      }
+    }
   }
   return false;
 }
@@ -763,82 +787,78 @@ function isConfigFile(filename: string): boolean {
 }
 
 /**
- * Recursively copy a directory, transforming config files along the way.
+ * Discover all importable files in a source directory using glob patterns.
  *
- * When `filterRoot` is true (used for the top-level source directory),
- * only entries matching the importable allowlist are processed.
- * Sub-directories are always copied in full without filtering.
+ * Returns relative paths (from sourceDir) for files that match
+ * {@link IMPORTABLE_GLOB_PATTERNS}.
  */
-async function copyDirectory(params: {
+export async function discoverImportableFiles(sourceDir: string): Promise<string[]> {
+  const files: string[] = [];
+  for await (const entry of fsp.glob(IMPORTABLE_GLOB_PATTERNS, { cwd: sourceDir })) {
+    const fullPath = path.join(sourceDir, entry);
+    const stat = await fsp.stat(fullPath);
+    if (!stat.isFile()) {
+      continue;
+    }
+    files.push(entry);
+  }
+  return files;
+}
+
+/**
+ * Copy a list of discovered files from source to target, applying config
+ * transforms along the way.
+ */
+async function copyImportableFiles(params: {
   sourceDir: string;
   targetDir: string;
+  files: string[];
   dryRun: boolean;
-  filterRoot: boolean;
   result: ImportResult;
   discoveredAuthProfileIds: string[];
 }): Promise<void> {
-  const { sourceDir, targetDir, dryRun, filterRoot, result } = params;
+  const { sourceDir, targetDir, files, dryRun, result } = params;
 
-  const entries = await fsp.readdir(sourceDir, { withFileTypes: true });
+  for (const relPath of files) {
+    const dir = path.dirname(relPath);
+    const basename = path.basename(relPath);
+    const targetBasename = resolveTargetFilename(basename);
+    const targetRelPath = path.join(dir, targetBasename);
+    const sourcePath = path.join(sourceDir, relPath);
+    const targetPath = path.join(targetDir, targetRelPath);
 
-  if (!dryRun) {
-    await fsp.mkdir(targetDir, { recursive: true });
-  }
-
-  for (const entry of entries) {
-    if (filterRoot && !isImportableRootEntry(entry.name)) {
-      result.skippedEntries.push(entry.name);
-      continue;
+    if (!dryRun) {
+      await fsp.mkdir(path.dirname(targetPath), { recursive: true });
     }
 
-    const sourcePath = path.join(sourceDir, entry.name);
-    const targetFilename = resolveTargetFilename(entry.name);
-    const targetPath = path.join(targetDir, targetFilename);
-
-    if (entry.isDirectory()) {
-      await copyDirectory({
-        sourceDir: sourcePath,
-        targetDir: targetPath,
-        dryRun,
-        filterRoot: false,
-        result,
-        discoveredAuthProfileIds: params.discoveredAuthProfileIds,
-      });
-    } else if (entry.isFile()) {
-      // Skip auth-profiles.json files — they are consolidated into the
-      // global auth store separately, not copied per-agent.
-      if (entry.name === AUTH_PROFILES_FILENAME) {
-        continue;
-      }
-      if (isConfigFile(entry.name)) {
-        const content = await fsp.readFile(sourcePath, "utf-8");
-        const { content: transformed, renames } = transformConfigContent(content);
-        // Apply structural config transforms to the main config file
-        const isMainConfig = entry.name === OPENCLAW_CONFIG_FILENAME;
-        const final = isMainConfig
-          ? stampImportedConfigVersion(
-              materializeAuthDefaults(
-                materializeWorkspaceDefaults(
-                  clearWizardSection(stripUnrecognizedConfigKeys(stripSchemaField(transformed))),
-                ),
-                params.discoveredAuthProfileIds,
+    if (isConfigFile(basename)) {
+      const content = await fsp.readFile(sourcePath, "utf-8");
+      const { content: transformed, renames } = transformConfigContent(content);
+      // Apply structural config transforms to the root-level main config only
+      const isMainConfig = basename === OPENCLAW_CONFIG_FILENAME && (dir === "." || dir === "");
+      const final = isMainConfig
+        ? stampImportedConfigVersion(
+            materializeAuthDefaults(
+              materializeWorkspaceDefaults(
+                clearWizardSection(stripUnrecognizedConfigKeys(stripSchemaField(transformed))),
               ),
-            )
-          : transformed;
-        if (renames.length > 0 || final !== transformed) {
-          result.transformedFiles.push(targetPath);
-          result.envVarRenames.push(...renames);
-        }
-        if (!dryRun) {
-          await fsp.writeFile(targetPath, final, "utf-8");
-        }
-        result.copiedFiles.push(targetPath);
-      } else {
-        if (!dryRun) {
-          await fsp.copyFile(sourcePath, targetPath);
-        }
-        result.copiedFiles.push(targetPath);
+              params.discoveredAuthProfileIds,
+            ),
+          )
+        : transformed;
+      if (renames.length > 0 || final !== transformed) {
+        result.transformedFiles.push(targetPath);
+        result.envVarRenames.push(...renames);
       }
+      if (!dryRun) {
+        await fsp.writeFile(targetPath, final, "utf-8");
+      }
+      result.copiedFiles.push(targetPath);
+    } else {
+      if (!dryRun) {
+        await fsp.copyFile(sourcePath, targetPath);
+      }
+      result.copiedFiles.push(targetPath);
     }
   }
 }
@@ -912,11 +932,18 @@ export async function importCommand(
   const discoveredAuthProfiles = discoverSourceAuthProfiles(sourcePath);
   const discoveredAuthProfileIds = [...new Set(discoveredAuthProfiles.map((p) => p.id))];
 
-  await copyDirectory({
+  const importableFiles = await discoverImportableFiles(sourcePath);
+
+  // Compute skipped root entries for reporting
+  const allRootEntries = await fsp.readdir(sourcePath);
+  const matchedRoots = new Set(importableFiles.map((f) => f.split("/")[0]));
+  result.skippedEntries = allRootEntries.filter((e) => !matchedRoots.has(e));
+
+  await copyImportableFiles({
     sourceDir: sourcePath,
     targetDir,
+    files: importableFiles,
     dryRun: Boolean(opts.dryRun),
-    filterRoot: true,
     result,
     discoveredAuthProfileIds,
   });


### PR DESCRIPTION
## Summary

- Replace directory-level allowlist (`IMPORTABLE_ROOT_ENTRIES` Set) with explicit glob patterns (`IMPORTABLE_GLOB_PATTERNS`), giving finer-grained control over which files are imported from OpenClaw installations
- Agent working directories (`agents/*/agent/`) are no longer imported — only session data (`agents/*/sessions/**/*`) is copied, preventing stale runtime state from leaking into the new installation
- `isImportableRootEntry` now derives from the glob patterns (single source of truth) instead of maintaining a separate set
- Config structural transforms (workspace defaults, auth defaults, etc.) are now correctly restricted to the root-level `openclaw.json` only

## Test plan

- [x] All 102 existing import tests pass
- [x] New `discoverImportableFiles` tests covering: glob matching, agent directory exclusion, non-importable file exclusion, workspace-* directories, directory-vs-file filtering
- [x] Updated integration test reflects new session-only import behavior
- [ ] CI: build, test, lint, docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)