### PR TITLE
Cherry-pick 8d3d742c6: refactor: require canonical talk resolved payload

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
@@ -88,29 +88,7 @@ class TalkModeManager(
       val rawProviders = talk["providers"].asObjectOrNull()
       val hasNormalizedPayload = rawProvider != null || rawProviders != null
       if (hasNormalizedPayload) {
-        val providers =
-          rawProviders?.entries?.mapNotNull { (key, value) ->
-            val providerId = normalizeTalkProviderId(key) ?: return@mapNotNull null
-            val providerConfig = value.asObjectOrNull() ?: return@mapNotNull null
-            providerId to providerConfig
-          }?.toMap().orEmpty()
-        val explicitProviderId = normalizeTalkProviderId(rawProvider)
-        if (explicitProviderId != null) {
-          if (providers.isNotEmpty() && providers[explicitProviderId] == null) {
-            return null
-          }
-          return TalkProviderConfigSelection(
-            provider = explicitProviderId,
-            config = providers[explicitProviderId] ?: buildJsonObject {},
-            normalizedPayload = true,
-          )
-        }
-        val providerId = providers.keys.singleOrNull() ?: return null
-        return TalkProviderConfigSelection(
-          provider = providerId,
-          config = providers[providerId] ?: buildJsonObject {},
-          normalizedPayload = true,
-        )
+        return null
       }
       return TalkProviderConfigSelection(
         provider = defaultTalkProvider,
@@ -893,6 +871,9 @@ class TalkModeManager(
       val config = root?.get("config").asObjectOrNull()
       val talk = config?.get("talk").asObjectOrNull()
       val selection = selectTalkProviderConfig(talk)
+      if (talk != null && selection == null) {
+        Log.w(tag, "talk config ignored: normalized payload missing talk.resolved")
+      }
       val activeProvider = selection?.provider ?: defaultTalkProvider
       val activeConfig = selection?.config
       val sessionCfg = config?.get("session").asObjectOrNull()

--- a/apps/android/app/src/test/java/org/remoteclaw/android/voice/TalkModeConfigParsingTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/voice/TalkModeConfigParsingTest.kt
@@ -60,10 +60,7 @@ class TalkModeConfigParsingTest {
         .jsonObject
 
     val selection = TalkModeManager.selectTalkProviderConfig(talk)
-    assertNotNull(selection)
-    assertEquals("elevenlabs", selection?.provider)
-    assertTrue(selection?.normalizedPayload == true)
-    assertEquals("voice-normalized", selection?.config?.get("voiceId")?.jsonPrimitive?.content)
+    assertEquals(null, selection)
   }
 
   @Test

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -1907,7 +1907,7 @@ extension TalkModeManager {
             let selection = Self.selectTalkProviderConfig(talk)
             if talk != nil, selection == nil {
                 GatewayDiagnostics.log(
-                    "talk config ignored: legacy payload unsupported on iOS beta; expected talk.provider/providers")
+                    "talk config ignored: normalized payload missing talk.resolved")
             }
             let activeProvider = selection?.provider ?? Self.defaultTalkProvider
             let activeConfig = selection?.config

--- a/apps/ios/Tests/Logic/TalkConfigParsingTests.swift
+++ b/apps/ios/Tests/Logic/TalkConfigParsingTests.swift
@@ -5,7 +5,7 @@ import Testing
 private let iOSSilenceTimeoutMs = 900
 
 @Suite struct TalkConfigParsingTests {
-    @Test func prefersNormalizedTalkProviderPayload() {
+    @Test func rejectsNormalizedTalkProviderPayloadWithoutResolved() {
         let talk: [String: Any] = [
             "provider": "elevenlabs",
             "providers": [
@@ -20,8 +20,7 @@ private let iOSSilenceTimeoutMs = 900
             TalkConfigParsing.bridgeFoundationDictionary(talk),
             defaultProvider: "elevenlabs",
             allowLegacyFallback: false)
-        #expect(selection?.provider == "elevenlabs")
-        #expect(selection?.config["voiceId"]?.stringValue == "voice-normalized")
+        #expect(selection == nil)
     }
 
     @Test func ignoresLegacyTalkFieldsWhenNormalizedPayloadMissing() {

--- a/apps/macos/Sources/RemoteClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/RemoteClaw/TalkModeRuntime.swift
@@ -826,6 +826,9 @@ extension TalkModeRuntime {
                 timeoutMs: 8000)
             let talk = snap.config?["talk"]?.dictionaryValue
             let selection = Self.selectTalkProviderConfig(talk)
+            if talk != nil, selection == nil {
+                self.ttsLogger.info("talk config ignored: normalized payload missing talk.resolved")
+            }
             let activeProvider = selection?.provider ?? Self.defaultTalkProvider
             let activeConfig = selection?.config
             let silenceTimeoutMs = Self.resolvedSilenceTimeoutMs(talk)
@@ -865,7 +868,7 @@ extension TalkModeRuntime {
                 self.ttsLogger
                     .info("talk provider \(activeProvider, privacy: .public) unsupported; using system voice")
             } else if selection?.normalizedPayload == true {
-                self.ttsLogger.info("talk config provider elevenlabs")
+                self.ttsLogger.info("talk config provider from talk.resolved")
             }
             return TalkRuntimeConfig(
                 voiceId: resolvedVoice,

--- a/apps/macos/Tests/RemoteClawIPCTests/TalkModeConfigParsingTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/TalkModeConfigParsingTests.swift
@@ -4,7 +4,7 @@ import Testing
 @testable import RemoteClaw
 
 @Suite struct TalkModeConfigParsingTests {
-    @Test func prefersNormalizedTalkProviderPayload() {
+    @Test func rejectsNormalizedTalkProviderPayloadWithoutResolved() {
         let talk: [String: AnyCodable] = [
             "provider": AnyCodable("elevenlabs"),
             "providers": AnyCodable([
@@ -16,9 +16,7 @@ import Testing
         ]
 
         let selection = TalkModeRuntime.selectTalkProviderConfig(talk)
-        #expect(selection?.provider == "elevenlabs")
-        #expect(selection?.normalizedPayload == true)
-        #expect(selection?.config["voiceId"]?.stringValue == "voice-normalized")
+        #expect(selection == nil)
     }
 
     @Test func fallsBackToLegacyTalkFieldsWhenNormalizedPayloadMissing() {
@@ -34,7 +32,7 @@ import Testing
         #expect(selection?.config["apiKey"]?.stringValue == "legacy-key")
     }
 
-    @Test func `reads configured silence timeout ms`() {
+    @Test func readsSilenceTimeoutMs() {
         let talk: [String: AnyCodable] = [
             "silenceTimeoutMs": AnyCodable(1500),
         ]
@@ -42,11 +40,11 @@ import Testing
         #expect(TalkModeRuntime.resolvedSilenceTimeoutMs(talk) == 1500)
     }
 
-    @Test func `defaults silence timeout ms when missing`() {
+    @Test func defaultsSilenceTimeoutMsWhenMissing() {
         #expect(TalkModeRuntime.resolvedSilenceTimeoutMs(nil) == TalkDefaults.silenceTimeoutMs)
     }
 
-    @Test func `defaults silence timeout ms when invalid`() {
+    @Test func defaultsSilenceTimeoutMsWhenInvalid() {
         let talk: [String: AnyCodable] = [
             "silenceTimeoutMs": AnyCodable(0),
         ]

--- a/apps/shared/RemoteClawKit/Sources/RemoteClawKit/TalkConfigParsing.swift
+++ b/apps/shared/RemoteClawKit/Sources/RemoteClawKit/TalkConfigParsing.swift
@@ -23,19 +23,12 @@ public enum TalkConfigParsing {
         allowLegacyFallback: Bool = true,
     ) -> TalkProviderConfigSelection? {
         guard let talk else { return nil }
-        let rawProvider = talk["provider"]?.stringValue
-        let rawProviders = talk["providers"]
-        let hasNormalizedPayload = rawProvider != nil || rawProviders != nil
+        if let resolvedSelection = self.resolvedProviderConfig(talk) {
+            return resolvedSelection
+        }
+        let hasNormalizedPayload = talk["provider"] != nil || talk["providers"] != nil
         if hasNormalizedPayload {
-            let normalizedProviders = self.normalizedTalkProviders(rawProviders)
-            let providerID =
-                self.normalizedTalkProviderID(rawProvider) ??
-                normalizedProviders.keys.min() ??
-                defaultProvider
-            return TalkProviderConfigSelection(
-                provider: providerID,
-                config: normalizedProviders[providerID] ?? [:],
-                normalizedPayload: true)
+            return nil
         }
         guard allowLegacyFallback else { return nil }
         return TalkProviderConfigSelection(
@@ -68,14 +61,16 @@ public enum TalkConfigParsing {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    private static func normalizedTalkProviders(_ raw: AnyCodable?) -> [String: [String: AnyCodable]] {
-        guard let providerMap = raw?.dictionaryValue else { return [:] }
-        return providerMap.reduce(into: [String: [String: AnyCodable]]()) { acc, entry in
-            guard
-                let providerID = self.normalizedTalkProviderID(entry.key),
-                let providerConfig = entry.value.dictionaryValue
-            else { return }
-            acc[providerID] = providerConfig
-        }
+    private static func resolvedProviderConfig(
+        _ talk: [String: AnyCodable]
+    ) -> TalkProviderConfigSelection? {
+        guard
+            let resolved = talk["resolved"]?.dictionaryValue,
+            let providerID = self.normalizedTalkProviderID(resolved["provider"]?.stringValue)
+        else { return nil }
+        return TalkProviderConfigSelection(
+            provider: providerID,
+            config: resolved["config"]?.dictionaryValue ?? [:],
+            normalizedPayload: true)
     }
 }

--- a/apps/shared/RemoteClawKit/Tests/RemoteClawKitTests/TalkConfigParsingTests.swift
+++ b/apps/shared/RemoteClawKit/Tests/RemoteClawKitTests/TalkConfigParsingTests.swift
@@ -2,7 +2,29 @@ import RemoteClawKit
 import Testing
 
 struct TalkConfigParsingTests {
-    @Test func prefersNormalizedTalkProviderPayload() {
+    @Test func prefersCanonicalResolvedTalkProviderPayload() {
+        let talk: [String: AnyCodable] = [
+            "resolved": AnyCodable([
+                "provider": "elevenlabs",
+                "config": [
+                    "voiceId": "voice-resolved",
+                ],
+            ]),
+            "provider": AnyCodable("elevenlabs"),
+            "providers": AnyCodable([
+                "elevenlabs": [
+                    "voiceId": "voice-normalized",
+                ],
+            ]),
+        ]
+
+        let selection = TalkConfigParsing.selectProviderConfig(talk, defaultProvider: "elevenlabs")
+        #expect(selection?.provider == "elevenlabs")
+        #expect(selection?.normalizedPayload == true)
+        #expect(selection?.config["voiceId"]?.stringValue == "voice-resolved")
+    }
+
+    @Test func rejectsNormalizedTalkProviderPayloadWithoutResolved() {
         let talk: [String: AnyCodable] = [
             "provider": AnyCodable("elevenlabs"),
             "providers": AnyCodable([
@@ -14,9 +36,7 @@ struct TalkConfigParsingTests {
         ]
 
         let selection = TalkConfigParsing.selectProviderConfig(talk, defaultProvider: "elevenlabs")
-        #expect(selection?.provider == "elevenlabs")
-        #expect(selection?.normalizedPayload == true)
-        #expect(selection?.config["voiceId"]?.stringValue == "voice-normalized")
+        #expect(selection == nil)
     }
 
     @Test func fallsBackToLegacyTalkFieldsWhenNormalizedPayloadMissing() {


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`8d3d742c6`](https://github.com/openclaw/openclaw/commit/8d3d742c6a2f641c103c0c2b7705224b6e902802)
- **Author**: [steipete](https://github.com/steipete)
- **Tier**: AUTO-PARTIAL

## Summary
Requires a canonical `resolved` payload in talk provider config selection. Normalized payloads without a `resolved` key are now rejected (return `nil`), simplifying the selection logic. The `resolvedProviderConfig()` method takes precedence over raw normalized field parsing.

## Adaptation
- Resolved conflicts in `TalkConfigParsing.swift` to apply upstream's simplified selection logic (resolved-first, reject bare normalized)
- Removed `normalizedTalkProviders()` helper (replaced by resolved path)
- Resolved test conflicts to use upstream's renamed test functions and updated assertions
- Preserved fork's rebranded imports and `@Suite`/`@testable` annotations

Depends on #1277.
Cherry-picked from openclaw/openclaw per [#902](https://github.com/remoteclaw/remoteclaw/issues/902).