### PR TITLE
Cherry-pick 18033d396: Cron+Slack: fix cooldown omission and cache cap

### DIFF
--- a/src/slack/sent-thread-cache.test.ts
+++ b/src/slack/sent-thread-cache.test.ts
@@ -55,4 +55,13 @@ describe("slack sent-thread-cache", () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.now() + 25 * 60 * 60 * 1000);
     expect(hasSlackThreadParticipation("A1", "C123", "1700000000.000001")).toBe(false);
   });
+
+  it("enforces maximum entries by evicting oldest fresh entries", () => {
+    for (let i = 0; i < 5001; i += 1) {
+      recordSlackThreadParticipation("A1", "C123", `1700000000.${String(i).padStart(6, "0")}`);
+    }
+
+    expect(hasSlackThreadParticipation("A1", "C123", "1700000000.000000")).toBe(false);
+    expect(hasSlackThreadParticipation("A1", "C123", "1700000000.005000")).toBe(true);
+  });
 });

--- a/src/slack/sent-thread-cache.ts
+++ b/src/slack/sent-thread-cache.ts
@@ -22,6 +22,13 @@ function evictExpired(): void {
   }
 }
 
+function evictOldest(): void {
+  const oldest = threadParticipation.keys().next().value;
+  if (oldest) {
+    threadParticipation.delete(oldest);
+  }
+}
+
 export function recordSlackThreadParticipation(
   accountId: string,
   channelId: string,
@@ -32,6 +39,9 @@ export function recordSlackThreadParticipation(
   }
   if (threadParticipation.size >= MAX_ENTRIES) {
     evictExpired();
+  }
+  if (threadParticipation.size >= MAX_ENTRIES) {
+    evictOldest();
   }
   threadParticipation.set(makeKey(accountId, channelId, threadTs), Date.now());
 }


### PR DESCRIPTION
Cherry-pick of upstream commit `18033d396` — "Cron+Slack: fix cooldown omission and cache cap enforcement"

**Conflicts resolved:**
- Content conflicts in `ui/src/ui/controllers/cron.ts` and `cron.test.ts` — fork removed `buildFailureAlert` function and related tests, kept the removal

Part of #677