### PR TITLE
Cherry-pick a0a229a3: Discord: align embed fallback in thread starter parsing

### DIFF
--- a/src/discord/monitor/message-utils.test.ts
+++ b/src/discord/monitor/message-utils.test.ts
@@ -367,6 +367,34 @@ describe("resolveDiscordMessageText", () => {
 
     expect(text).toBe("hello from content");
   });
+
+  it("joins forwarded snapshot embed title and description when content is empty", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "",
+        rawData: {
+          message_snapshots: [
+            {
+              message: {
+                content: "",
+                embeds: [{ title: "Forwarded title", description: "Forwarded details" }],
+                attachments: [],
+                author: {
+                  id: "u2",
+                  username: "Bob",
+                  discriminator: "0",
+                },
+              },
+            },
+          ],
+        },
+      }),
+      { includeForwarded: true },
+    );
+
+    expect(text).toContain("[Forwarded message from @Bob]");
+    expect(text).toContain("Forwarded title\nForwarded details");
+  });
 });
 
 describe("resolveDiscordChannelInfo", () => {

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -403,7 +403,7 @@ function buildDiscordMediaPlaceholder(params: {
   return attachmentText || stickerText || "";
 }
 
-function resolveDiscordEmbedText(
+export function resolveDiscordEmbedText(
   embed?: { title?: string | null; description?: string | null } | null,
 ): string {
   const title = embed?.title?.trim() || "";

--- a/src/discord/monitor/threading.starter.test.ts
+++ b/src/discord/monitor/threading.starter.test.ts
@@ -1,0 +1,55 @@
+import { ChannelType, type Client } from "@buape/carbon";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetDiscordThreadStarterCacheForTest,
+  resolveDiscordThreadStarter,
+} from "./threading.js";
+
+describe("resolveDiscordThreadStarter", () => {
+  beforeEach(() => {
+    __resetDiscordThreadStarterCacheForTest();
+  });
+
+  it("falls back to joined embed title and description when content is empty", async () => {
+    const get = vi.fn().mockResolvedValue({
+      content: "   ",
+      embeds: [{ title: "Alert", description: "Details" }],
+      author: { username: "Alice", discriminator: "0" },
+      timestamp: "2026-02-24T12:00:00.000Z",
+    });
+    const client = { rest: { get } } as unknown as Client;
+
+    const result = await resolveDiscordThreadStarter({
+      channel: { id: "thread-1" },
+      client,
+      parentId: "parent-1",
+      parentType: ChannelType.GuildText,
+      resolveTimestampMs: () => 123,
+    });
+
+    expect(result).toEqual({
+      text: "Alert\nDetails",
+      author: "Alice",
+      timestamp: 123,
+    });
+  });
+
+  it("prefers starter content over embed fallback text", async () => {
+    const get = vi.fn().mockResolvedValue({
+      content: "starter content",
+      embeds: [{ title: "Alert", description: "Details" }],
+      author: { username: "Alice", discriminator: "0" },
+    });
+    const client = { rest: { get } } as unknown as Client;
+
+    const result = await resolveDiscordThreadStarter({
+      channel: { id: "thread-1" },
+      client,
+      parentId: "parent-1",
+      parentType: ChannelType.GuildText,
+      resolveTimestampMs: () => undefined,
+    });
+
+    expect(result?.text).toBe("starter content");
+  });
+});

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -7,7 +7,11 @@ import { buildAgentSessionKey } from "../../routing/resolve-route.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import type { DiscordChannelConfigResolved } from "./allow-list.js";
 import type { DiscordMessageEvent } from "./listeners.js";
-import { resolveDiscordChannelInfo, resolveDiscordMessageChannelId } from "./message-utils.js";
+import {
+  resolveDiscordChannelInfo,
+  resolveDiscordEmbedText,
+  resolveDiscordMessageChannelId,
+} from "./message-utils.js";
 
 export type DiscordThreadChannel = {
   id: string;
@@ -172,7 +176,7 @@ export async function resolveDiscordThreadStarter(params: {
       Routes.channelMessage(messageChannelId, params.channel.id),
     )) as {
       content?: string | null;
-      embeds?: Array<{ description?: string | null }>;
+      embeds?: Array<{ title?: string | null; description?: string | null }>;
       member?: { nick?: string | null; displayName?: string | null };
       author?: {
         id?: string | null;
@@ -184,7 +188,9 @@ export async function resolveDiscordThreadStarter(params: {
     if (!starter) {
       return null;
     }
-    const text = starter.content?.trim() ?? starter.embeds?.[0]?.description?.trim() ?? "";
+    const content = starter.content?.trim() ?? "";
+    const embedText = resolveDiscordEmbedText(starter.embeds?.[0]);
+    const text = content || embedText;
     if (!text) {
       return null;
     }


### PR DESCRIPTION
Cherry-pick of upstream `a0a229a3bb` — align embed fallback text extraction in Discord thread starter parsing to match the message-utils path.

Part of #574.

(cherry picked from commit a0a229a3bb)