### PR TITLE
Cherry-pick issue #768: test infrastructure improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "test:install:smoke": "bash scripts/test-install-sh-docker.sh",
     "test:live": "REMOTECLAW_LIVE_TEST=1 vitest run --config vitest.live.config.ts",
     "test:macmini": "REMOTECLAW_TEST_VM_FORKS=0 REMOTECLAW_TEST_PROFILE=serial node scripts/test-parallel.mjs",
+    "test:perf:budget": "node scripts/test-perf-budget.mjs",
     "test:sectriage": "pnpm exec vitest run --config vitest.gateway.config.ts && vitest run --config vitest.unit.config.ts --exclude src/daemon/launchd.integration.test.ts --exclude src/process/exec.test.ts",
     "test:ui": "pnpm lint:ui:no-raw-window-open && pnpm --dir ui test",
     "test:voicecall:closedloop": "vitest run extensions/voice-call/src/manager.test.ts extensions/voice-call/src/media-stream.test.ts src/plugins/voice-call.plugin.test.ts --maxWorkers=1",

--- a/scripts/test-perf-budget.mjs
+++ b/scripts/test-perf-budget.mjs
@@ -1,0 +1,127 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+function readEnvNumber(name) {
+  const raw = process.env[name]?.trim();
+  if (!raw) {
+    return null;
+  }
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseArgs(argv) {
+  const args = {
+    config: "vitest.unit.config.ts",
+    maxWallMs: readEnvNumber("OPENCLAW_TEST_PERF_MAX_WALL_MS"),
+    baselineWallMs: readEnvNumber("OPENCLAW_TEST_PERF_BASELINE_WALL_MS"),
+    maxRegressionPct: readEnvNumber("OPENCLAW_TEST_PERF_MAX_REGRESSION_PCT") ?? 10,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--config") {
+      args.config = argv[i + 1] ?? args.config;
+      i += 1;
+      continue;
+    }
+    if (arg === "--max-wall-ms") {
+      const parsed = Number.parseFloat(argv[i + 1] ?? "");
+      if (Number.isFinite(parsed)) {
+        args.maxWallMs = parsed;
+      }
+      i += 1;
+      continue;
+    }
+    if (arg === "--baseline-wall-ms") {
+      const parsed = Number.parseFloat(argv[i + 1] ?? "");
+      if (Number.isFinite(parsed)) {
+        args.baselineWallMs = parsed;
+      }
+      i += 1;
+      continue;
+    }
+    if (arg === "--max-regression-pct") {
+      const parsed = Number.parseFloat(argv[i + 1] ?? "");
+      if (Number.isFinite(parsed)) {
+        args.maxRegressionPct = parsed;
+      }
+      i += 1;
+      continue;
+    }
+  }
+  return args;
+}
+
+function formatMs(ms) {
+  return `${ms.toFixed(1)}ms`;
+}
+
+const opts = parseArgs(process.argv.slice(2));
+const reportPath = path.join(os.tmpdir(), `openclaw-vitest-perf-${Date.now()}.json`);
+const cmd = [
+  "vitest",
+  "run",
+  "--config",
+  opts.config,
+  "--reporter=json",
+  "--outputFile",
+  reportPath,
+];
+
+const startedAt = process.hrtime.bigint();
+const run = spawnSync("pnpm", cmd, {
+  stdio: "inherit",
+  env: process.env,
+});
+const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+
+if (run.status !== 0) {
+  process.exit(run.status ?? 1);
+}
+
+let totalFileDurationMs = 0;
+let fileCount = 0;
+try {
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  for (const result of report.testResults ?? []) {
+    if (typeof result.startTime === "number" && typeof result.endTime === "number") {
+      totalFileDurationMs += Math.max(0, result.endTime - result.startTime);
+      fileCount += 1;
+    }
+  }
+} catch {
+  // Keep budget checks based on wall time when JSON parsing fails.
+}
+
+const allowedByBaseline =
+  opts.baselineWallMs !== null
+    ? opts.baselineWallMs * (1 + (opts.maxRegressionPct ?? 0) / 100)
+    : null;
+
+let failed = false;
+if (opts.maxWallMs !== null && elapsedMs > opts.maxWallMs) {
+  console.error(
+    `[test-perf-budget] wall time ${formatMs(elapsedMs)} exceeded max ${formatMs(opts.maxWallMs)}.`,
+  );
+  failed = true;
+}
+if (allowedByBaseline !== null && elapsedMs > allowedByBaseline) {
+  console.error(
+    `[test-perf-budget] wall time ${formatMs(elapsedMs)} exceeded baseline budget ${formatMs(
+      allowedByBaseline,
+    )} (baseline ${formatMs(opts.baselineWallMs ?? 0)}, +${String(opts.maxRegressionPct)}%).`,
+  );
+  failed = true;
+}
+
+console.log(
+  `[test-perf-budget] config=${opts.config} wall=${formatMs(elapsedMs)} file-sum=${formatMs(
+    totalFileDurationMs,
+  )} files=${String(fileCount)}`,
+);
+
+if (failed) {
+  process.exit(1);
+}

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -871,7 +871,7 @@ describe("runReplyAgent messaging tool suppression", () => {
 });
 
 describe("runReplyAgent reminder commitment guard", () => {
-  function createRun() {
+  function createRun(params?: { sessionKey?: string; omitSessionKey?: boolean }) {
     const typing = createMockTypingController();
     const sessionCtx = {
       Provider: "telegram",
@@ -910,7 +910,7 @@ describe("runReplyAgent reminder commitment guard", () => {
       isActive: false,
       typing,
       sessionCtx,
-      sessionKey: "main",
+      ...(params?.omitSessionKey ? {} : { sessionKey: params?.sessionKey ?? "main" }),
       defaultModel: "anthropic/claude-opus-4-5",
       resolvedVerboseLevel: "off",
       isNewSession: false,

--- a/src/channels/plugins/plugins-core.test.ts
+++ b/src/channels/plugins/plugins-core.test.ts
@@ -75,6 +75,29 @@ describe("channel plugin registry", () => {
     const pluginIds = listChannelPlugins().map((plugin) => plugin.id);
     expect(pluginIds).toEqual(["telegram", "slack", "signal"]);
   });
+
+  it("refreshes cached channel lookups when the same registry instance is re-activated", () => {
+    const registry = createTestRegistry([
+      {
+        pluginId: "slack",
+        plugin: createPlugin("slack"),
+        source: "test",
+      },
+    ]);
+    setActivePluginRegistry(registry, "registry-test");
+    expect(listChannelPlugins().map((plugin) => plugin.id)).toEqual(["slack"]);
+
+    registry.channels = [
+      {
+        pluginId: "telegram",
+        plugin: createPlugin("telegram"),
+        source: "test",
+      },
+    ] as typeof registry.channels;
+    setActivePluginRegistry(registry, "registry-test");
+
+    expect(listChannelPlugins().map((plugin) => plugin.id)).toEqual(["telegram"]);
+  });
 });
 
 describe("channel plugin catalog", () => {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConfigFileSnapshot, RemoteClawConfig } from "../config/types.js";
 
 /**
@@ -61,25 +61,22 @@ function setSnapshotOnce(snapshot: ConfigFileSnapshot) {
 }
 
 let registerConfigCli: typeof import("./config-cli.js").registerConfigCli;
+let sharedProgram: Command;
 
 async function runConfigCommand(args: string[]) {
-  const program = new Command();
-  program.exitOverride();
-  registerConfigCli(program);
-  await program.parseAsync(args, { from: "user" });
+  await sharedProgram.parseAsync(args, { from: "user" });
 }
 
 describe("config cli", () => {
   beforeAll(async () => {
     ({ registerConfigCli } = await import("./config-cli.js"));
+    sharedProgram = new Command();
+    sharedProgram.exitOverride();
+    registerConfigCli(sharedProgram);
   });
 
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe("config set - issue #6070", () => {

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { runRegisteredCli } from "../../test-utils/command-runner.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 
 const callGatewayCli = vi.fn(async (_method: string, _opts: unknown, _params?: unknown) => ({
@@ -113,9 +112,13 @@ vi.mock("./discover.js", () => ({
 
 describe("gateway register option collisions", () => {
   let registerGatewayCli: typeof import("./register.js").registerGatewayCli;
+  let sharedProgram: Command;
 
   beforeAll(async () => {
     ({ registerGatewayCli } = await import("./register.js"));
+    sharedProgram = new Command();
+    sharedProgram.exitOverride();
+    registerGatewayCli(sharedProgram);
   });
 
   beforeEach(() => {
@@ -125,9 +128,8 @@ describe("gateway register option collisions", () => {
   });
 
   it("forwards --token to gateway call when parent and child option names collide", async () => {
-    await runRegisteredCli({
-      register: registerGatewayCli as (program: Command) => void,
-      argv: ["gateway", "call", "health", "--token", "tok_call", "--json"],
+    await sharedProgram.parseAsync(["gateway", "call", "health", "--token", "tok_call", "--json"], {
+      from: "user",
     });
 
     expect(callGatewayCli).toHaveBeenCalledWith(
@@ -140,9 +142,8 @@ describe("gateway register option collisions", () => {
   });
 
   it("forwards --token to gateway probe when parent and child option names collide", async () => {
-    await runRegisteredCli({
-      register: registerGatewayCli as (program: Command) => void,
-      argv: ["gateway", "probe", "--token", "tok_probe", "--json"],
+    await sharedProgram.parseAsync(["gateway", "probe", "--token", "tok_probe", "--json"], {
+      from: "user",
     });
 
     expect(gatewayStatusCommand).toHaveBeenCalledWith(

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { runRegisteredCli } from "../../test-utils/command-runner.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 
 const startGatewayServer = vi.fn(async (_port: number, _opts?: unknown) => ({
@@ -88,9 +87,14 @@ vi.mock("./run-loop.js", () => ({
 
 describe("gateway run option collisions", () => {
   let addGatewayRunCommand: typeof import("./run.js").addGatewayRunCommand;
+  let sharedProgram: Command;
 
   beforeAll(async () => {
     ({ addGatewayRunCommand } = await import("./run.js"));
+    sharedProgram = new Command();
+    sharedProgram.exitOverride();
+    const gateway = addGatewayRunCommand(sharedProgram.command("gateway"));
+    addGatewayRunCommand(gateway.command("run"));
   });
 
   beforeEach(() => {
@@ -103,13 +107,7 @@ describe("gateway run option collisions", () => {
   });
 
   async function runGatewayCli(argv: string[]) {
-    await runRegisteredCli({
-      register: ((program: Command) => {
-        const gateway = addGatewayRunCommand(program.command("gateway"));
-        addGatewayRunCommand(gateway.command("run"));
-      }) as (program: Command) => void,
-      argv,
-    });
+    await sharedProgram.parseAsync(argv, { from: "user" });
   }
 
   function expectAuthOverrideMode(mode: string) {

--- a/src/cli/nodes-cli.coverage.test.ts
+++ b/src/cli/nodes-cli.coverage.test.ts
@@ -12,6 +12,9 @@ type NodeInvokeCall = {
   };
 };
 
+let lastNodeInvokeCall: NodeInvokeCall | null = null;
+let _lastApprovalRequestCall: { params?: Record<string, unknown> } | null = null;
+
 const callGateway = vi.fn(async (opts: NodeInvokeCall) => {
   if (opts.method === "node.list") {
     return {
@@ -28,6 +31,7 @@ const callGateway = vi.fn(async (opts: NodeInvokeCall) => {
     };
   }
   if (opts.method === "node.invoke") {
+    lastNodeInvokeCall = opts;
     const command = opts.params?.command;
     if (command === "system.run.prepare") {
       const params = (opts.params?.params ?? {}) as {
@@ -84,6 +88,7 @@ const callGateway = vi.fn(async (opts: NodeInvokeCall) => {
     };
   }
   if (opts.method === "exec.approval.request") {
+    _lastApprovalRequestCall = opts as { params?: Record<string, unknown> };
     return { decision: "allow-once" };
   }
   return { ok: true };
@@ -108,39 +113,34 @@ vi.mock("../config/config.js", () => ({
 
 describe("nodes-cli coverage", () => {
   let registerNodesCli: (program: Command) => void;
+  let sharedProgram: Command;
 
   const getNodeInvokeCall = () => {
-    const nodeInvokeCalls = callGateway.mock.calls
-      .map((call) => call[0])
-      .filter((entry): entry is NodeInvokeCall => entry?.method === "node.invoke");
-    const last = nodeInvokeCalls.at(-1);
+    const last = lastNodeInvokeCall;
     if (!last) {
       throw new Error("expected node.invoke call");
     }
     return last;
   };
 
-  const createNodesProgram = () => {
-    const program = new Command();
-    program.exitOverride();
-    registerNodesCli(program);
-    return program;
-  };
-
   const runNodesCommand = async (args: string[]) => {
-    const program = createNodesProgram();
-    await program.parseAsync(args, { from: "user" });
+    await sharedProgram.parseAsync(args, { from: "user" });
     return getNodeInvokeCall();
   };
 
   beforeAll(async () => {
     ({ registerNodesCli } = await import("./nodes-cli.js"));
+    sharedProgram = new Command();
+    sharedProgram.exitOverride();
+    registerNodesCli(sharedProgram);
   });
 
   beforeEach(() => {
     resetRuntimeCapture();
     callGateway.mockClear();
     randomIdempotencyKey.mockClear();
+    lastNodeInvokeCall = null;
+    _lastApprovalRequestCall = null;
   });
 
   it("invokes system.run with parsed params", async () => {

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -14,6 +14,8 @@ import {
 import { withTempHome } from "./test-helpers.js";
 import type { RemoteClawConfig } from "./types.js";
 
+const IS_WINDOWS = process.platform === "win32";
+
 describe("config backup rotation", () => {
   it("keeps a 5-deep backup ring for config writes", async () => {
     await withTempHome(async () => {
@@ -55,7 +57,8 @@ describe("config backup rotation", () => {
     });
   });
 
-  it("hardenBackupPermissions sets 0o600 on all backup files", async () => {
+  // chmod is a no-op on Windows — 0o600 can never be observed there.
+  it.skipIf(IS_WINDOWS)("hardenBackupPermissions sets 0o600 on all backup files", async () => {
     await withTempHome(async () => {
       const configPath = resolveConfigPathFromTempState();
 

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -14,8 +14,6 @@ import {
 import { withTempHome } from "./test-helpers.js";
 import type { RemoteClawConfig } from "./types.js";
 
-const IS_WINDOWS = process.platform === "win32";
-
 describe("config backup rotation", () => {
   it("keeps a 5-deep backup ring for config writes", async () => {
     await withTempHome(async () => {

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1,22 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { buildConfigSchema } from "./schema.js";
 import { applyDerivedTags, CONFIG_TAGS, deriveTagsForPath } from "./schema.tags.js";
 
 describe("config schema", () => {
-  it("exports schema + hints", () => {
-    const res = buildConfigSchema();
-    const schema = res.schema as { properties?: Record<string, unknown> };
-    expect(schema.properties?.gateway).toBeTruthy();
-    expect(schema.properties?.agents).toBeTruthy();
-    expect(schema.properties?.$schema).toBeUndefined();
-    expect(res.uiHints.gateway?.label).toBe("Gateway");
-    expect(res.uiHints["gateway.auth.token"]?.sensitive).toBe(true);
-    expect(res.version).toBeTruthy();
-    expect(res.generatedAt).toBeTruthy();
-  });
+  type SchemaInput = NonNullable<Parameters<typeof buildConfigSchema>[0]>;
+  let baseSchema: ReturnType<typeof buildConfigSchema>;
+  let pluginUiHintInput: SchemaInput;
+  let tokenHintInput: SchemaInput;
+  let mergedSchemaInput: SchemaInput;
+  let heartbeatChannelInput: SchemaInput;
+  let cachedMergeInput: SchemaInput;
 
-  it("merges plugin ui hints", () => {
-    const res = buildConfigSchema({
+  beforeAll(() => {
+    baseSchema = buildConfigSchema();
+    pluginUiHintInput = {
       plugins: [
         {
           id: "voice-call",
@@ -28,18 +25,8 @@ describe("config schema", () => {
           },
         },
       ],
-    });
-
-    expect(res.uiHints["plugins.entries.voice-call"]?.label).toBe("Voice Call");
-    expect(res.uiHints["plugins.entries.voice-call.config"]?.label).toBe("Voice Call Config");
-    expect(res.uiHints["plugins.entries.voice-call.config.twilio.authToken"]?.label).toBe(
-      "Auth Token",
-    );
-    expect(res.uiHints["plugins.entries.voice-call.config.twilio.authToken"]?.sensitive).toBe(true);
-  });
-
-  it("does not re-mark existing non-sensitive token-like fields", () => {
-    const res = buildConfigSchema({
+    };
+    tokenHintInput = {
       plugins: [
         {
           id: "voice-call",
@@ -48,13 +35,8 @@ describe("config schema", () => {
           },
         },
       ],
-    });
-
-    expect(res.uiHints["plugins.entries.voice-call.config.tokens"]?.sensitive).toBe(false);
-  });
-
-  it("merges plugin + channel schemas", () => {
-    const res = buildConfigSchema({
+    };
+    mergedSchemaInput = {
       plugins: [
         {
           id: "voice-call",
@@ -79,7 +61,65 @@ describe("config schema", () => {
           },
         },
       ],
-    });
+    };
+    heartbeatChannelInput = {
+      channels: [
+        {
+          id: "bluebubbles",
+          label: "BlueBubbles",
+          configSchema: { type: "object" },
+        },
+      ],
+    };
+    cachedMergeInput = {
+      plugins: [
+        {
+          id: "voice-call",
+          name: "Voice Call",
+          configSchema: { type: "object", properties: { provider: { type: "string" } } },
+        },
+      ],
+      channels: [
+        {
+          id: "matrix",
+          label: "Matrix",
+          configSchema: { type: "object", properties: { accessToken: { type: "string" } } },
+        },
+      ],
+    };
+  });
+
+  it("exports schema + hints", () => {
+    const res = baseSchema;
+    const schema = res.schema as { properties?: Record<string, unknown> };
+    expect(schema.properties?.gateway).toBeTruthy();
+    expect(schema.properties?.agents).toBeTruthy();
+    expect(schema.properties?.$schema).toBeUndefined();
+    expect(res.uiHints.gateway?.label).toBe("Gateway");
+    expect(res.uiHints["gateway.auth.token"]?.sensitive).toBe(true);
+    expect(res.version).toBeTruthy();
+    expect(res.generatedAt).toBeTruthy();
+  });
+
+  it("merges plugin ui hints", () => {
+    const res = buildConfigSchema(pluginUiHintInput);
+
+    expect(res.uiHints["plugins.entries.voice-call"]?.label).toBe("Voice Call");
+    expect(res.uiHints["plugins.entries.voice-call.config"]?.label).toBe("Voice Call Config");
+    expect(res.uiHints["plugins.entries.voice-call.config.twilio.authToken"]?.label).toBe(
+      "Auth Token",
+    );
+    expect(res.uiHints["plugins.entries.voice-call.config.twilio.authToken"]?.sensitive).toBe(true);
+  });
+
+  it("does not re-mark existing non-sensitive token-like fields", () => {
+    const res = buildConfigSchema(tokenHintInput);
+
+    expect(res.uiHints["plugins.entries.voice-call.config.tokens"]?.sensitive).toBe(false);
+  });
+
+  it("merges plugin + channel schemas", () => {
+    const res = buildConfigSchema(mergedSchemaInput);
 
     const schema = res.schema as {
       properties?: Record<string, unknown>;
@@ -102,15 +142,7 @@ describe("config schema", () => {
   });
 
   it("adds heartbeat target hints with dynamic channels", () => {
-    const res = buildConfigSchema({
-      channels: [
-        {
-          id: "bluebubbles",
-          label: "BlueBubbles",
-          configSchema: { type: "object" },
-        },
-      ],
-    });
+    const res = buildConfigSchema(heartbeatChannelInput);
 
     const defaultsHint = res.uiHints["agents.defaults.heartbeat.target"];
     const listHint = res.uiHints["agents.list.*.heartbeat.target"];
@@ -120,26 +152,10 @@ describe("config schema", () => {
   });
 
   it("caches merged schemas for identical plugin/channel metadata", () => {
-    const params = {
-      plugins: [
-        {
-          id: "voice-call",
-          name: "Voice Call",
-          configSchema: { type: "object", properties: { provider: { type: "string" } } },
-        },
-      ],
-      channels: [
-        {
-          id: "matrix",
-          label: "Matrix",
-          configSchema: { type: "object", properties: { accessToken: { type: "string" } } },
-        },
-      ],
-    };
-    const first = buildConfigSchema(params);
+    const first = buildConfigSchema(cachedMergeInput);
     const second = buildConfigSchema({
-      plugins: [{ ...params.plugins[0] }],
-      channels: [{ ...params.channels[0] }],
+      plugins: [{ ...cachedMergeInput.plugins![0] }],
+      channels: [{ ...cachedMergeInput.channels![0] }],
     });
     expect(second).toBe(first);
   });

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -36,6 +36,7 @@ vi.mock("../infra/net/fetch-guard.js", () => ({
 installGatewayTestHooks({ scope: "suite" });
 const CRON_WAIT_INTERVAL_MS = 5;
 const CRON_WAIT_TIMEOUT_MS = 3_000;
+const EMPTY_CRON_STORE_CONTENT = JSON.stringify({ version: 1, jobs: [] });
 let cronSuiteTempRootPromise: Promise<string> | null = null;
 let cronSuiteCaseId = 0;
 
@@ -79,10 +80,20 @@ async function waitForCondition(check: () => boolean | Promise<boolean>, timeout
   );
 }
 
+async function createCronCasePaths(tempPrefix: string): Promise<{
+  dir: string;
+  storePath: string;
+}> {
+  const suiteRoot = await getCronSuiteTempRoot();
+  const dir = path.join(suiteRoot, `${tempPrefix}${cronSuiteCaseId++}`);
+  const storePath = path.join(dir, "cron", "jobs.json");
+  await fs.mkdir(path.dirname(storePath), { recursive: true });
+  return { dir, storePath };
+}
+
 async function cleanupCronTestRun(params: {
   ws: { close: () => void };
   server: { close: () => Promise<void> };
-  dir: string;
   prevSkipCron: string | undefined;
   clearSessionConfig?: boolean;
 }) {
@@ -108,16 +119,13 @@ async function setupCronTestRun(params: {
 }): Promise<{ prevSkipCron: string | undefined; dir: string }> {
   const prevSkipCron = process.env.REMOTECLAW_SKIP_CRON;
   process.env.REMOTECLAW_SKIP_CRON = "0";
-  const suiteRoot = await getCronSuiteTempRoot();
-  const dir = path.join(suiteRoot, `${params.tempPrefix}${cronSuiteCaseId++}`);
-  await fs.mkdir(dir, { recursive: true });
-  testState.cronStorePath = path.join(dir, "cron", "jobs.json");
+  const { dir, storePath } = await createCronCasePaths(params.tempPrefix);
+  testState.cronStorePath = storePath;
   testState.sessionConfig = params.sessionConfig;
   testState.cronEnabled = params.cronEnabled;
-  await fs.mkdir(path.dirname(testState.cronStorePath), { recursive: true });
   await fs.writeFile(
     testState.cronStorePath,
-    JSON.stringify({ version: 1, jobs: params.jobs ?? [] }),
+    params.jobs ? JSON.stringify({ version: 1, jobs: params.jobs }) : EMPTY_CRON_STORE_CONTENT,
   );
   return { prevSkipCron, dir };
 }
@@ -138,7 +146,7 @@ describe("gateway server cron", () => {
   });
 
   test("handles cron CRUD, normalization, and patch semantics", { timeout: 20_000 }, async () => {
-    const { prevSkipCron, dir } = await setupCronTestRun({
+    const { prevSkipCron } = await setupCronTestRun({
       tempPrefix: "remoteclaw-gw-cron-",
       sessionConfig: { mainKey: "primary" },
       cronEnabled: false,
@@ -403,7 +411,6 @@ describe("gateway server cron", () => {
       await cleanupCronTestRun({
         ws,
         server,
-        dir,
         prevSkipCron,
         clearSessionConfig: true,
       });
@@ -514,7 +521,7 @@ describe("gateway server cron", () => {
       const runs = autoEntries?.entries ?? [];
       expect(runs.at(-1)?.jobId).toBe(autoJobId);
     } finally {
-      await cleanupCronTestRun({ ws, server, dir, prevSkipCron });
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
     }
   }, 45_000);
 
@@ -532,7 +539,7 @@ describe("gateway server cron", () => {
       payload: { kind: "systemEvent", text: "legacy webhook" },
       state: {},
     };
-    const { prevSkipCron, dir } = await setupCronTestRun({
+    const { prevSkipCron } = await setupCronTestRun({
       tempPrefix: "remoteclaw-gw-cron-webhook-",
       cronEnabled: false,
       jobs: [legacyNotifyJob],
@@ -741,7 +748,7 @@ describe("gateway server cron", () => {
       await yieldToEventLoop();
       expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
     } finally {
-      await cleanupCronTestRun({ ws, server, dir, prevSkipCron });
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
     }
   }, 60_000);
 });

--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -6,6 +6,7 @@ import {
   extensionForMime,
   imageMimeFromFormat,
   isAudioFileName,
+  kindFromMime,
   normalizeMimeType,
 } from "./mime.js";
 
@@ -130,5 +131,9 @@ describe("mediaKindFromMime", () => {
     { mime: "model/gltf+json", expected: "unknown" },
   ] as const)("classifies $mime", ({ mime, expected }) => {
     expect(mediaKindFromMime(mime)).toBe(expected);
+  });
+
+  it("normalizes MIME strings before kind classification", () => {
+    expect(kindFromMime(" Audio/Ogg; codecs=opus ")).toBe("audio");
   });
 });

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -22,6 +22,34 @@ const archiveFixturePathCache = new Map<string, string>();
 const dynamicArchiveTemplatePathCache = new Map<string, string>();
 let installPluginFromDirTemplateDir = "";
 let manifestInstallTemplateDir = "";
+const DYNAMIC_ARCHIVE_TEMPLATE_PRESETS = [
+  {
+    outName: "traversal.tgz",
+    withDistIndex: true,
+    packageJson: {
+      name: "@evil/..",
+      version: "0.0.1",
+      remoteclaw: { extensions: ["./dist/index.js"] },
+    } as Record<string, unknown>,
+  },
+  {
+    outName: "reserved.tgz",
+    withDistIndex: true,
+    packageJson: {
+      name: "@evil/.",
+      version: "0.0.1",
+      remoteclaw: { extensions: ["./dist/index.js"] },
+    } as Record<string, unknown>,
+  },
+  {
+    outName: "bad.tgz",
+    withDistIndex: false,
+    packageJson: {
+      name: "@remoteclaw/nope",
+      version: "0.0.1",
+    } as Record<string, unknown>,
+  },
+];
 
 function ensureSuiteTempRoot() {
   if (suiteTempRoot) {
@@ -41,7 +69,7 @@ let runCommandWithTimeout: typeof import("../process/exec.js").runCommandWithTim
 function makeTempDir() {
   const dir = path.join(ensureSuiteTempRoot(), `case-${String(tempDirCounter)}`);
   tempDirCounter += 1;
-  fs.mkdirSync(dir, { recursive: true });
+  fs.mkdirSync(dir);
   return dir;
 }
 
@@ -157,8 +185,10 @@ function setupPluginInstallDirs() {
 }
 
 function setupInstallPluginFromDirFixture(params?: { devDependencies?: Record<string, string> }) {
-  const stateDir = makeTempDir();
-  const pluginDir = path.join(makeTempDir(), "plugin");
+  const caseDir = makeTempDir();
+  const stateDir = path.join(caseDir, "state");
+  const pluginDir = path.join(caseDir, "plugin");
+  fs.mkdirSync(stateDir, { recursive: true });
   fs.cpSync(installPluginFromDirTemplateDir, pluginDir, { recursive: true });
   if (params?.devDependencies) {
     const packageJsonPath = path.join(pluginDir, "package.json");
@@ -172,8 +202,10 @@ function setupInstallPluginFromDirFixture(params?: { devDependencies?: Record<st
 }
 
 function setupManifestInstallFixture(params: { manifestId: string }) {
-  const stateDir = makeTempDir();
-  const pluginDir = path.join(makeTempDir(), "plugin-src");
+  const caseDir = makeTempDir();
+  const stateDir = path.join(caseDir, "state");
+  const pluginDir = path.join(caseDir, "plugin-src");
+  fs.mkdirSync(stateDir, { recursive: true });
   fs.cpSync(manifestInstallTemplateDir, pluginDir, { recursive: true });
   fs.writeFileSync(
     path.join(pluginDir, "remoteclaw.plugin.json"),
@@ -213,31 +245,11 @@ async function installArchivePackageAndReturnResult(params: {
   withDistIndex?: boolean;
 }) {
   const stateDir = makeTempDir();
-  const templateKey = JSON.stringify({
+  const archivePath = await ensureDynamicArchiveTemplate({
+    outName: params.outName,
     packageJson: params.packageJson,
     withDistIndex: params.withDistIndex === true,
   });
-  let archivePath = dynamicArchiveTemplatePathCache.get(templateKey);
-  if (!archivePath) {
-    const templateDir = makeTempDir();
-    const pkgDir = path.join(templateDir, "package");
-    fs.mkdirSync(pkgDir, { recursive: true });
-    if (params.withDistIndex) {
-      fs.mkdirSync(path.join(pkgDir, "dist"), { recursive: true });
-      fs.writeFileSync(path.join(pkgDir, "dist", "index.js"), "export {};", "utf-8");
-    }
-    fs.writeFileSync(
-      path.join(pkgDir, "package.json"),
-      JSON.stringify(params.packageJson),
-      "utf-8",
-    );
-    archivePath = await packToArchive({
-      pkgDir,
-      outDir: ensureSuiteFixtureRoot(),
-      outName: params.outName,
-    });
-    dynamicArchiveTemplatePathCache.set(templateKey, archivePath);
-  }
 
   const extensionsDir = path.join(stateDir, "extensions");
   const result = await installPluginFromArchive({
@@ -245,6 +257,46 @@ async function installArchivePackageAndReturnResult(params: {
     extensionsDir,
   });
   return result;
+}
+
+function buildDynamicArchiveTemplateKey(params: {
+  packageJson: Record<string, unknown>;
+  withDistIndex: boolean;
+}): string {
+  return JSON.stringify({
+    packageJson: params.packageJson,
+    withDistIndex: params.withDistIndex,
+  });
+}
+
+async function ensureDynamicArchiveTemplate(params: {
+  packageJson: Record<string, unknown>;
+  outName: string;
+  withDistIndex: boolean;
+}): Promise<string> {
+  const templateKey = buildDynamicArchiveTemplateKey({
+    packageJson: params.packageJson,
+    withDistIndex: params.withDistIndex,
+  });
+  const cachedPath = dynamicArchiveTemplatePathCache.get(templateKey);
+  if (cachedPath) {
+    return cachedPath;
+  }
+  const templateDir = makeTempDir();
+  const pkgDir = path.join(templateDir, "package");
+  fs.mkdirSync(pkgDir, { recursive: true });
+  if (params.withDistIndex) {
+    fs.mkdirSync(path.join(pkgDir, "dist"), { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, "dist", "index.js"), "export {};", "utf-8");
+  }
+  fs.writeFileSync(path.join(pkgDir, "package.json"), JSON.stringify(params.packageJson), "utf-8");
+  const archivePath = await packToArchive({
+    pkgDir,
+    outDir: ensureSuiteFixtureRoot(),
+    outName: params.outName,
+  });
+  dynamicArchiveTemplatePathCache.set(templateKey, archivePath);
+  return archivePath;
 }
 
 afterAll(() => {
@@ -314,6 +366,14 @@ beforeAll(async () => {
     }),
     "utf-8",
   );
+
+  for (const preset of DYNAMIC_ARCHIVE_TEMPLATE_PRESETS) {
+    await ensureDynamicArchiveTemplate({
+      packageJson: preset.packageJson,
+      outName: preset.outName,
+      withDistIndex: preset.withDistIndex,
+    });
+  }
 });
 
 beforeEach(() => {

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -15,8 +15,13 @@ vi.mock("../process/exec.js", () => ({
 }));
 
 let suiteTempRoot = "";
+let suiteFixtureRoot = "";
 let tempDirCounter = 0;
 const pluginFixturesDir = path.resolve(process.cwd(), "test", "fixtures", "plugins-install");
+const archiveFixturePathCache = new Map<string, string>();
+const dynamicArchiveTemplatePathCache = new Map<string, string>();
+let installPluginFromDirTemplateDir = "";
+let manifestInstallTemplateDir = "";
 
 function ensureSuiteTempRoot() {
   if (suiteTempRoot) {
@@ -38,6 +43,15 @@ function makeTempDir() {
   tempDirCounter += 1;
   fs.mkdirSync(dir, { recursive: true });
   return dir;
+}
+
+function ensureSuiteFixtureRoot() {
+  if (suiteFixtureRoot) {
+    return suiteFixtureRoot;
+  }
+  suiteFixtureRoot = path.join(ensureSuiteTempRoot(), "_fixtures");
+  fs.mkdirSync(suiteFixtureRoot, { recursive: true });
+  return suiteFixtureRoot;
 }
 
 async function packToArchive({
@@ -66,10 +80,18 @@ async function createVoiceCallArchiveBuffer(version: string): Promise<Buffer> {
   return fs.readFileSync(path.join(pluginFixturesDir, `voice-call-${version}.tgz`));
 }
 
-function writeArchiveBuffer(params: { outName: string; buffer: Buffer }): string {
-  const workDir = makeTempDir();
-  const archivePath = path.join(workDir, params.outName);
+function getArchiveFixturePath(params: {
+  cacheKey: string;
+  outName: string;
+  buffer: Buffer;
+}): string {
+  const hit = archiveFixturePathCache.get(params.cacheKey);
+  if (hit) {
+    return hit;
+  }
+  const archivePath = path.join(ensureSuiteFixtureRoot(), params.outName);
   fs.writeFileSync(archivePath, params.buffer);
+  archiveFixturePathCache.set(params.cacheKey, archivePath);
   return archivePath;
 }
 
@@ -94,7 +116,11 @@ async function getVoiceCallArchiveBuffer(version: string): Promise<Buffer> {
 async function setupVoiceCallArchiveInstall(params: { outName: string; version: string }) {
   const stateDir = makeTempDir();
   const archiveBuffer = await getVoiceCallArchiveBuffer(params.version);
-  const archivePath = writeArchiveBuffer({ outName: params.outName, buffer: archiveBuffer });
+  const archivePath = getArchiveFixturePath({
+    cacheKey: `voice-call:${params.version}`,
+    outName: params.outName,
+    buffer: archiveBuffer,
+  });
   return {
     stateDir,
     archivePath,
@@ -131,38 +157,24 @@ function setupPluginInstallDirs() {
 }
 
 function setupInstallPluginFromDirFixture(params?: { devDependencies?: Record<string, string> }) {
-  const workDir = makeTempDir();
   const stateDir = makeTempDir();
-  const pluginDir = path.join(workDir, "plugin");
-  fs.mkdirSync(path.join(pluginDir, "dist"), { recursive: true });
-  fs.writeFileSync(
-    path.join(pluginDir, "package.json"),
-    JSON.stringify({
-      name: "@remoteclaw/test-plugin",
-      version: "0.0.1",
-      remoteclaw: { extensions: ["./dist/index.js"] },
-      dependencies: { "left-pad": "1.3.0" },
-      ...(params?.devDependencies ? { devDependencies: params.devDependencies } : {}),
-    }),
-    "utf-8",
-  );
-  fs.writeFileSync(path.join(pluginDir, "dist", "index.js"), "export {};", "utf-8");
+  const pluginDir = path.join(makeTempDir(), "plugin");
+  fs.cpSync(installPluginFromDirTemplateDir, pluginDir, { recursive: true });
+  if (params?.devDependencies) {
+    const packageJsonPath = path.join(pluginDir, "package.json");
+    const manifest = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as {
+      devDependencies?: Record<string, string>;
+    };
+    manifest.devDependencies = params.devDependencies;
+    fs.writeFileSync(packageJsonPath, JSON.stringify(manifest), "utf-8");
+  }
   return { pluginDir, extensionsDir: path.join(stateDir, "extensions") };
 }
 
 function setupManifestInstallFixture(params: { manifestId: string }) {
-  const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-  fs.mkdirSync(path.join(pluginDir, "dist"), { recursive: true });
-  fs.writeFileSync(
-    path.join(pluginDir, "package.json"),
-    JSON.stringify({
-      name: "@remoteclaw/cognee-remoteclaw",
-      version: "0.0.1",
-      remoteclaw: { extensions: ["./dist/index.js"] },
-    }),
-    "utf-8",
-  );
-  fs.writeFileSync(path.join(pluginDir, "dist", "index.js"), "export {};", "utf-8");
+  const stateDir = makeTempDir();
+  const pluginDir = path.join(makeTempDir(), "plugin-src");
+  fs.cpSync(manifestInstallTemplateDir, pluginDir, { recursive: true });
   fs.writeFileSync(
     path.join(pluginDir, "remoteclaw.plugin.json"),
     JSON.stringify({
@@ -171,7 +183,7 @@ function setupManifestInstallFixture(params: { manifestId: string }) {
     }),
     "utf-8",
   );
-  return { pluginDir, extensionsDir };
+  return { pluginDir, extensionsDir: path.join(stateDir, "extensions") };
 }
 
 async function expectArchiveInstallReservedSegmentRejection(params: {
@@ -201,20 +213,31 @@ async function installArchivePackageAndReturnResult(params: {
   withDistIndex?: boolean;
 }) {
   const stateDir = makeTempDir();
-  const workDir = makeTempDir();
-  const pkgDir = path.join(workDir, "package");
-  fs.mkdirSync(pkgDir, { recursive: true });
-  if (params.withDistIndex) {
-    fs.mkdirSync(path.join(pkgDir, "dist"), { recursive: true });
-    fs.writeFileSync(path.join(pkgDir, "dist", "index.js"), "export {};", "utf-8");
-  }
-  fs.writeFileSync(path.join(pkgDir, "package.json"), JSON.stringify(params.packageJson), "utf-8");
-
-  const archivePath = await packToArchive({
-    pkgDir,
-    outDir: workDir,
-    outName: params.outName,
+  const templateKey = JSON.stringify({
+    packageJson: params.packageJson,
+    withDistIndex: params.withDistIndex === true,
   });
+  let archivePath = dynamicArchiveTemplatePathCache.get(templateKey);
+  if (!archivePath) {
+    const templateDir = makeTempDir();
+    const pkgDir = path.join(templateDir, "package");
+    fs.mkdirSync(pkgDir, { recursive: true });
+    if (params.withDistIndex) {
+      fs.mkdirSync(path.join(pkgDir, "dist"), { recursive: true });
+      fs.writeFileSync(path.join(pkgDir, "dist", "index.js"), "export {};", "utf-8");
+    }
+    fs.writeFileSync(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify(params.packageJson),
+      "utf-8",
+    );
+    archivePath = await packToArchive({
+      pkgDir,
+      outDir: ensureSuiteFixtureRoot(),
+      outName: params.outName,
+    });
+    dynamicArchiveTemplatePathCache.set(templateKey, archivePath);
+  }
 
   const extensionsDir = path.join(stateDir, "extensions");
   const result = await installPluginFromArchive({
@@ -245,6 +268,52 @@ beforeAll(async () => {
     PLUGIN_INSTALL_ERROR_CODE,
   } = await import("./install.js"));
   ({ runCommandWithTimeout } = await import("../process/exec.js"));
+
+  installPluginFromDirTemplateDir = path.join(
+    ensureSuiteFixtureRoot(),
+    "install-from-dir-template",
+  );
+  fs.mkdirSync(path.join(installPluginFromDirTemplateDir, "dist"), { recursive: true });
+  fs.writeFileSync(
+    path.join(installPluginFromDirTemplateDir, "package.json"),
+    JSON.stringify({
+      name: "@remoteclaw/test-plugin",
+      version: "0.0.1",
+      remoteclaw: { extensions: ["./dist/index.js"] },
+      dependencies: { "left-pad": "1.3.0" },
+    }),
+    "utf-8",
+  );
+  fs.writeFileSync(
+    path.join(installPluginFromDirTemplateDir, "dist", "index.js"),
+    "export {};",
+    "utf-8",
+  );
+
+  manifestInstallTemplateDir = path.join(ensureSuiteFixtureRoot(), "manifest-install-template");
+  fs.mkdirSync(path.join(manifestInstallTemplateDir, "dist"), { recursive: true });
+  fs.writeFileSync(
+    path.join(manifestInstallTemplateDir, "package.json"),
+    JSON.stringify({
+      name: "@remoteclaw/cognee-remoteclaw",
+      version: "0.0.1",
+      remoteclaw: { extensions: ["./dist/index.js"] },
+    }),
+    "utf-8",
+  );
+  fs.writeFileSync(
+    path.join(manifestInstallTemplateDir, "dist", "index.js"),
+    "export {};",
+    "utf-8",
+  );
+  fs.writeFileSync(
+    path.join(manifestInstallTemplateDir, "remoteclaw.plugin.json"),
+    JSON.stringify({
+      id: "manifest-template",
+      configSchema: { type: "object", properties: {} },
+    }),
+    "utf-8",
+  );
 });
 
 beforeEach(() => {
@@ -290,8 +359,9 @@ describe("installPluginFromArchive", () => {
 
   it("installs from a zip archive", async () => {
     const stateDir = makeTempDir();
-    const archivePath = writeArchiveBuffer({
-      outName: "plugin.zip",
+    const archivePath = getArchiveFixturePath({
+      cacheKey: "zipper:0.0.1",
+      outName: "zipper-0.0.1.zip",
       buffer: await ZIPPER_ARCHIVE_BUFFER_PROMISE,
     });
 
@@ -305,12 +375,14 @@ describe("installPluginFromArchive", () => {
 
   it("allows updates when mode is update", async () => {
     const stateDir = makeTempDir();
-    const archiveV1 = writeArchiveBuffer({
-      outName: "plugin-v1.tgz",
+    const archiveV1 = getArchiveFixturePath({
+      cacheKey: "voice-call:0.0.1",
+      outName: "voice-call-0.0.1.tgz",
       buffer: await VOICE_CALL_ARCHIVE_V1_BUFFER_PROMISE,
     });
-    const archiveV2 = writeArchiveBuffer({
-      outName: "plugin-v2.tgz",
+    const archiveV2 = getArchiveFixturePath({
+      cacheKey: "voice-call:0.0.2",
+      outName: "voice-call-0.0.2.tgz",
       buffer: await VOICE_CALL_ARCHIVE_V2_BUFFER_PROMISE,
     });
 

--- a/test/scripts/ios-team-id.test.ts
+++ b/test/scripts/ios-team-id.test.ts
@@ -16,6 +16,60 @@ let sharedHomeDir = "";
 let sharedHomeBinDir = "";
 let sharedFakePythonPath = "";
 const runScriptCache = new Map<string, { ok: boolean; stdout: string; stderr: string }>();
+type TeamCandidate = {
+  teamId: string;
+  isFree: boolean;
+  teamName: string;
+};
+
+function parseTeamCandidateRows(raw: string): TeamCandidate[] {
+  return raw
+    .split("\n")
+    .map((line) => line.replace(/\r/g, "").trim())
+    .filter(Boolean)
+    .map((line) => line.split("\t"))
+    .filter((parts) => parts.length >= 3)
+    .map((parts) => ({
+      teamId: parts[0] ?? "",
+      isFree: (parts[1] ?? "0") === "1",
+      teamName: parts[2] ?? "",
+    }))
+    .filter((candidate) => candidate.teamId.length > 0);
+}
+
+function pickTeamIdFromCandidates(params: {
+  candidates: TeamCandidate[];
+  preferredTeamId?: string;
+  preferredTeamName?: string;
+  preferNonFreeTeam?: boolean;
+}): string | undefined {
+  const preferredTeamId = (params.preferredTeamId ?? "").trim();
+  if (preferredTeamId) {
+    const preferred = params.candidates.find((candidate) => candidate.teamId === preferredTeamId);
+    if (preferred) {
+      return preferred.teamId;
+    }
+  }
+
+  const preferredTeamName = (params.preferredTeamName ?? "").trim().toLowerCase();
+  if (preferredTeamName) {
+    const preferredByName = params.candidates.find(
+      (candidate) => candidate.teamName.trim().toLowerCase() === preferredTeamName,
+    );
+    if (preferredByName) {
+      return preferredByName.teamId;
+    }
+  }
+
+  if (params.preferNonFreeTeam !== false) {
+    const paid = params.candidates.find((candidate) => !candidate.isFree);
+    if (paid) {
+      return paid.teamId;
+    }
+  }
+
+  return params.candidates[0]?.teamId;
+}
 
 async function writeExecutable(filePath: string, body: string): Promise<void> {
   await writeFile(filePath, body, "utf8");
@@ -133,19 +187,32 @@ printf 'BBBBB22222\\t0\\tBeta Team\\r\\n'`,
     await rm(fixtureRoot, { recursive: true, force: true });
   });
 
-  it("resolves fallback and preferred team IDs from Xcode team listings", async () => {
-    const fallbackResult = runScript(sharedHomeDir, {
-      IOS_PYTHON_BIN: sharedFakePythonPath,
+  it("parses team listings and prioritizes preferred IDs without shelling out", () => {
+    const rows = parseTeamCandidateRows(
+      "AAAAA11111\t1\tAlpha Team\r\nBBBBB22222\t0\tBeta Team\r\n",
+    );
+    expect(rows).toStrictEqual([
+      { teamId: "AAAAA11111", isFree: true, teamName: "Alpha Team" },
+      { teamId: "BBBBB22222", isFree: false, teamName: "Beta Team" },
+    ]);
+
+    const preferred = pickTeamIdFromCandidates({
+      candidates: rows,
+      preferredTeamId: "BBBBB22222",
     });
+    expect(preferred).toBe("BBBBB22222");
+
+    const fallback = pickTeamIdFromCandidates({
+      candidates: rows,
+      preferredTeamId: "CCCCCC3333",
+    });
+    expect(fallback).toBe("BBBBB22222");
+  });
+
+  it("resolves a fallback team ID from Xcode team listings (smoke)", async () => {
+    const fallbackResult = runScript(sharedHomeDir, { IOS_PYTHON_BIN: sharedFakePythonPath });
     expect(fallbackResult.ok).toBe(true);
     expect(fallbackResult.stdout).toBe("AAAAA11111");
-
-    const crlfResult = runScript(sharedHomeDir, {
-      IOS_PYTHON_BIN: sharedFakePythonPath,
-      IOS_PREFERRED_TEAM_ID: "BBBBB22222",
-    });
-    expect(crlfResult.ok).toBe(true);
-    expect(crlfResult.stdout).toBe("BBBBB22222");
   });
 
   it("prints actionable guidance when Xcode account exists but no Team ID is resolvable", async () => {


### PR DESCRIPTION
## Cherry-picks from upstream (issue #768)

Test infrastructure improvements: suite micro-optimizations, fixture deduplication, coverage hardening, and perf budget guard.

**Commits (7 applied, 2 skipped):**
- `2287d1ec1` test: micro-optimize slow suites and CLI command setup (RESOLVED)
- `de77a3657` test: harden MIME normalization regression coverage (RESOLVED)
- `73e08ed7b` test: expand reminder guard fail-closed coverage (RESOLVED)
- `4d19dc867` test(cron): assert embedded model on last call — SKIPPED (only touches gutted cron file)
- `41bdf2df4` test: skip chmod-dependent backup rotation tests on Windows (RESOLVED)
- `abec8a4f0` test: preserve windows backup-rotation compose coverage — SKIPPED (fork already had equivalent)
- `4bfbf2dff` test(refactor): dedupe secret resolver posix fixtures (PARTIAL — kept plugins-core.test.ts only)
- `4b3d9f4fb` test(perf): trim fixture churn in install and cron suites (RESOLVED)
- `d37ad9d86` test(perf): slim ios team-id harness and add perf budget guard (RESOLVED)

See #768 for full triage details.