### PR TITLE
Cherry-pick 0af3118d0: fix: harden talk silence timeout parsing

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
@@ -121,7 +121,9 @@ class TalkModeManager(
     }
 
     internal fun resolvedSilenceTimeoutMs(talk: JsonObject?): Long {
-      val timeout = talk?.get("silenceTimeoutMs").asDoubleOrNull() ?: return defaultSilenceTimeoutMs
+      val primitive = talk?.get("silenceTimeoutMs") as? JsonPrimitive ?: return defaultSilenceTimeoutMs
+      if (primitive.isString) return defaultSilenceTimeoutMs
+      val timeout = primitive.content.toDoubleOrNull() ?: return defaultSilenceTimeoutMs
       if (timeout <= 0 || timeout % 1.0 != 0.0 || timeout > Long.MAX_VALUE.toDouble()) {
         return defaultSilenceTimeoutMs
       }

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -78,7 +78,7 @@ final class TalkModeManager: NSObject {
 
     private var gateway: GatewayNodeSession?
     private var gatewayConnected = false
-    private var silenceWindow: TimeInterval = TimeInterval(Self.defaultSilenceTimeoutMs) / 1000
+    private var silenceWindow: TimeInterval = TimeInterval(TalkModeManager.defaultSilenceTimeoutMs) / 1000
     private var lastAudioActivity: Date?
     private var noiseFloorSamples: [Double] = []
     private var noiseFloor: Double?
@@ -1926,6 +1926,9 @@ extension TalkModeManager {
             where timeout > 0 && timeout.rounded(.towardZero) == timeout && timeout <= Double(Int.max):
             return Int(timeout)
         case let timeout as NSNumber:
+            if CFGetTypeID(timeout) == CFBooleanGetTypeID() {
+                return Self.defaultSilenceTimeoutMs
+            }
             let value = timeout.doubleValue
             if value > 0 && value.rounded(.towardZero) == value && value <= Double(Int.max) {
                 return Int(value)

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -48,4 +48,12 @@ import Testing
 
         #expect(TalkModeManager.resolvedSilenceTimeoutMs(talk) == 900)
     }
+
+    @Test func defaultsSilenceTimeoutMsWhenBool() {
+        let talk: [String: Any] = [
+            "silenceTimeoutMs": true,
+        ]
+
+        #expect(TalkModeManager.resolvedSilenceTimeoutMs(talk) == 900)
+    }
 }


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`0af3118d0`](https://github.com/openclaw/openclaw/commit/0af3118d08f3078dec3c2c43c14488120088d275)
- **Author**: [steipete](https://github.com/steipete) (thanks [danodoesdesign](https://github.com/danodoesdesign))
- **Tier**: AUTO-PICK

## Summary

Hardens silence timeout parsing to handle edge cases (negative values, non-integer values) gracefully across Android, iOS platforms.

## Adaptation

- Discarded Android test file (path deleted in fork)
- Resolved .secrets.baseline conflict (took ours)

Depends on #1273.
Cherry-picked from openclaw/openclaw per [#902](https://github.com/remoteclaw/remoteclaw/issues/902).