### PR TITLE
Cherry-pick 31c0b04c4: fix(nextcloud-talk): keep startAccount pending until abort

### DIFF
--- a/extensions/nextcloud-talk/src/channel.startup.test.ts
+++ b/extensions/nextcloud-talk/src/channel.startup.test.ts
@@ -1,0 +1,115 @@
+import type {
+  ChannelAccountSnapshot,
+  ChannelGatewayContext,
+  OpenClawConfig,
+} from "openclaw/plugin-sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeEnv } from "../../test-utils/runtime-env.js";
+import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
+
+const hoisted = vi.hoisted(() => ({
+  monitorNextcloudTalkProvider: vi.fn(),
+}));
+
+vi.mock("./monitor.js", async () => {
+  const actual = await vi.importActual<typeof import("./monitor.js")>("./monitor.js");
+  return {
+    ...actual,
+    monitorNextcloudTalkProvider: hoisted.monitorNextcloudTalkProvider,
+  };
+});
+
+import { nextcloudTalkPlugin } from "./channel.js";
+
+function createStartAccountCtx(params: {
+  account: ResolvedNextcloudTalkAccount;
+  abortSignal: AbortSignal;
+}): ChannelGatewayContext<ResolvedNextcloudTalkAccount> {
+  const snapshot: ChannelAccountSnapshot = {
+    accountId: params.account.accountId,
+    configured: true,
+    enabled: true,
+    running: false,
+  };
+  return {
+    accountId: params.account.accountId,
+    account: params.account,
+    cfg: {} as OpenClawConfig,
+    runtime: createRuntimeEnv(),
+    abortSignal: params.abortSignal,
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    getStatus: () => snapshot,
+    setStatus: (next) => {
+      Object.assign(snapshot, next);
+    },
+  };
+}
+
+function buildAccount(): ResolvedNextcloudTalkAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    baseUrl: "https://nextcloud.example.com",
+    secret: "secret",
+    secretSource: "config",
+    config: {
+      baseUrl: "https://nextcloud.example.com",
+      botSecret: "secret",
+      webhookPath: "/nextcloud-talk-webhook",
+      webhookPort: 8788,
+    },
+  };
+}
+
+describe("nextcloudTalkPlugin gateway.startAccount", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps startAccount pending until abort, then stops the monitor", async () => {
+    const stop = vi.fn();
+    hoisted.monitorNextcloudTalkProvider.mockResolvedValue({ stop });
+    const abort = new AbortController();
+
+    const task = nextcloudTalkPlugin.gateway!.startAccount!(
+      createStartAccountCtx({
+        account: buildAccount(),
+        abortSignal: abort.signal,
+      }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    let settled = false;
+    void task.then(() => {
+      settled = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(settled).toBe(false);
+    expect(hoisted.monitorNextcloudTalkProvider).toHaveBeenCalledOnce();
+    expect(stop).not.toHaveBeenCalled();
+
+    abort.abort();
+    await task;
+
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it("stops immediately when startAccount receives an already-aborted signal", async () => {
+    const stop = vi.fn();
+    hoisted.monitorNextcloudTalkProvider.mockResolvedValue({ stop });
+    const abort = new AbortController();
+    abort.abort();
+
+    await nextcloudTalkPlugin.gateway!.startAccount!(
+      createStartAccountCtx({
+        account: buildAccount(),
+        abortSignal: abort.signal,
+      }),
+    );
+
+    expect(hoisted.monitorNextcloudTalkProvider).toHaveBeenCalledOnce();
+    expect(stop).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/nextcloud-talk/src/channel.startup.test.ts
+++ b/extensions/nextcloud-talk/src/channel.startup.test.ts
@@ -1,8 +1,8 @@
 import type {
   ChannelAccountSnapshot,
   ChannelGatewayContext,
-  OpenClawConfig,
-} from "openclaw/plugin-sdk";
+  RemoteClawConfig,
+} from "remoteclaw/plugin-sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createRuntimeEnv } from "../../test-utils/runtime-env.js";
 import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
@@ -34,12 +34,12 @@ function createStartAccountCtx(params: {
   return {
     accountId: params.account.accountId,
     account: params.account,
-    cfg: {} as OpenClawConfig,
+    cfg: {} as RemoteClawConfig,
     runtime: createRuntimeEnv(),
     abortSignal: params.abortSignal,
     log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     getStatus: () => snapshot,
-    setStatus: (next) => {
+    setStatus: (next: Partial<ChannelAccountSnapshot>) => {
       Object.assign(snapshot, next);
     },
   };

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -12,6 +12,7 @@ import {
   type RemoteClawConfig,
   type ChannelSetupInput,
 } from "remoteclaw/plugin-sdk";
+import { waitForAbortSignal } from "../../../src/infra/abort-signal.js";
 import {
   listNextcloudTalkAccountIds,
   resolveDefaultNextcloudTalkAccountId,
@@ -332,7 +333,9 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> = 
         statusSink: (patch) => ctx.setStatus({ accountId: ctx.accountId, ...patch }),
       });
 
-      return { stop };
+      // Keep webhook channels pending for the account lifecycle.
+      await waitForAbortSignal(ctx.abortSignal);
+      stop();
     },
     logoutAccount: async ({ accountId, cfg }) => {
       const nextCfg = { ...cfg } as RemoteClawConfig;


### PR DESCRIPTION
## Upstream Cherry-Pick

- **Commit**: [`31c0b04c4`](https://github.com/openclaw/openclaw/commit/31c0b04c4)
- **Author**: Peter Steinberger (@steipete)
- **Tier**: AUTO-PICK
- **Issue**: #661
- **Depends on**: #1228

Fixes restart loop in Nextcloud-Talk adapter where `startAccount` resolved before abort completed. Adds `waitForAbortSignal` to keep the promise pending until abort. Includes lifecycle regression test.

Conflicts resolved: CHANGELOG (kept ours), import path (kept `remoteclaw/plugin-sdk`, added `waitForAbortSignal` import). Test file rebranded (`openclaw/plugin-sdk` → `remoteclaw/plugin-sdk`, `OpenClawConfig` → `RemoteClawConfig`).

Cherry-picked-from: 31c0b04c4