### PR TITLE
Cherry-pick 371c53b28: expand talk config contract fixtures

### DIFF
--- a/apps/android/app/src/test/java/org/remoteclaw/android/voice/TalkModeConfigContractTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/voice/TalkModeConfigContractTest.kt
@@ -14,6 +14,7 @@ import org.junit.Test
 @Serializable
 private data class TalkConfigContractFixture(
   @SerialName("selectionCases") val selectionCases: List<SelectionCase>,
+  @SerialName("timeoutCases") val timeoutCases: List<TimeoutCase>,
 ) {
   @Serializable
   data class SelectionCase(
@@ -29,6 +30,15 @@ private data class TalkConfigContractFixture(
     val provider: String,
     val normalizedPayload: Boolean,
     val voiceId: String? = null,
+    val apiKey: String? = null,
+  )
+
+  @Serializable
+  data class TimeoutCase(
+    val id: String,
+    val fallback: Long,
+    val expectedTimeoutMs: Long,
+    val talk: JsonObject,
   )
 }
 
@@ -52,7 +62,21 @@ class TalkModeConfigContractTest {
         expected.voiceId,
         (selection?.config?.get("voiceId") as? JsonPrimitive)?.content,
       )
+      assertEquals(
+        fixture.id,
+        expected.apiKey,
+        (selection?.config?.get("apiKey") as? JsonPrimitive)?.content,
+      )
       assertEquals(fixture.id, true, fixture.payloadValid)
+    }
+  }
+
+  @Test
+  fun timeoutFixtures() {
+    for (fixture in loadFixtures().timeoutCases) {
+      val timeout = TalkModeGatewayConfigParser.resolvedSilenceTimeoutMs(fixture.talk)
+      assertEquals(fixture.id, fixture.expectedTimeoutMs, timeout)
+      assertEquals(fixture.id, TalkDefaults.defaultSilenceTimeoutMs, fixture.fallback)
     }
   }
 

--- a/apps/shared/RemoteClawKit/Tests/RemoteClawKitTests/TalkConfigContractTests.swift
+++ b/apps/shared/RemoteClawKit/Tests/RemoteClawKitTests/TalkConfigContractTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import RemoteClawKit
+import Testing
+
+private struct TalkConfigContractFixture: Decodable {
+    let selectionCases: [SelectionCase]
+    let timeoutCases: [TimeoutCase]
+
+    struct SelectionCase: Decodable {
+        let id: String
+        let defaultProvider: String
+        let payloadValid: Bool
+        let expectedSelection: ExpectedSelection?
+        let talk: [String: AnyCodable]
+    }
+
+    struct ExpectedSelection: Decodable {
+        let provider: String
+        let normalizedPayload: Bool
+        let voiceId: String?
+        let apiKey: String?
+    }
+
+    struct TimeoutCase: Decodable {
+        let id: String
+        let fallback: Int
+        let expectedTimeoutMs: Int
+        let talk: [String: AnyCodable]
+    }
+}
+
+private enum TalkConfigContractFixtureLoader {
+    static func load() throws -> TalkConfigContractFixture {
+        let fixtureURL = try self.findFixtureURL(startingAt: URL(fileURLWithPath: #filePath))
+        let data = try Data(contentsOf: fixtureURL)
+        return try JSONDecoder().decode(TalkConfigContractFixture.self, from: data)
+    }
+
+    private static func findFixtureURL(startingAt fileURL: URL) throws -> URL {
+        var directory = fileURL.deletingLastPathComponent()
+        while directory.path != "/" {
+            let candidate = directory.appendingPathComponent("test-fixtures/talk-config-contract.json")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+            directory.deleteLastPathComponent()
+        }
+        throw NSError(domain: "TalkConfigContractFixtureLoader", code: 1)
+    }
+}
+
+struct TalkConfigContractTests {
+    @Test func selectionFixtures() throws {
+        for fixture in try TalkConfigContractFixtureLoader.load().selectionCases {
+            let selection = TalkConfigParsing.selectProviderConfig(
+                fixture.talk,
+                defaultProvider: fixture.defaultProvider)
+            if let expected = fixture.expectedSelection {
+                #expect(selection != nil)
+                #expect(selection?.provider == expected.provider)
+                #expect(selection?.normalizedPayload == expected.normalizedPayload)
+                #expect(selection?.config["voiceId"]?.stringValue == expected.voiceId)
+                #expect(selection?.config["apiKey"]?.stringValue == expected.apiKey)
+            } else {
+                #expect(selection == nil)
+            }
+            #expect(fixture.payloadValid == (selection != nil))
+        }
+    }
+
+    @Test func timeoutFixtures() throws {
+        for fixture in try TalkConfigContractFixtureLoader.load().timeoutCases {
+            #expect(
+                TalkConfigParsing.resolvedSilenceTimeoutMs(
+                    fixture.talk,
+                    fallback: fixture.fallback) == fixture.expectedTimeoutMs,
+                "\(fixture.id)")
+        }
+    }
+}

--- a/src/gateway/protocol/talk-config.contract.test.ts
+++ b/src/gateway/protocol/talk-config.contract.test.ts
@@ -1,11 +1,13 @@
 import fs from "node:fs";
 import { describe, expect, it } from "vitest";
+import { buildTalkConfigResponse } from "../../config/talk.js";
 import { validateTalkConfigResult } from "./index.js";
 
 type ExpectedSelection = {
   provider: string;
   normalizedPayload: boolean;
   voiceId?: string;
+  apiKey?: string;
 };
 
 type SelectionContractCase = {
@@ -16,8 +18,16 @@ type SelectionContractCase = {
   talk: Record<string, unknown>;
 };
 
+type TimeoutContractCase = {
+  id: string;
+  fallback: number;
+  expectedTimeoutMs: number;
+  talk: Record<string, unknown>;
+};
+
 type TalkConfigContractFixture = {
   selectionCases: SelectionContractCase[];
+  timeoutCases: TimeoutContractCase[];
 };
 
 const fixturePath = new URL("../../../test-fixtures/talk-config-contract.json", import.meta.url);
@@ -42,9 +52,11 @@ describe("talk.config contract fixtures", () => {
           provider?: string;
           config?: {
             voiceId?: string;
+            apiKey?: string;
           };
         };
         voiceId?: string;
+        apiKey?: string;
       };
       expect(talk.resolved?.provider ?? fixture.defaultProvider).toBe(
         fixture.expectedSelection.provider,
@@ -52,6 +64,14 @@ describe("talk.config contract fixtures", () => {
       expect(talk.resolved?.config?.voiceId ?? talk.voiceId).toBe(
         fixture.expectedSelection.voiceId,
       );
+      expect(talk.resolved?.config?.apiKey ?? talk.apiKey).toBe(fixture.expectedSelection.apiKey);
+    });
+  }
+
+  for (const fixture of fixtures.timeoutCases) {
+    it(`timeout:${fixture.id}`, () => {
+      const payload = buildTalkConfigResponse(fixture.talk);
+      expect(payload?.silenceTimeoutMs ?? fixture.fallback).toBe(fixture.expectedTimeoutMs);
     });
   }
 });

--- a/test-fixtures/talk-config-contract.json
+++ b/test-fixtures/talk-config-contract.json
@@ -7,22 +7,26 @@
       "expectedSelection": {
         "provider": "elevenlabs",
         "normalizedPayload": true,
-        "voiceId": "voice-resolved"
+        "voiceId": "voice-resolved",
+        "apiKey": "resolved-key"
       },
       "talk": {
         "resolved": {
           "provider": "elevenlabs",
           "config": {
-            "voiceId": "voice-resolved"
+            "voiceId": "voice-resolved",
+            "apiKey": "resolved-key"
           }
         },
         "provider": "elevenlabs",
         "providers": {
           "elevenlabs": {
-            "voiceId": "voice-normalized"
+            "voiceId": "voice-normalized",
+            "apiKey": "normalized-key"
           }
         },
-        "voiceId": "voice-legacy"
+        "voiceId": "voice-legacy",
+        "apiKey": "legacy-key"
       }
     },
     {
@@ -77,11 +81,62 @@
       "expectedSelection": {
         "provider": "elevenlabs",
         "normalizedPayload": false,
-        "voiceId": "voice-legacy"
+        "voiceId": "voice-legacy",
+        "apiKey": "legacy-key"
       },
       "talk": {
         "voiceId": "voice-legacy",
         "apiKey": "legacy-key"
+      }
+    }
+  ],
+  "timeoutCases": [
+    {
+      "id": "integer_timeout_kept",
+      "fallback": 700,
+      "expectedTimeoutMs": 1500,
+      "talk": {
+        "silenceTimeoutMs": 1500
+      }
+    },
+    {
+      "id": "integer_like_double_timeout_kept",
+      "fallback": 700,
+      "expectedTimeoutMs": 1500,
+      "talk": {
+        "silenceTimeoutMs": 1500.0
+      }
+    },
+    {
+      "id": "zero_timeout_falls_back",
+      "fallback": 700,
+      "expectedTimeoutMs": 700,
+      "talk": {
+        "silenceTimeoutMs": 0
+      }
+    },
+    {
+      "id": "boolean_timeout_falls_back",
+      "fallback": 700,
+      "expectedTimeoutMs": 700,
+      "talk": {
+        "silenceTimeoutMs": true
+      }
+    },
+    {
+      "id": "string_timeout_falls_back",
+      "fallback": 700,
+      "expectedTimeoutMs": 700,
+      "talk": {
+        "silenceTimeoutMs": "1500"
+      }
+    },
+    {
+      "id": "fractional_timeout_falls_back",
+      "fallback": 700,
+      "expectedTimeoutMs": 700,
+      "talk": {
+        "silenceTimeoutMs": 1500.5
       }
     }
   ]


### PR DESCRIPTION
## Upstream Cherry-Pick

- **Commit**: [`371c53b28`](https://github.com/openclaw/openclaw/commit/371c53b28)
- **Author**: [steipete](https://github.com/steipete) (Peter Steinberger)
- **Tier**: AUTO-PICK (alive=3, partial: rebranded=1)
- **Issue**: #912
- **Depends on**: #1331

## Summary

Expands talk config contract test fixtures with additional selection and timeout test cases across TS, Android (Kotlin), and iOS (Swift) test suites.

## Conflict Resolution

- DU conflict: `apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkConfigContractTests.swift` deleted in fork (rebranded path). Created rebranded copy at `apps/shared/RemoteClawKit/Tests/RemoteClawKitTests/TalkConfigContractTests.swift` with `OpenClawKit` → `RemoteClawKit` import.

---

*Cherry-picked from upstream with `-x`.*