### PR TITLE
Cherry-pick b4c895041: refactor: centralize talk silence timeout defaults

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkDefaults.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkDefaults.kt
@@ -1,0 +1,5 @@
+package org.remoteclaw.android.voice
+
+internal object TalkDefaults {
+  const val defaultSilenceTimeoutMs = 700L
+}

--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
@@ -55,7 +55,6 @@ class TalkModeManager(
     private const val defaultModelIdFallback = "eleven_v3"
     private const val defaultOutputFormatFallback = "pcm_24000"
     private const val defaultTalkProvider = "elevenlabs"
-    private const val defaultSilenceTimeoutMs = 700L
     private const val listenWatchdogMs = 12_000L
     private const val chatFinalWaitWithSubscribeMs = 45_000L
     private const val chatFinalWaitWithoutSubscribeMs = 6_000L
@@ -121,11 +120,12 @@ class TalkModeManager(
     }
 
     internal fun resolvedSilenceTimeoutMs(talk: JsonObject?): Long {
-      val primitive = talk?.get("silenceTimeoutMs") as? JsonPrimitive ?: return defaultSilenceTimeoutMs
-      if (primitive.isString) return defaultSilenceTimeoutMs
-      val timeout = primitive.content.toDoubleOrNull() ?: return defaultSilenceTimeoutMs
+      val fallback = TalkDefaults.defaultSilenceTimeoutMs
+      val primitive = talk?.get("silenceTimeoutMs") as? JsonPrimitive ?: return fallback
+      if (primitive.isString) return fallback
+      val timeout = primitive.content.toDoubleOrNull() ?: return fallback
       if (timeout <= 0 || timeout % 1.0 != 0.0 || timeout > Long.MAX_VALUE.toDouble()) {
-        return defaultSilenceTimeoutMs
+        return fallback
       }
       return timeout.toLong()
     }
@@ -158,7 +158,7 @@ class TalkModeManager(
   private var listeningMode = false
 
   private var silenceJob: Job? = null
-  private var silenceWindowMs = defaultSilenceTimeoutMs
+  private var silenceWindowMs = TalkDefaults.defaultSilenceTimeoutMs
   private var lastTranscript: String = ""
   private var lastHeardAtMs: Long? = null
   private var lastSpokenText: String? = null
@@ -942,7 +942,7 @@ class TalkModeManager(
         Log.d(tag, "talk config provider=elevenlabs")
       }
     } catch (_: Throwable) {
-      silenceWindowMs = defaultSilenceTimeoutMs
+      silenceWindowMs = TalkDefaults.defaultSilenceTimeoutMs
       defaultVoiceId = envVoice?.takeIf { it.isNotEmpty() } ?: sagVoice?.takeIf { it.isNotEmpty() }
       defaultModelId = defaultModelIdFallback
       if (!modelOverrideActive) currentModelId = defaultModelId

--- a/apps/android/app/src/test/java/org/remoteclaw/android/voice/TalkModeConfigParsingTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/voice/TalkModeConfigParsingTest.kt
@@ -130,4 +130,30 @@ class TalkModeConfigParsingTest {
     assertEquals("voice-legacy", selection?.config?.get("voiceId")?.jsonPrimitive?.content)
     assertEquals("legacy-key", selection?.config?.get("apiKey")?.jsonPrimitive?.content)
   }
+
+  @Test
+  fun readsConfiguredSilenceTimeoutMs() {
+    val talk = buildJsonObject { put("silenceTimeoutMs", 1500) }
+
+    assertEquals(1500L, TalkModeManager.resolvedSilenceTimeoutMs(talk))
+  }
+
+  @Test
+  fun defaultsSilenceTimeoutMsWhenMissing() {
+    assertEquals(TalkDefaults.defaultSilenceTimeoutMs, TalkModeManager.resolvedSilenceTimeoutMs(null))
+  }
+
+  @Test
+  fun defaultsSilenceTimeoutMsWhenInvalid() {
+    val talk = buildJsonObject { put("silenceTimeoutMs", 0) }
+
+    assertEquals(TalkDefaults.defaultSilenceTimeoutMs, TalkModeManager.resolvedSilenceTimeoutMs(talk))
+  }
+
+  @Test
+  fun defaultsSilenceTimeoutMsWhenString() {
+    val talk = buildJsonObject { put("silenceTimeoutMs", "1500") }
+
+    assertEquals(TalkDefaults.defaultSilenceTimeoutMs, TalkModeManager.resolvedSilenceTimeoutMs(talk))
+  }
 }

--- a/apps/ios/Sources/Voice/TalkDefaults.swift
+++ b/apps/ios/Sources/Voice/TalkDefaults.swift
@@ -1,0 +1,3 @@
+enum TalkDefaults {
+    static let silenceTimeoutMs = 900
+}

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -17,7 +17,7 @@ final class TalkModeManager: NSObject {
     private typealias SpeechRequest = SFSpeechAudioBufferRecognitionRequest
     private static let defaultModelIdFallback = "eleven_v3"
     private static let defaultTalkProvider = "elevenlabs"
-    private static let defaultSilenceTimeoutMs = 900
+    private static let defaultSilenceTimeoutMs = TalkDefaults.silenceTimeoutMs
     private static let redactedConfigSentinel = "__REMOTECLAW_REDACTED__"
     var isEnabled: Bool = false
     var isListening: Bool = false

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -42,7 +42,7 @@ import Testing
     }
 
     @Test func defaultsSilenceTimeoutMsWhenMissing() {
-        #expect(TalkModeManager.resolvedSilenceTimeoutMs(nil) == 900)
+        #expect(TalkModeManager.resolvedSilenceTimeoutMs(nil) == TalkDefaults.silenceTimeoutMs)
     }
 
     @Test func defaultsSilenceTimeoutMsWhenInvalid() {
@@ -50,7 +50,7 @@ import Testing
             "silenceTimeoutMs": 0,
         ]
 
-        #expect(TalkModeManager.resolvedSilenceTimeoutMs(TalkConfigParsing.bridgeFoundationDictionary(talk)) == 900)
+        #expect(TalkModeManager.resolvedSilenceTimeoutMs(TalkConfigParsing.bridgeFoundationDictionary(talk)) == TalkDefaults.silenceTimeoutMs)
     }
 
     @Test func defaultsSilenceTimeoutMsWhenBool() {
@@ -58,6 +58,6 @@ import Testing
             "silenceTimeoutMs": true,
         ]
 
-        #expect(TalkModeManager.resolvedSilenceTimeoutMs(TalkConfigParsing.bridgeFoundationDictionary(talk)) == 900)
+        #expect(TalkModeManager.resolvedSilenceTimeoutMs(TalkConfigParsing.bridgeFoundationDictionary(talk)) == TalkDefaults.silenceTimeoutMs)
     }
 }

--- a/apps/macos/Sources/RemoteClaw/TalkDefaults.swift
+++ b/apps/macos/Sources/RemoteClaw/TalkDefaults.swift
@@ -1,0 +1,3 @@
+enum TalkDefaults {
+    static let silenceTimeoutMs = 700
+}

--- a/apps/macos/Sources/RemoteClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/RemoteClaw/TalkModeRuntime.swift
@@ -12,7 +12,7 @@ actor TalkModeRuntime {
     private let ttsLogger = Logger(subsystem: "org.remoteclaw", category: "talk.tts")
     private static let defaultModelIdFallback = "eleven_v3"
     private static let defaultTalkProvider = "elevenlabs"
-    private static let defaultSilenceTimeoutMs = 700
+    private static let defaultSilenceTimeoutMs = TalkDefaults.silenceTimeoutMs
 
     private final class RMSMeter: @unchecked Sendable {
         private let lock = NSLock()

--- a/apps/macos/Tests/RemoteClawIPCTests/TalkModeConfigParsingTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/TalkModeConfigParsingTests.swift
@@ -34,7 +34,7 @@ import Testing
         #expect(selection?.config["apiKey"]?.stringValue == "legacy-key")
     }
 
-    @Test func readsConfiguredSilenceTimeoutMs() {
+    @Test func `reads configured silence timeout ms`() {
         let talk: [String: AnyCodable] = [
             "silenceTimeoutMs": AnyCodable(1500),
         ]
@@ -42,15 +42,15 @@ import Testing
         #expect(TalkModeRuntime.resolvedSilenceTimeoutMs(talk) == 1500)
     }
 
-    @Test func defaultsSilenceTimeoutMsWhenMissing() {
-        #expect(TalkModeRuntime.resolvedSilenceTimeoutMs(nil) == 700)
+    @Test func `defaults silence timeout ms when missing`() {
+        #expect(TalkModeRuntime.resolvedSilenceTimeoutMs(nil) == TalkDefaults.silenceTimeoutMs)
     }
 
-    @Test func defaultsSilenceTimeoutMsWhenInvalid() {
+    @Test func `defaults silence timeout ms when invalid`() {
         let talk: [String: AnyCodable] = [
             "silenceTimeoutMs": AnyCodable(0),
         ]
 
-        #expect(TalkModeRuntime.resolvedSilenceTimeoutMs(talk) == 700)
+        #expect(TalkModeRuntime.resolvedSilenceTimeoutMs(talk) == TalkDefaults.silenceTimeoutMs)
     }
 }

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1347,7 +1347,7 @@ Defaults for Talk mode (macOS/iOS/Android).
 - Voice IDs fall back to `ELEVENLABS_VOICE_ID` or `SAG_VOICE_ID`.
 - `apiKey` falls back to `ELEVENLABS_API_KEY`.
 - `voiceAliases` lets Talk directives use friendly names.
-- `silenceTimeoutMs` controls how long Talk mode waits after user silence before it sends the transcript. Unset keeps the platform default pause window (`700` ms on macOS and Android, `900` ms on iOS).
+- `silenceTimeoutMs` controls how long Talk mode waits after user silence before it sends the transcript. Unset keeps the platform default pause window (`700 ms on macOS and Android, 900 ms on iOS`).
 
 ---
 

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -65,7 +65,7 @@ Supported keys:
 Defaults:
 
 - `interruptOnSpeech`: true
-- `silenceTimeoutMs`: when unset, Talk keeps the platform default pause window before sending the transcript (`700` ms on macOS and Android, `900` ms on iOS)
+- `silenceTimeoutMs`: when unset, Talk keeps the platform default pause window before sending the transcript (`700 ms on macOS and Android, 900 ms on iOS`)
 - `voiceId`: falls back to `ELEVENLABS_VOICE_ID` / `SAG_VOICE_ID` (or first ElevenLabs voice when API key is available)
 - `modelId`: defaults to `eleven_v3` when unset
 - `apiKey`: falls back to `ELEVENLABS_API_KEY` (or gateway shell profile if available)

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1,4 +1,5 @@
 import { IRC_FIELD_HELP } from "./schema.irc.js";
+import { describeTalkSilenceTimeoutDefaults } from "./talk-defaults.js";
 
 export const FIELD_HELP: Record<string, string> = {
   meta: "Metadata fields automatically maintained by RemoteClaw to record write/version history for this config file. Keep these values system-managed and avoid manual edits unless debugging migration history.",
@@ -153,8 +154,7 @@ export const FIELD_HELP: Record<string, string> = {
     "Use this legacy ElevenLabs API key for Talk mode only during migration, and keep secrets in env-backed storage. Prefer talk.providers.elevenlabs.apiKey (fallback: ELEVENLABS_API_KEY).",
   "talk.interruptOnSpeech":
     "If true (default), stop assistant speech when the user starts speaking in Talk mode. Keep enabled for conversational turn-taking.",
-  "talk.silenceTimeoutMs":
-    "Milliseconds of user silence before Talk mode finalizes and sends the current transcript. Leave unset to keep the platform default pause window (700 ms on macOS and Android, 900 ms on iOS).",
+  "talk.silenceTimeoutMs": `Milliseconds of user silence before Talk mode finalizes and sends the current transcript. Leave unset to keep the platform default pause window (${describeTalkSilenceTimeoutDefaults()}).`,
   agents:
     "Agent runtime configuration root covering defaults and explicit agent entries used for routing and execution context. Keep this section explicit so model/tool behavior stays predictable across multi-agent workflows.",
   "agents.defaults":

--- a/src/config/talk-defaults.test.ts
+++ b/src/config/talk-defaults.test.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { FIELD_HELP } from "./schema.help.js";
+import {
+  describeTalkSilenceTimeoutDefaults,
+  TALK_SILENCE_TIMEOUT_MS_BY_PLATFORM,
+} from "./talk-defaults.js";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+describe("talk silence timeout defaults", () => {
+  it("keeps help text and docs aligned with the policy", () => {
+    const defaultsDescription = describeTalkSilenceTimeoutDefaults();
+
+    expect(FIELD_HELP["talk.silenceTimeoutMs"]).toContain(defaultsDescription);
+    expect(readRepoFile("docs/gateway/configuration-reference.md")).toContain(defaultsDescription);
+    expect(readRepoFile("docs/nodes/talk.md")).toContain(defaultsDescription);
+  });
+
+  it("matches the Apple and Android runtime constants", () => {
+    const macDefaults = readRepoFile("apps/macos/Sources/RemoteClaw/TalkDefaults.swift");
+    const iosDefaults = readRepoFile("apps/ios/Sources/Voice/TalkDefaults.swift");
+    const androidDefaults = readRepoFile(
+      "apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkDefaults.kt",
+    );
+
+    expect(macDefaults).toContain(
+      `static let silenceTimeoutMs = ${TALK_SILENCE_TIMEOUT_MS_BY_PLATFORM.macos}`,
+    );
+    expect(iosDefaults).toContain(
+      `static let silenceTimeoutMs = ${TALK_SILENCE_TIMEOUT_MS_BY_PLATFORM.ios}`,
+    );
+    expect(androidDefaults).toContain(
+      `const val defaultSilenceTimeoutMs = ${TALK_SILENCE_TIMEOUT_MS_BY_PLATFORM.android}L`,
+    );
+  });
+});

--- a/src/config/talk-defaults.ts
+++ b/src/config/talk-defaults.ts
@@ -1,0 +1,11 @@
+export const TALK_SILENCE_TIMEOUT_MS_BY_PLATFORM = {
+  macos: 700,
+  android: 700,
+  ios: 900,
+} as const;
+
+export function describeTalkSilenceTimeoutDefaults(): string {
+  const macos = TALK_SILENCE_TIMEOUT_MS_BY_PLATFORM.macos;
+  const ios = TALK_SILENCE_TIMEOUT_MS_BY_PLATFORM.ios;
+  return `${macos} ms on macOS and Android, ${ios} ms on iOS`;
+}


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`b4c895041`](https://github.com/openclaw/openclaw/commit/b4c8950417626fb1076d1dc06f2c7fe3bf1d1e0f)
- **Author**: [steipete](https://github.com/steipete)
- **Tier**: AUTO-PARTIAL

## Summary
Centralizes talk silence timeout defaults into dedicated `TalkDefaults` constants on each platform (Android, iOS, macOS) and a new `src/config/talk-defaults.ts` module for the gateway. Adds a cross-platform consistency test that verifies help text, docs, and native constants all agree on the default values.

## Adaptation
- Rebranded Android `TalkDefaults.kt` package from `ai.openclaw.app.voice` to `org.remoteclaw.android.voice`
- New file placed at rebranded macOS path (`Sources/RemoteClaw/` instead of `Sources/OpenClaw/`)
- Updated test file paths in `talk-defaults.test.ts` to use rebranded directory structure
- Resolved conflict in `schema.help.ts` to accept upstream's template literal while preserving fork's gutted ACP entries
- Preserved fork's `__REMOTECLAW_REDACTED__` sentinel in iOS `TalkModeManager.swift`
- Added silence timeout tests to Android test file (not present in fork HEAD, upstream semantic change applied)

Depends on #1275.
Cherry-picked from openclaw/openclaw per [#902](https://github.com/remoteclaw/remoteclaw/issues/902).