### PR TITLE
Cherry-pick batch: Refactors — dedupe commands, shared types, plugin-sdk, vitest config

### DIFF
--- a/.pi/extensions/ui/paged-select.ts
+++ b/.pi/extensions/ui/paged-select.ts
@@ -1,0 +1,82 @@
+import { DynamicBorder } from "@mariozechner/pi-coding-agent";
+import {
+  Container,
+  Key,
+  matchesKey,
+  type SelectItem,
+  SelectList,
+  Text,
+} from "@mariozechner/pi-tui";
+
+type CustomUiContext = {
+  ui: {
+    custom: <T>(
+      render: (
+        tui: { requestRender: () => void },
+        theme: {
+          fg: (tone: string, text: string) => string;
+          bold: (text: string) => string;
+        },
+        kb: unknown,
+        done: () => void,
+      ) => {
+        render: (width: number) => string;
+        invalidate: () => void;
+        handleInput: (data: string) => void;
+      },
+    ) => Promise<T>;
+  };
+};
+
+export async function showPagedSelectList(params: {
+  ctx: CustomUiContext;
+  title: string;
+  items: SelectItem[];
+  onSelect: (item: SelectItem) => void;
+}): Promise<void> {
+  await params.ctx.ui.custom<void>((tui, theme, _kb, done) => {
+    const container = new Container();
+
+    container.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
+    container.addChild(new Text(theme.fg("accent", theme.bold(params.title)), 0, 0));
+
+    const visibleRows = Math.min(params.items.length, 15);
+    let currentIndex = 0;
+
+    const selectList = new SelectList(params.items, visibleRows, {
+      selectedPrefix: (text) => theme.fg("accent", text),
+      selectedText: (text) => text,
+      description: (text) => theme.fg("muted", text),
+      scrollInfo: (text) => theme.fg("dim", text),
+      noMatch: (text) => theme.fg("warning", text),
+    });
+    selectList.onSelect = (item) => params.onSelect(item);
+    selectList.onCancel = () => done();
+    selectList.onSelectionChange = (item) => {
+      currentIndex = params.items.indexOf(item);
+    };
+    container.addChild(selectList);
+
+    container.addChild(
+      new Text(theme.fg("dim", " ↑↓ navigate • ←→ page • enter open • esc close"), 0, 0),
+    );
+    container.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
+
+    return {
+      render: (width) => container.render(width),
+      invalidate: () => container.invalidate(),
+      handleInput: (data) => {
+        if (matchesKey(data, Key.left)) {
+          currentIndex = Math.max(0, currentIndex - visibleRows);
+          selectList.setSelectedIndex(currentIndex);
+        } else if (matchesKey(data, Key.right)) {
+          currentIndex = Math.min(params.items.length - 1, currentIndex + visibleRows);
+          selectList.setSelectedIndex(currentIndex);
+        } else {
+          selectList.handleInput(data);
+        }
+        tui.requestRender();
+      },
+    };
+  });
+}

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/CameraCaptureManager.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/CameraCaptureManager.kt
@@ -33,10 +33,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.contentOrNull
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.concurrent.Executor
@@ -101,7 +98,7 @@ class CameraCaptureManager(private val context: Context) {
     withContext(Dispatchers.Main) {
       ensureCameraPermission()
       val owner = lifecycleOwner ?: throw IllegalStateException("UNAVAILABLE: camera not ready")
-      val params = parseParamsObject(paramsJson)
+      val params = parseJsonParamsObject(paramsJson)
       val facing = parseFacing(params) ?: "front"
       val quality = (parseQuality(params) ?: 0.95).coerceIn(0.1, 1.0)
       val maxWidth = parseMaxWidth(params) ?: 1600
@@ -167,7 +164,7 @@ class CameraCaptureManager(private val context: Context) {
     withContext(Dispatchers.Main) {
       ensureCameraPermission()
       val owner = lifecycleOwner ?: throw IllegalStateException("UNAVAILABLE: camera not ready")
-      val params = parseParamsObject(paramsJson)
+      val params = parseJsonParamsObject(paramsJson)
       val facing = parseFacing(params) ?: "front"
       val durationMs = (parseDurationMs(params) ?: 3_000).coerceIn(200, 60_000)
       val includeAudio = parseIncludeAudio(params) ?: true
@@ -293,20 +290,8 @@ class CameraCaptureManager(private val context: Context) {
     return rotated
   }
 
-  private fun parseParamsObject(paramsJson: String?): JsonObject? {
-    if (paramsJson.isNullOrBlank()) return null
-    return try {
-      Json.parseToJsonElement(paramsJson).asObjectOrNull()
-    } catch (_: Throwable) {
-      null
-    }
-  }
-
-  private fun readPrimitive(params: JsonObject?, key: String): JsonPrimitive? =
-    params?.get(key) as? JsonPrimitive
-
   private fun parseFacing(params: JsonObject?): String? {
-    val value = readPrimitive(params, "facing")?.contentOrNull?.trim()?.lowercase() ?: return null
+    val value = parseJsonString(params, "facing")?.trim()?.lowercase() ?: return null
     return when (value) {
       "front", "back" -> value
       else -> null
@@ -314,31 +299,21 @@ class CameraCaptureManager(private val context: Context) {
   }
 
   private fun parseQuality(params: JsonObject?): Double? =
-    readPrimitive(params, "quality")?.contentOrNull?.toDoubleOrNull()
+    parseJsonDouble(params, "quality")
 
   private fun parseMaxWidth(params: JsonObject?): Int? =
-    readPrimitive(params, "maxWidth")
-      ?.contentOrNull
-      ?.toIntOrNull()
+    parseJsonInt(params, "maxWidth")
       ?.takeIf { it > 0 }
 
   private fun parseDurationMs(params: JsonObject?): Int? =
-    readPrimitive(params, "durationMs")?.contentOrNull?.toIntOrNull()
+    parseJsonInt(params, "durationMs")
 
   private fun parseDeviceId(params: JsonObject?): String? =
-    readPrimitive(params, "deviceId")
-      ?.contentOrNull
+    parseJsonString(params, "deviceId")
       ?.trim()
       ?.takeIf { it.isNotEmpty() }
 
-  private fun parseIncludeAudio(params: JsonObject?): Boolean? {
-    val value = readPrimitive(params, "includeAudio")?.contentOrNull?.trim()?.lowercase()
-    return when (value) {
-      "true" -> true
-      "false" -> false
-      else -> null
-    }
-  }
+  private fun parseIncludeAudio(params: JsonObject?): Boolean? = parseJsonBooleanFlag(params, "includeAudio")
 
   private fun Context.mainExecutor(): Executor = ContextCompat.getMainExecutor(this)
 

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/NodeUtils.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/NodeUtils.kt
@@ -1,10 +1,12 @@
 package org.remoteclaw.android.node
 
 import org.remoteclaw.android.gateway.parseInvokeErrorFromThrowable
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 
 const val DEFAULT_SEAM_COLOR_ARGB: Long = 0xFF4F7A9A
 
@@ -20,6 +22,35 @@ fun String.toJsonString(): String {
 }
 
 fun JsonElement?.asObjectOrNull(): JsonObject? = this as? JsonObject
+
+fun parseJsonParamsObject(paramsJson: String?): JsonObject? {
+  if (paramsJson.isNullOrBlank()) return null
+  return try {
+    Json.parseToJsonElement(paramsJson).asObjectOrNull()
+  } catch (_: Throwable) {
+    null
+  }
+}
+
+fun readJsonPrimitive(params: JsonObject?, key: String): JsonPrimitive? = params?.get(key) as? JsonPrimitive
+
+fun parseJsonInt(params: JsonObject?, key: String): Int? =
+  readJsonPrimitive(params, key)?.contentOrNull?.toIntOrNull()
+
+fun parseJsonDouble(params: JsonObject?, key: String): Double? =
+  readJsonPrimitive(params, key)?.contentOrNull?.toDoubleOrNull()
+
+fun parseJsonString(params: JsonObject?, key: String): String? =
+  readJsonPrimitive(params, key)?.contentOrNull
+
+fun parseJsonBooleanFlag(params: JsonObject?, key: String): Boolean? {
+  val value = readJsonPrimitive(params, key)?.contentOrNull?.trim()?.lowercase() ?: return null
+  return when (value) {
+    "true" -> true
+    "false" -> false
+    else -> null
+  }
+}
 
 fun JsonElement?.asStringOrNull(): String? =
   when (this) {

--- a/extensions/bluebubbles/src/actions.ts
+++ b/extensions/bluebubbles/src/actions.ts
@@ -5,6 +5,7 @@ import {
   extractToolSend,
   jsonResult,
   readNumberParam,
+  readBooleanParam,
   readReactionParams,
   readStringParam,
   type ChannelMessageActionAdapter,
@@ -50,23 +51,6 @@ function mapTarget(raw: string): BlueBubblesSendTarget {
 
 function readMessageText(params: Record<string, unknown>): string | undefined {
   return readStringParam(params, "text") ?? readStringParam(params, "message");
-}
-
-function readBooleanParam(params: Record<string, unknown>, key: string): boolean | undefined {
-  const raw = params[key];
-  if (typeof raw === "boolean") {
-    return raw;
-  }
-  if (typeof raw === "string") {
-    const trimmed = raw.trim().toLowerCase();
-    if (trimmed === "true") {
-      return true;
-    }
-    if (trimmed === "false") {
-      return false;
-    }
-  }
-  return undefined;
 }
 
 /** Supported action names for BlueBubbles */

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -2,7 +2,6 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { RemoteClawConfig } from "remoteclaw/plugin-sdk";
 import {
   GROUP_POLICY_BLOCKED_LABEL,
-  createInboundEnvelopeBuilder,
   createScopedPairingAccess,
   createReplyPrefixOptions,
   readJsonBodyWithLimit,
@@ -11,6 +10,7 @@ import {
   isDangerousNameMatchingEnabled,
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
+  resolveInboundRouteEnvelopeBuilderWithRuntime,
   resolveSingleWebhookTargetAsync,
   resolveWebhookPath,
   resolveWebhookTargets,
@@ -638,7 +638,7 @@ async function processMessageWithPipeline(params: {
     return;
   }
 
-  const route = core.channel.routing.resolveAgentRoute({
+  const { route, buildEnvelope } = resolveInboundRouteEnvelopeBuilderWithRuntime({
     cfg: config,
     channel: "googlechat",
     accountId: account.accountId,
@@ -646,15 +646,8 @@ async function processMessageWithPipeline(params: {
       kind: isGroup ? "group" : "direct",
       id: spaceId,
     },
-  });
-  const buildEnvelope = createInboundEnvelopeBuilder({
-    cfg: config,
-    route,
+    runtime: core.channel,
     sessionStore: config.session?.store,
-    resolveStorePath: core.channel.session.resolveStorePath,
-    readSessionUpdatedAt: core.channel.session.readSessionUpdatedAt,
-    resolveEnvelopeFormatOptions: core.channel.reply.resolveEnvelopeFormatOptions,
-    formatAgentEnvelope: core.channel.reply.formatAgentEnvelope,
   });
 
   let mediaPath: string | undefined;

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -646,7 +646,8 @@ async function processMessageWithPipeline(params: {
       kind: isGroup ? "group" : "direct",
       id: spaceId,
     },
-    runtime: core.channel,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    runtime: core.channel as any,
     sessionStore: config.session?.store,
   });
 

--- a/extensions/matrix/src/matrix/monitor/allowlist.ts
+++ b/extensions/matrix/src/matrix/monitor/allowlist.ts
@@ -78,7 +78,10 @@ export function resolveMatrixAllowListMatch(params: {
     return { allowed: true, matchKey: "*", matchSource: "wildcard" };
   }
   const userId = normalizeMatrixUser(params.userId);
-  const candidates: Array<{ value?: string; source: MatrixAllowListMatch["matchSource"] }> = [
+  const candidates: Array<{
+    value?: string;
+    source: NonNullable<MatrixAllowListMatch["matchSource"]>;
+  }> = [
     { value: userId, source: "id" },
     { value: userId ? `matrix:${userId}` : "", source: "prefixed-id" },
     { value: userId ? `user:${userId}` : "", source: "prefixed-user" },

--- a/extensions/matrix/src/matrix/monitor/allowlist.ts
+++ b/extensions/matrix/src/matrix/monitor/allowlist.ts
@@ -1,4 +1,4 @@
-import type { AllowlistMatch } from "remoteclaw/plugin-sdk";
+import { resolveAllowlistMatchByCandidates, type AllowlistMatch } from "remoteclaw/plugin-sdk";
 
 function normalizeAllowList(list?: Array<string | number>) {
   return (list ?? []).map((entry) => String(entry).trim()).filter(Boolean);
@@ -83,19 +83,7 @@ export function resolveMatrixAllowListMatch(params: {
     { value: userId ? `matrix:${userId}` : "", source: "prefixed-id" },
     { value: userId ? `user:${userId}` : "", source: "prefixed-user" },
   ];
-  for (const candidate of candidates) {
-    if (!candidate.value) {
-      continue;
-    }
-    if (allowList.includes(candidate.value)) {
-      return {
-        allowed: true,
-        matchKey: candidate.value,
-        matchSource: candidate.source,
-      };
-    }
-  }
-  return { allowed: false };
+  return resolveAllowlistMatchByCandidates({ allowList, candidates });
 }
 
 export function resolveMatrixAllowListMatches(params: { allowList: string[]; userId?: string }) {

--- a/extensions/matrix/src/matrix/monitor/allowlist.ts
+++ b/extensions/matrix/src/matrix/monitor/allowlist.ts
@@ -83,7 +83,7 @@ export function resolveMatrixAllowListMatch(params: {
     { value: userId ? `matrix:${userId}` : "", source: "prefixed-id" },
     { value: userId ? `user:${userId}` : "", source: "prefixed-user" },
   ];
-  return resolveAllowlistMatchByCandidates({ allowList, candidates });
+  return resolveAllowlistMatchByCandidates({ allowList, candidates }) as MatrixAllowListMatch;
 }
 
 export function resolveMatrixAllowListMatches(params: { allowList: string[]; userId?: string }) {

--- a/extensions/nextcloud-talk/src/accounts.ts
+++ b/extensions/nextcloud-talk/src/accounts.ts
@@ -1,5 +1,9 @@
 import { readFileSync } from "node:fs";
 import {
+  listConfiguredAccountIds as listConfiguredAccountIdsFromSection,
+  resolveAccountWithDefaultFallback,
+} from "openclaw/plugin-sdk";
+import {
   DEFAULT_ACCOUNT_ID,
   normalizeAccountId,
   normalizeOptionalAccountId,
@@ -28,18 +32,10 @@ export type ResolvedNextcloudTalkAccount = {
 };
 
 function listConfiguredAccountIds(cfg: CoreConfig): string[] {
-  const accounts = cfg.channels?.["nextcloud-talk"]?.accounts;
-  if (!accounts || typeof accounts !== "object") {
-    return [];
-  }
-  const ids = new Set<string>();
-  for (const key of Object.keys(accounts)) {
-    if (!key) {
-      continue;
-    }
-    ids.add(normalizeAccountId(key));
-  }
-  return [...ids];
+  return listConfiguredAccountIdsFromSection({
+    accounts: cfg.channels?.["nextcloud-talk"]?.accounts as Record<string, unknown> | undefined,
+    normalizeAccountId,
+  });
 }
 
 export function listNextcloudTalkAccountIds(cfg: CoreConfig): string[] {
@@ -134,7 +130,6 @@ export function resolveNextcloudTalkAccount(params: {
   cfg: CoreConfig;
   accountId?: string | null;
 }): ResolvedNextcloudTalkAccount {
-  const hasExplicitAccountId = Boolean(params.accountId?.trim());
   const baseEnabled = params.cfg.channels?.["nextcloud-talk"]?.enabled !== false;
 
   const resolve = (accountId: string) => {
@@ -162,24 +157,13 @@ export function resolveNextcloudTalkAccount(params: {
     } satisfies ResolvedNextcloudTalkAccount;
   };
 
-  const normalized = normalizeAccountId(params.accountId);
-  const primary = resolve(normalized);
-  if (hasExplicitAccountId) {
-    return primary;
-  }
-  if (primary.secretSource !== "none") {
-    return primary;
-  }
-
-  const fallbackId = resolveDefaultNextcloudTalkAccountId(params.cfg);
-  if (fallbackId === primary.accountId) {
-    return primary;
-  }
-  const fallback = resolve(fallbackId);
-  if (fallback.secretSource === "none") {
-    return primary;
-  }
-  return fallback;
+  return resolveAccountWithDefaultFallback({
+    accountId: params.accountId,
+    normalizeAccountId,
+    resolvePrimary: resolve,
+    hasCredential: (account) => account.secretSource !== "none",
+    resolveDefaultAccountId: () => resolveDefaultNextcloudTalkAccountId(params.cfg),
+  });
 }
 
 export function listEnabledNextcloudTalkAccounts(cfg: CoreConfig): ResolvedNextcloudTalkAccount[] {

--- a/extensions/nextcloud-talk/src/accounts.ts
+++ b/extensions/nextcloud-talk/src/accounts.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import {
   listConfiguredAccountIds as listConfiguredAccountIdsFromSection,
   resolveAccountWithDefaultFallback,
-} from "openclaw/plugin-sdk";
+} from "remoteclaw/plugin-sdk";
 import {
   DEFAULT_ACCOUNT_ID,
   normalizeAccountId,

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -5,12 +5,13 @@ import type {
   OutboundReplyPayload,
 } from "remoteclaw/plugin-sdk";
 import {
-  createInboundEnvelopeBuilder,
   createScopedPairingAccess,
   createReplyPrefixOptions,
-  resolveSenderCommandAuthorization,
+  resolveDirectDmAuthorizationOutcome,
+  resolveSenderCommandAuthorizationWithRuntime,
   resolveOutboundMediaUrls,
   resolveDefaultGroupPolicy,
+  resolveInboundRouteEnvelopeBuilderWithRuntime,
   sendMediaWithLeadingCaption,
   resolveWebhookPath,
   warnMissingProviderGroupPolicyFallbackOnce,
@@ -371,75 +372,67 @@ async function processMessageWithPipeline(params: {
   }
 
   const rawBody = text?.trim() || (mediaPath ? "<media:image>" : "");
-  const { senderAllowedForCommands, commandAuthorized } = await resolveSenderCommandAuthorization({
-    cfg: config,
-    rawBody,
+  const { senderAllowedForCommands, commandAuthorized } =
+    await resolveSenderCommandAuthorizationWithRuntime({
+      cfg: config,
+      rawBody,
+      isGroup,
+      dmPolicy,
+      configuredAllowFrom: configAllowFrom,
+      configuredGroupAllowFrom: groupAllowFrom,
+      senderId,
+      isSenderAllowed: isZaloSenderAllowed,
+      readAllowFromStore: pairing.readAllowFromStore,
+      runtime: core.channel.commands,
+    });
+
+  const directDmOutcome = resolveDirectDmAuthorizationOutcome({
     isGroup,
     dmPolicy,
-    configuredAllowFrom: configAllowFrom,
-    configuredGroupAllowFrom: groupAllowFrom,
-    senderId,
-    isSenderAllowed: isZaloSenderAllowed,
-    readAllowFromStore: pairing.readAllowFromStore,
-    shouldComputeCommandAuthorized: (body, cfg) =>
-      core.channel.commands.shouldComputeCommandAuthorized(body, cfg),
-    resolveCommandAuthorizedFromAuthorizers: (params) =>
-      core.channel.commands.resolveCommandAuthorizedFromAuthorizers(params),
+    senderAllowedForCommands,
   });
+  if (directDmOutcome === "disabled") {
+    logVerbose(core, runtime, `Blocked zalo DM from ${senderId} (dmPolicy=disabled)`);
+    return;
+  }
+  if (directDmOutcome === "unauthorized") {
+    if (dmPolicy === "pairing") {
+      const { code, created } = await pairing.upsertPairingRequest({
+        id: senderId,
+        meta: { name: senderName ?? undefined },
+      });
 
-  if (!isGroup) {
-    if (dmPolicy === "disabled") {
-      logVerbose(core, runtime, `Blocked zalo DM from ${senderId} (dmPolicy=disabled)`);
-      return;
-    }
-
-    if (dmPolicy !== "open") {
-      const allowed = senderAllowedForCommands;
-
-      if (!allowed) {
-        if (dmPolicy === "pairing") {
-          const { code, created } = await pairing.upsertPairingRequest({
-            id: senderId,
-            meta: { name: senderName ?? undefined },
-          });
-
-          if (created) {
-            logVerbose(core, runtime, `zalo pairing request sender=${senderId}`);
-            try {
-              await sendMessage(
-                token,
-                {
-                  chat_id: chatId,
-                  text: core.channel.pairing.buildPairingReply({
-                    channel: "zalo",
-                    idLine: `Your Zalo user id: ${senderId}`,
-                    code,
-                  }),
-                },
-                fetcher,
-              );
-              statusSink?.({ lastOutboundAt: Date.now() });
-            } catch (err) {
-              logVerbose(
-                core,
-                runtime,
-                `zalo pairing reply failed for ${senderId}: ${String(err)}`,
-              );
-            }
-          }
-        } else {
-          logVerbose(
-            core,
-            runtime,
-            `Blocked unauthorized zalo sender ${senderId} (dmPolicy=${dmPolicy})`,
+      if (created) {
+        logVerbose(core, runtime, `zalo pairing request sender=${senderId}`);
+        try {
+          await sendMessage(
+            token,
+            {
+              chat_id: chatId,
+              text: core.channel.pairing.buildPairingReply({
+                channel: "zalo",
+                idLine: `Your Zalo user id: ${senderId}`,
+                code,
+              }),
+            },
+            fetcher,
           );
+          statusSink?.({ lastOutboundAt: Date.now() });
+        } catch (err) {
+          logVerbose(core, runtime, `zalo pairing reply failed for ${senderId}: ${String(err)}`);
         }
-        return;
       }
+    } else {
+      logVerbose(
+        core,
+        runtime,
+        `Blocked unauthorized zalo sender ${senderId} (dmPolicy=${dmPolicy})`,
+      );
     }
+    return;
   }
 
-  const route = core.channel.routing.resolveAgentRoute({
+  const { route, buildEnvelope } = resolveInboundRouteEnvelopeBuilderWithRuntime({
     cfg: config,
     channel: "zalo",
     accountId: account.accountId,
@@ -447,15 +440,8 @@ async function processMessageWithPipeline(params: {
       kind: isGroup ? "group" : "direct",
       id: chatId,
     },
-  });
-  const buildEnvelope = createInboundEnvelopeBuilder({
-    cfg: config,
-    route,
+    runtime: core.channel,
     sessionStore: config.session?.store,
-    resolveStorePath: core.channel.session.resolveStorePath,
-    readSessionUpdatedAt: core.channel.session.readSessionUpdatedAt,
-    resolveEnvelopeFormatOptions: core.channel.reply.resolveEnvelopeFormatOptions,
-    formatAgentEnvelope: core.channel.reply.formatAgentEnvelope,
   });
 
   if (

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -440,7 +440,8 @@ async function processMessageWithPipeline(params: {
       kind: isGroup ? "group" : "direct",
       id: chatId,
     },
-    runtime: core.channel,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    runtime: core.channel as any,
     sessionStore: config.session?.store,
   });
 

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -177,7 +177,6 @@ async function processMessage(
 
   const dmPolicy = account.config.dmPolicy ?? "pairing";
   const configAllowFrom = (account.config.allowFrom ?? []).map((v) => String(v));
-  const rawBody = content.trim();
   const { senderAllowedForCommands, commandAuthorized } =
     await resolveSenderCommandAuthorizationWithRuntime({
       cfg: config,
@@ -264,7 +263,8 @@ async function processMessage(
       kind: peer.kind,
       id: peer.id,
     },
-    runtime: core.channel,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    runtime: core.channel as any,
     sessionStore: config.session?.store,
   });
 

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -9,9 +9,11 @@ import {
   createReplyPrefixOptions,
   resolveOutboundMediaUrls,
   mergeAllowlist,
+  resolveDirectDmAuthorizationOutcome,
   resolveOpenProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
-  resolveSenderCommandAuthorization,
+  resolveInboundRouteEnvelopeBuilderWithRuntime,
+  resolveSenderCommandAuthorizationWithRuntime,
   sendMediaWithLeadingCaption,
   summarizeMapping,
   warnMissingProviderGroupPolicyFallbackOnce,
@@ -175,67 +177,65 @@ async function processMessage(
 
   const dmPolicy = account.config.dmPolicy ?? "pairing";
   const configAllowFrom = (account.config.allowFrom ?? []).map((v) => String(v));
-  const { senderAllowedForCommands, commandAuthorized } = await resolveSenderCommandAuthorization({
-    cfg: config,
-    rawBody,
+  const rawBody = content.trim();
+  const { senderAllowedForCommands, commandAuthorized } =
+    await resolveSenderCommandAuthorizationWithRuntime({
+      cfg: config,
+      rawBody,
+      isGroup,
+      dmPolicy,
+      configuredAllowFrom: configAllowFrom,
+      senderId,
+      isSenderAllowed,
+      readAllowFromStore: pairing.readAllowFromStore,
+      runtime: core.channel.commands,
+    });
+
+  const directDmOutcome = resolveDirectDmAuthorizationOutcome({
     isGroup,
     dmPolicy,
-    configuredAllowFrom: configAllowFrom,
-    senderId,
-    isSenderAllowed,
-    readAllowFromStore: pairing.readAllowFromStore,
-    shouldComputeCommandAuthorized: (body, cfg) =>
-      core.channel.commands.shouldComputeCommandAuthorized(body, cfg),
-    resolveCommandAuthorizedFromAuthorizers: (params) =>
-      core.channel.commands.resolveCommandAuthorizedFromAuthorizers(params),
+    senderAllowedForCommands,
   });
+  if (directDmOutcome === "disabled") {
+    logVerbose(core, runtime, `Blocked zalouser DM from ${senderId} (dmPolicy=disabled)`);
+    return;
+  }
+  if (directDmOutcome === "unauthorized") {
+    if (dmPolicy === "pairing") {
+      const { code, created } = await pairing.upsertPairingRequest({
+        id: senderId,
+        meta: { name: senderName || undefined },
+      });
 
-  if (!isGroup) {
-    if (dmPolicy === "disabled") {
-      logVerbose(core, runtime, `Blocked zalouser DM from ${senderId} (dmPolicy=disabled)`);
-      return;
-    }
-
-    if (dmPolicy !== "open") {
-      const allowed = senderAllowedForCommands;
-      if (!allowed) {
-        if (dmPolicy === "pairing") {
-          const { code, created } = await pairing.upsertPairingRequest({
-            id: senderId,
-            meta: { name: senderName || undefined },
-          });
-
-          if (created) {
-            logVerbose(core, runtime, `zalouser pairing request sender=${senderId}`);
-            try {
-              await sendMessageZalouser(
-                chatId,
-                core.channel.pairing.buildPairingReply({
-                  channel: "zalouser",
-                  idLine: `Your Zalo user id: ${senderId}`,
-                  code,
-                }),
-                { profile: account.profile },
-              );
-              statusSink?.({ lastOutboundAt: Date.now() });
-            } catch (err) {
-              logVerbose(
-                core,
-                runtime,
-                `zalouser pairing reply failed for ${senderId}: ${String(err)}`,
-              );
-            }
-          }
-        } else {
+      if (created) {
+        logVerbose(core, runtime, `zalouser pairing request sender=${senderId}`);
+        try {
+          await sendMessageZalouser(
+            chatId,
+            core.channel.pairing.buildPairingReply({
+              channel: "zalouser",
+              idLine: `Your Zalo user id: ${senderId}`,
+              code,
+            }),
+            { profile: account.profile },
+          );
+          statusSink?.({ lastOutboundAt: Date.now() });
+        } catch (err) {
           logVerbose(
             core,
             runtime,
-            `Blocked unauthorized zalouser sender ${senderId} (dmPolicy=${dmPolicy})`,
+            `zalouser pairing reply failed for ${senderId}: ${String(err)}`,
           );
         }
-        return;
       }
+    } else {
+      logVerbose(
+        core,
+        runtime,
+        `Blocked unauthorized zalouser sender ${senderId} (dmPolicy=${dmPolicy})`,
+      );
     }
+    return;
   }
 
   if (
@@ -255,7 +255,7 @@ async function processMessage(
     ? { kind: "group" as const, id: chatId }
     : { kind: "group" as const, id: senderId };
 
-  const route = core.channel.routing.resolveAgentRoute({
+  const { route, buildEnvelope } = resolveInboundRouteEnvelopeBuilderWithRuntime({
     cfg: config,
     channel: "zalouser",
     accountId: account.accountId,
@@ -264,6 +264,8 @@ async function processMessage(
       kind: peer.kind,
       id: peer.id,
     },
+    runtime: core.channel,
+    sessionStore: config.session?.store,
   });
 
   const fromLabel = isGroup ? groupName || `group:${chatId}` : senderName || `user:${senderId}`;

--- a/scripts/check-no-pairing-store-group-auth.mjs
+++ b/scripts/check-no-pairing-store-group-auth.mjs
@@ -1,24 +1,22 @@
 #!/usr/bin/env node
 
-import path from "node:path";
 import ts from "typescript";
+import { createPairingGuardContext } from "./lib/pairing-guard-context.mjs";
 import {
   collectFileViolations,
   getPropertyNameText,
-  resolveRepoRoot,
   runAsScript,
   toLine,
 } from "./lib/ts-guard-utils.mjs";
 
-const repoRoot = resolveRepoRoot(import.meta.url);
-const sourceRoots = [path.join(repoRoot, "src"), path.join(repoRoot, "extensions")];
+const { repoRoot, sourceRoots, resolveFromRepo } = createPairingGuardContext(import.meta.url);
 
 const allowedFiles = new Set([
-  path.join(repoRoot, "src", "security", "dm-policy-shared.ts"),
-  path.join(repoRoot, "src", "channels", "allow-from.ts"),
+  resolveFromRepo("src/security/dm-policy-shared.ts"),
+  resolveFromRepo("src/channels/allow-from.ts"),
   // Config migration/audit logic may intentionally reference store + group fields.
-  path.join(repoRoot, "src", "security", "fix.ts"),
-  path.join(repoRoot, "src", "security", "audit-channel.ts"),
+  resolveFromRepo("src/security/fix.ts"),
+  resolveFromRepo("src/security/audit-channel.ts"),
 ]);
 
 const storeIdentifierRe = /^(?:storeAllowFrom|storedAllowFrom|storeAllowList)$/i;

--- a/scripts/check-no-random-messaging-tmp.mjs
+++ b/scripts/check-no-random-messaging-tmp.mjs
@@ -1,24 +1,11 @@
 #!/usr/bin/env node
 
-import { promises as fs } from "node:fs";
-import path from "node:path";
 import ts from "typescript";
-import {
-  collectTypeScriptFiles,
-  resolveRepoRoot,
-  runAsScript,
-  toLine,
-  unwrapExpression,
-} from "./lib/ts-guard-utils.mjs";
+import { runCallsiteGuard } from "./lib/callsite-guard.mjs";
+import { runAsScript, toLine, unwrapExpression } from "./lib/ts-guard-utils.mjs";
 
-const repoRoot = resolveRepoRoot(import.meta.url);
-const sourceRoots = [
-  path.join(repoRoot, "src", "channels"),
-  path.join(repoRoot, "src", "infra", "outbound"),
-  path.join(repoRoot, "src", "line"),
-  path.join(repoRoot, "extensions"),
-];
-const allowedCallsites = new Set([path.join(repoRoot, "extensions", "feishu", "src", "dedup.ts")]);
+const sourceRoots = ["src/channels", "src/infra/outbound", "src/line", "extensions"];
+const allowedRelativePaths = new Set(["extensions/feishu/src/dedup.ts"]);
 
 function collectOsTmpdirImports(sourceFile) {
   const osModuleSpecifiers = new Set(["node:os", "os"]);
@@ -81,40 +68,16 @@ export function findMessagingTmpdirCallLines(content, fileName = "source.ts") {
 }
 
 export async function main() {
-  const files = (
-    await Promise.all(
-      sourceRoots.map(
-        async (dir) =>
-          await collectTypeScriptFiles(dir, {
-            ignoreMissing: true,
-          }),
-      ),
-    )
-  ).flat();
-  const violations = [];
-
-  for (const filePath of files) {
-    if (allowedCallsites.has(filePath)) {
-      continue;
-    }
-    const content = await fs.readFile(filePath, "utf8");
-    for (const line of findMessagingTmpdirCallLines(content, filePath)) {
-      violations.push(`${path.relative(repoRoot, filePath)}:${line}`);
-    }
-  }
-
-  if (violations.length === 0) {
-    return;
-  }
-
-  console.error("Found os.tmpdir()/tmpdir() usage in messaging/channel runtime sources:");
-  for (const violation of violations) {
-    console.error(`- ${violation}`);
-  }
-  console.error(
-    "Use resolvePreferredRemoteClawTmpDir() or plugin-sdk temp helpers instead of host tmp defaults.",
-  );
-  process.exit(1);
+  await runCallsiteGuard({
+    importMetaUrl: import.meta.url,
+    sourceRoots,
+    findCallLines: findMessagingTmpdirCallLines,
+    skipRelativePath: (relativePath) => allowedRelativePaths.has(relativePath),
+    header: "Found os.tmpdir()/tmpdir() usage in messaging/channel runtime sources:",
+    footer:
+      "Use resolvePreferredRemoteClawTmpDir() or plugin-sdk temp helpers instead of host tmp defaults.",
+    sortViolations: false,
+  });
 }
 
 runAsScript(import.meta.url, main);

--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -1,28 +1,20 @@
 #!/usr/bin/env node
 
-import { promises as fs } from "node:fs";
-import path from "node:path";
 import ts from "typescript";
-import {
-  collectTypeScriptFiles,
-  resolveRepoRoot,
-  runAsScript,
-  toLine,
-  unwrapExpression,
-} from "./lib/ts-guard-utils.mjs";
+import { runCallsiteGuard } from "./lib/callsite-guard.mjs";
+import { runAsScript, toLine, unwrapExpression } from "./lib/ts-guard-utils.mjs";
 
-const repoRoot = resolveRepoRoot(import.meta.url);
 const sourceRoots = [
-  path.join(repoRoot, "src", "telegram"),
-  path.join(repoRoot, "src", "discord"),
-  path.join(repoRoot, "src", "slack"),
-  path.join(repoRoot, "src", "signal"),
-  path.join(repoRoot, "src", "imessage"),
-  path.join(repoRoot, "src", "web"),
-  path.join(repoRoot, "src", "channels"),
-  path.join(repoRoot, "src", "routing"),
-  path.join(repoRoot, "src", "line"),
-  path.join(repoRoot, "extensions"),
+  "src/telegram",
+  "src/discord",
+  "src/slack",
+  "src/signal",
+  "src/imessage",
+  "src/web",
+  "src/channels",
+  "src/routing",
+  "src/line",
+  "extensions",
 ];
 
 // Temporary allowlist for legacy callsites. New raw fetch callsites in channel/plugin runtime
@@ -100,43 +92,15 @@ export function findRawFetchCallLines(content, fileName = "source.ts") {
 }
 
 export async function main() {
-  const files = (
-    await Promise.all(
-      sourceRoots.map(
-        async (sourceRoot) =>
-          await collectTypeScriptFiles(sourceRoot, {
-            extraTestSuffixes: [".browser.test.ts", ".node.test.ts"],
-            ignoreMissing: true,
-          }),
-      ),
-    )
-  ).flat();
-
-  const violations = [];
-  for (const filePath of files) {
-    const content = await fs.readFile(filePath, "utf8");
-    const relPath = path.relative(repoRoot, filePath).replaceAll(path.sep, "/");
-    for (const line of findRawFetchCallLines(content, filePath)) {
-      const callsite = `${relPath}:${line}`;
-      if (allowedRawFetchCallsites.has(callsite)) {
-        continue;
-      }
-      violations.push(callsite);
-    }
-  }
-
-  if (violations.length === 0) {
-    return;
-  }
-
-  console.error("Found raw fetch() usage in channel/plugin runtime sources outside allowlist:");
-  for (const violation of violations.toSorted()) {
-    console.error(`- ${violation}`);
-  }
-  console.error(
-    "Use fetchWithSsrFGuard() or existing channel/plugin SDK wrappers for network calls.",
-  );
-  process.exit(1);
+  await runCallsiteGuard({
+    importMetaUrl: import.meta.url,
+    sourceRoots,
+    extraTestSuffixes: [".browser.test.ts", ".node.test.ts"],
+    findCallLines: findRawFetchCallLines,
+    allowCallsite: (callsite) => allowedRawFetchCallsites.has(callsite),
+    header: "Found raw fetch() usage in channel/plugin runtime sources outside allowlist:",
+    footer: "Use fetchWithSsrFGuard() or existing channel/plugin SDK wrappers for network calls.",
+  });
 }
 
 runAsScript(import.meta.url, main);

--- a/scripts/check-pairing-account-scope.mjs
+++ b/scripts/check-pairing-account-scope.mjs
@@ -1,17 +1,15 @@
 #!/usr/bin/env node
 
-import path from "node:path";
 import ts from "typescript";
+import { createPairingGuardContext } from "./lib/pairing-guard-context.mjs";
 import {
   collectFileViolations,
   getPropertyNameText,
-  resolveRepoRoot,
   runAsScript,
   toLine,
 } from "./lib/ts-guard-utils.mjs";
 
-const repoRoot = resolveRepoRoot(import.meta.url);
-const sourceRoots = [path.join(repoRoot, "src"), path.join(repoRoot, "extensions")];
+const { repoRoot, sourceRoots } = createPairingGuardContext(import.meta.url);
 
 function isUndefinedLikeExpression(node) {
   if (ts.isIdentifier(node) && node.text === "undefined") {

--- a/scripts/lib/callsite-guard.mjs
+++ b/scripts/lib/callsite-guard.mjs
@@ -1,0 +1,45 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  collectTypeScriptFilesFromRoots,
+  resolveRepoRoot,
+  resolveSourceRoots,
+} from "./ts-guard-utils.mjs";
+
+export async function runCallsiteGuard(params) {
+  const repoRoot = resolveRepoRoot(params.importMetaUrl);
+  const sourceRoots = resolveSourceRoots(repoRoot, params.sourceRoots);
+  const files = await collectTypeScriptFilesFromRoots(sourceRoots, {
+    extraTestSuffixes: params.extraTestSuffixes,
+  });
+  const violations = [];
+
+  for (const filePath of files) {
+    const relPath = path.relative(repoRoot, filePath).replaceAll(path.sep, "/");
+    if (params.skipRelativePath?.(relPath)) {
+      continue;
+    }
+    const content = await fs.readFile(filePath, "utf8");
+    for (const line of params.findCallLines(content, filePath)) {
+      const callsite = `${relPath}:${line}`;
+      if (params.allowCallsite?.(callsite)) {
+        continue;
+      }
+      violations.push(callsite);
+    }
+  }
+
+  if (violations.length === 0) {
+    return;
+  }
+
+  console.error(params.header);
+  const output = params.sortViolations === false ? violations : violations.toSorted();
+  for (const violation of output) {
+    console.error(`- ${violation}`);
+  }
+  if (params.footer) {
+    console.error(params.footer);
+  }
+  process.exit(1);
+}

--- a/scripts/lib/pairing-guard-context.mjs
+++ b/scripts/lib/pairing-guard-context.mjs
@@ -1,0 +1,13 @@
+import path from "node:path";
+import { resolveRepoRoot, resolveSourceRoots } from "./ts-guard-utils.mjs";
+
+export function createPairingGuardContext(importMetaUrl) {
+  const repoRoot = resolveRepoRoot(importMetaUrl);
+  const sourceRoots = resolveSourceRoots(repoRoot, ["src", "extensions"]);
+  return {
+    repoRoot,
+    sourceRoots,
+    resolveFromRepo: (relativePath) =>
+      path.join(repoRoot, ...relativePath.split("/").filter(Boolean)),
+  };
+}

--- a/scripts/lib/ts-guard-utils.mjs
+++ b/scripts/lib/ts-guard-utils.mjs
@@ -9,6 +9,10 @@ export function resolveRepoRoot(importMetaUrl) {
   return path.resolve(path.dirname(fileURLToPath(importMetaUrl)), "..", "..");
 }
 
+export function resolveSourceRoots(repoRoot, relativeRoots) {
+  return relativeRoots.map((root) => path.join(repoRoot, ...root.split("/").filter(Boolean)));
+}
+
 export function isTestLikeTypeScriptFile(filePath, options = {}) {
   const extraTestSuffixes = options.extraTestSuffixes ?? [];
   return [...baseTestSuffixes, ...extraTestSuffixes].some((suffix) => filePath.endsWith(suffix));
@@ -68,18 +72,24 @@ export async function collectTypeScriptFiles(targetPath, options = {}) {
   return out;
 }
 
-export async function collectFileViolations(params) {
-  const files = (
+export async function collectTypeScriptFilesFromRoots(sourceRoots, options = {}) {
+  return (
     await Promise.all(
-      params.sourceRoots.map(
+      sourceRoots.map(
         async (root) =>
           await collectTypeScriptFiles(root, {
             ignoreMissing: true,
-            extraTestSuffixes: params.extraTestSuffixes,
+            ...options,
           }),
       ),
     )
   ).flat();
+}
+
+export async function collectFileViolations(params) {
+  const files = await collectTypeScriptFilesFromRoots(params.sourceRoots, {
+    extraTestSuffixes: params.extraTestSuffixes,
+  });
 
   const violations = [];
   for (const filePath of files) {

--- a/src/channels/allowlist-match.ts
+++ b/src/channels/allowlist-match.ts
@@ -22,6 +22,25 @@ export function formatAllowlistMatchMeta(
   return `matchKey=${match?.matchKey ?? "none"} matchSource=${match?.matchSource ?? "none"}`;
 }
 
+export function resolveAllowlistMatchByCandidates<TSource extends string>(params: {
+  allowList: string[];
+  candidates: Array<{ value?: string; source: TSource }>;
+}): AllowlistMatch<TSource> {
+  for (const candidate of params.candidates) {
+    if (!candidate.value) {
+      continue;
+    }
+    if (params.allowList.includes(candidate.value)) {
+      return {
+        allowed: true,
+        matchKey: candidate.value,
+        matchSource: candidate.source,
+      };
+    }
+  }
+  return { allowed: false };
+}
+
 export function resolveAllowlistMatchSimple(params: {
   allowFrom: Array<string | number>;
   senderId: string;

--- a/src/commands/session-store-targets.ts
+++ b/src/commands/session-store-targets.ts
@@ -2,6 +2,7 @@ import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveStorePath } from "../config/sessions.js";
 import type { RemoteClawConfig } from "../config/types.remoteclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
+import type { RuntimeEnv } from "../runtime.js";
 
 export type SessionStoreSelectionOptions = {
   store?: string;
@@ -77,4 +78,18 @@ export function resolveSessionStoreTargets(
       storePath: resolveStorePath(cfg.session?.store, { agentId: defaultAgentId }),
     },
   ];
+}
+
+export function resolveSessionStoreTargetsOrExit(params: {
+  cfg: RemoteClawConfig;
+  opts: SessionStoreSelectionOptions;
+  runtime: RuntimeEnv;
+}): SessionStoreTarget[] | null {
+  try {
+    return resolveSessionStoreTargets(params.cfg, params.opts);
+  } catch (error) {
+    params.runtime.error(error instanceof Error ? error.message : String(error));
+    params.runtime.exit(1);
+    return null;
+  }
 }

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -5,6 +5,7 @@ import type { RuntimeEnv } from "../runtime.js";
 const mocks = vi.hoisted(() => ({
   loadConfig: vi.fn(),
   resolveSessionStoreTargets: vi.fn(),
+  resolveSessionStoreTargetsOrExit: vi.fn(),
   resolveMaintenanceConfig: vi.fn(),
   loadSessionStore: vi.fn(),
   resolveSessionFilePath: vi.fn(),
@@ -21,6 +22,7 @@ vi.mock("../config/config.js", () => ({
 
 vi.mock("./session-store-targets.js", () => ({
   resolveSessionStoreTargets: mocks.resolveSessionStoreTargets,
+  resolveSessionStoreTargetsOrExit: mocks.resolveSessionStoreTargetsOrExit,
 }));
 
 vi.mock("../config/sessions.js", () => ({
@@ -55,6 +57,17 @@ describe("sessionsCleanupCommand", () => {
     mocks.resolveSessionStoreTargets.mockReturnValue([
       { agentId: "main", storePath: "/resolved/sessions.json" },
     ]);
+    mocks.resolveSessionStoreTargetsOrExit.mockImplementation(
+      (params: { cfg: unknown; opts: unknown; runtime: RuntimeEnv }) => {
+        try {
+          return mocks.resolveSessionStoreTargets(params.cfg, params.opts);
+        } catch (error) {
+          params.runtime.error(error instanceof Error ? error.message : String(error));
+          params.runtime.exit(1);
+          return null;
+        }
+      },
+    );
     mocks.resolveMaintenanceConfig.mockReturnValue({
       mode: "warn",
       pruneAfterMs: 7 * 24 * 60 * 60 * 1000,

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -14,7 +14,10 @@ import {
 } from "../config/sessions.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { isRich, theme } from "../terminal/theme.js";
-import { resolveSessionStoreTargets, type SessionStoreTarget } from "./session-store-targets.js";
+import {
+  resolveSessionStoreTargetsOrExit,
+  type SessionStoreTarget,
+} from "./session-store-targets.js";
 import {
   formatSessionAgeCell,
   formatSessionFlagsCell,
@@ -291,16 +294,16 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
   const cfg = loadConfig();
   const displayDefaults = resolveSessionDisplayDefaults(cfg);
   const mode = opts.enforce ? "enforce" : resolveMaintenanceConfig().mode;
-  let targets: SessionStoreTarget[];
-  try {
-    targets = resolveSessionStoreTargets(cfg, {
+  const targets = resolveSessionStoreTargetsOrExit({
+    cfg,
+    opts: {
       store: opts.store,
       agent: opts.agent,
       allAgents: opts.allAgents,
-    });
-  } catch (error) {
-    runtime.error(error instanceof Error ? error.message : String(error));
-    runtime.exit(1);
+    },
+    runtime,
+  });
+  if (!targets) {
     return;
   }
 

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -6,7 +6,7 @@ import { info } from "../globals.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { isRich, theme } from "../terminal/theme.js";
-import { resolveSessionStoreTargets } from "./session-store-targets.js";
+import { resolveSessionStoreTargetsOrExit } from "./session-store-targets.js";
 import {
   formatSessionAgeCell,
   formatSessionFlagsCell,
@@ -91,16 +91,16 @@ export async function sessionsCommand(
   const cfg = loadConfig();
   const displayDefaults = resolveSessionDisplayDefaults(cfg);
   const configContextTokens = cfg.agents?.defaults?.contextTokens ?? 200_000;
-  let targets: ReturnType<typeof resolveSessionStoreTargets>;
-  try {
-    targets = resolveSessionStoreTargets(cfg, {
+  const targets = resolveSessionStoreTargetsOrExit({
+    cfg,
+    opts: {
       store: opts.store,
       agent: opts.agent,
       allAgents: opts.allAgents,
-    });
-  } catch (error) {
-    runtime.error(error instanceof Error ? error.message : String(error));
-    runtime.exit(1);
+    },
+    runtime,
+  });
+  if (!targets) {
     return;
   }
 

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import type { ConfigUiHints } from "../shared/config-ui-hints-types.js";
 import { FIELD_HELP } from "./schema.help.js";
 import { FIELD_LABELS } from "./schema.labels.js";
 import { applyDerivedTags } from "./schema.tags.js";
@@ -7,19 +8,7 @@ import { sensitive } from "./zod-schema.sensitive.js";
 
 const log = createSubsystemLogger("config/schema");
 
-export type ConfigUiHint = {
-  label?: string;
-  help?: string;
-  tags?: string[];
-  group?: string;
-  order?: number;
-  advanced?: boolean;
-  sensitive?: boolean;
-  placeholder?: string;
-  itemTemplate?: unknown;
-};
-
-export type ConfigUiHints = Record<string, ConfigUiHint>;
+export type { ConfigUiHint, ConfigUiHints } from "../shared/config-ui-hints-types.js";
 
 const GROUP_LABELS: Record<string, string> = {
   wizard: "Wizard",

--- a/src/gateway/assistant-identity.ts
+++ b/src/gateway/assistant-identity.ts
@@ -2,6 +2,7 @@ import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveAgentIdentity } from "../agents/identity.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { normalizeAgentId } from "../routing/session-key.js";
+import { coerceIdentityValue } from "../shared/assistant-identity-values.js";
 import {
   isAvatarHttpUrl,
   isAvatarImageDataUrl,
@@ -24,20 +25,6 @@ export type AssistantIdentity = {
   avatar: string;
   emoji?: string;
 };
-
-function coerceIdentityValue(value: string | undefined, maxLength: number): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  if (trimmed.length <= maxLength) {
-    return trimmed;
-  }
-  return trimmed.slice(0, maxLength);
-}
 
 function isAvatarUrl(value: string): boolean {
   return isAvatarHttpUrl(value) || isAvatarImageDataUrl(value);

--- a/src/gateway/hooks-test-helpers.ts
+++ b/src/gateway/hooks-test-helpers.ts
@@ -1,0 +1,42 @@
+import type { IncomingMessage } from "node:http";
+import type { HooksConfigResolved } from "./hooks.js";
+
+export function createHooksConfig(): HooksConfigResolved {
+  return {
+    basePath: "/hooks",
+    token: "hook-secret",
+    maxBodyBytes: 1024,
+    mappings: [],
+    agentPolicy: {
+      defaultAgentId: "main",
+      knownAgentIds: new Set(["main"]),
+      allowedAgentIds: undefined,
+    },
+    sessionPolicy: {
+      allowRequestSessionKey: false,
+      defaultSessionKey: undefined,
+      allowedSessionKeyPrefixes: undefined,
+    },
+  };
+}
+
+export function createGatewayRequest(params: {
+  path: string;
+  authorization?: string;
+  method?: string;
+  remoteAddress?: string;
+  host?: string;
+}): IncomingMessage {
+  const headers: Record<string, string> = {
+    host: params.host ?? "localhost:18789",
+  };
+  if (params.authorization) {
+    headers.authorization = params.authorization;
+  }
+  return {
+    method: params.method ?? "GET",
+    url: params.path,
+    headers,
+    socket: { remoteAddress: params.remoteAddress ?? "127.0.0.1" },
+  } as IncomingMessage;
+}

--- a/src/gateway/server-http.hooks-request-timeout.test.ts
+++ b/src/gateway/server-http.hooks-request-timeout.test.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
-import type { HooksConfigResolved } from "./hooks.js";
+import { createGatewayRequest, createHooksConfig } from "./hooks-test-helpers.js";
 
 const { readJsonBodyMock } = vi.hoisted(() => ({
   readJsonBodyMock: vi.fn(),
@@ -19,39 +19,18 @@ import { createHooksRequestHandler } from "./server-http.js";
 
 type HooksHandlerDeps = Parameters<typeof createHooksRequestHandler>[0];
 
-function createHooksConfig(): HooksConfigResolved {
-  return {
-    basePath: "/hooks",
-    token: "hook-secret",
-    maxBodyBytes: 1024,
-    mappings: [],
-    agentPolicy: {
-      defaultAgentId: "main",
-      knownAgentIds: new Set(["main"]),
-      allowedAgentIds: undefined,
-    },
-    sessionPolicy: {
-      allowRequestSessionKey: false,
-      defaultSessionKey: undefined,
-      allowedSessionKeyPrefixes: undefined,
-    },
-  };
-}
-
 function createRequest(params?: {
   authorization?: string;
   remoteAddress?: string;
   url?: string;
 }): IncomingMessage {
-  return {
+  return createGatewayRequest({
     method: "POST",
-    url: params?.url ?? "/hooks/wake",
-    headers: {
-      host: "127.0.0.1:18789",
-      authorization: params?.authorization ?? "Bearer hook-secret",
-    },
-    socket: { remoteAddress: params?.remoteAddress ?? "127.0.0.1" },
-  } as IncomingMessage;
+    path: params?.url ?? "/hooks/wake",
+    host: "127.0.0.1:18789",
+    authorization: params?.authorization ?? "Bearer hook-secret",
+    remoteAddress: params?.remoteAddress,
+  });
 }
 
 function createResponse(): {

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, expect, test, vi } from "vitest";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import type { HooksConfigResolved } from "./hooks.js";
+import { createHooksConfig } from "./hooks-test-helpers.js";
 import { canonicalizePathVariant } from "./security-path.js";
 import { createGatewayHttpServer, createHooksRequestHandler } from "./server-http.js";
 import { withTempConfig } from "./test-temp-config.js";
@@ -66,25 +66,6 @@ async function dispatchRequest(
 ): Promise<void> {
   server.emit("request", req, res);
   await new Promise((resolve) => setImmediate(resolve));
-}
-
-function createHooksConfig(): HooksConfigResolved {
-  return {
-    basePath: "/hooks",
-    token: "hook-secret",
-    maxBodyBytes: 1024,
-    mappings: [],
-    agentPolicy: {
-      defaultAgentId: "main",
-      knownAgentIds: new Set(["main"]),
-      allowedAgentIds: undefined,
-    },
-    sessionPolicy: {
-      allowRequestSessionKey: false,
-      defaultSessionKey: undefined,
-      allowedSessionKeyPrefixes: undefined,
-    },
-  };
 }
 
 function canonicalizePluginPath(pathname: string): string {

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -9,29 +9,12 @@ import type {
 } from "../../channels/plugins/types.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import { extensionForMime } from "../../media/mime.js";
+import { readBooleanParam as readBooleanParamShared } from "../../plugin-sdk/boolean-param.js";
 import { parseSlackTarget } from "../../slack/targets.js";
 import { parseTelegramTarget } from "../../telegram/targets.js";
 import { loadWebMedia } from "../../web/media.js";
 
-export function readBooleanParam(
-  params: Record<string, unknown>,
-  key: string,
-): boolean | undefined {
-  const raw = params[key];
-  if (typeof raw === "boolean") {
-    return raw;
-  }
-  if (typeof raw === "string") {
-    const trimmed = raw.trim().toLowerCase();
-    if (trimmed === "true") {
-      return true;
-    }
-    if (trimmed === "false") {
-      return false;
-    }
-  }
-  return undefined;
-}
+export const readBooleanParam = readBooleanParamShared;
 
 export function resolveSlackAutoThreadId(params: {
   to: string;

--- a/src/infra/session-cost-usage.types.ts
+++ b/src/infra/session-cost-usage.types.ts
@@ -1,4 +1,8 @@
 import type { NormalizedUsage } from "../agents/usage.js";
+import type {
+  SessionUsageTimePoint as SharedSessionUsageTimePoint,
+  SessionUsageTimeSeries as SharedSessionUsageTimeSeries,
+} from "../shared/session-usage-timeseries-types.js";
 
 export type CostBreakdown = {
   total?: number;
@@ -141,22 +145,9 @@ export type DiscoveredSession = {
   firstUserMessage?: string;
 };
 
-export type SessionUsageTimePoint = {
-  timestamp: number;
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-  totalTokens: number;
-  cost: number;
-  cumulativeTokens: number;
-  cumulativeCost: number;
-};
+export type SessionUsageTimePoint = SharedSessionUsageTimePoint;
 
-export type SessionUsageTimeSeries = {
-  sessionId?: string;
-  points: SessionUsageTimePoint[];
-};
+export type SessionUsageTimeSeries = SharedSessionUsageTimeSeries;
 
 export type SessionLogEntry = {
   timestamp: number;

--- a/src/plugin-sdk/account-resolution.ts
+++ b/src/plugin-sdk/account-resolution.ts
@@ -1,0 +1,41 @@
+export function resolveAccountWithDefaultFallback<TAccount>(params: {
+  accountId?: string | null;
+  normalizeAccountId: (accountId?: string | null) => string;
+  resolvePrimary: (accountId: string) => TAccount;
+  hasCredential: (account: TAccount) => boolean;
+  resolveDefaultAccountId: () => string;
+}): TAccount {
+  const hasExplicitAccountId = Boolean(params.accountId?.trim());
+  const normalizedAccountId = params.normalizeAccountId(params.accountId);
+  const primary = params.resolvePrimary(normalizedAccountId);
+  if (hasExplicitAccountId || params.hasCredential(primary)) {
+    return primary;
+  }
+
+  const fallbackId = params.resolveDefaultAccountId();
+  if (fallbackId === normalizedAccountId) {
+    return primary;
+  }
+  const fallback = params.resolvePrimary(fallbackId);
+  if (!params.hasCredential(fallback)) {
+    return primary;
+  }
+  return fallback;
+}
+
+export function listConfiguredAccountIds(params: {
+  accounts: Record<string, unknown> | undefined;
+  normalizeAccountId: (accountId: string) => string;
+}): string[] {
+  if (!params.accounts) {
+    return [];
+  }
+  const ids = new Set<string>();
+  for (const key of Object.keys(params.accounts)) {
+    if (!key) {
+      continue;
+    }
+    ids.add(params.normalizeAccountId(key));
+  }
+  return [...ids];
+}

--- a/src/plugin-sdk/boolean-param.ts
+++ b/src/plugin-sdk/boolean-param.ts
@@ -1,0 +1,19 @@
+export function readBooleanParam(
+  params: Record<string, unknown>,
+  key: string,
+): boolean | undefined {
+  const raw = params[key];
+  if (typeof raw === "boolean") {
+    return raw;
+  }
+  if (typeof raw === "string") {
+    const trimmed = raw.trim().toLowerCase();
+    if (trimmed === "true") {
+      return true;
+    }
+    if (trimmed === "false") {
+      return false;
+    }
+  }
+  return undefined;
+}

--- a/src/plugin-sdk/command-auth.ts
+++ b/src/plugin-sdk/command-auth.ts
@@ -18,6 +18,48 @@ export type ResolveSenderCommandAuthorizationParams = {
   }) => boolean;
 };
 
+export type CommandAuthorizationRuntime = {
+  shouldComputeCommandAuthorized: (rawBody: string, cfg: OpenClawConfig) => boolean;
+  resolveCommandAuthorizedFromAuthorizers: (params: {
+    useAccessGroups: boolean;
+    authorizers: Array<{ configured: boolean; allowed: boolean }>;
+  }) => boolean;
+};
+
+export type ResolveSenderCommandAuthorizationWithRuntimeParams = Omit<
+  ResolveSenderCommandAuthorizationParams,
+  "shouldComputeCommandAuthorized" | "resolveCommandAuthorizedFromAuthorizers"
+> & {
+  runtime: CommandAuthorizationRuntime;
+};
+
+export function resolveDirectDmAuthorizationOutcome(params: {
+  isGroup: boolean;
+  dmPolicy: string;
+  senderAllowedForCommands: boolean;
+}): "disabled" | "unauthorized" | "allowed" {
+  if (params.isGroup) {
+    return "allowed";
+  }
+  if (params.dmPolicy === "disabled") {
+    return "disabled";
+  }
+  if (params.dmPolicy !== "open" && !params.senderAllowedForCommands) {
+    return "unauthorized";
+  }
+  return "allowed";
+}
+
+export async function resolveSenderCommandAuthorizationWithRuntime(
+  params: ResolveSenderCommandAuthorizationWithRuntimeParams,
+): ReturnType<typeof resolveSenderCommandAuthorization> {
+  return resolveSenderCommandAuthorization({
+    ...params,
+    shouldComputeCommandAuthorized: params.runtime.shouldComputeCommandAuthorized,
+    resolveCommandAuthorizedFromAuthorizers: params.runtime.resolveCommandAuthorizedFromAuthorizers,
+  });
+}
+
 export async function resolveSenderCommandAuthorization(
   params: ResolveSenderCommandAuthorizationParams,
 ): Promise<{

--- a/src/plugin-sdk/command-auth.ts
+++ b/src/plugin-sdk/command-auth.ts
@@ -19,7 +19,7 @@ export type ResolveSenderCommandAuthorizationParams = {
 };
 
 export type CommandAuthorizationRuntime = {
-  shouldComputeCommandAuthorized: (rawBody: string, cfg: OpenClawConfig) => boolean;
+  shouldComputeCommandAuthorized: (rawBody: string, cfg: RemoteClawConfig) => boolean;
   resolveCommandAuthorizedFromAuthorizers: (params: {
     useAccessGroups: boolean;
     authorizers: Array<{ configured: boolean; allowed: boolean }>;

--- a/src/plugin-sdk/inbound-envelope.ts
+++ b/src/plugin-sdk/inbound-envelope.ts
@@ -3,6 +3,11 @@ type RouteLike = {
   sessionKey: string;
 };
 
+type RoutePeerLike = {
+  kind: string;
+  id: string | number;
+};
+
 export function createInboundEnvelopeBuilder<TConfig, TEnvelope>(params: {
   cfg: TConfig;
   route: RouteLike;
@@ -38,4 +43,108 @@ export function createInboundEnvelopeBuilder<TConfig, TEnvelope>(params: {
     });
     return { storePath, body };
   };
+}
+
+export function resolveInboundRouteEnvelopeBuilder<
+  TConfig,
+  TEnvelope,
+  TRoute extends RouteLike,
+>(params: {
+  cfg: TConfig;
+  channel: string;
+  accountId: string;
+  peer: RoutePeerLike;
+  resolveAgentRoute: (params: {
+    cfg: TConfig;
+    channel: string;
+    accountId: string;
+    peer: RoutePeerLike;
+  }) => TRoute;
+  sessionStore?: string;
+  resolveStorePath: (store: string | undefined, opts: { agentId: string }) => string;
+  readSessionUpdatedAt: (params: { storePath: string; sessionKey: string }) => number | undefined;
+  resolveEnvelopeFormatOptions: (cfg: TConfig) => TEnvelope;
+  formatAgentEnvelope: (params: {
+    channel: string;
+    from: string;
+    timestamp?: number;
+    previousTimestamp?: number;
+    envelope: TEnvelope;
+    body: string;
+  }) => string;
+}): {
+  route: TRoute;
+  buildEnvelope: ReturnType<typeof createInboundEnvelopeBuilder<TConfig, TEnvelope>>;
+} {
+  const route = params.resolveAgentRoute({
+    cfg: params.cfg,
+    channel: params.channel,
+    accountId: params.accountId,
+    peer: params.peer,
+  });
+  const buildEnvelope = createInboundEnvelopeBuilder({
+    cfg: params.cfg,
+    route,
+    sessionStore: params.sessionStore,
+    resolveStorePath: params.resolveStorePath,
+    readSessionUpdatedAt: params.readSessionUpdatedAt,
+    resolveEnvelopeFormatOptions: params.resolveEnvelopeFormatOptions,
+    formatAgentEnvelope: params.formatAgentEnvelope,
+  });
+  return { route, buildEnvelope };
+}
+
+type InboundRouteEnvelopeRuntime<TConfig, TEnvelope, TRoute extends RouteLike> = {
+  routing: {
+    resolveAgentRoute: (params: {
+      cfg: TConfig;
+      channel: string;
+      accountId: string;
+      peer: RoutePeerLike;
+    }) => TRoute;
+  };
+  session: {
+    resolveStorePath: (store: string | undefined, opts: { agentId: string }) => string;
+    readSessionUpdatedAt: (params: { storePath: string; sessionKey: string }) => number | undefined;
+  };
+  reply: {
+    resolveEnvelopeFormatOptions: (cfg: TConfig) => TEnvelope;
+    formatAgentEnvelope: (params: {
+      channel: string;
+      from: string;
+      timestamp?: number;
+      previousTimestamp?: number;
+      envelope: TEnvelope;
+      body: string;
+    }) => string;
+  };
+};
+
+export function resolveInboundRouteEnvelopeBuilderWithRuntime<
+  TConfig,
+  TEnvelope,
+  TRoute extends RouteLike,
+>(params: {
+  cfg: TConfig;
+  channel: string;
+  accountId: string;
+  peer: RoutePeerLike;
+  runtime: InboundRouteEnvelopeRuntime<TConfig, TEnvelope, TRoute>;
+  sessionStore?: string;
+}): {
+  route: TRoute;
+  buildEnvelope: ReturnType<typeof createInboundEnvelopeBuilder<TConfig, TEnvelope>>;
+} {
+  return resolveInboundRouteEnvelopeBuilder({
+    cfg: params.cfg,
+    channel: params.channel,
+    accountId: params.accountId,
+    peer: params.peer,
+    resolveAgentRoute: (routeParams) => params.runtime.routing.resolveAgentRoute(routeParams),
+    sessionStore: params.sessionStore,
+    resolveStorePath: params.runtime.session.resolveStorePath,
+    readSessionUpdatedAt: params.runtime.session.readSessionUpdatedAt,
+    resolveEnvelopeFormatOptions: params.runtime.reply.resolveEnvelopeFormatOptions,
+    formatAgentEnvelope: params.runtime.reply.formatAgentEnvelope,
+  });
 }

--- a/src/plugin-sdk/inbound-envelope.ts
+++ b/src/plugin-sdk/inbound-envelope.ts
@@ -1,5 +1,6 @@
 type RouteLike = {
   agentId: string;
+  accountId?: string;
   sessionKey: string;
 };
 

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -222,6 +222,7 @@ export { buildMediaPayload } from "../channels/plugins/media-payload.js";
 export type { MediaPayload, MediaPayloadInput } from "../channels/plugins/media-payload.js";
 export { createLoggerBackedRuntime } from "./runtime.js";
 export { chunkTextForOutbound } from "./text-chunking.js";
+export { readBooleanParam } from "./boolean-param.js";
 export { readJsonFileWithFallback, writeJsonFileAtomically } from "./json-store.js";
 export { generatePkceVerifierChallenge, toFormUrlEncoded } from "./oauth-utils.js";
 export { buildRandomTempFilePath, withTempDownloadPath } from "./temp-path.js";

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -126,6 +126,7 @@ export { createPluginRuntimeStore } from "./runtime-store.js";
 export { formatResolvedUnresolvedNote } from "./resolution-notes.js";
 export type { ChannelDock } from "../channels/dock.js";
 export { getChatChannelMeta } from "../channels/registry.js";
+export { resolveAllowlistMatchByCandidates } from "../channels/allowlist-match.js";
 export type {
   BlockStreamingCoalesceConfig,
   DmPolicy,
@@ -201,9 +202,22 @@ export {
   type SenderGroupAccessDecision,
   type SenderGroupAccessReason,
 } from "./group-access.js";
-export { resolveSenderCommandAuthorization } from "./command-auth.js";
+export {
+  resolveDirectDmAuthorizationOutcome,
+  resolveSenderCommandAuthorization,
+  resolveSenderCommandAuthorizationWithRuntime,
+} from "./command-auth.js";
+export type { CommandAuthorizationRuntime } from "./command-auth.js";
 export { createScopedPairingAccess } from "./pairing-access.js";
-export { createInboundEnvelopeBuilder } from "./inbound-envelope.js";
+export {
+  createInboundEnvelopeBuilder,
+  resolveInboundRouteEnvelopeBuilder,
+  resolveInboundRouteEnvelopeBuilderWithRuntime,
+} from "./inbound-envelope.js";
+export {
+  listConfiguredAccountIds,
+  resolveAccountWithDefaultFallback,
+} from "./account-resolution.js";
 export { issuePairingChallenge } from "../pairing/pairing-challenge.js";
 export { handleSlackMessageAction } from "./slack-message-actions.js";
 export { extractToolSend } from "./tool-send.js";

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -2,9 +2,8 @@ import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import process from "node:process";
 import { describe, expect, it, vi } from "vitest";
-import { withEnvAsync } from "../test-utils/env.js";
 import { attachChildProcessBridge } from "./child-process-bridge.js";
-import { runCommandWithTimeout, shouldSpawnWithShell } from "./exec.js";
+import { resolveCommandEnv, runCommandWithTimeout, shouldSpawnWithShell } from "./exec.js";
 
 describe("runCommandWithTimeout", () => {
   it("never enables shell execution (Windows cmd.exe injection hardening)", () => {
@@ -16,24 +15,31 @@ describe("runCommandWithTimeout", () => {
     ).toBe(false);
   });
 
-  it("merges custom env with process.env", async () => {
-    await withEnvAsync({ REMOTECLAW_BASE_ENV: "base" }, async () => {
-      const result = await runCommandWithTimeout(
-        [
-          process.execPath,
-          "-e",
-          'process.stdout.write((process.env.REMOTECLAW_BASE_ENV ?? "") + "|" + (process.env.REMOTECLAW_TEST_ENV ?? ""))',
-        ],
-        {
-          timeoutMs: 80,
-          env: { REMOTECLAW_TEST_ENV: "ok" },
-        },
-      );
-
-      expect(result.code).toBe(0);
-      expect(result.stdout).toBe("base|ok");
-      expect(result.termination).toBe("exit");
+  it("merges custom env with base env and drops undefined values", async () => {
+    const resolved = resolveCommandEnv({
+      argv: ["node", "script.js"],
+      baseEnv: {
+        REMOTECLAW_BASE_ENV: "base",
+        REMOTECLAW_TO_REMOVE: undefined,
+      },
+      env: {
+        REMOTECLAW_TEST_ENV: "ok",
+      },
     });
+
+    expect(resolved.REMOTECLAW_BASE_ENV).toBe("base");
+    expect(resolved.REMOTECLAW_TEST_ENV).toBe("ok");
+    expect(resolved.REMOTECLAW_TO_REMOVE).toBeUndefined();
+  });
+
+  it("suppresses npm fund prompts for npm argv", async () => {
+    const resolved = resolveCommandEnv({
+      argv: ["npm", "--version"],
+      baseEnv: {},
+    });
+
+    expect(resolved.NPM_CONFIG_FUND).toBe("false");
+    expect(resolved.npm_config_fund).toBe("false");
   });
 
   it("kills command when no output timeout elapses", async () => {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -173,16 +173,13 @@ export type CommandOptions = {
   noOutputTimeoutMs?: number;
 };
 
-export async function runCommandWithTimeout(
-  argv: string[],
-  optionsOrTimeout: number | CommandOptions,
-): Promise<SpawnResult> {
-  const options: CommandOptions =
-    typeof optionsOrTimeout === "number" ? { timeoutMs: optionsOrTimeout } : optionsOrTimeout;
-  const { timeoutMs, cwd, input, env, noOutputTimeoutMs } = options;
-  const { windowsVerbatimArguments } = options;
-  const hasInput = input !== undefined;
-
+export function resolveCommandEnv(params: {
+  argv: string[];
+  env?: NodeJS.ProcessEnv;
+  baseEnv?: NodeJS.ProcessEnv;
+}): NodeJS.ProcessEnv {
+  const baseEnv = params.baseEnv ?? process.env;
+  const argv = params.argv;
   const shouldSuppressNpmFund = (() => {
     const cmd = path.basename(argv[0] ?? "");
     if (cmd === "npm" || cmd === "npm.cmd" || cmd === "npm.exe") {
@@ -195,7 +192,7 @@ export async function runCommandWithTimeout(
     return false;
   })();
 
-  const mergedEnv = env ? { ...process.env, ...env } : { ...process.env };
+  const mergedEnv = params.env ? { ...baseEnv, ...params.env } : { ...baseEnv };
   const resolvedEnv = Object.fromEntries(
     Object.entries(mergedEnv)
       .filter(([, value]) => value !== undefined)
@@ -209,6 +206,19 @@ export async function runCommandWithTimeout(
       resolvedEnv.npm_config_fund = "false";
     }
   }
+  return resolvedEnv;
+}
+
+export async function runCommandWithTimeout(
+  argv: string[],
+  optionsOrTimeout: number | CommandOptions,
+): Promise<SpawnResult> {
+  const options: CommandOptions =
+    typeof optionsOrTimeout === "number" ? { timeoutMs: optionsOrTimeout } : optionsOrTimeout;
+  const { timeoutMs, cwd, input, env, noOutputTimeoutMs } = options;
+  const { windowsVerbatimArguments } = options;
+  const hasInput = input !== undefined;
+  const resolvedEnv = resolveCommandEnv({ argv, env });
 
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
   const finalArgv = process.platform === "win32" ? (resolveNpmArgvForWindows(argv) ?? argv) : argv;

--- a/src/shared/assistant-identity-values.ts
+++ b/src/shared/assistant-identity-values.ts
@@ -1,0 +1,16 @@
+export function coerceIdentityValue(
+  value: string | undefined,
+  maxLength: number,
+): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+  return trimmed.slice(0, maxLength);
+}

--- a/src/shared/config-ui-hints-types.ts
+++ b/src/shared/config-ui-hints-types.ts
@@ -1,0 +1,13 @@
+export type ConfigUiHint = {
+  label?: string;
+  help?: string;
+  tags?: string[];
+  group?: string;
+  order?: number;
+  advanced?: boolean;
+  sensitive?: boolean;
+  placeholder?: string;
+  itemTemplate?: unknown;
+};
+
+export type ConfigUiHints = Record<string, ConfigUiHint>;

--- a/src/shared/session-usage-timeseries-types.ts
+++ b/src/shared/session-usage-timeseries-types.ts
@@ -1,0 +1,16 @@
+export type SessionUsageTimePoint = {
+  timestamp: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  cost: number;
+  cumulativeTokens: number;
+  cumulativeCost: number;
+};
+
+export type SessionUsageTimeSeries = {
+  sessionId?: string;
+  points: SessionUsageTimePoint[];
+};

--- a/src/slack/monitor/allow-list.ts
+++ b/src/slack/monitor/allow-list.ts
@@ -1,4 +1,7 @@
-import type { AllowlistMatch } from "../../channels/allowlist-match.js";
+import {
+  resolveAllowlistMatchByCandidates,
+  type AllowlistMatch,
+} from "../../channels/allowlist-match.js";
 import {
   normalizeHyphenSlug,
   normalizeStringEntries,
@@ -49,19 +52,7 @@ export function resolveSlackAllowListMatch(params: {
         ] satisfies Array<{ value?: string; source: SlackAllowListMatch["matchSource"] }>)
       : []),
   ];
-  for (const candidate of candidates) {
-    if (!candidate.value) {
-      continue;
-    }
-    if (allowList.includes(candidate.value)) {
-      return {
-        allowed: true,
-        matchKey: candidate.value,
-        matchSource: candidate.source,
-      };
-    }
-  }
-  return { allowed: false };
+  return resolveAllowlistMatchByCandidates({ allowList, candidates });
 }
 
 export function allowListMatches(params: {

--- a/src/slack/monitor/allow-list.ts
+++ b/src/slack/monitor/allow-list.ts
@@ -52,7 +52,7 @@ export function resolveSlackAllowListMatch(params: {
         ] satisfies Array<{ value?: string; source: SlackAllowListMatch["matchSource"] }>)
       : []),
   ];
-  return resolveAllowlistMatchByCandidates({ allowList, candidates });
+  return resolveAllowlistMatchByCandidates({ allowList, candidates }) as SlackAllowListMatch;
 }
 
 export function allowListMatches(params: {

--- a/src/slack/monitor/allow-list.ts
+++ b/src/slack/monitor/allow-list.ts
@@ -40,7 +40,10 @@ export function resolveSlackAllowListMatch(params: {
   const id = params.id?.toLowerCase();
   const name = params.name?.toLowerCase();
   const slug = normalizeSlackSlug(name);
-  const candidates: Array<{ value?: string; source: SlackAllowListMatch["matchSource"] }> = [
+  const candidates: Array<{
+    value?: string;
+    source: NonNullable<SlackAllowListMatch["matchSource"]>;
+  }> = [
     { value: id, source: "id" },
     { value: id ? `slack:${id}` : undefined, source: "prefixed-id" },
     { value: id ? `user:${id}` : undefined, source: "prefixed-user" },
@@ -49,7 +52,10 @@ export function resolveSlackAllowListMatch(params: {
           { value: name, source: "name" as const },
           { value: name ? `slack:${name}` : undefined, source: "prefixed-name" as const },
           { value: slug, source: "slug" as const },
-        ] satisfies Array<{ value?: string; source: SlackAllowListMatch["matchSource"] }>)
+        ] satisfies Array<{
+          value?: string;
+          source: NonNullable<SlackAllowListMatch["matchSource"]>;
+        }>)
       : []),
   ];
   return resolveAllowlistMatchByCandidates({ allowList, candidates }) as SlackAllowListMatch;

--- a/src/telegram/accounts.ts
+++ b/src/telegram/accounts.ts
@@ -4,6 +4,10 @@ import type { RemoteClawConfig } from "../config/config.js";
 import type { TelegramAccountConfig, TelegramActionConfig } from "../config/types.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  listConfiguredAccountIds as listConfiguredAccountIdsFromSection,
+  resolveAccountWithDefaultFallback,
+} from "../plugin-sdk/account-resolution.js";
 import { resolveAccountEntry } from "../routing/account-lookup.js";
 import { listBoundAccountIds, resolveDefaultAgentBoundAccountId } from "../routing/bindings.js";
 import {
@@ -42,18 +46,10 @@ export type ResolvedTelegramAccount = {
 };
 
 function listConfiguredAccountIds(cfg: RemoteClawConfig): string[] {
-  const accounts = cfg.channels?.telegram?.accounts;
-  if (!accounts || typeof accounts !== "object") {
-    return [];
-  }
-  const ids = new Set<string>();
-  for (const key of Object.keys(accounts)) {
-    if (!key) {
-      continue;
-    }
-    ids.add(normalizeAccountId(key));
-  }
-  return [...ids];
+  return listConfiguredAccountIdsFromSection({
+    accounts: cfg.channels?.telegram?.accounts,
+    normalizeAccountId,
+  });
 }
 
 export function listTelegramAccountIds(cfg: RemoteClawConfig): string[] {
@@ -138,7 +134,6 @@ export function resolveTelegramAccount(params: {
   cfg: RemoteClawConfig;
   accountId?: string | null;
 }): ResolvedTelegramAccount {
-  const hasExplicitAccountId = Boolean(params.accountId?.trim());
   const baseEnabled = params.cfg.channels?.telegram?.enabled !== false;
 
   const resolve = (accountId: string) => {
@@ -161,27 +156,16 @@ export function resolveTelegramAccount(params: {
     } satisfies ResolvedTelegramAccount;
   };
 
-  const normalized = normalizeAccountId(params.accountId);
-  const primary = resolve(normalized);
-  if (hasExplicitAccountId) {
-    return primary;
-  }
-  if (primary.tokenSource !== "none") {
-    return primary;
-  }
-
   // If accountId is omitted, prefer a configured account token over failing on
   // the implicit "default" account. This keeps env-based setups working while
   // making config-only tokens work for things like heartbeats.
-  const fallbackId = resolveDefaultTelegramAccountId(params.cfg);
-  if (fallbackId === primary.accountId) {
-    return primary;
-  }
-  const fallback = resolve(fallbackId);
-  if (fallback.tokenSource === "none") {
-    return primary;
-  }
-  return fallback;
+  return resolveAccountWithDefaultFallback({
+    accountId: params.accountId,
+    normalizeAccountId,
+    resolvePrimary: resolve,
+    hasCredential: (account) => account.tokenSource !== "none",
+    resolveDefaultAccountId: () => resolveDefaultTelegramAccountId(params.cfg),
+  });
 }
 
 export function listEnabledTelegramAccounts(cfg: RemoteClawConfig): ResolvedTelegramAccount[] {

--- a/ui/src/ui/assistant-identity.ts
+++ b/ui/src/ui/assistant-identity.ts
@@ -1,3 +1,5 @@
+import { coerceIdentityValue } from "../../../src/shared/assistant-identity-values.js";
+
 const MAX_ASSISTANT_NAME = 50;
 const MAX_ASSISTANT_AVATAR = 200;
 
@@ -9,20 +11,6 @@ export type AssistantIdentity = {
   name: string;
   avatar: string | null;
 };
-
-function coerceIdentityValue(value: string | undefined, maxLength: number): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  if (trimmed.length <= maxLength) {
-    return trimmed;
-  }
-  return trimmed.slice(0, maxLength);
-}
 
 export function normalizeAssistantIdentity(
   input?: Partial<AssistantIdentity> | null,

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -1,4 +1,5 @@
 export type UpdateAvailable = import("../../../src/infra/update-startup.js").UpdateAvailable;
+import type { ConfigUiHints } from "../../../src/shared/config-ui-hints-types.js";
 
 export type ChannelsStatusSnapshot = {
   ts: number;
@@ -282,20 +283,6 @@ export type ConfigSnapshot = {
   config?: Record<string, unknown> | null;
   issues?: ConfigSnapshotIssue[] | null;
 };
-
-export type ConfigUiHint = {
-  label?: string;
-  help?: string;
-  tags?: string[];
-  group?: string;
-  order?: number;
-  advanced?: boolean;
-  sensitive?: boolean;
-  placeholder?: string;
-  itemTemplate?: unknown;
-};
-
-export type ConfigUiHints = Record<string, ConfigUiHint>;
 
 export type ConfigSchemaResponse = {
   schema: unknown;

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -1,4 +1,5 @@
 export type UpdateAvailable = import("../../../src/infra/update-startup.js").UpdateAvailable;
+export type { ConfigUiHints } from "../../../src/shared/config-ui-hints-types.js";
 import type { ConfigUiHints } from "../../../src/shared/config-ui-hints-types.js";
 
 export type ChannelsStatusSnapshot = {

--- a/ui/src/ui/usage-types.ts
+++ b/ui/src/ui/usage-types.ts
@@ -1,3 +1,8 @@
+import type {
+  SessionUsageTimePoint as SharedSessionUsageTimePoint,
+  SessionUsageTimeSeries as SharedSessionUsageTimeSeries,
+} from "../../../src/shared/session-usage-timeseries-types.js";
+
 export type SessionsUsageEntry = {
   key: string;
   label?: string;
@@ -197,19 +202,6 @@ export type CostUsageSummary = {
   totals: SessionsUsageTotals;
 };
 
-export type SessionUsageTimePoint = {
-  timestamp: number;
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-  totalTokens: number;
-  cost: number;
-  cumulativeTokens: number;
-  cumulativeCost: number;
-};
+export type SessionUsageTimePoint = SharedSessionUsageTimePoint;
 
-export type SessionUsageTimeSeries = {
-  sessionId?: string;
-  points: SessionUsageTimePoint[];
-};
+export type SessionUsageTimeSeries = SharedSessionUsageTimeSeries;

--- a/ui/src/ui/views/agents-panels-status-files.ts
+++ b/ui/src/ui/views/agents-panels-status-files.ts
@@ -15,6 +15,7 @@ import type {
   CronStatus,
 } from "../types.ts";
 import { formatBytes, type AgentContext } from "./agents-utils.ts";
+import { resolveChannelExtras as resolveChannelExtrasFromConfig } from "./channel-config-extras.ts";
 
 function renderAgentContextCard(context: AgentContext, subtitle: string) {
   return html`
@@ -95,55 +96,6 @@ function resolveChannelEntries(snapshot: ChannelsStatusSnapshot | null): Channel
 }
 
 const CHANNEL_EXTRA_FIELDS = ["groupPolicy", "streamMode", "dmPolicy"] as const;
-
-function resolveChannelConfigValue(
-  configForm: Record<string, unknown> | null,
-  channelId: string,
-): Record<string, unknown> | null {
-  if (!configForm) {
-    return null;
-  }
-  const channels = (configForm.channels ?? {}) as Record<string, unknown>;
-  const fromChannels = channels[channelId];
-  if (fromChannels && typeof fromChannels === "object") {
-    return fromChannels as Record<string, unknown>;
-  }
-  const fallback = configForm[channelId];
-  if (fallback && typeof fallback === "object") {
-    return fallback as Record<string, unknown>;
-  }
-  return null;
-}
-
-function formatChannelExtraValue(raw: unknown): string {
-  if (raw == null) {
-    return "n/a";
-  }
-  if (typeof raw === "string" || typeof raw === "number" || typeof raw === "boolean") {
-    return String(raw);
-  }
-  try {
-    return JSON.stringify(raw);
-  } catch {
-    return "n/a";
-  }
-}
-
-function resolveChannelExtras(
-  configForm: Record<string, unknown> | null,
-  channelId: string,
-): Array<{ label: string; value: string }> {
-  const value = resolveChannelConfigValue(configForm, channelId);
-  if (!value) {
-    return [];
-  }
-  return CHANNEL_EXTRA_FIELDS.flatMap((field) => {
-    if (!(field in value)) {
-      return [];
-    }
-    return [{ label: field, value: formatChannelExtraValue(value[field]) }];
-  });
-}
 
 function summarizeChannelAccounts(accounts: ChannelAccountSnapshot[]) {
   let connected = 0;
@@ -230,7 +182,11 @@ export function renderAgentChannels(params: {
                       ? `${summary.configured} configured`
                       : "not configured";
                     const enabled = summary.total ? `${summary.enabled} enabled` : "disabled";
-                    const extras = resolveChannelExtras(params.configForm, entry.id);
+                    const extras = resolveChannelExtrasFromConfig({
+                      configForm: params.configForm,
+                      channelId: entry.id,
+                      fields: CHANNEL_EXTRA_FIELDS,
+                    });
                     return html`
                       <div class="list-item">
                         <div class="list-main">

--- a/ui/src/ui/views/channel-config-extras.ts
+++ b/ui/src/ui/views/channel-config-extras.ts
@@ -1,0 +1,49 @@
+export function resolveChannelConfigValue(
+  configForm: Record<string, unknown> | null | undefined,
+  channelId: string,
+): Record<string, unknown> | null {
+  if (!configForm) {
+    return null;
+  }
+  const channels = (configForm.channels ?? {}) as Record<string, unknown>;
+  const fromChannels = channels[channelId];
+  if (fromChannels && typeof fromChannels === "object") {
+    return fromChannels as Record<string, unknown>;
+  }
+  const fallback = configForm[channelId];
+  if (fallback && typeof fallback === "object") {
+    return fallback as Record<string, unknown>;
+  }
+  return null;
+}
+
+export function formatChannelExtraValue(raw: unknown): string {
+  if (raw == null) {
+    return "n/a";
+  }
+  if (typeof raw === "string" || typeof raw === "number" || typeof raw === "boolean") {
+    return String(raw);
+  }
+  try {
+    return JSON.stringify(raw);
+  } catch {
+    return "n/a";
+  }
+}
+
+export function resolveChannelExtras(params: {
+  configForm: Record<string, unknown> | null | undefined;
+  channelId: string;
+  fields: readonly string[];
+}): Array<{ label: string; value: string }> {
+  const value = resolveChannelConfigValue(params.configForm, params.channelId);
+  if (!value) {
+    return [];
+  }
+  return params.fields.flatMap((field) => {
+    if (!(field in value)) {
+      return [];
+    }
+    return [{ label: field, value: formatChannelExtraValue(value[field]) }];
+  });
+}

--- a/ui/src/ui/views/channels.config.ts
+++ b/ui/src/ui/views/channels.config.ts
@@ -1,5 +1,6 @@
 import { html } from "lit";
 import type { ConfigUiHints } from "../types.ts";
+import { formatChannelExtraValue, resolveChannelConfigValue } from "./channel-config-extras.ts";
 import type { ChannelsProps } from "./channels.types.ts";
 import { analyzeConfigSchema, renderNode, schemaType, type JsonSchema } from "./config-form.ts";
 
@@ -52,32 +53,10 @@ function resolveChannelValue(
   config: Record<string, unknown>,
   channelId: string,
 ): Record<string, unknown> {
-  const channels = (config.channels ?? {}) as Record<string, unknown>;
-  const fromChannels = channels[channelId];
-  const fallback = config[channelId];
-  const resolved =
-    (fromChannels && typeof fromChannels === "object"
-      ? (fromChannels as Record<string, unknown>)
-      : null) ??
-    (fallback && typeof fallback === "object" ? (fallback as Record<string, unknown>) : null);
-  return resolved ?? {};
+  return resolveChannelConfigValue(config, channelId) ?? {};
 }
 
 const EXTRA_CHANNEL_FIELDS = ["groupPolicy", "streamMode", "dmPolicy"] as const;
-
-function formatExtraValue(raw: unknown): string {
-  if (raw == null) {
-    return "n/a";
-  }
-  if (typeof raw === "string" || typeof raw === "number" || typeof raw === "boolean") {
-    return String(raw);
-  }
-  try {
-    return JSON.stringify(raw);
-  } catch {
-    return "n/a";
-  }
-}
 
 function renderExtraChannelFields(value: Record<string, unknown>) {
   const entries = EXTRA_CHANNEL_FIELDS.flatMap((field) => {
@@ -95,7 +74,7 @@ function renderExtraChannelFields(value: Record<string, unknown>) {
         ([field, raw]) => html`
           <div>
             <span class="label">${field}</span>
-            <span>${formatExtraValue(raw)}</span>
+            <span>${formatChannelExtraValue(raw)}</span>
           </div>
         `,
       )}

--- a/vitest.extensions.config.ts
+++ b/vitest.extensions.config.ts
@@ -1,15 +1,3 @@
-import { defineConfig } from "vitest/config";
-import baseConfig from "./vitest.config.ts";
+import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
-const base = baseConfig as unknown as Record<string, unknown>;
-const baseTest = (baseConfig as { test?: { exclude?: string[] } }).test ?? {};
-const exclude = baseTest.exclude ?? [];
-
-export default defineConfig({
-  ...base,
-  test: {
-    ...baseTest,
-    include: ["extensions/**/*.test.ts"],
-    exclude,
-  },
-});
+export default createScopedVitestConfig(["extensions/**/*.test.ts"]);

--- a/vitest.gateway.config.ts
+++ b/vitest.gateway.config.ts
@@ -1,15 +1,3 @@
-import { defineConfig } from "vitest/config";
-import baseConfig from "./vitest.config.ts";
+import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
-const base = baseConfig as unknown as Record<string, unknown>;
-const baseTest = (baseConfig as { test?: { exclude?: string[] } }).test ?? {};
-const exclude = baseTest.exclude ?? [];
-
-export default defineConfig({
-  ...base,
-  test: {
-    ...baseTest,
-    include: ["src/gateway/**/*.test.ts"],
-    exclude,
-  },
-});
+export default createScopedVitestConfig(["src/gateway/**/*.test.ts"]);

--- a/vitest.scoped-config.ts
+++ b/vitest.scoped-config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+import baseConfig from "./vitest.config.ts";
+
+export function createScopedVitestConfig(include: string[]) {
+  const base = baseConfig as unknown as Record<string, unknown>;
+  const baseTest = (baseConfig as { test?: { exclude?: string[] } }).test ?? {};
+  const exclude = baseTest.exclude ?? [];
+
+  return defineConfig({
+    ...base,
+    test: {
+      ...baseTest,
+      include,
+      exclude,
+    },
+  });
+}


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #726
**Commits**: 9 cherry-picked

| Hash | Subject | Result |
|------|---------|--------|
| `234e07fcc` | refactor(process): extract command env resolution helper | RESOLVED |
| `3efd224ec` | refactor(commands): dedupe session target resolution and fs tool test setup | RESOLVED |
| `693f61404` | refactor(shared): centralize assistant identity and usage timeseries types | RESOLVED |
| `741e74972` | refactor(plugin-sdk): share boolean action param parsing | PICKED |
| `e41f9998f` | refactor(test): extract shared gateway hook and vitest scoped config helpers | RESOLVED |
| `dbc78243f` | refactor(scripts): share guard runners and paged select UI | PICKED |
| `dcf8308c8` | refactor(ui): share channel config extras and hint types | PICKED |
| `ed21b63bb` | refactor(plugin-sdk): share auth, routing, and stream/account helpers | RESOLVED |
| `b85facfb5` | refactor(android): share node JSON param parsing helpers | RESOLVED |

### Adaptation notes
- Fork rebrand preserved (openclaw → remoteclaw in types, imports, env vars)
- Fork-deleted agent files discarded (bash-tools.exec-*, ollama-stream, openai-ws-stream, stream-message-shared)
- Fork-deleted pi-tools test discarded
- Fork-deleted .pi/extensions/{diff,files}.ts discarded; new paged-select.ts kept
- Type fixes for AllowlistMatch generic narrowing and InboundRouteEnvelopeRuntime peer kind
- Fork's simplified configContextTokens preserved (no lookupContextTokens)
- Fork's ZaloInboundMessage interface preserved (vs upstream's ZcaMessage destructuring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)