### PR TITLE
Cherry-pick 355b4c62b: fix(mattermost): route private channels as group

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.channel-kind.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.channel-kind.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { mapMattermostChannelTypeToChatType } from "./monitor.js";
+
+describe("mapMattermostChannelTypeToChatType", () => {
+  it("maps direct and group dm channel types", () => {
+    expect(mapMattermostChannelTypeToChatType("D")).toBe("direct");
+    expect(mapMattermostChannelTypeToChatType("g")).toBe("group");
+  });
+
+  it("maps private channels to group", () => {
+    expect(mapMattermostChannelTypeToChatType("P")).toBe("group");
+    expect(mapMattermostChannelTypeToChatType(" p ")).toBe("group");
+  });
+
+  it("keeps public channels and unknown values as channel", () => {
+    expect(mapMattermostChannelTypeToChatType("O")).toBe("channel");
+    expect(mapMattermostChannelTypeToChatType("x")).toBe("channel");
+    expect(mapMattermostChannelTypeToChatType(undefined)).toBe("channel");
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -109,15 +109,22 @@ function isSystemPost(post: MattermostPost): boolean {
   return Boolean(type);
 }
 
-function channelKind(channelType?: string | null): ChatType {
+export function mapMattermostChannelTypeToChatType(channelType?: string | null): ChatType {
   if (!channelType) {
     return "channel";
   }
+  // Mattermost channel types: D=direct, G=group DM, O=public channel, P=private channel.
   const normalized = channelType.trim().toUpperCase();
   if (normalized === "D") {
     return "direct";
   }
   if (normalized === "G") {
+    return "group";
+  }
+  if (normalized === "P") {
+    // Private channels are invitation-restricted spaces; route as "group" so
+    // groupPolicy / groupAllowFrom can gate access separately from open public
+    // channels (type "O"), and the From prefix becomes mattermost:group:<id>.
     return "group";
   }
   return "channel";
@@ -396,7 +403,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
 
     const channelInfo = await resolveChannelInfo(channelId);
     const channelType = payload.data?.channel_type ?? channelInfo?.type ?? undefined;
-    const kind = channelKind(channelType);
+    const kind = mapMattermostChannelTypeToChatType(channelType);
     const chatType = channelChatType(kind);
 
     const senderName =
@@ -905,7 +912,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       logVerboseMessage(`mattermost: drop reaction (cannot resolve channel type for ${channelId})`);
       return;
     }
-    const kind = channelKind(channelInfo.type);
+    const kind = mapMattermostChannelTypeToChatType(channelInfo.type);
 
     // Enforce DM/group policy and allowlist checks (same as normal messages)
     const dmPolicy = account.config.dmPolicy ?? "pairing";


### PR DESCRIPTION
Cherry-pick of upstream [`355b4c62b`](https://github.com/openclaw/openclaw/commit/355b4c62b). Thanks @BlueBirdBack.

Route Mattermost private channels as group messages.

Conflict resolved: CHANGELOG.md deleted (fork convention).

Part of #679.