### PR TITLE
Cherry-pick ae658aa: style: add curly braces to satisfy eslint(curly)

### DIFF
--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -20,6 +20,9 @@ export function createTypingCallbacks(params: {
   let closed = false;
 
   const fireStart = async () => {
+    if (closed) {
+      return;
+    }
     try {
       await params.start();
     } catch (err) {


### PR DESCRIPTION
Cherry-pick of upstream [`ae658aa84c`](https://github.com/openclaw/openclaw/commit/ae658aa84c).

## Summary

- Adds curly braces to single-line `if` guard in `typing.ts` to satisfy `eslint(curly)` rule
- Depends on PR #948 (cherry-pick 97eb554) which introduces the guarded line

## Conflicts resolved

- `src/channels/typing.ts` — conflict because the `if (closed) return;` line from commit 13 isn't on main yet (it's on PR #948's branch); took theirs' curly-braced version

## Note

This PR includes the guard line from commit 13 (PR #948) with curly braces. Should be merged after #948.

Relates to #568

Cherry-picked-from: ae658aa84c