### PR TITLE
cherry-pick: harden channel auth path checks (da0ba1b, partial)

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -88,6 +88,19 @@ function isCanvasPath(pathname: string): boolean {
   );
 }
 
+function decodePathnameOnce(pathname: string): string {
+  try {
+    return decodeURIComponent(pathname);
+  } catch {
+    return pathname;
+  }
+}
+
+function isProtectedPluginChannelPath(pathname: string): boolean {
+  const normalized = decodePathnameOnce(pathname).toLowerCase();
+  return normalized === "/api/channels" || normalized.startsWith("/api/channels/");
+}
+
 function isNodeWsClient(client: GatewayWsClient): boolean {
   if (client.connect.role === "node") {
     return true;
@@ -491,7 +504,7 @@ export function createGatewayHttpServer(opts: {
         // Channel HTTP endpoints are gateway-auth protected by default.
         // Non-channel plugin routes remain plugin-owned and must enforce
         // their own auth when exposing sensitive functionality.
-        if (requestPath === "/api/channels" || requestPath.startsWith("/api/channels/")) {
+        if (isProtectedPluginChannelPath(requestPath)) {
           const token = getBearerToken(req);
           const authResult = await authorizeHttpGatewayConnect({
             auth: resolvedAuth,

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -1,7 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, expect, test, vi } from "vitest";
+import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { createGatewayHttpServer } from "./server-http.js";
+import type { HooksConfigResolved } from "./hooks.js";
+import { createGatewayHttpServer, createHooksRequestHandler } from "./server-http.js";
 import { withTempConfig } from "./test-temp-config.js";
 
 function createRequest(params: {
@@ -63,6 +65,25 @@ async function dispatchRequest(
 ): Promise<void> {
   server.emit("request", req, res);
   await new Promise((resolve) => setImmediate(resolve));
+}
+
+function createHooksConfig(): HooksConfigResolved {
+  return {
+    basePath: "/hooks",
+    token: "hook-secret",
+    maxBodyBytes: 1024,
+    mappings: [],
+    agentPolicy: {
+      defaultAgentId: "main",
+      knownAgentIds: new Set(["main"]),
+      allowedAgentIds: undefined,
+    },
+    sessionPolicy: {
+      allowRequestSessionKey: false,
+      defaultSessionKey: undefined,
+      allowedSessionKeyPrefixes: undefined,
+    },
+  };
 }
 
 describe("gateway plugin HTTP auth boundary", () => {
@@ -217,6 +238,175 @@ describe("gateway plugin HTTP auth boundary", () => {
         expect(unauthenticatedPublic.getBody()).toContain('"route":"public"');
 
         expect(handlePluginRequest).toHaveBeenCalledTimes(2);
+      },
+    });
+  });
+
+  test("requires gateway auth for canonicalized /api/channels variants", async () => {
+    const resolvedAuth: ResolvedGatewayAuth = {
+      mode: "token",
+      token: "test-token",
+      password: undefined,
+      allowTailscale: false,
+    };
+
+    await withTempConfig({
+      cfg: { gateway: { trustedProxies: [] } },
+      prefix: "openclaw-plugin-http-auth-canonicalized-test-",
+      run: async () => {
+        const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
+          const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+          const canonicalPath = decodeURIComponent(pathname).toLowerCase();
+          if (canonicalPath === "/api/channels/nostr/default/profile") {
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "application/json; charset=utf-8");
+            res.end(JSON.stringify({ ok: true, route: "channel-canonicalized" }));
+            return true;
+          }
+          return false;
+        });
+
+        const server = createGatewayHttpServer({
+          canvasHost: null,
+          clients: new Set(),
+          controlUiEnabled: false,
+          controlUiBasePath: "/__control__",
+          openAiChatCompletionsEnabled: false,
+          openResponsesEnabled: false,
+          handleHooksRequest: async () => false,
+          handlePluginRequest,
+          resolvedAuth,
+        });
+
+        const unauthenticatedCaseVariant = createResponse();
+        await dispatchRequest(
+          server,
+          createRequest({ path: "/API/channels/nostr/default/profile" }),
+          unauthenticatedCaseVariant.res,
+        );
+        expect(unauthenticatedCaseVariant.res.statusCode).toBe(401);
+        expect(unauthenticatedCaseVariant.getBody()).toContain("Unauthorized");
+        expect(handlePluginRequest).not.toHaveBeenCalled();
+
+        const unauthenticatedEncodedSlash = createResponse();
+        await dispatchRequest(
+          server,
+          createRequest({ path: "/api/channels%2Fnostr%2Fdefault%2Fprofile" }),
+          unauthenticatedEncodedSlash.res,
+        );
+        expect(unauthenticatedEncodedSlash.res.statusCode).toBe(401);
+        expect(unauthenticatedEncodedSlash.getBody()).toContain("Unauthorized");
+        expect(handlePluginRequest).not.toHaveBeenCalled();
+
+        const authenticatedCaseVariant = createResponse();
+        await dispatchRequest(
+          server,
+          createRequest({
+            path: "/API/channels/nostr/default/profile",
+            authorization: "Bearer test-token",
+          }),
+          authenticatedCaseVariant.res,
+        );
+        expect(authenticatedCaseVariant.res.statusCode).toBe(200);
+        expect(authenticatedCaseVariant.getBody()).toContain('"route":"channel-canonicalized"');
+        expect(handlePluginRequest).toHaveBeenCalledTimes(1);
+      },
+    });
+  });
+
+  test.each(["0.0.0.0", "::"])(
+    "returns 404 (not 500) for non-hook routes with hooks enabled and bindHost=%s",
+    async (bindHost) => {
+      const resolvedAuth: ResolvedGatewayAuth = {
+        mode: "none",
+        token: undefined,
+        password: undefined,
+        allowTailscale: false,
+      };
+
+      await withTempConfig({
+        cfg: { gateway: { trustedProxies: [] } },
+        prefix: "openclaw-plugin-http-hooks-bindhost-",
+        run: async () => {
+          const handleHooksRequest = createHooksRequestHandler({
+            getHooksConfig: () => createHooksConfig(),
+            bindHost,
+            port: 18789,
+            logHooks: {
+              warn: vi.fn(),
+              debug: vi.fn(),
+              info: vi.fn(),
+              error: vi.fn(),
+            } as unknown as ReturnType<typeof createSubsystemLogger>,
+            dispatchWakeHook: () => {},
+            dispatchAgentHook: () => "run-1",
+          });
+          const server = createGatewayHttpServer({
+            canvasHost: null,
+            clients: new Set(),
+            controlUiEnabled: false,
+            controlUiBasePath: "/__control__",
+            openAiChatCompletionsEnabled: false,
+            openResponsesEnabled: false,
+            handleHooksRequest,
+            resolvedAuth,
+          });
+
+          const response = createResponse();
+          await dispatchRequest(server, createRequest({ path: "/" }), response.res);
+
+          expect(response.res.statusCode).toBe(404);
+          expect(response.getBody()).toBe("Not Found");
+        },
+      });
+    },
+  );
+
+  test("rejects query-token hooks requests with bindHost=::", async () => {
+    const resolvedAuth: ResolvedGatewayAuth = {
+      mode: "none",
+      token: undefined,
+      password: undefined,
+      allowTailscale: false,
+    };
+
+    await withTempConfig({
+      cfg: { gateway: { trustedProxies: [] } },
+      prefix: "openclaw-plugin-http-hooks-query-token-",
+      run: async () => {
+        const handleHooksRequest = createHooksRequestHandler({
+          getHooksConfig: () => createHooksConfig(),
+          bindHost: "::",
+          port: 18789,
+          logHooks: {
+            warn: vi.fn(),
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+          } as unknown as ReturnType<typeof createSubsystemLogger>,
+          dispatchWakeHook: () => {},
+          dispatchAgentHook: () => "run-1",
+        });
+        const server = createGatewayHttpServer({
+          canvasHost: null,
+          clients: new Set(),
+          controlUiEnabled: false,
+          controlUiBasePath: "/__control__",
+          openAiChatCompletionsEnabled: false,
+          openResponsesEnabled: false,
+          handleHooksRequest,
+          resolvedAuth,
+        });
+
+        const response = createResponse();
+        await dispatchRequest(
+          server,
+          createRequest({ path: "/hooks/wake?token=bad" }),
+          response.res,
+        );
+
+        expect(response.res.statusCode).toBe(400);
+        expect(response.getBody()).toContain("Hook token must be provided");
       },
     });
   });


### PR DESCRIPTION
Cherry-pick of openclaw/openclaw@da0ba1b73a (**PARTIAL** — gateway auth only).

**Original author:** Peter Steinberger <steipete@gmail.com>
**Original message:** fix(security): harden channel auth path checks and exec approval routing

## What changed (partial pick — gateway auth only)

Adds URL-decoding and case-insensitive matching for the `/api/channels` protected route check in `server-http.ts`:

- `decodePathnameOnce()` — safely decodes `%2F` and similar encoded sequences
- `isProtectedPluginChannelPath()` — decode + lowercase before prefix matching
- Call site updated from literal string match to `isProtectedPluginChannelPath(requestPath)`
- New test: canonicalized variant coverage (case, encoded-slash, authenticated pass-through)
- New tests: hooks auth boundary (404 for non-hook routes, query-token rejection)

## Skipped files (exec-approval routing — gutted in fork)

All `src/agents/` files (exec-approval routing changes), `src/gateway/protocol/schema/exec-approvals.ts`, `src/gateway/server-methods/exec-approval.ts`, `src/gateway/server-methods/server-methods.test.ts`, `src/infra/exec-approval-forwarder.*`, `src/infra/exec-approvals.ts`, `CHANGELOG.md`.

## Conflicts resolved

- `server.plugin-http-auth.test.ts`: Fork's main lacked hooks tests (added by commit 5 on separate branch). Took upstream's canonicalized variant test + hooks tests. Added missing imports (`createSubsystemLogger`, `HooksConfigResolved`, `createHooksRequestHandler`) and `createHooksConfig` helper.
- Multiple modify/delete conflicts for gutted agents/exec-approval files — all discarded (files don't exist in fork).

Cherry-picked-from: openclaw/openclaw@da0ba1b73a
Part of #595