### PR TITLE
Cherry-pick batch: security hardening

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,6 +55,7 @@ These are frequently reported but are typically closed with no code change:
 - Reports that assume per-user multi-tenant authorization on a shared gateway host/config.
 - Reports that only show differences in heuristic detection/parity (for example obfuscation-pattern detection on one exec path but not another, such as `node.invoke -> system.run` parity gaps) without demonstrating bypass of auth, approvals, allowlist enforcement, sandboxing, or other documented trust boundaries.
 - ReDoS/DoS claims that require trusted operator configuration input (for example catastrophic regex in `sessionFilter` or `logging.redactPatterns`) without a trust-boundary bypass.
+- Archive/install extraction claims that require pre-existing local filesystem priming in trusted state (for example planting symlink/hardlink aliases under destination directories such as skills/tools paths) without showing an untrusted path that can create/control that primitive.
 - Missing HSTS findings on default local/loopback deployments.
 - Slack webhook signature findings when HTTP mode already uses signing-secret verification.
 - Discord inbound webhook signature findings for paths not used by this repo's Discord integration.
@@ -111,6 +112,7 @@ Plugins/extensions are part of RemoteClaw's trusted computing base for a gateway
 - Deployments where mutually untrusted/adversarial operators share one gateway host and config (for example, reports expecting per-operator isolation for `sessions.list`, `sessions.preview`, `chat.history`, or similar control-plane reads)
 - Prompt-injection-only attacks (without a policy/auth/sandbox boundary bypass)
 - Reports that require write access to trusted local state (`~/.remoteclaw`, workspace files like `MEMORY.md` / `memory/*.md`)
+- Reports where exploitability depends on attacker-controlled pre-existing symlink/hardlink filesystem state in trusted local paths (for example extraction/install target trees) unless a separate untrusted boundary bypass is shown that creates that state.
 - Reports where the only demonstrated impact is an already-authorized sender intentionally invoking a local-action command (for example `/export-session` writing to an absolute host path) without bypassing auth, sandbox, or another documented boundary
 - Reports where the only claim is that a trusted-installed/enabled plugin can execute with gateway/host privileges (documented trust model behavior).
 - Any report whose only claim is that an operator-enabled `dangerous*`/`dangerously*` config option weakens defaults (these are explicit break-glass tradeoffs by design)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -205,6 +205,14 @@ For threat model + hardening guidance (including `remoteclaw security audit --de
 - `tools.fs.workspaceOnly: true` (optional): restricts `read`/`write`/`edit`/`apply_patch` paths and native prompt image auto-load paths to the workspace directory.
 - Avoid setting `tools.exec.applyPatch.workspaceOnly: false` unless you fully trust who can trigger tool execution.
 
+### Sub-agent delegation hardening
+
+- Keep `sessions_spawn` denied unless you explicitly need delegated runs.
+- Keep `agents.list[].subagents.allowAgents` narrow, and only include agents with sandbox settings you trust.
+- When delegation must stay sandboxed, call `sessions_spawn` with `sandbox: "require"` (default is `inherit`).
+  - `sandbox: "require"` rejects the spawn unless the target child runtime is sandboxed.
+  - This prevents a less-restricted session from delegating work into an unsandboxed child by mistake.
+
 ### Web Interface Safety
 
 RemoteClaw's web interface (Gateway Control UI + HTTP endpoints) is intended for **local use only**.

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -875,6 +875,15 @@ Also consider agent workspace access inside the sandbox:
 - `agents.defaults.sandbox.workspaceAccess: "ro"` mounts the agent workspace read-only at `/agent` (disables `write`/`edit`/`apply_patch`)
 - `agents.defaults.sandbox.workspaceAccess: "rw"` mounts the agent workspace read/write at `/workspace`
 
+### Sub-agent delegation guardrail
+
+If you allow session tools, treat delegated sub-agent runs as another boundary decision:
+
+- Deny `sessions_spawn` unless the agent truly needs delegation.
+- Keep `agents.list[].subagents.allowAgents` restricted to known-safe target agents.
+- For any workflow that must remain sandboxed, call `sessions_spawn` with `sandbox: "require"` (default is `inherit`).
+- `sandbox: "require"` fails fast when the target child runtime is not sandboxed.
+
 ## Browser control risks
 
 Enabling browser control gives the model the ability to drive a real browser.

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -2,12 +2,15 @@ import * as crypto from "crypto";
 import * as http from "http";
 import * as Lark from "@larksuiteoapi/node-sdk";
 import {
+  applyBasicWebhookRequestGuards,
   type ClawdbotConfig,
-  createBoundedCounter,
   createFixedWindowRateLimiter,
+  createWebhookAnomalyTracker,
   type RuntimeEnv,
   type HistoryEntry,
   installRequestBodyLimitGuard,
+  WEBHOOK_ANOMALY_COUNTER_DEFAULTS,
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
 } from "remoteclaw/plugin-sdk";
 import { resolveFeishuAccount, listEnabledFeishuAccounts } from "./accounts.js";
 import { handleFeishuMessage, type FeishuMessageEvent, type FeishuBotAddedEvent } from "./bot.js";
@@ -30,12 +33,6 @@ const httpServers = new Map<string, http.Server>();
 const botOpenIds = new Map<string, string>();
 const FEISHU_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const FEISHU_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
-const FEISHU_WEBHOOK_RATE_LIMIT_WINDOW_MS = 60_000;
-const FEISHU_WEBHOOK_RATE_LIMIT_MAX_REQUESTS = 120;
-const FEISHU_WEBHOOK_RATE_LIMIT_MAX_TRACKED_KEYS = 4_096;
-const FEISHU_WEBHOOK_COUNTER_LOG_EVERY = 25;
-const FEISHU_WEBHOOK_COUNTER_MAX_TRACKED_KEYS = 4_096;
-const FEISHU_WEBHOOK_COUNTER_TTL_MS = 6 * 60 * 60_000;
 const FEISHU_REACTION_VERIFY_TIMEOUT_MS = 1_500;
 
 export type FeishuReactionCreatedEvent = {
@@ -60,27 +57,19 @@ type ResolveReactionSyntheticEventParams = {
 };
 
 const feishuWebhookRateLimiter = createFixedWindowRateLimiter({
-  windowMs: FEISHU_WEBHOOK_RATE_LIMIT_WINDOW_MS,
-  maxRequests: FEISHU_WEBHOOK_RATE_LIMIT_MAX_REQUESTS,
-  maxTrackedKeys: FEISHU_WEBHOOK_RATE_LIMIT_MAX_TRACKED_KEYS,
+  windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs,
+  maxRequests: WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests,
+  maxTrackedKeys: WEBHOOK_RATE_LIMIT_DEFAULTS.maxTrackedKeys,
 });
-const feishuWebhookStatusCounters = createBoundedCounter({
-  maxTrackedKeys: FEISHU_WEBHOOK_COUNTER_MAX_TRACKED_KEYS,
-  ttlMs: FEISHU_WEBHOOK_COUNTER_TTL_MS,
+const feishuWebhookAnomalyTracker = createWebhookAnomalyTracker({
+  maxTrackedKeys: WEBHOOK_ANOMALY_COUNTER_DEFAULTS.maxTrackedKeys,
+  ttlMs: WEBHOOK_ANOMALY_COUNTER_DEFAULTS.ttlMs,
+  logEvery: WEBHOOK_ANOMALY_COUNTER_DEFAULTS.logEvery,
 });
-
-function isJsonContentType(value: string | string[] | undefined): boolean {
-  const first = Array.isArray(value) ? value[0] : value;
-  if (!first) {
-    return false;
-  }
-  const mediaType = first.split(";", 1)[0]?.trim().toLowerCase();
-  return mediaType === "application/json" || Boolean(mediaType?.endsWith("+json"));
-}
 
 export function clearFeishuWebhookRateLimitStateForTest(): void {
   feishuWebhookRateLimiter.clear();
-  feishuWebhookStatusCounters.clear();
+  feishuWebhookAnomalyTracker.clear();
 }
 
 export function getFeishuWebhookRateLimitStateSizeForTest(): number {
@@ -91,25 +80,19 @@ export function isWebhookRateLimitedForTest(key: string, nowMs: number): boolean
   return feishuWebhookRateLimiter.isRateLimited(key, nowMs);
 }
 
-function isWebhookRateLimited(key: string, nowMs: number): boolean {
-  return isWebhookRateLimitedForTest(key, nowMs);
-}
-
 function recordWebhookStatus(
   runtime: RuntimeEnv | undefined,
   accountId: string,
   path: string,
   statusCode: number,
 ): void {
-  if (![400, 401, 408, 413, 415, 429].includes(statusCode)) {
-    return;
-  }
-  const key = `${accountId}:${path}:${statusCode}`;
-  const next = feishuWebhookStatusCounters.increment(key);
-  if (next === 1 || next % FEISHU_WEBHOOK_COUNTER_LOG_EVERY === 0) {
-    const log = runtime?.log ?? console.log;
-    log(`feishu[${accountId}]: webhook anomaly path=${path} status=${statusCode} count=${next}`);
-  }
+  feishuWebhookAnomalyTracker.record({
+    key: `${accountId}:${path}:${statusCode}`,
+    statusCode,
+    log: runtime?.log ?? console.log,
+    message: (count) =>
+      `feishu[${accountId}]: webhook anomaly path=${path} status=${statusCode} count=${count}`,
+  });
 }
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | null> {
@@ -462,15 +445,16 @@ async function monitorWebhook({
     });
 
     const rateLimitKey = `${accountId}:${path}:${req.socket.remoteAddress ?? "unknown"}`;
-    if (isWebhookRateLimited(rateLimitKey, Date.now())) {
-      res.statusCode = 429;
-      res.end("Too Many Requests");
-      return;
-    }
-
-    if (req.method === "POST" && !isJsonContentType(req.headers["content-type"])) {
-      res.statusCode = 415;
-      res.end("Unsupported Media Type");
+    if (
+      !applyBasicWebhookRequestGuards({
+        req,
+        res,
+        rateLimiter: feishuWebhookRateLimiter,
+        rateLimitKey,
+        nowMs: Date.now(),
+        requireJsonContentType: true,
+      })
+    ) {
       return;
     }
 

--- a/extensions/nostr/src/nostr-profile-http.ts
+++ b/extensions/nostr/src/nostr-profile-http.ts
@@ -9,6 +9,7 @@
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
+  createFixedWindowRateLimiter,
   isBlockedHostnameOrIp,
   readJsonBodyWithLimit,
   requestBodyErrorToText,
@@ -41,30 +42,29 @@ export interface NostrProfileHttpContext {
 // Rate Limiting
 // ============================================================================
 
-interface RateLimitEntry {
-  count: number;
-  windowStart: number;
-}
-
-const rateLimitMap = new Map<string, RateLimitEntry>();
 const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
 const RATE_LIMIT_MAX_REQUESTS = 5; // 5 requests per minute
+const RATE_LIMIT_MAX_TRACKED_KEYS = 2_048;
+const profileRateLimiter = createFixedWindowRateLimiter({
+  windowMs: RATE_LIMIT_WINDOW_MS,
+  maxRequests: RATE_LIMIT_MAX_REQUESTS,
+  maxTrackedKeys: RATE_LIMIT_MAX_TRACKED_KEYS,
+});
+
+export function clearNostrProfileRateLimitStateForTest(): void {
+  profileRateLimiter.clear();
+}
+
+export function getNostrProfileRateLimitStateSizeForTest(): number {
+  return profileRateLimiter.size();
+}
+
+export function isNostrProfileRateLimitedForTest(accountId: string, nowMs: number): boolean {
+  return profileRateLimiter.isRateLimited(accountId, nowMs);
+}
 
 function checkRateLimit(accountId: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitMap.get(accountId);
-
-  if (!entry || now - entry.windowStart > RATE_LIMIT_WINDOW_MS) {
-    rateLimitMap.set(accountId, { count: 1, windowStart: now });
-    return true;
-  }
-
-  if (entry.count >= RATE_LIMIT_MAX_REQUESTS) {
-    return false;
-  }
-
-  entry.count++;
-  return true;
+  return !profileRateLimiter.isRateLimited(accountId);
 }
 
 // ============================================================================

--- a/extensions/synology-chat/src/channel.integration.test.ts
+++ b/extensions/synology-chat/src/channel.integration.test.ts
@@ -11,12 +11,16 @@ type RegisteredRoute = {
 const registerPluginHttpRouteMock = vi.fn<(params: RegisteredRoute) => () => void>(() => vi.fn());
 const dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockResolvedValue({ counts: {} });
 
-vi.mock("remoteclaw/plugin-sdk", () => ({
-  DEFAULT_ACCOUNT_ID: "default",
-  setAccountEnabledInConfigSection: vi.fn((_opts: any) => ({})),
-  registerPluginHttpRoute: registerPluginHttpRouteMock,
-  buildChannelConfigSchema: vi.fn((schema: any) => ({ schema })),
-}));
+vi.mock("remoteclaw/plugin-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("remoteclaw/plugin-sdk")>();
+  return {
+    ...actual,
+    DEFAULT_ACCOUNT_ID: "default",
+    setAccountEnabledInConfigSection: vi.fn((_opts: any) => ({})),
+    registerPluginHttpRoute: registerPluginHttpRouteMock,
+    buildChannelConfigSchema: vi.fn((schema: any) => ({ schema })),
+  };
+});
 
 vi.mock("./runtime.js", () => ({
   getSynologyRuntime: vi.fn(() => ({

--- a/extensions/synology-chat/src/security.test.ts
+++ b/extensions/synology-chat/src/security.test.ts
@@ -134,4 +134,13 @@ describe("RateLimiter", () => {
     // user2 should still be allowed
     expect(limiter.check("user2")).toBe(true);
   });
+
+  it("caps tracked users to prevent unbounded growth", () => {
+    const limiter = new RateLimiter(1, 60, 3);
+    expect(limiter.check("user1")).toBe(true);
+    expect(limiter.check("user2")).toBe(true);
+    expect(limiter.check("user3")).toBe(true);
+    expect(limiter.check("user4")).toBe(true);
+    expect(limiter.size()).toBeLessThanOrEqual(3);
+  });
 });

--- a/extensions/synology-chat/src/security.ts
+++ b/extensions/synology-chat/src/security.ts
@@ -3,6 +3,7 @@
  */
 
 import * as crypto from "node:crypto";
+import { createFixedWindowRateLimiter, type FixedWindowRateLimiter } from "remoteclaw/plugin-sdk";
 
 export type DmAuthorizationResult =
   | { allowed: true }
@@ -86,55 +87,35 @@ export function sanitizeInput(text: string): string {
  * Sliding window rate limiter per user ID.
  */
 export class RateLimiter {
-  private requests: Map<string, number[]> = new Map();
-  private limit: number;
-  private windowMs: number;
-  private lastCleanup = 0;
-  private cleanupIntervalMs: number;
+  private readonly limiter: FixedWindowRateLimiter;
+  private readonly limit: number;
 
-  constructor(limit = 30, windowSeconds = 60) {
+  constructor(limit = 30, windowSeconds = 60, maxTrackedUsers = 5_000) {
     this.limit = limit;
-    this.windowMs = windowSeconds * 1000;
-    this.cleanupIntervalMs = this.windowMs * 5; // cleanup every 5 windows
+    this.limiter = createFixedWindowRateLimiter({
+      windowMs: Math.max(1, Math.floor(windowSeconds * 1000)),
+      maxRequests: Math.max(1, Math.floor(limit)),
+      maxTrackedKeys: Math.max(1, Math.floor(maxTrackedUsers)),
+    });
   }
 
   /** Returns true if the request is allowed, false if rate-limited. */
   check(userId: string): boolean {
-    const now = Date.now();
-    const windowStart = now - this.windowMs;
-
-    // Periodic cleanup of stale entries to prevent memory leak
-    if (now - this.lastCleanup > this.cleanupIntervalMs) {
-      this.cleanup(windowStart);
-      this.lastCleanup = now;
-    }
-
-    let timestamps = this.requests.get(userId);
-    if (timestamps) {
-      timestamps = timestamps.filter((ts) => ts > windowStart);
-    } else {
-      timestamps = [];
-    }
-
-    if (timestamps.length >= this.limit) {
-      this.requests.set(userId, timestamps);
-      return false;
-    }
-
-    timestamps.push(now);
-    this.requests.set(userId, timestamps);
-    return true;
+    return !this.limiter.isRateLimited(userId);
   }
 
-  /** Remove entries with no recent activity. */
-  private cleanup(windowStart: number): void {
-    for (const [userId, timestamps] of this.requests) {
-      const active = timestamps.filter((ts) => ts > windowStart);
-      if (active.length === 0) {
-        this.requests.delete(userId);
-      } else {
-        this.requests.set(userId, active);
-      }
-    }
+  /** Exposed for tests and diagnostics. */
+  size(): number {
+    return this.limiter.size();
+  }
+
+  /** Exposed for tests and account lifecycle cleanup. */
+  clear(): void {
+    this.limiter.clear();
+  }
+
+  /** Exposed for tests. */
+  maxRequests(): number {
+    return this.limit;
   }
 }

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -2,7 +2,10 @@ import { EventEmitter } from "node:events";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ResolvedSynologyChatAccount } from "./types.js";
-import { createWebhookHandler } from "./webhook-handler.js";
+import {
+  clearSynologyWebhookRateLimiterStateForTest,
+  createWebhookHandler,
+} from "./webhook-handler.js";
 
 // Mock sendMessage to prevent real HTTP calls
 vi.mock("./client.js", () => ({
@@ -73,6 +76,7 @@ describe("createWebhookHandler", () => {
   let log: { info: any; warn: any; error: any };
 
   beforeEach(() => {
+    clearSynologyWebhookRateLimiterStateForTest();
     log = {
       info: vi.fn(),
       warn: vi.fn(),

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -14,11 +14,23 @@ const rateLimiters = new Map<string, RateLimiter>();
 
 function getRateLimiter(account: ResolvedSynologyChatAccount): RateLimiter {
   let rl = rateLimiters.get(account.accountId);
-  if (!rl) {
+  if (!rl || rl.maxRequests() !== account.rateLimitPerMinute) {
+    rl?.clear();
     rl = new RateLimiter(account.rateLimitPerMinute);
     rateLimiters.set(account.accountId, rl);
   }
   return rl;
+}
+
+export function clearSynologyWebhookRateLimiterStateForTest(): void {
+  for (const limiter of rateLimiters.values()) {
+    limiter.clear();
+  }
+  rateLimiters.clear();
+}
+
+export function getSynologyWebhookRateLimiterCountForTest(): number {
+  return rateLimiters.size;
 }
 
 /** Read the full request body as a string. */

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -32,6 +32,9 @@ import {
   resolveZaloRuntimeGroupPolicy,
 } from "./group-access.js";
 import {
+  clearZaloWebhookSecurityStateForTest,
+  getZaloWebhookRateLimitStateSizeForTest,
+  getZaloWebhookStatusCounterSizeForTest,
   handleZaloWebhookRequest as handleZaloWebhookRequestInternal,
   registerZaloWebhookTarget as registerZaloWebhookTargetInternal,
   type ZaloWebhookTarget,
@@ -76,6 +79,12 @@ function logVerbose(core: ZaloCoreRuntime, runtime: ZaloRuntimeEnv, message: str
 export function registerZaloWebhookTarget(target: ZaloWebhookTarget): () => void {
   return registerZaloWebhookTargetInternal(target);
 }
+
+export {
+  clearZaloWebhookSecurityStateForTest,
+  getZaloWebhookRateLimitStateSizeForTest,
+  getZaloWebhookStatusCounterSizeForTest,
+};
 
 export async function handleZaloWebhookRequest(
   req: IncomingMessage,

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -1,8 +1,14 @@
 import { createServer, type RequestListener } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { RemoteClawConfig, PluginRuntime } from "remoteclaw/plugin-sdk";
-import { describe, expect, it, vi } from "vitest";
-import { handleZaloWebhookRequest, registerZaloWebhookTarget } from "./monitor.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearZaloWebhookSecurityStateForTest,
+  getZaloWebhookRateLimitStateSizeForTest,
+  getZaloWebhookStatusCounterSizeForTest,
+  handleZaloWebhookRequest,
+  registerZaloWebhookTarget,
+} from "./monitor.js";
 import type { ResolvedZaloAccount } from "./types.js";
 
 async function withServer(handler: RequestListener, fn: (baseUrl: string) => Promise<void>) {
@@ -56,6 +62,10 @@ function registerTarget(params: {
 }
 
 describe("handleZaloWebhookRequest", () => {
+  afterEach(() => {
+    clearZaloWebhookSecurityStateForTest();
+  });
+
   it("returns 400 for non-object payloads", async () => {
     const unregister = registerTarget({ path: "/hook" });
 
@@ -191,6 +201,59 @@ describe("handleZaloWebhookRequest", () => {
         }
 
         expect(saw429).toBe(true);
+      });
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does not grow status counters when query strings churn on unauthorized requests", async () => {
+    const unregister = registerTarget({ path: "/hook-query-status" });
+
+    try {
+      await withServer(webhookRequestHandler, async (baseUrl) => {
+        for (let i = 0; i < 200; i += 1) {
+          const response = await fetch(`${baseUrl}/hook-query-status?nonce=${i}`, {
+            method: "POST",
+            headers: {
+              "x-bot-api-secret-token": "invalid-token",
+              "content-type": "application/json",
+            },
+            body: "{}",
+          });
+          expect(response.status).toBe(401);
+        }
+
+        expect(getZaloWebhookStatusCounterSizeForTest()).toBe(1);
+      });
+    } finally {
+      unregister();
+    }
+  });
+
+  it("rate limits authenticated requests even when query strings churn", async () => {
+    const unregister = registerTarget({ path: "/hook-query-rate" });
+
+    try {
+      await withServer(webhookRequestHandler, async (baseUrl) => {
+        let saw429 = false;
+        for (let i = 0; i < 130; i += 1) {
+          const response = await fetch(`${baseUrl}/hook-query-rate?nonce=${i}`, {
+            method: "POST",
+            headers: {
+              "x-bot-api-secret-token": "secret",
+              "content-type": "application/json",
+            },
+            body: "{}",
+          });
+          if (response.status === 429) {
+            saw429 = true;
+            break;
+          }
+        }
+
+        expect(saw429).toBe(true);
+        expect(getZaloWebhookRateLimitStateSizeForTest()).toBe(1);
       });
     } finally {
       unregister();

--- a/extensions/zalo/src/monitor.webhook.ts
+++ b/extensions/zalo/src/monitor.webhook.ts
@@ -2,7 +2,9 @@ import { timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { RemoteClawConfig } from "remoteclaw/plugin-sdk";
 import {
+  createBoundedCounter,
   createDedupeCache,
+  createFixedWindowRateLimiter,
   readJsonBodyWithLimit,
   registerWebhookTarget,
   rejectNonPostWebhookRequest,
@@ -14,12 +16,13 @@ import type { ResolvedZaloAccount } from "./accounts.js";
 import type { ZaloFetch, ZaloUpdate } from "./api.js";
 import type { ZaloRuntimeEnv } from "./monitor.js";
 
-type WebhookRateLimitState = { count: number; windowStartMs: number };
-
 const ZALO_WEBHOOK_RATE_LIMIT_WINDOW_MS = 60_000;
 const ZALO_WEBHOOK_RATE_LIMIT_MAX_REQUESTS = 120;
+const ZALO_WEBHOOK_RATE_LIMIT_MAX_TRACKED_KEYS = 4_096;
 const ZALO_WEBHOOK_REPLAY_WINDOW_MS = 5 * 60_000;
 const ZALO_WEBHOOK_COUNTER_LOG_EVERY = 25;
+const ZALO_WEBHOOK_COUNTER_MAX_TRACKED_KEYS = 4_096;
+const ZALO_WEBHOOK_COUNTER_TTL_MS = 6 * 60 * 60_000;
 
 export type ZaloWebhookTarget = {
   token: string;
@@ -40,12 +43,32 @@ export type ZaloWebhookProcessUpdate = (params: {
 }) => Promise<void>;
 
 const webhookTargets = new Map<string, ZaloWebhookTarget[]>();
-const webhookRateLimits = new Map<string, WebhookRateLimitState>();
+const webhookRateLimiter = createFixedWindowRateLimiter({
+  windowMs: ZALO_WEBHOOK_RATE_LIMIT_WINDOW_MS,
+  maxRequests: ZALO_WEBHOOK_RATE_LIMIT_MAX_REQUESTS,
+  maxTrackedKeys: ZALO_WEBHOOK_RATE_LIMIT_MAX_TRACKED_KEYS,
+});
 const recentWebhookEvents = createDedupeCache({
   ttlMs: ZALO_WEBHOOK_REPLAY_WINDOW_MS,
   maxSize: 5000,
 });
-const webhookStatusCounters = new Map<string, number>();
+const webhookStatusCounters = createBoundedCounter({
+  maxTrackedKeys: ZALO_WEBHOOK_COUNTER_MAX_TRACKED_KEYS,
+  ttlMs: ZALO_WEBHOOK_COUNTER_TTL_MS,
+});
+
+export function clearZaloWebhookSecurityStateForTest(): void {
+  webhookRateLimiter.clear();
+  webhookStatusCounters.clear();
+}
+
+export function getZaloWebhookRateLimitStateSizeForTest(): number {
+  return webhookRateLimiter.size();
+}
+
+export function getZaloWebhookStatusCounterSizeForTest(): number {
+  return webhookStatusCounters.size();
+}
 
 function isJsonContentType(value: string | string[] | undefined): boolean {
   const first = Array.isArray(value) ? value[0] : value;
@@ -73,20 +96,6 @@ function timingSafeEquals(left: string, right: string): boolean {
   return timingSafeEqual(leftBuffer, rightBuffer);
 }
 
-function isWebhookRateLimited(key: string, nowMs: number): boolean {
-  const state = webhookRateLimits.get(key);
-  if (!state || nowMs - state.windowStartMs >= ZALO_WEBHOOK_RATE_LIMIT_WINDOW_MS) {
-    webhookRateLimits.set(key, { count: 1, windowStartMs: nowMs });
-    return false;
-  }
-
-  state.count += 1;
-  if (state.count > ZALO_WEBHOOK_RATE_LIMIT_MAX_REQUESTS) {
-    return true;
-  }
-  return false;
-}
-
 function isReplayEvent(update: ZaloUpdate, nowMs: number): boolean {
   const messageId = update.message?.message_id;
   if (!messageId) {
@@ -105,8 +114,7 @@ function recordWebhookStatus(
     return;
   }
   const key = `${path}:${statusCode}`;
-  const next = (webhookStatusCounters.get(key) ?? 0) + 1;
-  webhookStatusCounters.set(key, next);
+  const next = webhookStatusCounters.increment(key);
   if (next === 1 || next % ZALO_WEBHOOK_COUNTER_LOG_EVERY === 0) {
     runtime?.log?.(
       `[zalo] webhook anomaly path=${path} status=${statusCode} count=${String(next)}`,
@@ -127,7 +135,7 @@ export async function handleZaloWebhookRequest(
   if (!resolved) {
     return false;
   }
-  const { targets } = resolved;
+  const { targets, path } = resolved;
 
   if (rejectNonPostWebhookRequest(req, res)) {
     return true;
@@ -140,21 +148,20 @@ export async function handleZaloWebhookRequest(
   if (matchedTarget.kind === "none") {
     res.statusCode = 401;
     res.end("unauthorized");
-    recordWebhookStatus(targets[0]?.runtime, req.url ?? "<unknown>", res.statusCode);
+    recordWebhookStatus(targets[0]?.runtime, path, res.statusCode);
     return true;
   }
   if (matchedTarget.kind === "ambiguous") {
     res.statusCode = 401;
     res.end("ambiguous webhook target");
-    recordWebhookStatus(targets[0]?.runtime, req.url ?? "<unknown>", res.statusCode);
+    recordWebhookStatus(targets[0]?.runtime, path, res.statusCode);
     return true;
   }
   const target = matchedTarget.target;
-  const path = req.url ?? "<unknown>";
   const rateLimitKey = `${path}:${req.socket.remoteAddress ?? "unknown"}`;
   const nowMs = Date.now();
 
-  if (isWebhookRateLimited(rateLimitKey, nowMs)) {
+  if (webhookRateLimiter.isRateLimited(rateLimitKey, nowMs)) {
     res.statusCode = 429;
     res.end("Too Many Requests");
     recordWebhookStatus(target.runtime, path, res.statusCode);

--- a/extensions/zalo/src/monitor.webhook.ts
+++ b/extensions/zalo/src/monitor.webhook.ts
@@ -2,27 +2,22 @@ import { timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { RemoteClawConfig } from "remoteclaw/plugin-sdk";
 import {
-  createBoundedCounter,
   createDedupeCache,
   createFixedWindowRateLimiter,
-  readJsonBodyWithLimit,
+  createWebhookAnomalyTracker,
+  readJsonWebhookBodyOrReject,
+  applyBasicWebhookRequestGuards,
   registerWebhookTarget,
-  rejectNonPostWebhookRequest,
-  requestBodyErrorToText,
   resolveSingleWebhookTarget,
   resolveWebhookTargets,
+  WEBHOOK_ANOMALY_COUNTER_DEFAULTS,
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
 } from "remoteclaw/plugin-sdk";
 import type { ResolvedZaloAccount } from "./accounts.js";
 import type { ZaloFetch, ZaloUpdate } from "./api.js";
 import type { ZaloRuntimeEnv } from "./monitor.js";
 
-const ZALO_WEBHOOK_RATE_LIMIT_WINDOW_MS = 60_000;
-const ZALO_WEBHOOK_RATE_LIMIT_MAX_REQUESTS = 120;
-const ZALO_WEBHOOK_RATE_LIMIT_MAX_TRACKED_KEYS = 4_096;
 const ZALO_WEBHOOK_REPLAY_WINDOW_MS = 5 * 60_000;
-const ZALO_WEBHOOK_COUNTER_LOG_EVERY = 25;
-const ZALO_WEBHOOK_COUNTER_MAX_TRACKED_KEYS = 4_096;
-const ZALO_WEBHOOK_COUNTER_TTL_MS = 6 * 60 * 60_000;
 
 export type ZaloWebhookTarget = {
   token: string;
@@ -44,22 +39,23 @@ export type ZaloWebhookProcessUpdate = (params: {
 
 const webhookTargets = new Map<string, ZaloWebhookTarget[]>();
 const webhookRateLimiter = createFixedWindowRateLimiter({
-  windowMs: ZALO_WEBHOOK_RATE_LIMIT_WINDOW_MS,
-  maxRequests: ZALO_WEBHOOK_RATE_LIMIT_MAX_REQUESTS,
-  maxTrackedKeys: ZALO_WEBHOOK_RATE_LIMIT_MAX_TRACKED_KEYS,
+  windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs,
+  maxRequests: WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests,
+  maxTrackedKeys: WEBHOOK_RATE_LIMIT_DEFAULTS.maxTrackedKeys,
 });
 const recentWebhookEvents = createDedupeCache({
   ttlMs: ZALO_WEBHOOK_REPLAY_WINDOW_MS,
   maxSize: 5000,
 });
-const webhookStatusCounters = createBoundedCounter({
-  maxTrackedKeys: ZALO_WEBHOOK_COUNTER_MAX_TRACKED_KEYS,
-  ttlMs: ZALO_WEBHOOK_COUNTER_TTL_MS,
+const webhookAnomalyTracker = createWebhookAnomalyTracker({
+  maxTrackedKeys: WEBHOOK_ANOMALY_COUNTER_DEFAULTS.maxTrackedKeys,
+  ttlMs: WEBHOOK_ANOMALY_COUNTER_DEFAULTS.ttlMs,
+  logEvery: WEBHOOK_ANOMALY_COUNTER_DEFAULTS.logEvery,
 });
 
 export function clearZaloWebhookSecurityStateForTest(): void {
   webhookRateLimiter.clear();
-  webhookStatusCounters.clear();
+  webhookAnomalyTracker.clear();
 }
 
 export function getZaloWebhookRateLimitStateSizeForTest(): number {
@@ -67,16 +63,7 @@ export function getZaloWebhookRateLimitStateSizeForTest(): number {
 }
 
 export function getZaloWebhookStatusCounterSizeForTest(): number {
-  return webhookStatusCounters.size();
-}
-
-function isJsonContentType(value: string | string[] | undefined): boolean {
-  const first = Array.isArray(value) ? value[0] : value;
-  if (!first) {
-    return false;
-  }
-  const mediaType = first.split(";", 1)[0]?.trim().toLowerCase();
-  return mediaType === "application/json" || Boolean(mediaType?.endsWith("+json"));
+  return webhookAnomalyTracker.size();
 }
 
 function timingSafeEquals(left: string, right: string): boolean {
@@ -110,16 +97,13 @@ function recordWebhookStatus(
   path: string,
   statusCode: number,
 ): void {
-  if (![400, 401, 408, 413, 415, 429].includes(statusCode)) {
-    return;
-  }
-  const key = `${path}:${statusCode}`;
-  const next = webhookStatusCounters.increment(key);
-  if (next === 1 || next % ZALO_WEBHOOK_COUNTER_LOG_EVERY === 0) {
-    runtime?.log?.(
-      `[zalo] webhook anomaly path=${path} status=${statusCode} count=${String(next)}`,
-    );
-  }
+  webhookAnomalyTracker.record({
+    key: `${path}:${statusCode}`,
+    statusCode,
+    log: runtime?.log,
+    message: (count) =>
+      `[zalo] webhook anomaly path=${path} status=${statusCode} count=${String(count)}`,
+  });
 }
 
 export function registerZaloWebhookTarget(target: ZaloWebhookTarget): () => void {
@@ -137,7 +121,13 @@ export async function handleZaloWebhookRequest(
   }
   const { targets, path } = resolved;
 
-  if (rejectNonPostWebhookRequest(req, res)) {
+  if (
+    !applyBasicWebhookRequestGuards({
+      req,
+      res,
+      allowMethods: ["POST"],
+    })
+  ) {
     return true;
   }
 
@@ -161,41 +151,34 @@ export async function handleZaloWebhookRequest(
   const rateLimitKey = `${path}:${req.socket.remoteAddress ?? "unknown"}`;
   const nowMs = Date.now();
 
-  if (webhookRateLimiter.isRateLimited(rateLimitKey, nowMs)) {
-    res.statusCode = 429;
-    res.end("Too Many Requests");
+  if (
+    !applyBasicWebhookRequestGuards({
+      req,
+      res,
+      rateLimiter: webhookRateLimiter,
+      rateLimitKey,
+      nowMs,
+      requireJsonContentType: true,
+    })
+  ) {
     recordWebhookStatus(target.runtime, path, res.statusCode);
     return true;
   }
-
-  if (!isJsonContentType(req.headers["content-type"])) {
-    res.statusCode = 415;
-    res.end("Unsupported Media Type");
-    recordWebhookStatus(target.runtime, path, res.statusCode);
-    return true;
-  }
-
-  const body = await readJsonBodyWithLimit(req, {
+  const body = await readJsonWebhookBodyOrReject({
+    req,
+    res,
     maxBytes: 1024 * 1024,
     timeoutMs: 30_000,
     emptyObjectOnEmpty: false,
+    invalidJsonMessage: "Bad Request",
   });
   if (!body.ok) {
-    res.statusCode =
-      body.code === "PAYLOAD_TOO_LARGE" ? 413 : body.code === "REQUEST_BODY_TIMEOUT" ? 408 : 400;
-    const message =
-      body.code === "PAYLOAD_TOO_LARGE"
-        ? requestBodyErrorToText("PAYLOAD_TOO_LARGE")
-        : body.code === "REQUEST_BODY_TIMEOUT"
-          ? requestBodyErrorToText("REQUEST_BODY_TIMEOUT")
-          : "Bad Request";
-    res.end(message);
     recordWebhookStatus(target.runtime, path, res.statusCode);
     return true;
   }
+  const raw = body.value;
 
   // Zalo sends updates directly as { event_name, message, ... }, not wrapped in { ok, result }.
-  const raw = body.value;
   const record = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : null;
   const update: ZaloUpdate | undefined =
     record && record.ok === true && record.result

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
 import { onAgentEvent } from "../../infra/agent-events.js";
-import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
+import { resetSystemEventsForTest } from "../../infra/system-events.js";
 import type {
   AgentDeliveryResult,
   BridgeCallbacks,
@@ -395,84 +395,6 @@ describe("runReplyAgent token update", () => {
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
     expect(stored[sessionKey].inputTokens).toBe(75_000);
     expect(stored[sessionKey].outputTokens).toBe(5_000);
-  });
-
-  it("does not enqueue legacy post-compaction audit warnings", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-no-audit-warning-"));
-    const workspaceDir = path.join(tmp, "workspace");
-    await fs.mkdir(workspaceDir, { recursive: true });
-    const sessionFile = path.join(tmp, "session.jsonl");
-    await fs.writeFile(
-      sessionFile,
-      `${JSON.stringify({ type: "message", message: { role: "assistant", content: [] } })}\n`,
-      "utf-8",
-    );
-
-    const storePath = path.join(tmp, "sessions.json");
-    const sessionKey = "main";
-    const sessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 10_000,
-      compactionCount: 0,
-    };
-
-    await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
-
-    runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
-      params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
-      params.onAgentEvent?.({ stream: "compaction", data: { phase: "end", willRetry: false } });
-      return {
-        payloads: [{ text: "done" }],
-        meta: {
-          agentMeta: {
-            usage: { input: 11_000, output: 500, total: 11_500 },
-            lastCallUsage: { input: 10_500, output: 500, total: 11_000 },
-            compactionCount: 1,
-          },
-        },
-      };
-    });
-
-    const config = {
-      agents: { defaults: { compaction: { memoryFlush: { enabled: false } } } },
-    };
-    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
-      storePath,
-      sessionEntry,
-      config,
-      sessionFile,
-      workspaceDir,
-    });
-
-    await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: "main",
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      isStreaming: false,
-      typing,
-      sessionCtx,
-      sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
-      storePath,
-      defaultModel: "anthropic/claude-opus-4-5",
-      agentCfgContextTokens: 200_000,
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
-
-    const queuedSystemEvents = peekSystemEvents(sessionKey);
-    expect(queuedSystemEvents.some((event) => event.includes("Post-Compaction Audit"))).toBe(false);
-    expect(queuedSystemEvents.some((event) => event.includes("WORKFLOW_AUTO.md"))).toBe(false);
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
 import { onAgentEvent } from "../../infra/agent-events.js";
+import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
 import type {
   AgentDeliveryResult,
   BridgeCallbacks,
@@ -124,6 +125,7 @@ beforeEach(() => {
   channelBridgeHandleMock.mockClear();
   runWithModelFallbackMock.mockClear();
   runtimeErrorMock.mockClear();
+  resetSystemEventsForTest();
 
   // Default: no provider switch; execute the chosen provider+model.
   runWithModelFallbackMock.mockImplementation(
@@ -137,6 +139,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  resetSystemEventsForTest();
 });
 
 describe("runReplyAgent onAgentRunStart", () => {
@@ -253,6 +256,8 @@ describe("runReplyAgent token update", () => {
     storePath: string;
     sessionEntry: Record<string, unknown>;
     config?: Record<string, unknown>;
+    sessionFile?: string;
+    workspaceDir?: string;
   }) {
     const typing = createMockTypingController();
     const sessionCtx = {
@@ -272,8 +277,8 @@ describe("runReplyAgent token update", () => {
         sessionId: "session",
         sessionKey: "main",
         messageProvider: "whatsapp",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
+        sessionFile: params.sessionFile ?? "/tmp/session.jsonl",
+        workspaceDir: params.workspaceDir ?? "/tmp",
         config: params.config ?? { agents: { defaults: { runtime: "claude" } } },
         provider: "anthropic",
         model: "claude",
@@ -390,6 +395,84 @@ describe("runReplyAgent token update", () => {
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
     expect(stored[sessionKey].inputTokens).toBe(75_000);
     expect(stored[sessionKey].outputTokens).toBe(5_000);
+  });
+
+  it("does not enqueue legacy post-compaction audit warnings", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-no-audit-warning-"));
+    const workspaceDir = path.join(tmp, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    const sessionFile = path.join(tmp, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ type: "message", message: { role: "assistant", content: [] } })}\n`,
+      "utf-8",
+    );
+
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 10_000,
+      compactionCount: 0,
+    };
+
+    await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+    runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
+      params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
+      params.onAgentEvent?.({ stream: "compaction", data: { phase: "end", willRetry: false } });
+      return {
+        payloads: [{ text: "done" }],
+        meta: {
+          agentMeta: {
+            usage: { input: 11_000, output: 500, total: 11_500 },
+            lastCallUsage: { input: 10_500, output: 500, total: 11_000 },
+            compactionCount: 1,
+          },
+        },
+      };
+    });
+
+    const config = {
+      agents: { defaults: { compaction: { memoryFlush: { enabled: false } } } },
+    };
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath,
+      sessionEntry,
+      config,
+      sessionFile,
+      workspaceDir,
+    });
+
+    await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      storePath,
+      defaultModel: "anthropic/claude-opus-4-5",
+      agentCfgContextTokens: 200_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    const queuedSystemEvents = peekSystemEvents(sessionKey);
+    expect(queuedSystemEvents.some((event) => event.includes("Post-Compaction Audit"))).toBe(false);
+    expect(queuedSystemEvents.some((event) => event.includes("WORKFLOW_AUTO.md"))).toBe(false);
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -38,6 +38,7 @@ import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-repl
 import { resolveBlockStreamingCoalescing } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
+import { readPostCompactionContext } from "./post-compaction-context.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import { enqueueFollowupRun, type FollowupRun, type QueueSettings } from "./queue.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
@@ -661,6 +662,35 @@ export async function runReplyAgent(params: {
       }
     }
 
+    if (autoCompactionCompleted) {
+      const count = await incrementRunCompactionCount({
+        sessionEntry: activeSessionEntry,
+        sessionStore: activeSessionStore,
+        sessionKey,
+        storePath,
+        lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
+        contextTokensUsed,
+      });
+
+      // Inject post-compaction workspace context for the next agent turn
+      if (sessionKey) {
+        const workspaceDir = process.cwd();
+        readPostCompactionContext(workspaceDir)
+          .then((contextContent) => {
+            if (contextContent) {
+              enqueueSystemEvent(contextContent, { sessionKey });
+            }
+          })
+          .catch(() => {
+            // Silent failure — post-compaction context is best-effort
+          });
+      }
+
+      if (verboseEnabled) {
+        const suffix = typeof count === "number" ? ` (count ${count})` : "";
+        verboseNotices.push({ text: `🧹 Auto-compaction complete${suffix}.` });
+      }
+    }
     if (verboseNotices.length > 0) {
       finalPayloads = [...verboseNotices, ...finalPayloads];
     }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -38,7 +38,6 @@ import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-repl
 import { resolveBlockStreamingCoalescing } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
-import { readPostCompactionContext } from "./post-compaction-context.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import { enqueueFollowupRun, type FollowupRun, type QueueSettings } from "./queue.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
@@ -662,35 +661,6 @@ export async function runReplyAgent(params: {
       }
     }
 
-    if (autoCompactionCompleted) {
-      const count = await incrementRunCompactionCount({
-        sessionEntry: activeSessionEntry,
-        sessionStore: activeSessionStore,
-        sessionKey,
-        storePath,
-        lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
-        contextTokensUsed,
-      });
-
-      // Inject post-compaction workspace context for the next agent turn
-      if (sessionKey) {
-        const workspaceDir = process.cwd();
-        readPostCompactionContext(workspaceDir)
-          .then((contextContent) => {
-            if (contextContent) {
-              enqueueSystemEvent(contextContent, { sessionKey });
-            }
-          })
-          .catch(() => {
-            // Silent failure — post-compaction context is best-effort
-          });
-      }
-
-      if (verboseEnabled) {
-        const suffix = typeof count === "number" ? ` (count ${count})` : "";
-        verboseNotices.push({ text: `🧹 Auto-compaction complete${suffix}.` });
-      }
-    }
     if (verboseNotices.length > 0) {
       finalPayloads = [...verboseNotices, ...finalPayloads];
     }

--- a/src/auto-reply/reply/commands-session-abort.ts
+++ b/src/auto-reply/reply/commands-session-abort.ts
@@ -13,6 +13,7 @@ import {
   setAbortMemory,
   stopSubagentsForRequester,
 } from "./abort.js";
+import { rejectUnauthorizedCommand } from "./command-gates.js";
 import { persistAbortTargetEntry } from "./commands-session-store.js";
 import type { CommandHandler } from "./commands-types.js";
 import { clearSessionQueues } from "./queue.js";
@@ -87,11 +88,9 @@ export const handleStopCommand: CommandHandler = async (params, allowTextCommand
   if (params.command.commandBodyNormalized !== "/stop") {
     return null;
   }
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring /stop from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
+  const unauthorizedStop = rejectUnauthorizedCommand(params, "/stop");
+  if (unauthorizedStop) {
+    return unauthorizedStop;
   }
   const abortTarget = resolveAbortTarget({
     ctx: params.ctx,
@@ -145,6 +144,10 @@ export const handleAbortTrigger: CommandHandler = async (params, allowTextComman
   }
   if (!isAbortTrigger(params.command.rawBodyNormalized)) {
     return null;
+  }
+  const unauthorizedAbortTrigger = rejectUnauthorizedCommand(params, "abort trigger");
+  if (unauthorizedAbortTrigger) {
+    return unauthorizedAbortTrigger;
   }
   const abortTarget = resolveAbortTarget({
     ctx: params.ctx,

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -8,7 +8,7 @@ import {
   resetSubagentRegistryForTests,
 } from "../../agents/subagent-registry.js";
 import type { RemoteClawConfig } from "../../config/config.js";
-import { updateSessionStore } from "../../config/sessions.js";
+import { updateSessionStore, type SessionEntry } from "../../config/sessions.js";
 import * as internalHooks from "../../hooks/internal-hooks.js";
 import { clearPluginCommands, registerPluginCommand } from "../../plugins/commands.js";
 import { typedCases } from "../../test-utils/typed-cases.js";

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -1007,3 +1007,39 @@ describe("handleCommands /tts", () => {
     expect(result.reply?.text).toContain("TTS status");
   });
 });
+
+describe("abort trigger command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects unauthorized natural-language abort triggers", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as RemoteClawConfig;
+    const params = buildParams("stop", cfg);
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: Date.now(),
+      abortedLastRun: false,
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      [params.sessionKey]: sessionEntry,
+    };
+
+    const result = await handleCommands({
+      ...params,
+      sessionEntry,
+      sessionStore,
+      command: {
+        ...params.command,
+        isAuthorizedSender: false,
+        senderId: "unauthorized",
+      },
+    });
+
+    expect(result).toEqual({ shouldContinue: false });
+    expect(sessionStore[params.sessionKey]?.abortedLastRun).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -102,4 +102,20 @@ describe("stripInboundMetadata", () => {
 This is plain user text`;
     expect(stripInboundMetadata(input)).toBe(input);
   });
+
+  it("does not strip lookalike sentinel lines with extra text", () => {
+    const input = `Conversation info (untrusted metadata): please ignore
+\`\`\`json
+{"x": 1}
+\`\`\`
+Real user content`;
+    expect(stripInboundMetadata(input)).toBe(input);
+  });
+
+  it("does not strip sentinel text when json fence is missing", () => {
+    const input = `Sender (untrusted metadata):
+name: test
+Hello from user`;
+    expect(stripInboundMetadata(input)).toBe(input);
+  });
 });

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -266,6 +266,8 @@ export {
   readRequestBodyWithLimit,
   requestBodyErrorToText,
 } from "../infra/http-body.js";
+export { createBoundedCounter, createFixedWindowRateLimiter } from "./webhook-memory-guards.js";
+export type { BoundedCounter, FixedWindowRateLimiter } from "./webhook-memory-guards.js";
 
 export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 export {

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -103,6 +103,11 @@ export {
   resolveWebhookTargets,
 } from "./webhook-targets.js";
 export type { WebhookTargetMatchResult } from "./webhook-targets.js";
+export {
+  applyBasicWebhookRequestGuards,
+  isJsonContentType,
+  readJsonWebhookBodyOrReject,
+} from "./webhook-request-guards.js";
 export type { AgentMediaPayload } from "./agent-media-payload.js";
 export { buildAgentMediaPayload } from "./agent-media-payload.js";
 export {
@@ -266,8 +271,19 @@ export {
   readRequestBodyWithLimit,
   requestBodyErrorToText,
 } from "../infra/http-body.js";
-export { createBoundedCounter, createFixedWindowRateLimiter } from "./webhook-memory-guards.js";
-export type { BoundedCounter, FixedWindowRateLimiter } from "./webhook-memory-guards.js";
+export {
+  WEBHOOK_ANOMALY_COUNTER_DEFAULTS,
+  WEBHOOK_ANOMALY_STATUS_CODES,
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
+  createBoundedCounter,
+  createFixedWindowRateLimiter,
+  createWebhookAnomalyTracker,
+} from "./webhook-memory-guards.js";
+export type {
+  BoundedCounter,
+  FixedWindowRateLimiter,
+  WebhookAnomalyTracker,
+} from "./webhook-memory-guards.js";
 
 export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 export {

--- a/src/plugin-sdk/webhook-memory-guards.test.ts
+++ b/src/plugin-sdk/webhook-memory-guards.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { createBoundedCounter, createFixedWindowRateLimiter } from "./webhook-memory-guards.js";
+
+describe("createFixedWindowRateLimiter", () => {
+  it("enforces a fixed-window request limit", () => {
+    const limiter = createFixedWindowRateLimiter({
+      windowMs: 60_000,
+      maxRequests: 3,
+      maxTrackedKeys: 100,
+    });
+
+    expect(limiter.isRateLimited("k", 1_000)).toBe(false);
+    expect(limiter.isRateLimited("k", 1_001)).toBe(false);
+    expect(limiter.isRateLimited("k", 1_002)).toBe(false);
+    expect(limiter.isRateLimited("k", 1_003)).toBe(true);
+  });
+
+  it("resets counters after the window elapses", () => {
+    const limiter = createFixedWindowRateLimiter({
+      windowMs: 10,
+      maxRequests: 1,
+      maxTrackedKeys: 100,
+    });
+
+    expect(limiter.isRateLimited("k", 100)).toBe(false);
+    expect(limiter.isRateLimited("k", 101)).toBe(true);
+    expect(limiter.isRateLimited("k", 111)).toBe(false);
+  });
+
+  it("caps tracked keys", () => {
+    const limiter = createFixedWindowRateLimiter({
+      windowMs: 60_000,
+      maxRequests: 10,
+      maxTrackedKeys: 5,
+    });
+
+    for (let i = 0; i < 20; i += 1) {
+      limiter.isRateLimited(`key-${i}`, 1_000 + i);
+    }
+
+    expect(limiter.size()).toBeLessThanOrEqual(5);
+  });
+
+  it("prunes stale keys", () => {
+    const limiter = createFixedWindowRateLimiter({
+      windowMs: 10,
+      maxRequests: 10,
+      maxTrackedKeys: 100,
+      pruneIntervalMs: 10,
+    });
+
+    for (let i = 0; i < 20; i += 1) {
+      limiter.isRateLimited(`key-${i}`, 100);
+    }
+    expect(limiter.size()).toBe(20);
+
+    limiter.isRateLimited("fresh", 120);
+    expect(limiter.size()).toBe(1);
+  });
+});
+
+describe("createBoundedCounter", () => {
+  it("increments and returns per-key counts", () => {
+    const counter = createBoundedCounter({ maxTrackedKeys: 100 });
+
+    expect(counter.increment("k", 1_000)).toBe(1);
+    expect(counter.increment("k", 1_001)).toBe(2);
+    expect(counter.increment("k", 1_002)).toBe(3);
+  });
+
+  it("caps tracked keys", () => {
+    const counter = createBoundedCounter({ maxTrackedKeys: 3 });
+
+    for (let i = 0; i < 10; i += 1) {
+      counter.increment(`k-${i}`, 1_000 + i);
+    }
+
+    expect(counter.size()).toBeLessThanOrEqual(3);
+  });
+
+  it("expires stale keys when ttl is set", () => {
+    const counter = createBoundedCounter({
+      maxTrackedKeys: 100,
+      ttlMs: 10,
+      pruneIntervalMs: 10,
+    });
+
+    counter.increment("old-1", 100);
+    counter.increment("old-2", 100);
+    expect(counter.size()).toBe(2);
+
+    counter.increment("fresh", 120);
+    expect(counter.size()).toBe(1);
+  });
+});

--- a/src/plugin-sdk/webhook-memory-guards.ts
+++ b/src/plugin-sdk/webhook-memory-guards.ts
@@ -1,0 +1,136 @@
+import { pruneMapToMaxSize } from "../infra/map-size.js";
+
+type FixedWindowState = {
+  count: number;
+  windowStartMs: number;
+};
+
+type CounterState = {
+  count: number;
+  updatedAtMs: number;
+};
+
+export type FixedWindowRateLimiter = {
+  isRateLimited: (key: string, nowMs?: number) => boolean;
+  size: () => number;
+  clear: () => void;
+};
+
+export type BoundedCounter = {
+  increment: (key: string, nowMs?: number) => number;
+  size: () => number;
+  clear: () => void;
+};
+
+export function createFixedWindowRateLimiter(options: {
+  windowMs: number;
+  maxRequests: number;
+  maxTrackedKeys: number;
+  pruneIntervalMs?: number;
+}): FixedWindowRateLimiter {
+  const windowMs = Math.max(1, Math.floor(options.windowMs));
+  const maxRequests = Math.max(1, Math.floor(options.maxRequests));
+  const maxTrackedKeys = Math.max(1, Math.floor(options.maxTrackedKeys));
+  const pruneIntervalMs = Math.max(1, Math.floor(options.pruneIntervalMs ?? windowMs));
+  const state = new Map<string, FixedWindowState>();
+  let lastPruneMs = 0;
+
+  const touch = (key: string, value: FixedWindowState) => {
+    state.delete(key);
+    state.set(key, value);
+  };
+
+  const prune = (nowMs: number) => {
+    for (const [key, entry] of state) {
+      if (nowMs - entry.windowStartMs >= windowMs) {
+        state.delete(key);
+      }
+    }
+  };
+
+  return {
+    isRateLimited: (key: string, nowMs = Date.now()) => {
+      if (!key) {
+        return false;
+      }
+      if (nowMs - lastPruneMs >= pruneIntervalMs) {
+        prune(nowMs);
+        lastPruneMs = nowMs;
+      }
+
+      const existing = state.get(key);
+      if (!existing || nowMs - existing.windowStartMs >= windowMs) {
+        touch(key, { count: 1, windowStartMs: nowMs });
+        pruneMapToMaxSize(state, maxTrackedKeys);
+        return false;
+      }
+
+      const nextCount = existing.count + 1;
+      touch(key, { count: nextCount, windowStartMs: existing.windowStartMs });
+      pruneMapToMaxSize(state, maxTrackedKeys);
+      return nextCount > maxRequests;
+    },
+    size: () => state.size,
+    clear: () => {
+      state.clear();
+      lastPruneMs = 0;
+    },
+  };
+}
+
+export function createBoundedCounter(options: {
+  maxTrackedKeys: number;
+  ttlMs?: number;
+  pruneIntervalMs?: number;
+}): BoundedCounter {
+  const maxTrackedKeys = Math.max(1, Math.floor(options.maxTrackedKeys));
+  const ttlMs = Math.max(0, Math.floor(options.ttlMs ?? 0));
+  const pruneIntervalMs = Math.max(
+    1,
+    Math.floor(options.pruneIntervalMs ?? (ttlMs > 0 ? ttlMs : 60_000)),
+  );
+  const counters = new Map<string, CounterState>();
+  let lastPruneMs = 0;
+
+  const touch = (key: string, value: CounterState) => {
+    counters.delete(key);
+    counters.set(key, value);
+  };
+
+  const isExpired = (entry: CounterState, nowMs: number) =>
+    ttlMs > 0 && nowMs - entry.updatedAtMs >= ttlMs;
+
+  const prune = (nowMs: number) => {
+    if (ttlMs > 0) {
+      for (const [key, entry] of counters) {
+        if (isExpired(entry, nowMs)) {
+          counters.delete(key);
+        }
+      }
+    }
+  };
+
+  return {
+    increment: (key: string, nowMs = Date.now()) => {
+      if (!key) {
+        return 0;
+      }
+      if (nowMs - lastPruneMs >= pruneIntervalMs) {
+        prune(nowMs);
+        lastPruneMs = nowMs;
+      }
+
+      const existing = counters.get(key);
+      const baseCount = existing && !isExpired(existing, nowMs) ? existing.count : 0;
+      const nextCount = baseCount + 1;
+      touch(key, { count: nextCount, updatedAtMs: nowMs });
+      pruneMapToMaxSize(counters, maxTrackedKeys);
+      return nextCount;
+    },
+    size: () => counters.size,
+    clear: () => {
+      counters.clear();
+      lastPruneMs = 0;
+    },
+  };
+}

--- a/src/plugin-sdk/webhook-request-guards.test.ts
+++ b/src/plugin-sdk/webhook-request-guards.test.ts
@@ -1,0 +1,160 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage } from "node:http";
+import { describe, expect, it } from "vitest";
+import { createMockServerResponse } from "../test-utils/mock-http-response.js";
+import { createFixedWindowRateLimiter } from "./webhook-memory-guards.js";
+import {
+  applyBasicWebhookRequestGuards,
+  isJsonContentType,
+  readJsonWebhookBodyOrReject,
+} from "./webhook-request-guards.js";
+
+type MockIncomingMessage = IncomingMessage & {
+  destroyed?: boolean;
+  destroy: () => MockIncomingMessage;
+};
+
+function createMockRequest(params: {
+  method?: string;
+  headers?: Record<string, string>;
+  chunks?: string[];
+  emitEnd?: boolean;
+}): MockIncomingMessage {
+  const req = new EventEmitter() as MockIncomingMessage;
+  req.method = params.method ?? "POST";
+  req.headers = params.headers ?? {};
+  req.destroyed = false;
+  req.destroy = (() => {
+    req.destroyed = true;
+    return req;
+  }) as MockIncomingMessage["destroy"];
+
+  if (params.chunks) {
+    void Promise.resolve().then(() => {
+      for (const chunk of params.chunks ?? []) {
+        req.emit("data", Buffer.from(chunk, "utf-8"));
+      }
+      if (params.emitEnd !== false) {
+        req.emit("end");
+      }
+    });
+  }
+
+  return req;
+}
+
+describe("isJsonContentType", () => {
+  it("accepts application/json and +json suffixes", () => {
+    expect(isJsonContentType("application/json")).toBe(true);
+    expect(isJsonContentType("application/cloudevents+json; charset=utf-8")).toBe(true);
+  });
+
+  it("rejects non-json media types", () => {
+    expect(isJsonContentType("text/plain")).toBe(false);
+    expect(isJsonContentType(undefined)).toBe(false);
+  });
+});
+
+describe("applyBasicWebhookRequestGuards", () => {
+  it("rejects disallowed HTTP methods", () => {
+    const req = createMockRequest({ method: "GET" });
+    const res = createMockServerResponse();
+    const ok = applyBasicWebhookRequestGuards({
+      req,
+      res,
+      allowMethods: ["POST"],
+    });
+    expect(ok).toBe(false);
+    expect(res.statusCode).toBe(405);
+    expect(res.getHeader("allow")).toBe("POST");
+  });
+
+  it("enforces rate limits", () => {
+    const limiter = createFixedWindowRateLimiter({
+      windowMs: 60_000,
+      maxRequests: 1,
+      maxTrackedKeys: 10,
+    });
+    const req1 = createMockRequest({ method: "POST" });
+    const res1 = createMockServerResponse();
+    const req2 = createMockRequest({ method: "POST" });
+    const res2 = createMockServerResponse();
+    expect(
+      applyBasicWebhookRequestGuards({
+        req: req1,
+        res: res1,
+        rateLimiter: limiter,
+        rateLimitKey: "k",
+        nowMs: 1_000,
+      }),
+    ).toBe(true);
+    expect(
+      applyBasicWebhookRequestGuards({
+        req: req2,
+        res: res2,
+        rateLimiter: limiter,
+        rateLimitKey: "k",
+        nowMs: 1_001,
+      }),
+    ).toBe(false);
+    expect(res2.statusCode).toBe(429);
+  });
+
+  it("rejects non-json requests when required", () => {
+    const req = createMockRequest({
+      method: "POST",
+      headers: { "content-type": "text/plain" },
+    });
+    const res = createMockServerResponse();
+    const ok = applyBasicWebhookRequestGuards({
+      req,
+      res,
+      requireJsonContentType: true,
+    });
+    expect(ok).toBe(false);
+    expect(res.statusCode).toBe(415);
+  });
+});
+
+describe("readJsonWebhookBodyOrReject", () => {
+  it("returns parsed JSON body", async () => {
+    const req = createMockRequest({ chunks: ['{"ok":true}'] });
+    const res = createMockServerResponse();
+    await expect(
+      readJsonWebhookBodyOrReject({
+        req,
+        res,
+        maxBytes: 1024,
+        emptyObjectOnEmpty: false,
+      }),
+    ).resolves.toEqual({ ok: true, value: { ok: true } });
+  });
+
+  it("preserves valid JSON null payload", async () => {
+    const req = createMockRequest({ chunks: ["null"] });
+    const res = createMockServerResponse();
+    await expect(
+      readJsonWebhookBodyOrReject({
+        req,
+        res,
+        maxBytes: 1024,
+        emptyObjectOnEmpty: false,
+      }),
+    ).resolves.toEqual({ ok: true, value: null });
+  });
+
+  it("writes 400 on invalid JSON payload", async () => {
+    const req = createMockRequest({ chunks: ["{bad json"] });
+    const res = createMockServerResponse();
+    await expect(
+      readJsonWebhookBodyOrReject({
+        req,
+        res,
+        maxBytes: 1024,
+        emptyObjectOnEmpty: false,
+      }),
+    ).resolves.toEqual({ ok: false });
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toBe("Bad Request");
+  });
+});

--- a/src/plugin-sdk/webhook-request-guards.ts
+++ b/src/plugin-sdk/webhook-request-guards.ts
@@ -1,0 +1,81 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { readJsonBodyWithLimit, requestBodyErrorToText } from "../infra/http-body.js";
+import type { FixedWindowRateLimiter } from "./webhook-memory-guards.js";
+
+export function isJsonContentType(value: string | string[] | undefined): boolean {
+  const first = Array.isArray(value) ? value[0] : value;
+  if (!first) {
+    return false;
+  }
+  const mediaType = first.split(";", 1)[0]?.trim().toLowerCase();
+  return mediaType === "application/json" || Boolean(mediaType?.endsWith("+json"));
+}
+
+export function applyBasicWebhookRequestGuards(params: {
+  req: IncomingMessage;
+  res: ServerResponse;
+  allowMethods?: readonly string[];
+  rateLimiter?: FixedWindowRateLimiter;
+  rateLimitKey?: string;
+  nowMs?: number;
+  requireJsonContentType?: boolean;
+}): boolean {
+  const allowMethods = params.allowMethods?.length ? params.allowMethods : null;
+  if (allowMethods && !allowMethods.includes(params.req.method ?? "")) {
+    params.res.statusCode = 405;
+    params.res.setHeader("Allow", allowMethods.join(", "));
+    params.res.end("Method Not Allowed");
+    return false;
+  }
+
+  if (
+    params.rateLimiter &&
+    params.rateLimitKey &&
+    params.rateLimiter.isRateLimited(params.rateLimitKey, params.nowMs ?? Date.now())
+  ) {
+    params.res.statusCode = 429;
+    params.res.end("Too Many Requests");
+    return false;
+  }
+
+  if (
+    params.requireJsonContentType &&
+    params.req.method === "POST" &&
+    !isJsonContentType(params.req.headers["content-type"])
+  ) {
+    params.res.statusCode = 415;
+    params.res.end("Unsupported Media Type");
+    return false;
+  }
+
+  return true;
+}
+
+export async function readJsonWebhookBodyOrReject(params: {
+  req: IncomingMessage;
+  res: ServerResponse;
+  maxBytes: number;
+  timeoutMs?: number;
+  emptyObjectOnEmpty?: boolean;
+  invalidJsonMessage?: string;
+}): Promise<{ ok: true; value: unknown } | { ok: false }> {
+  const body = await readJsonBodyWithLimit(params.req, {
+    maxBytes: params.maxBytes,
+    timeoutMs: params.timeoutMs,
+    emptyObjectOnEmpty: params.emptyObjectOnEmpty,
+  });
+  if (body.ok) {
+    return { ok: true, value: body.value };
+  }
+
+  params.res.statusCode =
+    body.code === "PAYLOAD_TOO_LARGE" ? 413 : body.code === "REQUEST_BODY_TIMEOUT" ? 408 : 400;
+  const message =
+    body.code === "PAYLOAD_TOO_LARGE"
+      ? requestBodyErrorToText("PAYLOAD_TOO_LARGE")
+      : body.code === "REQUEST_BODY_TIMEOUT"
+        ? requestBodyErrorToText("REQUEST_BODY_TIMEOUT")
+        : (params.invalidJsonMessage ?? "Bad Request");
+  params.res.end(message);
+  return { ok: false };
+}

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -705,13 +705,13 @@ describe("security audit", () => {
   });
 
   it("flags wildcard Control UI origins by exposure level", async () => {
-    const loopbackCfg: OpenClawConfig = {
+    const loopbackCfg: RemoteClawConfig = {
       gateway: {
         bind: "loopback",
         controlUi: { allowedOrigins: ["*"] },
       },
     };
-    const exposedCfg: OpenClawConfig = {
+    const exposedCfg: RemoteClawConfig = {
       gateway: {
         bind: "lan",
         auth: { mode: "token", token: "very-long-browser-token-0123456789" },

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -704,6 +704,29 @@ describe("security audit", () => {
     expectFinding(res, "gateway.control_ui.allowed_origins_required", "critical");
   });
 
+  it("flags wildcard Control UI origins by exposure level", async () => {
+    const loopbackCfg: OpenClawConfig = {
+      gateway: {
+        bind: "loopback",
+        controlUi: { allowedOrigins: ["*"] },
+      },
+    };
+    const exposedCfg: OpenClawConfig = {
+      gateway: {
+        bind: "lan",
+        auth: { mode: "token", token: "very-long-browser-token-0123456789" },
+        controlUi: { allowedOrigins: ["*"] },
+      },
+    };
+
+    const loopback = await audit(loopbackCfg);
+    const exposed = await audit(exposedCfg);
+
+    expectFinding(loopback, "gateway.control_ui.allowed_origins_wildcard", "warn");
+    expectFinding(exposed, "gateway.control_ui.allowed_origins_wildcard", "critical");
+    expectNoFinding(exposed, "gateway.control_ui.allowed_origins_required");
+  });
+
   it("flags dangerous host-header origin fallback and suppresses missing allowed-origins finding", async () => {
     const cfg: RemoteClawConfig = {
       gateway: {
@@ -724,7 +747,7 @@ describe("security audit", () => {
     );
   });
 
-  it("warns when Feishu doc tool is enabled because create can grant requester access", async () => {
+  it("warns when Feishu doc tool is enabled because create supports owner_open_id", async () => {
     const cfg: RemoteClawConfig = {
       channels: {
         feishu: {
@@ -738,7 +761,7 @@ describe("security audit", () => {
     expectFinding(res, "channels.feishu.doc_owner_open_id", "warn");
   });
 
-  it("does not warn for Feishu doc grant risk when doc tools are disabled", async () => {
+  it("does not warn for Feishu owner_open_id when doc tools are disabled", async () => {
     const cfg: RemoteClawConfig = {
       channels: {
         feishu: {

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -398,6 +398,18 @@ function collectGatewayConfigFindings(
         "If your deployment intentionally relies on Host-header origin fallback, set gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback=true.",
     });
   }
+  if (controlUiAllowedOrigins.includes("*")) {
+    const exposed = bind !== "loopback";
+    findings.push({
+      checkId: "gateway.control_ui.allowed_origins_wildcard",
+      severity: exposed ? "critical" : "warn",
+      title: "Control UI allowed origins contains wildcard",
+      detail:
+        'gateway.controlUi.allowedOrigins includes "*" which effectively disables origin allowlisting for Control UI/WebChat requests.',
+      remediation:
+        "Replace wildcard origins with explicit trusted origins (for example https://control.example.com).",
+    });
+  }
   if (dangerouslyAllowHostHeaderOriginFallback) {
     const exposed = bind !== "loopback";
     findings.push({
@@ -488,11 +500,11 @@ function collectGatewayConfigFindings(
     findings.push({
       checkId: "channels.feishu.doc_owner_open_id",
       severity: "warn",
-      title: "Feishu doc create can grant requester permissions",
+      title: "Feishu doc create can grant owner permissions",
       detail:
-        'channels.feishu tools include "doc"; feishu_doc action "create" can grant document access to the trusted requesting Feishu user.',
+        'channels.feishu tools include "doc"; feishu_doc action "create" accepts owner_open_id and can grant document access to that user.',
       remediation:
-        "Disable channels.feishu.tools.doc when not needed, and restrict tool access for untrusted prompts.",
+        "Disable channels.feishu.tools.doc when not needed, and restrict tool access so untrusted prompts cannot set owner_open_id.",
     });
   }
 

--- a/src/security/external-content.ts
+++ b/src/security/external-content.ts
@@ -111,6 +111,20 @@ const ANGLE_BRACKET_MAP: Record<number, string> = {
   0x27e9: ">", // mathematical right angle bracket
   0xfe64: "<", // small less-than sign
   0xfe65: ">", // small greater-than sign
+  0x00ab: "<", // left-pointing double angle quotation mark
+  0x00bb: ">", // right-pointing double angle quotation mark
+  0x300a: "<", // left double angle bracket
+  0x300b: ">", // right double angle bracket
+  0x27ea: "<", // mathematical left double angle bracket
+  0x27eb: ">", // mathematical right double angle bracket
+  0x27ec: "<", // mathematical left white tortoise shell bracket
+  0x27ed: ">", // mathematical right white tortoise shell bracket
+  0x27ee: "<", // mathematical left flattened parenthesis
+  0x27ef: ">", // mathematical right flattened parenthesis
+  0x276c: "<", // medium left-pointing angle bracket ornament
+  0x276d: ">", // medium right-pointing angle bracket ornament
+  0x276e: "<", // heavy left-pointing angle quotation mark ornament
+  0x276f: ">", // heavy right-pointing angle quotation mark ornament
 };
 
 function foldMarkerChar(char: string): string {
@@ -130,7 +144,7 @@ function foldMarkerChar(char: string): string {
 
 function foldMarkerText(input: string): string {
   return input.replace(
-    /[\uFF21-\uFF3A\uFF41-\uFF5A\uFF1C\uFF1E\u2329\u232A\u3008\u3009\u2039\u203A\u27E8\u27E9\uFE64\uFE65]/g,
+    /[\uFF21-\uFF3A\uFF41-\uFF5A\uFF1C\uFF1E\u2329\u232A\u3008\u3009\u2039\u203A\u27E8\u27E9\uFE64\uFE65\u00AB\u00BB\u300A\u300B\u27EA\u27EB\u27EC\u27ED\u27EE\u27EF\u276C\u276D\u276E\u276F]/g,
     (char) => foldMarkerChar(char),
   );
 }

--- a/src/test-utils/mock-http-response.ts
+++ b/src/test-utils/mock-http-response.ts
@@ -7,6 +7,7 @@ export function createMockServerResponse(): ServerResponse & { body?: string } {
     statusCode: number;
     body?: string;
     setHeader: (key: string, value: string) => unknown;
+    getHeader: (key: string) => string | undefined;
     end: (body?: string) => unknown;
   } = {
     headersSent: false,
@@ -15,6 +16,7 @@ export function createMockServerResponse(): ServerResponse & { body?: string } {
       headers[key.toLowerCase()] = value;
       return res;
     },
+    getHeader: (key: string) => headers[key.toLowerCase()],
     end: (body?: string) => {
       res.headersSent = true;
       res.body = body;


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #686

Upstream security commits cherry-picked and adapted for fork rebrand.

### Commits picked (9)

| # | Upstream SHA | Title | Result |
|---|-------------|-------|--------|
| 1 | `a374325fc` | docs(security): clarify local link-priming reports as out-of-scope | RESOLVED (SECURITY.md `~/.remoteclaw` kept, new bullet added) |
| 2 | `b81e1b902` | Fixes minor security vulnerability (#30948) (#30951) | RESOLVED (CHANGELOG deleted, expanded bracket pairs in shared code, wrapWebContent tests dropped per fork removal) |
| 3 | `f8459ef46` | docs(security): document sessions_spawn sandbox=require hardening | RESOLVED (tools.elevated paragraph kept removed, new sub-agent guardrail section added) |
| 4 | `17bae9368` | fix(security): warn on wildcard control-ui origins and feishu owner grants | RESOLVED (deduplicated helper functions, kept fork's `RemoteClawConfig`, took upstream's improved `owner_open_id` finding text) |
| 5 | `70a4f25ab` | fix(security): remove post-compaction audit injection message | RESOLVED (post-compaction files already deleted in fork, import + dead compaction block removed) |
| 6 | `3a93a7bb1` | fix(security): enforce auth for abort triggers and models | RESOLVED (CHANGELOG + commands-models.ts deleted in fork, auth enforcement in abort commands applied, `/models` test skipped as gutted) |
| 7 | `b99666a47` | fix(security): harden inbound metadata sentinel stripping | PICKED (clean) |
| 8 | `43cad8268` | fix(security): harden webhook memory guards across channels | RESOLVED (CHANGELOG deleted, `openclaw/plugin-sdk` -> `remoteclaw/plugin-sdk`, `OpenClawConfig` -> `RemoteClawConfig`) |
| 9 | `3a68c5626` | refactor(security): unify webhook guardrails across channels | RESOLVED (import paths fixed to `remoteclaw/plugin-sdk`) |

### Adaptation commit

Fixes applied after cherry-picks: removed dead compaction block and import pulled in during commit 5 resolution, removed inapplicable post-compaction audit test, fixed 2 remaining `OpenClawConfig` references, added missing `SessionEntry` import, removed unused `peekSystemEvents` import.

Type-check (`pnpm tsgo`) passes cleanly.

Generated with [Claude Code](https://claude.com/claude-code)