### PR TITLE
Cherry-pick d4e59a366: Cron: enforce cron-owned delivery contract

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -29,6 +29,7 @@ Troubleshooting: [/automation/troubleshooting](/automation/troubleshooting)
 - Wakeups are first-class: a job can request “wake now” vs “next heartbeat”.
 - Webhook posting is per job via `delivery.mode = "webhook"` + `delivery.to = "<url>"`.
 - Legacy fallback remains for stored jobs with `notify: true` when `cron.webhook` is set, migrate those jobs to webhook delivery mode.
+- For upgrades, `remoteclaw doctor --fix` can normalize legacy cron store fields before the scheduler touches them.
 
 ## Quick start (actionable)
 

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -28,6 +28,12 @@ Note: retention/pruning is controlled in config:
 - `cron.sessionRetention` (default `24h`) prunes completed isolated run sessions.
 - `cron.runLog.maxBytes` + `cron.runLog.keepLines` prune `~/.remoteclaw/cron/runs/<jobId>.jsonl`.
 
+Upgrade note: if you have older cron jobs from before the current delivery/store format, run
+`remoteclaw doctor --fix`. Doctor now normalizes legacy cron fields (`jobId`, `schedule.cron`,
+top-level delivery fields, payload `provider` delivery aliases) and migrates simple
+`notify: true` webhook fallback jobs to explicit webhook delivery when `cron.webhook` is
+configured.
+
 ## Common edits
 
 Update delivery settings without changing the message:

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -28,6 +28,7 @@ Notes:
 - Interactive prompts (like keychain/OAuth fixes) only run when stdin is a TTY and `--non-interactive` is **not** set. Headless runs (cron, Telegram, no terminal) will skip prompts.
 - `--fix` (alias for `--repair`) writes a backup to `~/.remoteclaw/remoteclaw.json.bak` and drops unknown config keys, listing each removal.
 - State integrity checks now detect orphan transcript files in the sessions directory and can archive them as `.deleted.<timestamp>` to reclaim space safely.
+- Doctor also scans `~/.remoteclaw/cron/jobs.json` (or `cron.store`) for legacy cron job shapes and can rewrite them in place before the scheduler has to auto-normalize them at runtime.
 - If sandbox mode is enabled but Docker is unavailable, doctor reports a high-signal warning with remediation (`install Docker` or `remoteclaw config set agents.defaults.sandbox.mode off`).
 
 ## macOS: `launchctl` env overrides

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -64,6 +64,7 @@ cat ~/.remoteclaw/remoteclaw.json
 - Skills status summary.
 - Config normalization for legacy values.
 - Legacy on-disk state migration (sessions/agent dir/WhatsApp auth).
+- Legacy cron store migration (`jobId`, `schedule.cron`, top-level delivery/payload fields, payload `provider`, simple `notify: true` webhook fallback jobs).
 - State integrity and permissions checks (sessions, transcripts, state dir).
 - Config file permission checks (chmod 600) when running locally.
 - Extra workspace dir detection (`~/remoteclaw`).
@@ -140,6 +141,25 @@ it leaves any legacy folders behind as backups. The Gateway/CLI also auto-migrat
 the legacy sessions + agent dir on startup so history/auth/models land in the
 per-agent path without a manual doctor run. WhatsApp auth is intentionally only
 migrated via `remoteclaw doctor`.
+
+### 3b) Legacy cron store migrations
+
+Doctor also checks the cron job store (`~/.remoteclaw/cron/jobs.json` by default,
+or `cron.store` when overridden) for old job shapes that the scheduler still
+accepts for compatibility.
+
+Current cron cleanups include:
+
+- `jobId` → `id`
+- `schedule.cron` → `schedule.expr`
+- top-level payload fields (`message`, `model`, `thinking`, ...) → `payload`
+- top-level delivery fields (`deliver`, `channel`, `to`, `provider`, ...) → `delivery`
+- payload `provider` delivery aliases → explicit `delivery.channel`
+- simple legacy `notify: true` webhook fallback jobs → explicit `delivery.mode="webhook"` with `delivery.to=cron.webhook`
+
+Doctor only auto-migrates `notify: true` jobs when it can do so without
+changing behavior. If a job combines legacy notify fallback with an existing
+non-webhook delivery mode, doctor warns and leaves that job for manual review.
 
 ### 4) State integrity checks (session persistence, routing, and safety)
 

--- a/src/cli/cron-cli/register.ts
+++ b/src/cli/cron-cli/register.ts
@@ -16,7 +16,7 @@ export function registerCronCli(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/cron", "docs.remoteclaw.org/cli/cron")}\n`,
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/cron", "docs.remoteclaw.org/cli/cron")}\n${theme.muted("Upgrade tip:")} run \`remoteclaw doctor --fix\` to normalize legacy cron job storage.\n`,
     );
 
   registerCronStatusCommand(cron);

--- a/src/commands/doctor-cron.test.ts
+++ b/src/commands/doctor-cron.test.ts
@@ -1,0 +1,158 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RemoteClawConfig } from "../config/config.js";
+import * as noteModule from "../terminal/note.js";
+import { maybeRepairLegacyCronStore } from "./doctor-cron.js";
+
+let tempRoot: string | null = null;
+
+async function makeTempStorePath() {
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-doctor-cron-"));
+  return path.join(tempRoot, "cron", "jobs.json");
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (tempRoot) {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    tempRoot = null;
+  }
+});
+
+function makePrompter(confirmResult = true) {
+  return {
+    confirm: vi.fn().mockResolvedValue(confirmResult),
+  };
+}
+
+describe("maybeRepairLegacyCronStore", () => {
+  it("repairs legacy cron store fields and migrates notify fallback to webhook delivery", async () => {
+    const storePath = await makeTempStorePath();
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              jobId: "legacy-job",
+              name: "Legacy job",
+              notify: true,
+              createdAtMs: Date.parse("2026-02-01T00:00:00.000Z"),
+              updatedAtMs: Date.parse("2026-02-02T00:00:00.000Z"),
+              schedule: { kind: "cron", cron: "0 7 * * *", tz: "UTC" },
+              payload: {
+                kind: "systemEvent",
+                text: "Morning brief",
+              },
+              state: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+    const cfg: RemoteClawConfig = {
+      cron: {
+        store: storePath,
+        webhook: "https://example.invalid/cron-finished",
+      },
+    };
+
+    await maybeRepairLegacyCronStore({
+      cfg,
+      options: {},
+      prompter: makePrompter(true),
+    });
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+    const [job] = persisted.jobs;
+    expect(job?.jobId).toBeUndefined();
+    expect(job?.id).toBe("legacy-job");
+    expect(job?.notify).toBeUndefined();
+    expect(job?.schedule).toMatchObject({
+      kind: "cron",
+      expr: "0 7 * * *",
+      tz: "UTC",
+    });
+    expect(job?.delivery).toMatchObject({
+      mode: "webhook",
+      to: "https://example.invalid/cron-finished",
+    });
+    expect(job?.payload).toMatchObject({
+      kind: "systemEvent",
+      text: "Morning brief",
+    });
+
+    expect(noteSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Legacy cron job storage detected"),
+      "Cron",
+    );
+    expect(noteSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Cron store normalized"),
+      "Doctor changes",
+    );
+  });
+
+  it("warns instead of replacing announce delivery for notify fallback jobs", async () => {
+    const storePath = await makeTempStorePath();
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              id: "notify-and-announce",
+              name: "Notify and announce",
+              notify: true,
+              createdAtMs: Date.parse("2026-02-01T00:00:00.000Z"),
+              updatedAtMs: Date.parse("2026-02-02T00:00:00.000Z"),
+              schedule: { kind: "every", everyMs: 60_000 },
+              sessionTarget: "isolated",
+              wakeMode: "now",
+              payload: { kind: "agentTurn", message: "Status" },
+              delivery: { mode: "announce", channel: "telegram", to: "123" },
+              state: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+
+    await maybeRepairLegacyCronStore({
+      cfg: {
+        cron: {
+          store: storePath,
+          webhook: "https://example.invalid/cron-finished",
+        },
+      },
+      options: { nonInteractive: true },
+      prompter: makePrompter(true),
+    });
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+    expect(persisted.jobs[0]?.notify).toBe(true);
+    expect(noteSpy).toHaveBeenCalledWith(
+      expect.stringContaining('uses legacy notify fallback alongside delivery mode "announce"'),
+      "Doctor warnings",
+    );
+  });
+});

--- a/src/commands/doctor-cron.ts
+++ b/src/commands/doctor-cron.ts
@@ -1,0 +1,186 @@
+import { formatCliCommand } from "../cli/command-format.js";
+import type { RemoteClawConfig } from "../config/config.js";
+import { normalizeStoredCronJobs } from "../cron/store-migration.js";
+import { resolveCronStorePath, loadCronStore, saveCronStore } from "../cron/store.js";
+import type { CronJob } from "../cron/types.js";
+import { note } from "../terminal/note.js";
+import { shortenHomePath } from "../utils.js";
+import type { DoctorPrompter, DoctorOptions } from "./doctor-prompter.js";
+
+type CronDoctorOutcome = {
+  changed: boolean;
+  warnings: string[];
+};
+
+function pluralize(count: number, noun: string) {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function formatLegacyIssuePreview(issues: Partial<Record<string, number>>): string[] {
+  const lines: string[] = [];
+  if (issues.jobId) {
+    lines.push(`- ${pluralize(issues.jobId, "job")} still uses legacy \`jobId\``);
+  }
+  if (issues.legacyScheduleString) {
+    lines.push(
+      `- ${pluralize(issues.legacyScheduleString, "job")} stores schedule as a bare string`,
+    );
+  }
+  if (issues.legacyScheduleCron) {
+    lines.push(`- ${pluralize(issues.legacyScheduleCron, "job")} still uses \`schedule.cron\``);
+  }
+  if (issues.legacyPayloadKind) {
+    lines.push(`- ${pluralize(issues.legacyPayloadKind, "job")} needs payload kind normalization`);
+  }
+  if (issues.legacyPayloadProvider) {
+    lines.push(
+      `- ${pluralize(issues.legacyPayloadProvider, "job")} still uses payload \`provider\` as a delivery alias`,
+    );
+  }
+  if (issues.legacyTopLevelPayloadFields) {
+    lines.push(
+      `- ${pluralize(issues.legacyTopLevelPayloadFields, "job")} still uses top-level payload fields`,
+    );
+  }
+  if (issues.legacyTopLevelDeliveryFields) {
+    lines.push(
+      `- ${pluralize(issues.legacyTopLevelDeliveryFields, "job")} still uses top-level delivery fields`,
+    );
+  }
+  if (issues.legacyDeliveryMode) {
+    lines.push(
+      `- ${pluralize(issues.legacyDeliveryMode, "job")} still uses delivery mode \`deliver\``,
+    );
+  }
+  return lines;
+}
+
+function trimString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function migrateLegacyNotifyFallback(params: {
+  jobs: Array<Record<string, unknown>>;
+  legacyWebhook?: string;
+}): CronDoctorOutcome {
+  let changed = false;
+  const warnings: string[] = [];
+
+  for (const raw of params.jobs) {
+    if (!("notify" in raw)) {
+      continue;
+    }
+
+    const jobName = trimString(raw.name) ?? trimString(raw.id) ?? "<unnamed>";
+    const notify = raw.notify === true;
+    if (!notify) {
+      delete raw.notify;
+      changed = true;
+      continue;
+    }
+
+    const delivery =
+      raw.delivery && typeof raw.delivery === "object" && !Array.isArray(raw.delivery)
+        ? (raw.delivery as Record<string, unknown>)
+        : null;
+    const mode = trimString(delivery?.mode)?.toLowerCase();
+    const to = trimString(delivery?.to);
+
+    if (mode === "webhook" && to) {
+      delete raw.notify;
+      changed = true;
+      continue;
+    }
+
+    if ((mode === undefined || mode === "none" || mode === "webhook") && params.legacyWebhook) {
+      raw.delivery = {
+        ...delivery,
+        mode: "webhook",
+        to: to ?? params.legacyWebhook,
+      };
+      delete raw.notify;
+      changed = true;
+      continue;
+    }
+
+    if (!params.legacyWebhook) {
+      warnings.push(
+        `Cron job "${jobName}" still uses legacy notify fallback, but cron.webhook is unset so doctor cannot migrate it automatically.`,
+      );
+      continue;
+    }
+
+    warnings.push(
+      `Cron job "${jobName}" uses legacy notify fallback alongside delivery mode "${mode}". Migrate it manually so webhook delivery does not replace existing announce behavior.`,
+    );
+  }
+
+  return { changed, warnings };
+}
+
+export async function maybeRepairLegacyCronStore(params: {
+  cfg: RemoteClawConfig;
+  options: DoctorOptions;
+  prompter: Pick<DoctorPrompter, "confirm">;
+}) {
+  const storePath = resolveCronStorePath(params.cfg.cron?.store);
+  const store = await loadCronStore(storePath);
+  const rawJobs = (store.jobs ?? []) as unknown as Array<Record<string, unknown>>;
+  if (rawJobs.length === 0) {
+    return;
+  }
+
+  const normalized = normalizeStoredCronJobs(rawJobs);
+  const legacyWebhook = trimString(params.cfg.cron?.webhook);
+  const notifyCount = rawJobs.filter((job) => job.notify === true).length;
+  const previewLines = formatLegacyIssuePreview(normalized.issues);
+  if (notifyCount > 0) {
+    previewLines.push(
+      `- ${pluralize(notifyCount, "job")} still uses legacy \`notify: true\` webhook fallback`,
+    );
+  }
+  if (previewLines.length === 0) {
+    return;
+  }
+
+  note(
+    [
+      `Legacy cron job storage detected at ${shortenHomePath(storePath)}.`,
+      ...previewLines,
+      `Repair with ${formatCliCommand("remoteclaw doctor --fix")} to normalize the store before the next scheduler run.`,
+    ].join("\n"),
+    "Cron",
+  );
+
+  const shouldRepair =
+    params.options.nonInteractive === true
+      ? true
+      : await params.prompter.confirm({
+          message: "Repair legacy cron jobs now?",
+          initialValue: true,
+        });
+  if (!shouldRepair) {
+    return;
+  }
+
+  const notifyMigration = migrateLegacyNotifyFallback({
+    jobs: rawJobs,
+    legacyWebhook,
+  });
+  const changed = normalized.mutated || notifyMigration.changed;
+  if (!changed && notifyMigration.warnings.length === 0) {
+    return;
+  }
+
+  if (changed) {
+    await saveCronStore(storePath, {
+      version: 1,
+      jobs: rawJobs as unknown as CronJob[],
+    });
+    note(`Cron store normalized at ${shortenHomePath(storePath)}.`, "Doctor changes");
+  }
+
+  if (notifyMigration.warnings.length > 0) {
+    note(notifyMigration.warnings.join("\n"), "Doctor warnings");
+  }
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -21,6 +21,7 @@ import {
 } from "./doctor-auth.js";
 import { doctorShellCompletion } from "./doctor-completion.js";
 import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
+import { maybeRepairLegacyCronStore } from "./doctor-cron.js";
 import { maybeRepairGatewayDaemon } from "./doctor-gateway-daemon-flow.js";
 import { checkGatewayHealth } from "./doctor-gateway-health.js";
 import {
@@ -180,6 +181,11 @@ export async function doctorCommand(
 
   await noteStateIntegrity(cfg, prompter, configResult.path ?? CONFIG_PATH);
   await noteSessionLockHealth({ shouldRepair: prompter.shouldRepair });
+  await maybeRepairLegacyCronStore({
+    cfg,
+    options,
+    prompter,
+  });
 
   await maybeScanExtraGatewayServices(options, runtime, prompter);
   await maybeRepairGatewayServiceConfig(cfg, resolveMode(cfg), runtime, prompter);

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -1,3 +1,6 @@
+/** Error types that can trigger retries for one-shot jobs. */
+export type CronRetryOn = "rate_limit" | "overloaded" | "network" | "timeout" | "server_error";
+
 export type CronConfig = {
   enabled?: boolean;
   store?: string;

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -98,7 +98,7 @@ type DispatchCronDeliveryParams = {
   resolvedDelivery: DeliveryTargetResolution;
   deliveryRequested: boolean;
   skipHeartbeatDelivery: boolean;
-  skipMessagingToolDelivery: boolean;
+  skipMessagingToolDelivery?: boolean;
   deliveryBestEffort: boolean;
   deliveryPayloadHasStructuredContent: boolean;
   deliveryPayloads: ReplyPayload[];
@@ -127,15 +127,17 @@ export type DispatchCronDeliveryState = {
 export async function dispatchCronDelivery(
   params: DispatchCronDeliveryParams,
 ): Promise<DispatchCronDeliveryState> {
+  const skipMessagingToolDelivery = params.skipMessagingToolDelivery === true;
   let summary = params.summary;
   let outputText = params.outputText;
   let synthesizedText = params.synthesizedText;
   let deliveryPayloads = params.deliveryPayloads;
 
-  // `true` means we confirmed at least one outbound send reached the target.
-  // Keep this strict so timer fallback can safely decide whether to wake main.
-  let delivered = params.skipMessagingToolDelivery;
-  let deliveryAttempted = params.skipMessagingToolDelivery;
+  // Shared callers can treat a matching message-tool send as the completed
+  // delivery path. Cron-owned callers keep this false so direct cron delivery
+  // remains the only source of delivered state.
+  let delivered = skipMessagingToolDelivery;
+  let deliveryAttempted = skipMessagingToolDelivery;
   const failDeliveryTarget = (error: string) =>
     params.withRunSession({
       status: "error",
@@ -345,11 +347,7 @@ export async function dispatchCronDelivery(
     return null;
   };
 
-  if (
-    params.deliveryRequested &&
-    !params.skipHeartbeatDelivery &&
-    !params.skipMessagingToolDelivery
-  ) {
+  if (params.deliveryRequested && !params.skipHeartbeatDelivery && !skipMessagingToolDelivery) {
     if (!params.resolvedDelivery.ok) {
       if (!params.deliveryBestEffort) {
         return {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -122,11 +122,10 @@ export type RunCronAgentTurnResult = {
   /** Last non-empty agent text output (not truncated). */
   outputText?: string;
   /**
-   * `true` when the isolated run already delivered its output to the target
-   * channel (via outbound payloads, the subagent announce flow, or a matching
-   * messaging-tool send). Callers should skip posting a summary to the main
-   * session to avoid duplicate
-   * messages.  See: https://github.com/remoteclaw/remoteclaw/issues/15692
+   * `true` when the isolated runner already handled the run's user-visible
+   * delivery outcome. Cron-owned callers use this for cron delivery or
+   * explicit suppression; shared callers may also use it for a matching
+   * message-tool send that already reached the target.
    */
   delivered?: boolean;
   /**
@@ -138,6 +137,52 @@ export type RunCronAgentTurnResult = {
 } & CronRunOutcome &
   CronRunTelemetry;
 
+type ResolvedCronDeliveryTarget = Awaited<ReturnType<typeof resolveDeliveryTarget>>;
+
+type IsolatedDeliveryContract = "cron-owned" | "shared";
+
+function resolveCronToolPolicy(params: {
+  deliveryRequested: boolean;
+  resolvedDelivery: ResolvedCronDeliveryTarget;
+  deliveryContract: IsolatedDeliveryContract;
+}) {
+  return {
+    // Only enforce an explicit message target when the cron delivery target
+    // was successfully resolved. When resolution fails the agent should not
+    // be blocked by a target it cannot satisfy (#27898).
+    requireExplicitMessageTarget: params.deliveryRequested && params.resolvedDelivery.ok,
+    // Cron-owned runs always route user-facing delivery through the runner
+    // itself. Shared callers keep the previous behavior so non-cron paths do
+    // not silently lose the message tool when no explicit delivery is active.
+    disableMessageTool: params.deliveryContract === "cron-owned" ? true : params.deliveryRequested,
+  };
+}
+
+async function resolveCronDeliveryContext(params: {
+  cfg: RemoteClawConfig;
+  job: CronJob;
+  agentId: string;
+  deliveryContract: IsolatedDeliveryContract;
+}) {
+  const deliveryPlan = resolveCronDeliveryPlan(params.job);
+  const resolvedDelivery = await resolveDeliveryTarget(params.cfg, params.agentId, {
+    channel: deliveryPlan.channel ?? "last",
+    to: deliveryPlan.to,
+    accountId: deliveryPlan.accountId,
+    sessionKey: params.job.sessionKey,
+  });
+  return {
+    deliveryPlan,
+    deliveryRequested: deliveryPlan.requested,
+    resolvedDelivery,
+    toolPolicy: resolveCronToolPolicy({
+      deliveryRequested: deliveryPlan.requested,
+      resolvedDelivery,
+      deliveryContract: params.deliveryContract,
+    }),
+  };
+}
+
 export async function runCronIsolatedAgentTurn(params: {
   cfg: RemoteClawConfig;
   deps: CliDeps;
@@ -148,6 +193,7 @@ export async function runCronIsolatedAgentTurn(params: {
   sessionKey: string;
   agentId?: string;
   lane?: string;
+  deliveryContract?: IsolatedDeliveryContract;
 }): Promise<RunCronAgentTurnResult> {
   const abortSignal = params.abortSignal ?? params.signal;
   const isAborted = () => abortSignal?.aborted === true;
@@ -158,6 +204,7 @@ export async function runCronIsolatedAgentTurn(params: {
       : "cron: job execution timed out";
   };
   const isFastTestEnv = process.env.REMOTECLAW_TEST_FAST === "1";
+  const deliveryContract = params.deliveryContract ?? "cron-owned";
   const defaultAgentId = resolveDefaultAgentId(params.cfg);
   const requestedAgentId =
     typeof params.agentId === "string" && params.agentId.trim()
@@ -275,14 +322,15 @@ export async function runCronIsolatedAgentTurn(params: {
   });
 
   const agentPayload = params.job.payload.kind === "agentTurn" ? params.job.payload : null;
-  const deliveryPlan = resolveCronDeliveryPlan(params.job);
-  const deliveryRequested = deliveryPlan.requested;
-
-  const resolvedDelivery = await resolveDeliveryTarget(cfgWithAgentDefaults, agentId, {
-    channel: deliveryPlan.channel ?? "last",
-    to: deliveryPlan.to,
-    sessionKey: params.job.sessionKey,
-    accountId: deliveryPlan.accountId,
+  const {
+    deliveryRequested,
+    resolvedDelivery,
+    toolPolicy: _toolPolicy,
+  } = await resolveCronDeliveryContext({
+    cfg: cfgWithAgentDefaults,
+    job: params.job,
+    agentId,
+    deliveryContract,
   });
 
   const { formattedTime, timeLine } = resolveCronStyleNow(params.cfg, now);
@@ -503,6 +551,7 @@ export async function runCronIsolatedAgentTurn(params: {
   const didSendViaMessagingTool =
     runResult.mcp.sentTexts.length > 0 || runResult.mcp.sentMediaUrls.length > 0;
   const skipMessagingToolDelivery =
+    deliveryContract === "shared" &&
     deliveryRequested &&
     didSendViaMessagingTool &&
     runResult.mcp.sentTargets.some((target) =>
@@ -512,7 +561,6 @@ export async function runCronIsolatedAgentTurn(params: {
         accountId: resolvedDelivery.accountId,
       }),
     );
-
   const deliveryResult = await dispatchCronDelivery({
     cfg: params.cfg,
     cfgWithAgentDefaults,

--- a/src/cron/legacy-delivery.ts
+++ b/src/cron/legacy-delivery.ts
@@ -1,11 +1,157 @@
-export function hasLegacyDeliveryHints(_payload: Record<string, unknown>) {
+export function hasLegacyDeliveryHints(payload: Record<string, unknown>) {
+  if (typeof payload.deliver === "boolean") {
+    return true;
+  }
+  if (typeof payload.bestEffortDeliver === "boolean") {
+    return true;
+  }
+  if (typeof payload.channel === "string" && payload.channel.trim()) {
+    return true;
+  }
+  if (typeof payload.provider === "string" && payload.provider.trim()) {
+    return true;
+  }
+  if (typeof payload.to === "string" && payload.to.trim()) {
+    return true;
+  }
   return false;
 }
 
 export function buildDeliveryFromLegacyPayload(
-  _payload: Record<string, unknown>,
+  payload: Record<string, unknown>,
 ): Record<string, unknown> {
-  return {};
+  const deliver = payload.deliver;
+  const mode = deliver === false ? "none" : "announce";
+  const channelRaw =
+    typeof payload.channel === "string" && payload.channel.trim()
+      ? payload.channel.trim().toLowerCase()
+      : typeof payload.provider === "string"
+        ? payload.provider.trim().toLowerCase()
+        : "";
+  const toRaw = typeof payload.to === "string" ? payload.to.trim() : "";
+  const next: Record<string, unknown> = { mode };
+  if (channelRaw) {
+    next.channel = channelRaw;
+  }
+  if (toRaw) {
+    next.to = toRaw;
+  }
+  if (typeof payload.bestEffortDeliver === "boolean") {
+    next.bestEffort = payload.bestEffortDeliver;
+  }
+  return next;
 }
 
-export function stripLegacyDeliveryFields(_payload: Record<string, unknown>) {}
+export function buildDeliveryPatchFromLegacyPayload(payload: Record<string, unknown>) {
+  const deliver = payload.deliver;
+  const channelRaw =
+    typeof payload.channel === "string" && payload.channel.trim()
+      ? payload.channel.trim().toLowerCase()
+      : typeof payload.provider === "string" && payload.provider.trim()
+        ? payload.provider.trim().toLowerCase()
+        : "";
+  const toRaw = typeof payload.to === "string" ? payload.to.trim() : "";
+  const next: Record<string, unknown> = {};
+  let hasPatch = false;
+
+  if (deliver === false) {
+    next.mode = "none";
+    hasPatch = true;
+  } else if (
+    deliver === true ||
+    channelRaw ||
+    toRaw ||
+    typeof payload.bestEffortDeliver === "boolean"
+  ) {
+    next.mode = "announce";
+    hasPatch = true;
+  }
+  if (channelRaw) {
+    next.channel = channelRaw;
+    hasPatch = true;
+  }
+  if (toRaw) {
+    next.to = toRaw;
+    hasPatch = true;
+  }
+  if (typeof payload.bestEffortDeliver === "boolean") {
+    next.bestEffort = payload.bestEffortDeliver;
+    hasPatch = true;
+  }
+
+  return hasPatch ? next : null;
+}
+
+export function mergeLegacyDeliveryInto(
+  delivery: Record<string, unknown>,
+  payload: Record<string, unknown>,
+) {
+  const patch = buildDeliveryPatchFromLegacyPayload(payload);
+  if (!patch) {
+    return { delivery, mutated: false };
+  }
+
+  const next = { ...delivery };
+  let mutated = false;
+
+  if ("mode" in patch && patch.mode !== next.mode) {
+    next.mode = patch.mode;
+    mutated = true;
+  }
+  if ("channel" in patch && patch.channel !== next.channel) {
+    next.channel = patch.channel;
+    mutated = true;
+  }
+  if ("to" in patch && patch.to !== next.to) {
+    next.to = patch.to;
+    mutated = true;
+  }
+  if ("bestEffort" in patch && patch.bestEffort !== next.bestEffort) {
+    next.bestEffort = patch.bestEffort;
+    mutated = true;
+  }
+
+  return { delivery: next, mutated };
+}
+
+export function normalizeLegacyDeliveryInput(params: {
+  delivery?: Record<string, unknown> | null;
+  payload?: Record<string, unknown> | null;
+}) {
+  if (!params.payload || !hasLegacyDeliveryHints(params.payload)) {
+    return {
+      delivery: params.delivery ?? undefined,
+      mutated: false,
+    };
+  }
+
+  const nextDelivery = params.delivery
+    ? mergeLegacyDeliveryInto(params.delivery, params.payload)
+    : {
+        delivery: buildDeliveryFromLegacyPayload(params.payload),
+        mutated: true,
+      };
+  stripLegacyDeliveryFields(params.payload);
+  return {
+    delivery: nextDelivery.delivery,
+    mutated: true,
+  };
+}
+
+export function stripLegacyDeliveryFields(payload: Record<string, unknown>) {
+  if ("deliver" in payload) {
+    delete payload.deliver;
+  }
+  if ("channel" in payload) {
+    delete payload.channel;
+  }
+  if ("provider" in payload) {
+    delete payload.provider;
+  }
+  if ("to" in payload) {
+    delete payload.to;
+  }
+  if ("bestEffortDeliver" in payload) {
+    delete payload.bestEffortDeliver;
+  }
+}

--- a/src/cron/payload-migration.ts
+++ b/src/cron/payload-migration.ts
@@ -1,5 +1,40 @@
 type UnknownRecord = Record<string, unknown>;
 
-export function migrateLegacyCronPayload(_payload: UnknownRecord): boolean {
-  return false;
+function readString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  return value;
+}
+
+function normalizeChannel(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function migrateLegacyCronPayload(payload: UnknownRecord): boolean {
+  let mutated = false;
+
+  const channelValue = readString(payload.channel);
+  const providerValue = readString(payload.provider);
+
+  const nextChannel =
+    typeof channelValue === "string" && channelValue.trim().length > 0
+      ? normalizeChannel(channelValue)
+      : typeof providerValue === "string" && providerValue.trim().length > 0
+        ? normalizeChannel(providerValue)
+        : "";
+
+  if (nextChannel) {
+    if (channelValue !== nextChannel) {
+      payload.channel = nextChannel;
+      mutated = true;
+    }
+  }
+
+  if ("provider" in payload) {
+    delete payload.provider;
+    mutated = true;
+  }
+
+  return mutated;
 }

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -10,6 +10,21 @@ function resolveCronTimezone(tz?: string) {
   return Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
 
+export function coerceFiniteScheduleNumber(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
 export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): number | undefined {
   if (schedule.kind === "at") {
     // Handle both canonical `at` (string) and legacy `atMs` (number) fields.

--- a/src/cron/service.delivery-plan.test.ts
+++ b/src/cron/service.delivery-plan.test.ts
@@ -86,7 +86,7 @@ describe("CronService delivery plan consistency", () => {
     });
   });
 
-  it("treats delivery object without mode as announce", async () => {
+  it("treats delivery object without mode as announce without reviving legacy relay fallback", async () => {
     await withCronService({}, async ({ cron, enqueueSystemEvent }) => {
       const job = await addIsolatedAgentTurnJob(cron, {
         name: "partial-delivery",
@@ -96,10 +96,8 @@ describe("CronService delivery plan consistency", () => {
 
       const result = await cron.run(job.id, "force");
       expect(result).toEqual({ ok: true, ran: true });
-      expect(enqueueSystemEvent).toHaveBeenCalledWith(
-        "Cron: done",
-        expect.objectContaining({ agentId: undefined }),
-      );
+      expect(enqueueSystemEvent).not.toHaveBeenCalled();
+      expect(cron.getJob(job.id)?.state.lastDeliveryStatus).toBe("unknown");
     });
   });
 

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -546,17 +546,14 @@ describe("CronService", () => {
     await store.cleanup();
   });
 
-  it("runs an isolated job and posts summary to main", async () => {
+  it("runs an isolated job without posting a fallback summary to main", async () => {
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
     const { store, cron, enqueueSystemEvent, requestHeartbeatNow, events } =
       await createIsolatedAnnounceHarness(runIsolatedAgentJob);
     await runIsolatedAnnounceJobAndWait({ cron, events, name: "weekly", status: "ok" });
     expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
-    expect(enqueueSystemEvent).toHaveBeenCalledWith(
-      "Cron: done",
-      expect.objectContaining({ agentId: undefined }),
-    );
-    expect(requestHeartbeatNow).toHaveBeenCalled();
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(requestHeartbeatNow).not.toHaveBeenCalled();
     cron.stop();
     await store.cleanup();
   });
@@ -604,7 +601,7 @@ describe("CronService", () => {
     await store.cleanup();
   });
 
-  it("posts last output to main even when isolated job errors", async () => {
+  it("does not post a fallback main summary when an isolated job errors", async () => {
     const runIsolatedAgentJob = vi.fn(async () => ({
       status: "error" as const,
       summary: "last output",
@@ -619,11 +616,8 @@ describe("CronService", () => {
       status: "error",
     });
 
-    expect(enqueueSystemEvent).toHaveBeenCalledWith(
-      "Cron (error): last output",
-      expect.objectContaining({ agentId: undefined }),
-    );
-    expect(requestHeartbeatNow).toHaveBeenCalled();
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(requestHeartbeatNow).not.toHaveBeenCalled();
     cron.stop();
     await store.cleanup();
   });

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { normalizeStoredCronJobs } from "../store-migration.js";
 import { loadCronStore, saveCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
 import { recomputeNextRuns } from "./jobs.js";
@@ -32,7 +33,9 @@ export async function ensureLoaded(
 
   const fileMtimeMs = await getFileMtimeMs(state.deps.storePath);
   const loaded = await loadCronStore(state.deps.storePath);
-  state.store = { version: 1, jobs: (loaded.jobs ?? []) as unknown as CronJob[] };
+  const jobs = (loaded.jobs ?? []) as unknown as Array<Record<string, unknown>>;
+  const { mutated: _mutated } = normalizeStoredCronJobs(jobs);
+  state.store = { version: 1, jobs: jobs as unknown as CronJob[] };
   state.storeLoadedAtMs = state.deps.nowMs();
   state.storeFileMtimeMs = fileMtimeMs;
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -732,39 +732,6 @@ export async function executeJobCore(
     return { status: "error", error: timeoutErrorMessage() };
   }
 
-  // Post a short summary back to the main session only when announce
-  // delivery was requested and we are confident no outbound delivery path
-  // ran. If delivery was attempted but final ack is uncertain, suppress the
-  // main summary to avoid duplicate user-facing sends.
-  // See: https://github.com/remoteclaw/remoteclaw/issues/15692
-  const summaryText = res.summary?.trim();
-  const deliveryPlan = resolveCronDeliveryPlan(job);
-  const suppressMainSummary =
-    res.status === "error" && res.errorKind === "delivery-target" && deliveryPlan.requested;
-  if (
-    summaryText &&
-    deliveryPlan.requested &&
-    !res.delivered &&
-    res.deliveryAttempted !== true &&
-    !suppressMainSummary
-  ) {
-    const prefix = "Cron";
-    const label =
-      res.status === "error" ? `${prefix} (error): ${summaryText}` : `${prefix}: ${summaryText}`;
-    state.deps.enqueueSystemEvent(label, {
-      agentId: job.agentId,
-      sessionKey: job.sessionKey,
-      contextKey: `cron:${job.id}`,
-    });
-    if (job.wakeMode === "now") {
-      state.deps.requestHeartbeatNow({
-        reason: `cron:${job.id}`,
-        agentId: job.agentId,
-        sessionKey: job.sessionKey,
-      });
-    }
-  }
-
   return {
     status: res.status,
     error: res.error,

--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { normalizeStoredCronJobs } from "./store-migration.js";
+
+describe("normalizeStoredCronJobs", () => {
+  it("normalizes legacy cron fields and reports migration issues", () => {
+    const jobs = [
+      {
+        jobId: "legacy-job",
+        schedule: { kind: "cron", cron: "*/5 * * * *", tz: "UTC" },
+        message: "say hi",
+        model: "openai/gpt-4.1",
+        deliver: true,
+        provider: " TeLeGrAm ",
+        to: "12345",
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(true);
+    expect(result.issues).toMatchObject({
+      jobId: 1,
+      legacyScheduleCron: 1,
+      legacyTopLevelPayloadFields: 1,
+      legacyTopLevelDeliveryFields: 1,
+    });
+
+    const [job] = jobs;
+    expect(job?.jobId).toBeUndefined();
+    expect(job?.id).toBe("legacy-job");
+    expect(job?.schedule).toMatchObject({
+      kind: "cron",
+      expr: "*/5 * * * *",
+      tz: "UTC",
+    });
+    expect(job?.message).toBeUndefined();
+    expect(job?.provider).toBeUndefined();
+    expect(job?.delivery).toMatchObject({
+      mode: "announce",
+      channel: "telegram",
+      to: "12345",
+    });
+    expect(job?.payload).toMatchObject({
+      kind: "agentTurn",
+      message: "say hi",
+      model: "openai/gpt-4.1",
+    });
+  });
+
+  it("normalizes payload provider alias into channel", () => {
+    const jobs = [
+      {
+        id: "legacy-provider",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: {
+          kind: "agentTurn",
+          message: "ping",
+          provider: " Slack ",
+        },
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(true);
+    expect(result.issues.legacyPayloadProvider).toBe(1);
+    expect(jobs[0]?.payload).toMatchObject({
+      kind: "agentTurn",
+      message: "ping",
+    });
+    const payload = jobs[0]?.payload as Record<string, unknown> | undefined;
+    expect(payload?.provider).toBeUndefined();
+    expect(jobs[0]?.delivery).toMatchObject({
+      mode: "announce",
+      channel: "slack",
+    });
+  });
+});

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -1,0 +1,491 @@
+import { normalizeLegacyDeliveryInput } from "./legacy-delivery.js";
+import { parseAbsoluteTimeMs } from "./parse.js";
+import { migrateLegacyCronPayload } from "./payload-migration.js";
+import { coerceFiniteScheduleNumber } from "./schedule.js";
+import { inferLegacyName, normalizeOptionalText } from "./service/normalize.js";
+import { normalizeCronStaggerMs, resolveDefaultCronStaggerMs } from "./stagger.js";
+
+type CronStoreIssueKey =
+  | "jobId"
+  | "legacyScheduleString"
+  | "legacyScheduleCron"
+  | "legacyPayloadKind"
+  | "legacyPayloadProvider"
+  | "legacyTopLevelPayloadFields"
+  | "legacyTopLevelDeliveryFields"
+  | "legacyDeliveryMode";
+
+type CronStoreIssues = Partial<Record<CronStoreIssueKey, number>>;
+
+type NormalizeCronStoreJobsResult = {
+  issues: CronStoreIssues;
+  jobs: Array<Record<string, unknown>>;
+  mutated: boolean;
+};
+
+function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
+  issues[key] = (issues[key] ?? 0) + 1;
+}
+
+function normalizePayloadKind(payload: Record<string, unknown>) {
+  const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
+  if (raw === "agentturn") {
+    payload.kind = "agentTurn";
+    return true;
+  }
+  if (raw === "systemevent") {
+    payload.kind = "systemEvent";
+    return true;
+  }
+  return false;
+}
+
+function inferPayloadIfMissing(raw: Record<string, unknown>) {
+  const message = typeof raw.message === "string" ? raw.message.trim() : "";
+  const text = typeof raw.text === "string" ? raw.text.trim() : "";
+  const command = typeof raw.command === "string" ? raw.command.trim() : "";
+  if (message) {
+    raw.payload = { kind: "agentTurn", message };
+    return true;
+  }
+  if (text) {
+    raw.payload = { kind: "systemEvent", text };
+    return true;
+  }
+  if (command) {
+    raw.payload = { kind: "systemEvent", text: command };
+    return true;
+  }
+  return false;
+}
+
+function copyTopLevelAgentTurnFields(
+  raw: Record<string, unknown>,
+  payload: Record<string, unknown>,
+) {
+  let mutated = false;
+
+  const copyTrimmedString = (field: "model" | "thinking") => {
+    const existing = payload[field];
+    if (typeof existing === "string" && existing.trim()) {
+      return;
+    }
+    const value = raw[field];
+    if (typeof value === "string" && value.trim()) {
+      payload[field] = value.trim();
+      mutated = true;
+    }
+  };
+  copyTrimmedString("model");
+  copyTrimmedString("thinking");
+
+  if (
+    typeof payload.timeoutSeconds !== "number" &&
+    typeof raw.timeoutSeconds === "number" &&
+    Number.isFinite(raw.timeoutSeconds)
+  ) {
+    payload.timeoutSeconds = Math.max(0, Math.floor(raw.timeoutSeconds));
+    mutated = true;
+  }
+
+  if (
+    typeof payload.allowUnsafeExternalContent !== "boolean" &&
+    typeof raw.allowUnsafeExternalContent === "boolean"
+  ) {
+    payload.allowUnsafeExternalContent = raw.allowUnsafeExternalContent;
+    mutated = true;
+  }
+
+  if (typeof payload.deliver !== "boolean" && typeof raw.deliver === "boolean") {
+    payload.deliver = raw.deliver;
+    mutated = true;
+  }
+  if (
+    typeof payload.channel !== "string" &&
+    typeof raw.channel === "string" &&
+    raw.channel.trim()
+  ) {
+    payload.channel = raw.channel.trim();
+    mutated = true;
+  }
+  if (typeof payload.to !== "string" && typeof raw.to === "string" && raw.to.trim()) {
+    payload.to = raw.to.trim();
+    mutated = true;
+  }
+  if (
+    typeof payload.bestEffortDeliver !== "boolean" &&
+    typeof raw.bestEffortDeliver === "boolean"
+  ) {
+    payload.bestEffortDeliver = raw.bestEffortDeliver;
+    mutated = true;
+  }
+  if (
+    typeof payload.provider !== "string" &&
+    typeof raw.provider === "string" &&
+    raw.provider.trim()
+  ) {
+    payload.provider = raw.provider.trim();
+    mutated = true;
+  }
+
+  return mutated;
+}
+
+function stripLegacyTopLevelFields(raw: Record<string, unknown>) {
+  if ("model" in raw) {
+    delete raw.model;
+  }
+  if ("thinking" in raw) {
+    delete raw.thinking;
+  }
+  if ("timeoutSeconds" in raw) {
+    delete raw.timeoutSeconds;
+  }
+  if ("allowUnsafeExternalContent" in raw) {
+    delete raw.allowUnsafeExternalContent;
+  }
+  if ("message" in raw) {
+    delete raw.message;
+  }
+  if ("text" in raw) {
+    delete raw.text;
+  }
+  if ("deliver" in raw) {
+    delete raw.deliver;
+  }
+  if ("channel" in raw) {
+    delete raw.channel;
+  }
+  if ("to" in raw) {
+    delete raw.to;
+  }
+  if ("bestEffortDeliver" in raw) {
+    delete raw.bestEffortDeliver;
+  }
+  if ("provider" in raw) {
+    delete raw.provider;
+  }
+  if ("command" in raw) {
+    delete raw.command;
+  }
+  if ("timeout" in raw) {
+    delete raw.timeout;
+  }
+}
+
+export function normalizeStoredCronJobs(
+  jobs: Array<Record<string, unknown>>,
+): NormalizeCronStoreJobsResult {
+  const issues: CronStoreIssues = {};
+  let mutated = false;
+
+  for (const raw of jobs) {
+    const jobIssues = new Set<CronStoreIssueKey>();
+    const trackIssue = (key: CronStoreIssueKey) => {
+      if (jobIssues.has(key)) {
+        return;
+      }
+      jobIssues.add(key);
+      incrementIssue(issues, key);
+    };
+
+    const state = raw.state;
+    if (!state || typeof state !== "object" || Array.isArray(state)) {
+      raw.state = {};
+      mutated = true;
+    }
+
+    const rawId = typeof raw.id === "string" ? raw.id.trim() : "";
+    const legacyJobId = typeof raw.jobId === "string" ? raw.jobId.trim() : "";
+    if (!rawId && legacyJobId) {
+      raw.id = legacyJobId;
+      mutated = true;
+      trackIssue("jobId");
+    } else if (rawId && raw.id !== rawId) {
+      raw.id = rawId;
+      mutated = true;
+    }
+    if ("jobId" in raw) {
+      delete raw.jobId;
+      mutated = true;
+      trackIssue("jobId");
+    }
+
+    if (typeof raw.schedule === "string") {
+      const expr = raw.schedule.trim();
+      raw.schedule = { kind: "cron", expr };
+      mutated = true;
+      trackIssue("legacyScheduleString");
+    }
+
+    const nameRaw = raw.name;
+    if (typeof nameRaw !== "string" || nameRaw.trim().length === 0) {
+      raw.name = inferLegacyName({
+        schedule: raw.schedule as never,
+        payload: raw.payload as never,
+      });
+      mutated = true;
+    } else {
+      raw.name = nameRaw.trim();
+    }
+
+    const desc = normalizeOptionalText(raw.description);
+    if (raw.description !== desc) {
+      raw.description = desc;
+      mutated = true;
+    }
+
+    if ("sessionKey" in raw) {
+      const sessionKey =
+        typeof raw.sessionKey === "string" ? normalizeOptionalText(raw.sessionKey) : undefined;
+      if (raw.sessionKey !== sessionKey) {
+        raw.sessionKey = sessionKey;
+        mutated = true;
+      }
+    }
+
+    if (typeof raw.enabled !== "boolean") {
+      raw.enabled = true;
+      mutated = true;
+    }
+
+    const wakeModeRaw = typeof raw.wakeMode === "string" ? raw.wakeMode.trim().toLowerCase() : "";
+    if (wakeModeRaw === "next-heartbeat") {
+      if (raw.wakeMode !== "next-heartbeat") {
+        raw.wakeMode = "next-heartbeat";
+        mutated = true;
+      }
+    } else if (wakeModeRaw === "now") {
+      if (raw.wakeMode !== "now") {
+        raw.wakeMode = "now";
+        mutated = true;
+      }
+    } else {
+      raw.wakeMode = "now";
+      mutated = true;
+    }
+
+    const payload = raw.payload;
+    if (
+      (!payload || typeof payload !== "object" || Array.isArray(payload)) &&
+      inferPayloadIfMissing(raw)
+    ) {
+      mutated = true;
+      trackIssue("legacyTopLevelPayloadFields");
+    }
+
+    const payloadRecord =
+      raw.payload && typeof raw.payload === "object" && !Array.isArray(raw.payload)
+        ? (raw.payload as Record<string, unknown>)
+        : null;
+
+    if (payloadRecord) {
+      if (normalizePayloadKind(payloadRecord)) {
+        mutated = true;
+        trackIssue("legacyPayloadKind");
+      }
+      if (!payloadRecord.kind) {
+        if (typeof payloadRecord.message === "string" && payloadRecord.message.trim()) {
+          payloadRecord.kind = "agentTurn";
+          mutated = true;
+          trackIssue("legacyPayloadKind");
+        } else if (typeof payloadRecord.text === "string" && payloadRecord.text.trim()) {
+          payloadRecord.kind = "systemEvent";
+          mutated = true;
+          trackIssue("legacyPayloadKind");
+        }
+      }
+      if (payloadRecord.kind === "agentTurn" && copyTopLevelAgentTurnFields(raw, payloadRecord)) {
+        mutated = true;
+      }
+    }
+
+    const hadLegacyTopLevelPayloadFields =
+      "model" in raw ||
+      "thinking" in raw ||
+      "timeoutSeconds" in raw ||
+      "allowUnsafeExternalContent" in raw ||
+      "message" in raw ||
+      "text" in raw ||
+      "command" in raw ||
+      "timeout" in raw;
+    const hadLegacyTopLevelDeliveryFields =
+      "deliver" in raw ||
+      "channel" in raw ||
+      "to" in raw ||
+      "bestEffortDeliver" in raw ||
+      "provider" in raw;
+    if (hadLegacyTopLevelPayloadFields || hadLegacyTopLevelDeliveryFields) {
+      stripLegacyTopLevelFields(raw);
+      mutated = true;
+      if (hadLegacyTopLevelPayloadFields) {
+        trackIssue("legacyTopLevelPayloadFields");
+      }
+      if (hadLegacyTopLevelDeliveryFields) {
+        trackIssue("legacyTopLevelDeliveryFields");
+      }
+    }
+
+    if (payloadRecord) {
+      const hadLegacyPayloadProvider =
+        typeof payloadRecord.provider === "string" && payloadRecord.provider.trim().length > 0;
+      if (migrateLegacyCronPayload(payloadRecord)) {
+        mutated = true;
+        if (hadLegacyPayloadProvider) {
+          trackIssue("legacyPayloadProvider");
+        }
+      }
+    }
+
+    const schedule = raw.schedule;
+    if (schedule && typeof schedule === "object" && !Array.isArray(schedule)) {
+      const sched = schedule as Record<string, unknown>;
+      const kind = typeof sched.kind === "string" ? sched.kind.trim().toLowerCase() : "";
+      if (!kind && ("at" in sched || "atMs" in sched)) {
+        sched.kind = "at";
+        mutated = true;
+      }
+      const atRaw = typeof sched.at === "string" ? sched.at.trim() : "";
+      const atMsRaw = sched.atMs;
+      const parsedAtMs =
+        typeof atMsRaw === "number"
+          ? atMsRaw
+          : typeof atMsRaw === "string"
+            ? parseAbsoluteTimeMs(atMsRaw)
+            : atRaw
+              ? parseAbsoluteTimeMs(atRaw)
+              : null;
+      if (parsedAtMs !== null) {
+        sched.at = new Date(parsedAtMs).toISOString();
+        if ("atMs" in sched) {
+          delete sched.atMs;
+        }
+        mutated = true;
+      }
+
+      const everyMsRaw = sched.everyMs;
+      const everyMsCoerced = coerceFiniteScheduleNumber(everyMsRaw);
+      const everyMs = everyMsCoerced !== undefined ? Math.floor(everyMsCoerced) : null;
+      if (everyMs !== null && everyMsRaw !== everyMs) {
+        sched.everyMs = everyMs;
+        mutated = true;
+      }
+      if ((kind === "every" || sched.kind === "every") && everyMs !== null) {
+        const anchorRaw = sched.anchorMs;
+        const anchorCoerced = coerceFiniteScheduleNumber(anchorRaw);
+        const normalizedAnchor =
+          anchorCoerced !== undefined
+            ? Math.max(0, Math.floor(anchorCoerced))
+            : typeof raw.createdAtMs === "number" && Number.isFinite(raw.createdAtMs)
+              ? Math.max(0, Math.floor(raw.createdAtMs))
+              : typeof raw.updatedAtMs === "number" && Number.isFinite(raw.updatedAtMs)
+                ? Math.max(0, Math.floor(raw.updatedAtMs))
+                : null;
+        if (normalizedAnchor !== null && anchorRaw !== normalizedAnchor) {
+          sched.anchorMs = normalizedAnchor;
+          mutated = true;
+        }
+      }
+
+      const exprRaw = typeof sched.expr === "string" ? sched.expr.trim() : "";
+      const legacyCronRaw = typeof sched.cron === "string" ? sched.cron.trim() : "";
+      let normalizedExpr = exprRaw;
+      if (!normalizedExpr && legacyCronRaw) {
+        normalizedExpr = legacyCronRaw;
+        sched.expr = normalizedExpr;
+        mutated = true;
+        trackIssue("legacyScheduleCron");
+      }
+      if (typeof sched.expr === "string" && sched.expr !== normalizedExpr) {
+        sched.expr = normalizedExpr;
+        mutated = true;
+      }
+      if ("cron" in sched) {
+        delete sched.cron;
+        mutated = true;
+        trackIssue("legacyScheduleCron");
+      }
+      if ((kind === "cron" || sched.kind === "cron") && normalizedExpr) {
+        const explicitStaggerMs = normalizeCronStaggerMs(sched.staggerMs);
+        const defaultStaggerMs = resolveDefaultCronStaggerMs(normalizedExpr);
+        const targetStaggerMs = explicitStaggerMs ?? defaultStaggerMs;
+        if (targetStaggerMs === undefined) {
+          if ("staggerMs" in sched) {
+            delete sched.staggerMs;
+            mutated = true;
+          }
+        } else if (sched.staggerMs !== targetStaggerMs) {
+          sched.staggerMs = targetStaggerMs;
+          mutated = true;
+        }
+      }
+    }
+
+    const delivery = raw.delivery;
+    if (delivery && typeof delivery === "object" && !Array.isArray(delivery)) {
+      const modeRaw = (delivery as { mode?: unknown }).mode;
+      if (typeof modeRaw === "string") {
+        const lowered = modeRaw.trim().toLowerCase();
+        if (lowered === "deliver") {
+          (delivery as { mode?: unknown }).mode = "announce";
+          mutated = true;
+          trackIssue("legacyDeliveryMode");
+        }
+      } else if (modeRaw === undefined || modeRaw === null) {
+        (delivery as { mode?: unknown }).mode = "announce";
+        mutated = true;
+      }
+    }
+
+    const isolation = raw.isolation;
+    if (isolation && typeof isolation === "object" && !Array.isArray(isolation)) {
+      delete raw.isolation;
+      mutated = true;
+    }
+
+    const payloadKind =
+      payloadRecord && typeof payloadRecord.kind === "string" ? payloadRecord.kind : "";
+    const normalizedSessionTarget =
+      typeof raw.sessionTarget === "string" ? raw.sessionTarget.trim().toLowerCase() : "";
+    if (normalizedSessionTarget === "main" || normalizedSessionTarget === "isolated") {
+      if (raw.sessionTarget !== normalizedSessionTarget) {
+        raw.sessionTarget = normalizedSessionTarget;
+        mutated = true;
+      }
+    } else {
+      const inferredSessionTarget = payloadKind === "agentTurn" ? "isolated" : "main";
+      if (raw.sessionTarget !== inferredSessionTarget) {
+        raw.sessionTarget = inferredSessionTarget;
+        mutated = true;
+      }
+    }
+
+    const sessionTarget =
+      typeof raw.sessionTarget === "string" ? raw.sessionTarget.trim().toLowerCase() : "";
+    const isIsolatedAgentTurn =
+      sessionTarget === "isolated" || (sessionTarget === "" && payloadKind === "agentTurn");
+    const hasDelivery = delivery && typeof delivery === "object" && !Array.isArray(delivery);
+    const normalizedLegacy = normalizeLegacyDeliveryInput({
+      delivery: hasDelivery ? (delivery as Record<string, unknown>) : null,
+      payload: payloadRecord,
+    });
+
+    if (isIsolatedAgentTurn && payloadKind === "agentTurn") {
+      if (!hasDelivery && normalizedLegacy.delivery) {
+        raw.delivery = normalizedLegacy.delivery;
+        mutated = true;
+      } else if (!hasDelivery) {
+        raw.delivery = { mode: "announce" };
+        mutated = true;
+      } else if (normalizedLegacy.mutated && normalizedLegacy.delivery) {
+        raw.delivery = normalizedLegacy.delivery;
+        mutated = true;
+      }
+    } else if (normalizedLegacy.mutated && normalizedLegacy.delivery) {
+      raw.delivery = normalizedLegacy.delivery;
+      mutated = true;
+    }
+  }
+
+  return { issues, jobs, mutated };
+}

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -644,6 +644,7 @@ describe("gateway server cron", () => {
       await yieldToEventLoop();
       expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
 
+      fetchWithSsrFGuardMock.mockClear();
       cronIsolatedRun.mockResolvedValueOnce({ status: "ok", summary: "" });
       const noSummaryRes = await rpcReq(ws, "cron.add", {
         name: "webhook no summary",
@@ -668,7 +669,7 @@ describe("gateway server cron", () => {
       expect(noSummaryRunRes.ok).toBe(true);
       await yieldToEventLoop();
       await yieldToEventLoop();
-      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
+      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
     } finally {
       await cleanupCronTestRun({ ws, server, dir, prevSkipCron });
     }

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -56,6 +56,10 @@ describe("gateway server hooks", () => {
       expect(resAgent.status).toBe(202);
       const agentEvents = await waitForSystemEvent();
       expect(agentEvents.some((e) => e.includes("Hook Email: done"))).toBe(true);
+      const firstCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
+        deliveryContract?: string;
+      };
+      expect(firstCall?.deliveryContract).toBe("shared");
       drainSystemEvents(resolveMainKey());
 
       cronIsolatedRun.mockClear();

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -69,6 +69,7 @@ export function createGatewayHooksRequestHandler(params: {
           message: value.message,
           sessionKey,
           lane: "cron",
+          deliveryContract: "shared",
         });
         const summary = result.summary?.trim() || result.error?.trim() || result.status;
         const prefix =


### PR DESCRIPTION
## Summary

AUTO-PARTIAL cherry-pick of upstream d4e59a366 — enforces cron-owned delivery contract.

**Changes:**
- Extracted cron store normalization into `store-migration.ts` (from inline code in `store.ts`)
- Added doctor cron store scanning (`doctor-cron.ts`)
- New `IsolatedDeliveryContract` type and `resolveCronDeliveryContext` helper in `run.ts`
- Updated delivery dispatch, timer, and test coverage

**Adaptations:**
- Rebranded openclaw → remoteclaw in all touched files
- Removed `delivery.failure-notify.test.ts` and failure destination test blocks (depend on `resolveFailureDestination` not in fork)
- Removed unused model override helpers in `run.ts` (fork stripped model management)
- Restored `legacy-delivery.ts` and `payload-migration.ts` from upstream (cron store normalization is kept infrastructure)
- Added `coerceFiniteScheduleNumber` to `schedule.ts` and `CronRetryOn` type to `types.cron.ts`

Cherry-picked-from: d4e59a366
Part of #925