### PR TITLE
fix(daemon): keep launchd KeepAlive while preserving restart hardening (cherry-pick openclaw#604 2/6)

### DIFF
--- a/src/daemon/launchd-plist.ts
+++ b/src/daemon/launchd-plist.ts
@@ -1,7 +1,5 @@
 import fs from "node:fs/promises";
 
-const LAUNCHD_THROTTLE_INTERVAL_SECONDS = 5;
-
 const plistEscape = (value: string): string =>
   value
     .replaceAll("&", "&amp;")
@@ -108,5 +106,5 @@ export function buildLaunchAgentPlist({
     ? `\n    <key>Comment</key>\n    <string>${plistEscape(comment.trim())}</string>`
     : "";
   const envXml = renderEnvDict(environment);
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <dict>\n      <key>SuccessfulExit</key>\n      <false/>\n    </dict>\n    <key>ThrottleInterval</key>\n    <integer>${LAUNCHD_THROTTLE_INTERVAL_SECONDS}</integer>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
 }

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -185,7 +185,7 @@ describe("launchd install", () => {
     expect(plist).toContain(`<string>${tmpDir}</string>`);
   });
 
-  it("writes crash-only KeepAlive policy with throttle interval", async () => {
+  it("writes KeepAlive=true policy", async () => {
     const env = createDefaultLaunchdEnv();
     await installLaunchAgent({
       env,
@@ -196,10 +196,9 @@ describe("launchd install", () => {
     const plistPath = resolveLaunchAgentPlistPath(env);
     const plist = state.files.get(plistPath) ?? "";
     expect(plist).toContain("<key>KeepAlive</key>");
-    expect(plist).toContain("<key>SuccessfulExit</key>");
-    expect(plist).toContain("<false/>");
-    expect(plist).toContain("<key>ThrottleInterval</key>");
-    expect(plist).toContain("<integer>5</integer>");
+    expect(plist).toContain("<true/>");
+    expect(plist).not.toContain("<key>SuccessfulExit</key>");
+    expect(plist).not.toContain("<key>ThrottleInterval</key>");
   });
 
   it("restarts LaunchAgent with bootout-bootstrap-kickstart order", async () => {


### PR DESCRIPTION
## Summary
- Cherry-pick of upstream `4ebefe647a` (openclaw#604 commit 2/6)
- Keeps launchd KeepAlive enabled while preserving the restart hardening from commit 1/6
- Adjusts plist test expectations

## Adaptation
- CHANGELOG-only conflict, discarded
- No openclaw references in changed code

Cherry-picked-from: 4ebefe647a