### PR TITLE
Cherry-pick f1bb26642: fix(gateway): scope notification wakeups to session

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/DeviceNotificationListenerService.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/DeviceNotificationListenerService.kt
@@ -137,6 +137,9 @@ class DeviceNotificationListenerService : NotificationListenerService() {
     super.onNotificationPosted(sbn)
     val entry = sbn?.toEntry() ?: return
     DeviceNotificationStore.upsert(entry)
+    if (entry.packageName == packageName) {
+      return
+    }
     emitNotificationsChanged(
       buildJsonObject {
         put("change", JsonPrimitive("posted"))
@@ -162,6 +165,9 @@ class DeviceNotificationListenerService : NotificationListenerService() {
       return
     }
     DeviceNotificationStore.remove(key)
+    if (removed.packageName == packageName) {
+      return
+    }
     emitNotificationsChanged(
       buildJsonObject {
         put("change", JsonPrimitive("removed"))

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -373,7 +373,10 @@ describe("notifications changed events", () => {
       "Notification posted (node=node-n1 key=notif-1 package=com.example.chat): Message - Ping from Alex",
       { sessionKey: "node-node-n1", contextKey: "notification:notif-1" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "notifications-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "notifications-event",
+      sessionKey: "node-node-n1",
+    });
   });
 
   it("enqueues notifications.changed removed events", async () => {
@@ -391,7 +394,27 @@ describe("notifications changed events", () => {
       "Notification removed (node=node-n2 key=notif-2 package=com.example.mail)",
       { sessionKey: "node-node-n2", contextKey: "notification:notif-2" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "notifications-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "notifications-event",
+      sessionKey: "node-node-n2",
+    });
+  });
+
+  it("wakes heartbeat on payload sessionKey when provided", async () => {
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-n4", {
+      event: "notifications.changed",
+      payloadJSON: JSON.stringify({
+        change: "posted",
+        key: "notif-4",
+        sessionKey: "agent:main:main",
+      }),
+    });
+
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "notifications-event",
+      sessionKey: "agent:main:main",
+    });
   });
 
   it("ignores notifications.changed payloads missing required fields", async () => {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -480,7 +480,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       }
 
       enqueueSystemEvent(summary, { sessionKey, contextKey: `notification:${key}` });
-      requestHeartbeatNow({ reason: "notifications-event" });
+      requestHeartbeatNow({ reason: "notifications-event", sessionKey });
       return;
     }
     case "chat.subscribe": {


### PR DESCRIPTION
Cherry-pick of upstream commit [`f1bb26642`](https://github.com/openclaw/openclaw/commit/f1bb26642).

**Author:** Ayaan Zaidi
**Tier:** T2 (gateway) + T3 (Android app)

Scopes notification wakeups to the session to prevent cross-session interference.

Depends on #1383
Part of #673