### PR TITLE
refactor(discord): unify DM command auth handling

### DIFF
--- a/src/discord/monitor/dm-command-decision.ts
+++ b/src/discord/monitor/dm-command-decision.ts
@@ -1,0 +1,39 @@
+import { upsertChannelPairingRequest } from "../../pairing/pairing-store.js";
+import type { DiscordDmCommandAccess } from "./dm-command-auth.js";
+
+export async function handleDiscordDmCommandDecision(params: {
+  dmAccess: DiscordDmCommandAccess;
+  accountId: string;
+  sender: {
+    id: string;
+    tag?: string;
+    name?: string;
+  };
+  onPairingCreated: (code: string) => Promise<void>;
+  onUnauthorized: () => Promise<void>;
+  upsertPairingRequest?: typeof upsertChannelPairingRequest;
+}): Promise<boolean> {
+  if (params.dmAccess.decision === "allow") {
+    return true;
+  }
+
+  if (params.dmAccess.decision === "pairing") {
+    const upsertPairingRequest = params.upsertPairingRequest ?? upsertChannelPairingRequest;
+    const { code, created } = await upsertPairingRequest({
+      channel: "discord",
+      id: params.sender.id,
+      accountId: params.accountId,
+      meta: {
+        tag: params.sender.tag,
+        name: params.sender.name,
+      },
+    });
+    if (created) {
+      await params.onPairingCreated(code);
+    }
+    return false;
+  }
+
+  await params.onUnauthorized();
+  return false;
+}

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -21,7 +21,6 @@ import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { logDebug } from "../../logger.js";
 import { getChildLogger } from "../../logging.js";
 import { buildPairingReply } from "../../pairing/pairing-messages.js";
-import { upsertChannelPairingRequest } from "../../pairing/pairing-store.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import { DEFAULT_ACCOUNT_ID, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { fetchPluralKitMessageInfo } from "../pluralkit.js";
@@ -38,6 +37,7 @@ import {
   resolveGroupDmAllow,
 } from "./allow-list.js";
 import { resolveDiscordDmCommandAccess } from "./dm-command-auth.js";
+import { handleDiscordDmCommandDecision } from "./dm-command-decision.js";
 import {
   formatDiscordUserTag,
   resolveDiscordSystemLocation,
@@ -171,6 +171,7 @@ export async function preflightDiscordMessage(
   const dmPolicy = params.discordConfig?.dmPolicy ?? params.discordConfig?.dm?.policy ?? "pairing";
   const useAccessGroups = params.cfg.commands?.useAccessGroups !== false;
   const resolvedAccountId = params.accountId ?? DEFAULT_ACCOUNT_ID;
+  const allowNameMatching = isDangerousNameMatchingEnabled(params.discordConfig);
   let commandAuthorized = true;
   if (isDirectMessage) {
     if (dmPolicy === "disabled") {
@@ -186,7 +187,7 @@ export async function preflightDiscordMessage(
         name: sender.name,
         tag: sender.tag,
       },
-      allowNameMatching: isDangerousNameMatchingEnabled(params.discordConfig),
+      allowNameMatching,
       useAccessGroups,
     });
     commandAuthorized = dmAccess.commandAuthorized;
@@ -194,17 +195,15 @@ export async function preflightDiscordMessage(
       const allowMatchMeta = formatAllowlistMatchMeta(
         dmAccess.allowMatch.allowed ? dmAccess.allowMatch : undefined,
       );
-      if (dmAccess.decision === "pairing") {
-        const { code, created } = await upsertChannelPairingRequest({
-          channel: "discord",
+      await handleDiscordDmCommandDecision({
+        dmAccess,
+        accountId: resolvedAccountId,
+        sender: {
           id: author.id,
-          accountId: resolvedAccountId,
-          meta: {
-            tag: formatDiscordUserTag(author),
-            name: author.username ?? undefined,
-          },
-        });
-        if (created) {
+          tag: formatDiscordUserTag(author),
+          name: author.username ?? undefined,
+        },
+        onPairingCreated: async (code) => {
           logVerbose(
             `discord pairing request sender=${author.id} tag=${formatDiscordUserTag(author)} (${allowMatchMeta})`,
           );
@@ -225,12 +224,13 @@ export async function preflightDiscordMessage(
           } catch (err) {
             logVerbose(`discord pairing reply failed for ${author.id}: ${String(err)}`);
           }
-        }
-      } else {
-        logVerbose(
-          `Blocked unauthorized discord sender ${sender.id} (dmPolicy=${dmPolicy}, ${allowMatchMeta})`,
-        );
-      }
+        },
+        onUnauthorized: async () => {
+          logVerbose(
+            `Blocked unauthorized discord sender ${sender.id} (dmPolicy=${dmPolicy}, ${allowMatchMeta})`,
+          );
+        },
+      });
       return null;
     }
   }
@@ -560,7 +560,7 @@ export async function preflightDiscordMessage(
     guildInfo,
     memberRoleIds,
     sender,
-    allowNameMatching: isDangerousNameMatchingEnabled(params.discordConfig),
+    allowNameMatching,
   });
 
   if (!isDirectMessage) {
@@ -577,7 +577,7 @@ export async function preflightDiscordMessage(
             name: sender.name,
             tag: sender.tag,
           },
-          { allowNameMatching: isDangerousNameMatchingEnabled(params.discordConfig) },
+          { allowNameMatching },
         )
       : false;
     const commandGate = resolveControlCommandGate({

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -41,7 +41,6 @@ import { logVerbose } from "../../globals.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { buildPairingReply } from "../../pairing/pairing-messages.js";
-import { upsertChannelPairingRequest } from "../../pairing/pairing-store.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { buildUntrustedChannelMetadata } from "../../security/channel-metadata.js";
@@ -59,6 +58,7 @@ import {
   resolveDiscordOwnerAllowFrom,
 } from "./allow-list.js";
 import { resolveDiscordDmCommandAccess } from "./dm-command-auth.js";
+import { handleDiscordDmCommandDecision } from "./dm-command-decision.js";
 import { resolveDiscordChannelInfo } from "./message-utils.js";
 import { resolveDiscordSenderIdentity } from "./sender-identity.js";
 import type { ThreadBindingManager } from "./thread-bindings.js";
@@ -562,6 +562,7 @@ async function dispatchDiscordCommandInteraction(params: {
   const memberRoleIds = Array.isArray(interaction.rawData.member?.roles)
     ? interaction.rawData.member.roles.map((roleId: string) => String(roleId))
     : [];
+  const allowNameMatching = isDangerousNameMatchingEnabled(discordConfig);
   const ownerAllowList = normalizeDiscordAllowList(
     discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? [],
     ["discord:", "user:", "pk:"],
@@ -575,7 +576,7 @@ async function dispatchDiscordCommandInteraction(params: {
             name: sender.name,
             tag: sender.tag,
           },
-          { allowNameMatching: isDangerousNameMatchingEnabled(discordConfig) },
+          { allowNameMatching },
         )
       : false;
   const guildInfo = resolveDiscordGuildEntry({
@@ -659,22 +660,20 @@ async function dispatchDiscordCommandInteraction(params: {
         name: sender.name,
         tag: sender.tag,
       },
-      allowNameMatching: isDangerousNameMatchingEnabled(discordConfig),
+      allowNameMatching,
       useAccessGroups,
     });
     commandAuthorized = dmAccess.commandAuthorized;
     if (dmAccess.decision !== "allow") {
-      if (dmAccess.decision === "pairing") {
-        const { code, created } = await upsertChannelPairingRequest({
-          channel: "discord",
+      await handleDiscordDmCommandDecision({
+        dmAccess,
+        accountId,
+        sender: {
           id: user.id,
-          accountId,
-          meta: {
-            tag: sender.tag,
-            name: sender.name,
-          },
-        });
-        if (created) {
+          tag: sender.tag,
+          name: sender.name,
+        },
+        onPairingCreated: async (code) => {
           await respond(
             buildPairingReply({
               channel: "discord",
@@ -683,10 +682,11 @@ async function dispatchDiscordCommandInteraction(params: {
             }),
             { ephemeral: true },
           );
-        }
-      } else {
-        await respond("You are not authorized to use this command.", { ephemeral: true });
-      }
+        },
+        onUnauthorized: async () => {
+          await respond("You are not authorized to use this command.", { ephemeral: true });
+        },
+      });
       return;
     }
   }
@@ -696,7 +696,7 @@ async function dispatchDiscordCommandInteraction(params: {
       guildInfo,
       memberRoleIds,
       sender,
-      allowNameMatching: isDangerousNameMatchingEnabled(discordConfig),
+      allowNameMatching,
     });
     const authorizers = useAccessGroups
       ? [
@@ -785,7 +785,7 @@ async function dispatchDiscordCommandInteraction(params: {
     channelConfig,
     guildInfo,
     sender: { id: sender.id, name: sender.name, tag: sender.tag },
-    allowNameMatching: isDangerousNameMatchingEnabled(discordConfig),
+    allowNameMatching,
   });
   const ctxPayload = finalizeInboundContext({
     Body: prompt,


### PR DESCRIPTION
Cherry-pick of upstream [`75596e937`](https://github.com/openclaw/openclaw/commit/75596e937).

**Author**: [steipete](https://github.com/steipete)

## Summary
- Extract DM command decision logic into a dedicated `dm-command-decision` module
- Separate the "should we handle this DM command?" decision from the auth gating and message preflight
- Simplifies message-handler.preflight.ts and native-command.ts by delegating the DM command routing decision

Depends on #1398

🤖 Generated with [Claude Code](https://claude.com/claude-code)