### PR TITLE
fix(typing): add main-run dispatch idle safety net (cherry-pick openclaw#601 1/3)

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -676,5 +676,12 @@ export async function runReplyAgent(params: {
   } finally {
     blockReplyPipeline?.stop();
     typing.markRunComplete();
+    // Safety net: the dispatcher's onIdle callback normally fires
+    // markDispatchIdle(), but if the dispatcher exits early, errors,
+    // or the reply path doesn't go through it cleanly, the second
+    // signal never fires and the typing keepalive loop runs forever.
+    // Calling this twice is harmless — cleanup() is guarded by the
+    // `active` flag.  Same pattern as the followup runner fix (#26881).
+    typing.markDispatchIdle();
   }
 }


### PR DESCRIPTION
## Summary
- Cherry-pick of upstream commit `199ef9f8ea` (issue #601, commit 1 of 3)
- Adds `markDispatchIdle()` safety net in `runReplyAgent` finally block
- Prevents typing keepalive loops from running forever when dispatcher exits early

## Cherry-pick details
- **Upstream**: openclaw/openclaw@199ef9f8ea
- **Apply mode**: AUTO-PARTIAL (CHANGELOG.md discarded)
- **Files**: `src/auto-reply/reply/agent-runner.ts`

## Test plan
- [x] Safety net call — idempotent by design
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cherry-picked-from: openclaw/openclaw@199ef9f8ea