### PR TITLE
Cherry-pick 27558806b: docs: clarify bot review conversation ownership

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,17 @@
 - Ensure CI checks pass
 - Keep PRs focused (one thing per PR; do not mix unrelated concerns)
 - Describe what & why
+- Reply to or resolve bot review conversations you addressed before asking for review again
+
+## Review Conversations Are Author-Owned
+
+If a review bot leaves review conversations on your PR, you are expected to handle the follow-through:
+
+- Resolve the conversation yourself once the code or explanation fully addresses the bot's concern
+- Reply and leave it open only when you need maintainer or reviewer judgment
+- Do not leave "fixed" bot review conversations for maintainers to clean up for you
+
+This applies to both human-authored and AI-assisted PRs.
 
 ## Control UI Decorators
 
@@ -43,8 +54,9 @@ Please include in your PR:
 - [ ] Note the degree of testing (untested / lightly tested / fully tested)
 - [ ] Include prompts or session logs if possible (super helpful!)
 - [ ] Confirm you understand what the code does
+- [ ] Resolve or reply to bot review conversations after you address them
 
-AI PRs are first-class citizens here. We just want transparency so reviewers know what to look for.
+AI PRs are first-class citizens here. We just want transparency so reviewers know what to look for. If you are using an LLM coding agent, instruct it to resolve bot review conversations it has addressed instead of leaving them for maintainers.
 
 ## Current Focus & Roadmap
 


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`27558806b`](https://github.com/openclaw/openclaw/commit/27558806b)
- **Author**: Tak Hoffman
- **Tier**: AUTO-PICK

## Summary

Clarifies that PR authors (not maintainers) are responsible for resolving bot review conversations. Adds a "Review Conversations Are Author-Owned" section to CONTRIBUTING.md and updates the AI/Vibe-Coded PRs checklist.

## Conflict Resolution

- `.github/pull_request_template.md`, `AGENTS.md`: deleted in fork (DU) — removed
- `CONTRIBUTING.md`: upstream added bot-review-conversation line above a screenshots line that fork had already removed — took upstream's new line, kept fork's removal of screenshots line

Cherry-picked from openclaw/openclaw#39942

🤖 Generated with [Claude Code](https://claude.com/claude-code)