### PR TITLE
fix(swiftformat): sync exclusions with RemoteClawProtocol

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -48,4 +48,4 @@
 --allman false
 
 # Exclusions
---exclude .build,.swiftpm,DerivedData,node_modules,dist,coverage,xcuserdata,Peekaboo,Swabble,apps/android,apps/ios,apps/shared,apps/macos/Sources/MoltbotProtocol
+--exclude .build,.swiftpm,DerivedData,node_modules,dist,coverage,xcuserdata,Peekaboo,Swabble,apps/android,apps/ios,apps/shared,apps/macos/Sources/RemoteClawProtocol


### PR DESCRIPTION
Cherry-pick of upstream `5decb00e9` — sync SwiftFormat exclusions with protocol module rename.

Updates `.swiftformat` exclusion path from `MoltbotProtocol` to `RemoteClawProtocol` (our rebranded equivalent of upstream's `OpenClawProtocol`).

Cherry-picked-from: 5decb00e9
Part of #933