### PR TITLE
Cherry-pick dc5645d45: test: add talk config contract fixtures

### DIFF
--- a/apps/android/app/src/test/java/org/remoteclaw/android/voice/TalkModeConfigContractTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/voice/TalkModeConfigContractTest.kt
@@ -1,0 +1,76 @@
+package org.remoteclaw.android.voice
+
+import java.io.File
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@Serializable
+private data class TalkConfigContractFixture(
+  @SerialName("selectionCases") val selectionCases: List<SelectionCase>,
+) {
+  @Serializable
+  data class SelectionCase(
+    val id: String,
+    val defaultProvider: String,
+    val payloadValid: Boolean,
+    val expectedSelection: ExpectedSelection? = null,
+    val talk: JsonObject,
+  )
+
+  @Serializable
+  data class ExpectedSelection(
+    val provider: String,
+    val normalizedPayload: Boolean,
+    val voiceId: String? = null,
+  )
+}
+
+class TalkModeConfigContractTest {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test
+  fun selectionFixtures() {
+    for (fixture in loadFixtures().selectionCases) {
+      val selection = TalkModeManager.selectTalkProviderConfig(fixture.talk)
+      val expected = fixture.expectedSelection
+      if (expected == null) {
+        assertNull(fixture.id, selection)
+        continue
+      }
+      assertNotNull(fixture.id, selection)
+      assertEquals(fixture.id, expected.provider, selection?.provider)
+      assertEquals(fixture.id, expected.normalizedPayload, selection?.normalizedPayload)
+      assertEquals(
+        fixture.id,
+        expected.voiceId,
+        (selection?.config?.get("voiceId") as? JsonPrimitive)?.content,
+      )
+      assertEquals(fixture.id, true, fixture.payloadValid)
+    }
+  }
+
+  private fun loadFixtures(): TalkConfigContractFixture {
+    val fixturePath = findFixtureFile()
+    return json.decodeFromString(File(fixturePath).readText())
+  }
+
+  private fun findFixtureFile(): String {
+    val startDir = System.getProperty("user.dir") ?: error("user.dir unavailable")
+    var current = File(startDir).absoluteFile
+    while (true) {
+      val candidate = File(current, "test-fixtures/talk-config-contract.json")
+      if (candidate.exists()) {
+        return candidate.absolutePath
+      }
+      current = current.parentFile ?: break
+    }
+    error("talk-config-contract.json not found from $startDir")
+  }
+}

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -311,6 +311,7 @@ export const validateWizardCancelParams = ajv.compile<WizardCancelParams>(Wizard
 export const validateWizardStatusParams = ajv.compile<WizardStatusParams>(WizardStatusParamsSchema);
 export const validateTalkModeParams = ajv.compile<TalkModeParams>(TalkModeParamsSchema);
 export const validateTalkConfigParams = ajv.compile<TalkConfigParams>(TalkConfigParamsSchema);
+export const validateTalkConfigResult = ajv.compile<TalkConfigResult>(TalkConfigResultSchema);
 export const validateChannelsStatusParams = ajv.compile<ChannelsStatusParams>(
   ChannelsStatusParamsSchema,
 );

--- a/src/gateway/protocol/talk-config.contract.test.ts
+++ b/src/gateway/protocol/talk-config.contract.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+import { validateTalkConfigResult } from "./index.js";
+
+type ExpectedSelection = {
+  provider: string;
+  normalizedPayload: boolean;
+  voiceId?: string;
+};
+
+type SelectionContractCase = {
+  id: string;
+  defaultProvider: string;
+  payloadValid: boolean;
+  expectedSelection: ExpectedSelection | null;
+  talk: Record<string, unknown>;
+};
+
+type TalkConfigContractFixture = {
+  selectionCases: SelectionContractCase[];
+};
+
+const fixturePath = new URL("../../../test-fixtures/talk-config-contract.json", import.meta.url);
+const fixtures = JSON.parse(fs.readFileSync(fixturePath, "utf-8")) as TalkConfigContractFixture;
+
+describe("talk.config contract fixtures", () => {
+  for (const fixture of fixtures.selectionCases) {
+    it(fixture.id, () => {
+      const payload = { config: { talk: fixture.talk } };
+      if (fixture.payloadValid) {
+        expect(validateTalkConfigResult(payload)).toBe(true);
+      } else {
+        expect((payload.config.talk as { resolved?: unknown }).resolved).toBeUndefined();
+      }
+
+      if (!fixture.expectedSelection) {
+        return;
+      }
+
+      const talk = payload.config.talk as {
+        resolved?: {
+          provider?: string;
+          config?: {
+            voiceId?: string;
+          };
+        };
+        voiceId?: string;
+      };
+      expect(talk.resolved?.provider ?? fixture.defaultProvider).toBe(
+        fixture.expectedSelection.provider,
+      );
+      expect(talk.resolved?.config?.voiceId ?? talk.voiceId).toBe(
+        fixture.expectedSelection.voiceId,
+      );
+    });
+  }
+});

--- a/test-fixtures/talk-config-contract.json
+++ b/test-fixtures/talk-config-contract.json
@@ -1,0 +1,88 @@
+{
+  "selectionCases": [
+    {
+      "id": "canonical_resolved_wins",
+      "defaultProvider": "elevenlabs",
+      "payloadValid": true,
+      "expectedSelection": {
+        "provider": "elevenlabs",
+        "normalizedPayload": true,
+        "voiceId": "voice-resolved"
+      },
+      "talk": {
+        "resolved": {
+          "provider": "elevenlabs",
+          "config": {
+            "voiceId": "voice-resolved"
+          }
+        },
+        "provider": "elevenlabs",
+        "providers": {
+          "elevenlabs": {
+            "voiceId": "voice-normalized"
+          }
+        },
+        "voiceId": "voice-legacy"
+      }
+    },
+    {
+      "id": "normalized_missing_resolved",
+      "defaultProvider": "elevenlabs",
+      "payloadValid": false,
+      "expectedSelection": null,
+      "talk": {
+        "provider": "elevenlabs",
+        "providers": {
+          "elevenlabs": {
+            "voiceId": "voice-normalized"
+          }
+        },
+        "voiceId": "voice-legacy"
+      }
+    },
+    {
+      "id": "provider_mismatch_missing_resolved",
+      "defaultProvider": "elevenlabs",
+      "payloadValid": false,
+      "expectedSelection": null,
+      "talk": {
+        "provider": "acme",
+        "providers": {
+          "elevenlabs": {
+            "voiceId": "voice-normalized"
+          }
+        }
+      }
+    },
+    {
+      "id": "ambiguous_providers_missing_resolved",
+      "defaultProvider": "elevenlabs",
+      "payloadValid": false,
+      "expectedSelection": null,
+      "talk": {
+        "providers": {
+          "acme": {
+            "voiceId": "voice-acme"
+          },
+          "elevenlabs": {
+            "voiceId": "voice-normalized"
+          }
+        }
+      }
+    },
+    {
+      "id": "legacy_payload_fallback",
+      "defaultProvider": "elevenlabs",
+      "payloadValid": true,
+      "expectedSelection": {
+        "provider": "elevenlabs",
+        "normalizedPayload": false,
+        "voiceId": "voice-legacy"
+      },
+      "talk": {
+        "voiceId": "voice-legacy",
+        "apiKey": "legacy-key"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Cherry-pick: `dc5645d45`

**Subject**: test: add talk config contract fixtures
**Author**: [Peter Steinberger](https://github.com/steipete)
**Upstream commit**: [`dc5645d45`](https://github.com/openclaw/openclaw/commit/dc5645d45)
**Tier**: AUTO-PARTIAL

### Changes

Adds shared talk config contract test fixtures (`test-fixtures/talk-config-contract.json`) and contract tests that verify talk provider selection behavior against the fixtures across platforms (TypeScript gateway protocol + Android).

### Discarded files (1)

- `apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkConfigContractTests.swift` — OpenClawKit deleted in fork (rebranded to RemoteClawKit; file auto-relocated by git but discarded per upstream tracking conventions)

### Rebrand fixups

- `apps/android/.../TalkModeConfigContractTest.kt` — `package ai.openclaw.app.voice` → `package org.remoteclaw.android.voice`

Depends on #1271

Cherry-picked as part of #901