### PR TITLE
Cherry-pick 3aad6c8bd: fix(slack): guard Socket Mode listeners access during startup

### DIFF
--- a/src/slack/monitor/slash.test.ts
+++ b/src/slack/monitor/slash.test.ts
@@ -439,6 +439,78 @@ describe("Slack native command argument menus", () => {
     expect(testHarness.optionsReceiverContexts[0]).toBe(testHarness.app);
   });
 
+  it("falls back to static menus when app.options() throws during registration", async () => {
+    const commands = new Map<string, (args: unknown) => Promise<void>>();
+    const actions = new Map<string, (args: unknown) => Promise<void>>();
+    const postEphemeral = vi.fn().mockResolvedValue({ ok: true });
+    const app = {
+      client: { chat: { postEphemeral } },
+      command: (name: string, handler: (args: unknown) => Promise<void>) => {
+        commands.set(name, handler);
+      },
+      action: (id: string, handler: (args: unknown) => Promise<void>) => {
+        actions.set(id, handler);
+      },
+      // Simulate Bolt throwing during options registration (e.g. receiver not initialized)
+      options: () => {
+        throw new Error("Cannot read properties of undefined (reading 'listeners')");
+      },
+    };
+    const ctx = {
+      cfg: { commands: { native: true, nativeSkills: false } },
+      runtime: {},
+      botToken: "bot-token",
+      botUserId: "bot",
+      teamId: "T1",
+      allowFrom: ["*"],
+      dmEnabled: true,
+      dmPolicy: "open",
+      groupDmEnabled: false,
+      groupDmChannels: [],
+      defaultRequireMention: true,
+      groupPolicy: "open",
+      useAccessGroups: false,
+      channelsConfig: undefined,
+      slashCommand: {
+        enabled: true,
+        name: "openclaw",
+        ephemeral: true,
+        sessionPrefix: "slack:slash",
+      },
+      textLimit: 4000,
+      app,
+      isChannelAllowed: () => true,
+      resolveChannelName: async () => ({ name: "dm", type: "im" }),
+      resolveUserName: async () => ({ name: "Ada" }),
+    } as unknown;
+    const account = {
+      accountId: "acct",
+      config: { commands: { native: true, nativeSkills: false } },
+    } as unknown;
+
+    // Registration should not throw despite app.options() throwing
+    await registerCommands(ctx, account);
+    expect(commands.size).toBeGreaterThan(0);
+    expect(actions.has("openclaw_cmdarg")).toBe(true);
+
+    // The /reportexternal command (140 choices) should fall back to static_select
+    // instead of external_select since options registration failed
+    const handler = commands.get("/reportexternal");
+    expect(handler).toBeDefined();
+    const respond = vi.fn().mockResolvedValue(undefined);
+    const ack = vi.fn().mockResolvedValue(undefined);
+    await handler!({
+      command: createSlashCommand(),
+      ack,
+      respond,
+    });
+    expect(respond).toHaveBeenCalledTimes(1);
+    const payload = respond.mock.calls[0]?.[0] as { blocks?: Array<{ type: string }> };
+    const actionsBlock = findFirstActionsBlock(payload);
+    // Should be static_select (fallback) not external_select
+    expect(actionsBlock?.elements?.[0]?.type).toBe("static_select");
+  });
+
   it("shows a button menu when required args are omitted", async () => {
     const { respond } = await runCommandHandler(usageHandler);
     const actions = expectArgMenuLayout(respond);

--- a/src/slack/monitor/slash.test.ts
+++ b/src/slack/monitor/slash.test.ts
@@ -473,7 +473,7 @@ describe("Slack native command argument menus", () => {
       channelsConfig: undefined,
       slashCommand: {
         enabled: true,
-        name: "openclaw",
+        name: "remoteclaw",
         ephemeral: true,
         sessionPrefix: "slack:slash",
       },
@@ -491,7 +491,7 @@ describe("Slack native command argument menus", () => {
     // Registration should not throw despite app.options() throwing
     await registerCommands(ctx, account);
     expect(commands.size).toBeGreaterThan(0);
-    expect(actions.has("openclaw_cmdarg")).toBe(true);
+    expect(actions.has("remoteclaw_cmdarg")).toBe(true);
 
     // The /reportexternal command (140 choices) should fall back to static_select
     // instead of external_select since options registration failed

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -274,7 +274,7 @@ export async function registerSlackMonitorSlashCommands(params: {
 
   const supportsInteractiveArgMenus =
     typeof (ctx.app as { action?: unknown }).action === "function";
-  const supportsExternalArgMenus = typeof (ctx.app as { options?: unknown }).options === "function";
+  let supportsExternalArgMenus = typeof (ctx.app as { options?: unknown }).options === "function";
 
   const slashCommand = resolveSlackSlashCommandConfig(
     ctx.slashCommand ?? account.config.slashCommand,
@@ -749,7 +749,17 @@ export async function registerSlackMonitorSlashCommands(params: {
       await ack({ options });
     });
   };
-  registerArgOptions();
+  // Treat external arg-menu registration as best-effort: if Bolt's app.options()
+  // throws (e.g. from receiver init issues), disable external selects and fall back
+  // to static_select/button menus instead of crashing the entire provider startup.
+  try {
+    registerArgOptions();
+  } catch (err) {
+    supportsExternalArgMenus = false;
+    logVerbose(
+      `slack: external arg-menu registration failed, falling back to static menus: ${String(err)}`,
+    );
+  }
 
   const registerArgAction = (actionId: string) => {
     (


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw commit `3aad6c8bd`.

**fix(slack): guard Socket Mode listeners access during startup (openclaw#28702) thanks @Glucksberg**

Guards Socket Mode listeners access during startup to prevent errors when listeners are not yet initialized.

## Conflicts resolved
- `CHANGELOG.md` — removed (deleted in fork)

Cherry-picked-from: 3aad6c8bdb

Part of #677