### PR TITLE
Cherry-pick c53b11dcc: test: fix pairing/daemon assertion drift

### DIFF
--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -119,9 +119,16 @@ describe("gatherDaemonStatus", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
 
   beforeEach(() => {
-    envSnapshot = captureEnv(["OPENCLAW_STATE_DIR", "OPENCLAW_CONFIG_PATH"]);
+    envSnapshot = captureEnv([
+      "OPENCLAW_STATE_DIR",
+      "OPENCLAW_CONFIG_PATH",
+      "OPENCLAW_GATEWAY_TOKEN",
+      "OPENCLAW_GATEWAY_PASSWORD",
+    ]);
     process.env.OPENCLAW_STATE_DIR = "/tmp/openclaw-cli";
     process.env.OPENCLAW_CONFIG_PATH = "/tmp/openclaw-cli/openclaw.json";
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_PASSWORD;
     callGatewayStatusProbe.mockClear();
     loadGatewayTlsRuntime.mockClear();
   });


### PR DESCRIPTION
## Upstream Cherry-Pick

- **Commit**: [`c53b11dcc`](https://github.com/openclaw/openclaw/commit/c53b11dcc)
- **Author**: Peter Steinberger (@steipete)
- **Tier**: AUTO-PICK
- **Issue**: #661
- **Depends on**: #1229

Fixes test assertion drift across feishu, msteams, nextcloud-talk, and daemon status tests. Conflict in msteams authz test resolved: convergent change (both ours and theirs updated to same object form assertion).

Cherry-picked-from: c53b11dcc