### PR TITLE
Cherry-pick 0b5d8e5b4: fix: harden discord audio preflight mention detection

### DIFF
--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -1,5 +1,11 @@
 import { ChannelType } from "@buape/carbon";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const transcribeFirstAudioMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../media-understanding/audio-preflight.js", () => ({
+  transcribeFirstAudio: (...args: unknown[]) => transcribeFirstAudioMock(...args),
+}));
 import {
   preflightDiscordMessage,
   resolvePreflightMentionRequirement,
@@ -7,6 +13,7 @@ import {
 } from "./message-handler.preflight.js";
 import {
   __testing as threadBindingTesting,
+  createNoopThreadBindingManager,
   createThreadBindingManager,
 } from "./thread-bindings.js";
 
@@ -59,6 +66,11 @@ describe("resolvePreflightMentionRequirement", () => {
 });
 
 describe("preflightDiscordMessage", () => {
+  beforeEach(() => {
+    threadBindingTesting.resetThreadBindingsForTests();
+    transcribeFirstAudioMock.mockReset();
+  });
+
   it("bypasses mention gating in bound threads for allowed bot senders", async () => {
     const threadBinding = createThreadBinding();
     const threadId = "thread-bot-focus";
@@ -142,6 +154,101 @@ describe("preflightDiscordMessage", () => {
     expect(result).not.toBeNull();
     expect(result?.boundSessionKey).toBe(threadBinding.targetSessionKey);
     expect(result?.shouldRequireMention).toBe(false);
+  });
+
+  it("uses attachment content_type for guild audio preflight mention detection", async () => {
+    transcribeFirstAudioMock.mockResolvedValue("hey openclaw");
+
+    const channelId = "channel-audio-1";
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === channelId) {
+          return {
+            id: channelId,
+            type: ChannelType.GuildText,
+            name: "general",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+
+    const message = {
+      id: "m-audio-1",
+      content: "",
+      timestamp: new Date().toISOString(),
+      channelId,
+      attachments: [
+        {
+          id: "att-1",
+          url: "https://cdn.discordapp.com/attachments/voice.ogg",
+          content_type: "audio/ogg",
+          filename: "voice.ogg",
+        },
+      ],
+      mentionedUsers: [],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+        messages: {
+          groupChat: {
+            mentionPatterns: ["remoteclaw"],
+          },
+        },
+      } as import("../../config/config.js").RemoteClawConfig,
+      discordConfig: {} as NonNullable<
+        import("../../config/config.js").RemoteClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: "remoteclaw-bot",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: createNoopThreadBindingManager("default"),
+      data: {
+        channel_id: channelId,
+        guild_id: "guild-1",
+        guild: {
+          id: "guild-1",
+          name: "Guild One",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
+    expect(transcribeFirstAudioMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          MediaUrls: ["https://cdn.discordapp.com/attachments/voice.ogg"],
+          MediaTypes: ["audio/ogg"],
+        }),
+      }),
+    );
+    expect(result).not.toBeNull();
+    expect(result?.wasMentioned).toBe(true);
   });
 });
 

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -489,11 +489,13 @@ export async function preflightDiscordMessage(
   const hasAudioAttachment = message.attachments?.some((att: { content_type?: string }) =>
     att.content_type?.startsWith("audio/"),
   );
+  const hasTypedText = Boolean(message.content?.trim());
   const needsPreflightTranscription =
     !isDirectMessage &&
     shouldRequireMention &&
     hasAudioAttachment &&
-    !baseText &&
+    // `baseText` includes media placeholders; gate on typed text only.
+    !hasTypedText &&
     mentionRegexes.length > 0;
 
   if (needsPreflightTranscription) {
@@ -526,10 +528,11 @@ export async function preflightDiscordMessage(
     }
   }
 
+  const mentionText = hasTypedText ? baseText : "";
   const wasMentioned =
     !isDirectMessage &&
     matchesMentionWithExplicit({
-      text: baseText,
+      text: mentionText,
       mentionRegexes,
       explicit: {
         hasAnyMention,


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: `0b5d8e5b47037771c46afac5f7a2a86bac9ee8a7`
**Author**: Peter Steinberger <steipete@gmail.com>

> fix: harden discord audio preflight mention detection (#32136) (thanks @jnMetaCode)

Resolves #758 (3/4)

Depends on #1616