### PR TITLE
Cherry-pick 125f4071b: block agents.files symlink escapes

### DIFF
--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -27,10 +27,12 @@ const mocks = vi.hoisted(() => ({
   fsAppendFile: vi.fn(async () => {}),
   fsReadFile: vi.fn(async () => ""),
   fsWriteFile: vi.fn(async () => {}),
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fsStat: vi.fn(async () => null) as any,
+  fsStat: vi.fn(async (..._args: unknown[]) => null as import("node:fs").Stats | null),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fsReaddir: vi.fn(async () => []) as any,
+  fsLstat: vi.fn(async (..._args: unknown[]) => null as import("node:fs").Stats | null),
+  fsRealpath: vi.fn(async (p: string) => p),
+  fsOpen: vi.fn(async () => ({}) as unknown),
 }));
 
 vi.mock("../../config/config.js", () => ({
@@ -91,6 +93,9 @@ vi.mock("node:fs/promises", async () => {
     writeFile: mocks.fsWriteFile,
     stat: mocks.fsStat,
     readdir: mocks.fsReaddir,
+    lstat: mocks.fsLstat,
+    realpath: mocks.fsRealpath,
+    open: mocks.fsOpen,
   };
   return { ...patched, default: patched };
 });
@@ -125,6 +130,33 @@ function createEnoentError() {
   return err;
 }
 
+function makeFileStat(params?: {
+  size?: number;
+  mtimeMs?: number;
+  dev?: number;
+  ino?: number;
+}): import("node:fs").Stats {
+  return {
+    isFile: () => true,
+    isSymbolicLink: () => false,
+    size: params?.size ?? 10,
+    mtimeMs: params?.mtimeMs ?? 1234,
+    dev: params?.dev ?? 1,
+    ino: params?.ino ?? 1,
+  } as unknown as import("node:fs").Stats;
+}
+
+function makeSymlinkStat(params?: { dev?: number; ino?: number }): import("node:fs").Stats {
+  return {
+    isFile: () => false,
+    isSymbolicLink: () => true,
+    size: 0,
+    mtimeMs: 0,
+    dev: params?.dev ?? 1,
+    ino: params?.ino ?? 2,
+  } as unknown as import("node:fs").Stats;
+}
+
 function expectNotFoundResponseAndNoWrite(respond: ReturnType<typeof vi.fn>) {
   expect(respond).toHaveBeenCalledWith(
     false,
@@ -141,6 +173,19 @@ beforeEach(() => {
   mocks.fsStat.mockImplementation(async () => {
     throw createEnoentError();
   });
+  mocks.fsLstat.mockImplementation(async () => {
+    throw createEnoentError();
+  });
+  mocks.fsRealpath.mockImplementation(async (p: string) => p);
+  mocks.fsOpen.mockImplementation(
+    async () =>
+      ({
+        stat: async () => makeFileStat(),
+        readFile: async () => Buffer.from(""),
+        writeFile: async () => {},
+        close: async () => {},
+      }) as unknown,
+  );
 });
 
 /* ------------------------------------------------------------------ */
@@ -439,11 +484,9 @@ describe("agents.files.list", () => {
       { name: "CLAUDE.md", isFile: () => true, isDirectory: () => false },
       { name: "secret.key", isFile: () => true, isDirectory: () => false },
     ]);
-    mocks.fsStat.mockImplementation(async () => ({
-      isFile: () => true,
-      size: 42,
-      mtimeMs: 1000,
-    }));
+    const fileStat = makeFileStat({ size: 42, mtimeMs: 1000 });
+    mocks.fsLstat.mockResolvedValue(fileStat);
+    mocks.fsStat.mockResolvedValue(fileStat);
 
     const { respond, promise } = makeCall("agents.files.list", { agentId: "main" });
     await promise;
@@ -465,11 +508,9 @@ describe("agents.files.list", () => {
       { name: "README.md", isFile: () => true, isDirectory: () => false },
       { name: "notes.txt", isFile: () => true, isDirectory: () => false },
     ]);
-    mocks.fsStat.mockImplementation(async () => ({
-      isFile: () => true,
-      size: 10,
-      mtimeMs: 2000,
-    }));
+    const fileStat = makeFileStat({ size: 10, mtimeMs: 2000 });
+    mocks.fsLstat.mockResolvedValue(fileStat);
+    mocks.fsStat.mockResolvedValue(fileStat);
 
     const { respond, promise } = makeCall("agents.files.list", { agentId: "main" });
     await promise;
@@ -519,12 +560,17 @@ describe("agents.files.get", () => {
   });
 
   it("returns file content for matching glob", async () => {
-    mocks.fsStat.mockImplementation(async () => ({
-      isFile: () => true,
-      size: 5,
-      mtimeMs: 3000,
-    }));
-    mocks.fsReadFile.mockImplementation(async () => "hello");
+    const fileStat = makeFileStat({ size: 5, mtimeMs: 3000 });
+    mocks.fsLstat.mockResolvedValue(fileStat);
+    mocks.fsStat.mockResolvedValue(fileStat);
+    mocks.fsOpen.mockImplementation(
+      async () =>
+        ({
+          stat: async () => fileStat,
+          readFile: async () => Buffer.from("hello"),
+          close: async () => {},
+        }) as unknown,
+    );
 
     const { respond, promise } = makeCall("agents.files.get", {
       agentId: "main",
@@ -572,15 +618,22 @@ describe("agents.files.set", () => {
       undefined,
       expect.objectContaining({ message: expect.stringContaining("not in editableFiles") }),
     );
-    expect(mocks.fsWriteFile).not.toHaveBeenCalled();
+    expect(mocks.fsOpen).not.toHaveBeenCalled();
   });
 
   it("writes file content for matching glob", async () => {
-    mocks.fsStat.mockImplementation(async () => ({
-      isFile: () => true,
-      size: 11,
-      mtimeMs: 4000,
-    }));
+    const fileStat = makeFileStat({ size: 11, mtimeMs: 4000 });
+    mocks.fsLstat.mockResolvedValue(fileStat);
+    mocks.fsStat.mockResolvedValue(fileStat);
+    mocks.fsOpen.mockImplementation(
+      async () =>
+        ({
+          stat: async () => fileStat,
+          readFile: async () => Buffer.from(""),
+          writeFile: async () => {},
+          close: async () => {},
+        }) as unknown,
+    );
 
     const { respond, promise } = makeCall("agents.files.set", {
       agentId: "main",
@@ -589,7 +642,7 @@ describe("agents.files.set", () => {
     });
     await promise;
 
-    expect(mocks.fsWriteFile).toHaveBeenCalled();
+    expect(mocks.fsOpen).toHaveBeenCalled();
     const [ok, result] = respond.mock.calls[0] ?? [];
     expect(ok).toBe(true);
     expect((result as { ok: boolean }).ok).toBe(true);
@@ -608,6 +661,152 @@ describe("agents.files.set", () => {
       undefined,
       expect.objectContaining({ message: expect.stringContaining("unsafe") }),
     );
-    expect(mocks.fsWriteFile).not.toHaveBeenCalled();
+    expect(mocks.fsOpen).not.toHaveBeenCalled();
+  });
+});
+
+describe("agents.files.get/set symlink safety", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadConfigReturn = {
+      agents: { defaults: { editableFiles: ["*.md"] } },
+    };
+    mocks.fsMkdir.mockResolvedValue(undefined);
+  });
+
+  it("rejects agents.files.get when allowlisted file symlink escapes workspace", async () => {
+    const workspace = "/workspace/test-agent";
+    const candidate = `${workspace}/AGENTS.md`;
+    mocks.fsRealpath.mockImplementation(async (p: string) => {
+      if (p === workspace) {
+        return workspace;
+      }
+      if (p === candidate) {
+        return "/outside/secret.txt";
+      }
+      return p;
+    });
+    mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
+      const p = typeof args[0] === "string" ? args[0] : "";
+      if (p === candidate) {
+        return makeSymlinkStat();
+      }
+      throw createEnoentError();
+    });
+
+    const { respond, promise } = makeCall("agents.files.get", {
+      agentId: "main",
+      name: "AGENTS.md",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("unsafe workspace file") }),
+    );
+  });
+
+  it("rejects agents.files.set when allowlisted file symlink escapes workspace", async () => {
+    const workspace = "/workspace/test-agent";
+    const candidate = `${workspace}/AGENTS.md`;
+    mocks.fsRealpath.mockImplementation(async (p: string) => {
+      if (p === workspace) {
+        return workspace;
+      }
+      if (p === candidate) {
+        return "/outside/secret.txt";
+      }
+      return p;
+    });
+    mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
+      const p = typeof args[0] === "string" ? args[0] : "";
+      if (p === candidate) {
+        return makeSymlinkStat();
+      }
+      throw createEnoentError();
+    });
+
+    const { respond, promise } = makeCall("agents.files.set", {
+      agentId: "main",
+      name: "AGENTS.md",
+      content: "x",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("unsafe workspace file") }),
+    );
+    expect(mocks.fsOpen).not.toHaveBeenCalled();
+  });
+
+  it("allows in-workspace symlink targets for get/set", async () => {
+    const workspace = "/workspace/test-agent";
+    const candidate = `${workspace}/AGENTS.md`;
+    const target = `${workspace}/policies/AGENTS.md`;
+    const targetStat = makeFileStat({ size: 7, mtimeMs: 1700, dev: 9, ino: 42 });
+
+    mocks.fsRealpath.mockImplementation(async (p: string) => {
+      if (p === workspace) {
+        return workspace;
+      }
+      if (p === candidate) {
+        return target;
+      }
+      return p;
+    });
+    mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
+      const p = typeof args[0] === "string" ? args[0] : "";
+      if (p === candidate) {
+        return makeSymlinkStat({ dev: 9, ino: 41 });
+      }
+      if (p === target) {
+        return targetStat;
+      }
+      throw createEnoentError();
+    });
+    mocks.fsStat.mockImplementation(async (...args: unknown[]) => {
+      const p = typeof args[0] === "string" ? args[0] : "";
+      if (p === target) {
+        return targetStat;
+      }
+      throw createEnoentError();
+    });
+    mocks.fsOpen.mockImplementation(
+      async () =>
+        ({
+          stat: async () => targetStat,
+          readFile: async () => Buffer.from("inside\n"),
+          writeFile: async () => {},
+          close: async () => {},
+        }) as unknown,
+    );
+
+    const getCall = makeCall("agents.files.get", { agentId: "main", name: "AGENTS.md" });
+    await getCall.promise;
+    expect(getCall.respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        file: expect.objectContaining({ missing: false, content: "inside\n" }),
+      }),
+      undefined,
+    );
+
+    const setCall = makeCall("agents.files.set", {
+      agentId: "main",
+      name: "AGENTS.md",
+      content: "updated\n",
+    });
+    await setCall.promise;
+    expect(setCall.respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        ok: true,
+        file: expect.objectContaining({ missing: false, content: "updated\n" }),
+      }),
+      undefined,
+    );
   });
 });

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -1,3 +1,4 @@
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -16,6 +17,9 @@ import {
 import { loadConfig, writeConfigFile } from "../../config/config.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import { resolveSessionTranscriptsDirForAgent } from "../../config/sessions/paths.js";
+import { sameFileIdentity } from "../../infra/file-identity.js";
+import { SafeOpenError, readLocalFileSafely } from "../../infra/fs-safe.js";
+import { isNotFoundPathError, isPathInside } from "../../infra/path-guards.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
 import { resolveUserPath } from "../../utils.js";
 import {
@@ -65,10 +69,113 @@ type FileMeta = {
   updatedAtMs: number;
 };
 
-async function statFile(filePath: string): Promise<FileMeta | null> {
+type ResolvedAgentWorkspaceFilePath =
+  | {
+      kind: "ready";
+      requestPath: string;
+      ioPath: string;
+      workspaceReal: string;
+    }
+  | {
+      kind: "missing";
+      requestPath: string;
+      ioPath: string;
+      workspaceReal: string;
+    }
+  | {
+      kind: "invalid";
+      requestPath: string;
+      reason: string;
+    };
+
+const SUPPORTS_NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in fsConstants;
+const OPEN_WRITE_FLAGS =
+  fsConstants.O_WRONLY |
+  fsConstants.O_CREAT |
+  fsConstants.O_TRUNC |
+  (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+
+async function resolveWorkspaceRealPath(workspaceDir: string): Promise<string> {
   try {
-    const stat = await fs.stat(filePath);
-    if (!stat.isFile()) {
+    return await fs.realpath(workspaceDir);
+  } catch {
+    return path.resolve(workspaceDir);
+  }
+}
+
+async function resolveAgentWorkspaceFilePath(params: {
+  workspaceDir: string;
+  name: string;
+  allowMissing: boolean;
+}): Promise<ResolvedAgentWorkspaceFilePath> {
+  const requestPath = path.join(params.workspaceDir, params.name);
+  const workspaceReal = await resolveWorkspaceRealPath(params.workspaceDir);
+  const candidatePath = path.resolve(workspaceReal, params.name);
+  if (!isPathInside(workspaceReal, candidatePath)) {
+    return { kind: "invalid", requestPath, reason: "path escapes workspace root" };
+  }
+
+  let candidateLstat: Awaited<ReturnType<typeof fs.lstat>>;
+  try {
+    candidateLstat = await fs.lstat(candidatePath);
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      if (params.allowMissing) {
+        return { kind: "missing", requestPath, ioPath: candidatePath, workspaceReal };
+      }
+      return { kind: "invalid", requestPath, reason: "file not found" };
+    }
+    throw err;
+  }
+
+  if (candidateLstat.isSymbolicLink()) {
+    let targetReal: string;
+    try {
+      targetReal = await fs.realpath(candidatePath);
+    } catch (err) {
+      if (isNotFoundPathError(err)) {
+        if (params.allowMissing) {
+          return { kind: "missing", requestPath, ioPath: candidatePath, workspaceReal };
+        }
+        return { kind: "invalid", requestPath, reason: "symlink target not found" };
+      }
+      throw err;
+    }
+    if (!isPathInside(workspaceReal, targetReal)) {
+      return { kind: "invalid", requestPath, reason: "symlink target escapes workspace root" };
+    }
+    try {
+      const targetStat = await fs.stat(targetReal);
+      if (!targetStat.isFile()) {
+        return { kind: "invalid", requestPath, reason: "symlink target is not a file" };
+      }
+    } catch (err) {
+      if (isNotFoundPathError(err) && params.allowMissing) {
+        return { kind: "missing", requestPath, ioPath: targetReal, workspaceReal };
+      }
+      throw err;
+    }
+    return { kind: "ready", requestPath, ioPath: targetReal, workspaceReal };
+  }
+
+  if (!candidateLstat.isFile()) {
+    return { kind: "invalid", requestPath, reason: "path is not a regular file" };
+  }
+
+  const candidateReal = await fs.realpath(candidatePath).catch(() => candidatePath);
+  if (!isPathInside(workspaceReal, candidateReal)) {
+    return { kind: "invalid", requestPath, reason: "resolved file escapes workspace root" };
+  }
+  return { kind: "ready", requestPath, ioPath: candidateReal, workspaceReal };
+}
+
+async function statFileSafely(filePath: string): Promise<FileMeta | null> {
+  try {
+    const [stat, lstat] = await Promise.all([fs.stat(filePath), fs.lstat(filePath)]);
+    if (lstat.isSymbolicLink() || !stat.isFile()) {
+      return null;
+    }
+    if (!sameFileIdentity(stat, lstat)) {
       return null;
     }
     return {
@@ -77,6 +184,22 @@ async function statFile(filePath: string): Promise<FileMeta | null> {
     };
   } catch {
     return null;
+  }
+}
+
+async function writeFileSafely(filePath: string, content: string): Promise<void> {
+  const handle = await fs.open(filePath, OPEN_WRITE_FLAGS, 0o600);
+  try {
+    const [stat, lstat] = await Promise.all([handle.stat(), fs.lstat(filePath)]);
+    if (lstat.isSymbolicLink() || !stat.isFile()) {
+      throw new Error("unsafe file path");
+    }
+    if (!sameFileIdentity(stat, lstat)) {
+      throw new Error("path changed during write");
+    }
+    await handle.writeFile(content, "utf-8");
+  } finally {
+    await handle.close().catch(() => {});
   }
 }
 
@@ -142,8 +265,13 @@ async function listAgentFiles(workspaceDir: string, globs: string[]) {
     if (!matchesEditableGlobs(relPath, globs)) {
       continue;
     }
-    const filePath = path.join(workspaceDir, relPath);
-    const meta = await statFile(filePath);
+    const resolved = await resolveAgentWorkspaceFilePath({
+      workspaceDir,
+      name: relPath,
+      allowMissing: true,
+    });
+    const filePath = resolved.requestPath;
+    const meta = resolved.kind === "ready" ? await statFileSafely(resolved.ioPath) : null;
     if (meta) {
       files.push({
         name: relPath,
@@ -479,8 +607,23 @@ export const agentsHandlers: GatewayRequestHandlers = {
     }
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
     const filePath = path.join(workspaceDir, name);
-    const meta = await statFile(filePath);
-    if (!meta) {
+    const resolvedPath = await resolveAgentWorkspaceFilePath({
+      workspaceDir,
+      name,
+      allowMissing: true,
+    });
+    if (resolvedPath.kind === "invalid") {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `unsafe workspace file "${name}" (${resolvedPath.reason})`,
+        ),
+      );
+      return;
+    }
+    if (resolvedPath.kind === "missing") {
       respond(
         true,
         {
@@ -492,7 +635,29 @@ export const agentsHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const content = await fs.readFile(filePath, "utf-8");
+    let safeRead: Awaited<ReturnType<typeof readLocalFileSafely>>;
+    try {
+      safeRead = await readLocalFileSafely({ filePath: resolvedPath.ioPath });
+    } catch (err) {
+      if (err instanceof SafeOpenError && err.code === "not-found") {
+        respond(
+          true,
+          {
+            agentId,
+            workspace: workspaceDir,
+            file: { name, path: filePath, missing: true },
+          },
+          undefined,
+        );
+        return;
+      }
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `unsafe workspace file "${name}"`),
+      );
+      return;
+    }
     respond(
       true,
       {
@@ -502,9 +667,9 @@ export const agentsHandlers: GatewayRequestHandlers = {
           name,
           path: filePath,
           missing: false,
-          size: meta.size,
-          updatedAtMs: meta.updatedAtMs,
-          content,
+          size: safeRead.stat.size,
+          updatedAtMs: Math.floor(safeRead.stat.mtimeMs),
+          content: safeRead.buffer.toString("utf-8"),
         },
       },
       undefined,
@@ -562,13 +727,38 @@ export const agentsHandlers: GatewayRequestHandlers = {
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
     await fs.mkdir(workspaceDir, { recursive: true });
     const filePath = path.join(workspaceDir, name);
-    const parentDir = path.dirname(filePath);
-    if (parentDir !== workspaceDir) {
+    const resolvedPath = await resolveAgentWorkspaceFilePath({
+      workspaceDir,
+      name,
+      allowMissing: true,
+    });
+    if (resolvedPath.kind === "invalid") {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `unsafe workspace file "${name}" (${resolvedPath.reason})`,
+        ),
+      );
+      return;
+    }
+    const parentDir = path.dirname(resolvedPath.ioPath);
+    if (parentDir !== resolvedPath.workspaceReal) {
       await fs.mkdir(parentDir, { recursive: true });
     }
     const content = String(params.content ?? "");
-    await fs.writeFile(filePath, content, "utf-8");
-    const meta = await statFile(filePath);
+    try {
+      await writeFileSafely(resolvedPath.ioPath, content);
+    } catch {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `unsafe workspace file "${name}"`),
+      );
+      return;
+    }
+    const meta = await statFileSafely(resolvedPath.ioPath);
     respond(
       true,
       {


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: 125f4071bc
**Author**: Peter Steinberger <steipete@gmail.com>
**Tier**: AUTO-PICK

> fix(gateway): block agents.files symlink escapes

Resolved conflicts: CHANGELOG.md discarded (gutted layer), agents.ts and agents-mutate.test.ts adapted for fork's glob-based editableFiles (vs upstream's bootstrap files). Added symlink-safe path resolution to glob walker and writeFileSafely to agents.files.set handler. Updated test mocks for safe file operations.