### PR TITLE
Cherry-pick fb92a91ef: fix(android): speak final voice replies in mic capture flow

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
@@ -20,6 +20,8 @@ import org.remoteclaw.android.gateway.probeGatewayTlsFingerprint
 import org.remoteclaw.android.node.*
 import org.remoteclaw.android.protocol.RemoteClawCanvasA2UIAction
 import org.remoteclaw.android.voice.MicCaptureManager
+import org.remoteclaw.android.voice.TalkModeManager
+import org.remoteclaw.android.voice.VoiceConversationEntry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -265,6 +267,18 @@ class NodeRuntime(context: Context) {
       json = json,
       supportsChatSubscribe = false,
     )
+  private val voiceReplySpeaker: TalkModeManager by lazy {
+    // Reuse the existing TalkMode speech engine (ElevenLabs + deterministic system-TTS fallback)
+    // without enabling the legacy talk capture loop.
+    TalkModeManager(
+      context = appContext,
+      scope = scope,
+      session = operatorSession,
+      supportsChatSubscribe = false,
+      isConnected = { operatorConnected },
+    )
+  }
+
   private val micCapture: MicCaptureManager by lazy {
     MicCaptureManager(
       context = appContext,
@@ -281,6 +295,9 @@ class NodeRuntime(context: Context) {
           }
         val response = operatorSession.request("chat.send", params.toString())
         parseChatSendRunId(response) ?: idempotencyKey
+      },
+      speakAssistantReply = { text ->
+        voiceReplySpeaker.speakAssistantReply(text)
       },
     )
   }

--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/MicCaptureManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/MicCaptureManager.kt
@@ -10,6 +10,7 @@ import android.os.Looper
 import android.speech.RecognitionListener
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
+import android.util.Log
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -18,6 +19,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
@@ -25,8 +27,10 @@ class MicCaptureManager(
   private val context: Context,
   private val scope: CoroutineScope,
   private val sendToGateway: suspend (String) -> String?,
+  private val speakAssistantReply: suspend (String) -> Unit = {},
 ) {
   companion object {
+    private const val tag = "MicCapture"
     private const val speechMinSessionMs = 30_000L
     private const val speechCompleteSilenceMs = 1_500L
     private const val speechPossibleSilenceMs = 900L
@@ -109,6 +113,10 @@ class MicCaptureManager(
     if (messageQueue.isNotEmpty()) {
       messageQueue.removeFirst()
       publishQueue()
+    }
+    val finalText = parseAssistantText(obj)?.trim().orEmpty()
+    if (finalText.isNotEmpty()) {
+      playAssistantReplyAsync(finalText)
     }
     pendingRunId = null
     _isSending.value = false
@@ -244,6 +252,34 @@ class MicCaptureManager(
       }
     }
   }
+
+  private fun parseAssistantText(payload: JsonObject): String? {
+    val message = payload["message"].asObjectOrNull() ?: return null
+    if (message["role"].asStringOrNull() != "assistant") return null
+    val content = message["content"] as? JsonArray ?: return null
+
+    val parts =
+      content.mapNotNull { item ->
+        val obj = item.asObjectOrNull() ?: return@mapNotNull null
+        if (obj["type"].asStringOrNull() != "text") return@mapNotNull null
+        obj["text"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+      }
+    if (parts.isEmpty()) return null
+    return parts.joinToString("\n")
+  }
+
+  private fun playAssistantReplyAsync(text: String) {
+    val spoken = text.trim()
+    if (spoken.isEmpty()) return
+    scope.launch {
+      try {
+        speakAssistantReply(spoken)
+      } catch (err: Throwable) {
+        Log.w(tag, "assistant speech failed: ${err.message ?: err::class.simpleName}")
+      }
+    }
+  }
+
 
   private fun disableMic(status: String) {
     stopRequested = true


### PR DESCRIPTION
Cherry-pick of upstream [`fb92a91ef`](https://github.com/openclaw/openclaw/commit/fb92a91ef).

**Author:** Ayaan Zaidi
**Tier:** T3

Wires TTS playback of final assistant replies during mic capture flow. Adds a `voiceReplySpeaker` (reuses `TalkModeManager` speech engine) in `NodeRuntime` and passes `speakAssistantReply` callback into `MicCaptureManager`.

Conflict resolution: integrated `playAssistantReplyAsync` and `parseAssistantText` into our simplified queue-based handler (the original conversation-tracking helper methods were removed in prior refactoring). Applied `openclaw` -> `remoteclaw` rebrand to imports and added `TalkModeManager`/`VoiceConversationEntry` imports.

Depends on #1369
Part of #673