### PR TITLE
Cherry-pick 37a138c55: fix: harden typing lifecycle and cross-channel suppression

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -935,27 +935,33 @@ export async function handleFeishuMessage(params: {
     });
 
     log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
-
-    const { queuedFinal, counts } = await core.channel.reply.dispatchReplyFromConfig({
-      ctx: ctxPayload,
-      cfg,
-      dispatcher,
-      replyOptions,
-    });
-
-    markDispatchIdle();
-
-    if (isGroup && historyKey && chatHistories) {
-      clearHistoryEntriesIfEnabled({
-        historyMap: chatHistories,
-        historyKey,
-        limit: historyLimit,
+    try {
+      const { queuedFinal, counts } = await core.channel.reply.dispatchReplyFromConfig({
+        ctx: ctxPayload,
+        cfg,
+        dispatcher,
+        replyOptions,
       });
-    }
 
-    log(
-      `feishu[${account.accountId}]: dispatch complete (queuedFinal=${queuedFinal}, replies=${counts.final})`,
-    );
+      if (isGroup && historyKey && chatHistories) {
+        clearHistoryEntriesIfEnabled({
+          historyMap: chatHistories,
+          historyKey,
+          limit: historyLimit,
+        });
+      }
+
+      log(
+        `feishu[${account.accountId}]: dispatch complete (queuedFinal=${queuedFinal}, replies=${counts.final})`,
+      );
+    } finally {
+      dispatcher.markComplete();
+      try {
+        await dispatcher.waitForIdle();
+      } finally {
+        markDispatchIdle();
+      }
+    }
   } catch (err) {
     error(`feishu[${account.accountId}]: failed to dispatch message: ${String(err)}`);
   }

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -686,31 +686,39 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           },
         });
 
-      const { queuedFinal, counts } = await core.channel.reply.dispatchReplyFromConfig({
-        ctx: ctxPayload,
-        cfg,
-        dispatcher,
-        replyOptions: {
-          ...replyOptions,
+      try {
+        const { queuedFinal, counts } = await core.channel.reply.dispatchReplyFromConfig({
+          ctx: ctxPayload,
+          cfg,
+          dispatcher,
+          replyOptions: {
+            ...replyOptions,
 
-          onModelSelected,
-        },
-      });
-      markDispatchIdle();
-      if (!queuedFinal) {
-        return;
-      }
-      didSendReply = true;
-      const finalCount = counts.final;
-      logVerboseMessage(
-        `matrix: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${replyTarget}`,
-      );
-      if (didSendReply) {
-        const previewText = bodyText.replace(/\s+/g, " ").slice(0, 160);
-        core.system.enqueueSystemEvent(`Matrix message from ${senderName}: ${previewText}`, {
-          sessionKey: route.sessionKey,
-          contextKey: `matrix:message:${roomId}:${messageId || "unknown"}`,
+            onModelSelected,
+          },
         });
+        if (!queuedFinal) {
+          return;
+        }
+        didSendReply = true;
+        const finalCount = counts.final;
+        logVerboseMessage(
+          `matrix: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${replyTarget}`,
+        );
+        if (didSendReply) {
+          const previewText = bodyText.replace(/\s+/g, " ").slice(0, 160);
+          core.system.enqueueSystemEvent(`Matrix message from ${senderName}: ${previewText}`, {
+            sessionKey: route.sessionKey,
+            contextKey: `matrix:message:${roomId}:${messageId || "unknown"}`,
+          });
+        }
+      } finally {
+        dispatcher.markComplete();
+        try {
+          await dispatcher.waitForIdle();
+        } finally {
+          markDispatchIdle();
+        }
       }
     } catch (err) {
       runtime.error?.(`matrix handler failed: ${String(err)}`);

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -827,24 +827,32 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         },
       });
 
-    await core.channel.reply.dispatchReplyFromConfig({
-      ctx: ctxPayload,
-      cfg,
-      dispatcher,
-      replyOptions: {
-        ...replyOptions,
-        disableBlockStreaming:
-          typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
-        onModelSelected,
-      },
-    });
-    markDispatchIdle();
-    if (historyKey) {
-      clearHistoryEntriesIfEnabled({
-        historyMap: channelHistories,
-        historyKey,
-        limit: historyLimit,
+    try {
+      await core.channel.reply.dispatchReplyFromConfig({
+        ctx: ctxPayload,
+        cfg,
+        dispatcher,
+        replyOptions: {
+          ...replyOptions,
+          disableBlockStreaming:
+            typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
+          onModelSelected,
+        },
       });
+      if (historyKey) {
+        clearHistoryEntriesIfEnabled({
+          historyMap: channelHistories,
+          historyKey,
+          limit: historyLimit,
+        });
+      }
+    } finally {
+      dispatcher.markComplete();
+      try {
+        await dispatcher.waitForIdle();
+      } finally {
+        markDispatchIdle();
+      }
     }
   };
 

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -557,17 +557,30 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
 
     log.info("dispatching to agent", { sessionKey: route.sessionKey });
     try {
-      const { queuedFinal, counts } = await core.channel.reply.dispatchReplyFromConfig({
-        ctx: ctxPayload,
-        cfg,
-        dispatcher,
-        replyOptions,
-      });
+      try {
+        const { queuedFinal, counts } = await core.channel.reply.dispatchReplyFromConfig({
+          ctx: ctxPayload,
+          cfg,
+          dispatcher,
+          replyOptions,
+        });
 
-      markDispatchIdle();
-      log.info("dispatch complete", { queuedFinal, counts });
+        log.info("dispatch complete", { queuedFinal, counts });
 
-      if (!queuedFinal) {
+        if (!queuedFinal) {
+          if (isRoomish && historyKey) {
+            clearHistoryEntriesIfEnabled({
+              historyMap: conversationHistories,
+              historyKey,
+              limit: historyLimit,
+            });
+          }
+          return;
+        }
+        const finalCount = counts.final;
+        logVerboseMessage(
+          `msteams: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${teamsTo}`,
+        );
         if (isRoomish && historyKey) {
           clearHistoryEntriesIfEnabled({
             historyMap: conversationHistories,
@@ -575,18 +588,13 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
             limit: historyLimit,
           });
         }
-        return;
-      }
-      const finalCount = counts.final;
-      logVerboseMessage(
-        `msteams: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${teamsTo}`,
-      );
-      if (isRoomish && historyKey) {
-        clearHistoryEntriesIfEnabled({
-          historyMap: conversationHistories,
-          historyKey,
-          limit: historyLimit,
-        });
+      } finally {
+        dispatcher.markComplete();
+        try {
+          await dispatcher.waitForIdle();
+        } finally {
+          markDispatchIdle();
+        }
       }
     } catch (err) {
       log.error("dispatch failed", { error: String(err) });

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -171,6 +171,45 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
+  it("forces suppressTyping when routing to a different originating channel", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "slack",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:999",
+    });
+
+    const replyResolver = async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      expect(opts?.suppressTyping).toBe(true);
+      expect(opts?.typingPolicy).toBe("system_event");
+      return { text: "hi" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+  });
+
+  it("forces suppressTyping for internal webchat turns", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "webchat",
+      Surface: "webchat",
+      OriginatingChannel: "webchat",
+      OriginatingTo: "session:abc",
+    });
+
+    const replyResolver = async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      expect(opts?.suppressTyping).toBe(true);
+      expect(opts?.typingPolicy).toBe("internal_webchat");
+      return { text: "hi" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+  });
+
   it("routes media-only tool results when summaries are suppressed", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -11,6 +11,7 @@ import {
 } from "../../logging/diagnostic.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import { getReplyFromConfig } from "../reply.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -243,6 +244,8 @@ export async function dispatchReplyFromConfig(params: {
   const currentSurface = (ctx.Surface ?? ctx.Provider)?.toLowerCase();
   const shouldRouteToOriginating =
     isRoutableChannel(originatingChannel) && originatingTo && originatingChannel !== currentSurface;
+  const shouldSuppressTyping =
+    shouldRouteToOriginating || originatingChannel === INTERNAL_MESSAGE_CHANNEL;
   const ttsChannel = shouldRouteToOriginating ? originatingChannel : currentSurface;
 
   /**
@@ -344,6 +347,14 @@ export async function dispatchReplyFromConfig(params: {
       ctx,
       {
         ...params.replyOptions,
+        typingPolicy:
+          params.replyOptions?.typingPolicy ??
+          (originatingChannel === INTERNAL_MESSAGE_CHANNEL
+            ? "internal_webchat"
+            : shouldRouteToOriginating
+              ? "system_event"
+              : undefined),
+        suppressTyping: params.replyOptions?.suppressTyping === true || shouldSuppressTyping,
         onToolResult: (payload: ReplyPayload) => {
           const run = async () => {
             const ttsPayload = await maybeApplyTtsToPayload({

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -65,6 +65,7 @@ vi.mock("./typing-mode.js", () => ({
 
 import { runReplyAgent } from "./agent-runner.js";
 import { routeReply } from "./route-reply.js";
+import { resolveTypingMode } from "./typing-mode.js";
 
 function baseParams(
   overrides: Partial<Parameters<typeof runPreparedReply>[0]> = {},
@@ -225,5 +226,49 @@ describe("runPreparedReply media-only handling", () => {
     );
 
     expect(vi.mocked(routeReply)).not.toHaveBeenCalled();
+  });
+
+  it("uses inbound origin channel for run messageProvider", async () => {
+    await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+          ThreadHistoryBody: "Earlier message in this thread",
+          OriginatingChannel: "webchat",
+          OriginatingTo: "session:abc",
+          ChatType: "group",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          ThreadHistoryBody: "Earlier message in this thread",
+          MediaPath: "/tmp/input.png",
+          Provider: "telegram",
+          ChatType: "group",
+          OriginatingChannel: "telegram",
+          OriginatingTo: "telegram:123",
+        },
+      }),
+    );
+
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call?.followupRun.run.messageProvider).toBe("webchat");
+  });
+
+  it("passes suppressTyping through typing mode resolution", async () => {
+    await runPreparedReply(
+      baseParams({
+        opts: {
+          suppressTyping: true,
+        },
+      }),
+    );
+
+    const call = vi.mocked(resolveTypingMode).mock.calls[0]?.[0] as
+      | { suppressTyping?: boolean }
+      | undefined;
+    expect(call?.suppressTyping).toBe(true);
   });
 });

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -9,6 +9,7 @@ import {
 import { logVerbose } from "../../globals.js";
 import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { hasControlCommand } from "../command-detection.js";
 import { buildInboundMediaNote } from "../media-note.js";
@@ -196,11 +197,21 @@ export async function runPreparedReply(
   const isGroupChat = sessionCtx.ChatType === "group";
   const wasMentioned = ctx.WasMentioned === true;
   const isHeartbeat = opts?.isHeartbeat === true;
+  const typingPolicy =
+    opts?.typingPolicy ??
+    (isHeartbeat
+      ? "heartbeat"
+      : ctx.OriginatingChannel === INTERNAL_MESSAGE_CHANNEL
+        ? "internal_webchat"
+        : "auto");
+  const suppressTyping = opts?.suppressTyping === true;
   const typingMode = resolveTypingMode({
     configured: sessionCfg?.typingMode ?? agentCfg?.typingMode,
     isGroupChat,
     wasMentioned,
     isHeartbeat,
+    typingPolicy,
+    suppressTyping,
   });
   const shouldInjectGroupIntro = Boolean(
     isGroupChat && (isFirstTurnInSession || sessionEntry?.groupActivationNeedsSystemIntro),
@@ -364,8 +375,8 @@ export async function runPreparedReply(
       sessionId: sessionIdFinal,
       sessionKey,
       messageProvider: resolveOriginMessageProvider({
-        originatingChannel: sessionCtx.OriginatingChannel,
-        provider: sessionCtx.Provider,
+        originatingChannel: ctx.OriginatingChannel ?? sessionCtx.OriginatingChannel,
+        provider: ctx.Surface ?? ctx.Provider ?? sessionCtx.Provider,
       }),
       agentAccountId: sessionCtx.AccountId,
       groupId: resolveGroupSessionKey(sessionCtx)?.id ?? undefined,

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -257,6 +257,28 @@ describe("resolveTypingMode", () => {
         },
         expected: "never",
       },
+      {
+        name: "suppressTyping forces never",
+        input: {
+          configured: "instant" as const,
+          isGroupChat: false,
+          wasMentioned: false,
+          isHeartbeat: false,
+          suppressTyping: true,
+        },
+        expected: "never",
+      },
+      {
+        name: "typingPolicy system_event forces never",
+        input: {
+          configured: "instant" as const,
+          isGroupChat: false,
+          wasMentioned: false,
+          isHeartbeat: false,
+          typingPolicy: "system_event" as const,
+        },
+        expected: "never",
+      },
     ] as const;
 
     for (const testCase of cases) {

--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -1,5 +1,6 @@
 import type { TypingMode } from "../../config/types.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+import type { TypingPolicy } from "../types.js";
 import type { TypingController } from "./typing.js";
 
 export type TypingModeContext = {
@@ -7,6 +8,8 @@ export type TypingModeContext = {
   isGroupChat: boolean;
   wasMentioned: boolean;
   isHeartbeat: boolean;
+  typingPolicy?: TypingPolicy;
+  suppressTyping?: boolean;
 };
 
 export const DEFAULT_GROUP_TYPING_MODE: TypingMode = "message";
@@ -16,8 +19,16 @@ export function resolveTypingMode({
   isGroupChat,
   wasMentioned,
   isHeartbeat,
+  typingPolicy,
+  suppressTyping,
 }: TypingModeContext): TypingMode {
-  if (isHeartbeat) {
+  if (
+    isHeartbeat ||
+    typingPolicy === "heartbeat" ||
+    typingPolicy === "system_event" ||
+    typingPolicy === "internal_webchat" ||
+    suppressTyping
+  ) {
     return "never";
   }
   if (configured) {

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -12,6 +12,13 @@ export type ModelSelectedContext = {
   model: string;
 };
 
+export type TypingPolicy =
+  | "auto"
+  | "user_message"
+  | "system_event"
+  | "internal_webchat"
+  | "heartbeat";
+
 export type GetReplyOptions = {
   /** Override run id for agent events (defaults to random UUID). */
   runId?: string;
@@ -26,6 +33,10 @@ export type GetReplyOptions = {
   onTypingCleanup?: () => void;
   onTypingController?: (typing: TypingController) => void;
   isHeartbeat?: boolean;
+  /** Policy-level typing control for run classes (user/system/internal/heartbeat). */
+  typingPolicy?: TypingPolicy;
+  /** Force-disable typing indicators for this run (system/internal/cross-channel routes). */
+  suppressTyping?: boolean;
   /** Resolved heartbeat model override (provider/model string from merged per-agent config). */
   heartbeatModelOverride?: string;
   /** If true, suppress tool error warning payloads for this run. */

--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -73,6 +73,80 @@ describe("createTypingCallbacks", () => {
     }
   });
 
+  it("stops keepalive after consecutive start failures", async () => {
+    vi.useFakeTimers();
+    try {
+      const start = vi.fn().mockRejectedValue(new Error("gone"));
+      const onStartError = vi.fn();
+      const callbacks = createTypingCallbacks({ start, onStartError });
+
+      await callbacks.onReplyStart();
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(onStartError).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(start).toHaveBeenCalledTimes(2);
+      expect(onStartError).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(9_000);
+      expect(start).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not restart keepalive when breaker trips on initial start", async () => {
+    vi.useFakeTimers();
+    try {
+      const start = vi.fn().mockRejectedValue(new Error("gone"));
+      const onStartError = vi.fn();
+      const callbacks = createTypingCallbacks({
+        start,
+        onStartError,
+        maxConsecutiveFailures: 1,
+      });
+
+      await callbacks.onReplyStart();
+      expect(start).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(9_000);
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(onStartError).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resets failure counter after a successful keepalive tick", async () => {
+    vi.useFakeTimers();
+    try {
+      let callCount = 0;
+      const start = vi.fn().mockImplementation(async () => {
+        callCount += 1;
+        if (callCount % 2 === 1) {
+          throw new Error("flaky");
+        }
+      });
+      const onStartError = vi.fn();
+      const callbacks = createTypingCallbacks({
+        start,
+        onStartError,
+        maxConsecutiveFailures: 2,
+      });
+
+      await callbacks.onReplyStart(); // fail
+      await vi.advanceTimersByTimeAsync(3_000); // success
+      await vi.advanceTimersByTimeAsync(3_000); // fail
+      await vi.advanceTimersByTimeAsync(3_000); // success
+      await vi.advanceTimersByTimeAsync(3_000); // fail
+
+      expect(start).toHaveBeenCalledTimes(5);
+      expect(onStartError).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("deduplicates stop across idle and cleanup", async () => {
     const start = vi.fn().mockResolvedValue(undefined);
     const stop = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [37a138c55](https://github.com/openclaw/openclaw/commit/37a138c55)
**Tier**: AUTO-PICK

> fix: harden typing lifecycle and cross-channel suppression

### Conflict Resolution
- `CHANGELOG.md`: Skipped (fork convention)
- `extensions/matrix/src/matrix/monitor/handler.ts`: Took upstream try/finally structure, kept fork's `skillFilter` removal
- `src/auto-reply/reply/dispatch-from-config.ts`: Kept fork's non-`Boolean()` expression style, added upstream's `shouldSuppressTyping` variable