### PR TITLE
Cherry-pick bed69339c: fix(cli): scope daemon status TLS fingerprint to local probes

### DIFF
--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -149,4 +149,34 @@ describe("gatherDaemonStatus", () => {
     expect(status.rpc?.url).toBe("wss://127.0.0.1:19001");
     expect(status.rpc?.ok).toBe(true);
   });
+
+  it("does not force local TLS fingerprint when probe URL is explicitly overridden", async () => {
+    const status = await gatherDaemonStatus({
+      rpc: { url: "wss://override.example:18790" },
+      probe: true,
+      deep: false,
+    });
+
+    expect(loadGatewayTlsRuntime).not.toHaveBeenCalled();
+    expect(callGatewayStatusProbe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "wss://override.example:18790",
+        tlsFingerprint: undefined,
+      }),
+    );
+    expect(status.gateway?.probeUrl).toBe("wss://override.example:18790");
+    expect(status.rpc?.url).toBe("wss://override.example:18790");
+  });
+
+  it("skips TLS runtime loading when probe is disabled", async () => {
+    const status = await gatherDaemonStatus({
+      rpc: {},
+      probe: false,
+      deep: false,
+    });
+
+    expect(loadGatewayTlsRuntime).not.toHaveBeenCalled();
+    expect(callGatewayStatusProbe).not.toHaveBeenCalled();
+    expect(status.rpc).toBeUndefined();
+  });
 });

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -222,9 +222,11 @@ export async function gatherDaemonStatus(
   const timeoutMsRaw = Number.parseInt(String(opts.rpc.timeout ?? "10000"), 10);
   const timeoutMs = Number.isFinite(timeoutMsRaw) && timeoutMsRaw > 0 ? timeoutMsRaw : 10_000;
 
-  // Load TLS config for secure WebSocket connections
   const tlsEnabled = daemonCfg.gateway?.tls?.enabled === true;
-  const tlsRuntime = tlsEnabled ? await loadGatewayTlsRuntime(daemonCfg.gateway?.tls) : undefined;
+  const shouldUseLocalTlsRuntime = opts.probe && !probeUrlOverride && tlsEnabled;
+  const tlsRuntime = shouldUseLocalTlsRuntime
+    ? await loadGatewayTlsRuntime(daemonCfg.gateway?.tls)
+    : undefined;
 
   const rpc = opts.probe
     ? await probeGatewayStatus({
@@ -237,7 +239,10 @@ export async function gatherDaemonStatus(
           opts.rpc.password ||
           mergedDaemonEnv.REMOTECLAW_GATEWAY_PASSWORD ||
           daemonCfg.gateway?.auth?.password,
-        tlsFingerprint: tlsRuntime?.enabled ? tlsRuntime.fingerprintSha256 : undefined,
+        tlsFingerprint:
+          shouldUseLocalTlsRuntime && tlsRuntime?.enabled
+            ? tlsRuntime.fingerprintSha256
+            : undefined,
         timeoutMs,
         json: opts.rpc.json,
         configPath: daemonConfigSummary.path,


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [bed69339c](https://github.com/openclaw/openclaw/commit/bed69339c)
**Author**: Shakker <shakkerdroid@gmail.com>
**Tier**: AUTO-PICK

> fix(cli): scope daemon status TLS fingerprint to local probes

Depends on #1167