### PR TITLE
Cherry-pick 042d06a19: fix(telegram): stop bot on polling teardown

### DIFF
--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -59,6 +59,10 @@ const { createTelegramBotErrors } = vi.hoisted(() => ({
   createTelegramBotErrors: [] as unknown[],
 }));
 
+const { createdBotStops } = vi.hoisted(() => ({
+  createdBotStops: [] as Array<ReturnType<typeof vi.fn<() => void>>>,
+}));
+
 const { createTelegramBotCalls } = vi.hoisted(() => ({
   createTelegramBotCalls: [] as Array<Record<string, unknown>>,
 }));
@@ -128,12 +132,14 @@ vi.mock("./bot.js", () => ({
       }
       await api.sendMessage(chatId, `echo:${text}`, { parse_mode: "HTML" });
     };
+    const stop = vi.fn<() => void>();
+    createdBotStops.push(stop);
     return {
       on: vi.fn(),
       api,
       me: { username: "mybot" },
       init: initSpy,
-      stop: vi.fn(),
+      stop,
       start: vi.fn(),
     };
   },
@@ -184,6 +190,7 @@ describe("monitorTelegramProvider (grammY)", () => {
     registerUnhandledRejectionHandlerMock.mockClear();
     resetUnhandledRejection();
     createTelegramBotErrors.length = 0;
+    createdBotStops.length = 0;
     createTelegramBotCalls.length = 0;
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
@@ -386,6 +393,22 @@ describe("monitorTelegramProvider (grammY)", () => {
     expect(computeBackoff).toHaveBeenCalled();
     expect(sleepWithAbort).toHaveBeenCalled();
     expect(runSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops bot instance when polling cycle exits", async () => {
+    const abort = new AbortController();
+    runSpy.mockImplementationOnce(() =>
+      makeRunnerStub({
+        task: async () => {
+          abort.abort();
+        },
+      }),
+    );
+
+    await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+
+    expect(createdBotStops.length).toBe(1);
+    expect(createdBotStops[0]).toHaveBeenCalledTimes(1);
   });
 
   it("surfaces non-recoverable errors", async () => {

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -198,6 +198,11 @@ export class TelegramPollingSession {
     } finally {
       this.opts.abortSignal?.removeEventListener("abort", stopOnAbort);
       await stopRunner();
+      await Promise.resolve(bot.stop())
+        .then(() => undefined)
+        .catch(() => {
+          // Bot may already be stopped by runner stop/abort paths.
+        });
       this.#activeRunner = undefined;
       if (this.#activeFetchAbort === fetchAbortController) {
         this.#activeFetchAbort = undefined;


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [`042d06a19`](https://github.com/openclaw/openclaw/commit/042d06a19)
**Author**: liuxiaopai-ai
**Tier**: AUTO-PICK (reimplemented)

> Telegram: stop bot on polling teardown

### Why reimplemented

Upstream applied `bot.stop()` to the inline polling code in `monitor.ts`. The fork previously cherry-picked `1d301f74a` which extracted that inline code into `TelegramPollingSession` class in `polling-session.ts`. So `git cherry-pick` couldn't match the context.

The fix is semantically identical: call `bot.stop()` in the `finally` block of `#runPollingCycle()` after `stopRunner()`, ensuring the bot instance is cleaned up when the polling cycle exits.

### Changes

- `src/telegram/polling-session.ts`: Added `bot.stop()` in `#runPollingCycle` finally block
- `src/telegram/monitor.test.ts`: Added `createdBotStops` tracking array + test verifying bot.stop() is called on polling exit

Reimplemented-for: remoteclaw-middleware
Co-authored-by: liuxiaopai-ai <73659136+liuxiaopai-ai@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)