### PR TITLE
Cherry-pick bf9585d05: feishu auto-grant document permissions

### DIFF
--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -21,6 +21,14 @@ export const FeishuDocSchema = Type.Union([
     action: Type.Literal("create"),
     title: Type.String({ description: "Document title" }),
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
+    owner_open_id: Type.Optional(
+      Type.String({ description: "Open ID of the user to grant ownership permission" }),
+    ),
+    owner_perm_type: Type.Optional(
+      Type.Union([Type.Literal("view"), Type.Literal("edit"), Type.Literal("full_access")], {
+        description: "Permission type (default: full_access)",
+      }),
+    ),
   }),
   Type.Object({
     action: Type.Literal("list_blocks"),

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -21,9 +21,11 @@ import { registerFeishuDocTools } from "./docx.js";
 
 describe("feishu_doc image fetch hardening", () => {
   const convertMock = vi.hoisted(() => vi.fn());
+  const documentCreateMock = vi.hoisted(() => vi.fn());
   const blockListMock = vi.hoisted(() => vi.fn());
   const blockChildrenCreateMock = vi.hoisted(() => vi.fn());
   const driveUploadAllMock = vi.hoisted(() => vi.fn());
+  const permissionMemberCreateMock = vi.hoisted(() => vi.fn());
   const blockPatchMock = vi.hoisted(() => vi.fn());
   const scopeListMock = vi.hoisted(() => vi.fn());
 
@@ -34,6 +36,7 @@ describe("feishu_doc image fetch hardening", () => {
       docx: {
         document: {
           convert: convertMock,
+          create: documentCreateMock,
         },
         documentBlock: {
           list: blockListMock,
@@ -46,6 +49,9 @@ describe("feishu_doc image fetch hardening", () => {
       drive: {
         media: {
           uploadAll: driveUploadAllMock,
+        },
+        permissionMember: {
+          create: permissionMemberCreateMock,
         },
       },
       application: {
@@ -78,6 +84,11 @@ describe("feishu_doc image fetch hardening", () => {
     });
 
     driveUploadAllMock.mockResolvedValue({ file_token: "token_1" });
+    documentCreateMock.mockResolvedValue({
+      code: 0,
+      data: { document: { document_id: "doc_created", title: "Created Doc" } },
+    });
+    permissionMemberCreateMock.mockResolvedValue({ code: 0 });
     blockPatchMock.mockResolvedValue({ code: 0 });
     scopeListMock.mockResolvedValue({ code: 0, data: { scopes: [] } });
   });
@@ -119,5 +130,108 @@ describe("feishu_doc image fetch hardening", () => {
     expect(result.details.images_processed).toBe(0);
     expect(consoleErrorSpy).toHaveBeenCalled();
     consoleErrorSpy.mockRestore();
+  });
+
+  it("reports owner permission details when grant succeeds", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDocTools({
+      config: {
+        channels: {
+          feishu: {
+            appId: "app_id",
+            appSecret: "app_secret",
+          },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+
+    const feishuDocTool = registerTool.mock.calls
+      .map((call) => call[0])
+      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
+      .find((tool) => tool.name === "feishu_doc");
+    expect(feishuDocTool).toBeDefined();
+
+    const result = await feishuDocTool.execute("tool-call", {
+      action: "create",
+      title: "Demo",
+      owner_open_id: "ou_123",
+      owner_perm_type: "edit",
+    });
+
+    expect(permissionMemberCreateMock).toHaveBeenCalled();
+    expect(result.details.owner_permission_added).toBe(true);
+    expect(result.details.owner_open_id).toBe("ou_123");
+    expect(result.details.owner_perm_type).toBe("edit");
+  });
+
+  it("does not report owner permission details when grant fails", async () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    permissionMemberCreateMock.mockRejectedValueOnce(new Error("permission denied"));
+
+    const registerTool = vi.fn();
+    registerFeishuDocTools({
+      config: {
+        channels: {
+          feishu: {
+            appId: "app_id",
+            appSecret: "app_secret",
+          },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+
+    const feishuDocTool = registerTool.mock.calls
+      .map((call) => call[0])
+      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
+      .find((tool) => tool.name === "feishu_doc");
+    expect(feishuDocTool).toBeDefined();
+
+    const result = await feishuDocTool.execute("tool-call", {
+      action: "create",
+      title: "Demo",
+      owner_open_id: "ou_123",
+      owner_perm_type: "edit",
+    });
+
+    expect(permissionMemberCreateMock).toHaveBeenCalled();
+    expect(result.details.owner_permission_added).toBeUndefined();
+    expect(result.details.owner_open_id).toBeUndefined();
+    expect(result.details.owner_perm_type).toBeUndefined();
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("skips permission grant when owner_open_id is omitted", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDocTools({
+      config: {
+        channels: {
+          feishu: {
+            appId: "app_id",
+            appSecret: "app_secret",
+          },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+
+    const feishuDocTool = registerTool.mock.calls
+      .map((call) => call[0])
+      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
+      .find((tool) => tool.name === "feishu_doc");
+    expect(feishuDocTool).toBeDefined();
+
+    const result = await feishuDocTool.execute("tool-call", {
+      action: "create",
+      title: "Demo",
+    });
+
+    expect(permissionMemberCreateMock).not.toHaveBeenCalled();
+    expect(result.details.owner_permission_added).toBeUndefined();
   });
 });

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -268,7 +268,13 @@ async function readDoc(client: Lark.Client, docToken: string) {
   };
 }
 
-async function createDoc(client: Lark.Client, title: string, folderToken?: string) {
+async function createDoc(
+  client: Lark.Client,
+  title: string,
+  folderToken?: string,
+  ownerOpenId?: string,
+  ownerPermType: "view" | "edit" | "full_access" = "full_access",
+) {
   const res = await client.docx.document.create({
     data: { title, folder_token: folderToken },
   });
@@ -276,10 +282,37 @@ async function createDoc(client: Lark.Client, title: string, folderToken?: strin
     throw new Error(res.msg);
   }
   const doc = res.data?.document;
+  const docToken = doc?.document_id;
+  let ownerPermissionAdded = false;
+
+  // Auto add owner permission if ownerOpenId is provided
+  if (docToken && ownerOpenId) {
+    try {
+      await client.drive.permissionMember.create({
+        path: { token: docToken },
+        params: { type: "docx", need_notification: false },
+        data: {
+          member_type: "openid",
+          member_id: ownerOpenId,
+          perm: ownerPermType,
+        },
+      });
+      ownerPermissionAdded = true;
+    } catch (err) {
+      console.warn("Failed to add owner permission (non-critical):", err);
+    }
+  }
+
   return {
-    document_id: doc?.document_id,
+    document_id: docToken,
     title: doc?.title,
-    url: `https://feishu.cn/docx/${doc?.document_id}`,
+    url: `https://feishu.cn/docx/${docToken}`,
+    ...(ownerOpenId &&
+      ownerPermissionAdded && {
+        owner_permission_added: true,
+        owner_open_id: ownerOpenId,
+        owner_perm_type: ownerPermType,
+      }),
   };
 }
 
@@ -484,7 +517,15 @@ export function registerFeishuDocTools(api: RemoteClawPluginApi) {
               case "append":
                 return json(await appendDoc(client, p.doc_token, p.content, mediaMaxBytes));
               case "create":
-                return json(await createDoc(client, p.title, p.folder_token));
+                return json(
+                  await createDoc(
+                    client,
+                    p.title,
+                    p.folder_token,
+                    p.owner_open_id,
+                    p.owner_perm_type,
+                  ),
+                );
               case "list_blocks":
                 return json(await listBlocks(client, p.doc_token));
               case "get_block":


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@bf9585d05.

> PR: Feishu Plugin - Auto-grant document permissions to requesting user (openclaw#28295) thanks @zhoulongchao77

Adds `owner_open_id` and `owner_perm_type` parameters to the `create` action of `feishu_doc` tool. When provided, auto-grants document permissions to the requesting user after creation.

**Conflict resolution**: Upstream uses factory-style `registerTool(ctx => {...})` while fork uses plain object style. Adapted the new `createDoc` params to fork's simplified call pattern.

Resolves part of #678.

Cherry-picked-from: bf9585d056