### PR TITLE
Cherry-pick eb6fa0dac: fix(googlechat): keep startAccount pending until abort to prevent restart loop

### DIFF
--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -563,14 +563,20 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
         webhookUrl: account.config.webhookUrl,
         statusSink: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
       });
-      return () => {
-        unregister?.();
-        ctx.setStatus({
-          accountId: account.accountId,
-          running: false,
-          lastStopAt: Date.now(),
-        });
-      };
+      // Keep the promise pending until abort (webhook mode is passive).
+      await new Promise<void>((resolve) => {
+        if (ctx.abortSignal.aborted) {
+          resolve();
+          return;
+        }
+        ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      unregister?.();
+      ctx.setStatus({
+        accountId: account.accountId,
+        running: false,
+        lastStopAt: Date.now(),
+      });
     },
   },
 };


### PR DESCRIPTION
## Upstream Cherry-Pick

- **Commit**: [`eb6fa0dac`](https://github.com/openclaw/openclaw/commit/eb6fa0dac)
- **Author**: Chang Shu-Huai (@junsuwhy)
- **Tier**: AUTO-PICK
- **Issue**: #661

Fixes restart loop in GoogleChat adapter where `startAccount` resolved before abort completed, allowing the account to restart prematurely.

Cherry-picked-from: eb6fa0dac