### PR TITLE
Cherry-pick 9c2f7e2a9: style(android): format gradle kotlin scripts

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -1,166 +1,167 @@
 import com.android.build.api.variant.impl.VariantOutputImpl
 
 plugins {
-  id("com.android.application")
-  id("org.jlleitschuh.gradle.ktlint")
-  id("org.jetbrains.kotlin.plugin.compose")
-  id("org.jetbrains.kotlin.plugin.serialization")
+    id("com.android.application")
+    id("org.jlleitschuh.gradle.ktlint")
+    id("org.jetbrains.kotlin.plugin.compose")
+    id("org.jetbrains.kotlin.plugin.serialization")
 }
 
 android {
-  namespace = "org.remoteclaw.android"
-  compileSdk = 36
+    namespace = "org.remoteclaw.android"
+    compileSdk = 36
 
-  sourceSets {
-    getByName("main") {
-      assets.directories.add("../../shared/RemoteClawKit/Sources/RemoteClawKit/Resources")
+    sourceSets {
+        getByName("main") {
+            assets.directories.add("../../shared/RemoteClawKit/Sources/RemoteClawKit/Resources")
+        }
     }
-  }
 
-  defaultConfig {
-    applicationId = "org.remoteclaw.android"
-    minSdk = 31
-    targetSdk = 36
-    versionCode = 1
-    versionName = "0.1.0"
-    ndk {
-      // Support all major ABIs — native libs are tiny (~47 KB per ABI)
-      abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+    defaultConfig {
+        applicationId = "org.remoteclaw.android"
+        minSdk = 31
+        targetSdk = 36
+        versionCode = 202602270
+        versionName = "2026.2.27"
+        ndk {
+            // Support all major ABIs — native libs are tiny (~47 KB per ABI)
+            abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+        }
     }
-  }
 
-  buildTypes {
-    release {
-      isMinifyEnabled = true
-      isShrinkResources = true
-      proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+        debug {
+            isMinifyEnabled = false
+        }
     }
-    debug {
-      isMinifyEnabled = false
+
+    buildFeatures {
+        compose = true
+        buildConfig = true
     }
-  }
 
-  buildFeatures {
-    compose = true
-    buildConfig = true
-  }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
-
-  packaging {
-    resources {
-      excludes += setOf(
-        "/META-INF/{AL2.0,LGPL2.1}",
-        "/META-INF/*.version",
-        "/META-INF/LICENSE*.txt",
-        "DebugProbesKt.bin",
-        "kotlin-tooling-metadata.json",
-      )
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
-  }
 
-  lint {
-    disable += setOf(
-      "GradleDependency",
-      "IconLauncherShape",
-      "NewerVersionAvailable",
-    )
-    warningsAsErrors = true
-  }
+    packaging {
+        resources {
+            excludes +=
+                setOf(
+                    "/META-INF/{AL2.0,LGPL2.1}",
+                    "/META-INF/*.version",
+                    "/META-INF/LICENSE*.txt",
+                    "DebugProbesKt.bin",
+                    "kotlin-tooling-metadata.json",
+                )
+        }
+    }
 
-  testOptions {
-    unitTests.isIncludeAndroidResources = true
-  }
+    lint {
+        disable +=
+            setOf(
+                "GradleDependency",
+                "IconLauncherShape",
+                "NewerVersionAvailable",
+            )
+        warningsAsErrors = true
+    }
+
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+    }
 }
 
 androidComponents {
-  onVariants { variant ->
-    variant.outputs
-      .filterIsInstance<VariantOutputImpl>()
-      .forEach { output ->
-        val versionName = output.versionName.orNull ?: "0"
-        val buildType = variant.buildType
+    onVariants { variant ->
+        variant.outputs
+            .filterIsInstance<VariantOutputImpl>()
+            .forEach { output ->
+                val versionName = output.versionName.orNull ?: "0"
+                val buildType = variant.buildType
 
-        val outputFileName = "remoteclaw-${versionName}-${buildType}.apk"
-        output.outputFileName = outputFileName
-      }
-  }
+                val outputFileName = "remoteclaw-$versionName-$buildType.apk"
+                output.outputFileName = outputFileName
+            }
+    }
 }
 kotlin {
-  compilerOptions {
-    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-    allWarningsAsErrors.set(true)
-  }
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        allWarningsAsErrors.set(true)
+    }
 }
 
 ktlint {
-  android.set(true)
-  ignoreFailures.set(false)
-  filter {
-    exclude("**/build/**")
-    exclude("**/*.kts")
-  }
+    android.set(true)
+    ignoreFailures.set(false)
+    filter {
+        exclude("**/build/**")
+    }
 }
 
 dependencies {
-  val composeBom = platform("androidx.compose:compose-bom:2026.02.00")
-  implementation(composeBom)
-  androidTestImplementation(composeBom)
+    val composeBom = platform("androidx.compose:compose-bom:2026.02.00")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
 
-  implementation("androidx.core:core-ktx:1.17.0")
-  implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.10.0")
-  implementation("androidx.activity:activity-compose:1.12.2")
-  implementation("androidx.webkit:webkit:1.15.0")
+    implementation("androidx.core:core-ktx:1.17.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.10.0")
+    implementation("androidx.activity:activity-compose:1.12.2")
+    implementation("androidx.webkit:webkit:1.15.0")
 
-  implementation("androidx.compose.ui:ui")
-  implementation("androidx.compose.ui:ui-tooling-preview")
-  implementation("androidx.compose.material3:material3")
-  // material-icons-extended pulled in full icon set (~20 MB DEX). Only ~18 icons used.
-  // R8 will tree-shake unused icons when minify is enabled on release builds.
-  implementation("androidx.compose.material:material-icons-extended")
-  implementation("androidx.navigation:navigation-compose:2.9.7")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    // material-icons-extended pulled in full icon set (~20 MB DEX). Only ~18 icons used.
+    // R8 will tree-shake unused icons when minify is enabled on release builds.
+    implementation("androidx.compose.material:material-icons-extended")
+    implementation("androidx.navigation:navigation-compose:2.9.7")
 
-  debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-tooling")
 
-  // Material Components (XML theme + resources)
-  implementation("com.google.android.material:material:1.13.0")
+    // Material Components (XML theme + resources)
+    implementation("com.google.android.material:material:1.13.0")
 
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
-  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
 
-  implementation("androidx.security:security-crypto:1.1.0")
-  implementation("androidx.exifinterface:exifinterface:1.4.2")
-  implementation("com.squareup.okhttp3:okhttp:5.3.2")
-  implementation("org.bouncycastle:bcprov-jdk18on:1.83")
-  implementation("org.commonmark:commonmark:0.27.1")
-  implementation("org.commonmark:commonmark-ext-autolink:0.27.1")
-  implementation("org.commonmark:commonmark-ext-gfm-strikethrough:0.27.1")
-  implementation("org.commonmark:commonmark-ext-gfm-tables:0.27.1")
-  implementation("org.commonmark:commonmark-ext-task-list-items:0.27.1")
+    implementation("androidx.security:security-crypto:1.1.0")
+    implementation("androidx.exifinterface:exifinterface:1.4.2")
+    implementation("com.squareup.okhttp3:okhttp:5.3.2")
+    implementation("org.bouncycastle:bcprov-jdk18on:1.83")
+    implementation("org.commonmark:commonmark:0.27.1")
+    implementation("org.commonmark:commonmark-ext-autolink:0.27.1")
+    implementation("org.commonmark:commonmark-ext-gfm-strikethrough:0.27.1")
+    implementation("org.commonmark:commonmark-ext-gfm-tables:0.27.1")
+    implementation("org.commonmark:commonmark-ext-task-list-items:0.27.1")
 
-  // CameraX (for node.invoke camera.* parity)
-  implementation("androidx.camera:camera-core:1.5.2")
-  implementation("androidx.camera:camera-camera2:1.5.2")
-  implementation("androidx.camera:camera-lifecycle:1.5.2")
-  implementation("androidx.camera:camera-video:1.5.2")
-  implementation("androidx.camera:camera-view:1.5.2")
-  implementation("com.journeyapps:zxing-android-embedded:4.3.0")
+    // CameraX (for node.invoke camera.* parity)
+    implementation("androidx.camera:camera-core:1.5.2")
+    implementation("androidx.camera:camera-camera2:1.5.2")
+    implementation("androidx.camera:camera-lifecycle:1.5.2")
+    implementation("androidx.camera:camera-video:1.5.2")
+    implementation("androidx.camera:camera-view:1.5.2")
+    implementation("com.journeyapps:zxing-android-embedded:4.3.0")
 
-  // Unicast DNS-SD (Wide-Area Bonjour) for tailnet discovery domains.
-  implementation("dnsjava:dnsjava:3.6.4")
+    // Unicast DNS-SD (Wide-Area Bonjour) for tailnet discovery domains.
+    implementation("dnsjava:dnsjava:3.6.4")
 
-  testImplementation("junit:junit:4.13.2")
-  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
-  testImplementation("io.kotest:kotest-runner-junit5-jvm:6.1.3")
-  testImplementation("io.kotest:kotest-assertions-core-jvm:6.1.3")
-  testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")
-  testImplementation("org.robolectric:robolectric:4.16.1")
-  testRuntimeOnly("org.junit.vintage:junit-vintage-engine:6.0.2")
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:6.1.3")
+    testImplementation("io.kotest:kotest-assertions-core-jvm:6.1.3")
+    testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")
+    testImplementation("org.robolectric:robolectric:4.16.1")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:6.0.2")
 }
 
 tasks.withType<Test>().configureEach {
-  useJUnitPlatform()
+    useJUnitPlatform()
 }


### PR DESCRIPTION
Cherry-pick of upstream commit [`9c2f7e2a9`](https://github.com/openclaw/openclaw/commit/9c2f7e2a9).

**Author:** Ayaan Zaidi
**Tier:** T3 (Android app)

Formats gradle kotlin scripts using ktlint conventions.

Conflicts resolved:
- `apps/android/app/build.gradle.kts`: took upstream formatting, applied rebrand
- `apps/android/benchmark/build.gradle.kts`: removed (deleted in fork)

Depends on #1387
Part of #673