### PR TITLE
fix(doctor): keep allowFrom account-scoped in multi-account configs (cherry-pick openclaw#603 2/3)

### DIFF
--- a/docs/channels/discord.mdx
+++ b/docs/channels/discord.mdx
@@ -368,6 +368,12 @@ Example:
 
     If DM policy is not open, unknown users are blocked (or prompted for pairing in `pairing` mode).
 
+    Multi-account precedence:
+
+    - `channels.discord.accounts.default.allowFrom` applies only to the `default` account.
+    - Named accounts inherit `channels.discord.allowFrom` when their own `allowFrom` is unset.
+    - Named accounts do not inherit `channels.discord.accounts.default.allowFrom`.
+
     DM target format for delivery:
 
     - `user:<id>`

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -156,6 +156,12 @@ For actions/directory reads, user token can be preferred when configured. For wr
     - `dm.groupEnabled` (group DMs default false)
     - `dm.groupChannels` (optional MPIM allowlist)
 
+    Multi-account precedence:
+
+    - `channels.slack.accounts.default.allowFrom` applies only to the `default` account.
+    - Named accounts inherit `channels.slack.allowFrom` when their own `allowFrom` is unset.
+    - Named accounts do not inherit `channels.slack.accounts.default.allowFrom`.
+
     Pairing in DMs uses `remoteclaw pairing approve slack <code>`.
 
   </TabItem>

--- a/docs/channels/telegram.mdx
+++ b/docs/channels/telegram.mdx
@@ -756,6 +756,10 @@ Primary reference:
 - `channels.telegram.allowFrom`: DM allowlist (numeric Telegram user IDs). `open` requires `"*"`. `remoteclaw doctor --fix` can resolve legacy `@username` entries to IDs.
 - `channels.telegram.groupPolicy`: `open | allowlist | disabled` (default: allowlist).
 - `channels.telegram.groupAllowFrom`: group sender allowlist (numeric Telegram user IDs). `remoteclaw doctor --fix` can resolve legacy `@username` entries to IDs.
+- Multi-account precedence:
+  - `channels.telegram.accounts.default.allowFrom` and `channels.telegram.accounts.default.groupAllowFrom` apply only to the `default` account.
+  - Named accounts inherit `channels.telegram.allowFrom` and `channels.telegram.groupAllowFrom` when account-level values are unset.
+  - Named accounts do not inherit `channels.telegram.accounts.default.allowFrom` / `groupAllowFrom`.
 - `channels.telegram.groups`: per-group defaults + allowlist (use `"*"` for global defaults).
   - `channels.telegram.groups.<id>.groupPolicy`: per-group override for groupPolicy (`open | allowlist | disabled`).
   - `channels.telegram.groups.<id>.requireMention`: mention gating default.

--- a/src/commands/doctor-config-flow.missing-default-account-bindings.integration.test.ts
+++ b/src/commands/doctor-config-flow.missing-default-account-bindings.integration.test.ts
@@ -14,7 +14,7 @@ vi.mock("./doctor-legacy-config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./doctor-legacy-config.js")>();
   return {
     ...actual,
-    normalizeLegacyConfigValues: (cfg: unknown) => ({
+    normalizeCompatibilityConfigValues: (cfg: unknown) => ({
       config: cfg,
       changes: [],
     }),

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -222,7 +222,14 @@ describe("doctor config flow", () => {
       });
 
       const cfg = result.cfg as unknown as {
-        channels: { discord: RepairedDiscordPolicy };
+        channels: {
+          discord: Omit<RepairedDiscordPolicy, "allowFrom"> & {
+            allowFrom?: string[];
+            accounts: Record<string, DiscordAccountRule> & {
+              default: { allowFrom: string[] };
+            };
+          };
+        };
       };
 
       expect(cfg.channels.discord.allowFrom).toEqual(["123"]);
@@ -246,6 +253,35 @@ describe("doctor config flow", () => {
         "1212",
       ]);
     });
+  });
+
+  it("does not restore top-level allowFrom when config is intentionally default-account scoped", async () => {
+    const result = await runDoctorConfigWithInput({
+      repair: true,
+      config: {
+        channels: {
+          discord: {
+            accounts: {
+              default: { token: "discord-default-token", allowFrom: ["123"] },
+              work: { token: "discord-work-token" },
+            },
+          },
+        },
+      },
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    const cfg = result.cfg as {
+      channels: {
+        discord: {
+          allowFrom?: string[];
+          accounts: Record<string, { allowFrom?: string[] }>;
+        };
+      };
+    };
+
+    expect(cfg.channels.discord.allowFrom).toBeUndefined();
+    expect(cfg.channels.discord.accounts.default.allowFrom).toEqual(["123"]);
   });
 
   it('adds allowFrom ["*"] when dmPolicy="open" and allowFrom is missing on repair', async () => {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -30,7 +30,7 @@ import {
 import { listTelegramAccountIds, resolveTelegramAccount } from "../telegram/accounts.js";
 import { note } from "../terminal/note.js";
 import { resolveHomeDir } from "../utils.js";
-import { normalizeLegacyConfigValues } from "./doctor-legacy-config.js";
+import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
 import { autoMigrateLegacyStateDir } from "./doctor-state-migrations.js";
 
@@ -1253,7 +1253,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   if (snapshot.legacyIssues.length > 0) {
     note(
       snapshot.legacyIssues.map((issue) => `- ${issue.path}: ${issue.message}`).join("\n"),
-      "Legacy config keys detected",
+      "Compatibility config keys detected",
     );
     const { config: migrated, changes } = migrateLegacyConfig(snapshot.parsed);
     if (changes.length > 0) {
@@ -1264,18 +1264,18 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       pendingChanges = pendingChanges || changes.length > 0;
     }
     if (shouldRepair) {
-      // Legacy migration (2026-01-02, commit: 16420e5b) — normalize per-provider allowlists; move WhatsApp gating into channels.whatsapp.allowFrom.
+      // Compatibility migration (2026-01-02, commit: 16420e5b) — normalize per-provider allowlists; move WhatsApp gating into channels.whatsapp.allowFrom.
       if (migrated) {
         cfg = migrated;
       }
     } else {
       fixHints.push(
-        `Run "${formatCliCommand("remoteclaw doctor --fix")}" to apply legacy migrations.`,
+        `Run "${formatCliCommand("remoteclaw doctor --fix")}" to apply compatibility migrations.`,
       );
     }
   }
 
-  const normalized = normalizeLegacyConfigValues(candidate);
+  const normalized = normalizeCompatibilityConfigValues(candidate);
   if (normalized.changes.length > 0) {
     note(normalized.changes.join("\n"), "Doctor changes");
     candidate = normalized.config;

--- a/src/commands/doctor-legacy-config.ts
+++ b/src/commands/doctor-legacy-config.ts
@@ -1,6 +1,6 @@
 import type { RemoteClawConfig } from "../config/config.js";
 
-export function normalizeLegacyConfigValues(cfg: RemoteClawConfig): {
+export function normalizeCompatibilityConfigValues(cfg: RemoteClawConfig): {
   config: RemoteClawConfig;
   changes: string[];
 } {

--- a/src/discord/accounts.test.ts
+++ b/src/discord/accounts.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { resolveDiscordAccount } from "./accounts.js";
+
+describe("resolveDiscordAccount allowFrom precedence", () => {
+  it("prefers accounts.default.allowFrom over top-level for default account", () => {
+    const resolved = resolveDiscordAccount({
+      cfg: {
+        channels: {
+          discord: {
+            allowFrom: ["top"],
+            accounts: {
+              default: { allowFrom: ["default"], token: "token-default" },
+            },
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(resolved.config.allowFrom).toEqual(["default"]);
+  });
+
+  it("falls back to top-level allowFrom for named account without override", () => {
+    const resolved = resolveDiscordAccount({
+      cfg: {
+        channels: {
+          discord: {
+            allowFrom: ["top"],
+            accounts: {
+              work: { token: "token-work" },
+            },
+          },
+        },
+      },
+      accountId: "work",
+    });
+
+    expect(resolved.config.allowFrom).toEqual(["top"]);
+  });
+
+  it("does not inherit default account allowFrom for named account when top-level is absent", () => {
+    const resolved = resolveDiscordAccount({
+      cfg: {
+        channels: {
+          discord: {
+            accounts: {
+              default: { allowFrom: ["default"], token: "token-default" },
+              work: { token: "token-work" },
+            },
+          },
+        },
+      },
+      accountId: "work",
+    });
+
+    expect(resolved.config.allowFrom).toBeUndefined();
+  });
+});

--- a/src/slack/accounts.test.ts
+++ b/src/slack/accounts.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { resolveSlackAccount } from "./accounts.js";
+
+describe("resolveSlackAccount allowFrom precedence", () => {
+  it("prefers accounts.default.allowFrom over top-level for default account", () => {
+    const resolved = resolveSlackAccount({
+      cfg: {
+        channels: {
+          slack: {
+            allowFrom: ["top"],
+            accounts: {
+              default: {
+                botToken: "xoxb-default",
+                appToken: "xapp-default",
+                allowFrom: ["default"],
+              },
+            },
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(resolved.config.allowFrom).toEqual(["default"]);
+  });
+
+  it("falls back to top-level allowFrom for named account without override", () => {
+    const resolved = resolveSlackAccount({
+      cfg: {
+        channels: {
+          slack: {
+            allowFrom: ["top"],
+            accounts: {
+              work: { botToken: "xoxb-work", appToken: "xapp-work" },
+            },
+          },
+        },
+      },
+      accountId: "work",
+    });
+
+    expect(resolved.config.allowFrom).toEqual(["top"]);
+  });
+
+  it("does not inherit default account allowFrom for named account when top-level is absent", () => {
+    const resolved = resolveSlackAccount({
+      cfg: {
+        channels: {
+          slack: {
+            accounts: {
+              default: {
+                botToken: "xoxb-default",
+                appToken: "xapp-default",
+                allowFrom: ["default"],
+              },
+              work: { botToken: "xoxb-work", appToken: "xapp-work" },
+            },
+          },
+        },
+      },
+      accountId: "work",
+    });
+
+    expect(resolved.config.allowFrom).toBeUndefined();
+  });
+
+  it("falls back to top-level dm.allowFrom when allowFrom alias is unset", () => {
+    const resolved = resolveSlackAccount({
+      cfg: {
+        channels: {
+          slack: {
+            dm: { allowFrom: ["U123"] },
+            accounts: {
+              work: { botToken: "xoxb-work", appToken: "xapp-work" },
+            },
+          },
+        },
+      },
+      accountId: "work",
+    });
+
+    expect(resolved.config.allowFrom).toBeUndefined();
+    expect(resolved.config.dm?.allowFrom).toEqual(["U123"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Cherry-pick of upstream `1ffc319831` (openclaw#603 commit 2/3)
- Renames `normalizeLegacyConfigValues` → `normalizeCompatibilityConfigValues` (fork keeps passthrough stub)
- Adds multi-account precedence docs for Slack, Telegram, Discord
- Adds new tests for account-scoped allowFrom behavior

## Adaptation
- `doctor-legacy-config.ts` kept as passthrough stub with renamed function
- Deleted modify/delete conflict files: `doctor-legacy-config.migrations.test.ts`, `doctor-legacy-config.test.ts`
- Test expectations adjusted: fork doesn't migrate top-level allowFrom to accounts.default (passthrough stub)
- Rebranded all `openclaw` → `remoteclaw` in CLI commands and docs

Cherry-picked-from: 1ffc319831