### PR TITLE
Cherry-pick 6c9b49a10: fix stale contextTokens on model switch

### DIFF
--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -32,6 +32,8 @@ const unitIsolatedFilesRaw = [
   "src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.test.ts",
   // Setup-heavy CLI update flow suite; move off unit-fast critical path.
   "src/cli/update-cli.test.ts",
+  // Uses temp repos + module cache resets; keep it off vmForks to avoid ref-resolution flakes.
+  "src/infra/git-commit.test.ts",
   // Expensive schema build/bootstrap checks; keep coverage but run in isolated lane.
   "src/config/schema.test.ts",
   "src/config/schema.tags.test.ts",

--- a/src/infra/git-commit.test.ts
+++ b/src/infra/git-commit.test.ts
@@ -43,6 +43,9 @@ describe("git commit resolution", () => {
 
   afterEach(() => {
     process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    vi.doUnmock("node:fs");
+    vi.doUnmock("node:module");
     vi.resetModules();
   });
 


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [`6c9b49a10`](https://github.com/openclaw/openclaw/commit/6c9b49a10)
**Author**: [yuweuii](https://github.com/yuweuii), [jalehman](https://github.com/jalehman)
**Tier**: AUTO-PARTIAL
**Issue**: #903
**Depends on**: #1282

## Changes

Adds test cleanup (restoreAllMocks, doUnmock) to git-commit.test.ts afterEach and adds test-parallel.mjs isolation entries.

### Adaptation

- **Discarded gutted files**: `CHANGELOG.md`, `src/process/supervisor/adapters/child.test.ts` (supervisor gutted), `src/sessions/model-overrides.ts` + test (model management gutted)
- **Conflict resolution**: `status.test.ts` (kept fork's imports, discarded upstream test using gutted `applyModelOverrideToSessionEntry`), `lifecycle.test.ts` (kept ours — gutted mock declarations)