### PR TITLE
Cherry-pick e48513d: fix(android): scale invoke result ack timeout to invoke budget

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/gateway/GatewaySession.kt
@@ -499,11 +499,16 @@ class GatewaySession(
           } catch (err: Throwable) {
             invokeErrorFromThrowable(err)
           }
-        sendInvokeResult(id, nodeId, result)
+        sendInvokeResult(id, nodeId, result, timeoutMs)
       }
     }
 
-    private suspend fun sendInvokeResult(id: String, nodeId: String, result: InvokeResult) {
+    private suspend fun sendInvokeResult(
+      id: String,
+      nodeId: String,
+      result: InvokeResult,
+      invokeTimeoutMs: Long?,
+    ) {
       val parsedPayload = result.payloadJson?.let { parseJsonOrNull(it) }
       val params =
         buildJsonObject {
@@ -525,10 +530,14 @@ class GatewaySession(
             )
           }
         }
+      val ackTimeoutMs = resolveInvokeResultAckTimeoutMs(invokeTimeoutMs)
       try {
-        request("node.invoke.result", params, timeoutMs = 15_000)
+        request("node.invoke.result", params, timeoutMs = ackTimeoutMs)
       } catch (err: Throwable) {
-        Log.w(loggerTag, "node.invoke.result failed: ${err.message ?: err::class.java.simpleName}")
+        Log.w(
+          loggerTag,
+          "node.invoke.result failed (ackTimeoutMs=$ackTimeoutMs): ${err.message ?: err::class.java.simpleName}",
+        )
       }
     }
 
@@ -711,4 +720,9 @@ private fun parseJsonOrNull(payload: String): JsonElement? {
   } catch (_: Throwable) {
     null
   }
+}
+
+internal fun resolveInvokeResultAckTimeoutMs(invokeTimeoutMs: Long?): Long {
+  val normalized = invokeTimeoutMs?.takeIf { it > 0L } ?: 15_000L
+  return normalized.coerceIn(15_000L, 120_000L)
 }

--- a/apps/android/app/src/test/java/org/remoteclaw/android/gateway/GatewaySessionInvokeTimeoutTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/gateway/GatewaySessionInvokeTimeoutTest.kt
@@ -1,0 +1,25 @@
+package org.remoteclaw.android.gateway
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GatewaySessionInvokeTimeoutTest {
+  @Test
+  fun resolveInvokeResultAckTimeoutMs_usesFloorWhenMissingOrTooSmall() {
+    assertEquals(15_000L, resolveInvokeResultAckTimeoutMs(null))
+    assertEquals(15_000L, resolveInvokeResultAckTimeoutMs(0L))
+    assertEquals(15_000L, resolveInvokeResultAckTimeoutMs(5_000L))
+  }
+
+  @Test
+  fun resolveInvokeResultAckTimeoutMs_usesInvokeBudgetWithinBounds() {
+    assertEquals(30_000L, resolveInvokeResultAckTimeoutMs(30_000L))
+    assertEquals(90_000L, resolveInvokeResultAckTimeoutMs(90_000L))
+  }
+
+  @Test
+  fun resolveInvokeResultAckTimeoutMs_capsAtUpperBound() {
+    assertEquals(120_000L, resolveInvokeResultAckTimeoutMs(121_000L))
+    assertEquals(120_000L, resolveInvokeResultAckTimeoutMs(Long.MAX_VALUE))
+  }
+}


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: openclaw/openclaw@e48513d51
- **Author**: Ayaan Zaidi
- **Tier**: FAST-PICK
- **Issue**: #656 (commit 7/17)
- **Depends on**: #1201

Scales invoke result ack timeout to invoke budget.

**Conflict resolution**: Test file directory rename — placed at rebranded `org/remoteclaw` path, updated package declaration.