### PR TITLE
ui: fix sessions table collapse on narrow widths

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1388,6 +1388,7 @@
 
 .table {
   display: grid;
+  container-type: inline-size;
   gap: 6px;
 }
 
@@ -1416,6 +1417,20 @@
 
 .table-row:hover {
   border-color: var(--border-strong);
+}
+
+@media (max-width: 1100px) {
+  .table-head,
+  .table-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+@container (max-width: 1100px) {
+  .table-head,
+  .table-row {
+    grid-template-columns: 1fr;
+  }
 }
 
 .session-link {


### PR DESCRIPTION
Cherry-pick of upstream `989ee21b2` — fix sessions table collapse on narrow widths.

Adds container query and media query responsive breakpoints for table grid layout so sessions table doesn't collapse on narrow viewports.

Cherry-picked-from: 989ee21b2
Part of #931