### PR TITLE
Cherry-pick 587790e84: fix(android): talk mode stability — thread safety, TTS fallback, mic cooldown

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/MainViewModel.kt
@@ -43,6 +43,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val locationPreciseEnabled: StateFlow<Boolean> = runtime.locationPreciseEnabled
   val preventSleep: StateFlow<Boolean> = runtime.preventSleep
   val micEnabled: StateFlow<Boolean> = runtime.micEnabled
+  val micCooldown: StateFlow<Boolean> = runtime.micCooldown
   val micStatusText: StateFlow<String> = runtime.micStatusText
   val micLiveTranscript: StateFlow<String?> = runtime.micLiveTranscript
   val micIsListening: StateFlow<Boolean> = runtime.micIsListening

--- a/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
@@ -292,8 +292,11 @@ class NodeRuntime(context: Context) {
     MicCaptureManager(
       context = appContext,
       scope = scope,
-      sendToGateway = { message ->
+      sendToGateway = { message, onRunIdKnown ->
         val idempotencyKey = UUID.randomUUID().toString()
+        // Notify MicCaptureManager of the idempotency key *before* the network
+        // call so pendingRunId is set before any chat events can arrive.
+        onRunIdKnown(idempotencyKey)
         val params =
           buildJsonObject {
             put("sessionKey", JsonPrimitive(resolveMainSessionKey()))
@@ -322,6 +325,9 @@ class NodeRuntime(context: Context) {
 
   val micEnabled: StateFlow<Boolean>
     get() = micCapture.micEnabled
+
+  val micCooldown: StateFlow<Boolean>
+    get() = micCapture.micCooldown
 
   val micQueuedMessages: StateFlow<List<String>>
     get() = micCapture.queuedMessages

--- a/apps/android/app/src/main/java/org/remoteclaw/android/ui/VoiceTabScreen.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/ui/VoiceTabScreen.kt
@@ -80,7 +80,9 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
 
   val gatewayStatus by viewModel.statusText.collectAsState()
   val micEnabled by viewModel.micEnabled.collectAsState()
+  val micCooldown by viewModel.micCooldown.collectAsState()
   val speakerEnabled by viewModel.speakerEnabled.collectAsState()
+  val micStatusText by viewModel.micStatusText.collectAsState()
   val micLiveTranscript by viewModel.micLiveTranscript.collectAsState()
   val micQueuedMessages by viewModel.micQueuedMessages.collectAsState()
   val micConversation by viewModel.micConversation.collectAsState()
@@ -240,6 +242,7 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
           }
           Button(
             onClick = {
+              if (micCooldown) return@Button
               if (micEnabled) {
                 viewModel.setMicEnabled(false)
                 return@Button
@@ -251,13 +254,16 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
                 requestMicPermission.launch(Manifest.permission.RECORD_AUDIO)
               }
             },
+            enabled = !micCooldown,
             shape = CircleShape,
             contentPadding = PaddingValues(0.dp),
             modifier = Modifier.size(60.dp),
             colors =
               ButtonDefaults.buttonColors(
-                containerColor = if (micEnabled) mobileDanger else mobileAccent,
+                containerColor = if (micCooldown) mobileTextSecondary else if (micEnabled) mobileDanger else mobileAccent,
                 contentColor = Color.White,
+                disabledContainerColor = mobileTextSecondary,
+                disabledContentColor = Color.White.copy(alpha = 0.5f),
               ),
           ) {
             Icon(
@@ -278,6 +284,7 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
         when {
           queueCount > 0 -> "$queueCount queued"
           micIsSending -> "Sending"
+          micCooldown -> "Cooldown"
           micEnabled -> "Listening"
           else -> "Mic off"
         }

--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/MicCaptureManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/MicCaptureManager.kt
@@ -10,7 +10,6 @@ import android.os.Looper
 import android.speech.RecognitionListener
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
-import android.util.Log
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -26,7 +25,12 @@ import kotlinx.serialization.json.JsonPrimitive
 class MicCaptureManager(
   private val context: Context,
   private val scope: CoroutineScope,
-  private val sendToGateway: suspend (String) -> String?,
+  /**
+   * Send [message] to the gateway and return the run ID.
+   * [onRunIdKnown] is called with the idempotency key *before* the network
+   * round-trip so [pendingRunId] is set before any chat events can arrive.
+   */
+  private val sendToGateway: suspend (message: String, onRunIdKnown: (String) -> Unit) -> String?,
   private val speakAssistantReply: suspend (String) -> Unit = {},
 ) {
   companion object {
@@ -41,6 +45,9 @@ class MicCaptureManager(
 
   private val _micEnabled = MutableStateFlow(false)
   val micEnabled: StateFlow<Boolean> = _micEnabled
+
+  private val _micCooldown = MutableStateFlow(false)
+  val micCooldown: StateFlow<Boolean> = _micCooldown
 
   private val _isListening = MutableStateFlow(false)
   val isListening: StateFlow<Boolean> = _isListening
@@ -68,6 +75,7 @@ class MicCaptureManager(
 
   private var recognizer: SpeechRecognizer? = null
   private var restartJob: Job? = null
+  private var drainJob: Job? = null
   private var stopRequested = false
 
   fun setMicEnabled(enabled: Boolean) {
@@ -76,9 +84,23 @@ class MicCaptureManager(
     if (enabled) {
       start()
     } else {
-      stop()
-      flushSessionToQueue()
-      sendQueuedIfIdle()
+      // Give the recognizer time to finish processing buffered audio.
+      // Cancel any prior drain to prevent duplicate sends on rapid toggle.
+      drainJob?.cancel()
+      _micCooldown.value = true
+      drainJob = scope.launch {
+        delay(2000L)
+        stop()
+        // Capture any partial transcript that didn't get a final result from the recognizer
+        val partial = _liveTranscript.value?.trim().orEmpty()
+        if (partial.isNotEmpty() && sessionSegments.isEmpty()) {
+          sessionSegments.add(partial)
+        }
+        flushSessionToQueue()
+        drainJob = null
+        _micCooldown.value = false
+        sendQueuedIfIdle()
+      }
     }
   }
 
@@ -231,8 +253,13 @@ class MicCaptureManager(
     _statusText.value = "Sending ${messageQueue.size} queued message(s)…"
     scope.launch {
       try {
-        val runId = sendToGateway(next)
-        pendingRunId = runId
+        val runId = sendToGateway(next) { earlyRunId ->
+          // Called with the idempotency key before chat.send fires so that
+          // pendingRunId is populated before any chat events can arrive.
+          pendingRunId = earlyRunId
+        }
+        // Update to the real runId if the gateway returned a different one.
+        if (runId != null && runId != pendingRunId) pendingRunId = runId
         if (runId == null) {
           if (messageQueue.isNotEmpty()) {
             messageQueue.removeFirst()


### PR DESCRIPTION
Cherry-pick of upstream [`587790e84`](https://github.com/openclaw/openclaw/commit/587790e84).

**Author:** Greg Mousseau
**Tier:** T3

Improves talk mode stability: adds mic cooldown state, drain job for mic toggle debouncing, early run ID callback for race-free event matching, and TTS fallback improvements.

Conflict resolution: integrated upstream's `drainJob` and mic cooldown into our simplified MicCaptureManager (which had removed the old timeout/conversation helpers).

Depends on #1375
Part of #673