### PR TITLE
Cherry-pick 6ff7e8f42: talk: add configurable silence timeout

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
@@ -55,6 +55,11 @@ class TalkModeManager(
     private const val defaultModelIdFallback = "eleven_v3"
     private const val defaultOutputFormatFallback = "pcm_24000"
     private const val defaultTalkProvider = "elevenlabs"
+    private const val defaultSilenceTimeoutMs = 700L
+    private const val listenWatchdogMs = 12_000L
+    private const val chatFinalWaitWithSubscribeMs = 45_000L
+    private const val chatFinalWaitWithoutSubscribeMs = 6_000L
+    private const val maxCachedRunCompletions = 128
 
     internal data class TalkProviderConfigSelection(
       val provider: String,
@@ -114,6 +119,14 @@ class TalkModeManager(
         normalizedPayload = false,
       )
     }
+
+    internal fun resolvedSilenceTimeoutMs(talk: JsonObject?): Long {
+      val timeout = talk?.get("silenceTimeoutMs").asDoubleOrNull() ?: return defaultSilenceTimeoutMs
+      if (timeout <= 0 || timeout % 1.0 != 0.0 || timeout > Long.MAX_VALUE.toDouble()) {
+        return defaultSilenceTimeoutMs
+      }
+      return timeout.toLong()
+    }
   }
 
   private val mainHandler = Handler(Looper.getMainLooper())
@@ -143,7 +156,7 @@ class TalkModeManager(
   private var listeningMode = false
 
   private var silenceJob: Job? = null
-  private val silenceWindowMs = 700L
+  private var silenceWindowMs = defaultSilenceTimeoutMs
   private var lastTranscript: String = ""
   private var lastHeardAtMs: Long? = null
   private var lastSpokenText: String? = null
@@ -893,6 +906,7 @@ class TalkModeManager(
         activeConfig?.get("outputFormat")?.asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
       val key = activeConfig?.get("apiKey")?.asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
       val interrupt = talk?.get("interruptOnSpeech")?.asBooleanOrNull()
+      val silenceTimeoutMs = resolvedSilenceTimeoutMs(talk)
 
       if (!isCanonicalMainSessionKey(mainSessionKey)) {
         mainSessionKey = mainKey
@@ -914,6 +928,11 @@ class TalkModeManager(
         } else {
           null
         }
+      silenceWindowMs = silenceTimeoutMs
+      Log.d(
+        tag,
+        "reloadConfig apiKey=${if (apiKey != null) "set" else "null"} voiceId=$defaultVoiceId silenceTimeoutMs=$silenceTimeoutMs",
+      )
       if (interrupt != null) interruptOnSpeech = interrupt
       if (activeProvider != defaultTalkProvider) {
         Log.w(tag, "talk provider $activeProvider unsupported; using system voice fallback")
@@ -921,6 +940,7 @@ class TalkModeManager(
         Log.d(tag, "talk config provider=elevenlabs")
       }
     } catch (_: Throwable) {
+      silenceWindowMs = defaultSilenceTimeoutMs
       defaultVoiceId = envVoice?.takeIf { it.isNotEmpty() } ?: sagVoice?.takeIf { it.isNotEmpty() }
       defaultModelId = defaultModelIdFallback
       if (!modelOverrideActive) currentModelId = defaultModelId

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -17,6 +17,7 @@ final class TalkModeManager: NSObject {
     private typealias SpeechRequest = SFSpeechAudioBufferRecognitionRequest
     private static let defaultModelIdFallback = "eleven_v3"
     private static let defaultTalkProvider = "elevenlabs"
+    private static let defaultSilenceTimeoutMs = 900
     private static let redactedConfigSentinel = "__REMOTECLAW_REDACTED__"
     var isEnabled: Bool = false
     var isListening: Bool = false
@@ -77,7 +78,7 @@ final class TalkModeManager: NSObject {
 
     private var gateway: GatewayNodeSession?
     private var gatewayConnected = false
-    private let silenceWindow: TimeInterval = 0.9
+    private var silenceWindow: TimeInterval = TimeInterval(Self.defaultSilenceTimeoutMs) / 1000
     private var lastAudioActivity: Date?
     private var noiseFloorSamples: [Double] = []
     private var noiseFloor: Double?
@@ -1917,6 +1918,24 @@ extension TalkModeManager {
             config: normalizedProviders[providerID] ?? [:])
     }
 
+    static func resolvedSilenceTimeoutMs(_ talk: [String: Any]?) -> Int {
+        switch talk?["silenceTimeoutMs"] {
+        case let timeout as Int where timeout > 0:
+            return timeout
+        case let timeout as Double
+            where timeout > 0 && timeout.rounded(.towardZero) == timeout && timeout <= Double(Int.max):
+            return Int(timeout)
+        case let timeout as NSNumber:
+            let value = timeout.doubleValue
+            if value > 0 && value.rounded(.towardZero) == value && value <= Double(Int.max) {
+                return Int(value)
+            }
+            return Self.defaultSilenceTimeoutMs
+        default:
+            return Self.defaultSilenceTimeoutMs
+        }
+    }
+
     func reloadConfig() async {
         guard let gateway else { return }
         do {
@@ -1931,6 +1950,7 @@ extension TalkModeManager {
             }
             let activeProvider = selection?.provider ?? Self.defaultTalkProvider
             let activeConfig = selection?.config
+            let silenceTimeoutMs = Self.resolvedSilenceTimeoutMs(talk)
             self.defaultVoiceId = (activeConfig?["voiceId"] as? String)?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             if let aliases = activeConfig?["voiceAliases"] as? [String: Any] {
@@ -1978,8 +1998,9 @@ extension TalkModeManager {
             if let interrupt = talk?["interruptOnSpeech"] as? Bool {
                 self.interruptOnSpeech = interrupt
             }
+            self.silenceWindow = TimeInterval(silenceTimeoutMs) / 1000
             if selection != nil {
-                GatewayDiagnostics.log("talk config provider=\(activeProvider)")
+                GatewayDiagnostics.log("talk config provider=\(activeProvider) silenceTimeoutMs=\(silenceTimeoutMs)")
             }
         } catch {
             self.defaultModelId = Self.defaultModelIdFallback
@@ -1990,6 +2011,7 @@ extension TalkModeManager {
             self.gatewayTalkDefaultModelId = nil
             self.gatewayTalkApiKeyConfigured = false
             self.gatewayTalkConfigLoaded = false
+            self.silenceWindow = TimeInterval(Self.defaultSilenceTimeoutMs) / 1000
         }
     }
 

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -28,4 +28,24 @@ import Testing
         let selection = TalkModeManager.selectTalkProviderConfig(talk)
         #expect(selection == nil)
     }
+
+    @Test func readsConfiguredSilenceTimeoutMs() {
+        let talk: [String: Any] = [
+            "silenceTimeoutMs": 1500,
+        ]
+
+        #expect(TalkModeManager.resolvedSilenceTimeoutMs(talk) == 1500)
+    }
+
+    @Test func defaultsSilenceTimeoutMsWhenMissing() {
+        #expect(TalkModeManager.resolvedSilenceTimeoutMs(nil) == 900)
+    }
+
+    @Test func defaultsSilenceTimeoutMsWhenInvalid() {
+        let talk: [String: Any] = [
+            "silenceTimeoutMs": 0,
+        ]
+
+        #expect(TalkModeManager.resolvedSilenceTimeoutMs(talk) == 900)
+    }
 }

--- a/apps/macos/Sources/RemoteClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/RemoteClaw/TalkModeRuntime.swift
@@ -12,6 +12,7 @@ actor TalkModeRuntime {
     private let ttsLogger = Logger(subsystem: "org.remoteclaw", category: "talk.tts")
     private static let defaultModelIdFallback = "eleven_v3"
     private static let defaultTalkProvider = "elevenlabs"
+    private static let defaultSilenceTimeoutMs = 700
 
     private final class RMSMeter: @unchecked Sendable {
         private let lock = NSLock()
@@ -66,7 +67,7 @@ actor TalkModeRuntime {
     private var fallbackVoiceId: String?
     private var lastPlaybackWasPCM: Bool = false
 
-    private let silenceWindow: TimeInterval = 0.7
+    private var silenceWindow: TimeInterval = TimeInterval(TalkModeRuntime.defaultSilenceTimeoutMs) / 1000
     private let minSpeechRMS: Double = 1e-3
     private let speechBoostFactor: Double = 6.0
 
@@ -778,6 +779,7 @@ extension TalkModeRuntime {
         }
         self.defaultOutputFormat = cfg.outputFormat
         self.interruptOnSpeech = cfg.interruptOnSpeech
+        self.silenceWindow = TimeInterval(cfg.silenceTimeoutMs) / 1000
         self.apiKey = cfg.apiKey
         let hasApiKey = (cfg.apiKey?.isEmpty == false)
         let voiceLabel = (cfg.voiceId?.isEmpty == false) ? cfg.voiceId! : "none"
@@ -787,7 +789,8 @@ extension TalkModeRuntime {
                 "talk config voiceId=\(voiceLabel, privacy: .public) " +
                     "modelId=\(modelLabel, privacy: .public) " +
                     "apiKey=\(hasApiKey, privacy: .public) " +
-                    "interrupt=\(cfg.interruptOnSpeech, privacy: .public)")
+                    "interrupt=\(cfg.interruptOnSpeech, privacy: .public) " +
+                    "silenceTimeoutMs=\(cfg.silenceTimeoutMs, privacy: .public)")
     }
 
     private struct TalkRuntimeConfig {
@@ -796,6 +799,7 @@ extension TalkModeRuntime {
         let modelId: String?
         let outputFormat: String?
         let interruptOnSpeech: Bool
+        let silenceTimeoutMs: Int
         let apiKey: String?
     }
 
@@ -875,6 +879,21 @@ extension TalkModeRuntime {
             normalizedPayload: false)
     }
 
+    static func resolvedSilenceTimeoutMs(_ talk: [String: AnyCodable]?) -> Int {
+        if let timeout = talk?["silenceTimeoutMs"]?.intValue, timeout > 0 {
+            return timeout
+        }
+        if
+            let timeout = talk?["silenceTimeoutMs"]?.doubleValue,
+            timeout > 0,
+            timeout.rounded(.towardZero) == timeout,
+            timeout <= Double(Int.max)
+        {
+            return Int(timeout)
+        }
+        return Self.defaultSilenceTimeoutMs
+    }
+
     private func fetchTalkConfig() async -> TalkRuntimeConfig {
         let env = ProcessInfo.processInfo.environment
         let envVoice = env["ELEVENLABS_VOICE_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -890,6 +909,7 @@ extension TalkModeRuntime {
             let selection = Self.selectTalkProviderConfig(talk)
             let activeProvider = selection?.provider ?? Self.defaultTalkProvider
             let activeConfig = selection?.config
+            let silenceTimeoutMs = Self.resolvedSilenceTimeoutMs(talk)
             let ui = snap.config?["ui"]?.dictionaryValue
             let rawSeam = ui?["seamColor"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             await MainActor.run {
@@ -934,6 +954,7 @@ extension TalkModeRuntime {
                 modelId: resolvedModel,
                 outputFormat: outputFormat,
                 interruptOnSpeech: interrupt ?? true,
+                silenceTimeoutMs: silenceTimeoutMs,
                 apiKey: resolvedApiKey)
         } catch {
             let resolvedVoice =
@@ -946,6 +967,7 @@ extension TalkModeRuntime {
                 modelId: Self.defaultModelIdFallback,
                 outputFormat: nil,
                 interruptOnSpeech: true,
+                silenceTimeoutMs: Self.defaultSilenceTimeoutMs,
                 apiKey: resolvedApiKey)
         }
     }

--- a/apps/macos/Tests/RemoteClawIPCTests/TalkModeConfigParsingTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/TalkModeConfigParsingTests.swift
@@ -33,4 +33,24 @@ import Testing
         #expect(selection?.config["voiceId"]?.stringValue == "voice-legacy")
         #expect(selection?.config["apiKey"]?.stringValue == "legacy-key")
     }
+
+    @Test func readsConfiguredSilenceTimeoutMs() {
+        let talk: [String: AnyCodable] = [
+            "silenceTimeoutMs": AnyCodable(1500),
+        ]
+
+        #expect(TalkModeRuntime.resolvedSilenceTimeoutMs(talk) == 1500)
+    }
+
+    @Test func defaultsSilenceTimeoutMsWhenMissing() {
+        #expect(TalkModeRuntime.resolvedSilenceTimeoutMs(nil) == 700)
+    }
+
+    @Test func defaultsSilenceTimeoutMsWhenInvalid() {
+        let talk: [String: AnyCodable] = [
+            "silenceTimeoutMs": AnyCodable(0),
+        ]
+
+        #expect(TalkModeRuntime.resolvedSilenceTimeoutMs(talk) == 700)
+    }
 }

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1338,6 +1338,7 @@ Defaults for Talk mode (macOS/iOS/Android).
     modelId: "eleven_v3",
     outputFormat: "mp3_44100_128",
     apiKey: "elevenlabs_api_key",
+    silenceTimeoutMs: 1500,
     interruptOnSpeech: true,
   },
 }
@@ -1346,6 +1347,7 @@ Defaults for Talk mode (macOS/iOS/Android).
 - Voice IDs fall back to `ELEVENLABS_VOICE_ID` or `SAG_VOICE_ID`.
 - `apiKey` falls back to `ELEVENLABS_API_KEY`.
 - `voiceAliases` lets Talk directives use friendly names.
+- `silenceTimeoutMs` controls how long Talk mode waits after user silence before it sends the transcript. Unset keeps the platform default pause window (`700` ms on macOS and Android, `900` ms on iOS).
 
 ---
 

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -56,6 +56,7 @@ Supported keys:
     modelId: "eleven_v3",
     outputFormat: "mp3_44100_128",
     apiKey: "elevenlabs_api_key",
+    silenceTimeoutMs: 1500,
     interruptOnSpeech: true,
   },
 }
@@ -64,6 +65,7 @@ Supported keys:
 Defaults:
 
 - `interruptOnSpeech`: true
+- `silenceTimeoutMs`: when unset, Talk keeps the platform default pause window before sending the transcript (`700` ms on macOS and Android, `900` ms on iOS)
 - `voiceId`: falls back to `ELEVENLABS_VOICE_ID` / `SAG_VOICE_ID` (or first ElevenLabs voice when API key is available)
 - `modelId`: defaults to `eleven_v3` when unset
 - `apiKey`: falls back to `ELEVENLABS_API_KEY` (or gateway shell profile if available)

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -234,6 +234,7 @@ const TARGET_KEYS = [
   "talk.modelId",
   "talk.outputFormat",
   "talk.interruptOnSpeech",
+  "talk.silenceTimeoutMs",
   "meta",
   "env",
   "env.shellEnv",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -153,6 +153,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Use this legacy ElevenLabs API key for Talk mode only during migration, and keep secrets in env-backed storage. Prefer talk.providers.elevenlabs.apiKey (fallback: ELEVENLABS_API_KEY).",
   "talk.interruptOnSpeech":
     "If true (default), stop assistant speech when the user starts speaking in Talk mode. Keep enabled for conversational turn-taking.",
+  "talk.silenceTimeoutMs":
+    "Milliseconds of user silence before Talk mode finalizes and sends the current transcript. Leave unset to keep the platform default pause window (700 ms on macOS and Android, 900 ms on iOS).",
   agents:
     "Agent runtime configuration root covering defaults and explicit agent entries used for routing and execution context. Keep this section explicit so model/tool behavior stays predictable across multi-agent workflows.",
   "agents.defaults":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -419,6 +419,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "talk.modelId": "Talk Model ID",
   "talk.outputFormat": "Talk Output Format",
   "talk.interruptOnSpeech": "Talk Interrupt on Speech",
+  "talk.silenceTimeoutMs": "Talk Silence Timeout (ms)",
   messages: "Messages",
   "messages.messagePrefix": "Inbound Message Prefix",
   "messages.responsePrefix": "Outbound Response Prefix",

--- a/src/config/talk.normalize.test.ts
+++ b/src/config/talk.normalize.test.ts
@@ -55,6 +55,7 @@ describe("talk normalization", () => {
       outputFormat: "pcm_44100",
       apiKey: "secret-key",
       interruptOnSpeech: false,
+      silenceTimeoutMs: 1500,
     });
 
     expect(normalized).toEqual({
@@ -74,6 +75,7 @@ describe("talk normalization", () => {
       outputFormat: "pcm_44100",
       apiKey: "secret-key",
       interruptOnSpeech: false,
+      silenceTimeoutMs: 1500,
     });
   });
 

--- a/src/config/talk.ts
+++ b/src/config/talk.ts
@@ -43,6 +43,13 @@ function normalizeVoiceAliases(value: unknown): Record<string, string> | undefin
   return Object.keys(aliases).length > 0 ? aliases : undefined;
 }
 
+function normalizeSilenceTimeoutMs(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    return undefined;
+  }
+  return value;
+}
+
 function normalizeTalkProviderConfig(value: unknown): TalkProviderConfig | undefined {
   if (!isPlainObject(value)) {
     return undefined;
@@ -113,6 +120,10 @@ function normalizedLegacyTalkFields(source: Record<string, unknown>): Partial<Ta
   const apiKey = normalizeString(source.apiKey);
   if (apiKey) {
     legacy.apiKey = apiKey;
+  }
+  const silenceTimeoutMs = normalizeSilenceTimeoutMs(source.silenceTimeoutMs);
+  if (silenceTimeoutMs !== undefined) {
+    legacy.silenceTimeoutMs = silenceTimeoutMs;
   }
   return legacy;
 }
@@ -258,6 +269,9 @@ export function buildTalkConfigResponse(value: unknown): TalkConfigResponse | un
   const payload: TalkConfigResponse = {};
   if (typeof normalized.interruptOnSpeech === "boolean") {
     payload.interruptOnSpeech = normalized.interruptOnSpeech;
+  }
+  if (typeof normalized.silenceTimeoutMs === "number") {
+    payload.silenceTimeoutMs = normalized.silenceTimeoutMs;
   }
   if (normalized.providers && Object.keys(normalized.providers).length > 0) {
     payload.providers = normalized.providers;

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -75,6 +75,8 @@ export type TalkConfig = {
   providers?: Record<string, TalkProviderConfig>;
   /** Stop speaking when user starts talking (default: true). */
   interruptOnSpeech?: boolean;
+  /** Milliseconds of user silence before Talk mode sends the transcript after a pause. */
+  silenceTimeoutMs?: number;
 
   /**
    * Legacy ElevenLabs compatibility fields.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -69,6 +69,7 @@ const TalkSchema = z
     outputFormat: z.string().optional(),
     apiKey: z.string().optional().register(sensitive),
     interruptOnSpeech: z.boolean().optional(),
+    silenceTimeoutMs: z.number().int().positive().optional(),
   })
   .strict()
   .superRefine((talk, ctx) => {

--- a/src/gateway/protocol/schema/channels.ts
+++ b/src/gateway/protocol/schema/channels.ts
@@ -51,6 +51,7 @@ export const TalkConfigResultSchema = Type.Object(
               outputFormat: Type.Optional(Type.String()),
               apiKey: Type.Optional(Type.String()),
               interruptOnSpeech: Type.Optional(Type.Boolean()),
+              silenceTimeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
             },
             { additionalProperties: false },
           ),

--- a/src/gateway/server.talk-config.test.ts
+++ b/src/gateway/server.talk-config.test.ts
@@ -56,7 +56,11 @@ async function connectOperator(ws: GatewaySocket, scopes: string[]) {
   });
 }
 
-async function writeTalkConfig(config: { apiKey?: string; voiceId?: string }) {
+async function writeTalkConfig(config: {
+  apiKey?: string;
+  voiceId?: string;
+  silenceTimeoutMs?: number;
+}) {
   const { writeConfigFile } = await import("../config/config.js");
   await writeConfigFile({ talk: config });
 }
@@ -68,6 +72,7 @@ describe("gateway talk.config", () => {
       talk: {
         voiceId: "voice-123",
         apiKey: "secret-key-abc",
+        silenceTimeoutMs: 1500,
       },
       session: {
         mainKey: "main-test",
@@ -92,6 +97,7 @@ describe("gateway talk.config", () => {
             };
             apiKey?: string;
             voiceId?: string;
+            silenceTimeoutMs?: number;
           };
         };
       }>(ws, "talk.config", {});
@@ -106,6 +112,7 @@ describe("gateway talk.config", () => {
       expect(res.payload?.config?.talk?.resolved?.config?.apiKey).toBe("__REMOTECLAW_REDACTED__");
       expect(res.payload?.config?.talk?.voiceId).toBe("voice-123");
       expect(res.payload?.config?.talk?.apiKey).toBe("__REMOTECLAW_REDACTED__");
+      expect(res.payload?.config?.talk?.silenceTimeoutMs).toBe(1500);
     });
   });
 


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`6ff7e8f42`](https://github.com/openclaw/openclaw/commit/6ff7e8f42ee9c8efb7f38eaf73e70a9dead4ca98)
- **Author**: [danodoesdesign](https://github.com/danodoesdesign)
- **Tier**: AUTO-PARTIAL (resolved: discarded gutted files)

## Summary

Adds configurable `silenceTimeoutMs` to Talk mode config, allowing users to control
how long silence is tolerated before the transcript is finalized. Platform defaults:
700ms (macOS/Android), 900ms (iOS).

## Adaptation

- Discarded Android test file (path deleted in fork)
- Resolved rebrand conflicts (OPENCLAW → REMOTECLAW sentinel names)
- Added `silenceTimeoutMs` to fork's extracted `TalkSchema` (upstream had inline schema)
- Preserved fork's provider-scoped apiKey logic in Android TalkModeManager
- Kept fork's removal of PCM format rejection tests in iOS

Cherry-picked from openclaw/openclaw per [#902](https://github.com/remoteclaw/remoteclaw/issues/902).