### PR TITLE
Cherry-pick 7af6849c: Discord: handle early gateway startup errors

### DIFF
--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -49,6 +49,8 @@ describe("runDiscordGatewayLifecycle", () => {
     accountId?: string;
     start?: () => Promise<void>;
     stop?: () => Promise<void>;
+    isDisallowedIntentsError?: (err: unknown) => boolean;
+    pendingGatewayErrors?: unknown[];
   }) => {
     const start = vi.fn(params?.start ?? (async () => undefined));
     const stop = vi.fn(params?.stop ?? (async () => undefined));
@@ -61,19 +63,24 @@ describe("runDiscordGatewayLifecycle", () => {
       error: runtimeError,
       exit: runtimeExit,
     };
+    const releaseEarlyGatewayErrorGuard = vi.fn();
     return {
       start,
       stop,
       threadStop,
+      runtimeError,
+      releaseEarlyGatewayErrorGuard,
       lifecycleParams: {
         accountId: params?.accountId ?? "default",
         client: { getPlugin: vi.fn(() => undefined) } as unknown as Client,
         runtime,
-        isDisallowedIntentsError: () => false,
+        isDisallowedIntentsError: params?.isDisallowedIntentsError ?? (() => false),
         voiceManager: null,
         voiceManagerRef: { current: null },
         execApprovalsHandler: { start, stop },
         threadBindings: { stop: threadStop },
+        pendingGatewayErrors: params?.pendingGatewayErrors,
+        releaseEarlyGatewayErrorGuard,
       },
     };
   };
@@ -83,6 +90,7 @@ describe("runDiscordGatewayLifecycle", () => {
     stop: ReturnType<typeof vi.fn>;
     threadStop: ReturnType<typeof vi.fn>;
     waitCalls: number;
+    releaseEarlyGatewayErrorGuard: ReturnType<typeof vi.fn>;
   }) {
     expect(params.start).toHaveBeenCalledTimes(1);
     expect(params.stop).toHaveBeenCalledTimes(1);
@@ -90,39 +98,109 @@ describe("runDiscordGatewayLifecycle", () => {
     expect(unregisterGatewayMock).toHaveBeenCalledWith("default");
     expect(stopGatewayLoggingMock).toHaveBeenCalledTimes(1);
     expect(params.threadStop).toHaveBeenCalledTimes(1);
+    expect(params.releaseEarlyGatewayErrorGuard).toHaveBeenCalledTimes(1);
   }
 
   it("cleans up thread bindings when exec approvals startup fails", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
-    const { lifecycleParams, start, stop, threadStop } = createLifecycleHarness({
-      start: async () => {
-        throw new Error("startup failed");
-      },
-    });
+    const { lifecycleParams, start, stop, threadStop, releaseEarlyGatewayErrorGuard } =
+      createLifecycleHarness({
+        start: async () => {
+          throw new Error("startup failed");
+        },
+      });
 
     await expect(runDiscordGatewayLifecycle(lifecycleParams)).rejects.toThrow("startup failed");
 
-    expectLifecycleCleanup({ start, stop, threadStop, waitCalls: 0 });
+    expectLifecycleCleanup({
+      start,
+      stop,
+      threadStop,
+      waitCalls: 0,
+      releaseEarlyGatewayErrorGuard,
+    });
   });
 
   it("cleans up when gateway wait fails after startup", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
     waitForDiscordGatewayStopMock.mockRejectedValueOnce(new Error("gateway wait failed"));
-    const { lifecycleParams, start, stop, threadStop } = createLifecycleHarness();
+    const { lifecycleParams, start, stop, threadStop, releaseEarlyGatewayErrorGuard } =
+      createLifecycleHarness();
 
     await expect(runDiscordGatewayLifecycle(lifecycleParams)).rejects.toThrow(
       "gateway wait failed",
     );
 
-    expectLifecycleCleanup({ start, stop, threadStop, waitCalls: 1 });
+    expectLifecycleCleanup({
+      start,
+      stop,
+      threadStop,
+      waitCalls: 1,
+      releaseEarlyGatewayErrorGuard,
+    });
   });
 
   it("cleans up after successful gateway wait", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
-    const { lifecycleParams, start, stop, threadStop } = createLifecycleHarness();
+    const { lifecycleParams, start, stop, threadStop, releaseEarlyGatewayErrorGuard } =
+      createLifecycleHarness();
 
     await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
 
-    expectLifecycleCleanup({ start, stop, threadStop, waitCalls: 1 });
+    expectLifecycleCleanup({
+      start,
+      stop,
+      threadStop,
+      waitCalls: 1,
+      releaseEarlyGatewayErrorGuard,
+    });
+  });
+
+  it("handles queued disallowed intents errors without waiting for gateway events", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const {
+      lifecycleParams,
+      start,
+      stop,
+      threadStop,
+      runtimeError,
+      releaseEarlyGatewayErrorGuard,
+    } = createLifecycleHarness({
+      pendingGatewayErrors: [new Error("Fatal Gateway error: 4014")],
+      isDisallowedIntentsError: (err) => String(err).includes("4014"),
+    });
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+    expect(runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("discord: gateway closed with code 4014"),
+    );
+    expectLifecycleCleanup({
+      start,
+      stop,
+      threadStop,
+      waitCalls: 0,
+      releaseEarlyGatewayErrorGuard,
+    });
+  });
+
+  it("throws queued non-disallowed fatal gateway errors", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const { lifecycleParams, start, stop, threadStop, releaseEarlyGatewayErrorGuard } =
+      createLifecycleHarness({
+        pendingGatewayErrors: [new Error("Fatal Gateway error: 4000")],
+      });
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).rejects.toThrow(
+      "Fatal Gateway error: 4000",
+    );
+
+    expectLifecycleCleanup({
+      start,
+      stop,
+      threadStop,
+      waitCalls: 0,
+      releaseEarlyGatewayErrorGuard,
+    });
   });
 });

--- a/src/discord/monitor/provider.test.ts
+++ b/src/discord/monitor/provider.test.ts
@@ -1,8 +1,11 @@
+import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RemoteClawConfig } from "../../config/config.js";
 import type { RuntimeEnv } from "../../runtime.js";
 
 const {
+  clientFetchUserMock,
+  clientGetPluginMock,
   createDiscordNativeCommandMock,
   createNoopThreadBindingManagerMock,
   createThreadBindingManagerMock,
@@ -15,6 +18,8 @@ const {
 } = vi.hoisted(() => {
   const createdBindingManagers: Array<{ stop: ReturnType<typeof vi.fn> }> = [];
   return {
+    clientFetchUserMock: vi.fn(async () => ({ id: "bot-1" })),
+    clientGetPluginMock: vi.fn(() => undefined),
     createDiscordNativeCommandMock: vi.fn(() => ({ name: "mock-command" })),
     createNoopThreadBindingManagerMock: vi.fn(() => {
       const manager = { stop: vi.fn() };
@@ -61,11 +66,11 @@ vi.mock("@buape/carbon", () => {
     async handleDeployRequest() {
       return undefined;
     }
-    async fetchUser(_target: string) {
-      return { id: "bot-1" };
+    async fetchUser(target: string) {
+      return await clientFetchUserMock(target);
     }
-    getPlugin(_name: string) {
-      return undefined;
+    getPlugin(name: string) {
+      return clientGetPluginMock(name);
     }
   }
   return { Client, ReadyListener };
@@ -231,6 +236,8 @@ describe("monitorDiscordProvider", () => {
     }) as RemoteClawConfig;
 
   beforeEach(() => {
+    clientFetchUserMock.mockClear().mockResolvedValue({ id: "bot-1" });
+    clientGetPluginMock.mockClear().mockReturnValue(undefined);
     createDiscordNativeCommandMock.mockClear().mockReturnValue({ name: "mock-command" });
     createNoopThreadBindingManagerMock.mockClear();
     createThreadBindingManagerMock.mockClear();
@@ -276,5 +283,29 @@ describe("monitorDiscordProvider", () => {
     expect(monitorLifecycleMock).toHaveBeenCalledTimes(1);
     expect(createdBindingManagers).toHaveLength(1);
     expect(createdBindingManagers[0]?.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures gateway errors emitted before lifecycle wait starts", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+    const emitter = new EventEmitter();
+    clientGetPluginMock.mockImplementation((name: string) =>
+      name === "gateway" ? { emitter, disconnect: vi.fn() } : undefined,
+    );
+    clientFetchUserMock.mockImplementationOnce(async () => {
+      emitter.emit("error", new Error("Fatal Gateway error: 4014"));
+      return { id: "bot-1" };
+    });
+
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+    });
+
+    expect(monitorLifecycleMock).toHaveBeenCalledTimes(1);
+    const lifecycleArgs = monitorLifecycleMock.mock.calls[0]?.[0] as {
+      pendingGatewayErrors?: unknown[];
+    };
+    expect(lifecycleArgs.pendingGatewayErrors).toHaveLength(1);
+    expect(String(lifecycleArgs.pendingGatewayErrors?.[0])).toContain("4014");
   });
 });

--- a/src/discord/monitor/provider.test.ts
+++ b/src/discord/monitor/provider.test.ts
@@ -18,8 +18,8 @@ const {
 } = vi.hoisted(() => {
   const createdBindingManagers: Array<{ stop: ReturnType<typeof vi.fn> }> = [];
   return {
-    clientFetchUserMock: vi.fn(async () => ({ id: "bot-1" })),
-    clientGetPluginMock: vi.fn(() => undefined),
+    clientFetchUserMock: vi.fn(async (_target?: string) => ({ id: "bot-1" })),
+    clientGetPluginMock: vi.fn((_name?: string): unknown => undefined),
     createDiscordNativeCommandMock: vi.fn(() => ({ name: "mock-command" })),
     createNoopThreadBindingManagerMock: vi.fn(() => {
       const manager = { stop: vi.fn() };
@@ -288,7 +288,7 @@ describe("monitorDiscordProvider", () => {
   it("captures gateway errors emitted before lifecycle wait starts", async () => {
     const { monitorDiscordProvider } = await import("./provider.js");
     const emitter = new EventEmitter();
-    clientGetPluginMock.mockImplementation((name: string) =>
+    clientGetPluginMock.mockImplementation((name?: string) =>
       name === "gateway" ? { emitter, disconnect: vi.fn() } : undefined,
     );
     clientFetchUserMock.mockImplementationOnce(async () => {

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -32,6 +32,7 @@ import { createDiscordRetryRunner } from "../../infra/retry-policy.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../runtime.js";
 import { resolveDiscordAccount } from "../accounts.js";
+import { getDiscordGatewayEmitter } from "../monitor.gateway.js";
 import { fetchDiscordApplicationId } from "../probe.js";
 import { normalizeDiscordToken } from "../token.js";
 import { createDiscordVoiceCommand } from "../voice/command.js";
@@ -204,6 +205,33 @@ function isDiscordDisallowedIntentsError(err: unknown): boolean {
   return message.includes(String(DISCORD_DISALLOWED_INTENTS_CODE));
 }
 
+type EarlyGatewayErrorGuard = {
+  pendingErrors: unknown[];
+  release: () => void;
+};
+
+function attachEarlyGatewayErrorGuard(client: Client): EarlyGatewayErrorGuard {
+  const pendingErrors: unknown[] = [];
+  const gateway = client.getPlugin<GatewayPlugin>("gateway");
+  const emitter = getDiscordGatewayEmitter(gateway);
+  if (!emitter) {
+    return {
+      pendingErrors,
+      release: () => {},
+    };
+  }
+  const onGatewayError = (err: unknown) => {
+    pendingErrors.push(err);
+  };
+  emitter.on("error", onGatewayError);
+  return {
+    pendingErrors,
+    release: () => {
+      emitter.removeListener("error", onGatewayError);
+    },
+  };
+}
+
 export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   const cfg = opts.config ?? loadConfig();
   const account = resolveDiscordAccount({
@@ -321,6 +349,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       })
     : createNoopThreadBindingManager(account.accountId);
   let lifecycleStarted = false;
+  let releaseEarlyGatewayErrorGuard = () => {};
   try {
     const commands: BaseCommand[] = commandSpecs.map((spec) =>
       createDiscordNativeCommand({
@@ -422,6 +451,8 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       },
       clientPlugins,
     );
+    const earlyGatewayErrorGuard = attachEarlyGatewayErrorGuard(client);
+    releaseEarlyGatewayErrorGuard = earlyGatewayErrorGuard.release;
 
     await deployDiscordCommands({ client, runtime, enabled: nativeEnabled });
 
@@ -538,8 +569,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       voiceManagerRef,
       execApprovalsHandler: null,
       threadBindings,
+      pendingGatewayErrors: earlyGatewayErrorGuard.pendingErrors,
+      releaseEarlyGatewayErrorGuard,
     });
   } finally {
+    releaseEarlyGatewayErrorGuard();
     if (!lifecycleStarted) {
       threadBindings.stop();
     }


### PR DESCRIPTION
Cherry-pick of upstream `7af6849c2f` — handle early gateway startup errors in Discord provider lifecycle, preventing silent crashes during gateway initialization.

Part of #574.

(cherry picked from commit 7af6849c2f)