### PR TITLE
Cherry-pick 496a76c: fix(security): harden browser trace/download temp path handling

### DIFF
--- a/src/browser/paths.test.ts
+++ b/src/browser/paths.test.ts
@@ -7,6 +7,7 @@ import {
   resolvePathsWithinRoot,
   resolvePathWithinRoot,
   resolveStrictExistingPathsWithinRoot,
+  resolveWritablePathWithinRoot,
 } from "./paths.js";
 
 async function createFixtureRoot(): Promise<{ baseDir: string; uploadsDir: string }> {
@@ -243,6 +244,45 @@ describe("resolvePathWithinRoot", () => {
       expect(result.error).toContain("must stay within uploads directory");
     }
   });
+});
+
+describe("resolveWritablePathWithinRoot", () => {
+  it("accepts a writable path under root when parent is a real directory", async () => {
+    await withFixtureRoot(async ({ uploadsDir }) => {
+      const result = await resolveWritablePathWithinRoot({
+        rootDir: uploadsDir,
+        requestedPath: "safe.txt",
+        scopeLabel: "uploads directory",
+      });
+      expect(result).toEqual({
+        ok: true,
+        path: path.resolve(uploadsDir, "safe.txt"),
+      });
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects write paths routed through a symlinked parent directory",
+    async () => {
+      await withFixtureRoot(async ({ baseDir, uploadsDir }) => {
+        const outsideDir = path.join(baseDir, "outside");
+        await fs.mkdir(outsideDir, { recursive: true });
+        const symlinkDir = path.join(uploadsDir, "escape-link");
+        await fs.symlink(outsideDir, symlinkDir);
+
+        const result = await resolveWritablePathWithinRoot({
+          rootDir: uploadsDir,
+          requestedPath: "escape-link/pwned.txt",
+          scopeLabel: "uploads directory",
+        });
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error).toContain("must stay within uploads directory");
+        }
+      });
+    },
+  );
 });
 
 describe("resolvePathsWithinRoot", () => {

--- a/src/browser/paths.ts
+++ b/src/browser/paths.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { SafeOpenError, openFileWithinRoot } from "../infra/fs-safe.js";
+import { isNotFoundPathError, isPathInside } from "../infra/path-guards.js";
 import { resolvePreferredRemoteClawTmpDir } from "../infra/tmp-remoteclaw-dir.js";
 
 export const DEFAULT_BROWSER_TMP_DIR = resolvePreferredRemoteClawTmpDir();
@@ -28,6 +29,67 @@ export function resolvePathWithinRoot(params: {
     return { ok: false, error: `Invalid path: must stay within ${params.scopeLabel}` };
   }
   return { ok: true, path: resolved };
+}
+
+export async function resolveWritablePathWithinRoot(params: {
+  rootDir: string;
+  requestedPath: string;
+  scopeLabel: string;
+  defaultFileName?: string;
+}): Promise<{ ok: true; path: string } | { ok: false; error: string }> {
+  const lexical = resolvePathWithinRoot(params);
+  if (!lexical.ok) {
+    return lexical;
+  }
+
+  const invalid = (): { ok: false; error: string } => ({
+    ok: false,
+    error: `Invalid path: must stay within ${params.scopeLabel}`,
+  });
+
+  const rootDir = path.resolve(params.rootDir);
+  let rootRealPath: string;
+  try {
+    const rootLstat = await fs.lstat(rootDir);
+    if (!rootLstat.isDirectory() || rootLstat.isSymbolicLink()) {
+      return invalid();
+    }
+    rootRealPath = await fs.realpath(rootDir);
+  } catch {
+    return invalid();
+  }
+
+  const requestedPath = lexical.path;
+  const parentDir = path.dirname(requestedPath);
+  try {
+    const parentLstat = await fs.lstat(parentDir);
+    if (!parentLstat.isDirectory() || parentLstat.isSymbolicLink()) {
+      return invalid();
+    }
+    const parentRealPath = await fs.realpath(parentDir);
+    if (!isPathInside(rootRealPath, parentRealPath)) {
+      return invalid();
+    }
+  } catch {
+    return invalid();
+  }
+
+  try {
+    const targetLstat = await fs.lstat(requestedPath);
+    if (targetLstat.isSymbolicLink() || !targetLstat.isFile()) {
+      return invalid();
+    }
+    const targetRealPath = await fs.realpath(requestedPath);
+    if (!isPathInside(rootRealPath, targetRealPath)) {
+      return invalid();
+    }
+  } catch (err) {
+    if (!isNotFoundPathError(err)) {
+      return invalid();
+    }
+  }
+
+  return lexical;
 }
 
 export function resolvePathsWithinRoot(params: {

--- a/src/browser/routes/agent.debug.ts
+++ b/src/browser/routes/agent.debug.ts
@@ -8,7 +8,7 @@ import {
   resolveTargetIdFromQuery,
   withPlaywrightRouteContext,
 } from "./agent.shared.js";
-import { DEFAULT_TRACE_DIR, resolvePathWithinRoot } from "./path-output.js";
+import { DEFAULT_TRACE_DIR, resolveWritablePathWithinRoot } from "./path-output.js";
 import type { BrowserRouteRegistrar } from "./types.js";
 import { toBoolean, toStringOrEmpty } from "./utils.js";
 
@@ -122,7 +122,7 @@ export function registerBrowserAgentDebugRoutes(
         const id = crypto.randomUUID();
         const dir = DEFAULT_TRACE_DIR;
         await fs.mkdir(dir, { recursive: true });
-        const tracePathResult = resolvePathWithinRoot({
+        const tracePathResult = await resolveWritablePathWithinRoot({
           rootDir: dir,
           requestedPath: out,
           scopeLabel: "trace directory",

--- a/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -1,7 +1,9 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fetch as realFetch } from "undici";
 import { describe, expect, it } from "vitest";
-import { DEFAULT_UPLOAD_DIR } from "./paths.js";
+import { DEFAULT_DOWNLOAD_DIR, DEFAULT_TRACE_DIR, DEFAULT_UPLOAD_DIR } from "./paths.js";
 import {
   installAgentContractHooks,
   postJson,
@@ -15,6 +17,23 @@ import {
 
 const state = getBrowserControlServerTestState();
 const pwMocks = getPwMocks();
+
+async function withSymlinkPathEscape<T>(params: {
+  rootDir: string;
+  run: (relativePath: string) => Promise<T>;
+}): Promise<T> {
+  const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-route-escape-"));
+  const linkName = `escape-link-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const linkPath = path.join(params.rootDir, linkName);
+  await fs.mkdir(params.rootDir, { recursive: true });
+  await fs.symlink(outsideDir, linkPath);
+  try {
+    return await params.run(`${linkName}/pwned.zip`);
+  } finally {
+    await fs.unlink(linkPath).catch(() => {});
+    await fs.rm(outsideDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
 
 describe("browser control server", () => {
   installAgentContractHooks();
@@ -267,6 +286,58 @@ describe("browser control server", () => {
     expect(downloadRes.error).toContain("Invalid path");
     expect(pwMocks.downloadViaPlaywright).not.toHaveBeenCalled();
   });
+
+  it.runIf(process.platform !== "win32")(
+    "trace stop rejects symlinked write path escape under trace dir",
+    async () => {
+      const base = await startServerAndBase();
+      await withSymlinkPathEscape({
+        rootDir: DEFAULT_TRACE_DIR,
+        run: async (pathEscape) => {
+          const res = await postJson<{ error?: string }>(`${base}/trace/stop`, {
+            path: pathEscape,
+          });
+          expect(res.error).toContain("Invalid path");
+          expect(pwMocks.traceStopViaPlaywright).not.toHaveBeenCalled();
+        },
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "wait/download rejects symlinked write path escape under downloads dir",
+    async () => {
+      const base = await startServerAndBase();
+      await withSymlinkPathEscape({
+        rootDir: DEFAULT_DOWNLOAD_DIR,
+        run: async (pathEscape) => {
+          const res = await postJson<{ error?: string }>(`${base}/wait/download`, {
+            path: pathEscape,
+          });
+          expect(res.error).toContain("Invalid path");
+          expect(pwMocks.waitForDownloadViaPlaywright).not.toHaveBeenCalled();
+        },
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "download rejects symlinked write path escape under downloads dir",
+    async () => {
+      const base = await startServerAndBase();
+      await withSymlinkPathEscape({
+        rootDir: DEFAULT_DOWNLOAD_DIR,
+        run: async (pathEscape) => {
+          const res = await postJson<{ error?: string }>(`${base}/download`, {
+            ref: "e12",
+            path: pathEscape,
+          });
+          expect(res.error).toContain("Invalid path");
+          expect(pwMocks.downloadViaPlaywright).not.toHaveBeenCalled();
+        },
+      });
+    },
+  );
 
   it("wait/download accepts in-root relative output path", async () => {
     const base = await startServerAndBase();

--- a/src/infra/tmp-remoteclaw-dir.test.ts
+++ b/src/infra/tmp-remoteclaw-dir.test.ts
@@ -11,24 +11,54 @@ function fallbackTmp(uid = 501) {
   return path.join("/var/fallback", `remoteclaw-${uid}`);
 }
 
+function nodeErrorWithCode(code: string) {
+  const err = new Error(code) as Error & { code?: string };
+  err.code = code;
+  return err;
+}
+
+function secureDirStat(uid = 501) {
+  return {
+    isDirectory: () => true,
+    isSymbolicLink: () => false,
+    uid,
+    mode: 0o40700,
+  };
+}
+
 function resolveWithMocks(params: {
   lstatSync: NonNullable<TmpDirOptions["lstatSync"]>;
+  fallbackLstatSync?: NonNullable<TmpDirOptions["lstatSync"]>;
   accessSync?: NonNullable<TmpDirOptions["accessSync"]>;
   uid?: number;
   tmpdirPath?: string;
 }) {
+  const uid = params.uid ?? 501;
+  const fallbackPath = fallbackTmp(uid);
   const accessSync = params.accessSync ?? vi.fn();
+  const wrappedLstatSync = vi.fn((target: string) => {
+    if (target === POSIX_REMOTECLAW_TMP_DIR) {
+      return params.lstatSync(target);
+    }
+    if (target === fallbackPath) {
+      if (params.fallbackLstatSync) {
+        return params.fallbackLstatSync(target);
+      }
+      return secureDirStat(uid);
+    }
+    return secureDirStat(uid);
+  }) as NonNullable<TmpDirOptions["lstatSync"]>;
   const mkdirSync = vi.fn();
-  const getuid = vi.fn(() => params.uid ?? 501);
+  const getuid = vi.fn(() => uid);
   const tmpdir = vi.fn(() => params.tmpdirPath ?? "/var/fallback");
   const resolved = resolvePreferredRemoteClawTmpDir({
     accessSync,
-    lstatSync: params.lstatSync,
+    lstatSync: wrappedLstatSync,
     mkdirSync,
     getuid,
     tmpdir,
   });
-  return { resolved, accessSync, lstatSync: params.lstatSync, mkdirSync, tmpdir };
+  return { resolved, accessSync, lstatSync: wrappedLstatSync, mkdirSync, tmpdir };
 }
 
 describe("resolvePreferredRemoteClawTmpDir", () => {
@@ -48,24 +78,12 @@ describe("resolvePreferredRemoteClawTmpDir", () => {
   });
 
   it("prefers /tmp/remoteclaw when it does not exist but /tmp is writable", () => {
-    const lstatSyncMock = vi.fn<NonNullable<TmpDirOptions["lstatSync"]>>(() => {
-      const err = new Error("missing") as Error & { code?: string };
-      err.code = "ENOENT";
-      throw err;
-    });
-
-    // second lstat call (after mkdir) should succeed
-    lstatSyncMock.mockImplementationOnce(() => {
-      const err = new Error("missing") as Error & { code?: string };
-      err.code = "ENOENT";
-      throw err;
-    });
-    lstatSyncMock.mockImplementationOnce(() => ({
-      isDirectory: () => true,
-      isSymbolicLink: () => false,
-      uid: 501,
-      mode: 0o40700,
-    }));
+    const lstatSyncMock = vi
+      .fn<NonNullable<TmpDirOptions["lstatSync"]>>()
+      .mockImplementationOnce(() => {
+        throw nodeErrorWithCode("ENOENT");
+      })
+      .mockImplementationOnce(() => secureDirStat(501));
 
     const { resolved, accessSync, mkdirSync, tmpdir } = resolveWithMocks({
       lstatSync: lstatSyncMock,
@@ -87,7 +105,7 @@ describe("resolvePreferredRemoteClawTmpDir", () => {
     const { resolved, tmpdir } = resolveWithMocks({ lstatSync });
 
     expect(resolved).toBe(fallbackTmp());
-    expect(tmpdir).toHaveBeenCalledTimes(1);
+    expect(tmpdir).toHaveBeenCalled();
   });
 
   it("falls back to os.tmpdir()/remoteclaw when /tmp is not writable", () => {
@@ -97,9 +115,7 @@ describe("resolvePreferredRemoteClawTmpDir", () => {
       }
     });
     const lstatSync = vi.fn(() => {
-      const err = new Error("missing") as Error & { code?: string };
-      err.code = "ENOENT";
-      throw err;
+      throw nodeErrorWithCode("ENOENT");
     });
     const { resolved, tmpdir } = resolveWithMocks({
       accessSync,
@@ -107,7 +123,7 @@ describe("resolvePreferredRemoteClawTmpDir", () => {
     });
 
     expect(resolved).toBe(fallbackTmp());
-    expect(tmpdir).toHaveBeenCalledTimes(1);
+    expect(tmpdir).toHaveBeenCalled();
   });
 
   it("falls back when /tmp/remoteclaw is a symlink", () => {
@@ -121,7 +137,7 @@ describe("resolvePreferredRemoteClawTmpDir", () => {
     const { resolved, tmpdir } = resolveWithMocks({ lstatSync });
 
     expect(resolved).toBe(fallbackTmp());
-    expect(tmpdir).toHaveBeenCalledTimes(1);
+    expect(tmpdir).toHaveBeenCalled();
   });
 
   it("falls back when /tmp/remoteclaw is not owned by the current user", () => {
@@ -135,7 +151,7 @@ describe("resolvePreferredRemoteClawTmpDir", () => {
     const { resolved, tmpdir } = resolveWithMocks({ lstatSync });
 
     expect(resolved).toBe(fallbackTmp());
-    expect(tmpdir).toHaveBeenCalledTimes(1);
+    expect(tmpdir).toHaveBeenCalled();
   });
 
   it("falls back when /tmp/remoteclaw is group/other writable", () => {
@@ -148,6 +164,51 @@ describe("resolvePreferredRemoteClawTmpDir", () => {
     const { resolved, tmpdir } = resolveWithMocks({ lstatSync });
 
     expect(resolved).toBe(fallbackTmp());
-    expect(tmpdir).toHaveBeenCalledTimes(1);
+    expect(tmpdir).toHaveBeenCalled();
+  });
+
+  it("throws when fallback path is a symlink", () => {
+    const lstatSync = vi.fn(() => ({
+      isDirectory: () => true,
+      isSymbolicLink: () => true,
+      uid: 501,
+      mode: 0o120777,
+    }));
+    const fallbackLstatSync = vi.fn(() => ({
+      isDirectory: () => true,
+      isSymbolicLink: () => true,
+      uid: 501,
+      mode: 0o120777,
+    }));
+
+    expect(() =>
+      resolveWithMocks({
+        lstatSync,
+        fallbackLstatSync,
+      }),
+    ).toThrow(/Unsafe fallback RemoteClaw temp dir/);
+  });
+
+  it("creates fallback directory when missing, then validates ownership and mode", () => {
+    const lstatSync = vi.fn(() => ({
+      isDirectory: () => true,
+      isSymbolicLink: () => true,
+      uid: 501,
+      mode: 0o120777,
+    }));
+    const fallbackLstatSync = vi
+      .fn<NonNullable<TmpDirOptions["lstatSync"]>>()
+      .mockImplementationOnce(() => {
+        throw nodeErrorWithCode("ENOENT");
+      })
+      .mockImplementationOnce(() => secureDirStat(501));
+
+    const { resolved, mkdirSync } = resolveWithMocks({
+      lstatSync,
+      fallbackLstatSync,
+    });
+
+    expect(resolved).toBe(fallbackTmp());
+    expect(mkdirSync).toHaveBeenCalledWith(fallbackTmp(), { recursive: true, mode: 0o700 });
   });
 });

--- a/src/infra/tmp-remoteclaw-dir.ts
+++ b/src/infra/tmp-remoteclaw-dir.ts
@@ -92,12 +92,53 @@ export function resolvePreferredRemoteClawTmpDir(
     }
   };
 
+  const resolveFallbackState = (
+    fallbackPath: string,
+    requireWritableAccess: boolean,
+  ): "available" | "missing" | "invalid" => {
+    try {
+      const candidate = lstatSync(fallbackPath);
+      if (!isTrustedTmpDir(candidate)) {
+        return "invalid";
+      }
+      if (requireWritableAccess) {
+        accessSync(fallbackPath, fs.constants.W_OK | fs.constants.X_OK);
+      }
+      return "available";
+    } catch (err) {
+      if (isNodeErrorWithCode(err, "ENOENT")) {
+        return "missing";
+      }
+      return "invalid";
+    }
+  };
+
+  const ensureTrustedFallbackDir = (): string => {
+    const fallbackPath = fallback();
+    const state = resolveFallbackState(fallbackPath, true);
+    if (state === "available") {
+      return fallbackPath;
+    }
+    if (state === "invalid") {
+      throw new Error(`Unsafe fallback RemoteClaw temp dir: ${fallbackPath}`);
+    }
+    try {
+      mkdirSync(fallbackPath, { recursive: true, mode: 0o700 });
+    } catch {
+      throw new Error(`Unable to create fallback RemoteClaw temp dir: ${fallbackPath}`);
+    }
+    if (resolveFallbackState(fallbackPath, true) !== "available") {
+      throw new Error(`Unsafe fallback RemoteClaw temp dir: ${fallbackPath}`);
+    }
+    return fallbackPath;
+  };
+
   const existingPreferredState = resolvePreferredState();
   if (existingPreferredState === "available") {
     return POSIX_REMOTECLAW_TMP_DIR;
   }
   if (existingPreferredState === "invalid") {
-    return fallback();
+    return ensureTrustedFallbackDir();
   }
 
   try {
@@ -105,10 +146,10 @@ export function resolvePreferredRemoteClawTmpDir(
     // Create with a safe default; subsequent callers expect it exists.
     mkdirSync(POSIX_REMOTECLAW_TMP_DIR, { recursive: true, mode: 0o700 });
     if (resolvePreferredState() !== "available") {
-      return fallback();
+      return ensureTrustedFallbackDir();
     }
     return POSIX_REMOTECLAW_TMP_DIR;
   } catch {
-    return fallback();
+    return ensureTrustedFallbackDir();
   }
 }


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: 496a76c03b
**Author**: Peter Steinberger <steipete@gmail.com>
**Tier**: HUMAN-REVIEW

> fix(security): harden browser trace/download temp path handling

Conflicts resolved: rebrand `tmp-openclaw-dir` → `tmp-remoteclaw-dir`, `isTrustedPreferredDir` → `isTrustedTmpDir` (fork name), `OpenClaw` → `RemoteClaw` in error messages, `resolvePreferredState()` signature (fork removed parameter).