### PR TITLE
cherry-pick: allow ACP sessions.patch lineage fields on ACP session keys

### DIFF
--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -5,6 +5,34 @@ import { applySessionsPatchToStore } from "./sessions-patch.js";
 
 const SUBAGENT_MODEL = "synthetic/hf:moonshotai/Kimi-K2.5";
 const KIMI_SUBAGENT_KEY = "agent:kimi:subagent:child";
+const MAIN_SESSION_KEY = "agent:main:main";
+const EMPTY_CFG = {} as RemoteClawConfig;
+
+type ApplySessionsPatchArgs = Parameters<typeof applySessionsPatchToStore>[0];
+
+async function runPatch(params: {
+  patch: ApplySessionsPatchArgs["patch"];
+  store?: Record<string, SessionEntry>;
+  cfg?: RemoteClawConfig;
+  storeKey?: string;
+}) {
+  return applySessionsPatchToStore({
+    cfg: params.cfg ?? EMPTY_CFG,
+    store: params.store ?? {},
+    storeKey: params.storeKey ?? MAIN_SESSION_KEY,
+    patch: params.patch,
+  });
+}
+
+function expectPatchOk(
+  result: Awaited<ReturnType<typeof applySessionsPatchToStore>>,
+): SessionEntry {
+  expect(result.ok).toBe(true);
+  if (!result.ok) {
+    throw new Error(result.error.message);
+  }
+  return result.entry;
+}
 
 async function applySubagentModelPatch(cfg: RemoteClawConfig) {
   const res = await applySessionsPatchToStore({
@@ -142,6 +170,29 @@ describe("gateway sessions patch", () => {
       return;
     }
     expect(res.entry.spawnDepth).toBe(2);
+  });
+
+  test("sets spawnedBy for ACP sessions", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        storeKey: "agent:main:acp:child",
+        patch: {
+          key: "agent:main:acp:child",
+          spawnedBy: "agent:main:main",
+        },
+      }),
+    );
+    expect(entry.spawnedBy).toBe("agent:main:main");
+  });
+
+  test("sets spawnDepth for ACP sessions", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        storeKey: "agent:main:acp:child",
+        patch: { key: "agent:main:acp:child", spawnDepth: 2 },
+      }),
+    );
+    expect(entry.spawnDepth).toBe(2);
   });
 
   test("rejects spawnDepth on non-subagent sessions", async () => {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -4,7 +4,7 @@ import { normalizeGroupActivation } from "../auto-reply/group-activation.js";
 import { normalizeUsageDisplay } from "../auto-reply/thinking.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
-import { isSubagentSessionKey } from "../routing/session-key.js";
+import { isAcpSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
 import { applyVerboseOverride, parseVerboseOverride } from "../sessions/level-overrides.js";
 import { normalizeSendPolicy } from "../sessions/send-policy.js";
 import { parseSessionLabel } from "../sessions/session-label.js";
@@ -17,6 +17,10 @@ import {
 
 function invalid(message: string): { ok: false; error: ErrorShape } {
   return { ok: false, error: errorShape(ErrorCodes.INVALID_REQUEST, message) };
+}
+
+function supportsSpawnLineage(storeKey: string): boolean {
+  return isSubagentSessionKey(storeKey) || isAcpSessionKey(storeKey);
 }
 
 export async function applySessionsPatchToStore(params: {
@@ -48,8 +52,8 @@ export async function applySessionsPatchToStore(params: {
       if (!trimmed) {
         return invalid("invalid spawnedBy: empty");
       }
-      if (!isSubagentSessionKey(storeKey)) {
-        return invalid("spawnedBy is only supported for subagent:* sessions");
+      if (!supportsSpawnLineage(storeKey)) {
+        return invalid("spawnedBy is only supported for subagent:* or acp:* sessions");
       }
       if (existing?.spawnedBy && existing.spawnedBy !== trimmed) {
         return invalid("spawnedBy cannot be changed once set");
@@ -65,8 +69,8 @@ export async function applySessionsPatchToStore(params: {
         return invalid("spawnDepth cannot be cleared once set");
       }
     } else if (raw !== undefined) {
-      if (!isSubagentSessionKey(storeKey)) {
-        return invalid("spawnDepth is only supported for subagent:* sessions");
+      if (!supportsSpawnLineage(storeKey)) {
+        return invalid("spawnDepth is only supported for subagent:* or acp:* sessions");
       }
       const numeric = Number(raw);
       if (!Number.isInteger(numeric) || numeric < 0) {


### PR DESCRIPTION
## Summary
- Cherry-pick of openclaw/openclaw@425bd89b4
- Extends spawnedBy/spawnDepth validation to accept `acp:*` session keys alongside `subagent:*` keys
- Adds `isAcpSessionKey` + `supportsSpawnLineage` helpers and test coverage
- CHANGELOG entry discarded (fork convention)

Closes #925 (2/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)