### PR TITLE
Cherry-pick 8bc80fad4: fix(slack): land #29032 /agentstatus alias from @maloqab

### DIFF
--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -212,7 +212,8 @@ For actions/directory reads, user token can be preferred when configured. For wr
 
 - Native command auto-mode is **off** for Slack (`commands.native: "auto"` does not enable Slack native commands).
 - Enable native Slack command handlers with `channels.slack.commands.native: true` (or global `commands.native: true`).
-- When native commands are enabled, register matching slash commands in Slack (`/<command>` names).
+- When native commands are enabled, register matching slash commands in Slack (`/<command>` names), with one exception:
+  - register `/agentstatus` for the status command (Slack reserves `/status`)
 - If native commands are not enabled, you can run a single configured slash command via `channels.slack.slashCommand`.
 - Native arg menus now adapt their rendering strategy:
   - up to 5 options: button blocks

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -166,3 +166,4 @@ Notes:
   - Telegram: `telegram:slash:<userId>` (targets the chat session via `CommandTargetSessionKey`)
 - **`/stop`** targets the active chat session so it can abort the current run.
 - **Slack:** `channels.slack.slashCommand` is still supported for a single `/remoteclaw`-style command. If you enable `commands.native`, you must create one Slack slash command per built-in command (same names as `/help`). Command argument menus for Slack are delivered as ephemeral Block Kit buttons.
+  - Slack native exception: register `/agentstatus` (not `/status`) because Slack reserves `/status`. Text `/status` still works in Slack messages.

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -82,6 +82,17 @@ describe("commands registry", () => {
     expect(findCommandByNativeName("tts", "discord")).toBeUndefined();
   });
 
+  it("renames status to agentstatus for slack", () => {
+    const native = listNativeCommandSpecsForConfig(
+      { commands: { native: true } },
+      { provider: "slack" },
+    );
+    expect(native.find((spec) => spec.name === "agentstatus")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "status")).toBeFalsy();
+    expect(findCommandByNativeName("agentstatus", "slack")?.key).toBe("status");
+    expect(findCommandByNativeName("status", "slack")).toBeUndefined();
+  });
+
   it("keeps discord native command specs within slash-command limits", () => {
     const native = listNativeCommandSpecsForConfig(
       { commands: { native: true } },

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -89,6 +89,11 @@ const NATIVE_NAME_OVERRIDES: Record<string, Record<string, string>> = {
   discord: {
     tts: "voice",
   },
+  slack: {
+    // Slack reserves /status — registering it returns "invalid name"
+    // and invalidates the entire slash_commands manifest array.
+    status: "agentstatus",
+  },
 };
 
 function resolveNativeName(command: ChatCommandDefinition, provider?: string): string | undefined {

--- a/src/slack/monitor/slash.test.ts
+++ b/src/slack/monitor/slash.test.ts
@@ -8,6 +8,7 @@ vi.mock("../../auto-reply/commands-registry.js", () => {
   const reportExternalCommand = { key: "reportexternal", nativeName: "reportexternal" };
   const reportLongCommand = { key: "reportlong", nativeName: "reportlong" };
   const unsafeConfirmCommand = { key: "unsafeconfirm", nativeName: "unsafeconfirm" };
+  const statusAliasCommand = { key: "status", nativeName: "status" };
   const periodArg = { name: "period", description: "period" };
   const baseReportPeriodChoices = [
     { value: "day", label: "day" },
@@ -73,6 +74,9 @@ vi.mock("../../auto-reply/commands-registry.js", () => {
       if (normalized === "unsafeconfirm") {
         return unsafeConfirmCommand;
       }
+      if (normalized === "agentstatus") {
+        return statusAliasCommand;
+      }
       return undefined;
     },
     listNativeCommandSpecsForConfig: () => [
@@ -110,6 +114,12 @@ vi.mock("../../auto-reply/commands-registry.js", () => {
         name: "unsafeconfirm",
         description: "UnsafeConfirm",
         acceptsArgs: true,
+        args: [],
+      },
+      {
+        name: "agentstatus",
+        description: "Status",
+        acceptsArgs: false,
         args: [],
       },
     ],
@@ -394,6 +404,7 @@ describe("Slack native command argument menus", () => {
   let reportExternalHandler: (args: unknown) => Promise<void>;
   let reportLongHandler: (args: unknown) => Promise<void>;
   let unsafeConfirmHandler: (args: unknown) => Promise<void>;
+  let agentStatusHandler: (args: unknown) => Promise<void>;
   let argMenuHandler: (args: unknown) => Promise<void>;
   let argMenuOptionsHandler: (args: unknown) => Promise<void>;
 
@@ -406,6 +417,7 @@ describe("Slack native command argument menus", () => {
     reportExternalHandler = requireHandler(harness.commands, "/reportexternal", "/reportexternal");
     reportLongHandler = requireHandler(harness.commands, "/reportlong", "/reportlong");
     unsafeConfirmHandler = requireHandler(harness.commands, "/unsafeconfirm", "/unsafeconfirm");
+    agentStatusHandler = requireHandler(harness.commands, "/agentstatus", "/agentstatus");
     argMenuHandler = requireHandler(harness.actions, "remoteclaw_cmdarg", "arg-menu action");
     argMenuOptionsHandler = requireHandler(
       harness.options,
@@ -476,6 +488,11 @@ describe("Slack native command argument menus", () => {
     expect(dispatchMock).toHaveBeenCalledTimes(1);
     const call = dispatchMock.mock.calls[0]?.[0] as { ctx?: { Body?: string } };
     expect(call.ctx?.Body).toBe("/usage tokens");
+  });
+
+  it("maps /agentstatus to /status when dispatching", async () => {
+    await runCommandHandler(agentStatusHandler);
+    expectSingleDispatchedSlashBody("/status");
   });
 
   it("dispatches the command when a static_select option is chosen", async () => {


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw commit `8bc80fad4`.

**fix(slack): land #29032 /agentstatus alias from @maloqab**

Adds `/agentstatus` as a native Slack slash command alias for `/status` (which Slack reserves). Text `/status` still works.

## Conflicts resolved
- `CHANGELOG.md` — removed (deleted in fork)
- `docs/tools/slash-commands.md` — kept fork's `remoteclaw` branding + added agentstatus note
- `src/slack/monitor/slash.test.ts` — added agentStatusHandler + kept fork's `remoteclaw_cmdarg` identifiers

Cherry-picked-from: 8bc80fad477e2700cb5cac909ca74b22ee7ce0d0

Part of #677