### PR TITLE
Cherry-pick 470c606: refactor(telegram): remove dmPolicy from group allow context helper

### DIFF
--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -168,7 +168,6 @@ async function resolveTelegramCommandAuth(params: {
   const groupAllowContext = await resolveTelegramGroupAllowFromContext({
     chatId,
     accountId,
-    dmPolicy: telegramCfg.dmPolicy ?? "pairing",
     isForum,
     messageThreadId,
     groupAllowFrom,

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -20,7 +20,6 @@ export type TelegramThreadSpec = {
 export async function resolveTelegramGroupAllowFromContext(params: {
   chatId: string | number;
   accountId?: string;
-  dmPolicy?: string;
   isForum?: boolean;
   messageThreadId?: number | null;
   groupAllowFrom?: Array<string | number>;


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: 470c606dac
**Author**: Ayaan Zaidi <zaidi@uplause.io>
**Tier**: HUMAN-REVIEW (conflict resolved)

> refactor(telegram): remove dmPolicy from group allow context helper

**Conflict resolution**: `bot-handlers.ts` — fork doesn't have the TelegramEventAuthorization abstraction layer (types, rules, context resolver, sender authorizer). Ours=empty, theirs=modified block. Took ours since 0 callers reference this abstraction in the fork. The `dmPolicy` removal in `bot/helpers.ts` and `bot-native-commands.ts` applied cleanly.

Closes #595 (2/9)