### PR TITLE
Cherry-pick f7041fbe: fix(windows): normalize namespaced path containment checks

### DIFF
--- a/src/config/includes.test.ts
+++ b/src/config/includes.test.ts
@@ -630,7 +630,7 @@ describe("security: path traversal protection (CWE-22)", () => {
           "{ logging: { redactSensitive: 'tools' } }\n",
           "utf-8",
         );
-        await fs.symlink(realRoot, linkRoot);
+        await fs.symlink(realRoot, linkRoot, process.platform === "win32" ? "junction" : undefined);
 
         const result = resolveConfigIncludes(
           { $include: "./includes/extra.json5" },

--- a/src/infra/restart.test.ts
+++ b/src/infra/restart.test.ts
@@ -37,7 +37,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("findGatewayPidsOnPortSync", () => {
+describe.runIf(process.platform !== "win32")("findGatewayPidsOnPortSync", () => {
   it("parses lsof output and filters non-remoteclaw/current processes", () => {
     spawnSyncMock.mockReturnValue({
       error: undefined,
@@ -76,7 +76,7 @@ describe("findGatewayPidsOnPortSync", () => {
   });
 });
 
-describe("cleanStaleGatewayProcessesSync", () => {
+describe.runIf(process.platform !== "win32")("cleanStaleGatewayProcessesSync", () => {
   it("kills stale gateway pids discovered on the gateway port", () => {
     spawnSyncMock.mockReturnValue({
       error: undefined,

--- a/src/plugins/path-safety.ts
+++ b/src/plugins/path-safety.ts
@@ -1,12 +1,8 @@
 import fs from "node:fs";
-import path from "node:path";
+import { isPathInside as isBoundaryPathInside } from "../infra/path-guards.js";
 
 export function isPathInside(baseDir: string, targetPath: string): boolean {
-  const rel = path.relative(baseDir, targetPath);
-  if (!rel) {
-    return true;
-  }
-  return !rel.startsWith("..") && !path.isAbsolute(rel);
+  return isBoundaryPathInside(baseDir, targetPath);
 }
 
 export function safeRealpathSync(targetPath: string, cache?: Map<string, string>): string | null {


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: openclaw/openclaw@f7041fbee
- **Author**: Shakker <shakkerdroid@gmail.com>
- **Tier**: AUTO-PICK
- **Result**: RESOLVED — 2 DU files (deleted in fork, rm'd), 1 UU hunk (took upstream's platform guard with fork's rebranded test description)

Normalizes Windows namespaced path (\\?\) containment checks across path-guards, config includes, plugin path-safety, and restart tests.

**Conflict resolution details:**
- `src/agents/sandbox/host-paths.ts`: DU — deleted in fork (sandbox gutted), removed
- `src/commands/onboard.test.ts`: DU — deleted in fork (onboard gutted), removed
- `src/infra/restart.test.ts`: UU — upstream added `describe.runIf(process.platform !== "win32")` guard; fork had rebranded `non-remoteclaw`. Took both: platform guard + rebranded name.

Depends on #1184

Cherry-picked-from: openclaw/openclaw@f7041fbee