### PR TITLE
Cherry-pick: Android Native — Invoke & Notifications (11 commits)

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -146,6 +146,7 @@ dependencies {
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
   testImplementation("io.kotest:kotest-runner-junit5-jvm:6.1.3")
   testImplementation("io.kotest:kotest-assertions-core-jvm:6.1.3")
+  testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")
   testImplementation("org.robolectric:robolectric:4.16.1")
   testRuntimeOnly("org.junit.vintage:junit-vintage-engine:6.0.2")
 }

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,15 @@
             android:name=".NodeForegroundService"
             android:exported="false"
             android:foregroundServiceType="dataSync|microphone|mediaProjection" />
+        <service
+            android:name=".node.DeviceNotificationListenerService"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
@@ -91,6 +91,10 @@ class NodeRuntime(context: Context) {
     locationPreciseEnabled = { locationPreciseEnabled.value },
   )
 
+  private val notificationsHandler: NotificationsHandler = NotificationsHandler(
+    appContext = appContext,
+  )
+
   private val screenHandler: ScreenHandler = ScreenHandler(
     screenRecorder = screenRecorder,
     setScreenRecordActive = { _screenRecordActive.value = it },
@@ -122,6 +126,7 @@ class NodeRuntime(context: Context) {
     canvas = canvas,
     cameraHandler = cameraHandler,
     locationHandler = locationHandler,
+    notificationsHandler = notificationsHandler,
     screenHandler = screenHandler,
     smsHandler = smsHandlerImpl,
     a2uiHandler = a2uiHandler,

--- a/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
@@ -130,6 +130,8 @@ class NodeRuntime(context: Context) {
     isForeground = { _isForeground.value },
     cameraEnabled = { cameraEnabled.value },
     locationEnabled = { locationMode.value != LocationMode.Off },
+    smsAvailable = { sms.canSendSms() },
+    debugBuild = { BuildConfig.DEBUG },
     onCanvasA2uiPush = {
       _canvasA2uiHydrated.value = true
       _canvasRehydratePending.value = false

--- a/apps/android/app/src/main/java/org/remoteclaw/android/gateway/DeviceAuthStore.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/gateway/DeviceAuthStore.kt
@@ -2,13 +2,18 @@ package org.remoteclaw.android.gateway
 
 import org.remoteclaw.android.SecurePrefs
 
-class DeviceAuthStore(private val prefs: SecurePrefs) {
-  fun loadToken(deviceId: String, role: String): String? {
+interface DeviceAuthTokenStore {
+  fun loadToken(deviceId: String, role: String): String?
+  fun saveToken(deviceId: String, role: String, token: String)
+}
+
+class DeviceAuthStore(private val prefs: SecurePrefs) : DeviceAuthTokenStore {
+  override fun loadToken(deviceId: String, role: String): String? {
     val key = tokenKey(deviceId, role)
     return prefs.getString(key)?.trim()?.takeIf { it.isNotEmpty() }
   }
 
-  fun saveToken(deviceId: String, role: String, token: String) {
+  override fun saveToken(deviceId: String, role: String, token: String) {
     val key = tokenKey(deviceId, role)
     prefs.putString(key, token.trim())
   }

--- a/apps/android/app/src/main/java/org/remoteclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/gateway/GatewaySession.kt
@@ -535,16 +535,8 @@ class GatewaySession(
     }
 
     private fun invokeErrorFromThrowable(err: Throwable): InvokeResult {
-      val msg = err.message?.trim().takeIf { !it.isNullOrEmpty() } ?: err::class.java.simpleName
-      val parts = msg.split(":", limit = 2)
-      if (parts.size == 2) {
-        val code = parts[0].trim()
-        val rest = parts[1].trim()
-        if (code.isNotEmpty() && code.all { it.isUpperCase() || it == '_' }) {
-          return InvokeResult.error(code = code, message = rest.ifEmpty { msg })
-        }
-      }
-      return InvokeResult.error(code = "UNAVAILABLE", message = msg)
+      val parsed = parseInvokeErrorFromThrowable(err, fallbackMessage = err::class.java.simpleName)
+      return InvokeResult.error(code = parsed.code, message = parsed.message)
     }
 
     private fun failPending() {

--- a/apps/android/app/src/main/java/org/remoteclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/gateway/GatewaySession.kt
@@ -200,9 +200,7 @@ class GatewaySession(
     suspend fun connect() {
       val scheme = if (tls != null) "wss" else "ws"
       val url = "$scheme://${endpoint.host}:${endpoint.port}"
-      val httpScheme = if (tls != null) "https" else "http"
-      val origin = "$httpScheme://${endpoint.host}:${endpoint.port}"
-      val request = Request.Builder().url(url).header("Origin", origin).build()
+      val request = Request.Builder().url(url).build()
       socket = client.newWebSocket(request, Listener())
       try {
         connectDeferred.await()

--- a/apps/android/app/src/main/java/org/remoteclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/gateway/GatewaySession.kt
@@ -55,7 +55,7 @@ data class GatewayConnectOptions(
 class GatewaySession(
   private val scope: CoroutineScope,
   private val identityStore: DeviceIdentityStore,
-  private val deviceAuthStore: DeviceAuthStore,
+  private val deviceAuthStore: DeviceAuthTokenStore,
   private val onConnected: (serverName: String?, remoteAddress: String?, mainSessionKey: String?) -> Unit,
   private val onDisconnected: (message: String) -> Unit,
   private val onEvent: (event: String, payloadJson: String?) -> Unit,

--- a/apps/android/app/src/main/java/org/remoteclaw/android/gateway/InvokeErrorParser.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/gateway/InvokeErrorParser.kt
@@ -1,0 +1,39 @@
+package org.remoteclaw.android.gateway
+
+data class ParsedInvokeError(
+  val code: String,
+  val message: String,
+  val hadExplicitCode: Boolean,
+) {
+  val prefixedMessage: String
+    get() = "$code: $message"
+}
+
+fun parseInvokeErrorMessage(raw: String): ParsedInvokeError {
+  val trimmed = raw.trim()
+  if (trimmed.isEmpty()) {
+    return ParsedInvokeError(code = "UNAVAILABLE", message = "error", hadExplicitCode = false)
+  }
+
+  val parts = trimmed.split(":", limit = 2)
+  if (parts.size == 2) {
+    val code = parts[0].trim()
+    val rest = parts[1].trim()
+    if (code.isNotEmpty() && code.all { it.isUpperCase() || it == '_' }) {
+      return ParsedInvokeError(
+        code = code,
+        message = rest.ifEmpty { trimmed },
+        hadExplicitCode = true,
+      )
+    }
+  }
+  return ParsedInvokeError(code = "UNAVAILABLE", message = trimmed, hadExplicitCode = false)
+}
+
+fun parseInvokeErrorFromThrowable(
+  err: Throwable,
+  fallbackMessage: String = "error",
+): ParsedInvokeError {
+  val raw = err.message?.trim().takeIf { !it.isNullOrEmpty() } ?: fallbackMessage
+  return parseInvokeErrorMessage(raw)
+}

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/CameraCaptureManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/CameraCaptureManager.kt
@@ -81,8 +81,8 @@ class CameraCaptureManager(private val context: Context) {
       ensureCameraPermission()
       val owner = lifecycleOwner ?: throw IllegalStateException("UNAVAILABLE: camera not ready")
       val facing = parseFacing(paramsJson) ?: "front"
-      val quality = (parseQuality(paramsJson) ?: 0.5).coerceIn(0.1, 1.0)
-      val maxWidth = parseMaxWidth(paramsJson) ?: 800
+      val quality = (parseQuality(paramsJson) ?: 0.95).coerceIn(0.1, 1.0)
+      val maxWidth = parseMaxWidth(paramsJson) ?: 1600
 
       val provider = context.cameraProvider()
       val capture = ImageCapture.Builder().build()

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/ConnectionManager.kt
@@ -7,12 +7,6 @@ import org.remoteclaw.android.gateway.GatewayClientInfo
 import org.remoteclaw.android.gateway.GatewayConnectOptions
 import org.remoteclaw.android.gateway.GatewayEndpoint
 import org.remoteclaw.android.gateway.GatewayTlsParams
-import org.remoteclaw.android.protocol.RemoteClawCanvasA2UICommand
-import org.remoteclaw.android.protocol.RemoteClawCanvasCommand
-import org.remoteclaw.android.protocol.RemoteClawCameraCommand
-import org.remoteclaw.android.protocol.RemoteClawLocationCommand
-import org.remoteclaw.android.protocol.RemoteClawScreenCommand
-import org.remoteclaw.android.protocol.RemoteClawSmsCommand
 import org.remoteclaw.android.protocol.RemoteClawCapability
 import org.remoteclaw.android.LocationMode
 import org.remoteclaw.android.VoiceWakeMode
@@ -80,32 +74,12 @@ class ConnectionManager(
   }
 
   fun buildInvokeCommands(): List<String> =
-    buildList {
-      add(RemoteClawCanvasCommand.Present.rawValue)
-      add(RemoteClawCanvasCommand.Hide.rawValue)
-      add(RemoteClawCanvasCommand.Navigate.rawValue)
-      add(RemoteClawCanvasCommand.Eval.rawValue)
-      add(RemoteClawCanvasCommand.Snapshot.rawValue)
-      add(RemoteClawCanvasA2UICommand.Push.rawValue)
-      add(RemoteClawCanvasA2UICommand.PushJSONL.rawValue)
-      add(RemoteClawCanvasA2UICommand.Reset.rawValue)
-      add(RemoteClawScreenCommand.Record.rawValue)
-      if (cameraEnabled()) {
-        add(RemoteClawCameraCommand.Snap.rawValue)
-        add(RemoteClawCameraCommand.Clip.rawValue)
-      }
-      if (locationMode() != LocationMode.Off) {
-        add(RemoteClawLocationCommand.Get.rawValue)
-      }
-      if (smsAvailable()) {
-        add(RemoteClawSmsCommand.Send.rawValue)
-      }
-      if (BuildConfig.DEBUG) {
-        add("debug.logs")
-        add("debug.ed25519")
-      }
-      add("app.update")
-    }
+    InvokeCommandRegistry.advertisedCommands(
+      cameraEnabled = cameraEnabled(),
+      locationEnabled = locationMode() != LocationMode.Off,
+      smsAvailable = smsAvailable(),
+      debugBuild = BuildConfig.DEBUG,
+    )
 
   fun buildCapabilities(): List<String> =
     buildList {

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/DeviceNotificationListenerService.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/DeviceNotificationListenerService.kt
@@ -1,0 +1,164 @@
+package org.remoteclaw.android.node
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.ComponentName
+import android.content.Context
+import android.os.Build
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+
+private const val MAX_NOTIFICATION_TEXT_CHARS = 512
+
+internal fun sanitizeNotificationText(value: CharSequence?): String? {
+  val normalized = value?.toString()?.trim().orEmpty()
+  return normalized.take(MAX_NOTIFICATION_TEXT_CHARS).ifEmpty { null }
+}
+
+data class DeviceNotificationEntry(
+  val key: String,
+  val packageName: String,
+  val title: String?,
+  val text: String?,
+  val subText: String?,
+  val category: String?,
+  val channelId: String?,
+  val postTimeMs: Long,
+  val isOngoing: Boolean,
+  val isClearable: Boolean,
+)
+
+data class DeviceNotificationSnapshot(
+  val enabled: Boolean,
+  val connected: Boolean,
+  val notifications: List<DeviceNotificationEntry>,
+)
+
+private object DeviceNotificationStore {
+  private val lock = Any()
+  private var connected = false
+  private val byKey = LinkedHashMap<String, DeviceNotificationEntry>()
+
+  fun replace(entries: List<DeviceNotificationEntry>) {
+    synchronized(lock) {
+      byKey.clear()
+      for (entry in entries) {
+        byKey[entry.key] = entry
+      }
+    }
+  }
+
+  fun upsert(entry: DeviceNotificationEntry) {
+    synchronized(lock) {
+      byKey[entry.key] = entry
+    }
+  }
+
+  fun remove(key: String) {
+    synchronized(lock) {
+      byKey.remove(key)
+    }
+  }
+
+  fun setConnected(value: Boolean) {
+    synchronized(lock) {
+      connected = value
+      if (!value) {
+        byKey.clear()
+      }
+    }
+  }
+
+  fun snapshot(enabled: Boolean): DeviceNotificationSnapshot {
+    val (isConnected, entries) =
+      synchronized(lock) {
+        connected to byKey.values.sortedByDescending { it.postTimeMs }
+      }
+    return DeviceNotificationSnapshot(
+      enabled = enabled,
+      connected = isConnected,
+      notifications = entries,
+    )
+  }
+}
+
+class DeviceNotificationListenerService : NotificationListenerService() {
+  override fun onListenerConnected() {
+    super.onListenerConnected()
+    DeviceNotificationStore.setConnected(true)
+    refreshActiveNotifications()
+  }
+
+  override fun onListenerDisconnected() {
+    DeviceNotificationStore.setConnected(false)
+    super.onListenerDisconnected()
+  }
+
+  override fun onNotificationPosted(sbn: StatusBarNotification?) {
+    super.onNotificationPosted(sbn)
+    val entry = sbn?.toEntry() ?: return
+    DeviceNotificationStore.upsert(entry)
+  }
+
+  override fun onNotificationRemoved(sbn: StatusBarNotification?) {
+    super.onNotificationRemoved(sbn)
+    val key = sbn?.key ?: return
+    DeviceNotificationStore.remove(key)
+  }
+
+  private fun refreshActiveNotifications() {
+    val entries =
+      runCatching {
+        activeNotifications
+          ?.mapNotNull { it.toEntry() }
+          ?: emptyList()
+      }.getOrElse { emptyList() }
+    DeviceNotificationStore.replace(entries)
+  }
+
+  private fun StatusBarNotification.toEntry(): DeviceNotificationEntry {
+    val extras = notification.extras
+    val keyValue = key.takeIf { it.isNotBlank() } ?: "$packageName:$id:$postTime"
+    val title = sanitizeNotificationText(extras?.getCharSequence(Notification.EXTRA_TITLE))
+    val body =
+      sanitizeNotificationText(extras?.getCharSequence(Notification.EXTRA_BIG_TEXT))
+        ?: sanitizeNotificationText(extras?.getCharSequence(Notification.EXTRA_TEXT))
+    val subText = sanitizeNotificationText(extras?.getCharSequence(Notification.EXTRA_SUB_TEXT))
+    return DeviceNotificationEntry(
+      key = keyValue,
+      packageName = packageName,
+      title = title,
+      text = body,
+      subText = subText,
+      category = notification.category?.trim()?.ifEmpty { null },
+      channelId = notification.channelId?.trim()?.ifEmpty { null },
+      postTimeMs = postTime,
+      isOngoing = isOngoing,
+      isClearable = isClearable,
+    )
+  }
+
+  companion object {
+    private fun serviceComponent(context: Context): ComponentName {
+      return ComponentName(context, DeviceNotificationListenerService::class.java)
+    }
+
+    fun isAccessEnabled(context: Context): Boolean {
+      val manager = context.getSystemService(NotificationManager::class.java) ?: return false
+      return manager.isNotificationListenerAccessGranted(serviceComponent(context))
+    }
+
+    fun snapshot(context: Context, enabled: Boolean = isAccessEnabled(context)): DeviceNotificationSnapshot {
+      return DeviceNotificationStore.snapshot(enabled = enabled)
+    }
+
+    fun requestServiceRebind(context: Context) {
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+        return
+      }
+      runCatching {
+        NotificationListenerService.requestRebind(serviceComponent(context))
+      }
+    }
+  }
+}

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeCommandRegistry.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeCommandRegistry.kt
@@ -1,0 +1,114 @@
+package org.remoteclaw.android.node
+
+import org.remoteclaw.android.protocol.RemoteClawCanvasA2UICommand
+import org.remoteclaw.android.protocol.RemoteClawCanvasCommand
+import org.remoteclaw.android.protocol.RemoteClawCameraCommand
+import org.remoteclaw.android.protocol.RemoteClawLocationCommand
+import org.remoteclaw.android.protocol.RemoteClawScreenCommand
+import org.remoteclaw.android.protocol.RemoteClawSmsCommand
+
+enum class InvokeCommandAvailability {
+  Always,
+  CameraEnabled,
+  LocationEnabled,
+  SmsAvailable,
+  DebugBuild,
+}
+
+data class InvokeCommandSpec(
+  val name: String,
+  val requiresForeground: Boolean = false,
+  val availability: InvokeCommandAvailability = InvokeCommandAvailability.Always,
+)
+
+object InvokeCommandRegistry {
+  val all: List<InvokeCommandSpec> =
+    listOf(
+      InvokeCommandSpec(
+        name = RemoteClawCanvasCommand.Present.rawValue,
+        requiresForeground = true,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawCanvasCommand.Hide.rawValue,
+        requiresForeground = true,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawCanvasCommand.Navigate.rawValue,
+        requiresForeground = true,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawCanvasCommand.Eval.rawValue,
+        requiresForeground = true,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawCanvasCommand.Snapshot.rawValue,
+        requiresForeground = true,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawCanvasA2UICommand.Push.rawValue,
+        requiresForeground = true,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawCanvasA2UICommand.PushJSONL.rawValue,
+        requiresForeground = true,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawCanvasA2UICommand.Reset.rawValue,
+        requiresForeground = true,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawScreenCommand.Record.rawValue,
+        requiresForeground = true,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawCameraCommand.Snap.rawValue,
+        requiresForeground = true,
+        availability = InvokeCommandAvailability.CameraEnabled,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawCameraCommand.Clip.rawValue,
+        requiresForeground = true,
+        availability = InvokeCommandAvailability.CameraEnabled,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawLocationCommand.Get.rawValue,
+        availability = InvokeCommandAvailability.LocationEnabled,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawSmsCommand.Send.rawValue,
+        availability = InvokeCommandAvailability.SmsAvailable,
+      ),
+      InvokeCommandSpec(
+        name = "debug.logs",
+        availability = InvokeCommandAvailability.DebugBuild,
+      ),
+      InvokeCommandSpec(
+        name = "debug.ed25519",
+        availability = InvokeCommandAvailability.DebugBuild,
+      ),
+      InvokeCommandSpec(name = "app.update"),
+    )
+
+  private val byNameInternal: Map<String, InvokeCommandSpec> = all.associateBy { it.name }
+
+  fun find(command: String): InvokeCommandSpec? = byNameInternal[command]
+
+  fun advertisedCommands(
+    cameraEnabled: Boolean,
+    locationEnabled: Boolean,
+    smsAvailable: Boolean,
+    debugBuild: Boolean,
+  ): List<String> {
+    return all
+      .filter { spec ->
+        when (spec.availability) {
+          InvokeCommandAvailability.Always -> true
+          InvokeCommandAvailability.CameraEnabled -> cameraEnabled
+          InvokeCommandAvailability.LocationEnabled -> locationEnabled
+          InvokeCommandAvailability.SmsAvailable -> smsAvailable
+          InvokeCommandAvailability.DebugBuild -> debugBuild
+        }
+      }
+      .map { it.name }
+  }
+}

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeCommandRegistry.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeCommandRegistry.kt
@@ -4,6 +4,7 @@ import org.remoteclaw.android.protocol.RemoteClawCanvasA2UICommand
 import org.remoteclaw.android.protocol.RemoteClawCanvasCommand
 import org.remoteclaw.android.protocol.RemoteClawCameraCommand
 import org.remoteclaw.android.protocol.RemoteClawLocationCommand
+import org.remoteclaw.android.protocol.RemoteClawNotificationsCommand
 import org.remoteclaw.android.protocol.RemoteClawScreenCommand
 import org.remoteclaw.android.protocol.RemoteClawSmsCommand
 
@@ -73,6 +74,9 @@ object InvokeCommandRegistry {
       InvokeCommandSpec(
         name = RemoteClawLocationCommand.Get.rawValue,
         availability = InvokeCommandAvailability.LocationEnabled,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawNotificationsCommand.List.rawValue,
       ),
       InvokeCommandSpec(
         name = RemoteClawSmsCommand.Send.rawValue,

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeDispatcher.kt
@@ -24,31 +24,25 @@ class InvokeDispatcher(
   private val onCanvasA2uiReset: () -> Unit,
 ) {
   suspend fun handleInvoke(command: String, paramsJson: String?): GatewaySession.InvokeResult {
-    // Check foreground requirement for canvas/camera/screen commands
-    if (
-      command.startsWith(RemoteClawCanvasCommand.NamespacePrefix) ||
-        command.startsWith(RemoteClawCanvasA2UICommand.NamespacePrefix) ||
-        command.startsWith(RemoteClawCameraCommand.NamespacePrefix) ||
-        command.startsWith(RemoteClawScreenCommand.NamespacePrefix)
-    ) {
-      if (!isForeground()) {
-        return GatewaySession.InvokeResult.error(
-          code = "NODE_BACKGROUND_UNAVAILABLE",
-          message = "NODE_BACKGROUND_UNAVAILABLE: canvas/camera/screen commands require foreground",
+    val spec =
+      InvokeCommandRegistry.find(command)
+        ?: return GatewaySession.InvokeResult.error(
+          code = "INVALID_REQUEST",
+          message = "INVALID_REQUEST: unknown command",
         )
-      }
+    if (spec.requiresForeground && !isForeground()) {
+      return GatewaySession.InvokeResult.error(
+        code = "NODE_BACKGROUND_UNAVAILABLE",
+        message = "NODE_BACKGROUND_UNAVAILABLE: canvas/camera/screen commands require foreground",
+      )
     }
-
-    // Check camera enabled
-    if (command.startsWith(RemoteClawCameraCommand.NamespacePrefix) && !cameraEnabled()) {
+    if (spec.availability == InvokeCommandAvailability.CameraEnabled && !cameraEnabled()) {
       return GatewaySession.InvokeResult.error(
         code = "CAMERA_DISABLED",
         message = "CAMERA_DISABLED: enable Camera in Settings",
       )
     }
-
-    // Check location enabled
-    if (command.startsWith(RemoteClawLocationCommand.NamespacePrefix) && !locationEnabled()) {
+    if (spec.availability == InvokeCommandAvailability.LocationEnabled && !locationEnabled()) {
       return GatewaySession.InvokeResult.error(
         code = "LOCATION_DISABLED",
         message = "LOCATION_DISABLED: enable Location in Settings",
@@ -75,53 +69,33 @@ class InvokeDispatcher(
               code = "INVALID_REQUEST",
               message = "INVALID_REQUEST: javaScript required",
             )
-        val result =
-          try {
-            canvas.eval(js)
-          } catch (err: Throwable) {
-            return GatewaySession.InvokeResult.error(
-              code = "NODE_BACKGROUND_UNAVAILABLE",
-              message = "NODE_BACKGROUND_UNAVAILABLE: canvas unavailable",
-            )
-          }
-        GatewaySession.InvokeResult.ok("""{"result":${result.toJsonString()}}""")
+        withCanvasAvailable {
+          val result = canvas.eval(js)
+          GatewaySession.InvokeResult.ok("""{"result":${result.toJsonString()}}""")
+        }
       }
       RemoteClawCanvasCommand.Snapshot.rawValue -> {
         val snapshotParams = CanvasController.parseSnapshotParams(paramsJson)
-        val base64 =
-          try {
+        withCanvasAvailable {
+          val base64 =
             canvas.snapshotBase64(
               format = snapshotParams.format,
               quality = snapshotParams.quality,
               maxWidth = snapshotParams.maxWidth,
             )
-          } catch (err: Throwable) {
-            return GatewaySession.InvokeResult.error(
-              code = "NODE_BACKGROUND_UNAVAILABLE",
-              message = "NODE_BACKGROUND_UNAVAILABLE: canvas unavailable",
-            )
-          }
-        GatewaySession.InvokeResult.ok("""{"format":"${snapshotParams.format.rawValue}","base64":"$base64"}""")
+          GatewaySession.InvokeResult.ok("""{"format":"${snapshotParams.format.rawValue}","base64":"$base64"}""")
+        }
       }
 
       // A2UI commands
-      RemoteClawCanvasA2UICommand.Reset.rawValue -> {
-        val a2uiUrl = a2uiHandler.resolveA2uiHostUrl()
-          ?: return GatewaySession.InvokeResult.error(
-            code = "A2UI_HOST_NOT_CONFIGURED",
-            message = "A2UI_HOST_NOT_CONFIGURED: gateway did not advertise canvas host",
-          )
-        val ready = a2uiHandler.ensureA2uiReady(a2uiUrl)
-        if (!ready) {
-          return GatewaySession.InvokeResult.error(
-            code = "A2UI_HOST_UNAVAILABLE",
-            message = "A2UI host not reachable",
-          )
+      RemoteClawCanvasA2UICommand.Reset.rawValue ->
+        withReadyA2ui {
+          withCanvasAvailable {
+            val res = canvas.eval(A2UIHandler.a2uiResetJS)
+            onCanvasA2uiReset()
+            GatewaySession.InvokeResult.ok(res)
+          }
         }
-        val res = canvas.eval(A2UIHandler.a2uiResetJS)
-        onCanvasA2uiReset()
-        GatewaySession.InvokeResult.ok(res)
-      }
       RemoteClawCanvasA2UICommand.Push.rawValue, RemoteClawCanvasA2UICommand.PushJSONL.rawValue -> {
         val messages =
           try {
@@ -132,22 +106,14 @@ class InvokeDispatcher(
               message = err.message ?: "invalid A2UI payload"
             )
           }
-        val a2uiUrl = a2uiHandler.resolveA2uiHostUrl()
-          ?: return GatewaySession.InvokeResult.error(
-            code = "A2UI_HOST_NOT_CONFIGURED",
-            message = "A2UI_HOST_NOT_CONFIGURED: gateway did not advertise canvas host",
-          )
-        val ready = a2uiHandler.ensureA2uiReady(a2uiUrl)
-        if (!ready) {
-          return GatewaySession.InvokeResult.error(
-            code = "A2UI_HOST_UNAVAILABLE",
-            message = "A2UI host not reachable",
-          )
+        withReadyA2ui {
+          withCanvasAvailable {
+            val js = A2UIHandler.a2uiApplyMessagesJS(messages)
+            val res = canvas.eval(js)
+            onCanvasA2uiPush()
+            GatewaySession.InvokeResult.ok(res)
+          }
         }
-        val js = A2UIHandler.a2uiApplyMessagesJS(messages)
-        val res = canvas.eval(js)
-        onCanvasA2uiPush()
-        GatewaySession.InvokeResult.ok(res)
       }
 
       // Camera commands
@@ -170,11 +136,38 @@ class InvokeDispatcher(
       // App update
       "app.update" -> appUpdateHandler.handleUpdate(paramsJson)
 
-      else ->
-        GatewaySession.InvokeResult.error(
-          code = "INVALID_REQUEST",
-          message = "INVALID_REQUEST: unknown command",
-        )
+      else -> GatewaySession.InvokeResult.error(code = "INVALID_REQUEST", message = "INVALID_REQUEST: unknown command")
+    }
+  }
+
+  private suspend fun withReadyA2ui(
+    block: suspend () -> GatewaySession.InvokeResult,
+  ): GatewaySession.InvokeResult {
+    val a2uiUrl = a2uiHandler.resolveA2uiHostUrl()
+      ?: return GatewaySession.InvokeResult.error(
+        code = "A2UI_HOST_NOT_CONFIGURED",
+        message = "A2UI_HOST_NOT_CONFIGURED: gateway did not advertise canvas host",
+      )
+    val ready = a2uiHandler.ensureA2uiReady(a2uiUrl)
+    if (!ready) {
+      return GatewaySession.InvokeResult.error(
+        code = "A2UI_HOST_UNAVAILABLE",
+        message = "A2UI host not reachable",
+      )
+    }
+    return block()
+  }
+
+  private suspend fun withCanvasAvailable(
+    block: suspend () -> GatewaySession.InvokeResult,
+  ): GatewaySession.InvokeResult {
+    return try {
+      block()
+    } catch (_: Throwable) {
+      GatewaySession.InvokeResult.error(
+        code = "NODE_BACKGROUND_UNAVAILABLE",
+        message = "NODE_BACKGROUND_UNAVAILABLE: canvas unavailable",
+      )
     }
   }
 }

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeDispatcher.kt
@@ -5,6 +5,7 @@ import org.remoteclaw.android.protocol.RemoteClawCanvasA2UICommand
 import org.remoteclaw.android.protocol.RemoteClawCanvasCommand
 import org.remoteclaw.android.protocol.RemoteClawCameraCommand
 import org.remoteclaw.android.protocol.RemoteClawLocationCommand
+import org.remoteclaw.android.protocol.RemoteClawNotificationsCommand
 import org.remoteclaw.android.protocol.RemoteClawScreenCommand
 import org.remoteclaw.android.protocol.RemoteClawSmsCommand
 
@@ -12,6 +13,7 @@ class InvokeDispatcher(
   private val canvas: CanvasController,
   private val cameraHandler: CameraHandler,
   private val locationHandler: LocationHandler,
+  private val notificationsHandler: NotificationsHandler,
   private val screenHandler: ScreenHandler,
   private val smsHandler: SmsHandler,
   private val a2uiHandler: A2UIHandler,
@@ -113,6 +115,9 @@ class InvokeDispatcher(
 
       // Location command
       RemoteClawLocationCommand.Get.rawValue -> locationHandler.handleLocationGet(paramsJson)
+
+      // Notifications command
+      RemoteClawNotificationsCommand.List.rawValue -> notificationsHandler.handleNotificationsList(paramsJson)
 
       // Screen command
       RemoteClawScreenCommand.Record.rawValue -> screenHandler.handleScreenRecord(paramsJson)

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/NodeUtils.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/NodeUtils.kt
@@ -1,5 +1,6 @@
 package org.remoteclaw.android.node
 
+import org.remoteclaw.android.gateway.parseInvokeErrorFromThrowable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
@@ -37,14 +38,9 @@ fun parseHexColorArgb(raw: String?): Long? {
 }
 
 fun invokeErrorFromThrowable(err: Throwable): Pair<String, String> {
-  val raw = (err.message ?: "").trim()
-  if (raw.isEmpty()) return "UNAVAILABLE" to "UNAVAILABLE: error"
-
-  val idx = raw.indexOf(':')
-  if (idx <= 0) return "UNAVAILABLE" to raw
-  val code = raw.substring(0, idx).trim().ifEmpty { "UNAVAILABLE" }
-  val message = raw.substring(idx + 1).trim().ifEmpty { raw }
-  return code to "$code: $message"
+  val parsed = parseInvokeErrorFromThrowable(err, fallbackMessage = "UNAVAILABLE: error")
+  val message = if (parsed.hadExplicitCode) parsed.prefixedMessage else parsed.message
+  return parsed.code to message
 }
 
 fun normalizeMainKey(raw: String?): String? {

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/NotificationsHandler.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/NotificationsHandler.kt
@@ -1,0 +1,81 @@
+package org.remoteclaw.android.node
+
+import android.content.Context
+import org.remoteclaw.android.gateway.GatewaySession
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+internal interface NotificationsStateProvider {
+  fun readSnapshot(context: Context): DeviceNotificationSnapshot
+
+  fun requestServiceRebind(context: Context)
+}
+
+private object SystemNotificationsStateProvider : NotificationsStateProvider {
+  override fun readSnapshot(context: Context): DeviceNotificationSnapshot {
+    val enabled = DeviceNotificationListenerService.isAccessEnabled(context)
+    if (!enabled) {
+      return DeviceNotificationSnapshot(
+        enabled = false,
+        connected = false,
+        notifications = emptyList(),
+      )
+    }
+    return DeviceNotificationListenerService.snapshot(context, enabled = true)
+  }
+
+  override fun requestServiceRebind(context: Context) {
+    DeviceNotificationListenerService.requestServiceRebind(context)
+  }
+}
+
+class NotificationsHandler private constructor(
+  private val appContext: Context,
+  private val stateProvider: NotificationsStateProvider,
+) {
+  constructor(appContext: Context) : this(appContext = appContext, stateProvider = SystemNotificationsStateProvider)
+
+  suspend fun handleNotificationsList(_paramsJson: String?): GatewaySession.InvokeResult {
+    val snapshot = stateProvider.readSnapshot(appContext)
+    if (snapshot.enabled && !snapshot.connected) {
+      stateProvider.requestServiceRebind(appContext)
+    }
+    return GatewaySession.InvokeResult.ok(snapshotPayloadJson(snapshot))
+  }
+
+  private fun snapshotPayloadJson(snapshot: DeviceNotificationSnapshot): String {
+    return buildJsonObject {
+      put("enabled", JsonPrimitive(snapshot.enabled))
+      put("connected", JsonPrimitive(snapshot.connected))
+      put("count", JsonPrimitive(snapshot.notifications.size))
+      put(
+        "notifications",
+        JsonArray(
+          snapshot.notifications.map { entry ->
+            buildJsonObject {
+              put("key", JsonPrimitive(entry.key))
+              put("packageName", JsonPrimitive(entry.packageName))
+              put("postTimeMs", JsonPrimitive(entry.postTimeMs))
+              put("isOngoing", JsonPrimitive(entry.isOngoing))
+              put("isClearable", JsonPrimitive(entry.isClearable))
+              entry.title?.let { put("title", JsonPrimitive(it)) }
+              entry.text?.let { put("text", JsonPrimitive(it)) }
+              entry.subText?.let { put("subText", JsonPrimitive(it)) }
+              entry.category?.let { put("category", JsonPrimitive(it)) }
+              entry.channelId?.let { put("channelId", JsonPrimitive(it)) }
+            }
+          },
+        ),
+      )
+    }.toString()
+  }
+
+  companion object {
+    internal fun forTesting(
+      appContext: Context,
+      stateProvider: NotificationsStateProvider,
+    ): NotificationsHandler = NotificationsHandler(appContext = appContext, stateProvider = stateProvider)
+  }
+}

--- a/apps/android/app/src/main/java/org/remoteclaw/android/protocol/RemoteClawProtocolConstants.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/protocol/RemoteClawProtocolConstants.kt
@@ -69,3 +69,12 @@ enum class RemoteClawLocationCommand(val rawValue: String) {
     const val NamespacePrefix: String = "location."
   }
 }
+
+enum class RemoteClawNotificationsCommand(val rawValue: String) {
+  List("notifications.list"),
+  ;
+
+  companion object {
+    const val NamespacePrefix: String = "notifications."
+  }
+}

--- a/apps/android/app/src/test/java/org/remoteclaw/android/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/gateway/GatewaySessionInvokeTest.kt
@@ -27,6 +27,16 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import java.util.concurrent.atomic.AtomicReference
 
+private class InMemoryDeviceAuthStore : DeviceAuthTokenStore {
+  private val tokens = mutableMapOf<String, String>()
+
+  override fun loadToken(deviceId: String, role: String): String? = tokens["${deviceId.trim()}|${role.trim()}"]?.trim()?.takeIf { it.isNotEmpty() }
+
+  override fun saveToken(deviceId: String, role: String, token: String) {
+    tokens["${deviceId.trim()}|${role.trim()}"] = token.trim()
+  }
+}
+
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class GatewaySessionInvokeTest {
@@ -84,11 +94,12 @@ class GatewaySessionInvokeTest {
 
     val app = RuntimeEnvironment.getApplication()
     val sessionJob = SupervisorJob()
+    val deviceAuthStore = InMemoryDeviceAuthStore()
     val session =
       GatewaySession(
         scope = CoroutineScope(sessionJob + Dispatchers.Default),
         identityStore = DeviceIdentityStore(app),
-        deviceAuthStore = null,
+        deviceAuthStore = deviceAuthStore,
         onConnected = { _, _, _ ->
           if (!connected.isCompleted) connected.complete(Unit)
         },
@@ -218,11 +229,12 @@ class GatewaySessionInvokeTest {
 
     val app = RuntimeEnvironment.getApplication()
     val sessionJob = SupervisorJob()
+    val deviceAuthStore = InMemoryDeviceAuthStore()
     val session =
       GatewaySession(
         scope = CoroutineScope(sessionJob + Dispatchers.Default),
         identityStore = DeviceIdentityStore(app),
-        deviceAuthStore = null,
+        deviceAuthStore = deviceAuthStore,
         onConnected = { _, _, _ ->
           if (!connected.isCompleted) connected.complete(Unit)
         },
@@ -347,11 +359,12 @@ class GatewaySessionInvokeTest {
 
     val app = RuntimeEnvironment.getApplication()
     val sessionJob = SupervisorJob()
+    val deviceAuthStore = InMemoryDeviceAuthStore()
     val session =
       GatewaySession(
         scope = CoroutineScope(sessionJob + Dispatchers.Default),
         identityStore = DeviceIdentityStore(app),
-        deviceAuthStore = null,
+        deviceAuthStore = deviceAuthStore,
         onConnected = { _, _, _ ->
           if (!connected.isCompleted) connected.complete(Unit)
         },

--- a/apps/android/app/src/test/java/org/remoteclaw/android/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/gateway/GatewaySessionInvokeTest.kt
@@ -1,0 +1,425 @@
+package org.remoteclaw.android.gateway
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.util.concurrent.atomic.AtomicReference
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class GatewaySessionInvokeTest {
+  @Test
+  fun nodeInvokeRequest_roundTripsInvokeResult() = runBlocking {
+    val json = Json { ignoreUnknownKeys = true }
+    val connected = CompletableDeferred<Unit>()
+    val invokeRequest = CompletableDeferred<GatewaySession.InvokeRequest>()
+    val invokeResultParams = CompletableDeferred<String>()
+    val lastDisconnect = AtomicReference("")
+    val server =
+      MockWebServer().apply {
+        dispatcher =
+          object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+              return MockResponse().withWebSocketUpgrade(
+                object : WebSocketListener() {
+                  override fun onOpen(webSocket: WebSocket, response: Response) {
+                    webSocket.send(
+                      """{"type":"event","event":"connect.challenge","payload":{"nonce":"android-test-nonce"}}""",
+                    )
+                  }
+
+                  override fun onMessage(webSocket: WebSocket, text: String) {
+                    val frame = json.parseToJsonElement(text).jsonObject
+                    if (frame["type"]?.jsonPrimitive?.content != "req") return
+                    val id = frame["id"]?.jsonPrimitive?.content ?: return
+                    val method = frame["method"]?.jsonPrimitive?.content ?: return
+                    when (method) {
+                      "connect" -> {
+                        webSocket.send(
+                          """{"type":"res","id":"$id","ok":true,"payload":{"snapshot":{"sessionDefaults":{"mainSessionKey":"main"}}}}""",
+                        )
+                        webSocket.send(
+                          """{"type":"event","event":"node.invoke.request","payload":{"id":"invoke-1","nodeId":"node-1","command":"debug.ping","params":{"ping":"pong"},"timeoutMs":5000}}""",
+                        )
+                      }
+                      "node.invoke.result" -> {
+                        if (!invokeResultParams.isCompleted) {
+                          invokeResultParams.complete(frame["params"]?.toString().orEmpty())
+                        }
+                        webSocket.send("""{"type":"res","id":"$id","ok":true,"payload":{"ok":true}}""")
+                        webSocket.close(1000, "done")
+                      }
+                    }
+                  }
+                },
+              )
+            }
+          }
+        start()
+      }
+
+    val app = RuntimeEnvironment.getApplication()
+    val sessionJob = SupervisorJob()
+    val session =
+      GatewaySession(
+        scope = CoroutineScope(sessionJob + Dispatchers.Default),
+        identityStore = DeviceIdentityStore(app),
+        deviceAuthStore = null,
+        onConnected = { _, _, _ ->
+          if (!connected.isCompleted) connected.complete(Unit)
+        },
+        onDisconnected = { message ->
+          lastDisconnect.set(message)
+        },
+        onEvent = { _, _ -> },
+        onInvoke = { req ->
+          if (!invokeRequest.isCompleted) invokeRequest.complete(req)
+          GatewaySession.InvokeResult.ok("""{"handled":true}""")
+        },
+      )
+
+    try {
+      session.connect(
+        endpoint =
+          GatewayEndpoint(
+            stableId = "manual|127.0.0.1|${server.port}",
+            name = "test",
+            host = "127.0.0.1",
+            port = server.port,
+            tlsEnabled = false,
+          ),
+        token = "test-token",
+        password = null,
+        options =
+          GatewayConnectOptions(
+            role = "node",
+            scopes = listOf("node:invoke"),
+            caps = emptyList(),
+            commands = emptyList(),
+            permissions = emptyMap(),
+            client =
+              GatewayClientInfo(
+                id = "openclaw-android-test",
+                displayName = "Android Test",
+                version = "1.0.0-test",
+                platform = "android",
+                mode = "node",
+                instanceId = "android-test-instance",
+                deviceFamily = "android",
+                modelIdentifier = "test",
+              ),
+          ),
+        tls = null,
+      )
+
+      val connectedWithinTimeout = withTimeoutOrNull(8_000) {
+        connected.await()
+        true
+      } == true
+      if (!connectedWithinTimeout) {
+        throw AssertionError("never connected; lastDisconnect=${lastDisconnect.get()}; requests=${server.requestCount}")
+      }
+      val req = withTimeout(8_000) { invokeRequest.await() }
+      val resultParamsJson = withTimeout(8_000) { invokeResultParams.await() }
+      val resultParams = json.parseToJsonElement(resultParamsJson).jsonObject
+
+      assertEquals("invoke-1", req.id)
+      assertEquals("node-1", req.nodeId)
+      assertEquals("debug.ping", req.command)
+      assertEquals("""{"ping":"pong"}""", req.paramsJson)
+      assertEquals("invoke-1", resultParams["id"]?.jsonPrimitive?.content)
+      assertEquals("node-1", resultParams["nodeId"]?.jsonPrimitive?.content)
+      assertEquals(true, resultParams["ok"]?.jsonPrimitive?.content?.toBooleanStrict())
+      assertEquals(
+        true,
+        resultParams["payload"]?.jsonObject?.get("handled")?.jsonPrimitive?.content?.toBooleanStrict(),
+      )
+    } finally {
+      session.disconnect()
+      sessionJob.cancelAndJoin()
+      server.shutdown()
+    }
+  }
+
+  @Test
+  fun nodeInvokeRequest_usesParamsJsonWhenProvided() = runBlocking {
+    val json = Json { ignoreUnknownKeys = true }
+    val connected = CompletableDeferred<Unit>()
+    val invokeRequest = CompletableDeferred<GatewaySession.InvokeRequest>()
+    val invokeResultParams = CompletableDeferred<String>()
+    val lastDisconnect = AtomicReference("")
+    val server =
+      MockWebServer().apply {
+        dispatcher =
+          object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+              return MockResponse().withWebSocketUpgrade(
+                object : WebSocketListener() {
+                  override fun onOpen(webSocket: WebSocket, response: Response) {
+                    webSocket.send(
+                      """{"type":"event","event":"connect.challenge","payload":{"nonce":"android-test-nonce"}}""",
+                    )
+                  }
+
+                  override fun onMessage(webSocket: WebSocket, text: String) {
+                    val frame = json.parseToJsonElement(text).jsonObject
+                    if (frame["type"]?.jsonPrimitive?.content != "req") return
+                    val id = frame["id"]?.jsonPrimitive?.content ?: return
+                    val method = frame["method"]?.jsonPrimitive?.content ?: return
+                    when (method) {
+                      "connect" -> {
+                        webSocket.send(
+                          """{"type":"res","id":"$id","ok":true,"payload":{"snapshot":{"sessionDefaults":{"mainSessionKey":"main"}}}}""",
+                        )
+                        webSocket.send(
+                          """{"type":"event","event":"node.invoke.request","payload":{"id":"invoke-2","nodeId":"node-2","command":"debug.raw","paramsJSON":"{\"raw\":true}","params":{"ignored":1},"timeoutMs":5000}}""",
+                        )
+                      }
+                      "node.invoke.result" -> {
+                        if (!invokeResultParams.isCompleted) {
+                          invokeResultParams.complete(frame["params"]?.toString().orEmpty())
+                        }
+                        webSocket.send("""{"type":"res","id":"$id","ok":true,"payload":{"ok":true}}""")
+                        webSocket.close(1000, "done")
+                      }
+                    }
+                  }
+                },
+              )
+            }
+          }
+        start()
+      }
+
+    val app = RuntimeEnvironment.getApplication()
+    val sessionJob = SupervisorJob()
+    val session =
+      GatewaySession(
+        scope = CoroutineScope(sessionJob + Dispatchers.Default),
+        identityStore = DeviceIdentityStore(app),
+        deviceAuthStore = null,
+        onConnected = { _, _, _ ->
+          if (!connected.isCompleted) connected.complete(Unit)
+        },
+        onDisconnected = { message ->
+          lastDisconnect.set(message)
+        },
+        onEvent = { _, _ -> },
+        onInvoke = { req ->
+          if (!invokeRequest.isCompleted) invokeRequest.complete(req)
+          GatewaySession.InvokeResult.ok("""{"handled":true}""")
+        },
+      )
+
+    try {
+      session.connect(
+        endpoint =
+          GatewayEndpoint(
+            stableId = "manual|127.0.0.1|${server.port}",
+            name = "test",
+            host = "127.0.0.1",
+            port = server.port,
+            tlsEnabled = false,
+          ),
+        token = "test-token",
+        password = null,
+        options =
+          GatewayConnectOptions(
+            role = "node",
+            scopes = listOf("node:invoke"),
+            caps = emptyList(),
+            commands = emptyList(),
+            permissions = emptyMap(),
+            client =
+              GatewayClientInfo(
+                id = "openclaw-android-test",
+                displayName = "Android Test",
+                version = "1.0.0-test",
+                platform = "android",
+                mode = "node",
+                instanceId = "android-test-instance",
+                deviceFamily = "android",
+                modelIdentifier = "test",
+              ),
+          ),
+        tls = null,
+      )
+
+      val connectedWithinTimeout = withTimeoutOrNull(8_000) {
+        connected.await()
+        true
+      } == true
+      if (!connectedWithinTimeout) {
+        throw AssertionError("never connected; lastDisconnect=${lastDisconnect.get()}; requests=${server.requestCount}")
+      }
+
+      val req = withTimeout(8_000) { invokeRequest.await() }
+      val resultParamsJson = withTimeout(8_000) { invokeResultParams.await() }
+      val resultParams = json.parseToJsonElement(resultParamsJson).jsonObject
+
+      assertEquals("invoke-2", req.id)
+      assertEquals("node-2", req.nodeId)
+      assertEquals("debug.raw", req.command)
+      assertEquals("""{"raw":true}""", req.paramsJson)
+      assertEquals("invoke-2", resultParams["id"]?.jsonPrimitive?.content)
+      assertEquals("node-2", resultParams["nodeId"]?.jsonPrimitive?.content)
+      assertEquals(true, resultParams["ok"]?.jsonPrimitive?.content?.toBooleanStrict())
+    } finally {
+      session.disconnect()
+      sessionJob.cancelAndJoin()
+      server.shutdown()
+    }
+  }
+
+  @Test
+  fun nodeInvokeRequest_mapsCodePrefixedErrorsIntoInvokeResult() = runBlocking {
+    val json = Json { ignoreUnknownKeys = true }
+    val connected = CompletableDeferred<Unit>()
+    val invokeResultParams = CompletableDeferred<String>()
+    val lastDisconnect = AtomicReference("")
+    val server =
+      MockWebServer().apply {
+        dispatcher =
+          object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+              return MockResponse().withWebSocketUpgrade(
+                object : WebSocketListener() {
+                  override fun onOpen(webSocket: WebSocket, response: Response) {
+                    webSocket.send(
+                      """{"type":"event","event":"connect.challenge","payload":{"nonce":"android-test-nonce"}}""",
+                    )
+                  }
+
+                  override fun onMessage(webSocket: WebSocket, text: String) {
+                    val frame = json.parseToJsonElement(text).jsonObject
+                    if (frame["type"]?.jsonPrimitive?.content != "req") return
+                    val id = frame["id"]?.jsonPrimitive?.content ?: return
+                    val method = frame["method"]?.jsonPrimitive?.content ?: return
+                    when (method) {
+                      "connect" -> {
+                        webSocket.send(
+                          """{"type":"res","id":"$id","ok":true,"payload":{"snapshot":{"sessionDefaults":{"mainSessionKey":"main"}}}}""",
+                        )
+                        webSocket.send(
+                          """{"type":"event","event":"node.invoke.request","payload":{"id":"invoke-3","nodeId":"node-3","command":"camera.snap","params":{"facing":"front"},"timeoutMs":5000}}""",
+                        )
+                      }
+                      "node.invoke.result" -> {
+                        if (!invokeResultParams.isCompleted) {
+                          invokeResultParams.complete(frame["params"]?.toString().orEmpty())
+                        }
+                        webSocket.send("""{"type":"res","id":"$id","ok":true,"payload":{"ok":true}}""")
+                        webSocket.close(1000, "done")
+                      }
+                    }
+                  }
+                },
+              )
+            }
+          }
+        start()
+      }
+
+    val app = RuntimeEnvironment.getApplication()
+    val sessionJob = SupervisorJob()
+    val session =
+      GatewaySession(
+        scope = CoroutineScope(sessionJob + Dispatchers.Default),
+        identityStore = DeviceIdentityStore(app),
+        deviceAuthStore = null,
+        onConnected = { _, _, _ ->
+          if (!connected.isCompleted) connected.complete(Unit)
+        },
+        onDisconnected = { message ->
+          lastDisconnect.set(message)
+        },
+        onEvent = { _, _ -> },
+        onInvoke = {
+          throw IllegalStateException("CAMERA_PERMISSION_REQUIRED: grant Camera permission")
+        },
+      )
+
+    try {
+      session.connect(
+        endpoint =
+          GatewayEndpoint(
+            stableId = "manual|127.0.0.1|${server.port}",
+            name = "test",
+            host = "127.0.0.1",
+            port = server.port,
+            tlsEnabled = false,
+          ),
+        token = "test-token",
+        password = null,
+        options =
+          GatewayConnectOptions(
+            role = "node",
+            scopes = listOf("node:invoke"),
+            caps = emptyList(),
+            commands = emptyList(),
+            permissions = emptyMap(),
+            client =
+              GatewayClientInfo(
+                id = "openclaw-android-test",
+                displayName = "Android Test",
+                version = "1.0.0-test",
+                platform = "android",
+                mode = "node",
+                instanceId = "android-test-instance",
+                deviceFamily = "android",
+                modelIdentifier = "test",
+              ),
+          ),
+        tls = null,
+      )
+
+      val connectedWithinTimeout = withTimeoutOrNull(8_000) {
+        connected.await()
+        true
+      } == true
+      if (!connectedWithinTimeout) {
+        throw AssertionError("never connected; lastDisconnect=${lastDisconnect.get()}; requests=${server.requestCount}")
+      }
+
+      val resultParamsJson = withTimeout(8_000) { invokeResultParams.await() }
+      val resultParams = json.parseToJsonElement(resultParamsJson).jsonObject
+
+      assertEquals("invoke-3", resultParams["id"]?.jsonPrimitive?.content)
+      assertEquals("node-3", resultParams["nodeId"]?.jsonPrimitive?.content)
+      assertEquals(false, resultParams["ok"]?.jsonPrimitive?.content?.toBooleanStrict())
+      assertEquals(
+        "CAMERA_PERMISSION_REQUIRED",
+        resultParams["error"]?.jsonObject?.get("code")?.jsonPrimitive?.content,
+      )
+      assertEquals(
+        "grant Camera permission",
+        resultParams["error"]?.jsonObject?.get("message")?.jsonPrimitive?.content,
+      )
+    } finally {
+      session.disconnect()
+      sessionJob.cancelAndJoin()
+      server.shutdown()
+    }
+  }
+}

--- a/apps/android/app/src/test/java/org/remoteclaw/android/gateway/InvokeErrorParserTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/gateway/InvokeErrorParserTest.kt
@@ -1,0 +1,33 @@
+package org.remoteclaw.android.gateway
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InvokeErrorParserTest {
+  @Test
+  fun parseInvokeErrorMessage_parsesUppercaseCodePrefix() {
+    val parsed = parseInvokeErrorMessage("CAMERA_PERMISSION_REQUIRED: grant Camera permission")
+    assertEquals("CAMERA_PERMISSION_REQUIRED", parsed.code)
+    assertEquals("grant Camera permission", parsed.message)
+    assertTrue(parsed.hadExplicitCode)
+    assertEquals("CAMERA_PERMISSION_REQUIRED: grant Camera permission", parsed.prefixedMessage)
+  }
+
+  @Test
+  fun parseInvokeErrorMessage_rejectsNonCanonicalCodePrefix() {
+    val parsed = parseInvokeErrorMessage("IllegalStateException: boom")
+    assertEquals("UNAVAILABLE", parsed.code)
+    assertEquals("IllegalStateException: boom", parsed.message)
+    assertFalse(parsed.hadExplicitCode)
+  }
+
+  @Test
+  fun parseInvokeErrorFromThrowable_usesFallbackWhenMessageMissing() {
+    val parsed = parseInvokeErrorFromThrowable(IllegalStateException(), fallbackMessage = "fallback")
+    assertEquals("UNAVAILABLE", parsed.code)
+    assertEquals("fallback", parsed.message)
+    assertFalse(parsed.hadExplicitCode)
+  }
+}

--- a/apps/android/app/src/test/java/org/remoteclaw/android/node/InvokeCommandRegistryTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/node/InvokeCommandRegistryTest.kt
@@ -1,8 +1,9 @@
 package org.remoteclaw.android.node
 
-import org.remoteclaw.android.protocol.OpenClawCameraCommand
-import org.remoteclaw.android.protocol.OpenClawLocationCommand
-import org.remoteclaw.android.protocol.OpenClawSmsCommand
+import org.remoteclaw.android.protocol.RemoteClawCameraCommand
+import org.remoteclaw.android.protocol.RemoteClawLocationCommand
+import org.remoteclaw.android.protocol.RemoteClawNotificationsCommand
+import org.remoteclaw.android.protocol.RemoteClawSmsCommand
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -18,10 +19,11 @@ class InvokeCommandRegistryTest {
         debugBuild = false,
       )
 
-    assertFalse(commands.contains(OpenClawCameraCommand.Snap.rawValue))
-    assertFalse(commands.contains(OpenClawCameraCommand.Clip.rawValue))
-    assertFalse(commands.contains(OpenClawLocationCommand.Get.rawValue))
-    assertFalse(commands.contains(OpenClawSmsCommand.Send.rawValue))
+    assertFalse(commands.contains(RemoteClawCameraCommand.Snap.rawValue))
+    assertFalse(commands.contains(RemoteClawCameraCommand.Clip.rawValue))
+    assertFalse(commands.contains(RemoteClawLocationCommand.Get.rawValue))
+    assertTrue(commands.contains(RemoteClawNotificationsCommand.List.rawValue))
+    assertFalse(commands.contains(RemoteClawSmsCommand.Send.rawValue))
     assertFalse(commands.contains("debug.logs"))
     assertFalse(commands.contains("debug.ed25519"))
     assertTrue(commands.contains("app.update"))
@@ -37,10 +39,11 @@ class InvokeCommandRegistryTest {
         debugBuild = true,
       )
 
-    assertTrue(commands.contains(OpenClawCameraCommand.Snap.rawValue))
-    assertTrue(commands.contains(OpenClawCameraCommand.Clip.rawValue))
-    assertTrue(commands.contains(OpenClawLocationCommand.Get.rawValue))
-    assertTrue(commands.contains(OpenClawSmsCommand.Send.rawValue))
+    assertTrue(commands.contains(RemoteClawCameraCommand.Snap.rawValue))
+    assertTrue(commands.contains(RemoteClawCameraCommand.Clip.rawValue))
+    assertTrue(commands.contains(RemoteClawLocationCommand.Get.rawValue))
+    assertTrue(commands.contains(RemoteClawNotificationsCommand.List.rawValue))
+    assertTrue(commands.contains(RemoteClawSmsCommand.Send.rawValue))
     assertTrue(commands.contains("debug.logs"))
     assertTrue(commands.contains("debug.ed25519"))
     assertTrue(commands.contains("app.update"))

--- a/apps/android/app/src/test/java/org/remoteclaw/android/node/InvokeCommandRegistryTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/node/InvokeCommandRegistryTest.kt
@@ -1,0 +1,48 @@
+package org.remoteclaw.android.node
+
+import org.remoteclaw.android.protocol.OpenClawCameraCommand
+import org.remoteclaw.android.protocol.OpenClawLocationCommand
+import org.remoteclaw.android.protocol.OpenClawSmsCommand
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InvokeCommandRegistryTest {
+  @Test
+  fun advertisedCommands_respectsFeatureAvailability() {
+    val commands =
+      InvokeCommandRegistry.advertisedCommands(
+        cameraEnabled = false,
+        locationEnabled = false,
+        smsAvailable = false,
+        debugBuild = false,
+      )
+
+    assertFalse(commands.contains(OpenClawCameraCommand.Snap.rawValue))
+    assertFalse(commands.contains(OpenClawCameraCommand.Clip.rawValue))
+    assertFalse(commands.contains(OpenClawLocationCommand.Get.rawValue))
+    assertFalse(commands.contains(OpenClawSmsCommand.Send.rawValue))
+    assertFalse(commands.contains("debug.logs"))
+    assertFalse(commands.contains("debug.ed25519"))
+    assertTrue(commands.contains("app.update"))
+  }
+
+  @Test
+  fun advertisedCommands_includesFeatureCommandsWhenEnabled() {
+    val commands =
+      InvokeCommandRegistry.advertisedCommands(
+        cameraEnabled = true,
+        locationEnabled = true,
+        smsAvailable = true,
+        debugBuild = true,
+      )
+
+    assertTrue(commands.contains(OpenClawCameraCommand.Snap.rawValue))
+    assertTrue(commands.contains(OpenClawCameraCommand.Clip.rawValue))
+    assertTrue(commands.contains(OpenClawLocationCommand.Get.rawValue))
+    assertTrue(commands.contains(OpenClawSmsCommand.Send.rawValue))
+    assertTrue(commands.contains("debug.logs"))
+    assertTrue(commands.contains("debug.ed25519"))
+    assertTrue(commands.contains("app.update"))
+  }
+}

--- a/apps/android/app/src/test/java/org/remoteclaw/android/node/NotificationsHandlerTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/node/NotificationsHandlerTest.kt
@@ -1,0 +1,146 @@
+package org.remoteclaw.android.node
+
+import android.content.Context
+import org.remoteclaw.android.gateway.GatewaySession
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class NotificationsHandlerTest {
+  @Test
+  fun notificationsListReturnsStatusPayloadWhenDisabled() =
+    runTest {
+      val provider =
+        FakeNotificationsStateProvider(
+          DeviceNotificationSnapshot(
+            enabled = false,
+            connected = false,
+            notifications = emptyList(),
+          ),
+        )
+      val handler = NotificationsHandler.forTesting(appContext = appContext(), stateProvider = provider)
+
+      val result = handler.handleNotificationsList(null)
+
+      assertTrue(result.ok)
+      assertNull(result.error)
+      val payload = parsePayload(result)
+      assertFalse(payload.getValue("enabled").jsonPrimitive.boolean)
+      assertFalse(payload.getValue("connected").jsonPrimitive.boolean)
+      assertEquals(0, payload.getValue("count").jsonPrimitive.int)
+      assertEquals(0, payload.getValue("notifications").jsonArray.size)
+      assertEquals(0, provider.rebindRequests)
+    }
+
+  @Test
+  fun notificationsListRequestsRebindWhenEnabledButDisconnected() =
+    runTest {
+      val provider =
+        FakeNotificationsStateProvider(
+          DeviceNotificationSnapshot(
+            enabled = true,
+            connected = false,
+            notifications = listOf(sampleEntry("n1")),
+          ),
+        )
+      val handler = NotificationsHandler.forTesting(appContext = appContext(), stateProvider = provider)
+
+      val result = handler.handleNotificationsList(null)
+
+      assertTrue(result.ok)
+      assertNull(result.error)
+      val payload = parsePayload(result)
+      assertTrue(payload.getValue("enabled").jsonPrimitive.boolean)
+      assertFalse(payload.getValue("connected").jsonPrimitive.boolean)
+      assertEquals(1, payload.getValue("count").jsonPrimitive.int)
+      assertEquals(1, payload.getValue("notifications").jsonArray.size)
+      assertEquals(1, provider.rebindRequests)
+    }
+
+  @Test
+  fun notificationsListDoesNotRequestRebindWhenConnected() =
+    runTest {
+      val provider =
+        FakeNotificationsStateProvider(
+          DeviceNotificationSnapshot(
+            enabled = true,
+            connected = true,
+            notifications = listOf(sampleEntry("n2")),
+          ),
+        )
+      val handler = NotificationsHandler.forTesting(appContext = appContext(), stateProvider = provider)
+
+      val result = handler.handleNotificationsList(null)
+
+      assertTrue(result.ok)
+      assertNull(result.error)
+      val payload = parsePayload(result)
+      assertTrue(payload.getValue("enabled").jsonPrimitive.boolean)
+      assertTrue(payload.getValue("connected").jsonPrimitive.boolean)
+      assertEquals(1, payload.getValue("count").jsonPrimitive.int)
+      assertEquals(0, provider.rebindRequests)
+    }
+
+  @Test
+  fun sanitizeNotificationTextReturnsNullForBlankInput() {
+    assertNull(sanitizeNotificationText(null))
+    assertNull(sanitizeNotificationText("    "))
+  }
+
+  @Test
+  fun sanitizeNotificationTextTrimsAndTruncates() {
+    val value = "  ${"x".repeat(600)}  "
+    val sanitized = sanitizeNotificationText(value)
+
+    assertEquals(512, sanitized?.length)
+    assertTrue((sanitized ?: "").all { it == 'x' })
+  }
+
+  private fun parsePayload(result: GatewaySession.InvokeResult): JsonObject {
+    val payloadJson = result.payloadJson ?: error("expected payload")
+    return Json.parseToJsonElement(payloadJson).jsonObject
+  }
+
+  private fun appContext(): Context = RuntimeEnvironment.getApplication()
+
+  private fun sampleEntry(key: String): DeviceNotificationEntry =
+    DeviceNotificationEntry(
+      key = key,
+      packageName = "com.example.app",
+      title = "Title",
+      text = "Text",
+      subText = null,
+      category = null,
+      channelId = null,
+      postTimeMs = 123L,
+      isOngoing = false,
+      isClearable = true,
+    )
+}
+
+private class FakeNotificationsStateProvider(
+  private val snapshot: DeviceNotificationSnapshot,
+) : NotificationsStateProvider {
+  var rebindRequests: Int = 0
+    private set
+
+  override fun readSnapshot(context: Context): DeviceNotificationSnapshot = snapshot
+
+  override fun requestServiceRebind(context: Context) {
+    rebindRequests += 1
+  }
+}

--- a/apps/android/app/src/test/java/org/remoteclaw/android/protocol/RemoteClawProtocolConstantsTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/protocol/RemoteClawProtocolConstantsTest.kt
@@ -32,4 +32,9 @@ class RemoteClawProtocolConstantsTest {
   fun screenCommandsUseStableStrings() {
     assertEquals("screen.record", RemoteClawScreenCommand.Record.rawValue)
   }
+
+  @Test
+  fun notificationsCommandsUseStableStrings() {
+    assertEquals("notifications.list", RemoteClawNotificationsCommand.List.rawValue)
+  }
 }


### PR DESCRIPTION
## Summary

Cherry-pick of 11 upstream Android commits for invoke dispatcher unification, gateway session fixes, and notifications.list node command.

### Commits applied

| # | Hash | Subject | Type |
|---|------|---------|------|
| 1 | `d4ae8a8d34` | test(android): cover invoke paramsJSON and error mapping | FAST-PICK |
| 2 | `18fc4c113b` | refactor(android): centralize invoke command registry | FAST-PICK |
| 3 | `39d362aeff` | refactor(android): distill invoke dispatcher command flow | FAST-PICK |
| 4 | `c3f54fcddd` | refactor(android): unify invoke error parsing | FAST-PICK |
| 5 | `f7865527af` | fix(android): omit websocket Origin for native gateway connect | FAST-PICK |
| 6 | `a87d961ebc` | fix(android): require gateway device auth store | FAST-PICK |
| 7 | `ac6539ed03` | refactor(android): unify invoke availability gating | FAST-PICK |
| 8 | `05817187fe` | refactor(android): unify notifications.list status flow | FAST-PICK |
| 9 | `bee0c564cf` | test(android): add GatewaySession invoke roundtrip test | AUTO-PICK |
| 10 | `cf4fe41957` | feat(android): add notifications.list node command | AUTO-PICK |
| 11 | `8117a13dd6` | fix(nodes): default camera snap to front high-quality image | PARTIAL-PICK |

### Adaptation notes

- All files placed at rebranded `org.remoteclaw.android` paths (fork rebrand from `ai.openclaw.android`)
- Protocol types rebranded: `OpenClaw*Command` → `RemoteClaw*Command`
- `DeviceNotificationListenerService`, `NotificationsHandler`, `GatewaySessionInvokeTest` created from full upstream versions (didn't exist in fork, created upstream post-fork)
- Commit 9 (`bee0c564cf`): test content already included from commit 1; only mockwebserver dependency added
- Commit 11 (`8117a13dd6`): Android files only — dropped `src/agents/` changes per issue notes
- User-facing "OpenClaw" → "RemoteClaw" in notification settings error message

Closes #605