### PR TITLE
Cherry-pick e5fdfec9d: fix(config): accept "remoteclaw" as browser profile driver in Zod schema

### DIFF
--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -320,7 +320,7 @@ const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "gateway.bind": ['"auto"', '"lan"', '"loopback"', '"custom"', '"tailnet"'],
   "gateway.auth.mode": ['"none"', '"token"', '"password"', '"trusted-proxy"'],
   "gateway.tailscale.mode": ['"off"', '"serve"', '"funnel"'],
-  "browser.profiles.*.driver": ['"openclaw"', '"clawd"', '"extension"'],
+  "browser.profiles.*.driver": ['"remoteclaw"', '"clawd"', '"extension"'],
   "discovery.mdns.mode": ['"off"', '"minimal"', '"full"'],
   "wizard.lastRunMode": ['"local"', '"remote"'],
   "diagnostics.otel.protocol": ['"http/protobuf"', '"grpc"'],

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -320,7 +320,7 @@ const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "gateway.bind": ['"auto"', '"lan"', '"loopback"', '"custom"', '"tailnet"'],
   "gateway.auth.mode": ['"none"', '"token"', '"password"', '"trusted-proxy"'],
   "gateway.tailscale.mode": ['"off"', '"serve"', '"funnel"'],
-  "browser.profiles.*.driver": ['"clawd"', '"extension"'],
+  "browser.profiles.*.driver": ['"openclaw"', '"clawd"', '"extension"'],
   "discovery.mdns.mode": ['"off"', '"minimal"', '"full"'],
   "wizard.lastRunMode": ['"local"', '"remote"'],
   "diagnostics.otel.protocol": ['"http/protobuf"', '"grpc"'],

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -192,7 +192,7 @@ export const FIELD_HELP: Record<string, string> = {
   "browser.profiles.*.cdpUrl":
     "Per-profile CDP websocket URL used for explicit remote browser routing by profile name. Use this when profile connections terminate on remote hosts or tunnels.",
   "browser.profiles.*.driver":
-    'Per-profile browser driver mode: "clawd" or "extension" depending on connection/runtime strategy. Use the driver that matches your browser control stack to avoid protocol mismatches.',
+    'Per-profile browser driver mode: "remoteclaw" (or legacy "clawd") or "extension" depending on connection/runtime strategy. Use the driver that matches your browser control stack to avoid protocol mismatches.',
   "browser.profiles.*.color":
     "Per-profile accent color for visual differentiation in dashboards and browser-related UI hints. Use distinct colors for high-signal operator recognition of active profiles.",
   "browser.evaluateEnabled":

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -4,7 +4,7 @@ export type BrowserProfileConfig = {
   /** CDP URL for this profile (use for remote Chrome). */
   cdpUrl?: string;
   /** Profile driver (default: remoteclaw). */
-  driver?: "remoteclaw" | "extension";
+  driver?: "remoteclaw" | "clawd" | "extension";
   /** Profile color (hex). Auto-assigned at creation. */
   color: string;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -234,7 +234,9 @@ export const RemoteClawSchema = z
               .object({
                 cdpPort: z.number().int().min(1).max(65535).optional(),
                 cdpUrl: z.string().optional(),
-                driver: z.union([z.literal("clawd"), z.literal("extension")]).optional(),
+                driver: z
+                  .union([z.literal("remoteclaw"), z.literal("clawd"), z.literal("extension")])
+                  .optional(),
                 color: HexColorSchema,
               })
               .strict()


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [`e5fdfec9d`](https://github.com/openclaw/openclaw/commit/e5fdfec9d)
**Author**: [gambletan](https://github.com/gambletan)
**Tier**: AUTO-PICK

Adds `"remoteclaw"` (rebranded from upstream `"openclaw"`) as an accepted browser profile driver value in the Zod config schema, alongside legacy `"clawd"`. Previously only `"clawd"` and `"extension"` were accepted, causing validation failures when users specified the product-named driver.

### Conflict resolution
- Rebranded `"openclaw"` → `"remoteclaw"` in type, schema, and help text
- Kept fork's removal of `attachOnly` field (fork-intentional divergence)
- Discarded CHANGELOG.md (deleted in fork)

Closes #905 — commit 1/4

🦀 Cherry-picked with [RemoteClaw HQ](https://github.com/remoteclaw/hq)