### PR TITLE
Cherry-pick 7ef6623bf: fix: forward resolved session key in agent delivery

### DIFF
--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -24,9 +24,9 @@ import type { AgentCommandOpts } from "./types.js";
 
 const NESTED_LOG_PREFIX = "[agent:nested]";
 
-function formatNestedLogPrefix(opts: AgentCommandOpts): string {
+function formatNestedLogPrefix(opts: AgentCommandOpts, sessionKey?: string): string {
   const parts = [NESTED_LOG_PREFIX];
-  const session = opts.sessionKey ?? opts.sessionId;
+  const session = sessionKey ?? opts.sessionKey ?? opts.sessionId;
   if (session) {
     parts.push(`session=${session}`);
   }
@@ -46,8 +46,13 @@ function formatNestedLogPrefix(opts: AgentCommandOpts): string {
   return parts.join(" ");
 }
 
-function logNestedOutput(runtime: RuntimeEnv, opts: AgentCommandOpts, output: string) {
-  const prefix = formatNestedLogPrefix(opts);
+function logNestedOutput(
+  runtime: RuntimeEnv,
+  opts: AgentCommandOpts,
+  output: string,
+  sessionKey?: string,
+) {
+  const prefix = formatNestedLogPrefix(opts, sessionKey);
   for (const line of output.split(/\r?\n/)) {
     if (!line) {
       continue;
@@ -76,6 +81,7 @@ export async function deliverAgentCommandResult(params: {
       usage: result.run.usage,
     },
   };
+  const effectiveSessionKey = outboundSession?.key ?? opts.sessionKey;
   const deliver = opts.deliver === true;
   const bestEffortDeliver = opts.bestEffortDeliver === true;
   const turnSourceChannel = opts.runContext?.messageChannel ?? opts.messageChannel;
@@ -207,7 +213,7 @@ export async function deliverAgentCommandResult(params: {
       return;
     }
     if (opts.lane === AGENT_LANE_NESTED) {
-      logNestedOutput(runtime, opts, output);
+      logNestedOutput(runtime, opts, output, effectiveSessionKey);
       return;
     }
     runtime.log(output);


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: [`7ef6623bf`](https://github.com/openclaw/openclaw/commit/7ef6623bf3b2a094c576e726606e8ffeb65a3d63)
- **Author**: Peter Steinberger <steipete@gmail.com>
- **Co-author**: Lucas Teixeira Campos Araujo
- **Tier**: AUTO-PICK
- **Issue**: #658 (Batch 5)
- **Depends on**: #1216, #1217

## Summary

Follow-up to the session context forwarding changes. Derives `effectiveSessionKey` from the outbound session context and threads it through nested agent log output, so that `--deliver` runs resumed via `--session-id` (without explicit `--session-key`) include session context in nested log prefixes.

## Adaptation

- **CHANGELOG.md**: Skipped (per issue adaptation notes).

## Conflict Resolution

- **delivery.ts**: Single conflict — upstream's `effectiveSessionKey` addition was placed after the destructuring line, which in the fork also has the `resultMeta` block. Both are independent additions; included both.

Cherry-picked-from: 7ef6623bf3b2a094c576e726606e8ffeb65a3d63