### PR TITLE
Cherry-pick batch: channel adapter fixes (Slack, Line, WhatsApp, voice-call)

### DIFF
--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -175,6 +175,43 @@ describe("VoiceCallWebhookServer path matching", () => {
 });
 
 describe("VoiceCallWebhookServer replay handling", () => {
+  it("rejects lookalike webhook paths that only match by prefix", async () => {
+    const verifyWebhook = vi.fn(() => ({ ok: true, verifiedRequestKey: "verified:req:prefix" }));
+    const parseWebhookEvent = vi.fn(() => ({ events: [], statusCode: 200 }));
+    const strictProvider: VoiceCallProvider = {
+      ...provider,
+      verifyWebhook,
+      parseWebhookEvent,
+    };
+    const { manager } = createManager([]);
+    const config = createConfig({ serve: { port: 0, bind: "127.0.0.1", path: "/voice/webhook" } });
+    const server = new VoiceCallWebhookServer(config, manager, strictProvider);
+
+    try {
+      const baseUrl = await server.start();
+      const address = (
+        server as unknown as { server?: { address?: () => unknown } }
+      ).server?.address?.();
+      const requestUrl = new URL(baseUrl);
+      if (address && typeof address === "object" && "port" in address && address.port) {
+        requestUrl.port = String(address.port);
+      }
+      requestUrl.pathname = "/voice/webhook-evil";
+
+      const response = await fetch(requestUrl.toString(), {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: "CallSid=CA123&SpeechResult=hello",
+      });
+
+      expect(response.status).toBe(404);
+      expect(verifyWebhook).not.toHaveBeenCalled();
+      expect(parseWebhookEvent).not.toHaveBeenCalled();
+    } finally {
+      await server.stop();
+    }
+  });
+
   it("acknowledges replayed webhook requests and skips event side effects", async () => {
     const replayProvider: VoiceCallProvider = {
       ...provider,

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -255,6 +255,25 @@ export class VoiceCallWebhookServer {
     }
   }
 
+  private normalizeWebhookPathForMatch(pathname: string): string {
+    const trimmed = pathname.trim();
+    if (!trimmed) {
+      return "/";
+    }
+    const prefixed = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+    if (prefixed === "/") {
+      return prefixed;
+    }
+    return prefixed.endsWith("/") ? prefixed.slice(0, -1) : prefixed;
+  }
+
+  private isWebhookPathMatch(requestPath: string, configuredPath: string): boolean {
+    return (
+      this.normalizeWebhookPathForMatch(requestPath) ===
+      this.normalizeWebhookPathForMatch(configuredPath)
+    );
+  }
+
   /**
    * Handle incoming HTTP request.
    */
@@ -266,7 +285,7 @@ export class VoiceCallWebhookServer {
     const url = new URL(req.url || "/", `http://${req.headers.host}`);
 
     // Check path
-    if (!url.pathname.startsWith(webhookPath)) {
+    if (!this.isWebhookPathMatch(url.pathname, webhookPath)) {
       res.statusCode = 404;
       res.end("Not Found");
       return;

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -111,14 +111,42 @@ describe("buildInboundUserContextPrefix", () => {
     expect(text).toBe("");
   });
 
-  it("hides message identifiers for direct chats", () => {
+  it("hides message identifiers for direct webchat chats", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "direct",
+      OriginatingChannel: "webchat",
       MessageSid: "short-id",
       MessageSidFull: "provider-full-id",
     } as TemplateContext);
 
     expect(text).toBe("");
+  });
+
+  it("includes message identifiers for direct external-channel chats", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "direct",
+      OriginatingChannel: "whatsapp",
+      MessageSid: "short-id",
+      MessageSidFull: "provider-full-id",
+      SenderE164: " +15551234567 ",
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["message_id"]).toBe("short-id");
+    expect(conversationInfo["message_id_full"]).toBeUndefined();
+    expect(conversationInfo["sender"]).toBe("+15551234567");
+    expect(conversationInfo["conversation_label"]).toBeUndefined();
+  });
+
+  it("includes message identifiers for direct chats when channel is inferred from Provider", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "direct",
+      Provider: "whatsapp",
+      MessageSid: "provider-only-id",
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["message_id"]).toBe("provider-only-id");
   });
 
   it("does not treat group chats as direct based on sender id", () => {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -31,6 +31,17 @@ function formatConversationTimestamp(value: unknown): string | undefined {
   }
 }
 
+function resolveInboundChannel(ctx: TemplateContext): string | undefined {
+  let channelValue = safeTrim(ctx.OriginatingChannel) ?? safeTrim(ctx.Surface);
+  if (!channelValue) {
+    const provider = safeTrim(ctx.Provider);
+    if (provider !== "webchat" && ctx.Surface !== "webchat") {
+      channelValue = provider;
+    }
+  }
+  return channelValue;
+}
+
 export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
@@ -44,18 +55,7 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
   // Resolve channel identity: prefer explicit channel, then surface, then provider.
   // For webchat/Hub Chat sessions (when Surface is 'webchat' or undefined with no real channel),
   // omit the channel field entirely rather than falling back to an unrelated provider.
-  let channelValue = safeTrim(ctx.OriginatingChannel) ?? safeTrim(ctx.Surface);
-  if (!channelValue) {
-    // Only fall back to Provider if it represents a real messaging channel.
-    // For webchat/internal sessions, ctx.Provider may be unrelated (e.g., the user's configured
-    // default channel), so skip it to avoid incorrect runtime labels like "channel=whatsapp".
-    const provider = safeTrim(ctx.Provider);
-    // Check if provider is "webchat" or if we're in an internal/webchat context
-    if (provider !== "webchat" && ctx.Surface !== "webchat") {
-      channelValue = provider;
-    }
-    // Otherwise leave channelValue undefined (no channel label)
-  }
+  const channelValue = resolveInboundChannel(ctx);
 
   const payload = {
     schema: "remoteclaw.inbound_meta.v1",
@@ -85,6 +85,11 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   const blocks: string[] = [];
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
+  const directChannelValue = resolveInboundChannel(ctx);
+  const includeDirectConversationInfo = Boolean(
+    directChannelValue && directChannelValue !== "webchat",
+  );
+  const shouldIncludeConversationInfo = !isDirect || includeDirectConversationInfo;
 
   const messageId = safeTrim(ctx.MessageSid);
   const messageIdFull = safeTrim(ctx.MessageSidFull);
@@ -92,16 +97,16 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   const timestampStr = formatConversationTimestamp(ctx.Timestamp);
 
   const conversationInfo = {
-    message_id: isDirect ? undefined : resolvedMessageId,
-    reply_to_id: isDirect ? undefined : safeTrim(ctx.ReplyToId),
-    sender_id: isDirect ? undefined : safeTrim(ctx.SenderId),
+    message_id: shouldIncludeConversationInfo ? resolvedMessageId : undefined,
+    reply_to_id: shouldIncludeConversationInfo ? safeTrim(ctx.ReplyToId) : undefined,
+    sender_id: shouldIncludeConversationInfo ? safeTrim(ctx.SenderId) : undefined,
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),
-    sender: isDirect
-      ? undefined
-      : (safeTrim(ctx.SenderName) ??
+    sender: shouldIncludeConversationInfo
+      ? (safeTrim(ctx.SenderName) ??
         safeTrim(ctx.SenderE164) ??
         safeTrim(ctx.SenderId) ??
-        safeTrim(ctx.SenderUsername)),
+        safeTrim(ctx.SenderUsername))
+      : undefined,
     timestamp: timestampStr,
     group_subject: safeTrim(ctx.GroupSubject),
     group_channel: safeTrim(ctx.GroupChannel),

--- a/src/auto-reply/reply/mentions.test.ts
+++ b/src/auto-reply/reply/mentions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { stripStructuralPrefixes } from "./mentions.js";
+
+describe("stripStructuralPrefixes", () => {
+  it("returns empty string for undefined input at runtime", () => {
+    expect(stripStructuralPrefixes(undefined as unknown as string)).toBe("");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripStructuralPrefixes("")).toBe("");
+  });
+
+  it("strips sender prefix labels", () => {
+    expect(stripStructuralPrefixes("John: hello")).toBe("hello");
+  });
+
+  it("passes through plain text", () => {
+    expect(stripStructuralPrefixes("just a message")).toBe("just a message");
+  });
+});

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -111,6 +111,9 @@ export function matchesMentionWithExplicit(params: {
 }
 
 export function stripStructuralPrefixes(text: string): string {
+  if (!text) {
+    return "";
+  }
   // Ignore wrapper labels, timestamps, and sender prefixes so directive-only
   // detection still works in group batches that include history/context.
   const afterMarker = text.includes(CURRENT_MESSAGE_MARKER)

--- a/src/line/monitor.lifecycle.test.ts
+++ b/src/line/monitor.lifecycle.test.ts
@@ -98,6 +98,9 @@ describe("monitorLineProvider lifecycle", () => {
     });
 
     await vi.waitFor(() => expect(registerPluginHttpRouteMock).toHaveBeenCalledTimes(1));
+    expect(registerPluginHttpRouteMock).toHaveBeenCalledWith(
+      expect.objectContaining({ auth: "plugin" }),
+    );
     expect(resolved).toBe(false);
 
     abort.abort();

--- a/src/slack/format.test.ts
+++ b/src/slack/format.test.ts
@@ -57,6 +57,10 @@ describe("markdownToSlackMrkdwn", () => {
       "*Important:* Check the _docs_ at <https://example.com|link>\n\n• first\n• second",
     );
   });
+
+  it("does not throw when input is undefined at runtime", () => {
+    expect(markdownToSlackMrkdwn(undefined as unknown as string)).toBe("");
+  });
 });
 
 describe("escapeSlackMrkdwn", () => {

--- a/src/slack/format.ts
+++ b/src/slack/format.ts
@@ -28,6 +28,9 @@ function isAllowedSlackAngleToken(token: string): boolean {
 }
 
 function escapeSlackMrkdwnContent(text: string): string {
+  if (!text) {
+    return "";
+  }
   if (!text.includes("&") && !text.includes("<") && !text.includes(">")) {
     return text;
   }
@@ -53,6 +56,9 @@ function escapeSlackMrkdwnContent(text: string): string {
 }
 
 function escapeSlackMrkdwnText(text: string): string {
+  if (!text) {
+    return "";
+  }
   if (!text.includes("&") && !text.includes("<") && !text.includes(">")) {
     return text;
   }

--- a/src/slack/monitor/events/messages.test.ts
+++ b/src/slack/monitor/events/messages.test.ts
@@ -33,8 +33,6 @@ function createMessageHandlers(overrides?: SlackSystemEventTestOverrides) {
   });
   return {
     handler: harness.getHandler("message") as MessageHandler | null,
-    channelHandler: harness.getHandler("message.channels") as MessageHandler | null,
-    groupHandler: harness.getHandler("message.groups") as MessageHandler | null,
     handleSlackMessage,
   };
 }
@@ -159,17 +157,17 @@ describe("registerSlackMessageEvents", () => {
     expect(messageQueueMock).not.toHaveBeenCalled();
   });
 
-  it("registers and forwards message.channels and message.groups events", async () => {
+  it("handles channel and group messages via the unified message handler", async () => {
     messageQueueMock.mockClear();
     messageAllowMock.mockReset().mockResolvedValue([]);
-    const { channelHandler, groupHandler, handleSlackMessage } = createMessageHandlers({
+    const { handler, handleSlackMessage } = createMessageHandlers({
       dmPolicy: "open",
       channelType: "channel",
     });
 
-    expect(channelHandler).toBeTruthy();
-    expect(groupHandler).toBeTruthy();
+    expect(handler).toBeTruthy();
 
+    // channel_type distinguishes the source; all arrive as event type "message"
     const channelMessage = {
       type: "message",
       channel: "C1",
@@ -178,8 +176,8 @@ describe("registerSlackMessageEvents", () => {
       text: "hello channel",
       ts: "123.100",
     };
-    await channelHandler!({ event: channelMessage, body: {} });
-    await groupHandler!({
+    await handler!({ event: channelMessage, body: {} });
+    await handler!({
       event: {
         ...channelMessage,
         channel_type: "group",
@@ -191,5 +189,29 @@ describe("registerSlackMessageEvents", () => {
 
     expect(handleSlackMessage).toHaveBeenCalledTimes(2);
     expect(messageQueueMock).not.toHaveBeenCalled();
+  });
+
+  it("applies subtype system-event handling for channel messages", async () => {
+    messageQueueMock.mockClear();
+    messageAllowMock.mockReset().mockResolvedValue([]);
+    const { handler, handleSlackMessage } = createMessageHandlers({
+      dmPolicy: "open",
+      channelType: "channel",
+    });
+
+    expect(handler).toBeTruthy();
+
+    // message_changed events from channels arrive via the generic "message"
+    // handler with channel_type:"channel" — not a separate event type.
+    await handler!({
+      event: {
+        ...makeChangedEvent({ channel: "C1", user: "U1" }),
+        channel_type: "channel",
+      },
+      body: {},
+    });
+
+    expect(handleSlackMessage).not.toHaveBeenCalled();
+    expect(messageQueueMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -97,23 +97,15 @@ export function registerSlackMessageEvents(params: {
     }
   };
 
+  // NOTE: Slack Event Subscriptions use names like "message.channels" and
+  // "message.groups" to control *which* message events are delivered, but the
+  // actual event payload always arrives with `type: "message"`.  The
+  // `channel_type` field ("channel" | "group" | "im" | "mpim") distinguishes
+  // the source.  Bolt rejects `app.event("message.channels")` since v4.6
+  // because it is a subscription label, not a valid event type.
   ctx.app.event("message", async ({ event, body }: SlackEventMiddlewareArgs<"message">) => {
     await handleIncomingMessageEvent({ event, body });
   });
-  // Slack may dispatch channel/group message subscriptions under typed event
-  // names. Register explicit handlers so both delivery styles are supported.
-  ctx.app.event(
-    "message.channels",
-    async ({ event, body }: SlackEventMiddlewareArgs<"message.channels">) => {
-      await handleIncomingMessageEvent({ event, body });
-    },
-  );
-  ctx.app.event(
-    "message.groups",
-    async ({ event, body }: SlackEventMiddlewareArgs<"message.groups">) => {
-      await handleIncomingMessageEvent({ event, body });
-    },
-  );
 
   ctx.app.event("app_mention", async ({ event, body }: SlackEventMiddlewareArgs<"app_mention">) => {
     try {


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #740
**Commits**: 5 cherry-picked (3 skipped: 1 changelog-only, 2 already applied/empty)

| Hash | Subject | Result |
|------|---------|--------|
| `d21cf4445` | fix(slack): remove message.channels/message.groups handlers that crash Bolt v4 | RESOLVED |
| `2a98fd3d0` | fix(slack): guard against undefined text in includes calls during mention handling | PICKED |
| `c146748d7` | fix: add changelog for mentions/slack null-safe guards | SKIPPED (changelog-only) |
| `d74bc257d` | fix(line): mark webhook route as plugin-authenticated | PICKED |
| `5c1eb071c` | fix(whatsapp): restore direct inbound metadata for relay agents | RESOLVED |
| `ffa7c13c9` | fix(voice-call): verify call status with provider before loading stale call state | SKIPPED (already applied) |
| `3bd050543` | Voice Call: enforce exact webhook path match | PICKED |
| `99392f986` | chore: keep #31930 scoped to voice webhook path fix | SKIPPED (empty after resolution) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)