### PR TITLE
Cherry-pick b044c149c: Mattermost: avoid raw fetch in monitor media download

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -65,7 +65,6 @@ export type MonitorMattermostOpts = {
   webSocketFactory?: MattermostWebSocketFactory;
 };
 
-type FetchLike = (input: URL | RequestInfo, init?: RequestInit) => Promise<Response>;
 type MediaKind = "image" | "audio" | "video" | "document" | "unknown";
 
 type MattermostReaction = {
@@ -276,12 +275,6 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     log: (message) => logVerboseMessage(message),
   });
 
-  const fetchWithAuth: FetchLike = (input, init) => {
-    const headers = new Headers(init?.headers);
-    headers.set("Authorization", `Bearer ${client.token}`);
-    return fetch(input, { ...init, headers });
-  };
-
   const resolveMattermostMedia = async (
     fileIds?: string[] | null,
   ): Promise<MattermostMediaInfo[]> => {
@@ -294,7 +287,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       try {
         const fetched = await core.channel.media.fetchRemoteMedia({
           url: `${client.apiBaseUrl}/files/${fileId}`,
-          fetchImpl: fetchWithAuth,
+          requestInit: {
+            headers: {
+              Authorization: `Bearer ${client.token}`,
+            },
+          },
           filePathHint: fileId,
           maxBytes: mediaMaxBytes,
         });

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -27,6 +27,7 @@ export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promis
 type FetchMediaOptions = {
   url: string;
   fetchImpl?: FetchLike;
+  requestInit?: RequestInit;
   filePathHint?: string;
   maxBytes?: number;
   maxRedirects?: number;
@@ -79,7 +80,16 @@ async function readErrorBodySnippet(res: Response, maxChars = 200): Promise<stri
 }
 
 export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<FetchMediaResult> {
-  const { url, fetchImpl, filePathHint, maxBytes, maxRedirects, ssrfPolicy, lookupFn } = options;
+  const {
+    url,
+    fetchImpl,
+    requestInit,
+    filePathHint,
+    maxBytes,
+    maxRedirects,
+    ssrfPolicy,
+    lookupFn,
+  } = options;
 
   let res: Response;
   let finalUrl = url;
@@ -88,6 +98,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     const result = await fetchWithSsrFGuard({
       url,
       fetchImpl,
+      init: requestInit,
       maxRedirects,
       policy: ssrfPolicy,
       lookupFn,


### PR DESCRIPTION
## Summary

Cherry-pick of upstream [`b044c149c`](https://github.com/openclaw/openclaw/commit/b044c149c) — Mattermost monitor uses SSRF-safe fetch for media downloads.

**Changes**:
- Replaces raw `fetch()` with SSRF-guarded `safeFetch()` in mattermost monitor media download
- Moves auth header injection into the shared fetch helper

Cherry-picked-from: b044c149c

Part of #643