### PR TITLE
Cherry-pick 2bef2910f: fix: preserve whitespace in telegram html retry chunking

### DIFF
--- a/src/telegram/format.wrap-md.test.ts
+++ b/src/telegram/format.wrap-md.test.ts
@@ -166,6 +166,14 @@ describe("markdownToTelegramChunks - file reference wrapping", () => {
     expect(chunks.map((chunk) => chunk.text).join("")).toBe(input);
     expect(chunks.every((chunk) => chunk.html.length <= 512)).toBe(true);
   });
+
+  it("preserves whitespace when html-limit retry splitting runs", () => {
+    const input = "a < b";
+    const chunks = markdownToTelegramChunks(input, 5);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.map((chunk) => chunk.text).join("")).toBe(input);
+    expect(chunks.every((chunk) => chunk.html.length <= 5)).toBe(true);
+  });
 });
 
 describe("edge cases", () => {


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw commit `2bef2910f`.

Cherry-picked-from: 2bef2910f
Part of #676