### PR TITLE
Cherry-pick cf311978ea: fix(plugins): fallback bundled channel specs when npm install returns 404

### DIFF
--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -6,6 +6,7 @@ import type { RemoteClawConfig } from "../config/config.js";
 import { loadConfig, writeConfigFile } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolveArchiveKind } from "../infra/archive.js";
+import { findBundledPluginByNpmSpec } from "../plugins/bundled-sources.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
 import { installPluginFromNpmSpec, installPluginFromPath } from "../plugins/install.js";
 import { recordPluginInstall } from "../plugins/installs.js";
@@ -151,6 +152,16 @@ function logSlotWarnings(warnings: string[]) {
   for (const warning of warnings) {
     defaultRuntime.log(theme.warn(warning));
   }
+}
+
+function isPackageNotFoundInstallError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("npm pack failed:") &&
+    (lower.includes("e404") ||
+      lower.includes("404 not found") ||
+      lower.includes("could not be found"))
+  );
 }
 
 export function registerPluginsCli(program: Command) {
@@ -623,8 +634,52 @@ export function registerPluginsCli(program: Command) {
         logger: createPluginInstallLogger(),
       });
       if (!result.ok) {
-        defaultRuntime.error(result.error);
-        process.exit(1);
+        const bundledFallback = isPackageNotFoundInstallError(result.error)
+          ? findBundledPluginByNpmSpec({ spec: raw })
+          : undefined;
+        if (!bundledFallback) {
+          defaultRuntime.error(result.error);
+          process.exit(1);
+        }
+
+        const existing = cfg.plugins?.load?.paths ?? [];
+        const mergedPaths = Array.from(new Set([...existing, bundledFallback.localPath]));
+        let next: RemoteClawConfig = {
+          ...cfg,
+          plugins: {
+            ...cfg.plugins,
+            load: {
+              ...cfg.plugins?.load,
+              paths: mergedPaths,
+            },
+            entries: {
+              ...cfg.plugins?.entries,
+              [bundledFallback.pluginId]: {
+                ...(cfg.plugins?.entries?.[bundledFallback.pluginId] as object | undefined),
+                enabled: true,
+              },
+            },
+          },
+        };
+        next = recordPluginInstall(next, {
+          pluginId: bundledFallback.pluginId,
+          source: "path",
+          spec: raw,
+          sourcePath: bundledFallback.localPath,
+          installPath: bundledFallback.localPath,
+        });
+        const slotResult = applySlotSelectionForPlugin(next, bundledFallback.pluginId);
+        next = slotResult.config;
+        await writeConfigFile(next);
+        logSlotWarnings(slotResult.warnings);
+        defaultRuntime.log(
+          theme.warn(
+            `npm package unavailable for ${raw}; using bundled plugin at ${shortenHomePath(bundledFallback.localPath)}.`,
+          ),
+        );
+        defaultRuntime.log(`Installed plugin: ${bundledFallback.pluginId}`);
+        defaultRuntime.log(`Restart the gateway to load plugins.`);
+        return;
       }
       // Ensure config validation sees newly installed plugin(s) even if the cache was warmed at startup.
       clearPluginManifestRegistryCache();

--- a/src/plugins/bundled-sources.test.ts
+++ b/src/plugins/bundled-sources.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { findBundledPluginByNpmSpec, resolveBundledPluginSources } from "./bundled-sources.js";
+
+const discoverRemoteClawPluginsMock = vi.fn();
+const loadPluginManifestMock = vi.fn();
+
+vi.mock("./discovery.js", () => ({
+  discoverRemoteClawPlugins: (...args: unknown[]) => discoverRemoteClawPluginsMock(...args),
+}));
+
+vi.mock("./manifest.js", () => ({
+  loadPluginManifest: (...args: unknown[]) => loadPluginManifestMock(...args),
+}));
+
+describe("bundled plugin sources", () => {
+  beforeEach(() => {
+    discoverRemoteClawPluginsMock.mockReset();
+    loadPluginManifestMock.mockReset();
+  });
+
+  it("resolves bundled sources keyed by plugin id", () => {
+    discoverRemoteClawPluginsMock.mockReturnValue({
+      candidates: [
+        {
+          origin: "global",
+          rootDir: "/global/feishu",
+          packageName: "@remoteclaw/feishu",
+          packageManifest: { install: { npmSpec: "@remoteclaw/feishu" } },
+        },
+        {
+          origin: "bundled",
+          rootDir: "/app/extensions/feishu",
+          packageName: "@remoteclaw/feishu",
+          packageManifest: { install: { npmSpec: "@remoteclaw/feishu" } },
+        },
+        {
+          origin: "bundled",
+          rootDir: "/app/extensions/feishu-dup",
+          packageName: "@remoteclaw/feishu",
+          packageManifest: { install: { npmSpec: "@remoteclaw/feishu" } },
+        },
+        {
+          origin: "bundled",
+          rootDir: "/app/extensions/msteams",
+          packageName: "@remoteclaw/msteams",
+          packageManifest: { install: { npmSpec: "@remoteclaw/msteams" } },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    loadPluginManifestMock.mockImplementation((rootDir: string) => {
+      if (rootDir === "/app/extensions/feishu") {
+        return { ok: true, manifest: { id: "feishu" } };
+      }
+      if (rootDir === "/app/extensions/msteams") {
+        return { ok: true, manifest: { id: "msteams" } };
+      }
+      return {
+        ok: false,
+        error: "invalid manifest",
+        manifestPath: `${rootDir}/remoteclaw.plugin.json`,
+      };
+    });
+
+    const map = resolveBundledPluginSources({});
+
+    expect(Array.from(map.keys())).toEqual(["feishu", "msteams"]);
+    expect(map.get("feishu")).toEqual({
+      pluginId: "feishu",
+      localPath: "/app/extensions/feishu",
+      npmSpec: "@remoteclaw/feishu",
+    });
+  });
+
+  it("finds bundled source by npm spec", () => {
+    discoverRemoteClawPluginsMock.mockReturnValue({
+      candidates: [
+        {
+          origin: "bundled",
+          rootDir: "/app/extensions/feishu",
+          packageName: "@remoteclaw/feishu",
+          packageManifest: { install: { npmSpec: "@remoteclaw/feishu" } },
+        },
+      ],
+      diagnostics: [],
+    });
+    loadPluginManifestMock.mockReturnValue({ ok: true, manifest: { id: "feishu" } });
+
+    const resolved = findBundledPluginByNpmSpec({ spec: "@remoteclaw/feishu" });
+    const missing = findBundledPluginByNpmSpec({ spec: "@remoteclaw/not-found" });
+
+    expect(resolved?.pluginId).toBe("feishu");
+    expect(resolved?.localPath).toBe("/app/extensions/feishu");
+    expect(missing).toBeUndefined();
+  });
+});

--- a/src/plugins/bundled-sources.ts
+++ b/src/plugins/bundled-sources.ts
@@ -1,0 +1,59 @@
+import { discoverRemoteClawPlugins } from "./discovery.js";
+import { loadPluginManifest } from "./manifest.js";
+
+export type BundledPluginSource = {
+  pluginId: string;
+  localPath: string;
+  npmSpec?: string;
+};
+
+export function resolveBundledPluginSources(params: {
+  workspaceDir?: string;
+}): Map<string, BundledPluginSource> {
+  const discovery = discoverRemoteClawPlugins({ workspaceDir: params.workspaceDir });
+  const bundled = new Map<string, BundledPluginSource>();
+
+  for (const candidate of discovery.candidates) {
+    if (candidate.origin !== "bundled") {
+      continue;
+    }
+    const manifest = loadPluginManifest(candidate.rootDir);
+    if (!manifest.ok) {
+      continue;
+    }
+    const pluginId = manifest.manifest.id;
+    if (bundled.has(pluginId)) {
+      continue;
+    }
+
+    const npmSpec =
+      candidate.packageManifest?.install?.npmSpec?.trim() ||
+      candidate.packageName?.trim() ||
+      undefined;
+
+    bundled.set(pluginId, {
+      pluginId,
+      localPath: candidate.rootDir,
+      npmSpec,
+    });
+  }
+
+  return bundled;
+}
+
+export function findBundledPluginByNpmSpec(params: {
+  spec: string;
+  workspaceDir?: string;
+}): BundledPluginSource | undefined {
+  const targetSpec = params.spec.trim();
+  if (!targetSpec) {
+    return undefined;
+  }
+  const bundled = resolveBundledPluginSources({ workspaceDir: params.workspaceDir });
+  for (const source of bundled.values()) {
+    if (source.npmSpec === targetSpec) {
+      return source;
+    }
+  }
+  return undefined;
+}

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -2,10 +2,9 @@ import fs from "node:fs/promises";
 import type { RemoteClawConfig } from "../config/config.js";
 import type { UpdateChannel } from "../infra/update-channels.js";
 import { resolveUserPath } from "../utils.js";
-import { discoverRemoteClawPlugins } from "./discovery.js";
+import { resolveBundledPluginSources } from "./bundled-sources.js";
 import { installPluginFromNpmSpec, resolvePluginInstallDir } from "./install.js";
 import { buildNpmResolutionInstallFields, recordPluginInstall } from "./installs.js";
-import { loadPluginManifest } from "./manifest.js";
 
 export type PluginUpdateLogger = {
   info?: (message: string) => void;
@@ -52,12 +51,6 @@ export type PluginChannelSyncResult = {
   summary: PluginChannelSyncSummary;
 };
 
-type BundledPluginSource = {
-  pluginId: string;
-  localPath: string;
-  npmSpec?: string;
-};
-
 type InstallIntegrityDrift = {
   spec: string;
   expectedIntegrity: string;
@@ -76,40 +69,6 @@ async function readInstalledPackageVersion(dir: string): Promise<string | undefi
   } catch {
     return undefined;
   }
-}
-
-function resolveBundledPluginSources(params: {
-  workspaceDir?: string;
-}): Map<string, BundledPluginSource> {
-  const discovery = discoverRemoteClawPlugins({ workspaceDir: params.workspaceDir });
-  const bundled = new Map<string, BundledPluginSource>();
-
-  for (const candidate of discovery.candidates) {
-    if (candidate.origin !== "bundled") {
-      continue;
-    }
-    const manifest = loadPluginManifest(candidate.rootDir);
-    if (!manifest.ok) {
-      continue;
-    }
-    const pluginId = manifest.manifest.id;
-    if (bundled.has(pluginId)) {
-      continue;
-    }
-
-    const npmSpec =
-      candidate.packageManifest?.install?.npmSpec?.trim() ||
-      candidate.packageName?.trim() ||
-      undefined;
-
-    bundled.set(pluginId, {
-      pluginId,
-      localPath: candidate.rootDir,
-      npmSpec,
-    });
-  }
-
-  return bundled;
 }
 
 function pathsEqual(left?: string, right?: string): boolean {


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [cf311978ea](https://github.com/openclaw/openclaw/commit/cf311978ea)
**Tier**: AUTO-PICK

> fix(plugins): fallback bundled channel specs when npm install returns 404

### Conflict resolution

- `src/plugins/update.ts`: Upstream extracted inline `resolveBundledPluginSources` to new `bundled-sources.ts`. Our fork had the rebranded inline version — took upstream's extraction, deleted inline copy.
- `src/plugins/bundled-sources.ts` (new): Rebranded `discoverOpenClawPlugins` → `discoverRemoteClawPlugins`.
- `src/plugins/bundled-sources.test.ts` (new): Rebranded mock names, npm specs (`@openclaw/` → `@remoteclaw/`), manifest filename (`openclaw.plugin.json` → `remoteclaw.plugin.json`).
- `src/cli/plugins-cli.ts`: Rebranded `OpenClawConfig` → `RemoteClawConfig`.