### PR TITLE
fix(gateway): use loopback for CLI status probe when bind=lan

### DIFF
--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -5,7 +5,6 @@ import {
 } from "../../daemon/constants.js";
 import { resolveGatewayLogPaths } from "../../daemon/launchd.js";
 import { formatRuntimeStatus } from "../../daemon/runtime-format.js";
-import { pickPrimaryLanIPv4 } from "../../gateway/net.js";
 import { getResolvedLoggerSettings } from "../../logging.js";
 import { colorize, isRich, theme } from "../../terminal/theme.js";
 import { formatCliCommand } from "../command-format.js";
@@ -73,7 +72,10 @@ export function pickProbeHostForBind(
     return tailnetIPv4 ?? "127.0.0.1";
   }
   if (bindMode === "lan") {
-    return pickPrimaryLanIPv4() ?? "127.0.0.1";
+    // Same as call.ts: self-connections should always target loopback.
+    // bind=lan controls which interfaces the server listens on (0.0.0.0),
+    // but co-located CLI probes should connect via 127.0.0.1.
+    return "127.0.0.1";
   }
   return "127.0.0.1";
 }


### PR DESCRIPTION
## Summary

- Use 127.0.0.1 for CLI status probe when gateway is bound to LAN (0.0.0.0)

Cherry-picked from openclaw/openclaw@327f0526d1 (AUTO-PARTIAL: discarded CHANGELOG).

Part of #597 (commit 1/5)

## Test plan

- [x] TypeScript type check passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)