### PR TITLE
Cherry-pick 53d6e07a6: fix(sessions): set transcriptPath to agent sessions directory

### DIFF
--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -1,6 +1,11 @@
+import path from "node:path";
 import { Type } from "@sinclair/typebox";
 import { loadConfig } from "../../config/config.js";
-import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../../config/sessions.js";
+import {
+  resolveSessionFilePath,
+  resolveSessionFilePathOptions,
+  resolveStorePath,
+} from "../../config/sessions.js";
 import { callGateway } from "../../gateway/call.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import type { AnyAgentTool } from "./common.js";
@@ -153,16 +158,26 @@ export function createSessionsListTool(opts?: {
         const sessionFileRaw = (entry as { sessionFile?: unknown }).sessionFile;
         const sessionFile = typeof sessionFileRaw === "string" ? sessionFileRaw : undefined;
         let transcriptPath: string | undefined;
-        if (sessionId && storePath) {
+        if (sessionId) {
           try {
-            const sessionPathOpts = resolveSessionFilePathOptions({
-              agentId: resolveAgentIdFromSessionKey(key),
-              storePath,
+            const agentId = resolveAgentIdFromSessionKey(key);
+            const trimmedStorePath = storePath?.trim();
+            let effectiveStorePath: string | undefined;
+            if (trimmedStorePath && trimmedStorePath !== "(multiple)") {
+              if (trimmedStorePath.includes("{agentId}") || trimmedStorePath.startsWith("~")) {
+                effectiveStorePath = resolveStorePath(trimmedStorePath, { agentId });
+              } else if (path.isAbsolute(trimmedStorePath)) {
+                effectiveStorePath = trimmedStorePath;
+              }
+            }
+            const filePathOpts = resolveSessionFilePathOptions({
+              agentId,
+              storePath: effectiveStorePath,
             });
             transcriptPath = resolveSessionFilePath(
               sessionId,
               sessionFile ? { sessionFile } : undefined,
-              sessionPathOpts,
+              filePathOpts,
             );
           } catch {
             transcriptPath = undefined;

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { extractAssistantText, sanitizeTextContent } from "./sessions-helpers.js";
@@ -7,15 +9,24 @@ vi.mock("../../gateway/call.js", () => ({
   callGateway: (opts: unknown) => callGatewayMock(opts),
 }));
 
+type SessionsToolTestConfig = {
+  session: { scope: "per-sender"; mainKey: string };
+  tools: {
+    agentToAgent: { enabled: boolean };
+    sessions?: { visibility: "all" | "own" };
+  };
+};
+
+const loadConfigMock = vi.fn<() => SessionsToolTestConfig>(() => ({
+  session: { scope: "per-sender", mainKey: "main" },
+  tools: { agentToAgent: { enabled: false } },
+}));
+
 vi.mock("../../config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../config/config.js")>();
   return {
     ...actual,
-    loadConfig: () =>
-      ({
-        session: { scope: "per-sender", mainKey: "main" },
-        tools: { agentToAgent: { enabled: false } },
-      }) as never,
+    loadConfig: () => loadConfigMock() as never,
   };
 });
 
@@ -92,6 +103,14 @@ describe("sanitizeTextContent", () => {
 beforeAll(async () => {
   ({ resolveAnnounceTarget } = await import("./sessions-announce-target.js"));
   ({ setActivePluginRegistry } = await import("../../plugins/runtime.js"));
+});
+
+beforeEach(() => {
+  loadConfigMock.mockReset();
+  loadConfigMock.mockReturnValue({
+    session: { scope: "per-sender", mainKey: "main" },
+    tools: { agentToAgent: { enabled: false } },
+  });
 });
 
 describe("extractAssistantText", () => {
@@ -196,6 +215,176 @@ describe("sessions_list gating", () => {
       count: 1,
       sessions: [{ key: "agent:main:main" }],
     });
+  });
+});
+
+describe("sessions_list transcriptPath resolution", () => {
+  beforeEach(() => {
+    callGatewayMock.mockClear();
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: {
+        agentToAgent: { enabled: true },
+        sessions: { visibility: "all" },
+      },
+    });
+  });
+
+  it("resolves cross-agent transcript paths from agent defaults when gateway store path is relative", async () => {
+    const stateDir = path.join(os.tmpdir(), "remoteclaw-state-relative");
+    vi.stubEnv("REMOTECLAW_STATE_DIR", stateDir);
+
+    try {
+      callGatewayMock.mockResolvedValueOnce({
+        path: "agents/main/sessions/sessions.json",
+        sessions: [
+          {
+            key: "agent:worker:main",
+            kind: "direct",
+            sessionId: "sess-worker",
+          },
+        ],
+      });
+
+      const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+      const result = await tool.execute("call1", {});
+
+      const details = result.details as
+        | { sessions?: Array<{ key?: string; transcriptPath?: string }> }
+        | undefined;
+      const session = details?.sessions?.[0];
+      expect(session).toMatchObject({ key: "agent:worker:main" });
+      const transcriptPath = String(session?.transcriptPath ?? "");
+      expect(path.normalize(transcriptPath)).toContain(path.join("agents", "worker", "sessions"));
+      expect(transcriptPath).toMatch(/sess-worker\.jsonl$/);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("resolves transcriptPath even when sessions.list does not return a store path", async () => {
+    const stateDir = path.join(os.tmpdir(), "remoteclaw-state-no-path");
+    vi.stubEnv("REMOTECLAW_STATE_DIR", stateDir);
+
+    try {
+      callGatewayMock.mockResolvedValueOnce({
+        sessions: [
+          {
+            key: "agent:worker:main",
+            kind: "direct",
+            sessionId: "sess-worker-no-path",
+          },
+        ],
+      });
+
+      const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+      const result = await tool.execute("call1", {});
+
+      const details = result.details as
+        | { sessions?: Array<{ key?: string; transcriptPath?: string }> }
+        | undefined;
+      const session = details?.sessions?.[0];
+      expect(session).toMatchObject({ key: "agent:worker:main" });
+      const transcriptPath = String(session?.transcriptPath ?? "");
+      expect(path.normalize(transcriptPath)).toContain(path.join("agents", "worker", "sessions"));
+      expect(transcriptPath).toMatch(/sess-worker-no-path\.jsonl$/);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("falls back to agent defaults when gateway path is non-string", async () => {
+    const stateDir = path.join(os.tmpdir(), "remoteclaw-state-non-string-path");
+    vi.stubEnv("REMOTECLAW_STATE_DIR", stateDir);
+
+    try {
+      callGatewayMock.mockResolvedValueOnce({
+        path: { raw: "agents/main/sessions/sessions.json" },
+        sessions: [
+          {
+            key: "agent:worker:main",
+            kind: "direct",
+            sessionId: "sess-worker-shape",
+          },
+        ],
+      });
+
+      const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+      const result = await tool.execute("call1", {});
+
+      const details = result.details as
+        | { sessions?: Array<{ key?: string; transcriptPath?: string }> }
+        | undefined;
+      const session = details?.sessions?.[0];
+      expect(session).toMatchObject({ key: "agent:worker:main" });
+      const transcriptPath = String(session?.transcriptPath ?? "");
+      expect(path.normalize(transcriptPath)).toContain(path.join("agents", "worker", "sessions"));
+      expect(transcriptPath).toMatch(/sess-worker-shape\.jsonl$/);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("falls back to agent defaults when gateway path is '(multiple)'", async () => {
+    const stateDir = path.join(os.tmpdir(), "remoteclaw-state-multiple");
+    vi.stubEnv("REMOTECLAW_STATE_DIR", stateDir);
+
+    try {
+      callGatewayMock.mockResolvedValueOnce({
+        path: "(multiple)",
+        sessions: [
+          {
+            key: "agent:worker:main",
+            kind: "direct",
+            sessionId: "sess-worker-multiple",
+          },
+        ],
+      });
+
+      const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+      const result = await tool.execute("call1", {});
+
+      const details = result.details as
+        | { sessions?: Array<{ key?: string; transcriptPath?: string }> }
+        | undefined;
+      const session = details?.sessions?.[0];
+      expect(session).toMatchObject({ key: "agent:worker:main" });
+      const transcriptPath = String(session?.transcriptPath ?? "");
+      expect(path.normalize(transcriptPath)).toContain(
+        path.join(stateDir, "agents", "worker", "sessions"),
+      );
+      expect(transcriptPath).toMatch(/sess-worker-multiple\.jsonl$/);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("resolves absolute {agentId} template paths per session agent", async () => {
+    const templateStorePath = "/tmp/remoteclaw/agents/{agentId}/sessions/sessions.json";
+
+    callGatewayMock.mockResolvedValueOnce({
+      path: templateStorePath,
+      sessions: [
+        {
+          key: "agent:worker:main",
+          kind: "direct",
+          sessionId: "sess-worker-template",
+        },
+      ],
+    });
+
+    const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", {});
+
+    const details = result.details as
+      | { sessions?: Array<{ key?: string; transcriptPath?: string }> }
+      | undefined;
+    const session = details?.sessions?.[0];
+    expect(session).toMatchObject({ key: "agent:worker:main" });
+    const transcriptPath = String(session?.transcriptPath ?? "");
+    const expectedSessionsDir = path.dirname(templateStorePath.replace("{agentId}", "worker"));
+    expect(path.normalize(transcriptPath)).toContain(path.normalize(expectedSessionsDir));
+    expect(transcriptPath).toMatch(/sess-worker-template\.jsonl$/);
   });
 });
 

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -8,6 +8,7 @@ import {
   deriveSessionKey,
   loadSessionStore,
   resolveSessionFilePath,
+  resolveSessionFilePathOptions,
   resolveSessionKey,
   resolveSessionTranscriptPath,
   resolveSessionTranscriptsDir,
@@ -554,6 +555,31 @@ describe("sessions", () => {
       expect(sessionFile).toBe(
         path.join(path.resolve("/different/state"), "agents", "bot1", "sessions", "sess-1.jsonl"),
       );
+    });
+  });
+
+  it("resolveSessionFilePathOptions keeps explicit agentId alongside absolute store path", () => {
+    const storePath = "/tmp/remoteclaw/agents/main/sessions/sessions.json";
+    const resolved = resolveSessionFilePathOptions({
+      agentId: "bot2",
+      storePath,
+    });
+    expect(resolved?.agentId).toBe("bot2");
+    expect(resolved?.sessionsDir).toBe(path.dirname(path.resolve(storePath)));
+  });
+
+  it("resolves sibling agent absolute sessionFile using alternate agentId from options", () => {
+    const stateDir = path.resolve("/home/user/.remoteclaw");
+    withStateDir(stateDir, () => {
+      const mainStorePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+      const bot2Session = path.join(stateDir, "agents", "bot2", "sessions", "sess-1.jsonl");
+      const opts = resolveSessionFilePathOptions({
+        agentId: "bot2",
+        storePath: mainStorePath,
+      });
+
+      const sessionFile = resolveSessionFilePath("sess-1", { sessionFile: bot2Session }, opts);
+      expect(sessionFile).toBe(bot2Session);
     });
   });
 


### PR DESCRIPTION
Cherry-pick of openclaw/openclaw@53d6e07a6.

**Original**: fix(sessions): set transcriptPath to agent sessions directory (openclaw#24775) thanks @martinfrancois

**Conflict resolution**:
- `CHANGELOG.md`: removed (deleted in fork)
- `src/config/sessions.test.ts`: rebrand `.openclaw` → `.remoteclaw` and `/tmp/openclaw/` → `/tmp/remoteclaw/` in test paths to match fork convention

Cherry-picked-from: 53d6e07a6