### PR TITLE
Cherry-pick e99b323a6: feat(node): add device diagnostics and notification action commands

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeCommandRegistry.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeCommandRegistry.kt
@@ -3,6 +3,7 @@ package org.remoteclaw.android.node
 import org.remoteclaw.android.protocol.RemoteClawCanvasA2UICommand
 import org.remoteclaw.android.protocol.RemoteClawCanvasCommand
 import org.remoteclaw.android.protocol.RemoteClawCameraCommand
+import org.remoteclaw.android.protocol.RemoteClawDeviceCommand
 import org.remoteclaw.android.protocol.RemoteClawLocationCommand
 import org.remoteclaw.android.protocol.RemoteClawNotificationsCommand
 import org.remoteclaw.android.protocol.RemoteClawScreenCommand
@@ -76,7 +77,16 @@ object InvokeCommandRegistry {
         availability = InvokeCommandAvailability.LocationEnabled,
       ),
       InvokeCommandSpec(
+        name = RemoteClawDeviceCommand.Permissions.rawValue,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawDeviceCommand.Health.rawValue,
+      ),
+      InvokeCommandSpec(
         name = RemoteClawNotificationsCommand.List.rawValue,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawNotificationsCommand.Actions.rawValue,
       ),
       InvokeCommandSpec(
         name = RemoteClawSmsCommand.Send.rawValue,

--- a/apps/android/app/src/main/java/org/remoteclaw/android/protocol/RemoteClawProtocolConstants.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/protocol/RemoteClawProtocolConstants.kt
@@ -70,8 +70,21 @@ enum class RemoteClawLocationCommand(val rawValue: String) {
   }
 }
 
+enum class RemoteClawDeviceCommand(val rawValue: String) {
+  Status("device.status"),
+  Info("device.info"),
+  Permissions("device.permissions"),
+  Health("device.health"),
+  ;
+
+  companion object {
+    const val NamespacePrefix: String = "device."
+  }
+}
+
 enum class RemoteClawNotificationsCommand(val rawValue: String) {
   List("notifications.list"),
+  Actions("notifications.actions"),
   ;
 
   companion object {

--- a/apps/android/app/src/test/java/org/remoteclaw/android/node/InvokeCommandRegistryTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/node/InvokeCommandRegistryTest.kt
@@ -1,6 +1,7 @@
 package org.remoteclaw.android.node
 
 import org.remoteclaw.android.protocol.RemoteClawCameraCommand
+import org.remoteclaw.android.protocol.RemoteClawDeviceCommand
 import org.remoteclaw.android.protocol.RemoteClawLocationCommand
 import org.remoteclaw.android.protocol.RemoteClawNotificationsCommand
 import org.remoteclaw.android.protocol.RemoteClawSmsCommand
@@ -22,7 +23,10 @@ class InvokeCommandRegistryTest {
     assertFalse(commands.contains(RemoteClawCameraCommand.Snap.rawValue))
     assertFalse(commands.contains(RemoteClawCameraCommand.Clip.rawValue))
     assertFalse(commands.contains(RemoteClawLocationCommand.Get.rawValue))
+    assertTrue(commands.contains(RemoteClawDeviceCommand.Permissions.rawValue))
+    assertTrue(commands.contains(RemoteClawDeviceCommand.Health.rawValue))
     assertTrue(commands.contains(RemoteClawNotificationsCommand.List.rawValue))
+    assertTrue(commands.contains(RemoteClawNotificationsCommand.Actions.rawValue))
     assertFalse(commands.contains(RemoteClawSmsCommand.Send.rawValue))
     assertFalse(commands.contains("debug.logs"))
     assertFalse(commands.contains("debug.ed25519"))
@@ -42,7 +46,10 @@ class InvokeCommandRegistryTest {
     assertTrue(commands.contains(RemoteClawCameraCommand.Snap.rawValue))
     assertTrue(commands.contains(RemoteClawCameraCommand.Clip.rawValue))
     assertTrue(commands.contains(RemoteClawLocationCommand.Get.rawValue))
+    assertTrue(commands.contains(RemoteClawDeviceCommand.Permissions.rawValue))
+    assertTrue(commands.contains(RemoteClawDeviceCommand.Health.rawValue))
     assertTrue(commands.contains(RemoteClawNotificationsCommand.List.rawValue))
+    assertTrue(commands.contains(RemoteClawNotificationsCommand.Actions.rawValue))
     assertTrue(commands.contains(RemoteClawSmsCommand.Send.rawValue))
     assertTrue(commands.contains("debug.logs"))
     assertTrue(commands.contains("debug.ed25519"))

--- a/apps/android/app/src/test/java/org/remoteclaw/android/protocol/RemoteClawProtocolConstantsTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/protocol/RemoteClawProtocolConstantsTest.kt
@@ -36,5 +36,14 @@ class RemoteClawProtocolConstantsTest {
   @Test
   fun notificationsCommandsUseStableStrings() {
     assertEquals("notifications.list", RemoteClawNotificationsCommand.List.rawValue)
+    assertEquals("notifications.actions", RemoteClawNotificationsCommand.Actions.rawValue)
+  }
+
+  @Test
+  fun deviceCommandsUseStableStrings() {
+    assertEquals("device.status", RemoteClawDeviceCommand.Status.rawValue)
+    assertEquals("device.info", RemoteClawDeviceCommand.Info.rawValue)
+    assertEquals("device.permissions", RemoteClawDeviceCommand.Permissions.rawValue)
+    assertEquals("device.health", RemoteClawDeviceCommand.Health.rawValue)
   }
 }

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -334,7 +334,7 @@ describe("resolveNodeCommandAllowlist", () => {
     }
   });
 
-  it("includes Android notifications.list by default", () => {
+  it("includes Android notifications and device diagnostics commands by default", () => {
     const allow = resolveNodeCommandAllowlist(
       {},
       {
@@ -344,6 +344,9 @@ describe("resolveNodeCommandAllowlist", () => {
     );
 
     expect(allow.has("notifications.list")).toBe(true);
+    expect(allow.has("notifications.actions")).toBe(true);
+    expect(allow.has("device.permissions")).toBe(true);
+    expect(allow.has("device.health")).toBe(true);
     expect(allow.has("system.notify")).toBe(false);
   });
 

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -24,8 +24,10 @@ const SCREEN_DANGEROUS_COMMANDS = ["screen.record"];
 
 const LOCATION_COMMANDS = ["location.get"];
 const NOTIFICATION_COMMANDS = ["notifications.list"];
+const ANDROID_NOTIFICATION_COMMANDS = [...NOTIFICATION_COMMANDS, "notifications.actions"];
 
 const DEVICE_COMMANDS = ["device.info", "device.status"];
+const ANDROID_DEVICE_COMMANDS = [...DEVICE_COMMANDS, "device.permissions", "device.health"];
 
 const CONTACTS_COMMANDS = ["contacts.search"];
 const CONTACTS_DANGEROUS_COMMANDS = ["contacts.add"];
@@ -79,8 +81,8 @@ const PLATFORM_DEFAULTS: Record<string, string[]> = {
     ...CANVAS_COMMANDS,
     ...CAMERA_COMMANDS,
     ...LOCATION_COMMANDS,
-    ...NOTIFICATION_COMMANDS,
-    ...DEVICE_COMMANDS,
+    ...ANDROID_NOTIFICATION_COMMANDS,
+    ...ANDROID_DEVICE_COMMANDS,
     ...CONTACTS_COMMANDS,
     ...CALENDAR_COMMANDS,
     ...REMINDERS_COMMANDS,


### PR DESCRIPTION
## Cherry-pick

- **Upstream commit**: [`e99b323a6`](https://github.com/openclaw/openclaw/commit/e99b323a6b406fd32d15fe45d3bd6bdf9ee9d609)
- **Author**: Ayaan Zaidi
- **Tier**: AUTO-PICK
- **Issue**: #655 (3/8)
- Depends on #1189

Adds device diagnostics (permissions, health) and notification action commands to protocol constants, command registry, command policy, and gateway tests.

**Conflict resolution**: Android files had rebrand conflicts (OpenClaw→RemoteClaw paths/types). Resolved by:
- Adding `RemoteClawDeviceCommand` enum with all 4 values (Status, Info, Permissions, Health) to protocol constants
- Adding `Permissions`, `Health` registry entries and `Actions` notification registry entry
- Skipping InvokeDispatcher device/notification handler wiring (DeviceHandler not yet in fork — will be added by Issue #656)
- Applying test assertions with rebranded type names

Gateway TypeScript side (node-command-policy.ts, gateway-misc.test.ts) applied cleanly.