### PR TITLE
Cherry-pick 2ed9d633b: fix browser fill default type parity

### DIFF
--- a/src/cli/browser-cli-actions-input/shared.test.ts
+++ b/src/cli/browser-cli-actions-input/shared.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { readFields } from "./shared.js";
+
+describe("readFields", () => {
+  it("defaults missing type to text", async () => {
+    await expect(readFields({ fields: '[{"ref":"7","value":"world"}]' })).resolves.toEqual([
+      { ref: "7", type: "text", value: "world" },
+    ]);
+  });
+
+  it("requires ref", async () => {
+    await expect(readFields({ fields: '[{"type":"textbox","value":"world"}]' })).rejects.toThrow(
+      "fields[0] must include ref",
+    );
+  });
+});

--- a/src/cli/browser-cli-actions-input/shared.ts
+++ b/src/cli/browser-cli-actions-input/shared.ts
@@ -70,18 +70,19 @@ export async function readFields(opts: {
     const rec = entry as Record<string, unknown>;
     const ref = typeof rec.ref === "string" ? rec.ref.trim() : "";
     const type = typeof rec.type === "string" ? rec.type.trim() : "";
-    if (!ref || !type) {
-      throw new Error(`fields[${index}] must include ref and type`);
+    if (!ref) {
+      throw new Error(`fields[${index}] must include ref`);
     }
+    const resolvedType = type || "text";
     if (
       typeof rec.value === "string" ||
       typeof rec.value === "number" ||
       typeof rec.value === "boolean"
     ) {
-      return { ref, type, value: rec.value };
+      return { ref, type: resolvedType, value: rec.value };
     }
     if (rec.value === undefined || rec.value === null) {
-      return { ref, type };
+      return { ref, type: resolvedType };
     }
     throw new Error(`fields[${index}].value must be string, number, boolean, or null`);
   });


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`2ed9d633b`](https://github.com/openclaw/openclaw/commit/2ed9d633b)
- **Author**: Peter Steinberger (thanks @Uface11)
- **Tier**: AUTO-PICK

Browser fill default type parity fix. CHANGELOG conflict resolved by keeping ours (skipping upstream CHANGELOG entries per adaptation notes).

Depends on #1213.

Part of #657.