### PR TITLE
Cherry-pick 930e94024: fix(android-voice): cancel in-flight speech when speaker muted

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
@@ -31,6 +31,7 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -438,8 +439,10 @@ class TalkModeManager(
   }
 
   fun setPlaybackEnabled(enabled: Boolean) {
+    if (playbackEnabled == enabled) return
     playbackEnabled = enabled
     if (!enabled) {
+      playbackGeneration += 1
       stopSpeaking()
     }
   }
@@ -450,9 +453,10 @@ class TalkModeManager(
 
   suspend fun speakAssistantReply(text: String) {
     if (!playbackEnabled) return
+    val playbackToken = playbackGeneration
     ensureConfigLoaded()
-    if (!playbackEnabled) return
-    playAssistant(text)
+    ensurePlaybackActive(playbackToken)
+    playAssistant(text, playbackToken)
   }
 
   private fun start() {
@@ -946,7 +950,6 @@ class TalkModeManager(
         Log.w(tag, "system voice failed: ${fallbackErr.message ?: fallbackErr::class.simpleName}")
       }
     } finally {
-
       _isSpeaking.value = false
     }
   }
@@ -1379,6 +1382,7 @@ class TalkModeManager(
     if (err is CancellationException) return true
     return !playbackEnabled || playbackToken != playbackGeneration.get()
   }
+
 
   private suspend fun ensureConfigLoaded() {
     if (!configLoaded) {


### PR DESCRIPTION
Cherry-pick of upstream [`930e94024`](https://github.com/openclaw/openclaw/commit/930e94024).

**Author:** Ayaan Zaidi
**Tier:** T3

Cancels in-flight TTS playback when the speaker is muted. Adds `playbackGeneration` gating and `ensurePlaybackActive` checks around speech operations.

Conflict resolution: kept our `AtomicLong`-based `playbackGeneration` (more thread-safe than upstream's volatile long). Kept our MP3 fallback format rewriting in `streamAndPlay`.

Depends on #1372
Part of #673