### PR TITLE
Cherry-pick 4e2290b84: refactor: add canonical talk config payload

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
@@ -67,8 +67,19 @@ class TalkModeManager(
       return trimmed.takeIf { it.isNotEmpty() }
     }
 
+    private fun selectResolvedTalkProviderConfig(talk: JsonObject): TalkProviderConfigSelection? {
+      val resolved = talk["resolved"].asObjectOrNull() ?: return null
+      val providerId = normalizeTalkProviderId(resolved["provider"].asStringOrNull()) ?: return null
+      return TalkProviderConfigSelection(
+        provider = providerId,
+        config = resolved["config"].asObjectOrNull() ?: buildJsonObject {},
+        normalizedPayload = true,
+      )
+    }
+
     internal fun selectTalkProviderConfig(talk: JsonObject?): TalkProviderConfigSelection? {
       if (talk == null) return null
+      selectResolvedTalkProviderConfig(talk)?.let { return it }
       val rawProvider = talk["provider"].asStringOrNull()
       val rawProviders = talk["providers"].asObjectOrNull()
       val hasNormalizedPayload = rawProvider != null || rawProviders != null

--- a/apps/android/app/src/test/java/org/remoteclaw/android/voice/TalkModeConfigParsingTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/voice/TalkModeConfigParsingTest.kt
@@ -12,6 +12,36 @@ class TalkModeConfigParsingTest {
   private val json = Json { ignoreUnknownKeys = true }
 
   @Test
+  fun prefersCanonicalResolvedTalkProviderPayload() {
+    val talk =
+      json.parseToJsonElement(
+          """
+          {
+            "resolved": {
+              "provider": "elevenlabs",
+              "config": {
+                "voiceId": "voice-resolved"
+              }
+            },
+            "provider": "elevenlabs",
+            "providers": {
+              "elevenlabs": {
+                "voiceId": "voice-normalized"
+              }
+            }
+          }
+          """.trimIndent(),
+        )
+        .jsonObject
+
+    val selection = TalkModeManager.selectTalkProviderConfig(talk)
+    assertNotNull(selection)
+    assertEquals("elevenlabs", selection?.provider)
+    assertTrue(selection?.normalizedPayload == true)
+    assertEquals("voice-resolved", selection?.config?.get("voiceId")?.jsonPrimitive?.content)
+  }
+
+  @Test
   fun prefersNormalizedTalkProviderPayload() {
     val talk =
       json.parseToJsonElement(

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -123,18 +123,18 @@ export function applyTalkApiKey(config: RemoteClawConfig): RemoteClawConfig {
 
   const talk = normalized.talk;
   const active = resolveActiveTalkProviderConfig(talk);
-  if (active.provider && active.provider !== DEFAULT_TALK_PROVIDER) {
+  if (active?.provider && active.provider !== DEFAULT_TALK_PROVIDER) {
     return normalized;
   }
 
   const existingProviderApiKey =
-    typeof active.config?.apiKey === "string" ? active.config.apiKey.trim() : "";
+    typeof active?.config?.apiKey === "string" ? active.config.apiKey.trim() : "";
   const existingLegacyApiKey = typeof talk?.apiKey === "string" ? talk.apiKey.trim() : "";
   if (existingProviderApiKey || existingLegacyApiKey) {
     return normalized;
   }
 
-  const providerId = active.provider ?? DEFAULT_TALK_PROVIDER;
+  const providerId = active?.provider ?? DEFAULT_TALK_PROVIDER;
   const providers = { ...talk?.providers };
   const providerConfig = { ...providers[providerId], apiKey: resolved };
   providers[providerId] = providerConfig;

--- a/src/config/talk.normalize.test.ts
+++ b/src/config/talk.normalize.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createConfigIO } from "./io.js";
-import { normalizeTalkSection } from "./talk.js";
+import { buildTalkConfigResponse, normalizeTalkSection } from "./talk.js";
 
 async function withTempConfig(
   config: unknown,
@@ -99,6 +99,40 @@ describe("talk normalization", () => {
         },
       },
       voiceId: "legacy-voice",
+      interruptOnSpeech: true,
+    });
+  });
+
+  it("builds a canonical resolved talk payload for clients", () => {
+    const payload = buildTalkConfigResponse({
+      provider: "acme",
+      providers: {
+        acme: {
+          voiceId: "acme-voice",
+          modelId: "acme-model",
+        },
+      },
+      voiceId: "legacy-voice",
+      interruptOnSpeech: true,
+    });
+
+    expect(payload).toEqual({
+      provider: "acme",
+      providers: {
+        acme: {
+          voiceId: "acme-voice",
+          modelId: "acme-model",
+        },
+      },
+      resolved: {
+        provider: "acme",
+        config: {
+          voiceId: "acme-voice",
+          modelId: "acme-model",
+        },
+      },
+      voiceId: "acme-voice",
+      modelId: "acme-model",
       interruptOnSpeech: true,
     });
   });

--- a/src/config/talk.ts
+++ b/src/config/talk.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { TalkConfig, TalkProviderConfig } from "./types.gateway.js";
+import type {
+  ResolvedTalkConfig,
+  TalkConfig,
+  TalkConfigResponse,
+  TalkProviderConfig,
+} from "./types.gateway.js";
 import type { RemoteClawConfig } from "./types.js";
 
 type TalkApiKeyDeps = {
@@ -220,25 +225,24 @@ export function normalizeTalkConfig(config: RemoteClawConfig): RemoteClawConfig 
   };
 }
 
-export function resolveActiveTalkProviderConfig(talk: TalkConfig | undefined): {
-  provider?: string;
-  config?: TalkProviderConfig;
-} {
+export function resolveActiveTalkProviderConfig(
+  talk: TalkConfig | undefined,
+): ResolvedTalkConfig | undefined {
   const normalizedTalk = normalizeTalkSection(talk);
   if (!normalizedTalk) {
-    return {};
+    return undefined;
   }
   const provider = activeProviderFromTalk(normalizedTalk);
   if (!provider) {
-    return {};
+    return undefined;
   }
   return {
     provider,
-    config: normalizedTalk.providers?.[provider],
+    config: normalizedTalk.providers?.[provider] ?? {},
   };
 }
 
-export function buildTalkConfigResponse(value: unknown): TalkConfig | undefined {
+export function buildTalkConfigResponse(value: unknown): TalkConfigResponse | undefined {
   if (!isPlainObject(value)) {
     return undefined;
   }
@@ -247,7 +251,7 @@ export function buildTalkConfigResponse(value: unknown): TalkConfig | undefined 
     return undefined;
   }
 
-  const payload: TalkConfig = {};
+  const payload: TalkConfigResponse = {};
   if (typeof normalized.interruptOnSpeech === "boolean") {
     payload.interruptOnSpeech = normalized.interruptOnSpeech;
   }
@@ -258,8 +262,12 @@ export function buildTalkConfigResponse(value: unknown): TalkConfig | undefined 
     payload.provider = normalized.provider;
   }
 
-  const activeProvider = activeProviderFromTalk(normalized);
-  const providerConfig = activeProvider ? normalized.providers?.[activeProvider] : undefined;
+  const resolved = resolveActiveTalkProviderConfig(normalized);
+  if (resolved) {
+    payload.resolved = resolved;
+  }
+
+  const providerConfig = resolved?.config;
   const providerCompatibilityLegacy = legacyTalkFieldsFromProviderConfig(providerConfig);
   const compatibilityLegacy =
     Object.keys(providerCompatibilityLegacy).length > 0

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -61,6 +61,13 @@ export type TalkProviderConfig = {
   [key: string]: unknown;
 };
 
+export type ResolvedTalkConfig = {
+  /** Active Talk TTS provider resolved from the current config payload. */
+  provider: string;
+  /** Provider config for the active Talk provider. */
+  config: TalkProviderConfig;
+};
+
 export type TalkConfig = {
   /** Active Talk TTS provider (for example "elevenlabs"). */
   provider?: string;
@@ -78,6 +85,11 @@ export type TalkConfig = {
   modelId?: string;
   outputFormat?: string;
   apiKey?: string;
+};
+
+export type TalkConfigResponse = TalkConfig & {
+  /** Canonical active Talk payload for clients. */
+  resolved?: ResolvedTalkConfig;
 };
 
 export type GatewayControlUiConfig = {

--- a/src/gateway/protocol/schema/channels.ts
+++ b/src/gateway/protocol/schema/channels.ts
@@ -27,6 +27,14 @@ const TalkProviderConfigSchema = Type.Object(
   { additionalProperties: true },
 );
 
+const ResolvedTalkConfigSchema = Type.Object(
+  {
+    provider: Type.String(),
+    config: TalkProviderConfigSchema,
+  },
+  { additionalProperties: false },
+);
+
 export const TalkConfigResultSchema = Type.Object(
   {
     config: Type.Object(
@@ -36,6 +44,7 @@ export const TalkConfigResultSchema = Type.Object(
             {
               provider: Type.Optional(Type.String()),
               providers: Type.Optional(Type.Record(Type.String(), TalkProviderConfigSchema)),
+              resolved: Type.Optional(ResolvedTalkConfigSchema),
               voiceId: Type.Optional(Type.String()),
               voiceAliases: Type.Optional(Type.Record(Type.String(), Type.String())),
               modelId: Type.Optional(Type.String()),

--- a/src/gateway/server.talk-config.test.ts
+++ b/src/gateway/server.talk-config.test.ts
@@ -86,6 +86,10 @@ describe("gateway talk.config", () => {
             providers?: {
               elevenlabs?: { voiceId?: string; apiKey?: string };
             };
+            resolved?: {
+              provider?: string;
+              config?: { voiceId?: string; apiKey?: string };
+            };
             apiKey?: string;
             voiceId?: string;
           };
@@ -97,6 +101,9 @@ describe("gateway talk.config", () => {
       expect(res.payload?.config?.talk?.providers?.elevenlabs?.apiKey).toBe(
         "__REMOTECLAW_REDACTED__",
       );
+      expect(res.payload?.config?.talk?.resolved?.provider).toBe("elevenlabs");
+      expect(res.payload?.config?.talk?.resolved?.config?.voiceId).toBe("voice-123");
+      expect(res.payload?.config?.talk?.resolved?.config?.apiKey).toBe("__REMOTECLAW_REDACTED__");
       expect(res.payload?.config?.talk?.voiceId).toBe("voice-123");
       expect(res.payload?.config?.talk?.apiKey).toBe("__REMOTECLAW_REDACTED__");
     });
@@ -149,6 +156,10 @@ describe("gateway talk.config", () => {
             providers?: {
               elevenlabs?: { voiceId?: string };
             };
+            resolved?: {
+              provider?: string;
+              config?: { voiceId?: string };
+            };
             voiceId?: string;
           };
         };
@@ -156,6 +167,8 @@ describe("gateway talk.config", () => {
       expect(res.ok).toBe(true);
       expect(res.payload?.config?.talk?.provider).toBe("elevenlabs");
       expect(res.payload?.config?.talk?.providers?.elevenlabs?.voiceId).toBe("voice-normalized");
+      expect(res.payload?.config?.talk?.resolved?.provider).toBe("elevenlabs");
+      expect(res.payload?.config?.talk?.resolved?.config?.voiceId).toBe("voice-normalized");
       expect(res.payload?.config?.talk?.voiceId).toBe("voice-normalized");
     });
   });


### PR DESCRIPTION
## Cherry-pick: `4e2290b84`

**Subject**: refactor: add canonical talk config payload
**Author**: [Peter Steinberger](https://github.com/steipete)
**Upstream commit**: [`4e2290b84`](https://github.com/openclaw/openclaw/commit/4e2290b84)
**Tier**: AUTO-PARTIAL

### Changes

Adds a canonical `buildTalkConfigResponse` function that produces a resolved talk config payload for clients, including provider/providers shape, resolved active provider config, and backward-compatible legacy fields. Also adds `ResolvedTalkConfig` and `TalkConfigResponse` types and updates the gateway protocol schema.

### Discarded files (2)

- `apps/shared/OpenClawKit/Sources/OpenClawKit/TalkConfigParsing.swift` — deleted in fork (rebranded)
- `apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkConfigParsingTests.swift` — deleted in fork (rebranded)

### Conflicts resolved

- `src/config/defaults.ts` — kept fork's inlined API key check (no `hasConfiguredSecretInput`), applied upstream's `?.` optional chaining fix on `active?.config?.apiKey`
- `src/config/talk.ts` — kept fork's `RemoteClawConfig` rebrand, no `coerceSecretRef`, added new types
- `src/config/talk.normalize.test.ts` — added new `buildTalkConfigResponse` test, kept fork's removal of SecretRef test

### Rebrand fixups

- `src/gateway/server.talk-config.test.ts` — `__OPENCLAW_REDACTED__` → `__REMOTECLAW_REDACTED__` in new resolved config assertion

Depends on #1269

Cherry-picked as part of #901