### PR TITLE
feat(agents): per-agent runtimeArgs and runtimeEnv (#591)

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -6,6 +6,9 @@ import {
   resolveAgentConfig,
   resolveAgentDir,
   resolveAgentRuntime,
+  resolveAgentRuntimeArgs,
+  resolveAgentRuntimeEnv,
+  resolveAgentRuntimeOrThrow,
   resolveFallbackAgentId,
   resolveAgentWorkspaceDir,
   resolveAgentWorkspaceDirOrNull,
@@ -369,5 +372,143 @@ describe("resolveAgentAuth", () => {
     // Agent "main" doesn't exist in list, so resolveAgentEntry returns undefined.
     // Falls through to defaults.auth.
     expect(resolveAgentAuth(cfg, "main")).toBe(false);
+  });
+});
+
+describe("resolveAgentRuntimeOrThrow", () => {
+  it("returns runtime when set on agent entry", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { runtime: "claude" },
+        list: [{ id: "main", workspace: "~/remoteclaw", runtime: "gemini" }],
+      },
+    };
+    expect(resolveAgentRuntimeOrThrow(cfg, "main")).toBe("gemini");
+  });
+
+  it("falls back to defaults runtime", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { runtime: "claude" },
+        list: [{ id: "main", workspace: "~/remoteclaw" }],
+      },
+    };
+    expect(resolveAgentRuntimeOrThrow(cfg, "main")).toBe("claude");
+  });
+
+  it("throws when no runtime is configured", () => {
+    expect(() => resolveAgentRuntimeOrThrow({}, "main")).toThrow("No runtime configured");
+  });
+
+  it("includes supported providers in error message", () => {
+    expect(() => resolveAgentRuntimeOrThrow({}, "main")).toThrow("claude, gemini, codex, opencode");
+  });
+});
+
+describe("resolveAgentRuntimeArgs", () => {
+  it("returns undefined when no agents config exists", () => {
+    expect(resolveAgentRuntimeArgs({}, "main")).toBeUndefined();
+  });
+
+  it("returns undefined when agent has no runtimeArgs and no defaults", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", workspace: "~/remoteclaw" }],
+      },
+    };
+    expect(resolveAgentRuntimeArgs(cfg, "main")).toBeUndefined();
+  });
+
+  it("inherits runtimeArgs from defaults when agent entry has none", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { runtimeArgs: ["--verbose"] },
+        list: [{ id: "main", workspace: "~/remoteclaw" }],
+      },
+    };
+    expect(resolveAgentRuntimeArgs(cfg, "main")).toEqual(["--verbose"]);
+  });
+
+  it("agent entry runtimeArgs replaces defaults entirely", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { runtimeArgs: ["--verbose"] },
+        list: [{ id: "main", workspace: "~/remoteclaw", runtimeArgs: ["--model", "sonnet"] }],
+      },
+    };
+    expect(resolveAgentRuntimeArgs(cfg, "main")).toEqual(["--model", "sonnet"]);
+  });
+
+  it("returns defaults runtimeArgs when agent entry does not exist", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { runtimeArgs: ["--dangerously-skip-permissions"] },
+        list: [{ id: "other", workspace: "~/remoteclaw" }],
+      },
+    };
+    expect(resolveAgentRuntimeArgs(cfg, "main")).toEqual(["--dangerously-skip-permissions"]);
+  });
+
+  it("agent entry with empty runtimeArgs clears defaults", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { runtimeArgs: ["--verbose"] },
+        list: [{ id: "main", workspace: "~/remoteclaw", runtimeArgs: [] }],
+      },
+    };
+    // Empty array is truthy — per-agent [] replaces defaults entirely.
+    expect(resolveAgentRuntimeArgs(cfg, "main")).toEqual([]);
+  });
+});
+
+describe("resolveAgentRuntimeEnv", () => {
+  it("returns undefined when no agents config exists", () => {
+    expect(resolveAgentRuntimeEnv({}, "main")).toBeUndefined();
+  });
+
+  it("returns undefined when agent has no runtimeEnv and no defaults", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", workspace: "~/remoteclaw" }],
+      },
+    };
+    expect(resolveAgentRuntimeEnv(cfg, "main")).toBeUndefined();
+  });
+
+  it("inherits runtimeEnv from defaults when agent entry has none", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { runtimeEnv: { API_KEY: "sk-default" } },
+        list: [{ id: "main", workspace: "~/remoteclaw" }],
+      },
+    };
+    expect(resolveAgentRuntimeEnv(cfg, "main")).toEqual({ API_KEY: "sk-default" });
+  });
+
+  it("agent entry runtimeEnv replaces defaults entirely", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { runtimeEnv: { API_KEY: "sk-default", SHARED: "yes" } },
+        list: [
+          {
+            id: "main",
+            workspace: "~/remoteclaw",
+            runtimeEnv: { API_KEY: "sk-agent-specific" },
+          },
+        ],
+      },
+    };
+    // Per-agent replaces entirely — SHARED is NOT inherited.
+    expect(resolveAgentRuntimeEnv(cfg, "main")).toEqual({ API_KEY: "sk-agent-specific" });
+  });
+
+  it("returns defaults runtimeEnv when agent entry does not exist", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { runtimeEnv: { API_KEY: "sk-default" } },
+        list: [{ id: "other", workspace: "~/remoteclaw" }],
+      },
+    };
+    expect(resolveAgentRuntimeEnv(cfg, "main")).toEqual({ API_KEY: "sk-default" });
   });
 });

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -35,6 +35,8 @@ type ResolvedAgentConfig = {
   tools?: AgentEntry["tools"];
   auth?: AgentEntry["auth"];
   runtime?: AgentEntry["runtime"];
+  runtimeArgs?: AgentEntry["runtimeArgs"];
+  runtimeEnv?: AgentEntry["runtimeEnv"];
 };
 
 let defaultAgentWarned = false;
@@ -134,6 +136,8 @@ export function resolveAgentConfig(
     tools: entry.tools,
     auth: entry.auth,
     runtime: entry.runtime,
+    runtimeArgs: entry.runtimeArgs,
+    runtimeEnv: entry.runtimeEnv,
   };
 }
 
@@ -174,6 +178,59 @@ export function resolveAgentRuntime(
     return entry.runtime;
   }
   return cfg.agents?.defaults?.runtime ?? undefined;
+}
+
+/**
+ * Resolve the effective runtime for an agent, throwing if unset.
+ *
+ * Same as {@link resolveAgentRuntime} but throws when neither the agent entry
+ * nor defaults define a runtime.
+ */
+export function resolveAgentRuntimeOrThrow(
+  cfg: RemoteClawConfig,
+  agentId: string,
+): "claude" | "gemini" | "codex" | "opencode" {
+  const runtime = resolveAgentRuntime(cfg, agentId);
+  if (!runtime) {
+    throw new Error(
+      "No runtime configured. Set agents.defaults.runtime to one of: claude, gemini, codex, opencode",
+    );
+  }
+  return runtime;
+}
+
+/**
+ * Resolve the effective runtimeArgs for an agent.
+ *
+ * Resolution: agent entry `runtimeArgs` replaces `agents.defaults.runtimeArgs`.
+ * Returns `undefined` when neither the entry nor defaults define runtimeArgs.
+ */
+export function resolveAgentRuntimeArgs(
+  cfg: RemoteClawConfig,
+  agentId: string,
+): string[] | undefined {
+  const entry = resolveAgentEntry(cfg, normalizeAgentId(agentId));
+  if (entry?.runtimeArgs) {
+    return entry.runtimeArgs;
+  }
+  return cfg.agents?.defaults?.runtimeArgs ?? undefined;
+}
+
+/**
+ * Resolve the effective runtimeEnv for an agent.
+ *
+ * Resolution: agent entry `runtimeEnv` replaces `agents.defaults.runtimeEnv`.
+ * Returns `undefined` when neither the entry nor defaults define runtimeEnv.
+ */
+export function resolveAgentRuntimeEnv(
+  cfg: RemoteClawConfig,
+  agentId: string,
+): Record<string, string> | undefined {
+  const entry = resolveAgentEntry(cfg, normalizeAgentId(agentId));
+  if (entry?.runtimeEnv) {
+    return entry.runtimeEnv;
+  }
+  return cfg.agents?.defaults?.runtimeEnv ?? undefined;
 }
 
 export function resolveFallbackAgentId(params: {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -7,6 +7,11 @@ import {
   isTransientHttpError,
   sanitizeUserFacingText,
 } from "../../agents/agent-helpers.js";
+import {
+  resolveAgentRuntimeArgs,
+  resolveAgentRuntimeEnv,
+  resolveAgentRuntimeOrThrow,
+} from "../../agents/agent-scope.js";
 import { resolveChannelMessageToolHints } from "../../agents/channel-tools.js";
 import { resolveUserTimezone } from "../../agents/date-time.js";
 import { resolveGatewayPort } from "../../config/paths.js";
@@ -20,11 +25,6 @@ import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { withAuthKeyRetry } from "../../middleware/auth-key-retry.js";
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
-import {
-  resolveCliRuntimeArgs,
-  resolveCliRuntimeEnv,
-  resolveCliRuntimeProvider,
-} from "../../middleware/runtime-factory.js";
 import type { SessionMap } from "../../middleware/session-map.js";
 import type {
   AgentDeliveryResult,
@@ -282,7 +282,8 @@ export async function runAgentTurnWithFallback(params: {
         });
 
         const cfg = params.followupRun.run.config;
-        const baseRuntimeEnv = resolveCliRuntimeEnv(cfg);
+        const agentId = params.followupRun.run.agentId;
+        const baseRuntimeEnv = resolveAgentRuntimeEnv(cfg, agentId);
 
         const messageToolHints = resolveChannelMessageToolHints({
           cfg,
@@ -377,12 +378,12 @@ export async function runAgentTurnWithFallback(params: {
           },
           async (runtimeEnv) => {
             const bridge = new ChannelBridge({
-              provider: resolveCliRuntimeProvider(cfg),
+              provider: resolveAgentRuntimeOrThrow(cfg, agentId),
               sessionMap,
               gatewayUrl: resolveGatewayUrlFromConfig(cfg),
               gatewayToken: resolveGatewayTokenFromConfig(cfg),
               workspaceDir: params.followupRun.run.workspaceDir,
-              runtimeArgs: resolveCliRuntimeArgs(cfg),
+              runtimeArgs: resolveAgentRuntimeArgs(cfg, agentId),
               runtimeEnv,
             });
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1,4 +1,9 @@
 import crypto from "node:crypto";
+import {
+  resolveAgentRuntimeArgs,
+  resolveAgentRuntimeEnv,
+  resolveAgentRuntimeOrThrow,
+} from "../../agents/agent-scope.js";
 import { resolveChannelMessageToolHints } from "../../agents/channel-tools.js";
 import { resolveGatewayPort } from "../../config/paths.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -6,11 +11,6 @@ import type { TypingMode } from "../../config/types.js";
 import { resolveGatewayCredentialsFromConfig } from "../../gateway/credentials.js";
 import { logVerbose } from "../../globals.js";
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
-import {
-  resolveCliRuntimeArgs,
-  resolveCliRuntimeEnv,
-  resolveCliRuntimeProvider,
-} from "../../middleware/runtime-factory.js";
 import type { SessionMap } from "../../middleware/session-map.js";
 import type { BridgeCallbacks, ChannelMessage } from "../../middleware/types.js";
 import type { GetReplyOptions } from "../types.js";
@@ -66,13 +66,13 @@ export function createFollowupRunner(params: {
         : "";
 
       const bridge = new ChannelBridge({
-        provider: resolveCliRuntimeProvider(cfg),
+        provider: resolveAgentRuntimeOrThrow(cfg, queued.run.agentId),
         sessionMap,
         gatewayUrl,
         gatewayToken,
         workspaceDir: queued.run.workspaceDir,
-        runtimeArgs: resolveCliRuntimeArgs(cfg),
-        runtimeEnv: resolveCliRuntimeEnv(cfg),
+        runtimeArgs: resolveAgentRuntimeArgs(cfg, queued.run.agentId),
+        runtimeEnv: resolveAgentRuntimeEnv(cfg, queued.run.agentId),
       });
 
       // Build channel message from followup run fields.

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1,5 +1,8 @@
 import {
   listAgentIds,
+  resolveAgentRuntimeArgs,
+  resolveAgentRuntimeEnv,
+  resolveAgentRuntimeOrThrow,
   resolveSessionAgentId,
   resolveAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
@@ -29,11 +32,6 @@ import {
   registerAgentRunContext,
 } from "../infra/agent-events.js";
 import { ChannelBridge } from "../middleware/channel-bridge.js";
-import {
-  resolveCliRuntimeArgs,
-  resolveCliRuntimeEnv,
-  resolveCliRuntimeProvider,
-} from "../middleware/runtime-factory.js";
 import type { SessionMap } from "../middleware/session-map.js";
 import type { AgentDeliveryResult, ChannelMessage } from "../middleware/types.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -291,13 +289,13 @@ export async function agentCommand(
       });
 
       const bridge = new ChannelBridge({
-        provider: resolveCliRuntimeProvider(cfg),
+        provider: resolveAgentRuntimeOrThrow(cfg, sessionAgentId),
         sessionMap,
         gatewayUrl: resolveGatewayUrlFromConfig(cfg),
         gatewayToken: resolveGatewayTokenFromConfig(cfg),
         workspaceDir,
-        runtimeArgs: resolveCliRuntimeArgs(cfg),
-        runtimeEnv: resolveCliRuntimeEnv(cfg),
+        runtimeArgs: resolveAgentRuntimeArgs(cfg, sessionAgentId),
+        runtimeEnv: resolveAgentRuntimeEnv(cfg, sessionAgentId),
       });
 
       const messageToolHints = resolveChannelMessageToolHints({

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -40,6 +40,10 @@ export type AgentConfig = {
   auth?: false | string | string[];
   /** Selected agent runtime (claude, gemini, codex, opencode). Overrides `agents.defaults.runtime`. */
   runtime?: "claude" | "gemini" | "codex" | "opencode";
+  /** Extra CLI arguments appended to runtime invocation. Replaces `agents.defaults.runtimeArgs`. */
+  runtimeArgs?: string[];
+  /** Extra environment variables injected into runtime invocation. Replaces `agents.defaults.runtimeEnv`. */
+  runtimeEnv?: Record<string, string>;
 };
 
 export type AgentsConfig = {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -243,6 +243,8 @@ export const AgentEntrySchema = z
     runtime: z
       .union([z.literal("claude"), z.literal("gemini"), z.literal("codex"), z.literal("opencode")])
       .optional(),
+    runtimeArgs: z.array(z.string()).optional(),
+    runtimeEnv: z.record(z.string(), z.string()).optional(),
   })
   .strict();
 

--- a/src/cron/isolated-agent/run.channel-bridge.test.ts
+++ b/src/cron/isolated-agent/run.channel-bridge.test.ts
@@ -33,6 +33,9 @@ vi.mock("../../agents/channel-tools.js", () => ({
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentConfig: vi.fn().mockReturnValue(undefined),
   resolveAgentDir: vi.fn().mockReturnValue("/tmp/agent-dir"),
+  resolveAgentRuntimeArgs: vi.fn().mockReturnValue(undefined),
+  resolveAgentRuntimeEnv: vi.fn().mockReturnValue(undefined),
+  resolveAgentRuntimeOrThrow: vi.fn().mockReturnValue("claude"),
   resolveAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/workspace"),
   resolveDefaultAgentId: vi.fn().mockReturnValue("default"),
 }));

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,6 +1,9 @@
 import crypto from "node:crypto";
 import {
   resolveAgentConfig,
+  resolveAgentRuntimeArgs,
+  resolveAgentRuntimeEnv,
+  resolveAgentRuntimeOrThrow,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../../agents/agent-scope.js";
@@ -23,11 +26,6 @@ import { resolveGatewayCredentialsFromConfig } from "../../gateway/credentials.j
 import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { logWarn } from "../../logger.js";
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
-import {
-  resolveCliRuntimeArgs,
-  resolveCliRuntimeEnv,
-  resolveCliRuntimeProvider,
-} from "../../middleware/runtime-factory.js";
 import type { SessionMap } from "../../middleware/session-map.js";
 import type { AgentDeliveryResult, ChannelMessage } from "../../middleware/types.js";
 import { buildAgentMainSessionKey, normalizeAgentId } from "../../routing/session-key.js";
@@ -349,13 +347,13 @@ export async function runCronIsolatedAgentTurn(params: {
     });
 
     const bridge = new ChannelBridge({
-      provider: resolveCliRuntimeProvider(cfgWithAgentDefaults),
+      provider: resolveAgentRuntimeOrThrow(params.cfg, agentId),
       sessionMap,
       gatewayUrl: resolveGatewayUrlFromConfig(cfgWithAgentDefaults),
       gatewayToken: resolveGatewayTokenFromConfig(cfgWithAgentDefaults),
       workspaceDir,
-      runtimeArgs: resolveCliRuntimeArgs(cfgWithAgentDefaults),
-      runtimeEnv: resolveCliRuntimeEnv(cfgWithAgentDefaults),
+      runtimeArgs: resolveAgentRuntimeArgs(params.cfg, agentId),
+      runtimeEnv: resolveAgentRuntimeEnv(params.cfg, agentId),
     });
 
     const messageToolHints = resolveChannelMessageToolHints({

--- a/src/middleware/runtime-factory.test.ts
+++ b/src/middleware/runtime-factory.test.ts
@@ -1,13 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  _resetValidationCache,
-  createCliRuntime,
-  resolveCliRuntimeArgs,
-  resolveCliRuntimeEnv,
-  resolveCliRuntimeProvider,
-  SUPPORTED_PROVIDERS,
-} from "./runtime-factory.js";
+import { _resetValidationCache, createCliRuntime, SUPPORTED_PROVIDERS } from "./runtime-factory.js";
 import { ClaudeCliRuntime } from "./runtimes/claude.js";
 import { CodexCliRuntime } from "./runtimes/codex.js";
 import { GeminiCliRuntime } from "./runtimes/gemini.js";
@@ -166,101 +159,5 @@ describe("createCliRuntime", () => {
       }
       expect(mockedExecFileSync).toHaveBeenCalledTimes(4);
     });
-  });
-});
-
-// ── resolveCliRuntimeProvider ─────────────────────────────────────────────
-
-describe("resolveCliRuntimeProvider", () => {
-  it("returns agents.defaults.runtime when set", () => {
-    expect(resolveCliRuntimeProvider({ agents: { defaults: { runtime: "gemini" } } })).toBe(
-      "gemini",
-    );
-  });
-
-  it("throws when runtime is undefined", () => {
-    expect(() => resolveCliRuntimeProvider({ agents: { defaults: {} } })).toThrow(
-      "No runtime configured",
-    );
-  });
-
-  it("throws when defaults is undefined", () => {
-    expect(() => resolveCliRuntimeProvider({ agents: {} })).toThrow("No runtime configured");
-  });
-
-  it("throws when agents is undefined", () => {
-    expect(() => resolveCliRuntimeProvider({})).toThrow("No runtime configured");
-  });
-
-  it("throws when config is undefined", () => {
-    expect(() => resolveCliRuntimeProvider(undefined)).toThrow("No runtime configured");
-  });
-
-  it("includes supported providers in error message", () => {
-    expect(() => resolveCliRuntimeProvider({})).toThrow("claude, gemini, codex, opencode");
-  });
-});
-
-// ── resolveCliRuntimeArgs ───────────────────────────────────────────────
-
-describe("resolveCliRuntimeArgs", () => {
-  it("returns agents.defaults.runtimeArgs when set", () => {
-    expect(
-      resolveCliRuntimeArgs({
-        agents: { defaults: { runtimeArgs: ["--dangerously-skip-permissions"] } },
-      }),
-    ).toEqual(["--dangerously-skip-permissions"]);
-  });
-
-  it("returns undefined when runtimeArgs is not set", () => {
-    expect(resolveCliRuntimeArgs({ agents: { defaults: {} } })).toBeUndefined();
-  });
-
-  it("returns undefined when defaults is undefined", () => {
-    expect(resolveCliRuntimeArgs({ agents: {} })).toBeUndefined();
-  });
-
-  it("returns undefined when agents is undefined", () => {
-    expect(resolveCliRuntimeArgs({})).toBeUndefined();
-  });
-
-  it("returns undefined when config is undefined", () => {
-    expect(resolveCliRuntimeArgs(undefined)).toBeUndefined();
-  });
-
-  it("returns empty array when set to empty array", () => {
-    expect(resolveCliRuntimeArgs({ agents: { defaults: { runtimeArgs: [] } } })).toEqual([]);
-  });
-});
-
-// ── resolveCliRuntimeEnv ────────────────────────────────────────────────
-
-describe("resolveCliRuntimeEnv", () => {
-  it("returns agents.defaults.runtimeEnv when set", () => {
-    expect(
-      resolveCliRuntimeEnv({
-        agents: { defaults: { runtimeEnv: { ANTHROPIC_API_KEY: "sk-ant-test" } } },
-      }),
-    ).toEqual({ ANTHROPIC_API_KEY: "sk-ant-test" });
-  });
-
-  it("returns undefined when runtimeEnv is not set", () => {
-    expect(resolveCliRuntimeEnv({ agents: { defaults: {} } })).toBeUndefined();
-  });
-
-  it("returns undefined when defaults is undefined", () => {
-    expect(resolveCliRuntimeEnv({ agents: {} })).toBeUndefined();
-  });
-
-  it("returns undefined when agents is undefined", () => {
-    expect(resolveCliRuntimeEnv({})).toBeUndefined();
-  });
-
-  it("returns undefined when config is undefined", () => {
-    expect(resolveCliRuntimeEnv(undefined)).toBeUndefined();
-  });
-
-  it("returns empty object when set to empty object", () => {
-    expect(resolveCliRuntimeEnv({ agents: { defaults: { runtimeEnv: {} } } })).toEqual({});
   });
 });

--- a/src/middleware/runtime-factory.ts
+++ b/src/middleware/runtime-factory.ts
@@ -42,49 +42,6 @@ export function _resetValidationCache(): void {
   validatedCommands.clear();
 }
 
-/**
- * Resolve the CLI runtime provider from config.
- *
- * Reads `agents.defaults.runtime` (set during onboarding) and throws when
- * unset.  This is the **CLI runtime** (which binary to spawn), NOT the
- * model-API provider (e.g. "anthropic").
- */
-export function resolveCliRuntimeProvider(cfg?: {
-  agents?: { defaults?: { runtime?: string } };
-}): string {
-  const runtime = cfg?.agents?.defaults?.runtime;
-  if (!runtime) {
-    throw new Error(
-      `No runtime configured. Set agents.defaults.runtime to one of: ${SUPPORTED_PROVIDERS.join(", ")}`,
-    );
-  }
-  return runtime;
-}
-
-/**
- * Resolve extra CLI runtime args from config.
- *
- * Reads `agents.defaults.runtimeArgs` — extra CLI flags appended to every
- * runtime invocation (e.g. `["--dangerously-skip-permissions"]`).
- */
-export function resolveCliRuntimeArgs(cfg?: {
-  agents?: { defaults?: { runtimeArgs?: string[] } };
-}): string[] | undefined {
-  return cfg?.agents?.defaults?.runtimeArgs;
-}
-
-/**
- * Resolve extra CLI runtime env vars from config.
- *
- * Reads `agents.defaults.runtimeEnv` — environment variables injected into
- * every runtime invocation (e.g. `{ "ANTHROPIC_API_KEY": "sk-ant-..." }`).
- */
-export function resolveCliRuntimeEnv(cfg?: {
-  agents?: { defaults?: { runtimeEnv?: Record<string, string> } };
-}): Record<string, string> | undefined {
-  return cfg?.agents?.defaults?.runtimeEnv;
-}
-
 export function createCliRuntime(provider: string): AgentRuntime {
   const normalized = provider.trim().toLowerCase();
   logDebug(`[runtime-factory] creating runtime: provider=${normalized}`);


### PR DESCRIPTION
## Summary

- Add `runtimeArgs` and `runtimeEnv` to per-agent config (`AgentConfig`) with replace semantics — per-agent values override defaults entirely, no merge
- Add `resolveAgentRuntimeArgs()`, `resolveAgentRuntimeEnv()`, and `resolveAgentRuntimeOrThrow()` resolvers in `agent-scope.ts`
- Wire per-agent resolvers into all 4 bridge construction sites (commands, auto-reply, followup-runner, cron)
- Gut `resolveCliRuntimeProvider`, `resolveCliRuntimeArgs`, `resolveCliRuntimeEnv` from `runtime-factory.ts` — all callers migrated to agent-scope per-agent resolvers

Closes #591

## Test plan

- [x] New unit tests for `resolveAgentRuntimeArgs`, `resolveAgentRuntimeEnv`, `resolveAgentRuntimeOrThrow` (inheritance, replace, throw on missing)
- [x] Existing `agent-scope.test.ts`, `runtime-factory.test.ts`, `channel-bridge.test.ts`, `agent.test.ts`, `run.channel-bridge.test.ts` all pass
- [x] Full test suite: 8080 passed (1 pre-existing flaky failure in `update-cli.test.ts`)
- [x] Typecheck clean, lint clean, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)