### PR TITLE
Cherry-pick issue #773: performance & routing optimizations

### DIFF
--- a/src/agents/remoteclaw-tools.camera.test.ts
+++ b/src/agents/remoteclaw-tools.camera.test.ts
@@ -1,5 +1,8 @@
-import * as fs from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  readFileUtf8AndCleanup,
+  stubFetchTextResponse,
+} from "../test-utils/camera-url-test-helpers.js";
 
 const { callGateway } = vi.hoisted(() => ({
   callGateway: vi.fn(),
@@ -148,10 +151,7 @@ describe("nodes camera_snap", () => {
   });
 
   it("downloads camera_snap url payloads when node remoteIp is available", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("url-image", { status: 200 })),
-    );
+    stubFetchTextResponse("url-image");
     setupNodeInvokeMock({
       remoteIp: "198.51.100.42",
       invokePayload: {
@@ -172,18 +172,11 @@ describe("nodes camera_snap", () => {
     const mediaPath = String((result.content?.[0] as { text?: string } | undefined)?.text ?? "")
       .replace(/^MEDIA:/, "")
       .trim();
-    try {
-      await expect(fs.readFile(mediaPath, "utf8")).resolves.toBe("url-image");
-    } finally {
-      await fs.unlink(mediaPath).catch(() => {});
-    }
+    await expect(readFileUtf8AndCleanup(mediaPath)).resolves.toBe("url-image");
   });
 
   it("rejects camera_snap url payloads when node remoteIp is missing", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("url-image", { status: 200 })),
-    );
+    stubFetchTextResponse("url-image");
     setupNodeInvokeMock({
       invokePayload: {
         format: "jpg",
@@ -205,10 +198,7 @@ describe("nodes camera_snap", () => {
 
 describe("nodes camera_clip", () => {
   it("downloads camera_clip url payloads when node remoteIp is available", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("url-clip", { status: 200 })),
-    );
+    stubFetchTextResponse("url-clip");
     setupNodeInvokeMock({
       remoteIp: "198.51.100.42",
       invokePayload: {
@@ -227,18 +217,11 @@ describe("nodes camera_clip", () => {
     const filePath = String((result.content?.[0] as { text?: string } | undefined)?.text ?? "")
       .replace(/^FILE:/, "")
       .trim();
-    try {
-      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("url-clip");
-    } finally {
-      await fs.unlink(filePath).catch(() => {});
-    }
+    await expect(readFileUtf8AndCleanup(filePath)).resolves.toBe("url-clip");
   });
 
   it("rejects camera_clip url payloads when node remoteIp is missing", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("url-clip", { status: 200 })),
-    );
+    stubFetchTextResponse("url-clip");
     setupNodeInvokeMock({
       invokePayload: {
         format: "mp4",

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -6,8 +6,7 @@ import {
   parseCameraClipPayload,
   parseCameraSnapPayload,
   writeCameraClipPayloadToFile,
-  writeBase64ToFile,
-  writeUrlToFile,
+  writeCameraPayloadToFile,
 } from "../../cli/nodes-camera.js";
 import { parseEnvPairs, parseTimeoutMs } from "../../cli/nodes-run.js";
 import {
@@ -284,16 +283,12 @@ export function createNodesTool(options?: {
                 facing,
                 ext: isJpeg ? "jpg" : "png",
               });
-              if (payload.url) {
-                if (!resolvedNode.remoteIp) {
-                  throw new Error("camera URL payload requires node remoteIp");
-                }
-                await writeUrlToFile(filePath, payload.url, {
-                  expectedHost: resolvedNode.remoteIp,
-                });
-              } else if (payload.base64) {
-                await writeBase64ToFile(filePath, payload.base64);
-              }
+              await writeCameraPayloadToFile({
+                filePath,
+                payload,
+                expectedHost: resolvedNode.remoteIp,
+                invalidPayloadMessage: "invalid camera.snap payload",
+              });
               content.push({ type: "text", text: `MEDIA:${filePath}` });
               if (payload.base64) {
                 content.push({

--- a/src/agents/tools/nodes-utils.ts
+++ b/src/agents/tools/nodes-utils.ts
@@ -1,6 +1,6 @@
 import { parseNodeList, parsePairingList } from "../../shared/node-list-parse.js";
 import type { NodeListNode } from "../../shared/node-list-types.js";
-import { resolveNodeIdFromCandidates } from "../../shared/node-match.js";
+import { resolveNodeFromNodeList, resolveNodeIdFromNodeList } from "../../shared/node-resolve.js";
 import { callGatewayTool, type GatewayCallOptions } from "./gateway.js";
 
 export type { NodeListNode };
@@ -57,17 +57,10 @@ export function resolveNodeIdFromList(
   query?: string,
   allowDefault = false,
 ): string {
-  const q = String(query ?? "").trim();
-  if (!q) {
-    if (allowDefault) {
-      const picked = pickDefaultNode(nodes);
-      if (picked) {
-        return picked.nodeId;
-      }
-    }
-    throw new Error("node required");
-  }
-  return resolveNodeIdFromCandidates(nodes, q);
+  return resolveNodeIdFromNodeList(nodes, query, {
+    allowDefault,
+    pickDefaultNode: pickDefaultNode,
+  });
 }
 
 export async function resolveNodeId(
@@ -84,6 +77,8 @@ export async function resolveNode(
   allowDefault = false,
 ): Promise<NodeListNode> {
   const nodes = await loadNodes(opts);
-  const nodeId = resolveNodeIdFromList(nodes, query, allowDefault);
-  return nodes.find((node) => node.nodeId === nodeId) ?? { nodeId };
+  return resolveNodeFromNodeList(nodes, query, {
+    allowDefault,
+    pickDefaultNode: pickDefaultNode,
+  });
 }

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -21,6 +21,8 @@ function deriveMentionPatterns(identity?: { name?: string; emoji?: string }) {
 }
 
 const BACKSPACE_CHAR = "\u0008";
+const mentionRegexCompileCache = new Map<string, RegExp[]>();
+const MAX_MENTION_REGEX_COMPILE_CACHE_KEYS = 512;
 
 export const CURRENT_MESSAGE_MARKER = "[Current message - respond to this]";
 
@@ -54,7 +56,15 @@ function resolveMentionPatterns(cfg: RemoteClawConfig | undefined, agentId?: str
 
 export function buildMentionRegexes(cfg: RemoteClawConfig | undefined, agentId?: string): RegExp[] {
   const patterns = normalizeMentionPatterns(resolveMentionPatterns(cfg, agentId));
-  return patterns
+  if (patterns.length === 0) {
+    return [];
+  }
+  const cacheKey = patterns.join("\u001f");
+  const cached = mentionRegexCompileCache.get(cacheKey);
+  if (cached) {
+    return [...cached];
+  }
+  const compiled = patterns
     .map((pattern) => {
       try {
         return new RegExp(pattern, "i");
@@ -63,6 +73,12 @@ export function buildMentionRegexes(cfg: RemoteClawConfig | undefined, agentId?:
       }
     })
     .filter((value): value is RegExp => Boolean(value));
+  mentionRegexCompileCache.set(cacheKey, compiled);
+  if (mentionRegexCompileCache.size > MAX_MENTION_REGEX_COMPILE_CACHE_KEYS) {
+    mentionRegexCompileCache.clear();
+    mentionRegexCompileCache.set(cacheKey, compiled);
+  }
+  return [...compiled];
 }
 
 export function normalizeMentionText(text: string): string {

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -3,6 +3,31 @@ import { escapeRegExp } from "../utils.js";
 export const SILENT_REPLY_TOKEN = "NO_REPLY";
 export const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
 
+const silentExactRegexByToken = new Map<string, RegExp>();
+const silentTrailingRegexByToken = new Map<string, RegExp>();
+
+function getSilentExactRegex(token: string): RegExp {
+  const cached = silentExactRegexByToken.get(token);
+  if (cached) {
+    return cached;
+  }
+  const escaped = escapeRegExp(token);
+  const regex = new RegExp(`^\\s*${escaped}\\s*$`);
+  silentExactRegexByToken.set(token, regex);
+  return regex;
+}
+
+function getSilentTrailingRegex(token: string): RegExp {
+  const cached = silentTrailingRegexByToken.get(token);
+  if (cached) {
+    return cached;
+  }
+  const escaped = escapeRegExp(token);
+  const regex = new RegExp(`(?:^|\\s+|\\*+)${escaped}\\s*$`);
+  silentTrailingRegexByToken.set(token, regex);
+  return regex;
+}
+
 export function isSilentReplyText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,
@@ -10,11 +35,9 @@ export function isSilentReplyText(
   if (!text) {
     return false;
   }
-  const escaped = escapeRegExp(token);
   // Match only the exact silent token with optional surrounding whitespace.
-  // This prevents
-  // substantive replies ending with NO_REPLY from being suppressed (#19537).
-  return new RegExp(`^\\s*${escaped}\\s*$`).test(text);
+  // This prevents substantive replies ending with NO_REPLY from being suppressed (#19537).
+  return getSilentExactRegex(token).test(text);
 }
 
 /**
@@ -23,8 +46,7 @@ export function isSilentReplyText(
  * If the result is empty, the entire message should be treated as silent.
  */
 export function stripSilentToken(text: string, token: string = SILENT_REPLY_TOKEN): string {
-  const escaped = escapeRegExp(token);
-  return text.replace(new RegExp(`(?:^|\\s+|\\*+)${escaped}\\s*$`), "").trim();
+  return text.replace(getSilentTrailingRegex(token), "").trim();
 }
 
 export function isSilentReplyPrefixText(

--- a/src/channels/plugins/index.ts
+++ b/src/channels/plugins/index.ts
@@ -1,4 +1,7 @@
-import { getActivePluginRegistryKey, requireActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  getActivePluginRegistryVersion,
+  requireActivePluginRegistry,
+} from "../../plugins/runtime.js";
 import { CHAT_CHANNEL_ORDER, type ChatChannelId, normalizeAnyChannelId } from "../registry.js";
 import type { ChannelId, ChannelPlugin } from "./types.js";
 
@@ -23,15 +26,13 @@ function dedupeChannels(channels: ChannelPlugin[]): ChannelPlugin[] {
 }
 
 type CachedChannelPlugins = {
-  registry: ReturnType<typeof requireActivePluginRegistry> | null;
-  registryKey: string | null;
+  registryVersion: number;
   sorted: ChannelPlugin[];
   byId: Map<string, ChannelPlugin>;
 };
 
 const EMPTY_CHANNEL_PLUGIN_CACHE: CachedChannelPlugins = {
-  registry: null,
-  registryKey: null,
+  registryVersion: -1,
   sorted: [],
   byId: new Map(),
 };
@@ -40,9 +41,9 @@ let cachedChannelPlugins = EMPTY_CHANNEL_PLUGIN_CACHE;
 
 function resolveCachedChannelPlugins(): CachedChannelPlugins {
   const registry = requireActivePluginRegistry();
-  const registryKey = getActivePluginRegistryKey();
+  const registryVersion = getActivePluginRegistryVersion();
   const cached = cachedChannelPlugins;
-  if (cached.registry === registry && cached.registryKey === registryKey) {
+  if (cached.registryVersion === registryVersion) {
     return cached;
   }
 
@@ -62,8 +63,7 @@ function resolveCachedChannelPlugins(): CachedChannelPlugins {
   }
 
   const next: CachedChannelPlugins = {
-    registry,
-    registryKey,
+    registryVersion,
     sorted,
     byId,
   };

--- a/src/channels/plugins/index.ts
+++ b/src/channels/plugins/index.ts
@@ -1,4 +1,4 @@
-import { requireActivePluginRegistry } from "../../plugins/runtime.js";
+import { getActivePluginRegistryKey, requireActivePluginRegistry } from "../../plugins/runtime.js";
 import { CHAT_CHANNEL_ORDER, type ChatChannelId, normalizeAnyChannelId } from "../registry.js";
 import type { ChannelId, ChannelPlugin } from "./types.js";
 
@@ -8,12 +8,6 @@ import type { ChannelId, ChannelPlugin } from "./types.js";
 // Shared code paths (reply flow, command auth, sandbox explain) should depend on `src/channels/dock.ts`
 // instead, and only call `getChannelPlugin()` at execution boundaries.
 //
-// Channel plugins are registered by the plugin loader (extensions/ or configured paths).
-function listPluginChannels(): ChannelPlugin[] {
-  const registry = requireActivePluginRegistry();
-  return registry.channels.map((entry) => entry.plugin);
-}
-
 function dedupeChannels(channels: ChannelPlugin[]): ChannelPlugin[] {
   const seen = new Set<string>();
   const resolved: ChannelPlugin[] = [];
@@ -28,9 +22,31 @@ function dedupeChannels(channels: ChannelPlugin[]): ChannelPlugin[] {
   return resolved;
 }
 
-export function listChannelPlugins(): ChannelPlugin[] {
-  const combined = dedupeChannels(listPluginChannels());
-  return combined.toSorted((a, b) => {
+type CachedChannelPlugins = {
+  registry: ReturnType<typeof requireActivePluginRegistry> | null;
+  registryKey: string | null;
+  sorted: ChannelPlugin[];
+  byId: Map<string, ChannelPlugin>;
+};
+
+const EMPTY_CHANNEL_PLUGIN_CACHE: CachedChannelPlugins = {
+  registry: null,
+  registryKey: null,
+  sorted: [],
+  byId: new Map(),
+};
+
+let cachedChannelPlugins = EMPTY_CHANNEL_PLUGIN_CACHE;
+
+function resolveCachedChannelPlugins(): CachedChannelPlugins {
+  const registry = requireActivePluginRegistry();
+  const registryKey = getActivePluginRegistryKey();
+  const cached = cachedChannelPlugins;
+  if (cached.registry === registry && cached.registryKey === registryKey) {
+    return cached;
+  }
+
+  const sorted = dedupeChannels(registry.channels.map((entry) => entry.plugin)).toSorted((a, b) => {
     const indexA = CHAT_CHANNEL_ORDER.indexOf(a.id as ChatChannelId);
     const indexB = CHAT_CHANNEL_ORDER.indexOf(b.id as ChatChannelId);
     const orderA = a.meta.order ?? (indexA === -1 ? 999 : indexA);
@@ -40,6 +56,23 @@ export function listChannelPlugins(): ChannelPlugin[] {
     }
     return a.id.localeCompare(b.id);
   });
+  const byId = new Map<string, ChannelPlugin>();
+  for (const plugin of sorted) {
+    byId.set(plugin.id, plugin);
+  }
+
+  const next: CachedChannelPlugins = {
+    registry,
+    registryKey,
+    sorted,
+    byId,
+  };
+  cachedChannelPlugins = next;
+  return next;
+}
+
+export function listChannelPlugins(): ChannelPlugin[] {
+  return resolveCachedChannelPlugins().sorted.slice();
 }
 
 export function getChannelPlugin(id: ChannelId): ChannelPlugin | undefined {
@@ -47,7 +80,7 @@ export function getChannelPlugin(id: ChannelId): ChannelPlugin | undefined {
   if (!resolvedId) {
     return undefined;
   }
-  return listChannelPlugins().find((plugin) => plugin.id === resolvedId);
+  return resolveCachedChannelPlugins().byId.get(resolvedId);
 }
 
 export function normalizeChannelId(raw?: string | null): ChannelId | null {

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -1,6 +1,10 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  readFileUtf8AndCleanup,
+  stubFetchResponse,
+} from "../test-utils/camera-url-test-helpers.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import {
   cameraTempPath,
@@ -17,13 +21,6 @@ async function withCameraTempDir<T>(run: (dir: string) => Promise<T>): Promise<T
 }
 
 describe("nodes camera helpers", () => {
-  function stubFetchResponse(response: Response) {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => response),
-    );
-  }
-
   it("parses camera.snap payload", () => {
     expect(
       parseCameraSnapPayload({
@@ -88,7 +85,7 @@ describe("nodes camera helpers", () => {
         id: "clip1",
       });
       expect(out).toBe(path.join(dir, "remoteclaw-camera-clip-front-clip1.mp4"));
-      await expect(fs.readFile(out, "utf8")).resolves.toBe("hi");
+      await expect(readFileUtf8AndCleanup(out)).resolves.toBe("hi");
     });
   });
 
@@ -109,7 +106,7 @@ describe("nodes camera helpers", () => {
         expectedHost,
       });
       expect(out).toBe(path.join(dir, "remoteclaw-camera-clip-back-clip2.mp4"));
-      await expect(fs.readFile(out, "utf8")).resolves.toBe("url-clip");
+      await expect(readFileUtf8AndCleanup(out)).resolves.toBe("url-clip");
     });
   });
 
@@ -132,7 +129,7 @@ describe("nodes camera helpers", () => {
     await withCameraTempDir(async (dir) => {
       const out = path.join(dir, "x.bin");
       await writeBase64ToFile(out, "aGk=");
-      await expect(fs.readFile(out, "utf8")).resolves.toBe("hi");
+      await expect(readFileUtf8AndCleanup(out)).resolves.toBe("hi");
     });
   });
 
@@ -147,7 +144,7 @@ describe("nodes camera helpers", () => {
       await writeUrlToFile(out, "https://198.51.100.42/clip.mp4", {
         expectedHost: "198.51.100.42",
       });
-      await expect(fs.readFile(out, "utf8")).resolves.toBe("url-content");
+      await expect(readFileUtf8AndCleanup(out)).resolves.toBe("url-content");
     });
   });
 

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -182,6 +182,33 @@ export async function writeBase64ToFile(filePath: string, base64: string) {
   return { path: filePath, bytes: buf.length };
 }
 
+export function requireNodeRemoteIp(remoteIp?: string): string {
+  const normalized = remoteIp?.trim();
+  if (!normalized) {
+    throw new Error("camera URL payload requires node remoteIp");
+  }
+  return normalized;
+}
+
+export async function writeCameraPayloadToFile(params: {
+  filePath: string;
+  payload: { url?: string; base64?: string };
+  expectedHost?: string;
+  invalidPayloadMessage?: string;
+}) {
+  if (params.payload.url) {
+    await writeUrlToFile(params.filePath, params.payload.url, {
+      expectedHost: requireNodeRemoteIp(params.expectedHost),
+    });
+    return;
+  }
+  if (params.payload.base64) {
+    await writeBase64ToFile(params.filePath, params.payload.base64);
+    return;
+  }
+  throw new Error(params.invalidPayloadMessage ?? "invalid camera payload");
+}
+
 export async function writeCameraClipPayloadToFile(params: {
   payload: CameraClipPayload;
   facing: CameraFacing;
@@ -196,15 +223,11 @@ export async function writeCameraClipPayloadToFile(params: {
     tmpDir: params.tmpDir,
     id: params.id,
   });
-  if (params.payload.url) {
-    if (!params.expectedHost) {
-      throw new Error("camera URL payload requires node remoteIp");
-    }
-    await writeUrlToFile(filePath, params.payload.url, { expectedHost: params.expectedHost });
-  } else if (params.payload.base64) {
-    await writeBase64ToFile(filePath, params.payload.base64);
-  } else {
-    throw new Error("invalid camera.clip payload");
-  }
+  await writeCameraPayloadToFile({
+    filePath,
+    payload: params.payload,
+    expectedHost: params.expectedHost,
+    invalidPayloadMessage: "invalid camera.clip payload",
+  });
   return filePath;
 }

--- a/src/cli/nodes-cli/register.camera.ts
+++ b/src/cli/nodes-cli/register.camera.ts
@@ -7,9 +7,8 @@ import {
   cameraTempPath,
   parseCameraClipPayload,
   parseCameraSnapPayload,
-  writeBase64ToFile,
+  writeCameraPayloadToFile,
   writeCameraClipPayloadToFile,
-  writeUrlToFile,
 } from "../nodes-camera.js";
 import { parseDurationMs } from "../parse-duration.js";
 import { getNodesTheme, runNodesCommand } from "./cli-utils.js";
@@ -166,14 +165,12 @@ export function registerNodesCameraCommands(nodes: Command) {
               facing,
               ext: payload.format === "jpeg" ? "jpg" : payload.format,
             });
-            if (payload.url) {
-              if (!node.remoteIp) {
-                throw new Error("camera URL payload requires node remoteIp");
-              }
-              await writeUrlToFile(filePath, payload.url, { expectedHost: node.remoteIp });
-            } else if (payload.base64) {
-              await writeBase64ToFile(filePath, payload.base64);
-            }
+            await writeCameraPayloadToFile({
+              filePath,
+              payload,
+              expectedHost: node.remoteIp,
+              invalidPayloadMessage: "invalid camera.snap payload",
+            });
             results.push({
               facing,
               path: filePath,

--- a/src/cli/nodes-cli/rpc.ts
+++ b/src/cli/nodes-cli/rpc.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { callGateway, randomIdempotencyKey } from "../../gateway/call.js";
-import { resolveNodeIdFromCandidates } from "../../shared/node-match.js";
+import { resolveNodeFromNodeList } from "../../shared/node-resolve.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
 import { withProgress } from "../progress.js";
 import { parseNodeList, parsePairingList } from "./format.js";
@@ -77,11 +77,6 @@ export async function resolveNodeId(opts: NodesRpcOpts, query: string) {
 }
 
 export async function resolveNode(opts: NodesRpcOpts, query: string): Promise<NodeListNode> {
-  const q = String(query ?? "").trim();
-  if (!q) {
-    throw new Error("node required");
-  }
-
   let nodes: NodeListNode[] = [];
   try {
     const res = await callGatewayCli("node.list", opts, {});
@@ -97,6 +92,5 @@ export async function resolveNode(opts: NodesRpcOpts, query: string): Promise<No
       remoteIp: n.remoteIp,
     }));
   }
-  const nodeId = resolveNodeIdFromCandidates(nodes, q);
-  return nodes.find((node) => node.nodeId === nodeId) ?? { nodeId };
+  return resolveNodeFromNodeList(nodes, query);
 }

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -193,8 +193,8 @@ function validateConfigObjectWithPluginsBase(
 
   type RegistryInfo = {
     registry: ReturnType<typeof loadPluginManifestRegistry>;
-    knownIds: Set<string>;
-    normalizedPlugins: ReturnType<typeof normalizePluginsConfig>;
+    knownIds?: Set<string>;
+    normalizedPlugins?: ReturnType<typeof normalizePluginsConfig>;
   };
 
   let registryInfo: RegistryInfo | null = null;
@@ -209,8 +209,6 @@ function validateConfigObjectWithPluginsBase(
       config,
       workspaceDir: workspaceDir ?? undefined,
     });
-    const knownIds = new Set(registry.plugins.map((record) => record.id));
-    const normalizedPlugins = normalizePluginsConfig(config.plugins);
 
     for (const diag of registry.diagnostics) {
       let path = diag.pluginId ? `plugins.entries.${diag.pluginId}` : "plugins";
@@ -226,8 +224,24 @@ function validateConfigObjectWithPluginsBase(
       }
     }
 
-    registryInfo = { registry, knownIds, normalizedPlugins };
+    registryInfo = { registry };
     return registryInfo;
+  };
+
+  const ensureKnownIds = (): Set<string> => {
+    const info = ensureRegistry();
+    if (!info.knownIds) {
+      info.knownIds = new Set(info.registry.plugins.map((record) => record.id));
+    }
+    return info.knownIds;
+  };
+
+  const ensureNormalizedPlugins = (): ReturnType<typeof normalizePluginsConfig> => {
+    const info = ensureRegistry();
+    if (!info.normalizedPlugins) {
+      info.normalizedPlugins = normalizePluginsConfig(config.plugins);
+    }
+    return info.normalizedPlugins;
   };
 
   const allowedChannels = new Set<string>(["defaults", "modelByChannel", ...CHANNEL_IDS]);
@@ -310,7 +324,9 @@ function validateConfigObjectWithPluginsBase(
     return { ok: true, config, warnings };
   }
 
-  const { registry, knownIds, normalizedPlugins } = ensureRegistry();
+  const { registry } = ensureRegistry();
+  const knownIds = ensureKnownIds();
+  const normalizedPlugins = ensureNormalizedPlugins();
   const pushMissingPluginIssue = (
     path: string,
     pluginId: string,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -240,6 +240,212 @@ type DeliverOutboundPayloadsParams = DeliverOutboundPayloadsCoreParams & {
   skipQueue?: boolean;
 };
 
+type MessageSentEvent = {
+  success: boolean;
+  content: string;
+  error?: string;
+  messageId?: string;
+};
+
+function hasMediaPayload(payload: ReplyPayload): boolean {
+  return Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+}
+
+function hasChannelDataPayload(payload: ReplyPayload): boolean {
+  return Boolean(payload.channelData && Object.keys(payload.channelData).length > 0);
+}
+
+function normalizePayloadForChannelDelivery(
+  payload: ReplyPayload,
+  channelId: string,
+): ReplyPayload | null {
+  const hasMedia = hasMediaPayload(payload);
+  const hasChannelData = hasChannelDataPayload(payload);
+  const rawText = typeof payload.text === "string" ? payload.text : "";
+  const normalizedText =
+    channelId === "whatsapp" ? rawText.replace(/^(?:[ \t]*\r?\n)+/, "") : rawText;
+  if (!normalizedText.trim()) {
+    if (!hasMedia && !hasChannelData) {
+      return null;
+    }
+    return {
+      ...payload,
+      text: "",
+    };
+  }
+  if (normalizedText === rawText) {
+    return payload;
+  }
+  return {
+    ...payload,
+    text: normalizedText,
+  };
+}
+
+function normalizePayloadsForChannelDelivery(
+  payloads: ReplyPayload[],
+  channel: Exclude<OutboundChannel, "none">,
+): ReplyPayload[] {
+  const normalizedPayloads: ReplyPayload[] = [];
+  for (const payload of normalizeReplyPayloadsForDelivery(payloads)) {
+    let sanitizedPayload = payload;
+    // Strip HTML tags for plain-text surfaces (WhatsApp, Signal, etc.)
+    // Models occasionally produce <br>, <b>, etc. that render as literal text.
+    // See https://github.com/openclaw/openclaw/issues/31884
+    if (isPlainTextSurface(channel) && payload.text) {
+      // Telegram sendPayload uses textMode:"html". Preserve raw HTML in this path.
+      if (!(channel === "telegram" && payload.channelData)) {
+        sanitizedPayload = { ...payload, text: sanitizeForPlainText(payload.text) };
+      }
+    }
+    const normalized = normalizePayloadForChannelDelivery(sanitizedPayload, channel);
+    if (normalized) {
+      normalizedPayloads.push(normalized);
+    }
+  }
+  return normalizedPayloads;
+}
+
+function buildPayloadSummary(payload: ReplyPayload): NormalizedOutboundPayload {
+  return {
+    text: payload.text ?? "",
+    mediaUrls: payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []),
+    channelData: payload.channelData,
+  };
+}
+
+function createMessageSentEmitter(params: {
+  hookRunner: ReturnType<typeof getGlobalHookRunner>;
+  channel: Exclude<OutboundChannel, "none">;
+  to: string;
+  accountId?: string;
+  sessionKeyForInternalHooks?: string;
+  mirrorIsGroup?: boolean;
+  mirrorGroupId?: string;
+}): { emitMessageSent: (event: MessageSentEvent) => void; hasMessageSentHooks: boolean } {
+  const hasMessageSentHooks = params.hookRunner?.hasHooks("message_sent") ?? false;
+  const canEmitInternalHook = Boolean(params.sessionKeyForInternalHooks);
+  const emitMessageSent = (event: MessageSentEvent) => {
+    if (!hasMessageSentHooks && !canEmitInternalHook) {
+      return;
+    }
+    const canonical = buildCanonicalSentMessageHookContext({
+      to: params.to,
+      content: event.content,
+      success: event.success,
+      error: event.error,
+      channelId: params.channel,
+      accountId: params.accountId ?? undefined,
+      conversationId: params.to,
+      messageId: event.messageId,
+      isGroup: params.mirrorIsGroup,
+      groupId: params.mirrorGroupId,
+    });
+    if (hasMessageSentHooks) {
+      fireAndForgetHook(
+        params.hookRunner!.runMessageSent(
+          toPluginMessageSentEvent(canonical),
+          toPluginMessageContext(canonical),
+        ),
+        "deliverOutboundPayloads: message_sent plugin hook failed",
+        (message) => {
+          log.warn(message);
+        },
+      );
+    }
+    if (!canEmitInternalHook) {
+      return;
+    }
+    fireAndForgetHook(
+      triggerInternalHook(
+        createInternalHookEvent(
+          "message",
+          "sent",
+          params.sessionKeyForInternalHooks!,
+          toInternalMessageSentContext(canonical),
+        ),
+      ),
+      "deliverOutboundPayloads: message:sent internal hook failed",
+      (message) => {
+        log.warn(message);
+      },
+    );
+  };
+  return { emitMessageSent, hasMessageSentHooks };
+}
+
+async function applyMessageSendingHook(params: {
+  hookRunner: ReturnType<typeof getGlobalHookRunner>;
+  enabled: boolean;
+  payload: ReplyPayload;
+  payloadSummary: NormalizedOutboundPayload;
+  to: string;
+  channel: Exclude<OutboundChannel, "none">;
+  accountId?: string;
+}): Promise<{
+  cancelled: boolean;
+  payload: ReplyPayload;
+  payloadSummary: NormalizedOutboundPayload;
+}> {
+  if (!params.enabled) {
+    return {
+      cancelled: false,
+      payload: params.payload,
+      payloadSummary: params.payloadSummary,
+    };
+  }
+  try {
+    const sendingResult = await params.hookRunner!.runMessageSending(
+      {
+        to: params.to,
+        content: params.payloadSummary.text,
+        metadata: {
+          channel: params.channel,
+          accountId: params.accountId,
+          mediaUrls: params.payloadSummary.mediaUrls,
+        },
+      },
+      {
+        channelId: params.channel,
+        accountId: params.accountId ?? undefined,
+      },
+    );
+    if (sendingResult?.cancel) {
+      return {
+        cancelled: true,
+        payload: params.payload,
+        payloadSummary: params.payloadSummary,
+      };
+    }
+    if (sendingResult?.content == null) {
+      return {
+        cancelled: false,
+        payload: params.payload,
+        payloadSummary: params.payloadSummary,
+      };
+    }
+    const payload = {
+      ...params.payload,
+      text: sendingResult.content,
+    };
+    return {
+      cancelled: false,
+      payload,
+      payloadSummary: {
+        ...params.payloadSummary,
+        text: sendingResult.content,
+      },
+    };
+  } catch {
+    // Don't block delivery on hook failure.
+    return {
+      cancelled: false,
+      payload: params.payload,
+      payloadSummary: params.payloadSummary,
+    };
+  }
+}
+
 export async function deliverOutboundPayloads(
   params: DeliverOutboundPayloadsParams,
 ): Promise<OutboundDeliveryResult[]> {
@@ -439,60 +645,21 @@ async function deliverOutboundPayloadsCore(
       })),
     };
   };
-  const hasMediaPayload = (payload: ReplyPayload): boolean =>
-    Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
-  const hasChannelDataPayload = (payload: ReplyPayload): boolean =>
-    Boolean(payload.channelData && Object.keys(payload.channelData).length > 0);
-  const normalizePayloadForChannelDelivery = (
-    payload: ReplyPayload,
-    channelId: string,
-  ): ReplyPayload | null => {
-    const hasMedia = hasMediaPayload(payload);
-    const hasChannelData = hasChannelDataPayload(payload);
-    const rawText = typeof payload.text === "string" ? payload.text : "";
-    const normalizedText =
-      channelId === "whatsapp" ? rawText.replace(/^(?:[ \t]*\r?\n)+/, "") : rawText;
-    if (!normalizedText.trim()) {
-      if (!hasMedia && !hasChannelData) {
-        return null;
-      }
-      return {
-        ...payload,
-        text: "",
-      };
-    }
-    if (normalizedText === rawText) {
-      return payload;
-    }
-    return {
-      ...payload,
-      text: normalizedText,
-    };
-  };
-  const normalizedPayloads: ReplyPayload[] = [];
-  for (const payload of normalizeReplyPayloadsForDelivery(payloads)) {
-    let sanitizedPayload = payload;
-    // Strip HTML tags for plain-text surfaces (WhatsApp, Signal, etc.)
-    // Models occasionally produce <br>, <b>, etc. that render as literal text.
-    // See https://github.com/openclaw/openclaw/issues/31884
-    if (isPlainTextSurface(channel) && payload.text) {
-      // Telegram sendPayload uses textMode:"html". Preserve raw HTML in this path.
-      if (!(channel === "telegram" && payload.channelData)) {
-        sanitizedPayload = { ...payload, text: sanitizeForPlainText(payload.text) };
-      }
-    }
-    const normalized = normalizePayloadForChannelDelivery(sanitizedPayload, channel);
-    if (normalized) {
-      normalizedPayloads.push(normalized);
-    }
-  }
+  const normalizedPayloads = normalizePayloadsForChannelDelivery(payloads, channel);
   const hookRunner = getGlobalHookRunner();
   const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.session?.key;
   const mirrorIsGroup = params.mirror?.isGroup;
   const mirrorGroupId = params.mirror?.groupId;
-  const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
+  const { emitMessageSent, hasMessageSentHooks } = createMessageSentEmitter({
+    hookRunner,
+    channel,
+    to,
+    accountId,
+    sessionKeyForInternalHooks,
+    mirrorIsGroup,
+    mirrorGroupId,
+  });
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
-  const canEmitInternalHook = Boolean(sessionKeyForInternalHooks);
   if (hasMessageSentHooks && params.session?.agentId && !sessionKeyForInternalHooks) {
     log.warn(
       "deliverOutboundPayloads: session.agentId present without session key; internal message:sent hook will be skipped",
@@ -504,91 +671,25 @@ async function deliverOutboundPayloadsCore(
     );
   }
   for (const payload of normalizedPayloads) {
-    const payloadSummary: NormalizedOutboundPayload = {
-      text: payload.text ?? "",
-      mediaUrls: payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []),
-      channelData: payload.channelData,
-    };
-    const emitMessageSent = (params: {
-      success: boolean;
-      content: string;
-      error?: string;
-      messageId?: string;
-    }) => {
-      if (!hasMessageSentHooks && !canEmitInternalHook) {
-        return;
-      }
-      const canonical = buildCanonicalSentMessageHookContext({
-        to,
-        content: params.content,
-        success: params.success,
-        error: params.error,
-        channelId: channel,
-        accountId: accountId ?? undefined,
-        conversationId: to,
-        messageId: params.messageId,
-        isGroup: mirrorIsGroup,
-        groupId: mirrorGroupId,
-      });
-      if (hasMessageSentHooks) {
-        fireAndForgetHook(
-          hookRunner!.runMessageSent(
-            toPluginMessageSentEvent(canonical),
-            toPluginMessageContext(canonical),
-          ),
-          "deliverOutboundPayloads: message_sent plugin hook failed",
-          (message) => {
-            log.warn(message);
-          },
-        );
-      }
-      if (!canEmitInternalHook) {
-        return;
-      }
-      fireAndForgetHook(
-        triggerInternalHook(
-          createInternalHookEvent(
-            "message",
-            "sent",
-            sessionKeyForInternalHooks!,
-            toInternalMessageSentContext(canonical),
-          ),
-        ),
-        "deliverOutboundPayloads: message:sent internal hook failed",
-        (message) => {
-          log.warn(message);
-        },
-      );
-    };
+    let payloadSummary = buildPayloadSummary(payload);
     try {
       throwIfAborted(abortSignal);
 
       // Run message_sending plugin hook (may modify content or cancel)
-      let effectivePayload = payload;
-      if (hasMessageSendingHooks) {
-        try {
-          const sendingResult = await hookRunner!.runMessageSending(
-            {
-              to,
-              content: payloadSummary.text,
-              metadata: { channel, accountId, mediaUrls: payloadSummary.mediaUrls },
-            },
-            {
-              channelId: channel,
-              accountId: accountId ?? undefined,
-            },
-          );
-          if (sendingResult?.cancel) {
-            continue;
-          }
-          if (sendingResult?.content != null) {
-            effectivePayload = { ...payload, text: sendingResult.content };
-            payloadSummary.text = sendingResult.content;
-          }
-        } catch {
-          // Don't block delivery on hook failure
-        }
+      const hookResult = await applyMessageSendingHook({
+        hookRunner,
+        enabled: hasMessageSendingHooks,
+        payload,
+        payloadSummary,
+        to,
+        channel,
+        accountId,
+      });
+      if (hookResult.cancelled) {
+        continue;
       }
+      const effectivePayload = hookResult.payload;
+      payloadSummary = hookResult.payloadSummary;
 
       params.onPayload?.(payloadSummary);
       const sendOverrides = {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -469,33 +469,31 @@ async function deliverOutboundPayloadsCore(
       text: normalizedText,
     };
   };
-  const normalizedPayloads = normalizeReplyPayloadsForDelivery(payloads)
-    .map((payload) => {
-      // Strip HTML tags for plain-text surfaces (WhatsApp, Signal, etc.)
-      // Models occasionally produce <br>, <b>, etc. that render as literal text.
-      // See https://github.com/openclaw/openclaw/issues/31884
-      if (!isPlainTextSurface(channel) || !payload.text) {
-        return payload;
-      }
+  const normalizedPayloads: ReplyPayload[] = [];
+  for (const payload of normalizeReplyPayloadsForDelivery(payloads)) {
+    let sanitizedPayload = payload;
+    // Strip HTML tags for plain-text surfaces (WhatsApp, Signal, etc.)
+    // Models occasionally produce <br>, <b>, etc. that render as literal text.
+    // See https://github.com/openclaw/openclaw/issues/31884
+    if (isPlainTextSurface(channel) && payload.text) {
       // Telegram sendPayload uses textMode:"html". Preserve raw HTML in this path.
-      if (channel === "telegram" && payload.channelData) {
-        return payload;
+      if (!(channel === "telegram" && payload.channelData)) {
+        sanitizedPayload = { ...payload, text: sanitizeForPlainText(payload.text) };
       }
-      return { ...payload, text: sanitizeForPlainText(payload.text) };
-    })
-    .flatMap((payload) => {
-      const normalized = normalizePayloadForChannelDelivery(payload, channel);
-      return normalized ? [normalized] : [];
-    });
+    }
+    const normalized = normalizePayloadForChannelDelivery(sanitizedPayload, channel);
+    if (normalized) {
+      normalizedPayloads.push(normalized);
+    }
+  }
   const hookRunner = getGlobalHookRunner();
   const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.session?.key;
   const mirrorIsGroup = params.mirror?.isGroup;
   const mirrorGroupId = params.mirror?.groupId;
-  if (
-    hookRunner?.hasHooks("message_sent") &&
-    params.session?.agentId &&
-    !sessionKeyForInternalHooks
-  ) {
+  const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
+  const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
+  const canEmitInternalHook = Boolean(sessionKeyForInternalHooks);
+  if (hasMessageSentHooks && params.session?.agentId && !sessionKeyForInternalHooks) {
     log.warn(
       "deliverOutboundPayloads: session.agentId present without session key; internal message:sent hook will be skipped",
       {
@@ -517,6 +515,9 @@ async function deliverOutboundPayloadsCore(
       error?: string;
       messageId?: string;
     }) => {
+      if (!hasMessageSentHooks && !canEmitInternalHook) {
+        return;
+      }
       const canonical = buildCanonicalSentMessageHookContext({
         to,
         content: params.content,
@@ -529,9 +530,9 @@ async function deliverOutboundPayloadsCore(
         isGroup: mirrorIsGroup,
         groupId: mirrorGroupId,
       });
-      if (hookRunner?.hasHooks("message_sent")) {
+      if (hasMessageSentHooks) {
         fireAndForgetHook(
-          hookRunner.runMessageSent(
+          hookRunner!.runMessageSent(
             toPluginMessageSentEvent(canonical),
             toPluginMessageContext(canonical),
           ),
@@ -541,7 +542,7 @@ async function deliverOutboundPayloadsCore(
           },
         );
       }
-      if (!sessionKeyForInternalHooks) {
+      if (!canEmitInternalHook) {
         return;
       }
       fireAndForgetHook(
@@ -549,7 +550,7 @@ async function deliverOutboundPayloadsCore(
           createInternalHookEvent(
             "message",
             "sent",
-            sessionKeyForInternalHooks,
+            sessionKeyForInternalHooks!,
             toInternalMessageSentContext(canonical),
           ),
         ),
@@ -564,9 +565,9 @@ async function deliverOutboundPayloadsCore(
 
       // Run message_sending plugin hook (may modify content or cancel)
       let effectivePayload = payload;
-      if (hookRunner?.hasHooks("message_sending")) {
+      if (hasMessageSendingHooks) {
         try {
-          const sendingResult = await hookRunner.runMessageSending(
+          const sendingResult = await hookRunner!.runMessageSending(
             {
               to,
               content: payloadSummary.text,

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -43,9 +43,10 @@ function mergeMediaUrls(...lists: Array<ReadonlyArray<string | undefined> | unde
 export function normalizeReplyPayloadsForDelivery(
   payloads: readonly ReplyPayload[],
 ): ReplyPayload[] {
-  return payloads.flatMap((payload) => {
+  const normalized: ReplyPayload[] = [];
+  for (const payload of payloads) {
     if (shouldSuppressReasoningPayload(payload)) {
-      return [];
+      continue;
     }
     const parsed = parseReplyDirectives(payload.text ?? "");
     const explicitMediaUrls = payload.mediaUrls ?? parsed.mediaUrls;
@@ -67,47 +68,50 @@ export function normalizeReplyPayloadsForDelivery(
       audioAsVoice: Boolean(payload.audioAsVoice || parsed.audioAsVoice),
     };
     if (parsed.isSilent && mergedMedia.length === 0) {
-      return [];
+      continue;
     }
     if (!isRenderablePayload(next)) {
-      return [];
+      continue;
     }
-    return [next];
-  });
+    normalized.push(next);
+  }
+  return normalized;
 }
 
 export function normalizeOutboundPayloads(
   payloads: readonly ReplyPayload[],
 ): NormalizedOutboundPayload[] {
-  return normalizeReplyPayloadsForDelivery(payloads)
-    .map((payload) => {
-      const channelData = payload.channelData;
-      const normalized: NormalizedOutboundPayload = {
-        text: payload.text ?? "",
-        mediaUrls: payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []),
-      };
-      if (channelData && Object.keys(channelData).length > 0) {
-        normalized.channelData = channelData;
-      }
-      return normalized;
-    })
-    .filter(
-      (payload) =>
-        payload.text ||
-        payload.mediaUrls.length > 0 ||
-        Boolean(payload.channelData && Object.keys(payload.channelData).length > 0),
-    );
+  const normalizedPayloads: NormalizedOutboundPayload[] = [];
+  for (const payload of normalizeReplyPayloadsForDelivery(payloads)) {
+    const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+    const channelData = payload.channelData;
+    const hasChannelData = Boolean(channelData && Object.keys(channelData).length > 0);
+    const text = payload.text ?? "";
+    if (!text && mediaUrls.length === 0 && !hasChannelData) {
+      continue;
+    }
+    normalizedPayloads.push({
+      text,
+      mediaUrls,
+      ...(hasChannelData ? { channelData } : {}),
+    });
+  }
+  return normalizedPayloads;
 }
 
 export function normalizeOutboundPayloadsForJson(
   payloads: readonly ReplyPayload[],
 ): OutboundPayloadJson[] {
-  return normalizeReplyPayloadsForDelivery(payloads).map((payload) => ({
-    text: payload.text ?? "",
-    mediaUrl: payload.mediaUrl ?? null,
-    mediaUrls: payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : undefined),
-    channelData: payload.channelData,
-  }));
+  const normalized: OutboundPayloadJson[] = [];
+  for (const payload of normalizeReplyPayloadsForDelivery(payloads)) {
+    normalized.push({
+      text: payload.text ?? "",
+      mediaUrl: payload.mediaUrl ?? null,
+      mediaUrls: payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : undefined),
+      channelData: payload.channelData,
+    });
+  }
+  return normalized;
 }
 
 export function formatOutboundPayloadLog(

--- a/src/infra/outbound/target-normalization.ts
+++ b/src/infra/outbound/target-normalization.ts
@@ -1,17 +1,45 @@
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import type { ChannelId } from "../../channels/plugins/types.js";
+import { getActivePluginRegistryVersion } from "../../plugins/runtime.js";
 
 export function normalizeChannelTargetInput(raw: string): string {
   return raw.trim();
+}
+
+type TargetNormalizer = ((raw: string) => string | undefined) | undefined;
+type TargetNormalizerCacheEntry = {
+  version: number;
+  normalizer: TargetNormalizer;
+};
+
+const targetNormalizerCacheByChannelId = new Map<string, TargetNormalizerCacheEntry>();
+
+function resolveTargetNormalizer(channelId: ChannelId): TargetNormalizer {
+  const version = getActivePluginRegistryVersion();
+  const cached = targetNormalizerCacheByChannelId.get(channelId);
+  if (cached?.version === version) {
+    return cached.normalizer;
+  }
+  const plugin = getChannelPlugin(channelId);
+  const normalizer = plugin?.messaging?.normalizeTarget;
+  targetNormalizerCacheByChannelId.set(channelId, {
+    version,
+    normalizer,
+  });
+  return normalizer;
 }
 
 export function normalizeTargetForProvider(provider: string, raw?: string): string | undefined {
   if (!raw) {
     return undefined;
   }
+  const fallback = raw.trim() || undefined;
+  if (!fallback) {
+    return undefined;
+  }
   const providerId = normalizeChannelId(provider);
-  const plugin = providerId ? getChannelPlugin(providerId) : undefined;
-  const normalized = plugin?.messaging?.normalizeTarget?.(raw) ?? (raw.trim() || undefined);
+  const normalizer = providerId ? resolveTargetNormalizer(providerId) : undefined;
+  const normalized = normalizer?.(raw) ?? fallback;
   return normalized || undefined;
 }
 

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -79,6 +79,10 @@ function unwrapQuoted(value: string): string | undefined {
   return trimmed.slice(1, -1).trim();
 }
 
+function mayContainFenceMarkers(input: string): boolean {
+  return input.includes("```") || input.includes("~~~");
+}
+
 // Check if a character offset is inside any fenced code block
 function isInsideFence(fenceSpans: Array<{ start: number; end: number }>, offset: number): boolean {
   return fenceSpans.some((span) => offset >= span.start && offset < span.end);
@@ -106,7 +110,8 @@ export function splitMediaFromOutput(raw: string): {
   let foundMediaToken = false;
 
   // Parse fenced code blocks to avoid extracting MEDIA tokens from inside them
-  const fenceSpans = parseFenceSpans(trimmedRaw);
+  const hasFenceMarkers = mayContainFenceMarkers(trimmedRaw);
+  const fenceSpans = hasFenceMarkers ? parseFenceSpans(trimmedRaw) : [];
 
   // Collect tokens line by line so we can strip them cleanly.
   const lines = trimmedRaw.split("\n");
@@ -115,7 +120,7 @@ export function splitMediaFromOutput(raw: string): {
   let lineOffset = 0; // Track character offset for fence checking
   for (const line of lines) {
     // Skip MEDIA extraction if this line is inside a fenced code block
-    if (isInsideFence(fenceSpans, lineOffset)) {
+    if (hasFenceMarkers && isInsideFence(fenceSpans, lineOffset)) {
       keptLines.push(line);
       lineOffset += line.length + 1; // +1 for newline
       continue;

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -96,6 +96,11 @@ export function splitMediaFromOutput(raw: string): {
   if (!trimmedRaw.trim()) {
     return { text: "" };
   }
+  const mayContainMediaToken = /media:/i.test(trimmedRaw);
+  const mayContainAudioTag = trimmedRaw.includes("[[");
+  if (!mayContainMediaToken && !mayContainAudioTag) {
+    return { text: trimmedRaw };
+  }
 
   const media: string[] = [];
   let foundMediaToken = false;

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -5,6 +5,7 @@ const REGISTRY_STATE = Symbol.for("remoteclaw.pluginRegistryState");
 type RegistryState = {
   registry: PluginRegistry | null;
   key: string | null;
+  version: number;
 };
 
 const state: RegistryState = (() => {
@@ -15,6 +16,7 @@ const state: RegistryState = (() => {
     globalState[REGISTRY_STATE] = {
       registry: createEmptyPluginRegistry(),
       key: null,
+      version: 0,
     };
   }
   return globalState[REGISTRY_STATE];
@@ -23,6 +25,7 @@ const state: RegistryState = (() => {
 export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
   state.registry = registry;
   state.key = cacheKey ?? null;
+  state.version += 1;
 }
 
 export function getActivePluginRegistry(): PluginRegistry | null {
@@ -32,10 +35,15 @@ export function getActivePluginRegistry(): PluginRegistry | null {
 export function requireActivePluginRegistry(): PluginRegistry {
   if (!state.registry) {
     state.registry = createEmptyPluginRegistry();
+    state.version += 1;
   }
   return state.registry;
 }
 
 export function getActivePluginRegistryKey(): string | null {
   return state.key;
+}
+
+export function getActivePluginRegistryVersion(): number {
+  return state.version;
 }

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -448,6 +448,35 @@ function formatRouteCachePeer(peer: RoutePeer | null): string {
   return `${peer.kind}:${peer.id}`;
 }
 
+function formatRoleIdsCacheKey(roleIds: string[]): string {
+  const count = roleIds.length;
+  if (count === 0) {
+    return "-";
+  }
+  if (count === 1) {
+    return roleIds[0] ?? "-";
+  }
+  if (count === 2) {
+    const first = roleIds[0] ?? "";
+    const second = roleIds[1] ?? "";
+    return first <= second ? `${first},${second}` : `${second},${first}`;
+  }
+  return roleIds.toSorted().join(",");
+}
+
+function buildResolvedRouteCacheKey(params: {
+  channel: string;
+  accountId: string;
+  peer: RoutePeer | null;
+  parentPeer: RoutePeer | null;
+  guildId: string;
+  teamId: string;
+  memberRoleIds: string[];
+  dmScope: string;
+}): string {
+  return `${params.channel}\t${params.accountId}\t${formatRouteCachePeer(params.peer)}\t${formatRouteCachePeer(params.parentPeer)}\t${params.guildId || "-"}\t${params.teamId || "-"}\t${formatRoleIdsCacheKey(params.memberRoleIds)}\t${params.dmScope}`;
+}
+
 function hasGuildConstraint(match: NormalizedBindingMatch): boolean {
   return Boolean(match.guildId);
 }
@@ -524,16 +553,16 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const routeCache =
     !shouldLogDebug && !identityLinks ? resolveRouteCacheForConfig(input.cfg) : null;
   const routeCacheKey = routeCache
-    ? [
+    ? buildResolvedRouteCacheKey({
         channel,
         accountId,
-        formatRouteCachePeer(peer),
-        formatRouteCachePeer(parentPeer),
-        guildId || "-",
-        teamId || "-",
-        memberRoleIds.length > 0 ? memberRoleIds.toSorted().join(",") : "-",
+        peer,
+        parentPeer,
+        guildId,
+        teamId,
+        memberRoleIds,
         dmScope,
-      ].join("\t")
+      })
     : "";
   if (routeCache && routeCacheKey) {
     const cachedRoute = routeCache.get(routeCacheKey);

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -204,6 +204,16 @@ type EvaluatedBindingsCache = {
 
 const evaluatedBindingsCacheByCfg = new WeakMap<RemoteClawConfig, EvaluatedBindingsCache>();
 const MAX_EVALUATED_BINDINGS_CACHE_KEYS = 2000;
+const resolvedRouteCacheByCfg = new WeakMap<
+  OpenClawConfig,
+  {
+    bindingsRef: OpenClawConfig["bindings"];
+    agentsRef: OpenClawConfig["agents"];
+    sessionRef: OpenClawConfig["session"];
+    byKey: Map<string, ResolvedAgentRoute>;
+  }
+>();
+const MAX_RESOLVED_ROUTE_CACHE_KEYS = 4000;
 
 type EvaluatedBindingsIndex = {
   byPeer: Map<string, EvaluatedBinding[]>;
@@ -411,6 +421,33 @@ function normalizeBindingMatch(
   };
 }
 
+function resolveRouteCacheForConfig(cfg: OpenClawConfig): Map<string, ResolvedAgentRoute> {
+  const existing = resolvedRouteCacheByCfg.get(cfg);
+  if (
+    existing &&
+    existing.bindingsRef === cfg.bindings &&
+    existing.agentsRef === cfg.agents &&
+    existing.sessionRef === cfg.session
+  ) {
+    return existing.byKey;
+  }
+  const byKey = new Map<string, ResolvedAgentRoute>();
+  resolvedRouteCacheByCfg.set(cfg, {
+    bindingsRef: cfg.bindings,
+    agentsRef: cfg.agents,
+    sessionRef: cfg.session,
+    byKey,
+  });
+  return byKey;
+}
+
+function formatRouteCachePeer(peer: RoutePeer | null): string {
+  if (!peer || !peer.id) {
+    return "-";
+  }
+  return `${peer.kind}:${peer.id}`;
+}
+
 function hasGuildConstraint(match: NormalizedBindingMatch): boolean {
   return Boolean(match.guildId);
 }
@@ -474,12 +511,39 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const teamId = normalizeId(input.teamId);
   const memberRoleIds = input.memberRoleIds ?? [];
   const memberRoleIdSet = new Set(memberRoleIds);
+  const dmScope = input.cfg.session?.dmScope ?? "main";
+  const identityLinks = input.cfg.session?.identityLinks;
+  const shouldLogDebug = shouldLogVerbose();
+  const parentPeer = input.parentPeer
+    ? {
+        kind: normalizeChatType(input.parentPeer.kind) ?? input.parentPeer.kind,
+        id: normalizeId(input.parentPeer.id),
+      }
+    : null;
+
+  const routeCache =
+    !shouldLogDebug && !identityLinks ? resolveRouteCacheForConfig(input.cfg) : null;
+  const routeCacheKey = routeCache
+    ? [
+        channel,
+        accountId,
+        formatRouteCachePeer(peer),
+        formatRouteCachePeer(parentPeer),
+        guildId || "-",
+        teamId || "-",
+        memberRoleIds.length > 0 ? memberRoleIds.toSorted().join(",") : "-",
+        dmScope,
+      ].join("\t")
+    : "";
+  if (routeCache && routeCacheKey) {
+    const cachedRoute = routeCache.get(routeCacheKey);
+    if (cachedRoute) {
+      return { ...cachedRoute };
+    }
+  }
 
   const bindings = getEvaluatedBindingsForChannelAccount(input.cfg, channel, accountId);
   const bindingsIndex = getEvaluatedBindingIndexForChannelAccount(input.cfg, channel, accountId);
-
-  const dmScope = input.cfg.session?.dmScope ?? "main";
-  const identityLinks = input.cfg.session?.identityLinks;
 
   const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {
     const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
@@ -495,7 +559,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       agentId: resolvedAgentId,
       mainKey: DEFAULT_MAIN_KEY,
     }).toLowerCase();
-    return {
+    const route = {
       agentId: resolvedAgentId,
       channel,
       accountId,
@@ -503,9 +567,16 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       mainSessionKey,
       matchedBy,
     };
+    if (routeCache && routeCacheKey) {
+      routeCache.set(routeCacheKey, route);
+      if (routeCache.size > MAX_RESOLVED_ROUTE_CACHE_KEYS) {
+        routeCache.clear();
+        routeCache.set(routeCacheKey, route);
+      }
+    }
+    return route;
   };
 
-  const shouldLogDebug = shouldLogVerbose();
   const formatPeer = (value?: RoutePeer | null) =>
     value?.kind && value?.id ? `${value.kind}:${value.id}` : "none";
   const formatNormalizedPeer = (value: NormalizedPeerConstraint) => {
@@ -529,12 +600,6 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     }
   }
   // Thread parent inheritance: if peer (thread) didn't match, check parent peer binding
-  const parentPeer = input.parentPeer
-    ? {
-        kind: normalizeChatType(input.parentPeer.kind) ?? input.parentPeer.kind,
-        id: normalizeId(input.parentPeer.id),
-      }
-    : null;
   const baseScope = {
     guildId,
     teamId,

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -205,11 +205,11 @@ type EvaluatedBindingsCache = {
 const evaluatedBindingsCacheByCfg = new WeakMap<RemoteClawConfig, EvaluatedBindingsCache>();
 const MAX_EVALUATED_BINDINGS_CACHE_KEYS = 2000;
 const resolvedRouteCacheByCfg = new WeakMap<
-  OpenClawConfig,
+  RemoteClawConfig,
   {
-    bindingsRef: OpenClawConfig["bindings"];
-    agentsRef: OpenClawConfig["agents"];
-    sessionRef: OpenClawConfig["session"];
+    bindingsRef: RemoteClawConfig["bindings"];
+    agentsRef: RemoteClawConfig["agents"];
+    sessionRef: RemoteClawConfig["session"];
     byKey: Map<string, ResolvedAgentRoute>;
   }
 >();
@@ -421,7 +421,7 @@ function normalizeBindingMatch(
   };
 }
 
-function resolveRouteCacheForConfig(cfg: OpenClawConfig): Map<string, ResolvedAgentRoute> {
+function resolveRouteCacheForConfig(cfg: RemoteClawConfig): Map<string, ResolvedAgentRoute> {
   const existing = resolvedRouteCacheByCfg.get(cfg);
   if (
     existing &&

--- a/src/shared/node-resolve.ts
+++ b/src/shared/node-resolve.ts
@@ -1,0 +1,33 @@
+import { type NodeMatchCandidate, resolveNodeIdFromCandidates } from "./node-match.js";
+
+type ResolveNodeFromListOptions<TNode extends NodeMatchCandidate> = {
+  allowDefault?: boolean;
+  pickDefaultNode?: (nodes: TNode[]) => TNode | null;
+};
+
+export function resolveNodeIdFromNodeList<TNode extends NodeMatchCandidate>(
+  nodes: TNode[],
+  query?: string,
+  options: ResolveNodeFromListOptions<TNode> = {},
+): string {
+  const q = String(query ?? "").trim();
+  if (!q) {
+    if (options.allowDefault === true && options.pickDefaultNode) {
+      const picked = options.pickDefaultNode(nodes);
+      if (picked) {
+        return picked.nodeId;
+      }
+    }
+    throw new Error("node required");
+  }
+  return resolveNodeIdFromCandidates(nodes, q);
+}
+
+export function resolveNodeFromNodeList<TNode extends NodeMatchCandidate>(
+  nodes: TNode[],
+  query?: string,
+  options: ResolveNodeFromListOptions<TNode> = {},
+): TNode {
+  const nodeId = resolveNodeIdFromNodeList(nodes, query, options);
+  return nodes.find((node) => node.nodeId === nodeId) ?? ({ nodeId } as TNode);
+}

--- a/src/test-utils/camera-url-test-helpers.ts
+++ b/src/test-utils/camera-url-test-helpers.ts
@@ -1,0 +1,21 @@
+import * as fs from "node:fs/promises";
+import { vi } from "vitest";
+
+export function stubFetchResponse(response: Response) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => response),
+  );
+}
+
+export function stubFetchTextResponse(text: string, init?: ResponseInit) {
+  stubFetchResponse(new Response(text, { status: 200, ...init }));
+}
+
+export async function readFileUtf8AndCleanup(filePath: string): Promise<string> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } finally {
+    await fs.unlink(filePath).catch(() => {});
+  }
+}

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -96,6 +96,15 @@ export function parseInlineDirectives(
       hasReplyTag: false,
     };
   }
+  if (!text.includes("[[")) {
+    return {
+      text: normalizeDirectiveWhitespace(text),
+      audioAsVoice: false,
+      replyToCurrent: false,
+      hasAudioTag: false,
+      hasReplyTag: false,
+    };
+  }
 
   let cleaned = text;
   let audioAsVoice = false;


### PR DESCRIPTION
## Cherry-picks from upstream (issue #773)

See issue #773 for full commit list and triage details.

**Commits (5)**:
- `ba5ae5b4f` perf(routing): cache route and mention regex resolution
- `bb60687b8` refactor(nodes): dedupe camera payload and node resolve helpers
- `d3dc4e54f` perf(runtime): trim hot-path allocations and cache channel plugin lookups
- `1d0a4d1be` refactor(runtime): harden channel-registry cache invalidation and split outbound
- `6bf84ac28` perf(runtime): reduce hot-path config and routing overhead

**Conflict resolution**: `bb60687b8` had 2 hunks in `src/cli/nodes-camera.test.ts` — fork rebrand (remoteclaw) preserved + upstream semantic change (readFileUtf8AndCleanup) applied.

Closes #773