### PR TITLE
Cherry-pick 75dfb71: fix(slack): gate pin/reaction system events by sender auth

### DIFF
--- a/src/slack/monitor/events/pins.test.ts
+++ b/src/slack/monitor/events/pins.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SlackMonitorContext } from "../context.js";
+import { registerSlackPinEvents } from "./pins.js";
+
+const enqueueSystemEventMock = vi.fn();
+const readAllowFromStoreMock = vi.fn();
+
+vi.mock("../../../infra/system-events.js", () => ({
+  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+}));
+
+vi.mock("../../../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: (...args: unknown[]) => readAllowFromStoreMock(...args),
+}));
+
+type SlackPinHandler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
+
+function createPinContext(overrides?: {
+  dmPolicy?: "open" | "pairing" | "allowlist" | "disabled";
+  allowFrom?: string[];
+  channelType?: "im" | "channel";
+  channelUsers?: string[];
+}) {
+  let addedHandler: SlackPinHandler | null = null;
+  let removedHandler: SlackPinHandler | null = null;
+  const channelType = overrides?.channelType ?? "im";
+  const app = {
+    event: vi.fn((name: string, handler: SlackPinHandler) => {
+      if (name === "pin_added") {
+        addedHandler = handler;
+      } else if (name === "pin_removed") {
+        removedHandler = handler;
+      }
+    }),
+  };
+  const ctx = {
+    app,
+    runtime: { error: vi.fn() },
+    dmEnabled: true,
+    dmPolicy: overrides?.dmPolicy ?? "open",
+    defaultRequireMention: true,
+    channelsConfig: overrides?.channelUsers
+      ? {
+          C1: {
+            users: overrides.channelUsers,
+            allow: true,
+          },
+        }
+      : undefined,
+    groupPolicy: "open",
+    allowFrom: overrides?.allowFrom ?? [],
+    allowNameMatching: false,
+    shouldDropMismatchedSlackEvent: vi.fn().mockReturnValue(false),
+    isChannelAllowed: vi.fn().mockReturnValue(true),
+    resolveChannelName: vi.fn().mockResolvedValue({
+      name: channelType === "im" ? "direct" : "general",
+      type: channelType,
+    }),
+    resolveUserName: vi.fn().mockResolvedValue({ name: "alice" }),
+    resolveSlackSystemEventSessionKey: vi.fn().mockReturnValue("agent:main:main"),
+  } as unknown as SlackMonitorContext;
+  registerSlackPinEvents({ ctx });
+  return {
+    ctx,
+    getAddedHandler: () => addedHandler,
+    getRemovedHandler: () => removedHandler,
+  };
+}
+
+function makePinEvent(overrides?: { user?: string; channel?: string }) {
+  return {
+    type: "pin_added",
+    user: overrides?.user ?? "U1",
+    channel_id: overrides?.channel ?? "D1",
+    event_ts: "123.456",
+    item: {
+      type: "message",
+      message: {
+        ts: "123.456",
+      },
+    },
+  };
+}
+
+describe("registerSlackPinEvents", () => {
+  it("enqueues DM pin system events when dmPolicy is open", async () => {
+    enqueueSystemEventMock.mockClear();
+    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    const { getAddedHandler } = createPinContext({ dmPolicy: "open" });
+    const addedHandler = getAddedHandler();
+    expect(addedHandler).toBeTruthy();
+
+    await addedHandler!({
+      event: makePinEvent(),
+      body: {},
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks DM pin system events when dmPolicy is disabled", async () => {
+    enqueueSystemEventMock.mockClear();
+    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    const { getAddedHandler } = createPinContext({ dmPolicy: "disabled" });
+    const addedHandler = getAddedHandler();
+    expect(addedHandler).toBeTruthy();
+
+    await addedHandler!({
+      event: makePinEvent(),
+      body: {},
+    });
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks DM pin system events for unauthorized senders in allowlist mode", async () => {
+    enqueueSystemEventMock.mockClear();
+    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    const { getAddedHandler } = createPinContext({
+      dmPolicy: "allowlist",
+      allowFrom: ["U2"],
+    });
+    const addedHandler = getAddedHandler();
+    expect(addedHandler).toBeTruthy();
+
+    await addedHandler!({
+      event: makePinEvent({ user: "U1" }),
+      body: {},
+    });
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+  });
+
+  it("allows DM pin system events for authorized senders in allowlist mode", async () => {
+    enqueueSystemEventMock.mockClear();
+    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    const { getAddedHandler } = createPinContext({
+      dmPolicy: "allowlist",
+      allowFrom: ["U1"],
+    });
+    const addedHandler = getAddedHandler();
+    expect(addedHandler).toBeTruthy();
+
+    await addedHandler!({
+      event: makePinEvent({ user: "U1" }),
+      body: {},
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks channel pin events for users outside channel users allowlist", async () => {
+    enqueueSystemEventMock.mockClear();
+    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    const { getAddedHandler } = createPinContext({
+      dmPolicy: "open",
+      channelType: "channel",
+      channelUsers: ["U_OWNER"],
+    });
+    const addedHandler = getAddedHandler();
+    expect(addedHandler).toBeTruthy();
+
+    await addedHandler!({
+      event: makePinEvent({ channel: "C1", user: "U_ATTACKER" }),
+      body: {},
+    });
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/slack/monitor/events/reactions.test.ts
+++ b/src/slack/monitor/events/reactions.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SlackMonitorContext } from "../context.js";
+import { registerSlackReactionEvents } from "./reactions.js";
+
+const enqueueSystemEventMock = vi.fn();
+const readAllowFromStoreMock = vi.fn();
+
+vi.mock("../../../infra/system-events.js", () => ({
+  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+}));
+
+vi.mock("../../../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: (...args: unknown[]) => readAllowFromStoreMock(...args),
+}));
+
+type SlackReactionHandler = (args: {
+  event: Record<string, unknown>;
+  body: unknown;
+}) => Promise<void>;
+
+function createReactionContext(overrides?: {
+  dmPolicy?: "open" | "pairing" | "allowlist" | "disabled";
+  allowFrom?: string[];
+  channelType?: "im" | "channel";
+  channelUsers?: string[];
+}) {
+  let addedHandler: SlackReactionHandler | null = null;
+  let removedHandler: SlackReactionHandler | null = null;
+  const channelType = overrides?.channelType ?? "im";
+  const app = {
+    event: vi.fn((name: string, handler: SlackReactionHandler) => {
+      if (name === "reaction_added") {
+        addedHandler = handler;
+      } else if (name === "reaction_removed") {
+        removedHandler = handler;
+      }
+    }),
+  };
+  const ctx = {
+    app,
+    runtime: { error: vi.fn() },
+    dmEnabled: true,
+    dmPolicy: overrides?.dmPolicy ?? "open",
+    defaultRequireMention: true,
+    channelsConfig: overrides?.channelUsers
+      ? {
+          C1: {
+            users: overrides.channelUsers,
+            allow: true,
+          },
+        }
+      : undefined,
+    groupPolicy: "open",
+    allowFrom: overrides?.allowFrom ?? [],
+    allowNameMatching: false,
+    shouldDropMismatchedSlackEvent: vi.fn().mockReturnValue(false),
+    isChannelAllowed: vi.fn().mockReturnValue(true),
+    resolveChannelName: vi.fn().mockResolvedValue({
+      name: channelType === "im" ? "direct" : "general",
+      type: channelType,
+    }),
+    resolveUserName: vi.fn().mockResolvedValue({ name: "alice" }),
+    resolveSlackSystemEventSessionKey: vi.fn().mockReturnValue("agent:main:main"),
+  } as unknown as SlackMonitorContext;
+  registerSlackReactionEvents({ ctx });
+  return {
+    ctx,
+    getAddedHandler: () => addedHandler,
+    getRemovedHandler: () => removedHandler,
+  };
+}
+
+function makeReactionEvent(overrides?: { user?: string; channel?: string }) {
+  return {
+    type: "reaction_added",
+    user: overrides?.user ?? "U1",
+    reaction: "thumbsup",
+    item: {
+      type: "message",
+      channel: overrides?.channel ?? "D1",
+      ts: "123.456",
+    },
+    item_user: "UBOT",
+  };
+}
+
+describe("registerSlackReactionEvents", () => {
+  it("enqueues DM reaction system events when dmPolicy is open", async () => {
+    enqueueSystemEventMock.mockClear();
+    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    const { getAddedHandler } = createReactionContext({ dmPolicy: "open" });
+    const addedHandler = getAddedHandler();
+    expect(addedHandler).toBeTruthy();
+
+    await addedHandler!({
+      event: makeReactionEvent(),
+      body: {},
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks DM reaction system events when dmPolicy is disabled", async () => {
+    enqueueSystemEventMock.mockClear();
+    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    const { getAddedHandler } = createReactionContext({ dmPolicy: "disabled" });
+    const addedHandler = getAddedHandler();
+    expect(addedHandler).toBeTruthy();
+
+    await addedHandler!({
+      event: makeReactionEvent(),
+      body: {},
+    });
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks DM reaction system events for unauthorized senders in allowlist mode", async () => {
+    enqueueSystemEventMock.mockClear();
+    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    const { getAddedHandler } = createReactionContext({
+      dmPolicy: "allowlist",
+      allowFrom: ["U2"],
+    });
+    const addedHandler = getAddedHandler();
+    expect(addedHandler).toBeTruthy();
+
+    await addedHandler!({
+      event: makeReactionEvent({ user: "U1" }),
+      body: {},
+    });
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+  });
+
+  it("allows DM reaction system events for authorized senders in allowlist mode", async () => {
+    enqueueSystemEventMock.mockClear();
+    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    const { getAddedHandler } = createReactionContext({
+      dmPolicy: "allowlist",
+      allowFrom: ["U1"],
+    });
+    const addedHandler = getAddedHandler();
+    expect(addedHandler).toBeTruthy();
+
+    await addedHandler!({
+      event: makeReactionEvent({ user: "U1" }),
+      body: {},
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("enqueues channel reaction events regardless of dmPolicy", async () => {
+    enqueueSystemEventMock.mockClear();
+    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    const { getRemovedHandler } = createReactionContext({
+      dmPolicy: "disabled",
+      channelType: "channel",
+    });
+    const removedHandler = getRemovedHandler();
+    expect(removedHandler).toBeTruthy();
+
+    await removedHandler!({
+      event: {
+        ...makeReactionEvent({ channel: "C1" }),
+        type: "reaction_removed",
+      },
+      body: {},
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks channel reaction events for users outside channel users allowlist", async () => {
+    enqueueSystemEventMock.mockClear();
+    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    const { getAddedHandler } = createReactionContext({
+      dmPolicy: "open",
+      channelType: "channel",
+      channelUsers: ["U_OWNER"],
+    });
+    const addedHandler = getAddedHandler();
+    expect(addedHandler).toBeTruthy();
+
+    await addedHandler!({
+      event: makeReactionEvent({ channel: "C1", user: "U_ATTACKER" }),
+      body: {},
+    });
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Cherry-pick of upstream [`75dfb71e4e`](https://github.com/openclaw/openclaw/commit/75dfb71e4e).

## Summary

- Replaces inline channel-allowed checks in pin/reaction handlers with `authorizeSlackSystemEventSender`
- Adds verbose logging for dropped unauthorized pin/reaction events
- Adds comprehensive pin event tests (170 lines)
- Adds sender auth tests for reaction events (30 lines)

## Conflicts resolved

- `CHANGELOG.md` — discarded (gutted layer)
- `src/slack/monitor/events/reactions.test.ts` — DU conflict (fork deleted, upstream modified); restored upstream version since file is needed for new tests
- `src/slack/monitor/events/reactions.ts` — import conflict: took theirs' `authorizeSlackSystemEventSender` import (replaces previous `resolveDmGroupAccessWithLists` + `resolveSlackAllowListMatch` + `resolveSlackEffectiveAllowFrom`); added missing `logVerbose` import lost in conflict resolution

## Procedure

AUTO-PARTIAL: `cherry-pick --no-commit`, discarded gutted `CHANGELOG.md`, committed with original author.

Relates to #568

Cherry-picked-from: 75dfb71e4e