### PR TITLE
Cherry-pick 3f056a7: fix(android): block onboarding advance until special setup is complete

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/ui/OnboardingFlow.kt
@@ -319,14 +319,18 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
       if (enabled.isEmpty()) "None selected" else enabled.joinToString(", ")
     }
 
-  val proceedFromPermissions: () -> Unit = {
-    when {
-      enableNotificationListener && !isNotificationListenerEnabled(context) -> {
-        openNotificationListenerSettings(context)
-      }
-      enableAppUpdates && !canInstallUnknownApps(context) -> {
-        openUnknownAppSourcesSettings(context)
-      }
+  val proceedFromPermissions: () -> Unit = proceed@{
+    var openedSpecialSetup = false
+    if (enableNotificationListener && !isNotificationListenerEnabled(context)) {
+      openNotificationListenerSettings(context)
+      openedSpecialSetup = true
+    }
+    if (enableAppUpdates && !canInstallUnknownApps(context)) {
+      openUnknownAppSourcesSettings(context)
+      openedSpecialSetup = true
+    }
+    if (openedSpecialSetup) {
+      return@proceed
     }
     step = OnboardingStep.FinalCheck
   }


### PR DESCRIPTION
Cherry-pick of upstream [`3f056a729`](https://github.com/openclaw/openclaw/commit/3f056a729).

**Author:** Ayaan Zaidi
**Tier:** android-fix (onboarding UX)

Blocks onboarding flow from advancing to the next step until any special setup (e.g., notification listener, usage stats) is fully complete. Prevents users from skipping required capability configuration.

Depends on #1365
Part of #673

Co-authored-by: Ayaan Zaidi <zaidi@uplause.io>