### PR TITLE
Cherry-pick 64d4d9aab: refactor: move bundled extension gap allowlists into manifests

### DIFF
--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -32,6 +32,11 @@
       "npmSpec": "@remoteclaw/googlechat",
       "localPath": "extensions/googlechat",
       "defaultChoice": "npm"
+    },
+    "releaseChecks": {
+      "rootDependencyMirrorAllowlist": [
+        "google-auth-library"
+      ]
     }
   }
 }

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -28,6 +28,13 @@
       "npmSpec": "@remoteclaw/matrix",
       "localPath": "extensions/matrix",
       "defaultChoice": "npm"
+    },
+    "releaseChecks": {
+      "rootDependencyMirrorAllowlist": [
+        "@matrix-org/matrix-sdk-crypto-nodejs",
+        "@vector-im/matrix-bot-sdk",
+        "music-metadata"
+      ]
     }
   }
 }

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -27,6 +27,11 @@
       "npmSpec": "@remoteclaw/msteams",
       "localPath": "extensions/msteams",
       "defaultChoice": "npm"
+    },
+    "releaseChecks": {
+      "rootDependencyMirrorAllowlist": [
+        "@microsoft/agents-hosting"
+      ]
     }
   }
 }

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -25,6 +25,11 @@
       "npmSpec": "@remoteclaw/nostr",
       "localPath": "extensions/nostr",
       "defaultChoice": "npm"
+    },
+    "releaseChecks": {
+      "rootDependencyMirrorAllowlist": [
+        "nostr-tools"
+      ]
     }
   }
 }

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -24,6 +24,13 @@
       "npmSpec": "@remoteclaw/tlon",
       "localPath": "extensions/tlon",
       "defaultChoice": "npm"
+    },
+    "releaseChecks": {
+      "rootDependencyMirrorAllowlist": [
+        "@tloncorp/api",
+        "@tloncorp/tlon-skill",
+        "@urbit/aura"
+      ]
     }
   }
 }

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -27,6 +27,11 @@
       "npmSpec": "@remoteclaw/zalouser",
       "localPath": "extensions/zalouser",
       "defaultChoice": "npm"
+    },
+    "releaseChecks": {
+      "rootDependencyMirrorAllowlist": [
+        "zca-js"
+      ]
     }
   }
 }

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -33,15 +33,6 @@ function normalizePluginSyncVersion(version: string): string {
   return normalized.replace(/[-+].*$/, "");
 }
 
-const ALLOWLISTED_BUNDLED_EXTENSION_ROOT_DEP_GAPS: Record<string, string[]> = {
-  googlechat: ["google-auth-library"],
-  matrix: ["@matrix-org/matrix-sdk-crypto-nodejs", "@vector-im/matrix-bot-sdk", "music-metadata"],
-  msteams: ["@microsoft/agents-hosting"],
-  nostr: ["nostr-tools"],
-  tlon: ["@tloncorp/api", "@tloncorp/tlon-skill", "@urbit/aura"],
-  zalouser: ["zca-js"],
-};
-
 export function collectBundledExtensionRootDependencyGapErrors(params: {
   rootPackage: PackageJson;
   extensions: BundledExtension[];
@@ -60,9 +51,7 @@ export function collectBundledExtensionRootDependencyGapErrors(params: {
     const missing = Object.keys(extension.packageJson.dependencies ?? {})
       .filter((dep) => dep !== "remoteclaw" && !rootDeps[dep])
       .toSorted();
-    const allowlisted = [
-      ...(ALLOWLISTED_BUNDLED_EXTENSION_ROOT_DEP_GAPS[extension.id] ?? []),
-    ].toSorted();
+    const allowlisted = [...extension.rootDependencyMirrorAllowlist].toSorted();
     if (missing.join("\n") !== allowlisted.join("\n")) {
       const unexpected = missing.filter((dep) => !allowlisted.includes(dep));
       const resolved = allowlisted.filter((dep) => !missing.includes(dep));


### PR DESCRIPTION
## Upstream Cherry-Pick

- **Commit**: [`64d4d9aab`](https://github.com/openclaw/openclaw/commit/64d4d9aabb61984c4384c2dfe93a3a74a9180411)
- **Author**: [steipete](https://github.com/steipete)
- **Tier**: AUTO-PICK (alive=8)

## Summary

Moves bundled extension root dependency gap allowlists from a hardcoded constant in `scripts/release-check.ts` into each extension's `package.json` manifest under `remoteclaw.releaseChecks.rootDependencyMirrorAllowlist`.

**Conflict resolution**: The fork had already extracted manifest parsing into `scripts/lib/bundled-extension-manifest.ts` with full `releaseChecks` support. The hardcoded constant was removed and the allowlist lookup updated to use the already-normalized `extension.rootDependencyMirrorAllowlist` field. The upstream's `test/release-check.test.ts` changes were dropped (file deleted in fork).

Closes #916 partially.