### PR TITLE
test(cron): add Asia/Shanghai year-regression coverage

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -13,6 +13,20 @@ describe("cron schedule", () => {
     expect(next).toBe(Date.parse("2025-12-17T17:00:00.000Z"));
   });
 
+  it("does not roll back year for Asia/Shanghai daily cron schedules (#30351)", () => {
+    // 2026-03-01 08:00:00 in Asia/Shanghai
+    const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
+      nowMs,
+    );
+
+    // Next 08:00 local should be the following day, not a past year.
+    expect(next).toBe(Date.parse("2026-03-02T00:00:00.000Z"));
+    expect(next).toBeGreaterThan(nowMs);
+    expect(new Date(next ?? 0).getUTCFullYear()).toBe(2026);
+  });
+
   it("throws a clear error when cron expr is missing at runtime", () => {
     const nowMs = Date.parse("2025-12-13T00:00:00.000Z");
     expect(() =>


### PR DESCRIPTION
Cherry-pick of openclaw/openclaw@e076665e5. Part of #681.