### PR TITLE
fix(podman): default run-remoteclaw-podman bind to loopback

### DIFF
--- a/docs/install/podman.md
+++ b/docs/install/podman.md
@@ -85,6 +85,7 @@ To add quadlet **after** an initial setup that did not use it, re-run: `./setup-
 - **Token:** Stored in `~remoteclaw/.remoteclaw/.env` as `REMOTECLAW_GATEWAY_TOKEN`. `setup-podman.sh` and `run-remoteclaw-podman.sh` generate it if missing (uses `openssl`, `python3`, or `od`).
 - **Optional:** In that `.env` you can set CLI agent API keys (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) and other RemoteClaw env vars.
 - **Host ports:** By default the script maps `18789` (gateway) and `18790` (bridge). Override the **host** port mapping with `REMOTECLAW_PODMAN_GATEWAY_HOST_PORT` and `REMOTECLAW_PODMAN_BRIDGE_HOST_PORT` when launching.
+- **Gateway bind:** By default, `run-remoteclaw-podman.sh` starts the gateway with `--bind loopback` for safe local access. To expose on LAN, set `REMOTECLAW_GATEWAY_BIND=lan` and configure `gateway.controlUi.allowedOrigins` (or explicitly enable host-header fallback) in `remoteclaw.json`.
 - **Paths:** Host config and workspace default to `~remoteclaw/.remoteclaw` and `~remoteclaw/.remoteclaw/workspace`. Override the host paths used by the launch script with `REMOTECLAW_CONFIG_DIR` and `REMOTECLAW_WORKSPACE_DIR`.
 
 ## Useful commands

--- a/scripts/run-remoteclaw-podman.sh
+++ b/scripts/run-remoteclaw-podman.sh
@@ -75,7 +75,9 @@ REMOTECLAW_IMAGE="${REMOTECLAW_PODMAN_IMAGE:-remoteclaw:local}"
 PODMAN_PULL="${REMOTECLAW_PODMAN_PULL:-never}"
 HOST_GATEWAY_PORT="${REMOTECLAW_PODMAN_GATEWAY_HOST_PORT:-${REMOTECLAW_GATEWAY_PORT:-18789}}"
 HOST_BRIDGE_PORT="${REMOTECLAW_PODMAN_BRIDGE_HOST_PORT:-${REMOTECLAW_BRIDGE_PORT:-18790}}"
-GATEWAY_BIND="${REMOTECLAW_GATEWAY_BIND:-lan}"
+# Keep Podman default local-only unless explicitly overridden.
+# Non-loopback binds require gateway.controlUi.allowedOrigins (security hardening).
+GATEWAY_BIND="${REMOTECLAW_GATEWAY_BIND:-loopback}"
 
 # Safe cwd for podman (remoteclaw is nologin; avoid inherited cwd from sudo)
 cd "$EFFECTIVE_HOME" 2>/dev/null || cd /tmp 2>/dev/null || true


### PR DESCRIPTION
Cherry-pick of upstream `5df9aacf68` — default podman bind to loopback.

Changes the default `GATEWAY_BIND` from `lan` to `loopback` in `run-remoteclaw-podman.sh` for safer default behavior. Adds documentation about the gateway bind option.

Cherry-picked-from: 5df9aacf68
Part of #597