### PR TITLE
Cherry-pick d307a7ca1: refactor: extract bundled extension manifest parser

### DIFF
--- a/scripts/lib/bundled-extension-manifest.ts
+++ b/scripts/lib/bundled-extension-manifest.ts
@@ -1,0 +1,72 @@
+export type ExtensionPackageJson = {
+  name?: string;
+  version?: string;
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  remoteclaw?: {
+    install?: {
+      npmSpec?: string;
+    };
+    releaseChecks?: {
+      rootDependencyMirrorAllowlist?: unknown[];
+    };
+  };
+};
+
+export type BundledExtension = { id: string; packageJson: ExtensionPackageJson };
+export type BundledExtensionMetadata = BundledExtension & {
+  npmSpec?: string;
+  rootDependencyMirrorAllowlist: string[];
+};
+
+export function normalizeBundledExtensionMetadata(
+  extensions: BundledExtension[],
+): BundledExtensionMetadata[] {
+  return extensions.map((extension) => ({
+    ...extension,
+    npmSpec:
+      typeof extension.packageJson.remoteclaw?.install?.npmSpec === "string"
+        ? extension.packageJson.remoteclaw.install.npmSpec.trim()
+        : undefined,
+    rootDependencyMirrorAllowlist:
+      extension.packageJson.remoteclaw?.releaseChecks?.rootDependencyMirrorAllowlist?.filter(
+        (entry): entry is string => typeof entry === "string" && entry.trim().length > 0,
+      ) ?? [],
+  }));
+}
+
+export function collectBundledExtensionManifestErrors(extensions: BundledExtension[]): string[] {
+  const errors: string[] = [];
+
+  for (const extension of extensions) {
+    const install = extension.packageJson.remoteclaw?.install;
+    if (
+      install &&
+      (!install.npmSpec || typeof install.npmSpec !== "string" || !install.npmSpec.trim())
+    ) {
+      errors.push(
+        `bundled extension '${extension.id}' manifest invalid | remoteclaw.install.npmSpec must be a non-empty string`,
+      );
+    }
+
+    const allowlist =
+      extension.packageJson.remoteclaw?.releaseChecks?.rootDependencyMirrorAllowlist;
+    if (allowlist === undefined) {
+      continue;
+    }
+    if (!Array.isArray(allowlist)) {
+      errors.push(
+        `bundled extension '${extension.id}' manifest invalid | remoteclaw.releaseChecks.rootDependencyMirrorAllowlist must be an array of non-empty strings`,
+      );
+      continue;
+    }
+    const invalidEntries = allowlist.filter((entry) => typeof entry !== "string" || !entry.trim());
+    if (invalidEntries.length > 0) {
+      errors.push(
+        `bundled extension '${extension.id}' manifest invalid | remoteclaw.releaseChecks.rootDependencyMirrorAllowlist must contain only non-empty strings`,
+      );
+    }
+  }
+
+  return errors;
+}

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -3,28 +3,17 @@
 import { execSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import {
+  collectBundledExtensionManifestErrors,
+  normalizeBundledExtensionMetadata,
+  type BundledExtension,
+  type ExtensionPackageJson as PackageJson,
+} from "./lib/bundled-extension-manifest.ts";
+
+export { collectBundledExtensionManifestErrors } from "./lib/bundled-extension-manifest.ts";
 
 type PackFile = { path: string };
 type PackResult = { files?: PackFile[] };
-type PackageJson = {
-  name?: string;
-  version?: string;
-  dependencies?: Record<string, string>;
-  optionalDependencies?: Record<string, string>;
-  remoteclaw?: {
-    install?: {
-      npmSpec?: string;
-    };
-    releaseChecks?: {
-      rootDependencyMirrorAllowlist?: unknown[];
-    };
-  };
-};
-type BundledExtension = { id: string; packageJson: PackageJson };
-type BundledExtensionMetadata = BundledExtension & {
-  npmSpec?: string;
-  rootDependencyMirrorAllowlist: string[];
-};
 
 const requiredPathGroups = [
   ["dist/index.js", "dist/index.mjs"],
@@ -91,56 +80,6 @@ export function collectBundledExtensionRootDependencyGapErrors(params: {
     }
   }
 
-  return errors;
-}
-
-function normalizeBundledExtensionMetadata(
-  extensions: BundledExtension[],
-): BundledExtensionMetadata[] {
-  return extensions.map((extension) => ({
-    ...extension,
-    npmSpec:
-      typeof extension.packageJson.remoteclaw?.install?.npmSpec === "string"
-        ? extension.packageJson.remoteclaw.install.npmSpec.trim()
-        : undefined,
-    rootDependencyMirrorAllowlist:
-      extension.packageJson.remoteclaw?.releaseChecks?.rootDependencyMirrorAllowlist?.filter(
-        (entry): entry is string => typeof entry === "string" && entry.trim().length > 0,
-      ) ?? [],
-  }));
-}
-
-export function collectBundledExtensionManifestErrors(extensions: BundledExtension[]): string[] {
-  const errors: string[] = [];
-  for (const extension of extensions) {
-    const install = extension.packageJson.remoteclaw?.install;
-    if (
-      install &&
-      (!install.npmSpec || typeof install.npmSpec !== "string" || !install.npmSpec.trim())
-    ) {
-      errors.push(
-        `bundled extension '${extension.id}' manifest invalid | remoteclaw.install.npmSpec must be a non-empty string`,
-      );
-    }
-
-    const allowlist =
-      extension.packageJson.remoteclaw?.releaseChecks?.rootDependencyMirrorAllowlist;
-    if (allowlist === undefined) {
-      continue;
-    }
-    if (!Array.isArray(allowlist)) {
-      errors.push(
-        `bundled extension '${extension.id}' manifest invalid | remoteclaw.releaseChecks.rootDependencyMirrorAllowlist must be an array of non-empty strings`,
-      );
-      continue;
-    }
-    const invalidEntries = allowlist.filter((entry) => typeof entry !== "string" || !entry.trim());
-    if (invalidEntries.length > 0) {
-      errors.push(
-        `bundled extension '${extension.id}' manifest invalid | remoteclaw.releaseChecks.rootDependencyMirrorAllowlist must contain only non-empty strings`,
-      );
-    }
-  }
   return errors;
 }
 


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`d307a7ca1`](https://github.com/openclaw/openclaw/commit/d307a7ca1a21b5650f74efa732368663c733a33d)
- **Author**: [steipete](https://github.com/steipete)
- **Tier**: AUTO-PICK

## Changes

Extracts `BundledExtension` types and manifest validation functions from `scripts/release-check.ts` into a new `scripts/lib/bundled-extension-manifest.ts` module.

Fork adaptations: rebranded `openclaw` → `remoteclaw` in the new extracted module, removed `pathToFileURL`/`sparkle-build` imports (not used in fork).

Depends on #1326

Resolves part of remoteclaw/remoteclaw#911