### PR TITLE
Cherry-pick 7dfd77abe: fix(setup-podman): cd to TMPDIR before podman load

### DIFF
--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -38,12 +38,17 @@ run_root() {
 }
 
 run_as_user() {
+  # When switching users, the caller's cwd may be inaccessible to the target
+  # user (e.g. a private home dir). Wrap in a subshell that cd's to a
+  # world-traversable directory so sudo/runuser don't fail with "cannot chdir".
+  # TODO: replace with fully rootless podman build to eliminate the need for
+  # user-switching entirely.
   local user="$1"
   shift
   if command -v sudo >/dev/null 2>&1; then
-    sudo -u "$user" "$@"
+    ( cd /tmp 2>/dev/null || cd /; sudo -u "$user" "$@" )
   elif is_root && command -v runuser >/dev/null 2>&1; then
-    runuser -u "$user" -- "$@"
+    ( cd /tmp 2>/dev/null || cd /; runuser -u "$user" -- "$@" )
   else
     echo "Need sudo (or root+runuser) to run commands as $user." >&2
     exit 1


### PR DESCRIPTION
Cherry-pick of upstream commit [`7dfd77abe`](https://github.com/openclaw/openclaw/commit/7dfd77abe).

**Author:** langdon
**Tier:** AUTO-PICK (alive=2)

Conflict resolution: removed CHANGELOG.md (deleted in fork).

Part of #907.
Depends on #1307.