### PR TITLE
Cherry-pick 235ed71e9: fix: handle late client.start() failures via single catch handler

### DIFF
--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -84,20 +84,23 @@ async function ensureSharedClientStarted(params: {
       }
     }
 
-    // bot-sdk start() returns a promise that never resolves (infinite sync loop).
-    // Fire-and-forget: the sync loop runs and events fire on the client,
-    // but we must not await or the entire provider startup hangs forever.
-    // If start() rejects during the grace window (e.g. bad token, unreachable
-    // homeserver), we propagate the error so the caller knows startup failed.
-    let startError: unknown = undefined;
-    client.start().catch((err: unknown) => {
-      startError = err;
+    // bot-sdk start() returns a promise that never resolves on success
+    // (infinite sync loop), so we must not await it or startup hangs forever.
+    // However, it DOES reject on errors (bad token, unreachable homeserver).
+    // Strategy: race client.start() against a grace timer. If start() rejects
+    // during or after the window, mark the client as failed so subsequent
+    // resolveSharedMatrixClient() calls know to retry.
+    const startPromiseInner = client.start();
+    let settled = false;
+    startPromiseInner.catch((err: unknown) => {
+      settled = true;
+      params.state.started = false;
       LogService.error("MatrixClientLite", "client.start() error:", err);
     });
     // Give the sync loop a moment to initialize before marking ready
     await new Promise((resolve) => setTimeout(resolve, 2000));
-    if (startError) {
-      throw startError;
+    if (settled) {
+      throw new Error("Matrix client.start() failed during initialization");
     }
     params.state.started = true;
   })();


### PR DESCRIPTION
Cherry-pick of upstream [`235ed71e9`](https://github.com/openclaw/openclaw/commit/235ed71e9).

Handle late client.start() failures via single catch handler — covers both early (within 2s) and late (after 2s) failures.

Conflict resolved: formatting only.

Part of #679.