### PR TITLE
Cherry-pick a007bed37: test: isolate plugin loader from mocked module cache

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2,9 +2,27 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { withEnv } from "../test-utils/env.js";
-import { loadRemoteClawPlugins } from "./loader.js";
+async function importFreshPluginTestModules() {
+  vi.resetModules();
+  vi.unmock("./hook-runner-global.js");
+  vi.unmock("./hooks.js");
+  vi.unmock("./loader.js");
+  vi.unmock("jiti");
+  const [loader, hookRunnerGlobal, hooks] = await Promise.all([
+    import("./loader.js"),
+    import("./hook-runner-global.js"),
+    import("./hooks.js"),
+  ]);
+  return {
+    ...loader,
+    ...hookRunnerGlobal,
+    ...hooks,
+  };
+}
+
+const { loadRemoteClawPlugins } = await importFreshPluginTestModules();
 
 type TempPlugin = { dir: string; file: string; id: string };
 


### PR DESCRIPTION
## Upstream Cherry-Pick

| Field | Value |
|-------|-------|
| **Source** | [`a007bed37`](https://github.com/openclaw/openclaw/commit/a007bed37551cf2b6f4cef08ad238c08ade7d9fe) |
| **Author** | [steipete](https://github.com/steipete) (Peter Steinberger) |
| **Tier** | AUTO-PICK (alive=1) |
| **Issue** | #917 |

## Summary

- Introduces `importFreshPluginTestModules()` helper that calls `vi.resetModules()` and dynamically imports loader, hook-runner-global, and hooks modules
- Prevents cross-test module cache pollution in plugin loader tests

## Conflict Resolution

Resolved merge conflict in `src/plugins/loader.test.ts`: upstream replaced static imports + `vi.unmock("jiti")` with dynamic `importFreshPluginTestModules()`. Fork had already rebranded `loadOpenClawPlugins` → `loadRemoteClawPlugins` and removed unused hook-runner/testing symbols. Resolution applies upstream's isolation pattern with fork's rebranded names, destructuring only `loadRemoteClawPlugins`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)