### PR TITLE
fix: use canonical cron session detection for spawn note

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -3,7 +3,11 @@ import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
 import { callGateway } from "../gateway/call.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import {
+  isCronSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../routing/session-key.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
@@ -479,7 +483,7 @@ export async function spawnSubagentDirect(
   // Check if we're in a cron isolated session - don't add "do not poll" note
   // because cron sessions end immediately after the agent produces a response,
   // so the agent needs to wait for subagent results to keep the turn alive.
-  const isCronSession = ctx.agentSessionKey?.includes(":cron:");
+  const isCronSession = isCronSessionKey(ctx.agentSessionKey);
   const note =
     spawnMode === "session"
       ? SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@452a8c9db9 (PR #27335, @AyaanZaidi).

**What**: Replaces inline `:cron:` string check with the canonical `isCronSessionKey()` utility for cron session detection in subagent spawn note suppression.

**Adaptation**: AUTO-PARTIAL — test file removed (depends on gutted sessions-spawn test harness). Production change in `subagent-spawn.ts` applies cleanly — `isCronSessionKey` already exists in fork at `src/sessions/session-key-utils.ts`. CHANGELOG hunks discarded per fork convention.

Cherry-picked-from: openclaw/openclaw@452a8c9db9
Part of #604