### PR TITLE
fix(android): refresh scoped canvas URLs without trailing slash (cherry-pick 8187fbc)

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/gateway/GatewaySession.kt
@@ -759,7 +759,7 @@ private fun parseJsonOrNull(payload: String): JsonElement? {
   }
 }
 
-private fun replaceCanvasCapabilityInScopedHostUrl(
+internal fun replaceCanvasCapabilityInScopedHostUrl(
   scopedUrl: String,
   capability: String,
 ): String? {
@@ -767,7 +767,10 @@ private fun replaceCanvasCapabilityInScopedHostUrl(
   val markerStart = scopedUrl.indexOf(marker)
   if (markerStart < 0) return null
   val capabilityStart = markerStart + marker.length
-  val capabilityEnd = scopedUrl.indexOf("/", capabilityStart)
+  val slashEnd = scopedUrl.indexOf("/", capabilityStart).takeIf { it >= 0 }
+  val queryEnd = scopedUrl.indexOf("?", capabilityStart).takeIf { it >= 0 }
+  val fragmentEnd = scopedUrl.indexOf("#", capabilityStart).takeIf { it >= 0 }
+  val capabilityEnd = listOfNotNull(slashEnd, queryEnd, fragmentEnd).minOrNull() ?: scopedUrl.length
   if (capabilityEnd <= capabilityStart) return null
   return scopedUrl.substring(0, capabilityStart) + capability + scopedUrl.substring(capabilityEnd)
 }

--- a/apps/android/app/src/test/java/org/remoteclaw/android/gateway/GatewaySessionInvokeTimeoutTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/gateway/GatewaySessionInvokeTimeoutTest.kt
@@ -22,4 +22,26 @@ class GatewaySessionInvokeTimeoutTest {
     assertEquals(120_000L, resolveInvokeResultAckTimeoutMs(121_000L))
     assertEquals(120_000L, resolveInvokeResultAckTimeoutMs(Long.MAX_VALUE))
   }
+
+  @Test
+  fun replaceCanvasCapabilityInScopedHostUrl_rewritesTerminalCapabilitySegment() {
+    assertEquals(
+      "http://127.0.0.1:18789/__openclaw__/cap/new-token",
+      replaceCanvasCapabilityInScopedHostUrl(
+        "http://127.0.0.1:18789/__openclaw__/cap/old-token",
+        "new-token",
+      ),
+    )
+  }
+
+  @Test
+  fun replaceCanvasCapabilityInScopedHostUrl_rewritesWhenQueryAndFragmentPresent() {
+    assertEquals(
+      "http://127.0.0.1:18789/__openclaw__/cap/new-token?a=1#frag",
+      replaceCanvasCapabilityInScopedHostUrl(
+        "http://127.0.0.1:18789/__openclaw__/cap/old-token?a=1#frag",
+        "new-token",
+      ),
+    )
+  }
 }


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@8187fbc.

Part of #656.