### PR TITLE
Cherry-pick 68db055f1: feat(android): wire TalkModeManager into NodeRuntime for voice screen TTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ dist/protocol.schema.json
 # Synthing
 **/.stfolder/
 .dev-state
+apps/android/.kotlin/

--- a/apps/android/app/src/main/java/org/remoteclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/MainViewModel.kt
@@ -125,6 +125,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     runtime.setCanvasDebugStatusEnabled(value)
   }
 
+  fun setVoiceScreenActive(active: Boolean) {
+    runtime.setVoiceScreenActive(active)
+  }
+
   fun setMicEnabled(enabled: Boolean) {
     runtime.setMicEnabled(enabled)
   }

--- a/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/NodeRuntime.kt
@@ -350,11 +350,22 @@ class NodeRuntime(context: Context) {
   val micIsSending: StateFlow<Boolean>
     get() = micCapture.isSending
 
+  private val talkMode: TalkModeManager by lazy {
+    TalkModeManager(
+      context = appContext,
+      scope = scope,
+      session = operatorSession,
+      supportsChatSubscribe = true,
+      isConnected = { operatorConnected },
+    )
+  }
+
   private fun applyMainSessionKey(candidate: String?) {
     val trimmed = normalizeMainKey(candidate) ?: return
     if (isCanonicalMainSessionKey(_mainSessionKey.value)) return
     if (_mainSessionKey.value == trimmed) return
     _mainSessionKey.value = trimmed
+    talkMode.setMainSessionKey(trimmed)
     chat.applyMainSessionKey(trimmed)
   }
 
@@ -486,7 +497,14 @@ class NodeRuntime(context: Context) {
 
     scope.launch {
       prefs.talkEnabled.collect { enabled ->
+        // MicCaptureManager handles STT + send to gateway.
+        // TalkModeManager plays TTS on assistant responses.
         micCapture.setMicEnabled(enabled)
+        if (enabled) {
+          // Mic on = user is on voice screen and wants TTS responses.
+          talkMode.ttsOnAllResponses = true
+          scope.launch { talkMode.ensureChatSubscribed() }
+        }
         externalAudioCaptureActive.value = enabled
       }
     }
@@ -597,8 +615,25 @@ class NodeRuntime(context: Context) {
     prefs.setCanvasDebugStatusEnabled(value)
   }
 
+  fun setVoiceScreenActive(active: Boolean) {
+    if (!active) {
+      // User left voice screen — stop mic and TTS
+      talkMode.ttsOnAllResponses = false
+      talkMode.stopTts()
+      micCapture.setMicEnabled(false)
+      prefs.setTalkEnabled(false)
+    }
+    // Don't re-enable on active=true; mic toggle drives that
+  }
+
   fun setMicEnabled(value: Boolean) {
     prefs.setTalkEnabled(value)
+    if (value) {
+      // Tapping mic on interrupts any active TTS (barge-in)
+      talkMode.stopTts()
+      talkMode.ttsOnAllResponses = true
+      scope.launch { talkMode.ensureChatSubscribed() }
+    }
     micCapture.setMicEnabled(value)
     externalAudioCaptureActive.value = value
   }
@@ -791,6 +826,7 @@ class NodeRuntime(context: Context) {
 
   private fun handleGatewayEvent(event: String, payloadJson: String?) {
     micCapture.handleGatewayEvent(event, payloadJson)
+    talkMode.handleGatewayEvent(event, payloadJson)
     chat.handleGatewayEvent(event, payloadJson)
   }
 

--- a/apps/android/app/src/main/java/org/remoteclaw/android/ui/PostOnboardingTabs.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/ui/PostOnboardingTabs.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -67,6 +68,11 @@ private enum class StatusVisual {
 @Composable
 fun PostOnboardingTabs(viewModel: MainViewModel, modifier: Modifier = Modifier) {
   var activeTab by rememberSaveable { mutableStateOf(HomeTab.Connect) }
+
+  // Stop TTS when user navigates away from voice tab
+  LaunchedEffect(activeTab) {
+    viewModel.setVoiceScreenActive(activeTab == HomeTab.Voice)
+  }
 
   val statusText by viewModel.statusText.collectAsState()
   val isConnected by viewModel.isConnected.collectAsState()

--- a/apps/android/app/src/main/java/org/remoteclaw/android/ui/VoiceTabScreen.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/ui/VoiceTabScreen.kt
@@ -103,7 +103,11 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
         }
       }
     lifecycleOwner.lifecycle.addObserver(observer)
-    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    onDispose {
+      lifecycleOwner.lifecycle.removeObserver(observer)
+      // Stop TTS when leaving the voice screen
+      viewModel.setVoiceScreenActive(false)
+    }
   }
 
   val requestMicPermission =

--- a/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/voice/TalkModeManager.kt
@@ -31,7 +31,6 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -421,28 +420,6 @@ class TalkModeManager(
     if (!enabled) {
       playbackGeneration.incrementAndGet()
       stopActiveStreamingTts()
-      stopSpeaking()
-    }
-  }
-
-  suspend fun refreshConfig() {
-    reloadConfig()
-  }
-
-  suspend fun speakAssistantReply(text: String) {
-    if (!playbackEnabled) return
-    val playbackToken = playbackGeneration.incrementAndGet()
-    stopSpeaking(resetInterrupt = false)
-    ensureConfigLoaded()
-    ensurePlaybackActive(playbackToken)
-    playAssistant(text, playbackToken)
-  }
-
-  fun setPlaybackEnabled(enabled: Boolean) {
-    if (playbackEnabled == enabled) return
-    playbackEnabled = enabled
-    if (!enabled) {
-      playbackGeneration.incrementAndGet()
       stopSpeaking()
     }
   }


### PR DESCRIPTION
Cherry-pick of upstream commit [`68db055f1`](https://github.com/openclaw/openclaw/commit/68db055f1).

**Author:** Greg Mousseau
**Tier:** T3 (Android app)

Wires TalkModeManager into NodeRuntime for voice screen TTS. TalkModeManager is instantiated lazily and drives ElevenLabs streaming TTS for all assistant responses when the voice screen is active.

Conflicts resolved:
- `.gitignore`: added `apps/android/.kotlin/` alongside existing `.dev-state`
- `TalkModeManager.kt`: resolved rebrand conflicts (imports, naming) and removed duplicate methods that were already present from earlier cherry-picks

Depends on #1384
Part of #673