### PR TITLE
Cherry-pick d6cbaea43: fix(tui): preserve streamed text during tool call transitions

### DIFF
--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -151,7 +151,7 @@ export class TuiStreamAssembler {
     const streamedDisplayText = state.displayText;
     const streamedTextBlocks = [...state.contentBlocks];
     const streamedSawNonTextContentBlocks = state.sawNonTextContentBlocks;
-    this.updateRunState(state, message, showThinking);
+    this.updateRunState(state, message, showThinking, { protectBoundaryDrops: true });
     const finalComposed = state.displayText;
     const shouldKeepStreamedText =
       streamedSawNonTextContentBlocks &&


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: openclaw/openclaw@d6cbaea43
- **Tier**: AUTO-PICK
- **Issue**: #649 (1/3)

Fixes streamed text preservation during tool call transitions in the TUI stream assembler.

Cherry-picked-from: d6cbaea43