### PR TITLE
Cherry-pick issue #781: cron auto-respond fixes and plugin heartbeat

### DIFF
--- a/extensions/test-utils/plugin-runtime-mock.ts
+++ b/extensions/test-utils/plugin-runtime-mock.ts
@@ -41,6 +41,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
     },
     system: {
       enqueueSystemEvent: vi.fn() as unknown as PluginRuntime["system"]["enqueueSystemEvent"],
+      requestHeartbeatNow: vi.fn() as unknown as PluginRuntime["system"]["requestHeartbeatNow"],
       runCommandWithTimeout: vi.fn() as unknown as PluginRuntime["system"]["runCommandWithTimeout"],
       formatNativeDependencyHint: vi.fn(
         () => "",

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -228,7 +228,9 @@ describe("resolveDeliveryTarget", () => {
     if (result.ok) {
       throw new Error("expected unresolved delivery target");
     }
-    expect(result.error.message).toContain('No delivery target resolved for channel "telegram"');
+    // resolveOutboundTarget provides the standard missing-target error when
+    // no explicit target, no session lastTo, and no plugin resolveDefaultTo.
+    expect(result.error.message).toContain("requires target");
   });
 
   it("returns an error when channel selection is ambiguous", async () => {

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -148,20 +148,6 @@ export async function resolveDeliveryTarget(
     };
   }
 
-  if (!toCandidate) {
-    return {
-      ok: false,
-      channel,
-      to: undefined,
-      accountId,
-      threadId,
-      mode,
-      error:
-        channelResolutionError ??
-        new Error(`No delivery target resolved for channel "${channel}". Set delivery.to.`),
-    };
-  }
-
   let allowFromOverride: string[] | undefined;
   if (channel === "whatsapp") {
     const resolvedAccountId = normalizeAccountId(accountId);
@@ -177,7 +163,7 @@ export async function resolveDeliveryTarget(
       .filter((entry): entry is string => Boolean(entry));
     allowFromOverride = [...new Set([...configuredAllowFrom, ...storeAllowFrom])];
 
-    if (mode === "implicit" && allowFromOverride.length > 0) {
+    if (toCandidate && mode === "implicit" && allowFromOverride.length > 0) {
       const normalizedCurrentTarget = normalizeWhatsAppTarget(toCandidate);
       if (!normalizedCurrentTarget || !allowFromOverride.includes(normalizedCurrentTarget)) {
         toCandidate = allowFromOverride[0];

--- a/src/cron/service.issue-regressions.test-helpers.ts
+++ b/src/cron/service.issue-regressions.test-helpers.ts
@@ -1,0 +1,165 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, vi } from "vitest";
+import { useFrozenTime, useRealTime } from "../test-utils/frozen-time.js";
+import type { CronService } from "./service.js";
+import type { CronJob, CronJobState } from "./types.js";
+
+const TOP_OF_HOUR_STAGGER_MS = 5 * 60 * 1_000;
+
+export const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  trace: () => {},
+};
+
+let fixtureRoot = "";
+let fixtureCount = 0;
+
+export type CronServiceOptions = ConstructorParameters<typeof CronService>[0];
+
+export function setupCronIssueRegressionFixtures() {
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cron-issues-"));
+  });
+
+  beforeEach(() => {
+    useFrozenTime("2026-02-06T10:05:00.000Z");
+  });
+
+  afterAll(async () => {
+    useRealTime();
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  return {
+    makeStorePath,
+  };
+}
+
+export function topOfHourOffsetMs(jobId: string) {
+  const digest = crypto.createHash("sha256").update(jobId).digest();
+  return digest.readUInt32BE(0) % TOP_OF_HOUR_STAGGER_MS;
+}
+
+export function makeStorePath() {
+  const storePath = path.join(fixtureRoot, `case-${fixtureCount++}.jobs.json`);
+  return {
+    storePath,
+  };
+}
+
+export function createDueIsolatedJob(params: {
+  id: string;
+  nowMs: number;
+  nextRunAtMs: number;
+  deleteAfterRun?: boolean;
+}): CronJob {
+  return {
+    id: params.id,
+    name: params.id,
+    enabled: true,
+    deleteAfterRun: params.deleteAfterRun ?? false,
+    createdAtMs: params.nowMs,
+    updatedAtMs: params.nowMs,
+    schedule: { kind: "at", at: new Date(params.nextRunAtMs).toISOString() },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: params.id },
+    delivery: { mode: "none" },
+    state: { nextRunAtMs: params.nextRunAtMs },
+  };
+}
+
+export function createDefaultIsolatedRunner(): CronServiceOptions["runIsolatedAgentJob"] {
+  return vi.fn().mockResolvedValue({
+    status: "ok",
+    summary: "ok",
+  }) as CronServiceOptions["runIsolatedAgentJob"];
+}
+
+export function createAbortAwareIsolatedRunner(summary = "late") {
+  let observedAbortSignal: AbortSignal | undefined;
+  const runIsolatedAgentJob = vi.fn(async ({ abortSignal }) => {
+    observedAbortSignal = abortSignal;
+    await new Promise<void>((resolve) => {
+      if (!abortSignal) {
+        return;
+      }
+      if (abortSignal.aborted) {
+        resolve();
+        return;
+      }
+      abortSignal.addEventListener("abort", () => resolve(), { once: true });
+    });
+    return { status: "ok" as const, summary };
+  }) as CronServiceOptions["runIsolatedAgentJob"];
+
+  return {
+    runIsolatedAgentJob,
+    getObservedAbortSignal: () => observedAbortSignal,
+  };
+}
+
+export function createIsolatedRegressionJob(params: {
+  id: string;
+  name: string;
+  scheduledAt: number;
+  schedule: CronJob["schedule"];
+  payload: CronJob["payload"];
+  state?: CronJobState;
+}): CronJob {
+  return {
+    id: params.id,
+    name: params.name,
+    enabled: true,
+    createdAtMs: params.scheduledAt - 86_400_000,
+    updatedAtMs: params.scheduledAt - 86_400_000,
+    schedule: params.schedule,
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: params.payload,
+    delivery: { mode: "announce" },
+    state: params.state ?? {},
+  };
+}
+
+export async function writeCronJobs(storePath: string, jobs: CronJob[]) {
+  await fs.writeFile(storePath, JSON.stringify({ version: 1, jobs }), "utf-8");
+}
+
+export async function writeCronStoreSnapshot(storePath: string, jobs: unknown[]) {
+  await fs.writeFile(storePath, JSON.stringify({ version: 1, jobs }), "utf-8");
+}
+
+export async function startCronForStore(params: {
+  storePath: string;
+  cronEnabled?: boolean;
+  enqueueSystemEvent?: CronServiceOptions["enqueueSystemEvent"];
+  requestHeartbeatNow?: CronServiceOptions["requestHeartbeatNow"];
+  runIsolatedAgentJob?: CronServiceOptions["runIsolatedAgentJob"];
+  onEvent?: CronServiceOptions["onEvent"];
+}) {
+  const enqueueSystemEvent =
+    params.enqueueSystemEvent ?? (vi.fn() as unknown as CronServiceOptions["enqueueSystemEvent"]);
+  const requestHeartbeatNow =
+    params.requestHeartbeatNow ?? (vi.fn() as unknown as CronServiceOptions["requestHeartbeatNow"]);
+  const runIsolatedAgentJob = params.runIsolatedAgentJob ?? createDefaultIsolatedRunner();
+
+  const { CronService } = await import("./service.js");
+  const cron = new CronService({
+    cronEnabled: params.cronEnabled ?? true,
+    storePath: params.storePath,
+    log: noopLogger,
+    enqueueSystemEvent,
+    requestHeartbeatNow,
+    runIsolatedAgentJob,
+    ...(params.onEvent ? { onEvent: params.onEvent } : {}),
+  });
+  await cron.start();
+  return cron;
+}

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1,10 +1,19 @@
-import crypto from "node:crypto";
 import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { HeartbeatRunResult } from "../infra/heartbeat-wake.js";
 import * as schedule from "./schedule.js";
+import {
+  createAbortAwareIsolatedRunner,
+  createDefaultIsolatedRunner,
+  createDueIsolatedJob,
+  createIsolatedRegressionJob,
+  noopLogger,
+  setupCronIssueRegressionFixtures,
+  startCronForStore,
+  topOfHourOffsetMs,
+  writeCronJobs,
+  writeCronStoreSnapshot,
+} from "./service.issue-regressions.test-helpers.js";
 import { CronService } from "./service.js";
 import { createDeferred, createRunningCronServiceState } from "./service.test-harness.js";
 import { computeJobNextRunAtMs } from "./service/jobs.js";
@@ -19,156 +28,10 @@ import {
 } from "./service/timer.js";
 import type { CronJob, CronJobState } from "./types.js";
 
-const noopLogger = {
-  info: () => {},
-  warn: () => {},
-  error: () => {},
-  debug: () => {},
-  trace: () => {},
-};
-const TOP_OF_HOUR_STAGGER_MS = 5 * 60 * 1_000;
 const FAST_TIMEOUT_SECONDS = 0.0025;
-type CronServiceOptions = ConstructorParameters<typeof CronService>[0];
-
-function topOfHourOffsetMs(jobId: string) {
-  const digest = crypto.createHash("sha256").update(jobId).digest();
-  return digest.readUInt32BE(0) % TOP_OF_HOUR_STAGGER_MS;
-}
-
-let fixtureRoot = "";
-let fixtureCount = 0;
-
-function makeStorePath() {
-  const storePath = path.join(fixtureRoot, `case-${fixtureCount++}.jobs.json`);
-  return {
-    storePath,
-  };
-}
-
-function createDueIsolatedJob(params: {
-  id: string;
-  nowMs: number;
-  nextRunAtMs: number;
-  deleteAfterRun?: boolean;
-}): CronJob {
-  return {
-    id: params.id,
-    name: params.id,
-    enabled: true,
-    deleteAfterRun: params.deleteAfterRun ?? false,
-    createdAtMs: params.nowMs,
-    updatedAtMs: params.nowMs,
-    schedule: { kind: "at", at: new Date(params.nextRunAtMs).toISOString() },
-    sessionTarget: "isolated",
-    wakeMode: "next-heartbeat",
-    payload: { kind: "agentTurn", message: params.id },
-    delivery: { mode: "none" },
-    state: { nextRunAtMs: params.nextRunAtMs },
-  };
-}
-
-function createDefaultIsolatedRunner(): CronServiceOptions["runIsolatedAgentJob"] {
-  return vi.fn().mockResolvedValue({
-    status: "ok",
-    summary: "ok",
-  }) as CronServiceOptions["runIsolatedAgentJob"];
-}
-
-function createAbortAwareIsolatedRunner(summary = "late") {
-  let observedAbortSignal: AbortSignal | undefined;
-  const runIsolatedAgentJob = vi.fn(async ({ abortSignal }) => {
-    observedAbortSignal = abortSignal;
-    await new Promise<void>((resolve) => {
-      if (!abortSignal) {
-        return;
-      }
-      if (abortSignal.aborted) {
-        resolve();
-        return;
-      }
-      abortSignal.addEventListener("abort", () => resolve(), { once: true });
-    });
-    return { status: "ok" as const, summary };
-  }) as CronServiceOptions["runIsolatedAgentJob"];
-
-  return {
-    runIsolatedAgentJob,
-    getObservedAbortSignal: () => observedAbortSignal,
-  };
-}
-
-function createIsolatedRegressionJob(params: {
-  id: string;
-  name: string;
-  scheduledAt: number;
-  schedule: CronJob["schedule"];
-  payload: CronJob["payload"];
-  state?: CronJobState;
-}): CronJob {
-  return {
-    id: params.id,
-    name: params.name,
-    enabled: true,
-    createdAtMs: params.scheduledAt - 86_400_000,
-    updatedAtMs: params.scheduledAt - 86_400_000,
-    schedule: params.schedule,
-    sessionTarget: "isolated",
-    wakeMode: "next-heartbeat",
-    payload: params.payload,
-    delivery: { mode: "announce" },
-    state: params.state ?? {},
-  };
-}
-
-async function writeCronJobs(storePath: string, jobs: CronJob[]) {
-  await fs.writeFile(storePath, JSON.stringify({ version: 1, jobs }), "utf-8");
-}
-
-async function writeCronStoreSnapshot(storePath: string, jobs: unknown[]) {
-  await fs.writeFile(storePath, JSON.stringify({ version: 1, jobs }), "utf-8");
-}
-
-async function startCronForStore(params: {
-  storePath: string;
-  cronEnabled?: boolean;
-  enqueueSystemEvent?: CronServiceOptions["enqueueSystemEvent"];
-  requestHeartbeatNow?: CronServiceOptions["requestHeartbeatNow"];
-  runIsolatedAgentJob?: CronServiceOptions["runIsolatedAgentJob"];
-  onEvent?: CronServiceOptions["onEvent"];
-}) {
-  const enqueueSystemEvent =
-    params.enqueueSystemEvent ?? (vi.fn() as unknown as CronServiceOptions["enqueueSystemEvent"]);
-  const requestHeartbeatNow =
-    params.requestHeartbeatNow ?? (vi.fn() as unknown as CronServiceOptions["requestHeartbeatNow"]);
-  const runIsolatedAgentJob = params.runIsolatedAgentJob ?? createDefaultIsolatedRunner();
-
-  const cron = new CronService({
-    cronEnabled: params.cronEnabled ?? true,
-    storePath: params.storePath,
-    log: noopLogger,
-    enqueueSystemEvent,
-    requestHeartbeatNow,
-    runIsolatedAgentJob,
-    ...(params.onEvent ? { onEvent: params.onEvent } : {}),
-  });
-  await cron.start();
-  return cron;
-}
 
 describe("Cron issue regressions", () => {
-  beforeAll(async () => {
-    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cron-issues-"));
-  });
-
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-02-06T10:05:00.000Z"));
-  });
-
-  afterAll(async () => {
-    vi.useRealTimers();
-    await fs.rm(fixtureRoot, { recursive: true, force: true });
-  });
+  const { makeStorePath } = setupCronIssueRegressionFixtures();
 
   it("covers schedule updates and payload patching", async () => {
     const store = makeStorePath();

--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -82,98 +82,96 @@ async function runSingleJobAndReadState(params: {
   return { job, updated: jobs.find((entry) => entry.id === job.id) };
 }
 
-describe("CronService persists delivered status", () => {
-  it("persists lastDelivered=true when isolated job reports delivered", async () => {
-    const store = await makeStorePath();
-    const { cron, finished } = createIsolatedCronWithFinishedBarrier({
-      storePath: store.storePath,
-      delivered: true,
-    });
+function expectSuccessfulCronRun(
+  updated: { state: { lastStatus?: string; lastRunStatus?: string } } | undefined,
+) {
+  expect(updated?.state.lastStatus).toBe("ok");
+  expect(updated?.state.lastRunStatus).toBe("ok");
+}
 
-    await cron.start();
+function expectDeliveryNotRequested(
+  updated:
+    | {
+        state: {
+          lastDelivered?: boolean;
+          lastDeliveryStatus?: string;
+          lastDeliveryError?: string;
+        };
+      }
+    | undefined,
+) {
+  expectSuccessfulCronRun(updated);
+  expect(updated?.state.lastDelivered).toBeUndefined();
+  expect(updated?.state.lastDeliveryStatus).toBe("not-requested");
+  expect(updated?.state.lastDeliveryError).toBeUndefined();
+}
+
+async function runIsolatedJobAndReadState(params: {
+  job: CronAddInput;
+  delivered?: boolean;
+  onFinished?: (evt: { jobId: string; delivered?: boolean; deliveryStatus?: string }) => void;
+}) {
+  const store = await makeStorePath();
+  const { cron, finished } = createIsolatedCronWithFinishedBarrier({
+    storePath: store.storePath,
+    ...(params.delivered !== undefined ? { delivered: params.delivered } : {}),
+    ...(params.onFinished ? { onFinished: params.onFinished } : {}),
+  });
+
+  await cron.start();
+  try {
     const { updated } = await runSingleJobAndReadState({
       cron,
       finished,
-      job: buildIsolatedAgentTurnJob("delivered-true"),
+      job: params.job,
     });
+    return updated;
+  } finally {
+    cron.stop();
+  }
+}
 
-    expect(updated?.state.lastStatus).toBe("ok");
-    expect(updated?.state.lastRunStatus).toBe("ok");
+describe("CronService persists delivered status", () => {
+  it("persists lastDelivered=true when isolated job reports delivered", async () => {
+    const updated = await runIsolatedJobAndReadState({
+      job: buildIsolatedAgentTurnJob("delivered-true"),
+      delivered: true,
+    });
+    expectSuccessfulCronRun(updated);
     expect(updated?.state.lastDelivered).toBe(true);
     expect(updated?.state.lastDeliveryStatus).toBe("delivered");
     expect(updated?.state.lastDeliveryError).toBeUndefined();
-
-    cron.stop();
   });
 
   it("persists lastDelivered=false when isolated job explicitly reports not delivered", async () => {
-    const store = await makeStorePath();
-    const { cron, finished } = createIsolatedCronWithFinishedBarrier({
-      storePath: store.storePath,
+    const updated = await runIsolatedJobAndReadState({
+      job: buildIsolatedAgentTurnJob("delivered-false"),
       delivered: false,
     });
-
-    await cron.start();
-    const { updated } = await runSingleJobAndReadState({
-      cron,
-      finished,
-      job: buildIsolatedAgentTurnJob("delivered-false"),
-    });
-
-    expect(updated?.state.lastStatus).toBe("ok");
-    expect(updated?.state.lastRunStatus).toBe("ok");
+    expectSuccessfulCronRun(updated);
     expect(updated?.state.lastDelivered).toBe(false);
     expect(updated?.state.lastDeliveryStatus).toBe("not-delivered");
     expect(updated?.state.lastDeliveryError).toBeUndefined();
-
-    cron.stop();
   });
 
   it("persists not-requested delivery state when delivery is not configured", async () => {
-    const store = await makeStorePath();
-    const { cron, finished } = createIsolatedCronWithFinishedBarrier({
-      storePath: store.storePath,
-    });
-
-    await cron.start();
-    const { updated } = await runSingleJobAndReadState({
-      cron,
-      finished,
+    const updated = await runIsolatedJobAndReadState({
       job: buildIsolatedAgentTurnJob("no-delivery"),
     });
-
-    expect(updated?.state.lastStatus).toBe("ok");
-    expect(updated?.state.lastRunStatus).toBe("ok");
-    expect(updated?.state.lastDelivered).toBeUndefined();
-    expect(updated?.state.lastDeliveryStatus).toBe("not-requested");
-    expect(updated?.state.lastDeliveryError).toBeUndefined();
-
-    cron.stop();
+    expectDeliveryNotRequested(updated);
   });
 
   it("persists unknown delivery state when delivery is requested but the runner omits delivered", async () => {
-    const store = await makeStorePath();
-    const { cron, finished } = createIsolatedCronWithFinishedBarrier({
-      storePath: store.storePath,
-    });
-
-    await cron.start();
-    const { updated } = await runSingleJobAndReadState({
-      cron,
-      finished,
+    const updated = await runIsolatedJobAndReadState({
       job: {
         ...buildIsolatedAgentTurnJob("delivery-unknown"),
         delivery: { mode: "announce", channel: "telegram", to: "123" },
       },
     });
-
-    expect(updated?.state.lastStatus).toBe("ok");
-    expect(updated?.state.lastRunStatus).toBe("ok");
+    expectSuccessfulCronRun(updated);
     expect(updated?.state.lastDelivered).toBeUndefined();
     expect(updated?.state.lastDeliveryStatus).toBe("unknown");
     expect(updated?.state.lastDeliveryError).toBeUndefined();
-
-    cron.stop();
   });
 
   it("does not set lastDelivered for main session jobs", async () => {
@@ -190,36 +188,24 @@ describe("CronService persists delivered status", () => {
       job: buildMainSessionSystemEventJob("main-session"),
     });
 
-    expect(updated?.state.lastStatus).toBe("ok");
-    expect(updated?.state.lastRunStatus).toBe("ok");
-    expect(updated?.state.lastDelivered).toBeUndefined();
-    expect(updated?.state.lastDeliveryStatus).toBe("not-requested");
+    expectDeliveryNotRequested(updated);
     expect(enqueueSystemEvent).toHaveBeenCalled();
 
     cron.stop();
   });
 
   it("emits delivered in the finished event", async () => {
-    const store = await makeStorePath();
     let capturedEvent: { jobId: string; delivered?: boolean; deliveryStatus?: string } | undefined;
-    const { cron, finished } = createIsolatedCronWithFinishedBarrier({
-      storePath: store.storePath,
+    await runIsolatedJobAndReadState({
+      job: buildIsolatedAgentTurnJob("event-test"),
       delivered: true,
       onFinished: (evt) => {
         capturedEvent = evt;
       },
     });
 
-    await cron.start();
-    await runSingleJobAndReadState({
-      cron,
-      finished,
-      job: buildIsolatedAgentTurnJob("event-test"),
-    });
-
     expect(capturedEvent).toBeDefined();
     expect(capturedEvent?.delivered).toBe(true);
     expect(capturedEvent?.deliveryStatus).toBe("delivered");
-    cron.stop();
   });
 });

--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -93,6 +93,8 @@ function expectDeliveryNotRequested(
   updated:
     | {
         state: {
+          lastStatus?: string;
+          lastRunStatus?: string;
           lastDelivered?: boolean;
           lastDeliveryStatus?: string;
           lastDeliveryError?: string;

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { onAgentEvent } from "../../infra/agent-events.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 
 const runCommandWithTimeoutMock = vi.hoisted(() => vi.fn());
@@ -46,5 +47,10 @@ describe("plugin runtime command execution", () => {
     const runtime = createPluginRuntime();
     expect(runtime.events.onAgentEvent).toBe(onAgentEvent);
     expect(runtime.events.onSessionTranscriptUpdate).toBe(onSessionTranscriptUpdate);
+  });
+
+  it("exposes runtime.system.requestHeartbeatNow", () => {
+    const runtime = createPluginRuntime();
+    expect(runtime.system.requestHeartbeatNow).toBe(requestHeartbeatNow);
   });
 });

--- a/src/plugins/runtime/runtime-system.ts
+++ b/src/plugins/runtime/runtime-system.ts
@@ -1,3 +1,4 @@
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { formatNativeDependencyHint } from "./native-deps.js";
@@ -6,6 +7,7 @@ import type { PluginRuntime } from "./types.js";
 export function createRuntimeSystem(): PluginRuntime["system"] {
   return {
     enqueueSystemEvent,
+    requestHeartbeatNow,
     runCommandWithTimeout,
     formatNativeDependencyHint,
   };

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -88,6 +88,7 @@ type WriteConfigFile = typeof import("../../config/config.js").writeConfigFile;
 type RecordChannelActivity = typeof import("../../infra/channel-activity.js").recordChannelActivity;
 type GetChannelActivity = typeof import("../../infra/channel-activity.js").getChannelActivity;
 type EnqueueSystemEvent = typeof import("../../infra/system-events.js").enqueueSystemEvent;
+type RequestHeartbeatNow = typeof import("../../infra/heartbeat-wake.js").requestHeartbeatNow;
 type RunCommandWithTimeout = typeof import("../../process/exec.js").runCommandWithTimeout;
 type FormatNativeDependencyHint = typeof import("./native-deps.js").formatNativeDependencyHint;
 type LoadWebMedia = typeof import("../../web/media.js").loadWebMedia;
@@ -195,6 +196,7 @@ export type PluginRuntime = {
   };
   system: {
     enqueueSystemEvent: EnqueueSystemEvent;
+    requestHeartbeatNow: RequestHeartbeatNow;
     runCommandWithTimeout: RunCommandWithTimeout;
     formatNativeDependencyHint: FormatNativeDependencyHint;
   };

--- a/src/test-utils/frozen-time.ts
+++ b/src/test-utils/frozen-time.ts
@@ -1,0 +1,10 @@
+import { vi } from "vitest";
+
+export function useFrozenTime(at: string | number | Date): void {
+  vi.useFakeTimers();
+  vi.setSystemTime(at);
+}
+
+export function useRealTime(): void {
+  vi.useRealTimers();
+}


### PR DESCRIPTION
## Cherry-picks from upstream (issue #781)

See issue #781 for full commit list and triage details.

**Picked (5)**:
- `586f057c2` fix(cron): let resolveOutboundTarget handle missing delivery target fallback
- `0f5f20ee6` refactor(tests): dedupe cron delivered status assertions
- `40e5c6a18` feat(plugins): expose requestHeartbeatNow on plugin runtime (RESOLVED — adapted to fork's extracted sub-modules)
- `ebbb57263` fix: add requestHeartbeatNow runtime coverage (RESOLVED — dropped fork-deleted CHANGELOG.md)
- `47736e343` refactor(test): extract cron issue-regression harness and frozen-time helper

**Skipped (3)**:
- `3b9877dee` fix: add requestHeartbeatNow to bluebubbles test mock — empty after resolution (fork mock helper handles defaults)
- `fbb88d506` refactor(tests): dedupe isolated agent cron turn assertions — only touched fork-deleted file
- `519318995` refactor(tests): dedupe cron store migration setup — only touched fork-deleted file

Closes #781