### PR TITLE
Cherry-pick ef326f5cd: fix(browser): revalidate upload paths at use time

### DIFF
--- a/src/browser/paths.test.ts
+++ b/src/browser/paths.test.ts
@@ -6,6 +6,7 @@ import {
   resolveExistingPathsWithinRoot,
   resolvePathsWithinRoot,
   resolvePathWithinRoot,
+  resolveStrictExistingPathsWithinRoot,
 } from "./paths.js";
 
 async function createFixtureRoot(): Promise<{ baseDir: string; uploadsDir: string }> {
@@ -192,6 +193,29 @@ describe("resolveExistingPathsWithinRoot", () => {
       });
     },
   );
+});
+
+describe("resolveStrictExistingPathsWithinRoot", () => {
+  function expectInvalidResult(
+    result: Awaited<ReturnType<typeof resolveStrictExistingPathsWithinRoot>>,
+    expectedSnippet: string,
+  ) {
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain(expectedSnippet);
+    }
+  }
+
+  it("rejects missing files instead of returning lexical fallbacks", async () => {
+    await withFixtureRoot(async ({ uploadsDir }) => {
+      const result = await resolveStrictExistingPathsWithinRoot({
+        rootDir: uploadsDir,
+        requestedPaths: ["missing.txt"],
+        scopeLabel: "uploads directory",
+      });
+      expectInvalidResult(result, "regular non-symlink file");
+    });
+  });
 });
 
 describe("resolvePathWithinRoot", () => {

--- a/src/browser/paths.ts
+++ b/src/browser/paths.ts
@@ -55,6 +55,29 @@ export async function resolveExistingPathsWithinRoot(params: {
   requestedPaths: string[];
   scopeLabel: string;
 }): Promise<{ ok: true; paths: string[] } | { ok: false; error: string }> {
+  return await resolveCheckedPathsWithinRoot({
+    ...params,
+    allowMissingFallback: true,
+  });
+}
+
+export async function resolveStrictExistingPathsWithinRoot(params: {
+  rootDir: string;
+  requestedPaths: string[];
+  scopeLabel: string;
+}): Promise<{ ok: true; paths: string[] } | { ok: false; error: string }> {
+  return await resolveCheckedPathsWithinRoot({
+    ...params,
+    allowMissingFallback: false,
+  });
+}
+
+async function resolveCheckedPathsWithinRoot(params: {
+  rootDir: string;
+  requestedPaths: string[];
+  scopeLabel: string;
+  allowMissingFallback: boolean;
+}): Promise<{ ok: true; paths: string[] } | { ok: false; error: string }> {
   const rootDir = path.resolve(params.rootDir);
   let rootRealPath: string | undefined;
   try {
@@ -119,7 +142,7 @@ export async function resolveExistingPathsWithinRoot(params: {
       });
       resolvedPaths.push(opened.realPath);
     } catch (err) {
-      if (err instanceof SafeOpenError && err.code === "not-found") {
+      if (params.allowMissingFallback && err instanceof SafeOpenError && err.code === "not-found") {
         // Preserve historical behavior for paths that do not exist yet.
         resolvedPaths.push(pathResult.fallbackPath);
         continue;

--- a/src/browser/pw-tools-core.downloads.ts
+++ b/src/browser/pw-tools-core.downloads.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright-core";
 import { resolvePreferredRemoteClawTmpDir } from "../infra/tmp-remoteclaw-dir.js";
+import { DEFAULT_UPLOAD_DIR, resolveStrictExistingPathsWithinRoot } from "./paths.js";
 import {
   ensurePageState,
   getPageForTargetId,
@@ -166,7 +167,20 @@ export async function armFileUploadViaPlaywright(opts: {
         }
         return;
       }
-      await fileChooser.setFiles(opts.paths);
+      const uploadPathsResult = await resolveStrictExistingPathsWithinRoot({
+        rootDir: DEFAULT_UPLOAD_DIR,
+        requestedPaths: opts.paths,
+        scopeLabel: `uploads directory (${DEFAULT_UPLOAD_DIR})`,
+      });
+      if (!uploadPathsResult.ok) {
+        try {
+          await page.keyboard.press("Escape");
+        } catch {
+          // Best-effort.
+        }
+        return;
+      }
+      await fileChooser.setFiles(uploadPathsResult.paths);
       try {
         const input =
           typeof fileChooser.element === "function"

--- a/src/browser/pw-tools-core.interactions.set-input-files.test.ts
+++ b/src/browser/pw-tools-core.interactions.set-input-files.test.ts
@@ -1,0 +1,111 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+let page: Record<string, unknown> | null = null;
+let locator: Record<string, unknown> | null = null;
+
+const getPageForTargetId = vi.fn(async () => {
+  if (!page) {
+    throw new Error("test: page not set");
+  }
+  return page;
+});
+const ensurePageState = vi.fn(() => ({}));
+const restoreRoleRefsForTarget = vi.fn(() => {});
+const refLocator = vi.fn(() => {
+  if (!locator) {
+    throw new Error("test: locator not set");
+  }
+  return locator;
+});
+const forceDisconnectPlaywrightForTarget = vi.fn(async () => {});
+
+const resolveStrictExistingPathsWithinRoot =
+  vi.fn<typeof import("./paths.js").resolveStrictExistingPathsWithinRoot>();
+
+vi.mock("./pw-session.js", () => {
+  return {
+    ensurePageState,
+    forceDisconnectPlaywrightForTarget,
+    getPageForTargetId,
+    refLocator,
+    restoreRoleRefsForTarget,
+  };
+});
+
+vi.mock("./paths.js", () => {
+  return {
+    DEFAULT_UPLOAD_DIR: "/tmp/openclaw/uploads",
+    resolveStrictExistingPathsWithinRoot,
+  };
+});
+
+let setInputFilesViaPlaywright: typeof import("./pw-tools-core.interactions.js").setInputFilesViaPlaywright;
+
+describe("setInputFilesViaPlaywright", () => {
+  beforeAll(async () => {
+    ({ setInputFilesViaPlaywright } = await import("./pw-tools-core.interactions.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    page = null;
+    locator = null;
+    resolveStrictExistingPathsWithinRoot.mockResolvedValue({
+      ok: true,
+      paths: ["/private/tmp/openclaw/uploads/ok.txt"],
+    });
+  });
+
+  it("revalidates upload paths and uses resolved canonical paths for inputRef", async () => {
+    const setInputFiles = vi.fn(async () => {});
+    locator = {
+      setInputFiles,
+      elementHandle: vi.fn(async () => null),
+    };
+    page = {
+      locator: vi.fn(() => ({ first: () => locator })),
+    };
+
+    await setInputFilesViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      inputRef: "e7",
+      paths: ["/tmp/openclaw/uploads/ok.txt"],
+    });
+
+    expect(resolveStrictExistingPathsWithinRoot).toHaveBeenCalledWith({
+      rootDir: "/tmp/openclaw/uploads",
+      requestedPaths: ["/tmp/openclaw/uploads/ok.txt"],
+      scopeLabel: "uploads directory (/tmp/openclaw/uploads)",
+    });
+    expect(refLocator).toHaveBeenCalledWith(page, "e7");
+    expect(setInputFiles).toHaveBeenCalledWith(["/private/tmp/openclaw/uploads/ok.txt"]);
+  });
+
+  it("throws and skips setInputFiles when use-time validation fails", async () => {
+    resolveStrictExistingPathsWithinRoot.mockResolvedValueOnce({
+      ok: false,
+      error: "Invalid path: must stay within uploads directory",
+    });
+
+    const setInputFiles = vi.fn(async () => {});
+    locator = {
+      setInputFiles,
+      elementHandle: vi.fn(async () => null),
+    };
+    page = {
+      locator: vi.fn(() => ({ first: () => locator })),
+    };
+
+    await expect(
+      setInputFilesViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        element: "input[type=file]",
+        paths: ["/tmp/openclaw/uploads/missing.txt"],
+      }),
+    ).rejects.toThrow("Invalid path: must stay within uploads directory");
+
+    expect(setInputFiles).not.toHaveBeenCalled();
+  });
+});

--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -1,4 +1,5 @@
 import type { BrowserFormField } from "./client-actions-core.js";
+import { DEFAULT_UPLOAD_DIR, resolveStrictExistingPathsWithinRoot } from "./paths.js";
 import {
   ensurePageState,
   forceDisconnectPlaywrightForTarget,
@@ -626,9 +627,18 @@ export async function setInputFilesViaPlaywright(opts: {
   }
 
   const locator = inputRef ? refLocator(page, inputRef) : page.locator(element).first();
+  const uploadPathsResult = await resolveStrictExistingPathsWithinRoot({
+    rootDir: DEFAULT_UPLOAD_DIR,
+    requestedPaths: opts.paths,
+    scopeLabel: `uploads directory (${DEFAULT_UPLOAD_DIR})`,
+  });
+  if (!uploadPathsResult.ok) {
+    throw new Error(uploadPathsResult.error);
+  }
+  const resolvedPaths = uploadPathsResult.paths;
 
   try {
-    await locator.setInputFiles(opts.paths);
+    await locator.setInputFiles(resolvedPaths);
   } catch (err) {
     throw toAIFriendlyError(err, inputRef || element);
   }


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: ef326f5cd0f761e02d5a02339be64ccfe1b96102
**Author**: Peter Steinberger <steipete@gmail.com>
**Tier**: AUTO-PICK

> fix(browser): revalidate upload paths at use time

Resolves remoteclaw/remoteclaw-hq#570 (1/3)