### PR TITLE
fix(voice-call): bind webhook dedupe to verified request identity

### DIFF
--- a/extensions/voice-call/src/providers/base.ts
+++ b/extensions/voice-call/src/providers/base.ts
@@ -4,6 +4,7 @@ import type {
   InitiateCallResult,
   PlayTtsInput,
   ProviderName,
+  WebhookParseOptions,
   ProviderWebhookParseResult,
   StartListeningInput,
   StopListeningInput,
@@ -36,7 +37,7 @@ export interface VoiceCallProvider {
    * Parse provider-specific webhook payload into normalized events.
    * Returns events and optional response to send back to provider.
    */
-  parseWebhookEvent(ctx: WebhookContext): ProviderWebhookParseResult;
+  parseWebhookEvent(ctx: WebhookContext, options?: WebhookParseOptions): ProviderWebhookParseResult;
 
   /**
    * Initiate an outbound call.

--- a/extensions/voice-call/src/providers/mock.ts
+++ b/extensions/voice-call/src/providers/mock.ts
@@ -6,6 +6,7 @@ import type {
   InitiateCallResult,
   NormalizedEvent,
   PlayTtsInput,
+  WebhookParseOptions,
   ProviderWebhookParseResult,
   StartListeningInput,
   StopListeningInput,
@@ -28,7 +29,10 @@ export class MockProvider implements VoiceCallProvider {
     return { ok: true };
   }
 
-  parseWebhookEvent(ctx: WebhookContext): ProviderWebhookParseResult {
+  parseWebhookEvent(
+    ctx: WebhookContext,
+    _options?: WebhookParseOptions,
+  ): ProviderWebhookParseResult {
     try {
       const payload = JSON.parse(ctx.rawBody);
       const events: NormalizedEvent[] = [];

--- a/extensions/voice-call/src/providers/plivo.test.ts
+++ b/extensions/voice-call/src/providers/plivo.test.ts
@@ -24,4 +24,26 @@ describe("PlivoProvider", () => {
     expect(result.providerResponseBody).toContain("<Wait");
     expect(result.providerResponseBody).toContain('length="300"');
   });
+
+  it("uses verified request key when provided", () => {
+    const provider = new PlivoProvider({
+      authId: "MA000000000000000000",
+      authToken: "test-token",
+    });
+
+    const result = provider.parseWebhookEvent(
+      {
+        headers: { host: "example.com", "x-plivo-signature-v3-nonce": "nonce-1" },
+        rawBody:
+          "CallUUID=call-uuid&CallStatus=in-progress&Direction=outbound&From=%2B15550000000&To=%2B15550000001&Event=StartApp",
+        url: "https://example.com/voice/webhook?provider=plivo&flow=answer&callId=internal-call-id",
+        method: "POST",
+        query: { provider: "plivo", flow: "answer", callId: "internal-call-id" },
+      },
+      { verifiedRequestKey: "plivo:v3:verified" },
+    );
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.dedupeKey).toBe("plivo:v3:verified");
+  });
 });

--- a/extensions/voice-call/src/providers/plivo.ts
+++ b/extensions/voice-call/src/providers/plivo.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk";
+import { fetchWithSsrFGuard } from "remoteclaw/plugin-sdk";
 import type { PlivoConfig, WebhookSecurityConfig } from "../config.js";
 import type {
   HangupCallInput,

--- a/extensions/voice-call/src/providers/telnyx.test.ts
+++ b/extensions/voice-call/src/providers/telnyx.test.ts
@@ -133,7 +133,34 @@ describe("TelnyxProvider.verifyWebhook", () => {
 
     expect(first.ok).toBe(true);
     expect(first.isReplay).toBeFalsy();
+    expect(first.verifiedRequestKey).toBeTruthy();
     expect(second.ok).toBe(true);
     expect(second.isReplay).toBe(true);
+    expect(second.verifiedRequestKey).toBe(first.verifiedRequestKey);
+  });
+});
+
+describe("TelnyxProvider.parseWebhookEvent", () => {
+  it("uses verified request key for manager dedupe", () => {
+    const provider = new TelnyxProvider({
+      apiKey: "KEY123",
+      connectionId: "CONN456",
+      publicKey: undefined,
+    });
+    const result = provider.parseWebhookEvent(
+      createCtx({
+        rawBody: JSON.stringify({
+          data: {
+            id: "evt-123",
+            event_type: "call.initiated",
+            payload: { call_control_id: "call-1" },
+          },
+        }),
+      }),
+      { verifiedRequestKey: "telnyx:req:abc" },
+    );
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.dedupeKey).toBe("telnyx:req:abc");
   });
 });

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk";
+import { fetchWithSsrFGuard } from "remoteclaw/plugin-sdk";
 import type { TelnyxConfig } from "../config.js";
 import type {
   EndReason,

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -13,6 +13,7 @@ import type {
   StartListeningInput,
   StopListeningInput,
   WebhookContext,
+  WebhookParseOptions,
   WebhookVerificationResult,
 } from "../types.js";
 import { escapeXml, mapVoiceToPolly } from "../voice-mapping.js";
@@ -31,19 +32,24 @@ function getHeader(
   return value;
 }
 
-function createTwilioRequestDedupeKey(ctx: WebhookContext): string {
-  const idempotencyToken = getHeader(ctx.headers, "i-twilio-idempotency-token");
-  if (idempotencyToken) {
-    return `twilio:idempotency:${idempotencyToken}`;
+function createTwilioRequestDedupeKey(ctx: WebhookContext, verifiedRequestKey?: string): string {
+  if (verifiedRequestKey) {
+    return verifiedRequestKey;
   }
 
   const signature = getHeader(ctx.headers, "x-twilio-signature") ?? "";
+  const params = new URLSearchParams(ctx.rawBody);
+  const callSid = params.get("CallSid") ?? "";
+  const callStatus = params.get("CallStatus") ?? "";
+  const direction = params.get("Direction") ?? "";
   const callId = typeof ctx.query?.callId === "string" ? ctx.query.callId.trim() : "";
   const flow = typeof ctx.query?.flow === "string" ? ctx.query.flow.trim() : "";
   const turnToken = typeof ctx.query?.turnToken === "string" ? ctx.query.turnToken.trim() : "";
   return `twilio:fallback:${crypto
     .createHash("sha256")
-    .update(`${signature}\n${callId}\n${flow}\n${turnToken}\n${ctx.rawBody}`)
+    .update(
+      `${signature}\n${callSid}\n${callStatus}\n${direction}\n${callId}\n${flow}\n${turnToken}\n${ctx.rawBody}`,
+    )
     .digest("hex")}`;
 }
 
@@ -232,7 +238,10 @@ export class TwilioProvider implements VoiceCallProvider {
   /**
    * Parse Twilio webhook event into normalized format.
    */
-  parseWebhookEvent(ctx: WebhookContext): ProviderWebhookParseResult {
+  parseWebhookEvent(
+    ctx: WebhookContext,
+    options?: WebhookParseOptions,
+  ): ProviderWebhookParseResult {
     try {
       const params = new URLSearchParams(ctx.rawBody);
       const callIdFromQuery =
@@ -243,7 +252,7 @@ export class TwilioProvider implements VoiceCallProvider {
         typeof ctx.query?.turnToken === "string" && ctx.query.turnToken.trim()
           ? ctx.query.turnToken.trim()
           : undefined;
-      const dedupeKey = createTwilioRequestDedupeKey(ctx);
+      const dedupeKey = createTwilioRequestDedupeKey(ctx, options?.verifiedRequestKey);
       const event = this.normalizeEvent(params, {
         callIdOverride: callIdFromQuery,
         dedupeKey,

--- a/extensions/voice-call/src/providers/twilio/webhook.ts
+++ b/extensions/voice-call/src/providers/twilio/webhook.ts
@@ -29,5 +29,6 @@ export function verifyTwilioProviderWebhook(params: {
     ok: result.ok,
     reason: result.reason,
     isReplay: result.isReplay,
+    verifiedRequestKey: result.verifiedRequestKey,
   };
 }

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -177,6 +177,13 @@ export type WebhookVerificationResult = {
   reason?: string;
   /** Signature is valid, but request was seen before within replay window. */
   isReplay?: boolean;
+  /** Stable key derived from authenticated request material. */
+  verifiedRequestKey?: string;
+};
+
+export type WebhookParseOptions = {
+  /** Stable request key from verifyWebhook. */
+  verifiedRequestKey?: string;
 };
 
 export type WebhookContext = {

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -343,7 +343,9 @@ export class VoiceCallWebhookServer {
     }
 
     // Parse events
-    const result = this.provider.parseWebhookEvent(ctx);
+    const result = this.provider.parseWebhookEvent(ctx, {
+      verifiedRequestKey: verification.verifiedRequestKey,
+    });
 
     // Process each event
     if (verification.isReplay) {


### PR DESCRIPTION
Cherry-pick of upstream [`1aadf26f9`](https://github.com/openclaw/openclaw/commit/1aadf26f9).

Binds webhook deduplication to verified request identity across Twilio/Plivo/Telnyx providers.

CHANGELOG.md conflict resolved by keeping fork version (entries skipped per convention).

Closes #645 — 1/4

> 🦀 Cherry-picked with [RemoteClaw](https://remoteclaw.com)