### PR TITLE
Cherry-pick 42cf32c38: fix(browser): land PR #26015 query-token auth for /json relay routes

### DIFF
--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -332,6 +332,19 @@ describe("chrome extension relay server", () => {
     ext.close();
   });
 
+  it("accepts /json endpoints with relay token query param", async () => {
+    const port = await getFreePort();
+    cdpUrl = `http://127.0.0.1:${port}`;
+    await ensureChromeExtensionRelayServer({ cdpUrl });
+
+    const token = relayAuthHeaders(cdpUrl)["x-openclaw-relay-token"];
+    expect(token).toBeTruthy();
+    const versionRes = await fetch(
+      `${cdpUrl}/json/version?token=${encodeURIComponent(String(token))}`,
+    );
+    expect(versionRes.status).toBe(200);
+  });
+
   it("accepts raw gateway token for relay auth compatibility", async () => {
     const port = await getFreePort();
     cdpUrl = `http://127.0.0.1:${port}`;

--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -337,7 +337,7 @@ describe("chrome extension relay server", () => {
     cdpUrl = `http://127.0.0.1:${port}`;
     await ensureChromeExtensionRelayServer({ cdpUrl });
 
-    const token = relayAuthHeaders(cdpUrl)["x-openclaw-relay-token"];
+    const token = relayAuthHeaders(cdpUrl)["x-remoteclaw-relay-token"];
     expect(token).toBeTruthy();
     const versionRes = await fetch(
       `${cdpUrl}/json/version?token=${encodeURIComponent(String(token))}`,

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -399,7 +399,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
     }
 
     if (path.startsWith("/json")) {
-      const token = getHeader(req, RELAY_AUTH_HEADER)?.trim();
+      const token = getRelayAuthTokenFromRequest(req, url);
       if (!token || !relayAuthTokens.has(token)) {
         res.writeHead(401);
         res.end("Unauthorized");


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [42cf32c38](https://github.com/openclaw/openclaw/commit/42cf32c386)
**Tier**: AUTO-PICK

> fix(browser): land PR #26015 query-token auth for /json relay routes