### PR TITLE
refactor(middleware): separate thread history from user prompt to gate on session resume (#614)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -131,6 +131,7 @@ function buildChannelMessage(params: {
   messageToolHints: string[] | undefined;
   senderIsOwner?: boolean;
   extraSystemPrompt?: string;
+  threadContext?: string;
   userName?: string;
   agentId?: string;
   timezone?: string;
@@ -149,6 +150,7 @@ function buildChannelMessage(params: {
     messageToolHints: params.messageToolHints?.length ? params.messageToolHints : undefined,
     senderIsOwner: params.senderIsOwner,
     extraContext: params.extraSystemPrompt || undefined,
+    threadContext: params.threadContext || undefined,
     userName: params.userName || undefined,
     agentId: params.agentId || undefined,
     timezone: params.timezone || undefined,
@@ -298,6 +300,7 @@ export async function runAgentTurnWithFallback(params: {
           messageToolHints,
           senderIsOwner: params.followupRun.run.senderIsOwner,
           extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+          threadContext: params.followupRun.run.threadContext,
           userName: params.followupRun.run.senderName,
           agentId: params.followupRun.run.agentId,
           timezone: resolveUserTimezone(cfg?.agents?.defaults?.userTimezone),

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -94,6 +94,7 @@ export function createFollowupRunner(params: {
         messageToolHints: messageToolHints?.length ? messageToolHints : undefined,
         senderIsOwner: queued.run.senderIsOwner,
         extraContext: queued.run.extraSystemPrompt || undefined,
+        threadContext: queued.run.threadContext || undefined,
       };
 
       // Wire BridgeCallbacks from opts callbacks.

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -132,18 +132,20 @@ describe("runPreparedReply media-only handling", () => {
     vi.clearAllMocks();
   });
 
-  it("allows media-only prompts and preserves thread context in queued followups", async () => {
+  it("allows media-only prompts and preserves thread context as structured field", async () => {
     const result = await runPreparedReply(baseParams());
     expect(result).toEqual({ text: "ok" });
 
     const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
     expect(call).toBeTruthy();
-    expect(call?.followupRun.prompt).toContain("[Thread history - for context]");
-    expect(call?.followupRun.prompt).toContain("Earlier message in this thread");
+    expect(call?.followupRun.run.threadContext).toContain("[Thread history - for context]");
+    expect(call?.followupRun.run.threadContext).toContain("Earlier message in this thread");
     expect(call?.followupRun.prompt).toContain("[User sent media without caption]");
+    // Thread context should NOT be baked into the prompt
+    expect(call?.followupRun.prompt).not.toContain("[Thread history - for context]");
   });
 
-  it("keeps thread history context on follow-up turns", async () => {
+  it("keeps thread history context on follow-up turns as structured field", async () => {
     const result = await runPreparedReply(
       baseParams({
         isNewSession: false,
@@ -153,8 +155,10 @@ describe("runPreparedReply media-only handling", () => {
 
     const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
     expect(call).toBeTruthy();
-    expect(call?.followupRun.prompt).toContain("[Thread history - for context]");
-    expect(call?.followupRun.prompt).toContain("Earlier message in this thread");
+    expect(call?.followupRun.run.threadContext).toContain("[Thread history - for context]");
+    expect(call?.followupRun.run.threadContext).toContain("Earlier message in this thread");
+    // Thread context should NOT be baked into the prompt
+    expect(call?.followupRun.prompt).not.toContain("[Thread history - for context]");
   });
 
   it("returns the empty-body reply when there is no text and no media", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -298,14 +298,13 @@ export async function runPreparedReply(
     : threadStarterBody
       ? `[Thread starter - for context]\n${threadStarterBody}`
       : undefined;
-  const prefixedBody = [threadContextNote, prefixedBodyBase].filter(Boolean).join("\n\n");
   const mediaNote = buildInboundMediaNote(ctx);
   const mediaReplyHint = mediaNote
     ? "To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg (spaces ok, quote if needed) or a safe relative path like MEDIA:./image.jpg. Avoid absolute paths (MEDIA:/...) and ~ paths — they are blocked for security. Keep caption in the text body."
     : undefined;
   const prefixedCommandBody = mediaNote
-    ? [mediaNote, mediaReplyHint, prefixedBody ?? ""].filter(Boolean).join("\n").trim()
-    : prefixedBody;
+    ? [mediaNote, mediaReplyHint, prefixedBodyBase ?? ""].filter(Boolean).join("\n").trim()
+    : prefixedBodyBase;
   if (resetTriggered && command.isAuthorizedSender) {
     await sendResetSessionNotice({
       ctx,
@@ -326,10 +325,9 @@ export async function runPreparedReply(
     sessionEntry,
     resolveSessionFilePathOptions({ agentId, storePath }),
   );
-  const queueBodyBase = [threadContextNote, effectiveBaseBody].filter(Boolean).join("\n\n");
   const queuedBody = mediaNote
-    ? [mediaNote, mediaReplyHint, queueBodyBase].filter(Boolean).join("\n").trim()
-    : queueBodyBase;
+    ? [mediaNote, mediaReplyHint, effectiveBaseBody].filter(Boolean).join("\n").trim()
+    : effectiveBaseBody;
   const resolvedQueue = resolveQueueSettings({
     cfg,
     channel: sessionCtx.Provider,
@@ -388,6 +386,7 @@ export async function runPreparedReply(
       blockReplyBreak: resolvedBlockStreamingBreak,
       ownerNumbers: command.ownerList.length > 0 ? command.ownerList : undefined,
       extraSystemPrompt: extraSystemPrompt || undefined,
+      threadContext: threadContextNote,
       ...(isReasoningTagProvider(provider) ? { enforceFinalTag: true } : {}),
     },
   };

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -64,6 +64,7 @@ export type FollowupRun = {
     blockReplyBreak: "text_end" | "message_end";
     ownerNumbers?: string[];
     extraSystemPrompt?: string;
+    threadContext?: string;
     enforceFinalTag?: boolean;
   };
 };

--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -212,6 +212,36 @@ describe("ChannelBridge", () => {
       expect(params.extraContext).toBeUndefined();
     });
 
+    it("passes threadContext as a separate field", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = createBridge();
+      await bridge.handle(
+        makeMessage({
+          text: "Thanks!",
+          threadContext: "[Thread history - for context]\nAlice: Hi\nBob: Hello",
+        }),
+      );
+
+      expect(executeFn).toHaveBeenCalledOnce();
+      const params = executeFn.mock.calls[0][0];
+      expect(params.prompt).toBe("Thanks!");
+      expect(params.threadContext).toBe("[Thread history - for context]\nAlice: Hi\nBob: Hello");
+    });
+
+    it("leaves threadContext undefined when not provided", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = createBridge();
+      await bridge.handle(makeMessage({ text: "What is 2+2?" }));
+
+      expect(executeFn).toHaveBeenCalledOnce();
+      const params = executeFn.mock.calls[0][0];
+      expect(params.threadContext).toBeUndefined();
+    });
+
     it("passes workingDirectory to runtime", async () => {
       const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
       mockRuntimeInstance = { execute: executeFn };

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -227,6 +227,7 @@ export class ChannelBridge {
             prompt: message.text,
             systemPrompt,
             extraContext: message.extraContext,
+            threadContext: message.threadContext,
             media: supportedMedia?.length ? supportedMedia : undefined,
             sessionId: existingSessionId,
             mcpServers,

--- a/src/middleware/cli-runtime-base.test.ts
+++ b/src/middleware/cli-runtime-base.test.ts
@@ -55,6 +55,10 @@ class TestRuntime extends CLIRuntimeBase {
   protected buildEnv(_params: AgentExecuteParams): Record<string, string> {
     return { TEST_VAR: "1" };
   }
+
+  public testComposePrompt(params: AgentExecuteParams): string {
+    return this.composePrompt(params);
+  }
 }
 
 /** Collect all events from the async iterable. */
@@ -681,6 +685,49 @@ describe("CLIRuntimeBase", () => {
       const last = events[events.length - 1];
 
       expect(last.type).toBe("done");
+    });
+  });
+
+  describe("composePrompt thread context gating", () => {
+    it("includes threadContext on new sessions (no sessionId)", () => {
+      const runtime = new TestRuntime("test-cli");
+      const result = runtime.testComposePrompt({
+        prompt: "hello",
+        systemPrompt: "system",
+        threadContext: "[Thread history - for context]\nAlice: Hi",
+      });
+      expect(result).toBe("system\n\n[Thread history - for context]\nAlice: Hi\n\nhello");
+    });
+
+    it("excludes threadContext on resume (sessionId set)", () => {
+      const runtime = new TestRuntime("test-cli");
+      const result = runtime.testComposePrompt({
+        prompt: "hello",
+        systemPrompt: "system",
+        sessionId: "sess-123",
+        threadContext: "[Thread history - for context]\nAlice: Hi",
+      });
+      expect(result).toBe("system\n\nhello");
+    });
+
+    it("includes threadContext between extraContext and prompt", () => {
+      const runtime = new TestRuntime("test-cli");
+      const result = runtime.testComposePrompt({
+        prompt: "hello",
+        systemPrompt: "system",
+        extraContext: "extra",
+        threadContext: "[Thread starter - for context]\nAlice: Hi",
+      });
+      expect(result).toBe("system\n\nextra\n\n[Thread starter - for context]\nAlice: Hi\n\nhello");
+    });
+
+    it("includes threadContext alone when no systemPrompt or extraContext", () => {
+      const runtime = new TestRuntime("test-cli");
+      const result = runtime.testComposePrompt({
+        prompt: "hello",
+        threadContext: "[Thread starter - for context]\nAlice: Hi",
+      });
+      expect(result).toBe("[Thread starter - for context]\nAlice: Hi\n\nhello");
     });
   });
 });

--- a/src/middleware/cli-runtime-base.ts
+++ b/src/middleware/cli-runtime-base.ts
@@ -49,6 +49,11 @@ export abstract class CLIRuntimeBase implements AgentRuntime {
     if (params.extraContext) {
       composed += (composed ? "\n\n" : "") + params.extraContext;
     }
+    // Include thread context only on new sessions — on resume the CLI
+    // already has conversation history, so injecting it again is redundant.
+    if (params.threadContext && !params.sessionId) {
+      composed += (composed ? "\n\n" : "") + params.threadContext;
+    }
     composed += (composed ? "\n\n" : "") + params.prompt;
     return composed;
   }

--- a/src/middleware/runtimes/claude.test.ts
+++ b/src/middleware/runtimes/claude.test.ts
@@ -171,6 +171,41 @@ describe("ClaudeCliRuntime", () => {
       expect(args[idx + 1]).toBe("Extra info");
     });
 
+    it("includes threadContext in --append-system-prompt on new sessions", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          systemPrompt: "System instructions",
+          threadContext: "[Thread history - for context]\nAlice: Hi",
+        }),
+      );
+      const idx = args.indexOf("--append-system-prompt");
+      expect(args[idx + 1]).toBe(
+        "System instructions\n\n[Thread history - for context]\nAlice: Hi",
+      );
+    });
+
+    it("excludes threadContext from --append-system-prompt on resume", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          sessionId: "sess-123",
+          systemPrompt: "System instructions",
+          threadContext: "[Thread history - for context]\nAlice: Hi",
+        }),
+      );
+      const idx = args.indexOf("--append-system-prompt");
+      expect(args[idx + 1]).toBe("System instructions");
+    });
+
+    it("includes threadContext alone in --append-system-prompt when no systemPrompt", () => {
+      const args = runtime.testBuildArgs(
+        makeParams({
+          threadContext: "[Thread starter - for context]\nAlice: Hi",
+        }),
+      );
+      const idx = args.indexOf("--append-system-prompt");
+      expect(args[idx + 1]).toBe("[Thread starter - for context]\nAlice: Hi");
+    });
+
     it("combines all flags: session + MCP + system prompt + prompt", () => {
       const args = runtime.testBuildArgs(
         makeParams({

--- a/src/middleware/runtimes/claude.ts
+++ b/src/middleware/runtimes/claude.ts
@@ -68,8 +68,13 @@ export class ClaudeCliRuntime extends CLIRuntimeBase {
       args.push("--mcp-config", JSON.stringify({ mcpServers: params.mcpServers }));
     }
 
-    // Pass system prompt via --append-system-prompt (includes extraContext)
-    const systemContent = [params.systemPrompt, params.extraContext].filter(Boolean).join("\n\n");
+    // Pass system prompt via --append-system-prompt (includes extraContext and
+    // thread context on new sessions — on resume the CLI already has history).
+    const systemParts = [params.systemPrompt, params.extraContext];
+    if (!params.sessionId && params.threadContext) {
+      systemParts.push(params.threadContext);
+    }
+    const systemContent = systemParts.filter(Boolean).join("\n\n");
     if (systemContent) {
       args.push("--append-system-prompt", systemContent);
     }

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -41,6 +41,8 @@ export type AgentExecuteParams = {
   systemPrompt?: string | undefined;
   /** Extra context inserted between the system prompt and user prompt. */
   extraContext?: string | undefined;
+  /** Thread history or thread-starter context (skipped on session resume). */
+  threadContext?: string | undefined;
   /** Media attachments to include with the prompt. */
   media?: MediaAttachment[] | undefined;
   /** Resume an existing session (CLI-specific session identifier). */
@@ -241,6 +243,8 @@ export type ChannelMessage = {
   messageToolHints?: string[] | undefined;
   /** Extra context to prepend between the system prompt and user text (e.g. per-channel instructions). */
   extraContext?: string | undefined;
+  /** Thread history or thread-starter context (skipped on session resume). */
+  threadContext?: string | undefined;
   /** Provider-specific metadata. */
   metadata?: Record<string, unknown> | undefined;
   /** Whether the message sender is the bot owner. Defaults to `false`. */


### PR DESCRIPTION
## Summary

- Add `threadContext` field to `AgentExecuteParams` and `ChannelMessage` types
- Stop baking thread history (`ThreadHistoryBody`/`ThreadStarterBody`) into `message.text` in `get-reply-run.ts` — pass as a structured field through `FollowupRun.run.threadContext`
- Propagate `threadContext` through `agent-runner-execution.ts` → `channel-bridge.ts` → runtime
- Gate inclusion on `!sessionId` in `CLIRuntimeBase.composePrompt()` and `ClaudeCliRuntime.buildArgs()` — thread context is only injected on new sessions, skipped on resume where the CLI already has conversation history

Closes #614

## Test plan

- [x] channel-bridge: passes/omits `threadContext` to runtime (2 new tests)
- [x] cli-runtime-base: `composePrompt` includes thread context on new sessions, excludes on resume (4 new tests)
- [x] claude runtime: `--append-system-prompt` includes thread context on new sessions, excludes on resume (3 new tests)
- [x] get-reply-run media-only: thread context flows via structured field, not baked into prompt (2 updated tests)
- [x] Full test suite passes (pre-existing canvas-auth failure only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)