### PR TITLE
Cherry-pick 39d725f4: Daemon tests: guard undefined runtime status

### DIFF
--- a/src/daemon/launchd.integration.test.ts
+++ b/src/daemon/launchd.integration.test.ts
@@ -45,7 +45,7 @@ async function waitForRunningRuntime(params: {
   let lastPid: number | undefined;
   while (Date.now() < deadline) {
     const runtime = await readLaunchAgentRuntime(params.env);
-    lastStatus = runtime.status;
+    lastStatus = runtime.status ?? "unknown";
     lastPid = runtime.pid;
     if (
       runtime.status === "running" &&


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [39d725f4d3](https://github.com/openclaw/openclaw/commit/39d725f4d3)
**Tier**: FAST-PICK

> Daemon tests: guard undefined runtime status