### PR TITLE
Cherry-pick 6fb082e: fix(typing): call markDispatchIdle in followup runner

### DIFF
--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -107,7 +107,15 @@ export function createFollowupRunner(params: {
       await bridge.handle(message, callbacks, opts?.abortSignal);
       logVerbose("followup queue: bridge.handle() completed");
     } finally {
+      // Both signals are required for the typing controller to clean up.
+      // The main inbound dispatch path calls markDispatchIdle() from the
+      // buffered dispatcher's finally block, but followup turns bypass the
+      // dispatcher entirely — so we must fire both signals here.  Without
+      // this, NO_REPLY / empty-payload followups leave the typing indicator
+      // stuck (the keepalive loop keeps sending "typing" to Telegram
+      // indefinitely until the TTL expires).
       typing.markRunComplete();
+      typing.markDispatchIdle();
     }
   };
 }


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: 6fb082e13160cfa7282c587a225d80b0e8c770bd
**Author**: codexGW <9350182+codexGW@users.noreply.github.com>
**Tier**: AUTO-PARTIAL

> fix(typing): call markDispatchIdle in followup runner to prevent stuck indicator (#26881)

**Adaptation**: Discarded deleted test file (followup-runner.test.ts was removed during fork gutting). CHANGELOG not present in this commit's touched files. Verified compatibility with WI-112 (followup-runner reconnected to ChannelBridge) — change adds `markDispatchIdle()` in the finally block alongside existing `markRunComplete()`.