### PR TITLE
Cherry-pick d06632b: refactor(gateway): share node command catalog

### DIFF
--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -1,4 +1,9 @@
 import type { RemoteClawConfig } from "../config/config.js";
+import {
+  NODE_BROWSER_PROXY_COMMAND,
+  NODE_SYSTEM_NOTIFY_COMMAND,
+  NODE_SYSTEM_RUN_COMMANDS,
+} from "../infra/node-commands.js";
 import type { NodeSession } from "./node-registry.js";
 
 const CANVAS_COMMANDS = [
@@ -38,14 +43,12 @@ const MOTION_COMMANDS = ["motion.activity", "motion.pedometer"];
 const SMS_DANGEROUS_COMMANDS = ["sms.send"];
 
 // iOS nodes don't implement system.run/which, but they do support notifications.
-const IOS_SYSTEM_COMMANDS = ["system.notify"];
+const IOS_SYSTEM_COMMANDS = [NODE_SYSTEM_NOTIFY_COMMAND];
 
 const SYSTEM_COMMANDS = [
-  "system.run.prepare",
-  "system.run",
-  "system.which",
-  "system.notify",
-  "browser.proxy",
+  ...NODE_SYSTEM_RUN_COMMANDS,
+  NODE_SYSTEM_NOTIFY_COMMAND,
+  NODE_BROWSER_PROXY_COMMAND,
 ];
 
 // "High risk" node commands. These can be enabled by explicitly adding them to

--- a/src/infra/node-commands.ts
+++ b/src/infra/node-commands.ts
@@ -1,0 +1,13 @@
+export const NODE_SYSTEM_RUN_COMMANDS = [
+  "system.run.prepare",
+  "system.run",
+  "system.which",
+] as const;
+
+export const NODE_SYSTEM_NOTIFY_COMMAND = "system.notify";
+export const NODE_BROWSER_PROXY_COMMAND = "browser.proxy";
+
+export const NODE_EXEC_APPROVALS_COMMANDS = [
+  "system.execApprovals.get",
+  "system.execApprovals.set",
+] as const;

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -3,6 +3,11 @@ import { loadConfig } from "../config/config.js";
 import { GatewayClient } from "../gateway/client.js";
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 import { getMachineDisplayName } from "../infra/machine-name.js";
+import {
+  NODE_BROWSER_PROXY_COMMAND,
+  NODE_EXEC_APPROVALS_COMMANDS,
+  NODE_SYSTEM_RUN_COMMANDS,
+} from "../infra/node-commands.js";
 import { ensureRemoteClawCliOnPath } from "../infra/path-env.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { VERSION } from "../version.js";
@@ -85,12 +90,9 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     scopes: [],
     caps: ["system", ...(browserProxyEnabled ? ["browser"] : [])],
     commands: [
-      "system.run.prepare",
-      "system.run",
-      "system.which",
-      "system.execApprovals.get",
-      "system.execApprovals.set",
-      ...(browserProxyEnabled ? ["browser.proxy"] : []),
+      ...NODE_SYSTEM_RUN_COMMANDS,
+      ...NODE_EXEC_APPROVALS_COMMANDS,
+      ...(browserProxyEnabled ? [NODE_BROWSER_PROXY_COMMAND] : []),
     ],
     pathEnv,
     permissions: undefined,


### PR DESCRIPTION
## Cherry-pick

- **Upstream commit**: [`d06632ba4`](https://github.com/openclaw/openclaw/commit/d06632ba4)
- **Author**: Peter Steinberger
- **Tier**: AUTO-PICK
- **Conflicts**: Resolved (import rebrand divergence in 2 files)

Extracts shared node command constants (`NODE_SYSTEM_RUN_COMMANDS`, `NODE_BROWSER_PROXY_COMMAND`, etc.) into `src/infra/node-commands.ts` and imports them in gateway policy and node-host runner.

Part of #654