### PR TITLE
Cherry-pick dbfdf60a4: fix(telegram): Allow ephemeral webhookPort

### DIFF
--- a/src/config/telegram-webhook-port.test.ts
+++ b/src/config/telegram-webhook-port.test.ts
@@ -15,13 +15,26 @@ describe("Telegram webhookPort config", () => {
     expect(res.ok).toBe(true);
   });
 
-  it("rejects non-positive webhookPort", () => {
+  it("accepts webhookPort set to 0 for ephemeral port binding", () => {
     const res = validateConfigObject({
       channels: {
         telegram: {
           webhookUrl: "https://example.com/telegram-webhook",
           webhookSecret: "secret",
           webhookPort: 0,
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects negative webhookPort", () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          webhookUrl: "https://example.com/telegram-webhook",
+          webhookSecret: "secret",
+          webhookPort: -1,
         },
       },
     });

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -191,9 +191,11 @@ export const TelegramAccountSchemaBase = z
     webhookPort: z
       .number()
       .int()
-      .positive()
+      .nonnegative()
       .optional()
-      .describe("Local bind port for the webhook listener. Defaults to 8787."),
+      .describe(
+        "Local bind port for the webhook listener. Defaults to 8787; set to 0 to let the OS assign an ephemeral port.",
+      ),
     actions: z
       .object({
         reactions: z.boolean().optional(),


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [dbfdf60a42](https://github.com/openclaw/openclaw/commit/dbfdf60a42)
**Tier**: AUTO-PICK

> fix(telegram): Allow ephemeral webhookPort

Closes #629 (4/4)