### PR TITLE
Cherry-pick 39a45121d: fix SSRF policy for media downloads

### DIFF
--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -2,8 +2,14 @@ import type { ChannelType, Client, Message } from "@buape/carbon";
 import { StickerFormatType, type APIAttachment, type APIStickerItem } from "discord-api-types/v10";
 import { buildMediaPayload } from "../../channels/plugins/media-payload.js";
 import { logVerbose } from "../../globals.js";
+import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { fetchRemoteMedia, type FetchLike } from "../../media/fetch.js";
 import { saveMediaBuffer } from "../../media/store.js";
+
+const DISCORD_MEDIA_SSRF_POLICY: SsrFPolicy = {
+  allowedHostnames: ["cdn.discordapp.com", "media.discordapp.net"],
+  allowRfc2544BenchmarkRange: true,
+};
 
 export type DiscordMediaInfo = {
   path: string;
@@ -228,6 +234,7 @@ async function appendResolvedMediaFromAttachments(params: {
         filePathHint: attachment.filename ?? attachment.url,
         maxBytes: params.maxBytes,
         fetchImpl: params.fetchImpl,
+        ssrfPolicy: DISCORD_MEDIA_SSRF_POLICY,
       });
       const saved = await saveMediaBuffer(
         fetched.buffer,
@@ -320,6 +327,7 @@ async function appendResolvedMediaFromStickers(params: {
           filePathHint: candidate.fileName,
           maxBytes: params.maxBytes,
           fetchImpl: params.fetchImpl,
+          ssrfPolicy: DISCORD_MEDIA_SSRF_POLICY,
         });
         const saved = await saveMediaBuffer(
           fetched.buffer,

--- a/src/slack/monitor/media.test.ts
+++ b/src/slack/monitor/media.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as ssrf from "../../infra/net/ssrf.js";
+import * as mediaFetch from "../../media/fetch.js";
 import type { SavedMedia } from "../../media/store.js";
 import * as mediaStore from "../../media/store.js";
 import { mockPinnedHostnameResolution } from "../../test-helpers/ssrf.js";
@@ -423,6 +424,80 @@ describe("resolveSlackMedia", () => {
     expect(result).toHaveLength(8);
     expect(saveMediaBufferMock).toHaveBeenCalledTimes(8);
     expect(mockFetch).toHaveBeenCalledTimes(8);
+  });
+});
+
+describe("Slack media SSRF policy", () => {
+  const originalFetchLocal = globalThis.fetch;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    globalThis.fetch = withFetchPreconnect(mockFetch);
+    mockPinnedHostnameResolution();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetchLocal;
+    vi.restoreAllMocks();
+  });
+
+  it("passes ssrfPolicy with Slack CDN allowedHostnames and allowRfc2544BenchmarkRange to file downloads", async () => {
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue(
+      createSavedMedia("/tmp/test.jpg", "image/jpeg"),
+    );
+    mockFetch.mockResolvedValueOnce(
+      new Response(Buffer.from("img"), { status: 200, headers: { "content-type": "image/jpeg" } }),
+    );
+
+    const spy = vi.spyOn(mediaFetch, "fetchRemoteMedia");
+
+    await resolveSlackMedia({
+      files: [{ url_private: "https://files.slack.com/test.jpg", name: "test.jpg" }],
+      token: "xoxb-test-token",
+      maxBytes: 1024,
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ssrfPolicy: expect.objectContaining({ allowRfc2544BenchmarkRange: true }),
+      }),
+    );
+
+    const policy = spy.mock.calls[0][0].ssrfPolicy;
+    expect(policy?.allowedHostnames).toEqual(
+      expect.arrayContaining(["*.slack.com", "*.slack-edge.com", "*.slack-files.com"]),
+    );
+  });
+
+  it("passes ssrfPolicy to forwarded attachment image downloads", async () => {
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue(
+      createSavedMedia("/tmp/fwd.jpg", "image/jpeg"),
+    );
+    vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockImplementation(async (hostname) => {
+      const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
+      return {
+        hostname: normalized,
+        addresses: ["93.184.216.34"],
+        lookup: ssrf.createPinnedLookup({ hostname: normalized, addresses: ["93.184.216.34"] }),
+      };
+    });
+    mockFetch.mockResolvedValueOnce(
+      new Response(Buffer.from("fwd"), { status: 200, headers: { "content-type": "image/jpeg" } }),
+    );
+
+    const spy = vi.spyOn(mediaFetch, "fetchRemoteMedia");
+
+    await resolveSlackAttachmentContent({
+      attachments: [{ is_share: true, image_url: "https://files.slack.com/forwarded.jpg" }],
+      token: "xoxb-test-token",
+      maxBytes: 1024,
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ssrfPolicy: expect.objectContaining({ allowRfc2544BenchmarkRange: true }),
+      }),
+    );
   });
 });
 

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -108,6 +108,11 @@ export async function fetchWithSlackAuth(url: string, token: string): Promise<Re
   return fetch(resolvedUrl.toString(), { redirect: "follow" });
 }
 
+const SLACK_MEDIA_SSRF_POLICY = {
+  allowedHostnames: ["*.slack.com", "*.slack-edge.com", "*.slack-files.com"],
+  allowRfc2544BenchmarkRange: true,
+};
+
 /**
  * Slack voice messages (audio clips, huddle recordings) carry a `subtype` of
  * `"slack_audio"` but are served with a `video/*` MIME type (e.g. `video/mp4`,
@@ -213,6 +218,7 @@ export async function resolveSlackMedia(params: {
           fetchImpl,
           filePathHint: file.name,
           maxBytes: params.maxBytes,
+          ssrfPolicy: SLACK_MEDIA_SSRF_POLICY,
         });
         if (fetched.buffer.byteLength > params.maxBytes) {
           return null;
@@ -276,6 +282,7 @@ export async function resolveSlackAttachmentContent(params: {
         const fetched = await fetchRemoteMedia({
           url: imageUrl,
           maxBytes: params.maxBytes,
+          ssrfPolicy: SLACK_MEDIA_SSRF_POLICY,
         });
         if (fetched.buffer.byteLength <= params.maxBytes) {
           const saved = await saveMediaBuffer(


### PR DESCRIPTION
Cherry-pick of upstream [`39a45121d`](https://github.com/openclaw/openclaw/commit/39a45121d9b672efe0ddee9255e5ae4e869a01f7).

**Author**: [Sid-Qin](https://github.com/Sid-Qin)

**Upstream PR**: openclaw/openclaw#25475

## Summary

- Add SSRF policy for media downloads in Discord and Slack proxy environments
- Prevents server-side request forgery when fetching media through proxy

Depends on #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)