### PR TITLE
Cherry-pick 1d43202: fix: repair Telegram allowlist DM migrations

### DIFF
--- a/docs/channels/telegram.mdx
+++ b/docs/channels/telegram.mdx
@@ -120,13 +120,15 @@ Token resolution order is account-aware. In practice, config values win over env
     `channels.telegram.dmPolicy` controls direct message access:
 
     - `pairing` (default)
-    - `allowlist`
+    - `allowlist` (requires at least one sender ID in `allowFrom`)
     - `open` (requires `allowFrom` to include `"*"`)
     - `disabled`
 
     `channels.telegram.allowFrom` accepts numeric Telegram user IDs. `telegram:` / `tg:` prefixes are accepted and normalized.
+    `dmPolicy: "allowlist"` with empty `allowFrom` blocks all DMs and is rejected by config validation.
     The onboarding wizard accepts `@username` input and resolves it to numeric IDs.
     If you upgraded and your config contains `@username` allowlist entries, run `remoteclaw doctor --fix` to resolve them (best-effort; requires a Telegram bot token).
+    If you previously relied on pairing-store allowlist files, `remoteclaw doctor --fix` can auto-migrate recovered entries into `channels.telegram.allowFrom`.
 
     ### Finding your Telegram user ID
 
@@ -753,7 +755,7 @@ Primary reference:
 - `channels.telegram.botToken`: bot token (BotFather).
 - `channels.telegram.tokenFile`: read token from file path.
 - `channels.telegram.dmPolicy`: `pairing | allowlist | open | disabled` (default: pairing).
-- `channels.telegram.allowFrom`: DM allowlist (numeric Telegram user IDs). `open` requires `"*"`. `remoteclaw doctor --fix` can resolve legacy `@username` entries to IDs.
+- `channels.telegram.allowFrom`: DM allowlist (numeric Telegram user IDs). `allowlist` requires at least one sender ID. `open` requires `"*"`. `remoteclaw doctor --fix` can resolve legacy `@username` entries to IDs and can restore allowlist entries from pairing-store files when available.
 - `channels.telegram.groupPolicy`: `open | allowlist | disabled` (default: allowlist).
 - `channels.telegram.groupAllowFrom`: group sender allowlist (numeric Telegram user IDs). `remoteclaw doctor --fix` can resolve legacy `@username` entries to IDs.
 - Multi-account precedence:

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -412,6 +412,50 @@ describe("doctor config flow", () => {
     expect(cfg.channels.discord.accounts.work.allowFrom).toEqual(["*"]);
   });
 
+  it('repairs dmPolicy="allowlist" by restoring allowFrom from pairing store on repair', async () => {
+    const result = await withTempHome(async (home) => {
+      const configDir = path.join(home, ".remoteclaw");
+      const credentialsDir = path.join(configDir, "credentials");
+      await fs.mkdir(credentialsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "remoteclaw.json"),
+        JSON.stringify(
+          {
+            channels: {
+              telegram: {
+                botToken: "fake-token",
+                dmPolicy: "allowlist",
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(credentialsDir, "telegram-allowFrom.json"),
+        JSON.stringify({ version: 1, allowFrom: ["12345"] }, null, 2),
+        "utf-8",
+      );
+      return await loadAndMaybeMigrateDoctorConfig({
+        options: { nonInteractive: true, repair: true },
+        confirm: async () => false,
+      });
+    });
+
+    const cfg = result.cfg as {
+      channels: {
+        telegram: {
+          dmPolicy: string;
+          allowFrom: string[];
+        };
+      };
+    };
+    expect(cfg.channels.telegram.dmPolicy).toBe("allowlist");
+    expect(cfg.channels.telegram.allowFrom).toEqual(["12345"]);
+  });
+
   it("migrates legacy toolsBySender keys to typed id entries on repair", async () => {
     const result = await runDoctorConfigWithInput({
       repair: true,

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -18,6 +18,7 @@ import {
 import { collectProviderDangerousNameMatchingScopes } from "../config/dangerous-name-matching.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { parseToolsBySenderTypedKey } from "../config/types.tools.js";
+import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 import {
   isDiscordMutableAllowEntry,
@@ -1054,10 +1055,167 @@ function maybeRepairOpenPolicyAllowFrom(cfg: RemoteClawConfig): {
   return { config: next, changes };
 }
 
+function hasAllowFromEntries(list?: Array<string | number>) {
+  return Array.isArray(list) && list.map((v) => String(v).trim()).filter(Boolean).length > 0;
+}
+
+async function maybeRepairAllowlistPolicyAllowFrom(cfg: RemoteClawConfig): Promise<{
+  config: RemoteClawConfig;
+  changes: string[];
+}> {
+  const channels = cfg.channels;
+  if (!channels || typeof channels !== "object") {
+    return { config: cfg, changes: [] };
+  }
+
+  type AllowFromMode = "topOnly" | "topOrNested" | "nestedOnly";
+
+  const resolveAllowFromMode = (channelName: string): AllowFromMode => {
+    if (channelName === "googlechat") {
+      return "nestedOnly";
+    }
+    if (channelName === "discord" || channelName === "slack") {
+      return "topOrNested";
+    }
+    return "topOnly";
+  };
+
+  const next = structuredClone(cfg);
+  const changes: string[] = [];
+
+  const applyRecoveredAllowFrom = (params: {
+    account: Record<string, unknown>;
+    allowFrom: string[];
+    mode: AllowFromMode;
+    prefix: string;
+  }) => {
+    const count = params.allowFrom.length;
+    const noun = count === 1 ? "entry" : "entries";
+
+    if (params.mode === "nestedOnly") {
+      const dmEntry = params.account.dm;
+      const dm =
+        dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
+          ? (dmEntry as Record<string, unknown>)
+          : {};
+      dm.allowFrom = params.allowFrom;
+      params.account.dm = dm;
+      changes.push(
+        `- ${params.prefix}.dm.allowFrom: restored ${count} sender ${noun} from pairing store (dmPolicy="allowlist").`,
+      );
+      return;
+    }
+
+    if (params.mode === "topOrNested") {
+      const dmEntry = params.account.dm;
+      const dm =
+        dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
+          ? (dmEntry as Record<string, unknown>)
+          : undefined;
+      const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
+      if (dm && !Array.isArray(params.account.allowFrom) && Array.isArray(nestedAllowFrom)) {
+        dm.allowFrom = params.allowFrom;
+        changes.push(
+          `- ${params.prefix}.dm.allowFrom: restored ${count} sender ${noun} from pairing store (dmPolicy="allowlist").`,
+        );
+        return;
+      }
+    }
+
+    params.account.allowFrom = params.allowFrom;
+    changes.push(
+      `- ${params.prefix}.allowFrom: restored ${count} sender ${noun} from pairing store (dmPolicy="allowlist").`,
+    );
+  };
+
+  const recoverAllowFromForAccount = async (params: {
+    channelName: string;
+    account: Record<string, unknown>;
+    accountId?: string;
+    prefix: string;
+  }) => {
+    const dmEntry = params.account.dm;
+    const dm =
+      dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
+        ? (dmEntry as Record<string, unknown>)
+        : undefined;
+    const dmPolicy =
+      (params.account.dmPolicy as string | undefined) ?? (dm?.policy as string | undefined);
+    if (dmPolicy !== "allowlist") {
+      return;
+    }
+
+    const topAllowFrom = params.account.allowFrom as Array<string | number> | undefined;
+    const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
+    if (hasAllowFromEntries(topAllowFrom) || hasAllowFromEntries(nestedAllowFrom)) {
+      return;
+    }
+
+    const normalizedChannelId = (normalizeChatChannelId(params.channelName) ?? params.channelName)
+      .trim()
+      .toLowerCase();
+    if (!normalizedChannelId) {
+      return;
+    }
+    const normalizedAccountId = normalizeAccountId(params.accountId) || DEFAULT_ACCOUNT_ID;
+    const fromStore = await readChannelAllowFromStore(
+      normalizedChannelId,
+      process.env,
+      normalizedAccountId,
+    ).catch(() => []);
+    const recovered = Array.from(new Set(fromStore.map((entry) => String(entry).trim()))).filter(
+      Boolean,
+    );
+    if (recovered.length === 0) {
+      return;
+    }
+
+    applyRecoveredAllowFrom({
+      account: params.account,
+      allowFrom: recovered,
+      mode: resolveAllowFromMode(params.channelName),
+      prefix: params.prefix,
+    });
+  };
+
+  const nextChannels = next.channels as Record<string, Record<string, unknown>>;
+  for (const [channelName, channelConfig] of Object.entries(nextChannels)) {
+    if (!channelConfig || typeof channelConfig !== "object") {
+      continue;
+    }
+    await recoverAllowFromForAccount({
+      channelName,
+      account: channelConfig,
+      prefix: `channels.${channelName}`,
+    });
+
+    const accounts = channelConfig.accounts as Record<string, Record<string, unknown>> | undefined;
+    if (!accounts || typeof accounts !== "object") {
+      continue;
+    }
+    for (const [accountId, accountConfig] of Object.entries(accounts)) {
+      if (!accountConfig || typeof accountConfig !== "object") {
+        continue;
+      }
+      await recoverAllowFromForAccount({
+        channelName,
+        account: accountConfig,
+        accountId,
+        prefix: `channels.${channelName}.accounts.${accountId}`,
+      });
+    }
+  }
+
+  if (changes.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+  return { config: next, changes };
+}
+
 /**
  * Scan all channel configs for dmPolicy="allowlist" without any allowFrom entries.
- * This configuration causes all DMs to be silently dropped because no sender can
- * match the empty allowlist. Common after upgrades that remove external allowlist
+ * This configuration blocks all DMs because no sender can match the empty
+ * allowlist. Common after upgrades that remove external allowlist
  * file support.
  */
 function detectEmptyAllowlistPolicy(cfg: RemoteClawConfig): string[] {
@@ -1067,9 +1225,6 @@ function detectEmptyAllowlistPolicy(cfg: RemoteClawConfig): string[] {
   }
 
   const warnings: string[] = [];
-
-  const hasEntries = (list?: Array<string | number>) =>
-    Array.isArray(list) && list.map((v) => String(v).trim()).filter(Boolean).length > 0;
 
   const checkAccount = (
     account: Record<string, unknown>,
@@ -1104,12 +1259,12 @@ function detectEmptyAllowlistPolicy(cfg: RemoteClawConfig): string[] {
     const parentNestedAllowFrom = parentDm?.allowFrom as Array<string | number> | undefined;
     const effectiveAllowFrom = topAllowFrom ?? nestedAllowFrom ?? parentNestedAllowFrom;
 
-    if (hasEntries(effectiveAllowFrom)) {
+    if (hasAllowFromEntries(effectiveAllowFrom)) {
       return;
     }
 
     warnings.push(
-      `- ${prefix}.dmPolicy is "allowlist" but allowFrom is empty — all DMs will be silently dropped. Add sender IDs to ${prefix}.allowFrom or change dmPolicy to "pairing".`,
+      `- ${prefix}.dmPolicy is "allowlist" but allowFrom is empty — all DMs will be blocked. Add sender IDs to ${prefix}.allowFrom, or run "${formatCliCommand("remoteclaw doctor --fix")}" to auto-migrate from pairing store when entries exist.`,
     );
   };
 
@@ -1411,6 +1566,14 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       candidate = allowFromRepair.config;
       pendingChanges = true;
       cfg = allowFromRepair.config;
+    }
+
+    const allowlistRepair = await maybeRepairAllowlistPolicyAllowFrom(candidate);
+    if (allowlistRepair.changes.length > 0) {
+      note(allowlistRepair.changes.join("\n"), "Doctor changes");
+      candidate = allowlistRepair.config;
+      pendingChanges = true;
+      cfg = allowlistRepair.config;
     }
 
     const emptyAllowlistWarnings = detectEmptyAllowlistPolicy(candidate);

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -293,6 +293,27 @@ export const TelegramConfigSchema = TelegramAccountSchemaBase.extend({
     if (account.enabled === false) {
       continue;
     }
+    const effectiveDmPolicy = account.dmPolicy ?? value.dmPolicy;
+    const effectiveAllowFrom = Array.isArray(account.allowFrom)
+      ? account.allowFrom
+      : value.allowFrom;
+    requireOpenAllowFrom({
+      policy: effectiveDmPolicy,
+      allowFrom: effectiveAllowFrom,
+      ctx,
+      path: ["accounts", accountId, "allowFrom"],
+      message:
+        'channels.telegram.accounts.*.dmPolicy="open" requires channels.telegram.allowFrom or channels.telegram.accounts.*.allowFrom to include "*"',
+    });
+    requireAllowlistAllowFrom({
+      policy: effectiveDmPolicy,
+      allowFrom: effectiveAllowFrom,
+      ctx,
+      path: ["accounts", accountId, "allowFrom"],
+      message:
+        'channels.telegram.accounts.*.dmPolicy="allowlist" requires channels.telegram.allowFrom or channels.telegram.accounts.*.allowFrom to contain at least one sender ID',
+    });
+
     const accountWebhookUrl =
       typeof account.webhookUrl === "string" ? account.webhookUrl.trim() : "";
     if (!accountWebhookUrl) {


### PR DESCRIPTION
## Cherry-pick

- **Upstream commit**: openclaw/openclaw@1d43202930255eefc95527fdfdaaa3d0c867d054
- **Author**: Peter Steinberger <steipete@gmail.com>
- **Tier**: AUTO-PICK
- **Issue**: #659
- **Depends on**: #1222

## Summary

Repairs Telegram allowlist DM migrations. Adds `maybeRepairAllowlistPolicyAllowFrom` to doctor flow that auto-migrates entries from pairing-store files into inline `allowFrom` arrays. Updates Telegram docs with pairing-store migration guidance. Contributed by @widingmarcus-cyber (#27936).

## Conflict Resolution

- `CHANGELOG.md`: Kept ours (CHANGELOG entries skipped per adaptation notes).
- `docs/channels/telegram.mdx`: Fork had rebranded `openclaw` → `remoteclaw` in doctor command references. Upstream added new pairing-store migration guidance. Took upstream's additions with fork branding.
- `src/commands/doctor-config-flow.ts`: Fork had deleted exec safe bin imports (gutted). Upstream added `readChannelAllowFromStore` import alongside them. Added only the new import. Rebranded `OpenClawConfig` → `RemoteClawConfig` and `openclaw doctor` → `remoteclaw doctor` in new code.
- `src/commands/doctor-config-flow.test.ts`: Rebranded `.openclaw` → `.remoteclaw` and `openclaw.json` → `remoteclaw.json` in new test fixtures.

## Verification

- No references to gutted layers in src/
- All OpenClaw references rebranded to RemoteClaw in changed files

Cherry-picked-from: 1d43202930255eefc95527fdfdaaa3d0c867d054