### PR TITLE
Cherry-pick 5056b6438: fix Discord reconnect recovery

### DIFF
--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -88,16 +88,7 @@ describe("DiscordMessageListener", () => {
     };
   }
 
-  async function expectPending(promise: Promise<unknown>) {
-    let resolved = false;
-    void promise.then(() => {
-      resolved = true;
-    });
-    await Promise.resolve();
-    expect(resolved).toBe(false);
-  }
-
-  it("awaits the handler before returning", async () => {
+  it("returns immediately while handler continues in background", async () => {
     let handlerResolved = false;
     const deferred = createDeferred();
     const handler = vi.fn(async () => {
@@ -111,17 +102,54 @@ describe("DiscordMessageListener", () => {
       {} as unknown as import("@buape/carbon").Client,
     );
 
-    // Handler should be called but not yet resolved
-    expect(handler).toHaveBeenCalledOnce();
+    // handle() returns immediately while the background queue starts on the next tick.
+    await expect(handlePromise).resolves.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledOnce();
+    });
     expect(handlerResolved).toBe(false);
-    await expectPending(handlePromise);
 
-    // Release the handler
+    // Release and let background handler finish.
     deferred.resolve();
-
-    // Now await handle() - it should complete only after handler resolves
-    await handlePromise;
+    await Promise.resolve();
     expect(handlerResolved).toBe(true);
+  });
+
+  it("queues subsequent events until prior message handling completes", async () => {
+    const first = createDeferred();
+    const second = createDeferred();
+    let runCount = 0;
+    const handler = vi.fn(async () => {
+      runCount += 1;
+      if (runCount === 1) {
+        await first.promise;
+        return;
+      }
+      await second.promise;
+    });
+    const listener = new DiscordMessageListener(handler);
+
+    await expect(
+      listener.handle(
+        {} as unknown as import("./monitor/listeners.js").DiscordMessageEvent,
+        {} as unknown as import("@buape/carbon").Client,
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      listener.handle(
+        {} as unknown as import("./monitor/listeners.js").DiscordMessageEvent,
+        {} as unknown as import("@buape/carbon").Client,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    first.resolve();
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    second.resolve();
+    await Promise.resolve();
   });
 
   it("logs handler failures", async () => {
@@ -138,9 +166,9 @@ describe("DiscordMessageListener", () => {
       {} as unknown as import("./monitor/listeners.js").DiscordMessageEvent,
       {} as unknown as import("@buape/carbon").Client,
     );
-    await Promise.resolve();
-
-    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("discord handler failed"));
+    await vi.waitFor(() => {
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("discord handler failed"));
+    });
   });
 
   it("logs slow handlers after the threshold", async () => {
@@ -156,21 +184,20 @@ describe("DiscordMessageListener", () => {
       } as unknown as ReturnType<typeof import("../logging/subsystem.js").createSubsystemLogger>;
       const listener = new DiscordMessageListener(handler, logger);
 
-      // Start handle() but don't await yet
+      // handle() should release immediately.
       const handlePromise = listener.handle(
         {} as unknown as import("./monitor/listeners.js").DiscordMessageEvent,
         {} as unknown as import("@buape/carbon").Client,
       );
-      await expectPending(handlePromise);
+      await expect(handlePromise).resolves.toBeUndefined();
+      expect(logger.warn).not.toHaveBeenCalled();
 
-      // Advance time past the slow listener threshold
+      // Advance wall clock past the slow listener threshold.
       vi.setSystemTime(31_000);
 
-      // Release the handler
+      // Release the background handler and allow slow-log finalizer to run.
       deferred.resolve();
-
-      // Now await handle() - it should complete and log the slow listener
-      await handlePromise;
+      await Promise.resolve();
 
       expect(logger.warn).toHaveBeenCalled();
       const warnMock = logger.warn as unknown as { mock: { calls: unknown[][] } };

--- a/src/discord/monitor/listeners.test.ts
+++ b/src/discord/monitor/listeners.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { DiscordMessageListener } from "./listeners.js";
+
+function createLogger() {
+  return {
+    error: vi.fn(),
+    warn: vi.fn(),
+  };
+}
+
+describe("DiscordMessageListener", () => {
+  it("returns immediately without awaiting handler completion", async () => {
+    let resolveHandler: (() => void) | undefined;
+    const handlerDone = new Promise<void>((resolve) => {
+      resolveHandler = resolve;
+    });
+    const handler = vi.fn(async () => {
+      await handlerDone;
+    });
+    const logger = createLogger();
+    const listener = new DiscordMessageListener(handler as never, logger as never);
+
+    await expect(listener.handle({} as never, {} as never)).resolves.toBeUndefined();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+
+    resolveHandler?.();
+    await handlerDone;
+  });
+
+  it("serializes queued handler runs while handle returns immediately", async () => {
+    let firstResolve: (() => void) | undefined;
+    let secondResolve: (() => void) | undefined;
+    const firstDone = new Promise<void>((resolve) => {
+      firstResolve = resolve;
+    });
+    const secondDone = new Promise<void>((resolve) => {
+      secondResolve = resolve;
+    });
+    let runCount = 0;
+    const handler = vi.fn(async () => {
+      runCount += 1;
+      if (runCount === 1) {
+        await firstDone;
+        return;
+      }
+      await secondDone;
+    });
+    const listener = new DiscordMessageListener(handler as never, createLogger() as never);
+
+    await expect(listener.handle({} as never, {} as never)).resolves.toBeUndefined();
+    await expect(listener.handle({} as never, {} as never)).resolves.toBeUndefined();
+
+    // Second event is queued until the first handler run settles.
+    expect(handler).toHaveBeenCalledTimes(1);
+    firstResolve?.();
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    secondResolve?.();
+    await secondDone;
+  });
+
+  it("logs async handler failures", async () => {
+    const handler = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const logger = createLogger();
+    const listener = new DiscordMessageListener(handler as never, logger as never);
+
+    await expect(listener.handle({} as never, {} as never)).resolves.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("discord handler failed: Error: boom"),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Cherry-pick of upstream [`5056b6438`](https://github.com/openclaw/openclaw/commit/5056b6438de58ccf6d463653d673518244c3d31a).

**Author**: [steipete](https://github.com/steipete)

## Summary

- Harden Discord reconnect recovery and preserve message delivery
- Improve gateway lifecycle handling during reconnection events

Depends on #1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)