### PR TITLE
Cherry-pick eea081c70: fix(android): update onboarding pairing commands

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/ui/OnboardingFlow.kt
@@ -1563,8 +1563,8 @@ private fun FinalStep(
       } else {
         GuideBlock(title = "Pairing Required") {
           Text("Run these on the gateway host:", style = onboardingCalloutStyle, color = onboardingTextSecondary)
-          CommandBlock("remoteclaw nodes pending")
-          CommandBlock("remoteclaw nodes approve <requestId>")
+          CommandBlock("remoteclaw devices list")
+          CommandBlock("remoteclaw devices approve <requestId>")
           Text("Then tap Connect again.", style = onboardingCalloutStyle, color = onboardingTextSecondary)
         }
       }


### PR DESCRIPTION
Cherry-pick of upstream [`eea081c70`](https://github.com/openclaw/openclaw/commit/eea081c70).

**Author:** Ayaan Zaidi
**Tier:** T3

Changes onboarding pairing commands from `nodes pending/approve` to `devices list/approve` to match the updated CLI surface.

Conflict resolution: applied rebrand (`openclaw` → `remoteclaw`) to the new `devices` command names.

Depends on #1367
Part of #673