### PR TITLE
Cherry-pick 53a2e72fc+f81093285: feishu post video extraction + locale test fix

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -658,6 +658,60 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("downloads embedded media tags from post messages as files", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-sender",
+        },
+      },
+      message: {
+        message_id: "msg-post-media",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "post",
+        content: JSON.stringify({
+          title: "Rich text",
+          content: [
+            [
+              {
+                tag: "media",
+                file_key: "file_post_media_payload",
+                file_name: "embedded.mov",
+              },
+            ],
+          ],
+        }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockDownloadMessageResourceFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "msg-post-media",
+        fileKey: "file_post_media_payload",
+        type: "file",
+      }),
+    );
+    expect(mockSaveMediaBuffer).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      "video/mp4",
+      "inbound",
+      expect.any(Number),
+    );
+  });
+
   it("includes message_id in BodyForAgent on its own line", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/post.test.ts
+++ b/extensions/feishu/src/post.test.ts
@@ -92,11 +92,13 @@ describe("parsePostContent", () => {
     expect(parsePostContent(wrappedByPost)).toEqual({
       textContent: "标题\n\n内容A",
       imageKeys: [],
+      mediaKeys: [],
       mentionedOpenIds: [],
     });
     expect(parsePostContent(wrappedByLocale)).toEqual({
       textContent: "标题\n\n内容B",
       imageKeys: [],
+      mediaKeys: [],
       mentionedOpenIds: [],
     });
   });


### PR DESCRIPTION
Combined cherry-pick of two dependent upstream commits:

1. openclaw/openclaw@53a2e72fc — feat(feishu): extract embedded video/media from post (rich text) messages (#21786)
2. openclaw/openclaw@f81093285 — Feishu: fix locale-wrapper post parser test (#29576)

Picked together because f81093285 fixes a test regression introduced by 53a2e72fc.

Part of #678.

Cherry-picked-from: 53a2e72fc, f81093285