### PR TITLE
fix(onboard): seed Control UI origins for non-loopback binds

### DIFF
--- a/src/wizard/onboarding.gateway-config.test.ts
+++ b/src/wizard/onboarding.gateway-config.test.ts
@@ -111,4 +111,29 @@ describe("configureGatewayForOnboarding", () => {
     expect(authConfig?.password).toBe("");
     expect(authConfig?.password).not.toBe("undefined");
   });
+
+  it("seeds control UI allowed origins for non-loopback binds", async () => {
+    mocks.randomToken.mockReturnValue("generated-token");
+
+    const prompter = createPrompter({
+      selectQueue: ["lan", "token", "off"],
+      textQueue: ["18789", undefined],
+    });
+    const runtime = createRuntime();
+
+    const result = await configureGatewayForOnboarding({
+      flow: "advanced",
+      baseConfig: {},
+      nextConfig: {},
+      localPort: 18789,
+      quickstartGateway: createQuickstartGateway("token"),
+      prompter,
+      runtime,
+    });
+
+    expect(result.nextConfig.gateway?.controlUi?.allowedOrigins).toEqual([
+      "http://localhost:18789",
+      "http://127.0.0.1:18789",
+    ]);
+  });
 });


### PR DESCRIPTION
Cherry-pick of upstream `da53015ef5` — seed Control UI allowed origins for non-loopback binds.

When gateway binds to LAN/custom host during onboarding, automatically seeds `controlUi.allowedOrigins` with localhost and 127.0.0.1 origins so the Control UI works without manual configuration.

Cherry-picked-from: da53015ef5
Part of #597