### PR TITLE
refactor(middleware): replace inactivity watchdog with startup-only timeout

### DIFF
--- a/docs/concepts/agent-runtimes.md
+++ b/docs/concepts/agent-runtimes.md
@@ -90,18 +90,21 @@ When `execute()` is called:
 5. **Event yielding**: Events are pushed into a queue and yielded to the
    caller via async iteration.
 
-6. **Termination**: After the process exits, any final events (watchdog
-   errors, abort markers) are emitted, followed by the `done` event.
+6. **Termination**: After the process exits, any final events (startup
+   timeout errors, abort markers) are emitted, followed by the `done` event.
 
-### Watchdog Timer
+### Startup Timeout
 
-A 5-minute inactivity watchdog resets on every NDJSON line received. If no
-output arrives within the timeout, the runtime triggers process termination
-and emits an error event with code `WATCHDOG_TIMEOUT`.
+A 5-minute startup timeout begins when the subprocess spawns. If the first
+NDJSON line arrives before the deadline, the timer is cancelled and the
+process runs without any further timeout — tool executions may take
+arbitrarily long. If no output arrives before the deadline, the runtime
+triggers process termination and emits an error event with code
+`STARTUP_TIMEOUT`.
 
 ### Signal Escalation
 
-Process termination (from watchdog, abort signal, or errors) follows a
+Process termination (from startup timeout, abort signal, or errors) follows a
 two-step escalation:
 
 1. **SIGTERM** — gives the CLI process a chance to clean up

--- a/src/middleware/cli-runtime-base.test.ts
+++ b/src/middleware/cli-runtime-base.test.ts
@@ -210,59 +210,58 @@ describe("CLIRuntimeBase", () => {
     });
   });
 
-  describe("watchdog timer", () => {
-    it("kills child process after inactivity timeout", async () => {
+  describe("startup timeout", () => {
+    it("kills child process when no output arrives before deadline", async () => {
       const runtime = new TestRuntime("test-cli", 1000);
 
       const promise = collectEvents(runtime.execute(defaultParams));
 
-      // Advance past the watchdog timeout with no output.
+      // Advance past the startup timeout with no output.
       await vi.advanceTimersByTimeAsync(1001);
 
       const events = await promise;
 
       expect(mockChild.kill).toHaveBeenCalledWith("SIGTERM");
       expect(events).toContainEqual(
-        expect.objectContaining({ type: "error", code: "WATCHDOG_TIMEOUT" }),
+        expect.objectContaining({ type: "error", code: "STARTUP_TIMEOUT" }),
       );
     });
 
-    it("resets on each NDJSON line", async () => {
+    it("does not fire after the first NDJSON line is received", async () => {
       const runtime = new TestRuntime("test-cli", 1000);
 
       const promise = collectEvents(runtime.execute(defaultParams));
 
-      // Emit a line at 800ms — should reset the watchdog.
-      await vi.advanceTimersByTimeAsync(800);
+      // Emit a line at 500ms — cancels the startup timer.
+      await vi.advanceTimersByTimeAsync(500);
       mockChild.stdout.write('{"type":"text","text":"alive"}\n');
 
-      // Advance another 800ms (total 1600ms, but only 800ms since last line).
-      await vi.advanceTimersByTimeAsync(800);
-      // Watchdog should NOT have fired yet.
+      // Advance well past the original deadline — no timeout should fire.
+      await vi.advanceTimersByTimeAsync(2000);
       expect(mockChild.kill).not.toHaveBeenCalled();
 
-      // Now advance past the remaining 200ms of the watchdog.
-      await vi.advanceTimersByTimeAsync(201);
+      // Close cleanly.
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
 
       const events = await promise;
 
-      // We should have the text event, then the watchdog error, then done.
       expect(events[0]).toEqual({ type: "text", text: "alive" });
-      expect(events).toContainEqual(
-        expect.objectContaining({ type: "error", code: "WATCHDOG_TIMEOUT" }),
+      expect(events).not.toContainEqual(
+        expect.objectContaining({ type: "error", code: "STARTUP_TIMEOUT" }),
       );
     });
   });
 
   describe("SIGKILL escalation", () => {
-    it("sends SIGKILL after SIGTERM if process does not exit (watchdog)", async () => {
+    it("sends SIGKILL after SIGTERM if process does not exit (startup timeout)", async () => {
       const stubbornChild = createMockChild({ exitOnKill: false });
       spawnMock.mockReturnValue(stubbornChild);
 
       const runtime = new TestRuntime("test-cli", 1000);
       const promise = collectEvents(runtime.execute(defaultParams));
 
-      // Advance past watchdog timeout → SIGTERM sent.
+      // Advance past startup timeout → SIGTERM sent.
       await vi.advanceTimersByTimeAsync(1001);
       expect(stubbornChild.kill).toHaveBeenCalledWith("SIGTERM");
       expect(stubbornChild.kill).not.toHaveBeenCalledWith("SIGKILL");
@@ -277,18 +276,18 @@ describe("CLIRuntimeBase", () => {
 
       const events = await promise;
       expect(events).toContainEqual(
-        expect.objectContaining({ type: "error", code: "WATCHDOG_TIMEOUT" }),
+        expect.objectContaining({ type: "error", code: "STARTUP_TIMEOUT" }),
       );
     });
 
-    it("cancels SIGKILL timer if process exits after SIGTERM (watchdog)", async () => {
+    it("cancels SIGKILL timer if process exits after SIGTERM (startup timeout)", async () => {
       const stubbornChild = createMockChild({ exitOnKill: false });
       spawnMock.mockReturnValue(stubbornChild);
 
       const runtime = new TestRuntime("test-cli", 1000);
       const promise = collectEvents(runtime.execute(defaultParams));
 
-      // Advance past watchdog → SIGTERM.
+      // Advance past startup timeout → SIGTERM.
       await vi.advanceTimersByTimeAsync(1001);
       expect(stubbornChild.kill).toHaveBeenCalledWith("SIGTERM");
 
@@ -302,7 +301,7 @@ describe("CLIRuntimeBase", () => {
       const events = await promise;
       expect(stubbornChild.kill).not.toHaveBeenCalledWith("SIGKILL");
       expect(events).toContainEqual(
-        expect.objectContaining({ type: "error", code: "WATCHDOG_TIMEOUT" }),
+        expect.objectContaining({ type: "error", code: "STARTUP_TIMEOUT" }),
       );
     });
 

--- a/src/middleware/cli-runtime-base.ts
+++ b/src/middleware/cli-runtime-base.ts
@@ -115,21 +115,19 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
       }
     });
 
-    // ── Watchdog timer ───────────────────────────────────────────────
-    let watchdogTimer: ReturnType<typeof setTimeout> | undefined;
-    let watchdogFired = false;
+    // ── Startup timeout ──────────────────────────────────────────────
+    // One-shot timer: fires if no NDJSON output arrives before the
+    // deadline.  Cancelled as soon as the first line is received.
+    let startupTimer: ReturnType<typeof setTimeout> | undefined;
+    let startupTimedOut = false;
 
-    const resetWatchdog = () => {
-      if (watchdogTimer !== undefined) {
-        clearTimeout(watchdogTimer);
-      }
-      watchdogTimer = setTimeout(() => {
-        watchdogFired = true;
-        logDebug(`[agent-runtime] pid=${child.pid}: watchdog timeout after ${this.timeoutMs}ms`);
-        killWithEscalation();
-      }, this.timeoutMs);
-    };
-    resetWatchdog();
+    startupTimer = setTimeout(() => {
+      startupTimedOut = true;
+      logDebug(
+        `[agent-runtime] pid=${child.pid}: startup timeout — no output within ${this.timeoutMs}ms`,
+      );
+      killWithEscalation();
+    }, this.timeoutMs);
 
     // ── Stream selection: NDJSON source + diagnostic capture ─────────
     const ndjsonSource = this.ndjsonStream === "stderr" ? child.stderr : child.stdout;
@@ -153,7 +151,10 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
     };
 
     rl.on("line", (line) => {
-      resetWatchdog();
+      if (startupTimer !== undefined) {
+        clearTimeout(startupTimer);
+        startupTimer = undefined;
+      }
       if (!line.trim()) {
         return;
       }
@@ -240,8 +241,8 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
         }
       }
     } finally {
-      if (watchdogTimer !== undefined) {
-        clearTimeout(watchdogTimer);
+      if (startupTimer !== undefined) {
+        clearTimeout(startupTimer);
       }
       params.abortSignal?.removeEventListener("abort", onAbort);
     }
@@ -268,11 +269,11 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
     }
 
     // ── Emit terminal events ─────────────────────────────────────────
-    if (watchdogFired) {
+    if (startupTimedOut) {
       yield {
         type: "error",
-        message: `Watchdog timeout: no output for ${this.timeoutMs}ms`,
-        code: "WATCHDOG_TIMEOUT",
+        message: `Startup timeout: no output within ${this.timeoutMs}ms`,
+        code: "STARTUP_TIMEOUT",
       } satisfies AgentErrorEvent;
     }
 

--- a/src/middleware/error-classifier.test.ts
+++ b/src/middleware/error-classifier.test.ts
@@ -160,7 +160,7 @@ describe("classifyError", () => {
         "timeout",
         "aborted",
         "execution aborted",
-        "watchdog timeout",
+        "startup timeout",
         "rate limit",
         "context length",
         "unauthorized",


### PR DESCRIPTION
## Summary

- Replaces the resetting inactivity watchdog in `CLIRuntimeBase` with a one-shot startup timeout
- Timer starts on subprocess spawn, cancels when the first NDJSON line arrives, and never fires again
- Tool executions can now run indefinitely without risk of being killed by the watchdog
- Updates error code from `WATCHDOG_TIMEOUT` to `STARTUP_TIMEOUT`
- Updates tests and docs to match

Closes #593

## Test plan

- [x] All existing tests updated and passing (98 tests across 2 files)
- [x] New test verifies no timeout fires after first output received
- [x] `pnpm check` passes (format + typecheck + lint)


🤖 Generated with [Claude Code](https://claude.com/claude-code)