### PR TITLE
Cherry-pick b7ad8fd66: fix: fail closed talk provider selection

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
@@ -90,10 +90,18 @@ class TalkModeManager(
             val providerConfig = value.asObjectOrNull() ?: return@mapNotNull null
             providerId to providerConfig
           }?.toMap().orEmpty()
-        val providerId =
-          normalizeTalkProviderId(rawProvider)
-            ?: providers.keys.sorted().firstOrNull()
-            ?: defaultTalkProvider
+        val explicitProviderId = normalizeTalkProviderId(rawProvider)
+        if (explicitProviderId != null) {
+          if (providers.isNotEmpty() && providers[explicitProviderId] == null) {
+            return null
+          }
+          return TalkProviderConfigSelection(
+            provider = explicitProviderId,
+            config = providers[explicitProviderId] ?: buildJsonObject {},
+            normalizedPayload = true,
+          )
+        }
+        val providerId = providers.keys.singleOrNull() ?: return null
         return TalkProviderConfigSelection(
           provider = providerId,
           config = providers[providerId] ?: buildJsonObject {},

--- a/apps/android/app/src/test/java/org/remoteclaw/android/voice/TalkModeConfigParsingTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/voice/TalkModeConfigParsingTest.kt
@@ -67,6 +67,50 @@ class TalkModeConfigParsingTest {
   }
 
   @Test
+  fun rejectsNormalizedTalkProviderPayloadWhenProviderMissingFromProviders() {
+    val talk =
+      json.parseToJsonElement(
+          """
+          {
+            "provider": "acme",
+            "providers": {
+              "elevenlabs": {
+                "voiceId": "voice-normalized"
+              }
+            }
+          }
+          """.trimIndent(),
+        )
+        .jsonObject
+
+    val selection = TalkModeManager.selectTalkProviderConfig(talk)
+    assertEquals(null, selection)
+  }
+
+  @Test
+  fun rejectsNormalizedTalkProviderPayloadWhenProviderIsAmbiguous() {
+    val talk =
+      json.parseToJsonElement(
+          """
+          {
+            "providers": {
+              "acme": {
+                "voiceId": "voice-acme"
+              },
+              "elevenlabs": {
+                "voiceId": "voice-normalized"
+              }
+            }
+          }
+          """.trimIndent(),
+        )
+        .jsonObject
+
+    val selection = TalkModeManager.selectTalkProviderConfig(talk)
+    assertEquals(null, selection)
+  }
+
+  @Test
   fun fallsBackToLegacyTalkFieldsWhenNormalizedPayloadMissing() {
     val talk =
       json.parseToJsonElement(

--- a/src/config/config.talk-validation.test.ts
+++ b/src/config/config.talk-validation.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { clearConfigCache, loadConfig } from "./config.js";
+import { withTempHomeConfig } from "./test-helpers.js";
+
+describe("talk config validation fail-closed behavior", () => {
+  beforeEach(() => {
+    clearConfigCache();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["boolean", true],
+    ["string", "1500"],
+    ["float", 1500.5],
+  ])("rejects %s talk.silenceTimeoutMs during config load", async (_label, value) => {
+    await withTempHomeConfig(
+      {
+        agents: { list: [{ id: "main" }] },
+        talk: {
+          silenceTimeoutMs: value,
+        },
+      },
+      async () => {
+        const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        const config = loadConfig();
+
+        // Fork behavior: loadConfig catches INVALID_CONFIG and returns empty config
+        expect(config).toEqual({});
+        expect(consoleSpy).toHaveBeenCalled();
+        const errorMessage = consoleSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+        expect(errorMessage).toMatch(/silenceTimeoutMs|talk|Invalid config/i);
+      },
+    );
+  });
+
+  it("rejects talk.provider when it does not match talk.providers during config load", async () => {
+    await withTempHomeConfig(
+      {
+        agents: { list: [{ id: "main" }] },
+        talk: {
+          provider: "acme",
+          providers: {
+            elevenlabs: {
+              voiceId: "voice-123",
+            },
+          },
+        },
+      },
+      async () => {
+        const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        const config = loadConfig();
+
+        expect(config).toEqual({});
+        expect(consoleSpy).toHaveBeenCalled();
+        const errorMessage = consoleSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+        expect(errorMessage).toMatch(/talk\.provider|talk\.providers|acme|Invalid config/i);
+      },
+    );
+  });
+
+  it("rejects multi-provider talk config without talk.provider during config load", async () => {
+    await withTempHomeConfig(
+      {
+        agents: { list: [{ id: "main" }] },
+        talk: {
+          providers: {
+            acme: {
+              voiceId: "voice-acme",
+            },
+            elevenlabs: {
+              voiceId: "voice-eleven",
+            },
+          },
+        },
+      },
+      async () => {
+        const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        const config = loadConfig();
+
+        expect(config).toEqual({});
+        expect(consoleSpy).toHaveBeenCalled();
+        const errorMessage = consoleSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+        expect(errorMessage).toMatch(/talk\.provider|required|Invalid config/i);
+      },
+    );
+  });
+});

--- a/src/config/talk.ts
+++ b/src/config/talk.ts
@@ -131,10 +131,14 @@ function legacyProviderConfigFromTalk(
 
 function activeProviderFromTalk(talk: TalkConfig): string | undefined {
   const provider = normalizeString(talk.provider);
+  const providers = talk.providers;
   if (provider) {
+    if (providers && !(provider in providers)) {
+      return undefined;
+    }
     return provider;
   }
-  const providerIds = talk.providers ? Object.keys(talk.providers) : [];
+  const providerIds = providers ? Object.keys(providers) : [];
   return providerIds.length === 1 ? providerIds[0] : undefined;
 }
 

--- a/src/config/zod-schema.talk.test.ts
+++ b/src/config/zod-schema.talk.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { RemoteClawSchema } from "./zod-schema.js";
+
+describe("RemoteClawSchema talk validation", () => {
+  it("rejects talk.provider when it does not match talk.providers", () => {
+    expect(() =>
+      RemoteClawSchema.parse({
+        talk: {
+          provider: "acme",
+          providers: {
+            elevenlabs: {
+              voiceId: "voice-123",
+            },
+          },
+        },
+      }),
+    ).toThrow(/talk\.provider|talk\.providers|missing "acme"/i);
+  });
+
+  it("rejects multi-provider talk config without talk.provider", () => {
+    expect(() =>
+      RemoteClawSchema.parse({
+        talk: {
+          providers: {
+            acme: {
+              voiceId: "voice-acme",
+            },
+            elevenlabs: {
+              voiceId: "voice-eleven",
+            },
+          },
+        },
+      }),
+    ).toThrow(/talk\.provider|required/i);
+  });
+});

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -49,6 +49,49 @@ const HttpUrlSchema = z
     return protocol === "http:" || protocol === "https:";
   }, "Expected http:// or https:// URL");
 
+const TalkProviderEntrySchema = z
+  .object({
+    voiceId: z.string().optional(),
+    voiceAliases: z.record(z.string(), z.string()).optional(),
+    modelId: z.string().optional(),
+    outputFormat: z.string().optional(),
+    apiKey: z.string().optional().register(sensitive),
+  })
+  .catchall(z.unknown());
+
+const TalkSchema = z
+  .object({
+    provider: z.string().optional(),
+    providers: z.record(z.string(), TalkProviderEntrySchema).optional(),
+    voiceId: z.string().optional(),
+    voiceAliases: z.record(z.string(), z.string()).optional(),
+    modelId: z.string().optional(),
+    outputFormat: z.string().optional(),
+    apiKey: z.string().optional().register(sensitive),
+    interruptOnSpeech: z.boolean().optional(),
+  })
+  .strict()
+  .superRefine((talk, ctx) => {
+    const provider = talk.provider?.trim().toLowerCase();
+    const providers = talk.providers ? Object.keys(talk.providers) : [];
+
+    if (provider && providers.length > 0 && !(provider in talk.providers!)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["provider"],
+        message: `talk.provider must match a key in talk.providers (missing "${provider}")`,
+      });
+    }
+
+    if (!provider && providers.length > 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["provider"],
+        message: "talk.provider is required when talk.providers defines multiple providers",
+      });
+    }
+  });
+
 export const RemoteClawSchema = z
   .object({
     $schema: z.string().optional(),
@@ -363,32 +406,7 @@ export const RemoteClawSchema = z
       })
       .strict()
       .optional(),
-    talk: z
-      .object({
-        provider: z.string().optional(),
-        providers: z
-          .record(
-            z.string(),
-            z
-              .object({
-                voiceId: z.string().optional(),
-                voiceAliases: z.record(z.string(), z.string()).optional(),
-                modelId: z.string().optional(),
-                outputFormat: z.string().optional(),
-                apiKey: z.string().optional().register(sensitive),
-              })
-              .catchall(z.unknown()),
-          )
-          .optional(),
-        voiceId: z.string().optional(),
-        voiceAliases: z.record(z.string(), z.string()).optional(),
-        modelId: z.string().optional(),
-        outputFormat: z.string().optional(),
-        apiKey: z.string().optional().register(sensitive),
-        interruptOnSpeech: z.boolean().optional(),
-      })
-      .strict()
-      .optional(),
+    talk: TalkSchema.optional(),
     gateway: z
       .object({
         port: z.number().int().positive().optional(),


### PR DESCRIPTION
## Cherry-pick: `b7ad8fd66`

**Subject**: fix: fail closed talk provider selection
**Author**: [Peter Steinberger](https://github.com/steipete)
**Upstream commit**: [`b7ad8fd66`](https://github.com/openclaw/openclaw/commit/b7ad8fd66)
**Tier**: AUTO-PARTIAL

### Changes

Adds `superRefine` validation to the talk config Zod schema ensuring:
- `talk.provider` must match a key in `talk.providers` when both are present
- `talk.provider` is required when `talk.providers` defines multiple providers

Also extracts the inline talk schema into standalone `TalkProviderEntrySchema` and `TalkSchema` constants, and adds corresponding validation tests.

### Discarded files (2)

- `apps/shared/OpenClawKit/Sources/OpenClawKit/TalkConfigParsing.swift` — deleted in fork (rebranded)
- `apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkConfigParsingTests.swift` — deleted in fork (rebranded)

### Conflicts resolved

- `src/config/zod-schema.ts` — kept fork's removal of SkillEntrySchema/PluginEntrySchema/ResponsesEndpointUrlFetchShape; added new TalkProviderEntrySchema and TalkSchema with fork's `z.string()` for apiKey (no SecretInputSchema); replaced inline talk schema with `TalkSchema.optional()` reference; omitted `silenceTimeoutMs` (not in fork)

### Rebrand fixups

- `src/config/zod-schema.talk.test.ts` — `OpenClawSchema` → `RemoteClawSchema`; removed `silenceTimeoutMs` tests (field not present in fork schema)

Depends on #1270

Cherry-picked as part of #901