### PR TITLE
fix(cron): migrate legacy schedule cron fields on load

### DIFF
--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -85,6 +85,25 @@ describe("normalizeCronJobCreate", () => {
     expectNormalizedAtSchedule({ kind: "at", atMs: "2026-01-12T18:00:00" });
   });
 
+  it("migrates legacy schedule.cron into schedule.expr", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "legacy-cron-field",
+      enabled: true,
+      schedule: { kind: "cron", cron: "*/10 * * * *", tz: "UTC" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: {
+        kind: "systemEvent",
+        text: "tick",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const schedule = normalized.schedule as Record<string, unknown>;
+    expect(schedule.kind).toBe("cron");
+    expect(schedule.expr).toBe("*/10 * * * *");
+    expect(schedule.cron).toBeUndefined();
+  });
+
   it("defaults cron stagger for recurring top-of-hour schedules", () => {
     const normalized = normalizeCronJobCreate({
       name: "hourly",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -19,6 +19,9 @@ function coerceSchedule(schedule: UnknownRecord) {
   const next: UnknownRecord = { ...schedule };
   const rawKind = typeof schedule.kind === "string" ? schedule.kind.trim().toLowerCase() : "";
   const kind = rawKind === "at" || rawKind === "every" || rawKind === "cron" ? rawKind : undefined;
+  const exprRaw = typeof schedule.expr === "string" ? schedule.expr.trim() : "";
+  const legacyCronRaw = typeof schedule.cron === "string" ? schedule.cron.trim() : "";
+  const normalizedExpr = exprRaw || legacyCronRaw;
   const atMsRaw = schedule.atMs;
   const atRaw = schedule.at;
   const atString = typeof atRaw === "string" ? atRaw.trim() : "";
@@ -42,7 +45,7 @@ function coerceSchedule(schedule: UnknownRecord) {
       next.kind = "at";
     } else if (typeof schedule.everyMs === "number") {
       next.kind = "every";
-    } else if (typeof schedule.expr === "string") {
+    } else if (normalizedExpr) {
       next.kind = "cron";
     }
   }
@@ -54,6 +57,15 @@ function coerceSchedule(schedule: UnknownRecord) {
   }
   if ("atMs" in next) {
     delete next.atMs;
+  }
+
+  if (normalizedExpr) {
+    next.expr = normalizedExpr;
+  } else if ("expr" in next) {
+    delete next.expr;
+  }
+  if ("cron" in next) {
+    delete next.cron;
   }
 
   const staggerMs = normalizeCronStaggerMs(schedule.staggerMs);

--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -25,6 +25,19 @@ describe("cron schedule", () => {
     ).toThrow("invalid cron schedule: expr is required");
   });
 
+  it("supports legacy cron field when expr is missing", () => {
+    const nowMs = Date.parse("2025-12-13T00:00:00.000Z");
+    const next = computeNextRunAtMs(
+      {
+        kind: "cron",
+        cron: "0 9 * * 3",
+        tz: "America/Los_Angeles",
+      } as unknown as { kind: "cron"; expr: string; tz?: string },
+      nowMs,
+    );
+    expect(next).toBe(Date.parse("2025-12-17T17:00:00.000Z"));
+  });
+
   it("computes next run for every schedule", () => {
     const anchor = Date.parse("2025-12-13T00:00:00.000Z");
     const now = anchor + 10_000;

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -56,7 +56,8 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
     return anchor + steps * everyMs;
   }
 
-  const exprSource = (schedule as { expr?: unknown }).expr;
+  const cronSchedule = schedule as { expr?: unknown; cron?: unknown };
+  const exprSource = typeof cronSchedule.expr === "string" ? cronSchedule.expr : cronSchedule.cron;
   if (typeof exprSource !== "string") {
     throw new Error("invalid cron schedule: expr is required");
   }


### PR DESCRIPTION
Cherry-pick of openclaw/openclaw@504c1f360.

**Conflict resolution**: Kept fork's `normalizeStoredCronJobs()` call in store.ts (fork already extracted the inline migration loop). Upstream's new `jobId→id` and `wakeMode` migrations were already present in our `store-migration.ts`. Deleted `service.store-migration.test.ts` (tests upstream's inline store.ts migration). Schedule cron→expr migration in `normalize.ts`, `schedule.ts`, and their tests applied cleanly.

Part of #681.