### PR TITLE
Cherry-pick c0a988f69: docs: fix duplicate heading lint error

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -215,7 +215,7 @@ API key.
 3. **Create a session** using the Browserbase API (or their SDK) and retrieve
    the CDP connect URL.
 
-### Configuration
+### Profile setup
 
 Browserbase sessions expose a WebSocket CDP endpoint. Point a profile at it:
 


### PR DESCRIPTION
## Cherry-pick

- **Upstream commit**: [`c0a988f69`](https://github.com/openclaw/openclaw/commit/c0a988f69)
- **Author**: Shrey Pandya
- **Tier**: AUTO-PICK

Fixes duplicate heading lint error in browser tool docs.

Depends on #1300.
Part of #907.