### PR TITLE
Cherry-pick 0cfd448ba: fix(delivery-queue): change break to continue to prevent head-of-line blocking

### DIFF
--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -253,11 +253,11 @@ export async function recoverPendingDeliveries(opts: {
     const backoff = computeBackoffMs(entry.retryCount + 1);
     if (backoff > 0) {
       if (now + backoff >= deadline) {
-        const deferred = pending.length - recovered - failed - skipped;
-        opts.log.warn(
-          `Recovery time budget exceeded — ${deferred} entries deferred to next restart`,
+        opts.log.info(
+          `Backoff ${backoff}ms exceeds budget for ${entry.id} — skipping to next entry`,
         );
-        break;
+        skipped += 1;
+        continue;
       }
       opts.log.info(`Waiting ${backoff}ms before retrying delivery ${entry.id}`);
       await delayFn(backoff);

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -394,12 +394,12 @@ describe("delivery-queue", () => {
 
       expect(deliver).not.toHaveBeenCalled();
       expect(delay).not.toHaveBeenCalled();
-      expect(result).toEqual({ recovered: 0, failed: 0, skipped: 0 });
+      expect(result).toEqual({ recovered: 0, failed: 0, skipped: 1 });
 
       const remaining = await loadPendingDeliveries(tmpDir);
       expect(remaining).toHaveLength(1);
 
-      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("deferred to next restart"));
+      expect(log.info).toHaveBeenCalledWith(expect.stringContaining("Backoff"));
     });
 
     it("returns zeros when queue is empty", async () => {


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: openclaw/openclaw@0cfd448ba
- **Author**: Xu Zimo <xuzimojimmy@163.com>
- **Tier**: AUTO-PICK

## Summary

Fixes head-of-line blocking in the delivery queue. A single failed delivery was blocking all subsequent deliveries because `break` was used instead of `continue` in the retry loop.

Part of #660.