### PR TITLE
Cherry-pick 8807267: fix(android): allow open and reply on non-clearable notifications

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/DeviceNotificationListenerService.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/DeviceNotificationListenerService.kt
@@ -54,6 +54,10 @@ data class NotificationActionResult(
   val message: String? = null,
 )
 
+internal fun actionRequiresClearableNotification(kind: NotificationActionKind): Boolean {
+  return kind == NotificationActionKind.Dismiss
+}
+
 private object DeviceNotificationStore {
   private val lock = Any()
   private var connected = false
@@ -221,7 +225,7 @@ class DeviceNotificationListenerService : NotificationListenerService() {
           code = "NOTIFICATION_NOT_FOUND",
           message = "NOTIFICATION_NOT_FOUND: notification key not found",
         )
-    if (!sbn.isClearable) {
+    if (actionRequiresClearableNotification(request.kind) && !sbn.isClearable) {
       return NotificationActionResult(
         ok = false,
         code = "NOTIFICATION_NOT_CLEARABLE",

--- a/apps/android/app/src/test/java/org/remoteclaw/android/node/NotificationsHandlerTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/node/NotificationsHandlerTest.kt
@@ -182,6 +182,13 @@ class NotificationsHandlerTest {
     assertTrue((sanitized ?: "").all { it == 'x' })
   }
 
+  @Test
+  fun notificationsActionClearablePolicy_onlyRequiresClearableForDismiss() {
+    assertTrue(actionRequiresClearableNotification(NotificationActionKind.Dismiss))
+    assertFalse(actionRequiresClearableNotification(NotificationActionKind.Open))
+    assertFalse(actionRequiresClearableNotification(NotificationActionKind.Reply))
+  }
+
   private fun parsePayload(result: GatewaySession.InvokeResult): JsonObject {
     val payloadJson = result.payloadJson ?: error("expected payload")
     return Json.parseToJsonElement(payloadJson).jsonObject


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: openclaw/openclaw@8807267bf
- **Author**: Ayaan Zaidi
- **Tier**: FAST-PICK
- **Issue**: #656 (commit 9/17)
- **Depends on**: #1203

Allows open and reply on non-clearable notifications.