### PR TITLE
Cherry-pick b3f60a68a: fix(slack): thread agent identity through channel reply path

### DIFF
--- a/src/slack/monitor/replies.test.ts
+++ b/src/slack/monitor/replies.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMock = vi.fn();
+vi.mock("../send.js", () => ({
+  sendMessageSlack: (...args: unknown[]) => sendMock(...args),
+}));
+
+import { deliverReplies } from "./replies.js";
+
+function baseParams(overrides?: Record<string, unknown>) {
+  return {
+    replies: [{ text: "hello" }],
+    target: "C123",
+    token: "xoxb-test",
+    runtime: { log: () => {}, error: () => {}, exit: () => {} },
+    textLimit: 4000,
+    replyToMode: "off" as const,
+    ...overrides,
+  };
+}
+
+describe("deliverReplies identity passthrough", () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+  });
+  it("passes identity to sendMessageSlack for text replies", async () => {
+    sendMock.mockResolvedValue(undefined);
+    const identity = { username: "Bot", iconEmoji: ":robot:" };
+    await deliverReplies(baseParams({ identity }));
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(sendMock.mock.calls[0][2]).toMatchObject({ identity });
+  });
+
+  it("passes identity to sendMessageSlack for media replies", async () => {
+    sendMock.mockResolvedValue(undefined);
+    const identity = { username: "Bot", iconUrl: "https://example.com/icon.png" };
+    await deliverReplies(
+      baseParams({
+        identity,
+        replies: [{ text: "caption", mediaUrls: ["https://example.com/img.png"] }],
+      }),
+    );
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(sendMock.mock.calls[0][2]).toMatchObject({ identity });
+  });
+
+  it("omits identity key when not provided", async () => {
+    sendMock.mockResolvedValue(undefined);
+    await deliverReplies(baseParams());
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(sendMock.mock.calls[0][2]).not.toHaveProperty("identity");
+  });
+});

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -6,7 +6,7 @@ import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
-import { sendMessageSlack } from "../send.js";
+import { sendMessageSlack, type SlackSendIdentity } from "../send.js";
 
 export async function deliverReplies(params: {
   replies: ReplyPayload[];
@@ -17,6 +17,7 @@ export async function deliverReplies(params: {
   textLimit: number;
   replyThreadTs?: string;
   replyToMode: "off" | "first" | "all";
+  identity?: SlackSendIdentity;
 }) {
   for (const payload of params.replies) {
     // Keep reply tags opt-in: when replyToMode is off, explicit reply tags
@@ -38,6 +39,7 @@ export async function deliverReplies(params: {
         token: params.token,
         threadTs,
         accountId: params.accountId,
+        ...(params.identity ? { identity: params.identity } : {}),
       });
     } else {
       let first = true;
@@ -49,6 +51,7 @@ export async function deliverReplies(params: {
           mediaUrl,
           threadTs,
           accountId: params.accountId,
+          ...(params.identity ? { identity: params.identity } : {}),
         });
       }
     }


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw commit `b3f60a68a`.

**fix(slack): thread agent identity through channel reply path (openclaw#27134) thanks @hou-rong**

Threads agent identity (name/icon) through the Slack reply path so multi-agent setups show correct identity per reply.

## Conflicts resolved
- `CHANGELOG.md` — removed (deleted in fork)

Cherry-picked-from: b3f60a68a0

Part of #677