### PR TITLE
Cherry-pick issue #782: feishu/lark adapter fixes

### DIFF
--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -66,6 +66,26 @@ describe("resolveDefaultFeishuAccountId", () => {
 });
 
 describe("resolveFeishuAccount", () => {
+  it("uses top-level credentials with configured default account id even without account map entry", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          defaultAccount: "router-d",
+          appId: "top_level_app",
+          appSecret: "top_level_secret",
+          accounts: {
+            default: { appId: "cli_default", appSecret: "secret_default" },
+          },
+        },
+      },
+    };
+
+    const account = resolveFeishuAccount({ cfg: cfg as never, accountId: undefined });
+    expect(account.accountId).toBe("router-d");
+    expect(account.configured).toBe(true);
+    expect(account.appId).toBe("top_level_app");
+  });
+
   it("uses configured default account when accountId is omitted", () => {
     const cfg = {
       channels: {

--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveDefaultFeishuAccountId, resolveFeishuAccount } from "./accounts.js";
+import {
+  resolveDefaultFeishuAccountId,
+  resolveDefaultFeishuAccountSelection,
+  resolveFeishuAccount,
+} from "./accounts.js";
 
 describe("resolveDefaultFeishuAccountId", () => {
   it("prefers channels.feishu.defaultAccount when configured", () => {
@@ -63,6 +67,35 @@ describe("resolveDefaultFeishuAccountId", () => {
 
     expect(resolveDefaultFeishuAccountId(cfg as never)).toBe("default");
   });
+
+  it("reports selection source for configured defaults and mapped defaults", () => {
+    const explicitDefaultCfg = {
+      channels: {
+        feishu: {
+          defaultAccount: "router-d",
+          accounts: {},
+        },
+      },
+    };
+    expect(resolveDefaultFeishuAccountSelection(explicitDefaultCfg as never)).toEqual({
+      accountId: "router-d",
+      source: "explicit-default",
+    });
+
+    const mappedDefaultCfg = {
+      channels: {
+        feishu: {
+          accounts: {
+            default: { appId: "cli_default", appSecret: "secret_default" },
+          },
+        },
+      },
+    };
+    expect(resolveDefaultFeishuAccountSelection(mappedDefaultCfg as never)).toEqual({
+      accountId: "default",
+      source: "mapped-default",
+    });
+  });
 });
 
 describe("resolveFeishuAccount", () => {
@@ -82,6 +115,7 @@ describe("resolveFeishuAccount", () => {
 
     const account = resolveFeishuAccount({ cfg: cfg as never, accountId: undefined });
     expect(account.accountId).toBe("router-d");
+    expect(account.selectionSource).toBe("explicit-default");
     expect(account.configured).toBe(true);
     expect(account.appId).toBe("top_level_app");
   });
@@ -101,6 +135,7 @@ describe("resolveFeishuAccount", () => {
 
     const account = resolveFeishuAccount({ cfg: cfg as never, accountId: undefined });
     expect(account.accountId).toBe("router-d");
+    expect(account.selectionSource).toBe("explicit-default");
     expect(account.configured).toBe(true);
     expect(account.appId).toBe("cli_router");
   });
@@ -120,6 +155,7 @@ describe("resolveFeishuAccount", () => {
 
     const account = resolveFeishuAccount({ cfg: cfg as never, accountId: "default" });
     expect(account.accountId).toBe("default");
+    expect(account.selectionSource).toBe("explicit");
     expect(account.appId).toBe("cli_default");
   });
 });

--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -33,11 +33,26 @@ describe("resolveDefaultFeishuAccountId", () => {
     expect(resolveDefaultFeishuAccountId(cfg as never)).toBe("router-d");
   });
 
-  it("falls back to literal default account id when preferred is missing", () => {
+  it("keeps configured defaultAccount even when not present in accounts map", () => {
     const cfg = {
       channels: {
         feishu: {
-          defaultAccount: "missing",
+          defaultAccount: "router-d",
+          accounts: {
+            default: { appId: "cli_default", appSecret: "secret_default" },
+            zeta: { appId: "cli_zeta", appSecret: "secret_zeta" },
+          },
+        },
+      },
+    };
+
+    expect(resolveDefaultFeishuAccountId(cfg as never)).toBe("router-d");
+  });
+
+  it("falls back to literal default account id when present", () => {
+    const cfg = {
+      channels: {
+        feishu: {
           accounts: {
             default: { appId: "cli_default", appSecret: "secret_default" },
             zeta: { appId: "cli_zeta", appSecret: "secret_zeta" },

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -37,10 +37,10 @@ export function listFeishuAccountIds(cfg: ClawdbotConfig): string[] {
 export function resolveDefaultFeishuAccountId(cfg: ClawdbotConfig): string {
   const preferredRaw = (cfg.channels?.feishu as FeishuConfig | undefined)?.defaultAccount?.trim();
   const preferred = preferredRaw ? normalizeAccountId(preferredRaw) : undefined;
-  const ids = listFeishuAccountIds(cfg);
-  if (preferred && ids.includes(preferred)) {
+  if (preferred) {
     return preferred;
   }
+  const ids = listFeishuAccountIds(cfg);
   if (ids.includes(DEFAULT_ACCOUNT_ID)) {
     return DEFAULT_ACCOUNT_ID;
   }

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -3,6 +3,7 @@ import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "remoteclaw/plugin-sdk/ac
 import type {
   FeishuConfig,
   FeishuAccountConfig,
+  FeishuDefaultAccountSelectionSource,
   FeishuDomain,
   ResolvedFeishuAccount,
 } from "./types.js";
@@ -32,19 +33,38 @@ export function listFeishuAccountIds(cfg: ClawdbotConfig): string[] {
 }
 
 /**
- * Resolve the default account ID.
+ * Resolve the default account selection and its source.
  */
-export function resolveDefaultFeishuAccountId(cfg: ClawdbotConfig): string {
+export function resolveDefaultFeishuAccountSelection(cfg: ClawdbotConfig): {
+  accountId: string;
+  source: FeishuDefaultAccountSelectionSource;
+} {
   const preferredRaw = (cfg.channels?.feishu as FeishuConfig | undefined)?.defaultAccount?.trim();
   const preferred = preferredRaw ? normalizeAccountId(preferredRaw) : undefined;
   if (preferred) {
-    return preferred;
+    return {
+      accountId: preferred,
+      source: "explicit-default",
+    };
   }
   const ids = listFeishuAccountIds(cfg);
   if (ids.includes(DEFAULT_ACCOUNT_ID)) {
-    return DEFAULT_ACCOUNT_ID;
+    return {
+      accountId: DEFAULT_ACCOUNT_ID,
+      source: "mapped-default",
+    };
   }
-  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+  return {
+    accountId: ids[0] ?? DEFAULT_ACCOUNT_ID,
+    source: "fallback",
+  };
+}
+
+/**
+ * Resolve the default account ID.
+ */
+export function resolveDefaultFeishuAccountId(cfg: ClawdbotConfig): string {
+  return resolveDefaultFeishuAccountSelection(cfg).accountId;
 }
 
 /**
@@ -111,9 +131,15 @@ export function resolveFeishuAccount(params: {
 }): ResolvedFeishuAccount {
   const hasExplicitAccountId =
     typeof params.accountId === "string" && params.accountId.trim() !== "";
+  const defaultSelection = hasExplicitAccountId
+    ? null
+    : resolveDefaultFeishuAccountSelection(params.cfg);
   const accountId = hasExplicitAccountId
     ? normalizeAccountId(params.accountId)
-    : resolveDefaultFeishuAccountId(params.cfg);
+    : (defaultSelection?.accountId ?? DEFAULT_ACCOUNT_ID);
+  const selectionSource = hasExplicitAccountId
+    ? "explicit"
+    : (defaultSelection?.source ?? "fallback");
   const feishuCfg = params.cfg.channels?.feishu as FeishuConfig | undefined;
 
   // Base enabled state (top-level)
@@ -131,6 +157,7 @@ export function resolveFeishuAccount(params: {
 
   return {
     accountId,
+    selectionSource,
     enabled,
     configured: Boolean(creds),
     name: (merged as FeishuAccountConfig).name?.trim() || undefined,

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -34,6 +34,7 @@ let priorProxyEnv: Partial<Record<ProxyEnvKey, string | undefined>> = {};
 
 const baseAccount: ResolvedFeishuAccount = {
   accountId: "main",
+  selectionSource: "explicit",
   enabled: true,
   configured: true,
   appId: "app_123",

--- a/extensions/feishu/src/monitor.startup.test.ts
+++ b/extensions/feishu/src/monitor.startup.test.ts
@@ -1,5 +1,6 @@
 import type { ClawdbotConfig } from "remoteclaw/plugin-sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { monitorFeishuProvider, stopFeishuMonitor } from "./monitor.js";
 
 const probeFeishuMock = vi.hoisted(() => vi.fn());
 
@@ -12,7 +13,22 @@ vi.mock("./client.js", () => ({
   createEventDispatcher: vi.fn(() => ({ register: vi.fn() })),
 }));
 
-import { monitorFeishuProvider, stopFeishuMonitor } from "./monitor.js";
+vi.mock("./runtime.js", () => ({
+  getFeishuRuntime: () => ({
+    channel: {
+      debounce: {
+        resolveInboundDebounceMs: () => 0,
+        createInboundDebouncer: () => ({
+          enqueue: async () => {},
+          flushKey: async () => {},
+        }),
+      },
+      text: {
+        hasControlCommand: () => false,
+      },
+    },
+  }),
+}));
 
 function buildMultiAccountWebsocketConfig(accountIds: string[]): ClawdbotConfig {
   return {

--- a/extensions/feishu/src/monitor.webhook-security.test.ts
+++ b/extensions/feishu/src/monitor.webhook-security.test.ts
@@ -14,6 +14,23 @@ vi.mock("./client.js", () => ({
   createEventDispatcher: vi.fn(() => ({ register: vi.fn() })),
 }));
 
+vi.mock("./runtime.js", () => ({
+  getFeishuRuntime: () => ({
+    channel: {
+      debounce: {
+        resolveInboundDebounceMs: () => 0,
+        createInboundDebouncer: () => ({
+          enqueue: async () => {},
+          flushKey: async () => {},
+        }),
+      },
+      text: {
+        hasControlCommand: () => false,
+      },
+    },
+  }),
+}));
+
 vi.mock("@larksuiteoapi/node-sdk", () => ({
   adaptDefault: vi.fn(
     () => (_req: unknown, res: { statusCode?: number; end: (s: string) => void }) => {

--- a/extensions/feishu/src/probe.test.ts
+++ b/extensions/feishu/src/probe.test.ts
@@ -59,7 +59,7 @@ describe("probeFeishu", () => {
     expect(requestFn).toHaveBeenCalledTimes(1);
   });
 
-  it("uses explicit timeout for bot info request", async () => {
+  it("passes the probe timeout to the Feishu request", async () => {
     const requestFn = setupClient({
       code: 0,
       bot: { bot_name: "TestBot", open_id: "ou_abc123" },
@@ -105,7 +105,6 @@ describe("probeFeishu", () => {
     expect(result).toMatchObject({ ok: false, error: "probe aborted" });
     expect(createFeishuClientMock).not.toHaveBeenCalled();
   });
-
   it("returns cached result on subsequent calls within TTL", async () => {
     const requestFn = setupClient({
       code: 0,
@@ -133,7 +132,7 @@ describe("probeFeishu", () => {
       await probeFeishu(creds);
       expect(requestFn).toHaveBeenCalledTimes(1);
 
-      // Advance time past the 10-minute TTL
+      // Advance time past the success TTL
       vi.advanceTimersByTime(10 * 60 * 1000 + 1);
 
       await probeFeishu(creds);
@@ -143,29 +142,48 @@ describe("probeFeishu", () => {
     }
   });
 
-  it("does not cache failed probe results (API error)", async () => {
-    const requestFn = makeRequestFn({ code: 99, msg: "token expired" });
-    createFeishuClientMock.mockReturnValue({ request: requestFn });
+  it("caches failed probe results (API error) for the error TTL", async () => {
+    vi.useFakeTimers();
+    try {
+      const requestFn = makeRequestFn({ code: 99, msg: "token expired" });
+      createFeishuClientMock.mockReturnValue({ request: requestFn });
 
-    const creds = { appId: "cli_123", appSecret: "secret" };
-    const first = await probeFeishu(creds);
-    expect(first).toMatchObject({ ok: false, error: "API error: token expired" });
+      const creds = { appId: "cli_123", appSecret: "secret" };
+      const first = await probeFeishu(creds);
+      const second = await probeFeishu(creds);
+      expect(first).toMatchObject({ ok: false, error: "API error: token expired" });
+      expect(second).toMatchObject({ ok: false, error: "API error: token expired" });
+      expect(requestFn).toHaveBeenCalledTimes(1);
 
-    // Second call should make a fresh request since failures are not cached
-    await probeFeishu(creds);
-    expect(requestFn).toHaveBeenCalledTimes(2);
+      vi.advanceTimersByTime(60 * 1000 + 1);
+
+      await probeFeishu(creds);
+      expect(requestFn).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
-  it("does not cache results when request throws", async () => {
-    const requestFn = vi.fn().mockRejectedValue(new Error("network error"));
-    createFeishuClientMock.mockReturnValue({ request: requestFn });
+  it("caches thrown request errors for the error TTL", async () => {
+    vi.useFakeTimers();
+    try {
+      const requestFn = vi.fn().mockRejectedValue(new Error("network error"));
+      createFeishuClientMock.mockReturnValue({ request: requestFn });
 
-    const creds = { appId: "cli_123", appSecret: "secret" };
-    const first = await probeFeishu(creds);
-    expect(first).toMatchObject({ ok: false, error: "network error" });
+      const creds = { appId: "cli_123", appSecret: "secret" };
+      const first = await probeFeishu(creds);
+      const second = await probeFeishu(creds);
+      expect(first).toMatchObject({ ok: false, error: "network error" });
+      expect(second).toMatchObject({ ok: false, error: "network error" });
+      expect(requestFn).toHaveBeenCalledTimes(1);
 
-    await probeFeishu(creds);
-    expect(requestFn).toHaveBeenCalledTimes(2);
+      vi.advanceTimersByTime(60 * 1000 + 1);
+
+      await probeFeishu(creds);
+      expect(requestFn).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("caches per account independently", async () => {

--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -2,15 +2,16 @@ import { raceWithTimeoutAndAbort } from "./async.js";
 import { createFeishuClient, type FeishuClientCredentials } from "./client.js";
 import type { FeishuProbeResult } from "./types.js";
 
-/** Cache successful probe results to reduce API calls (bot info is static).
+/** Cache probe results to reduce repeated health-check calls.
  * Gateway health checks call probeFeishu() every minute; without caching this
  * burns ~43,200 calls/month, easily exceeding Feishu's free-tier quota.
- * A 10-min TTL cuts that to ~4,320 calls/month. (#26684) */
+ * Successful bot info is effectively static, while failures are cached briefly
+ * to avoid hammering the API during transient outages. */
 const probeCache = new Map<string, { result: FeishuProbeResult; expiresAt: number }>();
-const PROBE_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const PROBE_SUCCESS_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const PROBE_ERROR_TTL_MS = 60 * 1000; // 1 minute
 const MAX_PROBE_CACHE_SIZE = 64;
 export const FEISHU_PROBE_REQUEST_TIMEOUT_MS = 10_000;
-
 export type ProbeFeishuOptions = {
   timeoutMs?: number;
   abortSignal?: AbortSignal;
@@ -22,6 +23,21 @@ type FeishuBotInfoResponse = {
   bot?: { bot_name?: string; open_id?: string };
   data?: { bot?: { bot_name?: string; open_id?: string } };
 };
+
+function setCachedProbeResult(
+  cacheKey: string,
+  result: FeishuProbeResult,
+  ttlMs: number,
+): FeishuProbeResult {
+  probeCache.set(cacheKey, { result, expiresAt: Date.now() + ttlMs });
+  if (probeCache.size > MAX_PROBE_CACHE_SIZE) {
+    const oldest = probeCache.keys().next().value;
+    if (oldest !== undefined) {
+      probeCache.delete(oldest);
+    }
+  }
+  return result;
+}
 
 export async function probeFeishu(
   creds?: FeishuClientCredentials,
@@ -78,11 +94,15 @@ export async function probeFeishu(
       };
     }
     if (responseResult.status === "timeout") {
-      return {
-        ok: false,
-        appId: creds.appId,
-        error: `probe timed out after ${timeoutMs}ms`,
-      };
+      return setCachedProbeResult(
+        cacheKey,
+        {
+          ok: false,
+          appId: creds.appId,
+          error: `probe timed out after ${timeoutMs}ms`,
+        },
+        PROBE_ERROR_TTL_MS,
+      );
     }
 
     const response = responseResult.value;
@@ -95,38 +115,38 @@ export async function probeFeishu(
     }
 
     if (response.code !== 0) {
-      return {
-        ok: false,
-        appId: creds.appId,
-        error: `API error: ${response.msg || `code ${response.code}`}`,
-      };
+      return setCachedProbeResult(
+        cacheKey,
+        {
+          ok: false,
+          appId: creds.appId,
+          error: `API error: ${response.msg || `code ${response.code}`}`,
+        },
+        PROBE_ERROR_TTL_MS,
+      );
     }
 
     const bot = response.bot || response.data?.bot;
-    const result: FeishuProbeResult = {
-      ok: true,
-      appId: creds.appId,
-      botName: bot?.bot_name,
-      botOpenId: bot?.open_id,
-    };
-
-    // Cache successful results only
-    probeCache.set(cacheKey, { result, expiresAt: Date.now() + PROBE_CACHE_TTL_MS });
-    // Evict oldest entry if cache exceeds max size
-    if (probeCache.size > MAX_PROBE_CACHE_SIZE) {
-      const oldest = probeCache.keys().next().value;
-      if (oldest !== undefined) {
-        probeCache.delete(oldest);
-      }
-    }
-
-    return result;
+    return setCachedProbeResult(
+      cacheKey,
+      {
+        ok: true,
+        appId: creds.appId,
+        botName: bot?.bot_name,
+        botOpenId: bot?.open_id,
+      },
+      PROBE_SUCCESS_TTL_MS,
+    );
   } catch (err) {
-    return {
-      ok: false,
-      appId: creds.appId,
-      error: err instanceof Error ? err.message : String(err),
-    };
+    return setCachedProbeResult(
+      cacheKey,
+      {
+        ok: false,
+        appId: creds.appId,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      PROBE_ERROR_TTL_MS,
+    );
   }
 }
 

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -94,6 +94,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       ) {
         return;
       }
+      // Feishu reactions persist until explicitly removed, so skip keepalive
+      // re-adds when a reaction already exists. Re-adding the same emoji
+      // triggers a new push notification for every call (#28660).
+      if (typingState?.reactionId) {
+        return;
+      }
       typingState = await addTypingIndicator({
         cfg,
         messageId: replyToMessageId,

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -14,8 +14,15 @@ export type FeishuAccountConfig = z.infer<typeof FeishuAccountConfigSchema>;
 export type FeishuDomain = "feishu" | "lark" | (string & {});
 export type FeishuConnectionMode = "websocket" | "webhook";
 
+export type FeishuDefaultAccountSelectionSource =
+  | "explicit-default"
+  | "mapped-default"
+  | "fallback";
+export type FeishuAccountSelectionSource = "explicit" | FeishuDefaultAccountSelectionSource;
+
 export type ResolvedFeishuAccount = {
   accountId: string;
+  selectionSource: FeishuAccountSelectionSource;
   enabled: boolean;
   configured: boolean;
   name?: string;

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -39,14 +39,16 @@ type DebounceBuffer<T> = {
   debounceMs: number;
 };
 
-export function createInboundDebouncer<T>(params: {
+export type InboundDebounceCreateParams<T> = {
   debounceMs: number;
   buildKey: (item: T) => string | null | undefined;
   shouldDebounce?: (item: T) => boolean;
   resolveDebounceMs?: (item: T) => number | undefined;
   onFlush: (items: T[]) => Promise<void>;
   onError?: (err: unknown, items: T[]) => void;
-}) {
+};
+
+export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>) {
   const buffers = new Map<string, DebounceBuffer<T>>();
   const defaultDebounceMs = Math.max(0, Math.trunc(params.debounceMs));
 

--- a/src/channels/inbound-debounce-policy.test.ts
+++ b/src/channels/inbound-debounce-policy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createChannelInboundDebouncer,
+  shouldDebounceTextInbound,
+} from "./inbound-debounce-policy.js";
+
+describe("shouldDebounceTextInbound", () => {
+  it("rejects blank text, media, and control commands", () => {
+    const cfg = {} as Parameters<typeof shouldDebounceTextInbound>[0]["cfg"];
+
+    expect(shouldDebounceTextInbound({ text: "   ", cfg })).toBe(false);
+    expect(shouldDebounceTextInbound({ text: "hello", cfg, hasMedia: true })).toBe(false);
+    expect(shouldDebounceTextInbound({ text: "/status", cfg })).toBe(false);
+  });
+
+  it("accepts normal text when debounce is allowed", () => {
+    const cfg = {} as Parameters<typeof shouldDebounceTextInbound>[0]["cfg"];
+    expect(shouldDebounceTextInbound({ text: "hello there", cfg })).toBe(true);
+    expect(shouldDebounceTextInbound({ text: "hello there", cfg, allowDebounce: false })).toBe(
+      false,
+    );
+  });
+});
+
+describe("createChannelInboundDebouncer", () => {
+  it("resolves per-channel debounce and forwards callbacks", async () => {
+    vi.useFakeTimers();
+    try {
+      const flushed: string[][] = [];
+      const cfg = {
+        messages: {
+          inbound: {
+            debounceMs: 10,
+            byChannel: {
+              slack: 25,
+            },
+          },
+        },
+      } as Parameters<typeof createChannelInboundDebouncer<{ id: string }>>[0]["cfg"];
+
+      const { debounceMs, debouncer } = createChannelInboundDebouncer<{ id: string }>({
+        cfg,
+        channel: "slack",
+        buildKey: (item) => item.id,
+        onFlush: async (items) => {
+          flushed.push(items.map((entry) => entry.id));
+        },
+      });
+
+      expect(debounceMs).toBe(25);
+
+      await debouncer.enqueue({ id: "a" });
+      await debouncer.enqueue({ id: "a" });
+      await vi.advanceTimersByTimeAsync(30);
+
+      expect(flushed).toEqual([["a", "a"]]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/channels/inbound-debounce-policy.ts
+++ b/src/channels/inbound-debounce-policy.ts
@@ -1,0 +1,51 @@
+import { hasControlCommand } from "../auto-reply/command-detection.js";
+import type { CommandNormalizeOptions } from "../auto-reply/commands-registry.js";
+import {
+  createInboundDebouncer,
+  resolveInboundDebounceMs,
+  type InboundDebounceCreateParams,
+} from "../auto-reply/inbound-debounce.js";
+import type { OpenClawConfig } from "../config/types.js";
+
+export function shouldDebounceTextInbound(params: {
+  text: string | null | undefined;
+  cfg: OpenClawConfig;
+  hasMedia?: boolean;
+  commandOptions?: CommandNormalizeOptions;
+  allowDebounce?: boolean;
+}): boolean {
+  if (params.allowDebounce === false) {
+    return false;
+  }
+  if (params.hasMedia) {
+    return false;
+  }
+  const text = params.text?.trim() ?? "";
+  if (!text) {
+    return false;
+  }
+  return !hasControlCommand(text, params.cfg, params.commandOptions);
+}
+
+export function createChannelInboundDebouncer<T>(
+  params: Omit<InboundDebounceCreateParams<T>, "debounceMs"> & {
+    cfg: OpenClawConfig;
+    channel: string;
+    debounceMsOverride?: number;
+  },
+): {
+  debounceMs: number;
+  debouncer: ReturnType<typeof createInboundDebouncer<T>>;
+} {
+  const debounceMs = resolveInboundDebounceMs({
+    cfg: params.cfg,
+    channel: params.channel,
+    overrideMs: params.debounceMsOverride,
+  });
+  const { cfg: _cfg, channel: _channel, debounceMsOverride: _override, ...rest } = params;
+  const debouncer = createInboundDebouncer<T>({
+    debounceMs,
+    ...rest,
+  });
+  return { debounceMs, debouncer };
+}

--- a/src/channels/inbound-debounce-policy.ts
+++ b/src/channels/inbound-debounce-policy.ts
@@ -5,11 +5,11 @@ import {
   resolveInboundDebounceMs,
   type InboundDebounceCreateParams,
 } from "../auto-reply/inbound-debounce.js";
-import type { OpenClawConfig } from "../config/types.js";
+import type { RemoteClawConfig } from "../config/types.js";
 
 export function shouldDebounceTextInbound(params: {
   text: string | null | undefined;
-  cfg: OpenClawConfig;
+  cfg: RemoteClawConfig;
   hasMedia?: boolean;
   commandOptions?: CommandNormalizeOptions;
   allowDebounce?: boolean;
@@ -29,7 +29,7 @@ export function shouldDebounceTextInbound(params: {
 
 export function createChannelInboundDebouncer<T>(
   params: Omit<InboundDebounceCreateParams<T>, "debounceMs"> & {
-    cfg: OpenClawConfig;
+    cfg: RemoteClawConfig;
     channel: string;
     debounceMsOverride?: number;
   },

--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -83,7 +83,15 @@ async function runSingleJobAndReadState(params: {
 }
 
 function expectSuccessfulCronRun(
-  updated: { state: { lastStatus?: string; lastRunStatus?: string } } | undefined,
+  updated:
+    | {
+        state: {
+          lastStatus?: string;
+          lastRunStatus?: string;
+          [key: string]: unknown;
+        };
+      }
+    | undefined,
 ) {
   expect(updated?.state.lastStatus).toBe("ok");
   expect(updated?.state.lastRunStatus).toBe("ok");

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -1,9 +1,8 @@
 import type { Client } from "@buape/carbon";
-import { hasControlCommand } from "../../auto-reply/command-detection.js";
 import {
-  createInboundDebouncer,
-  resolveInboundDebounceMs,
-} from "../../auto-reply/inbound-debounce.js";
+  createChannelInboundDebouncer,
+  shouldDebounceTextInbound,
+} from "../../channels/inbound-debounce-policy.js";
 import { resolveOpenProviderRuntimeGroupPolicy } from "../../config/runtime-group-policy.js";
 import { danger } from "../../globals.js";
 import type { DiscordMessageEvent, DiscordMessageHandler } from "./listeners.js";
@@ -33,10 +32,12 @@ export function createDiscordMessageHandler(
     params.discordConfig?.ackReactionScope ??
     params.cfg.messages?.ackReactionScope ??
     "group-mentions";
-  const debounceMs = resolveInboundDebounceMs({ cfg: params.cfg, channel: "discord" });
-
-  const debouncer = createInboundDebouncer<{ data: DiscordMessageEvent; client: Client }>({
-    debounceMs,
+  const { debouncer } = createChannelInboundDebouncer<{
+    data: DiscordMessageEvent;
+    client: Client;
+  }>({
+    cfg: params.cfg,
+    channel: "discord",
     buildKey: (entry) => {
       const message = entry.data.message;
       const authorId = entry.data.author?.id;
@@ -57,17 +58,15 @@ export function createDiscordMessageHandler(
       if (!message) {
         return false;
       }
-      if (message.attachments && message.attachments.length > 0) {
-        return false;
-      }
-      if (hasDiscordMessageStickers(message)) {
-        return false;
-      }
       const baseText = resolveDiscordMessageText(message, { includeForwarded: false });
-      if (!baseText.trim()) {
-        return false;
-      }
-      return !hasControlCommand(baseText, params.cfg);
+      return shouldDebounceTextInbound({
+        text: baseText,
+        cfg: params.cfg,
+        hasMedia: Boolean(
+          (message.attachments && message.attachments.length > 0) ||
+          hasDiscordMessageStickers(message),
+        ),
+      });
     },
     onFlush: async (entries) => {
       const last = entries.at(-1);

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -26,6 +26,8 @@ import {
 } from "./control-ui-shared.js";
 
 const ROOT_PREFIX = "/";
+const CONTROL_UI_ASSETS_MISSING_MESSAGE =
+  "Control UI assets not found. Build them with `pnpm ui:build` (auto-installs UI deps), or run `pnpm ui:dev` during development.";
 
 export type ControlUiRequestOptions = {
   basePath?: string;
@@ -116,6 +118,31 @@ function sendJson(res: ServerResponse, status: number, body: unknown) {
   res.end(JSON.stringify(body));
 }
 
+function respondControlUiAssetsUnavailable(
+  res: ServerResponse,
+  options?: { configuredRootPath?: string },
+) {
+  if (options?.configuredRootPath) {
+    respondPlainText(
+      res,
+      503,
+      `Control UI assets not found at ${options.configuredRootPath}. Build them with \`pnpm ui:build\` (auto-installs UI deps), or update gateway.controlUi.root.`,
+    );
+    return;
+  }
+  respondPlainText(res, 503, CONTROL_UI_ASSETS_MISSING_MESSAGE);
+}
+
+function respondHeadForFile(req: IncomingMessage, res: ServerResponse, filePath: string): boolean {
+  if (req.method !== "HEAD") {
+    return false;
+  }
+  res.statusCode = 200;
+  setStaticFileHeaders(res, filePath);
+  res.end();
+  return true;
+}
+
 function isValidAgentId(agentId: string): boolean {
   return /^[a-z0-9][a-z0-9_-]{0,63}$/i.test(agentId);
 }
@@ -176,11 +203,7 @@ export function handleControlUiAvatarRequest(
     return true;
   }
   try {
-    if (req.method === "HEAD") {
-      res.statusCode = 200;
-      res.setHeader("Content-Type", contentTypeForExt(path.extname(safeAvatar.path).toLowerCase()));
-      res.setHeader("Cache-Control", "no-cache");
-      res.end();
+    if (respondHeadForFile(req, res, safeAvatar.path)) {
       return true;
     }
 
@@ -342,19 +365,11 @@ export function handleControlUiHttpRequest(
 
   const rootState = opts?.root;
   if (rootState?.kind === "invalid") {
-    respondPlainText(
-      res,
-      503,
-      `Control UI assets not found at ${rootState.path}. Build them with \`pnpm ui:build\` (auto-installs UI deps), or update gateway.controlUi.root.`,
-    );
+    respondControlUiAssetsUnavailable(res, { configuredRootPath: rootState.path });
     return true;
   }
   if (rootState?.kind === "missing") {
-    respondPlainText(
-      res,
-      503,
-      "Control UI assets not found. Build them with `pnpm ui:build` (auto-installs UI deps), or run `pnpm ui:dev` during development.",
-    );
+    respondControlUiAssetsUnavailable(res);
     return true;
   }
 
@@ -367,11 +382,7 @@ export function handleControlUiHttpRequest(
           cwd: process.cwd(),
         });
   if (!root) {
-    respondPlainText(
-      res,
-      503,
-      "Control UI assets not found. Build them with `pnpm ui:build` (auto-installs UI deps), or run `pnpm ui:dev` during development.",
-    );
+    respondControlUiAssetsUnavailable(res);
     return true;
   }
 
@@ -386,11 +397,7 @@ export function handleControlUiHttpRequest(
     }
   })();
   if (!rootReal) {
-    respondPlainText(
-      res,
-      503,
-      "Control UI assets not found. Build them with `pnpm ui:build` (auto-installs UI deps), or run `pnpm ui:dev` during development.",
-    );
+    respondControlUiAssetsUnavailable(res);
     return true;
   }
 
@@ -422,10 +429,7 @@ export function handleControlUiHttpRequest(
   const safeFile = resolveSafeControlUiFile(rootReal, filePath);
   if (safeFile) {
     try {
-      if (req.method === "HEAD") {
-        res.statusCode = 200;
-        setStaticFileHeaders(res, safeFile.path);
-        res.end();
+      if (respondHeadForFile(req, res, safeFile.path)) {
         return true;
       }
       if (path.basename(safeFile.path) === "index.html") {
@@ -454,10 +458,7 @@ export function handleControlUiHttpRequest(
   const safeIndex = resolveSafeControlUiFile(rootReal, indexPath);
   if (safeIndex) {
     try {
-      if (req.method === "HEAD") {
-        res.statusCode = 200;
-        setStaticFileHeaders(res, safeIndex.path);
-        res.end();
+      if (respondHeadForFile(req, res, safeIndex.path)) {
         return true;
       }
       serveResolvedIndexHtml(res, fs.readFileSync(safeIndex.fd, "utf8"));

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -322,64 +322,97 @@ export function createInternalHookEvent(
   };
 }
 
+function isHookEventTypeAndAction(
+  event: InternalHookEvent,
+  type: InternalHookEventType,
+  action: string,
+): boolean {
+  return event.type === type && event.action === action;
+}
+
+function getHookContext<T extends Record<string, unknown>>(
+  event: InternalHookEvent,
+): Partial<T> | null {
+  const context = event.context as Partial<T> | null;
+  if (!context || typeof context !== "object") {
+    return null;
+  }
+  return context;
+}
+
+function hasStringContextField<T extends Record<string, unknown>>(
+  context: Partial<T>,
+  key: keyof T,
+): boolean {
+  return typeof context[key] === "string";
+}
+
+function hasBooleanContextField<T extends Record<string, unknown>>(
+  context: Partial<T>,
+  key: keyof T,
+): boolean {
+  return typeof context[key] === "boolean";
+}
+
 export function isGatewayStartupEvent(event: InternalHookEvent): event is GatewayStartupHookEvent {
-  if (event.type !== "gateway" || event.action !== "startup") {
+  if (!isHookEventTypeAndAction(event, "gateway", "startup")) {
     return false;
   }
-  const context = event.context as GatewayStartupHookContext | null;
-  return Boolean(context && typeof context === "object");
+  return Boolean(getHookContext<GatewayStartupHookContext>(event));
 }
 
 export function isMessageReceivedEvent(
   event: InternalHookEvent,
 ): event is MessageReceivedHookEvent {
-  if (event.type !== "message" || event.action !== "received") {
+  if (!isHookEventTypeAndAction(event, "message", "received")) {
     return false;
   }
-  const context = event.context as Partial<MessageReceivedHookContext> | null;
-  if (!context || typeof context !== "object") {
+  const context = getHookContext<MessageReceivedHookContext>(event);
+  if (!context) {
     return false;
   }
-  return typeof context.from === "string" && typeof context.channelId === "string";
+  return hasStringContextField(context, "from") && hasStringContextField(context, "channelId");
 }
 
 export function isMessageSentEvent(event: InternalHookEvent): event is MessageSentHookEvent {
-  if (event.type !== "message" || event.action !== "sent") {
+  if (!isHookEventTypeAndAction(event, "message", "sent")) {
     return false;
   }
-  const context = event.context as Partial<MessageSentHookContext> | null;
-  if (!context || typeof context !== "object") {
+  const context = getHookContext<MessageSentHookContext>(event);
+  if (!context) {
     return false;
   }
   return (
-    typeof context.to === "string" &&
-    typeof context.channelId === "string" &&
-    typeof context.success === "boolean"
+    hasStringContextField(context, "to") &&
+    hasStringContextField(context, "channelId") &&
+    hasBooleanContextField(context, "success")
   );
 }
 
 export function isMessageTranscribedEvent(
   event: InternalHookEvent,
 ): event is MessageTranscribedHookEvent {
-  if (event.type !== "message" || event.action !== "transcribed") {
+  if (!isHookEventTypeAndAction(event, "message", "transcribed")) {
     return false;
   }
-  const context = event.context as Partial<MessageTranscribedHookContext> | null;
-  if (!context || typeof context !== "object") {
+  const context = getHookContext<MessageTranscribedHookContext>(event);
+  if (!context) {
     return false;
   }
-  return typeof context.transcript === "string" && typeof context.channelId === "string";
+  return (
+    hasStringContextField(context, "transcript") && hasStringContextField(context, "channelId")
+  );
 }
 
 export function isMessagePreprocessedEvent(
   event: InternalHookEvent,
 ): event is MessagePreprocessedHookEvent {
-  if (event.type !== "message" || event.action !== "preprocessed") {
+  if (!isHookEventTypeAndAction(event, "message", "preprocessed")) {
     return false;
   }
-  const context = event.context as Partial<MessagePreprocessedHookContext> | null;
-  if (!context || typeof context !== "object") {
+  const context = getHookContext<MessagePreprocessedHookContext>(event);
+  if (!context) {
     return false;
   }
-  return typeof context.channelId === "string";
+  return hasStringContextField(context, "channelId");
 }

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -1,18 +1,17 @@
 import fs from "node:fs/promises";
 import { resolveHumanDelayConfig } from "../../agents/identity.js";
 import { resolveTextChunkLimit } from "../../auto-reply/chunk.js";
-import { hasControlCommand } from "../../auto-reply/command-detection.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
-import {
-  createInboundDebouncer,
-  resolveInboundDebounceMs,
-} from "../../auto-reply/inbound-debounce.js";
 import {
   clearHistoryEntriesIfEnabled,
   DEFAULT_GROUP_HISTORY_LIMIT,
   type HistoryEntry,
 } from "../../auto-reply/reply/history.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
+import {
+  createChannelInboundDebouncer,
+  shouldDebounceTextInbound,
+} from "../../channels/inbound-debounce-policy.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { recordInboundSession } from "../../channels/session.js";
 import { loadConfig } from "../../config/config.js";
@@ -153,9 +152,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     }
   }
 
-  const inboundDebounceMs = resolveInboundDebounceMs({ cfg, channel: "imessage" });
-  const inboundDebouncer = createInboundDebouncer<{ message: IMessagePayload }>({
-    debounceMs: inboundDebounceMs,
+  const { debouncer: inboundDebouncer } = createChannelInboundDebouncer<{
+    message: IMessagePayload;
+  }>({
+    cfg,
+    channel: "imessage",
     buildKey: (entry) => {
       const sender = entry.message.sender?.trim();
       if (!sender) {
@@ -168,14 +169,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       return `imessage:${accountInfo.accountId}:${conversationId}:${sender}`;
     },
     shouldDebounce: (entry) => {
-      const text = entry.message.text?.trim() ?? "";
-      if (!text) {
-        return false;
-      }
-      if (entry.message.attachments && entry.message.attachments.length > 0) {
-        return false;
-      }
-      return !hasControlCommand(text, cfg);
+      return shouldDebounceTextInbound({
+        text: entry.message.text,
+        cfg,
+        hasMedia: Boolean(entry.message.attachments && entry.message.attachments.length > 0),
+      });
     },
     onFlush: async (entries) => {
       const last = entries.at(-1);

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -7,10 +7,6 @@ import {
   resolveEnvelopeFormatOptions,
 } from "../../auto-reply/envelope.js";
 import {
-  createInboundDebouncer,
-  resolveInboundDebounceMs,
-} from "../../auto-reply/inbound-debounce.js";
-import {
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
   recordPendingHistoryEntryIfEnabled,
@@ -19,6 +15,10 @@ import { finalizeInboundContext } from "../../auto-reply/reply/inbound-context.j
 import { buildMentionRegexes, matchesMentionPatterns } from "../../auto-reply/reply/mentions.js";
 import { createReplyDispatcherWithTyping } from "../../auto-reply/reply/reply-dispatcher.js";
 import { resolveControlCommandGate } from "../../channels/command-gating.js";
+import {
+  createChannelInboundDebouncer,
+  shouldDebounceTextInbound,
+} from "../../channels/inbound-debounce-policy.js";
 import { logInboundDrop, logTypingFailure } from "../../channels/logging.js";
 import { resolveMentionGatingWithBypass } from "../../channels/mention-gating.js";
 import { normalizeSignalMessagingTarget } from "../../channels/plugins/normalize/signal.js";
@@ -57,8 +57,6 @@ import type {
 } from "./event-handler.types.js";
 import { renderSignalMentions } from "./mentions.js";
 export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
-  const inboundDebounceMs = resolveInboundDebounceMs({ cfg: deps.cfg, channel: "signal" });
-
   type SignalInboundEntry = {
     senderName: string;
     senderDisplay: string;
@@ -299,8 +297,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     }
   }
 
-  const inboundDebouncer = createInboundDebouncer<SignalInboundEntry>({
-    debounceMs: inboundDebounceMs,
+  const { debouncer: inboundDebouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
+    cfg: deps.cfg,
+    channel: "signal",
     buildKey: (entry) => {
       const conversationId = entry.isGroup ? (entry.groupId ?? "unknown") : entry.senderPeerId;
       if (!conversationId || !entry.senderPeerId) {
@@ -309,13 +308,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       return `signal:${deps.accountId}:${conversationId}:${entry.senderPeerId}`;
     },
     shouldDebounce: (entry) => {
-      if (!entry.bodyText.trim()) {
-        return false;
-      }
-      if (entry.mediaPath || entry.mediaType) {
-        return false;
-      }
-      return !hasControlCommand(entry.bodyText, deps.cfg);
+      return shouldDebounceTextInbound({
+        text: entry.bodyText,
+        cfg: deps.cfg,
+        hasMedia: Boolean(entry.mediaPath || entry.mediaType),
+      });
     },
     onFlush: async (entries) => {
       const last = entries.at(-1);

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -1,8 +1,7 @@
-import { hasControlCommand } from "../../auto-reply/command-detection.js";
 import {
-  createInboundDebouncer,
-  resolveInboundDebounceMs,
-} from "../../auto-reply/inbound-debounce.js";
+  createChannelInboundDebouncer,
+  shouldDebounceTextInbound,
+} from "../../channels/inbound-debounce-policy.js";
 import type { ResolvedSlackAccount } from "../accounts.js";
 import type { SlackMessageEvent } from "../types.js";
 import { stripSlackMentionsForCommandDetection } from "./commands.js";
@@ -44,14 +43,12 @@ function buildTopLevelSlackConversationKey(
 
 function shouldDebounceSlackMessage(message: SlackMessageEvent, cfg: SlackMonitorContext["cfg"]) {
   const text = message.text ?? "";
-  if (!text.trim()) {
-    return false;
-  }
-  if (message.files && message.files.length > 0) {
-    return false;
-  }
   const textForCommandDetection = stripSlackMentionsForCommandDetection(text);
-  return !hasControlCommand(textForCommandDetection, cfg);
+  return shouldDebounceTextInbound({
+    text: textForCommandDetection,
+    cfg,
+    hasMedia: Boolean(message.files && message.files.length > 0),
+  });
 }
 
 /**
@@ -88,15 +85,12 @@ export function createSlackMessageHandler(params: {
   trackEvent?: () => void;
 }): SlackMessageHandler {
   const { ctx, account, trackEvent } = params;
-  const debounceMs = resolveInboundDebounceMs({ cfg: ctx.cfg, channel: "slack" });
-  const threadTsResolver = createSlackThreadTsResolver({ client: ctx.app.client });
-  const pendingTopLevelDebounceKeys = new Map<string, Set<string>>();
-
-  const debouncer = createInboundDebouncer<{
+  const { debounceMs, debouncer } = createChannelInboundDebouncer<{
     message: SlackMessageEvent;
     opts: { source: "message" | "app_mention"; wasMentioned?: boolean };
   }>({
-    debounceMs,
+    cfg: ctx.cfg,
+    channel: "slack",
     buildKey: (entry) => buildSlackDebounceKey(entry.message, ctx.accountId),
     shouldDebounce: (entry) => shouldDebounceSlackMessage(entry.message, ctx.cfg),
     onFlush: async (entries) => {
@@ -156,6 +150,8 @@ export function createSlackMessageHandler(params: {
       ctx.runtime.error?.(`slack inbound debounce flush failed: ${String(err)}`);
     },
   });
+  const threadTsResolver = createSlackThreadTsResolver({ client: ctx.app.client });
+  const pendingTopLevelDebounceKeys = new Map<string, Set<string>>();
 
   return async (message, opts) => {
     if (opts.source === "message" && message.type !== "message") {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,12 +1,12 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
 } from "../auto-reply/inbound-debounce.js";
 import { buildCommandsPaginationKeyboard } from "../auto-reply/reply/commands-info.js";
 import { buildCommandsMessagePaginated } from "../auto-reply/status.js";
+import { shouldDebounceTextInbound } from "../channels/inbound-debounce-policy.js";
 import { resolveChannelConfigWrites } from "../channels/plugins/config-writes.js";
 import { loadConfig } from "../config/config.js";
 import { writeConfigFile } from "../config/io.js";
@@ -185,14 +185,18 @@ export const registerTelegramHandlers = ({
     buildKey: (entry) => entry.debounceKey,
     shouldDebounce: (entry) => {
       const text = entry.msg.text ?? entry.msg.caption ?? "";
-      const hasText = text.trim().length > 0;
-      if (hasText && hasControlCommand(text, cfg, { botUsername: entry.botUsername })) {
+      const hasDebounceableText = shouldDebounceTextInbound({
+        text,
+        cfg,
+        commandOptions: { botUsername: entry.botUsername },
+      });
+      if (!hasDebounceableText) {
         return false;
       }
       if (entry.debounceLane === "forward") {
         return true;
       }
-      return entry.allMedia.length === 0 && hasText;
+      return entry.allMedia.length === 0;
     },
     onFlush: async (entries) => {
       const last = entries.at(-1);


### PR DESCRIPTION
## Cherry-picks from upstream (issue #782)

| Hash | Subject | Result |
|------|---------|--------|
| `47083460e` | refactor: unify inbound debounce policy and split gateway/models helpers | RESOLVED |
| `46df7e242` | fix(feishu): skip typing indicator keepalive re-adds to prevent notification spam | RESOLVED |
| `4e4a10003` | Feishu: honor configured default account | PICKED |
| `118746404` | fix: feishu default account outbound resolution (#32253) | RESOLVED |
| `cdc1ef85e` | Feishu: cache failing probes (#29970) | RESOLVED |
| `3e6451f2d` | refactor(feishu): expose default-account selection source | PICKED |
| `61f29830b` | fix(test): resolve upstream typing drift in feishu and cron suites | PICKED |

Closes #782