### PR TITLE
Cherry-pick 8a51891: test(exec-approvals): cover v1 binding precedence

### DIFF
--- a/src/gateway/system-run-approval-binding.test.ts
+++ b/src/gateway/system-run-approval-binding.test.ts
@@ -4,6 +4,7 @@ import {
   buildSystemRunApprovalEnvBinding,
   matchSystemRunApprovalBindingV1,
   matchSystemRunApprovalEnvHash,
+  toSystemRunApprovalMismatchError,
 } from "./system-run-approval-binding.js";
 
 describe("buildSystemRunApprovalEnvBinding", () => {
@@ -97,5 +98,34 @@ describe("matchSystemRunApprovalBindingV1", () => {
       throw new Error("unreachable");
     }
     expect(result.code).toBe("APPROVAL_ENV_MISMATCH");
+  });
+});
+
+describe("toSystemRunApprovalMismatchError", () => {
+  test("includes runId/code and preserves mismatch details", () => {
+    const result = toSystemRunApprovalMismatchError({
+      runId: "approval-123",
+      match: {
+        ok: false,
+        code: "APPROVAL_ENV_MISMATCH",
+        message: "approval id env binding mismatch",
+        details: {
+          envKeys: ["SAFE_A"],
+          expectedEnvHash: "expected-hash",
+          actualEnvHash: "actual-hash",
+        },
+      },
+    });
+    expect(result).toEqual({
+      ok: false,
+      message: "approval id env binding mismatch",
+      details: {
+        code: "APPROVAL_ENV_MISMATCH",
+        runId: "approval-123",
+        envKeys: ["SAFE_A"],
+        expectedEnvHash: "expected-hash",
+        actualEnvHash: "actual-hash",
+      },
+    });
   });
 });


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [8a51891ed](https://github.com/openclaw/openclaw/commit/8a51891ed)
**Tier**: AUTO-PICK

> test(exec-approvals): cover v1 binding precedence and mismatch mapping

### Files

- `src/gateway/system-run-approval-binding.test.ts` — additional v1 binding tests (clean merge)

**Dropped**: `src/gateway/node-invoke-system-run-approval-match.test.ts` (fork-deleted)

Part of #639.