### PR TITLE
Cherry-pick e56b0cf: fix: enforce telegram reaction authorization

### DIFF
--- a/docs/channels/telegram.mdx
+++ b/docs/channels/telegram.mdx
@@ -581,6 +581,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     Notes:
 
     - `own` means user reactions to bot-sent messages only (best-effort via sent-message cache).
+    - Reaction events still respect Telegram access controls (`dmPolicy`, `allowFrom`, `groupPolicy`, `groupAllowFrom`); unauthorized senders are dropped.
     - Telegram does not provide thread IDs in reaction updates.
       - non-forum groups route to group chat session
       - forum groups route to the group general-topic session (`:topic:1`), not the exact originating topic

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -415,6 +415,99 @@ export const registerTelegramHandlers = ({
     return false;
   };
 
+  const isTelegramEventSenderAuthorized = async (params: {
+    chatId: number;
+    chatTitle?: string;
+    isGroup: boolean;
+    isForum: boolean;
+    messageThreadId?: number;
+    senderId: string;
+    senderUsername: string;
+    enforceDirectAuthorization: boolean;
+    enforceGroupAllowlistAuthorization: boolean;
+    deniedDmReason: string;
+    deniedGroupReason: string;
+    groupAllowContext?: Awaited<ReturnType<typeof resolveTelegramGroupAllowFromContext>>;
+  }) => {
+    const {
+      chatId,
+      chatTitle,
+      isGroup,
+      isForum,
+      messageThreadId,
+      senderId,
+      senderUsername,
+      enforceDirectAuthorization,
+      enforceGroupAllowlistAuthorization,
+      deniedDmReason,
+      deniedGroupReason,
+      groupAllowContext: preResolvedGroupAllowContext,
+    } = params;
+    const dmPolicy = telegramCfg.dmPolicy ?? "pairing";
+    const groupAllowContext =
+      preResolvedGroupAllowContext ??
+      (await resolveTelegramGroupAllowFromContext({
+        chatId,
+        accountId,
+        dmPolicy,
+        isForum,
+        messageThreadId,
+        groupAllowFrom,
+        resolveTelegramGroupConfig,
+      }));
+    const {
+      resolvedThreadId,
+      storeAllowFrom,
+      groupConfig,
+      topicConfig,
+      effectiveGroupAllow,
+      hasGroupAllowOverride,
+    } = groupAllowContext;
+    if (
+      shouldSkipGroupMessage({
+        isGroup,
+        chatId,
+        chatTitle,
+        resolvedThreadId,
+        senderId,
+        senderUsername,
+        effectiveGroupAllow,
+        hasGroupAllowOverride,
+        groupConfig,
+        topicConfig,
+      })
+    ) {
+      return false;
+    }
+
+    if (!isGroup && enforceDirectAuthorization) {
+      if (dmPolicy === "disabled") {
+        logVerbose(
+          `Blocked telegram direct event from ${senderId || "unknown"} (${deniedDmReason})`,
+        );
+        return false;
+      }
+      if (dmPolicy !== "open") {
+        const effectiveDmAllow = normalizeAllowFromWithStore({
+          allowFrom,
+          storeAllowFrom,
+          dmPolicy,
+        });
+        if (!isAllowlistAuthorized(effectiveDmAllow, senderId, senderUsername)) {
+          logVerbose(`Blocked telegram direct sender ${senderId || "unknown"} (${deniedDmReason})`);
+          return false;
+        }
+      }
+    }
+    if (isGroup && enforceGroupAllowlistAuthorization) {
+      if (!isAllowlistAuthorized(effectiveGroupAllow, senderId, senderUsername)) {
+        logVerbose(`Blocked telegram group sender ${senderId || "unknown"} (${deniedGroupReason})`);
+        return false;
+      }
+    }
+    return true;
+  };
+
   // Handle emoji reactions to messages.
   bot.on("message_reaction", async (ctx) => {
     try {
@@ -429,6 +522,10 @@ export const registerTelegramHandlers = ({
       const chatId = reaction.chat.id;
       const messageId = reaction.message_id;
       const user = reaction.user;
+      const senderId = user?.id != null ? String(user.id) : "";
+      const senderUsername = user?.username ?? "";
+      const isGroup = reaction.chat.type === "group" || reaction.chat.type === "supergroup";
+      const isForum = reaction.chat.is_forum === true;
 
       // Resolve reaction notification mode (default: "own").
       const reactionMode = telegramCfg.reactionNotifications ?? "own";
@@ -439,6 +536,21 @@ export const registerTelegramHandlers = ({
         return;
       }
       if (reactionMode === "own" && !wasSentByBot(chatId, messageId)) {
+        return;
+      }
+      const senderAuthorized = await isTelegramEventSenderAuthorized({
+        chatId,
+        chatTitle: reaction.chat.title,
+        isGroup,
+        isForum,
+        senderId,
+        senderUsername,
+        enforceDirectAuthorization: true,
+        enforceGroupAllowlistAuthorization: false,
+        deniedDmReason: "reaction unauthorized by dm policy/allowlist",
+        deniedGroupReason: "reaction unauthorized by group allowlist",
+      });
+      if (!senderAuthorized) {
         return;
       }
 
@@ -460,12 +572,12 @@ export const registerTelegramHandlers = ({
       const senderName = user
         ? [user.first_name, user.last_name].filter(Boolean).join(" ").trim() || user.username
         : undefined;
-      const senderUsername = user?.username ? `@${user.username}` : undefined;
+      const senderUsernameLabel = user?.username ? `@${user.username}` : undefined;
       let senderLabel = senderName;
-      if (senderName && senderUsername) {
-        senderLabel = `${senderName} (${senderUsername})`;
-      } else if (!senderName && senderUsername) {
-        senderLabel = senderUsername;
+      if (senderName && senderUsernameLabel) {
+        senderLabel = `${senderName} (${senderUsernameLabel})`;
+      } else if (!senderName && senderUsernameLabel) {
+        senderLabel = senderUsernameLabel;
       }
       if (!senderLabel && user?.id) {
         senderLabel = `id:${user.id}`;
@@ -475,8 +587,6 @@ export const registerTelegramHandlers = ({
       // Reactions target a specific message_id; the Telegram Bot API does not include
       // message_thread_id on MessageReactionUpdated, so we route to the chat-level
       // session (forum topic routing is not available for reactions).
-      const isGroup = reaction.chat.type === "group" || reaction.chat.type === "supergroup";
-      const isForum = reaction.chat.is_forum === true;
       const resolvedThreadId = isForum
         ? resolveTelegramForumThreadId({ isForum, messageThreadId: undefined })
         : undefined;
@@ -754,56 +864,25 @@ export const registerTelegramHandlers = ({
         groupAllowFrom,
         resolveTelegramGroupConfig,
       });
-      const {
-        resolvedThreadId,
-        storeAllowFrom,
-        groupConfig,
-        topicConfig,
-        effectiveGroupAllow,
-        hasGroupAllowOverride,
-      } = groupAllowContext;
-      const dmPolicy = telegramCfg.dmPolicy ?? "pairing";
-      const effectiveDmAllow = normalizeAllowFromWithStore({
-        allowFrom: telegramCfg.allowFrom,
-        storeAllowFrom,
-        dmPolicy,
-      });
+      const { storeAllowFrom } = groupAllowContext;
       const senderId = callback.from?.id ? String(callback.from.id) : "";
       const senderUsername = callback.from?.username ?? "";
-      if (
-        shouldSkipGroupMessage({
-          isGroup,
-          chatId,
-          chatTitle: callbackMessage.chat.title,
-          resolvedThreadId,
-          senderId,
-          senderUsername,
-          effectiveGroupAllow,
-          hasGroupAllowOverride,
-          groupConfig,
-          topicConfig,
-        })
-      ) {
+      const senderAuthorized = await isTelegramEventSenderAuthorized({
+        chatId,
+        chatTitle: callbackMessage.chat.title,
+        isGroup,
+        isForum,
+        messageThreadId,
+        senderId,
+        senderUsername,
+        enforceDirectAuthorization: inlineButtonsScope === "allowlist",
+        enforceGroupAllowlistAuthorization: inlineButtonsScope === "allowlist",
+        deniedDmReason: "callback unauthorized by inlineButtonsScope allowlist",
+        deniedGroupReason: "callback unauthorized by inlineButtonsScope allowlist",
+        groupAllowContext,
+      });
+      if (!senderAuthorized) {
         return;
-      }
-
-      if (inlineButtonsScope === "allowlist") {
-        if (!isGroup) {
-          if (dmPolicy === "disabled") {
-            return;
-          }
-          if (dmPolicy !== "open") {
-            const allowed = isAllowlistAuthorized(effectiveDmAllow, senderId, senderUsername);
-            if (!allowed) {
-              return;
-            }
-          }
-        } else {
-          const allowed = isAllowlistAuthorized(effectiveGroupAllow, senderId, senderUsername);
-          if (!allowed) {
-            return;
-          }
-        }
       }
 
       const paginationMatch = data.match(/^commands_page_(\d+|noop)(?::(.+))?$/);

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -833,6 +833,131 @@ describe("createTelegramBot", () => {
     );
   });
 
+  it("blocks reaction when dmPolicy is disabled", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "disabled", reactionNotifications: "all" },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 510 },
+      messageReaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "👍" }],
+      },
+    });
+
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks reaction in allowlist mode for unauthorized direct sender", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "allowlist", allowFrom: ["12345"], reactionNotifications: "all" },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 511 },
+      messageReaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "👍" }],
+      },
+    });
+
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows reaction in allowlist mode for authorized direct sender", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "allowlist", allowFrom: ["9"], reactionNotifications: "all" },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 512 },
+      messageReaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "👍" }],
+      },
+    });
+
+    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks reaction in group allowlist mode for unauthorized sender", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["12345"],
+          reactionNotifications: "all",
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 513 },
+      messageReaction: {
+        chat: { id: 9999, type: "supergroup" },
+        message_id: 77,
+        user: { id: 9, first_name: "Ada" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "🔥" }],
+      },
+    });
+
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
+
   it("skips reaction when reactionNotifications is off", async () => {
     onSpy.mockClear();
     enqueueSystemEventSpy.mockClear();


### PR DESCRIPTION
Cherry-pick of upstream [`e56b0cf1a0`](https://github.com/openclaw/openclaw/commit/e56b0cf1a0).

## Summary

- Adds `isTelegramEventSenderAuthorized` helper consolidating DM policy/allowlist + group allowlist checks
- Enforces auth on reaction events (previously unchecked)
- Refactors callback_query auth to use the same shared helper
- Adds tests for reaction blocking (disabled DM, allowlist, group allowlist)
- Documents reaction auth behavior in telegram.mdx

## Conflicts resolved

- `CHANGELOG.md` — discarded (gutted layer)
- Lint fix: removed unused `resolvedThreadId` destructuring at callback_query handler (same pattern as prior cherry-picks)

## Procedure

AUTO-PARTIAL: `cherry-pick --no-commit`, discarded gutted `CHANGELOG.md`, committed with original author.

Relates to #568

Cherry-picked-from: e56b0cf1a0