### PR TITLE
Cherry-pick 615466b: Docs: use placeholder OpenRouter key in Perplexity guide

### DIFF
--- a/docs/perplexity.md
+++ b/docs/perplexity.md
@@ -66,7 +66,7 @@ Optional legacy controls:
       search: {
         provider: "perplexity",
         perplexity: {
-          apiKey: "sk-or-v1-...",
+          apiKey: "<openrouter-api-key>",
           baseUrl: "https://openrouter.ai/api/v1",
           model: "perplexity/sonar-pro",
         },


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: [`615466bdf`](https://github.com/openclaw/openclaw/commit/615466bdf42cbe842c27c854f59cf89c77303e6f)
- **Author**: [vincentkoc](https://github.com/vincentkoc)
- **Tier**: AUTO-PICK
- **Result**: PICKED (clean)

Replaces real-looking OpenRouter key with placeholder in Perplexity docs.

Depends on #1261

Cherry-picked for: remoteclaw/hq#900