### PR TITLE
Cherry-pick f5adb66bb: fix npm link for CLI permission denied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV REMOTECLAW_PREFER_PNPM=1
 RUN pnpm ui:build
+RUN npm link
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
## Upstream Cherry-Pick

- **Commit**: [`f5adb66bb`](https://github.com/openclaw/openclaw/commit/f5adb66bb)
- **Subject**: fix: add npm link to fix CLI permission denied (exit 127) (#17151)
- **Author**: Yutaka Sasaki
- **Tier**: AUTO-PICK

Adds `npm link` after build to fix CLI permission denied (exit 127) errors in Docker containers.

Part of #669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)