### PR TITLE
Cherry-pick: Telegram shutdown/polling + browser SSRF redirect-hop checks

### DIFF
--- a/src/browser/navigation-guard.test.ts
+++ b/src/browser/navigation-guard.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { SsrFBlockedError, type LookupFn } from "../infra/net/ssrf.js";
 import {
   assertBrowserNavigationAllowed,
+  assertBrowserNavigationRedirectChainAllowed,
   assertBrowserNavigationResultAllowed,
   InvalidBrowserNavigationUrlError,
+  requiresInspectableBrowserNavigationRedirects,
 } from "./navigation-guard.js";
 
 function createLookupFn(address: string): LookupFn {
@@ -119,5 +121,59 @@ describe("browser navigation guard", () => {
         url: "chrome-error://chromewebdata/",
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("blocks private intermediate redirect hops", async () => {
+    const publicLookup = createLookupFn("93.184.216.34");
+    const privateLookup = createLookupFn("127.0.0.1");
+    const finalRequest = {
+      url: () => "https://public.example/final",
+      redirectedFrom: () => ({
+        url: () => "http://private.example/internal",
+        redirectedFrom: () => ({
+          url: () => "https://public.example/start",
+          redirectedFrom: () => null,
+        }),
+      }),
+    };
+
+    await expect(
+      assertBrowserNavigationRedirectChainAllowed({
+        request: finalRequest,
+        lookupFn: vi.fn(async (hostname: string) =>
+          hostname === "private.example"
+            ? privateLookup(hostname, { all: true })
+            : publicLookup(hostname, { all: true }),
+        ) as unknown as LookupFn,
+      }),
+    ).rejects.toBeInstanceOf(SsrFBlockedError);
+  });
+
+  it("allows redirect chains when every hop is public", async () => {
+    const lookupFn = createLookupFn("93.184.216.34");
+    const finalRequest = {
+      url: () => "https://public.example/final",
+      redirectedFrom: () => ({
+        url: () => "https://public.example/middle",
+        redirectedFrom: () => ({
+          url: () => "https://public.example/start",
+          redirectedFrom: () => null,
+        }),
+      }),
+    };
+
+    await expect(
+      assertBrowserNavigationRedirectChainAllowed({
+        request: finalRequest,
+        lookupFn,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("treats default browser SSRF mode as requiring redirect-hop inspection", () => {
+    expect(requiresInspectableBrowserNavigationRedirects()).toBe(true);
+    expect(requiresInspectableBrowserNavigationRedirects({ allowPrivateNetwork: true })).toBe(
+      false,
+    );
   });
 });

--- a/src/browser/navigation-guard.ts
+++ b/src/browser/navigation-guard.ts
@@ -23,10 +23,21 @@ export type BrowserNavigationPolicyOptions = {
   ssrfPolicy?: SsrFPolicy;
 };
 
+export type BrowserNavigationRequestLike = {
+  url(): string;
+  redirectedFrom(): BrowserNavigationRequestLike | null;
+};
+
 export function withBrowserNavigationPolicy(
   ssrfPolicy?: SsrFPolicy,
 ): BrowserNavigationPolicyOptions {
   return ssrfPolicy ? { ssrfPolicy } : {};
+}
+
+export function requiresInspectableBrowserNavigationRedirects(ssrfPolicy?: SsrFPolicy): boolean {
+  return (
+    ssrfPolicy?.allowPrivateNetwork !== true && ssrfPolicy?.dangerouslyAllowPrivateNetwork !== true
+  );
 }
 
 export async function assertBrowserNavigationAllowed(
@@ -88,5 +99,26 @@ export async function assertBrowserNavigationResultAllowed(
     isAllowedNonNetworkNavigationUrl(parsed)
   ) {
     await assertBrowserNavigationAllowed(opts);
+  }
+}
+
+export async function assertBrowserNavigationRedirectChainAllowed(
+  opts: {
+    request?: BrowserNavigationRequestLike | null;
+    lookupFn?: LookupFn;
+  } & BrowserNavigationPolicyOptions,
+): Promise<void> {
+  const chain: string[] = [];
+  let current = opts.request ?? null;
+  while (current) {
+    chain.push(current.url());
+    current = current.redirectedFrom();
+  }
+  for (const url of chain.toReversed()) {
+    await assertBrowserNavigationAllowed({
+      url,
+      lookupFn: opts.lookupFn,
+      ssrfPolicy: opts.ssrfPolicy,
+    });
   }
 }

--- a/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -1,5 +1,6 @@
 import { chromium } from "playwright-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import * as chromeModule from "./chrome.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
 import { closePlaywrightBrowserConnection, createPageViaPlaywright } from "./pw-session.js";
@@ -9,7 +10,9 @@ const getChromeWebSocketUrlSpy = vi.spyOn(chromeModule, "getChromeWebSocketUrl")
 
 function installBrowserMocks() {
   const pageOn = vi.fn();
-  const pageGoto = vi.fn(async () => {});
+  const pageGoto = vi.fn<
+    (...args: unknown[]) => Promise<null | { request: () => Record<string, unknown> }>
+  >(async () => null);
   const pageTitle = vi.fn(async () => "");
   const pageUrl = vi.fn(() => "about:blank");
   const contextOn = vi.fn();
@@ -83,5 +86,28 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
 
     expect(created.targetId).toBe("TARGET_1");
     expect(pageGoto).not.toHaveBeenCalled();
+  });
+
+  it("blocks private intermediate redirect hops", async () => {
+    const { pageGoto } = installBrowserMocks();
+    pageGoto.mockResolvedValueOnce({
+      request: () => ({
+        url: () => "https://93.184.216.34/final",
+        redirectedFrom: () => ({
+          url: () => "http://127.0.0.1:18080/internal-hop",
+          redirectedFrom: () => ({
+            url: () => "https://93.184.216.34/start",
+            redirectedFrom: () => null,
+          }),
+        }),
+      }),
+    });
+
+    await expect(
+      createPageViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        url: "https://93.184.216.34/start",
+      }),
+    ).rejects.toBeInstanceOf(SsrFBlockedError);
   });
 });

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -14,6 +14,7 @@ import { normalizeCdpWsUrl } from "./cdp.js";
 import { getChromeWebSocketUrl } from "./chrome.js";
 import {
   assertBrowserNavigationAllowed,
+  assertBrowserNavigationRedirectChainAllowed,
   assertBrowserNavigationResultAllowed,
   withBrowserNavigationPolicy,
 } from "./navigation-guard.js";
@@ -747,8 +748,13 @@ export async function createPageViaPlaywright(opts: {
       url: targetUrl,
       ...navigationPolicy,
     });
-    await page.goto(targetUrl, { timeout: 30_000 }).catch(() => {
+    const response = await page.goto(targetUrl, { timeout: 30_000 }).catch(() => {
       // Navigation might fail for some URLs, but page is still created
+      return null;
+    });
+    await assertBrowserNavigationRedirectChainAllowed({
+      request: response?.request(),
+      ...navigationPolicy,
     });
     await assertBrowserNavigationResultAllowed({
       url: page.url(),

--- a/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
 import {
   getPwToolsCoreSessionMocks,
@@ -43,5 +44,33 @@ describe("pw-tools-core.snapshot navigate guard", () => {
 
     expect(goto).toHaveBeenCalledWith("https://example.com", { timeout: 1000 });
     expect(result.url).toBe("https://example.com");
+  });
+
+  it("blocks private intermediate redirect hops during navigation", async () => {
+    const goto = vi.fn(async () => ({
+      request: () => ({
+        url: () => "https://93.184.216.34/final",
+        redirectedFrom: () => ({
+          url: () => "http://127.0.0.1:18080/internal-hop",
+          redirectedFrom: () => ({
+            url: () => "https://93.184.216.34/start",
+            redirectedFrom: () => null,
+          }),
+        }),
+      }),
+    }));
+    setPwToolsCoreCurrentPage({
+      goto,
+      url: vi.fn(() => "https://93.184.216.34/final"),
+    });
+
+    await expect(
+      mod.navigateViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        url: "https://93.184.216.34/start",
+      }),
+    ).rejects.toBeInstanceOf(SsrFBlockedError);
+
+    expect(goto).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/browser/pw-tools-core.snapshot.ts
+++ b/src/browser/pw-tools-core.snapshot.ts
@@ -2,6 +2,7 @@ import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { type AriaSnapshotNode, formatAriaSnapshot, type RawAXNode } from "./cdp.js";
 import {
   assertBrowserNavigationAllowed,
+  assertBrowserNavigationRedirectChainAllowed,
   assertBrowserNavigationResultAllowed,
   withBrowserNavigationPolicy,
 } from "./navigation-guard.js";
@@ -176,8 +177,12 @@ export async function navigateViaPlaywright(opts: {
   });
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
-  await page.goto(url, {
+  const response = await page.goto(url, {
     timeout: Math.max(1000, Math.min(120_000, opts.timeoutMs ?? 20_000)),
+  });
+  await assertBrowserNavigationRedirectChainAllowed({
+    request: response?.request(),
+    ...withBrowserNavigationPolicy(opts.ssrfPolicy),
   });
   const finalUrl = page.url();
   await assertBrowserNavigationResultAllowed({

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -83,6 +83,27 @@ describe("createTelegramBot", () => {
       globalThis.fetch = originalFetch;
     }
   });
+  it("aborts wrapped client fetch when fetchAbortSignal aborts", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => init?.signal);
+    const shutdown = new AbortController();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      createTelegramBot({ token: "tok", fetchAbortSignal: shutdown.signal });
+      const clientFetch = (botCtorSpy.mock.calls[0]?.[1] as { client?: { fetch?: unknown } })
+        ?.client?.fetch as (input: RequestInfo | URL, init?: RequestInit) => Promise<unknown>;
+      expect(clientFetch).toBeTypeOf("function");
+
+      const observedSignal = (await clientFetch("https://example.test")) as AbortSignal;
+      expect(observedSignal).toBeInstanceOf(AbortSignal);
+      expect(observedSignal.aborted).toBe(false);
+
+      shutdown.abort(new Error("shutdown"));
+      expect(observedSignal.aborted).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
   it("applies global and per-account timeoutSeconds", () => {
     loadConfig.mockReturnValue({
       agents: { list: [{ id: "main", workspace: "/tmp/test-workspace" }] },

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -85,7 +85,15 @@ describe("createTelegramBot", () => {
   });
   it("aborts wrapped client fetch when fetchAbortSignal aborts", async () => {
     const originalFetch = globalThis.fetch;
-    const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => init?.signal);
+    // Capture the signal passed to fetch by returning a never-resolving promise.
+    // The wrapped fetch installs abort listeners and cleans them up in .finally();
+    // if the mock resolves immediately the listeners are removed before we can
+    // fire the shutdown signal.
+    let capturedSignal: AbortSignal | undefined;
+    const fetchSpy = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedSignal = init?.signal as AbortSignal | undefined;
+      return new Promise<Response>(() => {}); // never resolves — simulates in-flight request
+    });
     const shutdown = new AbortController();
     globalThis.fetch = fetchSpy as unknown as typeof fetch;
     try {
@@ -94,12 +102,13 @@ describe("createTelegramBot", () => {
         ?.client?.fetch as (input: RequestInfo | URL, init?: RequestInit) => Promise<unknown>;
       expect(clientFetch).toBeTypeOf("function");
 
-      const observedSignal = (await clientFetch("https://example.test")) as AbortSignal;
-      expect(observedSignal).toBeInstanceOf(AbortSignal);
-      expect(observedSignal.aborted).toBe(false);
+      // Start the fetch but do NOT await it — the promise never resolves.
+      void clientFetch("https://example.test");
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal!.aborted).toBe(false);
 
       shutdown.abort(new Error("shutdown"));
-      expect(observedSignal.aborted).toBe(true);
+      expect(capturedSignal!.aborted).toBe(true);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -52,6 +52,8 @@ export type TelegramBotOptions = {
   replyToMode?: ReplyToMode;
   proxyFetch?: typeof fetch;
   config?: RemoteClawConfig;
+  /** Signal to abort in-flight Telegram API fetch requests (e.g. getUpdates) on shutdown. */
+  fetchAbortSignal?: AbortSignal;
   updateOffset?: {
     lastUpdateId?: number | null;
     onUpdateId?: (updateId: number) => void | Promise<void>;
@@ -128,14 +130,56 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   // grammY's ApiClientOptions types still track `node-fetch` types; Node 22+ global fetch
   // (undici) is structurally compatible at runtime but not assignable in TS.
   const fetchForClient = fetchImpl as unknown as NonNullable<ApiClientOptions["fetch"]>;
+
+  // When a shutdown abort signal is provided, wrap fetch so every Telegram API request
+  // (especially long-polling getUpdates) aborts immediately on shutdown. Without this,
+  // the in-flight getUpdates hangs for up to 30s, and a new gateway instance starting
+  // its own poll triggers a 409 Conflict from Telegram.
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  let finalFetch: NonNullable<ApiClientOptions["fetch"]> | undefined =
+    shouldProvideFetch && fetchImpl ? fetchForClient : undefined;
+  if (opts.fetchAbortSignal) {
+    const baseFetch =
+      finalFetch ?? (globalThis.fetch as unknown as NonNullable<ApiClientOptions["fetch"]>);
+    const shutdownSignal = opts.fetchAbortSignal;
+    // Cast baseFetch to global fetch to avoid node-fetch ↔ global-fetch type divergence;
+    // they are runtime-compatible (the codebase already casts at every fetch boundary).
+    const callFetch = baseFetch as unknown as typeof globalThis.fetch;
+    finalFetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const controller = new AbortController();
+      const abortWith = (signal: AbortSignal) => controller.abort(signal.reason);
+      const onShutdown = () => abortWith(shutdownSignal);
+      let onRequestAbort: (() => void) | undefined;
+      if (shutdownSignal.aborted) {
+        abortWith(shutdownSignal);
+      } else {
+        shutdownSignal.addEventListener("abort", onShutdown, { once: true });
+      }
+      if (init?.signal) {
+        if (init.signal.aborted) {
+          abortWith(init.signal);
+        } else {
+          onRequestAbort = () => abortWith(init.signal as AbortSignal);
+          init.signal.addEventListener("abort", onRequestAbort, { once: true });
+        }
+      }
+      return callFetch(input, { ...init, signal: controller.signal }).finally(() => {
+        shutdownSignal.removeEventListener("abort", onShutdown);
+        if (init?.signal && onRequestAbort) {
+          init.signal.removeEventListener("abort", onRequestAbort);
+        }
+      });
+    }) as unknown as NonNullable<ApiClientOptions["fetch"]>;
+  }
+
   const timeoutSeconds =
     typeof telegramCfg?.timeoutSeconds === "number" && Number.isFinite(telegramCfg.timeoutSeconds)
       ? Math.max(1, Math.floor(telegramCfg.timeoutSeconds))
       : undefined;
   const client: ApiClientOptions | undefined =
-    shouldProvideFetch || timeoutSeconds
+    finalFetch || timeoutSeconds
       ? {
-          ...(shouldProvideFetch && fetchImpl ? { fetch: fetchForClient } : {}),
+          ...(finalFetch ? { fetch: finalFetch } : {}),
           ...(timeoutSeconds ? { timeoutSeconds } : {}),
         }
       : undefined;

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -145,6 +145,9 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     // Cast baseFetch to global fetch to avoid node-fetch ↔ global-fetch type divergence;
     // they are runtime-compatible (the codebase already casts at every fetch boundary).
     const callFetch = baseFetch as unknown as typeof globalThis.fetch;
+    // Use manual event forwarding instead of AbortSignal.any() to avoid the cross-realm
+    // AbortSignal issue in Node.js (grammY's signal may come from a different module context,
+    // causing "signals[0] must be an instance of AbortSignal" errors).
     finalFetch = ((input: RequestInfo | URL, init?: RequestInit) => {
       const controller = new AbortController();
       const abortWith = (signal: AbortSignal) => controller.abort(signal.reason);

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -59,6 +59,10 @@ const { createTelegramBotErrors } = vi.hoisted(() => ({
   createTelegramBotErrors: [] as unknown[],
 }));
 
+const { createTelegramBotCalls } = vi.hoisted(() => ({
+  createTelegramBotCalls: [] as Array<Record<string, unknown>>,
+}));
+
 const { computeBackoff, sleepWithAbort } = vi.hoisted(() => ({
   computeBackoff: vi.fn(() => 0),
   sleepWithAbort: vi.fn(async () => undefined),
@@ -106,7 +110,8 @@ vi.mock("../config/config.js", async (importOriginal) => {
 });
 
 vi.mock("./bot.js", () => ({
-  createTelegramBot: () => {
+  createTelegramBot: (opts: Record<string, unknown>) => {
+    createTelegramBotCalls.push(opts);
     const nextError = createTelegramBotErrors.shift();
     if (nextError) {
       throw nextError;
@@ -179,6 +184,7 @@ describe("monitorTelegramProvider (grammY)", () => {
     registerUnhandledRejectionHandlerMock.mockClear();
     resetUnhandledRejection();
     createTelegramBotErrors.length = 0;
+    createTelegramBotCalls.length = 0;
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
@@ -430,6 +436,47 @@ describe("monitorTelegramProvider (grammY)", () => {
     expect(computeBackoff).toHaveBeenCalled();
     expect(sleepWithAbort).toHaveBeenCalled();
     expect(runSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts the active Telegram fetch when unhandled network rejection forces restart", async () => {
+    const abort = new AbortController();
+    let running = true;
+    let releaseTask: (() => void) | undefined;
+    const stop = vi.fn(async () => {
+      running = false;
+      releaseTask?.();
+    });
+
+    runSpy
+      .mockImplementationOnce(() =>
+        makeRunnerStub({
+          task: () =>
+            new Promise<void>((resolve) => {
+              releaseTask = resolve;
+            }),
+          stop,
+          isRunning: () => running,
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeRunnerStub({
+          task: async () => {
+            abort.abort();
+          },
+        }),
+      );
+
+    const monitor = monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+    await vi.waitFor(() => expect(createTelegramBotCalls.length).toBeGreaterThanOrEqual(1));
+    const firstSignal = createTelegramBotCalls[0]?.fetchAbortSignal;
+    expect(firstSignal).toBeInstanceOf(AbortSignal);
+    expect((firstSignal as AbortSignal).aborted).toBe(false);
+
+    expect(emitUnhandledRejection(new TypeError("fetch failed"))).toBe(true);
+    await monitor;
+
+    expect((firstSignal as AbortSignal).aborted).toBe(true);
+    expect(stop).toHaveBeenCalled();
   });
 
   it("passes configured webhookHost to webhook listener", async () => {

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -1,18 +1,15 @@
-import { type RunOptions, run } from "@grammyjs/runner";
+import type { RunOptions } from "@grammyjs/runner";
 import { resolveAgentMaxConcurrent } from "../config/agent-limits.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import { waitForAbortSignal } from "../infra/abort-signal.js";
-import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { formatDurationPrecise } from "../infra/format-time/format-duration.ts";
 import { registerUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveTelegramAccount } from "./accounts.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
-import { withTelegramApiErrorLogging } from "./api-logging.js";
-import { createTelegramBot } from "./bot.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
+import { TelegramPollingSession } from "./polling-session.js";
 import { makeProxyFetch } from "./proxy.js";
 import { readTelegramUpdateOffset, writeTelegramUpdateOffset } from "./update-offset-store.js";
 import { startTelegramWebhook } from "./webhook.js";
@@ -54,37 +51,6 @@ export function createTelegramRunnerOptions(cfg: RemoteClawConfig): RunOptions<u
   };
 }
 
-const TELEGRAM_POLL_RESTART_POLICY = {
-  initialMs: 2000,
-  maxMs: 30_000,
-  factor: 1.8,
-  jitter: 0.25,
-};
-
-type TelegramBot = ReturnType<typeof createTelegramBot>;
-
-const isGetUpdatesConflict = (err: unknown) => {
-  if (!err || typeof err !== "object") {
-    return false;
-  }
-  const typed = err as {
-    error_code?: number;
-    errorCode?: number;
-    description?: string;
-    method?: string;
-    message?: string;
-  };
-  const errorCode = typed.error_code ?? typed.errorCode;
-  if (errorCode !== 409) {
-    return false;
-  }
-  const haystack = [typed.method, typed.description, typed.message]
-    .filter((value): value is string => typeof value === "string")
-    .join(" ")
-    .toLowerCase();
-  return haystack.includes("getupdates");
-};
-
 /** Check if error is a Grammy HttpError (used to scope unhandled rejection handling) */
 const isGrammyHttpError = (err: unknown): boolean => {
   if (!err || typeof err !== "object") {
@@ -95,31 +61,26 @@ const isGrammyHttpError = (err: unknown): boolean => {
 
 export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
   const log = opts.runtime?.error ?? console.error;
-  let activeRunner: ReturnType<typeof run> | undefined;
-  let activeFetchAbort: AbortController | undefined;
-  let forceRestarted = false;
+  let pollingSession: TelegramPollingSession | undefined;
 
-  // Register handler for Grammy HttpError unhandled rejections.
-  // This catches network errors that escape the polling loop's try-catch
-  // (e.g., from setMyCommands during bot setup).
-  // We gate on isGrammyHttpError to avoid suppressing non-Telegram errors.
   const unregisterHandler = registerUnhandledRejectionHandler((err) => {
     const isNetworkError = isRecoverableTelegramNetworkError(err, { context: "polling" });
     if (isGrammyHttpError(err) && isNetworkError) {
       log(`[telegram] Suppressed network error: ${formatErrorMessage(err)}`);
-      return true; // handled - don't crash
+      return true;
     }
-    // Network failures can surface outside the runner task promise and leave
-    // polling stuck; force-stop the active runner so the loop can recover.
+
+    const activeRunner = pollingSession?.activeRunner;
     if (isNetworkError && activeRunner && activeRunner.isRunning()) {
-      forceRestarted = true;
-      activeFetchAbort?.abort();
+      pollingSession?.markForceRestarted();
+      pollingSession?.abortActiveFetch();
       void activeRunner.stop().catch(() => {});
       log(
         `[telegram] Restarting polling after unhandled network error: ${formatErrorMessage(err)}`,
       );
-      return true; // handled
+      return true;
     }
+
     return false;
   });
 
@@ -179,175 +140,19 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       return;
     }
 
-    // Use grammyjs/runner for concurrent update processing
-    let restartAttempts = 0;
-    let webhookCleared = false;
-    const runnerOptions = createTelegramRunnerOptions(cfg);
-    const waitBeforeRestart = async (buildLine: (delay: string) => string): Promise<boolean> => {
-      restartAttempts += 1;
-      const delayMs = computeBackoff(TELEGRAM_POLL_RESTART_POLICY, restartAttempts);
-      const delay = formatDurationPrecise(delayMs);
-      log(buildLine(delay));
-      try {
-        await sleepWithAbort(delayMs, opts.abortSignal);
-      } catch (sleepErr) {
-        if (opts.abortSignal?.aborted) {
-          return false;
-        }
-        throw sleepErr;
-      }
-      return true;
-    };
-
-    const waitBeforeRetryOnRecoverableSetupError = async (
-      err: unknown,
-      logPrefix: string,
-    ): Promise<boolean> => {
-      if (opts.abortSignal?.aborted) {
-        return false;
-      }
-      if (!isRecoverableTelegramNetworkError(err, { context: "unknown" })) {
-        throw err;
-      }
-      return waitBeforeRestart(
-        (delay) => `${logPrefix}: ${formatErrorMessage(err)}; retrying in ${delay}.`,
-      );
-    };
-
-    const createPollingBot = async (
-      fetchAbortController: AbortController,
-    ): Promise<TelegramBot | undefined> => {
-      try {
-        return createTelegramBot({
-          token,
-          runtime: opts.runtime,
-          proxyFetch,
-          config: cfg,
-          accountId: account.accountId,
-          fetchAbortSignal: fetchAbortController.signal,
-          updateOffset: {
-            lastUpdateId,
-            onUpdateId: persistUpdateId,
-          },
-        });
-      } catch (err) {
-        const shouldRetry = await waitBeforeRetryOnRecoverableSetupError(
-          err,
-          "Telegram setup network error",
-        );
-        if (!shouldRetry) {
-          return undefined;
-        }
-        return undefined;
-      }
-    };
-
-    const ensureWebhookCleanup = async (bot: TelegramBot): Promise<"ready" | "retry" | "exit"> => {
-      if (webhookCleared) {
-        return "ready";
-      }
-      try {
-        await withTelegramApiErrorLogging({
-          operation: "deleteWebhook",
-          runtime: opts.runtime,
-          fn: () => bot.api.deleteWebhook({ drop_pending_updates: false }),
-        });
-        webhookCleared = true;
-        return "ready";
-      } catch (err) {
-        const shouldRetry = await waitBeforeRetryOnRecoverableSetupError(
-          err,
-          "Telegram webhook cleanup failed",
-        );
-        return shouldRetry ? "retry" : "exit";
-      }
-    };
-
-    const runPollingCycle = async (
-      bot: TelegramBot,
-      fetchAbortController: AbortController,
-    ): Promise<"continue" | "exit"> => {
-      const runner = run(bot, runnerOptions);
-      activeRunner = runner;
-      let stopPromise: Promise<void> | undefined;
-      const stopRunner = () => {
-        fetchAbortController.abort();
-        stopPromise ??= Promise.resolve(runner.stop())
-          .then(() => undefined)
-          .catch(() => {
-            // Runner may already be stopped by abort/retry paths.
-          });
-        return stopPromise;
-      };
-      const stopOnAbort = () => {
-        if (opts.abortSignal?.aborted) {
-          void stopRunner();
-        }
-      };
-      opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
-      try {
-        // runner.task() returns a promise that resolves when the runner stops
-        await runner.task();
-        if (opts.abortSignal?.aborted) {
-          return "exit";
-        }
-        const reason = forceRestarted
-          ? "unhandled network error"
-          : "runner stopped (maxRetryTime exceeded or graceful stop)";
-        forceRestarted = false;
-        const shouldRestart = await waitBeforeRestart(
-          (delay) => `Telegram polling runner stopped (${reason}); restarting in ${delay}.`,
-        );
-        return shouldRestart ? "continue" : "exit";
-      } catch (err) {
-        forceRestarted = false;
-        if (opts.abortSignal?.aborted) {
-          throw err;
-        }
-        const isConflict = isGetUpdatesConflict(err);
-        const isRecoverable = isRecoverableTelegramNetworkError(err, { context: "polling" });
-        if (!isConflict && !isRecoverable) {
-          throw err;
-        }
-        const reason = isConflict ? "getUpdates conflict" : "network error";
-        const errMsg = formatErrorMessage(err);
-        const shouldRestart = await waitBeforeRestart(
-          (delay) => `Telegram ${reason}: ${errMsg}; retrying in ${delay}.`,
-        );
-        return shouldRestart ? "continue" : "exit";
-      } finally {
-        opts.abortSignal?.removeEventListener("abort", stopOnAbort);
-        await stopRunner();
-        if (activeFetchAbort === fetchAbortController) {
-          activeFetchAbort = undefined;
-        }
-      }
-    };
-
-    while (!opts.abortSignal?.aborted) {
-      const fetchAbortController = new AbortController();
-      activeFetchAbort = fetchAbortController;
-      const bot = await createPollingBot(fetchAbortController);
-      if (!bot) {
-        if (activeFetchAbort === fetchAbortController) {
-          activeFetchAbort = undefined;
-        }
-        continue;
-      }
-
-      const cleanupState = await ensureWebhookCleanup(bot);
-      if (cleanupState === "retry") {
-        continue;
-      }
-      if (cleanupState === "exit") {
-        return;
-      }
-
-      const state = await runPollingCycle(bot, fetchAbortController);
-      if (state === "exit") {
-        return;
-      }
-    }
+    pollingSession = new TelegramPollingSession({
+      token,
+      config: cfg,
+      accountId: account.accountId,
+      runtime: opts.runtime,
+      proxyFetch,
+      abortSignal: opts.abortSignal,
+      runnerOptions: createTelegramRunnerOptions(cfg),
+      getLastUpdateId: () => lastUpdateId,
+      persistUpdateId,
+      log,
+    });
+    await pollingSession.runUntilAbort();
   } finally {
     unregisterHandler();
   }

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -96,6 +96,7 @@ const isGrammyHttpError = (err: unknown): boolean => {
 export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
   const log = opts.runtime?.error ?? console.error;
   let activeRunner: ReturnType<typeof run> | undefined;
+  let activeFetchAbort: AbortController | undefined;
   let forceRestarted = false;
 
   // Register handler for Grammy HttpError unhandled rejections.
@@ -112,6 +113,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
     // polling stuck; force-stop the active runner so the loop can recover.
     if (isNetworkError && activeRunner && activeRunner.isRunning()) {
       forceRestarted = true;
+      activeFetchAbort?.abort();
       void activeRunner.stop().catch(() => {});
       log(
         `[telegram] Restarting polling after unhandled network error: ${formatErrorMessage(err)}`,
@@ -212,7 +214,9 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       );
     };
 
-    const createPollingBot = async (): Promise<TelegramBot | undefined> => {
+    const createPollingBot = async (
+      fetchAbortController: AbortController,
+    ): Promise<TelegramBot | undefined> => {
       try {
         return createTelegramBot({
           token,
@@ -220,6 +224,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           proxyFetch,
           config: cfg,
           accountId: account.accountId,
+          fetchAbortSignal: fetchAbortController.signal,
           updateOffset: {
             lastUpdateId,
             onUpdateId: persistUpdateId,
@@ -258,11 +263,15 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       }
     };
 
-    const runPollingCycle = async (bot: TelegramBot): Promise<"continue" | "exit"> => {
+    const runPollingCycle = async (
+      bot: TelegramBot,
+      fetchAbortController: AbortController,
+    ): Promise<"continue" | "exit"> => {
       const runner = run(bot, runnerOptions);
       activeRunner = runner;
       let stopPromise: Promise<void> | undefined;
       const stopRunner = () => {
+        fetchAbortController.abort();
         stopPromise ??= Promise.resolve(runner.stop())
           .then(() => undefined)
           .catch(() => {
@@ -309,12 +318,20 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       } finally {
         opts.abortSignal?.removeEventListener("abort", stopOnAbort);
         await stopRunner();
+        if (activeFetchAbort === fetchAbortController) {
+          activeFetchAbort = undefined;
+        }
       }
     };
 
     while (!opts.abortSignal?.aborted) {
-      const bot = await createPollingBot();
+      const fetchAbortController = new AbortController();
+      activeFetchAbort = fetchAbortController;
+      const bot = await createPollingBot(fetchAbortController);
       if (!bot) {
+        if (activeFetchAbort === fetchAbortController) {
+          activeFetchAbort = undefined;
+        }
         continue;
       }
 
@@ -326,7 +343,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         return;
       }
 
-      const state = await runPollingCycle(bot);
+      const state = await runPollingCycle(bot, fetchAbortController);
       if (state === "exit") {
         return;
       }

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -1,0 +1,229 @@
+import { type RunOptions, run } from "@grammyjs/runner";
+import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { formatDurationPrecise } from "../infra/format-time/format-duration.ts";
+import { withTelegramApiErrorLogging } from "./api-logging.js";
+import { createTelegramBot } from "./bot.js";
+import { isRecoverableTelegramNetworkError } from "./network-errors.js";
+
+const TELEGRAM_POLL_RESTART_POLICY = {
+  initialMs: 2000,
+  maxMs: 30_000,
+  factor: 1.8,
+  jitter: 0.25,
+};
+
+type TelegramBot = ReturnType<typeof createTelegramBot>;
+
+type TelegramPollingSessionOpts = {
+  token: string;
+  config: Parameters<typeof createTelegramBot>[0]["config"];
+  accountId: string;
+  runtime: Parameters<typeof createTelegramBot>[0]["runtime"];
+  proxyFetch: Parameters<typeof createTelegramBot>[0]["proxyFetch"];
+  abortSignal?: AbortSignal;
+  runnerOptions: RunOptions<unknown>;
+  getLastUpdateId: () => number | null;
+  persistUpdateId: (updateId: number) => Promise<void>;
+  log: (line: string) => void;
+};
+
+export class TelegramPollingSession {
+  #restartAttempts = 0;
+  #webhookCleared = false;
+  #forceRestarted = false;
+  #activeRunner: ReturnType<typeof run> | undefined;
+  #activeFetchAbort: AbortController | undefined;
+
+  constructor(private readonly opts: TelegramPollingSessionOpts) {}
+
+  get activeRunner() {
+    return this.#activeRunner;
+  }
+
+  markForceRestarted() {
+    this.#forceRestarted = true;
+  }
+
+  abortActiveFetch() {
+    this.#activeFetchAbort?.abort();
+  }
+
+  async runUntilAbort(): Promise<void> {
+    while (!this.opts.abortSignal?.aborted) {
+      const bot = await this.#createPollingBot();
+      if (!bot) {
+        continue;
+      }
+
+      const cleanupState = await this.#ensureWebhookCleanup(bot);
+      if (cleanupState === "retry") {
+        continue;
+      }
+      if (cleanupState === "exit") {
+        return;
+      }
+
+      const state = await this.#runPollingCycle(bot);
+      if (state === "exit") {
+        return;
+      }
+    }
+  }
+
+  async #waitBeforeRestart(buildLine: (delay: string) => string): Promise<boolean> {
+    this.#restartAttempts += 1;
+    const delayMs = computeBackoff(TELEGRAM_POLL_RESTART_POLICY, this.#restartAttempts);
+    const delay = formatDurationPrecise(delayMs);
+    this.opts.log(buildLine(delay));
+    try {
+      await sleepWithAbort(delayMs, this.opts.abortSignal);
+    } catch (sleepErr) {
+      if (this.opts.abortSignal?.aborted) {
+        return false;
+      }
+      throw sleepErr;
+    }
+    return true;
+  }
+
+  async #waitBeforeRetryOnRecoverableSetupError(err: unknown, logPrefix: string): Promise<boolean> {
+    if (this.opts.abortSignal?.aborted) {
+      return false;
+    }
+    if (!isRecoverableTelegramNetworkError(err, { context: "unknown" })) {
+      throw err;
+    }
+    return this.#waitBeforeRestart(
+      (delay) => `${logPrefix}: ${formatErrorMessage(err)}; retrying in ${delay}.`,
+    );
+  }
+
+  async #createPollingBot(): Promise<TelegramBot | undefined> {
+    const fetchAbortController = new AbortController();
+    this.#activeFetchAbort = fetchAbortController;
+    try {
+      return createTelegramBot({
+        token: this.opts.token,
+        runtime: this.opts.runtime,
+        proxyFetch: this.opts.proxyFetch,
+        config: this.opts.config,
+        accountId: this.opts.accountId,
+        fetchAbortSignal: fetchAbortController.signal,
+        updateOffset: {
+          lastUpdateId: this.opts.getLastUpdateId(),
+          onUpdateId: this.opts.persistUpdateId,
+        },
+      });
+    } catch (err) {
+      await this.#waitBeforeRetryOnRecoverableSetupError(err, "Telegram setup network error");
+      if (this.#activeFetchAbort === fetchAbortController) {
+        this.#activeFetchAbort = undefined;
+      }
+      return undefined;
+    }
+  }
+
+  async #ensureWebhookCleanup(bot: TelegramBot): Promise<"ready" | "retry" | "exit"> {
+    if (this.#webhookCleared) {
+      return "ready";
+    }
+    try {
+      await withTelegramApiErrorLogging({
+        operation: "deleteWebhook",
+        runtime: this.opts.runtime,
+        fn: () => bot.api.deleteWebhook({ drop_pending_updates: false }),
+      });
+      this.#webhookCleared = true;
+      return "ready";
+    } catch (err) {
+      const shouldRetry = await this.#waitBeforeRetryOnRecoverableSetupError(
+        err,
+        "Telegram webhook cleanup failed",
+      );
+      return shouldRetry ? "retry" : "exit";
+    }
+  }
+
+  async #runPollingCycle(bot: TelegramBot): Promise<"continue" | "exit"> {
+    const runner = run(bot, this.opts.runnerOptions);
+    this.#activeRunner = runner;
+    const fetchAbortController = this.#activeFetchAbort;
+    let stopPromise: Promise<void> | undefined;
+    const stopRunner = () => {
+      fetchAbortController?.abort();
+      stopPromise ??= Promise.resolve(runner.stop())
+        .then(() => undefined)
+        .catch(() => {
+          // Runner may already be stopped by abort/retry paths.
+        });
+      return stopPromise;
+    };
+    const stopOnAbort = () => {
+      if (this.opts.abortSignal?.aborted) {
+        void stopRunner();
+      }
+    };
+
+    this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+    try {
+      await runner.task();
+      if (this.opts.abortSignal?.aborted) {
+        return "exit";
+      }
+      const reason = this.#forceRestarted
+        ? "unhandled network error"
+        : "runner stopped (maxRetryTime exceeded or graceful stop)";
+      this.#forceRestarted = false;
+      const shouldRestart = await this.#waitBeforeRestart(
+        (delay) => `Telegram polling runner stopped (${reason}); restarting in ${delay}.`,
+      );
+      return shouldRestart ? "continue" : "exit";
+    } catch (err) {
+      this.#forceRestarted = false;
+      if (this.opts.abortSignal?.aborted) {
+        throw err;
+      }
+      const isConflict = isGetUpdatesConflict(err);
+      const isRecoverable = isRecoverableTelegramNetworkError(err, { context: "polling" });
+      if (!isConflict && !isRecoverable) {
+        throw err;
+      }
+      const reason = isConflict ? "getUpdates conflict" : "network error";
+      const errMsg = formatErrorMessage(err);
+      const shouldRestart = await this.#waitBeforeRestart(
+        (delay) => `Telegram ${reason}: ${errMsg}; retrying in ${delay}.`,
+      );
+      return shouldRestart ? "continue" : "exit";
+    } finally {
+      this.opts.abortSignal?.removeEventListener("abort", stopOnAbort);
+      await stopRunner();
+      this.#activeRunner = undefined;
+      if (this.#activeFetchAbort === fetchAbortController) {
+        this.#activeFetchAbort = undefined;
+      }
+    }
+  }
+}
+
+const isGetUpdatesConflict = (err: unknown) => {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const typed = err as {
+    error_code?: number;
+    errorCode?: number;
+    description?: string;
+    method?: string;
+    message?: string;
+  };
+  const errorCode = typed.error_code ?? typed.errorCode;
+  if (errorCode !== 409) {
+    return false;
+  }
+  const haystack = [typed.method, typed.description, typed.message]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes("getupdates");
+};


### PR DESCRIPTION
## Cherry-pick from upstream

**Source**: Issue #924 — 7 upstream commits evaluated, 4 applied, 3 skipped.

### Applied commits

| # | Upstream SHA | Subject | Fork SHA |
|---|---|---|---|
| 2 | `2767907ab` | fix(telegram): abort in-flight getUpdates fetch on shutdown | `c913b6424` |
| 3 | `6186f620d` | fix(telegram): use manual signal forwarding to avoid cross-realm AbortSignal | `d54312f5f` |
| 4 | `1d301f74a` | refactor: extract telegram polling session | `f45269443` |
| 7 | `93775ef6a` | fix(browser): enforce redirect-hop SSRF checks | `eb030b3cc` |

### Skipped commits

| # | Upstream SHA | Subject | Reason |
|---|---|---|---|
| 1 | `99cbda83a` | fix(media): accept reader read result type | Function `readChunkWithIdleTimeout` doesn't exist in fork (upstream-only) |
| 5 | `912aa8744` | test: fix Windows fake runtime bin fixtures | File `invoke-system-run-plan.test.ts` doesn't exist in fork (upstream refactoring) |
| 6 | `7b88249c9` | fix(telegram): bridge direct delivery to internal message:sent hooks | High adaptation cost: fork's delivery structure diverges (no `delivery.replies.ts`, missing `fire-and-forget.ts` and `message-hook-mappers.ts`) |

### Adaptations

**Commits 2-3** (Telegram shutdown abort):
- Removed `stalledRestart` variable (only used in intermediate upstream state between commits 2 and 4)
- Removed `stopBot()` call from finally block (upstream-only, added separately)
- Added `eslint-disable` for redundant type constituent in `ApiClientOptions["fetch"]`
- Removed `stopBot()` call in cleanup (function doesn't exist in fork)

**Commit 4** (Extract polling session):
- Adapted to fork's current `monitor.ts` (no watchdog/stall detection, no `confirmPersistedOffset`, no `normalizePersistedUpdateId`, no `stopBot` — all upstream-only additions)
- Used `RemoteClawConfig` instead of `OpenClawConfig`
- Added `#activeRunner = undefined` cleanup in finally block (upstream improvement from this commit)

**Commit 7** (Browser SSRF):
- Inlined `isPrivateNetworkAllowedByPolicy` check (upstream renamed+exported `resolveAllowPrivateNetwork` in ssrf.ts; fork still has it as private)
- Skipped `server-context.tab-ops.ts` changes (file doesn't exist in fork — upstream refactoring)
- Skipped `server-context.remote-profile-tab-ops.suite.ts` test (file doesn't exist in fork)
- Skipped CHANGELOG.md (OpenClaw branding)

### Authors

Co-authored-by: Peter Steinberger <steipete@gmail.com>

Cherry-picked-from: openclaw/openclaw@2767907ab
Cherry-picked-from: openclaw/openclaw@6186f620d
Cherry-picked-from: openclaw/openclaw@1d301f74a
Cherry-picked-from: openclaw/openclaw@93775ef6a