### PR TITLE
fix(ui): replace Manual RPC text input with sorted method dropdown

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -968,6 +968,7 @@ export function renderApp(state: AppViewState) {
                 health: state.debugHealth,
                 heartbeat: state.debugHeartbeat,
                 eventLog: state.eventLog,
+                methods: (state.hello?.features?.methods ?? []).toSorted(),
                 callMethod: state.debugCallMethod,
                 callParams: state.debugCallParams,
                 callResult: state.debugCallResult,

--- a/ui/src/ui/views/debug.ts
+++ b/ui/src/ui/views/debug.ts
@@ -8,6 +8,7 @@ export type DebugProps = {
   health: Record<string, unknown> | null;
   heartbeat: unknown;
   eventLog: EventLogEntry[];
+  methods: string[];
   callMethod: string;
   callParams: string;
   callResult: string | null;
@@ -70,14 +71,22 @@ export function renderDebug(props: DebugProps) {
       <div class="card">
         <div class="card-title">Manual RPC</div>
         <div class="card-sub">Send a raw gateway method with JSON params.</div>
-        <div class="form-grid" style="margin-top: 16px;">
+        <div class="stack" style="margin-top: 16px;">
           <label class="field">
             <span>Method</span>
-            <input
+            <select
               .value=${props.callMethod}
-              @input=${(e: Event) => props.onCallMethodChange((e.target as HTMLInputElement).value)}
-              placeholder="system-presence"
-            />
+              @change=${(e: Event) => props.onCallMethodChange((e.target as HTMLSelectElement).value)}
+            >
+              ${
+                !props.callMethod
+                  ? html`
+                      <option value="" disabled>Select a method…</option>
+                    `
+                  : nothing
+              }
+              ${props.methods.map((m) => html`<option value=${m}>${m}</option>`)}
+            </select>
           </label>
           <label class="field">
             <span>Params (JSON)</span>


### PR DESCRIPTION
Cherry-pick of upstream `9d403fd41` — replace Manual RPC text input with sorted method dropdown.

Replaces the free-text RPC method input in the debug view with a sorted dropdown of available gateway methods for better UX.

Cherry-picked-from: 9d403fd41
Part of #931