### PR TITLE
Cherry-pick 3ada30e67: fix: restore gate after rebase

### DIFF
--- a/src/infra/git-commit.test.ts
+++ b/src/infra/git-commit.test.ts
@@ -3,8 +3,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { pathToFileURL } from "node:url";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 async function makeTempDir(label: string): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), `remoteclaw-${label}-`));
@@ -39,23 +39,33 @@ async function makeFakeGitRepo(
 }
 
 describe("git commit resolution", () => {
-  const originalCwd = process.cwd();
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
-  afterEach(() => {
-    process.chdir(originalCwd);
+  beforeEach(async () => {
+    process.chdir(repoRoot);
     vi.restoreAllMocks();
     vi.doUnmock("node:fs");
     vi.doUnmock("node:module");
     vi.resetModules();
+    const { __testing } = await import("./git-commit.js");
+    __testing.clearCachedGitCommits();
+  });
+
+  afterEach(async () => {
+    process.chdir(repoRoot);
+    vi.restoreAllMocks();
+    vi.doUnmock("node:fs");
+    vi.doUnmock("node:module");
+    vi.resetModules();
+    const { __testing } = await import("./git-commit.js");
+    __testing.clearCachedGitCommits();
   });
 
   it("resolves commit metadata from the caller module root instead of the caller cwd", async () => {
     const repoHead = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
-      cwd: originalCwd,
+      cwd: repoRoot,
       encoding: "utf-8",
-    })
-      .trim()
-      .slice(0, 7);
+    }).trim();
 
     const temp = await makeTempDir("git-commit-cwd");
     const otherRepo = path.join(temp, "other");
@@ -71,13 +81,11 @@ describe("git commit resolution", () => {
     const otherHead = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
       cwd: otherRepo,
       encoding: "utf-8",
-    })
-      .trim()
-      .slice(0, 7);
+    }).trim();
 
     process.chdir(otherRepo);
     const { resolveCommitHash } = await import("./git-commit.js");
-    const entryModuleUrl = pathToFileURL(path.join(originalCwd, "src", "entry.ts")).href;
+    const entryModuleUrl = pathToFileURL(path.join(repoRoot, "src", "entry.ts")).href;
 
     expect(resolveCommitHash({ moduleUrl: entryModuleUrl })).toBe(repoHead);
     expect(resolveCommitHash({ moduleUrl: entryModuleUrl })).not.toBe(otherHead);
@@ -85,107 +93,82 @@ describe("git commit resolution", () => {
 
   it("prefers live git metadata over stale build info in a real checkout", async () => {
     const repoHead = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
-      cwd: originalCwd,
+      cwd: repoRoot,
       encoding: "utf-8",
-    })
-      .trim()
-      .slice(0, 7);
-
-    vi.doMock("node:module", () => ({
-      createRequire: () => {
-        return (specifier: string) => {
-          if (specifier === "../build-info.json" || specifier === "./build-info.json") {
-            return { commit: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" };
-          }
-          throw Object.assign(new Error(`Cannot find module ${specifier}`), {
-            code: "MODULE_NOT_FOUND",
-          });
-        };
-      },
-    }));
-    vi.resetModules();
+    }).trim();
 
     const { resolveCommitHash } = await import("./git-commit.js");
-    const entryModuleUrl = pathToFileURL(path.join(originalCwd, "src", "entry.ts")).href;
+    const entryModuleUrl = pathToFileURL(path.join(repoRoot, "src", "entry.ts")).href;
 
-    expect(resolveCommitHash({ moduleUrl: entryModuleUrl, env: {} })).toBe(repoHead);
-
-    vi.doUnmock("node:module");
+    expect(
+      resolveCommitHash({
+        moduleUrl: entryModuleUrl,
+        env: {},
+        readers: {
+          readBuildInfoCommit: () => "deadbee",
+        },
+      }),
+    ).toBe(repoHead);
   });
 
   it("caches build-info fallback results per resolved search directory", async () => {
     const temp = await makeTempDir("git-commit-build-info-cache");
-    const moduleRequire = vi.fn((specifier: string) => {
-      if (specifier === "../build-info.json" || specifier === "./build-info.json") {
-        return { commit: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" };
-      }
-      throw Object.assign(new Error(`Cannot find module ${specifier}`), {
-        code: "MODULE_NOT_FOUND",
-      });
-    });
-
-    vi.doMock("node:module", () => ({
-      createRequire: () => moduleRequire,
-    }));
-    vi.resetModules();
-
     const { resolveCommitHash } = await import("./git-commit.js");
+    const readBuildInfoCommit = vi.fn(() => "deadbee");
 
-    expect(resolveCommitHash({ cwd: temp, env: {} })).toBe("deadbee");
-    const firstCallRequires = moduleRequire.mock.calls.length;
+    expect(resolveCommitHash({ cwd: temp, env: {}, readers: { readBuildInfoCommit } })).toBe(
+      "deadbee",
+    );
+    const firstCallRequires = readBuildInfoCommit.mock.calls.length;
     expect(firstCallRequires).toBeGreaterThan(0);
-    expect(resolveCommitHash({ cwd: temp, env: {} })).toBe("deadbee");
-    expect(moduleRequire.mock.calls.length).toBe(firstCallRequires);
-
-    vi.doUnmock("node:module");
+    expect(resolveCommitHash({ cwd: temp, env: {}, readers: { readBuildInfoCommit } })).toBe(
+      "deadbee",
+    );
+    expect(readBuildInfoCommit.mock.calls.length).toBe(firstCallRequires);
   });
 
   it("caches package.json fallback results per resolved search directory", async () => {
     const temp = await makeTempDir("git-commit-package-json-cache");
-    const moduleRequire = vi.fn((specifier: string) => {
-      if (specifier === "../build-info.json" || specifier === "./build-info.json") {
-        throw Object.assign(new Error(`Cannot find module ${specifier}`), {
-          code: "MODULE_NOT_FOUND",
-        });
-      }
-      if (specifier === "../../package.json") {
-        return { gitHead: "badc0ffee0ddf00d" };
-      }
-      throw Object.assign(new Error(`Cannot find module ${specifier}`), {
-        code: "MODULE_NOT_FOUND",
-      });
-    });
-
-    vi.doMock("node:module", () => ({
-      createRequire: () => moduleRequire,
-    }));
-    vi.resetModules();
-
     const { resolveCommitHash } = await import("./git-commit.js");
+    const readPackageJsonCommit = vi.fn(() => "badc0ff");
 
-    expect(resolveCommitHash({ cwd: temp, env: {} })).toBe("badc0ff");
-    const firstCallRequires = moduleRequire.mock.calls.length;
+    expect(
+      resolveCommitHash({
+        cwd: temp,
+        env: {},
+        readers: {
+          readBuildInfoCommit: () => null,
+          readPackageJsonCommit,
+        },
+      }),
+    ).toBe("badc0ff");
+    const firstCallRequires = readPackageJsonCommit.mock.calls.length;
     expect(firstCallRequires).toBeGreaterThan(0);
-    expect(resolveCommitHash({ cwd: temp, env: {} })).toBe("badc0ff");
-    expect(moduleRequire.mock.calls.length).toBe(firstCallRequires);
-
-    vi.doUnmock("node:module");
+    expect(
+      resolveCommitHash({
+        cwd: temp,
+        env: {},
+        readers: {
+          readBuildInfoCommit: () => null,
+          readPackageJsonCommit,
+        },
+      }),
+    ).toBe("badc0ff");
+    expect(readPackageJsonCommit.mock.calls.length).toBe(firstCallRequires);
   });
 
   it("treats invalid moduleUrl inputs as a fallback hint instead of throwing", async () => {
     const repoHead = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
-      cwd: originalCwd,
+      cwd: repoRoot,
       encoding: "utf-8",
-    })
-      .trim()
-      .slice(0, 7);
+    }).trim();
 
     const { resolveCommitHash } = await import("./git-commit.js");
 
     expect(() =>
-      resolveCommitHash({ moduleUrl: "not-a-file-url", cwd: originalCwd, env: {} }),
+      resolveCommitHash({ moduleUrl: "not-a-file-url", cwd: repoRoot, env: {} }),
     ).not.toThrow();
-    expect(resolveCommitHash({ moduleUrl: "not-a-file-url", cwd: originalCwd, env: {} })).toBe(
+    expect(resolveCommitHash({ moduleUrl: "not-a-file-url", cwd: repoRoot, env: {} })).toBe(
       repoHead,
     );
   });
@@ -212,28 +195,19 @@ describe("git commit resolution", () => {
     );
     const moduleUrl = pathToFileURL(path.join(packageRoot, "dist", "entry.js")).href;
 
-    vi.doMock("node:module", () => ({
-      createRequire: () => {
-        return (specifier: string) => {
-          if (specifier === "../build-info.json" || specifier === "./build-info.json") {
-            return { commit: "feedfacefeedfacefeedfacefeedfacefeedface" };
-          }
-          if (specifier === "../../package.json") {
-            return { name: "remoteclaw", version: "2026.3.8", gitHead: "badc0ffee0ddf00d" };
-          }
-          throw Object.assign(new Error(`Cannot find module ${specifier}`), {
-            code: "MODULE_NOT_FOUND",
-          });
-        };
-      },
-    }));
-    vi.resetModules();
-
     const { resolveCommitHash } = await import("./git-commit.js");
 
-    expect(resolveCommitHash({ moduleUrl, cwd: packageRoot, env: {} })).toBe("feedfac");
-
-    vi.doUnmock("node:module");
+    expect(
+      resolveCommitHash({
+        moduleUrl,
+        cwd: packageRoot,
+        env: {},
+        readers: {
+          readBuildInfoCommit: () => "feedfac",
+          readPackageJsonCommit: () => "badc0ff",
+        },
+      }),
+    ).toBe("feedfac");
   });
 
   it("caches git lookups per resolved search directory", async () => {
@@ -261,27 +235,14 @@ describe("git commit resolution", () => {
       head: "not-a-commit\n",
     });
 
-    const actualFs = await vi.importActual<typeof import("node:fs")>("node:fs");
-    const readFileSyncSpy = vi.fn(actualFs.readFileSync);
-    vi.doMock("node:fs", () => ({
-      ...actualFs,
-      default: {
-        ...actualFs,
-        readFileSync: readFileSyncSpy,
-      },
-      readFileSync: readFileSyncSpy,
-    }));
-    vi.resetModules();
-
     const { resolveCommitHash } = await import("./git-commit.js");
+    const readGitCommit = vi.fn(() => null);
 
-    expect(resolveCommitHash({ cwd: repoRoot, env: {} })).toBeNull();
-    const firstCallReads = readFileSyncSpy.mock.calls.length;
+    expect(resolveCommitHash({ cwd: repoRoot, env: {}, readers: { readGitCommit } })).toBeNull();
+    const firstCallReads = readGitCommit.mock.calls.length;
     expect(firstCallReads).toBeGreaterThan(0);
-    expect(resolveCommitHash({ cwd: repoRoot, env: {} })).toBeNull();
-    expect(readFileSyncSpy.mock.calls.length).toBe(firstCallReads);
-
-    vi.doUnmock("node:fs");
+    expect(resolveCommitHash({ cwd: repoRoot, env: {}, readers: { readGitCommit } })).toBeNull();
+    expect(readGitCommit.mock.calls.length).toBe(firstCallReads);
   });
 
   it("caches caught null fallback results per resolved search directory", async () => {
@@ -290,49 +251,39 @@ describe("git commit resolution", () => {
     await makeFakeGitRepo(repoRoot, {
       head: "0123456789abcdef0123456789abcdef01234567\n",
     });
-    const headPath = path.join(repoRoot, ".git", "HEAD");
-
-    const actualFs = await vi.importActual<typeof import("node:fs")>("node:fs");
-    const readFileSyncSpy = vi.fn((filePath: string, ...args: unknown[]) => {
-      if (path.resolve(filePath) === path.resolve(headPath)) {
-        const error = Object.assign(new Error(`EACCES: permission denied, open '${filePath}'`), {
-          code: "EACCES",
-        });
-        throw error;
-      }
-      return Reflect.apply(actualFs.readFileSync, actualFs, [filePath, ...args]);
-    });
-    vi.doMock("node:fs", () => ({
-      ...actualFs,
-      default: {
-        ...actualFs,
-        readFileSync: readFileSyncSpy,
-      },
-      readFileSync: readFileSyncSpy,
-    }));
-    vi.doMock("node:module", () => ({
-      createRequire: () => {
-        return (specifier: string) => {
-          throw Object.assign(new Error(`Cannot find module ${specifier}`), {
-            code: "MODULE_NOT_FOUND",
-          });
-        };
-      },
-    }));
-    vi.resetModules();
-
     const { resolveCommitHash } = await import("./git-commit.js");
+    const readGitCommit = vi.fn(() => {
+      const error = Object.assign(new Error(`EACCES: permission denied`), {
+        code: "EACCES",
+      });
+      throw error;
+    });
 
-    expect(resolveCommitHash({ cwd: repoRoot, env: {} })).toBeNull();
-    const headReadCount = () =>
-      readFileSyncSpy.mock.calls.filter(([filePath]) => path.resolve(filePath) === headPath).length;
-    const firstCallReads = headReadCount();
+    expect(
+      resolveCommitHash({
+        cwd: repoRoot,
+        env: {},
+        readers: {
+          readGitCommit,
+          readBuildInfoCommit: () => null,
+          readPackageJsonCommit: () => null,
+        },
+      }),
+    ).toBeNull();
+    const firstCallReads = readGitCommit.mock.calls.length;
     expect(firstCallReads).toBe(2);
-    expect(resolveCommitHash({ cwd: repoRoot, env: {} })).toBeNull();
-    expect(headReadCount()).toBe(firstCallReads);
-
-    vi.doUnmock("node:fs");
-    vi.doUnmock("node:module");
+    expect(
+      resolveCommitHash({
+        cwd: repoRoot,
+        env: {},
+        readers: {
+          readGitCommit,
+          readBuildInfoCommit: () => null,
+          readPackageJsonCommit: () => null,
+        },
+      }),
+    ).toBeNull();
+    expect(readGitCommit.mock.calls.length).toBe(firstCallReads);
   });
 
   it("formats env-provided commit strings consistently", async () => {

--- a/src/infra/git-commit.ts
+++ b/src/infra/git-commit.ts
@@ -56,6 +56,10 @@ const safeReadFilePrefix = (filePath: string, limit = 256) => {
   }
 };
 
+const clearCachedGitCommits = () => {
+  cachedGitCommitBySearchDir.clear();
+};
+
 const cacheGitCommit = (searchDir: string, commit: string | null) => {
   cachedGitCommitBySearchDir.set(searchDir, commit);
   return commit;
@@ -213,4 +217,8 @@ export const resolveCommitHash = (
   } catch {
     return cacheGitCommit(searchDir, null);
   }
+};
+
+export const __testing = {
+  clearCachedGitCommits,
 };


### PR DESCRIPTION
## Upstream Cherry-Pick

**Commit**: [`3ada30e67`](https://github.com/openclaw/openclaw/commit/3ada30e67)
**Author**: [steipete](https://github.com/steipete)
**Tier**: AUTO-PICK (alive=3, partial: gutted=1)

Fixes test reliability in `git-commit.test.ts` by using a stable `repoRoot` derived from `import.meta.url` instead of `process.cwd()`, and adds `beforeEach`/`afterEach` hooks that clear cached git commits between tests. Also adds the required `__testing` export to `git-commit.ts`.

### Resolution Notes

- 2 DU files removed (gutted pi-embedded-runner, provider-capabilities — not in fork)
- `scripts/test-parallel.mjs` conflict: kept fork version (variables restructured/rebranded in fork, upstream's `shouldSplitUnitRuns` change not applicable)
- `src/infra/git-commit.test.ts` conflict: took upstream's repoRoot refactoring with rebrand applied
- Added `clearCachedGitCommits()` and `__testing` export to `git-commit.ts` (required by new test setup)

Cherry-picked from openclaw/openclaw@3ada30e67 (issue #913)