### PR TITLE
Cherry-pick 55465d8: Docs: use placeholder OpenRouter key in web tool docs

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -150,7 +150,7 @@ In this mode, `country` and `language` / `search_lang` still work, but `ui_lang`
         enabled: true,
         provider: "perplexity",
         perplexity: {
-          apiKey: "sk-or-v1-...", // optional if OPENROUTER_API_KEY is set
+          apiKey: "<openrouter-api-key>", // optional if OPENROUTER_API_KEY is set
           baseUrl: "https://openrouter.ai/api/v1",
           model: "perplexity/sonar-pro",
         },


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: [`55465d86d`](https://github.com/openclaw/openclaw/commit/55465d86d93d4026b74f6dd3621618be45124988)
- **Author**: [vincentkoc](https://github.com/vincentkoc)
- **Tier**: AUTO-PICK
- **Result**: PICKED (clean)

Replaces real-looking OpenRouter key with placeholder in web tool docs.

Depends on #1262

Cherry-picked for: remoteclaw/hq#900