### PR TITLE
Cherry-pick 1a364cd: Docs: clarify notarization handoff in mac release flow

### DIFF
--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -42,10 +42,12 @@ BUILD_CONFIG=release \
 SIGN_IDENTITY="Developer ID Application: <Developer Name> (<TEAMID>)" \
 scripts/package-mac-app.sh
 
-# Zip for distribution (includes resource forks for Sparkle delta support)
+# `package-mac-dist.sh` already creates the zip + DMG.
+# If you used `package-mac-app.sh` directly instead, create them manually:
+# If you want notarization/stapling in this step, use the NOTARIZE command below.
 ditto -c -k --sequesterRsrc --keepParent dist/RemoteClaw.app dist/RemoteClaw-0.1.0.zip
 
-# Optional: also build a styled DMG for humans (drag to /Applications)
+# Optional: build a styled DMG for humans (drag to /Applications)
 scripts/create-dmg.sh dist/RemoteClaw.app dist/RemoteClaw-0.1.0.dmg
 
 # Recommended: build + notarize/staple zip + DMG


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: [`1a364cd06`](https://github.com/openclaw/openclaw/commit/1a364cd066d05d281bb261cbf924ce3e61a80a27)
- **Author**: [cgdusek](https://github.com/cgdusek) (Charles Dusek)
- **Tier**: AUTO-PICK
- **Result**: RESOLVED (rebrand conflicts — applied upstream's improved comments with fork's rebranded paths/names)

Clarifies notarization handoff: `package-mac-dist.sh` already creates zip + DMG, and notes when to use the NOTARIZE command separately.

Depends on #1259

Cherry-picked for: remoteclaw/hq#900