### PR TITLE
Cherry-pick 046feb6: refactor: simplify telegram event authorization flow

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -10,6 +10,7 @@ import { buildCommandsMessagePaginated } from "../auto-reply/status.js";
 import { resolveChannelConfigWrites } from "../channels/plugins/config-writes.js";
 import { loadConfig } from "../config/config.js";
 import { writeConfigFile } from "../config/io.js";
+import type { DmPolicy } from "../config/types.base.js";
 import type { TelegramGroupConfig, TelegramTopicConfig } from "../config/types.js";
 import { danger, logVerbose, warn } from "../globals.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
@@ -415,6 +416,131 @@ export const registerTelegramHandlers = ({
     return false;
   };
 
+  type TelegramGroupAllowContext = Awaited<ReturnType<typeof resolveTelegramGroupAllowFromContext>>;
+  type TelegramEventAuthorizationMode = "reaction" | "callback-scope" | "callback-allowlist";
+  type TelegramEventAuthorizationResult = { allowed: true } | { allowed: false; reason: string };
+  type TelegramEventAuthorizationContext = TelegramGroupAllowContext & { dmPolicy: DmPolicy };
+
+  const TELEGRAM_EVENT_AUTH_RULES: Record<
+    TelegramEventAuthorizationMode,
+    {
+      enforceDirectAuthorization: boolean;
+      enforceGroupAllowlistAuthorization: boolean;
+      deniedDmReason: string;
+      deniedGroupReason: string;
+    }
+  > = {
+    reaction: {
+      enforceDirectAuthorization: true,
+      enforceGroupAllowlistAuthorization: false,
+      deniedDmReason: "reaction unauthorized by dm policy/allowlist",
+      deniedGroupReason: "reaction unauthorized by group allowlist",
+    },
+    "callback-scope": {
+      enforceDirectAuthorization: false,
+      enforceGroupAllowlistAuthorization: false,
+      deniedDmReason: "callback unauthorized by inlineButtonsScope",
+      deniedGroupReason: "callback unauthorized by inlineButtonsScope",
+    },
+    "callback-allowlist": {
+      enforceDirectAuthorization: true,
+      enforceGroupAllowlistAuthorization: true,
+      deniedDmReason: "callback unauthorized by inlineButtonsScope allowlist",
+      deniedGroupReason: "callback unauthorized by inlineButtonsScope allowlist",
+    },
+  };
+
+  const resolveTelegramEventAuthorizationContext = async (params: {
+    chatId: number;
+    isForum: boolean;
+    messageThreadId?: number;
+    groupAllowContext?: TelegramGroupAllowContext;
+  }): Promise<TelegramEventAuthorizationContext> => {
+    const dmPolicy = telegramCfg.dmPolicy ?? "pairing";
+    const groupAllowContext =
+      params.groupAllowContext ??
+      (await resolveTelegramGroupAllowFromContext({
+        chatId: params.chatId,
+        accountId,
+        dmPolicy,
+        isForum: params.isForum,
+        messageThreadId: params.messageThreadId,
+        groupAllowFrom,
+        resolveTelegramGroupConfig,
+      }));
+    return { dmPolicy, ...groupAllowContext };
+  };
+
+  const authorizeTelegramEventSender = (params: {
+    chatId: number;
+    chatTitle?: string;
+    isGroup: boolean;
+    senderId: string;
+    senderUsername: string;
+    mode: TelegramEventAuthorizationMode;
+    context: TelegramEventAuthorizationContext;
+  }): TelegramEventAuthorizationResult => {
+    const { chatId, chatTitle, isGroup, senderId, senderUsername, mode, context } = params;
+    const {
+      dmPolicy,
+      resolvedThreadId,
+      storeAllowFrom,
+      groupConfig,
+      topicConfig,
+      effectiveGroupAllow,
+      hasGroupAllowOverride,
+    } = context;
+    const authRules = TELEGRAM_EVENT_AUTH_RULES[mode];
+    const {
+      enforceDirectAuthorization,
+      enforceGroupAllowlistAuthorization,
+      deniedDmReason,
+      deniedGroupReason,
+    } = authRules;
+    if (
+      shouldSkipGroupMessage({
+        isGroup,
+        chatId,
+        chatTitle,
+        resolvedThreadId,
+        senderId,
+        senderUsername,
+        effectiveGroupAllow,
+        hasGroupAllowOverride,
+        groupConfig,
+        topicConfig,
+      })
+    ) {
+      return { allowed: false, reason: "group-policy" };
+    }
+
+    if (!isGroup && enforceDirectAuthorization) {
+      if (dmPolicy === "disabled") {
+        logVerbose(
+          `Blocked telegram direct event from ${senderId || "unknown"} (${deniedDmReason})`,
+        );
+        return { allowed: false, reason: "direct-disabled" };
+      }
+      if (dmPolicy !== "open") {
+        const effectiveDmAllow = normalizeAllowFromWithStore({
+          allowFrom,
+          storeAllowFrom,
+          dmPolicy,
+        });
+        if (!isAllowlistAuthorized(effectiveDmAllow, senderId, senderUsername)) {
+          logVerbose(`Blocked telegram direct sender ${senderId || "unknown"} (${deniedDmReason})`);
+          return { allowed: false, reason: "direct-unauthorized" };
+        }
+      }
+    }
+    if (isGroup && enforceGroupAllowlistAuthorization) {
+      if (!isAllowlistAuthorized(effectiveGroupAllow, senderId, senderUsername)) {
+        logVerbose(`Blocked telegram group sender ${senderId || "unknown"} (${deniedGroupReason})`);
+        return { allowed: false, reason: "group-unauthorized" };
+      }
+    }
+    return { allowed: true };
+  };
   // Handle emoji reactions to messages.
   bot.on("message_reaction", async (ctx) => {
     try {
@@ -439,6 +565,22 @@ export const registerTelegramHandlers = ({
         return;
       }
       if (reactionMode === "own" && !wasSentByBot(chatId, messageId)) {
+        return;
+      }
+      const eventAuthContext = await resolveTelegramEventAuthorizationContext({
+        chatId,
+        isForum,
+      });
+      const senderAuthorization = authorizeTelegramEventSender({
+        chatId,
+        chatTitle: reaction.chat.title,
+        isGroup,
+        senderId,
+        senderUsername,
+        mode: "reaction",
+        context: eventAuthContext,
+      });
+      if (!senderAuthorization.allowed) {
         return;
       }
 
@@ -745,65 +887,27 @@ export const registerTelegramHandlers = ({
 
       const messageThreadId = callbackMessage.message_thread_id;
       const isForum = callbackMessage.chat.is_forum === true;
-      const groupAllowContext = await resolveTelegramGroupAllowFromContext({
+      const eventAuthContext = await resolveTelegramEventAuthorizationContext({
         chatId,
-        accountId,
-        dmPolicy: telegramCfg.dmPolicy ?? "pairing",
         isForum,
         messageThreadId,
-        groupAllowFrom,
-        resolveTelegramGroupConfig,
       });
-      const {
-        resolvedThreadId,
-        storeAllowFrom,
-        groupConfig,
-        topicConfig,
-        effectiveGroupAllow,
-        hasGroupAllowOverride,
-      } = groupAllowContext;
-      const dmPolicy = telegramCfg.dmPolicy ?? "pairing";
-      const effectiveDmAllow = normalizeAllowFromWithStore({
-        allowFrom: telegramCfg.allowFrom,
-        storeAllowFrom,
-        dmPolicy,
-      });
+      const { storeAllowFrom } = eventAuthContext;
       const senderId = callback.from?.id ? String(callback.from.id) : "";
       const senderUsername = callback.from?.username ?? "";
-      if (
-        shouldSkipGroupMessage({
-          isGroup,
-          chatId,
-          chatTitle: callbackMessage.chat.title,
-          resolvedThreadId,
-          senderId,
-          senderUsername,
-          effectiveGroupAllow,
-          hasGroupAllowOverride,
-          groupConfig,
-          topicConfig,
-        })
-      ) {
+      const authorizationMode: TelegramEventAuthorizationMode =
+        inlineButtonsScope === "allowlist" ? "callback-allowlist" : "callback-scope";
+      const senderAuthorization = authorizeTelegramEventSender({
+        chatId,
+        chatTitle: callbackMessage.chat.title,
+        isGroup,
+        senderId,
+        senderUsername,
+        mode: authorizationMode,
+        context: eventAuthContext,
+      });
+      if (!senderAuthorization.allowed) {
         return;
-      }
-
-      if (inlineButtonsScope === "allowlist") {
-        if (!isGroup) {
-          if (dmPolicy === "disabled") {
-            return;
-          }
-          if (dmPolicy !== "open") {
-            const allowed = isAllowlistAuthorized(effectiveDmAllow, senderId, senderUsername);
-            if (!allowed) {
-              return;
-            }
-          }
-        } else {
-          const allowed = isAllowlistAuthorized(effectiveGroupAllow, senderId, senderUsername);
-          if (!allowed) {
-            return;
-          }
-        }
       }
 
       const paginationMatch = data.match(/^commands_page_(\d+|noop)(?::(.+))?$/);
@@ -929,25 +1033,20 @@ export const registerTelegramHandlers = ({
       if (shouldSkipUpdate(event.ctxForDedupe)) {
         return;
       }
-      const dmPolicy = telegramCfg.dmPolicy ?? "pairing";
-
-      const groupAllowContext = await resolveTelegramGroupAllowFromContext({
+      const eventAuthContext = await resolveTelegramEventAuthorizationContext({
         chatId: event.chatId,
-        accountId,
-        dmPolicy,
         isForum: event.isForum,
         messageThreadId: event.messageThreadId,
-        groupAllowFrom,
-        resolveTelegramGroupConfig,
       });
       const {
+        dmPolicy,
         resolvedThreadId,
         storeAllowFrom,
         groupConfig,
         topicConfig,
         effectiveGroupAllow,
         hasGroupAllowOverride,
-      } = groupAllowContext;
+      } = eventAuthContext;
       const effectiveDmAllow = normalizeAllowFromWithStore({
         allowFrom,
         storeAllowFrom,

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -833,6 +833,94 @@ describe("createTelegramBot", () => {
     );
   });
 
+  it.each([
+    {
+      name: "blocks reaction when dmPolicy is disabled",
+      updateId: 510,
+      channelConfig: { dmPolicy: "disabled", reactionNotifications: "all" },
+      reaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "👍" }],
+      },
+      expectedEnqueueCalls: 0,
+    },
+    {
+      name: "blocks reaction in allowlist mode for unauthorized direct sender",
+      updateId: 511,
+      channelConfig: {
+        dmPolicy: "allowlist",
+        allowFrom: ["12345"],
+        reactionNotifications: "all",
+      },
+      reaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "👍" }],
+      },
+      expectedEnqueueCalls: 0,
+    },
+    {
+      name: "allows reaction in allowlist mode for authorized direct sender",
+      updateId: 512,
+      channelConfig: { dmPolicy: "allowlist", allowFrom: ["9"], reactionNotifications: "all" },
+      reaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "👍" }],
+      },
+      expectedEnqueueCalls: 1,
+    },
+    {
+      name: "blocks reaction in group allowlist mode for unauthorized sender",
+      updateId: 513,
+      channelConfig: {
+        dmPolicy: "open",
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["12345"],
+        reactionNotifications: "all",
+      },
+      reaction: {
+        chat: { id: 9999, type: "supergroup" },
+        message_id: 77,
+        user: { id: 9, first_name: "Ada" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "🔥" }],
+      },
+      expectedEnqueueCalls: 0,
+    },
+  ])("$name", async ({ updateId, channelConfig, reaction, expectedEnqueueCalls }) => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: channelConfig,
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: updateId },
+      messageReaction: reaction,
+    });
+
+    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(expectedEnqueueCalls);
+  });
   it("skips reaction when reactionNotifications is off", async () => {
     onSpy.mockClear();
     enqueueSystemEventSpy.mockClear();


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: 046feb6b0e
**Author**: Peter Steinberger <steipete@gmail.com>
**Tier**: AUTO-PICK

> refactor: simplify telegram event authorization flow

Conflicts resolved: Adapted upstream's `authorizeTelegramEventSender`/`resolveTelegramEventAuthorizationContext` type system to replace fork's inline auth checks. Removed redundant inline callback auth block that was superseded by the new centralized authorization. Dropped unused `resolvedThreadId` destructuring (lint). Dropped unused `loadSessionStore`/`resolveStorePath` import.