### PR TITLE
Cherry-pick 6476061: macOS: default release app builds to universal binaries

### DIFF
--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -40,7 +40,7 @@ APP_VERSION=0.1.0 \
 APP_BUILD="$(git rev-list --count HEAD)" \
 BUILD_CONFIG=release \
 SIGN_IDENTITY="Developer ID Application: <Developer Name> (<TEAMID>)" \
-scripts/package-mac-app.sh
+scripts/package-mac-dist.sh
 
 # `package-mac-dist.sh` already creates the zip + DMG.
 # If you used `package-mac-app.sh` directly instead, create them manually:

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -16,7 +16,14 @@ GIT_BUILD_NUMBER=$(cd "$ROOT_DIR" && git rev-list --count HEAD 2>/dev/null || ec
 APP_VERSION="${APP_VERSION:-$PKG_VERSION}"
 APP_BUILD="${APP_BUILD:-$GIT_BUILD_NUMBER}"
 BUILD_CONFIG="${BUILD_CONFIG:-debug}"
-BUILD_ARCHS_VALUE="${BUILD_ARCHS:-$(uname -m)}"
+if [[ -n "${BUILD_ARCHS:-}" ]]; then
+  BUILD_ARCHS_VALUE="${BUILD_ARCHS}"
+elif [[ "$BUILD_CONFIG" == "release" ]]; then
+  # Release packaging should be universal unless explicitly overridden.
+  BUILD_ARCHS_VALUE="all"
+else
+  BUILD_ARCHS_VALUE="$(uname -m)"
+fi
 if [[ "${BUILD_ARCHS_VALUE}" == "all" ]]; then
   BUILD_ARCHS_VALUE="arm64 x86_64"
 fi


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: [`64760614a`](https://github.com/openclaw/openclaw/commit/64760614aa9cb29152feadf3a476f3252b049a4a)
- **Author**: [cgdusek](https://github.com/cgdusek) (Charles Dusek)
- **Tier**: AUTO-PICK
- **Result**: PICKED (clean)

Makes `package-mac-app.sh` default to universal (`arm64 x86_64`) for release builds. Dev builds still default to current architecture.

Depends on #1263

Cherry-picked for: remoteclaw/hq#900