### PR TITLE
Cherry-pick cbed0e0: fix: reject dmPolicy=allowlist with empty allowFrom

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1054,6 +1054,72 @@ function maybeRepairOpenPolicyAllowFrom(cfg: RemoteClawConfig): {
   return { config: next, changes };
 }
 
+/**
+ * Scan all channel configs for dmPolicy="allowlist" without any allowFrom entries.
+ * This configuration causes all DMs to be silently dropped because no sender can
+ * match the empty allowlist. Common after upgrades that remove external allowlist
+ * file support.
+ */
+function detectEmptyAllowlistPolicy(cfg: RemoteClawConfig): string[] {
+  const channels = cfg.channels;
+  if (!channels || typeof channels !== "object") {
+    return [];
+  }
+
+  const warnings: string[] = [];
+
+  const hasEntries = (list?: Array<string | number>) =>
+    Array.isArray(list) && list.map((v) => String(v).trim()).filter(Boolean).length > 0;
+
+  const checkAccount = (account: Record<string, unknown>, prefix: string) => {
+    const dmEntry = account.dm;
+    const dm =
+      dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
+        ? (dmEntry as Record<string, unknown>)
+        : undefined;
+    const dmPolicy =
+      (account.dmPolicy as string | undefined) ?? (dm?.policy as string | undefined) ?? undefined;
+
+    if (dmPolicy !== "allowlist") {
+      return;
+    }
+
+    const topAllowFrom = account.allowFrom as Array<string | number> | undefined;
+    const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
+
+    if (hasEntries(topAllowFrom) || hasEntries(nestedAllowFrom)) {
+      return;
+    }
+
+    warnings.push(
+      `- ${prefix}.dmPolicy is "allowlist" but allowFrom is empty — all DMs will be silently dropped. Add sender IDs to ${prefix}.allowFrom or change dmPolicy to "pairing".`,
+    );
+  };
+
+  for (const [channelName, channelConfig] of Object.entries(
+    channels as Record<string, Record<string, unknown>>,
+  )) {
+    if (!channelConfig || typeof channelConfig !== "object") {
+      continue;
+    }
+    checkAccount(channelConfig, `channels.${channelName}`);
+
+    const accounts = channelConfig.accounts;
+    if (accounts && typeof accounts === "object") {
+      for (const [accountId, account] of Object.entries(
+        accounts as Record<string, Record<string, unknown>>,
+      )) {
+        if (!account || typeof account !== "object") {
+          continue;
+        }
+        checkAccount(account, `channels.${channelName}.accounts.${accountId}`);
+      }
+    }
+  }
+
+  return warnings;
+}
+
 type LegacyToolsBySenderKeyHit = {
   toolsBySenderPath: Array<string | number>;
   pathLabel: string;
@@ -1330,6 +1396,11 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       cfg = allowFromRepair.config;
     }
 
+    const emptyAllowlistWarnings = detectEmptyAllowlistPolicy(candidate);
+    if (emptyAllowlistWarnings.length > 0) {
+      note(emptyAllowlistWarnings.join("\n"), "Doctor warnings");
+    }
+
     const toolsBySenderRepair = maybeRepairLegacyToolsBySenderKeys(candidate);
     if (toolsBySenderRepair.changes.length > 0) {
       note(toolsBySenderRepair.changes.join("\n"), "Doctor changes");
@@ -1369,6 +1440,11 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
         ].join("\n"),
         "Doctor warnings",
       );
+    }
+
+    const emptyAllowlistWarnings = detectEmptyAllowlistPolicy(candidate);
+    if (emptyAllowlistWarnings.length > 0) {
+      note(emptyAllowlistWarnings.join("\n"), "Doctor warnings");
     }
 
     const toolsBySenderHits = scanLegacyToolsBySenderKeys(candidate);

--- a/src/config/config.allowlist-requires-allowfrom.test.ts
+++ b/src/config/config.allowlist-requires-allowfrom.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+describe('dmPolicy="allowlist" requires non-empty allowFrom', () => {
+  it('rejects telegram dmPolicy="allowlist" without allowFrom', () => {
+    const res = validateConfigObject({
+      channels: { telegram: { dmPolicy: "allowlist", botToken: "fake" } },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((i) => i.path.includes("allowFrom"))).toBe(true);
+    }
+  });
+
+  it('rejects telegram dmPolicy="allowlist" with empty allowFrom', () => {
+    const res = validateConfigObject({
+      channels: { telegram: { dmPolicy: "allowlist", allowFrom: [], botToken: "fake" } },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((i) => i.path.includes("allowFrom"))).toBe(true);
+    }
+  });
+
+  it('accepts telegram dmPolicy="allowlist" with allowFrom entries', () => {
+    const res = validateConfigObject({
+      channels: { telegram: { dmPolicy: "allowlist", allowFrom: ["12345"], botToken: "fake" } },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('accepts telegram dmPolicy="pairing" without allowFrom', () => {
+    const res = validateConfigObject({
+      channels: { telegram: { dmPolicy: "pairing", botToken: "fake" } },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects signal dmPolicy="allowlist" without allowFrom', () => {
+    const res = validateConfigObject({
+      channels: { signal: { dmPolicy: "allowlist" } },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((i) => i.path.includes("allowFrom"))).toBe(true);
+    }
+  });
+
+  it('accepts signal dmPolicy="allowlist" with allowFrom entries', () => {
+    const res = validateConfigObject({
+      channels: { signal: { dmPolicy: "allowlist", allowFrom: ["+1234567890"] } },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects discord dmPolicy="allowlist" without allowFrom', () => {
+    const res = validateConfigObject({
+      channels: { discord: { dmPolicy: "allowlist" } },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((i) => i.path.includes("allowFrom"))).toBe(true);
+    }
+  });
+
+  it('accepts discord dmPolicy="allowlist" with allowFrom entries', () => {
+    const res = validateConfigObject({
+      channels: { discord: { dmPolicy: "allowlist", allowFrom: ["123456789"] } },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects whatsapp dmPolicy="allowlist" without allowFrom', () => {
+    const res = validateConfigObject({
+      channels: { whatsapp: { dmPolicy: "allowlist" } },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((i) => i.path.includes("allowFrom"))).toBe(true);
+    }
+  });
+
+  it('accepts whatsapp dmPolicy="allowlist" with allowFrom entries', () => {
+    const res = validateConfigObject({
+      channels: { whatsapp: { dmPolicy: "allowlist", allowFrom: ["+1234567890"] } },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects telegram account dmPolicy="allowlist" without allowFrom', () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          accounts: {
+            bot1: { dmPolicy: "allowlist", botToken: "fake" },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((i) => i.path.includes("allowFrom"))).toBe(true);
+    }
+  });
+
+  it('accepts telegram account dmPolicy="allowlist" with allowFrom entries', () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          accounts: {
+            bot1: { dmPolicy: "allowlist", allowFrom: ["12345"], botToken: "fake" },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -325,6 +325,32 @@ export const requireOpenAllowFrom = (params: {
   });
 };
 
+/**
+ * Validate that dmPolicy="allowlist" has a non-empty allowFrom array.
+ * Without this, all DMs are silently dropped because the allowlist is empty
+ * and no senders can match.
+ */
+export const requireAllowlistAllowFrom = (params: {
+  policy?: string;
+  allowFrom?: Array<string | number>;
+  ctx: z.RefinementCtx;
+  path: Array<string | number>;
+  message: string;
+}) => {
+  if (params.policy !== "allowlist") {
+    return;
+  }
+  const allow = normalizeAllowFrom(params.allowFrom);
+  if (allow.length > 0) {
+    return;
+  }
+  params.ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    path: params.path,
+    message: params.message,
+  });
+};
+
 export const MSTeamsReplyStyleSchema = z.enum(["thread", "top-level"]);
 
 export const RetryConfigSchema = z

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -29,6 +29,7 @@ import {
   ReplyToModeSchema,
   RetryConfigSchema,
   TtsConfigSchema,
+  requireAllowlistAllowFrom,
   requireOpenAllowFrom,
 } from "./zod-schema.core.js";
 import { sensitive } from "./zod-schema.sensitive.js";
@@ -225,6 +226,14 @@ export const TelegramAccountSchema = TelegramAccountSchemaBase.superRefine((valu
     message:
       'channels.telegram.dmPolicy="open" requires channels.telegram.allowFrom to include "*"',
   });
+  requireAllowlistAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.telegram.dmPolicy="allowlist" requires channels.telegram.allowFrom to contain at least one sender ID',
+  });
   validateTelegramCustomCommands(value, ctx);
 });
 
@@ -239,6 +248,14 @@ export const TelegramConfigSchema = TelegramAccountSchemaBase.extend({
     path: ["allowFrom"],
     message:
       'channels.telegram.dmPolicy="open" requires channels.telegram.allowFrom to include "*"',
+  });
+  requireAllowlistAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.telegram.dmPolicy="allowlist" requires channels.telegram.allowFrom to contain at least one sender ID',
   });
   validateTelegramCustomCommands(value, ctx);
 
@@ -504,6 +521,14 @@ export const DiscordAccountSchema = z
       message:
         'channels.discord.dmPolicy="open" requires channels.discord.allowFrom (or channels.discord.dm.allowFrom) to include "*"',
     });
+    requireAllowlistAllowFrom({
+      policy: dmPolicy,
+      allowFrom,
+      ctx,
+      path: [...allowFromPath],
+      message:
+        'channels.discord.dmPolicy="allowlist" requires channels.discord.allowFrom (or channels.discord.dm.allowFrom) to contain at least one sender ID',
+    });
   });
 
 export const DiscordConfigSchema = DiscordAccountSchema.extend({
@@ -525,6 +550,14 @@ export const GoogleChatDmSchema = z
       path: ["allowFrom"],
       message:
         'channels.googlechat.dm.policy="open" requires channels.googlechat.dm.allowFrom to include "*"',
+    });
+    requireAllowlistAllowFrom({
+      policy: value.policy,
+      allowFrom: value.allowFrom,
+      ctx,
+      path: ["allowFrom"],
+      message:
+        'channels.googlechat.dm.policy="allowlist" requires channels.googlechat.dm.allowFrom to contain at least one sender ID',
     });
   });
 
@@ -713,6 +746,14 @@ export const SlackAccountSchema = z
       message:
         'channels.slack.dmPolicy="open" requires channels.slack.allowFrom (or channels.slack.dm.allowFrom) to include "*"',
     });
+    requireAllowlistAllowFrom({
+      policy: dmPolicy,
+      allowFrom,
+      ctx,
+      path: [...allowFromPath],
+      message:
+        'channels.slack.dmPolicy="allowlist" requires channels.slack.allowFrom (or channels.slack.dm.allowFrom) to contain at least one sender ID',
+    });
   });
 
 export const SlackConfigSchema = SlackAccountSchema.safeExtend({
@@ -809,6 +850,14 @@ export const SignalAccountSchema = SignalAccountSchemaBase.superRefine((value, c
     path: ["allowFrom"],
     message: 'channels.signal.dmPolicy="open" requires channels.signal.allowFrom to include "*"',
   });
+  requireAllowlistAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.signal.dmPolicy="allowlist" requires channels.signal.allowFrom to contain at least one sender ID',
+  });
 });
 
 export const SignalConfigSchema = SignalAccountSchemaBase.extend({
@@ -820,6 +869,14 @@ export const SignalConfigSchema = SignalAccountSchemaBase.extend({
     ctx,
     path: ["allowFrom"],
     message: 'channels.signal.dmPolicy="open" requires channels.signal.allowFrom to include "*"',
+  });
+  requireAllowlistAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.signal.dmPolicy="allowlist" requires channels.signal.allowFrom to contain at least one sender ID',
   });
 });
 
@@ -891,6 +948,14 @@ function refineIrcAllowFromAndNickserv(value: IrcBaseConfig, ctx: z.RefinementCt
     ctx,
     path: ["allowFrom"],
     message: 'channels.irc.dmPolicy="open" requires channels.irc.allowFrom to include "*"',
+  });
+  requireAllowlistAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.irc.dmPolicy="allowlist" requires channels.irc.allowFrom to contain at least one sender ID',
   });
   if (value.nickserv?.register && !value.nickserv.registerEmail?.trim()) {
     ctx.addIssue({
@@ -973,6 +1038,14 @@ export const IMessageAccountSchema = IMessageAccountSchemaBase.superRefine((valu
     message:
       'channels.imessage.dmPolicy="open" requires channels.imessage.allowFrom to include "*"',
   });
+  requireAllowlistAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.imessage.dmPolicy="allowlist" requires channels.imessage.allowFrom to contain at least one sender ID',
+  });
 });
 
 export const IMessageConfigSchema = IMessageAccountSchemaBase.extend({
@@ -985,6 +1058,14 @@ export const IMessageConfigSchema = IMessageAccountSchemaBase.extend({
     path: ["allowFrom"],
     message:
       'channels.imessage.dmPolicy="open" requires channels.imessage.allowFrom to include "*"',
+  });
+  requireAllowlistAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.imessage.dmPolicy="allowlist" requires channels.imessage.allowFrom to contain at least one sender ID',
   });
 });
 
@@ -1053,6 +1134,14 @@ export const BlueBubblesAccountSchema = BlueBubblesAccountSchemaBase.superRefine
     path: ["allowFrom"],
     message: 'channels.bluebubbles.accounts.*.dmPolicy="open" requires allowFrom to include "*"',
   });
+  requireAllowlistAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.bluebubbles.accounts.*.dmPolicy="allowlist" requires allowFrom to contain at least one sender ID',
+  });
 });
 
 export const BlueBubblesConfigSchema = BlueBubblesAccountSchemaBase.extend({
@@ -1066,6 +1155,14 @@ export const BlueBubblesConfigSchema = BlueBubblesAccountSchemaBase.extend({
     path: ["allowFrom"],
     message:
       'channels.bluebubbles.dmPolicy="open" requires channels.bluebubbles.allowFrom to include "*"',
+  });
+  requireAllowlistAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.bluebubbles.dmPolicy="allowlist" requires channels.bluebubbles.allowFrom to contain at least one sender ID',
   });
 });
 
@@ -1137,5 +1234,13 @@ export const MSTeamsConfigSchema = z
       path: ["allowFrom"],
       message:
         'channels.msteams.dmPolicy="open" requires channels.msteams.allowFrom to include "*"',
+    });
+    requireAllowlistAllowFrom({
+      policy: value.dmPolicy,
+      allowFrom: value.allowFrom,
+      ctx,
+      path: ["allowFrom"],
+      message:
+        'channels.msteams.dmPolicy="allowlist" requires channels.msteams.allowFrom to contain at least one sender ID',
     });
   });


### PR DESCRIPTION
## Cherry-pick

- **Upstream commit**: openclaw/openclaw@cbed0e065c78ff5ad4bdaa677e94e54857cee095
- **Author**: Marcus Widing <widing.marcus@gmail.com>
- **Tier**: AUTO-PICK
- **Issue**: #659
- **Depends on**: #1219

## Summary

Rejects `dmPolicy="allowlist"` with empty `allowFrom` across all channels. Adds schema validation (zod refinement) and doctor warning (`detectEmptyAllowlistPolicy`) to surface the silent-drop misconfiguration. Includes 12 test cases.

## Conflict Resolution

- `src/commands/doctor-config-flow.ts`: Fork had deleted the exec safe bin code block (gutted in fork). Upstream added `detectEmptyAllowlistPolicy` before that block. Resolution: added `detectEmptyAllowlistPolicy` function only (rebranded `OpenClawConfig` → `RemoteClawConfig`), kept fork's exec safe bin deletion. Call sites auto-merged cleanly.

## Verification

- No references to gutted layers in src/
- All OpenClaw references rebranded to RemoteClaw

Cherry-picked-from: cbed0e065c78ff5ad4bdaa677e94e54857cee095