### PR TITLE
fix(middleware): skip session map update after failed --resume (#612)

### DIFF
--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -372,6 +372,40 @@ describe("ChannelBridge", () => {
       expect(stored).toBe("old-session");
     });
 
+    it("does not update session when runtime emits an error event", async () => {
+      const msg = makeMessage();
+      const key = buildSessionKey(msg);
+      await sessionMap.set(key, "old-session");
+
+      // Runtime emits error then done with a new (meaningless) sessionId
+      mockRuntimeInstance = mockRuntime([
+        { type: "error", message: "No conversation found" },
+        makeDone({ sessionId: "bad-session-id" }),
+      ]);
+
+      const bridge = createBridge();
+      await bridge.handle(msg);
+
+      // Old session preserved — bad ID not stored
+      const stored = await sessionMap.get(key);
+      expect(stored).toBe("old-session");
+    });
+
+    it("does not update session when runtime throws", async () => {
+      const msg = makeMessage();
+      const key = buildSessionKey(msg);
+      await sessionMap.set(key, "old-session");
+
+      mockRuntimeInstance = { execute: () => failingStream("spawn error") };
+
+      const bridge = createBridge();
+      await bridge.handle(msg);
+
+      // Old session preserved — runtime crash doesn't corrupt the map
+      const stored = await sessionMap.get(key);
+      expect(stored).toBe("old-session");
+    });
+
     it("uses separate sessions for different threads", async () => {
       const msg1 = makeMessage({ replyToId: "thread-1" });
       const msg2 = makeMessage({ replyToId: "thread-2" });

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -273,8 +273,9 @@ export class ChannelBridge {
         `[channel-bridge] side effects: sentTexts=${mcp.sentTexts.length} sentMedia=${mcp.sentMediaUrls.length} cronAdds=${mcp.cronAdds}`,
       );
 
-      // 9. Session update
-      if (runResult?.sessionId) {
+      // 9. Session update — skip when runtime errored to avoid overwriting
+      // a potentially-recoverable session ID with a meaningless one.
+      if (runResult?.sessionId && !lastError) {
         logDebug(
           `[channel-bridge] session update: key=${formatSessionKeyString(sessionKey)} sessionId=${runResult.sessionId}`,
         );


### PR DESCRIPTION
## Summary

- Gate session map update on `!lastError` in `channel-bridge.ts` — when `--resume` fails with a stale session ID, the runtime emits a meaningless new session ID that was overwriting the old entry and making recovery impossible
- Add two tests: error-event path and runtime-throw path both preserve the existing session entry

Closes #612

## Test plan

- [x] Existing 68 session/bridge tests pass
- [x] New test: session preserved when runtime emits error event with bad session ID
- [x] New test: session preserved when runtime throws (spawn failure)
- [x] Type-check clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)