### PR TITLE
Cherry-pick 4320cde91: fix(slack): land #31028 from @taw0002

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -16,6 +16,10 @@ vi.mock("./runtime.js", () => ({
 import { slackPlugin } from "./channel.js";
 
 describe("slackPlugin actions", () => {
+  it("prefers session lookup for announce target routing", () => {
+    expect(slackPlugin.meta.preferSessionLookupForAnnounceTarget).toBe(true);
+  });
+
   it("forwards read threadId to Slack action handler", async () => {
     handleSlackActionMock.mockResolvedValueOnce({ messages: [], hasMore: false });
     const handleAction = slackPlugin.actions?.handleAction;

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -67,6 +67,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
   id: "slack",
   meta: {
     ...meta,
+    preferSessionLookupForAnnounceTarget: true,
   },
   onboarding: slackOnboardingAdapter,
   pairing: {


### PR DESCRIPTION
Cherry-pick of upstream commit `4320cde91` — "fix(slack): land #31028 from @taw0002"

**Conflicts resolved:**
- `CHANGELOG.md` — removed (deleted in fork)

Part of #677