### PR TITLE
Cherry-pick issue #783: agents-acp-improvements-gemini

### DIFF
--- a/src/agents/schema/clean-for-gemini.test.ts
+++ b/src/agents/schema/clean-for-gemini.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { cleanSchemaForGemini } from "./clean-for-gemini.js";
+
+describe("cleanSchemaForGemini", () => {
+  it("coerces null properties to an empty object", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: null,
+    }) as { type?: unknown; properties?: unknown };
+
+    expect(cleaned.type).toBe("object");
+    expect(cleaned.properties).toEqual({});
+  });
+
+  it("coerces non-object properties to an empty object", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: "invalid",
+    }) as { properties?: unknown };
+
+    expect(cleaned.properties).toEqual({});
+  });
+
+  it("coerces nested null properties while preserving valid siblings", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: {
+        bad: {
+          type: "object",
+          properties: null,
+        },
+        good: {
+          type: "string",
+        },
+      },
+    }) as {
+      properties?: {
+        bad?: { properties?: unknown };
+        good?: { type?: unknown };
+      };
+    };
+
+    expect(cleaned.properties?.bad?.properties).toEqual({});
+    expect(cleaned.properties?.good?.type).toBe("string");
+  });
+});

--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -304,14 +304,20 @@ function cleanSchemaForGeminiWithDefs(
       continue;
     }
 
-    if (key === "properties" && value && typeof value === "object") {
-      const props = value as Record<string, unknown>;
-      cleaned[key] = Object.fromEntries(
-        Object.entries(props).map(([k, v]) => [
-          k,
-          cleanSchemaForGeminiWithDefs(v, nextDefs, refStack),
-        ]),
-      );
+    if (key === "properties") {
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        const props = value as Record<string, unknown>;
+        cleaned[key] = Object.fromEntries(
+          Object.entries(props).map(([k, v]) => [
+            k,
+            cleanSchemaForGeminiWithDefs(v, nextDefs, refStack),
+          ]),
+        );
+      } else {
+        // Guard malformed schemas (e.g. properties: null) that can trigger
+        // downstream Object.* crashes in strict provider validators.
+        cleaned[key] = {};
+      }
     } else if (key === "items" && value) {
       if (Array.isArray(value)) {
         cleaned[key] = value.map((entry) =>

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -157,6 +157,27 @@ describe("typing controller", () => {
     vi.useRealTimers();
   });
 
+  function createTestTypingController() {
+    const onReplyStart = vi.fn();
+    const typing = createTypingController({
+      onReplyStart,
+      typingIntervalSeconds: 1,
+      typingTtlMs: 30_000,
+    });
+    return { typing, onReplyStart };
+  }
+
+  function markTypingState(
+    typing: ReturnType<typeof createTypingController>,
+    state: "run" | "idle",
+  ) {
+    if (state === "run") {
+      typing.markRunComplete();
+      return;
+    }
+    typing.markDispatchIdle();
+  }
+
   it("stops only after both run completion and dispatcher idle are set (any order)", async () => {
     vi.useFakeTimers();
     const cases = [
@@ -165,12 +186,7 @@ describe("typing controller", () => {
     ] as const;
 
     for (const testCase of cases) {
-      const onReplyStart = vi.fn();
-      const typing = createTypingController({
-        onReplyStart,
-        typingIntervalSeconds: 1,
-        typingTtlMs: 30_000,
-      });
+      const { typing, onReplyStart } = createTestTypingController();
 
       await typing.startTypingLoop();
       expect(onReplyStart, testCase.name).toHaveBeenCalledTimes(1);
@@ -178,19 +194,11 @@ describe("typing controller", () => {
       await vi.advanceTimersByTimeAsync(2_000);
       expect(onReplyStart, testCase.name).toHaveBeenCalledTimes(3);
 
-      if (testCase.first === "run") {
-        typing.markRunComplete();
-      } else {
-        typing.markDispatchIdle();
-      }
+      markTypingState(typing, testCase.first);
       await vi.advanceTimersByTimeAsync(2_000);
       expect(onReplyStart, testCase.name).toHaveBeenCalledTimes(testCase.first === "run" ? 3 : 5);
 
-      if (testCase.second === "run") {
-        typing.markRunComplete();
-      } else {
-        typing.markDispatchIdle();
-      }
+      markTypingState(typing, testCase.second);
       await vi.advanceTimersByTimeAsync(2_000);
       expect(onReplyStart, testCase.name).toHaveBeenCalledTimes(testCase.first === "run" ? 3 : 5);
     }
@@ -198,12 +206,7 @@ describe("typing controller", () => {
 
   it("does not start typing after run completion", async () => {
     vi.useFakeTimers();
-    const onReplyStart = vi.fn();
-    const typing = createTypingController({
-      onReplyStart,
-      typingIntervalSeconds: 1,
-      typingTtlMs: 30_000,
-    });
+    const { typing, onReplyStart } = createTestTypingController();
 
     typing.markRunComplete();
     await typing.startTypingOnText("late text");
@@ -213,12 +216,7 @@ describe("typing controller", () => {
 
   it("does not restart typing after it has stopped", async () => {
     vi.useFakeTimers();
-    const onReplyStart = vi.fn();
-    const typing = createTypingController({
-      onReplyStart,
-      typingIntervalSeconds: 1,
-      typingTtlMs: 30_000,
-    });
+    const { typing, onReplyStart } = createTestTypingController();
 
     await typing.startTypingLoop();
     expect(onReplyStart).toHaveBeenCalledTimes(1);
@@ -358,6 +356,21 @@ describe("parseAudioTag", () => {
 });
 
 describe("resolveResponsePrefixTemplate", () => {
+  function expectResolvedTemplateCases<
+    T extends ReadonlyArray<{
+      name: string;
+      template: string | undefined;
+      values: Parameters<typeof resolveResponsePrefixTemplate>[1];
+      expected: string | undefined;
+    }>,
+  >(cases: T) {
+    for (const testCase of cases) {
+      expect(resolveResponsePrefixTemplate(testCase.template, testCase.values), testCase.name).toBe(
+        testCase.expected,
+      );
+    }
+  }
+
   it("resolves known variables, aliases, and case-insensitive tokens", () => {
     const cases = [
       {
@@ -407,11 +420,7 @@ describe("resolveResponsePrefixTemplate", () => {
         expected: "[RemoteClaw] anthropic/claude-opus-4-5",
       },
     ] as const;
-    for (const testCase of cases) {
-      expect(resolveResponsePrefixTemplate(testCase.template, testCase.values), testCase.name).toBe(
-        testCase.expected,
-      );
-    }
+    expectResolvedTemplateCases(cases);
   });
 
   it("preserves unresolved/unknown placeholders and handles static inputs", () => {
@@ -437,11 +446,7 @@ describe("resolveResponsePrefixTemplate", () => {
         expected: "[gpt-5.2 | {provider}]",
       },
     ] as const;
-    for (const testCase of cases) {
-      expect(resolveResponsePrefixTemplate(testCase.template, testCase.values), testCase.name).toBe(
-        testCase.expected,
-      );
-    }
+    expectResolvedTemplateCases(cases);
   });
 });
 
@@ -543,15 +548,31 @@ describe("block reply coalescer", () => {
     vi.useRealTimers();
   });
 
-  it("coalesces chunks within the idle window", async () => {
-    vi.useFakeTimers();
+  function createBlockCoalescerHarness(config: {
+    minChars: number;
+    maxChars: number;
+    idleMs: number;
+    joiner: string;
+    flushOnEnqueue?: boolean;
+  }) {
     const flushes: string[] = [];
     const coalescer = createBlockReplyCoalescer({
-      config: { minChars: 1, maxChars: 200, idleMs: 100, joiner: " " },
+      config,
       shouldAbort: () => false,
       onFlush: (payload) => {
         flushes.push(payload.text ?? "");
       },
+    });
+    return { flushes, coalescer };
+  }
+
+  it("coalesces chunks within the idle window", async () => {
+    vi.useFakeTimers();
+    const { flushes, coalescer } = createBlockCoalescerHarness({
+      minChars: 1,
+      maxChars: 200,
+      idleMs: 100,
+      joiner: " ",
     });
 
     coalescer.enqueue({ text: "Hello" });
@@ -564,13 +585,11 @@ describe("block reply coalescer", () => {
 
   it("waits until minChars before idle flush", async () => {
     vi.useFakeTimers();
-    const flushes: string[] = [];
-    const coalescer = createBlockReplyCoalescer({
-      config: { minChars: 10, maxChars: 200, idleMs: 50, joiner: " " },
-      shouldAbort: () => false,
-      onFlush: (payload) => {
-        flushes.push(payload.text ?? "");
-      },
+    const { flushes, coalescer } = createBlockCoalescerHarness({
+      minChars: 10,
+      maxChars: 200,
+      idleMs: 50,
+      joiner: " ",
     });
 
     coalescer.enqueue({ text: "short" });
@@ -585,13 +604,11 @@ describe("block reply coalescer", () => {
 
   it("still accumulates when flushOnEnqueue is not set (default)", async () => {
     vi.useFakeTimers();
-    const flushes: string[] = [];
-    const coalescer = createBlockReplyCoalescer({
-      config: { minChars: 1, maxChars: 2000, idleMs: 100, joiner: "\n\n" },
-      shouldAbort: () => false,
-      onFlush: (payload) => {
-        flushes.push(payload.text ?? "");
-      },
+    const { flushes, coalescer } = createBlockCoalescerHarness({
+      minChars: 1,
+      maxChars: 2000,
+      idleMs: 100,
+      joiner: "\n\n",
     });
 
     coalescer.enqueue({ text: "First paragraph" });
@@ -617,14 +634,7 @@ describe("block reply coalescer", () => {
     ] as const;
 
     for (const testCase of cases) {
-      const flushes: string[] = [];
-      const coalescer = createBlockReplyCoalescer({
-        config: testCase.config,
-        shouldAbort: () => false,
-        onFlush: (payload) => {
-          flushes.push(payload.text ?? "");
-        },
-      });
+      const { flushes, coalescer } = createBlockCoalescerHarness(testCase.config);
       for (const input of testCase.inputs) {
         coalescer.enqueue({ text: input });
       }

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { setImmediate as setImmediatePromise } from "node:timers/promises";
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import type { WebSocket } from "ws";
 import type { GuardedFetchOptions } from "../infra/net/fetch-guard.js";
 import {
   connectOk,
@@ -130,6 +131,43 @@ async function setupCronTestRun(params: {
   return { prevSkipCron, dir };
 }
 
+function expectCronJobIdFromResponse(response: { ok?: unknown; payload?: unknown }) {
+  expect(response.ok).toBe(true);
+  const value = (response.payload as { id?: unknown } | null)?.id;
+  const id = typeof value === "string" ? value : "";
+  expect(id.length > 0).toBe(true);
+  return id;
+}
+
+async function addMainSystemEventCronJob(params: { ws: WebSocket; name: string; text?: string }) {
+  const response = await rpcReq(params.ws, "cron.add", {
+    name: params.name,
+    enabled: true,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: params.text ?? "hello" },
+  });
+  return expectCronJobIdFromResponse(response);
+}
+
+function getWebhookCall(index: number) {
+  const [args] = fetchWithSsrFGuardMock.mock.calls[index] as unknown as [
+    {
+      url?: string;
+      init?: {
+        method?: string;
+        headers?: Record<string, string>;
+        body?: string;
+      };
+    },
+  ];
+  const url = args.url ?? "";
+  const init = args.init ?? {};
+  const body = JSON.parse(init.body ?? "{}") as Record<string, unknown>;
+  return { url, init, body };
+}
+
 describe("gateway server cron", () => {
   afterAll(async () => {
     if (!cronSuiteTempRootPromise) {
@@ -215,18 +253,7 @@ describe("gateway server cron", () => {
       expect(wrappedPayload?.wakeMode).toBe("now");
       expect((wrappedPayload?.schedule as { kind?: unknown } | undefined)?.kind).toBe("at");
 
-      const patchRes = await rpcReq(ws, "cron.add", {
-        name: "patch test",
-        enabled: true,
-        schedule: { kind: "every", everyMs: 60_000 },
-        sessionTarget: "main",
-        wakeMode: "next-heartbeat",
-        payload: { kind: "systemEvent", text: "hello" },
-      });
-      expect(patchRes.ok).toBe(true);
-      const patchJobIdValue = (patchRes.payload as { id?: unknown } | null)?.id;
-      const patchJobId = typeof patchJobIdValue === "string" ? patchJobIdValue : "";
-      expect(patchJobId.length > 0).toBe(true);
+      const patchJobId = await addMainSystemEventCronJob({ ws, name: "patch test" });
 
       const atMs = Date.now() + 1_000;
       const updateRes = await rpcReq(ws, "cron.update", {
@@ -344,18 +371,7 @@ describe("gateway server cron", () => {
       expect(legacyDeliveryPatched?.delivery?.to).toBe("+15550001111");
       expect(legacyDeliveryPatched?.delivery?.bestEffort).toBe(true);
 
-      const rejectRes = await rpcReq(ws, "cron.add", {
-        name: "patch reject",
-        enabled: true,
-        schedule: { kind: "every", everyMs: 60_000 },
-        sessionTarget: "main",
-        wakeMode: "next-heartbeat",
-        payload: { kind: "systemEvent", text: "hello" },
-      });
-      expect(rejectRes.ok).toBe(true);
-      const rejectJobIdValue = (rejectRes.payload as { id?: unknown } | null)?.id;
-      const rejectJobId = typeof rejectJobIdValue === "string" ? rejectJobIdValue : "";
-      expect(rejectJobId.length > 0).toBe(true);
+      const rejectJobId = await addMainSystemEventCronJob({ ws, name: "patch reject" });
 
       const rejectUpdateRes = await rpcReq(ws, "cron.update", {
         id: rejectJobId,
@@ -365,18 +381,7 @@ describe("gateway server cron", () => {
       });
       expect(rejectUpdateRes.ok).toBe(false);
 
-      const jobIdRes = await rpcReq(ws, "cron.add", {
-        name: "jobId test",
-        enabled: true,
-        schedule: { kind: "every", everyMs: 60_000 },
-        sessionTarget: "main",
-        wakeMode: "next-heartbeat",
-        payload: { kind: "systemEvent", text: "hello" },
-      });
-      expect(jobIdRes.ok).toBe(true);
-      const jobIdValue = (jobIdRes.payload as { id?: unknown } | null)?.id;
-      const jobId = typeof jobIdValue === "string" ? jobIdValue : "";
-      expect(jobId.length > 0).toBe(true);
+      const jobId = await addMainSystemEventCronJob({ ws, name: "jobId test" });
 
       const jobIdUpdateRes = await rpcReq(ws, "cron.update", {
         jobId,
@@ -387,18 +392,7 @@ describe("gateway server cron", () => {
       });
       expect(jobIdUpdateRes.ok).toBe(true);
 
-      const disableRes = await rpcReq(ws, "cron.add", {
-        name: "disable test",
-        enabled: true,
-        schedule: { kind: "every", everyMs: 60_000 },
-        sessionTarget: "main",
-        wakeMode: "next-heartbeat",
-        payload: { kind: "systemEvent", text: "hello" },
-      });
-      expect(disableRes.ok).toBe(true);
-      const disableJobIdValue = (disableRes.payload as { id?: unknown } | null)?.id;
-      const disableJobId = typeof disableJobIdValue === "string" ? disableJobIdValue : "";
-      expect(disableJobId.length > 0).toBe(true);
+      const disableJobId = await addMainSystemEventCronJob({ ws, name: "disable test" });
 
       const disableUpdateRes = await rpcReq(ws, "cron.update", {
         id: disableJobId,
@@ -601,23 +595,12 @@ describe("gateway server cron", () => {
         () => fetchWithSsrFGuardMock.mock.calls.length === 1,
         CRON_WAIT_TIMEOUT_MS,
       );
-      const [notifyArgs] = fetchWithSsrFGuardMock.mock.calls[0] as unknown as [
-        {
-          url?: string;
-          init?: {
-            method?: string;
-            headers?: Record<string, string>;
-            body?: string;
-          };
-        },
-      ];
-      const notifyUrl = notifyArgs.url ?? "";
-      const notifyInit = notifyArgs.init ?? {};
-      expect(notifyUrl).toBe("https://example.invalid/cron-finished");
-      expect(notifyInit.method).toBe("POST");
-      expect(notifyInit.headers?.Authorization).toBe("Bearer cron-webhook-token");
-      expect(notifyInit.headers?.["Content-Type"]).toBe("application/json");
-      const notifyBody = JSON.parse(notifyInit.body ?? "{}");
+      const notifyCall = getWebhookCall(0);
+      expect(notifyCall.url).toBe("https://example.invalid/cron-finished");
+      expect(notifyCall.init.method).toBe("POST");
+      expect(notifyCall.init.headers?.Authorization).toBe("Bearer cron-webhook-token");
+      expect(notifyCall.init.headers?.["Content-Type"]).toBe("application/json");
+      const notifyBody = notifyCall.body;
       expect(notifyBody.action).toBe("finished");
       expect(notifyBody.jobId).toBe(notifyJobId);
 
@@ -632,22 +615,11 @@ describe("gateway server cron", () => {
         () => fetchWithSsrFGuardMock.mock.calls.length === 2,
         CRON_WAIT_TIMEOUT_MS,
       );
-      const [legacyArgs] = fetchWithSsrFGuardMock.mock.calls[1] as unknown as [
-        {
-          url?: string;
-          init?: {
-            method?: string;
-            headers?: Record<string, string>;
-            body?: string;
-          };
-        },
-      ];
-      const legacyUrl = legacyArgs.url ?? "";
-      const legacyInit = legacyArgs.init ?? {};
-      expect(legacyUrl).toBe("https://legacy.example.invalid/cron-finished");
-      expect(legacyInit.method).toBe("POST");
-      expect(legacyInit.headers?.Authorization).toBe("Bearer cron-webhook-token");
-      const legacyBody = JSON.parse(legacyInit.body ?? "{}");
+      const legacyCall = getWebhookCall(1);
+      expect(legacyCall.url).toBe("https://legacy.example.invalid/cron-finished");
+      expect(legacyCall.init.method).toBe("POST");
+      expect(legacyCall.init.headers?.Authorization).toBe("Bearer cron-webhook-token");
+      const legacyBody = legacyCall.body;
       expect(legacyBody.action).toBe("finished");
       expect(legacyBody.jobId).toBe("legacy-notify-job");
 
@@ -706,18 +678,9 @@ describe("gateway server cron", () => {
         () => fetchWithSsrFGuardMock.mock.calls.length === 1,
         CRON_WAIT_TIMEOUT_MS,
       );
-      const [failureDestArgs] = fetchWithSsrFGuardMock.mock.calls[0] as unknown as [
-        {
-          url?: string;
-          init?: {
-            method?: string;
-            headers?: Record<string, string>;
-            body?: string;
-          };
-        },
-      ];
-      expect(failureDestArgs.url).toBe("https://example.invalid/failure-destination");
-      const failureDestBody = JSON.parse(failureDestArgs.init?.body ?? "{}");
+      const failureDestCall = getWebhookCall(0);
+      expect(failureDestCall.url).toBe("https://example.invalid/failure-destination");
+      const failureDestBody = failureDestCall.body;
       expect(failureDestBody.message).toBe(
         'Cron job "failure destination webhook" failed: unknown error',
       );

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -83,6 +83,10 @@ const whatsappChunkConfig: RemoteClawConfig = {
   channels: { whatsapp: { textChunkLimit: 4000 } },
 };
 
+type DeliverOutboundArgs = Parameters<typeof deliverOutboundPayloads>[0];
+type DeliverOutboundPayload = DeliverOutboundArgs["payloads"][number];
+type DeliverSession = DeliverOutboundArgs["session"];
+
 async function deliverWhatsAppPayload(params: {
   sendWhatsApp: NonNullable<
     NonNullable<Parameters<typeof deliverOutboundPayloads>[0]["deps"]>["sendWhatsApp"]
@@ -96,6 +100,24 @@ async function deliverWhatsAppPayload(params: {
     to: "+1555",
     payloads: [params.payload],
     deps: { sendWhatsApp: params.sendWhatsApp },
+  });
+}
+
+async function deliverTelegramPayload(params: {
+  sendTelegram: NonNullable<NonNullable<DeliverOutboundArgs["deps"]>["sendTelegram"]>;
+  payload: DeliverOutboundPayload;
+  cfg?: RemoteClawConfig;
+  accountId?: string;
+  session?: DeliverSession;
+}) {
+  return deliverOutboundPayloads({
+    cfg: params.cfg ?? telegramChunkConfig,
+    channel: "telegram",
+    to: "123",
+    payloads: [params.payload],
+    deps: { sendTelegram: params.sendTelegram },
+    ...(params.accountId ? { accountId: params.accountId } : {}),
+    ...(params.session ? { session: params.session } : {}),
   });
 }
 
@@ -129,6 +151,42 @@ async function deliverSingleWhatsAppForHookTest(params?: { sessionKey?: string }
     payloads: [{ text: "hello" }],
     deps: { sendWhatsApp },
     ...(params?.sessionKey ? { session: { key: params.sessionKey } } : {}),
+  });
+}
+
+async function runBestEffortPartialFailureDelivery() {
+  const sendWhatsApp = vi
+    .fn()
+    .mockRejectedValueOnce(new Error("fail"))
+    .mockResolvedValueOnce({ messageId: "w2", toJid: "jid" });
+  const onError = vi.fn();
+  const cfg: RemoteClawConfig = {};
+  const results = await deliverOutboundPayloads({
+    cfg,
+    channel: "whatsapp",
+    to: "+1555",
+    payloads: [{ text: "a" }, { text: "b" }],
+    deps: { sendWhatsApp },
+    bestEffort: true,
+    onError,
+  });
+  return { sendWhatsApp, onError, results };
+}
+
+function expectSuccessfulWhatsAppInternalHookPayload(
+  expected: Partial<{
+    content: string;
+    messageId: string;
+    isGroup: boolean;
+    groupId: string;
+  }>,
+) {
+  return expect.objectContaining({
+    to: "+1555",
+    success: true,
+    channelId: "whatsapp",
+    conversationId: "+1555",
+    ...expected,
   });
 }
 
@@ -221,13 +279,10 @@ describe("deliverOutboundPayloads", () => {
   it("passes explicit accountId to sendTelegram", async () => {
     const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "c1" });
 
-    await deliverOutboundPayloads({
-      cfg: telegramChunkConfig,
-      channel: "telegram",
-      to: "123",
+    await deliverTelegramPayload({
+      sendTelegram,
       accountId: "default",
-      payloads: [{ text: "hi" }],
-      deps: { sendTelegram },
+      payload: { text: "hi" },
     });
 
     expect(sendTelegram).toHaveBeenCalledWith(
@@ -240,17 +295,12 @@ describe("deliverOutboundPayloads", () => {
   it("preserves HTML text for telegram sendPayload channelData path", async () => {
     const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "c1" });
 
-    await deliverOutboundPayloads({
-      cfg: telegramChunkConfig,
-      channel: "telegram",
-      to: "123",
-      payloads: [
-        {
-          text: "<b>hello</b>",
-          channelData: { telegram: { buttons: [] } },
-        },
-      ],
-      deps: { sendTelegram },
+    await deliverTelegramPayload({
+      sendTelegram,
+      payload: {
+        text: "<b>hello</b>",
+        channelData: { telegram: { buttons: [] } },
+      },
     });
 
     expect(sendTelegram).toHaveBeenCalledTimes(1);
@@ -264,13 +314,10 @@ describe("deliverOutboundPayloads", () => {
   it("scopes media local roots to the active agent workspace when agentId is provided", async () => {
     const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "c1" });
 
-    await deliverOutboundPayloads({
-      cfg: telegramChunkConfig,
-      channel: "telegram",
-      to: "123",
+    await deliverTelegramPayload({
+      sendTelegram,
       session: { agentId: "work" },
-      payloads: [{ text: "hi", mediaUrl: "file:///tmp/f.png" }],
-      deps: { sendTelegram },
+      payload: { text: "hi", mediaUrl: "file:///tmp/f.png" },
     });
 
     expect(sendTelegram).toHaveBeenCalledWith(
@@ -286,12 +333,9 @@ describe("deliverOutboundPayloads", () => {
   it("includes RemoteClaw tmp root in telegram mediaLocalRoots", async () => {
     const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "c1" });
 
-    await deliverOutboundPayloads({
-      cfg: telegramChunkConfig,
-      channel: "telegram",
-      to: "123",
-      payloads: [{ text: "hi", mediaUrl: "https://example.com/x.png" }],
-      deps: { sendTelegram },
+    await deliverTelegramPayload({
+      sendTelegram,
+      payload: { text: "hi", mediaUrl: "https://example.com/x.png" },
     });
 
     expect(sendTelegram).toHaveBeenCalledWith(
@@ -617,22 +661,7 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("continues on errors when bestEffort is enabled", async () => {
-    const sendWhatsApp = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("fail"))
-      .mockResolvedValueOnce({ messageId: "w2", toJid: "jid" });
-    const onError = vi.fn();
-    const cfg: RemoteClawConfig = {};
-
-    const results = await deliverOutboundPayloads({
-      cfg,
-      channel: "whatsapp",
-      to: "+1555",
-      payloads: [{ text: "a" }, { text: "b" }],
-      deps: { sendWhatsApp },
-      bestEffort: true,
-      onError,
-    });
+    const { sendWhatsApp, onError, results } = await runBestEffortPartialFailureDelivery();
 
     expect(sendWhatsApp).toHaveBeenCalledTimes(2);
     expect(onError).toHaveBeenCalledTimes(1);
@@ -654,12 +683,8 @@ describe("deliverOutboundPayloads", () => {
       "message",
       "sent",
       "agent:main:main",
-      expect.objectContaining({
-        to: "+1555",
+      expectSuccessfulWhatsAppInternalHookPayload({
         content: "abcd",
-        success: true,
-        channelId: "whatsapp",
-        conversationId: "+1555",
         messageId: "w2",
         isGroup: true,
         groupId: "whatsapp:group:123",
@@ -683,14 +708,7 @@ describe("deliverOutboundPayloads", () => {
       "message",
       "sent",
       "agent:main:main",
-      expect.objectContaining({
-        to: "+1555",
-        content: "hello",
-        success: true,
-        channelId: "whatsapp",
-        conversationId: "+1555",
-        messageId: "w1",
-      }),
+      expectSuccessfulWhatsAppInternalHookPayload({ content: "hello", messageId: "w1" }),
     );
     expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
   });
@@ -720,22 +738,7 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("calls failDelivery instead of ackDelivery on bestEffort partial failure", async () => {
-    const sendWhatsApp = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("fail"))
-      .mockResolvedValueOnce({ messageId: "w2", toJid: "jid" });
-    const onError = vi.fn();
-    const cfg: RemoteClawConfig = {};
-
-    await deliverOutboundPayloads({
-      cfg,
-      channel: "whatsapp",
-      to: "+1555",
-      payloads: [{ text: "a" }, { text: "b" }],
-      deps: { sendWhatsApp },
-      bestEffort: true,
-      onError,
-    });
+    const { onError } = await runBestEffortPartialFailureDelivery();
 
     // onError was called for the first payload's failure.
     expect(onError).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Cherry-picks from upstream (issue #783)

**Picked (2/6)**:
- `1a7a18d0b` fix(agents): guard gemini tool schema properties against null — clean pick
- `a48a3dbdd` refactor(tests): dedupe tool, projector, and delivery fixtures — partial pick, adapted for fork

**Skipped (4/6)**:
- `980388fcf` plugin-sdk: expose onAgentEvent + onSessionTranscriptUpdate — fork already has this via `createRuntimeEvents()`
- `bf6aa7ca6` fix(agents): treat host edit tool as success — only touches gutted `pi-tools.read.ts`
- `0fb3f188b` fix(agents): only recover edit when oldText no longer in file — only touches gutted `pi-tools.read.ts`
- `287606e44` feat(acp): add kimi harness support surfaces — all files DU (prerequisite source absent in fork)

See issue #783 for full commit list and triage details.