### PR TITLE
cherry-pick: test(auto-reply): cover inbound timestamp guard

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -145,6 +145,36 @@ describe("buildInboundUserContextPrefix", () => {
     expect(conversationInfo["sender"]).toBe("+15551234567");
   });
 
+  it("includes formatted timestamp in conversation info when provided", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      MessageSid: "msg-with-ts",
+      Timestamp: Date.UTC(2026, 1, 15, 13, 35),
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["timestamp"]).toEqual(expect.any(String));
+  });
+
+  it("omits invalid timestamps instead of throwing", () => {
+    expect(() =>
+      buildInboundUserContextPrefix({
+        ChatType: "group",
+        MessageSid: "msg-with-bad-ts",
+        Timestamp: 1e20,
+      } as TemplateContext),
+    ).not.toThrow();
+
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      MessageSid: "msg-with-bad-ts",
+      Timestamp: 1e20,
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["timestamp"]).toBeUndefined();
+  });
+
   it("includes message_id in conversation info", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "group",


### PR DESCRIPTION
Cherry-pick of upstream [`fe842b5f1`](https://github.com/openclaw/openclaw/commit/fe842b5f1).

Adds test coverage for the inbound timestamp guard logic introduced in the previous cherry-pick (`c596658b8`).

**Disposition**: Clean pick — no conflicts.

Part of #641.