### PR TITLE
fix(matrix): preserve sender labels in Matrix BodyForAgent

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -28,6 +28,7 @@ import {
   resolveMatrixAllowListMatch,
   resolveMatrixAllowListMatches,
 } from "./allowlist.js";
+import { resolveMatrixBodyForAgent } from "./inbound-body.js";
 import { resolveMatrixLocation, type MatrixLocationPayload } from "./location.js";
 import { downloadMatrixMedia } from "./media.js";
 import { resolveMentions } from "./mentions.js";
@@ -223,6 +224,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       }
 
       const senderName = await getMemberDisplayName(roomId, senderId);
+      const senderUsername = senderId.split(":")[0]?.replace(/^@/, "");
       const storeAllowFrom = isDirectMessage
         ? await readStoreAllowFromForDmPolicy({
             provider: "matrix",
@@ -529,19 +531,26 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         storePath,
         sessionKey: route.sessionKey,
       });
-      const body = core.channel.reply.formatAgentEnvelope({
+      const body = core.channel.reply.formatInboundEnvelope({
         channel: "Matrix",
         from: envelopeFrom,
         timestamp: eventTs ?? undefined,
         previousTimestamp,
         envelope: envelopeOptions,
         body: textWithId,
+        chatType: isDirectMessage ? "direct" : "channel",
+        sender: { name: senderName, username: senderUsername },
       });
 
       const groupSystemPrompt = roomConfig?.systemPrompt?.trim() || undefined;
       const ctxPayload = core.channel.reply.finalizeInboundContext({
         Body: body,
-        BodyForAgent: bodyText,
+        BodyForAgent: resolveMatrixBodyForAgent({
+          isDirectMessage,
+          bodyText,
+          senderName,
+          senderId,
+        }),
         RawBody: bodyText,
         CommandBody: bodyText,
         From: isDirectMessage ? `matrix:${senderId}` : `matrix:channel:${roomId}`,
@@ -552,7 +561,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         ConversationLabel: envelopeFrom,
         SenderName: senderName,
         SenderId: senderId,
-        SenderUsername: senderId.split(":")[0]?.replace(/^@/, ""),
+        SenderUsername: senderUsername,
         GroupSubject: isRoom ? (roomName ?? roomId) : undefined,
         GroupChannel: isRoom ? (roomInfo.canonicalAlias ?? roomId) : undefined,
         GroupSystemPrompt: isRoom ? groupSystemPrompt : undefined,

--- a/extensions/matrix/src/matrix/monitor/inbound-body.test.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-body.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { resolveMatrixBodyForAgent, resolveMatrixInboundSenderLabel } from "./inbound-body.js";
+
+describe("resolveMatrixInboundSenderLabel", () => {
+  it("includes sender username when it differs from display name", () => {
+    expect(
+      resolveMatrixInboundSenderLabel({
+        senderName: "Bu",
+        senderId: "@bu:matrix.example.org",
+      }),
+    ).toBe("Bu (bu)");
+  });
+
+  it("falls back to sender username when display name is blank", () => {
+    expect(
+      resolveMatrixInboundSenderLabel({
+        senderName: " ",
+        senderId: "@zhang:matrix.example.org",
+      }),
+    ).toBe("zhang");
+  });
+
+  it("falls back to sender id when username cannot be parsed", () => {
+    expect(
+      resolveMatrixInboundSenderLabel({
+        senderName: "",
+        senderId: "matrix-user-without-colon",
+      }),
+    ).toBe("matrix-user-without-colon");
+  });
+});
+
+describe("resolveMatrixBodyForAgent", () => {
+  it("keeps direct message body unchanged", () => {
+    expect(
+      resolveMatrixBodyForAgent({
+        isDirectMessage: true,
+        bodyText: "show me my commits",
+        senderName: "Bu",
+        senderId: "@bu:matrix.example.org",
+      }),
+    ).toBe("show me my commits");
+  });
+
+  it("prefixes non-direct message body with sender label", () => {
+    expect(
+      resolveMatrixBodyForAgent({
+        isDirectMessage: false,
+        bodyText: "show me my commits",
+        senderName: "Bu",
+        senderId: "@bu:matrix.example.org",
+      }),
+    ).toBe("Bu (bu): show me my commits");
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/inbound-body.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-body.ts
@@ -1,0 +1,32 @@
+function resolveMatrixSenderUsername(senderId: string): string | undefined {
+  const username = senderId.split(":")[0]?.replace(/^@/, "").trim();
+  return username ? username : undefined;
+}
+
+export function resolveMatrixInboundSenderLabel(params: {
+  senderName: string;
+  senderId: string;
+}): string {
+  const senderName = params.senderName.trim();
+  const senderUsername = resolveMatrixSenderUsername(params.senderId);
+  if (senderName && senderUsername && senderName !== senderUsername) {
+    return `${senderName} (${senderUsername})`;
+  }
+  return senderName || senderUsername || params.senderId;
+}
+
+export function resolveMatrixBodyForAgent(params: {
+  isDirectMessage: boolean;
+  bodyText: string;
+  senderName: string;
+  senderId: string;
+}): string {
+  if (params.isDirectMessage) {
+    return params.bodyText;
+  }
+  const senderLabel = resolveMatrixInboundSenderLabel({
+    senderName: params.senderName,
+    senderId: params.senderId,
+  });
+  return `${senderLabel}: ${params.bodyText}`;
+}


### PR DESCRIPTION
Cherry-pick of upstream [`01b4f42f9`](https://github.com/openclaw/openclaw/commit/01b4f42f9).

Preserves sender display names in Matrix `BodyForAgent` so that multi-user conversations correctly attribute messages.

CHANGELOG.md conflict resolved by keeping ours (fork has diverged CHANGELOG).

Closes #644 — commit 1 of 2.