### PR TITLE
Cherry-pick bbab0b0: fix(android): rebind listener before notification actions

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/NotificationsHandler.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/NotificationsHandler.kt
@@ -55,6 +55,11 @@ class NotificationsHandler private constructor(
   }
 
   suspend fun handleNotificationsActions(paramsJson: String?): GatewaySession.InvokeResult {
+    val snapshot = stateProvider.readSnapshot(appContext)
+    if (snapshot.enabled && !snapshot.connected) {
+      stateProvider.requestServiceRebind(appContext)
+    }
+
     val params = parseParamsObject(paramsJson)
       ?: return GatewaySession.InvokeResult.error(
         code = "INVALID_REQUEST",

--- a/apps/android/app/src/test/java/org/remoteclaw/android/node/NotificationsHandlerTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/node/NotificationsHandlerTest.kt
@@ -168,6 +168,26 @@ class NotificationsHandlerTest {
     }
 
   @Test
+  fun notificationsActions_requestsRebindWhenEnabledButDisconnected() =
+    runTest {
+      val provider =
+        FakeNotificationsStateProvider(
+          DeviceNotificationSnapshot(
+            enabled = true,
+            connected = false,
+            notifications = listOf(sampleEntry("n5")),
+          ),
+        )
+      val handler = NotificationsHandler.forTesting(appContext = appContext(), stateProvider = provider)
+
+      val result = handler.handleNotificationsActions("""{"key":"n5","action":"open"}""")
+
+      assertTrue(result.ok)
+      assertEquals(1, provider.rebindRequests)
+      assertEquals(1, provider.actionRequests)
+    }
+
+  @Test
   fun sanitizeNotificationTextReturnsNullForBlankInput() {
     assertNull(sanitizeNotificationText(null))
     assertNull(sanitizeNotificationText("    "))


### PR DESCRIPTION
## Cherry-pick from upstream
- **Upstream commit**: openclaw/openclaw@bbab0b005
- **Author**: Ayaan Zaidi
- **Tier**: FAST-PICK
- **Issue**: #656 (commit 10/17)
- **Depends on**: #1204