### PR TITLE
Cherry-pick c5facb847: fix(discord): avoid invalid /acp native option payload

### DIFF
--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -82,6 +82,23 @@ describe("commands registry", () => {
     expect(findCommandByNativeName("tts", "discord")).toBeUndefined();
   });
 
+  it("keeps discord native command specs within slash-command limits", () => {
+    const native = listNativeCommandSpecsForConfig(
+      { commands: { native: true } },
+      { provider: "discord" },
+    );
+    for (const spec of native) {
+      expect(spec.name).toMatch(/^[a-z0-9_-]{1,32}$/);
+      expect(spec.description.length).toBeGreaterThan(0);
+      expect(spec.description.length).toBeLessThanOrEqual(100);
+      for (const arg of spec.args ?? []) {
+        expect(arg.name).toMatch(/^[a-z0-9_-]{1,32}$/);
+        expect(arg.description.length).toBeGreaterThan(0);
+        expect(arg.description.length).toBeLessThanOrEqual(100);
+      }
+    }
+  });
+
   it("detects known text commands", () => {
     const detection = getCommandDetection();
     expect(detection.exact.has("/commands")).toBe(true);


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [c5facb847](https://github.com/openclaw/openclaw/commit/c5facb847)
**Tier**: AUTO-PICK

> fix(discord): avoid invalid /acp native option payload

### Conflict Resolution
- `commands-registry.data.ts`: ACP command gutted in fork; kept deletion, discarded upstream's description shortening
- `commands-registry.test.ts`: Kept new Discord slash-command limits test (applies to all commands), dropped ACP-specific test (command doesn't exist in fork)