### PR TITLE
Cherry-pick 9ce79bb: Docs: mark basic mac dist example as non-notarized

### DIFF
--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -32,7 +32,9 @@ Notes:
 
 ```bash
 # From repo root; set release IDs so Sparkle feed is enabled.
+# This command builds release artifacts without notarization.
 # APP_BUILD must be numeric + monotonic for Sparkle compare.
+SKIP_NOTARIZE=1 \
 BUNDLE_ID=org.remoteclaw.mac \
 APP_VERSION=0.1.0 \
 APP_BUILD="$(git rev-list --count HEAD)" \


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: [`9ce79bba3`](https://github.com/openclaw/openclaw/commit/9ce79bba34)
- **Author**: [cgdusek](https://github.com/cgdusek) (Charles Dusek)
- **Tier**: AUTO-PICK
- **Result**: RESOLVED (conflict in docs/platforms/mac/release.md — applied upstream's SKIP_NOTARIZE=1 addition with fork's rebranded bundle ID and version)

Adds `SKIP_NOTARIZE=1` to the basic (non-notarized) build example and a comment clarifying the example builds without notarization.

Depends on #1258

Cherry-picked for: remoteclaw/hq#900