### PR TITLE
Cherry-pick 0c2d855: test(refactor): dedupe cli and ios script scenarios

### DIFF
--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -72,48 +72,83 @@ afterEach(() => {
 });
 
 describe("registerPreActionHooks", () => {
-  function buildProgram() {
+  type CommandKey =
+    | "status"
+    | "doctor"
+    | "completion"
+    | "update-status"
+    | "config-set"
+    | "agents"
+    | "configure"
+    | "onboard"
+    | "message-send";
+
+  function buildProgram(keys: readonly CommandKey[]) {
+    const enabled = new Set<CommandKey>(keys);
+    const has = (key: CommandKey) => enabled.has(key);
     const program = new Command().name("remoteclaw");
-    program.command("status").action(() => {});
-    program.command("doctor").action(() => {});
-    program.command("completion").action(() => {});
-    program
-      .command("update")
-      .command("status")
-      .option("--json")
-      .action(() => {});
-    const config = program.command("config");
-    config
-      .command("set")
-      .argument("<path>")
-      .argument("<value>")
-      .option("--json")
-      .action(() => {});
-    program.command("agents").action(() => {});
-    program.command("configure").action(() => {});
-    program.command("onboard").action(() => {});
-    program
-      .command("message")
-      .command("send")
-      .option("--json")
-      .action(() => {});
+    if (has("status")) {
+      program.command("status").action(() => {});
+    }
+    if (has("doctor")) {
+      program.command("doctor").action(() => {});
+    }
+    if (has("completion")) {
+      program.command("completion").action(() => {});
+    }
+    if (has("update-status")) {
+      program
+        .command("update")
+        .command("status")
+        .option("--json")
+        .action(() => {});
+    }
+    if (has("config-set")) {
+      const config = program.command("config");
+      config
+        .command("set")
+        .argument("<path>")
+        .argument("<value>")
+        .option("--json")
+        .action(() => {});
+    }
+    if (has("agents")) {
+      program.command("agents").action(() => {});
+    }
+    if (has("configure")) {
+      program.command("configure").action(() => {});
+    }
+    if (has("onboard")) {
+      program.command("onboard").action(() => {});
+    }
+    if (has("message-send")) {
+      program
+        .command("message")
+        .command("send")
+        .option("--json")
+        .action(() => {});
+    }
     registerPreActionHooks(program, "9.9.9-test");
     return program;
   }
 
   async function runCommand(
     params: { parseArgv: string[]; processArgv?: string[] },
-    program = buildProgram(),
+    program: Command,
   ) {
     process.argv = params.processArgv ?? [...params.parseArgv];
     await program.parseAsync(params.parseArgv, { from: "user" });
   }
 
   it("emits banner, resolves config, and enables verbose from --debug", async () => {
-    await runCommand({
-      parseArgv: ["status"],
-      processArgv: ["node", "remoteclaw", "status", "--debug"],
-    });
+    const program = buildProgram(["status"]);
+    await runCommand(
+      {
+        parseArgv: ["status"],
+        processArgv: ["node", "remoteclaw", "status", "--debug"],
+      },
+      program,
+    );
 
     expect(emitCliBannerMock).toHaveBeenCalledWith("9.9.9-test");
     expect(setVerboseMock).toHaveBeenCalledWith(true);
@@ -126,10 +161,14 @@ describe("registerPreActionHooks", () => {
   });
 
   it("loads plugin registry for plugin-required commands", async () => {
-    await runCommand({
-      parseArgv: ["message", "send"],
-      processArgv: ["node", "remoteclaw", "message", "send"],
-    });
+    const program = buildProgram(["message-send"]);
+    await runCommand(
+      {
+        parseArgv: ["message", "send"],
+        processArgv: ["node", "remoteclaw", "message", "send"],
+      },
+      program,
+    );
 
     expect(setVerboseMock).toHaveBeenCalledWith(false);
     expect(process.env.NODE_NO_WARNINGS).toBe("1");
@@ -142,7 +181,7 @@ describe("registerPreActionHooks", () => {
 
   it("loads plugin registry for configure/onboard/agents commands", async () => {
     const commands = ["configure", "onboard", "agents"] as const;
-    const program = buildProgram();
+    const program = buildProgram(["configure", "onboard", "agents"]);
     for (const command of commands) {
       vi.clearAllMocks();
       await runCommand(
@@ -157,7 +196,7 @@ describe("registerPreActionHooks", () => {
   });
 
   it("skips config guard for doctor and completion commands", async () => {
-    const program = buildProgram();
+    const program = buildProgram(["doctor", "completion"]);
     await runCommand(
       {
         parseArgv: ["doctor"],
@@ -177,10 +216,14 @@ describe("registerPreActionHooks", () => {
   });
 
   it("skips preaction work when argv indicates help/version", async () => {
-    await runCommand({
-      parseArgv: ["status"],
-      processArgv: ["node", "remoteclaw", "--version"],
-    });
+    const program = buildProgram(["status"]);
+    await runCommand(
+      {
+        parseArgv: ["status"],
+        processArgv: ["node", "remoteclaw", "--version"],
+      },
+      program,
+    );
 
     expect(emitCliBannerMock).not.toHaveBeenCalled();
     expect(setVerboseMock).not.toHaveBeenCalled();
@@ -189,17 +232,21 @@ describe("registerPreActionHooks", () => {
 
   it("hides banner when REMOTECLAW_HIDE_BANNER is truthy", async () => {
     process.env.REMOTECLAW_HIDE_BANNER = "1";
-    await runCommand({
-      parseArgv: ["status"],
-      processArgv: ["node", "remoteclaw", "status"],
-    });
+    const program = buildProgram(["status"]);
+    await runCommand(
+      {
+        parseArgv: ["status"],
+        processArgv: ["node", "remoteclaw", "status"],
+      },
+      program,
+    );
 
     expect(emitCliBannerMock).not.toHaveBeenCalled();
     expect(ensureConfigReadyMock).toHaveBeenCalledTimes(1);
   });
 
   it("suppresses doctor stdout for any --json output command", async () => {
-    const program = buildProgram();
+    const program = buildProgram(["message-send", "update-status"]);
     await runCommand(
       {
         parseArgv: ["message", "send", "--json"],
@@ -232,10 +279,14 @@ describe("registerPreActionHooks", () => {
   });
 
   it("does not treat config set --json (strict-parse alias) as json output mode", async () => {
-    await runCommand({
-      parseArgv: ["config", "set", "gateway.auth.mode", "{bad", "--json"],
-      processArgv: ["node", "remoteclaw", "config", "set", "gateway.auth.mode", "{bad", "--json"],
-    });
+    const program = buildProgram(["config-set"]);
+    await runCommand(
+      {
+        parseArgv: ["config", "set", "gateway.auth.mode", "{bad", "--json"],
+        processArgv: ["node", "remoteclaw", "config", "set", "gateway.auth.mode", "{bad", "--json"],
+      },
+      program,
+    );
 
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,


### PR DESCRIPTION
## Upstream Cherry-Pick

- **Commit**: [`0c2d85529`](https://github.com/openclaw/openclaw/commit/0c2d85529)
- **Author**: Peter Steinberger
- **Tier**: AUTO-PICK

## Adaptation

Conflict resolution required for fork rebrand divergences:
- `preaction.test.ts`: Applied upstream's `buildProgram(keys)` refactoring with fork's rebranded names (`remoteclaw`, `REMOTECLAW_HIDE_BANNER`) and removed `secrets` command (gutted in fork)
- `ios-team-id.test.ts`: Resolved to keep fork's version (superset with `BASH_ARGS` and `fake-python` approach)

Cherry-picked from issue #719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)