### PR TITLE
Cherry-pick fa83010b1: fix(plugins): ship Feishu bundled runtime dependency

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -12,18 +12,16 @@ Feishu (Lark) is a team chat platform used by companies for messaging and collab
 
 ---
 
-## Plugin required
+## Bundled plugin
 
-Install the Feishu plugin:
+Feishu ships bundled with current RemoteClaw releases, so no separate plugin install
+is required.
+
+If you are using an older build or a custom install that does not include bundled
+Feishu, install it manually:
 
 ```bash
 remoteclaw plugins install @remoteclaw/feishu
-```
-
-Local checkout (when running from a git repo):
-
-```bash
-remoteclaw plugins install ./extensions/feishu
 ```
 
 ---

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -1,0 +1,25 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+type PackageManifest = {
+  dependencies?: Record<string, string>;
+};
+
+function readJson<T>(relativePath: string): T {
+  const absolutePath = path.resolve(process.cwd(), relativePath);
+  return JSON.parse(fs.readFileSync(absolutePath, "utf8")) as T;
+}
+
+describe("bundled plugin runtime dependencies", () => {
+  it("keeps bundled Feishu runtime deps available from the published root package", () => {
+    const rootManifest = readJson<PackageManifest>("package.json");
+    const feishuManifest = readJson<PackageManifest>("extensions/feishu/package.json");
+    const feishuSpec = feishuManifest.dependencies?.["@larksuiteoapi/node-sdk"];
+    const rootSpec = rootManifest.dependencies?.["@larksuiteoapi/node-sdk"];
+
+    expect(feishuSpec).toBeTruthy();
+    expect(rootSpec).toBeTruthy();
+    expect(rootSpec).toBe(feishuSpec);
+  });
+});


### PR DESCRIPTION
Partial cherry-pick of [`fa83010b1`](https://github.com/openclaw/openclaw/commit/fa83010b17bb0cc52273b555040b731a29eede91).

**Author**: [Tak Hoffman](https://github.com/Takhoffman)
**Tier**: AUTO-PARTIAL (alive=2, gutted=1)
**Tracking**: #904

## Changes

- Updates `docs/channels/feishu.md` to reflect Feishu as a bundled plugin (removes local checkout install instructions, rebrands to RemoteClaw)
- Adds `src/plugins/bundled-runtime-deps.test.ts` — verifies the Feishu `@larksuiteoapi/node-sdk` dependency stays in the root `package.json`

## Discarded files

- `docs/zh-CN/channels/feishu.md` — gutted (Chinese translations deleted from fork)