### PR TITLE
Cherry-pick 09f4abdd6: fix(msteams): Send invokeResponse immediately to prevent Teams timeout

### DIFF
--- a/extensions/msteams/src/monitor-handler.file-consent.test.ts
+++ b/extensions/msteams/src/monitor-handler.file-consent.test.ts
@@ -159,7 +159,7 @@ describe("msteams file consent invoke authz", () => {
     await vi.waitFor(() => {
       expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledTimes(1);
     });
-    
+
     expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "https://upload.example.com/put",

--- a/extensions/msteams/src/monitor-handler.file-consent.test.ts
+++ b/extensions/msteams/src/monitor-handler.file-consent.test.ts
@@ -148,18 +148,24 @@ describe("msteams file consent invoke authz", () => {
 
     await handler.run?.(context);
 
-    expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledTimes(1);
+    // invokeResponse should be sent immediately
+    expect(sendActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "invokeResponse",
+      }),
+    );
+
+    // Wait for async upload to complete
+    await vi.waitFor(() => {
+      expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledTimes(1);
+    });
+    
     expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "https://upload.example.com/put",
       }),
     );
     expect(getPendingUpload(uploadId)).toBeUndefined();
-    expect(sendActivity).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "invokeResponse",
-      }),
-    );
   });
 
   it("rejects cross-conversation accept invoke and keeps pending upload", async () => {

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -145,7 +145,7 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
       if (ctx.activity?.type === "invoke" && ctx.activity?.name === "fileConsent/invoke") {
         // Send invoke response IMMEDIATELY to prevent Teams timeout
         await ctx.sendActivity({ type: "invokeResponse", value: { status: 200 } });
-        
+
         // Handle file upload asynchronously (don't await)
         handleFileConsentInvoke(ctx, deps.log).catch((err) => {
           deps.log.debug?.("file consent handler error", { error: String(err) });

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -143,12 +143,14 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
       const ctx = context as MSTeamsTurnContext;
       // Handle file consent invokes before passing to normal flow
       if (ctx.activity?.type === "invoke" && ctx.activity?.name === "fileConsent/invoke") {
-        const handled = await handleFileConsentInvoke(ctx, deps.log);
-        if (handled) {
-          // Send invoke response for file consent
-          await ctx.sendActivity({ type: "invokeResponse", value: { status: 200 } });
-          return;
-        }
+        // Send invoke response IMMEDIATELY to prevent Teams timeout
+        await ctx.sendActivity({ type: "invokeResponse", value: { status: 200 } });
+        
+        // Handle file upload asynchronously (don't await)
+        handleFileConsentInvoke(ctx, deps.log).catch((err) => {
+          deps.log.debug?.("file consent handler error", { error: String(err) });
+        });
+        return;
       }
       return originalRun.call(handler, context);
     };


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [09f4abdd6](https://github.com/openclaw/openclaw/commit/09f4abdd6)
**Tier**: AUTO-PICK

> fix(msteams): Send invokeResponse immediately to prevent Teams timeout (#27632)