### PR TITLE
Cherry-pick 4ad49de89: feat(feishu): add parent/root inbound context for quote support (openclaw#18529)

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -263,6 +263,51 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockCreateFeishuClient).not.toHaveBeenCalled();
   });
 
+  it("propagates parent/root message ids into inbound context for reply reconstruction", async () => {
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "om_parent_001",
+      chatId: "oc-group",
+      content: "quoted content",
+      contentType: "text",
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          enabled: true,
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-replier",
+        },
+      },
+      message: {
+        message_id: "om_reply_001",
+        root_id: "om_root_001",
+        parent_id: "om_parent_001",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "reply text" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ReplyToId: "om_parent_001",
+        RootMessageId: "om_root_001",
+        ReplyToBody: "quoted content",
+      }),
+    );
+  });
+
   it("creates pairing request and drops unauthorized DMs in pairing mode", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockReadAllowFromStore.mockResolvedValue([]);

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1122,6 +1122,10 @@ export async function handleFeishuMessage(params: {
       Body: combinedBody,
       BodyForAgent: messageBody,
       InboundHistory: inboundHistory,
+      // Quote/reply message support: use standard ReplyToId for parent,
+      // and pass root_id for thread reconstruction.
+      ReplyToId: ctx.parentId,
+      RootMessageId: ctx.rootId,
       RawBody: ctx.content,
       CommandBody: ctx.content,
       From: feishuFrom,

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -1,0 +1,71 @@
+import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMessageFeishu } from "./send.js";
+
+const { mockClientGet, mockCreateFeishuClient, mockResolveFeishuAccount } = vi.hoisted(() => ({
+  mockClientGet: vi.fn(),
+  mockCreateFeishuClient: vi.fn(),
+  mockResolveFeishuAccount: vi.fn(),
+}));
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: mockCreateFeishuClient,
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveFeishuAccount: mockResolveFeishuAccount,
+}));
+
+describe("getMessageFeishu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveFeishuAccount.mockReturnValue({
+      accountId: "default",
+      configured: true,
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          get: mockClientGet,
+        },
+      },
+    });
+  });
+
+  it("extracts text content from interactive card elements", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_1",
+            chat_id: "oc_1",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                elements: [
+                  { tag: "markdown", content: "hello markdown" },
+                  { tag: "div", text: { content: "hello div" } },
+                ],
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_1",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_1",
+        chatId: "oc_1",
+        contentType: "interactive",
+        content: "hello markdown\nhello div",
+      }),
+    );
+  });
+});

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -1,4 +1,4 @@
-import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import type { ClawdbotConfig } from "remoteclaw/plugin-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getMessageFeishu } from "./send.js";
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -73,6 +73,17 @@ export async function getMessageFeishu(params: {
       const parsed = JSON.parse(content);
       if (item.msg_type === "text" && parsed.text) {
         content = parsed.text;
+      } else if (item.msg_type === "interactive" && parsed.elements) {
+        // Extract text from interactive card
+        const texts: string[] = [];
+        for (const element of parsed.elements) {
+          if (element.tag === "div" && element.text?.content) {
+            texts.push(element.text.content);
+          } else if (element.tag === "markdown" && element.content) {
+            texts.push(element.content);
+          }
+        }
+        content = texts.join("\n") || "[Interactive Card]";
       }
     } catch {
       // Keep raw content if parsing fails

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -51,6 +51,11 @@ export type MsgContext = {
   MessageSidFirst?: string;
   MessageSidLast?: string;
   ReplyToId?: string;
+  /**
+   * Root message id for thread reconstruction (used by Feishu for root_id).
+   * When a message is part of a thread, this is the id of the first message.
+   */
+  RootMessageId?: string;
   /** Provider-specific full reply-to id when ReplyToId is a shortened alias. */
   ReplyToIdFull?: string;
   ReplyToBody?: string;


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@4ad49de89.

**Original**: feat(feishu): add parent/root inbound context for quote support (openclaw#18529)

Part of #678.

Cherry-picked-from: 4ad49de89