### PR TITLE
Cherry-pick c6dfa26: refactor(signal): unify reaction auth flow and table-drive tests

### DIFF
--- a/src/signal/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
+++ b/src/signal/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
@@ -378,6 +378,48 @@ describe("monitorSignalProvider tool results", () => {
     expect(events.some((text) => text.includes("Signal reaction added"))).toBe(true);
   });
 
+  it.each([
+    {
+      name: "blocks reaction notifications from unauthorized senders when dmPolicy is allowlist",
+      mode: "all" as const,
+      extra: { dmPolicy: "allowlist", allowFrom: ["+15550007777"] } as Record<string, unknown>,
+      targetAuthor: "+15550002222",
+      shouldEnqueue: false,
+    },
+    {
+      name: "blocks reaction notifications from unauthorized senders when dmPolicy is pairing",
+      mode: "own" as const,
+      extra: {
+        dmPolicy: "pairing",
+        allowFrom: [],
+        account: "+15550009999",
+      } as Record<string, unknown>,
+      targetAuthor: "+15550009999",
+      shouldEnqueue: false,
+    },
+    {
+      name: "allows reaction notifications for allowlisted senders when dmPolicy is allowlist",
+      mode: "all" as const,
+      extra: { dmPolicy: "allowlist", allowFrom: ["+15550001111"] } as Record<string, unknown>,
+      targetAuthor: "+15550002222",
+      shouldEnqueue: true,
+    },
+  ])("$name", async ({ mode, extra, targetAuthor, shouldEnqueue }) => {
+    setReactionNotificationConfig(mode, extra);
+    await receiveSingleEnvelope({
+      ...makeBaseEnvelope(),
+      reactionMessage: {
+        emoji: "✅",
+        targetAuthor,
+        targetSentTimestamp: 2,
+      },
+    });
+
+    const events = getDirectSignalEventsFor("+15550001111");
+    expect(events.some((text) => text.includes("Signal reaction added"))).toBe(shouldEnqueue);
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
+  });
   it("notifies on own reactions when target includes uuid + phone", async () => {
     setReactionNotificationConfig("own", { account: "+15550002222" });
     await receiveSingleEnvelope({

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -45,9 +45,15 @@ import {
   resolveSignalPeerId,
   resolveSignalRecipient,
   resolveSignalSender,
+  type SignalSender,
 } from "../identity.js";
 import { sendMessageSignal, sendReadReceiptSignal, sendTypingSignal } from "../send.js";
-import type { SignalEventHandlerDeps, SignalReceivePayload } from "./event-handler.types.js";
+import type {
+  SignalEnvelope,
+  SignalEventHandlerDeps,
+  SignalReactionMessage,
+  SignalReceivePayload,
+} from "./event-handler.types.js";
 import { renderSignalMentions } from "./mentions.js";
 export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   const inboundDebounceMs = resolveInboundDebounceMs({ cfg: deps.cfg, channel: "signal" });
@@ -317,6 +323,85 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     },
   });
 
+  function handleReactionOnlyInbound(params: {
+    envelope: SignalEnvelope;
+    sender: SignalSender;
+    senderDisplay: string;
+    reaction: SignalReactionMessage;
+    hasBodyContent: boolean;
+    resolveAccessDecision: (isGroup: boolean) => {
+      decision: "allow" | "block" | "pairing";
+      reason: string;
+    };
+  }): boolean {
+    if (params.hasBodyContent) {
+      return false;
+    }
+    if (params.reaction.isRemove) {
+      return true; // Ignore reaction removals
+    }
+    const emojiLabel = params.reaction.emoji?.trim() || "emoji";
+    const senderName = params.envelope.sourceName ?? params.senderDisplay;
+    logVerbose(`signal reaction: ${emojiLabel} from ${senderName}`);
+    const groupId = params.reaction.groupInfo?.groupId ?? undefined;
+    const groupName = params.reaction.groupInfo?.groupName ?? undefined;
+    const isGroup = Boolean(groupId);
+    const reactionAccess = params.resolveAccessDecision(isGroup);
+    if (reactionAccess.decision !== "allow") {
+      logVerbose(
+        `Blocked signal reaction sender ${params.senderDisplay} (${reactionAccess.reason})`,
+      );
+      return true;
+    }
+    const targets = deps.resolveSignalReactionTargets(params.reaction);
+    const shouldNotify = deps.shouldEmitSignalReactionNotification({
+      mode: deps.reactionMode,
+      account: deps.account,
+      targets,
+      sender: params.sender,
+      allowlist: deps.reactionAllowlist,
+    });
+    if (!shouldNotify) {
+      return true;
+    }
+
+    const senderPeerId = resolveSignalPeerId(params.sender);
+    const route = resolveAgentRoute({
+      cfg: deps.cfg,
+      channel: "signal",
+      accountId: deps.accountId,
+      peer: {
+        kind: isGroup ? "group" : "direct",
+        id: isGroup ? (groupId ?? "unknown") : senderPeerId,
+      },
+    });
+    const groupLabel = isGroup ? `${groupName ?? "Signal Group"} id:${groupId}` : undefined;
+    const messageId = params.reaction.targetSentTimestamp
+      ? String(params.reaction.targetSentTimestamp)
+      : "unknown";
+    const text = deps.buildSignalReactionSystemEventText({
+      emojiLabel,
+      actorLabel: senderName,
+      messageId,
+      targetLabel: targets[0]?.display,
+      groupLabel,
+    });
+    const senderId = formatSignalSenderId(params.sender);
+    const contextKey = [
+      "signal",
+      "reaction",
+      "added",
+      messageId,
+      senderId,
+      emojiLabel,
+      groupId ?? "",
+    ]
+      .filter(Boolean)
+      .join(":");
+    enqueueSystemEvent(text, { sessionKey: route.sessionKey, contextKey });
+    return true;
+  }
+
   return async (event: { event?: string; data?: string }) => {
     if (event.event !== "receive" || !event.data) {
       return;
@@ -366,71 +451,69 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const quoteText = dataMessage?.quote?.text?.trim() ?? "";
     const hasBodyContent =
       Boolean(messageText || quoteText) || Boolean(!reaction && dataMessage?.attachments?.length);
-
-    if (reaction && !hasBodyContent) {
-      if (reaction.isRemove) {
-        return;
-      } // Ignore reaction removals
-      const emojiLabel = reaction.emoji?.trim() || "emoji";
-      const senderDisplay = formatSignalSenderDisplay(sender);
-      const senderName = envelope.sourceName ?? senderDisplay;
-      logVerbose(`signal reaction: ${emojiLabel} from ${senderName}`);
-      const targets = deps.resolveSignalReactionTargets(reaction);
-      const shouldNotify = deps.shouldEmitSignalReactionNotification({
-        mode: deps.reactionMode,
-        account: deps.account,
-        targets,
-        sender,
-        allowlist: deps.reactionAllowlist,
-      });
-      if (!shouldNotify) {
-        return;
+    const senderDisplay = formatSignalSenderDisplay(sender);
+    const storeAllowFrom =
+      deps.dmPolicy === "allowlist"
+        ? []
+        : await readChannelAllowFromStore("signal").catch(() => []);
+    const effectiveDmAllow = [...deps.allowFrom, ...storeAllowFrom];
+    const effectiveGroupAllow = [...deps.groupAllowFrom, ...storeAllowFrom];
+    const resolveAccessDecision = (
+      isGroup: boolean,
+    ): {
+      decision: "allow" | "block" | "pairing";
+      reason: string;
+    } => {
+      if (isGroup) {
+        if (deps.groupPolicy === "disabled") {
+          return { decision: "block", reason: "groupPolicy: disabled" };
+        }
+        if (deps.groupPolicy === "allowlist") {
+          if (effectiveGroupAllow.length === 0) {
+            return { decision: "block", reason: "groupPolicy: allowlist, no groupAllowFrom" };
+          }
+          if (!isSignalSenderAllowed(sender, effectiveGroupAllow)) {
+            return { decision: "block", reason: "not in groupAllowFrom" };
+          }
+        }
+        return { decision: "allow", reason: "group allowed" };
       }
+      if (deps.dmPolicy === "disabled") {
+        return { decision: "block", reason: "dmPolicy: disabled" };
+      }
+      if (deps.dmPolicy === "open") {
+        return { decision: "allow", reason: "dmPolicy: open" };
+      }
+      const allowed = isSignalSenderAllowed(sender, effectiveDmAllow);
+      if (deps.dmPolicy === "pairing") {
+        return allowed
+          ? { decision: "allow", reason: "sender in allowFrom" }
+          : { decision: "pairing", reason: "dmPolicy: pairing, sender not allowed" };
+      }
+      return allowed
+        ? { decision: "allow", reason: "sender in allowFrom" }
+        : { decision: "block", reason: `dmPolicy: ${deps.dmPolicy}, sender not allowed` };
+    };
+    const dmAccess = resolveAccessDecision(false);
+    const dmAllowed = dmAccess.decision === "allow";
 
-      const groupId = reaction.groupInfo?.groupId ?? undefined;
-      const groupName = reaction.groupInfo?.groupName ?? undefined;
-      const isGroup = Boolean(groupId);
-      const senderPeerId = resolveSignalPeerId(sender);
-      const route = resolveAgentRoute({
-        cfg: deps.cfg,
-        channel: "signal",
-        accountId: deps.accountId,
-        peer: {
-          kind: isGroup ? "group" : "direct",
-          id: isGroup ? (groupId ?? "unknown") : senderPeerId,
-        },
-      });
-      const groupLabel = isGroup ? `${groupName ?? "Signal Group"} id:${groupId}` : undefined;
-      const messageId = reaction.targetSentTimestamp
-        ? String(reaction.targetSentTimestamp)
-        : "unknown";
-      const text = deps.buildSignalReactionSystemEventText({
-        emojiLabel,
-        actorLabel: senderName,
-        messageId,
-        targetLabel: targets[0]?.display,
-        groupLabel,
-      });
-      const senderId = formatSignalSenderId(sender);
-      const contextKey = [
-        "signal",
-        "reaction",
-        "added",
-        messageId,
-        senderId,
-        emojiLabel,
-        groupId ?? "",
-      ]
-        .filter(Boolean)
-        .join(":");
-      enqueueSystemEvent(text, { sessionKey: route.sessionKey, contextKey });
+    if (
+      reaction &&
+      handleReactionOnlyInbound({
+        envelope,
+        sender,
+        senderDisplay,
+        reaction,
+        hasBodyContent,
+        resolveAccessDecision,
+      })
+    ) {
       return;
     }
     if (!dataMessage) {
       return;
     }
 
-    const senderDisplay = formatSignalSenderDisplay(sender);
     const senderRecipient = resolveSignalRecipient(sender);
     const senderPeerId = resolveSignalPeerId(sender);
     const senderAllowId = formatSignalSenderId(sender);
@@ -441,14 +524,6 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const groupId = dataMessage.groupInfo?.groupId ?? undefined;
     const groupName = dataMessage.groupInfo?.groupName ?? undefined;
     const isGroup = Boolean(groupId);
-    const storeAllowFrom =
-      deps.dmPolicy === "allowlist"
-        ? []
-        : await readChannelAllowFromStore("signal").catch(() => []);
-    const effectiveDmAllow = [...deps.allowFrom, ...storeAllowFrom];
-    const effectiveGroupAllow = [...deps.groupAllowFrom, ...storeAllowFrom];
-    const dmAllowed =
-      deps.dmPolicy === "open" ? true : isSignalSenderAllowed(sender, effectiveDmAllow);
 
     if (!isGroup) {
       if (deps.dmPolicy === "disabled") {


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: c6dfa26f03
**Author**: Peter Steinberger <steipete@gmail.com>
**Tier**: AUTO-PICK

> refactor(signal): unify reaction auth flow and table-drive tests

Conflicts resolved: Adapted `resolveAccessDecision` callback to fork's inline auth pattern (fork doesn't have upstream's `resolveEffectiveAllowFromLists`/`resolveDmGroupAccessDecision` helpers). Moved allowFrom computation before reaction handling to enable auth checks on reactions. Removed duplicate senderDisplay/allowFrom computations from later in the handler.