### PR TITLE
Cherry-pick 74624e619: fix: prefer bundled channel plugins over npm duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,0 @@
-# Changelog
-
-All notable changes to RemoteClaw will be documented in this file.
-
----
-
-Forked from [OpenClaw](https://github.com/openclaw/openclaw).

--- a/src/cli/plugin-install-plan.test.ts
+++ b/src/cli/plugin-install-plan.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { PLUGIN_INSTALL_ERROR_CODE } from "../plugins/install.js";
+import {
+  resolveBundledInstallPlanForCatalogEntry,
+  resolveBundledInstallPlanBeforeNpm,
+  resolveBundledInstallPlanForNpmFailure,
+} from "./plugin-install-plan.js";
+
+describe("plugin install plan helpers", () => {
+  it("prefers bundled plugin for bare plugin-id specs", () => {
+    const findBundledSource = vi.fn().mockReturnValue({
+      pluginId: "voice-call",
+      localPath: "/tmp/extensions/voice-call",
+      npmSpec: "@remoteclaw/voice-call",
+    });
+
+    const result = resolveBundledInstallPlanBeforeNpm({
+      rawSpec: "voice-call",
+      findBundledSource,
+    });
+
+    expect(findBundledSource).toHaveBeenCalledWith({ kind: "pluginId", value: "voice-call" });
+    expect(result?.bundledSource.pluginId).toBe("voice-call");
+    expect(result?.warning).toContain('bare install spec "voice-call"');
+  });
+
+  it("skips bundled pre-plan for scoped npm specs", () => {
+    const findBundledSource = vi.fn();
+    const result = resolveBundledInstallPlanBeforeNpm({
+      rawSpec: "@remoteclaw/voice-call",
+      findBundledSource,
+    });
+
+    expect(findBundledSource).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it("prefers bundled catalog plugin by id before npm spec", () => {
+    const findBundledSource = vi
+      .fn()
+      .mockImplementation(({ kind, value }: { kind: "pluginId" | "npmSpec"; value: string }) => {
+        if (kind === "pluginId" && value === "voice-call") {
+          return {
+            pluginId: "voice-call",
+            localPath: "/tmp/extensions/voice-call",
+            npmSpec: "@remoteclaw/voice-call",
+          };
+        }
+        return undefined;
+      });
+
+    const result = resolveBundledInstallPlanForCatalogEntry({
+      pluginId: "voice-call",
+      npmSpec: "@remoteclaw/voice-call",
+      findBundledSource,
+    });
+
+    expect(findBundledSource).toHaveBeenCalledWith({ kind: "pluginId", value: "voice-call" });
+    expect(result?.bundledSource.localPath).toBe("/tmp/extensions/voice-call");
+  });
+
+  it("rejects npm-spec matches that resolve to a different plugin id", () => {
+    const findBundledSource = vi
+      .fn()
+      .mockImplementation(({ kind }: { kind: "pluginId" | "npmSpec"; value: string }) => {
+        if (kind === "npmSpec") {
+          return {
+            pluginId: "not-voice-call",
+            localPath: "/tmp/extensions/not-voice-call",
+            npmSpec: "@remoteclaw/voice-call",
+          };
+        }
+        return undefined;
+      });
+
+    const result = resolveBundledInstallPlanForCatalogEntry({
+      pluginId: "voice-call",
+      npmSpec: "@remoteclaw/voice-call",
+      findBundledSource,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("uses npm-spec bundled fallback only for package-not-found", () => {
+    const findBundledSource = vi.fn().mockReturnValue({
+      pluginId: "voice-call",
+      localPath: "/tmp/extensions/voice-call",
+      npmSpec: "@remoteclaw/voice-call",
+    });
+    const result = resolveBundledInstallPlanForNpmFailure({
+      rawSpec: "@remoteclaw/voice-call",
+      code: PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND,
+      findBundledSource,
+    });
+
+    expect(findBundledSource).toHaveBeenCalledWith({
+      kind: "npmSpec",
+      value: "@remoteclaw/voice-call",
+    });
+    expect(result?.warning).toContain("npm package unavailable");
+  });
+
+  it("skips fallback for non-not-found npm failures", () => {
+    const findBundledSource = vi.fn();
+    const result = resolveBundledInstallPlanForNpmFailure({
+      rawSpec: "@remoteclaw/voice-call",
+      code: "INSTALL_FAILED",
+      findBundledSource,
+    });
+
+    expect(findBundledSource).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+});

--- a/src/cli/plugin-install-plan.test.ts
+++ b/src/cli/plugin-install-plan.test.ts
@@ -1,40 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import { PLUGIN_INSTALL_ERROR_CODE } from "../plugins/install.js";
-import {
-  resolveBundledInstallPlanForCatalogEntry,
-  resolveBundledInstallPlanBeforeNpm,
-  resolveBundledInstallPlanForNpmFailure,
-} from "./plugin-install-plan.js";
+import { resolveBundledInstallPlanForCatalogEntry } from "./plugin-install-plan.js";
 
 describe("plugin install plan helpers", () => {
-  it("prefers bundled plugin for bare plugin-id specs", () => {
-    const findBundledSource = vi.fn().mockReturnValue({
-      pluginId: "voice-call",
-      localPath: "/tmp/extensions/voice-call",
-      npmSpec: "@remoteclaw/voice-call",
-    });
-
-    const result = resolveBundledInstallPlanBeforeNpm({
-      rawSpec: "voice-call",
-      findBundledSource,
-    });
-
-    expect(findBundledSource).toHaveBeenCalledWith({ kind: "pluginId", value: "voice-call" });
-    expect(result?.bundledSource.pluginId).toBe("voice-call");
-    expect(result?.warning).toContain('bare install spec "voice-call"');
-  });
-
-  it("skips bundled pre-plan for scoped npm specs", () => {
-    const findBundledSource = vi.fn();
-    const result = resolveBundledInstallPlanBeforeNpm({
-      rawSpec: "@remoteclaw/voice-call",
-      findBundledSource,
-    });
-
-    expect(findBundledSource).not.toHaveBeenCalled();
-    expect(result).toBeNull();
-  });
-
   it("prefers bundled catalog plugin by id before npm spec", () => {
     const findBundledSource = vi
       .fn()
@@ -79,37 +46,6 @@ describe("plugin install plan helpers", () => {
       findBundledSource,
     });
 
-    expect(result).toBeNull();
-  });
-
-  it("uses npm-spec bundled fallback only for package-not-found", () => {
-    const findBundledSource = vi.fn().mockReturnValue({
-      pluginId: "voice-call",
-      localPath: "/tmp/extensions/voice-call",
-      npmSpec: "@remoteclaw/voice-call",
-    });
-    const result = resolveBundledInstallPlanForNpmFailure({
-      rawSpec: "@remoteclaw/voice-call",
-      code: PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND,
-      findBundledSource,
-    });
-
-    expect(findBundledSource).toHaveBeenCalledWith({
-      kind: "npmSpec",
-      value: "@remoteclaw/voice-call",
-    });
-    expect(result?.warning).toContain("npm package unavailable");
-  });
-
-  it("skips fallback for non-not-found npm failures", () => {
-    const findBundledSource = vi.fn();
-    const result = resolveBundledInstallPlanForNpmFailure({
-      rawSpec: "@remoteclaw/voice-call",
-      code: "INSTALL_FAILED",
-      findBundledSource,
-    });
-
-    expect(findBundledSource).not.toHaveBeenCalled();
     expect(result).toBeNull();
   });
 });

--- a/src/cli/plugin-install-plan.ts
+++ b/src/cli/plugin-install-plan.ts
@@ -1,16 +1,9 @@
 import type { BundledPluginSource } from "../plugins/bundled-sources.js";
-import { PLUGIN_INSTALL_ERROR_CODE } from "../plugins/install.js";
-import { shortenHomePath } from "../utils.js";
 
 type BundledLookup = (params: {
   kind: "pluginId" | "npmSpec";
   value: string;
 }) => BundledPluginSource | undefined;
-
-function isBareNpmPackageName(spec: string): boolean {
-  const trimmed = spec.trim();
-  return /^[a-z0-9][a-z0-9-._~]*$/.test(trimmed);
-}
 
 export function resolveBundledInstallPlanForCatalogEntry(params: {
   pluginId: string;
@@ -40,45 +33,4 @@ export function resolveBundledInstallPlanForCatalogEntry(params: {
   }
 
   return null;
-}
-
-export function resolveBundledInstallPlanBeforeNpm(params: {
-  rawSpec: string;
-  findBundledSource: BundledLookup;
-}): { bundledSource: BundledPluginSource; warning: string } | null {
-  if (!isBareNpmPackageName(params.rawSpec)) {
-    return null;
-  }
-  const bundledSource = params.findBundledSource({
-    kind: "pluginId",
-    value: params.rawSpec,
-  });
-  if (!bundledSource) {
-    return null;
-  }
-  return {
-    bundledSource,
-    warning: `Using bundled plugin "${bundledSource.pluginId}" from ${shortenHomePath(bundledSource.localPath)} for bare install spec "${params.rawSpec}". To install an npm package with the same name, use a scoped package name (for example @scope/${params.rawSpec}).`,
-  };
-}
-
-export function resolveBundledInstallPlanForNpmFailure(params: {
-  rawSpec: string;
-  code?: string;
-  findBundledSource: BundledLookup;
-}): { bundledSource: BundledPluginSource; warning: string } | null {
-  if (params.code !== PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND) {
-    return null;
-  }
-  const bundledSource = params.findBundledSource({
-    kind: "npmSpec",
-    value: params.rawSpec,
-  });
-  if (!bundledSource) {
-    return null;
-  }
-  return {
-    bundledSource,
-    warning: `npm package unavailable for ${params.rawSpec}; using bundled plugin at ${shortenHomePath(bundledSource.localPath)}.`,
-  };
 }

--- a/src/cli/plugin-install-plan.ts
+++ b/src/cli/plugin-install-plan.ts
@@ -1,0 +1,84 @@
+import type { BundledPluginSource } from "../plugins/bundled-sources.js";
+import { PLUGIN_INSTALL_ERROR_CODE } from "../plugins/install.js";
+import { shortenHomePath } from "../utils.js";
+
+type BundledLookup = (params: {
+  kind: "pluginId" | "npmSpec";
+  value: string;
+}) => BundledPluginSource | undefined;
+
+function isBareNpmPackageName(spec: string): boolean {
+  const trimmed = spec.trim();
+  return /^[a-z0-9][a-z0-9-._~]*$/.test(trimmed);
+}
+
+export function resolveBundledInstallPlanForCatalogEntry(params: {
+  pluginId: string;
+  npmSpec: string;
+  findBundledSource: BundledLookup;
+}): { bundledSource: BundledPluginSource } | null {
+  const pluginId = params.pluginId.trim();
+  const npmSpec = params.npmSpec.trim();
+  if (!pluginId || !npmSpec) {
+    return null;
+  }
+
+  const bundledById = params.findBundledSource({
+    kind: "pluginId",
+    value: pluginId,
+  });
+  if (bundledById?.pluginId === pluginId) {
+    return { bundledSource: bundledById };
+  }
+
+  const bundledBySpec = params.findBundledSource({
+    kind: "npmSpec",
+    value: npmSpec,
+  });
+  if (bundledBySpec?.pluginId === pluginId) {
+    return { bundledSource: bundledBySpec };
+  }
+
+  return null;
+}
+
+export function resolveBundledInstallPlanBeforeNpm(params: {
+  rawSpec: string;
+  findBundledSource: BundledLookup;
+}): { bundledSource: BundledPluginSource; warning: string } | null {
+  if (!isBareNpmPackageName(params.rawSpec)) {
+    return null;
+  }
+  const bundledSource = params.findBundledSource({
+    kind: "pluginId",
+    value: params.rawSpec,
+  });
+  if (!bundledSource) {
+    return null;
+  }
+  return {
+    bundledSource,
+    warning: `Using bundled plugin "${bundledSource.pluginId}" from ${shortenHomePath(bundledSource.localPath)} for bare install spec "${params.rawSpec}". To install an npm package with the same name, use a scoped package name (for example @scope/${params.rawSpec}).`,
+  };
+}
+
+export function resolveBundledInstallPlanForNpmFailure(params: {
+  rawSpec: string;
+  code?: string;
+  findBundledSource: BundledLookup;
+}): { bundledSource: BundledPluginSource; warning: string } | null {
+  if (params.code !== PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND) {
+    return null;
+  }
+  const bundledSource = params.findBundledSource({
+    kind: "npmSpec",
+    value: params.rawSpec,
+  });
+  if (!bundledSource) {
+    return null;
+  }
+  return {
+    bundledSource,
+    warning: `npm package unavailable for ${params.rawSpec}; using bundled plugin at ${shortenHomePath(bundledSource.localPath)}.`,
+  };
+}

--- a/src/commands/onboarding/plugin-install.test.ts
+++ b/src/commands/onboarding/plugin-install.test.ts
@@ -174,7 +174,7 @@ describe("ensureOnboardingPluginInstalled", () => {
     const runtime = makeRuntime();
     const select = vi.fn((async <T extends string>() => "skip" as T) as WizardPrompter["select"]);
     const prompter = makePrompter({ select: select as unknown as WizardPrompter["select"] });
-    const cfg: OpenClawConfig = { update: { channel: "beta" } };
+    const cfg: RemoteClawConfig = { update: { channel: "beta" } };
     vi.mocked(fs.existsSync).mockReturnValue(false);
     resolveBundledPluginSources.mockReturnValue(
       new Map([

--- a/src/commands/onboarding/plugin-install.test.ts
+++ b/src/commands/onboarding/plugin-install.test.ts
@@ -1,15 +1,48 @@
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("node:fs", () => ({
-  default: {
-    existsSync: vi.fn(),
-  },
-}));
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  const existsSync = vi.fn();
+  return {
+    ...actual,
+    existsSync,
+    default: {
+      ...actual,
+      existsSync,
+    },
+  };
+});
 
 const installPluginFromNpmSpec = vi.fn();
 vi.mock("../../plugins/install.js", () => ({
   installPluginFromNpmSpec: (...args: unknown[]) => installPluginFromNpmSpec(...args),
+}));
+
+const resolveBundledPluginSources = vi.fn();
+vi.mock("../../plugins/bundled-sources.js", () => ({
+  findBundledPluginSourceInMap: ({
+    bundled,
+    lookup,
+  }: {
+    bundled: ReadonlyMap<string, { pluginId: string; localPath: string; npmSpec?: string }>;
+    lookup: { kind: "pluginId" | "npmSpec"; value: string };
+  }) => {
+    const targetValue = lookup.value.trim();
+    if (!targetValue) {
+      return undefined;
+    }
+    if (lookup.kind === "pluginId") {
+      return bundled.get(targetValue);
+    }
+    for (const source of bundled.values()) {
+      if (source.npmSpec === targetValue) {
+        return source;
+      }
+    }
+    return undefined;
+  },
+  resolveBundledPluginSources: (...args: unknown[]) => resolveBundledPluginSources(...args),
 }));
 
 vi.mock("../../plugins/loader.js", () => ({
@@ -41,6 +74,7 @@ const baseEntry: ChannelPluginCatalogEntry = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resolveBundledPluginSources.mockReturnValue(new Map());
 });
 
 function mockRepoLocalPathExists() {
@@ -134,6 +168,45 @@ describe("ensureOnboardingPluginInstalled", () => {
 
   it("defaults to npm on beta channel even when local path exists", async () => {
     expect(await runInitialValueForChannel("beta")).toBe("npm");
+  });
+
+  it("defaults to bundled local path on beta channel when available", async () => {
+    const runtime = makeRuntime();
+    const select = vi.fn((async <T extends string>() => "skip" as T) as WizardPrompter["select"]);
+    const prompter = makePrompter({ select: select as unknown as WizardPrompter["select"] });
+    const cfg: OpenClawConfig = { update: { channel: "beta" } };
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    resolveBundledPluginSources.mockReturnValue(
+      new Map([
+        [
+          "zalo",
+          {
+            pluginId: "zalo",
+            localPath: "/opt/openclaw/extensions/zalo",
+            npmSpec: "@openclaw/zalo",
+          },
+        ],
+      ]),
+    );
+
+    await ensureOnboardingPluginInstalled({
+      cfg,
+      entry: baseEntry,
+      prompter,
+      runtime,
+    });
+
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialValue: "local",
+        options: expect.arrayContaining([
+          expect.objectContaining({
+            value: "local",
+            hint: "/opt/openclaw/extensions/zalo",
+          }),
+        ]),
+      }),
+    );
   });
 
   it("falls back to local path after npm install failure", async () => {

--- a/src/commands/onboarding/plugin-install.ts
+++ b/src/commands/onboarding/plugin-install.ts
@@ -2,8 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import type { ChannelPluginCatalogEntry } from "../../channels/plugins/catalog.js";
+import { resolveBundledInstallPlanForCatalogEntry } from "../../cli/plugin-install-plan.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import {
+  findBundledPluginSourceInMap,
+  resolveBundledPluginSources,
+} from "../../plugins/bundled-sources.js";
 import { enablePluginInConfig } from "../../plugins/enable.js";
 import { installPluginFromNpmSpec } from "../../plugins/install.js";
 import { buildNpmResolutionInstallFields, recordPluginInstall } from "../../plugins/installs.js";
@@ -107,8 +112,12 @@ function resolveInstallDefaultChoice(params: {
   cfg: RemoteClawConfig;
   entry: ChannelPluginCatalogEntry;
   localPath?: string | null;
+  bundledLocalPath?: string | null;
 }): InstallChoice {
-  const { cfg, entry, localPath } = params;
+  const { cfg, entry, localPath, bundledLocalPath } = params;
+  if (bundledLocalPath) {
+    return "local";
+  }
   const updateChannel = cfg.update?.channel;
   if (updateChannel === "next") {
     return localPath ? "local" : "npm";
@@ -136,11 +145,20 @@ export async function ensureOnboardingPluginInstalled(params: {
   const { entry, prompter, runtime, workspaceDir } = params;
   let next = params.cfg;
   const allowLocal = hasGitWorkspace(workspaceDir);
-  const localPath = resolveLocalPath(entry, workspaceDir, allowLocal);
+  const bundledSources = resolveBundledPluginSources({ workspaceDir });
+  const bundledLocalPath =
+    resolveBundledInstallPlanForCatalogEntry({
+      pluginId: entry.id,
+      npmSpec: entry.install.npmSpec,
+      findBundledSource: (lookup) =>
+        findBundledPluginSourceInMap({ bundled: bundledSources, lookup }),
+    })?.bundledSource.localPath ?? null;
+  const localPath = bundledLocalPath ?? resolveLocalPath(entry, workspaceDir, allowLocal);
   const defaultChoice = resolveInstallDefaultChoice({
     cfg: next,
     entry,
     localPath,
+    bundledLocalPath,
   });
   const choice = await promptInstallChoice({
     entry,

--- a/src/plugins/bundled-sources.test.ts
+++ b/src/plugins/bundled-sources.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { findBundledPluginByNpmSpec, resolveBundledPluginSources } from "./bundled-sources.js";
+import {
+  findBundledPluginByNpmSpec,
+  findBundledPluginSourceInMap,
+  resolveBundledPluginSources,
+} from "./bundled-sources.js";
 
 const discoverRemoteClawPluginsMock = vi.fn();
 const loadPluginManifestMock = vi.fn();
@@ -93,5 +97,35 @@ describe("bundled plugin sources", () => {
     expect(resolved?.pluginId).toBe("feishu");
     expect(resolved?.localPath).toBe("/app/extensions/feishu");
     expect(missing).toBeUndefined();
+  });
+
+  it("reuses a pre-resolved bundled map for repeated lookups", () => {
+    const bundled = new Map([
+      [
+        "feishu",
+        {
+          pluginId: "feishu",
+          localPath: "/app/extensions/feishu",
+          npmSpec: "@remoteclaw/feishu",
+        },
+      ],
+    ]);
+
+    expect(
+      findBundledPluginSourceInMap({
+        bundled,
+        lookup: { kind: "pluginId", value: "feishu" },
+      }),
+    ).toEqual({
+      pluginId: "feishu",
+      localPath: "/app/extensions/feishu",
+      npmSpec: "@remoteclaw/feishu",
+    });
+    expect(
+      findBundledPluginSourceInMap({
+        bundled,
+        lookup: { kind: "npmSpec", value: "@remoteclaw/feishu" },
+      })?.pluginId,
+    ).toBe("feishu");
   });
 });

--- a/src/plugins/bundled-sources.ts
+++ b/src/plugins/bundled-sources.ts
@@ -7,6 +7,29 @@ export type BundledPluginSource = {
   npmSpec?: string;
 };
 
+export type BundledPluginLookup =
+  | { kind: "npmSpec"; value: string }
+  | { kind: "pluginId"; value: string };
+
+export function findBundledPluginSourceInMap(params: {
+  bundled: ReadonlyMap<string, BundledPluginSource>;
+  lookup: BundledPluginLookup;
+}): BundledPluginSource | undefined {
+  const targetValue = params.lookup.value.trim();
+  if (!targetValue) {
+    return undefined;
+  }
+  if (params.lookup.kind === "pluginId") {
+    return params.bundled.get(targetValue);
+  }
+  for (const source of params.bundled.values()) {
+    if (source.npmSpec === targetValue) {
+      return source;
+    }
+  }
+  return undefined;
+}
+
 export function resolveBundledPluginSources(params: {
   workspaceDir?: string;
 }): Map<string, BundledPluginSource> {

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -397,42 +397,26 @@ export async function syncPluginsForUpdateChannel(params: {
       if (!pathsEqual(record.sourcePath, bundledInfo.localPath)) {
         continue;
       }
-
-      const spec = record.spec ?? bundledInfo.npmSpec;
-      if (!spec) {
-        summary.warnings.push(`Missing npm spec for ${pluginId}; keeping local path.`);
-        continue;
-      }
-
-      let result: Awaited<ReturnType<typeof installPluginFromNpmSpec>>;
-      try {
-        result = await installPluginFromNpmSpec({
-          spec,
-          mode: "update",
-          expectedPluginId: pluginId,
-          logger: params.logger,
-        });
-      } catch (err) {
-        summary.errors.push(`Failed to install ${pluginId}: ${String(err)}`);
-        continue;
-      }
-      if (!result.ok) {
-        summary.errors.push(`Failed to install ${pluginId}: ${result.error}`);
+      // Keep explicit bundled installs on release channels. Replacing them with
+      // npm installs can reintroduce duplicate-id shadowing and packaging drift.
+      loadHelpers.addPath(bundledInfo.localPath);
+      const alreadyBundled =
+        record.source === "path" &&
+        pathsEqual(record.sourcePath, bundledInfo.localPath) &&
+        pathsEqual(record.installPath, bundledInfo.localPath);
+      if (alreadyBundled) {
         continue;
       }
 
       next = recordPluginInstall(next, {
         pluginId,
-        source: "npm",
-        spec,
-        installPath: result.targetDir,
-        version: result.version,
-        ...buildNpmResolutionInstallFields(result.npmResolution),
-        sourcePath: undefined,
+        source: "path",
+        sourcePath: bundledInfo.localPath,
+        installPath: bundledInfo.localPath,
+        spec: record.spec ?? bundledInfo.npmSpec,
+        version: record.version,
       });
-      summary.switchedToNpm.push(pluginId);
       changed = true;
-      loadHelpers.removePath(bundledInfo.localPath);
     }
   }
 


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`74624e619`](https://github.com/openclaw/openclaw/commit/74624e619)
- **Author**: [Takhoffman](https://github.com/Takhoffman)
- **Tier**: AUTO-PICK
- **Issue**: #904

Fixes bundled channel plugins being shadowed by npm duplicates during onboarding and updates. Adds `resolveBundledInstallPlanForCatalogEntry` helper and `findBundledPluginSourceInMap` for map-based bundled source lookups.

### Conflict resolution
- `CHANGELOG.md`: removed (deleted in fork)
- `src/cli/plugin-install-plan.ts`: restored from upstream (new file, never existed in fork)
- `src/cli/plugin-install-plan.test.ts`: restored from upstream with rebrand
- `src/plugins/update.test.ts`: skipped (never existed in fork)
- `src/commands/onboarding/plugin-install.ts`: resolved import conflict (RemoteClawConfig + new import)
- `src/plugins/bundled-sources.ts`: accepted upstream's new type + function, kept fork's code
- `src/plugins/bundled-sources.test.ts`: accepted upstream's new test, rebranded fixtures