### PR TITLE
fix: correct remoteclaw.ai and remoteclaw.com domain references to remoteclaw.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1
 # OCI base-image metadata for downstream image consumers.
 # If you change these annotations, also update:
 # - docs/install/docker.md ("Base image metadata" section)
-# - https://docs.remoteclaw.com/install/docker
+# - https://docs.remoteclaw.org/install/docker
 LABEL org.opencontainers.image.base.name="docker.io/library/node:22-bookworm" \
   org.opencontainers.image.base.digest="sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935" \
   org.opencontainers.image.source="https://github.com/remoteclaw/remoteclaw" \
-  org.opencontainers.image.url="https://remoteclaw.com" \
-  org.opencontainers.image.documentation="https://docs.remoteclaw.com/install/docker" \
-  org.opencontainers.image.licenses="MIT" \
+  org.opencontainers.image.url="https://remoteclaw.org" \
+  org.opencontainers.image.documentation="https://docs.remoteclaw.org/install/docker" \
+  org.opencontainers.image.licenses="AGPL-3.0-only" \
   org.opencontainers.image.title="RemoteClaw" \
   org.opencontainers.image.description="RemoteClaw gateway and CLI runtime container image"
 

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -2170,7 +2170,7 @@ extension NodeAppModel {
 
         let payload = SharedContentPayload(
             title: "RemoteClaw Share Self-Test",
-            url: URL(string: "https://remoteclaw.com/share-self-test"),
+            url: URL(string: "https://remoteclaw.org/share-self-test"),
             text: "Validate iOS share->deep-link->gateway forwarding.")
         guard let deepLink = ShareToAgentDeepLink.buildURL(
             from: payload,

--- a/apps/macos/Sources/RemoteClaw/AboutSettings.swift
+++ b/apps/macos/Sources/RemoteClaw/AboutSettings.swift
@@ -50,7 +50,7 @@ struct AboutSettings: View {
                     icon: "chevron.left.slash.chevron.right",
                     title: "GitHub",
                     url: "https://github.com/remoteclaw/remoteclaw")
-                AboutLinkRow(icon: "globe", title: "Website", url: "https://remoteclaw.com")
+                AboutLinkRow(icon: "globe", title: "Website", url: "https://remoteclaw.org")
                 AboutLinkRow(icon: "bubble.left.and.bubble.right", title: "Discussions", url: "https://github.com/remoteclaw/remoteclaw/discussions")
                 AboutLinkRow(icon: "exclamationmark.triangle", title: "Issues", url: "https://github.com/remoteclaw/remoteclaw/issues")
             }

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -443,7 +443,7 @@ echo "Telegram (bot token):"
 echo "  ${COMPOSE_HINT} run --rm remoteclaw-cli channels add --channel telegram --token <token>"
 echo "Discord (bot token):"
 echo "  ${COMPOSE_HINT} run --rm remoteclaw-cli channels add --channel discord --token <token>"
-echo "Docs: https://docs.remoteclaw.ai/channels"
+echo "Docs: https://docs.remoteclaw.org/channels"
 
 echo ""
 echo "==> Starting gateway"
@@ -527,7 +527,7 @@ if [[ -n "$SANDBOX_ENABLED" ]]; then
 
   if [[ "$sandbox_config_ok" == true ]]; then
     echo "Sandbox enabled: mode=non-main, scope=agent, workspaceAccess=none"
-    echo "Docs: https://docs.remoteclaw.ai/gateway/sandboxing"
+    echo "Docs: https://docs.remoteclaw.org/gateway/sandboxing"
     # Restart gateway with sandbox compose overlay to pick up socket mount + config.
     docker compose "${COMPOSE_ARGS[@]}" up -d remoteclaw-gateway
   else

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -23,7 +23,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   - [It is stuck on "wake up my friend" / onboarding will not hatch. What now?](#it-is-stuck-on-wake-up-my-friend-onboarding-will-not-hatch-what-now)
   - [Can I migrate my setup to a new machine (Mac mini) without redoing onboarding?](#can-i-migrate-my-setup-to-a-new-machine-mac-mini-without-redoing-onboarding)
   - [Where do I see what is new in the latest version?](#where-do-i-see-what-is-new-in-the-latest-version)
-  - [I can't access docs.remoteclaw.ai (SSL error). What now?](#i-cant-access-docsremoteclawai-ssl-error-what-now)
+  - [I can't access docs.remoteclaw.org (SSL error). What now?](#i-cant-access-docsremoteclawai-ssl-error-what-now)
   - [What's the difference between stable and beta?](#whats-the-difference-between-stable-and-beta)
   - [How do I install the beta version, and what's the difference between beta and dev?](#how-do-i-install-the-beta-version-and-whats-the-difference-between-beta-and-dev)
   - [How do I try the latest bits?](#how-do-i-try-the-latest-bits)
@@ -275,7 +275,7 @@ setup (PATH, services, permissions, auth files). Give them the **full source che
 the hackable (git) install:
 
 ```bash
-curl -fsSL https://remoteclaw.ai/install.sh | bash -s -- --install-method git
+curl -fsSL https://remoteclaw.org/install.sh | bash -s -- --install-method git
 ```
 
 This installs RemoteClaw **from a git checkout**, so the agent can read the code + docs and
@@ -314,7 +314,7 @@ Install docs: [Install](/install), [Installer flags](/install/installer), [Updat
 The repo recommends running from source and using the onboarding wizard:
 
 ```bash
-curl -fsSL https://remoteclaw.ai/install.sh | bash
+curl -fsSL https://remoteclaw.org/install.sh | bash
 remoteclaw onboard --install-daemon
 ```
 
@@ -439,10 +439,10 @@ Newest entries are at the top. If the top section is marked **Unreleased**, the 
 section is the latest shipped version. Entries are grouped by **Highlights**, **Changes**, and
 **Fixes** (plus docs/other sections when needed).
 
-### I can't access docs.remoteclaw.ai SSL error What now
+### I can't access docs.remoteclaw.org SSL error What now
 
-Some Comcast/Xfinity connections incorrectly block `docs.remoteclaw.ai` via Xfinity
-Advanced Security. Disable it or allowlist `docs.remoteclaw.ai`, then retry. More
+Some Comcast/Xfinity connections incorrectly block `docs.remoteclaw.org` via Xfinity
+Advanced Security. Disable it or allowlist `docs.remoteclaw.org`, then retry. More
 detail: [Troubleshooting](/help/troubleshooting#docsremoteclawai-shows-an-ssl-error-comcastxfinity).
 Please help us unblock it by reporting here: [https://spa.xfinity.com/check_url_status](https://spa.xfinity.com/check_url_status).
 
@@ -471,15 +471,15 @@ See what changed:
 One-liners (macOS/Linux):
 
 ```bash
-curl -fsSL --proto '=https' --tlsv1.2 https://remoteclaw.ai/install.sh | bash -s -- --beta
+curl -fsSL --proto '=https' --tlsv1.2 https://remoteclaw.org/install.sh | bash -s -- --beta
 ```
 
 ```bash
-curl -fsSL --proto '=https' --tlsv1.2 https://remoteclaw.ai/install.sh | bash -s -- --install-method git
+curl -fsSL --proto '=https' --tlsv1.2 https://remoteclaw.org/install.sh | bash -s -- --install-method git
 ```
 
 Windows installer (PowerShell):
-[https://remoteclaw.ai/install.ps1](https://remoteclaw.ai/install.ps1)
+[https://remoteclaw.org/install.ps1](https://remoteclaw.org/install.ps1)
 
 More detail: [Development channels](/install/development-channels) and [Installer flags](/install/installer).
 
@@ -508,7 +508,7 @@ This switches to the `main` branch and updates from source.
 2. **Hackable install (from the installer site):**
 
 ```bash
-curl -fsSL https://remoteclaw.ai/install.sh | bash -s -- --install-method git
+curl -fsSL https://remoteclaw.org/install.sh | bash -s -- --install-method git
 ```
 
 That gives you a local repo you can edit, then update via git.
@@ -530,19 +530,19 @@ Docs: [Update](/cli/update), [Development channels](/install/development-channel
 Re-run the installer with **verbose output**:
 
 ```bash
-curl -fsSL https://remoteclaw.ai/install.sh | bash -s -- --verbose
+curl -fsSL https://remoteclaw.org/install.sh | bash -s -- --verbose
 ```
 
 Beta install with verbose:
 
 ```bash
-curl -fsSL https://remoteclaw.ai/install.sh | bash -s -- --beta --verbose
+curl -fsSL https://remoteclaw.org/install.sh | bash -s -- --beta --verbose
 ```
 
 For a hackable (git) install:
 
 ```bash
-curl -fsSL https://remoteclaw.ai/install.sh | bash -s -- --install-method git --verbose
+curl -fsSL https://remoteclaw.org/install.sh | bash -s -- --install-method git --verbose
 ```
 
 Windows (PowerShell) equivalent:
@@ -550,7 +550,7 @@ Windows (PowerShell) equivalent:
 ```powershell
 # install.ps1 has no dedicated -Verbose flag yet.
 Set-PSDebug -Trace 1
-& ([scriptblock]::Create((iwr -useb https://remoteclaw.ai/install.ps1))) -NoOnboard
+& ([scriptblock]::Create((iwr -useb https://remoteclaw.org/install.ps1))) -NoOnboard
 Set-PSDebug -Trace 0
 ```
 
@@ -586,7 +586,7 @@ Use the **hackable (git) install** so you have the full source and docs locally,
 your bot (or Claude/Codex) _from that folder_ so it can read the repo and answer precisely.
 
 ```bash
-curl -fsSL https://remoteclaw.ai/install.sh | bash -s -- --install-method git
+curl -fsSL https://remoteclaw.org/install.sh | bash -s -- --install-method git
 ```
 
 More detail: [Install](/install) and [Installer flags](/install/installer).
@@ -1008,7 +1008,7 @@ Advantages:
 - **Always-on Gateway** (run on a VPS, interact from anywhere)
 - **Nodes** for local browser/screen/camera/exec
 
-Showcase: [https://remoteclaw.ai/showcase](https://remoteclaw.ai/showcase)
+Showcase: [https://remoteclaw.org/showcase](https://remoteclaw.org/showcase)
 
 ## Skills and automation
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -161,9 +161,9 @@ The docker image now publishes OCI base-image annotations (sha256 is an example)
 - `org.opencontainers.image.base.name=docker.io/library/node:22-bookworm`
 - `org.opencontainers.image.base.digest=sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935`
 - `org.opencontainers.image.source=https://github.com/remoteclaw/remoteclaw`
-- `org.opencontainers.image.url=https://remoteclaw.com`
-- `org.opencontainers.image.documentation=https://docs.remoteclaw.com/install/docker`
-- `org.opencontainers.image.licenses=MIT`
+- `org.opencontainers.image.url=https://remoteclaw.org`
+- `org.opencontainers.image.documentation=https://docs.remoteclaw.org/install/docker`
+- `org.opencontainers.image.licenses=AGPL-3.0-only`
 - `org.opencontainers.image.title=RemoteClaw`
 - `org.opencontainers.image.description=RemoteClaw gateway and CLI runtime container image`
 - `org.opencontainers.image.revision=<git-sha>`

--- a/extensions/mattermost/src/onboarding.ts
+++ b/extensions/mattermost/src/onboarding.ts
@@ -20,7 +20,7 @@ async function noteMattermostSetup(prompter: WizardPrompter): Promise<void> {
       "2) Create a bot + copy its token",
       "3) Use your server base URL (e.g., https://chat.example.com)",
       "Tip: the bot must be a member of any channel you want it to monitor.",
-      "Docs: https://docs.remoteclaw.com/channels/mattermost",
+      "Docs: https://docs.remoteclaw.org/channels/mattermost",
     ].join("\n"),
     "Mattermost bot token",
   );

--- a/extensions/tlon/README.md
+++ b/extensions/tlon/README.md
@@ -2,4 +2,4 @@
 
 Tlon/Urbit channel plugin for RemoteClaw. Supports DMs, group mentions, and thread replies.
 
-Docs: https://docs.remoteclaw.com/channels/tlon
+Docs: https://docs.remoteclaw.org/channels/tlon

--- a/extensions/twitch/README.md
+++ b/extensions/twitch/README.md
@@ -80,7 +80,7 @@ Multi-account config (advanced):
 
 ## Full documentation
 
-See https://docs.remoteclaw.com/channels/twitch for:
+See https://docs.remoteclaw.org/channels/twitch for:
 
 - Token refresh setup
 - Access control patterns

--- a/extensions/voice-call/README.md
+++ b/extensions/voice-call/README.md
@@ -9,8 +9,8 @@ Providers:
 - **Plivo** (Voice API + XML transfer + GetInput speech)
 - **Mock** (dev/no network)
 
-Docs: `https://docs.remoteclaw.com/plugins/voice-call`
-Plugin system: `https://docs.remoteclaw.com/plugin`
+Docs: `https://docs.remoteclaw.org/plugins/voice-call`
+Plugin system: `https://docs.remoteclaw.org/plugin`
 
 ## Install (local dev)
 

--- a/extensions/voice-call/src/cli.ts
+++ b/extensions/voice-call/src/cli.ts
@@ -112,7 +112,7 @@ export function registerVoiceCallCli(params: {
   const root = program
     .command("voicecall")
     .description("Voice call utilities")
-    .addHelpText("after", () => `\nDocs: https://docs.remoteclaw.com/cli/voicecall\n`);
+    .addHelpText("after", () => `\nDocs: https://docs.remoteclaw.org/cli/voicecall\n`);
 
   root
     .command("call")

--- a/extensions/zalo/src/onboarding.ts
+++ b/extensions/zalo/src/onboarding.ts
@@ -118,7 +118,7 @@ async function noteZaloTokenHelp(prompter: WizardPrompter): Promise<void> {
       "2) Create a bot and get the token",
       "3) Token looks like 12345689:abc-xyz",
       "Tip: you can also set ZALO_BOT_TOKEN in your env.",
-      "Docs: https://docs.remoteclaw.com/channels/zalo",
+      "Docs: https://docs.remoteclaw.org/channels/zalo",
     ].join("\n"),
     "Zalo bot token",
   );

--- a/extensions/zalouser/src/onboarding.ts
+++ b/extensions/zalouser/src/onboarding.ts
@@ -97,7 +97,7 @@ async function noteZalouserHelp(prompter: WizardPrompter): Promise<void> {
       "",
       "This plugin uses zca-js directly (no external CLI dependency).",
       "",
-      "Docs: https://docs.remoteclaw.com/channels/zalouser",
+      "Docs: https://docs.remoteclaw.org/channels/zalouser",
     ].join("\n"),
     "Zalo Personal Setup",
   );

--- a/scripts/protocol-gen.ts
+++ b/scripts/protocol-gen.ts
@@ -14,7 +14,7 @@ async function writeJsonSchema() {
 
   const rootSchema = {
     $schema: "http://json-schema.org/draft-07/schema#",
-    $id: "https://remoteclaw.com/protocol.schema.json",
+    $id: "https://remoteclaw.org/protocol.schema.json",
     title: "RemoteClaw Gateway Protocol",
     description: "Handshake, request/response, and event frames for the Gateway WebSocket.",
     oneOf: [

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -475,7 +475,7 @@ export async function restartLaunchAgent({
           `LaunchAgent restart requires a logged-in macOS GUI session for this user (${domain}).`,
           "This usually means you are running from SSH/headless context or as the wrong user (including sudo).",
           "Fix: sign in to the macOS desktop as the target user and rerun `remoteclaw gateway restart`.",
-          "Headless deployments should use a dedicated logged-in user session or a custom LaunchDaemon (not shipped): https://docs.remoteclaw.com/gateway",
+          "Headless deployments should use a dedicated logged-in user session or a custom LaunchDaemon (not shipped): https://docs.remoteclaw.org/gateway",
         ].join("\n"),
       );
     }

--- a/src/infra/install-source-utils.test.ts
+++ b/src/infra/install-source-utils.test.ts
@@ -259,7 +259,7 @@ describe("packNpmSpecToArchive", () => {
     if (!result.ok) {
       expect(result.error).toContain("Package not found on npm");
       expect(result.error).toContain("@remoteclaw/whatsapp");
-      expect(result.error).toContain("docs.remoteclaw.com/tools/plugin");
+      expect(result.error).toContain("docs.remoteclaw.org/tools/plugin");
     }
   });
 

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -211,7 +211,7 @@ export async function packNpmSpecToArchive(params: {
     if (/E404|is not in this registry/i.test(raw)) {
       return {
         ok: false,
-        error: `Package not found on npm: ${params.spec}. See https://docs.remoteclaw.com/tools/plugin for installable plugins.`,
+        error: `Package not found on npm: ${params.spec}. See https://docs.remoteclaw.org/tools/plugin for installable plugins.`,
       };
     }
     return { ok: false, error: `npm pack failed: ${raw}` };


### PR DESCRIPTION
## Summary

- Replace all `remoteclaw.ai` → `remoteclaw.org` references (16 occurrences in `docs/help/faq.md`, 2 in `docker-setup.sh`)
- Replace all `remoteclaw.com` → `remoteclaw.org` references across Dockerfile, extensions, apps, src, docs (15 files)
- Fix OCI license label `MIT` → `AGPL-3.0-only` in `Dockerfile` and `docs/install/docker.md`

Closes #1567

## Test plan

- [x] `grep -r "remoteclaw\.ai\|remoteclaw\.com"` returns zero domain URL matches (one false positive: `remoteclaw.command` property access in test — not a domain)
- [x] All 661 test files pass (5595 tests)
- [x] Lint hook passes on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)