### PR TITLE
Cherry-pick 892a9c2: refactor(security): centralize channel allowlist auth policy

### DIFF
--- a/extensions/irc/src/inbound.policy.test.ts
+++ b/extensions/irc/src/inbound.policy.test.ts
@@ -7,6 +7,7 @@ describe("irc inbound policy", () => {
       configAllowFrom: ["owner"],
       configGroupAllowFrom: [],
       storeAllowList: ["paired-user"],
+      dmPolicy: "pairing",
     });
 
     expect(resolved.effectiveAllowFrom).toEqual(["owner", "paired-user"]);
@@ -17,6 +18,7 @@ describe("irc inbound policy", () => {
       configAllowFrom: ["owner"],
       configGroupAllowFrom: ["group-owner"],
       storeAllowList: ["paired-user"],
+      dmPolicy: "pairing",
     });
 
     expect(resolved.effectiveGroupAllowFrom).toEqual(["group-owner"]);
@@ -27,6 +29,7 @@ describe("irc inbound policy", () => {
       configAllowFrom: ["owner"],
       configGroupAllowFrom: [],
       storeAllowList: ["paired-user"],
+      dmPolicy: "pairing",
     });
 
     expect(resolved.effectiveGroupAllowFrom).toEqual([]);

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -9,6 +9,7 @@ import {
   resolveOutboundMediaUrls,
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
+  resolveEffectiveAllowFromLists,
   warnMissingProviderGroupPolicyFallbackOnce,
   type OutboundReplyPayload,
   type RemoteClawConfig,
@@ -35,13 +36,19 @@ function resolveIrcEffectiveAllowlists(params: {
   configAllowFrom: string[];
   configGroupAllowFrom: string[];
   storeAllowList: string[];
+  dmPolicy: string;
 }): {
   effectiveAllowFrom: string[];
   effectiveGroupAllowFrom: string[];
 } {
-  const effectiveAllowFrom = [...params.configAllowFrom, ...params.storeAllowList].filter(Boolean);
-  // Pairing-store entries are DM approvals and must not widen group sender authorization.
-  const effectiveGroupAllowFrom = [...params.configGroupAllowFrom].filter(Boolean);
+  const { effectiveAllowFrom, effectiveGroupAllowFrom } = resolveEffectiveAllowFromLists({
+    allowFrom: params.configAllowFrom,
+    groupAllowFrom: params.configGroupAllowFrom,
+    storeAllowFrom: params.storeAllowList,
+    dmPolicy: params.dmPolicy,
+    // IRC intentionally requires explicit groupAllowFrom; do not fallback to allowFrom.
+    groupAllowFromFallbackToAllowFrom: false,
+  });
   return { effectiveAllowFrom, effectiveGroupAllowFrom };
 }
 
@@ -141,6 +148,7 @@ export async function handleIrcInbound(params: {
     configAllowFrom,
     configGroupAllowFrom,
     storeAllowList,
+    dmPolicy,
   });
 
   const allowTextCommands = core.channel.commands.shouldHandleTextCommands({

--- a/extensions/mattermost/src/mattermost/monitor-auth.ts
+++ b/extensions/mattermost/src/mattermost/monitor-auth.ts
@@ -1,0 +1,58 @@
+import { resolveAllowlistMatchSimple, resolveEffectiveAllowFromLists } from "openclaw/plugin-sdk";
+
+export function normalizeMattermostAllowEntry(entry: string): string {
+  const trimmed = entry.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (trimmed === "*") {
+    return "*";
+  }
+  return trimmed
+    .replace(/^(mattermost|user):/i, "")
+    .replace(/^@/, "")
+    .toLowerCase();
+}
+
+export function normalizeMattermostAllowList(entries: Array<string | number>): string[] {
+  const normalized = entries
+    .map((entry) => normalizeMattermostAllowEntry(String(entry)))
+    .filter(Boolean);
+  return Array.from(new Set(normalized));
+}
+
+export function resolveMattermostEffectiveAllowFromLists(params: {
+  allowFrom?: Array<string | number> | null;
+  groupAllowFrom?: Array<string | number> | null;
+  storeAllowFrom?: Array<string | number> | null;
+  dmPolicy?: string | null;
+}): {
+  effectiveAllowFrom: string[];
+  effectiveGroupAllowFrom: string[];
+} {
+  return resolveEffectiveAllowFromLists({
+    allowFrom: normalizeMattermostAllowList(params.allowFrom ?? []),
+    groupAllowFrom: normalizeMattermostAllowList(params.groupAllowFrom ?? []),
+    storeAllowFrom: normalizeMattermostAllowList(params.storeAllowFrom ?? []),
+    dmPolicy: params.dmPolicy,
+  });
+}
+
+export function isMattermostSenderAllowed(params: {
+  senderId: string;
+  senderName?: string;
+  allowFrom: string[];
+  allowNameMatching?: boolean;
+}): boolean {
+  const allowFrom = params.allowFrom;
+  if (allowFrom.length === 0) {
+    return false;
+  }
+  const match = resolveAllowlistMatchSimple({
+    allowFrom,
+    senderId: normalizeMattermostAllowEntry(params.senderId),
+    senderName: params.senderName ? normalizeMattermostAllowEntry(params.senderName) : undefined,
+    allowNameMatching: params.allowNameMatching,
+  });
+  return match.allowed;
+}

--- a/extensions/mattermost/src/mattermost/monitor.authz.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.authz.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { resolveMattermostEffectiveAllowFromLists } from "./monitor-auth.js";
+
+describe("mattermost monitor authz", () => {
+  it("keeps DM allowlist merged with pairing-store entries", () => {
+    const resolved = resolveMattermostEffectiveAllowFromLists({
+      dmPolicy: "pairing",
+      allowFrom: ["@trusted-user"],
+      groupAllowFrom: ["@group-owner"],
+      storeAllowFrom: ["user:attacker"],
+    });
+
+    expect(resolved.effectiveAllowFrom).toEqual(["trusted-user", "attacker"]);
+  });
+
+  it("uses explicit groupAllowFrom without pairing-store inheritance", () => {
+    const resolved = resolveMattermostEffectiveAllowFromLists({
+      dmPolicy: "pairing",
+      allowFrom: ["@trusted-user"],
+      groupAllowFrom: ["@group-owner"],
+      storeAllowFrom: ["user:attacker"],
+    });
+
+    expect(resolved.effectiveGroupAllowFrom).toEqual(["group-owner"]);
+  });
+
+  it("does not inherit pairing-store entries into group allowlist", () => {
+    const resolved = resolveMattermostEffectiveAllowFromLists({
+      dmPolicy: "pairing",
+      allowFrom: ["@trusted-user"],
+      storeAllowFrom: ["user:attacker"],
+    });
+
+    expect(resolved.effectiveAllowFrom).toEqual(["trusted-user", "attacker"]);
+    expect(resolved.effectiveGroupAllowFrom).toEqual(["trusted-user"]);
+  });
+});

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -9,6 +9,7 @@ import {
   isDangerousNameMatchingEnabled,
   resolveMentionGating,
   formatAllowlistMatchMeta,
+  resolveEffectiveAllowFromLists,
   type HistoryEntry,
 } from "remoteclaw/plugin-sdk";
 import {
@@ -136,7 +137,14 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     // Check DM policy for direct messages.
     const dmAllowFrom = msteamsCfg?.allowFrom ?? [];
     const configuredDmAllowFrom = dmAllowFrom.map((v) => String(v));
-    const effectiveDmAllowFrom = [...configuredDmAllowFrom, ...storedAllowFrom];
+    const groupAllowFrom = msteamsCfg?.groupAllowFrom;
+    const resolvedAllowFromLists = resolveEffectiveAllowFromLists({
+      allowFrom: configuredDmAllowFrom,
+      groupAllowFrom,
+      storeAllowFrom: storedAllowFrom,
+      dmPolicy,
+    });
+    const effectiveDmAllowFrom = resolvedAllowFromLists.effectiveAllowFrom;
     if (isDirectMessage && msteamsCfg) {
       const allowFrom = dmAllowFrom;
 
@@ -184,13 +192,8 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       !isDirectMessage && msteamsCfg
         ? (msteamsCfg.groupPolicy ?? defaultGroupPolicy ?? "allowlist")
         : "disabled";
-    const groupAllowFrom =
-      !isDirectMessage && msteamsCfg
-        ? (msteamsCfg.groupAllowFrom ??
-          (msteamsCfg.allowFrom && msteamsCfg.allowFrom.length > 0 ? msteamsCfg.allowFrom : []))
-        : [];
     const effectiveGroupAllowFrom =
-      !isDirectMessage && msteamsCfg ? groupAllowFrom.map((v) => String(v)) : [];
+      !isDirectMessage && msteamsCfg ? resolvedAllowFromLists.effectiveGroupAllowFrom : [];
     const teamId = activity.channelData?.team?.id;
     const teamName = activity.channelData?.team?.name;
     const channelName = activity.channelData?.channel?.name;

--- a/src/channels/allow-from.test.ts
+++ b/src/channels/allow-from.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { firstDefined, isSenderIdAllowed, mergeAllowFromSources } from "./allow-from.js";
+import {
+  firstDefined,
+  isSenderIdAllowed,
+  mergeAllowFromSources,
+  resolveGroupAllowFromSources,
+} from "./allow-from.js";
 
 describe("mergeAllowFromSources", () => {
   it("merges, trims, and filters empty values", () => {
@@ -29,6 +34,36 @@ describe("mergeAllowFromSources", () => {
         dmPolicy: "pairing",
       }),
     ).toEqual(["+1111", "+2222"]);
+  });
+});
+
+describe("resolveGroupAllowFromSources", () => {
+  it("prefers explicit group allowlist", () => {
+    expect(
+      resolveGroupAllowFromSources({
+        allowFrom: ["owner"],
+        groupAllowFrom: ["group-owner", " group-admin "],
+      }),
+    ).toEqual(["group-owner", "group-admin"]);
+  });
+
+  it("falls back to DM allowlist when group allowlist is unset/empty", () => {
+    expect(
+      resolveGroupAllowFromSources({
+        allowFrom: [" owner ", "", "owner2"],
+        groupAllowFrom: [],
+      }),
+    ).toEqual(["owner", "owner2"]);
+  });
+
+  it("can disable fallback to DM allowlist", () => {
+    expect(
+      resolveGroupAllowFromSources({
+        allowFrom: ["owner", "owner2"],
+        groupAllowFrom: [],
+        fallbackToAllowFrom: false,
+      }),
+    ).toEqual([]);
   });
 });
 

--- a/src/channels/allow-from.ts
+++ b/src/channels/allow-from.ts
@@ -9,6 +9,23 @@ export function mergeAllowFromSources(params: {
     .filter(Boolean);
 }
 
+export function resolveGroupAllowFromSources(params: {
+  allowFrom?: Array<string | number>;
+  groupAllowFrom?: Array<string | number>;
+  fallbackToAllowFrom?: boolean;
+}): string[] {
+  const explicitGroupAllowFrom =
+    Array.isArray(params.groupAllowFrom) && params.groupAllowFrom.length > 0
+      ? params.groupAllowFrom
+      : undefined;
+  const scoped = explicitGroupAllowFrom
+    ? explicitGroupAllowFrom
+    : params.fallbackToAllowFrom === false
+      ? []
+      : (params.allowFrom ?? []);
+  return scoped.map((value) => String(value).trim()).filter(Boolean);
+}
+
 export function firstDefined<T>(...values: Array<T | undefined>) {
   for (const value of values) {
     if (typeof value !== "undefined") {

--- a/src/security/dm-policy-shared.test.ts
+++ b/src/security/dm-policy-shared.test.ts
@@ -53,6 +53,17 @@ describe("security/dm-policy-shared", () => {
     expect(lists.effectiveGroupAllowFrom).toEqual(["owner", "owner2"]);
   });
 
+  it("can keep group allowlist empty when fallback is disabled", () => {
+    const lists = resolveEffectiveAllowFromLists({
+      allowFrom: ["owner"],
+      groupAllowFrom: [],
+      storeAllowFrom: ["paired-user"],
+      groupAllowFromFallbackToAllowFrom: false,
+    });
+    expect(lists.effectiveAllowFrom).toEqual(["owner", "paired-user"]);
+    expect(lists.effectiveGroupAllowFrom).toEqual([]);
+  });
+
   it("excludes storeAllowFrom when dmPolicy is allowlist", () => {
     const lists = resolveEffectiveAllowFromLists({
       allowFrom: ["+1111"],

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -1,3 +1,4 @@
+import { mergeAllowFromSources, resolveGroupAllowFromSources } from "../channels/allow-from.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
@@ -7,25 +8,29 @@ export function resolveEffectiveAllowFromLists(params: {
   groupAllowFrom?: Array<string | number> | null;
   storeAllowFrom?: Array<string | number> | null;
   dmPolicy?: string | null;
+  groupAllowFromFallbackToAllowFrom?: boolean | null;
 }): {
   effectiveAllowFrom: string[];
   effectiveGroupAllowFrom: string[];
 } {
-  const configAllowFrom = normalizeStringEntries(
-    Array.isArray(params.allowFrom) ? params.allowFrom : undefined,
+  const allowFrom = Array.isArray(params.allowFrom) ? params.allowFrom : undefined;
+  const groupAllowFrom = Array.isArray(params.groupAllowFrom) ? params.groupAllowFrom : undefined;
+  const storeAllowFrom = Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined;
+  const effectiveAllowFrom = normalizeStringEntries(
+    mergeAllowFromSources({
+      allowFrom,
+      storeAllowFrom,
+      dmPolicy: params.dmPolicy ?? undefined,
+    }),
   );
-  const configGroupAllowFrom = normalizeStringEntries(
-    Array.isArray(params.groupAllowFrom) ? params.groupAllowFrom : undefined,
+  // Group auth is explicit (groupAllowFrom fallback allowFrom). Pairing store is DM-only.
+  const effectiveGroupAllowFrom = normalizeStringEntries(
+    resolveGroupAllowFromSources({
+      allowFrom,
+      groupAllowFrom,
+      fallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom ?? undefined,
+    }),
   );
-  const storeAllowFrom =
-    params.dmPolicy === "allowlist"
-      ? []
-      : normalizeStringEntries(
-          Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined,
-        );
-  const effectiveAllowFrom = normalizeStringEntries([...configAllowFrom, ...storeAllowFrom]);
-  const groupBase = configGroupAllowFrom.length > 0 ? configGroupAllowFrom : configAllowFrom;
-  const effectiveGroupAllowFrom = normalizeStringEntries([...groupBase, ...storeAllowFrom]);
   return { effectiveAllowFrom, effectiveGroupAllowFrom };
 }
 
@@ -75,6 +80,43 @@ export function resolveDmGroupAccessDecision(params: {
     return { decision: "pairing", reason: "dmPolicy=pairing (not allowlisted)" };
   }
   return { decision: "block", reason: `dmPolicy=${dmPolicy} (not allowlisted)` };
+}
+
+export function resolveDmGroupAccessWithLists(params: {
+  isGroup: boolean;
+  dmPolicy?: string | null;
+  groupPolicy?: string | null;
+  allowFrom?: Array<string | number> | null;
+  groupAllowFrom?: Array<string | number> | null;
+  storeAllowFrom?: Array<string | number> | null;
+  groupAllowFromFallbackToAllowFrom?: boolean | null;
+  isSenderAllowed: (allowFrom: string[]) => boolean;
+}): {
+  decision: DmGroupAccessDecision;
+  reason: string;
+  effectiveAllowFrom: string[];
+  effectiveGroupAllowFrom: string[];
+} {
+  const { effectiveAllowFrom, effectiveGroupAllowFrom } = resolveEffectiveAllowFromLists({
+    allowFrom: params.allowFrom,
+    groupAllowFrom: params.groupAllowFrom,
+    storeAllowFrom: params.storeAllowFrom,
+    dmPolicy: params.dmPolicy,
+    groupAllowFromFallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom,
+  });
+  const access = resolveDmGroupAccessDecision({
+    isGroup: params.isGroup,
+    dmPolicy: params.dmPolicy,
+    groupPolicy: params.groupPolicy,
+    effectiveAllowFrom,
+    effectiveGroupAllowFrom,
+    isSenderAllowed: params.isSenderAllowed,
+  });
+  return {
+    ...access,
+    effectiveAllowFrom,
+    effectiveGroupAllowFrom,
+  };
 }
 
 export async function resolveDmAllowState(params: {

--- a/src/telegram/bot-message-context.test-harness.ts
+++ b/src/telegram/bot-message-context.test-harness.ts
@@ -64,5 +64,6 @@ export async function buildTelegramMessageContextForTest(
         groupConfig: { requireMention: false },
         topicConfig: undefined,
       })),
+    sendChatActionHandler: { sendChatAction: vi.fn() } as never,
   });
 }


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: 892a9c24b0
**Author**: Peter Steinberger <steipete@gmail.com>
**Tier**: HUMAN-REVIEW (multiple conflicts resolved)

> refactor(security): centralize channel allowlist auth policy

**Conflicts resolved**:
- `extensions/mattermost/src/mattermost/monitor.authz.test.ts`: DU — accepted upstream's version (new file)
- `extensions/mattermost/src/mattermost/monitor.ts`: (1) Import — added `resolveDmGroupAccessWithLists`. (2) Extracted local functions to `monitor-auth.ts`. (3) Replaced inline allowlist computation with `resolveMattermostEffectiveAllowFromLists`. (4) Replaced inline reaction policy checks with `resolveDmGroupAccessWithLists`
- `src/channels/allow-from.ts`: Added `resolveGroupAllowFromSources` with `fallbackToAllowFrom` param
- `src/channels/allow-from.test.ts`: Added tests for `resolveGroupAllowFromSources` including fallback disable test
- `src/security/dm-policy-shared.ts`: (1) Replaced inline group allowlist logic with `resolveGroupAllowFromSources` + `mergeAllowFromSources`. (2) Added `resolveDmGroupAccessWithLists` with `groupAllowFromFallbackToAllowFrom` option

Closes #595 (4/9)