### PR TITLE
Cherry-pick f729cc7: fix(android): stop auto canvas rehydrate on node connect

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
@@ -278,7 +278,6 @@ class NodeRuntime(context: Context) {
         _canvasRehydrateErrorText.value = null
         updateStatus()
         maybeNavigateToA2uiOnConnect()
-        requestCanvasRehydrate(source = "node_connect", force = false)
       },
       onDisconnected = { message ->
         _nodeConnected.value = false


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: f729cc7b078f17ca4137e92a8d19d65a899bdeca
**Author**: Ayaan Zaidi <zaidi@uplause.io>
**Tier**: FAST-PICK

> fix(android): stop auto canvas rehydrate on node connect