### PR TITLE
Cherry-pick 930841cd7: fix(android): wire MP3 fallback call, prevent double-speaking

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
@@ -309,7 +309,11 @@ class NodeRuntime(context: Context) {
         parseChatSendRunId(response) ?: idempotencyKey
       },
       speakAssistantReply = { text ->
-        voiceReplySpeaker.speakAssistantReply(text)
+        // Skip if TalkModeManager is handling TTS (ttsOnAllResponses) to avoid
+        // double-speaking the same assistant reply from both pipelines.
+        if (!talkMode.ttsOnAllResponses) {
+          voiceReplySpeaker.speakAssistantReply(text)
+        }
       },
     )
   }


### PR DESCRIPTION
Cherry-pick of upstream [`930841cd7`](https://github.com/openclaw/openclaw/commit/930841cd7).

**Author:** Greg Mousseau
**Tier:** T3

Wires the MP3 fallback call in `NodeRuntime` voice reply speaker and prevents double-speaking by guarding the `speakAssistantReply` callback.

Depends on #1376
Part of #673