### PR TITLE
Cherry-pick: Gateway, Nodes, Protocol & Agent Routing (6 commits)

### DIFF
--- a/apps/macos/Sources/RemoteClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/RemoteClawProtocol/GatewayModels.swift
@@ -2781,6 +2781,7 @@ public struct ExecApprovalsSnapshot: Codable, Sendable {
 public struct ExecApprovalRequestParams: Codable, Sendable {
     public let id: String?
     public let command: String
+    public let commandargv: [String]?
     public let cwd: AnyCodable?
     public let nodeid: AnyCodable?
     public let host: AnyCodable?
@@ -2795,6 +2796,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public init(
         id: String?,
         command: String,
+        commandargv: [String]?,
         cwd: AnyCodable?,
         nodeid: AnyCodable?,
         host: AnyCodable?,
@@ -2808,6 +2810,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     {
         self.id = id
         self.command = command
+        self.commandargv = commandargv
         self.cwd = cwd
         self.nodeid = nodeid
         self.host = host
@@ -2823,6 +2826,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case id
         case command
+        case commandargv = "commandArgv"
         case cwd
         case nodeid = "nodeId"
         case host

--- a/apps/shared/RemoteClawKit/Sources/RemoteClawProtocol/GatewayModels.swift
+++ b/apps/shared/RemoteClawKit/Sources/RemoteClawProtocol/GatewayModels.swift
@@ -2781,6 +2781,7 @@ public struct ExecApprovalsSnapshot: Codable, Sendable {
 public struct ExecApprovalRequestParams: Codable, Sendable {
     public let id: String?
     public let command: String
+    public let commandargv: [String]?
     public let cwd: AnyCodable?
     public let nodeid: AnyCodable?
     public let host: AnyCodable?
@@ -2795,6 +2796,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public init(
         id: String?,
         command: String,
+        commandargv: [String]?,
         cwd: AnyCodable?,
         nodeid: AnyCodable?,
         host: AnyCodable?,
@@ -2808,6 +2810,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     {
         self.id = id
         self.command = command
+        self.commandargv = commandargv
         self.cwd = cwd
         self.nodeid = nodeid
         self.host = host
@@ -2823,6 +2826,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case id
         case command
+        case commandargv = "commandArgv"
         case cwd
         case nodeid = "nodeId"
         case host

--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -1,5 +1,5 @@
 ---
-description: "CLI reference for `remoteclaw agents` (list/add/delete/set identity)"
+description: "CLI reference for `remoteclaw agents` (list/add/delete/bindings/bind/unbind/set identity)"
 read_when:
   - You want multiple isolated agents (workspaces + routing + auth)
 title: "agents"
@@ -19,8 +19,56 @@ Related:
 ```bash
 remoteclaw agents list
 remoteclaw agents add work --workspace ~/.remoteclaw/workspace-work
+remoteclaw agents bindings
+remoteclaw agents bind --agent work --bind telegram:ops
+remoteclaw agents unbind --agent work --bind telegram:ops
 remoteclaw agents set-identity --agent main --avatar avatars/remoteclaw.png
 remoteclaw agents delete work
+```
+
+## Routing bindings
+
+Use routing bindings to pin inbound channel traffic to a specific agent.
+
+List bindings:
+
+```bash
+remoteclaw agents bindings
+remoteclaw agents bindings --agent work
+remoteclaw agents bindings --json
+```
+
+Add bindings:
+
+```bash
+remoteclaw agents bind --agent work --bind telegram:ops --bind discord:guild-a
+```
+
+If you omit `accountId` (`--bind <channel>`), RemoteClaw resolves it from channel defaults and plugin setup hooks when available.
+
+### Binding scope behavior
+
+- A binding without `accountId` matches the channel default account only.
+- `accountId: "*"` is the channel-wide fallback (all accounts) and is less specific than an explicit account binding.
+- If the same agent already has a matching channel binding without `accountId`, and you later bind with an explicit or resolved `accountId`, RemoteClaw upgrades that existing binding in place instead of adding a duplicate.
+
+Example:
+
+```bash
+# initial channel-only binding
+remoteclaw agents bind --agent work --bind telegram
+
+# later upgrade to account-scoped binding
+remoteclaw agents bind --agent work --bind telegram:ops
+```
+
+After the upgrade, routing for that binding is scoped to `telegram:ops`. If you also want default-account routing, add it explicitly (for example `--bind telegram:default`).
+
+Remove bindings:
+
+```bash
+remoteclaw agents unbind --agent work --bind telegram:ops
+remoteclaw agents unbind --agent work --all
 ```
 
 ## Set identity

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -35,6 +35,16 @@ remoteclaw channels remove --channel telegram --delete
 
 Tip: `remoteclaw channels add --help` shows per-channel flags (token, app token, signal-cli paths, etc).
 
+When you run `remoteclaw channels add` without flags, the interactive wizard can prompt:
+
+- account ids per selected channel
+- optional display names for those accounts
+- `Bind configured channel accounts to agents now?`
+
+If you confirm bind now, the wizard asks which agent should own each configured channel account and writes account-scoped routing bindings.
+
+You can also manage the same routing rules later with `remoteclaw agents bindings`, `remoteclaw agents bind`, and `remoteclaw agents unbind` (see [agents](/cli/agents)).
+
 When you add a non-default account to a channel that is still using single-account top-level settings (no `channels.<channel>.accounts` entries yet), RemoteClaw moves account-scoped single-account top-level values into `channels.<channel>.accounts.default`, then writes the new account. This preserves the original account behavior while moving to the multi-account shape.
 
 Routing behavior stays consistent:

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -517,7 +517,37 @@ Options:
 - `--non-interactive`
 - `--json`
 
-Binding specs use `channel[:accountId]`. When `accountId` is omitted for WhatsApp, the default account id is used.
+Binding specs use `channel[:accountId]`. When `accountId` is omitted, RemoteClaw may resolve account scope via channel defaults/plugin hooks; otherwise it is a channel binding without explicit account scope.
+
+#### `agents bindings`
+
+List routing bindings.
+
+Options:
+
+- `--agent <id>`
+- `--json`
+
+#### `agents bind`
+
+Add routing bindings for an agent.
+
+Options:
+
+- `--agent <id>`
+- `--bind <channel[:accountId]>` (repeatable)
+- `--json`
+
+#### `agents unbind`
+
+Remove routing bindings for an agent.
+
+Options:
+
+- `--agent <id>`
+- `--bind <channel[:accountId]>` (repeatable)
+- `--all`
+- `--json`
 
 #### `agents delete <id>`
 

--- a/docs/concepts/multi-agent.mdx
+++ b/docs/concepts/multi-agent.mdx
@@ -180,6 +180,12 @@ Bindings are **deterministic** and **most-specific wins**:
 If multiple bindings match in the same tier, the first one in config order wins.
 If a binding sets multiple match fields (for example `peer` + `guildId`), all specified fields are required (`AND` semantics).
 
+Important account-scope detail:
+
+- A binding that omits `accountId` matches the default account only.
+- Use `accountId: "*"` for a channel-wide fallback across all accounts.
+- If you later add the same binding for the same agent with an explicit account id, RemoteClaw upgrades the existing channel-only binding to account-scoped instead of duplicating it.
+
 ## Multiple accounts / phone numbers
 
 Channels that support **multiple accounts** (e.g. WhatsApp) use `accountId` to identify

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -429,4 +429,4 @@ Only enable direct mutable name/email/nick matching with each channel's `dangero
 - If you set `dmPolicy: "open"`, the matching `allowFrom` list must include `"*"`.
 - Provider IDs differ (phone numbers, user IDs, channel IDs). Use the provider docs to confirm the format.
 - Optional sections to add later: `web`, `browser`, `ui`, `discovery`, `canvasHost`, `talk`, `signal`, `imessage`.
-- See [Providers](/channels/whatsapp) and [Troubleshooting](/gateway/troubleshooting) for deeper setup notes.
+- See [Providers](/providers) and [Troubleshooting](/gateway/troubleshooting) for deeper setup notes.

--- a/src/agents/remoteclaw-tools.camera.test.ts
+++ b/src/agents/remoteclaw-tools.camera.test.ts
@@ -103,6 +103,42 @@ describe("nodes camera_snap", () => {
   });
 });
 
+describe("nodes notifications_list", () => {
+  it("invokes notifications.list and returns payload", async () => {
+    callGateway.mockImplementation(async ({ method, params }) => {
+      if (method === "node.list") {
+        return mockNodeList(["notifications.list"]);
+      }
+      if (method === "node.invoke") {
+        expect(params).toMatchObject({
+          nodeId: NODE_ID,
+          command: "notifications.list",
+          params: {},
+        });
+        return {
+          payload: {
+            enabled: true,
+            connected: true,
+            count: 1,
+            notifications: [{ key: "n1", packageName: "com.example.app" }],
+          },
+        };
+      }
+      return unexpectedGatewayMethod(method);
+    });
+
+    const result = await executeNodes({
+      action: "notifications_list",
+      node: NODE_ID,
+    });
+
+    expect(result.content?.[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining('"notifications"'),
+    });
+  });
+});
+
 describe("nodes run", () => {
   it("passes invoke and command timeouts", async () => {
     callGateway.mockImplementation(async ({ method, params }) => {

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -39,6 +39,7 @@ const NODES_TOOL_ACTIONS = [
   "camera_clip",
   "screen_record",
   "location_get",
+  "notifications_list",
   "run",
   "invoke",
 ] as const;
@@ -121,7 +122,7 @@ export function createNodesTool(options?: {
     label: "Nodes",
     name: "nodes",
     description:
-      "Discover and control paired nodes (status/describe/pairing/notify/camera/screen/location/run/invoke).",
+      "Discover and control paired nodes (status/describe/pairing/notify/camera/screen/location/notifications/run/invoke).",
     parameters: NodesToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args;
@@ -401,6 +402,17 @@ export function createNodesTool(options?: {
                 desiredAccuracy,
                 timeoutMs: locationTimeoutMs,
               },
+              idempotencyKey: crypto.randomUUID(),
+            });
+            return jsonResult(raw?.payload ?? {});
+          }
+          case "notifications_list": {
+            const node = readStringParam(params, "node", { required: true });
+            const nodeId = await resolveNodeId(gatewayOpts, node);
+            const raw = await callGatewayTool<{ payload: unknown }>("node.invoke", gatewayOpts, {
+              nodeId,
+              command: "notifications.list",
+              params: {},
               idempotencyKey: crypto.randomUUID(),
             });
             return jsonResult(raw?.payload ?? {});

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -48,6 +48,23 @@ const NOTIFY_PRIORITIES = ["passive", "active", "timeSensitive"] as const;
 const NOTIFY_DELIVERIES = ["system", "overlay", "auto"] as const;
 const CAMERA_FACING = ["front", "back", "both"] as const;
 const LOCATION_ACCURACY = ["coarse", "balanced", "precise"] as const;
+type GatewayCallOptions = ReturnType<typeof readGatewayCallOptions>;
+
+async function invokeNodeCommandPayload(params: {
+  gatewayOpts: GatewayCallOptions;
+  node: string;
+  command: string;
+  commandParams?: Record<string, unknown>;
+}): Promise<unknown> {
+  const nodeId = await resolveNodeId(params.gatewayOpts, params.node);
+  const raw = await callGatewayTool<{ payload: unknown }>("node.invoke", params.gatewayOpts, {
+    nodeId,
+    command: params.command,
+    params: params.commandParams ?? {},
+    idempotencyKey: crypto.randomUUID(),
+  });
+  return raw?.payload ?? {};
+}
 
 function isPairingRequiredMessage(message: string): boolean {
   const lower = message.toLowerCase();
@@ -272,15 +289,13 @@ export function createNodesTool(options?: {
           }
           case "camera_list": {
             const node = readStringParam(params, "node", { required: true });
-            const nodeId = await resolveNodeId(gatewayOpts, node);
-            const raw = await callGatewayTool<{ payload: unknown }>("node.invoke", gatewayOpts, {
-              nodeId,
+            const payloadRaw = await invokeNodeCommandPayload({
+              gatewayOpts,
+              node,
               command: "camera.list",
-              params: {},
-              idempotencyKey: crypto.randomUUID(),
             });
             const payload =
-              raw && typeof raw.payload === "object" && raw.payload !== null ? raw.payload : {};
+              payloadRaw && typeof payloadRaw === "object" && payloadRaw !== null ? payloadRaw : {};
             return jsonResult(payload);
           }
           case "camera_clip": {
@@ -378,7 +393,6 @@ export function createNodesTool(options?: {
           }
           case "location_get": {
             const node = readStringParam(params, "node", { required: true });
-            const nodeId = await resolveNodeId(gatewayOpts, node);
             const maxAgeMs =
               typeof params.maxAgeMs === "number" && Number.isFinite(params.maxAgeMs)
                 ? params.maxAgeMs
@@ -394,28 +408,26 @@ export function createNodesTool(options?: {
               Number.isFinite(params.locationTimeoutMs)
                 ? params.locationTimeoutMs
                 : undefined;
-            const raw = await callGatewayTool<{ payload: unknown }>("node.invoke", gatewayOpts, {
-              nodeId,
+            const payload = await invokeNodeCommandPayload({
+              gatewayOpts,
+              node,
               command: "location.get",
-              params: {
+              commandParams: {
                 maxAgeMs,
                 desiredAccuracy,
                 timeoutMs: locationTimeoutMs,
               },
-              idempotencyKey: crypto.randomUUID(),
             });
-            return jsonResult(raw?.payload ?? {});
+            return jsonResult(payload);
           }
           case "notifications_list": {
             const node = readStringParam(params, "node", { required: true });
-            const nodeId = await resolveNodeId(gatewayOpts, node);
-            const raw = await callGatewayTool<{ payload: unknown }>("node.invoke", gatewayOpts, {
-              nodeId,
+            const payload = await invokeNodeCommandPayload({
+              gatewayOpts,
+              node,
               command: "notifications.list",
-              params: {},
-              idempotencyKey: crypto.randomUUID(),
             });
-            return jsonResult(raw?.payload ?? {});
+            return jsonResult(payload);
           }
           case "run": {
             const node = readStringParam(params, "node", { required: true });

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -21,7 +21,16 @@ import type {
 } from "./types.core.js";
 
 export type ChannelSetupAdapter = {
-  resolveAccountId?: (params: { cfg: RemoteClawConfig; accountId?: string }) => string;
+  resolveAccountId?: (params: {
+    cfg: RemoteClawConfig;
+    accountId?: string;
+    input?: ChannelSetupInput;
+  }) => string;
+  resolveBindingAccountId?: (params: {
+    cfg: RemoteClawConfig;
+    agentId: string;
+    accountId?: string;
+  }) => string | undefined;
   applyAccountName?: (params: {
     cfg: RemoteClawConfig;
     accountId: string;

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -80,6 +80,7 @@ describe("registerPreActionHooks", () => {
     program.command("update").action(async () => {});
     program.command("channels").action(async () => {});
     program.command("directory").action(async () => {});
+    program.command("agents").action(async () => {});
     program.command("configure").action(async () => {});
     program.command("onboard").action(async () => {});
     program
@@ -140,6 +141,15 @@ describe("registerPreActionHooks", () => {
     await runCommand({
       parseArgv: ["onboard"],
       processArgv: ["node", "remoteclaw", "onboard"],
+    });
+
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads plugin registry for agents command", async () => {
+    await runCommand({
+      parseArgv: ["agents"],
+      processArgv: ["node", "remoteclaw", "agents"],
     });
 
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -25,6 +25,7 @@ const PLUGIN_REQUIRED_COMMANDS = new Set([
   "message",
   "channels",
   "directory",
+  "agents",
   "configure",
   "onboard",
 ]);

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -2,9 +2,12 @@ import type { Command } from "commander";
 import { agentCliCommand } from "../../commands/agent-via-gateway.js";
 import {
   agentsAddCommand,
+  agentsBindingsCommand,
+  agentsBindCommand,
   agentsDeleteCommand,
   agentsListCommand,
   agentsSetIdentityCommand,
+  agentsUnbindCommand,
 } from "../../commands/agents.js";
 import { setVerbose } from "../../globals.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -97,6 +100,68 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.remoteclaw.org/cli/
       await runCommandWithRuntime(defaultRuntime, async () => {
         await agentsListCommand(
           { json: Boolean(opts.json), bindings: Boolean(opts.bindings) },
+          defaultRuntime,
+        );
+      });
+    });
+
+  agents
+    .command("bindings")
+    .description("List routing bindings")
+    .option("--agent <id>", "Filter by agent id")
+    .option("--json", "Output JSON instead of text", false)
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await agentsBindingsCommand(
+          {
+            agent: opts.agent as string | undefined,
+            json: Boolean(opts.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  agents
+    .command("bind")
+    .description("Add routing bindings for an agent")
+    .option("--agent <id>", "Agent id (defaults to current default agent)")
+    .option(
+      "--bind <channel[:accountId]>",
+      "Binding to add (repeatable). If omitted, accountId is resolved by channel defaults/hooks.",
+      collectOption,
+      [],
+    )
+    .option("--json", "Output JSON summary", false)
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await agentsBindCommand(
+          {
+            agent: opts.agent as string | undefined,
+            bind: Array.isArray(opts.bind) ? (opts.bind as string[]) : undefined,
+            json: Boolean(opts.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  agents
+    .command("unbind")
+    .description("Remove routing bindings for an agent")
+    .option("--agent <id>", "Agent id (defaults to current default agent)")
+    .option("--bind <channel[:accountId]>", "Binding to remove (repeatable)", collectOption, [])
+    .option("--all", "Remove all bindings for this agent", false)
+    .option("--json", "Output JSON summary", false)
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await agentsUnbindCommand(
+          {
+            agent: opts.agent as string | undefined,
+            bind: Array.isArray(opts.bind) ? (opts.bind as string[]) : undefined,
+            all: Boolean(opts.all),
+            json: Boolean(opts.json),
+          },
           defaultRuntime,
         );
       });

--- a/src/commands/agents.bind.commands.test.ts
+++ b/src/commands/agents.bind.commands.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
+
+const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
+const writeConfigFileMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/config.js")>()),
+  readConfigFileSnapshot: readConfigFileSnapshotMock,
+  writeConfigFile: writeConfigFileMock,
+}));
+
+vi.mock("../channels/plugins/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../channels/plugins/index.js")>();
+  return {
+    ...actual,
+    getChannelPlugin: (channel: string) => {
+      if (channel === "matrix-js") {
+        return {
+          id: "matrix-js",
+          setup: {
+            resolveBindingAccountId: ({ agentId }: { agentId: string }) => agentId.toLowerCase(),
+          },
+        };
+      }
+      return actual.getChannelPlugin(channel);
+    },
+    normalizeChannelId: (channel: string) => {
+      if (channel.trim().toLowerCase() === "matrix-js") {
+        return "matrix-js";
+      }
+      return actual.normalizeChannelId(channel);
+    },
+  };
+});
+
+import { agentsBindCommand, agentsBindingsCommand, agentsUnbindCommand } from "./agents.js";
+
+const runtime = createTestRuntime();
+
+describe("agents bind/unbind commands", () => {
+  beforeEach(() => {
+    readConfigFileSnapshotMock.mockClear();
+    writeConfigFileMock.mockClear();
+    runtime.log.mockClear();
+    runtime.error.mockClear();
+    runtime.exit.mockClear();
+  });
+
+  it("lists all bindings by default", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        bindings: [
+          { agentId: "main", match: { channel: "matrix-js" } },
+          { agentId: "ops", match: { channel: "telegram", accountId: "work" } },
+        ],
+      },
+    });
+
+    await agentsBindingsCommand({}, runtime);
+
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("main <- matrix-js"));
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("ops <- telegram accountId=work"),
+    );
+  });
+
+  it("binds routes to default agent when --agent is omitted", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {},
+    });
+
+    await agentsBindCommand({ bind: ["telegram"] }, runtime);
+
+    expect(writeConfigFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bindings: [{ agentId: "main", match: { channel: "telegram" } }],
+      }),
+    );
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("defaults matrix-js accountId to the target agent id when omitted", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {},
+    });
+
+    await agentsBindCommand({ agent: "main", bind: ["matrix-js"] }, runtime);
+
+    expect(writeConfigFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bindings: [{ agentId: "main", match: { channel: "matrix-js", accountId: "main" } }],
+      }),
+    );
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("upgrades existing channel-only binding when accountId is later provided", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        bindings: [{ agentId: "main", match: { channel: "telegram" } }],
+      },
+    });
+
+    await agentsBindCommand({ bind: ["telegram:work"] }, runtime);
+
+    expect(writeConfigFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bindings: [{ agentId: "main", match: { channel: "telegram", accountId: "work" } }],
+      }),
+    );
+    expect(runtime.log).toHaveBeenCalledWith("Updated bindings:");
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("unbinds all routes for an agent", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        agents: { list: [{ id: "ops", workspace: "/tmp/ops" }] },
+        bindings: [
+          { agentId: "main", match: { channel: "matrix-js" } },
+          { agentId: "ops", match: { channel: "telegram", accountId: "work" } },
+        ],
+      },
+    });
+
+    await agentsUnbindCommand({ agent: "ops", all: true }, runtime);
+
+    expect(writeConfigFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bindings: [{ agentId: "main", match: { channel: "matrix-js" } }],
+      }),
+    );
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("reports ownership conflicts during unbind and exits 1", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        agents: { list: [{ id: "ops", workspace: "/tmp/ops" }] },
+        bindings: [{ agentId: "main", match: { channel: "telegram", accountId: "ops" } }],
+      },
+    });
+
+    await agentsUnbindCommand({ agent: "ops", bind: ["telegram:ops"] }, runtime);
+
+    expect(writeConfigFileMock).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith("Bindings are owned by another agent:");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("keeps role-based bindings when removing channel-level discord binding", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        bindings: [
+          {
+            agentId: "main",
+            match: {
+              channel: "discord",
+              accountId: "guild-a",
+              roles: ["111", "222"],
+            },
+          },
+          {
+            agentId: "main",
+            match: {
+              channel: "discord",
+              accountId: "guild-a",
+            },
+          },
+        ],
+      },
+    });
+
+    await agentsUnbindCommand({ bind: ["discord:guild-a"] }, runtime);
+
+    expect(writeConfigFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bindings: [
+          {
+            agentId: "main",
+            match: {
+              channel: "discord",
+              accountId: "guild-a",
+              roles: ["111", "222"],
+            },
+          },
+        ],
+      }),
+    );
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/agents.bind.commands.test.ts
+++ b/src/commands/agents.bind.commands.test.ts
@@ -69,7 +69,7 @@ describe("agents bind/unbind commands", () => {
   it("binds routes to default agent when --agent is omitted", async () => {
     readConfigFileSnapshotMock.mockResolvedValue({
       ...baseConfigSnapshot,
-      config: {},
+      config: { agents: { list: [{ id: "main", workspace: "/tmp/main" }] } },
     });
 
     await agentsBindCommand({ bind: ["telegram"] }, runtime);
@@ -85,7 +85,7 @@ describe("agents bind/unbind commands", () => {
   it("defaults matrix-js accountId to the target agent id when omitted", async () => {
     readConfigFileSnapshotMock.mockResolvedValue({
       ...baseConfigSnapshot,
-      config: {},
+      config: { agents: { list: [{ id: "main", workspace: "/tmp/main" }] } },
     });
 
     await agentsBindCommand({ agent: "main", bind: ["matrix-js"] }, runtime);
@@ -102,6 +102,7 @@ describe("agents bind/unbind commands", () => {
     readConfigFileSnapshotMock.mockResolvedValue({
       ...baseConfigSnapshot,
       config: {
+        agents: { list: [{ id: "main", workspace: "/tmp/main" }] },
         bindings: [{ agentId: "main", match: { channel: "telegram" } }],
       },
     });
@@ -159,6 +160,7 @@ describe("agents bind/unbind commands", () => {
     readConfigFileSnapshotMock.mockResolvedValue({
       ...baseConfigSnapshot,
       config: {
+        agents: { list: [{ id: "main", workspace: "/tmp/main" }] },
         bindings: [
           {
             agentId: "main",

--- a/src/commands/agents.bindings.ts
+++ b/src/commands/agents.bindings.ts
@@ -8,14 +8,49 @@ import type { ChannelChoice } from "./onboard-types.js";
 
 function bindingMatchKey(match: AgentBinding["match"]) {
   const accountId = match.accountId?.trim() || DEFAULT_ACCOUNT_ID;
+  const identityKey = bindingMatchIdentityKey(match);
+  return [identityKey, accountId].join("|");
+}
+
+function bindingMatchIdentityKey(match: AgentBinding["match"]) {
+  const roles = Array.isArray(match.roles)
+    ? Array.from(
+        new Set(
+          match.roles
+            .map((role) => role.trim())
+            .filter(Boolean)
+            .toSorted(),
+        ),
+      )
+    : [];
   return [
     match.channel,
-    accountId,
     match.peer?.kind ?? "",
     match.peer?.id ?? "",
     match.guildId ?? "",
     match.teamId ?? "",
+    roles.join(","),
   ].join("|");
+}
+
+function canUpgradeBindingAccountScope(params: {
+  existing: AgentBinding;
+  incoming: AgentBinding;
+  normalizedIncomingAgentId: string;
+}): boolean {
+  if (!params.incoming.match.accountId?.trim()) {
+    return false;
+  }
+  if (params.existing.match.accountId?.trim()) {
+    return false;
+  }
+  if (normalizeAgentId(params.existing.agentId) !== params.normalizedIncomingAgentId) {
+    return false;
+  }
+  return (
+    bindingMatchIdentityKey(params.existing.match) ===
+    bindingMatchIdentityKey(params.incoming.match)
+  );
 }
 
 export function describeBinding(binding: AgentBinding) {
@@ -42,10 +77,11 @@ export function applyAgentBindings(
 ): {
   config: RemoteClawConfig;
   added: AgentBinding[];
+  updated: AgentBinding[];
   skipped: AgentBinding[];
   conflicts: Array<{ binding: AgentBinding; existingAgentId: string }>;
 } {
-  const existing = cfg.bindings ?? [];
+  const existing = [...(cfg.bindings ?? [])];
   const existingMatchMap = new Map<string, string>();
   for (const binding of existing) {
     const key = bindingMatchKey(binding.match);
@@ -55,6 +91,7 @@ export function applyAgentBindings(
   }
 
   const added: AgentBinding[] = [];
+  const updated: AgentBinding[] = [];
   const skipped: AgentBinding[] = [];
   const conflicts: Array<{ binding: AgentBinding; existingAgentId: string }> = [];
 
@@ -70,12 +107,41 @@ export function applyAgentBindings(
       }
       continue;
     }
+
+    const upgradeIndex = existing.findIndex((candidate) =>
+      canUpgradeBindingAccountScope({
+        existing: candidate,
+        incoming: binding,
+        normalizedIncomingAgentId: agentId,
+      }),
+    );
+    if (upgradeIndex >= 0) {
+      const current = existing[upgradeIndex];
+      if (!current) {
+        continue;
+      }
+      const previousKey = bindingMatchKey(current.match);
+      const upgradedBinding: AgentBinding = {
+        ...current,
+        agentId,
+        match: {
+          ...current.match,
+          accountId: binding.match.accountId?.trim(),
+        },
+      };
+      existing[upgradeIndex] = upgradedBinding;
+      existingMatchMap.delete(previousKey);
+      existingMatchMap.set(bindingMatchKey(upgradedBinding.match), agentId);
+      updated.push(upgradedBinding);
+      continue;
+    }
+
     existingMatchMap.set(key, agentId);
     added.push({ ...binding, agentId });
   }
 
-  if (added.length === 0) {
-    return { config: cfg, added, skipped, conflicts };
+  if (added.length === 0 && updated.length === 0) {
+    return { config: cfg, added, updated, skipped, conflicts };
   }
 
   return {
@@ -84,7 +150,74 @@ export function applyAgentBindings(
       bindings: [...existing, ...added],
     },
     added,
+    updated,
     skipped,
+    conflicts,
+  };
+}
+
+export function removeAgentBindings(
+  cfg: RemoteClawConfig,
+  bindings: AgentBinding[],
+): {
+  config: RemoteClawConfig;
+  removed: AgentBinding[];
+  missing: AgentBinding[];
+  conflicts: Array<{ binding: AgentBinding; existingAgentId: string }>;
+} {
+  const existing = cfg.bindings ?? [];
+  const removeIndexes = new Set<number>();
+  const removed: AgentBinding[] = [];
+  const missing: AgentBinding[] = [];
+  const conflicts: Array<{ binding: AgentBinding; existingAgentId: string }> = [];
+
+  for (const binding of bindings) {
+    const desiredAgentId = normalizeAgentId(binding.agentId);
+    const key = bindingMatchKey(binding.match);
+    let matchedIndex = -1;
+    let conflictingAgentId: string | null = null;
+    for (let i = 0; i < existing.length; i += 1) {
+      if (removeIndexes.has(i)) {
+        continue;
+      }
+      const current = existing[i];
+      if (!current || bindingMatchKey(current.match) !== key) {
+        continue;
+      }
+      const currentAgentId = normalizeAgentId(current.agentId);
+      if (currentAgentId === desiredAgentId) {
+        matchedIndex = i;
+        break;
+      }
+      conflictingAgentId = currentAgentId;
+    }
+    if (matchedIndex >= 0) {
+      const matched = existing[matchedIndex];
+      if (matched) {
+        removeIndexes.add(matchedIndex);
+        removed.push(matched);
+      }
+      continue;
+    }
+    if (conflictingAgentId) {
+      conflicts.push({ binding, existingAgentId: conflictingAgentId });
+      continue;
+    }
+    missing.push(binding);
+  }
+
+  if (removeIndexes.size === 0) {
+    return { config: cfg, removed, missing, conflicts };
+  }
+
+  const nextBindings = existing.filter((_, index) => !removeIndexes.has(index));
+  return {
+    config: {
+      ...cfg,
+      bindings: nextBindings.length > 0 ? nextBindings : undefined,
+    },
+    removed,
+    missing,
     conflicts,
   };
 }
@@ -97,6 +230,33 @@ function resolveDefaultAccountId(cfg: RemoteClawConfig, provider: ChannelId): st
   return resolveChannelDefaultAccountId({ plugin, cfg });
 }
 
+function resolveBindingAccountId(params: {
+  channel: ChannelId;
+  config: RemoteClawConfig;
+  agentId: string;
+  explicitAccountId?: string;
+}): string | undefined {
+  const explicitAccountId = params.explicitAccountId?.trim();
+  if (explicitAccountId) {
+    return explicitAccountId;
+  }
+
+  const plugin = getChannelPlugin(params.channel);
+  const pluginAccountId = plugin?.setup?.resolveBindingAccountId?.({
+    cfg: params.config,
+    agentId: params.agentId,
+  });
+  if (pluginAccountId?.trim()) {
+    return pluginAccountId.trim();
+  }
+
+  if (plugin?.meta.forceAccountBinding) {
+    return resolveDefaultAccountId(params.config, params.channel);
+  }
+
+  return undefined;
+}
+
 export function buildChannelBindings(params: {
   agentId: string;
   selection: ChannelChoice[];
@@ -107,14 +267,14 @@ export function buildChannelBindings(params: {
   const agentId = normalizeAgentId(params.agentId);
   for (const channel of params.selection) {
     const match: AgentBinding["match"] = { channel };
-    const accountId = params.accountIds?.[channel]?.trim();
+    const accountId = resolveBindingAccountId({
+      channel,
+      config: params.config,
+      agentId,
+      explicitAccountId: params.accountIds?.[channel],
+    });
     if (accountId) {
       match.accountId = accountId;
-    } else {
-      const plugin = getChannelPlugin(channel);
-      if (plugin?.meta.forceAccountBinding) {
-        match.accountId = resolveDefaultAccountId(params.config, channel);
-      }
     }
     bindings.push({ agentId, match });
   }
@@ -141,17 +301,17 @@ export function parseBindingSpecs(params: {
       errors.push(`Unknown channel "${channelRaw}".`);
       continue;
     }
-    let accountId = accountRaw?.trim();
+    let accountId: string | undefined = accountRaw?.trim();
     if (accountRaw !== undefined && !accountId) {
       errors.push(`Invalid binding "${trimmed}" (empty account id).`);
       continue;
     }
-    if (!accountId) {
-      const plugin = getChannelPlugin(channel);
-      if (plugin?.meta.forceAccountBinding) {
-        accountId = resolveDefaultAccountId(params.config, channel);
-      }
-    }
+    accountId = resolveBindingAccountId({
+      channel,
+      config: params.config,
+      agentId,
+      explicitAccountId: accountId,
+    });
     const match: AgentBinding["match"] = { channel };
     if (accountId) {
       match.accountId = accountId;

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -107,7 +107,7 @@ export async function agentsAddCommand(
     const bindingResult =
       bindingParse.bindings.length > 0
         ? applyAgentBindings(nextConfig, bindingParse.bindings)
-        : { config: nextConfig, added: [], skipped: [], conflicts: [] };
+        : { config: nextConfig, added: [], updated: [], skipped: [], conflicts: [] };
 
     await writeConfigFile(bindingResult.config);
     if (!opts.json) {
@@ -126,6 +126,7 @@ export async function agentsAddCommand(
       model,
       bindings: {
         added: bindingResult.added.map(describeBinding),
+        updated: bindingResult.updated.map(describeBinding),
         skipped: bindingResult.skipped.map(describeBinding),
         conflicts: bindingResult.conflicts.map(
           (conflict) => `${describeBinding(conflict.binding)} (agent=${conflict.existingAgentId})`,

--- a/src/commands/agents.commands.bind.ts
+++ b/src/commands/agents.commands.bind.ts
@@ -1,0 +1,324 @@
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { writeConfigFile } from "../config/config.js";
+import { logConfigUpdated } from "../config/logging.js";
+import type { AgentBinding } from "../config/types.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { defaultRuntime } from "../runtime.js";
+import {
+  applyAgentBindings,
+  describeBinding,
+  parseBindingSpecs,
+  removeAgentBindings,
+} from "./agents.bindings.js";
+import { requireValidConfig } from "./agents.command-shared.js";
+import { buildAgentSummaries } from "./agents.config.js";
+
+type AgentsBindingsListOptions = {
+  agent?: string;
+  json?: boolean;
+};
+
+type AgentsBindOptions = {
+  agent?: string;
+  bind?: string[];
+  json?: boolean;
+};
+
+type AgentsUnbindOptions = {
+  agent?: string;
+  bind?: string[];
+  all?: boolean;
+  json?: boolean;
+};
+
+function resolveAgentId(
+  cfg: Awaited<ReturnType<typeof requireValidConfig>>,
+  agentInput: string | undefined,
+  params?: { fallbackToDefault?: boolean },
+): string | null {
+  if (!cfg) {
+    return null;
+  }
+  if (agentInput?.trim()) {
+    return normalizeAgentId(agentInput);
+  }
+  if (params?.fallbackToDefault) {
+    return resolveDefaultAgentId(cfg);
+  }
+  return null;
+}
+
+function hasAgent(cfg: Awaited<ReturnType<typeof requireValidConfig>>, agentId: string): boolean {
+  if (!cfg) {
+    return false;
+  }
+  return buildAgentSummaries(cfg).some((summary) => summary.id === agentId);
+}
+
+function formatBindingOwnerLine(binding: AgentBinding): string {
+  return `${normalizeAgentId(binding.agentId)} <- ${describeBinding(binding)}`;
+}
+
+export async function agentsBindingsCommand(
+  opts: AgentsBindingsListOptions,
+  runtime: RuntimeEnv = defaultRuntime,
+) {
+  const cfg = await requireValidConfig(runtime);
+  if (!cfg) {
+    return;
+  }
+
+  const filterAgentId = resolveAgentId(cfg, opts.agent?.trim());
+  if (opts.agent && !filterAgentId) {
+    runtime.error("Agent id is required.");
+    runtime.exit(1);
+    return;
+  }
+  if (filterAgentId && !hasAgent(cfg, filterAgentId)) {
+    runtime.error(`Agent "${filterAgentId}" not found.`);
+    runtime.exit(1);
+    return;
+  }
+
+  const filtered = (cfg.bindings ?? []).filter(
+    (binding) => !filterAgentId || normalizeAgentId(binding.agentId) === filterAgentId,
+  );
+  if (opts.json) {
+    runtime.log(
+      JSON.stringify(
+        filtered.map((binding) => ({
+          agentId: normalizeAgentId(binding.agentId),
+          match: binding.match,
+          description: describeBinding(binding),
+        })),
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  if (filtered.length === 0) {
+    runtime.log(
+      filterAgentId ? `No routing bindings for agent "${filterAgentId}".` : "No routing bindings.",
+    );
+    return;
+  }
+
+  runtime.log(
+    [
+      "Routing bindings:",
+      ...filtered.map((binding) => `- ${formatBindingOwnerLine(binding)}`),
+    ].join("\n"),
+  );
+}
+
+export async function agentsBindCommand(
+  opts: AgentsBindOptions,
+  runtime: RuntimeEnv = defaultRuntime,
+) {
+  const cfg = await requireValidConfig(runtime);
+  if (!cfg) {
+    return;
+  }
+
+  const agentId = resolveAgentId(cfg, opts.agent?.trim(), { fallbackToDefault: true });
+  if (!agentId) {
+    runtime.error("Unable to resolve agent id.");
+    runtime.exit(1);
+    return;
+  }
+  if (!hasAgent(cfg, agentId)) {
+    runtime.error(`Agent "${agentId}" not found.`);
+    runtime.exit(1);
+    return;
+  }
+
+  const specs = (opts.bind ?? []).map((value) => value.trim()).filter(Boolean);
+  if (specs.length === 0) {
+    runtime.error("Provide at least one --bind <channel[:accountId]>.");
+    runtime.exit(1);
+    return;
+  }
+
+  const parsed = parseBindingSpecs({ agentId, specs, config: cfg });
+  if (parsed.errors.length > 0) {
+    runtime.error(parsed.errors.join("\n"));
+    runtime.exit(1);
+    return;
+  }
+
+  const result = applyAgentBindings(cfg, parsed.bindings);
+  if (result.added.length > 0 || result.updated.length > 0) {
+    await writeConfigFile(result.config);
+    if (!opts.json) {
+      logConfigUpdated(runtime);
+    }
+  }
+
+  const payload = {
+    agentId,
+    added: result.added.map(describeBinding),
+    updated: result.updated.map(describeBinding),
+    skipped: result.skipped.map(describeBinding),
+    conflicts: result.conflicts.map(
+      (conflict) => `${describeBinding(conflict.binding)} (agent=${conflict.existingAgentId})`,
+    ),
+  };
+  if (opts.json) {
+    runtime.log(JSON.stringify(payload, null, 2));
+    if (result.conflicts.length > 0) {
+      runtime.exit(1);
+    }
+    return;
+  }
+
+  if (result.added.length > 0) {
+    runtime.log("Added bindings:");
+    for (const binding of result.added) {
+      runtime.log(`- ${describeBinding(binding)}`);
+    }
+  } else if (result.updated.length === 0) {
+    runtime.log("No new bindings added.");
+  }
+
+  if (result.updated.length > 0) {
+    runtime.log("Updated bindings:");
+    for (const binding of result.updated) {
+      runtime.log(`- ${describeBinding(binding)}`);
+    }
+  }
+
+  if (result.skipped.length > 0) {
+    runtime.log("Already present:");
+    for (const binding of result.skipped) {
+      runtime.log(`- ${describeBinding(binding)}`);
+    }
+  }
+
+  if (result.conflicts.length > 0) {
+    runtime.error("Skipped bindings already claimed by another agent:");
+    for (const conflict of result.conflicts) {
+      runtime.error(`- ${describeBinding(conflict.binding)} (agent=${conflict.existingAgentId})`);
+    }
+    runtime.exit(1);
+  }
+}
+
+export async function agentsUnbindCommand(
+  opts: AgentsUnbindOptions,
+  runtime: RuntimeEnv = defaultRuntime,
+) {
+  const cfg = await requireValidConfig(runtime);
+  if (!cfg) {
+    return;
+  }
+
+  const agentId = resolveAgentId(cfg, opts.agent?.trim(), { fallbackToDefault: true });
+  if (!agentId) {
+    runtime.error("Unable to resolve agent id.");
+    runtime.exit(1);
+    return;
+  }
+  if (!hasAgent(cfg, agentId)) {
+    runtime.error(`Agent "${agentId}" not found.`);
+    runtime.exit(1);
+    return;
+  }
+  if (opts.all && (opts.bind?.length ?? 0) > 0) {
+    runtime.error("Use either --all or --bind, not both.");
+    runtime.exit(1);
+    return;
+  }
+
+  if (opts.all) {
+    const existing = cfg.bindings ?? [];
+    const removed = existing.filter((binding) => normalizeAgentId(binding.agentId) === agentId);
+    const kept = existing.filter((binding) => normalizeAgentId(binding.agentId) !== agentId);
+    if (removed.length === 0) {
+      runtime.log(`No bindings to remove for agent "${agentId}".`);
+      return;
+    }
+    const next = {
+      ...cfg,
+      bindings: kept.length > 0 ? kept : undefined,
+    };
+    await writeConfigFile(next);
+    if (!opts.json) {
+      logConfigUpdated(runtime);
+    }
+    const payload = {
+      agentId,
+      removed: removed.map(describeBinding),
+      missing: [] as string[],
+      conflicts: [] as string[],
+    };
+    if (opts.json) {
+      runtime.log(JSON.stringify(payload, null, 2));
+      return;
+    }
+    runtime.log(`Removed ${removed.length} binding(s) for "${agentId}".`);
+    return;
+  }
+
+  const specs = (opts.bind ?? []).map((value) => value.trim()).filter(Boolean);
+  if (specs.length === 0) {
+    runtime.error("Provide at least one --bind <channel[:accountId]> or use --all.");
+    runtime.exit(1);
+    return;
+  }
+
+  const parsed = parseBindingSpecs({ agentId, specs, config: cfg });
+  if (parsed.errors.length > 0) {
+    runtime.error(parsed.errors.join("\n"));
+    runtime.exit(1);
+    return;
+  }
+
+  const result = removeAgentBindings(cfg, parsed.bindings);
+  if (result.removed.length > 0) {
+    await writeConfigFile(result.config);
+    if (!opts.json) {
+      logConfigUpdated(runtime);
+    }
+  }
+
+  const payload = {
+    agentId,
+    removed: result.removed.map(describeBinding),
+    missing: result.missing.map(describeBinding),
+    conflicts: result.conflicts.map(
+      (conflict) => `${describeBinding(conflict.binding)} (agent=${conflict.existingAgentId})`,
+    ),
+  };
+  if (opts.json) {
+    runtime.log(JSON.stringify(payload, null, 2));
+    if (result.conflicts.length > 0) {
+      runtime.exit(1);
+    }
+    return;
+  }
+
+  if (result.removed.length > 0) {
+    runtime.log("Removed bindings:");
+    for (const binding of result.removed) {
+      runtime.log(`- ${describeBinding(binding)}`);
+    }
+  } else {
+    runtime.log("No bindings removed.");
+  }
+  if (result.missing.length > 0) {
+    runtime.log("Not found:");
+    for (const binding of result.missing) {
+      runtime.log(`- ${describeBinding(binding)}`);
+    }
+  }
+  if (result.conflicts.length > 0) {
+    runtime.error("Bindings are owned by another agent:");
+    for (const conflict of result.conflicts) {
+      runtime.error(`- ${describeBinding(conflict.binding)} (agent=${conflict.existingAgentId})`);
+    }
+    runtime.exit(1);
+  }
+}

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -6,6 +6,7 @@ import {
   applyAgentConfig,
   buildAgentSummaries,
   pruneAgentConfig,
+  removeAgentBindings,
 } from "./agents.js";
 
 describe("agents helpers", () => {
@@ -102,6 +103,114 @@ describe("agents helpers", () => {
     expect(result.skipped).toHaveLength(1);
     expect(result.conflicts).toHaveLength(1);
     expect(result.config.bindings).toHaveLength(2);
+  });
+
+  it("applyAgentBindings upgrades channel-only binding to account-specific binding for same agent", () => {
+    const cfg: RemoteClawConfig = {
+      bindings: [
+        {
+          agentId: "main",
+          match: { channel: "telegram" },
+        },
+      ],
+    };
+
+    const result = applyAgentBindings(cfg, [
+      {
+        agentId: "main",
+        match: { channel: "telegram", accountId: "work" },
+      },
+    ]);
+
+    expect(result.added).toHaveLength(0);
+    expect(result.updated).toHaveLength(1);
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.config.bindings).toEqual([
+      {
+        agentId: "main",
+        match: { channel: "telegram", accountId: "work" },
+      },
+    ]);
+  });
+
+  it("applyAgentBindings treats role-based bindings as distinct routes", () => {
+    const cfg: RemoteClawConfig = {
+      bindings: [
+        {
+          agentId: "main",
+          match: {
+            channel: "discord",
+            accountId: "guild-a",
+            guildId: "123",
+            roles: ["111", "222"],
+          },
+        },
+      ],
+    };
+
+    const result = applyAgentBindings(cfg, [
+      {
+        agentId: "work",
+        match: {
+          channel: "discord",
+          accountId: "guild-a",
+          guildId: "123",
+        },
+      },
+    ]);
+
+    expect(result.added).toHaveLength(1);
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.config.bindings).toHaveLength(2);
+  });
+
+  it("removeAgentBindings does not remove role-based bindings when removing channel-level routes", () => {
+    const cfg: RemoteClawConfig = {
+      bindings: [
+        {
+          agentId: "main",
+          match: {
+            channel: "discord",
+            accountId: "guild-a",
+            guildId: "123",
+            roles: ["111", "222"],
+          },
+        },
+        {
+          agentId: "main",
+          match: {
+            channel: "discord",
+            accountId: "guild-a",
+            guildId: "123",
+          },
+        },
+      ],
+    };
+
+    const result = removeAgentBindings(cfg, [
+      {
+        agentId: "main",
+        match: {
+          channel: "discord",
+          accountId: "guild-a",
+          guildId: "123",
+        },
+      },
+    ]);
+
+    expect(result.removed).toHaveLength(1);
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.config.bindings).toEqual([
+      {
+        agentId: "main",
+        match: {
+          channel: "discord",
+          accountId: "guild-a",
+          guildId: "123",
+          roles: ["111", "222"],
+        },
+      },
+    ]);
   });
 
   it("pruneAgentConfig removes agent, bindings, and allowlist entries", () => {

--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -1,4 +1,5 @@
 export * from "./agents.bindings.js";
+export * from "./agents.commands.bind.js";
 export * from "./agents.commands.add.js";
 export * from "./agents.commands.delete.js";
 export * from "./agents.commands.identity.js";

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -10,6 +10,8 @@ import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import { resolveTelegramAccount } from "../../telegram/accounts.js";
 import { deleteTelegramUpdateOffset } from "../../telegram/update-offset-store.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
+import { applyAgentBindings, describeBinding } from "../agents.bindings.js";
+import { buildAgentSummaries } from "../agents.config.js";
 import { setupChannels } from "../onboard-channels.js";
 import type { ChannelChoice } from "../onboard-types.js";
 import {
@@ -113,6 +115,68 @@ export async function channelsAddCommand(
       }
     }
 
+    const bindTargets = selection
+      .map((channel) => ({
+        channel,
+        accountId: accountIds[channel]?.trim(),
+      }))
+      .filter(
+        (
+          value,
+        ): value is {
+          channel: ChannelChoice;
+          accountId: string;
+        } => Boolean(value.accountId),
+      );
+    if (bindTargets.length > 0) {
+      const bindNow = await prompter.confirm({
+        message: "Bind configured channel accounts to agents now?",
+        initialValue: true,
+      });
+      if (bindNow) {
+        const agentSummaries = buildAgentSummaries(nextConfig);
+        const defaultAgentId = resolveDefaultAgentId(nextConfig);
+        for (const target of bindTargets) {
+          const targetAgentId = await prompter.select({
+            message: `Route ${target.channel} account "${target.accountId}" to agent`,
+            options: agentSummaries.map((agent) => ({
+              value: agent.id,
+              label: agent.isDefault ? `${agent.id} (default)` : agent.id,
+            })),
+            initialValue: defaultAgentId,
+          });
+          const bindingResult = applyAgentBindings(nextConfig, [
+            {
+              agentId: targetAgentId,
+              match: { channel: target.channel, accountId: target.accountId },
+            },
+          ]);
+          nextConfig = bindingResult.config;
+          if (bindingResult.added.length > 0 || bindingResult.updated.length > 0) {
+            await prompter.note(
+              [
+                ...bindingResult.added.map((binding) => `Added: ${describeBinding(binding)}`),
+                ...bindingResult.updated.map((binding) => `Updated: ${describeBinding(binding)}`),
+              ].join("\n"),
+              "Routing bindings",
+            );
+          }
+          if (bindingResult.conflicts.length > 0) {
+            await prompter.note(
+              [
+                "Skipped bindings already claimed by another agent:",
+                ...bindingResult.conflicts.map(
+                  (conflict) =>
+                    `- ${describeBinding(conflict.binding)} (agent=${conflict.existingAgentId})`,
+                ),
+              ].join("\n"),
+              "Routing bindings",
+            );
+          }
+        }
+      }
+    }
+
     await writeConfigFile(nextConfig);
     await prompter.outro("Channels updated.");
     return;
@@ -155,9 +219,6 @@ export async function channelsAddCommand(
     runtime.exit(1);
     return;
   }
-  const accountId =
-    plugin.setup.resolveAccountId?.({ cfg: nextConfig, accountId: opts.account }) ??
-    normalizeAccountId(opts.account);
   const useEnv = opts.useEnv === true;
   const initialSyncLimit =
     typeof opts.initialSyncLimit === "number"
@@ -201,6 +262,12 @@ export async function channelsAddCommand(
     dmAllowlist,
     autoDiscoverChannels: opts.autoDiscoverChannels,
   };
+  const accountId =
+    plugin.setup.resolveAccountId?.({
+      cfg: nextConfig,
+      accountId: opts.account,
+      input,
+    }) ?? normalizeAccountId(opts.account);
 
   const validationError = plugin.setup.validateInput?.({
     cfg: nextConfig,

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -334,6 +334,19 @@ describe("resolveNodeCommandAllowlist", () => {
     }
   });
 
+  it("includes Android notifications.list by default", () => {
+    const allow = resolveNodeCommandAllowlist(
+      {},
+      {
+        platform: "android 16",
+        deviceFamily: "Android",
+      },
+    );
+
+    expect(allow.has("notifications.list")).toBe(true);
+    expect(allow.has("system.notify")).toBe(false);
+  });
+
   it("can explicitly allow dangerous commands via allowCommands", () => {
     const allow = resolveNodeCommandAllowlist(
       {

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -18,6 +18,7 @@ const CAMERA_DANGEROUS_COMMANDS = ["camera.snap", "camera.clip"];
 const SCREEN_DANGEROUS_COMMANDS = ["screen.record"];
 
 const LOCATION_COMMANDS = ["location.get"];
+const NOTIFICATION_COMMANDS = ["notifications.list"];
 
 const DEVICE_COMMANDS = ["device.info", "device.status"];
 
@@ -69,6 +70,7 @@ const PLATFORM_DEFAULTS: Record<string, string[]> = {
     ...CANVAS_COMMANDS,
     ...CAMERA_COMMANDS,
     ...LOCATION_COMMANDS,
+    ...NOTIFICATION_COMMANDS,
     ...DEVICE_COMMANDS,
     ...CONTACTS_COMMANDS,
     ...CALENDAR_COMMANDS,


### PR DESCRIPTION
## Summary

Cherry-picks 6 upstream commits for gateway, nodes, protocol, and agent routing improvements:

- `550000049`: Add `commandargv` to `ExecApprovalRequestParams` in Swift protocol models
- `e6a5d5784c`: Add Android notifications.list to default node command policy
- `92c309f2e1`: Fix wrong Providers link in configuration examples docs
- `c0073b3d47`: Add nodes `notifications_list` action and tests
- `a0cf753b2e`: Dedupe node read invoke commands via `invokeNodeCommandPayload` helper
- `96c7702526`: Add account-scoped bind and routing commands (`agents bindings/bind/unbind`), with plugin-resolved account IDs, binding scope upgrades, and optional binding prompts in `channels add`

All rebranded openclaw → remoteclaw.

Closes #606.

Cherry-picked-from: 550000049, e6a5d5784c, 92c309f2e1, c0073b3d47, a0cf753b2e, 96c7702526