### PR TITLE
Cherry-pick 7bbfb9de5: fix(update): fallback to --omit=optional when global npm update fails

### DIFF
--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -14,7 +14,7 @@ function makeResult(
     steps: [
       {
         name: stepName,
-        command: "npm i -g remoteclaw@latest",
+        command: "npm i -g remoteclaw@next",
         cwd: "/tmp",
         durationMs: 1,
         exitCode: 1,

--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { UpdateRunResult } from "../../infra/update-runner.js";
+import { inferUpdateFailureHints } from "./progress.js";
+
+function makeResult(
+  stepName: string,
+  stderrTail: string,
+  mode: UpdateRunResult["mode"] = "npm",
+): UpdateRunResult {
+  return {
+    status: "error",
+    mode,
+    reason: stepName,
+    steps: [
+      {
+        name: stepName,
+        command: "npm i -g remoteclaw@latest",
+        cwd: "/tmp",
+        durationMs: 1,
+        exitCode: 1,
+        stderrTail,
+      },
+    ],
+    durationMs: 1,
+  };
+}
+
+describe("inferUpdateFailureHints", () => {
+  it("returns EACCES hint for global update permission failures", () => {
+    const result = makeResult(
+      "global update",
+      "npm ERR! code EACCES\nnpm ERR! Error: EACCES: permission denied",
+    );
+    const hints = inferUpdateFailureHints(result);
+    expect(hints.join("\n")).toContain("EACCES");
+    expect(hints.join("\n")).toContain("npm config set prefix ~/.local");
+  });
+
+  it("returns native optional dependency hint for node-gyp/opus failures", () => {
+    const result = makeResult(
+      "global update",
+      "node-pre-gyp ERR!\n@discordjs/opus\nnode-gyp rebuild failed",
+    );
+    const hints = inferUpdateFailureHints(result);
+    expect(hints.join("\n")).toContain("--omit=optional");
+  });
+
+  it("does not return npm hints for non-npm install modes", () => {
+    const result = makeResult(
+      "global update",
+      "npm ERR! code EACCES\nnpm ERR! Error: EACCES: permission denied",
+      "pnpm",
+    );
+    expect(inferUpdateFailureHints(result)).toEqual([]);
+  });
+});

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -28,11 +28,46 @@ const STEP_LABELS: Record<string, string> = {
   "remoteclaw doctor": "Running doctor checks",
   "git rev-parse HEAD (after)": "Verifying update",
   "global update": "Updating via package manager",
+  "global update (omit optional)": "Retrying update without optional deps",
   "global install": "Installing global package",
 };
 
 function getStepLabel(step: UpdateStepInfo): string {
   return STEP_LABELS[step.name] ?? step.name;
+}
+
+export function inferUpdateFailureHints(result: UpdateRunResult): string[] {
+  if (result.status !== "error" || result.mode !== "npm") {
+    return [];
+  }
+  const failedStep = [...result.steps].toReversed().find((step) => step.exitCode !== 0);
+  if (!failedStep) {
+    return [];
+  }
+
+  const stderr = (failedStep.stderrTail ?? "").toLowerCase();
+  const hints: string[] = [];
+
+  if (failedStep.name.startsWith("global update") && stderr.includes("eacces")) {
+    hints.push(
+      "Detected permission failure (EACCES). Re-run with a writable global prefix or sudo (for system-managed Node installs).",
+    );
+    hints.push("Example: npm config set prefix ~/.local && npm i -g remoteclaw@latest");
+  }
+
+  if (
+    failedStep.name.startsWith("global update") &&
+    (stderr.includes("node-gyp") ||
+      stderr.includes("@discordjs/opus") ||
+      stderr.includes("prebuild"))
+  ) {
+    hints.push(
+      "Detected native optional dependency build failure (e.g. opus). The updater retries with --omit=optional automatically.",
+    );
+    hints.push("If it still fails: npm i -g remoteclaw@latest --omit=optional");
+  }
+
+  return hints;
 }
 
 export type ProgressController = {
@@ -146,6 +181,15 @@ export function printResult(result: UpdateRunResult, opts: PrintResultOptions): 
           }
         }
       }
+    }
+  }
+
+  const hints = inferUpdateFailureHints(result);
+  if (hints.length > 0) {
+    defaultRuntime.log("");
+    defaultRuntime.log(theme.heading("Recovery hints:"));
+    for (const hint of hints) {
+      defaultRuntime.log(`  - ${theme.warn(hint)}`);
     }
   }
 

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -14,6 +14,10 @@ const PRIMARY_PACKAGE_NAME = "remoteclaw";
 const ALL_PACKAGE_NAMES = [PRIMARY_PACKAGE_NAME] as const;
 const GLOBAL_RENAME_PREFIX = ".";
 const NPM_GLOBAL_INSTALL_QUIET_FLAGS = ["--no-fund", "--no-audit", "--loglevel=error"] as const;
+const NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS = [
+  "--omit=optional",
+  ...NPM_GLOBAL_INSTALL_QUIET_FLAGS,
+] as const;
 
 async function tryRealpath(targetPath: string): Promise<string> {
   try {
@@ -137,6 +141,16 @@ export function globalInstallArgs(manager: GlobalInstallManager, spec: string): 
     return ["bun", "add", "-g", spec];
   }
   return ["npm", "i", "-g", spec, ...NPM_GLOBAL_INSTALL_QUIET_FLAGS];
+}
+
+export function globalInstallFallbackArgs(
+  manager: GlobalInstallManager,
+  spec: string,
+): string[] | null {
+  if (manager !== "npm") {
+    return null;
+  }
+  return ["npm", "i", "-g", spec, ...NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS];
 }
 
 export async function cleanupGlobalRenameDirs(params: {

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -236,12 +236,12 @@ describe("runGatewayUpdate", () => {
       if (key === "pnpm root -g") {
         return { stdout: "", stderr: "", code: 1 };
       }
-      if (key === "npm i -g remoteclaw@latest --no-fund --no-audit --loglevel=error") {
+      if (key === "npm i -g remoteclaw@next --no-fund --no-audit --loglevel=error") {
         firstAttempt = false;
         return { stdout: "", stderr: "node-gyp failed", code: 1 };
       }
       if (
-        key === "npm i -g remoteclaw@latest --omit=optional --no-fund --no-audit --loglevel=error"
+        key === "npm i -g remoteclaw@next --omit=optional --no-fund --no-audit --loglevel=error"
       ) {
         await fs.writeFile(
           path.join(pkgRoot, "package.json"),

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -219,6 +219,51 @@ describe("runGatewayUpdate", () => {
     expect(await pathExists(staleDir)).toBe(false);
   });
 
+  it("retries global npm update with --omit=optional when initial install fails", async () => {
+    const nodeModules = path.join(tempDir, "node_modules");
+    const pkgRoot = path.join(nodeModules, "remoteclaw");
+    await seedGlobalPackageRoot(pkgRoot);
+
+    let firstAttempt = true;
+    const runCommand = async (argv: string[]) => {
+      const key = argv.join(" ");
+      if (key === `git -C ${pkgRoot} rev-parse --show-toplevel`) {
+        return { stdout: "", stderr: "not a git repository", code: 128 };
+      }
+      if (key === "npm root -g") {
+        return { stdout: nodeModules, stderr: "", code: 0 };
+      }
+      if (key === "pnpm root -g") {
+        return { stdout: "", stderr: "", code: 1 };
+      }
+      if (key === "npm i -g remoteclaw@latest --no-fund --no-audit --loglevel=error") {
+        firstAttempt = false;
+        return { stdout: "", stderr: "node-gyp failed", code: 1 };
+      }
+      if (
+        key === "npm i -g remoteclaw@latest --omit=optional --no-fund --no-audit --loglevel=error"
+      ) {
+        await fs.writeFile(
+          path.join(pkgRoot, "package.json"),
+          JSON.stringify({ name: "remoteclaw", version: "2.0.0" }),
+          "utf-8",
+        );
+        return { stdout: "ok", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const result = await runWithCommand(runCommand, { cwd: pkgRoot });
+
+    expect(firstAttempt).toBe(false);
+    expect(result.status).toBe("ok");
+    expect(result.mode).toBe("npm");
+    expect(result.steps.map((s) => s.name)).toEqual([
+      "global update",
+      "global update (omit optional)",
+    ]);
+  });
+
   it("updates global bun installs when detected", async () => {
     const bunInstall = path.join(tempDir, "bun-install");
     await withEnvAsync({ BUN_INSTALL: bunInstall }, async () => {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -7,6 +7,7 @@ import {
   cleanupGlobalRenameDirs,
   detectGlobalInstallManagerForRoot,
   globalInstallArgs,
+  globalInstallFallbackArgs,
 } from "./update-global.js";
 
 export type UpdateStepResult = {
@@ -198,12 +199,53 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       stderrTail,
     };
     const steps = [updateStep];
+
+    let finalStep = updateStep;
+    if (updateStep.exitCode !== 0) {
+      const fallbackArgv = globalInstallFallbackArgs(globalManager, spec);
+      if (fallbackArgv) {
+        const fbCommand = fallbackArgv.join(" ");
+        const fbStepInfo: UpdateStepInfo = {
+          name: "global update (omit optional)",
+          command: fbCommand,
+          index: 0,
+          total: 1,
+        };
+        progress?.onStepStart?.(fbStepInfo);
+        const fbStarted = Date.now();
+        const fbResult = await runCommand(fallbackArgv, {
+          cwd: pkgRoot,
+          timeoutMs,
+        });
+        const fbDurationMs = Date.now() - fbStarted;
+        const fbStderrTail = trimLogTail(fbResult.stderr, MAX_LOG_CHARS);
+        progress?.onStepComplete?.({
+          ...fbStepInfo,
+          durationMs: fbDurationMs,
+          exitCode: fbResult.code,
+          stderrTail: fbStderrTail,
+        });
+
+        const fallbackStep: UpdateStepResult = {
+          name: "global update (omit optional)",
+          command: fbCommand,
+          cwd: pkgRoot,
+          durationMs: fbDurationMs,
+          exitCode: fbResult.code,
+          stdoutTail: trimLogTail(fbResult.stdout, MAX_LOG_CHARS),
+          stderrTail: fbStderrTail,
+        };
+        steps.push(fallbackStep);
+        finalStep = fallbackStep;
+      }
+    }
+
     const afterVersion = await readPackageVersion(pkgRoot);
     return {
-      status: updateStep.exitCode === 0 ? "ok" : "error",
+      status: finalStep.exitCode === 0 ? "ok" : "error",
       mode: globalManager,
       root: pkgRoot,
-      reason: updateStep.exitCode === 0 ? undefined : updateStep.name,
+      reason: finalStep.exitCode === 0 ? undefined : finalStep.name,
       before: { version: beforeVersion },
       after: { version: afterVersion },
       steps,


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [`7bbfb9de5`](https://github.com/openclaw/openclaw/commit/7bbfb9de5)
**Author**: [Xinhua Gu](https://github.com/xgu)
**Tier**: PICK (needs rebrand)
**Issue**: #668

## Summary

- Adds `--omit=optional` retry when `npm i -g` fails during CLI self-update (e.g. `@discordjs/opus` native build failure)
- Adds `globalInstallFallbackArgs()` to `update-global.ts`
- Adds `inferUpdateFailureHints()` for user-facing EACCES and native-dep failure messages
- New test coverage for fallback retry and hint inference

## Adaptation

- Conflict in `src/infra/update-runner.ts`: fork uses inline progress callbacks instead of upstream's `runStep` helper. Resolved by inlining the fallback step execution with the fork's progress callback pattern.
- Rebranded `openclaw` → `remoteclaw` in hint messages (`progress.ts`), test fixtures (`progress.test.ts`, `update-runner.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)