### PR TITLE
Cherry-pick cd653c55d: windows: unify non-core spawn handling across acp

### DIFF
--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -1,6 +1,13 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
-import { describe, expect, it, vi } from "vitest";
-import { resolveAcpClientSpawnEnv, resolvePermissionRequest } from "./client.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveAcpClientSpawnEnv,
+  resolveAcpClientSpawnInvocation,
+  resolvePermissionRequest,
+} from "./client.js";
 import { extractAttachmentsFromPrompt, extractTextFromPrompt } from "./event-mapper.js";
 
 function makePermissionRequest(
@@ -28,6 +35,24 @@ function makePermissionRequest(
   };
 }
 
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "openclaw-acp-client-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (!dir) {
+      continue;
+    }
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 describe("resolveAcpClientSpawnEnv", () => {
   it("sets REMOTECLAW_SHELL marker and preserves existing env values", () => {
     const env = resolveAcpClientSpawnEnv({
@@ -45,6 +70,69 @@ describe("resolveAcpClientSpawnEnv", () => {
       REMOTECLAW_SHELL: "wrong",
     });
     expect(env.REMOTECLAW_SHELL).toBe("acp-client");
+  });
+});
+
+describe("resolveAcpClientSpawnInvocation", () => {
+  it("keeps non-windows invocation unchanged", () => {
+    const resolved = resolveAcpClientSpawnInvocation(
+      { serverCommand: "openclaw", serverArgs: ["acp", "--verbose"] },
+      {
+        platform: "darwin",
+        env: {},
+        execPath: "/usr/bin/node",
+      },
+    );
+    expect(resolved).toEqual({
+      command: "openclaw",
+      args: ["acp", "--verbose"],
+      shell: undefined,
+      windowsHide: undefined,
+    });
+  });
+
+  it("unwraps .cmd shim entrypoint on windows", async () => {
+    const dir = await createTempDir();
+    const scriptPath = path.join(dir, "openclaw", "dist", "entry.js");
+    const shimPath = path.join(dir, "openclaw.cmd");
+    await mkdir(path.dirname(scriptPath), { recursive: true });
+    await writeFile(scriptPath, "console.log('ok')\n", "utf8");
+    await writeFile(shimPath, `@ECHO off\r\n"%~dp0\\openclaw\\dist\\entry.js" %*\r\n`, "utf8");
+
+    const resolved = resolveAcpClientSpawnInvocation(
+      { serverCommand: shimPath, serverArgs: ["acp", "--verbose"] },
+      {
+        platform: "win32",
+        env: { PATH: dir, PATHEXT: ".CMD;.EXE;.BAT" },
+        execPath: "C:\\node\\node.exe",
+      },
+    );
+    expect(resolved.command).toBe("C:\\node\\node.exe");
+    expect(resolved.args).toEqual([scriptPath, "acp", "--verbose"]);
+    expect(resolved.shell).toBeUndefined();
+    expect(resolved.windowsHide).toBe(true);
+  });
+
+  it("falls back to shell mode for unresolved wrappers on windows", async () => {
+    const dir = await createTempDir();
+    const shimPath = path.join(dir, "openclaw.cmd");
+    await writeFile(shimPath, "@ECHO off\r\necho wrapper\r\n", "utf8");
+
+    const resolved = resolveAcpClientSpawnInvocation(
+      { serverCommand: shimPath, serverArgs: ["acp"] },
+      {
+        platform: "win32",
+        env: { PATH: dir, PATHEXT: ".CMD;.EXE;.BAT" },
+        execPath: "C:\\node\\node.exe",
+      },
+    );
+
+    expect(resolved).toEqual({
+      command: shimPath,
+      args: ["acp"],
+      shell: true,
+      windowsHide: undefined,
+    });
   });
 });
 

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -14,6 +14,10 @@ import {
 } from "@agentclientprotocol/sdk";
 import { isKnownCoreToolId } from "../agents/tool-catalog.js";
 import { ensureRemoteClawCliOnPath } from "../infra/path-env.js";
+import {
+  materializeWindowsSpawnProgram,
+  resolveWindowsSpawnProgram,
+} from "../plugin-sdk/windows-spawn.js";
 import { DANGEROUS_ACP_TOOLS } from "../security/dangerous-tools.js";
 
 const SAFE_AUTO_APPROVE_TOOL_IDS = new Set(["search"]);
@@ -247,6 +251,39 @@ export function resolveAcpClientSpawnEnv(
   return { ...baseEnv, REMOTECLAW_SHELL: "acp-client" };
 }
 
+type AcpSpawnRuntime = {
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+  execPath: string;
+};
+
+const DEFAULT_ACP_SPAWN_RUNTIME: AcpSpawnRuntime = {
+  platform: process.platform,
+  env: process.env,
+  execPath: process.execPath,
+};
+
+export function resolveAcpClientSpawnInvocation(
+  params: { serverCommand: string; serverArgs: string[] },
+  runtime: AcpSpawnRuntime = DEFAULT_ACP_SPAWN_RUNTIME,
+): { command: string; args: string[]; shell?: boolean; windowsHide?: boolean } {
+  const program = resolveWindowsSpawnProgram({
+    command: params.serverCommand,
+    platform: runtime.platform,
+    env: runtime.env,
+    execPath: runtime.execPath,
+    packageName: "remoteclaw",
+    allowShellFallback: true,
+  });
+  const resolved = materializeWindowsSpawnProgram(program, params.serverArgs);
+  return {
+    command: resolved.command,
+    args: resolved.argv,
+    shell: resolved.shell,
+    windowsHide: resolved.windowsHide,
+  };
+}
+
 function resolveSelfEntryPath(): string | null {
   // Prefer a path relative to the built module location (dist/acp/client.js -> dist/entry.js).
   try {
@@ -312,13 +349,24 @@ export async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpC
   const entryPath = resolveSelfEntryPath();
   const serverCommand = opts.serverCommand ?? (entryPath ? process.execPath : "remoteclaw");
   const effectiveArgs = opts.serverCommand || !entryPath ? serverArgs : [entryPath, ...serverArgs];
+  const spawnEnv = resolveAcpClientSpawnEnv();
+  const spawnInvocation = resolveAcpClientSpawnInvocation(
+    { serverCommand, serverArgs: effectiveArgs },
+    {
+      platform: process.platform,
+      env: spawnEnv,
+      execPath: process.execPath,
+    },
+  );
 
-  log(`spawning: ${serverCommand} ${effectiveArgs.join(" ")}`);
+  log(`spawning: ${spawnInvocation.command} ${spawnInvocation.args.join(" ")}`);
 
-  const agent = spawn(serverCommand, effectiveArgs, {
+  const agent = spawn(spawnInvocation.command, spawnInvocation.args, {
     stdio: ["pipe", "pipe", "inherit"],
     cwd,
-    env: resolveAcpClientSpawnEnv(),
+    env: spawnEnv,
+    shell: spawnInvocation.shell,
+    windowsHide: spawnInvocation.windowsHide,
   });
 
   if (!agent.stdin || !agent.stdout) {

--- a/src/plugin-sdk/windows-spawn.ts
+++ b/src/plugin-sdk/windows-spawn.ts
@@ -1,0 +1,299 @@
+import { readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+export type WindowsSpawnResolution =
+  | "direct"
+  | "node-entrypoint"
+  | "exe-entrypoint"
+  | "shell-fallback";
+
+export type WindowsSpawnCandidateResolution = Exclude<WindowsSpawnResolution, "shell-fallback">;
+export type WindowsSpawnProgramCandidate = {
+  command: string;
+  leadingArgv: string[];
+  resolution: WindowsSpawnCandidateResolution | "unresolved-wrapper";
+  windowsHide?: boolean;
+};
+
+export type WindowsSpawnProgram = {
+  command: string;
+  leadingArgv: string[];
+  resolution: WindowsSpawnResolution;
+  shell?: boolean;
+  windowsHide?: boolean;
+};
+
+export type WindowsSpawnInvocation = {
+  command: string;
+  argv: string[];
+  resolution: WindowsSpawnResolution;
+  shell?: boolean;
+  windowsHide?: boolean;
+};
+
+export type ResolveWindowsSpawnProgramParams = {
+  command: string;
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  execPath?: string;
+  packageName?: string;
+  allowShellFallback?: boolean;
+};
+export type ResolveWindowsSpawnProgramCandidateParams = Omit<
+  ResolveWindowsSpawnProgramParams,
+  "allowShellFallback"
+>;
+
+function isFilePath(candidate: string): boolean {
+  try {
+    return statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function resolveWindowsExecutablePath(command: string, env: NodeJS.ProcessEnv): string {
+  if (command.includes("/") || command.includes("\\") || path.isAbsolute(command)) {
+    return command;
+  }
+
+  const pathValue = env.PATH ?? env.Path ?? process.env.PATH ?? process.env.Path ?? "";
+  const pathEntries = pathValue
+    .split(";")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  const hasExtension = path.extname(command).length > 0;
+  const pathExtRaw =
+    env.PATHEXT ??
+    env.Pathext ??
+    process.env.PATHEXT ??
+    process.env.Pathext ??
+    ".EXE;.CMD;.BAT;.COM";
+  const pathExt = hasExtension
+    ? [""]
+    : pathExtRaw
+        .split(";")
+        .map((ext) => ext.trim())
+        .filter(Boolean)
+        .map((ext) => (ext.startsWith(".") ? ext : `.${ext}`));
+
+  for (const dir of pathEntries) {
+    for (const ext of pathExt) {
+      for (const candidateExt of [ext, ext.toLowerCase(), ext.toUpperCase()]) {
+        const candidate = path.join(dir, `${command}${candidateExt}`);
+        if (isFilePath(candidate)) {
+          return candidate;
+        }
+      }
+    }
+  }
+
+  return command;
+}
+
+function resolveEntrypointFromCmdShim(wrapperPath: string): string | null {
+  if (!isFilePath(wrapperPath)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(wrapperPath, "utf8");
+    const candidates: string[] = [];
+    for (const match of content.matchAll(/"([^"\r\n]*)"/g)) {
+      const token = match[1] ?? "";
+      const relMatch = token.match(/%~?dp0%?\s*[\\/]*(.*)$/i);
+      const relative = relMatch?.[1]?.trim();
+      if (!relative) {
+        continue;
+      }
+      const normalizedRelative = relative.replace(/[\\/]+/g, path.sep).replace(/^[\\/]+/, "");
+      const candidate = path.resolve(path.dirname(wrapperPath), normalizedRelative);
+      if (isFilePath(candidate)) {
+        candidates.push(candidate);
+      }
+    }
+    const nonNode = candidates.find((candidate) => {
+      const base = path.basename(candidate).toLowerCase();
+      return base !== "node.exe" && base !== "node";
+    });
+    return nonNode ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveBinEntry(
+  packageName: string | undefined,
+  binField: string | Record<string, string> | undefined,
+): string | null {
+  if (typeof binField === "string") {
+    const trimmed = binField.trim();
+    return trimmed || null;
+  }
+  if (!binField || typeof binField !== "object") {
+    return null;
+  }
+
+  if (packageName) {
+    const preferred = binField[packageName];
+    if (typeof preferred === "string" && preferred.trim()) {
+      return preferred.trim();
+    }
+  }
+
+  for (const value of Object.values(binField)) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function resolveEntrypointFromPackageJson(
+  wrapperPath: string,
+  packageName?: string,
+): string | null {
+  if (!packageName) {
+    return null;
+  }
+
+  const wrapperDir = path.dirname(wrapperPath);
+  const packageDirs = [
+    path.resolve(wrapperDir, "..", packageName),
+    path.resolve(wrapperDir, "node_modules", packageName),
+  ];
+
+  for (const packageDir of packageDirs) {
+    const packageJsonPath = path.join(packageDir, "package.json");
+    if (!isFilePath(packageJsonPath)) {
+      continue;
+    }
+    try {
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+        bin?: string | Record<string, string>;
+      };
+      const entryRel = resolveBinEntry(packageName, packageJson.bin);
+      if (!entryRel) {
+        continue;
+      }
+      const entryPath = path.resolve(packageDir, entryRel);
+      if (isFilePath(entryPath)) {
+        return entryPath;
+      }
+    } catch {
+      // Ignore malformed package metadata.
+    }
+  }
+
+  return null;
+}
+
+export function resolveWindowsSpawnProgramCandidate(
+  params: ResolveWindowsSpawnProgramCandidateParams,
+): WindowsSpawnProgramCandidate {
+  const platform = params.platform ?? process.platform;
+  const env = params.env ?? process.env;
+  const execPath = params.execPath ?? process.execPath;
+
+  if (platform !== "win32") {
+    return {
+      command: params.command,
+      leadingArgv: [],
+      resolution: "direct",
+    };
+  }
+
+  const resolvedCommand = resolveWindowsExecutablePath(params.command, env);
+  const ext = path.extname(resolvedCommand).toLowerCase();
+  if (ext === ".js" || ext === ".cjs" || ext === ".mjs") {
+    return {
+      command: execPath,
+      leadingArgv: [resolvedCommand],
+      resolution: "node-entrypoint",
+      windowsHide: true,
+    };
+  }
+
+  if (ext === ".cmd" || ext === ".bat") {
+    const entrypoint =
+      resolveEntrypointFromCmdShim(resolvedCommand) ??
+      resolveEntrypointFromPackageJson(resolvedCommand, params.packageName);
+    if (entrypoint) {
+      const entryExt = path.extname(entrypoint).toLowerCase();
+      if (entryExt === ".exe") {
+        return {
+          command: entrypoint,
+          leadingArgv: [],
+          resolution: "exe-entrypoint",
+          windowsHide: true,
+        };
+      }
+      return {
+        command: execPath,
+        leadingArgv: [entrypoint],
+        resolution: "node-entrypoint",
+        windowsHide: true,
+      };
+    }
+
+    return {
+      command: resolvedCommand,
+      leadingArgv: [],
+      resolution: "unresolved-wrapper",
+    };
+  }
+
+  return {
+    command: resolvedCommand,
+    leadingArgv: [],
+    resolution: "direct",
+  };
+}
+
+export function applyWindowsSpawnProgramPolicy(params: {
+  candidate: WindowsSpawnProgramCandidate;
+  allowShellFallback?: boolean;
+}): WindowsSpawnProgram {
+  if (params.candidate.resolution !== "unresolved-wrapper") {
+    return {
+      command: params.candidate.command,
+      leadingArgv: params.candidate.leadingArgv,
+      resolution: params.candidate.resolution,
+      windowsHide: params.candidate.windowsHide,
+    };
+  }
+  if (params.allowShellFallback !== false) {
+    return {
+      command: params.candidate.command,
+      leadingArgv: [],
+      resolution: "shell-fallback",
+      shell: true,
+    };
+  }
+  throw new Error(
+    `${path.basename(params.candidate.command)} wrapper resolved, but no executable/Node entrypoint could be resolved without shell execution.`,
+  );
+}
+
+export function resolveWindowsSpawnProgram(
+  params: ResolveWindowsSpawnProgramParams,
+): WindowsSpawnProgram {
+  const candidate = resolveWindowsSpawnProgramCandidate(params);
+  return applyWindowsSpawnProgramPolicy({
+    candidate,
+    allowShellFallback: params.allowShellFallback,
+  });
+}
+
+export function materializeWindowsSpawnProgram(
+  program: WindowsSpawnProgram,
+  argv: string[],
+): WindowsSpawnInvocation {
+  return {
+    command: program.command,
+    argv: [...program.leadingArgv, ...argv],
+    resolution: program.resolution,
+    shell: program.shell,
+    windowsHide: program.windowsHide,
+  };
+}


### PR DESCRIPTION
## Cherry-pick

**Upstream commit**: openclaw/openclaw@cd653c55d
**Author**: @Takhoffman
**Tier**: AUTO-PARTIAL

## Summary

- Unified Windows spawn handling for ACP client via `resolveWindowsSpawnProgram` / `materializeWindowsSpawnProgram`
- Partial pick: only ACP client files (docker, memory, changelog files gutted in fork)
- Brought in `src/plugin-sdk/windows-spawn.ts` dependency (post-fork-point upstream file)
- Rebranded `packageName: "openclaw"` → `"remoteclaw"`

Cherry-picked-from: openclaw/openclaw@cd653c55d

🦀 The crab way.