### PR TITLE
fix(cron): prevent isolated hook session-key double-prefixing

### DIFF
--- a/src/cron/isolated-agent/run.session-key.test.ts
+++ b/src/cron/isolated-agent/run.session-key.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { resolveCronAgentSessionKey } from "./run.js";
+
+describe("resolveCronAgentSessionKey", () => {
+  it("builds an agent-scoped key for legacy aliases", () => {
+    expect(resolveCronAgentSessionKey({ sessionKey: "main", agentId: "main" })).toBe(
+      "agent:main:main",
+    );
+  });
+
+  it("preserves canonical agent keys instead of prefixing twice", () => {
+    expect(resolveCronAgentSessionKey({ sessionKey: "agent:main:main", agentId: "main" })).toBe(
+      "agent:main:main",
+    );
+  });
+
+  it("normalizes canonical keys to lowercase before reuse", () => {
+    expect(
+      resolveCronAgentSessionKey({ sessionKey: "AGENT:Main:Hook:Webhook:42", agentId: "x" }),
+    ).toBe("agent:main:hook:webhook:42");
+  });
+
+  it("keeps hook keys scoped under the target agent", () => {
+    expect(resolveCronAgentSessionKey({ sessionKey: "hook:webhook:42", agentId: "main" })).toBe(
+      "agent:main:hook:webhook:42",
+    );
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -28,7 +28,11 @@ import { logWarn } from "../../logger.js";
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
 import type { SessionMap } from "../../middleware/session-map.js";
 import type { AgentDeliveryResult, ChannelMessage } from "../../middleware/types.js";
-import { buildAgentMainSessionKey, normalizeAgentId } from "../../routing/session-key.js";
+import {
+  buildAgentMainSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../../routing/session-key.js";
 import {
   buildSafeExternalPrompt,
   detectSuspiciousPatterns,
@@ -180,10 +184,7 @@ export async function runCronIsolatedAgentTurn(params: {
   };
 
   const baseSessionKey = (params.sessionKey?.trim() || `cron:${params.job.id}`).trim();
-  const agentSessionKey = buildAgentMainSessionKey({
-    agentId,
-    mainKey: baseSessionKey,
-  });
+  const agentSessionKey = resolveCronAgentSessionKey({ sessionKey: baseSessionKey, agentId });
 
   const workspaceDirRaw = resolveAgentWorkspaceDir(params.cfg, agentId);
   const workspaceDir = await ensureAgentWorkspace(workspaceDirRaw);
@@ -559,4 +560,19 @@ export async function runCronIsolatedAgentTurn(params: {
   outputText = deliveryResult.outputText;
 
   return resolveRunOutcome({ delivered, deliveryAttempted });
+}
+
+export function resolveCronAgentSessionKey(params: {
+  sessionKey: string;
+  agentId: string;
+}): string {
+  const baseSessionKey = params.sessionKey.trim();
+  const normalizedBaseSessionKey = baseSessionKey.toLowerCase();
+  if (parseAgentSessionKey(normalizedBaseSessionKey)) {
+    return normalizedBaseSessionKey;
+  }
+  return buildAgentMainSessionKey({
+    agentId: params.agentId,
+    mainKey: baseSessionKey,
+  });
 }


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@8b5ebff67b (PR #27333, @MaheshBhushan).

**What**: Prevents double-prefixing of session keys in isolated cron hook runs. When a hook session key already contained an agent prefix, `buildAgentMainSessionKey` would add a second prefix. Now uses `parseAgentSessionKey` to strip existing prefix before rebuilding.

**Adaptation**: AUTO-PARTIAL — resolved import conflict (kept fork's ChannelBridge middleware imports, added new `parseAgentSessionKey` import). CHANGELOG hunks discarded per fork convention.

Cherry-picked-from: openclaw/openclaw@8b5ebff67b
Part of #604