### PR TITLE
Cherry-pick 01f1d355a: feat(nodes): add device status and info actions

### DIFF
--- a/src/agents/remoteclaw-tools.camera.test.ts
+++ b/src/agents/remoteclaw-tools.camera.test.ts
@@ -139,6 +139,71 @@ describe("nodes notifications_list", () => {
   });
 });
 
+describe("nodes device_status and device_info", () => {
+  it("invokes device.status and returns payload", async () => {
+    callGateway.mockImplementation(async ({ method, params }) => {
+      if (method === "node.list") {
+        return mockNodeList(["device.status", "device.info"]);
+      }
+      if (method === "node.invoke") {
+        expect(params).toMatchObject({
+          nodeId: NODE_ID,
+          command: "device.status",
+          params: {},
+        });
+        return {
+          payload: {
+            battery: { state: "charging", lowPowerModeEnabled: false },
+          },
+        };
+      }
+      return unexpectedGatewayMethod(method);
+    });
+
+    const result = await executeNodes({
+      action: "device_status",
+      node: NODE_ID,
+    });
+
+    expect(result.content?.[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining('"battery"'),
+    });
+  });
+
+  it("invokes device.info and returns payload", async () => {
+    callGateway.mockImplementation(async ({ method, params }) => {
+      if (method === "node.list") {
+        return mockNodeList(["device.status", "device.info"]);
+      }
+      if (method === "node.invoke") {
+        expect(params).toMatchObject({
+          nodeId: NODE_ID,
+          command: "device.info",
+          params: {},
+        });
+        return {
+          payload: {
+            systemName: "Android",
+            appVersion: "1.0.0",
+          },
+        };
+      }
+      return unexpectedGatewayMethod(method);
+    });
+
+    const result = await executeNodes({
+      action: "device_info",
+      node: NODE_ID,
+    });
+
+    expect(result.content?.[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining('"systemName"'),
+    });
+  });
+});
+
 describe("nodes run", () => {
   it("passes invoke and command timeouts", async () => {
     callGateway.mockImplementation(async ({ method, params }) => {

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -40,6 +40,8 @@ const NODES_TOOL_ACTIONS = [
   "screen_record",
   "location_get",
   "notifications_list",
+  "device_status",
+  "device_info",
   "run",
   "invoke",
 ] as const;
@@ -287,12 +289,23 @@ export function createNodesTool(options?: {
             const result: AgentToolResult = { content, details };
             return await sanitizeToolResultImages(result, "nodes:camera_snap", imageSanitization);
           }
-          case "camera_list": {
+          case "camera_list":
+          case "notifications_list":
+          case "device_status":
+          case "device_info": {
             const node = readStringParam(params, "node", { required: true });
+            const command =
+              action === "camera_list"
+                ? "camera.list"
+                : action === "notifications_list"
+                  ? "notifications.list"
+                  : action === "device_status"
+                    ? "device.status"
+                    : "device.info";
             const payloadRaw = await invokeNodeCommandPayload({
               gatewayOpts,
               node,
-              command: "camera.list",
+              command,
             });
             const payload =
               payloadRaw && typeof payloadRaw === "object" && payloadRaw !== null ? payloadRaw : {};
@@ -417,15 +430,6 @@ export function createNodesTool(options?: {
                 desiredAccuracy,
                 timeoutMs: locationTimeoutMs,
               },
-            });
-            return jsonResult(payload);
-          }
-          case "notifications_list": {
-            const node = readStringParam(params, "node", { required: true });
-            const payload = await invokeNodeCommandPayload({
-              gatewayOpts,
-              node,
-              command: "notifications.list",
             });
             return jsonResult(payload);
           }


### PR DESCRIPTION
## Cherry-pick

- **Upstream commit**: [`01f1d355a`](https://github.com/openclaw/openclaw/commit/01f1d355a467723957ec628141f77edbee970276)
- **Author**: Ayaan Zaidi
- **Tier**: AUTO-PICK
- **Issue**: #655 (1/8)

Adds device status and info actions to the nodes tool — camera list and device selection capabilities.

Applied cleanly with fork's rebranded file names (`remoteclaw-tools.camera.test.ts`).