### PR TITLE
Cherry-pick f4391c172: docs(security): clarify Teams fileConsent uploadUrl scope

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,6 +57,7 @@ These are frequently reported but are typically closed with no code change:
 - Missing HSTS findings on default local/loopback deployments.
 - Slack webhook signature findings when HTTP mode already uses signing-secret verification.
 - Discord inbound webhook signature findings for paths not used by this repo's Discord integration.
+- Claims that Microsoft Teams `fileConsent/invoke` `uploadInfo.uploadUrl` is attacker-controlled without demonstrating one of: auth boundary bypass, a real authenticated Teams/Bot Framework event carrying attacker-chosen URL, or compromise of the Microsoft/Bot trust path.
 - Scanner-only claims against stale/nonexistent paths, or claims without a working repro.
 
 ### Duplicate Report Handling
@@ -116,6 +117,7 @@ Plugins/extensions are part of RemoteClaw's trusted computing base for a gateway
 - Reports whose only claim is heuristic/parity drift in command-risk detection (for example obfuscation-pattern checks) across exec surfaces, without a demonstrated trust-boundary bypass. These may be accepted as hardening improvements, but not as vulnerabilities.
 - Exposed secrets that are third-party/user-controlled credentials (not RemoteClaw-owned and not granting access to RemoteClaw-operated infrastructure/services) without demonstrated RemoteClaw impact
 - Reports whose only claim is host-side exec when sandbox runtime is disabled/unavailable (documented default behavior in the trusted-operator model), without a boundary bypass.
+- Reports whose only claim is that a platform-provided upload destination URL is untrusted (for example Microsoft Teams `fileConsent/invoke` `uploadInfo.uploadUrl`) without proving attacker control in an authenticated production flow.
 
 ## Deployment Assumptions
 


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: openclaw/openclaw@f4391c172
- **Author**: Peter Steinberger
- **Tier**: AUTO-PICK

Clarifies the scope of Teams fileConsent uploadUrl reports in SECURITY.md.

Clean cherry-pick, no conflicts.

Depends on #1181

Cherry-picked for remoteclaw/remoteclaw-hq#650