### PR TITLE
Cherry-pick a779c2ca6: fix(telegram): skip nullish final text sends

### DIFF
--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -829,7 +829,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
   it.each([undefined, null] as const)(
     "skips outbound send when final payload text is %s and has no media",
     async (emptyText) => {
-      setupDraftStreams({ answerMessageId: 999 });
+      const draftStream = createDraftStream(999);
+      createTelegramDraftStream.mockReturnValue(draftStream);
       dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
         await dispatcherOptions.deliver(
           { text: emptyText as unknown as string },

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -826,6 +826,26 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it.each([undefined, null] as const)(
+    "skips outbound send when final payload text is %s and has no media",
+    async (emptyText) => {
+      setupDraftStreams({ answerMessageId: 999 });
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver(
+          { text: emptyText as unknown as string },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      });
+      deliverReplies.mockResolvedValue({ delivered: true });
+
+      await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+      expect(deliverReplies).not.toHaveBeenCalled();
+      expect(editMessageTelegram).not.toHaveBeenCalled();
+    },
+  );
+
   it("edits stop-created preview when final text is shorter than buffered draft", async () => {
     let answerMessageId: number | undefined;
     const answerDraftStream = {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -381,7 +381,7 @@ export const dispatchTelegramMessage = async ({
           if (info.kind === "final") {
             await answerLane.stream?.stop();
           }
-          const canSendAsIs = hasMedia || typeof text !== "string" || text.length > 0;
+          const canSendAsIs = hasMedia || (typeof text === "string" && text.length > 0);
           if (!canSendAsIs) {
             return;
           }


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw commit `a779c2ca6`.

Resolved conflicts: CHANGELOG.md (deleted in fork), bot-message-dispatch.ts (adapted `payload.text` to fork's destructured `text` variable), bot-message-dispatch.test.ts (reasoning lane tests removed in fork; extracted only the new nullish-text test).

Cherry-picked-from: a779c2ca6
Part of #676