### PR TITLE
Cherry-pick 0f7664f: fix(android): reject non-positive camera maxWidth

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/CameraCaptureManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/CameraCaptureManager.kt
@@ -300,7 +300,10 @@ class CameraCaptureManager(private val context: Context) {
     readPrimitive(params, "quality")?.contentOrNull?.toDoubleOrNull()
 
   private fun parseMaxWidth(params: JsonObject?): Int? =
-    readPrimitive(params, "maxWidth")?.contentOrNull?.toIntOrNull()
+    readPrimitive(params, "maxWidth")
+      ?.contentOrNull
+      ?.toIntOrNull()
+      ?.takeIf { it > 0 }
 
   private fun parseDurationMs(params: JsonObject?): Int? =
     readPrimitive(params, "durationMs")?.contentOrNull?.toIntOrNull()


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: openclaw/openclaw@0f7664fda
- **Author**: Ayaan Zaidi
- **Tier**: FAST-PICK
- **Issue**: #656 (commit 5/17)
- **Depends on**: #1199

Rejects non-positive camera maxWidth values.