### PR TITLE
Cherry-pick b28344eac: fix(feishu): insert document blocks sequentially to preserve order (#26022) (openclaw#26172) thanks @echoVic

### DIFF
--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -119,17 +119,25 @@ async function insertBlocks(
     return { children: [], skipped };
   }
 
-  const res = await client.docx.documentBlockChildren.create({
-    path: { document_id: docToken, block_id: blockId },
-    data: {
-      children: cleaned,
-      ...(index !== undefined && { index }),
-    },
-  });
-  if (res.code !== 0) {
-    throw new Error(res.msg);
+  // Insert blocks one at a time to preserve document order.
+  // The batch API (sending all children at once) does not guarantee ordering
+  // because Feishu processes the batch asynchronously.  Sequential single-block
+  // inserts (each appended to the end) produce deterministic results.
+  const allInserted: any[] = [];
+  for (const [offset, block] of cleaned.entries()) {
+    const res = await client.docx.documentBlockChildren.create({
+      path: { document_id: docToken, block_id: blockId },
+      data: {
+        children: [block],
+        ...(index !== undefined ? { index: index + offset } : {}),
+      },
+    });
+    if (res.code !== 0) {
+      throw new Error(res.msg);
+    }
+    allInserted.push(...(res.data?.children ?? []));
   }
-  return { children: res.data?.children ?? [], skipped };
+  return { children: allInserted, skipped };
 }
 
 async function clearDocumentContent(client: Lark.Client, docToken: string) {


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@b28344eac.

**Original**: fix(feishu): insert document blocks sequentially to preserve order (#26022) (openclaw#26172) thanks @echoVic

Part of #678.

Cherry-picked-from: b28344eac