### PR TITLE
Cherry-pick e915b4c64: refactor: unify monitor abort lifecycle handling

### DIFF
--- a/src/discord/monitor/gateway-error-guard.test.ts
+++ b/src/discord/monitor/gateway-error-guard.test.ts
@@ -1,0 +1,33 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { attachEarlyGatewayErrorGuard } from "./gateway-error-guard.js";
+
+describe("attachEarlyGatewayErrorGuard", () => {
+  it("captures gateway errors until released", () => {
+    const emitter = new EventEmitter();
+    const fallbackErrorListener = vi.fn();
+    emitter.on("error", fallbackErrorListener);
+    const client = {
+      getPlugin: vi.fn(() => ({ emitter })),
+    };
+
+    const guard = attachEarlyGatewayErrorGuard(client as never);
+    emitter.emit("error", new Error("Fatal Gateway error: 4014"));
+    expect(guard.pendingErrors).toHaveLength(1);
+
+    guard.release();
+    emitter.emit("error", new Error("Fatal Gateway error: 4000"));
+    expect(guard.pendingErrors).toHaveLength(1);
+    expect(fallbackErrorListener).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns noop guard when gateway emitter is unavailable", () => {
+    const client = {
+      getPlugin: vi.fn(() => undefined),
+    };
+
+    const guard = attachEarlyGatewayErrorGuard(client as never);
+    expect(guard.pendingErrors).toEqual([]);
+    expect(() => guard.release()).not.toThrow();
+  });
+});

--- a/src/discord/monitor/gateway-error-guard.ts
+++ b/src/discord/monitor/gateway-error-guard.ts
@@ -1,0 +1,36 @@
+import type { Client } from "@buape/carbon";
+import { getDiscordGatewayEmitter } from "../monitor.gateway.js";
+
+export type EarlyGatewayErrorGuard = {
+  pendingErrors: unknown[];
+  release: () => void;
+};
+
+export function attachEarlyGatewayErrorGuard(client: Client): EarlyGatewayErrorGuard {
+  const pendingErrors: unknown[] = [];
+  const gateway = client.getPlugin("gateway");
+  const emitter = getDiscordGatewayEmitter(gateway);
+  if (!emitter) {
+    return {
+      pendingErrors,
+      release: () => {},
+    };
+  }
+
+  let released = false;
+  const onGatewayError = (err: unknown) => {
+    pendingErrors.push(err);
+  };
+  emitter.on("error", onGatewayError);
+
+  return {
+    pendingErrors,
+    release: () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      emitter.removeListener("error", onGatewayError);
+    },
+  };
+}

--- a/src/infra/abort-signal.test.ts
+++ b/src/infra/abort-signal.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { waitForAbortSignal } from "./abort-signal.js";
+
+describe("waitForAbortSignal", () => {
+  it("resolves immediately when signal is missing", async () => {
+    await expect(waitForAbortSignal(undefined)).resolves.toBeUndefined();
+  });
+
+  it("resolves immediately when signal is already aborted", async () => {
+    const abort = new AbortController();
+    abort.abort();
+    await expect(waitForAbortSignal(abort.signal)).resolves.toBeUndefined();
+  });
+
+  it("waits until abort fires", async () => {
+    const abort = new AbortController();
+    let resolved = false;
+
+    const task = waitForAbortSignal(abort.signal).then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    abort.abort();
+    await task;
+    expect(resolved).toBe(true);
+  });
+});

--- a/src/infra/abort-signal.ts
+++ b/src/infra/abort-signal.ts
@@ -1,0 +1,12 @@
+export async function waitForAbortSignal(signal?: AbortSignal): Promise<void> {
+  if (!signal || signal.aborted) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/src/line/monitor.lifecycle.test.ts
+++ b/src/line/monitor.lifecycle.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+
+const { createLineBotMock, registerPluginHttpRouteMock, unregisterHttpMock } = vi.hoisted(() => ({
+  createLineBotMock: vi.fn(() => ({
+    account: { accountId: "default" },
+    handleWebhook: vi.fn(),
+  })),
+  registerPluginHttpRouteMock: vi.fn(),
+  unregisterHttpMock: vi.fn(),
+}));
+
+vi.mock("./bot.js", () => ({
+  createLineBot: createLineBotMock,
+}));
+
+vi.mock("../plugins/http-path.js", () => ({
+  normalizePluginHttpPath: (_path: string | undefined, fallback: string) => fallback,
+}));
+
+vi.mock("../plugins/http-registry.js", () => ({
+  registerPluginHttpRoute: registerPluginHttpRouteMock,
+}));
+
+vi.mock("./webhook-node.js", () => ({
+  createLineNodeWebhookHandler: vi.fn(() => vi.fn()),
+}));
+
+describe("monitorLineProvider lifecycle", () => {
+  beforeEach(() => {
+    createLineBotMock.mockClear();
+    unregisterHttpMock.mockClear();
+    registerPluginHttpRouteMock.mockClear().mockReturnValue(unregisterHttpMock);
+  });
+
+  it("waits for abort before resolving", async () => {
+    const { monitorLineProvider } = await import("./monitor.js");
+    const abort = new AbortController();
+    let resolved = false;
+
+    const task = monitorLineProvider({
+      channelAccessToken: "token",
+      channelSecret: "secret",
+      config: {} as OpenClawConfig,
+      runtime: {} as RuntimeEnv,
+      abortSignal: abort.signal,
+    }).then((monitor) => {
+      resolved = true;
+      return monitor;
+    });
+
+    await vi.waitFor(() => expect(registerPluginHttpRouteMock).toHaveBeenCalledTimes(1));
+    expect(resolved).toBe(false);
+
+    abort.abort();
+    await task;
+    expect(unregisterHttpMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops immediately when signal is already aborted", async () => {
+    const { monitorLineProvider } = await import("./monitor.js");
+    const abort = new AbortController();
+    abort.abort();
+
+    await monitorLineProvider({
+      channelAccessToken: "token",
+      channelSecret: "secret",
+      config: {} as OpenClawConfig,
+      runtime: {} as RuntimeEnv,
+      abortSignal: abort.signal,
+    });
+
+    expect(unregisterHttpMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns immediately without abort signal and stop is idempotent", async () => {
+    const { monitorLineProvider } = await import("./monitor.js");
+
+    const monitor = await monitorLineProvider({
+      channelAccessToken: "token",
+      channelSecret: "secret",
+      config: {} as OpenClawConfig,
+      runtime: {} as RuntimeEnv,
+    });
+
+    expect(unregisterHttpMock).not.toHaveBeenCalled();
+    monitor.stop();
+    monitor.stop();
+    expect(unregisterHttpMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/line/monitor.ts
+++ b/src/line/monitor.ts
@@ -4,6 +4,7 @@ import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/pr
 import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { danger, logVerbose } from "../globals.js";
+import { waitForAbortSignal } from "../infra/abort-signal.js";
 import { normalizePluginHttpPath } from "../plugins/http-path.js";
 import { registerPluginHttpRoute } from "../plugins/http-registry.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -296,7 +297,12 @@ export async function monitorLineProvider(
   logVerbose(`line: registered webhook handler at ${normalizedPath}`);
 
   // Handle abort signal
+  let stopped = false;
   const stopHandler = () => {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
     logVerbose(`line: stopping provider for account ${resolvedAccountId}`);
     unregisterHttp();
     recordChannelRuntimeState({
@@ -309,7 +315,12 @@ export async function monitorLineProvider(
     });
   };
 
-  abortSignal?.addEventListener("abort", stopHandler);
+  if (abortSignal?.aborted) {
+    stopHandler();
+  } else if (abortSignal) {
+    abortSignal.addEventListener("abort", stopHandler, { once: true });
+    await waitForAbortSignal(abortSignal);
+  }
 
   return {
     account: bot.account,

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { monitorTelegramProvider } from "./monitor.js";
 
 type MockCtx = {
@@ -130,19 +130,30 @@ vi.mock("../auto-reply/reply.js", () => ({
 }));
 
 describe("monitorTelegramProvider (grammY)", () => {
+  let consoleErrorSpy: { mockRestore: () => void } | undefined;
+
   beforeEach(() => {
     loadConfig.mockReturnValue({
       agents: { defaults: { maxConcurrent: 2 } },
       channels: { telegram: {} },
     });
     initSpy.mockClear();
-    runSpy.mockClear();
+    runSpy.mockReset().mockImplementation(() =>
+      makeRunnerStub({
+        task: () => Promise.reject(new Error("runSpy called without explicit test stub")),
+      }),
+    );
     computeBackoff.mockClear();
     sleepWithAbort.mockClear();
     startTelegramWebhookSpy.mockClear();
     registerUnhandledRejectionHandlerMock.mockClear();
     resetUnhandledRejection();
     createTelegramBotErrors.length = 0;
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy?.mockRestore();
   });
 
   it("processes a DM and sends reply", async () => {

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -2,6 +2,7 @@ import { type RunOptions, run } from "@grammyjs/runner";
 import { resolveAgentMaxConcurrent } from "../config/agent-limits.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
+import { waitForAbortSignal } from "../infra/abort-signal.js";
 import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatDurationPrecise } from "../infra/format-time/format-duration.ts";
@@ -169,16 +170,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         abortSignal: opts.abortSignal,
         publicUrl: opts.webhookUrl,
       });
-      const abortSignal = opts.abortSignal;
-      if (abortSignal && !abortSignal.aborted) {
-        await new Promise<void>((resolve) => {
-          const onAbort = () => {
-            abortSignal.removeEventListener("abort", onAbort);
-            resolve();
-          };
-          abortSignal.addEventListener("abort", onAbort, { once: true });
-        });
-      }
+      await waitForAbortSignal(opts.abortSignal);
       return;
     }
 


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: e915b4c64a
**Author**: Peter Steinberger <steipete@gmail.com>
**Tier**: HUMAN-REVIEW

> refactor: unify monitor abort lifecycle handling

**Partial pick**: skipped `scripts/pr` (score 2) and `changelog/fragments/README` (score 6).

**Conflicts resolved**:
- Line extension test: convergent (fork already removed abort-await + extra tests)
- Line extension channel.ts: convergent (fork already returns directly without abort-await)
- Discord provider.ts: exec-approvals import stays removed (gutted in fork), unused `attachEarlyGatewayErrorGuard` import dropped (no call site in fork)

**Files added**: `gateway-error-guard.ts` (+ test), `abort-signal.ts` (+ test), `monitor.lifecycle.test.ts`
**Files modified**: `monitor.ts` (line, telegram), `monitor.test.ts` (telegram)