### PR TITLE
chore: add .dev-state to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ dist/protocol.schema.json
 
 # Synthing
 **/.stfolder/
+.dev-state


### PR DESCRIPTION
Cherry-pick of upstream `d340ea92d` — add `.dev-state` to `.gitignore`.

Cherry-picked-from: d340ea92d
Part of #930