### PR TITLE
Cherry-pick e70fc5eb6: fix(nodes): cap screen_record duration to 5 minutes

### DIFF
--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type MockFn = (...args: never[]) => unknown;
+
+const gatewayMocks = vi.hoisted(() => ({
+  callGatewayTool: vi.fn<MockFn>(),
+  readGatewayCallOptions: vi.fn<MockFn>(() => ({})),
+}));
+
+const nodeUtilsMocks = vi.hoisted(() => ({
+  resolveNodeId: vi.fn<MockFn>(async () => "node-1"),
+  listNodes: vi.fn<MockFn>(async () => []),
+  resolveNodeIdFromList: vi.fn<MockFn>(() => "node-1"),
+}));
+
+const screenMocks = vi.hoisted(() => ({
+  parseScreenRecordPayload: vi.fn<MockFn>(() => ({
+    base64: "ZmFrZQ==",
+    format: "mp4",
+    durationMs: 300_000,
+    fps: 10,
+    screenIndex: 0,
+    hasAudio: true,
+  })),
+  screenRecordTempPath: vi.fn<MockFn>(() => "/tmp/screen-record.mp4"),
+  writeScreenRecordToFile: vi.fn<MockFn>(async () => ({ path: "/tmp/screen-record.mp4" })),
+}));
+
+vi.mock("./gateway.js", () => ({
+  callGatewayTool: (...args: unknown[]) => gatewayMocks.callGatewayTool(...args),
+  readGatewayCallOptions: (...args: unknown[]) => gatewayMocks.readGatewayCallOptions(...args),
+}));
+
+vi.mock("./nodes-utils.js", () => ({
+  resolveNodeId: (...args: unknown[]) => nodeUtilsMocks.resolveNodeId(...args),
+  listNodes: (...args: unknown[]) => nodeUtilsMocks.listNodes(...args),
+  resolveNodeIdFromList: (...args: unknown[]) => nodeUtilsMocks.resolveNodeIdFromList(...args),
+}));
+
+vi.mock("../../cli/nodes-screen.js", () => ({
+  parseScreenRecordPayload: (...args: unknown[]) => screenMocks.parseScreenRecordPayload(...args),
+  screenRecordTempPath: (...args: unknown[]) => screenMocks.screenRecordTempPath(...args),
+  writeScreenRecordToFile: (...args: unknown[]) => screenMocks.writeScreenRecordToFile(...args),
+}));
+
+import { createNodesTool } from "./nodes-tool.js";
+
+describe("createNodesTool screen_record duration guardrails", () => {
+  beforeEach(() => {
+    gatewayMocks.callGatewayTool.mockReset();
+    gatewayMocks.readGatewayCallOptions.mockReset();
+    gatewayMocks.readGatewayCallOptions.mockReturnValue({});
+    nodeUtilsMocks.resolveNodeId.mockClear();
+    screenMocks.parseScreenRecordPayload.mockClear();
+    screenMocks.writeScreenRecordToFile.mockClear();
+  });
+
+  it("caps durationMs schema at 300000", () => {
+    const tool = createNodesTool();
+    const schema = tool.parameters as {
+      properties?: {
+        durationMs?: {
+          maximum?: number;
+        };
+      };
+    };
+    expect(schema.properties?.durationMs?.maximum).toBe(300_000);
+  });
+
+  it("clamps screen_record durationMs argument to 300000 before gateway invoke", async () => {
+    gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
+    const tool = createNodesTool();
+
+    await tool.execute("call-1", {
+      action: "screen_record",
+      node: "macbook",
+      durationMs: 900_000,
+    });
+
+    expect(gatewayMocks.callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      {},
+      expect.objectContaining({
+        params: expect.objectContaining({
+          durationMs: 300_000,
+        }),
+      }),
+    );
+  });
+});

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -117,7 +117,7 @@ const NodesToolSchema = Type.Object({
   delayMs: Type.Optional(Type.Number()),
   deviceId: Type.Optional(Type.String()),
   duration: Type.Optional(Type.String()),
-  durationMs: Type.Optional(Type.Number()),
+  durationMs: Type.Optional(Type.Number({ maximum: 300_000 })),
   includeAudio: Type.Optional(Type.Boolean()),
   // screen_record
   fps: Type.Optional(Type.Number()),
@@ -410,12 +410,14 @@ export function createNodesTool(options?: {
           case "screen_record": {
             const node = readStringParam(params, "node", { required: true });
             const nodeId = await resolveNodeId(gatewayOpts, node);
-            const durationMs =
+            const durationMs = Math.min(
               typeof params.durationMs === "number" && Number.isFinite(params.durationMs)
                 ? params.durationMs
                 : typeof params.duration === "string"
                   ? parseDurationMs(params.duration)
-                  : 10_000;
+                  : 10_000,
+              300_000,
+            );
             const fps =
               typeof params.fps === "number" && Number.isFinite(params.fps) ? params.fps : 10;
             const screenIndex =


### PR DESCRIPTION
Cherry-pick of openclaw/openclaw@e70fc5eb6.

**Conflict resolution**: `CHANGELOG.md` removed (deleted in fork). No other conflicts.

Cherry-picked-from: e70fc5eb6