### PR TITLE
Cherry-pick 8884f99c9: fix: address review feedback — handle start failure, remove placeholder URL

### DIFF
--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -85,15 +85,18 @@ async function ensureSharedClientStarted(params: {
     }
 
     // bot-sdk start() returns a promise that never resolves (infinite sync loop).
-    // Fire-and-forget: the sync loop runs, events fire on the client,
-    // but we must not await or the entire provider startup hangs.
-    // See: https://github.com/openclaw/openclaw/issues/NEW
+    // Fire-and-forget: the sync loop runs and events fire on the client,
+    // but we must not await or the entire provider startup hangs forever.
+    let startFailed = false;
     client.start().catch((err: unknown) => {
+      startFailed = true;
       LogService.error("MatrixClientLite", "client.start() error:", err);
     });
-    // Give the sync loop a moment to initialize
+    // Give the sync loop a moment to initialize before marking ready
     await new Promise((resolve) => setTimeout(resolve, 2000));
-    params.state.started = true;
+    if (!startFailed) {
+      params.state.started = true;
+    }
   })();
   sharedClientStartPromises.set(key, startPromise);
   try {


### PR DESCRIPTION
Cherry-pick of upstream [`8884f99c9`](https://github.com/openclaw/openclaw/commit/8884f99c9).

Address review feedback — handle start failure, remove placeholder URL.

Conflict resolved: merged upstream's `startFailed` guard with fork's formatting.

Part of #679.