### PR TITLE
Cherry-pick d320b30b9: Docs: expand ACP first-use naming and link protocol site

### DIFF
--- a/docs/cli/acp.md
+++ b/docs/cli/acp.md
@@ -8,7 +8,7 @@ title: "acp"
 
 # acp
 
-Run the ACP (Agent Client Protocol) bridge that talks to a RemoteClaw Gateway.
+Run the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) bridge that talks to a RemoteClaw Gateway.
 
 This command speaks ACP over stdio for IDEs and forwards prompts to the Gateway
 over WebSocket. It keeps ACP sessions mapped to Gateway session keys.


### PR DESCRIPTION
## Upstream Cherry-Pick

- **Commit**: [`d320b30b9`](https://github.com/openclaw/openclaw/commit/d320b30b9)
- **Author**: [philippspiess](https://github.com/philippspiess) (Philipp Spiess)
- **Tier**: AUTO-PICK

## Changes

Expands the first use of "ACP" in the CLI docs to include a hyperlink to the Agent Client Protocol site.

Conflict resolved: upstream's link addition merged with fork's RemoteClaw rebrand. Deleted `docs/tools/acp-agents.md` (already removed in fork).

Depends on #1239

Part of #665

🤖 Generated with [Claude Code](https://claude.ai/code)