### PR TITLE
Cherry-pick 5dd264d2f: refactor(daemon): unify runtime binary detection

### DIFF
--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -1,3 +1,5 @@
+import { isBunRuntime, isNodeRuntime } from "../daemon/runtime-binary.js";
+
 const HELP_FLAGS = new Set(["-h", "--help"]);
 const VERSION_FLAGS = new Set(["-V", "--version"]);
 const ROOT_VERSION_ALIAS_FLAG = "-v";
@@ -163,29 +165,13 @@ export function buildParseArgv(params: {
       : baseArgv[0]?.endsWith("remoteclaw")
         ? baseArgv.slice(1)
         : baseArgv;
-  const executable = (normalizedArgv[0]?.split(/[/\\]/).pop() ?? "").toLowerCase();
   const looksLikeNode =
-    normalizedArgv.length >= 2 && (isNodeExecutable(executable) || isBunExecutable(executable));
+    normalizedArgv.length >= 2 &&
+    (isNodeRuntime(normalizedArgv[0] ?? "") || isBunRuntime(normalizedArgv[0] ?? ""));
   if (looksLikeNode) {
     return normalizedArgv;
   }
   return ["node", programName || "remoteclaw", ...normalizedArgv];
-}
-
-const nodeExecutablePattern = /^node(?:-\d+|\d+)(?:\.\d+)*(?:\.exe)?$/;
-
-function isNodeExecutable(executable: string): boolean {
-  return (
-    executable === "node" ||
-    executable === "node.exe" ||
-    executable === "nodejs" ||
-    executable === "nodejs.exe" ||
-    nodeExecutablePattern.test(executable)
-  );
-}
-
-function isBunExecutable(executable: string): boolean {
-  return executable === "bun" || executable === "bun.exe";
 }
 
 export function shouldMigrateStateFromPath(path: string[]): boolean {

--- a/src/daemon/runtime-binary.test.ts
+++ b/src/daemon/runtime-binary.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { isBunRuntime, isNodeRuntime } from "./runtime-binary.js";
+
+describe("isNodeRuntime", () => {
+  it("recognizes standard node binaries", () => {
+    expect(isNodeRuntime("/usr/bin/node")).toBe(true);
+    expect(isNodeRuntime("C:\\Program Files\\nodejs\\node.exe")).toBe(true);
+    expect(isNodeRuntime("/usr/bin/nodejs")).toBe(true);
+    expect(isNodeRuntime("C:\\nodejs.exe")).toBe(true);
+  });
+
+  it("recognizes versioned node binaries with and without dashes", () => {
+    expect(isNodeRuntime("/usr/bin/node24")).toBe(true);
+    expect(isNodeRuntime("/usr/bin/node-24")).toBe(true);
+    expect(isNodeRuntime("/usr/bin/node24.1")).toBe(true);
+    expect(isNodeRuntime("/usr/bin/node-24.1")).toBe(true);
+    expect(isNodeRuntime("C:\\node24.exe")).toBe(true);
+    expect(isNodeRuntime("C:\\node-24.exe")).toBe(true);
+  });
+
+  it("handles quotes and casing", () => {
+    expect(isNodeRuntime('"/usr/bin/node24"')).toBe(true);
+    expect(isNodeRuntime("'C:\\Program Files\\nodejs\\NODE.EXE'")).toBe(true);
+  });
+
+  it("rejects non-node runtimes", () => {
+    expect(isNodeRuntime("/usr/bin/bun")).toBe(false);
+    expect(isNodeRuntime("/usr/bin/node-dev")).toBe(false);
+    expect(isNodeRuntime("/usr/bin/nodeenv")).toBe(false);
+    expect(isNodeRuntime("/usr/bin/nodemon")).toBe(false);
+  });
+});
+
+describe("isBunRuntime", () => {
+  it("recognizes bun binaries", () => {
+    expect(isBunRuntime("/usr/bin/bun")).toBe(true);
+    expect(isBunRuntime("C:\\BUN.EXE")).toBe(true);
+    expect(isBunRuntime('"/opt/homebrew/bin/bun"')).toBe(true);
+  });
+
+  it("rejects non-bun runtimes", () => {
+    expect(isBunRuntime("/usr/bin/node")).toBe(false);
+    expect(isBunRuntime("/usr/bin/bunx")).toBe(false);
+  });
+});

--- a/src/daemon/runtime-binary.ts
+++ b/src/daemon/runtime-binary.ts
@@ -1,11 +1,24 @@
-import path from "node:path";
+const NODE_VERSIONED_PATTERN = /^node(?:-\d+|\d+)(?:\.\d+)*(?:\.exe)?$/;
+
+function normalizeRuntimeBasename(execPath: string): string {
+  const trimmed = execPath.trim().replace(/^["']|["']$/g, "");
+  const lastSlash = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  const basename = lastSlash === -1 ? trimmed : trimmed.slice(lastSlash + 1);
+  return basename.toLowerCase();
+}
 
 export function isNodeRuntime(execPath: string): boolean {
-  const base = path.basename(execPath).toLowerCase();
-  return base === "node" || base === "node.exe";
+  const base = normalizeRuntimeBasename(execPath);
+  return (
+    base === "node" ||
+    base === "node.exe" ||
+    base === "nodejs" ||
+    base === "nodejs.exe" ||
+    NODE_VERSIONED_PATTERN.test(base)
+  );
 }
 
 export function isBunRuntime(execPath: string): boolean {
-  const base = path.basename(execPath).toLowerCase();
+  const base = normalizeRuntimeBasename(execPath);
   return base === "bun" || base === "bun.exe";
 }


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`5dd264d2f`](https://github.com/openclaw/openclaw/commit/5dd264d2f)
- **Author**: Peter Steinberger <steipete@gmail.com>
- **Tier**: AUTO-PICK

Extracts runtime binary detection into a shared utility (`src/daemon/runtime-binary.ts`) used by both the CLI argv parser and the daemon, with dedicated tests.

Depends on #1231.

Cherry-picked for #662.