### PR TITLE
cherry-pick: enforce strict account-scoped pairing state (91a3f0a)

### DIFF
--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -43,7 +43,14 @@ Supported channels: `telegram`, `whatsapp`, `signal`, `imessage`, `discord`, `sl
 Stored under `~/.remoteclaw/credentials/`:
 
 - Pending requests: `<channel>-pairing.json`
-- Approved allowlist store: `<channel>-allowFrom.json`
+- Approved allowlist store:
+  - Default account: `<channel>-allowFrom.json`
+  - Non-default account: `<channel>-<accountId>-allowFrom.json`
+
+Account scoping behavior:
+
+- Non-default accounts read/write only their scoped allowlist file.
+- Default account uses the channel-scoped unscoped allowlist file.
 
 Treat these as sensitive (they gate access to your assistant).
 

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -200,7 +200,9 @@ Use this when auditing access or deciding what to back up:
 - **Telegram bot token**: config/env or `channels.telegram.tokenFile`
 - **Discord bot token**: config/env (token file not yet supported)
 - **Slack tokens**: config/env (`channels.slack.*`)
-- **Pairing allowlists**: `~/.remoteclaw/credentials/<channel>-allowFrom.json`
+- **Pairing allowlists**:
+  - `~/.remoteclaw/credentials/<channel>-allowFrom.json` (default account)
+  - `~/.remoteclaw/credentials/<channel>-<accountId>-allowFrom.json` (non-default accounts)
 
 ## Security Audit Checklist
 
@@ -481,7 +483,7 @@ If you run multiple accounts on the same channel, use `per-account-channel-peer`
 RemoteClaw has two separate “who can trigger me?” layers:
 
 - **DM allowlist** (`allowFrom` / `channels.discord.allowFrom` / `channels.slack.allowFrom`; legacy: `channels.discord.dm.allowFrom`, `channels.slack.dm.allowFrom`): who is allowed to talk to the bot in direct messages.
-  - When `dmPolicy="pairing"`, approvals are written to `~/.remoteclaw/credentials/<channel>-allowFrom.json` (merged with config allowlists).
+  - When `dmPolicy="pairing"`, approvals are written to the account-scoped pairing allowlist store under `~/.remoteclaw/credentials/` (`<channel>-allowFrom.json` for default account, `<channel>-<accountId>-allowFrom.json` for non-default accounts), merged with config allowlists.
 - **Group allowlist** (channel-specific): which groups/channels/guilds the bot will accept messages from at all.
   - Common patterns:
     - `channels.whatsapp.groups`, `channels.telegram.groups`, `channels.imessage.groups`: per-group defaults like `requireMention`; when set, it also acts as a group allowlist (include `"*"` to keep allow-all behavior).

--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -130,7 +130,9 @@ Use this when debugging auth or deciding what to back up:
 - **Telegram bot token**: config/env or `channels.telegram.tokenFile`
 - **Discord bot token**: config/env (token file not yet supported)
 - **Slack tokens**: config/env (`channels.slack.*`)
-- **Pairing allowlists**: `~/.remoteclaw/credentials/<channel>-allowFrom.json`
+- **Pairing allowlists**:
+  - `~/.remoteclaw/credentials/<channel>-allowFrom.json` (default account)
+  - `~/.remoteclaw/credentials/<channel>-<accountId>-allowFrom.json` (non-default accounts)
 - **Agent auth profiles**: `~/.remoteclaw/agents/<agentId>/agent/auth-profiles.json`
   More detail: [Security](/gateway/security#credential-storage-map).
 

--- a/src/pairing/pairing-store.test.ts
+++ b/src/pairing/pairing-store.test.ts
@@ -35,11 +35,17 @@ async function withTempStateDir<T>(fn: (stateDir: string) => Promise<T>) {
 }
 
 async function writeJsonFixture(filePath: string, value: unknown) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
 function resolvePairingFilePath(stateDir: string, channel: string) {
   return path.join(resolveOAuthDir(process.env, stateDir), `${channel}-pairing.json`);
+}
+
+function resolveAllowFromFilePath(stateDir: string, channel: string, accountId?: string) {
+  const suffix = accountId ? `-${accountId}` : "";
+  return path.join(resolveOAuthDir(process.env, stateDir), `${channel}${suffix}-allowFrom.json`);
 }
 
 async function writeAllowFromFixture(params: {
@@ -274,7 +280,67 @@ describe("pairing store", () => {
       const scoped = readChannelAllowFromStoreSync("telegram", process.env, "yy");
       const channelScoped = readChannelAllowFromStoreSync("telegram");
       expect(scoped).toEqual(["1002", "1001"]);
-      expect(channelScoped).toEqual(["1001", "1001"]);
+      expect(channelScoped).toEqual(["1001"]);
+    });
+  });
+
+  it("does not read legacy channel-scoped allowFrom for non-default account ids", async () => {
+    await withTempStateDir(async (stateDir) => {
+      await writeAllowFromFixture({
+        stateDir,
+        channel: "telegram",
+        allowFrom: ["1001", "*", "1002", "1001"],
+      });
+      await writeAllowFromFixture({
+        stateDir,
+        channel: "telegram",
+        accountId: "yy",
+        allowFrom: ["1003"],
+      });
+
+      const asyncScoped = await readChannelAllowFromStore("telegram", process.env, "yy");
+      const syncScoped = readChannelAllowFromStoreSync("telegram", process.env, "yy");
+      expect(asyncScoped).toEqual(["1003"]);
+      expect(syncScoped).toEqual(["1003"]);
+    });
+  });
+
+  it("does not fall back to legacy allowFrom when scoped file exists but is empty", async () => {
+    await withTempStateDir(async (stateDir) => {
+      await writeAllowFromFixture({
+        stateDir,
+        channel: "telegram",
+        allowFrom: ["1001"],
+      });
+      await writeAllowFromFixture({
+        stateDir,
+        channel: "telegram",
+        accountId: "yy",
+        allowFrom: [],
+      });
+
+      const asyncScoped = await readChannelAllowFromStore("telegram", process.env, "yy");
+      const syncScoped = readChannelAllowFromStoreSync("telegram", process.env, "yy");
+      expect(asyncScoped).toEqual([]);
+      expect(syncScoped).toEqual([]);
+    });
+  });
+
+  it("keeps async and sync reads aligned for malformed scoped allowFrom files", async () => {
+    await withTempStateDir(async (stateDir) => {
+      await writeAllowFromFixture({
+        stateDir,
+        channel: "telegram",
+        allowFrom: ["1001"],
+      });
+      const malformedScopedPath = resolveAllowFromFilePath(stateDir, "telegram", "yy");
+      await fs.mkdir(path.dirname(malformedScopedPath), { recursive: true });
+      await fs.writeFile(malformedScopedPath, "{ this is not json\n", "utf8");
+
+      const asyncScoped = await readChannelAllowFromStore("telegram", process.env, "yy");
+      const syncScoped = readChannelAllowFromStoreSync("telegram", process.env, "yy");
+      expect(asyncScoped).toEqual([]);
+      expect(syncScoped).toEqual([]);
     });
   });
 

--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -237,7 +237,9 @@ function normalizeAllowEntry(channel: PairingChannel, entry: string): string {
 
 function normalizeAllowFromList(channel: PairingChannel, store: AllowFromStore): string[] {
   const list = Array.isArray(store.allowFrom) ? store.allowFrom : [];
-  return list.map((v) => normalizeAllowEntry(channel, String(v))).filter(Boolean);
+  return dedupePreserveOrder(
+    list.map((v) => normalizeAllowEntry(channel, String(v))).filter(Boolean),
+  );
 }
 
 function normalizeAllowFromInput(channel: PairingChannel, entry: string | number): string {
@@ -262,20 +264,46 @@ async function readAllowFromStateForPath(
   channel: PairingChannel,
   filePath: string,
 ): Promise<string[]> {
-  const { value } = await readJsonFile<AllowFromStore>(filePath, {
+  return (await readAllowFromStateForPathWithExists(channel, filePath)).entries;
+}
+
+async function readAllowFromStateForPathWithExists(
+  channel: PairingChannel,
+  filePath: string,
+): Promise<{ entries: string[]; exists: boolean }> {
+  const { value, exists } = await readJsonFile<AllowFromStore>(filePath, {
     version: 1,
     allowFrom: [],
   });
-  return normalizeAllowFromList(channel, value);
+  const entries = normalizeAllowFromList(channel, value);
+  return { entries, exists };
 }
 
 function readAllowFromStateForPathSync(channel: PairingChannel, filePath: string): string[] {
+  return readAllowFromStateForPathSyncWithExists(channel, filePath).entries;
+}
+
+function readAllowFromStateForPathSyncWithExists(
+  channel: PairingChannel,
+  filePath: string,
+): { entries: string[]; exists: boolean } {
+  let raw = "";
   try {
-    const raw = fs.readFileSync(filePath, "utf8");
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "ENOENT") {
+      return { entries: [], exists: false };
+    }
+    return { entries: [], exists: false };
+  }
+  try {
     const parsed = JSON.parse(raw) as AllowFromStore;
-    return normalizeAllowFromList(channel, parsed);
+    const entries = normalizeAllowFromList(channel, parsed);
+    return { entries, exists: true };
   } catch {
-    return [];
+    // Keep parity with async reads: malformed JSON still means the file exists.
+    return { entries: [], exists: true };
   }
 }
 
@@ -298,6 +326,24 @@ async function writeAllowFromState(filePath: string, allowFrom: string[]): Promi
     version: 1,
     allowFrom,
   } satisfies AllowFromStore);
+}
+
+async function readNonDefaultAccountAllowFrom(params: {
+  channel: PairingChannel;
+  env: NodeJS.ProcessEnv;
+  accountId: string;
+}): Promise<string[]> {
+  const scopedPath = resolveAllowFromPath(params.channel, params.env, params.accountId);
+  return await readAllowFromStateForPath(params.channel, scopedPath);
+}
+
+function readNonDefaultAccountAllowFromSync(params: {
+  channel: PairingChannel;
+  env: NodeJS.ProcessEnv;
+  accountId: string;
+}): string[] {
+  const scopedPath = resolveAllowFromPath(params.channel, params.env, params.accountId);
+  return readAllowFromStateForPathSync(params.channel, scopedPath);
 }
 
 async function updateAllowFromStoreEntry(params: {
@@ -342,6 +388,13 @@ export async function readChannelAllowFromStore(
     return await readAllowFromStateForPath(channel, filePath);
   }
 
+  if (!shouldIncludeLegacyAllowFromEntries(normalizedAccountId)) {
+    return await readNonDefaultAccountAllowFrom({
+      channel,
+      env,
+      accountId: normalizedAccountId,
+    });
+  }
   const scopedPath = resolveAllowFromPath(channel, env, accountId);
   const scopedEntries = await readAllowFromStateForPath(channel, scopedPath);
   // Backward compatibility: legacy channel-level allowFrom store was unscoped.
@@ -362,6 +415,13 @@ export function readChannelAllowFromStoreSync(
     return readAllowFromStateForPathSync(channel, filePath);
   }
 
+  if (!shouldIncludeLegacyAllowFromEntries(normalizedAccountId)) {
+    return readNonDefaultAccountAllowFromSync({
+      channel,
+      env,
+      accountId: normalizedAccountId,
+    });
+  }
   const scopedPath = resolveAllowFromPath(channel, env, accountId);
   const scopedEntries = readAllowFromStateForPathSync(channel, scopedPath);
   const legacyPath = resolveAllowFromPath(channel, env);
@@ -503,7 +563,13 @@ export async function upsertChannelPairingRequest(params: {
         nowMs,
       );
       reqs = prunedExpired;
-      const existingIdx = reqs.findIndex((r) => r.id === id);
+      const normalizedMatchingAccountId = normalizePairingAccountId(normalizedAccountId);
+      const existingIdx = reqs.findIndex((r) => {
+        if (r.id !== id) {
+          return false;
+        }
+        return requestMatchesAccountId(r, normalizedMatchingAccountId);
+      });
       const existingCodes = new Set(
         reqs.map((req) =>
           String(req.code ?? "")


### PR DESCRIPTION
Cherry-pick of openclaw/openclaw@91a3f0a3fe.

**Original author:** Gustavo Madeira Santana <gumadeiras@gmail.com>
**Original message:** pairing: enforce strict account-scoped state

## What changed

Enforces strict account-scoped isolation in the pairing store:

- Channel-scoped (legacy) allowFrom no longer falls back for non-default accounts
- `findIndex` for existing pairing requests now matches by both ID and account scope
- Docs updated with account-scoped file path patterns (default vs non-default accounts)
- 3 new tests: non-default account isolation, empty scoped file, malformed scoped file

## Conflicts resolved

- `docs/gateway/security/index.md`: Took upstream's multi-line pairing allowlist format, rebranded `~/.openclaw/` → `~/.remoteclaw/`. Kept fork's removals (no Model auth profiles or Legacy OAuth lines).
- `docs/start/setup.md`: Same rebrand + kept fork's "Agent auth profiles" naming.
- `src/pairing/pairing-store.test.ts`: Took upstream's `channelScoped` dedup fix (`["1001"]` not `["1001", "1001"]`) and 3 new tests.
- `src/pairing/pairing-store.ts`: Took upstream's account-scoped `findIndex` with `requestMatchesAccountId`.
- `CHANGELOG.md`: Discarded (gutted layer).

Cherry-picked-from: openclaw/openclaw@91a3f0a3fe
Part of #595