### PR TITLE
fix: suppress SUBAGENT_SPAWN_ACCEPTED_NOTE for cron isolated sessions

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -476,13 +476,23 @@ export async function spawnSubagentDirect(
     }
   }
 
+  // Check if we're in a cron isolated session - don't add "do not poll" note
+  // because cron sessions end immediately after the agent produces a response,
+  // so the agent needs to wait for subagent results to keep the turn alive.
+  const isCronSession = ctx.agentSessionKey?.includes(":cron:");
+  const note =
+    spawnMode === "session"
+      ? SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE
+      : isCronSession
+        ? undefined
+        : SUBAGENT_SPAWN_ACCEPTED_NOTE;
+
   return {
     status: "accepted",
     childSessionKey,
     runId: childRunId,
     mode: spawnMode,
-    note:
-      spawnMode === "session" ? SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE : SUBAGENT_SPAWN_ACCEPTED_NOTE,
+    note,
     modelApplied: resolvedModel ? modelApplied : undefined,
   };
 }


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@69590de276 (PR #27334, @TarasLukavyi).

**What**: Suppresses the "do not poll" accepted note for cron isolated sessions. Cron sessions end immediately after the agent produces a response, so the agent needs to wait for subagent results to keep the turn alive — the polling warning is misleading in this context.

**Adaptation**: AUTO-PARTIAL — test file (`openclaw-tools.subagents.sessions-spawn.cron-note.test.ts`) removed because it depends on gutted infrastructure (`sessions-spawn-tool.ts`, `subagent-registry.ts`, test harness). Production change in `subagent-spawn.ts` applies cleanly. CHANGELOG hunks discarded per fork convention.

Cherry-picked-from: openclaw/openclaw@69590de276
Part of #604