### PR TITLE
Cherry-pick 347f7b95: fix(msteams): bind file consent invokes to conversation

### DIFF
--- a/extensions/msteams/src/monitor-handler.file-consent.test.ts
+++ b/extensions/msteams/src/monitor-handler.file-consent.test.ts
@@ -1,0 +1,220 @@
+import type { RemoteClawConfig, PluginRuntime, RuntimeEnv } from "remoteclaw/plugin-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MSTeamsConversationStore } from "./conversation-store.js";
+import type { MSTeamsAdapter } from "./messenger.js";
+import {
+  type MSTeamsActivityHandler,
+  type MSTeamsMessageHandlerDeps,
+  registerMSTeamsHandlers,
+} from "./monitor-handler.js";
+import { clearPendingUploads, getPendingUpload, storePendingUpload } from "./pending-uploads.js";
+import type { MSTeamsPollStore } from "./polls.js";
+import { setMSTeamsRuntime } from "./runtime.js";
+import type { MSTeamsTurnContext } from "./sdk-types.js";
+
+const fileConsentMockState = vi.hoisted(() => ({
+  uploadToConsentUrl: vi.fn(),
+}));
+
+vi.mock("./file-consent.js", async () => {
+  const actual = await vi.importActual<typeof import("./file-consent.js")>("./file-consent.js");
+  return {
+    ...actual,
+    uploadToConsentUrl: fileConsentMockState.uploadToConsentUrl,
+  };
+});
+
+const runtimeStub: PluginRuntime = {
+  logging: {
+    shouldLogVerbose: () => false,
+  },
+  channel: {
+    debounce: {
+      resolveInboundDebounceMs: () => 0,
+      createInboundDebouncer: () => ({
+        enqueue: async () => {},
+      }),
+    },
+  },
+} as unknown as PluginRuntime;
+
+function createDeps(): MSTeamsMessageHandlerDeps {
+  const adapter: MSTeamsAdapter = {
+    continueConversation: async () => {},
+    process: async () => {},
+  };
+  const conversationStore: MSTeamsConversationStore = {
+    upsert: async () => {},
+    get: async () => null,
+    list: async () => [],
+    remove: async () => false,
+    findByUserId: async () => null,
+  };
+  const pollStore: MSTeamsPollStore = {
+    createPoll: async () => {},
+    getPoll: async () => null,
+    recordVote: async () => null,
+  };
+  return {
+    cfg: {} as RemoteClawConfig,
+    runtime: {
+      error: vi.fn(),
+    } as unknown as RuntimeEnv,
+    appId: "test-app-id",
+    adapter,
+    tokenProvider: {
+      getAccessToken: async () => "token",
+    },
+    textLimit: 4000,
+    mediaMaxBytes: 8 * 1024 * 1024,
+    conversationStore,
+    pollStore,
+    log: {
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  };
+}
+
+function createActivityHandler(): MSTeamsActivityHandler {
+  let handler: MSTeamsActivityHandler;
+  handler = {
+    onMessage: () => handler,
+    onMembersAdded: () => handler,
+    run: async () => {},
+  };
+  return handler;
+}
+
+function createInvokeContext(params: {
+  conversationId: string;
+  uploadId: string;
+  action: "accept" | "decline";
+}): { context: MSTeamsTurnContext; sendActivity: ReturnType<typeof vi.fn> } {
+  const sendActivity = vi.fn(async () => ({ id: "activity-id" }));
+  const uploadInfo =
+    params.action === "accept"
+      ? {
+          name: "secret.txt",
+          uploadUrl: "https://upload.example.com/put",
+          contentUrl: "https://content.example.com/file",
+          uniqueId: "unique-id",
+          fileType: "txt",
+        }
+      : undefined;
+  return {
+    context: {
+      activity: {
+        type: "invoke",
+        name: "fileConsent/invoke",
+        conversation: { id: params.conversationId },
+        value: {
+          type: "fileUpload",
+          action: params.action,
+          uploadInfo,
+          context: { uploadId: params.uploadId },
+        },
+      },
+      sendActivity,
+      sendActivities: async () => [],
+    } as unknown as MSTeamsTurnContext,
+    sendActivity,
+  };
+}
+
+describe("msteams file consent invoke authz", () => {
+  beforeEach(() => {
+    setMSTeamsRuntime(runtimeStub);
+    clearPendingUploads();
+    fileConsentMockState.uploadToConsentUrl.mockReset();
+    fileConsentMockState.uploadToConsentUrl.mockResolvedValue(undefined);
+  });
+
+  it("uploads when invoke conversation matches pending upload conversation", async () => {
+    const uploadId = storePendingUpload({
+      buffer: Buffer.from("TOP_SECRET_VICTIM_FILE\n"),
+      filename: "secret.txt",
+      contentType: "text/plain",
+      conversationId: "19:victim@thread.v2",
+    });
+    const deps = createDeps();
+    const handler = registerMSTeamsHandlers(createActivityHandler(), deps);
+    const { context, sendActivity } = createInvokeContext({
+      conversationId: "19:victim@thread.v2;messageid=abc123",
+      uploadId,
+      action: "accept",
+    });
+
+    await handler.run?.(context);
+
+    expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledTimes(1);
+    expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://upload.example.com/put",
+      }),
+    );
+    expect(getPendingUpload(uploadId)).toBeUndefined();
+    expect(sendActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "invokeResponse",
+      }),
+    );
+  });
+
+  it("rejects cross-conversation accept invoke and keeps pending upload", async () => {
+    const uploadId = storePendingUpload({
+      buffer: Buffer.from("TOP_SECRET_VICTIM_FILE\n"),
+      filename: "secret.txt",
+      contentType: "text/plain",
+      conversationId: "19:victim@thread.v2",
+    });
+    const deps = createDeps();
+    const handler = registerMSTeamsHandlers(createActivityHandler(), deps);
+    const { context, sendActivity } = createInvokeContext({
+      conversationId: "19:attacker@thread.v2",
+      uploadId,
+      action: "accept",
+    });
+
+    await handler.run?.(context);
+
+    expect(fileConsentMockState.uploadToConsentUrl).not.toHaveBeenCalled();
+    expect(getPendingUpload(uploadId)).toBeDefined();
+    expect(sendActivity).toHaveBeenCalledWith(
+      "The file upload request has expired. Please try sending the file again.",
+    );
+    expect(sendActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "invokeResponse",
+      }),
+    );
+  });
+
+  it("ignores cross-conversation decline invoke and keeps pending upload", async () => {
+    const uploadId = storePendingUpload({
+      buffer: Buffer.from("TOP_SECRET_VICTIM_FILE\n"),
+      filename: "secret.txt",
+      contentType: "text/plain",
+      conversationId: "19:victim@thread.v2",
+    });
+    const deps = createDeps();
+    const handler = registerMSTeamsHandlers(createActivityHandler(), deps);
+    const { context, sendActivity } = createInvokeContext({
+      conversationId: "19:attacker@thread.v2",
+      uploadId,
+      action: "decline",
+    });
+
+    await handler.run?.(context);
+
+    expect(fileConsentMockState.uploadToConsentUrl).not.toHaveBeenCalled();
+    expect(getPendingUpload(uploadId)).toBeDefined();
+    expect(sendActivity).toHaveBeenCalledTimes(1);
+    expect(sendActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "invokeResponse",
+      }),
+    );
+  });
+});

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -1,6 +1,7 @@
 import type { RemoteClawConfig, RuntimeEnv } from "remoteclaw/plugin-sdk";
 import type { MSTeamsConversationStore } from "./conversation-store.js";
 import { buildFileInfoCard, parseFileConsentInvoke, uploadToConsentUrl } from "./file-consent.js";
+import { normalizeMSTeamsConversationId } from "./inbound.js";
 import type { MSTeamsAdapter } from "./messenger.js";
 import { createMSTeamsMessageHandler } from "./monitor-handler/message-handler.js";
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
@@ -42,6 +43,8 @@ async function handleFileConsentInvoke(
   context: MSTeamsTurnContext,
   log: MSTeamsMonitorLogger,
 ): Promise<boolean> {
+  const expiredUploadMessage =
+    "The file upload request has expired. Please try sending the file again.";
   const activity = context.activity;
   if (activity.type !== "invoke" || activity.name !== "fileConsent/invoke") {
     return false;
@@ -57,9 +60,24 @@ async function handleFileConsentInvoke(
     typeof consentResponse.context?.uploadId === "string"
       ? consentResponse.context.uploadId
       : undefined;
+  const pendingFile = getPendingUpload(uploadId);
+  if (pendingFile) {
+    const pendingConversationId = normalizeMSTeamsConversationId(pendingFile.conversationId);
+    const invokeConversationId = normalizeMSTeamsConversationId(activity.conversation?.id ?? "");
+    if (!invokeConversationId || pendingConversationId !== invokeConversationId) {
+      log.info("file consent conversation mismatch", {
+        uploadId,
+        expectedConversationId: pendingConversationId,
+        receivedConversationId: invokeConversationId || undefined,
+      });
+      if (consentResponse.action === "accept") {
+        await context.sendActivity(expiredUploadMessage);
+      }
+      return true;
+    }
+  }
 
   if (consentResponse.action === "accept" && consentResponse.uploadInfo) {
-    const pendingFile = getPendingUpload(uploadId);
     if (pendingFile) {
       log.debug?.("user accepted file consent, uploading", {
         uploadId,
@@ -101,9 +119,7 @@ async function handleFileConsentInvoke(
       }
     } else {
       log.debug?.("pending file not found for consent", { uploadId });
-      await context.sendActivity(
-        "The file upload request has expired. Please try sending the file again.",
-      );
+      await context.sendActivity(expiredUploadMessage);
     }
   } else {
     // User declined


### PR DESCRIPTION
Cherry-pick of upstream `347f7b9550` — bind `fileConsent/invoke` upload acceptance/decline to the originating conversation before consuming pending uploads, preventing cross-conversation pending-file upload or cancellation.

Part of #572.

(cherry picked from commit 347f7b9550064f5f5b33c6e07f64e85b9657b6f1)