### PR TITLE
Cherry-pick dfbdab5a2: fix(slack): map legacy streaming=false to off

### DIFF
--- a/src/config/discord-preview-streaming.ts
+++ b/src/config/discord-preview-streaming.ts
@@ -121,9 +121,9 @@ export function resolveSlackStreamingMode(
   if (legacyStreamMode) {
     return mapSlackLegacyDraftStreamModeToStreaming(legacyStreamMode);
   }
-  // Legacy `streaming` was a Slack native-streaming toggle; preview mode stayed replace.
+  // Legacy boolean `streaming` values map to the unified enum.
   if (typeof params.streaming === "boolean") {
-    return "partial";
+    return params.streaming ? "partial" : "off";
   }
   return "partial";
 }

--- a/src/slack/stream-mode.test.ts
+++ b/src/slack/stream-mode.test.ts
@@ -40,10 +40,15 @@ describe("resolveSlackStreamingConfig", () => {
     });
   });
 
-  it("moves legacy streaming boolean to native streaming toggle", () => {
+  it("maps legacy streaming booleans to unified mode and native streaming toggle", () => {
     expect(resolveSlackStreamingConfig({ streaming: false })).toEqual({
-      mode: "partial",
+      mode: "off",
       nativeStreaming: false,
+      draftMode: "replace",
+    });
+    expect(resolveSlackStreamingConfig({ streaming: true })).toEqual({
+      mode: "partial",
+      nativeStreaming: true,
       draftMode: "replace",
     });
   });


### PR DESCRIPTION
Cherry-pick of upstream commit `dfbdab5a2` — "fix(slack): map legacy streaming=false to off (openclaw#26020) thanks @chilu18"

**Conflicts resolved:**
- `CHANGELOG.md` — removed (deleted in fork)
- `src/commands/doctor-legacy-config.test.ts` — removed (deleted in fork)
- `src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts` — removed (deleted in fork)

Part of #677