### PR TITLE
Cherry-pick e70fc5eb6: fix(nodes): cap screen_record duration to 5 minutes

### DIFF
--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const gatewayMocks = vi.hoisted(() => ({
+  callGatewayTool: vi.fn(),
+  readGatewayCallOptions: vi.fn(() => ({})),
+}));
+
+const nodeUtilsMocks = vi.hoisted(() => ({
+  resolveNodeId: vi.fn(async () => "node-1"),
+  listNodes: vi.fn(async () => []),
+  resolveNodeIdFromList: vi.fn(() => "node-1"),
+}));
+
+const screenMocks = vi.hoisted(() => ({
+  parseScreenRecordPayload: vi.fn(() => ({
+    base64: "ZmFrZQ==",
+    format: "mp4",
+    durationMs: 300_000,
+    fps: 10,
+    screenIndex: 0,
+    hasAudio: true,
+  })),
+  screenRecordTempPath: vi.fn(() => "/tmp/screen-record.mp4"),
+  writeScreenRecordToFile: vi.fn(async () => ({ path: "/tmp/screen-record.mp4" })),
+}));
+
+vi.mock("./gateway.js", () => gatewayMocks);
+
+vi.mock("./nodes-utils.js", () => nodeUtilsMocks);
+
+vi.mock("../../cli/nodes-screen.js", () => screenMocks);
+
+import { createNodesTool } from "./nodes-tool.js";
+
+describe("createNodesTool screen_record duration guardrails", () => {
+  beforeEach(() => {
+    gatewayMocks.callGatewayTool.mockReset();
+    gatewayMocks.readGatewayCallOptions.mockReset();
+    gatewayMocks.readGatewayCallOptions.mockReturnValue({});
+    nodeUtilsMocks.resolveNodeId.mockClear();
+    screenMocks.parseScreenRecordPayload.mockClear();
+    screenMocks.writeScreenRecordToFile.mockClear();
+  });
+
+  it("caps durationMs schema at 300000", () => {
+    const tool = createNodesTool();
+    const schema = tool.parameters as {
+      properties?: {
+        durationMs?: {
+          maximum?: number;
+        };
+      };
+    };
+    expect(schema.properties?.durationMs?.maximum).toBe(300_000);
+  });
+
+  it("clamps screen_record durationMs argument to 300000 before gateway invoke", async () => {
+    gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
+    const tool = createNodesTool();
+
+    await tool.execute("call-1", {
+      action: "screen_record",
+      node: "macbook",
+      durationMs: 900_000,
+    });
+
+    expect(gatewayMocks.callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      {},
+      expect.objectContaining({
+        params: expect.objectContaining({
+          durationMs: 300_000,
+        }),
+      }),
+    );
+  });
+});

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -117,7 +117,7 @@ const NodesToolSchema = Type.Object({
   delayMs: Type.Optional(Type.Number()),
   deviceId: Type.Optional(Type.String()),
   duration: Type.Optional(Type.String()),
-  durationMs: Type.Optional(Type.Number()),
+  durationMs: Type.Optional(Type.Number({ maximum: 300_000 })),
   includeAudio: Type.Optional(Type.Boolean()),
   // screen_record
   fps: Type.Optional(Type.Number()),
@@ -410,12 +410,14 @@ export function createNodesTool(options?: {
           case "screen_record": {
             const node = readStringParam(params, "node", { required: true });
             const nodeId = await resolveNodeId(gatewayOpts, node);
-            const durationMs =
+            const durationMs = Math.min(
               typeof params.durationMs === "number" && Number.isFinite(params.durationMs)
                 ? params.durationMs
                 : typeof params.duration === "string"
                   ? parseDurationMs(params.duration)
-                  : 10_000;
+                  : 10_000,
+              300_000,
+            );
             const fps =
               typeof params.fps === "number" && Number.isFinite(params.fps) ? params.fps : 10;
             const screenIndex =


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: [`e70fc5eb6`](https://github.com/openclaw/openclaw/commit/e70fc5eb6)
**Author**: Peter Steinberger (steipete)

> fix(nodes): cap screen_record duration to 5 minutes (land #31106 by @BlueBirdBack)

Retry of closed #1506 — fixed test mock typing for fork's stricter TS settings.

### Adaptation
- `nodes-tool.test.ts`: Simplified vi.mock factories to directly return mock objects instead of wrapper functions with `(...args: unknown[])` spread (fork's strict TS rejects spread into typed mock params)
- `CHANGELOG.md`: deleted in fork (git rm)

Co-authored-by: BlueBirdBack <126304167+BlueBirdBack@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)