### PR TITLE
Cherry-pick 20467d987: fix(usage): clamp negative input token counts to zero

### DIFF
--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -88,6 +88,23 @@ describe("normalizeUsage", () => {
     });
   });
 
+  it("clamps negative input to zero (pre-subtracted cached_tokens > prompt_tokens)", () => {
+    // pi-ai OpenAI-format providers subtract cached_tokens from prompt_tokens
+    // upstream.  When cached_tokens exceeds prompt_tokens the result is negative.
+    const usage = normalizeUsage({
+      input: -4900,
+      output: 200,
+      cacheRead: 5000,
+    });
+    expect(usage).toEqual({
+      input: 0,
+      output: 200,
+      cacheRead: 5000,
+      cacheWrite: undefined,
+      total: undefined,
+    });
+  });
+
   it("returns undefined when no valid fields are provided", () => {
     const usage = normalizeUsage(null);
     expect(usage).toBeUndefined();

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -58,9 +58,13 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
     return undefined;
   }
 
-  const input = asFiniteNumber(
+  // Some providers (pi-ai OpenAI-format) pre-subtract cached_tokens from
+  // prompt_tokens upstream.  When cached_tokens > prompt_tokens the result is
+  // negative, which is nonsensical.  Clamp to 0.
+  const rawInput = asFiniteNumber(
     raw.input ?? raw.inputTokens ?? raw.input_tokens ?? raw.promptTokens ?? raw.prompt_tokens,
   );
+  const input = rawInput !== undefined && rawInput < 0 ? 0 : rawInput;
   const output = asFiniteNumber(
     raw.output ??
       raw.outputTokens ??


### PR DESCRIPTION
Cherry-pick of openclaw/openclaw@20467d987.

Clean cherry-pick, no conflicts.

Cherry-picked-from: 20467d987