### PR TITLE
Cherry-pick 97eb554: fix(typing): guard fireStart against post-close invocation

### DIFF
--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -20,6 +20,7 @@ export function createTypingCallbacks(params: {
   let closed = false;
 
   const fireStart = async () => {
+    if (closed) return;
     try {
       await params.start();
     } catch (err) {


### PR DESCRIPTION
Cherry-pick of upstream [`97eb5542e8`](https://github.com/openclaw/openclaw/commit/97eb5542e8).

## Summary

- Adds `closed` early-return guard in `fireStart` to prevent stale typing indicators after reply delivery
- Defense-in-depth fix for Telegram typing indicator lingering ~5s after bot message appears

## Conflicts

None — clean apply.

Relates to #568

Cherry-picked-from: 97eb5542e8