### PR TITLE
Cherry-pick 39a1c136: chore(ci): fix cross-platform symlink path assertions in agents file tests

### DIFF
--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 /* ------------------------------------------------------------------ */
@@ -676,7 +677,7 @@ describe("agents.files.get/set symlink safety", () => {
 
   it("rejects agents.files.get when allowlisted file symlink escapes workspace", async () => {
     const workspace = "/workspace/test-agent";
-    const candidate = `${workspace}/AGENTS.md`;
+    const candidate = path.resolve(workspace, "AGENTS.md");
     mocks.fsRealpath.mockImplementation(async (p: string) => {
       if (p === workspace) {
         return workspace;
@@ -709,7 +710,7 @@ describe("agents.files.get/set symlink safety", () => {
 
   it("rejects agents.files.set when allowlisted file symlink escapes workspace", async () => {
     const workspace = "/workspace/test-agent";
-    const candidate = `${workspace}/AGENTS.md`;
+    const candidate = path.resolve(workspace, "AGENTS.md");
     mocks.fsRealpath.mockImplementation(async (p: string) => {
       if (p === workspace) {
         return workspace;
@@ -744,8 +745,8 @@ describe("agents.files.get/set symlink safety", () => {
 
   it("allows in-workspace symlink targets for get/set", async () => {
     const workspace = "/workspace/test-agent";
-    const candidate = `${workspace}/AGENTS.md`;
-    const target = `${workspace}/policies/AGENTS.md`;
+    const candidate = path.resolve(workspace, "AGENTS.md");
+    const target = path.resolve(workspace, "policies", "AGENTS.md");
     const targetStat = makeFileStat({ size: 7, mtimeMs: 1700, dev: 9, ino: 42 });
 
     mocks.fsRealpath.mockImplementation(async (p: string) => {


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [39a1c13635](https://github.com/openclaw/openclaw/commit/39a1c13635)
**Tier**: AUTO-PICK

> chore(ci): fix cross-platform symlink path assertions in agents file tests