### PR TITLE
Cherry-pick 8d7778d1d: refactor: dedupe plugin runtime stores

### DIFF
--- a/extensions/bluebubbles/src/runtime.ts
+++ b/extensions/bluebubbles/src/runtime.ts
@@ -1,31 +1,26 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
+const runtimeStore = createPluginRuntimeStore<PluginRuntime>("BlueBubbles runtime not initialized");
 type LegacyRuntimeLogShape = { log?: (message: string) => void };
-
-export function setBlueBubblesRuntime(next: PluginRuntime): void {
-  runtime = next;
-}
+export const setBlueBubblesRuntime = runtimeStore.setRuntime;
 
 export function clearBlueBubblesRuntime(): void {
-  runtime = null;
+  runtimeStore.clearRuntime();
 }
 
 export function tryGetBlueBubblesRuntime(): PluginRuntime | null {
-  return runtime;
+  return runtimeStore.tryGetRuntime();
 }
 
 export function getBlueBubblesRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("BlueBubbles runtime not initialized");
-  }
-  return runtime;
+  return runtimeStore.getRuntime();
 }
 
 export function warnBlueBubbles(message: string): void {
   const formatted = `[bluebubbles] ${message}`;
   // Backward-compatible with tests/legacy injections that pass { log }.
-  const log = (runtime as unknown as LegacyRuntimeLogShape | null)?.log;
+  const log = (runtimeStore.tryGetRuntime() as unknown as LegacyRuntimeLogShape | null)?.log;
   if (typeof log === "function") {
     log(formatted);
     return;

--- a/extensions/discord/src/runtime.ts
+++ b/extensions/discord/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setDiscordRuntime(next: PluginRuntime) {
-  runtime = next;
-}
-
-export function getDiscordRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("Discord runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setDiscordRuntime, getRuntime: getDiscordRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Discord runtime not initialized");
+export { getDiscordRuntime, setDiscordRuntime };

--- a/extensions/feishu/src/runtime.ts
+++ b/extensions/feishu/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setFeishuRuntime(next: PluginRuntime) {
-  runtime = next;
-}
-
-export function getFeishuRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("Feishu runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setFeishuRuntime, getRuntime: getFeishuRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Feishu runtime not initialized");
+export { getFeishuRuntime, setFeishuRuntime };

--- a/extensions/googlechat/src/runtime.ts
+++ b/extensions/googlechat/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setGoogleChatRuntime(next: PluginRuntime) {
-  runtime = next;
-}
-
-export function getGoogleChatRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("Google Chat runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setGoogleChatRuntime, getRuntime: getGoogleChatRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Google Chat runtime not initialized");
+export { getGoogleChatRuntime, setGoogleChatRuntime };

--- a/extensions/imessage/src/runtime.ts
+++ b/extensions/imessage/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setIMessageRuntime(next: PluginRuntime) {
-  runtime = next;
-}
-
-export function getIMessageRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("iMessage runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setIMessageRuntime, getRuntime: getIMessageRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("iMessage runtime not initialized");
+export { getIMessageRuntime, setIMessageRuntime };

--- a/extensions/irc/src/runtime.ts
+++ b/extensions/irc/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setIrcRuntime(next: PluginRuntime) {
-  runtime = next;
-}
-
-export function getIrcRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("IRC runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setIrcRuntime, getRuntime: getIrcRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("IRC runtime not initialized");
+export { getIrcRuntime, setIrcRuntime };

--- a/extensions/line/src/runtime.ts
+++ b/extensions/line/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setLineRuntime(r: PluginRuntime): void {
-  runtime = r;
-}
-
-export function getLineRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("LINE runtime not initialized - plugin not registered");
-  }
-  return runtime;
-}
+const { setRuntime: setLineRuntime, getRuntime: getLineRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("LINE runtime not initialized - plugin not registered");
+export { getLineRuntime, setLineRuntime };

--- a/extensions/matrix/src/runtime.ts
+++ b/extensions/matrix/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setMatrixRuntime(next: PluginRuntime) {
-  runtime = next;
-}
-
-export function getMatrixRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("Matrix runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setMatrixRuntime, getRuntime: getMatrixRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Matrix runtime not initialized");
+export { getMatrixRuntime, setMatrixRuntime };

--- a/extensions/mattermost/src/runtime.ts
+++ b/extensions/mattermost/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setMattermostRuntime(next: PluginRuntime) {
-  runtime = next;
-}
-
-export function getMattermostRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("Mattermost runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setMattermostRuntime, getRuntime: getMattermostRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Mattermost runtime not initialized");
+export { getMattermostRuntime, setMattermostRuntime };

--- a/extensions/msteams/src/runtime.ts
+++ b/extensions/msteams/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setMSTeamsRuntime(next: PluginRuntime) {
-  runtime = next;
-}
-
-export function getMSTeamsRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("MSTeams runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setMSTeamsRuntime, getRuntime: getMSTeamsRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("MSTeams runtime not initialized");
+export { getMSTeamsRuntime, setMSTeamsRuntime };

--- a/extensions/nextcloud-talk/src/runtime.ts
+++ b/extensions/nextcloud-talk/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setNextcloudTalkRuntime(next: PluginRuntime) {
-  runtime = next;
-}
-
-export function getNextcloudTalkRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("Nextcloud Talk runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setNextcloudTalkRuntime, getRuntime: getNextcloudTalkRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Nextcloud Talk runtime not initialized");
+export { getNextcloudTalkRuntime, setNextcloudTalkRuntime };

--- a/extensions/nostr/src/runtime.ts
+++ b/extensions/nostr/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setNostrRuntime(next: PluginRuntime): void {
-  runtime = next;
-}
-
-export function getNostrRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("Nostr runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setNostrRuntime, getRuntime: getNostrRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Nostr runtime not initialized");
+export { getNostrRuntime, setNostrRuntime };

--- a/extensions/signal/src/runtime.ts
+++ b/extensions/signal/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setSignalRuntime(next: PluginRuntime) {
-  runtime = next;
-}
-
-export function getSignalRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("Signal runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setSignalRuntime, getRuntime: getSignalRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Signal runtime not initialized");
+export { getSignalRuntime, setSignalRuntime };

--- a/extensions/slack/src/runtime.ts
+++ b/extensions/slack/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setSlackRuntime(next: PluginRuntime) {
-  runtime = next;
-}
-
-export function getSlackRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("Slack runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setSlackRuntime, getRuntime: getSlackRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Slack runtime not initialized");
+export { getSlackRuntime, setSlackRuntime };

--- a/extensions/synology-chat/src/runtime.ts
+++ b/extensions/synology-chat/src/runtime.ts
@@ -1,20 +1,8 @@
-/**
- * Plugin runtime singleton.
- * Stores the PluginRuntime from api.runtime (set during register()).
- * Used by channel.ts to access dispatch functions.
- */
-
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setSynologyRuntime(r: PluginRuntime): void {
-  runtime = r;
-}
-
-export function getSynologyRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("Synology Chat runtime not initialized - plugin not registered");
-  }
-  return runtime;
-}
+const { setRuntime: setSynologyRuntime, getRuntime: getSynologyRuntime } =
+  createPluginRuntimeStore<PluginRuntime>(
+    "Synology Chat runtime not initialized - plugin not registered",
+  );
+export { getSynologyRuntime, setSynologyRuntime };

--- a/extensions/telegram/src/runtime.ts
+++ b/extensions/telegram/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setTelegramRuntime(next: PluginRuntime) {
-  runtime = next;
-}
-
-export function getTelegramRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("Telegram runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setTelegramRuntime, getRuntime: getTelegramRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Telegram runtime not initialized");
+export { getTelegramRuntime, setTelegramRuntime };

--- a/extensions/tlon/src/runtime.ts
+++ b/extensions/tlon/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setTlonRuntime(next: PluginRuntime) {
-  runtime = next;
-}
-
-export function getTlonRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("Tlon runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setTlonRuntime, getRuntime: getTlonRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Tlon runtime not initialized");
+export { getTlonRuntime, setTlonRuntime };

--- a/extensions/twitch/src/runtime.ts
+++ b/extensions/twitch/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setTwitchRuntime(next: PluginRuntime) {
-  runtime = next;
-}
-
-export function getTwitchRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("Twitch runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setTwitchRuntime, getRuntime: getTwitchRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Twitch runtime not initialized");
+export { getTwitchRuntime, setTwitchRuntime };

--- a/extensions/whatsapp/src/runtime.ts
+++ b/extensions/whatsapp/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setWhatsAppRuntime(next: PluginRuntime) {
-  runtime = next;
-}
-
-export function getWhatsAppRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("WhatsApp runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setWhatsAppRuntime, getRuntime: getWhatsAppRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("WhatsApp runtime not initialized");
+export { getWhatsAppRuntime, setWhatsAppRuntime };

--- a/extensions/zalo/src/runtime.ts
+++ b/extensions/zalo/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setZaloRuntime(next: PluginRuntime): void {
-  runtime = next;
-}
-
-export function getZaloRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("Zalo runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setZaloRuntime, getRuntime: getZaloRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Zalo runtime not initialized");
+export { getZaloRuntime, setZaloRuntime };

--- a/extensions/zalouser/src/runtime.ts
+++ b/extensions/zalouser/src/runtime.ts
@@ -1,14 +1,6 @@
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk";
 import type { PluginRuntime } from "remoteclaw/plugin-sdk";
 
-let runtime: PluginRuntime | null = null;
-
-export function setZalouserRuntime(next: PluginRuntime): void {
-  runtime = next;
-}
-
-export function getZalouserRuntime(): PluginRuntime {
-  if (!runtime) {
-    throw new Error("Zalouser runtime not initialized");
-  }
-  return runtime;
-}
+const { setRuntime: setZalouserRuntime, getRuntime: getZalouserRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Zalouser runtime not initialized");
+export { getZalouserRuntime, setZalouserRuntime };

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -116,6 +116,7 @@ export {
   AllowFromEntrySchema,
   buildCatchallMultiAccountChannelSchema,
 } from "../channels/plugins/config-schema.js";
+export { createPluginRuntimeStore } from "./runtime-store.js";
 export type { ChannelDock } from "../channels/dock.js";
 export { getChatChannelMeta } from "../channels/registry.js";
 export type {

--- a/src/plugin-sdk/runtime-store.ts
+++ b/src/plugin-sdk/runtime-store.ts
@@ -1,0 +1,26 @@
+export function createPluginRuntimeStore<T>(errorMessage: string): {
+  setRuntime: (next: T) => void;
+  clearRuntime: () => void;
+  tryGetRuntime: () => T | null;
+  getRuntime: () => T;
+} {
+  let runtime: T | null = null;
+
+  return {
+    setRuntime(next: T) {
+      runtime = next;
+    },
+    clearRuntime() {
+      runtime = null;
+    },
+    tryGetRuntime() {
+      return runtime;
+    },
+    getRuntime() {
+      if (!runtime) {
+        throw new Error(errorMessage);
+      }
+      return runtime;
+    },
+  };
+}


### PR DESCRIPTION
## Upstream Cherry-Pick

- **Commit**: [`8d7778d1d`](https://github.com/openclaw/openclaw/commit/8d7778d1d6c56c85311d5d8de5a2658a181e0083)
- **Author**: [steipete](https://github.com/steipete)
- **Tier**: AUTO-PICK (alive=23)
- **Depends on**: #1340

## Summary

Extracts a shared `createPluginRuntimeStore<T>()` factory into `src/plugin-sdk/runtime-store.ts` and replaces 21 duplicated runtime singleton patterns across all channel extension `runtime.ts` files.

Each extension's `runtime.ts` is reduced from ~16 lines of boilerplate to a 2-line import + `createPluginRuntimeStore()` call.

**Conflict resolution**: All 21 extension `runtime.ts` files had import path conflicts (`openclaw/plugin-sdk` → `remoteclaw/plugin-sdk`). The `src/plugin-sdk/index.ts` conflict was resolved by keeping the fork's restructured exports and adding the new `createPluginRuntimeStore` re-export.

Closes #916 partially.