### PR TITLE
chore: remove vendor-specific references from code comments

### DIFF
--- a/src/browser/cdp.helpers.ts
+++ b/src/browser/cdp.helpers.ts
@@ -7,7 +7,7 @@ export { isLoopbackHost };
 
 /**
  * Returns true when the URL uses a WebSocket protocol (ws: or wss:).
- * Used to distinguish direct-WebSocket CDP endpoints (e.g. Browserbase)
+ * Used to distinguish direct-WebSocket CDP endpoints
  * from HTTP(S) endpoints that require /json/version discovery.
  */
 export function isWebSocketUrl(url: string): boolean {

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -108,7 +108,7 @@ export async function createTargetViaCdp(opts: {
 
   let wsUrl: string;
   if (isWebSocketUrl(opts.cdpUrl)) {
-    // Direct WebSocket URL (e.g. Browserbase) — skip /json/version discovery.
+    // Direct WebSocket URL — skip /json/version discovery.
     wsUrl = opts.cdpUrl;
   } else {
     // Standard HTTP(S) CDP endpoint — discover WebSocket URL via /json/version.

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -71,7 +71,7 @@ function cdpUrlForPort(cdpPort: number) {
 
 export async function isChromeReachable(cdpUrl: string, timeoutMs = 500): Promise<boolean> {
   if (isWebSocketUrl(cdpUrl)) {
-    // Direct WebSocket endpoint (e.g. Browserbase) — probe via WS handshake.
+    // Direct WebSocket endpoint — probe via WS handshake.
     return await canOpenWebSocket(cdpUrl, timeoutMs);
   }
   const version = await fetchChromeVersion(cdpUrl, timeoutMs);


### PR DESCRIPTION
Cherry-pick of upstream [`7b58507224`](https://github.com/openclaw/openclaw/commit/7b58507224).

**Author:** [shrey150](https://github.com/shrey150)
**Tier:** AUTO-PICK

Removes vendor-specific (Browserbase) references from code comments, replacing with generic phrasing.

Part of #908.