### PR TITLE
Cherry-pick 047f4ac: Docs: clarify release build arch defaults for mac packaging

### DIFF
--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -27,7 +27,7 @@ This app now ships Sparkle auto-updates. Release builds must be Developer ID–s
 Notes:
 
 - `APP_BUILD` maps to `CFBundleVersion`/`sparkle:version`; keep it numeric + monotonic (no `-beta`), or Sparkle compares it as equal.
-- Defaults to the current architecture (`$(uname -m)`). For release/universal builds, set `BUILD_ARCHS="arm64 x86_64"` (or `BUILD_ARCHS=all`).
+- For `BUILD_CONFIG=release`, `scripts/package-mac-app.sh` now defaults to universal (`arm64 x86_64`) automatically. You can still override with `BUILD_ARCHS=arm64` or `BUILD_ARCHS=x86_64`. For local/dev builds (`BUILD_CONFIG=debug`), it defaults to the current architecture (`$(uname -m)`).
 - Use `scripts/package-mac-dist.sh` for release artifacts (zip + DMG + notarization). Use `scripts/package-mac-app.sh` for local/dev packaging.
 
 ```bash


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: [`047f4acac`](https://github.com/openclaw/openclaw/commit/047f4acacf9e3fe972290c0b30586e22cfb59041)
- **Author**: [cgdusek](https://github.com/cgdusek) (Charles Dusek)
- **Tier**: AUTO-PICK
- **Result**: RESOLVED (conflict in docs/platforms/mac/release.md — took upstream's updated BUILD_ARCHS default description, dropped fork-removed APP_BUILD derivation lines)

Clarifies that `BUILD_CONFIG=release` now defaults to universal (`arm64 x86_64`) automatically, while dev builds default to the current architecture.

Cherry-picked for: remoteclaw/hq#900