### PR TITLE
Cherry-pick e16e8f5: refactor(slack): share system-event ingress and test harness

### DIFF
--- a/src/slack/monitor/events/reactions.test.ts
+++ b/src/slack/monitor/events/reactions.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import type { SlackMonitorContext } from "../context.js";
 import { registerSlackReactionEvents } from "./reactions.js";
+import {
+  createSlackSystemEventTestHarness,
+  type SlackSystemEventTestOverrides,
+} from "./system-event-test-harness.js";
 
 const enqueueSystemEventMock = vi.fn();
 const readAllowFromStoreMock = vi.fn();
@@ -18,44 +21,12 @@ type SlackReactionHandler = (args: {
   body: unknown;
 }) => Promise<void>;
 
-function createReactionContext(overrides?: {
-  dmPolicy?: "open" | "pairing" | "allowlist" | "disabled";
-  allowFrom?: string[];
-  channelType?: "im" | "channel";
-}) {
-  let addedHandler: SlackReactionHandler | null = null;
-  let removedHandler: SlackReactionHandler | null = null;
-  const channelType = overrides?.channelType ?? "im";
-  const app = {
-    event: vi.fn((name: string, handler: SlackReactionHandler) => {
-      if (name === "reaction_added") {
-        addedHandler = handler;
-      } else if (name === "reaction_removed") {
-        removedHandler = handler;
-      }
-    }),
-  };
-  const ctx = {
-    app,
-    runtime: { error: vi.fn() },
-    dmPolicy: overrides?.dmPolicy ?? "open",
-    groupPolicy: "open",
-    allowFrom: overrides?.allowFrom ?? [],
-    allowNameMatching: false,
-    shouldDropMismatchedSlackEvent: vi.fn().mockReturnValue(false),
-    isChannelAllowed: vi.fn().mockReturnValue(true),
-    resolveChannelName: vi.fn().mockResolvedValue({
-      name: channelType === "im" ? "direct" : "general",
-      type: channelType,
-    }),
-    resolveUserName: vi.fn().mockResolvedValue({ name: "alice" }),
-    resolveSlackSystemEventSessionKey: vi.fn().mockReturnValue("agent:main:main"),
-  } as unknown as SlackMonitorContext;
-  registerSlackReactionEvents({ ctx });
+function createReactionContext(overrides?: SlackSystemEventTestOverrides) {
+  const harness = createSlackSystemEventTestHarness(overrides);
+  registerSlackReactionEvents({ ctx: harness.ctx });
   return {
-    ctx,
-    getAddedHandler: () => addedHandler,
-    getRemovedHandler: () => removedHandler,
+    getAddedHandler: () => harness.getHandler("reaction_added") as SlackReactionHandler | null,
+    getRemovedHandler: () => harness.getHandler("reaction_removed") as SlackReactionHandler | null,
   };
 }
 

--- a/src/slack/monitor/events/system-event-context.ts
+++ b/src/slack/monitor/events/system-event-context.ts
@@ -1,0 +1,44 @@
+import { logVerbose } from "../../../globals.js";
+import { authorizeSlackSystemEventSender } from "../auth.js";
+import { resolveSlackChannelLabel } from "../channel-config.js";
+import type { SlackMonitorContext } from "../context.js";
+
+export type SlackAuthorizedSystemEventContext = {
+  channelLabel: string;
+  sessionKey: string;
+};
+
+export async function authorizeAndResolveSlackSystemEventContext(params: {
+  ctx: SlackMonitorContext;
+  senderId?: string;
+  channelId?: string;
+  channelType?: string | null;
+  eventKind: string;
+}): Promise<SlackAuthorizedSystemEventContext | undefined> {
+  const { ctx, senderId, channelId, channelType, eventKind } = params;
+  const auth = await authorizeSlackSystemEventSender({
+    ctx,
+    senderId,
+    channelId,
+    channelType,
+  });
+  if (!auth.allowed) {
+    logVerbose(
+      `slack: drop ${eventKind} sender ${senderId ?? "unknown"} channel=${channelId ?? "unknown"} reason=${auth.reason ?? "unauthorized"}`,
+    );
+    return undefined;
+  }
+
+  const channelLabel = resolveSlackChannelLabel({
+    channelId,
+    channelName: auth.channelName,
+  });
+  const sessionKey = ctx.resolveSlackSystemEventSessionKey({
+    channelId,
+    channelType: auth.channelType,
+  });
+  return {
+    channelLabel,
+    sessionKey,
+  };
+}

--- a/src/slack/monitor/events/system-event-test-harness.ts
+++ b/src/slack/monitor/events/system-event-test-harness.ts
@@ -1,0 +1,56 @@
+import type { SlackMonitorContext } from "../context.js";
+
+export type SlackSystemEventHandler = (args: {
+  event: Record<string, unknown>;
+  body: unknown;
+}) => Promise<void>;
+
+export type SlackSystemEventTestOverrides = {
+  dmPolicy?: "open" | "pairing" | "allowlist" | "disabled";
+  allowFrom?: string[];
+  channelType?: "im" | "channel";
+  channelUsers?: string[];
+};
+
+export function createSlackSystemEventTestHarness(overrides?: SlackSystemEventTestOverrides) {
+  const handlers: Record<string, SlackSystemEventHandler> = {};
+  const channelType = overrides?.channelType ?? "im";
+  const app = {
+    event: (name: string, handler: SlackSystemEventHandler) => {
+      handlers[name] = handler;
+    },
+  };
+  const ctx = {
+    app,
+    runtime: { error: () => {} },
+    dmEnabled: true,
+    dmPolicy: overrides?.dmPolicy ?? "open",
+    defaultRequireMention: true,
+    channelsConfig: overrides?.channelUsers
+      ? {
+          C1: {
+            users: overrides.channelUsers,
+            allow: true,
+          },
+        }
+      : undefined,
+    groupPolicy: "open",
+    allowFrom: overrides?.allowFrom ?? [],
+    allowNameMatching: false,
+    shouldDropMismatchedSlackEvent: () => false,
+    isChannelAllowed: () => true,
+    resolveChannelName: async () => ({
+      name: channelType === "im" ? "direct" : "general",
+      type: channelType,
+    }),
+    resolveUserName: async () => ({ name: "alice" }),
+    resolveSlackSystemEventSessionKey: () => "agent:main:main",
+  } as unknown as SlackMonitorContext;
+
+  return {
+    ctx,
+    getHandler(name: string): SlackSystemEventHandler | null {
+      return handlers[name] ?? null;
+    },
+  };
+}


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: e16e8f5af2
**Author**: Peter Steinberger <steipete@gmail.com>
**Tier**: AUTO-PICK
**Conflict resolution**: DU pins.test.ts (fork deleted, keep deleted). UU pins.ts, reactions.ts, reactions.test.ts — took upstream's unified `authorizeAndResolveSlackSystemEventContext` replacing fork's manual channel-allow + dm-policy checks.

> refactor(slack): share system-event ingress and test harness

Part of #568

Depends on #1026