### PR TITLE
Cherry-pick 4da4cc94c: fix(slack): treat HTTP mode accounts as configured

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -1,3 +1,4 @@
+import type { RemoteClawConfig } from "remoteclaw/plugin-sdk";
 import { describe, expect, it, vi } from "vitest";
 
 const handleSlackActionMock = vi.fn();
@@ -102,5 +103,52 @@ describe("slackPlugin outbound", () => {
       }),
     );
     expect(result).toEqual({ channel: "slack", messageId: "m-media" });
+  });
+});
+
+describe("slackPlugin config", () => {
+  it("treats HTTP mode accounts with bot token + signing secret as configured", async () => {
+    const cfg: RemoteClawConfig = {
+      channels: {
+        slack: {
+          mode: "http",
+          botToken: "xoxb-http",
+          signingSecret: "secret-http",
+        },
+      },
+    };
+
+    const account = slackPlugin.config.resolveAccount(cfg, "default");
+    const configured = slackPlugin.config.isConfigured?.(account, cfg);
+    const snapshot = await slackPlugin.status?.buildAccountSnapshot?.({
+      account,
+      cfg,
+      runtime: undefined,
+    });
+
+    expect(configured).toBe(true);
+    expect(snapshot?.configured).toBe(true);
+  });
+
+  it("keeps socket mode requiring app token", async () => {
+    const cfg: RemoteClawConfig = {
+      channels: {
+        slack: {
+          mode: "socket",
+          botToken: "xoxb-socket",
+        },
+      },
+    };
+
+    const account = slackPlugin.config.resolveAccount(cfg, "default");
+    const configured = slackPlugin.config.isConfigured?.(account, cfg);
+    const snapshot = await slackPlugin.status?.buildAccountSnapshot?.({
+      account,
+      cfg,
+      runtime: undefined,
+    });
+
+    expect(configured).toBe(false);
+    expect(snapshot?.configured).toBe(false);
   });
 });


### PR DESCRIPTION
Cherry-pick of upstream commit `4da4cc94c` — "fix(slack): treat HTTP mode accounts as configured [AI-assisted] (openclaw#30571) thanks @liuxiaopai-ai"

**Conflicts resolved:**
- `CHANGELOG.md` — removed (deleted in fork)
- Fixed `OpenClawConfig` → `RemoteClawConfig` in test files
- Fixed `openclaw/plugin-sdk` → `remoteclaw/plugin-sdk` import

Part of #677