### PR TITLE
Cherry-pick c70151e87: test: isolate legacy plugin-sdk root import check

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -6,6 +6,9 @@ import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { withEnv } from "../test-utils/env.js";
 async function importFreshPluginTestModules() {
   vi.resetModules();
+  vi.unmock("node:fs");
+  vi.unmock("node:fs/promises");
+  vi.unmock("node:module");
   vi.unmock("./hook-runner-global.js");
   vi.unmock("./hooks.js");
   vi.unmock("./loader.js");


### PR DESCRIPTION
## Upstream Cherry-Pick

| Field | Value |
|-------|-------|
| **Source** | [`c70151e87`](https://github.com/openclaw/openclaw/commit/c70151e873aaa4b6549968b80e092bd1872be0af) |
| **Author** | [steipete](https://github.com/steipete) (Peter Steinberger) |
| **Tier** | AUTO-PICK (alive=1) |
| **Issue** | #917 |
| **Depends on** | #1346 |

## Summary

- Adds `node:fs`, `node:fs/promises`, `node:module` unmocks to `importFreshPluginTestModules()` for broader module cache isolation

## Conflict Resolution

Resolved two conflicts in `src/plugins/loader.test.ts`:
1. **Imports**: Fork has `randomUUID` (for temp dir naming), upstream added `execFileSync` and `pathToFileURL` (for subprocess test isolation). Kept fork's `randomUUID`, dropped upstream-only imports (unused in fork's trimmed test suite).
2. **Test body**: Upstream modified tests that the fork intentionally removed (hardlink tests, legacy plugin-sdk tests, `__testing` alias tests — all use functions absent from fork). Kept fork's trimmed test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)