### PR TITLE
Cherry-pick f66cc886d: normalize live model not-found skips

### DIFF
--- a/src/agents/live-model-errors.test.ts
+++ b/src/agents/live-model-errors.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import {
+  isMiniMaxModelNotFoundErrorMessage,
+  isModelNotFoundErrorMessage,
+} from "./live-model-errors.js";
+
+describe("live model error helpers", () => {
+  it("detects generic model-not-found messages", () => {
+    expect(isModelNotFoundErrorMessage('{"code":404,"message":"model not found"}')).toBe(true);
+    expect(isModelNotFoundErrorMessage("model: MiniMax-M2.5-highspeed not found")).toBe(true);
+    expect(isModelNotFoundErrorMessage("request ended without sending any chunks")).toBe(false);
+  });
+
+  it("detects bare minimax 404 page-not-found responses", () => {
+    expect(isMiniMaxModelNotFoundErrorMessage("404 page not found")).toBe(true);
+    expect(isMiniMaxModelNotFoundErrorMessage("Error: 404 404 page not found")).toBe(true);
+    expect(isMiniMaxModelNotFoundErrorMessage("request ended without sending any chunks")).toBe(
+      false,
+    );
+  });
+});

--- a/src/agents/live-model-errors.ts
+++ b/src/agents/live-model-errors.ts
@@ -1,0 +1,24 @@
+export function isModelNotFoundErrorMessage(raw: string): boolean {
+  const msg = raw.trim();
+  if (!msg) {
+    return false;
+  }
+  if (/\b404\b/.test(msg) && /not(?:[_\-\s])?found/i.test(msg)) {
+    return true;
+  }
+  if (/not_found_error/i.test(msg)) {
+    return true;
+  }
+  if (/model:\s*[a-z0-9._-]+/i.test(msg) && /not(?:[_\-\s])?found/i.test(msg)) {
+    return true;
+  }
+  return false;
+}
+
+export function isMiniMaxModelNotFoundErrorMessage(raw: string): boolean {
+  const msg = raw.trim();
+  if (!msg) {
+    return false;
+  }
+  return /\b404\b.*\bpage not found\b/i.test(msg);
+}


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`f66cc886d`](https://github.com/openclaw/openclaw/commit/f66cc886d3)
- **Author**: [steipete](https://github.com/steipete) (Peter Steinberger)
- **Tier**: AUTO-PICK (resolved: discarded gutted models.profiles.live.test.ts)

Extracts model-not-found test skip logic into reusable `live-model-errors.ts` helper.

Depends on #1253.

Part of #899.