### PR TITLE
Cherry-pick b38f37163: add @tloncorp/api to pnpm onlyBuiltDependencies allowlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,6 +249,7 @@
     "onlyBuiltDependencies": [
       "@matrix-org/matrix-sdk-crypto-nodejs",
       "@napi-rs/canvas",
+      "@tloncorp/api",
       "@whiskeysockets/baileys",
       "authenticate-pam",
       "esbuild",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
 onlyBuiltDependencies:
   - "@matrix-org/matrix-sdk-crypto-nodejs"
   - "@napi-rs/canvas"
+  - "@tloncorp/api"
   - "@whiskeysockets/baileys"
   - authenticate-pam
   - esbuild


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`b38f37163`](https://github.com/openclaw/openclaw/commit/b38f37163)
- **Author**: J. Campbell
- **Tier**: AUTO-PICK
- **PR**: openclaw/openclaw#39027

Adds `@tloncorp/api` to the `pnpm.onlyBuiltDependencies` allowlist in `package.json`, and registers the `tlon` workspace in `pnpm-workspace.yaml`.

Part of hq#898.