### PR TITLE
Cherry-pick 035a2dbb4: docs: consolidate grammy links to telegram

### DIFF
--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -43,5 +43,4 @@ Text is supported everywhere; media and reactions vary by channel.
   stores more state on disk.
 - Group behavior varies by channel; see [Groups](/channels/groups).
 - DM pairing and allowlists are enforced for safety; see [Security](/gateway/security).
-- Telegram internals: [grammY notes](/channels/grammy).
 - Troubleshooting: [Channel troubleshooting](/channels/troubleshooting).

--- a/docs/start/hubs.md
+++ b/docs/start/hubs.md
@@ -66,7 +66,6 @@ Use these hubs to discover every page, including deep dives and reference docs t
 - [Chat channels hub](/channels)
 - [WhatsApp](/channels/whatsapp)
 - [Telegram](/channels/telegram)
-- [Telegram (grammY notes)](/channels/grammy)
 - [Slack](/channels/slack)
 - [Discord](/channels/discord)
 - [Mattermost](/channels/mattermost) (plugin)


### PR DESCRIPTION
## Upstream Cherry-Pick

- **Commit**: [`035a2dbb4`](https://github.com/openclaw/openclaw/commit/035a2dbb4)
- **Author**: [ayaanzaidi](https://github.com/ayaanzaidi) (Ayaan Zaidi)
- **Tier**: AUTO-PICK

## Changes

Consolidates grammY library links into the Telegram channel docs page, removing duplicate references from the channels index and hubs pages.

Conflict resolved: `docs/docs.json` (deleted in fork) discarded.

Depends on #1240

Part of #665

🤖 Generated with [Claude Code](https://claude.ai/code)