### PR TITLE
test(doctor): tighten discord work account type in config flow (cherry-pick openclaw#603 3/3)

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -227,6 +227,12 @@ describe("doctor config flow", () => {
             allowFrom?: string[];
             accounts: Record<string, DiscordAccountRule> & {
               default: { allowFrom: string[] };
+              work: {
+                allowFrom: string[];
+                dm: { allowFrom: string[]; groupChannels: string[] };
+                execApprovals: { approvers: string[] };
+                guilds: Record<string, DiscordGuildRule>;
+              };
             };
           };
         };


### PR DESCRIPTION
## Summary
- Cherry-pick of upstream `e273b9851e` (openclaw#603 commit 3/3)
- Tightens the `work` account type assertion in the discord doctor config flow test

## Adaptation
- Clean apply, no conflicts

Cherry-picked-from: e273b9851e