### PR TITLE
fix(telegram): allow inline button callbacks in groups

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -444,7 +444,9 @@ export const registerTelegramHandlers = ({
     },
     "callback-allowlist": {
       enforceDirectAuthorization: true,
-      enforceGroupAllowlistAuthorization: true,
+      // Group auth is already enforced by shouldSkipGroupMessage (group policy + allowlist).
+      // An extra allowlist gate here would block users whose original command was authorized.
+      enforceGroupAllowlistAuthorization: false,
       deniedDmReason: "callback unauthorized by inlineButtonsScope allowlist",
       deniedGroupReason: "callback unauthorized by inlineButtonsScope allowlist",
     },

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -191,7 +191,6 @@ describe("createTelegramBot", () => {
   it("allows callback_query in groups when group policy authorizes the sender", async () => {
     onSpy.mockClear();
     editMessageTextSpy.mockClear();
-    listSkillCommandsForAgents.mockClear();
 
     createTelegramBot({
       token: "tok",
@@ -223,7 +222,7 @@ describe("createTelegramBot", () => {
           message_id: 20,
         },
       },
-      me: { username: "openclaw_bot" },
+      me: { username: "remoteclaw_bot" },
       getFile: async () => ({ download: async () => new Uint8Array() }),
     });
 

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -188,6 +188,50 @@ describe("createTelegramBot", () => {
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-2");
   });
 
+  it("allows callback_query in groups when group policy authorizes the sender", async () => {
+    onSpy.mockClear();
+    editMessageTextSpy.mockClear();
+    listSkillCommandsForAgents.mockClear();
+
+    createTelegramBot({
+      token: "tok",
+      config: {
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            capabilities: { inlineButtons: "allowlist" },
+            allowFrom: [],
+            groupPolicy: "open",
+            groups: { "*": { requireMention: false } },
+          },
+        },
+      },
+    });
+    const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    expect(callbackHandler).toBeDefined();
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-group-1",
+        data: "commands_page_2",
+        from: { id: 42, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: -100999, type: "supergroup", title: "Test Group" },
+          date: 1736380800,
+          message_id: 20,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    // The callback should be processed (not silently blocked)
+    expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-group-1");
+  });
+
   it("edits commands list for pagination callbacks", async () => {
     onSpy.mockClear();
 


### PR DESCRIPTION
Cherry-pick of upstream 58fef1d703. Clean apply.

Fixes inline button callbacks being dropped in group chats.

Part of #599.