### PR TITLE
Cherry-pick 7aa233790: Fix npm-spec plugin installs when npm pack output is empty

### DIFF
--- a/src/infra/install-source-utils.test.ts
+++ b/src/infra/install-source-utils.test.ts
@@ -123,6 +123,8 @@ describe("resolveArchiveSourcePath", () => {
 describe("packNpmSpecToArchive", () => {
   it("packs spec and returns archive path using JSON output metadata", async () => {
     const cwd = await createFixtureDir();
+    const archivePath = path.join(cwd, "remoteclaw-plugin-1.2.3.tgz");
+    await fs.writeFile(archivePath, "", "utf-8");
     mockPackCommandResult({
       stdout: JSON.stringify([
         {
@@ -140,7 +142,7 @@ describe("packNpmSpecToArchive", () => {
 
     expect(result).toEqual({
       ok: true,
-      archivePath: path.join(cwd, "remoteclaw-plugin-1.2.3.tgz"),
+      archivePath,
       metadata: {
         name: "remoteclaw-plugin",
         version: "1.2.3",
@@ -160,6 +162,8 @@ describe("packNpmSpecToArchive", () => {
 
   it("falls back to parsing final stdout line when npm json output is unavailable", async () => {
     const cwd = await createFixtureDir();
+    const expectedArchivePath = path.join(cwd, "remoteclaw-plugin-1.2.3.tgz");
+    await fs.writeFile(expectedArchivePath, "", "utf-8");
     mockPackCommandResult({
       stdout: "npm notice created package\nremoteclaw-plugin-1.2.3.tgz\n",
     });
@@ -168,7 +172,7 @@ describe("packNpmSpecToArchive", () => {
 
     expect(result).toEqual({
       ok: true,
-      archivePath: path.join(cwd, "remoteclaw-plugin-1.2.3.tgz"),
+      archivePath: expectedArchivePath,
       metadata: {},
     });
   });
@@ -190,6 +194,56 @@ describe("packNpmSpecToArchive", () => {
     }
   });
 
+  it("falls back to archive detected in cwd when npm pack stdout is empty", async () => {
+    const cwd = await createTempDir("remoteclaw-install-source-utils-");
+    const archivePath = path.join(cwd, "remoteclaw-plugin-1.2.3.tgz");
+    await fs.writeFile(archivePath, "", "utf-8");
+    runCommandWithTimeoutMock.mockResolvedValue({
+      stdout: " \n\n",
+      stderr: "",
+      code: 0,
+      signal: null,
+      killed: false,
+    });
+
+    const result = await packNpmSpecToArchive({
+      spec: "remoteclaw-plugin@1.2.3",
+      timeoutMs: 5000,
+      cwd,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      archivePath,
+      metadata: {},
+    });
+  });
+
+  it("falls back to archive detected in cwd when stdout does not contain a tgz", async () => {
+    const cwd = await createTempDir("remoteclaw-install-source-utils-");
+    const archivePath = path.join(cwd, "remoteclaw-plugin-1.2.3.tgz");
+    await fs.writeFile(archivePath, "", "utf-8");
+    runCommandWithTimeoutMock.mockResolvedValue({
+      stdout: "npm pack completed successfully\n",
+      stderr: "",
+      code: 0,
+      signal: null,
+      killed: false,
+    });
+
+    const result = await packNpmSpecToArchive({
+      spec: "remoteclaw-plugin@1.2.3",
+      timeoutMs: 5000,
+      cwd,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      archivePath,
+      metadata: {},
+    });
+  });
+
   it("returns explicit error when npm pack produces no archive name", async () => {
     const cwd = await createFixtureDir();
     mockPackCommandResult({
@@ -206,6 +260,7 @@ describe("packNpmSpecToArchive", () => {
 
   it("parses scoped metadata from id-only json output even with npm notice prefix", async () => {
     const cwd = await createFixtureDir();
+    await fs.writeFile(path.join(cwd, "remoteclaw-plugin-demo-2.0.0.tgz"), "", "utf-8");
     mockPackCommandResult({
       stdout:
         "npm notice creating package\n" +

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -144,6 +144,42 @@ function parseNpmPackJsonOutput(
   return null;
 }
 
+function parsePackedArchiveFromStdout(stdout: string): string | undefined {
+  const lines = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index];
+    const match = line?.match(/([^\s"']+\.tgz)/);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  return undefined;
+}
+
+async function findPackedArchiveInDir(cwd: string): Promise<string | undefined> {
+  const entries = await fs.readdir(cwd, { withFileTypes: true }).catch(() => []);
+  const archives = entries.filter((entry) => entry.isFile() && entry.name.endsWith(".tgz"));
+  if (archives.length === 0) {
+    return undefined;
+  }
+  if (archives.length === 1) {
+    return archives[0]?.name;
+  }
+
+  const sortedByMtime = await Promise.all(
+    archives.map(async (entry) => ({
+      name: entry.name,
+      mtimeMs: (await fs.stat(path.join(cwd, entry.name))).mtimeMs,
+    })),
+  );
+  sortedByMtime.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return sortedByMtime[0]?.name;
+}
+
 export async function packNpmSpecToArchive(params: {
   spec: string;
   timeoutMs: number;
@@ -176,20 +212,26 @@ export async function packNpmSpecToArchive(params: {
 
   const parsedJson = parseNpmPackJsonOutput(res.stdout || "");
 
-  const packed =
-    parsedJson?.filename ??
-    (res.stdout || "")
-      .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .pop();
+  let packed = parsedJson?.filename ?? parsePackedArchiveFromStdout(res.stdout || "");
+  if (!packed) {
+    packed = await findPackedArchiveInDir(params.cwd);
+  }
   if (!packed) {
     return { ok: false, error: "npm pack produced no archive" };
   }
 
+  let archivePath = path.isAbsolute(packed) ? packed : path.join(params.cwd, packed);
+  if (!(await fileExists(archivePath))) {
+    const fallbackPacked = await findPackedArchiveInDir(params.cwd);
+    if (!fallbackPacked) {
+      return { ok: false, error: "npm pack produced no archive" };
+    }
+    archivePath = path.join(params.cwd, fallbackPacked);
+  }
+
   return {
     ok: true,
-    archivePath: path.join(params.cwd, packed),
+    archivePath,
     metadata: parsedJson?.metadata ?? {},
   };
 }


### PR DESCRIPTION
## Cherry-pick

- **Upstream commit**: [`7aa233790`](https://github.com/openclaw/openclaw/commit/7aa233790)
- **Author**: [graysurf](https://github.com/graysurf)
- **Tier**: AUTO-PICK
- **Source PR**: openclaw/openclaw#21039

## Summary

Fixes npm-spec plugin installs when `npm pack` output is empty or doesn't contain a `.tgz` filename. Adds fallback logic to detect the packed archive by scanning the working directory.

- Extracts `parsePackedArchiveFromStdout` and `findPackedArchiveInDir` helpers
- Falls back to directory scan when stdout is empty or lacks a tgz reference
- Verifies archive file existence before returning path
- Updates test helper to write fixture archive during mock pack

**Conflict resolution**: Test file had rebrand conflicts (openclaw→remoteclaw fixture filenames). Resolved by applying upstream's variable-style assertions with rebranded fixture names.

Part of #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)