### PR TITLE
Cherry-pick da3cccb21: test: decouple ios talk parsing coverage

### DIFF
--- a/apps/ios/Tests/Logic/TalkConfigParsingTests.swift
+++ b/apps/ios/Tests/Logic/TalkConfigParsingTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import RemoteClawKit
+import Testing
+
+private let iOSSilenceTimeoutMs = 900
+
+@Suite struct TalkConfigParsingTests {
+    @Test func prefersNormalizedTalkProviderPayload() {
+        let talk: [String: Any] = [
+            "provider": "elevenlabs",
+            "providers": [
+                "elevenlabs": [
+                    "voiceId": "voice-normalized",
+                ],
+            ],
+            "voiceId": "voice-legacy",
+        ]
+
+        let selection = TalkConfigParsing.selectProviderConfig(
+            TalkConfigParsing.bridgeFoundationDictionary(talk),
+            defaultProvider: "elevenlabs",
+            allowLegacyFallback: false)
+        #expect(selection?.provider == "elevenlabs")
+        #expect(selection?.config["voiceId"]?.stringValue == "voice-normalized")
+    }
+
+    @Test func ignoresLegacyTalkFieldsWhenNormalizedPayloadMissing() {
+        let talk: [String: Any] = [
+            "voiceId": "voice-legacy",
+            "apiKey": "legacy-key", // pragma: allowlist secret
+        ]
+
+        let selection = TalkConfigParsing.selectProviderConfig(
+            TalkConfigParsing.bridgeFoundationDictionary(talk),
+            defaultProvider: "elevenlabs",
+            allowLegacyFallback: false)
+        #expect(selection == nil)
+    }
+
+    @Test func readsConfiguredSilenceTimeoutMs() {
+        let talk: [String: Any] = [
+            "silenceTimeoutMs": 1500,
+        ]
+
+        #expect(
+            TalkConfigParsing.resolvedSilenceTimeoutMs(
+                TalkConfigParsing.bridgeFoundationDictionary(talk),
+                fallback: iOSSilenceTimeoutMs) == 1500)
+    }
+
+    @Test func defaultsSilenceTimeoutMsWhenMissing() {
+        #expect(TalkConfigParsing.resolvedSilenceTimeoutMs(nil, fallback: iOSSilenceTimeoutMs) == iOSSilenceTimeoutMs)
+    }
+
+    @Test func defaultsSilenceTimeoutMsWhenInvalid() {
+        let talk: [String: Any] = [
+            "silenceTimeoutMs": 0,
+        ]
+
+        #expect(
+            TalkConfigParsing.resolvedSilenceTimeoutMs(
+                TalkConfigParsing.bridgeFoundationDictionary(talk),
+                fallback: iOSSilenceTimeoutMs) == iOSSilenceTimeoutMs)
+    }
+
+    @Test func defaultsSilenceTimeoutMsWhenBool() {
+        let talk: [String: Any] = [
+            "silenceTimeoutMs": true,
+        ]
+
+        #expect(
+            TalkConfigParsing.resolvedSilenceTimeoutMs(
+                TalkConfigParsing.bridgeFoundationDictionary(talk),
+                fallback: iOSSilenceTimeoutMs) == iOSSilenceTimeoutMs)
+    }
+}

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -1,63 +1,24 @@
 import Foundation
-import RemoteClawKit
 import Testing
 @testable import RemoteClaw
 
 @MainActor
-@Suite struct TalkModeConfigParsingTests {
-    @Test func prefersNormalizedTalkProviderPayload() {
-        let talk: [String: Any] = [
-            "provider": "elevenlabs",
-            "providers": [
-                "elevenlabs": [
-                    "voiceId": "voice-normalized",
-                ],
-            ],
-            "voiceId": "voice-legacy",
-        ]
-
-        let selection = TalkModeManager.selectTalkProviderConfig(
-            TalkConfigParsing.bridgeFoundationDictionary(talk))
-        #expect(selection?.provider == "elevenlabs")
-        #expect(selection?.config["voiceId"]?.stringValue == "voice-normalized")
+@Suite struct TalkModeManagerTests {
+    @Test func detectsPCMFormatRejectionFromElevenLabsError() {
+        let error = NSError(
+            domain: "ElevenLabsTTS",
+            code: 403,
+            userInfo: [
+                NSLocalizedDescriptionKey: "ElevenLabs failed: 403 subscription_required output_format=pcm_44100",
+            ])
+        #expect(TalkModeManager._test_isPCMFormatRejectedByAPI(error))
     }
 
-    @Test func ignoresLegacyTalkFieldsWhenNormalizedPayloadMissing() {
-        let talk: [String: Any] = [
-            "voiceId": "voice-legacy",
-            "apiKey": "legacy-key",
-        ]
-
-        let selection = TalkModeManager.selectTalkProviderConfig(
-            TalkConfigParsing.bridgeFoundationDictionary(talk))
-        #expect(selection == nil)
-    }
-
-    @Test func readsConfiguredSilenceTimeoutMs() {
-        let talk: [String: Any] = [
-            "silenceTimeoutMs": 1500,
-        ]
-
-        #expect(TalkModeManager.resolvedSilenceTimeoutMs(TalkConfigParsing.bridgeFoundationDictionary(talk)) == 1500)
-    }
-
-    @Test func defaultsSilenceTimeoutMsWhenMissing() {
-        #expect(TalkModeManager.resolvedSilenceTimeoutMs(nil) == TalkDefaults.silenceTimeoutMs)
-    }
-
-    @Test func defaultsSilenceTimeoutMsWhenInvalid() {
-        let talk: [String: Any] = [
-            "silenceTimeoutMs": 0,
-        ]
-
-        #expect(TalkModeManager.resolvedSilenceTimeoutMs(TalkConfigParsing.bridgeFoundationDictionary(talk)) == TalkDefaults.silenceTimeoutMs)
-    }
-
-    @Test func defaultsSilenceTimeoutMsWhenBool() {
-        let talk: [String: Any] = [
-            "silenceTimeoutMs": true,
-        ]
-
-        #expect(TalkModeManager.resolvedSilenceTimeoutMs(TalkConfigParsing.bridgeFoundationDictionary(talk)) == TalkDefaults.silenceTimeoutMs)
+    @Test func ignoresGenericPlaybackFailuresForPCMFormatRejection() {
+        let error = NSError(
+            domain: "StreamingAudio",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: "queue enqueue failed"])
+        #expect(TalkModeManager._test_isPCMFormatRejectedByAPI(error) == false)
     }
 }

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -24,6 +24,15 @@ schemes:
     test:
       targets:
         - RemoteClawTests
+        - RemoteClawLogicTests
+  RemoteClawLogicTests:
+    shared: true
+    build:
+      targets:
+        RemoteClawLogicTests: all
+    test:
+      targets:
+        - RemoteClawLogicTests
 
 targets:
   RemoteClaw:
@@ -111,7 +120,11 @@ targets:
         NSLocationWhenInUseUsageDescription: RemoteClaw uses your location when you allow location sharing.
         NSLocationAlwaysAndWhenInUseUsageDescription: RemoteClaw can share your location in the background when you enable Always.
         NSMicrophoneUsageDescription: RemoteClaw needs microphone access for voice wake.
+        NSMotionUsageDescription: RemoteClaw may use motion data to support device-aware interactions and automations.
+        NSPhotoLibraryUsageDescription: RemoteClaw needs photo library access when you choose existing photos to share with your assistant.
         NSSpeechRecognitionUsageDescription: RemoteClaw uses on-device speech recognition for voice wake.
+        NSSupportsLiveActivities: true
+        ITSAppUsesNonExemptEncryption: false
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
           - UIInterfaceOrientationPortraitUpsideDown
@@ -215,6 +228,8 @@ targets:
       Release: Signing.xcconfig
     sources:
       - path: Tests
+        excludes:
+          - Logic
     dependencies:
       - target: RemoteClaw
       - package: Swabble
@@ -234,5 +249,31 @@ targets:
       path: Tests/Info.plist
       properties:
         CFBundleDisplayName: RemoteClawTests
+        CFBundleShortVersionString: "2026.2.23"
+        CFBundleVersion: "20260223"
+
+  RemoteClawLogicTests:
+    type: bundle.unit-test
+    platform: iOS
+    configFiles:
+      Debug: Signing.xcconfig
+      Release: Signing.xcconfig
+    sources:
+      - path: Tests/Logic
+    dependencies:
+      - package: RemoteClawKit
+    settings:
+      base:
+        CODE_SIGN_IDENTITY: "Apple Development"
+        CODE_SIGN_STYLE: "$(REMOTECLAW_CODE_SIGN_STYLE)"
+        DEVELOPMENT_TEAM: "$(REMOTECLAW_DEVELOPMENT_TEAM)"
+        PRODUCT_BUNDLE_IDENTIFIER: org.remoteclaw.ios.logic-tests
+        ENABLE_APP_INTENTS_METADATA_GENERATION: NO
+        SWIFT_VERSION: "6.0"
+        SWIFT_STRICT_CONCURRENCY: complete
+    info:
+      path: Tests/Info.plist
+      properties:
+        CFBundleDisplayName: RemoteClawLogicTests
         CFBundleShortVersionString: "2026.2.23"
         CFBundleVersion: "20260223"


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`da3cccb21`](https://github.com/openclaw/openclaw/commit/da3cccb21233e2298cc693ef0071dd5a687345c0)
- **Author**: [steipete](https://github.com/steipete)
- **Tier**: AUTO-PICK

## Summary
Splits iOS talk config parsing tests into a separate `Tests/Logic/TalkConfigParsingTests.swift` file that depends only on `RemoteClawKit` (no app host required). The main test file is reduced to `TalkModeManagerTests` containing only PCM format detection tests that need the app target.

Adds a new `RemoteClawLogicTests` test target and scheme in `project.yml` for the logic-only tests.

## Adaptation
- Resolved conflicts in test file to keep rebranded imports (`RemoteClawKit`, `RemoteClaw`)
- Rebranded `OpenClawKit` import to `RemoteClawKit` in new logic test file
- Rebranded `OpenClawLogicTests` target/scheme to `RemoteClawLogicTests` in `project.yml`
- Rebranded all `OPENCLAW_*` build settings to `REMOTECLAW_*` and bundle IDs to `org.remoteclaw.*`
- Preserved fork's version strings (`2026.2.23`) instead of upstream's (`2026.3.8`)
- Added upstream's new Info.plist entries (NSMotionUsageDescription, NSPhotoLibraryUsageDescription, NSSupportsLiveActivities, ITSAppUsesNonExemptEncryption) with rebranded text

Depends on #1276.
Cherry-picked from openclaw/openclaw per [#902](https://github.com/remoteclaw/remoteclaw/issues/902).