### PR TITLE
Cherry-pick: Browser fixes — CDP readiness, port range, attachOnly, extraArgs

### DIFF
--- a/src/browser/bridge-server.auth.test.ts
+++ b/src/browser/bridge-server.auth.test.ts
@@ -11,6 +11,8 @@ function buildResolvedConfig(): ResolvedBrowserConfig {
     enabled: true,
     evaluateEnabled: false,
     controlPort: 0,
+    cdpPortRangeStart: 18800,
+    cdpPortRangeEnd: 18899,
     cdpProtocol: "http",
     cdpHost: "127.0.0.1",
     cdpIsLoopback: true,

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -55,6 +55,22 @@ describe("browser config", () => {
     });
   });
 
+  it("supports overriding the local CDP auto-allocation range start", () => {
+    const resolved = resolveBrowserConfig({
+      cdpPortRangeStart: 19000,
+    });
+    const openclaw = resolveProfile(resolved, "openclaw");
+    expect(resolved.cdpPortRangeStart).toBe(19000);
+    expect(openclaw?.cdpPort).toBe(19000);
+    expect(openclaw?.cdpUrl).toBe("http://127.0.0.1:19000");
+  });
+
+  it("rejects cdpPortRangeStart values that overflow the CDP range window", () => {
+    expect(() => resolveBrowserConfig({ cdpPortRangeStart: 65535 })).toThrow(
+      /cdpPortRangeStart .* too high/i,
+    );
+  });
+
   it("normalizes hex colors", () => {
     const resolved = resolveBrowserConfig({
       color: "ff4500",

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -125,6 +125,30 @@ describe("browser config", () => {
     expect(remote?.cdpIsLoopback).toBe(false);
   });
 
+  it("inherits attachOnly from global browser config when profile override is not set", () => {
+    const resolved = resolveBrowserConfig({
+      attachOnly: true,
+      profiles: {
+        remote: { cdpUrl: "http://127.0.0.1:9222", color: "#0066CC" },
+      },
+    });
+
+    const remote = resolveProfile(resolved, "remote");
+    expect(remote?.attachOnly).toBe(true);
+  });
+
+  it("allows profile attachOnly to override global browser attachOnly", () => {
+    const resolved = resolveBrowserConfig({
+      attachOnly: false,
+      profiles: {
+        remote: { cdpUrl: "http://127.0.0.1:9222", attachOnly: true, color: "#0066CC" },
+      },
+    });
+
+    const remote = resolveProfile(resolved, "remote");
+    expect(remote?.attachOnly).toBe(true);
+  });
+
   it("uses base protocol for profiles with only cdpPort", () => {
     const resolved = resolveBrowserConfig({
       cdpUrl: "https://example.com:9443",

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -59,10 +59,10 @@ describe("browser config", () => {
     const resolved = resolveBrowserConfig({
       cdpPortRangeStart: 19000,
     });
-    const openclaw = resolveProfile(resolved, "openclaw");
+    const remoteclaw = resolveProfile(resolved, "remoteclaw");
     expect(resolved.cdpPortRangeStart).toBe(19000);
-    expect(openclaw?.cdpPort).toBe(19000);
-    expect(openclaw?.cdpUrl).toBe("http://127.0.0.1:19000");
+    expect(remoteclaw?.cdpPort).toBe(19000);
+    expect(remoteclaw?.cdpUrl).toBe("http://127.0.0.1:19000");
   });
 
   it("rejects cdpPortRangeStart values that overflow the CDP range window", () => {

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -47,6 +47,7 @@ export type ResolvedBrowserProfile = {
   cdpIsLoopback: boolean;
   color: string;
   driver: "remoteclaw" | "extension";
+  attachOnly: boolean;
 };
 
 function normalizeHexColor(raw: string | undefined) {
@@ -358,6 +359,7 @@ export function resolveProfile(
     cdpIsLoopback: isLoopbackHost(cdpHost),
     color: profile.color,
     driver,
+    attachOnly: profile.attachOnly ?? resolved.attachOnly,
   };
 }
 

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -20,6 +20,8 @@ export type ResolvedBrowserConfig = {
   enabled: boolean;
   evaluateEnabled: boolean;
   controlPort: number;
+  cdpPortRangeStart: number;
+  cdpPortRangeEnd: number;
   cdpProtocol: "http" | "https";
   cdpHost: string;
   cdpIsLoopback: boolean;
@@ -62,6 +64,27 @@ function normalizeHexColor(raw: string | undefined) {
 function normalizeTimeoutMs(raw: number | undefined, fallback: number) {
   const value = typeof raw === "number" && Number.isFinite(raw) ? Math.floor(raw) : fallback;
   return value < 0 ? fallback : value;
+}
+
+function resolveCdpPortRangeStart(
+  rawStart: number | undefined,
+  fallbackStart: number,
+  rangeSpan: number,
+) {
+  const start =
+    typeof rawStart === "number" && Number.isFinite(rawStart)
+      ? Math.floor(rawStart)
+      : fallbackStart;
+  if (start < 1 || start > 65535) {
+    throw new Error(`browser.cdpPortRangeStart must be between 1 and 65535, got: ${start}`);
+  }
+  const maxStart = 65535 - rangeSpan;
+  if (start > maxStart) {
+    throw new Error(
+      `browser.cdpPortRangeStart (${start}) is too high for a ${rangeSpan + 1}-port range; max is ${maxStart}.`,
+    );
+  }
+  return start;
 }
 
 function normalizeStringList(raw: string[] | undefined): string[] | undefined {
@@ -201,6 +224,13 @@ export function resolveBrowserConfig(
   );
 
   const derivedCdpRange = deriveDefaultBrowserCdpPortRange(controlPort);
+  const cdpRangeSpan = derivedCdpRange.end - derivedCdpRange.start;
+  const cdpPortRangeStart = resolveCdpPortRangeStart(
+    cfg?.cdpPortRangeStart,
+    derivedCdpRange.start,
+    cdpRangeSpan,
+  );
+  const cdpPortRangeEnd = cdpPortRangeStart + cdpRangeSpan;
 
   const rawCdpUrl = (cfg?.cdpUrl ?? "").trim();
   let cdpInfo:
@@ -242,7 +272,7 @@ export function resolveBrowserConfig(
       cfg?.profiles,
       defaultColor,
       legacyCdpPort,
-      derivedCdpRange.start,
+      cdpPortRangeStart,
       legacyCdpUrl,
     ),
     controlPort,
@@ -270,6 +300,8 @@ export function resolveBrowserConfig(
     enabled,
     evaluateEnabled,
     controlPort,
+    cdpPortRangeStart,
+    cdpPortRangeEnd,
     cdpProtocol,
     cdpHost: cdpInfo.parsed.hostname,
     cdpIsLoopback: isLoopbackHost(cdpInfo.parsed.hostname),

--- a/src/browser/profiles-service.ts
+++ b/src/browser/profiles-service.ts
@@ -40,6 +40,30 @@ export type DeleteProfileResult = {
 
 const HEX_COLOR_RE = /^#[0-9A-Fa-f]{6}$/;
 
+const cdpPortRange = (resolved: {
+  controlPort: number;
+  cdpPortRangeStart?: number;
+  cdpPortRangeEnd?: number;
+}): { start: number; end: number } => {
+  const start = resolved.cdpPortRangeStart;
+  const end = resolved.cdpPortRangeEnd;
+  if (
+    typeof start === "number" &&
+    Number.isFinite(start) &&
+    Number.isInteger(start) &&
+    typeof end === "number" &&
+    Number.isFinite(end) &&
+    Number.isInteger(end) &&
+    start > 0 &&
+    end >= start &&
+    end <= 65535
+  ) {
+    return { start, end };
+  }
+
+  return deriveDefaultBrowserCdpPortRange(resolved.controlPort);
+};
+
 export function createBrowserProfilesService(ctx: BrowserRouteContext) {
   const listProfiles = async (): Promise<ProfileStatus[]> => {
     return await ctx.listProfiles();
@@ -80,7 +104,7 @@ export function createBrowserProfilesService(ctx: BrowserRouteContext) {
       };
     } else {
       const usedPorts = getUsedPorts(resolvedProfiles);
-      const range = deriveDefaultBrowserCdpPortRange(state.resolved.controlPort);
+      const range = cdpPortRange(state.resolved);
       const cdpPort = allocateCdpPort(usedPorts, range);
       if (cdpPort === null) {
         throw new Error("no available CDP ports in range");

--- a/src/browser/routes/basic.ts
+++ b/src/browser/routes/basic.ts
@@ -86,7 +86,7 @@ export function registerBrowserBasicRoutes(app: BrowserRouteRegistrar, ctx: Brow
       headless: current.resolved.headless,
       noSandbox: current.resolved.noSandbox,
       executablePath: current.resolved.executablePath ?? null,
-      attachOnly: current.resolved.attachOnly,
+      attachOnly: profileCtx.profile.attachOnly,
     });
   });
 

--- a/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
+++ b/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
@@ -1,0 +1,77 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as chromeModule from "./chrome.js";
+import "./server-context.chrome-test-harness.js";
+import type { BrowserServerState } from "./server-context.js";
+import { createBrowserRouteContext } from "./server-context.js";
+
+function makeBrowserState(): BrowserServerState {
+  return {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    server: null as any,
+    port: 0,
+    resolved: {
+      enabled: true,
+      controlPort: 18791,
+      cdpProtocol: "http",
+      cdpHost: "127.0.0.1",
+      cdpIsLoopback: true,
+      evaluateEnabled: false,
+      remoteCdpTimeoutMs: 1500,
+      remoteCdpHandshakeTimeoutMs: 3000,
+      extraArgs: [],
+      color: "#FF4500",
+      headless: true,
+      noSandbox: false,
+      attachOnly: false,
+      ssrfPolicy: { allowPrivateNetwork: true },
+      defaultProfile: "openclaw",
+      profiles: {
+        openclaw: { cdpPort: 18800, color: "#FF4500" },
+      },
+    },
+    profiles: new Map(),
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("browser server-context ensureBrowserAvailable", () => {
+  it("waits for CDP readiness after launching to avoid follow-up PortInUseError races (#21149)", async () => {
+    vi.useFakeTimers();
+
+    const launchOpenClawChrome = vi.mocked(chromeModule.launchOpenClawChrome);
+    const stopOpenClawChrome = vi.mocked(chromeModule.stopOpenClawChrome);
+    const isChromeReachable = vi.mocked(chromeModule.isChromeReachable);
+    const isChromeCdpReady = vi.mocked(chromeModule.isChromeCdpReady);
+
+    isChromeReachable.mockResolvedValue(false);
+    isChromeCdpReady.mockResolvedValueOnce(false).mockResolvedValue(true);
+
+    const proc = new EventEmitter() as unknown as ChildProcessWithoutNullStreams;
+    launchOpenClawChrome.mockResolvedValue({
+      pid: 123,
+      exe: { kind: "chromium", path: "/usr/bin/chromium" },
+      userDataDir: "/tmp/openclaw-test",
+      cdpPort: 18800,
+      startedAt: Date.now(),
+      proc,
+    });
+
+    const state = makeBrowserState();
+    const ctx = createBrowserRouteContext({ getState: () => state });
+    const profile = ctx.forProfile("openclaw");
+
+    const promise = profile.ensureBrowserAvailable();
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(promise).resolves.toBeUndefined();
+
+    expect(launchOpenClawChrome).toHaveBeenCalledTimes(1);
+    expect(isChromeCdpReady).toHaveBeenCalled();
+    expect(stopOpenClawChrome).not.toHaveBeenCalled();
+  });
+});

--- a/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
+++ b/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
@@ -1,10 +1,23 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { installChromeUserDataDirHooks } from "./chrome-user-data-dir.test-harness.js";
 import * as chromeModule from "./chrome.js";
-import "./server-context.chrome-test-harness.js";
 import type { BrowserServerState } from "./server-context.js";
 import { createBrowserRouteContext } from "./server-context.js";
+
+const chromeUserDataDir = { dir: "/tmp/remoteclaw" };
+installChromeUserDataDirHooks(chromeUserDataDir);
+
+vi.mock("./chrome.js", () => ({
+  isChromeCdpReady: vi.fn(async () => true),
+  isChromeReachable: vi.fn(async () => true),
+  launchRemoteClawChrome: vi.fn(async () => {
+    throw new Error("unexpected launch");
+  }),
+  resolveRemoteClawUserDataDir: vi.fn(() => chromeUserDataDir.dir),
+  stopRemoteClawChrome: vi.fn(async () => {}),
+}));
 
 function makeBrowserState(): BrowserServerState {
   return {
@@ -14,6 +27,8 @@ function makeBrowserState(): BrowserServerState {
     resolved: {
       enabled: true,
       controlPort: 18791,
+      cdpPortRangeStart: 18800,
+      cdpPortRangeEnd: 18899,
       cdpProtocol: "http",
       cdpHost: "127.0.0.1",
       cdpIsLoopback: true,
@@ -26,9 +41,9 @@ function makeBrowserState(): BrowserServerState {
       noSandbox: false,
       attachOnly: false,
       ssrfPolicy: { allowPrivateNetwork: true },
-      defaultProfile: "openclaw",
+      defaultProfile: "remoteclaw",
       profiles: {
-        openclaw: { cdpPort: 18800, color: "#FF4500" },
+        remoteclaw: { cdpPort: 18800, color: "#FF4500" },
       },
     },
     profiles: new Map(),
@@ -44,19 +59,18 @@ describe("browser server-context ensureBrowserAvailable", () => {
   it("waits for CDP readiness after launching to avoid follow-up PortInUseError races (#21149)", async () => {
     vi.useFakeTimers();
 
-    const launchOpenClawChrome = vi.mocked(chromeModule.launchOpenClawChrome);
-    const stopOpenClawChrome = vi.mocked(chromeModule.stopOpenClawChrome);
     const isChromeReachable = vi.mocked(chromeModule.isChromeReachable);
     const isChromeCdpReady = vi.mocked(chromeModule.isChromeCdpReady);
+    const launchRemoteClawChrome = vi.mocked(chromeModule.launchRemoteClawChrome);
 
     isChromeReachable.mockResolvedValue(false);
     isChromeCdpReady.mockResolvedValueOnce(false).mockResolvedValue(true);
 
     const proc = new EventEmitter() as unknown as ChildProcessWithoutNullStreams;
-    launchOpenClawChrome.mockResolvedValue({
+    launchRemoteClawChrome.mockResolvedValue({
       pid: 123,
       exe: { kind: "chromium", path: "/usr/bin/chromium" },
-      userDataDir: "/tmp/openclaw-test",
+      userDataDir: "/tmp/remoteclaw-test",
       cdpPort: 18800,
       startedAt: Date.now(),
       proc,
@@ -64,14 +78,14 @@ describe("browser server-context ensureBrowserAvailable", () => {
 
     const state = makeBrowserState();
     const ctx = createBrowserRouteContext({ getState: () => state });
-    const profile = ctx.forProfile("openclaw");
+    const profile = ctx.forProfile("remoteclaw");
 
     const promise = profile.ensureBrowserAvailable();
     await vi.advanceTimersByTimeAsync(100);
     await expect(promise).resolves.toBeUndefined();
 
-    expect(launchOpenClawChrome).toHaveBeenCalledTimes(1);
+    expect(launchRemoteClawChrome).toHaveBeenCalledTimes(1);
     expect(isChromeCdpReady).toHaveBeenCalled();
-    expect(stopOpenClawChrome).not.toHaveBeenCalled();
+    expect(chromeModule.stopRemoteClawChrome).not.toHaveBeenCalled();
   });
 });

--- a/src/browser/server-context.ensure-tab-available.prefers-last-target.test.ts
+++ b/src/browser/server-context.ensure-tab-available.prefers-last-target.test.ts
@@ -12,6 +12,8 @@ function makeBrowserState(): BrowserServerState {
     resolved: {
       enabled: true,
       controlPort: 18791,
+      cdpPortRangeStart: 18800,
+      cdpPortRangeEnd: 18899,
       cdpProtocol: "http",
       cdpHost: "127.0.0.1",
       cdpIsLoopback: true,

--- a/src/browser/server-context.remote-tab-ops.test.ts
+++ b/src/browser/server-context.remote-tab-ops.test.ts
@@ -24,6 +24,8 @@ function makeState(
     resolved: {
       enabled: true,
       controlPort: 18791,
+      cdpPortRangeStart: 18800,
+      cdpPortRangeEnd: 18899,
       cdpProtocol: profile === "remote" ? "https" : "http",
       cdpHost: profile === "remote" ? "browserless.example" : "127.0.0.1",
       cdpIsLoopback: profile !== "remote",

--- a/src/browser/server-context.remote-tab-ops.test.ts
+++ b/src/browser/server-context.remote-tab-ops.test.ts
@@ -100,19 +100,19 @@ function createJsonListFetchMock(entries: JsonListEntry[]) {
 
 describe("browser server-context remote profile tab operations", () => {
   it("uses profile-level attachOnly when global attachOnly is false", async () => {
-    const state = makeState("openclaw");
+    const state = makeState("remoteclaw");
     state.resolved.attachOnly = false;
-    state.resolved.profiles.openclaw = {
+    state.resolved.profiles.remoteclaw = {
       cdpPort: 18800,
       attachOnly: true,
       color: "#FF4500",
     };
 
     const reachableMock = vi.mocked(chromeModule.isChromeReachable).mockResolvedValueOnce(false);
-    const launchMock = vi.mocked(chromeModule.launchOpenClawChrome);
+    const launchMock = vi.mocked(chromeModule.launchRemoteClawChrome);
     const ctx = createBrowserRouteContext({ getState: () => state });
 
-    await expect(ctx.forProfile("openclaw").ensureBrowserAvailable()).rejects.toThrow(
+    await expect(ctx.forProfile("remoteclaw").ensureBrowserAvailable()).rejects.toThrow(
       /attachOnly is enabled/i,
     );
     expect(reachableMock).toHaveBeenCalled();
@@ -120,9 +120,9 @@ describe("browser server-context remote profile tab operations", () => {
   });
 
   it("keeps attachOnly websocket failures off the loopback ownership error path", async () => {
-    const state = makeState("openclaw");
+    const state = makeState("remoteclaw");
     state.resolved.attachOnly = false;
-    state.resolved.profiles.openclaw = {
+    state.resolved.profiles.remoteclaw = {
       cdpPort: 18800,
       attachOnly: true,
       color: "#FF4500",
@@ -130,10 +130,10 @@ describe("browser server-context remote profile tab operations", () => {
 
     const httpReachableMock = vi.mocked(chromeModule.isChromeReachable).mockResolvedValueOnce(true);
     const wsReachableMock = vi.mocked(chromeModule.isChromeCdpReady).mockResolvedValueOnce(false);
-    const launchMock = vi.mocked(chromeModule.launchOpenClawChrome);
+    const launchMock = vi.mocked(chromeModule.launchRemoteClawChrome);
     const ctx = createBrowserRouteContext({ getState: () => state });
 
-    await expect(ctx.forProfile("openclaw").ensureBrowserAvailable()).rejects.toThrow(
+    await expect(ctx.forProfile("remoteclaw").ensureBrowserAvailable()).rejects.toThrow(
       /attachOnly is enabled and CDP websocket/i,
     );
     expect(httpReachableMock).toHaveBeenCalled();

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -283,7 +283,7 @@ function createProfileContext(
     const profileState = getProfileState();
     const httpReachable = await isHttpReachable();
     const waitForCdpReadyAfterLaunch = async () => {
-      // launchOpenClawChrome() can return before Chrome is fully ready to serve /json/version + CDP WS.
+      // launchRemoteClawChrome() can return before Chrome is fully ready to serve /json/version + CDP WS.
       // If a follow-up call (snapshot/screenshot/etc.) races ahead, we can hit PortInUseError trying to
       // launch again on the same port. Poll briefly so browser(action="start"/"open") is stable.
       const maxAttempts = 50;
@@ -340,7 +340,7 @@ function createProfileContext(
       try {
         await waitForCdpReadyAfterLaunch();
       } catch (err) {
-        await stopOpenClawChrome(launched).catch(() => {});
+        await stopRemoteClawChrome(launched).catch(() => {});
         setProfileRunning(null);
         throw err;
       }

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -278,6 +278,7 @@ function createProfileContext(
   const ensureBrowserAvailable = async (): Promise<void> => {
     const current = state();
     const remoteCdp = !profile.cdpIsLoopback;
+    const attachOnly = profile.attachOnly;
     const isExtension = profile.driver === "extension";
     const profileState = getProfileState();
     const httpReachable = await isHttpReachable();
@@ -306,13 +307,13 @@ function createProfileContext(
     }
 
     if (!httpReachable) {
-      if ((current.resolved.attachOnly || remoteCdp) && opts.onEnsureAttachTarget) {
+      if ((attachOnly || remoteCdp) && opts.onEnsureAttachTarget) {
         await opts.onEnsureAttachTarget(profile);
         if (await isHttpReachable(1200)) {
           return;
         }
       }
-      if (current.resolved.attachOnly || remoteCdp) {
+      if (attachOnly || remoteCdp) {
         throw new Error(
           remoteCdp
             ? `Remote CDP for profile "${profile.name}" is not reachable at ${profile.cdpUrl}.`
@@ -329,17 +330,9 @@ function createProfileContext(
       return;
     }
 
-    // HTTP responds but WebSocket fails - port in use by something else.
-    // Skip this check for remote CDP profiles since we never own the remote process.
-    if (!profileState.running && !remoteCdp) {
-      throw new Error(
-        `Port ${profile.cdpPort} is in use for profile "${profile.name}" but not by remoteclaw. ` +
-          `Run action=reset-profile profile=${profile.name} to kill the process.`,
-      );
-    }
-
-    // We own it but WebSocket failed - restart
-    if (current.resolved.attachOnly || remoteCdp) {
+    // HTTP responds but WebSocket fails. For attachOnly/remote profiles, never perform
+    // local ownership/restart handling; just run attach retries and surface attach errors.
+    if (attachOnly || remoteCdp) {
       if (opts.onEnsureAttachTarget) {
         await opts.onEnsureAttachTarget(profile);
         if (await isReachable(1200)) {
@@ -353,9 +346,18 @@ function createProfileContext(
       );
     }
 
+    // HTTP responds but WebSocket fails - port in use by something else.
+    if (!profileState.running) {
+      throw new Error(
+        `Port ${profile.cdpPort} is in use for profile "${profile.name}" but not by remoteclaw. ` +
+          `Run action=reset-profile profile=${profile.name} to kill the process.`,
+      );
+    }
+
+    // We own it but WebSocket failed - restart
     // At this point profileState.running is always non-null: the !remoteCdp guard
-    // above throws when running is null, and the remoteCdp path always exits via
-    // the attachOnly/remoteCdp block. Add an explicit guard for TypeScript.
+    // above throws when running is null, and attachOnly/remoteCdp paths always
+    // exit via the block above. Add an explicit guard for TypeScript.
     if (!profileState.running) {
       throw new Error(
         `Unexpected state for profile "${profile.name}": no running process to restart.`,

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -282,6 +282,21 @@ function createProfileContext(
     const isExtension = profile.driver === "extension";
     const profileState = getProfileState();
     const httpReachable = await isHttpReachable();
+    const waitForCdpReadyAfterLaunch = async () => {
+      // launchOpenClawChrome() can return before Chrome is fully ready to serve /json/version + CDP WS.
+      // If a follow-up call (snapshot/screenshot/etc.) races ahead, we can hit PortInUseError trying to
+      // launch again on the same port. Poll briefly so browser(action="start"/"open") is stable.
+      const maxAttempts = 50;
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (await isReachable(1200)) {
+          return;
+        }
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      throw new Error(
+        `Chrome CDP websocket for profile "${profile.name}" is not reachable after start.`,
+      );
+    };
 
     if (isExtension && remoteCdp) {
       throw new Error(
@@ -322,6 +337,13 @@ function createProfileContext(
       }
       const launched = await launchRemoteClawChrome(current.resolved, profile);
       attachRunning(launched);
+      try {
+        await waitForCdpReadyAfterLaunch();
+      } catch (err) {
+        await stopOpenClawChrome(launched).catch(() => {});
+        setProfileRunning(null);
+        throw err;
+      }
       return;
     }
 

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -102,4 +102,24 @@ describe("config schema regressions", () => {
       expect(res.issues[0]?.path).toBe("channels.imessage.attachmentRoots.0");
     }
   });
+
+  it("accepts browser.extraArgs for proxy and custom flags", () => {
+    const res = validateConfigObject({
+      browser: {
+        extraArgs: ["--proxy-server=http://127.0.0.1:7890"],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects browser.extraArgs with non-array value", () => {
+    const res = validateConfigObject({
+      browser: {
+        extraArgs: "--proxy-server=http://127.0.0.1:7890" as unknown,
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
 });

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -204,6 +204,7 @@ const TARGET_KEYS = [
   "browser.noSandbox",
   "browser.profiles",
   "browser.profiles.*.driver",
+  "browser.profiles.*.attachOnly",
   "tools",
   "tools.allow",
   "tools.deny",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -183,6 +183,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Disables Chromium sandbox isolation flags for environments where sandboxing fails at runtime. Keep this off whenever possible because process isolation protections are reduced.",
   "browser.attachOnly":
     "Restricts browser mode to attach-only behavior without starting local browser processes. Use this when all browser sessions are externally managed by a remote CDP provider.",
+  "browser.cdpPortRangeStart":
+    "Starting local CDP port used for auto-allocated browser profile ports. Increase this when host-level port defaults conflict with other local services.",
   "browser.defaultProfile":
     "Default browser profile name selected when callers do not explicitly choose a profile. Use a stable low-privilege profile as the default to reduce accidental cross-context state use.",
   "browser.relayBindHost":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -197,6 +197,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Per-profile CDP websocket URL used for explicit remote browser routing by profile name. Use this when profile connections terminate on remote hosts or tunnels.",
   "browser.profiles.*.driver":
     'Per-profile browser driver mode: "remoteclaw" (or legacy "clawd") or "extension" depending on connection/runtime strategy. Use the driver that matches your browser control stack to avoid protocol mismatches.',
+  "browser.profiles.*.attachOnly":
+    "Per-profile attach-only override that skips local browser launch and only attaches to an existing CDP endpoint. Useful when one profile is externally managed but others are locally launched.",
   "browser.profiles.*.color":
     "Per-profile accent color for visual differentiation in dashboards and browser-related UI hints. Use distinct colors for high-signal operator recognition of active profiles.",
   "browser.evaluateEnabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -103,6 +103,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "browser.headless": "Browser Headless Mode",
   "browser.noSandbox": "Browser No-Sandbox Mode",
   "browser.attachOnly": "Browser Attach-only Mode",
+  "browser.cdpPortRangeStart": "Browser CDP Port Range Start",
   "browser.defaultProfile": "Browser Default Profile",
   "browser.relayBindHost": "Browser Relay Bind Address",
   "browser.profiles": "Browser Profiles",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -110,6 +110,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "browser.profiles.*.cdpPort": "Browser Profile CDP Port",
   "browser.profiles.*.cdpUrl": "Browser Profile CDP URL",
   "browser.profiles.*.driver": "Browser Profile Driver",
+  "browser.profiles.*.attachOnly": "Browser Profile Attach-only Mode",
   "browser.profiles.*.color": "Browser Profile Accent Color",
   tools: "Tools",
   "tools.allow": "Tool Allowlist",

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -48,6 +48,8 @@ export type BrowserConfig = {
   noSandbox?: boolean;
   /** If true: never launch; only attach to an existing browser. Default: false */
   attachOnly?: boolean;
+  /** Starting local CDP port for auto-assigned browser profiles. Default derives from gateway port. */
+  cdpPortRangeStart?: number;
   /** Default profile to use when profile param is omitted. Default: "chrome" */
   defaultProfile?: string;
   /** Named browser profiles with explicit CDP ports or URLs. */

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -5,6 +5,8 @@ export type BrowserProfileConfig = {
   cdpUrl?: string;
   /** Profile driver (default: remoteclaw). */
   driver?: "remoteclaw" | "clawd" | "extension";
+  /** If true, never launch a browser for this profile; only attach. Falls back to browser.attachOnly. */
+  attachOnly?: boolean;
   /** Profile color (hex). Auto-assigned at creation. */
   color: string;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -214,6 +214,7 @@ export const RemoteClawSchema = z
         headless: z.boolean().optional(),
         noSandbox: z.boolean().optional(),
         attachOnly: z.boolean().optional(),
+        cdpPortRangeStart: z.number().int().min(1).max(65535).optional(),
         defaultProfile: z.string().optional(),
         snapshotDefaults: BrowserSnapshotDefaultsSchema,
         ssrfPolicy: z

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -248,6 +248,7 @@ export const RemoteClawSchema = z
           )
           .optional(),
         relayBindHost: z.union([z.string().ipv4(), z.string().ipv6()]).optional(),
+        extraArgs: z.array(z.string()).optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -238,6 +238,7 @@ export const RemoteClawSchema = z
                 driver: z
                   .union([z.literal("remoteclaw"), z.literal("clawd"), z.literal("extension")])
                   .optional(),
+                attachOnly: z.boolean().optional(),
                 color: HexColorSchema,
               })
               .strict()


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #715
**Commits**: 5 cherry-picked

| Hash | Subject | Tier | Result |
|------|---------|------|--------|
| `22be0c580` | fix(browser): support configurable CDP auto-port range start (#31352) | AUTO-PARTIAL | RESOLVED |
| `5d53b61d9` | fix(browser): honor profile attachOnly for loopback CDP (#31429) | AUTO-PICK | RESOLVED |
| `925117d27` | config: add extraArgs to browser zod schema | AUTO-PICK | RESOLVED |
| `910c65480` | test(config): add schema regression tests for browser.extraArgs | AUTO-PICK | PICKED |
| `d06cc77f3` | fix(browser): wait for CDP readiness after start (#21149) | AUTO-PICK | RESOLVED |

### Adaptations
- `22be0c580`: Dropped `src/agents/sandbox/browser.ts` (gutted layer); resolved config.ts conflict (keep fork's `legacyCdpUrl` + upstream's `cdpPortRangeStart`)
- `5d53b61d9`: Resolved 5 conflicts preserving fork rebrand (`remoteclaw` driver, error messages) while adding upstream's `attachOnly` feature
- `925117d27`: Resolved zod-schema conflict (keep fork's `relayBindHost` + upstream's `extraArgs`)
- `d06cc77f3`: Fixed upstream `OpenClaw` references → `RemoteClaw` in function names and comments
- Test adaptations: Rebranded `openclaw` → `remoteclaw` in profile names/mocks, inlined `vi.mock` for CDP readiness test (vitest harness hoisting limitation), added missing `cdpPortRangeStart`/`cdpPortRangeEnd` to test harness

Cherry-picked-from: 22be0c5801, 5d53b61d9e, 925117d277, 910c654807, d06cc77f38

🤖 Generated with [Claude Code](https://claude.com/claude-code)