### PR TITLE
Cherry-pick b1bbf3fff: harden temp dir perms for umask 0002

### DIFF
--- a/src/infra/tmp-remoteclaw-dir.test.ts
+++ b/src/infra/tmp-remoteclaw-dir.test.ts
@@ -30,12 +30,16 @@ function resolveWithMocks(params: {
   lstatSync: NonNullable<TmpDirOptions["lstatSync"]>;
   fallbackLstatSync?: NonNullable<TmpDirOptions["lstatSync"]>;
   accessSync?: NonNullable<TmpDirOptions["accessSync"]>;
+  chmodSync?: NonNullable<TmpDirOptions["chmodSync"]>;
+  warn?: NonNullable<TmpDirOptions["warn"]>;
   uid?: number;
   tmpdirPath?: string;
 }) {
   const uid = params.uid ?? 501;
   const fallbackPath = fallbackTmp(uid);
   const accessSync = params.accessSync ?? vi.fn();
+  const chmodSync = params.chmodSync ?? vi.fn();
+  const warn = params.warn ?? vi.fn();
   const wrappedLstatSync = vi.fn((target: string) => {
     if (target === POSIX_REMOTECLAW_TMP_DIR) {
       return params.lstatSync(target);
@@ -53,10 +57,12 @@ function resolveWithMocks(params: {
   const tmpdir = vi.fn(() => params.tmpdirPath ?? "/var/fallback");
   const resolved = resolvePreferredRemoteClawTmpDir({
     accessSync,
+    chmodSync,
     lstatSync: wrappedLstatSync,
     mkdirSync,
     getuid,
     tmpdir,
+    warn,
   });
   return { resolved, accessSync, lstatSync: wrappedLstatSync, mkdirSync, tmpdir };
 }
@@ -210,5 +216,96 @@ describe("resolvePreferredRemoteClawTmpDir", () => {
 
     expect(resolved).toBe(fallbackTmp());
     expect(mkdirSync).toHaveBeenCalledWith(fallbackTmp(), { recursive: true, mode: 0o700 });
+  });
+
+  it("repairs fallback directory permissions after create when umask makes it group-writable", () => {
+    const fallbackPath = fallbackTmp();
+    let fallbackMode = 0o40775;
+    const lstatSync = vi.fn<NonNullable<TmpDirOptions["lstatSync"]>>(() => {
+      throw nodeErrorWithCode("ENOENT");
+    });
+    const fallbackLstatSync = vi
+      .fn<NonNullable<TmpDirOptions["lstatSync"]>>()
+      .mockImplementationOnce(() => {
+        throw nodeErrorWithCode("ENOENT");
+      })
+      .mockImplementation(() => ({
+        isDirectory: () => true,
+        isSymbolicLink: () => false,
+        uid: 501,
+        mode: fallbackMode,
+      }));
+    const chmodSync = vi.fn((target: string, mode: number) => {
+      if (target === fallbackPath && mode === 0o700) {
+        fallbackMode = 0o40700;
+      }
+    });
+
+    const resolved = resolvePreferredRemoteClawTmpDir({
+      accessSync: vi.fn((target: string) => {
+        if (target === "/tmp") {
+          throw new Error("read-only");
+        }
+      }),
+      lstatSync: vi.fn((target: string) => {
+        if (target === POSIX_REMOTECLAW_TMP_DIR) {
+          return lstatSync(target);
+        }
+        if (target === fallbackPath) {
+          return fallbackLstatSync(target);
+        }
+        return secureDirStat(501);
+      }),
+      mkdirSync: vi.fn(),
+      chmodSync,
+      getuid: vi.fn(() => 501),
+      tmpdir: vi.fn(() => "/var/fallback"),
+      warn: vi.fn(),
+    });
+
+    expect(resolved).toBe(fallbackPath);
+    expect(chmodSync).toHaveBeenCalledWith(fallbackPath, 0o700);
+  });
+
+  it("repairs existing fallback directory when permissions are too broad", () => {
+    const fallbackPath = fallbackTmp();
+    let fallbackMode = 0o40775;
+    const chmodSync = vi.fn((target: string, mode: number) => {
+      if (target === fallbackPath && mode === 0o700) {
+        fallbackMode = 0o40700;
+      }
+    });
+    const warn = vi.fn();
+
+    const resolved = resolvePreferredRemoteClawTmpDir({
+      accessSync: vi.fn((target: string) => {
+        if (target === "/tmp") {
+          throw new Error("read-only");
+        }
+      }),
+      lstatSync: vi.fn((target: string) => {
+        if (target === POSIX_REMOTECLAW_TMP_DIR) {
+          throw nodeErrorWithCode("ENOENT");
+        }
+        if (target === fallbackPath) {
+          return {
+            isDirectory: () => true,
+            isSymbolicLink: () => false,
+            uid: 501,
+            mode: fallbackMode,
+          };
+        }
+        return secureDirStat(501);
+      }),
+      mkdirSync: vi.fn(),
+      chmodSync,
+      getuid: vi.fn(() => 501),
+      tmpdir: vi.fn(() => "/var/fallback"),
+      warn,
+    });
+
+    expect(resolved).toBe(fallbackPath);
+    expect(chmodSync).toHaveBeenCalledWith(fallbackPath, 0o700);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("tightened permissions on temp dir"));
   });
 });

--- a/src/infra/tmp-remoteclaw-dir.ts
+++ b/src/infra/tmp-remoteclaw-dir.ts
@@ -7,6 +7,7 @@ const TMP_DIR_ACCESS_MODE = fs.constants.W_OK | fs.constants.X_OK;
 
 type ResolvePreferredRemoteClawTmpDirOptions = {
   accessSync?: (path: string, mode?: number) => void;
+  chmodSync?: (path: string, mode: number) => void;
   lstatSync?: (path: string) => {
     isDirectory(): boolean;
     isSymbolicLink(): boolean;
@@ -16,6 +17,7 @@ type ResolvePreferredRemoteClawTmpDirOptions = {
   mkdirSync?: (path: string, opts: { recursive: boolean; mode?: number }) => void;
   getuid?: () => number | undefined;
   tmpdir?: () => string;
+  warn?: (message: string) => void;
 };
 
 type MaybeNodeError = { code?: string };
@@ -33,8 +35,10 @@ export function resolvePreferredRemoteClawTmpDir(
   options: ResolvePreferredRemoteClawTmpDirOptions = {},
 ): string {
   const accessSync = options.accessSync ?? fs.accessSync;
+  const chmodSync = options.chmodSync ?? fs.chmodSync;
   const lstatSync = options.lstatSync ?? fs.lstatSync;
   const mkdirSync = options.mkdirSync ?? fs.mkdirSync;
+  const warn = options.warn ?? ((message: string) => console.warn(message));
   const getuid =
     options.getuid ??
     (() => {
@@ -97,6 +101,26 @@ export function resolvePreferredRemoteClawTmpDir(
     }
   };
 
+  const tryRepairWritableBits = (candidatePath: string): boolean => {
+    try {
+      const st = lstatSync(candidatePath);
+      if (!st.isDirectory() || st.isSymbolicLink()) {
+        return false;
+      }
+      if (uid !== undefined && typeof st.uid === "number" && st.uid !== uid) {
+        return false;
+      }
+      if (typeof st.mode !== "number" || (st.mode & 0o022) === 0) {
+        return false;
+      }
+      chmodSync(candidatePath, 0o700);
+      warn(`[remoteclaw] tightened permissions on temp dir: ${candidatePath}`);
+      return resolveDirState(candidatePath, false) === "available";
+    } catch {
+      return false;
+    }
+  };
+
   const ensureTrustedFallbackDir = (): string => {
     const fallbackPath = fallback();
     const state = resolveDirState(fallbackPath, true);
@@ -104,14 +128,21 @@ export function resolvePreferredRemoteClawTmpDir(
       return fallbackPath;
     }
     if (state === "invalid") {
+      if (tryRepairWritableBits(fallbackPath)) {
+        return fallbackPath;
+      }
       throw new Error(`Unsafe fallback RemoteClaw temp dir: ${fallbackPath}`);
     }
     try {
       mkdirSync(fallbackPath, { recursive: true, mode: 0o700 });
+      chmodSync(fallbackPath, 0o700);
     } catch {
       throw new Error(`Unable to create fallback RemoteClaw temp dir: ${fallbackPath}`);
     }
-    if (resolveDirState(fallbackPath, true) !== "available") {
+    if (
+      resolveDirState(fallbackPath, true) !== "available" &&
+      !tryRepairWritableBits(fallbackPath)
+    ) {
       throw new Error(`Unsafe fallback RemoteClaw temp dir: ${fallbackPath}`);
     }
     return fallbackPath;
@@ -122,6 +153,9 @@ export function resolvePreferredRemoteClawTmpDir(
     return POSIX_REMOTECLAW_TMP_DIR;
   }
   if (existingPreferredState === "invalid") {
+    if (tryRepairWritableBits(POSIX_REMOTECLAW_TMP_DIR)) {
+      return POSIX_REMOTECLAW_TMP_DIR;
+    }
     return ensureTrustedFallbackDir();
   }
 
@@ -129,7 +163,11 @@ export function resolvePreferredRemoteClawTmpDir(
     accessSync("/tmp", TMP_DIR_ACCESS_MODE);
     // Create with a safe default; subsequent callers expect it exists.
     mkdirSync(POSIX_REMOTECLAW_TMP_DIR, { recursive: true, mode: 0o700 });
-    if (resolveDirState(POSIX_REMOTECLAW_TMP_DIR, true) !== "available") {
+    chmodSync(POSIX_REMOTECLAW_TMP_DIR, 0o700);
+    if (
+      resolveDirState(POSIX_REMOTECLAW_TMP_DIR, true) !== "available" &&
+      !tryRepairWritableBits(POSIX_REMOTECLAW_TMP_DIR)
+    ) {
       return ensureTrustedFallbackDir();
     }
     return POSIX_REMOTECLAW_TMP_DIR;


### PR DESCRIPTION
## Cherry-pick from upstream

| Field | Value |
|-------|-------|
| **Upstream commit** | [`b1bbf3fff`](https://github.com/openclaw/openclaw/commit/b1bbf3fff16bb66f9a96a4824017c28c312942e3) |
| **Author** | [steipete](https://github.com/steipete) (landed from #27860 by [stakeswky](https://github.com/stakeswky)) |
| **Tier** | PICK (needs rebrand) |

Hardens temp directory permissions for `umask 0002` environments (multi-user hosts). Adds `tryRepairWritableBits()` that detects group/other-writable temp dirs and tightens to `0o700`. Also adds explicit `chmodSync` after `mkdirSync` to counteract restrictive umask.

### Adaptation

- Applied to `tmp-remoteclaw-dir.ts` (renamed from `tmp-openclaw-dir.ts` in WI-142)
- Rebranded all `OpenClaw`/`openclaw` references to `RemoteClaw`/`remoteclaw` in new code
- CHANGELOG entry skipped (fork maintains separate changelog)
- Fixed `resolveDirState` call in `tryRepairWritableBits` to pass explicit `false` (fork's signature requires 2 args)

Depends on #1246

Closes #666