### PR TITLE
Cherry-pick batch: MS Teams adapter fixes + hardening

### DIFF
--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -164,7 +164,9 @@ const IMAGE_ATTACHMENT = { contentType: CONTENT_TYPE_IMAGE_PNG, contentUrl: TEST
 const PNG_BUFFER = Buffer.from("png");
 const PNG_BASE64 = PNG_BUFFER.toString("base64");
 const PDF_BUFFER = Buffer.from("pdf");
-const createTokenProvider = () => ({ getAccessToken: vi.fn(async () => "token") });
+const createTokenProvider = (token = "token") => ({
+  getAccessToken: vi.fn(async () => token),
+});
 const asSingleItemArray = <T>(value: T) => [value];
 const withLabel = <T extends object>(label: string, fields: T): T & LabeledCase => ({
   label,

--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -794,6 +794,49 @@ describe("msteams attachments", () => {
   describe("downloadMSTeamsGraphMedia", () => {
     it.each<GraphMediaSuccessCase>(GRAPH_MEDIA_SUCCESS_CASES)("$label", runGraphMediaSuccessCase);
 
+    it("does not forward Authorization for SharePoint redirects outside auth allowlist", async () => {
+      const tokenProvider = createTokenProvider("top-secret-token");
+      const escapedUrl = "https://example.com/collect";
+      const seen: Array<{ url: string; auth: string }> = [];
+      const referenceAttachment = createReferenceAttachment();
+      const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const auth = new Headers(init?.headers).get("Authorization") ?? "";
+        seen.push({ url, auth });
+
+        if (url === DEFAULT_MESSAGE_URL) {
+          return createJsonResponse({ attachments: [referenceAttachment] });
+        }
+        if (url === `${DEFAULT_MESSAGE_URL}/hostedContents`) {
+          return createGraphCollectionResponse([]);
+        }
+        if (url === `${DEFAULT_MESSAGE_URL}/attachments`) {
+          return createGraphCollectionResponse([referenceAttachment]);
+        }
+        if (url.startsWith(GRAPH_SHARES_URL_PREFIX)) {
+          return createRedirectResponse(escapedUrl);
+        }
+        if (url === escapedUrl) {
+          return createPdfResponse();
+        }
+        return createNotFoundResponse();
+      });
+
+      const media = await downloadMSTeamsGraphMedia({
+        messageUrl: DEFAULT_MESSAGE_URL,
+        tokenProvider,
+        maxBytes: DEFAULT_MAX_BYTES,
+        allowHosts: [...DEFAULT_SHAREPOINT_ALLOW_HOSTS, "example.com"],
+        authAllowHosts: DEFAULT_SHAREPOINT_ALLOW_HOSTS,
+        fetchFn: asFetchFn(fetchMock),
+      });
+
+      expectAttachmentMediaLength(media.media, 1);
+      const redirected = seen.find((entry) => entry.url === escapedUrl);
+      expect(redirected).toBeDefined();
+      expect(redirected?.auth).toBe("");
+    });
+
     it("blocks SharePoint redirects to hosts outside allowHosts", async () => {
       const escapedUrl = "https://evil.example/internal.pdf";
       const { fetchMock, media } = await downloadGraphMediaWithMockOptions(

--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -164,8 +164,12 @@ const IMAGE_ATTACHMENT = { contentType: CONTENT_TYPE_IMAGE_PNG, contentUrl: TEST
 const PNG_BUFFER = Buffer.from("png");
 const PNG_BASE64 = PNG_BUFFER.toString("base64");
 const PDF_BUFFER = Buffer.from("pdf");
-const createTokenProvider = (token = "token") => ({
-  getAccessToken: vi.fn(async () => token),
+const createTokenProvider = (
+  tokenOrResolver: string | ((scope: string) => string | Promise<string>) = "token",
+) => ({
+  getAccessToken: vi.fn(async (scope: string) =>
+    typeof tokenOrResolver === "function" ? await tokenOrResolver(scope) : tokenOrResolver,
+  ),
 });
 const asSingleItemArray = <T>(value: T) => [value];
 const withLabel = <T extends object>(label: string, fields: T): T & LabeledCase => ({
@@ -742,6 +746,73 @@ describe("msteams attachments", () => {
       expectAttachmentMediaLength(media, 1);
       expect(tokenProvider.getAccessToken).toHaveBeenCalledOnce();
       expect(fetchMock.mock.calls.map(([calledUrl]) => String(calledUrl))).toContain(redirectedUrl);
+    });
+
+    it("continues scope fallback after non-auth failure and succeeds on later scope", async () => {
+      let authAttempt = 0;
+      const tokenProvider = createTokenProvider((scope) => `token:${scope}`);
+      const fetchMock = vi.fn(async (_url: string, opts?: RequestInit) => {
+        const auth = new Headers(opts?.headers).get("Authorization");
+        if (!auth) {
+          return createTextResponse("unauthorized", 401);
+        }
+        authAttempt += 1;
+        if (authAttempt === 1) {
+          return createTextResponse("upstream transient", 500);
+        }
+        return createBufferResponse(PNG_BUFFER, CONTENT_TYPE_IMAGE_PNG);
+      });
+
+      const media = await downloadAttachmentsWithFetch(
+        createImageAttachments(TEST_URL_IMAGE),
+        fetchMock,
+        { tokenProvider, authAllowHosts: [TEST_HOST] },
+      );
+
+      expectAttachmentMediaLength(media, 1);
+      expect(tokenProvider.getAccessToken).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not forward Authorization to redirects outside auth allowlist", async () => {
+      const tokenProvider = createTokenProvider("top-secret-token");
+      const graphFileUrl = createUrlForHost(GRAPH_HOST, "file");
+      const seen: Array<{ url: string; auth: string }> = [];
+      const fetchMock = vi.fn(async (url: string, opts?: RequestInit) => {
+        const auth = new Headers(opts?.headers).get("Authorization") ?? "";
+        seen.push({ url, auth });
+        if (url === graphFileUrl && !auth) {
+          return new Response("unauthorized", { status: 401 });
+        }
+        if (url === graphFileUrl && auth) {
+          return new Response("", {
+            status: 302,
+            headers: { location: "https://attacker.azureedge.net/collect" },
+          });
+        }
+        if (url === "https://attacker.azureedge.net/collect") {
+          return new Response(Buffer.from("png"), {
+            status: 200,
+            headers: { "content-type": CONTENT_TYPE_IMAGE_PNG },
+          });
+        }
+        return createNotFoundResponse();
+      });
+
+      const media = await downloadMSTeamsAttachments(
+        buildDownloadParams([{ contentType: CONTENT_TYPE_IMAGE_PNG, contentUrl: graphFileUrl }], {
+          tokenProvider,
+          allowHosts: [GRAPH_HOST, AZUREEDGE_HOST],
+          authAllowHosts: [GRAPH_HOST],
+          fetchFn: asFetchFn(fetchMock),
+        }),
+      );
+
+      expectSingleMedia(media);
+      const redirected = seen.find(
+        (entry) => entry.url === "https://attacker.azureedge.net/collect",
+      );
+      expect(redirected).toBeDefined();
+      expect(redirected?.auth).toBe("");
     });
 
     it("skips urls outside the allowlist", async () => {

--- a/extensions/msteams/src/attachments/download.ts
+++ b/extensions/msteams/src/attachments/download.ts
@@ -86,6 +86,10 @@ function scopeCandidatesForUrl(url: string): string[] {
   }
 }
 
+function isRedirectStatus(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
 async function fetchWithAuthFallback(params: {
   url: string;
   tokenProvider?: MSTeamsAccessTokenProvider;
@@ -123,6 +127,7 @@ async function fetchWithAuthFallback(params: {
       const authAttempt = await safeFetch({
         url: params.url,
         allowHosts: params.allowHosts,
+        authorizationAllowHosts: params.authAllowHosts,
         fetchFn,
         requestInit: {
           ...params.requestInit,
@@ -132,10 +137,13 @@ async function fetchWithAuthFallback(params: {
       if (authAttempt.ok) {
         return authAttempt;
       }
-      if (authAttempt.status !== 401 && authAttempt.status !== 403) {
-        // Non-auth failures (including redirects in guarded fetch mode) should
-        // be handled by the caller's redirect/error policy.
+      if (isRedirectStatus(authAttempt.status)) {
+        // Redirects in guarded fetch mode must propagate to the outer guard.
         return authAttempt;
+      }
+      if (authAttempt.status !== 401 && authAttempt.status !== 403) {
+        // Preserve scope fallback semantics for non-auth failures.
+        continue;
       }
     } catch {
       // Try the next scope.

--- a/extensions/msteams/src/attachments/download.ts
+++ b/extensions/msteams/src/attachments/download.ts
@@ -6,12 +6,12 @@ import {
   isDownloadableAttachment,
   isRecord,
   isUrlAllowed,
+  type MSTeamsAttachmentFetchPolicy,
   normalizeContentType,
   resolveMediaSsrfPolicy,
+  resolveAttachmentFetchPolicy,
   resolveRequestUrl,
-  resolveAuthAllowedHosts,
-  resolveAllowedHosts,
-  safeFetch,
+  safeFetchWithPolicy,
 } from "./shared.js";
 import type {
   MSTeamsAccessTokenProvider,
@@ -95,12 +95,11 @@ async function fetchWithAuthFallback(params: {
   tokenProvider?: MSTeamsAccessTokenProvider;
   fetchFn?: typeof fetch;
   requestInit?: RequestInit;
-  allowHosts: string[];
-  authAllowHosts: string[];
+  policy: MSTeamsAttachmentFetchPolicy;
 }): Promise<Response> {
-  const firstAttempt = await safeFetch({
+  const firstAttempt = await safeFetchWithPolicy({
     url: params.url,
-    allowHosts: params.allowHosts,
+    policy: params.policy,
     fetchFn: params.fetchFn,
     requestInit: params.requestInit,
   });
@@ -113,7 +112,7 @@ async function fetchWithAuthFallback(params: {
   if (firstAttempt.status !== 401 && firstAttempt.status !== 403) {
     return firstAttempt;
   }
-  if (!isUrlAllowed(params.url, params.authAllowHosts)) {
+  if (!isUrlAllowed(params.url, params.policy.authAllowHosts)) {
     return firstAttempt;
   }
 
@@ -124,10 +123,9 @@ async function fetchWithAuthFallback(params: {
       const token = await params.tokenProvider.getAccessToken(scope);
       const authHeaders = new Headers(params.requestInit?.headers);
       authHeaders.set("Authorization", `Bearer ${token}`);
-      const authAttempt = await safeFetch({
+      const authAttempt = await safeFetchWithPolicy({
         url: params.url,
-        allowHosts: params.allowHosts,
-        authorizationAllowHosts: params.authAllowHosts,
+        policy: params.policy,
         fetchFn,
         requestInit: {
           ...params.requestInit,
@@ -171,8 +169,11 @@ export async function downloadMSTeamsAttachments(params: {
   if (list.length === 0) {
     return [];
   }
-  const allowHosts = resolveAllowedHosts(params.allowHosts);
-  const authAllowHosts = resolveAuthAllowedHosts(params.authAllowHosts);
+  const policy = resolveAttachmentFetchPolicy({
+    allowHosts: params.allowHosts,
+    authAllowHosts: params.authAllowHosts,
+  });
+  const allowHosts = policy.allowHosts;
   const ssrfPolicy = resolveMediaSsrfPolicy(allowHosts);
 
   // Download ANY downloadable attachment (not just images)
@@ -249,8 +250,7 @@ export async function downloadMSTeamsAttachments(params: {
             tokenProvider: params.tokenProvider,
             fetchFn: params.fetchFn,
             requestInit: init,
-            allowHosts,
-            authAllowHosts,
+            policy,
           }),
       });
       out.push(media);

--- a/extensions/msteams/src/attachments/download.ts
+++ b/extensions/msteams/src/attachments/download.ts
@@ -1,4 +1,3 @@
-import { fetchWithBearerAuthScopeFallback } from "remoteclaw/plugin-sdk";
 import { getMSTeamsRuntime } from "../runtime.js";
 import { downloadAndStoreMSTeamsRemoteMedia } from "./remote-media.js";
 import {
@@ -12,6 +11,7 @@ import {
   resolveRequestUrl,
   resolveAuthAllowedHosts,
   resolveAllowedHosts,
+  safeFetch,
 } from "./shared.js";
 import type {
   MSTeamsAccessTokenProvider,
@@ -91,16 +91,14 @@ async function fetchWithAuthFallback(params: {
   tokenProvider?: MSTeamsAccessTokenProvider;
   fetchFn?: typeof fetch;
   requestInit?: RequestInit;
+  allowHosts: string[];
   authAllowHosts: string[];
 }): Promise<Response> {
-  return await fetchWithBearerAuthScopeFallback({
+  const firstAttempt = await safeFetch({
     url: params.url,
-    scopes: scopeCandidatesForUrl(params.url),
-    tokenProvider: params.tokenProvider,
+    allowHosts: params.allowHosts,
     fetchFn: params.fetchFn,
     requestInit: params.requestInit,
-    requireHttps: true,
-    shouldAttachAuth: (url) => isUrlAllowed(url, params.authAllowHosts),
   });
   if (firstAttempt.ok) {
     return firstAttempt;
@@ -116,6 +114,7 @@ async function fetchWithAuthFallback(params: {
   }
 
   const scopes = scopeCandidatesForUrl(params.url);
+  const fetchFn = params.fetchFn ?? fetch;
   for (const scope of scopes) {
     try {
       const token = await params.tokenProvider.getAccessToken(scope);
@@ -129,7 +128,6 @@ async function fetchWithAuthFallback(params: {
           ...params.requestInit,
           headers: authHeaders,
         },
-        resolveFn: params.resolveFn,
       });
       if (authAttempt.ok) {
         return authAttempt;
@@ -138,25 +136,6 @@ async function fetchWithAuthFallback(params: {
         // Non-auth failures (including redirects in guarded fetch mode) should
         // be handled by the caller's redirect/error policy.
         return authAttempt;
-      }
-
-      const finalUrl =
-        typeof authAttempt.url === "string" && authAttempt.url ? authAttempt.url : "";
-      if (!finalUrl || finalUrl === params.url || !isUrlAllowed(finalUrl, params.authAllowHosts)) {
-        continue;
-      }
-      const redirectedAuthAttempt = await safeFetch({
-        url: finalUrl,
-        allowHosts: params.allowHosts,
-        fetchFn,
-        requestInit: {
-          ...params.requestInit,
-          headers: authHeaders,
-        },
-        resolveFn: params.resolveFn,
-      });
-      if (redirectedAuthAttempt.ok) {
-        return redirectedAuthAttempt;
       }
     } catch {
       // Try the next scope.
@@ -262,6 +241,7 @@ export async function downloadMSTeamsAttachments(params: {
             tokenProvider: params.tokenProvider,
             fetchFn: params.fetchFn,
             requestInit: init,
+            allowHosts,
             authAllowHosts,
           }),
       });

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -10,7 +10,9 @@ import {
   normalizeContentType,
   resolveMediaSsrfPolicy,
   resolveRequestUrl,
+  resolveAuthAllowedHosts,
   resolveAllowedHosts,
+  safeFetch,
 } from "./shared.js";
 import type {
   MSTeamsAccessTokenProvider,
@@ -242,6 +244,7 @@ export async function downloadMSTeamsGraphMedia(params: {
     return { media: [] };
   }
   const allowHosts = resolveAllowedHosts(params.allowHosts);
+  const authAllowHosts = resolveAuthAllowedHosts(params.authAllowHosts);
   const ssrfPolicy = resolveMediaSsrfPolicy(allowHosts);
   const messageUrl = params.messageUrl;
   let accessToken: string;
@@ -304,8 +307,21 @@ export async function downloadMSTeamsGraphMedia(params: {
               fetchImpl: async (input, init) => {
                 const requestUrl = resolveRequestUrl(input);
                 const headers = new Headers(init?.headers);
-                headers.set("Authorization", `Bearer ${accessToken}`);
-                return await fetchFn(requestUrl, { ...init, headers });
+                if (isUrlAllowed(requestUrl, authAllowHosts)) {
+                  headers.set("Authorization", `Bearer ${accessToken}`);
+                } else {
+                  headers.delete("Authorization");
+                }
+                return await safeFetch({
+                  url: requestUrl,
+                  allowHosts,
+                  authorizationAllowHosts: authAllowHosts,
+                  fetchFn,
+                  requestInit: {
+                    ...init,
+                    headers,
+                  },
+                });
               },
             });
             sharePointMedia.push(media);
@@ -313,35 +329,6 @@ export async function downloadMSTeamsGraphMedia(params: {
           } catch {
             // Ignore SharePoint download failures.
           }
-          const encodedUrl = Buffer.from(shareUrl).toString("base64url");
-          const sharesUrl = `${GRAPH_ROOT}/shares/u!${encodedUrl}/driveItem/content`;
-
-          const media = await downloadAndStoreMSTeamsRemoteMedia({
-            url: sharesUrl,
-            filePathHint: name,
-            maxBytes: params.maxBytes,
-            contentTypeHint: "application/octet-stream",
-            preserveFilenames: params.preserveFilenames,
-            fetchImpl: async (input, init) => {
-              const requestUrl = resolveRequestUrl(input);
-              const headers = new Headers(init?.headers);
-              headers.set("Authorization", `Bearer ${accessToken}`);
-              return await safeFetch({
-                url: requestUrl,
-                allowHosts,
-                authorizationAllowHosts: params.authAllowHosts,
-                fetchFn,
-                requestInit: {
-                  ...init,
-                  headers,
-                },
-              });
-            },
-          });
-          sharePointMedia.push(media);
-          downloadedReferenceUrls.add(shareUrl);
-        } catch {
-          // Ignore SharePoint download failures.
         }
       }
     } finally {
@@ -387,7 +374,7 @@ export async function downloadMSTeamsGraphMedia(params: {
     maxBytes: params.maxBytes,
     tokenProvider: params.tokenProvider,
     allowHosts,
-    authAllowHosts: params.authAllowHosts,
+    authAllowHosts,
     fetchFn: params.fetchFn,
     preserveFilenames: params.preserveFilenames,
   });

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -3,16 +3,17 @@ import { getMSTeamsRuntime } from "../runtime.js";
 import { downloadMSTeamsAttachments } from "./download.js";
 import { downloadAndStoreMSTeamsRemoteMedia } from "./remote-media.js";
 import {
+  applyAuthorizationHeaderForUrl,
   GRAPH_ROOT,
   inferPlaceholder,
   isRecord,
   isUrlAllowed,
+  type MSTeamsAttachmentFetchPolicy,
   normalizeContentType,
   resolveMediaSsrfPolicy,
+  resolveAttachmentFetchPolicy,
   resolveRequestUrl,
-  resolveAuthAllowedHosts,
-  resolveAllowedHosts,
-  safeFetch,
+  safeFetchWithPolicy,
 } from "./shared.js";
 import type {
   MSTeamsAccessTokenProvider,
@@ -243,9 +244,11 @@ export async function downloadMSTeamsGraphMedia(params: {
   if (!params.messageUrl || !params.tokenProvider) {
     return { media: [] };
   }
-  const allowHosts = resolveAllowedHosts(params.allowHosts);
-  const authAllowHosts = resolveAuthAllowedHosts(params.authAllowHosts);
-  const ssrfPolicy = resolveMediaSsrfPolicy(allowHosts);
+  const policy: MSTeamsAttachmentFetchPolicy = resolveAttachmentFetchPolicy({
+    allowHosts: params.allowHosts,
+    authAllowHosts: params.authAllowHosts,
+  });
+  const ssrfPolicy = resolveMediaSsrfPolicy(policy.allowHosts);
   const messageUrl = params.messageUrl;
   let accessToken: string;
   try {
@@ -291,7 +294,7 @@ export async function downloadMSTeamsGraphMedia(params: {
           try {
             // SharePoint URLs need to be accessed via Graph shares API
             const shareUrl = att.contentUrl!;
-            if (!isUrlAllowed(shareUrl, allowHosts)) {
+            if (!isUrlAllowed(shareUrl, policy.allowHosts)) {
               continue;
             }
             const encodedUrl = Buffer.from(shareUrl).toString("base64url");
@@ -307,15 +310,15 @@ export async function downloadMSTeamsGraphMedia(params: {
               fetchImpl: async (input, init) => {
                 const requestUrl = resolveRequestUrl(input);
                 const headers = new Headers(init?.headers);
-                if (isUrlAllowed(requestUrl, authAllowHosts)) {
-                  headers.set("Authorization", `Bearer ${accessToken}`);
-                } else {
-                  headers.delete("Authorization");
-                }
-                return await safeFetch({
+                applyAuthorizationHeaderForUrl({
+                  headers,
                   url: requestUrl,
-                  allowHosts,
-                  authorizationAllowHosts: authAllowHosts,
+                  authAllowHosts: policy.authAllowHosts,
+                  bearerToken: accessToken,
+                });
+                return await safeFetchWithPolicy({
+                  url: requestUrl,
+                  policy,
                   fetchFn,
                   requestInit: {
                     ...init,
@@ -373,8 +376,8 @@ export async function downloadMSTeamsGraphMedia(params: {
     attachments: filteredAttachments,
     maxBytes: params.maxBytes,
     tokenProvider: params.tokenProvider,
-    allowHosts,
-    authAllowHosts,
+    allowHosts: policy.allowHosts,
+    authAllowHosts: policy.authAllowHosts,
     fetchFn: params.fetchFn,
     preserveFilenames: params.preserveFilenames,
   });

--- a/extensions/msteams/src/attachments/shared.test.ts
+++ b/extensions/msteams/src/attachments/shared.test.ts
@@ -19,10 +19,250 @@ describe("msteams attachment allowlists", () => {
     expect(isUrlAllowed("https://evil.example.com/file.png", allowHosts)).toBe(false);
   });
 
-  it("builds shared SSRF policy from suffix allowlist", () => {
-    expect(resolveMediaSsrfPolicy(["sharepoint.com"])).toEqual({
-      hostnameAllowlist: ["sharepoint.com", "*.sharepoint.com"],
+  it.each([
+    ["999.999.999.999", true],
+    ["256.0.0.1", true],
+    ["10.0.0.256", true],
+    ["-1.0.0.1", false],
+    ["1.2.3.4.5", false],
+    ["0:0:0:0:0:0:0:1", true],
+  ] as const)("malformed/expanded %s → %s (SDK fails closed)", (ip, expected) => {
+    expect(isPrivateOrReservedIP(ip)).toBe(expected);
+  });
+});
+
+// ─── resolveAndValidateIP ────────────────────────────────────────────────────
+
+describe("resolveAndValidateIP", () => {
+  it("accepts a hostname resolving to a public IP", async () => {
+    const ip = await resolveAndValidateIP("teams.sharepoint.com", publicResolve);
+    expect(ip).toBe("13.107.136.10");
+  });
+
+  it("rejects a hostname resolving to 10.x.x.x", async () => {
+    await expect(resolveAndValidateIP("evil.test", privateResolve("10.0.0.1"))).rejects.toThrow(
+      "private/reserved IP",
+    );
+  });
+
+  it("rejects a hostname resolving to 169.254.169.254", async () => {
+    await expect(
+      resolveAndValidateIP("evil.test", privateResolve("169.254.169.254")),
+    ).rejects.toThrow("private/reserved IP");
+  });
+
+  it("rejects a hostname resolving to loopback", async () => {
+    await expect(resolveAndValidateIP("evil.test", privateResolve("127.0.0.1"))).rejects.toThrow(
+      "private/reserved IP",
+    );
+  });
+
+  it("rejects a hostname resolving to IPv6 loopback", async () => {
+    await expect(resolveAndValidateIP("evil.test", privateResolve("::1"))).rejects.toThrow(
+      "private/reserved IP",
+    );
+  });
+
+  it("throws on DNS resolution failure", async () => {
+    await expect(resolveAndValidateIP("nonexistent.test", failingResolve)).rejects.toThrow(
+      "DNS resolution failed",
+    );
+  });
+});
+
+// ─── safeFetch ───────────────────────────────────────────────────────────────
+
+describe("safeFetch", () => {
+  it("fetches a URL directly when no redirect occurs", async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => {
+      return new Response("ok", { status: 200 });
     });
-    expect(resolveMediaSsrfPolicy(["*"])).toBeUndefined();
+    const res = await safeFetch({
+      url: "https://teams.sharepoint.com/file.pdf",
+      allowHosts: ["sharepoint.com"],
+      fetchFn: fetchMock as unknown as typeof fetch,
+      resolveFn: publicResolve,
+    });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    // Should have used redirect: "manual"
+    expect(fetchMock.mock.calls[0][1]).toHaveProperty("redirect", "manual");
+  });
+
+  it("follows a redirect to an allowlisted host with public IP", async () => {
+    const fetchMock = mockFetchWithRedirect({
+      "https://teams.sharepoint.com/file.pdf": "https://cdn.sharepoint.com/storage/file.pdf",
+    });
+    const res = await safeFetch({
+      url: "https://teams.sharepoint.com/file.pdf",
+      allowHosts: ["sharepoint.com"],
+      fetchFn: fetchMock as unknown as typeof fetch,
+      resolveFn: publicResolve,
+    });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the redirect response when dispatcher is provided by an outer guard", async () => {
+    const redirectedTo = "https://cdn.sharepoint.com/storage/file.pdf";
+    const fetchMock = mockFetchWithRedirect({
+      "https://teams.sharepoint.com/file.pdf": redirectedTo,
+    });
+    const res = await safeFetch({
+      url: "https://teams.sharepoint.com/file.pdf",
+      allowHosts: ["sharepoint.com"],
+      fetchFn: fetchMock as unknown as typeof fetch,
+      requestInit: { dispatcher: {} } as RequestInit,
+      resolveFn: publicResolve,
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(redirectedTo);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("still enforces allowlist checks before returning dispatcher-mode redirects", async () => {
+    const fetchMock = mockFetchWithRedirect({
+      "https://teams.sharepoint.com/file.pdf": "https://evil.example.com/steal",
+    });
+    await expect(
+      safeFetch({
+        url: "https://teams.sharepoint.com/file.pdf",
+        allowHosts: ["sharepoint.com"],
+        fetchFn: fetchMock as unknown as typeof fetch,
+        requestInit: { dispatcher: {} } as RequestInit,
+        resolveFn: publicResolve,
+      }),
+    ).rejects.toThrow("blocked by allowlist");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("blocks a redirect to a non-allowlisted host", async () => {
+    const fetchMock = mockFetchWithRedirect({
+      "https://teams.sharepoint.com/file.pdf": "https://evil.example.com/steal",
+    });
+    await expect(
+      safeFetch({
+        url: "https://teams.sharepoint.com/file.pdf",
+        allowHosts: ["sharepoint.com"],
+        fetchFn: fetchMock as unknown as typeof fetch,
+        resolveFn: publicResolve,
+      }),
+    ).rejects.toThrow("blocked by allowlist");
+    // Should not have fetched the evil URL
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks a redirect to an allowlisted host that resolves to a private IP (DNS rebinding)", async () => {
+    let callCount = 0;
+    const rebindingResolve = async () => {
+      callCount++;
+      // First call (initial URL) resolves to public IP
+      if (callCount === 1) return { address: "13.107.136.10" };
+      // Second call (redirect target) resolves to private IP
+      return { address: "169.254.169.254" };
+    };
+
+    const fetchMock = mockFetchWithRedirect({
+      "https://teams.sharepoint.com/file.pdf": "https://evil.trafficmanager.net/metadata",
+    });
+    await expect(
+      safeFetch({
+        url: "https://teams.sharepoint.com/file.pdf",
+        allowHosts: ["sharepoint.com", "trafficmanager.net"],
+        fetchFn: fetchMock as unknown as typeof fetch,
+        resolveFn: rebindingResolve,
+      }),
+    ).rejects.toThrow("private/reserved IP");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks when the initial URL resolves to a private IP", async () => {
+    const fetchMock = vi.fn();
+    await expect(
+      safeFetch({
+        url: "https://evil.sharepoint.com/file.pdf",
+        allowHosts: ["sharepoint.com"],
+        fetchFn: fetchMock as unknown as typeof fetch,
+        resolveFn: privateResolve("10.0.0.1"),
+      }),
+    ).rejects.toThrow("Initial download URL blocked");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks when initial URL DNS resolution fails", async () => {
+    const fetchMock = vi.fn();
+    await expect(
+      safeFetch({
+        url: "https://nonexistent.sharepoint.com/file.pdf",
+        allowHosts: ["sharepoint.com"],
+        fetchFn: fetchMock as unknown as typeof fetch,
+        resolveFn: failingResolve,
+      }),
+    ).rejects.toThrow("Initial download URL blocked");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("follows multiple redirects when all are valid", async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "https://a.sharepoint.com/1" && init?.redirect === "manual") {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://b.sharepoint.com/2" },
+        });
+      }
+      if (url === "https://b.sharepoint.com/2" && init?.redirect === "manual") {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://c.sharepoint.com/3" },
+        });
+      }
+      return new Response("final", { status: 200 });
+    });
+
+    const res = await safeFetch({
+      url: "https://a.sharepoint.com/1",
+      allowHosts: ["sharepoint.com"],
+      fetchFn: fetchMock as unknown as typeof fetch,
+      resolveFn: publicResolve,
+    });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws on too many redirects", async () => {
+    let counter = 0;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.redirect === "manual") {
+        counter++;
+        return new Response(null, {
+          status: 302,
+          headers: { location: `https://loop${counter}.sharepoint.com/x` },
+        });
+      }
+      return new Response("ok", { status: 200 });
+    });
+
+    await expect(
+      safeFetch({
+        url: "https://start.sharepoint.com/x",
+        allowHosts: ["sharepoint.com"],
+        fetchFn: fetchMock as unknown as typeof fetch,
+        resolveFn: publicResolve,
+      }),
+    ).rejects.toThrow("Too many redirects");
+  });
+
+  it("blocks redirect to HTTP (non-HTTPS)", async () => {
+    const fetchMock = mockFetchWithRedirect({
+      "https://teams.sharepoint.com/file": "http://internal.sharepoint.com/file",
+    });
+    await expect(
+      safeFetch({
+        url: "https://teams.sharepoint.com/file",
+        allowHosts: ["sharepoint.com"],
+        fetchFn: fetchMock as unknown as typeof fetch,
+        resolveFn: publicResolve,
+      }),
+    ).rejects.toThrow("blocked by allowlist");
   });
 });

--- a/extensions/msteams/src/attachments/shared.test.ts
+++ b/extensions/msteams/src/attachments/shared.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  applyAuthorizationHeaderForUrl,
   isPrivateOrReservedIP,
   isUrlAllowed,
   resolveAndValidateIP,
+  resolveAttachmentFetchPolicy,
   resolveAllowedHosts,
   resolveAuthAllowedHosts,
   resolveMediaSsrfPolicy,
   safeFetch,
+  safeFetchWithPolicy,
 } from "./shared.js";
 
 const publicResolve = async () => ({ address: "13.107.136.10" });
@@ -32,6 +35,18 @@ describe("msteams attachment allowlists", () => {
   it("normalizes wildcard host lists", () => {
     expect(resolveAllowedHosts(["*", "graph.microsoft.com"])).toEqual(["*"]);
     expect(resolveAuthAllowedHosts(["*", "graph.microsoft.com"])).toEqual(["*"]);
+  });
+
+  it("resolves a normalized attachment fetch policy", () => {
+    expect(
+      resolveAttachmentFetchPolicy({
+        allowHosts: ["sharepoint.com"],
+        authAllowHosts: ["graph.microsoft.com"],
+      }),
+    ).toEqual({
+      allowHosts: ["sharepoint.com"],
+      authAllowHosts: ["graph.microsoft.com"],
+    });
   });
 
   it("requires https and host suffix match", () => {
@@ -293,5 +308,71 @@ describe("safeFetch", () => {
         resolveFn: publicResolve,
       }),
     ).rejects.toThrow("blocked by allowlist");
+  });
+
+  it("strips authorization across redirects outside auth allowlist", async () => {
+    const seenAuth: string[] = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const auth = new Headers(init?.headers).get("authorization") ?? "";
+      seenAuth.push(`${url}|${auth}`);
+      if (url === "https://teams.sharepoint.com/file.pdf") {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://cdn.sharepoint.com/storage/file.pdf" },
+        });
+      }
+      return new Response("ok", { status: 200 });
+    });
+
+    const headers = new Headers({ Authorization: "Bearer secret" });
+    const res = await safeFetch({
+      url: "https://teams.sharepoint.com/file.pdf",
+      allowHosts: ["sharepoint.com"],
+      authorizationAllowHosts: ["graph.microsoft.com"],
+      fetchFn: fetchMock as unknown as typeof fetch,
+      requestInit: { headers },
+      resolveFn: publicResolve,
+    });
+    expect(res.status).toBe(200);
+    expect(seenAuth[0]).toContain("Bearer secret");
+    expect(seenAuth[1]).toMatch(/\|$/);
+  });
+});
+
+describe("attachment fetch auth helpers", () => {
+  it("sets and clears authorization header by auth allowlist", () => {
+    const headers = new Headers();
+    applyAuthorizationHeaderForUrl({
+      headers,
+      url: "https://graph.microsoft.com/v1.0/me",
+      authAllowHosts: ["graph.microsoft.com"],
+      bearerToken: "token-1",
+    });
+    expect(headers.get("authorization")).toBe("Bearer token-1");
+
+    applyAuthorizationHeaderForUrl({
+      headers,
+      url: "https://evil.example.com/collect",
+      authAllowHosts: ["graph.microsoft.com"],
+      bearerToken: "token-1",
+    });
+    expect(headers.get("authorization")).toBeNull();
+  });
+
+  it("safeFetchWithPolicy forwards policy allowlists", async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => {
+      return new Response("ok", { status: 200 });
+    });
+    const res = await safeFetchWithPolicy({
+      url: "https://teams.sharepoint.com/file.pdf",
+      policy: resolveAttachmentFetchPolicy({
+        allowHosts: ["sharepoint.com"],
+        authAllowHosts: ["graph.microsoft.com"],
+      }),
+      fetchFn: fetchMock as unknown as typeof fetch,
+      resolveFn: publicResolve,
+    });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -268,6 +268,112 @@ export function isUrlAllowed(url: string, allowlist: string[]): boolean {
   return isHttpsUrlAllowedByHostnameSuffixAllowlist(url, allowlist);
 }
 
-export function resolveMediaSsrfPolicy(allowHosts: string[]): SsrFPolicy | undefined {
-  return buildHostnameAllowlistPolicyFromSuffixAllowlist(allowHosts);
+/**
+ * Returns true if the given IPv4 or IPv6 address is in a private, loopback,
+ * or link-local range that must never be reached from media downloads.
+ *
+ * Delegates to the SDK's `isPrivateIpAddress` which handles IPv4-mapped IPv6,
+ * expanded notation, NAT64, 6to4, Teredo, octal IPv4, and fails closed on
+ * parse errors.
+ */
+export const isPrivateOrReservedIP: (ip: string) => boolean = isPrivateIpAddress;
+
+/**
+ * Resolve a hostname via DNS and reject private/reserved IPs.
+ * Throws if the resolved IP is private or resolution fails.
+ */
+export async function resolveAndValidateIP(
+  hostname: string,
+  resolveFn?: (hostname: string) => Promise<{ address: string }>,
+): Promise<string> {
+  const resolve = resolveFn ?? lookup;
+  let resolved: { address: string };
+  try {
+    resolved = await resolve(hostname);
+  } catch {
+    throw new Error(`DNS resolution failed for "${hostname}"`);
+  }
+  if (isPrivateOrReservedIP(resolved.address)) {
+    throw new Error(`Hostname "${hostname}" resolves to private/reserved IP (${resolved.address})`);
+  }
+  return resolved.address;
+}
+
+/** Maximum number of redirects to follow in safeFetch. */
+const MAX_SAFE_REDIRECTS = 5;
+
+/**
+ * Fetch a URL with redirect: "manual", validating each redirect target
+ * against the hostname allowlist and DNS-resolved IP (anti-SSRF).
+ *
+ * This prevents:
+ * - Auto-following redirects to non-allowlisted hosts
+ * - DNS rebinding attacks where an allowlisted domain resolves to a private IP
+ */
+export async function safeFetch(params: {
+  url: string;
+  allowHosts: string[];
+  fetchFn?: typeof fetch;
+  requestInit?: RequestInit;
+  resolveFn?: (hostname: string) => Promise<{ address: string }>;
+}): Promise<Response> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const resolveFn = params.resolveFn;
+  const hasDispatcher = Boolean(
+    params.requestInit &&
+    typeof params.requestInit === "object" &&
+    "dispatcher" in (params.requestInit as Record<string, unknown>),
+  );
+  let currentUrl = params.url;
+
+  // Validate the initial URL's resolved IP
+  try {
+    const initialHost = new URL(currentUrl).hostname;
+    await resolveAndValidateIP(initialHost, resolveFn);
+  } catch {
+    throw new Error(`Initial download URL blocked: ${currentUrl}`);
+  }
+
+  for (let i = 0; i <= MAX_SAFE_REDIRECTS; i++) {
+    const res = await fetchFn(currentUrl, {
+      ...params.requestInit,
+      redirect: "manual",
+    });
+
+    if (![301, 302, 303, 307, 308].includes(res.status)) {
+      return res;
+    }
+
+    const location = res.headers.get("location");
+    if (!location) {
+      return res;
+    }
+
+    let redirectUrl: string;
+    try {
+      redirectUrl = new URL(location, currentUrl).toString();
+    } catch {
+      throw new Error(`Invalid redirect URL: ${location}`);
+    }
+
+    // Validate redirect target against hostname allowlist
+    if (!isUrlAllowed(redirectUrl, params.allowHosts)) {
+      throw new Error(`Media redirect target blocked by allowlist: ${redirectUrl}`);
+    }
+
+    // When a pinned dispatcher is already injected by an upstream guard
+    // (for example fetchWithSsrFGuard), let that guard own redirect handling
+    // after this allowlist validation step.
+    if (hasDispatcher) {
+      return res;
+    }
+
+    // Validate redirect target's resolved IP
+    const redirectHost = new URL(redirectUrl).hostname;
+    await resolveAndValidateIP(redirectHost, resolveFn);
+
+    currentUrl = redirectUrl;
+  }
+
+  throw new Error(`Too many redirects (>${MAX_SAFE_REDIRECTS})`);
 }

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -266,8 +266,40 @@ export function resolveAuthAllowedHosts(input?: string[]): string[] {
   return normalizeHostnameSuffixAllowlist(input, DEFAULT_MEDIA_AUTH_HOST_ALLOWLIST);
 }
 
+export type MSTeamsAttachmentFetchPolicy = {
+  allowHosts: string[];
+  authAllowHosts: string[];
+};
+
+export function resolveAttachmentFetchPolicy(params?: {
+  allowHosts?: string[];
+  authAllowHosts?: string[];
+}): MSTeamsAttachmentFetchPolicy {
+  return {
+    allowHosts: resolveAllowedHosts(params?.allowHosts),
+    authAllowHosts: resolveAuthAllowedHosts(params?.authAllowHosts),
+  };
+}
+
 export function isUrlAllowed(url: string, allowlist: string[]): boolean {
   return isHttpsUrlAllowedByHostnameSuffixAllowlist(url, allowlist);
+}
+
+export function applyAuthorizationHeaderForUrl(params: {
+  headers: Headers;
+  url: string;
+  authAllowHosts: string[];
+  bearerToken?: string;
+}): void {
+  if (!params.bearerToken) {
+    params.headers.delete("Authorization");
+    return;
+  }
+  if (isUrlAllowed(params.url, params.authAllowHosts)) {
+    params.headers.set("Authorization", `Bearer ${params.bearerToken}`);
+    return;
+  }
+  params.headers.delete("Authorization");
 }
 
 export function resolveMediaSsrfPolicy(allowHosts: string[]): SsrFPolicy | undefined {
@@ -407,4 +439,21 @@ export async function safeFetch(params: {
   }
 
   throw new Error(`Too many redirects (>${MAX_SAFE_REDIRECTS})`);
+}
+
+export async function safeFetchWithPolicy(params: {
+  url: string;
+  policy: MSTeamsAttachmentFetchPolicy;
+  fetchFn?: typeof fetch;
+  requestInit?: RequestInit;
+  resolveFn?: (hostname: string) => Promise<{ address: string }>;
+}): Promise<Response> {
+  return await safeFetch({
+    url: params.url,
+    allowHosts: params.policy.allowHosts,
+    authorizationAllowHosts: params.policy.authAllowHosts,
+    fetchFn: params.fetchFn,
+    requestInit: params.requestInit,
+    resolveFn: params.resolveFn,
+  });
 }

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -319,6 +319,12 @@ const MAX_SAFE_REDIRECTS = 5;
 export async function safeFetch(params: {
   url: string;
   allowHosts: string[];
+  /**
+   * Optional allowlist for forwarding Authorization across redirects.
+   * When set, Authorization is stripped before following redirects to hosts
+   * outside this list.
+   */
+  authorizationAllowHosts?: string[];
   fetchFn?: typeof fetch;
   requestInit?: RequestInit;
   resolveFn?: (hostname: string) => Promise<{ address: string }>;
@@ -330,6 +336,7 @@ export async function safeFetch(params: {
     typeof params.requestInit === "object" &&
     "dispatcher" in (params.requestInit as Record<string, unknown>),
   );
+  const currentHeaders = new Headers(params.requestInit?.headers);
   let currentUrl = params.url;
 
   if (!isUrlAllowed(currentUrl, params.allowHosts)) {
@@ -348,6 +355,7 @@ export async function safeFetch(params: {
   for (let i = 0; i <= MAX_SAFE_REDIRECTS; i++) {
     const res = await fetchFn(currentUrl, {
       ...params.requestInit,
+      headers: currentHeaders,
       redirect: "manual",
     });
 
@@ -370,6 +378,16 @@ export async function safeFetch(params: {
     // Validate redirect target against hostname allowlist
     if (!isUrlAllowed(redirectUrl, params.allowHosts)) {
       throw new Error(`Media redirect target blocked by allowlist: ${redirectUrl}`);
+    }
+
+    // Prevent credential bleed: only keep Authorization on redirect hops that
+    // are explicitly auth-allowlisted.
+    if (
+      currentHeaders.has("authorization") &&
+      params.authorizationAllowHosts &&
+      !isUrlAllowed(redirectUrl, params.authorizationAllowHosts)
+    ) {
+      currentHeaders.delete("authorization");
     }
 
     // When a pinned dispatcher is already injected by an upstream guard

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -1,6 +1,8 @@
+import { lookup } from "node:dns/promises";
 import {
   buildHostnameAllowlistPolicyFromSuffixAllowlist,
   isHttpsUrlAllowedByHostnameSuffixAllowlist,
+  isPrivateIpAddress,
   normalizeHostnameSuffixAllowlist,
 } from "remoteclaw/plugin-sdk";
 import type { SsrFPolicy } from "remoteclaw/plugin-sdk";
@@ -268,6 +270,10 @@ export function isUrlAllowed(url: string, allowlist: string[]): boolean {
   return isHttpsUrlAllowedByHostnameSuffixAllowlist(url, allowlist);
 }
 
+export function resolveMediaSsrfPolicy(allowHosts: string[]): SsrFPolicy | undefined {
+  return buildHostnameAllowlistPolicyFromSuffixAllowlist(allowHosts);
+}
+
 /**
  * Returns true if the given IPv4 or IPv6 address is in a private, loopback,
  * or link-local range that must never be reached from media downloads.
@@ -304,11 +310,11 @@ const MAX_SAFE_REDIRECTS = 5;
 
 /**
  * Fetch a URL with redirect: "manual", validating each redirect target
- * against the hostname allowlist and DNS-resolved IP (anti-SSRF).
+ * against the hostname allowlist and optional DNS-resolved IP (anti-SSRF).
  *
  * This prevents:
  * - Auto-following redirects to non-allowlisted hosts
- * - DNS rebinding attacks where an allowlisted domain resolves to a private IP
+ * - DNS rebinding attacks when a lookup function is provided
  */
 export async function safeFetch(params: {
   url: string;
@@ -326,12 +332,17 @@ export async function safeFetch(params: {
   );
   let currentUrl = params.url;
 
-  // Validate the initial URL's resolved IP
-  try {
-    const initialHost = new URL(currentUrl).hostname;
-    await resolveAndValidateIP(initialHost, resolveFn);
-  } catch {
+  if (!isUrlAllowed(currentUrl, params.allowHosts)) {
     throw new Error(`Initial download URL blocked: ${currentUrl}`);
+  }
+
+  if (resolveFn) {
+    try {
+      const initialHost = new URL(currentUrl).hostname;
+      await resolveAndValidateIP(initialHost, resolveFn);
+    } catch {
+      throw new Error(`Initial download URL blocked: ${currentUrl}`);
+    }
   }
 
   for (let i = 0; i <= MAX_SAFE_REDIRECTS; i++) {
@@ -369,8 +380,10 @@ export async function safeFetch(params: {
     }
 
     // Validate redirect target's resolved IP
-    const redirectHost = new URL(redirectUrl).hostname;
-    await resolveAndValidateIP(redirectHost, resolveFn);
+    if (resolveFn) {
+      const redirectHost = new URL(redirectUrl).hostname;
+      await resolveAndValidateIP(redirectHost, resolveFn);
+    }
 
     currentUrl = redirectUrl;
   }

--- a/extensions/msteams/src/errors.test.ts
+++ b/extensions/msteams/src/errors.test.ts
@@ -3,6 +3,7 @@ import {
   classifyMSTeamsSendError,
   formatMSTeamsSendErrorHint,
   formatUnknownError,
+  isRevokedProxyError,
 } from "./errors.js";
 
 describe("msteams errors", () => {
@@ -41,5 +42,29 @@ describe("msteams errors", () => {
   it("provides actionable hints for common cases", () => {
     expect(formatMSTeamsSendErrorHint({ kind: "auth" })).toContain("msteams");
     expect(formatMSTeamsSendErrorHint({ kind: "throttled" })).toContain("throttled");
+  });
+
+  describe("isRevokedProxyError", () => {
+    it("returns true for revoked proxy TypeError", () => {
+      expect(
+        isRevokedProxyError(new TypeError("Cannot perform 'set' on a proxy that has been revoked")),
+      ).toBe(true);
+      expect(
+        isRevokedProxyError(new TypeError("Cannot perform 'get' on a proxy that has been revoked")),
+      ).toBe(true);
+    });
+
+    it("returns false for non-TypeError errors", () => {
+      expect(isRevokedProxyError(new Error("proxy that has been revoked"))).toBe(false);
+    });
+
+    it("returns false for unrelated TypeErrors", () => {
+      expect(isRevokedProxyError(new TypeError("undefined is not a function"))).toBe(false);
+    });
+
+    it("returns false for non-error values", () => {
+      expect(isRevokedProxyError(null)).toBe(false);
+      expect(isRevokedProxyError("proxy that has been revoked")).toBe(false);
+    });
   });
 });

--- a/extensions/msteams/src/errors.ts
+++ b/extensions/msteams/src/errors.ts
@@ -174,6 +174,21 @@ export function classifyMSTeamsSendError(err: unknown): MSTeamsSendErrorClassifi
   };
 }
 
+/**
+ * Detect whether an error is caused by a revoked Proxy.
+ *
+ * The Bot Framework SDK wraps TurnContext in a Proxy that is revoked once the
+ * turn handler returns.  Any later access (e.g. from a debounced callback)
+ * throws a TypeError whose message contains the distinctive "proxy that has
+ * been revoked" string.
+ */
+export function isRevokedProxyError(err: unknown): boolean {
+  if (!(err instanceof TypeError)) {
+    return false;
+  }
+  return /proxy that has been revoked/i.test(err.message);
+}
+
 export function formatMSTeamsSendErrorHint(
   classification: MSTeamsSendErrorClassification,
 ): string | undefined {

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -293,6 +293,38 @@ describe("msteams messenger", () => {
       ).rejects.toMatchObject({ statusCode: 400 });
     });
 
+    it("falls back to proactive messaging when thread context is revoked", async () => {
+      const proactiveSent: string[] = [];
+
+      const ctx = {
+        sendActivity: async () => {
+          throw new TypeError("Cannot perform 'set' on a proxy that has been revoked");
+        },
+      };
+
+      const adapter: MSTeamsAdapter = {
+        continueConversation: async (_appId, _reference, logic) => {
+          await logic({
+            sendActivity: createRecordedSendActivity(proactiveSent),
+          });
+        },
+        process: async () => {},
+      };
+
+      const ids = await sendMSTeamsMessages({
+        replyStyle: "thread",
+        adapter,
+        appId: "app123",
+        conversationRef: baseRef,
+        context: ctx,
+        messages: [{ text: "hello" }],
+      });
+
+      // Should have fallen back to proactive messaging
+      expect(proactiveSent).toEqual(["hello"]);
+      expect(ids).toEqual(["id:hello"]);
+    });
+
     it("retries top-level sends on transient (5xx)", async () => {
       const attempts: string[] = [];
 

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -325,6 +325,47 @@ describe("msteams messenger", () => {
       expect(ids).toEqual(["id:hello"]);
     });
 
+    it("falls back only for remaining thread messages after context revocation", async () => {
+      const threadSent: string[] = [];
+      const proactiveSent: string[] = [];
+      let attempt = 0;
+
+      const ctx = {
+        sendActivity: async (activity: unknown) => {
+          const { text } = activity as { text?: string };
+          const content = text ?? "";
+          attempt += 1;
+          if (attempt === 1) {
+            threadSent.push(content);
+            return { id: `id:${content}` };
+          }
+          throw new TypeError("Cannot perform 'set' on a proxy that has been revoked");
+        },
+      };
+
+      const adapter: MSTeamsAdapter = {
+        continueConversation: async (_appId, _reference, logic) => {
+          await logic({
+            sendActivity: createRecordedSendActivity(proactiveSent),
+          });
+        },
+        process: async () => {},
+      };
+
+      const ids = await sendMSTeamsMessages({
+        replyStyle: "thread",
+        adapter,
+        appId: "app123",
+        conversationRef: baseRef,
+        context: ctx,
+        messages: [{ text: "one" }, { text: "two" }, { text: "three" }],
+      });
+
+      expect(threadSent).toEqual(["one"]);
+      expect(proactiveSent).toEqual(["two", "three"]);
+      expect(ids).toEqual(["id:one", "id:two", "id:three"]);
+    });
+
     it("retries top-level sends on transient (5xx)", async () => {
       const attempts: string[] = [];
 

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -441,9 +441,13 @@ export async function sendMSTeamsMessages(params: {
     }
   };
 
-  const sendMessagesInContext = async (ctx: SendContext): Promise<string[]> => {
+  const sendMessagesInContext = async (
+    ctx: SendContext,
+    batch: MSTeamsRenderedMessage[] = messages,
+    offset = 0,
+  ): Promise<string[]> => {
     const messageIds: string[] = [];
-    for (const [idx, message] of messages.entries()) {
+    for (const [idx, message] of batch.entries()) {
       const response = await sendWithRetry(
         async () =>
           await ctx.sendActivity(
@@ -455,10 +459,27 @@ export async function sendMSTeamsMessages(params: {
               params.mediaMaxBytes,
             ),
           ),
-        { messageIndex: idx, messageCount: messages.length },
+        { messageIndex: offset + idx, messageCount: messages.length },
       );
       messageIds.push(extractMessageId(response) ?? "unknown");
     }
+    return messageIds;
+  };
+
+  const sendProactively = async (
+    batch: MSTeamsRenderedMessage[] = messages,
+    offset = 0,
+  ): Promise<string[]> => {
+    const baseRef = buildConversationReference(params.conversationRef);
+    const proactiveRef: MSTeamsConversationReference = {
+      ...baseRef,
+      activityId: undefined,
+    };
+
+    const messageIds: string[] = [];
+    await params.adapter.continueConversation(params.appId, proactiveRef, async (ctx) => {
+      messageIds.push(...(await sendMessagesInContext(ctx, batch, offset)));
+    });
     return messageIds;
   };
 
@@ -467,26 +488,23 @@ export async function sendMSTeamsMessages(params: {
     if (!ctx) {
       throw new Error("Missing context for replyStyle=thread");
     }
-    try {
-      return await sendMessagesInContext(ctx);
-    } catch (err) {
-      if (!isRevokedProxyError(err)) {
-        throw err;
+    const messageIds: string[] = [];
+    for (const [idx, message] of messages.entries()) {
+      try {
+        messageIds.push(...(await sendMessagesInContext(ctx, [message], idx)));
+      } catch (err) {
+        if (!isRevokedProxyError(err)) {
+          throw err;
+        }
+        const remaining = messages.slice(idx);
+        if (remaining.length > 0) {
+          messageIds.push(...(await sendProactively(remaining, idx)));
+        }
+        return messageIds;
       }
-      // Turn context revoked (debounced message) — fall back to proactive
-      // messaging so the reply still reaches the user.
     }
+    return messageIds;
   }
 
-  const baseRef = buildConversationReference(params.conversationRef);
-  const proactiveRef: MSTeamsConversationReference = {
-    ...baseRef,
-    activityId: undefined,
-  };
-
-  const messageIds: string[] = [];
-  await params.adapter.continueConversation(params.appId, proactiveRef, async (ctx) => {
-    messageIds.push(...(await sendMessagesInContext(ctx)));
-  });
-  return messageIds;
+  return await sendProactively(messages, 0);
 }

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -10,7 +10,7 @@ import {
 } from "remoteclaw/plugin-sdk";
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 import type { StoredConversationReference } from "./conversation-store.js";
-import { classifyMSTeamsSendError, isRevokedProxyError } from "./errors.js";
+import { classifyMSTeamsSendError } from "./errors.js";
 import { prepareFileConsentActivity, requiresFileConsent } from "./file-consent-helpers.js";
 import { buildTeamsFileInfoCard } from "./graph-chat.js";
 import {
@@ -20,6 +20,7 @@ import {
 } from "./graph-upload.js";
 import { extractFilename, extractMessageId, getMimeType, isLocalPath } from "./media-helpers.js";
 import { parseMentions } from "./mentions.js";
+import { withRevokedProxyFallback } from "./revoked-context.js";
 import { getMSTeamsRuntime } from "./runtime.js";
 
 /**
@@ -441,34 +442,42 @@ export async function sendMSTeamsMessages(params: {
     }
   };
 
-  const sendMessagesInContext = async (
+  const sendMessageInContext = async (
     ctx: SendContext,
-    batch: MSTeamsRenderedMessage[] = messages,
-    offset = 0,
+    message: MSTeamsRenderedMessage,
+    messageIndex: number,
+  ): Promise<string> => {
+    const response = await sendWithRetry(
+      async () =>
+        await ctx.sendActivity(
+          await buildActivity(
+            message,
+            params.conversationRef,
+            params.tokenProvider,
+            params.sharePointSiteId,
+            params.mediaMaxBytes,
+          ),
+        ),
+      { messageIndex, messageCount: messages.length },
+    );
+    return extractMessageId(response) ?? "unknown";
+  };
+
+  const sendMessageBatchInContext = async (
+    ctx: SendContext,
+    batch: MSTeamsRenderedMessage[],
+    startIndex: number,
   ): Promise<string[]> => {
     const messageIds: string[] = [];
     for (const [idx, message] of batch.entries()) {
-      const response = await sendWithRetry(
-        async () =>
-          await ctx.sendActivity(
-            await buildActivity(
-              message,
-              params.conversationRef,
-              params.tokenProvider,
-              params.sharePointSiteId,
-              params.mediaMaxBytes,
-            ),
-          ),
-        { messageIndex: offset + idx, messageCount: messages.length },
-      );
-      messageIds.push(extractMessageId(response) ?? "unknown");
+      messageIds.push(await sendMessageInContext(ctx, message, startIndex + idx));
     }
     return messageIds;
   };
 
   const sendProactively = async (
-    batch: MSTeamsRenderedMessage[] = messages,
-    offset = 0,
+    batch: MSTeamsRenderedMessage[],
+    startIndex: number,
   ): Promise<string[]> => {
     const baseRef = buildConversationReference(params.conversationRef);
     const proactiveRef: MSTeamsConversationReference = {
@@ -478,7 +487,7 @@ export async function sendMSTeamsMessages(params: {
 
     const messageIds: string[] = [];
     await params.adapter.continueConversation(params.appId, proactiveRef, async (ctx) => {
-      messageIds.push(...(await sendMessagesInContext(ctx, batch, offset)));
+      messageIds.push(...(await sendMessageBatchInContext(ctx, batch, startIndex)));
     });
     return messageIds;
   };
@@ -490,16 +499,21 @@ export async function sendMSTeamsMessages(params: {
     }
     const messageIds: string[] = [];
     for (const [idx, message] of messages.entries()) {
-      try {
-        messageIds.push(...(await sendMessagesInContext(ctx, [message], idx)));
-      } catch (err) {
-        if (!isRevokedProxyError(err)) {
-          throw err;
-        }
-        const remaining = messages.slice(idx);
-        if (remaining.length > 0) {
-          messageIds.push(...(await sendProactively(remaining, idx)));
-        }
+      const result = await withRevokedProxyFallback({
+        run: async () => ({
+          ids: [await sendMessageInContext(ctx, message, idx)],
+          fellBack: false,
+        }),
+        onRevoked: async () => {
+          const remaining = messages.slice(idx);
+          return {
+            ids: remaining.length > 0 ? await sendProactively(remaining, idx) : [],
+            fellBack: true,
+          };
+        },
+      });
+      messageIds.push(...result.ids);
+      if (result.fellBack) {
         return messageIds;
       }
     }

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -10,7 +10,7 @@ import {
 } from "remoteclaw/plugin-sdk";
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 import type { StoredConversationReference } from "./conversation-store.js";
-import { classifyMSTeamsSendError } from "./errors.js";
+import { classifyMSTeamsSendError, isRevokedProxyError } from "./errors.js";
 import { prepareFileConsentActivity, requiresFileConsent } from "./file-consent-helpers.js";
 import { buildTeamsFileInfoCard } from "./graph-chat.js";
 import {
@@ -467,7 +467,15 @@ export async function sendMSTeamsMessages(params: {
     if (!ctx) {
       throw new Error("Missing context for replyStyle=thread");
     }
-    return await sendMessagesInContext(ctx);
+    try {
+      return await sendMessagesInContext(ctx);
+    } catch (err) {
+      if (!isRevokedProxyError(err)) {
+        throw err;
+      }
+      // Turn context revoked (debounced message) — fall back to proactive
+      // messaging so the reply still reaches the user.
+    }
   }
 
   const baseRef = buildConversationReference(params.conversationRef);

--- a/extensions/msteams/src/monitor-handler.file-consent.test.ts
+++ b/extensions/msteams/src/monitor-handler.file-consent.test.ts
@@ -155,10 +155,7 @@ describe("msteams file consent invoke authz", () => {
       }),
     );
 
-    // Wait for async upload to complete
-    await vi.waitFor(() => {
-      expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledTimes(1);
-    });
+    expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledTimes(1);
 
     expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -192,12 +189,9 @@ describe("msteams file consent invoke authz", () => {
       }),
     );
 
-    // Wait for async handler to complete
-    await vi.waitFor(() => {
-      expect(sendActivity).toHaveBeenCalledWith(
-        "The file upload request has expired. Please try sending the file again.",
-      );
-    });
+    expect(sendActivity).toHaveBeenCalledWith(
+      "The file upload request has expired. Please try sending the file again.",
+    );
 
     expect(fileConsentMockState.uploadToConsentUrl).not.toHaveBeenCalled();
     expect(getPendingUpload(uploadId)).toBeDefined();

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -7,6 +7,7 @@ import { createMSTeamsMessageHandler } from "./monitor-handler/message-handler.j
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
 import { getPendingUpload, removePendingUpload } from "./pending-uploads.js";
 import type { MSTeamsPollStore } from "./polls.js";
+import { withRevokedProxyFallback } from "./revoked-context.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 
 export type MSTeamsAccessTokenProvider = {
@@ -146,10 +147,19 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
         // Send invoke response IMMEDIATELY to prevent Teams timeout
         await ctx.sendActivity({ type: "invokeResponse", value: { status: 200 } });
 
-        // Handle file upload asynchronously (don't await)
-        handleFileConsentInvoke(ctx, deps.log).catch((err) => {
+        try {
+          await withRevokedProxyFallback({
+            run: async () => await handleFileConsentInvoke(ctx, deps.log),
+            onRevoked: async () => true,
+            onRevokedLog: () => {
+              deps.log.debug?.(
+                "turn context revoked during file consent invoke; skipping delayed response",
+              );
+            },
+          });
+        } catch (err) {
           deps.log.debug?.("file consent handler error", { error: String(err) });
-        });
+        }
         return;
       }
       return originalRun.call(handler, context);

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -78,7 +78,7 @@ const loadMSTeamsSdkWithAuth = vi.hoisted(() =>
 );
 
 vi.mock("./monitor-handler.js", () => ({
-  registerMSTeamsHandlers: (...args: unknown[]) => registerMSTeamsHandlers(...args),
+  registerMSTeamsHandlers: () => registerMSTeamsHandlers(),
 }));
 
 vi.mock("./resolve-allowlist.js", () => ({
@@ -87,8 +87,8 @@ vi.mock("./resolve-allowlist.js", () => ({
 }));
 
 vi.mock("./sdk.js", () => ({
-  createMSTeamsAdapter: (...args: unknown[]) => createMSTeamsAdapter(...args),
-  loadMSTeamsSdkWithAuth: (...args: unknown[]) => loadMSTeamsSdkWithAuth(...args),
+  createMSTeamsAdapter: () => createMSTeamsAdapter(),
+  loadMSTeamsSdkWithAuth: () => loadMSTeamsSdkWithAuth(),
 }));
 
 vi.mock("./runtime.js", () => ({

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -1,0 +1,190 @@
+import { EventEmitter } from "node:events";
+import type { OpenClawConfig, RuntimeEnv } from "openclaw/plugin-sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MSTeamsConversationStore } from "./conversation-store.js";
+import type { MSTeamsPollStore } from "./polls.js";
+
+type FakeServer = EventEmitter & {
+  close: (callback?: (err?: Error | null) => void) => void;
+};
+
+const expressControl = vi.hoisted(() => ({
+  mode: { value: "listening" as "listening" | "error" },
+}));
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  DEFAULT_WEBHOOK_MAX_BODY_BYTES: 1024 * 1024,
+  mergeAllowlist: (params: { existing?: string[]; additions?: string[] }) =>
+    Array.from(new Set([...(params.existing ?? []), ...(params.additions ?? [])])),
+  summarizeMapping: vi.fn(),
+}));
+
+vi.mock("express", () => {
+  const json = vi.fn(() => {
+    return (_req: unknown, _res: unknown, next?: (err?: unknown) => void) => {
+      next?.();
+    };
+  });
+
+  const factory = () => ({
+    use: vi.fn(),
+    post: vi.fn(),
+    listen: vi.fn((_port: number) => {
+      const server = new EventEmitter() as FakeServer;
+      server.close = (callback?: (err?: Error | null) => void) => {
+        queueMicrotask(() => {
+          server.emit("close");
+          callback?.(null);
+        });
+      };
+      queueMicrotask(() => {
+        if (expressControl.mode.value === "error") {
+          server.emit("error", new Error("listen EADDRINUSE"));
+          return;
+        }
+        server.emit("listening");
+      });
+      return server;
+    }),
+  });
+
+  return {
+    default: factory,
+    json,
+  };
+});
+
+const registerMSTeamsHandlers = vi.hoisted(() =>
+  vi.fn(() => ({
+    run: vi.fn(async () => {}),
+  })),
+);
+const createMSTeamsAdapter = vi.hoisted(() =>
+  vi.fn(() => ({
+    process: vi.fn(async () => {}),
+  })),
+);
+const loadMSTeamsSdkWithAuth = vi.hoisted(() =>
+  vi.fn(async () => ({
+    sdk: {
+      ActivityHandler: class {},
+      MsalTokenProvider: class {},
+      authorizeJWT:
+        () => (_req: unknown, _res: unknown, next: ((err?: unknown) => void) | undefined) =>
+          next?.(),
+    },
+    authConfig: {},
+  })),
+);
+
+vi.mock("./monitor-handler.js", () => ({
+  registerMSTeamsHandlers: (...args: unknown[]) => registerMSTeamsHandlers(...args),
+}));
+
+vi.mock("./resolve-allowlist.js", () => ({
+  resolveMSTeamsChannelAllowlist: vi.fn(async () => []),
+  resolveMSTeamsUserAllowlist: vi.fn(async () => []),
+}));
+
+vi.mock("./sdk.js", () => ({
+  createMSTeamsAdapter: (...args: unknown[]) => createMSTeamsAdapter(...args),
+  loadMSTeamsSdkWithAuth: (...args: unknown[]) => loadMSTeamsSdkWithAuth(...args),
+}));
+
+vi.mock("./runtime.js", () => ({
+  getMSTeamsRuntime: () => ({
+    logging: {
+      getChildLogger: () => ({
+        info: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      }),
+    },
+    channel: {
+      text: {
+        resolveTextChunkLimit: () => 4000,
+      },
+    },
+  }),
+}));
+
+import { monitorMSTeamsProvider } from "./monitor.js";
+
+function createConfig(port: number): OpenClawConfig {
+  return {
+    channels: {
+      msteams: {
+        enabled: true,
+        appId: "app-id",
+        appPassword: "app-password",
+        tenantId: "tenant-id",
+        webhook: {
+          port,
+          path: "/api/messages",
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+function createRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: (code: number): never => {
+      throw new Error(`exit ${code}`);
+    },
+  };
+}
+
+function createStores() {
+  return {
+    conversationStore: {} as MSTeamsConversationStore,
+    pollStore: {} as MSTeamsPollStore,
+  };
+}
+
+describe("monitorMSTeamsProvider lifecycle", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    expressControl.mode.value = "listening";
+  });
+
+  it("stays active until aborted", async () => {
+    const abort = new AbortController();
+    const stores = createStores();
+    const task = monitorMSTeamsProvider({
+      cfg: createConfig(0),
+      runtime: createRuntime(),
+      abortSignal: abort.signal,
+      conversationStore: stores.conversationStore,
+      pollStore: stores.pollStore,
+    });
+
+    const early = await Promise.race([
+      task.then(() => "resolved"),
+      new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 50)),
+    ]);
+    expect(early).toBe("pending");
+
+    abort.abort();
+    await expect(task).resolves.toEqual(
+      expect.objectContaining({
+        shutdown: expect.any(Function),
+      }),
+    );
+  });
+
+  it("rejects startup when webhook port is already in use", async () => {
+    expressControl.mode.value = "error";
+    await expect(
+      monitorMSTeamsProvider({
+        cfg: createConfig(3978),
+        runtime: createRuntime(),
+        abortSignal: new AbortController().signal,
+        conversationStore: createStores().conversationStore,
+        pollStore: createStores().pollStore,
+      }),
+    ).rejects.toThrow(/EADDRINUSE/);
+  });
+});

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -6,6 +6,9 @@ import type { MSTeamsPollStore } from "./polls.js";
 
 type FakeServer = EventEmitter & {
   close: (callback?: (err?: Error | null) => void) => void;
+  setTimeout: (msecs: number) => FakeServer;
+  requestTimeout: number;
+  headersTimeout: number;
 };
 
 const expressControl = vi.hoisted(() => ({
@@ -14,6 +17,18 @@ const expressControl = vi.hoisted(() => ({
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_WEBHOOK_MAX_BODY_BYTES: 1024 * 1024,
+  keepHttpServerTaskAlive: vi.fn(
+    async (params: { abortSignal?: AbortSignal; onAbort?: () => Promise<void> | void }) => {
+      await new Promise<void>((resolve) => {
+        if (params.abortSignal?.aborted) {
+          resolve();
+          return;
+        }
+        params.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      await params.onAbort?.();
+    },
+  ),
   mergeAllowlist: (params: { existing?: string[]; additions?: string[] }) =>
     Array.from(new Set([...(params.existing ?? []), ...(params.additions ?? [])])),
   summarizeMapping: vi.fn(),
@@ -31,6 +46,9 @@ vi.mock("express", () => {
     post: vi.fn(),
     listen: vi.fn((_port: number) => {
       const server = new EventEmitter() as FakeServer;
+      server.setTimeout = vi.fn((_msecs: number) => server);
+      server.requestTimeout = 0;
+      server.headersTimeout = 0;
       server.close = (callback?: (err?: Error | null) => void) => {
         queueMicrotask(() => {
           server.emit("close");

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import type { OpenClawConfig, RuntimeEnv } from "openclaw/plugin-sdk";
+import type { RemoteClawConfig, RuntimeEnv } from "remoteclaw/plugin-sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MSTeamsConversationStore } from "./conversation-store.js";
 import type { MSTeamsPollStore } from "./polls.js";
@@ -15,7 +15,7 @@ const expressControl = vi.hoisted(() => ({
   mode: { value: "listening" as "listening" | "error" },
 }));
 
-vi.mock("openclaw/plugin-sdk", () => ({
+vi.mock("remoteclaw/plugin-sdk", () => ({
   DEFAULT_WEBHOOK_MAX_BODY_BYTES: 1024 * 1024,
   keepHttpServerTaskAlive: vi.fn(
     async (params: { abortSignal?: AbortSignal; onAbort?: () => Promise<void> | void }) => {
@@ -128,7 +128,7 @@ vi.mock("./runtime.js", () => ({
 
 import { monitorMSTeamsProvider } from "./monitor.js";
 
-function createConfig(port: number): OpenClawConfig {
+function createConfig(port: number): RemoteClawConfig {
   return {
     channels: {
       msteams: {
@@ -142,7 +142,7 @@ function createConfig(port: number): OpenClawConfig {
         },
       },
     },
-  } as OpenClawConfig;
+  } as RemoteClawConfig;
 }
 
 function createRuntime(): RuntimeEnv {

--- a/extensions/msteams/src/monitor.test.ts
+++ b/extensions/msteams/src/monitor.test.ts
@@ -1,0 +1,85 @@
+import { once } from "node:events";
+import type { Server } from "node:http";
+import { createConnection, type AddressInfo } from "node:net";
+import express from "express";
+import { describe, expect, it } from "vitest";
+import { applyMSTeamsWebhookTimeouts } from "./monitor.js";
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+async function waitForSlowBodySocketClose(port: number, timeoutMs: number): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const startedAt = Date.now();
+    const socket = createConnection({ host: "127.0.0.1", port }, () => {
+      socket.write("POST /api/messages HTTP/1.1\r\n");
+      socket.write("Host: localhost\r\n");
+      socket.write("Content-Type: application/json\r\n");
+      socket.write("Content-Length: 1048576\r\n");
+      socket.write("\r\n");
+      socket.write('{"type":"message"');
+    });
+    socket.on("error", () => {
+      // ECONNRESET is expected once the server drops the socket.
+    });
+    const failTimer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`socket stayed open for ${timeoutMs}ms`));
+    }, timeoutMs);
+    socket.on("close", () => {
+      clearTimeout(failTimer);
+      resolve(Date.now() - startedAt);
+    });
+  });
+}
+
+describe("msteams monitor webhook hardening", () => {
+  it("applies explicit webhook timeout values", async () => {
+    const app = express();
+    const server = app.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    try {
+      applyMSTeamsWebhookTimeouts(server, {
+        inactivityTimeoutMs: 3210,
+        requestTimeoutMs: 6543,
+        headersTimeoutMs: 9876,
+      });
+
+      expect(server.timeout).toBe(3210);
+      expect(server.requestTimeout).toBe(6543);
+      expect(server.headersTimeout).toBe(6543);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("drops slow-body webhook requests within configured inactivity timeout", async () => {
+    const app = express();
+    app.use(express.json({ limit: "1mb" }));
+    app.use((_req, res, _next) => {
+      res.status(401).end("unauthorized");
+    });
+    app.post("/api/messages", (_req, res) => {
+      res.end("ok");
+    });
+
+    const server = app.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    try {
+      applyMSTeamsWebhookTimeouts(server, {
+        inactivityTimeoutMs: 400,
+        requestTimeoutMs: 1500,
+        headersTimeoutMs: 1500,
+      });
+
+      const port = (server.address() as AddressInfo).port;
+      const closedMs = await waitForSlowBodySocketClose(port, 3000);
+      expect(closedMs).toBeLessThan(2500);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -1,3 +1,4 @@
+import type { Server } from "node:http";
 import type { Request, Response } from "express";
 import {
   DEFAULT_WEBHOOK_MAX_BODY_BYTES,
@@ -34,6 +35,31 @@ export type MonitorMSTeamsResult = {
 };
 
 const MSTEAMS_WEBHOOK_MAX_BODY_BYTES = DEFAULT_WEBHOOK_MAX_BODY_BYTES;
+const MSTEAMS_WEBHOOK_INACTIVITY_TIMEOUT_MS = 30_000;
+const MSTEAMS_WEBHOOK_REQUEST_TIMEOUT_MS = 30_000;
+const MSTEAMS_WEBHOOK_HEADERS_TIMEOUT_MS = 15_000;
+
+export type ApplyMSTeamsWebhookTimeoutsOpts = {
+  inactivityTimeoutMs?: number;
+  requestTimeoutMs?: number;
+  headersTimeoutMs?: number;
+};
+
+export function applyMSTeamsWebhookTimeouts(
+  httpServer: Server,
+  opts?: ApplyMSTeamsWebhookTimeoutsOpts,
+): void {
+  const inactivityTimeoutMs = opts?.inactivityTimeoutMs ?? MSTEAMS_WEBHOOK_INACTIVITY_TIMEOUT_MS;
+  const requestTimeoutMs = opts?.requestTimeoutMs ?? MSTEAMS_WEBHOOK_REQUEST_TIMEOUT_MS;
+  const headersTimeoutMs = Math.min(
+    opts?.headersTimeoutMs ?? MSTEAMS_WEBHOOK_HEADERS_TIMEOUT_MS,
+    requestTimeoutMs,
+  );
+
+  httpServer.setTimeout(inactivityTimeoutMs);
+  httpServer.requestTimeout = requestTimeoutMs;
+  httpServer.headersTimeout = headersTimeoutMs;
+}
 
 export async function monitorMSTeamsProvider(
   opts: MonitorMSTeamsOpts,
@@ -289,6 +315,7 @@ export async function monitorMSTeamsProvider(
     httpServer.once("listening", onListening);
     httpServer.once("error", onError);
   });
+  applyMSTeamsWebhookTimeouts(httpServer);
 
   httpServer.on("error", (err) => {
     log.error("msteams server error", { error: String(err) });

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -2,6 +2,7 @@ import type { Server } from "node:http";
 import type { Request, Response } from "express";
 import {
   DEFAULT_WEBHOOK_MAX_BODY_BYTES,
+  keepHttpServerTaskAlive,
   mergeAllowlist,
   summarizeMapping,
   type RemoteClawConfig,
@@ -333,25 +334,12 @@ export async function monitorMSTeamsProvider(
     });
   };
 
-  // Handle abort signal
-  const onAbort = () => {
-    void shutdown();
-  };
-  if (opts.abortSignal) {
-    if (opts.abortSignal.aborted) {
-      onAbort();
-    } else {
-      opts.abortSignal.addEventListener("abort", onAbort, { once: true });
-    }
-  }
-
-  // Keep this task alive until shutdown/close so gateway runtime does not treat startup as exit.
-  await new Promise<void>((resolve) => {
-    httpServer.once("close", () => {
-      resolve();
-    });
+  // Keep this task alive until close so gateway runtime does not treat startup as exit.
+  await keepHttpServerTaskAlive({
+    server: httpServer,
+    abortSignal: opts.abortSignal,
+    onAbort: shutdown,
   });
-  opts.abortSignal?.removeEventListener("abort", onAbort);
 
   return { app: expressApp, shutdown };
 }

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -13,7 +13,6 @@ import {
   classifyMSTeamsSendError,
   formatMSTeamsSendErrorHint,
   formatUnknownError,
-  isRevokedProxyError,
 } from "./errors.js";
 import {
   buildConversationReference,
@@ -22,6 +21,7 @@ import {
   sendMSTeamsMessages,
 } from "./messenger.js";
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
+import { withRevokedProxyFallback } from "./revoked-context.js";
 import { getMSTeamsRuntime } from "./runtime.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 
@@ -53,23 +53,24 @@ export function createMSTeamsReplyDispatcher(params: {
    * the stored conversation reference so the user still sees the "…" bubble.
    */
   const sendTypingIndicator = async () => {
-    try {
-      await params.context.sendActivity({ type: "typing" });
-    } catch (err) {
-      if (!isRevokedProxyError(err)) {
-        throw err;
-      }
-      // Turn context revoked — fall back to proactive typing.
-      params.log.debug?.("turn context revoked, sending typing via proactive messaging");
-      const baseRef = buildConversationReference(params.conversationRef);
-      await params.adapter.continueConversation(
-        params.appId,
-        { ...baseRef, activityId: undefined },
-        async (ctx) => {
-          await ctx.sendActivity({ type: "typing" });
-        },
-      );
-    }
+    await withRevokedProxyFallback({
+      run: async () => {
+        await params.context.sendActivity({ type: "typing" });
+      },
+      onRevoked: async () => {
+        const baseRef = buildConversationReference(params.conversationRef);
+        await params.adapter.continueConversation(
+          params.appId,
+          { ...baseRef, activityId: undefined },
+          async (ctx) => {
+            await ctx.sendActivity({ type: "typing" });
+          },
+        );
+      },
+      onRevokedLog: () => {
+        params.log.debug?.("turn context revoked, sending typing via proactive messaging");
+      },
+    });
   };
 
   const typingCallbacks = createTypingCallbacks({

--- a/extensions/msteams/src/revoked-context.test.ts
+++ b/extensions/msteams/src/revoked-context.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { withRevokedProxyFallback } from "./revoked-context.js";
+
+describe("msteams revoked context helper", () => {
+  it("returns primary result when no error occurs", async () => {
+    await expect(
+      withRevokedProxyFallback({
+        run: async () => "ok",
+        onRevoked: async () => "fallback",
+      }),
+    ).resolves.toBe("ok");
+  });
+
+  it("uses fallback when proxy-revoked TypeError is thrown", async () => {
+    const onRevokedLog = vi.fn();
+    await expect(
+      withRevokedProxyFallback({
+        run: async () => {
+          throw new TypeError("Cannot perform 'get' on a proxy that has been revoked");
+        },
+        onRevoked: async () => "fallback",
+        onRevokedLog,
+      }),
+    ).resolves.toBe("fallback");
+    expect(onRevokedLog).toHaveBeenCalledOnce();
+  });
+
+  it("rethrows non-revoked errors", async () => {
+    const err = Object.assign(new Error("boom"), { statusCode: 500 });
+    await expect(
+      withRevokedProxyFallback({
+        run: async () => {
+          throw err;
+        },
+        onRevoked: async () => "fallback",
+      }),
+    ).rejects.toBe(err);
+  });
+});

--- a/extensions/msteams/src/revoked-context.ts
+++ b/extensions/msteams/src/revoked-context.ts
@@ -1,0 +1,17 @@
+import { isRevokedProxyError } from "./errors.js";
+
+export async function withRevokedProxyFallback<T>(params: {
+  run: () => Promise<T>;
+  onRevoked: () => Promise<T>;
+  onRevokedLog?: () => void;
+}): Promise<T> {
+  try {
+    return await params.run();
+  } catch (err) {
+    if (!isRevokedProxyError(err)) {
+      throw err;
+    }
+    params.onRevokedLog?.();
+    return await params.onRevoked();
+  }
+}

--- a/src/plugin-sdk/channel-lifecycle.test.ts
+++ b/src/plugin-sdk/channel-lifecycle.test.ts
@@ -1,0 +1,66 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { keepHttpServerTaskAlive, waitUntilAbort } from "./channel-lifecycle.js";
+
+type FakeServer = EventEmitter & {
+  close: (callback?: () => void) => void;
+};
+
+function createFakeServer(): FakeServer {
+  const server = new EventEmitter() as FakeServer;
+  server.close = (callback) => {
+    queueMicrotask(() => {
+      server.emit("close");
+      callback?.();
+    });
+  };
+  return server;
+}
+
+describe("plugin-sdk channel lifecycle helpers", () => {
+  it("resolves waitUntilAbort when signal aborts", async () => {
+    const abort = new AbortController();
+    const task = waitUntilAbort(abort.signal);
+
+    const early = await Promise.race([
+      task.then(() => "resolved"),
+      new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 25)),
+    ]);
+    expect(early).toBe("pending");
+
+    abort.abort();
+    await expect(task).resolves.toBeUndefined();
+  });
+
+  it("keeps server task pending until close, then resolves", async () => {
+    const server = createFakeServer();
+    const task = keepHttpServerTaskAlive({ server });
+
+    const early = await Promise.race([
+      task.then(() => "resolved"),
+      new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 25)),
+    ]);
+    expect(early).toBe("pending");
+
+    server.close();
+    await expect(task).resolves.toBeUndefined();
+  });
+
+  it("triggers abort hook once and resolves after close", async () => {
+    const server = createFakeServer();
+    const abort = new AbortController();
+    const onAbort = vi.fn(async () => {
+      server.close();
+    });
+
+    const task = keepHttpServerTaskAlive({
+      server,
+      abortSignal: abort.signal,
+      onAbort,
+    });
+
+    abort.abort();
+    await expect(task).resolves.toBeUndefined();
+    expect(onAbort).toHaveBeenCalledOnce();
+  });
+});

--- a/src/plugin-sdk/channel-lifecycle.ts
+++ b/src/plugin-sdk/channel-lifecycle.ts
@@ -1,0 +1,66 @@
+type CloseAwareServer = {
+  once: (event: "close", listener: () => void) => unknown;
+};
+
+/**
+ * Return a promise that resolves when the signal is aborted.
+ *
+ * If no signal is provided, the promise stays pending forever.
+ */
+export function waitUntilAbort(signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (!signal) {
+      return;
+    }
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    signal.addEventListener("abort", () => resolve(), { once: true });
+  });
+}
+
+/**
+ * Keep a channel/provider task pending until the HTTP server closes.
+ *
+ * When an abort signal is provided, `onAbort` is invoked once and should
+ * trigger server shutdown. The returned promise resolves only after `close`.
+ */
+export async function keepHttpServerTaskAlive(params: {
+  server: CloseAwareServer;
+  abortSignal?: AbortSignal;
+  onAbort?: () => void | Promise<void>;
+}): Promise<void> {
+  const { server, abortSignal, onAbort } = params;
+  let abortTask: Promise<void> = Promise.resolve();
+  let abortTriggered = false;
+
+  const triggerAbort = () => {
+    if (abortTriggered) {
+      return;
+    }
+    abortTriggered = true;
+    abortTask = Promise.resolve(onAbort?.()).then(() => undefined);
+  };
+
+  const onAbortSignal = () => {
+    triggerAbort();
+  };
+
+  if (abortSignal) {
+    if (abortSignal.aborted) {
+      triggerAbort();
+    } else {
+      abortSignal.addEventListener("abort", onAbortSignal, { once: true });
+    }
+  }
+
+  await new Promise<void>((resolve) => {
+    server.once("close", () => resolve());
+  });
+
+  if (abortSignal) {
+    abortSignal.removeEventListener("abort", onAbortSignal);
+  }
+  await abortTask;
+}

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -116,6 +116,7 @@ export {
   isJsonContentType,
   readJsonWebhookBodyOrReject,
 } from "./webhook-request-guards.js";
+export { keepHttpServerTaskAlive, waitUntilAbort } from "./channel-lifecycle.js";
 export type { AgentMediaPayload } from "./agent-media-payload.js";
 export { buildAgentMediaPayload } from "./agent-media-payload.js";
 export {


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #746
**Commits**: 11 cherry-picked, 1 skipped (CHANGELOG-only)

| Hash | Subject | Result |
|------|---------|--------|
| `c9d0e345c` | fix(msteams): keep monitor alive until shutdown | PICKED |
| `15677133c` | test(msteams): remove tuple-unsafe spread in lifecycle mocks | PICKED |
| `6945ba189` | msteams: harden webhook ingress timeouts | PICKED |
| `cceecc8bd` | msteams: enforce guarded redirect ownership in safeFetch | PICKED |
| `c582a5455` | fix(msteams): preserve guarded dispatcher redirects | RESOLVED |
| `8937c10f1` | fix(msteams): scope graph auth redirects | PICKED |
| `da22a9113` | test(msteams): cover auth stripping on graph redirect hops | PICKED |
| `4a414c5e5` | fix(msteams): scope auth across media redirects | PICKED |
| `d2bb04b43` | fix: document msteams auth redirect scoping hardening (#25045) | SKIPPED |
| `e0b91067e` | fix(msteams): add proactive fallback for revoked turn context | PICKED |
| `089a8785b` | fix: harden msteams revoked-context fallback delivery (#27224) | RESOLVED |
| `866bd91c6` | refactor: harden msteams lifecycle and attachment flows | RESOLVED |

**Adaptation**: `openclaw/plugin-sdk` → `remoteclaw/plugin-sdk` + `OpenClawConfig` → `RemoteClawConfig` in lifecycle test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)