### PR TITLE
Cherry-pick 0d620a5: test(refactor): reuse shared program setup in preaction tests

### DIFF
--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -72,62 +72,33 @@ afterEach(() => {
 });
 
 describe("registerPreActionHooks", () => {
-  type CommandKey =
-    | "status"
-    | "doctor"
-    | "completion"
-    | "update-status"
-    | "config-set"
-    | "agents"
-    | "configure"
-    | "onboard"
-    | "message-send";
+  let program: Command;
 
-  function buildProgram(keys: readonly CommandKey[]) {
-    const enabled = new Set<CommandKey>(keys);
-    const has = (key: CommandKey) => enabled.has(key);
+  function buildProgram() {
     const program = new Command().name("remoteclaw");
-    if (has("status")) {
-      program.command("status").action(() => {});
-    }
-    if (has("doctor")) {
-      program.command("doctor").action(() => {});
-    }
-    if (has("completion")) {
-      program.command("completion").action(() => {});
-    }
-    if (has("update-status")) {
-      program
-        .command("update")
-        .command("status")
-        .option("--json")
-        .action(() => {});
-    }
-    if (has("config-set")) {
-      const config = program.command("config");
-      config
-        .command("set")
-        .argument("<path>")
-        .argument("<value>")
-        .option("--json")
-        .action(() => {});
-    }
-    if (has("agents")) {
-      program.command("agents").action(() => {});
-    }
-    if (has("configure")) {
-      program.command("configure").action(() => {});
-    }
-    if (has("onboard")) {
-      program.command("onboard").action(() => {});
-    }
-    if (has("message-send")) {
-      program
-        .command("message")
-        .command("send")
-        .option("--json")
-        .action(() => {});
-    }
+    program.command("status").action(() => {});
+    program.command("doctor").action(() => {});
+    program.command("completion").action(() => {});
+    program.command("agents").action(() => {});
+    program.command("configure").action(() => {});
+    program.command("onboard").action(() => {});
+    program
+      .command("update")
+      .command("status")
+      .option("--json")
+      .action(() => {});
+    program
+      .command("message")
+      .command("send")
+      .option("--json")
+      .action(() => {});
+    const config = program.command("config");
+    config
+      .command("set")
+      .argument("<path>")
+      .argument("<value>")
+      .option("--json")
+      .action(() => {});
     registerPreActionHooks(program, "9.9.9-test");
     return program;
   }
@@ -141,7 +112,6 @@ describe("registerPreActionHooks", () => {
   }
 
   it("emits banner, resolves config, and enables verbose from --debug", async () => {
-    const program = buildProgram(["status"]);
     await runCommand(
       {
         parseArgv: ["status"],
@@ -161,7 +131,6 @@ describe("registerPreActionHooks", () => {
   });
 
   it("loads plugin registry for plugin-required commands", async () => {
-    const program = buildProgram(["message-send"]);
     await runCommand(
       {
         parseArgv: ["message", "send"],
@@ -180,7 +149,6 @@ describe("registerPreActionHooks", () => {
   });
 
   it("loads plugin registry for configure command", async () => {
-    const program = buildProgram(["configure"]);
     await runCommand(
       {
         parseArgv: ["configure"],
@@ -193,7 +161,6 @@ describe("registerPreActionHooks", () => {
   });
 
   it("skips config guard for doctor command", async () => {
-    const program = buildProgram(["doctor"]);
     await runCommand(
       {
         parseArgv: ["doctor"],
@@ -206,7 +173,6 @@ describe("registerPreActionHooks", () => {
   });
 
   it("skips preaction work when argv indicates help/version", async () => {
-    const program = buildProgram(["status"]);
     await runCommand(
       {
         parseArgv: ["status"],
@@ -222,7 +188,6 @@ describe("registerPreActionHooks", () => {
 
   it("hides banner when REMOTECLAW_HIDE_BANNER is truthy", async () => {
     process.env.REMOTECLAW_HIDE_BANNER = "1";
-    const program = buildProgram(["status"]);
     await runCommand(
       {
         parseArgv: ["status"],
@@ -236,7 +201,6 @@ describe("registerPreActionHooks", () => {
   });
 
   it("suppresses doctor stdout for any --json output command", async () => {
-    const program = buildProgram(["message-send", "update-status"]);
     await runCommand(
       {
         parseArgv: ["message", "send", "--json"],
@@ -269,7 +233,6 @@ describe("registerPreActionHooks", () => {
   });
 
   it("does not treat config set --json (strict-parse alias) as json output mode", async () => {
-    const program = buildProgram(["config-set"]);
     await runCommand(
       {
         parseArgv: ["config", "set", "gateway.auth.mode", "{bad", "--json"],
@@ -282,5 +245,9 @@ describe("registerPreActionHooks", () => {
       runtime: runtimeMock,
       commandPath: ["config", "set"],
     });
+  });
+
+  beforeAll(() => {
+    program = buildProgram();
   });
 });


### PR DESCRIPTION
## Upstream Cherry-Pick

- **Commit**: [`0d620a56e`](https://github.com/openclaw/openclaw/commit/0d620a56e)
- **Author**: Peter Steinberger
- **Tier**: AUTO-PICK
- **Depends on**: #1556

## Adaptation

Conflict resolution required for fork rebrand divergences:
- Reverted from parameterized `buildProgram(keys)` to shared program instance (upstream's final approach)
- Applied fork's rebranded names (`remoteclaw`, `REMOTECLAW_HIDE_BANNER`) and removed `secrets` command

Cherry-picked from issue #719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)