### PR TITLE
Cherry-pick d7d3416b1: fix(cron): disable messaging tool when delivery.mode is none

### DIFF
--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -43,6 +43,18 @@ describe("resolveCronDeliveryPlan", () => {
     expect(plan.requested).toBe(false);
   });
 
+  it("resolves mode=none with requested=false and no channel (#21808)", () => {
+    const plan = resolveCronDeliveryPlan(
+      makeJob({
+        delivery: { mode: "none", to: "telegram:123" },
+      }),
+    );
+    expect(plan.mode).toBe("none");
+    expect(plan.requested).toBe(false);
+    expect(plan.channel).toBeUndefined();
+    expect(plan.to).toBe("telegram:123");
+  });
+
   it("resolves webhook mode without channel routing", () => {
     const plan = resolveCronDeliveryPlan(
       makeJob({


### PR DESCRIPTION
Cherry-pick of upstream [`d7d3416b1`](https://github.com/openclaw/openclaw/commit/d7d3416b1) — fix(cron): disable messaging tool when delivery.mode is none (#21808) (#21896)

**Conflicts resolved**: CHANGELOG.md (deleted in fork), `run.ts` (Pi-embedded code replaced by ChannelBridge — fork's `resolveCronToolPolicy` already handles this for cron-owned contract), `delivery.test.ts` (accountId tests already removed in fork, kept new mode=none test)

Part of #681