### PR TITLE
Cherry-pick 309683723: fix(cron): enable completion direct send for text-only announce delivery

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -69,12 +69,17 @@ function buildCompletionDeliveryMessage(params: {
   subagentName: string;
   spawnMode?: SpawnSubagentMode;
   outcome?: SubagentRunOutcome;
+  announceType?: SubagentAnnounceType;
 }): string {
   const findingsText = params.findings.trim();
   if (isAnnounceSkip(findingsText)) {
     return "";
   }
   const hasFindings = findingsText.length > 0 && findingsText !== "(no output)";
+  // Cron completions are standalone messages — skip the subagent status header.
+  if (params.announceType === "cron job") {
+    return hasFindings ? findingsText : "";
+  }
   const header = (() => {
     if (params.outcome?.status === "error") {
       return params.spawnMode === "session"
@@ -1286,6 +1291,7 @@ export async function runSubagentAnnounceFlow(params: {
       subagentName,
       spawnMode: params.spawnMode,
       outcome,
+      announceType,
     });
     const internalSummaryMessage = [
       `[System Message] [sessionId: ${announceSessionId}] A ${announceType} "${taskLabel}" just ${statusLabel}.`,

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -311,6 +311,10 @@ export async function dispatchCronDelivery(
         timeoutMs: params.timeoutMs,
         cleanup: params.job.deleteAfterRun ? "delete" : "keep",
         roundOneReply: synthesizedText,
+        // Cron output is a finished completion message: send it directly to the
+        // target channel via the completion-direct-send path rather than injecting
+        // a trigger message into the (likely idle) main agent session.
+        expectsCompletionMessage: true,
         // Keep delivery outcome truthful for cron state: if outbound send fails,
         // announce flow must report false so caller can apply best-effort policy.
         bestEffortDeliver: false,


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@309683723.

fix(cron): enable completion direct send for text-only announce delivery (#29151)

**Conflicts resolved**: Removed 2 test files deleted in fork (isolated-agent integration tests from gutted Pi-embedded layer).

**Changes kept**: subagent-announce.ts (cron completions skip subagent header), delivery-dispatch.ts (expectsCompletionMessage flag for direct send path).

Cherry-picked-from: 309683723