### PR TITLE
Cherry-pick a4408a917: fix sessionKey forwarding for message:sent hook

### DIFF
--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -236,6 +236,7 @@ export async function deliverAgentCommandResult(params: {
         onError: (err) => logDeliveryError(err),
         onPayload: logPayload,
         deps: createOutboundSendDeps(deps),
+        sessionKey: opts.sessionKey,
       });
     }
   }

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -184,6 +184,7 @@ export async function dispatchCronDelivery(
         bestEffort: params.deliveryBestEffort,
         deps: createOutboundSendDeps(params.deps),
         abortSignal: params.abortSignal,
+        sessionKey: params.agentSessionKey,
       });
       delivered = deliveryResults.length > 0;
       return null;

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -239,6 +239,7 @@ async function sendReceiptAck(params: {
     agentId,
     bestEffort: true,
     deps: createOutboundSendDeps(params.deps),
+    sessionKey: params.sessionKey,
   });
 }
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -657,6 +657,7 @@ export async function runHeartbeatOnce(opts: {
       payloads: [{ text: summary }],
       agentId,
       deps: opts.deps,
+      sessionKey,
     });
     return true;
   };
@@ -842,6 +843,7 @@ export async function runHeartbeatOnce(opts: {
         },
       ],
       deps: opts.deps,
+      sessionKey,
     });
 
     // Record last delivered heartbeat payload for dedupe.

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -229,6 +229,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
             mediaUrls: mirrorMediaUrls.length ? mirrorMediaUrls : undefined,
           }
         : undefined,
+      sessionKey: params.mirror?.sessionKey,
     });
 
     return {


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: openclaw/openclaw@a4408a917eab805c5a41dc53c35998c662d54d0b
- **Author**: Lucas Teixeira Campos Araujo
- **Tier**: AUTO-PICK
- **Depends on**: #1172

## Summary

Passes `sessionKey` to `deliverOutboundPayloads()` at 5 call sites that were missing it, so the internal `message:sent` hook actually fires instead of being silently skipped.

## Context

Part of cherry-pick batch from issue #648. First of a sessionKey forwarding pair (paired with 4cb405399).

Cherry-picked-from: openclaw/openclaw@a4408a917