### PR TITLE
Cherry-pick d85d3c88d: refactor(agents): centralize tool display definitions

### DIFF
--- a/src/canvas-host/a2ui/index.html
+++ b/src/canvas-host/a2ui/index.html
@@ -226,11 +226,11 @@
   </head>
   <body>
     <canvas id="remoteclaw-canvas"></canvas>
-    <div id="remoteclaw-status">
-      <div class="card">
+    <div id="remoteclaw-status" role="status" aria-live="polite">
+      <section class="card">
         <div class="title" id="remoteclaw-status-title">Ready</div>
         <div class="subtitle" id="remoteclaw-status-subtitle">Waiting for agent</div>
-      </div>
+      </section>
     </div>
     <remoteclaw-a2ui-host></remoteclaw-a2ui-host>
     <script src="a2ui.bundle.js"></script>


### PR DESCRIPTION
## Cherry-pick from upstream

- **Commit**: [`d85d3c88d`](https://github.com/openclaw/openclaw/commit/d85d3c88d)
- **Author**: Peter Steinberger
- **Tier**: AUTO-PARTIAL

## Adaptation

Only took the canvas-host a2ui accessibility improvement:
- Added `role="status" aria-live="polite"` to status container
- Changed inner `div.card` to `section.card` (semantic HTML)

Discarded:
- JSON centralization to `apps/shared/OpenClawKit/` (native app path doesn't exist in fork)
- `tool-display-overrides.json` (gutted layer)
- `tool-display.ts` import restructuring (depends on above)

Depends on #1552

Part of #718