### PR TITLE
Cherry-pick e6049345d: fix(telegram): preserve HTTP proxy env in global dispatcher workaround

### DIFF
--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -1,6 +1,6 @@
 import * as dns from "node:dns";
 import * as net from "node:net";
-import { Agent, setGlobalDispatcher } from "undici";
+import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -46,7 +46,7 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
   ) {
     try {
       setGlobalDispatcher(
-        new Agent({
+        new EnvHttpProxyAgent({
           connect: {
             autoSelectFamily: autoSelectDecision.value,
             autoSelectFamilyAttemptTimeout: 300,

--- a/src/telegram/proxy.test.ts
+++ b/src/telegram/proxy.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-const { ProxyAgent, undiciFetch, proxyAgentSpy, getLastAgent } = vi.hoisted(() => {
+const mocks = vi.hoisted(() => {
   const undiciFetch = vi.fn();
   const proxyAgentSpy = vi.fn();
+  const setGlobalDispatcher = vi.fn();
   class ProxyAgent {
     static lastCreated: ProxyAgent | undefined;
     proxyUrl: string;
@@ -17,13 +18,15 @@ const { ProxyAgent, undiciFetch, proxyAgentSpy, getLastAgent } = vi.hoisted(() =
     ProxyAgent,
     undiciFetch,
     proxyAgentSpy,
+    setGlobalDispatcher,
     getLastAgent: () => ProxyAgent.lastCreated,
   };
 });
 
 vi.mock("undici", () => ({
-  ProxyAgent,
-  fetch: undiciFetch,
+  ProxyAgent: mocks.ProxyAgent,
+  fetch: mocks.undiciFetch,
+  setGlobalDispatcher: mocks.setGlobalDispatcher,
 }));
 
 import { makeProxyFetch } from "./proxy.js";
@@ -31,15 +34,16 @@ import { makeProxyFetch } from "./proxy.js";
 describe("makeProxyFetch", () => {
   it("uses undici fetch with ProxyAgent dispatcher", async () => {
     const proxyUrl = "http://proxy.test:8080";
-    undiciFetch.mockResolvedValue({ ok: true });
+    mocks.undiciFetch.mockResolvedValue({ ok: true });
 
     const proxyFetch = makeProxyFetch(proxyUrl);
     await proxyFetch("https://api.telegram.org/bot123/getMe");
 
-    expect(proxyAgentSpy).toHaveBeenCalledWith(proxyUrl);
-    expect(undiciFetch).toHaveBeenCalledWith(
+    expect(mocks.proxyAgentSpy).toHaveBeenCalledWith(proxyUrl);
+    expect(mocks.undiciFetch).toHaveBeenCalledWith(
       "https://api.telegram.org/bot123/getMe",
-      expect.objectContaining({ dispatcher: getLastAgent() }),
+      expect.objectContaining({ dispatcher: mocks.getLastAgent() }),
     );
+    expect(mocks.setGlobalDispatcher).not.toHaveBeenCalled();
   });
 });

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -4,6 +4,8 @@ export function makeProxyFetch(proxyUrl: string): typeof fetch {
   const agent = new ProxyAgent(proxyUrl);
   // undici's fetch is runtime-compatible with global fetch but the types diverge
   // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
+  // Keep proxy dispatching request-scoped. Replacing the global dispatcher breaks
+  // env-driven HTTP(S)_PROXY behavior for unrelated outbound requests.
   const fetcher = ((input: RequestInfo | URL, init?: RequestInit) =>
     undiciFetch(input as string | URL, {
       ...(init as Record<string, unknown>),


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw commit `e6049345d`.

Cherry-picked-from: e6049345d
Part of #676