### PR TITLE
Cherry-pick 2a381e6d7: replyToMode first only applies reply-to to first chunk

### DIFF
--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -1853,10 +1853,16 @@ describe("createTelegramBot", () => {
       });
 
       expect(sendMessageSpy.mock.calls.length).toBeGreaterThan(1);
-      for (const call of sendMessageSpy.mock.calls) {
-        expect((call[2] as { reply_to_message_id?: number } | undefined)?.reply_to_message_id).toBe(
-          messageId,
-        );
+      for (let i = 0; i < sendMessageSpy.mock.calls.length; i++) {
+        const call = sendMessageSpy.mock.calls[i];
+        const replyTo = (call[2] as { reply_to_message_id?: number } | undefined)
+          ?.reply_to_message_id;
+        if (mode === "all") {
+          expect(replyTo).toBe(messageId);
+        } else {
+          // mode === "first": only the first chunk carries reply-to
+          expect(replyTo).toBe(i === 0 ? messageId : undefined);
+        }
       }
     }
   });

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -376,6 +376,7 @@ describe("deliverReplies", () => {
           mediaUrl: "https://example.com/note.ogg",
           text: "chunk-one\n\nchunk-two",
           replyToId: "77",
+          audioAsVoice: true,
         },
       ],
       runtime,

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -359,6 +359,39 @@ describe("deliverReplies", () => {
     );
   });
 
+  it("voice fallback applies reply-to only on first chunk when replyToMode is first", async () => {
+    const { runtime, sendVoice, sendMessage, bot } = createVoiceFailureHarness({
+      voiceError: createVoiceMessagesForbiddenError(),
+      sendMessageResult: {
+        message_id: 6,
+        chat: { id: "123" },
+      },
+    });
+
+    mockMediaLoad("note.ogg", "audio/ogg", "voice");
+
+    await deliverWith({
+      replies: [
+        {
+          mediaUrl: "https://example.com/note.ogg",
+          text: "chunk-one\n\nchunk-two",
+          replyToId: "77",
+        },
+      ],
+      runtime,
+      bot,
+      replyToMode: "first",
+      textLimit: 12,
+    });
+
+    expect(sendVoice).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(sendMessage.mock.calls[0][2]).toEqual(
+      expect.objectContaining({ reply_to_message_id: 77 }),
+    );
+    expect(sendMessage.mock.calls[1][2]).not.toHaveProperty("reply_to_message_id");
+  });
+
   it("rethrows non-VOICE_MESSAGES_FORBIDDEN errors from sendVoice", async () => {
     const runtime = createRuntime();
     const sendVoice = vi.fn().mockRejectedValue(new Error("Network error"));
@@ -378,6 +411,89 @@ describe("deliverReplies", () => {
     expect(sendVoice).toHaveBeenCalledTimes(1);
     // Text fallback should NOT be attempted for other errors
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("replyToMode 'first' only applies reply-to to the first text chunk", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 20,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    // Use a small textLimit to force multiple chunks
+    await deliverReplies({
+      replies: [{ text: "chunk-one\n\nchunk-two", replyToId: "700" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "first",
+      textLimit: 12,
+    });
+
+    expect(sendMessage.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // First chunk should have reply_to_message_id
+    expect(sendMessage.mock.calls[0][2]).toEqual(
+      expect.objectContaining({ reply_to_message_id: 700 }),
+    );
+    // Second chunk should NOT have reply_to_message_id
+    expect(sendMessage.mock.calls[1][2]).not.toHaveProperty("reply_to_message_id");
+  });
+
+  it("replyToMode 'all' applies reply-to to every text chunk", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 21,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    await deliverReplies({
+      replies: [{ text: "chunk-one\n\nchunk-two", replyToId: "800" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "all",
+      textLimit: 12,
+    });
+
+    expect(sendMessage.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // Both chunks should have reply_to_message_id
+    for (const call of sendMessage.mock.calls) {
+      expect(call[2]).toEqual(expect.objectContaining({ reply_to_message_id: 800 }));
+    }
+  });
+
+  it("replyToMode 'first' only applies reply-to to first media item", async () => {
+    const runtime = createRuntime();
+    const sendPhoto = vi.fn().mockResolvedValue({
+      message_id: 30,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendPhoto });
+
+    mockMediaLoad("a.jpg", "image/jpeg", "img1");
+    mockMediaLoad("b.jpg", "image/jpeg", "img2");
+
+    await deliverReplies({
+      replies: [{ mediaUrls: ["https://a.jpg", "https://b.jpg"], replyToId: "900" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "first",
+      textLimit: 4000,
+    });
+
+    expect(sendPhoto).toHaveBeenCalledTimes(2);
+    // First media should have reply_to_message_id
+    expect(sendPhoto.mock.calls[0][2]).toEqual(
+      expect.objectContaining({ reply_to_message_id: 900 }),
+    );
+    // Second media should NOT have reply_to_message_id
+    expect(sendPhoto.mock.calls[1][2]).not.toHaveProperty("reply_to_message_id");
   });
 
   it("rethrows VOICE_MESSAGES_FORBIDDEN when no text fallback is available", async () => {

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -285,7 +285,7 @@ export async function deliverReplies(params: {
                   replyMarkup,
                 });
               }
-              if (replyToMessageIdForPayload && !hasReplied) {
+              if (replyToId && !hasReplied) {
                 hasReplied = true;
               }
               continue;


### PR DESCRIPTION
Cherry-pick of upstream [`2a381e6d7`](https://github.com/openclaw/openclaw/commit/2a381e6d7) — fix(telegram): replyToMode 'first' now only applies reply-to to first chunk

## Conflicts resolved
- `CHANGELOG.md` — `git rm` (deleted in fork)

Part of #676.

Cherry-picked-from: 2a381e6d7