### PR TITLE
Cherry-pick 3b2ed8fe6: fix(telegram): prevent channel-level groups from leaking in multi-account

### DIFF
--- a/src/telegram/accounts.ts
+++ b/src/telegram/accounts.ts
@@ -87,10 +87,25 @@ function mergeTelegramAccountConfig(
   cfg: RemoteClawConfig,
   accountId: string,
 ): TelegramAccountConfig {
-  const { accounts: _ignored, ...base } = (cfg.channels?.telegram ??
-    {}) as TelegramAccountConfig & { accounts?: unknown };
+  const {
+    accounts: _ignored,
+    groups: channelGroups,
+    ...base
+  } = (cfg.channels?.telegram ?? {}) as TelegramAccountConfig & { accounts?: unknown };
   const account = resolveAccountConfig(cfg, accountId) ?? {};
-  return { ...base, ...account };
+
+  // In multi-account setups, channel-level `groups` must NOT be inherited by
+  // accounts that don't have their own `groups` config.  A bot that is not a
+  // member of a configured group will fail when handling group messages, and
+  // this failure disrupts message delivery for *all* accounts.
+  // Single-account setups keep backward compat: channel-level groups still
+  // applies when the account has no override.
+  // See: https://github.com/openclaw/openclaw/issues/30673
+  const configuredAccountIds = Object.keys(cfg.channels?.telegram?.accounts ?? {});
+  const isMultiAccount = configuredAccountIds.length > 1;
+  const groups = account.groups ?? (isMultiAccount ? undefined : channelGroups);
+
+  return { ...base, ...account, groups };
 }
 
 export function createTelegramActionGate(params: {


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw commit `3b2ed8fe6`.

Resolved conflict: adapted destructuring to include `groups: channelGroups` while keeping fork RemoteClawConfig type and multi-line formatting.

Cherry-picked-from: 3b2ed8fe6
Part of #676