### PR TITLE
Cherry-pick 2330c71b6: fix(cron): suppress delivery when multi-payload response contains HEARTBEAT_OK

### DIFF
--- a/src/cron/isolated-agent/helpers.test.ts
+++ b/src/cron/isolated-agent/helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isHeartbeatOnlyResponse,
   pickLastDeliverablePayload,
   pickLastNonEmptyTextFromPayloads,
   pickSummaryFromPayloads,
@@ -82,5 +83,67 @@ describe("pickLastDeliverablePayload", () => {
     const normal = { text: "ok", isError: undefined };
     const error = { text: "bad", isError: true as const };
     expect(pickLastDeliverablePayload([normal, error])).toBe(normal);
+  });
+});
+
+describe("isHeartbeatOnlyResponse", () => {
+  const ACK_MAX = 300;
+
+  it("returns true for empty payloads", () => {
+    expect(isHeartbeatOnlyResponse([], ACK_MAX)).toBe(true);
+  });
+
+  it("returns true for a single HEARTBEAT_OK payload", () => {
+    expect(isHeartbeatOnlyResponse([{ text: "HEARTBEAT_OK" }], ACK_MAX)).toBe(true);
+  });
+
+  it("returns false for a single non-heartbeat payload", () => {
+    expect(isHeartbeatOnlyResponse([{ text: "Something important happened" }], ACK_MAX)).toBe(
+      false,
+    );
+  });
+
+  it("returns true when multiple payloads include narration followed by HEARTBEAT_OK", () => {
+    // Agent narrates its work then signals nothing needs attention.
+    expect(
+      isHeartbeatOnlyResponse(
+        [
+          { text: "It's 12:49 AM — quiet hours. Let me run the checks quickly." },
+          { text: "Emails: Just 2 calendar invites. Not urgent." },
+          { text: "HEARTBEAT_OK" },
+        ],
+        ACK_MAX,
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when media is present even with HEARTBEAT_OK text", () => {
+    expect(
+      isHeartbeatOnlyResponse(
+        [{ text: "HEARTBEAT_OK", mediaUrl: "https://example.com/img.png" }],
+        ACK_MAX,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when media is in a different payload than HEARTBEAT_OK", () => {
+    expect(
+      isHeartbeatOnlyResponse(
+        [
+          { text: "HEARTBEAT_OK" },
+          { text: "Here's an image", mediaUrl: "https://example.com/img.png" },
+        ],
+        ACK_MAX,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when no payload contains HEARTBEAT_OK", () => {
+    expect(
+      isHeartbeatOnlyResponse(
+        [{ text: "Checked emails — found 3 urgent messages from your manager." }],
+        ACK_MAX,
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: `2330c71b6`
**Author**: Adhish <adhishthite@Adhishs-MacBook-Pro.local>

> fix(cron): suppress delivery when multi-payload response contains HEARTBEAT_OK

Depends on #1618