### PR TITLE
Cherry-pick 5232f96d5: Agents: use tool emoji for ACP tool_call summaries

### DIFF
--- a/src/agents/tool-display.json
+++ b/src/agents/tool-display.json
@@ -25,6 +25,16 @@
     ]
   },
   "tools": {
+    "tool_call": {
+      "emoji": "🧰",
+      "title": "Tool Call",
+      "detailKeys": []
+    },
+    "tool_call_update": {
+      "emoji": "🧰",
+      "title": "Tool Call",
+      "detailKeys": []
+    },
     "attach": {
       "emoji": "📎",
       "title": "Attach",


### PR DESCRIPTION
Cherry-pick of openclaw/openclaw@5232f96d5.

**Original**: Agents: use tool emoji for ACP tool_call summaries

**Conflict resolution**:
- `src/agents/tool-display.json`: Fork had already removed dead tool entries (exec, process, read, write, edit, apply_patch). Added only the two new entries (`tool_call`, `tool_call_update`) that are the purpose of this commit.

Cherry-picked-from: 5232f96d5