### PR TITLE
Cherry-pick 296210636: fix(telegram): Log bound port if ephemeral (0) is configured

### DIFF
--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -304,6 +304,7 @@ describe("startTelegramWebhook", () => {
 
   it("registers webhook using the bound listening port when port is 0", async () => {
     setWebhookSpy.mockClear();
+    const runtimeLog = vi.fn();
     const abort = new AbortController();
     const { server } = await startTelegramWebhook({
       token: "tok",
@@ -311,6 +312,7 @@ describe("startTelegramWebhook", () => {
       port: 0,
       abortSignal: abort.signal,
       path: "/hook",
+      runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
     });
     try {
       const addr = server.address();
@@ -324,6 +326,9 @@ describe("startTelegramWebhook", () => {
         expect.objectContaining({
           secret_token: "secret",
         }),
+      );
+      expect(runtimeLog).toHaveBeenCalledWith(
+        `webhook local listener on http://127.0.0.1:${addr.port}/hook`,
       );
     } finally {
       abort.abort();

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -222,6 +222,8 @@ export async function startTelegramWebhook(opts: {
     port,
     host,
   });
+  const boundAddress = server.address();
+  const boundPort = boundAddress && typeof boundAddress !== "string" ? boundAddress.port : port;
 
   const publicUrl = resolveWebhookPublicUrl({
     configuredPublicUrl: opts.publicUrl,
@@ -250,7 +252,7 @@ export async function startTelegramWebhook(opts: {
     throw err;
   }
 
-  runtime.log?.(`webhook local listener on http://${host}:${port}${path}`);
+  runtime.log?.(`webhook local listener on http://${host}:${boundPort}${path}`);
   runtime.log?.(`webhook advertised to telegram on ${publicUrl}`);
 
   let shutDown = false;


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [296210636d](https://github.com/openclaw/openclaw/commit/296210636d)
**Tier**: AUTO-PICK

> fix(telegram): Log bound port if ephemeral (0) is configured

Closes #629 (3/4)