### PR TITLE
fix(auto-reply): tighten silent token prefix streaming (cherry-pick openclaw#600 2/4)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -34,7 +34,12 @@ import type {
 import { defaultRuntime } from "../../runtime.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
-import { isSilentReplyPrefixText, isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+import {
+  HEARTBEAT_TOKEN,
+  isSilentReplyPrefixText,
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+} from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { type BlockReplyPipeline } from "./block-reply-pipeline.js";
 import type { FollowupRun } from "./queue.js";
@@ -222,6 +227,12 @@ export async function runAgentTurnWithFallback(params: {
       const normalizeStreamingText = (payload: ReplyPayload): { text?: string; skip: boolean } => {
         const text = payload.text;
         if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+          return { skip: true };
+        }
+        if (
+          isSilentReplyPrefixText(text, SILENT_REPLY_TOKEN) ||
+          isSilentReplyPrefixText(text, HEARTBEAT_TOKEN)
+        ) {
           return { skip: true };
         }
         if (!text) {

--- a/src/auto-reply/reply/streaming-directives.ts
+++ b/src/auto-reply/reply/streaming-directives.ts
@@ -1,6 +1,6 @@
 import { splitMediaFromOutput } from "../../media/parse.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+import { isSilentReplyPrefixText, isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { ReplyDirectiveParseResult } from "./reply-directives.js";
 
 type PendingReplyState = {
@@ -47,7 +47,8 @@ const parseChunk = (raw: string, options?: { silentToken?: string }): ParsedChun
   }
 
   const silentToken = options?.silentToken ?? SILENT_REPLY_TOKEN;
-  const isSilent = isSilentReplyText(text, silentToken);
+  const isSilent =
+    isSilentReplyText(text, silentToken) || isSilentReplyPrefixText(text, silentToken);
   if (isSilent) {
     text = "";
   }

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -1,5 +1,5 @@
 import { createTypingKeepaliveLoop } from "../../channels/typing-lifecycle.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+import { isSilentReplyPrefixText, isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 
 export type TypingController = {
   onReplyStart: () => Promise<void>;
@@ -163,7 +163,10 @@ export function createTypingController(params: {
     if (!trimmed) {
       return;
     }
-    if (silentToken && isSilentReplyText(trimmed, silentToken)) {
+    if (
+      silentToken &&
+      (isSilentReplyText(trimmed, silentToken) || isSilentReplyPrefixText(trimmed, silentToken))
+    ) {
       return;
     }
     refreshTypingTtl();

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isSilentReplyText } from "./tokens.js";
+import { isSilentReplyPrefixText, isSilentReplyText } from "./tokens.js";
 
 describe("isSilentReplyText", () => {
   it("returns true for exact token", () => {
@@ -33,5 +33,26 @@ describe("isSilentReplyText", () => {
   it("works with custom token", () => {
     expect(isSilentReplyText("HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(true);
     expect(isSilentReplyText("Checked inbox. HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(false);
+  });
+});
+
+describe("isSilentReplyPrefixText", () => {
+  it("matches uppercase underscore prefixes", () => {
+    expect(isSilentReplyPrefixText("NO_")).toBe(true);
+    expect(isSilentReplyPrefixText("NO_RE")).toBe(true);
+    expect(isSilentReplyPrefixText("NO_REPLY")).toBe(true);
+    expect(isSilentReplyPrefixText("  HEARTBEAT_", "HEARTBEAT_OK")).toBe(true);
+  });
+
+  it("rejects ambiguous natural-language prefixes", () => {
+    expect(isSilentReplyPrefixText("N")).toBe(false);
+    expect(isSilentReplyPrefixText("No")).toBe(false);
+    expect(isSilentReplyPrefixText("Hello")).toBe(false);
+  });
+
+  it("rejects non-prefixes and mixed characters", () => {
+    expect(isSilentReplyPrefixText("NO_X")).toBe(false);
+    expect(isSilentReplyPrefixText("NO_REPLY more")).toBe(false);
+    expect(isSilentReplyPrefixText("NO-")).toBe(false);
   });
 });

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -1,6 +1,7 @@
 import { escapeRegExp } from "../utils.js";
 
 export const SILENT_REPLY_TOKEN = "NO_REPLY";
+export const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
 
 export function isSilentReplyText(
   text: string | undefined,

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -11,7 +11,7 @@ export function isSilentReplyText(
   }
   const escaped = escapeRegExp(token);
   // Only match when the entire response (trimmed) is the silent token,
-  // optionally surrounded by whitespace/punctuation. This prevents
+  // optionally surrounded by whitespace. This prevents
   // substantive replies ending with NO_REPLY from being suppressed (#19537).
   return new RegExp(`^\\s*${escaped}\\s*$`).test(text);
 }


### PR DESCRIPTION
## Summary
- Cherry-pick of upstream commit `e64d72299e` (issue #600, commit 2 of 4)
- Adds `isSilentReplyPrefixText` checks to agent-runner-execution, streaming-directives, and typing controller
- Prevents partial silent-token prefixes (e.g. "NO_" mid-stream) from triggering typing indicators or being forwarded

## Cherry-pick details
- **Upstream**: openclaw/openclaw@e64d72299e
- **Apply mode**: AUTO-PARTIAL (test-only changes already applied in PR #1064)
- **Files**: `src/auto-reply/reply/agent-runner-execution.ts`, `src/auto-reply/reply/streaming-directives.ts`, `src/auto-reply/reply/typing.ts`, `src/auto-reply/tokens.ts`, `src/auto-reply/tokens.test.ts`

## Test plan
- [x] Existing + new tests for isSilentReplyPrefixText
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cherry-picked-from: openclaw/openclaw@e64d72299e