### PR TITLE
Cherry-pick 9597cf189: docs(security): scope obfuscation parity reports

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,6 +52,7 @@ These are frequently reported but are typically closed with no code change:
 - Authorized user-triggered local actions presented as privilege escalation. Example: an allowlisted/owner sender running `/export-session /absolute/path.html` to write on the host. In this trust model, authorized user actions are trusted host actions unless you demonstrate an auth/sandbox/boundary bypass.
 - Reports that only show a malicious plugin executing privileged actions after a trusted operator installs/enables it.
 - Reports that assume per-user multi-tenant authorization on a shared gateway host/config.
+- Reports that only show differences in heuristic detection/parity (for example obfuscation-pattern detection on one exec path but not another) without demonstrating bypass of auth, approvals, allowlist enforcement, sandboxing, or other documented trust boundaries.
 - ReDoS/DoS claims that require trusted operator configuration input (for example catastrophic regex in `sessionFilter` or `logging.redactPatterns`) without a trust-boundary bypass.
 - Missing HSTS findings on default local/loopback deployments.
 - Slack webhook signature findings when HTTP mode already uses signing-secret verification.
@@ -112,6 +113,7 @@ Plugins/extensions are part of RemoteClaw's trusted computing base for a gateway
 - Reports where the only claim is that a trusted-installed/enabled plugin can execute with gateway/host privileges (documented trust model behavior).
 - Any report whose only claim is that an operator-enabled `dangerous*`/`dangerously*` config option weakens defaults (these are explicit break-glass tradeoffs by design)
 - Reports that depend on trusted operator-supplied configuration values to trigger availability impact (for example custom regex patterns). These may still be fixed as defense-in-depth hardening, but are not security-boundary bypasses.
+- Reports whose only claim is heuristic/parity drift in command-risk detection (for example obfuscation-pattern checks) across exec surfaces, without a demonstrated trust-boundary bypass. These may be accepted as hardening improvements, but not as vulnerabilities.
 - Exposed secrets that are third-party/user-controlled credentials (not RemoteClaw-owned and not granting access to RemoteClaw-operated infrastructure/services) without demonstrated RemoteClaw impact
 - Reports whose only claim is host-side exec when sandbox runtime is disabled/unavailable (documented default behavior in the trusted-operator model), without a boundary bypass.
 


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: openclaw/openclaw@9597cf189
- **Author**: Peter Steinberger
- **Tier**: AUTO-PICK

Scopes obfuscation parity reports as hardening improvements (not vulnerabilities) in SECURITY.md.

**Conflict resolution**: `SECURITY.md` — combined fork rebrand (`OpenClaw` → `RemoteClaw`) with upstream's new heuristic/parity drift bullet point.

Depends on #1180

Cherry-picked for remoteclaw/remoteclaw-hq#650