### PR TITLE
fix: preserve loopback ws cdp tab ops

### DIFF
--- a/src/browser/browser-utils.test.ts
+++ b/src/browser/browser-utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { appendCdpPath, getHeadersWithAuth } from "./cdp.helpers.js";
+import {
+  appendCdpPath,
+  getHeadersWithAuth,
+  normalizeCdpHttpBaseForJsonEndpoints,
+} from "./cdp.helpers.js";
 import { __test } from "./client-fetch.js";
 import { resolveBrowserConfig, resolveProfile } from "./config.js";
 import { shouldRejectBrowserMutation } from "./csrf.js";
@@ -153,6 +157,18 @@ describe("cdp.helpers", () => {
   it("appends paths under a base prefix", () => {
     const url = appendCdpPath("https://example.com/chrome/?token=abc", "json/list");
     expect(url).toBe("https://example.com/chrome/json/list?token=abc");
+  });
+
+  it("normalizes direct WebSocket CDP URLs to an HTTP base for /json endpoints", () => {
+    const url = normalizeCdpHttpBaseForJsonEndpoints(
+      "wss://connect.example.com/devtools/browser/ABC?token=abc",
+    );
+    expect(url).toBe("https://connect.example.com/?token=abc");
+  });
+
+  it("strips a trailing /cdp suffix when normalizing HTTP bases", () => {
+    const url = normalizeCdpHttpBaseForJsonEndpoints("ws://127.0.0.1:9222/cdp?token=abc");
+    expect(url).toBe("http://127.0.0.1:9222/?token=abc");
   });
 
   it("adds basic auth headers when credentials are present", () => {

--- a/src/browser/cdp.helpers.ts
+++ b/src/browser/cdp.helpers.ts
@@ -65,6 +65,28 @@ export function appendCdpPath(cdpUrl: string, path: string): string {
   return url.toString();
 }
 
+export function normalizeCdpHttpBaseForJsonEndpoints(cdpUrl: string): string {
+  try {
+    const url = new URL(cdpUrl);
+    if (url.protocol === "ws:") {
+      url.protocol = "http:";
+    } else if (url.protocol === "wss:") {
+      url.protocol = "https:";
+    }
+    url.pathname = url.pathname.replace(/\/devtools\/browser\/.*$/, "");
+    url.pathname = url.pathname.replace(/\/cdp$/, "");
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    // Best-effort fallback for non-URL-ish inputs.
+    return cdpUrl
+      .replace(/^ws:/, "http:")
+      .replace(/^wss:/, "https:")
+      .replace(/\/devtools\/browser\/.*$/, "")
+      .replace(/\/cdp$/, "")
+      .replace(/\/$/, "");
+  }
+}
+
 function createCdpSender(ws: WebSocket) {
   let nextId = 1;
   const pending = new Map<number, Pending>();

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -9,7 +9,13 @@ import type {
 import { chromium } from "playwright-core";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
-import { appendCdpPath, fetchJson, getHeadersWithAuth, withCdpSocket } from "./cdp.helpers.js";
+import {
+  appendCdpPath,
+  fetchJson,
+  getHeadersWithAuth,
+  normalizeCdpHttpBaseForJsonEndpoints,
+  withCdpSocket,
+} from "./cdp.helpers.js";
 import { normalizeCdpWsUrl } from "./cdp.js";
 import { getChromeWebSocketUrl } from "./chrome.js";
 import {
@@ -529,28 +535,6 @@ export async function closePlaywrightBrowserConnection(): Promise<void> {
     cur.browser.off("disconnected", cur.onDisconnected);
   }
   await cur.browser.close().catch(() => {});
-}
-
-function normalizeCdpHttpBaseForJsonEndpoints(cdpUrl: string): string {
-  try {
-    const url = new URL(cdpUrl);
-    if (url.protocol === "ws:") {
-      url.protocol = "http:";
-    } else if (url.protocol === "wss:") {
-      url.protocol = "https:";
-    }
-    url.pathname = url.pathname.replace(/\/devtools\/browser\/.*$/, "");
-    url.pathname = url.pathname.replace(/\/cdp$/, "");
-    return url.toString().replace(/\/$/, "");
-  } catch {
-    // Best-effort fallback for non-URL-ish inputs.
-    return cdpUrl
-      .replace(/^ws:/, "http:")
-      .replace(/^wss:/, "https:")
-      .replace(/\/devtools\/browser\/.*$/, "")
-      .replace(/\/cdp$/, "")
-      .replace(/\/$/, "");
-  }
 }
 
 function cdpSocketNeedsAttach(wsUrl: string): boolean {


### PR DESCRIPTION
Cherry-pick of upstream [`9914b48c57`](https://github.com/openclaw/openclaw/commit/9914b48c57).

**Author:** [steipete](https://github.com/steipete) (thanks [shrey150](https://github.com/shrey150))
**Tier:** AUTO-PICK

Ensures loopback WebSocket CDP URLs are properly normalized to HTTP for JSON API endpoints (`/json/list`, `/json/activate`, `/json/close`, `/json/new`). Extracts `normalizeCdpHttpBaseForJsonEndpoints` from local `pw-session.ts` to shared `cdp.helpers.ts` export.

**Conflict resolution:**
- `CHANGELOG.md`, `server-context.selection.ts`, `server-context.tab-ops.ts`: deleted in fork (selection/tab-ops were consolidated in PR #1310; their `normalizeCdpHttpBase` usage was already present via `pw-session.ts` local function).
- `pw-session.ts`: import conflict — fork had removed `withNoProxyForCdpUrl`; resolved by importing `normalizeCdpHttpBaseForJsonEndpoints` from `cdp.helpers.ts` and removing the local copy.
- `server-context.loopback-direct-ws.test.ts`: removed — depends on `server-context.remote-tab-ops.harness.ts` which doesn't exist in fork.

Part of #908.