### PR TITLE
Cherry-pick 3dbb6be: Gateway tests: handle async restart callback path

### DIFF
--- a/src/gateway/server.reload.test.ts
+++ b/src/gateway/server.reload.test.ts
@@ -281,7 +281,7 @@ describe("gateway hot reload", () => {
       const signalSpy = vi.fn();
       process.once("SIGUSR1", signalSpy);
 
-      onRestart?.(
+      const restartResult = onRestart?.(
         {
           changedPaths: ["gateway.port"],
           restartGateway: true,
@@ -297,6 +297,7 @@ describe("gateway hot reload", () => {
         },
         {},
       );
+      await Promise.resolve(restartResult);
 
       expect(signalSpy).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [`3dbb6be270`](https://github.com/openclaw/openclaw/commit/3dbb6be270)
**Author**: joshavant
**Tier**: AUTO-PICK

> Gateway tests: handle async restart callback path

- `src/gateway/server.reload.test.ts`

Depends on #1124