### PR TITLE
Cherry-pick 04b4b4807: fix(android): persist legacy location mode migration

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/SecurePrefs.kt
@@ -19,6 +19,7 @@ class SecurePrefs(context: Context) {
   companion object {
     val defaultWakeWords: List<String> = listOf("remoteclaw", "claude")
     private const val displayNameKey = "node.displayName"
+    private const val locationModeKey = "location.enabledMode"
     private const val voiceWakeModeKey = "voiceWake.mode"
   }
 
@@ -44,8 +45,7 @@ class SecurePrefs(context: Context) {
   private val _cameraEnabled = MutableStateFlow(prefs.getBoolean("camera.enabled", true))
   val cameraEnabled: StateFlow<Boolean> = _cameraEnabled
 
-  private val _locationMode =
-    MutableStateFlow(LocationMode.fromRawValue(prefs.getString("location.enabledMode", "off")))
+  private val _locationMode = MutableStateFlow(loadLocationMode())
   val locationMode: StateFlow<LocationMode> = _locationMode
 
   private val _locationPreciseEnabled =
@@ -116,7 +116,7 @@ class SecurePrefs(context: Context) {
   }
 
   fun setLocationMode(mode: LocationMode) {
-    prefs.edit { putString("location.enabledMode", mode.rawValue) }
+    prefs.edit { putString(locationModeKey, mode.rawValue) }
     _locationMode.value = mode
   }
 
@@ -273,6 +273,15 @@ class SecurePrefs(context: Context) {
       prefs.edit { putString(voiceWakeModeKey, resolved.rawValue) }
     }
 
+    return resolved
+  }
+
+  private fun loadLocationMode(): LocationMode {
+    val raw = prefs.getString(locationModeKey, "off")
+    val resolved = LocationMode.fromRawValue(raw)
+    if (raw?.trim()?.lowercase() == "always") {
+      prefs.edit { putString(locationModeKey, resolved.rawValue) }
+    }
     return resolved
   }
 

--- a/apps/android/app/src/test/java/org/remoteclaw/android/SecurePrefsTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/SecurePrefsTest.kt
@@ -1,0 +1,23 @@
+package org.remoteclaw.android
+
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class SecurePrefsTest {
+  @Test
+  fun loadLocationMode_migratesLegacyAlwaysValue() {
+    val context = RuntimeEnvironment.getApplication()
+    val prefs = context.getSharedPreferences("remoteclaw.node.secure", Context.MODE_PRIVATE)
+    prefs.edit().clear().putString("location.enabledMode", "always").commit()
+
+    val securePrefs = SecurePrefs(context)
+
+    assertEquals(LocationMode.WhileUsing, securePrefs.locationMode.value)
+    assertEquals("whileUsing", prefs.getString("location.enabledMode", null))
+  }
+}


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: [`04b4b4807`](https://github.com/openclaw/openclaw/commit/04b4b4807)
- **Author**: Ayaan Zaidi
- **Tier**: AUTO-PICK

## Resolution

Resolved conflicts in SecurePrefs.kt by applying upstream's `loadLocationMode()` migration function with fork's `prefs` variable name (fork uses single encrypted prefs instead of upstream's plain+secure split). Rebranded test file package path and prefs name.

Depends on #1268.

Cherry-picked as part of #901.