### PR TITLE
Cherry-pick a0b12f2ba: fix(browser): accept fill fields without explicit type

### DIFF
--- a/src/browser/routes/agent.act.ts
+++ b/src/browser/routes/agent.act.ts
@@ -192,8 +192,8 @@ export function registerBrowserAgentActRoutes(
                 }
                 const rec = field as Record<string, unknown>;
                 const ref = toStringOrEmpty(rec.ref);
-                const type = toStringOrEmpty(rec.type);
-                if (!ref || !type) {
+                const type = toStringOrEmpty(rec.type) || "text";
+                if (!ref) {
                   return null;
                 }
                 const value =

--- a/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -69,6 +69,17 @@ describe("browser control server", () => {
         fields: [{ ref: "6", type: "textbox", value: "hello" }],
       });
 
+      const fillWithoutType = await postJson<{ ok: boolean }>(`${base}/act`, {
+        kind: "fill",
+        fields: [{ ref: "7", value: "world" }],
+      });
+      expect(fillWithoutType.ok).toBe(true);
+      expect(pwMocks.fillFormViaPlaywright).toHaveBeenCalledWith({
+        cdpUrl: state.cdpBaseUrl,
+        targetId: "abcd1234",
+        fields: [{ ref: "7", type: "text", value: "world" }],
+      });
+
       const resize = await postJson<{ ok: boolean }>(`${base}/act`, {
         kind: "resize",
         width: 800,


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`a0b12f2ba`](https://github.com/openclaw/openclaw/commit/a0b12f2ba)
- **Author**: Rick
- **Tier**: AUTO-PICK

Upstream fix to accept browser fill fields without an explicit type attribute.

Part of #657.