### PR TITLE
Cherry-pick b9aa2d436: fix(security): enforce sandbox inheritance for sessions_spawn

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -160,6 +160,7 @@ Parameters:
 Allowlist:
 
 - `agents.list[].subagents.allowAgents`: list of agent ids allowed via `agentId` (`["*"]` to allow any). Default: only the requester agent.
+- Sandbox inheritance guard: if the requester session is sandboxed, `sessions_spawn` rejects targets that would run unsandboxed.
 
 Discovery:
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1006,6 +1006,7 @@ scripts/sandbox-browser-setup.sh   # optional browser image
 - `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
 - `subagents.allowAgents`: allowlist of agent ids for `sessions_spawn` (`["*"]` = any; default: same agent only).
+- Sandbox inheritance guard: if the requester session is sandboxed, `sessions_spawn` rejects targets that would run unsandboxed.
 
 ---
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -123,6 +123,7 @@ See [Configuration Reference](/gateway/configuration-reference) and [Slash comma
 Allowlist:
 
 - `agents.list[].subagents.allowAgents`: list of agent ids that can be targeted via `agentId` (`["*"]` to allow any). Default: only the requester agent.
+- Sandbox inheritance guard: if the requester session is sandboxed, `sessions_spawn` rejects targets that would run unsandboxed.
 
 Discovery:
 

--- a/src/agents/remoteclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/remoteclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -154,4 +154,41 @@ describe("remoteclaw-tools: subagents (sessions_spawn allowlist)", () => {
       acceptedAt: 5200,
     });
   });
+
+  it("forbids sandboxed cross-agent spawns that would unsandbox the child", async () => {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "all",
+          },
+        },
+        list: [
+          {
+            id: "main",
+            subagents: {
+              allowAgents: ["research"],
+            },
+          },
+          {
+            id: "research",
+            sandbox: {
+              mode: "off",
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await executeSpawn("call11", "research");
+    const details = result.details as { status?: string; error?: string };
+
+    expect(details.status).toBe("forbidden");
+    expect(details.error).toContain("Sandboxed sessions cannot spawn unsandboxed subagents.");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -11,6 +11,7 @@ import {
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
+import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 import { buildSubagentSystemPrompt } from "./subagent-announce.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { countActiveRunsForSession, registerSubagentRun } from "./subagent-registry.js";
@@ -264,6 +265,21 @@ export async function spawnSubagentDirect(
     }
   }
   const childSessionKey = `agent:${targetAgentId}:subagent:${crypto.randomUUID()}`;
+  const requesterRuntime = resolveSandboxRuntimeStatus({
+    cfg,
+    sessionKey: requesterInternalKey,
+  });
+  const childRuntime = resolveSandboxRuntimeStatus({
+    cfg,
+    sessionKey: childSessionKey,
+  });
+  if (requesterRuntime.sandboxed && !childRuntime.sandboxed) {
+    return {
+      status: "forbidden",
+      error:
+        "Sandboxed sessions cannot spawn unsandboxed subagents. Set a sandboxed target agent or use the same agent runtime.",
+    };
+  }
   const childDepth = callerDepth + 1;
   const spawnedByKey = requesterInternalKey;
   // Model config gutted — CLIs own model selection. Pass through explicit


### PR DESCRIPTION
Cherry-pick of openclaw/openclaw@b9aa2d436.

**Conflict resolution**:
- `CHANGELOG.md`: removed (deleted in fork)
- `src/agents/subagent-spawn.ts`: removed stale model-selection import (gutted in fork), kept new sandbox/runtime-status import

Cherry-picked-from: b9aa2d436