### PR TITLE
Cherry-pick dc6e4a5b1: fix: harden dm command authorization in open mode

### DIFF
--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -688,7 +688,6 @@ export async function processMessage(
           chatIdentifier: message.chatIdentifier ?? undefined,
         })
       : false;
-  const dmAuthorized = dmPolicy === "open" || ownerAllowedForCommands;
   const commandGate = resolveControlCommandGate({
     useAccessGroups,
     authorizers: [
@@ -698,7 +697,7 @@ export async function processMessage(
     allowTextCommands: true,
     hasControlCommand: hasControlCmd,
   });
-  const commandAuthorized = isGroup ? commandGate.commandAuthorized : dmAuthorized;
+  const commandAuthorized = commandGate.commandAuthorized;
 
   // Block control commands from unauthorized senders in groups
   if (isGroup && commandGate.shouldBlock) {

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -2287,6 +2287,51 @@ describe("BlueBubbles webhook monitor", () => {
 
       expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     });
+
+    it("does not auto-authorize DM control commands in open mode without allowlists", async () => {
+      mockHasControlCommand.mockReturnValue(true);
+
+      const account = createMockAccount({
+        dmPolicy: "open",
+        allowFrom: [],
+      });
+      const config: RemoteClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: "/status",
+          handle: { address: "+15559999999" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-dm-open-unauthorized",
+          date: Date.now(),
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+      const latestDispatch =
+        mockDispatchReplyWithBufferedBlockDispatcher.mock.calls[
+          mockDispatchReplyWithBufferedBlockDispatcher.mock.calls.length - 1
+        ]?.[0];
+      expect(latestDispatch?.ctx?.CommandAuthorized).toBe(false);
+    });
   });
 
   describe("typing/read receipt toggles", () => {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -460,8 +460,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       allowTextCommands,
       hasControlCommand,
     });
-    const commandAuthorized =
-      kind === "direct" ? accessDecision.decision === "allow" : commandGate.commandAuthorized;
+    const commandAuthorized = commandGate.commandAuthorized;
 
     if (accessDecision.decision !== "allow") {
       if (kind === "direct") {

--- a/src/imessage/monitor/inbound-processing.test.ts
+++ b/src/imessage/monitor/inbound-processing.test.ts
@@ -58,3 +58,71 @@ describe("describeIMessageEchoDropLog", () => {
     ).toContain("id=abc-123");
   });
 });
+
+describe("resolveIMessageInboundDecision command auth", () => {
+  const cfg = {} as RemoteClawConfig;
+
+  it("does not auto-authorize DM commands in open mode without allowlists", () => {
+    const decision = resolveIMessageInboundDecision({
+      cfg,
+      accountId: "default",
+      message: {
+        id: 100,
+        sender: "+15555550123",
+        text: "/status",
+        is_from_me: false,
+        is_group: false,
+      },
+      opts: undefined,
+      messageText: "/status",
+      bodyText: "/status",
+      allowFrom: [],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      historyLimit: 0,
+      groupHistories: new Map(),
+      echoCache: undefined,
+      logVerbose: undefined,
+    });
+
+    expect(decision.kind).toBe("dispatch");
+    if (decision.kind !== "dispatch") {
+      return;
+    }
+    expect(decision.commandAuthorized).toBe(false);
+  });
+
+  it("authorizes DM commands for senders in pairing-store allowlist", () => {
+    const decision = resolveIMessageInboundDecision({
+      cfg,
+      accountId: "default",
+      message: {
+        id: 101,
+        sender: "+15555550123",
+        text: "/status",
+        is_from_me: false,
+        is_group: false,
+      },
+      opts: undefined,
+      messageText: "/status",
+      bodyText: "/status",
+      allowFrom: [],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+      dmPolicy: "open",
+      storeAllowFrom: ["+15555550123"],
+      historyLimit: 0,
+      groupHistories: new Map(),
+      echoCache: undefined,
+      logVerbose: undefined,
+    });
+
+    expect(decision.kind).toBe("dispatch");
+    if (decision.kind !== "dispatch") {
+      return;
+    }
+    expect(decision.commandAuthorized).toBe(true);
+  });
+});

--- a/src/imessage/monitor/inbound-processing.ts
+++ b/src/imessage/monitor/inbound-processing.ts
@@ -161,7 +161,6 @@ export function resolveIMessageInboundDecision(params: {
   });
   const effectiveDmAllowFrom = accessDecision.effectiveAllowFrom;
   const effectiveGroupAllowFrom = accessDecision.effectiveGroupAllowFrom;
-  const dmAuthorized = !isGroup && accessDecision.decision === "allow";
 
   if (accessDecision.decision !== "allow") {
     if (isGroup) {
@@ -287,7 +286,7 @@ export function resolveIMessageInboundDecision(params: {
     allowTextCommands: true,
     hasControlCommand: hasControlCommandInMessage,
   });
-  const commandAuthorized = isGroup ? commandGate.commandAuthorized : dmAuthorized;
+  const commandAuthorized = commandGate.commandAuthorized;
   if (isGroup && commandGate.shouldBlock) {
     if (params.logVerbose) {
       logInboundDrop({

--- a/src/signal/monitor/event-handler.inbound-contract.test.ts
+++ b/src/signal/monitor/event-handler.inbound-contract.test.ts
@@ -143,4 +143,33 @@ describe("signal createSignalEventHandler inbound contract", () => {
       expect.any(Object),
     );
   });
+
+  it("does not auto-authorize DM commands in open mode without allowlists", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 } },
+          channels: { signal: { dmPolicy: "open", allowFrom: [] } },
+        },
+        allowFrom: [],
+        groupAllowFrom: [],
+        account: "+15550009999",
+        blockStreaming: false,
+        historyLimit: 0,
+        groupHistories: new Map(),
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "/status",
+          attachments: [],
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.CommandAuthorized).toBe(false);
+  });
 });

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -475,7 +475,6 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const dmAccess = resolveAccessDecision(false);
     const effectiveDmAllow = dmAccess.effectiveAllowFrom;
     const effectiveGroupAllow = dmAccess.effectiveGroupAllowFrom;
-    const dmAllowed = dmAccess.decision === "allow";
 
     if (
       reaction &&
@@ -573,7 +572,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       allowTextCommands: true,
       hasControlCommand: hasControlCommandInMessage,
     });
-    const commandAuthorized = isGroup ? commandGate.commandAuthorized : dmAllowed;
+    const commandAuthorized = commandGate.commandAuthorized;
     if (isGroup && commandGate.shouldBlock) {
       logInboundDrop({
         log: logVerbose,


### PR DESCRIPTION
## Summary

Cherry-pick of upstream [`dc6e4a5b1`](https://github.com/openclaw/openclaw/commit/dc6e4a5b135db80215fa963d77dd496125a51637).

**Security fix**: Removes per-channel `dmAuthorized` bypass that auto-authorized DM commands when `access.decision === "allow"` (open mode). Now all channels consistently delegate to `commandGate.commandAuthorized`, matching the shared function fix from `262bca9bd`.

**Channels hardened**: bluebubbles, mattermost, imessage, signal.

**Skipped**: `extensions/mattermost/src/mattermost/monitor.authz.test.ts` (depends on `monitor-auth.ts` which doesn't exist in the fork).

Part of #638.

## Changes
- `extensions/bluebubbles/src/monitor-processing.ts`: Remove `dmAuthorized`, use `commandGate.commandAuthorized`
- `extensions/mattermost/src/mattermost/monitor.ts`: Same pattern
- `src/imessage/monitor/inbound-processing.ts`: Same pattern
- `src/signal/monitor/event-handler.ts`: Same pattern
- `extensions/bluebubbles/src/monitor.test.ts`: New open-mode DM command test
- `src/imessage/monitor/inbound-processing.test.ts`: Two new command auth tests
- `src/signal/monitor/event-handler.inbound-contract.test.ts`: New open-mode DM command test

## Fork adaptations
- `OpenClawConfig` → `RemoteClawConfig` in new test code

## Test plan
- [x] Build passes (`npm run build`)
- [x] bluebubbles tests pass (68 tests)
- [x] imessage inbound-processing tests pass (5 tests)
- [x] signal inbound-contract tests pass (3 tests)