### PR TITLE
Cherry-pick 15cfba707: fix cron model fallback to agent defaults

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -191,10 +191,13 @@ export async function runCronIsolatedAgentTurn(params: {
   if (modelOverride !== undefined && modelOverride.length > 0) {
     const parsed = parseModelRef(modelOverride, resolvedDefault.provider);
     if (!parsed) {
-      return { status: "error", error: `Unrecognized model "${modelOverride}".` };
+      logWarn(
+        `cron: payload.model '${modelOverride}' not recognized, falling back to agent defaults`,
+      );
+    } else {
+      provider = parsed.provider;
+      model = parsed.model;
     }
-    provider = parsed.provider;
-    model = parsed.model;
   }
   const now = Date.now();
   const cronSession = resolveCronSession({


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: 15cfba7075
**Author**: Youyou972
**Tier**: AUTO-PARTIAL

> fix: cron model fallback to agent defaults when payload.model fails

Adapted for fork: uses `parseModelRef` instead of `resolveAllowedModelRef` (model catalog was gutted). When model can't be parsed, logs warning and falls back to agent defaults instead of hard-erroring. Skill-filter test discarded (skills gutted). CHANGELOG.md discarded.