### PR TITLE
Cherry-pick 6dbbc58a8: fix(slack): use SLACK_USER_TOKEN when connecting

### DIFF
--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -108,7 +108,7 @@ export async function handleSlackAction(
   const account = resolveSlackAccount({ cfg, accountId });
   const actionConfig = account.actions ?? cfg.channels?.slack?.actions;
   const isActionEnabled = createActionGate(actionConfig);
-  const userToken = account.config.userToken?.trim() || undefined;
+  const userToken = account.userToken;
   const botToken = account.botToken?.trim();
   const allowUserWrites = account.config.userTokenReadOnly === false;
 

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -327,7 +327,7 @@ async function resolveSlackNames(params: {
   entries: string[];
 }) {
   const account = resolveSlackAccount({ cfg: params.cfg, accountId: params.accountId });
-  const token = account.config.userToken?.trim() || account.botToken?.trim();
+  const token = account.userToken || account.botToken?.trim();
   if (!token) {
     return new Map<string, string>();
   }

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -152,7 +152,7 @@ async function promptSlackAllowFrom(params: {
     defaultAccountId: resolveDefaultSlackAccountId(params.cfg),
   });
   const resolved = resolveSlackAccount({ cfg: params.cfg, accountId });
-  const token = resolved.config.userToken ?? resolved.config.botToken ?? "";
+  const token = resolved.userToken ?? resolved.botToken ?? "";
   const existing =
     params.cfg.channels?.slack?.allowFrom ?? params.cfg.channels?.slack?.dm?.allowFrom ?? [];
   const parseId = (value: string) =>

--- a/src/commands/channels/capabilities.test.ts
+++ b/src/commands/channels/capabilities.test.ts
@@ -90,6 +90,7 @@ describe("channelsCapabilitiesCommand", () => {
       account: {
         accountId: "default",
         botToken: "xoxb-bot",
+        userToken: "xoxp-user",
         config: { userToken: "xoxp-user" },
       },
       probe: { ok: true, bot: { name: "remoteclaw" }, team: { name: "team" } },

--- a/src/commands/channels/capabilities.ts
+++ b/src/commands/channels/capabilities.ts
@@ -384,9 +384,7 @@ async function resolveChannelReports(params: {
     let slackScopes: ChannelCapabilitiesReport["slackScopes"];
     if (plugin.id === "slack" && configured && enabled) {
       const botToken = (resolvedAccount as { botToken?: string }).botToken?.trim();
-      const userToken = (
-        resolvedAccount as { config?: { userToken?: string } }
-      ).config?.userToken?.trim();
+      const userToken = (resolvedAccount as { userToken?: string }).userToken?.trim();
       const scopeReports: NonNullable<ChannelCapabilitiesReport["slackScopes"]> = [];
       if (botToken) {
         scopeReports.push({

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -161,9 +161,7 @@ async function resolveSlackChannelType(params: {
     return "channel";
   }
 
-  const token =
-    account.botToken?.trim() ||
-    (typeof account.config.userToken === "string" ? account.config.userToken.trim() : "");
+  const token = account.botToken?.trim() || account.userToken || "";
   if (!token) {
     SLACK_CHANNEL_TYPE_CACHE.set(`${account.accountId}:${channelId}`, "unknown");
     return "unknown";

--- a/src/slack/accounts.ts
+++ b/src/slack/accounts.ts
@@ -4,7 +4,7 @@ import type { RemoteClawConfig } from "../config/config.js";
 import type { SlackAccountConfig } from "../config/types.js";
 import { resolveAccountEntry } from "../routing/account-lookup.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
-import { resolveSlackAppToken, resolveSlackBotToken } from "./token.js";
+import { resolveSlackAppToken, resolveSlackBotToken, resolveSlackUserToken } from "./token.js";
 
 export type SlackTokenSource = "env" | "config" | "none";
 
@@ -14,8 +14,10 @@ export type ResolvedSlackAccount = {
   name?: string;
   botToken?: string;
   appToken?: string;
+  userToken?: string;
   botTokenSource: SlackTokenSource;
   appTokenSource: SlackTokenSource;
+  userTokenSource: SlackTokenSource;
   config: SlackAccountConfig;
   groupPolicy?: SlackAccountConfig["groupPolicy"];
   textChunkLimit?: SlackAccountConfig["textChunkLimit"];
@@ -61,12 +63,16 @@ export function resolveSlackAccount(params: {
   const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
   const envBot = allowEnv ? resolveSlackBotToken(process.env.SLACK_BOT_TOKEN) : undefined;
   const envApp = allowEnv ? resolveSlackAppToken(process.env.SLACK_APP_TOKEN) : undefined;
+  const envUser = allowEnv ? resolveSlackUserToken(process.env.SLACK_USER_TOKEN) : undefined;
   const configBot = resolveSlackBotToken(merged.botToken);
   const configApp = resolveSlackAppToken(merged.appToken);
+  const configUser = resolveSlackUserToken(merged.userToken);
   const botToken = configBot ?? envBot;
   const appToken = configApp ?? envApp;
+  const userToken = configUser ?? envUser;
   const botTokenSource: SlackTokenSource = configBot ? "config" : envBot ? "env" : "none";
   const appTokenSource: SlackTokenSource = configApp ? "config" : envApp ? "env" : "none";
+  const userTokenSource: SlackTokenSource = configUser ? "config" : envUser ? "env" : "none";
 
   return {
     accountId,
@@ -74,8 +80,10 @@ export function resolveSlackAccount(params: {
     name: merged.name?.trim() || undefined,
     botToken,
     appToken,
+    userToken,
     botTokenSource,
     appTokenSource,
+    userTokenSource,
     config: merged,
     groupPolicy: merged.groupPolicy,
     textChunkLimit: merged.textChunkLimit,

--- a/src/slack/directory-live.ts
+++ b/src/slack/directory-live.ts
@@ -36,8 +36,7 @@ type SlackListChannelsResponse = {
 
 function resolveReadToken(params: DirectoryConfigParams): string | undefined {
   const account = resolveSlackAccount({ cfg: params.cfg, accountId: params.accountId });
-  const userToken = account.config.userToken?.trim() || undefined;
-  return userToken ?? account.botToken?.trim();
+  return account.userToken ?? account.botToken?.trim();
 }
 
 function normalizeQuery(value?: string | null): string {

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -101,6 +101,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     enabled: true,
     botTokenSource: "config",
     appTokenSource: "config",
+    userTokenSource: "none",
     config: {},
   };
 
@@ -119,6 +120,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       enabled: true,
       botTokenSource: "config",
       appTokenSource: "config",
+      userTokenSource: "none",
       config,
       replyToMode: config.replyToMode,
       replyToModeByChatType: config.replyToModeByChatType,
@@ -165,6 +167,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       enabled: true,
       botTokenSource: "config",
       appTokenSource: "config",
+      userTokenSource: "none",
       config: {
         replyToMode: "all",
         thread: { initialHistoryLimit: 20 },
@@ -378,6 +381,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       enabled: true,
       botTokenSource: "config",
       appTokenSource: "config",
+      userTokenSource: "none",
       config: {},
     };
 
@@ -461,6 +465,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       enabled: true,
       botTokenSource: "config",
       appTokenSource: "config",
+      userTokenSource: "none",
       config: {},
     };
 

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -225,7 +225,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     log: (message) => runtime.log?.(warn(message)),
   });
 
-  const resolveToken = slackCfg.userToken?.trim() || botToken;
+  const resolveToken = account.userToken || botToken;
   const useAccessGroups = cfg.commands?.useAccessGroups !== false;
   const reactionMode = slackCfg.reactionNotifications ?? "own";
   const reactionAllowlist = slackCfg.reactionAllowlist ?? [];

--- a/src/slack/token.ts
+++ b/src/slack/token.ts
@@ -10,3 +10,7 @@ export function resolveSlackBotToken(raw?: string): string | undefined {
 export function resolveSlackAppToken(raw?: string): string | undefined {
   return normalizeSlackToken(raw);
 }
+
+export function resolveSlackUserToken(raw?: string): string | undefined {
+  return normalizeSlackToken(raw);
+}


### PR DESCRIPTION
Cherry-pick of upstream commit `6dbbc58a8` — "fix(slack): use SLACK_USER_TOKEN when connecting to Slack (#28103)"

**Conflicts resolved:**
- `CHANGELOG.md` — removed (deleted in fork)

Part of #677