### PR TITLE
fix(android): avoid duplicate A2UI readiness probe on happy path (cherry-pick 6222d66)

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeDispatcher.kt
@@ -146,7 +146,8 @@ class InvokeDispatcher(
         code = "A2UI_HOST_NOT_CONFIGURED",
         message = "A2UI_HOST_NOT_CONFIGURED: gateway did not advertise canvas host",
       )
-    if (!a2uiHandler.ensureA2uiReady(a2uiUrl)) {
+    val readyOnFirstCheck = a2uiHandler.ensureA2uiReady(a2uiUrl)
+    if (!readyOnFirstCheck) {
       if (!refreshNodeCanvasCapability()) {
         return GatewaySession.InvokeResult.error(
           code = "A2UI_HOST_UNAVAILABLE",
@@ -158,12 +159,12 @@ class InvokeDispatcher(
           code = "A2UI_HOST_NOT_CONFIGURED",
           message = "A2UI_HOST_NOT_CONFIGURED: gateway did not advertise canvas host",
         )
-    }
-    if (!a2uiHandler.ensureA2uiReady(a2uiUrl)) {
-      return GatewaySession.InvokeResult.error(
-        code = "A2UI_HOST_UNAVAILABLE",
-        message = "A2UI_HOST_UNAVAILABLE: A2UI host not reachable",
-      )
+      if (!a2uiHandler.ensureA2uiReady(a2uiUrl)) {
+        return GatewaySession.InvokeResult.error(
+          code = "A2UI_HOST_UNAVAILABLE",
+          message = "A2UI_HOST_UNAVAILABLE: A2UI host not reachable",
+        )
+      }
     }
     return block()
   }


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@6222d6650.

Part of #656.