### PR TITLE
Cherry-pick f9c3fdb: refactor(android): expose voice conversation state to viewmodel

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/MainViewModel.kt
@@ -8,6 +8,7 @@ import org.remoteclaw.android.node.CameraCaptureManager
 import org.remoteclaw.android.node.CanvasController
 import org.remoteclaw.android.node.ScreenRecordManager
 import org.remoteclaw.android.node.SmsManager
+import org.remoteclaw.android.voice.VoiceConversationEntry
 import kotlinx.coroutines.flow.StateFlow
 
 class MainViewModel(app: Application) : AndroidViewModel(app) {
@@ -45,14 +46,14 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val locationMode: StateFlow<LocationMode> = runtime.locationMode
   val locationPreciseEnabled: StateFlow<Boolean> = runtime.locationPreciseEnabled
   val preventSleep: StateFlow<Boolean> = runtime.preventSleep
-  val wakeWords: StateFlow<List<String>> = runtime.wakeWords
-  val voiceWakeMode: StateFlow<VoiceWakeMode> = runtime.voiceWakeMode
-  val voiceWakeStatusText: StateFlow<String> = runtime.voiceWakeStatusText
-  val voiceWakeIsListening: StateFlow<Boolean> = runtime.voiceWakeIsListening
-  val talkEnabled: StateFlow<Boolean> = runtime.talkEnabled
-  val talkStatusText: StateFlow<String> = runtime.talkStatusText
-  val talkIsListening: StateFlow<Boolean> = runtime.talkIsListening
-  val talkIsSpeaking: StateFlow<Boolean> = runtime.talkIsSpeaking
+  val micEnabled: StateFlow<Boolean> = runtime.micEnabled
+  val micStatusText: StateFlow<String> = runtime.micStatusText
+  val micLiveTranscript: StateFlow<String?> = runtime.micLiveTranscript
+  val micIsListening: StateFlow<Boolean> = runtime.micIsListening
+  val micQueuedMessages: StateFlow<List<String>> = runtime.micQueuedMessages
+  val micConversation: StateFlow<List<VoiceConversationEntry>> = runtime.micConversation
+  val micInputLevel: StateFlow<Float> = runtime.micInputLevel
+  val micIsSending: StateFlow<Boolean> = runtime.micIsSending
   val manualEnabled: StateFlow<Boolean> = runtime.manualEnabled
   val manualHost: StateFlow<String> = runtime.manualHost
   val manualPort: StateFlow<Int> = runtime.manualPort
@@ -66,6 +67,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val chatMessages = runtime.chatMessages
   val chatError: StateFlow<String?> = runtime.chatError
   val chatHealthOk: StateFlow<Boolean> = runtime.chatHealthOk
+  val chatThinkingLevel: StateFlow<String> = runtime.chatThinkingLevel
   val chatStreamingAssistantText: StateFlow<String?> = runtime.chatStreamingAssistantText
   val chatPendingToolCalls = runtime.chatPendingToolCalls
   val chatSessions = runtime.chatSessions
@@ -127,24 +129,8 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     runtime.setCanvasDebugStatusEnabled(value)
   }
 
-  fun setWakeWords(words: List<String>) {
-    runtime.setWakeWords(words)
-  }
-
-  fun resetWakeWordsDefaults() {
-    runtime.resetWakeWordsDefaults()
-  }
-
-  fun setVoiceWakeMode(mode: VoiceWakeMode) {
-    runtime.setVoiceWakeMode(mode)
-  }
-
-  fun setTalkEnabled(enabled: Boolean) {
-    runtime.setTalkEnabled(enabled)
-  }
-
-  fun logGatewayDebugSnapshot(source: String = "manual") {
-    runtime.logGatewayDebugSnapshot(source)
+  fun setMicEnabled(enabled: Boolean) {
+    runtime.setMicEnabled(enabled)
   }
 
   fun refreshGatewayConnection() {
@@ -191,6 +177,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     runtime.refreshChatSessions(limit = limit)
   }
 
+  fun setChatThinkingLevel(level: String) {
+    runtime.setChatThinkingLevel(level)
+  }
+
   fun switchChatSession(sessionKey: String) {
     runtime.switchChatSession(sessionKey)
   }
@@ -199,7 +189,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     runtime.abortChat()
   }
 
-  fun sendChat(message: String, attachments: List<OutgoingAttachment>) {
-    runtime.sendChat(message = message, attachments = attachments)
+  fun sendChat(message: String, thinking: String, attachments: List<OutgoingAttachment>) {
+    runtime.sendChat(message = message, thinking = thinking, attachments = attachments)
   }
 }

--- a/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
@@ -18,9 +18,9 @@ import org.remoteclaw.android.gateway.GatewayEndpoint
 import org.remoteclaw.android.gateway.GatewaySession
 import org.remoteclaw.android.gateway.probeGatewayTlsFingerprint
 import org.remoteclaw.android.node.*
-import org.remoteclaw.android.protocol.RemoteClawCanvasA2UIAction
-import org.remoteclaw.android.voice.TalkModeManager
-import org.remoteclaw.android.voice.VoiceWakeManager
+import org.remoteclaw.android.protocol.OpenClawCanvasA2UIAction
+import org.remoteclaw.android.voice.MicCaptureManager
+import org.remoteclaw.android.voice.VoiceConversationEntry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -37,6 +37,7 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 
 class NodeRuntime(context: Context) {
@@ -53,39 +54,6 @@ class NodeRuntime(context: Context) {
   private val json = Json { ignoreUnknownKeys = true }
 
   private val externalAudioCaptureActive = MutableStateFlow(false)
-
-  private val voiceWake: VoiceWakeManager by lazy {
-    VoiceWakeManager(
-      context = appContext,
-      scope = scope,
-      onCommand = { command ->
-        nodeSession.sendNodeEvent(
-          event = "agent.request",
-          payloadJson =
-            buildJsonObject {
-              put("message", JsonPrimitive(command))
-              put("sessionKey", JsonPrimitive(resolveMainSessionKey()))
-              put("deliver", JsonPrimitive(false))
-            }.toString(),
-        )
-      },
-    )
-  }
-
-  val voiceWakeIsListening: StateFlow<Boolean>
-    get() = voiceWake.isListening
-
-  val voiceWakeStatusText: StateFlow<String>
-    get() = voiceWake.statusText
-
-  val talkStatusText: StateFlow<String>
-    get() = talkMode.statusText
-
-  val talkIsListening: StateFlow<Boolean>
-    get() = talkMode.isListening
-
-  val talkIsSpeaking: StateFlow<Boolean>
-    get() = talkMode.isSpeaking
 
   private val discovery = GatewayDiscovery(appContext, scope = scope)
   val gateways: StateFlow<List<GatewayEndpoint>> = discovery.gateways
@@ -145,7 +113,7 @@ class NodeRuntime(context: Context) {
     prefs = prefs,
     cameraEnabled = { cameraEnabled.value },
     locationMode = { locationMode.value },
-    voiceWakeMode = { voiceWakeMode.value },
+    voiceWakeMode = { VoiceWakeMode.Off },
     smsAvailable = { sms.canSendSms() },
     hasRecordAudioPermission = { hasRecordAudioPermission() },
     manualTls = { manualTls.value },
@@ -170,8 +138,6 @@ class NodeRuntime(context: Context) {
     },
     onCanvasA2uiReset = { _canvasA2uiHydrated.value = false },
   )
-
-  private lateinit var gatewayEventHandler: GatewayEventHandler
 
   data class GatewayTrustPrompt(
     val endpoint: GatewayEndpoint,
@@ -241,8 +207,8 @@ class NodeRuntime(context: Context) {
         _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
         applyMainSessionKey(mainSessionKey)
         updateStatus()
+        micCapture.onGatewayConnectionChanged(true)
         scope.launch { refreshBrandingFromGateway() }
-        scope.launch { gatewayEventHandler.refreshWakeWordsFromGateway() }
       },
       onDisconnected = { message ->
         operatorConnected = false
@@ -253,11 +219,10 @@ class NodeRuntime(context: Context) {
         if (!isCanonicalMainSessionKey(_mainSessionKey.value)) {
           _mainSessionKey.value = "main"
         }
-        val mainKey = resolveMainSessionKey()
-        talkMode.setMainSessionKey(mainKey)
-        chat.applyMainSessionKey(mainKey)
+        chat.applyMainSessionKey(resolveMainSessionKey())
         chat.onDisconnected(message)
         updateStatus()
+        micCapture.onGatewayConnectionChanged(false)
       },
       onEvent = { event, payloadJson ->
         handleGatewayEvent(event, payloadJson)
@@ -306,34 +271,74 @@ class NodeRuntime(context: Context) {
       json = json,
       supportsChatSubscribe = false,
     )
-  private val talkMode: TalkModeManager by lazy {
-    TalkModeManager(
+  private val micCapture: MicCaptureManager by lazy {
+    MicCaptureManager(
       context = appContext,
       scope = scope,
-      session = operatorSession,
-      supportsChatSubscribe = false,
-      isConnected = { operatorConnected },
+      sendToGateway = { message ->
+        val idempotencyKey = UUID.randomUUID().toString()
+        val params =
+          buildJsonObject {
+            put("sessionKey", JsonPrimitive(resolveMainSessionKey()))
+            put("message", JsonPrimitive(message))
+            put("thinking", JsonPrimitive(chatThinkingLevel.value))
+            put("timeoutMs", JsonPrimitive(30_000))
+            put("idempotencyKey", JsonPrimitive(idempotencyKey))
+          }
+        val response = operatorSession.request("chat.send", params.toString())
+        parseChatSendRunId(response) ?: idempotencyKey
+      },
     )
   }
+
+  val micStatusText: StateFlow<String>
+    get() = micCapture.statusText
+
+  val micLiveTranscript: StateFlow<String?>
+    get() = micCapture.liveTranscript
+
+  val micIsListening: StateFlow<Boolean>
+    get() = micCapture.isListening
+
+  val micEnabled: StateFlow<Boolean>
+    get() = micCapture.micEnabled
+
+  val micQueuedMessages: StateFlow<List<String>>
+    get() = micCapture.queuedMessages
+
+  val micConversation: StateFlow<List<VoiceConversationEntry>>
+    get() = micCapture.conversation
+
+  val micInputLevel: StateFlow<Float>
+    get() = micCapture.inputLevel
+
+  val micIsSending: StateFlow<Boolean>
+    get() = micCapture.isSending
 
   private fun applyMainSessionKey(candidate: String?) {
     val trimmed = normalizeMainKey(candidate) ?: return
     if (isCanonicalMainSessionKey(_mainSessionKey.value)) return
     if (_mainSessionKey.value == trimmed) return
     _mainSessionKey.value = trimmed
-    talkMode.setMainSessionKey(trimmed)
     chat.applyMainSessionKey(trimmed)
   }
 
   private fun updateStatus() {
     _isConnected.value = operatorConnected
+    val operator = operatorStatusText.trim()
+    val node = nodeStatusText.trim()
     _statusText.value =
       when {
         operatorConnected && _nodeConnected.value -> "Connected"
         operatorConnected && !_nodeConnected.value -> "Connected (node offline)"
-        !operatorConnected && _nodeConnected.value -> "Connected (operator offline)"
-        operatorStatusText.isNotBlank() && operatorStatusText != "Offline" -> operatorStatusText
-        else -> nodeStatusText
+        !operatorConnected && _nodeConnected.value ->
+          if (operator.isNotEmpty() && operator != "Offline") {
+            "Connected (operator: $operator)"
+          } else {
+            "Connected (operator offline)"
+          }
+        operator.isNotBlank() && operator != "Offline" -> operator
+        else -> node
       }
   }
 
@@ -384,6 +389,7 @@ class NodeRuntime(context: Context) {
             buildJsonObject {
               put("message", JsonPrimitive(prompt))
               put("sessionKey", JsonPrimitive(sessionKey))
+              put("thinking", JsonPrimitive("low"))
               put("deliver", JsonPrimitive(false))
             }.toString(),
         )
@@ -395,7 +401,7 @@ class NodeRuntime(context: Context) {
           _canvasRehydratePending.value = false
           _canvasRehydrateErrorText.value = "Failed to request restore. Tap to retry."
         }
-        Log.w("RemoteClawCanvas", "canvas rehydrate request failed ($source): transport unavailable")
+        Log.w("OpenClawCanvas", "canvas rehydrate request failed ($source): transport unavailable")
         return@launch
       }
       scope.launch {
@@ -415,9 +421,6 @@ class NodeRuntime(context: Context) {
   val locationMode: StateFlow<LocationMode> = prefs.locationMode
   val locationPreciseEnabled: StateFlow<Boolean> = prefs.locationPreciseEnabled
   val preventSleep: StateFlow<Boolean> = prefs.preventSleep
-  val wakeWords: StateFlow<List<String>> = prefs.wakeWords
-  val voiceWakeMode: StateFlow<VoiceWakeMode> = prefs.voiceWakeMode
-  val talkEnabled: StateFlow<Boolean> = prefs.talkEnabled
   val manualEnabled: StateFlow<Boolean> = prefs.manualEnabled
   val manualHost: StateFlow<String> = prefs.manualHost
   val manualPort: StateFlow<Int> = prefs.manualPort
@@ -437,56 +440,20 @@ class NodeRuntime(context: Context) {
   val chatMessages: StateFlow<List<ChatMessage>> = chat.messages
   val chatError: StateFlow<String?> = chat.errorText
   val chatHealthOk: StateFlow<Boolean> = chat.healthOk
+  val chatThinkingLevel: StateFlow<String> = chat.thinkingLevel
   val chatStreamingAssistantText: StateFlow<String?> = chat.streamingAssistantText
   val chatPendingToolCalls: StateFlow<List<ChatPendingToolCall>> = chat.pendingToolCalls
   val chatSessions: StateFlow<List<ChatSessionEntry>> = chat.sessions
   val pendingRunCount: StateFlow<Int> = chat.pendingRunCount
 
   init {
-    gatewayEventHandler = GatewayEventHandler(
-      scope = scope,
-      prefs = prefs,
-      json = json,
-      operatorSession = operatorSession,
-      isConnected = { _isConnected.value },
-    )
-
-    scope.launch {
-      combine(
-        voiceWakeMode,
-        isForeground,
-        externalAudioCaptureActive,
-        wakeWords,
-      ) { mode, foreground, externalAudio, words ->
-        Quad(mode, foreground, externalAudio, words)
-      }.distinctUntilChanged()
-        .collect { (mode, foreground, externalAudio, words) ->
-          voiceWake.setTriggerWords(words)
-
-          val shouldListen =
-            when (mode) {
-              VoiceWakeMode.Off -> false
-              VoiceWakeMode.Foreground -> foreground
-              VoiceWakeMode.Always -> true
-            } && !externalAudio
-
-          if (!shouldListen) {
-            voiceWake.stop(statusText = if (mode == VoiceWakeMode.Off) "Off" else "Paused")
-            return@collect
-          }
-
-          if (!hasRecordAudioPermission()) {
-            voiceWake.stop(statusText = "Microphone permission required")
-            return@collect
-          }
-
-          voiceWake.start()
-        }
+    if (prefs.voiceWakeMode.value != VoiceWakeMode.Off) {
+      prefs.setVoiceWakeMode(VoiceWakeMode.Off)
     }
 
     scope.launch {
-      talkEnabled.collect { enabled ->
-        talkMode.setEnabled(enabled)
+      prefs.talkEnabled.collect { enabled ->
+        micCapture.setMicEnabled(enabled)
         externalAudioCaptureActive.value = enabled
       }
     }
@@ -594,34 +561,18 @@ class NodeRuntime(context: Context) {
     prefs.setCanvasDebugStatusEnabled(value)
   }
 
-  fun setWakeWords(words: List<String>) {
-    prefs.setWakeWords(words)
-    gatewayEventHandler.scheduleWakeWordsSyncIfNeeded()
-  }
-
-  fun resetWakeWordsDefaults() {
-    setWakeWords(SecurePrefs.defaultWakeWords)
-  }
-
-  fun setVoiceWakeMode(mode: VoiceWakeMode) {
-    prefs.setVoiceWakeMode(mode)
-  }
-
-  fun setTalkEnabled(value: Boolean) {
+  fun setMicEnabled(value: Boolean) {
     prefs.setTalkEnabled(value)
   }
 
-  fun logGatewayDebugSnapshot(source: String = "manual") {
-    val flowToken = gatewayToken.value.trim()
-    val loadedToken = prefs.loadGatewayToken().orEmpty()
-    Log.i(
-      "RemoteClawGatewayDebug",
-      "source=$source manualEnabled=${manualEnabled.value} host=${manualHost.value} port=${manualPort.value} tls=${manualTls.value} flowTokenLen=${flowToken.length} loadTokenLen=${loadedToken.length} connected=${isConnected.value} status=${statusText.value}",
-    )
-  }
-
   fun refreshGatewayConnection() {
-    val endpoint = connectedEndpoint ?: return
+    val endpoint =
+      connectedEndpoint ?: run {
+        _statusText.value = "Failed: no cached gateway endpoint"
+        return
+      }
+    operatorStatusText = "Connecting…"
+    updateStatus()
     val token = prefs.loadGatewayToken()
     val password = prefs.loadGatewayPassword()
     val tls = connectionManager.resolveTlsParams(endpoint)
@@ -708,7 +659,7 @@ class NodeRuntime(context: Context) {
       val actionId = (userActionObj["id"] as? JsonPrimitive)?.content?.trim().orEmpty().ifEmpty {
         java.util.UUID.randomUUID().toString()
       }
-      val name = RemoteClawCanvasA2UIAction.extractActionName(userActionObj) ?: return@launch
+      val name = OpenClawCanvasA2UIAction.extractActionName(userActionObj) ?: return@launch
 
       val surfaceId =
         (userActionObj["surfaceId"] as? JsonPrimitive)?.content?.trim().orEmpty().ifEmpty { "main" }
@@ -718,7 +669,7 @@ class NodeRuntime(context: Context) {
 
       val sessionKey = resolveMainSessionKey()
       val message =
-        RemoteClawCanvasA2UIAction.formatAgentMessage(
+        OpenClawCanvasA2UIAction.formatAgentMessage(
           actionName = name,
           sessionKey = sessionKey,
           surfaceId = surfaceId,
@@ -738,6 +689,7 @@ class NodeRuntime(context: Context) {
               buildJsonObject {
                 put("message", JsonPrimitive(message))
                 put("sessionKey", JsonPrimitive(sessionKey))
+                put("thinking", JsonPrimitive("low"))
                 put("deliver", JsonPrimitive(false))
                 put("key", JsonPrimitive(actionId))
               }.toString(),
@@ -751,7 +703,7 @@ class NodeRuntime(context: Context) {
 
       try {
         canvas.eval(
-          RemoteClawCanvasA2UIAction.jsDispatchA2UIActionStatus(
+          OpenClawCanvasA2UIAction.jsDispatchA2UIActionStatus(
             actionId = actionId,
             ok = connected && error == null,
             error = error,
@@ -776,6 +728,10 @@ class NodeRuntime(context: Context) {
     chat.refreshSessions(limit = limit)
   }
 
+  fun setChatThinkingLevel(level: String) {
+    chat.setThinkingLevel(level)
+  }
+
   fun switchChatSession(sessionKey: String) {
     chat.switchSession(sessionKey)
   }
@@ -784,18 +740,22 @@ class NodeRuntime(context: Context) {
     chat.abort()
   }
 
-  fun sendChat(message: String, attachments: List<OutgoingAttachment>) {
-    chat.sendMessage(message = message, attachments = attachments)
+  fun sendChat(message: String, thinking: String, attachments: List<OutgoingAttachment>) {
+    chat.sendMessage(message = message, thinkingLevel = thinking, attachments = attachments)
   }
 
   private fun handleGatewayEvent(event: String, payloadJson: String?) {
-    if (event == "voicewake.changed") {
-      gatewayEventHandler.handleVoiceWakeChangedEvent(payloadJson)
-      return
-    }
-
-    talkMode.handleGatewayEvent(event, payloadJson)
+    micCapture.handleGatewayEvent(event, payloadJson)
     chat.handleGatewayEvent(event, payloadJson)
+  }
+
+  private fun parseChatSendRunId(response: String): String? {
+    return try {
+      val root = json.parseToJsonElement(response).asObjectOrNull() ?: return null
+      root["runId"].asStringOrNull()
+    } catch (_: Throwable) {
+      null
+    }
   }
 
   private suspend fun refreshBrandingFromGateway() {


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: f9c3fdba458ebf8aac9502df11afa50f5cd0b046
**Author**: Ayaan Zaidi <zaidi@uplause.io>
**Tier**: FAST-PICK

> refactor(android): expose voice conversation state to viewmodel

**Conflict resolution**: UU on MainViewModel.kt and NodeRuntime.kt — package path divergence (ai.openclaw → org.remoteclaw rebrand). Took upstream content with fork package paths. Also replaced legacy voice wake fields with upstream mic fields.