### PR TITLE
Cherry-pick 72e135083: feat(android-voice): add speaker toggle in voice tab

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/MainViewModel.kt
@@ -49,6 +49,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val micQueuedMessages: StateFlow<List<String>> = runtime.micQueuedMessages
   val micInputLevel: StateFlow<Float> = runtime.micInputLevel
   val micIsSending: StateFlow<Boolean> = runtime.micIsSending
+  val speakerEnabled: StateFlow<Boolean> = runtime.speakerEnabled
   val manualEnabled: StateFlow<Boolean> = runtime.manualEnabled
   val manualHost: StateFlow<String> = runtime.manualHost
   val manualPort: StateFlow<Int> = runtime.manualPort
@@ -125,6 +126,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun setMicEnabled(enabled: Boolean) {
     runtime.setMicEnabled(enabled)
+  }
+
+  fun setSpeakerEnabled(enabled: Boolean) {
+    runtime.setSpeakerEnabled(enabled)
   }
 
   fun refreshGatewayConnection() {

--- a/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
@@ -297,7 +297,9 @@ class NodeRuntime(context: Context) {
         parseChatSendRunId(response) ?: idempotencyKey
       },
       speakAssistantReply = { text ->
-        voiceReplySpeaker.speakAssistantReply(text)
+        if (prefs.speakerEnabled.value) {
+          voiceReplySpeaker.speakAssistantReply(text)
+        }
       },
     )
   }
@@ -574,6 +576,13 @@ class NodeRuntime(context: Context) {
     prefs.setTalkEnabled(value)
     micCapture.setMicEnabled(value)
     externalAudioCaptureActive.value = value
+  }
+
+  val speakerEnabled: StateFlow<Boolean>
+    get() = prefs.speakerEnabled
+
+  fun setSpeakerEnabled(value: Boolean) {
+    prefs.setSpeakerEnabled(value)
   }
 
   fun refreshGatewayConnection() {

--- a/apps/android/app/src/main/java/org/remoteclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/SecurePrefs.kt
@@ -98,6 +98,9 @@ class SecurePrefs(context: Context) {
   private val _talkEnabled = MutableStateFlow(prefs.getBoolean("talk.enabled", false))
   val talkEnabled: StateFlow<Boolean> = _talkEnabled
 
+  private val _speakerEnabled = MutableStateFlow(plainPrefs.getBoolean("voice.speakerEnabled", true))
+  val speakerEnabled: StateFlow<Boolean> = _speakerEnabled
+
   fun setLastDiscoveredStableId(value: String) {
     val trimmed = value.trim()
     prefs.edit { putString("gateway.lastDiscoveredStableID", trimmed) }
@@ -262,6 +265,11 @@ class SecurePrefs(context: Context) {
   fun setTalkEnabled(value: Boolean) {
     prefs.edit { putBoolean("talk.enabled", value) }
     _talkEnabled.value = value
+  }
+
+  fun setSpeakerEnabled(value: Boolean) {
+    plainPrefs.edit { putBoolean("voice.speakerEnabled", value) }
+    _speakerEnabled.value = value
   }
 
   private fun loadVoiceWakeMode(): VoiceWakeMode {

--- a/apps/android/app/src/main/java/org/remoteclaw/android/ui/VoiceTabScreen.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/ui/VoiceTabScreen.kt
@@ -10,12 +10,6 @@ import android.net.Uri
 import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -23,28 +17,36 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.MicOff
+import androidx.compose.material.icons.automirrored.filled.VolumeOff
+import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -52,9 +54,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.app.ActivityCompat
@@ -63,9 +67,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import org.remoteclaw.android.MainViewModel
-import kotlin.math.PI
+import org.remoteclaw.android.voice.VoiceConversationEntry
+import org.remoteclaw.android.voice.VoiceConversationRole
 import kotlin.math.max
-import kotlin.math.sin
 
 @Composable
 fun VoiceTabScreen(viewModel: MainViewModel) {
@@ -74,14 +78,17 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
   val activity = remember(context) { context.findActivity() }
   val listState = rememberLazyListState()
 
-  val isConnected by viewModel.isConnected.collectAsState()
   val gatewayStatus by viewModel.statusText.collectAsState()
   val micEnabled by viewModel.micEnabled.collectAsState()
-  val micStatusText by viewModel.micStatusText.collectAsState()
-  val liveTranscript by viewModel.micLiveTranscript.collectAsState()
-  val queuedMessages by viewModel.micQueuedMessages.collectAsState()
+  val speakerEnabled by viewModel.speakerEnabled.collectAsState()
+  val micLiveTranscript by viewModel.micLiveTranscript.collectAsState()
+  val micQueuedMessages by viewModel.micQueuedMessages.collectAsState()
+  val micConversation by viewModel.micConversation.collectAsState()
   val micInputLevel by viewModel.micInputLevel.collectAsState()
   val micIsSending by viewModel.micIsSending.collectAsState()
+
+  val hasStreamingAssistant = micConversation.any { it.role == VoiceConversationRole.Assistant && it.isStreaming }
+  val showThinkingBubble = micIsSending && !hasStreamingAssistant
 
   var hasMicPermission by remember { mutableStateOf(context.hasRecordAudioPermission()) }
   var pendingMicEnable by remember { mutableStateOf(false) }
@@ -106,238 +113,278 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
       pendingMicEnable = false
     }
 
-  LazyColumn(
-    state = listState,
+  LaunchedEffect(micConversation.size, showThinkingBubble) {
+    val total = micConversation.size + if (showThinkingBubble) 1 else 0
+    if (total > 0) {
+      listState.animateScrollToItem(total - 1)
+    }
+  }
+
+  Column(
     modifier =
       Modifier
-        .fillMaxWidth()
+        .fillMaxSize()
+        .background(mobileBackgroundGradient)
         .imePadding()
-        .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
-    contentPadding = PaddingValues(horizontal = 20.dp, vertical = 16.dp),
+        .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom))
+        .padding(horizontal = 20.dp, vertical = 14.dp),
     verticalArrangement = Arrangement.spacedBy(10.dp),
   ) {
-    item {
-      Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(
-          "VOICE",
-          style = mobileCaption1.copy(fontWeight = FontWeight.Bold, letterSpacing = 1.sp),
-          color = mobileAccent,
-        )
-        Text("Mic capture", style = mobileTitle2, color = mobileText)
-        Text(
-          if (isConnected) {
-            "Mic on captures speech continuously. Mic off sends the full transcript queue."
-          } else {
-            "Gateway offline. Mic off will keep messages queued until reconnect."
-          },
-          style = mobileCallout,
-          color = mobileTextSecondary,
-        )
+    LazyColumn(
+      state = listState,
+      modifier = Modifier.fillMaxWidth().weight(1f),
+      contentPadding = PaddingValues(vertical = 4.dp),
+      verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+      if (micConversation.isEmpty() && !showThinkingBubble) {
+        item {
+          Box(
+            modifier = Modifier.fillParentMaxHeight().fillMaxWidth(),
+            contentAlignment = Alignment.Center,
+          ) {
+            Column(
+              horizontalAlignment = Alignment.CenterHorizontally,
+              verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+              Icon(
+                imageVector = Icons.Default.Mic,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = mobileTextTertiary,
+              )
+              Text(
+                "Tap the mic to start",
+                style = mobileHeadline,
+                color = mobileTextSecondary,
+              )
+              Text(
+                "Each pause sends a turn automatically.",
+                style = mobileCallout,
+                color = mobileTextTertiary,
+              )
+            }
+          }
+        }
+      }
+
+      items(items = micConversation, key = { it.id }) { entry ->
+        VoiceTurnBubble(entry = entry)
+      }
+
+      if (showThinkingBubble) {
+        item {
+          VoiceThinkingBubble()
+        }
       }
     }
 
-    item {
-      Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        color = Color.White,
-        border = BorderStroke(1.dp, mobileBorder),
-      ) {
-        Column(
-          modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
-          verticalArrangement = Arrangement.spacedBy(10.dp),
+    Column(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+      if (!micLiveTranscript.isNullOrBlank()) {
+        Surface(
+          modifier = Modifier.fillMaxWidth(),
+          shape = RoundedCornerShape(14.dp),
+          color = mobileAccentSoft,
+          border = BorderStroke(1.dp, mobileAccent.copy(alpha = 0.2f)),
         ) {
-          Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
+          Text(
+            micLiveTranscript!!.trim(),
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+            style = mobileCallout,
+            color = mobileText,
+          )
+        }
+      }
+
+      // Mic button with input-reactive ring + speaker toggle
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        // Speaker toggle
+        IconButton(
+          onClick = { viewModel.setSpeakerEnabled(!speakerEnabled) },
+          modifier = Modifier.size(48.dp),
+          colors =
+            IconButtonDefaults.iconButtonColors(
+              containerColor = if (speakerEnabled) mobileSurface else mobileDangerSoft,
+            ),
+        ) {
+          Icon(
+            imageVector = if (speakerEnabled) Icons.AutoMirrored.Filled.VolumeUp else Icons.AutoMirrored.Filled.VolumeOff,
+            contentDescription = if (speakerEnabled) "Mute speaker" else "Unmute speaker",
+            modifier = Modifier.size(22.dp),
+            tint = if (speakerEnabled) mobileTextSecondary else mobileDanger,
+          )
+        }
+
+        // Ring size = 68dp base + up to 22dp driven by mic input level.
+        // The outer Box is fixed at 90dp (max ring size) so the ring never shifts the button.
+        Box(
+          modifier = Modifier.padding(horizontal = 16.dp).size(90.dp),
+          contentAlignment = Alignment.Center,
+        ) {
+          if (micEnabled) {
+            val ringLevel = micInputLevel.coerceIn(0f, 1f)
+            val ringSize = 68.dp + (22.dp * max(ringLevel, 0.05f))
+            Box(
+              modifier =
+                Modifier
+                  .size(ringSize)
+                  .background(mobileAccent.copy(alpha = 0.12f + 0.14f * ringLevel), CircleShape),
+            )
+          }
+          Button(
+            onClick = {
+              if (micEnabled) {
+                viewModel.setMicEnabled(false)
+                return@Button
+              }
+              if (hasMicPermission) {
+                viewModel.setMicEnabled(true)
+              } else {
+                pendingMicEnable = true
+                requestMicPermission.launch(Manifest.permission.RECORD_AUDIO)
+              }
+            },
+            shape = CircleShape,
+            contentPadding = PaddingValues(0.dp),
+            modifier = Modifier.size(60.dp),
+            colors =
+              ButtonDefaults.buttonColors(
+                containerColor = if (micEnabled) mobileDanger else mobileAccent,
+                contentColor = Color.White,
+              ),
           ) {
-            Text("Gateway", style = mobileCaption1, color = mobileTextSecondary)
-            Text(gatewayStatus, style = mobileCaption1, color = mobileText)
-          }
-          Text(micStatusText, style = mobileHeadline, color = mobileText)
-          Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Button(
-              onClick = {
-                if (micEnabled) {
-                  viewModel.setMicEnabled(false)
-                  return@Button
-                }
-                if (hasMicPermission) {
-                  viewModel.setMicEnabled(true)
-                } else {
-                  pendingMicEnable = true
-                  requestMicPermission.launch(Manifest.permission.RECORD_AUDIO)
-                }
-              },
-              shape = RoundedCornerShape(12.dp),
-              colors =
-                ButtonDefaults.buttonColors(
-                  containerColor = if (micEnabled) mobileDanger else mobileAccent,
-                  contentColor = Color.White,
-                ),
-            ) {
-              Text(
-                if (micEnabled) "Mic off" else "Mic on",
-                style = mobileCallout.copy(fontWeight = FontWeight.Bold),
-              )
-            }
-            if (!hasMicPermission) {
-              Button(
-                onClick = { openAppSettings(context) },
-                shape = RoundedCornerShape(12.dp),
-                colors =
-                  ButtonDefaults.buttonColors(
-                    containerColor = mobileSurfaceStrong,
-                    contentColor = mobileText,
-                  ),
-              ) {
-                Text("Open settings", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold))
-              }
-            }
-          }
-          if (!hasMicPermission) {
-            val showRationale =
-              if (activity == null) {
-                false
-              } else {
-                ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.RECORD_AUDIO)
-              }
-            Text(
-              if (showRationale) {
-                "Microphone permission required to capture speech."
-              } else {
-                "Microphone is blocked. Enable it in app settings."
-              },
-              style = mobileCallout,
-              color = mobileWarning,
+            Icon(
+              imageVector = if (micEnabled) Icons.Default.MicOff else Icons.Default.Mic,
+              contentDescription = if (micEnabled) "Turn microphone off" else "Turn microphone on",
+              modifier = Modifier.size(24.dp),
             )
           }
         }
-      }
-    }
 
-    item {
-      Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        color = Color.White,
-        border = BorderStroke(1.dp, mobileBorder),
-      ) {
-        Column(
-          modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
-          verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-          Text("Mic waveform", style = mobileHeadline, color = mobileText)
-          MicWaveform(level = micInputLevel, active = micEnabled)
+        // Invisible spacer to balance the row (same size as speaker button)
+        Box(modifier = Modifier.size(48.dp))
+      }
+
+      // Status + labels
+      val queueCount = micQueuedMessages.size
+      val stateText =
+        when {
+          queueCount > 0 -> "$queueCount queued"
+          micIsSending -> "Sending"
+          micEnabled -> "Listening"
+          else -> "Mic off"
         }
-      }
-    }
+      Text(
+        "$gatewayStatus · $stateText",
+        style = mobileCaption1,
+        color = mobileTextSecondary,
+      )
 
-    item {
-      Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        color = Color.White,
-        border = BorderStroke(1.dp, mobileBorder),
-      ) {
-        Column(
-          modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
-          verticalArrangement = Arrangement.spacedBy(6.dp),
-        ) {
-          Text("Live transcript", style = mobileHeadline, color = mobileText)
-          Text(
-            liveTranscript?.trim().takeUnless { it.isNullOrEmpty() } ?: "Waiting for speech…",
-            style = mobileCallout,
-            color = if (liveTranscript.isNullOrBlank()) mobileTextTertiary else mobileText,
-          )
-        }
-      }
-    }
-
-    item {
-      Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        color = Color.White,
-        border = BorderStroke(1.dp, mobileBorder),
-      ) {
-        Column(
-          modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
-          verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-          Text("Queued messages", style = mobileHeadline, color = mobileText)
-          Text(
-            if (queuedMessages.isEmpty()) {
-              "No queued transcripts."
-            } else {
-              "${queuedMessages.size} queued${if (micIsSending) " · sending…" else ""}"
-            },
-            style = mobileCallout,
-            color = mobileTextSecondary,
-          )
-          if (queuedMessages.isNotEmpty()) {
-            HorizontalDivider(color = mobileBorder)
-          }
-          if (queuedMessages.isEmpty()) {
-            Text("Turn mic off to flush captured speech into the queue.", style = mobileCallout, color = mobileTextTertiary)
+      if (!hasMicPermission) {
+        val showRationale =
+          if (activity == null) {
+            false
           } else {
-            queuedMessages.forEachIndexed { index, item ->
-              Surface(
-                modifier = Modifier.fillMaxWidth().padding(bottom = if (index == queuedMessages.lastIndex) 0.dp else 8.dp),
-                shape = RoundedCornerShape(12.dp),
-                color = mobileSurface,
-                border = BorderStroke(1.dp, mobileBorder),
-              ) {
-                Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp)) {
-                  Text("Message ${index + 1}", style = mobileCaption1, color = mobileTextSecondary)
-                  Text(item, style = mobileCallout, color = mobileText)
-                }
-              }
-            }
+            ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.RECORD_AUDIO)
           }
+        Text(
+          if (showRationale) {
+            "Microphone permission is required for voice mode."
+          } else {
+            "Microphone blocked. Open app settings to enable it."
+          },
+          style = mobileCaption1,
+          color = mobileWarning,
+          textAlign = TextAlign.Center,
+        )
+        Button(
+          onClick = { openAppSettings(context) },
+          shape = RoundedCornerShape(12.dp),
+          colors = ButtonDefaults.buttonColors(containerColor = mobileSurfaceStrong, contentColor = mobileText),
+        ) {
+          Text("Open settings", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold))
         }
       }
     }
-
-    item { Spacer(modifier = Modifier.height(24.dp)) }
   }
 }
 
 @Composable
-private fun MicWaveform(level: Float, active: Boolean) {
-  val transition = rememberInfiniteTransition(label = "wave")
-  val phase by
-    transition.animateFloat(
-      initialValue = 0f,
-      targetValue = 1f,
-      animationSpec = infiniteRepeatable(animation = tween(1_200, easing = LinearEasing), repeatMode = RepeatMode.Restart),
-      label = "wavePhase",
-    )
-  val effective = if (active) level.coerceIn(0f, 1f) else 0f
-  val base = max(effective, if (active) 0.08f else 0f)
+private fun VoiceTurnBubble(entry: VoiceConversationEntry) {
+  val isUser = entry.role == VoiceConversationRole.User
   Row(
-    modifier = Modifier.fillMaxWidth().heightIn(min = 60.dp),
-    horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
-    verticalAlignment = Alignment.CenterVertically,
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start,
   ) {
-    repeat(22) { index ->
-      val pulse =
-        if (!active) {
-          0f
-        } else {
-          ((sin(((phase * 2f * PI) + (index * 0.5f)).toDouble()) + 1.0) * 0.5).toFloat()
-        }
-      val barHeight = 8.dp + (52.dp * (base * pulse))
-      Box(
-        modifier =
-          Modifier
-            .width(6.dp)
-            .height(barHeight)
-            .background(if (active) mobileAccent else mobileBorderStrong, RoundedCornerShape(999.dp)),
-      )
+    Surface(
+      modifier = Modifier.fillMaxWidth(0.90f),
+      shape = RoundedCornerShape(12.dp),
+      color = if (isUser) mobileAccentSoft else Color.White,
+      border = BorderStroke(1.dp, if (isUser) mobileAccent else mobileBorderStrong),
+    ) {
+      Column(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 11.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(3.dp),
+      ) {
+        Text(
+          if (isUser) "You" else "RemoteClaw",
+          style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold, letterSpacing = 0.6.sp),
+          color = if (isUser) mobileAccent else mobileTextSecondary,
+        )
+        Text(
+          if (entry.isStreaming && entry.text.isBlank()) "Listening response…" else entry.text,
+          style = mobileCallout,
+          color = mobileText,
+        )
+      }
     }
   }
+}
+
+@Composable
+private fun VoiceThinkingBubble() {
+  Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
+    Surface(
+      modifier = Modifier.fillMaxWidth(0.68f),
+      shape = RoundedCornerShape(12.dp),
+      color = Color.White,
+      border = BorderStroke(1.dp, mobileBorderStrong),
+    ) {
+      Row(
+        modifier = Modifier.padding(horizontal = 11.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        ThinkingDots(color = mobileTextSecondary)
+        Text("RemoteClaw is thinking…", style = mobileCallout, color = mobileTextSecondary)
+      }
+    }
+  }
+}
+
+@Composable
+private fun ThinkingDots(color: Color) {
+  Row(horizontalArrangement = Arrangement.spacedBy(5.dp), verticalAlignment = Alignment.CenterVertically) {
+    ThinkingDot(alpha = 0.38f, color = color)
+    ThinkingDot(alpha = 0.62f, color = color)
+    ThinkingDot(alpha = 0.90f, color = color)
+  }
+}
+
+@Composable
+private fun ThinkingDot(alpha: Float, color: Color) {
+  Surface(
+    modifier = Modifier.size(6.dp).alpha(alpha),
+    shape = CircleShape,
+    color = color,
+  ) {}
 }
 
 private fun Context.hasRecordAudioPermission(): Boolean {


### PR DESCRIPTION
Cherry-pick of upstream [`72e135083`](https://github.com/openclaw/openclaw/commit/72e135083).

**Author:** Ayaan Zaidi
**Tier:** T3

Adds a speaker on/off toggle to the voice tab UI. Includes `speakerEnabled` state in `MainViewModel`, persistence in `SecurePrefs`, and a refactored `VoiceTabScreen` layout with the new toggle button.

Conflict resolution: DU conflict on `VoiceTabScreen.kt` (file moved to rebranded path in our fork). Took upstream version and applied `openclaw` -> `remoteclaw` rebrand.

Depends on #1370
Part of #673