### PR TITLE
Cherry-pick 2c5b898ee: feat(slack): add download-file action

### DIFF
--- a/src/agents/tools/slack-actions.test.ts
+++ b/src/agents/tools/slack-actions.test.ts
@@ -3,6 +3,7 @@ import type { RemoteClawConfig } from "../../config/config.js";
 import { handleSlackAction } from "./slack-actions.js";
 
 const deleteSlackMessage = vi.fn(async (..._args: unknown[]) => ({}));
+const downloadSlackFile = vi.fn(async (..._args: unknown[]) => null);
 const editSlackMessage = vi.fn(async (..._args: unknown[]) => ({}));
 const getSlackMemberInfo = vi.fn(async (..._args: unknown[]) => ({}));
 const listSlackEmojis = vi.fn(async (..._args: unknown[]) => ({}));
@@ -19,6 +20,7 @@ const unpinSlackMessage = vi.fn(async (..._args: unknown[]) => ({}));
 vi.mock("../../slack/actions.js", () => ({
   deleteSlackMessage: (...args: Parameters<typeof deleteSlackMessage>) =>
     deleteSlackMessage(...args),
+  downloadSlackFile: (...args: Parameters<typeof downloadSlackFile>) => downloadSlackFile(...args),
   editSlackMessage: (...args: Parameters<typeof editSlackMessage>) => editSlackMessage(...args),
   getSlackMemberInfo: (...args: Parameters<typeof getSlackMemberInfo>) =>
     getSlackMemberInfo(...args),
@@ -192,6 +194,26 @@ describe("handleSlackAction", () => {
       threadTs: "1234567890.123456",
       blocks: undefined,
     });
+  });
+
+  it("returns a friendly error when downloadFile cannot fetch the attachment", async () => {
+    downloadSlackFile.mockResolvedValueOnce(null);
+    const result = await handleSlackAction(
+      {
+        action: "downloadFile",
+        fileId: "F123",
+      },
+      slackConfig(),
+    );
+    expect(downloadSlackFile).toHaveBeenCalledWith(
+      "F123",
+      expect.objectContaining({ maxBytes: 20 * 1024 * 1024 }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({ ok: false }),
+      }),
+    );
   });
 
   it.each([

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -2,6 +2,7 @@ import type { RemoteClawConfig } from "../../config/config.js";
 import { resolveSlackAccount } from "../../slack/accounts.js";
 import {
   deleteSlackMessage,
+  downloadSlackFile,
   editSlackMessage,
   getSlackMemberInfo,
   listSlackEmojis,
@@ -22,13 +23,20 @@ import type { AgentToolResult } from "../agent-types.js";
 import { withNormalizedTimestamp } from "../date-time.js";
 import {
   createActionGate,
+  imageResultFromFile,
   jsonResult,
   readNumberParam,
   readReactionParams,
   readStringParam,
 } from "./common.js";
 
-const messagingActions = new Set(["sendMessage", "editMessage", "deleteMessage", "readMessages"]);
+const messagingActions = new Set([
+  "sendMessage",
+  "editMessage",
+  "deleteMessage",
+  "readMessages",
+  "downloadFile",
+]);
 
 const reactionsActions = new Set(["react", "reactions"]);
 const pinActions = new Set(["pinMessage", "unpinMessage", "listPins"]);
@@ -279,6 +287,28 @@ export async function handleSlackAction(
           ),
         );
         return jsonResult({ ok: true, messages, hasMore: result.hasMore });
+      }
+      case "downloadFile": {
+        const fileId = readStringParam(params, "fileId", { required: true });
+        const maxBytes = account.config?.mediaMaxMb
+          ? account.config.mediaMaxMb * 1024 * 1024
+          : 20 * 1024 * 1024;
+        const downloaded = await downloadSlackFile(fileId, {
+          ...readOpts,
+          maxBytes,
+        });
+        if (!downloaded) {
+          return jsonResult({
+            ok: false,
+            error: "File could not be downloaded (not found, too large, or inaccessible).",
+          });
+        }
+        return await imageResultFromFile({
+          label: "slack-file",
+          path: downloaded.path,
+          extraText: downloaded.placeholder,
+          details: { fileId, path: downloaded.path },
+        });
       }
       default:
         break;

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -50,6 +50,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "kick",
   "ban",
   "set-presence",
+  "download-file",
 ] as const;
 
 export type ChannelMessageActionName = (typeof CHANNEL_MESSAGE_ACTION_NAMES)[number];

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -55,6 +55,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     kick: "none",
     ban: "none",
     "set-presence": "none",
+    "download-file": "none",
   };
 
 const ACTION_TARGET_ALIASES: Partial<Record<ChannelMessageActionName, string[]>> = {

--- a/src/plugin-sdk/slack-message-actions.test.ts
+++ b/src/plugin-sdk/slack-message-actions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleSlackMessageAction } from "./slack-message-actions.js";
+
+describe("handleSlackMessageAction", () => {
+  it("maps download-file to the internal downloadFile action", async () => {
+    const invoke = vi.fn(async (action: Record<string, unknown>) => ({
+      ok: true,
+      content: action,
+    }));
+
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "download-file",
+        cfg: {},
+        params: {
+          channelId: "C1",
+          fileId: "F123",
+        },
+      } as never,
+      invoke: invoke as never,
+    });
+
+    expect(invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "downloadFile",
+        fileId: "F123",
+      }),
+      expect.any(Object),
+    );
+  });
+});

--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -176,5 +176,10 @@ export async function handleSlackMessageAction(params: {
     return await invoke({ action: "emojiList", limit, accountId }, cfg);
   }
 
+  if (action === "download-file") {
+    const fileId = readStringParam(actionParams, "fileId", { required: true });
+    return await invoke({ action: "downloadFile", fileId, accountId }, cfg);
+  }
+
   throw new Error(`Action ${action} is not supported for provider ${providerId}.`);
 }

--- a/src/slack/actions.download-file.test.ts
+++ b/src/slack/actions.download-file.test.ts
@@ -1,0 +1,88 @@
+import type { WebClient } from "@slack/web-api";
+import { describe, expect, it, vi } from "vitest";
+
+const resolveSlackMedia = vi.fn();
+
+vi.mock("./monitor/media.js", () => ({
+  resolveSlackMedia: (...args: Parameters<typeof resolveSlackMedia>) => resolveSlackMedia(...args),
+}));
+
+const { downloadSlackFile } = await import("./actions.js");
+
+function createClient() {
+  return {
+    files: {
+      info: vi.fn(async () => ({ file: {} })),
+    },
+  } as unknown as WebClient & {
+    files: {
+      info: ReturnType<typeof vi.fn>;
+    };
+  };
+}
+
+describe("downloadSlackFile", () => {
+  it("returns null when files.info has no private download URL", async () => {
+    const client = createClient();
+    client.files.info.mockResolvedValueOnce({
+      file: {
+        id: "F123",
+        name: "image.png",
+      },
+    });
+
+    const result = await downloadSlackFile("F123", {
+      client,
+      token: "xoxb-test",
+      maxBytes: 1024,
+    });
+
+    expect(result).toBeNull();
+    expect(resolveSlackMedia).not.toHaveBeenCalled();
+  });
+
+  it("downloads via resolveSlackMedia using fresh files.info metadata", async () => {
+    const client = createClient();
+    client.files.info.mockResolvedValueOnce({
+      file: {
+        id: "F123",
+        name: "image.png",
+        mimetype: "image/png",
+        url_private_download: "https://files.slack.com/files-pri/T1-F123/image.png",
+      },
+    });
+    resolveSlackMedia.mockResolvedValueOnce([
+      {
+        path: "/tmp/image.png",
+        contentType: "image/png",
+        placeholder: "[Slack file: image.png]",
+      },
+    ]);
+
+    const result = await downloadSlackFile("F123", {
+      client,
+      token: "xoxb-test",
+      maxBytes: 1024,
+    });
+
+    expect(client.files.info).toHaveBeenCalledWith({ file: "F123" });
+    expect(resolveSlackMedia).toHaveBeenCalledWith({
+      files: [
+        {
+          id: "F123",
+          name: "image.png",
+          mimetype: "image/png",
+          url_private: undefined,
+          url_private_download: "https://files.slack.com/files-pri/T1-F123/image.png",
+        },
+      ],
+      token: "xoxb-test",
+      maxBytes: 1024,
+    });
+    expect(result).toEqual({
+      path: "/tmp/image.png",
+      contentType: "image/png",
+      placeholder: "[Slack file: image.png]",
+    });
+  });
+});

--- a/src/slack/message-actions.test.ts
+++ b/src/slack/message-actions.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import type { RemoteClawConfig } from "../config/config.js";
+import { listSlackMessageActions } from "./message-actions.js";
+
+describe("listSlackMessageActions", () => {
+  it("includes download-file when message actions are enabled", () => {
+    const cfg = {
+      channels: {
+        slack: {
+          botToken: "xoxb-test",
+          actions: {
+            messages: true,
+          },
+        },
+      },
+    } as RemoteClawConfig;
+
+    expect(listSlackMessageActions(cfg)).toEqual(
+      expect.arrayContaining(["read", "edit", "delete", "download-file"]),
+    );
+  });
+});

--- a/src/slack/message-actions.ts
+++ b/src/slack/message-actions.ts
@@ -32,6 +32,7 @@ export function listSlackMessageActions(cfg: RemoteClawConfig): ChannelMessageAc
     actions.add("read");
     actions.add("edit");
     actions.add("delete");
+    actions.add("download-file");
   }
   if (isActionEnabled("pins")) {
     actions.add("pin");


### PR DESCRIPTION
Cherry-pick of upstream commit `2c5b898ee` — "feat(slack): add download-file action for on-demand file attachment access (#24723)"

**Conflicts resolved:**
- Fixed `OpenClawConfig` → `RemoteClawConfig` in test files

Part of #677