### PR TITLE
Cherry-pick issue #777: cherry-pick-misc-fixes-ci-typing-regress

### DIFF
--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -129,6 +129,11 @@ function createMockRuntime(): PluginRuntime {
         vi.fn() as unknown as PluginRuntime["tools"]["createMemorySearchTool"],
       registerMemoryCli: vi.fn() as unknown as PluginRuntime["tools"]["registerMemoryCli"],
     },
+    events: {
+      onAgentEvent: vi.fn() as unknown as PluginRuntime["events"]["onAgentEvent"],
+      onSessionTranscriptUpdate:
+        vi.fn() as unknown as PluginRuntime["events"]["onSessionTranscriptUpdate"],
+    },
     channel: {
       text: {
         chunkMarkdownText:

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../logging/subsystem.js";
 import { createEmptyPluginRegistry, type PluginRegistry } from "../plugins/registry.js";
 import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
+import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createChannelManager } from "./server-channels.js";
@@ -87,7 +88,7 @@ function installTestRegistry(plugin: ChannelPlugin<TestAccount>) {
   setActivePluginRegistry(registry);
 }
 
-function createManager() {
+function createManager(options?: { channelRuntime?: PluginRuntime["channel"] }) {
   const log = createSubsystemLogger("gateway/server-channels-test");
   const channelLogs = { discord: log } as Record<ChannelId, SubsystemLogger>;
   const runtime = runtimeForLogger(log);
@@ -96,6 +97,7 @@ function createManager() {
     loadConfig: () => ({}),
     channelLogs,
     channelRuntimeEnvs,
+    ...(options?.channelRuntime ? { channelRuntime: options.channelRuntime } : {}),
   });
 }
 
@@ -164,5 +166,18 @@ describe("server-channels auto restart", () => {
     const account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
     expect(account?.enabled).toBe(true);
     expect(account?.configured).toBe(true);
+  });
+
+  it("passes channelRuntime through channel gateway context when provided", async () => {
+    const channelRuntime = { marker: "channel-runtime" } as unknown as PluginRuntime["channel"];
+    const startAccount = vi.fn(async (ctx) => {
+      expect(ctx.channelRuntime).toBe(channelRuntime);
+    });
+
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager({ channelRuntime });
+
+    await manager.startChannels();
+    expect(startAccount).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { onAgentEvent } from "../../infra/agent-events.js";
+import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 
 const runCommandWithTimeoutMock = vi.hoisted(() => vi.fn());
 
@@ -38,5 +40,11 @@ describe("plugin runtime command execution", () => {
       runtime.system.runCommandWithTimeout(["echo", "hello"], { timeoutMs: 1000 }),
     ).rejects.toThrow("boom");
     expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(["echo", "hello"], { timeoutMs: 1000 });
+  });
+
+  it("exposes runtime.events listener registration helpers", () => {
+    const runtime = createPluginRuntime();
+    expect(runtime.events.onAgentEvent).toBe(onAgentEvent);
+    expect(runtime.events.onSessionTranscriptUpdate).toBe(onSessionTranscriptUpdate);
   });
 });

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -137,6 +137,7 @@ import {
 } from "../../web/auth-store.js";
 import { loadWebMedia } from "../../web/media.js";
 import { formatNativeDependencyHint } from "./native-deps.js";
+import { createRuntimeEvents } from "./runtime-events.js";
 import type { PluginRuntime } from "./types.js";
 
 let cachedVersion: string | null = null;
@@ -246,6 +247,7 @@ export function createPluginRuntime(): PluginRuntime {
       transcribeAudioFile: async () => ({ text: undefined }),
     },
     tools: createRuntimeTools(),
+    events: createRuntimeEvents(),
     channel: createRuntimeChannel(),
     logging: createRuntimeLogging(),
     state: { resolveStateDir },

--- a/src/plugins/runtime/runtime-events.ts
+++ b/src/plugins/runtime/runtime-events.ts
@@ -1,0 +1,10 @@
+import { onAgentEvent } from "../../infra/agent-events.js";
+import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import type { PluginRuntime } from "./types.js";
+
+export function createRuntimeEvents(): PluginRuntime["events"] {
+  return {
+    onAgentEvent,
+    onSessionTranscriptUpdate,
+  };
+}

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -213,6 +213,10 @@ export type PluginRuntime = {
     transcribeAudioFile: TranscribeAudioFile;
   };
   tools: Record<string, never>;
+  events: {
+    onAgentEvent: typeof import("../../infra/agent-events.js").onAgentEvent;
+    onSessionTranscriptUpdate: typeof import("../../sessions/transcript-events.js").onSessionTranscriptUpdate;
+  };
   channel: {
     text: {
       chunkByNewline: ChunkByNewline;

--- a/src/security/dm-policy-shared.test.ts
+++ b/src/security/dm-policy-shared.test.ts
@@ -302,8 +302,12 @@ describe("security/dm-policy-shared", () => {
     expectedReactionAllowed: boolean;
   };
 
-  function createParityCase(overrides: Partial<ParityCase> & Pick<ParityCase, "name">): ParityCase {
+  function createParityCase({
+    name,
+    ...overrides
+  }: Partial<ParityCase> & Pick<ParityCase, "name">): ParityCase {
     return {
+      name,
       isGroup: false,
       dmPolicy: "open",
       groupPolicy: "allowlist",

--- a/src/sessions/transcript-events.test.ts
+++ b/src/sessions/transcript-events.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { emitSessionTranscriptUpdate, onSessionTranscriptUpdate } from "./transcript-events.js";
+
+const cleanup: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanup.length > 0) {
+    cleanup.pop()?.();
+  }
+});
+
+describe("transcript events", () => {
+  it("emits trimmed session file updates", () => {
+    const listener = vi.fn();
+    cleanup.push(onSessionTranscriptUpdate(listener));
+
+    emitSessionTranscriptUpdate("  /tmp/session.jsonl  ");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ sessionFile: "/tmp/session.jsonl" });
+  });
+
+  it("continues notifying other listeners when one throws", () => {
+    const first = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const second = vi.fn();
+    cleanup.push(onSessionTranscriptUpdate(first));
+    cleanup.push(onSessionTranscriptUpdate(second));
+
+    expect(() => emitSessionTranscriptUpdate("/tmp/session.jsonl")).not.toThrow();
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/sessions/transcript-events.ts
+++ b/src/sessions/transcript-events.ts
@@ -19,11 +19,11 @@ export function emitSessionTranscriptUpdate(sessionFile: string): void {
     return;
   }
   const update = { sessionFile: trimmed };
-	for (const listener of SESSION_TRANSCRIPT_LISTENERS) {
-		try {
-			listener(update);
-		} catch {
-			/* ignore */
-		}
-	}
+  for (const listener of SESSION_TRANSCRIPT_LISTENERS) {
+    try {
+      listener(update);
+    } catch {
+      /* ignore */
+    }
+  }
 }

--- a/src/sessions/transcript-events.ts
+++ b/src/sessions/transcript-events.ts
@@ -19,7 +19,11 @@ export function emitSessionTranscriptUpdate(sessionFile: string): void {
     return;
   }
   const update = { sessionFile: trimmed };
-  for (const listener of SESSION_TRANSCRIPT_LISTENERS) {
-    listener(update);
-  }
+	for (const listener of SESSION_TRANSCRIPT_LISTENERS) {
+		try {
+			listener(update);
+		} catch {
+			/* ignore */
+		}
+	}
 }

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -2,11 +2,6 @@ import DOMPurify from "dompurify";
 import { marked } from "marked";
 import { truncateText } from "./format.ts";
 
-marked.setOptions({
-  gfm: true,
-  breaks: true,
-});
-
 const allowedTags = [
   "a",
   "b",


### PR DESCRIPTION
## Cherry-picks from upstream (issue #777)

See issue for full commit list and triage details.

### Picked (6 commits)
- `e93051715` fix(ci): resolve docs lint and test typing regressions (PARTIAL — kept dm-policy-shared.test.ts)
- `3e4dd8451` fix: webchat gfm table rendering and overflow
- `1ca69c8fd` fix: add channelRuntime regression coverage
- `2aab6dff7` fix: wrap transcript event listeners in try/catch
- `b91a22a3f` style: fix indentation in transcript-events
- `ee646dae8` fix: add runtime.events regression tests

### Skipped (10 commits — all changes in gutted layers or CHANGELOG-only)
- `f3e6578e6` fix(test): tighten websocket and runner fixture typing — both files gutted
- `503d39578` fix(memoryFlush): guard transcript-size forced flush — memory-flush module gutted
- `ddd71bc9f` fix: guard gemini schema null properties — schema tests gutted
- `61adcea68` fix(test): tighten tool result typing in context pruning — pi-extensions gutted
- `85f01cd9e` Fix styles — empty (already covered by prior commits)
- `bd8c3230e` fix: force supportsDeveloperRole=false — model-compat gutted
- `fd782d811` fix: preserve idle reset timestamp — CHANGELOG-only
- `7dadd5027` fix: enforce node v22.12+ preflight — CHANGELOG-only
- `f77f1d380` fix: preserve inline code copy fidelity — CHANGELOG-only
- `d3c637d19` fix: recover host edit success — CHANGELOG-only