### PR TITLE
Cherry-pick 1bc9da8: fix(android): stabilize motion sampling and gate pedometer command

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
@@ -104,6 +104,8 @@ class NodeRuntime(context: Context) {
     cameraEnabled = { cameraEnabled.value },
     locationMode = { locationMode.value },
     voiceWakeMode = { VoiceWakeMode.Off },
+    motionActivityAvailable = { motionHandler.isActivityAvailable() },
+    motionPedometerAvailable = { motionHandler.isPedometerAvailable() },
     smsAvailable = { sms.canSendSms() },
     hasRecordAudioPermission = { hasRecordAudioPermission() },
     manualTls = { manualTls.value },
@@ -131,6 +133,8 @@ class NodeRuntime(context: Context) {
       _canvasRehydrateErrorText.value = null
     },
     onCanvasA2uiReset = { _canvasA2uiHydrated.value = false },
+    motionActivityAvailable = { motionHandler.isActivityAvailable() },
+    motionPedometerAvailable = { motionHandler.isPedometerAvailable() },
   )
 
   data class GatewayTrustPrompt(

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/ConnectionManager.kt
@@ -15,6 +15,8 @@ class ConnectionManager(
   private val cameraEnabled: () -> Boolean,
   private val locationMode: () -> LocationMode,
   private val voiceWakeMode: () -> VoiceWakeMode,
+  private val motionActivityAvailable: () -> Boolean,
+  private val motionPedometerAvailable: () -> Boolean,
   private val smsAvailable: () -> Boolean,
   private val hasRecordAudioPermission: () -> Boolean,
   private val manualTls: () -> Boolean,
@@ -78,6 +80,8 @@ class ConnectionManager(
       locationEnabled = locationMode() != LocationMode.Off,
       smsAvailable = smsAvailable(),
       voiceWakeEnabled = voiceWakeMode() != VoiceWakeMode.Off && hasRecordAudioPermission(),
+      motionActivityAvailable = motionActivityAvailable(),
+      motionPedometerAvailable = motionPedometerAvailable(),
       debugBuild = BuildConfig.DEBUG,
     )
 

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeCommandRegistry.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeCommandRegistry.kt
@@ -1,20 +1,27 @@
 package org.remoteclaw.android.node
 
+import org.remoteclaw.android.protocol.RemoteClawCalendarCommand
 import org.remoteclaw.android.protocol.RemoteClawCanvasA2UICommand
 import org.remoteclaw.android.protocol.RemoteClawCanvasCommand
 import org.remoteclaw.android.protocol.RemoteClawCameraCommand
 import org.remoteclaw.android.protocol.RemoteClawCapability
+import org.remoteclaw.android.protocol.RemoteClawContactsCommand
 import org.remoteclaw.android.protocol.RemoteClawDeviceCommand
 import org.remoteclaw.android.protocol.RemoteClawLocationCommand
+import org.remoteclaw.android.protocol.RemoteClawMotionCommand
 import org.remoteclaw.android.protocol.RemoteClawNotificationsCommand
+import org.remoteclaw.android.protocol.RemoteClawPhotosCommand
 import org.remoteclaw.android.protocol.RemoteClawScreenCommand
 import org.remoteclaw.android.protocol.RemoteClawSmsCommand
+import org.remoteclaw.android.protocol.RemoteClawSystemCommand
 
 data class NodeRuntimeFlags(
   val cameraEnabled: Boolean,
   val locationEnabled: Boolean,
   val smsAvailable: Boolean,
   val voiceWakeEnabled: Boolean,
+  val motionActivityAvailable: Boolean,
+  val motionPedometerAvailable: Boolean,
   val debugBuild: Boolean,
 )
 
@@ -23,6 +30,8 @@ enum class InvokeCommandAvailability {
   CameraEnabled,
   LocationEnabled,
   SmsAvailable,
+  MotionActivityAvailable,
+  MotionPedometerAvailable,
   DebugBuild,
 }
 
@@ -32,6 +41,7 @@ enum class NodeCapabilityAvailability {
   LocationEnabled,
   SmsAvailable,
   VoiceWakeEnabled,
+  MotionAvailable,
 }
 
 data class NodeCapabilitySpec(
@@ -66,6 +76,13 @@ object InvokeCommandRegistry {
       NodeCapabilitySpec(
         name = RemoteClawCapability.Location.rawValue,
         availability = NodeCapabilityAvailability.LocationEnabled,
+      ),
+      NodeCapabilitySpec(name = RemoteClawCapability.Photos.rawValue),
+      NodeCapabilitySpec(name = RemoteClawCapability.Contacts.rawValue),
+      NodeCapabilitySpec(name = RemoteClawCapability.Calendar.rawValue),
+      NodeCapabilitySpec(
+        name = RemoteClawCapability.Motion.rawValue,
+        availability = NodeCapabilityAvailability.MotionAvailable,
       ),
     )
 
@@ -108,6 +125,9 @@ object InvokeCommandRegistry {
         requiresForeground = true,
       ),
       InvokeCommandSpec(
+        name = RemoteClawSystemCommand.Notify.rawValue,
+      ),
+      InvokeCommandSpec(
         name = RemoteClawCameraCommand.List.rawValue,
         requiresForeground = true,
         availability = InvokeCommandAvailability.CameraEnabled,
@@ -127,6 +147,12 @@ object InvokeCommandRegistry {
         availability = InvokeCommandAvailability.LocationEnabled,
       ),
       InvokeCommandSpec(
+        name = RemoteClawDeviceCommand.Status.rawValue,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawDeviceCommand.Info.rawValue,
+      ),
+      InvokeCommandSpec(
         name = RemoteClawDeviceCommand.Permissions.rawValue,
       ),
       InvokeCommandSpec(
@@ -137,6 +163,29 @@ object InvokeCommandRegistry {
       ),
       InvokeCommandSpec(
         name = RemoteClawNotificationsCommand.Actions.rawValue,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawPhotosCommand.Latest.rawValue,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawContactsCommand.Search.rawValue,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawContactsCommand.Add.rawValue,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawCalendarCommand.Events.rawValue,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawCalendarCommand.Add.rawValue,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawMotionCommand.Activity.rawValue,
+        availability = InvokeCommandAvailability.MotionActivityAvailable,
+      ),
+      InvokeCommandSpec(
+        name = RemoteClawMotionCommand.Pedometer.rawValue,
+        availability = InvokeCommandAvailability.MotionPedometerAvailable,
       ),
       InvokeCommandSpec(
         name = RemoteClawSmsCommand.Send.rawValue,
@@ -166,6 +215,7 @@ object InvokeCommandRegistry {
           NodeCapabilityAvailability.LocationEnabled -> flags.locationEnabled
           NodeCapabilityAvailability.SmsAvailable -> flags.smsAvailable
           NodeCapabilityAvailability.VoiceWakeEnabled -> flags.voiceWakeEnabled
+          NodeCapabilityAvailability.MotionAvailable -> flags.motionActivityAvailable || flags.motionPedometerAvailable
         }
       }
       .map { it.name }
@@ -179,6 +229,8 @@ object InvokeCommandRegistry {
           InvokeCommandAvailability.CameraEnabled -> flags.cameraEnabled
           InvokeCommandAvailability.LocationEnabled -> flags.locationEnabled
           InvokeCommandAvailability.SmsAvailable -> flags.smsAvailable
+          InvokeCommandAvailability.MotionActivityAvailable -> flags.motionActivityAvailable
+          InvokeCommandAvailability.MotionPedometerAvailable -> flags.motionPedometerAvailable
           InvokeCommandAvailability.DebugBuild -> flags.debugBuild
         }
       }

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeDispatcher.kt
@@ -1,23 +1,36 @@
 package org.remoteclaw.android.node
 
 import org.remoteclaw.android.gateway.GatewaySession
+import org.remoteclaw.android.protocol.RemoteClawCalendarCommand
 import org.remoteclaw.android.protocol.RemoteClawCanvasA2UICommand
 import org.remoteclaw.android.protocol.RemoteClawCanvasCommand
 import org.remoteclaw.android.protocol.RemoteClawCameraCommand
+import org.remoteclaw.android.protocol.RemoteClawContactsCommand
+import org.remoteclaw.android.protocol.RemoteClawDeviceCommand
 import org.remoteclaw.android.protocol.RemoteClawLocationCommand
+import org.remoteclaw.android.protocol.RemoteClawMotionCommand
 import org.remoteclaw.android.protocol.RemoteClawNotificationsCommand
+import org.remoteclaw.android.protocol.RemoteClawPhotosCommand
+import org.remoteclaw.android.protocol.RemoteClawScreenCommand
 import org.remoteclaw.android.protocol.RemoteClawSmsCommand
+import org.remoteclaw.android.protocol.RemoteClawSystemCommand
 
 class InvokeDispatcher(
   private val canvas: CanvasController,
   private val cameraHandler: CameraHandler,
   private val locationHandler: LocationHandler,
+  private val deviceHandler: DeviceHandler,
   private val notificationsHandler: NotificationsHandler,
-
-
+  private val systemHandler: SystemHandler,
+  private val photosHandler: PhotosHandler,
+  private val contactsHandler: ContactsHandler,
+  private val calendarHandler: CalendarHandler,
+  private val motionHandler: MotionHandler,
+  private val screenHandler: ScreenHandler,
   private val smsHandler: SmsHandler,
   private val a2uiHandler: A2UIHandler,
   private val debugHandler: DebugHandler,
+  private val appUpdateHandler: AppUpdateHandler,
   private val isForeground: () -> Boolean,
   private val cameraEnabled: () -> Boolean,
   private val locationEnabled: () -> Boolean,
@@ -26,6 +39,8 @@ class InvokeDispatcher(
   private val refreshNodeCanvasCapability: suspend () -> Boolean,
   private val onCanvasA2uiPush: () -> Unit,
   private val onCanvasA2uiReset: () -> Unit,
+  private val motionActivityAvailable: () -> Boolean,
+  private val motionPedometerAvailable: () -> Boolean,
 ) {
   suspend fun handleInvoke(command: String, paramsJson: String?): GatewaySession.InvokeResult {
     val spec =
@@ -117,10 +132,36 @@ class InvokeDispatcher(
       // Location command
       RemoteClawLocationCommand.Get.rawValue -> locationHandler.handleLocationGet(paramsJson)
 
+      // Device commands
+      RemoteClawDeviceCommand.Status.rawValue -> deviceHandler.handleDeviceStatus(paramsJson)
+      RemoteClawDeviceCommand.Info.rawValue -> deviceHandler.handleDeviceInfo(paramsJson)
+      RemoteClawDeviceCommand.Permissions.rawValue -> deviceHandler.handleDevicePermissions(paramsJson)
+      RemoteClawDeviceCommand.Health.rawValue -> deviceHandler.handleDeviceHealth(paramsJson)
+
       // Notifications command
       RemoteClawNotificationsCommand.List.rawValue -> notificationsHandler.handleNotificationsList(paramsJson)
+      RemoteClawNotificationsCommand.Actions.rawValue -> notificationsHandler.handleNotificationsActions(paramsJson)
 
+      // System command
+      RemoteClawSystemCommand.Notify.rawValue -> systemHandler.handleSystemNotify(paramsJson)
 
+      // Photos command
+      RemoteClawPhotosCommand.Latest.rawValue -> photosHandler.handlePhotosLatest(paramsJson)
+
+      // Contacts command
+      RemoteClawContactsCommand.Search.rawValue -> contactsHandler.handleContactsSearch(paramsJson)
+      RemoteClawContactsCommand.Add.rawValue -> contactsHandler.handleContactsAdd(paramsJson)
+
+      // Calendar command
+      RemoteClawCalendarCommand.Events.rawValue -> calendarHandler.handleCalendarEvents(paramsJson)
+      RemoteClawCalendarCommand.Add.rawValue -> calendarHandler.handleCalendarAdd(paramsJson)
+
+      // Motion command
+      RemoteClawMotionCommand.Activity.rawValue -> motionHandler.handleMotionActivity(paramsJson)
+      RemoteClawMotionCommand.Pedometer.rawValue -> motionHandler.handleMotionPedometer(paramsJson)
+
+      // Screen command
+      RemoteClawScreenCommand.Record.rawValue -> screenHandler.handleScreenRecord(paramsJson)
 
       // SMS command
       RemoteClawSmsCommand.Send.rawValue -> smsHandler.handleSmsSend(paramsJson)
@@ -128,6 +169,10 @@ class InvokeDispatcher(
       // Debug commands
       "debug.ed25519" -> debugHandler.handleEd25519()
       "debug.logs" -> debugHandler.handleLogs()
+
+      // App update
+      "app.update" -> appUpdateHandler.handleUpdate(paramsJson)
+
       else -> GatewaySession.InvokeResult.error(code = "INVALID_REQUEST", message = "INVALID_REQUEST: unknown command")
     }
   }
@@ -195,6 +240,24 @@ class InvokeDispatcher(
           GatewaySession.InvokeResult.error(
             code = "LOCATION_DISABLED",
             message = "LOCATION_DISABLED: enable Location in Settings",
+          )
+        }
+      InvokeCommandAvailability.MotionActivityAvailable ->
+        if (motionActivityAvailable()) {
+          null
+        } else {
+          GatewaySession.InvokeResult.error(
+            code = "MOTION_UNAVAILABLE",
+            message = "MOTION_UNAVAILABLE: accelerometer not available",
+          )
+        }
+      InvokeCommandAvailability.MotionPedometerAvailable ->
+        if (motionPedometerAvailable()) {
+          null
+        } else {
+          GatewaySession.InvokeResult.error(
+            code = "PEDOMETER_UNAVAILABLE",
+            message = "PEDOMETER_UNAVAILABLE: step counter not available",
           )
         }
       InvokeCommandAvailability.SmsAvailable ->

--- a/apps/android/app/src/test/java/org/remoteclaw/android/node/InvokeCommandRegistryTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/node/InvokeCommandRegistryTest.kt
@@ -1,11 +1,16 @@
 package org.remoteclaw.android.node
 
+import org.remoteclaw.android.protocol.RemoteClawCalendarCommand
 import org.remoteclaw.android.protocol.RemoteClawCameraCommand
 import org.remoteclaw.android.protocol.RemoteClawCapability
+import org.remoteclaw.android.protocol.RemoteClawContactsCommand
 import org.remoteclaw.android.protocol.RemoteClawDeviceCommand
 import org.remoteclaw.android.protocol.RemoteClawLocationCommand
+import org.remoteclaw.android.protocol.RemoteClawMotionCommand
 import org.remoteclaw.android.protocol.RemoteClawNotificationsCommand
+import org.remoteclaw.android.protocol.RemoteClawPhotosCommand
 import org.remoteclaw.android.protocol.RemoteClawSmsCommand
+import org.remoteclaw.android.protocol.RemoteClawSystemCommand
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -20,6 +25,8 @@ class InvokeCommandRegistryTest {
           locationEnabled = false,
           smsAvailable = false,
           voiceWakeEnabled = false,
+          motionActivityAvailable = false,
+          motionPedometerAvailable = false,
           debugBuild = false,
         ),
       )
@@ -31,6 +38,10 @@ class InvokeCommandRegistryTest {
     assertFalse(capabilities.contains(RemoteClawCapability.Location.rawValue))
     assertFalse(capabilities.contains(RemoteClawCapability.Sms.rawValue))
     assertFalse(capabilities.contains(RemoteClawCapability.VoiceWake.rawValue))
+    assertTrue(capabilities.contains(RemoteClawCapability.Photos.rawValue))
+    assertTrue(capabilities.contains(RemoteClawCapability.Contacts.rawValue))
+    assertTrue(capabilities.contains(RemoteClawCapability.Calendar.rawValue))
+    assertFalse(capabilities.contains(RemoteClawCapability.Motion.rawValue))
   }
 
   @Test
@@ -42,6 +53,8 @@ class InvokeCommandRegistryTest {
           locationEnabled = true,
           smsAvailable = true,
           voiceWakeEnabled = true,
+          motionActivityAvailable = true,
+          motionPedometerAvailable = true,
           debugBuild = false,
         ),
       )
@@ -53,6 +66,10 @@ class InvokeCommandRegistryTest {
     assertTrue(capabilities.contains(RemoteClawCapability.Location.rawValue))
     assertTrue(capabilities.contains(RemoteClawCapability.Sms.rawValue))
     assertTrue(capabilities.contains(RemoteClawCapability.VoiceWake.rawValue))
+    assertTrue(capabilities.contains(RemoteClawCapability.Photos.rawValue))
+    assertTrue(capabilities.contains(RemoteClawCapability.Contacts.rawValue))
+    assertTrue(capabilities.contains(RemoteClawCapability.Calendar.rawValue))
+    assertTrue(capabilities.contains(RemoteClawCapability.Motion.rawValue))
   }
 
   @Test
@@ -64,6 +81,8 @@ class InvokeCommandRegistryTest {
           locationEnabled = false,
           smsAvailable = false,
           voiceWakeEnabled = false,
+          motionActivityAvailable = false,
+          motionPedometerAvailable = false,
           debugBuild = false,
         ),
       )
@@ -72,10 +91,20 @@ class InvokeCommandRegistryTest {
     assertFalse(commands.contains(RemoteClawCameraCommand.Clip.rawValue))
     assertFalse(commands.contains(RemoteClawCameraCommand.List.rawValue))
     assertFalse(commands.contains(RemoteClawLocationCommand.Get.rawValue))
+    assertTrue(commands.contains(RemoteClawDeviceCommand.Status.rawValue))
+    assertTrue(commands.contains(RemoteClawDeviceCommand.Info.rawValue))
     assertTrue(commands.contains(RemoteClawDeviceCommand.Permissions.rawValue))
     assertTrue(commands.contains(RemoteClawDeviceCommand.Health.rawValue))
     assertTrue(commands.contains(RemoteClawNotificationsCommand.List.rawValue))
     assertTrue(commands.contains(RemoteClawNotificationsCommand.Actions.rawValue))
+    assertTrue(commands.contains(RemoteClawSystemCommand.Notify.rawValue))
+    assertTrue(commands.contains(RemoteClawPhotosCommand.Latest.rawValue))
+    assertTrue(commands.contains(RemoteClawContactsCommand.Search.rawValue))
+    assertTrue(commands.contains(RemoteClawContactsCommand.Add.rawValue))
+    assertTrue(commands.contains(RemoteClawCalendarCommand.Events.rawValue))
+    assertTrue(commands.contains(RemoteClawCalendarCommand.Add.rawValue))
+    assertFalse(commands.contains(RemoteClawMotionCommand.Activity.rawValue))
+    assertFalse(commands.contains(RemoteClawMotionCommand.Pedometer.rawValue))
     assertFalse(commands.contains(RemoteClawSmsCommand.Send.rawValue))
     assertFalse(commands.contains("debug.logs"))
     assertFalse(commands.contains("debug.ed25519"))
@@ -91,6 +120,8 @@ class InvokeCommandRegistryTest {
           locationEnabled = true,
           smsAvailable = true,
           voiceWakeEnabled = false,
+          motionActivityAvailable = true,
+          motionPedometerAvailable = true,
           debugBuild = true,
         ),
       )
@@ -99,13 +130,42 @@ class InvokeCommandRegistryTest {
     assertTrue(commands.contains(RemoteClawCameraCommand.Clip.rawValue))
     assertTrue(commands.contains(RemoteClawCameraCommand.List.rawValue))
     assertTrue(commands.contains(RemoteClawLocationCommand.Get.rawValue))
+    assertTrue(commands.contains(RemoteClawDeviceCommand.Status.rawValue))
+    assertTrue(commands.contains(RemoteClawDeviceCommand.Info.rawValue))
     assertTrue(commands.contains(RemoteClawDeviceCommand.Permissions.rawValue))
     assertTrue(commands.contains(RemoteClawDeviceCommand.Health.rawValue))
     assertTrue(commands.contains(RemoteClawNotificationsCommand.List.rawValue))
     assertTrue(commands.contains(RemoteClawNotificationsCommand.Actions.rawValue))
+    assertTrue(commands.contains(RemoteClawSystemCommand.Notify.rawValue))
+    assertTrue(commands.contains(RemoteClawPhotosCommand.Latest.rawValue))
+    assertTrue(commands.contains(RemoteClawContactsCommand.Search.rawValue))
+    assertTrue(commands.contains(RemoteClawContactsCommand.Add.rawValue))
+    assertTrue(commands.contains(RemoteClawCalendarCommand.Events.rawValue))
+    assertTrue(commands.contains(RemoteClawCalendarCommand.Add.rawValue))
+    assertTrue(commands.contains(RemoteClawMotionCommand.Activity.rawValue))
+    assertTrue(commands.contains(RemoteClawMotionCommand.Pedometer.rawValue))
     assertTrue(commands.contains(RemoteClawSmsCommand.Send.rawValue))
     assertTrue(commands.contains("debug.logs"))
     assertTrue(commands.contains("debug.ed25519"))
     assertTrue(commands.contains("app.update"))
+  }
+
+  @Test
+  fun advertisedCommands_onlyIncludesSupportedMotionCommands() {
+    val commands =
+      InvokeCommandRegistry.advertisedCommands(
+        NodeRuntimeFlags(
+          cameraEnabled = false,
+          locationEnabled = false,
+          smsAvailable = false,
+          voiceWakeEnabled = false,
+          motionActivityAvailable = true,
+          motionPedometerAvailable = false,
+          debugBuild = false,
+        ),
+      )
+
+    assertTrue(commands.contains(RemoteClawMotionCommand.Activity.rawValue))
+    assertFalse(commands.contains(RemoteClawMotionCommand.Pedometer.rawValue))
   }
 }

--- a/apps/android/app/src/test/java/org/remoteclaw/android/node/MotionHandlerTest.kt
+++ b/apps/android/app/src/test/java/org/remoteclaw/android/node/MotionHandlerTest.kt
@@ -92,7 +92,8 @@ class MotionHandlerTest {
 
 private class FakeMotionDataSource(
   private val hasPermission: Boolean,
-  private val available: Boolean = true,
+  private val activityAvailable: Boolean = true,
+  private val pedometerAvailable: Boolean = true,
   private val activityRecord: MotionActivityRecord =
     MotionActivityRecord(
       startISO = "2026-02-28T00:00:00Z",
@@ -117,7 +118,9 @@ private class FakeMotionDataSource(
   private val activityError: Throwable? = null,
   private val pedometerError: Throwable? = null,
 ) : MotionDataSource {
-  override fun isAvailable(context: Context): Boolean = available
+  override fun isActivityAvailable(context: Context): Boolean = activityAvailable
+
+  override fun isPedometerAvailable(context: Context): Boolean = pedometerAvailable
 
   override fun hasPermission(context: Context): Boolean = hasPermission
 


### PR DESCRIPTION
Cherry-pick of upstream [`1bc9da8f9`](https://github.com/openclaw/openclaw/commit/1bc9da8f9).

**Author:** Ayaan Zaidi
**Tier:** android-fix (stability)

Stabilizes motion activity sampling by splitting the monolithic `motionAvailable` flag into separate `motionActivityAvailable` and `motionPedometerAvailable` capability flags. Gates the pedometer command behind actual sensor availability. Adds guard for accelerometer sensor availability before attempting registration.

**Conflicts resolved:** Rebrand conflicts across NodeRuntime.kt, ConnectionManager.kt, InvokeCommandRegistry.kt, InvokeDispatcher.kt, plus DU test file relocation.

Depends on #1363
Part of #673

Co-authored-by: Ayaan Zaidi <zaidi@uplause.io>