### PR TITLE
Cherry-pick dadd7f99c: fix(ci): scope secrets scan to branch changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,6 +69,8 @@ repos:
           - '"ap[i]Key": "xxxxx"(,)?'
           - --exclude-lines
           - 'ap[i]Key: "A[I]za\.\.\.",'
+          - --exclude-lines
+          - '"ap[i]Key": "(resolved|normalized|legacy)-key"(,)?'
   # Shell script linting
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.11.0


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`dadd7f99c`](https://github.com/openclaw/openclaw/commit/dadd7f99cd3b277eba150bd0a7240b3f1be69d7c)
- **Author**: [Nimrod Gutman](https://github.com/nicegamer7)
- **Tier**: AUTO-PICK (partial)

## What survived

Only `.pre-commit-config.yaml` — adds a new `--exclude-lines` pattern for `apiKey` test fixtures.

## What was discarded

- `src/agents/models-config.*.test.ts` — gutted layer (model config)
- `apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift` — deleted in fork
- `.github/workflows/ci.yml` — change already present in fork
- `.secrets.baseline` — fork-specific baseline kept

Resolves part of remoteclaw/remoteclaw#911