### PR TITLE
Cherry-pick issue #767: feishu/lark adapter fixes

### DIFF
--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -3,7 +3,7 @@ import { parseFeishuMessageEvent } from "./bot.js";
 
 // Helper to build a minimal FeishuMessageEvent for testing
 function makeEvent(
-  chatType: "p2p" | "group",
+  chatType: "p2p" | "group" | "private",
   mentions?: Array<{ key: string; name: string; id: { open_id?: string } }>,
   text = "hello",
 ) {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1124,6 +1124,83 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("keeps root_id as topic key when root_id and thread_id both exist", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group_topic_sender",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-user" } },
+      message: {
+        message_id: "msg-scope-topic-thread-id",
+        chat_id: "oc-group",
+        chat_type: "group",
+        root_id: "om_root_topic",
+        thread_id: "omt_topic_1",
+        message_type: "text",
+        content: JSON.stringify({ text: "topic sender scope" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockResolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        peer: { kind: "group", id: "oc-group:topic:om_root_topic:sender:ou-topic-user" },
+        parentPeer: { kind: "group", id: "oc-group" },
+      }),
+    );
+  });
+
+  it("uses thread_id as topic key when root_id is missing", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group_topic_sender",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-user" } },
+      message: {
+        message_id: "msg-scope-topic-thread-only",
+        chat_id: "oc-group",
+        chat_type: "group",
+        thread_id: "omt_topic_1",
+        message_type: "text",
+        content: JSON.stringify({ text: "topic sender scope" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockResolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        peer: { kind: "group", id: "oc-group:topic:omt_topic_1:sender:ou-topic-user" },
+        parentPeer: { kind: "group", id: "oc-group" },
+      }),
+    );
+  });
+
   it("maps legacy topicSessionMode=enabled to group_topic routing", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
@@ -1147,6 +1224,45 @@ describe("handleFeishuMessage command authorization", () => {
         chat_id: "oc-group",
         chat_type: "group",
         root_id: "om_root_legacy",
+        message_type: "text",
+        content: JSON.stringify({ text: "legacy topic mode" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockResolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        peer: { kind: "group", id: "oc-group:topic:om_root_legacy" },
+        parentPeer: { kind: "group", id: "oc-group" },
+      }),
+    );
+  });
+
+  it("maps legacy topicSessionMode=enabled to root_id when both root_id and thread_id exist", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          topicSessionMode: "enabled",
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-legacy-thread-id" } },
+      message: {
+        message_id: "msg-legacy-topic-thread-id",
+        chat_id: "oc-group",
+        chat_type: "group",
+        root_id: "om_root_legacy",
+        thread_id: "omt_topic_legacy",
         message_type: "text",
         content: JSON.stringify({ text: "legacy topic mode" }),
       },
@@ -1196,6 +1312,102 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         peer: { kind: "group", id: "oc-group:topic:msg-new-topic-root" },
         parentPeer: { kind: "group", id: "oc-group" },
+      }),
+    );
+  });
+
+  it("keeps topic session key stable after first turn creates a thread", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group_topic",
+              replyInThread: "enabled",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const firstTurn: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-init" } },
+      message: {
+        message_id: "msg-topic-first",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "create topic" }),
+      },
+    };
+    const secondTurn: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-init" } },
+      message: {
+        message_id: "msg-topic-second",
+        chat_id: "oc-group",
+        chat_type: "group",
+        root_id: "msg-topic-first",
+        thread_id: "omt_topic_created",
+        message_type: "text",
+        content: JSON.stringify({ text: "follow up in same topic" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event: firstTurn });
+    await dispatchMessage({ cfg, event: secondTurn });
+
+    expect(mockResolveAgentRoute).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        peer: { kind: "group", id: "oc-group:topic:msg-topic-first" },
+      }),
+    );
+    expect(mockResolveAgentRoute).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        peer: { kind: "group", id: "oc-group:topic:msg-topic-first" },
+      }),
+    );
+  });
+
+  it("forces thread replies when inbound message contains thread_id", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group",
+              replyInThread: "disabled",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-thread-reply" } },
+      message: {
+        message_id: "msg-thread-reply",
+        chat_id: "oc-group",
+        chat_type: "group",
+        thread_id: "omt_topic_thread_reply",
+        message_type: "text",
+        content: JSON.stringify({ text: "thread content" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyInThread: true,
+        threadReply: true,
       }),
     );
   });

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1434,6 +1434,44 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("replies to the topic root when handling a message inside an existing topic", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              replyInThread: "enabled",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-user" } },
+      message: {
+        message_id: "om_child_message",
+        root_id: "om_root_topic",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "reply inside topic" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_root_topic",
+        rootId: "om_root_topic",
+      }),
+    );
+  });
+
   it("forces thread replies when inbound message contains thread_id", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1049,6 +1049,67 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("ignores stale non-existent contact scope permission errors", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockCreateFeishuClient.mockReturnValue({
+      contact: {
+        user: {
+          get: vi.fn().mockRejectedValue({
+            response: {
+              data: {
+                code: 99991672,
+                msg: "permission denied: contact:contact.base:readonly https://open.feishu.cn/app/cli_scope_bug",
+              },
+            },
+          }),
+        },
+      },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_scope_bug",
+          appSecret: "sec_scope_bug",
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-perm-scope",
+        },
+      },
+      message: {
+        message_id: "msg-perm-scope-1",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello group" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.not.stringContaining("Permission grant URL"),
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining("ou-perm-scope: hello group"),
+      }),
+    );
+  });
+
   it("routes group sessions by sender when groupSessionScope=group_sender", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -342,6 +342,41 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("replies pairing challenge to DM chat_id instead of user:sender id", async () => {
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "pairing",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          user_id: "u_mobile_only",
+        },
+      },
+      message: {
+        message_id: "msg-pairing-chat-reply",
+        chat_id: "oc_dm_chat_1",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello" }),
+      },
+    };
+
+    mockReadAllowFromStore.mockResolvedValue([]);
+    mockUpsertPairingRequest.mockResolvedValue({ code: "ABCDEFGH", created: true });
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockSendMessageFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat:oc_dm_chat_1",
+      }),
+    );
+  });
   it("creates pairing request and drops unauthorized DMs in pairing mode", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockReadAllowFromStore.mockResolvedValue([]);
@@ -386,7 +421,7 @@ describe("handleFeishuMessage command authorization", () => {
     });
     expect(mockSendMessageFeishu).toHaveBeenCalledWith(
       expect.objectContaining({
-        to: "user:ou-unapproved",
+        to: "chat:oc-dm",
         accountId: "default",
       }),
     );

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -44,6 +44,13 @@ type PermissionError = {
   grantUrl?: string;
 };
 
+const IGNORED_PERMISSION_SCOPE_TOKENS = ["contact:contact.base:readonly"];
+
+function shouldSuppressPermissionErrorNotice(permissionError: PermissionError): boolean {
+  const message = permissionError.message.toLowerCase();
+  return IGNORED_PERMISSION_SCOPE_TOKENS.some((token) => message.includes(token));
+}
+
 function extractPermissionError(err: unknown): PermissionError | null {
   if (!err || typeof err !== "object") return null;
 
@@ -140,6 +147,10 @@ async function resolveFeishuSenderName(params: {
     // Check if this is a permission error
     const permErr = extractPermissionError(err);
     if (permErr) {
+      if (shouldSuppressPermissionErrorNotice(permErr)) {
+        log(`feishu: ignoring stale permission scope error: ${permErr.message}`);
+        return {};
+      }
       log(`feishu: permission error resolving sender name: code=${permErr.code}`);
       return { permissionError: permErr };
     }

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -164,6 +164,7 @@ export type FeishuMessageEvent = {
     message_id: string;
     root_id?: string;
     parent_id?: string;
+    thread_id?: string;
     chat_id: string;
     chat_type: "p2p" | "group" | "private";
     message_type: string;
@@ -192,6 +193,94 @@ export type FeishuBotAddedEvent = {
   external: boolean;
   operator_tenant_key?: string;
 };
+
+type GroupSessionScope = "group" | "group_sender" | "group_topic" | "group_topic_sender";
+
+type ResolvedFeishuGroupSession = {
+  peerId: string;
+  parentPeer: { kind: "group"; id: string } | null;
+  groupSessionScope: GroupSessionScope;
+  replyInThread: boolean;
+  threadReply: boolean;
+};
+
+function resolveFeishuGroupSession(params: {
+  chatId: string;
+  senderOpenId: string;
+  messageId: string;
+  rootId?: string;
+  threadId?: string;
+  groupConfig?: {
+    groupSessionScope?: GroupSessionScope;
+    topicSessionMode?: "enabled" | "disabled";
+    replyInThread?: "enabled" | "disabled";
+  };
+  feishuCfg?: {
+    groupSessionScope?: GroupSessionScope;
+    topicSessionMode?: "enabled" | "disabled";
+    replyInThread?: "enabled" | "disabled";
+  };
+}): ResolvedFeishuGroupSession {
+  const { chatId, senderOpenId, messageId, rootId, threadId, groupConfig, feishuCfg } = params;
+
+  const normalizedThreadId = threadId?.trim();
+  const normalizedRootId = rootId?.trim();
+  const threadReply = Boolean(normalizedThreadId || normalizedRootId);
+  const replyInThread =
+    (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled" ||
+    threadReply;
+
+  const legacyTopicSessionMode =
+    groupConfig?.topicSessionMode ?? feishuCfg?.topicSessionMode ?? "disabled";
+  const groupSessionScope: GroupSessionScope =
+    groupConfig?.groupSessionScope ??
+    feishuCfg?.groupSessionScope ??
+    (legacyTopicSessionMode === "enabled" ? "group_topic" : "group");
+
+  // Keep topic session keys stable across the "first turn creates thread" flow:
+  // first turn may only have message_id, while the next turn carries root_id/thread_id.
+  // Prefer root_id first so both turns stay on the same peer key.
+  const topicScope =
+    groupSessionScope === "group_topic" || groupSessionScope === "group_topic_sender"
+      ? (normalizedRootId ?? normalizedThreadId ?? (replyInThread ? messageId : null))
+      : null;
+
+  let peerId = chatId;
+  switch (groupSessionScope) {
+    case "group_sender":
+      peerId = `${chatId}:sender:${senderOpenId}`;
+      break;
+    case "group_topic":
+      peerId = topicScope ? `${chatId}:topic:${topicScope}` : chatId;
+      break;
+    case "group_topic_sender":
+      peerId = topicScope
+        ? `${chatId}:topic:${topicScope}:sender:${senderOpenId}`
+        : `${chatId}:sender:${senderOpenId}`;
+      break;
+    case "group":
+    default:
+      peerId = chatId;
+      break;
+  }
+
+  const parentPeer =
+    topicScope &&
+    (groupSessionScope === "group_topic" || groupSessionScope === "group_topic_sender")
+      ? {
+          kind: "group" as const,
+          id: chatId,
+        }
+      : null;
+
+  return {
+    peerId,
+    parentPeer,
+    groupSessionScope,
+    replyInThread,
+    threadReply,
+  };
+}
 
 function parseMessageContent(content: string, messageType: string): string {
   if (messageType === "post") {
@@ -624,6 +713,7 @@ export function parseFeishuMessageEvent(
     mentionedBot,
     rootId: event.message.root_id || undefined,
     parentId: event.message.parent_id || undefined,
+    threadId: event.message.thread_id || undefined,
     content,
     contentType: event.message.message_type,
   };
@@ -744,6 +834,18 @@ export async function handleFeishuMessage(params: {
   const groupConfig = isGroup
     ? resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: ctx.chatId })
     : undefined;
+  const groupSession = isGroup
+    ? resolveFeishuGroupSession({
+        chatId: ctx.chatId,
+        senderOpenId: ctx.senderOpenId,
+        messageId: ctx.messageId,
+        rootId: ctx.rootId,
+        threadId: ctx.threadId,
+        groupConfig,
+        feishuCfg,
+      })
+    : null;
+  const groupHistoryKey = isGroup ? (groupSession?.peerId ?? ctx.chatId) : undefined;
   const dmPolicy = feishuCfg?.dmPolicy ?? "pairing";
   const configAllowFrom = feishuCfg?.allowFrom ?? [];
   const useAccessGroups = cfg.commands?.useAccessGroups !== false;
@@ -812,10 +914,10 @@ export async function handleFeishuMessage(params: {
       log(
         `feishu[${account.accountId}]: message in group ${ctx.chatId} did not mention bot, recording to history`,
       );
-      if (chatHistories) {
+      if (chatHistories && groupHistoryKey) {
         recordPendingHistoryEntryIfEnabled({
           historyMap: chatHistories,
-          historyKey: ctx.chatId,
+          historyKey: groupHistoryKey,
           limit: historyLimit,
           entry: {
             sender: ctx.senderOpenId,
@@ -910,50 +1012,14 @@ export async function handleFeishuMessage(params: {
     // Using a group-scoped From causes the agent to treat different users as the same person.
     const feishuFrom = `feishu:${ctx.senderOpenId}`;
     const feishuTo = isGroup ? `chat:${ctx.chatId}` : `user:${ctx.senderOpenId}`;
+    const peerId = isGroup ? (groupSession?.peerId ?? ctx.chatId) : ctx.senderOpenId;
+    const parentPeer = isGroup ? (groupSession?.parentPeer ?? null) : null;
+    const replyInThread = isGroup ? (groupSession?.replyInThread ?? false) : false;
 
-    // Resolve peer ID for session routing.
-    // Default is one session per group chat; this can be customized with groupSessionScope.
-    let peerId = isGroup ? ctx.chatId : ctx.senderOpenId;
-    let groupSessionScope: "group" | "group_sender" | "group_topic" | "group_topic_sender" =
-      "group";
-    let topicRootForSession: string | null = null;
-    const replyInThread =
-      isGroup &&
-      (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
-
-    if (isGroup) {
-      const legacyTopicSessionMode =
-        groupConfig?.topicSessionMode ?? feishuCfg?.topicSessionMode ?? "disabled";
-      groupSessionScope =
-        groupConfig?.groupSessionScope ??
-        feishuCfg?.groupSessionScope ??
-        (legacyTopicSessionMode === "enabled" ? "group_topic" : "group");
-
-      // When topic-scoped sessions are enabled and replyInThread is on, the first
-      // bot reply creates the thread rooted at the current message ID.
-      if (groupSessionScope === "group_topic" || groupSessionScope === "group_topic_sender") {
-        topicRootForSession = ctx.rootId ?? (replyInThread ? ctx.messageId : null);
-      }
-
-      switch (groupSessionScope) {
-        case "group_sender":
-          peerId = `${ctx.chatId}:sender:${ctx.senderOpenId}`;
-          break;
-        case "group_topic":
-          peerId = topicRootForSession ? `${ctx.chatId}:topic:${topicRootForSession}` : ctx.chatId;
-          break;
-        case "group_topic_sender":
-          peerId = topicRootForSession
-            ? `${ctx.chatId}:topic:${topicRootForSession}:sender:${ctx.senderOpenId}`
-            : `${ctx.chatId}:sender:${ctx.senderOpenId}`;
-          break;
-        case "group":
-        default:
-          peerId = ctx.chatId;
-          break;
-      }
-
-      log(`feishu[${account.accountId}]: group session scope=${groupSessionScope}, peer=${peerId}`);
+    if (isGroup && groupSession) {
+      log(
+        `feishu[${account.accountId}]: group session scope=${groupSession.groupSessionScope}, peer=${peerId}`,
+      );
     }
 
     let route = core.channel.routing.resolveAgentRoute({
@@ -964,16 +1030,7 @@ export async function handleFeishuMessage(params: {
         kind: isGroup ? "group" : "direct",
         id: peerId,
       },
-      // Add parentPeer for binding inheritance in topic-scoped modes.
-      parentPeer:
-        isGroup &&
-        topicRootForSession &&
-        (groupSessionScope === "group_topic" || groupSessionScope === "group_topic_sender")
-          ? {
-              kind: "group",
-              id: ctx.chatId,
-            }
-          : null,
+      parentPeer,
     });
 
     // Dynamic agent creation for DM users
@@ -1091,7 +1148,7 @@ export async function handleFeishuMessage(params: {
     });
 
     let combinedBody = body;
-    const historyKey = isGroup ? ctx.chatId : undefined;
+    const historyKey = groupHistoryKey;
 
     if (isGroup && historyKey && chatHistories) {
       combinedBody = buildPendingHistoryContextFromMap({
@@ -1164,6 +1221,7 @@ export async function handleFeishuMessage(params: {
       skipReplyToInMessages: !isGroup,
       replyInThread,
       rootId: ctx.rootId,
+      threadReply: isGroup ? (groupSession?.threadReply ?? false) : false,
       mentionTargets: ctx.mentionTargets,
       accountId: account.accountId,
       messageCreateTimeMs,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -165,7 +165,7 @@ export type FeishuMessageEvent = {
     root_id?: string;
     parent_id?: string;
     chat_id: string;
-    chat_type: "p2p" | "group";
+    chat_type: "p2p" | "group" | "private";
     message_type: string;
     content: string;
     create_time?: string;
@@ -668,6 +668,7 @@ export async function handleFeishuMessage(params: {
 
   let ctx = parseFeishuMessageEvent(event, botOpenId);
   const isGroup = ctx.chatType === "group";
+  const isDirect = !isGroup;
   const senderUserId = event.sender.sender_id.user_id?.trim() || undefined;
 
   // Handle merge_forward messages: fetch full message via API then expand sub-messages
@@ -854,7 +855,7 @@ export async function handleFeishuMessage(params: {
       senderName: ctx.senderName,
     }).allowed;
 
-    if (!isGroup && dmPolicy !== "open" && !dmAllowed) {
+    if (isDirect && dmPolicy !== "open" && !dmAllowed) {
       if (dmPolicy === "pairing") {
         const { code, created } = await pairing.upsertPairingRequest({
           id: ctx.senderOpenId,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1222,13 +1222,13 @@ export async function handleFeishuMessage(params: {
     const messageCreateTimeMs = event.message.create_time
       ? parseInt(event.message.create_time, 10)
       : undefined;
-
+    const replyTargetMessageId = ctx.rootId ?? ctx.messageId;
     const { dispatcher, replyOptions, markDispatchIdle } = createFeishuReplyDispatcher({
       cfg,
       agentId: route.agentId,
       runtime: runtime as RuntimeEnv,
       chatId: ctx.chatId,
-      replyToMessageId: ctx.messageId,
+      replyToMessageId: replyTargetMessageId,
       skipReplyToInMessages: !isGroup,
       replyInThread,
       rootId: ctx.rootId,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -866,7 +866,7 @@ export async function handleFeishuMessage(params: {
           try {
             await sendMessageFeishu({
               cfg,
-              to: `user:${ctx.senderOpenId}`,
+              to: `chat:${ctx.chatId}`,
               text: core.channel.pairing.buildPairingReply({
                 channel: "feishu",
                 idLine: `Your Feishu user id: ${ctx.senderOpenId}`,

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -110,6 +110,9 @@ const GroupSessionScopeSchema = z
  * Topic session isolation mode for group chats.
  * - "disabled" (default): All messages in a group share one session
  * - "enabled": Messages in different topics get separate sessions
+ *
+ * Topic routing uses `root_id` when present to keep session continuity and
+ * falls back to `thread_id` when `root_id` is unavailable.
  */
 const TopicSessionModeSchema = z.enum(["disabled", "enabled"]).optional();
 const ReactionNotificationModeSchema = z.enum(["off", "own", "all"]).optional();

--- a/extensions/feishu/src/dedup.ts
+++ b/extensions/feishu/src/dedup.ts
@@ -89,3 +89,12 @@ export async function hasRecordedMessagePersistent(
     return false;
   }
 }
+
+export async function warmupDedupFromDisk(
+  namespace: string,
+  log?: (...args: unknown[]) => void,
+): Promise<number> {
+  return persistentDedupe.warmup(namespace, (error) => {
+    log?.(`feishu-dedup: warmup disk error: ${String(error)}`);
+  });
+}

--- a/extensions/feishu/src/dedup.ts
+++ b/extensions/feishu/src/dedup.ts
@@ -1,11 +1,16 @@
 import os from "node:os";
 import path from "node:path";
-import { createDedupeCache, createPersistentDedupe } from "remoteclaw/plugin-sdk";
+import {
+  createDedupeCache,
+  createPersistentDedupe,
+  readJsonFileWithFallback,
+} from "remoteclaw/plugin-sdk";
 
 // Persistent TTL: 24 hours — survives restarts & WebSocket reconnects.
 const DEDUP_TTL_MS = 24 * 60 * 60 * 1000;
 const MEMORY_MAX_SIZE = 1_000;
 const FILE_MAX_ENTRIES = 10_000;
+type PersistentDedupeData = Record<string, number>;
 
 const memoryDedupe = createDedupeCache({ ttlMs: DEDUP_TTL_MS, maxSize: MEMORY_MAX_SIZE });
 
@@ -40,6 +45,14 @@ export function tryRecordMessage(messageId: string): boolean {
   return !memoryDedupe.check(messageId);
 }
 
+export function hasRecordedMessage(messageId: string): boolean {
+  const trimmed = messageId.trim();
+  if (!trimmed) {
+    return false;
+  }
+  return memoryDedupe.peek(trimmed);
+}
+
 export async function tryRecordMessagePersistent(
   messageId: string,
   namespace = "global",
@@ -51,4 +64,28 @@ export async function tryRecordMessagePersistent(
       log?.(`feishu-dedup: disk error, falling back to memory: ${String(error)}`);
     },
   });
+}
+
+export async function hasRecordedMessagePersistent(
+  messageId: string,
+  namespace = "global",
+  log?: (...args: unknown[]) => void,
+): Promise<boolean> {
+  const trimmed = messageId.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const now = Date.now();
+  const filePath = resolveNamespaceFilePath(namespace);
+  try {
+    const { value } = await readJsonFileWithFallback<PersistentDedupeData>(filePath, {});
+    const seenAt = value[trimmed];
+    if (typeof seenAt !== "number" || !Number.isFinite(seenAt)) {
+      return false;
+    }
+    return DEDUP_TTL_MS <= 0 || now - seenAt < DEDUP_TTL_MS;
+  } catch (error) {
+    log?.(`feishu-dedup: persistent peek failed: ${String(error)}`);
+    return false;
+  }
 }

--- a/extensions/feishu/src/mention.ts
+++ b/extensions/feishu/src/mention.ts
@@ -53,7 +53,7 @@ export function isMentionForwardRequest(event: FeishuMessageEvent, botOpenId?: s
     return false;
   }
 
-  const isDirectMessage = event.message.chat_type === "p2p";
+  const isDirectMessage = event.message.chat_type !== "group";
   const hasOtherMention = mentions.some((m) => m.id.open_id !== botOpenId);
 
   if (isDirectMessage) {

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -17,7 +17,7 @@ const FEISHU_REACTION_VERIFY_TIMEOUT_MS = 1_500;
 export type FeishuReactionCreatedEvent = {
   message_id: string;
   chat_id?: string;
-  chat_type?: "p2p" | "group";
+  chat_type?: "p2p" | "group" | "private";
   reaction_type?: { emoji_type?: string };
   operator_type?: string;
   user_id?: { open_id?: string };
@@ -93,7 +93,8 @@ export async function resolveReactionSyntheticEvent(
 
   const syntheticChatIdRaw = event.chat_id ?? reactedMsg.chatId;
   const syntheticChatId = syntheticChatIdRaw?.trim() ? syntheticChatIdRaw : `p2p:${senderId}`;
-  const syntheticChatType: "p2p" | "group" = event.chat_type ?? "p2p";
+  const syntheticChatType: "p2p" | "group" | "private" =
+    event.chat_type === "group" ? "group" : "p2p";
   return {
     sender: {
       sender_id: { open_id: senderId },

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -16,6 +16,7 @@ import {
   hasRecordedMessagePersistent,
   tryRecordMessage,
   tryRecordMessagePersistent,
+  warmupDedupFromDisk,
 } from "./dedup.js";
 import { isMentionForwardRequest } from "./mention.js";
 import { fetchBotOpenIdForMonitor } from "./monitor.startup.js";
@@ -508,6 +509,11 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
   const connectionMode = account.config.connectionMode ?? "websocket";
   if (connectionMode === "webhook" && !account.verificationToken?.trim()) {
     throw new Error(`Feishu account "${accountId}" webhook mode requires verificationToken`);
+  }
+
+  const warmupCount = await warmupDedupFromDisk(accountId, log);
+  if (warmupCount > 0) {
+    log(`feishu[${accountId}]: dedup warmup loaded ${warmupCount} entries from disk`);
   }
 
   const eventDispatcher = createEventDispatcher(account);

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -133,6 +133,25 @@ type RegisterEventHandlersContext = {
   fireAndForget?: boolean;
 };
 
+/**
+ * Per-chat serial queue that ensures messages from the same chat are processed
+ * in arrival order while allowing different chats to run concurrently.
+ */
+function createChatQueue() {
+  const queues = new Map<string, Promise<void>>();
+  return (chatId: string, task: () => Promise<void>): Promise<void> => {
+    const prev = queues.get(chatId) ?? Promise.resolve();
+    const next = prev.then(task, task);
+    queues.set(chatId, next);
+    void next.finally(() => {
+      if (queues.get(chatId) === next) {
+        queues.delete(chatId);
+      }
+    });
+    return next;
+  };
+}
+
 function mergeFeishuDebounceMentions(
   entries: FeishuMessageEvent[],
 ): FeishuMessageEvent["message"]["mentions"] | undefined {
@@ -219,15 +238,19 @@ function registerEventHandlers(
   });
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
+  const enqueue = createChatQueue();
   const dispatchFeishuMessage = async (event: FeishuMessageEvent) => {
-    await handleFeishuMessage({
-      cfg,
-      event,
-      botOpenId: botOpenIds.get(accountId),
-      runtime,
-      chatHistories,
-      accountId,
-    });
+    const chatId = event.message.chat_id?.trim() || "unknown";
+    const task = () =>
+      handleFeishuMessage({
+        cfg,
+        event,
+        botOpenId: botOpenIds.get(accountId),
+        runtime,
+        chatHistories,
+        accountId,
+      });
+    await enqueue(chatId, task);
   };
   const resolveSenderDebounceId = (event: FeishuMessageEvent): string | undefined => {
     const senderId =

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -3,12 +3,25 @@ import * as Lark from "@larksuiteoapi/node-sdk";
 import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "remoteclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { raceWithTimeoutAndAbort } from "./async.js";
-import { handleFeishuMessage, type FeishuMessageEvent, type FeishuBotAddedEvent } from "./bot.js";
+import {
+  handleFeishuMessage,
+  parseFeishuMessageEvent,
+  type FeishuMessageEvent,
+  type FeishuBotAddedEvent,
+} from "./bot.js";
 import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
 import { createEventDispatcher } from "./client.js";
+import {
+  hasRecordedMessage,
+  hasRecordedMessagePersistent,
+  tryRecordMessage,
+  tryRecordMessagePersistent,
+} from "./dedup.js";
+import { isMentionForwardRequest } from "./mention.js";
 import { fetchBotOpenIdForMonitor } from "./monitor.startup.js";
 import { botOpenIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
+import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu } from "./send.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
@@ -120,33 +133,238 @@ type RegisterEventHandlersContext = {
   fireAndForget?: boolean;
 };
 
+function mergeFeishuDebounceMentions(
+  entries: FeishuMessageEvent[],
+): FeishuMessageEvent["message"]["mentions"] | undefined {
+  const merged = new Map<string, NonNullable<FeishuMessageEvent["message"]["mentions"]>[number]>();
+  for (const entry of entries) {
+    for (const mention of entry.message.mentions ?? []) {
+      const stableId =
+        mention.id.open_id?.trim() || mention.id.user_id?.trim() || mention.id.union_id?.trim();
+      const mentionName = mention.name?.trim();
+      const mentionKey = mention.key?.trim();
+      const fallback =
+        mentionName && mentionKey ? `${mentionName}|${mentionKey}` : mentionName || mentionKey;
+      const key = stableId || fallback;
+      if (!key || merged.has(key)) {
+        continue;
+      }
+      merged.set(key, mention);
+    }
+  }
+  if (merged.size === 0) {
+    return undefined;
+  }
+  return Array.from(merged.values());
+}
+
+function dedupeFeishuDebounceEntriesByMessageId(
+  entries: FeishuMessageEvent[],
+): FeishuMessageEvent[] {
+  const seen = new Set<string>();
+  const deduped: FeishuMessageEvent[] = [];
+  for (const entry of entries) {
+    const messageId = entry.message.message_id?.trim();
+    if (!messageId) {
+      deduped.push(entry);
+      continue;
+    }
+    if (seen.has(messageId)) {
+      continue;
+    }
+    seen.add(messageId);
+    deduped.push(entry);
+  }
+  return deduped;
+}
+
+function resolveFeishuDebounceMentions(params: {
+  entries: FeishuMessageEvent[];
+  botOpenId?: string;
+}): FeishuMessageEvent["message"]["mentions"] | undefined {
+  const { entries, botOpenId } = params;
+  if (entries.length === 0) {
+    return undefined;
+  }
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (isMentionForwardRequest(entry, botOpenId)) {
+      // Keep mention-forward semantics scoped to a single source message.
+      return mergeFeishuDebounceMentions([entry]);
+    }
+  }
+  const merged = mergeFeishuDebounceMentions(entries);
+  if (!merged) {
+    return undefined;
+  }
+  const normalizedBotOpenId = botOpenId?.trim();
+  if (!normalizedBotOpenId) {
+    return undefined;
+  }
+  const botMentions = merged.filter(
+    (mention) => mention.id.open_id?.trim() === normalizedBotOpenId,
+  );
+  return botMentions.length > 0 ? botMentions : undefined;
+}
+
 function registerEventHandlers(
   eventDispatcher: Lark.EventDispatcher,
   context: RegisterEventHandlersContext,
 ): void {
   const { cfg, accountId, runtime, chatHistories, fireAndForget } = context;
+  const core = getFeishuRuntime();
+  const inboundDebounceMs = core.channel.debounce.resolveInboundDebounceMs({
+    cfg,
+    channel: "feishu",
+  });
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
+  const dispatchFeishuMessage = async (event: FeishuMessageEvent) => {
+    await handleFeishuMessage({
+      cfg,
+      event,
+      botOpenId: botOpenIds.get(accountId),
+      runtime,
+      chatHistories,
+      accountId,
+    });
+  };
+  const resolveSenderDebounceId = (event: FeishuMessageEvent): string | undefined => {
+    const senderId =
+      event.sender.sender_id.open_id?.trim() || event.sender.sender_id.user_id?.trim();
+    return senderId || undefined;
+  };
+  const resolveDebounceText = (event: FeishuMessageEvent): string => {
+    const botOpenId = botOpenIds.get(accountId);
+    const parsed = parseFeishuMessageEvent(event, botOpenId);
+    return parsed.content.trim();
+  };
+  const recordSuppressedMessageIds = async (
+    entries: FeishuMessageEvent[],
+    dispatchMessageId?: string,
+  ) => {
+    const keepMessageId = dispatchMessageId?.trim();
+    const suppressedIds = new Set(
+      entries
+        .map((entry) => entry.message.message_id?.trim())
+        .filter((id): id is string => Boolean(id) && (!keepMessageId || id !== keepMessageId)),
+    );
+    if (suppressedIds.size === 0) {
+      return;
+    }
+    for (const messageId of suppressedIds) {
+      // Keep in-memory dedupe in sync with handleFeishuMessage's keying.
+      tryRecordMessage(`${accountId}:${messageId}`);
+      try {
+        await tryRecordMessagePersistent(messageId, accountId, log);
+      } catch (err) {
+        error(
+          `feishu[${accountId}]: failed to record merged dedupe id ${messageId}: ${String(err)}`,
+        );
+      }
+    }
+  };
+  const isMessageAlreadyProcessed = async (entry: FeishuMessageEvent): Promise<boolean> => {
+    const messageId = entry.message.message_id?.trim();
+    if (!messageId) {
+      return false;
+    }
+    const memoryKey = `${accountId}:${messageId}`;
+    if (hasRecordedMessage(memoryKey)) {
+      return true;
+    }
+    return hasRecordedMessagePersistent(messageId, accountId, log);
+  };
+  const inboundDebouncer = core.channel.debounce.createInboundDebouncer<FeishuMessageEvent>({
+    debounceMs: inboundDebounceMs,
+    buildKey: (event) => {
+      const chatId = event.message.chat_id?.trim();
+      const senderId = resolveSenderDebounceId(event);
+      if (!chatId || !senderId) {
+        return null;
+      }
+      const rootId = event.message.root_id?.trim();
+      const threadKey = rootId ? `thread:${rootId}` : "chat";
+      return `feishu:${accountId}:${chatId}:${threadKey}:${senderId}`;
+    },
+    shouldDebounce: (event) => {
+      if (event.message.message_type !== "text") {
+        return false;
+      }
+      const text = resolveDebounceText(event);
+      if (!text) {
+        return false;
+      }
+      return !core.channel.text.hasControlCommand(text, cfg);
+    },
+    onFlush: async (entries) => {
+      const last = entries.at(-1);
+      if (!last) {
+        return;
+      }
+      if (entries.length === 1) {
+        await dispatchFeishuMessage(last);
+        return;
+      }
+      const dedupedEntries = dedupeFeishuDebounceEntriesByMessageId(entries);
+      const freshEntries: FeishuMessageEvent[] = [];
+      for (const entry of dedupedEntries) {
+        if (!(await isMessageAlreadyProcessed(entry))) {
+          freshEntries.push(entry);
+        }
+      }
+      const dispatchEntry = freshEntries.at(-1);
+      if (!dispatchEntry) {
+        return;
+      }
+      await recordSuppressedMessageIds(dedupedEntries, dispatchEntry.message.message_id);
+      const combinedText = freshEntries
+        .map((entry) => resolveDebounceText(entry))
+        .filter(Boolean)
+        .join("\n");
+      const mergedMentions = resolveFeishuDebounceMentions({
+        entries: freshEntries,
+        botOpenId: botOpenIds.get(accountId),
+      });
+      if (!combinedText.trim()) {
+        await dispatchFeishuMessage({
+          ...dispatchEntry,
+          message: {
+            ...dispatchEntry.message,
+            mentions: mergedMentions ?? dispatchEntry.message.mentions,
+          },
+        });
+        return;
+      }
+      await dispatchFeishuMessage({
+        ...dispatchEntry,
+        message: {
+          ...dispatchEntry.message,
+          message_type: "text",
+          content: JSON.stringify({ text: combinedText }),
+          mentions: mergedMentions ?? dispatchEntry.message.mentions,
+        },
+      });
+    },
+    onError: (err) => {
+      error(`feishu[${accountId}]: inbound debounce flush failed: ${String(err)}`);
+    },
+  });
 
   eventDispatcher.register({
     "im.message.receive_v1": async (data) => {
-      try {
+      const processMessage = async () => {
         const event = data as unknown as FeishuMessageEvent;
-        const promise = handleFeishuMessage({
-          cfg,
-          event,
-          botOpenId: botOpenIds.get(accountId),
-          runtime,
-          chatHistories,
-          accountId,
+        await inboundDebouncer.enqueue(event);
+      };
+      if (fireAndForget) {
+        void processMessage().catch((err) => {
+          error(`feishu[${accountId}]: error handling message: ${String(err)}`);
         });
-        if (fireAndForget) {
-          promise.catch((err) => {
-            error(`feishu[${accountId}]: error handling message: ${String(err)}`);
-          });
-        } else {
-          await promise;
-        }
+        return;
+      }
+      try {
+        await processMessage();
       } catch (err) {
         error(`feishu[${accountId}]: error handling message: ${String(err)}`);
       }

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -1,6 +1,40 @@
-import type { ClawdbotConfig } from "remoteclaw/plugin-sdk";
-import { describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig, PluginRuntime, RuntimeEnv } from "remoteclaw/plugin-sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { hasControlCommand } from "../../../src/auto-reply/command-detection.js";
+import {
+  createInboundDebouncer,
+  resolveInboundDebounceMs,
+} from "../../../src/auto-reply/inbound-debounce.js";
+import { parseFeishuMessageEvent, type FeishuMessageEvent } from "./bot.js";
+import * as dedup from "./dedup.js";
+import { monitorSingleAccount } from "./monitor.account.js";
 import { resolveReactionSyntheticEvent, type FeishuReactionCreatedEvent } from "./monitor.js";
+import { setFeishuRuntime } from "./runtime.js";
+import type { ResolvedFeishuAccount } from "./types.js";
+
+const handleFeishuMessageMock = vi.hoisted(() => vi.fn(async (_params: { event?: unknown }) => {}));
+const createEventDispatcherMock = vi.hoisted(() => vi.fn());
+const monitorWebSocketMock = vi.hoisted(() => vi.fn(async () => {}));
+const monitorWebhookMock = vi.hoisted(() => vi.fn(async () => {}));
+
+let handlers: Record<string, (data: unknown) => Promise<void>> = {};
+
+vi.mock("./client.js", () => ({
+  createEventDispatcher: createEventDispatcherMock,
+}));
+
+vi.mock("./bot.js", async () => {
+  const actual = await vi.importActual<typeof import("./bot.js")>("./bot.js");
+  return {
+    ...actual,
+    handleFeishuMessage: handleFeishuMessageMock,
+  };
+});
+
+vi.mock("./monitor.transport.js", () => ({
+  monitorWebSocket: monitorWebSocketMock,
+  monitorWebhook: monitorWebhookMock,
+}));
 
 const cfg = {} as ClawdbotConfig;
 
@@ -14,6 +48,100 @@ function makeReactionEvent(
     user_id: { open_id: "ou_user1" },
     ...overrides,
   };
+}
+
+type FeishuMention = NonNullable<FeishuMessageEvent["message"]["mentions"]>[number];
+
+function buildDebounceConfig(): ClawdbotConfig {
+  return {
+    messages: {
+      inbound: {
+        debounceMs: 0,
+        byChannel: {
+          feishu: 20,
+        },
+      },
+    },
+    channels: {
+      feishu: {
+        enabled: true,
+      },
+    },
+  } as ClawdbotConfig;
+}
+
+function buildDebounceAccount(): ResolvedFeishuAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    configured: true,
+    appId: "cli_test",
+    appSecret: "secret_test",
+    domain: "feishu",
+    config: {
+      enabled: true,
+      connectionMode: "websocket",
+    },
+  } as ResolvedFeishuAccount;
+}
+
+function createTextEvent(params: {
+  messageId: string;
+  text: string;
+  senderId?: string;
+  mentions?: FeishuMention[];
+}): FeishuMessageEvent {
+  const senderId = params.senderId ?? "ou_sender";
+  return {
+    sender: {
+      sender_id: { open_id: senderId },
+      sender_type: "user",
+    },
+    message: {
+      message_id: params.messageId,
+      chat_id: "oc_group_1",
+      chat_type: "group",
+      message_type: "text",
+      content: JSON.stringify({ text: params.text }),
+      mentions: params.mentions,
+    },
+  };
+}
+
+async function setupDebounceMonitor(): Promise<(data: unknown) => Promise<void>> {
+  const register = vi.fn((registered: Record<string, (data: unknown) => Promise<void>>) => {
+    handlers = registered;
+  });
+  createEventDispatcherMock.mockReturnValue({ register });
+
+  await monitorSingleAccount({
+    cfg: buildDebounceConfig(),
+    account: buildDebounceAccount(),
+    runtime: {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    } as RuntimeEnv,
+    botOpenIdSource: { kind: "prefetched", botOpenId: "ou_bot" },
+  });
+
+  const onMessage = handlers["im.message.receive_v1"];
+  if (!onMessage) {
+    throw new Error("missing im.message.receive_v1 handler");
+  }
+  return onMessage;
+}
+
+function getFirstDispatchedEvent(): FeishuMessageEvent {
+  const firstCall = handleFeishuMessageMock.mock.calls[0];
+  if (!firstCall) {
+    throw new Error("missing dispatch call");
+  }
+  const firstParams = firstCall[0] as { event?: FeishuMessageEvent } | undefined;
+  if (!firstParams?.event) {
+    throw new Error("missing dispatched event payload");
+  }
+  return firstParams.event;
 }
 
 describe("resolveReactionSyntheticEvent", () => {
@@ -231,5 +359,217 @@ describe("resolveReactionSyntheticEvent", () => {
     expect(log).toHaveBeenCalledWith(
       expect.stringContaining("ignoring reaction on non-bot/unverified message om_msg1"),
     );
+  });
+});
+
+describe("Feishu inbound debounce regressions", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    handlers = {};
+    handleFeishuMessageMock.mockClear();
+    setFeishuRuntime({
+      channel: {
+        debounce: {
+          createInboundDebouncer,
+          resolveInboundDebounceMs,
+        },
+        text: {
+          hasControlCommand,
+        },
+      },
+    } as unknown as PluginRuntime);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps bot mention when per-message mention keys collide across non-forward messages", async () => {
+    vi.spyOn(dedup, "tryRecordMessage").mockReturnValue(true);
+    vi.spyOn(dedup, "tryRecordMessagePersistent").mockResolvedValue(true);
+    vi.spyOn(dedup, "hasRecordedMessage").mockReturnValue(false);
+    vi.spyOn(dedup, "hasRecordedMessagePersistent").mockResolvedValue(false);
+    const onMessage = await setupDebounceMonitor();
+
+    await onMessage(
+      createTextEvent({
+        messageId: "om_1",
+        text: "first",
+        mentions: [
+          {
+            key: "@_user_1",
+            id: { open_id: "ou_user_a" },
+            name: "user-a",
+          },
+        ],
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await onMessage(
+      createTextEvent({
+        messageId: "om_2",
+        text: "@bot second",
+        mentions: [
+          {
+            key: "@_user_1",
+            id: { open_id: "ou_bot" },
+            name: "bot",
+          },
+        ],
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(handleFeishuMessageMock).toHaveBeenCalledTimes(1);
+    const dispatched = getFirstDispatchedEvent();
+    const mergedMentions = dispatched.message.mentions ?? [];
+    expect(mergedMentions.some((mention) => mention.id.open_id === "ou_bot")).toBe(true);
+    expect(mergedMentions.some((mention) => mention.id.open_id === "ou_user_a")).toBe(false);
+  });
+
+  it("does not synthesize mention-forward intent across separate messages", async () => {
+    vi.spyOn(dedup, "tryRecordMessage").mockReturnValue(true);
+    vi.spyOn(dedup, "tryRecordMessagePersistent").mockResolvedValue(true);
+    vi.spyOn(dedup, "hasRecordedMessage").mockReturnValue(false);
+    vi.spyOn(dedup, "hasRecordedMessagePersistent").mockResolvedValue(false);
+    const onMessage = await setupDebounceMonitor();
+
+    await onMessage(
+      createTextEvent({
+        messageId: "om_user_mention",
+        text: "@alice first",
+        mentions: [
+          {
+            key: "@_user_1",
+            id: { open_id: "ou_alice" },
+            name: "alice",
+          },
+        ],
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await onMessage(
+      createTextEvent({
+        messageId: "om_bot_mention",
+        text: "@bot second",
+        mentions: [
+          {
+            key: "@_user_1",
+            id: { open_id: "ou_bot" },
+            name: "bot",
+          },
+        ],
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(handleFeishuMessageMock).toHaveBeenCalledTimes(1);
+    const dispatched = getFirstDispatchedEvent();
+    const parsed = parseFeishuMessageEvent(dispatched, "ou_bot");
+    expect(parsed.mentionedBot).toBe(true);
+    expect(parsed.mentionTargets).toBeUndefined();
+    const mergedMentions = dispatched.message.mentions ?? [];
+    expect(mergedMentions.every((mention) => mention.id.open_id === "ou_bot")).toBe(true);
+  });
+
+  it("preserves bot mention signal when the latest merged message has no mentions", async () => {
+    vi.spyOn(dedup, "tryRecordMessage").mockReturnValue(true);
+    vi.spyOn(dedup, "tryRecordMessagePersistent").mockResolvedValue(true);
+    vi.spyOn(dedup, "hasRecordedMessage").mockReturnValue(false);
+    vi.spyOn(dedup, "hasRecordedMessagePersistent").mockResolvedValue(false);
+    const onMessage = await setupDebounceMonitor();
+
+    await onMessage(
+      createTextEvent({
+        messageId: "om_bot_first",
+        text: "@bot first",
+        mentions: [
+          {
+            key: "@_user_1",
+            id: { open_id: "ou_bot" },
+            name: "bot",
+          },
+        ],
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await onMessage(
+      createTextEvent({
+        messageId: "om_plain_second",
+        text: "plain follow-up",
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(handleFeishuMessageMock).toHaveBeenCalledTimes(1);
+    const dispatched = getFirstDispatchedEvent();
+    const parsed = parseFeishuMessageEvent(dispatched, "ou_bot");
+    expect(parsed.mentionedBot).toBe(true);
+  });
+
+  it("excludes previously processed retries from combined debounce text", async () => {
+    vi.spyOn(dedup, "tryRecordMessage").mockReturnValue(true);
+    vi.spyOn(dedup, "tryRecordMessagePersistent").mockResolvedValue(true);
+    vi.spyOn(dedup, "hasRecordedMessage").mockImplementation((key) => key.endsWith(":om_old"));
+    vi.spyOn(dedup, "hasRecordedMessagePersistent").mockImplementation(
+      async (messageId) => messageId === "om_old",
+    );
+    const onMessage = await setupDebounceMonitor();
+
+    await onMessage(createTextEvent({ messageId: "om_old", text: "stale" }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await onMessage(createTextEvent({ messageId: "om_new_1", text: "first" }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await onMessage(createTextEvent({ messageId: "om_old", text: "stale" }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await onMessage(createTextEvent({ messageId: "om_new_2", text: "second" }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(handleFeishuMessageMock).toHaveBeenCalledTimes(1);
+    const dispatched = getFirstDispatchedEvent();
+    expect(dispatched.message.message_id).toBe("om_new_2");
+    const combined = JSON.parse(dispatched.message.content) as { text?: string };
+    expect(combined.text).toBe("first\nsecond");
+  });
+
+  it("uses latest fresh message id when debounce batch ends with stale retry", async () => {
+    const recordSpy = vi.spyOn(dedup, "tryRecordMessage").mockReturnValue(true);
+    vi.spyOn(dedup, "tryRecordMessagePersistent").mockResolvedValue(true);
+    vi.spyOn(dedup, "hasRecordedMessage").mockImplementation((key) => key.endsWith(":om_old"));
+    vi.spyOn(dedup, "hasRecordedMessagePersistent").mockImplementation(
+      async (messageId) => messageId === "om_old",
+    );
+    const onMessage = await setupDebounceMonitor();
+
+    await onMessage(createTextEvent({ messageId: "om_new", text: "fresh" }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await onMessage(createTextEvent({ messageId: "om_old", text: "stale" }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(handleFeishuMessageMock).toHaveBeenCalledTimes(1);
+    const dispatched = getFirstDispatchedEvent();
+    expect(dispatched.message.message_id).toBe("om_new");
+    const combined = JSON.parse(dispatched.message.content) as { text?: string };
+    expect(combined.text).toBe("fresh");
+    expect(recordSpy).toHaveBeenCalledWith("default:om_old");
+    expect(recordSpy).not.toHaveBeenCalledWith("default:om_new");
   });
 });

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -369,6 +369,30 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("disables streaming for thread replies and keeps reply metadata", async () => {
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+      replyToMessageId: "om_msg",
+      replyInThread: false,
+      threadReply: true,
+      rootId: "om_root_topic",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(0);
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_msg",
+        replyInThread: true,
+      }),
+    );
+  });
+
   it("passes replyInThread to media attachments", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -45,6 +45,8 @@ export type CreateFeishuReplyDispatcherParams = {
   /** When true, preserve typing indicator on reply target but send messages without reply metadata */
   skipReplyToInMessages?: boolean;
   replyInThread?: boolean;
+  /** True when inbound message is already inside a thread/topic context */
+  threadReply?: boolean;
   rootId?: string;
   mentionTargets?: MentionTarget[];
   accountId?: string;
@@ -62,11 +64,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyToMessageId,
     skipReplyToInMessages,
     replyInThread,
+    threadReply,
     rootId,
     mentionTargets,
     accountId,
   } = params;
   const sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
+  const threadReplyMode = threadReply === true;
+  const effectiveReplyInThread = threadReplyMode ? true : replyInThread;
   const account = resolveFeishuAccount({ cfg, accountId });
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
 
@@ -125,7 +130,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const chunkMode = core.channel.text.resolveChunkMode(cfg, "feishu");
   const tableMode = core.channel.text.resolveMarkdownTableMode({ cfg, channel: "feishu" });
   const renderMode = account.config?.renderMode ?? "auto";
-  const streamingEnabled = account.config?.streaming !== false && renderMode !== "raw";
+  // Card streaming may miss thread affinity in topic contexts; use direct replies there.
+  const streamingEnabled =
+    !threadReplyMode && account.config?.streaming !== false && renderMode !== "raw";
 
   let streaming: FeishuStreamingSession | null = null;
   let streamText = "";
@@ -152,7 +159,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       try {
         await streaming.start(chatId, resolveReceiveIdType(chatId), {
           replyToMessageId,
-          replyInThread,
+          replyInThread: effectiveReplyInThread,
           rootId,
         });
       } catch (error) {
@@ -235,7 +242,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                   to: chatId,
                   mediaUrl,
                   replyToMessageId: sendReplyToMessageId,
-                  replyInThread,
+                  replyInThread: effectiveReplyInThread,
                   accountId,
                 });
               }
@@ -255,7 +262,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 to: chatId,
                 text: chunk,
                 replyToMessageId: sendReplyToMessageId,
-                replyInThread,
+                replyInThread: effectiveReplyInThread,
                 mentions: first ? mentionTargets : undefined,
                 accountId,
               });
@@ -273,7 +280,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 to: chatId,
                 text: chunk,
                 replyToMessageId: sendReplyToMessageId,
-                replyInThread,
+                replyInThread: effectiveReplyInThread,
                 mentions: first ? mentionTargets : undefined,
                 accountId,
               });
@@ -289,7 +296,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               to: chatId,
               mediaUrl,
               replyToMessageId: sendReplyToMessageId,
-              replyInThread,
+              replyInThread: effectiveReplyInThread,
               accountId,
             });
           }

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -40,6 +40,7 @@ export type FeishuMessageContext = {
   mentionedBot: boolean;
   rootId?: string;
   parentId?: string;
+  threadId?: string;
   content: string;
   contentType: string;
   /** Mention forward targets (excluding the bot itself) */

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -36,7 +36,7 @@ export type FeishuMessageContext = {
   senderId: string;
   senderOpenId: string;
   senderName?: string;
-  chatType: "p2p" | "group";
+  chatType: "p2p" | "group" | "private";
   mentionedBot: boolean;
   rootId?: string;
   parentId?: string;

--- a/src/plugin-sdk/persistent-dedupe.test.ts
+++ b/src/plugin-sdk/persistent-dedupe.test.ts
@@ -70,4 +70,69 @@ describe("createPersistentDedupe", () => {
     expect(await dedupe.checkAndRecord("memory-only", { namespace: "x" })).toBe(true);
     expect(await dedupe.checkAndRecord("memory-only", { namespace: "x" })).toBe(false);
   });
+
+  it("warmup loads persisted entries into memory", async () => {
+    const root = await makeTmpRoot();
+    const resolveFilePath = (namespace: string) => path.join(root, `${namespace}.json`);
+
+    const writer = createPersistentDedupe({
+      ttlMs: 24 * 60 * 60 * 1000,
+      memoryMaxSize: 100,
+      fileMaxEntries: 1000,
+      resolveFilePath,
+    });
+    expect(await writer.checkAndRecord("msg-1", { namespace: "acct" })).toBe(true);
+    expect(await writer.checkAndRecord("msg-2", { namespace: "acct" })).toBe(true);
+
+    const reader = createPersistentDedupe({
+      ttlMs: 24 * 60 * 60 * 1000,
+      memoryMaxSize: 100,
+      fileMaxEntries: 1000,
+      resolveFilePath,
+    });
+    const loaded = await reader.warmup("acct");
+    expect(loaded).toBe(2);
+    expect(await reader.checkAndRecord("msg-1", { namespace: "acct" })).toBe(false);
+    expect(await reader.checkAndRecord("msg-2", { namespace: "acct" })).toBe(false);
+    expect(await reader.checkAndRecord("msg-3", { namespace: "acct" })).toBe(true);
+  });
+
+  it("warmup returns 0 when no disk file exists", async () => {
+    const root = await makeTmpRoot();
+    const dedupe = createPersistentDedupe({
+      ttlMs: 10_000,
+      memoryMaxSize: 100,
+      fileMaxEntries: 1000,
+      resolveFilePath: (ns) => path.join(root, `${ns}.json`),
+    });
+    const loaded = await dedupe.warmup("nonexistent");
+    expect(loaded).toBe(0);
+  });
+
+  it("warmup skips expired entries", async () => {
+    const root = await makeTmpRoot();
+    const resolveFilePath = (namespace: string) => path.join(root, `${namespace}.json`);
+    const ttlMs = 1000;
+
+    const writer = createPersistentDedupe({
+      ttlMs,
+      memoryMaxSize: 100,
+      fileMaxEntries: 1000,
+      resolveFilePath,
+    });
+    const oldNow = Date.now() - 2000;
+    expect(await writer.checkAndRecord("old-msg", { namespace: "acct", now: oldNow })).toBe(true);
+    expect(await writer.checkAndRecord("new-msg", { namespace: "acct" })).toBe(true);
+
+    const reader = createPersistentDedupe({
+      ttlMs,
+      memoryMaxSize: 100,
+      fileMaxEntries: 1000,
+      resolveFilePath,
+    });
+    const loaded = await reader.warmup("acct");
+    expect(loaded).toBe(1);
+    expect(await reader.checkAndRecord("old-msg", { namespace: "acct" })).toBe(true);
+    expect(await reader.checkAndRecord("new-msg", { namespace: "acct" })).toBe(false);
+  });
 });

--- a/src/plugin-sdk/persistent-dedupe.ts
+++ b/src/plugin-sdk/persistent-dedupe.ts
@@ -22,6 +22,7 @@ export type PersistentDedupeCheckOptions = {
 
 export type PersistentDedupe = {
   checkAndRecord: (key: string, options?: PersistentDedupeCheckOptions) => Promise<boolean>;
+  warmup: (namespace?: string, onError?: (error: unknown) => void) => Promise<number>;
   clearMemory: () => void;
   memorySize: () => number;
 };
@@ -127,7 +128,30 @@ export function createPersistentDedupe(options: PersistentDedupeOptions): Persis
       return !duplicate;
     } catch (error) {
       onDiskError?.(error);
+      memory.check(scopedKey, now);
       return true;
+    }
+  }
+
+  async function warmup(namespace = "global", onError?: (error: unknown) => void): Promise<number> {
+    const filePath = options.resolveFilePath(namespace);
+    const now = Date.now();
+    try {
+      const { value } = await readJsonFileWithFallback<PersistentDedupeData>(filePath, {});
+      const data = sanitizeData(value);
+      let loaded = 0;
+      for (const [key, ts] of Object.entries(data)) {
+        if (ttlMs > 0 && now - ts >= ttlMs) {
+          continue;
+        }
+        const scopedKey = `${namespace}:${key}`;
+        memory.check(scopedKey, ts);
+        loaded++;
+      }
+      return loaded;
+    } catch (error) {
+      onError?.(error);
+      return 0;
     }
   }
 
@@ -158,6 +182,7 @@ export function createPersistentDedupe(options: PersistentDedupeOptions): Persis
 
   return {
     checkAndRecord,
+    warmup,
     clearMemory: () => memory.clear(),
     memorySize: () => memory.size(),
   };


### PR DESCRIPTION
## Cherry-picks from upstream (issue #767)

See issue #767 for full commit list and triage details.

**Commits picked (8/9):**
- `3043e68df` fix(feishu): support Lark private chats as direct messages
- `3b3e47e15` Feishu: wire inbound message debounce
- `350d041ea` fix(feishu): serialize message handling per chat
- `66397c285` fix(feishu): restore private chat pairing replies
- `481da215b` fix(feishu): persist dedup cache across gateway restarts
- `f22fc17c7` feat(feishu): prefer thread_id for topic session routing
- `55f04636f` fix(feishu): suppress stale missing-scope grant notices
- `1234cc4c3` Feishu: reply to topic roots

**Skipped (1/9):**
- `53fd7f816` fix(test): resolve Feishu hoisted mock export syntax error — already applied in fork (empty after conflict resolution)

Closes #767