### PR TITLE
Cherry-pick: Refactor dedupe — scripts, tests, ios, core, runtime helpers

### DIFF
--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/CanvasController.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/CanvasController.kt
@@ -44,6 +44,14 @@ class CanvasController {
     return (q * 100.0).toInt().coerceIn(1, 100)
   }
 
+  private fun Bitmap.scaleForMaxWidth(maxWidth: Int?): Bitmap {
+    if (maxWidth == null || maxWidth <= 0 || width <= maxWidth) {
+      return this
+    }
+    val scaledHeight = (height.toDouble() * (maxWidth.toDouble() / width.toDouble())).toInt().coerceAtLeast(1)
+    return scale(maxWidth, scaledHeight)
+  }
+
   fun attach(webView: WebView) {
     this.webView = webView
     reload()
@@ -148,13 +156,7 @@ class CanvasController {
     withContext(Dispatchers.Main) {
       val wv = webView ?: throw IllegalStateException("no webview")
       val bmp = wv.captureBitmap()
-      val scaled =
-        if (maxWidth != null && maxWidth > 0 && bmp.width > maxWidth) {
-          val h = (bmp.height.toDouble() * (maxWidth.toDouble() / bmp.width.toDouble())).toInt().coerceAtLeast(1)
-          bmp.scale(maxWidth, h)
-        } else {
-          bmp
-        }
+      val scaled = bmp.scaleForMaxWidth(maxWidth)
 
       val out = ByteArrayOutputStream()
       scaled.compress(Bitmap.CompressFormat.PNG, 100, out)
@@ -165,13 +167,7 @@ class CanvasController {
     withContext(Dispatchers.Main) {
       val wv = webView ?: throw IllegalStateException("no webview")
       val bmp = wv.captureBitmap()
-      val scaled =
-        if (maxWidth != null && maxWidth > 0 && bmp.width > maxWidth) {
-          val h = (bmp.height.toDouble() * (maxWidth.toDouble() / bmp.width.toDouble())).toInt().coerceAtLeast(1)
-          bmp.scale(maxWidth, h)
-        } else {
-          bmp
-        }
+      val scaled = bmp.scaleForMaxWidth(maxWidth)
 
       val out = ByteArrayOutputStream()
       val (compressFormat, compressQuality) =

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/ContactsHandler.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/ContactsHandler.kt
@@ -248,30 +248,37 @@ private object SystemContactsDataSource : ContactsDataSource {
   }
 
   private fun loadPhones(resolver: ContentResolver, contactId: Long): List<String> {
-    val projection = arrayOf(ContactsContract.CommonDataKinds.Phone.NUMBER)
-    resolver.query(
-      ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
-      projection,
-      "${ContactsContract.CommonDataKinds.Phone.CONTACT_ID}=?",
-      arrayOf(contactId.toString()),
-      null,
-    ).use { cursor ->
-      if (cursor == null) return emptyList()
-      val out = LinkedHashSet<String>()
-      while (cursor.moveToNext()) {
-        val value = cursor.getString(0)?.trim().orEmpty()
-        if (value.isNotEmpty()) out += value
-      }
-      return out.toList()
-    }
+    return queryContactValues(
+      resolver = resolver,
+      contentUri = ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
+      valueColumn = ContactsContract.CommonDataKinds.Phone.NUMBER,
+      contactIdColumn = ContactsContract.CommonDataKinds.Phone.CONTACT_ID,
+      contactId = contactId,
+    )
   }
 
   private fun loadEmails(resolver: ContentResolver, contactId: Long): List<String> {
-    val projection = arrayOf(ContactsContract.CommonDataKinds.Email.ADDRESS)
+    return queryContactValues(
+      resolver = resolver,
+      contentUri = ContactsContract.CommonDataKinds.Email.CONTENT_URI,
+      valueColumn = ContactsContract.CommonDataKinds.Email.ADDRESS,
+      contactIdColumn = ContactsContract.CommonDataKinds.Email.CONTACT_ID,
+      contactId = contactId,
+    )
+  }
+
+  private fun queryContactValues(
+    resolver: ContentResolver,
+    contentUri: android.net.Uri,
+    valueColumn: String,
+    contactIdColumn: String,
+    contactId: Long,
+  ): List<String> {
+    val projection = arrayOf(valueColumn)
     resolver.query(
-      ContactsContract.CommonDataKinds.Email.CONTENT_URI,
+      contentUri,
       projection,
-      "${ContactsContract.CommonDataKinds.Email.CONTACT_ID}=?",
+      "$contactIdColumn=?",
       arrayOf(contactId.toString()),
       null,
     ).use { cursor ->

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/DeviceNotificationListenerService.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/DeviceNotificationListenerService.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.Intent
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -32,6 +33,21 @@ data class DeviceNotificationEntry(
   val isOngoing: Boolean,
   val isClearable: Boolean,
 )
+
+internal fun DeviceNotificationEntry.toJsonObject(): JsonObject {
+  return buildJsonObject {
+    put("key", JsonPrimitive(key))
+    put("packageName", JsonPrimitive(packageName))
+    put("postTimeMs", JsonPrimitive(postTimeMs))
+    put("isOngoing", JsonPrimitive(isOngoing))
+    put("isClearable", JsonPrimitive(isClearable))
+    title?.let { put("title", JsonPrimitive(it)) }
+    text?.let { put("text", JsonPrimitive(it)) }
+    subText?.let { put("subText", JsonPrimitive(it)) }
+    category?.let { put("category", JsonPrimitive(it)) }
+    channelId?.let { put("channelId", JsonPrimitive(it)) }
+  }
+}
 
 data class DeviceNotificationSnapshot(
   val enabled: Boolean,

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/InvokeDispatcher.kt
@@ -10,7 +10,6 @@ import org.remoteclaw.android.protocol.RemoteClawDeviceCommand
 import org.remoteclaw.android.protocol.RemoteClawLocationCommand
 import org.remoteclaw.android.protocol.RemoteClawMotionCommand
 import org.remoteclaw.android.protocol.RemoteClawNotificationsCommand
-import org.remoteclaw.android.protocol.RemoteClawPhotosCommand
 import org.remoteclaw.android.protocol.RemoteClawScreenCommand
 import org.remoteclaw.android.protocol.RemoteClawSmsCommand
 import org.remoteclaw.android.protocol.RemoteClawSystemCommand
@@ -146,7 +145,9 @@ class InvokeDispatcher(
       RemoteClawSystemCommand.Notify.rawValue -> systemHandler.handleSystemNotify(paramsJson)
 
       // Photos command
-      RemoteClawPhotosCommand.Latest.rawValue -> photosHandler.handlePhotosLatest(paramsJson)
+      org.remoteclaw.android.protocol.RemoteClawPhotosCommand.Latest.rawValue -> photosHandler.handlePhotosLatest(
+        paramsJson,
+      )
 
       // Contacts command
       RemoteClawContactsCommand.Search.rawValue -> contactsHandler.handleContactsSearch(paramsJson)

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/NotificationsHandler.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/NotificationsHandler.kt
@@ -131,20 +131,7 @@ class NotificationsHandler private constructor(
       put(
         "notifications",
         JsonArray(
-          snapshot.notifications.map { entry ->
-            buildJsonObject {
-              put("key", JsonPrimitive(entry.key))
-              put("packageName", JsonPrimitive(entry.packageName))
-              put("postTimeMs", JsonPrimitive(entry.postTimeMs))
-              put("isOngoing", JsonPrimitive(entry.isOngoing))
-              put("isClearable", JsonPrimitive(entry.isClearable))
-              entry.title?.let { put("title", JsonPrimitive(it)) }
-              entry.text?.let { put("text", JsonPrimitive(it)) }
-              entry.subText?.let { put("subText", JsonPrimitive(it)) }
-              entry.category?.let { put("category", JsonPrimitive(it)) }
-              entry.channelId?.let { put("channelId", JsonPrimitive(it)) }
-            }
-          },
+          snapshot.notifications.map { entry -> entry.toJsonObject() },
         ),
       )
     }.toString()

--- a/apps/android/app/src/main/java/org/remoteclaw/android/ui/chat/Base64ImageState.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/ui/chat/Base64ImageState.kt
@@ -1,0 +1,42 @@
+package org.remoteclaw.android.ui.chat
+
+import android.graphics.BitmapFactory
+import android.util.Base64
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal data class Base64ImageState(
+  val image: ImageBitmap?,
+  val failed: Boolean,
+)
+
+@Composable
+internal fun rememberBase64ImageState(base64: String): Base64ImageState {
+  var image by remember(base64) { mutableStateOf<ImageBitmap?>(null) }
+  var failed by remember(base64) { mutableStateOf(false) }
+
+  LaunchedEffect(base64) {
+    failed = false
+    image =
+      withContext(Dispatchers.Default) {
+        try {
+          val bytes = Base64.decode(base64, Base64.DEFAULT)
+          val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size) ?: return@withContext null
+          bitmap.asImageBitmap()
+        } catch (_: Throwable) {
+          null
+        }
+      }
+    if (image == null) failed = true
+  }
+
+  return Base64ImageState(image = image, failed = failed)
+}

--- a/apps/android/app/src/main/java/org/remoteclaw/android/ui/chat/ChatMarkdown.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/ui/chat/ChatMarkdown.kt
@@ -1,7 +1,5 @@
 package org.remoteclaw.android.ui.chat
 
-import android.graphics.BitmapFactory
-import android.util.Base64
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -20,15 +18,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -47,8 +40,6 @@ import org.remoteclaw.android.ui.mobileCaption1
 import org.remoteclaw.android.ui.mobileCodeBg
 import org.remoteclaw.android.ui.mobileCodeText
 import org.remoteclaw.android.ui.mobileTextSecondary
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.commonmark.Extension
 import org.commonmark.ext.autolink.AutolinkExtension
 import org.commonmark.ext.gfm.strikethrough.Strikethrough
@@ -555,23 +546,8 @@ private data class ParsedDataImage(
 
 @Composable
 private fun InlineBase64Image(base64: String, mimeType: String?) {
-  var image by remember(base64) { mutableStateOf<androidx.compose.ui.graphics.ImageBitmap?>(null) }
-  var failed by remember(base64) { mutableStateOf(false) }
-
-  LaunchedEffect(base64) {
-    failed = false
-    image =
-      withContext(Dispatchers.Default) {
-        try {
-          val bytes = Base64.decode(base64, Base64.DEFAULT)
-          val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size) ?: return@withContext null
-          bitmap.asImageBitmap()
-        } catch (_: Throwable) {
-          null
-        }
-      }
-    if (image == null) failed = true
-  }
+  val imageState = rememberBase64ImageState(base64)
+  val image = imageState.image
 
   if (image != null) {
     Image(
@@ -580,7 +556,7 @@ private fun InlineBase64Image(base64: String, mimeType: String?) {
       contentScale = ContentScale.Fit,
       modifier = Modifier.fillMaxWidth(),
     )
-  } else if (failed) {
+  } else if (imageState.failed) {
     Text(
       text = "Image unavailable",
       modifier = Modifier.padding(vertical = 2.dp),

--- a/apps/android/app/src/main/java/org/remoteclaw/android/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/ui/chat/ChatMessageViews.kt
@@ -1,7 +1,5 @@
 package org.remoteclaw.android.ui.chat
 
-import android.graphics.BitmapFactory
-import android.util.Base64
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
@@ -16,16 +14,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
@@ -51,8 +43,6 @@ import org.remoteclaw.android.ui.mobileTextSecondary
 import org.remoteclaw.android.ui.mobileWarning
 import org.remoteclaw.android.ui.mobileWarningSoft
 import java.util.Locale
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 private data class ChatBubbleStyle(
   val alignEnd: Boolean,
@@ -241,23 +231,8 @@ private fun roleLabel(role: String): String {
 
 @Composable
 private fun ChatBase64Image(base64: String, mimeType: String?) {
-  var image by remember(base64) { mutableStateOf<androidx.compose.ui.graphics.ImageBitmap?>(null) }
-  var failed by remember(base64) { mutableStateOf(false) }
-
-  LaunchedEffect(base64) {
-    failed = false
-    image =
-      withContext(Dispatchers.Default) {
-        try {
-          val bytes = Base64.decode(base64, Base64.DEFAULT)
-          val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size) ?: return@withContext null
-          bitmap.asImageBitmap()
-        } catch (_: Throwable) {
-          null
-        }
-      }
-    if (image == null) failed = true
-  }
+  val imageState = rememberBase64ImageState(base64)
+  val image = imageState.image
 
   if (image != null) {
     Surface(
@@ -273,7 +248,7 @@ private fun ChatBase64Image(base64: String, mimeType: String?) {
         modifier = Modifier.fillMaxWidth(),
       )
     }
-  } else if (failed) {
+  } else if (imageState.failed) {
     Text("Unsupported attachment", style = mobileCaption1, color = mobileTextSecondary)
   }
 }

--- a/apps/ios/Sources/Camera/CameraController.swift
+++ b/apps/ios/Sources/Camera/CameraController.swift
@@ -52,46 +52,27 @@ actor CameraController {
 
         try await self.ensureAccess(for: .video)
 
-        let session = AVCaptureSession()
-        session.sessionPreset = .photo
-
-        guard let device = Self.pickCamera(facing: facing, deviceId: params.deviceId) else {
-            throw CameraError.cameraUnavailable
-        }
-
-        let input = try AVCaptureDeviceInput(device: device)
-        guard session.canAddInput(input) else {
-            throw CameraError.captureFailed("Failed to add camera input")
-        }
-        session.addInput(input)
-
-        let output = AVCapturePhotoOutput()
-        guard session.canAddOutput(output) else {
-            throw CameraError.captureFailed("Failed to add photo output")
-        }
-        session.addOutput(output)
-        output.maxPhotoQualityPrioritization = .quality
+        let prepared = try CameraCapturePipelineSupport.preparePhotoSession(
+            preferFrontCamera: facing == .front,
+            deviceId: params.deviceId,
+            pickCamera: { preferFrontCamera, deviceId in
+                Self.pickCamera(facing: preferFrontCamera ? .front : .back, deviceId: deviceId)
+            },
+            cameraUnavailableError: CameraError.cameraUnavailable,
+            mapSetupError: { setupError in
+                CameraError.captureFailed(setupError.localizedDescription)
+            })
+        let session = prepared.session
+        let output = prepared.output
 
         session.startRunning()
         defer { session.stopRunning() }
-        await Self.warmUpCaptureSession()
+        await CameraCapturePipelineSupport.warmUpCaptureSession()
         await Self.sleepDelayMs(delayMs)
 
-        let settings: AVCapturePhotoSettings = {
-            if output.availablePhotoCodecTypes.contains(.jpeg) {
-                return AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.jpeg])
-            }
-            return AVCapturePhotoSettings()
-        }()
-        settings.photoQualityPrioritization = .quality
-
-        var delegate: PhotoCaptureDelegate?
-        let rawData: Data = try await withCheckedThrowingContinuation { cont in
-            let d = PhotoCaptureDelegate(cont)
-            delegate = d
-            output.capturePhoto(with: settings, delegate: d)
+        let rawData = try await CameraCapturePipelineSupport.capturePhotoData(output: output) { continuation in
+            PhotoCaptureDelegate(continuation)
         }
-        withExtendedLifetime(delegate) {}
 
         let res = try PhotoCapture.transcodeJPEGForGateway(
             rawData: rawData,
@@ -121,63 +102,36 @@ actor CameraController {
             try await self.ensureAccess(for: .audio)
         }
 
-        let session = AVCaptureSession()
-        session.sessionPreset = .high
-
-        guard let camera = Self.pickCamera(facing: facing, deviceId: params.deviceId) else {
-            throw CameraError.cameraUnavailable
-        }
-        let cameraInput = try AVCaptureDeviceInput(device: camera)
-        guard session.canAddInput(cameraInput) else {
-            throw CameraError.captureFailed("Failed to add camera input")
-        }
-        session.addInput(cameraInput)
-
-        if includeAudio {
-            guard let mic = AVCaptureDevice.default(for: .audio) else {
-                throw CameraError.microphoneUnavailable
-            }
-            let micInput = try AVCaptureDeviceInput(device: mic)
-            if session.canAddInput(micInput) {
-                session.addInput(micInput)
-            } else {
-                throw CameraError.captureFailed("Failed to add microphone input")
-            }
-        }
-
-        let output = AVCaptureMovieFileOutput()
-        guard session.canAddOutput(output) else {
-            throw CameraError.captureFailed("Failed to add movie output")
-        }
-        session.addOutput(output)
-        output.maxRecordedDuration = CMTime(value: Int64(durationMs), timescale: 1000)
-
-        session.startRunning()
-        defer { session.stopRunning() }
-        await Self.warmUpCaptureSession()
-
         let movURL = FileManager().temporaryDirectory
             .appendingPathComponent("remoteclaw-camera-\(UUID().uuidString).mov")
         let mp4URL = FileManager().temporaryDirectory
             .appendingPathComponent("remoteclaw-camera-\(UUID().uuidString).mp4")
-
         defer {
             try? FileManager().removeItem(at: movURL)
             try? FileManager().removeItem(at: mp4URL)
         }
 
-        var delegate: MovieFileDelegate?
-        let recordedURL: URL = try await withCheckedThrowingContinuation { cont in
-            let d = MovieFileDelegate(cont)
-            delegate = d
-            output.startRecording(to: movURL, recordingDelegate: d)
-        }
-        withExtendedLifetime(delegate) {}
-
-        // Transcode .mov -> .mp4 for easier downstream handling.
-        try await Self.exportToMP4(inputURL: recordedURL, outputURL: mp4URL)
-
-        let data = try Data(contentsOf: mp4URL)
+        let data = try await CameraCapturePipelineSupport.withWarmMovieSession(
+            preferFrontCamera: facing == .front,
+            deviceId: params.deviceId,
+            includeAudio: includeAudio,
+            durationMs: durationMs,
+            pickCamera: { preferFrontCamera, deviceId in
+                Self.pickCamera(facing: preferFrontCamera ? .front : .back, deviceId: deviceId)
+            },
+            cameraUnavailableError: CameraError.cameraUnavailable,
+            mapSetupError: Self.mapMovieSetupError) { output in
+                var delegate: MovieFileDelegate?
+                let recordedURL: URL = try await withCheckedThrowingContinuation { cont in
+                    let d = MovieFileDelegate(cont)
+                    delegate = d
+                    output.startRecording(to: movURL, recordingDelegate: d)
+                }
+                withExtendedLifetime(delegate) {}
+                // Transcode .mov -> .mp4 for easier downstream handling.
+                try await Self.exportToMP4(inputURL: recordedURL, outputURL: mp4URL)
+                return try Data(contentsOf: mp4URL)
+            }
         return (
             format: format.rawValue,
             base64: data.base64EncodedString(),
@@ -196,22 +150,7 @@ actor CameraController {
     }
 
     private func ensureAccess(for mediaType: AVMediaType) async throws {
-        let status = AVCaptureDevice.authorizationStatus(for: mediaType)
-        switch status {
-        case .authorized:
-            return
-        case .notDetermined:
-            let ok = await withCheckedContinuation(isolation: nil) { cont in
-                AVCaptureDevice.requestAccess(for: mediaType) { granted in
-                    cont.resume(returning: granted)
-                }
-            }
-            if !ok {
-                throw CameraError.permissionDenied(kind: mediaType == .video ? "Camera" : "Microphone")
-            }
-        case .denied, .restricted:
-            throw CameraError.permissionDenied(kind: mediaType == .video ? "Camera" : "Microphone")
-        @unknown default:
+        if !(await CameraAuthorization.isAuthorized(for: mediaType)) {
             throw CameraError.permissionDenied(kind: mediaType == .video ? "Camera" : "Microphone")
         }
     }
@@ -233,12 +172,15 @@ actor CameraController {
         return AVCaptureDevice.default(for: .video)
     }
 
+    private nonisolated static func mapMovieSetupError(_ setupError: CameraSessionConfigurationError) -> CameraError {
+        CameraCapturePipelineSupport.mapMovieSetupError(
+            setupError,
+            microphoneUnavailableError: .microphoneUnavailable,
+            captureFailed: { .captureFailed($0) })
+    }
+
     private nonisolated static func positionLabel(_ position: AVCaptureDevice.Position) -> String {
-        switch position {
-        case .front: "front"
-        case .back: "back"
-        default: "unspecified"
-        }
+        CameraCapturePipelineSupport.positionLabel(position)
     }
 
     private nonisolated static func discoverVideoDevices() -> [AVCaptureDevice] {
@@ -305,11 +247,6 @@ actor CameraController {
                 throw CameraError.exportFailed("export did not complete")
             }
         }
-    }
-
-    private nonisolated static func warmUpCaptureSession() async {
-        // A short delay after `startRunning()` significantly reduces "blank first frame" captures on some devices.
-        try? await Task.sleep(nanoseconds: 150_000_000) // 150ms
     }
 
     private nonisolated static func sleepDelayMs(_ delayMs: Int) async {

--- a/apps/ios/Sources/Contacts/ContactsService.swift
+++ b/apps/ios/Sources/Contacts/ContactsService.swift
@@ -15,14 +15,7 @@ final class ContactsService: ContactsServicing {
     }
 
     func search(params: RemoteClawContactsSearchParams) async throws -> RemoteClawContactsSearchPayload {
-        let store = CNContactStore()
-        let status = CNContactStore.authorizationStatus(for: .contacts)
-        let authorized = await Self.ensureAuthorization(store: store, status: status)
-        guard authorized else {
-            throw NSError(domain: "Contacts", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "CONTACTS_PERMISSION_REQUIRED: grant Contacts permission",
-            ])
-        }
+        let store = try await Self.authorizedStore()
 
         let limit = max(1, min(params.limit ?? 25, 200))
 
@@ -47,14 +40,7 @@ final class ContactsService: ContactsServicing {
     }
 
     func add(params: RemoteClawContactsAddParams) async throws -> RemoteClawContactsAddPayload {
-        let store = CNContactStore()
-        let status = CNContactStore.authorizationStatus(for: .contacts)
-        let authorized = await Self.ensureAuthorization(store: store, status: status)
-        guard authorized else {
-            throw NSError(domain: "Contacts", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "CONTACTS_PERMISSION_REQUIRED: grant Contacts permission",
-            ])
-        }
+        let store = try await Self.authorizedStore()
 
         let givenName = params.givenName?.trimmingCharacters(in: .whitespacesAndNewlines)
         let familyName = params.familyName?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -125,6 +111,18 @@ final class ContactsService: ContactsServicing {
         @unknown default:
             return false
         }
+    }
+
+    private static func authorizedStore() async throws -> CNContactStore {
+        let store = CNContactStore()
+        let status = CNContactStore.authorizationStatus(for: .contacts)
+        let authorized = await Self.ensureAuthorization(store: store, status: status)
+        guard authorized else {
+            throw NSError(domain: "Contacts", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "CONTACTS_PERMISSION_REQUIRED: grant Contacts permission",
+            ])
+        }
+        return store
     }
 
     private static func normalizeStrings(_ values: [String]?, lowercased: Bool = false) -> [String] {

--- a/apps/ios/Sources/Gateway/GatewayDiscoveryModel.swift
+++ b/apps/ios/Sources/Gateway/GatewayDiscoveryModel.swift
@@ -53,23 +53,17 @@ final class GatewayDiscoveryModel {
         self.appendDebugLog("start()")
 
         for domain in RemoteClawBonjour.gatewayServiceDomains {
-            let params = NWParameters.tcp
-            params.includePeerToPeer = true
-            let browser = NWBrowser(
-                for: .bonjour(type: RemoteClawBonjour.gatewayServiceType, domain: domain),
-                using: params)
-
-            browser.stateUpdateHandler = { [weak self] state in
-                Task { @MainActor in
+            let browser = GatewayDiscoveryBrowserSupport.makeBrowser(
+                serviceType: RemoteClawBonjour.gatewayServiceType,
+                domain: domain,
+                queueLabelPrefix: "org.remoteclaw.ios.gateway-discovery",
+                onState: { [weak self] state in
                     guard let self else { return }
                     self.statesByDomain[domain] = state
                     self.updateStatusText()
                     self.appendDebugLog("state[\(domain)]: \(Self.prettyState(state))")
-                }
-            }
-
-            browser.browseResultsChangedHandler = { [weak self] results, _ in
-                Task { @MainActor in
+                },
+                onResults: { [weak self] results in
                     guard let self else { return }
                     self.gatewaysByDomain[domain] = results.compactMap { result -> DiscoveredGateway? in
                         switch result.endpoint {
@@ -98,13 +92,10 @@ final class GatewayDiscoveryModel {
                         }
                     }
                     .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-
                     self.recomputeGateways()
-                }
-            }
+                })
 
             self.browsers[domain] = browser
-            browser.start(queue: DispatchQueue(label: "org.remoteclaw.ios.gateway-discovery.\(domain)"))
         }
     }
 

--- a/apps/ios/Sources/Gateway/GatewayServiceResolver.swift
+++ b/apps/ios/Sources/Gateway/GatewayServiceResolver.swift
@@ -1,4 +1,5 @@
 import Foundation
+import RemoteClawKit
 
 // NetService-based resolver for Bonjour services.
 // Used to resolve the service endpoint (SRV + A/AAAA) without trusting TXT for routing.
@@ -20,8 +21,7 @@ final class GatewayServiceResolver: NSObject, NetServiceDelegate {
     }
 
     func start(timeout: TimeInterval = 2.0) {
-        self.service.schedule(in: .main, forMode: .common)
-        self.service.resolve(withTimeout: timeout)
+        BonjourServiceResolverSupport.start(self.service, timeout: timeout)
     }
 
     func netServiceDidResolveAddress(_ sender: NetService) {
@@ -47,9 +47,6 @@ final class GatewayServiceResolver: NSObject, NetServiceDelegate {
     }
 
     private static func normalizeHost(_ raw: String?) -> String? {
-        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if trimmed.isEmpty { return nil }
-        return trimmed.hasSuffix(".") ? String(trimmed.dropLast()) : trimmed
+        BonjourServiceResolverSupport.normalizeHost(raw)
     }
 }
-

--- a/apps/ios/Sources/Location/LocationService.swift
+++ b/apps/ios/Sources/Location/LocationService.swift
@@ -3,7 +3,7 @@ import CoreLocation
 import Foundation
 
 @MainActor
-final class LocationService: NSObject, CLLocationManagerDelegate {
+final class LocationService: NSObject, CLLocationManagerDelegate, LocationServiceCommon {
     enum Error: Swift.Error {
         case timeout
         case unavailable
@@ -17,21 +17,18 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
     private var significantLocationCallback: (@Sendable (CLLocation) -> Void)?
     private var isMonitoringSignificantChanges = false
 
+    var locationManager: CLLocationManager {
+        self.manager
+    }
+
+    var locationRequestContinuation: CheckedContinuation<CLLocation, Error>? {
+        get { self.locationContinuation }
+        set { self.locationContinuation = newValue }
+    }
+
     override init() {
         super.init()
-        self.manager.delegate = self
-        self.manager.desiredAccuracy = kCLLocationAccuracyBest
-    }
-
-    func authorizationStatus() -> CLAuthorizationStatus {
-        self.manager.authorizationStatus
-    }
-
-    func accuracyAuthorization() -> CLAccuracyAuthorization {
-        if #available(iOS 14.0, *) {
-            return self.manager.accuracyAuthorization
-        }
-        return .fullAccuracy
+        self.configureLocationManager()
     }
 
     func ensureAuthorization(mode: RemoteClawLocationMode) async -> CLAuthorizationStatus {
@@ -62,25 +59,14 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
         maxAgeMs: Int?,
         timeoutMs: Int?) async throws -> CLLocation
     {
-        let now = Date()
-        if let maxAgeMs,
-           let cached = self.manager.location,
-           now.timeIntervalSince(cached.timestamp) * 1000 <= Double(maxAgeMs)
-        {
-            return cached
-        }
-
-        self.manager.desiredAccuracy = Self.accuracyValue(desiredAccuracy)
-        let timeout = max(0, timeoutMs ?? 10000)
-        return try await self.withTimeout(timeoutMs: timeout) {
-            try await self.requestLocation()
-        }
-    }
-
-    private func requestLocation() async throws -> CLLocation {
-        try await withCheckedThrowingContinuation { cont in
-            self.locationContinuation = cont
-            self.manager.requestLocation()
+        _ = params
+        return try await LocationCurrentRequest.resolve(
+            manager: self.manager,
+            desiredAccuracy: desiredAccuracy,
+            maxAgeMs: maxAgeMs,
+            timeoutMs: timeoutMs,
+            request: { try await self.requestLocationOnce() }) { timeoutMs, operation in
+                try await self.withTimeout(timeoutMs: timeoutMs, operation: operation)
         }
     }
 
@@ -97,24 +83,13 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
         try await AsyncTimeout.withTimeoutMs(timeoutMs: timeoutMs, onTimeout: { Error.timeout }, operation: operation)
     }
 
-    private static func accuracyValue(_ accuracy: RemoteClawLocationAccuracy) -> CLLocationAccuracy {
-        switch accuracy {
-        case .coarse:
-            kCLLocationAccuracyKilometer
-        case .balanced:
-            kCLLocationAccuracyHundredMeters
-        case .precise:
-            kCLLocationAccuracyBest
-        }
-    }
-
     func startLocationUpdates(
         desiredAccuracy: RemoteClawLocationAccuracy,
         significantChangesOnly: Bool) -> AsyncStream<CLLocation>
     {
         self.stopLocationUpdates()
 
-        self.manager.desiredAccuracy = Self.accuracyValue(desiredAccuracy)
+        self.manager.desiredAccuracy = LocationCurrentRequest.accuracyValue(desiredAccuracy)
         self.manager.pausesLocationUpdatesAutomatically = true
         self.manager.allowsBackgroundLocationUpdates = true
 

--- a/apps/ios/Sources/Model/NodeAppModel+Canvas.swift
+++ b/apps/ios/Sources/Model/NodeAppModel+Canvas.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Network
+import RemoteClawKit
 import os
 
 enum A2UIReadyState {
@@ -27,22 +28,10 @@ extension NodeAppModel {
         guard let raw = await self.gatewaySession.currentCanvasHostUrl() else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, let base = URL(string: trimmed) else { return nil }
-        if let host = base.host, Self.isLoopbackHost(host) {
+        if let host = base.host, LoopbackHost.isLoopback(host) {
             return nil
         }
         return base.appendingPathComponent("__remoteclaw__/a2ui/").absoluteString + "?platform=ios"
-    }
-
-    private static func isLoopbackHost(_ host: String) -> Bool {
-        let normalized = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if normalized.isEmpty { return true }
-        if normalized == "localhost" || normalized == "::1" || normalized == "0.0.0.0" {
-            return true
-        }
-        if normalized == "127.0.0.1" || normalized.hasPrefix("127.") {
-            return true
-        }
-        return false
     }
 
     func showA2UIOnConnectIfNeeded() async {

--- a/apps/ios/Sources/Onboarding/GatewayOnboardingView.swift
+++ b/apps/ios/Sources/Onboarding/GatewayOnboardingView.swift
@@ -41,15 +41,17 @@ private struct AutoDetectStep: View {
                     .foregroundStyle(.secondary)
             }
 
-            Section("Connection status") {
-                ConnectionStatusBox(
-                    statusLines: self.connectionStatusLines(),
-                    secondaryLine: self.connectStatusText)
-            }
+            gatewayConnectionStatusSection(
+                appModel: self.appModel,
+                gatewayController: self.gatewayController,
+                secondaryLine: self.connectStatusText)
 
             Section {
                 Button("Retry") {
-                    self.resetConnectionState()
+                    resetGatewayConnectionState(
+                        appModel: self.appModel,
+                        connectStatusText: &self.connectStatusText,
+                        connectingGatewayID: &self.connectingGatewayID)
                     self.triggerAutoConnect()
                 }
                 .disabled(self.connectingGatewayID != nil)
@@ -94,15 +96,6 @@ private struct AutoDetectStep: View {
         return nil
     }
 
-    private func connectionStatusLines() -> [String] {
-        ConnectionStatusBox.defaultLines(appModel: self.appModel, gatewayController: self.gatewayController)
-    }
-
-    private func resetConnectionState() {
-        self.appModel.disconnectGateway()
-        self.connectStatusText = nil
-        self.connectingGatewayID = nil
-    }
 }
 
 private struct ManualEntryStep: View {
@@ -162,11 +155,10 @@ private struct ManualEntryStep: View {
                     .autocorrectionDisabled()
             }
 
-            Section("Connection status") {
-                ConnectionStatusBox(
-                    statusLines: self.connectionStatusLines(),
-                    secondaryLine: self.connectStatusText)
-            }
+            gatewayConnectionStatusSection(
+                appModel: self.appModel,
+                gatewayController: self.gatewayController,
+                secondaryLine: self.connectStatusText)
 
             Section {
                 Button {
@@ -185,7 +177,10 @@ private struct ManualEntryStep: View {
                 .disabled(self.connectingGatewayID != nil)
 
                 Button("Retry") {
-                    self.resetConnectionState()
+                    resetGatewayConnectionState(
+                        appModel: self.appModel,
+                        connectStatusText: &self.connectStatusText,
+                        connectingGatewayID: &self.connectingGatewayID)
                     self.resetManualForm()
                 }
                 .disabled(self.connectingGatewayID != nil)
@@ -235,16 +230,6 @@ private struct ManualEntryStep: View {
         let trimmed = self.manualPortText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         return Int(trimmed.filter { $0.isNumber })
-    }
-
-    private func connectionStatusLines() -> [String] {
-        ConnectionStatusBox.defaultLines(appModel: self.appModel, gatewayController: self.gatewayController)
-    }
-
-    private func resetConnectionState() {
-        self.appModel.disconnectGateway()
-        self.connectStatusText = nil
-        self.connectingGatewayID = nil
     }
 
     private func resetManualForm() {
@@ -315,6 +300,38 @@ private struct ManualEntryStep: View {
     }
 
     // (GatewaySetupCode) decode raw setup codes.
+}
+
+private func gatewayConnectionStatusLines(
+    appModel: NodeAppModel,
+    gatewayController: GatewayConnectionController) -> [String]
+{
+    ConnectionStatusBox.defaultLines(appModel: appModel, gatewayController: gatewayController)
+}
+
+private func resetGatewayConnectionState(
+    appModel: NodeAppModel,
+    connectStatusText: inout String?,
+    connectingGatewayID: inout String?)
+{
+    appModel.disconnectGateway()
+    connectStatusText = nil
+    connectingGatewayID = nil
+}
+
+@ViewBuilder
+private func gatewayConnectionStatusSection(
+    appModel: NodeAppModel,
+    gatewayController: GatewayConnectionController,
+    secondaryLine: String?) -> some View
+{
+    Section("Connection status") {
+        ConnectionStatusBox(
+            statusLines: gatewayConnectionStatusLines(
+                appModel: appModel,
+                gatewayController: gatewayController),
+            secondaryLine: secondaryLine)
+    }
 }
 
 private struct ConnectionStatusBox: View {

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -489,21 +489,7 @@ struct OnboardingWizardView: View {
             TextField("Port", text: self.$manualPortText)
                 .keyboardType(.numberPad)
             Toggle("Use TLS", isOn: self.$manualTLS)
-
-            Button {
-                Task { await self.connectManual() }
-            } label: {
-                if self.connectingGatewayID == "manual" {
-                    HStack(spacing: 8) {
-                        ProgressView()
-                            .progressViewStyle(.circular)
-                        Text("Connecting…")
-                    }
-                } else {
-                    Text("Connect")
-                }
-            }
-            .disabled(!self.canConnectManual || self.connectingGatewayID != nil)
+            self.manualConnectButton
         } header: {
             Text("Developer Local")
         } footer: {
@@ -631,22 +617,25 @@ struct OnboardingWizardView: View {
             TextField("Discovery Domain (optional)", text: self.$discoveryDomain)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
-
-            Button {
-                Task { await self.connectManual() }
-            } label: {
-                if self.connectingGatewayID == "manual" {
-                    HStack(spacing: 8) {
-                        ProgressView()
-                            .progressViewStyle(.circular)
-                        Text("Connecting…")
-                    }
-                } else {
-                    Text("Connect")
-                }
-            }
-            .disabled(!self.canConnectManual || self.connectingGatewayID != nil)
+            self.manualConnectButton
         }
+    }
+
+    private var manualConnectButton: some View {
+        Button {
+            Task { await self.connectManual() }
+        } label: {
+            if self.connectingGatewayID == "manual" {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                    Text("Connecting…")
+                }
+            } else {
+                Text("Connect")
+            }
+        }
+        .disabled(!self.canConnectManual || self.connectingGatewayID != nil)
     }
 
     private func handleScannedLink(_ link: GatewayConnectDeepLink) {

--- a/apps/ios/Sources/RemoteClawApp.swift
+++ b/apps/ios/Sources/RemoteClawApp.swift
@@ -456,11 +456,7 @@ enum WatchPromptNotificationBridge {
     ) async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             center.add(request) { error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume(returning: ())
-                }
+                ThrowingContinuationSupport.resumeVoid(continuation, error: error)
             }
         }
     }

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -70,38 +70,14 @@ struct RootTabs: View {
             self.toastDismissTask?.cancel()
             self.toastDismissTask = nil
         }
-        .confirmationDialog(
-            "Gateway",
+        .gatewayActionsDialog(
             isPresented: self.$showGatewayActions,
-            titleVisibility: .visible)
-        {
-            Button("Disconnect", role: .destructive) {
-                self.appModel.disconnectGateway()
-            }
-            Button("Open Settings") {
-                self.selectedTab = 2
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("Disconnect from the gateway?")
-        }
+            onDisconnect: { self.appModel.disconnectGateway() },
+            onOpenSettings: { self.selectedTab = 2 })
     }
 
     private var gatewayStatus: StatusPill.GatewayState {
-        if self.appModel.gatewayServerName != nil { return .connected }
-
-        let text = self.appModel.gatewayStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
-        if text.localizedCaseInsensitiveContains("connecting") ||
-            text.localizedCaseInsensitiveContains("reconnecting")
-        {
-            return .connecting
-        }
-
-        if text.localizedCaseInsensitiveContains("error") {
-            return .error
-        }
-
-        return .disconnected
+        GatewayStatusBuilder.build(appModel: self.appModel)
     }
 
     private var statusActivity: StatusPill.Activity? {

--- a/apps/ios/Sources/Screen/ScreenController.swift
+++ b/apps/ios/Sources/Screen/ScreenController.swift
@@ -35,7 +35,7 @@ final class ScreenController {
         if let url = URL(string: trimmed),
            !url.isFileURL,
            let host = url.host,
-           Self.isLoopbackHost(host)
+           LoopbackHost.isLoopback(host)
         {
             // Never try to load loopback URLs from a remote gateway.
             self.showDefaultCanvas()
@@ -87,25 +87,11 @@ final class ScreenController {
 
     func applyDebugStatusIfNeeded() {
         guard let webView = self.activeWebView else { return }
-        let enabled = self.debugStatusEnabled
-        let title = self.debugStatusTitle
-        let subtitle = self.debugStatusSubtitle
-        let js = """
-        (() => {
-          try {
-            const api = globalThis.__remoteclaw;
-            if (!api) return;
-            if (typeof api.setDebugStatusEnabled === 'function') {
-              api.setDebugStatusEnabled(\(enabled ? "true" : "false"));
-            }
-            if (!\(enabled ? "true" : "false")) return;
-            if (typeof api.setStatus === 'function') {
-              api.setStatus(\(Self.jsValue(title)), \(Self.jsValue(subtitle)));
-            }
-          } catch (_) {}
-        })()
-        """
-        webView.evaluateJavaScript(js) { _, _ in }
+        WebViewJavaScriptSupport.applyDebugStatus(
+            webView: webView,
+            enabled: self.debugStatusEnabled,
+            title: self.debugStatusTitle,
+            subtitle: self.debugStatusSubtitle)
     }
 
     func waitForA2UIReady(timeoutMs: Int) async -> Bool {
@@ -116,7 +102,7 @@ final class ScreenController {
                 let res = try await self.eval(javaScript: """
                 (() => {
                   try {
-                    const host = globalThis.remoteclawA2UI;
+                    const host = globalThis.remoteClawA2UI;
                     return !!host && typeof host.applyMessages === 'function';
                   } catch (_) { return false; }
                 })()
@@ -137,46 +123,11 @@ final class ScreenController {
                 NSLocalizedDescriptionKey: "web view unavailable",
             ])
         }
-        return try await withCheckedThrowingContinuation { cont in
-            webView.evaluateJavaScript(javaScript) { result, error in
-                if let error {
-                    cont.resume(throwing: error)
-                    return
-                }
-                if let result {
-                    cont.resume(returning: String(describing: result))
-                } else {
-                    cont.resume(returning: "")
-                }
-            }
-        }
+        return try await WebViewJavaScriptSupport.evaluateToString(webView: webView, javaScript: javaScript)
     }
 
     func snapshotPNGBase64(maxWidth: CGFloat? = nil) async throws -> String {
-        let config = WKSnapshotConfiguration()
-        if let maxWidth {
-            config.snapshotWidth = NSNumber(value: Double(maxWidth))
-        }
-        guard let webView = self.activeWebView else {
-            throw NSError(domain: "Screen", code: 3, userInfo: [
-                NSLocalizedDescriptionKey: "web view unavailable",
-            ])
-        }
-        let image: UIImage = try await withCheckedThrowingContinuation { cont in
-            webView.takeSnapshot(with: config) { image, error in
-                if let error {
-                    cont.resume(throwing: error)
-                    return
-                }
-                guard let image else {
-                    cont.resume(throwing: NSError(domain: "Screen", code: 2, userInfo: [
-                        NSLocalizedDescriptionKey: "snapshot failed",
-                    ]))
-                    return
-                }
-                cont.resume(returning: image)
-            }
-        }
+        let image = try await self.snapshotImage(maxWidth: maxWidth)
         guard let data = image.pngData() else {
             throw NSError(domain: "Screen", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "snapshot encode failed",
@@ -190,30 +141,7 @@ final class ScreenController {
         format: RemoteClawCanvasSnapshotFormat,
         quality: Double? = nil) async throws -> String
     {
-        let config = WKSnapshotConfiguration()
-        if let maxWidth {
-            config.snapshotWidth = NSNumber(value: Double(maxWidth))
-        }
-        guard let webView = self.activeWebView else {
-            throw NSError(domain: "Screen", code: 3, userInfo: [
-                NSLocalizedDescriptionKey: "web view unavailable",
-            ])
-        }
-        let image: UIImage = try await withCheckedThrowingContinuation { cont in
-            webView.takeSnapshot(with: config) { image, error in
-                if let error {
-                    cont.resume(throwing: error)
-                    return
-                }
-                guard let image else {
-                    cont.resume(throwing: NSError(domain: "Screen", code: 2, userInfo: [
-                        NSLocalizedDescriptionKey: "snapshot failed",
-                    ]))
-                    return
-                }
-                cont.resume(returning: image)
-            }
-        }
+        let image = try await self.snapshotImage(maxWidth: maxWidth)
 
         let data: Data?
         switch format {
@@ -229,6 +157,34 @@ final class ScreenController {
             ])
         }
         return data.base64EncodedString()
+    }
+
+    private func snapshotImage(maxWidth: CGFloat?) async throws -> UIImage {
+        let config = WKSnapshotConfiguration()
+        if let maxWidth {
+            config.snapshotWidth = NSNumber(value: Double(maxWidth))
+        }
+        guard let webView = self.activeWebView else {
+            throw NSError(domain: "Screen", code: 3, userInfo: [
+                NSLocalizedDescriptionKey: "web view unavailable",
+            ])
+        }
+        let image: UIImage = try await withCheckedThrowingContinuation { cont in
+            webView.takeSnapshot(with: config) { image, error in
+                if let error {
+                    cont.resume(throwing: error)
+                    return
+                }
+                guard let image else {
+                    cont.resume(throwing: NSError(domain: "Screen", code: 2, userInfo: [
+                        NSLocalizedDescriptionKey: "snapshot failed",
+                    ]))
+                    return
+                }
+                cont.resume(returning: image)
+            }
+        }
+        return image
     }
 
     func attachWebView(_ webView: WKWebView) {
@@ -258,17 +214,6 @@ final class ScreenController {
         ext: "html",
         subdirectory: "CanvasScaffold")
 
-    private static func isLoopbackHost(_ host: String) -> Bool {
-        let normalized = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if normalized.isEmpty { return true }
-        if normalized == "localhost" || normalized == "::1" || normalized == "0.0.0.0" {
-            return true
-        }
-        if normalized == "127.0.0.1" || normalized.hasPrefix("127.") {
-            return true
-        }
-        return false
-    }
     func isTrustedCanvasUIURL(_ url: URL) -> Bool {
         guard url.isFileURL else { return false }
         let std = url.standardizedFileURL
@@ -290,59 +235,8 @@ final class ScreenController {
         scrollView.bounces = allowScroll
     }
 
-    private static func jsValue(_ value: String?) -> String {
-        guard let value else { return "null" }
-        if let data = try? JSONSerialization.data(withJSONObject: [value]),
-           let encoded = String(data: data, encoding: .utf8),
-           encoded.count >= 2
-        {
-            return String(encoded.dropFirst().dropLast())
-        }
-        return "null"
-    }
-
     func isLocalNetworkCanvasURL(_ url: URL) -> Bool {
-        guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
-            return false
-        }
-        guard let host = url.host?.trimmingCharacters(in: .whitespacesAndNewlines), !host.isEmpty else {
-            return false
-        }
-        if host == "localhost" { return true }
-        if host.hasSuffix(".local") { return true }
-        if host.hasSuffix(".ts.net") { return true }
-        if host.hasSuffix(".tailscale.net") { return true }
-        // Allow MagicDNS / LAN hostnames like "peters-mac-studio-1".
-        if !host.contains("."), !host.contains(":") { return true }
-        if let ipv4 = Self.parseIPv4(host) {
-            return Self.isLocalNetworkIPv4(ipv4)
-        }
-        return false
-    }
-
-    private static func parseIPv4(_ host: String) -> (UInt8, UInt8, UInt8, UInt8)? {
-        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
-        guard parts.count == 4 else { return nil }
-        let bytes: [UInt8] = parts.compactMap { UInt8($0) }
-        guard bytes.count == 4 else { return nil }
-        return (bytes[0], bytes[1], bytes[2], bytes[3])
-    }
-
-    private static func isLocalNetworkIPv4(_ ip: (UInt8, UInt8, UInt8, UInt8)) -> Bool {
-        let (a, b, _, _) = ip
-        // 10.0.0.0/8
-        if a == 10 { return true }
-        // 172.16.0.0/12
-        if a == 172, (16...31).contains(Int(b)) { return true }
-        // 192.168.0.0/16
-        if a == 192, b == 168 { return true }
-        // 127.0.0.0/8
-        if a == 127 { return true }
-        // 169.254.0.0/16 (link-local)
-        if a == 169, b == 254 { return true }
-        // Tailscale: 100.64.0.0/10
-        if a == 100, (64...127).contains(Int(b)) { return true }
-        return false
+        LocalNetworkURLSupport.isLocalNetworkHTTPURL(url)
     }
 
     nonisolated static func parseA2UIActionBody(_ body: Any) -> [String: Any]? {

--- a/apps/ios/Sources/Screen/ScreenRecordService.swift
+++ b/apps/ios/Sources/Screen/ScreenRecordService.swift
@@ -84,8 +84,8 @@ final class ScreenRecordService: @unchecked Sendable {
             throw ScreenRecordError.invalidScreenIndex(idx)
         }
 
-        let durationMs = Self.clampDurationMs(durationMs)
-        let fps = Self.clampFps(fps)
+        let durationMs = CaptureRateLimits.clampDurationMs(durationMs)
+        let fps = CaptureRateLimits.clampFps(fps, maxFps: 30)
         let fpsInt = Int32(fps.rounded())
         let fpsValue = Double(fpsInt)
         let includeAudio = includeAudio ?? true
@@ -319,16 +319,6 @@ final class ScreenRecordService: @unchecked Sendable {
         }
     }
 
-    private nonisolated static func clampDurationMs(_ ms: Int?) -> Int {
-        let v = ms ?? 10000
-        return min(60000, max(250, v))
-    }
-
-    private nonisolated static func clampFps(_ fps: Double?) -> Double {
-        let v = fps ?? 10
-        if !v.isFinite { return 10 }
-        return min(30, max(1, v))
-    }
 }
 
 @MainActor
@@ -350,11 +340,11 @@ private func stopReplayKitCapture(_ completion: @escaping @Sendable (Error?) -> 
 #if DEBUG
 extension ScreenRecordService {
     nonisolated static func _test_clampDurationMs(_ ms: Int?) -> Int {
-        self.clampDurationMs(ms)
+        CaptureRateLimits.clampDurationMs(ms)
     }
 
     nonisolated static func _test_clampFps(_ fps: Double?) -> Double {
-        self.clampFps(fps)
+        CaptureRateLimits.clampFps(fps, maxFps: 30)
     }
 }
 #endif

--- a/apps/ios/Sources/Status/GatewayActionsDialog.swift
+++ b/apps/ios/Sources/Status/GatewayActionsDialog.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+extension View {
+    func gatewayActionsDialog(
+        isPresented: Binding<Bool>,
+        onDisconnect: @escaping () -> Void,
+        onOpenSettings: @escaping () -> Void) -> some View
+    {
+        self.confirmationDialog(
+            "Gateway",
+            isPresented: isPresented,
+            titleVisibility: .visible)
+        {
+            Button("Disconnect", role: .destructive) {
+                onDisconnect()
+            }
+            Button("Open Settings") {
+                onOpenSettings()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Disconnect from the gateway?")
+        }
+    }
+}

--- a/apps/ios/Sources/Status/GatewayStatusBuilder.swift
+++ b/apps/ios/Sources/Status/GatewayStatusBuilder.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum GatewayStatusBuilder {
+    @MainActor
+    static func build(appModel: NodeAppModel) -> StatusPill.GatewayState {
+        if appModel.gatewayServerName != nil { return .connected }
+
+        let text = appModel.gatewayStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if text.localizedCaseInsensitiveContains("connecting") ||
+            text.localizedCaseInsensitiveContains("reconnecting")
+        {
+            return .connecting
+        }
+
+        if text.localizedCaseInsensitiveContains("error") {
+            return .error
+        }
+
+        return .disconnected
+    }
+}

--- a/apps/ios/Sources/Status/StatusGlassCard.swift
+++ b/apps/ios/Sources/Status/StatusGlassCard.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+private struct StatusGlassCardModifier: ViewModifier {
+    @Environment(\.colorSchemeContrast) private var contrast
+
+    let brighten: Bool
+    let verticalPadding: CGFloat
+    let horizontalPadding: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .padding(.vertical, self.verticalPadding)
+            .padding(.horizontal, self.horizontalPadding)
+            .background {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(.ultraThinMaterial)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .strokeBorder(
+                                .white.opacity(self.contrast == .increased ? 0.5 : (self.brighten ? 0.24 : 0.18)),
+                                lineWidth: self.contrast == .increased ? 1.0 : 0.5
+                            )
+                    }
+                    .shadow(color: .black.opacity(0.25), radius: 12, y: 6)
+            }
+    }
+}
+
+extension View {
+    func statusGlassCard(brighten: Bool, verticalPadding: CGFloat, horizontalPadding: CGFloat = 12) -> some View {
+        self.modifier(
+            StatusGlassCardModifier(
+                brighten: brighten,
+                verticalPadding: verticalPadding,
+                horizontalPadding: horizontalPadding
+            )
+        )
+    }
+}

--- a/apps/ios/Sources/Status/StatusPill.swift
+++ b/apps/ios/Sources/Status/StatusPill.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct StatusPill: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @Environment(\.colorSchemeContrast) private var contrast
 
     enum GatewayState: Equatable {
         case connected
@@ -86,20 +85,7 @@ struct StatusPill: View {
                         .transition(.opacity.combined(with: .move(edge: .top)))
                 }
             }
-            .padding(.vertical, 8)
-            .padding(.horizontal, 12)
-            .background {
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(.ultraThinMaterial)
-                    .overlay {
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .strokeBorder(
-                                .white.opacity(self.contrast == .increased ? 0.5 : (self.brighten ? 0.24 : 0.18)),
-                                lineWidth: self.contrast == .increased ? 1.0 : 0.5
-                            )
-                    }
-                    .shadow(color: .black.opacity(0.25), radius: 12, y: 6)
-            }
+            .statusGlassCard(brighten: self.brighten, verticalPadding: 8)
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Connection Status")

--- a/apps/ios/Sources/Status/VoiceWakeToast.swift
+++ b/apps/ios/Sources/Status/VoiceWakeToast.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
 struct VoiceWakeToast: View {
-    @Environment(\.colorSchemeContrast) private var contrast
-
     var command: String
     var brighten: Bool = false
 
@@ -18,20 +16,7 @@ struct VoiceWakeToast: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
         }
-        .padding(.vertical, 10)
-        .padding(.horizontal, 12)
-        .background {
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(.ultraThinMaterial)
-                .overlay {
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .strokeBorder(
-                            .white.opacity(self.contrast == .increased ? 0.5 : (self.brighten ? 0.24 : 0.18)),
-                            lineWidth: self.contrast == .increased ? 1.0 : 0.5
-                        )
-                }
-                .shadow(color: .black.opacity(0.25), radius: 12, y: 6)
-        }
+        .statusGlassCard(brighten: self.brighten, verticalPadding: 10)
         .accessibilityLabel("Voice Wake triggered")
         .accessibilityValue("Command: \(self.command)")
     }

--- a/apps/ios/Sources/Voice/VoiceWakeManager.swift
+++ b/apps/ios/Sources/Voice/VoiceWakeManager.swift
@@ -216,22 +216,7 @@ final class VoiceWakeManager: NSObject {
         self.isEnabled = false
         self.isListening = false
         self.statusText = "Off"
-
-        self.tapDrainTask?.cancel()
-        self.tapDrainTask = nil
-        self.tapQueue?.clear()
-        self.tapQueue = nil
-
-        self.recognitionTask?.cancel()
-        self.recognitionTask = nil
-        self.recognitionRequest = nil
-
-        if self.audioEngine.isRunning {
-            self.audioEngine.stop()
-            self.audioEngine.inputNode.removeTap(onBus: 0)
-        }
-
-        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        self.tearDownRecognitionPipeline()
     }
 
     /// Temporarily releases the microphone so other subsystems (e.g. camera video capture) can record audio.
@@ -241,22 +226,7 @@ final class VoiceWakeManager: NSObject {
 
         self.isListening = false
         self.statusText = "Paused"
-
-        self.tapDrainTask?.cancel()
-        self.tapDrainTask = nil
-        self.tapQueue?.clear()
-        self.tapQueue = nil
-
-        self.recognitionTask?.cancel()
-        self.recognitionTask = nil
-        self.recognitionRequest = nil
-
-        if self.audioEngine.isRunning {
-            self.audioEngine.stop()
-            self.audioEngine.inputNode.removeTap(onBus: 0)
-        }
-
-        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        self.tearDownRecognitionPipeline()
         return true
     }
 
@@ -308,6 +278,24 @@ final class VoiceWakeManager: NSObject {
                 }
             }
         }
+    }
+
+    private func tearDownRecognitionPipeline() {
+        self.tapDrainTask?.cancel()
+        self.tapDrainTask = nil
+        self.tapQueue?.clear()
+        self.tapQueue = nil
+
+        self.recognitionTask?.cancel()
+        self.recognitionTask = nil
+        self.recognitionRequest = nil
+
+        if self.audioEngine.isRunning {
+            self.audioEngine.stop()
+            self.audioEngine.inputNode.removeTap(onBus: 0)
+        }
+
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 
     private nonisolated func makeRecognitionResultHandler() -> @Sendable (SFSpeechRecognitionResult?, Error?) -> Void {
@@ -404,16 +392,10 @@ final class VoiceWakeManager: NSObject {
     }
 
     private nonisolated static func microphonePermissionMessage(kind: String) -> String {
-        switch AVAudioApplication.shared.recordPermission {
-        case .denied:
-            return "\(kind) permission denied"
-        case .undetermined:
-            return "\(kind) permission not granted"
-        case .granted:
-            return "\(kind) permission denied"
-        @unknown default:
-            return "\(kind) permission denied"
-        }
+        let status = AVAudioApplication.shared.recordPermission
+        return self.deniedByDefaultPermissionMessage(
+            kind: kind,
+            isUndetermined: status == .undetermined)
     }
 
     private nonisolated static func requestSpeechPermission() async -> Bool {
@@ -463,16 +445,7 @@ final class VoiceWakeManager: NSObject {
         kind: String,
         status: AVAudioSession.RecordPermission) -> String
     {
-        switch status {
-        case .denied:
-            return "\(kind) permission denied"
-        case .undetermined:
-            return "\(kind) permission not granted"
-        case .granted:
-            return "\(kind) permission denied"
-        @unknown default:
-            return "\(kind) permission denied"
-        }
+        self.deniedByDefaultPermissionMessage(kind: kind, isUndetermined: status == .undetermined)
     }
 
     private static func permissionMessage(
@@ -491,6 +464,13 @@ final class VoiceWakeManager: NSObject {
         @unknown default:
             return "\(kind) permission denied"
         }
+    }
+
+    private static func deniedByDefaultPermissionMessage(kind: String, isUndetermined: Bool) -> String {
+        if isUndetermined {
+            return "\(kind) permission not granted"
+        }
+        return "\(kind) permission denied"
     }
 }
 

--- a/apps/ios/Tests/DeepLinkParserTests.swift
+++ b/apps/ios/Tests/DeepLinkParserTests.swift
@@ -10,6 +10,28 @@ private func setupCode(from payload: String) -> String {
         .replacingOccurrences(of: "=", with: "")
 }
 
+private func agentAction(
+    message: String,
+    sessionKey: String? = nil,
+    thinking: String? = nil,
+    deliver: Bool = false,
+    to: String? = nil,
+    channel: String? = nil,
+    timeoutSeconds: Int? = nil,
+    key: String? = nil) -> DeepLinkRoute
+{
+    .agent(
+        .init(
+            message: message,
+            sessionKey: sessionKey,
+            thinking: thinking,
+            deliver: deliver,
+            to: to,
+            channel: channel,
+            timeoutSeconds: timeoutSeconds,
+            key: key))
+}
+
 @Suite struct DeepLinkParserTests {
     @Test func parseRejectsUnknownHost() {
         let url = URL(string: "remoteclaw://nope?message=hi")!
@@ -18,15 +40,7 @@ private func setupCode(from payload: String) -> String {
 
     @Test func parseHostIsCaseInsensitive() {
         let url = URL(string: "remoteclaw://AGENT?message=Hello")!
-        #expect(DeepLinkParser.parse(url) == .agent(.init(
-            message: "Hello",
-            sessionKey: nil,
-            thinking: nil,
-            deliver: false,
-            to: nil,
-            channel: nil,
-            timeoutSeconds: nil,
-            key: nil)))
+        #expect(DeepLinkParser.parse(url) == agentAction(message: "Hello"))
     }
 
     @Test func parseRejectsNonRemoteClawScheme() {
@@ -42,47 +56,29 @@ private func setupCode(from payload: String) -> String {
     @Test func parseAgentLinkParsesCommonFields() {
         let url =
             URL(string: "remoteclaw://agent?message=Hello&deliver=1&sessionKey=node-test&thinking=low&timeoutSeconds=30")!
-        #expect(
-            DeepLinkParser.parse(url) == .agent(
-                .init(
-                    message: "Hello",
-                    sessionKey: "node-test",
-                    thinking: "low",
-                    deliver: true,
-                    to: nil,
-                    channel: nil,
-                    timeoutSeconds: 30,
-                    key: nil)))
+        #expect(DeepLinkParser.parse(url) == agentAction(
+            message: "Hello",
+            sessionKey: "node-test",
+            thinking: "low",
+            deliver: true,
+            timeoutSeconds: 30))
     }
 
     @Test func parseAgentLinkParsesTargetRoutingFields() {
         let url =
             URL(
                 string: "remoteclaw://agent?message=Hello%20World&deliver=1&to=%2B15551234567&channel=whatsapp&key=secret")!
-        #expect(
-            DeepLinkParser.parse(url) == .agent(
-                .init(
-                    message: "Hello World",
-                    sessionKey: nil,
-                    thinking: nil,
-                    deliver: true,
-                    to: "+15551234567",
-                    channel: "whatsapp",
-                    timeoutSeconds: nil,
-                    key: "secret")))
+        #expect(DeepLinkParser.parse(url) == agentAction(
+            message: "Hello World",
+            deliver: true,
+            to: "+15551234567",
+            channel: "whatsapp",
+            key: "secret"))
     }
 
     @Test func parseRejectsNegativeTimeoutSeconds() {
         let url = URL(string: "remoteclaw://agent?message=Hello&timeoutSeconds=-1")!
-        #expect(DeepLinkParser.parse(url) == .agent(.init(
-            message: "Hello",
-            sessionKey: nil,
-            thinking: nil,
-            deliver: false,
-            to: nil,
-            channel: nil,
-            timeoutSeconds: nil,
-            key: nil)))
+        #expect(DeepLinkParser.parse(url) == agentAction(message: "Hello"))
     }
 
     @Test func parseGatewayLinkParsesCommonFields() {

--- a/apps/ios/Tests/DeepLinkParserTests.swift
+++ b/apps/ios/Tests/DeepLinkParserTests.swift
@@ -2,6 +2,14 @@ import RemoteClawKit
 import Foundation
 import Testing
 
+private func setupCode(from payload: String) -> String {
+    Data(payload.utf8)
+        .base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+}
+
 @Suite struct DeepLinkParserTests {
     @Test func parseRejectsUnknownHost() {
         let url = URL(string: "remoteclaw://nope?message=hi")!
@@ -99,13 +107,7 @@ import Testing
 
     @Test func parseGatewaySetupCodeParsesBase64UrlPayload() {
         let payload = #"{"url":"wss://gateway.example.com:443","token":"tok","password":"pw"}"#
-        let encoded = Data(payload.utf8)
-            .base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
-
-        let link = GatewayConnectDeepLink.fromSetupCode(encoded)
+        let link = GatewayConnectDeepLink.fromSetupCode(setupCode(from: payload))
 
         #expect(link == .init(
             host: "gateway.example.com",
@@ -121,13 +123,7 @@ import Testing
 
     @Test func parseGatewaySetupCodeDefaultsTo443ForWssWithoutPort() {
         let payload = #"{"url":"wss://gateway.example.com","token":"tok"}"#
-        let encoded = Data(payload.utf8)
-            .base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
-
-        let link = GatewayConnectDeepLink.fromSetupCode(encoded)
+        let link = GatewayConnectDeepLink.fromSetupCode(setupCode(from: payload))
 
         #expect(link == .init(
             host: "gateway.example.com",
@@ -139,37 +135,19 @@ import Testing
 
     @Test func parseGatewaySetupCodeRejectsInsecureNonLoopbackWs() {
         let payload = #"{"url":"ws://attacker.example:18789","token":"tok"}"#
-        let encoded = Data(payload.utf8)
-            .base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
-
-        let link = GatewayConnectDeepLink.fromSetupCode(encoded)
+        let link = GatewayConnectDeepLink.fromSetupCode(setupCode(from: payload))
         #expect(link == nil)
     }
 
     @Test func parseGatewaySetupCodeRejectsInsecurePrefixBypassHost() {
         let payload = #"{"url":"ws://127.attacker.example:18789","token":"tok"}"#
-        let encoded = Data(payload.utf8)
-            .base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
-
-        let link = GatewayConnectDeepLink.fromSetupCode(encoded)
+        let link = GatewayConnectDeepLink.fromSetupCode(setupCode(from: payload))
         #expect(link == nil)
     }
 
     @Test func parseGatewaySetupCodeAllowsLoopbackWs() {
         let payload = #"{"url":"ws://127.0.0.1:18789","token":"tok"}"#
-        let encoded = Data(payload.utf8)
-            .base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
-
-        let link = GatewayConnectDeepLink.fromSetupCode(encoded)
+        let link = GatewayConnectDeepLink.fromSetupCode(setupCode(from: payload))
 
         #expect(link == .init(
             host: "127.0.0.1",

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -4,31 +4,6 @@ import Testing
 import UIKit
 @testable import RemoteClaw
 
-private func withUserDefaults<T>(_ updates: [String: Any?], _ body: () throws -> T) rethrows -> T {
-    let defaults = UserDefaults.standard
-    var snapshot: [String: Any?] = [:]
-    for key in updates.keys {
-        snapshot[key] = defaults.object(forKey: key)
-    }
-    for (key, value) in updates {
-        if let value {
-            defaults.set(value, forKey: key)
-        } else {
-            defaults.removeObject(forKey: key)
-        }
-    }
-    defer {
-        for (key, value) in snapshot {
-            if let value {
-                defaults.set(value, forKey: key)
-            } else {
-                defaults.removeObject(forKey: key)
-            }
-        }
-    }
-    return try body()
-}
-
 @Suite(.serialized) struct GatewayConnectionControllerTests {
     @Test @MainActor func resolvedDisplayNameSetsDefaultWhenMissing() {
         let defaults = UserDefaults.standard

--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -5,6 +5,32 @@ import Testing
 @testable import RemoteClaw
 
 @Suite(.serialized) struct GatewayConnectionSecurityTests {
+    private func makeController() -> GatewayConnectionController {
+        GatewayConnectionController(appModel: NodeAppModel(), startDiscovery: false)
+    }
+
+    private func makeDiscoveredGateway(
+        stableID: String,
+        lanHost: String?,
+        tailnetDns: String?,
+        gatewayPort: Int?,
+        fingerprint: String?) -> GatewayDiscoveryModel.DiscoveredGateway
+    {
+        let endpoint: NWEndpoint = .service(name: "Test", type: "_remoteclaw-gw._tcp", domain: "local.", interface: nil)
+        return GatewayDiscoveryModel.DiscoveredGateway(
+            name: "Test",
+            endpoint: endpoint,
+            stableID: stableID,
+            debugID: "debug",
+            lanHost: lanHost,
+            tailnetDns: tailnetDns,
+            gatewayPort: gatewayPort,
+            canvasPort: nil,
+            tlsEnabled: true,
+            tlsFingerprintSha256: fingerprint,
+            cliPath: nil)
+    }
+
     private func clearTLSFingerprint(stableID: String) {
         let suite = UserDefaults(suiteName: "org.remoteclaw.shared") ?? .standard
         suite.removeObject(forKey: "gateway.tls.\(stableID)")
@@ -17,22 +43,13 @@ import Testing
 
         GatewayTLSStore.saveFingerprint("11", stableID: stableID)
 
-        let endpoint: NWEndpoint = .service(name: "Test", type: "_remoteclaw-gw._tcp", domain: "local.", interface: nil)
-        let gateway = GatewayDiscoveryModel.DiscoveredGateway(
-            name: "Test",
-            endpoint: endpoint,
+        let gateway = makeDiscoveredGateway(
             stableID: stableID,
-            debugID: "debug",
             lanHost: "evil.example.com",
             tailnetDns: "evil.example.com",
             gatewayPort: 12345,
-            canvasPort: nil,
-            tlsEnabled: true,
-            tlsFingerprintSha256: "22",
-            cliPath: nil)
-
-        let appModel = NodeAppModel()
-        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+            fingerprint: "22")
+        let controller = makeController()
 
         let params = controller._test_resolveDiscoveredTLSParams(gateway: gateway, allowTOFU: true)
         #expect(params?.expectedFingerprint == "11")
@@ -44,22 +61,13 @@ import Testing
         defer { clearTLSFingerprint(stableID: stableID) }
         clearTLSFingerprint(stableID: stableID)
 
-        let endpoint: NWEndpoint = .service(name: "Test", type: "_remoteclaw-gw._tcp", domain: "local.", interface: nil)
-        let gateway = GatewayDiscoveryModel.DiscoveredGateway(
-            name: "Test",
-            endpoint: endpoint,
+        let gateway = makeDiscoveredGateway(
             stableID: stableID,
-            debugID: "debug",
             lanHost: nil,
             tailnetDns: nil,
             gatewayPort: nil,
-            canvasPort: nil,
-            tlsEnabled: true,
-            tlsFingerprintSha256: "22",
-            cliPath: nil)
-
-        let appModel = NodeAppModel()
-        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+            fingerprint: "22")
+        let controller = makeController()
 
         let params = controller._test_resolveDiscoveredTLSParams(gateway: gateway, allowTOFU: true)
         #expect(params?.expectedFingerprint == nil)
@@ -82,22 +90,13 @@ import Testing
         defaults.removeObject(forKey: "gateway.preferredStableID")
         defaults.set(stableID, forKey: "gateway.lastDiscoveredStableID")
 
-        let endpoint: NWEndpoint = .service(name: "Test", type: "_remoteclaw-gw._tcp", domain: "local.", interface: nil)
-        let gateway = GatewayDiscoveryModel.DiscoveredGateway(
-            name: "Test",
-            endpoint: endpoint,
+        let gateway = makeDiscoveredGateway(
             stableID: stableID,
-            debugID: "debug",
             lanHost: "test.local",
             tailnetDns: nil,
             gatewayPort: 18789,
-            canvasPort: nil,
-            tlsEnabled: true,
-            tlsFingerprintSha256: nil,
-            cliPath: nil)
-
-        let appModel = NodeAppModel()
-        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+            fingerprint: nil)
+        let controller = makeController()
         controller._test_setGateways([gateway])
         controller._test_triggerAutoConnect()
 
@@ -105,8 +104,7 @@ import Testing
     }
 
     @Test @MainActor func manualConnectionsForceTLSForNonLoopbackHosts() async {
-        let appModel = NodeAppModel()
-        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+        let controller = makeController()
 
         #expect(controller._test_resolveManualUseTLS(host: "gateway.example.com", useTLS: false) == true)
         #expect(controller._test_resolveManualUseTLS(host: "remoteclaw.local", useTLS: false) == true)
@@ -121,8 +119,7 @@ import Testing
     }
 
     @Test @MainActor func manualDefaultPortUses443OnlyForTailnetTLSHosts() async {
-        let appModel = NodeAppModel()
-        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+        let controller = makeController()
 
         #expect(controller._test_resolveManualPort(host: "gateway.example.com", port: 0, useTLS: true) == 18789)
         #expect(controller._test_resolveManualPort(host: "device.sample.ts.net", port: 0, useTLS: true) == 443)

--- a/apps/ios/Tests/GatewaySettingsStoreTests.swift
+++ b/apps/ios/Tests/GatewaySettingsStoreTests.swift
@@ -14,6 +14,19 @@ private let instanceIdEntry = KeychainEntry(service: nodeService, account: "inst
 private let preferredGatewayEntry = KeychainEntry(service: gatewayService, account: "preferredStableID")
 private let lastGatewayEntry = KeychainEntry(service: gatewayService, account: "lastDiscoveredStableID")
 private let talkAcmeProviderEntry = KeychainEntry(service: talkService, account: "provider.apiKey.acme")
+private let bootstrapDefaultsKeys = [
+    "node.instanceId",
+    "gateway.preferredStableID",
+    "gateway.lastDiscoveredStableID",
+]
+private let bootstrapKeychainEntries = [instanceIdEntry, preferredGatewayEntry, lastGatewayEntry]
+private let lastGatewayDefaultsKeys = [
+    "gateway.last.kind",
+    "gateway.last.host",
+    "gateway.last.port",
+    "gateway.last.tls",
+    "gateway.last.stableID",
+]
 
 private func snapshotDefaults(_ keys: [String]) -> [String: Any?] {
     let defaults = UserDefaults.standard
@@ -61,142 +74,112 @@ private func restoreKeychain(_ snapshot: [KeychainEntry: String?]) {
     applyKeychain(snapshot)
 }
 
+private func withBootstrapSnapshots(_ body: () -> Void) {
+    let defaultsSnapshot = snapshotDefaults(bootstrapDefaultsKeys)
+    let keychainSnapshot = snapshotKeychain(bootstrapKeychainEntries)
+    defer {
+        restoreDefaults(defaultsSnapshot)
+        restoreKeychain(keychainSnapshot)
+    }
+    body()
+}
+
+private func withLastGatewayDefaultsSnapshot(_ body: () -> Void) {
+    let snapshot = snapshotDefaults(lastGatewayDefaultsKeys)
+    defer { restoreDefaults(snapshot) }
+    body()
+}
+
 @Suite(.serialized) struct GatewaySettingsStoreTests {
     @Test func bootstrapCopiesDefaultsToKeychainWhenMissing() {
-        let defaultsKeys = [
-            "node.instanceId",
-            "gateway.preferredStableID",
-            "gateway.lastDiscoveredStableID",
-        ]
-        let entries = [instanceIdEntry, preferredGatewayEntry, lastGatewayEntry]
-        let defaultsSnapshot = snapshotDefaults(defaultsKeys)
-        let keychainSnapshot = snapshotKeychain(entries)
-        defer {
-            restoreDefaults(defaultsSnapshot)
-            restoreKeychain(keychainSnapshot)
+        withBootstrapSnapshots {
+            applyDefaults([
+                "node.instanceId": "node-test",
+                "gateway.preferredStableID": "preferred-test",
+                "gateway.lastDiscoveredStableID": "last-test",
+            ])
+            applyKeychain([
+                instanceIdEntry: nil,
+                preferredGatewayEntry: nil,
+                lastGatewayEntry: nil,
+            ])
+
+            GatewaySettingsStore.bootstrapPersistence()
+
+            #expect(KeychainStore.loadString(service: nodeService, account: "instanceId") == "node-test")
+            #expect(KeychainStore.loadString(service: gatewayService, account: "preferredStableID") == "preferred-test")
+            #expect(KeychainStore.loadString(service: gatewayService, account: "lastDiscoveredStableID") == "last-test")
         }
-
-        applyDefaults([
-            "node.instanceId": "node-test",
-            "gateway.preferredStableID": "preferred-test",
-            "gateway.lastDiscoveredStableID": "last-test",
-        ])
-        applyKeychain([
-            instanceIdEntry: nil,
-            preferredGatewayEntry: nil,
-            lastGatewayEntry: nil,
-        ])
-
-        GatewaySettingsStore.bootstrapPersistence()
-
-        #expect(KeychainStore.loadString(service: nodeService, account: "instanceId") == "node-test")
-        #expect(KeychainStore.loadString(service: gatewayService, account: "preferredStableID") == "preferred-test")
-        #expect(KeychainStore.loadString(service: gatewayService, account: "lastDiscoveredStableID") == "last-test")
     }
 
     @Test func bootstrapCopiesKeychainToDefaultsWhenMissing() {
-        let defaultsKeys = [
-            "node.instanceId",
-            "gateway.preferredStableID",
-            "gateway.lastDiscoveredStableID",
-        ]
-        let entries = [instanceIdEntry, preferredGatewayEntry, lastGatewayEntry]
-        let defaultsSnapshot = snapshotDefaults(defaultsKeys)
-        let keychainSnapshot = snapshotKeychain(entries)
-        defer {
-            restoreDefaults(defaultsSnapshot)
-            restoreKeychain(keychainSnapshot)
+        withBootstrapSnapshots {
+            applyDefaults([
+                "node.instanceId": nil,
+                "gateway.preferredStableID": nil,
+                "gateway.lastDiscoveredStableID": nil,
+            ])
+            applyKeychain([
+                instanceIdEntry: "node-from-keychain",
+                preferredGatewayEntry: "preferred-from-keychain",
+                lastGatewayEntry: "last-from-keychain",
+            ])
+
+            GatewaySettingsStore.bootstrapPersistence()
+
+            let defaults = UserDefaults.standard
+            #expect(defaults.string(forKey: "node.instanceId") == "node-from-keychain")
+            #expect(defaults.string(forKey: "gateway.preferredStableID") == "preferred-from-keychain")
+            #expect(defaults.string(forKey: "gateway.lastDiscoveredStableID") == "last-from-keychain")
         }
-
-        applyDefaults([
-            "node.instanceId": nil,
-            "gateway.preferredStableID": nil,
-            "gateway.lastDiscoveredStableID": nil,
-        ])
-        applyKeychain([
-            instanceIdEntry: "node-from-keychain",
-            preferredGatewayEntry: "preferred-from-keychain",
-            lastGatewayEntry: "last-from-keychain",
-        ])
-
-        GatewaySettingsStore.bootstrapPersistence()
-
-        let defaults = UserDefaults.standard
-        #expect(defaults.string(forKey: "node.instanceId") == "node-from-keychain")
-        #expect(defaults.string(forKey: "gateway.preferredStableID") == "preferred-from-keychain")
-        #expect(defaults.string(forKey: "gateway.lastDiscoveredStableID") == "last-from-keychain")
     }
 
     @Test func lastGateway_manualRoundTrip() {
-        let keys = [
-            "gateway.last.kind",
-            "gateway.last.host",
-            "gateway.last.port",
-            "gateway.last.tls",
-            "gateway.last.stableID",
-        ]
-        let snapshot = snapshotDefaults(keys)
-        defer { restoreDefaults(snapshot) }
+        withLastGatewayDefaultsSnapshot {
+            GatewaySettingsStore.saveLastGatewayConnectionManual(
+                host: "example.com",
+                port: 443,
+                useTLS: true,
+                stableID: "manual|example.com|443")
 
-        GatewaySettingsStore.saveLastGatewayConnectionManual(
-            host: "example.com",
-            port: 443,
-            useTLS: true,
-            stableID: "manual|example.com|443")
-
-        let loaded = GatewaySettingsStore.loadLastGatewayConnection()
-        #expect(loaded == .manual(host: "example.com", port: 443, useTLS: true, stableID: "manual|example.com|443"))
+            let loaded = GatewaySettingsStore.loadLastGatewayConnection()
+            #expect(loaded == .manual(host: "example.com", port: 443, useTLS: true, stableID: "manual|example.com|443"))
+        }
     }
 
     @Test func lastGateway_discoveredDoesNotPersistResolvedHostPort() {
-        let keys = [
-            "gateway.last.kind",
-            "gateway.last.host",
-            "gateway.last.port",
-            "gateway.last.tls",
-            "gateway.last.stableID",
-        ]
-        let snapshot = snapshotDefaults(keys)
-        defer { restoreDefaults(snapshot) }
+        withLastGatewayDefaultsSnapshot {
+            // Simulate a prior manual record that included host/port.
+            applyDefaults([
+                "gateway.last.host": "10.0.0.99",
+                "gateway.last.port": 18789,
+                "gateway.last.tls": true,
+                "gateway.last.stableID": "manual|10.0.0.99|18789",
+                "gateway.last.kind": "manual",
+            ])
 
-        // Simulate a prior manual record that included host/port.
-        applyDefaults([
-            "gateway.last.host": "10.0.0.99",
-            "gateway.last.port": 18789,
-            "gateway.last.tls": true,
-            "gateway.last.stableID": "manual|10.0.0.99|18789",
-            "gateway.last.kind": "manual",
-        ])
+            GatewaySettingsStore.saveLastGatewayConnectionDiscovered(stableID: "gw|abc", useTLS: true)
 
-        GatewaySettingsStore.saveLastGatewayConnectionDiscovered(stableID: "gw|abc", useTLS: true)
-
-        let defaults = UserDefaults.standard
-        #expect(defaults.object(forKey: "gateway.last.host") == nil)
-        #expect(defaults.object(forKey: "gateway.last.port") == nil)
-        #expect(GatewaySettingsStore.loadLastGatewayConnection() == .discovered(stableID: "gw|abc", useTLS: true))
+            let defaults = UserDefaults.standard
+            #expect(defaults.object(forKey: "gateway.last.host") == nil)
+            #expect(defaults.object(forKey: "gateway.last.port") == nil)
+            #expect(GatewaySettingsStore.loadLastGatewayConnection() == .discovered(stableID: "gw|abc", useTLS: true))
+        }
     }
 
     @Test func lastGateway_backCompat_manualLoadsWhenKindMissing() {
-        let keys = [
-            "gateway.last.kind",
-            "gateway.last.host",
-            "gateway.last.port",
-            "gateway.last.tls",
-            "gateway.last.stableID",
-        ]
-        let snapshot = snapshotDefaults(keys)
-        defer { restoreDefaults(snapshot) }
+        withLastGatewayDefaultsSnapshot {
+            applyDefaults([
+                "gateway.last.kind": nil,
+                "gateway.last.host": "example.org",
+                "gateway.last.port": 18789,
+                "gateway.last.tls": false,
+                "gateway.last.stableID": "manual|example.org|18789",
+            ])
 
-        applyDefaults([
-            "gateway.last.kind": nil,
-            "gateway.last.host": "example.org",
-            "gateway.last.port": 18789,
-            "gateway.last.tls": false,
-            "gateway.last.stableID": "manual|example.org|18789",
-        ])
-
-        let loaded = GatewaySettingsStore.loadLastGatewayConnection()
-        #expect(loaded == .manual(host: "example.org", port: 18789, useTLS: false, stableID: "manual|example.org|18789"))
+            let loaded = GatewaySettingsStore.loadLastGatewayConnection()
+            #expect(loaded == .manual(host: "example.org", port: 18789, useTLS: false, stableID: "manual|example.org|18789"))
+        }
     }
 
     @Test func talkProviderApiKey_genericRoundTrip() {

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -4,31 +4,6 @@ import Testing
 import UIKit
 @testable import RemoteClaw
 
-private func withUserDefaults<T>(_ updates: [String: Any?], _ body: () throws -> T) rethrows -> T {
-    let defaults = UserDefaults.standard
-    var snapshot: [String: Any?] = [:]
-    for key in updates.keys {
-        snapshot[key] = defaults.object(forKey: key)
-    }
-    for (key, value) in updates {
-        if let value {
-            defaults.set(value, forKey: key)
-        } else {
-            defaults.removeObject(forKey: key)
-        }
-    }
-    defer {
-        for (key, value) in snapshot {
-            if let value {
-                defaults.set(value, forKey: key)
-            } else {
-                defaults.removeObject(forKey: key)
-            }
-        }
-    }
-    return try body()
-}
-
 private func makeAgentDeepLinkURL(
     message: String,
     deliver: Bool = false,

--- a/apps/ios/Tests/TestDefaultsSupport.swift
+++ b/apps/ios/Tests/TestDefaultsSupport.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+func withUserDefaults<T>(_ updates: [String: Any?], _ body: () throws -> T) rethrows -> T {
+    let defaults = UserDefaults.standard
+    var snapshot: [String: Any?] = [:]
+    for key in updates.keys {
+        snapshot[key] = defaults.object(forKey: key)
+    }
+    for (key, value) in updates {
+        if let value {
+            defaults.set(value, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+    }
+    defer {
+        for (key, value) in snapshot {
+            if let value {
+                defaults.set(value, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+    }
+    return try body()
+}

--- a/apps/ios/Tests/VoiceWakeManagerExtractCommandTests.swift
+++ b/apps/ios/Tests/VoiceWakeManagerExtractCommandTests.swift
@@ -3,6 +3,19 @@ import SwabbleKit
 import Testing
 @testable import RemoteClaw
 
+private let remoteClawTranscript = "hey remoteclaw do thing"
+
+private func remoteClawSegments(postTriggerStart: TimeInterval) -> [WakeWordSegment] {
+    makeSegments(
+        transcript: remoteClawTranscript,
+        words: [
+            ("hey", 0.0, 0.1),
+            ("remoteclaw", 0.2, 0.1),
+            ("do", postTriggerStart, 0.1),
+            ("thing", postTriggerStart + 0.2, 0.1),
+        ])
+}
+
 @Suite struct VoiceWakeManagerExtractCommandTests {
     @Test func extractCommandReturnsNilWhenNoTriggerFound() {
         let transcript = "hello world"
@@ -13,17 +26,9 @@ import Testing
     }
 
     @Test func extractCommandTrimsTokensAndResult() {
-        let transcript = "hey remoteclaw do thing"
-        let segments = makeSegments(
-            transcript: transcript,
-            words: [
-                ("hey", 0.0, 0.1),
-                ("remoteclaw", 0.2, 0.1),
-                ("do", 0.9, 0.1),
-                ("thing", 1.1, 0.1),
-            ])
+        let segments = remoteClawSegments(postTriggerStart: 0.9)
         let cmd = VoiceWakeManager.extractCommand(
-            from: transcript,
+            from: remoteClawTranscript,
             segments: segments,
             triggers: ["  remoteclaw  "],
             minPostTriggerGap: 0.3)
@@ -31,17 +36,9 @@ import Testing
     }
 
     @Test func extractCommandReturnsNilWhenGapTooShort() {
-        let transcript = "hey remoteclaw do thing"
-        let segments = makeSegments(
-            transcript: transcript,
-            words: [
-                ("hey", 0.0, 0.1),
-                ("remoteclaw", 0.2, 0.1),
-                ("do", 0.35, 0.1),
-                ("thing", 0.5, 0.1),
-            ])
+        let segments = remoteClawSegments(postTriggerStart: 0.35)
         let cmd = VoiceWakeManager.extractCommand(
-            from: transcript,
+            from: remoteClawTranscript,
             segments: segments,
             triggers: ["remoteclaw"],
             minPostTriggerGap: 0.3)
@@ -57,17 +54,9 @@ import Testing
     }
 
     @Test func extractCommandIgnoresEmptyTriggers() {
-        let transcript = "hey remoteclaw do thing"
-        let segments = makeSegments(
-            transcript: transcript,
-            words: [
-                ("hey", 0.0, 0.1),
-                ("remoteclaw", 0.2, 0.1),
-                ("do", 0.9, 0.1),
-                ("thing", 1.1, 0.1),
-            ])
+        let segments = remoteClawSegments(postTriggerStart: 0.9)
         let cmd = VoiceWakeManager.extractCommand(
-            from: transcript,
+            from: remoteClawTranscript,
             segments: segments,
             triggers: ["", "   ", "remoteclaw"],
             minPostTriggerGap: 0.3)

--- a/scripts/check-no-pairing-store-group-auth.mjs
+++ b/scripts/check-no-pairing-store-group-auth.mjs
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 
-import { promises as fs } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import ts from "typescript";
+import {
+  collectFileViolations,
+  getPropertyNameText,
+  resolveRepoRoot,
+  runAsScript,
+  toLine,
+} from "./lib/ts-guard-utils.mjs";
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolveRepoRoot(import.meta.url);
 const sourceRoots = [path.join(repoRoot, "src"), path.join(repoRoot, "extensions")];
 
 const allowedFiles = new Set([
@@ -30,43 +35,6 @@ const allowedResolverCallNames = new Set([
   "resolveMattermostEffectiveAllowFromLists",
   "resolveIrcEffectiveAllowlists",
 ]);
-
-function isTestLikeFile(filePath) {
-  return (
-    filePath.endsWith(".test.ts") ||
-    filePath.endsWith(".test-utils.ts") ||
-    filePath.endsWith(".test-harness.ts") ||
-    filePath.endsWith(".e2e-harness.ts")
-  );
-}
-
-async function collectTypeScriptFiles(dir) {
-  const entries = await fs.readdir(dir, { withFileTypes: true });
-  const out = [];
-  for (const entry of entries) {
-    const entryPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      out.push(...(await collectTypeScriptFiles(entryPath)));
-      continue;
-    }
-    if (!entry.isFile() || !entryPath.endsWith(".ts") || isTestLikeFile(entryPath)) {
-      continue;
-    }
-    out.push(entryPath);
-  }
-  return out;
-}
-
-function toLine(sourceFile, node) {
-  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
-}
-
-function getPropertyNameText(name) {
-  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
-    return name.text;
-  }
-  return null;
-}
 
 function getDeclarationNameText(name) {
   if (ts.isIdentifier(name)) {
@@ -190,24 +158,12 @@ function findViolations(content, filePath) {
 }
 
 async function main() {
-  const files = (
-    await Promise.all(sourceRoots.map(async (root) => await collectTypeScriptFiles(root)))
-  ).flat();
-
-  const violations = [];
-  for (const filePath of files) {
-    if (allowedFiles.has(filePath)) {
-      continue;
-    }
-    const content = await fs.readFile(filePath, "utf8");
-    const fileViolations = findViolations(content, filePath);
-    for (const violation of fileViolations) {
-      violations.push({
-        path: path.relative(repoRoot, filePath),
-        ...violation,
-      });
-    }
-  }
+  const violations = await collectFileViolations({
+    sourceRoots,
+    repoRoot,
+    findViolations,
+    skipFile: (filePath) => allowedFiles.has(filePath),
+  });
 
   if (violations.length === 0) {
     return;
@@ -223,17 +179,4 @@ async function main() {
   process.exit(1);
 }
 
-const isDirectExecution = (() => {
-  const entry = process.argv[1];
-  if (!entry) {
-    return false;
-  }
-  return path.resolve(entry) === fileURLToPath(import.meta.url);
-})();
-
-if (isDirectExecution) {
-  main().catch((error) => {
-    console.error(error);
-    process.exit(1);
-  });
-}
+runAsScript(import.meta.url, main);

--- a/scripts/check-no-random-messaging-tmp.mjs
+++ b/scripts/check-no-random-messaging-tmp.mjs
@@ -2,10 +2,16 @@
 
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import ts from "typescript";
+import {
+  collectTypeScriptFiles,
+  resolveRepoRoot,
+  runAsScript,
+  toLine,
+  unwrapExpression,
+} from "./lib/ts-guard-utils.mjs";
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolveRepoRoot(import.meta.url);
 const sourceRoots = [
   path.join(repoRoot, "src", "channels"),
   path.join(repoRoot, "src", "infra", "outbound"),
@@ -13,38 +19,6 @@ const sourceRoots = [
   path.join(repoRoot, "extensions"),
 ];
 const allowedCallsites = new Set([path.join(repoRoot, "extensions", "feishu", "src", "dedup.ts")]);
-
-function isTestLikeFile(filePath) {
-  return (
-    filePath.endsWith(".test.ts") ||
-    filePath.endsWith(".test-utils.ts") ||
-    filePath.endsWith(".test-harness.ts") ||
-    filePath.endsWith(".e2e-harness.ts")
-  );
-}
-
-async function collectTypeScriptFiles(dir) {
-  const entries = await fs.readdir(dir, { withFileTypes: true });
-  const out = [];
-  for (const entry of entries) {
-    const entryPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      out.push(...(await collectTypeScriptFiles(entryPath)));
-      continue;
-    }
-    if (!entry.isFile()) {
-      continue;
-    }
-    if (!entryPath.endsWith(".ts")) {
-      continue;
-    }
-    if (isTestLikeFile(entryPath)) {
-      continue;
-    }
-    out.push(entryPath);
-  }
-  return out;
-}
 
 function collectOsTmpdirImports(sourceFile) {
   const osModuleSpecifiers = new Set(["node:os", "os"]);
@@ -80,25 +54,6 @@ function collectOsTmpdirImports(sourceFile) {
   return { osNamespaceOrDefault, namedTmpdir };
 }
 
-function unwrapExpression(expression) {
-  let current = expression;
-  while (true) {
-    if (ts.isParenthesizedExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isAsExpression(current) || ts.isTypeAssertionExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isNonNullExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    return current;
-  }
-}
-
 export function findMessagingTmpdirCallLines(content, fileName = "source.ts") {
   const sourceFile = ts.createSourceFile(fileName, content, ts.ScriptTarget.Latest, true);
   const { osNamespaceOrDefault, namedTmpdir } = collectOsTmpdirImports(sourceFile);
@@ -113,11 +68,9 @@ export function findMessagingTmpdirCallLines(content, fileName = "source.ts") {
         ts.isIdentifier(callee.expression) &&
         osNamespaceOrDefault.has(callee.expression.text)
       ) {
-        const line = sourceFile.getLineAndCharacterOfPosition(callee.getStart(sourceFile)).line + 1;
-        lines.push(line);
+        lines.push(toLine(sourceFile, callee));
       } else if (ts.isIdentifier(callee) && namedTmpdir.has(callee.text)) {
-        const line = sourceFile.getLineAndCharacterOfPosition(callee.getStart(sourceFile)).line + 1;
-        lines.push(line);
+        lines.push(toLine(sourceFile, callee));
       }
     }
     ts.forEachChild(node, visit);
@@ -129,7 +82,14 @@ export function findMessagingTmpdirCallLines(content, fileName = "source.ts") {
 
 export async function main() {
   const files = (
-    await Promise.all(sourceRoots.map(async (dir) => await collectTypeScriptFiles(dir)))
+    await Promise.all(
+      sourceRoots.map(
+        async (dir) =>
+          await collectTypeScriptFiles(dir, {
+            ignoreMissing: true,
+          }),
+      ),
+    )
   ).flat();
   const violations = [];
 
@@ -157,17 +117,4 @@ export async function main() {
   process.exit(1);
 }
 
-const isDirectExecution = (() => {
-  const entry = process.argv[1];
-  if (!entry) {
-    return false;
-  }
-  return path.resolve(entry) === fileURLToPath(import.meta.url);
-})();
-
-if (isDirectExecution) {
-  main().catch((error) => {
-    console.error(error);
-    process.exit(1);
-  });
-}
+runAsScript(import.meta.url, main);

--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -2,10 +2,16 @@
 
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import ts from "typescript";
+import {
+  collectTypeScriptFiles,
+  resolveRepoRoot,
+  runAsScript,
+  toLine,
+  unwrapExpression,
+} from "./lib/ts-guard-utils.mjs";
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolveRepoRoot(import.meta.url);
 const sourceRoots = [
   path.join(repoRoot, "src", "telegram"),
   path.join(repoRoot, "src", "discord"),
@@ -40,7 +46,7 @@ const allowedRawFetchCallsites = new Set([
   "extensions/matrix/src/directory-live.ts:41",
   "extensions/matrix/src/matrix/client/config.ts:171",
   "extensions/mattermost/src/mattermost/client.ts:211",
-  "extensions/mattermost/src/mattermost/monitor.ts:234",
+  "extensions/mattermost/src/mattermost/monitor.ts:230",
   "extensions/mattermost/src/mattermost/probe.ts:27",
   "extensions/minimax-portal-auth/oauth.ts:71",
   "extensions/minimax-portal-auth/oauth.ts:112",
@@ -65,66 +71,6 @@ const allowedRawFetchCallsites = new Set([
   "src/slack/monitor/media.ts:108",
 ]);
 
-function isTestLikeFile(filePath) {
-  return (
-    filePath.endsWith(".test.ts") ||
-    filePath.endsWith(".test-utils.ts") ||
-    filePath.endsWith(".test-harness.ts") ||
-    filePath.endsWith(".e2e-harness.ts") ||
-    filePath.endsWith(".browser.test.ts") ||
-    filePath.endsWith(".node.test.ts")
-  );
-}
-
-async function collectTypeScriptFiles(targetPath) {
-  const stat = await fs.stat(targetPath);
-  if (stat.isFile()) {
-    if (!targetPath.endsWith(".ts") || isTestLikeFile(targetPath)) {
-      return [];
-    }
-    return [targetPath];
-  }
-  const entries = await fs.readdir(targetPath, { withFileTypes: true });
-  const files = [];
-  for (const entry of entries) {
-    const entryPath = path.join(targetPath, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...(await collectTypeScriptFiles(entryPath)));
-      continue;
-    }
-    if (!entry.isFile()) {
-      continue;
-    }
-    if (!entryPath.endsWith(".ts")) {
-      continue;
-    }
-    if (isTestLikeFile(entryPath)) {
-      continue;
-    }
-    files.push(entryPath);
-  }
-  return files;
-}
-
-function unwrapExpression(expression) {
-  let current = expression;
-  while (true) {
-    if (ts.isParenthesizedExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isAsExpression(current) || ts.isTypeAssertionExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isNonNullExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    return current;
-  }
-}
-
 function isRawFetchCall(expression) {
   const callee = unwrapExpression(expression);
   if (ts.isIdentifier(callee)) {
@@ -145,9 +91,7 @@ export function findRawFetchCallLines(content, fileName = "source.ts") {
   const lines = [];
   const visit = (node) => {
     if (ts.isCallExpression(node) && isRawFetchCall(node.expression)) {
-      const line =
-        sourceFile.getLineAndCharacterOfPosition(node.expression.getStart(sourceFile)).line + 1;
-      lines.push(line);
+      lines.push(toLine(sourceFile, node.expression));
     }
     ts.forEachChild(node, visit);
   };
@@ -158,13 +102,13 @@ export function findRawFetchCallLines(content, fileName = "source.ts") {
 export async function main() {
   const files = (
     await Promise.all(
-      sourceRoots.map(async (sourceRoot) => {
-        try {
-          return await collectTypeScriptFiles(sourceRoot);
-        } catch {
-          return [];
-        }
-      }),
+      sourceRoots.map(
+        async (sourceRoot) =>
+          await collectTypeScriptFiles(sourceRoot, {
+            extraTestSuffixes: [".browser.test.ts", ".node.test.ts"],
+            ignoreMissing: true,
+          }),
+      ),
     )
   ).flat();
 
@@ -195,17 +139,4 @@ export async function main() {
   process.exit(1);
 }
 
-const isDirectExecution = (() => {
-  const entry = process.argv[1];
-  if (!entry) {
-    return false;
-  }
-  return path.resolve(entry) === fileURLToPath(import.meta.url);
-})();
-
-if (isDirectExecution) {
-  main().catch((error) => {
-    console.error(error);
-    process.exit(1);
-  });
-}
+runAsScript(import.meta.url, main);

--- a/scripts/check-pairing-account-scope.mjs
+++ b/scripts/check-pairing-account-scope.mjs
@@ -1,49 +1,17 @@
 #!/usr/bin/env node
 
-import { promises as fs } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import ts from "typescript";
+import {
+  collectFileViolations,
+  getPropertyNameText,
+  resolveRepoRoot,
+  runAsScript,
+  toLine,
+} from "./lib/ts-guard-utils.mjs";
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolveRepoRoot(import.meta.url);
 const sourceRoots = [path.join(repoRoot, "src"), path.join(repoRoot, "extensions")];
-
-function isTestLikeFile(filePath) {
-  return (
-    filePath.endsWith(".test.ts") ||
-    filePath.endsWith(".test-utils.ts") ||
-    filePath.endsWith(".test-harness.ts") ||
-    filePath.endsWith(".e2e-harness.ts")
-  );
-}
-
-async function collectTypeScriptFiles(dir) {
-  const entries = await fs.readdir(dir, { withFileTypes: true });
-  const out = [];
-  for (const entry of entries) {
-    const entryPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      out.push(...(await collectTypeScriptFiles(entryPath)));
-      continue;
-    }
-    if (!entry.isFile() || !entryPath.endsWith(".ts") || isTestLikeFile(entryPath)) {
-      continue;
-    }
-    out.push(entryPath);
-  }
-  return out;
-}
-
-function toLine(sourceFile, node) {
-  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
-}
-
-function getPropertyNameText(name) {
-  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
-    return name.text;
-  }
-  return null;
-}
 
 function isUndefinedLikeExpression(node) {
   if (ts.isIdentifier(node) && node.text === "undefined") {
@@ -114,21 +82,11 @@ function findViolations(content, filePath) {
 }
 
 async function main() {
-  const files = (
-    await Promise.all(sourceRoots.map(async (root) => await collectTypeScriptFiles(root)))
-  ).flat();
-  const violations = [];
-
-  for (const filePath of files) {
-    const content = await fs.readFile(filePath, "utf8");
-    const fileViolations = findViolations(content, filePath);
-    for (const violation of fileViolations) {
-      violations.push({
-        path: path.relative(repoRoot, filePath),
-        ...violation,
-      });
-    }
-  }
+  const violations = await collectFileViolations({
+    sourceRoots,
+    repoRoot,
+    findViolations,
+  });
 
   if (violations.length === 0) {
     return;
@@ -141,17 +99,4 @@ async function main() {
   process.exit(1);
 }
 
-const isDirectExecution = (() => {
-  const entry = process.argv[1];
-  if (!entry) {
-    return false;
-  }
-  return path.resolve(entry) === fileURLToPath(import.meta.url);
-})();
-
-if (isDirectExecution) {
-  main().catch((error) => {
-    console.error(error);
-    process.exit(1);
-  });
-}
+runAsScript(import.meta.url, main);

--- a/scripts/lib/ts-guard-utils.mjs
+++ b/scripts/lib/ts-guard-utils.mjs
@@ -1,0 +1,147 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const baseTestSuffixes = [".test.ts", ".test-utils.ts", ".test-harness.ts", ".e2e-harness.ts"];
+
+export function resolveRepoRoot(importMetaUrl) {
+  return path.resolve(path.dirname(fileURLToPath(importMetaUrl)), "..", "..");
+}
+
+export function isTestLikeTypeScriptFile(filePath, options = {}) {
+  const extraTestSuffixes = options.extraTestSuffixes ?? [];
+  return [...baseTestSuffixes, ...extraTestSuffixes].some((suffix) => filePath.endsWith(suffix));
+}
+
+export async function collectTypeScriptFiles(targetPath, options = {}) {
+  const includeTests = options.includeTests ?? false;
+  const extraTestSuffixes = options.extraTestSuffixes ?? [];
+  const skipNodeModules = options.skipNodeModules ?? true;
+  const ignoreMissing = options.ignoreMissing ?? false;
+
+  let stat;
+  try {
+    stat = await fs.stat(targetPath);
+  } catch (error) {
+    if (
+      ignoreMissing &&
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return [];
+    }
+    throw error;
+  }
+
+  if (stat.isFile()) {
+    if (!targetPath.endsWith(".ts")) {
+      return [];
+    }
+    if (!includeTests && isTestLikeTypeScriptFile(targetPath, { extraTestSuffixes })) {
+      return [];
+    }
+    return [targetPath];
+  }
+
+  const entries = await fs.readdir(targetPath, { withFileTypes: true });
+  const out = [];
+  for (const entry of entries) {
+    const entryPath = path.join(targetPath, entry.name);
+    if (entry.isDirectory()) {
+      if (skipNodeModules && entry.name === "node_modules") {
+        continue;
+      }
+      out.push(...(await collectTypeScriptFiles(entryPath, options)));
+      continue;
+    }
+    if (!entry.isFile() || !entryPath.endsWith(".ts")) {
+      continue;
+    }
+    if (!includeTests && isTestLikeTypeScriptFile(entryPath, { extraTestSuffixes })) {
+      continue;
+    }
+    out.push(entryPath);
+  }
+  return out;
+}
+
+export async function collectFileViolations(params) {
+  const files = (
+    await Promise.all(
+      params.sourceRoots.map(
+        async (root) =>
+          await collectTypeScriptFiles(root, {
+            ignoreMissing: true,
+            extraTestSuffixes: params.extraTestSuffixes,
+          }),
+      ),
+    )
+  ).flat();
+
+  const violations = [];
+  for (const filePath of files) {
+    if (params.skipFile?.(filePath)) {
+      continue;
+    }
+    const content = await fs.readFile(filePath, "utf8");
+    const fileViolations = params.findViolations(content, filePath);
+    for (const violation of fileViolations) {
+      violations.push({
+        path: path.relative(params.repoRoot, filePath),
+        ...violation,
+      });
+    }
+  }
+  return violations;
+}
+
+export function toLine(sourceFile, node) {
+  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+}
+
+export function getPropertyNameText(name) {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+  return null;
+}
+
+export function unwrapExpression(expression) {
+  let current = expression;
+  while (true) {
+    if (ts.isParenthesizedExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+    if (ts.isAsExpression(current) || ts.isTypeAssertionExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+    if (ts.isNonNullExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+    return current;
+  }
+}
+
+export function isDirectExecution(importMetaUrl) {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return path.resolve(entry) === fileURLToPath(importMetaUrl);
+}
+
+export function runAsScript(importMetaUrl, main) {
+  if (!isDirectExecution(importMetaUrl)) {
+    return;
+  }
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/src/commands/agents.commands.bind.ts
+++ b/src/commands/agents.commands.bind.ts
@@ -60,6 +60,74 @@ function formatBindingOwnerLine(binding: AgentBinding): string {
   return `${normalizeAgentId(binding.agentId)} <- ${describeBinding(binding)}`;
 }
 
+function resolveTargetAgentIdOrExit(params: {
+  cfg: Awaited<ReturnType<typeof requireValidConfig>>;
+  runtime: RuntimeEnv;
+  agentInput: string | undefined;
+}): string | null {
+  const agentId = resolveAgentId(params.cfg, params.agentInput?.trim(), {
+    fallbackToDefault: true,
+  });
+  if (!agentId) {
+    params.runtime.error("Unable to resolve agent id.");
+    params.runtime.exit(1);
+    return null;
+  }
+  if (!hasAgent(params.cfg, agentId)) {
+    params.runtime.error(`Agent "${agentId}" not found.`);
+    params.runtime.exit(1);
+    return null;
+  }
+  return agentId;
+}
+
+function formatBindingConflicts(
+  conflicts: Array<{ binding: AgentBinding; existingAgentId: string }>,
+): string[] {
+  return conflicts.map(
+    (conflict) => `${describeBinding(conflict.binding)} (agent=${conflict.existingAgentId})`,
+  );
+}
+
+function resolveParsedBindingsOrExit(params: {
+  runtime: RuntimeEnv;
+  cfg: NonNullable<Awaited<ReturnType<typeof requireValidConfig>>>;
+  agentId: string;
+  bindValues: string[] | undefined;
+  emptyMessage: string;
+}): ReturnType<typeof parseBindingSpecs> | null {
+  const specs = (params.bindValues ?? []).map((value) => value.trim()).filter(Boolean);
+  if (specs.length === 0) {
+    params.runtime.error(params.emptyMessage);
+    params.runtime.exit(1);
+    return null;
+  }
+
+  const parsed = parseBindingSpecs({ agentId: params.agentId, specs, config: params.cfg });
+  if (parsed.errors.length > 0) {
+    params.runtime.error(parsed.errors.join("\n"));
+    params.runtime.exit(1);
+    return null;
+  }
+  return parsed;
+}
+
+function emitJsonPayload(params: {
+  runtime: RuntimeEnv;
+  json: boolean | undefined;
+  payload: unknown;
+  conflictCount?: number;
+}): boolean {
+  if (!params.json) {
+    return false;
+  }
+  params.runtime.log(JSON.stringify(params.payload, null, 2));
+  if ((params.conflictCount ?? 0) > 0) {
+    params.runtime.exit(1);
+  }
+  return true;
+}
+
 export async function agentsBindingsCommand(
   opts: AgentsBindingsListOptions,
   runtime: RuntimeEnv = defaultRuntime,
@@ -123,29 +191,19 @@ export async function agentsBindCommand(
     return;
   }
 
-  const agentId = resolveAgentId(cfg, opts.agent?.trim(), { fallbackToDefault: true });
+  const agentId = resolveTargetAgentIdOrExit({ cfg, runtime, agentInput: opts.agent });
   if (!agentId) {
-    runtime.error("Unable to resolve agent id.");
-    runtime.exit(1);
-    return;
-  }
-  if (!hasAgent(cfg, agentId)) {
-    runtime.error(`Agent "${agentId}" not found.`);
-    runtime.exit(1);
     return;
   }
 
-  const specs = (opts.bind ?? []).map((value) => value.trim()).filter(Boolean);
-  if (specs.length === 0) {
-    runtime.error("Provide at least one --bind <channel[:accountId]>.");
-    runtime.exit(1);
-    return;
-  }
-
-  const parsed = parseBindingSpecs({ agentId, specs, config: cfg });
-  if (parsed.errors.length > 0) {
-    runtime.error(parsed.errors.join("\n"));
-    runtime.exit(1);
+  const parsed = resolveParsedBindingsOrExit({
+    runtime,
+    cfg,
+    agentId,
+    bindValues: opts.bind,
+    emptyMessage: "Provide at least one --bind <channel[:accountId]>.",
+  });
+  if (!parsed) {
     return;
   }
 
@@ -162,15 +220,11 @@ export async function agentsBindCommand(
     added: result.added.map(describeBinding),
     updated: result.updated.map(describeBinding),
     skipped: result.skipped.map(describeBinding),
-    conflicts: result.conflicts.map(
-      (conflict) => `${describeBinding(conflict.binding)} (agent=${conflict.existingAgentId})`,
-    ),
+    conflicts: formatBindingConflicts(result.conflicts),
   };
-  if (opts.json) {
-    runtime.log(JSON.stringify(payload, null, 2));
-    if (result.conflicts.length > 0) {
-      runtime.exit(1);
-    }
+  if (
+    emitJsonPayload({ runtime, json: opts.json, payload, conflictCount: result.conflicts.length })
+  ) {
     return;
   }
 
@@ -215,15 +269,8 @@ export async function agentsUnbindCommand(
     return;
   }
 
-  const agentId = resolveAgentId(cfg, opts.agent?.trim(), { fallbackToDefault: true });
+  const agentId = resolveTargetAgentIdOrExit({ cfg, runtime, agentInput: opts.agent });
   if (!agentId) {
-    runtime.error("Unable to resolve agent id.");
-    runtime.exit(1);
-    return;
-  }
-  if (!hasAgent(cfg, agentId)) {
-    runtime.error(`Agent "${agentId}" not found.`);
-    runtime.exit(1);
     return;
   }
   if (opts.all && (opts.bind?.length ?? 0) > 0) {
@@ -254,25 +301,21 @@ export async function agentsUnbindCommand(
       missing: [] as string[],
       conflicts: [] as string[],
     };
-    if (opts.json) {
-      runtime.log(JSON.stringify(payload, null, 2));
+    if (emitJsonPayload({ runtime, json: opts.json, payload })) {
       return;
     }
     runtime.log(`Removed ${removed.length} binding(s) for "${agentId}".`);
     return;
   }
 
-  const specs = (opts.bind ?? []).map((value) => value.trim()).filter(Boolean);
-  if (specs.length === 0) {
-    runtime.error("Provide at least one --bind <channel[:accountId]> or use --all.");
-    runtime.exit(1);
-    return;
-  }
-
-  const parsed = parseBindingSpecs({ agentId, specs, config: cfg });
-  if (parsed.errors.length > 0) {
-    runtime.error(parsed.errors.join("\n"));
-    runtime.exit(1);
+  const parsed = resolveParsedBindingsOrExit({
+    runtime,
+    cfg,
+    agentId,
+    bindValues: opts.bind,
+    emptyMessage: "Provide at least one --bind <channel[:accountId]> or use --all.",
+  });
+  if (!parsed) {
     return;
   }
 
@@ -288,15 +331,11 @@ export async function agentsUnbindCommand(
     agentId,
     removed: result.removed.map(describeBinding),
     missing: result.missing.map(describeBinding),
-    conflicts: result.conflicts.map(
-      (conflict) => `${describeBinding(conflict.binding)} (agent=${conflict.existingAgentId})`,
-    ),
+    conflicts: formatBindingConflicts(result.conflicts),
   };
-  if (opts.json) {
-    runtime.log(JSON.stringify(payload, null, 2));
-    if (result.conflicts.length > 0) {
-      runtime.exit(1);
-    }
+  if (
+    emitJsonPayload({ runtime, json: opts.json, payload, conflictCount: result.conflicts.length })
+  ) {
     return;
   }
 

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -16,6 +16,13 @@ import { getUpdateCheckResult } from "./status.update.js";
 
 type DeferredResult<T> = { ok: true; value: T } | { ok: false; error: unknown };
 
+type GatewayProbeSnapshot = {
+  gatewayConnection: ReturnType<typeof buildGatewayConnectionDetails>;
+  remoteUrlMissing: boolean;
+  gatewayMode: "local" | "remote";
+  gatewayProbe: Awaited<ReturnType<typeof probeGateway>> | null;
+};
+
 function deferResult<T>(promise: Promise<T>): Promise<DeferredResult<T>> {
   return promise.then(
     (value) => ({ ok: true, value }),
@@ -28,6 +35,43 @@ function unwrapDeferredResult<T>(result: DeferredResult<T>): T {
     throw result.error;
   }
   return result.value;
+}
+
+async function resolveGatewayProbeSnapshot(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  opts: { timeoutMs?: number; all?: boolean };
+}): Promise<GatewayProbeSnapshot> {
+  const gatewayConnection = buildGatewayConnectionDetails();
+  const isRemoteMode = params.cfg.gateway?.mode === "remote";
+  const remoteUrlRaw =
+    typeof params.cfg.gateway?.remote?.url === "string" ? params.cfg.gateway.remote.url : "";
+  const remoteUrlMissing = isRemoteMode && !remoteUrlRaw.trim();
+  const gatewayMode = isRemoteMode ? "remote" : "local";
+  const gatewayProbe = remoteUrlMissing
+    ? null
+    : await probeGateway({
+        url: gatewayConnection.url,
+        auth: resolveGatewayProbeAuth(params.cfg),
+        timeoutMs: Math.min(params.opts.all ? 5000 : 2500, params.opts.timeoutMs ?? 10_000),
+      }).catch(() => null);
+  return { gatewayConnection, remoteUrlMissing, gatewayMode, gatewayProbe };
+}
+
+async function resolveChannelsStatus(params: {
+  gatewayReachable: boolean;
+  opts: { timeoutMs?: number; all?: boolean };
+}) {
+  if (!params.gatewayReachable) {
+    return null;
+  }
+  return await callGateway({
+    method: "channels.status",
+    params: {
+      probe: false,
+      timeoutMs: Math.min(8000, params.opts.timeoutMs ?? 10_000),
+    },
+    timeoutMs: Math.min(params.opts.all ? 5000 : 2500, params.opts.timeoutMs ?? 10_000),
+  }).catch(() => null);
 }
 
 export type StatusScanResult = {
@@ -72,20 +116,9 @@ async function scanStatusJsonFast(opts: {
           runExec(cmd, args, { timeoutMs: 1200, maxBuffer: 200_000 }),
         ).catch(() => null);
 
-  const gatewayConnection = buildGatewayConnectionDetails();
-  const isRemoteMode = cfg.gateway?.mode === "remote";
-  const remoteUrlRaw = typeof cfg.gateway?.remote?.url === "string" ? cfg.gateway.remote.url : "";
-  const remoteUrlMissing = isRemoteMode && !remoteUrlRaw.trim();
-  const gatewayMode = isRemoteMode ? "remote" : "local";
-  const gatewayProbePromise = remoteUrlMissing
-    ? Promise.resolve<Awaited<ReturnType<typeof probeGateway>> | null>(null)
-    : probeGateway({
-        url: gatewayConnection.url,
-        auth: resolveGatewayProbeAuth(cfg),
-        timeoutMs: Math.min(opts.all ? 5000 : 2500, opts.timeoutMs ?? 10_000),
-      }).catch(() => null);
+  const gatewayProbePromise = resolveGatewayProbeSnapshot({ cfg, opts });
 
-  const [tailscaleDns, update, agentStatus, gatewayProbe, summary] = await Promise.all([
+  const [tailscaleDns, update, agentStatus, gatewaySnapshot, summary] = await Promise.all([
     tailscaleDnsPromise,
     updatePromise,
     agentStatusPromise,
@@ -97,21 +130,12 @@ async function scanStatusJsonFast(opts: {
       ? `https://${tailscaleDns}${normalizeControlUiBasePath(cfg.gateway?.controlUi?.basePath)}`
       : null;
 
+  const { gatewayConnection, remoteUrlMissing, gatewayMode, gatewayProbe } = gatewaySnapshot;
   const gatewayReachable = gatewayProbe?.ok === true;
   const gatewaySelf = gatewayProbe?.presence
     ? pickGatewaySelfPresence(gatewayProbe.presence)
     : null;
-  const channelsStatusPromise = gatewayReachable
-    ? callGateway({
-        method: "channels.status",
-        params: {
-          probe: false,
-          timeoutMs: Math.min(8000, opts.timeoutMs ?? 10_000),
-        },
-        timeoutMs: Math.min(opts.all ? 5000 : 2500, opts.timeoutMs ?? 10_000),
-      }).catch(() => null)
-    : Promise.resolve(null);
-  const channelsStatus = await channelsStatusPromise;
+  const channelsStatus = await resolveChannelsStatus({ gatewayReachable, opts });
   const channelIssues = channelsStatus ? collectChannelStatusIssues(channelsStatus) : [];
 
   return {
@@ -191,19 +215,8 @@ export async function scanStatus(
       progress.tick();
 
       progress.setLabel("Probing gateway…");
-      const gatewayConnection = buildGatewayConnectionDetails();
-      const isRemoteMode = cfg.gateway?.mode === "remote";
-      const remoteUrlRaw =
-        typeof cfg.gateway?.remote?.url === "string" ? cfg.gateway.remote.url : "";
-      const remoteUrlMissing = isRemoteMode && !remoteUrlRaw.trim();
-      const gatewayMode = isRemoteMode ? "remote" : "local";
-      const gatewayProbe = remoteUrlMissing
-        ? null
-        : await probeGateway({
-            url: gatewayConnection.url,
-            auth: resolveGatewayProbeAuth(cfg),
-            timeoutMs: Math.min(opts.all ? 5000 : 2500, opts.timeoutMs ?? 10_000),
-          }).catch(() => null);
+      const { gatewayConnection, remoteUrlMissing, gatewayMode, gatewayProbe } =
+        await resolveGatewayProbeSnapshot({ cfg, opts });
       const gatewayReachable = gatewayProbe?.ok === true;
       const gatewaySelf = gatewayProbe?.presence
         ? pickGatewaySelfPresence(gatewayProbe.presence)
@@ -211,16 +224,7 @@ export async function scanStatus(
       progress.tick();
 
       progress.setLabel("Querying channel status…");
-      const channelsStatus = gatewayReachable
-        ? await callGateway({
-            method: "channels.status",
-            params: {
-              probe: false,
-              timeoutMs: Math.min(8000, opts.timeoutMs ?? 10_000),
-            },
-            timeoutMs: Math.min(opts.all ? 5000 : 2500, opts.timeoutMs ?? 10_000),
-          }).catch(() => null)
-        : null;
+      const channelsStatus = await resolveChannelsStatus({ gatewayReachable, opts });
       const channelIssues = channelsStatus ? collectChannelStatusIssues(channelsStatus) : [];
       progress.tick();
 

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -240,29 +240,20 @@ export function buildServiceEnvironment(params: {
 }): Record<string, string | undefined> {
   const { env, port, token, launchdLabel } = params;
   const platform = params.platform ?? process.platform;
+  const sharedEnv = resolveSharedServiceEnvironmentFields(env, platform);
   const profile = env.REMOTECLAW_PROFILE;
   const resolvedLaunchdLabel =
     launchdLabel || (platform === "darwin" ? resolveGatewayLaunchAgentLabel(profile) : undefined);
   const systemdUnit = `${resolveGatewaySystemdServiceName(profile)}.service`;
-  const stateDir = env.REMOTECLAW_STATE_DIR;
-  const configPath = env.REMOTECLAW_CONFIG_PATH;
-  // Keep a usable temp directory for supervised services even when the host env omits TMPDIR.
-  const tmpDir = env.TMPDIR?.trim() || os.tmpdir();
-  const proxyEnv = readServiceProxyEnvironment(env);
-  // On macOS, launchd services don't inherit the shell environment, so Node's undici/fetch
-  // cannot locate the system CA bundle. Default to /etc/ssl/cert.pem so TLS verification
-  // works correctly when running as a LaunchAgent without extra user configuration.
-  const nodeCaCerts =
-    env.NODE_EXTRA_CA_CERTS ?? (platform === "darwin" ? "/etc/ssl/cert.pem" : undefined);
   return {
     HOME: env.HOME,
-    TMPDIR: tmpDir,
-    PATH: buildMinimalServicePath({ env }),
-    ...proxyEnv,
-    NODE_EXTRA_CA_CERTS: nodeCaCerts,
+    TMPDIR: sharedEnv.tmpDir,
+    PATH: sharedEnv.minimalPath,
+    ...sharedEnv.proxyEnv,
+    NODE_EXTRA_CA_CERTS: sharedEnv.nodeCaCerts,
     REMOTECLAW_PROFILE: profile,
-    REMOTECLAW_STATE_DIR: stateDir,
-    REMOTECLAW_CONFIG_PATH: configPath,
+    REMOTECLAW_STATE_DIR: sharedEnv.stateDir,
+    REMOTECLAW_CONFIG_PATH: sharedEnv.configPath,
     REMOTECLAW_GATEWAY_PORT: String(port),
     REMOTECLAW_GATEWAY_TOKEN: token,
     REMOTECLAW_LAUNCHD_LABEL: resolvedLaunchdLabel,
@@ -279,25 +270,17 @@ export function buildNodeServiceEnvironment(params: {
 }): Record<string, string | undefined> {
   const { env } = params;
   const platform = params.platform ?? process.platform;
+  const sharedEnv = resolveSharedServiceEnvironmentFields(env, platform);
   const gatewayToken =
     env.REMOTECLAW_GATEWAY_TOKEN?.trim() || env.CLAWDBOT_GATEWAY_TOKEN?.trim() || undefined;
-  const stateDir = env.REMOTECLAW_STATE_DIR;
-  const configPath = env.REMOTECLAW_CONFIG_PATH;
-  const tmpDir = env.TMPDIR?.trim() || os.tmpdir();
-  const proxyEnv = readServiceProxyEnvironment(env);
-  // On macOS, launchd services don't inherit the shell environment, so Node's undici/fetch
-  // cannot locate the system CA bundle. Default to /etc/ssl/cert.pem so TLS verification
-  // works correctly when running as a LaunchAgent without extra user configuration.
-  const nodeCaCerts =
-    env.NODE_EXTRA_CA_CERTS ?? (platform === "darwin" ? "/etc/ssl/cert.pem" : undefined);
   return {
     HOME: env.HOME,
-    TMPDIR: tmpDir,
-    PATH: buildMinimalServicePath({ env }),
-    ...proxyEnv,
-    NODE_EXTRA_CA_CERTS: nodeCaCerts,
-    REMOTECLAW_STATE_DIR: stateDir,
-    REMOTECLAW_CONFIG_PATH: configPath,
+    TMPDIR: sharedEnv.tmpDir,
+    PATH: sharedEnv.minimalPath,
+    ...sharedEnv.proxyEnv,
+    NODE_EXTRA_CA_CERTS: sharedEnv.nodeCaCerts,
+    REMOTECLAW_STATE_DIR: sharedEnv.stateDir,
+    REMOTECLAW_CONFIG_PATH: sharedEnv.configPath,
     REMOTECLAW_GATEWAY_TOKEN: gatewayToken,
     REMOTECLAW_LAUNCHD_LABEL: resolveNodeLaunchAgentLabel(),
     REMOTECLAW_SYSTEMD_UNIT: resolveNodeSystemdServiceName(),
@@ -307,5 +290,36 @@ export function buildNodeServiceEnvironment(params: {
     REMOTECLAW_SERVICE_MARKER: NODE_SERVICE_MARKER,
     REMOTECLAW_SERVICE_KIND: NODE_SERVICE_KIND,
     REMOTECLAW_SERVICE_VERSION: VERSION,
+  };
+}
+
+function resolveSharedServiceEnvironmentFields(
+  env: Record<string, string | undefined>,
+  platform: NodeJS.Platform,
+): {
+  stateDir: string | undefined;
+  configPath: string | undefined;
+  tmpDir: string;
+  minimalPath: string;
+  proxyEnv: Record<string, string | undefined>;
+  nodeCaCerts: string | undefined;
+} {
+  const stateDir = env.REMOTECLAW_STATE_DIR;
+  const configPath = env.REMOTECLAW_CONFIG_PATH;
+  // Keep a usable temp directory for supervised services even when the host env omits TMPDIR.
+  const tmpDir = env.TMPDIR?.trim() || os.tmpdir();
+  const proxyEnv = readServiceProxyEnvironment(env);
+  // On macOS, launchd services don't inherit the shell environment, so Node's undici/fetch
+  // cannot locate the system CA bundle. Default to /etc/ssl/cert.pem so TLS verification
+  // works correctly when running as a LaunchAgent without extra user configuration.
+  const nodeCaCerts =
+    env.NODE_EXTRA_CA_CERTS ?? (platform === "darwin" ? "/etc/ssl/cert.pem" : undefined);
+  return {
+    stateDir,
+    configPath,
+    tmpDir,
+    minimalPath: buildMinimalServicePath({ env }),
+    proxyEnv,
+    nodeCaCerts,
   };
 }

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -318,6 +318,40 @@ async function moveToTrashBestEffort(pathname: string): Promise<void> {
   }
 }
 
+function respondWorkspaceFileInvalid(respond: RespondFn, name: string, reason: string): void {
+  respond(
+    false,
+    undefined,
+    errorShape(ErrorCodes.INVALID_REQUEST, `unsafe workspace file "${name}" (${reason})`),
+  );
+}
+
+function respondWorkspaceFileUnsafe(respond: RespondFn, name: string): void {
+  respond(
+    false,
+    undefined,
+    errorShape(ErrorCodes.INVALID_REQUEST, `unsafe workspace file "${name}"`),
+  );
+}
+
+function respondWorkspaceFileMissing(params: {
+  respond: RespondFn;
+  agentId: string;
+  workspaceDir: string;
+  name: string;
+  filePath: string;
+}): void {
+  params.respond(
+    true,
+    {
+      agentId: params.agentId,
+      workspace: params.workspaceDir,
+      file: { name: params.name, path: params.filePath, missing: true },
+    },
+    undefined,
+  );
+}
+
 export const agentsHandlers: GatewayRequestHandlers = {
   "agents.list": ({ params, respond }) => {
     if (!validateAgentsListParams(params)) {
@@ -613,26 +647,11 @@ export const agentsHandlers: GatewayRequestHandlers = {
       allowMissing: true,
     });
     if (resolvedPath.kind === "invalid") {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          `unsafe workspace file "${name}" (${resolvedPath.reason})`,
-        ),
-      );
+      respondWorkspaceFileInvalid(respond, name, resolvedPath.reason);
       return;
     }
     if (resolvedPath.kind === "missing") {
-      respond(
-        true,
-        {
-          agentId,
-          workspace: workspaceDir,
-          file: { name, path: filePath, missing: true },
-        },
-        undefined,
-      );
+      respondWorkspaceFileMissing({ respond, agentId, workspaceDir, name, filePath });
       return;
     }
     let safeRead: Awaited<ReturnType<typeof readLocalFileSafely>>;
@@ -640,22 +659,10 @@ export const agentsHandlers: GatewayRequestHandlers = {
       safeRead = await readLocalFileSafely({ filePath: resolvedPath.ioPath });
     } catch (err) {
       if (err instanceof SafeOpenError && err.code === "not-found") {
-        respond(
-          true,
-          {
-            agentId,
-            workspace: workspaceDir,
-            file: { name, path: filePath, missing: true },
-          },
-          undefined,
-        );
+        respondWorkspaceFileMissing({ respond, agentId, workspaceDir, name, filePath });
         return;
       }
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `unsafe workspace file "${name}"`),
-      );
+      respondWorkspaceFileUnsafe(respond, name);
       return;
     }
     respond(
@@ -733,14 +740,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
       allowMissing: true,
     });
     if (resolvedPath.kind === "invalid") {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          `unsafe workspace file "${name}" (${resolvedPath.reason})`,
-        ),
-      );
+      respondWorkspaceFileInvalid(respond, name, resolvedPath.reason);
       return;
     }
     const parentDir = path.dirname(resolvedPath.ioPath);
@@ -751,11 +751,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     try {
       await writeFileSafely(resolvedPath.ioPath, content);
     } catch {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `unsafe workspace file "${name}"`),
-      );
+      respondWorkspaceFileUnsafe(respond, name);
       return;
     }
     const meta = await statFileSafely(resolvedPath.ioPath);

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
-import { getAcpSessionManager } from "../../acp/control-plane/manager.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import { clearBootstrapSnapshot } from "../../agents/bootstrap-cache.js";
-import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../../agents/pi-embedded.js";
+import {
+  listSubagentRunsForRequester,
+  markSubagentRunTerminated,
+} from "../../agents/subagent-registry.js";
+import { spawnSubagentDirect } from "../../agents/subagent-spawn.js";
 import { stopSubagentsForRequester } from "../../auto-reply/reply/abort.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue.js";
 import { loadConfig } from "../../config/config.js";
@@ -15,7 +17,6 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import { unbindThreadBindingsBySessionKey } from "../../discord/monitor/thread-bindings.js";
-import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import {
@@ -23,7 +24,6 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../../routing/session-key.js";
-import { GATEWAY_CLIENT_IDS } from "../protocol/client-info.js";
 import {
   ErrorCodes,
   errorShape,
@@ -85,9 +85,6 @@ function rejectWebchatSessionMutation(params: {
   respond: RespondFn;
 }): boolean {
   if (!params.client?.connect || !params.isWebchatConnect(params.client.connect)) {
-    return false;
-  }
-  if (params.client.connect.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI) {
     return false;
   }
   params.respond(
@@ -192,122 +189,8 @@ async function ensureSessionRuntimeCleanup(params: {
     queueKeys.add(params.sessionId);
   }
   clearSessionQueues([...queueKeys]);
-  clearBootstrapSnapshot(params.target.canonicalKey);
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
-  if (!params.sessionId) {
-    return undefined;
-  }
-  abortEmbeddedPiRun(params.sessionId);
-  const ended = await waitForEmbeddedPiRunEnd(params.sessionId, 15_000);
-  if (ended) {
-    return undefined;
-  }
-  return errorShape(
-    ErrorCodes.UNAVAILABLE,
-    `Session ${params.key} is still active; try again in a moment.`,
-  );
-}
-
-const ACP_RUNTIME_CLEANUP_TIMEOUT_MS = 15_000;
-
-async function runAcpCleanupStep(params: {
-  op: () => Promise<void>;
-}): Promise<{ status: "ok" } | { status: "timeout" } | { status: "error"; error: unknown }> {
-  let timer: NodeJS.Timeout | undefined;
-  const timeoutPromise = new Promise<{ status: "timeout" }>((resolve) => {
-    timer = setTimeout(() => resolve({ status: "timeout" }), ACP_RUNTIME_CLEANUP_TIMEOUT_MS);
-  });
-  const opPromise = params
-    .op()
-    .then(() => ({ status: "ok" as const }))
-    .catch((error: unknown) => ({ status: "error" as const, error }));
-  const outcome = await Promise.race([opPromise, timeoutPromise]);
-  if (timer) {
-    clearTimeout(timer);
-  }
-  return outcome;
-}
-
-async function closeAcpRuntimeForSession(params: {
-  cfg: ReturnType<typeof loadConfig>;
-  sessionKey: string;
-  entry?: SessionEntry;
-  reason: "session-reset" | "session-delete";
-}) {
-  if (!params.entry?.acp) {
-    return undefined;
-  }
-  const acpManager = getAcpSessionManager();
-  const cancelOutcome = await runAcpCleanupStep({
-    op: async () => {
-      await acpManager.cancelSession({
-        cfg: params.cfg,
-        sessionKey: params.sessionKey,
-        reason: params.reason,
-      });
-    },
-  });
-  if (cancelOutcome.status === "timeout") {
-    return errorShape(
-      ErrorCodes.UNAVAILABLE,
-      `Session ${params.sessionKey} is still active; try again in a moment.`,
-    );
-  }
-  if (cancelOutcome.status === "error") {
-    logVerbose(
-      `sessions.${params.reason}: ACP cancel failed for ${params.sessionKey}: ${String(cancelOutcome.error)}`,
-    );
-  }
-
-  const closeOutcome = await runAcpCleanupStep({
-    op: async () => {
-      await acpManager.closeSession({
-        cfg: params.cfg,
-        sessionKey: params.sessionKey,
-        reason: params.reason,
-        requireAcpSession: false,
-        allowBackendUnavailable: true,
-      });
-    },
-  });
-  if (closeOutcome.status === "timeout") {
-    return errorShape(
-      ErrorCodes.UNAVAILABLE,
-      `Session ${params.sessionKey} is still active; try again in a moment.`,
-    );
-  }
-  if (closeOutcome.status === "error") {
-    logVerbose(
-      `sessions.${params.reason}: ACP runtime close failed for ${params.sessionKey}: ${String(closeOutcome.error)}`,
-    );
-  }
   return undefined;
-}
-
-async function cleanupSessionBeforeMutation(params: {
-  cfg: ReturnType<typeof loadConfig>;
-  key: string;
-  target: ReturnType<typeof resolveGatewaySessionStoreTarget>;
-  entry: SessionEntry | undefined;
-  legacyKey?: string;
-  canonicalKey?: string;
-  reason: "session-reset" | "session-delete";
-}) {
-  const cleanupError = await ensureSessionRuntimeCleanup({
-    cfg: params.cfg,
-    key: params.key,
-    target: params.target,
-    sessionId: params.entry?.sessionId,
-  });
-  if (cleanupError) {
-    return cleanupError;
-  }
-  return await closeAcpRuntimeForSession({
-    cfg: params.cfg,
-    sessionKey: params.legacyKey ?? params.canonicalKey ?? params.target.canonicalKey ?? params.key,
-    entry: params.entry,
-    reason: params.reason,
-  });
 }
 
 export const sessionsHandlers: GatewayRequestHandlers = {
@@ -402,7 +285,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     }
     respond(true, { ok: true, key: resolved.key }, undefined);
   },
-  "sessions.patch": async ({ params, respond, context, client, isWebchatConnect }) => {
+  "sessions.patch": async ({ params, respond, client, isWebchatConnect }) => {
     if (!assertValidParams(params, validateSessionsPatchParams, "sessions.patch", respond)) {
       return;
     }
@@ -423,7 +306,6 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         store,
         storeKey: primaryKey,
         patch: p,
-        loadGatewayModelCatalog: context.loadGatewayModelCatalog,
       });
     });
     if (!applied.ok) {
@@ -456,7 +338,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     }
 
     const { cfg, target, storePath } = resolveGatewaySessionTargetFromKey(key);
-    const { entry, legacyKey, canonicalKey } = loadSessionEntry(key);
+    const { entry } = loadSessionEntry(key);
     const hadExistingEntry = Boolean(entry);
     const commandReason = p.reason === "new" ? "new" : "reset";
     const hookEvent = createInternalHookEvent(
@@ -471,17 +353,10 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       },
     );
     await triggerInternalHook(hookEvent);
-    const mutationCleanupError = await cleanupSessionBeforeMutation({
-      cfg,
-      key,
-      target,
-      entry,
-      legacyKey,
-      canonicalKey,
-      reason: "session-reset",
-    });
-    if (mutationCleanupError) {
-      respond(false, undefined, mutationCleanupError);
+    const sessionId = entry?.sessionId;
+    const cleanupError = await ensureSessionRuntimeCleanup({ cfg, key, target, sessionId });
+    if (cleanupError) {
+      respond(false, undefined, cleanupError);
       return;
     }
     let oldSessionId: string | undefined;
@@ -489,9 +364,6 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const next = await updateSessionStore(storePath, (store) => {
       const { primaryKey } = migrateAndPruneSessionStoreKey({ cfg, key, store });
       const entry = store[primaryKey];
-      const parsed = parseAgentSessionKey(primaryKey);
-      const sessionAgentId = normalizeAgentId(parsed?.agentId ?? resolveDefaultAgentId(cfg));
-      const resolvedModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
       oldSessionId = entry?.sessionId;
       oldSessionFile = entry?.sessionFile;
       const now = Date.now();
@@ -500,19 +372,16 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         updatedAt: now,
         systemSent: false,
         abortedLastRun: false,
-        thinkingLevel: entry?.thinkingLevel,
         verboseLevel: entry?.verboseLevel,
-        reasoningLevel: entry?.reasoningLevel,
         responseUsage: entry?.responseUsage,
-        model: resolvedModel.model,
-        modelProvider: resolvedModel.provider,
+        model: entry?.model,
+        modelProvider: entry?.modelProvider,
         contextTokens: entry?.contextTokens,
         sendPolicy: entry?.sendPolicy,
         label: entry?.label,
         origin: snapshotSessionOrigin(entry),
         lastChannel: entry?.lastChannel,
         lastTo: entry?.lastTo,
-        skillsSnapshot: entry?.skillsSnapshot,
         // Reset token counts to 0 on session reset (#1523)
         inputTokens: 0,
         outputTokens: 0,
@@ -564,21 +433,13 @@ export const sessionsHandlers: GatewayRequestHandlers = {
 
     const deleteTranscript = typeof p.deleteTranscript === "boolean" ? p.deleteTranscript : true;
 
-    const { entry, legacyKey, canonicalKey } = loadSessionEntry(key);
-    const mutationCleanupError = await cleanupSessionBeforeMutation({
-      cfg,
-      key,
-      target,
-      entry,
-      legacyKey,
-      canonicalKey,
-      reason: "session-delete",
-    });
-    if (mutationCleanupError) {
-      respond(false, undefined, mutationCleanupError);
+    const { entry } = loadSessionEntry(key);
+    const sessionId = entry?.sessionId;
+    const cleanupError = await ensureSessionRuntimeCleanup({ cfg, key, target, sessionId });
+    if (cleanupError) {
+      respond(false, undefined, cleanupError);
       return;
     }
-    const sessionId = entry?.sessionId;
     const deleted = await updateSessionStore(storePath, (store) => {
       const { primaryKey } = migrateAndPruneSessionStoreKey({ cfg, key, store });
       const hadEntry = Boolean(store[primaryKey]);
@@ -709,6 +570,75 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         kept: keptLines.length,
       },
       undefined,
+    );
+  },
+  "sessions.spawn": async ({ params, respond }) => {
+    const task = typeof params.task === "string" ? params.task.trim() : "";
+    if (!task) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "task is required"));
+      return;
+    }
+    const agentId =
+      typeof params.agentId === "string" ? params.agentId.trim() || undefined : undefined;
+    const label = typeof params.label === "string" ? params.label.trim() || undefined : undefined;
+    const sessionKey =
+      typeof params.sessionKey === "string" ? params.sessionKey.trim() || undefined : undefined;
+
+    try {
+      const result = await spawnSubagentDirect(
+        { task, agentId, label },
+        { agentSessionKey: sessionKey },
+      );
+      respond(true, result, undefined);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, message));
+    }
+  },
+  "sessions.subagents": ({ params, respond }) => {
+    const action = typeof params.action === "string" ? params.action.trim() : "list";
+    const sessionKey = typeof params.sessionKey === "string" ? params.sessionKey.trim() : "";
+    if (!sessionKey) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "sessionKey is required"));
+      return;
+    }
+
+    if (action === "list") {
+      const runs = listSubagentRunsForRequester(sessionKey);
+      respond(true, { status: "ok", action: "list", runs }, undefined);
+      return;
+    }
+
+    if (action === "status") {
+      const runId = typeof params.runId === "string" ? params.runId.trim() : "";
+      const runs = listSubagentRunsForRequester(sessionKey);
+      if (runId) {
+        const run = runs.find((r) => r.runId === runId);
+        respond(true, { status: "ok", action: "status", run: run ?? null }, undefined);
+      } else {
+        respond(true, { status: "ok", action: "status", runs }, undefined);
+      }
+      return;
+    }
+
+    if (action === "cancel") {
+      const runId = typeof params.runId === "string" ? params.runId.trim() : "";
+      const childSessionKey =
+        typeof params.childSessionKey === "string" ? params.childSessionKey.trim() : "";
+      const reason = typeof params.reason === "string" ? params.reason.trim() : "cancelled";
+      const terminated = markSubagentRunTerminated({
+        runId: runId || undefined,
+        childSessionKey: childSessionKey || undefined,
+        reason,
+      });
+      respond(true, { status: "ok", action: "cancel", terminated }, undefined);
+      return;
+    }
+
+    respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.INVALID_REQUEST, `unsupported action: ${action}`),
     );
   },
 };

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1,11 +1,9 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
+import { getAcpSessionManager } from "../../acp/control-plane/manager.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import {
-  listSubagentRunsForRequester,
-  markSubagentRunTerminated,
-} from "../../agents/subagent-registry.js";
-import { spawnSubagentDirect } from "../../agents/subagent-spawn.js";
+import { clearBootstrapSnapshot } from "../../agents/bootstrap-cache.js";
+import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../../agents/pi-embedded.js";
 import { stopSubagentsForRequester } from "../../auto-reply/reply/abort.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue.js";
 import { loadConfig } from "../../config/config.js";
@@ -17,6 +15,7 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import { unbindThreadBindingsBySessionKey } from "../../discord/monitor/thread-bindings.js";
+import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import {
@@ -24,6 +23,7 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../../routing/session-key.js";
+import { GATEWAY_CLIENT_IDS } from "../protocol/client-info.js";
 import {
   ErrorCodes,
   errorShape,
@@ -85,6 +85,9 @@ function rejectWebchatSessionMutation(params: {
   respond: RespondFn;
 }): boolean {
   if (!params.client?.connect || !params.isWebchatConnect(params.client.connect)) {
+    return false;
+  }
+  if (params.client.connect.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI) {
     return false;
   }
   params.respond(
@@ -189,8 +192,122 @@ async function ensureSessionRuntimeCleanup(params: {
     queueKeys.add(params.sessionId);
   }
   clearSessionQueues([...queueKeys]);
+  clearBootstrapSnapshot(params.target.canonicalKey);
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
+  if (!params.sessionId) {
+    return undefined;
+  }
+  abortEmbeddedPiRun(params.sessionId);
+  const ended = await waitForEmbeddedPiRunEnd(params.sessionId, 15_000);
+  if (ended) {
+    return undefined;
+  }
+  return errorShape(
+    ErrorCodes.UNAVAILABLE,
+    `Session ${params.key} is still active; try again in a moment.`,
+  );
+}
+
+const ACP_RUNTIME_CLEANUP_TIMEOUT_MS = 15_000;
+
+async function runAcpCleanupStep(params: {
+  op: () => Promise<void>;
+}): Promise<{ status: "ok" } | { status: "timeout" } | { status: "error"; error: unknown }> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<{ status: "timeout" }>((resolve) => {
+    timer = setTimeout(() => resolve({ status: "timeout" }), ACP_RUNTIME_CLEANUP_TIMEOUT_MS);
+  });
+  const opPromise = params
+    .op()
+    .then(() => ({ status: "ok" as const }))
+    .catch((error: unknown) => ({ status: "error" as const, error }));
+  const outcome = await Promise.race([opPromise, timeoutPromise]);
+  if (timer) {
+    clearTimeout(timer);
+  }
+  return outcome;
+}
+
+async function closeAcpRuntimeForSession(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  sessionKey: string;
+  entry?: SessionEntry;
+  reason: "session-reset" | "session-delete";
+}) {
+  if (!params.entry?.acp) {
+    return undefined;
+  }
+  const acpManager = getAcpSessionManager();
+  const cancelOutcome = await runAcpCleanupStep({
+    op: async () => {
+      await acpManager.cancelSession({
+        cfg: params.cfg,
+        sessionKey: params.sessionKey,
+        reason: params.reason,
+      });
+    },
+  });
+  if (cancelOutcome.status === "timeout") {
+    return errorShape(
+      ErrorCodes.UNAVAILABLE,
+      `Session ${params.sessionKey} is still active; try again in a moment.`,
+    );
+  }
+  if (cancelOutcome.status === "error") {
+    logVerbose(
+      `sessions.${params.reason}: ACP cancel failed for ${params.sessionKey}: ${String(cancelOutcome.error)}`,
+    );
+  }
+
+  const closeOutcome = await runAcpCleanupStep({
+    op: async () => {
+      await acpManager.closeSession({
+        cfg: params.cfg,
+        sessionKey: params.sessionKey,
+        reason: params.reason,
+        requireAcpSession: false,
+        allowBackendUnavailable: true,
+      });
+    },
+  });
+  if (closeOutcome.status === "timeout") {
+    return errorShape(
+      ErrorCodes.UNAVAILABLE,
+      `Session ${params.sessionKey} is still active; try again in a moment.`,
+    );
+  }
+  if (closeOutcome.status === "error") {
+    logVerbose(
+      `sessions.${params.reason}: ACP runtime close failed for ${params.sessionKey}: ${String(closeOutcome.error)}`,
+    );
+  }
   return undefined;
+}
+
+async function cleanupSessionBeforeMutation(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  key: string;
+  target: ReturnType<typeof resolveGatewaySessionStoreTarget>;
+  entry: SessionEntry | undefined;
+  legacyKey?: string;
+  canonicalKey?: string;
+  reason: "session-reset" | "session-delete";
+}) {
+  const cleanupError = await ensureSessionRuntimeCleanup({
+    cfg: params.cfg,
+    key: params.key,
+    target: params.target,
+    sessionId: params.entry?.sessionId,
+  });
+  if (cleanupError) {
+    return cleanupError;
+  }
+  return await closeAcpRuntimeForSession({
+    cfg: params.cfg,
+    sessionKey: params.legacyKey ?? params.canonicalKey ?? params.target.canonicalKey ?? params.key,
+    entry: params.entry,
+    reason: params.reason,
+  });
 }
 
 export const sessionsHandlers: GatewayRequestHandlers = {
@@ -285,7 +402,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     }
     respond(true, { ok: true, key: resolved.key }, undefined);
   },
-  "sessions.patch": async ({ params, respond, client, isWebchatConnect }) => {
+  "sessions.patch": async ({ params, respond, context, client, isWebchatConnect }) => {
     if (!assertValidParams(params, validateSessionsPatchParams, "sessions.patch", respond)) {
       return;
     }
@@ -306,6 +423,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         store,
         storeKey: primaryKey,
         patch: p,
+        loadGatewayModelCatalog: context.loadGatewayModelCatalog,
       });
     });
     if (!applied.ok) {
@@ -338,7 +456,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     }
 
     const { cfg, target, storePath } = resolveGatewaySessionTargetFromKey(key);
-    const { entry } = loadSessionEntry(key);
+    const { entry, legacyKey, canonicalKey } = loadSessionEntry(key);
     const hadExistingEntry = Boolean(entry);
     const commandReason = p.reason === "new" ? "new" : "reset";
     const hookEvent = createInternalHookEvent(
@@ -353,10 +471,17 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       },
     );
     await triggerInternalHook(hookEvent);
-    const sessionId = entry?.sessionId;
-    const cleanupError = await ensureSessionRuntimeCleanup({ cfg, key, target, sessionId });
-    if (cleanupError) {
-      respond(false, undefined, cleanupError);
+    const mutationCleanupError = await cleanupSessionBeforeMutation({
+      cfg,
+      key,
+      target,
+      entry,
+      legacyKey,
+      canonicalKey,
+      reason: "session-reset",
+    });
+    if (mutationCleanupError) {
+      respond(false, undefined, mutationCleanupError);
       return;
     }
     let oldSessionId: string | undefined;
@@ -364,6 +489,9 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const next = await updateSessionStore(storePath, (store) => {
       const { primaryKey } = migrateAndPruneSessionStoreKey({ cfg, key, store });
       const entry = store[primaryKey];
+      const parsed = parseAgentSessionKey(primaryKey);
+      const sessionAgentId = normalizeAgentId(parsed?.agentId ?? resolveDefaultAgentId(cfg));
+      const resolvedModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
       oldSessionId = entry?.sessionId;
       oldSessionFile = entry?.sessionFile;
       const now = Date.now();
@@ -372,16 +500,19 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         updatedAt: now,
         systemSent: false,
         abortedLastRun: false,
+        thinkingLevel: entry?.thinkingLevel,
         verboseLevel: entry?.verboseLevel,
+        reasoningLevel: entry?.reasoningLevel,
         responseUsage: entry?.responseUsage,
-        model: entry?.model,
-        modelProvider: entry?.modelProvider,
+        model: resolvedModel.model,
+        modelProvider: resolvedModel.provider,
         contextTokens: entry?.contextTokens,
         sendPolicy: entry?.sendPolicy,
         label: entry?.label,
         origin: snapshotSessionOrigin(entry),
         lastChannel: entry?.lastChannel,
         lastTo: entry?.lastTo,
+        skillsSnapshot: entry?.skillsSnapshot,
         // Reset token counts to 0 on session reset (#1523)
         inputTokens: 0,
         outputTokens: 0,
@@ -433,13 +564,21 @@ export const sessionsHandlers: GatewayRequestHandlers = {
 
     const deleteTranscript = typeof p.deleteTranscript === "boolean" ? p.deleteTranscript : true;
 
-    const { entry } = loadSessionEntry(key);
-    const sessionId = entry?.sessionId;
-    const cleanupError = await ensureSessionRuntimeCleanup({ cfg, key, target, sessionId });
-    if (cleanupError) {
-      respond(false, undefined, cleanupError);
+    const { entry, legacyKey, canonicalKey } = loadSessionEntry(key);
+    const mutationCleanupError = await cleanupSessionBeforeMutation({
+      cfg,
+      key,
+      target,
+      entry,
+      legacyKey,
+      canonicalKey,
+      reason: "session-delete",
+    });
+    if (mutationCleanupError) {
+      respond(false, undefined, mutationCleanupError);
       return;
     }
+    const sessionId = entry?.sessionId;
     const deleted = await updateSessionStore(storePath, (store) => {
       const { primaryKey } = migrateAndPruneSessionStoreKey({ cfg, key, store });
       const hadEntry = Boolean(store[primaryKey]);
@@ -570,75 +709,6 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         kept: keptLines.length,
       },
       undefined,
-    );
-  },
-  "sessions.spawn": async ({ params, respond }) => {
-    const task = typeof params.task === "string" ? params.task.trim() : "";
-    if (!task) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "task is required"));
-      return;
-    }
-    const agentId =
-      typeof params.agentId === "string" ? params.agentId.trim() || undefined : undefined;
-    const label = typeof params.label === "string" ? params.label.trim() || undefined : undefined;
-    const sessionKey =
-      typeof params.sessionKey === "string" ? params.sessionKey.trim() || undefined : undefined;
-
-    try {
-      const result = await spawnSubagentDirect(
-        { task, agentId, label },
-        { agentSessionKey: sessionKey },
-      );
-      respond(true, result, undefined);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, message));
-    }
-  },
-  "sessions.subagents": ({ params, respond }) => {
-    const action = typeof params.action === "string" ? params.action.trim() : "list";
-    const sessionKey = typeof params.sessionKey === "string" ? params.sessionKey.trim() : "";
-    if (!sessionKey) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "sessionKey is required"));
-      return;
-    }
-
-    if (action === "list") {
-      const runs = listSubagentRunsForRequester(sessionKey);
-      respond(true, { status: "ok", action: "list", runs }, undefined);
-      return;
-    }
-
-    if (action === "status") {
-      const runId = typeof params.runId === "string" ? params.runId.trim() : "";
-      const runs = listSubagentRunsForRequester(sessionKey);
-      if (runId) {
-        const run = runs.find((r) => r.runId === runId);
-        respond(true, { status: "ok", action: "status", run: run ?? null }, undefined);
-      } else {
-        respond(true, { status: "ok", action: "status", runs }, undefined);
-      }
-      return;
-    }
-
-    if (action === "cancel") {
-      const runId = typeof params.runId === "string" ? params.runId.trim() : "";
-      const childSessionKey =
-        typeof params.childSessionKey === "string" ? params.childSessionKey.trim() : "";
-      const reason = typeof params.reason === "string" ? params.reason.trim() : "cancelled";
-      const terminated = markSubagentRunTerminated({
-        runId: runId || undefined,
-        childSessionKey: childSessionKey || undefined,
-        reason,
-      });
-      respond(true, { status: "ok", action: "cancel", terminated }, undefined);
-      return;
-    }
-
-    respond(
-      false,
-      undefined,
-      errorShape(ErrorCodes.INVALID_REQUEST, `unsupported action: ${action}`),
     );
   },
 };

--- a/src/infra/executable-path.ts
+++ b/src/infra/executable-path.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+import { expandHomePrefix } from "./home-dir.js";
+
+function resolveWindowsExecutableExtensions(
+  executable: string,
+  env: NodeJS.ProcessEnv | undefined,
+): string[] {
+  if (process.platform !== "win32") {
+    return [""];
+  }
+  if (path.extname(executable).length > 0) {
+    return [""];
+  }
+  return (
+    env?.PATHEXT ??
+    env?.Pathext ??
+    process.env.PATHEXT ??
+    process.env.Pathext ??
+    ".EXE;.CMD;.BAT;.COM"
+  )
+    .split(";")
+    .map((ext) => ext.toLowerCase());
+}
+
+export function isExecutableFile(filePath: string): boolean {
+  try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile()) {
+      return false;
+    }
+    if (process.platform !== "win32") {
+      fs.accessSync(filePath, fs.constants.X_OK);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function resolveExecutableFromPathEnv(
+  executable: string,
+  pathEnv: string,
+  env?: NodeJS.ProcessEnv,
+): string | undefined {
+  const entries = pathEnv.split(path.delimiter).filter(Boolean);
+  const extensions = resolveWindowsExecutableExtensions(executable, env);
+  for (const entry of entries) {
+    for (const ext of extensions) {
+      const candidate = path.join(entry, executable + ext);
+      if (isExecutableFile(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return undefined;
+}
+
+export function resolveExecutablePath(
+  rawExecutable: string,
+  options?: { cwd?: string; env?: NodeJS.ProcessEnv },
+): string | undefined {
+  const expanded = rawExecutable.startsWith("~") ? expandHomePrefix(rawExecutable) : rawExecutable;
+  if (expanded.includes("/") || expanded.includes("\\")) {
+    if (path.isAbsolute(expanded)) {
+      return isExecutableFile(expanded) ? expanded : undefined;
+    }
+    const base = options?.cwd && options.cwd.trim() ? options.cwd.trim() : process.cwd();
+    const candidate = path.resolve(base, expanded);
+    return isExecutableFile(candidate) ? candidate : undefined;
+  }
+  const envPath =
+    options?.env?.PATH ?? options?.env?.Path ?? process.env.PATH ?? process.env.Path ?? "";
+  return resolveExecutableFromPathEnv(expanded, envPath, options?.env);
+}

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -6,7 +6,6 @@ import os from "node:os";
 import path from "node:path";
 import { sameFileIdentity } from "./file-identity.js";
 import { expandHomePrefix } from "./home-dir.js";
-import { assertNoPathAliasEscape } from "./path-alias-guards.js";
 import {
   hasNodeErrorCode,
   isNotFoundPathError,
@@ -47,13 +46,6 @@ export type SafeLocalReadResult = {
 
 const SUPPORTS_NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in fsConstants;
 const OPEN_READ_FLAGS = fsConstants.O_RDONLY | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
-const OPEN_WRITE_EXISTING_FLAGS =
-  fsConstants.O_WRONLY | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
-const OPEN_WRITE_CREATE_FLAGS =
-  fsConstants.O_WRONLY |
-  fsConstants.O_CREAT |
-  fsConstants.O_EXCL |
-  (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
 
 const ensureTrailingSep = (value: string) => (value.endsWith(path.sep) ? value : value + path.sep);
 
@@ -67,14 +59,9 @@ async function expandRelativePathWithHome(relativePath: string): Promise<string>
   return expandHomePrefix(relativePath, { home });
 }
 
-async function openVerifiedLocalFile(
-  filePath: string,
-  options?: {
-    rejectHardlinks?: boolean;
-  },
-): Promise<SafeOpenResult> {
+async function openVerifiedLocalFile(filePath: string): Promise<SafeOpenResult> {
   // Reject directories before opening so we never surface EISDIR to callers (e.g. tool
-  // results that get sent to messaging channels). See remoteclaw/remoteclaw#31186.
+  // results that get sent to messaging channels). See openclaw/openclaw#31186.
   try {
     const preStat = await fs.lstat(filePath);
     if (preStat.isDirectory()) {
@@ -112,18 +99,12 @@ async function openVerifiedLocalFile(
     if (!stat.isFile()) {
       throw new SafeOpenError("not-file", "not a file");
     }
-    if (options?.rejectHardlinks && stat.nlink > 1) {
-      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
-    }
     if (!sameFileIdentity(stat, lstat)) {
       throw new SafeOpenError("path-mismatch", "path changed during read");
     }
 
     const realPath = await fs.realpath(filePath);
     const realStat = await fs.stat(realPath);
-    if (options?.rejectHardlinks && realStat.nlink > 1) {
-      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
-    }
     if (!sameFileIdentity(stat, realStat)) {
       throw new SafeOpenError("path-mismatch", "path mismatch");
     }
@@ -185,11 +166,6 @@ export async function openFileWithinRoot(params: {
     throw err;
   }
 
-  if (params.rejectHardlinks !== false && opened.stat.nlink > 1) {
-    await opened.handle.close().catch(() => {});
-    throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
-  }
-
   if (!isPathInside(rootWithSep, opened.realPath)) {
     await opened.handle.close().catch(() => {});
     throw new SafeOpenError("outside-workspace", "file is outside workspace root");
@@ -198,191 +174,21 @@ export async function openFileWithinRoot(params: {
   return opened;
 }
 
-export async function readFileWithinRoot(params: {
-  rootDir: string;
-  relativePath: string;
-  rejectHardlinks?: boolean;
-  maxBytes?: number;
-}): Promise<SafeLocalReadResult> {
-  const opened = await openFileWithinRoot({
-    rootDir: params.rootDir,
-    relativePath: params.relativePath,
-    rejectHardlinks: params.rejectHardlinks,
-  });
-  try {
-    return await readOpenedFileSafely({ opened, maxBytes: params.maxBytes });
-  } finally {
-    await opened.handle.close().catch(() => {});
-  }
-}
-
-export async function readPathWithinRoot(params: {
-  rootDir: string;
-  filePath: string;
-  rejectHardlinks?: boolean;
-  maxBytes?: number;
-}): Promise<SafeLocalReadResult> {
-  const rootDir = path.resolve(params.rootDir);
-  const candidatePath = path.isAbsolute(params.filePath)
-    ? path.resolve(params.filePath)
-    : path.resolve(rootDir, params.filePath);
-  const relativePath = path.relative(rootDir, candidatePath);
-  return await readFileWithinRoot({
-    rootDir,
-    relativePath,
-    rejectHardlinks: params.rejectHardlinks,
-    maxBytes: params.maxBytes,
-  });
-}
-
-export function createRootScopedReadFile(params: {
-  rootDir: string;
-  rejectHardlinks?: boolean;
-  maxBytes?: number;
-}): (filePath: string) => Promise<Buffer> {
-  const rootDir = path.resolve(params.rootDir);
-  return async (filePath: string) => {
-    const safeRead = await readPathWithinRoot({
-      rootDir,
-      filePath,
-      rejectHardlinks: params.rejectHardlinks,
-      maxBytes: params.maxBytes,
-    });
-    return safeRead.buffer;
-  };
-}
-
 export async function readLocalFileSafely(params: {
   filePath: string;
   maxBytes?: number;
 }): Promise<SafeLocalReadResult> {
   const opened = await openVerifiedLocalFile(params.filePath);
   try {
-    return await readOpenedFileSafely({ opened, maxBytes: params.maxBytes });
+    if (params.maxBytes !== undefined && opened.stat.size > params.maxBytes) {
+      throw new SafeOpenError(
+        "too-large",
+        `file exceeds limit of ${params.maxBytes} bytes (got ${opened.stat.size})`,
+      );
+    }
+    const buffer = await opened.handle.readFile();
+    return { buffer, realPath: opened.realPath, stat: opened.stat };
   } finally {
     await opened.handle.close().catch(() => {});
-  }
-}
-
-async function readOpenedFileSafely(params: {
-  opened: SafeOpenResult;
-  maxBytes?: number;
-}): Promise<SafeLocalReadResult> {
-  if (params.maxBytes !== undefined && params.opened.stat.size > params.maxBytes) {
-    throw new SafeOpenError(
-      "too-large",
-      `file exceeds limit of ${params.maxBytes} bytes (got ${params.opened.stat.size})`,
-    );
-  }
-  const buffer = await params.opened.handle.readFile();
-  return {
-    buffer,
-    realPath: params.opened.realPath,
-    stat: params.opened.stat,
-  };
-}
-
-export async function writeFileWithinRoot(params: {
-  rootDir: string;
-  relativePath: string;
-  data: string | Buffer;
-  encoding?: BufferEncoding;
-  mkdir?: boolean;
-}): Promise<void> {
-  const { rootReal, rootWithSep, resolved } = await resolvePathWithinRoot(params);
-  try {
-    await assertNoPathAliasEscape({
-      absolutePath: resolved,
-      rootPath: rootReal,
-      boundaryLabel: "root",
-    });
-  } catch (err) {
-    throw new SafeOpenError("invalid-path", "path alias escape blocked", { cause: err });
-  }
-  if (params.mkdir !== false) {
-    await fs.mkdir(path.dirname(resolved), { recursive: true });
-  }
-
-  let ioPath = resolved;
-  try {
-    const resolvedRealPath = await fs.realpath(resolved);
-    if (!isPathInside(rootWithSep, resolvedRealPath)) {
-      throw new SafeOpenError("outside-workspace", "file is outside workspace root");
-    }
-    ioPath = resolvedRealPath;
-  } catch (err) {
-    if (err instanceof SafeOpenError) {
-      throw err;
-    }
-    if (!isNotFoundPathError(err)) {
-      throw err;
-    }
-  }
-
-  let handle: FileHandle;
-  let createdForWrite = false;
-  try {
-    try {
-      handle = await fs.open(ioPath, OPEN_WRITE_EXISTING_FLAGS, 0o600);
-    } catch (err) {
-      if (!isNotFoundPathError(err)) {
-        throw err;
-      }
-      handle = await fs.open(ioPath, OPEN_WRITE_CREATE_FLAGS, 0o600);
-      createdForWrite = true;
-    }
-  } catch (err) {
-    if (isNotFoundPathError(err)) {
-      throw new SafeOpenError("not-found", "file not found");
-    }
-    if (isSymlinkOpenError(err)) {
-      throw new SafeOpenError("invalid-path", "symlink open blocked", { cause: err });
-    }
-    throw err;
-  }
-
-  let openedRealPath: string | null = null;
-  try {
-    const [stat, lstat] = await Promise.all([handle.stat(), fs.lstat(ioPath)]);
-    if (lstat.isSymbolicLink() || !stat.isFile()) {
-      throw new SafeOpenError("invalid-path", "path is not a regular file under root");
-    }
-    if (stat.nlink > 1) {
-      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
-    }
-    if (!sameFileIdentity(stat, lstat)) {
-      throw new SafeOpenError("path-mismatch", "path changed during write");
-    }
-
-    const realPath = await fs.realpath(ioPath);
-    openedRealPath = realPath;
-    const realStat = await fs.stat(realPath);
-    if (!sameFileIdentity(stat, realStat)) {
-      throw new SafeOpenError("path-mismatch", "path mismatch");
-    }
-    if (realStat.nlink > 1) {
-      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
-    }
-    if (!isPathInside(rootWithSep, realPath)) {
-      throw new SafeOpenError("outside-workspace", "file is outside workspace root");
-    }
-
-    // Truncate only after boundary and identity checks complete. This avoids
-    // irreversible side effects if a symlink target changes before validation.
-    if (!createdForWrite) {
-      await handle.truncate(0);
-    }
-    if (typeof params.data === "string") {
-      await handle.writeFile(params.data, params.encoding ?? "utf8");
-    } else {
-      await handle.writeFile(params.data);
-    }
-  } catch (err) {
-    if (createdForWrite && err instanceof SafeOpenError && openedRealPath) {
-      await fs.rm(openedRealPath, { force: true }).catch(() => {});
-    }
-    throw err;
-  } finally {
-    await handle.close().catch(() => {});
   }
 }

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { sameFileIdentity } from "./file-identity.js";
 import { expandHomePrefix } from "./home-dir.js";
+import { assertNoPathAliasEscape } from "./path-alias-guards.js";
 import {
   hasNodeErrorCode,
   isNotFoundPathError,
@@ -46,6 +47,13 @@ export type SafeLocalReadResult = {
 
 const SUPPORTS_NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in fsConstants;
 const OPEN_READ_FLAGS = fsConstants.O_RDONLY | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+const OPEN_WRITE_EXISTING_FLAGS =
+  fsConstants.O_WRONLY | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+const OPEN_WRITE_CREATE_FLAGS =
+  fsConstants.O_WRONLY |
+  fsConstants.O_CREAT |
+  fsConstants.O_EXCL |
+  (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
 
 const ensureTrailingSep = (value: string) => (value.endsWith(path.sep) ? value : value + path.sep);
 
@@ -59,9 +67,14 @@ async function expandRelativePathWithHome(relativePath: string): Promise<string>
   return expandHomePrefix(relativePath, { home });
 }
 
-async function openVerifiedLocalFile(filePath: string): Promise<SafeOpenResult> {
+async function openVerifiedLocalFile(
+  filePath: string,
+  options?: {
+    rejectHardlinks?: boolean;
+  },
+): Promise<SafeOpenResult> {
   // Reject directories before opening so we never surface EISDIR to callers (e.g. tool
-  // results that get sent to messaging channels). See openclaw/openclaw#31186.
+  // results that get sent to messaging channels). See remoteclaw/remoteclaw#31186.
   try {
     const preStat = await fs.lstat(filePath);
     if (preStat.isDirectory()) {
@@ -99,12 +112,18 @@ async function openVerifiedLocalFile(filePath: string): Promise<SafeOpenResult> 
     if (!stat.isFile()) {
       throw new SafeOpenError("not-file", "not a file");
     }
+    if (options?.rejectHardlinks && stat.nlink > 1) {
+      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+    }
     if (!sameFileIdentity(stat, lstat)) {
       throw new SafeOpenError("path-mismatch", "path changed during read");
     }
 
     const realPath = await fs.realpath(filePath);
     const realStat = await fs.stat(realPath);
+    if (options?.rejectHardlinks && realStat.nlink > 1) {
+      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+    }
     if (!sameFileIdentity(stat, realStat)) {
       throw new SafeOpenError("path-mismatch", "path mismatch");
     }
@@ -166,6 +185,11 @@ export async function openFileWithinRoot(params: {
     throw err;
   }
 
+  if (params.rejectHardlinks !== false && opened.stat.nlink > 1) {
+    await opened.handle.close().catch(() => {});
+    throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+  }
+
   if (!isPathInside(rootWithSep, opened.realPath)) {
     await opened.handle.close().catch(() => {});
     throw new SafeOpenError("outside-workspace", "file is outside workspace root");
@@ -174,21 +198,191 @@ export async function openFileWithinRoot(params: {
   return opened;
 }
 
+export async function readFileWithinRoot(params: {
+  rootDir: string;
+  relativePath: string;
+  rejectHardlinks?: boolean;
+  maxBytes?: number;
+}): Promise<SafeLocalReadResult> {
+  const opened = await openFileWithinRoot({
+    rootDir: params.rootDir,
+    relativePath: params.relativePath,
+    rejectHardlinks: params.rejectHardlinks,
+  });
+  try {
+    return await readOpenedFileSafely({ opened, maxBytes: params.maxBytes });
+  } finally {
+    await opened.handle.close().catch(() => {});
+  }
+}
+
+export async function readPathWithinRoot(params: {
+  rootDir: string;
+  filePath: string;
+  rejectHardlinks?: boolean;
+  maxBytes?: number;
+}): Promise<SafeLocalReadResult> {
+  const rootDir = path.resolve(params.rootDir);
+  const candidatePath = path.isAbsolute(params.filePath)
+    ? path.resolve(params.filePath)
+    : path.resolve(rootDir, params.filePath);
+  const relativePath = path.relative(rootDir, candidatePath);
+  return await readFileWithinRoot({
+    rootDir,
+    relativePath,
+    rejectHardlinks: params.rejectHardlinks,
+    maxBytes: params.maxBytes,
+  });
+}
+
+export function createRootScopedReadFile(params: {
+  rootDir: string;
+  rejectHardlinks?: boolean;
+  maxBytes?: number;
+}): (filePath: string) => Promise<Buffer> {
+  const rootDir = path.resolve(params.rootDir);
+  return async (filePath: string) => {
+    const safeRead = await readPathWithinRoot({
+      rootDir,
+      filePath,
+      rejectHardlinks: params.rejectHardlinks,
+      maxBytes: params.maxBytes,
+    });
+    return safeRead.buffer;
+  };
+}
+
 export async function readLocalFileSafely(params: {
   filePath: string;
   maxBytes?: number;
 }): Promise<SafeLocalReadResult> {
   const opened = await openVerifiedLocalFile(params.filePath);
   try {
-    if (params.maxBytes !== undefined && opened.stat.size > params.maxBytes) {
-      throw new SafeOpenError(
-        "too-large",
-        `file exceeds limit of ${params.maxBytes} bytes (got ${opened.stat.size})`,
-      );
-    }
-    const buffer = await opened.handle.readFile();
-    return { buffer, realPath: opened.realPath, stat: opened.stat };
+    return await readOpenedFileSafely({ opened, maxBytes: params.maxBytes });
   } finally {
     await opened.handle.close().catch(() => {});
+  }
+}
+
+async function readOpenedFileSafely(params: {
+  opened: SafeOpenResult;
+  maxBytes?: number;
+}): Promise<SafeLocalReadResult> {
+  if (params.maxBytes !== undefined && params.opened.stat.size > params.maxBytes) {
+    throw new SafeOpenError(
+      "too-large",
+      `file exceeds limit of ${params.maxBytes} bytes (got ${params.opened.stat.size})`,
+    );
+  }
+  const buffer = await params.opened.handle.readFile();
+  return {
+    buffer,
+    realPath: params.opened.realPath,
+    stat: params.opened.stat,
+  };
+}
+
+export async function writeFileWithinRoot(params: {
+  rootDir: string;
+  relativePath: string;
+  data: string | Buffer;
+  encoding?: BufferEncoding;
+  mkdir?: boolean;
+}): Promise<void> {
+  const { rootReal, rootWithSep, resolved } = await resolvePathWithinRoot(params);
+  try {
+    await assertNoPathAliasEscape({
+      absolutePath: resolved,
+      rootPath: rootReal,
+      boundaryLabel: "root",
+    });
+  } catch (err) {
+    throw new SafeOpenError("invalid-path", "path alias escape blocked", { cause: err });
+  }
+  if (params.mkdir !== false) {
+    await fs.mkdir(path.dirname(resolved), { recursive: true });
+  }
+
+  let ioPath = resolved;
+  try {
+    const resolvedRealPath = await fs.realpath(resolved);
+    if (!isPathInside(rootWithSep, resolvedRealPath)) {
+      throw new SafeOpenError("outside-workspace", "file is outside workspace root");
+    }
+    ioPath = resolvedRealPath;
+  } catch (err) {
+    if (err instanceof SafeOpenError) {
+      throw err;
+    }
+    if (!isNotFoundPathError(err)) {
+      throw err;
+    }
+  }
+
+  let handle: FileHandle;
+  let createdForWrite = false;
+  try {
+    try {
+      handle = await fs.open(ioPath, OPEN_WRITE_EXISTING_FLAGS, 0o600);
+    } catch (err) {
+      if (!isNotFoundPathError(err)) {
+        throw err;
+      }
+      handle = await fs.open(ioPath, OPEN_WRITE_CREATE_FLAGS, 0o600);
+      createdForWrite = true;
+    }
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      throw new SafeOpenError("not-found", "file not found");
+    }
+    if (isSymlinkOpenError(err)) {
+      throw new SafeOpenError("invalid-path", "symlink open blocked", { cause: err });
+    }
+    throw err;
+  }
+
+  let openedRealPath: string | null = null;
+  try {
+    const [stat, lstat] = await Promise.all([handle.stat(), fs.lstat(ioPath)]);
+    if (lstat.isSymbolicLink() || !stat.isFile()) {
+      throw new SafeOpenError("invalid-path", "path is not a regular file under root");
+    }
+    if (stat.nlink > 1) {
+      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+    }
+    if (!sameFileIdentity(stat, lstat)) {
+      throw new SafeOpenError("path-mismatch", "path changed during write");
+    }
+
+    const realPath = await fs.realpath(ioPath);
+    openedRealPath = realPath;
+    const realStat = await fs.stat(realPath);
+    if (!sameFileIdentity(stat, realStat)) {
+      throw new SafeOpenError("path-mismatch", "path mismatch");
+    }
+    if (realStat.nlink > 1) {
+      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+    }
+    if (!isPathInside(rootWithSep, realPath)) {
+      throw new SafeOpenError("outside-workspace", "file is outside workspace root");
+    }
+
+    // Truncate only after boundary and identity checks complete. This avoids
+    // irreversible side effects if a symlink target changes before validation.
+    if (!createdForWrite) {
+      await handle.truncate(0);
+    }
+    if (typeof params.data === "string") {
+      await handle.writeFile(params.data, params.encoding ?? "utf8");
+    } else {
+      await handle.writeFile(params.data);
+    }
+  } catch (err) {
+    if (createdForWrite && err instanceof SafeOpenError && openedRealPath) {
+      await fs.rm(openedRealPath, { force: true }).catch(() => {});
+    }
+    throw err;
+  } finally {
+    await handle.close().catch(() => {});
   }
 }

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -2,6 +2,8 @@ import { resolveBrowserConfig } from "../browser/config.js";
 import { loadConfig } from "../config/config.js";
 import { GatewayClient } from "../gateway/client.js";
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
+import type { SkillBinTrustEntry } from "../infra/exec-approvals.js";
+import { resolveExecutableFromPathEnv } from "../infra/executable-path.js";
 import { getMachineDisplayName } from "../infra/machine-name.js";
 import {
   NODE_BROWSER_PROXY_COMMAND,
@@ -12,7 +14,12 @@ import { ensureRemoteClawCliOnPath } from "../infra/path-env.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { VERSION } from "../version.js";
 import { ensureNodeHostConfig, saveNodeHostConfig, type NodeHostGatewayConfig } from "./config.js";
-import { coerceNodeInvokePayload, handleInvoke, buildNodeInvokeResultParams } from "./invoke.js";
+import {
+  coerceNodeInvokePayload,
+  handleInvoke,
+  type SkillBinsProvider,
+  buildNodeInvokeResultParams,
+} from "./invoke.js";
 
 export { buildNodeInvokeResultParams };
 
@@ -26,6 +33,70 @@ type NodeHostRunOptions = {
 };
 
 const DEFAULT_NODE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+function resolveExecutablePathFromEnv(bin: string, pathEnv: string): string | null {
+  if (bin.includes("/") || bin.includes("\\")) {
+    return null;
+  }
+  return resolveExecutableFromPathEnv(bin, pathEnv) ?? null;
+}
+
+function resolveSkillBinTrustEntries(bins: string[], pathEnv: string): SkillBinTrustEntry[] {
+  const trustEntries: SkillBinTrustEntry[] = [];
+  const seen = new Set<string>();
+  for (const bin of bins) {
+    const name = bin.trim();
+    if (!name) {
+      continue;
+    }
+    const resolvedPath = resolveExecutablePathFromEnv(name, pathEnv);
+    if (!resolvedPath) {
+      continue;
+    }
+    const key = `${name}\u0000${resolvedPath}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    trustEntries.push({ name, resolvedPath });
+  }
+  return trustEntries.toSorted(
+    (left, right) =>
+      left.name.localeCompare(right.name) || left.resolvedPath.localeCompare(right.resolvedPath),
+  );
+}
+
+class SkillBinsCache implements SkillBinsProvider {
+  private bins: SkillBinTrustEntry[] = [];
+  private lastRefresh = 0;
+  private readonly ttlMs = 90_000;
+  private readonly fetch: () => Promise<string[]>;
+  private readonly pathEnv: string;
+
+  constructor(fetch: () => Promise<string[]>, pathEnv: string) {
+    this.fetch = fetch;
+    this.pathEnv = pathEnv;
+  }
+
+  async current(force = false): Promise<SkillBinTrustEntry[]> {
+    if (force || Date.now() - this.lastRefresh > this.ttlMs) {
+      await this.refresh();
+    }
+    return this.bins;
+  }
+
+  private async refresh() {
+    try {
+      const bins = await this.fetch();
+      this.bins = resolveSkillBinTrustEntries(bins, this.pathEnv);
+      this.lastRefresh = Date.now();
+    } catch {
+      if (!this.lastRefresh) {
+        this.bins = [];
+      }
+    }
+  }
+}
 
 function ensureNodePathEnv(): string {
   ensureRemoteClawCliOnPath({ pathEnv: process.env.PATH ?? "" });
@@ -106,7 +177,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
       if (!payload) {
         return;
       }
-      void handleInvoke(payload, client);
+      void handleInvoke(payload, client, skillBins);
     },
     onConnectError: (err) => {
       // keep retrying (handled by GatewayClient)
@@ -118,6 +189,12 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
       console.error(`node host gateway closed (${code}): ${reason}`);
     },
   });
+
+  const skillBins = new SkillBinsCache(async () => {
+    const res = await client.request<{ bins: Array<unknown> }>("skills.bins", {});
+    const bins = Array.isArray(res?.bins) ? res.bins.map((bin) => String(bin)) : [];
+    return bins;
+  }, pathEnv);
 
   client.start();
   await new Promise(() => {});

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -2,8 +2,6 @@ import { resolveBrowserConfig } from "../browser/config.js";
 import { loadConfig } from "../config/config.js";
 import { GatewayClient } from "../gateway/client.js";
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
-import type { SkillBinTrustEntry } from "../infra/exec-approvals.js";
-import { resolveExecutableFromPathEnv } from "../infra/executable-path.js";
 import { getMachineDisplayName } from "../infra/machine-name.js";
 import {
   NODE_BROWSER_PROXY_COMMAND,
@@ -14,12 +12,7 @@ import { ensureRemoteClawCliOnPath } from "../infra/path-env.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { VERSION } from "../version.js";
 import { ensureNodeHostConfig, saveNodeHostConfig, type NodeHostGatewayConfig } from "./config.js";
-import {
-  coerceNodeInvokePayload,
-  handleInvoke,
-  type SkillBinsProvider,
-  buildNodeInvokeResultParams,
-} from "./invoke.js";
+import { coerceNodeInvokePayload, handleInvoke, buildNodeInvokeResultParams } from "./invoke.js";
 
 export { buildNodeInvokeResultParams };
 
@@ -33,70 +26,6 @@ type NodeHostRunOptions = {
 };
 
 const DEFAULT_NODE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-
-function resolveExecutablePathFromEnv(bin: string, pathEnv: string): string | null {
-  if (bin.includes("/") || bin.includes("\\")) {
-    return null;
-  }
-  return resolveExecutableFromPathEnv(bin, pathEnv) ?? null;
-}
-
-function resolveSkillBinTrustEntries(bins: string[], pathEnv: string): SkillBinTrustEntry[] {
-  const trustEntries: SkillBinTrustEntry[] = [];
-  const seen = new Set<string>();
-  for (const bin of bins) {
-    const name = bin.trim();
-    if (!name) {
-      continue;
-    }
-    const resolvedPath = resolveExecutablePathFromEnv(name, pathEnv);
-    if (!resolvedPath) {
-      continue;
-    }
-    const key = `${name}\u0000${resolvedPath}`;
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    trustEntries.push({ name, resolvedPath });
-  }
-  return trustEntries.toSorted(
-    (left, right) =>
-      left.name.localeCompare(right.name) || left.resolvedPath.localeCompare(right.resolvedPath),
-  );
-}
-
-class SkillBinsCache implements SkillBinsProvider {
-  private bins: SkillBinTrustEntry[] = [];
-  private lastRefresh = 0;
-  private readonly ttlMs = 90_000;
-  private readonly fetch: () => Promise<string[]>;
-  private readonly pathEnv: string;
-
-  constructor(fetch: () => Promise<string[]>, pathEnv: string) {
-    this.fetch = fetch;
-    this.pathEnv = pathEnv;
-  }
-
-  async current(force = false): Promise<SkillBinTrustEntry[]> {
-    if (force || Date.now() - this.lastRefresh > this.ttlMs) {
-      await this.refresh();
-    }
-    return this.bins;
-  }
-
-  private async refresh() {
-    try {
-      const bins = await this.fetch();
-      this.bins = resolveSkillBinTrustEntries(bins, this.pathEnv);
-      this.lastRefresh = Date.now();
-    } catch {
-      if (!this.lastRefresh) {
-        this.bins = [];
-      }
-    }
-  }
-}
 
 function ensureNodePathEnv(): string {
   ensureRemoteClawCliOnPath({ pathEnv: process.env.PATH ?? "" });
@@ -177,7 +106,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
       if (!payload) {
         return;
       }
-      void handleInvoke(payload, client, skillBins);
+      void handleInvoke(payload, client);
     },
     onConnectError: (err) => {
       // keep retrying (handled by GatewayClient)
@@ -189,12 +118,6 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
       console.error(`node host gateway closed (${code}): ${reason}`);
     },
   });
-
-  const skillBins = new SkillBinsCache(async () => {
-    const res = await client.request<{ bins: Array<unknown> }>("skills.bins", {});
-    const bins = Array.isArray(res?.bins) ? res.bins.map((bin) => String(bin)) : [];
-    return bins;
-  }, pathEnv);
 
   client.start();
   await new Promise(() => {});

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -1,4 +1,4 @@
-import { resolveGroupAllowFromSources } from "../channels/allow-from.js";
+import { mergeDmAllowFromSources, resolveGroupAllowFromSources } from "../channels/allow-from.js";
 import { resolveControlCommandGate } from "../channels/command-gating.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
@@ -9,33 +9,29 @@ export function resolveEffectiveAllowFromLists(params: {
   groupAllowFrom?: Array<string | number> | null;
   storeAllowFrom?: Array<string | number> | null;
   dmPolicy?: string | null;
-  groupAllowFromFallbackToAllowFrom?: boolean;
+  groupAllowFromFallbackToAllowFrom?: boolean | null;
 }): {
   effectiveAllowFrom: string[];
   effectiveGroupAllowFrom: string[];
 } {
-  const configAllowFrom = normalizeStringEntries(
-    Array.isArray(params.allowFrom) ? params.allowFrom : undefined,
+  const allowFrom = Array.isArray(params.allowFrom) ? params.allowFrom : undefined;
+  const groupAllowFrom = Array.isArray(params.groupAllowFrom) ? params.groupAllowFrom : undefined;
+  const storeAllowFrom = Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined;
+  const effectiveAllowFrom = normalizeStringEntries(
+    mergeDmAllowFromSources({
+      allowFrom,
+      storeAllowFrom,
+      dmPolicy: params.dmPolicy ?? undefined,
+    }),
   );
-  const configGroupAllowFrom = normalizeStringEntries(
-    Array.isArray(params.groupAllowFrom) ? params.groupAllowFrom : undefined,
+  // Group auth is explicit (groupAllowFrom fallback allowFrom). Pairing store is DM-only.
+  const effectiveGroupAllowFrom = normalizeStringEntries(
+    resolveGroupAllowFromSources({
+      allowFrom,
+      groupAllowFrom,
+      fallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom ?? undefined,
+    }),
   );
-  const storeAllowFrom =
-    params.dmPolicy === "allowlist"
-      ? []
-      : normalizeStringEntries(
-          Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined,
-        );
-  const effectiveAllowFrom = normalizeStringEntries([...configAllowFrom, ...storeAllowFrom]);
-  const fallbackToAllowFrom = params.groupAllowFromFallbackToAllowFrom !== false;
-  const groupBase =
-    configGroupAllowFrom.length > 0
-      ? configGroupAllowFrom
-      : fallbackToAllowFrom
-        ? configAllowFrom
-        : [];
-  // Pairing store is DM-only — do not include storeAllowFrom in group allowlist
-  const effectiveGroupAllowFrom = normalizeStringEntries(groupBase);
   return { effectiveAllowFrom, effectiveGroupAllowFrom };
 }
 
@@ -53,6 +49,17 @@ export const DM_GROUP_ACCESS_REASON = {
 } as const;
 export type DmGroupAccessReasonCode =
   (typeof DM_GROUP_ACCESS_REASON)[keyof typeof DM_GROUP_ACCESS_REASON];
+
+type DmGroupAccessInputParams = {
+  isGroup: boolean;
+  dmPolicy?: string | null;
+  groupPolicy?: string | null;
+  allowFrom?: Array<string | number> | null;
+  groupAllowFrom?: Array<string | number> | null;
+  storeAllowFrom?: Array<string | number> | null;
+  groupAllowFromFallbackToAllowFrom?: boolean | null;
+  isSenderAllowed: (allowFrom: string[]) => boolean;
+};
 
 export async function readStoreAllowFromForDmPolicy(params: {
   provider: ChannelId;
@@ -154,16 +161,7 @@ export function resolveDmGroupAccessDecision(params: {
   };
 }
 
-export function resolveDmGroupAccessWithLists(params: {
-  isGroup: boolean;
-  dmPolicy?: string | null;
-  groupPolicy?: string | null;
-  allowFrom?: Array<string | number> | null;
-  groupAllowFrom?: Array<string | number> | null;
-  storeAllowFrom?: Array<string | number> | null;
-  groupAllowFromFallbackToAllowFrom?: boolean;
-  isSenderAllowed: (allowFrom: string[]) => boolean;
-}): {
+export function resolveDmGroupAccessWithLists(params: DmGroupAccessInputParams): {
   decision: DmGroupAccessDecision;
   reasonCode: DmGroupAccessReasonCode;
   reason: string;
@@ -192,21 +190,15 @@ export function resolveDmGroupAccessWithLists(params: {
   };
 }
 
-export function resolveDmGroupAccessWithCommandGate(params: {
-  isGroup: boolean;
-  dmPolicy?: string | null;
-  groupPolicy?: string | null;
-  allowFrom?: Array<string | number> | null;
-  groupAllowFrom?: Array<string | number> | null;
-  storeAllowFrom?: Array<string | number> | null;
-  groupAllowFromFallbackToAllowFrom?: boolean | null;
-  isSenderAllowed: (allowFrom: string[]) => boolean;
-  command?: {
-    useAccessGroups: boolean;
-    allowTextCommands: boolean;
-    hasControlCommand: boolean;
-  };
-}): {
+export function resolveDmGroupAccessWithCommandGate(
+  params: DmGroupAccessInputParams & {
+    command?: {
+      useAccessGroups: boolean;
+      allowTextCommands: boolean;
+      hasControlCommand: boolean;
+    };
+  },
+): {
   decision: DmGroupAccessDecision;
   reason: string;
   effectiveAllowFrom: string[];
@@ -221,7 +213,7 @@ export function resolveDmGroupAccessWithCommandGate(params: {
     allowFrom: params.allowFrom,
     groupAllowFrom: params.groupAllowFrom,
     storeAllowFrom: params.storeAllowFrom,
-    groupAllowFromFallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom ?? undefined,
+    groupAllowFromFallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom,
     isSenderAllowed: params.isSenderAllowed,
   });
 

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -1,4 +1,4 @@
-import { mergeDmAllowFromSources, resolveGroupAllowFromSources } from "../channels/allow-from.js";
+import { resolveGroupAllowFromSources } from "../channels/allow-from.js";
 import { resolveControlCommandGate } from "../channels/command-gating.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
@@ -9,29 +9,33 @@ export function resolveEffectiveAllowFromLists(params: {
   groupAllowFrom?: Array<string | number> | null;
   storeAllowFrom?: Array<string | number> | null;
   dmPolicy?: string | null;
-  groupAllowFromFallbackToAllowFrom?: boolean | null;
+  groupAllowFromFallbackToAllowFrom?: boolean;
 }): {
   effectiveAllowFrom: string[];
   effectiveGroupAllowFrom: string[];
 } {
-  const allowFrom = Array.isArray(params.allowFrom) ? params.allowFrom : undefined;
-  const groupAllowFrom = Array.isArray(params.groupAllowFrom) ? params.groupAllowFrom : undefined;
-  const storeAllowFrom = Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined;
-  const effectiveAllowFrom = normalizeStringEntries(
-    mergeDmAllowFromSources({
-      allowFrom,
-      storeAllowFrom,
-      dmPolicy: params.dmPolicy ?? undefined,
-    }),
+  const configAllowFrom = normalizeStringEntries(
+    Array.isArray(params.allowFrom) ? params.allowFrom : undefined,
   );
-  // Group auth is explicit (groupAllowFrom fallback allowFrom). Pairing store is DM-only.
-  const effectiveGroupAllowFrom = normalizeStringEntries(
-    resolveGroupAllowFromSources({
-      allowFrom,
-      groupAllowFrom,
-      fallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom ?? undefined,
-    }),
+  const configGroupAllowFrom = normalizeStringEntries(
+    Array.isArray(params.groupAllowFrom) ? params.groupAllowFrom : undefined,
   );
+  const storeAllowFrom =
+    params.dmPolicy === "allowlist"
+      ? []
+      : normalizeStringEntries(
+          Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined,
+        );
+  const effectiveAllowFrom = normalizeStringEntries([...configAllowFrom, ...storeAllowFrom]);
+  const fallbackToAllowFrom = params.groupAllowFromFallbackToAllowFrom !== false;
+  const groupBase =
+    configGroupAllowFrom.length > 0
+      ? configGroupAllowFrom
+      : fallbackToAllowFrom
+        ? configAllowFrom
+        : [];
+  // Pairing store is DM-only — do not include storeAllowFrom in group allowlist
+  const effectiveGroupAllowFrom = normalizeStringEntries(groupBase);
   return { effectiveAllowFrom, effectiveGroupAllowFrom };
 }
 
@@ -57,7 +61,7 @@ type DmGroupAccessInputParams = {
   allowFrom?: Array<string | number> | null;
   groupAllowFrom?: Array<string | number> | null;
   storeAllowFrom?: Array<string | number> | null;
-  groupAllowFromFallbackToAllowFrom?: boolean | null;
+  groupAllowFromFallbackToAllowFrom?: boolean;
   isSenderAllowed: (allowFrom: string[]) => boolean;
 };
 
@@ -213,7 +217,7 @@ export function resolveDmGroupAccessWithCommandGate(
     allowFrom: params.allowFrom,
     groupAllowFrom: params.groupAllowFrom,
     storeAllowFrom: params.storeAllowFrom,
-    groupAllowFromFallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom,
+    groupAllowFromFallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom ?? undefined,
     isSenderAllowed: params.isSenderAllowed,
   });
 


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #716
**Commits**: 6 cherry-picked + 1 adaptation

| Hash | Subject | Result |
|------|---------|--------|
| `00a2456b7` | refactor(scripts): dedupe guard checks and smoke helpers | RESOLVED — 2 gutted scripts discarded, new ts-guard-utils.mjs created |
| `500883775` | refactor(tests): dedupe ios defaults and setup-code helpers | PICKED — clean, new TestDefaultsSupport.swift created |
| `8553d2242` | refactor(tests): dedupe ios gateway and deeplink fixtures | RESOLVED — rebrand conflicts in 3 test files |
| `cd011897d` | refactor(ios): dedupe status, gateway, and service flows | RESOLVED — rebrand conflicts in 5 source files, 3 new Status views created |
| `b02b94673` | refactor: dedupe runtime and helper flows | RESOLVED — 5 gutted files discarded, new executable-path.ts created, 4 files kept at fork state (gutted-module imports) |
| `753301553` | refactor(android): extract shared dedupe helpers for node and chat | RESOLVED — path rebrand (ai.openclaw → org.remoteclaw), new Base64ImageState.kt created |

### Adaptation notes
- Fork rebrand applied to all iOS/Android files (OpenClaw→RemoteClaw, ai.openclaw→org.remoteclaw)
- Gutted files (auto-reply, thread-bindings, boundary-*, exec-command-resolution) discarded
- sessions.ts, fs-safe.ts, runner.ts kept at fork state — upstream changes reference gutted modules
- dm-policy-shared.ts: extracted DmGroupAccessInputParams type (upstream dedupe), kept fork naming
- status.scan.ts: took upstream gateway/channel helpers, skipped memory code (gutted in fork)
- ios-team-id.test.ts: kept fork version (already deduped differently with proper cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)