### PR TITLE
Cherry-pick 0fa5d6ed2: test(usage): cover negative prompt_tokens alias clamp

### DIFF
--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -105,6 +105,20 @@ describe("normalizeUsage", () => {
     });
   });
 
+  it("clamps negative prompt_tokens alias to zero", () => {
+    const usage = normalizeUsage({
+      prompt_tokens: -12,
+      completion_tokens: 4,
+    });
+    expect(usage).toEqual({
+      input: 0,
+      output: 4,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+      total: undefined,
+    });
+  });
+
   it("returns undefined when no valid fields are provided", () => {
     const usage = normalizeUsage(null);
     expect(usage).toBeUndefined();


### PR DESCRIPTION
Cherry-pick of openclaw/openclaw@0fa5d6ed2.

Clean cherry-pick, no conflicts.

Cherry-picked-from: 0fa5d6ed2