### PR TITLE
Cherry-pick issue #780: hooks, gateway fixes, and install dedup

### DIFF
--- a/src/auto-reply/reply/session-hooks-context.test.ts
+++ b/src/auto-reply/reply/session-hooks-context.test.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import type { HookRunner } from "../../plugins/hooks.js";
+
+const hookRunnerMocks = vi.hoisted(() => ({
+  hasHooks: vi.fn<HookRunner["hasHooks"]>(),
+  runSessionStart: vi.fn<HookRunner["runSessionStart"]>(),
+  runSessionEnd: vi.fn<HookRunner["runSessionEnd"]>(),
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () =>
+    ({
+      hasHooks: hookRunnerMocks.hasHooks,
+      runSessionStart: hookRunnerMocks.runSessionStart,
+      runSessionEnd: hookRunnerMocks.runSessionEnd,
+    }) as unknown as HookRunner,
+}));
+
+const { initSessionState } = await import("./session.js");
+
+async function createStorePath(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), `${prefix}-`));
+  return path.join(root, "sessions.json");
+}
+
+async function writeStore(
+  storePath: string,
+  store: Record<string, SessionEntry | Record<string, unknown>>,
+): Promise<void> {
+  await fs.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.writeFile(storePath, JSON.stringify(store), "utf-8");
+}
+
+describe("session hook context wiring", () => {
+  beforeEach(() => {
+    hookRunnerMocks.hasHooks.mockReset();
+    hookRunnerMocks.runSessionStart.mockReset();
+    hookRunnerMocks.runSessionEnd.mockReset();
+    hookRunnerMocks.runSessionStart.mockResolvedValue(undefined);
+    hookRunnerMocks.runSessionEnd.mockResolvedValue(undefined);
+    hookRunnerMocks.hasHooks.mockImplementation(
+      (hookName) => hookName === "session_start" || hookName === "session_end",
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes sessionKey to session_start hook context", async () => {
+    const sessionKey = "agent:main:telegram:direct:123";
+    const storePath = await createStorePath("openclaw-session-hook-start");
+    await writeStore(storePath, {});
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    await initSessionState({
+      ctx: { Body: "hello", SessionKey: sessionKey },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    await vi.waitFor(() => expect(hookRunnerMocks.runSessionStart).toHaveBeenCalledTimes(1));
+    const [event, context] = hookRunnerMocks.runSessionStart.mock.calls[0] ?? [];
+    expect(event).toMatchObject({ sessionKey });
+    expect(context).toMatchObject({ sessionKey });
+  });
+
+  it("passes sessionKey to session_end hook context on reset", async () => {
+    const sessionKey = "agent:main:telegram:direct:123";
+    const storePath = await createStorePath("openclaw-session-hook-end");
+    await writeStore(storePath, {
+      [sessionKey]: {
+        sessionId: "old-session",
+        updatedAt: Date.now(),
+      },
+    });
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    await initSessionState({
+      ctx: { Body: "/new", SessionKey: sessionKey },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    await vi.waitFor(() => expect(hookRunnerMocks.runSessionEnd).toHaveBeenCalledTimes(1));
+    const [event, context] = hookRunnerMocks.runSessionEnd.mock.calls[0] ?? [];
+    expect(event).toMatchObject({ sessionKey });
+    expect(context).toMatchObject({ sessionKey });
+  });
+});

--- a/src/auto-reply/reply/session-hooks-context.test.ts
+++ b/src/auto-reply/reply/session-hooks-context.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../../config/config.js";
+import type { RemoteClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { HookRunner } from "../../plugins/hooks.js";
 
@@ -56,7 +56,7 @@ describe("session hook context wiring", () => {
     const sessionKey = "agent:main:telegram:direct:123";
     const storePath = await createStorePath("openclaw-session-hook-start");
     await writeStore(storePath, {});
-    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const cfg = { session: { store: storePath } } as RemoteClawConfig;
 
     await initSessionState({
       ctx: { Body: "hello", SessionKey: sessionKey },
@@ -79,7 +79,7 @@ describe("session hook context wiring", () => {
         updatedAt: Date.now(),
       },
     });
-    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const cfg = { session: { store: storePath } } as RemoteClawConfig;
 
     await initSessionState({
       ctx: { Body: "/new", SessionKey: sessionKey },

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -201,6 +201,7 @@ describe("channel-health-monitor", () => {
   });
 
   it("restarts a stuck channel (running but not connected)", async () => {
+    const now = Date.now();
     const manager = createSnapshotManager({
       whatsapp: {
         default: {
@@ -209,6 +210,7 @@ describe("channel-health-monitor", () => {
           enabled: true,
           configured: true,
           linked: true,
+          lastStartAt: now - 300_000,
         },
       },
     });
@@ -216,6 +218,41 @@ describe("channel-health-monitor", () => {
     expect(manager.stopChannel).toHaveBeenCalledWith("whatsapp", "default");
     expect(manager.resetRestartAttempts).toHaveBeenCalledWith("whatsapp", "default");
     expect(manager.startChannel).toHaveBeenCalledWith("whatsapp", "default");
+    monitor.stop();
+  });
+
+  it("skips recently-started channels while they are still connecting", async () => {
+    const now = Date.now();
+    const manager = createSnapshotManager({
+      discord: {
+        default: {
+          running: true,
+          connected: false,
+          enabled: true,
+          configured: true,
+          lastStartAt: now - 5_000,
+        },
+      },
+    });
+    await expectNoRestart(manager);
+  });
+
+  it("respects custom per-channel startup grace", async () => {
+    const now = Date.now();
+    const manager = createSnapshotManager({
+      discord: {
+        default: {
+          running: true,
+          connected: false,
+          enabled: true,
+          configured: true,
+          lastStartAt: now - 30_000,
+        },
+      },
+    });
+    const monitor = await startAndRunCheck(manager, { channelStartupGraceMs: 60_000 });
+    expect(manager.stopChannel).not.toHaveBeenCalled();
+    expect(manager.startChannel).not.toHaveBeenCalled();
     monitor.stop();
   });
 

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -65,7 +65,7 @@ async function startAndRunCheck(
   overrides: Partial<Omit<Parameters<typeof startChannelHealthMonitor>[0], "channelManager">> = {},
 ) {
   const monitor = startDefaultMonitor(manager, overrides);
-  const startupGraceMs = overrides.startupGraceMs ?? 0;
+  const startupGraceMs = overrides.timing?.monitorStartupGraceMs ?? overrides.startupGraceMs ?? 0;
   const checkIntervalMs = overrides.checkIntervalMs ?? DEFAULT_CHECK_INTERVAL_MS;
   await vi.advanceTimersByTimeAsync(startupGraceMs + checkIntervalMs + 1);
   return monitor;
@@ -150,6 +150,14 @@ describe("channel-health-monitor", () => {
     const manager = createMockChannelManager();
     const monitor = await startAndRunCheck(manager, { startupGraceMs: 1_000 });
     expect(manager.getRuntimeSnapshot).toHaveBeenCalled();
+    monitor.stop();
+  });
+
+  it("accepts timing.monitorStartupGraceMs", async () => {
+    const manager = createMockChannelManager();
+    const monitor = startDefaultMonitor(manager, { timing: { monitorStartupGraceMs: 60_000 } });
+    await vi.advanceTimersByTimeAsync(5_001);
+    expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
     monitor.stop();
   });
 

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -10,12 +10,23 @@ const DEFAULT_COOLDOWN_CYCLES = 2;
 const DEFAULT_MAX_RESTARTS_PER_HOUR = 10;
 const ONE_HOUR_MS = 60 * 60_000;
 
+/**
+ * How long a connected channel can go without receiving any event before
+ * the health monitor treats it as a "stale socket" and triggers a restart.
+ * This catches the half-dead WebSocket scenario where the connection appears
+ * alive (health checks pass) but Slack silently stops delivering events.
+ */
+const DEFAULT_STALE_EVENT_THRESHOLD_MS = 30 * 60_000;
+const DEFAULT_CHANNEL_STARTUP_GRACE_MS = 120_000;
+
 export type ChannelHealthMonitorDeps = {
   channelManager: ChannelManager;
   checkIntervalMs?: number;
   startupGraceMs?: number;
   cooldownCycles?: number;
   maxRestartsPerHour?: number;
+  staleEventThresholdMs?: number;
+  channelStartupGraceMs?: number;
   abortSignal?: AbortSignal;
 };
 
@@ -32,17 +43,28 @@ function isManagedAccount(snapshot: { enabled?: boolean; configured?: boolean })
   return snapshot.enabled !== false && snapshot.configured !== false;
 }
 
-function isChannelHealthy(snapshot: {
-  running?: boolean;
-  connected?: boolean;
-  enabled?: boolean;
-  configured?: boolean;
-}): boolean {
+function isChannelHealthy(
+  snapshot: {
+    running?: boolean;
+    connected?: boolean;
+    enabled?: boolean;
+    configured?: boolean;
+    lastEventAt?: number | null;
+    lastStartAt?: number | null;
+  },
+  opts: { now: number; staleEventThresholdMs: number; channelStartupGraceMs: number },
+): boolean {
   if (!isManagedAccount(snapshot)) {
     return true;
   }
   if (!snapshot.running) {
     return false;
+  }
+  if (snapshot.lastStartAt != null) {
+    const upDuration = opts.now - snapshot.lastStartAt;
+    if (upDuration < opts.channelStartupGraceMs) {
+      return true;
+    }
   }
   if (snapshot.connected === false) {
     return false;
@@ -57,6 +79,8 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
     startupGraceMs = DEFAULT_STARTUP_GRACE_MS,
     cooldownCycles = DEFAULT_COOLDOWN_CYCLES,
     maxRestartsPerHour = DEFAULT_MAX_RESTARTS_PER_HOUR,
+    staleEventThresholdMs = DEFAULT_STALE_EVENT_THRESHOLD_MS,
+    channelStartupGraceMs = DEFAULT_CHANNEL_STARTUP_GRACE_MS,
     abortSignal,
   } = deps;
 
@@ -101,7 +125,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           if (channelManager.isManuallyStopped(channelId as ChannelId, accountId)) {
             continue;
           }
-          if (isChannelHealthy(status)) {
+          if (isChannelHealthy(status, { now, staleEventThresholdMs, channelStartupGraceMs })) {
             continue;
           }
 

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -1,11 +1,16 @@
 import type { ChannelId } from "../channels/plugins/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  evaluateChannelHealth,
+  resolveChannelRestartReason,
+  type ChannelHealthPolicy,
+} from "./channel-health-policy.js";
 import type { ChannelManager } from "./server-channels.js";
 
 const log = createSubsystemLogger("gateway/health-monitor");
 
 const DEFAULT_CHECK_INTERVAL_MS = 5 * 60_000;
-const DEFAULT_STARTUP_GRACE_MS = 60_000;
+const DEFAULT_MONITOR_STARTUP_GRACE_MS = 60_000;
 const DEFAULT_COOLDOWN_CYCLES = 2;
 const DEFAULT_MAX_RESTARTS_PER_HOUR = 10;
 const ONE_HOUR_MS = 60 * 60_000;
@@ -17,16 +22,26 @@ const ONE_HOUR_MS = 60 * 60_000;
  * alive (health checks pass) but Slack silently stops delivering events.
  */
 const DEFAULT_STALE_EVENT_THRESHOLD_MS = 30 * 60_000;
-const DEFAULT_CHANNEL_STARTUP_GRACE_MS = 120_000;
+const DEFAULT_CHANNEL_CONNECT_GRACE_MS = 120_000;
+
+export type ChannelHealthTimingPolicy = {
+  monitorStartupGraceMs: number;
+  channelConnectGraceMs: number;
+  staleEventThresholdMs: number;
+};
 
 export type ChannelHealthMonitorDeps = {
   channelManager: ChannelManager;
   checkIntervalMs?: number;
+  /** @deprecated use timing.monitorStartupGraceMs */
   startupGraceMs?: number;
+  /** @deprecated use timing.channelConnectGraceMs */
+  channelStartupGraceMs?: number;
+  /** @deprecated use timing.staleEventThresholdMs */
+  staleEventThresholdMs?: number;
+  timing?: Partial<ChannelHealthTimingPolicy>;
   cooldownCycles?: number;
   maxRestartsPerHour?: number;
-  staleEventThresholdMs?: number;
-  channelStartupGraceMs?: number;
   abortSignal?: AbortSignal;
 };
 
@@ -39,50 +54,35 @@ type RestartRecord = {
   restartsThisHour: { at: number }[];
 };
 
-function isManagedAccount(snapshot: { enabled?: boolean; configured?: boolean }): boolean {
-  return snapshot.enabled !== false && snapshot.configured !== false;
-}
-
-function isChannelHealthy(
-  snapshot: {
-    running?: boolean;
-    connected?: boolean;
-    enabled?: boolean;
-    configured?: boolean;
-    lastEventAt?: number | null;
-    lastStartAt?: number | null;
-  },
-  opts: { now: number; staleEventThresholdMs: number; channelStartupGraceMs: number },
-): boolean {
-  if (!isManagedAccount(snapshot)) {
-    return true;
-  }
-  if (!snapshot.running) {
-    return false;
-  }
-  if (snapshot.lastStartAt != null) {
-    const upDuration = opts.now - snapshot.lastStartAt;
-    if (upDuration < opts.channelStartupGraceMs) {
-      return true;
-    }
-  }
-  if (snapshot.connected === false) {
-    return false;
-  }
-  return true;
+function resolveTimingPolicy(
+  deps: Pick<
+    ChannelHealthMonitorDeps,
+    "startupGraceMs" | "channelStartupGraceMs" | "staleEventThresholdMs" | "timing"
+  >,
+): ChannelHealthTimingPolicy {
+  return {
+    monitorStartupGraceMs:
+      deps.timing?.monitorStartupGraceMs ?? deps.startupGraceMs ?? DEFAULT_MONITOR_STARTUP_GRACE_MS,
+    channelConnectGraceMs:
+      deps.timing?.channelConnectGraceMs ??
+      deps.channelStartupGraceMs ??
+      DEFAULT_CHANNEL_CONNECT_GRACE_MS,
+    staleEventThresholdMs:
+      deps.timing?.staleEventThresholdMs ??
+      deps.staleEventThresholdMs ??
+      DEFAULT_STALE_EVENT_THRESHOLD_MS,
+  };
 }
 
 export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): ChannelHealthMonitor {
   const {
     channelManager,
     checkIntervalMs = DEFAULT_CHECK_INTERVAL_MS,
-    startupGraceMs = DEFAULT_STARTUP_GRACE_MS,
     cooldownCycles = DEFAULT_COOLDOWN_CYCLES,
     maxRestartsPerHour = DEFAULT_MAX_RESTARTS_PER_HOUR,
-    staleEventThresholdMs = DEFAULT_STALE_EVENT_THRESHOLD_MS,
-    channelStartupGraceMs = DEFAULT_CHANNEL_STARTUP_GRACE_MS,
     abortSignal,
   } = deps;
+  const timing = resolveTimingPolicy(deps);
 
   const cooldownMs = cooldownCycles * checkIntervalMs;
   const restartRecords = new Map<string, RestartRecord>();
@@ -105,7 +105,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
 
     try {
       const now = Date.now();
-      if (now - startedAt < startupGraceMs) {
+      if (now - startedAt < timing.monitorStartupGraceMs) {
         return;
       }
 
@@ -119,13 +119,16 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           if (!status) {
             continue;
           }
-          if (!isManagedAccount(status)) {
-            continue;
-          }
           if (channelManager.isManuallyStopped(channelId as ChannelId, accountId)) {
             continue;
           }
-          if (isChannelHealthy(status, { now, staleEventThresholdMs, channelStartupGraceMs })) {
+          const healthPolicy: ChannelHealthPolicy = {
+            now,
+            staleEventThresholdMs: timing.staleEventThresholdMs,
+            channelConnectGraceMs: timing.channelConnectGraceMs,
+          };
+          const health = evaluateChannelHealth(status, healthPolicy);
+          if (health.healthy) {
             continue;
           }
 
@@ -147,11 +150,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             continue;
           }
 
-          const reason = !status.running
-            ? status.reconnectAttempts && status.reconnectAttempts >= 10
-              ? "gave-up"
-              : "stopped"
-            : "stuck";
+          const reason = resolveChannelRestartReason(status, health);
 
           log.info?.(`[${channelId}:${accountId}] health-monitor: restarting (reason: ${reason})`);
 
@@ -193,7 +192,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
       timer.unref();
     }
     log.info?.(
-      `started (interval: ${Math.round(checkIntervalMs / 1000)}s, grace: ${Math.round(startupGraceMs / 1000)}s)`,
+      `started (interval: ${Math.round(checkIntervalMs / 1000)}s, startup-grace: ${Math.round(timing.monitorStartupGraceMs / 1000)}s, channel-connect-grace: ${Math.round(timing.channelConnectGraceMs / 1000)}s)`,
     );
   }
 

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { evaluateChannelHealth, resolveChannelRestartReason } from "./channel-health-policy.js";
+
+describe("evaluateChannelHealth", () => {
+  it("treats disabled accounts as healthy unmanaged", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: false,
+        enabled: false,
+        configured: true,
+      },
+      {
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "unmanaged" });
+  });
+
+  it("uses channel connect grace before flagging disconnected", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: false,
+        enabled: true,
+        configured: true,
+        lastStartAt: 95_000,
+      },
+      {
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "startup-connect-grace" });
+  });
+
+  it("flags stale sockets when no events arrive beyond threshold", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastEventAt: null,
+      },
+      {
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
+  });
+});
+
+describe("resolveChannelRestartReason", () => {
+  it("maps not-running + high reconnect attempts to gave-up", () => {
+    const reason = resolveChannelRestartReason(
+      {
+        running: false,
+        reconnectAttempts: 10,
+      },
+      { healthy: false, reason: "not-running" },
+    );
+    expect(reason).toBe("gave-up");
+  });
+});

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -1,0 +1,80 @@
+export type ChannelHealthSnapshot = {
+  running?: boolean;
+  connected?: boolean;
+  enabled?: boolean;
+  configured?: boolean;
+  lastEventAt?: number | null;
+  lastStartAt?: number | null;
+  reconnectAttempts?: number;
+};
+
+export type ChannelHealthEvaluationReason =
+  | "healthy"
+  | "unmanaged"
+  | "not-running"
+  | "startup-connect-grace"
+  | "disconnected"
+  | "stale-socket";
+
+export type ChannelHealthEvaluation = {
+  healthy: boolean;
+  reason: ChannelHealthEvaluationReason;
+};
+
+export type ChannelHealthPolicy = {
+  now: number;
+  staleEventThresholdMs: number;
+  channelConnectGraceMs: number;
+};
+
+export type ChannelRestartReason = "gave-up" | "stopped" | "stale-socket" | "stuck";
+
+function isManagedAccount(snapshot: ChannelHealthSnapshot): boolean {
+  return snapshot.enabled !== false && snapshot.configured !== false;
+}
+
+export function evaluateChannelHealth(
+  snapshot: ChannelHealthSnapshot,
+  policy: ChannelHealthPolicy,
+): ChannelHealthEvaluation {
+  if (!isManagedAccount(snapshot)) {
+    return { healthy: true, reason: "unmanaged" };
+  }
+  if (!snapshot.running) {
+    return { healthy: false, reason: "not-running" };
+  }
+  if (snapshot.lastStartAt != null) {
+    const upDuration = policy.now - snapshot.lastStartAt;
+    if (upDuration < policy.channelConnectGraceMs) {
+      return { healthy: true, reason: "startup-connect-grace" };
+    }
+  }
+  if (snapshot.connected === false) {
+    return { healthy: false, reason: "disconnected" };
+  }
+  if (snapshot.lastEventAt != null || snapshot.lastStartAt != null) {
+    const upSince = snapshot.lastStartAt ?? 0;
+    const upDuration = policy.now - upSince;
+    if (upDuration > policy.staleEventThresholdMs) {
+      const lastEvent = snapshot.lastEventAt ?? 0;
+      const eventAge = policy.now - lastEvent;
+      if (eventAge > policy.staleEventThresholdMs) {
+        return { healthy: false, reason: "stale-socket" };
+      }
+    }
+  }
+  return { healthy: true, reason: "healthy" };
+}
+
+export function resolveChannelRestartReason(
+  snapshot: ChannelHealthSnapshot,
+  evaluation: ChannelHealthEvaluation,
+): ChannelRestartReason {
+  if (evaluation.reason === "stale-socket") {
+    return "stale-socket";
+  }
+  if (evaluation.reason === "not-running") {
+    return snapshot.reconnectAttempts && snapshot.reconnectAttempts >= 10 ? "gave-up" : "stopped";
+  }
+  return "stuck";
+}

--- a/src/hooks/install.test.ts
+++ b/src/hooks/install.test.ts
@@ -87,6 +87,43 @@ function expectInstallFailureContains(
   }
 }
 
+function writeHookPackManifest(params: {
+  pkgDir: string;
+  hooks: string[];
+  dependencies?: Record<string, string>;
+}) {
+  fs.writeFileSync(
+    path.join(params.pkgDir, "package.json"),
+    JSON.stringify({
+      name: "@remoteclaw/test-hooks",
+      version: "0.0.1",
+      remoteclaw: { hooks: params.hooks },
+      ...(params.dependencies ? { dependencies: params.dependencies } : {}),
+    }),
+    "utf-8",
+  );
+}
+
+async function installArchiveFixture(params: { fileName: string; contents: Buffer }) {
+  const fixture = writeArchiveFixture(params);
+  const result = await installHooksFromArchive({
+    archivePath: fixture.archivePath,
+    hooksDir: fixture.hooksDir,
+  });
+  return { fixture, result };
+}
+
+function expectPathInstallFailureContains(
+  result: Awaited<ReturnType<typeof installHooksFromPath>>,
+  snippet: string,
+) {
+  expect(result.ok).toBe(false);
+  if (result.ok) {
+    throw new Error("expected install failure");
+  }
+  expect(result.error).toContain(snippet);
+}
+
 describe("installHooksFromArchive", () => {
   it.each([
     {
@@ -104,10 +141,9 @@ describe("installHooksFromArchive", () => {
       expectedHook: "tar-hook",
     },
   ])("installs hook packs from $name archives", async (tc) => {
-    const fixture = writeArchiveFixture({ fileName: tc.fileName, contents: tc.contents });
-    const result = await installHooksFromArchive({
-      archivePath: fixture.archivePath,
-      hooksDir: fixture.hooksDir,
+    const { fixture, result } = await installArchiveFixture({
+      fileName: tc.fileName,
+      contents: tc.contents,
     });
 
     expect(result.ok).toBe(true);
@@ -136,10 +172,9 @@ describe("installHooksFromArchive", () => {
       expectedDetail: "escapes destination",
     },
   ])("rejects $name archives with traversal entries", async (tc) => {
-    const fixture = writeArchiveFixture({ fileName: tc.fileName, contents: tc.contents });
-    const result = await installHooksFromArchive({
-      archivePath: fixture.archivePath,
-      hooksDir: fixture.hooksDir,
+    const { result } = await installArchiveFixture({
+      fileName: tc.fileName,
+      contents: tc.contents,
     });
     expectInstallFailureContains(result, ["failed to extract archive", tc.expectedDetail]);
   });
@@ -154,10 +189,9 @@ describe("installHooksFromArchive", () => {
       contents: tarReservedIdBuffer,
     },
   ])("rejects hook packs with $name", async (tc) => {
-    const fixture = writeArchiveFixture({ fileName: "hooks.tar", contents: tc.contents });
-    const result = await installHooksFromArchive({
-      archivePath: fixture.archivePath,
-      hooksDir: fixture.hooksDir,
+    const { result } = await installArchiveFixture({
+      fileName: "hooks.tar",
+      contents: tc.contents,
     });
     expectInstallFailureContains(result, ["reserved path segment"]);
   });
@@ -169,16 +203,11 @@ describe("installHooksFromPath", () => {
     const stateDir = makeTempDir();
     const pkgDir = path.join(workDir, "package");
     fs.mkdirSync(path.join(pkgDir, "hooks", "one-hook"), { recursive: true });
-    fs.writeFileSync(
-      path.join(pkgDir, "package.json"),
-      JSON.stringify({
-        name: "@remoteclaw/test-hooks",
-        version: "0.0.1",
-        remoteclaw: { hooks: ["./hooks/one-hook"] },
-        dependencies: { "left-pad": "1.3.0" },
-      }),
-      "utf-8",
-    );
+    writeHookPackManifest({
+      pkgDir,
+      hooks: ["./hooks/one-hook"],
+      dependencies: { "left-pad": "1.3.0" },
+    });
     fs.writeFileSync(
       path.join(pkgDir, "hooks", "one-hook", "HOOK.md"),
       [
@@ -249,15 +278,10 @@ describe("installHooksFromPath", () => {
     const outsideHookDir = path.join(workDir, "outside");
     fs.mkdirSync(pkgDir, { recursive: true });
     fs.mkdirSync(outsideHookDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(pkgDir, "package.json"),
-      JSON.stringify({
-        name: "@remoteclaw/test-hooks",
-        version: "0.0.1",
-        remoteclaw: { hooks: ["../outside"] },
-      }),
-      "utf-8",
-    );
+    writeHookPackManifest({
+      pkgDir,
+      hooks: ["../outside"],
+    });
     fs.writeFileSync(path.join(outsideHookDir, "HOOK.md"), "---\nname: outside\n---\n", "utf-8");
     fs.writeFileSync(path.join(outsideHookDir, "handler.ts"), "export default async () => {};\n");
 
@@ -266,11 +290,7 @@ describe("installHooksFromPath", () => {
       hooksDir: path.join(stateDir, "hooks"),
     });
 
-    expect(result.ok).toBe(false);
-    if (result.ok) {
-      return;
-    }
-    expect(result.error).toContain("remoteclaw.hooks entry escapes package directory");
+    expectPathInstallFailureContains(result, "remoteclaw.hooks entry escapes package directory");
   });
 
   it("rejects hook pack entries that escape via symlink", async () => {
@@ -288,26 +308,20 @@ describe("installHooksFromPath", () => {
     } catch {
       return;
     }
-    fs.writeFileSync(
-      path.join(pkgDir, "package.json"),
-      JSON.stringify({
-        name: "@remoteclaw/test-hooks",
-        version: "0.0.1",
-        remoteclaw: { hooks: ["./linked"] },
-      }),
-      "utf-8",
-    );
+    writeHookPackManifest({
+      pkgDir,
+      hooks: ["./linked"],
+    });
 
     const result = await installHooksFromPath({
       path: pkgDir,
       hooksDir: path.join(stateDir, "hooks"),
     });
 
-    expect(result.ok).toBe(false);
-    if (result.ok) {
-      return;
-    }
-    expect(result.error).toContain("remoteclaw.hooks entry resolves outside package directory");
+    expectPathInstallFailureContains(
+      result,
+      "remoteclaw.hooks entry resolves outside package directory",
+    );
   });
 });
 

--- a/src/hooks/install.ts
+++ b/src/hooks/install.ts
@@ -60,6 +60,30 @@ export type HookNpmIntegrityDriftParams = {
 
 const defaultLogger: HookInstallLogger = {};
 
+type HookInstallForwardParams = {
+  hooksDir?: string;
+  timeoutMs?: number;
+  logger?: HookInstallLogger;
+  mode?: "install" | "update";
+  dryRun?: boolean;
+  expectedHookPackId?: string;
+};
+
+type HookPackageInstallParams = { packageDir: string } & HookInstallForwardParams;
+type HookArchiveInstallParams = { archivePath: string } & HookInstallForwardParams;
+type HookPathInstallParams = { path: string } & HookInstallForwardParams;
+
+function buildHookInstallForwardParams(params: HookInstallForwardParams): HookInstallForwardParams {
+  return {
+    hooksDir: params.hooksDir,
+    timeoutMs: params.timeoutMs,
+    logger: params.logger,
+    mode: params.mode,
+    dryRun: params.dryRun,
+    expectedHookPackId: params.expectedHookPackId,
+  };
+}
+
 function validateHookId(hookId: string): string | null {
   if (!hookId) {
     return "invalid hook name: missing";
@@ -115,6 +139,54 @@ async function resolveInstallTargetDir(
   });
 }
 
+async function resolveAvailableHookInstallTarget(params: {
+  id: string;
+  hooksDir?: string;
+  mode: "install" | "update";
+  alreadyExistsError: (targetDir: string) => string;
+}): Promise<{ ok: true; targetDir: string } | { ok: false; error: string }> {
+  const targetDirResult = await resolveInstallTargetDir(params.id, params.hooksDir);
+  if (!targetDirResult.ok) {
+    return targetDirResult;
+  }
+  const targetDir = targetDirResult.targetDir;
+  const availability = await ensureInstallTargetAvailable({
+    mode: params.mode,
+    targetDir,
+    alreadyExistsError: params.alreadyExistsError(targetDir),
+  });
+  if (!availability.ok) {
+    return availability;
+  }
+  return { ok: true, targetDir };
+}
+
+async function installFromResolvedHookDir(
+  resolvedDir: string,
+  params: HookInstallForwardParams,
+): Promise<InstallHooksResult> {
+  const manifestPath = path.join(resolvedDir, "package.json");
+  if (await fileExists(manifestPath)) {
+    return await installHookPackageFromDir({
+      packageDir: resolvedDir,
+      hooksDir: params.hooksDir,
+      timeoutMs: params.timeoutMs,
+      logger: params.logger,
+      mode: params.mode,
+      dryRun: params.dryRun,
+      expectedHookPackId: params.expectedHookPackId,
+    });
+  }
+  return await installHookFromDir({
+    hookDir: resolvedDir,
+    hooksDir: params.hooksDir,
+    logger: params.logger,
+    mode: params.mode,
+    dryRun: params.dryRun,
+    expectedHookPackId: params.expectedHookPackId,
+  });
+}
+
 async function resolveHookNameFromDir(hookDir: string): Promise<string> {
   const hookMdPath = path.join(hookDir, "HOOK.md");
   if (!(await fileExists(hookMdPath))) {
@@ -141,15 +213,9 @@ async function validateHookDir(hookDir: string): Promise<void> {
   }
 }
 
-async function installHookPackageFromDir(params: {
-  packageDir: string;
-  hooksDir?: string;
-  timeoutMs?: number;
-  logger?: HookInstallLogger;
-  mode?: "install" | "update";
-  dryRun?: boolean;
-  expectedHookPackId?: string;
-}): Promise<InstallHooksResult> {
+async function installHookPackageFromDir(
+  params: HookPackageInstallParams,
+): Promise<InstallHooksResult> {
   const { logger, timeoutMs, mode, dryRun } = resolveTimedInstallModeOptions(params, defaultLogger);
 
   const manifestPath = path.join(params.packageDir, "package.json");
@@ -184,19 +250,16 @@ async function installHookPackageFromDir(params: {
     };
   }
 
-  const targetDirResult = await resolveInstallTargetDir(hookPackId, params.hooksDir);
-  if (!targetDirResult.ok) {
-    return { ok: false, error: targetDirResult.error };
-  }
-  const targetDir = targetDirResult.targetDir;
-  const availability = await ensureInstallTargetAvailable({
+  const target = await resolveAvailableHookInstallTarget({
+    id: hookPackId,
+    hooksDir: params.hooksDir,
     mode,
-    targetDir,
-    alreadyExistsError: `hook pack already exists: ${targetDir} (delete it first)`,
+    alreadyExistsError: (targetDir) => `hook pack already exists: ${targetDir} (delete it first)`,
   });
-  if (!availability.ok) {
-    return availability;
+  if (!target.ok) {
+    return target;
   }
+  const targetDir = target.targetDir;
 
   const resolvedHooks = [] as string[];
   for (const entry of hookEntries) {
@@ -281,19 +344,16 @@ async function installHookFromDir(params: {
     };
   }
 
-  const targetDirResult = await resolveInstallTargetDir(hookName, params.hooksDir);
-  if (!targetDirResult.ok) {
-    return { ok: false, error: targetDirResult.error };
-  }
-  const targetDir = targetDirResult.targetDir;
-  const availability = await ensureInstallTargetAvailable({
+  const target = await resolveAvailableHookInstallTarget({
+    id: hookName,
+    hooksDir: params.hooksDir,
     mode,
-    targetDir,
-    alreadyExistsError: `hook already exists: ${targetDir} (delete it first)`,
+    alreadyExistsError: (targetDir) => `hook already exists: ${targetDir} (delete it first)`,
   });
-  if (!availability.ok) {
-    return availability;
+  if (!target.ok) {
+    return target;
   }
+  const targetDir = target.targetDir;
 
   if (dryRun) {
     return { ok: true, hookPackId: hookName, hooks: [hookName], targetDir };
@@ -323,15 +383,9 @@ async function installHookFromDir(params: {
   return { ok: true, hookPackId: hookName, hooks: [hookName], targetDir };
 }
 
-export async function installHooksFromArchive(params: {
-  archivePath: string;
-  hooksDir?: string;
-  timeoutMs?: number;
-  logger?: HookInstallLogger;
-  mode?: "install" | "update";
-  dryRun?: boolean;
-  expectedHookPackId?: string;
-}): Promise<InstallHooksResult> {
+export async function installHooksFromArchive(
+  params: HookArchiveInstallParams,
+): Promise<InstallHooksResult> {
   const logger = params.logger ?? defaultLogger;
   const timeoutMs = params.timeoutMs ?? 120_000;
   const archivePathResult = await resolveArchiveSourcePath(params.archivePath);
@@ -345,29 +399,18 @@ export async function installHooksFromArchive(params: {
     tempDirPrefix: "remoteclaw-hook-",
     timeoutMs,
     logger,
-    onExtracted: async (rootDir) => {
-      const manifestPath = path.join(rootDir, "package.json");
-      if (await fileExists(manifestPath)) {
-        return await installHookPackageFromDir({
-          packageDir: rootDir,
+    onExtracted: async (rootDir) =>
+      await installFromResolvedHookDir(
+        rootDir,
+        buildHookInstallForwardParams({
           hooksDir: params.hooksDir,
           timeoutMs,
           logger,
           mode: params.mode,
           dryRun: params.dryRun,
           expectedHookPackId: params.expectedHookPackId,
-        });
-      }
-
-      return await installHookFromDir({
-        hookDir: rootDir,
-        hooksDir: params.hooksDir,
-        logger,
-        mode: params.mode,
-        dryRun: params.dryRun,
-        expectedHookPackId: params.expectedHookPackId,
-      });
-    },
+        }),
+      ),
   });
 }
 
@@ -401,55 +444,37 @@ export async function installHooksFromNpmSpec(params: {
       logger.warn?.(message);
     },
     installFromArchive: installHooksFromArchive,
-    archiveInstallParams: {
+    archiveInstallParams: buildHookInstallForwardParams({
       hooksDir: params.hooksDir,
       timeoutMs,
       logger,
       mode,
       dryRun,
       expectedHookPackId,
-    },
+    }),
   });
   return finalizeNpmSpecArchiveInstall(flowResult);
 }
 
-export async function installHooksFromPath(params: {
-  path: string;
-  hooksDir?: string;
-  timeoutMs?: number;
-  logger?: HookInstallLogger;
-  mode?: "install" | "update";
-  dryRun?: boolean;
-  expectedHookPackId?: string;
-}): Promise<InstallHooksResult> {
+export async function installHooksFromPath(
+  params: HookPathInstallParams,
+): Promise<InstallHooksResult> {
   const pathResult = await resolveExistingInstallPath(params.path);
   if (!pathResult.ok) {
     return pathResult;
   }
   const { resolvedPath: resolved, stat } = pathResult;
+  const forwardParams = buildHookInstallForwardParams({
+    hooksDir: params.hooksDir,
+    timeoutMs: params.timeoutMs,
+    logger: params.logger,
+    mode: params.mode,
+    dryRun: params.dryRun,
+    expectedHookPackId: params.expectedHookPackId,
+  });
 
   if (stat.isDirectory()) {
-    const manifestPath = path.join(resolved, "package.json");
-    if (await fileExists(manifestPath)) {
-      return await installHookPackageFromDir({
-        packageDir: resolved,
-        hooksDir: params.hooksDir,
-        timeoutMs: params.timeoutMs,
-        logger: params.logger,
-        mode: params.mode,
-        dryRun: params.dryRun,
-        expectedHookPackId: params.expectedHookPackId,
-      });
-    }
-
-    return await installHookFromDir({
-      hookDir: resolved,
-      hooksDir: params.hooksDir,
-      logger: params.logger,
-      mode: params.mode,
-      dryRun: params.dryRun,
-      expectedHookPackId: params.expectedHookPackId,
-    });
+    return await installFromResolvedHookDir(resolved, forwardParams);
   }
 
   if (!resolveArchiveKind(resolved)) {
@@ -458,11 +483,6 @@ export async function installHooksFromPath(params: {
 
   return await installHooksFromArchive({
     archivePath: resolved,
-    hooksDir: params.hooksDir,
-    timeoutMs: params.timeoutMs,
-    logger: params.logger,
-    mode: params.mode,
-    dryRun: params.dryRun,
-    expectedHookPackId: params.expectedHookPackId,
+    ...forwardParams,
   });
 }

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -313,6 +313,37 @@ describe("runMessageAction context isolation", () => {
     expect(result.channel).toBe("slack");
   });
 
+  it("falls back to tool-context provider when channel param is an id", async () => {
+    const result = await runDrySend({
+      cfg: slackConfig,
+      actionParams: {
+        channel: "C12345678",
+        target: "#C12345678",
+        message: "hi",
+      },
+      toolContext: { currentChannelId: "C12345678", currentChannelProvider: "slack" },
+    });
+
+    expect(result.kind).toBe("send");
+    expect(result.channel).toBe("slack");
+  });
+
+  it("falls back to tool-context provider for broadcast channel ids", async () => {
+    const result = await runDryAction({
+      cfg: slackConfig,
+      action: "broadcast",
+      actionParams: {
+        targets: ["channel:C12345678"],
+        channel: "C12345678",
+        message: "hi",
+      },
+      toolContext: { currentChannelProvider: "slack" },
+    });
+
+    expect(result.kind).toBe("broadcast");
+    expect(result.channel).toBe("slack");
+  });
+
   it("blocks cross-provider sends by default", async () => {
     await expect(
       runDrySend({

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -16,7 +16,12 @@ import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import type { AgentToolResult } from "../../types/agent-types.js";
-import { type GatewayClientMode, type GatewayClientName } from "../../utils/message-channel.js";
+import {
+  type GatewayClientMode,
+  type GatewayClientName,
+  isDeliverableMessageChannel,
+  normalizeMessageChannel,
+} from "../../utils/message-channel.js";
 import { throwIfAborted } from "./abort.js";
 import {
   listConfiguredMessageChannels,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -208,13 +208,28 @@ async function maybeApplyCrossContextMarker(params: {
   });
 }
 
-async function resolveChannel(cfg: RemoteClawConfig, params: Record<string, unknown>) {
+async function resolveChannel(
+  cfg: RemoteClawConfig,
+  params: Record<string, unknown>,
+  toolContext?: { currentChannelProvider?: string },
+) {
   const channelHint = readStringParam(params, "channel");
-  const selection = await resolveMessageChannelSelection({
-    cfg,
-    channel: channelHint,
-  });
-  return selection.channel;
+  try {
+    const selection = await resolveMessageChannelSelection({
+      cfg,
+      channel: channelHint,
+    });
+    return selection.channel;
+  } catch (error) {
+    if (channelHint && toolContext?.currentChannelProvider) {
+      const fallback = normalizeMessageChannel(toolContext.currentChannelProvider);
+      if (fallback && isDeliverableMessageChannel(fallback)) {
+        params.channel = fallback;
+        return fallback;
+      }
+    }
+    throw error;
+  }
 }
 
 async function resolveActionTarget(params: {
@@ -308,7 +323,7 @@ async function handleBroadcastAction(
   }
   const targetChannels =
     channelHint && channelHint.trim().toLowerCase() !== "all"
-      ? [await resolveChannel(input.cfg, { channel: channelHint })]
+      ? [await resolveChannel(input.cfg, { channel: channelHint }, input.toolContext)]
       : configured;
   const results: Array<{
     channel: ChannelId;
@@ -706,7 +721,7 @@ export async function runMessageAction(
     toolContext: input.toolContext,
   });
 
-  const channel = await resolveChannel(cfg, params);
+  const channel = await resolveChannel(cfg, params, input.toolContext);
   let accountId = readStringParam(params, "accountId") ?? input.defaultAccountId;
   if (!accountId && resolvedAgentId) {
     const byAgent = buildChannelAccountBindings(cfg).get(channel);

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -445,17 +445,20 @@ export type PluginHookBeforeMessageWriteResult = {
 export type PluginHookSessionContext = {
   agentId?: string;
   sessionId: string;
+  sessionKey?: string;
 };
 
 // session_start hook
 export type PluginHookSessionStartEvent = {
   sessionId: string;
+  sessionKey?: string;
   resumedFrom?: string;
 };
 
 // session_end hook
 export type PluginHookSessionEndEvent = {
   sessionId: string;
+  sessionKey?: string;
   messageCount: number;
   durationMs?: number;
 };

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -389,13 +389,21 @@ export type PluginHookToolContext = {
   sessionKey?: string;
   /** Ephemeral session UUID — regenerated on /new and /reset. */
   sessionId?: string;
+  /** Stable run identifier for this agent invocation. */
+  runId?: string;
   toolName: string;
+  /** Provider-specific tool call ID when available. */
+  toolCallId?: string;
 };
 
 // before_tool_call hook
 export type PluginHookBeforeToolCallEvent = {
   toolName: string;
   params: Record<string, unknown>;
+  /** Stable run identifier for this agent invocation. */
+  runId?: string;
+  /** Provider-specific tool call ID when available. */
+  toolCallId?: string;
 };
 
 export type PluginHookBeforeToolCallResult = {
@@ -408,6 +416,10 @@ export type PluginHookBeforeToolCallResult = {
 export type PluginHookAfterToolCallEvent = {
   toolName: string;
   params: Record<string, unknown>;
+  /** Stable run identifier for this agent invocation. */
+  runId?: string;
+  /** Provider-specific tool call ID when available. */
+  toolCallId?: string;
   result?: unknown;
   error?: string;
   durationMs?: number;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -339,6 +339,10 @@ export type PluginHookAgentContext = {
   sessionId?: string;
   workspaceDir?: string;
   messageProvider?: string;
+  /** What initiated this agent run: "user", "heartbeat", "cron", or "memory". */
+  trigger?: string;
+  /** Channel identifier (e.g. "telegram", "discord", "whatsapp"). */
+  channelId?: string;
 };
 
 // before_reset hook — fired when /new or /reset clears a session

--- a/src/plugins/wired-hooks-session.test.ts
+++ b/src/plugins/wired-hooks-session.test.ts
@@ -14,13 +14,13 @@ describe("session hook runner methods", () => {
     const runner = createHookRunner(registry);
 
     await runner.runSessionStart(
-      { sessionId: "abc-123", resumedFrom: "old-session" },
-      { sessionId: "abc-123", agentId: "main" },
+      { sessionId: "abc-123", sessionKey: "agent:main:abc", resumedFrom: "old-session" },
+      { sessionId: "abc-123", sessionKey: "agent:main:abc", agentId: "main" },
     );
 
     expect(handler).toHaveBeenCalledWith(
-      { sessionId: "abc-123", resumedFrom: "old-session" },
-      { sessionId: "abc-123", agentId: "main" },
+      { sessionId: "abc-123", sessionKey: "agent:main:abc", resumedFrom: "old-session" },
+      { sessionId: "abc-123", sessionKey: "agent:main:abc", agentId: "main" },
     );
   });
 
@@ -30,13 +30,13 @@ describe("session hook runner methods", () => {
     const runner = createHookRunner(registry);
 
     await runner.runSessionEnd(
-      { sessionId: "abc-123", messageCount: 42 },
-      { sessionId: "abc-123", agentId: "main" },
+      { sessionId: "abc-123", sessionKey: "agent:main:abc", messageCount: 42 },
+      { sessionId: "abc-123", sessionKey: "agent:main:abc", agentId: "main" },
     );
 
     expect(handler).toHaveBeenCalledWith(
-      { sessionId: "abc-123", messageCount: 42 },
-      { sessionId: "abc-123", agentId: "main" },
+      { sessionId: "abc-123", sessionKey: "agent:main:abc", messageCount: 42 },
+      { sessionId: "abc-123", sessionKey: "agent:main:abc", agentId: "main" },
     );
   });
 


### PR DESCRIPTION
## Cherry-picks from upstream (issue #780)

See issue #780 for full commit list and triage details.

### Commits picked (7/9)
| Hash | Subject | Result |
|------|---------|--------|
| `c3d515912` | refactor(hooks): dedupe install parameter wiring | RESOLVED |
| `f0640b010` | fix(test): align gateway and session spawn hook typings | SKIPPED (empty) |
| `747902a26` | fix(hooks): propagate run/tool IDs for tool hook correlation (#32360) | RESOLVED |
| `6b6af1a64` | refactor(tests): dedupe web fetch and embedded tool hook fixtures | SKIPPED (empty) |
| `11e1363d2` | feat(hooks): add trigger and channelId to plugin hook agent context (#28623) | RESOLVED |
| `20c15ccc6` | Plugins: add sessionKey to session lifecycle hooks | RESOLVED |
| `c0715db3c` | fix: add session hook context regression tests (#26394) | RESOLVED |
| `71cd33713` | fix(gateway): harden message action channel fallback and startup grace | RESOLVED |
| `2f6718b8e` | refactor(gateway): extract channel health policy and timing aliases | RESOLVED |

### Adaptation notes
- Gutted pi-embedded-runner files discarded from AUTO-PARTIAL picks
- Fork naming preserved (remoteclaw) in test helpers and error messages
- Channel health monitor conflicts resolved by taking upstream improvements (stale socket detection, startup grace, timing policy extraction)
- Unused WebSocket import removed after fork-deleted function made it unnecessary