### PR TITLE
Cherry-pick e8ad80afc: test: cover invalid talk config inputs

### DIFF
--- a/src/config/zod-schema.talk.test.ts
+++ b/src/config/zod-schema.talk.test.ts
@@ -2,6 +2,30 @@ import { describe, expect, it } from "vitest";
 import { RemoteClawSchema } from "./zod-schema.js";
 
 describe("RemoteClawSchema talk validation", () => {
+  it("accepts a positive integer talk.silenceTimeoutMs", () => {
+    expect(() =>
+      RemoteClawSchema.parse({
+        talk: {
+          silenceTimeoutMs: 1500,
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it.each([
+    ["boolean", true],
+    ["string", "1500"],
+    ["float", 1500.5],
+  ])("rejects %s talk.silenceTimeoutMs", (_label, value) => {
+    expect(() =>
+      RemoteClawSchema.parse({
+        talk: {
+          silenceTimeoutMs: value,
+        },
+      }),
+    ).toThrow(/silenceTimeoutMs|number|integer/i);
+  });
+
   it("rejects talk.provider when it does not match talk.providers", () => {
     expect(() =>
       RemoteClawSchema.parse({


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [`e8ad80afc`](https://github.com/openclaw/openclaw/commit/e8ad80afc)
**Author**: [steipete](https://github.com/steipete)
**Tier**: AUTO-PICK

Adds schema-level tests for invalid talk config inputs (silenceTimeoutMs positive integer acceptance + rejection of boolean/string/float values). Union-merged with fork's existing tests that already covered the config-load-level validation and provider mismatch cases.

### Conflict resolution
- add/add conflict: both fork and upstream independently created these test files
- Fork's `config.talk-validation.test.ts` kept as-is (more comprehensive, fork behavior pattern)
- Upstream's `zod-schema.talk.test.ts` schema tests added to fork's existing provider tests (rebranded `OpenClawSchema` → `RemoteClawSchema`)

Depends on #1292

Closes #905 — commit 2/4

🦀 Cherry-picked with [RemoteClaw HQ](https://github.com/remoteclaw/hq)