### PR TITLE
Cherry-pick daa418895: fix(cron): avoid marking queued announce paths as delivered

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1354,7 +1354,17 @@ export async function runSubagentAnnounceFlow(params: {
       directIdempotencyKey,
       signal: params.signal,
     });
-    didAnnounce = delivery.delivered;
+    // Cron delivery state should only be marked as delivered when we have a
+    // direct path result. Queue/steer means "accepted for later processing",
+    // not a confirmed channel send, and can otherwise produce false positives.
+    if (
+      announceType === "cron job" &&
+      (delivery.path === "queued" || delivery.path === "steered")
+    ) {
+      didAnnounce = false;
+    } else {
+      didAnnounce = delivery.delivered;
+    }
     if (!delivery.delivered && delivery.path === "direct" && delivery.error) {
       defaultRuntime.error?.(
         `Subagent completion direct announce failed for run ${params.childRunId}: ${delivery.error}`,


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@daa418895.

fix(cron): avoid marking queued announce paths as delivered (#29716)

Clean cherry-pick, no conflicts.

Cherry-picked-from: daa418895