### PR TITLE
Cherry-pick 3a3503551: fix(android): send object params for canvas capability refresh

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/gateway/GatewaySession.kt
@@ -177,7 +177,11 @@ class GatewaySession(
     val conn = currentConnection ?: return false
     val response =
       try {
-        conn.request("node.canvas.capability.refresh", params = null, timeoutMs = timeoutMs)
+        conn.request(
+          "node.canvas.capability.refresh",
+          params = buildJsonObject {},
+          timeoutMs = timeoutMs,
+        )
       } catch (err: Throwable) {
         Log.w("OpenClawGateway", "node.canvas.capability.refresh failed: ${err.message ?: err::class.java.simpleName}")
         return false


### PR DESCRIPTION
Cherry-pick of upstream commit [`3a3503551`](https://github.com/openclaw/openclaw/commit/3a3503551).

**Author:** Ayaan Zaidi
**Tier:** FAST (clean pick)

Fixes canvas capability refresh to send object params instead of primitives.

Part of #673.