### PR TITLE
feat(agents): allow editing normalized agent ID in add wizard (#559)

### DIFF
--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -94,6 +94,71 @@ describe("agents add command", () => {
     const textMock = vi
       .fn()
       .mockResolvedValueOnce("My Agent") // agent name
+      .mockResolvedValueOnce("my-agent") // editable agent id (normalized differs from name)
+      .mockResolvedValueOnce("/tmp/workspace"); // workspace directory
+    const confirmMock = vi.fn().mockResolvedValue(false);
+    const outroMock = vi.fn();
+
+    wizardMocks.createClackPrompter.mockReturnValue({
+      intro: vi.fn(),
+      text: textMock,
+      confirm: confirmMock,
+      select: vi.fn(),
+      note: vi.fn(),
+      outro: outroMock,
+    });
+
+    await agentsAddCommand({}, runtime);
+
+    expect(textMock).toHaveBeenCalledTimes(3);
+    expect(textMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ message: "Agent id", initialValue: "my-agent" }),
+    );
+    expect(textMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ message: "Workspace directory" }),
+    );
+    expect(writeConfigFileMock).toHaveBeenCalled();
+    expect(outroMock).toHaveBeenCalledWith(expect.stringContaining("my-agent"));
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("allows user to override the normalized agent id", async () => {
+    const cfg = { ...baseConfigSnapshot };
+    readConfigFileSnapshotMock.mockResolvedValue(cfg);
+    setupChannelsMock.mockImplementation((c: unknown) => Promise.resolve(c));
+
+    const textMock = vi
+      .fn()
+      .mockResolvedValueOnce("My Agent") // agent name
+      .mockResolvedValueOnce("custom-id") // user overrides normalized id
+      .mockResolvedValueOnce("/tmp/workspace"); // workspace directory
+    const confirmMock = vi.fn().mockResolvedValue(false);
+    const outroMock = vi.fn();
+
+    wizardMocks.createClackPrompter.mockReturnValue({
+      intro: vi.fn(),
+      text: textMock,
+      confirm: confirmMock,
+      select: vi.fn(),
+      note: vi.fn(),
+      outro: outroMock,
+    });
+
+    await agentsAddCommand({}, runtime);
+
+    expect(outroMock).toHaveBeenCalledWith(expect.stringContaining("custom-id"));
+  });
+
+  it("skips agent id prompt when name already matches normalized id", async () => {
+    const cfg = { ...baseConfigSnapshot };
+    readConfigFileSnapshotMock.mockResolvedValue(cfg);
+    setupChannelsMock.mockImplementation((c: unknown) => Promise.resolve(c));
+
+    const textMock = vi
+      .fn()
+      .mockResolvedValueOnce("myagent") // agent name (already normalized)
       .mockResolvedValueOnce("/tmp/workspace"); // workspace directory
     const confirmMock = vi.fn().mockResolvedValue(false);
     const outroMock = vi.fn();
@@ -110,12 +175,48 @@ describe("agents add command", () => {
     await agentsAddCommand({}, runtime);
 
     expect(textMock).toHaveBeenCalledTimes(2);
-    expect(textMock).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ message: "Workspace directory" }),
-    );
-    expect(writeConfigFileMock).toHaveBeenCalled();
-    expect(outroMock).toHaveBeenCalledWith(expect.stringContaining("my-agent"));
-    expect(runtime.exit).not.toHaveBeenCalled();
+    expect(outroMock).toHaveBeenCalledWith(expect.stringContaining("myagent"));
+  });
+
+  it("validates the editable agent id rejects reserved and invalid values", async () => {
+    const cfg = { ...baseConfigSnapshot };
+    readConfigFileSnapshotMock.mockResolvedValue(cfg);
+    setupChannelsMock.mockImplementation((c: unknown) => Promise.resolve(c));
+
+    let capturedValidate: ((value: string) => string | undefined) | undefined;
+    const textMock = vi
+      .fn()
+      .mockImplementation(
+        (params: { validate?: (value: string) => string | undefined; message: string }) => {
+          if (params.message === "Agent id" && params.validate) {
+            capturedValidate = params.validate;
+          }
+          if (params.message === "Agent name") {
+            return Promise.resolve("My Agent");
+          }
+          if (params.message === "Agent id") {
+            return Promise.resolve("my-agent");
+          }
+          return Promise.resolve("/tmp/workspace");
+        },
+      );
+    const confirmMock = vi.fn().mockResolvedValue(false);
+
+    wizardMocks.createClackPrompter.mockReturnValue({
+      intro: vi.fn(),
+      text: textMock,
+      confirm: confirmMock,
+      select: vi.fn(),
+      note: vi.fn(),
+      outro: vi.fn(),
+    });
+
+    await agentsAddCommand({}, runtime);
+
+    expect(capturedValidate).toBeDefined();
+    expect(capturedValidate!("")).toBe("Required");
+    expect(capturedValidate!("main")).toContain("reserved");
+    expect(capturedValidate!("!!!")).toContain("Must start");
+    expect(capturedValidate!("valid-id")).toBeUndefined();
   });
 });

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -176,9 +176,31 @@ export async function agentsAddCommand(
       }));
 
     const agentName = String(name ?? "").trim();
-    const agentId = normalizeAgentId(agentName);
+    let agentId = normalizeAgentId(agentName);
     if (agentName !== agentId) {
-      await prompter.note(`Normalized id to "${agentId}".`, "Agent id");
+      const existingIds = new Set(listAgentEntries(cfg).map((a) => normalizeAgentId(a.id)));
+      agentId = await prompter.text({
+        message: "Agent id",
+        initialValue: agentId,
+        validate: (value) => {
+          const trimmed = value.trim();
+          if (!trimmed) {
+            return "Required";
+          }
+          if (!/^[a-z0-9][a-z0-9_-]{0,63}$/i.test(trimmed)) {
+            return "Must start with a letter or digit and contain only letters, digits, hyphens, and underscores (max 64 chars).";
+          }
+          const normalized = trimmed.toLowerCase();
+          if (normalized === DEFAULT_AGENT_ID) {
+            return `"${DEFAULT_AGENT_ID}" is reserved. Choose another id.`;
+          }
+          if (existingIds.has(normalized)) {
+            return `Agent "${normalized}" already exists.`;
+          }
+          return undefined;
+        },
+      });
+      agentId = agentId.trim().toLowerCase();
     }
 
     const existingAgent = listAgentEntries(cfg).find(


### PR DESCRIPTION
## Summary
- Replace read-only `prompter.note()` with editable `prompter.text()` prompt pre-filled with the normalized agent ID
- Add validation: required, valid characters (`[a-z0-9][a-z0-9_-]{0,63}`), not reserved (`main`), not already taken
- Skip prompt when agent name already matches normalized ID
- Add 3 new test cases: custom ID override, skip-when-normalized, validation rejection of reserved names

Closes #559

## Test plan
- [x] Existing wizard tests pass
- [x] New tests cover: custom ID, skip-when-normalized, reserved-name rejection
- [x] `pnpm check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>