### PR TITLE
Cherry-pick fe9a7c408: fix(cron): force main-target system events onto main session

### DIFF
--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -466,7 +466,7 @@ describe("CronService", () => {
     await store.cleanup();
   });
 
-  it("passes agentId + sessionKey to runHeartbeatOnce for main-session wakeMode now jobs", async () => {
+  it("passes agentId and resolves main session for wakeMode now main jobs", async () => {
     const runHeartbeatOnce = vi.fn(async () => ({ status: "ran" as const, durationMs: 1 }));
 
     const { store, cron, enqueueSystemEvent, requestHeartbeatNow } =
@@ -491,13 +491,13 @@ describe("CronService", () => {
       expect.objectContaining({
         reason: `cron:${job.id}`,
         agentId: "ops",
-        sessionKey,
+        sessionKey: undefined,
       }),
     );
     expect(requestHeartbeatNow).not.toHaveBeenCalled();
     expect(enqueueSystemEvent).toHaveBeenCalledWith(
       "hello",
-      expect.objectContaining({ agentId: "ops", sessionKey }),
+      expect.objectContaining({ agentId: "ops", sessionKey: undefined }),
     );
 
     cron.stop();
@@ -535,7 +535,7 @@ describe("CronService", () => {
     expect(requestHeartbeatNow).toHaveBeenCalledWith(
       expect.objectContaining({
         reason: `cron:${job.id}`,
-        sessionKey,
+        sessionKey: undefined,
       }),
     );
     expect(job.state.lastStatus).toBe("ok");

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -640,9 +640,12 @@ export async function executeJobCore(
             : 'main job requires payload.kind="systemEvent"',
       };
     }
+    // main-target cron jobs should always resolve via the agent's main session.
+    // Avoid forwarding persisted channel session keys from legacy records.
+    const targetMainSessionKey = undefined;
     state.deps.enqueueSystemEvent(text, {
       agentId: job.agentId,
-      sessionKey: job.sessionKey,
+      sessionKey: targetMainSessionKey,
       contextKey: `cron:${job.id}`,
     });
     if (job.wakeMode === "now" && state.deps.runHeartbeatOnce) {
@@ -659,7 +662,7 @@ export async function executeJobCore(
         heartbeatResult = await state.deps.runHeartbeatOnce({
           reason,
           agentId: job.agentId,
-          sessionKey: job.sessionKey,
+          sessionKey: targetMainSessionKey,
           // Cron-triggered heartbeats should deliver to the last active channel.
           // Without this override, heartbeat target defaults to "none" (since
           // e2362d35) and cron main-session responses are silently swallowed.
@@ -682,7 +685,7 @@ export async function executeJobCore(
           state.deps.requestHeartbeatNow({
             reason,
             agentId: job.agentId,
-            sessionKey: job.sessionKey,
+            sessionKey: targetMainSessionKey,
           });
           return { status: "ok", summary: text };
         }
@@ -703,7 +706,7 @@ export async function executeJobCore(
       state.deps.requestHeartbeatNow({
         reason: `cron:${job.id}`,
         agentId: job.agentId,
-        sessionKey: job.sessionKey,
+        sessionKey: targetMainSessionKey,
       });
       return { status: "ok", summary: text };
     }


### PR DESCRIPTION
Cherry-pick of upstream [`fe9a7c408`](https://github.com/openclaw/openclaw/commit/fe9a7c408) — fix(cron): force main-target system events onto main session (#28898)

**Conflicts resolved**: `src/cron/service/timer.ts` — merged upstream's `sessionKey: targetMainSessionKey` with fork's `heartbeat: { target: "last" }` override (both needed)

Part of #681