### PR TITLE
Cherry-pick 9d52dcf: fix: stabilize launchd CA env tests

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -334,12 +334,18 @@ describe("buildServiceEnvironment", () => {
     const env = buildServiceEnvironment({
       env: { HOME: "/home/user" },
       port: 18789,
+      platform: "darwin",
     });
-    if (process.platform === "darwin") {
-      expect(env.NODE_EXTRA_CA_CERTS).toBe("/etc/ssl/cert.pem");
-    } else {
-      expect(env.NODE_EXTRA_CA_CERTS).toBeUndefined();
-    }
+    expect(env.NODE_EXTRA_CA_CERTS).toBe("/etc/ssl/cert.pem");
+  });
+
+  it("does not default NODE_EXTRA_CA_CERTS on non-macOS", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user" },
+      port: 18789,
+      platform: "linux",
+    });
+    expect(env.NODE_EXTRA_CA_CERTS).toBeUndefined();
   });
 
   it("respects user-provided NODE_EXTRA_CA_CERTS over the default", () => {
@@ -389,12 +395,17 @@ describe("buildNodeServiceEnvironment", () => {
   it("defaults NODE_EXTRA_CA_CERTS to system cert bundle on macOS for node services", () => {
     const env = buildNodeServiceEnvironment({
       env: { HOME: "/home/user" },
+      platform: "darwin",
     });
-    if (process.platform === "darwin") {
-      expect(env.NODE_EXTRA_CA_CERTS).toBe("/etc/ssl/cert.pem");
-    } else {
-      expect(env.NODE_EXTRA_CA_CERTS).toBeUndefined();
-    }
+    expect(env.NODE_EXTRA_CA_CERTS).toBe("/etc/ssl/cert.pem");
+  });
+
+  it("does not default NODE_EXTRA_CA_CERTS on non-macOS for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user" },
+      platform: "linux",
+    });
+    expect(env.NODE_EXTRA_CA_CERTS).toBeUndefined();
   });
 
   it("respects user-provided NODE_EXTRA_CA_CERTS for node services", () => {

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -236,12 +236,13 @@ export function buildServiceEnvironment(params: {
   port: number;
   token?: string;
   launchdLabel?: string;
+  platform?: NodeJS.Platform;
 }): Record<string, string | undefined> {
   const { env, port, token, launchdLabel } = params;
+  const platform = params.platform ?? process.platform;
   const profile = env.REMOTECLAW_PROFILE;
   const resolvedLaunchdLabel =
-    launchdLabel ||
-    (process.platform === "darwin" ? resolveGatewayLaunchAgentLabel(profile) : undefined);
+    launchdLabel || (platform === "darwin" ? resolveGatewayLaunchAgentLabel(profile) : undefined);
   const systemdUnit = `${resolveGatewaySystemdServiceName(profile)}.service`;
   const stateDir = env.REMOTECLAW_STATE_DIR;
   const configPath = env.REMOTECLAW_CONFIG_PATH;
@@ -252,7 +253,7 @@ export function buildServiceEnvironment(params: {
   // cannot locate the system CA bundle. Default to /etc/ssl/cert.pem so TLS verification
   // works correctly when running as a LaunchAgent without extra user configuration.
   const nodeCaCerts =
-    env.NODE_EXTRA_CA_CERTS ?? (process.platform === "darwin" ? "/etc/ssl/cert.pem" : undefined);
+    env.NODE_EXTRA_CA_CERTS ?? (platform === "darwin" ? "/etc/ssl/cert.pem" : undefined);
   return {
     HOME: env.HOME,
     TMPDIR: tmpDir,
@@ -274,8 +275,10 @@ export function buildServiceEnvironment(params: {
 
 export function buildNodeServiceEnvironment(params: {
   env: Record<string, string | undefined>;
+  platform?: NodeJS.Platform;
 }): Record<string, string | undefined> {
   const { env } = params;
+  const platform = params.platform ?? process.platform;
   const stateDir = env.REMOTECLAW_STATE_DIR;
   const configPath = env.REMOTECLAW_CONFIG_PATH;
   const tmpDir = env.TMPDIR?.trim() || os.tmpdir();
@@ -284,7 +287,7 @@ export function buildNodeServiceEnvironment(params: {
   // cannot locate the system CA bundle. Default to /etc/ssl/cert.pem so TLS verification
   // works correctly when running as a LaunchAgent without extra user configuration.
   const nodeCaCerts =
-    env.NODE_EXTRA_CA_CERTS ?? (process.platform === "darwin" ? "/etc/ssl/cert.pem" : undefined);
+    env.NODE_EXTRA_CA_CERTS ?? (platform === "darwin" ? "/etc/ssl/cert.pem" : undefined);
   return {
     HOME: env.HOME,
     TMPDIR: tmpDir,


### PR DESCRIPTION
Cherry-pick of upstream [`9d52dcf1f`](https://github.com/openclaw/openclaw/commit/9d52dcf1f4) by @Lukavyi.

**Tier:** AUTO-PICK

Stabilizes launchd CA env tests by adding an injectable `platform` parameter to `buildServiceEnvironment` and `buildNodeServiceEnvironment`, so tests no longer depend on the host platform for `NODE_EXTRA_CA_CERTS` assertions.

**Conflict resolution:** Rebrand conflict in `service-env.ts` — upstream's semantic change (`const platform = params.platform ?? process.platform`) applied alongside fork's `REMOTECLAW_` env var names. CHANGELOG conflict resolved with ours.

Depends on #1234

Cherry-picked for #662