### PR TITLE
Cherry-pick 2970d72: docs: update Brave Search API docs for Feb 2026 plan restructuring

### DIFF
--- a/docs/brave-search.md
+++ b/docs/brave-search.md
@@ -13,7 +13,7 @@ Brave Search can be configured as the web search provider when using RemoteClaw'
 ## Get an API key
 
 1. Create a Brave Search API account at [https://brave.com/search/api/](https://brave.com/search/api/)
-2. In the dashboard, choose the **Data for Search** plan and generate an API key.
+2. In the dashboard, choose the **Search** plan and generate an API key.
 3. Set `BRAVE_API_KEY` in the Gateway environment, or configure it in `tools.web.search`.
 
 ## Config example
@@ -37,7 +37,9 @@ Brave Search can be configured as the web search provider when using RemoteClaw'
 
 ## Notes
 
-- The Data for AI plan is **not** compatible with `web_search`.
-- Brave provides a free tier plus paid plans; check the Brave API portal for current limits.
+- RemoteClaw uses the Brave **Search** plan. If you have a legacy subscription (e.g. the original Free plan with 2,000 queries/month), it remains valid but does not include newer features like LLM Context or higher rate limits.
+- Each Brave plan includes **$5/month in free credit** (renewing). The Search plan costs $5 per 1,000 requests, so the credit covers 1,000 queries/month. Set your usage limit in the Brave dashboard to avoid unexpected charges. See the [Brave API portal](https://brave.com/search/api/) for current plans.
+- The Search plan includes the LLM Context endpoint and AI inference rights. Storing results to train or tune models requires a plan with explicit storage rights. See the Brave [Terms of Service](https://api-dashboard.search.brave.com/terms-of-service).
+- Results are cached for 15 minutes by default (configurable via `cacheTtlMinutes`).
 
 See [Web tools](/tools/web) for the full web_search configuration.

--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -64,9 +64,7 @@ See [Media understanding](/nodes/media-understanding).
 
 **Brave free tier (generous):**
 
-- **2,000 requests/month**
-- **1 request/second**
-- **Credit card required** for verification (no charge unless you upgrade)
+Each Brave plan includes **$5/month in renewing free credit**. The Search plan costs $5 per 1,000 requests, so the credit covers 1,000 requests/month at no charge. Set your usage limit in the Brave dashboard to avoid unexpected charges.
 
 See [Web tools](/tools/web).
 

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -56,10 +56,14 @@ Use `remoteclaw configure --section web` to set up your API key and choose a pro
 ### Brave Search
 
 1. Create a Brave Search API account at [brave.com/search/api](https://brave.com/search/api/)
-2. In the dashboard, choose the **Data for Search** plan (not "Data for AI") and generate an API key.
+2. In the dashboard, choose the **Search** plan and generate an API key.
 3. Run `remoteclaw configure --section web` to store the key in config, or set `BRAVE_API_KEY` in your environment.
 
-Brave provides paid plans; check the Brave API portal for the current limits and pricing.
+Each Brave plan includes **$5/month in free credit** (renewing). The Search
+plan costs $5 per 1,000 requests, so the credit covers 1,000 queries/month. Set
+your usage limit in the Brave dashboard to avoid unexpected charges. See the
+[Brave API portal](https://brave.com/search/api/) for current plans and
+pricing.
 
 ### Perplexity Search
 


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: [`2970d7255`](https://github.com/openclaw/openclaw/commit/2970d72554512b27b80d7dfbc82b40d034f81d9d)
- **Author**: [remusao](https://github.com/remusao)
- **Tier**: AUTO-PICK
- **Result**: RESOLVED

Updates Brave Search docs to reflect Feb 2026 plan restructuring: "Data for Search" → "Search" plan, updated pricing info.

Depends on #1260

Cherry-picked for: remoteclaw/hq#900