### PR TITLE
Cherry-pick 1560f02: Gateway: mark restart callback promise as intentionally detached

### DIFF
--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -254,7 +254,7 @@ export function startGatewayConfigReloader(opts: {
   initialConfig: RemoteClawConfig;
   readSnapshot: () => Promise<ConfigFileSnapshot>;
   onHotReload: (plan: GatewayReloadPlan, nextConfig: RemoteClawConfig) => Promise<void>;
-  onRestart: (plan: GatewayReloadPlan, nextConfig: RemoteClawConfig) => void;
+  onRestart: (plan: GatewayReloadPlan, nextConfig: RemoteClawConfig) => Promise<void> | void;
   log: {
     info: (msg: string) => void;
     warn: (msg: string) => void;

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -290,7 +290,7 @@ export function startGatewayConfigReloader(opts: {
       return;
     }
     restartQueued = true;
-    opts.onRestart(plan, nextConfig);
+    void opts.onRestart(plan, nextConfig);
   };
 
   const handleMissingSnapshot = (snapshot: ConfigFileSnapshot): boolean => {


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [`1560f02561`](https://github.com/openclaw/openclaw/commit/1560f02561)
**Author**: joshavant
**Tier**: AUTO-PICK

> Gateway: mark restart callback promise as intentionally detached

- `src/gateway/config-reload.ts`