### PR TITLE
Cherry-pick batch: Scripts and build tooling

### DIFF
--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -1,0 +1,153 @@
+import { spawnSync } from "node:child_process";
+
+type CommandCase = {
+  name: string;
+  args: string[];
+};
+
+type Sample = {
+  ms: number;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+};
+
+const DEFAULT_RUNS = 8;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_ENTRY = "dist/entry.js";
+
+const DEFAULT_CASES: CommandCase[] = [
+  { name: "--version", args: ["--version"] },
+  { name: "--help", args: ["--help"] },
+  { name: "health --json", args: ["health", "--json"] },
+  { name: "status --json", args: ["status", "--json"] },
+  { name: "status", args: ["status"] },
+];
+
+function parseFlagValue(flag: string): string | undefined {
+  const idx = process.argv.indexOf(flag);
+  if (idx === -1) {
+    return undefined;
+  }
+  return process.argv[idx + 1];
+}
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].toSorted((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return sorted[mid];
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].toSorted((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[index];
+}
+
+function runCase(params: {
+  entry: string;
+  runCase: CommandCase;
+  runs: number;
+  timeoutMs: number;
+}): Sample[] {
+  const results: Sample[] = [];
+  for (let i = 0; i < params.runs; i += 1) {
+    const started = process.hrtime.bigint();
+    const proc = spawnSync(process.execPath, [params.entry, ...params.runCase.args], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        OPENCLAW_HIDE_BANNER: "1",
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+      encoding: "utf8",
+      timeout: params.timeoutMs,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    const ms = Number(process.hrtime.bigint() - started) / 1e6;
+    results.push({
+      ms,
+      exitCode: proc.status,
+      signal: proc.signal,
+    });
+  }
+  return results;
+}
+
+function summarize(samples: Sample[]) {
+  const values = samples.map((entry) => entry.ms);
+  const total = values.reduce((sum, value) => sum + value, 0);
+  const avg = values.length > 0 ? total / values.length : 0;
+  const min = values.length > 0 ? Math.min(...values) : 0;
+  const max = values.length > 0 ? Math.max(...values) : 0;
+  return {
+    avg,
+    p50: median(values),
+    p95: percentile(values, 95),
+    min,
+    max,
+  };
+}
+
+function formatMs(value: number): string {
+  return `${value.toFixed(1)}ms`;
+}
+
+function collectExitSummary(samples: Sample[]): string {
+  const buckets = new Map<string, number>();
+  for (const sample of samples) {
+    const key =
+      sample.signal != null
+        ? `signal:${sample.signal}`
+        : `code:${sample.exitCode == null ? "null" : String(sample.exitCode)}`;
+    buckets.set(key, (buckets.get(key) ?? 0) + 1);
+  }
+  return [...buckets.entries()].map(([key, count]) => `${key}x${count}`).join(", ");
+}
+
+async function main(): Promise<void> {
+  const entry = parseFlagValue("--entry") ?? DEFAULT_ENTRY;
+  const runs = parsePositiveInt(parseFlagValue("--runs"), DEFAULT_RUNS);
+  const timeoutMs = parsePositiveInt(parseFlagValue("--timeout-ms"), DEFAULT_TIMEOUT_MS);
+
+  console.log(`Node: ${process.version}`);
+  console.log(`Entry: ${entry}`);
+  console.log(`Runs per command: ${runs}`);
+  console.log(`Timeout: ${timeoutMs}ms`);
+  console.log("");
+
+  for (const commandCase of DEFAULT_CASES) {
+    const samples = runCase({
+      entry,
+      runCase: commandCase,
+      runs,
+      timeoutMs,
+    });
+    const stats = summarize(samples);
+    const exitSummary = collectExitSummary(samples);
+    console.log(
+      `${commandCase.name.padEnd(13)} avg=${formatMs(stats.avg)} p50=${formatMs(stats.p50)} p95=${formatMs(stats.p95)} min=${formatMs(stats.min)} max=${formatMs(stats.max)} exits=[${exitSummary}]`,
+    );
+  }
+}
+
+await main();

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -41,20 +41,6 @@ sparkle_canonical_build_from_version() {
   node --import tsx "$ROOT_DIR/scripts/sparkle-build.ts" canonical-build "$1"
 }
 
-if [[ -z "${APP_BUILD:-}" ]]; then
-  APP_BUILD="$GIT_BUILD_NUMBER"
-  if CANONICAL_BUILD="$(sparkle_canonical_build_from_version "$APP_VERSION" 2>/dev/null)"; then
-    if [[ "$CANONICAL_BUILD" =~ ^[0-9]+$ ]] && (( CANONICAL_BUILD > APP_BUILD )); then
-      APP_BUILD="$CANONICAL_BUILD"
-    fi
-  fi
-fi
-
-if [[ "$AUTO_CHECKS" == "true" && ! "$APP_BUILD" =~ ^[0-9]+$ ]]; then
-  echo "ERROR: APP_BUILD must be numeric for Sparkle compare (CFBundleVersion). Got: $APP_BUILD" >&2
-  exit 1
-fi
-
 build_path_for_arch() {
   echo "$BUILD_ROOT/$1"
 }
@@ -130,6 +116,25 @@ merge_framework_machos() {
 
 echo "📦 Ensuring deps (pnpm install)"
 (cd "$ROOT_DIR" && pnpm install --no-frozen-lockfile --config.node-linker=hoisted)
+
+if [[ -z "${APP_BUILD:-}" ]]; then
+  APP_BUILD="$GIT_BUILD_NUMBER"
+  if [[ "$APP_VERSION" =~ ^[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}([.-].*)?$ ]]; then
+    CANONICAL_BUILD="$(sparkle_canonical_build_from_version "$APP_VERSION")" || {
+      echo "ERROR: Failed to derive canonical Sparkle APP_BUILD from APP_VERSION '$APP_VERSION'." >&2
+      exit 1
+    }
+    if [[ "$CANONICAL_BUILD" =~ ^[0-9]+$ ]] && (( CANONICAL_BUILD > APP_BUILD )); then
+      APP_BUILD="$CANONICAL_BUILD"
+    fi
+  fi
+fi
+
+if [[ "$AUTO_CHECKS" == "true" && ! "$APP_BUILD" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: APP_BUILD must be numeric for Sparkle compare (CFBundleVersion). Got: $APP_BUILD" >&2
+  exit 1
+fi
+
 if [[ "${SKIP_TSC:-0}" != "1" ]]; then
   echo "📦 Building JS (pnpm build)"
   (cd "$ROOT_DIR" && pnpm build)

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -41,7 +41,7 @@ sparkle_canonical_build_from_version() {
   node --import tsx "$ROOT_DIR/scripts/sparkle-build.ts" canonical-build "$1"
 }
 
-if [[ -z "${APP_BUILD+x}" ]]; then
+if [[ -z "${APP_BUILD:-}" ]]; then
   APP_BUILD="$GIT_BUILD_NUMBER"
   if CANONICAL_BUILD="$(sparkle_canonical_build_from_version "$APP_VERSION" 2>/dev/null)"; then
     if [[ "$CANONICAL_BUILD" =~ ^[0-9]+$ ]] && (( CANONICAL_BUILD > APP_BUILD )); then

--- a/scripts/podman/remoteclaw.container.in
+++ b/scripts/podman/remoteclaw.container.in
@@ -9,6 +9,8 @@ Description=RemoteClaw gateway (rootless Podman)
 Image=remoteclaw:local
 ContainerName=remoteclaw
 UserNS=keep-id
+# Keep container UID/GID aligned with the invoking user so mounted config is readable.
+User=%U:%G
 Volume={{REMOTECLAW_HOME}}/.remoteclaw:/home/node/.remoteclaw
 EnvironmentFile={{REMOTECLAW_HOME}}/.remoteclaw/.env
 Environment=HOME=/home/node

--- a/scripts/pr
+++ b/scripts/pr
@@ -1000,7 +1000,7 @@ merge_run() {
   local reviewer_coauthor_email="${reviewer_id}+${reviewer}@users.noreply.github.com"
 
   cat > .local/merge-body.txt <<EOF_BODY
-Merged via /review-pr -> /prepare-pr -> /merge-pr.
+Merged via squash.
 
 Prepared head SHA: $PREP_HEAD_SHA
 Co-authored-by: $contrib <$contrib_coauthor_email>

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -23,6 +23,7 @@ const requiredPathGroups = [
   "dist/build-info.json",
 ];
 const forbiddenPrefixes = ["dist/RemoteClaw.app/"];
+const appcastPath = resolve("appcast.xml");
 
 function normalizePluginSyncVersion(version: string): string {
   const normalized = version.trim().replace(/^v/, "");
@@ -174,9 +175,85 @@ function checkPluginVersions() {
   }
 }
 
+function canonicalSparkleVersionFromShortVersion(shortVersion: string): number | null {
+  const match = /^([0-9]{4})\.([0-9]{1,2})\.([0-9]{1,2})([.-].*)?$/.exec(shortVersion.trim());
+  if (!match) {
+    return null;
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (
+    !Number.isInteger(year) ||
+    !Number.isInteger(month) ||
+    !Number.isInteger(day) ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > 31
+  ) {
+    return null;
+  }
+  return Number(`${year}${String(month).padStart(2, "0")}${String(day).padStart(2, "0")}0`);
+}
+
+function extractTag(item: string, tag: string): string | null {
+  const escapedTag = tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`<${escapedTag}>([^<]+)</${escapedTag}>`);
+  return regex.exec(item)?.[1]?.trim() ?? null;
+}
+
+function checkAppcastSparkleVersions() {
+  const xml = readFileSync(appcastPath, "utf8");
+  const itemMatches = [...xml.matchAll(/<item>([\s\S]*?)<\/item>/g)];
+  const errors: string[] = [];
+
+  if (itemMatches.length === 0) {
+    errors.push("appcast.xml contains no <item> entries.");
+  }
+
+  for (const [, item] of itemMatches) {
+    const title = extractTag(item, "title") ?? "unknown";
+    const shortVersion = extractTag(item, "sparkle:shortVersionString");
+    const sparkleVersion = extractTag(item, "sparkle:version");
+
+    if (!sparkleVersion) {
+      errors.push(`appcast item '${title}' is missing sparkle:version.`);
+      continue;
+    }
+    if (!/^[0-9]+$/.test(sparkleVersion)) {
+      errors.push(`appcast item '${title}' has non-numeric sparkle:version '${sparkleVersion}'.`);
+      continue;
+    }
+
+    if (!shortVersion) {
+      continue;
+    }
+    const canonicalFloor = canonicalSparkleVersionFromShortVersion(shortVersion);
+    if (canonicalFloor === null) {
+      continue;
+    }
+    const sparkleBuild = Number(sparkleVersion);
+    if (sparkleBuild < canonicalFloor) {
+      errors.push(
+        `appcast item '${title}' has sparkle:version ${sparkleBuild} below canonical floor ${canonicalFloor} derived from ${shortVersion}.`,
+      );
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error("release-check: appcast sparkle version validation failed:");
+    for (const error of errors) {
+      console.error(`  - ${error}`);
+    }
+    process.exit(1);
+  }
+}
+
 function main() {
   checkPluginVersions();
   checkBundledExtensionRootDependencyMirrors();
+  checkAppcastSparkleVersions();
 
   const results = runPackDry();
   const files = results.flatMap((entry) => entry.files ?? []);

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -25,6 +25,12 @@ const requiredPathGroups = [
 const forbiddenPrefixes = ["dist/RemoteClaw.app/"];
 const appcastPath = resolve("appcast.xml");
 
+type CalverSparkleFloors = {
+  dateKey: number;
+  legacyFloor: number;
+  laneFloor: number;
+};
+
 function normalizePluginSyncVersion(version: string): string {
   const normalized = version.trim().replace(/^v/, "");
   const base = /^([0-9]+\.[0-9]+\.[0-9]+)/.exec(normalized)?.[1];
@@ -175,7 +181,7 @@ function checkPluginVersions() {
   }
 }
 
-function canonicalSparkleVersionFromShortVersion(shortVersion: string): number | null {
+function sparkleFloorsFromShortVersion(shortVersion: string): CalverSparkleFloors | null {
   const match = /^([0-9]{4})\.([0-9]{1,2})\.([0-9]{1,2})([.-].*)?$/.exec(shortVersion.trim());
   if (!match) {
     return null;
@@ -194,7 +200,24 @@ function canonicalSparkleVersionFromShortVersion(shortVersion: string): number |
   ) {
     return null;
   }
-  return Number(`${year}${String(month).padStart(2, "0")}${String(day).padStart(2, "0")}0`);
+
+  const dateKey = Number(`${year}${String(month).padStart(2, "0")}${String(day).padStart(2, "0")}`);
+  const legacyFloor = Number(`${dateKey}0`);
+
+  // Must stay aligned with canonical_build_from_version in scripts/package-mac-app.sh.
+  const suffix = match[4] ?? "";
+  let lane = 90;
+  if (suffix.length > 0) {
+    const numericSuffix = /([0-9]+)$/.exec(suffix)?.[1];
+    if (numericSuffix) {
+      lane = Math.min(Number.parseInt(numericSuffix, 10), 89);
+    } else {
+      lane = 1;
+    }
+  }
+
+  const laneFloor = Number(`${dateKey}${String(lane).padStart(2, "0")}`);
+  return { dateKey, legacyFloor, laneFloor };
 }
 
 function extractTag(item: string, tag: string): string | null {
@@ -207,6 +230,8 @@ function checkAppcastSparkleVersions() {
   const xml = readFileSync(appcastPath, "utf8");
   const itemMatches = [...xml.matchAll(/<item>([\s\S]*?)<\/item>/g)];
   const errors: string[] = [];
+  const calverItems: Array<{ title: string; sparkleBuild: number; floors: CalverSparkleFloors }> =
+    [];
 
   if (itemMatches.length === 0) {
     errors.push("appcast.xml contains no <item> entries.");
@@ -229,14 +254,30 @@ function checkAppcastSparkleVersions() {
     if (!shortVersion) {
       continue;
     }
-    const canonicalFloor = canonicalSparkleVersionFromShortVersion(shortVersion);
-    if (canonicalFloor === null) {
+    const floors = sparkleFloorsFromShortVersion(shortVersion);
+    if (floors === null) {
       continue;
     }
+
     const sparkleBuild = Number(sparkleVersion);
-    if (sparkleBuild < canonicalFloor) {
+    calverItems.push({ title, sparkleBuild, floors });
+  }
+
+  const adoptionDateKey = calverItems
+    .filter((item) => item.sparkleBuild >= 1_000_000_000)
+    .map((item) => item.floors.dateKey)
+    .toSorted((a, b) => a - b)[0];
+
+  for (const item of calverItems) {
+    const expectLaneFloor =
+      item.sparkleBuild >= 1_000_000_000 ||
+      (typeof adoptionDateKey === "number" && item.floors.dateKey >= adoptionDateKey);
+    const floor = expectLaneFloor ? item.floors.laneFloor : item.floors.legacyFloor;
+
+    if (item.sparkleBuild < floor) {
+      const floorLabel = expectLaneFloor ? "lane floor" : "legacy floor";
       errors.push(
-        `appcast item '${title}' has sparkle:version ${sparkleBuild} below canonical floor ${canonicalFloor} derived from ${shortVersion}.`,
+        `appcast item '${item.title}' has sparkle:version ${item.sparkleBuild} below ${floorLabel} ${floor}.`,
       );
     }
   }

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -3,12 +3,14 @@
 import { execSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   collectBundledExtensionManifestErrors,
   normalizeBundledExtensionMetadata,
   type BundledExtension,
   type ExtensionPackageJson as PackageJson,
 } from "./lib/bundled-extension-manifest.ts";
+import { sparkleBuildFloorsFromShortVersion, type SparkleBuildFloors } from "./sparkle-build.ts";
 
 export { collectBundledExtensionManifestErrors } from "./lib/bundled-extension-manifest.ts";
 
@@ -24,12 +26,8 @@ const requiredPathGroups = [
 ];
 const forbiddenPrefixes = ["dist/RemoteClaw.app/"];
 const appcastPath = resolve("appcast.xml");
-
-type CalverSparkleFloors = {
-  dateKey: number;
-  legacyFloor: number;
-  laneFloor: number;
-};
+const laneBuildMin = 1_000_000_000;
+const laneFloorAdoptionDateKey = 20260227;
 
 function normalizePluginSyncVersion(version: string): string {
   const normalized = version.trim().replace(/^v/, "");
@@ -181,56 +179,16 @@ function checkPluginVersions() {
   }
 }
 
-function sparkleFloorsFromShortVersion(shortVersion: string): CalverSparkleFloors | null {
-  const match = /^([0-9]{4})\.([0-9]{1,2})\.([0-9]{1,2})([.-].*)?$/.exec(shortVersion.trim());
-  if (!match) {
-    return null;
-  }
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  if (
-    !Number.isInteger(year) ||
-    !Number.isInteger(month) ||
-    !Number.isInteger(day) ||
-    month < 1 ||
-    month > 12 ||
-    day < 1 ||
-    day > 31
-  ) {
-    return null;
-  }
-
-  const dateKey = Number(`${year}${String(month).padStart(2, "0")}${String(day).padStart(2, "0")}`);
-  const legacyFloor = Number(`${dateKey}0`);
-
-  // Must stay aligned with canonical_build_from_version in scripts/package-mac-app.sh.
-  const suffix = match[4] ?? "";
-  let lane = 90;
-  if (suffix.length > 0) {
-    const numericSuffix = /([0-9]+)$/.exec(suffix)?.[1];
-    if (numericSuffix) {
-      lane = Math.min(Number.parseInt(numericSuffix, 10), 89);
-    } else {
-      lane = 1;
-    }
-  }
-
-  const laneFloor = Number(`${dateKey}${String(lane).padStart(2, "0")}`);
-  return { dateKey, legacyFloor, laneFloor };
-}
-
 function extractTag(item: string, tag: string): string | null {
   const escapedTag = tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const regex = new RegExp(`<${escapedTag}>([^<]+)</${escapedTag}>`);
   return regex.exec(item)?.[1]?.trim() ?? null;
 }
 
-function checkAppcastSparkleVersions() {
-  const xml = readFileSync(appcastPath, "utf8");
+export function collectAppcastSparkleVersionErrors(xml: string): string[] {
   const itemMatches = [...xml.matchAll(/<item>([\s\S]*?)<\/item>/g)];
   const errors: string[] = [];
-  const calverItems: Array<{ title: string; sparkleBuild: number; floors: CalverSparkleFloors }> =
+  const calverItems: Array<{ title: string; sparkleBuild: number; floors: SparkleBuildFloors }> =
     [];
 
   if (itemMatches.length === 0) {
@@ -254,7 +212,7 @@ function checkAppcastSparkleVersions() {
     if (!shortVersion) {
       continue;
     }
-    const floors = sparkleFloorsFromShortVersion(shortVersion);
+    const floors = sparkleBuildFloorsFromShortVersion(shortVersion);
     if (floors === null) {
       continue;
     }
@@ -263,15 +221,18 @@ function checkAppcastSparkleVersions() {
     calverItems.push({ title, sparkleBuild, floors });
   }
 
-  const adoptionDateKey = calverItems
-    .filter((item) => item.sparkleBuild >= 1_000_000_000)
+  const observedLaneAdoptionDateKey = calverItems
+    .filter((item) => item.sparkleBuild >= laneBuildMin)
     .map((item) => item.floors.dateKey)
     .toSorted((a, b) => a - b)[0];
+  const effectiveLaneAdoptionDateKey =
+    typeof observedLaneAdoptionDateKey === "number"
+      ? Math.min(observedLaneAdoptionDateKey, laneFloorAdoptionDateKey)
+      : laneFloorAdoptionDateKey;
 
   for (const item of calverItems) {
     const expectLaneFloor =
-      item.sparkleBuild >= 1_000_000_000 ||
-      (typeof adoptionDateKey === "number" && item.floors.dateKey >= adoptionDateKey);
+      item.sparkleBuild >= laneBuildMin || item.floors.dateKey >= effectiveLaneAdoptionDateKey;
     const floor = expectLaneFloor ? item.floors.laneFloor : item.floors.legacyFloor;
 
     if (item.sparkleBuild < floor) {
@@ -282,6 +243,12 @@ function checkAppcastSparkleVersions() {
     }
   }
 
+  return errors;
+}
+
+function checkAppcastSparkleVersions() {
+  const xml = readFileSync(appcastPath, "utf8");
+  const errors = collectAppcastSparkleVersionErrors(xml);
   if (errors.length > 0) {
     console.error("release-check: appcast sparkle version validation failed:");
     for (const error of errors) {
@@ -331,4 +298,6 @@ function main() {
   console.log("release-check: npm pack contents look OK.");
 }
 
-main();
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main();
+}

--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -61,6 +61,11 @@ run_as_remoteclaw() {
   run_as_user "$REMOTECLAW_USER" env HOME="$REMOTECLAW_HOME" "$@"
 }
 
+escape_sed_replacement_pipe_delim() {
+  # Escape replacement metacharacters for sed "s|...|...|g" replacement text.
+  printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
 # Quadlet: opt-in via --quadlet or REMOTECLAW_PODMAN_QUADLET=1
 INSTALL_QUADLET=false
 for arg in "$@"; do
@@ -229,7 +234,7 @@ QUADLET_DIR="$REMOTECLAW_HOME/.config/containers/systemd"
 if [[ "$INSTALL_QUADLET" == true && -f "$QUADLET_TEMPLATE" ]]; then
   echo "Installing systemd quadlet for $REMOTECLAW_USER..."
   run_as_remoteclaw mkdir -p "$QUADLET_DIR"
-  REMOTECLAW_HOME_SED="$(printf '%s' "$REMOTECLAW_HOME" | sed -e 's/[\\/&|]/\\\\&/g')"
+  REMOTECLAW_HOME_SED="$(escape_sed_replacement_pipe_delim "$REMOTECLAW_HOME")"
   sed "s|{{REMOTECLAW_HOME}}|$REMOTECLAW_HOME_SED|g" "$QUADLET_TEMPLATE" | run_as_remoteclaw tee "$QUADLET_DIR/remoteclaw.container" >/dev/null
   run_as_remoteclaw chmod 700 "$REMOTECLAW_HOME/.config" "$REMOTECLAW_HOME/.config/containers" "$QUADLET_DIR" 2>/dev/null || true
   run_as_remoteclaw chmod 600 "$QUADLET_DIR/remoteclaw.container" 2>/dev/null || true

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { collectAppcastSparkleVersionErrors } from "../scripts/release-check.ts";
+
+function makeItem(shortVersion: string, sparkleVersion: string): string {
+  return `<item><title>${shortVersion}</title><sparkle:shortVersionString>${shortVersion}</sparkle:shortVersionString><sparkle:version>${sparkleVersion}</sparkle:version></item>`;
+}
+
+describe("collectAppcastSparkleVersionErrors", () => {
+  it("accepts legacy 9-digit calver builds before lane-floor cutover", () => {
+    const xml = `<rss><channel>${makeItem("2026.2.26", "202602260")}</channel></rss>`;
+
+    expect(collectAppcastSparkleVersionErrors(xml)).toEqual([]);
+  });
+
+  it("requires lane-floor builds on and after lane-floor cutover", () => {
+    const xml = `<rss><channel>${makeItem("2026.2.27", "202602270")}</channel></rss>`;
+
+    expect(collectAppcastSparkleVersionErrors(xml)).toEqual([
+      "appcast item '2026.2.27' has sparkle:version 202602270 below lane floor 2026022790.",
+    ]);
+  });
+
+  it("accepts canonical stable lane builds on and after lane-floor cutover", () => {
+    const xml = `<rss><channel>${makeItem("2026.2.27", "2026022790")}</channel></rss>`;
+
+    expect(collectAppcastSparkleVersionErrors(xml)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #688
**Commits**: 9 cherry-picked, 3 skipped

| Hash | Subject | Result |
|------|---------|--------|
| `46d9605ef` | merge-pr: use short squash merge banner | PICKED |
| `7237b4666` | macos: make default Sparkle build version monotonic | SKIPPED (fork uses TypeScript sparkle-build.ts) |
| `3be12b9fc` | release-check: validate appcast sparkle version floor | RESOLVED (rebrand + import merge) |
| `e4ee585b7` | release-check: align appcast floor with Sparkle build lanes | RESOLVED (rebrand + type merge) |
| `0332dce20` | macos: parse calver month/day as decimal for Sparkle build | SKIPPED (fork uses TypeScript sparkle-build.ts) |
| `84adedd1c` | macos: treat empty APP_BUILD as fallback | PICKED |
| `83698bf13` | fix(macos): derive canonical APP_BUILD after deps install | PICKED |
| `f29c642c1` | fix(release): enforce lane floor for calver appcast entries | RESOLVED (refactored to use shared sparkle-build.ts imports) |
| `26db298d3` | fix: sed escaping and UID mismatch in Podman Quadlet setup | RESOLVED (applied to rebranded remoteclaw.container.in + setup-podman.sh) |
| `79fcc8404` | Scripts: add openclaw driver mode to discord ACP smoke | SKIPPED (dev script deleted in fork) |
| `bdd59e014` | Scripts: add CLI startup benchmark harness | PICKED |
| `6c5633598` | fix(security): harden clawlog command execution | RESOLVED (CHANGELOG.md conflict) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)