### PR TITLE
cherry-pick: extract protected-route path policy helpers (6632fd1)

### DIFF
--- a/src/gateway/security-path.test.ts
+++ b/src/gateway/security-path.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  PROTECTED_PLUGIN_ROUTE_PREFIXES,
+  canonicalizePathForSecurity,
+  isPathProtectedByPrefixes,
+  isProtectedPluginRoutePath,
+} from "./security-path.js";
+
+describe("security-path canonicalization", () => {
+  it("canonicalizes decoded case/slash variants", () => {
+    expect(canonicalizePathForSecurity("/API/channels//nostr/default/profile/")).toEqual({
+      path: "/api/channels/nostr/default/profile",
+      malformedEncoding: false,
+      rawNormalizedPath: "/api/channels/nostr/default/profile",
+    });
+    expect(canonicalizePathForSecurity("/api/%63hannels%2Fnostr%2Fdefault%2Fprofile").path).toBe(
+      "/api/channels/nostr/default/profile",
+    );
+  });
+
+  it("marks malformed encoding", () => {
+    expect(canonicalizePathForSecurity("/api/channels%2").malformedEncoding).toBe(true);
+    expect(canonicalizePathForSecurity("/api/channels%zz").malformedEncoding).toBe(true);
+  });
+});
+
+describe("security-path protected-prefix matching", () => {
+  const channelVariants = [
+    "/API/channels/nostr/default/profile",
+    "/api/channels%2Fnostr%2Fdefault%2Fprofile",
+    "/api/%63hannels/nostr/default/profile",
+    "/api/channels%2",
+    "/api/channels%zz",
+  ];
+
+  for (const path of channelVariants) {
+    it(`protects plugin channel path variant: ${path}`, () => {
+      expect(isProtectedPluginRoutePath(path)).toBe(true);
+      expect(isPathProtectedByPrefixes(path, PROTECTED_PLUGIN_ROUTE_PREFIXES)).toBe(true);
+    });
+  }
+
+  it("does not protect unrelated paths", () => {
+    expect(isProtectedPluginRoutePath("/plugin/public")).toBe(false);
+    expect(isProtectedPluginRoutePath("/api/channels-public")).toBe(false);
+    expect(isProtectedPluginRoutePath("/api/channel")).toBe(false);
+  });
+});

--- a/src/gateway/security-path.ts
+++ b/src/gateway/security-path.ts
@@ -1,0 +1,59 @@
+export type SecurityPathCanonicalization = {
+  path: string;
+  malformedEncoding: boolean;
+  rawNormalizedPath: string;
+};
+
+function normalizePathSeparators(pathname: string): string {
+  const collapsed = pathname.replace(/\/{2,}/g, "/");
+  if (collapsed.length <= 1) {
+    return collapsed;
+  }
+  return collapsed.replace(/\/+$/, "");
+}
+
+function normalizeProtectedPrefix(prefix: string): string {
+  return normalizePathSeparators(prefix.toLowerCase()) || "/";
+}
+
+function prefixMatch(pathname: string, prefix: string): boolean {
+  return (
+    pathname === prefix ||
+    pathname.startsWith(`${prefix}/`) ||
+    // Fail closed when malformed %-encoding follows the protected prefix.
+    pathname.startsWith(`${prefix}%`)
+  );
+}
+
+export function canonicalizePathForSecurity(pathname: string): SecurityPathCanonicalization {
+  let decoded = pathname;
+  let malformedEncoding = false;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    malformedEncoding = true;
+  }
+  return {
+    path: normalizePathSeparators(decoded.toLowerCase()) || "/",
+    malformedEncoding,
+    rawNormalizedPath: normalizePathSeparators(pathname.toLowerCase()) || "/",
+  };
+}
+
+export function isPathProtectedByPrefixes(pathname: string, prefixes: readonly string[]): boolean {
+  const canonical = canonicalizePathForSecurity(pathname);
+  const normalizedPrefixes = prefixes.map(normalizeProtectedPrefix);
+  if (normalizedPrefixes.some((prefix) => prefixMatch(canonical.path, prefix))) {
+    return true;
+  }
+  if (!canonical.malformedEncoding) {
+    return false;
+  }
+  return normalizedPrefixes.some((prefix) => prefixMatch(canonical.rawNormalizedPath, prefix));
+}
+
+export const PROTECTED_PLUGIN_ROUTE_PREFIXES = ["/api/channels"] as const;
+
+export function isProtectedPluginRoutePath(pathname: string): boolean {
+  return isPathProtectedByPrefixes(pathname, PROTECTED_PLUGIN_ROUTE_PREFIXES);
+}

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -59,6 +59,7 @@ import { getBearerToken } from "./http-utils.js";
 import { handleOpenAiHttpRequest } from "./openai-http.js";
 import { handleOpenResponsesHttpRequest } from "./openresponses-http.js";
 import { GATEWAY_CLIENT_MODES, normalizeGatewayClientMode } from "./protocol/client-info.js";
+import { isProtectedPluginRoutePath } from "./security-path.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { handleToolsInvokeHttpRequest } from "./tools-invoke-http.js";
 
@@ -167,6 +168,34 @@ async function authorizeCanvasRequest(params: {
     return { ok: true };
   }
   return lastAuthFailure ?? { ok: false, reason: "unauthorized" };
+}
+
+async function enforcePluginRouteGatewayAuth(params: {
+  requestPath: string;
+  req: IncomingMessage;
+  res: ServerResponse;
+  auth: ResolvedGatewayAuth;
+  trustedProxies: string[];
+  allowRealIpFallback: boolean;
+  rateLimiter?: AuthRateLimiter;
+}): Promise<boolean> {
+  if (!isProtectedPluginRoutePath(params.requestPath)) {
+    return true;
+  }
+  const token = getBearerToken(params.req);
+  const authResult = await authorizeHttpGatewayConnect({
+    auth: params.auth,
+    connectAuth: token ? { token, password: token } : null,
+    req: params.req,
+    trustedProxies: params.trustedProxies,
+    allowRealIpFallback: params.allowRealIpFallback,
+    rateLimiter: params.rateLimiter,
+  });
+  if (!authResult.ok) {
+    sendGatewayAuthFailure(params.res, authResult);
+    return false;
+  }
+  return true;
 }
 
 function writeUpgradeAuthFailure(
@@ -488,23 +517,20 @@ export function createGatewayHttpServer(opts: {
         return;
       }
       if (handlePluginRequest) {
-        // Channel HTTP endpoints are gateway-auth protected by default.
-        // Non-channel plugin routes remain plugin-owned and must enforce
+        // Protected plugin route prefixes are gateway-auth protected by default.
+        // Non-protected plugin routes remain plugin-owned and must enforce
         // their own auth when exposing sensitive functionality.
-        if (requestPath === "/api/channels" || requestPath.startsWith("/api/channels/")) {
-          const token = getBearerToken(req);
-          const authResult = await authorizeHttpGatewayConnect({
-            auth: resolvedAuth,
-            connectAuth: token ? { token, password: token } : null,
-            req,
-            trustedProxies,
-            allowRealIpFallback,
-            rateLimiter,
-          });
-          if (!authResult.ok) {
-            sendGatewayAuthFailure(res, authResult);
-            return;
-          }
+        const pluginAuthOk = await enforcePluginRouteGatewayAuth({
+          requestPath,
+          req,
+          res,
+          auth: resolvedAuth,
+          trustedProxies,
+          allowRealIpFallback,
+          rateLimiter,
+        });
+        if (!pluginAuthOk) {
+          return;
         }
         if (await handlePluginRequest(req, res)) {
           return;

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -1,7 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, expect, test, vi } from "vitest";
+import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { createGatewayHttpServer } from "./server-http.js";
+import type { HooksConfigResolved } from "./hooks.js";
+import { createGatewayHttpServer, createHooksRequestHandler } from "./server-http.js";
 import { withTempConfig } from "./test-temp-config.js";
 
 function createRequest(params: {
@@ -63,6 +65,108 @@ async function dispatchRequest(
 ): Promise<void> {
   server.emit("request", req, res);
   await new Promise((resolve) => setImmediate(resolve));
+}
+
+function createHooksConfig(): HooksConfigResolved {
+  return {
+    basePath: "/hooks",
+    token: "hook-secret",
+    maxBodyBytes: 1024,
+    mappings: [],
+    agentPolicy: {
+      defaultAgentId: "main",
+      knownAgentIds: new Set(["main"]),
+      allowedAgentIds: undefined,
+    },
+    sessionPolicy: {
+      allowRequestSessionKey: false,
+      defaultSessionKey: undefined,
+      allowedSessionKeyPrefixes: undefined,
+    },
+  };
+}
+
+function canonicalizePluginPath(pathname: string): string {
+  let decoded = pathname;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    decoded = pathname;
+  }
+  const collapsed = decoded.toLowerCase().replace(/\/{2,}/g, "/");
+  if (collapsed.length <= 1) {
+    return collapsed;
+  }
+  return collapsed.replace(/\/+$/, "");
+}
+
+type RouteVariant = {
+  label: string;
+  path: string;
+};
+
+const CANONICAL_UNAUTH_VARIANTS: RouteVariant[] = [
+  { label: "case-variant", path: "/API/channels/nostr/default/profile" },
+  { label: "encoded-slash", path: "/api/channels%2Fnostr%2Fdefault%2Fprofile" },
+  { label: "encoded-segment", path: "/api/%63hannels/nostr/default/profile" },
+  { label: "duplicate-slashes", path: "/api/channels//nostr/default/profile" },
+  { label: "trailing-slash", path: "/api/channels/nostr/default/profile/" },
+  { label: "malformed-short-percent", path: "/api/channels%2" },
+  { label: "malformed-double-slash-short-percent", path: "/api//channels%2" },
+];
+
+const CANONICAL_AUTH_VARIANTS: RouteVariant[] = [
+  { label: "auth-case-variant", path: "/API/channels/nostr/default/profile" },
+  { label: "auth-encoded-segment", path: "/api/%63hannels/nostr/default/profile" },
+  { label: "auth-duplicate-trailing-slash", path: "/api/channels//nostr/default/profile/" },
+];
+
+function buildChannelPathFuzzCorpus(): RouteVariant[] {
+  const variants = [
+    "/api/channels/nostr/default/profile",
+    "/API/channels/nostr/default/profile",
+    "/api/channels//nostr/default/profile/",
+    "/api/channels%2Fnostr%2Fdefault%2Fprofile",
+    "/api/channels%252Fnostr%252Fdefault%252Fprofile",
+    "/api//channels/nostr/default/profile",
+    "/api/channels%2",
+    "/api/channels%zz",
+    "/api//channels%2",
+    "/api//channels%zz",
+  ];
+  return variants.map((path) => ({ label: `fuzz:${path}`, path }));
+}
+
+async function expectUnauthorizedVariants(params: {
+  server: ReturnType<typeof createGatewayHttpServer>;
+  variants: RouteVariant[];
+}) {
+  for (const variant of params.variants) {
+    const response = createResponse();
+    await dispatchRequest(params.server, createRequest({ path: variant.path }), response.res);
+    expect(response.res.statusCode, variant.label).toBe(401);
+    expect(response.getBody(), variant.label).toContain("Unauthorized");
+  }
+}
+
+async function expectAuthorizedVariants(params: {
+  server: ReturnType<typeof createGatewayHttpServer>;
+  variants: RouteVariant[];
+  authorization: string;
+}) {
+  for (const variant of params.variants) {
+    const response = createResponse();
+    await dispatchRequest(
+      params.server,
+      createRequest({
+        path: variant.path,
+        authorization: params.authorization,
+      }),
+      response.res,
+    );
+    expect(response.res.statusCode, variant.label).toBe(200);
+    expect(response.getBody(), variant.label).toContain('"route":"channel-canonicalized"');
+  }
 }
 
 describe("gateway plugin HTTP auth boundary", () => {
@@ -217,6 +321,200 @@ describe("gateway plugin HTTP auth boundary", () => {
         expect(unauthenticatedPublic.getBody()).toContain('"route":"public"');
 
         expect(handlePluginRequest).toHaveBeenCalledTimes(2);
+      },
+    });
+  });
+
+  test("requires gateway auth for canonicalized /api/channels variants", async () => {
+    const resolvedAuth: ResolvedGatewayAuth = {
+      mode: "token",
+      token: "test-token",
+      password: undefined,
+      allowTailscale: false,
+    };
+
+    await withTempConfig({
+      cfg: { gateway: { trustedProxies: [] } },
+      prefix: "openclaw-plugin-http-auth-canonicalized-test-",
+      run: async () => {
+        const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
+          const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+          const canonicalPath = canonicalizePluginPath(pathname);
+          if (canonicalPath === "/api/channels/nostr/default/profile") {
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "application/json; charset=utf-8");
+            res.end(JSON.stringify({ ok: true, route: "channel-canonicalized" }));
+            return true;
+          }
+          return false;
+        });
+
+        const server = createGatewayHttpServer({
+          canvasHost: null,
+          clients: new Set(),
+          controlUiEnabled: false,
+          controlUiBasePath: "/__control__",
+          openAiChatCompletionsEnabled: false,
+          openResponsesEnabled: false,
+          handleHooksRequest: async () => false,
+          handlePluginRequest,
+          resolvedAuth,
+        });
+
+        await expectUnauthorizedVariants({ server, variants: CANONICAL_UNAUTH_VARIANTS });
+        expect(handlePluginRequest).not.toHaveBeenCalled();
+
+        await expectAuthorizedVariants({
+          server,
+          variants: CANONICAL_AUTH_VARIANTS,
+          authorization: "Bearer test-token",
+        });
+        expect(handlePluginRequest).toHaveBeenCalledTimes(CANONICAL_AUTH_VARIANTS.length);
+      },
+    });
+  });
+
+  test("rejects unauthenticated plugin-channel fuzz corpus variants", async () => {
+    const resolvedAuth: ResolvedGatewayAuth = {
+      mode: "token",
+      token: "test-token",
+      password: undefined,
+      allowTailscale: false,
+    };
+
+    await withTempConfig({
+      cfg: { gateway: { trustedProxies: [] } },
+      prefix: "openclaw-plugin-http-auth-fuzz-corpus-test-",
+      run: async () => {
+        const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
+          const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+          const canonicalPath = canonicalizePluginPath(pathname);
+          if (canonicalPath === "/api/channels/nostr/default/profile") {
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "application/json; charset=utf-8");
+            res.end(JSON.stringify({ ok: true, route: "channel-canonicalized" }));
+            return true;
+          }
+          return false;
+        });
+
+        const server = createGatewayHttpServer({
+          canvasHost: null,
+          clients: new Set(),
+          controlUiEnabled: false,
+          controlUiBasePath: "/__control__",
+          openAiChatCompletionsEnabled: false,
+          openResponsesEnabled: false,
+          handleHooksRequest: async () => false,
+          handlePluginRequest,
+          resolvedAuth,
+        });
+
+        for (const variant of buildChannelPathFuzzCorpus()) {
+          const response = createResponse();
+          await dispatchRequest(server, createRequest({ path: variant.path }), response.res);
+          expect(response.res.statusCode, variant.label).not.toBe(200);
+          expect(response.getBody(), variant.label).not.toContain(
+            '"route":"channel-canonicalized"',
+          );
+        }
+      },
+    });
+  });
+
+  test.each(["0.0.0.0", "::"])(
+    "returns 404 (not 500) for non-hook routes with hooks enabled and bindHost=%s",
+    async (bindHost) => {
+      const resolvedAuth: ResolvedGatewayAuth = {
+        mode: "none",
+        token: undefined,
+        password: undefined,
+        allowTailscale: false,
+      };
+
+      await withTempConfig({
+        cfg: { gateway: { trustedProxies: [] } },
+        prefix: "openclaw-plugin-http-hooks-bindhost-",
+        run: async () => {
+          const handleHooksRequest = createHooksRequestHandler({
+            getHooksConfig: () => createHooksConfig(),
+            bindHost,
+            port: 18789,
+            logHooks: {
+              warn: vi.fn(),
+              debug: vi.fn(),
+              info: vi.fn(),
+              error: vi.fn(),
+            } as unknown as ReturnType<typeof createSubsystemLogger>,
+            dispatchWakeHook: () => {},
+            dispatchAgentHook: () => "run-1",
+          });
+          const server = createGatewayHttpServer({
+            canvasHost: null,
+            clients: new Set(),
+            controlUiEnabled: false,
+            controlUiBasePath: "/__control__",
+            openAiChatCompletionsEnabled: false,
+            openResponsesEnabled: false,
+            handleHooksRequest,
+            resolvedAuth,
+          });
+
+          const response = createResponse();
+          await dispatchRequest(server, createRequest({ path: "/" }), response.res);
+
+          expect(response.res.statusCode).toBe(404);
+          expect(response.getBody()).toBe("Not Found");
+        },
+      });
+    },
+  );
+
+  test("rejects query-token hooks requests with bindHost=::", async () => {
+    const resolvedAuth: ResolvedGatewayAuth = {
+      mode: "none",
+      token: undefined,
+      password: undefined,
+      allowTailscale: false,
+    };
+
+    await withTempConfig({
+      cfg: { gateway: { trustedProxies: [] } },
+      prefix: "openclaw-plugin-http-hooks-query-token-",
+      run: async () => {
+        const handleHooksRequest = createHooksRequestHandler({
+          getHooksConfig: () => createHooksConfig(),
+          bindHost: "::",
+          port: 18789,
+          logHooks: {
+            warn: vi.fn(),
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+          } as unknown as ReturnType<typeof createSubsystemLogger>,
+          dispatchWakeHook: () => {},
+          dispatchAgentHook: () => "run-1",
+        });
+        const server = createGatewayHttpServer({
+          canvasHost: null,
+          clients: new Set(),
+          controlUiEnabled: false,
+          controlUiBasePath: "/__control__",
+          openAiChatCompletionsEnabled: false,
+          openResponsesEnabled: false,
+          handleHooksRequest,
+          resolvedAuth,
+        });
+
+        const response = createResponse();
+        await dispatchRequest(
+          server,
+          createRequest({ path: "/hooks/wake?token=bad" }),
+          response.res,
+        );
+
+        expect(response.res.statusCode).toBe(400);
+        expect(response.getBody()).toContain("Hook token must be provided");
       },
     });
   });


### PR DESCRIPTION
Cherry-pick of openclaw/openclaw@6632fd1ea9.

**Original author:** Peter Steinberger <steipete@gmail.com>
**Original message:** refactor(security): extract protected-route path policy helpers

## What changed

Extracts inline security path canonicalization and protected-route prefix matching from `server-http.ts` into a dedicated `security-path.ts` module:

- `canonicalizePathForSecurity()` — decodes, lowercases, collapses slashes, detects malformed encoding
- `isPathProtectedByPrefixes()` — generic prefix matching with fail-closed malformed encoding
- `isProtectedPluginRoutePath()` — concrete check for `/api/channels` prefix
- `enforcePluginRouteGatewayAuth()` — extracted auth enforcement helper in server-http.ts
- New `security-path.test.ts` with canonicalization and prefix-matching unit tests
- Refactored integration tests: shared variant arrays, fuzz corpus builder, helper functions
- Added fuzz corpus test for unauthenticated plugin-channel path variants

## Conflicts resolved

- `server-http.ts`: Fork's main used inline `requestPath === "/api/channels"` check (commit 5's `isProtectedPluginChannelPath` is on a separate branch). Took upstream's `enforcePluginRouteGatewayAuth` call.
- `server.plugin-http-auth.test.ts`: Fork's main lacked the test helpers and hooks tests added by commit 5 (separate branch). Took upstream's complete refactored tests. Added missing imports (`createSubsystemLogger`, `HooksConfigResolved`, `createHooksRequestHandler`).

Cherry-picked-from: openclaw/openclaw@6632fd1ea9
Part of #595