### PR TITLE
Cherry-pick issue #770: hooks, gateway fixes & globalThis singleton

### DIFF
--- a/docs/automation/webhook.md
+++ b/docs/automation/webhook.md
@@ -155,7 +155,7 @@ Mapping options (summary):
 ## Responses
 
 - `200` for `/hooks/wake`
-- `202` for `/hooks/agent` (async run started)
+- `200` for `/hooks/agent` (async run accepted)
 - `401` on auth failure
 - `429` after repeated auth failures from the same client (check `Retry-After`)
 - `400` on invalid payload

--- a/src/agents/remoteclaw-tools.plugin-context.test.ts
+++ b/src/agents/remoteclaw-tools.plugin-context.test.ts
@@ -28,4 +28,21 @@ describe("createRemoteClawTools plugin context", () => {
       }),
     );
   });
+
+  it("forwards ephemeral sessionId to plugin tool context", () => {
+    createOpenClawTools({
+      config: {} as never,
+      agentSessionKey: "agent:main:telegram:direct:12345",
+      sessionId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    });
+
+    expect(resolvePluginToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          sessionKey: "agent:main:telegram:direct:12345",
+          sessionId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        }),
+      }),
+    );
+  });
 });

--- a/src/agents/remoteclaw-tools.plugin-context.test.ts
+++ b/src/agents/remoteclaw-tools.plugin-context.test.ts
@@ -30,7 +30,7 @@ describe("createRemoteClawTools plugin context", () => {
   });
 
   it("forwards ephemeral sessionId to plugin tool context", () => {
-    createOpenClawTools({
+    createRemoteClawTools({
       config: {} as never,
       agentSessionKey: "agent:main:telegram:direct:12345",
       sessionId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",

--- a/src/agents/remoteclaw-tools.ts
+++ b/src/agents/remoteclaw-tools.ts
@@ -60,6 +60,8 @@ export function createRemoteClawTools(options?: {
   requesterSenderId?: string | null;
   /** Whether the requesting sender is an owner. */
   senderIsOwner?: boolean;
+  /** Ephemeral session UUID — regenerated on /new and /reset. */
+  sessionId?: string;
 }): AnyAgentTool[] {
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir);
   const messageTool = options?.disableMessageTool
@@ -139,6 +141,7 @@ export function createRemoteClawTools(options?: {
         config: options?.config,
       }),
       sessionKey: options?.agentSessionKey,
+      sessionId: options?.sessionId,
       messageChannel: options?.agentChannel,
       agentAccountId: options?.agentAccountId,
       requesterSenderId: options?.requesterSenderId ?? undefined,

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -34,6 +34,8 @@ async function writePluginFixture(params: {
 describe("config plugin validation", () => {
   let fixtureRoot = "";
   let suiteHome = "";
+  let badPluginDir = "";
+  let bluebubblesPluginDir = "";
   const envSnapshot = {
     REMOTECLAW_STATE_DIR: process.env.REMOTECLAW_STATE_DIR,
     REMOTECLAW_PLUGIN_MANIFEST_CACHE_MS: process.env.REMOTECLAW_PLUGIN_MANIFEST_CACHE_MS,
@@ -45,6 +47,8 @@ describe("config plugin validation", () => {
     fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-config-plugin-validation-"));
     suiteHome = path.join(fixtureRoot, "home");
     await fs.mkdir(suiteHome, { recursive: true });
+    badPluginDir = path.join(suiteHome, "bad-plugin");
+    bluebubblesPluginDir = path.join(suiteHome, "bluebubbles-plugin");
     process.env.REMOTECLAW_STATE_DIR = path.join(suiteHome, ".remoteclaw");
     process.env.REMOTECLAW_PLUGIN_MANIFEST_CACHE_MS = "10000";
     clearPluginManifestRegistryCache();

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -48,6 +48,14 @@ describe("config plugin validation", () => {
     process.env.REMOTECLAW_STATE_DIR = path.join(suiteHome, ".remoteclaw");
     process.env.REMOTECLAW_PLUGIN_MANIFEST_CACHE_MS = "10000";
     clearPluginManifestRegistryCache();
+    // Warm the plugin manifest cache once so path-based validations can reuse
+    // parsed manifests across test cases.
+    validateInSuite({
+      plugins: {
+        enabled: false,
+        load: { paths: [badPluginDir, bluebubblesPluginDir] },
+      },
+    });
   });
 
   afterAll(async () => {

--- a/src/gateway/control-ui-http-utils.ts
+++ b/src/gateway/control-ui-http-utils.ts
@@ -13,7 +13,3 @@ export function respondPlainText(res: ServerResponse, statusCode: number, body: 
 export function respondNotFound(res: ServerResponse): void {
   respondPlainText(res, 404, "Not Found");
 }
-
-export function respondMethodNotAllowed(res: ServerResponse): void {
-  respondPlainText(res, 405, "Method Not Allowed");
-}

--- a/src/gateway/control-ui-routing.test.ts
+++ b/src/gateway/control-ui-routing.test.ts
@@ -22,14 +22,26 @@ describe("classifyControlUiRequest", () => {
     expect(classified).toEqual({ kind: "not-found" });
   });
 
-  it("returns method-not-allowed for basePath non-read methods", () => {
+  it("falls through basePath non-read methods for plugin webhooks", () => {
     const classified = classifyControlUiRequest({
       basePath: "/remoteclaw",
       pathname: "/remoteclaw",
       search: "",
       method: "POST",
     });
-    expect(classified).toEqual({ kind: "method-not-allowed" });
+    expect(classified).toEqual({ kind: "not-control-ui" });
+  });
+
+  it("falls through PUT/DELETE/PATCH/OPTIONS under basePath for plugin handlers", () => {
+    for (const method of ["PUT", "DELETE", "PATCH", "OPTIONS"]) {
+      const classified = classifyControlUiRequest({
+        basePath: "/openclaw",
+        pathname: "/openclaw/webhook",
+        search: "",
+        method,
+      });
+      expect(classified, `${method} should fall through`).toEqual({ kind: "not-control-ui" });
+    }
   });
 
   it("returns redirect for basePath entrypoint GET", () => {

--- a/src/gateway/control-ui-routing.ts
+++ b/src/gateway/control-ui-routing.ts
@@ -3,7 +3,6 @@ import { isReadHttpMethod } from "./control-ui-http-utils.js";
 export type ControlUiRequestClassification =
   | { kind: "not-control-ui" }
   | { kind: "not-found" }
-  | { kind: "method-not-allowed" }
   | { kind: "redirect"; location: string }
   | { kind: "serve" };
 
@@ -36,7 +35,7 @@ export function classifyControlUiRequest(params: {
     return { kind: "not-control-ui" };
   }
   if (!isReadHttpMethod(method)) {
-    return { kind: "method-not-allowed" };
+    return { kind: "not-control-ui" };
   }
   if (pathname === basePath) {
     return { kind: "redirect", location: `${basePath}/${search}` };

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -405,19 +405,18 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
-  it("returns 405 for POST requests under configured basePath", async () => {
+  it("falls through POST requests under configured basePath (plugin webhook passthrough)", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
         for (const route of ["/remoteclaw", "/remoteclaw/", "/remoteclaw/some-page"]) {
-          const { handled, res, end } = runControlUiRequest({
+          const { handled, end } = runControlUiRequest({
             url: route,
             method: "POST",
             rootPath: tmp,
             basePath: "/remoteclaw",
           });
-          expect(handled, `expected ${route} to be handled`).toBe(true);
-          expect(res.statusCode, `expected ${route} status`).toBe(405);
-          expect(end, `expected ${route} body`).toHaveBeenCalledWith("Method Not Allowed");
+          expect(handled, `POST to ${route} should pass through to plugin handlers`).toBe(false);
+          expect(end, `POST to ${route} should not write a response`).not.toHaveBeenCalled();
         }
       },
     });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -14,7 +14,6 @@ import {
 import { buildControlUiCspHeader } from "./control-ui-csp.js";
 import {
   isReadHttpMethod,
-  respondMethodNotAllowed,
   respondNotFound as respondControlUiNotFound,
   respondPlainText,
 } from "./control-ui-http-utils.js";
@@ -300,10 +299,6 @@ export function handleControlUiHttpRequest(
   if (route.kind === "not-found") {
     applyControlUiSecurityHeaders(res);
     respondControlUiNotFound(res);
-    return true;
-  }
-  if (route.kind === "method-not-allowed") {
-    respondMethodNotAllowed(res);
     return true;
   }
   if (route.kind === "redirect") {

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -485,7 +485,7 @@ export function createHooksRequestHandler(
         }),
         agentId: targetAgentId,
       });
-      sendJson(res, 202, { ok: true, runId });
+      sendJson(res, 200, { ok: true, runId });
       return true;
     }
 
@@ -551,7 +551,7 @@ export function createHooksRequestHandler(
             timeoutSeconds: mapped.action.timeoutSeconds,
             allowUnsafeExternalContent: mapped.action.allowUnsafeExternalContent,
           });
-          sendJson(res, 202, { ok: true, runId });
+          sendJson(res, 200, { ok: true, runId });
           return true;
         }
       } catch (err) {

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -64,7 +64,7 @@ describe("gateway server hooks", () => {
         summary: "done",
       });
       const resAgent = await postHook(port, "/hooks/agent", { message: "Do it", name: "Email" });
-      expect(resAgent.status).toBe(202);
+      expect(resAgent.status).toBe(200);
       const agentEvents = await waitForSystemEvent();
       expect(agentEvents.some((e) => e.includes("Hook Email: done"))).toBe(true);
       const firstCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
@@ -83,7 +83,7 @@ describe("gateway server hooks", () => {
         name: "Email",
         model: "openai/gpt-4.1-mini",
       });
-      expect(resAgentModel.status).toBe(202);
+      expect(resAgentModel.status).toBe(200);
       await waitForSystemEvent();
       const call = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { payload?: { model?: string } };
@@ -101,7 +101,7 @@ describe("gateway server hooks", () => {
         name: "Email",
         agentId: "hooks",
       });
-      expect(resAgentWithId.status).toBe(202);
+      expect(resAgentWithId.status).toBe(200);
       await waitForSystemEvent();
       const routedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };
@@ -119,7 +119,7 @@ describe("gateway server hooks", () => {
         name: "Email",
         agentId: "missing-agent",
       });
-      expect(resAgentUnknown.status).toBe(202);
+      expect(resAgentUnknown.status).toBe(200);
       await waitForSystemEvent();
       const fallbackCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };
@@ -209,8 +209,15 @@ describe("gateway server hooks", () => {
       cronIsolatedRun.mockClear();
       cronIsolatedRun.mockResolvedValue({ status: "ok", summary: "done" });
 
-      const defaultRoute = await postHook(port, "/hooks/agent", { message: "No key" });
-      expect(defaultRoute.status).toBe(202);
+      const defaultRoute = await fetch(`http://127.0.0.1:${port}/hooks/agent`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer hook-secret",
+        },
+        body: JSON.stringify({ message: "No key" }),
+      });
+      expect(defaultRoute.status).toBe(200);
       await waitForSystemEvent();
       const defaultCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
         | { sessionKey?: string }
@@ -220,8 +227,15 @@ describe("gateway server hooks", () => {
 
       cronIsolatedRun.mockClear();
       cronIsolatedRun.mockResolvedValue({ status: "ok", summary: "done" });
-      const mappedOk = await postHook(port, "/hooks/mapped-ok", { subject: "hello", id: "42" });
-      expect(mappedOk.status).toBe(202);
+      const mappedOk = await fetch(`http://127.0.0.1:${port}/hooks/mapped-ok`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer hook-secret",
+        },
+        body: JSON.stringify({ subject: "hello", id: "42" }),
+      });
+      expect(mappedOk.status).toBe(200);
       await waitForSystemEvent();
       const mappedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
         | { sessionKey?: string }
@@ -263,7 +277,7 @@ describe("gateway server hooks", () => {
         agentId: "hooks",
         sessionKey: "agent:hooks:slack:channel:c123",
       });
-      expect(resAgent.status).toBe(202);
+      expect(resAgent.status).toBe(200);
       await waitForSystemEvent();
 
       const routedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
@@ -299,7 +313,7 @@ describe("gateway server hooks", () => {
         summary: "done",
       });
       const resNoAgent = await postHook(port, "/hooks/agent", { message: "No explicit agent" });
-      expect(resNoAgent.status).toBe(202);
+      expect(resNoAgent.status).toBe(200);
       await waitForSystemEvent();
       const noAgentCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };
@@ -316,7 +330,7 @@ describe("gateway server hooks", () => {
         message: "Allowed",
         agentId: "hooks",
       });
-      expect(resAllowed.status).toBe(202);
+      expect(resAllowed.status).toBe(200);
       await waitForSystemEvent();
       const allowedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };

--- a/src/hooks/install.test.ts
+++ b/src/hooks/install.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -13,7 +13,9 @@ import {
 import { isAddressInUseError } from "./gmail-watcher.js";
 
 const fixtureRoot = path.join(os.tmpdir(), `remoteclaw-hook-install-${randomUUID()}`);
+const sharedArchiveDir = path.join(fixtureRoot, "_archives");
 let tempDirIndex = 0;
+const sharedArchivePathByName = new Map<string, string>();
 
 const fixturesDir = path.resolve(process.cwd(), "test", "fixtures", "hooks-install");
 const zipHooksBuffer = fs.readFileSync(path.join(fixturesDir, "zip-hooks.zip"));
@@ -30,7 +32,7 @@ vi.mock("../process/exec.js", () => ({
 
 function makeTempDir() {
   const dir = path.join(fixtureRoot, `case-${tempDirIndex++}`);
-  fs.mkdirSync(dir, { recursive: true });
+  fs.mkdirSync(dir);
   return dir;
 }
 
@@ -52,13 +54,19 @@ beforeEach(() => {
 
 beforeAll(() => {
   fs.mkdirSync(fixtureRoot, { recursive: true });
+  fs.mkdirSync(sharedArchiveDir, { recursive: true });
 });
 
 function writeArchiveFixture(params: { fileName: string; contents: Buffer }) {
   const stateDir = makeTempDir();
-  const workDir = makeTempDir();
-  const archivePath = path.join(workDir, params.fileName);
-  fs.writeFileSync(archivePath, params.contents);
+  const archiveHash = createHash("sha256").update(params.contents).digest("hex").slice(0, 12);
+  const archiveKey = `${params.fileName}:${archiveHash}`;
+  let archivePath = sharedArchivePathByName.get(archiveKey);
+  if (!archivePath) {
+    archivePath = path.join(sharedArchiveDir, `${archiveHash}-${params.fileName}`);
+    fs.writeFileSync(archivePath, params.contents);
+    sharedArchivePathByName.set(archiveKey, archivePath);
+  }
   return {
     stateDir,
     archivePath,

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -140,6 +140,25 @@ describe("hooks", () => {
       const event = createInternalHookEvent("command", "new", "test-session");
       await expect(triggerInternalHook(event)).resolves.not.toThrow();
     });
+
+    it("stores handlers in the global singleton registry", async () => {
+      const globalHooks = globalThis as typeof globalThis & {
+        __openclaw_internal_hook_handlers__?: Map<string, Array<(event: unknown) => unknown>>;
+      };
+      const handler = vi.fn();
+      registerInternalHook("command:new", handler);
+
+      const event = createInternalHookEvent("command", "new", "test-session");
+      await triggerInternalHook(event);
+
+      expect(handler).toHaveBeenCalledWith(event);
+      expect(globalHooks.__openclaw_internal_hook_handlers__?.has("command:new")).toBe(true);
+
+      const injectedHandler = vi.fn();
+      globalHooks.__openclaw_internal_hook_handlers__?.set("command:new", [injectedHandler]);
+      await triggerInternalHook(event);
+      expect(injectedHandler).toHaveBeenCalledWith(event);
+    });
   });
 
   describe("createInternalHookEvent", () => {

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -197,10 +197,10 @@ export type InternalHookHandler = (event: InternalHookEvent) => Promise<void> | 
 const _g = globalThis as typeof globalThis & {
   __openclaw_internal_hook_handlers__?: Map<string, InternalHookHandler[]>;
 };
-if (!_g.__openclaw_internal_hook_handlers__) {
-  _g.__openclaw_internal_hook_handlers__ = new Map<string, InternalHookHandler[]>();
-}
-const handlers = _g.__openclaw_internal_hook_handlers__;
+const handlers = (_g.__openclaw_internal_hook_handlers__ ??= new Map<
+  string,
+  InternalHookHandler[]
+>());
 const log = createSubsystemLogger("internal-hooks");
 
 /**

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -184,8 +184,23 @@ export interface InternalHookEvent {
 
 export type InternalHookHandler = (event: InternalHookEvent) => Promise<void> | void;
 
-/** Registry of hook handlers by event key */
-const handlers = new Map<string, InternalHookHandler[]>();
+/**
+ * Registry of hook handlers by event key.
+ *
+ * Uses a globalThis singleton so that registerInternalHook and
+ * triggerInternalHook always share the same Map even when the bundler
+ * emits multiple copies of this module into separate chunks (bundle
+ * splitting). Without the singleton, handlers registered in one chunk
+ * are invisible to triggerInternalHook in another chunk, causing hooks
+ * to silently fire with zero handlers.
+ */
+const _g = globalThis as typeof globalThis & {
+  __openclaw_internal_hook_handlers__?: Map<string, InternalHookHandler[]>;
+};
+if (!_g.__openclaw_internal_hook_handlers__) {
+  _g.__openclaw_internal_hook_handlers__ = new Map<string, InternalHookHandler[]>();
+}
+const handlers = _g.__openclaw_internal_hook_handlers__;
 const log = createSubsystemLogger("internal-hooks");
 
 /**

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -63,6 +63,8 @@ export type RemoteClawPluginToolContext = {
   agentDir?: string;
   agentId?: string;
   sessionKey?: string;
+  /** Ephemeral session UUID — regenerated on /new and /reset. Use for per-conversation isolation. */
+  sessionId?: string;
   messageChannel?: string;
   agentAccountId?: string;
   /** Trusted sender id from inbound context (runtime-provided, not tool args). */
@@ -385,6 +387,8 @@ export type PluginHookMessageSentEvent = {
 export type PluginHookToolContext = {
   agentId?: string;
   sessionKey?: string;
+  /** Ephemeral session UUID — regenerated on /new and /reset. */
+  sessionId?: string;
   toolName: string;
 };
 

--- a/src/slack/monitor.tool-result.test.ts
+++ b/src/slack/monitor.tool-result.test.ts
@@ -37,16 +37,17 @@ describe("monitorSlackProvider tool results", () => {
     parent_user_id?: string;
   };
 
+  const baseSlackMessageEvent = Object.freeze({
+    type: "message",
+    user: "U1",
+    text: "hello",
+    ts: "123",
+    channel: "C1",
+    channel_type: "im",
+  }) as SlackMessageEvent;
+
   function makeSlackMessageEvent(overrides: Partial<SlackMessageEvent> = {}): SlackMessageEvent {
-    return {
-      type: "message",
-      user: "U1",
-      text: "hello",
-      ts: "123",
-      channel: "C1",
-      channel_type: "im",
-      ...overrides,
-    };
+    return { ...baseSlackMessageEvent, ...overrides };
   }
 
   function setDirectMessageReplyMode(replyToMode: "off" | "all" | "first") {

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -59,14 +59,14 @@ describe("slack prepareSlackMessage inbound contract", () => {
     userTokenSource: "none",
     config: {},
   };
-  const defaultMessageTemplate: SlackMessageEvent = {
+  const defaultMessageTemplate = Object.freeze({
     channel: "D123",
     channel_type: "im",
     user: "U1",
     text: "hi",
     ts: "1.000",
-  } as SlackMessageEvent;
-  const threadAccount: ResolvedSlackAccount = {
+  }) as SlackMessageEvent;
+  const threadAccount = Object.freeze({
     accountId: "default",
     enabled: true,
     botTokenSource: "config",
@@ -77,14 +77,15 @@ describe("slack prepareSlackMessage inbound contract", () => {
       thread: { initialHistoryLimit: 20 },
     },
     replyToMode: "all",
-  };
+  }) as ResolvedSlackAccount;
+  const defaultPrepareOpts = Object.freeze({ source: "message" }) as { source: "message" };
 
   async function prepareWithDefaultCtx(message: SlackMessageEvent) {
     return prepareSlackMessage({
       ctx: createDefaultSlackCtx(),
       account: defaultAccount,
       message,
-      opts: { source: "message" },
+      opts: defaultPrepareOpts,
     });
   }
 
@@ -101,7 +102,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       ctx,
       account,
       message,
-      opts: { source: "message" },
+      opts: defaultPrepareOpts,
     });
   }
 


### PR DESCRIPTION
## Cherry-picks from upstream (issue #770)

| Hash | Subject | Result |
|------|---------|--------|
| `0954b6bf5` | fix(hooks): propagate ephemeral sessionId through embedded tool contexts | RESOLVED (partial — gutted pi-embedded files discarded) |
| `3e9c8721f` | fix(gateway): let non-GET requests fall through controlUi routing when basePath | RESOLVED (fork path rename conflict) |
| `e870cee54` | fix: restore control-ui basePath webhook passthrough | SKIPPED (CHANGELOG-only, empty after resolution) |
| `051b380d3` | fix(hooks): return 200 instead of 202 for webhook responses | RESOLVED (CHANGELOG DU conflict) |
| `0d8beeb4e` | fix(hooks): use globalThis singleton for handler registry | PICKED |
| `d0a3743ab` | refactor: use ??= operator for cleaner globalThis singleton init | PICKED |
| `68e982ec8` | fix: stabilize internal hooks singleton registry | RESOLVED (CHANGELOG DU conflict) |
| `9657ded2e` | test(perf): trim slack, hook, and plugin-validation test overhead | RESOLVED (fork path rename conflict) |

See #770 for full commit list and triage details.