### PR TITLE
Cherry-pick issue #771: browser subsystem fixes (CDP)

### DIFF
--- a/src/browser/chrome.test.ts
+++ b/src/browser/chrome.test.ts
@@ -1,13 +1,17 @@
 import fs from "node:fs";
 import fsp from "node:fs/promises";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
 import {
   decorateRemoteClawProfile,
   ensureProfileCleanExit,
   findChromeExecutableMac,
   findChromeExecutableWindows,
+  isChromeCdpReady,
   isChromeReachable,
   resolveBrowserExecutableForPlatform,
   stopRemoteClawChrome,
@@ -251,6 +255,108 @@ describe("browser chrome helpers", () => {
     // No WS server listening → handshake fails → not reachable
     await expect(isChromeReachable("ws://127.0.0.1:19999", 50)).resolves.toBe(false);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("reports cdpReady only when Browser.getVersion command succeeds", async () => {
+    const server = createServer((req, res) => {
+      if (req.url === "/json/version") {
+        const addr = server.address() as AddressInfo;
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            webSocketDebuggerUrl: `ws://127.0.0.1:${addr.port}/devtools/browser/health`,
+          }),
+        );
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    const wss = new WebSocketServer({ noServer: true });
+    server.on("upgrade", (req, socket, head) => {
+      if (req.url !== "/devtools/browser/health") {
+        socket.destroy();
+        return;
+      }
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        wss.emit("connection", ws, req);
+      });
+    });
+    wss.on("connection", (ws) => {
+      ws.on("message", (raw) => {
+        let message: { id?: unknown; method?: unknown } | null = null;
+        try {
+          const text =
+            typeof raw === "string"
+              ? raw
+              : Buffer.isBuffer(raw)
+                ? raw.toString("utf8")
+                : Array.isArray(raw)
+                  ? Buffer.concat(raw).toString("utf8")
+                  : Buffer.from(raw).toString("utf8");
+          message = JSON.parse(text) as { id?: unknown; method?: unknown };
+        } catch {
+          return;
+        }
+        if (message?.method === "Browser.getVersion" && message.id === 1) {
+          ws.send(
+            JSON.stringify({
+              id: 1,
+              result: { product: "Chrome/Mock" },
+            }),
+          );
+        }
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+      server.once("error", reject);
+    });
+    const addr = server.address() as AddressInfo;
+    await expect(isChromeCdpReady(`http://127.0.0.1:${addr.port}`, 300, 400)).resolves.toBe(true);
+
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("reports cdpReady false when websocket opens but command channel is stale", async () => {
+    const server = createServer((req, res) => {
+      if (req.url === "/json/version") {
+        const addr = server.address() as AddressInfo;
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            webSocketDebuggerUrl: `ws://127.0.0.1:${addr.port}/devtools/browser/stale`,
+          }),
+        );
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    const wss = new WebSocketServer({ noServer: true });
+    server.on("upgrade", (req, socket, head) => {
+      if (req.url !== "/devtools/browser/stale") {
+        socket.destroy();
+        return;
+      }
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        wss.emit("connection", ws, req);
+      });
+    });
+    // Simulate a stale command channel: WS opens but never responds to commands.
+    wss.on("connection", (_ws) => {});
+
+    await new Promise<void>((resolve, reject) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+      server.once("error", reject);
+    });
+    const addr = server.address() as AddressInfo;
+    await expect(isChromeCdpReady(`http://127.0.0.1:${addr.port}`, 300, 150)).resolves.toBe(false);
+
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+    await new Promise<void>((resolve) => server.close(() => resolve()));
   });
 
   it("stopRemoteClawChrome no-ops when process is already killed", async () => {

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -2,7 +2,6 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type WebSocket from "ws";
 import { ensurePortAvailable } from "../infra/ports.js";
 import { rawDataToString } from "../infra/ws.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -2,6 +2,7 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type WebSocket from "ws";
 import { ensurePortAvailable } from "../infra/ports.js";
 import { rawDataToString } from "../infra/ws.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -144,7 +144,7 @@ async function canRunCdpHealthCommand(
       handshakeTimeoutMs: timeoutMs,
     });
     let settled = false;
-    const onMessage = (raw: WebSocket.RawData) => {
+    const onMessage = (raw: Parameters<typeof rawDataToString>[0]) => {
       if (settled) {
         return;
       }

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { ensurePortAvailable } from "../infra/ports.js";
+import { rawDataToString } from "../infra/ws.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { CONFIG_DIR } from "../utils.js";
 import {
@@ -134,7 +135,7 @@ export async function getChromeWebSocketUrl(
   return normalizeCdpWsUrl(wsUrl, cdpUrl);
 }
 
-async function canOpenWebSocket(
+async function canRunCdpHealthCommand(
   wsUrl: string,
   timeoutMs = CHROME_WS_READY_TIMEOUT_MS,
 ): Promise<boolean> {
@@ -142,6 +143,37 @@ async function canOpenWebSocket(
     const ws = openCdpWebSocket(wsUrl, {
       handshakeTimeoutMs: timeoutMs,
     });
+    let settled = false;
+    const onMessage = (raw: WebSocket.RawData) => {
+      if (settled) {
+        return;
+      }
+      let parsed: { id?: unknown; result?: unknown } | null = null;
+      try {
+        parsed = JSON.parse(rawDataToString(raw)) as { id?: unknown; result?: unknown };
+      } catch {
+        return;
+      }
+      if (parsed?.id !== 1) {
+        return;
+      }
+      finish(Boolean(parsed.result && typeof parsed.result === "object"));
+    };
+
+    const finish = (value: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      ws.off("message", onMessage);
+      try {
+        ws.close();
+      } catch {
+        // ignore
+      }
+      resolve(value);
+    };
     const timer = setTimeout(
       () => {
         try {
@@ -149,22 +181,31 @@ async function canOpenWebSocket(
         } catch {
           // ignore
         }
-        resolve(false);
+        finish(false);
       },
       Math.max(50, timeoutMs + 25),
     );
+
     ws.once("open", () => {
-      clearTimeout(timer);
       try {
-        ws.close();
+        ws.send(
+          JSON.stringify({
+            id: 1,
+            method: "Browser.getVersion",
+          }),
+        );
       } catch {
-        // ignore
+        finish(false);
       }
-      resolve(true);
     });
+
+    ws.on("message", onMessage);
+
     ws.once("error", () => {
-      clearTimeout(timer);
-      resolve(false);
+      finish(false);
+    });
+    ws.once("close", () => {
+      finish(false);
     });
   });
 }
@@ -178,7 +219,7 @@ export async function isChromeCdpReady(
   if (!wsUrl) {
     return false;
   }
-  return await canOpenWebSocket(wsUrl, handshakeTimeoutMs);
+  return await canRunCdpHealthCommand(wsUrl, handshakeTimeoutMs);
 }
 
 export async function launchRemoteClawChrome(

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -86,7 +86,7 @@ export async function isChromeReachable(
 ): Promise<boolean> {
   if (isWebSocketUrl(cdpUrl)) {
     // Direct WebSocket endpoint (e.g. Browserbase) — probe via WS handshake.
-    return await canOpenWebSocket(cdpUrl, timeoutMs);
+    return await canRunCdpHealthCommand(cdpUrl, timeoutMs);
   }
   const version = await fetchChromeVersion(cdpUrl, timeoutMs);
   return Boolean(version);


### PR DESCRIPTION
## Cherry-picks from upstream (issue #771)

See issue #771 for full commit list and triage details.

| Hash | Subject | Result |
|------|---------|--------|
| `8f3eb0f7b` | fix(browser): use CDP command probe for cdpReady health (#31421) | RESOLVED |
| `7365aefa1` | fix(ci): resolve chrome websocket raw-data typing | PICKED |
| `e2483a538` | Browser: fix ws RawData type import for dts build | PICKED |
| `a282b459b` | fix(ci): remove unused chrome ws type import | PICKED |

**Conflict resolution**: Commit 1 had conflicts in `CHANGELOG.md` (fork-deleted, removed) and `src/browser/chrome.test.ts` (union merge — kept fork's WebSocket probe test + upstream's two new cdpReady tests + fork's `stopRemoteClawChrome` naming).