### PR TITLE
Cherry-pick 2e97d0dd9: fix: finalize teams file-consent timeout landing

### DIFF
--- a/extensions/msteams/src/monitor-handler.file-consent.test.ts
+++ b/extensions/msteams/src/monitor-handler.file-consent.test.ts
@@ -227,9 +227,6 @@ describe("msteams file consent invoke authz", () => {
       }),
     );
 
-    // Wait a bit for async handler to complete
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
     expect(fileConsentMockState.uploadToConsentUrl).not.toHaveBeenCalled();
     expect(getPendingUpload(uploadId)).toBeDefined();
     expect(sendActivity).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [2e97d0dd9](https://github.com/openclaw/openclaw/commit/2e97d0dd9)
**Tier**: AUTO-PICK

> fix: finalize teams file-consent timeout landing (#27641) (thanks @scz2011)