### PR TITLE
Cherry-pick 16a5f0b00: refactor: split talk gateway config loaders

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeGatewayConfig.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeGatewayConfig.kt
@@ -1,0 +1,110 @@
+package org.remoteclaw.android.voice
+
+import org.remoteclaw.android.normalizeMainKey
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+
+internal data class TalkModeGatewayConfigState(
+  val activeProvider: String,
+  val normalizedPayload: Boolean,
+  val missingResolvedPayload: Boolean,
+  val mainSessionKey: String,
+  val defaultVoiceId: String?,
+  val voiceAliases: Map<String, String>,
+  val defaultModelId: String,
+  val defaultOutputFormat: String,
+  val apiKey: String?,
+  val interruptOnSpeech: Boolean?,
+  val silenceTimeoutMs: Long,
+)
+
+internal object TalkModeGatewayConfigParser {
+  fun parse(
+    config: JsonObject?,
+    defaultProvider: String,
+    defaultModelIdFallback: String,
+    defaultOutputFormatFallback: String,
+    envVoice: String?,
+    sagVoice: String?,
+    envKey: String?,
+  ): TalkModeGatewayConfigState {
+    val talk = config?.get("talk").asObjectOrNull()
+    val selection = TalkModeManager.selectTalkProviderConfig(talk)
+    val activeProvider = selection?.provider ?: defaultProvider
+    val activeConfig = selection?.config
+    val sessionCfg = config?.get("session").asObjectOrNull()
+    val mainKey = normalizeMainKey(sessionCfg?.get("mainKey").asStringOrNull())
+    val voice = activeConfig?.get("voiceId")?.asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+    val aliases =
+      activeConfig?.get("voiceAliases").asObjectOrNull()?.entries?.mapNotNull { (key, value) ->
+        val id = value.asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+        normalizeTalkAliasKey(key).takeIf { it.isNotEmpty() }?.let { it to id }
+      }?.toMap().orEmpty()
+    val model = activeConfig?.get("modelId")?.asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+    val outputFormat =
+      activeConfig?.get("outputFormat")?.asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+    val key = activeConfig?.get("apiKey")?.asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+    val interrupt = talk?.get("interruptOnSpeech")?.asBooleanOrNull()
+    val silenceTimeoutMs = TalkModeManager.resolvedSilenceTimeoutMs(talk)
+
+    return TalkModeGatewayConfigState(
+      activeProvider = activeProvider,
+      normalizedPayload = selection?.normalizedPayload == true,
+      missingResolvedPayload = talk != null && selection == null,
+      mainSessionKey = mainKey,
+      defaultVoiceId =
+        if (activeProvider == defaultProvider) {
+          voice ?: envVoice?.takeIf { it.isNotEmpty() } ?: sagVoice?.takeIf { it.isNotEmpty() }
+        } else {
+          voice
+        },
+      voiceAliases = aliases,
+      defaultModelId = model ?: defaultModelIdFallback,
+      defaultOutputFormat = outputFormat ?: defaultOutputFormatFallback,
+      apiKey = key ?: envKey?.takeIf { it.isNotEmpty() },
+      interruptOnSpeech = interrupt,
+      silenceTimeoutMs = silenceTimeoutMs,
+    )
+  }
+
+  fun fallback(
+    defaultProvider: String,
+    defaultModelIdFallback: String,
+    defaultOutputFormatFallback: String,
+    envVoice: String?,
+    sagVoice: String?,
+    envKey: String?,
+  ): TalkModeGatewayConfigState =
+    TalkModeGatewayConfigState(
+      activeProvider = defaultProvider,
+      normalizedPayload = false,
+      missingResolvedPayload = false,
+      mainSessionKey = "main",
+      defaultVoiceId = envVoice?.takeIf { it.isNotEmpty() } ?: sagVoice?.takeIf { it.isNotEmpty() },
+      voiceAliases = emptyMap(),
+      defaultModelId = defaultModelIdFallback,
+      defaultOutputFormat = defaultOutputFormatFallback,
+      apiKey = envKey?.takeIf { it.isNotEmpty() },
+      interruptOnSpeech = null,
+      silenceTimeoutMs = TalkDefaults.defaultSilenceTimeoutMs,
+    )
+}
+
+private fun normalizeTalkAliasKey(value: String): String =
+  value.trim().lowercase()
+
+private fun JsonElement?.asStringOrNull(): String? =
+  this?.let { element ->
+    element as? JsonPrimitive
+  }?.contentOrNull
+
+private fun JsonElement?.asBooleanOrNull(): Boolean? {
+  val primitive = this as? JsonPrimitive ?: return null
+  return primitive.booleanOrNull
+}
+
+private fun JsonElement?.asObjectOrNull(): JsonObject? =
+  this as? JsonObject

--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.media.AudioAttributes
+import android.media.AudioFocusRequest
 import android.media.AudioFormat
 import android.media.AudioManager
 import android.media.AudioTrack
@@ -23,14 +24,18 @@ import androidx.core.content.ContextCompat
 import org.remoteclaw.android.gateway.GatewaySession
 import org.remoteclaw.android.isCanonicalMainSessionKey
 import org.remoteclaw.android.normalizeMainKey
+import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -150,22 +155,54 @@ class TalkModeManager(
   private var defaultOutputFormat: String? = null
   private var apiKey: String? = null
   private var voiceAliases: Map<String, String> = emptyMap()
-  private var interruptOnSpeech: Boolean = true
+  // Interrupt-on-speech is disabled by default: starting a SpeechRecognizer during
+  // TTS creates an audio session conflict on OxygenOS/OnePlus that causes AudioTrack
+  // write to return 0 and MediaPlayer to error. Can be enabled via gateway talk config.
+  private var activeProviderIsElevenLabs: Boolean = true
+  private var interruptOnSpeech: Boolean = false
   private var voiceOverrideActive = false
   private var modelOverrideActive = false
   private var mainSessionKey: String = "main"
 
-  private var pendingRunId: String? = null
+  @Volatile private var pendingRunId: String? = null
   private var pendingFinal: CompletableDeferred<Boolean>? = null
+  private val completedRunsLock = Any()
+  private val completedRunStates = LinkedHashMap<String, Boolean>()
+  private val completedRunTexts = LinkedHashMap<String, String>()
   private var chatSubscribedSessionKey: String? = null
+  private var configLoaded = false
+  @Volatile private var playbackEnabled = true
+  private val playbackGeneration = AtomicLong(0L)
 
+  private var ttsJob: Job? = null
   private var player: MediaPlayer? = null
   private var streamingSource: StreamingMediaDataSource? = null
   private var pcmTrack: AudioTrack? = null
   @Volatile private var pcmStopRequested = false
+  @Volatile private var finalizeInFlight = false
+  private var listenWatchdogJob: Job? = null
   private var systemTts: TextToSpeech? = null
   private var systemTtsPending: CompletableDeferred<Unit>? = null
   private var systemTtsPendingId: String? = null
+
+  private var audioFocusRequest: AudioFocusRequest? = null
+  private val audioFocusListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
+    when (focusChange) {
+      AudioManager.AUDIOFOCUS_LOSS,
+      AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
+        if (_isSpeaking.value) {
+          Log.d(tag, "audio focus lost; stopping TTS")
+          stopSpeaking(resetInterrupt = true)
+        }
+      }
+      else -> { /* regained or duck — ignore */ }
+    }
+  }
+
+  suspend fun ensureChatSubscribed() {
+    reloadConfig()
+    subscribeChatIfNeeded(session = session, sessionKey = mainSessionKey.ifBlank { "main" })
+  }
 
   fun setMainSessionKey(sessionKey: String?) {
     val trimmed = sessionKey?.trim().orEmpty()
@@ -186,10 +223,174 @@ class TalkModeManager(
     }
   }
 
+  /**
+   * Speak a wake-word command through TalkMode's full pipeline:
+   * chat.send → wait for final → read assistant text → TTS.
+   * Calls [onComplete] when done so the caller can disable TalkMode and re-arm VoiceWake.
+   */
+  fun speakWakeCommand(command: String, onComplete: () -> Unit) {
+    scope.launch {
+      try {
+        reloadConfig()
+        subscribeChatIfNeeded(session = session, sessionKey = mainSessionKey.ifBlank { "main" })
+        val startedAt = System.currentTimeMillis().toDouble() / 1000.0
+        val prompt = buildPrompt(command)
+        val runId = sendChat(prompt, session)
+        val ok = waitForChatFinal(runId)
+        val assistant = consumeRunText(runId)
+          ?: waitForAssistantText(session, startedAt, if (ok) 12_000 else 25_000)
+        if (!assistant.isNullOrBlank()) {
+          val playbackToken = playbackGeneration.incrementAndGet()
+          _statusText.value = "Speaking…"
+          playAssistant(assistant, playbackToken)
+        } else {
+          _statusText.value = "No reply"
+        }
+      } catch (err: Throwable) {
+        Log.w(tag, "speakWakeCommand failed: ${err.message}")
+      }
+      onComplete()
+    }
+  }
+
+  /** When true, play TTS for all final chat responses (even ones we didn't initiate). */
+  @Volatile var ttsOnAllResponses = false
+
+  // Streaming TTS: active session keyed by runId
+  private var streamingTts: ElevenLabsStreamingTts? = null
+  private var streamingFullText: String = ""
+  @Volatile private var lastHandledStreamingRunId: String? = null
+  private var drainingTts: ElevenLabsStreamingTts? = null
+
+  private fun stopActiveStreamingTts() {
+    streamingTts?.stop()
+    streamingTts = null
+    drainingTts?.stop()
+    drainingTts = null
+    streamingFullText = ""
+  }
+
+  /** Handle agent stream events — only speak assistant text, not tool calls or thinking. */
+  private fun handleAgentStreamEvent(payloadJson: String?) {
+    if (payloadJson.isNullOrBlank()) return
+    val payload = try {
+      json.parseToJsonElement(payloadJson).asObjectOrNull()
+    } catch (_: Throwable) { null } ?: return
+
+    // Only speak events for the active session — prevents TTS leaking from
+    // concurrent sessions/channels (privacy + correctness).
+    val eventSession = payload["sessionKey"]?.asStringOrNull()
+    val activeSession = mainSessionKey.ifBlank { "main" }
+    if (eventSession != null && eventSession != activeSession) return
+
+    val stream = payload["stream"]?.asStringOrNull() ?: return
+    if (stream != "assistant") return  // Only speak assistant text
+    val data = payload["data"]?.asObjectOrNull() ?: return
+    if (data["type"]?.asStringOrNull() == "thinking") return  // Skip thinking tokens
+    val text = data["text"]?.asStringOrNull()?.trim() ?: return
+    if (text.isEmpty()) return
+    if (!playbackEnabled) {
+      stopActiveStreamingTts()
+      return
+    }
+
+    // Start streaming session if not already active
+    if (streamingTts == null) {
+      if (!activeProviderIsElevenLabs) return  // Non-ElevenLabs provider — skip streaming TTS
+      val voiceId = currentVoiceId ?: defaultVoiceId
+      val apiKey = this.apiKey
+      if (voiceId == null || apiKey == null) {
+        Log.w(tag, "streaming TTS: missing voiceId or apiKey")
+        return
+      }
+      val modelId = currentModelId ?: defaultModelId ?: ""
+      val streamModel = if (ElevenLabsStreamingTts.supportsStreaming(modelId)) {
+        modelId
+      } else {
+        "eleven_flash_v2_5"
+      }
+      val tts = ElevenLabsStreamingTts(
+        scope = scope,
+        voiceId = voiceId,
+        apiKey = apiKey,
+        modelId = streamModel,
+        outputFormat = "pcm_24000",
+        sampleRate = 24000,
+      )
+      streamingTts = tts
+      streamingFullText = ""
+      _isSpeaking.value = true
+      _statusText.value = "Speaking…"
+      tts.start()
+      Log.d(tag, "streaming TTS started for agent assistant text")
+      lastHandledStreamingRunId = null  // will be set on final
+    }
+
+    val accepted = streamingTts?.sendText(text) ?: false
+    if (!accepted && streamingTts != null) {
+      Log.d(tag, "text diverged, restarting streaming TTS")
+      streamingTts?.stop()
+      streamingTts = null
+      // Restart with the new text
+      val voiceId2 = currentVoiceId ?: defaultVoiceId
+      val apiKey2 = this.apiKey
+      if (voiceId2 != null && apiKey2 != null) {
+        val modelId2 = currentModelId ?: defaultModelId ?: ""
+        val streamModel2 = if (ElevenLabsStreamingTts.supportsStreaming(modelId2)) modelId2 else "eleven_flash_v2_5"
+        val newTts = ElevenLabsStreamingTts(
+          scope = scope, voiceId = voiceId2, apiKey = apiKey2,
+          modelId = streamModel2, outputFormat = "pcm_24000", sampleRate = 24000,
+        )
+        streamingTts = newTts
+        streamingFullText = text
+        newTts.start()
+        newTts.sendText(streamingFullText)
+        Log.d(tag, "streaming TTS restarted with new text")
+      }
+    }
+  }
+
+  /** Called when chat final/error/aborted arrives — finish any active streaming TTS. */
+  private fun finishStreamingTts() {
+    streamingFullText = ""
+    val tts = streamingTts ?: return
+    // Null out immediately so the next response creates a fresh TTS instance.
+    // The drain coroutine below holds a reference to this instance for cleanup.
+    streamingTts = null
+    drainingTts = tts
+    tts.finish()
+    scope.launch {
+      delay(500)
+      while (tts.isPlaying.value) { delay(200) }
+      if (drainingTts === tts) drainingTts = null
+      _isSpeaking.value = false
+      _statusText.value = "Ready"
+    }
+  }
+
+  fun playTtsForText(text: String) {
+    val playbackToken = playbackGeneration.incrementAndGet()
+    ttsJob?.cancel()
+    ttsJob = scope.launch {
+      reloadConfig()
+      ensurePlaybackActive(playbackToken)
+      _isSpeaking.value = true
+      _statusText.value = "Speaking…"
+      playAssistant(text, playbackToken)
+      ttsJob = null
+    }
+  }
+
   fun handleGatewayEvent(event: String, payloadJson: String?) {
+    if (ttsOnAllResponses) {
+      Log.d(tag, "gateway event: $event")
+    }
+    if (event == "agent" && ttsOnAllResponses) {
+      handleAgentStreamEvent(payloadJson)
+      return
+    }
     if (event != "chat") return
     if (payloadJson.isNullOrBlank()) return
-    val pending = pendingRunId ?: return
     val obj =
       try {
         json.parseToJsonElement(payloadJson).asObjectOrNull()
@@ -197,13 +398,91 @@ class TalkModeManager(
         null
       } ?: return
     val runId = obj["runId"].asStringOrNull() ?: return
-    if (runId != pending) return
     val state = obj["state"].asStringOrNull() ?: return
-    if (state == "final") {
-      pendingFinal?.complete(true)
-      pendingFinal = null
-      pendingRunId = null
+
+    // Only speak events for the active session — prevents TTS from other
+    // sessions/channels leaking into voice mode (privacy + correctness).
+    val eventSession = obj["sessionKey"]?.asStringOrNull()
+    val activeSession = mainSessionKey.ifBlank { "main" }
+    if (eventSession != null && eventSession != activeSession) return
+
+    // If this is a response we initiated, handle normally below.
+    // Otherwise, if ttsOnAllResponses, finish streaming TTS on terminal events.
+    val pending = pendingRunId
+    if (pending == null || runId != pending) {
+      if (ttsOnAllResponses && state in listOf("final", "error", "aborted")) {
+        // Skip if we already handled TTS for this run (multiple final events
+        // can arrive on different threads for the same run).
+        if (lastHandledStreamingRunId == runId) {
+          if (pending == null || runId != pending) return
+        }
+        lastHandledStreamingRunId = runId
+        val stts = streamingTts
+        if (stts != null) {
+          // Finish streaming and let the drain coroutine handle playback completion.
+          // Don’t check hasReceivedAudio synchronously — audio may still be in flight
+          // from the WebSocket (EOS was just sent). The drain coroutine in finishStreamingTts
+          // waits for playback to complete; if ElevenLabs truly fails, the user just won’t
+          // hear anything (silent failure is better than double-speaking with system TTS).
+          finishStreamingTts()
+        } else if (state == "final") {
+          // No streaming was active — fall back to non-streaming
+          val text = extractTextFromChatEventMessage(obj["message"])
+          if (!text.isNullOrBlank()) {
+            playTtsForText(text)
+          }
+        }
+      }
+      if (pending == null || runId != pending) return
     }
+    Log.d(tag, "chat event arrived runId=$runId state=$state pendingRunId=$pendingRunId")
+    val terminal =
+      when (state) {
+        "final" -> true
+        "aborted", "error" -> false
+        else -> null
+      } ?: return
+    // Cache text from final event so we never need to poll chat.history
+    if (terminal) {
+      val text = extractTextFromChatEventMessage(obj["message"])
+      if (!text.isNullOrBlank()) {
+        synchronized(completedRunsLock) {
+          completedRunTexts[runId] = text
+          while (completedRunTexts.size > maxCachedRunCompletions) {
+            completedRunTexts.entries.firstOrNull()?.let { completedRunTexts.remove(it.key) }
+          }
+        }
+      }
+    }
+    cacheRunCompletion(runId, terminal)
+
+    if (runId != pendingRunId) return
+    pendingFinal?.complete(terminal)
+    pendingFinal = null
+    pendingRunId = null
+  }
+
+  fun setPlaybackEnabled(enabled: Boolean) {
+    if (playbackEnabled == enabled) return
+    playbackEnabled = enabled
+    if (!enabled) {
+      playbackGeneration.incrementAndGet()
+      stopActiveStreamingTts()
+      stopSpeaking()
+    }
+  }
+
+  suspend fun refreshConfig() {
+    reloadConfig()
+  }
+
+  suspend fun speakAssistantReply(text: String) {
+    if (!playbackEnabled) return
+    val playbackToken = playbackGeneration.incrementAndGet()
+    stopSpeaking(resetInterrupt = false)
+    ensureConfigLoaded()
+    ensurePlaybackActive(playbackToken)
+    playAssistant(text, playbackToken)
   }
 
   private fun start() {
@@ -243,6 +522,7 @@ class TalkModeManager(
 
   private fun stop() {
     stopRequested = true
+    finalizeInFlight = false
     listeningMode = false
     restartJob?.cancel()
     restartJob = null
@@ -255,6 +535,13 @@ class TalkModeManager(
     stopSpeaking()
     _usingFallbackTts.value = false
     chatSubscribedSessionKey = null
+    pendingRunId = null
+    pendingFinal?.cancel()
+    pendingFinal = null
+    synchronized(completedRunsLock) {
+      completedRunStates.clear()
+      completedRunTexts.clear()
+    }
 
     mainHandler.post {
       recognizer?.cancel()
@@ -275,6 +562,10 @@ class TalkModeManager(
         putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
         putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 3)
         putExtra(RecognizerIntent.EXTRA_CALLING_PACKAGE, context.packageName)
+        // Use cloud recognition — it handles natural speech and pauses better
+        // than on-device which cuts off aggressively after short silences.
+        putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS, 2500L)
+        putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS, 1800L)
       }
 
     if (markListening) {
@@ -294,8 +585,8 @@ class TalkModeManager(
           if (stopRequested) return@post
           try {
             recognizer?.cancel()
-            val shouldListen = listeningMode
-            val shouldInterrupt = _isSpeaking.value && interruptOnSpeech
+            val shouldListen = listeningMode && !finalizeInFlight
+            val shouldInterrupt = _isSpeaking.value && interruptOnSpeech && shouldAllowSpeechInterrupt()
             if (!shouldListen && !shouldInterrupt) return@post
             startListeningInternal(markListening = shouldListen)
           } catch (_: Throwable) {
@@ -323,6 +614,9 @@ class TalkModeManager(
 
     if (isFinal) {
       lastTranscript = trimmed
+      // Don't finalize immediately — let the silence monitor trigger after
+      // silenceWindowMs. This allows the recognizer to fire onResults and
+      // still give the user a natural pause before we send.
     }
   }
 
@@ -344,7 +638,15 @@ class TalkModeManager(
     val lastHeard = lastHeardAtMs ?: return
     val elapsed = SystemClock.elapsedRealtime() - lastHeard
     if (elapsed < silenceWindowMs) return
-    scope.launch { finalizeTranscript(transcript) }
+    if (finalizeInFlight) return
+    finalizeInFlight = true
+    scope.launch {
+      try {
+        finalizeTranscript(transcript)
+      } finally {
+        finalizeInFlight = false
+      }
+    }
   }
 
   private suspend fun finalizeTranscript(transcript: String) {
@@ -353,8 +655,18 @@ class TalkModeManager(
     _statusText.value = "Thinking…"
     lastTranscript = ""
     lastHeardAtMs = null
+    // Release SpeechRecognizer before making the API call and playing TTS.
+    // Must use withContext(Main) — not post() — so we WAIT for destruction before
+    // proceeding. A fire-and-forget post() races with TTS startup: the recognizer
+    // stays alive, picks up TTS audio as speech (onBeginningOfSpeech), and the
+    // OS kills the AudioTrack write (returns 0) on OxygenOS/OnePlus devices.
+    withContext(Dispatchers.Main) {
+      recognizer?.cancel()
+      recognizer?.destroy()
+      recognizer = null
+    }
 
-    reloadConfig()
+    ensureConfigLoaded()
     val prompt = buildPrompt(transcript)
     if (!isConnected()) {
       _statusText.value = "Gateway not connected"
@@ -373,7 +685,9 @@ class TalkModeManager(
       if (!ok) {
         Log.w(tag, "chat final timeout runId=$runId; attempting history fallback")
       }
-      val assistant = waitForAssistantText(session, startedAt, if (ok) 12_000 else 25_000)
+      // Use text cached from the final event first — avoids chat.history polling
+      val assistant = consumeRunText(runId)
+        ?: waitForAssistantText(session, startedAt, if (ok) 12_000 else 25_000)
       if (assistant.isNullOrBlank()) {
         _statusText.value = "No reply"
         Log.w(tag, "assistant text timeout runId=$runId")
@@ -381,8 +695,15 @@ class TalkModeManager(
         return
       }
       Log.d(tag, "assistant text ok chars=${assistant.length}")
-      playAssistant(assistant)
+      val playbackToken = playbackGeneration.incrementAndGet()
+      stopSpeaking(resetInterrupt = false)
+      ensurePlaybackActive(playbackToken)
+      playAssistant(assistant, playbackToken)
     } catch (err: Throwable) {
+      if (err is CancellationException) {
+        Log.d(tag, "finalize speech cancelled")
+        return
+      }
       _statusText.value = "Talk failed: ${err.message ?: err::class.simpleName}"
       Log.w(tag, "finalize failed: ${err.message ?: err::class.simpleName}")
     }
@@ -426,6 +747,7 @@ class TalkModeManager(
       buildJsonObject {
         put("sessionKey", JsonPrimitive(mainSessionKey.ifBlank { "main" }))
         put("message", JsonPrimitive(message))
+        put("thinking", JsonPrimitive("low"))
         put("timeoutMs", JsonPrimitive(30_000))
         put("idempotencyKey", JsonPrimitive(runId))
       }
@@ -457,6 +779,36 @@ class TalkModeManager(
       pendingRunId = null
     }
     return result
+  }
+
+  private fun cacheRunCompletion(runId: String, isFinal: Boolean) {
+    synchronized(completedRunsLock) {
+      completedRunStates[runId] = isFinal
+      while (completedRunStates.size > maxCachedRunCompletions) {
+        val first = completedRunStates.entries.firstOrNull() ?: break
+        completedRunStates.remove(first.key)
+      }
+    }
+  }
+
+  private fun consumeRunCompletion(runId: String): Boolean? {
+    synchronized(completedRunsLock) {
+      return completedRunStates.remove(runId)
+    }
+  }
+
+  private fun consumeRunText(runId: String): String? {
+    synchronized(completedRunsLock) {
+      return completedRunTexts.remove(runId)
+    }
+  }
+
+  private fun extractTextFromChatEventMessage(messageEl: JsonElement?): String? {
+    val msg = messageEl?.asObjectOrNull() ?: return null
+    val content = msg["content"] as? JsonArray ?: return null
+    return content.mapNotNull { entry ->
+      entry.asObjectOrNull()?.get("text")?.asStringOrNull()?.trim()
+    }.filter { it.isNotEmpty() }.joinToString("\n").takeIf { it.isNotBlank() }
   }
 
   private suspend fun waitForAssistantText(
@@ -498,7 +850,7 @@ class TalkModeManager(
     return null
   }
 
-  private suspend fun playAssistant(text: String) {
+  private suspend fun playAssistant(text: String, playbackToken: Long) {
     val parsed = TalkDirectiveParser.parse(text)
     if (parsed.unknownKeys.isNotEmpty()) {
       Log.w(tag, "Unknown talk directive keys: ${parsed.unknownKeys}")
@@ -526,6 +878,7 @@ class TalkModeManager(
         modelOverrideActive = true
       }
     }
+    ensurePlaybackActive(playbackToken)
 
     val apiKey =
       apiKey?.trim()?.takeIf { it.isNotEmpty() }
@@ -542,6 +895,7 @@ class TalkModeManager(
     _isSpeaking.value = true
     lastSpokenText = cleaned
     ensureInterruptListener()
+    requestAudioFocusForTts()
 
     try {
       val canUseElevenLabs = !voiceId.isNullOrBlank() && !apiKey.isNullOrEmpty()
@@ -552,9 +906,10 @@ class TalkModeManager(
         if (apiKey.isNullOrEmpty()) {
           Log.w(tag, "missing ELEVENLABS_API_KEY; falling back to system voice")
         }
+        ensurePlaybackActive(playbackToken)
         _usingFallbackTts.value = true
         _statusText.value = "Speaking (System)…"
-        speakWithSystemTts(cleaned)
+        speakWithSystemTts(cleaned, playbackToken)
       } else {
         _usingFallbackTts.value = false
         val ttsStarted = SystemClock.elapsedRealtime()
@@ -575,43 +930,78 @@ class TalkModeManager(
             language = TalkModeRuntime.validatedLanguage(directive?.language),
             latencyTier = TalkModeRuntime.validatedLatencyTier(directive?.latencyTier),
           )
-        streamAndPlay(voiceId = voiceId!!, apiKey = apiKey!!, request = request)
+        streamAndPlay(voiceId = voiceId!!, apiKey = apiKey!!, request = request, playbackToken = playbackToken)
         Log.d(tag, "elevenlabs stream ok durMs=${SystemClock.elapsedRealtime() - ttsStarted}")
       }
     } catch (err: Throwable) {
+      if (isPlaybackCancelled(err, playbackToken)) {
+        Log.d(tag, "assistant speech cancelled")
+        return
+      }
       Log.w(tag, "speak failed: ${err.message ?: err::class.simpleName}; falling back to system voice")
       try {
+        ensurePlaybackActive(playbackToken)
         _usingFallbackTts.value = true
         _statusText.value = "Speaking (System)…"
-        speakWithSystemTts(cleaned)
+        speakWithSystemTts(cleaned, playbackToken)
       } catch (fallbackErr: Throwable) {
+        if (isPlaybackCancelled(fallbackErr, playbackToken)) {
+          Log.d(tag, "assistant fallback speech cancelled")
+          return
+        }
         _statusText.value = "Speak failed: ${fallbackErr.message ?: fallbackErr::class.simpleName}"
         Log.w(tag, "system voice failed: ${fallbackErr.message ?: fallbackErr::class.simpleName}")
       }
-    }
+    } finally {
 
-    _isSpeaking.value = false
+      _isSpeaking.value = false
+    }
   }
 
-  private suspend fun streamAndPlay(voiceId: String, apiKey: String, request: ElevenLabsRequest) {
+  private suspend fun streamAndPlay(
+    voiceId: String,
+    apiKey: String,
+    request: ElevenLabsRequest,
+    playbackToken: Long,
+  ) {
+    ensurePlaybackActive(playbackToken)
     stopSpeaking(resetInterrupt = false)
+    ensurePlaybackActive(playbackToken)
 
     pcmStopRequested = false
     val pcmSampleRate = TalkModeRuntime.parsePcmSampleRate(request.outputFormat)
     if (pcmSampleRate != null) {
       try {
-        streamAndPlayPcm(voiceId = voiceId, apiKey = apiKey, request = request, sampleRate = pcmSampleRate)
+        streamAndPlayPcm(
+          voiceId = voiceId,
+          apiKey = apiKey,
+          request = request,
+          sampleRate = pcmSampleRate,
+          playbackToken = playbackToken,
+        )
         return
       } catch (err: Throwable) {
-        if (pcmStopRequested) return
+        if (isPlaybackCancelled(err, playbackToken) || pcmStopRequested) return
         Log.w(tag, "pcm playback failed; falling back to mp3: ${err.message ?: err::class.simpleName}")
       }
     }
 
-    streamAndPlayMp3(voiceId = voiceId, apiKey = apiKey, request = request)
+    // When falling back from PCM, rewrite format to MP3 and download to file.
+    // File-based playback avoids custom DataSource races and is reliable across OEMs.
+    val mp3Request = if (request.outputFormat?.startsWith("pcm_") == true) {
+      request.copy(outputFormat = "mp3_44100_128")
+    } else {
+      request
+    }
+    streamAndPlayMp3(voiceId = voiceId, apiKey = apiKey, request = mp3Request, playbackToken = playbackToken)
   }
 
-  private suspend fun streamAndPlayMp3(voiceId: String, apiKey: String, request: ElevenLabsRequest) {
+  private suspend fun streamAndPlayMp3(
+    voiceId: String,
+    apiKey: String,
+    request: ElevenLabsRequest,
+    playbackToken: Long,
+  ) {
     val dataSource = StreamingMediaDataSource()
     streamingSource = dataSource
 
@@ -624,7 +1014,7 @@ class TalkModeManager(
     player.setAudioAttributes(
       AudioAttributes.Builder()
         .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-        .setUsage(AudioAttributes.USAGE_ASSISTANT)
+        .setUsage(AudioAttributes.USAGE_MEDIA)
         .build(),
     )
     player.setOnPreparedListener {
@@ -648,7 +1038,7 @@ class TalkModeManager(
     val fetchJob =
       scope.launch(Dispatchers.IO) {
         try {
-          streamTts(voiceId = voiceId, apiKey = apiKey, request = request, sink = dataSource)
+          streamTts(voiceId = voiceId, apiKey = apiKey, request = request, sink = dataSource, playbackToken = playbackToken)
           fetchError.complete(null)
         } catch (err: Throwable) {
           dataSource.fail()
@@ -658,8 +1048,11 @@ class TalkModeManager(
 
     Log.d(tag, "play start")
     try {
+      ensurePlaybackActive(playbackToken)
       prepared.await()
+      ensurePlaybackActive(playbackToken)
       finished.await()
+      ensurePlaybackActive(playbackToken)
       fetchError.await()?.let { throw it }
     } finally {
       fetchJob.cancel()
@@ -668,12 +1061,82 @@ class TalkModeManager(
     Log.d(tag, "play done")
   }
 
+  /**
+   * Download ElevenLabs audio to a temp file, then play from disk via MediaPlayer.
+   * Simpler and more reliable than streaming: avoids custom DataSource races and
+   * AudioTrack underrun issues on OxygenOS/OnePlus.
+   */
+  private suspend fun streamAndPlayViaFile(voiceId: String, apiKey: String, request: ElevenLabsRequest) {
+    val tempFile = withContext(Dispatchers.IO) {
+      val file = File.createTempFile("tts_", ".mp3", context.cacheDir)
+      val conn = openTtsConnection(voiceId = voiceId, apiKey = apiKey, request = request)
+      try {
+        val payload = buildRequestPayload(request)
+        conn.outputStream.use { it.write(payload.toByteArray()) }
+        val code = conn.responseCode
+        if (code >= 400) {
+          val body = conn.errorStream?.readBytes()?.toString(Charsets.UTF_8) ?: ""
+          file.delete()
+          throw IllegalStateException("ElevenLabs failed: $code $body")
+        }
+        Log.d(tag, "elevenlabs http code=$code voiceId=$voiceId format=${request.outputFormat}")
+        // Manual loop so cancellation is honoured on every chunk.
+        // input.copyTo() is a single blocking call with no yield points; if the
+        // coroutine is cancelled mid-download the entire response would finish
+        // before cancellation was observed.
+        conn.inputStream.use { input ->
+          file.outputStream().use { out ->
+            val buf = ByteArray(8192)
+            var n: Int
+            while (input.read(buf).also { n = it } != -1) {
+              ensureActive()
+              out.write(buf, 0, n)
+            }
+          }
+        }
+      } catch (err: Throwable) {
+        file.delete()
+        throw err
+      } finally {
+        conn.disconnect()
+      }
+      file
+    }
+    try {
+      val player = MediaPlayer()
+      this.player = player
+      val finished = CompletableDeferred<Unit>()
+      player.setAudioAttributes(
+        AudioAttributes.Builder()
+          .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+          .setUsage(AudioAttributes.USAGE_MEDIA)
+          .build(),
+      )
+      player.setOnCompletionListener { finished.complete(Unit) }
+      player.setOnErrorListener { _, what, extra ->
+        finished.completeExceptionally(IllegalStateException("MediaPlayer error what=$what extra=$extra"))
+        true
+      }
+      player.setDataSource(tempFile.absolutePath)
+      withContext(Dispatchers.IO) { player.prepare() }
+      Log.d(tag, "file play start bytes=${tempFile.length()}")
+      player.start()
+      finished.await()
+      Log.d(tag, "file play done")
+    } finally {
+      try { cleanupPlayer() } catch (_: Throwable) {}
+      tempFile.delete()
+    }
+  }
+
   private suspend fun streamAndPlayPcm(
     voiceId: String,
     apiKey: String,
     request: ElevenLabsRequest,
     sampleRate: Int,
+    playbackToken: Long,
   ) {
+    ensurePlaybackActive(playbackToken)
     val minBuffer =
       AudioTrack.getMinBufferSize(
         sampleRate,
@@ -689,7 +1152,7 @@ class TalkModeManager(
       AudioTrack(
         AudioAttributes.Builder()
           .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-          .setUsage(AudioAttributes.USAGE_ASSISTANT)
+          .setUsage(AudioAttributes.USAGE_MEDIA)
           .build(),
         AudioFormat.Builder()
           .setSampleRate(sampleRate)
@@ -705,24 +1168,29 @@ class TalkModeManager(
       throw IllegalStateException("AudioTrack init failed")
     }
     pcmTrack = track
-    track.play()
+    // Don't call track.play() yet — start the track only when the first audio
+    // chunk arrives from ElevenLabs (see streamPcm). OxygenOS/OnePlus kills an
+    // AudioTrack that underruns (no data written) for ~1+ seconds, causing
+    // write() to return 0. Deferring play() until first data avoids the underrun.
 
     Log.d(tag, "pcm play start sampleRate=$sampleRate bufferSize=$bufferSize")
     try {
-      streamPcm(voiceId = voiceId, apiKey = apiKey, request = request, track = track)
+      streamPcm(voiceId = voiceId, apiKey = apiKey, request = request, track = track, playbackToken = playbackToken)
     } finally {
       cleanupPcmTrack()
     }
     Log.d(tag, "pcm play done")
   }
 
-  private suspend fun speakWithSystemTts(text: String) {
+  private suspend fun speakWithSystemTts(text: String, playbackToken: Long) {
     val trimmed = text.trim()
     if (trimmed.isEmpty()) return
+    ensurePlaybackActive(playbackToken)
     val ok = ensureSystemTts()
     if (!ok) {
       throw IllegalStateException("system TTS unavailable")
     }
+    ensurePlaybackActive(playbackToken)
 
     val tts = systemTts ?: throw IllegalStateException("system TTS unavailable")
     val utteranceId = "talk-${UUID.randomUUID()}"
@@ -732,6 +1200,7 @@ class TalkModeManager(
     systemTtsPendingId = utteranceId
 
     withContext(Dispatchers.Main) {
+      ensurePlaybackActive(playbackToken)
       val params = Bundle()
       tts.speak(trimmed, TextToSpeech.QUEUE_FLUSH, params, utteranceId)
     }
@@ -742,6 +1211,7 @@ class TalkModeManager(
       } catch (err: Throwable) {
         throw err
       }
+      ensurePlaybackActive(playbackToken)
     }
   }
 
@@ -807,6 +1277,14 @@ class TalkModeManager(
     }
   }
 
+  /** Stop any active TTS immediately — call when user taps mic to barge in. */
+  fun stopTts() {
+    stopActiveStreamingTts()
+    stopSpeaking(resetInterrupt = true)
+    _isSpeaking.value = false
+    _statusText.value = "Listening"
+  }
+
   private fun stopSpeaking(resetInterrupt: Boolean = true) {
     pcmStopRequested = true
     if (!_isSpeaking.value) {
@@ -816,6 +1294,7 @@ class TalkModeManager(
       systemTtsPending?.cancel()
       systemTtsPending = null
       systemTtsPendingId = null
+      abandonAudioFocus()
       return
     }
     if (resetInterrupt) {
@@ -829,6 +1308,42 @@ class TalkModeManager(
     systemTtsPending = null
     systemTtsPendingId = null
     _isSpeaking.value = false
+    abandonAudioFocus()
+  }
+
+  private fun shouldAllowSpeechInterrupt(): Boolean {
+    return !finalizeInFlight
+  }
+
+  private fun clearListenWatchdog() {
+    listenWatchdogJob?.cancel()
+    listenWatchdogJob = null
+  }
+
+  private fun requestAudioFocusForTts(): Boolean {
+    val am = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager ?: return true
+    val req = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+      .setAudioAttributes(
+        AudioAttributes.Builder()
+          .setUsage(AudioAttributes.USAGE_MEDIA)
+          .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+          .build()
+      )
+      .setOnAudioFocusChangeListener(audioFocusListener)
+      .build()
+    audioFocusRequest = req
+    val result = am.requestAudioFocus(req)
+    Log.d(tag, "audio focus request result=$result")
+    return result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED || result == AudioManager.AUDIOFOCUS_REQUEST_DELAYED
+  }
+
+  private fun abandonAudioFocus() {
+    val am = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager ?: return
+    audioFocusRequest?.let {
+      am.abandonAudioFocusRequest(it)
+      Log.d(tag, "audio focus abandoned")
+    }
+    audioFocusRequest = null
   }
 
   private fun cleanupPlayer() {
@@ -861,6 +1376,23 @@ class TalkModeManager(
     return true
   }
 
+  private fun ensurePlaybackActive(playbackToken: Long) {
+    if (!playbackEnabled || playbackToken != playbackGeneration.get()) {
+      throw CancellationException("assistant speech cancelled")
+    }
+  }
+
+  private fun isPlaybackCancelled(err: Throwable?, playbackToken: Long): Boolean {
+    if (err is CancellationException) return true
+    return !playbackEnabled || playbackToken != playbackGeneration.get()
+  }
+
+  private suspend fun ensureConfigLoaded() {
+    if (!configLoaded) {
+      reloadConfig()
+    }
+  }
+
   private suspend fun reloadConfig() {
     val envVoice = System.getenv("ELEVENLABS_VOICE_ID")?.trim()
     val sagVoice = System.getenv("SAG_VOICE_ID")?.trim()
@@ -868,68 +1400,66 @@ class TalkModeManager(
     try {
       val res = session.request("talk.config", """{"includeSecrets":true}""")
       val root = json.parseToJsonElement(res).asObjectOrNull()
-      val config = root?.get("config").asObjectOrNull()
-      val talk = config?.get("talk").asObjectOrNull()
-      val selection = selectTalkProviderConfig(talk)
-      if (talk != null && selection == null) {
+      val parsed =
+        TalkModeGatewayConfigParser.parse(
+          config = root?.get("config").asObjectOrNull(),
+          defaultProvider = defaultTalkProvider,
+          defaultModelIdFallback = defaultModelIdFallback,
+          defaultOutputFormatFallback = defaultOutputFormatFallback,
+          envVoice = envVoice,
+          sagVoice = sagVoice,
+          envKey = envKey,
+        )
+      if (parsed.missingResolvedPayload) {
         Log.w(tag, "talk config ignored: normalized payload missing talk.resolved")
       }
-      val activeProvider = selection?.provider ?: defaultTalkProvider
-      val activeConfig = selection?.config
-      val sessionCfg = config?.get("session").asObjectOrNull()
-      val mainKey = normalizeMainKey(sessionCfg?.get("mainKey").asStringOrNull())
-      val voice = activeConfig?.get("voiceId")?.asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
-      val aliases =
-        activeConfig?.get("voiceAliases").asObjectOrNull()?.entries?.mapNotNull { (key, value) ->
-          val id = value.asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: return@mapNotNull null
-          normalizeAliasKey(key).takeIf { it.isNotEmpty() }?.let { it to id }
-        }?.toMap().orEmpty()
-      val model = activeConfig?.get("modelId")?.asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
-      val outputFormat =
-        activeConfig?.get("outputFormat")?.asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
-      val key = activeConfig?.get("apiKey")?.asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
-      val interrupt = talk?.get("interruptOnSpeech")?.asBooleanOrNull()
-      val silenceTimeoutMs = resolvedSilenceTimeoutMs(talk)
 
       if (!isCanonicalMainSessionKey(mainSessionKey)) {
-        mainSessionKey = mainKey
+        mainSessionKey = parsed.mainSessionKey
       }
-      defaultVoiceId =
-        if (activeProvider == defaultTalkProvider) {
-          voice ?: envVoice?.takeIf { it.isNotEmpty() } ?: sagVoice?.takeIf { it.isNotEmpty() }
-        } else {
-          voice
-        }
-      voiceAliases = aliases
+      defaultVoiceId = parsed.defaultVoiceId
+      voiceAliases = parsed.voiceAliases
       if (!voiceOverrideActive) currentVoiceId = defaultVoiceId
-      defaultModelId = model ?: defaultModelIdFallback
+      defaultModelId = parsed.defaultModelId
       if (!modelOverrideActive) currentModelId = defaultModelId
-      defaultOutputFormat = outputFormat ?: defaultOutputFormatFallback
-      apiKey =
-        if (activeProvider == defaultTalkProvider) {
-          key ?: envKey?.takeIf { it.isNotEmpty() }
-        } else {
-          null
-        }
-      silenceWindowMs = silenceTimeoutMs
+      defaultOutputFormat = parsed.defaultOutputFormat
+      apiKey = parsed.apiKey
+      silenceWindowMs = parsed.silenceTimeoutMs
       Log.d(
         tag,
-        "reloadConfig apiKey=${if (apiKey != null) "set" else "null"} voiceId=$defaultVoiceId silenceTimeoutMs=$silenceTimeoutMs",
+        "reloadConfig apiKey=${if (apiKey != null) "set" else "null"} voiceId=$defaultVoiceId silenceTimeoutMs=${parsed.silenceTimeoutMs}",
       )
-      if (interrupt != null) interruptOnSpeech = interrupt
-      if (activeProvider != defaultTalkProvider) {
-        Log.w(tag, "talk provider $activeProvider unsupported; using system voice fallback")
-      } else if (selection?.normalizedPayload == true) {
+      if (parsed.interruptOnSpeech != null) interruptOnSpeech = parsed.interruptOnSpeech
+      activeProviderIsElevenLabs = parsed.activeProvider == defaultTalkProvider
+      if (!activeProviderIsElevenLabs) {
+        // Clear ElevenLabs credentials so playAssistant won't attempt ElevenLabs calls
+        apiKey = null
+        defaultVoiceId = null
+        if (!voiceOverrideActive) currentVoiceId = null
+        Log.w(tag, "talk provider ${parsed.activeProvider} unsupported; using system voice fallback")
+      } else if (parsed.normalizedPayload) {
         Log.d(tag, "talk config provider=elevenlabs")
       }
+      configLoaded = true
     } catch (_: Throwable) {
-      silenceWindowMs = TalkDefaults.defaultSilenceTimeoutMs
-      defaultVoiceId = envVoice?.takeIf { it.isNotEmpty() } ?: sagVoice?.takeIf { it.isNotEmpty() }
-      defaultModelId = defaultModelIdFallback
+      val fallback =
+        TalkModeGatewayConfigParser.fallback(
+          defaultProvider = defaultTalkProvider,
+          defaultModelIdFallback = defaultModelIdFallback,
+          defaultOutputFormatFallback = defaultOutputFormatFallback,
+          envVoice = envVoice,
+          sagVoice = sagVoice,
+          envKey = envKey,
+        )
+      silenceWindowMs = fallback.silenceTimeoutMs
+      defaultVoiceId = fallback.defaultVoiceId
+      defaultModelId = fallback.defaultModelId
       if (!modelOverrideActive) currentModelId = defaultModelId
-      apiKey = envKey?.takeIf { it.isNotEmpty() }
-      voiceAliases = emptyMap()
-      defaultOutputFormat = defaultOutputFormatFallback
+      apiKey = fallback.apiKey
+      voiceAliases = fallback.voiceAliases
+      defaultOutputFormat = fallback.defaultOutputFormat
+      // Keep config load retryable after transient fetch failures.
+      configLoaded = false
     }
   }
 
@@ -943,16 +1473,20 @@ class TalkModeManager(
     apiKey: String,
     request: ElevenLabsRequest,
     sink: StreamingMediaDataSource,
+    playbackToken: Long,
   ) {
     withContext(Dispatchers.IO) {
+      ensurePlaybackActive(playbackToken)
       val conn = openTtsConnection(voiceId = voiceId, apiKey = apiKey, request = request)
       try {
         val payload = buildRequestPayload(request)
         conn.outputStream.use { it.write(payload.toByteArray()) }
 
         val code = conn.responseCode
+        Log.d(tag, "elevenlabs http code=$code voiceId=$voiceId format=${request.outputFormat} keyLen=${apiKey.length}")
         if (code >= 400) {
           val message = conn.errorStream?.readBytes()?.toString(Charsets.UTF_8) ?: ""
+          Log.w(tag, "elevenlabs error code=$code voiceId=$voiceId body=$message")
           sink.fail()
           throw IllegalStateException("ElevenLabs failed: $code $message")
         }
@@ -960,8 +1494,10 @@ class TalkModeManager(
         val buffer = ByteArray(8 * 1024)
         conn.inputStream.use { input ->
           while (true) {
+            ensurePlaybackActive(playbackToken)
             val read = input.read(buffer)
             if (read <= 0) break
+            ensurePlaybackActive(playbackToken)
             sink.append(buffer.copyOf(read))
           }
         }
@@ -977,8 +1513,10 @@ class TalkModeManager(
     apiKey: String,
     request: ElevenLabsRequest,
     track: AudioTrack,
+    playbackToken: Long,
   ) {
     withContext(Dispatchers.IO) {
+      ensurePlaybackActive(playbackToken)
       val conn = openTtsConnection(voiceId = voiceId, apiKey = apiKey, request = request)
       try {
         val payload = buildRequestPayload(request)
@@ -990,24 +1528,33 @@ class TalkModeManager(
           throw IllegalStateException("ElevenLabs failed: $code $message")
         }
 
+        var totalBytesWritten = 0L
+        var trackStarted = false
         val buffer = ByteArray(8 * 1024)
         conn.inputStream.use { input ->
           while (true) {
-            if (pcmStopRequested) return@withContext
+            if (pcmStopRequested || isPlaybackCancelled(null, playbackToken)) return@withContext
             val read = input.read(buffer)
             if (read <= 0) break
+            // Start the AudioTrack only when the first chunk is ready — avoids
+            // the ~1.4s underrun window while ElevenLabs prepares audio.
+            // OxygenOS kills a track that underruns for >1s (write() returns 0).
+            if (!trackStarted) {
+              track.play()
+              trackStarted = true
+            }
             var offset = 0
             while (offset < read) {
-              if (pcmStopRequested) return@withContext
+              if (pcmStopRequested || isPlaybackCancelled(null, playbackToken)) return@withContext
               val wrote =
                 try {
                   track.write(buffer, offset, read - offset)
                 } catch (err: Throwable) {
-                  if (pcmStopRequested) return@withContext
+                  if (pcmStopRequested || isPlaybackCancelled(err, playbackToken)) return@withContext
                   throw err
                 }
               if (wrote <= 0) {
-                if (pcmStopRequested) return@withContext
+                if (pcmStopRequested || isPlaybackCancelled(null, playbackToken)) return@withContext
                 throw IllegalStateException("AudioTrack write failed: $wrote")
               }
               offset += wrote
@@ -1016,6 +1563,20 @@ class TalkModeManager(
         }
       } finally {
         conn.disconnect()
+      }
+    }
+  }
+
+  private suspend fun waitForPcmDrain(track: AudioTrack, totalFrames: Long, sampleRate: Int) {
+    if (totalFrames <= 0) return
+    withContext(Dispatchers.IO) {
+      val drainDeadline = SystemClock.elapsedRealtime() + 15_000
+      while (!pcmStopRequested && SystemClock.elapsedRealtime() < drainDeadline) {
+        val played = track.playbackHeadPosition.toLong().and(0xFFFFFFFFL)
+        if (played >= totalFrames) break
+        val remainingFrames = totalFrames - played
+        val sleepMs = ((remainingFrames * 1000L) / sampleRate.toLong()).coerceIn(12L, 120L)
+        delay(sleepMs)
       }
     }
   }
@@ -1170,9 +1731,13 @@ class TalkModeManager(
   }
 
   private fun ensureInterruptListener() {
-    if (!interruptOnSpeech || !_isEnabled.value) return
+    if (!interruptOnSpeech || !_isEnabled.value || !shouldAllowSpeechInterrupt()) return
+    // Don't create a new recognizer when we just destroyed one for TTS (finalizeInFlight=true).
+    // Starting a new recognizer mid-TTS causes audio session conflict that kills AudioTrack
+    // writes (returns 0) and MediaPlayer on OxygenOS/OnePlus devices.
+    if (finalizeInFlight) return
     mainHandler.post {
-      if (stopRequested) return@post
+      if (stopRequested || finalizeInFlight) return@post
       if (!SpeechRecognizer.isRecognitionAvailable(context)) return@post
       try {
         if (recognizer == null) {
@@ -1199,8 +1764,9 @@ class TalkModeManager(
     val trimmed = preferred?.trim().orEmpty()
     if (trimmed.isNotEmpty()) {
       val resolved = resolveVoiceAlias(trimmed)
-      if (resolved != null) return resolved
-      Log.w(tag, "unknown voice alias $trimmed")
+      // If it resolves as an alias, use the alias target.
+      // Otherwise treat it as a direct voice ID (e.g. "21m00Tcm4TlvDq8ikWAM").
+      return resolved ?: trimmed
     }
     fallbackVoiceId?.let { return it }
 
@@ -1276,7 +1842,12 @@ class TalkModeManager(
       override fun onBufferReceived(buffer: ByteArray?) {}
 
       override fun onEndOfSpeech() {
-        scheduleRestart()
+        clearListenWatchdog()
+        // Don't restart while a transcript is being processed — the recognizer
+        // competing for audio resources kills AudioTrack PCM playback.
+        if (!finalizeInFlight) {
+          scheduleRestart()
+        }
       }
 
       override fun onError(error: Int) {

--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -1,0 +1,69 @@
+import Foundation
+import RemoteClawKit
+
+struct TalkModeGatewayConfigState {
+    let activeProvider: String
+    let normalizedPayload: Bool
+    let missingResolvedPayload: Bool
+    let defaultVoiceId: String?
+    let voiceAliases: [String: String]
+    let defaultModelId: String
+    let defaultOutputFormat: String?
+    let rawConfigApiKey: String?
+    let interruptOnSpeech: Bool?
+    let silenceTimeoutMs: Int
+}
+
+enum TalkModeGatewayConfigParser {
+    static func parse(
+        config: [String: Any],
+        defaultProvider: String,
+        defaultModelIdFallback: String,
+        defaultSilenceTimeoutMs: Int
+    ) -> TalkModeGatewayConfigState {
+        let talk = TalkConfigParsing.bridgeFoundationDictionary(config["talk"] as? [String: Any])
+        let selection = TalkConfigParsing.selectProviderConfig(
+            talk,
+            defaultProvider: defaultProvider,
+            allowLegacyFallback: false)
+        let activeProvider = selection?.provider ?? defaultProvider
+        let activeConfig = selection?.config
+        let defaultVoiceId = activeConfig?["voiceId"]?.stringValue?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let voiceAliases: [String: String]
+        if let aliases = activeConfig?["voiceAliases"]?.dictionaryValue {
+            var resolved: [String: String] = [:]
+            for (key, value) in aliases {
+                guard let id = value.stringValue else { continue }
+                let normalizedKey = key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                let trimmedId = id.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !normalizedKey.isEmpty, !trimmedId.isEmpty else { continue }
+                resolved[normalizedKey] = trimmedId
+            }
+            voiceAliases = resolved
+        } else {
+            voiceAliases = [:]
+        }
+        let model = activeConfig?["modelId"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultModelId = (model?.isEmpty == false) ? model! : defaultModelIdFallback
+        let defaultOutputFormat = activeConfig?["outputFormat"]?.stringValue?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let rawConfigApiKey = activeConfig?["apiKey"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let interruptOnSpeech = talk?["interruptOnSpeech"]?.boolValue
+        let silenceTimeoutMs = TalkConfigParsing.resolvedSilenceTimeoutMs(
+            talk,
+            fallback: defaultSilenceTimeoutMs)
+
+        return TalkModeGatewayConfigState(
+            activeProvider: activeProvider,
+            normalizedPayload: selection?.normalizedPayload == true,
+            missingResolvedPayload: talk != nil && selection == nil,
+            defaultVoiceId: defaultVoiceId,
+            voiceAliases: voiceAliases,
+            defaultModelId: defaultModelId,
+            defaultOutputFormat: defaultOutputFormat,
+            rawConfigApiKey: rawConfigApiKey,
+            interruptOnSpeech: interruptOnSpeech,
+            silenceTimeoutMs: silenceTimeoutMs)
+    }
+}

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -1886,58 +1886,33 @@ extension TalkModeManager {
         return trimmed
     }
 
-    static func selectTalkProviderConfig(_ talk: [String: AnyCodable]?) -> TalkProviderConfigSelection? {
-        TalkConfigParsing.selectProviderConfig(
-            talk,
-            defaultProvider: Self.defaultTalkProvider,
-            allowLegacyFallback: false)
-    }
-
-    static func resolvedSilenceTimeoutMs(_ talk: [String: AnyCodable]?) -> Int {
-        TalkConfigParsing.resolvedSilenceTimeoutMs(talk, fallback: Self.defaultSilenceTimeoutMs)
-    }
-
     func reloadConfig() async {
         guard let gateway else { return }
         do {
             let res = try await gateway.request(method: "talk.config", paramsJSON: "{\"includeSecrets\":true}", timeoutSeconds: 8)
             guard let json = try JSONSerialization.jsonObject(with: res) as? [String: Any] else { return }
             guard let config = json["config"] as? [String: Any] else { return }
-            let talk = TalkConfigParsing.bridgeFoundationDictionary(config["talk"] as? [String: Any])
-            let selection = Self.selectTalkProviderConfig(talk)
-            if talk != nil, selection == nil {
+            let parsed = TalkModeGatewayConfigParser.parse(
+                config: config,
+                defaultProvider: Self.defaultTalkProvider,
+                defaultModelIdFallback: Self.defaultModelIdFallback,
+                defaultSilenceTimeoutMs: Self.defaultSilenceTimeoutMs)
+            if parsed.missingResolvedPayload {
                 GatewayDiagnostics.log(
                     "talk config ignored: normalized payload missing talk.resolved")
             }
-            let activeProvider = selection?.provider ?? Self.defaultTalkProvider
-            let activeConfig = selection?.config
-            let silenceTimeoutMs = Self.resolvedSilenceTimeoutMs(talk)
-            self.defaultVoiceId = activeConfig?["voiceId"]?.stringValue?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            if let aliases = activeConfig?["voiceAliases"]?.dictionaryValue {
-                var resolved: [String: String] = [:]
-                for (key, value) in aliases {
-                    guard let id = value.stringValue else { continue }
-                    let normalizedKey = key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-                    let trimmedId = id.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !normalizedKey.isEmpty, !trimmedId.isEmpty else { continue }
-                    resolved[normalizedKey] = trimmedId
-                }
-                self.voiceAliases = resolved
-            } else {
-                self.voiceAliases = [:]
-            }
+            let activeProvider = parsed.activeProvider
+            self.defaultVoiceId = parsed.defaultVoiceId
+            self.voiceAliases = parsed.voiceAliases
             if !self.voiceOverrideActive {
                 self.currentVoiceId = self.defaultVoiceId
             }
-            let model = activeConfig?["modelId"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
-            self.defaultModelId = (model?.isEmpty == false) ? model : Self.defaultModelIdFallback
+            self.defaultModelId = parsed.defaultModelId
             if !self.modelOverrideActive {
                 self.currentModelId = self.defaultModelId
             }
-            self.defaultOutputFormat = activeConfig?["outputFormat"]?.stringValue?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            let rawConfigApiKey = activeConfig?["apiKey"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+            self.defaultOutputFormat = parsed.defaultOutputFormat
+            let rawConfigApiKey = parsed.rawConfigApiKey
             let configApiKey = Self.normalizedTalkApiKey(rawConfigApiKey)
             let localApiKey = Self.normalizedTalkApiKey(
                 GatewaySettingsStore.loadTalkProviderApiKey(provider: activeProvider))
@@ -1956,12 +1931,13 @@ extension TalkModeManager {
             self.gatewayTalkDefaultModelId = self.defaultModelId
             self.gatewayTalkApiKeyConfigured = (self.apiKey?.isEmpty == false)
             self.gatewayTalkConfigLoaded = true
-            if let interrupt = talk?["interruptOnSpeech"]?.boolValue {
+            if let interrupt = parsed.interruptOnSpeech {
                 self.interruptOnSpeech = interrupt
             }
-            self.silenceWindow = TimeInterval(silenceTimeoutMs) / 1000
-            if selection != nil {
-                GatewayDiagnostics.log("talk config provider=\(activeProvider) silenceTimeoutMs=\(silenceTimeoutMs)")
+            self.silenceWindow = TimeInterval(parsed.silenceTimeoutMs) / 1000
+            if parsed.normalizedPayload || parsed.defaultVoiceId != nil || parsed.rawConfigApiKey != nil {
+                GatewayDiagnostics.log(
+                    "talk config provider=\(activeProvider) silenceTimeoutMs=\(parsed.silenceTimeoutMs)")
             }
         } catch {
             self.defaultModelId = Self.defaultModelIdFallback

--- a/apps/macos/Sources/RemoteClaw/TalkModeGatewayConfig.swift
+++ b/apps/macos/Sources/RemoteClaw/TalkModeGatewayConfig.swift
@@ -1,0 +1,104 @@
+import Foundation
+import RemoteClawKit
+
+struct TalkModeGatewayConfigState {
+    let activeProvider: String
+    let normalizedPayload: Bool
+    let missingResolvedPayload: Bool
+    let voiceId: String?
+    let voiceAliases: [String: String]
+    let modelId: String?
+    let outputFormat: String?
+    let interruptOnSpeech: Bool
+    let silenceTimeoutMs: Int
+    let apiKey: String?
+    let seamColorHex: String?
+}
+
+enum TalkModeGatewayConfigParser {
+    static func parse(
+        snapshot: ConfigSnapshot,
+        defaultProvider: String,
+        defaultModelIdFallback: String,
+        defaultSilenceTimeoutMs: Int,
+        envVoice: String?,
+        sagVoice: String?,
+        envApiKey: String?
+    ) -> TalkModeGatewayConfigState {
+        let talk = snapshot.config?["talk"]?.dictionaryValue
+        let selection = TalkConfigParsing.selectProviderConfig(talk, defaultProvider: defaultProvider)
+        let activeProvider = selection?.provider ?? defaultProvider
+        let activeConfig = selection?.config
+        let silenceTimeoutMs = TalkConfigParsing.resolvedSilenceTimeoutMs(
+            talk,
+            fallback: defaultSilenceTimeoutMs)
+        let ui = snapshot.config?["ui"]?.dictionaryValue
+        let rawSeam = ui?["seamColor"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let voice = activeConfig?["voiceId"]?.stringValue
+        let rawAliases = activeConfig?["voiceAliases"]?.dictionaryValue
+        let resolvedAliases: [String: String] =
+            rawAliases?.reduce(into: [:]) { acc, entry in
+                let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                let value = entry.value.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                guard !key.isEmpty, !value.isEmpty else { return }
+                acc[key] = value
+            } ?? [:]
+        let model = activeConfig?["modelId"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedModel = (model?.isEmpty == false) ? model! : defaultModelIdFallback
+        let outputFormat = activeConfig?["outputFormat"]?.stringValue
+        let interrupt = talk?["interruptOnSpeech"]?.boolValue
+        let apiKey = activeConfig?["apiKey"]?.stringValue
+        let resolvedVoice: String? = if activeProvider == defaultProvider {
+            (voice?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? voice : nil) ??
+                (envVoice?.isEmpty == false ? envVoice : nil) ??
+                (sagVoice?.isEmpty == false ? sagVoice : nil)
+        } else {
+            (voice?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? voice : nil)
+        }
+        let resolvedApiKey: String? = if activeProvider == defaultProvider {
+            (envApiKey?.isEmpty == false ? envApiKey : nil) ??
+                (apiKey?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? apiKey : nil)
+        } else {
+            nil
+        }
+
+        return TalkModeGatewayConfigState(
+            activeProvider: activeProvider,
+            normalizedPayload: selection?.normalizedPayload == true,
+            missingResolvedPayload: talk != nil && selection == nil,
+            voiceId: resolvedVoice,
+            voiceAliases: resolvedAliases,
+            modelId: resolvedModel,
+            outputFormat: outputFormat,
+            interruptOnSpeech: interrupt ?? true,
+            silenceTimeoutMs: silenceTimeoutMs,
+            apiKey: resolvedApiKey,
+            seamColorHex: rawSeam.isEmpty ? nil : rawSeam)
+    }
+
+    static func fallback(
+        defaultModelIdFallback: String,
+        defaultSilenceTimeoutMs: Int,
+        envVoice: String?,
+        sagVoice: String?,
+        envApiKey: String?
+    ) -> TalkModeGatewayConfigState {
+        let resolvedVoice =
+            (envVoice?.isEmpty == false ? envVoice : nil) ??
+            (sagVoice?.isEmpty == false ? sagVoice : nil)
+        let resolvedApiKey = envApiKey?.isEmpty == false ? envApiKey : nil
+
+        return TalkModeGatewayConfigState(
+            activeProvider: "elevenlabs",
+            normalizedPayload: false,
+            missingResolvedPayload: false,
+            voiceId: resolvedVoice,
+            voiceAliases: [:],
+            modelId: defaultModelIdFallback,
+            outputFormat: nil,
+            interruptOnSpeech: true,
+            silenceTimeoutMs: defaultSilenceTimeoutMs,
+            apiKey: resolvedApiKey,
+            seamColorHex: nil)
+    }
+}

--- a/apps/macos/Sources/RemoteClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/RemoteClaw/TalkModeRuntime.swift
@@ -793,16 +793,6 @@ extension TalkModeRuntime {
                     "silenceTimeoutMs=\(cfg.silenceTimeoutMs, privacy: .public)")
     }
 
-    private struct TalkRuntimeConfig {
-        let voiceId: String?
-        let voiceAliases: [String: String]
-        let modelId: String?
-        let outputFormat: String?
-        let interruptOnSpeech: Bool
-        let silenceTimeoutMs: Int
-        let apiKey: String?
-    }
-
     static func selectTalkProviderConfig(
         _ talk: [String: AnyCodable]?) -> TalkProviderConfigSelection?
     {
@@ -813,7 +803,7 @@ extension TalkModeRuntime {
         TalkConfigParsing.resolvedSilenceTimeoutMs(talk, fallback: self.defaultSilenceTimeoutMs)
     }
 
-    private func fetchTalkConfig() async -> TalkRuntimeConfig {
+    private func fetchTalkConfig() async -> TalkModeGatewayConfigState {
         let env = ProcessInfo.processInfo.environment
         let envVoice = env["ELEVENLABS_VOICE_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines)
         let sagVoice = env["SAG_VOICE_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -824,73 +814,34 @@ extension TalkModeRuntime {
                 method: .talkConfig,
                 params: ["includeSecrets": AnyCodable(true)],
                 timeoutMs: 8000)
-            let talk = snap.config?["talk"]?.dictionaryValue
-            let selection = Self.selectTalkProviderConfig(talk)
-            if talk != nil, selection == nil {
+            let parsed = TalkModeGatewayConfigParser.parse(
+                snapshot: snap,
+                defaultProvider: Self.defaultTalkProvider,
+                defaultModelIdFallback: Self.defaultModelIdFallback,
+                defaultSilenceTimeoutMs: Self.defaultSilenceTimeoutMs,
+                envVoice: envVoice,
+                sagVoice: sagVoice,
+                envApiKey: envApiKey)
+            if parsed.missingResolvedPayload {
                 self.ttsLogger.info("talk config ignored: normalized payload missing talk.resolved")
             }
-            let activeProvider = selection?.provider ?? Self.defaultTalkProvider
-            let activeConfig = selection?.config
-            let silenceTimeoutMs = Self.resolvedSilenceTimeoutMs(talk)
-            let ui = snap.config?["ui"]?.dictionaryValue
-            let rawSeam = ui?["seamColor"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             await MainActor.run {
-                AppStateStore.shared.seamColorHex = rawSeam.isEmpty ? nil : rawSeam
+                AppStateStore.shared.seamColorHex = parsed.seamColorHex
             }
-            let voice = activeConfig?["voiceId"]?.stringValue
-            let rawAliases = activeConfig?["voiceAliases"]?.dictionaryValue
-            let resolvedAliases: [String: String] =
-                rawAliases?.reduce(into: [:]) { acc, entry in
-                    let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-                    let value = entry.value.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                    guard !key.isEmpty, !value.isEmpty else { return }
-                    acc[key] = value
-                } ?? [:]
-            let model = activeConfig?["modelId"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let resolvedModel = (model?.isEmpty == false) ? model! : Self.defaultModelIdFallback
-            let outputFormat = activeConfig?["outputFormat"]?.stringValue
-            let interrupt = talk?["interruptOnSpeech"]?.boolValue
-            let apiKey = activeConfig?["apiKey"]?.stringValue
-            let resolvedVoice: String? = if activeProvider == Self.defaultTalkProvider {
-                (voice?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? voice : nil) ??
-                    (envVoice?.isEmpty == false ? envVoice : nil) ??
-                    (sagVoice?.isEmpty == false ? sagVoice : nil)
-            } else {
-                (voice?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? voice : nil)
-            }
-            let resolvedApiKey: String? = if activeProvider == Self.defaultTalkProvider {
-                (envApiKey?.isEmpty == false ? envApiKey : nil) ??
-                    (apiKey?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? apiKey : nil)
-            } else {
-                nil
-            }
-            if activeProvider != Self.defaultTalkProvider {
+            if parsed.activeProvider != Self.defaultTalkProvider {
                 self.ttsLogger
-                    .info("talk provider \(activeProvider, privacy: .public) unsupported; using system voice")
-            } else if selection?.normalizedPayload == true {
+                    .info("talk provider \(parsed.activeProvider, privacy: .public) unsupported; using system voice")
+            } else if parsed.normalizedPayload {
                 self.ttsLogger.info("talk config provider from talk.resolved")
             }
-            return TalkRuntimeConfig(
-                voiceId: resolvedVoice,
-                voiceAliases: resolvedAliases,
-                modelId: resolvedModel,
-                outputFormat: outputFormat,
-                interruptOnSpeech: interrupt ?? true,
-                silenceTimeoutMs: silenceTimeoutMs,
-                apiKey: resolvedApiKey)
+            return parsed
         } catch {
-            let resolvedVoice =
-                (envVoice?.isEmpty == false ? envVoice : nil) ??
-                (sagVoice?.isEmpty == false ? sagVoice : nil)
-            let resolvedApiKey = envApiKey?.isEmpty == false ? envApiKey : nil
-            return TalkRuntimeConfig(
-                voiceId: resolvedVoice,
-                voiceAliases: [:],
-                modelId: Self.defaultModelIdFallback,
-                outputFormat: nil,
-                interruptOnSpeech: true,
-                silenceTimeoutMs: Self.defaultSilenceTimeoutMs,
-                apiKey: resolvedApiKey)
+            return TalkModeGatewayConfigParser.fallback(
+                defaultModelIdFallback: Self.defaultModelIdFallback,
+                defaultSilenceTimeoutMs: Self.defaultSilenceTimeoutMs,
+                envVoice: envVoice,
+                sagVoice: sagVoice,
+                envApiKey: envApiKey)
         }
     }
 


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`16a5f0b00`](https://github.com/openclaw/openclaw/commit/16a5f0b006919f9b6150332474e8ceca08320513)
- **Author**: [steipete](https://github.com/steipete)
- **Tier**: AUTO-PARTIAL

## Summary
Extracts gateway config loading logic from TalkModeManager into dedicated `TalkModeGatewayConfig` files on each platform (Android, iOS, macOS). This separates config parsing/assembly from the talk mode runtime, reducing manager complexity.

## Adaptation
- Rebranded new `TalkModeGatewayConfig.kt` package from `ai.openclaw.app.voice` to `org.remoteclaw.android.voice` and imports accordingly
- Rebranded `import OpenClawKit` to `import RemoteClawKit` in new iOS and macOS gateway config files
- Resolved Android `TalkModeManager.kt` conflict by taking upstream's refactored version and re-applying fork rebrand (package, imports)
- New files auto-placed at rebranded paths by git

Depends on #1278.
Cherry-picked from openclaw/openclaw per [#902](https://github.com/remoteclaw/remoteclaw/issues/902).