### PR TITLE
Cherry-pick 18e7938: refactor(android): remove unreachable motion classify branch

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/MotionHandler.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/MotionHandler.kt
@@ -217,8 +217,7 @@ private object SystemMotionDataSource : MotionDataSource {
     return when {
       averageDelta <= 0.55 -> "stationary"
       averageDelta <= 1.80 -> "walking"
-      averageDelta > 1.80 -> "running"
-      else -> "unknown"
+      else -> "running"
     }
   }
 


### PR DESCRIPTION
Cherry-pick of upstream [`18e7938df`](https://github.com/openclaw/openclaw/commit/18e7938df).

**Author:** Ayaan Zaidi
**Tier:** android-cleanup (refactor)

Removes an unreachable branch in the motion activity classifier — the `else` case for a boolean condition that was already exhaustively covered by the `if`/`else if` arms.

Depends on #1362
Part of #673

Co-authored-by: Ayaan Zaidi <zaidi@uplause.io>