### PR TITLE
Cherry-pick batch: misc fixes (delivery, queue, Discord, voice-call, models, docs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,7 +93,7 @@ USER.md
 !.agent/workflows/
 /local/
 package-lock.json
-.claude/settings.local.json
+.claude/
 .agents/
 .agents
 .agent/

--- a/extensions/matrix/index.ts
+++ b/extensions/matrix/index.ts
@@ -1,6 +1,6 @@
 import type { RemoteClawPluginApi } from "remoteclaw/plugin-sdk";
 import { emptyPluginConfigSchema } from "remoteclaw/plugin-sdk";
-import { matrixPlugin } from "./src/channel.js";
+import { ensureMatrixCryptoRuntime } from "./src/matrix/deps.js";
 import { setMatrixRuntime } from "./src/runtime.js";
 
 const plugin = {
@@ -8,8 +8,10 @@ const plugin = {
   name: "Matrix",
   description: "Matrix channel plugin (matrix-js-sdk)",
   configSchema: emptyPluginConfigSchema(),
-  register(api: RemoteClawPluginApi) {
+  async register(api: RemoteClawPluginApi) {
     setMatrixRuntime(api.runtime);
+    await ensureMatrixCryptoRuntime();
+    const { matrixPlugin } = await import("./src/channel.js");
     api.registerChannel({ plugin: matrixPlugin });
   },
 };

--- a/extensions/matrix/src/matrix/client-bootstrap.ts
+++ b/extensions/matrix/src/matrix/client-bootstrap.ts
@@ -1,6 +1,6 @@
-import { LogService } from "@vector-im/matrix-bot-sdk";
 import { createMatrixClient } from "./client/create-client.js";
 import { startMatrixClientWithGrace } from "./client/startup.js";
+import { getMatrixLogService } from "./sdk-runtime.js";
 
 type MatrixClientBootstrapAuth = {
   homeserver: string;
@@ -39,6 +39,7 @@ export async function createPreparedMatrixClient(opts: {
   await startMatrixClientWithGrace({
     client,
     onError: (err: unknown) => {
+      const LogService = getMatrixLogService();
       LogService.error("MatrixClientBootstrap", "client.start() error:", err);
     },
   });

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -1,7 +1,7 @@
-import { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "remoteclaw/plugin-sdk/account-id";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { CoreConfig } from "../../types.js";
+import { loadMatrixSdk } from "../sdk-runtime.js";
 import { ensureMatrixSdkLoggingConfigured } from "./logging.js";
 import type { MatrixAuth, MatrixResolvedConfig } from "./types.js";
 
@@ -119,6 +119,7 @@ export async function resolveMatrixAuth(params?: {
     if (!userId) {
       // Fetch userId from access token via whoami
       ensureMatrixSdkLoggingConfigured();
+      const { MatrixClient } = loadMatrixSdk();
       const tempClient = new MatrixClient(resolved.homeserver, resolved.accessToken);
       const whoami = await tempClient.getUserId();
       userId = whoami;

--- a/extensions/matrix/src/matrix/client/create-client.ts
+++ b/extensions/matrix/src/matrix/client/create-client.ts
@@ -1,11 +1,10 @@
 import fs from "node:fs";
-import type { IStorageProvider, ICryptoStorageProvider } from "@vector-im/matrix-bot-sdk";
-import {
-  LogService,
+import type {
+  IStorageProvider,
+  ICryptoStorageProvider,
   MatrixClient,
-  SimpleFsStorageProvider,
-  RustSdkCryptoStorageProvider,
 } from "@vector-im/matrix-bot-sdk";
+import { loadMatrixSdk } from "../sdk-runtime.js";
 import { ensureMatrixSdkLoggingConfigured } from "./logging.js";
 import {
   maybeMigrateLegacyStorage,
@@ -14,6 +13,7 @@ import {
 } from "./storage.js";
 
 function sanitizeUserIdList(input: unknown, label: string): string[] {
+  const LogService = loadMatrixSdk().LogService;
   if (input == null) {
     return [];
   }
@@ -44,6 +44,8 @@ export async function createMatrixClient(params: {
   localTimeoutMs?: number;
   accountId?: string | null;
 }): Promise<MatrixClient> {
+  const { MatrixClient, SimpleFsStorageProvider, RustSdkCryptoStorageProvider, LogService } =
+    loadMatrixSdk();
   ensureMatrixSdkLoggingConfigured();
   const env = process.env;
 

--- a/extensions/matrix/src/matrix/client/logging.ts
+++ b/extensions/matrix/src/matrix/client/logging.ts
@@ -1,7 +1,15 @@
-import { ConsoleLogger, LogService } from "@vector-im/matrix-bot-sdk";
+import { loadMatrixSdk } from "../sdk-runtime.js";
 
 let matrixSdkLoggingConfigured = false;
-const matrixSdkBaseLogger = new ConsoleLogger();
+let matrixSdkBaseLogger:
+  | {
+      trace: (module: string, ...messageOrObject: unknown[]) => void;
+      debug: (module: string, ...messageOrObject: unknown[]) => void;
+      info: (module: string, ...messageOrObject: unknown[]) => void;
+      warn: (module: string, ...messageOrObject: unknown[]) => void;
+      error: (module: string, ...messageOrObject: unknown[]) => void;
+    }
+  | undefined;
 
 function shouldSuppressMatrixHttpNotFound(module: string, messageOrObject: unknown[]): boolean {
   if (module !== "MatrixHttpClient") {
@@ -19,18 +27,20 @@ export function ensureMatrixSdkLoggingConfigured(): void {
   if (matrixSdkLoggingConfigured) {
     return;
   }
+  const { ConsoleLogger, LogService } = loadMatrixSdk();
+  matrixSdkBaseLogger = new ConsoleLogger();
   matrixSdkLoggingConfigured = true;
 
   LogService.setLogger({
-    trace: (module, ...messageOrObject) => matrixSdkBaseLogger.trace(module, ...messageOrObject),
-    debug: (module, ...messageOrObject) => matrixSdkBaseLogger.debug(module, ...messageOrObject),
-    info: (module, ...messageOrObject) => matrixSdkBaseLogger.info(module, ...messageOrObject),
-    warn: (module, ...messageOrObject) => matrixSdkBaseLogger.warn(module, ...messageOrObject),
+    trace: (module, ...messageOrObject) => matrixSdkBaseLogger?.trace(module, ...messageOrObject),
+    debug: (module, ...messageOrObject) => matrixSdkBaseLogger?.debug(module, ...messageOrObject),
+    info: (module, ...messageOrObject) => matrixSdkBaseLogger?.info(module, ...messageOrObject),
+    warn: (module, ...messageOrObject) => matrixSdkBaseLogger?.warn(module, ...messageOrObject),
     error: (module, ...messageOrObject) => {
       if (shouldSuppressMatrixHttpNotFound(module, messageOrObject)) {
         return;
       }
-      matrixSdkBaseLogger.error(module, ...messageOrObject);
+      matrixSdkBaseLogger?.error(module, ...messageOrObject);
     },
   });
 }

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -1,7 +1,7 @@
 import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
-import { LogService } from "@vector-im/matrix-bot-sdk";
 import { normalizeAccountId } from "remoteclaw/plugin-sdk/account-id";
 import type { CoreConfig } from "../../types.js";
+import { getMatrixLogService } from "../sdk-runtime.js";
 import { resolveMatrixAuth } from "./config.js";
 import { createMatrixClient } from "./create-client.js";
 import { startMatrixClientWithGrace } from "./startup.js";
@@ -81,6 +81,7 @@ async function ensureSharedClientStarted(params: {
           params.state.cryptoReady = true;
         }
       } catch (err) {
+        const LogService = getMatrixLogService();
         LogService.warn("MatrixClientLite", "Failed to prepare crypto:", err);
       }
     }
@@ -89,6 +90,7 @@ async function ensureSharedClientStarted(params: {
       client,
       onError: (err: unknown) => {
         params.state.started = false;
+        const LogService = getMatrixLogService();
         LogService.error("MatrixClientLite", "client.start() error:", err);
       },
     });

--- a/extensions/matrix/src/matrix/deps.test.ts
+++ b/extensions/matrix/src/matrix/deps.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { ensureMatrixCryptoRuntime } from "./deps.js";
+
+const logStub = vi.fn();
+
+describe("ensureMatrixCryptoRuntime", () => {
+  it("returns immediately when matrix SDK loads", async () => {
+    const runCommand = vi.fn();
+    const requireFn = vi.fn(() => ({}));
+
+    await ensureMatrixCryptoRuntime({
+      log: logStub,
+      requireFn,
+      runCommand,
+      resolveFn: () => "/tmp/download-lib.js",
+      nodeExecutable: "/usr/bin/node",
+    });
+
+    expect(requireFn).toHaveBeenCalledTimes(1);
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("bootstraps missing crypto runtime and retries matrix SDK load", async () => {
+    let bootstrapped = false;
+    const requireFn = vi.fn(() => {
+      if (!bootstrapped) {
+        throw new Error(
+          "Cannot find module '@matrix-org/matrix-sdk-crypto-nodejs-linux-x64-gnu' (required by matrix sdk)",
+        );
+      }
+      return {};
+    });
+    const runCommand = vi.fn(async () => {
+      bootstrapped = true;
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await ensureMatrixCryptoRuntime({
+      log: logStub,
+      requireFn,
+      runCommand,
+      resolveFn: () => "/tmp/download-lib.js",
+      nodeExecutable: "/usr/bin/node",
+    });
+
+    expect(runCommand).toHaveBeenCalledWith({
+      argv: ["/usr/bin/node", "/tmp/download-lib.js"],
+      cwd: "/tmp",
+      timeoutMs: 300_000,
+      env: { COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
+    });
+    expect(requireFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("rethrows non-crypto module errors without bootstrapping", async () => {
+    const runCommand = vi.fn();
+    const requireFn = vi.fn(() => {
+      throw new Error("Cannot find module '@vector-im/matrix-bot-sdk'");
+    });
+
+    await expect(
+      ensureMatrixCryptoRuntime({
+        log: logStub,
+        requireFn,
+        runCommand,
+        resolveFn: () => "/tmp/download-lib.js",
+        nodeExecutable: "/usr/bin/node",
+      }),
+    ).rejects.toThrow("Cannot find module '@vector-im/matrix-bot-sdk'");
+
+    expect(runCommand).not.toHaveBeenCalled();
+    expect(requireFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/matrix/src/matrix/deps.ts
+++ b/extensions/matrix/src/matrix/deps.ts
@@ -5,6 +5,27 @@ import { fileURLToPath } from "node:url";
 import { runPluginCommandWithTimeout, type RuntimeEnv } from "remoteclaw/plugin-sdk";
 
 const MATRIX_SDK_PACKAGE = "@vector-im/matrix-bot-sdk";
+const MATRIX_CRYPTO_DOWNLOAD_HELPER = "@matrix-org/matrix-sdk-crypto-nodejs/download-lib.js";
+
+function formatCommandError(result: { stderr: string; stdout: string }): string {
+  const stderr = result.stderr.trim();
+  if (stderr) {
+    return stderr;
+  }
+  const stdout = result.stdout.trim();
+  if (stdout) {
+    return stdout;
+  }
+  return "unknown error";
+}
+
+function isMissingMatrixCryptoRuntimeError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err ?? "");
+  return (
+    message.includes("Cannot find module") &&
+    message.includes("@matrix-org/matrix-sdk-crypto-nodejs-")
+  );
+}
 
 export function isMatrixSdkAvailable(): boolean {
   try {
@@ -19,6 +40,51 @@ export function isMatrixSdkAvailable(): boolean {
 function resolvePluginRoot(): string {
   const currentDir = path.dirname(fileURLToPath(import.meta.url));
   return path.resolve(currentDir, "..", "..");
+}
+
+export async function ensureMatrixCryptoRuntime(
+  params: {
+    log?: (message: string) => void;
+    requireFn?: (id: string) => unknown;
+    resolveFn?: (id: string) => string;
+    runCommand?: typeof runPluginCommandWithTimeout;
+    nodeExecutable?: string;
+  } = {},
+): Promise<void> {
+  const req = createRequire(import.meta.url);
+  const requireFn = params.requireFn ?? ((id: string) => req(id));
+  const resolveFn = params.resolveFn ?? ((id: string) => req.resolve(id));
+  const runCommand = params.runCommand ?? runPluginCommandWithTimeout;
+  const nodeExecutable = params.nodeExecutable ?? process.execPath;
+
+  try {
+    requireFn(MATRIX_SDK_PACKAGE);
+    return;
+  } catch (err) {
+    if (!isMissingMatrixCryptoRuntimeError(err)) {
+      throw err;
+    }
+  }
+
+  const scriptPath = resolveFn(MATRIX_CRYPTO_DOWNLOAD_HELPER);
+  params.log?.("matrix: crypto runtime missing; downloading platform library…");
+  const result = await runCommand({
+    argv: [nodeExecutable, scriptPath],
+    cwd: path.dirname(scriptPath),
+    timeoutMs: 300_000,
+    env: { COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
+  });
+  if (result.code !== 0) {
+    throw new Error(`Matrix crypto runtime bootstrap failed: ${formatCommandError(result)}`);
+  }
+
+  try {
+    requireFn(MATRIX_SDK_PACKAGE);
+  } catch (err) {
+    throw new Error(
+      `Matrix crypto runtime remains unavailable after bootstrap: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 export async function ensureMatrixSdkInstalled(params: {

--- a/extensions/matrix/src/matrix/monitor/auto-join.ts
+++ b/extensions/matrix/src/matrix/monitor/auto-join.ts
@@ -1,8 +1,8 @@
 import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
-import { AutojoinRoomsMixin } from "@vector-im/matrix-bot-sdk";
 import type { RuntimeEnv } from "remoteclaw/plugin-sdk";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { CoreConfig } from "../../types.js";
+import { loadMatrixSdk } from "../sdk-runtime.js";
 
 export function registerMatrixAutoJoin(params: {
   client: MatrixClient;
@@ -26,6 +26,7 @@ export function registerMatrixAutoJoin(params: {
 
   if (autoJoin === "always") {
     // Use the built-in autojoin mixin for "always" mode
+    const { AutojoinRoomsMixin } = loadMatrixSdk();
     AutojoinRoomsMixin.setupOnClient(client);
     logVerbose("matrix: auto-join enabled for all invites");
     return;

--- a/extensions/matrix/src/matrix/sdk-runtime.ts
+++ b/extensions/matrix/src/matrix/sdk-runtime.ts
@@ -1,0 +1,18 @@
+import { createRequire } from "node:module";
+
+type MatrixSdkRuntime = typeof import("@vector-im/matrix-bot-sdk");
+
+let cachedMatrixSdkRuntime: MatrixSdkRuntime | null = null;
+
+export function loadMatrixSdk(): MatrixSdkRuntime {
+  if (cachedMatrixSdkRuntime) {
+    return cachedMatrixSdkRuntime;
+  }
+  const req = createRequire(import.meta.url);
+  cachedMatrixSdkRuntime = req("@vector-im/matrix-bot-sdk") as MatrixSdkRuntime;
+  return cachedMatrixSdkRuntime;
+}
+
+export function getMatrixLogService() {
+  return loadMatrixSdk().LogService;
+}

--- a/src/agents/provider-utils.ts
+++ b/src/agents/provider-utils.ts
@@ -41,6 +41,17 @@ export function normalizeProviderId(provider: string): string {
   return normalized;
 }
 
+export function normalizeProviderIdForAuth(provider: string): string {
+  const normalized = normalizeProviderId(provider);
+  if (normalized === "volcengine-plan") {
+    return "volcengine";
+  }
+  if (normalized === "byteplus-plan") {
+    return "byteplus";
+  }
+  return normalized;
+}
+
 export function findNormalizedProviderValue<T>(
   entries: Record<string, T> | undefined,
   provider: string,

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -300,13 +300,13 @@ describe("acquireSessionWriteLock", () => {
     }
   });
 
-  it("does not reclaim lock files without starttime (backward compat)", async () => {
+  it("reclaims orphan lock files without starttime when PID matches current process", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
     try {
       const sessionFile = path.join(root, "sessions.json");
       const lockPath = `${sessionFile}.lock`;
-      // Old-format lock without starttime — should NOT be reclaimed just because
-      // starttime is missing. The PID is alive, so the lock is valid.
+      // Simulate an old-format lock file left behind by a previous process
+      // instance that reused the same PID (common in containers).
       await fs.writeFile(
         lockPath,
         JSON.stringify({
@@ -316,19 +316,46 @@ describe("acquireSessionWriteLock", () => {
         "utf8",
       );
 
-      await expect(acquireSessionWriteLock({ sessionFile, timeoutMs: 50 })).rejects.toThrow(
-        /session file locked/,
-      );
+      await expectCurrentPidOwnsLock({ sessionFile, timeoutMs: 500 });
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
   });
 
-  it("does not treat malformed starttime as recycled", async () => {
+  it("does not reclaim active in-process lock files without starttime", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
     try {
       const sessionFile = path.join(root, "sessions.json");
       const lockPath = `${sessionFile}.lock`;
+      const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date().toISOString(),
+        }),
+        "utf8",
+      );
+
+      await expect(
+        acquireSessionWriteLock({
+          sessionFile,
+          timeoutMs: 50,
+          allowReentrant: false,
+        }),
+      ).rejects.toThrow(/session file locked/);
+      await lock.release();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not reclaim active in-process lock files with malformed starttime", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    try {
+      const sessionFile = path.join(root, "sessions.json");
+      const lockPath = `${sessionFile}.lock`;
+      const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
       await fs.writeFile(
         lockPath,
         JSON.stringify({
@@ -339,9 +366,14 @@ describe("acquireSessionWriteLock", () => {
         "utf8",
       );
 
-      await expect(acquireSessionWriteLock({ sessionFile, timeoutMs: 50 })).rejects.toThrow(
-        /session file locked/,
-      );
+      await expect(
+        acquireSessionWriteLock({
+          sessionFile,
+          timeoutMs: 50,
+          allowReentrant: false,
+        }),
+      ).rejects.toThrow(/session file locked/);
+      await lock.release();
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -369,6 +369,21 @@ async function shouldReclaimContendedLockFile(
   }
 }
 
+function shouldTreatAsOrphanSelfLock(params: {
+  payload: LockFilePayload | null;
+  normalizedSessionFile: string;
+}): boolean {
+  const pid = isValidLockNumber(params.payload?.pid) ? params.payload.pid : null;
+  if (pid !== process.pid) {
+    return false;
+  }
+  const hasValidStarttime = isValidLockNumber(params.payload?.starttime);
+  if (hasValidStarttime) {
+    return false;
+  }
+  return !HELD_LOCKS.has(params.normalizedSessionFile);
+}
+
 export async function cleanStaleLockFiles(params: {
   sessionsDir: string;
   staleMs?: number;
@@ -509,7 +524,20 @@ export async function acquireSessionWriteLock(params: {
       const payload = await readLockPayload(lockPath);
       const nowMs = Date.now();
       const inspected = inspectLockPayload(payload, staleMs, nowMs);
-      if (await shouldReclaimContendedLockFile(lockPath, inspected, staleMs, nowMs)) {
+      const orphanSelfLock = shouldTreatAsOrphanSelfLock({
+        payload,
+        normalizedSessionFile,
+      });
+      const reclaimDetails = orphanSelfLock
+        ? {
+            ...inspected,
+            stale: true,
+            staleReasons: inspected.staleReasons.includes("orphan-self-pid")
+              ? inspected.staleReasons
+              : [...inspected.staleReasons, "orphan-self-pid"],
+          }
+        : inspected;
+      if (await shouldReclaimContendedLockFile(lockPath, reclaimDetails, staleMs, nowMs)) {
         await fs.rm(lockPath, { force: true });
         continue;
       }

--- a/src/auth/order.test.ts
+++ b/src/auth/order.test.ts
@@ -642,4 +642,24 @@ describe("resolveAuthProfileOrder — cooldown auto-expiry", () => {
     expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(0);
     expect(store.usageStats?.["openai:default"]?.errorCount).toBe(0);
   });
+
+  it("accepts base-provider credentials for volcengine-plan auth lookup", () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "volcengine:default": {
+          type: "api_key",
+          provider: "volcengine",
+          key: "sk-test",
+        },
+      },
+    };
+
+    const order = resolveAuthProfileOrder({
+      store,
+      provider: "volcengine-plan",
+    });
+
+    expect(order).toEqual(["volcengine:default"]);
+  });
 });

--- a/src/auth/order.ts
+++ b/src/auth/order.ts
@@ -1,4 +1,8 @@
-import { findNormalizedProviderValue, normalizeProviderId } from "../agents/provider-utils.js";
+import {
+  findNormalizedProviderValue,
+  normalizeProviderId,
+  normalizeProviderIdForAuth,
+} from "../agents/provider-utils.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { dedupeProfileIds, listProfilesForProvider } from "./profiles.js";
 import type { AuthProfileStore } from "./types.js";
@@ -16,6 +20,7 @@ export function resolveAuthProfileOrder(params: {
 }): string[] {
   const { cfg, store, provider, preferredProfile } = params;
   const providerKey = normalizeProviderId(provider);
+  const providerAuthKey = normalizeProviderIdForAuth(provider);
   const now = Date.now();
 
   // Clear any cooldowns that have expired since the last check so profiles
@@ -27,12 +32,12 @@ export function resolveAuthProfileOrder(params: {
   const explicitOrder = storedOrder ?? configuredOrder;
   const explicitProfiles = cfg?.auth?.profiles
     ? Object.entries(cfg.auth.profiles)
-        .filter(([, profile]) => normalizeProviderId(profile.provider) === providerKey)
+        .filter(([, profile]) => normalizeProviderIdForAuth(profile.provider) === providerAuthKey)
         .map(([profileId]) => profileId)
     : [];
   const baseOrder =
     explicitOrder ??
-    (explicitProfiles.length > 0 ? explicitProfiles : listProfilesForProvider(store, providerKey));
+    (explicitProfiles.length > 0 ? explicitProfiles : listProfilesForProvider(store, provider));
   if (baseOrder.length === 0) {
     return [];
   }
@@ -42,12 +47,12 @@ export function resolveAuthProfileOrder(params: {
     if (!cred) {
       return false;
     }
-    if (normalizeProviderId(cred.provider) !== providerKey) {
+    if (normalizeProviderIdForAuth(cred.provider) !== providerAuthKey) {
       return false;
     }
     const profileConfig = cfg?.auth?.profiles?.[profileId];
     if (profileConfig) {
-      if (normalizeProviderId(profileConfig.provider) !== providerKey) {
+      if (normalizeProviderIdForAuth(profileConfig.provider) !== providerAuthKey) {
         return false;
       }
       if (profileConfig.mode !== cred.type) {
@@ -80,7 +85,7 @@ export function resolveAuthProfileOrder(params: {
   // provider's stored credentials and use any valid entries.
   const allBaseProfilesMissing = baseOrder.every((profileId) => !store.profiles[profileId]);
   if (filtered.length === 0 && explicitProfiles.length > 0 && allBaseProfilesMissing) {
-    const storeProfiles = listProfilesForProvider(store, providerKey);
+    const storeProfiles = listProfilesForProvider(store, provider);
     filtered = storeProfiles.filter(isValidProfile);
   }
 

--- a/src/auto-reply/reply/queue/cleanup.ts
+++ b/src/auto-reply/reply/queue/cleanup.ts
@@ -1,4 +1,5 @@
 import { clearCommandLane } from "../../../process/command-queue.js";
+import { clearFollowupDrainCallback } from "./drain.js";
 import { clearFollowupQueue } from "./state.js";
 
 export type ClearSessionQueueResult = {
@@ -21,6 +22,7 @@ export function clearSessionQueues(keys: Array<string | undefined>): ClearSessio
     seen.add(cleaned);
     clearedKeys.push(cleaned);
     followupCleared += clearFollowupQueue(cleaned);
+    clearFollowupDrainCallback(cleaned);
     laneCleared += clearCommandLane("default");
   }
 

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -13,6 +13,23 @@ import { isRoutableChannel } from "../route-reply.js";
 import { FOLLOWUP_QUEUES } from "./state.js";
 import type { FollowupRun } from "./types.js";
 
+// Persists the most recent runFollowup callback per queue key so that
+// enqueueFollowupRun can restart a drain that finished and deleted the queue.
+const FOLLOWUP_RUN_CALLBACKS = new Map<string, (run: FollowupRun) => Promise<void>>();
+
+export function clearFollowupDrainCallback(key: string): void {
+  FOLLOWUP_RUN_CALLBACKS.delete(key);
+}
+
+/** Restart the drain for `key` if it is currently idle, using the stored callback. */
+export function kickFollowupDrainIfIdle(key: string): void {
+  const cb = FOLLOWUP_RUN_CALLBACKS.get(key);
+  if (!cb) {
+    return;
+  }
+  scheduleFollowupDrain(key, cb);
+}
+
 type OriginRoutingMetadata = Pick<
   FollowupRun,
   "originatingChannel" | "originatingTo" | "originatingAccountId" | "originatingThreadId"
@@ -50,6 +67,9 @@ export function scheduleFollowupDrain(
   key: string,
   runFollowup: (run: FollowupRun) => Promise<void>,
 ): void {
+  // Cache the callback so enqueueFollowupRun can restart drain after the queue
+  // has been deleted and recreated (the post-drain idle window race condition).
+  FOLLOWUP_RUN_CALLBACKS.set(key, runFollowup);
   const queue = beginQueueDrain(FOLLOWUP_QUEUES, key);
   if (!queue) {
     return;

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -67,13 +67,13 @@ export function scheduleFollowupDrain(
   key: string,
   runFollowup: (run: FollowupRun) => Promise<void>,
 ): void {
-  // Cache the callback so enqueueFollowupRun can restart drain after the queue
-  // has been deleted and recreated (the post-drain idle window race condition).
-  FOLLOWUP_RUN_CALLBACKS.set(key, runFollowup);
   const queue = beginQueueDrain(FOLLOWUP_QUEUES, key);
   if (!queue) {
     return;
   }
+  // Cache callback only when a drain actually starts. Avoid keeping stale
+  // callbacks around from finalize calls where no queue work is pending.
+  FOLLOWUP_RUN_CALLBACKS.set(key, runFollowup);
   void (async () => {
     try {
       const collectState = { forceIndividualCollect: false };

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -1,4 +1,5 @@
 import { applyQueueDropPolicy, shouldSkipQueueItem } from "../../../utils/queue-helpers.js";
+import { kickFollowupDrainIfIdle } from "./drain.js";
 import { getExistingFollowupQueue, getFollowupQueue } from "./state.js";
 import type { FollowupRun, QueueDedupeMode, QueueSettings } from "./types.js";
 
@@ -53,6 +54,12 @@ export function enqueueFollowupRun(
   }
 
   queue.items.push(run);
+  // If drain finished and deleted the queue before this item arrived, a new queue
+  // object was created (draining: false) but nobody scheduled a drain for it.
+  // Use the cached callback to restart the drain now.
+  if (!queue.draining) {
+    kickFollowupDrainIfIdle(key);
+  }
   return true;
 }
 

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1097,6 +1097,33 @@ describe("followup queue collect routing", () => {
 });
 
 describe("followup queue drain restart after idle window", () => {
+  it("does not retain stale callbacks when scheduleFollowupDrain runs with an empty queue", async () => {
+    const key = `test-no-stale-callback-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const staleCalls: FollowupRun[] = [];
+    const freshCalls: FollowupRun[] = [];
+    const drained = createDeferred<void>();
+
+    // Simulate finalizeWithFollowup calling schedule without pending queue items.
+    scheduleFollowupDrain(key, async (run) => {
+      staleCalls.push(run);
+    });
+
+    enqueueFollowupRun(key, createRun({ prompt: "after-empty-schedule" }), settings);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(staleCalls).toHaveLength(0);
+
+    scheduleFollowupDrain(key, async (run) => {
+      freshCalls.push(run);
+      drained.resolve();
+    });
+    await drained.promise;
+
+    expect(staleCalls).toHaveLength(0);
+    expect(freshCalls).toHaveLength(1);
+    expect(freshCalls[0]?.prompt).toBe("after-empty-schedule");
+  });
+
   it("processes a message enqueued after the drain empties and deletes the queue", async () => {
     const key = `test-idle-window-race-${Date.now()}`;
     const calls: FollowupRun[] = [];

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1096,6 +1096,118 @@ describe("followup queue collect routing", () => {
   });
 });
 
+describe("followup queue drain restart after idle window", () => {
+  it("processes a message enqueued after the drain empties and deletes the queue", async () => {
+    const key = `test-idle-window-race-${Date.now()}`;
+    const calls: FollowupRun[] = [];
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+
+    const firstProcessed = createDeferred<void>();
+    const secondProcessed = createDeferred<void>();
+    let callCount = 0;
+    const runFollowup = async (run: FollowupRun) => {
+      callCount++;
+      calls.push(run);
+      if (callCount === 1) {
+        firstProcessed.resolve();
+      }
+      if (callCount === 2) {
+        secondProcessed.resolve();
+      }
+    };
+
+    // Enqueue first message and start drain.
+    enqueueFollowupRun(key, createRun({ prompt: "before-idle" }), settings);
+    scheduleFollowupDrain(key, runFollowup);
+
+    // Wait for the first message to be processed by the drain.
+    await firstProcessed.promise;
+
+    // Yield past the drain's finally block so it can set draining:false and
+    // delete the queue key from FOLLOWUP_QUEUES (the idle-window boundary).
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    // Simulate the race: a new message arrives AFTER the drain finished and
+    // deleted the queue, but WITHOUT calling scheduleFollowupDrain again.
+    enqueueFollowupRun(key, createRun({ prompt: "after-idle" }), settings);
+
+    // kickFollowupDrainIfIdle should have restarted the drain automatically.
+    await secondProcessed.promise;
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.prompt).toBe("before-idle");
+    expect(calls[1]?.prompt).toBe("after-idle");
+  });
+
+  it("does not double-drain when a message arrives while drain is still running", async () => {
+    const key = `test-no-double-drain-${Date.now()}`;
+    const calls: FollowupRun[] = [];
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+
+    const allProcessed = createDeferred<void>();
+    // runFollowup resolves only after both items are enqueued so the second
+    // item is already in the queue when the first drain step finishes.
+    let runFollowupResolve!: () => void;
+    const runFollowupGate = new Promise<void>((res) => {
+      runFollowupResolve = res;
+    });
+    const runFollowup = async (run: FollowupRun) => {
+      await runFollowupGate;
+      calls.push(run);
+      if (calls.length >= 2) {
+        allProcessed.resolve();
+      }
+    };
+
+    enqueueFollowupRun(key, createRun({ prompt: "first" }), settings);
+    scheduleFollowupDrain(key, runFollowup);
+
+    // Enqueue second message while the drain is mid-flight (draining:true).
+    enqueueFollowupRun(key, createRun({ prompt: "second" }), settings);
+
+    // Release the gate so both items can drain.
+    runFollowupResolve();
+
+    await allProcessed.promise;
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.prompt).toBe("first");
+    expect(calls[1]?.prompt).toBe("second");
+  });
+
+  it("does not process messages after clearSessionQueues clears the callback", async () => {
+    const key = `test-clear-callback-${Date.now()}`;
+    const calls: FollowupRun[] = [];
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+
+    const firstProcessed = createDeferred<void>();
+    const runFollowup = async (run: FollowupRun) => {
+      calls.push(run);
+      firstProcessed.resolve();
+    };
+
+    enqueueFollowupRun(key, createRun({ prompt: "before-clear" }), settings);
+    scheduleFollowupDrain(key, runFollowup);
+    await firstProcessed.promise;
+
+    // Let drain finish and delete the queue.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    // Clear queues (simulates session teardown) — should also clear the callback.
+    const { clearSessionQueues } = await import("./queue.js");
+    clearSessionQueues([key]);
+
+    // Enqueue after clear: should NOT auto-start a drain (callback is gone).
+    enqueueFollowupRun(key, createRun({ prompt: "after-clear" }), settings);
+
+    // Yield a few ticks; no drain should fire.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    // Only the first message was processed; the post-clear one is still pending.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.prompt).toBe("before-clear");
+  });
+});
+
 const emptyCfg = {} as RemoteClawConfig;
 
 describe("createReplyDispatcher", () => {

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -62,6 +62,12 @@ describe("stripSilentToken", () => {
     expect(stripSilentToken("  NO_REPLY  ")).toBe("");
   });
 
+  it("strips token preceded by bold markdown formatting", () => {
+    expect(stripSilentToken("**NO_REPLY")).toBe("");
+    expect(stripSilentToken("some text **NO_REPLY")).toBe("some text");
+    expect(stripSilentToken("reasoning**NO_REPLY")).toBe("reasoning");
+  });
+
   it("works with custom token", () => {
     expect(stripSilentToken("done HEARTBEAT_OK", "HEARTBEAT_OK")).toBe("done");
   });

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -24,7 +24,7 @@ export function isSilentReplyText(
  */
 export function stripSilentToken(text: string, token: string = SILENT_REPLY_TOKEN): string {
   const escaped = escapeRegExp(token);
-  return text.replace(new RegExp(`(?:^|\\s+)${escaped}\\s*$`), "").trim();
+  return text.replace(new RegExp(`(?:^|\\s+|\\*+)${escaped}\\s*$`), "").trim();
 }
 
 export function isSilentReplyPrefixText(

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -340,15 +340,16 @@ async function runPluginInstallCommand(params: {
     logger: createPluginInstallLogger(),
   });
   if (!result.ok) {
-    const shouldTryBundledFallback =
-      result.code === PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND ||
+    const isNpmNotFound = result.code === PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND;
+    const isNotPlugin =
       result.code === PLUGIN_INSTALL_ERROR_CODE.MISSING_REMOTECLAW_EXTENSIONS ||
       result.code === PLUGIN_INSTALL_ERROR_CODE.EMPTY_REMOTECLAW_EXTENSIONS;
-    const bundledFallback = shouldTryBundledFallback
-      ? findBundledPluginSource({
-          lookup: { kind: "npmSpec", value: raw },
-        })
-      : undefined;
+    const bundledFallback =
+      isNpmNotFound || isNotPlugin
+        ? findBundledPluginSource({
+            lookup: { kind: "npmSpec", value: raw },
+          })
+        : undefined;
     if (!bundledFallback) {
       defaultRuntime.error(result.error);
       process.exit(1);
@@ -358,7 +359,9 @@ async function runPluginInstallCommand(params: {
       config: cfg,
       rawSpec: raw,
       bundledSource: bundledFallback,
-      warning: `npm package unavailable for ${raw}; using bundled plugin at ${shortenHomePath(bundledFallback.localPath)}.`,
+      warning: isNpmNotFound
+        ? `npm package unavailable for ${raw}; using bundled plugin at ${shortenHomePath(bundledFallback.localPath)}.`
+        : `npm package "${raw}" is not a valid RemoteClaw plugin; using bundled plugin at ${shortenHomePath(bundledFallback.localPath)}.`,
     });
     return;
   }

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -193,7 +193,7 @@ export function mapSensitivePaths(
   if (isSensitive) {
     next[path] = { ...next[path], sensitive: true };
   } else if (isSensitiveConfigPath(path) && !next[path]?.sensitive) {
-    log.warn(`possibly sensitive key found: (${path})`);
+    log.debug(`possibly sensitive key found: (${path})`);
   }
 
   if (currentSchema instanceof z.ZodObject) {

--- a/src/discord/monitor/listeners.test.ts
+++ b/src/discord/monitor/listeners.test.ts
@@ -8,6 +8,10 @@ function createLogger() {
   };
 }
 
+function fakeEvent(channelId: string) {
+  return { channel_id: channelId } as never;
+}
+
 describe("DiscordMessageListener", () => {
   it("returns immediately without awaiting handler completion", async () => {
     let resolveHandler: (() => void) | undefined;
@@ -20,7 +24,7 @@ describe("DiscordMessageListener", () => {
     const logger = createLogger();
     const listener = new DiscordMessageListener(handler as never, logger as never);
 
-    await expect(listener.handle({} as never, {} as never)).resolves.toBeUndefined();
+    await expect(listener.handle(fakeEvent("ch-1"), {} as never)).resolves.toBeUndefined();
     expect(handler).toHaveBeenCalledTimes(1);
     expect(logger.error).not.toHaveBeenCalled();
 
@@ -28,7 +32,7 @@ describe("DiscordMessageListener", () => {
     await handlerDone;
   });
 
-  it("serializes queued handler runs while handle returns immediately", async () => {
+  it("serializes queued handler runs for the same channel", async () => {
     let firstResolve: (() => void) | undefined;
     let secondResolve: (() => void) | undefined;
     const firstDone = new Promise<void>((resolve) => {
@@ -48,10 +52,9 @@ describe("DiscordMessageListener", () => {
     });
     const listener = new DiscordMessageListener(handler as never, createLogger() as never);
 
-    await expect(listener.handle({} as never, {} as never)).resolves.toBeUndefined();
-    await expect(listener.handle({} as never, {} as never)).resolves.toBeUndefined();
+    await expect(listener.handle(fakeEvent("ch-1"), {} as never)).resolves.toBeUndefined();
+    await expect(listener.handle(fakeEvent("ch-1"), {} as never)).resolves.toBeUndefined();
 
-    // Second event is queued until the first handler run settles.
     expect(handler).toHaveBeenCalledTimes(1);
     firstResolve?.();
     await vi.waitFor(() => {
@@ -62,6 +65,48 @@ describe("DiscordMessageListener", () => {
     await secondDone;
   });
 
+  it("runs handlers for different channels in parallel", async () => {
+    let resolveA: (() => void) | undefined;
+    let resolveB: (() => void) | undefined;
+    const doneA = new Promise<void>((r) => {
+      resolveA = r;
+    });
+    const doneB = new Promise<void>((r) => {
+      resolveB = r;
+    });
+    const order: string[] = [];
+    const handler = vi.fn(async (data: { channel_id: string }) => {
+      order.push(`start:${data.channel_id}`);
+      if (data.channel_id === "ch-a") {
+        await doneA;
+      } else {
+        await doneB;
+      }
+      order.push(`end:${data.channel_id}`);
+    });
+    const listener = new DiscordMessageListener(handler as never, createLogger() as never);
+
+    await listener.handle(fakeEvent("ch-a"), {} as never);
+    await listener.handle(fakeEvent("ch-b"), {} as never);
+
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+    expect(order).toContain("start:ch-a");
+    expect(order).toContain("start:ch-b");
+
+    resolveB?.();
+    await vi.waitFor(() => {
+      expect(order).toContain("end:ch-b");
+    });
+    expect(order).not.toContain("end:ch-a");
+
+    resolveA?.();
+    await vi.waitFor(() => {
+      expect(order).toContain("end:ch-a");
+    });
+  });
+
   it("logs async handler failures", async () => {
     const handler = vi.fn(async () => {
       throw new Error("boom");
@@ -69,7 +114,7 @@ describe("DiscordMessageListener", () => {
     const logger = createLogger();
     const listener = new DiscordMessageListener(handler as never, logger as never);
 
-    await expect(listener.handle({} as never, {} as never)).resolves.toBeUndefined();
+    await expect(listener.handle(fakeEvent("ch-1"), {} as never)).resolves.toBeUndefined();
     await vi.waitFor(() => {
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining("discord handler failed: Error: boom"),

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -864,6 +864,39 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("preserves channelData-only payloads with empty text for non-WhatsApp sendPayload channels", async () => {
+    const sendPayload = vi.fn().mockResolvedValue({ channel: "line", messageId: "ln-1" });
+    const sendText = vi.fn();
+    const sendMedia = vi.fn();
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: { deliveryMode: "direct", sendPayload, sendText, sendMedia },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: " \n\t ", channelData: { mode: "flex" } }],
+    });
+
+    expect(sendPayload).toHaveBeenCalledTimes(1);
+    expect(sendPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ text: "", channelData: { mode: "flex" } }),
+      }),
+    );
+    expect(results).toEqual([{ channel: "line", messageId: "ln-1" }]);
+  });
+
   it("emits message_sent failure when delivery errors", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
     const sendWhatsApp = vi.fn().mockRejectedValue(new Error("downstream failed"));

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -428,37 +428,35 @@ async function deliverOutboundPayloadsCore(
       })),
     };
   };
-  const normalizeWhatsAppPayload = (payload: ReplyPayload): ReplyPayload | null => {
-    const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+  const hasMediaPayload = (payload: ReplyPayload): boolean =>
+    Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+  const hasChannelDataPayload = (payload: ReplyPayload): boolean =>
+    Boolean(payload.channelData && Object.keys(payload.channelData).length > 0);
+  const normalizePayloadForChannelDelivery = (
+    payload: ReplyPayload,
+    channelId: string,
+  ): ReplyPayload | null => {
+    const hasMedia = hasMediaPayload(payload);
+    const hasChannelData = hasChannelDataPayload(payload);
     const rawText = typeof payload.text === "string" ? payload.text : "";
-    const normalizedText = rawText.replace(/^(?:[ \t]*\r?\n)+/, "");
+    const normalizedText =
+      channelId === "whatsapp" ? rawText.replace(/^(?:[ \t]*\r?\n)+/, "") : rawText;
     if (!normalizedText.trim()) {
-      if (!hasMedia) {
+      if (!hasMedia && !hasChannelData) {
         return null;
       }
       return {
         ...payload,
         text: "",
       };
+    }
+    if (normalizedText === rawText) {
+      return payload;
     }
     return {
       ...payload,
       text: normalizedText,
     };
-  };
-  const normalizeEmptyTextPayload = (payload: ReplyPayload): ReplyPayload | null => {
-    const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
-    const rawText = typeof payload.text === "string" ? payload.text : "";
-    if (!rawText.trim()) {
-      if (!hasMedia) {
-        return null;
-      }
-      return {
-        ...payload,
-        text: "",
-      };
-    }
-    return payload;
   };
   const normalizedPayloads = normalizeReplyPayloadsForDelivery(payloads)
     .map((payload) => {
@@ -475,10 +473,7 @@ async function deliverOutboundPayloadsCore(
       return { ...payload, text: sanitizeForPlainText(payload.text) };
     })
     .flatMap((payload) => {
-      const normalized =
-        channel === "whatsapp"
-          ? normalizeWhatsAppPayload(payload)
-          : normalizeEmptyTextPayload(payload);
+      const normalized = normalizePayloadForChannelDelivery(payload, channel);
       return normalized ? [normalized] : [];
     });
   const hookRunner = getGlobalHookRunner();

--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -79,4 +79,32 @@ describe("fetchCodexUsage", () => {
       { label: "Week", usedPercent: 10, resetAt: 1_700_500_000_000 },
     ]);
   });
+
+  it("labels secondary window as Week when reset cadence clearly exceeds one day", async () => {
+    const primaryReset = 1_700_000_000;
+    const weeklyLikeSecondaryReset = primaryReset + 5 * 24 * 60 * 60;
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        rate_limit: {
+          primary_window: {
+            limit_window_seconds: 10_800,
+            used_percent: 14,
+            reset_at: primaryReset,
+          },
+          secondary_window: {
+            // Observed in production: API reports 24h, but dashboard shows a weekly window.
+            limit_window_seconds: 86_400,
+            used_percent: 20,
+            reset_at: weeklyLikeSecondaryReset,
+          },
+        },
+      }),
+    );
+
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+    expect(result.windows).toEqual([
+      { label: "3h", usedPercent: 14, resetAt: 1_700_000_000_000 },
+      { label: "Week", usedPercent: 20, resetAt: weeklyLikeSecondaryReset * 1000 },
+    ]);
+  });
 });

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -19,6 +19,31 @@ type CodexUsageResponse = {
   credits?: { balance?: number | string | null };
 };
 
+const WEEKLY_RESET_GAP_SECONDS = 3 * 24 * 60 * 60;
+
+function resolveSecondaryWindowLabel(params: {
+  windowHours: number;
+  secondaryResetAt?: number;
+  primaryResetAt?: number;
+}): string {
+  if (params.windowHours >= 168) {
+    return "Week";
+  }
+  if (params.windowHours < 24) {
+    return `${params.windowHours}h`;
+  }
+  // Codex occasionally reports a 24h secondary window while exposing a
+  // weekly reset cadence in reset timestamps. Prefer cadence in that case.
+  if (
+    typeof params.secondaryResetAt === "number" &&
+    typeof params.primaryResetAt === "number" &&
+    params.secondaryResetAt - params.primaryResetAt >= WEEKLY_RESET_GAP_SECONDS
+  ) {
+    return "Week";
+  }
+  return "Day";
+}
+
 export async function fetchCodexUsage(
   token: string,
   accountId: string | undefined,
@@ -65,7 +90,11 @@ export async function fetchCodexUsage(
   if (data.rate_limit?.secondary_window) {
     const sw = data.rate_limit.secondary_window;
     const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
-    const label = windowHours >= 168 ? "Week" : windowHours >= 24 ? "Day" : `${windowHours}h`;
+    const label = resolveSecondaryWindowLabel({
+      windowHours,
+      primaryResetAt: data.rate_limit?.primary_window?.reset_at,
+      secondaryResetAt: sw.reset_at,
+    });
     windows.push({
       label,
       usedPercent: clampPercent(sw.used_percent || 0),

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -4,7 +4,9 @@ import { isPathInsideWithRealpath } from "../security/scan-paths.js";
 import { resolveConfigDir, resolveUserPath } from "../utils.js";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import {
+  DEFAULT_PLUGIN_ENTRY_CANDIDATES,
   getPackageManifestMetadata,
+  resolvePackageExtensionEntries,
   type RemoteClawPackageManifest,
   type PackageManifest,
 } from "./manifest.js";
@@ -256,14 +258,6 @@ function readPackageManifest(dir: string): PackageManifest | null {
   }
 }
 
-function resolvePackageExtensions(manifest: PackageManifest): string[] {
-  const raw = getPackageManifestMetadata(manifest)?.extensions;
-  if (!Array.isArray(raw)) {
-    return [];
-  }
-  return raw.map((entry) => (typeof entry === "string" ? entry.trim() : "")).filter(Boolean);
-}
-
 function deriveIdHint(params: {
   filePath: string;
   packageName?: string;
@@ -404,7 +398,8 @@ function discoverInDirectory(params: {
     }
 
     const manifest = readPackageManifest(fullPath);
-    const extensions = manifest ? resolvePackageExtensions(manifest) : [];
+    const extensionResolution = resolvePackageExtensionEntries(manifest ?? undefined);
+    const extensions = extensionResolution.status === "ok" ? extensionResolution.entries : [];
 
     if (extensions.length > 0) {
       for (const extPath of extensions) {
@@ -438,8 +433,7 @@ function discoverInDirectory(params: {
       continue;
     }
 
-    const indexCandidates = ["index.ts", "index.js", "index.mjs", "index.cjs"];
-    const indexFile = indexCandidates
+    const indexFile = [...DEFAULT_PLUGIN_ENTRY_CANDIDATES]
       .map((candidate) => path.join(fullPath, candidate))
       .find((candidate) => fs.existsSync(candidate));
     if (indexFile && isExtensionFile(indexFile)) {
@@ -505,7 +499,8 @@ function discoverFromPath(params: {
 
   if (stat.isDirectory()) {
     const manifest = readPackageManifest(resolved);
-    const extensions = manifest ? resolvePackageExtensions(manifest) : [];
+    const extensionResolution = resolvePackageExtensionEntries(manifest ?? undefined);
+    const extensions = extensionResolution.status === "ok" ? extensionResolution.entries : [];
 
     if (extensions.length > 0) {
       for (const extPath of extensions) {
@@ -539,8 +534,7 @@ function discoverFromPath(params: {
       return;
     }
 
-    const indexCandidates = ["index.ts", "index.js", "index.mjs", "index.cjs"];
-    const indexFile = indexCandidates
+    const indexFile = [...DEFAULT_PLUGIN_ENTRY_CANDIDATES]
       .map((candidate) => path.join(resolved, candidate))
       .find((candidate) => fs.existsSync(candidate));
 

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -29,21 +29,20 @@ import {
 import { validateRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { extensionUsesSkippedScannerPath, isPathInside } from "../security/scan-paths.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
-import { loadPluginManifest } from "./manifest.js";
+import {
+  loadPluginManifest,
+  resolvePackageExtensionEntries,
+  type PackageManifest as PluginPackageManifest,
+} from "./manifest.js";
 
 type PluginInstallLogger = {
   info?: (message: string) => void;
   warn?: (message: string) => void;
 };
 
-const MANIFEST_KEY = "remoteclaw" as const;
-
-type ManifestMeta = { extensions?: string[] };
-type PackageManifest = {
-  name?: string;
-  version?: string;
+type PackageManifest = PluginPackageManifest & {
   dependencies?: Record<string, string>;
-} & Partial<Record<typeof MANIFEST_KEY, ManifestMeta>>;
+};
 
 export const PLUGIN_INSTALL_ERROR_CODE = {
   INVALID_NPM_SPEC: "invalid_npm_spec",
@@ -104,16 +103,15 @@ function ensureRemoteClawExtensions(manifest: PackageManifest):
       error: string;
       code: PluginInstallErrorCode;
     } {
-  const extensions = manifest[MANIFEST_KEY]?.extensions;
-  if (!Array.isArray(extensions)) {
+  const resolved = resolvePackageExtensionEntries(manifest);
+  if (resolved.status === "missing") {
     return {
       ok: false,
       error: "package.json missing remoteclaw.extensions",
       code: PLUGIN_INSTALL_ERROR_CODE.MISSING_REMOTECLAW_EXTENSIONS,
     };
   }
-  const list = extensions.map((e) => (typeof e === "string" ? e.trim() : "")).filter(Boolean);
-  if (list.length === 0) {
+  if (resolved.status === "empty") {
     return {
       ok: false,
       error: "package.json remoteclaw.extensions is empty",
@@ -122,7 +120,7 @@ function ensureRemoteClawExtensions(manifest: PackageManifest):
   }
   return {
     ok: true,
-    entries: list,
+    entries: resolved.entries,
   };
 }
 

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -29,20 +29,21 @@ import {
 import { validateRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { extensionUsesSkippedScannerPath, isPathInside } from "../security/scan-paths.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
-import {
-  loadPluginManifest,
-  resolvePackageExtensionEntries,
-  type PackageManifest as PluginPackageManifest,
-} from "./manifest.js";
+import { loadPluginManifest } from "./manifest.js";
 
 type PluginInstallLogger = {
   info?: (message: string) => void;
   warn?: (message: string) => void;
 };
 
-type PackageManifest = PluginPackageManifest & {
+const MANIFEST_KEY = "remoteclaw" as const;
+
+type ManifestMeta = { extensions?: string[] };
+type PackageManifest = {
+  name?: string;
+  version?: string;
   dependencies?: Record<string, string>;
-};
+} & Partial<Record<typeof MANIFEST_KEY, ManifestMeta>>;
 
 export const PLUGIN_INSTALL_ERROR_CODE = {
   INVALID_NPM_SPEC: "invalid_npm_spec",
@@ -103,15 +104,16 @@ function ensureRemoteClawExtensions(manifest: PackageManifest):
       error: string;
       code: PluginInstallErrorCode;
     } {
-  const resolved = resolvePackageExtensionEntries(manifest);
-  if (resolved.status === "missing") {
+  const extensions = manifest[MANIFEST_KEY]?.extensions;
+  if (!Array.isArray(extensions)) {
     return {
       ok: false,
       error: "package.json missing remoteclaw.extensions",
       code: PLUGIN_INSTALL_ERROR_CODE.MISSING_REMOTECLAW_EXTENSIONS,
     };
   }
-  if (resolved.status === "empty") {
+  const list = extensions.map((e) => (typeof e === "string" ? e.trim() : "")).filter(Boolean);
+  if (list.length === 0) {
     return {
       ok: false,
       error: "package.json remoteclaw.extensions is empty",
@@ -120,7 +122,7 @@ function ensureRemoteClawExtensions(manifest: PackageManifest):
   }
   return {
     ok: true,
-    entries: resolved.entries,
+    entries: list,
   };
 }
 

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -130,6 +130,18 @@ export type RemoteClawPackageManifest = {
   install?: PluginPackageInstall;
 };
 
+export const DEFAULT_PLUGIN_ENTRY_CANDIDATES = [
+  "index.ts",
+  "index.js",
+  "index.mjs",
+  "index.cjs",
+] as const;
+
+export type PackageExtensionResolution =
+  | { status: "ok"; entries: string[] }
+  | { status: "missing"; entries: [] }
+  | { status: "empty"; entries: [] };
+
 export type ManifestKey = typeof MANIFEST_KEY;
 
 export type PackageManifest = {
@@ -145,4 +157,20 @@ export function getPackageManifestMetadata(
     return undefined;
   }
   return manifest[MANIFEST_KEY];
+}
+
+export function resolvePackageExtensionEntries(
+  manifest: PackageManifest | undefined,
+): PackageExtensionResolution {
+  const raw = getPackageManifestMetadata(manifest)?.extensions;
+  if (!Array.isArray(raw)) {
+    return { status: "missing", entries: [] };
+  }
+  const entries = raw
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter(Boolean);
+  if (entries.length === 0) {
+    return { status: "empty", entries: [] };
+  }
+  return { status: "ok", entries };
 }

--- a/src/process/exec.no-output-timer.test.ts
+++ b/src/process/exec.no-output-timer.test.ts
@@ -1,0 +1,73 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+import { runCommandWithTimeout } from "./exec.js";
+
+function createFakeSpawnedChild() {
+  const child = new EventEmitter() as EventEmitter & ChildProcess;
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  let killed = false;
+  const kill = vi.fn<(signal?: NodeJS.Signals) => boolean>(() => {
+    killed = true;
+    return true;
+  });
+  Object.defineProperty(child, "killed", {
+    get: () => killed,
+    configurable: true,
+  });
+  Object.defineProperty(child, "pid", {
+    value: 12345,
+    configurable: true,
+  });
+  child.stdout = stdout as ChildProcess["stdout"];
+  child.stderr = stderr as ChildProcess["stderr"];
+  child.stdin = null;
+  child.kill = kill as ChildProcess["kill"];
+  return { child, stdout, stderr, kill };
+}
+
+describe("runCommandWithTimeout no-output timer", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("resets no-output timeout when spawned child keeps emitting stdout", async () => {
+    vi.useFakeTimers();
+    const fake = createFakeSpawnedChild();
+    spawnMock.mockReturnValue(fake.child);
+
+    const runPromise = runCommandWithTimeout(["node", "-e", "ignored"], {
+      timeoutMs: 1_000,
+      noOutputTimeoutMs: 80,
+    });
+
+    fake.stdout.emit("data", Buffer.from("."));
+    await vi.advanceTimersByTimeAsync(40);
+    fake.stdout.emit("data", Buffer.from("."));
+    await vi.advanceTimersByTimeAsync(40);
+    fake.stdout.emit("data", Buffer.from("."));
+    await vi.advanceTimersByTimeAsync(20);
+
+    fake.child.emit("close", 0, null);
+    const result = await runPromise;
+
+    expect(result.code ?? 0).toBe(0);
+    expect(result.termination).toBe("exit");
+    expect(result.noOutputTimedOut).toBe(false);
+    expect(result.stdout).toBe("...");
+    expect(fake.kill).not.toHaveBeenCalled();
+  });
+});

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -56,38 +56,6 @@ describe("runCommandWithTimeout", () => {
     expect(result.code).not.toBe(0);
   });
 
-  it("resets no output timer when command keeps emitting output", async () => {
-    const result = await runCommandWithTimeout(
-      [
-        process.execPath,
-        "-e",
-        [
-          "let count = 0;",
-          "const emit = () => {",
-          'process.stdout.write(".");',
-          "count += 1;",
-          "if (count >= 4) {",
-          "process.exit(0);",
-          "return;",
-          "}",
-          "setTimeout(emit, 40);",
-          "};",
-          "emit();",
-        ].join(" "),
-      ],
-      {
-        timeoutMs: 2_000,
-        // Keep a healthy margin above the emit interval for loaded CI runners.
-        noOutputTimeoutMs: 400,
-      },
-    );
-
-    expect(result.code ?? 0).toBe(0);
-    expect(result.termination).toBe("exit");
-    expect(result.noOutputTimedOut).toBe(false);
-    expect(result.stdout.length).toBeGreaterThanOrEqual(3);
-  });
-
   it("reports global timeout termination when overall timeout elapses", async () => {
     const result = await runCommandWithTimeout(
       [process.execPath, "-e", "setTimeout(() => {}, 10)"],

--- a/src/telegram/bot-native-command-menu.test.ts
+++ b/src/telegram/bot-native-command-menu.test.ts
@@ -208,6 +208,43 @@ describe("bot-native-command-menu", () => {
     expect(runtimeLog).not.toHaveBeenCalledWith("telegram: command menu unchanged; skipping sync");
   });
 
+  it("does not cache empty-menu hash when deleteMyCommands fails", async () => {
+    const deleteMyCommands = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient failure"))
+      .mockResolvedValue(undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    const runtimeLog = vi.fn();
+    const accountId = `test-empty-delete-fail-${Date.now()}`;
+
+    syncTelegramMenuCommands({
+      bot: { api: { deleteMyCommands, setMyCommands } } as unknown as Parameters<
+        typeof syncTelegramMenuCommands
+      >[0]["bot"],
+      runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() } as Parameters<
+        typeof syncTelegramMenuCommands
+      >[0]["runtime"],
+      commandsToRegister: [],
+      accountId,
+      botIdentity: "bot-a",
+    });
+    await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(1));
+
+    syncTelegramMenuCommands({
+      bot: { api: { deleteMyCommands, setMyCommands } } as unknown as Parameters<
+        typeof syncTelegramMenuCommands
+      >[0]["bot"],
+      runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() } as Parameters<
+        typeof syncTelegramMenuCommands
+      >[0]["runtime"],
+      commandsToRegister: [],
+      accountId,
+      botIdentity: "bot-a",
+    });
+    await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(2));
+    expect(runtimeLog).not.toHaveBeenCalledWith("telegram: command menu unchanged; skipping sync");
+  });
+
   it("retries with fewer commands on BOT_COMMANDS_TOO_MUCH", async () => {
     const deleteMyCommands = vi.fn(async () => undefined);
     const setMyCommands = vi

--- a/src/telegram/bot-native-command-menu.ts
+++ b/src/telegram/bot-native-command-menu.ts
@@ -174,15 +174,22 @@ export function syncTelegramMenuCommands(params: {
     }
 
     // Keep delete -> set ordering to avoid stale deletions racing after fresh registrations.
+    let deleteSucceeded = true;
     if (typeof bot.api.deleteMyCommands === "function") {
-      await withTelegramApiErrorLogging({
+      deleteSucceeded = await withTelegramApiErrorLogging({
         operation: "deleteMyCommands",
         runtime,
         fn: () => bot.api.deleteMyCommands(),
-      }).catch(() => {});
+      })
+        .then(() => true)
+        .catch(() => false);
     }
 
     if (commandsToRegister.length === 0) {
+      if (!deleteSucceeded) {
+        runtime.log?.("telegram: deleteMyCommands failed; skipping empty-menu hash cache write");
+        return;
+      }
       await writeCachedCommandHash(accountId, botIdentity, currentHash);
       return;
     }


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #753
**Commits**: 13 cherry-picked, 12 skipped

### Picked
| Hash | Subject | Notes |
|------|---------|-------|
| `6add2bcc1` | test(process): replace no-output timer subprocess with spawn mock | Clean pick |
| `ea1fe77c8` | fix: normalize coding-plan providers in auth order validation | Resolved: added `normalizeProviderIdForAuth` to `provider-utils.ts`, adapted import paths |
| `66c1da45d` | matrix: bootstrap crypto runtime when npm scripts are skipped | Resolved: combined fork renames with upstream async register + crypto bootstrap |
| `60130203e` | fix(queue): restart drain when message enqueued after idle window | Resolved: added `clearFollowupDrainCallback` call with fork's `"default"` lane, added new tests |
| `b64565492` | fix: avoid stale followup drain callbacks | Resolved: CHANGELOG conflict, code applied cleanly |
| `4985c561d` | sessions: reclaim orphan self-pid lock files | Clean pick |
| `f534ea990` | fix: prevent reasoning text leak through handleMessageEnd fallback | Partial: kept token changes, discarded gutted pi-embedded files |
| `479095bcf` | fix(discord): use per-channel message queues to restore parallel dispatch | Resolved: kept fork's `KeyedAsyncQueue`, took new tests |
| `16e7fc256` | fix(models): infer codex weekly usage labels from reset cadence | Clean pick |
| `e45d26b9e` | chore(gitignore): add .claude folder to gitignore | Clean pick |
| `bfb6c6290` | fix: distinguish warning message for non-RemoteClaw vs missing npm | Manual adapt: rebranded OpenClaw→RemoteClaw, applied to fork's refactored plugin install |
| `d98a61a97` | fix(config): move sensitive-schema hint warnings to debug | Clean pick |
| `c424836fb` | refactor: harden outbound, matrix bootstrap, and plugin entry resolution | Resolved: 5 conflicts (matrix SDK lazy loading + fork renames, plugin manifest refactor) |

### Skipped
| Hash | Subject | Reason |
|------|---------|--------|
| `ffa7c13c9` | fix(voice-call): verify call status with provider | Already applied |
| `a71b8d23b` | fix: add changelog credit for x-ai reasoning guard | CHANGELOG-only |
| `aab87ec88` | fix(agents): scope volcengine-plan/byteplus-plan auth lookup | Touches gutted model selection layer |
| `4a2329e0a` | fix: add changelog credit for fsPolicy image/pdf propagation | CHANGELOG-only |
| `62d0cfeee` | fix(delivery): strip HTML tags for plain-text messaging surfaces | Already applied (fork has superset) |
| `160dad56c` | fix: suppress HEARTBEAT_OK fallback leak | CHANGELOG-only |
| `0cf533ac6` | fix: recover orphan same-pid session locks | CHANGELOG-only |
| `a351ab248` | fix: persist webchat stream-only finals | CHANGELOG-only |
| `c48a0621f` | fix(agents): map sandbox workdir from container path | Touches gutted sandbox code |
| `ee0d7ba6d` | chore: normalize changelog credit for #31841 | CHANGELOG-only |
| `700361597` | fix: resolve rebase conflict markers | All changes already in fork |
| `00347bda7` | fix(tools): strip xAI-unsupported JSON Schema keywords | Touches gutted pi-tools, new utility has no callers |

### Community
@scoootscooob, @Lanfei, @Sid-Qin, @bmendonca3, @liuxiaopai-ai, @justingx

🤖 Generated with [Claude Code](https://claude.com/claude-code)