### PR TITLE
Cherry-pick 87640f9a6: align talk config secret schemas

### DIFF
--- a/extensions/talk-voice/index.ts
+++ b/extensions/talk-voice/index.ts
@@ -84,7 +84,9 @@ export default function register(api: RemoteClawPluginApi) {
       const action = (tokens[0] ?? "status").toLowerCase();
 
       const cfg = api.runtime.config.loadConfig();
-      const apiKey = (cfg.talk?.apiKey ?? "").trim();
+      const rawApiKey = cfg.talk?.apiKey;
+      const apiKey =
+        typeof rawApiKey === "string" ? rawApiKey.trim() : rawApiKey != null ? "configured" : "";
       if (!apiKey) {
         return {
           text:

--- a/src/config/talk.ts
+++ b/src/config/talk.ts
@@ -9,6 +9,20 @@ import type {
 } from "./types.gateway.js";
 import type { RemoteClawConfig } from "./types.js";
 
+type SecretRef = { source: "env" | "file" | "exec"; provider: string; id: string };
+
+function isSecretRef(value: unknown): value is SecretRef {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return (
+    (obj.source === "env" || obj.source === "file" || obj.source === "exec") &&
+    typeof obj.provider === "string" &&
+    typeof obj.id === "string"
+  );
+}
+
 type TalkApiKeyDeps = {
   fs?: typeof fs;
   os?: typeof os;
@@ -67,10 +81,21 @@ function normalizeTalkProviderConfig(value: unknown): TalkProviderConfig | undef
       }
       continue;
     }
-    if (key === "voiceId" || key === "modelId" || key === "outputFormat" || key === "apiKey") {
+    if (key === "voiceId" || key === "modelId" || key === "outputFormat") {
       const normalized = normalizeString(raw);
       if (normalized) {
         provider[key] = normalized;
+      }
+      continue;
+    }
+    if (key === "apiKey") {
+      if (isSecretRef(raw)) {
+        provider.apiKey = raw;
+      } else {
+        const normalized = normalizeString(raw);
+        if (normalized) {
+          provider.apiKey = normalized;
+        }
       }
       continue;
     }
@@ -117,9 +142,13 @@ function normalizedLegacyTalkFields(source: Record<string, unknown>): Partial<Ta
   if (outputFormat) {
     legacy.outputFormat = outputFormat;
   }
-  const apiKey = normalizeString(source.apiKey);
-  if (apiKey) {
-    legacy.apiKey = apiKey;
+  if (isSecretRef(source.apiKey)) {
+    legacy.apiKey = source.apiKey;
+  } else {
+    const apiKey = normalizeString(source.apiKey);
+    if (apiKey) {
+      legacy.apiKey = apiKey;
+    }
   }
   const silenceTimeoutMs = normalizeSilenceTimeoutMs(source.silenceTimeoutMs);
   if (silenceTimeoutMs !== undefined) {
@@ -179,7 +208,7 @@ function legacyTalkFieldsFromProviderConfig(
   if (typeof config.outputFormat === "string") {
     legacy.outputFormat = config.outputFormat;
   }
-  if (typeof config.apiKey === "string") {
+  if (typeof config.apiKey === "string" || isSecretRef(config.apiKey)) {
     legacy.apiKey = config.apiKey;
   }
   return legacy;

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -56,7 +56,7 @@ export type TalkProviderConfig = {
   /** Default provider output format (for example pcm_44100). */
   outputFormat?: string;
   /** Provider API key (optional; provider-specific env fallback may apply). */
-  apiKey?: string;
+  apiKey?: string | { source: "env" | "file" | "exec"; provider: string; id: string };
   /** Provider-specific extensions. */
   [key: string]: unknown;
 };
@@ -86,7 +86,7 @@ export type TalkConfig = {
   voiceAliases?: Record<string, string>;
   modelId?: string;
   outputFormat?: string;
-  apiKey?: string;
+  apiKey?: string | { source: "env" | "file" | "exec"; provider: string; id: string };
 };
 
 export type TalkConfigResponse = TalkConfig & {

--- a/src/gateway/protocol/index.test.ts
+++ b/src/gateway/protocol/index.test.ts
@@ -1,6 +1,6 @@
 import type { ErrorObject } from "ajv";
 import { describe, expect, it } from "vitest";
-import { formatValidationErrors } from "./index.js";
+import { formatValidationErrors, validateTalkConfigResult } from "./index.js";
 
 const makeError = (overrides: Partial<ErrorObject>): ErrorObject => ({
   keyword: "type",
@@ -60,5 +60,43 @@ describe("formatValidationErrors", () => {
     expect(formatValidationErrors([err, err])).toBe(
       "at /auth: must have required property 'token'",
     );
+  });
+});
+
+describe("validateTalkConfigResult", () => {
+  it("accepts Talk SecretRef payloads", () => {
+    expect(
+      validateTalkConfigResult({
+        config: {
+          talk: {
+            provider: "elevenlabs",
+            providers: {
+              elevenlabs: {
+                apiKey: {
+                  source: "env",
+                  provider: "default",
+                  id: "ELEVENLABS_API_KEY",
+                },
+              },
+            },
+            resolved: {
+              provider: "elevenlabs",
+              config: {
+                apiKey: {
+                  source: "env",
+                  provider: "default",
+                  id: "ELEVENLABS_API_KEY",
+                },
+              },
+            },
+            apiKey: {
+              source: "env",
+              provider: "default",
+              id: "ELEVENLABS_API_KEY",
+            },
+          },
+        },
+      }),
+    ).toBe(true);
   });
 });

--- a/src/gateway/protocol/schema/channels.ts
+++ b/src/gateway/protocol/schema/channels.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox";
-import { NonEmptyString } from "./primitives.js";
+import { NonEmptyString, SecretInputSchema } from "./primitives.js";
 
 export const TalkModeParamsSchema = Type.Object(
   {
@@ -22,7 +22,7 @@ const TalkProviderConfigSchema = Type.Object(
     voiceAliases: Type.Optional(Type.Record(Type.String(), Type.String())),
     modelId: Type.Optional(Type.String()),
     outputFormat: Type.Optional(Type.String()),
-    apiKey: Type.Optional(Type.String()),
+    apiKey: Type.Optional(SecretInputSchema),
   },
   { additionalProperties: true },
 );
@@ -49,7 +49,7 @@ export const TalkConfigResultSchema = Type.Object(
               voiceAliases: Type.Optional(Type.Record(Type.String(), Type.String())),
               modelId: Type.Optional(Type.String()),
               outputFormat: Type.Optional(Type.String()),
-              apiKey: Type.Optional(Type.String()),
+              apiKey: Type.Optional(SecretInputSchema),
               interruptOnSpeech: Type.Optional(Type.Boolean()),
               silenceTimeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
             },

--- a/src/gateway/protocol/schema/primitives.ts
+++ b/src/gateway/protocol/schema/primitives.ts
@@ -15,3 +15,20 @@ export const GatewayClientIdSchema = Type.Union(
 export const GatewayClientModeSchema = Type.Union(
   Object.values(GATEWAY_CLIENT_MODES).map((value) => Type.Literal(value)),
 );
+
+export const SecretRefSourceSchema = Type.Union([
+  Type.Literal("env"),
+  Type.Literal("file"),
+  Type.Literal("exec"),
+]);
+
+export const SecretRefSchema = Type.Object(
+  {
+    source: SecretRefSourceSchema,
+    provider: NonEmptyString,
+    id: NonEmptyString,
+  },
+  { additionalProperties: false },
+);
+
+export const SecretInputSchema = Type.Union([Type.String(), SecretRefSchema]);

--- a/src/gateway/server.talk-config.test.ts
+++ b/src/gateway/server.talk-config.test.ts
@@ -7,6 +7,7 @@ import {
   signDevicePayload,
 } from "../infra/device-identity.js";
 import { buildDeviceAuthPayload } from "./device-auth.js";
+import { validateTalkConfigResult } from "./protocol/index.js";
 import {
   connectOk,
   installGatewayTestHooks,
@@ -57,7 +58,7 @@ async function connectOperator(ws: GatewaySocket, scopes: string[]) {
 }
 
 async function writeTalkConfig(config: {
-  apiKey?: string;
+  apiKey?: string | { source: "env" | "file" | "exec"; provider: string; id: string };
   voiceId?: string;
   silenceTimeoutMs?: number;
 }) {
@@ -137,6 +138,58 @@ describe("gateway talk.config", () => {
       });
       expect(res.ok).toBe(true);
       expect(res.payload?.config?.talk?.apiKey).toBe("secret-key-abc");
+    });
+  });
+
+  it("returns Talk SecretRef payloads that satisfy the protocol schema", async () => {
+    await writeTalkConfig({
+      apiKey: {
+        source: "env",
+        provider: "default",
+        id: "ELEVENLABS_API_KEY",
+      },
+    });
+
+    await withServer(async (ws) => {
+      await connectOperator(ws, ["operator.read", "operator.write", "operator.talk.secrets"]);
+      const res = await rpcReq<{
+        config?: {
+          talk?: {
+            apiKey?: { source?: string; provider?: string; id?: string };
+            providers?: {
+              elevenlabs?: {
+                apiKey?: { source?: string; provider?: string; id?: string };
+              };
+            };
+            resolved?: {
+              provider?: string;
+              config?: {
+                apiKey?: { source?: string; provider?: string; id?: string };
+              };
+            };
+          };
+        };
+      }>(ws, "talk.config", {
+        includeSecrets: true,
+      });
+      expect(res.ok).toBe(true);
+      expect(validateTalkConfigResult(res.payload)).toBe(true);
+      expect(res.payload?.config?.talk?.apiKey).toEqual({
+        source: "env",
+        provider: "default",
+        id: "ELEVENLABS_API_KEY",
+      });
+      expect(res.payload?.config?.talk?.providers?.elevenlabs?.apiKey).toEqual({
+        source: "env",
+        provider: "default",
+        id: "ELEVENLABS_API_KEY",
+      });
+      expect(res.payload?.config?.talk?.resolved?.provider).toBe("elevenlabs");
+      expect(res.payload?.config?.talk?.resolved?.config?.apiKey).toEqual({
+        source: "env",
+        provider: "default",
+        id: "ELEVENLABS_API_KEY",
+      });
     });
   });
 


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [`87640f9a6`](https://github.com/openclaw/openclaw/commit/87640f9a6)
**Author**: [steipete](https://github.com/steipete) (Peter Steinberger)
**Tier**: AUTO-PICK
**Issue**: #903
**Depends on**: #1285

## Changes

Align talk config secret schemas — ensures channel config schemas properly mark secret fields and adds validation tests for talk config secret handling.