### PR TITLE
Cherry-pick cb917b7f0: chore: silence onboard warning noise

### DIFF
--- a/scripts/e2e/onboard-docker.sh
+++ b/scripts/e2e/onboard-docker.sh
@@ -406,6 +406,7 @@ NODE
     # Seed a remote config to exercise reset path.
 	    cat > "$HOME/.remoteclaw/remoteclaw.json" <<'"'"'JSON'"'"'
 {
+  "meta": {},
   "agents": { "defaults": { "workspace": "/root/old" } },
   "gateway": {
     "mode": "remote",
@@ -501,6 +502,7 @@ NODE
     # Seed skills config to ensure it survives the wizard.
 	    cat > "$HOME/.remoteclaw/remoteclaw.json" <<'"'"'JSON'"'"'
 {
+  "meta": {},
   "skills": {
     "allowBundled": ["__none__"],
     "install": { "nodeManager": "bun" }

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -31,6 +31,8 @@ export default defineConfig(() => {
       outDir: path.resolve(here, "../dist/control-ui"),
       emptyOutDir: true,
       sourcemap: true,
+      // Keep CI/onboard logs clean; current control UI chunking is intentionally above 500 kB.
+      chunkSizeWarningLimit: 1024,
     },
     server: {
       host: true,


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [`cb917b7f0`](https://github.com/openclaw/openclaw/commit/cb917b7f0)
**Author**: [steipete](https://github.com/steipete)
**Tier**: PICK (needs rebrand)
**Issue**: #668
**Depends on**: #1352

## Summary

- Adds `"meta": {}` to onboard e2e seed JSON to prevent warning noise
- Raises vite `chunkSizeWarningLimit` to 1024

## Adaptation

Clean cherry-pick — no rebrand needed. The e2e script paths were already rebranded in the fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)