### PR TITLE
Cherry-pick f81093285: Feishu: fix locale-wrapper post parser test (#29576)

### DIFF
--- a/extensions/feishu/src/post.test.ts
+++ b/extensions/feishu/src/post.test.ts
@@ -92,11 +92,13 @@ describe("parsePostContent", () => {
     expect(parsePostContent(wrappedByPost)).toEqual({
       textContent: "标题\n\n内容A",
       imageKeys: [],
+      mediaKeys: [],
       mentionedOpenIds: [],
     });
     expect(parsePostContent(wrappedByLocale)).toEqual({
       textContent: "标题\n\n内容B",
       imageKeys: [],
+      mediaKeys: [],
       mentionedOpenIds: [],
     });
   });


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@f81093285.

**Original**: Feishu: fix locale-wrapper post parser test (#29576)

Part of #678.

Cherry-picked-from: f81093285