### PR TITLE
Cherry-pick a29b18c00: Protocol: regenerate Swift models for systemRunPlanV2

### DIFF
--- a/apps/macos/Sources/RemoteClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/RemoteClawProtocol/GatewayModels.swift
@@ -2796,6 +2796,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public let id: String?
     public let command: String
     public let commandargv: [String]?
+    public let systemrunplanv2: [String: AnyCodable]?
     public let env: [String: AnyCodable]?
     public let cwd: AnyCodable?
     public let nodeid: AnyCodable?
@@ -2816,6 +2817,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         id: String?,
         command: String,
         commandargv: [String]?,
+        systemrunplanv2: [String: AnyCodable]?,
         env: [String: AnyCodable]?,
         cwd: AnyCodable?,
         nodeid: AnyCodable?,
@@ -2835,6 +2837,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         self.id = id
         self.command = command
         self.commandargv = commandargv
+        self.systemrunplanv2 = systemrunplanv2
         self.env = env
         self.cwd = cwd
         self.nodeid = nodeid
@@ -2856,6 +2859,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         case id
         case command
         case commandargv = "commandArgv"
+        case systemrunplanv2 = "systemRunPlanV2"
         case env
         case cwd
         case nodeid = "nodeId"

--- a/apps/shared/RemoteClawKit/Sources/RemoteClawProtocol/GatewayModels.swift
+++ b/apps/shared/RemoteClawKit/Sources/RemoteClawProtocol/GatewayModels.swift
@@ -2796,6 +2796,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public let id: String?
     public let command: String
     public let commandargv: [String]?
+    public let systemrunplanv2: [String: AnyCodable]?
     public let env: [String: AnyCodable]?
     public let cwd: AnyCodable?
     public let nodeid: AnyCodable?
@@ -2816,6 +2817,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         id: String?,
         command: String,
         commandargv: [String]?,
+        systemrunplanv2: [String: AnyCodable]?,
         env: [String: AnyCodable]?,
         cwd: AnyCodable?,
         nodeid: AnyCodable?,
@@ -2835,6 +2837,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         self.id = id
         self.command = command
         self.commandargv = commandargv
+        self.systemrunplanv2 = systemrunplanv2
         self.env = env
         self.cwd = cwd
         self.nodeid = nodeid
@@ -2856,6 +2859,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         case id
         case command
         case commandargv = "commandArgv"
+        case systemrunplanv2 = "systemRunPlanV2"
         case env
         case cwd
         case nodeid = "nodeId"


### PR DESCRIPTION
## Cherry-pick from upstream

- **Upstream commit**: [`a29b18c00`](https://github.com/openclaw/openclaw/commit/a29b18c0031991587d29bffc9da1e61794cbb536)
- **Author**: Philipp Spiess
- **Tier**: PICK (needs rebrand)

Adds `systemRunPlanV2` model to the regenerated Swift protocol models in both macOS and shared kit.

Paths auto-resolved to rebranded locations (`RemoteClawProtocol/`, `RemoteClawKit/`).

Closes #667 — commit 1 of 3.