### PR TITLE
Cherry-pick 262bca9bd: fix: restore dm command and self-chat auth behavior

### DIFF
--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -110,7 +110,8 @@ describe("runCommandWithTimeout", () => {
       ],
       {
         timeoutMs: 7_000,
-        noOutputTimeoutMs: 450,
+        // Keep a generous idle budget; CI event-loop stalls can exceed 450ms.
+        noOutputTimeoutMs: 900,
       },
     );
 

--- a/src/security/dm-policy-shared.test.ts
+++ b/src/security/dm-policy-shared.test.ts
@@ -188,6 +188,26 @@ describe("security/dm-policy-shared", () => {
     expect(resolved.shouldBlockControlCommand).toBe(false);
   });
 
+  it("does not auto-authorize dm commands in open mode without explicit allowlists", () => {
+    const resolved = resolveDmGroupAccessWithCommandGate({
+      isGroup: false,
+      dmPolicy: "open",
+      groupPolicy: "allowlist",
+      allowFrom: [],
+      groupAllowFrom: [],
+      storeAllowFrom: [],
+      isSenderAllowed: () => false,
+      command: {
+        useAccessGroups: true,
+        allowTextCommands: true,
+        hasControlCommand: true,
+      },
+    });
+    expect(resolved.decision).toBe("allow");
+    expect(resolved.commandAuthorized).toBe(false);
+    expect(resolved.shouldBlockControlCommand).toBe(false);
+  });
+
   it("keeps allowlist mode strict in shared resolver (no pairing-store fallback)", () => {
     const resolved = resolveDmGroupAccessWithLists({
       isGroup: false,

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -255,7 +255,7 @@ export function resolveDmGroupAccessWithCommandGate(params: {
 
   return {
     ...access,
-    commandAuthorized: params.isGroup ? commandGate.commandAuthorized : access.decision === "allow",
+    commandAuthorized: commandGate.commandAuthorized,
     shouldBlockControlCommand: params.isGroup && commandGate.shouldBlock,
   };
 }

--- a/src/web/inbound/access-control.test.ts
+++ b/src/web/inbound/access-control.test.ts
@@ -130,4 +130,31 @@ describe("WhatsApp dmPolicy precedence", () => {
     expectSilentlyBlocked(result);
     expect(readAllowFromStoreMock).not.toHaveBeenCalled();
   });
+
+  it("always allows same-phone DMs even when allowFrom is restrictive", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          dmPolicy: "pairing",
+          allowFrom: ["+15550001111"],
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550009999",
+      selfE164: "+15550009999",
+      senderE164: "+15550009999",
+      group: false,
+      pushName: "Owner",
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550009999@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Cherry-pick of upstream [`262bca9bd`](https://github.com/openclaw/openclaw/commit/262bca9bdd7b637c188c7436833de88fe6dbf4f6) (PARTIAL-PICK — skipped `src/secrets/apply.test.ts` which doesn't exist in the fork).

**Security fix**: `resolveDmGroupAccessWithCommandGate` no longer auto-authorizes DM commands when `access.decision === "allow"` (open mode). Now consistently delegates to `commandGate.commandAuthorized` for both DM and group contexts.

**Test reliability**: Launchd integration test timeouts increased, exec idle-budget bumped for CI stability, self-chat DM auth test added.

Part of #638.

## Changes
- `src/security/dm-policy-shared.ts`: Fix `commandAuthorized` to use `commandGate.commandAuthorized` instead of `access.decision === "allow"` for DM
- `src/security/dm-policy-shared.test.ts`: New test for open-mode DM command non-authorization
- `src/web/inbound/access-control.test.ts`: New self-chat DM auth test
- `src/daemon/launchd.integration.test.ts`: Timeout + withTimeout helper for CI stability
- `src/process/exec.test.ts`: Bump noOutputTimeoutMs 450→900 for CI

## Test plan
- [x] Build passes (`npm run build`)
- [x] dm-policy-shared tests pass (47 tests)
- [x] access-control tests pass (6 tests)
- [x] exec tests pass (6 tests)