### PR TITLE
Cherry-pick eac86c2: refactor: unify boundary hardening for file reads

### DIFF
--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -610,4 +610,66 @@ describe("agents.files.set", () => {
     );
     expect(mocks.fsWriteFile).not.toHaveBeenCalled();
   });
+
+  it("rejects agents.files.get when allowlisted file is a hardlinked alias", async () => {
+    const workspace = "/workspace/test-agent";
+    const candidate = path.resolve(workspace, "AGENTS.md");
+    mocks.fsRealpath.mockImplementation(async (p: string) => {
+      if (p === workspace) {
+        return workspace;
+      }
+      return p;
+    });
+    mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
+      const p = typeof args[0] === "string" ? args[0] : "";
+      if (p === candidate) {
+        return makeFileStat({ nlink: 2 });
+      }
+      throw createEnoentError();
+    });
+
+    const { respond, promise } = makeCall("agents.files.get", {
+      agentId: "main",
+      name: "AGENTS.md",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("unsafe workspace file") }),
+    );
+  });
+
+  it("rejects agents.files.set when allowlisted file is a hardlinked alias", async () => {
+    const workspace = "/workspace/test-agent";
+    const candidate = path.resolve(workspace, "AGENTS.md");
+    mocks.fsRealpath.mockImplementation(async (p: string) => {
+      if (p === workspace) {
+        return workspace;
+      }
+      return p;
+    });
+    mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
+      const p = typeof args[0] === "string" ? args[0] : "";
+      if (p === candidate) {
+        return makeFileStat({ nlink: 2 });
+      }
+      throw createEnoentError();
+    });
+
+    const { respond, promise } = makeCall("agents.files.set", {
+      agentId: "main",
+      name: "AGENTS.md",
+      content: "x",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("unsafe workspace file") }),
+    );
+    expect(mocks.fsOpen).not.toHaveBeenCalled();
+  });
 });

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -5,10 +5,11 @@
  * and from directory-based discovery (bundled, managed, workspace)
  */
 
+import fs from "node:fs";
 import path from "node:path";
 import type { RemoteClawConfig } from "../config/config.js";
+import { openBoundaryFile } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { isPathInsideWithRealpath } from "../security/scan-paths.js";
 import { resolveHookConfig } from "./config.js";
 import { shouldIncludeHook } from "./config.js";
 import { buildImportUrl } from "./import-url.js";
@@ -73,18 +74,23 @@ export async function loadInternalHooks(
       }
 
       try {
-        if (
-          !isPathInsideWithRealpath(entry.hook.baseDir, entry.hook.handlerPath, {
-            requireRealpath: true,
-          })
-        ) {
+        const hookBaseDir = safeRealpathOrResolve(entry.hook.baseDir);
+        const opened = await openBoundaryFile({
+          absolutePath: entry.hook.handlerPath,
+          rootPath: hookBaseDir,
+          boundaryLabel: "hook directory",
+        });
+        if (!opened.ok) {
           log.error(
-            `Hook '${entry.hook.name}' handler path resolves outside hook directory: ${entry.hook.handlerPath}`,
+            `Hook '${entry.hook.name}' handler path fails boundary checks: ${entry.hook.handlerPath}`,
           );
           continue;
         }
+        const safeHandlerPath = opened.path;
+        fs.closeSync(opened.fd);
+
         // Import handler module — only cache-bust mutable (workspace/managed) hooks
-        const importUrl = buildImportUrl(entry.hook.handlerPath, entry.hook.source);
+        const importUrl = buildImportUrl(safeHandlerPath, entry.hook.source);
         const mod = (await import(importUrl)) as Record<string, unknown>;
 
         // Get handler function (default or named export)
@@ -144,24 +150,27 @@ export async function loadInternalHooks(
       }
       const baseDir = path.resolve(workspaceDir);
       const modulePath = path.resolve(baseDir, rawModule);
+      const baseDirReal = safeRealpathOrResolve(baseDir);
+      const modulePathSafe = safeRealpathOrResolve(modulePath);
       const rel = path.relative(baseDir, modulePath);
       if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {
         log.error(`Handler module path must stay within workspaceDir: ${rawModule}`);
         continue;
       }
-      if (
-        !isPathInsideWithRealpath(baseDir, modulePath, {
-          requireRealpath: true,
-        })
-      ) {
-        log.error(
-          `Handler module path resolves outside workspaceDir after symlink resolution: ${rawModule}`,
-        );
+      const opened = await openBoundaryFile({
+        absolutePath: modulePathSafe,
+        rootPath: baseDirReal,
+        boundaryLabel: "workspace directory",
+      });
+      if (!opened.ok) {
+        log.error(`Handler module path fails boundary checks under workspaceDir: ${rawModule}`);
         continue;
       }
+      const safeModulePath = opened.path;
+      fs.closeSync(opened.fd);
 
       // Legacy handlers are always workspace-relative, so use mtime-based cache busting
-      const importUrl = buildImportUrl(modulePath, "remoteclaw-workspace");
+      const importUrl = buildImportUrl(safeModulePath, "remoteclaw-workspace");
       const mod = (await import(importUrl)) as Record<string, unknown>;
 
       // Get the handler function
@@ -189,4 +198,12 @@ export async function loadInternalHooks(
   }
 
   return loadedCount;
+}
+
+function safeRealpathOrResolve(value: string): string {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return path.resolve(value);
+  }
 }

--- a/src/hooks/workspace.test.ts
+++ b/src/hooks/workspace.test.ts
@@ -103,4 +103,67 @@ describe("hooks workspace", () => {
     const entries = loadHookEntriesFromDir({ dir: hooksRoot, source: "remoteclaw-workspace" });
     expect(entries.some((e) => e.hook.name === "outside")).toBe(false);
   });
+
+  it("ignores hooks with hardlinked HOOK.md aliases", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-workspace-hardlink-"));
+    const hooksRoot = path.join(root, "hooks");
+    fs.mkdirSync(hooksRoot, { recursive: true });
+
+    const hookDir = path.join(hooksRoot, "hardlink-hook");
+    const outsideDir = path.join(root, "outside");
+    fs.mkdirSync(hookDir, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(path.join(hookDir, "handler.js"), "export default async () => {};\n");
+    const outsideHookMd = path.join(outsideDir, "HOOK.md");
+    const linkedHookMd = path.join(hookDir, "HOOK.md");
+    fs.writeFileSync(linkedHookMd, "---\nname: hardlink-hook\n---\n");
+    fs.rmSync(linkedHookMd);
+    fs.writeFileSync(outsideHookMd, "---\nname: outside\n---\n");
+    try {
+      fs.linkSync(outsideHookMd, linkedHookMd);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    const entries = loadHookEntriesFromDir({ dir: hooksRoot, source: "openclaw-workspace" });
+    expect(entries.some((e) => e.hook.name === "hardlink-hook")).toBe(false);
+    expect(entries.some((e) => e.hook.name === "outside")).toBe(false);
+  });
+
+  it("ignores hooks with hardlinked handler aliases", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-workspace-hardlink-"));
+    const hooksRoot = path.join(root, "hooks");
+    fs.mkdirSync(hooksRoot, { recursive: true });
+
+    const hookDir = path.join(hooksRoot, "hardlink-handler-hook");
+    const outsideDir = path.join(root, "outside");
+    fs.mkdirSync(hookDir, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(path.join(hookDir, "HOOK.md"), "---\nname: hardlink-handler-hook\n---\n");
+    const outsideHandler = path.join(outsideDir, "handler.js");
+    const linkedHandler = path.join(hookDir, "handler.js");
+    fs.writeFileSync(outsideHandler, "export default async () => {};\n");
+    try {
+      fs.linkSync(outsideHandler, linkedHandler);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    const entries = loadHookEntriesFromDir({ dir: hooksRoot, source: "openclaw-workspace" });
+    expect(entries.some((e) => e.hook.name === "hardlink-handler-hook")).toBe(false);
+  });
 });

--- a/src/hooks/workspace.ts
+++ b/src/hooks/workspace.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { RemoteClawConfig } from "../config/config.js";
+import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isPathInsideWithRealpath } from "../security/scan-paths.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
@@ -37,11 +38,15 @@ function filterHookEntries(
 
 function readHookPackageManifest(dir: string): HookPackageManifest | null {
   const manifestPath = path.join(dir, "package.json");
-  if (!fs.existsSync(manifestPath)) {
+  const raw = readBoundaryFileUtf8({
+    absolutePath: manifestPath,
+    rootPath: dir,
+    boundaryLabel: "hook package directory",
+  });
+  if (raw === null) {
     return null;
   }
   try {
-    const raw = fs.readFileSync(manifestPath, "utf-8");
     return JSON.parse(raw) as HookPackageManifest;
   } catch {
     return null;
@@ -76,12 +81,15 @@ function loadHookFromDir(params: {
   nameHint?: string;
 }): Hook | null {
   const hookMdPath = path.join(params.hookDir, "HOOK.md");
-  if (!fs.existsSync(hookMdPath)) {
+  const content = readBoundaryFileUtf8({
+    absolutePath: hookMdPath,
+    rootPath: params.hookDir,
+    boundaryLabel: "hook directory",
+  });
+  if (content === null) {
     return null;
   }
-
   try {
-    const content = fs.readFileSync(hookMdPath, "utf-8");
     const frontmatter = parseFrontmatter(content);
 
     const name = frontmatter.name || params.nameHint || path.basename(params.hookDir);
@@ -91,8 +99,13 @@ function loadHookFromDir(params: {
     let handlerPath: string | undefined;
     for (const candidate of handlerCandidates) {
       const candidatePath = path.join(params.hookDir, candidate);
-      if (fs.existsSync(candidatePath)) {
-        handlerPath = candidatePath;
+      const safeCandidatePath = resolveBoundaryFilePath({
+        absolutePath: candidatePath,
+        rootPath: params.hookDir,
+        boundaryLabel: "hook directory",
+      });
+      if (safeCandidatePath) {
+        handlerPath = safeCandidatePath;
         break;
       }
     }
@@ -193,11 +206,13 @@ export function loadHookEntriesFromDir(params: {
   });
   return hooks.map((hook) => {
     let frontmatter: ParsedHookFrontmatter = {};
-    try {
-      const raw = fs.readFileSync(hook.filePath, "utf-8");
+    const raw = readBoundaryFileUtf8({
+      absolutePath: hook.filePath,
+      rootPath: hook.baseDir,
+      boundaryLabel: "hook directory",
+    });
+    if (raw !== null) {
       frontmatter = parseFrontmatter(raw);
-    } catch {
-      // ignore malformed hooks
     }
     const entry: HookEntry = {
       hook: {
@@ -268,11 +283,13 @@ function loadHookEntries(
 
   return Array.from(merged.values()).map((hook) => {
     let frontmatter: ParsedHookFrontmatter = {};
-    try {
-      const raw = fs.readFileSync(hook.filePath, "utf-8");
+    const raw = readBoundaryFileUtf8({
+      absolutePath: hook.filePath,
+      rootPath: hook.baseDir,
+      boundaryLabel: "hook directory",
+    });
+    if (raw !== null) {
       frontmatter = parseFrontmatter(raw);
-    } catch {
-      // ignore malformed hooks
     }
     return {
       hook,
@@ -316,4 +333,44 @@ export function loadWorkspaceHookEntries(
   },
 ): HookEntry[] {
   return loadHookEntries(workspaceDir, opts);
+}
+
+function readBoundaryFileUtf8(params: {
+  absolutePath: string;
+  rootPath: string;
+  boundaryLabel: string;
+}): string | null {
+  const opened = openBoundaryFileSync({
+    absolutePath: params.absolutePath,
+    rootPath: params.rootPath,
+    boundaryLabel: params.boundaryLabel,
+  });
+  if (!opened.ok) {
+    return null;
+  }
+  try {
+    return fs.readFileSync(opened.fd, "utf-8");
+  } catch {
+    return null;
+  } finally {
+    fs.closeSync(opened.fd);
+  }
+}
+
+function resolveBoundaryFilePath(params: {
+  absolutePath: string;
+  rootPath: string;
+  boundaryLabel: string;
+}): string | null {
+  const opened = openBoundaryFileSync({
+    absolutePath: params.absolutePath,
+    rootPath: params.rootPath,
+    boundaryLabel: params.boundaryLabel,
+  });
+  if (!opened.ok) {
+    return null;
+  }
+  const safePath = opened.path;
+  fs.closeSync(opened.fd);
+  return safePath;
 }

--- a/src/infra/boundary-file-read.ts
+++ b/src/infra/boundary-file-read.ts
@@ -1,0 +1,144 @@
+import fs from "node:fs";
+import path from "node:path";
+import { assertNoPathAliasEscape, type PathAliasPolicy } from "./path-alias-guards.js";
+import { isNotFoundPathError, isPathInside } from "./path-guards.js";
+import { openVerifiedFileSync, type SafeOpenSyncFailureReason } from "./safe-open-sync.js";
+
+type BoundaryReadFs = Pick<
+  typeof fs,
+  | "closeSync"
+  | "constants"
+  | "fstatSync"
+  | "lstatSync"
+  | "openSync"
+  | "readFileSync"
+  | "realpathSync"
+>;
+
+export type BoundaryFileOpenFailureReason = SafeOpenSyncFailureReason | "validation";
+
+export type BoundaryFileOpenResult =
+  | { ok: true; path: string; fd: number; stat: fs.Stats; rootRealPath: string }
+  | { ok: false; reason: BoundaryFileOpenFailureReason; error?: unknown };
+
+export type OpenBoundaryFileSyncParams = {
+  absolutePath: string;
+  rootPath: string;
+  boundaryLabel: string;
+  rootRealPath?: string;
+  maxBytes?: number;
+  rejectHardlinks?: boolean;
+  skipLexicalRootCheck?: boolean;
+  ioFs?: BoundaryReadFs;
+};
+
+export type OpenBoundaryFileParams = OpenBoundaryFileSyncParams & {
+  aliasPolicy?: PathAliasPolicy;
+};
+
+function safeRealpathSync(ioFs: Pick<typeof fs, "realpathSync">, value: string): string {
+  try {
+    return path.resolve(ioFs.realpathSync(value));
+  } catch {
+    return path.resolve(value);
+  }
+}
+
+export function canUseBoundaryFileOpen(ioFs: typeof fs): boolean {
+  return (
+    typeof ioFs.openSync === "function" &&
+    typeof ioFs.closeSync === "function" &&
+    typeof ioFs.fstatSync === "function" &&
+    typeof ioFs.lstatSync === "function" &&
+    typeof ioFs.realpathSync === "function" &&
+    typeof ioFs.readFileSync === "function" &&
+    typeof ioFs.constants === "object" &&
+    ioFs.constants !== null
+  );
+}
+
+export function openBoundaryFileSync(params: OpenBoundaryFileSyncParams): BoundaryFileOpenResult {
+  const ioFs = params.ioFs ?? fs;
+  const absolutePath = path.resolve(params.absolutePath);
+  const rootPath = path.resolve(params.rootPath);
+  const rootRealPath = params.rootRealPath
+    ? path.resolve(params.rootRealPath)
+    : safeRealpathSync(ioFs, rootPath);
+
+  let resolvedPath = absolutePath;
+  const lexicalInsideRoot = isPathInside(rootPath, absolutePath);
+  try {
+    const candidateRealPath = path.resolve(ioFs.realpathSync(absolutePath));
+    if (
+      !params.skipLexicalRootCheck &&
+      !lexicalInsideRoot &&
+      !isPathInside(rootRealPath, candidateRealPath)
+    ) {
+      return {
+        ok: false,
+        reason: "validation",
+        error: new Error(
+          `Path escapes ${params.boundaryLabel}: ${absolutePath} (root: ${rootPath})`,
+        ),
+      };
+    }
+    if (!isPathInside(rootRealPath, candidateRealPath)) {
+      return {
+        ok: false,
+        reason: "validation",
+        error: new Error(
+          `Path resolves outside ${params.boundaryLabel}: ${absolutePath} (root: ${rootRealPath})`,
+        ),
+      };
+    }
+    resolvedPath = candidateRealPath;
+  } catch (error) {
+    if (!params.skipLexicalRootCheck && !lexicalInsideRoot) {
+      return {
+        ok: false,
+        reason: "validation",
+        error: new Error(
+          `Path escapes ${params.boundaryLabel}: ${absolutePath} (root: ${rootPath})`,
+        ),
+      };
+    }
+    if (!isNotFoundPathError(error)) {
+      // Keep resolvedPath as lexical path; openVerifiedFileSync below will produce
+      // a canonical error classification for missing/unreadable targets.
+    }
+  }
+
+  const opened = openVerifiedFileSync({
+    filePath: absolutePath,
+    resolvedPath,
+    rejectHardlinks: params.rejectHardlinks ?? true,
+    maxBytes: params.maxBytes,
+    ioFs,
+  });
+  if (!opened.ok) {
+    return opened;
+  }
+  return {
+    ok: true,
+    path: opened.path,
+    fd: opened.fd,
+    stat: opened.stat,
+    rootRealPath,
+  };
+}
+
+export async function openBoundaryFile(
+  params: OpenBoundaryFileParams,
+): Promise<BoundaryFileOpenResult> {
+  try {
+    await assertNoPathAliasEscape({
+      absolutePath: params.absolutePath,
+      rootPath: params.rootPath,
+      boundaryLabel: params.boundaryLabel,
+      policy: params.aliasPolicy,
+    });
+  } catch (error) {
+    return { ok: false, reason: "validation", error };
+  }
+  return openBoundaryFileSync(params);
+}

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -231,6 +231,46 @@ describe("discoverRemoteClawPlugins", () => {
     );
   });
 
+  it("rejects package extension entries that are hardlinked aliases", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions", "pack");
+    const outsideDir = path.join(stateDir, "outside");
+    const outsideFile = path.join(outsideDir, "escape.ts");
+    const linkedFile = path.join(globalExt, "escape.ts");
+    fs.mkdirSync(globalExt, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(outsideFile, "export default {}", "utf-8");
+    try {
+      fs.linkSync(outsideFile, linkedFile);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    fs.writeFileSync(
+      path.join(globalExt, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/pack",
+        openclaw: { extensions: ["./escape.ts"] },
+      }),
+      "utf-8",
+    );
+
+    const { candidates, diagnostics } = await withStateDir(stateDir, async () => {
+      return discoverOpenClawPlugins({});
+    });
+
+    expect(candidates.some((candidate) => candidate.idHint === "pack")).toBe(false);
+    expect(diagnostics.some((entry) => entry.message.includes("escapes package directory"))).toBe(
+      true,
+    );
+  });
+
   it.runIf(process.platform !== "win32")("blocks world-writable plugin paths", async () => {
     const stateDir = makeTempDir();
     const globalExt = path.join(stateDir, "extensions");

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -528,4 +528,54 @@ describe("loadRemoteClawPlugins", () => {
     expect(record?.status).not.toBe("loaded");
     expect(registry.diagnostics.some((entry) => entry.message.includes("escapes"))).toBe(true);
   });
+
+  it("rejects plugin entry files that escape plugin root via hardlink", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    process.env.REMOTECLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    const pluginDir = makeTempDir();
+    const outsideDir = makeTempDir();
+    const outsideEntry = path.join(outsideDir, "outside.js");
+    const linkedEntry = path.join(pluginDir, "entry.js");
+    fs.writeFileSync(
+      outsideEntry,
+      'export default { id: "hardlinked", register() { throw new Error("should not run"); } };',
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "remoteclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "hardlinked",
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    try {
+      fs.linkSync(outsideEntry, linkedEntry);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    const registry = loadRemoteClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [linkedEntry] },
+          allow: ["hardlinked"],
+        },
+      },
+    });
+
+    const record = registry.plugins.find((entry) => entry.id === "hardlinked");
+    expect(record?.status).not.toBe("loaded");
+    expect(registry.diagnostics.some((entry) => entry.message.includes("escapes"))).toBe(true);
+  });
 });

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -4,8 +4,8 @@ import { fileURLToPath } from "node:url";
 import { createJiti } from "jiti";
 import type { RemoteClawConfig } from "../config/config.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
+import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { isPathInsideWithRealpath } from "../security/scan-paths.js";
 import { resolveUserPath } from "../utils.js";
 import { clearPluginCommands } from "./commands.js";
 import {
@@ -513,13 +513,15 @@ export function loadRemoteClawPlugins(options: PluginLoadOptions = {}): PluginRe
       continue;
     }
 
-    if (
-      !isPathInsideWithRealpath(candidate.rootDir, candidate.source, {
-        requireRealpath: true,
-      })
-    ) {
+    const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
+    const opened = openBoundaryFileSync({
+      absolutePath: candidate.source,
+      rootPath: pluginRoot,
+      boundaryLabel: "plugin root",
+    });
+    if (!opened.ok) {
       record.status = "error";
-      record.error = "plugin entry path escapes plugin root";
+      record.error = "plugin entry path escapes plugin root or fails alias checks";
       registry.plugins.push(record);
       seenIds.set(pluginId, candidate.origin);
       registry.diagnostics.push({
@@ -530,10 +532,12 @@ export function loadRemoteClawPlugins(options: PluginLoadOptions = {}): PluginRe
       });
       continue;
     }
+    const safeSource = opened.path;
+    fs.closeSync(opened.fd);
 
     let mod: RemoteClawPluginModule | null = null;
     try {
-      mod = getJiti()(candidate.source) as RemoteClawPluginModule;
+      mod = getJiti()(safeSource) as RemoteClawPluginModule;
     } catch (err) {
       recordPluginError({
         logger,
@@ -663,4 +667,12 @@ export function loadRemoteClawPlugins(options: PluginLoadOptions = {}): PluginRe
   setActivePluginRegistry(registry, cacheKey);
   initializeGlobalHookRunner(registry);
   return registry;
+}
+
+function safeRealpathOrResolve(value: string): string {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return path.resolve(value);
+  }
 }


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: eac86c2081803fd69d1a20c25129c5fc464e92ce
**Author**: Peter Steinberger <steipete@gmail.com>
**Tier**: RESOLVED (conflicts in rebrand paths + fork-simplified code)

> refactor: unify boundary hardening for file reads

**Conflict resolutions:**
- `agents-mutate.test.ts`: Kept fork version (test helpers deleted by fork)
- `agents.ts` (2 hunks): Kept fork's simplified `statFile` and `walkDir` (fork removed `resolveAgentWorkspaceFilePath`, `statFileSafely`, `writeFileSafely`)
- `hooks/loader.ts`: Merged fork's `RemoteClawConfig` rebrand + upstream's `openBoundaryFile` import + `safeModulePath` usage
- `hooks/workspace.ts`: Merged fork's `RemoteClawConfig` rebrand + upstream's `openBoundaryFileSync` import
- `plugins/loader.ts`: Applied upstream's `safeSource` with fork's `RemoteClawPluginModule` type
- `plugins/loader.test.ts`: Added upstream's hardlink escape test, rebranded (`loadRemoteClawPlugins`, `remoteclaw.plugin.json`, `REMOTECLAW_BUNDLED_PLUGINS_DIR`)
- `boundary-file-read.ts`: Added new module (DU conflict — file didn't exist in fork)

Part of #596