### PR TITLE
Cherry-pick batch: Browser fixes — CDP, auth, relay, and params

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -833,7 +833,7 @@ async function onDebuggerDetach(source, reason) {
         setBadge(tabId, 'connecting')
         void chrome.action.setTitle({
           tabId,
-          title: 'OpenClaw Browser Relay: attached, waiting for relay reconnect…',
+          title: 'RemoteClaw Browser Relay: attached, waiting for relay reconnect…',
         })
       }
       return

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -821,19 +821,21 @@ async function onDebuggerDetach(source, reason) {
       return
     }
 
-    if (!relayWs || relayWs.readyState !== WebSocket.OPEN) {
-      reattachPending.delete(tabId)
-      setBadge(tabId, 'error')
-      void chrome.action.setTitle({
-        tabId,
-        title: 'RemoteClaw Browser Relay: relay disconnected during re-attach',
-      })
-      return
-    }
+    const relayUp = relayWs && relayWs.readyState === WebSocket.OPEN
 
     try {
-      await attachTab(tabId)
+      // When relay is down, still attach the debugger but skip sending the
+      // relay event. reannounceAttachedTabs() will notify the relay once it
+      // reconnects, so the tab stays tracked across transient relay drops.
+      await attachTab(tabId, { skipAttachedEvent: !relayUp })
       reattachPending.delete(tabId)
+      if (!relayUp) {
+        setBadge(tabId, 'connecting')
+        void chrome.action.setTitle({
+          tabId,
+          title: 'OpenClaw Browser Relay: attached, waiting for relay reconnect…',
+        })
+      }
       return
     } catch {
       // continue retries

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -295,6 +295,16 @@ export async function launchRemoteClawChrome(
   }
 
   const proc = spawnOnce();
+
+  // Collect stderr for diagnostics in case Chrome fails to start.
+  // The listener is removed on success to avoid unbounded memory growth
+  // from a long-lived Chrome process that emits periodic warnings.
+  const stderrChunks: Buffer[] = [];
+  const onStderr = (chunk: Buffer) => {
+    stderrChunks.push(chunk);
+  };
+  proc.stderr?.on("data", onStderr);
+
   // Wait for CDP to come up.
   const readyDeadline = Date.now() + 15_000;
   while (Date.now() < readyDeadline) {
@@ -305,15 +315,25 @@ export async function launchRemoteClawChrome(
   }
 
   if (!(await isChromeReachable(profile.cdpUrl, 500))) {
+    const stderrOutput = Buffer.concat(stderrChunks).toString("utf8").trim();
+    const stderrHint = stderrOutput ? `\nChrome stderr:\n${stderrOutput.slice(0, 2000)}` : "";
+    const sandboxHint =
+      process.platform === "linux" && !resolved.noSandbox
+        ? "\nHint: If running in a container or as root, try setting browser.noSandbox: true in config."
+        : "";
     try {
       proc.kill("SIGKILL");
     } catch {
       // ignore
     }
     throw new Error(
-      `Failed to start Chrome CDP on port ${profile.cdpPort} for profile "${profile.name}".`,
+      `Failed to start Chrome CDP on port ${profile.cdpPort} for profile "${profile.name}".${sandboxHint}${stderrHint}`,
     );
   }
+
+  // Chrome started successfully — detach the stderr listener and release the buffer.
+  proc.stderr?.off("data", onStderr);
+  stderrChunks.length = 0;
 
   const pid = proc.pid ?? -1;
   log.info(

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -244,26 +244,26 @@ describe("browser config", () => {
       expect(resolved.defaultProfile).toBe("chrome");
     });
 
-    it("prefers openclaw profile when headless=true", () => {
+    it("prefers remoteclaw profile when headless=true", () => {
       const resolved = resolveBrowserConfig({
         headless: true,
       });
-      expect(resolved.defaultProfile).toBe("openclaw");
+      expect(resolved.defaultProfile).toBe("remoteclaw");
     });
 
-    it("prefers openclaw profile when noSandbox=true", () => {
+    it("prefers remoteclaw profile when noSandbox=true", () => {
       const resolved = resolveBrowserConfig({
         noSandbox: true,
       });
-      expect(resolved.defaultProfile).toBe("openclaw");
+      expect(resolved.defaultProfile).toBe("remoteclaw");
     });
 
-    it("prefers openclaw profile when both headless and noSandbox are true", () => {
+    it("prefers remoteclaw profile when both headless and noSandbox are true", () => {
       const resolved = resolveBrowserConfig({
         headless: true,
         noSandbox: true,
       });
-      expect(resolved.defaultProfile).toBe("openclaw");
+      expect(resolved.defaultProfile).toBe("remoteclaw");
     });
 
     it("explicit defaultProfile config overrides headless preference", () => {

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -233,4 +233,64 @@ describe("browser config", () => {
     });
     expect(resolved.ssrfPolicy).toEqual({});
   });
+
+  // Tests for headless/noSandbox profile preference (issue #14895)
+  describe("headless/noSandbox profile preference", () => {
+    it("defaults to chrome profile when headless=false and noSandbox=false", () => {
+      const resolved = resolveBrowserConfig({
+        headless: false,
+        noSandbox: false,
+      });
+      expect(resolved.defaultProfile).toBe("chrome");
+    });
+
+    it("prefers openclaw profile when headless=true", () => {
+      const resolved = resolveBrowserConfig({
+        headless: true,
+      });
+      expect(resolved.defaultProfile).toBe("openclaw");
+    });
+
+    it("prefers openclaw profile when noSandbox=true", () => {
+      const resolved = resolveBrowserConfig({
+        noSandbox: true,
+      });
+      expect(resolved.defaultProfile).toBe("openclaw");
+    });
+
+    it("prefers openclaw profile when both headless and noSandbox are true", () => {
+      const resolved = resolveBrowserConfig({
+        headless: true,
+        noSandbox: true,
+      });
+      expect(resolved.defaultProfile).toBe("openclaw");
+    });
+
+    it("explicit defaultProfile config overrides headless preference", () => {
+      const resolved = resolveBrowserConfig({
+        headless: true,
+        defaultProfile: "chrome",
+      });
+      expect(resolved.defaultProfile).toBe("chrome");
+    });
+
+    it("explicit defaultProfile config overrides noSandbox preference", () => {
+      const resolved = resolveBrowserConfig({
+        noSandbox: true,
+        defaultProfile: "chrome",
+      });
+      expect(resolved.defaultProfile).toBe("chrome");
+    });
+
+    it("allows custom profile as default even in headless mode", () => {
+      const resolved = resolveBrowserConfig({
+        headless: true,
+        defaultProfile: "custom",
+        profiles: {
+          custom: { cdpPort: 19999, color: "#00FF00" },
+        },
+      });
+      expect(resolved.defaultProfile).toBe("custom");
+    });
+  });
 });

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -248,11 +248,17 @@ export function resolveBrowserConfig(
     controlPort,
   );
   const cdpProtocol = cdpInfo.parsed.protocol === "https:" ? "https" : "http";
+
+  // In headless/noSandbox environments (servers), prefer "remoteclaw" profile over "chrome"
+  // because Chrome extension relay requires a GUI browser which isn't available headless.
+  const preferRemoteClawProfile = headless || noSandbox;
   const defaultProfile =
     defaultProfileFromConfig ??
-    (profiles[DEFAULT_BROWSER_DEFAULT_PROFILE_NAME]
-      ? DEFAULT_BROWSER_DEFAULT_PROFILE_NAME
-      : DEFAULT_REMOTECLAW_BROWSER_PROFILE_NAME);
+    (preferRemoteClawProfile && profiles[DEFAULT_REMOTECLAW_BROWSER_PROFILE_NAME]
+      ? DEFAULT_REMOTECLAW_BROWSER_PROFILE_NAME
+      : profiles[DEFAULT_BROWSER_DEFAULT_PROFILE_NAME]
+        ? DEFAULT_BROWSER_DEFAULT_PROFILE_NAME
+        : DEFAULT_REMOTECLAW_BROWSER_PROFILE_NAME);
 
   const extraArgs = Array.isArray(cfg?.extraArgs)
     ? cfg.extraArgs.filter((a): a is string => typeof a === "string" && a.trim().length > 0)

--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -530,7 +530,7 @@ describe("chrome extension relay server", () => {
   });
 
   it("stops advertising websocket endpoint after reconnect grace expires", async () => {
-    process.env.OPENCLAW_EXTENSION_RELAY_RECONNECT_GRACE_MS = "120";
+    process.env.REMOTECLAW_EXTENSION_RELAY_RECONNECT_GRACE_MS = "120";
 
     const { ext } = await startRelayWithExtension();
     ext.send(

--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -838,6 +838,176 @@ describe("chrome extension relay server", () => {
     }
   });
 
+  it(
+    "restores tabs after extension reconnects and re-announces",
+    async () => {
+      process.env.REMOTECLAW_EXTENSION_RELAY_RECONNECT_GRACE_MS = "200";
+
+      const { port, ext: ext1 } = await startRelayWithExtension();
+
+      ext1.send(
+        JSON.stringify({
+          method: "forwardCDPEvent",
+          params: {
+            method: "Target.attachedToTarget",
+            params: {
+              sessionId: "cb-tab-10",
+              targetInfo: {
+                targetId: "t10",
+                type: "page",
+                title: "My Page",
+                url: "https://example.com",
+              },
+              waitingForDebugger: false,
+            },
+          },
+        }),
+      );
+
+      const list1 = await waitForListMatch(
+        async () =>
+          (await fetch(`${cdpUrl}/json/list`, {
+            headers: relayAuthHeaders(cdpUrl),
+          }).then((r) => r.json())) as Array<{ id?: string }>,
+        (list) => list.some((t) => t.id === "t10"),
+      );
+      expect(list1.some((t) => t.id === "t10")).toBe(true);
+
+      // Disconnect extension and wait for grace period cleanup.
+      const ext1Closed = waitForClose(ext1, 2_000);
+      ext1.close();
+      await ext1Closed;
+      await new Promise((r) => setTimeout(r, 400));
+
+      const listEmpty = (await fetch(`${cdpUrl}/json/list`, {
+        headers: relayAuthHeaders(cdpUrl),
+      }).then((r) => r.json())) as Array<{ id?: string }>;
+      expect(listEmpty.length).toBe(0);
+
+      // Reconnect and re-announce the same tab (simulates reannounceAttachedTabs).
+      const ext2 = new WebSocket(`ws://127.0.0.1:${port}/extension`, {
+        headers: relayAuthHeaders(`ws://127.0.0.1:${port}/extension`),
+      });
+      await waitForOpen(ext2);
+
+      ext2.send(
+        JSON.stringify({
+          method: "forwardCDPEvent",
+          params: {
+            method: "Target.attachedToTarget",
+            params: {
+              sessionId: "cb-tab-10",
+              targetInfo: {
+                targetId: "t10",
+                type: "page",
+                title: "My Page",
+                url: "https://example.com",
+              },
+              waitingForDebugger: false,
+            },
+          },
+        }),
+      );
+
+      const list2 = await waitForListMatch(
+        async () =>
+          (await fetch(`${cdpUrl}/json/list`, {
+            headers: relayAuthHeaders(cdpUrl),
+          }).then((r) => r.json())) as Array<{ id?: string; title?: string }>,
+        (list) => list.some((t) => t.id === "t10"),
+      );
+      expect(list2.some((t) => t.id === "t10" && t.title === "My Page")).toBe(true);
+
+      ext2.close();
+    },
+    RELAY_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "preserves tab across a fast extension reconnect within grace period",
+    async () => {
+      process.env.REMOTECLAW_EXTENSION_RELAY_RECONNECT_GRACE_MS = "2000";
+
+      const { port, ext: ext1 } = await startRelayWithExtension();
+
+      ext1.send(
+        JSON.stringify({
+          method: "forwardCDPEvent",
+          params: {
+            method: "Target.attachedToTarget",
+            params: {
+              sessionId: "cb-tab-20",
+              targetInfo: {
+                targetId: "t20",
+                type: "page",
+                title: "Persistent",
+                url: "https://example.org",
+              },
+              waitingForDebugger: false,
+            },
+          },
+        }),
+      );
+
+      await waitForListMatch(
+        async () =>
+          (await fetch(`${cdpUrl}/json/list`, {
+            headers: relayAuthHeaders(cdpUrl),
+          }).then((r) => r.json())) as Array<{ id?: string }>,
+        (list) => list.some((t) => t.id === "t20"),
+      );
+
+      // Disconnect briefly (within grace period).
+      const ext1Closed = waitForClose(ext1, 2_000);
+      ext1.close();
+      await ext1Closed;
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Tab should still be listed during grace period.
+      const listDuringGrace = (await fetch(`${cdpUrl}/json/list`, {
+        headers: relayAuthHeaders(cdpUrl),
+      }).then((r) => r.json())) as Array<{ id?: string }>;
+      expect(listDuringGrace.some((t) => t.id === "t20")).toBe(true);
+
+      // Reconnect within grace and re-announce with updated info.
+      const ext2 = new WebSocket(`ws://127.0.0.1:${port}/extension`, {
+        headers: relayAuthHeaders(`ws://127.0.0.1:${port}/extension`),
+      });
+      await waitForOpen(ext2);
+
+      ext2.send(
+        JSON.stringify({
+          method: "forwardCDPEvent",
+          params: {
+            method: "Target.attachedToTarget",
+            params: {
+              sessionId: "cb-tab-20",
+              targetInfo: {
+                targetId: "t20",
+                type: "page",
+                title: "Persistent Updated",
+                url: "https://example.org/new",
+              },
+              waitingForDebugger: false,
+            },
+          },
+        }),
+      );
+
+      const list2 = await waitForListMatch(
+        async () =>
+          (await fetch(`${cdpUrl}/json/list`, {
+            headers: relayAuthHeaders(cdpUrl),
+          }).then((r) => r.json())) as Array<{ id?: string; title?: string; url?: string }>,
+        (list) => list.some((t) => t.id === "t20" && t.title === "Persistent Updated"),
+      );
+      expect(list2.some((t) => t.id === "t20" && t.url === "https://example.org/new")).toBe(true);
+
+      ext2.close();
+    },
+    RELAY_TEST_TIMEOUT_MS,
+  );
+
   it("does not swallow EADDRINUSE when occupied port is not an remoteclaw relay", async () => {
     const port = await getFreePort();
     const blocker = createServer((_, res) => {

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -378,6 +378,70 @@ export async function ensureChromeExtensionRelayServer(opts: {
       ws.send(JSON.stringify(res));
     };
 
+    const dropConnectedTargetSession = (sessionId: string): ConnectedTarget | undefined => {
+      const existing = connectedTargets.get(sessionId);
+      if (!existing) {
+        return undefined;
+      }
+      connectedTargets.delete(sessionId);
+      return existing;
+    };
+
+    const dropConnectedTargetsByTargetId = (targetId: string): ConnectedTarget[] => {
+      const removed: ConnectedTarget[] = [];
+      for (const [sessionId, target] of connectedTargets) {
+        if (target.targetId !== targetId) {
+          continue;
+        }
+        connectedTargets.delete(sessionId);
+        removed.push(target);
+      }
+      return removed;
+    };
+
+    const broadcastDetachedTarget = (target: ConnectedTarget, targetId?: string) => {
+      broadcastToCdpClients({
+        method: "Target.detachedFromTarget",
+        params: {
+          sessionId: target.sessionId,
+          targetId: targetId ?? target.targetId,
+        },
+        sessionId: target.sessionId,
+      });
+    };
+
+    const isMissingTargetError = (err: unknown) => {
+      const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+      return (
+        message.includes("target not found") ||
+        message.includes("no target with given id") ||
+        message.includes("session not found") ||
+        message.includes("cannot find session")
+      );
+    };
+
+    const pruneStaleTargetsFromCommandFailure = (cmd: CdpCommand, err: unknown) => {
+      if (!isMissingTargetError(err)) {
+        return;
+      }
+      if (cmd.sessionId) {
+        const removed = dropConnectedTargetSession(cmd.sessionId);
+        if (removed) {
+          broadcastDetachedTarget(removed);
+          return;
+        }
+      }
+      const params = (cmd.params ?? {}) as { targetId?: unknown };
+      const targetId = typeof params.targetId === "string" ? params.targetId : undefined;
+      if (!targetId) {
+        return;
+      }
+      const removedTargets = dropConnectedTargetsByTargetId(targetId);
+      for (const removed of removedTargets) {
+        broadcastDetachedTarget(removed, targetId);
+      }
+    };
+
     const ensureTargetEventsForClient = (ws: WebSocket, mode: "autoAttach" | "discover") => {
       for (const target of connectedTargets.values()) {
         if (mode === "autoAttach") {
@@ -775,7 +839,18 @@ export async function ensureChromeExtensionRelayServer(opts: {
           if (method === "Target.detachedFromTarget") {
             const detached = (params ?? {}) as DetachedFromTargetEvent;
             if (detached?.sessionId) {
-              connectedTargets.delete(detached.sessionId);
+              dropConnectedTargetSession(detached.sessionId);
+            } else if (detached?.targetId) {
+              dropConnectedTargetsByTargetId(detached.targetId);
+            }
+            broadcastToCdpClients({ method, params, sessionId });
+            return;
+          }
+
+          if (method === "Target.targetDestroyed" || method === "Target.targetCrashed") {
+            const targetEvent = (params ?? {}) as { targetId?: string };
+            if (targetEvent.targetId) {
+              dropConnectedTargetsByTargetId(targetEvent.targetId);
             }
             broadcastToCdpClients({ method, params, sessionId });
             return;
@@ -884,6 +959,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
 
           sendResponseToCdp(ws, { id: cmd.id, sessionId: cmd.sessionId, result });
         } catch (err) {
+          pruneStaleTargetsFromCommandFailure(cmd, err);
           sendResponseToCdp(ws, {
             id: cmd.id,
             sessionId: cmd.sessionId,

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -82,7 +82,7 @@ type ConnectedTarget = {
 };
 
 const RELAY_AUTH_HEADER = "x-remoteclaw-relay-token";
-const DEFAULT_EXTENSION_RECONNECT_GRACE_MS = 5_000;
+const DEFAULT_EXTENSION_RECONNECT_GRACE_MS = 20_000;
 const DEFAULT_EXTENSION_COMMAND_RECONNECT_WAIT_MS = 3_000;
 
 function headerValue(value: string | string[] | undefined): string | undefined {
@@ -267,6 +267,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
     const cdpClients = new Set<WebSocket>();
     const connectedTargets = new Map<string, ConnectedTarget>();
     const extensionConnected = () => extensionWs?.readyState === WebSocket.OPEN;
+    const hasConnectedTargets = () => connectedTargets.size > 0;
     let extensionDisconnectCleanupTimer: NodeJS.Timeout | null = null;
     const extensionReconnectWaiters = new Set<(connected: boolean) => void>();
 
@@ -545,8 +546,9 @@ export async function ensureChromeExtensionRelayServer(opts: {
           Browser: "OpenClaw/extension-relay",
           "Protocol-Version": "1.3",
         };
-        // Only advertise the WS URL if a real extension is connected.
-        if (extensionConnected()) {
+        // Keep reporting CDP WS while attached targets are cached, so callers can
+        // reconnect through brief MV3 worker disconnects.
+        if (extensionConnected() || hasConnectedTargets()) {
           payload.webSocketDebuggerUrl = cdpWsUrl;
         }
         res.writeHead(200, { "Content-Type": "application/json" });
@@ -671,10 +673,8 @@ export async function ensureChromeExtensionRelayServer(opts: {
           rejectUpgrade(socket, 401, "Unauthorized");
           return;
         }
-        if (!extensionConnected()) {
-          rejectUpgrade(socket, 503, "Extension not connected");
-          return;
-        }
+        // Allow CDP clients to connect even during brief extension worker drops.
+        // Individual commands already wait briefly for extension reconnect.
         wssCdp.handleUpgrade(req, socket, head, (ws) => {
           wssCdp.emit("connection", ws, req);
         });

--- a/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -40,6 +40,7 @@ describe("pw-tools-core.snapshot navigate guard", () => {
       cdpUrl: "http://127.0.0.1:18792",
       url: "https://example.com",
       timeoutMs: 10,
+      ssrfPolicy: { allowPrivateNetwork: true },
     });
 
     expect(goto).toHaveBeenCalledWith("https://example.com", { timeout: 1000 });
@@ -72,5 +73,35 @@ describe("pw-tools-core.snapshot navigate guard", () => {
     ).rejects.toBeInstanceOf(SsrFBlockedError);
 
     expect(goto).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconnects and retries once when navigation detaches frame", async () => {
+    const goto = vi
+      .fn<(...args: unknown[]) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("page.goto: Frame has been detached"))
+      .mockResolvedValueOnce(undefined);
+    setPwToolsCoreCurrentPage({
+      goto,
+      url: vi.fn(() => "https://example.com/recovered"),
+    });
+
+    const result = await mod.navigateViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "tab-1",
+      url: "https://example.com/recovered",
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+
+    expect(getPwToolsCoreSessionMocks().getPageForTargetId).toHaveBeenCalledTimes(2);
+    expect(getPwToolsCoreSessionMocks().forceDisconnectPlaywrightForTarget).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(getPwToolsCoreSessionMocks().forceDisconnectPlaywrightForTarget).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "tab-1",
+      reason: "retry navigate after detached frame",
+    });
+    expect(goto).toHaveBeenCalledTimes(2);
+    expect(result.url).toBe("https://example.com/recovered");
   });
 });

--- a/src/browser/pw-tools-core.snapshot.ts
+++ b/src/browser/pw-tools-core.snapshot.ts
@@ -15,6 +15,7 @@ import {
 } from "./pw-role-snapshot.js";
 import {
   ensurePageState,
+  forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
   storeRoleRefsForTarget,
   type WithSnapshotForAI,
@@ -172,6 +173,19 @@ export async function navigateViaPlaywright(opts: {
   timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
 }): Promise<{ url: string }> {
+  const isRetryableNavigateError = (err: unknown): boolean => {
+    const msg =
+      typeof err === "string"
+        ? err.toLowerCase()
+        : err instanceof Error
+          ? err.message.toLowerCase()
+          : "";
+    return (
+      msg.includes("frame has been detached") ||
+      msg.includes("target page, context or browser has been closed")
+    );
+  };
+
   const url = String(opts.url ?? "").trim();
   if (!url) {
     throw new Error("url is required");
@@ -180,11 +194,27 @@ export async function navigateViaPlaywright(opts: {
     url,
     ...withBrowserNavigationPolicy(opts.ssrfPolicy),
   });
-  const page = await getPageForTargetId(opts);
+  const timeout = Math.max(1000, Math.min(120_000, opts.timeoutMs ?? 20_000));
+  let page = await getPageForTargetId(opts);
   ensurePageState(page);
-  const response = await page.goto(url, {
-    timeout: Math.max(1000, Math.min(120_000, opts.timeoutMs ?? 20_000)),
-  });
+  let response: Awaited<ReturnType<typeof page.goto>> | undefined;
+  try {
+    response = await page.goto(url, { timeout });
+  } catch (err) {
+    if (!isRetryableNavigateError(err)) {
+      throw err;
+    }
+    // Extension relays can briefly drop CDP during renderer swaps/navigation.
+    // Force a clean reconnect, then retry once on the refreshed page handle.
+    await forceDisconnectPlaywrightForTarget({
+      cdpUrl: opts.cdpUrl,
+      targetId: opts.targetId,
+      reason: "retry navigate after detached frame",
+    }).catch(() => {});
+    page = await getPageForTargetId(opts);
+    ensurePageState(page);
+    response = await page.goto(url, { timeout });
+  }
   await assertBrowserNavigationRedirectChainAllowed({
     request: response?.request(),
     ...withBrowserNavigationPolicy(opts.ssrfPolicy),

--- a/src/browser/pw-tools-core.test-harness.ts
+++ b/src/browser/pw-tools-core.test-harness.ts
@@ -22,7 +22,9 @@ const sessionMocks = vi.hoisted(() => ({
     return currentPage;
   }),
   ensurePageState: vi.fn(() => pageState),
+  forceDisconnectPlaywrightForTarget: vi.fn(async () => {}),
   restoreRoleRefsForTarget: vi.fn(() => {}),
+  storeRoleRefsForTarget: vi.fn(() => {}),
   refLocator: vi.fn(() => {
     if (!currentRefLocator) {
       throw new Error("missing locator");

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -336,8 +336,9 @@ function createProfileContext(
       return;
     }
 
-    // HTTP responds but WebSocket fails - port in use by something else
-    if (!profileState.running) {
+    // HTTP responds but WebSocket fails - port in use by something else.
+    // Skip this check for remote CDP profiles since we never own the remote process.
+    if (!profileState.running && !remoteCdp) {
       throw new Error(
         `Port ${profile.cdpPort} is in use for profile "${profile.name}" but not by remoteclaw. ` +
           `Run action=reset-profile profile=${profile.name} to kill the process.`,
@@ -359,6 +360,14 @@ function createProfileContext(
       );
     }
 
+    // At this point profileState.running is always non-null: the !remoteCdp guard
+    // above throws when running is null, and the remoteCdp path always exits via
+    // the attachOnly/remoteCdp block. Add an explicit guard for TypeScript.
+    if (!profileState.running) {
+      throw new Error(
+        `Unexpected state for profile "${profile.name}": no running process to restart.`,
+      );
+    }
     await stopRemoteClawChrome(profileState.running);
     setProfileRunning(null);
 

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -294,22 +294,15 @@ function createProfileContext(
           cdpUrl: profile.cdpUrl,
           bindHost: current.resolved.relayBindHost,
         });
-        if (await isHttpReachable(1200)) {
-          // continue: we still need the extension to connect for CDP websocket.
-        } else {
+        if (!(await isHttpReachable(1200))) {
           throw new Error(
             `Chrome extension relay for profile "${profile.name}" is not reachable at ${profile.cdpUrl}.`,
           );
         }
       }
-
-      if (await isReachable(600)) {
-        return;
-      }
-      // Relay server is up, but no attached tab yet. Prompt user to attach.
-      throw new Error(
-        `Chrome extension relay is running, but no tab is connected. Click the RemoteClaw Chrome extension icon on a tab to attach it (profile "${profile.name}").`,
-      );
+      // Browser startup should only ensure relay availability.
+      // Tab attachment is checked when a tab is actually required.
+      return;
     }
 
     if (!httpReachable) {

--- a/src/browser/server.auth-fail-closed.test.ts
+++ b/src/browser/server.auth-fail-closed.test.ts
@@ -1,5 +1,5 @@
-import { createServer, type AddressInfo } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getFreePort } from "./test-port.js";
 
 const mocks = vi.hoisted(() => ({
   controlPort: 0,
@@ -12,12 +12,13 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/config.js")>();
+  const browserConfig = {
+    enabled: true,
+  };
   return {
     ...actual,
     loadConfig: () => ({
-      browser: {
-        enabled: true,
-      },
+      browser: browserConfig,
     }),
   };
 });
@@ -57,17 +58,6 @@ vi.mock("./pw-ai-state.js", () => ({
 
 const { startBrowserControlServerFromConfig, stopBrowserControlServer } =
   await import("./server.js");
-
-async function getFreePort(): Promise<number> {
-  const probe = createServer();
-  await new Promise<void>((resolve, reject) => {
-    probe.once("error", reject);
-    probe.listen(0, "127.0.0.1", () => resolve());
-  });
-  const addr = probe.address() as AddressInfo;
-  await new Promise<void>((resolve) => probe.close(() => resolve()));
-  return addr.port;
-}
 
 describe("browser control auth bootstrap failures", () => {
   beforeEach(async () => {

--- a/src/browser/server.evaluate-disabled-does-not-block-storage.test.ts
+++ b/src/browser/server.evaluate-disabled-does-not-block-storage.test.ts
@@ -1,6 +1,6 @@
-import { createServer, type AddressInfo } from "node:net";
 import { fetch as realFetch } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getFreePort } from "./test-port.js";
 
 let testPort = 0;
 let prevGatewayPort: string | undefined;
@@ -67,17 +67,6 @@ vi.mock("./server-context.js", async (importOriginal) => {
 
 const { startBrowserControlServerFromConfig, stopBrowserControlServer } =
   await import("./server.js");
-
-async function getFreePort(): Promise<number> {
-  const probe = createServer();
-  await new Promise<void>((resolve, reject) => {
-    probe.once("error", reject);
-    probe.listen(0, "127.0.0.1", () => resolve());
-  });
-  const addr = probe.address() as AddressInfo;
-  await new Promise<void>((resolve) => probe.close(() => resolve()));
-  return addr.port;
-}
 
 describe("browser control evaluate gating", () => {
   beforeEach(async () => {

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -26,6 +26,27 @@ async function withStateDir<T>(stateDir: string, fn: () => Promise<T>) {
   );
 }
 
+function writePluginPackageManifest(params: {
+  packageDir: string;
+  packageName: string;
+  extensions: string[];
+}) {
+  fs.writeFileSync(
+    path.join(params.packageDir, "package.json"),
+    JSON.stringify({
+      name: params.packageName,
+      remoteclaw: { extensions: params.extensions },
+    }),
+    "utf-8",
+  );
+}
+
+function expectEscapesPackageDiagnostic(diagnostics: Array<{ message: string }>) {
+  expect(diagnostics.some((entry) => entry.message.includes("escapes package directory"))).toBe(
+    true,
+  );
+}
+
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     try {
@@ -95,14 +116,11 @@ describe("discoverRemoteClawPlugins", () => {
     const globalExt = path.join(stateDir, "extensions", "pack");
     fs.mkdirSync(path.join(globalExt, "src"), { recursive: true });
 
-    fs.writeFileSync(
-      path.join(globalExt, "package.json"),
-      JSON.stringify({
-        name: "pack",
-        remoteclaw: { extensions: ["./src/one.ts", "./src/two.ts"] },
-      }),
-      "utf-8",
-    );
+    writePluginPackageManifest({
+      packageDir: globalExt,
+      packageName: "pack",
+      extensions: ["./src/one.ts", "./src/two.ts"],
+    });
     fs.writeFileSync(
       path.join(globalExt, "src", "one.ts"),
       "export default function () {}",
@@ -128,14 +146,11 @@ describe("discoverRemoteClawPlugins", () => {
     const globalExt = path.join(stateDir, "extensions", "voice-call-pack");
     fs.mkdirSync(path.join(globalExt, "src"), { recursive: true });
 
-    fs.writeFileSync(
-      path.join(globalExt, "package.json"),
-      JSON.stringify({
-        name: "@remoteclaw/voice-call",
-        remoteclaw: { extensions: ["./src/index.ts"] },
-      }),
-      "utf-8",
-    );
+    writePluginPackageManifest({
+      packageDir: globalExt,
+      packageName: "@remoteclaw/voice-call",
+      extensions: ["./src/index.ts"],
+    });
     fs.writeFileSync(
       path.join(globalExt, "src", "index.ts"),
       "export default function () {}",
@@ -155,14 +170,11 @@ describe("discoverRemoteClawPlugins", () => {
     const packDir = path.join(stateDir, "packs", "demo-plugin-dir");
     fs.mkdirSync(packDir, { recursive: true });
 
-    fs.writeFileSync(
-      path.join(packDir, "package.json"),
-      JSON.stringify({
-        name: "@remoteclaw/demo-plugin-dir",
-        remoteclaw: { extensions: ["./index.js"] },
-      }),
-      "utf-8",
-    );
+    writePluginPackageManifest({
+      packageDir: packDir,
+      packageName: "@remoteclaw/demo-plugin-dir",
+      extensions: ["./index.js"],
+    });
     fs.writeFileSync(path.join(packDir, "index.js"), "module.exports = {}", "utf-8");
 
     const { candidates } = await withStateDir(stateDir, async () => {
@@ -178,14 +190,11 @@ describe("discoverRemoteClawPlugins", () => {
     const outside = path.join(stateDir, "outside.js");
     fs.mkdirSync(globalExt, { recursive: true });
 
-    fs.writeFileSync(
-      path.join(globalExt, "package.json"),
-      JSON.stringify({
-        name: "@remoteclaw/escape-pack",
-        remoteclaw: { extensions: ["../../outside.js"] },
-      }),
-      "utf-8",
-    );
+    writePluginPackageManifest({
+      packageDir: globalExt,
+      packageName: "@remoteclaw/escape-pack",
+      extensions: ["../../outside.js"],
+    });
     fs.writeFileSync(outside, "export default function () {}", "utf-8");
 
     const result = await withStateDir(stateDir, async () => {
@@ -193,9 +202,7 @@ describe("discoverRemoteClawPlugins", () => {
     });
 
     expect(result.candidates).toHaveLength(0);
-    expect(
-      result.diagnostics.some((diag) => diag.message.includes("escapes package directory")),
-    ).toBe(true);
+    expectEscapesPackageDiagnostic(result.diagnostics);
   });
 
   it("rejects package extension entries that escape via symlink", async () => {
@@ -212,23 +219,89 @@ describe("discoverRemoteClawPlugins", () => {
       return;
     }
 
-    fs.writeFileSync(
-      path.join(globalExt, "package.json"),
-      JSON.stringify({
-        name: "@remoteclaw/pack",
-        remoteclaw: { extensions: ["./linked/escape.ts"] },
-      }),
-      "utf-8",
-    );
+    writePluginPackageManifest({
+      packageDir: globalExt,
+      packageName: "@remoteclaw/pack",
+      extensions: ["./linked/escape.ts"],
+    });
 
     const { candidates, diagnostics } = await withStateDir(stateDir, async () => {
       return discoverRemoteClawPlugins({});
     });
 
     expect(candidates.some((candidate) => candidate.idHint === "pack")).toBe(false);
-    expect(diagnostics.some((entry) => entry.message.includes("escapes package directory"))).toBe(
-      true,
+    expectEscapesPackageDiagnostic(diagnostics);
+  });
+
+  it("rejects package extension entries that are hardlinked aliases", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions", "pack");
+    const outsideDir = path.join(stateDir, "outside");
+    const outsideFile = path.join(outsideDir, "escape.ts");
+    const linkedFile = path.join(globalExt, "escape.ts");
+    fs.mkdirSync(globalExt, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(outsideFile, "export default {}", "utf-8");
+    try {
+      fs.linkSync(outsideFile, linkedFile);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    writePluginPackageManifest({
+      packageDir: globalExt,
+      packageName: "@remoteclaw/pack",
+      extensions: ["./escape.ts"],
+    });
+
+    const { candidates, diagnostics } = await withStateDir(stateDir, async () => {
+      return discoverRemoteClawPlugins({});
+    });
+
+    expect(candidates.some((candidate) => candidate.idHint === "pack")).toBe(false);
+    expectEscapesPackageDiagnostic(diagnostics);
+  });
+
+  it("ignores package manifests that are hardlinked aliases", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions", "pack");
+    const outsideDir = path.join(stateDir, "outside");
+    const outsideManifest = path.join(outsideDir, "package.json");
+    const linkedManifest = path.join(globalExt, "package.json");
+    fs.mkdirSync(globalExt, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(path.join(globalExt, "entry.ts"), "export default {}", "utf-8");
+    fs.writeFileSync(
+      outsideManifest,
+      JSON.stringify({
+        name: "@remoteclaw/pack",
+        remoteclaw: { extensions: ["./entry.ts"] },
+      }),
+      "utf-8",
     );
+    try {
+      fs.linkSync(outsideManifest, linkedManifest);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    const { candidates } = await withStateDir(stateDir, async () => {
+      return discoverRemoteClawPlugins({});
+    });
+
+    expect(candidates.some((candidate) => candidate.idHint === "pack")).toBe(false);
   });
 
   it.runIf(process.platform !== "win32")("blocks world-writable plugin paths", async () => {

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -71,17 +71,31 @@ function checkSourceEscapesRoot(params: {
   if (!sourceRealPath || !rootRealPath) {
     return null;
   }
-  if (isPathInside(rootRealPath, sourceRealPath)) {
-    return null;
+  if (!isPathInside(rootRealPath, sourceRealPath)) {
+    return {
+      reason: "source_escapes_root",
+      sourcePath: params.source,
+      rootPath: params.rootDir,
+      targetPath: params.source,
+      sourceRealPath,
+      rootRealPath,
+    };
   }
-  return {
-    reason: "source_escapes_root",
-    sourcePath: params.source,
-    rootPath: params.rootDir,
-    targetPath: params.source,
-    sourceRealPath,
-    rootRealPath,
-  };
+  // Hardlinks share the same inode but realpath cannot detect them.
+  // Reject files with multiple hard links because they may alias content
+  // outside the root directory.
+  const stat = safeStatSync(params.source);
+  if (stat?.isFile() && stat.nlink > 1) {
+    return {
+      reason: "source_escapes_root",
+      sourcePath: params.source,
+      rootPath: params.rootDir,
+      targetPath: params.source,
+      sourceRealPath,
+      rootRealPath,
+    };
+  }
+  return null;
 }
 
 function checkPathStatAndPermissions(params: {
@@ -229,6 +243,12 @@ function readPackageManifest(dir: string): PackageManifest | null {
     return null;
   }
   try {
+    // Reject hardlinked manifests — they may alias content outside the
+    // package directory and bypass path containment checks.
+    const stat = fs.statSync(manifestPath);
+    if (stat.isFile() && stat.nlink > 1) {
+      return null;
+    }
     const raw = fs.readFileSync(manifestPath, "utf-8");
     return JSON.parse(raw) as PackageManifest;
   } catch {

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -157,6 +157,19 @@ function expectPluginFiles(result: { targetDir: string }, stateDir: string, plug
   expect(fs.existsSync(path.join(result.targetDir, "dist", "index.js"))).toBe(true);
 }
 
+function expectSuccessfulArchiveInstall(params: {
+  result: Awaited<ReturnType<typeof installPluginFromArchive>>;
+  stateDir: string;
+  pluginId: string;
+}) {
+  expect(params.result.ok).toBe(true);
+  if (!params.result.ok) {
+    return;
+  }
+  expect(params.result.pluginId).toBe(params.pluginId);
+  expectPluginFiles(params.result, params.stateDir, params.pluginId);
+}
+
 function setupPluginInstallDirs() {
   const tmpDir = makeTempDir();
   const pluginDir = path.join(tmpDir, "plugin-src");
@@ -184,6 +197,30 @@ function setupInstallPluginFromDirFixture(params?: { devDependencies?: Record<st
   );
   fs.writeFileSync(path.join(pluginDir, "dist", "index.js"), "export {};", "utf-8");
   return { pluginDir, extensionsDir: path.join(stateDir, "extensions") };
+}
+
+function setupManifestInstallFixture(params: { manifestId: string }) {
+  const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+  fs.mkdirSync(path.join(pluginDir, "dist"), { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginDir, "package.json"),
+    JSON.stringify({
+      name: "@remoteclaw/cognee-remoteclaw",
+      version: "0.0.1",
+      remoteclaw: { extensions: ["./dist/index.js"] },
+    }),
+    "utf-8",
+  );
+  fs.writeFileSync(path.join(pluginDir, "dist", "index.js"), "export {};", "utf-8");
+  fs.writeFileSync(
+    path.join(pluginDir, "remoteclaw.plugin.json"),
+    JSON.stringify({
+      id: params.manifestId,
+      configSchema: { type: "object", properties: {} },
+    }),
+    "utf-8",
+  );
+  return { pluginDir, extensionsDir };
 }
 
 async function expectArchiveInstallReservedSegmentRejection(params: {
@@ -267,12 +304,7 @@ describe("installPluginFromArchive", () => {
       archivePath,
       extensionsDir,
     });
-    expect(result.ok).toBe(true);
-    if (!result.ok) {
-      return;
-    }
-    expect(result.pluginId).toBe("voice-call");
-    expectPluginFiles(result, stateDir, "voice-call");
+    expectSuccessfulArchiveInstall({ result, stateDir, pluginId: "voice-call" });
   });
 
   it("rejects installing when plugin already exists", async () => {
@@ -310,13 +342,7 @@ describe("installPluginFromArchive", () => {
       archivePath,
       extensionsDir,
     });
-
-    expect(result.ok).toBe(true);
-    if (!result.ok) {
-      return;
-    }
-    expect(result.pluginId).toBe("zipper");
-    expectPluginFiles(result, stateDir, "zipper");
+    expectSuccessfulArchiveInstall({ result, stateDir, pluginId: "zipper" });
   });
 
   it("allows updates when mode is update", async () => {
@@ -431,26 +457,9 @@ describe("installPluginFromDir", () => {
   });
 
   it("uses remoteclaw.plugin.json id as install key when it differs from package name", async () => {
-    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-    fs.mkdirSync(path.join(pluginDir, "dist"), { recursive: true });
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "@remoteclaw/cognee-remoteclaw",
-        version: "0.0.1",
-        remoteclaw: { extensions: ["./dist/index.js"] },
-      }),
-      "utf-8",
-    );
-    fs.writeFileSync(path.join(pluginDir, "dist", "index.js"), "export {};", "utf-8");
-    fs.writeFileSync(
-      path.join(pluginDir, "remoteclaw.plugin.json"),
-      JSON.stringify({
-        id: "memory-cognee",
-        configSchema: { type: "object", properties: {} },
-      }),
-      "utf-8",
-    );
+    const { pluginDir, extensionsDir } = setupManifestInstallFixture({
+      manifestId: "memory-cognee",
+    });
 
     const infoMessages: string[] = [];
     const res = await installPluginFromDir({
@@ -475,26 +484,9 @@ describe("installPluginFromDir", () => {
   });
 
   it("normalizes scoped manifest ids to unscoped install keys", async () => {
-    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-    fs.mkdirSync(path.join(pluginDir, "dist"), { recursive: true });
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "@remoteclaw/cognee-remoteclaw",
-        version: "0.0.1",
-        remoteclaw: { extensions: ["./dist/index.js"] },
-      }),
-      "utf-8",
-    );
-    fs.writeFileSync(path.join(pluginDir, "dist", "index.js"), "export {};", "utf-8");
-    fs.writeFileSync(
-      path.join(pluginDir, "remoteclaw.plugin.json"),
-      JSON.stringify({
-        id: "@team/memory-cognee",
-        configSchema: { type: "object", properties: {} },
-      }),
-      "utf-8",
-    );
+    const { pluginDir, extensionsDir } = setupManifestInstallFixture({
+      manifestId: "@team/memory-cognee",
+    });
 
     const res = await installPluginFromDir({
       dirPath: pluginDir,

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -25,7 +25,7 @@ async function importFreshPluginTestModules() {
   };
 }
 
-const { loadRemoteClawPlugins } = await importFreshPluginTestModules();
+const { loadRemoteClawPlugins, __testing } = await importFreshPluginTestModules();
 
 type TempPlugin = { dir: string; file: string; id: string };
 

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -102,6 +102,70 @@ function expectTelegramLoaded(registry: ReturnType<typeof loadRemoteClawPlugins>
   expect(registry.channels.some((entry) => entry.plugin.id === "telegram")).toBe(true);
 }
 
+function useNoBundledPlugins() {
+  process.env.REMOTECLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+}
+
+function loadRegistryFromSinglePlugin(params: {
+  plugin: TempPlugin;
+  pluginConfig?: Record<string, unknown>;
+  includeWorkspaceDir?: boolean;
+  options?: Omit<Parameters<typeof loadRemoteClawPlugins>[0], "cache" | "workspaceDir" | "config">;
+}) {
+  const pluginConfig = params.pluginConfig ?? {};
+  return loadRemoteClawPlugins({
+    cache: false,
+    ...(params.includeWorkspaceDir === false ? {} : { workspaceDir: params.plugin.dir }),
+    ...params.options,
+    config: {
+      plugins: {
+        load: { paths: [params.plugin.file] },
+        ...pluginConfig,
+      },
+    },
+  });
+}
+
+function createWarningLogger(warnings: string[]) {
+  return {
+    info: () => {},
+    warn: (msg: string) => warnings.push(msg),
+    error: () => {},
+  };
+}
+
+function createEscapingEntryFixture(params: { id: string; sourceBody: string }) {
+  const pluginDir = makeTempDir();
+  const outsideDir = makeTempDir();
+  const outsideEntry = path.join(outsideDir, "outside.js");
+  const linkedEntry = path.join(pluginDir, "entry.js");
+  fs.writeFileSync(outsideEntry, params.sourceBody, "utf-8");
+  fs.writeFileSync(
+    path.join(pluginDir, "remoteclaw.plugin.json"),
+    JSON.stringify(
+      {
+        id: params.id,
+        configSchema: EMPTY_PLUGIN_SCHEMA,
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+  return { pluginDir, outsideEntry, linkedEntry };
+}
+
+function createPluginSdkAliasFixture() {
+  const root = makeTempDir();
+  const srcFile = path.join(root, "src", "plugin-sdk", "index.ts");
+  const distFile = path.join(root, "dist", "plugin-sdk", "index.js");
+  fs.mkdirSync(path.dirname(srcFile), { recursive: true });
+  fs.mkdirSync(path.dirname(distFile), { recursive: true });
+  fs.writeFileSync(srcFile, "export {};\n", "utf-8");
+  fs.writeFileSync(distFile, "export {};\n", "utf-8");
+  return { root, srcFile, distFile };
+}
+
 afterEach(() => {
   if (prevBundledDir === undefined) {
     delete process.env.REMOTECLAW_BUNDLED_PLUGINS_DIR;
@@ -243,7 +307,7 @@ describe("loadRemoteClawPlugins", () => {
   });
 
   it("loads plugins when source and root differ only by realpath alias", () => {
-    process.env.REMOTECLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    useNoBundledPlugins();
     const plugin = writePlugin({
       id: "alias-safe",
       body: `export default { id: "alias-safe", register() {} };`,
@@ -253,14 +317,10 @@ describe("loadRemoteClawPlugins", () => {
       return;
     }
 
-    const registry = loadRemoteClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["alias-safe"],
-        },
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["alias-safe"],
       },
     });
 
@@ -269,21 +329,17 @@ describe("loadRemoteClawPlugins", () => {
   });
 
   it("denylist disables plugins even if allowed", () => {
-    process.env.REMOTECLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    useNoBundledPlugins();
     const plugin = writePlugin({
       id: "blocked",
       body: `export default { id: "blocked", register() {} };`,
     });
 
-    const registry = loadRemoteClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["blocked"],
-          deny: ["blocked"],
-        },
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["blocked"],
+        deny: ["blocked"],
       },
     });
 
@@ -292,22 +348,18 @@ describe("loadRemoteClawPlugins", () => {
   });
 
   it("fails fast on invalid plugin config", () => {
-    process.env.REMOTECLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    useNoBundledPlugins();
     const plugin = writePlugin({
       id: "configurable",
       body: `export default { id: "configurable", register() {} };`,
     });
 
-    const registry = loadRemoteClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          entries: {
-            configurable: {
-              config: "nope" as unknown as Record<string, unknown>,
-            },
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        entries: {
+          configurable: {
+            config: "nope" as unknown as Record<string, unknown>,
           },
         },
       },
@@ -319,7 +371,7 @@ describe("loadRemoteClawPlugins", () => {
   });
 
   it("registers channel plugins", () => {
-    process.env.REMOTECLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    useNoBundledPlugins();
     const plugin = writePlugin({
       id: "channel-demo",
       body: `export default { id: "channel-demo", register(api) {
@@ -344,14 +396,10 @@ describe("loadRemoteClawPlugins", () => {
 } };`,
     });
 
-    const registry = loadRemoteClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["channel-demo"],
-        },
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["channel-demo"],
       },
     });
 
@@ -360,7 +408,7 @@ describe("loadRemoteClawPlugins", () => {
   });
 
   it("registers http handlers", () => {
-    process.env.REMOTECLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    useNoBundledPlugins();
     const plugin = writePlugin({
       id: "http-demo",
       body: `export default { id: "http-demo", register(api) {
@@ -368,14 +416,10 @@ describe("loadRemoteClawPlugins", () => {
 } };`,
     });
 
-    const registry = loadRemoteClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["http-demo"],
-        },
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["http-demo"],
       },
     });
 
@@ -386,7 +430,7 @@ describe("loadRemoteClawPlugins", () => {
   });
 
   it("registers http routes", () => {
-    process.env.REMOTECLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    useNoBundledPlugins();
     const plugin = writePlugin({
       id: "http-route-demo",
       body: `export default { id: "http-route-demo", register(api) {
@@ -394,14 +438,10 @@ describe("loadRemoteClawPlugins", () => {
 } };`,
     });
 
-    const registry = loadRemoteClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["http-route-demo"],
-        },
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["http-route-demo"],
       },
     });
 
@@ -512,7 +552,7 @@ describe("loadRemoteClawPlugins", () => {
   });
 
   it("warns when plugins.allow is empty and non-bundled plugins are discoverable", () => {
-    process.env.REMOTECLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    useNoBundledPlugins();
     const plugin = writePlugin({
       id: "warn-open-allow",
       body: `export default { id: "warn-open-allow", register() {} };`,
@@ -520,11 +560,7 @@ describe("loadRemoteClawPlugins", () => {
     const warnings: string[] = [];
     loadRemoteClawPlugins({
       cache: false,
-      logger: {
-        info: () => {},
-        warn: (msg) => warnings.push(msg),
-        error: () => {},
-      },
+      logger: createWarningLogger(warnings),
       config: {
         plugins: {
           load: { paths: [plugin.file] },
@@ -537,7 +573,7 @@ describe("loadRemoteClawPlugins", () => {
   });
 
   it("warns when loaded non-bundled plugin has no install/load-path provenance", () => {
-    process.env.REMOTECLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    useNoBundledPlugins();
     const stateDir = makeTempDir();
     withEnv({ REMOTECLAW_STATE_DIR: stateDir, CLAWDBOT_STATE_DIR: undefined }, () => {
       const globalDir = path.join(stateDir, "extensions", "rogue");
@@ -552,11 +588,7 @@ describe("loadRemoteClawPlugins", () => {
       const warnings: string[] = [];
       const registry = loadRemoteClawPlugins({
         cache: false,
-        logger: {
-          info: () => {},
-          warn: (msg) => warnings.push(msg),
-          error: () => {},
-        },
+        logger: createWarningLogger(warnings),
         config: {
           plugins: {
             allow: ["rogue"],
@@ -576,28 +608,12 @@ describe("loadRemoteClawPlugins", () => {
   });
 
   it("rejects plugin entry files that escape plugin root via symlink", () => {
-    process.env.REMOTECLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
-    const pluginDir = makeTempDir();
-    const outsideDir = makeTempDir();
-    const outsideEntry = path.join(outsideDir, "outside.js");
-    const linkedEntry = path.join(pluginDir, "entry.js");
-    fs.writeFileSync(
-      outsideEntry,
-      'export default { id: "symlinked", register() { throw new Error("should not run"); } };',
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "remoteclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "symlinked",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    useNoBundledPlugins();
+    const { outsideEntry, linkedEntry } = createEscapingEntryFixture({
+      id: "symlinked",
+      sourceBody:
+        'export default { id: "symlinked", register() { throw new Error("should not run"); } };',
+    });
     try {
       fs.symlinkSync(outsideEntry, linkedEntry);
     } catch {
@@ -617,5 +633,63 @@ describe("loadRemoteClawPlugins", () => {
     const record = registry.plugins.find((entry) => entry.id === "symlinked");
     expect(record?.status).not.toBe("loaded");
     expect(registry.diagnostics.some((entry) => entry.message.includes("escapes"))).toBe(true);
+  });
+
+  it("rejects plugin entry files that escape plugin root via hardlink", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    useNoBundledPlugins();
+    const { outsideEntry, linkedEntry } = createEscapingEntryFixture({
+      id: "hardlinked",
+      sourceBody:
+        'export default { id: "hardlinked", register() { throw new Error("should not run"); } };',
+    });
+    try {
+      fs.linkSync(outsideEntry, linkedEntry);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    const registry = loadRemoteClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [linkedEntry] },
+          allow: ["hardlinked"],
+        },
+      },
+    });
+
+    const record = registry.plugins.find((entry) => entry.id === "hardlinked");
+    expect(record?.status).not.toBe("loaded");
+    expect(registry.diagnostics.some((entry) => entry.message.includes("escapes"))).toBe(true);
+  });
+
+  it("prefers dist plugin-sdk alias when loader runs from dist", () => {
+    const { root, distFile } = createPluginSdkAliasFixture();
+
+    const resolved = __testing.resolvePluginSdkAliasFile({
+      srcFile: "index.ts",
+      distFile: "index.js",
+      modulePath: path.join(root, "dist", "plugins", "loader.js"),
+    });
+    expect(resolved).toBe(distFile);
+  });
+
+  it("prefers src plugin-sdk alias when loader runs from src in non-production", () => {
+    const { root, srcFile } = createPluginSdkAliasFixture();
+
+    const resolved = withEnv({ NODE_ENV: undefined }, () =>
+      __testing.resolvePluginSdkAliasFile({
+        srcFile: "index.ts",
+        distFile: "index.js",
+        modulePath: path.join(root, "src", "plugins", "loader.ts"),
+      }),
+    );
+    expect(resolved).toBe(srcFile);
   });
 });

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -53,15 +53,19 @@ const resolvePluginSdkAliasFile = (params: {
     const modulePath = params.modulePath ?? fileURLToPath(import.meta.url);
     const isProduction = process.env.NODE_ENV === "production";
     const isTest = process.env.VITEST || process.env.NODE_ENV === "test";
+    // When the loader itself runs from dist/, prefer the dist SDK alias even
+    // in non-production mode (e.g. test-from-dist scenarios).
+    const loaderFromDist = /[\\/]dist[\\/]/.test(modulePath);
     let cursor = path.dirname(modulePath);
     for (let i = 0; i < 6; i += 1) {
       const srcCandidate = path.join(cursor, "src", "plugin-sdk", params.srcFile);
       const distCandidate = path.join(cursor, "dist", "plugin-sdk", params.distFile);
-      const orderedCandidates = isProduction
-        ? isTest
-          ? [distCandidate, srcCandidate]
-          : [distCandidate]
-        : [srcCandidate, distCandidate];
+      const orderedCandidates =
+        isProduction || loaderFromDist
+          ? isTest
+            ? [distCandidate, srcCandidate]
+            : [distCandidate]
+          : [srcCandidate, distCandidate];
       for (const candidate of orderedCandidates) {
         if (fs.existsSync(candidate)) {
           return candidate;

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -47,9 +47,10 @@ const defaultLogger = () => createSubsystemLogger("plugins");
 const resolvePluginSdkAliasFile = (params: {
   srcFile: string;
   distFile: string;
+  modulePath?: string;
 }): string | null => {
   try {
-    const modulePath = fileURLToPath(import.meta.url);
+    const modulePath = params.modulePath ?? fileURLToPath(import.meta.url);
     const isProduction = process.env.NODE_ENV === "production";
     const isTest = process.env.VITEST || process.env.NODE_ENV === "test";
     let cursor = path.dirname(modulePath);
@@ -664,3 +665,6 @@ export function loadRemoteClawPlugins(options: PluginLoadOptions = {}): PluginRe
   initializeGlobalHookRunner(registry);
   return registry;
 }
+
+/** @internal Exposed for unit tests only. */
+export const __testing = { resolvePluginSdkAliasFile };

--- a/src/security/scan-paths.ts
+++ b/src/security/scan-paths.ts
@@ -29,7 +29,23 @@ export function isPathInsideWithRealpath(
   if (!baseReal || !candidateReal) {
     return opts?.requireRealpath !== true;
   }
-  return isPathInside(baseReal, candidateReal);
+  if (!isPathInside(baseReal, candidateReal)) {
+    return false;
+  }
+  // Hardlinks share the same inode but realpath cannot detect them.
+  // When strict mode is requested, reject files with multiple hard links
+  // because they may alias content outside the base directory.
+  if (opts?.requireRealpath) {
+    try {
+      const stat = fs.statSync(candidatePath);
+      if (stat.isFile() && stat.nlink > 1) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+  }
+  return true;
 }
 
 export function extensionUsesSkippedScannerPath(entry: string): boolean {

--- a/src/slack/actions.download-file.test.ts
+++ b/src/slack/actions.download-file.test.ts
@@ -21,6 +21,45 @@ function createClient() {
   };
 }
 
+function makeSlackFileInfo(overrides?: Record<string, unknown>) {
+  return {
+    id: "F123",
+    name: "image.png",
+    mimetype: "image/png",
+    url_private_download: "https://files.slack.com/files-pri/T1-F123/image.png",
+    ...overrides,
+  };
+}
+
+function makeResolvedSlackMedia() {
+  return {
+    path: "/tmp/image.png",
+    contentType: "image/png",
+    placeholder: "[Slack file: image.png]",
+  };
+}
+
+function expectNoMediaDownload(result: Awaited<ReturnType<typeof downloadSlackFile>>) {
+  expect(result).toBeNull();
+  expect(resolveSlackMedia).not.toHaveBeenCalled();
+}
+
+function expectResolveSlackMediaCalledWithDefaults() {
+  expect(resolveSlackMedia).toHaveBeenCalledWith({
+    files: [
+      {
+        id: "F123",
+        name: "image.png",
+        mimetype: "image/png",
+        url_private: undefined,
+        url_private_download: "https://files.slack.com/files-pri/T1-F123/image.png",
+      },
+    ],
+    token: "xoxb-test",
+    maxBytes: 1024,
+  });
+}
+
 describe("downloadSlackFile", () => {
   beforeEach(() => {
     resolveSlackMedia.mockReset();
@@ -48,20 +87,9 @@ describe("downloadSlackFile", () => {
   it("downloads via resolveSlackMedia using fresh files.info metadata", async () => {
     const client = createClient();
     client.files.info.mockResolvedValueOnce({
-      file: {
-        id: "F123",
-        name: "image.png",
-        mimetype: "image/png",
-        url_private_download: "https://files.slack.com/files-pri/T1-F123/image.png",
-      },
+      file: makeSlackFileInfo(),
     });
-    resolveSlackMedia.mockResolvedValueOnce([
-      {
-        path: "/tmp/image.png",
-        contentType: "image/png",
-        placeholder: "[Slack file: image.png]",
-      },
-    ]);
+    resolveSlackMedia.mockResolvedValueOnce([makeResolvedSlackMedia()]);
 
     const result = await downloadSlackFile("F123", {
       client,
@@ -70,36 +98,14 @@ describe("downloadSlackFile", () => {
     });
 
     expect(client.files.info).toHaveBeenCalledWith({ file: "F123" });
-    expect(resolveSlackMedia).toHaveBeenCalledWith({
-      files: [
-        {
-          id: "F123",
-          name: "image.png",
-          mimetype: "image/png",
-          url_private: undefined,
-          url_private_download: "https://files.slack.com/files-pri/T1-F123/image.png",
-        },
-      ],
-      token: "xoxb-test",
-      maxBytes: 1024,
-    });
-    expect(result).toEqual({
-      path: "/tmp/image.png",
-      contentType: "image/png",
-      placeholder: "[Slack file: image.png]",
-    });
+    expectResolveSlackMediaCalledWithDefaults();
+    expect(result).toEqual(makeResolvedSlackMedia());
   });
 
   it("returns null when channel scope definitely mismatches file shares", async () => {
     const client = createClient();
     client.files.info.mockResolvedValueOnce({
-      file: {
-        id: "F123",
-        name: "image.png",
-        mimetype: "image/png",
-        url_private_download: "https://files.slack.com/files-pri/T1-F123/image.png",
-        channels: ["C999"],
-      },
+      file: makeSlackFileInfo({ channels: ["C999"] }),
     });
 
     const result = await downloadSlackFile("F123", {
@@ -109,24 +115,19 @@ describe("downloadSlackFile", () => {
       channelId: "C123",
     });
 
-    expect(result).toBeNull();
-    expect(resolveSlackMedia).not.toHaveBeenCalled();
+    expectNoMediaDownload(result);
   });
 
   it("returns null when thread scope definitely mismatches file share thread", async () => {
     const client = createClient();
     client.files.info.mockResolvedValueOnce({
-      file: {
-        id: "F123",
-        name: "image.png",
-        mimetype: "image/png",
-        url_private_download: "https://files.slack.com/files-pri/T1-F123/image.png",
+      file: makeSlackFileInfo({
         shares: {
           private: {
             C123: [{ ts: "111.111", thread_ts: "111.111" }],
           },
         },
-      },
+      }),
     });
 
     const result = await downloadSlackFile("F123", {
@@ -137,27 +138,15 @@ describe("downloadSlackFile", () => {
       threadId: "222.222",
     });
 
-    expect(result).toBeNull();
-    expect(resolveSlackMedia).not.toHaveBeenCalled();
+    expectNoMediaDownload(result);
   });
 
   it("keeps legacy behavior when file metadata does not expose channel/thread shares", async () => {
     const client = createClient();
     client.files.info.mockResolvedValueOnce({
-      file: {
-        id: "F123",
-        name: "image.png",
-        mimetype: "image/png",
-        url_private_download: "https://files.slack.com/files-pri/T1-F123/image.png",
-      },
+      file: makeSlackFileInfo(),
     });
-    resolveSlackMedia.mockResolvedValueOnce([
-      {
-        path: "/tmp/image.png",
-        contentType: "image/png",
-        placeholder: "[Slack file: image.png]",
-      },
-    ]);
+    resolveSlackMedia.mockResolvedValueOnce([makeResolvedSlackMedia()]);
 
     const result = await downloadSlackFile("F123", {
       client,
@@ -167,11 +156,8 @@ describe("downloadSlackFile", () => {
       threadId: "222.222",
     });
 
-    expect(result).toEqual({
-      path: "/tmp/image.png",
-      contentType: "image/png",
-      placeholder: "[Slack file: image.png]",
-    });
+    expect(result).toEqual(makeResolvedSlackMedia());
     expect(resolveSlackMedia).toHaveBeenCalledTimes(1);
+    expectResolveSlackMediaCalledWithDefaults();
   });
 });

--- a/src/slack/monitor/events/members.test.ts
+++ b/src/slack/monitor/events/members.test.ts
@@ -25,7 +25,6 @@ type MemberCaseArgs = {
   body?: unknown;
   overrides?: MemberOverrides;
   handler?: "joined" | "left";
-  trackEvent?: () => void;
   shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
 };
 
@@ -40,14 +39,13 @@ function makeMemberEvent(overrides?: { channel?: string; user?: string }) {
 
 function getMemberHandlers(params: {
   overrides?: MemberOverrides;
-  trackEvent?: () => void;
   shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
 }) {
   const harness = initSlackHarness(params.overrides);
   if (params.shouldDropMismatchedSlackEvent) {
     harness.ctx.shouldDropMismatchedSlackEvent = params.shouldDropMismatchedSlackEvent;
   }
-  registerSlackMemberEvents({ ctx: harness.ctx, trackEvent: params.trackEvent });
+  registerSlackMemberEvents({ ctx: harness.ctx });
   return {
     joined: harness.getHandler("member_joined_channel") as MemberHandler | null,
     left: harness.getHandler("member_left_channel") as MemberHandler | null,
@@ -59,7 +57,6 @@ async function runMemberCase(args: MemberCaseArgs = {}): Promise<void> {
   memberMocks.readAllow.mockReset().mockResolvedValue([]);
   const handlers = getMemberHandlers({
     overrides: args.overrides,
-    trackEvent: args.trackEvent,
     shouldDropMismatchedSlackEvent: args.shouldDropMismatchedSlackEvent,
   });
   const key = args.handler ?? "joined";
@@ -75,18 +72,18 @@ describe("registerSlackMemberEvents", () => {
   it.each([
     {
       name: "enqueues DM member events when dmPolicy is open",
-      args: { overrides: { dmPolicy: "open" } },
+      args: { overrides: { dmPolicy: "open" as const } },
       calls: 1,
     },
     {
       name: "blocks DM member events when dmPolicy is disabled",
-      args: { overrides: { dmPolicy: "disabled" } },
+      args: { overrides: { dmPolicy: "disabled" as const } },
       calls: 0,
     },
     {
       name: "blocks DM member events for unauthorized senders in allowlist mode",
       args: {
-        overrides: { dmPolicy: "allowlist", allowFrom: ["U2"] },
+        overrides: { dmPolicy: "allowlist" as const, allowFrom: ["U2"] },
         event: makeMemberEvent({ user: "U1" }),
       },
       calls: 0,
@@ -95,7 +92,7 @@ describe("registerSlackMemberEvents", () => {
       name: "allows DM member events for authorized senders in allowlist mode",
       args: {
         handler: "left" as const,
-        overrides: { dmPolicy: "allowlist", allowFrom: ["U1"] },
+        overrides: { dmPolicy: "allowlist" as const, allowFrom: ["U1"] },
         event: { ...makeMemberEvent({ user: "U1" }), type: "member_left_channel" },
       },
       calls: 1,
@@ -104,8 +101,8 @@ describe("registerSlackMemberEvents", () => {
       name: "blocks channel member events for users outside channel users allowlist",
       args: {
         overrides: {
-          dmPolicy: "open",
-          channelType: "channel",
+          dmPolicy: "open" as const,
+          channelType: "channel" as const,
           channelUsers: ["U_OWNER"],
         },
         event: makeMemberEvent({ channel: "C1", user: "U_ATTACKER" }),
@@ -117,21 +114,12 @@ describe("registerSlackMemberEvents", () => {
     expect(memberMocks.enqueue).toHaveBeenCalledTimes(calls);
   });
 
-  it("does not track mismatched events", async () => {
-    const trackEvent = vi.fn();
+  it("drops mismatched events", async () => {
     await runMemberCase({
-      trackEvent,
       shouldDropMismatchedSlackEvent: () => true,
       body: { api_app_id: "A_OTHER" },
     });
 
-    expect(trackEvent).not.toHaveBeenCalled();
-  });
-
-  it("tracks accepted member events", async () => {
-    const trackEvent = vi.fn();
-    await runMemberCase({ trackEvent });
-
-    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(memberMocks.enqueue).not.toHaveBeenCalled();
   });
 });

--- a/src/slack/monitor/events/members.test.ts
+++ b/src/slack/monitor/events/members.test.ts
@@ -1,37 +1,35 @@
 import { describe, expect, it, vi } from "vitest";
 import { registerSlackMemberEvents } from "./members.js";
 import {
-  createSlackSystemEventTestHarness,
-  type SlackSystemEventTestOverrides,
+  createSlackSystemEventTestHarness as initSlackHarness,
+  type SlackSystemEventTestOverrides as MemberOverrides,
 } from "./system-event-test-harness.js";
 
-const enqueueSystemEventMock = vi.fn();
-const readAllowFromStoreMock = vi.fn();
+const memberMocks = vi.hoisted(() => ({
+  enqueue: vi.fn(),
+  readAllow: vi.fn(),
+}));
 
 vi.mock("../../../infra/system-events.js", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+  enqueueSystemEvent: memberMocks.enqueue,
 }));
 
 vi.mock("../../../pairing/pairing-store.js", () => ({
-  readChannelAllowFromStore: (...args: unknown[]) => readAllowFromStoreMock(...args),
+  readChannelAllowFromStore: memberMocks.readAllow,
 }));
 
-type SlackMemberHandler = (args: {
-  event: Record<string, unknown>;
-  body: unknown;
-}) => Promise<void>;
+type MemberHandler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
 
-function createMembersContext(overrides?: SlackSystemEventTestOverrides) {
-  const harness = createSlackSystemEventTestHarness(overrides);
-  registerSlackMemberEvents({ ctx: harness.ctx });
-  return {
-    getJoinedHandler: () =>
-      harness.getHandler("member_joined_channel") as SlackMemberHandler | null,
-    getLeftHandler: () => harness.getHandler("member_left_channel") as SlackMemberHandler | null,
-  };
-}
+type MemberCaseArgs = {
+  event?: Record<string, unknown>;
+  body?: unknown;
+  overrides?: MemberOverrides;
+  handler?: "joined" | "left";
+  trackEvent?: () => void;
+  shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
+};
 
-function makeMemberEvent(overrides?: { user?: string; channel?: string }) {
+function makeMemberEvent(overrides?: { channel?: string; user?: string }) {
   return {
     type: "member_joined_channel",
     user: overrides?.user ?? "U1",
@@ -40,92 +38,100 @@ function makeMemberEvent(overrides?: { user?: string; channel?: string }) {
   };
 }
 
+function getMemberHandlers(params: {
+  overrides?: MemberOverrides;
+  trackEvent?: () => void;
+  shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
+}) {
+  const harness = initSlackHarness(params.overrides);
+  if (params.shouldDropMismatchedSlackEvent) {
+    harness.ctx.shouldDropMismatchedSlackEvent = params.shouldDropMismatchedSlackEvent;
+  }
+  registerSlackMemberEvents({ ctx: harness.ctx, trackEvent: params.trackEvent });
+  return {
+    joined: harness.getHandler("member_joined_channel") as MemberHandler | null,
+    left: harness.getHandler("member_left_channel") as MemberHandler | null,
+  };
+}
+
+async function runMemberCase(args: MemberCaseArgs = {}): Promise<void> {
+  memberMocks.enqueue.mockClear();
+  memberMocks.readAllow.mockReset().mockResolvedValue([]);
+  const handlers = getMemberHandlers({
+    overrides: args.overrides,
+    trackEvent: args.trackEvent,
+    shouldDropMismatchedSlackEvent: args.shouldDropMismatchedSlackEvent,
+  });
+  const key = args.handler ?? "joined";
+  const handler = handlers[key];
+  expect(handler).toBeTruthy();
+  await handler!({
+    event: (args.event ?? makeMemberEvent()) as Record<string, unknown>,
+    body: args.body ?? {},
+  });
+}
+
 describe("registerSlackMemberEvents", () => {
-  it("enqueues DM member events when dmPolicy is open", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getJoinedHandler } = createMembersContext({ dmPolicy: "open" });
-    const joinedHandler = getJoinedHandler();
-    expect(joinedHandler).toBeTruthy();
-
-    await joinedHandler!({
-      event: makeMemberEvent(),
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("blocks DM member events when dmPolicy is disabled", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getJoinedHandler } = createMembersContext({ dmPolicy: "disabled" });
-    const joinedHandler = getJoinedHandler();
-    expect(joinedHandler).toBeTruthy();
-
-    await joinedHandler!({
-      event: makeMemberEvent(),
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
-  });
-
-  it("blocks DM member events for unauthorized senders in allowlist mode", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getJoinedHandler } = createMembersContext({
-      dmPolicy: "allowlist",
-      allowFrom: ["U2"],
-    });
-    const joinedHandler = getJoinedHandler();
-    expect(joinedHandler).toBeTruthy();
-
-    await joinedHandler!({
-      event: makeMemberEvent({ user: "U1" }),
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
-  });
-
-  it("allows DM member events for authorized senders in allowlist mode", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getLeftHandler } = createMembersContext({
-      dmPolicy: "allowlist",
-      allowFrom: ["U1"],
-    });
-    const leftHandler = getLeftHandler();
-    expect(leftHandler).toBeTruthy();
-
-    await leftHandler!({
-      event: {
-        ...makeMemberEvent({ user: "U1" }),
-        type: "member_left_channel",
+  it.each([
+    {
+      name: "enqueues DM member events when dmPolicy is open",
+      args: { overrides: { dmPolicy: "open" } },
+      calls: 1,
+    },
+    {
+      name: "blocks DM member events when dmPolicy is disabled",
+      args: { overrides: { dmPolicy: "disabled" } },
+      calls: 0,
+    },
+    {
+      name: "blocks DM member events for unauthorized senders in allowlist mode",
+      args: {
+        overrides: { dmPolicy: "allowlist", allowFrom: ["U2"] },
+        event: makeMemberEvent({ user: "U1" }),
       },
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+      calls: 0,
+    },
+    {
+      name: "allows DM member events for authorized senders in allowlist mode",
+      args: {
+        handler: "left" as const,
+        overrides: { dmPolicy: "allowlist", allowFrom: ["U1"] },
+        event: { ...makeMemberEvent({ user: "U1" }), type: "member_left_channel" },
+      },
+      calls: 1,
+    },
+    {
+      name: "blocks channel member events for users outside channel users allowlist",
+      args: {
+        overrides: {
+          dmPolicy: "open",
+          channelType: "channel",
+          channelUsers: ["U_OWNER"],
+        },
+        event: makeMemberEvent({ channel: "C1", user: "U_ATTACKER" }),
+      },
+      calls: 0,
+    },
+  ])("$name", async ({ args, calls }) => {
+    await runMemberCase(args);
+    expect(memberMocks.enqueue).toHaveBeenCalledTimes(calls);
   });
 
-  it("blocks channel member events for users outside channel users allowlist", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getJoinedHandler } = createMembersContext({
-      dmPolicy: "open",
-      channelType: "channel",
-      channelUsers: ["U_OWNER"],
-    });
-    const joinedHandler = getJoinedHandler();
-    expect(joinedHandler).toBeTruthy();
-
-    await joinedHandler!({
-      event: makeMemberEvent({ channel: "C1", user: "U_ATTACKER" }),
-      body: {},
+  it("does not track mismatched events", async () => {
+    const trackEvent = vi.fn();
+    await runMemberCase({
+      trackEvent,
+      shouldDropMismatchedSlackEvent: () => true,
+      body: { api_app_id: "A_OTHER" },
     });
 
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
+  it("tracks accepted member events", async () => {
+    const trackEvent = vi.fn();
+    await runMemberCase({ trackEvent });
+
+    expect(trackEvent).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/slack/monitor/events/messages.test.ts
+++ b/src/slack/monitor/events/messages.test.ts
@@ -5,23 +5,26 @@ import {
   type SlackSystemEventTestOverrides,
 } from "./system-event-test-harness.js";
 
-const enqueueSystemEventMock = vi.fn();
-const readAllowFromStoreMock = vi.fn();
+const messageQueueMock = vi.fn();
+const messageAllowMock = vi.fn();
 
 vi.mock("../../../infra/system-events.js", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+  enqueueSystemEvent: (...args: unknown[]) => messageQueueMock(...args),
 }));
 
 vi.mock("../../../pairing/pairing-store.js", () => ({
-  readChannelAllowFromStore: (...args: unknown[]) => readAllowFromStoreMock(...args),
+  readChannelAllowFromStore: (...args: unknown[]) => messageAllowMock(...args),
 }));
 
-type SlackMessageHandler = (args: {
-  event: Record<string, unknown>;
-  body: unknown;
-}) => Promise<void>;
+type MessageHandler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
 
-function createMessagesContext(overrides?: SlackSystemEventTestOverrides) {
+type MessageCase = {
+  overrides?: SlackSystemEventTestOverrides;
+  event?: Record<string, unknown>;
+  body?: unknown;
+};
+
+function createMessageHandlers(overrides?: SlackSystemEventTestOverrides) {
   const harness = createSlackSystemEventTestHarness(overrides);
   const handleSlackMessage = vi.fn(async () => {});
   registerSlackMessageEvents({
@@ -29,7 +32,7 @@ function createMessagesContext(overrides?: SlackSystemEventTestOverrides) {
     handleSlackMessage,
   });
   return {
-    getMessageHandler: () => harness.getHandler("message") as SlackMessageHandler | null,
+    handler: harness.getHandler("message") as MessageHandler | null,
     handleSlackMessage,
   };
 }
@@ -40,14 +43,8 @@ function makeChangedEvent(overrides?: { channel?: string; user?: string }) {
     type: "message",
     subtype: "message_changed",
     channel: overrides?.channel ?? "D1",
-    message: {
-      ts: "123.456",
-      user,
-    },
-    previous_message: {
-      ts: "123.450",
-      user,
-    },
+    message: { ts: "123.456", user },
+    previous_message: { ts: "123.450", user },
     event_ts: "123.456",
   };
 }
@@ -73,113 +70,78 @@ function makeThreadBroadcastEvent(overrides?: { channel?: string; user?: string 
     subtype: "thread_broadcast",
     channel: overrides?.channel ?? "D1",
     user,
-    message: {
-      ts: "123.456",
-      user,
-    },
+    message: { ts: "123.456", user },
     event_ts: "123.456",
   };
 }
 
+async function runMessageCase(input: MessageCase = {}): Promise<void> {
+  messageQueueMock.mockClear();
+  messageAllowMock.mockReset().mockResolvedValue([]);
+  const { handler } = createMessageHandlers(input.overrides);
+  expect(handler).toBeTruthy();
+  await handler!({
+    event: (input.event ?? makeChangedEvent()) as Record<string, unknown>,
+    body: input.body ?? {},
+  });
+}
+
 describe("registerSlackMessageEvents", () => {
-  it("enqueues message_changed system events when dmPolicy is open", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getMessageHandler } = createMessagesContext({ dmPolicy: "open" });
-    const messageHandler = getMessageHandler();
-    expect(messageHandler).toBeTruthy();
-
-    await messageHandler!({
-      event: makeChangedEvent(),
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("blocks message_changed system events when dmPolicy is disabled", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getMessageHandler } = createMessagesContext({ dmPolicy: "disabled" });
-    const messageHandler = getMessageHandler();
-    expect(messageHandler).toBeTruthy();
-
-    await messageHandler!({
-      event: makeChangedEvent(),
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
-  });
-
-  it("blocks message_changed system events for unauthorized senders in allowlist mode", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getMessageHandler } = createMessagesContext({
-      dmPolicy: "allowlist",
-      allowFrom: ["U2"],
-    });
-    const messageHandler = getMessageHandler();
-    expect(messageHandler).toBeTruthy();
-
-    await messageHandler!({
-      event: makeChangedEvent({ user: "U1" }),
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
-  });
-
-  it("blocks message_deleted system events for users outside channel users allowlist", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getMessageHandler } = createMessagesContext({
-      dmPolicy: "open",
-      channelType: "channel",
-      channelUsers: ["U_OWNER"],
-    });
-    const messageHandler = getMessageHandler();
-    expect(messageHandler).toBeTruthy();
-
-    await messageHandler!({
-      event: makeDeletedEvent({ channel: "C1", user: "U_ATTACKER" }),
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
-  });
-
-  it("blocks thread_broadcast system events without an authenticated sender", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getMessageHandler } = createMessagesContext({ dmPolicy: "open" });
-    const messageHandler = getMessageHandler();
-    expect(messageHandler).toBeTruthy();
-
-    await messageHandler!({
-      event: {
-        ...makeThreadBroadcastEvent(),
-        user: undefined,
-        message: {
-          ts: "123.456",
+  it.each([
+    {
+      name: "enqueues message_changed system events when dmPolicy is open",
+      input: { overrides: { dmPolicy: "open" }, event: makeChangedEvent() },
+      calls: 1,
+    },
+    {
+      name: "blocks message_changed system events when dmPolicy is disabled",
+      input: { overrides: { dmPolicy: "disabled" }, event: makeChangedEvent() },
+      calls: 0,
+    },
+    {
+      name: "blocks message_changed system events for unauthorized senders in allowlist mode",
+      input: {
+        overrides: { dmPolicy: "allowlist", allowFrom: ["U2"] },
+        event: makeChangedEvent({ user: "U1" }),
+      },
+      calls: 0,
+    },
+    {
+      name: "blocks message_deleted system events for users outside channel users allowlist",
+      input: {
+        overrides: {
+          dmPolicy: "open",
+          channelType: "channel",
+          channelUsers: ["U_OWNER"],
+        },
+        event: makeDeletedEvent({ channel: "C1", user: "U_ATTACKER" }),
+      },
+      calls: 0,
+    },
+    {
+      name: "blocks thread_broadcast system events without an authenticated sender",
+      input: {
+        overrides: { dmPolicy: "open" },
+        event: {
+          ...makeThreadBroadcastEvent(),
+          user: undefined,
+          message: { ts: "123.456" },
         },
       },
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+      calls: 0,
+    },
+  ])("$name", async ({ input, calls }) => {
+    await runMessageCase(input);
+    expect(messageQueueMock).toHaveBeenCalledTimes(calls);
   });
 
   it("passes regular message events to the message handler", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getMessageHandler, handleSlackMessage } = createMessagesContext({
-      dmPolicy: "open",
-    });
-    const messageHandler = getMessageHandler();
-    expect(messageHandler).toBeTruthy();
+    messageQueueMock.mockClear();
+    messageAllowMock.mockReset().mockResolvedValue([]);
+    const { handler, handleSlackMessage } = createMessageHandlers({ dmPolicy: "open" });
+    expect(handler).toBeTruthy();
 
-    await messageHandler!({
+    await handler!({
       event: {
         type: "message",
         channel: "D1",
@@ -191,6 +153,6 @@ describe("registerSlackMessageEvents", () => {
     });
 
     expect(handleSlackMessage).toHaveBeenCalledTimes(1);
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(messageQueueMock).not.toHaveBeenCalled();
   });
 });

--- a/src/slack/monitor/events/messages.test.ts
+++ b/src/slack/monitor/events/messages.test.ts
@@ -90,18 +90,18 @@ describe("registerSlackMessageEvents", () => {
   it.each([
     {
       name: "enqueues message_changed system events when dmPolicy is open",
-      input: { overrides: { dmPolicy: "open" }, event: makeChangedEvent() },
+      input: { overrides: { dmPolicy: "open" as const }, event: makeChangedEvent() },
       calls: 1,
     },
     {
       name: "blocks message_changed system events when dmPolicy is disabled",
-      input: { overrides: { dmPolicy: "disabled" }, event: makeChangedEvent() },
+      input: { overrides: { dmPolicy: "disabled" as const }, event: makeChangedEvent() },
       calls: 0,
     },
     {
       name: "blocks message_changed system events for unauthorized senders in allowlist mode",
       input: {
-        overrides: { dmPolicy: "allowlist", allowFrom: ["U2"] },
+        overrides: { dmPolicy: "allowlist" as const, allowFrom: ["U2"] },
         event: makeChangedEvent({ user: "U1" }),
       },
       calls: 0,
@@ -110,8 +110,8 @@ describe("registerSlackMessageEvents", () => {
       name: "blocks message_deleted system events for users outside channel users allowlist",
       input: {
         overrides: {
-          dmPolicy: "open",
-          channelType: "channel",
+          dmPolicy: "open" as const,
+          channelType: "channel" as const,
           channelUsers: ["U_OWNER"],
         },
         event: makeDeletedEvent({ channel: "C1", user: "U_ATTACKER" }),
@@ -121,7 +121,7 @@ describe("registerSlackMessageEvents", () => {
     {
       name: "blocks thread_broadcast system events without an authenticated sender",
       input: {
-        overrides: { dmPolicy: "open" },
+        overrides: { dmPolicy: "open" as const },
         event: {
           ...makeThreadBroadcastEvent(),
           user: undefined,

--- a/src/slack/monitor/events/pins.test.ts
+++ b/src/slack/monitor/events/pins.test.ts
@@ -1,33 +1,32 @@
 import { describe, expect, it, vi } from "vitest";
 import { registerSlackPinEvents } from "./pins.js";
 import {
-  createSlackSystemEventTestHarness,
-  type SlackSystemEventTestOverrides,
+  createSlackSystemEventTestHarness as buildPinHarness,
+  type SlackSystemEventTestOverrides as PinOverrides,
 } from "./system-event-test-harness.js";
 
-const enqueueSystemEventMock = vi.fn();
-const readAllowFromStoreMock = vi.fn();
+const pinEnqueueMock = vi.hoisted(() => vi.fn());
+const pinAllowMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../../../infra/system-events.js", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
-}));
-
+vi.mock("../../../infra/system-events.js", () => {
+  return { enqueueSystemEvent: pinEnqueueMock };
+});
 vi.mock("../../../pairing/pairing-store.js", () => ({
-  readChannelAllowFromStore: (...args: unknown[]) => readAllowFromStoreMock(...args),
+  readChannelAllowFromStore: pinAllowMock,
 }));
 
-type SlackPinHandler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
+type PinHandler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
 
-function createPinContext(overrides?: SlackSystemEventTestOverrides) {
-  const harness = createSlackSystemEventTestHarness(overrides);
-  registerSlackPinEvents({ ctx: harness.ctx });
-  return {
-    getAddedHandler: () => harness.getHandler("pin_added") as SlackPinHandler | null,
-    getRemovedHandler: () => harness.getHandler("pin_removed") as SlackPinHandler | null,
-  };
-}
+type PinCase = {
+  body?: unknown;
+  event?: Record<string, unknown>;
+  handler?: "added" | "removed";
+  overrides?: PinOverrides;
+  trackEvent?: () => void;
+  shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
+};
 
-function makePinEvent(overrides?: { user?: string; channel?: string }) {
+function makePinEvent(overrides?: { channel?: string; user?: string }) {
   return {
     type: "pin_added",
     user: overrides?.user ?? "U1",
@@ -35,96 +34,102 @@ function makePinEvent(overrides?: { user?: string; channel?: string }) {
     event_ts: "123.456",
     item: {
       type: "message",
-      message: {
-        ts: "123.456",
-      },
+      message: { ts: "123.456" },
     },
   };
 }
 
+function installPinHandlers(args: {
+  overrides?: PinOverrides;
+  trackEvent?: () => void;
+  shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
+}) {
+  const harness = buildPinHarness(args.overrides);
+  if (args.shouldDropMismatchedSlackEvent) {
+    harness.ctx.shouldDropMismatchedSlackEvent = args.shouldDropMismatchedSlackEvent;
+  }
+  registerSlackPinEvents({ ctx: harness.ctx, trackEvent: args.trackEvent });
+  return {
+    added: harness.getHandler("pin_added") as PinHandler | null,
+    removed: harness.getHandler("pin_removed") as PinHandler | null,
+  };
+}
+
+async function runPinCase(input: PinCase = {}): Promise<void> {
+  pinEnqueueMock.mockClear();
+  pinAllowMock.mockReset().mockResolvedValue([]);
+  const { added, removed } = installPinHandlers({
+    overrides: input.overrides,
+    trackEvent: input.trackEvent,
+    shouldDropMismatchedSlackEvent: input.shouldDropMismatchedSlackEvent,
+  });
+  const handlerKey = input.handler ?? "added";
+  const handler = handlerKey === "removed" ? removed : added;
+  expect(handler).toBeTruthy();
+  const event = (input.event ?? makePinEvent()) as Record<string, unknown>;
+  const body = input.body ?? {};
+  await handler!({
+    body,
+    event,
+  });
+}
+
 describe("registerSlackPinEvents", () => {
-  it("enqueues DM pin system events when dmPolicy is open", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getAddedHandler } = createPinContext({ dmPolicy: "open" });
-    const addedHandler = getAddedHandler();
-    expect(addedHandler).toBeTruthy();
-
-    await addedHandler!({
-      event: makePinEvent(),
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+  it.each([
+    ["enqueues DM pin system events when dmPolicy is open", { overrides: { dmPolicy: "open" } }, 1],
+    [
+      "blocks DM pin system events when dmPolicy is disabled",
+      { overrides: { dmPolicy: "disabled" } },
+      0,
+    ],
+    [
+      "blocks DM pin system events for unauthorized senders in allowlist mode",
+      {
+        overrides: { dmPolicy: "allowlist", allowFrom: ["U2"] },
+        event: makePinEvent({ user: "U1" }),
+      },
+      0,
+    ],
+    [
+      "allows DM pin system events for authorized senders in allowlist mode",
+      {
+        overrides: { dmPolicy: "allowlist", allowFrom: ["U1"] },
+        event: makePinEvent({ user: "U1" }),
+      },
+      1,
+    ],
+    [
+      "blocks channel pin events for users outside channel users allowlist",
+      {
+        overrides: {
+          dmPolicy: "open",
+          channelType: "channel",
+          channelUsers: ["U_OWNER"],
+        },
+        event: makePinEvent({ channel: "C1", user: "U_ATTACKER" }),
+      },
+      0,
+    ],
+  ])("%s", async (_name, args: PinCase, expectedCalls: number) => {
+    await runPinCase(args);
+    expect(pinEnqueueMock).toHaveBeenCalledTimes(expectedCalls);
   });
 
-  it("blocks DM pin system events when dmPolicy is disabled", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getAddedHandler } = createPinContext({ dmPolicy: "disabled" });
-    const addedHandler = getAddedHandler();
-    expect(addedHandler).toBeTruthy();
-
-    await addedHandler!({
-      event: makePinEvent(),
-      body: {},
+  it("does not track mismatched events", async () => {
+    const trackEvent = vi.fn();
+    await runPinCase({
+      trackEvent,
+      shouldDropMismatchedSlackEvent: () => true,
+      body: { api_app_id: "A_OTHER" },
     });
 
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
   });
 
-  it("blocks DM pin system events for unauthorized senders in allowlist mode", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getAddedHandler } = createPinContext({
-      dmPolicy: "allowlist",
-      allowFrom: ["U2"],
-    });
-    const addedHandler = getAddedHandler();
-    expect(addedHandler).toBeTruthy();
+  it("tracks accepted pin events", async () => {
+    const trackEvent = vi.fn();
+    await runPinCase({ trackEvent });
 
-    await addedHandler!({
-      event: makePinEvent({ user: "U1" }),
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
-  });
-
-  it("allows DM pin system events for authorized senders in allowlist mode", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getAddedHandler } = createPinContext({
-      dmPolicy: "allowlist",
-      allowFrom: ["U1"],
-    });
-    const addedHandler = getAddedHandler();
-    expect(addedHandler).toBeTruthy();
-
-    await addedHandler!({
-      event: makePinEvent({ user: "U1" }),
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("blocks channel pin events for users outside channel users allowlist", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getAddedHandler } = createPinContext({
-      dmPolicy: "open",
-      channelType: "channel",
-      channelUsers: ["U_OWNER"],
-    });
-    const addedHandler = getAddedHandler();
-    expect(addedHandler).toBeTruthy();
-
-    await addedHandler!({
-      event: makePinEvent({ channel: "C1", user: "U_ATTACKER" }),
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(trackEvent).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/slack/monitor/events/pins.test.ts
+++ b/src/slack/monitor/events/pins.test.ts
@@ -22,7 +22,6 @@ type PinCase = {
   event?: Record<string, unknown>;
   handler?: "added" | "removed";
   overrides?: PinOverrides;
-  trackEvent?: () => void;
   shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
 };
 
@@ -41,14 +40,13 @@ function makePinEvent(overrides?: { channel?: string; user?: string }) {
 
 function installPinHandlers(args: {
   overrides?: PinOverrides;
-  trackEvent?: () => void;
   shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
 }) {
   const harness = buildPinHarness(args.overrides);
   if (args.shouldDropMismatchedSlackEvent) {
     harness.ctx.shouldDropMismatchedSlackEvent = args.shouldDropMismatchedSlackEvent;
   }
-  registerSlackPinEvents({ ctx: harness.ctx, trackEvent: args.trackEvent });
+  registerSlackPinEvents({ ctx: harness.ctx });
   return {
     added: harness.getHandler("pin_added") as PinHandler | null,
     removed: harness.getHandler("pin_removed") as PinHandler | null,
@@ -60,7 +58,6 @@ async function runPinCase(input: PinCase = {}): Promise<void> {
   pinAllowMock.mockReset().mockResolvedValue([]);
   const { added, removed } = installPinHandlers({
     overrides: input.overrides,
-    trackEvent: input.trackEvent,
     shouldDropMismatchedSlackEvent: input.shouldDropMismatchedSlackEvent,
   });
   const handlerKey = input.handler ?? "added";
@@ -76,16 +73,20 @@ async function runPinCase(input: PinCase = {}): Promise<void> {
 
 describe("registerSlackPinEvents", () => {
   it.each([
-    ["enqueues DM pin system events when dmPolicy is open", { overrides: { dmPolicy: "open" } }, 1],
+    [
+      "enqueues DM pin system events when dmPolicy is open",
+      { overrides: { dmPolicy: "open" as const } },
+      1,
+    ],
     [
       "blocks DM pin system events when dmPolicy is disabled",
-      { overrides: { dmPolicy: "disabled" } },
+      { overrides: { dmPolicy: "disabled" as const } },
       0,
     ],
     [
       "blocks DM pin system events for unauthorized senders in allowlist mode",
       {
-        overrides: { dmPolicy: "allowlist", allowFrom: ["U2"] },
+        overrides: { dmPolicy: "allowlist" as const, allowFrom: ["U2"] },
         event: makePinEvent({ user: "U1" }),
       },
       0,
@@ -93,7 +94,7 @@ describe("registerSlackPinEvents", () => {
     [
       "allows DM pin system events for authorized senders in allowlist mode",
       {
-        overrides: { dmPolicy: "allowlist", allowFrom: ["U1"] },
+        overrides: { dmPolicy: "allowlist" as const, allowFrom: ["U1"] },
         event: makePinEvent({ user: "U1" }),
       },
       1,
@@ -102,8 +103,8 @@ describe("registerSlackPinEvents", () => {
       "blocks channel pin events for users outside channel users allowlist",
       {
         overrides: {
-          dmPolicy: "open",
-          channelType: "channel",
+          dmPolicy: "open" as const,
+          channelType: "channel" as const,
           channelUsers: ["U_OWNER"],
         },
         event: makePinEvent({ channel: "C1", user: "U_ATTACKER" }),
@@ -115,21 +116,12 @@ describe("registerSlackPinEvents", () => {
     expect(pinEnqueueMock).toHaveBeenCalledTimes(expectedCalls);
   });
 
-  it("does not track mismatched events", async () => {
-    const trackEvent = vi.fn();
+  it("drops mismatched events", async () => {
     await runPinCase({
-      trackEvent,
       shouldDropMismatchedSlackEvent: () => true,
       body: { api_app_id: "A_OTHER" },
     });
 
-    expect(trackEvent).not.toHaveBeenCalled();
-  });
-
-  it("tracks accepted pin events", async () => {
-    const trackEvent = vi.fn();
-    await runPinCase({ trackEvent });
-
-    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(pinEnqueueMock).not.toHaveBeenCalled();
   });
 });

--- a/src/slack/monitor/events/reactions.test.ts
+++ b/src/slack/monitor/events/reactions.test.ts
@@ -27,7 +27,6 @@ type ReactionRunInput = {
   overrides?: SlackSystemEventTestOverrides;
   event?: Record<string, unknown>;
   body?: unknown;
-  trackEvent?: () => void;
   shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
 };
 
@@ -47,14 +46,13 @@ function buildReactionEvent(overrides?: { user?: string; channel?: string }) {
 
 function createReactionHandlers(params: {
   overrides?: SlackSystemEventTestOverrides;
-  trackEvent?: () => void;
   shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
 }) {
   const harness = createSlackSystemEventTestHarness(params.overrides);
   if (params.shouldDropMismatchedSlackEvent) {
     harness.ctx.shouldDropMismatchedSlackEvent = params.shouldDropMismatchedSlackEvent;
   }
-  registerSlackReactionEvents({ ctx: harness.ctx, trackEvent: params.trackEvent });
+  registerSlackReactionEvents({ ctx: harness.ctx });
   return {
     added: harness.getHandler("reaction_added") as ReactionHandler | null,
     removed: harness.getHandler("reaction_removed") as ReactionHandler | null,
@@ -66,7 +64,6 @@ async function executeReactionCase(input: ReactionRunInput = {}) {
   reactionAllowMock.mockReset().mockResolvedValue([]);
   const handlers = createReactionHandlers({
     overrides: input.overrides,
-    trackEvent: input.trackEvent,
     shouldDropMismatchedSlackEvent: input.shouldDropMismatchedSlackEvent,
   });
   const handler = handlers[input.handler ?? "added"];
@@ -81,18 +78,18 @@ describe("registerSlackReactionEvents", () => {
   it.each([
     {
       name: "enqueues DM reaction system events when dmPolicy is open",
-      args: { overrides: { dmPolicy: "open" } },
+      args: { overrides: { dmPolicy: "open" as const } },
       expectedCalls: 1,
     },
     {
       name: "blocks DM reaction system events when dmPolicy is disabled",
-      args: { overrides: { dmPolicy: "disabled" } },
+      args: { overrides: { dmPolicy: "disabled" as const } },
       expectedCalls: 0,
     },
     {
       name: "blocks DM reaction system events for unauthorized senders in allowlist mode",
       args: {
-        overrides: { dmPolicy: "allowlist", allowFrom: ["U2"] },
+        overrides: { dmPolicy: "allowlist" as const, allowFrom: ["U2"] },
         event: buildReactionEvent({ user: "U1" }),
       },
       expectedCalls: 0,
@@ -100,7 +97,7 @@ describe("registerSlackReactionEvents", () => {
     {
       name: "allows DM reaction system events for authorized senders in allowlist mode",
       args: {
-        overrides: { dmPolicy: "allowlist", allowFrom: ["U1"] },
+        overrides: { dmPolicy: "allowlist" as const, allowFrom: ["U1"] },
         event: buildReactionEvent({ user: "U1" }),
       },
       expectedCalls: 1,
@@ -109,7 +106,7 @@ describe("registerSlackReactionEvents", () => {
       name: "enqueues channel reaction events regardless of dmPolicy",
       args: {
         handler: "removed" as const,
-        overrides: { dmPolicy: "disabled", channelType: "channel" },
+        overrides: { dmPolicy: "disabled" as const, channelType: "channel" as const },
         event: {
           ...buildReactionEvent({ channel: "C1" }),
           type: "reaction_removed",
@@ -121,8 +118,8 @@ describe("registerSlackReactionEvents", () => {
       name: "blocks channel reaction events for users outside channel users allowlist",
       args: {
         overrides: {
-          dmPolicy: "open",
-          channelType: "channel",
+          dmPolicy: "open" as const,
+          channelType: "channel" as const,
           channelUsers: ["U_OWNER"],
         },
         event: buildReactionEvent({ channel: "C1", user: "U_ATTACKER" }),
@@ -134,21 +131,12 @@ describe("registerSlackReactionEvents", () => {
     expect(reactionQueueMock).toHaveBeenCalledTimes(expectedCalls);
   });
 
-  it("does not track mismatched events", async () => {
-    const trackEvent = vi.fn();
+  it("drops mismatched events", async () => {
     await executeReactionCase({
-      trackEvent,
       shouldDropMismatchedSlackEvent: () => true,
       body: { api_app_id: "A_OTHER" },
     });
 
-    expect(trackEvent).not.toHaveBeenCalled();
-  });
-
-  it("tracks accepted message reactions", async () => {
-    const trackEvent = vi.fn();
-    await executeReactionCase({ trackEvent });
-
-    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(reactionQueueMock).not.toHaveBeenCalled();
   });
 });

--- a/src/slack/monitor/events/reactions.test.ts
+++ b/src/slack/monitor/events/reactions.test.ts
@@ -5,32 +5,33 @@ import {
   type SlackSystemEventTestOverrides,
 } from "./system-event-test-harness.js";
 
-const enqueueSystemEventMock = vi.fn();
-const readAllowFromStoreMock = vi.fn();
+const reactionQueueMock = vi.fn();
+const reactionAllowMock = vi.fn();
 
-vi.mock("../../../infra/system-events.js", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
-}));
-
-vi.mock("../../../pairing/pairing-store.js", () => ({
-  readChannelAllowFromStore: (...args: unknown[]) => readAllowFromStoreMock(...args),
-}));
-
-type SlackReactionHandler = (args: {
-  event: Record<string, unknown>;
-  body: unknown;
-}) => Promise<void>;
-
-function createReactionContext(overrides?: SlackSystemEventTestOverrides) {
-  const harness = createSlackSystemEventTestHarness(overrides);
-  registerSlackReactionEvents({ ctx: harness.ctx });
+vi.mock("../../../infra/system-events.js", () => {
   return {
-    getAddedHandler: () => harness.getHandler("reaction_added") as SlackReactionHandler | null,
-    getRemovedHandler: () => harness.getHandler("reaction_removed") as SlackReactionHandler | null,
+    enqueueSystemEvent: (...args: unknown[]) => reactionQueueMock(...args),
   };
-}
+});
 
-function makeReactionEvent(overrides?: { user?: string; channel?: string }) {
+vi.mock("../../../pairing/pairing-store.js", () => {
+  return {
+    readChannelAllowFromStore: (...args: unknown[]) => reactionAllowMock(...args),
+  };
+});
+
+type ReactionHandler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
+
+type ReactionRunInput = {
+  handler?: "added" | "removed";
+  overrides?: SlackSystemEventTestOverrides;
+  event?: Record<string, unknown>;
+  body?: unknown;
+  trackEvent?: () => void;
+  shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
+};
+
+function buildReactionEvent(overrides?: { user?: string; channel?: string }) {
   return {
     type: "reaction_added",
     user: overrides?.user ?? "U1",
@@ -44,110 +45,110 @@ function makeReactionEvent(overrides?: { user?: string; channel?: string }) {
   };
 }
 
+function createReactionHandlers(params: {
+  overrides?: SlackSystemEventTestOverrides;
+  trackEvent?: () => void;
+  shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
+}) {
+  const harness = createSlackSystemEventTestHarness(params.overrides);
+  if (params.shouldDropMismatchedSlackEvent) {
+    harness.ctx.shouldDropMismatchedSlackEvent = params.shouldDropMismatchedSlackEvent;
+  }
+  registerSlackReactionEvents({ ctx: harness.ctx, trackEvent: params.trackEvent });
+  return {
+    added: harness.getHandler("reaction_added") as ReactionHandler | null,
+    removed: harness.getHandler("reaction_removed") as ReactionHandler | null,
+  };
+}
+
+async function executeReactionCase(input: ReactionRunInput = {}) {
+  reactionQueueMock.mockClear();
+  reactionAllowMock.mockReset().mockResolvedValue([]);
+  const handlers = createReactionHandlers({
+    overrides: input.overrides,
+    trackEvent: input.trackEvent,
+    shouldDropMismatchedSlackEvent: input.shouldDropMismatchedSlackEvent,
+  });
+  const handler = handlers[input.handler ?? "added"];
+  expect(handler).toBeTruthy();
+  await handler!({
+    event: (input.event ?? buildReactionEvent()) as Record<string, unknown>,
+    body: input.body ?? {},
+  });
+}
+
 describe("registerSlackReactionEvents", () => {
-  it("enqueues DM reaction system events when dmPolicy is open", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getAddedHandler } = createReactionContext({ dmPolicy: "open" });
-    const addedHandler = getAddedHandler();
-    expect(addedHandler).toBeTruthy();
-
-    await addedHandler!({
-      event: makeReactionEvent(),
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("blocks DM reaction system events when dmPolicy is disabled", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getAddedHandler } = createReactionContext({ dmPolicy: "disabled" });
-    const addedHandler = getAddedHandler();
-    expect(addedHandler).toBeTruthy();
-
-    await addedHandler!({
-      event: makeReactionEvent(),
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
-  });
-
-  it("blocks DM reaction system events for unauthorized senders in allowlist mode", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getAddedHandler } = createReactionContext({
-      dmPolicy: "allowlist",
-      allowFrom: ["U2"],
-    });
-    const addedHandler = getAddedHandler();
-    expect(addedHandler).toBeTruthy();
-
-    await addedHandler!({
-      event: makeReactionEvent({ user: "U1" }),
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
-  });
-
-  it("allows DM reaction system events for authorized senders in allowlist mode", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getAddedHandler } = createReactionContext({
-      dmPolicy: "allowlist",
-      allowFrom: ["U1"],
-    });
-    const addedHandler = getAddedHandler();
-    expect(addedHandler).toBeTruthy();
-
-    await addedHandler!({
-      event: makeReactionEvent({ user: "U1" }),
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("enqueues channel reaction events regardless of dmPolicy", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getRemovedHandler } = createReactionContext({
-      dmPolicy: "disabled",
-      channelType: "channel",
-    });
-    const removedHandler = getRemovedHandler();
-    expect(removedHandler).toBeTruthy();
-
-    await removedHandler!({
-      event: {
-        ...makeReactionEvent({ channel: "C1" }),
-        type: "reaction_removed",
+  it.each([
+    {
+      name: "enqueues DM reaction system events when dmPolicy is open",
+      args: { overrides: { dmPolicy: "open" } },
+      expectedCalls: 1,
+    },
+    {
+      name: "blocks DM reaction system events when dmPolicy is disabled",
+      args: { overrides: { dmPolicy: "disabled" } },
+      expectedCalls: 0,
+    },
+    {
+      name: "blocks DM reaction system events for unauthorized senders in allowlist mode",
+      args: {
+        overrides: { dmPolicy: "allowlist", allowFrom: ["U2"] },
+        event: buildReactionEvent({ user: "U1" }),
       },
-      body: {},
-    });
-
-    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+      expectedCalls: 0,
+    },
+    {
+      name: "allows DM reaction system events for authorized senders in allowlist mode",
+      args: {
+        overrides: { dmPolicy: "allowlist", allowFrom: ["U1"] },
+        event: buildReactionEvent({ user: "U1" }),
+      },
+      expectedCalls: 1,
+    },
+    {
+      name: "enqueues channel reaction events regardless of dmPolicy",
+      args: {
+        handler: "removed" as const,
+        overrides: { dmPolicy: "disabled", channelType: "channel" },
+        event: {
+          ...buildReactionEvent({ channel: "C1" }),
+          type: "reaction_removed",
+        },
+      },
+      expectedCalls: 1,
+    },
+    {
+      name: "blocks channel reaction events for users outside channel users allowlist",
+      args: {
+        overrides: {
+          dmPolicy: "open",
+          channelType: "channel",
+          channelUsers: ["U_OWNER"],
+        },
+        event: buildReactionEvent({ channel: "C1", user: "U_ATTACKER" }),
+      },
+      expectedCalls: 0,
+    },
+  ])("$name", async ({ args, expectedCalls }) => {
+    await executeReactionCase(args);
+    expect(reactionQueueMock).toHaveBeenCalledTimes(expectedCalls);
   });
 
-  it("blocks channel reaction events for users outside channel users allowlist", async () => {
-    enqueueSystemEventMock.mockClear();
-    readAllowFromStoreMock.mockReset().mockResolvedValue([]);
-    const { getAddedHandler } = createReactionContext({
-      dmPolicy: "open",
-      channelType: "channel",
-      channelUsers: ["U_OWNER"],
-    });
-    const addedHandler = getAddedHandler();
-    expect(addedHandler).toBeTruthy();
-
-    await addedHandler!({
-      event: makeReactionEvent({ channel: "C1", user: "U_ATTACKER" }),
-      body: {},
+  it("does not track mismatched events", async () => {
+    const trackEvent = vi.fn();
+    await executeReactionCase({
+      trackEvent,
+      shouldDropMismatchedSlackEvent: () => true,
+      body: { api_app_id: "A_OTHER" },
     });
 
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
+  it("tracks accepted message reactions", async () => {
+    const trackEvent = vi.fn();
+    await executeReactionCase({ trackEvent });
+
+    expect(trackEvent).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -189,6 +189,73 @@ describe("slack prepareSlackMessage inbound contract", () => {
     return prepareMessageWith(ctx, createThreadAccount(), createThreadReplyMessage(overrides));
   }
 
+  function createDmScopeMainSlackCtx(): SlackMonitorContext {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true } },
+        session: { dmScope: "main" },
+      } as RemoteClawConfig,
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+    // Simulate API returning correct type for DM channel
+    slackCtx.resolveChannelName = async () => ({ name: undefined, type: "im" as const });
+    return slackCtx;
+  }
+
+  function createMainScopedDmMessage(overrides: Partial<SlackMessageEvent>): SlackMessageEvent {
+    return createSlackMessage({
+      channel: "D0ACP6B1T8V",
+      user: "U1",
+      text: "hello from DM",
+      ts: "1.000",
+      ...overrides,
+    });
+  }
+
+  function expectMainScopedDmClassification(
+    prepared: Awaited<ReturnType<typeof prepareSlackMessage>>,
+    options?: { includeFromCheck?: boolean },
+  ) {
+    expect(prepared).toBeTruthy();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expectInboundContextContract(prepared!.ctxPayload as any);
+    expect(prepared!.isDirectMessage).toBe(true);
+    expect(prepared!.route.sessionKey).toBe("agent:main:main");
+    expect(prepared!.ctxPayload.ChatType).toBe("direct");
+    if (options?.includeFromCheck) {
+      expect(prepared!.ctxPayload.From).toContain("slack:U1");
+    }
+  }
+
+  function createReplyToAllSlackCtx(params?: {
+    groupPolicy?: "open";
+    defaultRequireMention?: boolean;
+    asChannel?: boolean;
+  }): SlackMonitorContext {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: {
+          slack: {
+            enabled: true,
+            replyToMode: "all",
+            ...(params?.groupPolicy ? { groupPolicy: params.groupPolicy } : {}),
+          },
+        },
+      } as RemoteClawConfig,
+      replyToMode: "all",
+      ...(params?.defaultRequireMention === undefined
+        ? {}
+        : { defaultRequireMention: params.defaultRequireMention }),
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+    if (params?.asChannel) {
+      slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+    }
+    return slackCtx;
+  }
+
   it("produces a finalized MsgContext", async () => {
     const message: SlackMessageEvent = {
       channel: "D123",
@@ -331,179 +398,34 @@ describe("slack prepareSlackMessage inbound contract", () => {
   });
 
   it("classifies D-prefix DMs correctly even when channel_type is wrong", async () => {
-    const slackCtx = createSlackMonitorContext({
-      cfg: {
-        channels: { slack: { enabled: true } },
-        session: { dmScope: "main" },
-      } as RemoteClawConfig,
-      accountId: "default",
-      botToken: "token",
-      app: { client: {} } as App,
-      runtime: {} as RuntimeEnv,
-      botUserId: "B1",
-      teamId: "T1",
-      apiAppId: "A1",
-      historyLimit: 0,
-      sessionScope: "per-sender",
-      mainKey: "main",
-      dmEnabled: true,
-      dmPolicy: "open",
-      allowFrom: [],
-      allowNameMatching: false,
-      groupDmEnabled: true,
-      groupDmChannels: [],
-      defaultRequireMention: true,
-      groupPolicy: "open",
-      useAccessGroups: false,
-      reactionMode: "off",
-      reactionAllowlist: [],
-      replyToMode: "off",
-      threadHistoryScope: "thread",
-      threadInheritParent: false,
-      slashCommand: {
-        enabled: false,
-        name: "remoteclaw",
-        sessionPrefix: "slack:slash",
-        ephemeral: true,
-      },
-      textLimit: 4000,
-      ackReactionScope: "group-mentions",
-      mediaMaxBytes: 1024,
-      removeAckAfterReply: false,
-    });
-    // oxlint-disable-next-line typescript/no-explicit-any
-    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
-    // Simulate API returning correct type for DM channel
-    slackCtx.resolveChannelName = async () => ({ name: undefined, type: "im" as const });
+    const prepared = await prepareMessageWith(
+      createDmScopeMainSlackCtx(),
+      createSlackAccount(),
+      createMainScopedDmMessage({
+        // Bug scenario: D-prefix channel but Slack event says channel_type: "channel"
+        channel_type: "channel",
+      }),
+    );
 
-    const account: ResolvedSlackAccount = {
-      accountId: "default",
-      enabled: true,
-      botTokenSource: "config",
-      appTokenSource: "config",
-      userTokenSource: "none",
-      config: {},
-    };
-
-    // Bug scenario: D-prefix channel but Slack event says channel_type: "channel"
-    const message: SlackMessageEvent = {
-      channel: "D0ACP6B1T8V",
-      channel_type: "channel",
-      user: "U1",
-      text: "hello from DM",
-      ts: "1.000",
-    } as SlackMessageEvent;
-
-    const prepared = await prepareSlackMessage({
-      ctx: slackCtx,
-      account,
-      message,
-      opts: { source: "message" },
-    });
-
-    expect(prepared).toBeTruthy();
-    // oxlint-disable-next-line typescript/no-explicit-any
-    expectInboundContextContract(prepared!.ctxPayload as any);
-    // Should be classified as DM, not channel
-    expect(prepared!.isDirectMessage).toBe(true);
-    // DM with dmScope: "main" should route to the main session
-    expect(prepared!.route.sessionKey).toBe("agent:main:main");
-    // ChatType should be "direct", not "channel"
-    expect(prepared!.ctxPayload.ChatType).toBe("direct");
-    // From should use user ID (DM pattern), not channel ID
-    expect(prepared!.ctxPayload.From).toContain("slack:U1");
+    expectMainScopedDmClassification(prepared, { includeFromCheck: true });
   });
 
   it("classifies D-prefix DMs when channel_type is missing", async () => {
-    const slackCtx = createSlackMonitorContext({
-      cfg: {
-        channels: { slack: { enabled: true } },
-        session: { dmScope: "main" },
-      } as RemoteClawConfig,
-      accountId: "default",
-      botToken: "token",
-      app: { client: {} } as App,
-      runtime: {} as RuntimeEnv,
-      botUserId: "B1",
-      teamId: "T1",
-      apiAppId: "A1",
-      historyLimit: 0,
-      sessionScope: "per-sender",
-      mainKey: "main",
-      dmEnabled: true,
-      dmPolicy: "open",
-      allowFrom: [],
-      allowNameMatching: false,
-      groupDmEnabled: true,
-      groupDmChannels: [],
-      defaultRequireMention: true,
-      groupPolicy: "open",
-      useAccessGroups: false,
-      reactionMode: "off",
-      reactionAllowlist: [],
-      replyToMode: "off",
-      threadHistoryScope: "thread",
-      threadInheritParent: false,
-      slashCommand: {
-        enabled: false,
-        name: "remoteclaw",
-        sessionPrefix: "slack:slash",
-        ephemeral: true,
-      },
-      textLimit: 4000,
-      ackReactionScope: "group-mentions",
-      mediaMaxBytes: 1024,
-      removeAckAfterReply: false,
-    });
-    // oxlint-disable-next-line typescript/no-explicit-any
-    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
-    // Simulate API returning correct type for DM channel
-    slackCtx.resolveChannelName = async () => ({ name: undefined, type: "im" as const });
-
-    const account: ResolvedSlackAccount = {
-      accountId: "default",
-      enabled: true,
-      botTokenSource: "config",
-      appTokenSource: "config",
-      userTokenSource: "none",
-      config: {},
-    };
-
-    // channel_type missing — should infer from D-prefix
-    const message: SlackMessageEvent = {
-      channel: "D0ACP6B1T8V",
-      user: "U1",
-      text: "hello from DM",
-      ts: "1.000",
-    } as SlackMessageEvent;
-
-    const prepared = await prepareSlackMessage({
-      ctx: slackCtx,
-      account,
+    const message = createMainScopedDmMessage({});
+    delete message.channel_type;
+    const prepared = await prepareMessageWith(
+      createDmScopeMainSlackCtx(),
+      createSlackAccount(),
+      // channel_type missing — should infer from D-prefix.
       message,
-      opts: { source: "message" },
-    });
+    );
 
-    expect(prepared).toBeTruthy();
-    // oxlint-disable-next-line typescript/no-explicit-any
-    expectInboundContextContract(prepared!.ctxPayload as any);
-    expect(prepared!.isDirectMessage).toBe(true);
-    expect(prepared!.route.sessionKey).toBe("agent:main:main");
-    expect(prepared!.ctxPayload.ChatType).toBe("direct");
+    expectMainScopedDmClassification(prepared);
   });
 
   it("sets MessageThreadId for top-level messages when replyToMode=all", async () => {
-    const slackCtx = createInboundSlackCtx({
-      cfg: {
-        channels: { slack: { enabled: true, replyToMode: "all" } },
-      } as RemoteClawConfig,
-      replyToMode: "all",
-    });
-    // oxlint-disable-next-line typescript/no-explicit-any
-    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
-
     const prepared = await prepareMessageWith(
-      slackCtx,
+      createReplyToAllSlackCtx(),
       createSlackAccount({ replyToMode: "all" }),
       createSlackMessage({}),
     );
@@ -513,17 +435,8 @@ describe("slack prepareSlackMessage inbound contract", () => {
   });
 
   it("respects replyToModeByChatType.direct override for DMs", async () => {
-    const slackCtx = createInboundSlackCtx({
-      cfg: {
-        channels: { slack: { enabled: true, replyToMode: "all" } },
-      } as RemoteClawConfig,
-      replyToMode: "all",
-    });
-    // oxlint-disable-next-line typescript/no-explicit-any
-    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
-
     const prepared = await prepareMessageWith(
-      slackCtx,
+      createReplyToAllSlackCtx(),
       createSlackAccount({ replyToMode: "all", replyToModeByChatType: { direct: "off" } }),
       createSlackMessage({}), // DM (channel_type: "im")
     );
@@ -534,19 +447,12 @@ describe("slack prepareSlackMessage inbound contract", () => {
   });
 
   it("still threads channel messages when replyToModeByChatType.direct is off", async () => {
-    const slackCtx = createInboundSlackCtx({
-      cfg: {
-        channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
-      } as RemoteClawConfig,
-      replyToMode: "all",
-      defaultRequireMention: false,
-    });
-    // oxlint-disable-next-line typescript/no-explicit-any
-    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
-    slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
-
     const prepared = await prepareMessageWith(
-      slackCtx,
+      createReplyToAllSlackCtx({
+        groupPolicy: "open",
+        defaultRequireMention: false,
+        asChannel: true,
+      }),
       createSlackAccount({ replyToMode: "all", replyToModeByChatType: { direct: "off" } }),
       createSlackMessage({ channel: "C123", channel_type: "channel" }),
     );
@@ -557,17 +463,8 @@ describe("slack prepareSlackMessage inbound contract", () => {
   });
 
   it("respects dm.replyToMode legacy override for DMs", async () => {
-    const slackCtx = createInboundSlackCtx({
-      cfg: {
-        channels: { slack: { enabled: true, replyToMode: "all" } },
-      } as RemoteClawConfig,
-      replyToMode: "all",
-    });
-    // oxlint-disable-next-line typescript/no-explicit-any
-    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
-
     const prepared = await prepareMessageWith(
-      slackCtx,
+      createReplyToAllSlackCtx(),
       createSlackAccount({ replyToMode: "all", dm: { replyToMode: "off" } }),
       createSlackMessage({}), // DM
     );

--- a/src/telegram/bot-message-dispatch.sticker-media.test.ts
+++ b/src/telegram/bot-message-dispatch.sticker-media.test.ts
@@ -1,9 +1,27 @@
 import { describe, expect, it } from "vitest";
 import { pruneStickerMediaFromContext } from "./bot-message-dispatch.js";
 
+type MediaCtx = {
+  MediaPath?: string;
+  MediaUrl?: string;
+  MediaType?: string;
+  MediaPaths?: string[];
+  MediaUrls?: string[];
+  MediaTypes?: string[];
+};
+
+function expectSingleImageMedia(ctx: MediaCtx, mediaPath: string) {
+  expect(ctx.MediaPath).toBe(mediaPath);
+  expect(ctx.MediaUrl).toBe(mediaPath);
+  expect(ctx.MediaType).toBe("image/jpeg");
+  expect(ctx.MediaPaths).toEqual([mediaPath]);
+  expect(ctx.MediaUrls).toEqual([mediaPath]);
+  expect(ctx.MediaTypes).toEqual(["image/jpeg"]);
+}
+
 describe("pruneStickerMediaFromContext", () => {
   it("preserves appended reply media while removing primary sticker media", () => {
-    const ctx = {
+    const ctx: MediaCtx = {
       MediaPath: "/tmp/sticker.webp",
       MediaUrl: "/tmp/sticker.webp",
       MediaType: "image/webp",
@@ -14,16 +32,11 @@ describe("pruneStickerMediaFromContext", () => {
 
     pruneStickerMediaFromContext(ctx);
 
-    expect(ctx.MediaPath).toBe("/tmp/replied.jpg");
-    expect(ctx.MediaUrl).toBe("/tmp/replied.jpg");
-    expect(ctx.MediaType).toBe("image/jpeg");
-    expect(ctx.MediaPaths).toEqual(["/tmp/replied.jpg"]);
-    expect(ctx.MediaUrls).toEqual(["/tmp/replied.jpg"]);
-    expect(ctx.MediaTypes).toEqual(["image/jpeg"]);
+    expectSingleImageMedia(ctx, "/tmp/replied.jpg");
   });
 
   it("clears media fields when sticker is the only media", () => {
-    const ctx = {
+    const ctx: MediaCtx = {
       MediaPath: "/tmp/sticker.webp",
       MediaUrl: "/tmp/sticker.webp",
       MediaType: "image/webp",
@@ -43,7 +56,7 @@ describe("pruneStickerMediaFromContext", () => {
   });
 
   it("does not prune when sticker media is already omitted from context", () => {
-    const ctx = {
+    const ctx: MediaCtx = {
       MediaPath: "/tmp/replied.jpg",
       MediaUrl: "/tmp/replied.jpg",
       MediaType: "image/jpeg",
@@ -54,11 +67,6 @@ describe("pruneStickerMediaFromContext", () => {
 
     pruneStickerMediaFromContext(ctx, { stickerMediaIncluded: false });
 
-    expect(ctx.MediaPath).toBe("/tmp/replied.jpg");
-    expect(ctx.MediaUrl).toBe("/tmp/replied.jpg");
-    expect(ctx.MediaType).toBe("image/jpeg");
-    expect(ctx.MediaPaths).toEqual(["/tmp/replied.jpg"]);
-    expect(ctx.MediaUrls).toEqual(["/tmp/replied.jpg"]);
-    expect(ctx.MediaTypes).toEqual(["image/jpeg"]);
+    expectSingleImageMedia(ctx, "/tmp/replied.jpg");
   });
 });

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -20,6 +20,9 @@ const createTelegramBotSpy = vi.hoisted(() =>
 );
 
 const WEBHOOK_POST_TIMEOUT_MS = process.platform === "win32" ? 20_000 : 8_000;
+const TELEGRAM_TOKEN = "tok";
+const TELEGRAM_SECRET = "secret";
+const TELEGRAM_WEBHOOK_PATH = "/hook";
 
 vi.mock("grammy", async (importOriginal) => {
   const actual = await importOriginal<typeof import("grammy")>();
@@ -202,96 +205,175 @@ function sha256(text: string): string {
   return createHash("sha256").update(text).digest("hex");
 }
 
+type StartWebhookOptions = Omit<
+  Parameters<typeof startTelegramWebhook>[0],
+  "token" | "port" | "abortSignal"
+>;
+
+type StartedWebhook = Awaited<ReturnType<typeof startTelegramWebhook>>;
+
+function getServerPort(server: StartedWebhook["server"]): number {
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("no addr");
+  }
+  return address.port;
+}
+
+function webhookUrl(port: number, webhookPath: string): string {
+  return `http://127.0.0.1:${port}${webhookPath}`;
+}
+
+async function withStartedWebhook<T>(
+  options: StartWebhookOptions,
+  run: (ctx: { server: StartedWebhook["server"]; port: number }) => Promise<T>,
+): Promise<T> {
+  const abort = new AbortController();
+  const started = await startTelegramWebhook({
+    token: TELEGRAM_TOKEN,
+    port: 0,
+    abortSignal: abort.signal,
+    ...options,
+  });
+  try {
+    return await run({ server: started.server, port: getServerPort(started.server) });
+  } finally {
+    abort.abort();
+  }
+}
+
+function expectSingleNearLimitUpdate(params: {
+  seenUpdates: Array<{ update_id: number; message: { text: string } }>;
+  expected: { update_id: number; message: { text: string } };
+}) {
+  expect(params.seenUpdates).toHaveLength(1);
+  expect(params.seenUpdates[0]?.update_id).toBe(params.expected.update_id);
+  expect(params.seenUpdates[0]?.message.text.length).toBe(params.expected.message.text.length);
+  expect(sha256(params.seenUpdates[0]?.message.text ?? "")).toBe(
+    sha256(params.expected.message.text),
+  );
+}
+
+async function runNearLimitPayloadTest(mode: "single" | "random-chunked"): Promise<void> {
+  const seenUpdates: Array<{ update_id: number; message: { text: string } }> = [];
+  webhookCallbackSpy.mockImplementationOnce(
+    () =>
+      vi.fn(
+        (
+          update: unknown,
+          reply: (json: string) => Promise<void>,
+          _secretHeader: string | undefined,
+          _unauthorized: () => Promise<void>,
+        ) => {
+          seenUpdates.push(update as { update_id: number; message: { text: string } });
+          void reply("ok");
+        },
+      ) as unknown as typeof handlerSpy,
+  );
+
+  const { payload, sizeBytes } = createNearLimitTelegramPayload();
+  expect(sizeBytes).toBeLessThan(1_024 * 1_024);
+  expect(sizeBytes).toBeGreaterThan(256 * 1_024);
+  const expected = JSON.parse(payload) as { update_id: number; message: { text: string } };
+
+  await withStartedWebhook(
+    {
+      secret: TELEGRAM_SECRET,
+      path: TELEGRAM_WEBHOOK_PATH,
+    },
+    async ({ port }) => {
+      const response = await postWebhookPayloadWithChunkPlan({
+        port,
+        path: TELEGRAM_WEBHOOK_PATH,
+        payload,
+        secret: TELEGRAM_SECRET,
+        mode,
+        timeoutMs: WEBHOOK_POST_TIMEOUT_MS,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expectSingleNearLimitUpdate({ seenUpdates, expected });
+    },
+  );
+}
+
 describe("startTelegramWebhook", () => {
   it("starts server, registers webhook, and serves health", async () => {
     initSpy.mockClear();
     createTelegramBotSpy.mockClear();
     webhookCallbackSpy.mockClear();
     const runtimeLog = vi.fn();
-    const abort = new AbortController();
     const cfg = { bindings: [] };
-    const { server } = await startTelegramWebhook({
-      token: "tok",
-      secret: "secret",
-      accountId: "opie",
-      config: cfg,
-      port: 0, // random free port
-      abortSignal: abort.signal,
-      runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
-    });
-    expect(createTelegramBotSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        accountId: "opie",
-        config: expect.objectContaining({ bindings: [] }),
-      }),
-    );
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("no address");
-    }
-    const url = `http://127.0.0.1:${address.port}`;
-
-    const health = await fetch(`${url}/healthz`);
-    expect(health.status).toBe(200);
-    expect(initSpy).toHaveBeenCalledTimes(1);
-    expect(setWebhookSpy).toHaveBeenCalled();
-    expect(webhookCallbackSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        api: expect.objectContaining({
-          setWebhook: expect.any(Function),
-        }),
-      }),
-      "callback",
+    await withStartedWebhook(
       {
-        secretToken: "secret",
-        onTimeout: "return",
-        timeoutMilliseconds: 10_000,
+        secret: TELEGRAM_SECRET,
+        accountId: "opie",
+        config: cfg,
+        runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
+      },
+      async ({ port }) => {
+        expect(createTelegramBotSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            accountId: "opie",
+            config: expect.objectContaining({ bindings: [] }),
+          }),
+        );
+        const health = await fetch(`http://127.0.0.1:${port}/healthz`);
+        expect(health.status).toBe(200);
+        expect(initSpy).toHaveBeenCalledTimes(1);
+        expect(setWebhookSpy).toHaveBeenCalled();
+        expect(webhookCallbackSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            api: expect.objectContaining({
+              setWebhook: expect.any(Function),
+            }),
+          }),
+          "callback",
+          {
+            secretToken: TELEGRAM_SECRET,
+            onTimeout: "return",
+            timeoutMilliseconds: 10_000,
+          },
+        );
+        expect(runtimeLog).toHaveBeenCalledWith(
+          expect.stringContaining("webhook local listener on http://127.0.0.1:"),
+        );
+        expect(runtimeLog).toHaveBeenCalledWith(expect.stringContaining("/telegram-webhook"));
+        expect(runtimeLog).toHaveBeenCalledWith(
+          expect.stringContaining("webhook advertised to telegram on http://"),
+        );
       },
     );
-    expect(runtimeLog).toHaveBeenCalledWith(
-      expect.stringContaining("webhook local listener on http://127.0.0.1:"),
-    );
-    expect(runtimeLog).toHaveBeenCalledWith(expect.stringContaining("/telegram-webhook"));
-    expect(runtimeLog).toHaveBeenCalledWith(
-      expect.stringContaining("webhook advertised to telegram on http://"),
-    );
-
-    abort.abort();
   });
 
   it("invokes webhook handler on matching path", async () => {
     handlerSpy.mockClear();
     createTelegramBotSpy.mockClear();
-    const abort = new AbortController();
     const cfg = { bindings: [] };
-    const { server } = await startTelegramWebhook({
-      token: "tok",
-      secret: "secret",
-      accountId: "opie",
-      config: cfg,
-      port: 0,
-      abortSignal: abort.signal,
-      path: "/hook",
-    });
-    expect(createTelegramBotSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
         accountId: "opie",
-        config: expect.objectContaining({ bindings: [] }),
-      }),
+        config: cfg,
+        path: TELEGRAM_WEBHOOK_PATH,
+      },
+      async ({ port }) => {
+        expect(createTelegramBotSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            accountId: "opie",
+            config: expect.objectContaining({ bindings: [] }),
+          }),
+        );
+        const payload = JSON.stringify({ update_id: 1, message: { text: "hello" } });
+        const response = await postWebhookJson({
+          url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+          payload,
+          secret: TELEGRAM_SECRET,
+        });
+        expect(response.status).toBe(200);
+        expect(handlerSpy).toHaveBeenCalled();
+      },
     );
-    const addr = server.address();
-    if (!addr || typeof addr === "string") {
-      throw new Error("no addr");
-    }
-    const payload = JSON.stringify({ update_id: 1, message: { text: "hello" } });
-    const response = await postWebhookJson({
-      url: `http://127.0.0.1:${addr.port}/hook`,
-      payload,
-      secret: "secret",
-    });
-    expect(response.status).toBe(200);
-    expect(handlerSpy).toHaveBeenCalled();
-    abort.abort();
   });
 
   it("rejects startup when webhook secret is missing", async () => {
@@ -305,34 +387,26 @@ describe("startTelegramWebhook", () => {
   it("registers webhook using the bound listening port when port is 0", async () => {
     setWebhookSpy.mockClear();
     const runtimeLog = vi.fn();
-    const abort = new AbortController();
-    const { server } = await startTelegramWebhook({
-      token: "tok",
-      secret: "secret",
-      port: 0,
-      abortSignal: abort.signal,
-      path: "/hook",
-      runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
-    });
-    try {
-      const addr = server.address();
-      if (!addr || typeof addr === "string") {
-        throw new Error("no addr");
-      }
-      expect(addr.port).toBeGreaterThan(0);
-      expect(setWebhookSpy).toHaveBeenCalledTimes(1);
-      expect(setWebhookSpy).toHaveBeenCalledWith(
-        `http://127.0.0.1:${addr.port}/hook`,
-        expect.objectContaining({
-          secret_token: "secret",
-        }),
-      );
-      expect(runtimeLog).toHaveBeenCalledWith(
-        `webhook local listener on http://127.0.0.1:${addr.port}/hook`,
-      );
-    } finally {
-      abort.abort();
-    }
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+        runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
+      },
+      async ({ port }) => {
+        expect(port).toBeGreaterThan(0);
+        expect(setWebhookSpy).toHaveBeenCalledTimes(1);
+        expect(setWebhookSpy).toHaveBeenCalledWith(
+          webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+          expect.objectContaining({
+            secret_token: TELEGRAM_SECRET,
+          }),
+        );
+        expect(runtimeLog).toHaveBeenCalledWith(
+          `webhook local listener on ${webhookUrl(port, TELEGRAM_WEBHOOK_PATH)}`,
+        );
+      },
+    );
   });
 
   it("keeps webhook payload readable when callback delays body read", async () => {
@@ -342,32 +416,23 @@ describe("startTelegramWebhook", () => {
       await reply(JSON.stringify(update));
     });
 
-    const abort = new AbortController();
-    const { server } = await startTelegramWebhook({
-      token: "tok",
-      secret: "secret",
-      port: 0,
-      abortSignal: abort.signal,
-      path: "/hook",
-    });
-    try {
-      const addr = server.address();
-      if (!addr || typeof addr === "string") {
-        throw new Error("no addr");
-      }
-
-      const payload = JSON.stringify({ update_id: 1, message: { text: "hello" } });
-      const res = await postWebhookJson({
-        url: `http://127.0.0.1:${addr.port}/hook`,
-        payload,
-        secret: "secret",
-      });
-      expect(res.status).toBe(200);
-      const responseBody = await res.text();
-      expect(JSON.parse(responseBody)).toEqual(JSON.parse(payload));
-    } finally {
-      abort.abort();
-    }
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+      },
+      async ({ port }) => {
+        const payload = JSON.stringify({ update_id: 1, message: { text: "hello" } });
+        const res = await postWebhookJson({
+          url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+          payload,
+          secret: TELEGRAM_SECRET,
+        });
+        expect(res.status).toBe(200);
+        const responseBody = await res.text();
+        expect(JSON.parse(responseBody)).toEqual(JSON.parse(payload));
+      },
+    );
   });
 
   it("keeps webhook payload readable across multiple delayed reads", async () => {
@@ -380,38 +445,29 @@ describe("startTelegramWebhook", () => {
     };
     handlerSpy.mockImplementationOnce(delayedHandler).mockImplementationOnce(delayedHandler);
 
-    const abort = new AbortController();
-    const { server } = await startTelegramWebhook({
-      token: "tok",
-      secret: "secret",
-      port: 0,
-      abortSignal: abort.signal,
-      path: "/hook",
-    });
-    try {
-      const addr = server.address();
-      if (!addr || typeof addr === "string") {
-        throw new Error("no addr");
-      }
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+      },
+      async ({ port }) => {
+        const payloads = [
+          JSON.stringify({ update_id: 1, message: { text: "first" } }),
+          JSON.stringify({ update_id: 2, message: { text: "second" } }),
+        ];
 
-      const payloads = [
-        JSON.stringify({ update_id: 1, message: { text: "first" } }),
-        JSON.stringify({ update_id: 2, message: { text: "second" } }),
-      ];
+        for (const payload of payloads) {
+          const res = await postWebhookJson({
+            url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+            payload,
+            secret: TELEGRAM_SECRET,
+          });
+          expect(res.status).toBe(200);
+        }
 
-      for (const payload of payloads) {
-        const res = await postWebhookJson({
-          url: `http://127.0.0.1:${addr.port}/hook`,
-          payload,
-          secret: "secret",
-        });
-        expect(res.status).toBe(200);
-      }
-
-      expect(seenPayloads.map((x) => JSON.parse(x))).toEqual(payloads.map((x) => JSON.parse(x)));
-    } finally {
-      abort.abort();
-    }
+        expect(seenPayloads.map((x) => JSON.parse(x))).toEqual(payloads.map((x) => JSON.parse(x)));
+      },
+    );
   });
 
   it("processes a second request after first-request delayed-init data loss", async () => {
@@ -434,237 +490,110 @@ describe("startTelegramWebhook", () => {
         ) as unknown as typeof handlerSpy,
     );
 
-    const secret = "secret";
-    const abort = new AbortController();
-    const { server } = await startTelegramWebhook({
-      token: "tok",
-      secret,
-      port: 0,
-      abortSignal: abort.signal,
-      path: "/hook",
-    });
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+      },
+      async ({ port }) => {
+        const firstPayload = JSON.stringify({ update_id: 100, message: { text: "first" } });
+        const secondPayload = JSON.stringify({ update_id: 101, message: { text: "second" } });
+        const firstResponse = await postWebhookPayloadWithChunkPlan({
+          port,
+          path: TELEGRAM_WEBHOOK_PATH,
+          payload: firstPayload,
+          secret: TELEGRAM_SECRET,
+          mode: "single",
+          timeoutMs: WEBHOOK_POST_TIMEOUT_MS,
+        });
+        const secondResponse = await postWebhookPayloadWithChunkPlan({
+          port,
+          path: TELEGRAM_WEBHOOK_PATH,
+          payload: secondPayload,
+          secret: TELEGRAM_SECRET,
+          mode: "single",
+          timeoutMs: WEBHOOK_POST_TIMEOUT_MS,
+        });
 
-    try {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        throw new Error("no addr");
-      }
-
-      const firstPayload = JSON.stringify({ update_id: 100, message: { text: "first" } });
-      const secondPayload = JSON.stringify({ update_id: 101, message: { text: "second" } });
-      const firstResponse = await postWebhookPayloadWithChunkPlan({
-        port: address.port,
-        path: "/hook",
-        payload: firstPayload,
-        secret,
-        mode: "single",
-        timeoutMs: WEBHOOK_POST_TIMEOUT_MS,
-      });
-      const secondResponse = await postWebhookPayloadWithChunkPlan({
-        port: address.port,
-        path: "/hook",
-        payload: secondPayload,
-        secret,
-        mode: "single",
-        timeoutMs: WEBHOOK_POST_TIMEOUT_MS,
-      });
-
-      expect(firstResponse.statusCode).toBe(200);
-      expect(secondResponse.statusCode).toBe(200);
-      expect(seenUpdates).toEqual([JSON.parse(firstPayload), JSON.parse(secondPayload)]);
-    } finally {
-      abort.abort();
-    }
+        expect(firstResponse.statusCode).toBe(200);
+        expect(secondResponse.statusCode).toBe(200);
+        expect(seenUpdates).toEqual([JSON.parse(firstPayload), JSON.parse(secondPayload)]);
+      },
+    );
   });
 
   it("handles near-limit payload with random chunk writes and event-loop yields", async () => {
-    const seenUpdates: Array<{ update_id: number; message: { text: string } }> = [];
-    webhookCallbackSpy.mockImplementationOnce(
-      () =>
-        vi.fn(
-          (
-            update: unknown,
-            reply: (json: string) => Promise<void>,
-            _secretHeader: string | undefined,
-            _unauthorized: () => Promise<void>,
-          ) => {
-            seenUpdates.push(update as { update_id: number; message: { text: string } });
-            void reply("ok");
-          },
-        ) as unknown as typeof handlerSpy,
-    );
-
-    const { payload, sizeBytes } = createNearLimitTelegramPayload();
-    expect(sizeBytes).toBeLessThan(1_024 * 1_024);
-    expect(sizeBytes).toBeGreaterThan(256 * 1_024);
-    const expected = JSON.parse(payload) as { update_id: number; message: { text: string } };
-
-    const secret = "secret";
-    const abort = new AbortController();
-    const { server } = await startTelegramWebhook({
-      token: "tok",
-      secret,
-      port: 0,
-      abortSignal: abort.signal,
-      path: "/hook",
-    });
-
-    try {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        throw new Error("no addr");
-      }
-
-      const response = await postWebhookPayloadWithChunkPlan({
-        port: address.port,
-        path: "/hook",
-        payload,
-        secret,
-        mode: "random-chunked",
-        timeoutMs: WEBHOOK_POST_TIMEOUT_MS,
-      });
-
-      expect(response.statusCode).toBe(200);
-      expect(seenUpdates).toHaveLength(1);
-      expect(seenUpdates[0]?.update_id).toBe(expected.update_id);
-      expect(seenUpdates[0]?.message.text.length).toBe(expected.message.text.length);
-      expect(sha256(seenUpdates[0]?.message.text ?? "")).toBe(sha256(expected.message.text));
-    } finally {
-      abort.abort();
-    }
+    await runNearLimitPayloadTest("random-chunked");
   });
 
   it("handles near-limit payload written in a single request write", async () => {
-    const seenUpdates: Array<{ update_id: number; message: { text: string } }> = [];
-    webhookCallbackSpy.mockImplementationOnce(
-      () =>
-        vi.fn(
-          (
-            update: unknown,
-            reply: (json: string) => Promise<void>,
-            _secretHeader: string | undefined,
-            _unauthorized: () => Promise<void>,
-          ) => {
-            seenUpdates.push(update as { update_id: number; message: { text: string } });
-            void reply("ok");
-          },
-        ) as unknown as typeof handlerSpy,
-    );
-
-    const { payload, sizeBytes } = createNearLimitTelegramPayload();
-    expect(sizeBytes).toBeLessThan(1_024 * 1_024);
-    expect(sizeBytes).toBeGreaterThan(256 * 1_024);
-    const expected = JSON.parse(payload) as { update_id: number; message: { text: string } };
-
-    const secret = "secret";
-    const abort = new AbortController();
-    const { server } = await startTelegramWebhook({
-      token: "tok",
-      secret,
-      port: 0,
-      abortSignal: abort.signal,
-      path: "/hook",
-    });
-
-    try {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        throw new Error("no addr");
-      }
-
-      const response = await postWebhookPayloadWithChunkPlan({
-        port: address.port,
-        path: "/hook",
-        payload,
-        secret,
-        mode: "single",
-        timeoutMs: WEBHOOK_POST_TIMEOUT_MS,
-      });
-
-      expect(response.statusCode).toBe(200);
-      expect(seenUpdates).toHaveLength(1);
-      expect(seenUpdates[0]?.update_id).toBe(expected.update_id);
-      expect(seenUpdates[0]?.message.text.length).toBe(expected.message.text.length);
-      expect(sha256(seenUpdates[0]?.message.text ?? "")).toBe(sha256(expected.message.text));
-    } finally {
-      abort.abort();
-    }
+    await runNearLimitPayloadTest("single");
   });
 
   it("rejects payloads larger than 1MB before invoking webhook handler", async () => {
     handlerSpy.mockClear();
-    const abort = new AbortController();
-    const { server } = await startTelegramWebhook({
-      token: "tok",
-      secret: "secret",
-      port: 0,
-      abortSignal: abort.signal,
-      path: "/hook",
-    });
-
-    try {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        throw new Error("no addr");
-      }
-
-      const responseOrError = await new Promise<
-        | { kind: "response"; statusCode: number; body: string }
-        | { kind: "error"; code: string | undefined }
-      >((resolve) => {
-        const req = request(
-          {
-            hostname: "127.0.0.1",
-            port: address.port,
-            path: "/hook",
-            method: "POST",
-            headers: {
-              "content-type": "application/json",
-              "content-length": String(1_024 * 1_024 + 2_048),
-              "x-telegram-bot-api-secret-token": "secret",
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+      },
+      async ({ port }) => {
+        const responseOrError = await new Promise<
+          | { kind: "response"; statusCode: number; body: string }
+          | { kind: "error"; code: string | undefined }
+        >((resolve) => {
+          const req = request(
+            {
+              hostname: "127.0.0.1",
+              port,
+              path: TELEGRAM_WEBHOOK_PATH,
+              method: "POST",
+              headers: {
+                "content-type": "application/json",
+                "content-length": String(1_024 * 1_024 + 2_048),
+                "x-telegram-bot-api-secret-token": TELEGRAM_SECRET,
+              },
             },
-          },
-          (res) => {
-            const chunks: Buffer[] = [];
-            res.on("data", (chunk: Buffer | string) => {
-              chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-            });
-            res.on("end", () => {
-              resolve({
-                kind: "response",
-                statusCode: res.statusCode ?? 0,
-                body: Buffer.concat(chunks).toString("utf-8"),
+            (res) => {
+              const chunks: Buffer[] = [];
+              res.on("data", (chunk: Buffer | string) => {
+                chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
               });
-            });
-          },
-        );
-        req.on("error", (error: NodeJS.ErrnoException) => {
-          resolve({ kind: "error", code: error.code });
+              res.on("end", () => {
+                resolve({
+                  kind: "response",
+                  statusCode: res.statusCode ?? 0,
+                  body: Buffer.concat(chunks).toString("utf-8"),
+                });
+              });
+            },
+          );
+          req.on("error", (error: NodeJS.ErrnoException) => {
+            resolve({ kind: "error", code: error.code });
+          });
+          req.end("{}");
         });
-        req.end("{}");
-      });
 
-      if (responseOrError.kind === "response") {
-        expect(responseOrError.statusCode).toBe(413);
-        expect(responseOrError.body).toBe("Payload too large");
-      } else {
-        expect(responseOrError.code).toBeOneOf(["ECONNRESET", "EPIPE"]);
-      }
-      expect(handlerSpy).not.toHaveBeenCalled();
-    } finally {
-      abort.abort();
-    }
+        if (responseOrError.kind === "response") {
+          expect(responseOrError.statusCode).toBe(413);
+          expect(responseOrError.body).toBe("Payload too large");
+        } else {
+          expect(responseOrError.code).toBeOneOf(["ECONNRESET", "EPIPE"]);
+        }
+        expect(handlerSpy).not.toHaveBeenCalled();
+      },
+    );
   });
 
   it("de-registers webhook when shutting down", async () => {
     deleteWebhookSpy.mockClear();
     const abort = new AbortController();
     await startTelegramWebhook({
-      token: "tok",
-      secret: "secret",
+      token: TELEGRAM_TOKEN,
+      secret: TELEGRAM_SECRET,
       port: 0,
       abortSignal: abort.signal,
-      path: "/hook",
+      path: TELEGRAM_WEBHOOK_PATH,
     });
 
     abort.abort();

--- a/src/tui/tui-local-shell.test.ts
+++ b/src/tui/tui-local-shell.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import { createLocalShellRunner } from "./tui-local-shell.js";
 
@@ -11,44 +12,93 @@ const createSelector = () => {
   return selector;
 };
 
+function createShellHarness(params?: {
+  spawnCommand?: typeof import("node:child_process").spawn;
+  env?: Record<string, string>;
+}) {
+  const messages: string[] = [];
+  const chatLog = {
+    addSystem: (line: string) => {
+      messages.push(line);
+    },
+  };
+  const tui = { requestRender: vi.fn() };
+  const openOverlay = vi.fn();
+  const closeOverlay = vi.fn();
+  let lastSelector: ReturnType<typeof createSelector> | null = null;
+  const createSelectorSpy = vi.fn(() => {
+    lastSelector = createSelector();
+    return lastSelector;
+  });
+  const spawnCommand = params?.spawnCommand ?? vi.fn();
+  const { runLocalShellLine } = createLocalShellRunner({
+    chatLog,
+    tui,
+    openOverlay,
+    closeOverlay,
+    createSelector: createSelectorSpy,
+    spawnCommand,
+    ...(params?.env ? { env: params.env } : {}),
+  });
+  return {
+    messages,
+    openOverlay,
+    createSelectorSpy,
+    spawnCommand,
+    runLocalShellLine,
+    getLastSelector: () => lastSelector,
+  };
+}
+
 describe("createLocalShellRunner", () => {
   it("logs denial on subsequent ! attempts without re-prompting", async () => {
-    const messages: string[] = [];
-    const chatLog = {
-      addSystem: (line: string) => {
-        messages.push(line);
-      },
-    };
-    const tui = { requestRender: vi.fn() };
-    const openOverlay = vi.fn();
-    const closeOverlay = vi.fn();
-    let lastSelector: ReturnType<typeof createSelector> | null = null;
-    const createSelectorSpy = vi.fn(() => {
-      lastSelector = createSelector();
-      return lastSelector;
-    });
-    const spawnCommand = vi.fn();
+    const harness = createShellHarness();
 
-    const { runLocalShellLine } = createLocalShellRunner({
-      chatLog,
-      tui,
-      openOverlay,
-      closeOverlay,
-      createSelector: createSelectorSpy,
-      spawnCommand,
-    });
-
-    const firstRun = runLocalShellLine("!ls");
-    expect(openOverlay).toHaveBeenCalledTimes(1);
-    const selector = lastSelector as ReturnType<typeof createSelector> | null;
+    const firstRun = harness.runLocalShellLine("!ls");
+    expect(harness.openOverlay).toHaveBeenCalledTimes(1);
+    const selector = harness.getLastSelector();
     selector?.onSelect?.({ value: "no", label: "No" });
     await firstRun;
 
-    await runLocalShellLine("!pwd");
+    await harness.runLocalShellLine("!pwd");
 
-    expect(messages).toContain("local shell: not enabled");
-    expect(messages).toContain("local shell: not enabled for this session");
-    expect(createSelectorSpy).toHaveBeenCalledTimes(1);
-    expect(spawnCommand).not.toHaveBeenCalled();
+    expect(harness.messages).toContain("local shell: not enabled");
+    expect(harness.messages).toContain("local shell: not enabled for this session");
+    expect(harness.createSelectorSpy).toHaveBeenCalledTimes(1);
+    expect(harness.spawnCommand).not.toHaveBeenCalled();
+  });
+
+  it("sets REMOTECLAW_SHELL when running local shell commands", async () => {
+    const spawnCommand = vi.fn((_command: string, _options: unknown) => {
+      const stdout = new EventEmitter();
+      const stderr = new EventEmitter();
+      return {
+        stdout,
+        stderr,
+        on: (event: string, callback: (...args: unknown[]) => void) => {
+          if (event === "close") {
+            setImmediate(() => callback(0, null));
+          }
+        },
+      };
+    });
+
+    const harness = createShellHarness({
+      spawnCommand: spawnCommand as unknown as typeof import("node:child_process").spawn,
+      env: { PATH: "/tmp/bin", USER: "dev" },
+    });
+
+    const firstRun = harness.runLocalShellLine("!echo hi");
+    expect(harness.openOverlay).toHaveBeenCalledTimes(1);
+    const selector = harness.getLastSelector();
+    selector?.onSelect?.({ value: "yes", label: "Yes" });
+    await firstRun;
+
+    expect(harness.createSelectorSpy).toHaveBeenCalledTimes(1);
+    expect(spawnCommand).toHaveBeenCalledTimes(1);
+    const spawnOptions = spawnCommand.mock.calls[0]?.[1] as { env?: Record<string, string> };
+    expect(spawnOptions.env?.REMOTECLAW_SHELL).toBe("tui-local");
+    expect(spawnOptions.env?.PATH).toBe("/tmp/bin");
+    expect(harness.messages).toContain("local shell: enabled for this session");
   });
 });

--- a/src/tui/tui-local-shell.ts
+++ b/src/tui/tui-local-shell.ts
@@ -111,7 +111,7 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
         // and is gated behind an explicit in-session approval prompt.
         shell: true,
         cwd: getCwd(),
-        env,
+        env: { ...env, REMOTECLAW_SHELL: "tui-local" },
       });
 
       let stdout = "";


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #703
**Commits**: 12 cherry-picked + 2 adaptation commits

| Hash | Subject | Result |
|------|---------|--------|
| `5bb26bf22` | fix(browser): skip port ownership check for remote CDP profiles (#28780) | RESOLVED |
| `7c9d2c1d4` | fix(browser): retry relay navigation after frame detach | RESOLVED |
| `821b7c80a` | fix(browser): avoid extension profile startup deadlock in browser start | RESOLVED |
| `f77f3fb83` | fix(browser): tolerate brief extension relay disconnects on attached tabs | RESOLVED |
| `b3cf6e7d7` | fix: harden relay reconnect grace coverage (#30232) | RESOLVED |
| `18cd77c8c` | fix: cover relay reannounce minimal target path (#27630) | RESOLVED |
| `04b3a51d3` | fix(browser): preserve debugger attachment across relay disconnects during navigation reattach | RESOLVED |
| `3e3b49cb9` | fix(browser): prefer openclaw profile in headless/noSandbox environments | RESOLVED |
| `d03928bb6` | test: Add tests for headless/noSandbox profile preference | PICKED |
| `281494ae5` | fix(browser): include Chrome stderr and sandbox hint in CDP startup error (#29355) | RESOLVED |
| `45888276a` | test(integration): dedupe messaging, secrets, and plugin test suites | RESOLVED |
| `5b55c2394` | fix(browser): evict stale extension relay targets from cache (#31362) | RESOLVED |

### Adaptation notes
- All `openclaw` → `remoteclaw` rebrand conflicts resolved (env vars, profile names, header names, badge titles)
- CHANGELOG.md conflicts auto-resolved (deleted in fork)
- Gutted layer test files (memory, secrets, sessions/model-overrides) kept deleted
- `as const` added to Slack test literals for fork's stricter TS
- `trackEvent` references removed (not in fork's SlackMonitorContext)
- `__testing` export added to loader.ts for plugin SDK alias tests
- Navigate retry merged with SSRF redirect-chain checking

🤖 Generated with [Claude Code](https://claude.com/claude-code)