### PR TITLE
fix(infra): make browser relay bind address configurable

### DIFF
--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -34,6 +34,7 @@ export type ResolvedBrowserConfig = {
   profiles: Record<string, BrowserProfileConfig>;
   ssrfPolicy?: SsrFPolicy;
   extraArgs: string[];
+  relayBindHost?: string;
 };
 
 export type ResolvedBrowserProfile = {
@@ -257,6 +258,7 @@ export function resolveBrowserConfig(
     ? cfg.extraArgs.filter((a): a is string => typeof a === "string" && a.trim().length > 0)
     : [];
   const ssrfPolicy = resolveBrowserSsrFPolicy(cfg);
+  const relayBindHost = cfg?.relayBindHost?.trim() || undefined;
 
   return {
     enabled,
@@ -276,6 +278,7 @@ export function resolveBrowserConfig(
     profiles,
     ssrfPolicy,
     extraArgs,
+    relayBindHost,
   };
 }
 

--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -739,4 +739,36 @@ describe("chrome extension relay server", () => {
     );
     await new Promise<void>((resolve) => blocker.close(() => resolve()));
   });
+
+  it(
+    "respects bindHost override to bind on a non-loopback address",
+    async () => {
+      const port = await getFreePort();
+      cdpUrl = `http://127.0.0.1:${port}`;
+      const relay = await ensureChromeExtensionRelayServer({
+        cdpUrl,
+        bindHost: "0.0.0.0",
+      });
+      expect(relay.port).toBe(port);
+
+      // Relay should be reachable on loopback (0.0.0.0 accepts all interfaces).
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      expect(res.status).toBe(200);
+    },
+    RELAY_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "defaults bindHost to cdpUrl host when not specified",
+    async () => {
+      const port = await getFreePort();
+      cdpUrl = `http://127.0.0.1:${port}`;
+      const relay = await ensureChromeExtensionRelayServer({ cdpUrl });
+      expect(relay.host).toBe("127.0.0.1");
+
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      expect(res.status).toBe(200);
+    },
+    RELAY_TEST_TIMEOUT_MS,
+  );
 });

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -223,11 +223,13 @@ export function getChromeExtensionRelayAuthHeaders(url: string): Record<string, 
 
 export async function ensureChromeExtensionRelayServer(opts: {
   cdpUrl: string;
+  bindHost?: string;
 }): Promise<ChromeExtensionRelayServer> {
   const info = parseBaseUrl(opts.cdpUrl);
   if (!isLoopbackHost(info.host)) {
     throw new Error(`extension relay requires loopback cdpUrl host (got ${info.host})`);
   }
+  const bindHost = opts.bindHost ?? info.host;
 
   const existing = relayRuntimeByPort.get(info.port);
   if (existing) {
@@ -886,7 +888,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
 
     try {
       await new Promise<void>((resolve, reject) => {
-        server.listen(info.port, info.host, () => resolve());
+        server.listen(info.port, bindHost, () => resolve());
         server.once("error", reject);
       });
     } catch (err) {

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -290,7 +290,10 @@ function createProfileContext(
 
     if (isExtension) {
       if (!httpReachable) {
-        await ensureChromeExtensionRelayServer({ cdpUrl: profile.cdpUrl });
+        await ensureChromeExtensionRelayServer({
+          cdpUrl: profile.cdpUrl,
+          bindHost: current.resolved.relayBindHost,
+        });
         if (await isHttpReachable(1200)) {
           // continue: we still need the extension to connect for CDP websocket.
         } else {

--- a/src/browser/server-lifecycle.ts
+++ b/src/browser/server-lifecycle.ts
@@ -16,7 +16,10 @@ export async function ensureExtensionRelayForProfiles(params: {
     if (!profile || profile.driver !== "extension") {
       continue;
     }
-    await ensureChromeExtensionRelayServer({ cdpUrl: profile.cdpUrl }).catch((err) => {
+    await ensureChromeExtensionRelayServer({
+      cdpUrl: profile.cdpUrl,
+      bindHost: params.resolved.relayBindHost,
+    }).catch((err) => {
       params.onWarn(`Chrome extension relay init failed for profile "${name}": ${String(err)}`);
     });
   }

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -62,4 +62,10 @@ export type BrowserConfig = {
    * Example: ["--window-size=1920,1080", "--disable-infobars"]
    */
   extraArgs?: string[];
+  /**
+   * Bind address for the Chrome extension relay server.
+   * Default: "127.0.0.1". Set to "0.0.0.0" for WSL2 or other environments where
+   * the relay must be reachable from a different network namespace.
+   */
+  relayBindHost?: string;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -245,6 +245,7 @@ export const RemoteClawSchema = z
               }),
           )
           .optional(),
+        relayBindHost: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
Cherry-pick of upstream [`436ae8a07c`](https://github.com/openclaw/openclaw/commit/436ae8a07c).

**Author:** [mvanhorn](https://github.com/mvanhorn)
**Tier:** AUTO-PICK

Adds `relayBindHost` config option for the browser extension relay server, allowing it to bind to a specific address instead of only localhost. Propagates the bind host through config types, Zod schema, relay server, and lifecycle start.

**Conflict resolution:**
- `server-context.availability.ts`: deleted in fork (consolidated into `server-context.ts`). Applied `bindHost` pass-through to `server-context.ts` line 293.
- `zod-schema.ts`: `extraArgs` was removed in fork. Added `relayBindHost` field after the profiles optional block.

Part of #908.