### PR TITLE
Cherry-pick 4221b5f80: fix: pass rootId to streaming card in Feishu topic groups (opencl

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1006,6 +1006,7 @@ export async function handleFeishuMessage(params: {
       chatId: ctx.chatId,
       replyToMessageId: ctx.messageId,
       replyInThread,
+      rootId: ctx.rootId,
       mentionTargets: ctx.mentionTargets,
       accountId: account.accountId,
     });

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -105,6 +105,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       agentId: "agent",
       runtime: { log: vi.fn(), error: vi.fn() } as never,
       chatId: "oc_chat",
+      rootId: "om_root_topic",
     });
 
     const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
@@ -112,6 +113,11 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
     expect(streamingInstances).toHaveLength(1);
     expect(streamingInstances[0].start).toHaveBeenCalledTimes(1);
+    expect(streamingInstances[0].start).toHaveBeenCalledWith("oc_chat", "chat_id", {
+      replyToMessageId: undefined,
+      replyInThread: undefined,
+      rootId: "om_root_topic",
+    });
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -29,14 +29,23 @@ export type CreateFeishuReplyDispatcherParams = {
   chatId: string;
   replyToMessageId?: string;
   replyInThread?: boolean;
+  rootId?: string;
   mentionTargets?: MentionTarget[];
   accountId?: string;
 };
 
 export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherParams) {
   const core = getFeishuRuntime();
-  const { cfg, agentId, chatId, replyToMessageId, replyInThread, mentionTargets, accountId } =
-    params;
+  const {
+    cfg,
+    agentId,
+    chatId,
+    replyToMessageId,
+    replyInThread,
+    rootId,
+    mentionTargets,
+    accountId,
+  } = params;
   const account = resolveFeishuAccount({ cfg, accountId });
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
 
@@ -105,6 +114,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         await streaming.start(chatId, resolveReceiveIdType(chatId), {
           replyToMessageId,
           replyInThread,
+          rootId,
         });
       } catch (error) {
         params.runtime.error?.(`feishu: streaming start failed: ${String(error)}`);

--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -24,9 +24,9 @@ const sourceRoots = [
 const allowedRawFetchCallsites = new Set([
   "extensions/bluebubbles/src/types.ts:131",
   "extensions/feishu/src/streaming-card.ts:31",
-  "extensions/feishu/src/streaming-card.ts:100",
-  "extensions/feishu/src/streaming-card.ts:141",
-  "extensions/feishu/src/streaming-card.ts:197",
+  "extensions/feishu/src/streaming-card.ts:101",
+  "extensions/feishu/src/streaming-card.ts:143",
+  "extensions/feishu/src/streaming-card.ts:199",
   "extensions/google-gemini-cli-auth/oauth.ts:372",
   "extensions/google-gemini-cli-auth/oauth.ts:408",
   "extensions/google-gemini-cli-auth/oauth.ts:447",


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@4221b5f80.

> fix: pass rootId to streaming card in Feishu topic groups (openclaw#28346) thanks @Sid-Qin

Resolves part of #678.
Cherry-picked-from: 4221b5f80