### PR TITLE
Cherry-pick 3f06693e7: refactor(android): share node capability and command manifest

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/ConnectionManager.kt
@@ -7,7 +7,6 @@ import org.remoteclaw.android.gateway.GatewayClientInfo
 import org.remoteclaw.android.gateway.GatewayConnectOptions
 import org.remoteclaw.android.gateway.GatewayEndpoint
 import org.remoteclaw.android.gateway.GatewayTlsParams
-import org.remoteclaw.android.protocol.RemoteClawCapability
 import org.remoteclaw.android.LocationMode
 import org.remoteclaw.android.VoiceWakeMode
 
@@ -73,27 +72,18 @@ class ConnectionManager(
     }
   }
 
-  fun buildInvokeCommands(): List<String> =
-    InvokeCommandRegistry.advertisedCommands(
+  private fun runtimeFlags(): NodeRuntimeFlags =
+    NodeRuntimeFlags(
       cameraEnabled = cameraEnabled(),
       locationEnabled = locationMode() != LocationMode.Off,
       smsAvailable = smsAvailable(),
+      voiceWakeEnabled = voiceWakeMode() != VoiceWakeMode.Off && hasRecordAudioPermission(),
       debugBuild = BuildConfig.DEBUG,
     )
 
-  fun buildCapabilities(): List<String> =
-    buildList {
-      add(RemoteClawCapability.Canvas.rawValue)
-      add(RemoteClawCapability.Screen.rawValue)
-      if (cameraEnabled()) add(RemoteClawCapability.Camera.rawValue)
-      if (smsAvailable()) add(RemoteClawCapability.Sms.rawValue)
-      if (voiceWakeMode() != VoiceWakeMode.Off && hasRecordAudioPermission()) {
-        add(RemoteClawCapability.VoiceWake.rawValue)
-      }
-      if (locationMode() != LocationMode.Off) {
-        add(RemoteClawCapability.Location.rawValue)
-      }
-    }
+  fun buildInvokeCommands(): List<String> = InvokeCommandRegistry.advertisedCommands(runtimeFlags())
+
+  fun buildCapabilities(): List<String> = InvokeCommandRegistry.advertisedCapabilities(runtimeFlags())
 
   fun resolvedVersionName(): String {
     val versionName = BuildConfig.VERSION_NAME.trim().ifEmpty { "dev" }

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeCommandRegistry.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeCommandRegistry.kt
@@ -3,11 +3,20 @@ package org.remoteclaw.android.node
 import org.remoteclaw.android.protocol.RemoteClawCanvasA2UICommand
 import org.remoteclaw.android.protocol.RemoteClawCanvasCommand
 import org.remoteclaw.android.protocol.RemoteClawCameraCommand
+import org.remoteclaw.android.protocol.RemoteClawCapability
 import org.remoteclaw.android.protocol.RemoteClawDeviceCommand
 import org.remoteclaw.android.protocol.RemoteClawLocationCommand
 import org.remoteclaw.android.protocol.RemoteClawNotificationsCommand
 import org.remoteclaw.android.protocol.RemoteClawScreenCommand
 import org.remoteclaw.android.protocol.RemoteClawSmsCommand
+
+data class NodeRuntimeFlags(
+  val cameraEnabled: Boolean,
+  val locationEnabled: Boolean,
+  val smsAvailable: Boolean,
+  val voiceWakeEnabled: Boolean,
+  val debugBuild: Boolean,
+)
 
 enum class InvokeCommandAvailability {
   Always,
@@ -17,6 +26,19 @@ enum class InvokeCommandAvailability {
   DebugBuild,
 }
 
+enum class NodeCapabilityAvailability {
+  Always,
+  CameraEnabled,
+  LocationEnabled,
+  SmsAvailable,
+  VoiceWakeEnabled,
+}
+
+data class NodeCapabilitySpec(
+  val name: String,
+  val availability: NodeCapabilityAvailability = NodeCapabilityAvailability.Always,
+)
+
 data class InvokeCommandSpec(
   val name: String,
   val requiresForeground: Boolean = false,
@@ -24,6 +46,29 @@ data class InvokeCommandSpec(
 )
 
 object InvokeCommandRegistry {
+  val capabilityManifest: List<NodeCapabilitySpec> =
+    listOf(
+      NodeCapabilitySpec(name = RemoteClawCapability.Canvas.rawValue),
+      NodeCapabilitySpec(name = RemoteClawCapability.Screen.rawValue),
+      NodeCapabilitySpec(name = RemoteClawCapability.Device.rawValue),
+      NodeCapabilitySpec(
+        name = RemoteClawCapability.Camera.rawValue,
+        availability = NodeCapabilityAvailability.CameraEnabled,
+      ),
+      NodeCapabilitySpec(
+        name = RemoteClawCapability.Sms.rawValue,
+        availability = NodeCapabilityAvailability.SmsAvailable,
+      ),
+      NodeCapabilitySpec(
+        name = RemoteClawCapability.VoiceWake.rawValue,
+        availability = NodeCapabilityAvailability.VoiceWakeEnabled,
+      ),
+      NodeCapabilitySpec(
+        name = RemoteClawCapability.Location.rawValue,
+        availability = NodeCapabilityAvailability.LocationEnabled,
+      ),
+    )
+
   val all: List<InvokeCommandSpec> =
     listOf(
       InvokeCommandSpec(
@@ -112,20 +157,29 @@ object InvokeCommandRegistry {
 
   fun find(command: String): InvokeCommandSpec? = byNameInternal[command]
 
-  fun advertisedCommands(
-    cameraEnabled: Boolean,
-    locationEnabled: Boolean,
-    smsAvailable: Boolean,
-    debugBuild: Boolean,
-  ): List<String> {
+  fun advertisedCapabilities(flags: NodeRuntimeFlags): List<String> {
+    return capabilityManifest
+      .filter { spec ->
+        when (spec.availability) {
+          NodeCapabilityAvailability.Always -> true
+          NodeCapabilityAvailability.CameraEnabled -> flags.cameraEnabled
+          NodeCapabilityAvailability.LocationEnabled -> flags.locationEnabled
+          NodeCapabilityAvailability.SmsAvailable -> flags.smsAvailable
+          NodeCapabilityAvailability.VoiceWakeEnabled -> flags.voiceWakeEnabled
+        }
+      }
+      .map { it.name }
+  }
+
+  fun advertisedCommands(flags: NodeRuntimeFlags): List<String> {
     return all
       .filter { spec ->
         when (spec.availability) {
           InvokeCommandAvailability.Always -> true
-          InvokeCommandAvailability.CameraEnabled -> cameraEnabled
-          InvokeCommandAvailability.LocationEnabled -> locationEnabled
-          InvokeCommandAvailability.SmsAvailable -> smsAvailable
-          InvokeCommandAvailability.DebugBuild -> debugBuild
+          InvokeCommandAvailability.CameraEnabled -> flags.cameraEnabled
+          InvokeCommandAvailability.LocationEnabled -> flags.locationEnabled
+          InvokeCommandAvailability.SmsAvailable -> flags.smsAvailable
+          InvokeCommandAvailability.DebugBuild -> flags.debugBuild
         }
       }
       .map { it.name }

--- a/apps/android/app/src/test/java/org/remoteclaw/android/node/InvokeCommandRegistryTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/node/InvokeCommandRegistryTest.kt
@@ -1,6 +1,7 @@
 package org.remoteclaw.android.node
 
 import org.remoteclaw.android.protocol.RemoteClawCameraCommand
+import org.remoteclaw.android.protocol.RemoteClawCapability
 import org.remoteclaw.android.protocol.RemoteClawDeviceCommand
 import org.remoteclaw.android.protocol.RemoteClawLocationCommand
 import org.remoteclaw.android.protocol.RemoteClawNotificationsCommand
@@ -11,13 +12,60 @@ import org.junit.Test
 
 class InvokeCommandRegistryTest {
   @Test
+  fun advertisedCapabilities_respectsFeatureAvailability() {
+    val capabilities =
+      InvokeCommandRegistry.advertisedCapabilities(
+        NodeRuntimeFlags(
+          cameraEnabled = false,
+          locationEnabled = false,
+          smsAvailable = false,
+          voiceWakeEnabled = false,
+          debugBuild = false,
+        ),
+      )
+
+    assertTrue(capabilities.contains(RemoteClawCapability.Canvas.rawValue))
+    assertTrue(capabilities.contains(RemoteClawCapability.Screen.rawValue))
+    assertTrue(capabilities.contains(RemoteClawCapability.Device.rawValue))
+    assertFalse(capabilities.contains(RemoteClawCapability.Camera.rawValue))
+    assertFalse(capabilities.contains(RemoteClawCapability.Location.rawValue))
+    assertFalse(capabilities.contains(RemoteClawCapability.Sms.rawValue))
+    assertFalse(capabilities.contains(RemoteClawCapability.VoiceWake.rawValue))
+  }
+
+  @Test
+  fun advertisedCapabilities_includesFeatureCapabilitiesWhenEnabled() {
+    val capabilities =
+      InvokeCommandRegistry.advertisedCapabilities(
+        NodeRuntimeFlags(
+          cameraEnabled = true,
+          locationEnabled = true,
+          smsAvailable = true,
+          voiceWakeEnabled = true,
+          debugBuild = false,
+        ),
+      )
+
+    assertTrue(capabilities.contains(RemoteClawCapability.Canvas.rawValue))
+    assertTrue(capabilities.contains(RemoteClawCapability.Screen.rawValue))
+    assertTrue(capabilities.contains(RemoteClawCapability.Device.rawValue))
+    assertTrue(capabilities.contains(RemoteClawCapability.Camera.rawValue))
+    assertTrue(capabilities.contains(RemoteClawCapability.Location.rawValue))
+    assertTrue(capabilities.contains(RemoteClawCapability.Sms.rawValue))
+    assertTrue(capabilities.contains(RemoteClawCapability.VoiceWake.rawValue))
+  }
+
+  @Test
   fun advertisedCommands_respectsFeatureAvailability() {
     val commands =
       InvokeCommandRegistry.advertisedCommands(
-        cameraEnabled = false,
-        locationEnabled = false,
-        smsAvailable = false,
-        debugBuild = false,
+        NodeRuntimeFlags(
+          cameraEnabled = false,
+          locationEnabled = false,
+          smsAvailable = false,
+          voiceWakeEnabled = false,
+          debugBuild = false,
+        ),
       )
 
     assertFalse(commands.contains(RemoteClawCameraCommand.Snap.rawValue))
@@ -38,10 +86,13 @@ class InvokeCommandRegistryTest {
   fun advertisedCommands_includesFeatureCommandsWhenEnabled() {
     val commands =
       InvokeCommandRegistry.advertisedCommands(
-        cameraEnabled = true,
-        locationEnabled = true,
-        smsAvailable = true,
-        debugBuild = true,
+        NodeRuntimeFlags(
+          cameraEnabled = true,
+          locationEnabled = true,
+          smsAvailable = true,
+          voiceWakeEnabled = false,
+          debugBuild = true,
+        ),
       )
 
     assertTrue(commands.contains(RemoteClawCameraCommand.Snap.rawValue))


### PR DESCRIPTION
Cherry-pick of upstream commit [`3f06693e7`](https://github.com/openclaw/openclaw/commit/3f06693e7).

**Author:** Ayaan Zaidi
**Tier:** RESOLVED (rebrand conflicts in imports + capability manifest)

Refactors node capability and command manifest into shared `InvokeCommandRegistry`, adding `advertisedCapabilities()` alongside existing `advertisedCommands()`.

Depends on #1356.
Part of #673.