### PR TITLE
Cherry-pick 22ad7523f: Docker CLI symlink instead of npm link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,11 @@ RUN pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV REMOTECLAW_PREFER_PNPM=1
 RUN pnpm ui:build
-RUN npm link
+
+# Expose the CLI binary without requiring npm global writes as non-root.
+USER root
+RUN ln -sf /app/remoteclaw.mjs /usr/local/bin/remoteclaw \
+ && chmod 755 /app/remoteclaw.mjs
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
## Upstream Cherry-Pick

- **Commit**: [`22ad7523f`](https://github.com/openclaw/openclaw/commit/22ad7523f)
- **Subject**: Docker: replace npm link with root CLI symlink (#28312)
- **Author**: Vincent Koc
- **Tier**: AUTO-PICK

Replaces `npm link` (from previous cherry-pick) with a cleaner root symlink approach. Switches to root user to create symlink, avoids npm global write permission issues.

**Rebrand applied**: `openclaw.mjs` → `remoteclaw.mjs`, `/usr/local/bin/openclaw` → `/usr/local/bin/remoteclaw`.

Depends on #1354.
Part of #669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)