### PR TITLE
fix(browser): wait for extension tabs after relay drop (#32331)

### DIFF
--- a/src/browser/server-context.ensure-tab-available.prefers-last-target.test.ts
+++ b/src/browser/server-context.ensure-tab-available.prefers-last-target.test.ts
@@ -120,4 +120,33 @@ describe("browser server-context ensureTabAvailable", () => {
     const chrome = ctx.forProfile("chrome");
     await expect(chrome.ensureTabAvailable()).rejects.toThrow(/no attached Chrome tabs/i);
   });
+
+  it("waits briefly for extension tabs to reappear when a previous target exists", async () => {
+    vi.useFakeTimers();
+    try {
+      const responses = [
+        // First call: select tab A and store lastTargetId.
+        [{ id: "A", type: "page", url: "https://a.example", webSocketDebuggerUrl: "ws://x/a" }],
+        [{ id: "A", type: "page", url: "https://a.example", webSocketDebuggerUrl: "ws://x/a" }],
+        // Second call: transient drop, then the extension re-announces attached tab A.
+        [],
+        [{ id: "A", type: "page", url: "https://a.example", webSocketDebuggerUrl: "ws://x/a" }],
+        [{ id: "A", type: "page", url: "https://a.example", webSocketDebuggerUrl: "ws://x/a" }],
+      ];
+      stubChromeJsonList(responses);
+      const state = makeBrowserState();
+
+      const ctx = createBrowserRouteContext({ getState: () => state });
+      const chrome = ctx.forProfile("chrome");
+      const first = await chrome.ensureTabAvailable();
+      expect(first.targetId).toBe("A");
+
+      const secondPromise = chrome.ensureTabAvailable();
+      await vi.advanceTimersByTimeAsync(250);
+      const second = await secondPromise;
+      expect(second.targetId).toBe("A");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -372,15 +372,28 @@ function createProfileContext(
   const ensureTabAvailable = async (targetId?: string): Promise<BrowserTab> => {
     await ensureBrowserAvailable();
     const profileState = getProfileState();
-    const tabs1 = await listTabs();
+    let tabs1 = await listTabs();
     if (tabs1.length === 0) {
       if (profile.driver === "extension") {
-        throw new Error(
-          `tab not found (no attached Chrome tabs for profile "${profile.name}"). ` +
-            "Click the RemoteClaw Browser Relay toolbar icon on the tab you want to control (badge ON).",
-        );
+        // Chrome extension relay can briefly drop its WebSocket connection (MV3 service worker
+        // lifecycle, relay restart). If we previously had a target selected, wait briefly for
+        // the extension to reconnect and re-announce its attached tabs before failing.
+        if (profileState.lastTargetId?.trim()) {
+          const deadlineAt = Date.now() + 3_000;
+          while (tabs1.length === 0 && Date.now() < deadlineAt) {
+            await new Promise((resolve) => setTimeout(resolve, 200));
+            tabs1 = await listTabs();
+          }
+        }
+        if (tabs1.length === 0) {
+          throw new Error(
+            `tab not found (no attached Chrome tabs for profile "${profile.name}"). ` +
+              "Click the RemoteClaw Browser Relay toolbar icon on the tab you want to control (badge ON).",
+          );
+        }
+      } else {
+        await openTab("about:blank");
       }
-      await openTab("about:blank");
     }
 
     const tabs = await listTabs();


### PR DESCRIPTION
Cherry-pick of upstream [`bcb0d1b8b4`](https://github.com/openclaw/openclaw/commit/bcb0d1b8b4).

**Author:** [AaronWander](https://github.com/AaronWander)
**Tier:** AUTO-PICK

Adds a 3-second retry loop for Chrome extension relay tab reconnection. When the MV3 service worker drops its WebSocket connection and we previously had a target selected, we now wait briefly for re-announcement instead of immediately failing.

**Conflict resolution:**
- `server-context.selection.ts`: deleted in fork (consolidated into `server-context.ts`). Applied equivalent changes to `server-context.ts` lines 372-394.

Part of #908.