### PR TITLE
Cherry-pick 5845b5bfb: share multi-account config schema fragments

### DIFF
--- a/extensions/bluebubbles/src/config-schema.ts
+++ b/extensions/bluebubbles/src/config-schema.ts
@@ -1,7 +1,10 @@
-import { MarkdownConfigSchema, ToolPolicySchema } from "remoteclaw/plugin-sdk";
+import {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+  MarkdownConfigSchema,
+  ToolPolicySchema,
+} from "remoteclaw/plugin-sdk";
 import { z } from "zod";
-
-const allowFromEntry = z.union([z.string(), z.number()]);
 
 const bluebubblesActionSchema = z
   .object({
@@ -33,8 +36,8 @@ const bluebubblesAccountSchema = z
     password: z.string().optional(),
     webhookPath: z.string().optional(),
     dmPolicy: z.enum(["pairing", "allowlist", "open", "disabled"]).optional(),
-    allowFrom: z.array(allowFromEntry).optional(),
-    groupAllowFrom: z.array(allowFromEntry).optional(),
+    allowFrom: z.array(AllowFromEntrySchema).optional(),
+    groupAllowFrom: z.array(AllowFromEntrySchema).optional(),
     groupPolicy: z.enum(["open", "disabled", "allowlist"]).optional(),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
@@ -59,7 +62,8 @@ const bluebubblesAccountSchema = z
     }
   });
 
-export const BlueBubblesConfigSchema = bluebubblesAccountSchema.extend({
-  accounts: z.object({}).catchall(bluebubblesAccountSchema).optional(),
+export const BlueBubblesConfigSchema = buildCatchallMultiAccountChannelSchema(
+  bluebubblesAccountSchema,
+).extend({
   actions: bluebubblesActionSchema,
 });

--- a/extensions/zalo/src/config-schema.ts
+++ b/extensions/zalo/src/config-schema.ts
@@ -1,7 +1,9 @@
-import { MarkdownConfigSchema } from "remoteclaw/plugin-sdk";
+import {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+  MarkdownConfigSchema,
+} from "remoteclaw/plugin-sdk";
 import { z } from "zod";
-
-const allowFromEntry = z.union([z.string(), z.number()]);
 
 const zaloAccountSchema = z.object({
   name: z.string().optional(),
@@ -13,15 +15,12 @@ const zaloAccountSchema = z.object({
   webhookSecret: z.string().optional(),
   webhookPath: z.string().optional(),
   dmPolicy: z.enum(["pairing", "allowlist", "open", "disabled"]).optional(),
-  allowFrom: z.array(allowFromEntry).optional(),
+  allowFrom: z.array(AllowFromEntrySchema).optional(),
   groupPolicy: z.enum(["disabled", "allowlist", "open"]).optional(),
-  groupAllowFrom: z.array(allowFromEntry).optional(),
+  groupAllowFrom: z.array(AllowFromEntrySchema).optional(),
   mediaMaxMb: z.number().optional(),
   proxy: z.string().optional(),
   responsePrefix: z.string().optional(),
 });
 
-export const ZaloConfigSchema = zaloAccountSchema.extend({
-  accounts: z.object({}).catchall(zaloAccountSchema).optional(),
-  defaultAccount: z.string().optional(),
-});
+export const ZaloConfigSchema = buildCatchallMultiAccountChannelSchema(zaloAccountSchema);

--- a/extensions/zalouser/src/config-schema.ts
+++ b/extensions/zalouser/src/config-schema.ts
@@ -1,7 +1,10 @@
-import { MarkdownConfigSchema, ToolPolicySchema } from "remoteclaw/plugin-sdk";
+import {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+  MarkdownConfigSchema,
+  ToolPolicySchema,
+} from "remoteclaw/plugin-sdk";
 import { z } from "zod";
-
-const allowFromEntry = z.union([z.string(), z.number()]);
 
 const groupConfigSchema = z.object({
   allow: z.boolean().optional(),
@@ -15,14 +18,11 @@ const zalouserAccountSchema = z.object({
   markdown: MarkdownConfigSchema,
   profile: z.string().optional(),
   dmPolicy: z.enum(["pairing", "allowlist", "open", "disabled"]).optional(),
-  allowFrom: z.array(allowFromEntry).optional(),
+  allowFrom: z.array(AllowFromEntrySchema).optional(),
   groupPolicy: z.enum(["disabled", "allowlist", "open"]).optional(),
   groups: z.object({}).catchall(groupConfigSchema).optional(),
   messagePrefix: z.string().optional(),
   responsePrefix: z.string().optional(),
 });
 
-export const ZalouserConfigSchema = zalouserAccountSchema.extend({
-  accounts: z.object({}).catchall(zalouserAccountSchema).optional(),
-  defaultAccount: z.string().optional(),
-});
+export const ZalouserConfigSchema = buildCatchallMultiAccountChannelSchema(zalouserAccountSchema);

--- a/src/channels/plugins/config-schema.ts
+++ b/src/channels/plugins/config-schema.ts
@@ -1,9 +1,24 @@
-import type { ZodTypeAny } from "zod";
+import { z, type ZodTypeAny } from "zod";
 import type { ChannelConfigSchema } from "./types.plugin.js";
 
 type ZodSchemaWithToJsonSchema = ZodTypeAny & {
   toJSONSchema?: (params?: Record<string, unknown>) => unknown;
 };
+
+type ExtendableZodObject = ZodTypeAny & {
+  extend: (shape: Record<string, ZodTypeAny>) => ZodTypeAny;
+};
+
+export const AllowFromEntrySchema = z.union([z.string(), z.number()]);
+
+export function buildCatchallMultiAccountChannelSchema<T extends ExtendableZodObject>(
+  accountSchema: T,
+): T {
+  return accountSchema.extend({
+    accounts: z.object({}).catchall(accountSchema).optional(),
+    defaultAccount: z.string().optional(),
+  }) as T;
+}
 
 export function buildChannelConfigSchema(schema: ZodTypeAny): ChannelConfigSchema {
   const schemaWithJson = schema as ZodSchemaWithToJsonSchema;

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -112,6 +112,10 @@ export {
   collectStatusIssuesFromLastError,
   createDefaultChannelRuntimeState,
 } from "./status-helpers.js";
+export {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+} from "../channels/plugins/config-schema.js";
 export type { ChannelDock } from "../channels/dock.js";
 export { getChatChannelMeta } from "../channels/registry.js";
 export type {


### PR DESCRIPTION
## Upstream Cherry-Pick

- **Commit**: [`5845b5bfb`](https://github.com/openclaw/openclaw/commit/5845b5bfb)
- **Author**: [steipete](https://github.com/steipete) (Peter Steinberger)
- **Tier**: AUTO-PICK (alive=5)
- **Issue**: #912

## Summary

Extracts shared `AllowFromEntrySchema` and `buildCatchallMultiAccountChannelSchema` helper into `channels/plugins/config-schema.ts`, then uses them across bluebubbles, zalo, and zalouser config schemas to eliminate duplicated multi-account boilerplate.

## Conflict Resolution

4 files had rebrand-path conflicts (`openclaw/plugin-sdk` → `remoteclaw/plugin-sdk`). Resolved by applying upstream's semantic changes with fork's rebranded import paths. Fork-intentional field removals in zalouser (historyLimit, groupAllowFrom) preserved.

---

*Cherry-picked from upstream with `-x`.*