### PR TITLE
Cherry-pick 69c39368e: fix: enforce telegram shared outbound chunking

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -166,7 +166,7 @@ describe("deliverOutboundPayloads", () => {
 
   it("clamps telegram text chunk size to protocol max even with higher config", async () => {
     const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "c1" });
-    const cfg: OpenClawConfig = {
+    const cfg: RemoteClawConfig = {
       channels: { telegram: { botToken: "tok-1", textChunkLimit: 10_000 } },
     };
     const text = "<".repeat(3_000);

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -164,6 +164,30 @@ describe("deliverOutboundPayloads", () => {
     });
   });
 
+  it("clamps telegram text chunk size to protocol max even with higher config", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "c1" });
+    const cfg: OpenClawConfig = {
+      channels: { telegram: { botToken: "tok-1", textChunkLimit: 10_000 } },
+    };
+    const text = "<".repeat(3_000);
+    await withEnvAsync({ TELEGRAM_BOT_TOKEN: "" }, async () => {
+      await deliverOutboundPayloads({
+        cfg,
+        channel: "telegram",
+        to: "123",
+        payloads: [{ text }],
+        deps: { sendTelegram },
+      });
+    });
+
+    expect(sendTelegram.mock.calls.length).toBeGreaterThan(1);
+    const sentHtmlChunks = sendTelegram.mock.calls
+      .map((call) => call[1])
+      .filter((message): message is string => typeof message === "string");
+    expect(sentHtmlChunks.length).toBeGreaterThan(1);
+    expect(sentHtmlChunks.every((message) => message.length <= 4096)).toBe(true);
+  });
+
   it("keeps payload replyToId across all chunked telegram sends", async () => {
     const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "c1" });
     await withEnvAsync({ TELEGRAM_BOT_TOKEN: "" }, async () => {

--- a/src/telegram/format.wrap-md.test.ts
+++ b/src/telegram/format.wrap-md.test.ts
@@ -158,6 +158,14 @@ describe("markdownToTelegramChunks - file reference wrapping", () => {
     expect(chunks[0].html).toContain("<code>README.md</code>");
     expect(chunks[0].html).toContain("<code>backup.sh</code>");
   });
+
+  it("keeps rendered html chunks within the provided limit", () => {
+    const input = "<".repeat(1500);
+    const chunks = markdownToTelegramChunks(input, 512);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.map((chunk) => chunk.text).join("")).toBe(input);
+    expect(chunks.every((chunk) => chunk.html.length <= 512)).toBe(true);
+  });
 });
 
 describe("edge cases", () => {


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw commit `69c39368e`.

**Original author:** Ayaan Zaidi <zaidi@uplause.io>
**Subject:** fix: enforce telegram shared outbound chunking

Ensures Telegram outbound delivery uses shared chunking logic for consistent message splitting.

Cherry-picked-from: 69c39368e
Part of #676