### PR TITLE
Cherry-pick 60bb47535 (partial): fix(telegram): preview text null safety

### DIFF
--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -110,12 +110,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     skipRegressive: "always" | "existingOnly";
     hadPreviewMessage: boolean;
   }): boolean => {
-    const preview = args.currentPreviewText;
+    const currentPreviewText = args.currentPreviewText;
     return (
-      preview != null &&
-      preview.length > 0 &&
-      preview.startsWith(args.text) &&
-      args.text.length < preview.length &&
+      currentPreviewText !== undefined &&
+      currentPreviewText.startsWith(args.text) &&
+      args.text.length < currentPreviewText.length &&
       (args.skipRegressive === "always" || args.hadPreviewMessage)
     );
   };


### PR DESCRIPTION
## Summary

Partial cherry-pick of upstream [`60bb47535`](https://github.com/openclaw/openclaw/commit/60bb47535) — only the telegram `lane-delivery.ts` null safety fix for preview text.

**Included**: Null narrowing for `currentPreviewText` in `shouldSkipRegressivePreviewUpdate` (replaces our earlier `Boolean()` workaround with upstream's `!== undefined` pattern).

**Skipped**: MiniMax API `authHeader` provider config changes (gutted files: `models-config.providers.ts`, `onboard-auth.config-minimax.ts`, `onboard-auth.test.ts`).

Cherry-picked-from: 60bb47535

Part of #643