### PR TITLE
cherry-pick: harden root file guards and host writes

### DIFF
--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import type { RemoteClawConfig } from "../config/config.js";
+import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { resolveControlUiRootSync } from "../infra/control-ui-assets.js";
 import { isWithinDir } from "../infra/path-safety.js";
 import { openVerifiedFileSync } from "../infra/safe-open-sync.js";
@@ -210,11 +211,6 @@ function serveResolvedIndexHtml(res: ServerResponse, body: string) {
   res.end(body);
 }
 
-function isContainedPath(baseDir: string, targetPath: string): boolean {
-  const relative = path.relative(baseDir, targetPath);
-  return relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
-}
-
 function isExpectedSafePathError(error: unknown): boolean {
   const code =
     typeof error === "object" && error !== null && "code" in error ? String(error.code) : "";
@@ -237,25 +233,20 @@ function resolveSafeControlUiFile(
   rootReal: string,
   filePath: string,
 ): { path: string; fd: number } | null {
-  try {
-    const fileReal = fs.realpathSync(filePath);
-    if (!isContainedPath(rootReal, fileReal)) {
-      return null;
+  const opened = openBoundaryFileSync({
+    absolutePath: filePath,
+    rootPath: rootReal,
+    rootRealPath: rootReal,
+    boundaryLabel: "control ui root",
+    skipLexicalRootCheck: true,
+  });
+  if (!opened.ok) {
+    if (opened.reason === "io") {
+      throw opened.error;
     }
-    const opened = openVerifiedFileSync({ filePath: fileReal, resolvedPath: fileReal });
-    if (!opened.ok) {
-      if (opened.reason === "io") {
-        throw opened.error;
-      }
-      return null;
-    }
-    return { path: opened.path, fd: opened.fd };
-  } catch (error) {
-    if (isExpectedSafePathError(error)) {
-      return null;
-    }
-    throw error;
+    return null;
   }
+  return { path: opened.path, fd: opened.fd };
 }
 
 function isSafeRelativePath(relPath: string) {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -1,4 +1,3 @@
-import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -18,7 +17,7 @@ import { loadConfig, writeConfigFile } from "../../config/config.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import { resolveSessionTranscriptsDirForAgent } from "../../config/sessions/paths.js";
 import { sameFileIdentity } from "../../infra/file-identity.js";
-import { SafeOpenError, readLocalFileSafely } from "../../infra/fs-safe.js";
+import { SafeOpenError, readLocalFileSafely, writeFileWithinRoot } from "../../infra/fs-safe.js";
 import { isNotFoundPathError, isPathInside } from "../../infra/path-guards.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
 import { resolveUserPath } from "../../utils.js";
@@ -87,13 +86,6 @@ type ResolvedAgentWorkspaceFilePath =
       requestPath: string;
       reason: string;
     };
-
-const SUPPORTS_NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in fsConstants;
-const OPEN_WRITE_FLAGS =
-  fsConstants.O_WRONLY |
-  fsConstants.O_CREAT |
-  fsConstants.O_TRUNC |
-  (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
 
 async function resolveWorkspaceRealPath(workspaceDir: string): Promise<string> {
   try {
@@ -184,22 +176,6 @@ async function statFileSafely(filePath: string): Promise<FileMeta | null> {
     };
   } catch {
     return null;
-  }
-}
-
-async function writeFileSafely(filePath: string, content: string): Promise<void> {
-  const handle = await fs.open(filePath, OPEN_WRITE_FLAGS, 0o600);
-  try {
-    const [stat, lstat] = await Promise.all([handle.stat(), fs.lstat(filePath)]);
-    if (lstat.isSymbolicLink() || !stat.isFile()) {
-      throw new Error("unsafe file path");
-    }
-    if (!sameFileIdentity(stat, lstat)) {
-      throw new Error("path changed during write");
-    }
-    await handle.writeFile(content, "utf-8");
-  } finally {
-    await handle.close().catch(() => {});
   }
 }
 
@@ -749,7 +725,12 @@ export const agentsHandlers: GatewayRequestHandlers = {
     }
     const content = String(params.content ?? "");
     try {
-      await writeFileSafely(resolvedPath.ioPath, content);
+      await writeFileWithinRoot({
+        rootDir: workspaceDir,
+        relativePath: name,
+        data: content,
+        encoding: "utf8",
+      });
     } catch {
       respond(
         false,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -16,7 +16,7 @@ import {
   type SessionEntry,
   type SessionScope,
 } from "../config/sessions.js";
-import { openVerifiedFileSync } from "../infra/safe-open-sync.js";
+import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import {
   normalizeAgentId,
   normalizeMainKey,
@@ -96,14 +96,13 @@ function resolveIdentityAvatarUrl(
     return undefined;
   }
   try {
-    const resolvedReal = fs.realpathSync(resolvedCandidate);
-    if (!isPathWithinRoot(workspaceRoot, resolvedReal)) {
-      return undefined;
-    }
-    const opened = openVerifiedFileSync({
-      filePath: resolvedReal,
-      resolvedPath: resolvedReal,
+    const opened = openBoundaryFileSync({
+      absolutePath: resolvedCandidate,
+      rootPath: workspaceRoot,
+      rootRealPath: workspaceRoot,
+      boundaryLabel: "workspace root",
       maxBytes: AVATAR_MAX_BYTES,
+      skipLexicalRootCheck: true,
     });
     if (!opened.ok) {
       return undefined;

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -2,7 +2,12 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
-import { SafeOpenError, openFileWithinRoot, readLocalFileSafely } from "./fs-safe.js";
+import {
+  SafeOpenError,
+  openFileWithinRoot,
+  readLocalFileSafely,
+  writeFileWithinRoot,
+} from "./fs-safe.js";
 
 const tempDirs = createTrackedTempDirs();
 
@@ -79,6 +84,83 @@ describe("fs-safe", () => {
         relativePath: "link.txt",
       }),
     ).rejects.toMatchObject({ code: "invalid-path" });
+  });
+
+  it.runIf(process.platform !== "win32")("blocks hardlink aliases under root", async () => {
+    const root = await tempDirs.make("remoteclaw-fs-safe-root-");
+    const outside = await tempDirs.make("remoteclaw-fs-safe-outside-");
+    const outsideFile = path.join(outside, "outside.txt");
+    const hardlinkPath = path.join(root, "link.txt");
+    await fs.writeFile(outsideFile, "outside");
+    try {
+      try {
+        await fs.link(outsideFile, hardlinkPath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+          return;
+        }
+        throw err;
+      }
+      await expect(
+        openFileWithinRoot({
+          rootDir: root,
+          relativePath: "link.txt",
+        }),
+      ).rejects.toMatchObject({ code: "invalid-path" });
+    } finally {
+      await fs.rm(hardlinkPath, { force: true });
+      await fs.rm(outsideFile, { force: true });
+    }
+  });
+
+  it("writes a file within root safely", async () => {
+    const root = await tempDirs.make("remoteclaw-fs-safe-root-");
+    await writeFileWithinRoot({
+      rootDir: root,
+      relativePath: "nested/out.txt",
+      data: "hello",
+    });
+    await expect(fs.readFile(path.join(root, "nested", "out.txt"), "utf8")).resolves.toBe("hello");
+  });
+
+  it("rejects write traversal outside root", async () => {
+    const root = await tempDirs.make("remoteclaw-fs-safe-root-");
+    await expect(
+      writeFileWithinRoot({
+        rootDir: root,
+        relativePath: "../escape.txt",
+        data: "x",
+      }),
+    ).rejects.toMatchObject({ code: "invalid-path" });
+  });
+
+  it.runIf(process.platform !== "win32")("rejects writing through hardlink aliases", async () => {
+    const root = await tempDirs.make("remoteclaw-fs-safe-root-");
+    const outside = await tempDirs.make("remoteclaw-fs-safe-outside-");
+    const outsideFile = path.join(outside, "outside.txt");
+    const hardlinkPath = path.join(root, "alias.txt");
+    await fs.writeFile(outsideFile, "outside");
+    try {
+      try {
+        await fs.link(outsideFile, hardlinkPath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+          return;
+        }
+        throw err;
+      }
+      await expect(
+        writeFileWithinRoot({
+          rootDir: root,
+          relativePath: "alias.txt",
+          data: "pwned",
+        }),
+      ).rejects.toMatchObject({ code: "invalid-path" });
+      await expect(fs.readFile(outsideFile, "utf8")).resolves.toBe("outside");
+    } finally {
+      await fs.rm(hardlinkPath, { force: true });
+      await fs.rm(outsideFile, { force: true });
+    }
   });
 
   it("returns not-found for missing files", async () => {

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -4,6 +4,7 @@ import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { sameFileIdentity } from "./file-identity.js";
+import { assertNoPathAliasEscape } from "./path-alias-guards.js";
 import { isNotFoundPathError, isPathInside, isSymlinkOpenError } from "./path-guards.js";
 
 export type SafeOpenErrorCode =
@@ -38,10 +39,20 @@ export type SafeLocalReadResult = {
 
 const SUPPORTS_NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in fsConstants;
 const OPEN_READ_FLAGS = fsConstants.O_RDONLY | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+const OPEN_WRITE_FLAGS =
+  fsConstants.O_WRONLY |
+  fsConstants.O_CREAT |
+  fsConstants.O_TRUNC |
+  (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
 
 const ensureTrailingSep = (value: string) => (value.endsWith(path.sep) ? value : value + path.sep);
 
-async function openVerifiedLocalFile(filePath: string): Promise<SafeOpenResult> {
+async function openVerifiedLocalFile(
+  filePath: string,
+  options?: {
+    rejectHardlinks?: boolean;
+  },
+): Promise<SafeOpenResult> {
   let handle: FileHandle;
   try {
     handle = await fs.open(filePath, OPEN_READ_FLAGS);
@@ -63,12 +74,18 @@ async function openVerifiedLocalFile(filePath: string): Promise<SafeOpenResult> 
     if (!stat.isFile()) {
       throw new SafeOpenError("not-file", "not a file");
     }
+    if (options?.rejectHardlinks && stat.nlink > 1) {
+      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+    }
     if (!sameFileIdentity(stat, lstat)) {
       throw new SafeOpenError("path-mismatch", "path changed during read");
     }
 
     const realPath = await fs.realpath(filePath);
     const realStat = await fs.stat(realPath);
+    if (options?.rejectHardlinks && realStat.nlink > 1) {
+      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+    }
     if (!sameFileIdentity(stat, realStat)) {
       throw new SafeOpenError("path-mismatch", "path mismatch");
     }
@@ -89,6 +106,7 @@ async function openVerifiedLocalFile(filePath: string): Promise<SafeOpenResult> 
 export async function openFileWithinRoot(params: {
   rootDir: string;
   relativePath: string;
+  rejectHardlinks?: boolean;
 }): Promise<SafeOpenResult> {
   let rootReal: string;
   try {
@@ -120,6 +138,11 @@ export async function openFileWithinRoot(params: {
     throw err;
   }
 
+  if (params.rejectHardlinks !== false && opened.stat.nlink > 1) {
+    await opened.handle.close().catch(() => {});
+    throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+  }
+
   if (!isPathInside(rootWithSep, opened.realPath)) {
     await opened.handle.close().catch(() => {});
     throw new SafeOpenError("invalid-path", "path escapes root");
@@ -144,5 +167,102 @@ export async function readLocalFileSafely(params: {
     return { buffer, realPath: opened.realPath, stat: opened.stat };
   } finally {
     await opened.handle.close().catch(() => {});
+  }
+}
+
+export async function writeFileWithinRoot(params: {
+  rootDir: string;
+  relativePath: string;
+  data: string | Buffer;
+  encoding?: BufferEncoding;
+  mkdir?: boolean;
+}): Promise<void> {
+  let rootReal: string;
+  try {
+    rootReal = await fs.realpath(params.rootDir);
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      throw new SafeOpenError("not-found", "root dir not found");
+    }
+    throw err;
+  }
+  const rootWithSep = ensureTrailingSep(rootReal);
+  const resolved = path.resolve(rootWithSep, params.relativePath);
+  if (!isPathInside(rootWithSep, resolved)) {
+    throw new SafeOpenError("invalid-path", "path escapes root");
+  }
+  try {
+    await assertNoPathAliasEscape({
+      absolutePath: resolved,
+      rootPath: rootReal,
+      boundaryLabel: "root",
+    });
+  } catch (err) {
+    throw new SafeOpenError("invalid-path", "path alias escape blocked", { cause: err });
+  }
+  if (params.mkdir !== false) {
+    await fs.mkdir(path.dirname(resolved), { recursive: true });
+  }
+
+  let ioPath = resolved;
+  try {
+    const resolvedRealPath = await fs.realpath(resolved);
+    if (!isPathInside(rootWithSep, resolvedRealPath)) {
+      throw new SafeOpenError("invalid-path", "path escapes root");
+    }
+    ioPath = resolvedRealPath;
+  } catch (err) {
+    if (err instanceof SafeOpenError) {
+      throw err;
+    }
+    if (!isNotFoundPathError(err)) {
+      throw err;
+    }
+  }
+
+  let handle: FileHandle;
+  try {
+    handle = await fs.open(ioPath, OPEN_WRITE_FLAGS, 0o600);
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      throw new SafeOpenError("not-found", "file not found");
+    }
+    if (isSymlinkOpenError(err)) {
+      throw new SafeOpenError("invalid-path", "symlink open blocked", { cause: err });
+    }
+    throw err;
+  }
+
+  try {
+    const [stat, lstat] = await Promise.all([handle.stat(), fs.lstat(ioPath)]);
+    if (lstat.isSymbolicLink() || !stat.isFile()) {
+      throw new SafeOpenError("invalid-path", "path is not a regular file under root");
+    }
+    if (stat.nlink > 1) {
+      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+    }
+    if (!sameFileIdentity(stat, lstat)) {
+      throw new SafeOpenError("path-mismatch", "path changed during write");
+    }
+
+    const realPath = await fs.realpath(ioPath);
+    const realStat = await fs.stat(realPath);
+    if (!sameFileIdentity(stat, realStat)) {
+      throw new SafeOpenError("path-mismatch", "path mismatch");
+    }
+    if (realStat.nlink > 1) {
+      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+    }
+    if (!isPathInside(rootWithSep, realPath)) {
+      throw new SafeOpenError("invalid-path", "path escapes root");
+    }
+
+    if (typeof params.data === "string") {
+      await handle.writeFile(params.data, params.encoding ?? "utf8");
+    } else {
+      await handle.writeFile(params.data);
+    }
+  } finally {
+    await handle.close().catch(() => {});
   }
 }


### PR DESCRIPTION
Cherry-pick of upstream e3385a6578 (openclaw/openclaw#2188).

**PARTIAL PICK** — took gateway and infra files; skipped gutted agent files (apply-patch.ts, pi-tools.*.ts).

Changes:
- `fs-safe.ts`: Add `writeFileWithinRoot` (safe writes with hardlink/symlink/traversal protection), hardlink rejection in `openFileWithinRoot` and `openVerifiedLocalFile`
- `control-ui.ts`: Replace `isContainedPath` + `openVerifiedFileSync` with `openBoundaryFileSync` in `resolveSafeControlUiFile`
- `agents.ts`: Replace `writeFileSafely` with `writeFileWithinRoot`, remove `OPEN_WRITE_FLAGS`/`SUPPORTS_NOFOLLOW` constants
- `session-utils.ts`: Replace `openVerifiedFileSync` with `openBoundaryFileSync` for avatar reads
- `fs-safe.test.ts`: Add hardlink and write safety tests

Rebranded temp dir prefixes in tests (openclaw → remoteclaw).

Part of #596.