### PR TITLE
Cherry-pick e5c06dd64: refactor: use model compat for anthropic tool payload normalization

### DIFF
--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -19,6 +19,7 @@ export type ModelCompatConfig = {
   requiresAssistantAfterToolResult?: boolean;
   requiresThinkingAsText?: boolean;
   requiresMistralToolIds?: boolean;
+  requiresOpenAiAnthropicToolPayload?: boolean;
 };
 
 export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "oauth" | "token";


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [`e5c06dd64`](https://github.com/openclaw/openclaw/commit/e5c06dd64)
**Author**: [steipete](https://github.com/steipete)
**Tier**: AUTO-PARTIAL (resolved: discard gutted)

Adds `toolCompat` field to `ModelProviderConfig` type for Anthropic tool payload normalization compatibility.

### What survived
- `src/config/types.models.ts` — new `toolCompat` field in provider config type (auto-merged cleanly)

### What was discarded
- `src/agents/models-config.providers.ts` — deleted in fork (model config gutted)
- `src/agents/pi-embedded-runner-extraparams.test.ts` — pi-embedded-runner gutted
- `src/agents/pi-embedded-runner/extra-params.ts` — pi-embedded-runner gutted

Depends on #1294

Closes #905 — commit 4/4

🦀 Cherry-picked with [RemoteClaw HQ](https://github.com/remoteclaw/hq)