### PR TITLE
Cherry-pick b9b47f500: fix(discord): use correct content_type property for audio attachment detection

### DIFF
--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -486,8 +486,8 @@ export async function preflightDiscordMessage(
   // Preflight audio transcription for mention detection in guilds
   // This allows voice notes to be checked for mentions before being dropped
   let preflightTranscript: string | undefined;
-  const hasAudioAttachment = message.attachments?.some((att: { contentType?: string }) =>
-    att.contentType?.startsWith("audio/"),
+  const hasAudioAttachment = message.attachments?.some((att: { content_type?: string }) =>
+    att.content_type?.startsWith("audio/"),
   );
   const needsPreflightTranscription =
     !isDirectMessage &&
@@ -501,18 +501,18 @@ export async function preflightDiscordMessage(
       const { transcribeFirstAudio } = await import("../../stt/preflight.js");
       const audioPaths =
         message.attachments
-          ?.filter((att: { contentType?: string; url: string }) =>
-            att.contentType?.startsWith("audio/"),
+          ?.filter((att: { content_type?: string; url: string }) =>
+            att.content_type?.startsWith("audio/"),
           )
           .map((att: { url: string }) => att.url) ?? [];
       if (audioPaths.length > 0) {
         const tempCtx = {
           MediaUrls: audioPaths,
           MediaTypes: message.attachments
-            ?.filter((att: { contentType?: string; url: string }) =>
-              att.contentType?.startsWith("audio/"),
+            ?.filter((att: { content_type?: string; url: string }) =>
+              att.content_type?.startsWith("audio/"),
             )
-            .map((att: { contentType?: string }) => att.contentType)
+            .map((att: { content_type?: string }) => att.content_type)
             .filter(Boolean) as string[],
         };
         preflightTranscript = await transcribeFirstAudio({


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: `b9b47f50023d9f6384372bad6eee1a181b98c48e`
**Author**: jiangnan <1394485448@qq.com>

> fix(discord): use correct content_type property for audio attachment detection

Resolves #758 (2/4)

Depends on #1615