### PR TITLE
Cherry-pick eb9a968336: fix(slack): suppress NO_REPLY before Slack API call

### DIFF
--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -9,6 +9,7 @@ import {
   resolveChunkMode,
   resolveTextChunkLimit,
 } from "../auto-reply/chunk.js";
+import { isSilentReplyText } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
@@ -231,6 +232,10 @@ export async function sendMessageSlack(
   opts: SlackSendOpts = {},
 ): Promise<SlackSendResult> {
   const trimmedMessage = message?.trim() ?? "";
+  if (isSilentReplyText(trimmedMessage) && !opts.mediaUrl && !opts.blocks) {
+    logVerbose("slack send: suppressed NO_REPLY token before API call");
+    return { messageId: "suppressed", channelId: "" };
+  }
   const blocks = opts.blocks == null ? undefined : validateSlackBlocksArray(opts.blocks);
   if (!trimmedMessage && !opts.mediaUrl && !blocks) {
     throw new Error("Slack send requires text, blocks, or media");


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [eb9a968336](https://github.com/openclaw/openclaw/commit/eb9a968336)
**Tier**: AUTO-PICK

> fix(slack): suppress NO_REPLY before Slack API call