### PR TITLE
Cherry-pick batch: Infrastructure, daemon, session routing, auto-reply, and misc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,14 @@ RUN if [ -n "$REMOTECLAW_INSTALL_BROWSER" ]; then \
 
 USER node
 COPY --chown=node:node . .
+# Normalize copied plugin/agent paths so plugin safety checks do not reject
+# world-writable directories inherited from source file modes.
+RUN for dir in /app/extensions /app/.agent /app/.agents; do \
+      if [ -d "$dir" ]; then \
+        find "$dir" -type d -exec chmod 755 {} +; \
+        find "$dir" -type f -exec chmod 644 {} +; \
+      fi; \
+    done
 RUN pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV REMOTECLAW_PREFER_PNPM=1

--- a/changelog/fragments/pr-5080.md
+++ b/changelog/fragments/pr-5080.md
@@ -1,0 +1,1 @@
+- Clarify block reply pipeline seen-check parameter naming for maintainability (#5080) (thanks @yassine20011)

--- a/extensions/synology-chat/src/channel.integration.test.ts
+++ b/extensions/synology-chat/src/channel.integration.test.ts
@@ -19,6 +19,11 @@ vi.mock("remoteclaw/plugin-sdk", async (importOriginal) => {
     setAccountEnabledInConfigSection: vi.fn((_opts: any) => ({})),
     registerPluginHttpRoute: registerPluginHttpRouteMock,
     buildChannelConfigSchema: vi.fn((schema: any) => ({ schema })),
+    createFixedWindowRateLimiter: vi.fn(() => ({
+      isRateLimited: vi.fn(() => false),
+      size: vi.fn(() => 0),
+      clear: vi.fn(),
+    })),
   };
 });
 

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -6,6 +6,11 @@ vi.mock("remoteclaw/plugin-sdk", () => ({
   setAccountEnabledInConfigSection: vi.fn((_opts: any) => ({})),
   registerPluginHttpRoute: vi.fn(() => vi.fn()),
   buildChannelConfigSchema: vi.fn((schema: any) => ({ schema })),
+  createFixedWindowRateLimiter: vi.fn(() => ({
+    isRateLimited: vi.fn(() => false),
+    size: vi.fn(() => 0),
+    clear: vi.fn(),
+  })),
 }));
 
 vi.mock("./client.js", () => ({

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "android:test": "cd apps/android && ./gradlew :app:testDebugUnitTest",
     "build": "pnpm canvas:a2ui:bundle && tsdown && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-export-html-templates.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-startup-metadata.ts && node --import tsx scripts/write-cli-compat.ts",
     "build:plugin-sdk:dts": "tsc -p tsconfig.plugin-sdk.dts.json",
+    "build:strict-smoke": "pnpm canvas:a2ui:bundle && tsdown && pnpm build:plugin-sdk:dts",
     "canvas:a2ui:bundle": "bash scripts/bundle-a2ui.sh",
     "check": "pnpm check:host-env-policy:swift && pnpm format:check && pnpm tsgo && pnpm lint && pnpm lint:tmp:no-random-messaging && pnpm lint:tmp:no-raw-channel-fetch && pnpm lint:auth:no-pairing-store-group && pnpm lint:auth:pairing-account-scope",
     "check:docs": "pnpm format:docs:check && pnpm lint:docs && pnpm docs:check-links",

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -12,6 +12,7 @@ import {
   listNativeCommandSpecsForConfig,
   normalizeCommandBody,
   parseCommandArgs,
+  resolveCommandArgChoices,
   resolveCommandArgMenu,
   serializeCommandArgs,
   shouldHandleTextCommands,
@@ -94,18 +95,54 @@ describe("commands registry", () => {
   });
 
   it("keeps discord native command specs within slash-command limits", () => {
-    const native = listNativeCommandSpecsForConfig(
-      { commands: { native: true } },
-      { provider: "discord" },
-    );
+    const cfg = { commands: { native: true } };
+    const native = listNativeCommandSpecsForConfig(cfg, { provider: "discord" });
     for (const spec of native) {
       expect(spec.name).toMatch(/^[a-z0-9_-]{1,32}$/);
       expect(spec.description.length).toBeGreaterThan(0);
       expect(spec.description.length).toBeLessThanOrEqual(100);
-      for (const arg of spec.args ?? []) {
+      expect(spec.args?.length ?? 0).toBeLessThanOrEqual(25);
+
+      const command = findCommandByNativeName(spec.name, "discord");
+      expect(command).toBeTruthy();
+
+      const args = command?.args ?? spec.args ?? [];
+      const argNames = new Set<string>();
+      let sawOptional = false;
+      for (const arg of args) {
+        expect(argNames.has(arg.name)).toBe(false);
+        argNames.add(arg.name);
+
+        const isRequired = arg.required ?? false;
+        if (!isRequired) {
+          sawOptional = true;
+        } else {
+          expect(sawOptional).toBe(false);
+        }
+
         expect(arg.name).toMatch(/^[a-z0-9_-]{1,32}$/);
         expect(arg.description.length).toBeGreaterThan(0);
         expect(arg.description.length).toBeLessThanOrEqual(100);
+
+        if (!command) {
+          continue;
+        }
+        const choices = resolveCommandArgChoices({
+          command,
+          arg,
+          cfg,
+          provider: "discord",
+        });
+        if (choices.length === 0) {
+          continue;
+        }
+        expect(choices.length).toBeLessThanOrEqual(25);
+        for (const choice of choices) {
+          expect(choice.label.length).toBeGreaterThan(0);
+          expect(choice.label.length).toBeLessThanOrEqual(100);
+          expect(choice.value.length).toBeGreaterThan(0);
+          expect(choice.value.length).toBeLessThanOrEqual(100);
+        }
       }
     }
   });

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -90,12 +90,12 @@ export function createBlockReplyPipeline(params: {
   let didStream = false;
   let didLogTimeout = false;
 
-  const sendPayload = (payload: ReplyPayload, skipSeen?: boolean) => {
+  const sendPayload = (payload: ReplyPayload, bypassSeenCheck: boolean = false) => {
     if (aborted) {
       return;
     }
     const payloadKey = createBlockReplyPayloadKey(payload);
-    if (!skipSeen) {
+    if (!bypassSeenCheck) {
       if (seenKeys.has(payloadKey)) {
         return;
       }
@@ -155,7 +155,7 @@ export function createBlockReplyPipeline(params: {
         shouldAbort: () => aborted,
         onFlush: (payload) => {
           bufferedKeys.clear();
-          sendPayload(payload);
+          sendPayload(payload, /* bypassSeenCheck */ true);
         },
       })
     : null;
@@ -186,7 +186,7 @@ export function createBlockReplyPipeline(params: {
     }
     for (const payload of bufferedPayloads) {
       const finalPayload = buffer?.finalize?.(payload) ?? payload;
-      sendPayload(finalPayload, true);
+      sendPayload(finalPayload, /* bypassSeenCheck */ true);
     }
     bufferedPayloads.length = 0;
     bufferedPayloadKeys.clear();
@@ -202,7 +202,7 @@ export function createBlockReplyPipeline(params: {
     const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
     if (hasMedia) {
       void coalescer?.flush({ force: true });
-      sendPayload(payload);
+      sendPayload(payload, /* bypassSeenCheck */ false);
       return;
     }
     if (coalescer) {
@@ -210,11 +210,12 @@ export function createBlockReplyPipeline(params: {
       if (seenKeys.has(payloadKey) || pendingKeys.has(payloadKey) || bufferedKeys.has(payloadKey)) {
         return;
       }
+      seenKeys.add(payloadKey);
       bufferedKeys.add(payloadKey);
       coalescer.enqueue(payload);
       return;
     }
-    sendPayload(payload);
+    sendPayload(payload, /* bypassSeenCheck */ false);
   };
 
   const flush = async (options?: { force?: boolean }) => {

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -114,10 +114,12 @@ export function createBlockReplyPipeline(params: {
           return false;
         }
         await withTimeout(
-          onBlockReply(payload, {
-            abortSignal: abortController.signal,
-            timeoutMs,
-          }) ?? Promise.resolve(),
+          Promise.resolve(
+            onBlockReply(payload, {
+              abortSignal: abortController.signal,
+              timeoutMs,
+            }),
+          ),
           timeoutMs,
           timeoutError,
         );

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -25,6 +25,7 @@ describe("buildInboundMetaSystemPrompt", () => {
       MessageSidFull: "123",
       ReplyToId: "99",
       OriginatingTo: "telegram:5494292670",
+      AccountId: " work ",
       OriginatingChannel: "telegram",
       Provider: "telegram",
       Surface: "telegram",
@@ -34,6 +35,7 @@ describe("buildInboundMetaSystemPrompt", () => {
     const payload = parseInboundMetaPayload(prompt);
     expect(payload["schema"]).toBe("remoteclaw.inbound_meta.v1");
     expect(payload["chat_id"]).toBe("telegram:5494292670");
+    expect(payload["account_id"]).toBe("work");
     expect(payload["channel"]).toBe("telegram");
   });
 

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -60,6 +60,7 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
   const payload = {
     schema: "remoteclaw.inbound_meta.v1",
     chat_id: safeTrim(ctx.OriginatingTo),
+    account_id: safeTrim(ctx.AccountId),
     channel: channelValue,
     provider: safeTrim(ctx.Provider),
     surface: safeTrim(ctx.Surface),

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -1,5 +1,5 @@
 import { sanitizeUserFacingText } from "../../agents/agent-helpers.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN, stripSilentToken } from "../tokens.js";
 import type { ReplyPayload } from "../types.js";
 import { hasLineDirectives, parseLineDirectives } from "./line-directives.js";
 import {
@@ -39,6 +39,16 @@ export function normalizeReplyPayload(
       return null;
     }
     text = "";
+  }
+  // Strip NO_REPLY from mixed-content messages (e.g. "😄 NO_REPLY") so the
+  // token never leaks to end users.  If stripping leaves nothing, treat it as
+  // silent just like the exact-match path above.  (#30916, #30955)
+  if (text && text.includes(silentToken) && !isSilentReplyText(text, silentToken)) {
+    text = stripSilentToken(text, silentToken);
+    if (!text && !hasMedia && !hasChannelData) {
+      opts.onSkip?.("silent");
+      return null;
+    }
   }
   if (text && !trimmed) {
     // Keep empty text when media exists so media-only replies still send.

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1341,13 +1341,50 @@ describe("initSessionState internal channel routing preservation", () => {
         Body: "internal follow-up",
         SessionKey: sessionKey,
         OriginatingChannel: "webchat",
+        OriginatingTo: "session:dashboard",
       },
       cfg,
       commandAuthorized: true,
     });
 
     expect(result.sessionEntry.lastChannel).toBe("telegram");
+    expect(result.sessionEntry.lastTo).toBe("group:12345");
     expect(result.sessionEntry.deliveryContext?.channel).toBe("telegram");
+    expect(result.sessionEntry.deliveryContext?.to).toBe("group:12345");
+  });
+
+  it("keeps persisted external route when OriginatingChannel is non-deliverable", async () => {
+    const storePath = await createStorePath("preserve-nondeliverable-route-");
+    const sessionKey = "agent:main:discord:channel:24680";
+    await saveSessionStore(storePath, {
+      [sessionKey]: {
+        sessionId: "sess-2",
+        updatedAt: Date.now(),
+        lastChannel: "discord",
+        lastTo: "channel:24680",
+        deliveryContext: {
+          channel: "discord",
+          to: "channel:24680",
+        },
+      },
+    });
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "internal handoff",
+        SessionKey: sessionKey,
+        OriginatingChannel: "sessions_send",
+        OriginatingTo: "session:handoff",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionEntry.lastChannel).toBe("discord");
+    expect(result.sessionEntry.lastTo).toBe("channel:24680");
+    expect(result.sessionEntry.deliveryContext?.channel).toBe("discord");
+    expect(result.sessionEntry.deliveryContext?.to).toBe("channel:24680");
   });
 
   it("uses session key channel hint when first turn is internal webchat", async () => {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1226,6 +1226,98 @@ describe("initSessionState stale threadId fallback", () => {
   });
 });
 
+describe("initSessionState dmScope delivery migration", () => {
+  it("retires stale main-session delivery route when dmScope uses per-channel DM keys", async () => {
+    const storePath = await createStorePath("dm-scope-retire-main-route-");
+    await saveSessionStore(storePath, {
+      "agent:main:main": {
+        sessionId: "legacy-main",
+        updatedAt: Date.now(),
+        lastChannel: "telegram",
+        lastTo: "6101296751",
+        lastAccountId: "default",
+        deliveryContext: {
+          channel: "telegram",
+          to: "6101296751",
+          accountId: "default",
+        },
+      },
+    });
+    const cfg = {
+      session: { store: storePath, dmScope: "per-channel-peer" },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "hello",
+        SessionKey: "agent:main:telegram:direct:6101296751",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "6101296751",
+        AccountId: "default",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionKey).toBe("agent:main:telegram:direct:6101296751");
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      SessionEntry
+    >;
+    expect(persisted["agent:main:main"]?.sessionId).toBe("legacy-main");
+    expect(persisted["agent:main:main"]?.deliveryContext).toBeUndefined();
+    expect(persisted["agent:main:main"]?.lastChannel).toBeUndefined();
+    expect(persisted["agent:main:main"]?.lastTo).toBeUndefined();
+    expect(persisted["agent:main:telegram:direct:6101296751"]?.deliveryContext?.to).toBe(
+      "6101296751",
+    );
+  });
+
+  it("keeps legacy main-session delivery route when current DM target does not match", async () => {
+    const storePath = await createStorePath("dm-scope-keep-main-route-");
+    await saveSessionStore(storePath, {
+      "agent:main:main": {
+        sessionId: "legacy-main",
+        updatedAt: Date.now(),
+        lastChannel: "telegram",
+        lastTo: "1111",
+        lastAccountId: "default",
+        deliveryContext: {
+          channel: "telegram",
+          to: "1111",
+          accountId: "default",
+        },
+      },
+    });
+    const cfg = {
+      session: { store: storePath, dmScope: "per-channel-peer" },
+    } as OpenClawConfig;
+
+    await initSessionState({
+      ctx: {
+        Body: "hello",
+        SessionKey: "agent:main:telegram:direct:6101296751",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "6101296751",
+        AccountId: "default",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      SessionEntry
+    >;
+    expect(persisted["agent:main:main"]?.deliveryContext).toEqual({
+      channel: "telegram",
+      to: "1111",
+      accountId: "default",
+    });
+    expect(persisted["agent:main:main"]?.lastTo).toBe("1111");
+  });
+});
+
 describe("initSessionState internal channel routing preservation", () => {
   it("keeps persisted external lastChannel when OriginatingChannel is internal webchat", async () => {
     const storePath = await createStorePath("preserve-external-channel-");

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RemoteClawConfig } from "../../config/config.js";
 import { saveSessionStore } from "../../config/sessions.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.ts";
 import { enqueueSystemEvent, resetSystemEventsForTest } from "../../infra/system-events.js";
 import { prependSystemEvents } from "./session-updates.js";
@@ -1245,7 +1246,7 @@ describe("initSessionState dmScope delivery migration", () => {
     });
     const cfg = {
       session: { store: storePath, dmScope: "per-channel-peer" },
-    } as OpenClawConfig;
+    } as RemoteClawConfig;
 
     const result = await initSessionState({
       ctx: {
@@ -1291,7 +1292,7 @@ describe("initSessionState dmScope delivery migration", () => {
     });
     const cfg = {
       session: { store: storePath, dmScope: "per-channel-peer" },
-    } as OpenClawConfig;
+    } as RemoteClawConfig;
 
     await initSessionState({
       ctx: {
@@ -1368,7 +1369,7 @@ describe("initSessionState internal channel routing preservation", () => {
         },
       },
     });
-    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const cfg = { session: { store: storePath } } as RemoteClawConfig;
 
     const result = await initSessionState({
       ctx: {
@@ -1408,7 +1409,7 @@ describe("initSessionState internal channel routing preservation", () => {
 
   it("keeps internal route when there is no persisted external fallback", async () => {
     const storePath = await createStorePath("no-external-fallback-");
-    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const cfg = { session: { store: storePath } } as RemoteClawConfig;
 
     const result = await initSessionState({
       ctx: {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1406,6 +1406,25 @@ describe("initSessionState internal channel routing preservation", () => {
     expect(result.sessionEntry.deliveryContext?.channel).toBe("telegram");
   });
 
+  it("keeps internal route when there is no persisted external fallback", async () => {
+    const storePath = await createStorePath("no-external-fallback-");
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "handoff only",
+        SessionKey: "agent:main:main",
+        OriginatingChannel: "sessions_send",
+        OriginatingTo: "session:handoff",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionEntry.lastChannel).toBe("sessions_send");
+    expect(result.sessionEntry.lastTo).toBe("session:handoff");
+  });
+
   it("keeps webchat channel for webchat/main sessions", async () => {
     const storePath = await createStorePath("preserve-webchat-main-");
     const cfg = { session: { store: storePath } } as RemoteClawConfig;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -30,9 +30,14 @@ import { archiveSessionTranscripts } from "../../gateway/session-utils.fs.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { normalizeMainKey } from "../../routing/session-key.js";
+import { buildAgentMainSessionKey, normalizeMainKey } from "../../routing/session-key.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
-import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.js";
+import {
+  deliveryContextFromSession,
+  deliveryContextKey,
+  normalizeDeliveryContext,
+  normalizeSessionDeliveryFields,
+} from "../../utils/delivery-context.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
   isDeliverableMessageChannel,
@@ -112,12 +117,78 @@ export type SessionInitResult = {
  */
 const DEFAULT_PARENT_FORK_MAX_TOKENS = 100_000;
 
+type LegacyMainDeliveryRetirement = {
+  key: string;
+  entry: SessionEntry;
+};
+
 function resolveParentForkMaxTokens(cfg: RemoteClawConfig): number {
   const configured = cfg.session?.parentForkMaxTokens;
   if (typeof configured === "number" && Number.isFinite(configured) && configured >= 0) {
     return Math.floor(configured);
   }
   return DEFAULT_PARENT_FORK_MAX_TOKENS;
+}
+
+function maybeRetireLegacyMainDeliveryRoute(params: {
+  sessionCfg: RemoteClawConfig["session"] | undefined;
+  sessionKey: string;
+  sessionStore: Record<string, SessionEntry>;
+  agentId: string;
+  mainKey: string;
+  isGroup: boolean;
+  ctx: MsgContext;
+}): LegacyMainDeliveryRetirement | undefined {
+  const dmScope = params.sessionCfg?.dmScope ?? "main";
+  if (dmScope === "main" || params.isGroup) {
+    return undefined;
+  }
+  const canonicalMainSessionKey = buildAgentMainSessionKey({
+    agentId: params.agentId,
+    mainKey: params.mainKey,
+  }).toLowerCase();
+  if (params.sessionKey === canonicalMainSessionKey) {
+    return undefined;
+  }
+  const legacyMain = params.sessionStore[canonicalMainSessionKey];
+  if (!legacyMain) {
+    return undefined;
+  }
+  const legacyRouteKey = deliveryContextKey(deliveryContextFromSession(legacyMain));
+  if (!legacyRouteKey) {
+    return undefined;
+  }
+  const activeDirectRouteKey = deliveryContextKey(
+    normalizeDeliveryContext({
+      channel: params.ctx.OriginatingChannel as string | undefined,
+      to: params.ctx.OriginatingTo || params.ctx.To,
+      accountId: params.ctx.AccountId,
+      threadId: params.ctx.MessageThreadId,
+    }),
+  );
+  if (!activeDirectRouteKey || activeDirectRouteKey !== legacyRouteKey) {
+    return undefined;
+  }
+  if (
+    legacyMain.deliveryContext === undefined &&
+    legacyMain.lastChannel === undefined &&
+    legacyMain.lastTo === undefined &&
+    legacyMain.lastAccountId === undefined &&
+    legacyMain.lastThreadId === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    key: canonicalMainSessionKey,
+    entry: {
+      ...legacyMain,
+      deliveryContext: undefined,
+      lastChannel: undefined,
+      lastTo: undefined,
+      lastAccountId: undefined,
+      lastThreadId: undefined,
+    },
+  };
 }
 
 function forkSessionFromParent(params: {
@@ -263,6 +334,18 @@ export async function initSessionState(params: {
   }
 
   sessionKey = resolveSessionKey(sessionScope, sessionCtxForState, mainKey);
+  const retiredLegacyMainDelivery = maybeRetireLegacyMainDeliveryRoute({
+    sessionCfg,
+    sessionKey,
+    sessionStore,
+    agentId,
+    mainKey,
+    isGroup,
+    ctx,
+  });
+  if (retiredLegacyMainDelivery) {
+    sessionStore[retiredLegacyMainDelivery.key] = retiredLegacyMainDelivery.entry;
+  }
   const entry = sessionStore[sessionKey];
   const previousSessionEntry = resetTriggered && entry ? { ...entry } : undefined;
   const now = Date.now();
@@ -457,6 +540,9 @@ export async function initSessionState(params: {
     (store) => {
       // Preserve per-session overrides while resetting compaction state on /new.
       store[sessionKey] = { ...store[sessionKey], ...sessionEntry };
+      if (retiredLegacyMainDelivery) {
+        store[retiredLegacyMainDelivery.key] = retiredLegacyMainDelivery.entry;
+      }
     },
     {
       activeSessionKey: sessionKey,

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -62,6 +62,12 @@ function resolveSessionKeyChannelHint(sessionKey?: string): string | undefined {
   return normalizeMessageChannel(head);
 }
 
+function isExternalRoutingChannel(channel?: string): channel is string {
+  return Boolean(
+    channel && channel !== INTERNAL_MESSAGE_CHANNEL && isDeliverableMessageChannel(channel),
+  );
+}
+
 function resolveLastChannelRaw(params: {
   originatingChannelRaw?: string;
   persistedLastChannel?: string;
@@ -71,24 +77,42 @@ function resolveLastChannelRaw(params: {
   const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);
   const sessionKeyChannelHint = resolveSessionKeyChannelHint(params.sessionKey);
   let resolved = params.originatingChannelRaw || params.persistedLastChannel;
-  // Internal webchat/system turns should not overwrite previously known external
-  // delivery routes (or explicit channel hints encoded in the session key).
-  if (originatingChannel === INTERNAL_MESSAGE_CHANNEL) {
-    if (
-      persistedChannel &&
-      persistedChannel !== INTERNAL_MESSAGE_CHANNEL &&
-      isDeliverableMessageChannel(persistedChannel)
-    ) {
+  // Internal/non-deliverable sources should not overwrite previously known
+  // external delivery routes (or explicit channel hints from the session key).
+  if (!isExternalRoutingChannel(originatingChannel)) {
+    if (isExternalRoutingChannel(persistedChannel)) {
       resolved = persistedChannel;
-    } else if (
-      sessionKeyChannelHint &&
-      sessionKeyChannelHint !== INTERNAL_MESSAGE_CHANNEL &&
-      isDeliverableMessageChannel(sessionKeyChannelHint)
-    ) {
+    } else if (isExternalRoutingChannel(sessionKeyChannelHint)) {
       resolved = sessionKeyChannelHint;
     }
   }
   return resolved;
+}
+
+function resolveLastToRaw(params: {
+  originatingChannelRaw?: string;
+  originatingToRaw?: string;
+  toRaw?: string;
+  persistedLastTo?: string;
+  persistedLastChannel?: string;
+  sessionKey?: string;
+}): string | undefined {
+  const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
+  const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);
+  const sessionKeyChannelHint = resolveSessionKeyChannelHint(params.sessionKey);
+
+  // When the turn originates from an internal/non-deliverable source, do not
+  // replace an established external destination with internal routing ids
+  // (e.g., session/webchat ids).
+  if (!isExternalRoutingChannel(originatingChannel)) {
+    const hasExternalFallback =
+      isExternalRoutingChannel(persistedChannel) || isExternalRoutingChannel(sessionKeyChannelHint);
+    if (hasExternalFallback && params.persistedLastTo) {
+      return params.persistedLastTo;
+    }
+  }
+
+  return params.originatingToRaw || params.toRaw || params.persistedLastTo;
 }
 
 export type SessionInitResult = {
@@ -408,7 +432,14 @@ export async function initSessionState(params: {
     persistedLastChannel: baseEntry?.lastChannel,
     sessionKey,
   });
-  const lastToRaw = ctx.OriginatingTo || ctx.To || baseEntry?.lastTo;
+  const lastToRaw = resolveLastToRaw({
+    originatingChannelRaw,
+    originatingToRaw: ctx.OriginatingTo,
+    toRaw: ctx.To,
+    persistedLastTo: baseEntry?.lastTo,
+    persistedLastChannel: baseEntry?.lastChannel,
+    sessionKey,
+  });
   const lastAccountIdRaw = ctx.AccountId || baseEntry?.lastAccountId;
   // Only fall back to persisted threadId for thread sessions.  Non-thread
   // sessions (e.g. DM without topics) must not inherit a stale threadId from a

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isSilentReplyPrefixText, isSilentReplyText } from "./tokens.js";
+import { isSilentReplyPrefixText, isSilentReplyText, stripSilentToken } from "./tokens.js";
 
 describe("isSilentReplyText", () => {
   it("returns true for exact token", () => {
@@ -33,6 +33,37 @@ describe("isSilentReplyText", () => {
   it("works with custom token", () => {
     expect(isSilentReplyText("HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(true);
     expect(isSilentReplyText("Checked inbox. HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(false);
+  });
+});
+
+describe("stripSilentToken", () => {
+  it("strips token from end of text", () => {
+    expect(stripSilentToken("Done.\n\nNO_REPLY")).toBe("Done.");
+  });
+
+  it("does not strip token from start of text", () => {
+    expect(stripSilentToken("NO_REPLY 👍")).toBe("NO_REPLY 👍");
+  });
+
+  it("strips token with emoji (#30916)", () => {
+    expect(stripSilentToken("😄 NO_REPLY")).toBe("😄");
+  });
+
+  it("does not strip embedded token suffix without whitespace delimiter", () => {
+    expect(stripSilentToken("interject.NO_REPLY")).toBe("interject.NO_REPLY");
+  });
+
+  it("strips only trailing occurrence", () => {
+    expect(stripSilentToken("NO_REPLY ok NO_REPLY")).toBe("NO_REPLY ok");
+  });
+
+  it("returns empty string when only token remains", () => {
+    expect(stripSilentToken("NO_REPLY")).toBe("");
+    expect(stripSilentToken("  NO_REPLY  ")).toBe("");
+  });
+
+  it("works with custom token", () => {
+    expect(stripSilentToken("done HEARTBEAT_OK", "HEARTBEAT_OK")).toBe("done");
   });
 });
 

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -17,6 +17,16 @@ export function isSilentReplyText(
   return new RegExp(`^\\s*${escaped}\\s*$`).test(text);
 }
 
+/**
+ * Strip a trailing silent reply token from mixed-content text.
+ * Returns the remaining text with the token removed (trimmed).
+ * If the result is empty, the entire message should be treated as silent.
+ */
+export function stripSilentToken(text: string, token: string = SILENT_REPLY_TOKEN): string {
+  const escaped = escapeRegExp(token);
+  return text.replace(new RegExp(`(?:^|\\s+)${escaped}\\s*$`), "").trim();
+}
+
 export function isSilentReplyPrefixText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,

--- a/src/daemon/launchd-plist.ts
+++ b/src/daemon/launchd-plist.ts
@@ -1,5 +1,10 @@
 import fs from "node:fs/promises";
 
+// launchd applies ThrottleInterval to any rapid relaunch, including
+// intentional gateway restarts. Keep it low so CLI restarts and forced
+// reinstalls do not stall for a full minute.
+export const LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS = 1;
+
 const plistEscape = (value: string): string =>
   value
     .replaceAll("&", "&amp;")
@@ -106,5 +111,5 @@ export function buildLaunchAgentPlist({
     ? `\n    <key>Comment</key>\n    <string>${plistEscape(comment.trim())}</string>`
     : "";
   const envXml = renderEnvDict(environment);
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>ThrottleInterval</key>\n    <integer>60</integer>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>ThrottleInterval</key>\n    <integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
 }

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1,5 +1,6 @@
 import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS } from "./launchd-plist.js";
 import {
   installLaunchAgent,
   isLaunchAgentListed,
@@ -199,7 +200,7 @@ describe("launchd install", () => {
     expect(plist).toContain("<true/>");
     expect(plist).not.toContain("<key>SuccessfulExit</key>");
     expect(plist).toContain("<key>ThrottleInterval</key>");
-    expect(plist).toContain("<integer>60</integer>");
+    expect(plist).toContain(`<integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>`);
   });
 
   it("restarts LaunchAgent with bootout-bootstrap-kickstart order", async () => {

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -365,6 +365,42 @@ describe("buildNodeServiceEnvironment", () => {
     expect(env.HOME).toBe("/home/user");
   });
 
+  it("passes through REMOTECLAW_GATEWAY_TOKEN for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user", REMOTECLAW_GATEWAY_TOKEN: " node-token " },
+    });
+    expect(env.REMOTECLAW_GATEWAY_TOKEN).toBe("node-token");
+  });
+
+  it("maps legacy CLAWDBOT_GATEWAY_TOKEN to REMOTECLAW_GATEWAY_TOKEN for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user", CLAWDBOT_GATEWAY_TOKEN: " legacy-token " },
+    });
+    expect(env.REMOTECLAW_GATEWAY_TOKEN).toBe("legacy-token");
+  });
+
+  it("prefers REMOTECLAW_GATEWAY_TOKEN over legacy CLAWDBOT_GATEWAY_TOKEN", () => {
+    const env = buildNodeServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+        REMOTECLAW_GATEWAY_TOKEN: "remoteclaw-token",
+        CLAWDBOT_GATEWAY_TOKEN: "legacy-token",
+      },
+    });
+    expect(env.REMOTECLAW_GATEWAY_TOKEN).toBe("remoteclaw-token");
+  });
+
+  it("omits REMOTECLAW_GATEWAY_TOKEN when both token env vars are empty", () => {
+    const env = buildNodeServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+        REMOTECLAW_GATEWAY_TOKEN: "   ",
+        CLAWDBOT_GATEWAY_TOKEN: " ",
+      },
+    });
+    expect(env.REMOTECLAW_GATEWAY_TOKEN).toBeUndefined();
+  });
+
   it("forwards proxy environment variables for node services", () => {
     const env = buildNodeServiceEnvironment({
       env: {

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -279,6 +279,8 @@ export function buildNodeServiceEnvironment(params: {
 }): Record<string, string | undefined> {
   const { env } = params;
   const platform = params.platform ?? process.platform;
+  const gatewayToken =
+    env.REMOTECLAW_GATEWAY_TOKEN?.trim() || env.CLAWDBOT_GATEWAY_TOKEN?.trim() || undefined;
   const stateDir = env.REMOTECLAW_STATE_DIR;
   const configPath = env.REMOTECLAW_CONFIG_PATH;
   const tmpDir = env.TMPDIR?.trim() || os.tmpdir();
@@ -296,6 +298,7 @@ export function buildNodeServiceEnvironment(params: {
     NODE_EXTRA_CA_CERTS: nodeCaCerts,
     REMOTECLAW_STATE_DIR: stateDir,
     REMOTECLAW_CONFIG_PATH: configPath,
+    REMOTECLAW_GATEWAY_TOKEN: gatewayToken,
     REMOTECLAW_LAUNCHD_LABEL: resolveNodeLaunchAgentLabel(),
     REMOTECLAW_SYSTEMD_UNIT: resolveNodeSystemdServiceName(),
     REMOTECLAW_WINDOWS_TASK_NAME: resolveNodeWindowsTaskName(),

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -20,4 +20,11 @@ describe("Dockerfile", () => {
     );
     expect(dockerfile).toContain("apt-get install -y --no-install-recommends xvfb");
   });
+
+  it("normalizes plugin and agent paths permissions in image layers", async () => {
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+    expect(dockerfile).toContain("for dir in /app/extensions /app/.agent /app/.agents");
+    expect(dockerfile).toContain('find "$dir" -type d -exec chmod 755 {} +');
+    expect(dockerfile).toContain('find "$dir" -type f -exec chmod 644 {} +');
+  });
 });

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -126,7 +126,7 @@ describe("tilde expansion in file tools", () => {
   });
 
   it("reads a file via ~/path after HOME override", async () => {
-    const root = await tempDirs.make("openclaw-tilde-test-");
+    const root = await tempDirs.make("remoteclaw-tilde-test-");
     const originalHome = process.env.HOME;
     process.env.HOME = root;
     try {
@@ -144,25 +144,8 @@ describe("tilde expansion in file tools", () => {
     }
   });
 
-  it("writes a file via ~/path after HOME override", async () => {
-    const root = await tempDirs.make("openclaw-tilde-test-");
-    const originalHome = process.env.HOME;
-    process.env.HOME = root;
-    try {
-      await writeFileWithinRoot({
-        rootDir: root,
-        relativePath: "~/output.txt",
-        data: "tilde-write-works",
-      });
-      const content = await fs.readFile(path.join(root, "output.txt"), "utf8");
-      expect(content).toBe("tilde-write-works");
-    } finally {
-      process.env.HOME = originalHome;
-    }
-  });
-
   it("rejects ~/path that resolves outside root", async () => {
-    const root = await tempDirs.make("openclaw-tilde-outside-");
+    const root = await tempDirs.make("remoteclaw-tilde-outside-");
     // HOME points to real home, ~/file goes to /home/dev/file which is outside root
     await expect(
       openFileWithinRoot({

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -65,6 +65,22 @@ describe("fs-safe", () => {
     ).rejects.toMatchObject({ code: "outside-workspace" });
   });
 
+  it("rejects directory path within root without leaking EISDIR (issue #31186)", async () => {
+    const root = await tempDirs.make("remoteclaw-fs-safe-root-");
+    await fs.mkdir(path.join(root, "memory"), { recursive: true });
+
+    await expect(
+      openFileWithinRoot({ rootDir: root, relativePath: "memory" }),
+    ).rejects.toMatchObject({ code: expect.stringMatching(/invalid-path|not-file/) });
+
+    const err = await openFileWithinRoot({
+      rootDir: root,
+      relativePath: "memory",
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(SafeOpenError);
+    expect((err as SafeOpenError).message).not.toMatch(/EISDIR/i);
+  });
+
   it.runIf(process.platform !== "win32")("blocks symlink escapes under root", async () => {
     const root = await tempDirs.make("remoteclaw-fs-safe-root-");
     const outside = await tempDirs.make("remoteclaw-fs-safe-outside-");

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -100,7 +100,7 @@ describe("tilde expansion in file tools", () => {
     process.env.HOME = fakeHome;
     try {
       const result = expandHomePrefix("~/file.txt");
-      expect(result).toBe(`${fakeHome}/file.txt`);
+      expect(path.normalize(result)).toBe(path.join(path.resolve(fakeHome), "file.txt"));
     } finally {
       process.env.HOME = originalHome;
     }

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -27,6 +27,9 @@ describe("fs-safe", () => {
     await expect(readLocalFileSafely({ filePath: dir })).rejects.toMatchObject({
       code: "not-file",
     });
+    const err = await readLocalFileSafely({ filePath: dir }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(SafeOpenError);
+    expect((err as SafeOpenError).message).not.toMatch(/EISDIR/i);
   });
 
   it("enforces maxBytes", async () => {

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -91,3 +91,67 @@ describe("fs-safe", () => {
     });
   });
 });
+
+describe("tilde expansion in file tools", () => {
+  it("expandHomePrefix respects process.env.HOME changes", async () => {
+    const { expandHomePrefix } = await import("./home-dir.js");
+    const originalHome = process.env.HOME;
+    const fakeHome = "/tmp/fake-home-test";
+    process.env.HOME = fakeHome;
+    try {
+      const result = expandHomePrefix("~/file.txt");
+      expect(result).toBe(`${fakeHome}/file.txt`);
+    } finally {
+      process.env.HOME = originalHome;
+    }
+  });
+
+  it("reads a file via ~/path after HOME override", async () => {
+    const root = await tempDirs.make("openclaw-tilde-test-");
+    const originalHome = process.env.HOME;
+    process.env.HOME = root;
+    try {
+      await fs.writeFile(path.join(root, "hello.txt"), "tilde-works");
+      const result = await openFileWithinRoot({
+        rootDir: root,
+        relativePath: "~/hello.txt",
+      });
+      const buf = Buffer.alloc(result.stat.size);
+      await result.handle.read(buf, 0, buf.length, 0);
+      await result.handle.close();
+      expect(buf.toString("utf8")).toBe("tilde-works");
+    } finally {
+      process.env.HOME = originalHome;
+    }
+  });
+
+  it("writes a file via ~/path after HOME override", async () => {
+    const root = await tempDirs.make("openclaw-tilde-test-");
+    const originalHome = process.env.HOME;
+    process.env.HOME = root;
+    try {
+      await writeFileWithinRoot({
+        rootDir: root,
+        relativePath: "~/output.txt",
+        data: "tilde-write-works",
+      });
+      const content = await fs.readFile(path.join(root, "output.txt"), "utf8");
+      expect(content).toBe("tilde-write-works");
+    } finally {
+      process.env.HOME = originalHome;
+    }
+  });
+
+  it("rejects ~/path that resolves outside root", async () => {
+    const root = await tempDirs.make("openclaw-tilde-outside-");
+    // HOME points to real home, ~/file goes to /home/dev/file which is outside root
+    await expect(
+      openFileWithinRoot({
+        rootDir: root,
+        relativePath: "~/escape.txt",
+      }),
+    ).rejects.toMatchObject({
+      code: expect.stringMatching(/outside-workspace|not-found|invalid-path/),
+    });
+  });
+});

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -6,7 +6,12 @@ import os from "node:os";
 import path from "node:path";
 import { sameFileIdentity } from "./file-identity.js";
 import { expandHomePrefix } from "./home-dir.js";
-import { isNotFoundPathError, isPathInside, isSymlinkOpenError } from "./path-guards.js";
+import {
+  hasNodeErrorCode,
+  isNotFoundPathError,
+  isPathInside,
+  isSymlinkOpenError,
+} from "./path-guards.js";
 
 export type SafeOpenErrorCode =
   | "invalid-path"
@@ -55,6 +60,20 @@ async function expandRelativePathWithHome(relativePath: string): Promise<string>
 }
 
 async function openVerifiedLocalFile(filePath: string): Promise<SafeOpenResult> {
+  // Reject directories before opening so we never surface EISDIR to callers (e.g. tool
+  // results that get sent to messaging channels). See openclaw/openclaw#31186.
+  try {
+    const preStat = await fs.lstat(filePath);
+    if (preStat.isDirectory()) {
+      throw new SafeOpenError("not-file", "not a file");
+    }
+  } catch (err) {
+    if (err instanceof SafeOpenError) {
+      throw err;
+    }
+    // ENOENT and other lstat errors: fall through and let fs.open handle.
+  }
+
   let handle: FileHandle;
   try {
     handle = await fs.open(filePath, OPEN_READ_FLAGS);
@@ -64,6 +83,10 @@ async function openVerifiedLocalFile(filePath: string): Promise<SafeOpenResult> 
     }
     if (isSymlinkOpenError(err)) {
       throw new SafeOpenError("symlink", "symlink open blocked", { cause: err });
+    }
+    // Defensive: if open still throws EISDIR (e.g. race), sanitize so it never leaks.
+    if (hasNodeErrorCode(err, "EISDIR")) {
+      throw new SafeOpenError("not-file", "not a file");
     }
     throw err;
   }

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -2,8 +2,10 @@ import type { Stats } from "node:fs";
 import { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { sameFileIdentity } from "./file-identity.js";
+import { expandHomePrefix } from "./home-dir.js";
 import { isNotFoundPathError, isPathInside, isSymlinkOpenError } from "./path-guards.js";
 
 export type SafeOpenErrorCode =
@@ -41,6 +43,16 @@ const SUPPORTS_NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in fsCons
 const OPEN_READ_FLAGS = fsConstants.O_RDONLY | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
 
 const ensureTrailingSep = (value: string) => (value.endsWith(path.sep) ? value : value + path.sep);
+
+async function expandRelativePathWithHome(relativePath: string): Promise<string> {
+  let home = process.env.HOME || process.env.USERPROFILE || os.homedir();
+  try {
+    home = await fs.realpath(home);
+  } catch {
+    // If the home dir cannot be canonicalized, keep lexical expansion behavior.
+  }
+  return expandHomePrefix(relativePath, { home });
+}
 
 async function openVerifiedLocalFile(filePath: string): Promise<SafeOpenResult> {
   let handle: FileHandle;
@@ -101,7 +113,8 @@ export async function openFileWithinRoot(params: {
     throw err;
   }
   const rootWithSep = ensureTrailingSep(rootReal);
-  const resolved = path.resolve(rootWithSep, params.relativePath);
+  const expanded = await expandRelativePathWithHome(params.relativePath);
+  const resolved = path.resolve(rootWithSep, expanded);
   if (!isPathInside(rootWithSep, resolved)) {
     throw new SafeOpenError("outside-workspace", "file is outside workspace root");
   }

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -784,7 +784,7 @@ function resolveTlonSession(
 
 /**
  * Feishu ID formats:
- * - oc_xxx: chat_id (group chat)
+ * - oc_xxx: chat_id (can be group or DM, use chat_mode to distinguish or explicit dm:/group: prefix)
  * - ou_xxx: user open_id (DM)
  * - on_xxx: user union_id (DM)
  * - cli_xxx: app_id (not a valid send target)
@@ -800,20 +800,27 @@ function resolveFeishuSession(
 
   const lower = trimmed.toLowerCase();
   let isGroup = false;
+  let typeExplicit = false;
 
   if (lower.startsWith("group:") || lower.startsWith("chat:")) {
     trimmed = trimmed.replace(/^(group|chat):/i, "").trim();
     isGroup = true;
+    typeExplicit = true;
   } else if (lower.startsWith("user:") || lower.startsWith("dm:")) {
     trimmed = trimmed.replace(/^(user|dm):/i, "").trim();
     isGroup = false;
+    typeExplicit = true;
   }
 
   const idLower = trimmed.toLowerCase();
-  if (idLower.startsWith("oc_")) {
-    isGroup = true;
-  } else if (idLower.startsWith("ou_") || idLower.startsWith("on_")) {
-    isGroup = false;
+  // Only infer type from ID prefix if not explicitly specified
+  // Note: oc_ is a chat_id and can be either group or DM (must check chat_mode from API)
+  // Only ou_/on_ can be reliably identified as user IDs (always DM)
+  if (!typeExplicit) {
+    if (idLower.startsWith("ou_") || idLower.startsWith("on_")) {
+      isGroup = false;
+    }
+    // oc_ requires explicit prefix: dm:oc_xxx or group:oc_xxx
   }
 
   const peer: RoutePeer = {

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -988,6 +988,42 @@ describe("resolveOutboundSessionRoute", () => {
           from: "slack:group:G123",
         },
       },
+      {
+        name: "Feishu explicit group prefix keeps group routing",
+        cfg: baseConfig,
+        channel: "feishu",
+        target: "group:oc_group_chat",
+        expected: {
+          sessionKey: "agent:main:feishu:group:oc_group_chat",
+          from: "feishu:group:oc_group_chat",
+          to: "oc_group_chat",
+          chatType: "group",
+        },
+      },
+      {
+        name: "Feishu explicit dm prefix keeps direct routing",
+        cfg: perChannelPeerCfg,
+        channel: "feishu",
+        target: "dm:oc_dm_chat",
+        expected: {
+          sessionKey: "agent:main:feishu:direct:oc_dm_chat",
+          from: "feishu:oc_dm_chat",
+          to: "oc_dm_chat",
+          chatType: "direct",
+        },
+      },
+      {
+        name: "Feishu bare oc_ target defaults to direct routing",
+        cfg: perChannelPeerCfg,
+        channel: "feishu",
+        target: "oc_ambiguous_chat",
+        expected: {
+          sessionKey: "agent:main:feishu:direct:oc_ambiguous_chat",
+          from: "feishu:oc_ambiguous_chat",
+          to: "oc_ambiguous_chat",
+          chatType: "direct",
+        },
+      },
     ];
 
     for (const testCase of cases) {

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -13,12 +13,26 @@ import { restartGatewayProcessWithFreshPid } from "./process-respawn.js";
 const originalArgv = [...process.argv];
 const originalExecArgv = [...process.execArgv];
 const envSnapshot = captureFullEnv();
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+function setPlatform(platform: string) {
+  if (!originalPlatformDescriptor) {
+    return;
+  }
+  Object.defineProperty(process, "platform", {
+    ...originalPlatformDescriptor,
+    value: platform,
+  });
+}
 
 afterEach(() => {
   envSnapshot.restore();
   process.argv = [...originalArgv];
   process.execArgv = [...originalExecArgv];
   spawnMock.mockClear();
+  if (originalPlatformDescriptor) {
+    Object.defineProperty(process, "platform", originalPlatformDescriptor);
+  }
 });
 
 function clearSupervisorHints() {
@@ -38,6 +52,53 @@ describe("restartGatewayProcessWithFreshPid", () => {
   it("returns supervised when launchd/systemd hints are present", () => {
     process.env.LAUNCH_JOB_LABEL = "org.remoteclaw.gateway";
     const result = restartGatewayProcessWithFreshPid();
+    expect(result.mode).toBe("supervised");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("schedules detached launchctl kickstart on macOS when launchd label is set", () => {
+    setPlatform("darwin");
+    process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    const unrefMock = vi.fn();
+    spawnMock.mockReturnValue({ unref: unrefMock, on: vi.fn() });
+
+    const result = restartGatewayProcessWithFreshPid();
+
+    expect(result.mode).toBe("supervised");
+    expect(spawnMock).toHaveBeenCalledWith(
+      "launchctl",
+      ["kickstart", "-k", expect.stringContaining("ai.openclaw.gateway")],
+      expect.objectContaining({ detached: true, stdio: "ignore" }),
+    );
+    expect(unrefMock).toHaveBeenCalledOnce();
+  });
+
+  it("still returns supervised even if kickstart spawn throws", () => {
+    setPlatform("darwin");
+    process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    spawnMock.mockImplementation((...args: unknown[]) => {
+      const [cmd] = args as [string];
+      if (cmd === "launchctl") {
+        throw new Error("spawn failed");
+      }
+      return { unref: vi.fn(), on: vi.fn() };
+    });
+
+    const result = restartGatewayProcessWithFreshPid();
+
+    // Kickstart is best-effort; failure should not block supervised exit
+    expect(result.mode).toBe("supervised");
+  });
+
+  it("does not schedule kickstart on non-darwin platforms", () => {
+    setPlatform("linux");
+    process.env.INVOCATION_ID = "abc123";
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+
+    const result = restartGatewayProcessWithFreshPid();
+
     expect(result.mode).toBe("supervised");
     expect(spawnMock).not.toHaveBeenCalled();
   });
@@ -64,10 +125,18 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("returns supervised when REMOTECLAW_LAUNCHD_LABEL is set (stock launchd plist)", () => {
     clearSupervisorHints();
+    setPlatform("darwin");
     process.env.REMOTECLAW_LAUNCHD_LABEL = "ai.remoteclaw.gateway";
+    const unrefMock = vi.fn();
+    spawnMock.mockReturnValue({ unref: unrefMock, on: vi.fn() });
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
-    expect(spawnMock).not.toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalledWith(
+      "launchctl",
+      expect.arrayContaining(["kickstart", "-k"]),
+      expect.objectContaining({ detached: true }),
+    );
+    expect(unrefMock).toHaveBeenCalledOnce();
   });
 
   it("returns supervised when REMOTECLAW_SYSTEMD_UNIT is set", () => {

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -3,9 +3,13 @@ import { captureFullEnv } from "../test-utils/env.js";
 import { SUPERVISOR_HINT_ENV_VARS } from "./supervisor-markers.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const triggerRemoteClawRestartMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", () => ({
   spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+vi.mock("./restart.js", () => ({
+  triggerRemoteClawRestart: (...args: unknown[]) => triggerRemoteClawRestartMock(...args),
 }));
 
 import { restartGatewayProcessWithFreshPid } from "./process-respawn.js";
@@ -30,6 +34,7 @@ afterEach(() => {
   process.argv = [...originalArgv];
   process.execArgv = [...originalExecArgv];
   spawnMock.mockClear();
+  triggerRemoteClawRestartMock.mockClear();
   if (originalPlatformDescriptor) {
     Object.defineProperty(process, "platform", originalPlatformDescriptor);
   }
@@ -56,50 +61,44 @@ describe("restartGatewayProcessWithFreshPid", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  it("schedules detached launchctl kickstart on macOS when launchd label is set", () => {
+  it("runs launchd kickstart helper on macOS when launchd label is set", () => {
     setPlatform("darwin");
-    process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
-    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-    const unrefMock = vi.fn();
-    spawnMock.mockReturnValue({ unref: unrefMock, on: vi.fn() });
+    process.env.LAUNCH_JOB_LABEL = "ai.remoteclaw.gateway";
+    process.env.REMOTECLAW_LAUNCHD_LABEL = "ai.remoteclaw.gateway";
+    triggerRemoteClawRestartMock.mockReturnValue({ ok: true, method: "launchctl" });
 
     const result = restartGatewayProcessWithFreshPid();
 
     expect(result.mode).toBe("supervised");
-    expect(spawnMock).toHaveBeenCalledWith(
-      "launchctl",
-      ["kickstart", "-k", expect.stringContaining("ai.openclaw.gateway")],
-      expect.objectContaining({ detached: true, stdio: "ignore" }),
-    );
-    expect(unrefMock).toHaveBeenCalledOnce();
+    expect(triggerRemoteClawRestartMock).toHaveBeenCalledOnce();
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  it("still returns supervised even if kickstart spawn throws", () => {
+  it("returns failed when launchd kickstart helper fails", () => {
     setPlatform("darwin");
-    process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
-    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-    spawnMock.mockImplementation((...args: unknown[]) => {
-      const [cmd] = args as [string];
-      if (cmd === "launchctl") {
-        throw new Error("spawn failed");
-      }
-      return { unref: vi.fn(), on: vi.fn() };
+    process.env.LAUNCH_JOB_LABEL = "ai.remoteclaw.gateway";
+    process.env.REMOTECLAW_LAUNCHD_LABEL = "ai.remoteclaw.gateway";
+    triggerRemoteClawRestartMock.mockReturnValue({
+      ok: false,
+      method: "launchctl",
+      detail: "spawn failed",
     });
 
     const result = restartGatewayProcessWithFreshPid();
 
-    // Kickstart is best-effort; failure should not block supervised exit
-    expect(result.mode).toBe("supervised");
+    expect(result.mode).toBe("failed");
+    expect(result.detail).toContain("spawn failed");
   });
 
   it("does not schedule kickstart on non-darwin platforms", () => {
     setPlatform("linux");
     process.env.INVOCATION_ID = "abc123";
-    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    process.env.REMOTECLAW_LAUNCHD_LABEL = "ai.remoteclaw.gateway";
 
     const result = restartGatewayProcessWithFreshPid();
 
     expect(result.mode).toBe("supervised");
+    expect(triggerRemoteClawRestartMock).not.toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
@@ -127,16 +126,11 @@ describe("restartGatewayProcessWithFreshPid", () => {
     clearSupervisorHints();
     setPlatform("darwin");
     process.env.REMOTECLAW_LAUNCHD_LABEL = "ai.remoteclaw.gateway";
-    const unrefMock = vi.fn();
-    spawnMock.mockReturnValue({ unref: unrefMock, on: vi.fn() });
+    triggerRemoteClawRestartMock.mockReturnValue({ ok: true, method: "launchctl" });
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
-    expect(spawnMock).toHaveBeenCalledWith(
-      "launchctl",
-      expect.arrayContaining(["kickstart", "-k"]),
-      expect.objectContaining({ detached: true }),
-    );
-    expect(unrefMock).toHaveBeenCalledOnce();
+    expect(triggerRemoteClawRestartMock).toHaveBeenCalledOnce();
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 
   it("returns supervised when REMOTECLAW_SYSTEMD_UNIT is set", () => {

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { triggerRemoteClawRestart } from "./restart.js";
 import { hasSupervisorHint } from "./supervisor-markers.js";
 
 type RespawnMode = "spawned" | "supervised" | "disabled" | "failed";
@@ -22,29 +23,6 @@ function isLikelySupervisedProcess(env: NodeJS.ProcessEnv = process.env): boolea
 }
 
 /**
- * Spawn a detached `launchctl kickstart -k` to force an immediate launchd
- * restart, bypassing ThrottleInterval.  The -k flag sends SIGTERM to the
- * current process, so this MUST be non-blocking (spawn, not spawnSync) to
- * avoid deadlocking — the gateway needs to be free to handle the signal
- * and exit so launchd can start the replacement.
- */
-function schedulelaunchdKickstart(label: string): boolean {
-  const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
-  const target = uid !== undefined ? `gui/${uid}/${label}` : label;
-  try {
-    const child = spawn("launchctl", ["kickstart", "-k", target], {
-      detached: true,
-      stdio: "ignore",
-    });
-    child.on("error", () => {}); // best-effort; suppress uncaught error event
-    child.unref();
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Attempt to restart this process with a fresh PID.
  * - supervised environments (launchd/systemd): caller should exit and let supervisor restart
  * - REMOTECLAW_NO_RESPAWN=1: caller should keep in-process restart behavior (tests/dev)
@@ -55,10 +33,16 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
     return { mode: "disabled" };
   }
   if (isLikelySupervisedProcess(process.env)) {
-    // On macOS under launchd, fire a detached kickstart so launchd restarts
-    // us immediately instead of waiting for ThrottleInterval (up to 60s).
-    if (process.platform === "darwin" && process.env.OPENCLAW_LAUNCHD_LABEL?.trim()) {
-      schedulelaunchdKickstart(process.env.OPENCLAW_LAUNCHD_LABEL.trim());
+    // On macOS under launchd, actively kickstart the supervised service to
+    // bypass ThrottleInterval delays for intentional restarts.
+    if (process.platform === "darwin" && process.env.REMOTECLAW_LAUNCHD_LABEL?.trim()) {
+      const restart = triggerRemoteClawRestart();
+      if (!restart.ok) {
+        return {
+          mode: "failed",
+          detail: restart.detail ?? "launchctl kickstart failed",
+        };
+      }
     }
     return { mode: "supervised" };
   }

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -22,6 +22,29 @@ function isLikelySupervisedProcess(env: NodeJS.ProcessEnv = process.env): boolea
 }
 
 /**
+ * Spawn a detached `launchctl kickstart -k` to force an immediate launchd
+ * restart, bypassing ThrottleInterval.  The -k flag sends SIGTERM to the
+ * current process, so this MUST be non-blocking (spawn, not spawnSync) to
+ * avoid deadlocking — the gateway needs to be free to handle the signal
+ * and exit so launchd can start the replacement.
+ */
+function schedulelaunchdKickstart(label: string): boolean {
+  const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
+  const target = uid !== undefined ? `gui/${uid}/${label}` : label;
+  try {
+    const child = spawn("launchctl", ["kickstart", "-k", target], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.on("error", () => {}); // best-effort; suppress uncaught error event
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Attempt to restart this process with a fresh PID.
  * - supervised environments (launchd/systemd): caller should exit and let supervisor restart
  * - REMOTECLAW_NO_RESPAWN=1: caller should keep in-process restart behavior (tests/dev)
@@ -32,6 +55,11 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
     return { mode: "disabled" };
   }
   if (isLikelySupervisedProcess(process.env)) {
+    // On macOS under launchd, fire a detached kickstart so launchd restarts
+    // us immediately instead of waiting for ThrottleInterval (up to 60s).
+    if (process.platform === "darwin" && process.env.OPENCLAW_LAUNCHD_LABEL?.trim()) {
+      schedulelaunchdKickstart(process.env.OPENCLAW_LAUNCHD_LABEL.trim());
+    }
     return { mode: "supervised" };
   }
 

--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -54,4 +54,29 @@ describe("fetchCodexUsage", () => {
       { label: "Day", usedPercent: 75, resetAt: 1_700_050_000_000 },
     ]);
   });
+
+  it("labels weekly secondary window as Week", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        rate_limit: {
+          primary_window: {
+            limit_window_seconds: 10_800,
+            used_percent: 7,
+            reset_at: 1_700_000_000,
+          },
+          secondary_window: {
+            limit_window_seconds: 604_800,
+            used_percent: 10,
+            reset_at: 1_700_500_000,
+          },
+        },
+      }),
+    );
+
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+    expect(result.windows).toEqual([
+      { label: "3h", usedPercent: 7, resetAt: 1_700_000_000_000 },
+      { label: "Week", usedPercent: 10, resetAt: 1_700_500_000_000 },
+    ]);
+  });
 });

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -65,7 +65,7 @@ export async function fetchCodexUsage(
   if (data.rate_limit?.secondary_window) {
     const sw = data.rate_limit.secondary_window;
     const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
-    const label = windowHours >= 24 ? "Day" : `${windowHours}h`;
+    const label = windowHours >= 168 ? "Week" : windowHours >= 24 ? "Day" : `${windowHours}h`;
     windows.push({
       label,
       usedPercent: clampPercent(sw.used_percent || 0),

--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -93,9 +93,21 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
         Object.assign(new Error("DNS resolve failed"), { code: "UND_ERR_DNS_RESOLVE_FAILED" }),
         Object.assign(new Error("Connection reset"), { code: "ECONNRESET" }),
         Object.assign(new Error("Timeout"), { code: "ETIMEDOUT" }),
+        Object.assign(
+          new Error(
+            "A request error occurred: Client network socket disconnected before secure TLS connection was established",
+          ),
+          { code: "slack_webapi_request_error" },
+        ),
         Object.assign(new Error("A request error occurred: getaddrinfo EAI_AGAIN slack.com"), {
           code: "slack_webapi_request_error",
           original: { code: "EAI_AGAIN", syscall: "getaddrinfo", hostname: "slack.com" },
+        }),
+        Object.assign(new Error("A request error occurred: unknown"), {
+          code: "slack_webapi_request_error",
+          original: Object.assign(new Error("connect timeout"), {
+            code: "UND_ERR_CONNECT_TIMEOUT",
+          }),
         }),
       ];
 
@@ -117,6 +129,17 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
         "[remoteclaw] Unhandled promise rejection:",
         expect.stringContaining("Something went wrong"),
       );
+    });
+
+    it("exits on non-transient Slack request errors", () => {
+      const slackErr = Object.assign(
+        new Error("A request error occurred: invalid request payload"),
+        {
+          code: "slack_webapi_request_error",
+        },
+      );
+
+      expectExitCodeFromUnhandled(slackErr, [1]);
     });
 
     it("does not exit on AbortError and logs suppression warning", () => {

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -49,6 +49,7 @@ const TRANSIENT_NETWORK_MESSAGE_CODE_RE =
 const TRANSIENT_NETWORK_MESSAGE_SNIPPETS = [
   "getaddrinfo",
   "socket hang up",
+  "client network socket disconnected before secure tls connection was established",
   "network error",
   "network is unreachable",
   "temporary failure in name resolution",

--- a/src/line/download.ts
+++ b/src/line/download.ts
@@ -80,15 +80,20 @@ function detectContentType(buffer: Buffer): string {
     ) {
       return "image/webp";
     }
-    // MP4
-    if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
-      return "video/mp4";
-    }
-    // M4A/AAC
-    if (buffer[0] === 0x00 && buffer[1] === 0x00 && buffer[2] === 0x00) {
-      if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
+    // MPEG-4 container (ftyp box) — distinguish audio (M4A) from video (MP4)
+    // by checking the major brand at bytes 8-11.
+    if (
+      buffer.length >= 12 &&
+      buffer[4] === 0x66 &&
+      buffer[5] === 0x74 &&
+      buffer[6] === 0x79 &&
+      buffer[7] === 0x70
+    ) {
+      const brand = String.fromCharCode(buffer[8], buffer[9], buffer[10], buffer[11]);
+      if (brand === "M4A " || brand === "M4B ") {
         return "audio/mp4";
       }
+      return "video/mp4";
     }
   }
 

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -599,16 +599,6 @@ export function discoverRemoteClawPlugins(params: {
     }
   }
 
-  const globalDir = path.join(resolveConfigDir(), "extensions");
-  discoverInDirectory({
-    dir: globalDir,
-    origin: "global",
-    ownershipUid: params.ownershipUid,
-    candidates,
-    diagnostics,
-    seen,
-  });
-
   const bundledDir = resolveBundledPluginsDir();
   if (bundledDir) {
     discoverInDirectory({
@@ -620,6 +610,18 @@ export function discoverRemoteClawPlugins(params: {
       seen,
     });
   }
+
+  // Keep auto-discovered global extensions behind bundled plugins.
+  // Users can still intentionally override via plugins.load.paths (origin=config).
+  const globalDir = path.join(resolveConfigDir(), "extensions");
+  discoverInDirectory({
+    dir: globalDir,
+    origin: "global",
+    ownershipUid: params.ownershipUid,
+    candidates,
+    diagnostics,
+    seen,
+  });
 
   return { candidates, diagnostics };
 }

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -468,6 +468,49 @@ describe("loadRemoteClawPlugins", () => {
     expect(loaded?.origin).toBe("config");
     expect(overridden?.origin).toBe("bundled");
   });
+
+  it("prefers bundled plugin over auto-discovered global duplicate ids", () => {
+    const bundledDir = makeTempDir();
+    writePlugin({
+      id: "feishu",
+      body: `export default { id: "feishu", register() {} };`,
+      dir: bundledDir,
+      filename: "index.js",
+    });
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+
+    const stateDir = makeTempDir();
+    withEnv({ OPENCLAW_STATE_DIR: stateDir, CLAWDBOT_STATE_DIR: undefined }, () => {
+      const globalDir = path.join(stateDir, "extensions", "feishu");
+      fs.mkdirSync(globalDir, { recursive: true });
+      writePlugin({
+        id: "feishu",
+        body: `export default { id: "feishu", register() {} };`,
+        dir: globalDir,
+        filename: "index.js",
+      });
+
+      const registry = loadOpenClawPlugins({
+        cache: false,
+        config: {
+          plugins: {
+            allow: ["feishu"],
+            entries: {
+              feishu: { enabled: true },
+            },
+          },
+        },
+      });
+
+      const entries = registry.plugins.filter((entry) => entry.id === "feishu");
+      const loaded = entries.find((entry) => entry.status === "loaded");
+      const overridden = entries.find((entry) => entry.status === "disabled");
+      expect(loaded?.origin).toBe("bundled");
+      expect(overridden?.origin).toBe("global");
+      expect(overridden?.error).toContain("overridden by bundled plugin");
+    });
+  });
+
   it("warns when plugins.allow is empty and non-bundled plugins are discoverable", () => {
     process.env.REMOTECLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
     const plugin = writePlugin({

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -490,7 +490,7 @@ describe("loadRemoteClawPlugins", () => {
         filename: "index.js",
       });
 
-      const registry = loadOpenClawPlugins({
+      const registry = loadRemoteClawPlugins({
         cache: false,
         config: {
           plugins: {
@@ -502,9 +502,9 @@ describe("loadRemoteClawPlugins", () => {
         },
       });
 
-      const entries = registry.plugins.filter((entry) => entry.id === "feishu");
-      const loaded = entries.find((entry) => entry.status === "loaded");
-      const overridden = entries.find((entry) => entry.status === "disabled");
+      const entries = registry.plugins.filter((entry: { id: string }) => entry.id === "feishu");
+      const loaded = entries.find((entry: { status: string }) => entry.status === "loaded");
+      const overridden = entries.find((entry: { status: string }) => entry.status === "disabled");
       expect(loaded?.origin).toBe("bundled");
       expect(overridden?.origin).toBe("global");
       expect(overridden?.error).toContain("overridden by bundled plugin");

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -477,10 +477,10 @@ describe("loadRemoteClawPlugins", () => {
       dir: bundledDir,
       filename: "index.js",
     });
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+    process.env.REMOTECLAW_BUNDLED_PLUGINS_DIR = bundledDir;
 
     const stateDir = makeTempDir();
-    withEnv({ OPENCLAW_STATE_DIR: stateDir, CLAWDBOT_STATE_DIR: undefined }, () => {
+    withEnv({ REMOTECLAW_STATE_DIR: stateDir, CLAWDBOT_STATE_DIR: undefined }, () => {
       const globalDir = path.join(stateDir, "extensions", "feishu");
       fs.mkdirSync(globalDir, { recursive: true });
       writePlugin({

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -134,6 +134,15 @@ describe("runCommandWithTimeout", () => {
     expect(result.noOutputTimedOut).toBe(false);
     expect(result.code).not.toBe(0);
   });
+
+  it.runIf(process.platform === "win32")(
+    "on Windows spawns node + npm-cli.js for npm argv to avoid spawn EINVAL",
+    async () => {
+      const result = await runCommandWithTimeout(["npm", "--version"], { timeoutMs: 10_000 });
+      expect(result.code).toBe(0);
+      expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+    },
+  );
 });
 
 describe("attachChildProcessBridge", () => {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -1,5 +1,7 @@
 import { execFile, spawn } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
+import process from "node:process";
 import { promisify } from "node:util";
 import { danger, shouldLogVerbose } from "../globals.js";
 import { logDebug, logError } from "../logger.js";
@@ -8,21 +10,45 @@ import { resolveCommandStdio } from "./spawn-utils.js";
 const execFileAsync = promisify(execFile);
 
 /**
+ * On Windows, Node 18.20.2+ (CVE-2024-27980) rejects spawning .cmd/.bat directly
+ * without shell, causing EINVAL. Resolve npm/npx to node + cli script so we
+ * spawn node.exe instead of npm.cmd.
+ */
+function resolveNpmArgvForWindows(argv: string[]): string[] | null {
+  if (process.platform !== "win32" || argv.length === 0) {
+    return null;
+  }
+  const basename = path
+    .basename(argv[0])
+    .toLowerCase()
+    .replace(/\.(cmd|exe|bat)$/, "");
+  const cliName = basename === "npx" ? "npx-cli.js" : basename === "npm" ? "npm-cli.js" : null;
+  if (!cliName) {
+    return null;
+  }
+  const nodeDir = path.dirname(process.execPath);
+  const cliPath = path.join(nodeDir, "node_modules", "npm", "bin", cliName);
+  if (!fs.existsSync(cliPath)) {
+    return null;
+  }
+  return [process.execPath, cliPath, ...argv.slice(1)];
+}
+
+/**
  * Resolves a command for Windows compatibility.
- * On Windows, non-.exe commands (like npm, pnpm) require their .cmd extension.
+ * On Windows, non-.exe commands (like pnpm, yarn) are resolved to .cmd; npm/npx
+ * are handled by resolveNpmArgvForWindows to avoid spawn EINVAL (no direct .cmd).
  */
 function resolveCommand(command: string): string {
   if (process.platform !== "win32") {
     return command;
   }
   const basename = path.basename(command).toLowerCase();
-  // Skip if already has an extension (.cmd, .exe, .bat, etc.)
   const ext = path.extname(basename);
   if (ext) {
     return command;
   }
-  // Common npm-related commands that need .cmd extension on Windows
-  const cmdCommands = ["npm", "pnpm", "yarn", "npx"];
+  const cmdCommands = ["pnpm", "yarn"];
   if (cmdCommands.includes(basename)) {
     return `${command}.cmd`;
   }
@@ -57,7 +83,23 @@ export async function runExec(
           encoding: "utf8" as const,
         };
   try {
-    const { stdout, stderr } = await execFileAsync(resolveCommand(command), args, options);
+    const argv = [command, ...args];
+    let execCommand: string;
+    let execArgs: string[];
+    if (process.platform === "win32") {
+      const resolved = resolveNpmArgvForWindows(argv);
+      if (resolved) {
+        execCommand = resolved[0] ?? "";
+        execArgs = resolved.slice(1);
+      } else {
+        execCommand = resolveCommand(command);
+        execArgs = args;
+      }
+    } else {
+      execCommand = resolveCommand(command);
+      execArgs = args;
+    }
+    const { stdout, stderr } = await execFileAsync(execCommand, execArgs, options);
     if (shouldLogVerbose()) {
       if (stdout.trim()) {
         logDebug(stdout.trim());
@@ -133,8 +175,9 @@ export async function runCommandWithTimeout(
   }
 
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
-  const resolvedCommand = resolveCommand(argv[0] ?? "");
-  const child = spawn(resolvedCommand, argv.slice(1), {
+  const finalArgv = process.platform === "win32" ? (resolveNpmArgvForWindows(argv) ?? argv) : argv;
+  const resolvedCommand = finalArgv !== argv ? (finalArgv[0] ?? "") : resolveCommand(argv[0] ?? "");
+  const child = spawn(resolvedCommand, finalArgv.slice(1), {
     stdio,
     cwd,
     env: resolvedEnv,

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -549,7 +549,7 @@ describe("backward compatibility: peer.kind dm → direct", () => {
 
 describe("backward compatibility: peer.kind group ↔ channel", () => {
   test("config group binding matches runtime channel scope", () => {
-    const cfg: OpenClawConfig = {
+    const cfg: RemoteClawConfig = {
       bindings: [
         {
           agentId: "slack-group-agent",
@@ -571,7 +571,7 @@ describe("backward compatibility: peer.kind group ↔ channel", () => {
   });
 
   test("config channel binding matches runtime group scope", () => {
-    const cfg: OpenClawConfig = {
+    const cfg: RemoteClawConfig = {
       bindings: [
         {
           agentId: "slack-channel-agent",
@@ -593,7 +593,7 @@ describe("backward compatibility: peer.kind group ↔ channel", () => {
   });
 
   test("group/channel compatibility does not match direct peer kind", () => {
-    const cfg: OpenClawConfig = {
+    const cfg: RemoteClawConfig = {
       bindings: [
         {
           agentId: "group-only-agent",

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -547,6 +547,74 @@ describe("backward compatibility: peer.kind dm → direct", () => {
   });
 });
 
+describe("backward compatibility: peer.kind group ↔ channel", () => {
+  test("config group binding matches runtime channel scope", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "slack-group-agent",
+          match: {
+            channel: "slack",
+            peer: { kind: "group", id: "C123456" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "slack",
+      accountId: null,
+      peer: { kind: "channel", id: "C123456" },
+    });
+    expect(route.agentId).toBe("slack-group-agent");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+
+  test("config channel binding matches runtime group scope", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "slack-channel-agent",
+          match: {
+            channel: "slack",
+            peer: { kind: "channel", id: "C123456" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "slack",
+      accountId: null,
+      peer: { kind: "group", id: "C123456" },
+    });
+    expect(route.agentId).toBe("slack-channel-agent");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+
+  test("group/channel compatibility does not match direct peer kind", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "group-only-agent",
+          match: {
+            channel: "slack",
+            peer: { kind: "group", id: "C123456" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "slack",
+      accountId: null,
+      peer: { kind: "direct", id: "C123456" },
+    });
+    expect(route.agentId).toBe("main");
+    expect(route.matchedBy).toBe("default");
+  });
+});
+
 describe("role-based agent routing", () => {
   type DiscordBinding = NonNullable<RemoteClawConfig["bindings"]>[number];
 

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -262,12 +262,24 @@ function hasRolesConstraint(match: NormalizedBindingMatch): boolean {
   return Boolean(match.roles);
 }
 
+function peerKindMatches(bindingKind: ChatType, scopeKind: ChatType): boolean {
+  if (bindingKind === scopeKind) {
+    return true;
+  }
+  const both = new Set([bindingKind, scopeKind]);
+  return both.has("group") && both.has("channel");
+}
+
 function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope): boolean {
   if (match.peer.state === "invalid") {
     return false;
   }
   if (match.peer.state === "valid") {
-    if (!scope.peer || scope.peer.kind !== match.peer.kind || scope.peer.id !== match.peer.id) {
+    if (
+      !scope.peer ||
+      !peerKindMatches(match.peer.kind, scope.peer.kind) ||
+      scope.peer.id !== match.peer.id
+    ) {
       return false;
     }
   }

--- a/src/signal/monitor/event-handler.inbound-contract.test.ts
+++ b/src/signal/monitor/event-handler.inbound-contract.test.ts
@@ -201,4 +201,29 @@ describe("signal createSignalEventHandler inbound contract", () => {
     expect(capture.ctx).toBeUndefined();
     expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
   });
+
+  it("drops sync envelopes when syncMessage is present but null", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 } },
+          channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
+        },
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        syncMessage: null,
+        dataMessage: {
+          message: "replayed sentTranscript envelope",
+          attachments: [],
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeUndefined();
+    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -438,9 +438,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       return;
     }
 
-    // For non-own sync messages (e.g., messages synced from other devices),
-    // we could process them but for now we skip to be conservative
-    if (envelope.syncMessage) {
+    // Filter all sync messages (sentTranscript, readReceipts, etc.).
+    // signal-cli may set syncMessage to null instead of omitting it, so
+    // check property existence rather than truthiness to avoid replaying
+    // the bot's own sent messages on daemon restart.
+    if ("syncMessage" in envelope) {
       return;
     }
 

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -85,10 +85,28 @@ describe("tts", () => {
   });
 
   describe("resolveOutputFormat", () => {
-    it("selects opus for Telegram and mp3 for other channels", () => {
+    it("selects opus for voice-bubble channels (telegram/feishu/whatsapp) and mp3 for others", () => {
       const cases = [
         {
           channel: "telegram",
+          expected: {
+            openai: "opus",
+            elevenlabs: "opus_48000_64",
+            extension: ".opus",
+            voiceCompatible: true,
+          },
+        },
+        {
+          channel: "feishu",
+          expected: {
+            openai: "opus",
+            elevenlabs: "opus_48000_64",
+            extension: ".opus",
+            voiceCompatible: true,
+          },
+        },
+        {
+          channel: "whatsapp",
           expected: {
             openai: "opus",
             elevenlabs: "opus_48000_64",

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -466,8 +466,11 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
   lastTtsAttempt = entry;
 }
 
+/** Channels that require opus audio and support voice-bubble playback */
+const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "feishu", "whatsapp"]);
+
 function resolveOutputFormat(channelId?: string | null) {
-  if (channelId === "telegram") {
+  if (channelId && VOICE_BUBBLE_CHANNELS.has(channelId)) {
     return TELEGRAM_OUTPUT;
   }
   return DEFAULT_OUTPUT;
@@ -1006,7 +1009,8 @@ export async function maybeApplyTtsToPayload(params: {
     };
 
     const channelId = resolveChannelId(params.channel);
-    const shouldVoice = channelId === "telegram" && result.voiceCompatible === true;
+    const shouldVoice =
+      channelId !== null && VOICE_BUBBLE_CHANNELS.has(channelId) && result.voiceCompatible === true;
     const finalPayload = {
       ...nextPayload,
       mediaUrl: result.audioPath,


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: remoteclaw/remoteclaw#690
**Commits**: 26 picked, 4 skipped

| Hash | Subject | Result |
|------|---------|--------|
| `db67492a0` | fix(infra): actively kickstart launchd on supervised gateway restart | RESOLVED |
| `4aa2dc685` | fix(infra): land #29078 from @cathrynlavery with restart fallback | RESOLVED |
| `e16d051d9` | fix: label Codex weekly usage window as "Week" instead of "Day" | PICKED |
| `6a8d83b6d` | fix(feishu): Remove incorrect oc_ prefix assumption in resolveFeishuSession | PICKED |
| `645d96395` | feat: expand ~ (tilde) to home directory in file tools | RESOLVED |
| `a54b85822` | Handle transient Slack request errors without crashing the gateway | PICKED |
| `ac5d7ee4c` | Tests: normalize HOME expansion assertion on Windows | PICKED |
| `6398a0ba8` | fix(infra): avoid EISDIR leak to messaging when Read targets directory | RESOLVED |
| `00dcd931c` | test(fs-safe): assert directory-read errors never leak EISDIR text | PICKED |
| `c0ce12551` | fix(gateway): shorten manual reinstall/restart delays | PICKED |
| `f1354869b` | Node install: persist gateway token in service env | RESOLVED |
| `577f2fa54` | fix(docker): harden /app/extensions permissions to 755 | PICKED |
| `577becf1a` | fix(plugins): prioritize bundled duplicates in auto-discovery | PICKED |
| `9e727893f` | refactor(session): consolidate transcript snapshot reads | SKIPPED (only touches gutted memory file) |
| `412eabc42` | fix(session): retire stale dm main route after dmScope migration | RESOLVED |
| `70ee256ae` | fix(routing): treat group/channel peer.kind as equivalent | PICKED |
| `95db5bb5e` | fix(session): preserve external lastTo routing for internal turns | PICKED |
| `072e1e9e3` | test(session): cover internal route without external fallback | PICKED |
| `61989091a` | fix(reply): fix duplicate block replies by unblocking coalesced payloads | PICKED |
| `a6a742f3d` | fix(auto-reply): land #31080 from @scoootscooob | RESOLVED |
| `1a42ea3ab` | fix(auto-reply): normalize block-reply callback to Promise for timeout path | RESOLVED |
| `5cb2a3aa1` | Tests: validate discord slash command options | PICKED |
| `5350f5b03` | fix(tts): use opus format and enable voice bubbles for feishu and whatsapp | PICKED |
| `54ed2efc2` | Tests: complete ACP meta dedupe coverage | SKIPPED (acp-projector.test.ts gutted, dispatch test heavily diverged) |
| `1c8ae978d` | test(lobster): preserve execFile in child_process mock | SKIPPED (lobster extension gutted) |
| `a262a3ea0` | fix(docker): ensure agent directory permissions in docker-setup.sh | SKIPPED (docker-setup.sh deleted in fork) |
| `a1a8ec687` | fix(windows): land #31147 plugin install spawn EINVAL | PICKED |
| `1da7906a5` | fix(line): land #31151 M4A voice MIME detection | PICKED |
| `08f8aea32` | fix(signal): land #31138 syncMessage presence filtering | PICKED |
| `0202d79df` | fix(inbound-meta): land #30984 include account_id context | PICKED |

**Adaptation**: Rebranded `OpenClawConfig` → `RemoteClawConfig`, `triggerOpenClawRestart` → `triggerRemoteClawRestart`, `OPENCLAW_*` env vars → `REMOTECLAW_*`, `openclaw/plugin-sdk` → `remoteclaw/plugin-sdk`. Removed `writeFileWithinRoot` test (function deleted in fork). Fixed implicit `any` types in plugin loader test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)