### PR TITLE
Cherry-pick 258d615c4: fix: harden plugin route auth path canonicalization

### DIFF
--- a/src/gateway/security-path.test.ts
+++ b/src/gateway/security-path.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  PROTECTED_PLUGIN_ROUTE_PREFIXES,
+  canonicalizePathForSecurity,
+  isPathProtectedByPrefixes,
+  isProtectedPluginRoutePath,
+} from "./security-path.js";
+
+describe("security-path canonicalization", () => {
+  it("canonicalizes decoded case/slash variants", () => {
+    expect(canonicalizePathForSecurity("/API/channels//nostr/default/profile/")).toEqual({
+      path: "/api/channels/nostr/default/profile",
+      candidates: ["/api/channels/nostr/default/profile"],
+      malformedEncoding: false,
+      rawNormalizedPath: "/api/channels/nostr/default/profile",
+    });
+    const encoded = canonicalizePathForSecurity("/api/%63hannels%2Fnostr%2Fdefault%2Fprofile");
+    expect(encoded.path).toBe("/api/channels/nostr/default/profile");
+    expect(encoded.candidates).toContain("/api/%63hannels%2fnostr%2fdefault%2fprofile");
+    expect(encoded.candidates).toContain("/api/channels/nostr/default/profile");
+  });
+
+  it("resolves traversal after repeated decoding", () => {
+    expect(canonicalizePathForSecurity("/api/foo/..%2fchannels/nostr/default/profile").path).toBe(
+      "/api/channels/nostr/default/profile",
+    );
+    expect(
+      canonicalizePathForSecurity("/api/foo/%252e%252e%252fchannels/nostr/default/profile").path,
+    ).toBe("/api/channels/nostr/default/profile");
+  });
+
+  it("marks malformed encoding", () => {
+    expect(canonicalizePathForSecurity("/api/channels%2").malformedEncoding).toBe(true);
+    expect(canonicalizePathForSecurity("/api/channels%zz").malformedEncoding).toBe(true);
+  });
+});
+
+describe("security-path protected-prefix matching", () => {
+  const channelVariants = [
+    "/API/channels/nostr/default/profile",
+    "/api/channels%2Fnostr%2Fdefault%2Fprofile",
+    "/api/%63hannels/nostr/default/profile",
+    "/api/foo/..%2fchannels/nostr/default/profile",
+    "/api/foo/%2e%2e%2fchannels/nostr/default/profile",
+    "/api/foo/%252e%252e%252fchannels/nostr/default/profile",
+    "/api/channels%2",
+    "/api/channels%zz",
+  ];
+
+  for (const path of channelVariants) {
+    it(`protects plugin channel path variant: ${path}`, () => {
+      expect(isProtectedPluginRoutePath(path)).toBe(true);
+      expect(isPathProtectedByPrefixes(path, PROTECTED_PLUGIN_ROUTE_PREFIXES)).toBe(true);
+    });
+  }
+
+  it("does not protect unrelated paths", () => {
+    expect(isProtectedPluginRoutePath("/plugin/public")).toBe(false);
+    expect(isProtectedPluginRoutePath("/api/channels-public")).toBe(false);
+    expect(isProtectedPluginRoutePath("/api/foo/..%2fchannels-public")).toBe(false);
+    expect(isProtectedPluginRoutePath("/api/channel")).toBe(false);
+  });
+});

--- a/src/gateway/security-path.ts
+++ b/src/gateway/security-path.ts
@@ -1,0 +1,102 @@
+export type SecurityPathCanonicalization = {
+  path: string;
+  candidates: string[];
+  malformedEncoding: boolean;
+  rawNormalizedPath: string;
+};
+
+const MAX_PATH_DECODE_PASSES = 3;
+
+function normalizePathSeparators(pathname: string): string {
+  const collapsed = pathname.replace(/\/{2,}/g, "/");
+  if (collapsed.length <= 1) {
+    return collapsed;
+  }
+  return collapsed.replace(/\/+$/, "");
+}
+
+function normalizeProtectedPrefix(prefix: string): string {
+  return normalizePathSeparators(prefix.toLowerCase()) || "/";
+}
+
+function resolveDotSegments(pathname: string): string {
+  try {
+    return new URL(pathname, "http://localhost").pathname;
+  } catch {
+    return pathname;
+  }
+}
+
+function normalizePathForSecurity(pathname: string): string {
+  return normalizePathSeparators(resolveDotSegments(pathname).toLowerCase()) || "/";
+}
+
+function prefixMatch(pathname: string, prefix: string): boolean {
+  return (
+    pathname === prefix ||
+    pathname.startsWith(`${prefix}/`) ||
+    // Fail closed when malformed %-encoding follows the protected prefix.
+    pathname.startsWith(`${prefix}%`)
+  );
+}
+
+export function canonicalizePathForSecurity(pathname: string): SecurityPathCanonicalization {
+  const candidates: string[] = [];
+  const seen = new Set<string>();
+  const pushCandidate = (value: string) => {
+    const normalized = normalizePathForSecurity(value);
+    if (seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    candidates.push(normalized);
+  };
+
+  pushCandidate(pathname);
+
+  let decoded = pathname;
+  let malformedEncoding = false;
+  for (let pass = 0; pass < MAX_PATH_DECODE_PASSES; pass++) {
+    let nextDecoded = decoded;
+    try {
+      nextDecoded = decodeURIComponent(decoded);
+    } catch {
+      malformedEncoding = true;
+      break;
+    }
+    if (nextDecoded === decoded) {
+      break;
+    }
+    decoded = nextDecoded;
+    pushCandidate(decoded);
+  }
+
+  return {
+    path: candidates[candidates.length - 1] ?? "/",
+    candidates,
+    malformedEncoding,
+    rawNormalizedPath: normalizePathSeparators(pathname.toLowerCase()) || "/",
+  };
+}
+
+export function isPathProtectedByPrefixes(pathname: string, prefixes: readonly string[]): boolean {
+  const canonical = canonicalizePathForSecurity(pathname);
+  const normalizedPrefixes = prefixes.map(normalizeProtectedPrefix);
+  if (
+    canonical.candidates.some((candidate) =>
+      normalizedPrefixes.some((prefix) => prefixMatch(candidate, prefix)),
+    )
+  ) {
+    return true;
+  }
+  if (!canonical.malformedEncoding) {
+    return false;
+  }
+  return normalizedPrefixes.some((prefix) => prefixMatch(canonical.rawNormalizedPath, prefix));
+}
+
+export const PROTECTED_PLUGIN_ROUTE_PREFIXES = ["/api/channels"] as const;
+
+export function isProtectedPluginRoutePath(pathname: string): boolean {
+  return isPathProtectedByPrefixes(pathname, PROTECTED_PLUGIN_ROUTE_PREFIXES);
+}

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -60,6 +60,7 @@ import { getBearerToken } from "./http-utils.js";
 import { handleOpenAiHttpRequest } from "./openai-http.js";
 import { handleOpenResponsesHttpRequest } from "./openresponses-http.js";
 import { GATEWAY_CLIENT_MODES, normalizeGatewayClientMode } from "./protocol/client-info.js";
+import { isProtectedPluginRoutePath } from "./security-path.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { handleToolsInvokeHttpRequest } from "./tools-invoke-http.js";
 
@@ -168,6 +169,34 @@ async function authorizeCanvasRequest(params: {
     return { ok: true };
   }
   return lastAuthFailure ?? { ok: false, reason: "unauthorized" };
+}
+
+async function enforcePluginRouteGatewayAuth(params: {
+  requestPath: string;
+  req: IncomingMessage;
+  res: ServerResponse;
+  auth: ResolvedGatewayAuth;
+  trustedProxies: string[];
+  allowRealIpFallback: boolean;
+  rateLimiter?: AuthRateLimiter;
+}): Promise<boolean> {
+  if (!isProtectedPluginRoutePath(params.requestPath)) {
+    return true;
+  }
+  const token = getBearerToken(params.req);
+  const authResult = await authorizeHttpGatewayConnect({
+    auth: params.auth,
+    connectAuth: token ? { token, password: token } : null,
+    req: params.req,
+    trustedProxies: params.trustedProxies,
+    allowRealIpFallback: params.allowRealIpFallback,
+    rateLimiter: params.rateLimiter,
+  });
+  if (!authResult.ok) {
+    sendGatewayAuthFailure(params.res, authResult);
+    return false;
+  }
+  return true;
 }
 
 function writeUpgradeAuthFailure(
@@ -499,23 +528,20 @@ export function createGatewayHttpServer(opts: {
         return;
       }
       if (handlePluginRequest) {
-        // Channel HTTP endpoints are gateway-auth protected by default.
-        // Non-channel plugin routes remain plugin-owned and must enforce
+        // Protected plugin route prefixes are gateway-auth protected by default.
+        // Non-protected plugin routes remain plugin-owned and must enforce
         // their own auth when exposing sensitive functionality.
-        if (requestPath === "/api/channels" || requestPath.startsWith("/api/channels/")) {
-          const token = getBearerToken(req);
-          const authResult = await authorizeHttpGatewayConnect({
-            auth: resolvedAuth,
-            connectAuth: token ? { token, password: token } : null,
-            req,
-            trustedProxies,
-            allowRealIpFallback,
-            rateLimiter,
-          });
-          if (!authResult.ok) {
-            sendGatewayAuthFailure(res, authResult);
-            return;
-          }
+        const pluginAuthOk = await enforcePluginRouteGatewayAuth({
+          requestPath,
+          req,
+          res,
+          auth: resolvedAuth,
+          trustedProxies,
+          allowRealIpFallback,
+          rateLimiter,
+        });
+        if (!pluginAuthOk) {
+          return;
         }
         if (await handlePluginRequest(req, res)) {
           return;

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -86,6 +86,122 @@ function createHooksConfig(): HooksConfigResolved {
   };
 }
 
+function canonicalizePluginPath(pathname: string): string {
+  let decoded = pathname;
+  for (let pass = 0; pass < 3; pass++) {
+    let nextDecoded = decoded;
+    try {
+      nextDecoded = decodeURIComponent(decoded);
+    } catch {
+      break;
+    }
+    if (nextDecoded === decoded) {
+      break;
+    }
+    decoded = nextDecoded;
+  }
+  let resolved = decoded;
+  try {
+    resolved = new URL(decoded, "http://localhost").pathname;
+  } catch {
+    resolved = decoded;
+  }
+  const collapsed = resolved.toLowerCase().replace(/\/{2,}/g, "/");
+  if (collapsed.length <= 1) {
+    return collapsed;
+  }
+  return collapsed.replace(/\/+$/, "");
+}
+
+type RouteVariant = {
+  label: string;
+  path: string;
+};
+
+const CANONICAL_UNAUTH_VARIANTS: RouteVariant[] = [
+  { label: "case-variant", path: "/API/channels/nostr/default/profile" },
+  { label: "encoded-slash", path: "/api/channels%2Fnostr%2Fdefault%2Fprofile" },
+  { label: "encoded-segment", path: "/api/%63hannels/nostr/default/profile" },
+  { label: "dot-traversal-encoded-slash", path: "/api/foo/..%2fchannels/nostr/default/profile" },
+  {
+    label: "dot-traversal-encoded-dotdot-slash",
+    path: "/api/foo/%2e%2e%2fchannels/nostr/default/profile",
+  },
+  {
+    label: "dot-traversal-double-encoded",
+    path: "/api/foo/%252e%252e%252fchannels/nostr/default/profile",
+  },
+  { label: "duplicate-slashes", path: "/api/channels//nostr/default/profile" },
+  { label: "trailing-slash", path: "/api/channels/nostr/default/profile/" },
+  { label: "malformed-short-percent", path: "/api/channels%2" },
+  { label: "malformed-double-slash-short-percent", path: "/api//channels%2" },
+];
+
+const CANONICAL_AUTH_VARIANTS: RouteVariant[] = [
+  { label: "auth-case-variant", path: "/API/channels/nostr/default/profile" },
+  { label: "auth-encoded-segment", path: "/api/%63hannels/nostr/default/profile" },
+  { label: "auth-duplicate-trailing-slash", path: "/api/channels//nostr/default/profile/" },
+  {
+    label: "auth-dot-traversal-encoded-slash",
+    path: "/api/foo/..%2fchannels/nostr/default/profile",
+  },
+  {
+    label: "auth-dot-traversal-double-encoded",
+    path: "/api/foo/%252e%252e%252fchannels/nostr/default/profile",
+  },
+];
+
+function buildChannelPathFuzzCorpus(): RouteVariant[] {
+  const variants = [
+    "/api/channels/nostr/default/profile",
+    "/API/channels/nostr/default/profile",
+    "/api/foo/..%2fchannels/nostr/default/profile",
+    "/api/foo/%2e%2e%2fchannels/nostr/default/profile",
+    "/api/foo/%252e%252e%252fchannels/nostr/default/profile",
+    "/api/channels//nostr/default/profile/",
+    "/api/channels%2Fnostr%2Fdefault%2Fprofile",
+    "/api/channels%252Fnostr%252Fdefault%252Fprofile",
+    "/api//channels/nostr/default/profile",
+    "/api/channels%2",
+    "/api/channels%zz",
+    "/api//channels%2",
+    "/api//channels%zz",
+  ];
+  return variants.map((path) => ({ label: `fuzz:${path}`, path }));
+}
+
+async function expectUnauthorizedVariants(params: {
+  server: ReturnType<typeof createGatewayHttpServer>;
+  variants: RouteVariant[];
+}) {
+  for (const variant of params.variants) {
+    const response = createResponse();
+    await dispatchRequest(params.server, createRequest({ path: variant.path }), response.res);
+    expect(response.res.statusCode, variant.label).toBe(401);
+    expect(response.getBody(), variant.label).toContain("Unauthorized");
+  }
+}
+
+async function expectAuthorizedVariants(params: {
+  server: ReturnType<typeof createGatewayHttpServer>;
+  variants: RouteVariant[];
+  authorization: string;
+}) {
+  for (const variant of params.variants) {
+    const response = createResponse();
+    await dispatchRequest(
+      params.server,
+      createRequest({
+        path: variant.path,
+        authorization: params.authorization,
+      }),
+      response.res,
+    );
+    expect(response.res.statusCode, variant.label).toBe(200);
+    expect(response.getBody(), variant.label).toContain('"route":"channel-canonicalized"');
+  }
+}
+
 describe("gateway plugin HTTP auth boundary", () => {
   test("applies default security headers and optional strict transport security", async () => {
     const resolvedAuth: ResolvedGatewayAuth = {
@@ -242,6 +358,103 @@ describe("gateway plugin HTTP auth boundary", () => {
     });
   });
 
+  test("requires gateway auth for canonicalized /api/channels variants", async () => {
+    const resolvedAuth: ResolvedGatewayAuth = {
+      mode: "token",
+      token: "test-token",
+      password: undefined,
+      allowTailscale: false,
+    };
+
+    await withTempConfig({
+      cfg: { gateway: { trustedProxies: [] } },
+      prefix: "remoteclaw-plugin-http-auth-canonicalized-test-",
+      run: async () => {
+        const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
+          const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+          const canonicalPath = canonicalizePluginPath(pathname);
+          if (canonicalPath === "/api/channels/nostr/default/profile") {
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "application/json; charset=utf-8");
+            res.end(JSON.stringify({ ok: true, route: "channel-canonicalized" }));
+            return true;
+          }
+          return false;
+        });
+
+        const server = createGatewayHttpServer({
+          canvasHost: null,
+          clients: new Set(),
+          controlUiEnabled: false,
+          controlUiBasePath: "/__control__",
+          openAiChatCompletionsEnabled: false,
+          openResponsesEnabled: false,
+          handleHooksRequest: async () => false,
+          handlePluginRequest,
+          resolvedAuth,
+        });
+
+        await expectUnauthorizedVariants({ server, variants: CANONICAL_UNAUTH_VARIANTS });
+        expect(handlePluginRequest).not.toHaveBeenCalled();
+
+        await expectAuthorizedVariants({
+          server,
+          variants: CANONICAL_AUTH_VARIANTS,
+          authorization: "Bearer test-token",
+        });
+        expect(handlePluginRequest).toHaveBeenCalledTimes(CANONICAL_AUTH_VARIANTS.length);
+      },
+    });
+  });
+
+  test("rejects unauthenticated plugin-channel fuzz corpus variants", async () => {
+    const resolvedAuth: ResolvedGatewayAuth = {
+      mode: "token",
+      token: "test-token",
+      password: undefined,
+      allowTailscale: false,
+    };
+
+    await withTempConfig({
+      cfg: { gateway: { trustedProxies: [] } },
+      prefix: "remoteclaw-plugin-http-auth-fuzz-corpus-test-",
+      run: async () => {
+        const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
+          const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+          const canonicalPath = canonicalizePluginPath(pathname);
+          if (canonicalPath === "/api/channels/nostr/default/profile") {
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "application/json; charset=utf-8");
+            res.end(JSON.stringify({ ok: true, route: "channel-canonicalized" }));
+            return true;
+          }
+          return false;
+        });
+
+        const server = createGatewayHttpServer({
+          canvasHost: null,
+          clients: new Set(),
+          controlUiEnabled: false,
+          controlUiBasePath: "/__control__",
+          openAiChatCompletionsEnabled: false,
+          openResponsesEnabled: false,
+          handleHooksRequest: async () => false,
+          handlePluginRequest,
+          resolvedAuth,
+        });
+
+        for (const variant of buildChannelPathFuzzCorpus()) {
+          const response = createResponse();
+          await dispatchRequest(server, createRequest({ path: variant.path }), response.res);
+          expect(response.res.statusCode, variant.label).not.toBe(200);
+          expect(response.getBody(), variant.label).not.toContain(
+            '"route":"channel-canonicalized"',
+          );
+        }
+      },
+    });
+  });
+
   test.each(["0.0.0.0", "::"])(
     "returns 404 (not 500) for non-hook routes with hooks enabled and bindHost=%s",
     async (bindHost) => {
@@ -254,7 +467,7 @@ describe("gateway plugin HTTP auth boundary", () => {
 
       await withTempConfig({
         cfg: { gateway: { trustedProxies: [] } },
-        prefix: "openclaw-plugin-http-hooks-bindhost-",
+        prefix: "remoteclaw-plugin-http-hooks-bindhost-",
         run: async () => {
           const handleHooksRequest = createHooksRequestHandler({
             getHooksConfig: () => createHooksConfig(),
@@ -300,7 +513,7 @@ describe("gateway plugin HTTP auth boundary", () => {
 
     await withTempConfig({
       cfg: { gateway: { trustedProxies: [] } },
-      prefix: "openclaw-plugin-http-hooks-query-token-",
+      prefix: "remoteclaw-plugin-http-hooks-query-token-",
       run: async () => {
         const handleHooksRequest = createHooksRequestHandler({
           getHooksConfig: () => createHooksConfig(),


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [258d615c4](https://github.com/openclaw/openclaw/commit/258d615c4d952926dc552be7776635f870ef3c9f)
**Tier**: AUTO-PICK

> fix: harden plugin route auth path canonicalization

**Conflicts resolved**:
- `CHANGELOG.md`: skipped (kept ours)
- `src/gateway/security-path.ts`, `src/gateway/security-path.test.ts`: accepted upstream (new files, never existed in fork — introduced by intermediate upstream commit `6632fd1ea`)
- `src/gateway/server.plugin-http-auth.test.ts`: accepted upstream test helpers + added two missing test cases from intermediate upstream commit; rebranded `openclaw-` temp dir prefixes to `remoteclaw-`