### PR TITLE
feat(onboarding): support plugin-owned interactive channel flows (cherry-pick openclaw#602 4/4)

### DIFF
--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -395,6 +395,29 @@ Notes:
 - `meta.preferOver` lists channel ids to skip auto-enable when both are configured.
 - `meta.detailLabel` and `meta.systemImage` let UIs show richer channel labels/icons.
 
+### Channel onboarding hooks
+
+Channel plugins can define optional onboarding hooks on `plugin.onboarding`:
+
+- `configure(ctx)` is the baseline setup flow.
+- `configureInteractive(ctx)` can fully own interactive setup for both configured and unconfigured states.
+- `configureWhenConfigured(ctx)` can override behavior only for already configured channels.
+
+Hook precedence in the wizard:
+
+1. `configureInteractive` (if present)
+2. `configureWhenConfigured` (only when channel status is already configured)
+3. fallback to `configure`
+
+Context details:
+
+- `configureInteractive` and `configureWhenConfigured` receive:
+  - `configured` (`true` or `false`)
+  - `label` (user-facing channel name used by prompts)
+  - plus the shared config/runtime/prompter/options fields
+- Returning `"skip"` leaves selection and account tracking unchanged.
+- Returning `{ cfg, accountId? }` applies config updates and records account selection.
+
 ### Write a new messaging channel (step‑by‑step)
 
 Use this when you want a **new chat surface** (a "messaging channel").

--- a/src/channels/plugins/onboarding-types.ts
+++ b/src/channels/plugins/onboarding-types.ts
@@ -62,6 +62,13 @@ export type ChannelOnboardingResult = {
   accountId?: string;
 };
 
+export type ChannelOnboardingConfiguredResult = ChannelOnboardingResult | "skip";
+
+export type ChannelOnboardingInteractiveContext = ChannelOnboardingConfigureContext & {
+  configured: boolean;
+  label: string;
+};
+
 export type ChannelOnboardingDmPolicy = {
   label: string;
   channel: ChannelId;
@@ -80,6 +87,12 @@ export type ChannelOnboardingAdapter = {
   channel: ChannelId;
   getStatus: (ctx: ChannelOnboardingStatusContext) => Promise<ChannelOnboardingStatus>;
   configure: (ctx: ChannelOnboardingConfigureContext) => Promise<ChannelOnboardingResult>;
+  configureInteractive?: (
+    ctx: ChannelOnboardingInteractiveContext,
+  ) => Promise<ChannelOnboardingConfiguredResult>;
+  configureWhenConfigured?: (
+    ctx: ChannelOnboardingInteractiveContext,
+  ) => Promise<ChannelOnboardingConfiguredResult>;
   dmPolicy?: ChannelOnboardingDmPolicy;
   onAccountRecorded?: (accountId: string, options?: SetupChannelsOptions) => void;
   disable?: (cfg: RemoteClawConfig) => RemoteClawConfig;

--- a/src/commands/onboard-channels.test.ts
+++ b/src/commands/onboard-channels.test.ts
@@ -3,7 +3,10 @@ import type { RemoteClawConfig } from "../config/config.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
-import { setDefaultChannelPluginRegistryForTests } from "./channel-test-helpers.js";
+import {
+  patchChannelOnboardingAdapter,
+  setDefaultChannelPluginRegistryForTests,
+} from "./channel-test-helpers.js";
 import { setupChannels } from "./onboard-channels.js";
 import { createExitThrowingRuntime, createWizardPrompter } from "./test-wizard-helpers.js";
 
@@ -265,5 +268,308 @@ describe("setupChannels", () => {
 
     expect(select).toHaveBeenCalledWith(expect.objectContaining({ message: "Select a channel" }));
     expect(multiselect).not.toHaveBeenCalled();
+  });
+
+  it("uses configureInteractive skip without mutating selection/account state", async () => {
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select channel (QuickStart)") {
+        return "telegram";
+      }
+      return "__done__";
+    });
+    const selection = vi.fn();
+    const onAccountId = vi.fn();
+    const configureInteractive = vi.fn(async () => "skip" as const);
+    const restore = patchChannelOnboardingAdapter("telegram", {
+      getStatus: vi.fn(async ({ cfg }) => ({
+        channel: "telegram",
+        configured: Boolean(cfg.channels?.telegram?.botToken),
+        statusLines: [],
+      })),
+      configureInteractive,
+    });
+    const { multiselect, text } = createUnexpectedPromptGuards();
+
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      multiselect,
+      text,
+    });
+
+    const runtime = createExitThrowingRuntime();
+    try {
+      const cfg = await setupChannels({} as RemoteClawConfig, runtime, prompter, {
+        skipConfirm: true,
+        quickstartDefaults: true,
+        onSelection: selection,
+        onAccountId,
+      });
+
+      expect(configureInteractive).toHaveBeenCalledWith(
+        expect.objectContaining({ configured: false, label: expect.any(String) }),
+      );
+      expect(selection).toHaveBeenCalledWith([]);
+      expect(onAccountId).not.toHaveBeenCalled();
+      expect(cfg.channels?.telegram?.botToken).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it("applies configureInteractive result cfg/account updates", async () => {
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select channel (QuickStart)") {
+        return "telegram";
+      }
+      return "__done__";
+    });
+    const selection = vi.fn();
+    const onAccountId = vi.fn();
+    const configureInteractive = vi.fn(async ({ cfg }: { cfg: RemoteClawConfig }) => ({
+      cfg: {
+        ...cfg,
+        channels: {
+          ...cfg.channels,
+          telegram: { ...cfg.channels?.telegram, botToken: "new-token" },
+        },
+      } as RemoteClawConfig,
+      accountId: "acct-1",
+    }));
+    const configure = vi.fn(async () => {
+      throw new Error("configure should not be called when configureInteractive is present");
+    });
+    const restore = patchChannelOnboardingAdapter("telegram", {
+      getStatus: vi.fn(async ({ cfg }) => ({
+        channel: "telegram",
+        configured: Boolean(cfg.channels?.telegram?.botToken),
+        statusLines: [],
+      })),
+      configureInteractive,
+      configure,
+    });
+    const { multiselect, text } = createUnexpectedPromptGuards();
+
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      multiselect,
+      text,
+    });
+
+    const runtime = createExitThrowingRuntime();
+    try {
+      const cfg = await setupChannels({} as RemoteClawConfig, runtime, prompter, {
+        skipConfirm: true,
+        quickstartDefaults: true,
+        onSelection: selection,
+        onAccountId,
+      });
+
+      expect(configureInteractive).toHaveBeenCalledTimes(1);
+      expect(configure).not.toHaveBeenCalled();
+      expect(selection).toHaveBeenCalledWith(["telegram"]);
+      expect(onAccountId).toHaveBeenCalledWith("telegram", "acct-1");
+      expect(cfg.channels?.telegram?.botToken).toBe("new-token");
+    } finally {
+      restore();
+    }
+  });
+
+  it("uses configureWhenConfigured when channel is already configured", async () => {
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select channel (QuickStart)") {
+        return "telegram";
+      }
+      return "__done__";
+    });
+    const selection = vi.fn();
+    const onAccountId = vi.fn();
+    const configureWhenConfigured = vi.fn(async ({ cfg }: { cfg: RemoteClawConfig }) => ({
+      cfg: {
+        ...cfg,
+        channels: {
+          ...cfg.channels,
+          telegram: { ...cfg.channels?.telegram, botToken: "updated-token" },
+        },
+      } as RemoteClawConfig,
+      accountId: "acct-2",
+    }));
+    const configure = vi.fn(async () => {
+      throw new Error(
+        "configure should not be called when configureWhenConfigured handles updates",
+      );
+    });
+    const restore = patchChannelOnboardingAdapter("telegram", {
+      getStatus: vi.fn(async ({ cfg }) => ({
+        channel: "telegram",
+        configured: Boolean(cfg.channels?.telegram?.botToken),
+        statusLines: [],
+      })),
+      configureInteractive: undefined,
+      configureWhenConfigured,
+      configure,
+    });
+    const { multiselect, text } = createUnexpectedPromptGuards();
+
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      multiselect,
+      text,
+    });
+
+    const runtime = createExitThrowingRuntime();
+    try {
+      const cfg = await setupChannels(
+        {
+          channels: {
+            telegram: {
+              botToken: "old-token",
+            },
+          },
+        } as RemoteClawConfig,
+        runtime,
+        prompter,
+        {
+          skipConfirm: true,
+          quickstartDefaults: true,
+          onSelection: selection,
+          onAccountId,
+        },
+      );
+
+      expect(configureWhenConfigured).toHaveBeenCalledTimes(1);
+      expect(configureWhenConfigured).toHaveBeenCalledWith(
+        expect.objectContaining({ configured: true, label: expect.any(String) }),
+      );
+      expect(configure).not.toHaveBeenCalled();
+      expect(selection).toHaveBeenCalledWith(["telegram"]);
+      expect(onAccountId).toHaveBeenCalledWith("telegram", "acct-2");
+      expect(cfg.channels?.telegram?.botToken).toBe("updated-token");
+    } finally {
+      restore();
+    }
+  });
+
+  it("respects configureWhenConfigured skip without mutating selection or account state", async () => {
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select channel (QuickStart)") {
+        return "telegram";
+      }
+      throw new Error(`unexpected select prompt: ${message}`);
+    });
+    const selection = vi.fn();
+    const onAccountId = vi.fn();
+    const configureWhenConfigured = vi.fn(async () => "skip" as const);
+    const configure = vi.fn(async () => {
+      throw new Error("configure should not run when configureWhenConfigured handles skip");
+    });
+    const restore = patchChannelOnboardingAdapter("telegram", {
+      getStatus: vi.fn(async ({ cfg }) => ({
+        channel: "telegram",
+        configured: Boolean(cfg.channels?.telegram?.botToken),
+        statusLines: [],
+      })),
+      configureInteractive: undefined,
+      configureWhenConfigured,
+      configure,
+    });
+    const { multiselect, text } = createUnexpectedPromptGuards();
+
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      multiselect,
+      text,
+    });
+
+    const runtime = createExitThrowingRuntime();
+    try {
+      const cfg = await setupChannels(
+        {
+          channels: {
+            telegram: {
+              botToken: "old-token",
+            },
+          },
+        } as RemoteClawConfig,
+        runtime,
+        prompter,
+        {
+          skipConfirm: true,
+          quickstartDefaults: true,
+          onSelection: selection,
+          onAccountId,
+        },
+      );
+
+      expect(configureWhenConfigured).toHaveBeenCalledWith(
+        expect.objectContaining({ configured: true, label: expect.any(String) }),
+      );
+      expect(configure).not.toHaveBeenCalled();
+      expect(selection).toHaveBeenCalledWith([]);
+      expect(onAccountId).not.toHaveBeenCalled();
+      expect(cfg.channels?.telegram?.botToken).toBe("old-token");
+    } finally {
+      restore();
+    }
+  });
+
+  it("prefers configureInteractive over configureWhenConfigured when both hooks exist", async () => {
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select channel (QuickStart)") {
+        return "telegram";
+      }
+      throw new Error(`unexpected select prompt: ${message}`);
+    });
+    const selection = vi.fn();
+    const onAccountId = vi.fn();
+    const configureInteractive = vi.fn(async () => "skip" as const);
+    const configureWhenConfigured = vi.fn(async () => {
+      throw new Error("configureWhenConfigured should not run when configureInteractive exists");
+    });
+    const restore = patchChannelOnboardingAdapter("telegram", {
+      getStatus: vi.fn(async ({ cfg }) => ({
+        channel: "telegram",
+        configured: Boolean(cfg.channels?.telegram?.botToken),
+        statusLines: [],
+      })),
+      configureInteractive,
+      configureWhenConfigured,
+    });
+    const { multiselect, text } = createUnexpectedPromptGuards();
+
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      multiselect,
+      text,
+    });
+
+    const runtime = createExitThrowingRuntime();
+    try {
+      await setupChannels(
+        {
+          channels: {
+            telegram: {
+              botToken: "old-token",
+            },
+          },
+        } as RemoteClawConfig,
+        runtime,
+        prompter,
+        {
+          skipConfirm: true,
+          quickstartDefaults: true,
+          onSelection: selection,
+          onAccountId,
+        },
+      );
+
+      expect(configureInteractive).toHaveBeenCalledWith(
+        expect.objectContaining({ configured: true, label: expect.any(String) }),
+      );
+      expect(configureWhenConfigured).not.toHaveBeenCalled();
+      expect(selection).toHaveBeenCalledWith([]);
+      expect(onAccountId).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
   });
 });

--- a/src/commands/onboard-channels.test.ts
+++ b/src/commands/onboard-channels.test.ts
@@ -298,12 +298,19 @@ describe("setupChannels", () => {
 
     const runtime = createExitThrowingRuntime();
     try {
-      const cfg = await setupChannels({} as RemoteClawConfig, runtime, prompter, {
-        skipConfirm: true,
-        quickstartDefaults: true,
-        onSelection: selection,
-        onAccountId,
-      });
+      const cfg = await setupChannels(
+        {
+          agents: { list: [{ id: "main", workspace: "/tmp/test-workspace" }] },
+        } as RemoteClawConfig,
+        runtime,
+        prompter,
+        {
+          skipConfirm: true,
+          quickstartDefaults: true,
+          onSelection: selection,
+          onAccountId,
+        },
+      );
 
       expect(configureInteractive).toHaveBeenCalledWith(
         expect.objectContaining({ configured: false, label: expect.any(String) }),
@@ -357,12 +364,19 @@ describe("setupChannels", () => {
 
     const runtime = createExitThrowingRuntime();
     try {
-      const cfg = await setupChannels({} as RemoteClawConfig, runtime, prompter, {
-        skipConfirm: true,
-        quickstartDefaults: true,
-        onSelection: selection,
-        onAccountId,
-      });
+      const cfg = await setupChannels(
+        {
+          agents: { list: [{ id: "main", workspace: "/tmp/test-workspace" }] },
+        } as RemoteClawConfig,
+        runtime,
+        prompter,
+        {
+          skipConfirm: true,
+          quickstartDefaults: true,
+          onSelection: selection,
+          onAccountId,
+        },
+      );
 
       expect(configureInteractive).toHaveBeenCalledTimes(1);
       expect(configure).not.toHaveBeenCalled();
@@ -420,6 +434,7 @@ describe("setupChannels", () => {
     try {
       const cfg = await setupChannels(
         {
+          agents: { list: [{ id: "main", workspace: "/tmp/test-workspace" }] },
           channels: {
             telegram: {
               botToken: "old-token",
@@ -484,6 +499,7 @@ describe("setupChannels", () => {
     try {
       const cfg = await setupChannels(
         {
+          agents: { list: [{ id: "main", workspace: "/tmp/test-workspace" }] },
           channels: {
             telegram: {
               botToken: "old-token",
@@ -546,6 +562,7 @@ describe("setupChannels", () => {
     try {
       await setupChannels(
         {
+          agents: { list: [{ id: "main", workspace: "/tmp/test-workspace" }] },
           channels: {
             telegram: {
               botToken: "old-token",


### PR DESCRIPTION
## Summary
- Cherry-pick of upstream commit `f08fe02a1b` (issue #602, commit 4 of 4)
- Adds `configureInteractive` and `configureWhenConfigured` hooks to plugin onboarding
- Allows plugins to provide custom interactive setup flows during channel configuration

## Cherry-pick details
- **Upstream**: openclaw/openclaw@f08fe02a1b
- **Apply mode**: AUTO-PARTIAL (CHANGELOG.md discarded, OpenClaw→RemoteClaw rebrand)
- **Files**: `src/commands/onboard-channels.ts`, `src/commands/onboard-channels.test.ts`, `src/commands/channel-test-helpers.ts`, `src/channels/plugins/onboarding-types.ts`, `docs/tools/plugin.md`

## Test plan
- [x] 308-line test expansion for plugin onboarding flows
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cherry-picked-from: openclaw/openclaw@f08fe02a1b