### PR TITLE
Cherry-pick d123ade0c: fix(gateway): allow required Google Fonts origins in Control UI CSP

### DIFF
--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -7,6 +7,12 @@ describe("buildControlUiCspHeader", () => {
     expect(csp).toContain("frame-ancestors 'none'");
     expect(csp).toContain("script-src 'self'");
     expect(csp).not.toContain("script-src 'self' 'unsafe-inline'");
-    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com");
+  });
+
+  it("allows Google Fonts for style and font loading", () => {
+    const csp = buildControlUiCspHeader();
+    expect(csp).toContain("https://fonts.googleapis.com");
+    expect(csp).toContain("font-src 'self' https://fonts.gstatic.com");
   });
 });

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -1,15 +1,17 @@
 export function buildControlUiCspHeader(): string {
   // Control UI: block framing, block inline scripts, keep styles permissive
   // (UI uses a lot of inline style attributes in templates).
+  // Keep Google Fonts origins explicit in CSP for deployments that load
+  // external Google Fonts stylesheets/font files.
   return [
     "default-src 'self'",
     "base-uri 'none'",
     "object-src 'none'",
     "frame-ancestors 'none'",
     "script-src 'self'",
-    "style-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https:",
-    "font-src 'self'",
+    "font-src 'self' https://fonts.gstatic.com",
     "connect-src 'self' ws: wss:",
   ].join("; ");
 }


### PR DESCRIPTION
Cherry-pick of upstream commit [`d123ade0c`](https://github.com/openclaw/openclaw/commit/d123ade0c).

**Author**: Vincent Koc
**Category**: Gateway fix

Adds Google Fonts origins to Control UI CSP to allow proper font loading.

Part of #674.