### PR TITLE
fix: soften overclaim in landscape page

### DIFF
--- a/docs/landscape.md
+++ b/docs/landscape.md
@@ -9,7 +9,7 @@ developers kept asking for.
 We mapped the AI agent landscape -- every fork, rewrite, bridge, and managed service
 we could find -- and discovered a product category that barely exists.
 
-100+ projects want to be your AI agent. Zero connect the one you already have.
+100+ projects want to be your AI agent. Almost none connect the one you already have.
 
 ## Two Kinds of Users
 


### PR DESCRIPTION
## Summary

- "Zero connect the one you already have" → "Almost none connect the one you already have"
- The same page lists cc-connect, Claude-Code-Remote, and other bridge projects — claiming "zero" contradicts our own data

🤖 Generated with [Claude Code](https://claude.com/claude-code)