### PR TITLE
Cherry-pick issue #784: docs & UI fixes (moonshot, GFM tables, inline code)

### DIFF
--- a/src/sessions/transcript-events.ts
+++ b/src/sessions/transcript-events.ts
@@ -10,6 +10,9 @@ const SESSION_TRANSCRIPT_LISTENERS = new Set<SessionTranscriptListener>();
  * Register a listener for session transcript updates.
  * Returns an unsubscribe function. Listeners are guarded with try/catch
  * so a throwing subscriber cannot prevent other listeners from firing.
+ *
+ * @param listener - Callback invoked with the updated session file path.
+ * @returns Unsubscribe function; call it to remove the listener.
  */
 export function onSessionTranscriptUpdate(listener: SessionTranscriptListener): () => void {
   SESSION_TRANSCRIPT_LISTENERS.add(listener);

--- a/src/sessions/transcript-events.ts
+++ b/src/sessions/transcript-events.ts
@@ -6,6 +6,11 @@ type SessionTranscriptListener = (update: SessionTranscriptUpdate) => void;
 
 const SESSION_TRANSCRIPT_LISTENERS = new Set<SessionTranscriptListener>();
 
+/**
+ * Register a listener for session transcript updates.
+ * Returns an unsubscribe function. Listeners are guarded with try/catch
+ * so a throwing subscriber cannot prevent other listeners from firing.
+ */
 export function onSessionTranscriptUpdate(listener: SessionTranscriptListener): () => void {
   SESSION_TRANSCRIPT_LISTENERS.add(listener);
   return () => {

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -81,6 +81,8 @@
   background: rgba(0, 0, 0, 0.15);
   padding: 0.15em 0.4em;
   border-radius: 4px;
+  overflow-wrap: normal;
+  word-break: keep-all;
 }
 
 .chat-text :where(pre) {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1890,6 +1890,8 @@
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--secondary);
+  overflow-wrap: normal;
+  word-break: keep-all;
 }
 
 :root[data-theme="light"] .chat-text :where(:not(pre) > code) {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1918,7 +1918,10 @@
   margin-top: 0.75em;
   border-collapse: collapse;
   width: 100%;
+  max-width: 100%;
   font-size: 13px;
+  display: block;
+  overflow-x: auto;
 }
 
 .chat-text :where(th, td) {

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -48,4 +48,38 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).not.toContain("javascript:");
     expect(html).not.toContain("src=");
   });
+
+  it("renders GFM markdown tables (#20410)", () => {
+    const md = [
+      "| Feature | Status |",
+      "|---------|--------|",
+      "| Tables  | ✅     |",
+      "| Borders | ✅     |",
+    ].join("\n");
+    const html = toSanitizedMarkdownHtml(md);
+    expect(html).toContain("<table");
+    expect(html).toContain("<thead");
+    expect(html).toContain("<th>");
+    expect(html).toContain("Feature");
+    expect(html).toContain("Tables");
+    expect(html).not.toContain("|---------|");
+  });
+
+  it("renders GFM tables surrounded by text (#20410)", () => {
+    const md = [
+      "Text before.",
+      "",
+      "| Col1 | Col2 |",
+      "|------|------|",
+      "| A    | B    |",
+      "",
+      "Text after.",
+    ].join("\n");
+    const html = toSanitizedMarkdownHtml(md);
+    expect(html).toContain("<table");
+    expect(html).toContain("Col1");
+    expect(html).toContain("Col2");
+    // Pipes from table delimiters must not appear as raw text
+    expect(html).not.toContain("|------|");
+  });
 });

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -112,6 +112,8 @@ export function toSanitizedMarkdownHtml(markdown: string): string {
   }
   const rendered = marked.parse(`${truncated.text}${suffix}`, {
     renderer: htmlEscapeRenderer,
+    gfm: true,
+    breaks: true,
   }) as string;
   const sanitized = DOMPurify.sanitize(rendered, sanitizeOptions);
   if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {


### PR DESCRIPTION
## Cherry-picks from upstream (issue #784)

See issue #784 for full commit list and triage details.

**Picked (4):**
- `2365c6c86` docs: add JSDoc to onSessionTranscriptUpdate
- `bab5d994b` docs: expand JSDoc for onSessionTranscriptUpdate params and return
- `5084621f4` fix(ui): ensure GFM tables render in WebChat markdown (#20410)
- `7c90ef7c5` fix(webui): prevent inline code from breaking mid-token on copy/paste

**Skipped (2):**
- `42626648d` docs(models): clarify moonshot thinking and failover stop-reason errors — all touched files deleted in fork (DU)
- `5ee6ca13b` docs(changelog): add landed notes for #32336 and #32364 — CHANGELOG.md deleted in fork (DU)