### PR TITLE
Cherry-pick df65ed7e9: test(gateway): align outbound session assertion shape

### DIFF
--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -355,7 +355,10 @@ describe("gateway send mirroring", () => {
 
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
-        session: expect.objectContaining({ agentId: "work" }),
+        session: expect.objectContaining({
+          agentId: "work",
+          key: "agent:work:slack:channel:resolved",
+        }),
         mirror: expect.objectContaining({
           sessionKey: "agent:work:slack:channel:resolved",
           agentId: "work",
@@ -377,7 +380,10 @@ describe("gateway send mirroring", () => {
 
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
-        session: expect.objectContaining({ agentId: "work" }),
+        session: expect.objectContaining({
+          agentId: "work",
+          key: "agent:work:slack:channel:c1",
+        }),
         mirror: expect.objectContaining({
           sessionKey: "agent:work:slack:channel:c1",
           agentId: "work",
@@ -400,7 +406,10 @@ describe("gateway send mirroring", () => {
 
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
-        session: expect.objectContaining({ agentId: "work" }),
+        session: expect.objectContaining({
+          agentId: "work",
+          key: "agent:main:slack:channel:c1",
+        }),
         mirror: expect.objectContaining({
           sessionKey: "agent:main:slack:channel:c1",
           agentId: "work",
@@ -423,7 +432,10 @@ describe("gateway send mirroring", () => {
 
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
-        session: expect.objectContaining({ agentId: "work" }),
+        session: expect.objectContaining({
+          agentId: "work",
+          key: "agent:work:slack:channel:c1",
+        }),
         mirror: expect.objectContaining({
           sessionKey: "agent:work:slack:channel:c1",
           agentId: "work",


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: [`df65ed7e9`](https://github.com/openclaw/openclaw/commit/df65ed7e9eba9060fab62b43197972100e794cb8)
- **Author**: Peter Steinberger <steipete@gmail.com>
- **Tier**: AUTO-PICK
- **Issue**: #658 (Batch 5)
- **Depends on**: #1216

## Summary

Aligns outbound session assertion shapes in gateway send and message tests. Tests now assert against the `session` object (with `agentId` + `key`) instead of the flat `agentId` property, matching the session context forwarding changes from the previous commit.

## Conflict Resolution

- **send.test.ts**: 4 identical conflicts — fork (Batch 4) already wrapped `agentId` in `session` object but without `key`. Took upstream's more specific assertions that include both `agentId` and `key`.
- **message.test.ts**: Both sides converged on session wrapper; fork changed channel from `telegram` to `mattermost` (rebrand). Kept fork's channel/to values with the session wrapper.

Cherry-picked-from: df65ed7e9eba9060fab62b43197972100e794cb8