### PR TITLE
Cherry-pick 492fe679a: infer workspace agent when launching TUI

### DIFF
--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -14,10 +14,17 @@ Related:
 
 - TUI guide: [TUI](/web/tui)
 
+Notes:
+
+- `tui` resolves configured gateway auth SecretRefs for token/password auth when possible (`env`/`file`/`exec` providers).
+- When launched from inside a configured agent workspace directory, TUI auto-selects that agent for the session key default (unless `--session` is explicitly `agent:<id>:...`).
+
 ## Examples
 
 ```bash
 remoteclaw tui
 remoteclaw tui --url ws://127.0.0.1:18789 --token <token>
 remoteclaw tui --session main --deliver
+# when run inside an agent workspace, infers that agent automatically
+remoteclaw tui --session bugfix
 ```

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RemoteClawConfig } from "../config/config.js";
@@ -12,6 +14,8 @@ import {
   resolveFallbackAgentId,
   resolveAgentWorkspaceDir,
   resolveAgentWorkspaceDirOrNull,
+  resolveAgentIdByWorkspacePath,
+  resolveAgentIdsByWorkspacePath,
 } from "./agent-scope.js";
 
 afterEach(() => {
@@ -510,5 +514,94 @@ describe("resolveAgentRuntimeEnv", () => {
       },
     };
     expect(resolveAgentRuntimeEnv(cfg, "main")).toEqual({ API_KEY: "sk-default" });
+  });
+});
+
+describe("resolveAgentIdByWorkspacePath", () => {
+  it("returns the most specific workspace match for a directory", () => {
+    const workspaceRoot = `/tmp/remoteclaw-agent-scope-${Date.now()}-root`;
+    const opsWorkspace = `${workspaceRoot}/projects/ops`;
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "main", workspace: workspaceRoot },
+          { id: "ops", workspace: opsWorkspace },
+        ],
+      },
+    };
+
+    expect(resolveAgentIdByWorkspacePath(cfg, `${opsWorkspace}/src`)).toBe("ops");
+  });
+
+  it("returns undefined when directory has no matching workspace", () => {
+    const workspaceRoot = `/tmp/remoteclaw-agent-scope-${Date.now()}-root`;
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "main", workspace: workspaceRoot },
+          { id: "ops", workspace: `${workspaceRoot}-ops` },
+        ],
+      },
+    };
+
+    expect(
+      resolveAgentIdByWorkspacePath(cfg, `/tmp/remoteclaw-agent-scope-${Date.now()}-unrelated`),
+    ).toBeUndefined();
+  });
+
+  it("matches workspace paths through symlink aliases", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-agent-scope-"));
+    const realWorkspaceRoot = path.join(tempRoot, "real-root");
+    const realOpsWorkspace = path.join(realWorkspaceRoot, "projects", "ops");
+    const aliasWorkspaceRoot = path.join(tempRoot, "alias-root");
+    try {
+      fs.mkdirSync(path.join(realOpsWorkspace, "src"), { recursive: true });
+      fs.symlinkSync(
+        realWorkspaceRoot,
+        aliasWorkspaceRoot,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+
+      const cfg: RemoteClawConfig = {
+        agents: {
+          list: [
+            { id: "main", workspace: realWorkspaceRoot },
+            { id: "ops", workspace: realOpsWorkspace },
+          ],
+        },
+      };
+
+      expect(
+        resolveAgentIdByWorkspacePath(cfg, path.join(aliasWorkspaceRoot, "projects", "ops")),
+      ).toBe("ops");
+      expect(
+        resolveAgentIdByWorkspacePath(cfg, path.join(aliasWorkspaceRoot, "projects", "ops", "src")),
+      ).toBe("ops");
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveAgentIdsByWorkspacePath", () => {
+  it("returns matching workspaces ordered by specificity", () => {
+    const workspaceRoot = `/tmp/remoteclaw-agent-scope-${Date.now()}-root`;
+    const opsWorkspace = `${workspaceRoot}/projects/ops`;
+    const opsDevWorkspace = `${opsWorkspace}/dev`;
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "main", workspace: workspaceRoot },
+          { id: "ops", workspace: opsWorkspace },
+          { id: "ops-dev", workspace: opsDevWorkspace },
+        ],
+      },
+    };
+
+    expect(resolveAgentIdsByWorkspacePath(cfg, `${opsDevWorkspace}/pkg`)).toEqual([
+      "ops-dev",
+      "ops",
+      "main",
+    ]);
   });
 });

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import type { RemoteClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -265,6 +266,62 @@ export function resolveAgentWorkspaceDirOrNull(
     return stripNullBytes(resolveUserPath(configured));
   }
   return null;
+}
+
+function normalizePathForComparison(input: string): string {
+  const resolved = path.resolve(stripNullBytes(resolveUserPath(input)));
+  let normalized = resolved;
+  // Prefer realpath when available to normalize aliases/symlinks (for example /tmp -> /private/tmp)
+  // and canonical path case without forcing case-folding on case-sensitive macOS volumes.
+  try {
+    normalized = fs.realpathSync.native(resolved);
+  } catch {
+    // Keep lexical path for non-existent directories.
+  }
+  if (process.platform === "win32") {
+    return normalized.toLowerCase();
+  }
+  return normalized;
+}
+
+function isPathWithinRoot(candidatePath: string, rootPath: string): boolean {
+  const relative = path.relative(rootPath, candidatePath);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+export function resolveAgentIdsByWorkspacePath(
+  cfg: RemoteClawConfig,
+  workspacePath: string,
+): string[] {
+  const normalizedWorkspacePath = normalizePathForComparison(workspacePath);
+  const ids = listAgentIds(cfg);
+  const matches: Array<{ id: string; workspaceDir: string; order: number }> = [];
+
+  for (let index = 0; index < ids.length; index += 1) {
+    const id = ids[index];
+    const workspaceDir = normalizePathForComparison(resolveAgentWorkspaceDir(cfg, id));
+    if (!isPathWithinRoot(normalizedWorkspacePath, workspaceDir)) {
+      continue;
+    }
+    matches.push({ id, workspaceDir, order: index });
+  }
+
+  matches.sort((left, right) => {
+    const workspaceLengthDelta = right.workspaceDir.length - left.workspaceDir.length;
+    if (workspaceLengthDelta !== 0) {
+      return workspaceLengthDelta;
+    }
+    return left.order - right.order;
+  });
+
+  return matches.map((entry) => entry.id);
+}
+
+export function resolveAgentIdByWorkspacePath(
+  cfg: RemoteClawConfig,
+  workspacePath: string,
+): string | undefined {
+  return resolveAgentIdsByWorkspacePath(cfg, workspacePath)[0];
 }
 
 export function resolveAgentDir(cfg: RemoteClawConfig, agentId: string) {

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
+import type { RemoteClawConfig } from "../config/config.js";
 import { getSlashCommands } from "./commands.js";
 import {
   createBackspaceDeduper,
   resolveCtrlCAction,
   resolveFinalAssistantText,
   resolveGatewayDisconnectState,
+  resolveInitialTuiAgentId,
   resolveTuiSessionKey,
 } from "./tui.js";
 
@@ -60,6 +62,50 @@ describe("resolveTuiSessionKey", () => {
         sessionMainKey: "agent:main:main",
       }),
     ).toBe("agent:ops:incident");
+  });
+});
+
+describe("resolveInitialTuiAgentId", () => {
+  const cfg: RemoteClawConfig = {
+    agents: {
+      list: [
+        { id: "main", workspace: "/tmp/remoteclaw" },
+        { id: "ops", workspace: "/tmp/remoteclaw/projects/ops" },
+      ],
+    },
+  };
+
+  it("infers agent from cwd when session is not agent-prefixed", () => {
+    expect(
+      resolveInitialTuiAgentId({
+        cfg,
+        fallbackAgentId: "main",
+        initialSessionInput: "",
+        cwd: "/tmp/remoteclaw/projects/ops/src",
+      }),
+    ).toBe("ops");
+  });
+
+  it("keeps explicit agent prefix from --session", () => {
+    expect(
+      resolveInitialTuiAgentId({
+        cfg,
+        fallbackAgentId: "main",
+        initialSessionInput: "agent:main:incident",
+        cwd: "/tmp/remoteclaw/projects/ops/src",
+      }),
+    ).toBe("main");
+  });
+
+  it("falls back when cwd has no matching workspace", () => {
+    expect(
+      resolveInitialTuiAgentId({
+        cfg,
+        fallbackAgentId: "main",
+        initialSessionInput: "",
+        cwd: "/var/tmp/unrelated",
+      }),
+    ).toBe("main");
   });
 });
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -8,8 +8,8 @@ import {
   Text,
   TUI,
 } from "@mariozechner/pi-tui";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { loadConfig } from "../config/config.js";
+import { resolveAgentIdByWorkspacePath, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { loadConfig, type RemoteClawConfig } from "../config/config.js";
 import {
   buildAgentMainSessionKey,
   normalizeAgentId,
@@ -208,6 +208,28 @@ export function resolveTuiSessionKey(params: {
   return `agent:${params.currentAgentId}:${trimmed}`;
 }
 
+export function resolveInitialTuiAgentId(params: {
+  cfg: RemoteClawConfig;
+  fallbackAgentId: string;
+  initialSessionInput?: string;
+  cwd?: string;
+}) {
+  const parsed = parseAgentSessionKey((params.initialSessionInput ?? "").trim());
+  if (parsed?.agentId) {
+    return normalizeAgentId(parsed.agentId);
+  }
+
+  const inferredFromWorkspace = resolveAgentIdByWorkspacePath(
+    params.cfg,
+    params.cwd ?? process.cwd(),
+  );
+  if (inferredFromWorkspace) {
+    return inferredFromWorkspace;
+  }
+
+  return normalizeAgentId(params.fallbackAgentId);
+}
+
 export function resolveGatewayDisconnectState(reason?: string): {
   connectionStatus: string;
   activityStatus: string;
@@ -279,7 +301,12 @@ export async function runTui(opts: TuiOptions) {
   let sessionScope: SessionScope = (config.session?.scope ?? "per-sender") as SessionScope;
   let sessionMainKey = normalizeMainKey(config.session?.mainKey);
   let agentDefaultId = resolveDefaultAgentId(config);
-  let currentAgentId = agentDefaultId;
+  let currentAgentId = resolveInitialTuiAgentId({
+    cfg: config,
+    fallbackAgentId: agentDefaultId,
+    initialSessionInput,
+    cwd: process.cwd(),
+  });
   let agents: AgentSummary[] = [];
   const agentNames = new Map<string, string>();
   let currentSessionKey = "";


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`492fe679a`](https://github.com/openclaw/openclaw/commit/492fe679a7)
- **Author**: [arceus77-7](https://github.com/arceus77-7)
- **Tier**: AUTO-PICK (resolved conflicts from rebrand)

When TUI is launched from inside a configured agent workspace directory, auto-selects that agent for the session key default. Adds `resolveAgentIdsByWorkspacePath` and `resolveAgentIdByWorkspacePath` functions for workspace-to-agent resolution with symlink-aware path normalization.

Depends on #1252.

Part of #899.