### PR TITLE
Cherry-pick f41715a18: refactor(browser): split act route modules and dedupe path guards

### DIFF
--- a/src/browser/paths.ts
+++ b/src/browser/paths.ts
@@ -1,12 +1,65 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { SafeOpenError, openFileWithinRoot } from "../infra/fs-safe.js";
+import { isNotFoundPathError, isPathInside } from "../infra/path-guards.js";
 import { resolvePreferredRemoteClawTmpDir } from "../infra/tmp-remoteclaw-dir.js";
 
 export const DEFAULT_BROWSER_TMP_DIR = resolvePreferredRemoteClawTmpDir();
 export const DEFAULT_TRACE_DIR = DEFAULT_BROWSER_TMP_DIR;
 export const DEFAULT_DOWNLOAD_DIR = path.join(DEFAULT_BROWSER_TMP_DIR, "downloads");
 export const DEFAULT_UPLOAD_DIR = path.join(DEFAULT_BROWSER_TMP_DIR, "uploads");
+
+type InvalidPathResult = { ok: false; error: string };
+
+function invalidPath(scopeLabel: string): InvalidPathResult {
+  return {
+    ok: false,
+    error: `Invalid path: must stay within ${scopeLabel}`,
+  };
+}
+
+async function resolveRealPathIfExists(targetPath: string): Promise<string | undefined> {
+  try {
+    return await fs.realpath(targetPath);
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveTrustedRootRealPath(rootDir: string): Promise<string | undefined> {
+  try {
+    const rootLstat = await fs.lstat(rootDir);
+    if (!rootLstat.isDirectory() || rootLstat.isSymbolicLink()) {
+      return undefined;
+    }
+    return await fs.realpath(rootDir);
+  } catch {
+    return undefined;
+  }
+}
+
+async function validateCanonicalPathWithinRoot(params: {
+  rootRealPath: string;
+  candidatePath: string;
+  expect: "directory" | "file";
+}): Promise<"ok" | "not-found" | "invalid"> {
+  try {
+    const candidateLstat = await fs.lstat(params.candidatePath);
+    if (candidateLstat.isSymbolicLink()) {
+      return "invalid";
+    }
+    if (params.expect === "directory" && !candidateLstat.isDirectory()) {
+      return "invalid";
+    }
+    if (params.expect === "file" && !candidateLstat.isFile()) {
+      return "invalid";
+    }
+    const candidateRealPath = await fs.realpath(params.candidatePath);
+    return isPathInside(params.rootRealPath, candidateRealPath) ? "ok" : "invalid";
+  } catch (err) {
+    return isNotFoundPathError(err) ? "not-found" : "invalid";
+  }
+}
 
 export function resolvePathWithinRoot(params: {
   rootDir: string;
@@ -28,6 +81,46 @@ export function resolvePathWithinRoot(params: {
     return { ok: false, error: `Invalid path: must stay within ${params.scopeLabel}` };
   }
   return { ok: true, path: resolved };
+}
+
+export async function resolveWritablePathWithinRoot(params: {
+  rootDir: string;
+  requestedPath: string;
+  scopeLabel: string;
+  defaultFileName?: string;
+}): Promise<{ ok: true; path: string } | { ok: false; error: string }> {
+  const lexical = resolvePathWithinRoot(params);
+  if (!lexical.ok) {
+    return lexical;
+  }
+
+  const rootDir = path.resolve(params.rootDir);
+  const rootRealPath = await resolveTrustedRootRealPath(rootDir);
+  if (!rootRealPath) {
+    return invalidPath(params.scopeLabel);
+  }
+
+  const requestedPath = lexical.path;
+  const parentDir = path.dirname(requestedPath);
+  const parentStatus = await validateCanonicalPathWithinRoot({
+    rootRealPath,
+    candidatePath: parentDir,
+    expect: "directory",
+  });
+  if (parentStatus !== "ok") {
+    return invalidPath(params.scopeLabel);
+  }
+
+  const targetStatus = await validateCanonicalPathWithinRoot({
+    rootRealPath,
+    candidatePath: requestedPath,
+    expect: "file",
+  });
+  if (targetStatus === "invalid") {
+    return invalidPath(params.scopeLabel);
+  }
+
+  return lexical;
 }
 
 export function resolvePathsWithinRoot(params: {
@@ -56,13 +149,8 @@ export async function resolveExistingPathsWithinRoot(params: {
   scopeLabel: string;
 }): Promise<{ ok: true; paths: string[] } | { ok: false; error: string }> {
   const rootDir = path.resolve(params.rootDir);
-  let rootRealPath: string | undefined;
-  try {
-    rootRealPath = await fs.realpath(rootDir);
-  } catch {
-    // Keep historical behavior for missing roots and rely on openFileWithinRoot for final checks.
-    rootRealPath = undefined;
-  }
+  // Keep historical behavior for missing roots and rely on openFileWithinRoot for final checks.
+  const rootRealPath = await resolveRealPathIfExists(rootDir);
 
   const isInRoot = (relativePath: string) =>
     Boolean(relativePath) && !relativePath.startsWith("..") && !path.isAbsolute(relativePath);

--- a/src/browser/routes/agent.act.download.ts
+++ b/src/browser/routes/agent.act.download.ts
@@ -1,0 +1,97 @@
+import type { BrowserRouteContext } from "../server-context.js";
+import { readBody, resolveTargetIdFromBody, withPlaywrightRouteContext } from "./agent.shared.js";
+import { ensureOutputRootDir, resolveWritableOutputPathOrRespond } from "./output-paths.js";
+import { DEFAULT_DOWNLOAD_DIR } from "./path-output.js";
+import type { BrowserRouteRegistrar } from "./types.js";
+import { jsonError, toNumber, toStringOrEmpty } from "./utils.js";
+
+function buildDownloadRequestBase(cdpUrl: string, targetId: string, timeoutMs: number | undefined) {
+  return {
+    cdpUrl,
+    targetId,
+    timeoutMs: timeoutMs ?? undefined,
+  };
+}
+
+export function registerBrowserAgentActDownloadRoutes(
+  app: BrowserRouteRegistrar,
+  ctx: BrowserRouteContext,
+) {
+  app.post("/wait/download", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const out = toStringOrEmpty(body.path) || "";
+    const timeoutMs = toNumber(body.timeoutMs);
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "wait for download",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await ensureOutputRootDir(DEFAULT_DOWNLOAD_DIR);
+        let downloadPath: string | undefined;
+        if (out.trim()) {
+          const resolvedDownloadPath = await resolveWritableOutputPathOrRespond({
+            res,
+            rootDir: DEFAULT_DOWNLOAD_DIR,
+            requestedPath: out,
+            scopeLabel: "downloads directory",
+          });
+          if (!resolvedDownloadPath) {
+            return;
+          }
+          downloadPath = resolvedDownloadPath;
+        }
+        const requestBase = buildDownloadRequestBase(cdpUrl, tab.targetId, timeoutMs);
+        const result = await pw.waitForDownloadViaPlaywright({
+          ...requestBase,
+          path: downloadPath,
+        });
+        res.json({ ok: true, targetId: tab.targetId, download: result });
+      },
+    });
+  });
+
+  app.post("/download", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const ref = toStringOrEmpty(body.ref);
+    const out = toStringOrEmpty(body.path);
+    const timeoutMs = toNumber(body.timeoutMs);
+    if (!ref) {
+      return jsonError(res, 400, "ref is required");
+    }
+    if (!out) {
+      return jsonError(res, 400, "path is required");
+    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "download",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await ensureOutputRootDir(DEFAULT_DOWNLOAD_DIR);
+        const downloadPath = await resolveWritableOutputPathOrRespond({
+          res,
+          rootDir: DEFAULT_DOWNLOAD_DIR,
+          requestedPath: out,
+          scopeLabel: "downloads directory",
+        });
+        if (!downloadPath) {
+          return;
+        }
+        const requestBase = buildDownloadRequestBase(cdpUrl, tab.targetId, timeoutMs);
+        const result = await pw.downloadViaPlaywright({
+          ...requestBase,
+          ref,
+          path: downloadPath,
+        });
+        res.json({ ok: true, targetId: tab.targetId, download: result });
+      },
+    });
+  });
+}

--- a/src/browser/routes/agent.act.hooks.ts
+++ b/src/browser/routes/agent.act.hooks.ts
@@ -1,0 +1,100 @@
+import type { BrowserRouteContext } from "../server-context.js";
+import { readBody, resolveTargetIdFromBody, withPlaywrightRouteContext } from "./agent.shared.js";
+import { DEFAULT_UPLOAD_DIR, resolveExistingPathsWithinRoot } from "./path-output.js";
+import type { BrowserRouteRegistrar } from "./types.js";
+import { jsonError, toBoolean, toNumber, toStringArray, toStringOrEmpty } from "./utils.js";
+
+export function registerBrowserAgentActHookRoutes(
+  app: BrowserRouteRegistrar,
+  ctx: BrowserRouteContext,
+) {
+  app.post("/hooks/file-chooser", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const ref = toStringOrEmpty(body.ref) || undefined;
+    const inputRef = toStringOrEmpty(body.inputRef) || undefined;
+    const element = toStringOrEmpty(body.element) || undefined;
+    const paths = toStringArray(body.paths) ?? [];
+    const timeoutMs = toNumber(body.timeoutMs);
+    if (!paths.length) {
+      return jsonError(res, 400, "paths are required");
+    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "file chooser hook",
+      run: async ({ cdpUrl, tab, pw }) => {
+        const uploadPathsResult = await resolveExistingPathsWithinRoot({
+          rootDir: DEFAULT_UPLOAD_DIR,
+          requestedPaths: paths,
+          scopeLabel: `uploads directory (${DEFAULT_UPLOAD_DIR})`,
+        });
+        if (!uploadPathsResult.ok) {
+          res.status(400).json({ error: uploadPathsResult.error });
+          return;
+        }
+        const resolvedPaths = uploadPathsResult.paths;
+
+        if (inputRef || element) {
+          if (ref) {
+            return jsonError(res, 400, "ref cannot be combined with inputRef/element");
+          }
+          await pw.setInputFilesViaPlaywright({
+            cdpUrl,
+            targetId: tab.targetId,
+            inputRef,
+            element,
+            paths: resolvedPaths,
+          });
+        } else {
+          await pw.armFileUploadViaPlaywright({
+            cdpUrl,
+            targetId: tab.targetId,
+            paths: resolvedPaths,
+            timeoutMs: timeoutMs ?? undefined,
+          });
+          if (ref) {
+            await pw.clickViaPlaywright({
+              cdpUrl,
+              targetId: tab.targetId,
+              ref,
+            });
+          }
+        }
+        res.json({ ok: true });
+      },
+    });
+  });
+
+  app.post("/hooks/dialog", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const accept = toBoolean(body.accept);
+    const promptText = toStringOrEmpty(body.promptText) || undefined;
+    const timeoutMs = toNumber(body.timeoutMs);
+    if (accept === undefined) {
+      return jsonError(res, 400, "accept is required");
+    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "dialog hook",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.armDialogViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          accept,
+          promptText,
+          timeoutMs: timeoutMs ?? undefined,
+        });
+        res.json({ ok: true });
+      },
+    });
+  });
+}

--- a/src/browser/routes/output-paths.ts
+++ b/src/browser/routes/output-paths.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs/promises";
+import { resolveWritablePathWithinRoot } from "./path-output.js";
+import type { BrowserResponse } from "./types.js";
+
+export async function ensureOutputRootDir(rootDir: string): Promise<void> {
+  await fs.mkdir(rootDir, { recursive: true });
+}
+
+export async function resolveWritableOutputPathOrRespond(params: {
+  res: BrowserResponse;
+  rootDir: string;
+  requestedPath: string;
+  scopeLabel: string;
+  defaultFileName?: string;
+  ensureRootDir?: boolean;
+}): Promise<string | null> {
+  if (params.ensureRootDir) {
+    await ensureOutputRootDir(params.rootDir);
+  }
+  const pathResult = await resolveWritablePathWithinRoot({
+    rootDir: params.rootDir,
+    requestedPath: params.requestedPath,
+    scopeLabel: params.scopeLabel,
+    defaultFileName: params.defaultFileName,
+  });
+  if (!pathResult.ok) {
+    params.res.status(400).json({ error: pathResult.error });
+    return null;
+  }
+  return pathResult.path;
+}

--- a/src/infra/tmp-remoteclaw-dir.ts
+++ b/src/infra/tmp-remoteclaw-dir.ts
@@ -75,16 +75,17 @@ export function resolvePreferredRemoteClawTmpDir(
     return st.isDirectory() && !st.isSymbolicLink() && isSecureDirForUser(st);
   };
 
-  const resolvePreferredState = (
+  const resolveDirState = (
+    candidatePath: string,
     requireWritableAccess: boolean,
   ): "available" | "missing" | "invalid" => {
     try {
-      const preferred = lstatSync(POSIX_REMOTECLAW_TMP_DIR);
-      if (!isTrustedPreferredDir(preferred)) {
+      const candidate = lstatSync(candidatePath);
+      if (!isTrustedPreferredDir(candidate)) {
         return "invalid";
       }
       if (requireWritableAccess) {
-        accessSync(POSIX_REMOTECLAW_TMP_DIR, fs.constants.W_OK | fs.constants.X_OK);
+        accessSync(candidatePath, fs.constants.W_OK | fs.constants.X_OK);
       }
       return "available";
     } catch (err) {
@@ -95,23 +96,43 @@ export function resolvePreferredRemoteClawTmpDir(
     }
   };
 
-  const existingPreferredState = resolvePreferredState(true);
+  const ensureTrustedFallbackDir = (): string => {
+    const fallbackPath = fallback();
+    const state = resolveDirState(fallbackPath, true);
+    if (state === "available") {
+      return fallbackPath;
+    }
+    if (state === "invalid") {
+      throw new Error(`Unsafe fallback RemoteClaw temp dir: ${fallbackPath}`);
+    }
+    try {
+      mkdirSync(fallbackPath, { recursive: true, mode: 0o700 });
+    } catch {
+      throw new Error(`Unable to create fallback RemoteClaw temp dir: ${fallbackPath}`);
+    }
+    if (resolveDirState(fallbackPath, true) !== "available") {
+      throw new Error(`Unsafe fallback RemoteClaw temp dir: ${fallbackPath}`);
+    }
+    return fallbackPath;
+  };
+
+  const existingPreferredState = resolveDirState(POSIX_REMOTECLAW_TMP_DIR, true);
   if (existingPreferredState === "available") {
     return POSIX_REMOTECLAW_TMP_DIR;
   }
   if (existingPreferredState === "invalid") {
-    return fallback();
+    return ensureTrustedFallbackDir();
   }
 
   try {
     accessSync("/tmp", fs.constants.W_OK | fs.constants.X_OK);
     // Create with a safe default; subsequent callers expect it exists.
     mkdirSync(POSIX_REMOTECLAW_TMP_DIR, { recursive: true, mode: 0o700 });
-    if (resolvePreferredState(true) !== "available") {
-      return fallback();
+    if (resolveDirState(POSIX_REMOTECLAW_TMP_DIR, true) !== "available") {
+      return ensureTrustedFallbackDir();
     }
     return POSIX_REMOTECLAW_TMP_DIR;
   } catch {
-    return fallback();
+    return ensureTrustedFallbackDir();
   }
 }


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: f41715a18f74d44154c78df2447dc34a347eeee7
**Author**: Peter Steinberger <steipete@gmail.com>
**Tier**: HUMAN-REVIEW

> refactor(browser): split act route modules and dedupe path guards

Conflict resolution: adapted `tmp-openclaw-dir` → `tmp-remoteclaw-dir` path references throughout, rebranded error messages from OpenClaw → RemoteClaw, added missing `path-guards.js` import to `paths.ts`, merged upstream's `resolveDirState` refactor (unified from separate `resolvePreferredState`/`resolveFallbackState`), took upstream's split route module structure (`agent.act.download.ts`, `agent.act.hooks.ts`, `output-paths.ts`).

**Note**: This commit depends on both `ef326f5cd` and `496a76c03b` (PRs #958 and #959). Merge those first.

Resolves remoteclaw/remoteclaw-hq#570 (3/3)