### PR TITLE
Cherry-pick 35e40f113: remove Google Fonts import blocked by CSP

### DIFF
--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
-
 :root {
   /* Background - Warmer dark with depth */
   --bg: #12141a;
@@ -80,12 +78,11 @@
   --theme-switch-x: 50%;
   --theme-switch-y: 50%;
 
-  /* Typography - Space Grotesk for personality */
+  /* Typography */
   --mono:
     "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace;
-  --font-body: "Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  --font-display:
-    "Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-display: var(--font-body);
 
   /* Shadows - Richer with subtle color */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
## Cherry-pick from upstream

| Field | Value |
|-------|-------|
| **Upstream commit** | [`35e40f113`](https://github.com/openclaw/openclaw/commit/35e40f1139c2e1b6f31e832d2ffcf5f16468af70) |
| **Author** | Philipp Spiess |
| **Tier** | AUTO-PICK |

Removes Google Fonts `@import` from `ui/src/styles/base.css` that was blocked by CSP (`style-src 'self' 'unsafe-inline'`). The fonts were never actually loaded.

Clean cherry-pick, no conflicts.

Closes #666 (partially)