### PR TITLE
Cherry-pick 53fb317e7: fix(macos): clean swiftformat pass and sendable warning

### DIFF
--- a/apps/macos/Sources/RemoteClaw/CameraCaptureService.swift
+++ b/apps/macos/Sources/RemoteClaw/CameraCaptureService.swift
@@ -6,14 +6,14 @@ import RemoteClawKit
 import OSLog
 
 actor CameraCaptureService {
-    struct CameraDeviceInfo: Encodable, Sendable {
+    struct CameraDeviceInfo: Encodable {
         let id: String
         let name: String
         let position: String
         let deviceType: String
     }
 
-    enum CameraError: LocalizedError, Sendable {
+    enum CameraError: LocalizedError {
         case cameraUnavailable
         case microphoneUnavailable
         case permissionDenied(kind: String)

--- a/apps/macos/Sources/RemoteClaw/ConfigStore.swift
+++ b/apps/macos/Sources/RemoteClaw/ConfigStore.swift
@@ -2,7 +2,7 @@ import Foundation
 import RemoteClawProtocol
 
 enum ConfigStore {
-    struct Overrides: Sendable {
+    struct Overrides {
         var isRemoteMode: (@Sendable () async -> Bool)?
         var loadLocal: (@MainActor @Sendable () -> [String: Any])?
         var saveLocal: (@MainActor @Sendable ([String: Any]) -> Void)?

--- a/apps/macos/Sources/RemoteClaw/ConnectionModeResolver.swift
+++ b/apps/macos/Sources/RemoteClaw/ConnectionModeResolver.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-enum EffectiveConnectionModeSource: Sendable, Equatable {
+enum EffectiveConnectionModeSource: Equatable {
     case configMode
     case configRemoteURL
     case userDefaults
     case onboarding
 }
 
-struct EffectiveConnectionMode: Sendable, Equatable {
+struct EffectiveConnectionMode: Equatable {
     let mode: AppState.ConnectionMode
     let source: EffectiveConnectionModeSource
 }

--- a/apps/macos/Sources/RemoteClaw/ControlChannel.swift
+++ b/apps/macos/Sources/RemoteClaw/ControlChannel.swift
@@ -14,7 +14,7 @@ struct ControlHeartbeatEvent: Codable {
     let reason: String?
 }
 
-struct ControlAgentEvent: Codable, Sendable, Identifiable {
+struct ControlAgentEvent: Codable, Identifiable {
     var id: String {
         "\(self.runId)-\(self.seq)"
     }

--- a/apps/macos/Sources/RemoteClaw/CronModels.swift
+++ b/apps/macos/Sources/RemoteClaw/CronModels.swift
@@ -226,7 +226,7 @@ struct CronJob: Identifiable, Codable, Equatable {
     }
 }
 
-struct CronEvent: Codable, Sendable {
+struct CronEvent: Codable {
     let jobId: String
     let action: String
     let runAtMs: Int?
@@ -237,7 +237,7 @@ struct CronEvent: Codable, Sendable {
     let nextRunAtMs: Int?
 }
 
-struct CronRunLogEntry: Codable, Identifiable, Sendable {
+struct CronRunLogEntry: Codable, Identifiable {
     var id: String {
         "\(self.jobId)-\(self.ts)"
     }

--- a/apps/macos/Sources/RemoteClaw/DeviceModelCatalog.swift
+++ b/apps/macos/Sources/RemoteClaw/DeviceModelCatalog.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct DevicePresentation: Sendable {
+struct DevicePresentation {
     let title: String
     let symbol: String?
 }

--- a/apps/macos/Sources/RemoteClaw/DiagnosticsFileLog.swift
+++ b/apps/macos/Sources/RemoteClaw/DiagnosticsFileLog.swift
@@ -7,7 +7,7 @@ actor DiagnosticsFileLog {
     private let maxBytes: Int64 = 5 * 1024 * 1024
     private let maxBackups = 5
 
-    struct Record: Codable, Sendable {
+    struct Record: Codable {
         let ts: String
         let pid: Int32
         let category: String

--- a/apps/macos/Sources/RemoteClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/RemoteClaw/ExecApprovals.swift
@@ -84,13 +84,13 @@ enum ExecAsk: String, CaseIterable, Codable, Identifiable {
     }
 }
 
-enum ExecApprovalDecision: String, Codable, Sendable {
+enum ExecApprovalDecision: String, Codable {
     case allowOnce = "allow-once"
     case allowAlways = "allow-always"
     case deny
 }
 
-enum ExecAllowlistPatternValidationReason: String, Codable, Sendable, Equatable {
+enum ExecAllowlistPatternValidationReason: String, Codable, Equatable {
     case empty
     case missingPathComponent
 
@@ -104,12 +104,12 @@ enum ExecAllowlistPatternValidationReason: String, Codable, Sendable, Equatable 
     }
 }
 
-enum ExecAllowlistPatternValidation: Sendable, Equatable {
+enum ExecAllowlistPatternValidation: Equatable {
     case valid(String)
     case invalid(ExecAllowlistPatternValidationReason)
 }
 
-struct ExecAllowlistRejectedEntry: Sendable, Equatable {
+struct ExecAllowlistRejectedEntry: Equatable {
     let id: UUID
     let pattern: String
     let reason: ExecAllowlistPatternValidationReason
@@ -734,7 +734,7 @@ enum ExecApprovalHelpers {
     }
 }
 
-struct ExecEventPayload: Codable, Sendable {
+struct ExecEventPayload: Codable {
     var sessionKey: String
     var runId: String
     var host: String

--- a/apps/macos/Sources/RemoteClaw/ExecApprovalsGatewayPrompter.swift
+++ b/apps/macos/Sources/RemoteClaw/ExecApprovalsGatewayPrompter.swift
@@ -11,7 +11,7 @@ final class ExecApprovalsGatewayPrompter {
     private let logger = Logger(subsystem: "org.remoteclaw", category: "exec-approvals.gateway")
     private var task: Task<Void, Never>?
 
-    struct GatewayApprovalRequest: Codable, Sendable {
+    struct GatewayApprovalRequest: Codable {
         var id: String
         var request: ExecApprovalPromptRequest
         var createdAtMs: Int

--- a/apps/macos/Sources/RemoteClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/RemoteClaw/ExecApprovalsSocket.swift
@@ -5,7 +5,7 @@ import Foundation
 import RemoteClawKit
 import OSLog
 
-struct ExecApprovalPromptRequest: Codable, Sendable {
+struct ExecApprovalPromptRequest: Codable {
     var command: String
     var cwd: String?
     var host: String?

--- a/apps/macos/Sources/RemoteClaw/ExecCommandResolution.swift
+++ b/apps/macos/Sources/RemoteClaw/ExecCommandResolution.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct ExecCommandResolution: Sendable {
+struct ExecCommandResolution {
     let rawExecutable: String
     let resolvedPath: String?
     let executableName: String

--- a/apps/macos/Sources/RemoteClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/RemoteClaw/GatewayConnection.swift
@@ -6,7 +6,7 @@ import OSLog
 
 private let gatewayConnectionLogger = Logger(subsystem: "org.remoteclaw", category: "gateway.connection")
 
-enum GatewayAgentChannel: String, Codable, CaseIterable, Sendable {
+enum GatewayAgentChannel: String, Codable, CaseIterable {
     case last
     case whatsapp
     case telegram
@@ -33,7 +33,7 @@ enum GatewayAgentChannel: String, Codable, CaseIterable, Sendable {
     }
 }
 
-struct GatewayAgentInvocation: Sendable {
+struct GatewayAgentInvocation {
     var message: String
     var sessionKey: String = "main"
     var thinking: String?
@@ -53,7 +53,7 @@ actor GatewayConnection {
 
     typealias Config = (url: URL, token: String?, password: String?)
 
-    enum Method: String, Sendable {
+    enum Method: String {
         case agent
         case status
         case setHeartbeats = "set-heartbeats"
@@ -386,9 +386,9 @@ actor GatewayConnection {
 // MARK: - Typed gateway API
 
 extension GatewayConnection {
-    struct ConfigGetSnapshot: Decodable, Sendable {
-        struct SnapshotConfig: Decodable, Sendable {
-            struct Session: Decodable, Sendable {
+    struct ConfigGetSnapshot: Decodable {
+        struct SnapshotConfig: Decodable {
+            struct Session: Decodable {
                 let mainKey: String?
                 let scope: String?
             }
@@ -651,7 +651,7 @@ extension GatewayConnection {
 
     // MARK: - Cron
 
-    struct CronSchedulerStatus: Decodable, Sendable {
+    struct CronSchedulerStatus: Decodable {
         let enabled: Bool
         let storePath: String
         let jobs: Int

--- a/apps/macos/Sources/RemoteClaw/GatewayEnvironment.swift
+++ b/apps/macos/Sources/RemoteClaw/GatewayEnvironment.swift
@@ -3,7 +3,7 @@ import RemoteClawIPC
 import OSLog
 
 /// Lightweight SemVer helper (major.minor.patch only) for gateway compatibility checks.
-struct Semver: Comparable, CustomStringConvertible, Sendable {
+struct Semver: Comparable, CustomStringConvertible {
     let major: Int
     let minor: Int
     let patch: Int

--- a/apps/macos/Sources/RemoteClaw/HealthStore.swift
+++ b/apps/macos/Sources/RemoteClaw/HealthStore.swift
@@ -3,14 +3,14 @@ import Network
 import Observation
 import SwiftUI
 
-struct HealthSnapshot: Codable, Sendable {
-    struct ChannelSummary: Codable, Sendable {
-        struct Probe: Codable, Sendable {
-            struct Bot: Codable, Sendable {
+struct HealthSnapshot: Codable {
+    struct ChannelSummary: Codable {
+        struct Probe: Codable {
+            struct Bot: Codable {
                 let username: String?
             }
 
-            struct Webhook: Codable, Sendable {
+            struct Webhook: Codable {
                 let url: String?
             }
 
@@ -29,13 +29,13 @@ struct HealthSnapshot: Codable, Sendable {
         let lastProbeAt: Double?
     }
 
-    struct SessionInfo: Codable, Sendable {
+    struct SessionInfo: Codable {
         let key: String
         let updatedAt: Double?
         let age: Double?
     }
 
-    struct Sessions: Codable, Sendable {
+    struct Sessions: Codable {
         let path: String
         let count: Int
         let recent: [SessionInfo]

--- a/apps/macos/Sources/RemoteClaw/Launchctl.swift
+++ b/apps/macos/Sources/RemoteClaw/Launchctl.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum Launchctl {
-    struct Result: Sendable {
+    struct Result {
         let status: Int32
         let output: String
     }
@@ -26,7 +26,7 @@ enum Launchctl {
     }
 }
 
-struct LaunchAgentPlistSnapshot: Equatable, Sendable {
+struct LaunchAgentPlistSnapshot: Equatable {
     let programArguments: [String]
     let environment: [String: String]
     let stdoutPath: String?

--- a/apps/macos/Sources/RemoteClaw/NodeMode/MacNodeScreenCommands.swift
+++ b/apps/macos/Sources/RemoteClaw/NodeMode/MacNodeScreenCommands.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-enum MacNodeScreenCommand: String, Codable, Sendable {
+enum MacNodeScreenCommand: String, Codable {
     case record = "screen.record"
 }
 
-struct MacNodeScreenRecordParams: Codable, Sendable, Equatable {
+struct MacNodeScreenRecordParams: Codable, Equatable {
     var screenIndex: Int?
     var durationMs: Int?
     var fps: Double?

--- a/apps/macos/Sources/RemoteClaw/PeekabooBridgeHostCoordinator.swift
+++ b/apps/macos/Sources/RemoteClaw/PeekabooBridgeHostCoordinator.swift
@@ -40,7 +40,7 @@ final class PeekabooBridgeHostCoordinator {
     private func startIfNeeded() async {
         guard self.host == nil else { return }
 
-        var allowlistedTeamIDs: Set<String> = ["Y5PE65HELJ"]
+        var allowlistedTeamIDs: Set = ["Y5PE65HELJ"]
         if let teamID = Self.currentTeamID() {
             allowlistedTeamIDs.insert(teamID)
         }

--- a/apps/macos/Sources/RemoteClaw/PortGuardian.swift
+++ b/apps/macos/Sources/RemoteClaw/PortGuardian.swift
@@ -15,7 +15,7 @@ actor PortGuardian {
         let timestamp: TimeInterval
     }
 
-    struct Descriptor: Sendable {
+    struct Descriptor {
         let pid: Int32
         let command: String
         let executablePath: String?

--- a/apps/macos/Sources/RemoteClaw/SessionMenuPreviewView.swift
+++ b/apps/macos/Sources/RemoteClaw/SessionMenuPreviewView.swift
@@ -4,13 +4,13 @@ import RemoteClawProtocol
 import OSLog
 import SwiftUI
 
-struct SessionPreviewItem: Identifiable, Sendable {
+struct SessionPreviewItem: Identifiable {
     let id: String
     let role: PreviewRole
     let text: String
 }
 
-enum PreviewRole: String, Sendable {
+enum PreviewRole: String {
     case user
     case assistant
     case tool
@@ -114,7 +114,7 @@ extension SessionPreviewCache {
 }
 #endif
 
-struct SessionMenuPreviewSnapshot: Sendable {
+struct SessionMenuPreviewSnapshot {
     let items: [SessionPreviewItem]
     let status: SessionMenuPreviewView.LoadStatus
 }

--- a/apps/macos/Sources/RemoteClaw/TalkAudioPlayer.swift
+++ b/apps/macos/Sources/RemoteClaw/TalkAudioPlayer.swift
@@ -152,7 +152,7 @@ final class TalkAudioPlayer: NSObject, @preconcurrency AVAudioPlayerDelegate {
     }
 }
 
-struct TalkPlaybackResult: Sendable {
+struct TalkPlaybackResult {
     let finished: Bool
     let interruptedAt: Double?
 }

--- a/apps/macos/Sources/RemoteClaw/VoiceWakeChime.swift
+++ b/apps/macos/Sources/RemoteClaw/VoiceWakeChime.swift
@@ -2,7 +2,7 @@ import AppKit
 import Foundation
 import OSLog
 
-enum VoiceWakeChime: Codable, Equatable, Sendable {
+enum VoiceWakeChime: Codable, Equatable {
     case none
     case system(name: String)
     case custom(displayName: String, bookmark: Data)

--- a/apps/macos/Sources/RemoteClaw/VoiceWakeForwarder.swift
+++ b/apps/macos/Sources/RemoteClaw/VoiceWakeForwarder.swift
@@ -32,7 +32,7 @@ enum VoiceWakeForwarder {
         }
     }
 
-    struct ForwardOptions: Sendable {
+    struct ForwardOptions {
         var sessionKey: String = "main"
         var thinking: String = "low"
         var deliver: Bool = true

--- a/apps/macos/Sources/RemoteClawDiscovery/WideAreaGatewayDiscovery.swift
+++ b/apps/macos/Sources/RemoteClawDiscovery/WideAreaGatewayDiscovery.swift
@@ -1,7 +1,7 @@
 import Foundation
 import RemoteClawKit
 
-struct WideAreaGatewayBeacon: Sendable, Equatable {
+struct WideAreaGatewayBeacon: Equatable {
     var instanceName: String
     var displayName: String
     var host: String
@@ -19,7 +19,7 @@ enum WideAreaGatewayDiscovery {
     private static let defaultTimeoutSeconds: TimeInterval = 0.2
     private static let nameserverProbeConcurrency = 6
 
-    struct DiscoveryContext: Sendable {
+    struct DiscoveryContext {
         var tailscaleStatus: @Sendable () -> String?
         var dig: @Sendable (_ args: [String], _ timeout: TimeInterval) -> String?
 

--- a/apps/macos/Tests/RemoteClawIPCTests/AgentEventStoreTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/AgentEventStoreTests.swift
@@ -3,11 +3,10 @@ import Foundation
 import Testing
 @testable import RemoteClaw
 
-@Suite
 @MainActor
 struct AgentEventStoreTests {
     @Test
-    func appendAndClear() {
+    func `append and clear`() {
         let store = AgentEventStore()
         #expect(store.events.isEmpty)
 
@@ -25,7 +24,7 @@ struct AgentEventStoreTests {
     }
 
     @Test
-    func trimsToMaxEvents() {
+    func `trims to max events`() {
         let store = AgentEventStore()
         for i in 1...401 {
             store.append(ControlAgentEvent(

--- a/apps/macos/Tests/RemoteClawIPCTests/AnyCodableEncodingTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/AnyCodableEncodingTests.swift
@@ -4,8 +4,8 @@ import Testing
 
 @testable import RemoteClaw
 
-@Suite struct AnyCodableEncodingTests {
-    @Test func encodesSwiftArrayAndDictionaryValues() throws {
+struct AnyCodableEncodingTests {
+    @Test func `encodes swift array and dictionary values`() throws {
         let payload: [String: Any] = [
             "tags": ["node", "ios"],
             "meta": ["count": 2],
@@ -20,7 +20,7 @@ import Testing
         #expect(obj["null"] is NSNull)
     }
 
-    @Test func protocolAnyCodableEncodesPrimitiveArrays() throws {
+    @Test func `protocol any codable encodes primitive arrays`() throws {
         let payload: [String: Any] = [
             "items": [1, "two", NSNull(), ["ok": true]],
         ]

--- a/apps/macos/Tests/RemoteClawIPCTests/AudioInputDeviceObserverTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/AudioInputDeviceObserverTests.swift
@@ -2,15 +2,15 @@ import Foundation
 import Testing
 @testable import RemoteClaw
 
-@Suite struct AudioInputDeviceObserverTests {
-    @Test func hasUsableDefaultInputDeviceReturnsBool() {
+struct AudioInputDeviceObserverTests {
+    @Test func `has usable default input device returns bool`() {
         // Smoke test: verifies the composition logic runs without crashing.
         // Actual result depends on whether the host has an audio input device.
         let result = AudioInputDeviceObserver.hasUsableDefaultInputDevice()
         _ = result // suppress unused-variable warning; the assertion is "no crash"
     }
 
-    @Test func hasUsableDefaultInputDeviceConsistentWithComponents() {
+    @Test func `has usable default input device consistent with components`() {
         // When no default UID exists, the method must return false.
         // When a default UID exists, the result must match alive-set membership.
         let uid = AudioInputDeviceObserver.defaultInputDeviceUID()

--- a/apps/macos/Tests/RemoteClawIPCTests/CLIInstallerTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/CLIInstallerTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct CLIInstallerTests {
-    @Test func installedLocationFindsExecutable() throws {
+    @Test func `installed location finds executable`() throws {
         let fm = FileManager()
         let root = fm.temporaryDirectory.appendingPathComponent(
             "remoteclaw-cli-installer-\(UUID().uuidString)")

--- a/apps/macos/Tests/RemoteClawIPCTests/CameraCaptureServiceTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/CameraCaptureServiceTests.swift
@@ -2,14 +2,14 @@ import Testing
 
 @testable import RemoteClaw
 
-@Suite struct CameraCaptureServiceTests {
-    @Test func normalizeSnapDefaults() {
+struct CameraCaptureServiceTests {
+    @Test func `normalize snap defaults`() {
         let res = CameraCaptureService.normalizeSnap(maxWidth: nil, quality: nil)
         #expect(res.maxWidth == 1600)
         #expect(res.quality == 0.9)
     }
 
-    @Test func normalizeSnapClampsValues() {
+    @Test func `normalize snap clamps values`() {
         let low = CameraCaptureService.normalizeSnap(maxWidth: -1, quality: -10)
         #expect(low.maxWidth == 1600)
         #expect(low.quality == 0.05)

--- a/apps/macos/Tests/RemoteClawIPCTests/CameraIPCTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/CameraIPCTests.swift
@@ -2,8 +2,8 @@ import RemoteClawIPC
 import Foundation
 import Testing
 
-@Suite struct CameraIPCTests {
-    @Test func cameraSnapCodableRoundtrip() throws {
+struct CameraIPCTests {
+    @Test func `camera snap codable roundtrip`() throws {
         let req: Request = .cameraSnap(
             facing: .front,
             maxWidth: 640,
@@ -24,7 +24,7 @@ import Testing
         }
     }
 
-    @Test func cameraClipCodableRoundtrip() throws {
+    @Test func `camera clip codable roundtrip`() throws {
         let req: Request = .cameraClip(
             facing: .back,
             durationMs: 3000,
@@ -45,7 +45,7 @@ import Testing
         }
     }
 
-    @Test func cameraClipDefaultsIncludeAudioToTrueWhenMissing() throws {
+    @Test func `camera clip defaults include audio to true when missing`() throws {
         let json = """
         {"type":"cameraClip","durationMs":1234}
         """

--- a/apps/macos/Tests/RemoteClawIPCTests/CanvasFileWatcherTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/CanvasFileWatcherTests.swift
@@ -11,7 +11,7 @@ import Testing
         return dir
     }
 
-    @Test func detectsInPlaceFileWrites() async throws {
+    @Test func `detects in place file writes`() async throws {
         let dir = try self.makeTempDir()
         defer { try? FileManager().removeItem(at: dir) }
 

--- a/apps/macos/Tests/RemoteClawIPCTests/CanvasIPCTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/CanvasIPCTests.swift
@@ -2,8 +2,8 @@ import RemoteClawIPC
 import Foundation
 import Testing
 
-@Suite struct CanvasIPCTests {
-    @Test func canvasPresentCodableRoundtrip() throws {
+struct CanvasIPCTests {
+    @Test func `canvas present codable roundtrip`() throws {
         let placement = CanvasPlacement(x: 10, y: 20, width: 640, height: 480)
         let req: Request = .canvasPresent(session: "main", path: "/index.html", placement: placement)
 
@@ -23,7 +23,7 @@ import Testing
         }
     }
 
-    @Test func canvasPresentDecodesNilPlacementWhenMissing() throws {
+    @Test func `canvas present decodes nil placement when missing`() throws {
         let json = """
         {"type":"canvasPresent","session":"s","path":"/"}
         """

--- a/apps/macos/Tests/RemoteClawIPCTests/ConfigStoreTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/ConfigStoreTests.swift
@@ -4,7 +4,7 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct ConfigStoreTests {
-    @Test func loadUsesRemoteInRemoteMode() async {
+    @Test func `load uses remote in remote mode`() async {
         var localHit = false
         var remoteHit = false
         await ConfigStore._testSetOverrides(.init(
@@ -20,7 +20,7 @@ struct ConfigStoreTests {
         #expect(result["remote"] as? Bool == true)
     }
 
-    @Test func loadUsesLocalInLocalMode() async {
+    @Test func `load uses local in local mode`() async {
         var localHit = false
         var remoteHit = false
         await ConfigStore._testSetOverrides(.init(
@@ -36,7 +36,7 @@ struct ConfigStoreTests {
         #expect(result["local"] as? Bool == true)
     }
 
-    @Test func saveRoutesToRemoteInRemoteMode() async throws {
+    @Test func `save routes to remote in remote mode`() async throws {
         var localHit = false
         var remoteHit = false
         await ConfigStore._testSetOverrides(.init(
@@ -51,7 +51,7 @@ struct ConfigStoreTests {
         #expect(!localHit)
     }
 
-    @Test func saveRoutesToLocalInLocalMode() async throws {
+    @Test func `save routes to local in local mode`() async throws {
         var localHit = false
         var remoteHit = false
         await ConfigStore._testSetOverrides(.init(

--- a/apps/macos/Tests/RemoteClawIPCTests/CoverageDumpTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/CoverageDumpTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @Suite(.serialized)
 struct CoverageDumpTests {
-    @Test func periodicallyFlushCoverage() async {
+    @Test func `periodically flush coverage`() async {
         guard ProcessInfo.processInfo.environment["LLVM_PROFILE_FILE"] != nil else { return }
         guard let writeProfile = resolveProfileWriteFile() else { return }
         let deadline = Date().addingTimeInterval(4)

--- a/apps/macos/Tests/RemoteClawIPCTests/CritterIconRendererTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/CritterIconRendererTests.swift
@@ -2,10 +2,9 @@ import AppKit
 import Testing
 @testable import RemoteClaw
 
-@Suite
 @MainActor
 struct CritterIconRendererTests {
-    @Test func makeIconRendersExpectedSize() {
+    @Test func `make icon renders expected size`() {
         let image = CritterIconRenderer.makeIcon(
             blink: 0.25,
             legWiggle: 0.5,
@@ -19,7 +18,7 @@ struct CritterIconRendererTests {
         #expect(image.tiffRepresentation != nil)
     }
 
-    @Test func makeIconRendersWithBadge() {
+    @Test func `make icon renders with badge`() {
         let image = CritterIconRenderer.makeIcon(
             blink: 0,
             legWiggle: 0,
@@ -31,7 +30,7 @@ struct CritterIconRendererTests {
         #expect(image.tiffRepresentation != nil)
     }
 
-    @Test func critterStatusLabelExercisesHelpers() async {
+    @Test func `critter status label exercises helpers`() async {
         await CritterStatusLabel.exerciseForTesting()
     }
 }

--- a/apps/macos/Tests/RemoteClawIPCTests/DeepLinkAgentPolicyTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/DeepLinkAgentPolicyTests.swift
@@ -2,8 +2,8 @@ import RemoteClawKit
 import Testing
 @testable import RemoteClaw
 
-@Suite struct DeepLinkAgentPolicyTests {
-    @Test func validateMessageForHandleRejectsTooLongWhenUnkeyed() {
+struct DeepLinkAgentPolicyTests {
+    @Test func `validate message for handle rejects too long when unkeyed`() {
         let msg = String(repeating: "a", count: DeepLinkAgentPolicy.maxUnkeyedConfirmChars + 1)
         let res = DeepLinkAgentPolicy.validateMessageForHandle(message: msg, allowUnattended: false)
         switch res {
@@ -17,7 +17,7 @@ import Testing
         }
     }
 
-    @Test func validateMessageForHandleAllowsTooLongWhenKeyed() {
+    @Test func `validate message for handle allows too long when keyed`() {
         let msg = String(repeating: "a", count: DeepLinkAgentPolicy.maxUnkeyedConfirmChars + 1)
         let res = DeepLinkAgentPolicy.validateMessageForHandle(message: msg, allowUnattended: true)
         switch res {
@@ -28,7 +28,7 @@ import Testing
         }
     }
 
-    @Test func effectiveDeliveryIgnoresDeliveryFieldsWhenUnkeyed() {
+    @Test func `effective delivery ignores delivery fields when unkeyed`() {
         let link = AgentDeepLink(
             message: "Hello",
             sessionKey: "s",
@@ -44,7 +44,7 @@ import Testing
         #expect(res.channel == .last)
     }
 
-    @Test func effectiveDeliveryHonorsDeliverForDeliverableChannelsWhenKeyed() {
+    @Test func `effective delivery honors deliver for deliverable channels when keyed`() {
         let link = AgentDeepLink(
             message: "Hello",
             sessionKey: "s",
@@ -60,7 +60,7 @@ import Testing
         #expect(res.channel == .whatsapp)
     }
 
-    @Test func effectiveDeliveryStillBlocksWebChatDeliveryWhenKeyed() {
+    @Test func `effective delivery still blocks web chat delivery when keyed`() {
         let link = AgentDeepLink(
             message: "Hello",
             sessionKey: "s",

--- a/apps/macos/Tests/RemoteClawIPCTests/DeviceModelCatalogTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/DeviceModelCatalogTests.swift
@@ -1,10 +1,9 @@
 import Testing
 @testable import RemoteClaw
 
-@Suite
 struct DeviceModelCatalogTests {
     @Test
-    func symbolPrefersModelIdentifierPrefixes() {
+    func `symbol prefers model identifier prefixes`() {
         #expect(DeviceModelCatalog
             .symbol(deviceFamily: "iPad", modelIdentifier: "iPad16,6", friendlyName: nil) == "ipad")
         #expect(DeviceModelCatalog
@@ -12,7 +11,7 @@ struct DeviceModelCatalogTests {
     }
 
     @Test
-    func symbolUsesFriendlyNameForMacVariants() {
+    func `symbol uses friendly name for mac variants`() {
         #expect(DeviceModelCatalog.symbol(
             deviceFamily: "Mac",
             modelIdentifier: "Mac99,1",
@@ -28,13 +27,13 @@ struct DeviceModelCatalogTests {
     }
 
     @Test
-    func symbolFallsBackToDeviceFamily() {
+    func `symbol falls back to device family`() {
         #expect(DeviceModelCatalog.symbol(deviceFamily: "Android", modelIdentifier: "", friendlyName: nil) == "android")
         #expect(DeviceModelCatalog.symbol(deviceFamily: "Linux", modelIdentifier: "", friendlyName: nil) == "cpu")
     }
 
     @Test
-    func presentationUsesBundledModelMappings() {
+    func `presentation uses bundled model mappings`() {
         let presentation = DeviceModelCatalog.presentation(deviceFamily: "iPhone", modelIdentifier: "iPhone1,1")
         #expect(presentation?.title == "iPhone")
     }

--- a/apps/macos/Tests/RemoteClawIPCTests/ExecApprovalHelpersTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/ExecApprovalHelpersTests.swift
@@ -2,8 +2,8 @@ import Foundation
 import Testing
 @testable import RemoteClaw
 
-@Suite struct ExecApprovalHelpersTests {
-    @Test func parseDecisionTrimsAndRejectsInvalid() {
+struct ExecApprovalHelpersTests {
+    @Test func `parse decision trims and rejects invalid`() {
         #expect(ExecApprovalHelpers.parseDecision("allow-once") == .allowOnce)
         #expect(ExecApprovalHelpers.parseDecision(" allow-always ") == .allowAlways)
         #expect(ExecApprovalHelpers.parseDecision("deny") == .deny)
@@ -11,7 +11,7 @@ import Testing
         #expect(ExecApprovalHelpers.parseDecision("nope") == nil)
     }
 
-    @Test func allowlistPatternPrefersResolution() {
+    @Test func `allowlist pattern prefers resolution`() {
         let resolved = ExecCommandResolution(
             rawExecutable: "rg",
             resolvedPath: "/opt/homebrew/bin/rg",
@@ -29,7 +29,7 @@ import Testing
         #expect(ExecApprovalHelpers.allowlistPattern(command: [], resolution: nil) == nil)
     }
 
-    @Test func validateAllowlistPatternReturnsReasons() {
+    @Test func `validate allowlist pattern returns reasons`() {
         #expect(ExecApprovalHelpers.isPathPattern("/usr/bin/rg"))
         #expect(ExecApprovalHelpers.isPathPattern(" ~/bin/rg "))
         #expect(!ExecApprovalHelpers.isPathPattern("rg"))
@@ -47,7 +47,7 @@ import Testing
         }
     }
 
-    @Test func requiresAskMatchesPolicy() {
+    @Test func `requires ask matches policy`() {
         let entry = ExecAllowlistEntry(pattern: "/bin/ls", lastUsedAt: nil, lastUsedCommand: nil, lastResolvedPath: nil)
         #expect(ExecApprovalHelpers.requiresAsk(
             ask: .always,

--- a/apps/macos/Tests/RemoteClawIPCTests/ExecApprovalsGatewayPrompterTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/ExecApprovalsGatewayPrompterTests.swift
@@ -1,10 +1,9 @@
 import Testing
 @testable import RemoteClaw
 
-@Suite
 @MainActor
 struct ExecApprovalsGatewayPrompterTests {
-    @Test func sessionMatchPrefersActiveSession() {
+    @Test func `session match prefers active session`() {
         let matches = ExecApprovalsGatewayPrompter._testShouldPresent(
             mode: .remote,
             activeSession: " main ",
@@ -20,7 +19,7 @@ struct ExecApprovalsGatewayPrompterTests {
         #expect(!mismatched)
     }
 
-    @Test func sessionFallbackUsesRecentActivity() {
+    @Test func `session fallback uses recent activity`() {
         let recent = ExecApprovalsGatewayPrompter._testShouldPresent(
             mode: .remote,
             activeSession: nil,
@@ -38,7 +37,7 @@ struct ExecApprovalsGatewayPrompterTests {
         #expect(!stale)
     }
 
-    @Test func defaultBehaviorMatchesMode() {
+    @Test func `default behavior matches mode`() {
         let local = ExecApprovalsGatewayPrompter._testShouldPresent(
             mode: .local,
             activeSession: nil,

--- a/apps/macos/Tests/RemoteClawIPCTests/ExecSystemRunCommandValidatorTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/ExecSystemRunCommandValidatorTests.swift
@@ -20,7 +20,7 @@ private struct SystemRunCommandContractExpected: Decodable {
 }
 
 struct ExecSystemRunCommandValidatorTests {
-    @Test func matchesSharedSystemRunCommandContractFixture() throws {
+    @Test func `matches shared system run command contract fixture`() throws {
         for entry in try Self.loadContractCases() {
             let result = ExecSystemRunCommandValidator.resolve(command: entry.command, rawCommand: entry.rawCommand)
 

--- a/apps/macos/Tests/RemoteClawIPCTests/FileHandleLegacyAPIGuardTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/FileHandleLegacyAPIGuardTests.swift
@@ -1,8 +1,8 @@
 import Foundation
 import Testing
 
-@Suite struct FileHandleLegacyAPIGuardTests {
-    @Test func sourcesAvoidLegacyNonThrowingFileHandleReadAPIs() throws {
+struct FileHandleLegacyAPIGuardTests {
+    @Test func `sources avoid legacy non throwing file handle read AP is`() throws {
         let testFile = URL(fileURLWithPath: #filePath)
         let packageRoot = testFile
             .deletingLastPathComponent() // RemoteClawIPCTests

--- a/apps/macos/Tests/RemoteClawIPCTests/FileHandleSafeReadTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/FileHandleSafeReadTests.swift
@@ -2,8 +2,8 @@ import Foundation
 import Testing
 @testable import RemoteClaw
 
-@Suite struct FileHandleSafeReadTests {
-    @Test func readToEndSafelyReturnsEmptyForClosedHandle() {
+struct FileHandleSafeReadTests {
+    @Test func `read to end safely returns empty for closed handle`() {
         let pipe = Pipe()
         let handle = pipe.fileHandleForReading
         try? handle.close()
@@ -12,7 +12,7 @@ import Testing
         #expect(data.isEmpty)
     }
 
-    @Test func readSafelyUpToCountReturnsEmptyForClosedHandle() {
+    @Test func `read safely up to count returns empty for closed handle`() {
         let pipe = Pipe()
         let handle = pipe.fileHandleForReading
         try? handle.close()
@@ -21,7 +21,7 @@ import Testing
         #expect(data.isEmpty)
     }
 
-    @Test func readToEndSafelyReadsPipeContents() {
+    @Test func `read to end safely reads pipe contents`() {
         let pipe = Pipe()
         let writeHandle = pipe.fileHandleForWriting
         writeHandle.write(Data("hello".utf8))
@@ -31,7 +31,7 @@ import Testing
         #expect(String(data: data, encoding: .utf8) == "hello")
     }
 
-    @Test func readSafelyUpToCountReadsIncrementally() {
+    @Test func `read safely up to count reads incrementally`() {
         let pipe = Pipe()
         let writeHandle = pipe.fileHandleForWriting
         writeHandle.write(Data("hello world".utf8))

--- a/apps/macos/Tests/RemoteClawIPCTests/GatewayAgentChannelTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/GatewayAgentChannelTests.swift
@@ -1,13 +1,13 @@
 import Testing
 @testable import RemoteClaw
 
-@Suite struct GatewayAgentChannelTests {
-    @Test func shouldDeliverBlocksWebChat() {
+struct GatewayAgentChannelTests {
+    @Test func `should deliver blocks web chat`() {
         #expect(GatewayAgentChannel.webchat.shouldDeliver(true) == false)
         #expect(GatewayAgentChannel.webchat.shouldDeliver(false) == false)
     }
 
-    @Test func shouldDeliverAllowsLastAndProviderChannels() {
+    @Test func `should deliver allows last and provider channels`() {
         #expect(GatewayAgentChannel.last.shouldDeliver(true) == true)
         #expect(GatewayAgentChannel.whatsapp.shouldDeliver(true) == true)
         #expect(GatewayAgentChannel.telegram.shouldDeliver(true) == true)
@@ -16,7 +16,7 @@ import Testing
         #expect(GatewayAgentChannel.last.shouldDeliver(false) == false)
     }
 
-    @Test func initRawNormalizesAndFallsBackToLast() {
+    @Test func `init raw normalizes and falls back to last`() {
         #expect(GatewayAgentChannel(raw: nil) == .last)
         #expect(GatewayAgentChannel(raw: "  ") == .last)
         #expect(GatewayAgentChannel(raw: "WEBCHAT") == .webchat)

--- a/apps/macos/Tests/RemoteClawIPCTests/GatewayAutostartPolicyTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/GatewayAutostartPolicyTests.swift
@@ -3,14 +3,14 @@ import Testing
 
 @Suite(.serialized)
 struct GatewayAutostartPolicyTests {
-    @Test func startsGatewayOnlyWhenLocalAndNotPaused() {
+    @Test func `starts gateway only when local and not paused`() {
         #expect(GatewayAutostartPolicy.shouldStartGateway(mode: .local, paused: false))
         #expect(!GatewayAutostartPolicy.shouldStartGateway(mode: .local, paused: true))
         #expect(!GatewayAutostartPolicy.shouldStartGateway(mode: .remote, paused: false))
         #expect(!GatewayAutostartPolicy.shouldStartGateway(mode: .unconfigured, paused: false))
     }
 
-    @Test func ensuresLaunchAgentWhenLocalAndNotAttachOnly() {
+    @Test func `ensures launch agent when local and not attach only`() {
         #expect(GatewayAutostartPolicy.shouldEnsureLaunchAgent(
             mode: .local,
             paused: false))

--- a/apps/macos/Tests/RemoteClawIPCTests/GatewayConnectionControlTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/GatewayConnectionControlTests.swift
@@ -39,14 +39,14 @@ private func makeTestGatewayConnection() -> GatewayConnection {
 }
 
 @Suite(.serialized) struct GatewayConnectionControlTests {
-    @Test func statusFailsWhenProcessMissing() async {
+    @Test func `status fails when process missing`() async {
         let connection = makeTestGatewayConnection()
         let result = await connection.status()
         #expect(result.ok == false)
         #expect(result.error != nil)
     }
 
-    @Test func rejectEmptyMessage() async {
+    @Test func `reject empty message`() async {
         let connection = makeTestGatewayConnection()
         let result = await connection.sendAgent(
             message: "",

--- a/apps/macos/Tests/RemoteClawIPCTests/GatewayEnvironmentTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/GatewayEnvironmentTests.swift
@@ -2,8 +2,8 @@ import Foundation
 import Testing
 @testable import RemoteClaw
 
-@Suite struct GatewayEnvironmentTests {
-    @Test func semverParsesCommonForms() {
+struct GatewayEnvironmentTests {
+    @Test func `semver parses common forms`() {
         #expect(Semver.parse("1.2.3") == Semver(major: 1, minor: 2, patch: 3))
         #expect(Semver.parse("  v1.2.3  \n") == Semver(major: 1, minor: 2, patch: 3))
         #expect(Semver.parse("v2.0.0") == Semver(major: 2, minor: 0, patch: 0))
@@ -21,7 +21,7 @@ import Testing
         #expect(Semver.parse("1.2.x") == nil)
     }
 
-    @Test func semverCompatibilityRequiresSameMajorAndNotOlder() {
+    @Test func `semver compatibility requires same major and not older`() {
         let required = Semver(major: 2, minor: 1, patch: 0)
         #expect(Semver(major: 2, minor: 1, patch: 0).compatible(with: required))
         #expect(Semver(major: 2, minor: 2, patch: 0).compatible(with: required))
@@ -31,7 +31,7 @@ import Testing
         #expect(Semver(major: 1, minor: 9, patch: 9).compatible(with: required) == false)
     }
 
-    @Test func gatewayPortDefaultsAndRespectsOverride() async {
+    @Test func `gateway port defaults and respects override`() async {
         let configPath = TestIsolation.tempConfigPath()
         await TestIsolation.withIsolatedState(
             env: ["REMOTECLAW_CONFIG_PATH": configPath],
@@ -46,7 +46,7 @@ import Testing
         }
     }
 
-    @Test func expectedGatewayVersionFromStringUsesParser() {
+    @Test func `expected gateway version from string uses parser`() {
         #expect(GatewayEnvironment.expectedGatewayVersion(from: "v9.1.2") == Semver(major: 9, minor: 1, patch: 2))
         #expect(GatewayEnvironment.expectedGatewayVersion(from: "2026.1.11-4") == Semver(
             major: 2026,

--- a/apps/macos/Tests/RemoteClawIPCTests/GatewayFrameDecodeTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/GatewayFrameDecodeTests.swift
@@ -2,8 +2,8 @@ import RemoteClawProtocol
 import Foundation
 import Testing
 
-@Suite struct GatewayFrameDecodeTests {
-    @Test func decodesEventFrameWithAnyCodablePayload() throws {
+struct GatewayFrameDecodeTests {
+    @Test func `decodes event frame with any codable payload`() throws {
         let json = """
         {
           "type": "event",
@@ -29,7 +29,7 @@ import Testing
         #expect(evt.seq == 7)
     }
 
-    @Test func decodesRequestFrameWithNestedParams() throws {
+    @Test func `decodes request frame with nested params`() throws {
         let json = """
         {
           "type": "req",
@@ -68,7 +68,7 @@ import Testing
         #expect(meta?["count"]?.value as? Int == 2)
     }
 
-    @Test func decodesUnknownFrameAndPreservesRaw() throws {
+    @Test func `decodes unknown frame and preserves raw`() throws {
         let json = """
         {
           "type": "made-up",

--- a/apps/macos/Tests/RemoteClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -2,8 +2,8 @@ import Foundation
 import Testing
 @testable import RemoteClaw
 
-@Suite struct GatewayLaunchAgentManagerTests {
-    @Test func launchAgentPlistSnapshotParsesArgsAndEnv() throws {
+struct GatewayLaunchAgentManagerTests {
+    @Test func `launch agent plist snapshot parses args and env`() throws {
         let url = FileManager().temporaryDirectory
             .appendingPathComponent("remoteclaw-launchd-\(UUID().uuidString).plist")
         let plist: [String: Any] = [
@@ -24,7 +24,7 @@ import Testing
         #expect(snapshot.password == "pw")
     }
 
-    @Test func launchAgentPlistSnapshotAllowsMissingBind() throws {
+    @Test func `launch agent plist snapshot allows missing bind`() throws {
         let url = FileManager().temporaryDirectory
             .appendingPathComponent("remoteclaw-launchd-\(UUID().uuidString).plist")
         let plist: [String: Any] = [

--- a/apps/macos/Tests/RemoteClawIPCTests/HoverHUDControllerTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/HoverHUDControllerTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct HoverHUDControllerTests {
-    @Test func hoverHUDControllerPresentsAndDismisses() async {
+    @Test func `hover HUD controller presents and dismisses`() async {
         let controller = HoverHUDController()
         controller.setSuppressed(false)
 

--- a/apps/macos/Tests/RemoteClawIPCTests/InstancesSettingsSmokeTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/InstancesSettingsSmokeTests.swift
@@ -4,7 +4,7 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct InstancesSettingsSmokeTests {
-    @Test func instancesSettingsBuildsBodyWithMultipleInstances() {
+    @Test func `instances settings builds body with multiple instances`() {
         let store = InstancesStore(isPreview: true)
         store.statusMessage = "Loaded"
         store.instances = [
@@ -53,7 +53,7 @@ struct InstancesSettingsSmokeTests {
         _ = view.body
     }
 
-    @Test func instancesSettingsExercisesHelpers() {
+    @Test func `instances settings exercises helpers`() {
         InstancesSettings.exerciseForTesting()
     }
 }

--- a/apps/macos/Tests/RemoteClawIPCTests/InstancesStoreTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/InstancesStoreTests.swift
@@ -2,10 +2,10 @@ import RemoteClawProtocol
 import Testing
 @testable import RemoteClaw
 
-@Suite struct InstancesStoreTests {
+struct InstancesStoreTests {
     @Test
     @MainActor
-    func presenceEventPayloadDecodesViaJSONEncoder() {
+    func `presence event payload decodes via JSON encoder`() {
         // Build a payload that mirrors the gateway's presence event shape:
         // { "presence": [ PresenceEntry ] }
         let entry: [String: RemoteClawProtocol.AnyCodable] = [

--- a/apps/macos/Tests/RemoteClawIPCTests/LowCoverageViewSmokeTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/LowCoverageViewSmokeTests.swift
@@ -8,7 +8,7 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct LowCoverageViewSmokeTests {
-    @Test func contextMenuCardBuildsBody() {
+    @Test func `context menu card builds body`() {
         let loading = ContextMenuCardView(rows: [], statusText: "Loading…", isLoading: true)
         _ = loading.body
 
@@ -19,14 +19,14 @@ struct LowCoverageViewSmokeTests {
         _ = withRows.body
     }
 
-    @Test func settingsToggleRowBuildsBody() {
+    @Test func `settings toggle row builds body`() {
         var flag = false
         let binding = Binding(get: { flag }, set: { flag = $0 })
         let view = SettingsToggleRow(title: "Enable", subtitle: "Detail", binding: binding)
         _ = view.body
     }
 
-    @Test func voiceWakeTestCardBuildsBodyAcrossStates() {
+    @Test func `voice wake test card builds body across states`() {
         var state = VoiceWakeTestState.idle
         var isTesting = false
         let stateBinding = Binding(get: { state }, set: { state = $0 })
@@ -45,7 +45,7 @@ struct LowCoverageViewSmokeTests {
         _ = VoiceWakeTestCard(testState: stateBinding, isTesting: testingBinding, onToggle: {}).body
     }
 
-    @Test func agentEventsWindowBuildsBodyWithEvent() {
+    @Test func `agent events window builds body with event`() {
         AgentEventStore.shared.clear()
         let sample = ControlAgentEvent(
             runId: "run-1",
@@ -59,7 +59,7 @@ struct LowCoverageViewSmokeTests {
         AgentEventStore.shared.clear()
     }
 
-    @Test func notifyOverlayPresentsAndDismisses() async {
+    @Test func `notify overlay presents and dismisses`() async {
         let controller = NotifyOverlayController()
         controller.present(title: "Hello", body: "World", autoDismissAfter: 0)
         controller.present(title: "Updated", body: "Again", autoDismissAfter: 0)
@@ -67,14 +67,14 @@ struct LowCoverageViewSmokeTests {
         try? await Task.sleep(nanoseconds: 250_000_000)
     }
 
-    @Test func visualEffectViewHostsInNSHostingView() {
+    @Test func `visual effect view hosts in NS hosting view`() {
         let hosting = NSHostingView(rootView: VisualEffectView(material: .sidebar))
         _ = hosting.fittingSize
         hosting.rootView = VisualEffectView(material: .popover, emphasized: true)
         _ = hosting.fittingSize
     }
 
-    @Test func menuHostedItemHostsContent() {
+    @Test func `menu hosted item hosts content`() {
         let view = MenuHostedItem(width: 240, rootView: AnyView(Text("Menu")))
         let hosting = NSHostingView(rootView: view)
         _ = hosting.fittingSize
@@ -82,18 +82,18 @@ struct LowCoverageViewSmokeTests {
         _ = hosting.fittingSize
     }
 
-    @Test func dockIconManagerUpdatesVisibility() {
+    @Test func `dock icon manager updates visibility`() {
         _ = NSApplication.shared
         UserDefaults.standard.set(false, forKey: showDockIconKey)
         DockIconManager.shared.updateDockVisibility()
         DockIconManager.shared.temporarilyShowDock()
     }
 
-    @Test func voiceWakeSettingsExercisesHelpers() {
+    @Test func `voice wake settings exercises helpers`() {
         VoiceWakeSettings.exerciseForTesting()
     }
 
-    @Test func debugSettingsExercisesHelpers() async {
+    @Test func `debug settings exercises helpers`() async {
         await DebugSettings.exerciseForTesting()
     }
 }

--- a/apps/macos/Tests/RemoteClawIPCTests/MasterDiscoveryMenuSmokeTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/MasterDiscoveryMenuSmokeTests.swift
@@ -6,7 +6,7 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct MasterDiscoveryMenuSmokeTests {
-    @Test func inlineListBuildsBodyWhenEmpty() {
+    @Test func `inline list builds body when empty`() {
         let discovery = GatewayDiscoveryModel(localDisplayName: InstanceIdentity.displayName)
         discovery.statusText = "Searching…"
         discovery.gateways = []
@@ -20,7 +20,7 @@ struct MasterDiscoveryMenuSmokeTests {
         _ = view.body
     }
 
-    @Test func inlineListBuildsBodyWithMasterAndSelection() {
+    @Test func `inline list builds body with master and selection`() {
         let discovery = GatewayDiscoveryModel(localDisplayName: InstanceIdentity.displayName)
         discovery.statusText = "Found 1"
         discovery.gateways = [
@@ -46,7 +46,7 @@ struct MasterDiscoveryMenuSmokeTests {
         _ = view.body
     }
 
-    @Test func menuBuildsBodyWithMasters() {
+    @Test func `menu builds body with masters`() {
         let discovery = GatewayDiscoveryModel(localDisplayName: InstanceIdentity.displayName)
         discovery.statusText = "Found 2"
         discovery.gateways = [

--- a/apps/macos/Tests/RemoteClawIPCTests/MenuContentSmokeTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/MenuContentSmokeTests.swift
@@ -5,28 +5,28 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct MenuContentSmokeTests {
-    @Test func menuContentBuildsBodyLocalMode() {
+    @Test func `menu content builds body local mode`() {
         let state = AppState(preview: true)
         state.connectionMode = .local
         let view = MenuContent(state: state, updater: nil)
         _ = view.body
     }
 
-    @Test func menuContentBuildsBodyRemoteMode() {
+    @Test func `menu content builds body remote mode`() {
         let state = AppState(preview: true)
         state.connectionMode = .remote
         let view = MenuContent(state: state, updater: nil)
         _ = view.body
     }
 
-    @Test func menuContentBuildsBodyUnconfiguredMode() {
+    @Test func `menu content builds body unconfigured mode`() {
         let state = AppState(preview: true)
         state.connectionMode = .unconfigured
         let view = MenuContent(state: state, updater: nil)
         _ = view.body
     }
 
-    @Test func menuContentBuildsBodyWithDebugAndCanvas() {
+    @Test func `menu content builds body with debug and canvas`() {
         let state = AppState(preview: true)
         state.connectionMode = .local
         state.debugPaneEnabled = true

--- a/apps/macos/Tests/RemoteClawIPCTests/MenuSessionsInjectorTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/MenuSessionsInjectorTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct MenuSessionsInjectorTests {
-    @Test func injectsDisconnectedMessage() {
+    @Test func `injects disconnected message`() {
         let injector = MenuSessionsInjector()
         injector.setTestingControlChannelConnected(false)
         injector.setTestingSnapshot(nil, errorText: nil)
@@ -19,7 +19,7 @@ struct MenuSessionsInjectorTests {
         #expect(menu.items.contains { $0.tag == 9_415_557 })
     }
 
-    @Test func injectsSessionRows() {
+    @Test func `injects session rows`() {
         let injector = MenuSessionsInjector()
         injector.setTestingControlChannelConnected(true)
 
@@ -92,7 +92,7 @@ struct MenuSessionsInjectorTests {
         #expect(menu.items.contains { $0.tag == 9_415_557 && $0.isSeparatorItem })
     }
 
-    @Test func costUsageSubmenuDoesNotUseInjectorDelegate() {
+    @Test func `cost usage submenu does not use injector delegate`() {
         let injector = MenuSessionsInjector()
         injector.setTestingControlChannelConnected(true)
 

--- a/apps/macos/Tests/RemoteClawIPCTests/NodePairingApprovalPrompterTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/NodePairingApprovalPrompterTests.swift
@@ -4,7 +4,7 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct NodePairingApprovalPrompterTests {
-    @Test func nodePairingApprovalPrompterExercises() async {
+    @Test func `node pairing approval prompter exercises`() async {
         await NodePairingApprovalPrompter.exerciseForTesting()
     }
 }

--- a/apps/macos/Tests/RemoteClawIPCTests/NodePairingReconcilePolicyTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/NodePairingReconcilePolicyTests.swift
@@ -1,14 +1,14 @@
 import Testing
 @testable import RemoteClaw
 
-@Suite struct NodePairingReconcilePolicyTests {
-    @Test func policyPollsOnlyWhenActive() {
+struct NodePairingReconcilePolicyTests {
+    @Test func `policy polls only when active`() {
         #expect(NodePairingReconcilePolicy.shouldPoll(pendingCount: 0, isPresenting: false) == false)
         #expect(NodePairingReconcilePolicy.shouldPoll(pendingCount: 1, isPresenting: false))
         #expect(NodePairingReconcilePolicy.shouldPoll(pendingCount: 0, isPresenting: true))
     }
 
-    @Test func policyUsesSlowSafetyInterval() {
+    @Test func `policy uses slow safety interval`() {
         #expect(NodePairingReconcilePolicy.activeIntervalMs >= 10000)
     }
 }

--- a/apps/macos/Tests/RemoteClawIPCTests/OnboardingCoverageTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/OnboardingCoverageTests.swift
@@ -4,7 +4,7 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct OnboardingCoverageTests {
-    @Test func exerciseOnboardingPages() {
+    @Test func `exercise onboarding pages`() {
         OnboardingView.exerciseForTesting()
     }
 }

--- a/apps/macos/Tests/RemoteClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/OnboardingViewSmokeTests.swift
@@ -7,7 +7,7 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct OnboardingViewSmokeTests {
-    @Test func onboardingViewBuildsBody() {
+    @Test func `onboarding view builds body`() {
         let state = AppState(preview: true)
         let view = OnboardingView(
             state: state,
@@ -16,18 +16,18 @@ struct OnboardingViewSmokeTests {
         _ = view.body
     }
 
-    @Test func pageOrderOmitsWorkspaceAndIdentitySteps() {
+    @Test func `page order omits workspace and identity steps`() {
         let order = OnboardingView.pageOrder(for: .local, showOnboardingChat: false)
         #expect(!order.contains(7))
         #expect(order.contains(3))
     }
 
-    @Test func pageOrderOmitsOnboardingChatWhenIdentityKnown() {
+    @Test func `page order omits onboarding chat when identity known`() {
         let order = OnboardingView.pageOrder(for: .local, showOnboardingChat: false)
         #expect(!order.contains(8))
     }
 
-    @Test func selectRemoteGatewayClearsStaleSshTargetWhenEndpointUnresolved() async {
+    @Test func `select remote gateway clears stale ssh target when endpoint unresolved`() async {
         let override = FileManager().temporaryDirectory
             .appendingPathComponent("remoteclaw-config-\(UUID().uuidString)")
             .appendingPathComponent("remoteclaw.json")

--- a/apps/macos/Tests/RemoteClawIPCTests/OnboardingWizardStepViewTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/OnboardingWizardStepViewTests.swift
@@ -8,7 +8,7 @@ private typealias ProtoAnyCodable = RemoteClawProtocol.AnyCodable
 @Suite(.serialized)
 @MainActor
 struct OnboardingWizardStepViewTests {
-    @Test func noteStepBuilds() {
+    @Test func `note step builds`() {
         let step = WizardStep(
             id: "step-1",
             type: ProtoAnyCodable("note"),
@@ -23,7 +23,7 @@ struct OnboardingWizardStepViewTests {
         _ = view.body
     }
 
-    @Test func selectStepBuilds() {
+    @Test func `select step builds`() {
         let options: [[String: ProtoAnyCodable]] = [
             ["value": ProtoAnyCodable("local"), "label": ProtoAnyCodable("Local"), "hint": ProtoAnyCodable("This Mac")],
             ["value": ProtoAnyCodable("remote"), "label": ProtoAnyCodable("Remote")],

--- a/apps/macos/Tests/RemoteClawIPCTests/PermissionManagerLocationTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/PermissionManagerLocationTests.swift
@@ -3,16 +3,15 @@ import Testing
 
 @testable import RemoteClaw
 
-@Suite("PermissionManager Location")
 struct PermissionManagerLocationTests {
-    @Test("authorizedAlways counts for both modes")
-    func authorizedAlwaysCountsForBothModes() {
+    @Test
+    func `authorizedAlways counts for both modes`() {
         #expect(PermissionManager.isLocationAuthorized(status: .authorizedAlways, requireAlways: false))
         #expect(PermissionManager.isLocationAuthorized(status: .authorizedAlways, requireAlways: true))
     }
 
-    @Test("other statuses not authorized")
-    func otherStatusesNotAuthorized() {
+    @Test
+    func `other statuses not authorized`() {
         #expect(!PermissionManager.isLocationAuthorized(status: .notDetermined, requireAlways: false))
         #expect(!PermissionManager.isLocationAuthorized(status: .denied, requireAlways: false))
         #expect(!PermissionManager.isLocationAuthorized(status: .restricted, requireAlways: false))

--- a/apps/macos/Tests/RemoteClawIPCTests/PermissionManagerTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/PermissionManagerTests.swift
@@ -6,31 +6,31 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct PermissionManagerTests {
-    @Test func voiceWakePermissionHelpersMatchStatus() async {
+    @Test func `voice wake permission helpers match status`() async {
         let direct = PermissionManager.voiceWakePermissionsGranted()
         let ensured = await PermissionManager.ensureVoiceWakePermissions(interactive: false)
         #expect(ensured == direct)
     }
 
-    @Test func statusCanQueryNonInteractiveCaps() async {
+    @Test func `status can query non interactive caps`() async {
         let caps: [Capability] = [.microphone, .speechRecognition, .screenRecording]
         let status = await PermissionManager.status(caps)
         #expect(status.keys.count == caps.count)
     }
 
-    @Test func ensureNonInteractiveDoesNotThrow() async {
+    @Test func `ensure non interactive does not throw`() async {
         let caps: [Capability] = [.microphone, .speechRecognition, .screenRecording]
         let ensured = await PermissionManager.ensure(caps, interactive: false)
         #expect(ensured.keys.count == caps.count)
     }
 
-    @Test func locationStatusMatchesAuthorizationAlways() async {
+    @Test func `location status matches authorization always`() async {
         let status = CLLocationManager().authorizationStatus
         let results = await PermissionManager.status([.location])
         #expect(results[.location] == (status == .authorizedAlways))
     }
 
-    @Test func ensureLocationNonInteractiveMatchesAuthorizationAlways() async {
+    @Test func `ensure location non interactive matches authorization always`() async {
         let status = CLLocationManager().authorizationStatus
         let ensured = await PermissionManager.ensure([.location], interactive: false)
         #expect(ensured[.location] == (status == .authorizedAlways))

--- a/apps/macos/Tests/RemoteClawIPCTests/Placeholder.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/Placeholder.swift
@@ -1,6 +1,6 @@
 import Testing
 
-@Suite struct PlaceholderTests {
+struct PlaceholderTests {
     @Test func placeholder() {
         #expect(true)
     }

--- a/apps/macos/Tests/RemoteClawIPCTests/RemotePortTunnelTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/RemotePortTunnelTests.swift
@@ -5,8 +5,8 @@ import Testing
 import Darwin
 import Foundation
 
-@Suite struct RemotePortTunnelTests {
-    @Test func drainStderrDoesNotCrashWhenHandleClosed() {
+struct RemotePortTunnelTests {
+    @Test func `drain stderr does not crash when handle closed`() {
         let pipe = Pipe()
         let handle = pipe.fileHandleForReading
         try? handle.close()
@@ -15,7 +15,7 @@ import Foundation
         #expect(drained.isEmpty)
     }
 
-    @Test func portIsFreeDetectsIPv4Listener() {
+    @Test func `port is free detects I pv4 listener`() {
         var fd = socket(AF_INET, SOCK_STREAM, 0)
         #expect(fd >= 0)
         guard fd >= 0 else { return }

--- a/apps/macos/Tests/RemoteClawIPCTests/RuntimeLocatorTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/RuntimeLocatorTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import RemoteClaw
 
-@Suite struct RuntimeLocatorTests {
+struct RuntimeLocatorTests {
     private func makeTempExecutable(contents: String) throws -> URL {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -13,7 +13,7 @@ import Testing
         return path
     }
 
-    @Test func resolveSucceedsWithValidNode() throws {
+    @Test func `resolve succeeds with valid node`() throws {
         let script = """
         #!/bin/sh
         echo v22.5.0
@@ -28,7 +28,7 @@ import Testing
         #expect(res.version == RuntimeVersion(major: 22, minor: 5, patch: 0))
     }
 
-    @Test func resolveFailsWhenTooOld() throws {
+    @Test func `resolve fails when too old`() throws {
         let script = """
         #!/bin/sh
         echo v18.2.0
@@ -43,7 +43,7 @@ import Testing
         #expect(path == node.path)
     }
 
-    @Test func resolveFailsWhenVersionUnparsable() throws {
+    @Test func `resolve fails when version unparsable`() throws {
         let script = """
         #!/bin/sh
         echo node-version:unknown
@@ -58,12 +58,12 @@ import Testing
         #expect(path == node.path)
     }
 
-    @Test func describeFailureIncludesPaths() {
+    @Test func `describe failure includes paths`() {
         let msg = RuntimeLocator.describeFailure(.notFound(searchPaths: ["/tmp/a", "/tmp/b"]))
         #expect(msg.contains("PATH searched: /tmp/a:/tmp/b"))
     }
 
-    @Test func runtimeVersionParsesWithLeadingVAndMetadata() {
+    @Test func `runtime version parses with leading V and metadata`() {
         #expect(RuntimeVersion.from(string: "v22.1.3") == RuntimeVersion(major: 22, minor: 1, patch: 3))
         #expect(RuntimeVersion.from(string: "node 22.3.0-alpha.1") == RuntimeVersion(major: 22, minor: 3, patch: 0))
         #expect(RuntimeVersion.from(string: "bogus") == nil)

--- a/apps/macos/Tests/RemoteClawIPCTests/ScreenshotSizeTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/ScreenshotSizeTests.swift
@@ -2,10 +2,9 @@ import Foundation
 import Testing
 @testable import RemoteClaw
 
-@Suite
 struct ScreenshotSizeTests {
     @Test
-    func readPNGSizeReturnsDimensions() throws {
+    func `read PNG size returns dimensions`() throws {
         let pngBase64 =
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+WZxkAAAAASUVORK5CYII="
         let data = try #require(Data(base64Encoded: pngBase64))
@@ -15,7 +14,7 @@ struct ScreenshotSizeTests {
     }
 
     @Test
-    func readPNGSizeRejectsNonPNGData() {
+    func `read PNG size rejects non PNG data`() {
         #expect(ScreenshotSize.readPNGSize(data: Data("nope".utf8)) == nil)
     }
 }

--- a/apps/macos/Tests/RemoteClawIPCTests/SemverTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/SemverTests.swift
@@ -1,8 +1,8 @@
 import Testing
 @testable import RemoteClaw
 
-@Suite struct SemverTests {
-    @Test func comparisonOrdersByMajorMinorPatch() {
+struct SemverTests {
+    @Test func `comparison orders by major minor patch`() {
         let a = Semver(major: 1, minor: 0, patch: 0)
         let b = Semver(major: 1, minor: 1, patch: 0)
         let c = Semver(major: 1, minor: 1, patch: 1)
@@ -14,7 +14,7 @@ import Testing
         #expect(d > a)
     }
 
-    @Test func descriptionMatchesParts() {
+    @Test func `description matches parts`() {
         let v = Semver(major: 3, minor: 2, patch: 1)
         #expect(v.description == "3.2.1")
     }

--- a/apps/macos/Tests/RemoteClawIPCTests/SessionDataTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/SessionDataTests.swift
@@ -2,27 +2,26 @@ import Foundation
 import Testing
 @testable import RemoteClaw
 
-@Suite
 struct SessionDataTests {
-    @Test func sessionKindFromKeyDetectsCommonKinds() {
+    @Test func `session kind from key detects common kinds`() {
         #expect(SessionKind.from(key: "global") == .global)
         #expect(SessionKind.from(key: "discord:group:engineering") == .group)
         #expect(SessionKind.from(key: "unknown") == .unknown)
         #expect(SessionKind.from(key: "user@example.com") == .direct)
     }
 
-    @Test func sessionTokenStatsFormatKTokensRoundsAsExpected() {
+    @Test func `session token stats format K tokens rounds as expected`() {
         #expect(SessionTokenStats.formatKTokens(999) == "999")
         #expect(SessionTokenStats.formatKTokens(1000) == "1.0k")
         #expect(SessionTokenStats.formatKTokens(12340) == "12k")
     }
 
-    @Test func sessionTokenStatsPercentUsedClampsTo100() {
+    @Test func `session token stats percent used clamps to100`() {
         let stats = SessionTokenStats(input: 0, output: 0, total: 250_000, contextTokens: 200_000)
         #expect(stats.percentUsed == 100)
     }
 
-    @Test func sessionRowFlagLabelsIncludeNonDefaultFlags() {
+    @Test func `session row flag labels include non default flags`() {
         let row = SessionRow(
             id: "x",
             key: "user@example.com",

--- a/apps/macos/Tests/RemoteClawIPCTests/SessionMenuPreviewTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/SessionMenuPreviewTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @Suite(.serialized)
 struct SessionMenuPreviewTests {
-    @Test func loaderReturnsCachedItems() async {
+    @Test func `loader returns cached items`() async {
         await SessionPreviewCache.shared._testReset()
         let items = [SessionPreviewItem(id: "1", role: .user, text: "Hi")]
         let snapshot = SessionMenuPreviewSnapshot(items: items, status: .ready)
@@ -16,7 +16,7 @@ struct SessionMenuPreviewTests {
         #expect(loaded.items.first?.text == "Hi")
     }
 
-    @Test func loaderReturnsEmptyWhenCachedEmpty() async {
+    @Test func `loader returns empty when cached empty`() async {
         await SessionPreviewCache.shared._testReset()
         let snapshot = SessionMenuPreviewSnapshot(items: [], status: .empty)
         await SessionPreviewCache.shared._testSet(snapshot: snapshot, for: "main")

--- a/apps/macos/Tests/RemoteClawIPCTests/TailscaleIntegrationSectionTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/TailscaleIntegrationSectionTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct TailscaleIntegrationSectionTests {
-    @Test func tailscaleSectionBuildsBodyWhenNotInstalled() {
+    @Test func `tailscale section builds body when not installed`() {
         let service = TailscaleService(isInstalled: false, isRunning: false, statusError: "not installed")
         var view = TailscaleIntegrationSection(connectionMode: .local, isPaused: false)
         view.setTestingService(service)
@@ -13,7 +13,7 @@ struct TailscaleIntegrationSectionTests {
         _ = view.body
     }
 
-    @Test func tailscaleSectionBuildsBodyForServeMode() {
+    @Test func `tailscale section builds body for serve mode`() {
         let service = TailscaleService(
             isInstalled: true,
             isRunning: true,
@@ -29,7 +29,7 @@ struct TailscaleIntegrationSectionTests {
         _ = view.body
     }
 
-    @Test func tailscaleSectionBuildsBodyForFunnelMode() {
+    @Test func `tailscale section builds body for funnel mode`() {
         let service = TailscaleService(
             isInstalled: true,
             isRunning: false,

--- a/apps/macos/Tests/RemoteClawIPCTests/TalkAudioPlayerTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/TalkAudioPlayerTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @Suite(.serialized) struct TalkAudioPlayerTests {
     @MainActor
-    @Test func playDoesNotHangWhenPlaybackEndsOrFails() async throws {
+    @Test func `play does not hang when playback ends or fails`() async throws {
         let wav = makeWav16Mono(sampleRate: 8000, samples: 80)
         defer { _ = TalkAudioPlayer.shared.stop() }
 
@@ -16,7 +16,7 @@ import Testing
     }
 
     @MainActor
-    @Test func playDoesNotHangWhenPlayIsCalledTwice() async throws {
+    @Test func `play does not hang when play is called twice`() async throws {
         let wav = makeWav16Mono(sampleRate: 8000, samples: 800)
         defer { _ = TalkAudioPlayer.shared.stop() }
 

--- a/apps/macos/Tests/RemoteClawIPCTests/VoicePushToTalkHotkeyTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/VoicePushToTalkHotkeyTests.swift
@@ -12,7 +12,7 @@ import Testing
         func snapshot() -> (began: Int, ended: Int) { (self.began, self.ended) }
     }
 
-    @Test func beginEndFiresOncePerHold() async {
+    @Test func `begin end fires once per hold`() async {
         let counter = Counter()
         let hotkey = VoicePushToTalkHotkey(
             beginAction: { await counter.incBegin() },

--- a/apps/macos/Tests/RemoteClawIPCTests/VoicePushToTalkTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/VoicePushToTalkTests.swift
@@ -1,23 +1,23 @@
 import Testing
 @testable import RemoteClaw
 
-@Suite struct VoicePushToTalkTests {
-    @Test func deltaTrimsCommittedPrefix() {
+struct VoicePushToTalkTests {
+    @Test func `delta trims committed prefix`() {
         let delta = VoicePushToTalk._testDelta(committed: "hello ", current: "hello world again")
         #expect(delta == "world again")
     }
 
-    @Test func deltaFallsBackWhenPrefixDiffers() {
+    @Test func `delta falls back when prefix differs`() {
         let delta = VoicePushToTalk._testDelta(committed: "goodbye", current: "hello world")
         #expect(delta == "hello world")
     }
 
-    @Test func attributedColorsDifferWhenNotFinal() {
+    @Test func `attributed colors differ when not final`() {
         let colors = VoicePushToTalk._testAttributedColors(isFinal: false)
         #expect(colors.0 != colors.1)
     }
 
-    @Test func attributedColorsMatchWhenFinal() {
+    @Test func `attributed colors match when final`() {
         let colors = VoicePushToTalk._testAttributedColors(isFinal: true)
         #expect(colors.0 == colors.1)
     }

--- a/apps/macos/Tests/RemoteClawIPCTests/VoiceWakeForwarderTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/VoiceWakeForwarderTests.swift
@@ -2,7 +2,7 @@ import Testing
 @testable import RemoteClaw
 
 @Suite(.serialized) struct VoiceWakeForwarderTests {
-    @Test func prefixedTranscriptUsesMachineName() {
+    @Test func `prefixed transcript uses machine name`() {
         let transcript = "hello world"
         let prefixed = VoiceWakeForwarder.prefixedTranscript(transcript, machineName: "My-Mac")
 
@@ -11,7 +11,7 @@ import Testing
         #expect(prefixed.hasSuffix("\n\nhello world"))
     }
 
-    @Test func forwardOptionsDefaults() {
+    @Test func `forward options defaults`() {
         let opts = VoiceWakeForwarder.ForwardOptions()
         #expect(opts.sessionKey == "main")
         #expect(opts.thinking == "low")

--- a/apps/macos/Tests/RemoteClawIPCTests/VoiceWakeHelpersTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/VoiceWakeHelpersTests.swift
@@ -2,33 +2,33 @@ import Testing
 @testable import RemoteClaw
 
 struct VoiceWakeHelpersTests {
-    @Test func sanitizeTriggersTrimsAndDropsEmpty() {
+    @Test func `sanitize triggers trims and drops empty`() {
         let cleaned = sanitizeVoiceWakeTriggers(["  hi  ", " ", "\n", "there"])
         #expect(cleaned == ["hi", "there"])
     }
 
-    @Test func sanitizeTriggersFallsBackToDefaults() {
+    @Test func `sanitize triggers falls back to defaults`() {
         let cleaned = sanitizeVoiceWakeTriggers(["   ", ""])
         #expect(cleaned == defaultVoiceWakeTriggers)
     }
 
-    @Test func sanitizeTriggersLimitsWordLength() {
+    @Test func `sanitize triggers limits word length`() {
         let long = String(repeating: "x", count: voiceWakeMaxWordLength + 5)
         let cleaned = sanitizeVoiceWakeTriggers(["ok", long])
         #expect(cleaned[1].count == voiceWakeMaxWordLength)
     }
 
-    @Test func sanitizeTriggersLimitsWordCount() {
+    @Test func `sanitize triggers limits word count`() {
         let words = (1...voiceWakeMaxWords + 3).map { "w\($0)" }
         let cleaned = sanitizeVoiceWakeTriggers(words)
         #expect(cleaned.count == voiceWakeMaxWords)
     }
 
-    @Test func normalizeLocaleStripsCollation() {
+    @Test func `normalize locale strips collation`() {
         #expect(normalizeLocaleIdentifier("en_US@collation=phonebook") == "en_US")
     }
 
-    @Test func normalizeLocaleStripsUnicodeExtensions() {
+    @Test func `normalize locale strips unicode extensions`() {
         #expect(normalizeLocaleIdentifier("de-DE-u-co-phonebk") == "de-DE")
         #expect(normalizeLocaleIdentifier("ja-JP-t-ja") == "ja-JP")
     }

--- a/apps/macos/Tests/RemoteClawIPCTests/VoiceWakeOverlayControllerTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/VoiceWakeOverlayControllerTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct VoiceWakeOverlayControllerTests {
-    @Test func overlayControllerLifecycleWithoutUI() async {
+    @Test func `overlay controller lifecycle without UI`() async {
         let controller = VoiceWakeOverlayController(enableUI: false)
         let token = controller.startSession(
             source: .wakeWord,
@@ -31,7 +31,7 @@ struct VoiceWakeOverlayControllerTests {
         #expect(controller.snapshot().token == nil)
     }
 
-    @Test func evaluateTokenDropsMismatchAndNoActive() {
+    @Test func `evaluate token drops mismatch and no active`() {
         let active = UUID()
         #expect(VoiceWakeOverlayController.evaluateToken(active: nil, incoming: active) == .dropNoActive)
         #expect(VoiceWakeOverlayController.evaluateToken(active: active, incoming: UUID()) == .dropMismatch)
@@ -39,7 +39,7 @@ struct VoiceWakeOverlayControllerTests {
         #expect(VoiceWakeOverlayController.evaluateToken(active: active, incoming: nil) == .accept)
     }
 
-    @Test func updateLevelThrottlesRapidChanges() async {
+    @Test func `update level throttles rapid changes`() async {
         let controller = VoiceWakeOverlayController(enableUI: false)
         let token = controller.startSession(
             source: .wakeWord,
@@ -62,7 +62,7 @@ struct VoiceWakeOverlayControllerTests {
         #expect(controller.model.level == 0.9)
     }
 
-    @Test func overlayControllerExercisesHelpers() async {
+    @Test func `overlay controller exercises helpers`() async {
         await VoiceWakeOverlayController.exerciseForTesting()
     }
 }

--- a/apps/macos/Tests/RemoteClawIPCTests/VoiceWakeOverlayTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/VoiceWakeOverlayTests.swift
@@ -2,19 +2,19 @@ import Foundation
 import Testing
 @testable import RemoteClaw
 
-@Suite struct VoiceWakeOverlayTests {
-    @Test func guardTokenDropsWhenNoActive() {
+struct VoiceWakeOverlayTests {
+    @Test func `guard token drops when no active`() {
         let outcome = VoiceWakeOverlayController.evaluateToken(active: nil, incoming: UUID())
         #expect(outcome == .dropNoActive)
     }
 
-    @Test func guardTokenAcceptsMatching() {
+    @Test func `guard token accepts matching`() {
         let token = UUID()
         let outcome = VoiceWakeOverlayController.evaluateToken(active: token, incoming: token)
         #expect(outcome == .accept)
     }
 
-    @Test func guardTokenDropsMismatchWithoutDismissing() {
+    @Test func `guard token drops mismatch without dismissing`() {
         let outcome = VoiceWakeOverlayController.evaluateToken(active: UUID(), incoming: UUID())
         #expect(outcome == .dropMismatch)
     }

--- a/apps/macos/Tests/RemoteClawIPCTests/VoiceWakeOverlayViewSmokeTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/VoiceWakeOverlayViewSmokeTests.swift
@@ -5,14 +5,14 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct VoiceWakeOverlayViewSmokeTests {
-    @Test func overlayViewBuildsBodyInDisplayMode() {
+    @Test func `overlay view builds body in display mode`() {
         let controller = VoiceWakeOverlayController(enableUI: false)
         _ = controller.startSession(source: .wakeWord, transcript: "hello", forwardEnabled: true)
         let view = VoiceWakeOverlayView(controller: controller)
         _ = view.body
     }
 
-    @Test func overlayViewBuildsBodyInEditingMode() {
+    @Test func `overlay view builds body in editing mode`() {
         let controller = VoiceWakeOverlayController(enableUI: false)
         let token = controller.startSession(source: .pushToTalk, transcript: "edit me", forwardEnabled: true)
         controller.userBeganEditing()
@@ -21,7 +21,7 @@ struct VoiceWakeOverlayViewSmokeTests {
         _ = view.body
     }
 
-    @Test func closeButtonOverlayBuildsBody() {
+    @Test func `close button overlay builds body`() {
         let view = CloseButtonOverlay(isVisible: true, onHover: { _ in }, onClose: {})
         _ = view.body
     }

--- a/apps/macos/Tests/RemoteClawIPCTests/VoiceWakeTesterTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/VoiceWakeTesterTests.swift
@@ -3,7 +3,7 @@ import SwabbleKit
 import Testing
 
 struct VoiceWakeTesterTests {
-    @Test func matchRespectsGapRequirement() {
+    @Test func `match respects gap requirement`() {
         let transcript = "hey claude do thing"
         let segments = makeSegments(
             transcript: transcript,
@@ -17,7 +17,7 @@ struct VoiceWakeTesterTests {
         #expect(WakeWordGate.match(transcript: transcript, segments: segments, config: config) == nil)
     }
 
-    @Test func matchReturnsCommandAfterGap() {
+    @Test func `match returns command after gap`() {
         let transcript = "hey claude do thing"
         let segments = makeSegments(
             transcript: transcript,

--- a/apps/macos/Tests/RemoteClawIPCTests/WebChatMainSessionKeyTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/WebChatMainSessionKeyTests.swift
@@ -2,8 +2,8 @@ import Foundation
 import Testing
 @testable import RemoteClaw
 
-@Suite struct WebChatMainSessionKeyTests {
-    @Test func configGetSnapshotMainKeyFallsBackToMainWhenMissing() throws {
+struct WebChatMainSessionKeyTests {
+    @Test func `config get snapshot main key falls back to main when missing`() throws {
         let json = """
         {
           "path": "/Users/pete/.remoteclaw/remoteclaw.json",
@@ -19,7 +19,7 @@ import Testing
         #expect(key == "main")
     }
 
-    @Test func configGetSnapshotMainKeyTrimsAndUsesValue() throws {
+    @Test func `config get snapshot main key trims and uses value`() throws {
         let json = """
         {
           "path": "/Users/pete/.remoteclaw/remoteclaw.json",
@@ -35,7 +35,7 @@ import Testing
         #expect(key == "main")
     }
 
-    @Test func configGetSnapshotMainKeyFallsBackWhenEmptyOrWhitespace() throws {
+    @Test func `config get snapshot main key falls back when empty or whitespace`() throws {
         let json = """
         {
           "config": { "session": { "mainKey": "   " } }
@@ -45,7 +45,7 @@ import Testing
         #expect(key == "main")
     }
 
-    @Test func configGetSnapshotMainKeyFallsBackWhenConfigNull() throws {
+    @Test func `config get snapshot main key falls back when config null`() throws {
         let json = """
         {
           "config": null
@@ -55,7 +55,7 @@ import Testing
         #expect(key == "main")
     }
 
-    @Test func configGetSnapshotUsesGlobalScope() throws {
+    @Test func `config get snapshot uses global scope`() throws {
         let json = """
         {
           "config": { "session": { "scope": "global" } }

--- a/apps/macos/Tests/RemoteClawIPCTests/WebChatManagerTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/WebChatManagerTests.swift
@@ -4,7 +4,7 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct WebChatManagerTests {
-    @Test func preferredSessionKeyIsNonEmpty() async {
+    @Test func `preferred session key is non empty`() async {
         let key = await WebChatManager.shared.preferredSessionKey()
         #expect(!key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
     }

--- a/apps/macos/Tests/RemoteClawIPCTests/WindowPlacementTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/WindowPlacementTests.swift
@@ -2,18 +2,17 @@ import AppKit
 import Testing
 @testable import RemoteClaw
 
-@Suite
 @MainActor
 struct WindowPlacementTests {
     @Test
-    func centeredFrameZeroBoundsFallsBackToOrigin() {
+    func `centered frame zero bounds falls back to origin`() {
         let frame = WindowPlacement.centeredFrame(size: NSSize(width: 120, height: 80), in: NSRect.zero)
         #expect(frame.origin == .zero)
         #expect(frame.size == NSSize(width: 120, height: 80))
     }
 
     @Test
-    func centeredFrameClampsToBoundsAndCenters() {
+    func `centered frame clamps to bounds and centers`() {
         let bounds = NSRect(x: 10, y: 20, width: 300, height: 200)
         let frame = WindowPlacement.centeredFrame(size: NSSize(width: 600, height: 120), in: bounds)
         #expect(frame.size.width == bounds.width)
@@ -23,7 +22,7 @@ struct WindowPlacementTests {
     }
 
     @Test
-    func topRightFrameZeroBoundsFallsBackToOrigin() {
+    func `top right frame zero bounds falls back to origin`() {
         let frame = WindowPlacement.topRightFrame(
             size: NSSize(width: 120, height: 80),
             padding: 12,
@@ -33,7 +32,7 @@ struct WindowPlacementTests {
     }
 
     @Test
-    func topRightFrameClampsToBoundsAndAppliesPadding() {
+    func `top right frame clamps to bounds and applies padding`() {
         let bounds = NSRect(x: 10, y: 20, width: 300, height: 200)
         let frame = WindowPlacement.topRightFrame(
             size: NSSize(width: 400, height: 50),
@@ -46,7 +45,7 @@ struct WindowPlacementTests {
     }
 
     @Test
-    func ensureOnScreenUsesFallbackWhenWindowOffscreen() {
+    func `ensure on screen uses fallback when window offscreen`() {
         let window = NSWindow(
             contentRect: NSRect(x: 100_000, y: 100_000, width: 200, height: 120),
             styleMask: [.borderless],
@@ -62,7 +61,7 @@ struct WindowPlacementTests {
     }
 
     @Test
-    func ensureOnScreenDoesNotMoveVisibleWindow() {
+    func `ensure on screen does not move visible window`() {
         let screen = NSScreen.main ?? NSScreen.screens.first
         #expect(screen != nil)
         guard let screen else { return }

--- a/apps/macos/Tests/RemoteClawIPCTests/WorkActivityStoreTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/WorkActivityStoreTests.swift
@@ -3,10 +3,9 @@ import Foundation
 import Testing
 @testable import RemoteClaw
 
-@Suite
 @MainActor
 struct WorkActivityStoreTests {
-    @Test func mainSessionJobPreemptsOther() {
+    @Test func `main session job preempts other`() {
         let store = WorkActivityStore()
 
         store.handleJob(sessionKey: "discord:group:1", state: "started")
@@ -26,7 +25,7 @@ struct WorkActivityStoreTests {
         #expect(store.current == nil)
     }
 
-    @Test func jobStaysWorkingAfterToolResultGrace() async {
+    @Test func `job stays working after tool result grace`() async {
         let store = WorkActivityStore()
 
         store.handleJob(sessionKey: "main", state: "started")
@@ -57,7 +56,7 @@ struct WorkActivityStoreTests {
         #expect(store.iconState == .idle)
     }
 
-    @Test func toolLabelExtractsFirstLineAndShortensHome() {
+    @Test func `tool label extracts first line and shortens home`() {
         let store = WorkActivityStore()
         let home = NSHomeDirectory()
 
@@ -85,7 +84,7 @@ struct WorkActivityStoreTests {
         #expect(store.iconState == .workingMain(.tool(.read)))
     }
 
-    @Test func resolveIconStateHonorsOverrideSelection() {
+    @Test func `resolve icon state honors override selection`() {
         let store = WorkActivityStore()
         store.handleJob(sessionKey: "main", state: "started")
         #expect(store.iconState == .workingMain(.job))


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`53fb317e7`](https://github.com/openclaw/openclaw/commit/53fb317e7fa523c424992d28706c7c24549ad306)
- **Author**: [steipete](https://github.com/steipete)
- **Tier**: AUTO-PARTIAL

## Summary
Clean swiftformat pass across macOS sources and tests, plus a `@Sendable` warning fix. Upstream touched 129 files; after excluding files deleted in the fork (at old OpenClaw paths) and resolving formatting conflicts, 82 files changed.

## Adaptation
- Removed 15 files at old `OpenClaw`/`OpenClawIPCTests` paths (deleted-by-us/modified-by-them conflicts) -- these files exist at rebranded paths
- Resolved 32 content conflicts by keeping fork's rebranded names; formatting changes that didn't conflict were auto-merged
- No semantic changes -- purely formatting and `@Sendable` compliance

Depends on #1279.
Cherry-picked from openclaw/openclaw per [#902](https://github.com/remoteclaw/remoteclaw/issues/902).