### PR TITLE
Cherry-pick ca2ae342d: fix(cli): accept node24 executable names in argv reparse

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -205,6 +205,18 @@ describe("argv helpers", () => {
         expected: ["/usr/bin/node-22.2.0", "remoteclaw", "status"],
       },
       {
+        rawArgs: ["node24", "remoteclaw", "status"],
+        expected: ["node24", "remoteclaw", "status"],
+      },
+      {
+        rawArgs: ["/usr/bin/node24", "remoteclaw", "status"],
+        expected: ["/usr/bin/node24", "remoteclaw", "status"],
+      },
+      {
+        rawArgs: ["node24.exe", "remoteclaw", "status"],
+        expected: ["node24.exe", "remoteclaw", "status"],
+      },
+      {
         rawArgs: ["nodejs", "remoteclaw", "status"],
         expected: ["nodejs", "remoteclaw", "status"],
       },

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -172,7 +172,7 @@ export function buildParseArgv(params: {
   return ["node", programName || "remoteclaw", ...normalizedArgv];
 }
 
-const nodeExecutablePattern = /^node-\d+(?:\.\d+)*(?:\.exe)?$/;
+const nodeExecutablePattern = /^node(?:-\d+|\d+)(?:\.\d+)*(?:\.exe)?$/;
 
 function isNodeExecutable(executable: string): boolean {
   return (


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`ca2ae342d`](https://github.com/openclaw/openclaw/commit/ca2ae342d)
- **Author**: Peter Steinberger <steipete@gmail.com>
- **Tier**: AUTO-PICK

Adds support for Node.js 24 executable names (`node24`, `/usr/bin/node24`, `node24.exe`) in the argv reparse logic.

**Conflict resolution**: Test file had rebrand conflict (`openclaw` → `remoteclaw`). Resolved by taking upstream's new `node24` test cases with fork's rebranded names.

Cherry-picked for #662.