### PR TITLE
Cherry-pick bbab94c1f: security(feishu): bind doc create grants to trusted requester context (#31184)

### DIFF
--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -29,12 +29,10 @@ export const FeishuDocSchema = Type.Union([
     action: Type.Literal("create"),
     title: Type.String({ description: "Document title" }),
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
-    owner_open_id: Type.Optional(
-      Type.String({ description: "Open ID of the user to grant ownership permission" }),
-    ),
-    owner_perm_type: Type.Optional(
-      Type.Union([Type.Literal("view"), Type.Literal("edit"), Type.Literal("full_access")], {
-        description: "Permission type (default: full_access)",
+    grant_to_requester: Type.Optional(
+      Type.Boolean({
+        description:
+          "Grant edit permission to the trusted requesting Feishu user from runtime context (default: true).",
       }),
     ),
   }),

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -320,10 +320,18 @@ describe("feishu_doc image fetch hardening", () => {
       registerTool,
     } as any);
 
-    const feishuDocTool = registerTool.mock.calls
+    const feishuDocToolOrFactory = registerTool.mock.calls
       .map((call) => call[0])
-      .find((tool) => tool.name === "feishu_doc");
-    expect(feishuDocTool).toBeDefined();
+      .find((entry) =>
+        typeof entry === "function"
+          ? entry({ messageChannel: "feishu" })?.name === "feishu_doc"
+          : entry.name === "feishu_doc",
+      );
+    expect(feishuDocToolOrFactory).toBeDefined();
+    const feishuDocTool =
+      typeof feishuDocToolOrFactory === "function"
+        ? feishuDocToolOrFactory({ messageChannel: "feishu" })
+        : feishuDocToolOrFactory;
 
     const result = await feishuDocTool.execute("tool-call", {
       action: "write",

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -339,7 +339,7 @@ describe("feishu_doc image fetch hardening", () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it("reports owner permission details when grant succeeds", async () => {
+  it("create grants permission only to trusted Feishu requester", async () => {
     const registerTool = vi.fn();
     registerFeishuDocTools({
       config: {
@@ -356,27 +356,35 @@ describe("feishu_doc image fetch hardening", () => {
 
     const feishuDocTool = registerTool.mock.calls
       .map((call) => call[0])
-      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
+      .map((tool) =>
+        typeof tool === "function"
+          ? tool({ messageChannel: "feishu", requesterSenderId: "ou_123" })
+          : tool,
+      )
       .find((tool) => tool.name === "feishu_doc");
     expect(feishuDocTool).toBeDefined();
 
     const result = await feishuDocTool.execute("tool-call", {
       action: "create",
       title: "Demo",
-      owner_open_id: "ou_123",
-      owner_perm_type: "edit",
     });
 
-    expect(permissionMemberCreateMock).toHaveBeenCalled();
-    expect(result.details.owner_permission_added).toBe(true);
-    expect(result.details.owner_open_id).toBe("ou_123");
-    expect(result.details.owner_perm_type).toBe("edit");
+    expect(result.details.document_id).toBe("doc_created");
+    expect(result.details.requester_permission_added).toBe(true);
+    expect(result.details.requester_open_id).toBe("ou_123");
+    expect(result.details.requester_perm_type).toBe("edit");
+    expect(permissionMemberCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          member_type: "openid",
+          member_id: "ou_123",
+          perm: "edit",
+        }),
+      }),
+    );
   });
 
-  it("does not report owner permission details when grant fails", async () => {
-    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    permissionMemberCreateMock.mockRejectedValueOnce(new Error("permission denied"));
-
+  it("create skips requester grant when trusted requester identity is unavailable", async () => {
     const registerTool = vi.fn();
     registerFeishuDocTools({
       config: {
@@ -393,43 +401,7 @@ describe("feishu_doc image fetch hardening", () => {
 
     const feishuDocTool = registerTool.mock.calls
       .map((call) => call[0])
-      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
-      .find((tool) => tool.name === "feishu_doc");
-    expect(feishuDocTool).toBeDefined();
-
-    const result = await feishuDocTool.execute("tool-call", {
-      action: "create",
-      title: "Demo",
-      owner_open_id: "ou_123",
-      owner_perm_type: "edit",
-    });
-
-    expect(permissionMemberCreateMock).toHaveBeenCalled();
-    expect(result.details.owner_permission_added).toBeUndefined();
-    expect(result.details.owner_open_id).toBeUndefined();
-    expect(result.details.owner_perm_type).toBeUndefined();
-    expect(consoleWarnSpy).toHaveBeenCalled();
-    consoleWarnSpy.mockRestore();
-  });
-
-  it("skips permission grant when owner_open_id is omitted", async () => {
-    const registerTool = vi.fn();
-    registerFeishuDocTools({
-      config: {
-        channels: {
-          feishu: {
-            appId: "app_id",
-            appSecret: "app_secret",
-          },
-        },
-      } as any,
-      logger: { debug: vi.fn(), info: vi.fn() } as any,
-      registerTool,
-    } as any);
-
-    const feishuDocTool = registerTool.mock.calls
-      .map((call) => call[0])
-      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
+      .map((tool) => (typeof tool === "function" ? tool({ messageChannel: "feishu" }) : tool))
       .find((tool) => tool.name === "feishu_doc");
     expect(feishuDocTool).toBeDefined();
 
@@ -439,7 +411,43 @@ describe("feishu_doc image fetch hardening", () => {
     });
 
     expect(permissionMemberCreateMock).not.toHaveBeenCalled();
-    expect(result.details.owner_permission_added).toBeUndefined();
+    expect(result.details.requester_permission_added).toBe(false);
+    expect(result.details.requester_permission_skipped_reason).toContain("trusted requester");
+  });
+
+  it("create never grants permissions when grant_to_requester is false", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDocTools({
+      config: {
+        channels: {
+          feishu: {
+            appId: "app_id",
+            appSecret: "app_secret",
+          },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+
+    const feishuDocTool = registerTool.mock.calls
+      .map((call) => call[0])
+      .map((tool) =>
+        typeof tool === "function"
+          ? tool({ messageChannel: "feishu", requesterSenderId: "ou_123" })
+          : tool,
+      )
+      .find((tool) => tool.name === "feishu_doc");
+    expect(feishuDocTool).toBeDefined();
+
+    const result = await feishuDocTool.execute("tool-call", {
+      action: "create",
+      title: "Demo",
+      grant_to_requester: false,
+    });
+
+    expect(permissionMemberCreateMock).not.toHaveBeenCalled();
+    expect(result.details.requester_permission_added).toBeUndefined();
   });
 
   it("returns an error when create response omits document_id", async () => {

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -748,8 +748,7 @@ async function createDoc(
   client: Lark.Client,
   title: string,
   folderToken?: string,
-  ownerOpenId?: string,
-  ownerPermType: "view" | "edit" | "full_access" = "full_access",
+  options?: { grantToRequester?: boolean; requesterOpenId?: string },
 ) {
   const res = await client.docx.document.create({
     data: { title, folder_token: folderToken },
@@ -762,23 +761,32 @@ async function createDoc(
   if (!docToken) {
     throw new Error("Document creation succeeded but no document_id was returned");
   }
-  let ownerPermissionAdded = false;
+  const shouldGrantToRequester = options?.grantToRequester !== false;
+  const requesterOpenId = options?.requesterOpenId?.trim();
+  const requesterPermType: "edit" = "edit";
 
-  // Auto add owner permission if ownerOpenId is provided
-  if (docToken && ownerOpenId) {
-    try {
-      await client.drive.permissionMember.create({
-        path: { token: docToken },
-        params: { type: "docx", need_notification: false },
-        data: {
-          member_type: "openid",
-          member_id: ownerOpenId,
-          perm: ownerPermType,
-        },
-      });
-      ownerPermissionAdded = true;
-    } catch (err) {
-      console.warn("Failed to add owner permission (non-critical):", err);
+  let requesterPermissionAdded = false;
+  let requesterPermissionSkippedReason: string | undefined;
+  let requesterPermissionError: string | undefined;
+
+  if (shouldGrantToRequester) {
+    if (!requesterOpenId) {
+      requesterPermissionSkippedReason = "trusted requester identity unavailable";
+    } else {
+      try {
+        await client.drive.permissionMember.create({
+          path: { token: docToken },
+          params: { type: "docx", need_notification: false },
+          data: {
+            member_type: "openid",
+            member_id: requesterOpenId,
+            perm: requesterPermType,
+          },
+        });
+        requesterPermissionAdded = true;
+      } catch (err) {
+        requesterPermissionError = err instanceof Error ? err.message : String(err);
+      }
     }
   }
 
@@ -786,12 +794,15 @@ async function createDoc(
     document_id: docToken,
     title: doc?.title,
     url: `https://feishu.cn/docx/${docToken}`,
-    ...(ownerOpenId &&
-      ownerPermissionAdded && {
-        owner_permission_added: true,
-        owner_open_id: ownerOpenId,
-        owner_perm_type: ownerPermType,
+    ...(shouldGrantToRequester && {
+      requester_permission_added: requesterPermissionAdded,
+      ...(requesterOpenId && { requester_open_id: requesterOpenId }),
+      requester_perm_type: requesterPermType,
+      ...(requesterPermissionSkippedReason && {
+        requester_permission_skipped_reason: requesterPermissionSkippedReason,
       }),
+      ...(requesterPermissionError && { requester_permission_error: requesterPermissionError }),
+    }),
   };
 }
 
@@ -1234,152 +1245,161 @@ export function registerFeishuDocTools(api: RemoteClawPluginApi) {
   const getClient = () => createFeishuClient(firstAccount);
   const registered: string[] = [];
 
-  // Main document tool with action-based dispatch
+  // Main document tool with action-based dispatch (factory pattern for trusted requester context)
   if (toolsCfg.doc) {
     api.registerTool(
-      {
-        name: "feishu_doc",
-        label: "Feishu Doc",
-        description:
-          "Feishu document operations. Actions: read, write, append, insert, create, list_blocks, get_block, update_block, delete_block, create_table, write_table_cells, create_table_with_values, insert_table_row, insert_table_column, delete_table_rows, delete_table_columns, merge_table_cells, upload_image, upload_file, color_text",
-        parameters: FeishuDocSchema,
-        async execute(_toolCallId, params) {
-          const p = params as FeishuDocParams;
-          try {
-            const client = getClient();
-            switch (p.action) {
-              case "read":
-                return json(await readDoc(client, p.doc_token));
-              case "write":
-                return json(
-                  await writeDoc(client, p.doc_token, p.content, mediaMaxBytes, api.logger),
-                );
-              case "append":
-                return json(
-                  await appendDoc(client, p.doc_token, p.content, mediaMaxBytes, api.logger),
-                );
-              case "insert":
-                return json(
-                  await insertDoc(
-                    client,
-                    p.doc_token,
-                    p.content,
-                    p.after_block_id,
-                    mediaMaxBytes,
-                    api.logger,
-                  ),
-                );
-              case "create":
-                return json(
-                  await createDoc(
-                    client,
-                    p.title,
-                    p.folder_token,
-                    p.owner_open_id,
-                    p.owner_perm_type,
-                  ),
-                );
-              case "list_blocks":
-                return json(await listBlocks(client, p.doc_token));
-              case "get_block":
-                return json(await getBlock(client, p.doc_token, p.block_id));
-              case "update_block":
-                return json(await updateBlock(client, p.doc_token, p.block_id, p.content));
-              case "delete_block":
-                return json(await deleteBlock(client, p.doc_token, p.block_id));
-              case "create_table":
-                return json(
-                  await createTable(
-                    client,
-                    p.doc_token,
-                    p.row_size,
-                    p.column_size,
-                    p.parent_block_id,
-                    p.column_width,
-                  ),
-                );
-              case "write_table_cells":
-                return json(await writeTableCells(client, p.doc_token, p.table_block_id, p.values));
-              case "create_table_with_values":
-                return json(
-                  await createTableWithValues(
-                    client,
-                    p.doc_token,
-                    p.row_size,
-                    p.column_size,
-                    p.values,
-                    p.parent_block_id,
-                    p.column_width,
-                  ),
-                );
-              case "upload_image":
-                return json(
-                  await uploadImageBlock(
-                    client,
-                    p.doc_token,
-                    mediaMaxBytes,
-                    p.url,
-                    p.file_path,
-                    p.parent_block_id,
-                    p.filename,
-                    p.index,
-                    p.image, // data URI or plain base64
-                  ),
-                );
-              case "upload_file":
-                return json(
-                  await uploadFileBlock(
-                    client,
-                    p.doc_token,
-                    mediaMaxBytes,
-                    p.url,
-                    p.file_path,
-                    p.parent_block_id,
-                    p.filename,
-                  ),
-                );
-              case "color_text":
-                return json(await updateColorText(client, p.doc_token, p.block_id, p.content));
-              case "insert_table_row":
-                return json(await insertTableRow(client, p.doc_token, p.block_id, p.row_index));
-              case "insert_table_column":
-                return json(
-                  await insertTableColumn(client, p.doc_token, p.block_id, p.column_index),
-                );
-              case "delete_table_rows":
-                return json(
-                  await deleteTableRows(client, p.doc_token, p.block_id, p.row_start, p.row_count),
-                );
-              case "delete_table_columns":
-                return json(
-                  await deleteTableColumns(
-                    client,
-                    p.doc_token,
-                    p.block_id,
-                    p.column_start,
-                    p.column_count,
-                  ),
-                );
-              case "merge_table_cells":
-                return json(
-                  await mergeTableCells(
-                    client,
-                    p.doc_token,
-                    p.block_id,
-                    p.row_start,
-                    p.row_end,
-                    p.column_start,
-                    p.column_end,
-                  ),
-                );
-              default:
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
-                return json({ error: `Unknown action: ${(p as any).action}` });
+      (ctx) => {
+        const trustedRequesterOpenId =
+          ctx.messageChannel === "feishu" ? ctx.requesterSenderId?.trim() || undefined : undefined;
+        return {
+          name: "feishu_doc",
+          label: "Feishu Doc",
+          description:
+            "Feishu document operations. Actions: read, write, append, insert, create, list_blocks, get_block, update_block, delete_block, create_table, write_table_cells, create_table_with_values, insert_table_row, insert_table_column, delete_table_rows, delete_table_columns, merge_table_cells, upload_image, upload_file, color_text",
+          parameters: FeishuDocSchema,
+          async execute(_toolCallId, params) {
+            const p = params as FeishuDocParams;
+            try {
+              const client = getClient();
+              switch (p.action) {
+                case "read":
+                  return json(await readDoc(client, p.doc_token));
+                case "write":
+                  return json(
+                    await writeDoc(client, p.doc_token, p.content, mediaMaxBytes, api.logger),
+                  );
+                case "append":
+                  return json(
+                    await appendDoc(client, p.doc_token, p.content, mediaMaxBytes, api.logger),
+                  );
+                case "insert":
+                  return json(
+                    await insertDoc(
+                      client,
+                      p.doc_token,
+                      p.content,
+                      p.after_block_id,
+                      mediaMaxBytes,
+                      api.logger,
+                    ),
+                  );
+                case "create":
+                  return json(
+                    await createDoc(client, p.title, p.folder_token, {
+                      grantToRequester: p.grant_to_requester,
+                      requesterOpenId: trustedRequesterOpenId,
+                    }),
+                  );
+                case "list_blocks":
+                  return json(await listBlocks(client, p.doc_token));
+                case "get_block":
+                  return json(await getBlock(client, p.doc_token, p.block_id));
+                case "update_block":
+                  return json(await updateBlock(client, p.doc_token, p.block_id, p.content));
+                case "delete_block":
+                  return json(await deleteBlock(client, p.doc_token, p.block_id));
+                case "create_table":
+                  return json(
+                    await createTable(
+                      client,
+                      p.doc_token,
+                      p.row_size,
+                      p.column_size,
+                      p.parent_block_id,
+                      p.column_width,
+                    ),
+                  );
+                case "write_table_cells":
+                  return json(
+                    await writeTableCells(client, p.doc_token, p.table_block_id, p.values),
+                  );
+                case "create_table_with_values":
+                  return json(
+                    await createTableWithValues(
+                      client,
+                      p.doc_token,
+                      p.row_size,
+                      p.column_size,
+                      p.values,
+                      p.parent_block_id,
+                      p.column_width,
+                    ),
+                  );
+                case "upload_image":
+                  return json(
+                    await uploadImageBlock(
+                      client,
+                      p.doc_token,
+                      mediaMaxBytes,
+                      p.url,
+                      p.file_path,
+                      p.parent_block_id,
+                      p.filename,
+                      p.index,
+                      p.image, // data URI or plain base64
+                    ),
+                  );
+                case "upload_file":
+                  return json(
+                    await uploadFileBlock(
+                      client,
+                      p.doc_token,
+                      mediaMaxBytes,
+                      p.url,
+                      p.file_path,
+                      p.parent_block_id,
+                      p.filename,
+                    ),
+                  );
+                case "color_text":
+                  return json(await updateColorText(client, p.doc_token, p.block_id, p.content));
+                case "insert_table_row":
+                  return json(await insertTableRow(client, p.doc_token, p.block_id, p.row_index));
+                case "insert_table_column":
+                  return json(
+                    await insertTableColumn(client, p.doc_token, p.block_id, p.column_index),
+                  );
+                case "delete_table_rows":
+                  return json(
+                    await deleteTableRows(
+                      client,
+                      p.doc_token,
+                      p.block_id,
+                      p.row_start,
+                      p.row_count,
+                    ),
+                  );
+                case "delete_table_columns":
+                  return json(
+                    await deleteTableColumns(
+                      client,
+                      p.doc_token,
+                      p.block_id,
+                      p.column_start,
+                      p.column_count,
+                    ),
+                  );
+                case "merge_table_cells":
+                  return json(
+                    await mergeTableCells(
+                      client,
+                      p.doc_token,
+                      p.block_id,
+                      p.row_start,
+                      p.row_end,
+                      p.column_start,
+                      p.column_end,
+                    ),
+                  );
+                default:
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
+                  return json({ error: `Unknown action: ${(p as any).action}` });
+              }
+            } catch (err) {
+              return json({ error: err instanceof Error ? err.message : String(err) });
             }
-          } catch (err) {
-            return json({ error: err instanceof Error ? err.message : String(err) });
-          }
-        },
+          },
+        };
       },
       { name: "feishu_doc" },
     );

--- a/src/agents/remoteclaw-tools.plugin-context.test.ts
+++ b/src/agents/remoteclaw-tools.plugin-context.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+
+const resolvePluginToolsMock = vi.fn(() => []);
+
+vi.mock("../plugins/tools.js", () => ({
+  resolvePluginTools: (params: unknown) => resolvePluginToolsMock(params),
+}));
+
+import { createRemoteClawTools } from "./remoteclaw-tools.js";
+
+describe("createRemoteClawTools plugin context", () => {
+  it("forwards trusted requester sender identity to plugin tool context", () => {
+    createRemoteClawTools({
+      config: {} as never,
+      requesterSenderId: "trusted-sender",
+      senderIsOwner: true,
+    });
+
+    expect(resolvePluginToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          requesterSenderId: "trusted-sender",
+          senderIsOwner: true,
+        }),
+      }),
+    );
+  });
+});

--- a/src/agents/remoteclaw-tools.plugin-context.test.ts
+++ b/src/agents/remoteclaw-tools.plugin-context.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
-const resolvePluginToolsMock = vi.fn(() => []);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock typing
+const resolvePluginToolsMock = vi.fn((_params: any) => []);
 
 vi.mock("../plugins/tools.js", () => ({
   resolvePluginTools: (params: unknown) => resolvePluginToolsMock(params),

--- a/src/agents/remoteclaw-tools.ts
+++ b/src/agents/remoteclaw-tools.ts
@@ -141,6 +141,8 @@ export function createRemoteClawTools(options?: {
       sessionKey: options?.agentSessionKey,
       messageChannel: options?.agentChannel,
       agentAccountId: options?.agentAccountId,
+      requesterSenderId: options?.requesterSenderId ?? undefined,
+      senderIsOwner: options?.senderIsOwner ?? undefined,
       sandboxed: options?.sandboxed,
     },
     existingToolNames: new Set(tools.map((tool) => tool.name)),

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -65,6 +65,10 @@ export type RemoteClawPluginToolContext = {
   sessionKey?: string;
   messageChannel?: string;
   agentAccountId?: string;
+  /** Trusted sender id from inbound context (runtime-provided, not tool args). */
+  requesterSenderId?: string;
+  /** Whether the trusted sender is an owner. */
+  senderIsOwner?: boolean;
   sandboxed?: boolean;
 };
 

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -724,6 +724,35 @@ describe("security audit", () => {
     );
   });
 
+  it("warns when Feishu doc tool is enabled because create can grant requester access", async () => {
+    const cfg: RemoteClawConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+        },
+      },
+    };
+
+    const res = await audit(cfg);
+    expectFinding(res, "channels.feishu.doc_owner_open_id", "warn");
+  });
+
+  it("does not warn for Feishu doc grant risk when doc tools are disabled", async () => {
+    const cfg: RemoteClawConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          tools: { doc: false },
+        },
+      },
+    };
+
+    const res = await audit(cfg);
+    expectNoFinding(res, "channels.feishu.doc_owner_open_id");
+  });
+
   it("scores X-Real-IP fallback risk by gateway exposure", async () => {
     const trustedProxyCfg = (trustedProxies: string[]): RemoteClawConfig => ({
       gateway: {

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -433,6 +433,18 @@ function collectGatewayConfigFindings(
     });
   }
 
+  if (isFeishuDocToolEnabled(cfg)) {
+    findings.push({
+      checkId: "channels.feishu.doc_owner_open_id",
+      severity: "warn",
+      title: "Feishu doc create can grant requester permissions",
+      detail:
+        'channels.feishu tools include "doc"; feishu_doc action "create" can grant document access to the trusted requesting Feishu user.',
+      remediation:
+        "Disable channels.feishu.tools.doc when not needed, and restrict tool access for untrusted prompts.",
+    });
+  }
+
   const enabledDangerousFlags = collectEnabledInsecureOrDangerousFlags(cfg);
   if (enabledDangerousFlags.length > 0) {
     findings.push({

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -240,6 +240,57 @@ async function collectFilesystemFindings(params: {
   return findings;
 }
 
+function auditAsRecord(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+function auditHasNonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isFeishuDocToolEnabled(cfg: RemoteClawConfig): boolean {
+  const channels = auditAsRecord(cfg.channels);
+  const feishu = auditAsRecord(channels?.feishu);
+  if (!feishu || feishu.enabled === false) {
+    return false;
+  }
+
+  const baseTools = auditAsRecord(feishu.tools);
+  const baseDocEnabled = baseTools?.doc !== false;
+  const baseAppId = auditHasNonEmptyString(feishu.appId);
+  const baseAppSecret = auditHasNonEmptyString(feishu.appSecret);
+  const baseConfigured = baseAppId && baseAppSecret;
+
+  const accounts = auditAsRecord(feishu.accounts);
+  if (!accounts || Object.keys(accounts).length === 0) {
+    return baseDocEnabled && baseConfigured;
+  }
+
+  for (const accountValue of Object.values(accounts)) {
+    const account = auditAsRecord(accountValue) ?? {};
+    if (account.enabled === false) {
+      continue;
+    }
+    const accountTools = auditAsRecord(account.tools);
+    const effectiveTools = accountTools ?? baseTools;
+    const docEnabled = effectiveTools?.doc !== false;
+    if (!docEnabled) {
+      continue;
+    }
+    const accountConfigured =
+      (auditHasNonEmptyString(account.appId) || baseAppId) &&
+      (auditHasNonEmptyString(account.appSecret) || baseAppSecret);
+    if (accountConfigured) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function collectGatewayConfigFindings(
   cfg: RemoteClawConfig,
   env: NodeJS.ProcessEnv,


### PR DESCRIPTION
Cherry-pick of openclaw/openclaw@bbab94c1f.

**Subject**: security(feishu): bind doc create grants to trusted requester context (#31184)

**Conflict resolution**:
- `extensions/feishu/src/docx.ts` — switched feishu_doc tool registration from plain-object style to factory pattern `(ctx) => { ... }` to access `ctx.requesterSenderId` for trusted requester context (required by security fix). Kept fork's `getClient()` (no args) and `mediaMaxBytes` (pre-computed) patterns. Applied upstream's `createDoc` signature change to options object.
- `src/security/audit.ts` — restored the Feishu doc security audit finding that was previously removed in fork; applied upstream's updated message text (now says "trusted requesting Feishu user" instead of "owner_open_id").
- `src/security/audit.test.ts` — restored corresponding test cases with upstream's updated descriptions; fixed config type from `OpenClawConfig` to `RemoteClawConfig`.
- `src/agents/openclaw-tools.plugin-context.test.ts` — renamed to `remoteclaw-tools.plugin-context.test.ts`, updated import path and function name to `createRemoteClawTools`.
- CHANGELOG.md removed per fork convention.

Cherry-picked-from: openclaw/openclaw@bbab94c1f
Co-authored-by: Tak Hoffman <781889+Takhoffman@users.noreply.github.com>