### PR TITLE
Cherry-pick ba430cc65: fix(android): drainingTts identity check, mark stopped on WebSocket failure

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/ElevenLabsStreamingTts.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/ElevenLabsStreamingTts.kt
@@ -178,6 +178,7 @@ class ElevenLabsStreamingTts(
 
       override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
         Log.e(TAG, "WebSocket error: ${t.message}")
+        stopped = true
         cleanup()
       }
 


### PR DESCRIPTION
Cherry-pick of upstream commit [`ba430cc65`](https://github.com/openclaw/openclaw/commit/ba430cc65).

**Author:** Greg Mousseau
**Tier:** T3 (Android app)

Fixes drainingTts identity check and marks stopped on WebSocket failure.

Depends on #1379
Part of #673