### PR TITLE
cherry-pick: harden node exec approvals against symlink rebind (upstream 78a7ff2d5)

### DIFF
--- a/src/cli/nodes-cli.coverage.test.ts
+++ b/src/cli/nodes-cli.coverage.test.ts
@@ -28,6 +28,35 @@ const callGateway = vi.fn(async (opts: NodeInvokeCall) => {
     };
   }
   if (opts.method === "node.invoke") {
+    const command = opts.params?.command;
+    if (command === "system.run.prepare") {
+      const params = (opts.params?.params ?? {}) as {
+        command?: unknown[];
+        rawCommand?: unknown;
+        cwd?: unknown;
+        agentId?: unknown;
+      };
+      const argv = Array.isArray(params.command)
+        ? params.command.map((entry) => String(entry))
+        : [];
+      const rawCommand =
+        typeof params.rawCommand === "string" && params.rawCommand.trim().length > 0
+          ? params.rawCommand
+          : null;
+      return {
+        payload: {
+          cmdText: rawCommand ?? argv.join(" "),
+          plan: {
+            version: 2,
+            argv,
+            cwd: typeof params.cwd === "string" ? params.cwd : null,
+            rawCommand,
+            agentId: typeof params.agentId === "string" ? params.agentId : null,
+            sessionKey: null,
+          },
+        },
+      };
+    }
     return {
       payload: {
         stdout: "",
@@ -80,8 +109,16 @@ vi.mock("../config/config.js", () => ({
 describe("nodes-cli coverage", () => {
   let registerNodesCli: (program: Command) => void;
 
-  const getNodeInvokeCall = () =>
-    callGateway.mock.calls.find((call) => call[0]?.method === "node.invoke")?.[0] as NodeInvokeCall;
+  const getNodeInvokeCall = () => {
+    const nodeInvokeCalls = callGateway.mock.calls
+      .map((call) => call[0])
+      .filter((entry): entry is NodeInvokeCall => entry?.method === "node.invoke");
+    const last = nodeInvokeCalls.at(-1);
+    if (!last) {
+      throw new Error("expected node.invoke call");
+    }
+    return last;
+  };
 
   const createNodesProgram = () => {
     const program = new Command();
@@ -130,6 +167,7 @@ describe("nodes-cli coverage", () => {
     expect(invoke?.params?.command).toBe("system.run");
     expect(invoke?.params?.params).toEqual({
       command: ["echo", "hi"],
+      rawCommand: null,
       cwd: "/tmp",
       env: { FOO: "bar" },
       timeoutMs: 1200,

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -4,6 +4,8 @@ import { loadConfig } from "../../config/config.js";
 import { randomIdempotencyKey } from "../../gateway/call.js";
 import { buildNodeShellCommand } from "../../infra/node-shell.js";
 import { applyPathPrepend } from "../../infra/path-prepend.js";
+import type { SystemRunApprovalPlanV2 } from "../../infra/system-run-approval-binding.js";
+import { normalizeSystemRunApprovalPlanV2 } from "../../infra/system-run-approval-binding.js";
 import { defaultRuntime } from "../../runtime.js";
 import { parseEnvPairs, parseTimeoutMs } from "../nodes-run.js";
 import { getNodesTheme, runNodesCommand } from "./cli-utils.js";
@@ -60,6 +62,22 @@ type ExecDefaults = {
   pathPrepend?: string[];
   safeBins?: string[];
 };
+
+function parsePreparedRunPlan(payload: unknown): {
+  cmdText: string;
+  plan: SystemRunApprovalPlanV2;
+} {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("invalid system.run.prepare response");
+  }
+  const raw = payload as { cmdText?: unknown; plan?: unknown };
+  const cmdText = typeof raw.cmdText === "string" ? raw.cmdText.trim() : "";
+  const plan = normalizeSystemRunApprovalPlanV2(raw.plan);
+  if (!cmdText || !plan) {
+    throw new Error("invalid system.run.prepare response");
+  }
+  return { cmdText, plan };
+}
 
 function normalizeExecSecurity(value?: string | null): ExecSecurity | null {
   const normalized = value?.trim().toLowerCase();
@@ -211,6 +229,20 @@ export function registerNodesInvokeCommands(nodes: Command) {
             applyPathPrepend(nodeEnv, execDefaults?.pathPrepend, { requireExisting: true });
           }
 
+          const prepareResponse = (await callGatewayCli("node.invoke", opts, {
+            nodeId,
+            command: "system.run.prepare",
+            params: {
+              command: argv,
+              rawCommand,
+              cwd: opts.cwd,
+              agentId,
+            },
+            idempotencyKey: `prepare-${randomIdempotencyKey()}`,
+          })) as { payload?: unknown } | null;
+          const prepared = parsePreparedRunPlan(prepareResponse?.payload);
+          const approvalPlan = prepared.plan;
+
           let approvedByAsk = false;
           let approvalDecision: "allow-once" | "allow-always" | null = null;
           const configuredSecurity = normalizeExecSecurity(execDefaults?.security) ?? "allowlist";
@@ -270,15 +302,17 @@ export function registerNodesInvokeCommands(nodes: Command) {
               opts,
               {
                 id: approvalId,
-                command: rawCommand ?? argv.join(" "),
-                cwd: opts.cwd,
+                command: prepared.cmdText,
+                commandArgv: approvalPlan.argv,
+                systemRunPlanV2: approvalPlan,
+                cwd: approvalPlan.cwd,
                 nodeId,
                 host: "node",
                 security: hostSecurity,
                 ask: hostAsk,
-                agentId,
+                agentId: approvalPlan.agentId ?? agentId,
                 resolvedPath: undefined,
-                sessionKey: undefined,
+                sessionKey: approvalPlan.sessionKey ?? undefined,
                 timeoutMs: approvalTimeoutMs,
               },
               { transportTimeoutMs },
@@ -314,19 +348,21 @@ export function registerNodesInvokeCommands(nodes: Command) {
             nodeId,
             command: "system.run",
             params: {
-              command: argv,
-              cwd: opts.cwd,
+              command: approvalPlan.argv,
+              rawCommand: approvalPlan.rawCommand,
+              cwd: approvalPlan.cwd,
               env: nodeEnv,
               timeoutMs,
               needsScreenRecording: opts.needsScreenRecording === true,
             },
             idempotencyKey: String(opts.idempotencyKey ?? randomIdempotencyKey()),
           };
-          if (agentId) {
-            (invokeParams.params as Record<string, unknown>).agentId = agentId;
+          if (approvalPlan.agentId ?? agentId) {
+            (invokeParams.params as Record<string, unknown>).agentId =
+              approvalPlan.agentId ?? agentId;
           }
-          if (rawCommand) {
-            (invokeParams.params as Record<string, unknown>).rawCommand = rawCommand;
+          if (approvalPlan.sessionKey) {
+            (invokeParams.params as Record<string, unknown>).sessionKey = approvalPlan.sessionKey;
           }
           (invokeParams.params as Record<string, unknown>).approved = approvedByAsk;
           if (approvalDecision) {

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -40,7 +40,13 @@ const SMS_DANGEROUS_COMMANDS = ["sms.send"];
 // iOS nodes don't implement system.run/which, but they do support notifications.
 const IOS_SYSTEM_COMMANDS = ["system.notify"];
 
-const SYSTEM_COMMANDS = ["system.run", "system.which", "system.notify", "browser.proxy"];
+const SYSTEM_COMMANDS = [
+  "system.run.prepare",
+  "system.run",
+  "system.which",
+  "system.notify",
+  "browser.proxy",
+];
 
 // "High risk" node commands. These can be enabled by explicitly adding them to
 // `gateway.nodes.allowCommands` (and ensuring they're not blocked by denyCommands).

--- a/src/infra/system-run-approval-binding.ts
+++ b/src/infra/system-run-approval-binding.ts
@@ -11,6 +11,16 @@ export type SystemRunApprovalBindingV1 = {
   envHash: string | null;
 };
 
+/** Minimal shape from the gutted exec-approvals module. */
+export type SystemRunApprovalPlanV2 = {
+  version: 2;
+  argv: string[];
+  cwd: string | null;
+  rawCommand: string | null;
+  agentId: string | null;
+  sessionKey: string | null;
+};
+
 type NormalizedSystemRunEnvEntry = [key: string, value: string];
 
 function normalizeString(value: unknown): string | null {
@@ -23,6 +33,28 @@ function normalizeString(value: unknown): string | null {
 
 function normalizeStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.map((entry) => String(entry)) : [];
+}
+
+export function normalizeSystemRunApprovalPlanV2(value: unknown): SystemRunApprovalPlanV2 | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (candidate.version !== 2) {
+    return null;
+  }
+  const argv = normalizeStringArray(candidate.argv);
+  if (argv.length === 0) {
+    return null;
+  }
+  return {
+    version: 2,
+    argv,
+    cwd: normalizeString(candidate.cwd),
+    rawCommand: normalizeString(candidate.rawCommand),
+    agentId: normalizeString(candidate.agentId),
+    sessionKey: normalizeString(candidate.sessionKey),
+  };
 }
 
 function normalizeSystemRunEnvEntries(env: unknown): NormalizedSystemRunEnvEntry[] {

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { handleSystemRunInvoke, formatSystemRunAllowlistMissMessage } from "./invoke-system-run.js";
 
@@ -16,6 +19,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       payload: Record<string, unknown>;
     } | null;
     command?: string[];
+    cwd?: string;
     security?: "full" | "allowlist";
     ask?: "off" | "on-miss" | "always";
     approved?: boolean;
@@ -37,6 +41,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       client: {} as never,
       params: {
         command: params.command ?? ["echo", "ok"],
+        cwd: params.cwd,
         approved: params.approved ?? false,
         sessionKey: "agent:main:main",
       },
@@ -109,4 +114,136 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       }),
     );
   });
+
+  it("forwards canonical cmdText to mac app exec host for positional-argv shell wrappers", async () => {
+    const { runViaMacAppExecHost } = await runSystemInvoke({
+      preferMacAppExecHost: true,
+      command: ["/bin/sh", "-lc", '$0 "$1"', "/usr/bin/touch", "/tmp/marker"],
+      runViaResponse: {
+        ok: true,
+        error: { reason: "", message: "" },
+        payload: {
+          success: true,
+          stdout: "app-ok",
+          stderr: "",
+          timedOut: false,
+          exitCode: 0,
+          error: null,
+        },
+      },
+    });
+
+    expect(runViaMacAppExecHost).toHaveBeenCalledWith({
+      approvals: expect.anything(),
+      request: expect.objectContaining({
+        command: ["/bin/sh", "-lc", '$0 "$1"', "/usr/bin/touch", "/tmp/marker"],
+        rawCommand: '/bin/sh -lc $0 "$1" /usr/bin/touch /tmp/marker',
+      }),
+    });
+  });
+
+  // Tests for env wrapper transparency and denial in allowlist mode are not applicable:
+  // the fork gutted exec-approvals infrastructure (analyzeArgvCommand, evaluateExecAllowlist,
+  // evaluateSystemRunPolicy are stubs).  Upstream tests exercised the real allowlist pipeline.
+
+  it.runIf(process.platform !== "win32")(
+    "denies approval-based execution when cwd is a symlink",
+    async () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-approval-cwd-link-"));
+      const safeDir = path.join(tmp, "safe");
+      const linkDir = path.join(tmp, "cwd-link");
+      const script = path.join(safeDir, "run.sh");
+      fs.mkdirSync(safeDir, { recursive: true });
+      fs.writeFileSync(script, "#!/bin/sh\necho SAFE\n");
+      fs.chmodSync(script, 0o755);
+      fs.symlinkSync(safeDir, linkDir, "dir");
+      try {
+        const { runCommand, sendInvokeResult } = await runSystemInvoke({
+          preferMacAppExecHost: false,
+          command: ["./run.sh"],
+          cwd: linkDir,
+          approved: true,
+          security: "full",
+          ask: "off",
+        });
+        expect(runCommand).not.toHaveBeenCalled();
+        expect(sendInvokeResult).toHaveBeenCalledWith(
+          expect.objectContaining({
+            ok: false,
+            error: expect.objectContaining({
+              message: expect.stringContaining("canonical cwd"),
+            }),
+          }),
+        );
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "denies approval-based execution when cwd contains a symlink parent component",
+    async () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-approval-cwd-parent-link-"));
+      const safeRoot = path.join(tmp, "safe-root");
+      const safeSub = path.join(safeRoot, "sub");
+      const linkRoot = path.join(tmp, "approved-link");
+      fs.mkdirSync(safeSub, { recursive: true });
+      fs.symlinkSync(safeRoot, linkRoot, "dir");
+      try {
+        const { runCommand, sendInvokeResult } = await runSystemInvoke({
+          preferMacAppExecHost: false,
+          command: ["./run.sh"],
+          cwd: path.join(linkRoot, "sub"),
+          approved: true,
+          security: "full",
+          ask: "off",
+        });
+        expect(runCommand).not.toHaveBeenCalled();
+        expect(sendInvokeResult).toHaveBeenCalledWith(
+          expect.objectContaining({
+            ok: false,
+            error: expect.objectContaining({
+              message: expect.stringContaining("no symlink path components"),
+            }),
+          }),
+        );
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("uses canonical executable path for approval-based relative command execution", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-approval-cwd-real-"));
+    const script = path.join(tmp, "run.sh");
+    fs.writeFileSync(script, "#!/bin/sh\necho SAFE\n");
+    fs.chmodSync(script, 0o755);
+    try {
+      const { runCommand, sendInvokeResult } = await runSystemInvoke({
+        preferMacAppExecHost: false,
+        command: ["./run.sh", "--flag"],
+        cwd: tmp,
+        approved: true,
+        security: "full",
+        ask: "off",
+      });
+      expect(runCommand).toHaveBeenCalledWith(
+        [fs.realpathSync(script), "--flag"],
+        fs.realpathSync(tmp),
+        undefined,
+        undefined,
+      );
+      expect(sendInvokeResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: true,
+        }),
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+  // Tests for env -S shell payloads and semicolon-chained shell payloads in allowlist mode
+  // are not applicable: the fork gutted exec-approvals infrastructure (evaluateSystemRunPolicy,
+  // analyzeArgvCommand are stubs).  Upstream tests exercised the real allowlist/policy pipeline.
 });

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -1,8 +1,12 @@
 import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 import { resolveAgentConfig } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
 import type { GatewayClient } from "../gateway/client.js";
+import { sameFileIdentity } from "../infra/file-identity.js";
 import { sanitizeSystemRunEnvOverrides } from "../infra/host-env-security.js";
+import type { SystemRunApprovalPlanV2 } from "../infra/system-run-approval-binding.js";
 
 // Stub types and functions: exec-approvals, exec-host, exec-safe-bin, system-run-command,
 // and exec-policy infrastructure was gutted.
@@ -212,6 +216,194 @@ function normalizeDeniedReason(reason: string | null | undefined): SystemRunDeni
     default:
       return "approval-required";
   }
+}
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function isPathLikeExecutableToken(value: string): boolean {
+  if (!value) {
+    return false;
+  }
+  if (value.startsWith(".") || value.startsWith("/") || value.startsWith("\\")) {
+    return true;
+  }
+  if (value.includes("/") || value.includes("\\")) {
+    return true;
+  }
+  if (process.platform === "win32" && /^[a-zA-Z]:[\\/]/.test(value)) {
+    return true;
+  }
+  return false;
+}
+
+function pathComponentsFromRootSync(targetPath: string): string[] {
+  const absolute = path.resolve(targetPath);
+  const parts: string[] = [];
+  let cursor = absolute;
+  while (true) {
+    parts.unshift(cursor);
+    const parent = path.dirname(cursor);
+    if (parent === cursor) {
+      return parts;
+    }
+    cursor = parent;
+  }
+}
+
+function isWritableByCurrentProcessSync(candidate: string): boolean {
+  try {
+    fs.accessSync(candidate, fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasMutableSymlinkPathComponentSync(targetPath: string): boolean {
+  for (const component of pathComponentsFromRootSync(targetPath)) {
+    try {
+      if (!fs.lstatSync(component).isSymbolicLink()) {
+        continue;
+      }
+      const parentDir = path.dirname(component);
+      if (isWritableByCurrentProcessSync(parentDir)) {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hardenApprovedExecutionPaths(params: {
+  approvedByAsk: boolean;
+  argv: string[];
+  shellCommand: string | null;
+  cwd: string | undefined;
+}): { ok: true; argv: string[]; cwd: string | undefined } | { ok: false; message: string } {
+  if (!params.approvedByAsk) {
+    return { ok: true, argv: params.argv, cwd: params.cwd };
+  }
+
+  let hardenedCwd = params.cwd;
+  if (hardenedCwd) {
+    const requestedCwd = path.resolve(hardenedCwd);
+    let cwdLstat: fs.Stats;
+    let cwdStat: fs.Stats;
+    let cwdReal: string;
+    let cwdRealStat: fs.Stats;
+    try {
+      cwdLstat = fs.lstatSync(requestedCwd);
+      cwdStat = fs.statSync(requestedCwd);
+      cwdReal = fs.realpathSync(requestedCwd);
+      cwdRealStat = fs.statSync(cwdReal);
+    } catch {
+      return {
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval requires an existing canonical cwd",
+      };
+    }
+    if (!cwdStat.isDirectory()) {
+      return {
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval requires cwd to be a directory",
+      };
+    }
+    if (hasMutableSymlinkPathComponentSync(requestedCwd)) {
+      return {
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval requires canonical cwd (no symlink path components)",
+      };
+    }
+    if (cwdLstat.isSymbolicLink()) {
+      return {
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval requires canonical cwd (no symlink cwd)",
+      };
+    }
+    if (
+      !sameFileIdentity(cwdStat, cwdLstat) ||
+      !sameFileIdentity(cwdStat, cwdRealStat) ||
+      !sameFileIdentity(cwdLstat, cwdRealStat)
+    ) {
+      return {
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: approval cwd identity mismatch",
+      };
+    }
+    hardenedCwd = cwdReal;
+  }
+
+  if (params.shellCommand !== null || params.argv.length === 0) {
+    return { ok: true, argv: params.argv, cwd: hardenedCwd };
+  }
+
+  const argv = [...params.argv];
+  const rawExecutable = argv[0] ?? "";
+  if (!isPathLikeExecutableToken(rawExecutable)) {
+    return { ok: true, argv, cwd: hardenedCwd };
+  }
+
+  const base = hardenedCwd ?? process.cwd();
+  const candidate = path.isAbsolute(rawExecutable)
+    ? rawExecutable
+    : path.resolve(base, rawExecutable);
+  try {
+    argv[0] = fs.realpathSync(candidate);
+  } catch {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval requires a stable executable path",
+    };
+  }
+  return { ok: true, argv, cwd: hardenedCwd };
+}
+
+export function buildSystemRunApprovalPlanV2(params: {
+  command?: unknown;
+  rawCommand?: unknown;
+  cwd?: unknown;
+  agentId?: unknown;
+  sessionKey?: unknown;
+}): { ok: true; plan: SystemRunApprovalPlanV2; cmdText: string } | { ok: false; message: string } {
+  const command = resolveSystemRunCommand({
+    command: params.command,
+    rawCommand: params.rawCommand,
+  });
+  if (!command.ok) {
+    return { ok: false, message: command.message };
+  }
+  if (command.argv.length === 0) {
+    return { ok: false, message: "command required" };
+  }
+  const hardening = hardenApprovedExecutionPaths({
+    approvedByAsk: true,
+    argv: command.argv,
+    shellCommand: command.shellCommand,
+    cwd: normalizeString(params.cwd) ?? undefined,
+  });
+  if (!hardening.ok) {
+    return { ok: false, message: hardening.message };
+  }
+  return {
+    ok: true,
+    plan: {
+      version: 2,
+      argv: hardening.argv,
+      cwd: hardening.cwd ?? null,
+      rawCommand: command.cmdText.trim() || null,
+      agentId: normalizeString(params.agentId),
+      sessionKey: normalizeString(params.sessionKey),
+    },
+    cmdText: command.cmdText,
+  };
 }
 
 export type HandleSystemRunInvokeOptions = {
@@ -513,6 +705,20 @@ async function evaluateSystemRunPolicyPhase(
     return null;
   }
 
+  const hardenedPaths = hardenApprovedExecutionPaths({
+    approvedByAsk: policy.approvedByAsk,
+    argv: parsed.argv,
+    shellCommand: parsed.shellCommand,
+    cwd: parsed.cwd,
+  });
+  if (!hardenedPaths.ok) {
+    await sendSystemRunDenied(opts, parsed.execution, {
+      reason: "approval-required",
+      message: hardenedPaths.message,
+    });
+    return null;
+  }
+
   const plannedAllowlistArgv = resolvePlannedAllowlistArgv({
     security,
     shellCommand: parsed.shellCommand,
@@ -528,6 +734,8 @@ async function evaluateSystemRunPolicyPhase(
   }
   return {
     ...parsed,
+    argv: hardenedPaths.argv,
+    cwd: hardenedPaths.cwd,
     approvals,
     security,
     policy,

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -58,7 +58,7 @@ async function requestExecHostViaSocket(_opts: {
   return null;
 }
 import { runBrowserProxyCommand } from "./invoke-browser.js";
-import { handleSystemRunInvoke } from "./invoke-system-run.js";
+import { buildSystemRunApprovalPlanV2, handleSystemRunInvoke } from "./invoke-system-run.js";
 import type { ExecEventPayload, RunResult, SystemRunParams } from "./invoke-types.js";
 
 const OUTPUT_CAP = 200_000;
@@ -441,6 +441,30 @@ export async function handleInvoke(frame: NodeInvokeRequestPayload, client: Gate
     try {
       const payload = await runBrowserProxyCommand(frame.paramsJSON);
       await sendRawPayloadResult(client, frame, payload);
+    } catch (err) {
+      await sendInvalidRequestResult(client, frame, err);
+    }
+    return;
+  }
+
+  if (command === "system.run.prepare") {
+    try {
+      const params = decodeParams<{
+        command?: unknown;
+        rawCommand?: unknown;
+        cwd?: unknown;
+        agentId?: unknown;
+        sessionKey?: unknown;
+      }>(frame.paramsJSON);
+      const prepared = buildSystemRunApprovalPlanV2(params);
+      if (!prepared.ok) {
+        await sendErrorResult(client, frame, "INVALID_REQUEST", prepared.message);
+        return;
+      }
+      await sendJsonPayloadResult(client, frame, {
+        cmdText: prepared.cmdText,
+        plan: prepared.plan,
+      });
     } catch (err) {
       await sendInvalidRequestResult(client, frame, err);
     }

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -85,6 +85,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     scopes: [],
     caps: ["system", ...(browserProxyEnabled ? ["browser"] : [])],
     commands: [
+      "system.run.prepare",
       "system.run",
       "system.which",
       "system.execApprovals.get",


### PR DESCRIPTION
## Summary

Cherry-pick of upstream `78a7ff2d5` — `fix(security): harden node exec approvals against symlink rebind`.

Hardens approval-based execution to prevent symlink rebind attacks:
- New `pathComponentsFromRootSync` / `isWritableByCurrentProcessSync` / `hasMutableSymlinkPathComponentSync` functions
- `hardenApprovedExecutionPaths` now checks for mutable symlink path components
- New `buildSystemRunApprovalPlanV2` for hardened execution plan creation
- `SystemRunApprovalPlanV2` type stub added to local approval-binding module
- CLI nodes invoke updated to use v2 approval plan fields
- Tests for symlink cwd denial, parent symlink denial, and canonical path resolution

**Adaptation notes:**
- DU conflicts on exec-approval files resolved by `git rm` (gutted in PR #70/#71)
- Tests requiring gutted infrastructure (`withTempApprovalsHome`, `skillBins`, `buildNestedEnvShellCommand`) dropped
- CLI coverage test approval assertions dropped (fork lacks `getApprovalRequestCall`)
- Rebranded temp dir prefixes: `openclaw-` → `remoteclaw-`

Part of #639 (exec approval hardening series, commit 5/6).

Cherry-picked-from: openclaw/openclaw@78a7ff2d5