### PR TITLE
Cherry-pick d5b305b25: fix: follow up #39321 and #38445 landings

### DIFF
--- a/apps/macos/Sources/RemoteClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/RemoteClaw/TalkModeRuntime.swift
@@ -71,6 +71,11 @@ actor TalkModeRuntime {
     private let minSpeechRMS: Double = 1e-3
     private let speechBoostFactor: Double = 6.0
 
+    static func configureRecognitionRequest(_ request: SFSpeechAudioBufferRecognitionRequest) {
+        request.shouldReportPartialResults = true
+        request.taskHint = .dictation
+    }
+
     // MARK: - Lifecycle
 
     func setEnabled(_ enabled: Bool) async {
@@ -177,9 +182,9 @@ actor TalkModeRuntime {
             return
         }
 
-        self.recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
-        self.recognitionRequest?.shouldReportPartialResults = true
-        guard let request = self.recognitionRequest else { return }
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        Self.configureRecognitionRequest(request)
+        self.recognitionRequest = request
 
         if self.audioEngine == nil {
             self.audioEngine = AVAudioEngine()

--- a/apps/macos/Tests/RemoteClawIPCTests/LowCoverageViewSmokeTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/LowCoverageViewSmokeTests.swift
@@ -67,6 +67,15 @@ struct LowCoverageViewSmokeTests {
         try? await Task.sleep(nanoseconds: 250_000_000)
     }
 
+    @Test func `talk overlay presents twice and dismisses`() async {
+        let controller = TalkOverlayController()
+        controller.present()
+        controller.updateLevel(0.4)
+        controller.present()
+        controller.dismiss()
+        try? await Task.sleep(nanoseconds: 250_000_000)
+    }
+
     @Test func `visual effect view hosts in NS hosting view`() {
         let hosting = NSHostingView(rootView: VisualEffectView(material: .sidebar))
         _ = hosting.fittingSize

--- a/apps/macos/Tests/RemoteClawIPCTests/TalkModeRuntimeSpeechTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/TalkModeRuntimeSpeechTests.swift
@@ -1,0 +1,14 @@
+import Speech
+import Testing
+@testable import RemoteClaw
+
+struct TalkModeRuntimeSpeechTests {
+    @Test func `speech request uses dictation defaults`() {
+        let request = SFSpeechAudioBufferRecognitionRequest()
+
+        TalkModeRuntime.configureRecognitionRequest(request)
+
+        #expect(request.shouldReportPartialResults)
+        #expect(request.taskHint == .dictation)
+    }
+}


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`d5b305b25`](https://github.com/openclaw/openclaw/commit/d5b305b250066a629d1a9d37620992814c272d36)
- **Author**: [steipete](https://github.com/steipete)
- **Tier**: AUTO-PARTIAL

## Summary
Follow-up fixes for upstream PRs #39321 and #38445: extracts speech recognition request configuration into a static `configureRecognitionRequest()` method on `TalkModeRuntime`, adds `.dictation` task hint, and adds a test verifying the defaults.

## Adaptation
- Took ours for `.secrets.baseline` and `CHANGELOG.md`
- Resolved `TalkModeRuntime.swift` conflict to take upstream's refactored `configureRecognitionRequest()` pattern
- Rebranded `@testable import OpenClaw` to `@testable import RemoteClaw` in new test file
- New test file auto-placed at rebranded path (`RemoteClawIPCTests/`)

Depends on #1280.
Cherry-picked from openclaw/openclaw per [#902](https://github.com/remoteclaw/remoteclaw/issues/902).