### PR TITLE
Cherry-pick batch: Browser, media, and file-safety fixes

### DIFF
--- a/src/browser/bridge-server.ts
+++ b/src/browser/bridge-server.ts
@@ -23,6 +23,39 @@ export type BrowserBridge = {
   state: BrowserServerState;
 };
 
+type ResolvedNoVncObserver = {
+  noVncPort: number;
+  password?: string;
+};
+
+function buildNoVncBootstrapHtml(params: ResolvedNoVncObserver): string {
+  const hash = new URLSearchParams({
+    autoconnect: "1",
+    resize: "remote",
+  });
+  if (params.password?.trim()) {
+    hash.set("password", params.password);
+  }
+  const targetUrl = `http://127.0.0.1:${params.noVncPort}/vnc.html#${hash.toString()}`;
+  const encodedTarget = JSON.stringify(targetUrl);
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="referrer" content="no-referrer" />
+  <title>RemoteClaw noVNC Observer</title>
+</head>
+<body>
+  <p>Opening sandbox observer...</p>
+  <script>
+    const target = ${encodedTarget};
+    window.location.replace(target);
+  </script>
+</body>
+</html>`;
+}
+
 export async function startBrowserBridgeServer(params: {
   resolved: ResolvedBrowserConfig;
   host?: string;
@@ -30,7 +63,7 @@ export async function startBrowserBridgeServer(params: {
   authToken?: string;
   authPassword?: string;
   onEnsureAttachTarget?: (profile: ProfileContext["profile"]) => Promise<void>;
-  resolveSandboxNoVncToken?: (token: string) => string | null;
+  resolveSandboxNoVncToken?: (token: string) => ResolvedNoVncObserver | null;
 }): Promise<BrowserBridge> {
   const host = params.host ?? "127.0.0.1";
   if (!isLoopbackHost(host)) {
@@ -43,18 +76,21 @@ export async function startBrowserBridgeServer(params: {
 
   if (params.resolveSandboxNoVncToken) {
     app.get("/sandbox/novnc", (req, res) => {
+      res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+      res.setHeader("Pragma", "no-cache");
+      res.setHeader("Expires", "0");
+      res.setHeader("Referrer-Policy", "no-referrer");
       const rawToken = typeof req.query?.token === "string" ? req.query.token.trim() : "";
       if (!rawToken) {
         res.status(400).send("Missing token");
         return;
       }
-      const redirectUrl = params.resolveSandboxNoVncToken?.(rawToken);
-      if (!redirectUrl) {
+      const resolved = params.resolveSandboxNoVncToken?.(rawToken);
+      if (!resolved) {
         res.status(404).send("Invalid or expired token");
         return;
       }
-      res.setHeader("Cache-Control", "no-store");
-      res.redirect(302, redirectUrl);
+      res.type("html").status(200).send(buildNoVncBootstrapHtml(resolved));
     });
   }
 

--- a/src/browser/output-atomic.ts
+++ b/src/browser/output-atomic.ts
@@ -1,0 +1,52 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+function sanitizeFileNameTail(fileName: string): string {
+  const trimmed = String(fileName ?? "").trim();
+  if (!trimmed) {
+    return "output.bin";
+  }
+  let base = path.posix.basename(trimmed);
+  base = path.win32.basename(base);
+  let cleaned = "";
+  for (let i = 0; i < base.length; i++) {
+    const code = base.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) {
+      continue;
+    }
+    cleaned += base[i];
+  }
+  base = cleaned.trim();
+  if (!base || base === "." || base === "..") {
+    return "output.bin";
+  }
+  if (base.length > 200) {
+    base = base.slice(0, 200);
+  }
+  return base;
+}
+
+function buildSiblingTempPath(targetPath: string): string {
+  const id = crypto.randomUUID();
+  const safeTail = sanitizeFileNameTail(path.basename(targetPath));
+  return path.join(path.dirname(targetPath), `.openclaw-output-${id}-${safeTail}.part`);
+}
+
+export async function writeViaSiblingTempPath(params: {
+  targetPath: string;
+  writeTemp: (tempPath: string) => Promise<void>;
+}): Promise<void> {
+  const targetPath = path.resolve(params.targetPath);
+  const tempPath = buildSiblingTempPath(targetPath);
+  let renameSucceeded = false;
+  try {
+    await params.writeTemp(tempPath);
+    await fs.rename(tempPath, targetPath);
+    renameSucceeded = true;
+  } finally {
+    if (!renameSucceeded) {
+      await fs.rm(tempPath, { force: true }).catch(() => {});
+    }
+  }
+}

--- a/src/browser/paths.ts
+++ b/src/browser/paths.ts
@@ -235,6 +235,12 @@ async function resolveCheckedPathsWithinRoot(params: {
         resolvedPaths.push(pathResult.fallbackPath);
         continue;
       }
+      if (err instanceof SafeOpenError && err.code === "outside-workspace") {
+        return {
+          ok: false,
+          error: `File is outside ${params.scopeLabel}`,
+        };
+      }
       return {
         ok: false,
         error: `Invalid path: must stay within ${params.scopeLabel} and be a regular non-symlink file`,

--- a/src/browser/paths.ts
+++ b/src/browser/paths.ts
@@ -54,6 +54,9 @@ async function validateCanonicalPathWithinRoot(params: {
     if (params.expect === "file" && !candidateLstat.isFile()) {
       return "invalid";
     }
+    if (params.expect === "file" && candidateLstat.nlink > 1) {
+      return "invalid";
+    }
     const candidateRealPath = await fs.realpath(params.candidatePath);
     return isPathInside(params.rootRealPath, candidateRealPath) ? "ok" : "invalid";
   } catch (err) {

--- a/src/browser/pw-tools-core.downloads.ts
+++ b/src/browser/pw-tools-core.downloads.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright-core";
 import { resolvePreferredRemoteClawTmpDir } from "../infra/tmp-remoteclaw-dir.js";
+import { writeViaSiblingTempPath } from "./output-atomic.js";
 import { DEFAULT_UPLOAD_DIR, resolveStrictExistingPathsWithinRoot } from "./paths.js";
 import {
   ensurePageState,
@@ -111,13 +112,25 @@ type DownloadPayload = {
 
 async function saveDownloadPayload(download: DownloadPayload, outPath: string) {
   const suggested = download.suggestedFilename?.() || "download.bin";
-  const resolvedOutPath = outPath?.trim() || buildTempDownloadPath(suggested);
+  const requestedPath = outPath?.trim();
+  const resolvedOutPath = path.resolve(requestedPath || buildTempDownloadPath(suggested));
   await fs.mkdir(path.dirname(resolvedOutPath), { recursive: true });
-  await download.saveAs?.(resolvedOutPath);
+
+  if (!requestedPath) {
+    await download.saveAs?.(resolvedOutPath);
+  } else {
+    await writeViaSiblingTempPath({
+      targetPath: resolvedOutPath,
+      writeTemp: async (tempPath) => {
+        await download.saveAs?.(tempPath);
+      },
+    });
+  }
+
   return {
     url: download.url?.() || "",
     suggestedFilename: suggested,
-    path: path.resolve(resolvedOutPath),
+    path: resolvedOutPath,
   };
 }
 

--- a/src/browser/pw-tools-core.trace.ts
+++ b/src/browser/pw-tools-core.trace.ts
@@ -1,3 +1,4 @@
+import { writeViaSiblingTempPath } from "./output-atomic.js";
 import { ensureContextState, getPageForTargetId } from "./pw-session.js";
 
 export async function traceStartViaPlaywright(opts: {
@@ -32,6 +33,11 @@ export async function traceStopViaPlaywright(opts: {
   if (!ctxState.traceActive) {
     throw new Error("No active trace. Start a trace before stopping it.");
   }
-  await context.tracing.stop({ path: opts.path });
+  await writeViaSiblingTempPath({
+    targetPath: opts.path,
+    writeTemp: async (tempPath) => {
+      await context.tracing.stop({ path: tempPath });
+    },
+  });
   ctxState.traceActive = false;
 }

--- a/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
+++ b/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
@@ -200,11 +200,8 @@ describe("pw-tools-core", () => {
       suggestedFilename: "file.bin",
     });
     expect(typeof outPath).toBe("string");
-    const expectedRootedDownloadsDir = path.join(
-      path.sep,
-      "tmp",
-      "remoteclaw-preferred",
-      "downloads",
+    const expectedRootedDownloadsDir = path.resolve(
+      path.join(path.sep, "tmp", "remoteclaw-preferred", "downloads"),
     );
     const expectedDownloadsTail = `${path.join("tmp", "remoteclaw-preferred", "downloads")}${path.sep}`;
     expect(path.dirname(String(outPath))).toBe(expectedRootedDownloadsDir);
@@ -221,7 +218,7 @@ describe("pw-tools-core", () => {
     });
     expect(typeof outPath).toBe("string");
     expect(path.dirname(String(outPath))).toBe(
-      path.join(path.sep, "tmp", "remoteclaw-preferred", "downloads"),
+      path.resolve(path.join(path.sep, "tmp", "remoteclaw-preferred", "downloads")),
     );
     expect(path.basename(String(outPath))).toMatch(/-passwd$/);
     expect(path.normalize(res.path)).toContain(

--- a/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
+++ b/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -22,6 +24,15 @@ describe("pw-tools-core", () => {
     }
     tmpDirMocks.resolvePreferredRemoteClawTmpDir.mockReturnValue("/tmp/remoteclaw");
   });
+
+  async function withTempDir<T>(run: (tempDir: string) => Promise<T>): Promise<T> {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-browser-download-test-"));
+    try {
+      return await run(tempDir);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  }
 
   async function waitForImplicitDownloadOutput(params: {
     downloadUrl: string;
@@ -67,64 +78,121 @@ describe("pw-tools-core", () => {
     };
   }
 
-  it("waits for the next download and saves it", async () => {
-    const harness = createDownloadEventHarness();
+  it("waits for the next download and atomically finalizes explicit output paths", async () => {
+    await withTempDir(async (tempDir) => {
+      const harness = createDownloadEventHarness();
+      const targetPath = path.join(tempDir, "file.bin");
 
-    const saveAs = vi.fn(async () => {});
-    const download = {
-      url: () => "https://example.com/file.bin",
-      suggestedFilename: () => "file.bin",
-      saveAs,
-    };
+      const saveAs = vi.fn(async (outPath: string) => {
+        await fs.writeFile(outPath, "file-content", "utf8");
+      });
+      const download = {
+        url: () => "https://example.com/file.bin",
+        suggestedFilename: () => "file.bin",
+        saveAs,
+      };
 
-    const targetPath = path.resolve("/tmp/file.bin");
-    const p = mod.waitForDownloadViaPlaywright({
-      cdpUrl: "http://127.0.0.1:18792",
-      targetId: "T1",
-      path: targetPath,
-      timeoutMs: 1000,
+      const p = mod.waitForDownloadViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        path: targetPath,
+        timeoutMs: 1000,
+      });
+
+      await Promise.resolve();
+      harness.expectArmed();
+      harness.trigger(download);
+
+      const res = await p;
+      const savedPath = saveAs.mock.calls[0]?.[0];
+      expect(typeof savedPath).toBe("string");
+      expect(savedPath).not.toBe(targetPath);
+      expect(path.dirname(String(savedPath))).toBe(tempDir);
+      expect(path.basename(String(savedPath))).toContain(".openclaw-output-");
+      expect(path.basename(String(savedPath))).toContain(".part");
+      expect(await fs.readFile(targetPath, "utf8")).toBe("file-content");
+      expect(res.path).toBe(targetPath);
     });
-
-    await Promise.resolve();
-    harness.expectArmed();
-    harness.trigger(download);
-
-    const res = await p;
-    expect(saveAs).toHaveBeenCalledWith(targetPath);
-    expect(res.path).toBe(targetPath);
   });
-  it("clicks a ref and saves the resulting download", async () => {
-    const harness = createDownloadEventHarness();
+  it("clicks a ref and atomically finalizes explicit download paths", async () => {
+    await withTempDir(async (tempDir) => {
+      const harness = createDownloadEventHarness();
 
-    const click = vi.fn(async () => {});
-    setPwToolsCoreCurrentRefLocator({ click });
+      const click = vi.fn(async () => {});
+      setPwToolsCoreCurrentRefLocator({ click });
 
-    const saveAs = vi.fn(async () => {});
-    const download = {
-      url: () => "https://example.com/report.pdf",
-      suggestedFilename: () => "report.pdf",
-      saveAs,
-    };
+      const saveAs = vi.fn(async (outPath: string) => {
+        await fs.writeFile(outPath, "report-content", "utf8");
+      });
+      const download = {
+        url: () => "https://example.com/report.pdf",
+        suggestedFilename: () => "report.pdf",
+        saveAs,
+      };
 
-    const targetPath = path.resolve("/tmp/report.pdf");
-    const p = mod.downloadViaPlaywright({
-      cdpUrl: "http://127.0.0.1:18792",
-      targetId: "T1",
-      ref: "e12",
-      path: targetPath,
-      timeoutMs: 1000,
+      const targetPath = path.join(tempDir, "report.pdf");
+      const p = mod.downloadViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        ref: "e12",
+        path: targetPath,
+        timeoutMs: 1000,
+      });
+
+      await Promise.resolve();
+      harness.expectArmed();
+      expect(click).toHaveBeenCalledWith({ timeout: 1000 });
+
+      harness.trigger(download);
+
+      const res = await p;
+      const savedPath = saveAs.mock.calls[0]?.[0];
+      expect(typeof savedPath).toBe("string");
+      expect(savedPath).not.toBe(targetPath);
+      expect(path.dirname(String(savedPath))).toBe(tempDir);
+      expect(path.basename(String(savedPath))).toContain(".openclaw-output-");
+      expect(path.basename(String(savedPath))).toContain(".part");
+      expect(await fs.readFile(targetPath, "utf8")).toBe("report-content");
+      expect(res.path).toBe(targetPath);
     });
-
-    await Promise.resolve();
-    harness.expectArmed();
-    expect(click).toHaveBeenCalledWith({ timeout: 1000 });
-
-    harness.trigger(download);
-
-    const res = await p;
-    expect(saveAs).toHaveBeenCalledWith(targetPath);
-    expect(res.path).toBe(targetPath);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "does not overwrite outside files when explicit output path is a hardlink alias",
+    async () => {
+      await withTempDir(async (tempDir) => {
+        const outsidePath = path.join(tempDir, "outside.txt");
+        await fs.writeFile(outsidePath, "outside-before", "utf8");
+        const linkedPath = path.join(tempDir, "linked.txt");
+        await fs.link(outsidePath, linkedPath);
+
+        const harness = createDownloadEventHarness();
+        const saveAs = vi.fn(async (outPath: string) => {
+          await fs.writeFile(outPath, "download-content", "utf8");
+        });
+        const p = mod.waitForDownloadViaPlaywright({
+          cdpUrl: "http://127.0.0.1:18792",
+          targetId: "T1",
+          path: linkedPath,
+          timeoutMs: 1000,
+        });
+
+        await Promise.resolve();
+        harness.expectArmed();
+        harness.trigger({
+          url: () => "https://example.com/file.bin",
+          suggestedFilename: () => "file.bin",
+          saveAs,
+        });
+
+        const res = await p;
+        expect(res.path).toBe(linkedPath);
+        expect(await fs.readFile(linkedPath, "utf8")).toBe("download-content");
+        expect(await fs.readFile(outsidePath, "utf8")).toBe("outside-before");
+      });
+    },
+  );
+
   it("uses preferred tmp dir when waiting for download without explicit path", async () => {
     tmpDirMocks.resolvePreferredRemoteClawTmpDir.mockReturnValue("/tmp/remoteclaw-preferred");
     const { res, outPath } = await waitForImplicitDownloadOutput({

--- a/src/browser/routes/agent.snapshot.test.ts
+++ b/src/browser/routes/agent.snapshot.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveTargetIdAfterNavigate } from "./agent.snapshot.js";
+
+type Tab = { targetId: string; url: string };
+
+function staticListTabs(tabs: Tab[]): () => Promise<Tab[]> {
+  return async () => tabs;
+}
+
+describe("resolveTargetIdAfterNavigate", () => {
+  it("returns original targetId when old target still exists (no swap)", async () => {
+    const result = await resolveTargetIdAfterNavigate({
+      oldTargetId: "old-123",
+      navigatedUrl: "https://example.com",
+      listTabs: staticListTabs([
+        { targetId: "old-123", url: "https://example.com" },
+        { targetId: "other-456", url: "https://other.com" },
+      ]),
+    });
+    expect(result).toBe("old-123");
+  });
+
+  it("resolves new targetId when old target is gone (renderer swap)", async () => {
+    const result = await resolveTargetIdAfterNavigate({
+      oldTargetId: "old-123",
+      navigatedUrl: "https://example.com",
+      listTabs: staticListTabs([{ targetId: "new-456", url: "https://example.com" }]),
+    });
+    expect(result).toBe("new-456");
+  });
+
+  it("prefers non-stale targetId when multiple tabs share the URL", async () => {
+    const result = await resolveTargetIdAfterNavigate({
+      oldTargetId: "old-123",
+      navigatedUrl: "https://example.com",
+      listTabs: staticListTabs([
+        { targetId: "preexisting-000", url: "https://example.com" },
+        { targetId: "fresh-777", url: "https://example.com" },
+      ]),
+    });
+    // Both differ from old targetId; the first non-stale match wins.
+    expect(result).toBe("preexisting-000");
+  });
+
+  it("retries and resolves targetId when first listTabs has no URL match", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+
+    const result$ = resolveTargetIdAfterNavigate({
+      oldTargetId: "old-123",
+      navigatedUrl: "https://delayed.com",
+      listTabs: async () => {
+        calls++;
+        if (calls === 1) {
+          return [{ targetId: "unrelated-1", url: "https://unrelated.com" }];
+        }
+        return [{ targetId: "delayed-999", url: "https://delayed.com" }];
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(800);
+    const result = await result$;
+
+    expect(result).toBe("delayed-999");
+    expect(calls).toBe(2);
+
+    vi.useRealTimers();
+  });
+
+  it("falls back to original targetId when no match found after retry", async () => {
+    vi.useFakeTimers();
+
+    const result$ = resolveTargetIdAfterNavigate({
+      oldTargetId: "old-123",
+      navigatedUrl: "https://no-match.com",
+      listTabs: staticListTabs([
+        { targetId: "unrelated-1", url: "https://unrelated.com" },
+        { targetId: "unrelated-2", url: "https://unrelated2.com" },
+      ]),
+    });
+
+    await vi.advanceTimersByTimeAsync(800);
+    const result = await result$;
+
+    expect(result).toBe("old-123");
+
+    vi.useRealTimers();
+  });
+
+  it("falls back to single remaining tab when no URL match after retry", async () => {
+    vi.useFakeTimers();
+
+    const result$ = resolveTargetIdAfterNavigate({
+      oldTargetId: "old-123",
+      navigatedUrl: "https://single-tab.com",
+      listTabs: staticListTabs([{ targetId: "only-tab", url: "https://some-other.com" }]),
+    });
+
+    await vi.advanceTimersByTimeAsync(800);
+    const result = await result$;
+
+    expect(result).toBe("only-tab");
+
+    vi.useRealTimers();
+  });
+
+  it("falls back to original targetId when listTabs throws", async () => {
+    const result = await resolveTargetIdAfterNavigate({
+      oldTargetId: "old-123",
+      navigatedUrl: "https://error.com",
+      listTabs: async () => {
+        throw new Error("CDP connection lost");
+      },
+    });
+    expect(result).toBe("old-123");
+  });
+});

--- a/src/browser/server.auth-fail-closed.test.ts
+++ b/src/browser/server.auth-fail-closed.test.ts
@@ -1,0 +1,92 @@
+import { createServer, type AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  controlPort: 0,
+  ensureBrowserControlAuth: vi.fn(async () => {
+    throw new Error("read-only config");
+  }),
+  resolveBrowserControlAuth: vi.fn(() => ({})),
+  ensureExtensionRelayForProfiles: vi.fn(async () => {}),
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => ({
+      browser: {
+        enabled: true,
+      },
+    }),
+  };
+});
+
+vi.mock("./config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./config.js")>();
+  return {
+    ...actual,
+    resolveBrowserConfig: vi.fn(() => ({
+      enabled: true,
+      controlPort: mocks.controlPort,
+    })),
+  };
+});
+
+vi.mock("./control-auth.js", () => ({
+  ensureBrowserControlAuth: mocks.ensureBrowserControlAuth,
+  resolveBrowserControlAuth: mocks.resolveBrowserControlAuth,
+}));
+
+vi.mock("./routes/index.js", () => ({
+  registerBrowserRoutes: vi.fn(() => {}),
+}));
+
+vi.mock("./server-context.js", () => ({
+  createBrowserRouteContext: vi.fn(() => ({})),
+}));
+
+vi.mock("./server-lifecycle.js", () => ({
+  ensureExtensionRelayForProfiles: mocks.ensureExtensionRelayForProfiles,
+  stopKnownBrowserProfiles: vi.fn(async () => {}),
+}));
+
+vi.mock("./pw-ai-state.js", () => ({
+  isPwAiLoaded: vi.fn(() => false),
+}));
+
+const { startBrowserControlServerFromConfig, stopBrowserControlServer } =
+  await import("./server.js");
+
+async function getFreePort(): Promise<number> {
+  const probe = createServer();
+  await new Promise<void>((resolve, reject) => {
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => resolve());
+  });
+  const addr = probe.address() as AddressInfo;
+  await new Promise<void>((resolve) => probe.close(() => resolve()));
+  return addr.port;
+}
+
+describe("browser control auth bootstrap failures", () => {
+  beforeEach(async () => {
+    mocks.controlPort = await getFreePort();
+    mocks.ensureBrowserControlAuth.mockClear();
+    mocks.resolveBrowserControlAuth.mockClear();
+    mocks.ensureExtensionRelayForProfiles.mockClear();
+  });
+
+  afterEach(async () => {
+    await stopBrowserControlServer();
+  });
+
+  it("fails closed when auth bootstrap throws and no auth is configured", async () => {
+    const started = await startBrowserControlServerFromConfig();
+
+    expect(started).toBeNull();
+    expect(mocks.ensureBrowserControlAuth).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveBrowserControlAuth).toHaveBeenCalledTimes(1);
+    expect(mocks.ensureExtensionRelayForProfiles).not.toHaveBeenCalled();
+  });
+});

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -62,7 +62,7 @@ describe("fs-safe", () => {
         rootDir: root,
         relativePath: path.join("..", path.basename(outside), "outside.txt"),
       }),
-    ).rejects.toMatchObject({ code: "invalid-path" });
+    ).rejects.toMatchObject({ code: "outside-workspace" });
   });
 
   it.runIf(process.platform !== "win32")("blocks symlink escapes under root", async () => {

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -9,6 +9,7 @@ import { isNotFoundPathError, isPathInside, isSymlinkOpenError } from "./path-gu
 export type SafeOpenErrorCode =
   | "invalid-path"
   | "not-found"
+  | "outside-workspace"
   | "symlink"
   | "not-file"
   | "path-mismatch"
@@ -102,7 +103,7 @@ export async function openFileWithinRoot(params: {
   const rootWithSep = ensureTrailingSep(rootReal);
   const resolved = path.resolve(rootWithSep, params.relativePath);
   if (!isPathInside(rootWithSep, resolved)) {
-    throw new SafeOpenError("invalid-path", "path escapes root");
+    throw new SafeOpenError("outside-workspace", "file is outside workspace root");
   }
 
   let opened: SafeOpenResult;
@@ -122,7 +123,7 @@ export async function openFileWithinRoot(params: {
 
   if (!isPathInside(rootWithSep, opened.realPath)) {
     await opened.handle.close().catch(() => {});
-    throw new SafeOpenError("invalid-path", "path escapes root");
+    throw new SafeOpenError("outside-workspace", "file is outside workspace root");
   }
 
   return opened;

--- a/src/media/server.outside-workspace.test.ts
+++ b/src/media/server.outside-workspace.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs/promises";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  openFileWithinRoot: vi.fn(),
+  cleanOldMedia: vi.fn().mockResolvedValue(undefined),
+}));
+
+let mediaDir = "";
+
+vi.mock("../infra/fs-safe.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/fs-safe.js")>();
+  return {
+    ...actual,
+    openFileWithinRoot: mocks.openFileWithinRoot,
+  };
+});
+
+vi.mock("./store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./store.js")>();
+  return {
+    ...actual,
+    getMediaDir: () => mediaDir,
+    cleanOldMedia: mocks.cleanOldMedia,
+  };
+});
+
+const { SafeOpenError } = await import("../infra/fs-safe.js");
+const { startMediaServer } = await import("./server.js");
+
+describe("media server outside-workspace mapping", () => {
+  let server: Awaited<ReturnType<typeof startMediaServer>>;
+  let port = 0;
+
+  beforeAll(async () => {
+    mediaDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-outside-workspace-"));
+    server = await startMediaServer(0, 1_000);
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(mediaDir, { recursive: true, force: true });
+    mediaDir = "";
+  });
+
+  it("returns 400 with a specific outside-workspace message", async () => {
+    mocks.openFileWithinRoot.mockRejectedValueOnce(
+      new SafeOpenError("outside-workspace", "file is outside workspace root"),
+    );
+
+    const response = await fetch(`http://127.0.0.1:${port}/media/ok-id`);
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("file is outside workspace root");
+  });
+});

--- a/src/media/server.ts
+++ b/src/media/server.ts
@@ -75,6 +75,10 @@ export function attachMediaRoutes(
       });
     } catch (err) {
       if (err instanceof SafeOpenError) {
+        if (err.code === "outside-workspace") {
+          res.status(400).send("file is outside workspace root");
+          return;
+        }
         if (err.code === "invalid-path") {
           res.status(400).send("invalid path");
           return;

--- a/src/media/store.outside-workspace.test.ts
+++ b/src/media/store.outside-workspace.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+
+const mocks = vi.hoisted(() => ({
+  readLocalFileSafely: vi.fn(),
+}));
+
+vi.mock("../infra/fs-safe.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/fs-safe.js")>();
+  return {
+    ...actual,
+    readLocalFileSafely: mocks.readLocalFileSafely,
+  };
+});
+
+const { saveMediaSource } = await import("./store.js");
+const { SafeOpenError } = await import("../infra/fs-safe.js");
+
+describe("media store outside-workspace mapping", () => {
+  let tempHome: TempHomeEnv;
+  let home = "";
+
+  beforeAll(async () => {
+    tempHome = await createTempHomeEnv("openclaw-media-store-test-home-");
+    home = tempHome.home;
+  });
+
+  afterAll(async () => {
+    await tempHome.restore();
+  });
+
+  it("maps outside-workspace reads to a descriptive invalid-path error", async () => {
+    const sourcePath = path.join(home, "outside-media.txt");
+    await fs.writeFile(sourcePath, "hello");
+    mocks.readLocalFileSafely.mockRejectedValueOnce(
+      new SafeOpenError("outside-workspace", "file is outside workspace root"),
+    );
+
+    await expect(saveMediaSource(sourcePath)).rejects.toMatchObject({
+      code: "invalid-path",
+      message: "Media path is outside workspace root",
+    });
+  });
+});

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -241,6 +241,10 @@ function toSaveMediaSourceError(err: SafeOpenError): SaveMediaSourceError {
       return new SaveMediaSourceError("too-large", "Media exceeds 5MB limit", { cause: err });
     case "not-found":
       return new SaveMediaSourceError("not-found", "Media path does not exist", { cause: err });
+    case "outside-workspace":
+      return new SaveMediaSourceError("invalid-path", "Media path is outside workspace root", {
+        cause: err,
+      });
     case "invalid-path":
     default:
       return new SaveMediaSourceError("invalid-path", "Media path is not safe to read", {


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #687

### Commits (8 cherry-picked)

| Hash | Subject | Result |
|------|---------|--------|
| `f5c2be191` | fix: distinguish outside-workspace errors from not-found in fs-safe | RESOLVED — pi-tools.read.ts deleted (gutted), writeFileWithinRoot removed (no callers), upstream semantic changes applied manually |
| `44220ef24` | test: add outside-workspace error mapping coverage | RESOLVED — removed pi-tools.read.host-edit-access.test.ts (tests gutted pi-coding-agent dep) |
| `28c80689d` | fix(browser): resolve correct targetId in navigate response after renderer swap (#25326) | PICKED |
| `e4d22fb07` | fix(browser): fail closed browser auth bootstrap | RESOLVED — CHANGELOG.md conflict |
| `002539c01` | fix(security): harden sandbox novnc observer flow | RESOLVED — sandbox files gutted, kept bridge-server.ts changes, rebranded OpenClaw→RemoteClaw in noVNC HTML |
| `6a80e9db0` | fix(browser): harden writable output paths | RESOLVED — CHANGELOG.md + downloads import conflict (fork rebrand), applied atomic write changes |
| `949200d7c` | test(browser): fix windows download tmp path assertions | RESOLVED — path.join→path.resolve for Windows compat, kept fork rebrand |
| `d6552998e` | fix: handle outside-workspace error in media store | PICKED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)