### PR TITLE
Cherry-pick 1d7b76a90: fix(android-voice): rotate playback token per assistant reply

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
@@ -442,7 +442,7 @@ class TalkModeManager(
     if (playbackEnabled == enabled) return
     playbackEnabled = enabled
     if (!enabled) {
-      playbackGeneration += 1
+      playbackGeneration.incrementAndGet()
       stopSpeaking()
     }
   }
@@ -453,7 +453,8 @@ class TalkModeManager(
 
   suspend fun speakAssistantReply(text: String) {
     if (!playbackEnabled) return
-    val playbackToken = playbackGeneration
+    val playbackToken = playbackGeneration.incrementAndGet()
+    stopSpeaking(resetInterrupt = false)
     ensureConfigLoaded()
     ensurePlaybackActive(playbackToken)
     playAssistant(text, playbackToken)


### PR DESCRIPTION
Cherry-pick of upstream [`1d7b76a90`](https://github.com/openclaw/openclaw/commit/1d7b76a90).

**Author:** Ayaan Zaidi
**Tier:** T3

Rotates the playback generation token on each `setPlaybackEnabled(false)` call, ensuring stale in-flight speech is properly cancelled when toggling the speaker.

Conflict resolution: import ordering (kept our `CancellationException` import position).

Depends on #1373
Part of #673