### PR TITLE
Cherry-pick d9e8e8ac1: resolve live config paths in status/gateway

### DIFF
--- a/src/config/logging.test.ts
+++ b/src/config/logging.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createConfigIO: vi.fn().mockReturnValue({
+    configPath: "/tmp/remoteclaw-dev/remoteclaw.json",
+  }),
+}));
+
+vi.mock("./io.js", () => ({
+  createConfigIO: mocks.createConfigIO,
+}));
+
+import { formatConfigPath, logConfigUpdated } from "./logging.js";
+
+describe("config logging", () => {
+  it("formats the live config path when no explicit path is provided", () => {
+    expect(formatConfigPath()).toBe("/tmp/remoteclaw-dev/remoteclaw.json");
+  });
+
+  it("logs the live config path when no explicit path is provided", () => {
+    const runtime = { log: vi.fn() };
+    logConfigUpdated(runtime as never);
+    expect(runtime.log).toHaveBeenCalledWith("Updated /tmp/remoteclaw-dev/remoteclaw.json");
+  });
+});

--- a/src/config/logging.ts
+++ b/src/config/logging.ts
@@ -1,18 +1,18 @@
 import type { RuntimeEnv } from "../runtime.js";
 import { displayPath } from "../utils.js";
-import { CONFIG_PATH } from "./paths.js";
+import { createConfigIO } from "./io.js";
 
 type LogConfigUpdatedOptions = {
   path?: string;
   suffix?: string;
 };
 
-export function formatConfigPath(path: string = CONFIG_PATH): string {
+export function formatConfigPath(path: string = createConfigIO().configPath): string {
   return displayPath(path);
 }
 
 export function logConfigUpdated(runtime: RuntimeEnv, opts: LogConfigUpdatedOptions = {}): void {
-  const path = formatConfigPath(opts.path ?? CONFIG_PATH);
+  const path = formatConfigPath(opts.path ?? createConfigIO().configPath);
   const suffix = opts.suffix ? ` ${opts.suffix}` : "";
   runtime.log(`Updated ${path}${suffix}`);
 }

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1,7 +1,7 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import {
-  CONFIG_PATH,
+  createConfigIO,
   loadConfig,
   parseConfigJson5,
   readConfigFileSnapshot,
@@ -182,6 +182,7 @@ function buildConfigRestartSentinelPayload(params: {
   threadId: ReturnType<typeof extractDeliveryInfo>["threadId"];
   note: string | undefined;
 }): RestartSentinelPayload {
+  const configPath = createConfigIO().configPath;
   return {
     kind: params.kind,
     status: "ok",
@@ -193,7 +194,7 @@ function buildConfigRestartSentinelPayload(params: {
     doctorHint: formatDoctorNonInteractiveHint(),
     stats: {
       mode: params.mode,
-      root: CONFIG_PATH,
+      root: configPath,
     },
   };
 }
@@ -275,7 +276,7 @@ export const configHandlers: GatewayRequestHandlers = {
       true,
       {
         ok: true,
-        path: CONFIG_PATH,
+        path: createConfigIO().configPath,
         config: redactConfigObject(parsed.config, parsed.schema.uiHints),
       },
       undefined,
@@ -392,7 +393,7 @@ export const configHandlers: GatewayRequestHandlers = {
       true,
       {
         ok: true,
-        path: CONFIG_PATH,
+        path: createConfigIO().configPath,
         config: redactConfigObject(validated.config, schemaPatch.uiHints),
         restart,
         sentinel: {
@@ -452,7 +453,7 @@ export const configHandlers: GatewayRequestHandlers = {
       true,
       {
         ok: true,
-        path: CONFIG_PATH,
+        path: createConfigIO().configPath,
         config: redactConfigObject(parsed.config, parsed.schema.uiHints),
         restart,
         sentinel: {

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -47,6 +47,31 @@ async function resetTempDir(name: string): Promise<string> {
 }
 
 describe("gateway config methods", () => {
+  it("round-trips config.set and returns the live config path", async () => {
+    const { createConfigIO } = await import("../config/config.js");
+    const current = await rpcReq<{
+      raw?: unknown;
+      hash?: string;
+      config?: Record<string, unknown>;
+    }>(requireWs(), "config.get", {});
+    expect(current.ok).toBe(true);
+    expect(typeof current.payload?.hash).toBe("string");
+    expect(current.payload?.config).toBeTruthy();
+
+    const res = await rpcReq<{
+      ok?: boolean;
+      path?: string;
+      config?: Record<string, unknown>;
+    }>(requireWs(), "config.set", {
+      raw: JSON.stringify(current.payload?.config ?? {}, null, 2),
+      baseHash: current.payload?.hash,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.payload?.path).toBe(createConfigIO().configPath);
+    expect(res.payload?.config).toBeTruthy();
+  });
+
   it("rejects config.patch when raw is not an object", async () => {
     const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.patch", {
       raw: "[]",

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -1,6 +1,6 @@
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { getHealthSnapshot, type HealthSummary } from "../../commands/health.js";
-import { CONFIG_PATH, STATE_DIR, loadConfig } from "../../config/config.js";
+import { STATE_DIR, createConfigIO, loadConfig } from "../../config/config.js";
 import { resolveMainSessionKey } from "../../config/sessions.js";
 import { listSystemPresence } from "../../infra/system-presence.js";
 import { getUpdateAvailable } from "../../infra/update-startup.js";
@@ -16,6 +16,7 @@ let broadcastHealthUpdate: ((snap: HealthSummary) => void) | null = null;
 
 export function buildGatewaySnapshot(): Snapshot {
   const cfg = loadConfig();
+  const configPath = createConfigIO().configPath;
   const defaultAgentId = resolveDefaultAgentId(cfg);
   const mainKey = normalizeMainKey(cfg.session?.mainKey);
   const mainSessionKey = resolveMainSessionKey(cfg);
@@ -32,7 +33,7 @@ export function buildGatewaySnapshot(): Snapshot {
     stateVersion: { presence: presenceVersion, health: healthVersion },
     uptimeMs,
     // Surface resolved paths so UIs can display the true config location.
-    configPath: CONFIG_PATH,
+    configPath,
     stateDir: STATE_DIR,
     sessionDefaults: {
       defaultAgentId,


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [`d9e8e8ac1`](https://github.com/openclaw/openclaw/commit/d9e8e8ac1)
**Author**: [Takhoffman](https://github.com/Takhoffman)
**Tier**: AUTO-PICK
**Issue**: #903
**Depends on**: #1284

## Changes

Fix config path resolution in status output and gateway metadata — use live `createConfigIO().configPath` instead of hardcoded paths. Adds `formatConfigPath()` and `logConfigUpdated()` helpers in `config/logging.ts`.

### Adaptation

- **Discarded deleted files**: `src/commands/models/list.status-command.ts`, `list.status.test.ts`, `server.auth.default-token.suite.ts` (all gutted in fork)
- **Conflict resolution**: `server.config-patch.test.ts` — took upstream's new config.set round-trip test, kept fork's deletion of schema.lookup tests
- **Rebrand applied**: `openclaw` → `remoteclaw` in new test fixtures