### PR TITLE
Cherry-pick 4b37b7b6a: serve JavaScript assets with text/javascript

### DIFF
--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -60,6 +60,13 @@ describe("mime detection", () => {
     });
     expect(mime).toBe("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
   });
+
+  it("uses extension mapping for JavaScript assets", async () => {
+    const mime = await detectMime({
+      filePath: "/tmp/a2ui.bundle.js",
+    });
+    expect(mime).toBe("text/javascript");
+  });
 });
 
 describe("extensionForMime", () => {

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -38,6 +38,7 @@ const MIME_BY_EXT: Record<string, string> = {
   ...Object.fromEntries(Object.entries(EXT_BY_MIME).map(([mime, ext]) => [ext, mime])),
   // Additional extension aliases
   ".jpeg": "image/jpeg",
+  ".js": "text/javascript",
 };
 
 const AUDIO_FILE_EXTENSIONS = new Set([


### PR DESCRIPTION
## Cherry-pick from upstream

| Field | Value |
|-------|-------|
| **Upstream commit** | [`4b37b7b6a`](https://github.com/openclaw/openclaw/commit/4b37b7b6a992930a682cf7fde3916a39d37b3b87) |
| **Author** | Ayaan Zaidi |
| **Tier** | AUTO-PICK |

Adds `.js` → `text/javascript` mapping to the media MIME type registry. Includes test coverage.

Clean cherry-pick, no conflicts.

Closes #666 (partially)