### PR TITLE
fix(browser): rewrite 0.0.0.0 and [::] wildcard addresses in CDP WebSocket URLs

### DIFF
--- a/src/browser/cdp.test.ts
+++ b/src/browser/cdp.test.ts
@@ -320,6 +320,22 @@ describe("cdp", () => {
     expect(normalized).toBe("wss://user:pass@example.com/devtools/browser/ABC?token=abc");
   });
 
+  it("rewrites 0.0.0.0 wildcard bind address to remote CDP host", () => {
+    const normalized = normalizeCdpWsUrl(
+      "ws://0.0.0.0:3000/devtools/browser/ABC",
+      "http://192.168.1.202:18850?token=secret",
+    );
+    expect(normalized).toBe("ws://192.168.1.202:18850/devtools/browser/ABC?token=secret");
+  });
+
+  it("rewrites :: wildcard bind address to remote CDP host", () => {
+    const normalized = normalizeCdpWsUrl(
+      "ws://[::]:3000/devtools/browser/ABC",
+      "http://192.168.1.202:18850",
+    );
+    expect(normalized).toBe("ws://192.168.1.202:18850/devtools/browser/ABC");
+  });
+
   it("upgrades ws to wss when CDP uses https", () => {
     const normalized = normalizeCdpWsUrl(
       "ws://production-sfo.browserless.io",

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -19,7 +19,11 @@ export {
 export function normalizeCdpWsUrl(wsUrl: string, cdpUrl: string): string {
   const ws = new URL(wsUrl);
   const cdp = new URL(cdpUrl);
-  if (isLoopbackHost(ws.hostname) && !isLoopbackHost(cdp.hostname)) {
+  // Treat 0.0.0.0 and :: as wildcard bind addresses that need rewriting.
+  // Containerized browsers (e.g. browserless) report ws://0.0.0.0:<internal-port>
+  // in /json/version — these must be rewritten to the external cdpUrl host:port.
+  const isWildcardBind = ws.hostname === "0.0.0.0" || ws.hostname === "[::]";
+  if ((isLoopbackHost(ws.hostname) || isWildcardBind) && !isLoopbackHost(cdp.hostname)) {
     ws.hostname = cdp.hostname;
     const cdpPort = cdp.port || (cdp.protocol === "https:" ? "443" : "80");
     if (cdpPort) {


### PR DESCRIPTION
Cherry-pick of upstream [`dfa3605bee`](https://github.com/openclaw/openclaw/commit/dfa3605bee).

**Author:** [steipete](https://github.com/steipete)
**Tier:** AUTO-PICK

Rewrites `0.0.0.0` and `[::]` wildcard bind addresses to `127.0.0.1` in CDP WebSocket URLs, preventing connection failures when the browser reports its listening address as a wildcard.

Part of #908.