### PR TITLE
Cherry-pick 2011edc: fix(gateway): preserve agentId through gateway send path

### DIFF
--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -22,6 +22,8 @@ export const SendParamsSchema = Type.Object(
     gifPlayback: Type.Optional(Type.Boolean()),
     channel: Type.Optional(Type.String()),
     accountId: Type.Optional(Type.String()),
+    /** Optional agent id for per-agent media root resolution on gateway sends. */
+    agentId: Type.Optional(Type.String()),
     /** Thread id (channel-specific meaning, e.g. Telegram forum topic id). */
     threadId: Type.Optional(Type.String()),
     /** Optional session key for mirroring delivered output back into the transcript. */

--- a/src/infra/outbound/message.channels.test.ts
+++ b/src/infra/outbound/message.channels.test.ts
@@ -194,6 +194,35 @@ describe("gateway url override hardening", () => {
       }),
     );
   });
+
+  it("forwards explicit agentId in gateway send params", async () => {
+    setRegistry(
+      createTestRegistry([
+        {
+          pluginId: "mattermost",
+          source: "test",
+          plugin: {
+            ...createMattermostLikePlugin({ onSendText: () => {} }),
+            outbound: { deliveryMode: "gateway" },
+          },
+        },
+      ]),
+    );
+
+    callGatewayMock.mockResolvedValueOnce({ messageId: "m-agent" });
+    await sendMessage({
+      cfg: {},
+      to: "channel:town-square",
+      content: "hi",
+      channel: "mattermost",
+      agentId: "work",
+    });
+
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      params?: Record<string, unknown>;
+    };
+    expect(call.params?.agentId).toBe("work");
+  });
 });
 
 const emptyRegistry = createTestRegistry([]);

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -251,6 +251,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       mediaUrls: mirrorMediaUrls.length ? mirrorMediaUrls : params.mediaUrls,
       gifPlayback: params.gifPlayback,
       accountId: params.accountId,
+      agentId: params.agentId,
       channel,
       sessionKey: params.mirror?.sessionKey,
       idempotencyKey: params.idempotencyKey ?? randomIdempotencyKey(),


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: 2011edc9e505ffa59949fb63f2c54a50f6400671
**Author**: Peter Steinberger <steipete@gmail.com>
**Tier**: HUMAN-REVIEW

> fix(gateway): preserve agentId through gateway send path

**Adaptation**: Discarded CHANGELOG.md (fork convention). Deferred Swift files (`apps/macos/Sources/RemoteClawProtocol/GatewayModels.swift`, `apps/shared/RemoteClawKit/Sources/RemoteClawProtocol/GatewayModels.swift`) to native apps phase per adaptation notes. Kept all `src/` changes (gateway schema, send handler, outbound message, tests).