### PR TITLE
Cherry-pick 1bf08ae7c: refactor(nodes): map read actions to invoke commands

### DIFF
--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -54,6 +54,14 @@ const NOTIFY_DELIVERIES = ["system", "overlay", "auto"] as const;
 const NOTIFICATIONS_ACTIONS = ["open", "dismiss", "reply"] as const;
 const CAMERA_FACING = ["front", "back", "both"] as const;
 const LOCATION_ACCURACY = ["coarse", "balanced", "precise"] as const;
+const NODE_READ_ACTION_COMMANDS = {
+  camera_list: "camera.list",
+  notifications_list: "notifications.list",
+  device_status: "device.status",
+  device_info: "device.info",
+  device_permissions: "device.permissions",
+  device_health: "device.health",
+} as const;
 type GatewayCallOptions = ReturnType<typeof readGatewayCallOptions>;
 
 async function invokeNodeCommandPayload(params: {
@@ -307,18 +315,7 @@ export function createNodesTool(options?: {
           case "device_permissions":
           case "device_health": {
             const node = readStringParam(params, "node", { required: true });
-            const command =
-              action === "camera_list"
-                ? "camera.list"
-                : action === "notifications_list"
-                  ? "notifications.list"
-                  : action === "device_status"
-                    ? "device.status"
-                    : action === "device_info"
-                      ? "device.info"
-                      : action === "device_permissions"
-                        ? "device.permissions"
-                        : "device.health";
+            const command = NODE_READ_ACTION_COMMANDS[action];
             const payloadRaw = await invokeNodeCommandPayload({
               gatewayOpts,
               node,


### PR DESCRIPTION
## Cherry-pick

- **Upstream commit**: [`1bf08ae7c`](https://github.com/openclaw/openclaw/commit/1bf08ae7c9142d2b10bcd5a3a3da589ae037f181)
- **Author**: Ayaan Zaidi
- **Tier**: AUTO-PICK
- **Issue**: #655 (6/8)
- Depends on #1192

Refactors nodes-tool to map read actions (device status/info, notifications list) to invoke commands, removing duplicated dispatch logic.

Applied cleanly.