### PR TITLE
Cherry-pick 166ae8f00: fix(matrix): preserve room ID casing

### DIFF
--- a/extensions/matrix/src/directory-live.test.ts
+++ b/extensions/matrix/src/directory-live.test.ts
@@ -71,4 +71,15 @@ describe("matrix directory live", () => {
     expect(result).toEqual([]);
     expect(resolveMatrixAuth).not.toHaveBeenCalled();
   });
+
+  it("preserves original casing for room IDs without :server suffix", async () => {
+    const mixedCaseId = "!EonMPPbOuhntHEHgZ2dnBO-c_EglMaXlIh2kdo8cgiA";
+    const result = await listMatrixDirectoryGroupsLive({
+      cfg,
+      query: mixedCaseId,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(mixedCaseId);
+  });
 });

--- a/extensions/matrix/src/directory-live.ts
+++ b/extensions/matrix/src/directory-live.ts
@@ -174,7 +174,8 @@ export async function listMatrixDirectoryGroupsLive(
   }
 
   if (query.startsWith("!")) {
-    return [createGroupDirectoryEntry({ id: query, name: query })];
+    const originalId = params.query?.trim() ?? query;
+    return [createGroupDirectoryEntry({ id: originalId, name: originalId })];
   }
 
   const joined = await fetchMatrixJson<MatrixJoinedRoomsResponse>({


### PR DESCRIPTION
Cherry-pick of upstream [`166ae8f00`](https://github.com/openclaw/openclaw/commit/166ae8f00). Thanks @williamos-dev.

Preserve room ID casing in Matrix directory lookups.

Conflict resolved: CHANGELOG.md deleted (fork convention).

Part of #679.