### PR TITLE
Cherry-pick ca5e352c5: CLI include commit hash in --version output

### DIFF
--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -453,7 +453,7 @@ export async function buildStatusMessage(args: StatusArgs): Promise<string> {
   const fallbackLine = isFallbackActive
     ? `↪️ Fallback: ${activeModelLabel} (${fallbackReason})`
     : null;
-  const commit = resolveCommitHash();
+  const commit = resolveCommitHash({ moduleUrl: import.meta.url });
   const versionLine = `🦀 RemoteClaw ${VERSION}${commit ? ` (${commit})` : ""}`;
   const usagePair = formatUsagePair(inputTokens, outputTokens);
   const cacheLine = formatCacheLine(inputTokens, cacheRead, cacheWrite);

--- a/src/cli/banner.ts
+++ b/src/cli/banner.ts
@@ -36,7 +36,8 @@ const hasVersionFlag = (argv: string[]) =>
   argv.some((arg) => arg === "--version" || arg === "-V") || hasRootVersionAlias(argv);
 
 export function formatCliBannerLine(version: string, options: BannerOptions = {}): string {
-  const commit = options.commit ?? resolveCommitHash({ env: options.env });
+  const commit =
+    options.commit ?? resolveCommitHash({ env: options.env, moduleUrl: import.meta.url });
   const commitLabel = commit ?? "unknown";
   const tagline = pickTagline(options);
   const rich = options.richTty ?? isRich();

--- a/src/cli/program/help.test.ts
+++ b/src/cli/program/help.test.ts
@@ -5,6 +5,7 @@ import type { ProgramContext } from "./context.js";
 const hasEmittedCliBannerMock = vi.fn(() => false);
 const formatCliBannerLineMock = vi.fn(() => "BANNER-LINE");
 const formatDocsLinkMock = vi.fn((_path: string, full: string) => `https://${full}`);
+const resolveCommitHashMock = vi.fn<() => string | null>(() => "abc1234");
 
 vi.mock("../../terminal/links.js", () => ({
   formatDocsLink: formatDocsLinkMock,
@@ -24,6 +25,10 @@ vi.mock("../../terminal/theme.js", () => ({
 vi.mock("../banner.js", () => ({
   formatCliBannerLine: formatCliBannerLineMock,
   hasEmittedCliBanner: hasEmittedCliBannerMock,
+}));
+
+vi.mock("../../infra/git-commit.js", () => ({
+  resolveCommitHash: resolveCommitHashMock,
 }));
 
 vi.mock("../cli-name.js", () => ({
@@ -55,6 +60,7 @@ describe("configureProgramHelp", () => {
     vi.clearAllMocks();
     originalArgv = [...process.argv];
     hasEmittedCliBannerMock.mockReturnValue(false);
+    resolveCommitHashMock.mockReturnValue("abc1234");
   });
 
   afterEach(() => {
@@ -116,7 +122,25 @@ describe("configureProgramHelp", () => {
 
     const program = makeProgramWithCommands();
     expect(() => configureProgramHelp(program, testProgramContext)).toThrow("exit:0");
-    expect(logSpy).toHaveBeenCalledWith("9.9.9-test");
+    expect(logSpy).toHaveBeenCalledWith("RemoteClaw 9.9.9-test (abc1234)");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("prints version and exits immediately without commit metadata", () => {
+    process.argv = ["node", "remoteclaw", "--version"];
+    resolveCommitHashMock.mockReturnValue(null);
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? ""}`);
+    }) as typeof process.exit);
+
+    const program = makeProgramWithCommands();
+    expect(() => configureProgramHelp(program, testProgramContext)).toThrow("exit:0");
+    expect(logSpy).toHaveBeenCalledWith("RemoteClaw 9.9.9-test");
     expect(exitSpy).toHaveBeenCalledWith(0);
 
     logSpy.mockRestore();

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { resolveCommitHash } from "../../infra/git-commit.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { isRich, theme } from "../../terminal/theme.js";
 import { escapeRegExp } from "../../utils.js";
@@ -112,7 +113,10 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     hasFlag(process.argv, "--version") ||
     hasRootVersionAlias(process.argv)
   ) {
-    console.log(ctx.programVersion);
+    const commit = resolveCommitHash({ moduleUrl: import.meta.url });
+    console.log(
+      commit ? `RemoteClaw ${ctx.programVersion} (${commit})` : `RemoteClaw ${ctx.programVersion}`,
+    );
     process.exit(0);
   }
 

--- a/src/infra/git-commit.test.ts
+++ b/src/infra/git-commit.test.ts
@@ -1,0 +1,402 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function makeTempDir(label: string): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), `remoteclaw-${label}-`));
+}
+
+async function makeFakeGitRepo(
+  root: string,
+  options: {
+    head: string;
+    refs?: Record<string, string>;
+    gitdir?: string;
+    commondir?: string;
+  },
+) {
+  await fs.mkdir(root, { recursive: true });
+  const gitdir = options.gitdir ?? path.join(root, ".git");
+  if (options.gitdir) {
+    await fs.writeFile(path.join(root, ".git"), `gitdir: ${options.gitdir}\n`, "utf-8");
+  } else {
+    await fs.mkdir(gitdir, { recursive: true });
+  }
+  await fs.mkdir(gitdir, { recursive: true });
+  await fs.writeFile(path.join(gitdir, "HEAD"), options.head, "utf-8");
+  if (options.commondir) {
+    await fs.writeFile(path.join(gitdir, "commondir"), options.commondir, "utf-8");
+  }
+  for (const [refPath, commit] of Object.entries(options.refs ?? {})) {
+    const targetPath = path.join(gitdir, refPath);
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.writeFile(targetPath, `${commit}\n`, "utf-8");
+  }
+}
+
+describe("git commit resolution", () => {
+  const originalCwd = process.cwd();
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.resetModules();
+  });
+
+  it("resolves commit metadata from the caller module root instead of the caller cwd", async () => {
+    const repoHead = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
+      cwd: originalCwd,
+      encoding: "utf-8",
+    }).trim();
+
+    const temp = await makeTempDir("git-commit-cwd");
+    const otherRepo = path.join(temp, "other");
+    await fs.mkdir(otherRepo, { recursive: true });
+    execFileSync("git", ["init", "-q"], { cwd: otherRepo });
+    await fs.writeFile(path.join(otherRepo, "note.txt"), "x\n", "utf-8");
+    execFileSync("git", ["add", "note.txt"], { cwd: otherRepo });
+    execFileSync(
+      "git",
+      ["-c", "user.name=test", "-c", "user.email=test@example.com", "commit", "-q", "-m", "init"],
+      { cwd: otherRepo },
+    );
+    const otherHead = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
+      cwd: otherRepo,
+      encoding: "utf-8",
+    }).trim();
+
+    process.chdir(otherRepo);
+    const { resolveCommitHash } = await import("./git-commit.js");
+    const entryModuleUrl = pathToFileURL(path.join(originalCwd, "src", "entry.ts")).href;
+
+    expect(resolveCommitHash({ moduleUrl: entryModuleUrl })).toBe(repoHead);
+    expect(resolveCommitHash({ moduleUrl: entryModuleUrl })).not.toBe(otherHead);
+  });
+
+  it("prefers live git metadata over stale build info in a real checkout", async () => {
+    const repoHead = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
+      cwd: originalCwd,
+      encoding: "utf-8",
+    }).trim();
+
+    vi.doMock("node:module", () => ({
+      createRequire: () => {
+        return (specifier: string) => {
+          if (specifier === "../build-info.json" || specifier === "./build-info.json") {
+            return { commit: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" };
+          }
+          throw Object.assign(new Error(`Cannot find module ${specifier}`), {
+            code: "MODULE_NOT_FOUND",
+          });
+        };
+      },
+    }));
+    vi.resetModules();
+
+    const { resolveCommitHash } = await import("./git-commit.js");
+    const entryModuleUrl = pathToFileURL(path.join(originalCwd, "src", "entry.ts")).href;
+
+    expect(resolveCommitHash({ moduleUrl: entryModuleUrl, env: {} })).toBe(repoHead);
+
+    vi.doUnmock("node:module");
+  });
+
+  it("caches build-info fallback results per resolved search directory", async () => {
+    const temp = await makeTempDir("git-commit-build-info-cache");
+    const moduleRequire = vi.fn((specifier: string) => {
+      if (specifier === "../build-info.json" || specifier === "./build-info.json") {
+        return { commit: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" };
+      }
+      throw Object.assign(new Error(`Cannot find module ${specifier}`), {
+        code: "MODULE_NOT_FOUND",
+      });
+    });
+
+    vi.doMock("node:module", () => ({
+      createRequire: () => moduleRequire,
+    }));
+    vi.resetModules();
+
+    const { resolveCommitHash } = await import("./git-commit.js");
+
+    expect(resolveCommitHash({ cwd: temp, env: {} })).toBe("deadbee");
+    const firstCallRequires = moduleRequire.mock.calls.length;
+    expect(firstCallRequires).toBeGreaterThan(0);
+    expect(resolveCommitHash({ cwd: temp, env: {} })).toBe("deadbee");
+    expect(moduleRequire.mock.calls.length).toBe(firstCallRequires);
+
+    vi.doUnmock("node:module");
+  });
+
+  it("caches package.json fallback results per resolved search directory", async () => {
+    const temp = await makeTempDir("git-commit-package-json-cache");
+    const moduleRequire = vi.fn((specifier: string) => {
+      if (specifier === "../build-info.json" || specifier === "./build-info.json") {
+        throw Object.assign(new Error(`Cannot find module ${specifier}`), {
+          code: "MODULE_NOT_FOUND",
+        });
+      }
+      if (specifier === "../../package.json") {
+        return { gitHead: "badc0ffee0ddf00d" };
+      }
+      throw Object.assign(new Error(`Cannot find module ${specifier}`), {
+        code: "MODULE_NOT_FOUND",
+      });
+    });
+
+    vi.doMock("node:module", () => ({
+      createRequire: () => moduleRequire,
+    }));
+    vi.resetModules();
+
+    const { resolveCommitHash } = await import("./git-commit.js");
+
+    expect(resolveCommitHash({ cwd: temp, env: {} })).toBe("badc0ff");
+    const firstCallRequires = moduleRequire.mock.calls.length;
+    expect(firstCallRequires).toBeGreaterThan(0);
+    expect(resolveCommitHash({ cwd: temp, env: {} })).toBe("badc0ff");
+    expect(moduleRequire.mock.calls.length).toBe(firstCallRequires);
+
+    vi.doUnmock("node:module");
+  });
+
+  it("treats invalid moduleUrl inputs as a fallback hint instead of throwing", async () => {
+    const repoHead = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
+      cwd: originalCwd,
+      encoding: "utf-8",
+    }).trim();
+
+    const { resolveCommitHash } = await import("./git-commit.js");
+
+    expect(() =>
+      resolveCommitHash({ moduleUrl: "not-a-file-url", cwd: originalCwd, env: {} }),
+    ).not.toThrow();
+    expect(resolveCommitHash({ moduleUrl: "not-a-file-url", cwd: originalCwd, env: {} })).toBe(
+      repoHead,
+    );
+  });
+
+  it("does not walk out of the remoteclaw package into a host repo", async () => {
+    const temp = await makeTempDir("git-commit-package-boundary");
+    const hostRepo = path.join(temp, "host");
+    await fs.mkdir(hostRepo, { recursive: true });
+    execFileSync("git", ["init", "-q"], { cwd: hostRepo });
+    await fs.writeFile(path.join(hostRepo, "host.txt"), "x\n", "utf-8");
+    execFileSync("git", ["add", "host.txt"], { cwd: hostRepo });
+    execFileSync(
+      "git",
+      ["-c", "user.name=test", "-c", "user.email=test@example.com", "commit", "-q", "-m", "init"],
+      { cwd: hostRepo },
+    );
+
+    const packageRoot = path.join(hostRepo, "node_modules", "remoteclaw");
+    await fs.mkdir(path.join(packageRoot, "dist"), { recursive: true });
+    await fs.writeFile(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "remoteclaw", version: "2026.3.8" }),
+      "utf-8",
+    );
+    const moduleUrl = pathToFileURL(path.join(packageRoot, "dist", "entry.js")).href;
+
+    vi.doMock("node:module", () => ({
+      createRequire: () => {
+        return (specifier: string) => {
+          if (specifier === "../build-info.json" || specifier === "./build-info.json") {
+            return { commit: "feedfacefeedfacefeedfacefeedfacefeedface" };
+          }
+          if (specifier === "../../package.json") {
+            return { name: "remoteclaw", version: "2026.3.8", gitHead: "badc0ffee0ddf00d" };
+          }
+          throw Object.assign(new Error(`Cannot find module ${specifier}`), {
+            code: "MODULE_NOT_FOUND",
+          });
+        };
+      },
+    }));
+    vi.resetModules();
+
+    const { resolveCommitHash } = await import("./git-commit.js");
+
+    expect(resolveCommitHash({ moduleUrl, cwd: packageRoot, env: {} })).toBe("feedfac");
+
+    vi.doUnmock("node:module");
+  });
+
+  it("caches git lookups per resolved search directory", async () => {
+    const temp = await makeTempDir("git-commit-cache");
+    const repoA = path.join(temp, "repo-a");
+    const repoB = path.join(temp, "repo-b");
+    await makeFakeGitRepo(repoA, {
+      head: "0123456789abcdef0123456789abcdef01234567\n",
+    });
+    await makeFakeGitRepo(repoB, {
+      head: "89abcdef0123456789abcdef0123456789abcdef\n",
+    });
+
+    const { resolveCommitHash } = await import("./git-commit.js");
+
+    expect(resolveCommitHash({ cwd: repoA, env: {} })).toBe("0123456");
+    expect(resolveCommitHash({ cwd: repoB, env: {} })).toBe("89abcde");
+    expect(resolveCommitHash({ cwd: repoA, env: {} })).toBe("0123456");
+  });
+
+  it("caches deterministic null results per resolved search directory", async () => {
+    const temp = await makeTempDir("git-commit-null-cache");
+    const repoRoot = path.join(temp, "repo");
+    await makeFakeGitRepo(repoRoot, {
+      head: "not-a-commit\n",
+    });
+
+    const actualFs = await vi.importActual<typeof import("node:fs")>("node:fs");
+    const readFileSyncSpy = vi.fn(actualFs.readFileSync);
+    vi.doMock("node:fs", () => ({
+      ...actualFs,
+      default: {
+        ...actualFs,
+        readFileSync: readFileSyncSpy,
+      },
+      readFileSync: readFileSyncSpy,
+    }));
+    vi.resetModules();
+
+    const { resolveCommitHash } = await import("./git-commit.js");
+
+    expect(resolveCommitHash({ cwd: repoRoot, env: {} })).toBeNull();
+    const firstCallReads = readFileSyncSpy.mock.calls.length;
+    expect(firstCallReads).toBeGreaterThan(0);
+    expect(resolveCommitHash({ cwd: repoRoot, env: {} })).toBeNull();
+    expect(readFileSyncSpy.mock.calls.length).toBe(firstCallReads);
+
+    vi.doUnmock("node:fs");
+  });
+
+  it("caches caught null fallback results per resolved search directory", async () => {
+    const temp = await makeTempDir("git-commit-caught-null-cache");
+    const repoRoot = path.join(temp, "repo");
+    await makeFakeGitRepo(repoRoot, {
+      head: "0123456789abcdef0123456789abcdef01234567\n",
+    });
+    const headPath = path.join(repoRoot, ".git", "HEAD");
+
+    const actualFs = await vi.importActual<typeof import("node:fs")>("node:fs");
+    const readFileSyncSpy = vi.fn((filePath: string, ...args: unknown[]) => {
+      if (path.resolve(filePath) === path.resolve(headPath)) {
+        const error = Object.assign(new Error(`EACCES: permission denied, open '${filePath}'`), {
+          code: "EACCES",
+        });
+        throw error;
+      }
+      return Reflect.apply(actualFs.readFileSync, actualFs, [filePath, ...args]);
+    });
+    vi.doMock("node:fs", () => ({
+      ...actualFs,
+      default: {
+        ...actualFs,
+        readFileSync: readFileSyncSpy,
+      },
+      readFileSync: readFileSyncSpy,
+    }));
+    vi.doMock("node:module", () => ({
+      createRequire: () => {
+        return (specifier: string) => {
+          throw Object.assign(new Error(`Cannot find module ${specifier}`), {
+            code: "MODULE_NOT_FOUND",
+          });
+        };
+      },
+    }));
+    vi.resetModules();
+
+    const { resolveCommitHash } = await import("./git-commit.js");
+
+    expect(resolveCommitHash({ cwd: repoRoot, env: {} })).toBeNull();
+    const headReadCount = () =>
+      readFileSyncSpy.mock.calls.filter(([filePath]) => path.resolve(filePath) === headPath).length;
+    const firstCallReads = headReadCount();
+    expect(firstCallReads).toBe(2);
+    expect(resolveCommitHash({ cwd: repoRoot, env: {} })).toBeNull();
+    expect(headReadCount()).toBe(firstCallReads);
+
+    vi.doUnmock("node:fs");
+    vi.doUnmock("node:module");
+  });
+
+  it("formats env-provided commit strings consistently", async () => {
+    const temp = await makeTempDir("git-commit-env");
+    const { resolveCommitHash } = await import("./git-commit.js");
+
+    expect(resolveCommitHash({ cwd: temp, env: { GIT_COMMIT: "ABCDEF0123456789" } })).toBe(
+      "abcdef0",
+    );
+    expect(
+      resolveCommitHash({ cwd: temp, env: { GIT_SHA: "commit abcdef0123456789 dirty" } }),
+    ).toBe("abcdef0");
+    expect(resolveCommitHash({ cwd: temp, env: { GIT_COMMIT: "not-a-sha" } })).toBeNull();
+    expect(resolveCommitHash({ cwd: temp, env: { GIT_COMMIT: "" } })).toBeNull();
+  });
+
+  it("rejects unsafe HEAD refs and accepts valid refs", async () => {
+    const temp = await makeTempDir("git-commit-refs");
+    const { resolveCommitHash } = await import("./git-commit.js");
+
+    const absoluteRepo = path.join(temp, "absolute");
+    await makeFakeGitRepo(absoluteRepo, { head: "ref: /tmp/evil\n" });
+    expect(resolveCommitHash({ cwd: absoluteRepo, env: {} })).toBeNull();
+
+    const traversalRepo = path.join(temp, "traversal");
+    await makeFakeGitRepo(traversalRepo, { head: "ref: refs/heads/../evil\n" });
+    expect(resolveCommitHash({ cwd: traversalRepo, env: {} })).toBeNull();
+
+    const invalidPrefixRepo = path.join(temp, "invalid-prefix");
+    await makeFakeGitRepo(invalidPrefixRepo, { head: "ref: heads/main\n" });
+    expect(resolveCommitHash({ cwd: invalidPrefixRepo, env: {} })).toBeNull();
+
+    const validRepo = path.join(temp, "valid");
+    await makeFakeGitRepo(validRepo, {
+      head: "ref: refs/heads/main\n",
+      refs: {
+        "refs/heads/main": "fedcba9876543210fedcba9876543210fedcba98",
+      },
+    });
+    expect(resolveCommitHash({ cwd: validRepo, env: {} })).toBe("fedcba9");
+  });
+
+  it("resolves refs from the git commondir in worktree layouts", async () => {
+    const temp = await makeTempDir("git-commit-worktree");
+    const repoRoot = path.join(temp, "repo");
+    const worktreeGitDir = path.join(temp, "worktree-git");
+    const commonGitDir = path.join(temp, "common-git");
+    await fs.mkdir(commonGitDir, { recursive: true });
+    const refPath = path.join(commonGitDir, "refs", "heads", "main");
+    await fs.mkdir(path.dirname(refPath), { recursive: true });
+    await fs.writeFile(refPath, "76543210fedcba9876543210fedcba9876543210\n", "utf-8");
+    await makeFakeGitRepo(repoRoot, {
+      gitdir: worktreeGitDir,
+      head: "ref: refs/heads/main\n",
+      commondir: "../common-git",
+    });
+
+    const { resolveCommitHash } = await import("./git-commit.js");
+
+    expect(resolveCommitHash({ cwd: repoRoot, env: {} })).toBe("7654321");
+  });
+
+  it("reads full HEAD refs before parsing long branch names", async () => {
+    const temp = await makeTempDir("git-commit-long-head");
+    const repoRoot = path.join(temp, "repo");
+    const longRefName = `refs/heads/${"segment/".repeat(40)}main`;
+    await makeFakeGitRepo(repoRoot, {
+      head: `ref: ${longRefName}\n`,
+      refs: {
+        [longRefName]: "0123456789abcdef0123456789abcdef01234567",
+      },
+    });
+
+    const { resolveCommitHash } = await import("./git-commit.js");
+
+    expect(resolveCommitHash({ cwd: repoRoot, env: {} })).toBe("0123456");
+  });
+});

--- a/src/infra/git-commit.ts
+++ b/src/infra/git-commit.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { resolveGitHeadPath } from "./git-root.js";
+import { resolveRemoteClawPackageRootSync } from "./remoteclaw-root.js";
 
 const formatCommit = (value?: string | null) => {
   if (!value) {
@@ -11,10 +13,127 @@ const formatCommit = (value?: string | null) => {
   if (!trimmed) {
     return null;
   }
-  return trimmed.length > 7 ? trimmed.slice(0, 7) : trimmed;
+  const match = trimmed.match(/[0-9a-fA-F]{7,40}/);
+  if (!match) {
+    return null;
+  }
+  return match[0].slice(0, 7).toLowerCase();
 };
 
-let cachedCommit: string | null | undefined;
+const cachedGitCommitBySearchDir = new Map<string, string | null>();
+
+function isMissingPathError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+const resolveCommitSearchDir = (options: { cwd?: string; moduleUrl?: string }) => {
+  if (options.cwd) {
+    return path.resolve(options.cwd);
+  }
+  if (options.moduleUrl) {
+    try {
+      return path.dirname(fileURLToPath(options.moduleUrl));
+    } catch {
+      // moduleUrl is not a valid file:// URL; fall back to process.cwd().
+    }
+  }
+  return process.cwd();
+};
+
+/** Read at most `limit` bytes from a file to avoid unbounded reads. */
+const safeReadFilePrefix = (filePath: string, limit = 256) => {
+  const fd = fs.openSync(filePath, "r");
+  try {
+    const buf = Buffer.alloc(limit);
+    const bytesRead = fs.readSync(fd, buf, 0, limit, 0);
+    return buf.subarray(0, bytesRead).toString("utf-8");
+  } finally {
+    fs.closeSync(fd);
+  }
+};
+
+const cacheGitCommit = (searchDir: string, commit: string | null) => {
+  cachedGitCommitBySearchDir.set(searchDir, commit);
+  return commit;
+};
+
+const resolveGitLookupDepth = (searchDir: string, packageRoot: string | null) => {
+  if (!packageRoot) {
+    return undefined;
+  }
+  const relative = path.relative(packageRoot, searchDir);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return undefined;
+  }
+  const depth = relative ? relative.split(path.sep).filter(Boolean).length : 0;
+  return depth + 1;
+};
+
+const readCommitFromGit = (
+  searchDir: string,
+  packageRoot: string | null,
+): string | null | undefined => {
+  const headPath = resolveGitHeadPath(searchDir, {
+    maxDepth: resolveGitLookupDepth(searchDir, packageRoot),
+  });
+  if (!headPath) {
+    return undefined;
+  }
+  const head = fs.readFileSync(headPath, "utf-8").trim();
+  if (!head) {
+    return null;
+  }
+  if (head.startsWith("ref:")) {
+    const ref = head.replace(/^ref:\s*/i, "").trim();
+    const refPath = resolveRefPath(headPath, ref);
+    if (!refPath) {
+      return null;
+    }
+    const refHash = safeReadFilePrefix(refPath).trim();
+    return formatCommit(refHash);
+  }
+  return formatCommit(head);
+};
+
+const resolveGitRefsBase = (headPath: string) => {
+  const gitDir = path.dirname(headPath);
+  try {
+    const commonDir = safeReadFilePrefix(path.join(gitDir, "commondir")).trim();
+    if (commonDir) {
+      return path.resolve(gitDir, commonDir);
+    }
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw error;
+    }
+    // Plain repo git dirs do not have commondir.
+  }
+  return gitDir;
+};
+
+/** Safely resolve a git ref path, rejecting traversal attacks from a crafted HEAD file. */
+const resolveRefPath = (headPath: string, ref: string) => {
+  if (!ref.startsWith("refs/")) {
+    return null;
+  }
+  if (path.isAbsolute(ref)) {
+    return null;
+  }
+  if (ref.split(/[/]/).includes("..")) {
+    return null;
+  }
+  const refsBase = resolveGitRefsBase(headPath);
+  const resolved = path.resolve(refsBase, ref);
+  const rel = path.relative(refsBase, resolved);
+  if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {
+    return null;
+  }
+  return resolved;
+};
 
 const readCommitFromPackageJson = () => {
   try {
@@ -52,49 +171,46 @@ const readCommitFromBuildInfo = () => {
   }
 };
 
-export const resolveCommitHash = (options: { cwd?: string; env?: NodeJS.ProcessEnv } = {}) => {
-  if (cachedCommit !== undefined) {
-    return cachedCommit;
-  }
+export const resolveCommitHash = (
+  options: {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    moduleUrl?: string;
+  } = {},
+) => {
   const env = options.env ?? process.env;
   const envCommit = env.GIT_COMMIT?.trim() || env.GIT_SHA?.trim();
   const normalized = formatCommit(envCommit);
   if (normalized) {
-    cachedCommit = normalized;
-    return cachedCommit;
+    return normalized;
+  }
+  const searchDir = resolveCommitSearchDir(options);
+  if (cachedGitCommitBySearchDir.has(searchDir)) {
+    return cachedGitCommitBySearchDir.get(searchDir) ?? null;
+  }
+  const packageRoot = resolveRemoteClawPackageRootSync({
+    cwd: options.cwd,
+    moduleUrl: options.moduleUrl,
+  });
+  try {
+    const gitCommit = readCommitFromGit(searchDir, packageRoot);
+    if (gitCommit !== undefined) {
+      return cacheGitCommit(searchDir, gitCommit);
+    }
+  } catch {
+    // Fall through to baked metadata for packaged installs that are not in a live checkout.
   }
   const buildInfoCommit = readCommitFromBuildInfo();
   if (buildInfoCommit) {
-    cachedCommit = buildInfoCommit;
-    return cachedCommit;
+    return cacheGitCommit(searchDir, buildInfoCommit);
   }
   const pkgCommit = readCommitFromPackageJson();
   if (pkgCommit) {
-    cachedCommit = pkgCommit;
-    return cachedCommit;
+    return cacheGitCommit(searchDir, pkgCommit);
   }
   try {
-    const headPath = resolveGitHeadPath(options.cwd ?? process.cwd());
-    if (!headPath) {
-      cachedCommit = null;
-      return cachedCommit;
-    }
-    const head = fs.readFileSync(headPath, "utf-8").trim();
-    if (!head) {
-      cachedCommit = null;
-      return cachedCommit;
-    }
-    if (head.startsWith("ref:")) {
-      const ref = head.replace(/^ref:\s*/i, "").trim();
-      const refPath = path.resolve(path.dirname(headPath), ref);
-      const refHash = fs.readFileSync(refPath, "utf-8").trim();
-      cachedCommit = formatCommit(refHash);
-      return cachedCommit;
-    }
-    cachedCommit = formatCommit(head);
-    return cachedCommit;
+    return cacheGitCommit(searchDir, readCommitFromGit(searchDir, packageRoot) ?? null);
   } catch {
-    cachedCommit = null;
-    return cachedCommit;
+    return cacheGitCommit(searchDir, null);
   }
 };

--- a/src/infra/remoteclaw-root.test.ts
+++ b/src/infra/remoteclaw-root.test.ts
@@ -141,6 +141,18 @@ describe("resolveRemoteClawPackageRoot", () => {
     expect(resolveRemoteClawPackageRootSync({ moduleUrl })).toBe(pkgRoot);
   });
 
+  it("ignores invalid moduleUrl values and falls back to cwd", async () => {
+    const pkgRoot = fx("invalid-moduleurl");
+    setFile(path.join(pkgRoot, "package.json"), JSON.stringify({ name: "remoteclaw" }));
+
+    expect(resolveRemoteClawPackageRootSync({ moduleUrl: "not-a-file-url", cwd: pkgRoot })).toBe(
+      pkgRoot,
+    );
+    await expect(
+      resolveRemoteClawPackageRoot({ moduleUrl: "not-a-file-url", cwd: pkgRoot }),
+    ).resolves.toBe(pkgRoot);
+  });
+
   it("returns null for non-remoteclaw package roots", async () => {
     const pkgRoot = fx("not-remoteclaw");
     setFile(path.join(pkgRoot, "package.json"), JSON.stringify({ name: "not-remoteclaw" }));

--- a/src/infra/remoteclaw-root.ts
+++ b/src/infra/remoteclaw-root.ts
@@ -116,7 +116,11 @@ function buildCandidates(opts: { cwd?: string; argv1?: string; moduleUrl?: strin
   const candidates: string[] = [];
 
   if (opts.moduleUrl) {
-    candidates.push(path.dirname(fileURLToPath(opts.moduleUrl)));
+    try {
+      candidates.push(path.dirname(fileURLToPath(opts.moduleUrl)));
+    } catch {
+      // Ignore invalid file:// URLs and keep other package-root hints.
+    }
   }
   if (opts.argv1) {
     candidates.push(...candidateDirsFromArgv1(opts.argv1));


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [`ca5e352c5`](https://github.com/openclaw/openclaw/commit/ca5e352c5)
**Author**: [Altay](https://github.com/altaygui), [echoVic](https://github.com/echoVic)
**Tier**: AUTO-PARTIAL
**Issue**: #903

## Changes

Include the git commit hash in `--version` output (e.g., `RemoteClaw 0.1.0 (abc1234)`). Hardens commit SHA resolution with `moduleUrl` anchoring to package root, caching per search directory, and safe ref path traversal.

### Adaptation

- **Discarded gutted files**: `CHANGELOG.md`, `scripts/docker/install-sh-*`, `scripts/install.sh`, `src/install-sh-version.test.ts`, `src/entry.version-fast-path.test.ts` (tests upstream's fast path which we gutted)
- **Rebrand applied**: `openclaw` → `remoteclaw` in imports, package names, test fixtures, user-facing strings
- **Conflict resolution**: `entry.ts` fast path functions (gutted in fork — kept ours), `status.ts` branding (applied upstream's `moduleUrl` param with our branding), `remoteclaw-root.test.ts` (union merge — added upstream's new invalid-moduleUrl test with rebranding)