### PR TITLE
Cherry-pick 4cb405399: complete sessionKey forwarding for message:sent hook

### DIFF
--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -95,6 +95,7 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
       payloads: [{ text: message }],
       agentId: resolveSessionAgentId({ sessionKey, config: cfg }),
       bestEffort: true,
+      sessionKey,
     });
   } catch (err) {
     enqueueSystemEvent(`${summary}\n${String(err)}`, { sessionKey });

--- a/src/infra/session-maintenance-warning.ts
+++ b/src/infra/session-maintenance-warning.ts
@@ -104,6 +104,7 @@ export async function deliverSessionMaintenanceWarning(params: WarningParams): P
       threadId: target.threadId,
       payloads: [{ text }],
       agentId: resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg }),
+      sessionKey: params.sessionKey,
     });
   } catch (err) {
     log.warn(`Failed to deliver session maintenance warning: ${String(err)}`);


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: openclaw/openclaw@4cb405399382b01e417eedd648ca6d1baf6ef775
- **Author**: Peter Steinberger (thanks @qualiobra)
- **Tier**: AUTO-PICK
- **Depends on**: #1173

## Summary

Completes sessionKey forwarding to remaining call sites (restart sentinel, session maintenance warning) so the `message:sent` internal hook fires consistently.

## Adaptation

- CHANGELOG.md entry skipped per fork convention.

## Context

Part of cherry-pick batch from issue #648. Second of the sessionKey forwarding pair (a4408a917 → 4cb405399).

Cherry-picked-from: openclaw/openclaw@4cb405399