### PR TITLE
Cherry-pick 10f1be107: fix(feishu): replace console.log with runtime log

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -59,13 +59,18 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (!replyToMessageId) {
         return;
       }
-      typingState = await addTypingIndicator({ cfg, messageId: replyToMessageId, accountId });
+      typingState = await addTypingIndicator({
+        cfg,
+        messageId: replyToMessageId,
+        accountId,
+        runtime: params.runtime,
+      });
     },
     stop: async () => {
       if (!typingState) {
         return;
       }
-      await removeTypingIndicator({ cfg, state: typingState, accountId });
+      await removeTypingIndicator({ cfg, state: typingState, accountId, runtime: params.runtime });
       typingState = null;
     },
     onStartError: (err) =>

--- a/extensions/feishu/src/typing.ts
+++ b/extensions/feishu/src/typing.ts
@@ -1,6 +1,7 @@
-import type { ClawdbotConfig } from "remoteclaw/plugin-sdk";
+import type { ClawdbotConfig, RuntimeEnv } from "remoteclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { getFeishuRuntime } from "./runtime.js";
 
 // Feishu emoji types for typing indicator
 // See: https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce
@@ -103,8 +104,9 @@ export async function addTypingIndicator(params: {
   cfg: ClawdbotConfig;
   messageId: string;
   accountId?: string;
+  runtime?: RuntimeEnv;
 }): Promise<TypingIndicatorState> {
-  const { cfg, messageId, accountId } = params;
+  const { cfg, messageId, accountId, runtime } = params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     return { messageId, reactionId: null };
@@ -124,9 +126,11 @@ export async function addTypingIndicator(params: {
     // instead of throwing. Detect backoff codes and throw to trip the breaker.
     const backoffCode = getBackoffCodeFromResponse(response);
     if (backoffCode !== undefined) {
-      console.log(
-        `[feishu] typing indicator response contains backoff code ${backoffCode}, stopping keepalive`,
-      );
+      if (getFeishuRuntime().logging.shouldLogVerbose()) {
+        runtime?.log?.(
+          `[feishu] typing indicator response contains backoff code ${backoffCode}, stopping keepalive`,
+        );
+      }
       throw new FeishuBackoffError(backoffCode);
     }
 
@@ -135,11 +139,15 @@ export async function addTypingIndicator(params: {
     return { messageId, reactionId };
   } catch (err) {
     if (isFeishuBackoffError(err)) {
-      console.log(`[feishu] typing indicator hit rate-limit/quota, stopping keepalive`);
+      if (getFeishuRuntime().logging.shouldLogVerbose()) {
+        runtime?.log?.("[feishu] typing indicator hit rate-limit/quota, stopping keepalive");
+      }
       throw err;
     }
     // Silently fail for other non-critical errors (e.g. message deleted, permission issues)
-    console.log(`[feishu] failed to add typing indicator: ${err}`);
+    if (getFeishuRuntime().logging.shouldLogVerbose()) {
+      runtime?.log?.(`[feishu] failed to add typing indicator: ${String(err)}`);
+    }
     return { messageId, reactionId: null };
   }
 }
@@ -153,8 +161,9 @@ export async function removeTypingIndicator(params: {
   cfg: ClawdbotConfig;
   state: TypingIndicatorState;
   accountId?: string;
+  runtime?: RuntimeEnv;
 }): Promise<void> {
-  const { cfg, state, accountId } = params;
+  const { cfg, state, accountId, runtime } = params;
   if (!state.reactionId) {
     return;
   }
@@ -177,17 +186,25 @@ export async function removeTypingIndicator(params: {
     // Check for backoff codes in non-throwing SDK responses
     const backoffCode = getBackoffCodeFromResponse(result);
     if (backoffCode !== undefined) {
-      console.log(
-        `[feishu] typing indicator removal response contains backoff code ${backoffCode}, stopping keepalive`,
-      );
+      if (getFeishuRuntime().logging.shouldLogVerbose()) {
+        runtime?.log?.(
+          `[feishu] typing indicator removal response contains backoff code ${backoffCode}, stopping keepalive`,
+        );
+      }
       throw new FeishuBackoffError(backoffCode);
     }
   } catch (err) {
     if (isFeishuBackoffError(err)) {
-      console.log(`[feishu] typing indicator removal hit rate-limit/quota, stopping keepalive`);
+      if (getFeishuRuntime().logging.shouldLogVerbose()) {
+        runtime?.log?.(
+          "[feishu] typing indicator removal hit rate-limit/quota, stopping keepalive",
+        );
+      }
       throw err;
     }
     // Silently fail for other non-critical errors
-    console.log(`[feishu] failed to remove typing indicator: ${err}`);
+    if (getFeishuRuntime().logging.shouldLogVerbose()) {
+      runtime?.log?.(`[feishu] failed to remove typing indicator: ${String(err)}`);
+    }
   }
 }

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -147,7 +147,7 @@ function startPollingLoop(params: {
       if (err instanceof ZaloApiError && err.isPollingTimeout) {
         // no updates
       } else if (!isStopped() && !abortSignal.aborted) {
-        console.error(`[${account.accountId}] Zalo polling error:`, err);
+        runtime.error?.(`[${account.accountId}] Zalo polling error: ${String(err)}`);
         await new Promise((resolve) => setTimeout(resolve, 5000));
       }
     }
@@ -194,10 +194,12 @@ async function processUpdate(
       );
       break;
     case "message.sticker.received":
-      console.log(`[${account.accountId}] Received sticker from ${message.from.id}`);
+      logVerbose(core, runtime, `[${account.accountId}] Received sticker from ${message.from.id}`);
       break;
     case "message.unsupported.received":
-      console.log(
+      logVerbose(
+        core,
+        runtime,
         `[${account.accountId}] Received unsupported message type from ${message.from.id}`,
       );
       break;
@@ -263,7 +265,7 @@ async function handleImageMessage(
       mediaPath = saved.path;
       mediaType = saved.contentType;
     } catch (err) {
-      console.error(`[${account.accountId}] Failed to download Zalo image:`, err);
+      runtime.error?.(`[${account.accountId}] Failed to download Zalo image: ${String(err)}`);
     }
   }
 


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@10f1be107.

**Original**: fix(feishu): replace console.log with runtime log for typing indicator errors (openclaw#18841) thanks @Clawborn

Conflict resolution: import path `openclaw/plugin-sdk` → `remoteclaw/plugin-sdk` (fork rebrand).

Part of #678.

Cherry-picked-from: 10f1be107