### PR TITLE
Cherry-pick 9a4b226: fix(security): bind node system.run approvals to env

### DIFF
--- a/apps/macos/Sources/RemoteClaw/HostEnvSanitizer.swift
+++ b/apps/macos/Sources/RemoteClaw/HostEnvSanitizer.swift
@@ -14,6 +14,7 @@ enum HostEnvSanitizer {
         "RUBYOPT",
         "BASH_ENV",
         "ENV",
+        "GIT_EXTERNAL_DIFF",
         "SHELL",
         "SHELLOPTS",
         "PS4",

--- a/src/gateway/system-run-approval-env-binding.test.ts
+++ b/src/gateway/system-run-approval-env-binding.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildSystemRunApprovalEnvBinding,
+  matchSystemRunApprovalEnvBinding,
+} from "./system-run-approval-env-binding.js";
+
+describe("buildSystemRunApprovalEnvBinding", () => {
+  test("normalizes keys and produces stable hash regardless of input order", () => {
+    const a = buildSystemRunApprovalEnvBinding({
+      Z_VAR: "z",
+      A_VAR: "a",
+      " BAD KEY": "ignored",
+    });
+    const b = buildSystemRunApprovalEnvBinding({
+      A_VAR: "a",
+      Z_VAR: "z",
+    });
+    expect(a.envKeys).toEqual(["A_VAR", "Z_VAR"]);
+    expect(a.envHash).toBe(b.envHash);
+  });
+});
+
+describe("matchSystemRunApprovalEnvBinding", () => {
+  test("accepts missing env hash when request has no env overrides", () => {
+    const result = matchSystemRunApprovalEnvBinding({
+      request: {},
+      env: undefined,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("rejects non-empty env overrides when approval has no env hash", () => {
+    const result = matchSystemRunApprovalEnvBinding({
+      request: {},
+      env: { GIT_EXTERNAL_DIFF: "/tmp/pwn.sh" },
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("unreachable");
+    }
+    expect(result.code).toBe("APPROVAL_ENV_BINDING_MISSING");
+  });
+
+  test("rejects env hash mismatch", () => {
+    const approved = buildSystemRunApprovalEnvBinding({ SAFE: "1" });
+    const result = matchSystemRunApprovalEnvBinding({
+      request: { envHash: approved.envHash },
+      env: { SAFE: "2" },
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("unreachable");
+    }
+    expect(result.code).toBe("APPROVAL_ENV_MISMATCH");
+  });
+
+  test("accepts matching env hash with key order differences", () => {
+    const approved = buildSystemRunApprovalEnvBinding({
+      SAFE_A: "1",
+      SAFE_B: "2",
+    });
+    const result = matchSystemRunApprovalEnvBinding({
+      request: { envHash: approved.envHash },
+      env: {
+        SAFE_B: "2",
+        SAFE_A: "1",
+      },
+    });
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/src/gateway/system-run-approval-env-binding.ts
+++ b/src/gateway/system-run-approval-env-binding.ts
@@ -1,0 +1,88 @@
+import crypto from "node:crypto";
+import type { ExecApprovalRequestPayload } from "../infra/exec-approvals.js";
+import { normalizeEnvVarKey } from "../infra/host-env-security.js";
+
+type NormalizedSystemRunEnvEntry = [key: string, value: string];
+
+function normalizeSystemRunEnvEntries(env: unknown): NormalizedSystemRunEnvEntry[] {
+  if (!env || typeof env !== "object" || Array.isArray(env)) {
+    return [];
+  }
+  const entries: NormalizedSystemRunEnvEntry[] = [];
+  for (const [rawKey, rawValue] of Object.entries(env as Record<string, unknown>)) {
+    if (typeof rawValue !== "string") {
+      continue;
+    }
+    const key = normalizeEnvVarKey(rawKey, { portable: true });
+    if (!key) {
+      continue;
+    }
+    entries.push([key, rawValue]);
+  }
+  entries.sort((a, b) => a[0].localeCompare(b[0]));
+  return entries;
+}
+
+function hashSystemRunEnvEntries(entries: NormalizedSystemRunEnvEntry[]): string | null {
+  if (entries.length === 0) {
+    return null;
+  }
+  return crypto.createHash("sha256").update(JSON.stringify(entries)).digest("hex");
+}
+
+export function buildSystemRunApprovalEnvBinding(env: unknown): {
+  envHash: string | null;
+  envKeys: string[];
+} {
+  const entries = normalizeSystemRunEnvEntries(env);
+  return {
+    envHash: hashSystemRunEnvEntries(entries),
+    envKeys: entries.map(([key]) => key),
+  };
+}
+
+export type SystemRunEnvBindingMatchResult =
+  | { ok: true }
+  | {
+      ok: false;
+      code: "APPROVAL_ENV_BINDING_MISSING" | "APPROVAL_ENV_MISMATCH";
+      message: string;
+      details?: Record<string, unknown>;
+    };
+
+export function matchSystemRunApprovalEnvBinding(params: {
+  request: Pick<ExecApprovalRequestPayload, "envHash">;
+  env: unknown;
+}): SystemRunEnvBindingMatchResult {
+  const expectedEnvHash =
+    typeof params.request.envHash === "string" && params.request.envHash.trim().length > 0
+      ? params.request.envHash.trim()
+      : null;
+  const actual = buildSystemRunApprovalEnvBinding(params.env);
+  const actualEnvHash = actual.envHash;
+
+  if (!expectedEnvHash && !actualEnvHash) {
+    return { ok: true };
+  }
+  if (!expectedEnvHash && actualEnvHash) {
+    return {
+      ok: false,
+      code: "APPROVAL_ENV_BINDING_MISSING",
+      message: "approval id missing env binding for requested env overrides",
+      details: { envKeys: actual.envKeys },
+    };
+  }
+  if (expectedEnvHash !== actualEnvHash) {
+    return {
+      ok: false,
+      code: "APPROVAL_ENV_MISMATCH",
+      message: "approval id env binding mismatch",
+      details: {
+        envKeys: actual.envKeys,
+        expectedEnvHash,
+        actualEnvHash,
+      },
+    };
+  }
+  return { ok: true };
+}

--- a/src/gateway/system-run-approval-env-binding.ts
+++ b/src/gateway/system-run-approval-env-binding.ts
@@ -1,6 +1,8 @@
 import crypto from "node:crypto";
-import type { ExecApprovalRequestPayload } from "../infra/exec-approvals.js";
 import { normalizeEnvVarKey } from "../infra/host-env-security.js";
+
+/** Minimal shape needed from the exec approval request payload (gutted module). */
+type ExecApprovalEnvFields = { envHash?: string | null };
 
 type NormalizedSystemRunEnvEntry = [key: string, value: string];
 
@@ -51,7 +53,7 @@ export type SystemRunEnvBindingMatchResult =
     };
 
 export function matchSystemRunApprovalEnvBinding(params: {
-  request: Pick<ExecApprovalRequestPayload, "envHash">;
+  request: ExecApprovalEnvFields;
   env: unknown;
 }): SystemRunEnvBindingMatchResult {
   const expectedEnvHash =

--- a/src/infra/host-env-security-policy.json
+++ b/src/infra/host-env-security-policy.json
@@ -10,6 +10,7 @@
     "RUBYOPT",
     "BASH_ENV",
     "ENV",
+    "GIT_EXTERNAL_DIFF",
     "SHELL",
     "SHELLOPTS",
     "PS4",

--- a/src/infra/host-env-security.test.ts
+++ b/src/infra/host-env-security.test.ts
@@ -16,6 +16,7 @@ describe("isDangerousHostEnvVarName", () => {
     expect(isDangerousHostEnvVarName("BASH_ENV")).toBe(true);
     expect(isDangerousHostEnvVarName("bash_env")).toBe(true);
     expect(isDangerousHostEnvVarName("SHELL")).toBe(true);
+    expect(isDangerousHostEnvVarName("GIT_EXTERNAL_DIFF")).toBe(true);
     expect(isDangerousHostEnvVarName("SHELLOPTS")).toBe(true);
     expect(isDangerousHostEnvVarName("ps4")).toBe(true);
     expect(isDangerousHostEnvVarName("DYLD_INSERT_LIBRARIES")).toBe(true);
@@ -32,6 +33,7 @@ describe("sanitizeHostExecEnv", () => {
       baseEnv: {
         PATH: "/usr/bin:/bin",
         BASH_ENV: "/tmp/pwn.sh",
+        GIT_EXTERNAL_DIFF: "/tmp/pwn.sh",
         LD_PRELOAD: "/tmp/pwn.so",
         OK: "1",
       },


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [9a4b2266c](https://github.com/openclaw/openclaw/commit/9a4b2266c)
**Tier**: PICK (needs rebrand)

> fix(security): bind node system.run approvals to env

### Files

**Kept (clean merge / new)**:
- `apps/macos/Sources/RemoteClaw/HostEnvSanitizer.swift` — env path addition
- `src/gateway/system-run-approval-env-binding.ts` — NEW: env binding logic
- `src/gateway/system-run-approval-env-binding.test.ts` — NEW: tests
- `src/infra/host-env-security-policy.json` — policy update
- `src/infra/host-env-security.test.ts` — test update

**Dropped (fork-deleted exec-approval infrastructure)**:
- `src/agents/bash-tools.exec-approval-request.ts`
- `src/agents/bash-tools.exec-host-node.ts`
- `src/discord/monitor/exec-approvals.ts`
- `src/gateway/node-invoke-system-run-approval-match.{ts,test.ts}`
- `src/gateway/node-invoke-system-run-approval.{ts,test.ts}`
- `src/gateway/protocol/schema/exec-approvals.ts`
- `src/gateway/server-methods/exec-approval.ts`
- `src/infra/exec-approval-forwarder.ts`
- `src/infra/exec-approvals.ts`
- `CHANGELOG.md` entries (fork maintains own changelog)
- Exec approval test block in `server-methods.test.ts`

Part of #639.