### PR TITLE
Cherry-pick 40fda40aa: fix(slack): scope download-file to channel and thread

### DIFF
--- a/src/agents/tools/slack-actions.test.ts
+++ b/src/agents/tools/slack-actions.test.ts
@@ -216,6 +216,33 @@ describe("handleSlackAction", () => {
     );
   });
 
+  it("passes download scope (channel/thread) to downloadSlackFile", async () => {
+    downloadSlackFile.mockResolvedValueOnce(null);
+
+    const result = await handleSlackAction(
+      {
+        action: "downloadFile",
+        fileId: "F123",
+        to: "channel:C1",
+        replyTo: "123.456",
+      },
+      slackConfig(),
+    );
+
+    expect(downloadSlackFile).toHaveBeenCalledWith(
+      "F123",
+      expect.objectContaining({
+        channelId: "C1",
+        threadId: "123.456",
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({ ok: false }),
+      }),
+    );
+  });
+
   it.each([
     {
       name: "JSON blocks",

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -290,12 +290,17 @@ export async function handleSlackAction(
       }
       case "downloadFile": {
         const fileId = readStringParam(params, "fileId", { required: true });
+        const channelTarget = readStringParam(params, "channelId") ?? readStringParam(params, "to");
+        const channelId = channelTarget ? resolveSlackChannelId(channelTarget) : undefined;
+        const threadId = readStringParam(params, "threadId") ?? readStringParam(params, "replyTo");
         const maxBytes = account.config?.mediaMaxMb
           ? account.config.mediaMaxMb * 1024 * 1024
           : 20 * 1024 * 1024;
         const downloaded = await downloadSlackFile(fileId, {
           ...readOpts,
           maxBytes,
+          channelId,
+          threadId: threadId ?? undefined,
         });
         if (!downloaded) {
           return jsonResult({

--- a/src/plugin-sdk/slack-message-actions.test.ts
+++ b/src/plugin-sdk/slack-message-actions.test.ts
@@ -16,6 +16,7 @@ describe("handleSlackMessageAction", () => {
         params: {
           channelId: "C1",
           fileId: "F123",
+          threadId: "111.222",
         },
       } as never,
       invoke: invoke as never,
@@ -25,6 +26,39 @@ describe("handleSlackMessageAction", () => {
       expect.objectContaining({
         action: "downloadFile",
         fileId: "F123",
+        channelId: "C1",
+        threadId: "111.222",
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("maps download-file target aliases to scope fields", async () => {
+    const invoke = vi.fn(async (action: Record<string, unknown>) => ({
+      ok: true,
+      content: action,
+    }));
+
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "download-file",
+        cfg: {},
+        params: {
+          to: "channel:C2",
+          fileId: "F999",
+          replyTo: "333.444",
+        },
+      } as never,
+      invoke: invoke as never,
+    });
+
+    expect(invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "downloadFile",
+        fileId: "F999",
+        channelId: "channel:C2",
+        threadId: "333.444",
       }),
       expect.any(Object),
     );

--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -178,7 +178,20 @@ export async function handleSlackMessageAction(params: {
 
   if (action === "download-file") {
     const fileId = readStringParam(actionParams, "fileId", { required: true });
-    return await invoke({ action: "downloadFile", fileId, accountId }, cfg);
+    const channelId =
+      readStringParam(actionParams, "channelId") ?? readStringParam(actionParams, "to");
+    const threadId =
+      readStringParam(actionParams, "threadId") ?? readStringParam(actionParams, "replyTo");
+    return await invoke(
+      {
+        action: "downloadFile",
+        fileId,
+        channelId: channelId ?? undefined,
+        threadId: threadId ?? undefined,
+        accountId,
+      },
+      cfg,
+    );
   }
 
   throw new Error(`Action ${action} is not supported for provider ${providerId}.`);


### PR DESCRIPTION
Cherry-pick of upstream commit `40fda40aa` — "fix(slack): scope download-file to channel and thread context"

Clean cherry-pick, no conflicts.

Part of #677