### PR TITLE
Cherry-pick batch: test performance — cli setup, preaction, cron, fixtures

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 type RestartHealthSnapshot = {
   healthy: boolean;
@@ -56,8 +56,13 @@ vi.mock("./lifecycle-core.js", () => ({
 }));
 
 describe("runDaemonRestart health checks", () => {
+  let runDaemonRestart: (opts?: { json?: boolean }) => Promise<boolean>;
+
+  beforeAll(async () => {
+    ({ runDaemonRestart } = await import("./lifecycle.js"));
+  });
+
   beforeEach(() => {
-    vi.resetModules();
     service.readCommand.mockClear();
     service.restart.mockClear();
     runServiceRestart.mockClear();
@@ -104,7 +109,6 @@ describe("runDaemonRestart health checks", () => {
     waitForGatewayHealthyRestart.mockResolvedValueOnce(unhealthy).mockResolvedValueOnce(healthy);
     terminateStaleGatewayPids.mockResolvedValue([1993]);
 
-    const { runDaemonRestart } = await import("./lifecycle.js");
     const result = await runDaemonRestart({ json: true });
 
     expect(result).toBe(true);
@@ -121,8 +125,6 @@ describe("runDaemonRestart health checks", () => {
       portUsage: { port: 18789, status: "free", listeners: [], hints: [] },
     };
     waitForGatewayHealthyRestart.mockResolvedValue(unhealthy);
-
-    const { runDaemonRestart } = await import("./lifecycle.js");
 
     await expect(runDaemonRestart({ json: true })).rejects.toMatchObject({
       message: "Gateway restart timed out after 60s waiting for health checks.",

--- a/src/cli/program.smoke.test.ts
+++ b/src/cli/program.smoke.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   configureCommand,
   ensureConfigReady,
@@ -26,14 +26,19 @@ vi.mock("./config-cli.js", () => ({
 const { buildProgram } = await import("./program.js");
 
 describe("cli program (smoke)", () => {
+  let program = createProgram();
+
   function createProgram() {
     return buildProgram();
   }
 
   async function runProgram(argv: string[]) {
-    const program = createProgram();
     await program.parseAsync(argv, { from: "user" });
   }
+
+  beforeAll(() => {
+    program = createProgram();
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -42,7 +47,6 @@ describe("cli program (smoke)", () => {
   });
 
   it("registers status command", () => {
-    const program = createProgram();
     const names = program.commands.map((command) => command.name());
     expect(names).toContain("message");
     expect(names).toContain("status");

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const loadAndMaybeMigrateDoctorConfigMock = vi.hoisted(() => vi.fn());
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
@@ -43,14 +43,15 @@ async function withCapturedStdout(run: () => Promise<void>): Promise<string> {
 }
 
 describe("ensureConfigReady", () => {
-  async function loadEnsureConfigReady() {
-    vi.resetModules();
-    return await import("./config-guard.js");
-  }
+  let ensureConfigReady: (params: {
+    runtime: unknown;
+    commandPath: string[];
+    suppressDoctorStdout?: boolean;
+  }) => Promise<void>;
+  let resetConfigGuardStateForTests: () => void;
 
   async function runEnsureConfigReady(commandPath: string[], suppressDoctorStdout = false) {
     const runtime = makeRuntime();
-    const { ensureConfigReady } = await loadEnsureConfigReady();
     await ensureConfigReady({ runtime: runtime as never, commandPath, suppressDoctorStdout });
     return runtime;
   }
@@ -65,8 +66,16 @@ describe("ensureConfigReady", () => {
     });
   }
 
+  beforeAll(async () => {
+    ({
+      ensureConfigReady,
+      __test__: { resetConfigGuardStateForTests },
+    } = await import("./config-guard.js"));
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    resetConfigGuardStateForTests();
     readConfigFileSnapshotMock.mockResolvedValue(makeSnapshot());
   });
 
@@ -107,7 +116,6 @@ describe("ensureConfigReady", () => {
   it("runs doctor migration flow only once per module instance", async () => {
     const runtimeA = makeRuntime();
     const runtimeB = makeRuntime();
-    const { ensureConfigReady } = await loadEnsureConfigReady();
 
     await ensureConfigReady({ runtime: runtimeA as never, commandPath: ["message"] });
     await ensureConfigReady({ runtime: runtimeB as never, commandPath: ["message"] });

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -43,11 +43,7 @@ async function withCapturedStdout(run: () => Promise<void>): Promise<string> {
 }
 
 describe("ensureConfigReady", () => {
-  let ensureConfigReady: (params: {
-    runtime: unknown;
-    commandPath: string[];
-    suppressDoctorStdout?: boolean;
-  }) => Promise<void>;
+  let ensureConfigReady: typeof import("./config-guard.js").ensureConfigReady;
   let resetConfigGuardStateForTests: () => void;
 
   async function runEnsureConfigReady(commandPath: string[], suppressDoctorStdout = false) {

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -23,6 +23,11 @@ let didRunDoctorConfigFlow = false;
 let configSnapshotPromise: Promise<Awaited<ReturnType<typeof readConfigFileSnapshot>>> | null =
   null;
 
+function resetConfigGuardStateForTests() {
+  didRunDoctorConfigFlow = false;
+  configSnapshotPromise = null;
+}
+
 function formatConfigIssues(issues: Array<{ path: string; message: string }>): string[] {
   return issues.map((issue) => `- ${issue.path || "<root>"}: ${issue.message}`);
 }
@@ -113,3 +118,7 @@ export async function ensureConfigReady(params: {
     params.runtime.exit(1);
   }
 }
+
+export const __test__ = {
+  resetConfigGuardStateForTests,
+};

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -73,6 +73,9 @@ afterEach(() => {
 
 describe("registerPreActionHooks", () => {
   let program: Command;
+  let preActionHook:
+    | ((thisCommand: Command, actionCommand: Command) => Promise<void> | void)
+    | null = null;
 
   function buildProgram() {
     const program = new Command().name("remoteclaw");
@@ -103,22 +106,32 @@ describe("registerPreActionHooks", () => {
     return program;
   }
 
-  async function runCommand(
-    params: { parseArgv: string[]; processArgv?: string[] },
-    program: Command,
-  ) {
+  function resolveActionCommand(parseArgv: string[]): Command {
+    let current = program;
+    for (const segment of parseArgv) {
+      const next = current.commands.find((command) => command.name() === segment);
+      if (!next) {
+        break;
+      }
+      current = next;
+    }
+    return current;
+  }
+
+  async function runPreAction(params: { parseArgv: string[]; processArgv?: string[] }) {
     process.argv = params.processArgv ?? [...params.parseArgv];
-    await program.parseAsync(params.parseArgv, { from: "user" });
+    const actionCommand = resolveActionCommand(params.parseArgv);
+    if (!preActionHook) {
+      throw new Error("missing preAction hook");
+    }
+    await preActionHook(program, actionCommand);
   }
 
   it("emits banner, resolves config, and enables verbose from --debug", async () => {
-    await runCommand(
-      {
-        parseArgv: ["status"],
-        processArgv: ["node", "remoteclaw", "status", "--debug"],
-      },
-      program,
-    );
+    await runPreAction({
+      parseArgv: ["status"],
+      processArgv: ["node", "remoteclaw", "status", "--debug"],
+    });
 
     expect(emitCliBannerMock).toHaveBeenCalledWith("9.9.9-test");
     expect(setVerboseMock).toHaveBeenCalledWith(true);
@@ -131,13 +144,10 @@ describe("registerPreActionHooks", () => {
   });
 
   it("loads plugin registry for plugin-required commands", async () => {
-    await runCommand(
-      {
-        parseArgv: ["message", "send"],
-        processArgv: ["node", "remoteclaw", "message", "send"],
-      },
-      program,
-    );
+    await runPreAction({
+      parseArgv: ["message", "send"],
+      processArgv: ["node", "remoteclaw", "message", "send"],
+    });
 
     expect(setVerboseMock).toHaveBeenCalledWith(false);
     expect(process.env.NODE_NO_WARNINGS).toBe("1");
@@ -149,37 +159,28 @@ describe("registerPreActionHooks", () => {
   });
 
   it("loads plugin registry for configure command", async () => {
-    await runCommand(
-      {
-        parseArgv: ["configure"],
-        processArgv: ["node", "remoteclaw", "configure"],
-      },
-      program,
-    );
+    await runPreAction({
+      parseArgv: ["configure"],
+      processArgv: ["node", "remoteclaw", "configure"],
+    });
 
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
   });
 
   it("skips config guard for doctor command", async () => {
-    await runCommand(
-      {
-        parseArgv: ["doctor"],
-        processArgv: ["node", "remoteclaw", "doctor"],
-      },
-      program,
-    );
+    await runPreAction({
+      parseArgv: ["doctor"],
+      processArgv: ["node", "remoteclaw", "doctor"],
+    });
 
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
   });
 
   it("skips preaction work when argv indicates help/version", async () => {
-    await runCommand(
-      {
-        parseArgv: ["status"],
-        processArgv: ["node", "remoteclaw", "--version"],
-      },
-      program,
-    );
+    await runPreAction({
+      parseArgv: ["status"],
+      processArgv: ["node", "remoteclaw", "--version"],
+    });
 
     expect(emitCliBannerMock).not.toHaveBeenCalled();
     expect(setVerboseMock).not.toHaveBeenCalled();
@@ -188,42 +189,20 @@ describe("registerPreActionHooks", () => {
 
   it("hides banner when REMOTECLAW_HIDE_BANNER is truthy", async () => {
     process.env.REMOTECLAW_HIDE_BANNER = "1";
-    await runCommand(
-      {
-        parseArgv: ["status"],
-        processArgv: ["node", "remoteclaw", "status"],
-      },
-      program,
-    );
+    await runPreAction({
+      parseArgv: ["status"],
+      processArgv: ["node", "remoteclaw", "status"],
+    });
 
     expect(emitCliBannerMock).not.toHaveBeenCalled();
     expect(ensureConfigReadyMock).toHaveBeenCalledTimes(1);
   });
 
-  it("suppresses doctor stdout for any --json output command", async () => {
-    await runCommand(
-      {
-        parseArgv: ["message", "send", "--json"],
-        processArgv: ["node", "remoteclaw", "message", "send", "--json"],
-      },
-      program,
-    );
-
-    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
-      runtime: runtimeMock,
-      commandPath: ["message", "send"],
-      suppressDoctorStdout: true,
+  it("suppresses doctor stdout for --json output command", async () => {
+    await runPreAction({
+      parseArgv: ["update", "status", "--json"],
+      processArgv: ["node", "remoteclaw", "update", "status", "--json"],
     });
-
-    vi.clearAllMocks();
-
-    await runCommand(
-      {
-        parseArgv: ["update", "status", "--json"],
-        processArgv: ["node", "remoteclaw", "update", "status", "--json"],
-      },
-      program,
-    );
 
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
@@ -233,13 +212,10 @@ describe("registerPreActionHooks", () => {
   });
 
   it("does not treat config set --json (strict-parse alias) as json output mode", async () => {
-    await runCommand(
-      {
-        parseArgv: ["config", "set", "gateway.auth.mode", "{bad", "--json"],
-        processArgv: ["node", "remoteclaw", "config", "set", "gateway.auth.mode", "{bad", "--json"],
-      },
-      program,
-    );
+    await runPreAction({
+      parseArgv: ["config", "set", "gateway.auth.mode", "{bad", "--json"],
+      processArgv: ["node", "remoteclaw", "config", "set", "gateway.auth.mode", "{bad", "--json"],
+    });
 
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
@@ -249,5 +225,13 @@ describe("registerPreActionHooks", () => {
 
   beforeAll(() => {
     program = buildProgram();
+    const hooks = (
+      program as unknown as {
+        _lifeCycleHooks?: {
+          preAction?: Array<(thisCommand: Command, actionCommand: Command) => Promise<void> | void>;
+        };
+      }
+    )._lifeCycleHooks?.preAction;
+    preActionHook = hooks?.[0] ?? null;
   });
 });

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -156,27 +156,28 @@ describe("registerPreActionHooks", () => {
       commandPath: ["message", "send"],
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
-  });
+    vi.clearAllMocks();
 
-  it("loads plugin registry for configure command", async () => {
     await runPreAction({
       parseArgv: ["configure"],
       processArgv: ["node", "remoteclaw", "configure"],
     });
 
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["configure"],
+    });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
   });
 
-  it("skips config guard for doctor command", async () => {
+  it("skips preaction work for doctor and help/version argv", async () => {
     await runPreAction({
       parseArgv: ["doctor"],
       processArgv: ["node", "remoteclaw", "doctor"],
     });
 
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
-  });
-
-  it("skips preaction work when argv indicates help/version", async () => {
+    vi.clearAllMocks();
     await runPreAction({
       parseArgv: ["status"],
       processArgv: ["node", "remoteclaw", "--version"],

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -127,7 +127,7 @@ describe("registerPreActionHooks", () => {
     await preActionHook(program, actionCommand);
   }
 
-  it("emits banner, resolves config, and enables verbose from --debug", async () => {
+  it("handles debug mode and plugin-required command preaction", async () => {
     await runPreAction({
       parseArgv: ["status"],
       processArgv: ["node", "remoteclaw", "status", "--debug"],
@@ -141,9 +141,8 @@ describe("registerPreActionHooks", () => {
     });
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
     expect(process.title).toBe("remoteclaw-status");
-  });
 
-  it("loads plugin registry for plugin-required commands", async () => {
+    vi.clearAllMocks();
     await runPreAction({
       parseArgv: ["message", "send"],
       processArgv: ["node", "remoteclaw", "message", "send"],
@@ -158,7 +157,7 @@ describe("registerPreActionHooks", () => {
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
   });
 
-  it("skips preaction work when argv indicates help/version", async () => {
+  it("skips help/version preaction and respects banner opt-out", async () => {
     await runPreAction({
       parseArgv: ["status"],
       processArgv: ["node", "remoteclaw", "--version"],
@@ -167,10 +166,10 @@ describe("registerPreActionHooks", () => {
     expect(emitCliBannerMock).not.toHaveBeenCalled();
     expect(setVerboseMock).not.toHaveBeenCalled();
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
-  });
 
-  it("hides banner when REMOTECLAW_HIDE_BANNER is truthy", async () => {
+    vi.clearAllMocks();
     process.env.REMOTECLAW_HIDE_BANNER = "1";
+
     await runPreAction({
       parseArgv: ["status"],
       processArgv: ["node", "remoteclaw", "status"],
@@ -180,7 +179,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledTimes(1);
   });
 
-  it("suppresses doctor stdout for --json output command", async () => {
+  it("applies --json stdout suppression only for explicit JSON output commands", async () => {
     await runPreAction({
       parseArgv: ["update", "status", "--json"],
       processArgv: ["node", "remoteclaw", "update", "status", "--json"],
@@ -191,9 +190,8 @@ describe("registerPreActionHooks", () => {
       commandPath: ["update", "status"],
       suppressDoctorStdout: true,
     });
-  });
 
-  it("does not treat config set --json (strict-parse alias) as json output mode", async () => {
+    vi.clearAllMocks();
     await runPreAction({
       parseArgv: ["config", "set", "gateway.auth.mode", "{bad", "--json"],
       processArgv: ["node", "remoteclaw", "config", "set", "gateway.auth.mode", "{bad", "--json"],

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -156,28 +156,9 @@ describe("registerPreActionHooks", () => {
       commandPath: ["message", "send"],
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
-    vi.clearAllMocks();
-
-    await runPreAction({
-      parseArgv: ["configure"],
-      processArgv: ["node", "remoteclaw", "configure"],
-    });
-
-    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
-      runtime: runtimeMock,
-      commandPath: ["configure"],
-    });
-    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
   });
 
-  it("skips preaction work for doctor and help/version argv", async () => {
-    await runPreAction({
-      parseArgv: ["doctor"],
-      processArgv: ["node", "remoteclaw", "doctor"],
-    });
-
-    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
-    vi.clearAllMocks();
+  it("skips preaction work when argv indicates help/version", async () => {
     await runPreAction({
       parseArgv: ["status"],
       processArgv: ["node", "remoteclaw", "--version"],

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -68,54 +68,37 @@ describe("config plugin validation", () => {
     await fs.rm(fixtureRoot, { recursive: true, force: true });
   });
 
-  it("rejects missing plugin load paths", async () => {
-    const missingPath = path.join(suiteHome, "missing-plugin");
-    const res = validateInSuite({
-      agents: { list: [{ id: "pi", workspace: "/tmp/test-workspace" }] },
-      plugins: { enabled: false, load: { paths: [missingPath] } },
-    });
-    expect(res.ok).toBe(false);
-    if (!res.ok) {
-      const hasIssue = res.issues.some(
-        (issue) =>
-          issue.path === "plugins.load.paths" && issue.message.includes("plugin path not found"),
-      );
-      expect(hasIssue).toBe(true);
-    }
-  });
-
-  it("warns for missing plugin ids in entries instead of failing validation", async () => {
-    const res = validateInSuite({
-      agents: { list: [{ id: "pi", workspace: "/tmp/test-workspace" }] },
-      plugins: { enabled: false, entries: { "missing-plugin": { enabled: true } } },
-    });
-    expect(res.ok).toBe(true);
-    if (res.ok) {
-      expect(res.warnings).toContainEqual({
-        path: "plugins.entries.missing-plugin",
-        message:
-          "plugin not found: missing-plugin (stale config entry ignored; remove it from plugins config)",
-      });
-    }
-  });
-
-  it("rejects missing plugin ids in allow/deny", async () => {
+  it("reports missing plugin refs across load paths, entries, and allowlist surfaces", async () => {
+    const missingPath = path.join(suiteHome, "missing-plugin-dir");
     const res = validateInSuite({
       agents: { list: [{ id: "pi", workspace: "/tmp/test-workspace" }] },
       plugins: {
         enabled: false,
+        load: { paths: [missingPath] },
+        entries: { "missing-plugin": { enabled: true } },
         allow: ["missing-allow"],
         deny: ["missing-deny"],
       },
     });
     expect(res.ok).toBe(false);
     if (!res.ok) {
+      expect(
+        res.issues.some(
+          (issue) =>
+            issue.path === "plugins.load.paths" && issue.message.includes("plugin path not found"),
+        ),
+      ).toBe(true);
       expect(res.issues).toEqual(
         expect.arrayContaining([
           { path: "plugins.allow", message: "plugin not found: missing-allow" },
           { path: "plugins.deny", message: "plugin not found: missing-deny" },
         ]),
       );
+      expect(res.warnings).toContainEqual({
+        path: "plugins.entries.missing-plugin",
+        message:
+          "plugin not found: missing-plugin (stale config entry ignored; remove it from plugins config)",
+      });
     }
   });
 
@@ -188,17 +171,14 @@ describe("config plugin validation", () => {
     }
   });
 
-  it("accepts known plugin ids", async () => {
+  it("accepts known plugin ids and valid channel/heartbeat enums", async () => {
     const res = validateInSuite({
-      agents: { list: [{ id: "pi", workspace: "/tmp/test-workspace" }] },
-      plugins: { enabled: false, entries: { discord: { enabled: true } } },
-    });
-    expect(res.ok).toBe(true);
-  });
-
-  it("accepts channels.modelByChannel", async () => {
-    const res = validateInSuite({
-      agents: { list: [{ id: "pi", workspace: "/tmp/test-workspace" }] },
+      agents: {
+        defaults: { heartbeat: { target: "last", directPolicy: "block" } },
+        list: [
+          { id: "pi", workspace: "/tmp/test-workspace", heartbeat: { directPolicy: "allow" } },
+        ],
+      },
       channels: {
         modelByChannel: {
           openai: {
@@ -206,6 +186,7 @@ describe("config plugin validation", () => {
           },
         },
       },
+      plugins: { enabled: false, entries: { discord: { enabled: true } } },
     });
     expect(res.ok).toBe(true);
   });
@@ -245,16 +226,6 @@ describe("config plugin validation", () => {
     }
   });
 
-  it("accepts heartbeat directPolicy enum values", async () => {
-    const res = validateInSuite({
-      agents: {
-        defaults: { heartbeat: { target: "last", directPolicy: "block" } },
-        list: [{ id: "pi", heartbeat: { directPolicy: "allow" } }],
-      },
-    });
-    expect(res.ok).toBe(true);
-  });
-
   it("rejects invalid heartbeat directPolicy values", async () => {
     const res = validateInSuite({
       agents: {
@@ -264,10 +235,9 @@ describe("config plugin validation", () => {
     });
     expect(res.ok).toBe(false);
     if (!res.ok) {
-      const hasIssue = res.issues.some(
-        (issue) => issue.path === "agents.defaults.heartbeat.directPolicy",
-      );
-      expect(hasIssue).toBe(true);
+      expect(
+        res.issues.some((issue) => issue.path === "agents.defaults.heartbeat.directPolicy"),
+      ).toBe(true);
     }
   });
 });

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1,15 +1,31 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
-import { withTempHome } from "./home-env.test-harness.js";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createConfigIO } from "./io.js";
 import type { RemoteClawConfig } from "./types.js";
 
 describe("config io write", () => {
+  let fixtureRoot = "";
+  let homeCaseId = 0;
   const silentLogger = {
     warn: () => {},
     error: () => {},
   };
+
+  async function withSuiteHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+    const home = path.join(fixtureRoot, `case-${homeCaseId++}`);
+    await fs.mkdir(home, { recursive: true });
+    return fn(home);
+  }
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-config-io-"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
 
   async function writeConfigAndCreateIo(params: {
     home: string;
@@ -110,7 +126,7 @@ describe("config io write", () => {
   }
 
   it("persists caller changes onto resolved config without leaking runtime defaults", async () => {
-    await withTempHome("remoteclaw-config-io-", async (home) => {
+    await withSuiteHome(async (home) => {
       const { configPath, io, snapshot } = await writeConfigAndCreateIo({
         home,
         initialConfig: { gateway: { port: 18789 } },
@@ -127,7 +143,7 @@ describe("config io write", () => {
   });
 
   it('shows actionable guidance for dmPolicy="open" without wildcard allowFrom', async () => {
-    await withTempHome("remoteclaw-config-io-", async (home) => {
+    await withSuiteHome(async (home) => {
       const io = createConfigIO({
         env: {} as NodeJS.ProcessEnv,
         homedir: () => home,
@@ -153,7 +169,7 @@ describe("config io write", () => {
   });
 
   it("honors explicit unset paths when schema defaults would otherwise reappear", async () => {
-    await withTempHome("remoteclaw-config-io-", async (home) => {
+    await withSuiteHome(async (home) => {
       const { configPath, io, snapshot } = await writeConfigAndCreateIo({
         home,
         initialConfig: {
@@ -181,7 +197,7 @@ describe("config io write", () => {
   });
 
   it("does not mutate caller config when unsetPaths is applied on first write", async () => {
-    await withTempHome("remoteclaw-config-io-", async (home) => {
+    await withSuiteHome(async (home) => {
       const configPath = path.join(home, ".remoteclaw", "remoteclaw.json");
       const io = createConfigIO({
         env: {} as NodeJS.ProcessEnv,
@@ -206,7 +222,7 @@ describe("config io write", () => {
   });
 
   it("does not mutate caller config when unsetPaths is applied on existing files", async () => {
-    await withTempHome("remoteclaw-config-io-", async (home) => {
+    await withSuiteHome(async (home) => {
       const { configPath, io, snapshot } = await writeConfigAndCreateIo({
         home,
         initialConfig: {
@@ -224,7 +240,7 @@ describe("config io write", () => {
   });
 
   it("keeps caller arrays immutable when unsetting array entries", async () => {
-    await withTempHome("remoteclaw-config-io-", async (home) => {
+    await withSuiteHome(async (home) => {
       const { configPath, io, snapshot } = await writeConfigAndCreateIo({
         home,
         initialConfig: {
@@ -245,7 +261,7 @@ describe("config io write", () => {
   });
 
   it("treats missing unset paths as no-op without mutating caller config", async () => {
-    await withTempHome("remoteclaw-config-io-", async (home) => {
+    await withSuiteHome(async (home) => {
       await runUnsetNoopCase({
         home,
         unsetPaths: [["commands", "missingKey"]],
@@ -254,7 +270,7 @@ describe("config io write", () => {
   });
 
   it("ignores blocked prototype-key unset path segments", async () => {
-    await withTempHome("remoteclaw-config-io-", async (home) => {
+    await withSuiteHome(async (home) => {
       await runUnsetNoopCase({
         home,
         unsetPaths: [
@@ -267,7 +283,7 @@ describe("config io write", () => {
   });
 
   it("preserves env var references when writing", async () => {
-    await withTempHome("remoteclaw-config-io-", async (home) => {
+    await withSuiteHome(async (home) => {
       const { configPath, io, snapshot } = await writeConfigAndCreateIo({
         home,
         env: { OPENAI_API_KEY: "sk-secret" } as NodeJS.ProcessEnv,
@@ -302,7 +318,7 @@ describe("config io write", () => {
   });
 
   it("does not reintroduce Slack/Discord legacy dm.policy defaults when writing", async () => {
-    await withTempHome("remoteclaw-config-io-", async (home) => {
+    await withSuiteHome(async (home) => {
       const { configPath, io, snapshot } = await writeConfigAndCreateIo({
         home,
         initialConfig: {
@@ -348,7 +364,7 @@ describe("config io write", () => {
   });
 
   it("keeps env refs in arrays when appending entries", async () => {
-    await withTempHome("remoteclaw-config-io-", async (home) => {
+    await withSuiteHome(async (home) => {
       const configPath = path.join(home, ".remoteclaw", "remoteclaw.json");
       await fs.mkdir(path.dirname(configPath), { recursive: true });
       await fs.writeFile(
@@ -382,17 +398,14 @@ describe("config io write", () => {
       expect(snapshot.valid).toBe(true);
 
       const next = structuredClone(snapshot.config);
-      const backends = next.agents?.defaults?.cliBackends as
-        | Record<string, Record<string, unknown>>
-        | undefined;
-      const codexBackend = backends?.codex;
-      const args = Array.isArray(codexBackend?.args) ? (codexBackend?.args as string[]) : [];
+      const codexBackend = next.agents?.defaults?.cliBackends?.codex;
+      const args = Array.isArray(codexBackend?.args) ? codexBackend?.args : [];
       next.agents = {
         ...next.agents,
         defaults: {
           ...next.agents?.defaults,
           cliBackends: {
-            ...backends,
+            ...next.agents?.defaults?.cliBackends,
             codex: {
               ...codexBackend,
               command: typeof codexBackend?.command === "string" ? codexBackend.command : "codex",
@@ -424,7 +437,7 @@ describe("config io write", () => {
   });
 
   it("logs an overwrite audit entry when replacing an existing config file", async () => {
-    await withTempHome("remoteclaw-config-io-", async (home) => {
+    await withSuiteHome(async (home) => {
       const warn = vi.fn();
       const { configPath, io, snapshot } = await writeConfigAndCreateIo({
         home,
@@ -454,7 +467,7 @@ describe("config io write", () => {
   });
 
   it("does not log an overwrite audit entry when creating config for the first time", async () => {
-    await withTempHome("remoteclaw-config-io-", async (home) => {
+    await withSuiteHome(async (home) => {
       const warn = vi.fn();
       const io = createConfigIO({
         env: {} as NodeJS.ProcessEnv,
@@ -477,7 +490,7 @@ describe("config io write", () => {
   });
 
   it("appends config write audit JSONL entries with forensic metadata", async () => {
-    await withTempHome("remoteclaw-config-io-", async (home) => {
+    await withSuiteHome(async (home) => {
       const { configPath, lines, last } = await writeGatewayPatchAndReadLastAuditEntry({
         home,
         initialConfig: { gateway: { port: 18789 } },
@@ -497,7 +510,7 @@ describe("config io write", () => {
   });
 
   it("records gateway watch session markers in config audit entries", async () => {
-    await withTempHome("remoteclaw-config-io-", async (home) => {
+    await withSuiteHome(async (home) => {
       const { last } = await writeGatewayPatchAndReadLastAuditEntry({
         home,
         initialConfig: { gateway: { mode: "local" } },

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -398,14 +398,17 @@ describe("config io write", () => {
       expect(snapshot.valid).toBe(true);
 
       const next = structuredClone(snapshot.config);
-      const codexBackend = next.agents?.defaults?.cliBackends?.codex;
+      const backends = next.agents?.defaults?.cliBackends as
+        | Record<string, Record<string, unknown>>
+        | undefined;
+      const codexBackend = backends?.codex;
       const args = Array.isArray(codexBackend?.args) ? codexBackend?.args : [];
       next.agents = {
         ...next.agents,
         defaults: {
           ...next.agents?.defaults,
           cliBackends: {
-            ...next.agents?.defaults?.cliBackends,
+            ...backends,
             codex: {
               ...codexBackend,
               command: typeof codexBackend?.command === "string" ? codexBackend.command : "codex",

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -10,6 +10,7 @@ import type { ConfigFileSnapshot } from "./types.remoteclaw.js";
 import { RemoteClawSchema } from "./zod-schema.js";
 
 const { mapSensitivePaths } = __test__;
+const mainSchemaHints = mapSensitivePaths(RemoteClawSchema, "", {});
 
 type TestSnapshot<TConfig extends Record<string, unknown>> = ConfigFileSnapshot & {
   parsed: TConfig;
@@ -725,7 +726,7 @@ describe("redactConfigSnapshot", () => {
   });
 
   it("contract-covers dynamic catchall/record paths for redact+restore", () => {
-    const hints = mapSensitivePaths(RemoteClawSchema, "", {});
+    const hints = mainSchemaHints;
     const snapshot = makeSnapshot({
       env: {
         GROQ_API_KEY: "gsk-contract-123",
@@ -991,7 +992,7 @@ describe("realredactConfigSnapshot_real", () => {
       unrepresentable: "any",
     });
     schema.title = "RemoteClawConfig";
-    const hints = mapSensitivePaths(RemoteClawSchema, "", {});
+    const hints = mainSchemaHints;
 
     const snapshot = makeSnapshot({
       agents: {

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -754,50 +754,76 @@ describe("Cron issue regressions", () => {
     }
   });
 
-  it("#24355: one-shot job retries on transient error, then succeeds", async () => {
-    const store = await makeStorePath();
+  it("#24355: one-shot retries then succeeds (with and without deleteAfterRun)", async () => {
     const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
 
-    const cronJob = createIsolatedRegressionJob({
+    const runRetryScenario = async (params: {
+      id: string;
+      deleteAfterRun: boolean;
+    }): Promise<{
+      state: ReturnType<typeof createCronServiceState>;
+      runIsolatedAgentJob: ReturnType<typeof vi.fn>;
+      firstRetryAtMs: number;
+    }> => {
+      const store = await makeStorePath();
+      const cronJob = createIsolatedRegressionJob({
+        id: params.id,
+        name: "reminder",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        payload: { kind: "agentTurn", message: "remind me" },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      cronJob.deleteAfterRun = params.deleteAfterRun;
+      await writeCronJobs(store.storePath, [cronJob]);
+
+      let now = scheduledAt;
+      const runIsolatedAgentJob = vi
+        .fn()
+        .mockResolvedValueOnce({ status: "error", error: "429 rate limit exceeded" })
+        .mockResolvedValueOnce({ status: "ok", summary: "done" });
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeatNow: vi.fn(),
+        runIsolatedAgentJob,
+      });
+
+      await onTimer(state);
+      const jobAfterRetry = state.store?.jobs.find((j) => j.id === params.id);
+      expect(jobAfterRetry).toBeDefined();
+      expect(jobAfterRetry!.enabled).toBe(true);
+      expect(jobAfterRetry!.state.lastStatus).toBe("error");
+      expect(jobAfterRetry!.state.nextRunAtMs).toBeDefined();
+      expect(jobAfterRetry!.state.nextRunAtMs).toBeGreaterThan(scheduledAt);
+
+      const firstRetryAtMs = (jobAfterRetry!.state.nextRunAtMs ?? 0) + 1;
+      now = firstRetryAtMs;
+      await onTimer(state);
+      return { state, runIsolatedAgentJob, firstRetryAtMs };
+    };
+
+    const keepResult = await runRetryScenario({
       id: "oneshot-retry",
-      name: "reminder",
-      scheduledAt,
-      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
-      payload: { kind: "agentTurn", message: "remind me" },
-      state: { nextRunAtMs: scheduledAt },
+      deleteAfterRun: false,
     });
-    cronJob.deleteAfterRun = false;
-    await writeCronJobs(store.storePath, [cronJob]);
+    const keepJob = keepResult.state.store?.jobs.find((j) => j.id === "oneshot-retry");
+    expect(keepJob).toBeDefined();
+    expect(keepJob!.state.lastStatus).toBe("ok");
+    expect(keepResult.runIsolatedAgentJob).toHaveBeenCalledTimes(2);
 
-    let now = scheduledAt;
-    const runIsolatedAgentJob = vi
-      .fn()
-      .mockResolvedValueOnce({ status: "error", error: "429 rate limit exceeded" })
-      .mockResolvedValueOnce({ status: "ok", summary: "done" });
-    const state = createCronServiceState({
-      cronEnabled: true,
-      storePath: store.storePath,
-      log: noopLogger,
-      nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeatNow: vi.fn(),
-      runIsolatedAgentJob,
+    const deleteResult = await runRetryScenario({
+      id: "oneshot-deleteAfterRun-retry",
+      deleteAfterRun: true,
     });
-
-    await onTimer(state);
-    let job = state.store?.jobs.find((j) => j.id === "oneshot-retry");
-    expect(job).toBeDefined();
-    expect(job!.enabled).toBe(true);
-    expect(job!.state.lastStatus).toBe("error");
-    expect(job!.state.nextRunAtMs).toBeDefined();
-    expect(job!.state.nextRunAtMs).toBeGreaterThan(scheduledAt);
-
-    now = (job!.state.nextRunAtMs ?? 0) + 1;
-    await onTimer(state);
-    job = state.store?.jobs.find((j) => j.id === "oneshot-retry");
-    expect(job).toBeDefined();
-    expect(job!.state.lastStatus).toBe("ok");
-    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
+    const deletedJob = deleteResult.state.store?.jobs.find(
+      (j) => j.id === "oneshot-deleteAfterRun-retry",
+    );
+    expect(deletedJob).toBeUndefined();
+    expect(deleteResult.runIsolatedAgentJob).toHaveBeenCalledTimes(2);
   });
 
   it("#24355: one-shot job disabled after max transient retries", async () => {
@@ -924,52 +950,6 @@ describe("Cron issue regressions", () => {
     expect(job!.enabled).toBe(false);
     expect(job!.state.lastStatus).toBe("error");
     expect(job!.state.nextRunAtMs).toBeUndefined();
-  });
-
-  it("#24355: deleteAfterRun:true one-shot job is deleted after successful retry", async () => {
-    const store = await makeStorePath();
-    const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
-
-    const cronJob = createIsolatedRegressionJob({
-      id: "oneshot-deleteAfterRun-retry",
-      name: "reminder",
-      scheduledAt,
-      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
-      payload: { kind: "agentTurn", message: "remind me" },
-      state: { nextRunAtMs: scheduledAt },
-    });
-    cronJob.deleteAfterRun = true;
-    await writeCronJobs(store.storePath, [cronJob]);
-
-    let now = scheduledAt;
-    const runIsolatedAgentJob = vi
-      .fn()
-      .mockResolvedValueOnce({ status: "error", error: "429 rate limit exceeded" })
-      .mockResolvedValueOnce({ status: "ok", summary: "done" });
-    const state = createCronServiceState({
-      cronEnabled: true,
-      storePath: store.storePath,
-      log: noopLogger,
-      nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeatNow: vi.fn(),
-      runIsolatedAgentJob,
-    });
-
-    // First run: transient error → retry scheduled, job still in store.
-    await onTimer(state);
-    let job = state.store?.jobs.find((j) => j.id === "oneshot-deleteAfterRun-retry");
-    expect(job).toBeDefined();
-    expect(job!.enabled).toBe(true);
-    expect(job!.state.lastStatus).toBe("error");
-    expect(job!.state.nextRunAtMs).toBeGreaterThan(scheduledAt);
-
-    // Second run: success → deleteAfterRun removes the job from the store.
-    now = (job!.state.nextRunAtMs ?? 0) + 1;
-    await onTimer(state);
-    const deleted = state.store?.jobs.find((j) => j.id === "oneshot-deleteAfterRun-retry");
-    expect(deleted).toBeUndefined();
-    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
   });
 
   it("prevents spin loop when cron job completes within the scheduled second (#17821)", async () => {

--- a/src/infra/system-presence.version.test.ts
+++ b/src/infra/system-presence.version.test.ts
@@ -7,12 +7,8 @@ async function withPresenceModule<T>(
 ): Promise<T> {
   return withEnvAsync(env, async () => {
     vi.resetModules();
-    try {
-      const module = await import("./system-presence.js");
-      return await run(module);
-    } finally {
-      vi.resetModules();
-    }
+    const module = await import("./system-presence.js");
+    return await run(module);
   });
 }
 

--- a/src/test-utils/runtime-source-guardrail-scan.ts
+++ b/src/test-utils/runtime-source-guardrail-scan.ts
@@ -22,7 +22,7 @@ const DEFAULT_GUARDRAIL_SKIP_PATTERNS = [
 ];
 
 const runtimeSourceGuardrailCache = new Map<string, Promise<RuntimeSourceGuardrailFile[]>>();
-const FILE_READ_CONCURRENCY = 32;
+const FILE_READ_CONCURRENCY = 16;
 
 export function shouldSkipGuardrailRuntimeSource(relativePath: string): boolean {
   return DEFAULT_GUARDRAIL_SKIP_PATTERNS.some((pattern) => pattern.test(relativePath));

--- a/test/scripts/ios-team-id.test.ts
+++ b/test/scripts/ios-team-id.test.ts
@@ -140,22 +140,7 @@ printf 'BBBBB22222\\t0\\tBeta Team\\r\\n'`,
   });
 
   it("prints actionable guidance when Xcode account exists but no Team ID is resolvable", async () => {
-    const { homeDir, binDir } = await createHomeDir();
-    await writeExecutable(
-      path.join(binDir, "defaults"),
-      `#!/usr/bin/env bash
-if [[ "$3" == "DVTDeveloperAccountManagerAppleIDLists" ]]; then
-  echo '(identifier = "dev@example.com";)'
-  exit 0
-fi
-echo "Domain/default pair of (com.apple.dt.Xcode, $3) does not exist" >&2
-exit 1`,
-    );
-    await writeExecutable(
-      path.join(binDir, "security"),
-      `#!/usr/bin/env bash
-exit 1`,
-    );
+    const { homeDir } = await createHomeDir();
 
     const result = runScript(homeDir);
     expect(result.ok).toBe(false);

--- a/test/scripts/ios-team-id.test.ts
+++ b/test/scripts/ios-team-id.test.ts
@@ -113,11 +113,8 @@ exit 1`,
     return { homeDir, binDir };
   }
 
-  it("resolves fallback and preferred team IDs from provisioning profiles", async () => {
+  it("resolves fallback and preferred team IDs from Xcode team listings", async () => {
     const { homeDir, binDir } = await createHomeDir();
-    const profilesDir = path.join(homeDir, "Library", "MobileDevice", "Provisioning Profiles");
-    await mkdir(profilesDir, { recursive: true });
-    await writeFile(path.join(profilesDir, "one.mobileprovision"), "stub1");
     await writeExecutable(
       path.join(binDir, "fake-python"),
       `#!/usr/bin/env bash


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #723
**Commits**: 13 cherry-picked + 1 adaptation fix

| Hash | Subject | Result |
|------|---------|--------|
| `534f436d4` | test(perf): reduce repeated cli program setup overhead | RESOLVED |
| `32c724297` | test(perf): simplify ios team-id fixtures | PICKED |
| `98e5851d8` | test(perf): collapse overlapping preaction scenarios | PICKED |
| `32475448e` | test(perf): trim ios team-id fixture setup | PICKED |
| `38bdb0d27` | test(perf): prune redundant preaction command-path cases | RESOLVED |
| `7d600ff4e` | test(perf): dedupe plugin validation scenarios | RESOLVED |
| `87bd6226b` | test(perf): merge overlapping preaction hook scenarios | RESOLVED |
| `a905b6dab` | test(perf): merge duplicate one-shot retry regression paths | PICKED |
| `3f2848433` | test(perf): reuse suite temp-home fixture in config io write tests | RESOLVED |
| `db3d8d82c` | test(perf): avoid module reset churn in daemon lifecycle tests | PICKED |
| `d01e82d54` | test(perf): avoid module reload churn in config guard tests | PICKED |
| `82247f09a` | test(perf): remove redundant module reset in system presence version tests | PICKED |
| `19f5d1345` | test(perf): cache redact hints and tune guardrail scan concurrency | RESOLVED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)