### PR TITLE
Cherry-pick 1e7ec8bfd: fix(routing): preserve explicit cron account routing

### DIFF
--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -54,4 +54,22 @@ describe("resolveCronDeliveryPlan", () => {
     expect(plan.channel).toBeUndefined();
     expect(plan.to).toBe("https://example.invalid/cron");
   });
+
+  it("threads delivery.accountId when explicitly configured", () => {
+    const plan = resolveCronDeliveryPlan(
+      makeJob({
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "123",
+          accountId: " bot-a ",
+        },
+      }),
+    );
+    expect(plan.mode).toBe("announce");
+    expect(plan.requested).toBe(true);
+    expect(plan.channel).toBe("telegram");
+    expect(plan.to).toBe("123");
+    expect(plan.accountId).toBe("bot-a");
+  });
 });

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -4,6 +4,7 @@ export type CronDeliveryPlan = {
   mode: CronDeliveryMode;
   channel?: CronMessageChannel;
   to?: string;
+  accountId?: string;
   source: "delivery" | "payload";
   requested: boolean;
 };
@@ -20,6 +21,14 @@ function normalizeChannel(value: unknown): CronMessageChannel | undefined {
 }
 
 function normalizeTo(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeAccountId(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
   }
@@ -50,6 +59,9 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
     (delivery as { channel?: unknown } | undefined)?.channel,
   );
   const deliveryTo = normalizeTo((delivery as { to?: unknown } | undefined)?.to);
+  const deliveryAccountId = normalizeAccountId(
+    (delivery as { accountId?: unknown } | undefined)?.accountId,
+  );
 
   const channel = deliveryChannel ?? payloadChannel ?? "last";
   const to = deliveryTo ?? payloadTo;
@@ -59,6 +71,7 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
       mode: resolvedMode,
       channel: resolvedMode === "announce" ? channel : undefined,
       to,
+      accountId: deliveryAccountId,
       source: "delivery",
       requested: resolvedMode === "announce",
     };

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -299,4 +299,39 @@ describe("resolveDeliveryTarget", () => {
     expect(result.to).toBe("987654");
     expect(result.ok).toBe(true);
   });
+
+  it("explicit delivery.accountId overrides session-derived accountId", async () => {
+    setMainSessionEntry({
+      sessionId: "sess-5",
+      updatedAt: 1000,
+      lastChannel: "telegram",
+      lastTo: "chat-999",
+      lastAccountId: "default",
+    });
+
+    const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
+      channel: "telegram",
+      to: "chat-999",
+      accountId: "bot-b",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.accountId).toBe("bot-b");
+  });
+
+  it("explicit delivery.accountId overrides bindings-derived accountId", async () => {
+    setMainSessionEntry(undefined);
+    const cfg = makeCfg({
+      bindings: [{ agentId: AGENT_ID, match: { channel: "telegram", accountId: "bound" } }],
+    });
+
+    const result = await resolveDeliveryTarget(cfg, AGENT_ID, {
+      channel: "telegram",
+      to: "chat-777",
+      accountId: "explicit",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.accountId).toBe("explicit");
+  });
 });

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -43,6 +43,7 @@ export async function resolveDeliveryTarget(
     channel?: "last" | ChannelId;
     to?: string;
     sessionKey?: string;
+    accountId?: string;
   },
 ): Promise<DeliveryTargetResolution> {
   const requestedChannel = typeof jobPayload.channel === "string" ? jobPayload.channel : "last";
@@ -112,6 +113,11 @@ export async function resolveDeliveryTarget(
     if (boundAccounts && boundAccounts.length > 0) {
       accountId = boundAccounts[0];
     }
+  }
+
+  // Explicit delivery account should override inferred session/binding account.
+  if (jobPayload.accountId) {
+    accountId = jobPayload.accountId;
   }
 
   // Carry threadId when it was explicitly set (from :topic: parsing or config)

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -272,6 +272,7 @@ export async function runCronIsolatedAgentTurn(params: {
     channel: deliveryPlan.channel ?? "last",
     to: deliveryPlan.to,
     sessionKey: params.job.sessionKey,
+    accountId: deliveryPlan.accountId,
   });
 
   const { formattedTime, timeLine } = resolveCronStyleNow(params.cfg, now);

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -22,6 +22,7 @@ export type CronDelivery = {
   mode: CronDeliveryMode;
   channel?: CronMessageChannel;
   to?: string;
+  accountId?: string;
   bestEffort?: boolean;
 };
 

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -138,6 +138,7 @@ export const CronPayloadPatchSchema = Type.Union([
 
 const CronDeliverySharedProperties = {
   channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString])),
+  accountId: Type.Optional(NonEmptyString),
   bestEffort: Type.Optional(Type.Boolean()),
 };
 

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -831,4 +831,32 @@ describe("runMessageAction accountId defaults", () => {
     expect(ctx.accountId).toBe("ops");
     expect(ctx.params.accountId).toBe("ops");
   });
+
+  it("falls back to the agent's bound account when accountId is omitted", async () => {
+    await runMessageAction({
+      cfg: {
+        bindings: [{ agentId: "agent-b", match: { channel: "discord", accountId: "account-b" } }],
+      } as OpenClawConfig,
+      action: "send",
+      params: {
+        channel: "discord",
+        target: "channel:123",
+        message: "hi",
+      },
+      agentId: "agent-b",
+    });
+
+    expect(handleAction).toHaveBeenCalled();
+    const ctx = (handleAction.mock.calls as unknown as Array<[unknown]>)[0]?.[0] as
+      | {
+          accountId?: string | null;
+          params: Record<string, unknown>;
+        }
+      | undefined;
+    if (!ctx) {
+      throw new Error("expected action context");
+    }
+    expect(ctx.accountId).toBe("account-b");
+    expect(ctx.params.accountId).toBe("account-b");
+  });
 });

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -13,6 +13,8 @@ import type {
 } from "../../channels/plugins/types.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
+import { buildChannelAccountBindings } from "../../routing/bindings.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 import type { AgentToolResult } from "../../types/agent-types.js";
 import {
   isDeliverableMessageChannel,
@@ -750,7 +752,14 @@ export async function runMessageAction(
   }
 
   const channel = await resolveChannel(cfg, params);
-  const accountId = readStringParam(params, "accountId") ?? input.defaultAccountId;
+  let accountId = readStringParam(params, "accountId") ?? input.defaultAccountId;
+  if (!accountId && resolvedAgentId) {
+    const byAgent = buildChannelAccountBindings(cfg).get(channel);
+    const boundAccountIds = byAgent?.get(normalizeAgentId(resolvedAgentId));
+    if (boundAccountIds && boundAccountIds.length > 0) {
+      accountId = boundAccountIds[0];
+    }
+  }
   if (accountId) {
     params.accountId = accountId;
   }


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: 1e7ec8bfd2
**Author**: Peter Steinberger <steipete@gmail.com>
**Tier**: AUTO-PARTIAL

> fix(routing): preserve explicit cron account and bound message defaults

CHANGELOG.md discarded (gutted layer). Import conflict resolved (union merge — both fork and upstream additions kept).