### PR TITLE
Cherry-pick 0b452a566: CLI: set local gateway mode in setup

### DIFF
--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { withTempHome } from "../../test/helpers/temp-home.js";
+import { setupCommand } from "./setup.js";
+
+describe("setupCommand", () => {
+  it("writes gateway.mode=local on first run", async () => {
+    await withTempHome(async (home) => {
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      await setupCommand(undefined, runtime);
+
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const raw = await fs.readFile(configPath, "utf-8");
+
+      expect(raw).toContain('"mode": "local"');
+      expect(raw).toContain('"workspace"');
+    });
+  });
+
+  it("adds gateway.mode=local to an existing config without overwriting workspace", async () => {
+    await withTempHome(async (home) => {
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+      const configDir = path.join(home, ".openclaw");
+      const configPath = path.join(configDir, "openclaw.json");
+      const workspace = path.join(home, "custom-workspace");
+
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          agents: {
+            defaults: {
+              workspace,
+            },
+          },
+        }),
+      );
+
+      await setupCommand(undefined, runtime);
+
+      const raw = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        agents?: { defaults?: { workspace?: string } };
+        gateway?: { mode?: string };
+      };
+
+      expect(raw.agents?.defaults?.workspace).toBe(workspace);
+      expect(raw.gateway?.mode).toBe("local");
+    });
+  });
+});

--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -15,11 +15,10 @@ describe("setupCommand", () => {
 
       await setupCommand(undefined, runtime);
 
-      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const configPath = path.join(home, ".remoteclaw", "remoteclaw.json");
       const raw = await fs.readFile(configPath, "utf-8");
 
       expect(raw).toContain('"mode": "local"');
-      expect(raw).toContain('"workspace"');
     });
   });
 
@@ -30,8 +29,8 @@ describe("setupCommand", () => {
         error: vi.fn(),
         exit: vi.fn(),
       };
-      const configDir = path.join(home, ".openclaw");
-      const configPath = path.join(configDir, "openclaw.json");
+      const configDir = path.join(home, ".remoteclaw");
+      const configPath = path.join(configDir, "remoteclaw.json");
       const workspace = path.join(home, "custom-workspace");
 
       await fs.mkdir(configDir, { recursive: true });

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -38,8 +38,16 @@ export async function setupCommand(
   const existingRaw = await readConfigFileRaw(configPath);
   const cfg = existingRaw.parsed;
 
-  if (!existingRaw.exists) {
-    await writeConfigFile(cfg);
+  const next: RemoteClawConfig = {
+    ...cfg,
+    gateway: {
+      ...cfg.gateway,
+      mode: cfg.gateway?.mode ?? "local",
+    },
+  };
+
+  if (!existingRaw.exists || cfg.gateway?.mode !== next.gateway?.mode) {
+    await writeConfigFile(next);
     runtime.log(`Wrote ${formatConfigPath(configPath)}`);
   } else {
     runtime.log(`Config OK: ${formatConfigPath(configPath)}`);


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`0b452a566`](https://github.com/openclaw/openclaw/commit/0b452a566)
- **Author**: [vincentkoc](https://github.com/vincentkoc)
- **Tier**: AUTO-PICK
- **Issue**: #904
- **Depends on**: #1287

Sets `gateway.mode: "local"` as default during setup if not already configured. Adapted to fork's simplified setup command (workspace/defaults handling was removed during gutting).