### PR TITLE
Cherry-pick 9f154efa8: docs(acp): expand /acp operator playbook

### DIFF
--- a/docs/channels/discord.mdx
+++ b/docs/channels/discord.mdx
@@ -675,9 +675,10 @@ Default slash command settings:
     - `session.threadBindings.*` sets global defaults.
     - `channels.discord.threadBindings.*` overrides Discord behavior.
     - `spawnSubagentSessions` must be true to auto-create/bind threads for `sessions_spawn({ thread: true })`.
+    - `spawnAcpSessions` must be true to auto-create/bind threads for ACP (`/acp spawn ... --thread ...` or `sessions_spawn({ runtime: "acp", thread: true })`).
     - If thread bindings are disabled for an account, `/focus` and related thread binding operations are unavailable.
 
-    See [Sub-agents](/tools/subagents) and [Configuration Reference](/gateway/configuration-reference).
+    See [Sub-agents](/tools/subagents), [ACP Agents](/tools/acp-agents), and [Configuration Reference](/gateway/configuration-reference).
 
 </details>
 


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: openclaw/openclaw@9f154efa8
- **Author**: Peter Steinberger
- **Tier**: AUTO-PICK

Expands the ACP operator playbook in Discord channel docs.

**Conflict resolution**: `docs/tools/acp-agents.md` — deleted in fork (DU conflict), removed per fork intent. Only `docs/channels/discord.mdx` changes retained.

Depends on #1179

Cherry-picked for remoteclaw/remoteclaw-hq#650