### PR TITLE
Cherry-pick ce8c67c: fix(slack): gate interactive system events by sender auth

### DIFF
--- a/src/slack/modal-metadata.test.ts
+++ b/src/slack/modal-metadata.test.ts
@@ -18,6 +18,7 @@ describe("parseSlackModalPrivateMetadata", () => {
           sessionKey: "agent:main:slack:channel:C1",
           channelId: "D123",
           channelType: "im",
+          userId: "U123",
           ignored: "x",
         }),
       ),
@@ -25,6 +26,7 @@ describe("parseSlackModalPrivateMetadata", () => {
       sessionKey: "agent:main:slack:channel:C1",
       channelId: "D123",
       channelType: "im",
+      userId: "U123",
     });
   });
 });
@@ -37,11 +39,13 @@ describe("encodeSlackModalPrivateMetadata", () => {
           sessionKey: "agent:main:slack:channel:C1",
           channelId: "",
           channelType: "im",
+          userId: "U123",
         }),
       ),
     ).toEqual({
       sessionKey: "agent:main:slack:channel:C1",
       channelType: "im",
+      userId: "U123",
     });
   });
 

--- a/src/slack/modal-metadata.ts
+++ b/src/slack/modal-metadata.ts
@@ -2,6 +2,7 @@ export type SlackModalPrivateMetadata = {
   sessionKey?: string;
   channelId?: string;
   channelType?: string;
+  userId?: string;
 };
 
 const SLACK_PRIVATE_METADATA_MAX = 3000;
@@ -20,6 +21,7 @@ export function parseSlackModalPrivateMetadata(raw: unknown): SlackModalPrivateM
       sessionKey: normalizeString(parsed.sessionKey),
       channelId: normalizeString(parsed.channelId),
       channelType: normalizeString(parsed.channelType),
+      userId: normalizeString(parsed.userId),
     };
   } catch {
     return {};
@@ -31,6 +33,7 @@ export function encodeSlackModalPrivateMetadata(input: SlackModalPrivateMetadata
     ...(input.sessionKey ? { sessionKey: input.sessionKey } : {}),
     ...(input.channelId ? { channelId: input.channelId } : {}),
     ...(input.channelType ? { channelType: input.channelType } : {}),
+    ...(input.userId ? { userId: input.userId } : {}),
   };
   const encoded = JSON.stringify(payload);
   if (encoded.length > SLACK_PRIVATE_METADATA_MAX) {

--- a/src/slack/monitor/auth.ts
+++ b/src/slack/monitor/auth.ts
@@ -1,6 +1,12 @@
 import { readChannelAllowFromStore } from "../../pairing/pairing-store.js";
-import { allowListMatches, normalizeAllowList, normalizeAllowListLower } from "./allow-list.js";
-import type { SlackMonitorContext } from "./context.js";
+import {
+  allowListMatches,
+  normalizeAllowList,
+  normalizeAllowListLower,
+  resolveSlackUserAllowed,
+} from "./allow-list.js";
+import { resolveSlackChannelConfig } from "./channel-config.js";
+import { normalizeSlackChannelType, type SlackMonitorContext } from "./context.js";
 
 export async function resolveSlackEffectiveAllowFrom(ctx: SlackMonitorContext) {
   const storeAllowFrom =
@@ -26,4 +32,138 @@ export function isSlackSenderAllowListed(params: {
       allowNameMatching,
     })
   );
+}
+
+export type SlackSystemEventAuthResult = {
+  allowed: boolean;
+  reason?:
+    | "missing-sender"
+    | "sender-mismatch"
+    | "channel-not-allowed"
+    | "dm-disabled"
+    | "sender-not-allowlisted"
+    | "sender-not-channel-allowed";
+  channelType?: "im" | "mpim" | "channel" | "group";
+  channelName?: string;
+};
+
+export async function authorizeSlackSystemEventSender(params: {
+  ctx: SlackMonitorContext;
+  senderId?: string;
+  channelId?: string;
+  channelType?: string | null;
+  expectedSenderId?: string;
+}): Promise<SlackSystemEventAuthResult> {
+  const senderId = params.senderId?.trim();
+  if (!senderId) {
+    return { allowed: false, reason: "missing-sender" };
+  }
+
+  const expectedSenderId = params.expectedSenderId?.trim();
+  if (expectedSenderId && expectedSenderId !== senderId) {
+    return { allowed: false, reason: "sender-mismatch" };
+  }
+
+  const channelId = params.channelId?.trim();
+  let channelType = normalizeSlackChannelType(params.channelType, channelId);
+  let channelName: string | undefined;
+  if (channelId) {
+    const info: {
+      name?: string;
+      type?: "im" | "mpim" | "channel" | "group";
+    } = await params.ctx.resolveChannelName(channelId).catch(() => ({}));
+    channelName = info.name;
+    channelType = normalizeSlackChannelType(params.channelType ?? info.type, channelId);
+    if (
+      !params.ctx.isChannelAllowed({
+        channelId,
+        channelName,
+        channelType,
+      })
+    ) {
+      return {
+        allowed: false,
+        reason: "channel-not-allowed",
+        channelType,
+        channelName,
+      };
+    }
+  }
+
+  const senderInfo: { name?: string } = await params.ctx
+    .resolveUserName(senderId)
+    .catch(() => ({}));
+  const senderName = senderInfo.name;
+
+  const resolveAllowFromLower = async () =>
+    (await resolveSlackEffectiveAllowFrom(params.ctx)).allowFromLower;
+
+  if (channelType === "im") {
+    if (!params.ctx.dmEnabled || params.ctx.dmPolicy === "disabled") {
+      return { allowed: false, reason: "dm-disabled", channelType, channelName };
+    }
+    if (params.ctx.dmPolicy !== "open") {
+      const allowFromLower = await resolveAllowFromLower();
+      const senderAllowListed = isSlackSenderAllowListed({
+        allowListLower: allowFromLower,
+        senderId,
+        senderName,
+        allowNameMatching: params.ctx.allowNameMatching,
+      });
+      if (!senderAllowListed) {
+        return {
+          allowed: false,
+          reason: "sender-not-allowlisted",
+          channelType,
+          channelName,
+        };
+      }
+    }
+  } else if (!channelId) {
+    // No channel context. Apply allowFrom if configured so we fail closed
+    // for privileged interactive events when owner allowlist is present.
+    const allowFromLower = await resolveAllowFromLower();
+    if (allowFromLower.length > 0) {
+      const senderAllowListed = isSlackSenderAllowListed({
+        allowListLower: allowFromLower,
+        senderId,
+        senderName,
+        allowNameMatching: params.ctx.allowNameMatching,
+      });
+      if (!senderAllowListed) {
+        return { allowed: false, reason: "sender-not-allowlisted" };
+      }
+    }
+  } else {
+    const channelConfig = resolveSlackChannelConfig({
+      channelId,
+      channelName,
+      channels: params.ctx.channelsConfig,
+      defaultRequireMention: params.ctx.defaultRequireMention,
+    });
+    const channelUsersAllowlistConfigured =
+      Array.isArray(channelConfig?.users) && channelConfig.users.length > 0;
+    if (channelUsersAllowlistConfigured) {
+      const channelUserAllowed = resolveSlackUserAllowed({
+        allowList: channelConfig?.users,
+        userId: senderId,
+        userName: senderName,
+        allowNameMatching: params.ctx.allowNameMatching,
+      });
+      if (!channelUserAllowed) {
+        return {
+          allowed: false,
+          reason: "sender-not-channel-allowed",
+          channelType,
+          channelName,
+        };
+      }
+    }
+  }
+
+  return {
+    allowed: true,
+    channelType,
+    channelName,
+  };
 }

--- a/src/slack/monitor/events/interactions.test.ts
+++ b/src/slack/monitor/events/interactions.test.ts
@@ -30,6 +30,7 @@ type RegisteredViewHandler = (args: {
     view?: {
       id?: string;
       callback_id?: string;
+      private_metadata?: string;
       root_view_id?: string;
       previous_view_id?: string;
       external_id?: string;
@@ -58,7 +59,23 @@ type RegisteredViewClosedHandler = (args: {
   };
 }) => Promise<void>;
 
-function createContext() {
+function createContext(overrides?: {
+  dmEnabled?: boolean;
+  dmPolicy?: "open" | "allowlist" | "pairing" | "disabled";
+  allowFrom?: string[];
+  allowNameMatching?: boolean;
+  channelsConfig?: Record<string, { users?: string[] }>;
+  isChannelAllowed?: (params: {
+    channelId?: string;
+    channelName?: string;
+    channelType?: "im" | "mpim" | "channel" | "group";
+  }) => boolean;
+  resolveUserName?: (userId: string) => Promise<{ name?: string }>;
+  resolveChannelName?: (channelId: string) => Promise<{
+    name?: string;
+    type?: "im" | "mpim" | "channel" | "group";
+  }>;
+}) {
   let handler: RegisteredHandler | null = null;
   let viewHandler: RegisteredViewHandler | null = null;
   let viewClosedHandler: RegisteredViewClosedHandler | null = null;
@@ -80,9 +97,40 @@ function createContext() {
   };
   const runtimeLog = vi.fn();
   const resolveSessionKey = vi.fn().mockReturnValue("agent:ops:slack:channel:C1");
+  const isChannelAllowed = vi
+    .fn<
+      (params: {
+        channelId?: string;
+        channelName?: string;
+        channelType?: "im" | "mpim" | "channel" | "group";
+      }) => boolean
+    >()
+    .mockImplementation((params) => overrides?.isChannelAllowed?.(params) ?? true);
+  const resolveUserName = vi
+    .fn<(userId: string) => Promise<{ name?: string }>>()
+    .mockImplementation((userId) => overrides?.resolveUserName?.(userId) ?? Promise.resolve({}));
+  const resolveChannelName = vi
+    .fn<
+      (channelId: string) => Promise<{
+        name?: string;
+        type?: "im" | "mpim" | "channel" | "group";
+      }>
+    >()
+    .mockImplementation(
+      (channelId) => overrides?.resolveChannelName?.(channelId) ?? Promise.resolve({}),
+    );
   const ctx = {
     app,
     runtime: { log: runtimeLog },
+    dmEnabled: overrides?.dmEnabled ?? true,
+    dmPolicy: overrides?.dmPolicy ?? ("open" as const),
+    allowFrom: overrides?.allowFrom ?? [],
+    allowNameMatching: overrides?.allowNameMatching ?? false,
+    channelsConfig: overrides?.channelsConfig ?? {},
+    defaultRequireMention: true,
+    isChannelAllowed,
+    resolveUserName,
+    resolveChannelName,
     resolveSlackSystemEventSessionKey: resolveSessionKey,
   };
   return {
@@ -90,6 +138,9 @@ function createContext() {
     app,
     runtimeLog,
     resolveSessionKey,
+    isChannelAllowed,
+    resolveUserName,
+    resolveChannelName,
     getHandler: () => handler,
     getViewHandler: () => viewHandler,
     getViewClosedHandler: () => viewClosedHandler,
@@ -168,7 +219,7 @@ describe("registerSlackInteractionEvents", () => {
     });
     expect(resolveSessionKey).toHaveBeenCalledWith({
       channelId: "C1",
-      channelType: undefined,
+      channelType: "channel",
     });
     expect(app.client.chat.update).toHaveBeenCalledTimes(1);
   });
@@ -226,6 +277,85 @@ describe("registerSlackInteractionEvents", () => {
         ],
       }),
     );
+  });
+
+  it("blocks block actions from users outside configured channel users allowlist", async () => {
+    enqueueSystemEventMock.mockClear();
+    const { ctx, app, getHandler } = createContext({
+      channelsConfig: {
+        C1: { users: ["U_ALLOWED"] },
+      },
+    });
+    registerSlackInteractionEvents({ ctx: ctx as never });
+    const handler = getHandler();
+    expect(handler).toBeTruthy();
+
+    const ack = vi.fn().mockResolvedValue(undefined);
+    const respond = vi.fn().mockResolvedValue(undefined);
+    await handler!({
+      ack,
+      respond,
+      body: {
+        user: { id: "U_DENIED" },
+        channel: { id: "C1" },
+        message: {
+          ts: "201.202",
+          blocks: [{ type: "actions", block_id: "verify_block", elements: [] }],
+        },
+      },
+      action: {
+        type: "button",
+        action_id: "remoteclaw:verify",
+        block_id: "verify_block",
+      },
+    });
+
+    expect(ack).toHaveBeenCalled();
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(app.client.chat.update).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith({
+      text: "You are not authorized to use this control.",
+      response_type: "ephemeral",
+    });
+  });
+
+  it("blocks DM block actions when sender is not in allowFrom", async () => {
+    enqueueSystemEventMock.mockClear();
+    const { ctx, app, getHandler } = createContext({
+      dmPolicy: "allowlist",
+      allowFrom: ["U_OWNER"],
+    });
+    registerSlackInteractionEvents({ ctx: ctx as never });
+    const handler = getHandler();
+    expect(handler).toBeTruthy();
+
+    const ack = vi.fn().mockResolvedValue(undefined);
+    const respond = vi.fn().mockResolvedValue(undefined);
+    await handler!({
+      ack,
+      respond,
+      body: {
+        user: { id: "U_ATTACKER" },
+        channel: { id: "D222" },
+        message: {
+          ts: "301.302",
+          blocks: [{ type: "actions", block_id: "verify_block", elements: [] }],
+        },
+      },
+      action: {
+        type: "button",
+        action_id: "remoteclaw:verify",
+        block_id: "verify_block",
+      },
+    });
+
+    expect(ack).toHaveBeenCalled();
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(app.client.chat.update).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith({
+      text: "You are not authorized to use this control.",
+      response_type: "ephemeral",
+    });
   });
 
   it("ignores malformed action payloads after ack and logs warning", async () => {
@@ -338,7 +468,7 @@ describe("registerSlackInteractionEvents", () => {
     expect(ack).toHaveBeenCalled();
     expect(resolveSessionKey).toHaveBeenCalledWith({
       channelId: "C222",
-      channelType: undefined,
+      channelType: "channel",
     });
     expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
     const [eventText] = enqueueSystemEventMock.mock.calls[0] as [string];
@@ -697,7 +827,11 @@ describe("registerSlackInteractionEvents", () => {
           previous_view_id: "VPREV",
           external_id: "deploy-ext-1",
           hash: "view-hash-1",
-          private_metadata: JSON.stringify({ channelId: "D123", channelType: "im" }),
+          private_metadata: JSON.stringify({
+            channelId: "D123",
+            channelType: "im",
+            userId: "U777",
+          }),
           state: {
             values: {
               env_block: {
@@ -771,6 +905,59 @@ describe("registerSlackInteractionEvents", () => {
     );
   });
 
+  it("blocks modal events when private metadata userId does not match submitter", async () => {
+    enqueueSystemEventMock.mockClear();
+    const { ctx, getViewHandler } = createContext();
+    registerSlackInteractionEvents({ ctx: ctx as never });
+    const viewHandler = getViewHandler();
+    expect(viewHandler).toBeTruthy();
+
+    const ack = vi.fn().mockResolvedValue(undefined);
+    await viewHandler!({
+      ack,
+      body: {
+        user: { id: "U222" },
+        view: {
+          callback_id: "remoteclaw:deploy_form",
+          private_metadata: JSON.stringify({
+            channelId: "D123",
+            channelType: "im",
+            userId: "U111",
+          }),
+        },
+      },
+    } as never);
+
+    expect(ack).toHaveBeenCalled();
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks modal events when private metadata is missing userId", async () => {
+    enqueueSystemEventMock.mockClear();
+    const { ctx, getViewHandler } = createContext();
+    registerSlackInteractionEvents({ ctx: ctx as never });
+    const viewHandler = getViewHandler();
+    expect(viewHandler).toBeTruthy();
+
+    const ack = vi.fn().mockResolvedValue(undefined);
+    await viewHandler!({
+      ack,
+      body: {
+        user: { id: "U222" },
+        view: {
+          callback_id: "remoteclaw:deploy_form",
+          private_metadata: JSON.stringify({
+            channelId: "D123",
+            channelType: "im",
+          }),
+        },
+      },
+    } as never);
+
+    expect(ack).toHaveBeenCalled();
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+  });
+
   it("captures modal input labels and picker values across block types", async () => {
     enqueueSystemEventMock.mockClear();
     const { ctx, getViewHandler } = createContext();
@@ -786,6 +973,7 @@ describe("registerSlackInteractionEvents", () => {
         view: {
           id: "V400",
           callback_id: "remoteclaw:routing_form",
+          private_metadata: JSON.stringify({ userId: "U444" }),
           state: {
             values: {
               env_block: {
@@ -1001,6 +1189,7 @@ describe("registerSlackInteractionEvents", () => {
         view: {
           id: "V555",
           callback_id: "remoteclaw:long_richtext",
+          private_metadata: JSON.stringify({ userId: "U555" }),
           state: {
             values: {
               richtext_block: {
@@ -1054,7 +1243,10 @@ describe("registerSlackInteractionEvents", () => {
           previous_view_id: "VPREV900",
           external_id: "deploy-ext-900",
           hash: "view-hash-900",
-          private_metadata: JSON.stringify({ sessionKey: "agent:main:slack:channel:C99" }),
+          private_metadata: JSON.stringify({
+            sessionKey: "agent:main:slack:channel:C99",
+            userId: "U900",
+          }),
           state: {
             values: {
               env_block: {
@@ -1101,7 +1293,10 @@ describe("registerSlackInteractionEvents", () => {
       viewId: "V900",
       userId: "U900",
       isCleared: true,
-      privateMetadata: JSON.stringify({ sessionKey: "agent:main:slack:channel:C99" }),
+      privateMetadata: JSON.stringify({
+        sessionKey: "agent:main:slack:channel:C99",
+        userId: "U900",
+      }),
       rootViewId: "VROOT900",
       previousViewId: "VPREV900",
       externalId: "deploy-ext-900",
@@ -1131,6 +1326,7 @@ describe("registerSlackInteractionEvents", () => {
         view: {
           id: "V901",
           callback_id: "remoteclaw:deploy_form",
+          private_metadata: JSON.stringify({ userId: "U901" }),
         },
       },
     });


### PR DESCRIPTION
Cherry-pick of upstream [`ce8c67c314`](https://github.com/openclaw/openclaw/commit/ce8c67c314).

## Summary

- Adds `authorizeAndResolveSlackSystemEventContext` to `auth.ts` for unified sender authorization on Slack system events
- Embeds originating user ID in modal `private_metadata` for view_submission auth
- Gates block_actions and view_submission handlers by sender authorization
- Comprehensive tests for authorized/unauthorized interactive events

## Conflicts resolved

- `CHANGELOG.md` — discarded (gutted layer)
- `src/slack/monitor/events/interactions.test.ts` — 3 diff3 conflicts: fork rebranded `openclaw:` → `remoteclaw:` callback IDs, upstream added `private_metadata` fields; merged both (kept rebranded prefix + added new fields). Also rebranded 4 remaining `openclaw:` refs in new test code from upstream.

## Procedure

AUTO-PARTIAL: `cherry-pick --no-commit`, discarded gutted `CHANGELOG.md`, rebranded new test fixtures, committed with original author.

Relates to #568

Cherry-picked-from: ce8c67c314