### PR TITLE
Cherry-pick fcf3e5b0a: fix(android): expose talk-mode assistant speech entrypoint

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
@@ -437,6 +437,11 @@ class TalkModeManager(
     playAssistant(text, playbackToken)
   }
 
+  suspend fun speakAssistantReply(text: String) {
+    reloadConfig()
+    playAssistant(text)
+  }
+
   private fun start() {
     mainHandler.post {
       if (_isListening.value) return@post


### PR DESCRIPTION
Cherry-pick of upstream [`fcf3e5b0a`](https://github.com/openclaw/openclaw/commit/fcf3e5b0a).

**Author:** Ayaan Zaidi
**Tier:** T3

Exposes a public `speakAssistantReply` entrypoint on `TalkModeManager` so callers outside the class can trigger TTS playback of assistant replies.

Depends on #1368
Part of #673