### PR TITLE
Cherry-pick 3ada30e67: fix: restore gate after rebase

### DIFF
--- a/src/infra/git-commit.test.ts
+++ b/src/infra/git-commit.test.ts
@@ -3,8 +3,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { pathToFileURL } from "node:url";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 async function makeTempDir(label: string): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), `remoteclaw-${label}-`));
@@ -39,10 +39,20 @@ async function makeFakeGitRepo(
 }
 
 describe("git commit resolution", () => {
-  const originalCwd = process.cwd();
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+  beforeEach(async () => {
+    process.chdir(repoRoot);
+    vi.restoreAllMocks();
+    vi.doUnmock("node:fs");
+    vi.doUnmock("node:module");
+    vi.resetModules();
+    const { __testing } = await import("./git-commit.js");
+    __testing.clearCachedGitCommits();
+  });
 
   afterEach(() => {
-    process.chdir(originalCwd);
+    process.chdir(repoRoot);
     vi.restoreAllMocks();
     vi.doUnmock("node:fs");
     vi.doUnmock("node:module");
@@ -51,7 +61,7 @@ describe("git commit resolution", () => {
 
   it("resolves commit metadata from the caller module root instead of the caller cwd", async () => {
     const repoHead = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
-      cwd: originalCwd,
+      cwd: repoRoot,
       encoding: "utf-8",
     })
       .trim()
@@ -77,7 +87,7 @@ describe("git commit resolution", () => {
 
     process.chdir(otherRepo);
     const { resolveCommitHash } = await import("./git-commit.js");
-    const entryModuleUrl = pathToFileURL(path.join(originalCwd, "src", "entry.ts")).href;
+    const entryModuleUrl = pathToFileURL(path.join(repoRoot, "src", "entry.ts")).href;
 
     expect(resolveCommitHash({ moduleUrl: entryModuleUrl })).toBe(repoHead);
     expect(resolveCommitHash({ moduleUrl: entryModuleUrl })).not.toBe(otherHead);
@@ -85,7 +95,7 @@ describe("git commit resolution", () => {
 
   it("prefers live git metadata over stale build info in a real checkout", async () => {
     const repoHead = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
-      cwd: originalCwd,
+      cwd: repoRoot,
       encoding: "utf-8",
     })
       .trim()
@@ -106,7 +116,7 @@ describe("git commit resolution", () => {
     vi.resetModules();
 
     const { resolveCommitHash } = await import("./git-commit.js");
-    const entryModuleUrl = pathToFileURL(path.join(originalCwd, "src", "entry.ts")).href;
+    const entryModuleUrl = pathToFileURL(path.join(repoRoot, "src", "entry.ts")).href;
 
     expect(resolveCommitHash({ moduleUrl: entryModuleUrl, env: {} })).toBe(repoHead);
 
@@ -174,7 +184,7 @@ describe("git commit resolution", () => {
 
   it("treats invalid moduleUrl inputs as a fallback hint instead of throwing", async () => {
     const repoHead = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
-      cwd: originalCwd,
+      cwd: repoRoot,
       encoding: "utf-8",
     })
       .trim()
@@ -183,9 +193,9 @@ describe("git commit resolution", () => {
     const { resolveCommitHash } = await import("./git-commit.js");
 
     expect(() =>
-      resolveCommitHash({ moduleUrl: "not-a-file-url", cwd: originalCwd, env: {} }),
+      resolveCommitHash({ moduleUrl: "not-a-file-url", cwd: repoRoot, env: {} }),
     ).not.toThrow();
-    expect(resolveCommitHash({ moduleUrl: "not-a-file-url", cwd: originalCwd, env: {} })).toBe(
+    expect(resolveCommitHash({ moduleUrl: "not-a-file-url", cwd: repoRoot, env: {} })).toBe(
       repoHead,
     );
   });


### PR DESCRIPTION
## Upstream Cherry-Pick

**Commit**: [`3ada30e67`](https://github.com/openclaw/openclaw/commit/3ada30e67)
**Author**: [steipete](https://github.com/steipete)
**Tier**: AUTO-PICK (alive=3, partial: gutted=1)

Fixes test reliability in `git-commit.test.ts` by using a stable `repoRoot` derived from `import.meta.url` instead of `process.cwd()`, and adds a `beforeEach` hook that clears cached git commits between tests.

### Resolution Notes

- 2 DU files removed (gutted pi-embedded-runner, provider-capabilities — not in fork)
- `scripts/test-parallel.mjs` conflict: kept fork version (variables restructured/rebranded in fork, upstream's `shouldSplitUnitRuns` change not applicable)
- `src/infra/git-commit.test.ts` conflict: composed fork's sync `afterEach` with upstream's `repoRoot` variable

Cherry-picked from openclaw/openclaw@3ada30e67 (issue #913)