### PR TITLE
fix(middleware): emit error event on non-zero CLI exit with empty stderr (#611)

### DIFF
--- a/src/middleware/cli-runtime-base.test.ts
+++ b/src/middleware/cli-runtime-base.test.ts
@@ -598,6 +598,56 @@ describe("CLIRuntimeBase", () => {
       );
       expect(stderrErrors).toHaveLength(0);
     });
+
+    it("emits CLI_EXIT_ERROR when non-zero exit with no stderr and no NDJSON output", async () => {
+      const runtime = new TestRuntime("test-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      mockChild.stdout.end();
+      mockChild.emit("exit", 1, null);
+
+      const events = await promise;
+
+      expect(events).toContainEqual({
+        type: "error",
+        message: "Agent process exited with code 1",
+        code: "CLI_EXIT_ERROR",
+      });
+    });
+
+    it("does not emit CLI_EXIT_ERROR when non-zero exit has NDJSON output", async () => {
+      const runtime = new TestRuntime("test-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      mockChild.stdout.write('{"type":"text","text":"partial"}\n');
+      mockChild.stdout.end();
+      mockChild.emit("exit", 1, null);
+
+      const events = await promise;
+
+      const exitErrors = events.filter(
+        (e) => e.type === "error" && "code" in e && e.code === "CLI_EXIT_ERROR",
+      );
+      expect(exitErrors).toHaveLength(0);
+    });
+
+    it("does not emit CLI_EXIT_ERROR on zero exit with no output", async () => {
+      const runtime = new TestRuntime("test-cli");
+
+      const promise = collectEvents(runtime.execute(defaultParams));
+
+      mockChild.stdout.end();
+      mockChild.emit("exit", 0, null);
+
+      const events = await promise;
+
+      const exitErrors = events.filter(
+        (e) => e.type === "error" && "code" in e && e.code === "CLI_EXIT_ERROR",
+      );
+      expect(exitErrors).toHaveLength(0);
+    });
   });
 
   describe("done event", () => {

--- a/src/middleware/cli-runtime-base.ts
+++ b/src/middleware/cli-runtime-base.ts
@@ -268,6 +268,15 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
       } satisfies AgentErrorEvent;
     }
 
+    // ── Fallback error for non-zero exit with no output ────────────────
+    if (exitCode !== 0 && !yieldedEvents && !stderr) {
+      yield {
+        type: "error",
+        message: `Agent process exited with code ${exitCode}`,
+        code: "CLI_EXIT_ERROR",
+      } satisfies AgentErrorEvent;
+    }
+
     // ── Emit terminal events ─────────────────────────────────────────
     if (startupTimedOut) {
       yield {


### PR DESCRIPTION
## Summary

- Adds a `CLI_EXIT_ERROR` fallback error event when the CLI exits with a non-zero code but stderr is empty and no NDJSON events were yielded
- Ensures the delivery adapter always has an error payload to surface to the messaging channel, closing the silent-failure gap from #374
- Adds 3 tests: positive case (fallback emitted), and two negative cases (suppressed when NDJSON output exists or exit code is zero)

Closes #611

## Test plan

- [x] `CLI_EXIT_ERROR` emitted when exit code ≠ 0, no stderr, no NDJSON output
- [x] `CLI_EXIT_ERROR` NOT emitted when NDJSON events were yielded (even with non-zero exit)
- [x] `CLI_EXIT_ERROR` NOT emitted on zero exit with no output
- [x] Existing `CLI_STDERR` behavior unchanged (verified by existing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)