### PR TITLE
Cherry-pick c94265545: fix(hooks): use resolveAgentIdFromSessionKey in runBeforeReset

### DIFF
--- a/src/auto-reply/reply/commands-core.test.ts
+++ b/src/auto-reply/reply/commands-core.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HookRunner } from "../../plugins/hooks.js";
+import type { HandleCommandsParams } from "./commands-types.js";
+
+const hookRunnerMocks = vi.hoisted(() => ({
+  hasHooks: vi.fn<HookRunner["hasHooks"]>(),
+  runBeforeReset: vi.fn<HookRunner["runBeforeReset"]>(),
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () =>
+    ({
+      hasHooks: hookRunnerMocks.hasHooks,
+      runBeforeReset: hookRunnerMocks.runBeforeReset,
+    }) as unknown as HookRunner,
+}));
+
+const { emitResetCommandHooks } = await import("./commands-core.js");
+
+describe("emitResetCommandHooks", () => {
+  async function runBeforeResetContext(sessionKey?: string) {
+    const command = {
+      surface: "discord",
+      senderId: "rai",
+      channel: "discord",
+      from: "discord:rai",
+      to: "discord:bot",
+      resetHookTriggered: false,
+    } as HandleCommandsParams["command"];
+
+    await emitResetCommandHooks({
+      action: "new",
+      ctx: {} as HandleCommandsParams["ctx"],
+      cfg: {} as HandleCommandsParams["cfg"],
+      command,
+      sessionKey,
+      previousSessionEntry: {
+        sessionId: "prev-session",
+      } as HandleCommandsParams["previousSessionEntry"],
+      workspaceDir: "/tmp/remoteclaw-workspace",
+    });
+
+    await vi.waitFor(() => expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledTimes(1));
+    const [, ctx] = hookRunnerMocks.runBeforeReset.mock.calls[0] ?? [];
+    return ctx;
+  }
+
+  beforeEach(() => {
+    hookRunnerMocks.hasHooks.mockReset();
+    hookRunnerMocks.runBeforeReset.mockReset();
+    hookRunnerMocks.hasHooks.mockImplementation((hookName) => hookName === "before_reset");
+    hookRunnerMocks.runBeforeReset.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes the bound agent id to before_reset hooks for multi-agent session keys", async () => {
+    const ctx = await runBeforeResetContext("agent:navi:main");
+    expect(ctx).toMatchObject({
+      agentId: "navi",
+      sessionKey: "agent:navi:main",
+      sessionId: "prev-session",
+      workspaceDir: "/tmp/remoteclaw-workspace",
+    });
+  });
+
+  it("falls back to main when the reset hook has no session key", async () => {
+    const ctx = await runBeforeResetContext(undefined);
+    expect(ctx).toMatchObject({
+      agentId: "main",
+      sessionKey: undefined,
+      sessionId: "prev-session",
+      workspaceDir: "/tmp/remoteclaw-workspace",
+    });
+  });
+
+  it("keeps the main-agent path on the main agent workspace", async () => {
+    const ctx = await runBeforeResetContext("agent:main:main");
+    expect(ctx).toMatchObject({
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      sessionId: "prev-session",
+      workspaceDir: "/tmp/remoteclaw-workspace",
+    });
+  });
+});

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { shouldHandleTextCommands } from "../commands-registry.js";
 import { handleAllowlistCommand } from "./commands-allowlist.js";
@@ -55,6 +56,7 @@ export async function emitResetCommandHooks(params: {
     previousSessionEntry: params.previousSessionEntry,
     commandSource: params.command.surface,
     senderId: params.command.senderId,
+    workspaceDir: params.workspaceDir,
     cfg: params.cfg, // Pass config for LLM slug generation
   });
   await triggerInternalHook(hookEvent);
@@ -112,7 +114,7 @@ export async function emitResetCommandHooks(params: {
         await hookRunner.runBeforeReset(
           { sessionFile, messages, reason: params.action },
           {
-            agentId: params.sessionKey?.split(":")[0] ?? "main",
+            agentId: resolveAgentIdFromSessionKey(params.sessionKey),
             sessionKey: params.sessionKey,
             sessionId: prevEntry?.sessionId,
             workspaceDir: params.workspaceDir,

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -533,6 +533,9 @@ describe("handleCommands hooks", () => {
         type: "command",
         action: "new",
         sessionKey: "agent:main:telegram:direct:123",
+        context: expect.objectContaining({
+          workspaceDir: testWorkspaceDir,
+        }),
       }),
     );
     spy.mockRestore();


### PR DESCRIPTION
Cherry-pick of [`c94265545`](https://github.com/openclaw/openclaw/commit/c94265545167b6d3ae18af7516cd6149b7b76c6e).

**Author**: [Hermione (rai)](https://github.com/rbutera)
**Tier**: AUTO-PICK (6 files; 3 alive, 3 gutted)
**Tracking**: #904

## Changes

- `src/auto-reply/reply/commands-core.ts` — replaces raw `sessionKey.split(":")[0]` with `resolveAgentIdFromSessionKey()` for correct agent ID resolution in `runBeforeReset` hook context; threads `workspaceDir` through to the hook event
- `src/auto-reply/reply/commands-core.test.ts` — **new** test verifying agent ID resolution for multi-agent session keys, fallback to main, and main-agent path (rebranded fixture paths)
- `src/auto-reply/reply/commands.test.ts` — adds `workspaceDir` assertion to existing hook test

## Discarded files

- `CHANGELOG.md` — gutted (not maintained in fork)
- `src/hooks/bundled/session-memory/handler.ts` — gutted (memory subsystem deleted)
- `src/hooks/bundled/session-memory/handler.test.ts` — gutted (memory subsystem deleted)