### PR TITLE
Cherry-pick e19b3679d: widen detect-secrets allowlist

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,28 @@ repos:
           - '=== "string"'
           - --exclude-lines
           - 'typeof remote\?\.password === "string"'
+          - --exclude-lines
+          - "REMOTECLAW_DOCKER_GPG_FINGERPRINT="
+          - --exclude-lines
+          - '"secretShape": "(secret_input|sibling_ref)"'
+          - --exclude-lines
+          - 'API key rotation \(provider-specific\): set `\*_API_KEYS`'
+          - --exclude-lines
+          - 'password: `REMOTECLAW_GATEWAY_PASSWORD` -> `gateway\.auth\.password` -> `gateway\.remote\.password`'
+          - --exclude-lines
+          - 'password: `REMOTECLAW_GATEWAY_PASSWORD` -> `gateway\.remote\.password` -> `gateway\.auth\.password`'
+          - --exclude-files
+          - '^src/gateway/client\.watchdog\.test\.ts$'
+          - --exclude-lines
+          - 'export CUSTOM_API_K[E]Y="your-key"'
+          - --exclude-lines
+          - 'grep -q ''N[O]DE_COMPILE_CACHE=/var/tmp/remoteclaw-compile-cache'' ~/.bashrc \|\| cat >> ~/.bashrc <<''EOF'''
+          - --exclude-lines
+          - 'env: \{ MISTRAL_API_K[E]Y: "sk-\.\.\." \},'
+          - --exclude-lines
+          - '"ap[i]Key": "xxxxx"(,)?'
+          - --exclude-lines
+          - 'ap[i]Key: "A[I]za\.\.\.",'
   # Shell script linting
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.11.0


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`e19b3679d`](https://github.com/openclaw/openclaw/commit/e19b3679d)
- **Author**: Vincent Koc
- **Tier**: AUTO-PICK

Widens the detect-secrets pre-commit allowlist with additional exclude patterns for API key placeholders and config references. Rebranded `OPENCLAW_` references to `REMOTECLAW_` during resolution.

Part of hq#898. Depends on #1249.