### PR TITLE
fix(browser): add IP validation, fix upgrade handler for non-loopback bind

### DIFF
--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -750,8 +750,9 @@ describe("chrome extension relay server", () => {
         bindHost: "0.0.0.0",
       });
       expect(relay.port).toBe(port);
+      // Verify the server actually bound to 0.0.0.0, not the cdpUrl host.
+      expect(relay.bindHost).toBe("0.0.0.0");
 
-      // Relay should be reachable on loopback (0.0.0.0 accepts all interfaces).
       const res = await fetch(`http://127.0.0.1:${port}/`);
       expect(res.status).toBe(200);
     },
@@ -765,6 +766,7 @@ describe("chrome extension relay server", () => {
       cdpUrl = `http://127.0.0.1:${port}`;
       const relay = await ensureChromeExtensionRelayServer({ cdpUrl });
       expect(relay.host).toBe("127.0.0.1");
+      expect(relay.bindHost).toBe("127.0.0.1");
 
       const res = await fetch(`http://127.0.0.1:${port}/`);
       expect(res.status).toBe(200);

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -113,6 +113,7 @@ function getRelayAuthTokenFromRequest(req: IncomingMessage, url?: URL): string |
 
 export type ChromeExtensionRelayServer = {
   host: string;
+  bindHost: string;
   port: number;
   baseUrl: string;
   cdpWsUrl: string;
@@ -618,7 +619,9 @@ export async function ensureChromeExtensionRelayServer(opts: {
       const pathname = url.pathname;
       const remote = req.socket.remoteAddress;
 
-      if (!isLoopbackAddress(remote)) {
+      // When bindHost is explicitly non-loopback (e.g. 0.0.0.0 for WSL2),
+      // allow non-loopback connections; otherwise enforce loopback-only.
+      if (!isLoopbackAddress(remote) && isLoopbackHost(bindHost)) {
         rejectUpgrade(socket, 403, "Forbidden");
         return;
       }
@@ -902,6 +905,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
       ) {
         const existingRelay: ChromeExtensionRelayServer = {
           host: info.host,
+          bindHost,
           port: info.port,
           baseUrl: info.baseUrl,
           cdpWsUrl: `ws://${info.host}:${info.port}/cdp`,
@@ -923,6 +927,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
 
     const relay: ChromeExtensionRelayServer = {
       host,
+      bindHost,
       port,
       baseUrl,
       cdpWsUrl: `ws://${host}:${port}/cdp`,

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -245,7 +245,7 @@ export const RemoteClawSchema = z
               }),
           )
           .optional(),
-        relayBindHost: z.string().optional(),
+        relayBindHost: z.union([z.string().ipv4(), z.string().ipv6()]).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
Cherry-pick of upstream [`e883d0b556`](https://github.com/openclaw/openclaw/commit/e883d0b556).

**Author:** [mvanhorn](https://github.com/mvanhorn)
**Tier:** AUTO-PICK

Adds IP validation to the `relayBindHost` Zod schema (IPv4/IPv6 union) and fixes the WebSocket upgrade handler to allow non-loopback connections when bind host is explicitly non-loopback (e.g. `0.0.0.0` for WSL2 scenarios). Also exposes `bindHost` on the relay server object for test assertions.

**Conflict resolution:**
- `zod-schema.ts`: context conflict from removed `extraArgs`; applied `z.union([z.string().ipv4(), z.string().ipv6()])` upgrade to existing `relayBindHost` field.

Part of #908.