### PR TITLE
fix(doctor): ignore slash sessions in transcript integrity check (cherry-pick openclaw#603 1/3)

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -171,4 +171,28 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(text).not.toContain("--active");
     expect(text).not.toContain(" ls ");
   });
+
+  it("ignores slash-routing sessions for recent missing transcript warnings", async () => {
+    const cfg: OpenClawConfig = {};
+    setupSessionState(cfg, process.env, process.env.HOME ?? "");
+    const storePath = resolveStorePath(cfg.session?.store, { agentId: "main" });
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify(
+        {
+          "agent:main:telegram:slash:6790081233": {
+            sessionId: "missing-slash-transcript",
+            updatedAt: Date.now(),
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await noteStateIntegrity(cfg, { confirmSkipInNonInteractive: vi.fn(async () => false) });
+
+    const text = stateIntegrityText();
+    expect(text).not.toContain("recent sessions are missing transcripts");
+  });
 });

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -173,7 +173,7 @@ describe("doctor state integrity oauth dir checks", () => {
   });
 
   it("ignores slash-routing sessions for recent missing transcript warnings", async () => {
-    const cfg: OpenClawConfig = {};
+    const cfg: RemoteClawConfig = {};
     setupSessionState(cfg, process.env, process.env.HOME ?? "");
     const storePath = resolveStorePath(cfg.session?.store, { agentId: "main" });
     fs.writeFileSync(

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -16,6 +16,7 @@ import {
   resolveStorePath,
 } from "../config/sessions.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
+import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { note } from "../terminal/note.js";
 import { shortenHomePath } from "../utils.js";
 
@@ -163,6 +164,15 @@ function hasPairingPolicy(value: unknown): boolean {
     }
   }
   return false;
+}
+
+function isSlashRoutingSessionKey(sessionKey: string): boolean {
+  const raw = sessionKey.trim().toLowerCase();
+  if (!raw) {
+    return false;
+  }
+  const scoped = parseAgentSessionKey(raw)?.rest ?? raw;
+  return /^[^:]+:slash:[^:]+(?:$|:)/.test(scoped);
 }
 
 function shouldRequireOAuthDir(cfg: RemoteClawConfig, env: NodeJS.ProcessEnv): boolean {
@@ -413,7 +423,8 @@ export async function noteStateIntegrity(
         return bUpdated - aUpdated;
       })
       .slice(0, 5);
-    const missing = recent.filter(([, entry]) => {
+    const recentTranscriptCandidates = recent.filter(([key]) => !isSlashRoutingSessionKey(key));
+    const missing = recentTranscriptCandidates.filter(([, entry]) => {
       const sessionId = entry.sessionId;
       if (!sessionId) {
         return false;
@@ -424,7 +435,7 @@ export async function noteStateIntegrity(
     if (missing.length > 0) {
       warnings.push(
         [
-          `- ${missing.length}/${recent.length} recent sessions are missing transcripts.`,
+          `- ${missing.length}/${recentTranscriptCandidates.length} recent sessions are missing transcripts.`,
           `  Verify sessions in store: ${formatCliCommand(`remoteclaw sessions --store "${absoluteStorePath}"`)}`,
           `  Preview cleanup impact: ${formatCliCommand(`remoteclaw sessions cleanup --store "${absoluteStorePath}" --dry-run`)}`,
         ].join("\n"),


### PR DESCRIPTION
## Summary
- Cherry-pick of upstream `a690b62391` (openclaw#603 commit 1/3)
- Adds `isSlashRoutingSessionKey()` to filter out slash-command routing sessions from transcript integrity checks
- Slash sessions use ephemeral routing keys and never produce transcript files, so counting them as "missing" is a false positive

## Adaptation
- Resolved merge conflict: kept fork's `RemoteClawConfig` type and `REMOTECLAW_OAUTH_DIR` env var
- Kept fork's `remoteclaw` CLI command name in user-facing messages
- Discarded CHANGELOG.md hunk

Cherry-picked-from: a690b62391