### PR TITLE
refactor: reuse broadcast route key construction

### DIFF
--- a/src/web/auto-reply/monitor/broadcast.ts
+++ b/src/web/auto-reply/monitor/broadcast.ts
@@ -11,6 +11,35 @@ import { whatsappInboundLog } from "../loggers.js";
 import type { WebInboundMsg } from "../types.js";
 import type { GroupHistoryEntry } from "./process-message.js";
 
+function buildBroadcastRouteKeys(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  msg: WebInboundMsg;
+  route: ReturnType<typeof resolveAgentRoute>;
+  peerId: string;
+  agentId: string;
+}) {
+  const sessionKey = buildAgentSessionKey({
+    agentId: params.agentId,
+    channel: "whatsapp",
+    accountId: params.route.accountId,
+    peer: {
+      kind: params.msg.chatType === "group" ? "group" : "direct",
+      id: params.peerId,
+    },
+    dmScope: params.cfg.session?.dmScope,
+    identityLinks: params.cfg.session?.identityLinks,
+  });
+  const mainSessionKey = buildAgentMainSessionKey({
+    agentId: params.agentId,
+    mainKey: DEFAULT_MAIN_KEY,
+  });
+
+  return {
+    sessionKey,
+    mainSessionKey,
+  };
+}
+
 export async function maybeBroadcastMessage(params: {
   cfg: ReturnType<typeof loadConfig>;
   msg: WebInboundMsg;
@@ -52,24 +81,17 @@ export async function maybeBroadcastMessage(params: {
       whatsappInboundLog.warn(`Broadcast agent ${agentId} not found in agents.list; skipping`);
       return false;
     }
+    const routeKeys = buildBroadcastRouteKeys({
+      cfg: params.cfg,
+      msg: params.msg,
+      route: params.route,
+      peerId: params.peerId,
+      agentId: normalizedAgentId,
+    });
     const agentRoute = {
       ...params.route,
       agentId: normalizedAgentId,
-      sessionKey: buildAgentSessionKey({
-        agentId: normalizedAgentId,
-        channel: "whatsapp",
-        accountId: params.route.accountId,
-        peer: {
-          kind: params.msg.chatType === "group" ? "group" : "direct",
-          id: params.peerId,
-        },
-        dmScope: params.cfg.session?.dmScope,
-        identityLinks: params.cfg.session?.identityLinks,
-      }),
-      mainSessionKey: buildAgentMainSessionKey({
-        agentId: normalizedAgentId,
-        mainKey: DEFAULT_MAIN_KEY,
-      }),
+      ...routeKeys,
     };
 
     try {


### PR DESCRIPTION
Cherry-pick of upstream [`52a253f18`](https://github.com/openclaw/openclaw/commit/52a253f18c93bdad81a892db2508e965b8afd8cc).
Upstream author: [steipete](https://github.com/steipete)
Tier: AUTO-PICK

Extracts the inline `buildAgentSessionKey` and `buildAgentMainSessionKey` calls in `maybeBroadcastMessage` into a `buildBroadcastRouteKeys` helper, replacing the duplicated inline construction with a `...routeKeys` spread.

**Conflict resolution**: The upstream version also includes `lastRoutePolicy` via `deriveLastRoutePolicy` (added upstream after the fork point), which does not exist in our fork. Resolved by applying the upstream's extraction pattern but omitting `lastRoutePolicy` from the helper's return value, matching our fork's existing behavior where `lastRoutePolicy` was never present in broadcast route construction.

Part of remoteclaw/remoteclaw-hq#915