### PR TITLE
Cherry-pick 46da76e26: fix(slack): honor replyToModeByChatType when ThreadLabel exists

### DIFF
--- a/src/slack/threading-tool-context.test.ts
+++ b/src/slack/threading-tool-context.test.ts
@@ -86,18 +86,62 @@ describe("buildSlackThreadingToolContext", () => {
     expect(result.replyToMode).toBe("all");
   });
 
-  it("uses all mode when ThreadLabel is present", () => {
+  it("uses all mode when MessageThreadId is present", () => {
     const cfg = {
       channels: {
-        slack: { replyToMode: "off" },
+        slack: {
+          replyToMode: "all",
+          replyToModeByChatType: { direct: "off" },
+        },
       },
     } as RemoteClawConfig;
     const result = buildSlackThreadingToolContext({
       cfg,
       accountId: null,
-      context: { ChatType: "channel", ThreadLabel: "some-thread" },
+      context: {
+        ChatType: "direct",
+        ThreadLabel: "thread-label",
+        MessageThreadId: "1771999998.834199",
+      },
     });
     expect(result.replyToMode).toBe("all");
+  });
+
+  it("does not force all mode from ThreadLabel alone", () => {
+    const cfg = {
+      channels: {
+        slack: {
+          replyToMode: "all",
+          replyToModeByChatType: { direct: "off" },
+        },
+      },
+    } as RemoteClawConfig;
+    const result = buildSlackThreadingToolContext({
+      cfg,
+      accountId: null,
+      context: {
+        ChatType: "direct",
+        ThreadLabel: "label-without-real-thread",
+      },
+    });
+    expect(result.replyToMode).toBe("off");
+  });
+
+  it("keeps configured channel behavior when not in a thread", () => {
+    const cfg = {
+      channels: {
+        slack: {
+          replyToMode: "off",
+          replyToModeByChatType: { channel: "first" },
+        },
+      },
+    } as RemoteClawConfig;
+    const result = buildSlackThreadingToolContext({
+      cfg,
+      accountId: null,
+      context: { ChatType: "channel", ThreadLabel: "label-only" },
+    });
+    expect(result.replyToMode).toBe("first");
   });
 
   it("defaults to off when no replyToMode is configured", () => {

--- a/src/slack/threading-tool-context.ts
+++ b/src/slack/threading-tool-context.ts
@@ -16,7 +16,8 @@ export function buildSlackThreadingToolContext(params: {
     accountId: params.accountId,
   });
   const configuredReplyToMode = resolveSlackReplyToMode(account, params.context.ChatType);
-  const effectiveReplyToMode = params.context.ThreadLabel ? "all" : configuredReplyToMode;
+  const hasExplicitThreadTarget = params.context.MessageThreadId != null;
+  const effectiveReplyToMode = hasExplicitThreadTarget ? "all" : configuredReplyToMode;
   const threadId = params.context.MessageThreadId ?? params.context.ReplyToId;
   return {
     currentChannelId: params.context.To?.startsWith("channel:")


### PR DESCRIPTION
Cherry-pick of upstream commit `46da76e26` — "fix(slack): honor replyToModeByChatType when ThreadLabel exists (#26251)"

**Conflicts resolved:**
- `CHANGELOG.md` — removed (deleted in fork)

Part of #677