### PR TITLE
Cherry-pick 94e480f: test(refactor): dedupe preaction command coverage

### DIFF
--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -179,35 +179,25 @@ describe("registerPreActionHooks", () => {
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
   });
 
-  it("loads plugin registry for configure/onboard/agents commands", async () => {
-    const commands = ["configure", "onboard", "agents"] as const;
-    const program = buildProgram(["configure", "onboard", "agents"]);
-    for (const command of commands) {
-      vi.clearAllMocks();
-      await runCommand(
-        {
-          parseArgv: [command],
-          processArgv: ["node", "remoteclaw", command],
-        },
-        program,
-      );
-      expect(ensurePluginRegistryLoadedMock, command).toHaveBeenCalledTimes(1);
-    }
+  it("loads plugin registry for configure command", async () => {
+    const program = buildProgram(["configure"]);
+    await runCommand(
+      {
+        parseArgv: ["configure"],
+        processArgv: ["node", "remoteclaw", "configure"],
+      },
+      program,
+    );
+
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
   });
 
-  it("skips config guard for doctor and completion commands", async () => {
-    const program = buildProgram(["doctor", "completion"]);
+  it("skips config guard for doctor command", async () => {
+    const program = buildProgram(["doctor"]);
     await runCommand(
       {
         parseArgv: ["doctor"],
         processArgv: ["node", "remoteclaw", "doctor"],
-      },
-      program,
-    );
-    await runCommand(
-      {
-        parseArgv: ["completion"],
-        processArgv: ["node", "remoteclaw", "completion"],
       },
       program,
     );


### PR DESCRIPTION
## Upstream Cherry-Pick

- **Commit**: [`94e480f64`](https://github.com/openclaw/openclaw/commit/94e480f64)
- **Author**: Peter Steinberger
- **Tier**: AUTO-PICK
- **Depends on**: #1555

## Adaptation

Conflict resolution required for fork rebrand divergences:
- Replaced combined loop tests with single representative tests per category (upstream's approach)
- Applied fork's rebranded names (`remoteclaw`) and removed `secrets` command references

Cherry-picked from issue #719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)