### PR TITLE
fix(update): false downgrade warning on next channel due to SHA-based version ordering (#610)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,8 @@ jobs:
         run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
           SHORT_SHA=$(git rev-parse --short HEAD)
-          NEXT_VERSION="${PKG_VERSION}-next.${SHORT_SHA}"
+          BUILD_TS=$(date -u +%Y%m%d%H%M%S)
+          NEXT_VERSION="${PKG_VERSION}-next.${BUILD_TS}.${SHORT_SHA}"
 
           if npm view "remoteclaw@${NEXT_VERSION}" version &>/dev/null; then
             echo "Version ${NEXT_VERSION} already published, skipping"

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -15,6 +15,27 @@ describe("compareSemverStrings", () => {
     expect(compareSemverStrings("1.0.0", "1.0.0.beta.1")).toBe(1);
   });
 
+  it("correctly orders next channel versions with datetime-based prerelease", () => {
+    expect(
+      compareSemverStrings(
+        "0.1.0-next.20260309160000.abc1234",
+        "0.1.0-next.20260309150000.def5678",
+      ),
+    ).toBe(1);
+    expect(
+      compareSemverStrings(
+        "0.1.0-next.20260309150000.def5678",
+        "0.1.0-next.20260309160000.abc1234",
+      ),
+    ).toBe(-1);
+    expect(
+      compareSemverStrings(
+        "0.1.0-next.20260309150000.abc1234",
+        "0.1.0-next.20260309150000.abc1234",
+      ),
+    ).toBe(0);
+  });
+
   it("returns null for invalid inputs", () => {
     expect(compareSemverStrings("1.0", "1.0.0")).toBeNull();
     expect(compareSemverStrings("latest", "1.0.0")).toBeNull();


### PR DESCRIPTION
## Summary

- Prepend UTC datetime (`YYYYMMDDHHmmSS`) before the git SHA in `next` channel version identifiers, changing the format from `0.1.0-next.<sha>` to `0.1.0-next.<datetime>.<sha>`
- The datetime is numeric and monotonically increasing, so semver numeric comparison orders versions correctly — eliminating false downgrade warnings
- Add test cases verifying `compareSemverStrings` correctly orders datetime-based `next` versions

Closes #610

## Test plan

- [x] `compareSemverStrings` correctly orders two datetime-based `next` versions (newer datetime > older datetime regardless of SHA ordering)
- [x] Existing semver comparison tests still pass (6/6)
- [ ] CI: build, test, lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)