### PR TITLE
Cherry-pick batch: CLI and status command improvements

### DIFF
--- a/docs/platforms/raspberry-pi.md
+++ b/docs/platforms/raspberry-pi.md
@@ -191,6 +191,57 @@ lsblk
 
 See [Pi USB boot guide](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#usb-mass-storage-boot) for setup.
 
+### Speed up CLI startup (module compile cache)
+
+On lower-power Pi hosts, enable Node's module compile cache so repeated CLI runs are faster:
+
+```bash
+grep -q 'NODE_COMPILE_CACHE=/var/tmp/remoteclaw-compile-cache' ~/.bashrc || cat >> ~/.bashrc <<'EOF'
+export NODE_COMPILE_CACHE=/var/tmp/remoteclaw-compile-cache
+mkdir -p /var/tmp/remoteclaw-compile-cache
+export REMOTECLAW_NO_RESPAWN=1
+EOF
+source ~/.bashrc
+```
+
+Notes:
+
+- `NODE_COMPILE_CACHE` speeds up subsequent runs (`status`, `health`, `--help`).
+- `/var/tmp` survives reboots better than `/tmp`.
+- `REMOTECLAW_NO_RESPAWN=1` avoids extra startup cost from CLI self-respawn.
+- First run warms the cache; later runs benefit most.
+
+### systemd startup tuning (optional)
+
+If this Pi is mostly running RemoteClaw, add a service drop-in to reduce restart
+jitter and keep startup env stable:
+
+```bash
+sudo systemctl edit remoteclaw
+```
+
+```ini
+[Service]
+Environment=REMOTECLAW_NO_RESPAWN=1
+Environment=NODE_COMPILE_CACHE=/var/tmp/remoteclaw-compile-cache
+Restart=always
+RestartSec=2
+TimeoutStartSec=90
+```
+
+Then apply:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart remoteclaw
+```
+
+If possible, keep RemoteClaw state/cache on SSD-backed storage to avoid SD-card
+random-I/O bottlenecks during cold starts.
+
+How `Restart=` policies help automated recovery:
+[systemd can automate service recovery](https://www.redhat.com/en/blog/systemd-automate-recovery).
+
 ### Reduce Memory Usage
 
 ```bash

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -51,3 +51,52 @@ You can keep the Gateway in the cloud and pair **nodes** on your local devices
 capabilities while the Gateway stays in the cloud.
 
 Docs: [Nodes](/nodes), [Nodes CLI](/cli/nodes)
+
+## Startup tuning for small VMs and ARM hosts
+
+If CLI commands feel slow on low-power VMs (or ARM hosts), enable Node's module compile cache:
+
+```bash
+grep -q 'NODE_COMPILE_CACHE=/var/tmp/remoteclaw-compile-cache' ~/.bashrc || cat >> ~/.bashrc <<'EOF'
+export NODE_COMPILE_CACHE=/var/tmp/remoteclaw-compile-cache
+mkdir -p /var/tmp/remoteclaw-compile-cache
+export REMOTECLAW_NO_RESPAWN=1
+EOF
+source ~/.bashrc
+```
+
+- `NODE_COMPILE_CACHE` improves repeated command startup times.
+- `REMOTECLAW_NO_RESPAWN=1` avoids extra startup overhead from a self-respawn path.
+- First command run warms cache; subsequent runs are faster.
+- For Raspberry Pi specifics, see [Raspberry Pi](/platforms/raspberry-pi).
+
+### systemd tuning checklist (optional)
+
+For VM hosts using `systemd`, consider:
+
+- Add service env for stable startup path:
+  - `REMOTECLAW_NO_RESPAWN=1`
+  - `NODE_COMPILE_CACHE=/var/tmp/remoteclaw-compile-cache`
+- Keep restart behavior explicit:
+  - `Restart=always`
+  - `RestartSec=2`
+  - `TimeoutStartSec=90`
+- Prefer SSD-backed disks for state/cache paths to reduce random-I/O cold-start penalties.
+
+Example:
+
+```bash
+sudo systemctl edit remoteclaw
+```
+
+```ini
+[Service]
+Environment=REMOTECLAW_NO_RESPAWN=1
+Environment=NODE_COMPILE_CACHE=/var/tmp/remoteclaw-compile-cache
+Restart=always
+RestartSec=2
+TimeoutStartSec=90
+```
+
+How `Restart=` policies help automated recovery:
+[systemd can automate service recovery](https://www.redhat.com/en/blog/systemd-automate-recovery).

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "android:lint:android": "cd apps/android && ./gradlew :app:lintDebug",
     "android:run": "cd apps/android && ./gradlew :app:installDebug && adb shell am start -n org.remoteclaw.android/.MainActivity",
     "android:test": "cd apps/android && ./gradlew :app:testDebugUnitTest",
-    "build": "pnpm canvas:a2ui:bundle && tsdown && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-export-html-templates.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-compat.ts",
+    "build": "pnpm canvas:a2ui:bundle && tsdown && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-export-html-templates.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-startup-metadata.ts && node --import tsx scripts/write-cli-compat.ts",
     "build:plugin-sdk:dts": "tsc -p tsconfig.plugin-sdk.dts.json",
     "canvas:a2ui:bundle": "bash scripts/bundle-a2ui.sh",
     "check": "pnpm check:host-env-policy:swift && pnpm format:check && pnpm tsgo && pnpm lint && pnpm lint:tmp:no-random-messaging && pnpm lint:tmp:no-raw-channel-fetch && pnpm lint:auth:no-pairing-store-group && pnpm lint:auth:pairing-account-scope",

--- a/scripts/write-cli-startup-metadata.ts
+++ b/scripts/write-cli-startup-metadata.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function dedupe(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    if (!value || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(scriptDir, "..");
+const distDir = path.join(rootDir, "dist");
+const outputPath = path.join(distDir, "cli-startup-metadata.json");
+const extensionsDir = path.join(rootDir, "extensions");
+const CORE_CHANNEL_ORDER = [
+  "telegram",
+  "whatsapp",
+  "discord",
+  "irc",
+  "googlechat",
+  "slack",
+  "signal",
+  "imessage",
+] as const;
+
+type ExtensionChannelEntry = {
+  id: string;
+  order: number;
+  label: string;
+};
+
+function readBundledChannelCatalogIds(): string[] {
+  const entries: ExtensionChannelEntry[] = [];
+  for (const dirEntry of readdirSync(extensionsDir, { withFileTypes: true })) {
+    if (!dirEntry.isDirectory()) {
+      continue;
+    }
+    const packageJsonPath = path.join(extensionsDir, dirEntry.name, "package.json");
+    try {
+      const raw = readFileSync(packageJsonPath, "utf8");
+      const parsed = JSON.parse(raw) as {
+        remoteclaw?: {
+          channel?: {
+            id?: unknown;
+            order?: unknown;
+            label?: unknown;
+          };
+        };
+      };
+      const id = parsed.remoteclaw?.channel?.id;
+      if (typeof id !== "string" || !id.trim()) {
+        continue;
+      }
+      const orderRaw = parsed.remoteclaw?.channel?.order;
+      const labelRaw = parsed.remoteclaw?.channel?.label;
+      entries.push({
+        id: id.trim(),
+        order: typeof orderRaw === "number" ? orderRaw : 999,
+        label: typeof labelRaw === "string" ? labelRaw : id.trim(),
+      });
+    } catch {
+      // Ignore malformed or missing extension package manifests.
+    }
+  }
+  return entries
+    .toSorted((a, b) => (a.order === b.order ? a.label.localeCompare(b.label) : a.order - b.order))
+    .map((entry) => entry.id);
+}
+
+const catalog = readBundledChannelCatalogIds();
+const channelOptions = dedupe([...CORE_CHANNEL_ORDER, ...catalog]);
+
+mkdirSync(distDir, { recursive: true });
+writeFileSync(
+  outputPath,
+  `${JSON.stringify(
+    {
+      generatedBy: "scripts/write-cli-startup-metadata.ts",
+      channelOptions,
+    },
+    null,
+    2,
+  )}\n`,
+  "utf8",
+);

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -66,6 +66,24 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Queue: collect");
   });
 
+  it("falls back to sessionEntry verboseLevel when resolvedVerbose is not passed", async () => {
+    const text = await buildStatusMessage({
+      agent: {
+        model: "anthropic/pi:opus",
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        verboseLevel: "full",
+      },
+      sessionKey: "agent:main:main",
+      queue: { mode: "collect", depth: 0 },
+    });
+    const normalized = normalizeTestText(text);
+
+    expect(normalized).toContain("verbose:full");
+  });
+
   it("notes channel model overrides in status output", async () => {
     const text = await buildStatusMessage({
       config: {

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -68,9 +68,7 @@ describe("buildStatusMessage", () => {
 
   it("falls back to sessionEntry verboseLevel when resolvedVerbose is not passed", async () => {
     const text = await buildStatusMessage({
-      agent: {
-        model: "anthropic/pi:opus",
-      },
+      agent: {},
       sessionEntry: {
         sessionId: "abc",
         updatedAt: 0,

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -335,7 +335,8 @@ export async function buildStatusMessage(args: StatusArgs): Promise<string> {
     }
   }
 
-  const verboseLevel = args.resolvedVerbose ?? args.agent?.verboseDefault ?? "off";
+  const verboseLevel =
+    args.resolvedVerbose ?? args.sessionEntry?.verboseLevel ?? args.agent?.verboseDefault ?? "off";
 
   const runtime = { label: resolveRuntimeLabel(args) };
 

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -8,6 +8,7 @@ import {
   getVerboseFlag,
   hasHelpOrVersion,
   hasFlag,
+  isRootHelpInvocation,
   isRootVersionInvocation,
   shouldMigrateState,
   shouldMigrateStateFromPath,
@@ -92,6 +93,51 @@ describe("argv helpers", () => {
     },
   ])("detects root-only version invocations: $name", ({ argv, expected }) => {
     expect(isRootVersionInvocation(argv)).toBe(expected);
+  });
+
+  it.each([
+    {
+      name: "root --help",
+      argv: ["node", "openclaw", "--help"],
+      expected: true,
+    },
+    {
+      name: "root -h",
+      argv: ["node", "openclaw", "-h"],
+      expected: true,
+    },
+    {
+      name: "root --help with profile",
+      argv: ["node", "openclaw", "--profile", "work", "--help"],
+      expected: true,
+    },
+    {
+      name: "subcommand --help",
+      argv: ["node", "openclaw", "status", "--help"],
+      expected: false,
+    },
+    {
+      name: "help before subcommand token",
+      argv: ["node", "openclaw", "--help", "status"],
+      expected: false,
+    },
+    {
+      name: "help after -- terminator",
+      argv: ["node", "openclaw", "nodes", "run", "--", "git", "--help"],
+      expected: false,
+    },
+    {
+      name: "unknown root flag before help",
+      argv: ["node", "openclaw", "--unknown", "--help"],
+      expected: false,
+    },
+    {
+      name: "unknown root flag after help",
+      argv: ["node", "openclaw", "--help", "--unknown"],
+      expected: false,
+    },
+  ])("detects root-only help invocations: $name", ({ argv, expected }) => {
+    expect(isRootHelpInvocation(argv)).toBe(expected);
   });
 
   it.each([

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -8,6 +8,7 @@ import {
   getVerboseFlag,
   hasHelpOrVersion,
   hasFlag,
+  isRootVersionInvocation,
   shouldMigrateState,
   shouldMigrateStateFromPath,
 } from "./argv.js";
@@ -61,6 +62,36 @@ describe("argv helpers", () => {
     },
   ])("detects help/version flags: $name", ({ argv, expected }) => {
     expect(hasHelpOrVersion(argv)).toBe(expected);
+  });
+
+  it.each([
+    {
+      name: "root --version",
+      argv: ["node", "openclaw", "--version"],
+      expected: true,
+    },
+    {
+      name: "root -V",
+      argv: ["node", "openclaw", "-V"],
+      expected: true,
+    },
+    {
+      name: "root -v alias with profile",
+      argv: ["node", "openclaw", "--profile", "work", "-v"],
+      expected: true,
+    },
+    {
+      name: "subcommand version flag",
+      argv: ["node", "openclaw", "status", "--version"],
+      expected: false,
+    },
+    {
+      name: "unknown root flag with version",
+      argv: ["node", "openclaw", "--unknown", "--version"],
+      expected: false,
+    },
+  ])("detects root-only version invocations: $name", ({ argv, expected }) => {
+    expect(isRootVersionInvocation(argv)).toBe(expected);
   });
 
   it.each([

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -83,6 +83,42 @@ export function hasRootVersionAlias(argv: string[]): boolean {
   return hasAlias;
 }
 
+export function isRootVersionInvocation(argv: string[]): boolean {
+  const args = argv.slice(2);
+  let hasVersion = false;
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (!arg) {
+      continue;
+    }
+    if (arg === FLAG_TERMINATOR) {
+      break;
+    }
+    if (arg === ROOT_VERSION_ALIAS_FLAG || VERSION_FLAGS.has(arg)) {
+      hasVersion = true;
+      continue;
+    }
+    if (ROOT_BOOLEAN_FLAGS.has(arg)) {
+      continue;
+    }
+    if (arg.startsWith("--profile=") || arg.startsWith("--log-level=")) {
+      continue;
+    }
+    if (ROOT_VALUE_FLAGS.has(arg)) {
+      const next = args[i + 1];
+      if (isValueToken(next)) {
+        i += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      return false;
+    }
+    return false;
+  }
+  return hasVersion;
+}
+
 export function getFlagValue(argv: string[], name: string): string | null | undefined {
   const args = argv.slice(2);
   for (let i = 0; i < args.length; i += 1) {

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -119,6 +119,40 @@ export function isRootVersionInvocation(argv: string[]): boolean {
   return hasVersion;
 }
 
+export function isRootHelpInvocation(argv: string[]): boolean {
+  const args = argv.slice(2);
+  let hasHelp = false;
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (!arg) {
+      continue;
+    }
+    if (arg === FLAG_TERMINATOR) {
+      break;
+    }
+    if (HELP_FLAGS.has(arg)) {
+      hasHelp = true;
+      continue;
+    }
+    if (ROOT_BOOLEAN_FLAGS.has(arg)) {
+      continue;
+    }
+    if (arg.startsWith("--profile=") || arg.startsWith("--log-level=")) {
+      continue;
+    }
+    if (ROOT_VALUE_FLAGS.has(arg)) {
+      const next = args[i + 1];
+      if (isValueToken(next)) {
+        i += 1;
+      }
+      continue;
+    }
+    // Unknown flags and subcommand-scoped help should fall back to Commander.
+    return false;
+  }
+  return hasHelp;
+}
+
 export function getFlagValue(argv: string[], name: string): string | null | undefined {
   const args = argv.slice(2);
   for (let i = 0; i < args.length; i += 1) {

--- a/src/cli/channel-options.test.ts
+++ b/src/cli/channel-options.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const readFileSyncMock = vi.hoisted(() => vi.fn());
+const listCatalogMock = vi.hoisted(() => vi.fn());
+const listPluginsMock = vi.hoisted(() => vi.fn());
+const ensurePluginRegistryLoadedMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  const base = ("default" in actual ? actual.default : actual) as Record<string, unknown>;
+  return {
+    ...actual,
+    default: {
+      ...base,
+      readFileSync: readFileSyncMock,
+    },
+    readFileSync: readFileSyncMock,
+  };
+});
+
+vi.mock("../channels/registry.js", () => ({
+  CHAT_CHANNEL_ORDER: ["telegram", "discord"],
+}));
+
+vi.mock("../channels/plugins/catalog.js", () => ({
+  listChannelPluginCatalogEntries: listCatalogMock,
+}));
+
+vi.mock("../channels/plugins/index.js", () => ({
+  listChannelPlugins: listPluginsMock,
+}));
+
+vi.mock("./plugin-registry.js", () => ({
+  ensurePluginRegistryLoaded: ensurePluginRegistryLoadedMock,
+}));
+
+async function loadModule() {
+  return await import("./channel-options.js");
+}
+
+describe("resolveCliChannelOptions", () => {
+  afterEach(() => {
+    delete process.env.REMOTECLAW_EAGER_CHANNEL_OPTIONS;
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("uses precomputed startup metadata when available", async () => {
+    readFileSyncMock.mockReturnValue(
+      JSON.stringify({ channelOptions: ["cached", "telegram", "cached"] }),
+    );
+    listCatalogMock.mockReturnValue([{ id: "catalog-only" }]);
+
+    const mod = await loadModule();
+    expect(mod.resolveCliChannelOptions()).toEqual(["cached", "telegram", "catalog-only"]);
+    expect(listCatalogMock).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to dynamic catalog resolution when metadata is missing", async () => {
+    readFileSyncMock.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    listCatalogMock.mockReturnValue([{ id: "feishu" }, { id: "telegram" }]);
+
+    const mod = await loadModule();
+    expect(mod.resolveCliChannelOptions()).toEqual(["telegram", "discord", "feishu"]);
+    expect(listCatalogMock).toHaveBeenCalledOnce();
+  });
+
+  it("respects eager mode and includes loaded plugin ids", async () => {
+    process.env.REMOTECLAW_EAGER_CHANNEL_OPTIONS = "1";
+    readFileSyncMock.mockReturnValue(JSON.stringify({ channelOptions: ["cached"] }));
+    listCatalogMock.mockReturnValue([{ id: "zalo" }]);
+    listPluginsMock.mockReturnValue([{ id: "custom-a" }, { id: "custom-b" }]);
+
+    const mod = await loadModule();
+    expect(mod.resolveCliChannelOptions()).toEqual([
+      "telegram",
+      "discord",
+      "zalo",
+      "custom-a",
+      "custom-b",
+    ]);
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledOnce();
+    expect(listPluginsMock).toHaveBeenCalledOnce();
+  });
+
+  it("keeps dynamic catalog resolution when external catalog env is set", async () => {
+    process.env.REMOTECLAW_PLUGIN_CATALOG_PATHS = "/tmp/plugins-catalog.json";
+    readFileSyncMock.mockReturnValue(JSON.stringify({ channelOptions: ["cached", "telegram"] }));
+    listCatalogMock.mockReturnValue([{ id: "custom-catalog" }]);
+
+    const mod = await loadModule();
+    expect(mod.resolveCliChannelOptions()).toEqual(["cached", "telegram", "custom-catalog"]);
+    expect(listCatalogMock).toHaveBeenCalledOnce();
+    delete process.env.REMOTECLAW_PLUGIN_CATALOG_PATHS;
+  });
+});

--- a/src/cli/channel-options.ts
+++ b/src/cli/channel-options.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { listChannelPluginCatalogEntries } from "../channels/plugins/catalog.js";
 import { listChannelPlugins } from "../channels/plugins/index.js";
 import { CHAT_CHANNEL_ORDER } from "../channels/registry.js";
@@ -17,14 +20,46 @@ function dedupe(values: string[]): string[] {
   return resolved;
 }
 
+let precomputedChannelOptions: string[] | null | undefined;
+
+function loadPrecomputedChannelOptions(): string[] | null {
+  if (precomputedChannelOptions !== undefined) {
+    return precomputedChannelOptions;
+  }
+  try {
+    const metadataPath = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "cli-startup-metadata.json",
+    );
+    const raw = fs.readFileSync(metadataPath, "utf8");
+    const parsed = JSON.parse(raw) as { channelOptions?: unknown };
+    if (Array.isArray(parsed.channelOptions)) {
+      precomputedChannelOptions = dedupe(
+        parsed.channelOptions.filter((value): value is string => typeof value === "string"),
+      );
+      return precomputedChannelOptions;
+    }
+  } catch {
+    // Fall back to dynamic catalog resolution.
+  }
+  precomputedChannelOptions = null;
+  return null;
+}
+
 export function resolveCliChannelOptions(): string[] {
-  const catalog = listChannelPluginCatalogEntries().map((entry) => entry.id);
-  const base = dedupe([...CHAT_CHANNEL_ORDER, ...catalog]);
   if (isTruthyEnvValue(process.env.REMOTECLAW_EAGER_CHANNEL_OPTIONS)) {
+    const catalog = listChannelPluginCatalogEntries().map((entry) => entry.id);
+    const base = dedupe([...CHAT_CHANNEL_ORDER, ...catalog]);
     ensurePluginRegistryLoaded();
     const pluginIds = listChannelPlugins().map((plugin) => plugin.id);
     return dedupe([...base, ...pluginIds]);
   }
+  const precomputed = loadPrecomputedChannelOptions();
+  const catalog = listChannelPluginCatalogEntries().map((entry) => entry.id);
+  const base = precomputed
+    ? dedupe([...precomputed, ...catalog])
+    : dedupe([...CHAT_CHANNEL_ORDER, ...catalog]);
   return base;
 }
 

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -141,6 +141,24 @@ describe("config cli", () => {
       expect(written.gateway?.port).toBe(18789);
       expect(written.gateway?.auth).toEqual({ mode: "token" });
     });
+
+    it("auto-seeds a valid Ollama provider when setting only models.providers.ollama.apiKey", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "set", "models.providers.ollama.apiKey", '"ollama-local"']);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = mockWriteConfigFile.mock.calls[0]?.[0];
+      expect(written.models?.providers?.ollama).toEqual({
+        baseUrl: "http://127.0.0.1:11434",
+        api: "ollama",
+        models: [],
+        apiKey: "ollama-local",
+      });
+    });
   });
 
   describe("config get", () => {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -143,7 +143,7 @@ describe("config cli", () => {
     });
 
     it("auto-seeds a valid Ollama provider when setting only models.providers.ollama.apiKey", async () => {
-      const resolved: OpenClawConfig = {
+      const resolved: RemoteClawConfig = {
         gateway: { port: 18789 },
       };
       setSnapshot(resolved, resolved);
@@ -151,8 +151,10 @@ describe("config cli", () => {
       await runConfigCommand(["config", "set", "models.providers.ollama.apiKey", '"ollama-local"']);
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
-      const written = mockWriteConfigFile.mock.calls[0]?.[0];
-      expect(written.models?.providers?.ollama).toEqual({
+      const written = mockWriteConfigFile.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(
+        (written as { models?: { providers?: { ollama?: unknown } } }).models?.providers?.ollama,
+      ).toEqual({
         baseUrl: "http://127.0.0.1:11434",
         api: "ollama",
         models: [],

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -40,15 +40,21 @@ const { registerCronCli } = await import("./cron-cli.js");
 type CronUpdatePatch = {
   patch?: {
     schedule?: { kind?: string; expr?: string; tz?: string; staggerMs?: number };
-    payload?: { message?: string; model?: string; thinking?: string };
-    delivery?: { mode?: string; channel?: string; to?: string; bestEffort?: boolean };
+    payload?: { kind?: string; message?: string; model?: string; thinking?: string };
+    delivery?: {
+      mode?: string;
+      channel?: string;
+      to?: string;
+      accountId?: string;
+      bestEffort?: boolean;
+    };
   };
 };
 
 type CronAddParams = {
   schedule?: { kind?: string; staggerMs?: number };
   payload?: { model?: string; thinking?: string };
-  delivery?: { mode?: string };
+  delivery?: { mode?: string; accountId?: string };
   deleteAfterRun?: boolean;
   agentId?: string;
   sessionTarget?: string;
@@ -246,6 +252,40 @@ describe("cron cli", () => {
     expect(params?.deleteAfterRun).toBe(false);
   });
 
+  it("includes --account on isolated cron add delivery", async () => {
+    const params = await runCronAddAndGetParams([
+      "--name",
+      "accounted add",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "isolated",
+      "--message",
+      "hello",
+      "--account",
+      "  coordinator  ",
+    ]);
+    expect(params?.delivery?.mode).toBe("announce");
+    expect(params?.delivery?.accountId).toBe("coordinator");
+  });
+
+  it("rejects --account on non-isolated/systemEvent cron add", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "add",
+      "--name",
+      "invalid account add",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "main",
+      "--system-event",
+      "tick",
+      "--account",
+      "coordinator",
+    ]);
+  });
+
   it.each([
     { command: "enable" as const, expectedEnabled: true },
     { command: "disable" as const, expectedEnabled: false },
@@ -352,6 +392,13 @@ describe("cron cli", () => {
 
     expect(patch?.patch?.payload?.kind).toBe("agentTurn");
     expect(patch?.patch?.delivery?.mode).toBe("none");
+  });
+
+  it("updates delivery account without requiring --message on cron edit", async () => {
+    const patch = await runCronEditAndGetPatch(["--account", "  coordinator  "]);
+    expect(patch?.patch?.payload?.kind).toBe("agentTurn");
+    expect(patch?.patch?.delivery?.accountId).toBe("coordinator");
+    expect(patch?.patch?.delivery?.mode).toBeUndefined();
   });
 
   it("does not include undefined delivery fields when updating message", async () => {

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -153,15 +153,17 @@ async function expectCronEditWithScheduleLookupExit(
 describe("cron cli", () => {
   it("exits 0 for cron run when job executes successfully", async () => {
     resetGatewayMock();
-    callGatewayFromCli.mockImplementation(async (method: string) => {
-      if (method === "cron.status") {
-        return { enabled: true };
-      }
-      if (method === "cron.run") {
-        return { ok: true, ran: true };
-      }
-      return { ok: true };
-    });
+    callGatewayFromCli.mockImplementation(
+      async (method: string, _opts: unknown, params?: unknown) => {
+        if (method === "cron.status") {
+          return { enabled: true } as never;
+        }
+        if (method === "cron.run") {
+          return { ok: true, ran: true, params } as never;
+        }
+        return { ok: true, params };
+      },
+    );
 
     const runtimeModule = await import("../runtime.js");
     const runtime = runtimeModule.defaultRuntime as { exit: (code: number) => void };
@@ -179,15 +181,17 @@ describe("cron cli", () => {
 
   it("exits 1 for cron run when job does not execute", async () => {
     resetGatewayMock();
-    callGatewayFromCli.mockImplementation(async (method: string) => {
-      if (method === "cron.status") {
-        return { enabled: true };
-      }
-      if (method === "cron.run") {
-        return { ok: true, ran: false };
-      }
-      return { ok: true };
-    });
+    callGatewayFromCli.mockImplementation(
+      async (method: string, _opts: unknown, params?: unknown) => {
+        if (method === "cron.status") {
+          return { enabled: true } as never;
+        }
+        if (method === "cron.run") {
+          return { ok: true, ran: false, params } as never;
+        }
+        return { ok: true, params };
+      },
+    );
 
     const runtimeModule = await import("../runtime.js");
     const runtime = runtimeModule.defaultRuntime as { exit: (code: number) => void };

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -92,6 +92,7 @@ export function registerCronAddCommand(cron: Command) {
         "--to <dest>",
         "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
       )
+      .option("--account <id>", "Channel account id for delivery (multi-account setups)")
       .option("--best-effort-deliver", "Do not fail the job if delivery fails", false)
       .option("--json", "Output JSON", false)
       .action(async (opts: GatewayRpcOpts & Record<string, unknown>, cmd?: Command) => {
@@ -221,6 +222,15 @@ export function registerCronAddCommand(cron: Command) {
             throw new Error("--announce/--no-deliver require --session isolated.");
           }
 
+          const accountId =
+            typeof opts.account === "string" && opts.account.trim()
+              ? opts.account.trim()
+              : undefined;
+
+          if (accountId && (sessionTarget !== "isolated" || payload.kind !== "agentTurn")) {
+            throw new Error("--account requires an isolated agentTurn job with delivery.");
+          }
+
           const deliveryMode =
             sessionTarget === "isolated" && payload.kind === "agentTurn"
               ? hasAnnounce
@@ -265,6 +275,7 @@ export function registerCronAddCommand(cron: Command) {
                       ? opts.channel.trim()
                       : undefined,
                   to: typeof opts.to === "string" && opts.to.trim() ? opts.to.trim() : undefined,
+                  accountId,
                   bestEffort: opts.bestEffortDeliver ? true : undefined,
                 }
               : undefined,

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -59,6 +59,7 @@ export function registerCronEditCommand(cron: Command) {
         "--to <dest>",
         "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
       )
+      .option("--account <id>", "Channel account id for delivery (multi-account setups)")
       .option("--best-effort-deliver", "Do not fail job if delivery fails")
       .option("--no-best-effort-deliver", "Fail job when delivery fails")
       .action(async (id, opts) => {
@@ -209,6 +210,7 @@ export function registerCronEditCommand(cron: Command) {
           const hasTimeoutSeconds = Boolean(timeoutSeconds && Number.isFinite(timeoutSeconds));
           const hasDeliveryModeFlag = opts.announce || typeof opts.deliver === "boolean";
           const hasDeliveryTarget = typeof opts.channel === "string" || typeof opts.to === "string";
+          const hasDeliveryAccount = typeof opts.account === "string";
           const hasBestEffort = typeof opts.bestEffortDeliver === "boolean";
           const hasAgentTurnPatch =
             typeof opts.message === "string" ||
@@ -217,6 +219,7 @@ export function registerCronEditCommand(cron: Command) {
             hasTimeoutSeconds ||
             hasDeliveryModeFlag ||
             hasDeliveryTarget ||
+            hasDeliveryAccount ||
             hasBestEffort;
           if (hasSystemEventPatch && hasAgentTurnPatch) {
             throw new Error("Choose at most one payload change");
@@ -235,14 +238,14 @@ export function registerCronEditCommand(cron: Command) {
             patch.payload = payload;
           }
 
-          if (hasDeliveryModeFlag || hasDeliveryTarget || hasBestEffort) {
-            const deliveryMode =
-              opts.announce || opts.deliver === true
-                ? "announce"
-                : opts.deliver === false
-                  ? "none"
-                  : "announce";
-            const delivery: Record<string, unknown> = { mode: deliveryMode };
+          if (hasDeliveryModeFlag || hasDeliveryTarget || hasDeliveryAccount || hasBestEffort) {
+            const delivery: Record<string, unknown> = {};
+            if (hasDeliveryModeFlag) {
+              delivery.mode = opts.announce || opts.deliver === true ? "announce" : "none";
+            } else if (hasBestEffort) {
+              // Back-compat: toggling best-effort alone has historically implied announce mode.
+              delivery.mode = "announce";
+            }
             if (typeof opts.channel === "string") {
               const channel = opts.channel.trim();
               delivery.channel = channel ? channel : undefined;
@@ -250,6 +253,10 @@ export function registerCronEditCommand(cron: Command) {
             if (typeof opts.to === "string") {
               const to = opts.to.trim();
               delivery.to = to ? to : undefined;
+            }
+            if (typeof opts.account === "string") {
+              const account = opts.account.trim();
+              delivery.accountId = account ? account : undefined;
             }
             if (typeof opts.bestEffortDeliver === "boolean") {
               delivery.bestEffort = opts.bestEffortDeliver;

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -100,6 +100,8 @@ export function registerCronSimpleCommands(cron: Command) {
             mode: opts.due ? "due" : "force",
           });
           defaultRuntime.log(JSON.stringify(res, null, 2));
+          const result = res as { ok?: boolean; ran?: boolean } | undefined;
+          defaultRuntime.exit(result?.ok && result?.ran ? 0 : 1);
         } catch (err) {
           defaultRuntime.error(danger(String(err)));
           defaultRuntime.exit(1);

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -86,6 +86,7 @@ const CRON_LAST_PAD = 10;
 const CRON_STATUS_PAD = 9;
 const CRON_TARGET_PAD = 9;
 const CRON_AGENT_PAD = 10;
+const CRON_MODEL_PAD = 20;
 
 const pad = (value: string, width: number) => value.padEnd(width);
 
@@ -171,7 +172,8 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
     pad("Last", CRON_LAST_PAD),
     pad("Status", CRON_STATUS_PAD),
     pad("Target", CRON_TARGET_PAD),
-    pad("Agent", CRON_AGENT_PAD),
+    pad("Agent ID", CRON_AGENT_PAD),
+    pad("Model", CRON_MODEL_PAD),
   ].join(" ");
 
   runtime.log(rich ? theme.heading(header) : header);
@@ -192,7 +194,14 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
     const statusRaw = formatStatus(job);
     const statusLabel = pad(statusRaw, CRON_STATUS_PAD);
     const targetLabel = pad(job.sessionTarget ?? "-", CRON_TARGET_PAD);
-    const agentLabel = pad(truncate(job.agentId ?? "default", CRON_AGENT_PAD), CRON_AGENT_PAD);
+    const agentLabel = pad(truncate(job.agentId ?? "-", CRON_AGENT_PAD), CRON_AGENT_PAD);
+    const modelLabel = pad(
+      truncate(
+        (job.payload.kind === "agentTurn" ? job.payload.model : undefined) ?? "-",
+        CRON_MODEL_PAD,
+      ),
+      CRON_MODEL_PAD,
+    );
 
     const coloredStatus = (() => {
       if (statusRaw === "ok") {
@@ -227,6 +236,9 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
       coloredStatus,
       coloredTarget,
       coloredAgent,
+      job.payload.kind === "agentTurn" && job.payload.model
+        ? colorize(rich, theme.info, modelLabel)
+        : colorize(rich, theme.muted, modelLabel),
     ].join(" ");
 
     runtime.log(line.trimEnd());

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -53,11 +53,18 @@ export async function ensureConfigReady(params: {
       await runDoctorConfigFlow();
     } else {
       const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+      const originalSuppressNotes = process.env.REMOTECLAW_SUPPRESS_NOTES;
       process.stdout.write = (() => true) as unknown as typeof process.stdout.write;
+      process.env.REMOTECLAW_SUPPRESS_NOTES = "1";
       try {
         await runDoctorConfigFlow();
       } finally {
         process.stdout.write = originalStdoutWrite;
+        if (originalSuppressNotes === undefined) {
+          delete process.env.REMOTECLAW_SUPPRESS_NOTES;
+        } else {
+          process.env.REMOTECLAW_SUPPRESS_NOTES = originalSuppressNotes;
+        }
       }
     }
   }

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -39,14 +39,27 @@ async function getConfigSnapshot() {
 export async function ensureConfigReady(params: {
   runtime: RuntimeEnv;
   commandPath?: string[];
+  suppressDoctorStdout?: boolean;
 }): Promise<void> {
   const commandPath = params.commandPath ?? [];
   if (!didRunDoctorConfigFlow && shouldMigrateStateFromPath(commandPath)) {
     didRunDoctorConfigFlow = true;
-    await loadAndMaybeMigrateDoctorConfig({
-      options: { nonInteractive: true },
-      confirm: async () => false,
-    });
+    const runDoctorConfigFlow = async () =>
+      loadAndMaybeMigrateDoctorConfig({
+        options: { nonInteractive: true },
+        confirm: async () => false,
+      });
+    if (!params.suppressDoctorStdout) {
+      await runDoctorConfigFlow();
+    } else {
+      const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+      process.stdout.write = (() => true) as unknown as typeof process.stdout.write;
+      try {
+        await runDoctorConfigFlow();
+      } finally {
+        process.stdout.write = originalStdoutWrite;
+      }
+    }
   }
 
   const snapshot = await getConfigSnapshot();

--- a/src/cli/program/context.test.ts
+++ b/src/cli/program/context.test.ts
@@ -14,24 +14,48 @@ const { createProgramContext } = await import("./context.js");
 
 describe("createProgramContext", () => {
   it("builds program context from version and resolved channel options", () => {
-    resolveCliChannelOptionsMock.mockReturnValue(["telegram", "whatsapp"]);
-
-    expect(createProgramContext()).toEqual({
+    resolveCliChannelOptionsMock.mockClear().mockReturnValue(["telegram", "whatsapp"]);
+    const ctx = createProgramContext();
+    expect(ctx).toEqual({
       programVersion: "9.9.9-test",
       channelOptions: ["telegram", "whatsapp"],
       messageChannelOptions: "telegram|whatsapp",
       agentChannelOptions: "last|telegram|whatsapp",
     });
+    expect(resolveCliChannelOptionsMock).toHaveBeenCalledOnce();
   });
 
   it("handles empty channel options", () => {
-    resolveCliChannelOptionsMock.mockReturnValue([]);
-
-    expect(createProgramContext()).toEqual({
+    resolveCliChannelOptionsMock.mockClear().mockReturnValue([]);
+    const ctx = createProgramContext();
+    expect(ctx).toEqual({
       programVersion: "9.9.9-test",
       channelOptions: [],
       messageChannelOptions: "",
       agentChannelOptions: "last",
     });
+    expect(resolveCliChannelOptionsMock).toHaveBeenCalledOnce();
+  });
+
+  it("does not resolve channel options before access", () => {
+    resolveCliChannelOptionsMock.mockClear();
+    createProgramContext();
+    expect(resolveCliChannelOptionsMock).not.toHaveBeenCalled();
+  });
+
+  it("reuses one channel option resolution across all getters", () => {
+    resolveCliChannelOptionsMock.mockClear().mockReturnValue(["telegram"]);
+    const ctx = createProgramContext();
+    expect(ctx.channelOptions).toEqual(["telegram"]);
+    expect(ctx.messageChannelOptions).toBe("telegram");
+    expect(ctx.agentChannelOptions).toBe("last|telegram");
+    expect(resolveCliChannelOptionsMock).toHaveBeenCalledOnce();
+  });
+
+  it("reads program version without resolving channel options", () => {
+    resolveCliChannelOptionsMock.mockClear();
+    const ctx = createProgramContext();
+    expect(ctx.programVersion).toBe("9.9.9-test");
+    expect(resolveCliChannelOptionsMock).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/program/context.ts
+++ b/src/cli/program/context.ts
@@ -9,11 +9,24 @@ export type ProgramContext = {
 };
 
 export function createProgramContext(): ProgramContext {
-  const channelOptions = resolveCliChannelOptions();
+  let cachedChannelOptions: string[] | undefined;
+  const getChannelOptions = (): string[] => {
+    if (cachedChannelOptions === undefined) {
+      cachedChannelOptions = resolveCliChannelOptions();
+    }
+    return cachedChannelOptions;
+  };
+
   return {
     programVersion: VERSION,
-    channelOptions,
-    messageChannelOptions: channelOptions.join("|"),
-    agentChannelOptions: ["last", ...channelOptions].join("|"),
+    get channelOptions() {
+      return getChannelOptions();
+    },
+    get messageChannelOptions() {
+      return getChannelOptions().join("|");
+    },
+    get agentChannelOptions() {
+      return ["last", ...getChannelOptions()].join("|");
+    },
   };
 }

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -205,7 +205,7 @@ describe("registerPreActionHooks", () => {
   it("suppresses doctor stdout for any --json output command", async () => {
     await runCommand({
       parseArgv: ["message", "send", "--json"],
-      processArgv: ["node", "openclaw", "message", "send", "--json"],
+      processArgv: ["node", "remoteclaw", "message", "send", "--json"],
     });
 
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
@@ -218,7 +218,7 @@ describe("registerPreActionHooks", () => {
 
     await runCommand({
       parseArgv: ["update", "status", "--json"],
-      processArgv: ["node", "openclaw", "update", "status", "--json"],
+      processArgv: ["node", "remoteclaw", "update", "status", "--json"],
     });
 
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
@@ -231,7 +231,7 @@ describe("registerPreActionHooks", () => {
   it("does not treat config set --json (strict-parse alias) as json output mode", async () => {
     await runCommand({
       parseArgv: ["config", "set", "gateway.auth.mode", "{bad", "--json"],
-      processArgv: ["node", "openclaw", "config", "set", "gateway.auth.mode", "{bad", "--json"],
+      processArgv: ["node", "remoteclaw", "config", "set", "gateway.auth.mode", "{bad", "--json"],
     });
 
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -234,10 +234,6 @@ describe("registerPreActionHooks", () => {
       processArgv: ["node", "openclaw", "config", "set", "gateway.auth.mode", "{bad", "--json"],
     });
 
-    const firstCall = ensureConfigReadyMock.mock.calls[0]?.[0] as
-      | { suppressDoctorStdout?: boolean }
-      | undefined;
-    expect(firstCall?.suppressDoctorStdout).toBeUndefined();
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["config", "set"],

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -77,7 +77,18 @@ describe("registerPreActionHooks", () => {
     program.command("status").action(async () => {});
     program.command("doctor").action(async () => {});
     program.command("completion").action(async () => {});
-    program.command("update").action(async () => {});
+    program
+      .command("update")
+      .command("status")
+      .option("--json")
+      .action(async () => {});
+    const config = program.command("config");
+    config
+      .command("set")
+      .argument("<path>")
+      .argument("<value>")
+      .option("--json")
+      .action(async () => {});
     program.command("channels").action(async () => {});
     program.command("directory").action(async () => {});
     program.command("agents").action(async () => {});
@@ -86,6 +97,7 @@ describe("registerPreActionHooks", () => {
     program
       .command("message")
       .command("send")
+      .option("--json")
       .action(async () => {});
     registerPreActionHooks(program, "9.9.9-test");
     return program;
@@ -188,5 +200,47 @@ describe("registerPreActionHooks", () => {
 
     expect(emitCliBannerMock).not.toHaveBeenCalled();
     expect(ensureConfigReadyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses doctor stdout for any --json output command", async () => {
+    await runCommand({
+      parseArgv: ["message", "send", "--json"],
+      processArgv: ["node", "openclaw", "message", "send", "--json"],
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["message", "send"],
+      suppressDoctorStdout: true,
+    });
+
+    vi.clearAllMocks();
+
+    await runCommand({
+      parseArgv: ["update", "status", "--json"],
+      processArgv: ["node", "openclaw", "update", "status", "--json"],
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["update", "status"],
+      suppressDoctorStdout: true,
+    });
+  });
+
+  it("does not treat config set --json (strict-parse alias) as json output mode", async () => {
+    await runCommand({
+      parseArgv: ["config", "set", "gateway.auth.mode", "{bad", "--json"],
+      processArgv: ["node", "openclaw", "config", "set", "gateway.auth.mode", "{bad", "--json"],
+    });
+
+    const firstCall = ensureConfigReadyMock.mock.calls[0]?.[0] as
+      | { suppressDoctorStdout?: boolean }
+      | undefined;
+    expect(firstCall?.suppressDoctorStdout).toBeUndefined();
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["config", "set"],
+    });
   });
 });

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -3,7 +3,7 @@ import { setVerbose } from "../../globals.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
 import type { LogLevel } from "../../logging/levels.js";
 import { defaultRuntime } from "../../runtime.js";
-import { getCommandPath, getVerboseFlag, hasHelpOrVersion } from "../argv.js";
+import { getCommandPath, getVerboseFlag, hasFlag, hasHelpOrVersion } from "../argv.js";
 import { emitCliBanner } from "../banner.js";
 import { resolveCliName } from "../cli-name.js";
 
@@ -29,6 +29,7 @@ const PLUGIN_REQUIRED_COMMANDS = new Set([
   "configure",
   "onboard",
 ]);
+const JSON_PARSE_ONLY_COMMANDS = new Set(["config set"]);
 
 function getRootCommand(command: Command): Command {
   let current = command;
@@ -48,6 +49,17 @@ function getCliLogLevel(actionCommand: Command): LogLevel | undefined {
   }
   const logLevel = root.opts<Record<string, unknown>>().logLevel;
   return typeof logLevel === "string" ? (logLevel as LogLevel) : undefined;
+}
+
+function isJsonOutputMode(commandPath: string[], argv: string[]): boolean {
+  if (!hasFlag(argv, "--json")) {
+    return false;
+  }
+  const key = `${commandPath[0] ?? ""} ${commandPath[1] ?? ""}`.trim();
+  if (JSON_PARSE_ONLY_COMMANDS.has(key)) {
+    return false;
+  }
+  return true;
 }
 
 export function registerPreActionHooks(program: Command, programVersion: string) {
@@ -78,8 +90,13 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     if (commandPath[0] === "doctor" || commandPath[0] === "completion") {
       return;
     }
+    const suppressDoctorStdout = isJsonOutputMode(commandPath, argv);
     const { ensureConfigReady } = await import("./config-guard.js");
-    await ensureConfigReady({ runtime: defaultRuntime, commandPath });
+    await ensureConfigReady({
+      runtime: defaultRuntime,
+      commandPath,
+      ...(suppressDoctorStdout ? { suppressDoctorStdout: true } : {}),
+    });
     // Load plugins for commands that need channel access
     if (PLUGIN_REQUIRED_COMMANDS.has(commandPath[0])) {
       const { ensurePluginRegistryLoaded } = await import("../plugin-registry.js");

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -18,9 +18,12 @@ describe("program routes", () => {
     expect(route?.loadPlugins).toBe(true);
   });
 
-  it("matches health route and preloads plugins for channel diagnostics", () => {
+  it("matches health route and preloads plugins only for text output", () => {
     const route = expectRoute(["health"]);
-    expect(route?.loadPlugins).toBe(true);
+    expect(typeof route?.loadPlugins).toBe("function");
+    const shouldLoad = route?.loadPlugins as (argv: string[]) => boolean;
+    expect(shouldLoad(["node", "openclaw", "health"])).toBe(true);
+    expect(shouldLoad(["node", "openclaw", "health", "--json"])).toBe(false);
   });
 
   it("returns false when status timeout flag value is missing", async () => {

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -13,15 +13,9 @@ describe("program routes", () => {
     await expect(route?.run(argv)).resolves.toBe(false);
   }
 
-  it("matches status route and loads plugins for human-readable output", () => {
+  it("matches status route and always loads plugins for security parity", () => {
     const route = expectRoute(["status"]);
-    expect(typeof route?.loadPlugins).toBe("function");
-    const loadPlugins = route?.loadPlugins;
-    if (typeof loadPlugins !== "function") {
-      throw new Error("expected status route loadPlugins predicate");
-    }
-    expect(loadPlugins(["node", "openclaw", "status"])).toBe(true);
-    expect(loadPlugins(["node", "openclaw", "status", "--json"])).toBe(false);
+    expect(route?.loadPlugins).toBe(true);
   });
 
   it("matches health route without eager plugin loading", () => {

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -18,9 +18,9 @@ describe("program routes", () => {
     expect(route?.loadPlugins).toBe(true);
   });
 
-  it("matches health route without eager plugin loading", () => {
+  it("matches health route and preloads plugins for channel diagnostics", () => {
     const route = expectRoute(["health"]);
-    expect(route?.loadPlugins).toBeUndefined();
+    expect(route?.loadPlugins).toBe(true);
   });
 
   it("returns false when status timeout flag value is missing", async () => {

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -13,9 +13,20 @@ describe("program routes", () => {
     await expect(route?.run(argv)).resolves.toBe(false);
   }
 
-  it("matches status route and preserves plugin loading", () => {
+  it("matches status route and loads plugins for human-readable output", () => {
     const route = expectRoute(["status"]);
-    expect(route?.loadPlugins).toBe(true);
+    expect(typeof route?.loadPlugins).toBe("function");
+    const loadPlugins = route?.loadPlugins;
+    if (typeof loadPlugins !== "function") {
+      throw new Error("expected status route loadPlugins predicate");
+    }
+    expect(loadPlugins(["node", "openclaw", "status"])).toBe(true);
+    expect(loadPlugins(["node", "openclaw", "status", "--json"])).toBe(false);
+  });
+
+  it("matches health route without eager plugin loading", () => {
+    const route = expectRoute(["health"]);
+    expect(route?.loadPlugins).toBeUndefined();
   });
 
   it("returns false when status timeout flag value is missing", async () => {

--- a/src/cli/program/routes.ts
+++ b/src/cli/program/routes.ts
@@ -9,6 +9,9 @@ export type RouteSpec = {
 
 const routeHealth: RouteSpec = {
   match: (path) => path[0] === "health",
+  // Health output uses channel plugin metadata for account fallback/log details.
+  // Keep routed behavior aligned with non-routed command execution.
+  loadPlugins: true,
   run: async (argv) => {
     const json = hasFlag(argv, "--json");
     const verbose = getVerboseFlag(argv, { includeDebug: true });

--- a/src/cli/program/routes.ts
+++ b/src/cli/program/routes.ts
@@ -9,9 +9,9 @@ export type RouteSpec = {
 
 const routeHealth: RouteSpec = {
   match: (path) => path[0] === "health",
-  // Health output uses channel plugin metadata for account fallback/log details.
-  // Keep routed behavior aligned with non-routed command execution.
-  loadPlugins: true,
+  // `health --json` only relays gateway RPC output and does not need local plugin metadata.
+  // Keep plugin preload for text output where channel diagnostics/logSelfId are rendered.
+  loadPlugins: (argv) => !hasFlag(argv, "--json"),
   run: async (argv) => {
     const json = hasFlag(argv, "--json");
     const verbose = getVerboseFlag(argv, { includeDebug: true });

--- a/src/cli/program/routes.ts
+++ b/src/cli/program/routes.ts
@@ -3,13 +3,12 @@ import { getFlagValue, getPositiveIntFlagValue, getVerboseFlag, hasFlag } from "
 
 export type RouteSpec = {
   match: (path: string[]) => boolean;
-  loadPlugins?: boolean;
+  loadPlugins?: boolean | ((argv: string[]) => boolean);
   run: (argv: string[]) => Promise<boolean>;
 };
 
 const routeHealth: RouteSpec = {
   match: (path) => path[0] === "health",
-  loadPlugins: true,
   run: async (argv) => {
     const json = hasFlag(argv, "--json");
     const verbose = getVerboseFlag(argv, { includeDebug: true });
@@ -25,7 +24,8 @@ const routeHealth: RouteSpec = {
 
 const routeStatus: RouteSpec = {
   match: (path) => path[0] === "status",
-  loadPlugins: true,
+  // JSON mode omits the human-readable channel table, so skip expensive plugin preloading.
+  loadPlugins: (argv) => !hasFlag(argv, "--json"),
   run: async (argv) => {
     const json = hasFlag(argv, "--json");
     const deep = hasFlag(argv, "--deep");

--- a/src/cli/program/routes.ts
+++ b/src/cli/program/routes.ts
@@ -24,8 +24,9 @@ const routeHealth: RouteSpec = {
 
 const routeStatus: RouteSpec = {
   match: (path) => path[0] === "status",
-  // JSON mode omits the human-readable channel table, so skip expensive plugin preloading.
-  loadPlugins: (argv) => !hasFlag(argv, "--json"),
+  // Status runs security audit with channel checks in both text and JSON output,
+  // so plugin registry must be ready for consistent findings.
+  loadPlugins: true,
   run: async (argv) => {
     const json = hasFlag(argv, "--json");
     const deep = hasFlag(argv, "--deep");

--- a/src/cli/route.test.ts
+++ b/src/cli/route.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const emitCliBannerMock = vi.hoisted(() => vi.fn());
+const ensureConfigReadyMock = vi.hoisted(() => vi.fn(async () => {}));
+const ensurePluginRegistryLoadedMock = vi.hoisted(() => vi.fn());
+const findRoutedCommandMock = vi.hoisted(() => vi.fn());
+const runRouteMock = vi.hoisted(() => vi.fn(async () => true));
+
+vi.mock("./banner.js", () => ({
+  emitCliBanner: emitCliBannerMock,
+}));
+
+vi.mock("./program/config-guard.js", () => ({
+  ensureConfigReady: ensureConfigReadyMock,
+}));
+
+vi.mock("./plugin-registry.js", () => ({
+  ensurePluginRegistryLoaded: ensurePluginRegistryLoadedMock,
+}));
+
+vi.mock("./program/routes.js", () => ({
+  findRoutedCommand: findRoutedCommandMock,
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: { error: vi.fn(), log: vi.fn(), exit: vi.fn() },
+}));
+
+describe("tryRouteCli", () => {
+  let tryRouteCli: typeof import("./route.js").tryRouteCli;
+  let originalDisableRouteFirst: string | undefined;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    originalDisableRouteFirst = process.env.REMOTECLAW_DISABLE_ROUTE_FIRST;
+    delete process.env.REMOTECLAW_DISABLE_ROUTE_FIRST;
+    vi.resetModules();
+    ({ tryRouteCli } = await import("./route.js"));
+    findRoutedCommandMock.mockReturnValue({
+      loadPlugins: false,
+      run: runRouteMock,
+    });
+  });
+
+  afterEach(() => {
+    if (originalDisableRouteFirst === undefined) {
+      delete process.env.REMOTECLAW_DISABLE_ROUTE_FIRST;
+    } else {
+      process.env.REMOTECLAW_DISABLE_ROUTE_FIRST = originalDisableRouteFirst;
+    }
+  });
+
+  it("passes suppressDoctorStdout=true for routed --json commands", async () => {
+    await expect(tryRouteCli(["node", "remoteclaw", "status", "--json"])).resolves.toBe(true);
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandPath: ["status"],
+        suppressDoctorStdout: true,
+      }),
+    );
+  });
+
+  it("does not pass suppressDoctorStdout for routed non-json commands", async () => {
+    await expect(tryRouteCli(["node", "remoteclaw", "status"])).resolves.toBe(true);
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandPath: ["status"],
+      }),
+    );
+    const firstCall = ensureConfigReadyMock.mock.calls[0]?.[0] as
+      | { suppressDoctorStdout?: boolean }
+      | undefined;
+    expect(firstCall?.suppressDoctorStdout).toBeUndefined();
+  });
+});

--- a/src/cli/route.test.ts
+++ b/src/cli/route.test.ts
@@ -64,14 +64,9 @@ describe("tryRouteCli", () => {
   it("does not pass suppressDoctorStdout for routed non-json commands", async () => {
     await expect(tryRouteCli(["node", "remoteclaw", "status"])).resolves.toBe(true);
 
-    expect(ensureConfigReadyMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        commandPath: ["status"],
-      }),
-    );
-    const firstCall = ensureConfigReadyMock.mock.calls[0]?.[0] as
-      | { suppressDoctorStdout?: boolean }
-      | undefined;
-    expect(firstCall?.suppressDoctorStdout).toBeUndefined();
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: expect.any(Object),
+      commandPath: ["status"],
+    });
   });
 });

--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -10,11 +10,13 @@ import { findRoutedCommand } from "./program/routes.js";
 async function prepareRoutedCommand(params: {
   argv: string[];
   commandPath: string[];
-  loadPlugins?: boolean;
+  loadPlugins?: boolean | ((argv: string[]) => boolean);
 }) {
   emitCliBanner(VERSION, { argv: params.argv });
   await ensureConfigReady({ runtime: defaultRuntime, commandPath: params.commandPath });
-  if (params.loadPlugins) {
+  const shouldLoadPlugins =
+    typeof params.loadPlugins === "function" ? params.loadPlugins(params.argv) : params.loadPlugins;
+  if (shouldLoadPlugins) {
     ensurePluginRegistryLoaded();
   }
 }

--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -1,7 +1,7 @@
 import { isTruthyEnvValue } from "../infra/env.js";
 import { defaultRuntime } from "../runtime.js";
 import { VERSION } from "../version.js";
-import { getCommandPath, hasHelpOrVersion } from "./argv.js";
+import { getCommandPath, hasFlag, hasHelpOrVersion } from "./argv.js";
 import { emitCliBanner } from "./banner.js";
 import { ensurePluginRegistryLoaded } from "./plugin-registry.js";
 import { ensureConfigReady } from "./program/config-guard.js";
@@ -12,8 +12,13 @@ async function prepareRoutedCommand(params: {
   commandPath: string[];
   loadPlugins?: boolean | ((argv: string[]) => boolean);
 }) {
+  const suppressDoctorStdout = hasFlag(params.argv, "--json");
   emitCliBanner(VERSION, { argv: params.argv });
-  await ensureConfigReady({ runtime: defaultRuntime, commandPath: params.commandPath });
+  await ensureConfigReady({
+    runtime: defaultRuntime,
+    commandPath: params.commandPath,
+    ...(suppressDoctorStdout ? { suppressDoctorStdout: true } : {}),
+  });
   const shouldLoadPlugins =
     typeof params.loadPlugins === "function" ? params.loadPlugins(params.argv) : params.loadPlugins;
   if (shouldLoadPlugins) {

--- a/src/commands/doctor-platform-notes.startup-optimization.test.ts
+++ b/src/commands/doctor-platform-notes.startup-optimization.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { noteStartupOptimizationHints } from "./doctor-platform-notes.js";
+
+describe("noteStartupOptimizationHints", () => {
+  it("does not warn when compile cache and no-respawn are configured", () => {
+    const noteFn = vi.fn();
+
+    noteStartupOptimizationHints(
+      {
+        NODE_COMPILE_CACHE: "/var/tmp/remoteclaw-compile-cache",
+        OPENCLAW_NO_RESPAWN: "1",
+      },
+      { platform: "linux", arch: "arm64", totalMemBytes: 4 * 1024 ** 3, noteFn },
+    );
+
+    expect(noteFn).not.toHaveBeenCalled();
+  });
+
+  it("warns when compile cache is under /tmp and no-respawn is not set", () => {
+    const noteFn = vi.fn();
+
+    noteStartupOptimizationHints(
+      {
+        NODE_COMPILE_CACHE: "/tmp/remoteclaw-compile-cache",
+      },
+      { platform: "linux", arch: "arm64", totalMemBytes: 4 * 1024 ** 3, noteFn },
+    );
+
+    expect(noteFn).toHaveBeenCalledTimes(1);
+    const [message, title] = noteFn.mock.calls[0] ?? [];
+    expect(title).toBe("Startup optimization");
+    expect(message).toContain("NODE_COMPILE_CACHE points to /tmp");
+    expect(message).toContain("OPENCLAW_NO_RESPAWN is not set to 1");
+    expect(message).toContain("export NODE_COMPILE_CACHE=/var/tmp/remoteclaw-compile-cache");
+    expect(message).toContain("export OPENCLAW_NO_RESPAWN=1");
+  });
+
+  it("warns when compile cache is disabled via env override", () => {
+    const noteFn = vi.fn();
+
+    noteStartupOptimizationHints(
+      {
+        NODE_COMPILE_CACHE: "/var/tmp/remoteclaw-compile-cache",
+        OPENCLAW_NO_RESPAWN: "1",
+        NODE_DISABLE_COMPILE_CACHE: "1",
+      },
+      { platform: "linux", arch: "arm64", totalMemBytes: 4 * 1024 ** 3, noteFn },
+    );
+
+    expect(noteFn).toHaveBeenCalledTimes(1);
+    const [message] = noteFn.mock.calls[0] ?? [];
+    expect(message).toContain("NODE_DISABLE_COMPILE_CACHE is set");
+    expect(message).toContain("unset NODE_DISABLE_COMPILE_CACHE");
+  });
+
+  it("skips startup optimization note on win32", () => {
+    const noteFn = vi.fn();
+
+    noteStartupOptimizationHints(
+      {
+        NODE_COMPILE_CACHE: "/tmp/remoteclaw-compile-cache",
+      },
+      { platform: "win32", arch: "arm64", totalMemBytes: 4 * 1024 ** 3, noteFn },
+    );
+
+    expect(noteFn).not.toHaveBeenCalled();
+  });
+
+  it("skips startup optimization note on non-target linux hosts", () => {
+    const noteFn = vi.fn();
+
+    noteStartupOptimizationHints(
+      {
+        NODE_COMPILE_CACHE: "/tmp/remoteclaw-compile-cache",
+      },
+      { platform: "linux", arch: "x64", totalMemBytes: 32 * 1024 ** 3, noteFn },
+    );
+
+    expect(noteFn).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/doctor-platform-notes.startup-optimization.test.ts
+++ b/src/commands/doctor-platform-notes.startup-optimization.test.ts
@@ -8,7 +8,7 @@ describe("noteStartupOptimizationHints", () => {
     noteStartupOptimizationHints(
       {
         NODE_COMPILE_CACHE: "/var/tmp/remoteclaw-compile-cache",
-        OPENCLAW_NO_RESPAWN: "1",
+        REMOTECLAW_NO_RESPAWN: "1",
       },
       { platform: "linux", arch: "arm64", totalMemBytes: 4 * 1024 ** 3, noteFn },
     );
@@ -30,9 +30,9 @@ describe("noteStartupOptimizationHints", () => {
     const [message, title] = noteFn.mock.calls[0] ?? [];
     expect(title).toBe("Startup optimization");
     expect(message).toContain("NODE_COMPILE_CACHE points to /tmp");
-    expect(message).toContain("OPENCLAW_NO_RESPAWN is not set to 1");
+    expect(message).toContain("REMOTECLAW_NO_RESPAWN is not set to 1");
     expect(message).toContain("export NODE_COMPILE_CACHE=/var/tmp/remoteclaw-compile-cache");
-    expect(message).toContain("export OPENCLAW_NO_RESPAWN=1");
+    expect(message).toContain("export REMOTECLAW_NO_RESPAWN=1");
   });
 
   it("warns when compile cache is disabled via env override", () => {
@@ -41,7 +41,7 @@ describe("noteStartupOptimizationHints", () => {
     noteStartupOptimizationHints(
       {
         NODE_COMPILE_CACHE: "/var/tmp/remoteclaw-compile-cache",
-        OPENCLAW_NO_RESPAWN: "1",
+        REMOTECLAW_NO_RESPAWN: "1",
         NODE_DISABLE_COMPILE_CACHE: "1",
       },
       { platform: "linux", arch: "arm64", totalMemBytes: 4 * 1024 ** 3, noteFn },

--- a/src/commands/doctor-platform-notes.ts
+++ b/src/commands/doctor-platform-notes.ts
@@ -140,3 +140,81 @@ export function noteDeprecatedLegacyEnvVars(
   ];
   (deps?.noteFn ?? note)(lines.join("\n"), "Environment");
 }
+
+function isTruthyEnvValue(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isTmpCompileCachePath(cachePath: string): boolean {
+  const normalized = cachePath.trim().replace(/\/+$/, "");
+  return (
+    normalized === "/tmp" ||
+    normalized.startsWith("/tmp/") ||
+    normalized === "/private/tmp" ||
+    normalized.startsWith("/private/tmp/")
+  );
+}
+
+export function noteStartupOptimizationHints(
+  env: NodeJS.ProcessEnv = process.env,
+  deps?: {
+    platform?: NodeJS.Platform;
+    arch?: string;
+    totalMemBytes?: number;
+    noteFn?: typeof note;
+  },
+) {
+  const platform = deps?.platform ?? process.platform;
+  if (platform === "win32") {
+    return;
+  }
+  const arch = deps?.arch ?? os.arch();
+  const totalMemBytes = deps?.totalMemBytes ?? os.totalmem();
+  const isArmHost = arch === "arm" || arch === "arm64";
+  const isLowMemoryLinux =
+    platform === "linux" && totalMemBytes > 0 && totalMemBytes <= 8 * 1024 ** 3;
+  const isStartupTuneTarget = platform === "linux" && (isArmHost || isLowMemoryLinux);
+  if (!isStartupTuneTarget) {
+    return;
+  }
+
+  const noteFn = deps?.noteFn ?? note;
+  const compileCache = env.NODE_COMPILE_CACHE?.trim() ?? "";
+  const disableCompileCache = env.NODE_DISABLE_COMPILE_CACHE?.trim() ?? "";
+  const noRespawn = env.REMOTECLAW_NO_RESPAWN?.trim() ?? "";
+  const lines: string[] = [];
+
+  if (!compileCache) {
+    lines.push(
+      "- NODE_COMPILE_CACHE is not set; repeated CLI runs can be slower on small hosts (Pi/VM).",
+    );
+  } else if (isTmpCompileCachePath(compileCache)) {
+    lines.push(
+      "- NODE_COMPILE_CACHE points to /tmp; use /var/tmp so cache survives reboots and warms startup reliably.",
+    );
+  }
+
+  if (isTruthyEnvValue(disableCompileCache)) {
+    lines.push("- NODE_DISABLE_COMPILE_CACHE is set; startup compile cache is disabled.");
+  }
+
+  if (noRespawn !== "1") {
+    lines.push(
+      "- REMOTECLAW_NO_RESPAWN is not set to 1; set it to avoid extra startup overhead from self-respawn.",
+    );
+  }
+
+  if (lines.length === 0) {
+    return;
+  }
+
+  const suggestions = [
+    "- Suggested env for low-power hosts:",
+    "  export NODE_COMPILE_CACHE=/var/tmp/remoteclaw-compile-cache",
+    "  mkdir -p /var/tmp/remoteclaw-compile-cache",
+    "  export REMOTECLAW_NO_RESPAWN=1",
+    isTruthyEnvValue(disableCompileCache) ? "  unset NODE_DISABLE_COMPILE_CACHE" : undefined,
+  ].filter((line): line is string => Boolean(line));
+
+  noteFn([...lines, ...suggestions].join("\n"), "Startup optimization");
+}

--- a/src/commands/doctor.fast-path-mocks.ts
+++ b/src/commands/doctor.fast-path-mocks.ts
@@ -15,6 +15,7 @@ vi.mock("./doctor-gateway-health.js", () => ({
 
 vi.mock("./doctor-platform-notes.js", () => ({
   noteDeprecatedLegacyEnvVars: vi.fn(),
+  noteStartupOptimizationHints: vi.fn(),
   noteMacLaunchAgentOverrides: vi.fn().mockResolvedValue(undefined),
   noteMacLaunchctlGatewayEnvOverrides: vi.fn().mockResolvedValue(undefined),
 }));

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -33,6 +33,7 @@ import {
   noteMacLaunchAgentOverrides,
   noteMacLaunchctlGatewayEnvOverrides,
   noteDeprecatedLegacyEnvVars,
+  noteStartupOptimizationHints,
 } from "./doctor-platform-notes.js";
 import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
 import { noteSecurityWarnings } from "./doctor-security.js";
@@ -84,6 +85,7 @@ export async function doctorCommand(
   await maybeRepairUiProtocolFreshness(runtime, prompter);
   noteSourceInstallIssues(root);
   noteDeprecatedLegacyEnvVars();
+  noteStartupOptimizationHints();
 
   const configResult = await loadAndMaybeMigrateDoctorConfig({
     options,

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -1,6 +1,6 @@
 import { formatCliCommand } from "../cli/command-format.js";
 import { withProgress } from "../cli/progress.js";
-import { resolveGatewayPort } from "../config/config.js";
+import { loadConfig, resolveGatewayPort } from "../config/config.js";
 import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
 import { info } from "../globals.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
@@ -73,10 +73,33 @@ export async function statusCommand(
     return;
   }
 
-  const scan = await scanStatus(
-    { json: opts.json, timeoutMs: opts.timeoutMs, all: opts.all },
-    runtime,
-  );
+  const [scan, securityAudit] = opts.json
+    ? await Promise.all([
+        scanStatus({ json: opts.json, timeoutMs: opts.timeoutMs, all: opts.all }, runtime),
+        runSecurityAudit({
+          config: loadConfig(),
+          deep: false,
+          includeFilesystem: true,
+          includeChannelSecurity: true,
+        }),
+      ])
+    : [
+        await scanStatus({ json: opts.json, timeoutMs: opts.timeoutMs, all: opts.all }, runtime),
+        await withProgress(
+          {
+            label: "Running security audit…",
+            indeterminate: true,
+            enabled: true,
+          },
+          async () =>
+            await runSecurityAudit({
+              config: loadConfig(),
+              deep: false,
+              includeFilesystem: true,
+              includeChannelSecurity: true,
+            }),
+        ),
+      ];
   const {
     cfg,
     osSummary,
@@ -95,21 +118,6 @@ export async function statusCommand(
     channels,
     summary,
   } = scan;
-
-  const securityAudit = await withProgress(
-    {
-      label: "Running security audit…",
-      indeterminate: true,
-      enabled: opts.json !== true,
-    },
-    async () =>
-      await runSecurityAudit({
-        config: cfg,
-        deep: false,
-        includeFilesystem: true,
-        includeChannelSecurity: true,
-      }),
-  );
 
   const usage = opts.usage
     ? await withProgress(

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -33,31 +33,6 @@ export type StatusScanResult = {
   summary: Awaited<ReturnType<typeof getStatusSummary>>;
 };
 
-async function resolveMemoryStatusSnapshot(params: {
-  cfg: ReturnType<typeof loadConfig>;
-  agentStatus: Awaited<ReturnType<typeof getAgentLocalStatuses>>;
-  memoryPlugin: MemoryPluginStatus;
-}): Promise<MemoryStatusSnapshot | null> {
-  const { cfg, agentStatus, memoryPlugin } = params;
-  if (!memoryPlugin.enabled) {
-    return null;
-  }
-  if (memoryPlugin.slot !== "memory-core") {
-    return null;
-  }
-  const agentId = agentStatus.defaultId ?? "main";
-  const { manager } = await getMemorySearchManager({ cfg, agentId, purpose: "status" });
-  if (!manager) {
-    return null;
-  }
-  try {
-    await manager.probeVectorAvailability();
-  } catch {}
-  const status = manager.status();
-  await manager.close?.().catch(() => {});
-  return { agentId, ...status };
-}
-
 async function scanStatusJsonFast(opts: {
   timeoutMs?: number;
   all?: boolean;
@@ -120,9 +95,7 @@ async function scanStatusJsonFast(opts: {
         timeoutMs: Math.min(opts.all ? 5000 : 2500, opts.timeoutMs ?? 10_000),
       }).catch(() => null)
     : Promise.resolve(null);
-  const memoryPlugin = resolveMemoryPluginStatus(cfg);
-  const memoryPromise = resolveMemoryStatusSnapshot({ cfg, agentStatus, memoryPlugin });
-  const [channelsStatus, memory] = await Promise.all([channelsStatusPromise, memoryPromise]);
+  const channelsStatus = await channelsStatusPromise;
   const channelIssues = channelsStatus ? collectChannelStatusIssues(channelsStatus) : [];
 
   return {
@@ -140,10 +113,8 @@ async function scanStatusJsonFast(opts: {
     gatewaySelf,
     channelIssues,
     agentStatus,
-    channels: [],
+    channels: { rows: [], details: [] },
     summary,
-    memory,
-    memoryPlugin,
   };
 }
 
@@ -162,7 +133,7 @@ export async function scanStatus(
     {
       label: "Scanning status…",
       total: 10,
-      enabled: opts.json !== true,
+      enabled: true,
     },
     async (progress) => {
       progress.setLabel("Loading config…");
@@ -232,13 +203,11 @@ export async function scanStatus(
       progress.tick();
 
       progress.setLabel("Summarizing channels…");
-      const channels = opts.json
-        ? []
-        : await buildChannelsTable(cfg, {
-            // Show token previews in regular status; keep `status --all` redacted.
-            // Set `REMOTECLAW_SHOW_SECRETS=0` to force redaction.
-            showSecrets: process.env.REMOTECLAW_SHOW_SECRETS?.trim() !== "0",
-          });
+      const channels = await buildChannelsTable(cfg, {
+        // Show token previews in regular status; keep `status --all` redacted.
+        // Set `REMOTECLAW_SHOW_SECRETS=0` to force redaction.
+        showSecrets: process.env.REMOTECLAW_SHOW_SECRETS?.trim() !== "0",
+      });
       progress.tick();
 
       progress.tick();

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -139,16 +139,25 @@ export async function scanStatus(
       progress.setLabel("Loading config…");
       const cfg = loadConfig();
       const osSummary = resolveOsSummary();
+      const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
+      const tailscaleDnsPromise =
+        tailscaleMode === "off"
+          ? Promise.resolve<string | null>(null)
+          : getTailnetHostname((cmd, args) =>
+              runExec(cmd, args, { timeoutMs: 1200, maxBuffer: 200_000 }),
+            ).catch(() => null);
+      const updateTimeoutMs = opts.all ? 6500 : 2500;
+      const updatePromise = getUpdateCheckResult({
+        timeoutMs: updateTimeoutMs,
+        fetchGit: true,
+        includeRegistry: true,
+      });
+      const agentStatusPromise = getAgentLocalStatuses();
+      const summaryPromise = getStatusSummary();
       progress.tick();
 
       progress.setLabel("Checking Tailscale…");
-      const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
-      const tailscaleDns =
-        tailscaleMode === "off"
-          ? null
-          : await getTailnetHostname((cmd, args) =>
-              runExec(cmd, args, { timeoutMs: 1200, maxBuffer: 200_000 }),
-            ).catch(() => null);
+      const tailscaleDns = await tailscaleDnsPromise;
       const tailscaleHttpsUrl =
         tailscaleMode !== "off" && tailscaleDns
           ? `https://${tailscaleDns}${normalizeControlUiBasePath(cfg.gateway?.controlUi?.basePath)}`
@@ -156,16 +165,11 @@ export async function scanStatus(
       progress.tick();
 
       progress.setLabel("Checking for updates…");
-      const updateTimeoutMs = opts.all ? 6500 : 2500;
-      const update = await getUpdateCheckResult({
-        timeoutMs: updateTimeoutMs,
-        fetchGit: true,
-        includeRegistry: true,
-      });
+      const update = await updatePromise;
       progress.tick();
 
       progress.setLabel("Resolving agents…");
-      const agentStatus = await getAgentLocalStatuses();
+      const agentStatus = await agentStatusPromise;
       progress.tick();
 
       progress.setLabel("Probing gateway…");
@@ -213,7 +217,7 @@ export async function scanStatus(
       progress.tick();
 
       progress.setLabel("Reading sessions…");
-      const summary = await getStatusSummary();
+      const summary = await summaryPromise;
       progress.tick();
 
       progress.setLabel("Rendering…");

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -115,11 +115,13 @@ export async function scanStatus(
       progress.tick();
 
       progress.setLabel("Summarizing channels…");
-      const channels = await buildChannelsTable(cfg, {
-        // Show token previews in regular status; keep `status --all` redacted.
-        // Set `REMOTECLAW_SHOW_SECRETS=0` to force redaction.
-        showSecrets: process.env.REMOTECLAW_SHOW_SECRETS?.trim() !== "0",
-      });
+      const channels = opts.json
+        ? []
+        : await buildChannelsTable(cfg, {
+            // Show token previews in regular status; keep `status --all` redacted.
+            // Set `REMOTECLAW_SHOW_SECRETS=0` to force redaction.
+            showSecrets: process.env.REMOTECLAW_SHOW_SECRETS?.trim() !== "0",
+          });
       progress.tick();
 
       progress.tick();

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -14,6 +14,22 @@ import { pickGatewaySelfPresence, resolveGatewayProbeAuth } from "./status.gatew
 import { getStatusSummary } from "./status.summary.js";
 import { getUpdateCheckResult } from "./status.update.js";
 
+type DeferredResult<T> = { ok: true; value: T } | { ok: false; error: unknown };
+
+function deferResult<T>(promise: Promise<T>): Promise<DeferredResult<T>> {
+  return promise.then(
+    (value) => ({ ok: true, value }),
+    (error: unknown) => ({ ok: false, error }),
+  );
+}
+
+function unwrapDeferredResult<T>(result: DeferredResult<T>): T {
+  if (!result.ok) {
+    throw result.error;
+  }
+  return result.value;
+}
+
 export type StatusScanResult = {
   cfg: ReturnType<typeof loadConfig>;
   osSummary: ReturnType<typeof resolveOsSummary>;
@@ -147,13 +163,15 @@ export async function scanStatus(
               runExec(cmd, args, { timeoutMs: 1200, maxBuffer: 200_000 }),
             ).catch(() => null);
       const updateTimeoutMs = opts.all ? 6500 : 2500;
-      const updatePromise = getUpdateCheckResult({
-        timeoutMs: updateTimeoutMs,
-        fetchGit: true,
-        includeRegistry: true,
-      });
-      const agentStatusPromise = getAgentLocalStatuses();
-      const summaryPromise = getStatusSummary();
+      const updatePromise = deferResult(
+        getUpdateCheckResult({
+          timeoutMs: updateTimeoutMs,
+          fetchGit: true,
+          includeRegistry: true,
+        }),
+      );
+      const agentStatusPromise = deferResult(getAgentLocalStatuses());
+      const summaryPromise = deferResult(getStatusSummary());
       progress.tick();
 
       progress.setLabel("Checking Tailscale…");
@@ -165,11 +183,11 @@ export async function scanStatus(
       progress.tick();
 
       progress.setLabel("Checking for updates…");
-      const update = await updatePromise;
+      const update = unwrapDeferredResult(await updatePromise);
       progress.tick();
 
       progress.setLabel("Resolving agents…");
-      const agentStatus = await agentStatusPromise;
+      const agentStatus = unwrapDeferredResult(await agentStatusPromise);
       progress.tick();
 
       progress.setLabel("Probing gateway…");
@@ -217,7 +235,7 @@ export async function scanStatus(
       progress.tick();
 
       progress.setLabel("Reading sessions…");
-      const summary = await summaryPromise;
+      const summary = unwrapDeferredResult(await summaryPromise);
       progress.tick();
 
       progress.setLabel("Rendering…");

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -33,6 +33,120 @@ export type StatusScanResult = {
   summary: Awaited<ReturnType<typeof getStatusSummary>>;
 };
 
+async function resolveMemoryStatusSnapshot(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  agentStatus: Awaited<ReturnType<typeof getAgentLocalStatuses>>;
+  memoryPlugin: MemoryPluginStatus;
+}): Promise<MemoryStatusSnapshot | null> {
+  const { cfg, agentStatus, memoryPlugin } = params;
+  if (!memoryPlugin.enabled) {
+    return null;
+  }
+  if (memoryPlugin.slot !== "memory-core") {
+    return null;
+  }
+  const agentId = agentStatus.defaultId ?? "main";
+  const { manager } = await getMemorySearchManager({ cfg, agentId, purpose: "status" });
+  if (!manager) {
+    return null;
+  }
+  try {
+    await manager.probeVectorAvailability();
+  } catch {}
+  const status = manager.status();
+  await manager.close?.().catch(() => {});
+  return { agentId, ...status };
+}
+
+async function scanStatusJsonFast(opts: {
+  timeoutMs?: number;
+  all?: boolean;
+}): Promise<StatusScanResult> {
+  const cfg = loadConfig();
+  const osSummary = resolveOsSummary();
+  const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
+  const updateTimeoutMs = opts.all ? 6500 : 2500;
+  const updatePromise = getUpdateCheckResult({
+    timeoutMs: updateTimeoutMs,
+    fetchGit: true,
+    includeRegistry: true,
+  });
+  const agentStatusPromise = getAgentLocalStatuses();
+  const summaryPromise = getStatusSummary();
+
+  const tailscaleDnsPromise =
+    tailscaleMode === "off"
+      ? Promise.resolve<string | null>(null)
+      : getTailnetHostname((cmd, args) =>
+          runExec(cmd, args, { timeoutMs: 1200, maxBuffer: 200_000 }),
+        ).catch(() => null);
+
+  const gatewayConnection = buildGatewayConnectionDetails();
+  const isRemoteMode = cfg.gateway?.mode === "remote";
+  const remoteUrlRaw = typeof cfg.gateway?.remote?.url === "string" ? cfg.gateway.remote.url : "";
+  const remoteUrlMissing = isRemoteMode && !remoteUrlRaw.trim();
+  const gatewayMode = isRemoteMode ? "remote" : "local";
+  const gatewayProbePromise = remoteUrlMissing
+    ? Promise.resolve<Awaited<ReturnType<typeof probeGateway>> | null>(null)
+    : probeGateway({
+        url: gatewayConnection.url,
+        auth: resolveGatewayProbeAuth(cfg),
+        timeoutMs: Math.min(opts.all ? 5000 : 2500, opts.timeoutMs ?? 10_000),
+      }).catch(() => null);
+
+  const [tailscaleDns, update, agentStatus, gatewayProbe, summary] = await Promise.all([
+    tailscaleDnsPromise,
+    updatePromise,
+    agentStatusPromise,
+    gatewayProbePromise,
+    summaryPromise,
+  ]);
+  const tailscaleHttpsUrl =
+    tailscaleMode !== "off" && tailscaleDns
+      ? `https://${tailscaleDns}${normalizeControlUiBasePath(cfg.gateway?.controlUi?.basePath)}`
+      : null;
+
+  const gatewayReachable = gatewayProbe?.ok === true;
+  const gatewaySelf = gatewayProbe?.presence
+    ? pickGatewaySelfPresence(gatewayProbe.presence)
+    : null;
+  const channelsStatusPromise = gatewayReachable
+    ? callGateway({
+        method: "channels.status",
+        params: {
+          probe: false,
+          timeoutMs: Math.min(8000, opts.timeoutMs ?? 10_000),
+        },
+        timeoutMs: Math.min(opts.all ? 5000 : 2500, opts.timeoutMs ?? 10_000),
+      }).catch(() => null)
+    : Promise.resolve(null);
+  const memoryPlugin = resolveMemoryPluginStatus(cfg);
+  const memoryPromise = resolveMemoryStatusSnapshot({ cfg, agentStatus, memoryPlugin });
+  const [channelsStatus, memory] = await Promise.all([channelsStatusPromise, memoryPromise]);
+  const channelIssues = channelsStatus ? collectChannelStatusIssues(channelsStatus) : [];
+
+  return {
+    cfg,
+    osSummary,
+    tailscaleMode,
+    tailscaleDns,
+    tailscaleHttpsUrl,
+    update,
+    gatewayConnection,
+    remoteUrlMissing,
+    gatewayMode,
+    gatewayProbe,
+    gatewayReachable,
+    gatewaySelf,
+    channelIssues,
+    agentStatus,
+    channels: [],
+    summary,
+    memory,
+    memoryPlugin,
+  };
+}
+
 export async function scanStatus(
   opts: {
     json?: boolean;
@@ -41,6 +155,9 @@ export async function scanStatus(
   },
   _runtime: RuntimeEnv,
 ): Promise<StatusScanResult> {
+  if (opts.json) {
+    return await scanStatusJsonFast({ timeoutMs: opts.timeoutMs, all: opts.all });
+  }
   return await withProgress(
     {
       label: "Scanning status…",

--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -55,6 +55,30 @@ describe("resolveCronDeliveryPlan", () => {
     expect(plan.to).toBe("telegram:123");
   });
 
+  it("passes through accountId from delivery config", () => {
+    const plan = resolveCronDeliveryPlan(
+      makeJob({
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "-1003816714067",
+          accountId: "coordinator",
+        },
+      }),
+    );
+    expect(plan.mode).toBe("announce");
+    expect(plan.accountId).toBe("coordinator");
+    expect(plan.to).toBe("-1003816714067");
+  });
+
+  it("returns undefined accountId when not set", () => {
+    const plan = resolveCronDeliveryPlan(
+      makeJob({
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      }),
+    );
+    expect(plan.accountId).toBeUndefined();
+  });
   it("resolves webhook mode without channel routing", () => {
     const plan = resolveCronDeliveryPlan(
       makeJob({

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -4,6 +4,7 @@ export type CronDeliveryPlan = {
   mode: CronDeliveryMode;
   channel?: CronMessageChannel;
   to?: string;
+  /** Explicit channel account id from the delivery config, if set. */
   accountId?: string;
   source: "delivery" | "payload";
   requested: boolean;
@@ -59,12 +60,11 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
     (delivery as { channel?: unknown } | undefined)?.channel,
   );
   const deliveryTo = normalizeTo((delivery as { to?: unknown } | undefined)?.to);
+  const channel = deliveryChannel ?? payloadChannel ?? "last";
+  const to = deliveryTo ?? payloadTo;
   const deliveryAccountId = normalizeAccountId(
     (delivery as { accountId?: unknown } | undefined)?.accountId,
   );
-
-  const channel = deliveryChannel ?? payloadChannel ?? "last";
-  const to = deliveryTo ?? payloadTo;
   if (hasDelivery) {
     const resolvedMode = mode ?? "announce";
     return {

--- a/src/cron/isolated-agent.delivery-target-thread-session.test.ts
+++ b/src/cron/isolated-agent.delivery-target-thread-session.test.ts
@@ -110,6 +110,27 @@ describe("resolveDeliveryTarget thread session lookup", () => {
     expect(result.channel).toBe("telegram");
   });
 
+  it("explicit accountId overrides session lastAccountId", async () => {
+    mockStore["/mock/store.json"] = {
+      "agent:main:main": {
+        sessionId: "s1",
+        updatedAt: 1,
+        lastChannel: "telegram",
+        lastTo: "-100444",
+        lastAccountId: "session-account",
+      },
+    };
+
+    const result = await resolveDeliveryTarget(cfg, "main", {
+      channel: "telegram",
+      to: "-100444",
+      accountId: "explicit-account",
+    });
+
+    expect(result.accountId).toBe("explicit-account");
+    expect(result.to).toBe("-100444");
+  });
+
   it("preserves threadId from :topic: when lastTo differs", async () => {
     mockStore["/mock/store.json"] = {
       "agent:main:main": {

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -178,6 +178,51 @@ describe("normalizeCronJobCreate", () => {
     expect(delivery.to).toBe("7200373102");
   });
 
+  it("normalizes delivery accountId and strips blanks", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "delivery account",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: {
+        kind: "agentTurn",
+        message: "hi",
+      },
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "-1003816714067",
+        accountId: " coordinator ",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const delivery = normalized.delivery as Record<string, unknown>;
+    expect(delivery.accountId).toBe("coordinator");
+  });
+
+  it("strips empty accountId from delivery", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "empty account",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: {
+        kind: "agentTurn",
+        message: "hi",
+      },
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        accountId: "   ",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const delivery = normalized.delivery as Record<string, unknown>;
+    expect("accountId" in delivery).toBe(false);
+  });
+
   it("normalizes webhook delivery mode and target URL", () => {
     const normalized = normalizeCronJobCreate({
       name: "webhook delivery",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -187,6 +187,16 @@ function coerceDelivery(delivery: UnknownRecord) {
       delete next.to;
     }
   }
+  if (typeof delivery.accountId === "string") {
+    const trimmed = delivery.accountId.trim();
+    if (trimmed) {
+      next.accountId = trimmed;
+    } else {
+      delete next.accountId;
+    }
+  } else if ("accountId" in next && typeof next.accountId !== "string") {
+    delete next.accountId;
+  }
   return next;
 }
 

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -115,6 +115,28 @@ describe("applyJobPatch", () => {
     });
   });
 
+  it("merges delivery.accountId from patch and preserves existing", () => {
+    const job = createIsolatedAgentTurnJob("job-acct", {
+      mode: "announce",
+      channel: "telegram",
+      to: "-100123",
+    });
+
+    applyJobPatch(job, { delivery: { mode: "announce", accountId: " coordinator " } });
+    expect(job.delivery?.accountId).toBe("coordinator");
+    expect(job.delivery?.mode).toBe("announce");
+    expect(job.delivery?.to).toBe("-100123");
+
+    // Updating other fields preserves accountId
+    applyJobPatch(job, { delivery: { mode: "announce", to: "-100999" } });
+    expect(job.delivery?.accountId).toBe("coordinator");
+    expect(job.delivery?.to).toBe("-100999");
+
+    // Clearing accountId with empty string
+    applyJobPatch(job, { delivery: { mode: "announce", accountId: "" } });
+    expect(job.delivery?.accountId).toBeUndefined();
+  });
+
   it("rejects webhook delivery without a valid http(s) target URL", () => {
     const expectedError = "cron webhook delivery requires delivery.to to be a valid http(s) URL";
     const cases = [

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -652,6 +652,7 @@ function mergeCronDelivery(
     mode: existing?.mode ?? "none",
     channel: existing?.channel,
     to: existing?.to,
+    accountId: existing?.accountId,
     bestEffort: existing?.bestEffort,
   };
 
@@ -665,6 +666,10 @@ function mergeCronDelivery(
   if ("to" in patch) {
     const to = typeof patch.to === "string" ? patch.to.trim() : "";
     next.to = to ? to : undefined;
+  }
+  if ("accountId" in patch) {
+    const accountId = typeof patch.accountId === "string" ? patch.accountId.trim() : "";
+    next.accountId = accountId ? accountId : undefined;
   }
   if (typeof patch.bestEffort === "boolean") {
     next.bestEffort = patch.bestEffort;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -22,6 +22,7 @@ export type CronDelivery = {
   mode: CronDeliveryMode;
   channel?: CronMessageChannel;
   to?: string;
+  /** Explicit channel account id for multi-account setups (e.g. multiple Telegram bots). */
   accountId?: string;
   bestEffort?: boolean;
 };

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
+import { enableCompileCache } from "node:module";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { isRootHelpInvocation, isRootVersionInvocation } from "./cli/argv.js";
@@ -32,6 +33,13 @@ if (
   process.title = "remoteclaw";
   installProcessWarningFilter();
   normalizeEnv();
+  if (!isTruthyEnvValue(process.env.NODE_DISABLE_COMPILE_CACHE)) {
+    try {
+      enableCompileCache();
+    } catch {
+      // Best-effort only; never block startup.
+    }
+  }
 
   if (process.argv.includes("--no-color")) {
     process.env.NO_COLOR = "1";

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -2,6 +2,7 @@
 import { spawn } from "node:child_process";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { isRootHelpInvocation, isRootVersionInvocation } from "./cli/argv.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile.js";
 import { shouldSkipRespawnForArgv } from "./cli/respawn-policy.js";
 import { normalizeWindowsArgv } from "./cli/windows-argv.js";
@@ -100,6 +101,42 @@ if (
     return true;
   }
 
+  function tryHandleRootVersionFastPath(argv: string[]): boolean {
+    if (!isRootVersionInvocation(argv)) {
+      return false;
+    }
+    import("./version.js")
+      .then(({ VERSION }) => {
+        console.log(VERSION);
+      })
+      .catch((error) => {
+        console.error(
+          "[remoteclaw] Failed to resolve version:",
+          error instanceof Error ? (error.stack ?? error.message) : error,
+        );
+        process.exitCode = 1;
+      });
+    return true;
+  }
+
+  function tryHandleRootHelpFastPath(argv: string[]): boolean {
+    if (!isRootHelpInvocation(argv)) {
+      return false;
+    }
+    import("./cli/program.js")
+      .then(({ buildProgram }) => {
+        buildProgram().outputHelp();
+      })
+      .catch((error) => {
+        console.error(
+          "[remoteclaw] Failed to display help:",
+          error instanceof Error ? (error.stack ?? error.message) : error,
+        );
+        process.exitCode = 1;
+      });
+    return true;
+  }
+
   process.argv = normalizeWindowsArgv(process.argv);
 
   if (!ensureExperimentalWarningSuppressed()) {
@@ -116,14 +153,16 @@ if (
       process.argv = parsed.argv;
     }
 
-    import("./cli/run-main.js")
-      .then(({ runCli }) => runCli(process.argv))
-      .catch((error) => {
-        console.error(
-          "[remoteclaw] Failed to start CLI:",
-          error instanceof Error ? (error.stack ?? error.message) : error,
-        );
-        process.exitCode = 1;
-      });
+    if (!tryHandleRootVersionFastPath(process.argv) && !tryHandleRootHelpFastPath(process.argv)) {
+      import("./cli/run-main.js")
+        .then(({ runCli }) => runCli(process.argv))
+        .catch((error) => {
+          console.error(
+            "[remoteclaw] Failed to start CLI:",
+            error instanceof Error ? (error.stack ?? error.message) : error,
+          );
+          process.exitCode = 1;
+        });
+    }
   }
 }

--- a/src/terminal/note.ts
+++ b/src/terminal/note.ts
@@ -6,6 +6,17 @@ const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const FILE_LIKE_RE = /^[a-zA-Z0-9._-]+$/;
 
+function isSuppressedByEnv(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return normalized !== "0" && normalized !== "false" && normalized !== "off";
+}
+
 function splitLongWord(word: string, maxLen: number): string[] {
   if (maxLen <= 0) {
     return [word];
@@ -130,5 +141,8 @@ export function wrapNoteMessage(
 }
 
 export function note(message: string, title?: string) {
+  if (isSuppressedByEnv(process.env.REMOTECLAW_SUPPRESS_NOTES)) {
+    return;
+  }
   clackNote(wrapNoteMessage(message), stylePromptTitle(title));
 }

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -1,0 +1,44 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "./helpers/temp-home.ts";
+
+describe("cli json stdout contract", () => {
+  it("keeps `update status --json` stdout parseable even with legacy doctor preflight inputs", async () => {
+    await withTempHome(
+      async (tempHome) => {
+        const legacyDir = path.join(tempHome, ".clawdbot");
+        await fs.mkdir(legacyDir, { recursive: true });
+        await fs.writeFile(path.join(legacyDir, "clawdbot.json"), "{}", "utf8");
+
+        const env = {
+          ...process.env,
+          HOME: tempHome,
+          USERPROFILE: tempHome,
+          REMOTECLAW_TEST_FAST: "1",
+        };
+        delete env.REMOTECLAW_HOME;
+        delete env.REMOTECLAW_STATE_DIR;
+        delete env.REMOTECLAW_CONFIG_PATH;
+        delete env.VITEST;
+
+        const entry = path.resolve(process.cwd(), "remoteclaw.mjs");
+        const result = spawnSync(
+          process.execPath,
+          [entry, "update", "status", "--json", "--timeout", "1"],
+          { cwd: process.cwd(), env, encoding: "utf8" },
+        );
+
+        expect(result.status).toBe(0);
+        const stdout = result.stdout.trim();
+        expect(stdout.length).toBeGreaterThan(0);
+        expect(() => JSON.parse(stdout)).not.toThrow();
+        expect(stdout).not.toContain("Doctor warnings");
+        expect(stdout).not.toContain("Doctor changes");
+        expect(stdout).not.toContain("Config invalid");
+      },
+      { prefix: "remoteclaw-json-e2e-" },
+    );
+  });
+});


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #682
**Commits**: 24 cherry-picked (2 skipped as already applied via earlier resolution)

| Hash | Subject | Result |
|------|---------|--------|
| `b297bae02` | fix(cli): allow Ollama apiKey config set without predeclared provider | PICKED |
| `5e2ef0e88` | feat(cron): add --account flag for multi-account delivery routing | RESOLVED |
| `cb6f993b4` | fix(cli): cron list Agent column shows agentId not model — add Model column | RESOLVED |
| `5e061fd8b` | CLI routes: skip plugin preload for health | PICKED |
| `af12e7bde` | CLI route: support argv-aware plugin preloading | PICKED |
| `3c4cdf72c` | CLI routes: test conditional plugin preload behavior | PICKED |
| `86a91cc01` | CLI argv: detect root-only version invocation | PICKED |
| `07da84337` | CLI argv: test root version fast-path detection | PICKED |
| `266084f4c` | CLI routes: preload plugins for status security parity | PICKED |
| `125ea585d` | CLI routes tests: assert status plugin preload | PICKED |
| `38da2d076` | CLI: add root --help fast path and lazy channel option resolution | RESOLVED |
| `e07c51b04` | CLI: avoid plugin preload for health --json route | PICKED |
| `ffe1937b9` | fix(cli): set cron run exit code from run outcome | RESOLVED |
| `9e4a366ee` | fix(cli): keep json preflight stdout machine-readable | RESOLVED |
| `67b98139b` | test(cli): avoid brittle mock call indexing in json-mode checks | PICKED |
| `342bf4838` | fix(cli): preserve json stdout while keeping doctor migration | RESOLVED |
| `310344b6e` | fix: read thinking/verbose/reasoning levels from session entry in status | RESOLVED |
| `22653c0e2` | Status scan: skip channel table work in JSON mode | RESOLVED |
| `153adc4c8` | Entry: fast-path root version command | SKIPPED (already applied) |
| `b0a73ae77` | Status command: parallelize JSON security audit | PICKED |
| `ba0aa3cfa` | Status scan: add parallel JSON fast path | PICKED |
| `7aa9267d0` | Status scan: fix JSON channels result typing | RESOLVED |
| `e4b4fd5ce` | Entry: avoid top-level return in version fast-path | SKIPPED (already applied) |
| `8c4071f36` | Entry: enable Node compile cache on startup | PICKED |
| `23c6e9836` | Status scan: overlap non-JSON async checks | PICKED |
| `79f818e8a` | Status scan: guard deferred promise rejections | RESOLVED |

### Adaptations
- Rebranded `openclaw` → `remoteclaw` in new docs, scripts, env vars, tests
- Removed memory subsystem references from JSON fast-path (memory gutted in fork)
- Kept fork's `resolveCronDeliveryContext` helper (already handles accountId)
- Kept fork's version-only verbose status (think/reasoning/elevated removed)
- Fixed lint: `process.stdout.write.bind(process.stdout)` for unbound method
- Fixed TS: mock typing for cron run exit code tests, config-cli Ollama test

🤖 Generated with [Claude Code](https://claude.com/claude-code)