### PR TITLE
Cherry-pick 712e23172: fix(agent): forward resolved outbound session context for delivery

### DIFF
--- a/src/commands/agent.delivery.test.ts
+++ b/src/commands/agent.delivery.test.ts
@@ -60,6 +60,7 @@ describe("deliverAgentCommandResult", () => {
 
   async function runDelivery(params: {
     opts: Record<string, unknown>;
+    outboundSession?: { key?: string; agentId?: string };
     sessionEntry?: SessionEntry;
     runtime?: RuntimeEnv;
     resultText?: string;
@@ -74,6 +75,7 @@ describe("deliverAgentCommandResult", () => {
       deps,
       runtime,
       opts: params.opts as never,
+      outboundSession: params.outboundSession,
       sessionEntry: params.sessionEntry,
       result,
       payloads: result.payloads,
@@ -243,6 +245,30 @@ describe("deliverAgentCommandResult", () => {
 
     expect(mocks.resolveOutboundTarget).toHaveBeenCalledWith(
       expect.objectContaining({ channel: "whatsapp", to: undefined }),
+    );
+  });
+
+  it("uses caller-provided outbound session context when opts.sessionKey is absent", async () => {
+    await runDelivery({
+      opts: {
+        message: "hello",
+        deliver: true,
+        channel: "whatsapp",
+        to: "+15551234567",
+      },
+      outboundSession: {
+        key: "agent:exec:hook:gmail:thread-1",
+        agentId: "exec",
+      },
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({
+          key: "agent:exec:hook:gmail:thread-1",
+          agentId: "exec",
+        }),
+      }),
     );
   });
 

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -12,6 +12,7 @@ import { setActivePluginRegistry } from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { agentCommand } from "./agent.js";
+import * as agentDeliveryModule from "./agent/delivery.js";
 
 // model-catalog.js was deleted; the mock is provided by isolated-agent.mocks.js.
 // Access the mock function via vi.hoisted so we can configure return values per-test.
@@ -118,6 +119,7 @@ const runtime: RuntimeEnv = {
 };
 
 const configSpy = vi.spyOn(configModule, "loadConfig");
+const deliverAgentCommandResultSpy = vi.spyOn(agentDeliveryModule, "deliverAgentCommandResult");
 
 async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
   return withTempHomeBase(fn, { prefix: "remoteclaw-agent-" });
@@ -279,6 +281,35 @@ describe("agentCommand", () => {
       await agentCommand({ message: "resume me", sessionId: "session-exec-hook" }, runtime);
 
       expect(bridgeHandleMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("forwards resolved outbound session context when resuming by sessionId", async () => {
+    await withTempHome(async (home) => {
+      const storePattern = path.join(home, "sessions", "{agentId}", "sessions.json");
+      const execStore = path.join(home, "sessions", "exec", "sessions.json");
+      writeSessionStoreSeed(execStore, {
+        "agent:exec:hook:gmail:thread-1": {
+          sessionId: "session-exec-hook",
+          updatedAt: Date.now(),
+          systemSent: true,
+        },
+      });
+      mockConfig(home, storePattern, undefined, undefined, [
+        { id: "dev" },
+        { id: "exec", default: true },
+      ]);
+
+      await agentCommand({ message: "resume me", sessionId: "session-exec-hook" }, runtime);
+
+      const deliverCall = deliverAgentCommandResultSpy.mock.calls.at(-1)?.[0];
+      expect(deliverCall?.opts.sessionKey).toBeUndefined();
+      expect(deliverCall?.outboundSession).toEqual(
+        expect.objectContaining({
+          key: "agent:exec:hook:gmail:thread-1",
+          agentId: "exec",
+        }),
+      );
     });
   });
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -31,6 +31,7 @@ import {
   emitAgentEvent,
   registerAgentRunContext,
 } from "../infra/agent-events.js";
+import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { ChannelBridge } from "../middleware/channel-bridge.js";
 import type { SessionMap } from "../middleware/session-map.js";
 import type { AgentDeliveryResult, ChannelMessage } from "../middleware/types.js";
@@ -186,6 +187,11 @@ export async function agentCommand(
       sessionKey: sessionKey ?? opts.sessionKey?.trim(),
       config: cfg,
     });
+  const outboundSession = buildOutboundSessionContext({
+    cfg,
+    agentId: sessionAgentId,
+    sessionKey,
+  });
   const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, sessionAgentId);
   const workspaceDir = await ensureAgentWorkspace(workspaceDirRaw);
   let sessionEntry = resolvedSessionEntry;
@@ -363,6 +369,7 @@ export async function agentCommand(
       deps,
       runtime,
       opts,
+      outboundSession,
       sessionEntry,
       result,
       payloads,

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -16,7 +16,7 @@ import {
   normalizeOutboundPayloads,
   normalizeOutboundPayloadsForJson,
 } from "../../infra/outbound/payloads.js";
-import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
+import type { OutboundSessionContext } from "../../infra/outbound/session-context.js";
 import type { AgentDeliveryResult } from "../../middleware/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
@@ -61,11 +61,12 @@ export async function deliverAgentCommandResult(params: {
   deps: CliDeps;
   runtime: RuntimeEnv;
   opts: AgentCommandOpts;
+  outboundSession: OutboundSessionContext | undefined;
   sessionEntry: SessionEntry | undefined;
   result: AgentDeliveryResult;
   payloads: AgentDeliveryResult["payloads"];
 }) {
-  const { cfg, deps, runtime, opts, sessionEntry, payloads, result } = params;
+  const { cfg, deps, runtime, opts, outboundSession, sessionEntry, payloads, result } = params;
   // Derive a meta object for backward-compatible JSON envelope output.
   const resultMeta = {
     durationMs: result.run.durationMs,
@@ -218,18 +219,13 @@ export async function deliverAgentCommandResult(params: {
   }
   if (deliver && deliveryChannel && !isInternalMessageChannel(deliveryChannel)) {
     if (deliveryTarget) {
-      const deliverySession = buildOutboundSessionContext({
-        cfg,
-        agentId: opts.agentId,
-        sessionKey: opts.sessionKey,
-      });
       await deliverOutboundPayloads({
         cfg,
         channel: deliveryChannel,
         to: deliveryTarget,
         accountId: resolvedAccountId,
         payloads: deliveryPayloads,
-        session: deliverySession,
+        session: outboundSession,
         replyToId: resolvedReplyToId ?? null,
         threadId: resolvedThreadTarget ?? null,
         bestEffort: bestEffortDeliver,


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: [`712e23172`](https://github.com/openclaw/openclaw/commit/712e2317250dc179383b8ccb6d06e5d650cf5b8b)
- **Author**: Peter Steinberger <steipete@gmail.com>
- **Tier**: AUTO-PICK
- **Issue**: #658 (Batch 5)

## Summary

Forwards the resolved outbound session context from `agentCommand` to `deliverAgentCommandResult`, so that delivery uses the pre-built session context rather than re-deriving it. This ensures consistent session context (key + agentId) is available for outbound payload delivery.

## Conflict Resolution

Three files had rebrand-related conflicts:
- **agent.ts**: Import conflict (fork uses middleware imports instead of `getRemoteSkillEligibility`; added `buildOutboundSessionContext` import alongside fork imports). ACP block conflict (fork gutted the ACP execution path; kept fork's empty block — the `outboundSession` additions to the two remaining `deliverAgentCommandResult` call sites auto-merged).
- **agent.test.ts**: Fork removed `runCliAgentSpy` (gutted CLI runner spy); kept only the new `deliverAgentCommandResultSpy` addition.
- **delivery.ts**: Import changed from function to type-only (`OutboundSessionContext`); kept fork's `AgentDeliveryResult` import. Destructuring merged: added `outboundSession` to params destructuring while preserving fork's `resultMeta` block.

Cherry-picked-from: 712e2317250dc179383b8ccb6d06e5d650cf5b8b