### PR TITLE
Cherry-pick a6131438e: fix(macos): improve tailscale gateway discovery

### DIFF
--- a/apps/macos/Sources/RemoteClaw/GatewayDiscoverySelectionSupport.swift
+++ b/apps/macos/Sources/RemoteClaw/GatewayDiscoverySelectionSupport.swift
@@ -1,0 +1,53 @@
+import RemoteClawDiscovery
+
+@MainActor
+enum GatewayDiscoverySelectionSupport {
+    static func applyRemoteSelection(
+        gateway: GatewayDiscoveryModel.DiscoveredGateway,
+        state: AppState)
+    {
+        let preferredTransport = self.preferredTransport(
+            for: gateway,
+            current: state.remoteTransport)
+        if preferredTransport != state.remoteTransport {
+            state.remoteTransport = preferredTransport
+        }
+
+        state.remoteUrl = GatewayDiscoveryHelpers.directUrl(for: gateway) ?? ""
+        state.remoteTarget = GatewayDiscoveryHelpers.sshTarget(for: gateway) ?? ""
+
+        if let endpoint = GatewayDiscoveryHelpers.serviceEndpoint(for: gateway) {
+            RemoteClawConfigFile.setRemoteGatewayUrl(
+                host: endpoint.host,
+                port: endpoint.port)
+        } else {
+            RemoteClawConfigFile.clearRemoteGatewayUrl()
+        }
+    }
+
+    static func preferredTransport(
+        for gateway: GatewayDiscoveryModel.DiscoveredGateway,
+        current: AppState.RemoteTransport) -> AppState.RemoteTransport
+    {
+        if self.shouldPreferDirectTransport(for: gateway) {
+            return .direct
+        }
+        return current
+    }
+
+    static func shouldPreferDirectTransport(
+        for gateway: GatewayDiscoveryModel.DiscoveredGateway) -> Bool
+    {
+        guard GatewayDiscoveryHelpers.directUrl(for: gateway) != nil else { return false }
+        if gateway.stableID.hasPrefix("tailscale-serve|") {
+            return true
+        }
+        guard let host = GatewayDiscoveryHelpers.resolvedServiceHost(for: gateway)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        else {
+            return false
+        }
+        return host.hasSuffix(".ts.net")
+    }
+}

--- a/apps/macos/Sources/RemoteClawDiscovery/TailscaleServeGatewayDiscovery.swift
+++ b/apps/macos/Sources/RemoteClawDiscovery/TailscaleServeGatewayDiscovery.swift
@@ -1,0 +1,329 @@
+import Foundation
+import RemoteClawKit
+
+struct TailscaleServeGatewayBeacon: Equatable {
+    var displayName: String
+    var tailnetDns: String
+    var host: String
+    var port: Int
+}
+
+enum TailscaleServeGatewayDiscovery {
+    private static let maxCandidates = 32
+    private static let probeConcurrency = 6
+    private static let defaultProbeTimeoutSeconds: TimeInterval = 1.6
+
+    struct DiscoveryContext {
+        var tailscaleStatus: @Sendable () async -> String?
+        var probeHost: @Sendable (_ host: String, _ timeout: TimeInterval) async -> Bool
+
+        static let live = DiscoveryContext(
+            tailscaleStatus: { await readTailscaleStatus() },
+            probeHost: { host, timeout in
+                await probeHostForGatewayChallenge(host: host, timeout: timeout)
+            })
+    }
+
+    static func discover(
+        timeoutSeconds: TimeInterval = 3.0,
+        context: DiscoveryContext = .live) async -> [TailscaleServeGatewayBeacon]
+    {
+        guard timeoutSeconds > 0 else { return [] }
+        guard let statusJson = await context.tailscaleStatus(),
+              let status = parseStatus(statusJson)
+        else {
+            return []
+        }
+
+        let candidates = self.collectCandidates(status: status)
+        if candidates.isEmpty { return [] }
+
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        let perProbeTimeout = min(self.defaultProbeTimeoutSeconds, max(0.5, timeoutSeconds * 0.45))
+
+        var byHost: [String: TailscaleServeGatewayBeacon] = [:]
+        await withTaskGroup(of: TailscaleServeGatewayBeacon?.self) { group in
+            var index = 0
+            let workerCount = min(self.probeConcurrency, candidates.count)
+
+            func submitOne() {
+                guard index < candidates.count else { return }
+                let candidate = candidates[index]
+                index += 1
+                group.addTask {
+                    let remaining = deadline.timeIntervalSinceNow
+                    if remaining <= 0 {
+                        return nil
+                    }
+                    let timeout = min(perProbeTimeout, remaining)
+                    let reachable = await context.probeHost(candidate.dnsName, timeout)
+                    if !reachable {
+                        return nil
+                    }
+                    return TailscaleServeGatewayBeacon(
+                        displayName: candidate.displayName,
+                        tailnetDns: candidate.dnsName,
+                        host: candidate.dnsName,
+                        port: 443)
+                }
+            }
+
+            for _ in 0..<workerCount {
+                submitOne()
+            }
+
+            while let beacon = await group.next() {
+                if let beacon {
+                    byHost[beacon.host.lowercased()] = beacon
+                }
+                submitOne()
+            }
+        }
+
+        return byHost.values.sorted {
+            $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
+    }
+
+    private struct Candidate {
+        var dnsName: String
+        var displayName: String
+    }
+
+    private static func collectCandidates(status: TailscaleStatus) -> [Candidate] {
+        let selfDns = self.normalizeDnsName(status.selfNode?.dnsName)
+        var out: [Candidate] = []
+        var seen = Set<String>()
+
+        for node in status.peer.values {
+            if node.online == false {
+                continue
+            }
+            guard let dnsName = normalizeDnsName(node.dnsName) else {
+                continue
+            }
+            if dnsName == selfDns {
+                continue
+            }
+            if seen.contains(dnsName) {
+                continue
+            }
+            seen.insert(dnsName)
+
+            out.append(Candidate(
+                dnsName: dnsName,
+                displayName: self.displayName(hostName: node.hostName, dnsName: dnsName)))
+
+            if out.count >= self.maxCandidates {
+                break
+            }
+        }
+
+        return out
+    }
+
+    private static func displayName(hostName: String?, dnsName: String) -> String {
+        if let hostName {
+            let trimmed = hostName.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return dnsName
+            .split(separator: ".")
+            .first
+            .map(String.init) ?? dnsName
+    }
+
+    private static func normalizeDnsName(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return nil }
+        let withoutDot = trimmed.hasSuffix(".") ? String(trimmed.dropLast()) : trimmed
+        let lower = withoutDot.lowercased()
+        return lower.isEmpty ? nil : lower
+    }
+
+    private static func readTailscaleStatus() async -> String? {
+        let candidates = [
+            "/usr/local/bin/tailscale",
+            "/opt/homebrew/bin/tailscale",
+            "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+            "tailscale",
+        ]
+
+        for candidate in candidates {
+            guard let executable = self.resolveExecutablePath(candidate) else { continue }
+            if let stdout = await self.run(path: executable, args: ["status", "--json"], timeout: 1.0) {
+                return stdout
+            }
+        }
+
+        return nil
+    }
+
+    static func resolveExecutablePath(
+        _ candidate: String,
+        env: [String: String] = ProcessInfo.processInfo.environment) -> String?
+    {
+        let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let fileManager = FileManager.default
+        let hasPathSeparator = trimmed.contains("/")
+        if hasPathSeparator {
+            return fileManager.isExecutableFile(atPath: trimmed) ? trimmed : nil
+        }
+
+        let pathRaw = env["PATH"] ?? ""
+        let entries = pathRaw.split(separator: ":").map(String.init)
+        for entry in entries {
+            let dir = entry.trimmingCharacters(in: .whitespacesAndNewlines)
+            if dir.isEmpty { continue }
+            let fullPath = URL(fileURLWithPath: dir)
+                .appendingPathComponent(trimmed)
+                .path
+            if fileManager.isExecutableFile(atPath: fullPath) {
+                return fullPath
+            }
+        }
+
+        return nil
+    }
+
+    private static func run(path: String, args: [String], timeout: TimeInterval) async -> String? {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                continuation.resume(returning: self.runBlocking(path: path, args: args, timeout: timeout))
+            }
+        }
+    }
+
+    private static func runBlocking(path: String, args: [String], timeout: TimeInterval) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = args
+        process.environment = self.commandEnvironment()
+        let outPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        if process.isRunning {
+            process.terminate()
+        }
+        process.waitUntilExit()
+
+        let data = (try? outPipe.fileHandleForReading.readToEnd()) ?? Data()
+        let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return output?.isEmpty == false ? output : nil
+    }
+
+    static func commandEnvironment(
+        base: [String: String] = ProcessInfo.processInfo.environment) -> [String: String]
+    {
+        var env = base
+        let term = env["TERM"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if term.isEmpty {
+            // The macOS Tailscale app binary exits with CLIError error 3 when TERM is missing,
+            // which is common for GUI-launched app environments.
+            env["TERM"] = "dumb"
+        }
+        return env
+    }
+
+    private static func parseStatus(_ raw: String) -> TailscaleStatus? {
+        guard let data = raw.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(TailscaleStatus.self, from: data)
+    }
+
+    private static func probeHostForGatewayChallenge(host: String, timeout: TimeInterval) async -> Bool {
+        var components = URLComponents()
+        components.scheme = "wss"
+        components.host = host
+        guard let url = components.url else { return false }
+
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = max(0.5, timeout)
+        config.timeoutIntervalForResource = max(0.5, timeout)
+        let session = URLSession(configuration: config)
+        let task = session.webSocketTask(with: url)
+        task.resume()
+
+        defer {
+            task.cancel(with: .goingAway, reason: nil)
+            session.invalidateAndCancel()
+        }
+
+        do {
+            return try await AsyncTimeout.withTimeout(
+                seconds: timeout,
+                onTimeout: { NSError(domain: "TailscaleServeDiscovery", code: 1, userInfo: nil) },
+                operation: {
+                    while true {
+                        let message = try await task.receive()
+                        if self.isConnectChallenge(message: message) {
+                            return true
+                        }
+                    }
+                })
+        } catch {
+            return false
+        }
+    }
+
+    private static func isConnectChallenge(message: URLSessionWebSocketTask.Message) -> Bool {
+        let data: Data
+        switch message {
+        case let .data(value):
+            data = value
+        case let .string(value):
+            guard let encoded = value.data(using: .utf8) else { return false }
+            data = encoded
+        @unknown default:
+            return false
+        }
+
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              let dict = object as? [String: Any],
+              let type = dict["type"] as? String,
+              type == "event",
+              let event = dict["event"] as? String
+        else {
+            return false
+        }
+
+        return event == "connect.challenge"
+    }
+}
+
+private struct TailscaleStatus: Decodable {
+    struct Node: Decodable {
+        let dnsName: String?
+        let hostName: String?
+        let online: Bool?
+
+        private enum CodingKeys: String, CodingKey {
+            case dnsName = "DNSName"
+            case hostName = "HostName"
+            case online = "Online"
+        }
+    }
+
+    let selfNode: Node?
+    let peer: [String: Node]
+
+    private enum CodingKeys: String, CodingKey {
+        case selfNode = "Self"
+        case peer = "Peer"
+    }
+}

--- a/apps/macos/Tests/RemoteClawIPCTests/GatewayDiscoverySelectionSupportTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/GatewayDiscoverySelectionSupportTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import RemoteClawDiscovery
+import Testing
+@testable import RemoteClaw
+
+@Suite(.serialized)
+@MainActor
+struct GatewayDiscoverySelectionSupportTests {
+    private func makeGateway(
+        serviceHost: String?,
+        servicePort: Int?,
+        tailnetDns: String? = nil,
+        sshPort: Int = 22,
+        stableID: String) -> GatewayDiscoveryModel.DiscoveredGateway
+    {
+        GatewayDiscoveryModel.DiscoveredGateway(
+            displayName: "Gateway",
+            serviceHost: serviceHost,
+            servicePort: servicePort,
+            lanHost: nil,
+            tailnetDns: tailnetDns,
+            sshPort: sshPort,
+            gatewayPort: servicePort,
+            cliPath: nil,
+            stableID: stableID,
+            debugID: UUID().uuidString,
+            isLocal: false)
+    }
+
+    @Test func `selecting tailscale serve gateway switches to direct transport`() async {
+        let tailnetHost = "gateway-host.tailnet-example.ts.net"
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withEnvValues(["REMOTECLAW_CONFIG_PATH": configPath]) {
+            let state = AppState(preview: true)
+            state.remoteTransport = .ssh
+            state.remoteTarget = "user@old-host"
+
+            GatewayDiscoverySelectionSupport.applyRemoteSelection(
+                gateway: self.makeGateway(
+                    serviceHost: tailnetHost,
+                    servicePort: 443,
+                    tailnetDns: tailnetHost,
+                    stableID: "tailscale-serve|\(tailnetHost)"),
+                state: state)
+
+            #expect(state.remoteTransport == .direct)
+            #expect(state.remoteUrl == "wss://\(tailnetHost)")
+            #expect(CommandResolver.parseSSHTarget(state.remoteTarget)?.host == tailnetHost)
+        }
+    }
+
+    @Test func `selecting merged tailnet gateway still switches to direct transport`() async {
+        let tailnetHost = "gateway-host.tailnet-example.ts.net"
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withEnvValues(["REMOTECLAW_CONFIG_PATH": configPath]) {
+            let state = AppState(preview: true)
+            state.remoteTransport = .ssh
+
+            GatewayDiscoverySelectionSupport.applyRemoteSelection(
+                gateway: self.makeGateway(
+                    serviceHost: tailnetHost,
+                    servicePort: 443,
+                    tailnetDns: tailnetHost,
+                    stableID: "wide-area|remoteclaw.internal.|gateway-host"),
+                state: state)
+
+            #expect(state.remoteTransport == .direct)
+            #expect(state.remoteUrl == "wss://\(tailnetHost)")
+        }
+    }
+
+    @Test func `selecting nearby lan gateway keeps ssh transport`() async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withEnvValues(["REMOTECLAW_CONFIG_PATH": configPath]) {
+            let state = AppState(preview: true)
+            state.remoteTransport = .ssh
+            state.remoteTarget = "user@old-host"
+
+            GatewayDiscoverySelectionSupport.applyRemoteSelection(
+                gateway: self.makeGateway(
+                    serviceHost: "nearby-gateway.local",
+                    servicePort: 18789,
+                    stableID: "bonjour|nearby-gateway"),
+                state: state)
+
+            #expect(state.remoteTransport == .ssh)
+            #expect(CommandResolver.parseSSHTarget(state.remoteTarget)?.host == "nearby-gateway.local")
+        }
+    }
+}

--- a/apps/macos/Tests/RemoteClawIPCTests/TailscaleServeGatewayDiscoveryTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/TailscaleServeGatewayDiscoveryTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+@testable import RemoteClawDiscovery
+
+struct TailscaleServeGatewayDiscoveryTests {
+    @Test func `discovers serve gateway from tailnet peers`() async {
+        let statusJson = """
+        {
+          "Self": {
+            "DNSName": "local-mac.tailnet-example.ts.net.",
+            "HostName": "local-mac",
+            "Online": true
+          },
+          "Peer": {
+            "peer-1": {
+              "DNSName": "gateway-host.tailnet-example.ts.net.",
+              "HostName": "gateway-host",
+              "Online": true
+            },
+            "peer-2": {
+              "DNSName": "offline.tailnet-example.ts.net.",
+              "HostName": "offline-box",
+              "Online": false
+            },
+            "peer-3": {
+              "DNSName": "local-mac.tailnet-example.ts.net.",
+              "HostName": "local-mac",
+              "Online": true
+            }
+          }
+        }
+        """
+
+        let context = TailscaleServeGatewayDiscovery.DiscoveryContext(
+            tailscaleStatus: { statusJson },
+            probeHost: { host, _ in
+                host == "gateway-host.tailnet-example.ts.net"
+            })
+
+        let beacons = await TailscaleServeGatewayDiscovery.discover(timeoutSeconds: 2.0, context: context)
+        #expect(beacons.count == 1)
+        #expect(beacons.first?.displayName == "gateway-host")
+        #expect(beacons.first?.tailnetDns == "gateway-host.tailnet-example.ts.net")
+        #expect(beacons.first?.host == "gateway-host.tailnet-example.ts.net")
+        #expect(beacons.first?.port == 443)
+    }
+
+    @Test func `returns empty when status unavailable`() async {
+        let context = TailscaleServeGatewayDiscovery.DiscoveryContext(
+            tailscaleStatus: { nil },
+            probeHost: { _, _ in true })
+
+        let beacons = await TailscaleServeGatewayDiscovery.discover(timeoutSeconds: 2.0, context: context)
+        #expect(beacons.isEmpty)
+    }
+
+    @Test func `resolves bare executable from PATH`() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let executable = tempDir.appendingPathComponent("tailscale")
+        try "#!/bin/sh\necho ok\n".write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let env: [String: String] = ["PATH": tempDir.path]
+        let resolved = TailscaleServeGatewayDiscovery.resolveExecutablePath("tailscale", env: env)
+        #expect(resolved == executable.path)
+    }
+
+    @Test func `rejects missing executable candidate`() {
+        #expect(TailscaleServeGatewayDiscovery.resolveExecutablePath("", env: [:]) == nil)
+        #expect(TailscaleServeGatewayDiscovery
+            .resolveExecutablePath("definitely-not-here", env: ["PATH": "/tmp"]) == nil)
+    }
+
+    @Test func `adds TERM for GUI-launched tailscale subprocesses`() {
+        let env = TailscaleServeGatewayDiscovery.commandEnvironment(base: [
+            "HOME": "/Users/tester",
+            "PATH": "/usr/bin:/bin",
+        ])
+
+        #expect(env["TERM"] == "dumb")
+        #expect(env["HOME"] == "/Users/tester")
+        #expect(env["PATH"] == "/usr/bin:/bin")
+    }
+
+    @Test func `preserves existing TERM when building tailscale subprocess environment`() {
+        let env = TailscaleServeGatewayDiscovery.commandEnvironment(base: [
+            "TERM": "xterm-256color",
+            "HOME": "/Users/tester",
+        ])
+
+        #expect(env["TERM"] == "xterm-256color")
+        #expect(env["HOME"] == "/Users/tester")
+    }
+}


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [`a6131438e`](https://github.com/openclaw/openclaw/commit/a6131438e)
**Author**: [steipete](https://github.com/steipete) (Peter Steinberger)
**Tier**: AUTO-PICK (alive=3, rebranded=4)

## Conflict resolution

This cherry-pick required conflict resolution for rebranded paths:

- **CHANGELOG.md**: Kept fork's deletion (fork removed CHANGELOG.md)
- **GatewayDiscoverySelectionSupport.swift**: Placed upstream's version at fork's rebranded path (`RemoteClaw/` instead of `OpenClaw/`), rebranded imports (`RemoteClawDiscovery`, `RemoteClawConfigFile`)
- **TailscaleServeGatewayDiscovery.swift**: Placed upstream's version at fork's rebranded path (`RemoteClawDiscovery/` instead of `OpenClawDiscovery/`), rebranded import (`RemoteClawKit`)
- **GatewayDiscoveryModel.swift**: Kept fork's version (fork replaced `scheduleTailscaleServeFallback` with `scheduleWideAreaFallback`; upstream's changes to the old method don't apply)
- **GatewayDiscoveryModelTests.swift**: Kept fork's version (tests for removed code don't apply)
- **TailscaleServeGatewayDiscoveryTests.swift**: Placed upstream's version at fork's rebranded path, rebranded imports
- **GatewayDiscoverySelectionSupportTests.swift**: New file placed at fork's rebranded path, rebranded imports and env var names (`REMOTECLAW_CONFIG_PATH`), domain names (`remoteclaw.internal.`)

Closes #914 — commit 3/4