### PR TITLE
Cherry-pick ae658aa: style: add curly braces to satisfy eslint(curly)

### DIFF
--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -20,6 +20,9 @@ export function createTypingCallbacks(params: {
   let closed = false;
 
   const fireStart = async () => {
+    if (closed) {
+      return;
+    }
     try {
       await params.start();
     } catch (err) {


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: ae658aa84c298f51ef490cdcc0dde29d788ec152
**Author**: Ubuntu
**Tier**: AUTO-PICK

> style: add curly braces to satisfy eslint(curly)

**Note**: Conflict resolved — our main lacked the `if (closed) return;` guard (added by prerequisite 97eb554 on a separate branch). Took theirs to include the guard with curly braces. Linter expanded to multi-line format.