### PR TITLE
Cherry-pick 62a248eb: Swift protocol model field additions

### DIFF
--- a/apps/macos/Sources/RemoteClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/RemoteClawProtocol/GatewayModels.swift
@@ -2964,6 +2964,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
     public let publickey: String
     public let displayname: String?
     public let platform: String?
+    public let devicefamily: String?
     public let clientid: String?
     public let clientmode: String?
     public let role: String?
@@ -2980,6 +2981,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
         publickey: String,
         displayname: String?,
         platform: String?,
+        devicefamily: String?,
         clientid: String?,
         clientmode: String?,
         role: String?,
@@ -2995,6 +2997,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
         self.publickey = publickey
         self.displayname = displayname
         self.platform = platform
+        self.devicefamily = devicefamily
         self.clientid = clientid
         self.clientmode = clientmode
         self.role = role
@@ -3012,6 +3015,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
         case publickey = "publicKey"
         case displayname = "displayName"
         case platform
+        case devicefamily = "deviceFamily"
         case clientid = "clientId"
         case clientmode = "clientMode"
         case role

--- a/apps/shared/RemoteClawKit/Sources/RemoteClawProtocol/GatewayModels.swift
+++ b/apps/shared/RemoteClawKit/Sources/RemoteClawProtocol/GatewayModels.swift
@@ -2964,6 +2964,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
     public let publickey: String
     public let displayname: String?
     public let platform: String?
+    public let devicefamily: String?
     public let clientid: String?
     public let clientmode: String?
     public let role: String?
@@ -2980,6 +2981,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
         publickey: String,
         displayname: String?,
         platform: String?,
+        devicefamily: String?,
         clientid: String?,
         clientmode: String?,
         role: String?,
@@ -2995,6 +2997,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
         self.publickey = publickey
         self.displayname = displayname
         self.platform = platform
+        self.devicefamily = devicefamily
         self.clientid = clientid
         self.clientmode = clientmode
         self.role = role
@@ -3012,6 +3015,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
         case publickey = "publicKey"
         case displayname = "displayName"
         case platform
+        case devicefamily = "deviceFamily"
         case clientid = "clientId"
         case clientmode = "clientMode"
         case role


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [`62a248eb`](https://github.com/openclaw/openclaw/commit/62a248eb993801b38e122f5c673b14847510b4f5)
**Tier**: PICK (needs rebrand)

> core(protocol): pnpm protocol:check

Adds missing `devicefamily` field to `DevicePairRequestedEvent` Swift struct (property, init parameter, init body, CodingKeys).

Files:
- `apps/macos/Sources/RemoteClawProtocol/GatewayModels.swift`
- `apps/shared/RemoteClawKit/Sources/RemoteClawProtocol/GatewayModels.swift`