### PR TITLE
Cherry-pick eba9dcc67: refactor release hardening follow-ups

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "build": "pnpm canvas:a2ui:bundle && tsdown && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-export-html-templates.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-compat.ts",
     "build:plugin-sdk:dts": "tsc -p tsconfig.plugin-sdk.dts.json",
     "canvas:a2ui:bundle": "bash scripts/bundle-a2ui.sh",
-    "check": "pnpm format:check && pnpm tsgo && pnpm lint && pnpm lint:tmp:no-random-messaging && pnpm lint:tmp:no-raw-channel-fetch && pnpm lint:auth:no-pairing-store-group && pnpm lint:auth:pairing-account-scope && pnpm check:host-env-policy:swift",
+    "check": "pnpm check:host-env-policy:swift && pnpm format:check && pnpm tsgo && pnpm lint && pnpm lint:tmp:no-random-messaging && pnpm lint:tmp:no-raw-channel-fetch && pnpm lint:auth:no-pairing-store-group && pnpm lint:auth:pairing-account-scope",
     "check:docs": "pnpm format:docs:check && pnpm lint:docs && pnpm docs:check-links",
     "check:host-env-policy:swift": "node scripts/generate-host-env-security-policy-swift.mjs --check",
     "check:loc": "node --import tsx scripts/check-ts-max-loc.ts --max 500",

--- a/scripts/pr
+++ b/scripts/pr
@@ -227,6 +227,30 @@ checkout_prep_branch() {
   git checkout "$prep_branch"
 }
 
+verify_prep_branch_matches_prepared_head() {
+  local pr="$1"
+  local prepared_head_sha="$2"
+
+  require_artifact .local/prep-context.env
+  checkout_prep_branch "$pr"
+
+  local prep_branch_head_sha
+  prep_branch_head_sha=$(git rev-parse HEAD)
+  if [ "$prep_branch_head_sha" = "$prepared_head_sha" ]; then
+    return 0
+  fi
+
+  echo "Local prep branch moved after prepare-push (expected $prepared_head_sha, got $prep_branch_head_sha)."
+  if git merge-base --is-ancestor "$prepared_head_sha" "$prep_branch_head_sha" 2>/dev/null; then
+    echo "Unpushed local commits on prep branch:"
+    git log --oneline "${prepared_head_sha}..${prep_branch_head_sha}" | sed 's/^/  /' || true
+    echo "Run scripts/pr prepare-sync-head $pr to push them before merge."
+  else
+    echo "Prep branch no longer contains the prepared head. Re-run prepare-init."
+  fi
+  exit 1
+}
+
 resolve_head_push_url() {
   # shellcheck disable=SC1091
   source .local/pr-meta.env
@@ -852,6 +876,7 @@ merge_verify() {
   require_artifact .local/prep.env
   # shellcheck disable=SC1091
   source .local/prep.env
+  verify_prep_branch_matches_prepared_head "$pr" "$PREP_HEAD_SHA"
 
   local json
   json=$(pr_meta_json "$pr")

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -6,6 +6,17 @@ import { join, resolve } from "node:path";
 
 type PackFile = { path: string };
 type PackResult = { files?: PackFile[] };
+type PackageJson = {
+  name?: string;
+  version?: string;
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  remoteclaw?: {
+    install?: {
+      npmSpec?: string;
+    };
+  };
+};
 
 const requiredPathGroups = [
   ["dist/index.js", "dist/index.mjs"],
@@ -16,11 +27,6 @@ const requiredPathGroups = [
 ];
 const forbiddenPrefixes = ["dist/RemoteClaw.app/"];
 
-type PackageJson = {
-  name?: string;
-  version?: string;
-};
-
 function normalizePluginSyncVersion(version: string): string {
   const normalized = version.trim().replace(/^v/, "");
   const base = /^([0-9]+\.[0-9]+\.[0-9]+)/.exec(normalized)?.[1];
@@ -28,6 +34,92 @@ function normalizePluginSyncVersion(version: string): string {
     return base;
   }
   return normalized.replace(/[-+].*$/, "");
+}
+
+const ALLOWLISTED_BUNDLED_EXTENSION_ROOT_DEP_GAPS: Record<string, string[]> = {
+  googlechat: ["google-auth-library"],
+  matrix: ["@matrix-org/matrix-sdk-crypto-nodejs", "@vector-im/matrix-bot-sdk", "music-metadata"],
+  msteams: ["@microsoft/agents-hosting"],
+  nostr: ["nostr-tools"],
+  tlon: ["@tloncorp/api", "@tloncorp/tlon-skill", "@urbit/aura"],
+  zalouser: ["zca-js"],
+};
+
+export function collectBundledExtensionRootDependencyGapErrors(params: {
+  rootPackage: PackageJson;
+  extensions: Array<{ id: string; packageJson: PackageJson }>;
+}): string[] {
+  const rootDeps = {
+    ...params.rootPackage.dependencies,
+    ...params.rootPackage.optionalDependencies,
+  };
+  const errors: string[] = [];
+
+  for (const extension of params.extensions) {
+    if (!extension.packageJson.remoteclaw?.install?.npmSpec) {
+      continue;
+    }
+
+    const missing = Object.keys(extension.packageJson.dependencies ?? {})
+      .filter((dep) => dep !== "remoteclaw" && !rootDeps[dep])
+      .toSorted();
+    const allowlisted = [
+      ...(ALLOWLISTED_BUNDLED_EXTENSION_ROOT_DEP_GAPS[extension.id] ?? []),
+    ].toSorted();
+    if (missing.join("\n") !== allowlisted.join("\n")) {
+      const unexpected = missing.filter((dep) => !allowlisted.includes(dep));
+      const resolved = allowlisted.filter((dep) => !missing.includes(dep));
+      const parts = [
+        `bundled extension '${extension.id}' root dependency mirror drift`,
+        `missing in root package: ${missing.length > 0 ? missing.join(", ") : "(none)"}`,
+      ];
+      if (unexpected.length > 0) {
+        parts.push(`new gaps: ${unexpected.join(", ")}`);
+      }
+      if (resolved.length > 0) {
+        parts.push(`remove stale allowlist entries: ${resolved.join(", ")}`);
+      }
+      errors.push(parts.join(" | "));
+    }
+  }
+
+  return errors;
+}
+
+function collectBundledExtensions(): Array<{ id: string; packageJson: PackageJson }> {
+  const extensionsDir = resolve("extensions");
+  const entries = readdirSync(extensionsDir, { withFileTypes: true }).filter((entry) =>
+    entry.isDirectory(),
+  );
+
+  return entries.flatMap((entry) => {
+    const packagePath = join(extensionsDir, entry.name, "package.json");
+    try {
+      return [
+        {
+          id: entry.name,
+          packageJson: JSON.parse(readFileSync(packagePath, "utf8")) as PackageJson,
+        },
+      ];
+    } catch {
+      return [];
+    }
+  });
+}
+
+function checkBundledExtensionRootDependencyMirrors() {
+  const rootPackage = JSON.parse(readFileSync(resolve("package.json"), "utf8")) as PackageJson;
+  const errors = collectBundledExtensionRootDependencyGapErrors({
+    rootPackage,
+    extensions: collectBundledExtensions(),
+  });
+  if (errors.length > 0) {
+    console.error("release-check: bundled extension root dependency mirror validation failed:");
+    for (const error of errors) {
+      console.error(`  - ${error}`);
+    }
+    process.exit(1);
+  }
 }
 
 function runPackDry(): PackResult[] {
@@ -89,6 +181,7 @@ function checkPluginVersions() {
 
 function main() {
   checkPluginVersions();
+  checkBundledExtensionRootDependencyMirrors();
 
   const results = runPackDry();
   const files = results.flatMap((entry) => entry.files ?? []);


### PR DESCRIPTION
## Summary

Partial cherry-pick of upstream [`eba9dcc67`](https://github.com/openclaw/openclaw/commit/eba9dcc67a4c3fd706f7905f6af45615be7dad89) — discards gutted files (models-config, pi-embedded-runner, transcript-policy, provider-capabilities, test/release-check.test.ts).

**Alive changes picked:**
- **build**: fail fast on stale host-env swift policy (reorder `check:host-env-policy:swift` to front of check pipeline)
- **build**: guard bundled extension root dependency gaps (new `checkBundledExtensionRootDependencyMirrors` validation)
- **fix**: block merge when prep branch has unpushed commits (`scripts/pr`)
- **HostEnvSecurityPolicy.generated.swift**: restore blocked override keys (GIT_SSH_COMMAND, EDITOR, OPENSSL_CONF, etc.)

**Rebrand applied**: `openclaw`→`remoteclaw` in `release-check.ts` PackageJson type and bundled extension dependency mirror validation.

Original author: [Peter Steinberger](https://github.com/steipete)

Part of #899.