### PR TITLE
Cherry-pick: UI config page fixes

### DIFF
--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -8,7 +8,7 @@
   grid-template-columns: 260px minmax(0, 1fr);
   gap: 0;
   height: calc(100vh - 160px);
-  margin: -12px -16px -32px;
+  margin: 0 -16px -32px; /* preserve margin-top: 0 for onboarding mode */
   border-radius: var(--radius-xl);
   border: 1px solid var(--border);
   background: var(--panel);

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -8,11 +8,11 @@
   grid-template-columns: 260px minmax(0, 1fr);
   gap: 0;
   height: calc(100vh - 160px);
-  margin: -16px;
-  margin-top: 0;
+  margin: -12px -16px -32px;
   border-radius: var(--radius-xl);
   border: 1px solid var(--border);
   background: var(--panel);
+  overflow: clip;
 }
 
 /* ===========================================
@@ -377,7 +377,7 @@
   min-height: 0;
   min-width: 0;
   background: var(--panel);
-  overflow: hidden;
+  overflow: clip;
 }
 
 /* Actions Bar */
@@ -389,6 +389,9 @@
   padding: 14px 22px;
   background: var(--bg-accent);
   border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  position: relative;
+  z-index: 2;
 }
 
 :root[data-theme="light"] .config-actions {

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -12,7 +12,22 @@
   border-radius: var(--radius-xl);
   border: 1px solid var(--border);
   background: var(--panel);
+  overflow: hidden; /* fallback for older browsers */
   overflow: clip;
+}
+
+/* Mobile: adjust margins to match mobile .content padding (4px 4px 16px) */
+@media (max-width: 600px) {
+  .config-layout {
+    margin: 0; /* safest: no negative margin cancellation on mobile */
+  }
+}
+
+/* Small mobile: even smaller padding */
+@media (max-width: 400px) {
+  .config-layout {
+    margin: 0;
+  }
 }
 
 /* ===========================================
@@ -377,6 +392,7 @@
   min-height: 0;
   min-width: 0;
   background: var(--panel);
+  overflow: hidden; /* fallback for older browsers */
   overflow: clip;
 }
 

--- a/ui/src/ui/config-form.browser.test.ts
+++ b/ui/src/ui/config-form.browser.test.ts
@@ -304,6 +304,83 @@ describe("config form renderer", () => {
     expect(noMatchContainer.textContent).toContain('No settings match "mode tag:security"');
   });
 
+  it("supports SecretInput unions in additionalProperties maps", () => {
+    const onPatch = vi.fn();
+    const container = document.createElement("div");
+    const schema = {
+      type: "object",
+      properties: {
+        models: {
+          type: "object",
+          properties: {
+            providers: {
+              type: "object",
+              additionalProperties: {
+                type: "object",
+                properties: {
+                  apiKey: {
+                    anyOf: [
+                      { type: "string" },
+                      {
+                        oneOf: [
+                          {
+                            type: "object",
+                            properties: {
+                              source: { type: "string", const: "env" },
+                              provider: { type: "string" },
+                              id: { type: "string" },
+                            },
+                            required: ["source", "provider", "id"],
+                            additionalProperties: false,
+                          },
+                          {
+                            type: "object",
+                            properties: {
+                              source: { type: "string", const: "file" },
+                              provider: { type: "string" },
+                              id: { type: "string" },
+                            },
+                            required: ["source", "provider", "id"],
+                            additionalProperties: false,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const analysis = analyzeConfigSchema(schema);
+    expect(analysis.unsupportedPaths).not.toContain("models.providers");
+    expect(analysis.unsupportedPaths).not.toContain("models.providers.*.apiKey");
+
+    render(
+      renderConfigForm({
+        schema: analysis.schema,
+        uiHints: {
+          "models.providers.*.apiKey": { sensitive: true },
+        },
+        unsupportedPaths: analysis.unsupportedPaths,
+        value: { models: { providers: { openai: { apiKey: "old" } } } },
+        onPatch,
+      }),
+      container,
+    );
+
+    const apiKeyInput: HTMLInputElement | null = container.querySelector("input[type='password']");
+    expect(apiKeyInput).not.toBeNull();
+    if (!apiKeyInput) {
+      return;
+    }
+    apiKeyInput.value = "new-key";
+    apiKeyInput.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenCalledWith(["models", "providers", "openai", "apiKey"], "new-key");
+  });
+
   it("flags unsupported unions", () => {
     const schema = {
       type: "object",

--- a/ui/src/ui/views/config-form.analyze.ts
+++ b/ui/src/ui/views/config-form.analyze.ts
@@ -118,6 +118,58 @@ function normalizeSchemaNode(
   };
 }
 
+function isSecretRefVariant(entry: JsonSchema): boolean {
+  if (schemaType(entry) !== "object") {
+    return false;
+  }
+  const source = entry.properties?.source;
+  const provider = entry.properties?.provider;
+  const id = entry.properties?.id;
+  if (!source || !provider || !id) {
+    return false;
+  }
+  return (
+    typeof source.const === "string" &&
+    schemaType(provider) === "string" &&
+    schemaType(id) === "string"
+  );
+}
+
+function isSecretRefUnion(entry: JsonSchema): boolean {
+  const variants = entry.oneOf ?? entry.anyOf;
+  if (!variants || variants.length === 0) {
+    return false;
+  }
+  return variants.every((variant) => isSecretRefVariant(variant));
+}
+
+function normalizeSecretInputUnion(
+  schema: JsonSchema,
+  path: Array<string | number>,
+  remaining: JsonSchema[],
+  nullable: boolean,
+): ConfigSchemaAnalysis | null {
+  const stringIndex = remaining.findIndex((entry) => schemaType(entry) === "string");
+  if (stringIndex < 0) {
+    return null;
+  }
+  const nonString = remaining.filter((_, index) => index !== stringIndex);
+  if (nonString.length !== 1 || !isSecretRefUnion(nonString[0])) {
+    return null;
+  }
+  return normalizeSchemaNode(
+    {
+      ...schema,
+      ...remaining[stringIndex],
+      nullable,
+      anyOf: undefined,
+      oneOf: undefined,
+      allOf: undefined,
+    },
+    path,
+  );
+}
+
 function normalizeUnion(
   schema: JsonSchema,
   path: Array<string | number>,
@@ -159,6 +211,13 @@ function normalizeUnion(
       continue;
     }
     remaining.push(entry);
+  }
+
+  // Config secrets accept either a raw key string or a structured secret ref object.
+  // The form only supports editing the string path for now.
+  const secretInput = normalizeSecretInputUnion(schema, path, remaining, nullable);
+  if (secretInput) {
+    return secretInput;
   }
 
   if (literals.length > 0 && remaining.length === 0) {


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #741
**Commits**: 4 cherry-picked

| Hash | Subject | Result |
|------|---------|--------|
| `20c36f7e8` | fix(ui): prevent config page save button from being clipped by overflow | PICKED |
| `24a13c05b` | fix(ui): add mobile responsive margins and overflow fallback | PICKED |
| `eb2e20c99` | fix(ui): preserve margin-top: 0 for onboarding mode | PICKED |
| `9c1312b5e` | fix(ui): handle SecretInput union in config form analyzer | PICKED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)