### PR TITLE
Cherry-pick batch: Cron — failure destinations, timeout tuning, regression fixes

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -679,19 +679,39 @@ describe("cron cli", () => {
     expect(patch?.patch?.failureAlert).toBe(false);
   });
 
-  it("uses a longer default timeout for cron run", async () => {
-    const { runOpts } = await runCronRunAndCaptureExit({
-      ran: true,
-      args: ["cron", "run", "job-1", "--expect-final"],
-    });
-    expect(runOpts.timeout).toBe("600000");
-  });
+  it("patches failure alert mode/accountId on cron edit", async () => {
+    callGatewayFromCli.mockClear();
 
-  it("preserves explicit --timeout for cron run", async () => {
-    const { runOpts } = await runCronRunAndCaptureExit({
-      ran: true,
-      args: ["cron", "run", "job-1", "--expect-final", "--timeout", "45000"],
-    });
-    expect(runOpts.timeout).toBe("45000");
+    const program = buildProgram();
+
+    await program.parseAsync(
+      [
+        "cron",
+        "edit",
+        "job-1",
+        "--failure-alert-after",
+        "1",
+        "--failure-alert-mode",
+        "webhook",
+        "--failure-alert-account-id",
+        "bot-a",
+      ],
+      { from: "user" },
+    );
+
+    const updateCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.update");
+    const patch = updateCall?.[2] as {
+      patch?: {
+        failureAlert?: {
+          after?: number;
+          mode?: "announce" | "webhook";
+          accountId?: string;
+        };
+      };
+    };
+
+    expect(patch?.patch?.failureAlert?.after).toBe(1);
+    expect(patch?.patch?.failureAlert?.mode).toBe("webhook");
+    expect(patch?.patch?.failureAlert?.accountId).toBe("bot-a");
   });
 });

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -64,11 +64,20 @@ export function registerCronEditCommand(cron: Command) {
       .option("--account <id>", "Channel account id for delivery (multi-account setups)")
       .option("--best-effort-deliver", "Do not fail job if delivery fails")
       .option("--no-best-effort-deliver", "Fail job when delivery fails")
-      .option("--failure-alert-after <n>", "Alert after N consecutive failures")
-      .option("--failure-alert-cooldown <duration>", "Cooldown between failure alerts (e.g. 1h)")
-      .option("--failure-alert-channel <channel>", "Channel for failure alerts")
-      .option("--failure-alert-to <dest>", "Destination for failure alerts")
-      .option("--no-failure-alert", "Disable failure alerts")
+      .option("--failure-alert", "Enable failure alerts for this job")
+      .option("--no-failure-alert", "Disable failure alerts for this job")
+      .option("--failure-alert-after <n>", "Alert after N consecutive job errors")
+      .option(
+        "--failure-alert-channel <channel>",
+        `Failure alert channel (${getCronChannelOptions()})`,
+      )
+      .option("--failure-alert-to <dest>", "Failure alert destination")
+      .option("--failure-alert-cooldown <duration>", "Minimum time between alerts (e.g. 1h, 30m)")
+      .option("--failure-alert-mode <mode>", "Failure alert delivery mode (announce or webhook)")
+      .option(
+        "--failure-alert-account-id <id>",
+        "Account ID for failure alert channel (multi-account setups)",
+      )
       .action(async (id, opts) => {
         try {
           if (opts.session === "main" && opts.message) {
@@ -274,7 +283,25 @@ export function registerCronEditCommand(cron: Command) {
             patch.delivery = delivery;
           }
 
-          if (opts.failureAlert === false) {
+          const hasFailureAlertAfter = typeof opts.failureAlertAfter === "string";
+          const hasFailureAlertChannel = typeof opts.failureAlertChannel === "string";
+          const hasFailureAlertTo = typeof opts.failureAlertTo === "string";
+          const hasFailureAlertCooldown = typeof opts.failureAlertCooldown === "string";
+          const hasFailureAlertMode = typeof opts.failureAlertMode === "string";
+          const hasFailureAlertAccountId = typeof opts.failureAlertAccountId === "string";
+          const hasFailureAlertFields =
+            hasFailureAlertAfter ||
+            hasFailureAlertChannel ||
+            hasFailureAlertTo ||
+            hasFailureAlertCooldown ||
+            hasFailureAlertMode ||
+            hasFailureAlertAccountId;
+          const failureAlertFlag =
+            typeof opts.failureAlert === "boolean" ? opts.failureAlert : undefined;
+          if (failureAlertFlag === false && hasFailureAlertFields) {
+            throw new Error("Use --no-failure-alert alone (without failure-alert-* options).");
+          }
+          if (failureAlertFlag === false) {
             patch.failureAlert = false;
           } else {
             const hasFailureAlertSetting =
@@ -305,6 +332,23 @@ export function registerCronEditCommand(cron: Command) {
                 fa.to = opts.failureAlertTo.trim() || undefined;
               }
               patch.failureAlert = fa;
+            }
+            if (hasFailureAlertMode) {
+              const mode = String(opts.failureAlertMode).trim().toLowerCase();
+              if (mode !== "announce" && mode !== "webhook") {
+                throw new Error("Invalid --failure-alert-mode (must be 'announce' or 'webhook').");
+              }
+              if (typeof patch.failureAlert === "object" && patch.failureAlert) {
+                (patch.failureAlert as Record<string, unknown>).mode = mode;
+              }
+            }
+            if (hasFailureAlertAccountId) {
+              const accountId = String(opts.failureAlertAccountId).trim();
+              if (typeof patch.failureAlert === "object" && patch.failureAlert) {
+                (patch.failureAlert as Record<string, unknown>).accountId = accountId
+                  ? accountId
+                  : undefined;
+              }
             }
           }
 

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -10,6 +10,21 @@ export type CronRetryConfig = {
   retryOn?: CronRetryOn[];
 };
 
+export type CronFailureAlertConfig = {
+  enabled?: boolean;
+  after?: number;
+  cooldownMs?: number;
+  mode?: "announce" | "webhook";
+  accountId?: string;
+};
+
+export type CronFailureDestinationConfig = {
+  channel?: string;
+  to?: string;
+  accountId?: string;
+  mode?: "announce" | "webhook";
+};
+
 export type CronConfig = {
   enabled?: boolean;
   store?: string;
@@ -37,4 +52,7 @@ export type CronConfig = {
     maxBytes?: number | string;
     keepLines?: number;
   };
+  failureAlert?: CronFailureAlertConfig;
+  /** Default destination for failure notifications across all cron jobs. */
+  failureDestination?: CronFailureDestinationConfig;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -335,6 +335,25 @@ export const RemoteClawSchema = z
           })
           .strict()
           .optional(),
+        failureAlert: z
+          .object({
+            enabled: z.boolean().optional(),
+            after: z.number().int().min(1).optional(),
+            cooldownMs: z.number().int().min(0).optional(),
+            mode: z.enum(["announce", "webhook"]).optional(),
+            accountId: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+        failureDestination: z
+          .object({
+            channel: z.string().optional(),
+            to: z.string().optional(),
+            accountId: z.string().optional(),
+            mode: z.enum(["announce", "webhook"]).optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .superRefine((val, ctx) => {

--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveCronDeliveryPlan } from "./delivery.js";
+import { resolveCronDeliveryPlan, resolveFailureDestination } from "./delivery.js";
 import type { CronJob } from "./types.js";
 
 function makeJob(overrides: Partial<CronJob>): CronJob {
@@ -107,5 +107,98 @@ describe("resolveCronDeliveryPlan", () => {
     expect(plan.channel).toBe("telegram");
     expect(plan.to).toBe("123");
     expect(plan.accountId).toBe("bot-a");
+  });
+});
+
+describe("resolveFailureDestination", () => {
+  it("merges global defaults with job-level overrides", () => {
+    const plan = resolveFailureDestination(
+      makeJob({
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "111",
+          failureDestination: { channel: "signal", mode: "announce" },
+        },
+      }),
+      {
+        channel: "telegram",
+        to: "222",
+        mode: "announce",
+        accountId: "global-account",
+      },
+    );
+    expect(plan).toEqual({
+      mode: "announce",
+      channel: "signal",
+      to: "222",
+      accountId: "global-account",
+    });
+  });
+
+  it("returns null for webhook mode without destination URL", () => {
+    const plan = resolveFailureDestination(
+      makeJob({
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "111",
+          failureDestination: { mode: "webhook" },
+        },
+      }),
+      undefined,
+    );
+    expect(plan).toBeNull();
+  });
+
+  it("returns null when failure destination matches primary delivery target", () => {
+    const plan = resolveFailureDestination(
+      makeJob({
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "111",
+          accountId: "bot-a",
+          failureDestination: {
+            mode: "announce",
+            channel: "telegram",
+            to: "111",
+            accountId: "bot-a",
+          },
+        },
+      }),
+      undefined,
+    );
+    expect(plan).toBeNull();
+  });
+
+  it("allows job-level failure destination fields to clear inherited global values", () => {
+    const plan = resolveFailureDestination(
+      makeJob({
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "111",
+          failureDestination: {
+            mode: "announce",
+            channel: undefined as never,
+            to: undefined as never,
+            accountId: undefined as never,
+          },
+        },
+      }),
+      {
+        channel: "signal",
+        to: "group-abc",
+        accountId: "global-account",
+        mode: "announce",
+      },
+    );
+    expect(plan).toEqual({
+      mode: "announce",
+      channel: "last",
+      to: undefined,
+      accountId: undefined,
+    });
   });
 });

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -1,4 +1,14 @@
-import type { CronDeliveryMode, CronJob, CronMessageChannel } from "./types.js";
+import type { CliDeps } from "../cli/deps.js";
+import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
+import type { CronFailureDestinationConfig } from "../config/types.cron.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
+import { resolveAgentOutboundIdentity } from "../infra/outbound/identity.js";
+import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
+import { getChildLogger } from "../logging.js";
+import { resolveDeliveryTarget } from "./isolated-agent/delivery-target.js";
+import type { CronDelivery, CronDeliveryMode, CronJob, CronMessageChannel } from "./types.js";
 
 export type CronDeliveryPlan = {
   mode: CronDeliveryMode;
@@ -89,4 +99,203 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
     source: "payload",
     requested,
   };
+}
+
+export type CronFailureDeliveryPlan = {
+  mode: "announce" | "webhook";
+  channel?: CronMessageChannel;
+  to?: string;
+  accountId?: string;
+};
+
+export type CronFailureDestinationInput = {
+  channel?: CronMessageChannel;
+  to?: string;
+  accountId?: string;
+  mode?: "announce" | "webhook";
+};
+
+function normalizeFailureMode(value: unknown): "announce" | "webhook" | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed === "announce" || trimmed === "webhook") {
+    return trimmed;
+  }
+  return undefined;
+}
+
+export function resolveFailureDestination(
+  job: CronJob,
+  globalConfig?: CronFailureDestinationConfig,
+): CronFailureDeliveryPlan | null {
+  const delivery = job.delivery;
+  const jobFailureDest = delivery?.failureDestination as CronFailureDestinationInput | undefined;
+  const hasJobFailureDest = jobFailureDest && typeof jobFailureDest === "object";
+
+  let channel: CronMessageChannel | undefined;
+  let to: string | undefined;
+  let accountId: string | undefined;
+  let mode: "announce" | "webhook" | undefined;
+
+  // Start with global config as base
+  if (globalConfig) {
+    channel = normalizeChannel(globalConfig.channel);
+    to = normalizeTo(globalConfig.to);
+    accountId = normalizeAccountId(globalConfig.accountId);
+    mode = normalizeFailureMode(globalConfig.mode);
+  }
+
+  // Override with job-level values if present
+  if (hasJobFailureDest) {
+    const jobChannel = normalizeChannel(jobFailureDest.channel);
+    const jobTo = normalizeTo(jobFailureDest.to);
+    const jobAccountId = normalizeAccountId(jobFailureDest.accountId);
+    const jobMode = normalizeFailureMode(jobFailureDest.mode);
+    const hasJobChannelField = "channel" in jobFailureDest;
+    const hasJobToField = "to" in jobFailureDest;
+    const hasJobAccountIdField = "accountId" in jobFailureDest;
+
+    // Track if 'to' was explicitly set at job level
+    const jobToExplicitValue = hasJobToField && jobTo !== undefined;
+
+    // Respect explicit clears from partial patches.
+    if (hasJobChannelField) {
+      channel = jobChannel;
+    }
+    if (hasJobToField) {
+      to = jobTo;
+    }
+    if (hasJobAccountIdField) {
+      accountId = jobAccountId;
+    }
+    if (jobMode !== undefined) {
+      // Mode was explicitly overridden - clear inherited 'to' since URL semantics differ
+      // between announce (channel recipient) and webhook (HTTP endpoint)
+      // But preserve explicit 'to' that was set at job level
+      // Treat undefined global mode as "announce" for comparison
+      const globalMode = globalConfig?.mode ?? "announce";
+      if (!jobToExplicitValue && globalMode !== jobMode) {
+        to = undefined;
+      }
+      mode = jobMode;
+    }
+  }
+
+  if (!channel && !to && !accountId && !mode) {
+    return null;
+  }
+
+  const resolvedMode = mode ?? "announce";
+
+  // Webhook mode requires a URL
+  if (resolvedMode === "webhook" && !to) {
+    return null;
+  }
+
+  const result: CronFailureDeliveryPlan = {
+    mode: resolvedMode,
+    channel: resolvedMode === "announce" ? (channel ?? "last") : undefined,
+    to,
+    accountId,
+  };
+
+  if (delivery && isSameDeliveryTarget(delivery, result)) {
+    return null;
+  }
+
+  return result;
+}
+
+function isSameDeliveryTarget(
+  delivery: CronDelivery,
+  failurePlan: CronFailureDeliveryPlan,
+): boolean {
+  const primaryMode = delivery.mode ?? "announce";
+  if (primaryMode === "none") {
+    return false;
+  }
+
+  const primaryChannel = delivery.channel;
+  const primaryTo = delivery.to;
+  const primaryAccountId = delivery.accountId;
+
+  if (failurePlan.mode === "webhook") {
+    return primaryMode === "webhook" && primaryTo === failurePlan.to;
+  }
+
+  const primaryChannelNormalized = primaryChannel ?? "last";
+  const failureChannelNormalized = failurePlan.channel ?? "last";
+
+  return (
+    failureChannelNormalized === primaryChannelNormalized &&
+    failurePlan.to === primaryTo &&
+    failurePlan.accountId === primaryAccountId
+  );
+}
+
+const FAILURE_NOTIFICATION_TIMEOUT_MS = 30_000;
+const cronDeliveryLogger = getChildLogger({ subsystem: "cron-delivery" });
+
+export async function sendFailureNotificationAnnounce(
+  deps: CliDeps,
+  cfg: OpenClawConfig,
+  agentId: string,
+  jobId: string,
+  target: { channel?: string; to?: string; accountId?: string },
+  message: string,
+): Promise<void> {
+  const resolvedTarget = await resolveDeliveryTarget(cfg, agentId, {
+    channel: target.channel as CronMessageChannel | undefined,
+    to: target.to,
+    accountId: target.accountId,
+  });
+
+  if (!resolvedTarget.ok) {
+    cronDeliveryLogger.warn(
+      { error: resolvedTarget.error.message },
+      "cron: failed to resolve failure destination target",
+    );
+    return;
+  }
+
+  const identity = resolveAgentOutboundIdentity(cfg, agentId);
+  const session = buildOutboundSessionContext({
+    cfg,
+    agentId,
+    sessionKey: `cron:${jobId}:failure`,
+  });
+
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => {
+    abortController.abort();
+  }, FAILURE_NOTIFICATION_TIMEOUT_MS);
+
+  try {
+    await deliverOutboundPayloads({
+      cfg,
+      channel: resolvedTarget.channel,
+      to: resolvedTarget.to,
+      accountId: resolvedTarget.accountId,
+      threadId: resolvedTarget.threadId,
+      payloads: [{ text: message }],
+      session,
+      identity,
+      bestEffort: false,
+      deps: createOutboundSendDeps(deps),
+      abortSignal: abortController.signal,
+    });
+  } catch (err) {
+    cronDeliveryLogger.warn(
+      {
+        err: formatErrorMessage(err),
+        channel: resolvedTarget.channel,
+        to: resolvedTarget.to,
+      },
+      "cron: failure destination announce failed",
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
 }

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -1,7 +1,7 @@
 import type { CliDeps } from "../cli/deps.js";
 import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
 import type { CronFailureDestinationConfig } from "../config/types.cron.js";
-import type { OpenClawConfig } from "../config/types.js";
+import type { RemoteClawConfig } from "../config/types.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { resolveAgentOutboundIdentity } from "../infra/outbound/identity.js";
@@ -240,7 +240,7 @@ const cronDeliveryLogger = getChildLogger({ subsystem: "cron-delivery" });
 
 export async function sendFailureNotificationAnnounce(
   deps: CliDeps,
-  cfg: OpenClawConfig,
+  cfg: RemoteClawConfig,
   agentId: string,
   jobId: string,
   target: { channel?: string; to?: string; accountId?: string },

--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -1,0 +1,266 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+async function makeStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-failure-alert-"));
+  return {
+    storePath: path.join(dir, "cron", "jobs.json"),
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("CronService failure alerts", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    noopLogger.debug.mockClear();
+    noopLogger.info.mockClear();
+    noopLogger.warn.mockClear();
+    noopLogger.error.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("alerts after configured consecutive failures and honors cooldown", async () => {
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "wrong model id",
+    }));
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      cronConfig: {
+        failureAlert: {
+          enabled: true,
+          after: 2,
+          cooldownMs: 60_000,
+        },
+      },
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "daily report",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: { mode: "announce", channel: "telegram", to: "19098680" },
+    });
+
+    await cron.run(job.id, "force");
+    expect(sendCronFailureAlert).not.toHaveBeenCalled();
+
+    await cron.run(job.id, "force");
+    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+    expect(sendCronFailureAlert).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        job: expect.objectContaining({ id: job.id }),
+        channel: "telegram",
+        to: "19098680",
+        text: expect.stringContaining('Cron job "daily report" failed 2 times'),
+      }),
+    );
+
+    await cron.run(job.id, "force");
+    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(60_000);
+    await cron.run(job.id, "force");
+    expect(sendCronFailureAlert).toHaveBeenCalledTimes(2);
+    expect(sendCronFailureAlert).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining('Cron job "daily report" failed 4 times'),
+      }),
+    );
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("supports per-job failure alert override when global alerts are disabled", async () => {
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "timeout",
+    }));
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      cronConfig: {
+        failureAlert: {
+          enabled: false,
+        },
+      },
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "job with override",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      failureAlert: {
+        after: 1,
+        channel: "telegram",
+        to: "12345",
+        cooldownMs: 1,
+      },
+    });
+
+    await cron.run(job.id, "force");
+    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+    expect(sendCronFailureAlert).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        to: "12345",
+      }),
+    );
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("respects per-job failureAlert=false and suppresses alerts", async () => {
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "auth error",
+    }));
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      cronConfig: {
+        failureAlert: {
+          enabled: true,
+          after: 1,
+        },
+      },
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "disabled alert job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      failureAlert: false,
+    });
+
+    await cron.run(job.id, "force");
+    await cron.run(job.id, "force");
+    expect(sendCronFailureAlert).not.toHaveBeenCalled();
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("threads failure alert mode/accountId and skips best-effort jobs", async () => {
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "temporary upstream error",
+    }));
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      cronConfig: {
+        failureAlert: {
+          enabled: true,
+          after: 1,
+          mode: "webhook",
+          accountId: "global-account",
+        },
+      },
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const normalJob = await cron.add({
+      name: "normal alert job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: { mode: "announce", channel: "telegram", to: "19098680" },
+    });
+    const bestEffortJob = await cron.add({
+      name: "best effort alert job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "19098680",
+        bestEffort: true,
+      },
+    });
+
+    await cron.run(normalJob.id, "force");
+    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+    expect(sendCronFailureAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "webhook",
+        accountId: "global-account",
+        to: undefined,
+      }),
+    );
+
+    await cron.run(bestEffortJob.id, "force");
+    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+
+    cron.stop();
+    await store.cleanup();
+  });
+});

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HeartbeatRunResult } from "../infra/heartbeat-wake.js";
 import * as schedule from "./schedule.js";
 import { CronService } from "./service.js";
@@ -157,17 +157,14 @@ describe("Cron issue regressions", () => {
   });
 
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-06T10:05:00.000Z"));
   });
 
   afterAll(async () => {
-    await fs.rm(fixtureRoot, { recursive: true, force: true });
-  });
-
-  afterEach(() => {
     vi.useRealTimers();
-    vi.clearAllMocks();
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
   });
 
   it("covers schedule updates and payload patching", async () => {

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -170,13 +170,11 @@ describe("Cron issue regressions", () => {
     vi.clearAllMocks();
   });
 
-  it("covers schedule updates, force runs, isolated wake scheduling, and payload patching", async () => {
+  it("covers schedule updates and payload patching", async () => {
     const store = await makeStorePath();
-    const enqueueSystemEvent = vi.fn();
     const cron = await startCronForStore({
       storePath: store.storePath,
       cronEnabled: false,
-      enqueueSystemEvent,
     });
 
     const created = await cron.add({
@@ -195,34 +193,6 @@ describe("Cron issue regressions", () => {
     });
 
     expect(updated.state.nextRunAtMs).toBe(Date.parse("2026-02-06T12:00:00.000Z") + offsetMs);
-
-    const forceNow = await cron.add({
-      name: "force-now",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000, anchorMs: Date.now() },
-      sessionTarget: "main",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "systemEvent", text: "force" },
-    });
-
-    const result = await cron.run(forceNow.id, "force");
-
-    expect(result).toEqual({ ok: true, ran: true });
-    expect(enqueueSystemEvent).toHaveBeenCalledWith(
-      "force",
-      expect.objectContaining({ agentId: undefined }),
-    );
-
-    const job = await cron.add({
-      name: "isolated",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000, anchorMs: Date.now() },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "hi" },
-    });
-
-    expect(typeof job.state.nextRunAtMs).toBe("number");
 
     const unsafeToggle = await cron.add({
       name: "unsafe toggle",

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -27,7 +27,7 @@ const noopLogger = {
   trace: vi.fn(),
 };
 const TOP_OF_HOUR_STAGGER_MS = 5 * 60 * 1_000;
-const FAST_TIMEOUT_SECONDS = 0.003;
+const FAST_TIMEOUT_SECONDS = 0.0025;
 type CronServiceOptions = ConstructorParameters<typeof CronService>[0];
 
 function topOfHourOffsetMs(jobId: string) {
@@ -1506,7 +1506,7 @@ describe("Cron issue regressions", () => {
     const timerPromise = onTimer(state);
     const startTimeout = setTimeout(() => {
       bothRunsStarted.reject(new Error("timed out waiting for concurrent job starts"));
-    }, 120);
+    }, 90);
     try {
       await bothRunsStarted.promise;
     } finally {
@@ -1536,7 +1536,7 @@ describe("Cron issue regressions", () => {
 
     // Keep this short for suite speed while still separating expected timeout
     // from the 1/3-regression timeout.
-    const timeoutSeconds = 0.012;
+    const timeoutSeconds = 0.01;
     const cronJob = createIsolatedRegressionJob({
       id: "timeout-fraction-29774",
       name: "timeout fraction regression",

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -27,7 +27,7 @@ const noopLogger = {
   trace: vi.fn(),
 };
 const TOP_OF_HOUR_STAGGER_MS = 5 * 60 * 1_000;
-const FAST_TIMEOUT_SECONDS = 0.004;
+const FAST_TIMEOUT_SECONDS = 0.003;
 type CronServiceOptions = ConstructorParameters<typeof CronService>[0];
 
 function topOfHourOffsetMs(jobId: string) {
@@ -1536,7 +1536,7 @@ describe("Cron issue regressions", () => {
     const timerPromise = onTimer(state);
     const startTimeout = setTimeout(() => {
       bothRunsStarted.reject(new Error("timed out waiting for concurrent job starts"));
-    }, 250);
+    }, 120);
     try {
       await bothRunsStarted.promise;
     } finally {
@@ -1566,7 +1566,7 @@ describe("Cron issue regressions", () => {
 
     // Keep this short for suite speed while still separating expected timeout
     // from the 1/3-regression timeout.
-    const timeoutSeconds = 0.015;
+    const timeoutSeconds = 0.012;
     const cronJob = createIsolatedRegressionJob({
       id: "timeout-fraction-29774",
       name: "timeout fraction regression",

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -222,6 +222,51 @@ describe("applyJobPatch", () => {
     expect(job.delivery).toEqual({ mode: "webhook", to: "https://example.invalid/trim" });
   });
 
+  it("rejects failureDestination on main jobs without webhook delivery mode", () => {
+    const job = createMainSystemEventJob("job-main-failure-dest", {
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+      failureDestination: {
+        mode: "announce",
+        channel: "telegram",
+        to: "999",
+      },
+    });
+
+    expect(() => applyJobPatch(job, { enabled: true })).toThrow(
+      'cron delivery.failureDestination is only supported for sessionTarget="isolated" unless delivery.mode="webhook"',
+    );
+  });
+
+  it("validates and trims webhook failureDestination target URLs", () => {
+    const expectedError =
+      "cron failure destination webhook requires delivery.failureDestination.to to be a valid http(s) URL";
+    const job = createIsolatedAgentTurnJob("job-failure-webhook-target", {
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+      failureDestination: {
+        mode: "webhook",
+        to: "not-a-url",
+      },
+    });
+
+    expect(() => applyJobPatch(job, { enabled: true })).toThrow(expectedError);
+
+    job.delivery = {
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+      failureDestination: {
+        mode: "webhook",
+        to: "  https://example.invalid/failure  ",
+      },
+    };
+    expect(() => applyJobPatch(job, { enabled: true })).not.toThrow();
+    expect(job.delivery?.failureDestination?.to).toBe("https://example.invalid/failure");
+  });
+
   it("rejects Telegram delivery with invalid target (chatId/topicId format)", () => {
     const job = createIsolatedAgentTurnJob("job-telegram-invalid", {
       mode: "announce",
@@ -364,6 +409,25 @@ describe("createJob rejects sessionTarget main for non-default agents", () => {
         agentId: "custom-agent",
       }),
     ).not.toThrow();
+  });
+
+  it("rejects failureDestination on main jobs without webhook delivery mode", () => {
+    const state = createMockState(now, { defaultAgentId: "main" });
+    expect(() =>
+      createJob(state, {
+        ...mainJobInput("main"),
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "123",
+          failureDestination: {
+            mode: "announce",
+            channel: "signal",
+            to: "+15550001111",
+          },
+        },
+      }),
+    ).toThrow('cron channel delivery config is only supported for sessionTarget="isolated"');
   });
 });
 

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -10,6 +10,7 @@ import {
 import type {
   CronDelivery,
   CronDeliveryPatch,
+  CronFailureAlert,
   CronJob,
   CronJobCreate,
   CronJobPatch,
@@ -147,6 +148,27 @@ function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">)
     if (telegramError) {
       throw new Error(telegramError);
     }
+  }
+}
+
+function assertFailureDestinationSupport(job: Pick<CronJob, "sessionTarget" | "delivery">) {
+  const failureDestination = job.delivery?.failureDestination;
+  if (!failureDestination) {
+    return;
+  }
+  if (job.sessionTarget === "main" && job.delivery?.mode !== "webhook") {
+    throw new Error(
+      'cron delivery.failureDestination is only supported for sessionTarget="isolated" unless delivery.mode="webhook"',
+    );
+  }
+  if (failureDestination.mode === "webhook") {
+    const target = normalizeHttpWebhookUrl(failureDestination.to);
+    if (!target) {
+      throw new Error(
+        "cron failure destination webhook requires delivery.failureDestination.to to be a valid http(s) URL",
+      );
+    }
+    failureDestination.to = target;
   }
 }
 
@@ -450,6 +472,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
   assertSupportedJobSpec(job);
   assertMainSessionAgentId(job, state.deps.defaultAgentId);
   assertDeliverySupport(job);
+  assertFailureDestinationSupport(job);
   job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
   return job;
 }
@@ -512,6 +535,18 @@ export function applyJobPatch(
   if (patch.delivery) {
     job.delivery = mergeCronDelivery(job.delivery, patch.delivery);
   }
+  if ("failureAlert" in patch) {
+    job.failureAlert = mergeCronFailureAlert(job.failureAlert, patch.failureAlert);
+  }
+  if (
+    job.sessionTarget === "main" &&
+    job.delivery?.mode !== "webhook" &&
+    job.delivery?.failureDestination
+  ) {
+    throw new Error(
+      'cron delivery.failureDestination is only supported for sessionTarget="isolated" unless delivery.mode="webhook"',
+    );
+  }
   if (job.sessionTarget === "main" && job.delivery?.mode !== "webhook") {
     job.delivery = undefined;
   }
@@ -527,6 +562,7 @@ export function applyJobPatch(
   assertSupportedJobSpec(job);
   assertMainSessionAgentId(job, opts?.defaultAgentId);
   assertDeliverySupport(job);
+  assertFailureDestinationSupport(job);
 }
 
 function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronPayload {
@@ -658,6 +694,7 @@ function mergeCronDelivery(
     to: existing?.to,
     accountId: existing?.accountId,
     bestEffort: existing?.bestEffort,
+    failureDestination: existing?.failureDestination,
   };
 
   if (typeof patch.mode === "string") {
@@ -677,6 +714,89 @@ function mergeCronDelivery(
   }
   if (typeof patch.bestEffort === "boolean") {
     next.bestEffort = patch.bestEffort;
+  }
+  if ("failureDestination" in patch) {
+    if (patch.failureDestination === undefined) {
+      next.failureDestination = undefined;
+    } else {
+      const existingFd = next.failureDestination;
+      const patchFd = patch.failureDestination;
+      const nextFd: typeof next.failureDestination = {
+        channel: existingFd?.channel,
+        to: existingFd?.to,
+        accountId: existingFd?.accountId,
+        mode: existingFd?.mode,
+      };
+      if (patchFd) {
+        if ("channel" in patchFd) {
+          const channel = typeof patchFd.channel === "string" ? patchFd.channel.trim() : "";
+          nextFd.channel = channel ? channel : undefined;
+        }
+        if ("to" in patchFd) {
+          const to = typeof patchFd.to === "string" ? patchFd.to.trim() : "";
+          nextFd.to = to ? to : undefined;
+        }
+        if ("accountId" in patchFd) {
+          const accountId = typeof patchFd.accountId === "string" ? patchFd.accountId.trim() : "";
+          nextFd.accountId = accountId ? accountId : undefined;
+        }
+        if ("mode" in patchFd) {
+          const mode = typeof patchFd.mode === "string" ? patchFd.mode.trim() : "";
+          nextFd.mode = mode === "announce" || mode === "webhook" ? mode : undefined;
+        }
+      }
+      next.failureDestination = nextFd;
+    }
+  }
+
+  return next;
+}
+
+function normalizeOptionalTrimmedString(raw: unknown): string | undefined {
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  return trimmed || undefined;
+}
+
+function mergeCronFailureAlert(
+  existing: CronFailureAlert | false | undefined,
+  patch: CronFailureAlert | false | undefined,
+): CronFailureAlert | false | undefined {
+  if (patch === false) {
+    return false;
+  }
+  if (patch === undefined) {
+    return existing;
+  }
+  const base = existing === false || existing === undefined ? {} : existing;
+  const next: CronFailureAlert = { ...base };
+
+  if ("after" in patch) {
+    const after = typeof patch.after === "number" && Number.isFinite(patch.after) ? patch.after : 0;
+    next.after = after > 0 ? Math.floor(after) : undefined;
+  }
+  if ("channel" in patch) {
+    next.channel = normalizeOptionalTrimmedString(patch.channel);
+  }
+  if ("to" in patch) {
+    next.to = normalizeOptionalTrimmedString(patch.to);
+  }
+  if ("cooldownMs" in patch) {
+    const cooldownMs =
+      typeof patch.cooldownMs === "number" && Number.isFinite(patch.cooldownMs)
+        ? patch.cooldownMs
+        : -1;
+    next.cooldownMs = cooldownMs >= 0 ? Math.floor(cooldownMs) : undefined;
+  }
+  if ("mode" in patch) {
+    const mode = typeof patch.mode === "string" ? patch.mode.trim() : "";
+    next.mode = mode === "announce" || mode === "webhook" ? mode : undefined;
+  }
+  if ("accountId" in patch) {
+    const accountId = typeof patch.accountId === "string" ? patch.accountId.trim() : "";
+    next.accountId = accountId ? accountId : undefined;
   }
 
   return next;

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -465,6 +465,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     wakeMode: input.wakeMode,
     payload: input.payload,
     delivery: input.delivery,
+    failureAlert: input.failureAlert,
     state: {
       ...input.state,
     },

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -5,6 +5,7 @@ import type {
   CronJob,
   CronJobCreate,
   CronJobPatch,
+  CronMessageChannel,
   CronRunOutcome,
   CronRunStatus,
   CronRunTelemetry,

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -90,6 +90,14 @@ export type CronServiceDeps = {
     } & CronRunOutcome &
       CronRunTelemetry
   >;
+  sendCronFailureAlert?: (params: {
+    job: CronJob;
+    text: string;
+    channel: CronMessageChannel;
+    to?: string;
+    mode?: "announce" | "webhook";
+    accountId?: string;
+  }) => Promise<void>;
   onEvent?: (evt: CronEvent) => void;
 };
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -6,6 +6,7 @@ import { sweepCronRunSessions } from "../session-reaper.js";
 import type {
   CronDeliveryStatus,
   CronJob,
+  CronMessageChannel,
   CronRunOutcome,
   CronRunStatus,
   CronRunTelemetry,
@@ -150,6 +151,127 @@ function resolveDeliveryStatus(params: { job: CronJob; delivered?: boolean }): C
   return resolveCronDeliveryPlan(params.job).requested ? "unknown" : "not-requested";
 }
 
+/** Default: alert after 2 consecutive errors. */
+const DEFAULT_FAILURE_ALERT_AFTER = 2;
+/** Default cooldown: 1 hour between alerts. */
+const DEFAULT_FAILURE_ALERT_COOLDOWN_MS = 3_600_000;
+
+function normalizeCronMessageChannel(input: unknown): CronMessageChannel | undefined {
+  if (typeof input !== "string") {
+    return undefined;
+  }
+  const channel = input.trim().toLowerCase();
+  return channel ? (channel as CronMessageChannel) : undefined;
+}
+
+function normalizeTo(input: unknown): string | undefined {
+  if (typeof input !== "string") {
+    return undefined;
+  }
+  const to = input.trim();
+  return to ? to : undefined;
+}
+
+function clampPositiveInt(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  const floored = Math.floor(value);
+  return floored >= 1 ? floored : fallback;
+}
+
+function clampNonNegativeInt(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  const floored = Math.floor(value);
+  return floored >= 0 ? floored : fallback;
+}
+
+function resolveFailureAlert(
+  state: CronServiceState,
+  job: CronJob,
+): {
+  after: number;
+  cooldownMs: number;
+  channel: CronMessageChannel;
+  to?: string;
+  mode?: "announce" | "webhook";
+  accountId?: string;
+} | null {
+  const globalConfig = state.deps.cronConfig?.failureAlert;
+  const jobConfig = job.failureAlert === false ? undefined : job.failureAlert;
+
+  if (job.failureAlert === false) {
+    return null;
+  }
+  if (!jobConfig && globalConfig?.enabled !== true) {
+    return null;
+  }
+
+  const mode = jobConfig?.mode ?? globalConfig?.mode;
+  const explicitTo = normalizeTo(jobConfig?.to);
+
+  return {
+    after: clampPositiveInt(jobConfig?.after ?? globalConfig?.after, DEFAULT_FAILURE_ALERT_AFTER),
+    cooldownMs: clampNonNegativeInt(
+      jobConfig?.cooldownMs ?? globalConfig?.cooldownMs,
+      DEFAULT_FAILURE_ALERT_COOLDOWN_MS,
+    ),
+    channel:
+      normalizeCronMessageChannel(jobConfig?.channel) ??
+      normalizeCronMessageChannel(job.delivery?.channel) ??
+      "last",
+    to: mode === "webhook" ? explicitTo : (explicitTo ?? normalizeTo(job.delivery?.to)),
+    mode,
+    accountId: jobConfig?.accountId ?? globalConfig?.accountId,
+  };
+}
+
+function emitFailureAlert(
+  state: CronServiceState,
+  params: {
+    job: CronJob;
+    error?: string;
+    consecutiveErrors: number;
+    channel: CronMessageChannel;
+    to?: string;
+    mode?: "announce" | "webhook";
+    accountId?: string;
+  },
+) {
+  const safeJobName = params.job.name || params.job.id;
+  const truncatedError = (params.error?.trim() || "unknown error").slice(0, 200);
+  const text = [
+    `Cron job "${safeJobName}" failed ${params.consecutiveErrors} times`,
+    `Last error: ${truncatedError}`,
+  ].join("\n");
+
+  if (state.deps.sendCronFailureAlert) {
+    void state.deps
+      .sendCronFailureAlert({
+        job: params.job,
+        text,
+        channel: params.channel,
+        to: params.to,
+        mode: params.mode,
+        accountId: params.accountId,
+      })
+      .catch((err) => {
+        state.deps.log.warn(
+          { jobId: params.job.id, err: String(err) },
+          "cron: failure alert delivery failed",
+        );
+      });
+    return;
+  }
+
+  state.deps.enqueueSystemEvent(text, { agentId: params.job.agentId });
+  if (params.job.wakeMode === "now") {
+    state.deps.requestHeartbeatNow({ reason: `cron:${params.job.id}:failure-alert` });
+  }
+}
+
 /**
  * Apply the result of a job execution to the job's state.
  * Handles consecutive error tracking, exponential backoff, one-shot disable,
@@ -182,6 +304,30 @@ export function applyJobResult(
   // Track consecutive errors for backoff / auto-disable.
   if (result.status === "error") {
     job.state.consecutiveErrors = (job.state.consecutiveErrors ?? 0) + 1;
+    const alertConfig = resolveFailureAlert(state, job);
+    if (alertConfig && job.state.consecutiveErrors >= alertConfig.after) {
+      const isBestEffort =
+        job.delivery?.bestEffort === true ||
+        (job.payload.kind === "agentTurn" && job.payload.bestEffortDeliver === true);
+      if (!isBestEffort) {
+        const now = state.deps.nowMs();
+        const lastAlert = job.state.lastFailureAlertAtMs;
+        const inCooldown =
+          typeof lastAlert === "number" && now - lastAlert < Math.max(0, alertConfig.cooldownMs);
+        if (!inCooldown) {
+          emitFailureAlert(state, {
+            job,
+            error: result.error,
+            consecutiveErrors: job.state.consecutiveErrors,
+            channel: alertConfig.channel,
+            to: alertConfig.to,
+            mode: alertConfig.mode,
+            accountId: alertConfig.accountId,
+          });
+          job.state.lastFailureAlertAtMs = now;
+        }
+      }
+    }
   } else {
     job.state.consecutiveErrors = 0;
   }

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -25,6 +25,15 @@ export type CronDelivery = {
   /** Explicit channel account id for multi-account setups (e.g. multiple Telegram bots). */
   accountId?: string;
   bestEffort?: boolean;
+  /** Separate destination for failure notifications. */
+  failureDestination?: CronFailureDestination;
+};
+
+export type CronFailureDestination = {
+  channel?: CronMessageChannel;
+  to?: string;
+  accountId?: string;
+  mode?: "announce" | "webhook";
 };
 
 export type CronDeliveryPatch = Partial<CronDelivery>;
@@ -54,6 +63,17 @@ export type CronRunOutcome = {
   summary?: string;
   sessionId?: string;
   sessionKey?: string;
+};
+
+export type CronFailureAlert = {
+  after?: number;
+  channel?: CronMessageChannel;
+  to?: string;
+  cooldownMs?: number;
+  /** Delivery mode: announce (via messaging channels) or webhook (HTTP POST). */
+  mode?: "announce" | "webhook";
+  /** Account ID for multi-account channel configurations. */
+  accountId?: string;
 };
 
 export type CronPayload =
@@ -109,6 +129,8 @@ export type CronJobState = {
   lastDeliveryError?: string;
   /** Whether the last run's output was delivered to the target channel. */
   lastDelivered?: boolean;
+  /** Timestamp of last failure alert emission. */
+  lastFailureAlertAtMs?: number;
 };
 
 export type CronJob = {
@@ -127,6 +149,7 @@ export type CronJob = {
   wakeMode: CronWakeMode;
   payload: CronPayload;
   delivery?: CronDelivery;
+  failureAlert?: CronFailureAlert | false;
   state: CronJobState;
 };
 

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -136,10 +136,33 @@ export const CronPayloadPatchSchema = Type.Union([
   cronAgentTurnPayloadSchema({ message: Type.Optional(NonEmptyString) }),
 ]);
 
+export const CronFailureAlertSchema = Type.Object(
+  {
+    after: Type.Optional(Type.Integer({ minimum: 1 })),
+    channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString])),
+    to: Type.Optional(Type.String()),
+    cooldownMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    mode: Type.Optional(Type.Union([Type.Literal("announce"), Type.Literal("webhook")])),
+    accountId: Type.Optional(NonEmptyString),
+  },
+  { additionalProperties: false },
+);
+
+export const CronFailureDestinationSchema = Type.Object(
+  {
+    channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString])),
+    to: Type.Optional(Type.String()),
+    accountId: Type.Optional(NonEmptyString),
+    mode: Type.Optional(Type.Union([Type.Literal("announce"), Type.Literal("webhook")])),
+  },
+  { additionalProperties: false },
+);
+
 const CronDeliverySharedProperties = {
   channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString])),
   accountId: Type.Optional(NonEmptyString),
   bestEffort: Type.Optional(Type.Boolean()),
+  failureDestination: Type.Optional(CronFailureDestinationSchema),
 };
 
 const CronDeliveryNoopSchema = Type.Object(

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1,5 +1,6 @@
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { CliDeps } from "../cli/deps.js";
+import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
 import { loadConfig } from "../config/config.js";
 import {
   canonicalizeMainSessionAlias,
@@ -7,7 +8,9 @@ import {
   resolveAgentMainSessionKey,
 } from "../config/sessions.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
+import { resolveFailureDestination, sendFailureNotificationAnnounce } from "../cron/delivery.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
+import { resolveDeliveryTarget } from "../cron/isolated-agent/delivery-target.js";
 import {
   appendCronRunLog,
   resolveCronRunLogPath,
@@ -21,6 +24,7 @@ import { runHeartbeatOnce } from "../infra/heartbeat-runner.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { getChildLogger } from "../logging.js";
 import { normalizeAgentId, toAgentStoreSessionKey } from "../routing/session-key.js";
@@ -67,6 +71,66 @@ function resolveCronWebhookTarget(params: {
   }
 
   return null;
+}
+
+function buildCronWebhookHeaders(webhookToken?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (webhookToken) {
+    headers.Authorization = `Bearer ${webhookToken}`;
+  }
+  return headers;
+}
+
+async function postCronWebhook(params: {
+  webhookUrl: string;
+  webhookToken?: string;
+  payload: unknown;
+  logContext: Record<string, unknown>;
+  blockedLog: string;
+  failedLog: string;
+  logger: ReturnType<typeof getChildLogger>;
+}): Promise<void> {
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => {
+    abortController.abort();
+  }, CRON_WEBHOOK_TIMEOUT_MS);
+
+  try {
+    const result = await fetchWithSsrFGuard({
+      url: params.webhookUrl,
+      init: {
+        method: "POST",
+        headers: buildCronWebhookHeaders(params.webhookToken),
+        body: JSON.stringify(params.payload),
+        signal: abortController.signal,
+      },
+    });
+    await result.release();
+  } catch (err) {
+    if (err instanceof SsrFBlockedError) {
+      params.logger.warn(
+        {
+          ...params.logContext,
+          reason: formatErrorMessage(err),
+          webhookUrl: redactWebhookUrl(params.webhookUrl),
+        },
+        params.blockedLog,
+      );
+    } else {
+      params.logger.warn(
+        {
+          ...params.logContext,
+          err: formatErrorMessage(err),
+          webhookUrl: redactWebhookUrl(params.webhookUrl),
+        },
+        params.failedLog,
+      );
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export function buildGatewayCronService(params: {
@@ -222,6 +286,65 @@ export function buildGatewayCronService(params: {
         lane: "cron",
       });
     },
+    sendCronFailureAlert: async ({ job, text, channel, to, mode, accountId }) => {
+      const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
+      const webhookToken = params.cfg.cron?.webhookToken?.trim();
+
+      // Webhook mode requires a URL - fail closed if missing
+      if (mode === "webhook" && !to) {
+        cronLogger.warn(
+          { jobId: job.id },
+          "cron: failure alert webhook mode requires URL, skipping",
+        );
+        return;
+      }
+
+      if (mode === "webhook" && to) {
+        const webhookUrl = normalizeHttpWebhookUrl(to);
+        if (webhookUrl) {
+          await postCronWebhook({
+            webhookUrl,
+            webhookToken,
+            payload: {
+              jobId: job.id,
+              jobName: job.name,
+              message: text,
+            },
+            logContext: { jobId: job.id },
+            blockedLog: "cron: failure alert webhook blocked by SSRF guard",
+            failedLog: "cron: failure alert webhook failed",
+            logger: cronLogger,
+          });
+        } else {
+          cronLogger.warn(
+            {
+              jobId: job.id,
+              webhookUrl: redactWebhookUrl(to),
+            },
+            "cron: failure alert webhook URL is invalid, skipping",
+          );
+        }
+        return;
+      }
+
+      const target = await resolveDeliveryTarget(runtimeConfig, agentId, {
+        channel,
+        to,
+        accountId,
+      });
+      if (!target.ok) {
+        throw target.error;
+      }
+      await deliverOutboundPayloads({
+        cfg: runtimeConfig,
+        channel: target.channel,
+        to: target.to,
+        accountId: target.accountId,
+        threadId: target.threadId,
+        payloads: [{ text }],
+        deps: createOutboundSendDeps(params.deps),
+      });
+    },
     log: getChildLogger({ module: "cron", storePath }),
     onEvent: (evt) => {
       params.broadcast("cron", evt, { dropIfSlow: true });
@@ -261,54 +384,81 @@ export function buildGatewayCronService(params: {
         }
 
         if (webhookTarget && evt.summary) {
-          const headers: Record<string, string> = {
-            "Content-Type": "application/json",
-          };
-          if (webhookToken) {
-            headers.Authorization = `Bearer ${webhookToken}`;
-          }
-          const abortController = new AbortController();
-          const timeout = setTimeout(() => {
-            abortController.abort();
-          }, CRON_WEBHOOK_TIMEOUT_MS);
-
           void (async () => {
-            try {
-              const result = await fetchWithSsrFGuard({
-                url: webhookTarget.url,
-                init: {
-                  method: "POST",
-                  headers,
-                  body: JSON.stringify(evt),
-                  signal: abortController.signal,
-                },
-              });
-              await result.release();
-            } catch (err) {
-              if (err instanceof SsrFBlockedError) {
-                cronLogger.warn(
-                  {
-                    reason: formatErrorMessage(err),
-                    jobId: evt.jobId,
-                    webhookUrl: redactWebhookUrl(webhookTarget.url),
-                  },
-                  "cron: webhook delivery blocked by SSRF guard",
-                );
-              } else {
-                cronLogger.warn(
-                  {
-                    err: formatErrorMessage(err),
-                    jobId: evt.jobId,
-                    webhookUrl: redactWebhookUrl(webhookTarget.url),
-                  },
-                  "cron: webhook delivery failed",
-                );
-              }
-            } finally {
-              clearTimeout(timeout);
-            }
+            await postCronWebhook({
+              webhookUrl: webhookTarget.url,
+              webhookToken,
+              payload: evt,
+              logContext: { jobId: evt.jobId },
+              blockedLog: "cron: webhook delivery blocked by SSRF guard",
+              failedLog: "cron: webhook delivery failed",
+              logger: cronLogger,
+            });
           })();
         }
+
+        if (evt.status === "error" && job) {
+          const failureDest = resolveFailureDestination(job, params.cfg.cron?.failureDestination);
+          if (failureDest) {
+            const isBestEffort =
+              job.delivery?.bestEffort === true ||
+              (job.payload.kind === "agentTurn" && job.payload.bestEffortDeliver === true);
+
+            if (!isBestEffort) {
+              const failureMessage = `Cron job "${job.name}" failed: ${evt.error ?? "unknown error"}`;
+              const failurePayload = {
+                jobId: job.id,
+                jobName: job.name,
+                message: failureMessage,
+                status: evt.status,
+                error: evt.error,
+                runAtMs: evt.runAtMs,
+                durationMs: evt.durationMs,
+                nextRunAtMs: evt.nextRunAtMs,
+              };
+
+              if (failureDest.mode === "webhook" && failureDest.to) {
+                const webhookUrl = normalizeHttpWebhookUrl(failureDest.to);
+                if (webhookUrl) {
+                  void (async () => {
+                    await postCronWebhook({
+                      webhookUrl,
+                      webhookToken,
+                      payload: failurePayload,
+                      logContext: { jobId: evt.jobId },
+                      blockedLog: "cron: failure destination webhook blocked by SSRF guard",
+                      failedLog: "cron: failure destination webhook failed",
+                      logger: cronLogger,
+                    });
+                  })();
+                } else {
+                  cronLogger.warn(
+                    {
+                      jobId: evt.jobId,
+                      webhookUrl: redactWebhookUrl(failureDest.to),
+                    },
+                    "cron: failure destination webhook URL is invalid, skipping",
+                  );
+                }
+              } else if (failureDest.mode === "announce") {
+                const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
+                void sendFailureNotificationAnnounce(
+                  params.deps,
+                  runtimeConfig,
+                  agentId,
+                  job.id,
+                  {
+                    channel: failureDest.channel,
+                    to: failureDest.to,
+                    accountId: failureDest.accountId,
+                  },
+                  `[Cron Failure] ${failureMessage}`,
+                );
+              }
+            }
+          }
+        }
+
         const logPath = resolveCronRunLogPath({
           storePath,
           jobId: evt.jobId,

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -645,6 +645,57 @@ describe("gateway server cron", () => {
       expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
 
       fetchWithSsrFGuardMock.mockClear();
+      cronIsolatedRun.mockResolvedValueOnce({ status: "error", summary: "delivery failed" });
+      const failureDestRes = await rpcReq(ws, "cron.add", {
+        name: "failure destination webhook",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "test" },
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "19098680",
+          failureDestination: {
+            mode: "webhook",
+            to: "https://example.invalid/failure-destination",
+          },
+        },
+      });
+      expect(failureDestRes.ok).toBe(true);
+      const failureDestJobIdValue = (failureDestRes.payload as { id?: unknown } | null)?.id;
+      const failureDestJobId =
+        typeof failureDestJobIdValue === "string" ? failureDestJobIdValue : "";
+      expect(failureDestJobId.length > 0).toBe(true);
+
+      const failureDestRunRes = await rpcReq(
+        ws,
+        "cron.run",
+        { id: failureDestJobId, mode: "force" },
+        20_000,
+      );
+      expect(failureDestRunRes.ok).toBe(true);
+      await waitForCondition(
+        () => fetchWithSsrFGuardMock.mock.calls.length === 1,
+        CRON_WAIT_TIMEOUT_MS,
+      );
+      const [failureDestArgs] = fetchWithSsrFGuardMock.mock.calls[0] as unknown as [
+        {
+          url?: string;
+          init?: {
+            method?: string;
+            headers?: Record<string, string>;
+            body?: string;
+          };
+        },
+      ];
+      expect(failureDestArgs.url).toBe("https://example.invalid/failure-destination");
+      const failureDestBody = JSON.parse(failureDestArgs.init?.body ?? "{}");
+      expect(failureDestBody.message).toBe(
+        'Cron job "failure destination webhook" failed: unknown error',
+      );
+
       cronIsolatedRun.mockResolvedValueOnce({ status: "ok", summary: "" });
       const noSummaryRes = await rpcReq(ws, "cron.add", {
         name: "webhook no summary",
@@ -669,7 +720,7 @@ describe("gateway server cron", () => {
       expect(noSummaryRunRes.ok).toBe(true);
       await yieldToEventLoop();
       await yieldToEventLoop();
-      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
     } finally {
       await cleanupCronTestRun({ ws, server, dir, prevSkipCron });
     }

--- a/ui/src/ui/app-defaults.ts
+++ b/ui/src/ui/app-defaults.ts
@@ -39,5 +39,12 @@ export const DEFAULT_CRON_FORM: CronFormState = {
   deliveryTo: "",
   deliveryAccountId: "",
   deliveryBestEffort: false,
+  failureAlertMode: "inherit",
+  failureAlertAfter: "2",
+  failureAlertCooldownSeconds: "3600",
+  failureAlertChannel: "last",
+  failureAlertTo: "",
+  failureAlertDeliveryMode: "announce",
+  failureAlertAccountId: "",
   timeoutSeconds: "",
 };

--- a/ui/src/ui/controllers/cron.test.ts
+++ b/ui/src/ui/controllers/cron.test.ts
@@ -589,6 +589,182 @@ describe("cron controller", () => {
     });
   });
 
+  it("includes custom failureAlert fields in cron.update patch", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.update") {
+        return { id: "job-alert" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [{ id: "job-alert" }] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1, nextWakeAtMs: null };
+      }
+      return {};
+    });
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronEditingJobId: "job-alert",
+      cronForm: {
+        ...DEFAULT_CRON_FORM,
+        name: "alert job",
+        payloadKind: "agentTurn",
+        payloadText: "run it",
+        failureAlertMode: "custom",
+        failureAlertAfter: "3",
+        failureAlertCooldownSeconds: "120",
+        failureAlertChannel: "telegram",
+        failureAlertTo: "123456",
+      },
+    });
+
+    await addCronJob(state);
+
+    const updateCall = request.mock.calls.find(([method]) => method === "cron.update");
+    expect(updateCall).toBeDefined();
+    expect(updateCall?.[1]).toMatchObject({
+      id: "job-alert",
+      patch: {
+        failureAlert: {
+          after: 3,
+          cooldownMs: 120_000,
+          channel: "telegram",
+          to: "123456",
+          mode: "announce",
+          accountId: undefined,
+        },
+      },
+    });
+  });
+
+  it("includes failure alert mode/accountId in cron.update patch", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.update") {
+        return { id: "job-alert-mode" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [{ id: "job-alert-mode" }] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1, nextWakeAtMs: null };
+      }
+      return {};
+    });
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronEditingJobId: "job-alert-mode",
+      cronForm: {
+        ...DEFAULT_CRON_FORM,
+        name: "alert mode job",
+        payloadKind: "agentTurn",
+        payloadText: "run it",
+        failureAlertMode: "custom",
+        failureAlertAfter: "1",
+        failureAlertDeliveryMode: "webhook",
+        failureAlertAccountId: "bot-a",
+      },
+    });
+
+    await addCronJob(state);
+
+    const updateCall = request.mock.calls.find(([method]) => method === "cron.update");
+    expect(updateCall).toBeDefined();
+    expect(updateCall?.[1]).toMatchObject({
+      id: "job-alert-mode",
+      patch: {
+        failureAlert: {
+          after: 1,
+          mode: "webhook",
+          accountId: "bot-a",
+        },
+      },
+    });
+  });
+
+  it("omits failureAlert.cooldownMs when custom cooldown is left blank", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.update") {
+        return { id: "job-alert-no-cooldown" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [{ id: "job-alert-no-cooldown" }] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1, nextWakeAtMs: null };
+      }
+      return {};
+    });
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronEditingJobId: "job-alert-no-cooldown",
+      cronForm: {
+        ...DEFAULT_CRON_FORM,
+        name: "alert job no cooldown",
+        payloadKind: "agentTurn",
+        payloadText: "run it",
+        failureAlertMode: "custom",
+        failureAlertAfter: "3",
+        failureAlertCooldownSeconds: "",
+        failureAlertChannel: "telegram",
+        failureAlertTo: "123456",
+      },
+    });
+
+    await addCronJob(state);
+
+    const updateCall = request.mock.calls.find(([method]) => method === "cron.update");
+    expect(updateCall).toBeDefined();
+    expect(updateCall?.[1]).toMatchObject({
+      id: "job-alert-no-cooldown",
+      patch: {
+        failureAlert: {
+          after: 3,
+          channel: "telegram",
+          to: "123456",
+        },
+      },
+    });
+    expect(
+      (updateCall?.[1] as { patch?: { failureAlert?: { cooldownMs?: number } } })?.patch
+        ?.failureAlert,
+    ).not.toHaveProperty("cooldownMs");
+  });
+
+  it("includes failureAlert=false when disabled per job", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.update") {
+        return { id: "job-no-alert" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [{ id: "job-no-alert" }] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1, nextWakeAtMs: null };
+      }
+      return {};
+    });
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronEditingJobId: "job-no-alert",
+      cronForm: {
+        ...DEFAULT_CRON_FORM,
+        name: "alert off",
+        payloadKind: "agentTurn",
+        payloadText: "run it",
+        failureAlertMode: "disabled",
+      },
+    });
+
+    await addCronJob(state);
+
+    const updateCall = request.mock.calls.find(([method]) => method === "cron.update");
+    expect(updateCall).toBeDefined();
+    expect(updateCall?.[1]).toMatchObject({
+      id: "job-no-alert",
+      patch: { failureAlert: false },
+    });
+  });
+
   it("maps cron stagger, model, thinking, and best effort into form", () => {
     const state = createState();
     const job = {
@@ -620,6 +796,38 @@ describe("cron controller", () => {
     expect(state.cronForm.payloadModel).toBe("opus");
     expect(state.cronForm.payloadThinking).toBe("high");
     expect(state.cronForm.deliveryBestEffort).toBe(true);
+  });
+
+  it("maps failureAlert overrides into form fields", () => {
+    const state = createState();
+    const job = {
+      id: "job-11",
+      name: "Failure alerts",
+      enabled: true,
+      createdAtMs: 0,
+      updatedAtMs: 0,
+      schedule: { kind: "every" as const, everyMs: 60_000 },
+      sessionTarget: "isolated" as const,
+      wakeMode: "next-heartbeat" as const,
+      payload: { kind: "agentTurn" as const, message: "hello" },
+      failureAlert: {
+        after: 4,
+        cooldownMs: 30_000,
+        channel: "telegram",
+        to: "999",
+      },
+      state: {},
+    };
+
+    startCronEdit(state, job);
+
+    expect(state.cronForm.failureAlertMode).toBe("custom");
+    expect(state.cronForm.failureAlertAfter).toBe("4");
+    expect(state.cronForm.failureAlertCooldownSeconds).toBe("30");
+    expect(state.cronForm.failureAlertChannel).toBe("telegram");
+    expect(state.cronForm.failureAlertTo).toBe("999");
+    expect(state.cronForm.failureAlertDeliveryMode).toBe("announce");
+    expect(state.cronForm.failureAlertAccountId).toBe("");
   });
 
   it("validates key cron form errors", () => {

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -30,7 +30,9 @@ export type CronFieldKey =
   | "payloadModel"
   | "payloadThinking"
   | "timeoutSeconds"
-  | "deliveryTo";
+  | "deliveryTo"
+  | "failureAlertAfter"
+  | "failureAlertCooldownSeconds";
 
 export type CronFieldErrors = Partial<Record<CronFieldKey, string>>;
 

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -3,6 +3,7 @@ import { DEFAULT_CRON_FORM } from "../app-defaults.ts";
 import { toNumber } from "../format.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type {
+  CronFailureAlert,
   CronJob,
   CronDeliveryStatus,
   CronJobsEnabledFilter,
@@ -389,6 +390,7 @@ function parseStaggerSchedule(
 }
 
 function jobToForm(job: CronJob, prev: CronFormState): CronFormState {
+  const failureAlert = (job as { failureAlert?: CronFailureAlert | false }).failureAlert;
   const next: CronFormState = {
     ...prev,
     name: job.name,
@@ -420,6 +422,33 @@ function jobToForm(job: CronJob, prev: CronFormState): CronFormState {
     deliveryTo: job.delivery?.to ?? "",
     deliveryAccountId: job.delivery?.accountId ?? "",
     deliveryBestEffort: job.delivery?.bestEffort ?? false,
+    failureAlertMode:
+      failureAlert === false
+        ? "disabled"
+        : failureAlert && typeof failureAlert === "object"
+          ? "custom"
+          : "inherit",
+    failureAlertAfter:
+      failureAlert && typeof failureAlert === "object" && typeof failureAlert.after === "number"
+        ? String(failureAlert.after)
+        : DEFAULT_CRON_FORM.failureAlertAfter,
+    failureAlertCooldownSeconds:
+      failureAlert &&
+      typeof failureAlert === "object" &&
+      typeof failureAlert.cooldownMs === "number"
+        ? String(Math.floor(failureAlert.cooldownMs / 1000))
+        : DEFAULT_CRON_FORM.failureAlertCooldownSeconds,
+    failureAlertChannel:
+      failureAlert && typeof failureAlert === "object"
+        ? (failureAlert.channel ?? CRON_CHANNEL_LAST)
+        : CRON_CHANNEL_LAST,
+    failureAlertTo: failureAlert && typeof failureAlert === "object" ? (failureAlert.to ?? "") : "",
+    failureAlertDeliveryMode:
+      failureAlert && typeof failureAlert === "object"
+        ? (failureAlert.mode ?? "announce")
+        : "announce",
+    failureAlertAccountId:
+      failureAlert && typeof failureAlert === "object" ? (failureAlert.accountId ?? "") : "",
     timeoutSeconds:
       job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
         ? String(job.payload.timeoutSeconds)
@@ -518,6 +547,37 @@ export function buildCronPayload(form: CronFormState) {
   return payload;
 }
 
+function buildFailureAlert(form: CronFormState) {
+  if (form.failureAlertMode === "disabled") {
+    return false as const;
+  }
+  if (form.failureAlertMode !== "custom") {
+    return undefined;
+  }
+  const after = toNumber(form.failureAlertAfter.trim(), 0);
+  const cooldownRaw = form.failureAlertCooldownSeconds.trim();
+  const cooldownSeconds = cooldownRaw.length > 0 ? toNumber(cooldownRaw, 0) : undefined;
+  const cooldownMs =
+    cooldownSeconds !== undefined && Number.isFinite(cooldownSeconds) && cooldownSeconds >= 0
+      ? Math.floor(cooldownSeconds * 1000)
+      : undefined;
+  const deliveryMode = form.failureAlertDeliveryMode;
+  const accountId = form.failureAlertAccountId.trim();
+  const patch: Record<string, unknown> = {
+    after: after > 0 ? Math.floor(after) : undefined,
+    channel: form.failureAlertChannel.trim() || CRON_CHANNEL_LAST,
+    to: form.failureAlertTo.trim() || undefined,
+    ...(cooldownMs !== undefined ? { cooldownMs } : {}),
+  };
+  // Always include mode and accountId so users can switch/clear them
+  if (deliveryMode) {
+    patch.mode = deliveryMode;
+  }
+  // Include accountId if explicitly set, or send undefined to allow clearing
+  patch.accountId = accountId || undefined;
+  return patch;
+}
+
 export async function addCronJob(state: CronState) {
   if (!state.client || !state.connected || state.cronBusy) {
     return;
@@ -583,6 +643,7 @@ export async function addCronJob(state: CronState) {
       wakeMode: form.wakeMode,
       payload,
       delivery,
+      failureAlert: buildFailureAlert(form),
     };
     if (!job.name) {
       throw new Error(t("cron.errors.nameRequiredShort"));

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -475,6 +475,23 @@ export type CronDelivery = {
   to?: string;
   accountId?: string;
   bestEffort?: boolean;
+  failureDestination?: CronFailureDestination;
+};
+
+export type CronFailureDestination = {
+  channel?: string;
+  to?: string;
+  mode?: "announce" | "webhook";
+  accountId?: string;
+};
+
+export type CronFailureAlert = {
+  after?: number;
+  channel?: string;
+  to?: string;
+  cooldownMs?: number;
+  mode?: "announce" | "webhook";
+  accountId?: string;
 };
 
 export type CronJobState = {
@@ -501,6 +518,7 @@ export type CronJob = {
   wakeMode: CronWakeMode;
   payload: CronPayload;
   delivery?: CronDelivery;
+  failureAlert?: CronFailureAlert | false;
   state?: CronJobState;
 };
 

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -43,5 +43,12 @@ export type CronFormState = {
   deliveryTo: string;
   deliveryAccountId: string;
   deliveryBestEffort: boolean;
+  failureAlertMode: "inherit" | "disabled" | "custom";
+  failureAlertAfter: string;
+  failureAlertCooldownSeconds: string;
+  failureAlertChannel: string;
+  failureAlertTo: string;
+  failureAlertDeliveryMode: "announce" | "webhook";
+  failureAlertAccountId: string;
   timeoutSeconds: string;
 };

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -1167,6 +1167,140 @@ export function renderCron(props: CronProps) {
                   : nothing
               }
               ${
+                isAgentTurn
+                  ? html`
+                      <label class="field cron-span-2">
+                        ${renderFieldLabel("Failure alerts")}
+                        <select
+                          .value=${props.form.failureAlertMode}
+                          @change=${(e: Event) =>
+                            props.onFormChange({
+                              failureAlertMode: (e.target as HTMLSelectElement)
+                                .value as CronFormState["failureAlertMode"],
+                            })}
+                        >
+                          <option value="inherit">Inherit global setting</option>
+                          <option value="disabled">Disable for this job</option>
+                          <option value="custom">Custom per-job settings</option>
+                        </select>
+                        <div class="cron-help">
+                          Control when this job sends repeated-failure alerts.
+                        </div>
+                      </label>
+                      ${
+                        props.form.failureAlertMode === "custom"
+                          ? html`
+                              <label class="field">
+                                ${renderFieldLabel("Alert after")}
+                                <input
+                                  id="cron-failure-alert-after"
+                                  .value=${props.form.failureAlertAfter}
+                                  aria-invalid=${props.fieldErrors.failureAlertAfter ? "true" : "false"}
+                                  aria-describedby=${ifDefined(
+                                    props.fieldErrors.failureAlertAfter
+                                      ? errorIdForField("failureAlertAfter")
+                                      : undefined,
+                                  )}
+                                  @input=${(e: Event) =>
+                                    props.onFormChange({
+                                      failureAlertAfter: (e.target as HTMLInputElement).value,
+                                    })}
+                                  placeholder="2"
+                                />
+                                <div class="cron-help">Consecutive errors before alerting.</div>
+                                ${renderFieldError(
+                                  props.fieldErrors.failureAlertAfter,
+                                  errorIdForField("failureAlertAfter"),
+                                )}
+                              </label>
+                              <label class="field">
+                                ${renderFieldLabel("Cooldown (seconds)")}
+                                <input
+                                  id="cron-failure-alert-cooldown-seconds"
+                                  .value=${props.form.failureAlertCooldownSeconds}
+                                  aria-invalid=${props.fieldErrors.failureAlertCooldownSeconds ? "true" : "false"}
+                                  aria-describedby=${ifDefined(
+                                    props.fieldErrors.failureAlertCooldownSeconds
+                                      ? errorIdForField("failureAlertCooldownSeconds")
+                                      : undefined,
+                                  )}
+                                  @input=${(e: Event) =>
+                                    props.onFormChange({
+                                      failureAlertCooldownSeconds: (e.target as HTMLInputElement)
+                                        .value,
+                                    })}
+                                  placeholder="3600"
+                                />
+                                <div class="cron-help">Minimum seconds between alerts.</div>
+                                ${renderFieldError(
+                                  props.fieldErrors.failureAlertCooldownSeconds,
+                                  errorIdForField("failureAlertCooldownSeconds"),
+                                )}
+                              </label>
+                              <label class="field">
+                                ${renderFieldLabel("Alert channel")}
+                                <select
+                                  .value=${props.form.failureAlertChannel || "last"}
+                                  @change=${(e: Event) =>
+                                    props.onFormChange({
+                                      failureAlertChannel: (e.target as HTMLSelectElement).value,
+                                    })}
+                                >
+                                  ${channelOptions.map(
+                                    (channel) =>
+                                      html`<option value=${channel}>
+                                        ${resolveChannelLabel(props, channel)}
+                                      </option>`,
+                                  )}
+                                </select>
+                              </label>
+                              <label class="field">
+                                ${renderFieldLabel("Alert to")}
+                                <input
+                                  .value=${props.form.failureAlertTo}
+                                  list="cron-delivery-to-suggestions"
+                                  @input=${(e: Event) =>
+                                    props.onFormChange({
+                                      failureAlertTo: (e.target as HTMLInputElement).value,
+                                    })}
+                                  placeholder="+1555... or chat id"
+                                />
+                                <div class="cron-help">
+                                  Optional recipient override for failure alerts.
+                                </div>
+                              </label>
+                              <label class="field">
+                                ${renderFieldLabel("Alert mode")}
+                                <select
+                                  .value=${props.form.failureAlertDeliveryMode || "announce"}
+                                  @change=${(e: Event) =>
+                                    props.onFormChange({
+                                      failureAlertDeliveryMode: (e.target as HTMLSelectElement)
+                                        .value as CronFormState["failureAlertDeliveryMode"],
+                                    })}
+                                >
+                                  <option value="announce">Announce (via channel)</option>
+                                  <option value="webhook">Webhook (HTTP POST)</option>
+                                </select>
+                              </label>
+                              <label class="field">
+                                ${renderFieldLabel("Alert account ID")}
+                                <input
+                                  .value=${props.form.failureAlertAccountId}
+                                  @input=${(e: Event) =>
+                                    props.onFormChange({
+                                      failureAlertAccountId: (e.target as HTMLInputElement).value,
+                                    })}
+                                  placeholder="Account ID for multi-account setups"
+                                />
+                              </label>
+                            `
+                          : nothing
+                      }
+                    `
+                  : nothing
+              }
+              ${
                 selectedDeliveryMode !== "none"
                   ? html`
                       <label class="field checkbox cron-checkbox cron-span-2">

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -277,6 +277,8 @@ function fieldLabelForKey(
     payloadThinking: t("cron.form.thinking"),
     timeoutSeconds: t("cron.form.timeoutSeconds"),
     deliveryTo: t("cron.form.to"),
+    failureAlertAfter: t("cron.form.failureAlertAfter"),
+    failureAlertCooldownSeconds: t("cron.form.failureAlertCooldown"),
   };
   return labels[key];
 }
@@ -297,6 +299,8 @@ function collectBlockingFields(
     "payloadThinking",
     "timeoutSeconds",
     "deliveryTo",
+    "failureAlertAfter",
+    "failureAlertCooldownSeconds",
   ];
   const fields: BlockingField[] = [];
   for (const key of orderedKeys) {


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #727

### Commits
| Hash | Subject | Result |
|------|---------|--------|
| `a05b8f47b` | test(perf): tighten cron regression timeout windows | PICKED |
| `cd1847240` | test(perf): trim redundant cron regression setup coverage | PICKED |
| `3fb0ab743` | test(perf): tighten cron issue-regression timeout windows | PICKED |
| `4b4ea5df8` | feat(cron): add failure destination support to failed cron jobs (#31059) | RESOLVED |
| `14fbd0e6b` | test(perf): reduce timer teardown overhead in cron issue regressions | PICKED |

### Adaptation notes
- `4b4ea5df8` had 15 file conflicts (fork rebrand openclaw→remoteclaw + previously removed failure alert types). Resolved by accepting upstream's new failure destination feature while preserving fork naming.
- Fixed `OpenClawConfig` → `RemoteClawConfig` in `src/cron/delivery.ts`
- Added `CronMessageChannel` import to `src/cron/service/state.ts`
- Added `failureAlertAfter` and `failureAlertCooldownSeconds` to `CronFieldKey` type and related UI records

🤖 Generated with [Claude Code](https://claude.com/claude-code)