### PR TITLE
Cherry-pick b6520d717: CI: scope CodeQL JavaScript analysis

### DIFF
--- a/.github/codeql/codeql-javascript-typescript.yml
+++ b/.github/codeql/codeql-javascript-typescript.yml
@@ -1,0 +1,18 @@
+name: remoteclaw-codeql-javascript-typescript
+
+paths:
+  - src
+  - extensions
+  - ui/src
+  - skills
+
+paths-ignore:
+  - apps
+  - dist
+  - docs
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`b6520d717`](https://github.com/openclaw/openclaw/commit/b6520d717)
- **Author**: Vincent Koc
- **Tier**: AUTO-PICK
- **Depends on**: #1296

## Summary

Adds a CodeQL JavaScript/TypeScript analysis config file that scopes scanning to `src`, `extensions`, `ui/src`, and `skills` directories while excluding test files, coverage, and node_modules.

## Conflict Resolution

- `.github/workflows/codeql.yml`: DU (fork doesn't have CodeQL workflow) — removed
- `.github/codeql/codeql-javascript-typescript.yml`: new file, rebranded `openclaw` → `remoteclaw` in config name

The workflow file changes were dropped since the fork doesn't have a CodeQL workflow. The config file is preserved for future use if CodeQL is added.

Cherry-picked from openclaw/openclaw

🤖 Generated with [Claude Code](https://claude.com/claude-code)