### PR TITLE
Cherry-pick 404b1527e: fix(acp): persist spawned child session history

### DIFF
--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -5,7 +5,7 @@ import "../cron/isolated-agent.mocks.js";
 import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import * as configModule from "../config/config.js";
-import * as sessionsModule from "../config/sessions.js";
+import * as transcriptModule from "../config/sessions/transcript.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import type { AgentDeliveryResult, ChannelMessage } from "../middleware/types.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
@@ -319,15 +319,15 @@ describe("agentCommand", () => {
       const store = path.join(customStoreDir, "sessions.json");
       writeSessionStoreSeed(store, {});
       mockConfig(home, store);
-      const resolveSessionFilePathOptionsSpy = vi.spyOn(
-        sessionsModule,
-        "resolveSessionFilePathOptions",
+      const resolveSessionTranscriptFileSpy = vi.spyOn(
+        transcriptModule,
+        "resolveSessionTranscriptFile",
       );
 
       await agentCommand({ message: "resume me", sessionId: "session-custom-123" }, runtime);
 
-      const matchingCall = resolveSessionFilePathOptionsSpy.mock.calls.find(
-        (call) => call[0]?.storePath === store,
+      const matchingCall = resolveSessionTranscriptFileSpy.mock.calls.find(
+        (call) => call[0]?.sessionId === "session-custom-123",
       );
       expect(matchingCall?.[0]).toEqual(
         expect.objectContaining({

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -17,14 +17,11 @@ import { type CliDeps, createDefaultDeps } from "../cli/deps.js";
 import { type RemoteClawConfig, loadConfig } from "../config/config.js";
 import { resolveGatewayPort } from "../config/paths.js";
 import {
-  parseSessionThreadInfo,
-  resolveAndPersistSessionFile,
   resolveAgentIdFromSessionKey,
-  resolveSessionFilePathOptions,
-  resolveSessionTranscriptPath,
   type SessionEntry,
   updateSessionStore,
 } from "../config/sessions.js";
+import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
 import { resolveGatewayCredentialsFromConfig } from "../gateway/credentials.js";
 import {
   clearAgentRunContext,
@@ -252,30 +249,25 @@ export async function agentCommand(
       provider = normalizedStored.provider;
       model = normalizedStored.model;
     }
-    const sessionPathOpts = resolveSessionFilePathOptions({
-      agentId: sessionAgentId,
-      storePath,
-    });
     if (sessionStore && sessionKey) {
-      const threadIdFromSessionKey = parseSessionThreadInfo(sessionKey).threadId;
-      const fallbackSessionFile = !sessionEntry?.sessionFile
-        ? resolveSessionTranscriptPath(
-            sessionId,
-            sessionAgentId,
-            opts.threadId ?? threadIdFromSessionKey,
-          )
-        : undefined;
-      const resolvedSessionFile = await resolveAndPersistSessionFile({
+      const resolvedSessionFile = await resolveSessionTranscriptFile({
         sessionId,
         sessionKey,
+        sessionEntry,
         sessionStore,
         storePath,
-        sessionEntry,
-        agentId: sessionPathOpts?.agentId,
-        sessionsDir: sessionPathOpts?.sessionsDir,
-        fallbackSessionFile,
+        agentId: sessionAgentId,
+        threadId: opts.threadId,
       });
       sessionEntry = resolvedSessionFile.sessionEntry;
+    } else {
+      await resolveSessionTranscriptFile({
+        sessionId,
+        sessionKey: sessionKey ?? sessionId,
+        sessionEntry,
+        agentId: sessionAgentId,
+        threadId: opts.threadId,
+      });
     }
 
     const startedAt = Date.now();

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -2,7 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { CURRENT_SESSION_VERSION } from "./constants.js";
-import { resolveDefaultSessionStorePath } from "./paths.js";
+import { parseSessionThreadInfo } from "./delivery-info.js";
+import {
+  resolveDefaultSessionStorePath,
+  resolveSessionFilePath,
+  resolveSessionFilePathOptions,
+  resolveSessionTranscriptPath,
+} from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import { loadSessionStore } from "./store.js";
 import type { SessionEntry } from "./types.js";
@@ -77,6 +83,51 @@ async function ensureSessionHeader(params: {
     encoding: "utf-8",
     mode: 0o600,
   });
+}
+
+export async function resolveSessionTranscriptFile(params: {
+  sessionId: string;
+  sessionKey: string;
+  sessionEntry: SessionEntry | undefined;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+  agentId: string;
+  threadId?: string | number;
+}): Promise<{ sessionFile: string; sessionEntry: SessionEntry | undefined }> {
+  const sessionPathOpts = resolveSessionFilePathOptions({
+    agentId: params.agentId,
+    storePath: params.storePath,
+  });
+  let sessionFile = resolveSessionFilePath(params.sessionId, params.sessionEntry, sessionPathOpts);
+  let sessionEntry = params.sessionEntry;
+
+  if (params.sessionStore && params.storePath) {
+    const threadIdFromSessionKey = parseSessionThreadInfo(params.sessionKey).threadId;
+    const fallbackSessionFile = !sessionEntry?.sessionFile
+      ? resolveSessionTranscriptPath(
+          params.sessionId,
+          params.agentId,
+          params.threadId ?? threadIdFromSessionKey,
+        )
+      : undefined;
+    const resolvedSessionFile = await resolveAndPersistSessionFile({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      sessionStore: params.sessionStore,
+      storePath: params.storePath,
+      sessionEntry,
+      agentId: sessionPathOpts?.agentId,
+      sessionsDir: sessionPathOpts?.sessionsDir,
+      fallbackSessionFile,
+    });
+    sessionFile = resolvedSessionFile.sessionFile;
+    sessionEntry = resolvedSessionFile.sessionEntry;
+  }
+
+  return {
+    sessionFile,
+    sessionEntry,
+  };
 }
 
 export async function appendAssistantMessageToSessionTranscript(params: {


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`404b1527e`](https://github.com/openclaw/openclaw/commit/404b1527e6bdf84a2b976f80111e5e5334c10e7c)
- **Author**: [mbelinky](https://github.com/mbelinky)
- **Tier**: AUTO-PICK (alive=7, partial: ACP-specific code discarded)
- **Issue**: #909

## Changes (adapted for fork)

Extracted `resolveSessionTranscriptFile()` from inline session transcript resolution logic in `agent.ts` into `transcript.ts`. This consolidates the session file path resolution + persistence into a reusable function.

**Discarded** (gutted layers):
- ACP spawn/test files (deleted in fork)
- `persistAcpTurnTranscript` function (ACP-specific)
- `.secrets.baseline` line number changes (fork has different numbers)
- `CHANGELOG.md` (deleted in fork)
- Pi-embedded imports