### PR TITLE
Cherry-pick 95c6b3a91: fix(telegram): recover polling after prolonged network outages

### DIFF
--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -45,8 +45,10 @@ export function createTelegramRunnerOptions(cfg: RemoteClawConfig): RunOptions<u
       },
       // Suppress grammY getUpdates stack traces; we log concise errors ourselves.
       silent: true,
-      // Retry transient failures for a limited window before surfacing errors.
-      maxRetryTime: 5 * 60 * 1000,
+      // Retry transient failures before surfacing errors. Use a generous
+      // window so the runner survives prolonged outages (e.g. scheduled
+      // internet downtime) without the outer loop needing to restart it.
+      maxRetryTime: 60 * 60 * 1000,
       retryInterval: "exponential",
     },
   };
@@ -277,14 +279,21 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       try {
         // runner.task() returns a promise that resolves when the runner stops
         await runner.task();
-        if (!forceRestarted) {
+        if (opts.abortSignal?.aborted) {
           return;
         }
-        forceRestarted = false;
+        // The runner stopped on its own. This can happen when grammY's
+        // maxRetryTime is exceeded (e.g. prolonged network outage).
+        // Instead of exiting permanently, restart with backoff so polling
+        // recovers once connectivity is restored.
         restartAttempts += 1;
         const delayMs = computeBackoff(TELEGRAM_POLL_RESTART_POLICY, restartAttempts);
+        const reason = forceRestarted
+          ? "unhandled network error"
+          : "runner stopped (maxRetryTime exceeded or graceful stop)";
+        forceRestarted = false;
         log(
-          `Telegram polling runner restarted after unhandled network error; retrying in ${formatDurationPrecise(delayMs)}.`,
+          `Telegram polling runner stopped (${reason}); restarting in ${formatDurationPrecise(delayMs)}.`,
         );
         await sleepWithAbort(delayMs, opts.abortSignal);
         continue;


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: 95c6b3a912
**Author**: sten moocow <stenmoocow@stens-Mac-mini.local>
**Tier**: AUTO-PICK

> fix(telegram): recover polling after prolonged network outages

Closes #573 (1/3)