### PR TITLE
Cherry-pick 8bdda7a: fix(security): keep DM pairing allowlists out of group auth

### DIFF
--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -146,6 +146,7 @@ Notes:
 
 - `groupPolicy` is separate from mention-gating (which requires @mentions).
 - WhatsApp/Telegram/Signal/iMessage/Microsoft Teams/Zalo: use `groupAllowFrom` (fallback: explicit `allowFrom`).
+- DM pairing approvals (`*-allowFrom` store entries) apply to DM access only; group sender authorization stays explicit to group allowlists.
 - Discord: allowlist uses `channels.discord.guilds.<id>.channels`.
 - Slack: allowlist uses `channels.slack.channels`.
 - Matrix: allowlist uses `channels.matrix.groups` (room IDs, aliases, or names). Use `channels.matrix.groupAllowFrom` to restrict senders; per-room `users` allowlists are also supported.

--- a/extensions/mattermost/src/mattermost/monitor.authz.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.authz.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { resolveMattermostEffectiveAllowFromLists } from "./monitor.js";
+
+describe("mattermost monitor authz", () => {
+  it("keeps DM allowlist merged with pairing-store entries", () => {
+    const resolved = resolveMattermostEffectiveAllowFromLists({
+      dmPolicy: "pairing",
+      allowFrom: ["@trusted-user"],
+      groupAllowFrom: ["@group-owner"],
+      storeAllowFrom: ["user:attacker"],
+    });
+
+    expect(resolved.effectiveAllowFrom).toEqual(["trusted-user", "attacker"]);
+  });
+
+  it("uses explicit groupAllowFrom without pairing-store inheritance", () => {
+    const resolved = resolveMattermostEffectiveAllowFromLists({
+      dmPolicy: "pairing",
+      allowFrom: ["@trusted-user"],
+      groupAllowFrom: ["@group-owner"],
+      storeAllowFrom: ["user:attacker"],
+    });
+
+    expect(resolved.effectiveGroupAllowFrom).toEqual(["group-owner"]);
+  });
+
+  it("does not inherit pairing-store entries into group allowlist", () => {
+    const resolved = resolveMattermostEffectiveAllowFromLists({
+      dmPolicy: "pairing",
+      allowFrom: ["@trusted-user"],
+      storeAllowFrom: ["user:attacker"],
+    });
+
+    expect(resolved.effectiveAllowFrom).toEqual(["trusted-user", "attacker"]);
+    expect(resolved.effectiveGroupAllowFrom).toEqual(["trusted-user"]);
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -17,6 +17,7 @@ import {
   recordPendingHistoryEntryIfEnabled,
   isDangerousNameMatchingEnabled,
   resolveControlCommandGate,
+  resolveEffectiveAllowFromLists,
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   resolveChannelMediaMaxBytes,
@@ -147,6 +148,23 @@ function normalizeAllowEntry(entry: string): string {
 function normalizeAllowList(entries: Array<string | number>): string[] {
   const normalized = entries.map((entry) => normalizeAllowEntry(String(entry))).filter(Boolean);
   return Array.from(new Set(normalized));
+}
+
+export function resolveMattermostEffectiveAllowFromLists(params: {
+  allowFrom?: Array<string | number> | null;
+  groupAllowFrom?: Array<string | number> | null;
+  storeAllowFrom?: Array<string | number> | null;
+  dmPolicy?: string | null;
+}): {
+  effectiveAllowFrom: string[];
+  effectiveGroupAllowFrom: string[];
+} {
+  return resolveEffectiveAllowFromLists({
+    allowFrom: normalizeAllowList(params.allowFrom ?? []),
+    groupAllowFrom: normalizeAllowList(params.groupAllowFrom ?? []),
+    storeAllowFrom: normalizeAllowList(params.storeAllowFrom ?? []),
+    dmPolicy: params.dmPolicy,
+  });
 }
 
 function isSenderAllowed(params: {
@@ -399,20 +417,18 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       senderId;
     const rawText = post.message?.trim() || "";
     const dmPolicy = account.config.dmPolicy ?? "pairing";
-    const configAllowFrom = normalizeAllowList(account.config.allowFrom ?? []);
-    const configGroupAllowFrom = normalizeAllowList(account.config.groupAllowFrom ?? []);
     const storeAllowFrom = normalizeAllowList(
       dmPolicy === "allowlist"
         ? []
         : await core.channel.pairing.readAllowFromStore("mattermost").catch(() => []),
     );
-    const effectiveAllowFrom = Array.from(new Set([...configAllowFrom, ...storeAllowFrom]));
-    const effectiveGroupAllowFrom = Array.from(
-      new Set([
-        ...(configGroupAllowFrom.length > 0 ? configGroupAllowFrom : configAllowFrom),
-        ...storeAllowFrom,
-      ]),
-    );
+    const { effectiveAllowFrom, effectiveGroupAllowFrom } =
+      resolveMattermostEffectiveAllowFromLists({
+        dmPolicy,
+        allowFrom: account.config.allowFrom,
+        groupAllowFrom: account.config.groupAllowFrom,
+        storeAllowFrom,
+      });
     const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
       cfg,
       surface: "mattermost",

--- a/src/channels/allow-from.test.ts
+++ b/src/channels/allow-from.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { firstDefined, isSenderIdAllowed, mergeAllowFromSources } from "./allow-from.js";
+import {
+  firstDefined,
+  isSenderIdAllowed,
+  mergeDmAllowFromSources,
+  resolveGroupAllowFromSources,
+} from "./allow-from.js";
 
-describe("mergeAllowFromSources", () => {
+describe("mergeDmAllowFromSources", () => {
   it("merges, trims, and filters empty values", () => {
     expect(
-      mergeAllowFromSources({
+      mergeDmAllowFromSources({
         allowFrom: ["  line:user:abc  ", "", 123],
         storeAllowFrom: ["   ", "telegram:456"],
       }),
@@ -13,7 +18,7 @@ describe("mergeAllowFromSources", () => {
 
   it("excludes pairing-store entries when dmPolicy is allowlist", () => {
     expect(
-      mergeAllowFromSources({
+      mergeDmAllowFromSources({
         allowFrom: ["+1111"],
         storeAllowFrom: ["+2222", "+3333"],
         dmPolicy: "allowlist",
@@ -23,12 +28,32 @@ describe("mergeAllowFromSources", () => {
 
   it("keeps pairing-store entries for non-allowlist policies", () => {
     expect(
-      mergeAllowFromSources({
+      mergeDmAllowFromSources({
         allowFrom: ["+1111"],
         storeAllowFrom: ["+2222"],
         dmPolicy: "pairing",
       }),
     ).toEqual(["+1111", "+2222"]);
+  });
+});
+
+describe("resolveGroupAllowFromSources", () => {
+  it("prefers explicit group allowlist", () => {
+    expect(
+      resolveGroupAllowFromSources({
+        allowFrom: ["owner"],
+        groupAllowFrom: ["group-owner", " group-admin "],
+      }),
+    ).toEqual(["group-owner", "group-admin"]);
+  });
+
+  it("falls back to DM allowlist when group allowlist is unset/empty", () => {
+    expect(
+      resolveGroupAllowFromSources({
+        allowFrom: [" owner ", "", "owner2"],
+        groupAllowFrom: [],
+      }),
+    ).toEqual(["owner", "owner2"]);
   });
 });
 

--- a/src/channels/allow-from.ts
+++ b/src/channels/allow-from.ts
@@ -1,12 +1,23 @@
-export function mergeAllowFromSources(params: {
+export function mergeDmAllowFromSources(params: {
   allowFrom?: Array<string | number>;
-  storeAllowFrom?: string[];
+  storeAllowFrom?: Array<string | number>;
   dmPolicy?: string;
 }): string[] {
   const storeEntries = params.dmPolicy === "allowlist" ? [] : (params.storeAllowFrom ?? []);
   return [...(params.allowFrom ?? []), ...storeEntries]
     .map((value) => String(value).trim())
     .filter(Boolean);
+}
+
+export function resolveGroupAllowFromSources(params: {
+  allowFrom?: Array<string | number>;
+  groupAllowFrom?: Array<string | number>;
+}): string[] {
+  const scoped =
+    params.groupAllowFrom && params.groupAllowFrom.length > 0
+      ? params.groupAllowFrom
+      : (params.allowFrom ?? []);
+  return scoped.map((value) => String(value).trim()).filter(Boolean);
 }
 
 export function firstDefined<T>(...values: Array<T | undefined>) {

--- a/src/line/bot-access.ts
+++ b/src/line/bot-access.ts
@@ -1,4 +1,8 @@
-import { firstDefined, isSenderIdAllowed, mergeAllowFromSources } from "../channels/allow-from.js";
+import {
+  firstDefined,
+  isSenderIdAllowed,
+  mergeDmAllowFromSources,
+} from "../channels/allow-from.js";
 
 export type NormalizedAllowFrom = {
   entries: string[];
@@ -27,11 +31,11 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   };
 };
 
-export const normalizeAllowFromWithStore = (params: {
+export const normalizeDmAllowFromWithStore = (params: {
   allowFrom?: Array<string | number>;
   storeAllowFrom?: string[];
   dmPolicy?: string;
-}): NormalizedAllowFrom => normalizeAllowFrom(mergeAllowFromSources(params));
+}): NormalizedAllowFrom => normalizeAllowFrom(mergeDmAllowFromSources(params));
 
 export const isSenderAllowed = (params: {
   allow: NormalizedAllowFrom;

--- a/src/security/dm-policy-shared.test.ts
+++ b/src/security/dm-policy-shared.test.ts
@@ -40,7 +40,7 @@ describe("security/dm-policy-shared", () => {
       storeAllowFrom: [" owner3 ", ""],
     });
     expect(lists.effectiveAllowFrom).toEqual(["owner", "owner2", "owner3"]);
-    expect(lists.effectiveGroupAllowFrom).toEqual(["group:abc", "owner3"]);
+    expect(lists.effectiveGroupAllowFrom).toEqual(["group:abc"]);
   });
 
   it("falls back to DM allowlist for groups when groupAllowFrom is empty", () => {
@@ -50,7 +50,7 @@ describe("security/dm-policy-shared", () => {
       storeAllowFrom: [" owner2 "],
     });
     expect(lists.effectiveAllowFrom).toEqual(["owner", "owner2"]);
-    expect(lists.effectiveGroupAllowFrom).toEqual(["owner", "owner2"]);
+    expect(lists.effectiveGroupAllowFrom).toEqual(["owner"]);
   });
 
   it("excludes storeAllowFrom when dmPolicy is allowlist", () => {
@@ -64,7 +64,7 @@ describe("security/dm-policy-shared", () => {
     expect(lists.effectiveGroupAllowFrom).toEqual(["group:abc"]);
   });
 
-  it("includes storeAllowFrom when dmPolicy is pairing", () => {
+  it("keeps group allowlist explicit when dmPolicy is pairing", () => {
     const lists = resolveEffectiveAllowFromLists({
       allowFrom: ["+1111"],
       groupAllowFrom: [],
@@ -72,7 +72,7 @@ describe("security/dm-policy-shared", () => {
       dmPolicy: "pairing",
     });
     expect(lists.effectiveAllowFrom).toEqual(["+1111", "+2222"]);
-    expect(lists.effectiveGroupAllowFrom).toEqual(["+1111", "+2222"]);
+    expect(lists.effectiveGroupAllowFrom).toEqual(["+1111"]);
   });
 
   const channels = [

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -1,4 +1,8 @@
-import { firstDefined, isSenderIdAllowed, mergeAllowFromSources } from "../channels/allow-from.js";
+import {
+  firstDefined,
+  isSenderIdAllowed,
+  mergeDmAllowFromSources,
+} from "../channels/allow-from.js";
 import type { AllowlistMatch } from "../channels/allowlist-match.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
@@ -53,11 +57,11 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   };
 };
 
-export const normalizeAllowFromWithStore = (params: {
+export const normalizeDmAllowFromWithStore = (params: {
   allowFrom?: Array<string | number>;
   storeAllowFrom?: string[];
   dmPolicy?: string;
-}): NormalizedAllowFrom => normalizeAllowFrom(mergeAllowFromSources(params));
+}): NormalizedAllowFrom => normalizeAllowFrom(mergeDmAllowFromSources(params));
 
 export const isSenderAllowed = (params: {
   allow: NormalizedAllowFrom;

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -19,7 +19,7 @@ import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
   isSenderAllowed,
-  normalizeAllowFromWithStore,
+  normalizeDmAllowFromWithStore,
   type NormalizedAllowFrom,
 } from "./bot-access.js";
 import type { TelegramMediaRef } from "./bot-message-context.js";
@@ -763,7 +763,7 @@ export const registerTelegramHandlers = ({
         hasGroupAllowOverride,
       } = groupAllowContext;
       const dmPolicy = telegramCfg.dmPolicy ?? "pairing";
-      const effectiveDmAllow = normalizeAllowFromWithStore({
+      const effectiveDmAllow = normalizeDmAllowFromWithStore({
         allowFrom: telegramCfg.allowFrom,
         storeAllowFrom,
         dmPolicy,
@@ -948,7 +948,7 @@ export const registerTelegramHandlers = ({
         effectiveGroupAllow,
         hasGroupAllowOverride,
       } = groupAllowContext;
-      const effectiveDmAllow = normalizeAllowFromWithStore({
+      const effectiveDmAllow = normalizeDmAllowFromWithStore({
         allowFrom,
         storeAllowFrom,
         dmPolicy,

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -30,7 +30,12 @@ import { recordChannelActivity } from "../infra/channel-activity.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
-import { firstDefined, isSenderAllowed, normalizeAllowFromWithStore } from "./bot-access.js";
+import {
+  firstDefined,
+  isSenderAllowed,
+  normalizeAllowFrom,
+  normalizeDmAllowFromWithStore,
+} from "./bot-access.js";
 import {
   buildGroupLabel,
   buildSenderLabel,
@@ -161,13 +166,9 @@ export const buildTelegramMessageContext = async ({
       : null;
   const sessionKey = threadKeys?.sessionKey ?? baseSessionKey;
   const mentionRegexes = buildMentionRegexes(cfg, route.agentId);
-  const effectiveDmAllow = normalizeAllowFromWithStore({ allowFrom, storeAllowFrom, dmPolicy });
+  const effectiveDmAllow = normalizeDmAllowFromWithStore({ allowFrom, storeAllowFrom, dmPolicy });
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
-  const effectiveGroupAllow = normalizeAllowFromWithStore({
-    allowFrom: groupAllowOverride ?? groupAllowFrom,
-    storeAllowFrom,
-    dmPolicy,
-  });
+  const effectiveGroupAllow = normalizeAllowFrom(groupAllowOverride ?? groupAllowFrom);
   const hasGroupAllowOverride = typeof groupAllowOverride !== "undefined";
   const senderId = msg.from?.id ? String(msg.from.id) : "";
   const senderUsername = msg.from?.username ?? "";

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -40,7 +40,7 @@ import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
-import { isSenderAllowed, normalizeAllowFromWithStore } from "./bot-access.js";
+import { isSenderAllowed, normalizeDmAllowFromWithStore } from "./bot-access.js";
 import {
   buildCappedTelegramMenuCommands,
   buildPluginTelegramMenuCommands,
@@ -250,7 +250,7 @@ async function resolveTelegramCommandAuth(params: {
     }
   }
 
-  const dmAllow = normalizeAllowFromWithStore({
+  const dmAllow = normalizeDmAllowFromWithStore({
     allowFrom: allowFrom,
     storeAllowFrom,
     dmPolicy: telegramCfg.dmPolicy ?? "pairing",

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -3,11 +3,7 @@ import { formatLocationText, type NormalizedLocation } from "../../channels/loca
 import { resolveTelegramPreviewStreamMode } from "../../config/discord-preview-streaming.js";
 import type { TelegramGroupConfig, TelegramTopicConfig } from "../../config/types.js";
 import { readChannelAllowFromStore } from "../../pairing/pairing-store.js";
-import {
-  firstDefined,
-  normalizeAllowFromWithStore,
-  type NormalizedAllowFrom,
-} from "../bot-access.js";
+import { firstDefined, normalizeAllowFrom, type NormalizedAllowFrom } from "../bot-access.js";
 import type { TelegramStreamMode } from "./types.js";
 
 const TELEGRAM_GENERAL_TOPIC_ID = 1;
@@ -20,7 +16,6 @@ export type TelegramThreadSpec = {
 export async function resolveTelegramGroupAllowFromContext(params: {
   chatId: string | number;
   accountId?: string;
-  dmPolicy?: string;
   isForum?: boolean;
   messageThreadId?: number | null;
   groupAllowFrom?: Array<string | number>;
@@ -51,11 +46,7 @@ export async function resolveTelegramGroupAllowFromContext(params: {
     resolvedThreadId,
   );
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
-  const effectiveGroupAllow = normalizeAllowFromWithStore({
-    allowFrom: groupAllowOverride ?? params.groupAllowFrom,
-    storeAllowFrom,
-    dmPolicy: params.dmPolicy,
-  });
+  const effectiveGroupAllow = normalizeAllowFrom(groupAllowOverride ?? params.groupAllowFrom);
   const hasGroupAllowOverride = typeof groupAllowOverride !== "undefined";
   return {
     resolvedThreadId,


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: 8bdda7a651
**Author**: Peter Steinberger <steipete@gmail.com>
**Tier**: AUTO-PARTIAL + RESOLVED

> fix(security): keep DM pairing allowlists out of group auth

**Discarded**: CHANGELOG.md (gutted layer)

**Conflicts resolved**:
- `extensions/mattermost/src/mattermost/monitor.ts`: Import — added `resolveEffectiveAllowFromLists` only (fork doesn't have `resolveDmGroupAccessWithLists`)
- `src/security/dm-policy-shared.test.ts`: Fork doesn't have `resolveDmGroupAccessWithLists` tests — kept ours (empty)
- `src/telegram/bot-handlers.ts`: (1) TelegramEventAuthorization abstraction block — fork doesn't have this, kept ours. (2) `normalizeAllowFromWithStore` → `normalizeDmAllowFromWithStore` rename applied with fork's `groupAllowContext` variable name
- `src/telegram/bot-message-context.ts`: Import renamed to `normalizeDmAllowFromWithStore`, group allowlist changed to `normalizeAllowFrom` (no store data for groups — the security fix)
- `src/telegram/bot/helpers.ts`: Aligned with upstream — group allowlist uses `normalizeAllowFrom` instead of `normalizeAllowFromWithStore`, removed unused `dmPolicy` param

Closes #595 (3/9)