### PR TITLE
Cherry-pick 792ce7b: fix: detect managed launchd/systemd services in process respawn

### DIFF
--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -23,9 +23,12 @@ afterEach(() => {
 function clearSupervisorHints() {
   delete process.env.LAUNCH_JOB_LABEL;
   delete process.env.LAUNCH_JOB_NAME;
+  delete process.env.REMOTECLAW_LAUNCHD_LABEL;
   delete process.env.INVOCATION_ID;
   delete process.env.SYSTEMD_EXEC_PID;
   delete process.env.JOURNAL_STREAM;
+  delete process.env.REMOTECLAW_SYSTEMD_UNIT;
+  delete process.env.REMOTECLAW_SERVICE_MARKER;
 }
 
 describe("restartGatewayProcessWithFreshPid", () => {
@@ -61,6 +64,30 @@ describe("restartGatewayProcessWithFreshPid", () => {
         stdio: "inherit",
       }),
     );
+  });
+
+  it("returns supervised when REMOTECLAW_LAUNCHD_LABEL is set (stock launchd plist)", () => {
+    clearSupervisorHints();
+    process.env.REMOTECLAW_LAUNCHD_LABEL = "ai.remoteclaw.gateway";
+    const result = restartGatewayProcessWithFreshPid();
+    expect(result.mode).toBe("supervised");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("returns supervised when REMOTECLAW_SYSTEMD_UNIT is set", () => {
+    clearSupervisorHints();
+    process.env.REMOTECLAW_SYSTEMD_UNIT = "remoteclaw-gateway.service";
+    const result = restartGatewayProcessWithFreshPid();
+    expect(result.mode).toBe("supervised");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("returns supervised when REMOTECLAW_SERVICE_MARKER is set", () => {
+    clearSupervisorHints();
+    process.env.REMOTECLAW_SERVICE_MARKER = "gateway";
+    const result = restartGatewayProcessWithFreshPid();
+    expect(result.mode).toBe("supervised");
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 
   it("returns failed when spawn throws", () => {

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -9,11 +9,21 @@ export type GatewayRespawnResult = {
 };
 
 const SUPERVISOR_HINT_ENV_VARS = [
+  // macOS launchd — native env vars (may be set by launchd itself)
   "LAUNCH_JOB_LABEL",
   "LAUNCH_JOB_NAME",
+  // macOS launchd — RemoteClaw's own plist generator sets these via
+  // buildServiceEnvironment() in service-env.ts. launchd does NOT
+  // automatically inject LAUNCH_JOB_LABEL into the child environment,
+  // so REMOTECLAW_LAUNCHD_LABEL is the reliable supervised-mode signal.
+  "REMOTECLAW_LAUNCHD_LABEL",
+  // Linux systemd
   "INVOCATION_ID",
   "SYSTEMD_EXEC_PID",
   "JOURNAL_STREAM",
+  "REMOTECLAW_SYSTEMD_UNIT",
+  // Generic service marker (set by both launchd and systemd plist/unit generators)
+  "REMOTECLAW_SERVICE_MARKER",
 ];
 
 function isTruthy(value: string | undefined): boolean {


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [792ce7b](https://github.com/openclaw/openclaw/commit/792ce7b5b)
**Author**: taw0002
**Tier**: PICK (needs rebrand)

> fix: detect OpenClaw-managed launchd/systemd services in process respawn

Rebranded `OPENCLAW_LAUNCHD_LABEL`, `OPENCLAW_SYSTEMD_UNIT`, `OPENCLAW_SERVICE_MARKER` env vars to `REMOTECLAW_*` prefix. Updated test values accordingly.