### PR TITLE
Cherry-pick batch: Synology Chat adapter fixes

### DIFF
--- a/extensions/synology-chat/src/channel.integration.test.ts
+++ b/extensions/synology-chat/src/channel.integration.test.ts
@@ -44,7 +44,6 @@ vi.mock("./client.js", () => ({
 }));
 
 const { createSynologyChatPlugin } = await import("./channel.js");
-
 describe("Synology channel wiring integration", () => {
   beforeEach(() => {
     registerPluginHttpRouteMock.mockClear();
@@ -53,6 +52,7 @@ describe("Synology channel wiring integration", () => {
 
   it("registers real webhook handler with resolved account config and enforces allowlist", async () => {
     const plugin = createSynologyChatPlugin();
+    const abortController = new AbortController();
     const ctx = {
       cfg: {
         channels: {
@@ -73,9 +73,10 @@ describe("Synology channel wiring integration", () => {
       },
       accountId: "alerts",
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      abortSignal: abortController.signal,
     };
 
-    const started = await plugin.gateway.startAccount(ctx);
+    const started = plugin.gateway.startAccount(ctx);
     expect(registerPluginHttpRouteMock).toHaveBeenCalledTimes(1);
 
     const firstCall = registerPluginHttpRouteMock.mock.calls[0];
@@ -101,9 +102,7 @@ describe("Synology channel wiring integration", () => {
     expect(res._status).toBe(403);
     expect(res._body).toContain("not authorized");
     expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
-
-    if (started && typeof started === "object" && "stop" in started) {
-      (started as { stop: () => void }).stop();
-    }
+    abortController.abort();
+    await started;
   });
 });

--- a/extensions/synology-chat/src/channel.integration.test.ts
+++ b/extensions/synology-chat/src/channel.integration.test.ts
@@ -102,6 +102,8 @@ describe("Synology channel wiring integration", () => {
     expect(res._body).toContain("not authorized");
     expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
 
-    started.stop();
+    if (started && typeof started === "object" && "stop" in started) {
+      (started as { stop: () => void }).stop();
+    }
   });
 });

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -317,35 +317,56 @@ describe("createSynologyChatPlugin", () => {
   });
 
   describe("gateway", () => {
-    it("startAccount returns stop function for disabled account", async () => {
+    it("startAccount returns pending promise for disabled account", async () => {
       const plugin = createSynologyChatPlugin();
+      const abortController = new AbortController();
       const ctx = {
         cfg: {
           channels: { "synology-chat": { enabled: false } },
         },
         accountId: "default",
         log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        abortSignal: abortController.signal,
       };
-      const result = await plugin.gateway.startAccount(ctx);
-      expect(typeof result.stop).toBe("function");
+      const result = plugin.gateway.startAccount(ctx);
+      expect(result).toBeInstanceOf(Promise);
+      // Promise should stay pending (never resolve) to prevent restart loop
+      const resolved = await Promise.race([
+        result,
+        new Promise((r) => setTimeout(() => r("pending"), 50)),
+      ]);
+      expect(resolved).toBe("pending");
+      abortController.abort();
+      await result;
     });
 
-    it("startAccount returns stop function for account without token", async () => {
+    it("startAccount returns pending promise for account without token", async () => {
       const plugin = createSynologyChatPlugin();
+      const abortController = new AbortController();
       const ctx = {
         cfg: {
           channels: { "synology-chat": { enabled: true } },
         },
         accountId: "default",
         log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        abortSignal: abortController.signal,
       };
-      const result = await plugin.gateway.startAccount(ctx);
-      expect(typeof result.stop).toBe("function");
+      const result = plugin.gateway.startAccount(ctx);
+      expect(result).toBeInstanceOf(Promise);
+      // Promise should stay pending (never resolve) to prevent restart loop
+      const resolved = await Promise.race([
+        result,
+        new Promise((r) => setTimeout(() => r("pending"), 50)),
+      ]);
+      expect(resolved).toBe("pending");
+      abortController.abort();
+      await result;
     });
 
     it("startAccount refuses allowlist accounts with empty allowedUserIds", async () => {
       const registerMock = vi.mocked(registerPluginHttpRoute);
       registerMock.mockClear();
+      const abortController = new AbortController();
 
       const plugin = createSynologyChatPlugin();
       const ctx = {
@@ -362,12 +383,20 @@ describe("createSynologyChatPlugin", () => {
         },
         accountId: "default",
         log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        abortSignal: abortController.signal,
       };
 
-      const result = await plugin.gateway.startAccount(ctx);
-      expect(typeof result.stop).toBe("function");
+      const result = plugin.gateway.startAccount(ctx);
+      expect(result).toBeInstanceOf(Promise);
+      const resolved = await Promise.race([
+        result,
+        new Promise((r) => setTimeout(() => r("pending"), 50)),
+      ]);
+      expect(resolved).toBe("pending");
       expect(ctx.log.warn).toHaveBeenCalledWith(expect.stringContaining("empty allowedUserIds"));
       expect(registerMock).not.toHaveBeenCalled();
+      abortController.abort();
+      await result;
     });
 
     it("deregisters stale route before re-registering same account/path", async () => {
@@ -377,7 +406,9 @@ describe("createSynologyChatPlugin", () => {
       registerMock.mockReturnValueOnce(unregisterFirst).mockReturnValueOnce(unregisterSecond);
 
       const plugin = createSynologyChatPlugin();
-      const ctx = {
+      const abortFirst = new AbortController();
+      const abortSecond = new AbortController();
+      const makeCtx = (abortCtrl: AbortController) => ({
         cfg: {
           channels: {
             "synology-chat": {
@@ -392,18 +423,25 @@ describe("createSynologyChatPlugin", () => {
         },
         accountId: "default",
         log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      };
+        abortSignal: abortCtrl.signal,
+      });
 
-      const first = await plugin.gateway.startAccount(ctx);
-      const second = await plugin.gateway.startAccount(ctx);
+      // Start first account (returns a pending promise)
+      const firstPromise = plugin.gateway.startAccount(makeCtx(abortFirst));
+      // Start second account on same path — should deregister the first route
+      const secondPromise = plugin.gateway.startAccount(makeCtx(abortSecond));
+
+      // Give microtasks time to settle
+      await new Promise((r) => setTimeout(r, 10));
 
       expect(registerMock).toHaveBeenCalledTimes(2);
       expect(unregisterFirst).toHaveBeenCalledTimes(1);
       expect(unregisterSecond).not.toHaveBeenCalled();
 
-      // Clean up active route map so this module-level state doesn't leak across tests.
-      first.stop();
-      second.stop();
+      // Clean up: abort both to resolve promises and prevent test leak
+      abortFirst.abort();
+      abortSecond.abort();
+      await Promise.allSettled([firstPromise, secondPromise]);
     });
   });
 });

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -268,18 +268,10 @@ describe("createSynologyChatPlugin", () => {
       const plugin = createSynologyChatPlugin();
       await expect(
         plugin.outbound.sendText({
-          account: {
-            accountId: "default",
-            enabled: true,
-            token: "t",
-            incomingUrl: "",
-            nasHost: "h",
-            webhookPath: "/w",
-            dmPolicy: "open",
-            allowedUserIds: [],
-            rateLimitPerMinute: 30,
-            botName: "Bot",
-            allowInsecureSsl: true,
+          cfg: {
+            channels: {
+              "synology-chat": { enabled: true, token: "t", incomingUrl: "" },
+            },
           },
           text: "hello",
           to: "user1",
@@ -290,18 +282,15 @@ describe("createSynologyChatPlugin", () => {
     it("sendText returns OutboundDeliveryResult on success", async () => {
       const plugin = createSynologyChatPlugin();
       const result = await plugin.outbound.sendText({
-        account: {
-          accountId: "default",
-          enabled: true,
-          token: "t",
-          incomingUrl: "https://nas/incoming",
-          nasHost: "h",
-          webhookPath: "/w",
-          dmPolicy: "open",
-          allowedUserIds: [],
-          rateLimitPerMinute: 30,
-          botName: "Bot",
-          allowInsecureSsl: true,
+        cfg: {
+          channels: {
+            "synology-chat": {
+              enabled: true,
+              token: "t",
+              incomingUrl: "https://nas/incoming",
+              allowInsecureSsl: true,
+            },
+          },
         },
         text: "hello",
         to: "user1",
@@ -315,18 +304,10 @@ describe("createSynologyChatPlugin", () => {
       const plugin = createSynologyChatPlugin();
       await expect(
         plugin.outbound.sendMedia({
-          account: {
-            accountId: "default",
-            enabled: true,
-            token: "t",
-            incomingUrl: "",
-            nasHost: "h",
-            webhookPath: "/w",
-            dmPolicy: "open",
-            allowedUserIds: [],
-            rateLimitPerMinute: 30,
-            botName: "Bot",
-            allowInsecureSsl: true,
+          cfg: {
+            channels: {
+              "synology-chat": { enabled: true, token: "t", incomingUrl: "" },
+            },
           },
           mediaUrl: "https://example.com/img.png",
           to: "user1",

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -178,8 +178,8 @@ export function createSynologyChatPlugin() {
       deliveryMode: "gateway" as const,
       textChunkLimit: 2000,
 
-      sendText: async ({ to, text, accountId, account: ctxAccount }: any) => {
-        const account: ResolvedSynologyChatAccount = ctxAccount ?? resolveAccount({}, accountId);
+      sendText: async ({ to, text, accountId, cfg }: any) => {
+        const account: ResolvedSynologyChatAccount = resolveAccount(cfg ?? {}, accountId);
 
         if (!account.incomingUrl) {
           throw new Error("Synology Chat incoming URL not configured");
@@ -192,8 +192,8 @@ export function createSynologyChatPlugin() {
         return { channel: CHANNEL_ID, messageId: `sc-${Date.now()}`, chatId: to };
       },
 
-      sendMedia: async ({ to, mediaUrl, accountId, account: ctxAccount }: any) => {
-        const account: ResolvedSynologyChatAccount = ctxAccount ?? resolveAccount({}, accountId);
+      sendMedia: async ({ to, mediaUrl, accountId, cfg }: any) => {
+        const account: ResolvedSynologyChatAccount = resolveAccount(cfg ?? {}, accountId);
 
         if (!account.incomingUrl) {
           throw new Error("Synology Chat incoming URL not configured");

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -246,14 +246,22 @@ export function createSynologyChatPlugin() {
             // Build MsgContext (same format as LINE/Signal/etc.)
             const msgCtx = {
               Body: msg.body,
-              From: msg.from,
-              To: account.botName,
+              RawBody: msg.body,
+              CommandBody: msg.body,
+              From: `synology-chat:${msg.from}`,
+              To: `synology-chat:${msg.from}`,
               SessionKey: msg.sessionKey,
               AccountId: account.accountId,
               OriginatingChannel: CHANNEL_ID as any,
               OriginatingTo: msg.from,
               ChatType: msg.chatType,
               SenderName: msg.senderName,
+              SenderId: msg.from,
+              Provider: CHANNEL_ID,
+              Surface: CHANNEL_ID,
+              ConversationLabel: msg.senderName || msg.from,
+              Timestamp: Date.now(),
+              CommandAuthorized: true,
             };
 
             // Dispatch via the SDK's buffered block dispatcher

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -243,8 +243,8 @@ export function createSynologyChatPlugin() {
             const rt = getSynologyRuntime();
             const currentCfg = await rt.config.loadConfig();
 
-            // Build MsgContext (same format as LINE/Signal/etc.)
-            const msgCtx = {
+            // Build MsgContext using SDK's finalizeInboundContext for proper normalization
+            const msgCtx = rt.channel.reply.finalizeInboundContext({
               Body: msg.body,
               RawBody: msg.body,
               CommandBody: msg.body,
@@ -252,8 +252,8 @@ export function createSynologyChatPlugin() {
               To: `synology-chat:${msg.from}`,
               SessionKey: msg.sessionKey,
               AccountId: account.accountId,
-              OriginatingChannel: CHANNEL_ID as any,
-              OriginatingTo: msg.from,
+              OriginatingChannel: CHANNEL_ID,
+              OriginatingTo: `synology-chat:${msg.from}`,
               ChatType: msg.chatType,
               SenderName: msg.senderName,
               SenderId: msg.from,
@@ -262,7 +262,7 @@ export function createSynologyChatPlugin() {
               ConversationLabel: msg.senderName || msg.from,
               Timestamp: Date.now(),
               CommandAuthorized: true,
-            };
+            });
 
             // Dispatch via the SDK's buffered block dispatcher
             await rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher({

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -243,6 +243,10 @@ export function createSynologyChatPlugin() {
             const rt = getSynologyRuntime();
             const currentCfg = await rt.config.loadConfig();
 
+            // The Chat API user_id (for sending) may differ from the webhook
+            // user_id (used for sessions/pairing). Use chatUserId for API calls.
+            const sendUserId = msg.chatUserId ?? msg.from;
+
             // Build MsgContext using SDK's finalizeInboundContext for proper normalization
             const msgCtx = rt.channel.reply.finalizeInboundContext({
               Body: msg.body,
@@ -275,7 +279,7 @@ export function createSynologyChatPlugin() {
                     await sendMessage(
                       account.incomingUrl,
                       text,
-                      msg.from,
+                      sendUserId,
                       account.allowInsecureSsl,
                     );
                   }

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -22,6 +22,23 @@ const SynologyChatConfigSchema = buildChannelConfigSchema(z.object({}).passthrou
 
 const activeRouteUnregisters = new Map<string, () => void>();
 
+function waitUntilAbort(signal?: AbortSignal, onAbort?: () => void): Promise<void> {
+  return new Promise((resolve) => {
+    const complete = () => {
+      onAbort?.();
+      resolve();
+    };
+    if (!signal) {
+      return;
+    }
+    if (signal.aborted) {
+      complete();
+      return;
+    }
+    signal.addEventListener("abort", complete, { once: true });
+  });
+}
+
 export function createSynologyChatPlugin() {
   return {
     id: CHANNEL_ID,
@@ -217,20 +234,20 @@ export function createSynologyChatPlugin() {
 
         if (!account.enabled) {
           log?.info?.(`Synology Chat account ${accountId} is disabled, skipping`);
-          return { stop: () => {} };
+          return waitUntilAbort(ctx.abortSignal);
         }
 
         if (!account.token || !account.incomingUrl) {
           log?.warn?.(
             `Synology Chat account ${accountId} not fully configured (missing token or incomingUrl)`,
           );
-          return { stop: () => {} };
+          return waitUntilAbort(ctx.abortSignal);
         }
         if (account.dmPolicy === "allowlist" && account.allowedUserIds.length === 0) {
           log?.warn?.(
             `Synology Chat account ${accountId} has dmPolicy=allowlist but empty allowedUserIds; refusing to start route`,
           );
-          return { stop: () => {} };
+          return waitUntilAbort(ctx.abortSignal);
         }
 
         log?.info?.(
@@ -317,13 +334,14 @@ export function createSynologyChatPlugin() {
 
         log?.info?.(`Registered HTTP route: ${account.webhookPath} for Synology Chat`);
 
-        return {
-          stop: () => {
-            log?.info?.(`Stopping Synology Chat channel (account: ${accountId})`);
-            if (typeof unregister === "function") unregister();
-            activeRouteUnregisters.delete(routeKey);
-          },
-        };
+        // Keep alive until abort signal fires.
+        // The gateway expects a Promise that stays pending while the channel is running.
+        // Resolving immediately triggers a restart loop.
+        return waitUntilAbort(ctx.abortSignal, () => {
+          log?.info?.(`Stopping Synology Chat channel (account: ${accountId})`);
+          if (typeof unregister === "function") unregister();
+          activeRouteUnregisters.delete(routeKey);
+        });
       },
 
       stopAccount: async (ctx: any) => {

--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -4,16 +4,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // Mock http and https modules before importing the client
 vi.mock("node:https", () => {
   const mockRequest = vi.fn();
-  return { default: { request: mockRequest }, request: mockRequest };
+  const mockGet = vi.fn();
+  return { default: { request: mockRequest, get: mockGet }, request: mockRequest, get: mockGet };
 });
 
 vi.mock("node:http", () => {
   const mockRequest = vi.fn();
-  return { default: { request: mockRequest }, request: mockRequest };
+  const mockGet = vi.fn();
+  return { default: { request: mockRequest, get: mockGet }, request: mockRequest, get: mockGet };
 });
 
 // Import after mocks are set up
-const { sendMessage, sendFileUrl } = await import("./client.js");
+const { sendMessage, sendFileUrl, fetchChatUsers, resolveChatUserId } = await import("./client.js");
 const https = await import("node:https");
 let fakeNowMs = 1_700_000_000_000;
 
@@ -109,5 +111,124 @@ describe("sendFileUrl", () => {
       sendFileUrl("https://nas.example.com/incoming", "https://example.com/file.png"),
     );
     expect(result).toBe(false);
+  });
+});
+
+// Helper to mock the user_list API response for fetchChatUsers / resolveChatUserId
+function mockUserListResponse(
+  users: Array<{ user_id: number; username: string; nickname: string }>,
+) {
+  const httpsGet = vi.mocked((https as any).get);
+  httpsGet.mockImplementation((_url: any, _opts: any, callback: any) => {
+    const res = new EventEmitter() as any;
+    res.statusCode = 200;
+    process.nextTick(() => {
+      callback(res);
+      res.emit("data", Buffer.from(JSON.stringify({ success: true, data: { users } })));
+      res.emit("end");
+    });
+    const req = new EventEmitter() as any;
+    req.destroy = vi.fn();
+    return req;
+  });
+}
+
+function mockUserListResponseOnce(
+  users: Array<{ user_id: number; username: string; nickname: string }>,
+) {
+  const httpsGet = vi.mocked((https as any).get);
+  httpsGet.mockImplementationOnce((_url: any, _opts: any, callback: any) => {
+    const res = new EventEmitter() as any;
+    res.statusCode = 200;
+    process.nextTick(() => {
+      callback(res);
+      res.emit("data", Buffer.from(JSON.stringify({ success: true, data: { users } })));
+      res.emit("end");
+    });
+    const req = new EventEmitter() as any;
+    req.destroy = vi.fn();
+    return req;
+  });
+}
+
+describe("resolveChatUserId", () => {
+  const baseUrl =
+    "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=chatbot&version=2&token=%22test%22";
+  const baseUrl2 =
+    "https://nas2.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=chatbot&version=2&token=%22test-2%22";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    // Advance time to invalidate any cached user list from previous tests
+    fakeNowMs += 10 * 60 * 1000;
+    vi.setSystemTime(fakeNowMs);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves user by nickname (webhook username = Chat nickname)", async () => {
+    mockUserListResponse([
+      { user_id: 4, username: "jmn67", nickname: "jmn" },
+      { user_id: 7, username: "she67", nickname: "sarah" },
+    ]);
+    const result = await resolveChatUserId(baseUrl, "jmn");
+    expect(result).toBe(4);
+  });
+
+  it("resolves user by username when nickname does not match", async () => {
+    mockUserListResponse([
+      { user_id: 4, username: "jmn67", nickname: "" },
+      { user_id: 7, username: "she67", nickname: "sarah" },
+    ]);
+    // Advance time to invalidate cache
+    fakeNowMs += 10 * 60 * 1000;
+    vi.setSystemTime(fakeNowMs);
+    const result = await resolveChatUserId(baseUrl, "jmn67");
+    expect(result).toBe(4);
+  });
+
+  it("is case-insensitive", async () => {
+    mockUserListResponse([{ user_id: 4, username: "JMN67", nickname: "JMN" }]);
+    fakeNowMs += 10 * 60 * 1000;
+    vi.setSystemTime(fakeNowMs);
+    const result = await resolveChatUserId(baseUrl, "jmn");
+    expect(result).toBe(4);
+  });
+
+  it("returns undefined when user is not found", async () => {
+    mockUserListResponse([{ user_id: 4, username: "jmn67", nickname: "jmn" }]);
+    fakeNowMs += 10 * 60 * 1000;
+    vi.setSystemTime(fakeNowMs);
+    const result = await resolveChatUserId(baseUrl, "unknown_user");
+    expect(result).toBeUndefined();
+  });
+
+  it("uses method=user_list instead of method=chatbot in the API URL", async () => {
+    mockUserListResponse([]);
+    fakeNowMs += 10 * 60 * 1000;
+    vi.setSystemTime(fakeNowMs);
+    await resolveChatUserId(baseUrl, "anyone");
+    const httpsGet = vi.mocked((https as any).get);
+    expect(httpsGet).toHaveBeenCalledWith(
+      expect.stringContaining("method=user_list"),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("keeps user cache scoped per incoming URL", async () => {
+    mockUserListResponseOnce([{ user_id: 4, username: "jmn67", nickname: "jmn" }]);
+    mockUserListResponseOnce([{ user_id: 9, username: "jmn67", nickname: "jmn" }]);
+
+    const result1 = await resolveChatUserId(baseUrl, "jmn");
+    const result2 = await resolveChatUserId(baseUrl2, "jmn");
+
+    expect(result1).toBe(4);
+    expect(result2).toBe(9);
+    const httpsGet = vi.mocked((https as any).get);
+    expect(httpsGet).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -9,6 +9,28 @@ import * as https from "node:https";
 const MIN_SEND_INTERVAL_MS = 500;
 let lastSendTime = 0;
 
+// --- Chat user_id resolution ---
+// Synology Chat uses two different user_id spaces:
+//   - Outgoing webhook user_id: per-integration sequential ID (e.g. 1)
+//   - Chat API user_id: global internal ID (e.g. 4)
+// The chatbot API (method=chatbot) requires the Chat API user_id in the
+// user_ids array. We resolve via the user_list API and cache the result.
+
+interface ChatUser {
+  user_id: number;
+  username: string;
+  nickname: string;
+}
+
+type ChatUserCacheEntry = {
+  users: ChatUser[];
+  cachedAt: number;
+};
+
+// Cache user lists per bot endpoint to avoid cross-account bleed.
+const chatUserCache = new Map<string, ChatUserCacheEntry>();
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
 /**
  * Send a text message to Synology Chat via the incoming webhook.
  *
@@ -90,6 +112,107 @@ export async function sendFileUrl(
   } catch {
     return false;
   }
+}
+
+/**
+ * Fetch the list of Chat users visible to this bot via the user_list API.
+ * Results are cached for CACHE_TTL_MS to avoid excessive API calls.
+ *
+ * The user_list endpoint uses the same base URL as the chatbot API but
+ * with method=user_list instead of method=chatbot.
+ */
+export async function fetchChatUsers(
+  incomingUrl: string,
+  allowInsecureSsl = true,
+  log?: { warn: (...args: unknown[]) => void },
+): Promise<ChatUser[]> {
+  const now = Date.now();
+  const listUrl = incomingUrl.replace(/method=\w+/, "method=user_list");
+  const cached = chatUserCache.get(listUrl);
+  if (cached && now - cached.cachedAt < CACHE_TTL_MS) {
+    return cached.users;
+  }
+
+  return new Promise((resolve) => {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(listUrl);
+    } catch {
+      log?.warn("fetchChatUsers: invalid user_list URL, using cached data");
+      resolve(cached?.users ?? []);
+      return;
+    }
+    const transport = parsedUrl.protocol === "https:" ? https : http;
+
+    transport
+      .get(listUrl, { rejectUnauthorized: !allowInsecureSsl } as any, (res) => {
+        let data = "";
+        res.on("data", (c: Buffer) => {
+          data += c.toString();
+        });
+        res.on("end", () => {
+          try {
+            const result = JSON.parse(data);
+            if (result.success && result.data?.users) {
+              const users = result.data.users.map((u: any) => ({
+                user_id: u.user_id,
+                username: u.username || "",
+                nickname: u.nickname || "",
+              }));
+              chatUserCache.set(listUrl, {
+                users,
+                cachedAt: now,
+              });
+              resolve(users);
+            } else {
+              log?.warn(
+                `fetchChatUsers: API returned success=${result.success}, using cached data`,
+              );
+              resolve(cached?.users ?? []);
+            }
+          } catch {
+            log?.warn("fetchChatUsers: failed to parse user_list response");
+            resolve(cached?.users ?? []);
+          }
+        });
+      })
+      .on("error", (err) => {
+        log?.warn(`fetchChatUsers: HTTP error — ${err instanceof Error ? err.message : err}`);
+        resolve(cached?.users ?? []);
+      });
+  });
+}
+
+/**
+ * Resolve a webhook username to the correct Chat API user_id.
+ *
+ * Synology Chat outgoing webhooks send a user_id that may NOT match the
+ * Chat-internal user_id needed by the chatbot API (method=chatbot).
+ * The webhook's "username" field corresponds to the Chat user's "nickname".
+ *
+ * @param incomingUrl - Bot incoming webhook URL (used to derive user_list URL)
+ * @param webhookUsername - The username from the outgoing webhook payload
+ * @param allowInsecureSsl - Skip TLS verification
+ * @returns The correct Chat user_id, or undefined if not found
+ */
+export async function resolveChatUserId(
+  incomingUrl: string,
+  webhookUsername: string,
+  allowInsecureSsl = true,
+  log?: { warn: (...args: unknown[]) => void },
+): Promise<number | undefined> {
+  const users = await fetchChatUsers(incomingUrl, allowInsecureSsl, log);
+  const lower = webhookUsername.toLowerCase();
+
+  // Match by nickname first (webhook "username" field = Chat "nickname")
+  const byNickname = users.find((u) => u.nickname.toLowerCase() === lower);
+  if (byNickname) return byNickname.user_id;
+
+  // Then by username
+  const byUsername = users.find((u) => u.username.toLowerCase() === lower);
+  if (byUsername) return byUsername.user_id;
+
+  return undefined;
 }
 
 function doPost(url: string, body: string, allowInsecureSsl = true): Promise<boolean> {

--- a/extensions/synology-chat/src/test-http-utils.ts
+++ b/extensions/synology-chat/src/test-http-utils.ts
@@ -2,10 +2,22 @@ import { EventEmitter } from "node:events";
 import type { IncomingMessage, ServerResponse } from "node:http";
 
 export function makeReq(method: string, body: string): IncomingMessage {
-  const req = new EventEmitter() as IncomingMessage;
+  const req = new EventEmitter() as IncomingMessage & { destroyed: boolean };
   req.method = method;
+  req.headers = {};
   req.socket = { remoteAddress: "127.0.0.1" } as unknown as IncomingMessage["socket"];
+  req.destroyed = false;
+  req.destroy = ((_: Error | undefined) => {
+    if (req.destroyed) {
+      return req;
+    }
+    req.destroyed = true;
+    return req;
+  }) as IncomingMessage["destroy"];
   process.nextTick(() => {
+    if (req.destroyed) {
+      return;
+    }
     req.emit("data", Buffer.from(body));
     req.emit("end");
   });

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -32,21 +32,48 @@ function makeAccount(
   };
 }
 
-function makeStalledReq(method: string): IncomingMessage {
+function makeReq(method: string, body: string): IncomingMessage {
   const req = new EventEmitter() as IncomingMessage & {
     destroyed: boolean;
-    destroy: () => void;
   };
   req.method = method;
   req.headers = {};
   req.socket = { remoteAddress: "127.0.0.1" } as any;
   req.destroyed = false;
-  req.destroy = () => {
+  req.destroy = ((_: Error | undefined) => {
+    if (req.destroyed) {
+      return req;
+    }
+    req.destroyed = true;
+    return req;
+  }) as IncomingMessage["destroy"];
+
+  // Simulate body delivery
+  process.nextTick(() => {
     if (req.destroyed) {
       return;
     }
-    req.destroyed = true;
+    req.emit("data", Buffer.from(body));
+    req.emit("end");
+  });
+
+  return req;
+}
+function makeStalledReq(method: string): IncomingMessage {
+  const req = new EventEmitter() as IncomingMessage & {
+    destroyed: boolean;
   };
+  req.method = method;
+  req.headers = {};
+  req.socket = { remoteAddress: "127.0.0.1" } as any;
+  req.destroyed = false;
+  req.destroy = ((_: Error | undefined) => {
+    if (req.destroyed) {
+      return req;
+    }
+    req.destroyed = true;
+    return req;
+  }) as IncomingMessage["destroy"];
   return req;
 }
 

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage } from "node:http";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { makeFormBody, makeReq, makeRes } from "./test-http-utils.js";
 import type { ResolvedSynologyChatAccount } from "./types.js";
@@ -28,6 +30,24 @@ function makeAccount(
     allowInsecureSsl: true,
     ...overrides,
   };
+}
+
+function makeStalledReq(method: string): IncomingMessage {
+  const req = new EventEmitter() as IncomingMessage & {
+    destroyed: boolean;
+    destroy: () => void;
+  };
+  req.method = method;
+  req.headers = {};
+  req.socket = { remoteAddress: "127.0.0.1" } as any;
+  req.destroyed = false;
+  req.destroy = () => {
+    if (req.destroyed) {
+      return;
+    }
+    req.destroyed = true;
+  };
+  return req;
 }
 
 const validBody = makeFormBody({
@@ -93,6 +113,29 @@ describe("createWebhookHandler", () => {
     await handler(req, res);
 
     expect(res._status).toBe(400);
+  });
+
+  it("returns 408 when request body times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = createWebhookHandler({
+        account: makeAccount(),
+        deliver: vi.fn(),
+        log,
+      });
+
+      const req = makeStalledReq("POST");
+      const res = makeRes();
+      const run = handler(req, res);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      await run;
+
+      expect(res._status).toBe(408);
+      expect(res._body).toContain("timeout");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns 401 for invalid token", async () => {

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -1,7 +1,6 @@
 import { EventEmitter } from "node:events";
-import type { IncomingMessage } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { makeFormBody, makeReq, makeRes } from "./test-http-utils.js";
 import type { ResolvedSynologyChatAccount } from "./types.js";
 import {
   clearSynologyWebhookRateLimiterStateForTest,
@@ -32,12 +31,17 @@ function makeAccount(
   };
 }
 
-function makeReq(method: string, body: string): IncomingMessage {
+function makeReq(
+  method: string,
+  body: string,
+  opts: { headers?: Record<string, string>; url?: string } = {},
+): IncomingMessage {
   const req = new EventEmitter() as IncomingMessage & {
     destroyed: boolean;
   };
   req.method = method;
-  req.headers = {};
+  req.headers = opts.headers ?? {};
+  req.url = opts.url ?? "/webhook/synology";
   req.socket = { remoteAddress: "127.0.0.1" } as any;
   req.destroyed = false;
   req.destroy = ((_: Error | undefined) => {
@@ -75,6 +79,26 @@ function makeStalledReq(method: string): IncomingMessage {
     return req;
   }) as IncomingMessage["destroy"];
   return req;
+}
+
+function makeRes(): ServerResponse & { _status: number; _body: string } {
+  const res = {
+    _status: 0,
+    _body: "",
+    writeHead(statusCode: number, _headers?: Record<string, string>) {
+      res._status = statusCode;
+    },
+    end(body?: string) {
+      res._body = body ?? "";
+    },
+  } as any;
+  return res;
+}
+
+function makeFormBody(fields: Record<string, string>): string {
+  return Object.entries(fields)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join("&");
 }
 
 const validBody = makeFormBody({
@@ -185,6 +209,85 @@ describe("createWebhookHandler", () => {
     expect(res._status).toBe(401);
   });
 
+  it("accepts application/json with alias fields", async () => {
+    const deliver = vi.fn().mockResolvedValue(null);
+    const handler = createWebhookHandler({
+      account: makeAccount({ accountId: "json-test-" + Date.now() }),
+      deliver,
+      log,
+    });
+
+    const req = makeReq(
+      "POST",
+      JSON.stringify({
+        token: "valid-token",
+        userId: "123",
+        name: "json-user",
+        message: "Hello from json",
+      }),
+      { headers: { "content-type": "application/json" } },
+    );
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(204);
+    expect(deliver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: "Hello from json",
+        from: "123",
+        senderName: "json-user",
+      }),
+    );
+  });
+
+  it("accepts token from query when body token is absent", async () => {
+    const deliver = vi.fn().mockResolvedValue(null);
+    const handler = createWebhookHandler({
+      account: makeAccount({ accountId: "query-token-test-" + Date.now() }),
+      deliver,
+      log,
+    });
+
+    const req = makeReq(
+      "POST",
+      makeFormBody({ user_id: "123", username: "testuser", text: "hello" }),
+      {
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        url: "/webhook/synology?token=valid-token",
+      },
+    );
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(204);
+    expect(deliver).toHaveBeenCalled();
+  });
+
+  it("accepts token from authorization header when body token is absent", async () => {
+    const deliver = vi.fn().mockResolvedValue(null);
+    const handler = createWebhookHandler({
+      account: makeAccount({ accountId: "header-token-test-" + Date.now() }),
+      deliver,
+      log,
+    });
+
+    const req = makeReq(
+      "POST",
+      makeFormBody({ user_id: "123", username: "testuser", text: "hello" }),
+      {
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          authorization: "Bearer valid-token",
+        },
+      },
+    );
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(204);
+    expect(deliver).toHaveBeenCalled();
+  });
+
   it("returns 403 for unauthorized user with allowlist policy", async () => {
     await expectForbiddenByPolicy({
       account: {
@@ -237,7 +340,7 @@ describe("createWebhookHandler", () => {
     const req1 = makeReq("POST", validBody);
     const res1 = makeRes();
     await handler(req1, res1);
-    expect(res1._status).toBe(200);
+    expect(res1._status).toBe(204);
 
     // Second request should be rate limited
     const req2 = makeReq("POST", validBody);
@@ -266,12 +369,12 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(200);
+    expect(res._status).toBe(204);
     // deliver should have been called with the stripped text
     expect(deliver).toHaveBeenCalledWith(expect.objectContaining({ body: "Hello there" }));
   });
 
-  it("responds 200 immediately and delivers async", async () => {
+  it("responds 204 immediately and delivers async", async () => {
     const deliver = vi.fn().mockResolvedValue("Bot reply");
     const handler = createWebhookHandler({
       account: makeAccount({ accountId: "async-test-" + Date.now() }),
@@ -283,8 +386,8 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(200);
-    expect(res._body).toContain("Processing");
+    expect(res._status).toBe(204);
+    expect(res._body).toBe("");
     expect(deliver).toHaveBeenCalledWith(
       expect.objectContaining({
         body: "Hello bot",

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -7,9 +7,10 @@ import {
   createWebhookHandler,
 } from "./webhook-handler.js";
 
-// Mock sendMessage to prevent real HTTP calls
+// Mock sendMessage and resolveChatUserId to prevent real HTTP calls
 vi.mock("./client.js", () => ({
   sendMessage: vi.fn().mockResolvedValue(true),
+  resolveChatUserId: vi.fn().mockResolvedValue(undefined),
 }));
 
 function makeAccount(

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -1,6 +1,6 @@
 /**
  * Inbound webhook handler for Synology Chat outgoing webhooks.
- * Parses form-urlencoded body, validates security, delivers to agent.
+ * Parses form-urlencoded/JSON body, validates security, delivers to agent.
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
@@ -69,34 +69,150 @@ async function readBody(req: IncomingMessage): Promise<
   }
 }
 
-/** Parse form-urlencoded body into SynologyWebhookPayload. */
-function parsePayload(body: string): SynologyWebhookPayload | null {
-  const parsed = querystring.parse(body);
+function firstNonEmptyString(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const normalized = firstNonEmptyString(item);
+      if (normalized) return normalized;
+    }
+    return undefined;
+  }
+  if (value === null || value === undefined) return undefined;
+  const str = String(value).trim();
+  return str.length > 0 ? str : undefined;
+}
 
-  const token = String(parsed.token ?? "");
-  const userId = String(parsed.user_id ?? "");
-  const username = String(parsed.username ?? "unknown");
-  const text = String(parsed.text ?? "");
+function pickAlias(record: Record<string, unknown>, aliases: string[]): string | undefined {
+  for (const alias of aliases) {
+    const normalized = firstNonEmptyString(record[alias]);
+    if (normalized) return normalized;
+  }
+  return undefined;
+}
+
+function parseQueryParams(req: IncomingMessage): Record<string, unknown> {
+  try {
+    const url = new URL(req.url ?? "", "http://localhost");
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of url.searchParams.entries()) {
+      out[key] = value;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function parseFormBody(body: string): Record<string, unknown> {
+  return querystring.parse(body) as Record<string, unknown>;
+}
+
+function parseJsonBody(body: string): Record<string, unknown> {
+  if (!body.trim()) return {};
+  const parsed = JSON.parse(body);
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
+    throw new Error("Invalid JSON body");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function headerValue(header: string | string[] | undefined): string | undefined {
+  return firstNonEmptyString(header);
+}
+
+function extractTokenFromHeaders(req: IncomingMessage): string | undefined {
+  const explicit =
+    headerValue(req.headers["x-synology-token"]) ??
+    headerValue(req.headers["x-webhook-token"]) ??
+    headerValue(req.headers["x-openclaw-token"]);
+  if (explicit) return explicit;
+
+  const auth = headerValue(req.headers.authorization);
+  if (!auth) return undefined;
+
+  const bearerMatch = auth.match(/^Bearer\s+(.+)$/i);
+  if (bearerMatch?.[1]) return bearerMatch[1].trim();
+  return auth.trim();
+}
+
+/**
+ * Parse/normalize incoming webhook payload.
+ *
+ * Supports:
+ * - application/x-www-form-urlencoded
+ * - application/json
+ *
+ * Token resolution order: body.token -> query.token -> headers
+ * Field aliases:
+ * - user_id <- user_id | userId | user
+ * - text    <- text | message | content
+ */
+function parsePayload(req: IncomingMessage, body: string): SynologyWebhookPayload | null {
+  const contentType = String(req.headers["content-type"] ?? "").toLowerCase();
+
+  let bodyFields: Record<string, unknown> = {};
+  if (contentType.includes("application/json")) {
+    bodyFields = parseJsonBody(body);
+  } else if (contentType.includes("application/x-www-form-urlencoded")) {
+    bodyFields = parseFormBody(body);
+  } else {
+    // Fallback for clients with missing/incorrect content-type.
+    // Try JSON first, then form-urlencoded.
+    try {
+      bodyFields = parseJsonBody(body);
+    } catch {
+      bodyFields = parseFormBody(body);
+    }
+  }
+
+  const queryFields = parseQueryParams(req);
+  const headerToken = extractTokenFromHeaders(req);
+
+  const token =
+    pickAlias(bodyFields, ["token"]) ?? pickAlias(queryFields, ["token"]) ?? headerToken;
+  const userId =
+    pickAlias(bodyFields, ["user_id", "userId", "user"]) ??
+    pickAlias(queryFields, ["user_id", "userId", "user"]);
+  const text =
+    pickAlias(bodyFields, ["text", "message", "content"]) ??
+    pickAlias(queryFields, ["text", "message", "content"]);
 
   if (!token || !userId || !text) return null;
 
   return {
     token,
-    channel_id: parsed.channel_id ? String(parsed.channel_id) : undefined,
-    channel_name: parsed.channel_name ? String(parsed.channel_name) : undefined,
+    channel_id:
+      pickAlias(bodyFields, ["channel_id"]) ?? pickAlias(queryFields, ["channel_id"]) ?? undefined,
+    channel_name:
+      pickAlias(bodyFields, ["channel_name"]) ??
+      pickAlias(queryFields, ["channel_name"]) ??
+      undefined,
     user_id: userId,
-    username,
-    post_id: parsed.post_id ? String(parsed.post_id) : undefined,
-    timestamp: parsed.timestamp ? String(parsed.timestamp) : undefined,
+    username:
+      pickAlias(bodyFields, ["username", "user_name", "name"]) ??
+      pickAlias(queryFields, ["username", "user_name", "name"]) ??
+      "unknown",
+    post_id: pickAlias(bodyFields, ["post_id"]) ?? pickAlias(queryFields, ["post_id"]) ?? undefined,
+    timestamp:
+      pickAlias(bodyFields, ["timestamp"]) ?? pickAlias(queryFields, ["timestamp"]) ?? undefined,
     text,
-    trigger_word: parsed.trigger_word ? String(parsed.trigger_word) : undefined,
+    trigger_word:
+      pickAlias(bodyFields, ["trigger_word", "triggerWord"]) ??
+      pickAlias(queryFields, ["trigger_word", "triggerWord"]) ??
+      undefined,
   };
 }
 
 /** Send a JSON response. */
-function respond(res: ServerResponse, statusCode: number, body: Record<string, unknown>) {
+function respondJson(res: ServerResponse, statusCode: number, body: Record<string, unknown>) {
   res.writeHead(statusCode, { "Content-Type": "application/json" });
   res.end(JSON.stringify(body));
+}
+
+/** Send a no-content ACK. */
+function respondNoContent(res: ServerResponse) {
+  res.writeHead(204);
+  res.end();
 }
 
 export interface WebhookHandlerDeps {
@@ -121,13 +237,13 @@ export interface WebhookHandlerDeps {
  * Create an HTTP request handler for Synology Chat outgoing webhooks.
  *
  * This handler:
- * 1. Parses form-urlencoded body
+ * 1. Parses form-urlencoded/JSON payload
  * 2. Validates token (constant-time)
  * 3. Checks user allowlist
  * 4. Checks rate limit
  * 5. Sanitizes input
- * 6. Delivers to the agent via deliver()
- * 7. Sends the agent response back to Synology Chat
+ * 6. Immediately ACKs request (204)
+ * 7. Delivers to the agent asynchronously and sends final reply via incomingUrl
  */
 export function createWebhookHandler(deps: WebhookHandlerDeps) {
   const { account, deliver, log } = deps;
@@ -136,29 +252,36 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
   return async (req: IncomingMessage, res: ServerResponse) => {
     // Only accept POST
     if (req.method !== "POST") {
-      respond(res, 405, { error: "Method not allowed" });
+      respondJson(res, 405, { error: "Method not allowed" });
       return;
     }
 
     // Parse body
-    const body = await readBody(req);
-    if (!body.ok) {
-      log?.error("Failed to read request body", body.error);
-      respond(res, body.statusCode, { error: body.error });
+    const bodyResult = await readBody(req);
+    if (!bodyResult.ok) {
+      log?.error("Failed to read request body", bodyResult.error);
+      respondJson(res, bodyResult.statusCode, { error: bodyResult.error });
       return;
     }
 
     // Parse payload
-    const payload = parsePayload(body.body);
+    let payload: SynologyWebhookPayload | null = null;
+    try {
+      payload = parsePayload(req, bodyResult.body);
+    } catch (err) {
+      log?.warn("Failed to parse webhook payload", err);
+      respondJson(res, 400, { error: "Invalid request body" });
+      return;
+    }
     if (!payload) {
-      respond(res, 400, { error: "Missing required fields (token, user_id, text)" });
+      respondJson(res, 400, { error: "Missing required fields (token, user_id, text)" });
       return;
     }
 
     // Token validation
     if (!validateToken(payload.token, account.token)) {
       log?.warn(`Invalid token from ${req.socket?.remoteAddress}`);
-      respond(res, 401, { error: "Invalid token" });
+      respondJson(res, 401, { error: "Invalid token" });
       return;
     }
 
@@ -166,25 +289,25 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
     const auth = authorizeUserForDm(payload.user_id, account.dmPolicy, account.allowedUserIds);
     if (!auth.allowed) {
       if (auth.reason === "disabled") {
-        respond(res, 403, { error: "DMs are disabled" });
+        respondJson(res, 403, { error: "DMs are disabled" });
         return;
       }
       if (auth.reason === "allowlist-empty") {
         log?.warn("Synology Chat allowlist is empty while dmPolicy=allowlist; rejecting message");
-        respond(res, 403, {
+        respondJson(res, 403, {
           error: "Allowlist is empty. Configure allowedUserIds or use dmPolicy=open.",
         });
         return;
       }
       log?.warn(`Unauthorized user: ${payload.user_id}`);
-      respond(res, 403, { error: "User not authorized" });
+      respondJson(res, 403, { error: "User not authorized" });
       return;
     }
 
     // Rate limit
     if (!rateLimiter.check(payload.user_id)) {
       log?.warn(`Rate limit exceeded for user: ${payload.user_id}`);
-      respond(res, 429, { error: "Rate limit exceeded" });
+      respondJson(res, 429, { error: "Rate limit exceeded" });
       return;
     }
 
@@ -197,15 +320,15 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
     }
 
     if (!cleanText) {
-      respond(res, 200, { text: "" });
+      respondNoContent(res);
       return;
     }
 
     const preview = cleanText.length > 100 ? `${cleanText.slice(0, 100)}...` : cleanText;
     log?.info(`Message from ${payload.username} (${payload.user_id}): ${preview}`);
 
-    // Respond 200 immediately to avoid Synology Chat timeout
-    respond(res, 200, { text: "Processing..." });
+    // ACK immediately so Synology Chat won't remain in "Processing..."
+    respondNoContent(res);
 
     // Deliver to agent asynchronously (with 120s timeout to match nginx proxy_read_timeout)
     try {

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -5,6 +5,11 @@
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import * as querystring from "node:querystring";
+import {
+  isRequestBodyLimitError,
+  readRequestBodyWithLimit,
+  requestBodyErrorToText,
+} from "openclaw/plugin-sdk";
 import { sendMessage } from "./client.js";
 import { validateToken, authorizeUserForDm, sanitizeInput, RateLimiter } from "./security.js";
 import type { SynologyWebhookPayload, ResolvedSynologyChatAccount } from "./types.js";
@@ -34,24 +39,34 @@ export function getSynologyWebhookRateLimiterCountForTest(): number {
 }
 
 /** Read the full request body as a string. */
-function readBody(req: IncomingMessage): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    let size = 0;
-    const maxSize = 1_048_576; // 1MB
-
-    req.on("data", (chunk: Buffer) => {
-      size += chunk.length;
-      if (size > maxSize) {
-        req.destroy();
-        reject(new Error("Request body too large"));
-        return;
-      }
-      chunks.push(chunk);
+async function readBody(req: IncomingMessage): Promise<
+  | { ok: true; body: string }
+  | {
+      ok: false;
+      statusCode: number;
+      error: string;
+    }
+> {
+  try {
+    const body = await readRequestBodyWithLimit(req, {
+      maxBytes: 1_048_576,
+      timeoutMs: 30_000,
     });
-    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
-    req.on("error", reject);
-  });
+    return { ok: true, body };
+  } catch (err) {
+    if (isRequestBodyLimitError(err)) {
+      return {
+        ok: false,
+        statusCode: err.statusCode,
+        error: requestBodyErrorToText(err.code),
+      };
+    }
+    return {
+      ok: false,
+      statusCode: 400,
+      error: "Invalid request body",
+    };
+  }
 }
 
 /** Parse form-urlencoded body into SynologyWebhookPayload. */
@@ -126,17 +141,15 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
     }
 
     // Parse body
-    let body: string;
-    try {
-      body = await readBody(req);
-    } catch (err) {
-      log?.error("Failed to read request body", err);
-      respond(res, 400, { error: "Invalid request body" });
+    const body = await readBody(req);
+    if (!body.ok) {
+      log?.error("Failed to read request body", body.error);
+      respond(res, body.statusCode, { error: body.error });
       return;
     }
 
     // Parse payload
-    const payload = parsePayload(body);
+    const payload = parsePayload(body.body);
     if (!payload) {
       respond(res, 400, { error: "Missing required fields (token, user_id, text)" });
       return;

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -10,7 +10,7 @@ import {
   readRequestBodyWithLimit,
   requestBodyErrorToText,
 } from "openclaw/plugin-sdk";
-import { sendMessage } from "./client.js";
+import { sendMessage, resolveChatUserId } from "./client.js";
 import { validateToken, authorizeUserForDm, sanitizeInput, RateLimiter } from "./security.js";
 import type { SynologyWebhookPayload, ResolvedSynologyChatAccount } from "./types.js";
 
@@ -225,6 +225,8 @@ export interface WebhookHandlerDeps {
     chatType: string;
     sessionKey: string;
     accountId: string;
+    /** Chat API user_id for sending replies (may differ from webhook user_id) */
+    chatUserId?: string;
   }) => Promise<string | null>;
   log?: {
     info: (...args: unknown[]) => void;
@@ -330,8 +332,29 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
     // ACK immediately so Synology Chat won't remain in "Processing..."
     respondNoContent(res);
 
+    // Default to webhook user_id; may be replaced with Chat API user_id below.
+    let replyUserId = payload.user_id;
+
     // Deliver to agent asynchronously (with 120s timeout to match nginx proxy_read_timeout)
     try {
+      // Resolve the Chat-internal user_id for sending replies.
+      // Synology Chat outgoing webhooks use a per-integration user_id that may
+      // differ from the global Chat API user_id required by method=chatbot.
+      // We resolve via the user_list API, matching by nickname/username.
+      const chatUserId = await resolveChatUserId(
+        account.incomingUrl,
+        payload.username,
+        account.allowInsecureSsl,
+        log,
+      );
+      if (chatUserId !== undefined) {
+        replyUserId = String(chatUserId);
+      } else {
+        log?.warn(
+          `Could not resolve Chat API user_id for "${payload.username}" — falling back to webhook user_id ${payload.user_id}. Reply delivery may fail.`,
+        );
+      }
+
       const sessionKey = `synology-chat-${payload.user_id}`;
       const deliverPromise = deliver({
         body: cleanText,
@@ -341,6 +364,7 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
         chatType: "direct",
         sessionKey,
         accountId: account.accountId,
+        chatUserId: replyUserId,
       });
 
       const timeoutPromise = new Promise<null>((_, reject) =>
@@ -349,11 +373,11 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
 
       const reply = await Promise.race([deliverPromise, timeoutPromise]);
 
-      // Send reply back to Synology Chat
+      // Send reply back to Synology Chat using the resolved Chat user_id
       if (reply) {
-        await sendMessage(account.incomingUrl, reply, payload.user_id, account.allowInsecureSsl);
+        await sendMessage(account.incomingUrl, reply, replyUserId, account.allowInsecureSsl);
         const replyPreview = reply.length > 100 ? `${reply.slice(0, 100)}...` : reply;
-        log?.info(`Reply sent to ${payload.username} (${payload.user_id}): ${replyPreview}`);
+        log?.info(`Reply sent to ${payload.username} (${replyUserId}): ${replyPreview}`);
       }
     } catch (err) {
       const errMsg = err instanceof Error ? `${err.message}\n${err.stack}` : String(err);
@@ -361,7 +385,7 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
       await sendMessage(
         account.incomingUrl,
         "Sorry, an error occurred while processing your message.",
-        payload.user_id,
+        replyUserId,
         account.allowInsecureSsl,
       );
     }

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -9,7 +9,7 @@ import {
   isRequestBodyLimitError,
   readRequestBodyWithLimit,
   requestBodyErrorToText,
-} from "openclaw/plugin-sdk";
+} from "remoteclaw/plugin-sdk";
 import { sendMessage, resolveChatUserId } from "./client.js";
 import { validateToken, authorizeUserForDm, sanitizeInput, RateLimiter } from "./security.js";
 import type { SynologyWebhookPayload, ResolvedSynologyChatAccount } from "./types.js";
@@ -53,7 +53,7 @@ async function readBody(req: IncomingMessage): Promise<
       timeoutMs: 30_000,
     });
     return { ok: true, body };
-  } catch (err) {
+  } catch (err: unknown) {
     if (isRequestBodyLimitError(err)) {
       return {
         ok: false,


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #745
**Commits**: 9 cherry-picked (2 skipped: 1 empty after resolution, 1 CHANGELOG-only)

| Hash | Subject | Result |
|------|---------|--------|
| `e51371410` | fix(synology-chat): read cfg from outbound context so incomingUrl resolves | PICKED |
| `e39164604` | fix(synology-chat): add missing context fields for message delivery | PICKED |
| `26b8a70a5` | fix(synology-chat): use finalizeInboundContext for proper normalization | PICKED |
| `6df36a8b3` | fix(synology-chat): bound webhook body read time | PICKED |
| `aeeb0474c` | test(synology-chat): match request destroy typing | PICKED |
| `2b088ca12` | test(synology-chat): use real plugin-sdk helper exports | SKIPPED (fork already had importOriginal + rename) |
| `a3bb7a5ee` | fix: land synology webhook bounded body reads (#25831) | RESOLVED (CHANGELOG rm) |
| `92bf77d9a` | fix(synology-chat): accept JSON/aliases and ACK webhook with 204 | PICKED |
| `2a2e2c363` | fix: land synology webhook payload compatibility ACK (#26635) | SKIPPED (CHANGELOG-only landing commit) |
| `9a3800d8e` | fix(synology-chat): resolve Chat API user_id for reply delivery (#23709) | RESOLVED (CHANGELOG rm) |
| `b52561bfa` | fix(synology-chat): prevent restart loop in startAccount (#23074) | RESOLVED (CHANGELOG rm) |

**Adaptation**: webhook-handler.ts — renamed `openclaw/plugin-sdk` → `remoteclaw/plugin-sdk`, added `err: unknown` annotation for fork TS strictness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)