### PR TITLE
docs(auto-reply): align silent token comment with regex (cherry-pick openclaw#600 3/4)

### DIFF
--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -11,8 +11,8 @@ export function isSilentReplyText(
     return false;
   }
   const escaped = escapeRegExp(token);
-  // Only match when the entire response (trimmed) is the silent token,
-  // optionally surrounded by whitespace. This prevents
+  // Match only the exact silent token with optional surrounding whitespace.
+  // This prevents
   // substantive replies ending with NO_REPLY from being suppressed (#19537).
   return new RegExp(`^\\s*${escaped}\\s*$`).test(text);
 }


### PR DESCRIPTION
## Summary
- Cherry-pick of upstream commit `133f14c0af` (issue #600, commit 3 of 4)
- Aligns comment in `isSilentReplyText` with the actual regex behavior

## Cherry-pick details
- **Upstream**: openclaw/openclaw@133f14c0af
- **Apply mode**: CLEAN
- **Files**: `src/auto-reply/tokens.ts`

## Test plan
- [x] Comment-only change, no behavioral impact
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cherry-picked-from: openclaw/openclaw@133f14c0af