### PR TITLE
Cherry-pick cceefe833: fix: harden delivery recovery backoff eligibility and tests

### DIFF
--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -47,6 +47,7 @@ export interface QueuedDelivery extends QueuedDeliveryPayload {
   id: string;
   enqueuedAt: number;
   retryCount: number;
+  lastAttemptAt?: number;
   lastError?: string;
 }
 
@@ -122,6 +123,7 @@ export async function failDelivery(id: string, error: string, stateDir?: string)
   const raw = await fs.promises.readFile(filePath, "utf-8");
   const entry: QueuedDelivery = JSON.parse(raw);
   entry.retryCount += 1;
+  entry.lastAttemptAt = Date.now();
   entry.lastError = error;
   const tmp = `${filePath}.${process.pid}.tmp`;
   await fs.promises.writeFile(tmp, JSON.stringify(entry, null, 2), {
@@ -208,8 +210,6 @@ export async function recoverPendingDeliveries(opts: {
   log: RecoveryLogger;
   cfg: RemoteClawConfig;
   stateDir?: string;
-  /** Override for testing — resolves instead of using real setTimeout. */
-  delay?: (ms: number) => Promise<void>;
   /** Maximum wall-clock time for recovery in ms. Remaining entries are deferred to next restart. Default: 60 000. */
   maxRecoveryMs?: number;
 }): Promise<{ recovered: number; failed: number; skipped: number }> {
@@ -223,12 +223,12 @@ export async function recoverPendingDeliveries(opts: {
 
   opts.log.info(`Found ${pending.length} pending delivery entries — starting recovery`);
 
-  const delayFn = opts.delay ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
   const deadline = Date.now() + (opts.maxRecoveryMs ?? 60_000);
 
   let recovered = 0;
   let failed = 0;
   let skipped = 0;
+  let deferred = 0;
 
   for (const entry of pending) {
     const now = Date.now();
@@ -252,15 +252,18 @@ export async function recoverPendingDeliveries(opts: {
 
     const backoff = computeBackoffMs(entry.retryCount + 1);
     if (backoff > 0) {
-      if (now + backoff >= deadline) {
-        opts.log.info(
-          `Backoff ${backoff}ms exceeds budget for ${entry.id} — skipping to next entry`,
-        );
-        skipped += 1;
-        continue;
+      const firstReplayAfterCrash = entry.retryCount === 0 && entry.lastAttemptAt === undefined;
+      if (!firstReplayAfterCrash) {
+        const baseAttemptAt = entry.lastAttemptAt ?? entry.enqueuedAt;
+        const nextEligibleAt = baseAttemptAt + backoff;
+        if (now < nextEligibleAt) {
+          deferred += 1;
+          opts.log.info(
+            `Delivery ${entry.id} not ready for retry yet — backoff ${nextEligibleAt - now}ms remaining`,
+          );
+          continue;
+        }
       }
-      opts.log.info(`Waiting ${backoff}ms before retrying delivery ${entry.id}`);
-      await delayFn(backoff);
     }
 
     try {
@@ -304,7 +307,7 @@ export async function recoverPendingDeliveries(opts: {
   }
 
   opts.log.info(
-    `Delivery recovery complete: ${recovered} recovered, ${failed} failed, ${skipped} skipped (max retries)`,
+    `Delivery recovery complete: ${recovered} recovered, ${failed} failed, ${skipped} skipped (max retries), ${deferred} deferred (backoff)`,
   );
   return { recovered, failed, skipped };
 }


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: openclaw/openclaw@cceefe833
- **Author**: Peter Steinberger <steipete@gmail.com>
- **Original contributor**: @Jimmy-xuzimo
- **Tier**: AUTO-PICK

## Summary

Hardens delivery recovery backoff eligibility logic and adds tests. CHANGELOG entry skipped (fork maintains separate changelog).

Depends on #1224.

Part of #660.