### PR TITLE
Cherry-pick cdbed3c9b: fix(googlechat): thread reply option support

### DIFF
--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -128,7 +128,11 @@ export async function sendGoogleChatMessage(params: {
       ...(item.contentName ? { contentName: item.contentName } : {}),
     }));
   }
-  const url = `${CHAT_API_BASE}/${space}/messages`;
+  const urlObj = new URL(`${CHAT_API_BASE}/${space}/messages`);
+  if (thread) {
+    urlObj.searchParams.set("messageReplyOption", "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD");
+  }
+  const url = urlObj.toString();
   const result = await fetchJson<{ name?: string }>(account, url, {
     method: "POST",
     body: JSON.stringify(body),


### PR DESCRIPTION
Cherry-pick of upstream [`cdbed3c9b`](https://github.com/openclaw/openclaw/commit/cdbed3c9b). Thanks @novan.

Add Google Chat thread reply option support.

Conflict resolved: CHANGELOG.md deleted (fork convention).

Part of #679.