### PR TITLE
Cherry-pick aef535510: fix(feishu): add reactionNotifications mode gating

### DIFF
--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -110,6 +110,7 @@ const GroupSessionScopeSchema = z
  * - "enabled": Messages in different topics get separate sessions
  */
 const TopicSessionModeSchema = z.enum(["disabled", "enabled"]).optional();
+const ReactionNotificationModeSchema = z.enum(["off", "own", "all"]).optional();
 
 /**
  * Reply-in-thread mode for group chats.
@@ -159,6 +160,7 @@ const FeishuSharedConfigShape = {
   streaming: StreamingModeSchema,
   tools: FeishuToolsConfigSchema,
   replyInThread: ReplyInThreadSchema,
+  reactionNotifications: ReactionNotificationModeSchema,
 };
 
 /**
@@ -195,6 +197,7 @@ export const FeishuConfigSchema = z
     webhookPath: z.string().optional().default("/feishu/events"),
     ...FeishuSharedConfigShape,
     dmPolicy: DmPolicySchema.optional().default("pairing"),
+    reactionNotifications: ReactionNotificationModeSchema.optional().default("own"),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     requireMention: z.boolean().optional().default(true),
     groupSessionScope: GroupSessionScopeSchema,

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -49,6 +49,31 @@ describe("resolveReactionSyntheticEvent", () => {
     expect(result).toBeNull();
   });
 
+  it("drops reactions when reactionNotifications is off", async () => {
+    const event = makeReactionEvent();
+    const result = await resolveReactionSyntheticEvent({
+      cfg: {
+        channels: {
+          feishu: {
+            reactionNotifications: "off",
+          },
+        },
+      } as ClawdbotConfig,
+      accountId: "default",
+      event,
+      botOpenId: "ou_bot",
+      fetchMessage: async () => ({
+        messageId: "om_msg1",
+        chatId: "oc_group",
+        senderOpenId: "ou_bot",
+        senderType: "app",
+        content: "hello",
+        contentType: "text",
+      }),
+    });
+    expect(result).toBeNull();
+  });
+
   it("filters reactions on non-bot messages", async () => {
     const event = makeReactionEvent();
     const result = await resolveReactionSyntheticEvent({
@@ -66,6 +91,32 @@ describe("resolveReactionSyntheticEvent", () => {
       }),
     });
     expect(result).toBeNull();
+  });
+
+  it("allows non-bot reactions when reactionNotifications is all", async () => {
+    const event = makeReactionEvent();
+    const result = await resolveReactionSyntheticEvent({
+      cfg: {
+        channels: {
+          feishu: {
+            reactionNotifications: "all",
+          },
+        },
+      } as ClawdbotConfig,
+      accountId: "default",
+      event,
+      botOpenId: "ou_bot",
+      fetchMessage: async () => ({
+        messageId: "om_msg1",
+        chatId: "oc_group",
+        senderOpenId: "ou_other",
+        senderType: "user",
+        content: "hello",
+        contentType: "text",
+      }),
+      uuid: () => "fixed-uuid",
+    });
+    expect(result?.message.message_id).toBe("om_msg1:reaction:THUMBSUP:fixed-uuid");
   });
 
   it("drops unverified reactions when sender verification times out", async () => {


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@aef535510.

**Original**: fix(feishu): add reactionNotifications mode gating (openclaw#29388) thanks @Takhoffman

Adds `reactionNotifications` mode to Feishu config schema gating reaction event notifications.

Part of #678.

Cherry-picked-from: aef535510