### PR TITLE
Cherry-pick efdba59e4: fix(plugins): clear error when npm package not found

### DIFF
--- a/src/infra/install-source-utils.test.ts
+++ b/src/infra/install-source-utils.test.ts
@@ -244,6 +244,25 @@ describe("packNpmSpecToArchive", () => {
     });
   });
 
+  it("returns friendly error for 404 (package not on npm)", async () => {
+    const cwd = await createFixtureDir();
+    mockPackCommandResult({
+      stdout: "",
+      stderr:
+        "npm error code E404\nnpm error 404  '@remoteclaw/whatsapp@*' is not in this registry.",
+      code: 1,
+    });
+
+    const result = await runPack("@remoteclaw/whatsapp", cwd);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Package not found on npm");
+      expect(result.error).toContain("@remoteclaw/whatsapp");
+      expect(result.error).toContain("docs.remoteclaw.com/tools/plugin");
+    }
+  });
+
   it("returns explicit error when npm pack produces no archive name", async () => {
     const cwd = await createFixtureDir();
     mockPackCommandResult({

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -207,7 +207,14 @@ export async function packNpmSpecToArchive(params: {
     },
   );
   if (res.code !== 0) {
-    return { ok: false, error: `npm pack failed: ${res.stderr.trim() || res.stdout.trim()}` };
+    const raw = res.stderr.trim() || res.stdout.trim();
+    if (/E404|is not in this registry/i.test(raw)) {
+      return {
+        ok: false,
+        error: `Package not found on npm: ${params.spec}. See https://docs.remoteclaw.com/tools/plugin for installable plugins.`,
+      };
+    }
+    return { ok: false, error: `npm pack failed: ${raw}` };
   }
 
   const parsedJson = parseNpmPackJsonOutput(res.stdout || "");


### PR DESCRIPTION
## Cherry-pick

- **Upstream commit**: [`efdba59e4`](https://github.com/openclaw/openclaw/commit/efdba59e4)
- **Author**: [daleyarborough](https://github.com/daleyarborough)
- **Tier**: AUTO-PICK
- **Source PR**: openclaw/openclaw#25073

## Summary

Improves error message when `npm pack` fails with E404 (package not found). Instead of dumping raw npm error output, returns a friendly message with a link to plugin documentation.

**Rebrand applied**: `docs.openclaw.ai` → `docs.remoteclaw.com`, `@openclaw/` → `@remoteclaw/` in test fixtures.

Depends on #1237

Part of #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)