### PR TITLE
Cherry-pick: WhatsApp adapter fixes (DM route guard, fromMe propagation)

### DIFF
--- a/src/auto-reply/envelope.test.ts
+++ b/src/auto-reply/envelope.test.ts
@@ -144,6 +144,29 @@ describe("formatInboundEnvelope", () => {
     expect(body).toBe("[Telegram Alice] follow-up message");
   });
 
+  it("prefixes DM body with (self) when fromMe is true", () => {
+    const body = formatInboundEnvelope({
+      channel: "WhatsApp",
+      from: "+1555",
+      body: "outbound msg",
+      chatType: "direct",
+      fromMe: true,
+    });
+    expect(body).toBe("[WhatsApp +1555] (self): outbound msg");
+  });
+
+  it("does not prefix group messages with (self) when fromMe is true", () => {
+    const body = formatInboundEnvelope({
+      channel: "WhatsApp",
+      from: "Family Chat",
+      body: "hello",
+      chatType: "group",
+      senderLabel: "Alice",
+      fromMe: true,
+    });
+    expect(body).toBe("[WhatsApp Family Chat] Alice: hello");
+  });
+
   it("resolves envelope options from config", () => {
     const options = resolveEnvelopeFormatOptions({
       agents: {

--- a/src/auto-reply/envelope.ts
+++ b/src/auto-reply/envelope.ts
@@ -197,12 +197,18 @@ export function formatInboundEnvelope(params: {
   sender?: SenderLabelParams;
   previousTimestamp?: number | Date;
   envelope?: EnvelopeFormatOptions;
+  fromMe?: boolean;
 }): string {
   const chatType = normalizeChatType(params.chatType);
   const isDirect = !chatType || chatType === "direct";
   const resolvedSenderRaw = params.senderLabel?.trim() || resolveSenderLabel(params.sender ?? {});
   const resolvedSender = resolvedSenderRaw ? sanitizeEnvelopeHeaderPart(resolvedSenderRaw) : "";
-  const body = !isDirect && resolvedSender ? `${resolvedSender}: ${params.body}` : params.body;
+  const body =
+    isDirect && params.fromMe
+      ? `(self): ${params.body}`
+      : !isDirect && resolvedSender
+        ? `${resolvedSender}: ${params.body}`
+        : params.body;
   return formatAgentEnvelope({
     channel: params.channel,
     from: params.from,

--- a/src/web/auto-reply/monitor/message-line.ts
+++ b/src/web/auto-reply/monitor/message-line.ts
@@ -43,5 +43,6 @@ export function buildInboundLine(params: {
     },
     previousTimestamp,
     envelope,
+    fromMe: msg.fromMe,
   });
 }

--- a/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
+++ b/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
@@ -351,4 +351,76 @@ describe("web processMessage inbound contract", () => {
 
     expect(updateLastRouteMock).not.toHaveBeenCalled();
   });
+
+  it("does not update main last route for non-owner sender when main DM scope is pinned", async () => {
+    const updateLastRouteMock = vi.mocked(updateLastRouteInBackground);
+    updateLastRouteMock.mockClear();
+
+    const args = makeProcessMessageArgs({
+      routeSessionKey: "agent:main:main",
+      groupHistoryKey: "+3000",
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: ["+1000"],
+          },
+        },
+        messages: {},
+        session: { store: sessionStorePath, dmScope: "main" },
+      } as unknown as ReturnType<typeof import("../../../config/config.js").loadConfig>,
+      msg: {
+        id: "msg-last-route-3",
+        from: "+3000",
+        to: "+2000",
+        chatType: "direct",
+        body: "hello",
+        senderE164: "+3000",
+      },
+    });
+    args.route = {
+      ...args.route,
+      sessionKey: "agent:main:main",
+      mainSessionKey: "agent:main:main",
+    };
+
+    await processMessage(args);
+
+    expect(updateLastRouteMock).not.toHaveBeenCalled();
+  });
+
+  it("updates main last route for owner sender when main DM scope is pinned", async () => {
+    const updateLastRouteMock = vi.mocked(updateLastRouteInBackground);
+    updateLastRouteMock.mockClear();
+
+    const args = makeProcessMessageArgs({
+      routeSessionKey: "agent:main:main",
+      groupHistoryKey: "+1000",
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: ["+1000"],
+          },
+        },
+        messages: {},
+        session: { store: sessionStorePath, dmScope: "main" },
+      } as unknown as ReturnType<typeof import("../../../config/config.js").loadConfig>,
+      msg: {
+        id: "msg-last-route-4",
+        from: "+1000",
+        to: "+2000",
+        chatType: "direct",
+        body: "hello",
+        senderE164: "+1000",
+      },
+    });
+    args.route = {
+      ...args.route,
+      sessionKey: "agent:main:main",
+      mainSessionKey: "agent:main:main",
+    };
+
+    await processMessage(args);
+
+    expect(updateLastRouteMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -107,6 +107,28 @@ async function resolveWhatsAppCommandAuthorized(params: {
   return access.commandAuthorized;
 }
 
+function resolvePinnedMainDmRecipient(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  msg: WebInboundMsg;
+}): string | null {
+  if ((params.cfg.session?.dmScope ?? "main") !== "main") {
+    return null;
+  }
+  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.msg.accountId });
+  const rawAllowFrom = account.allowFrom ?? [];
+  if (rawAllowFrom.includes("*")) {
+    return null;
+  }
+  const normalizedOwners = Array.from(
+    new Set(
+      rawAllowFrom
+        .map((entry) => normalizeE164(String(entry)))
+        .filter((entry): entry is string => Boolean(entry)),
+    ),
+  );
+  return normalizedOwners.length === 1 ? normalizedOwners[0] : null;
+}
+
 export async function processMessage(params: {
   cfg: ReturnType<typeof loadConfig>;
   msg: WebInboundMsg;
@@ -319,7 +341,17 @@ export async function processMessage(params: {
   // Only update main session's lastRoute when DM actually IS the main session.
   // When dmScope="per-channel-peer", the DM uses an isolated sessionKey,
   // and updating mainSessionKey would corrupt routing for the session owner.
-  if (dmRouteTarget && params.route.sessionKey === params.route.mainSessionKey) {
+  const pinnedMainDmRecipient = resolvePinnedMainDmRecipient({
+    cfg: params.cfg,
+    msg: params.msg,
+  });
+  const shouldUpdateMainLastRoute =
+    !pinnedMainDmRecipient || pinnedMainDmRecipient === dmRouteTarget;
+  if (
+    dmRouteTarget &&
+    params.route.sessionKey === params.route.mainSessionKey &&
+    shouldUpdateMainLastRoute
+  ) {
     updateLastRouteInBackground({
       cfg: params.cfg,
       backgroundTasks: params.backgroundTasks,
@@ -331,6 +363,14 @@ export async function processMessage(params: {
       ctx: ctxPayload,
       warn: params.replyLogger.warn.bind(params.replyLogger),
     });
+  } else if (
+    dmRouteTarget &&
+    params.route.sessionKey === params.route.mainSessionKey &&
+    pinnedMainDmRecipient
+  ) {
+    logVerbose(
+      `Skipping main-session last route update for ${dmRouteTarget} (pinned owner ${pinnedMainDmRecipient})`,
+    );
   }
 
   const metaTask = recordSessionMetaFromInbound({

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -323,6 +323,7 @@ export async function monitorWebInbox(options: {
         mentionedJids: mentionedJids ?? undefined,
         selfJid,
         selfE164,
+        fromMe: Boolean(msg.key?.fromMe),
         location: location ?? undefined,
         sendComposing,
         reply,

--- a/src/web/inbound/types.ts
+++ b/src/web/inbound/types.ts
@@ -31,6 +31,7 @@ export type WebInboundMessage = {
   mentionedJids?: string[];
   selfJid?: string | null;
   selfE164?: string | null;
+  fromMe?: boolean;
   location?: NormalizedLocation;
   sendComposing: () => Promise<void>;
   reply: (text: string) => Promise<void>;


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #751
**Commits**: 2 cherry-picked, 1 skipped (empty — CHANGELOG only)

| Hash | Subject | Result |
|------|---------|--------|
| `ab0b2c21f` | WhatsApp: guard main DM last-route to single owner | PICKED |
| `73e6dc361` | fix(whatsapp): propagate fromMe through inbound message pipeline | PICKED |
| `af637deed` | fix: propagate whatsapp inbound fromMe context (#32167) | SKIPPED (empty after CHANGELOG conflict — code changes already in 73e6dc361) |

Community: @scoootscooob

🤖 Generated with [Claude Code](https://claude.com/claude-code)