### PR TITLE
Cherry-pick 7f9274b71: chore(android): add kotlin lint/format tooling

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -9,14 +9,14 @@ Status: **extremely alpha**. The app is actively being rebuilt from the ground u
 - [x] Encrypted persistence for gateway setup/auth state
 - [x] Chat UI restyled
 - [x] Settings UI restyled and de-duplicated (gateway controls moved to Connect)
-- [ ] QR code scanning in onboarding
-- [ ] Performance improvements
-- [ ] Streaming support in chat UI
-- [ ] Request camera/location and other permissions in onboarding/settings flow
-- [ ] Push notifications for gateway/chat status updates
-- [ ] Security hardening (biometric lock, token handling, safer defaults)
-- [ ] Voice tab full functionality
-- [ ] Screen tab full functionality
+- [x] QR code scanning in onboarding
+- [x] Performance improvements
+- [x] Streaming support in chat UI
+- [x] Request camera/location and other permissions in onboarding/settings flow
+- [x] Push notifications for gateway/chat status updates
+- [x] Security hardening (biometric lock, token handling, safer defaults)
+- [x] Voice tab full functionality
+- [x] Screen tab full functionality
 - [ ] Full end-to-end QA and release hardening
 
 ## Open in Android Studio
@@ -30,6 +30,28 @@ cd apps/android
 ./gradlew :app:assembleDebug
 ./gradlew :app:installDebug
 ./gradlew :app:testDebugUnitTest
+```
+
+## Kotlin Lint + Format
+
+```bash
+pnpm android:lint
+pnpm android:format
+```
+
+Android framework/resource lint (separate pass):
+
+```bash
+pnpm android:lint:android
+```
+
+Direct Gradle tasks:
+
+```bash
+cd apps/android
+./gradlew :app:ktlintCheck :benchmark:ktlintCheck
+./gradlew :app:ktlintFormat :benchmark:ktlintFormat
+./gradlew :app:lintDebug
 ```
 
 `gradlew` auto-detects the Android SDK at `~/Library/Android/sdk` (macOS default) if `ANDROID_SDK_ROOT` / `ANDROID_HOME` are unset.

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -2,6 +2,7 @@ import com.android.build.api.variant.impl.VariantOutputImpl
 
 plugins {
   id("com.android.application")
+  id("org.jlleitschuh.gradle.ktlint")
   id("org.jetbrains.kotlin.plugin.compose")
   id("org.jetbrains.kotlin.plugin.serialization")
 }
@@ -92,6 +93,15 @@ kotlin {
   compilerOptions {
     jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     allWarningsAsErrors.set(true)
+  }
+}
+
+ktlint {
+  android.set(true)
+  ignoreFailures.set(false)
+  filter {
+    exclude("**/build/**")
+    exclude("**/*.kts")
   }
 }
 

--- a/apps/android/build.gradle.kts
+++ b/apps/android/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("com.android.application") version "9.0.1" apply false
+  id("org.jlleitschuh.gradle.ktlint") version "14.0.1" apply false
   id("org.jetbrains.kotlin.plugin.compose") version "2.2.21" apply false
   id("org.jetbrains.kotlin.plugin.serialization") version "2.2.21" apply false
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,10 @@
   },
   "scripts": {
     "android:assemble": "cd apps/android && ./gradlew :app:assembleDebug",
+    "android:format": "cd apps/android && ./gradlew :app:ktlintFormat",
     "android:install": "cd apps/android && ./gradlew :app:installDebug",
+    "android:lint": "cd apps/android && ./gradlew :app:ktlintCheck",
+    "android:lint:android": "cd apps/android && ./gradlew :app:lintDebug",
     "android:run": "cd apps/android && ./gradlew :app:installDebug && adb shell am start -n org.remoteclaw.android/.MainActivity",
     "android:test": "cd apps/android && ./gradlew :app:testDebugUnitTest",
     "build": "pnpm canvas:a2ui:bundle && tsdown && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-export-html-templates.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-compat.ts",


### PR DESCRIPTION
Cherry-pick of upstream commit [`7f9274b71`](https://github.com/openclaw/openclaw/commit/7f9274b71).

**Author:** Ayaan Zaidi
**Tier:** T3 (Android app)

Adds kotlin lint/format tooling (ktlint) to the Android app.

Conflicts resolved:
- `apps/android/benchmark/build.gradle.kts`: removed (benchmark deleted in fork)
- `apps/android/build.gradle.kts`: added ktlint plugin without com.android.test (benchmark deleted)
- `package.json`: added format/lint scripts without benchmark references, kept rebranded package name

Depends on #1386
Part of #673