### PR TITLE
refactor(middleware): separate system prompt from user prompt (#613)

### DIFF
--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -172,7 +172,7 @@ describe("ChannelBridge", () => {
       expect(result.error).toBeUndefined();
     });
 
-    it("passes system prompt + message text as the prompt", async () => {
+    it("passes user text as prompt and system prompt separately", async () => {
       const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
       mockRuntimeInstance = { execute: executeFn };
 
@@ -181,10 +181,11 @@ describe("ChannelBridge", () => {
 
       expect(executeFn).toHaveBeenCalledOnce();
       const params = executeFn.mock.calls[0][0];
-      expect(params.prompt).toBe("SYSTEM_PROMPT\n\nWhat is 2+2?");
+      expect(params.prompt).toBe("What is 2+2?");
+      expect(params.systemPrompt).toBe("SYSTEM_PROMPT");
     });
 
-    it("prepends extraContext between system prompt and user text", async () => {
+    it("passes extraContext as a separate field", async () => {
       const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
       mockRuntimeInstance = { execute: executeFn };
 
@@ -193,10 +194,12 @@ describe("ChannelBridge", () => {
 
       expect(executeFn).toHaveBeenCalledOnce();
       const params = executeFn.mock.calls[0][0];
-      expect(params.prompt).toBe("SYSTEM_PROMPT\n\nAnswer in French\n\nWhat is 2+2?");
+      expect(params.prompt).toBe("What is 2+2?");
+      expect(params.systemPrompt).toBe("SYSTEM_PROMPT");
+      expect(params.extraContext).toBe("Answer in French");
     });
 
-    it("omits extraContext section when not provided", async () => {
+    it("leaves extraContext undefined when not provided", async () => {
       const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
       mockRuntimeInstance = { execute: executeFn };
 
@@ -205,7 +208,8 @@ describe("ChannelBridge", () => {
 
       expect(executeFn).toHaveBeenCalledOnce();
       const params = executeFn.mock.calls[0][0];
-      expect(params.prompt).toBe("SYSTEM_PROMPT\n\nWhat is 2+2?");
+      expect(params.prompt).toBe("What is 2+2?");
+      expect(params.extraContext).toBeUndefined();
     });
 
     it("passes workingDirectory to runtime", async () => {

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -224,11 +224,9 @@ export class ChannelBridge {
       try {
         const captured = captureResult(
           runtime.execute({
-            prompt:
-              systemPrompt +
-              (message.extraContext ? "\n\n" + message.extraContext : "") +
-              "\n\n" +
-              message.text,
+            prompt: message.text,
+            systemPrompt,
+            extraContext: message.extraContext,
             media: supportedMedia?.length ? supportedMedia : undefined,
             sessionId: existingSessionId,
             mcpServers,

--- a/src/middleware/cli-runtime-base.ts
+++ b/src/middleware/cli-runtime-base.ts
@@ -37,6 +37,23 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
   protected abstract buildEnv(params: AgentExecuteParams): Record<string, string>;
 
   /**
+   * Compose the full prompt from structured parts (system + extra context + user).
+   * Runtimes that support separate system prompt delivery (e.g. Claude) should
+   * override or bypass this and handle the parts individually.
+   */
+  protected composePrompt(params: AgentExecuteParams): string {
+    let composed = "";
+    if (params.systemPrompt) {
+      composed += params.systemPrompt;
+    }
+    if (params.extraContext) {
+      composed += (composed ? "\n\n" : "") + params.extraContext;
+    }
+    composed += (composed ? "\n\n" : "") + params.prompt;
+    return composed;
+  }
+
+  /**
    * Construct a custom stdin payload for the subprocess.
    * When this returns a string, it is written to stdin instead of
    * the default large-prompt fallback.  Subclasses may override.
@@ -193,15 +210,14 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
         `[agent-runtime] pid=${child.pid}: delivering custom stdin payload (${customStdin.length} chars)`,
       );
       child.stdin.write(customStdin);
-    } else if (
-      this.supportsStdinPrompt &&
-      params.prompt.length > CLIRuntimeBase.STDIN_PROMPT_THRESHOLD &&
-      child.stdin
-    ) {
-      logDebug(
-        `[agent-runtime] pid=${child.pid}: delivering prompt via stdin (${params.prompt.length} chars)`,
-      );
-      child.stdin.write(params.prompt);
+    } else if (this.supportsStdinPrompt && child.stdin) {
+      const composedPrompt = this.composePrompt(params);
+      if (composedPrompt.length > CLIRuntimeBase.STDIN_PROMPT_THRESHOLD) {
+        logDebug(
+          `[agent-runtime] pid=${child.pid}: delivering prompt via stdin (${composedPrompt.length} chars)`,
+        );
+        child.stdin.write(composedPrompt);
+      }
     }
     // Always close stdin so CLIs that read from stdin get EOF and don't hang.
     child.stdin?.end();

--- a/src/middleware/runtimes/claude.test.ts
+++ b/src/middleware/runtimes/claude.test.ts
@@ -140,11 +140,43 @@ describe("ClaudeCliRuntime", () => {
       expect(args).not.toContain("--mcp-config");
     });
 
-    it("combines all flags: session + MCP + prompt", () => {
+    it("adds --append-system-prompt when systemPrompt is provided", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({ systemPrompt: "You are a helpful assistant." }),
+      );
+      expect(args).toContain("--append-system-prompt");
+      const idx = args.indexOf("--append-system-prompt");
+      expect(args[idx + 1]).toBe("You are a helpful assistant.");
+    });
+
+    it("combines systemPrompt and extraContext in --append-system-prompt", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          systemPrompt: "You are a helpful assistant.",
+          extraContext: "Answer in French",
+        }),
+      );
+      const idx = args.indexOf("--append-system-prompt");
+      expect(args[idx + 1]).toBe("You are a helpful assistant.\n\nAnswer in French");
+    });
+
+    it("does not add --append-system-prompt when neither systemPrompt nor extraContext is set", () => {
+      const args = runtime.testBuildArgs(makeParams());
+      expect(args).not.toContain("--append-system-prompt");
+    });
+
+    it("adds --append-system-prompt with extraContext alone", () => {
+      const args = runtime.testBuildArgs(makeParams({ extraContext: "Extra info" }));
+      const idx = args.indexOf("--append-system-prompt");
+      expect(args[idx + 1]).toBe("Extra info");
+    });
+
+    it("combines all flags: session + MCP + system prompt + prompt", () => {
       const args = runtime.testBuildArgs(
         makeParams({
           sessionId: "sess-456",
           mcpServers: { s1: { command: "cmd" } },
+          systemPrompt: "System instructions",
         }),
       );
 
@@ -154,6 +186,8 @@ describe("ClaudeCliRuntime", () => {
       expect(args).toContain("--resume");
       expect(args).toContain("sess-456");
       expect(args).toContain("--mcp-config");
+      expect(args).toContain("--append-system-prompt");
+      expect(args[args.indexOf("--append-system-prompt") + 1]).toBe("System instructions");
       // --print prompt comes last
       expect(args[args.length - 2]).toBe("--print");
       expect(args[args.length - 1]).toBe("Hello, Claude!");

--- a/src/middleware/runtimes/claude.ts
+++ b/src/middleware/runtimes/claude.ts
@@ -68,6 +68,12 @@ export class ClaudeCliRuntime extends CLIRuntimeBase {
       args.push("--mcp-config", JSON.stringify({ mcpServers: params.mcpServers }));
     }
 
+    // Pass system prompt via --append-system-prompt (includes extraContext)
+    const systemContent = [params.systemPrompt, params.extraContext].filter(Boolean).join("\n\n");
+    if (systemContent) {
+      args.push("--append-system-prompt", systemContent);
+    }
+
     // When image media is present (with base64 populated), use stream-json stdin
     // delivery instead of --print so content blocks can carry inline images.
     // -p activates print mode (required for --input-format / --output-format).

--- a/src/middleware/runtimes/codex.ts
+++ b/src/middleware/runtimes/codex.ts
@@ -79,11 +79,13 @@ export class CodexCliRuntime extends CLIRuntimeBase {
   // ── CLIRuntimeBase abstract method implementations ────────────────────
 
   protected buildArgs(params: AgentExecuteParams): string[] {
+    const composed = this.composePrompt(params);
+
     if (params.sessionId) {
       // Session resume: codex exec resume --json <id> <prompt>
       // Note: --color is not supported by the resume subcommand.
       // Images are skipped on resume — Codex propagates conversation context internally.
-      return ["exec", "resume", "--json", params.sessionId, params.prompt];
+      return ["exec", "resume", "--json", params.sessionId, composed];
     }
 
     // New session: codex exec --json --color never [--image ...] <prompt>
@@ -98,7 +100,7 @@ export class CodexCliRuntime extends CLIRuntimeBase {
       }
     }
 
-    args.push(params.prompt);
+    args.push(composed);
     return args;
   }
 

--- a/src/middleware/runtimes/gemini.ts
+++ b/src/middleware/runtimes/gemini.ts
@@ -75,7 +75,12 @@ export class GeminiCliRuntime extends CLIRuntimeBase {
   // ── CLIRuntimeBase abstract method implementations ────────────────────
 
   protected buildArgs(params: AgentExecuteParams): string[] {
-    const args: string[] = ["--output-format", "stream-json", "--prompt", params.prompt];
+    const args: string[] = [
+      "--output-format",
+      "stream-json",
+      "--prompt",
+      this.composePrompt(params),
+    ];
 
     if (params.sessionId) {
       args.push("--resume", params.sessionId);

--- a/src/middleware/runtimes/opencode.ts
+++ b/src/middleware/runtimes/opencode.ts
@@ -84,7 +84,7 @@ export class OpenCodeCliRuntime extends CLIRuntimeBase {
       args.push("--session", params.sessionId);
     }
 
-    args.push(params.prompt);
+    args.push(this.composePrompt(params));
     return args;
   }
 

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -37,6 +37,10 @@ export type MediaAttachment = {
 export type AgentExecuteParams = {
   /** The user prompt to send to the agent. */
   prompt: string;
+  /** System instructions for the agent (passed separately where supported). */
+  systemPrompt?: string | undefined;
+  /** Extra context inserted between the system prompt and user prompt. */
+  extraContext?: string | undefined;
   /** Media attachments to include with the prompt. */
   media?: MediaAttachment[] | undefined;
   /** Resume an existing session (CLI-specific session identifier). */


### PR DESCRIPTION
## Summary

- Add `systemPrompt` and `extraContext` as structured fields on `AgentExecuteParams` instead of pre-concatenating them into the `prompt` string
- Channel bridge now passes system prompt, extra context, and user text as separate params
- Claude runtime uses `--append-system-prompt` for system content, keeping only user text in `--print`
- Other runtimes (Gemini, Codex, OpenCode) use a new `composePrompt()` base class helper to concatenate as before (behavior-preserving)

Closes #613

## Test plan

- [x] All 601 middleware tests pass (26 test files)
- [x] Updated channel-bridge tests verify separated fields (`prompt`, `systemPrompt`, `extraContext`)
- [x] Added 4 new tests for `--append-system-prompt` flag in Claude runtime
- [x] Format, typecheck, and lint all pass (`pnpm check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)