### PR TITLE
Cherry-pick 3daed77ba: fix(android): unify voice speaker gating and config refresh

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
@@ -205,7 +205,12 @@ class NodeRuntime(context: Context) {
         applyMainSessionKey(mainSessionKey)
         updateStatus()
         micCapture.onGatewayConnectionChanged(true)
-        scope.launch { refreshBrandingFromGateway() }
+        scope.launch {
+          refreshBrandingFromGateway()
+          if (voiceReplySpeakerLazy.isInitialized()) {
+            voiceReplySpeaker.refreshConfig()
+          }
+        }
       },
       onDisconnected = { message ->
         operatorConnected = false
@@ -267,7 +272,7 @@ class NodeRuntime(context: Context) {
       json = json,
       supportsChatSubscribe = false,
     )
-  private val voiceReplySpeaker: TalkModeManager by lazy {
+  private val voiceReplySpeakerLazy: Lazy<TalkModeManager> = lazy {
     // Reuse the existing TalkMode speech engine (ElevenLabs + deterministic system-TTS fallback)
     // without enabling the legacy talk capture loop.
     TalkModeManager(
@@ -276,8 +281,12 @@ class NodeRuntime(context: Context) {
       session = operatorSession,
       supportsChatSubscribe = false,
       isConnected = { operatorConnected },
-    )
+    ).also { speaker ->
+      speaker.setPlaybackEnabled(prefs.speakerEnabled.value)
+    }
   }
+  private val voiceReplySpeaker: TalkModeManager
+    get() = voiceReplySpeakerLazy.value
 
   private val micCapture: MicCaptureManager by lazy {
     MicCaptureManager(
@@ -297,9 +306,7 @@ class NodeRuntime(context: Context) {
         parseChatSendRunId(response) ?: idempotencyKey
       },
       speakAssistantReply = { text ->
-        if (prefs.speakerEnabled.value) {
-          voiceReplySpeaker.speakAssistantReply(text)
-        }
+        voiceReplySpeaker.speakAssistantReply(text)
       },
     )
   }
@@ -583,6 +590,9 @@ class NodeRuntime(context: Context) {
 
   fun setSpeakerEnabled(value: Boolean) {
     prefs.setSpeakerEnabled(value)
+    if (voiceReplySpeakerLazy.isInitialized()) {
+      voiceReplySpeaker.setPlaybackEnabled(value)
+    }
   }
 
   fun refreshGatewayConnection() {

--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
@@ -437,8 +437,21 @@ class TalkModeManager(
     playAssistant(text, playbackToken)
   }
 
-  suspend fun speakAssistantReply(text: String) {
+  fun setPlaybackEnabled(enabled: Boolean) {
+    playbackEnabled = enabled
+    if (!enabled) {
+      stopSpeaking()
+    }
+  }
+
+  suspend fun refreshConfig() {
     reloadConfig()
+  }
+
+  suspend fun speakAssistantReply(text: String) {
+    if (!playbackEnabled) return
+    ensureConfigLoaded()
+    if (!playbackEnabled) return
     playAssistant(text)
   }
 
@@ -1372,6 +1385,7 @@ class TalkModeManager(
       reloadConfig()
     }
   }
+
 
   private suspend fun reloadConfig() {
     val envVoice = System.getenv("ELEVENLABS_VOICE_ID")?.trim()


### PR DESCRIPTION
Cherry-pick of upstream [`3daed77ba`](https://github.com/openclaw/openclaw/commit/3daed77ba).

**Author:** Ayaan Zaidi
**Tier:** T3

Unifies speaker gating logic and config refresh in NodeRuntime and TalkModeManager. Adds `configLoaded` flag, `playbackEnabled` volatile, and `ensureConfigLoaded` lazy-load pattern.

Conflict resolution: kept our superset (includes `playbackGeneration`, `ensurePlaybackActive`, `isPlaybackCancelled` from prior cherry-picks). Kept our `fallback`-based error handler with `configLoaded = false` (retry on transient failures) over upstream's `configLoaded = true`.

Depends on #1371
Part of #673