### PR TITLE
Cherry-pick 069bbf9: fix(slack): allowlist channel ID case-insensitive match

### DIFF
--- a/src/slack/monitor/channel-config.ts
+++ b/src/slack/monitor/channel-config.ts
@@ -94,8 +94,16 @@ export function resolveSlackChannelConfig(params: {
   const keys = Object.keys(entries);
   const normalizedName = channelName ? normalizeSlackSlug(channelName) : "";
   const directName = channelName ? channelName.trim() : "";
+  // Slack always delivers channel IDs in uppercase (e.g. C0ABC12345) but
+  // operators commonly write them in lowercase in their config. Add both
+  // case variants so the lookup is case-insensitive without requiring a full
+  // entry-scan. buildChannelKeyCandidates deduplicates identical keys.
+  const channelIdLower = channelId.toLowerCase();
+  const channelIdUpper = channelId.toUpperCase();
   const candidates = buildChannelKeyCandidates(
     channelId,
+    channelIdLower !== channelId ? channelIdLower : undefined,
+    channelIdUpper !== channelId ? channelIdUpper : undefined,
     channelName ? `#${directName}` : undefined,
     directName,
     normalizedName,

--- a/src/slack/monitor/monitor.test.ts
+++ b/src/slack/monitor/monitor.test.ts
@@ -60,6 +60,27 @@ describe("resolveSlackChannelConfig", () => {
       matchSource: "direct",
     });
   });
+
+  it("matches channel config key stored in lowercase when Slack delivers uppercase channel ID", () => {
+    // Slack always delivers channel IDs in uppercase (e.g. C0ABC12345).
+    // Users commonly copy them in lowercase from docs or older CLI output.
+    const res = resolveSlackChannelConfig({
+      channelId: "C0ABC12345",
+      channels: { c0abc12345: { allow: true, requireMention: false } },
+      defaultRequireMention: true,
+    });
+    expect(res).toMatchObject({ allowed: true, requireMention: false });
+  });
+
+  it("matches channel config key stored in uppercase when user types lowercase channel ID", () => {
+    // Defensive: also handle the inverse direction.
+    const res = resolveSlackChannelConfig({
+      channelId: "c0abc12345",
+      channels: { C0ABC12345: { allow: true, requireMention: false } },
+      defaultRequireMention: true,
+    });
+    expect(res).toMatchObject({ allowed: true, requireMention: false });
+  });
 });
 
 const baseParams = () => ({


### PR DESCRIPTION
Cherry-pick of upstream [`069bbf9741`](https://github.com/openclaw/openclaw/commit/069bbf9741).

## Summary

- Makes Slack channel ID matching case-insensitive (adds lowercase/uppercase variants to candidate keys)
- Fixes mismatch when operators write channel IDs in lowercase but Slack delivers uppercase
- Regression tests for both directions

Original contributor: @lbo728

## Conflicts resolved

- `CHANGELOG.md` — discarded (gutted layer)

## Procedure

AUTO-PARTIAL: `cherry-pick --no-commit`, discarded gutted `CHANGELOG.md`, committed with original authors.

Relates to #568

Cherry-picked-from: 069bbf9741
Co-authored-by: lbo728 <extreme0728@gmail.com>