### PR TITLE
Cherry-pick b8373eadd: fix(nodes): reject facing=both when camera deviceId is set

### DIFF
--- a/src/agents/remoteclaw-tools.camera.test.ts
+++ b/src/agents/remoteclaw-tools.camera.test.ts
@@ -101,6 +101,17 @@ describe("nodes camera_snap", () => {
       deviceId: "cam-123",
     });
   });
+
+  it("rejects facing both when deviceId is provided", async () => {
+    await expect(
+      executeNodes({
+        action: "camera_snap",
+        node: NODE_ID,
+        facing: "both",
+        deviceId: "cam-123",
+      }),
+    ).rejects.toThrow(/facing=both is not allowed when deviceId is set/i);
+  });
 });
 
 describe("nodes notifications_list", () => {

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -238,6 +238,9 @@ export function createNodesTool(options?: {
               typeof params.deviceId === "string" && params.deviceId.trim()
                 ? params.deviceId.trim()
                 : undefined;
+            if (deviceId && facings.length > 1) {
+              throw new Error("facing=both is not allowed when deviceId is set");
+            }
 
             const content: AgentToolResult["content"] = [];
             const details: Array<Record<string, unknown>> = [];

--- a/src/cli/nodes-cli/register.camera.ts
+++ b/src/cli/nodes-cli/register.camera.ts
@@ -121,6 +121,9 @@ export function registerNodesCameraCommands(nodes: Command) {
           const quality = opts.quality ? Number.parseFloat(String(opts.quality)) : undefined;
           const delayMs = opts.delayMs ? Number.parseInt(String(opts.delayMs), 10) : undefined;
           const deviceId = opts.deviceId ? String(opts.deviceId).trim() : undefined;
+          if (deviceId && facings.length > 1) {
+            throw new Error("facing=both is not allowed when --device-id is set");
+          }
           const timeoutMs = opts.invokeTimeout
             ? Number.parseInt(String(opts.invokeTimeout), 10)
             : undefined;

--- a/src/cli/program.nodes-media.test.ts
+++ b/src/cli/program.nodes-media.test.ts
@@ -284,6 +284,38 @@ describe("cli program (nodes media)", () => {
     );
   });
 
+  it("fails nodes camera snap when --facing both and --device-id are combined", async () => {
+    mockNodeGateway();
+
+    const program = new Command();
+    program.exitOverride();
+    registerNodesCli(program);
+    runtime.error.mockClear();
+
+    await expect(
+      program.parseAsync(
+        [
+          "nodes",
+          "camera",
+          "snap",
+          "--node",
+          "ios-node",
+          "--facing",
+          "both",
+          "--device-id",
+          "cam-123",
+        ],
+        { from: "user" },
+      ),
+    ).rejects.toThrow(/exit/i);
+
+    expect(
+      runtime.error.mock.calls.some(([msg]) =>
+        /facing=both is not allowed when --device-id is set/i.test(String(msg)),
+      ),
+    ).toBe(true);
+  });
+
   describe("URL-based payloads", () => {
     let originalFetch: typeof globalThis.fetch;
 


### PR DESCRIPTION
## Cherry-pick

- **Upstream commit**: [`b8373eadd`](https://github.com/openclaw/openclaw/commit/b8373eaddce2243b34bff46ad5518933751d4561)
- **Author**: Ayaan Zaidi
- **Tier**: AUTO-PICK
- **Issue**: #655 (5/8)
- Depends on #1191

Rejects `facing=both` when a specific camera `deviceId` is set, adding validation in nodes-tool and CLI register, with tests.

Applied cleanly.