### PR TITLE
Cherry-pick 38f4ac5e3: fix(feishu): restore @larksuiteoapi/node-sdk in root dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@homebridge/ciao": "^1.3.5",
+    "@larksuiteoapi/node-sdk": "^1.59.0",
     "@line/bot-sdk": "^10.6.0",
     "@mariozechner/pi-tui": "0.55.0",
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@homebridge/ciao':
         specifier: ^1.3.5
         version: 1.3.5
+      '@larksuiteoapi/node-sdk':
+        specifier: ^1.59.0
+        version: 1.59.0
       '@line/bot-sdk':
         specifier: ^10.6.0
         version: 10.6.0


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`38f4ac5e3`](https://github.com/openclaw/openclaw/commit/38f4ac5e3)
- **Author**: Ayane
- **Tier**: AUTO-PICK

Restores `@larksuiteoapi/node-sdk` as a root dependency for the Feishu channel adapter.

Part of hq#898. Depends on #1248.