### PR TITLE
Cherry-pick 6f63fc288: fix(android): return NOT_AUTHORIZED when notify permission is lost

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/SystemHandler.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/SystemHandler.kt
@@ -61,7 +61,7 @@ private class AndroidSystemNotificationPoster(
       ContextCompat.checkSelfPermission(appContext, Manifest.permission.POST_NOTIFICATIONS) !=
       PackageManager.PERMISSION_GRANTED
     ) {
-      return
+      throw SecurityException("notifications permission missing")
     }
     NotificationManagerCompat.from(appContext).notify((System.currentTimeMillis() and 0x7FFFFFFF).toInt(), notification)
   }
@@ -127,6 +127,11 @@ class SystemHandler private constructor(
     return try {
       poster.post(params)
       GatewaySession.InvokeResult.ok(null)
+    } catch (_: SecurityException) {
+      GatewaySession.InvokeResult.error(
+        code = "NOT_AUTHORIZED",
+        message = "NOT_AUTHORIZED: notifications",
+      )
     } catch (err: Throwable) {
       GatewaySession.InvokeResult.error(
         code = "UNAVAILABLE",


### PR DESCRIPTION
Cherry-pick of upstream commit [`6f63fc288`](https://github.com/openclaw/openclaw/commit/6f63fc288).

**Author:** Ayaan Zaidi
**Tier:** T3 (Android app)

Returns NOT_AUTHORIZED when notify permission is lost instead of silently failing.

Depends on #1381
Part of #673