### PR TITLE
Cherry-pick d33f24c: fix NODE_EXTRA_CA_CERTS missing from LaunchAgent environment on macOS

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -329,6 +329,26 @@ describe("buildServiceEnvironment", () => {
     expect(env.http_proxy).toBe("http://proxy.local:7890");
     expect(env.all_proxy).toBe("socks5://proxy.local:1080");
   });
+
+  it("defaults NODE_EXTRA_CA_CERTS to system cert bundle on macOS", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user" },
+      port: 18789,
+    });
+    if (process.platform === "darwin") {
+      expect(env.NODE_EXTRA_CA_CERTS).toBe("/etc/ssl/cert.pem");
+    } else {
+      expect(env.NODE_EXTRA_CA_CERTS).toBeUndefined();
+    }
+  });
+
+  it("respects user-provided NODE_EXTRA_CA_CERTS over the default", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user", NODE_EXTRA_CA_CERTS: "/custom/certs/ca.pem" },
+      port: 18789,
+    });
+    expect(env.NODE_EXTRA_CA_CERTS).toBe("/custom/certs/ca.pem");
+  });
 });
 
 describe("buildNodeServiceEnvironment", () => {
@@ -364,6 +384,24 @@ describe("buildNodeServiceEnvironment", () => {
       env: { HOME: "/home/user" },
     });
     expect(env.TMPDIR).toBe(os.tmpdir());
+  });
+
+  it("defaults NODE_EXTRA_CA_CERTS to system cert bundle on macOS for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user" },
+    });
+    if (process.platform === "darwin") {
+      expect(env.NODE_EXTRA_CA_CERTS).toBe("/etc/ssl/cert.pem");
+    } else {
+      expect(env.NODE_EXTRA_CA_CERTS).toBeUndefined();
+    }
+  });
+
+  it("respects user-provided NODE_EXTRA_CA_CERTS for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user", NODE_EXTRA_CA_CERTS: "/custom/certs/ca.pem" },
+    });
+    expect(env.NODE_EXTRA_CA_CERTS).toBe("/custom/certs/ca.pem");
   });
 });
 

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -248,11 +248,17 @@ export function buildServiceEnvironment(params: {
   // Keep a usable temp directory for supervised services even when the host env omits TMPDIR.
   const tmpDir = env.TMPDIR?.trim() || os.tmpdir();
   const proxyEnv = readServiceProxyEnvironment(env);
+  // On macOS, launchd services don't inherit the shell environment, so Node's undici/fetch
+  // cannot locate the system CA bundle. Default to /etc/ssl/cert.pem so TLS verification
+  // works correctly when running as a LaunchAgent without extra user configuration.
+  const nodeCaCerts =
+    env.NODE_EXTRA_CA_CERTS ?? (process.platform === "darwin" ? "/etc/ssl/cert.pem" : undefined);
   return {
     HOME: env.HOME,
     TMPDIR: tmpDir,
     PATH: buildMinimalServicePath({ env }),
     ...proxyEnv,
+    NODE_EXTRA_CA_CERTS: nodeCaCerts,
     REMOTECLAW_PROFILE: profile,
     REMOTECLAW_STATE_DIR: stateDir,
     REMOTECLAW_CONFIG_PATH: configPath,
@@ -274,11 +280,17 @@ export function buildNodeServiceEnvironment(params: {
   const configPath = env.REMOTECLAW_CONFIG_PATH;
   const tmpDir = env.TMPDIR?.trim() || os.tmpdir();
   const proxyEnv = readServiceProxyEnvironment(env);
+  // On macOS, launchd services don't inherit the shell environment, so Node's undici/fetch
+  // cannot locate the system CA bundle. Default to /etc/ssl/cert.pem so TLS verification
+  // works correctly when running as a LaunchAgent without extra user configuration.
+  const nodeCaCerts =
+    env.NODE_EXTRA_CA_CERTS ?? (process.platform === "darwin" ? "/etc/ssl/cert.pem" : undefined);
   return {
     HOME: env.HOME,
     TMPDIR: tmpDir,
     PATH: buildMinimalServicePath({ env }),
     ...proxyEnv,
+    NODE_EXTRA_CA_CERTS: nodeCaCerts,
     REMOTECLAW_STATE_DIR: stateDir,
     REMOTECLAW_CONFIG_PATH: configPath,
     REMOTECLAW_LAUNCHD_LABEL: resolveNodeLaunchAgentLabel(),


### PR DESCRIPTION
Cherry-pick of upstream [`d33f24c4e`](https://github.com/openclaw/openclaw/commit/d33f24c4e9) by @Clawborn.

**Tier:** AUTO-PICK

On macOS, launchd services don't inherit the shell environment, so Node's undici/fetch cannot locate the system CA bundle. This fix defaults `NODE_EXTRA_CA_CERTS` to `/etc/ssl/cert.pem` when running as a LaunchAgent without extra user configuration, for both gateway and node services.

**Conflict resolution:** Rebrand conflict in `service-env.ts` — upstream's semantic change (`NODE_EXTRA_CA_CERTS: nodeCaCerts`) applied with fork's `REMOTECLAW_` env var names. Also fixed a missing closing brace in the test file (auto-merge artifact; will be separately fixed upstream in 6b59c87).

Depends on #1233

Cherry-picked for #662