### PR TITLE
Cherry-pick issue #789: CI infrastructure, Windows, Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -51,6 +51,10 @@ vendor/
 # Keep the rest of apps/ and vendor/ excluded to avoid a large build context.
 !apps/shared/
 !apps/shared/OpenClawKit/
+!apps/shared/OpenClawKit/Sources/
+!apps/shared/OpenClawKit/Sources/OpenClawKit/
+!apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/
+!apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
 !apps/shared/OpenClawKit/Tools/
 !apps/shared/OpenClawKit/Tools/CanvasA2UI/
 !apps/shared/OpenClawKit/Tools/CanvasA2UI/**

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: Whether to install Bun alongside Node.
     required: false
     default: "true"
+  use-sticky-disk:
+    description: Use Blacksmith sticky disks for pnpm store caching.
+    required: false
+    default: "false"
   frozen-lockfile:
     description: Whether to use --frozen-lockfile for install.
     required: false
@@ -47,6 +51,7 @@ runs:
       with:
         pnpm-version: ${{ inputs.pnpm-version }}
         cache-key-suffix: "node22"
+        use-sticky-disk: ${{ inputs.use-sticky-disk }}
 
     - name: Setup Bun
       if: inputs.install-bun == 'true'

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -1,7 +1,7 @@
 name: Setup Node environment
 description: >
   Initialize submodules with retry, install Node 22, pnpm, optionally Bun,
-  and run pnpm install. Requires actions/checkout to run first.
+  and optionally run pnpm install. Requires actions/checkout to run first.
 inputs:
   node-version:
     description: Node.js version to install.
@@ -19,6 +19,10 @@ inputs:
     description: Use Blacksmith sticky disks for pnpm store caching.
     required: false
     default: "false"
+  install-deps:
+    description: Whether to run pnpm install after environment setup.
+    required: false
+    default: "true"
   frozen-lockfile:
     description: Whether to use --frozen-lockfile for install.
     required: false
@@ -44,7 +48,7 @@ runs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ inputs.node-version }}
-        check-latest: true
+        check-latest: false
 
     - name: Setup pnpm + cache store
       uses: ./.github/actions/setup-pnpm-store-cache
@@ -68,10 +72,12 @@ runs:
         if command -v bun &>/dev/null; then bun -v; fi
 
     - name: Capture node path
+      if: inputs.install-deps == 'true'
       shell: bash
       run: echo "NODE_BIN=$(dirname "$(node -p "process.execPath")")" >> "$GITHUB_ENV"
 
     - name: Install dependencies
+      if: inputs.install-deps == 'true'
       shell: bash
       env:
         CI: "true"

--- a/.github/actions/setup-pnpm-store-cache/action.yml
+++ b/.github/actions/setup-pnpm-store-cache/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Suffix appended to the cache key.
     required: false
     default: "node22"
+  use-sticky-disk:
+    description: Use Blacksmith sticky disks instead of actions/cache for pnpm store.
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
@@ -38,7 +42,15 @@ runs:
       shell: bash
       run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
+    - name: Mount pnpm store sticky disk
+      if: inputs.use-sticky-disk == 'true'
+      uses: useblacksmith/stickydisk@v1
+      with:
+        key: ${{ github.repository }}-pnpm-store-${{ runner.os }}-${{ inputs.cache-key-suffix }}
+        path: ${{ steps.pnpm-store.outputs.path }}
+
     - name: Restore pnpm store cache
+      if: inputs.use-sticky-disk != 'true'
       uses: actions/cache@v4
       with:
         path: ${{ steps.pnpm-store.outputs.path }}

--- a/.github/actions/setup-pnpm-store-cache/action.yml
+++ b/.github/actions/setup-pnpm-store-cache/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: Use Blacksmith sticky disks instead of actions/cache for pnpm store.
     required: false
     default: "false"
+  use-restore-keys:
+    description: Whether to use restore-keys fallback for actions/cache.
+    required: false
+    default: "true"
 runs:
   using: composite
   steps:
@@ -49,8 +53,15 @@ runs:
         key: ${{ github.repository }}-pnpm-store-${{ runner.os }}-${{ inputs.cache-key-suffix }}
         path: ${{ steps.pnpm-store.outputs.path }}
 
-    - name: Restore pnpm store cache
-      if: inputs.use-sticky-disk != 'true'
+    - name: Restore pnpm store cache (exact key only)
+      if: inputs.use-sticky-disk != 'true' && inputs.use-restore-keys != 'true'
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: ${{ runner.os }}-pnpm-store-${{ inputs.cache-key-suffix }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+    - name: Restore pnpm store cache (with fallback keys)
+      if: inputs.use-sticky-disk != 'true' && inputs.use-restore-keys == 'true'
       uses: actions/cache@v4
       with:
         path: ${{ steps.pnpm-store.outputs.path }}

--- a/.github/actions/setup-pnpm-store-cache/action.yml
+++ b/.github/actions/setup-pnpm-store-cache/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: Whether to use restore-keys fallback for actions/cache.
     required: false
     default: "true"
+  use-actions-cache:
+    description: Whether to restore/save pnpm store with actions/cache.
+    required: false
+    default: "true"
 runs:
   using: composite
   steps:
@@ -54,14 +58,14 @@ runs:
         path: ${{ steps.pnpm-store.outputs.path }}
 
     - name: Restore pnpm store cache (exact key only)
-      if: inputs.use-sticky-disk != 'true' && inputs.use-restore-keys != 'true'
+      if: inputs.use-actions-cache == 'true' && inputs.use-sticky-disk != 'true' && inputs.use-restore-keys != 'true'
       uses: actions/cache@v4
       with:
         path: ${{ steps.pnpm-store.outputs.path }}
         key: ${{ runner.os }}-pnpm-store-${{ inputs.cache-key-suffix }}-${{ hashFiles('pnpm-lock.yaml') }}
 
     - name: Restore pnpm store cache (with fallback keys)
-      if: inputs.use-sticky-disk != 'true' && inputs.use-restore-keys == 'true'
+      if: inputs.use-actions-cache == 'true' && inputs.use-sticky-disk != 'true' && inputs.use-restore-keys == 'true'
       uses: actions/cache@v4
       with:
         path: ${{ steps.pnpm-store.outputs.path }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN if [ -n "$REMOTECLAW_INSTALL_DOCKER_CLI" ]; then \
       # Update REMOTECLAW_DOCKER_GPG_FINGERPRINT when Docker rotates release keys.
       curl -fsSL https://download.docker.com/linux/debian/gpg -o /tmp/docker.gpg.asc && \
       expected_fingerprint="$(printf '%s' "$REMOTECLAW_DOCKER_GPG_FINGERPRINT" | tr '[:lower:]' '[:upper:]' | tr -d '[:space:]')" && \
-      actual_fingerprint="$(gpg --batch --show-keys --with-colons /tmp/docker.gpg.asc | awk -F: '$1 == \"fpr\" { print toupper($10); exit }')" && \
+      actual_fingerprint="$(gpg --batch --show-keys --with-colons /tmp/docker.gpg.asc | awk -F: '$1 == "fpr" { print toupper($10); exit }')" && \
       if [ -z "$actual_fingerprint" ] || [ "$actual_fingerprint" != "$expected_fingerprint" ]; then \
         echo "ERROR: Docker apt key fingerprint mismatch (expected $expected_fingerprint, got ${actual_fingerprint:-<empty>})" >&2; \
         exit 1; \

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -35,6 +35,8 @@ Jobs are ordered so cheap checks fail before expensive ones run:
 2. `build-artifacts` (blocked on above)
 3. `checks`, `checks-windows`, `macos`, `android` (blocked on build)
 
+Scope logic lives in `scripts/ci-changed-scope.mjs` and is covered by unit tests in `src/scripts/ci-changed-scope.test.ts`.
+
 ## Runners
 
 | Runner                           | Jobs                                       |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -42,7 +42,7 @@ Scope logic lives in `scripts/ci-changed-scope.mjs` and is covered by unit tests
 | Runner                           | Jobs                                       |
 | -------------------------------- | ------------------------------------------ |
 | `blacksmith-16vcpu-ubuntu-2404`  | Most Linux jobs, including scope detection |
-| `blacksmith-16vcpu-windows-2025` | `checks-windows`                           |
+| `blacksmith-32vcpu-windows-2025` | `checks-windows`                           |
 | `macos-latest`                   | `macos`, `ios`                             |
 
 ## Local Equivalents

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -12,20 +12,20 @@ The CI runs on every push to `main` and every pull request. It uses smart scopin
 
 ## Job Overview
 
-| Job               | Purpose                                         | When it runs                                      |
-| ----------------- | ----------------------------------------------- | ------------------------------------------------- |
-| `docs-scope`      | Detect docs-only changes                        | Always                                            |
-| `changed-scope`   | Detect which areas changed (node/macos/android) | Non-docs PRs                                      |
-| `check`           | TypeScript types, lint, format                  | Push to `main`, or PRs with Node-relevant changes |
-| `check-docs`      | Markdown lint + broken link check               | Docs changed                                      |
-| `code-analysis`   | LOC threshold check (1000 lines)                | PRs only                                          |
-| `secrets`         | Detect leaked secrets                           | Always                                            |
-| `build-artifacts` | Build dist once, share with other jobs          | Non-docs, node changes                            |
-| `release-check`   | Validate npm pack contents                      | After build                                       |
-| `checks`          | Node/Bun tests + protocol check                 | Non-docs, node changes                            |
-| `checks-windows`  | Windows-specific tests                          | Non-docs, node changes                            |
-| `macos`           | Swift lint/build/test + TS tests                | PRs with macos changes                            |
-| `android`         | Gradle build + tests                            | Non-docs, android changes                         |
+| Job               | Purpose                                                 | When it runs                                      |
+| ----------------- | ------------------------------------------------------- | ------------------------------------------------- |
+| `docs-scope`      | Detect docs-only changes                                | Always                                            |
+| `changed-scope`   | Detect which areas changed (node/macos/android/windows) | Non-docs PRs                                      |
+| `check`           | TypeScript types, lint, format                          | Push to `main`, or PRs with Node-relevant changes |
+| `check-docs`      | Markdown lint + broken link check                       | Docs changed                                      |
+| `code-analysis`   | LOC threshold check (1000 lines)                        | PRs only                                          |
+| `secrets`         | Detect leaked secrets                                   | Always                                            |
+| `build-artifacts` | Build dist once, share with other jobs                  | Non-docs, node changes                            |
+| `release-check`   | Validate npm pack contents                              | After build                                       |
+| `checks`          | Node/Bun tests + protocol check                         | Non-docs, node changes                            |
+| `checks-windows`  | Windows-specific tests                                  | Non-docs, windows-relevant changes                |
+| `macos`           | Swift lint/build/test + TS tests                        | PRs with macos changes                            |
+| `android`         | Gradle build + tests                                    | Non-docs, android changes                         |
 
 ## Fail-Fast Order
 

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 
 /** @typedef {{ runNode: boolean; runMacos: boolean; runAndroid: boolean; runWindows: boolean }} ChangedScope */
@@ -80,7 +80,7 @@ export function listChangedPaths(base, head = "HEAD") {
   if (!base) {
     return [];
   }
-  const output = execSync(`git diff --name-only ${base} ${head}`, {
+  const output = execFileSync("git", ["diff", "--name-only", base, head], {
     stdio: ["ignore", "pipe", "pipe"],
     encoding: "utf8",
   });

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 
-/** @typedef {{ runNode: boolean; runMacos: boolean; runAndroid: boolean }} ChangedScope */
+/** @typedef {{ runNode: boolean; runMacos: boolean; runAndroid: boolean; runWindows: boolean }} ChangedScope */
 
 const DOCS_PATH_RE = /^(docs\/|.*\.mdx?$)/;
 const MACOS_PROTOCOL_GEN_RE =
@@ -10,6 +10,8 @@ const MACOS_NATIVE_RE = /^(apps\/macos\/|apps\/ios\/|apps\/shared\/|Swabble\/)/;
 const ANDROID_NATIVE_RE = /^(apps\/android\/|apps\/shared\/)/;
 const NODE_SCOPE_RE =
   /^(src\/|test\/|extensions\/|packages\/|scripts\/|ui\/|\.github\/|openclaw\.mjs$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig.*\.json$|vitest.*\.ts$|tsdown\.config\.ts$|\.oxlintrc\.json$|\.oxfmtrc\.jsonc$)/;
+const WINDOWS_SCOPE_RE =
+  /^(src\/|test\/|extensions\/|packages\/|scripts\/|ui\/|openclaw\.mjs$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig.*\.json$|vitest.*\.ts$|tsdown\.config\.ts$|\.github\/workflows\/ci\.yml$|\.github\/actions\/setup-node-env\/action\.yml$|\.github\/actions\/setup-pnpm-store-cache\/action\.yml$)/;
 const NATIVE_ONLY_RE =
   /^(apps\/android\/|apps\/ios\/|apps\/macos\/|apps\/shared\/|Swabble\/|appcast\.xml$)/;
 
@@ -19,12 +21,13 @@ const NATIVE_ONLY_RE =
  */
 export function detectChangedScope(changedPaths) {
   if (!Array.isArray(changedPaths) || changedPaths.length === 0) {
-    return { runNode: true, runMacos: true, runAndroid: true };
+    return { runNode: true, runMacos: true, runAndroid: true, runWindows: true };
   }
 
   let runNode = false;
   let runMacos = false;
   let runAndroid = false;
+  let runWindows = false;
   let hasNonDocs = false;
   let hasNonNativeNonDocs = false;
 
@@ -52,6 +55,10 @@ export function detectChangedScope(changedPaths) {
       runNode = true;
     }
 
+    if (WINDOWS_SCOPE_RE.test(path)) {
+      runWindows = true;
+    }
+
     if (!NATIVE_ONLY_RE.test(path)) {
       hasNonNativeNonDocs = true;
     }
@@ -61,7 +68,7 @@ export function detectChangedScope(changedPaths) {
     runNode = true;
   }
 
-  return { runNode, runMacos, runAndroid };
+  return { runNode, runMacos, runAndroid, runWindows };
 }
 
 /**
@@ -94,6 +101,7 @@ export function writeGitHubOutput(scope, outputPath = process.env.GITHUB_OUTPUT)
   appendFileSync(outputPath, `run_node=${scope.runNode}\n`, "utf8");
   appendFileSync(outputPath, `run_macos=${scope.runMacos}\n`, "utf8");
   appendFileSync(outputPath, `run_android=${scope.runAndroid}\n`, "utf8");
+  appendFileSync(outputPath, `run_windows=${scope.runWindows}\n`, "utf8");
 }
 
 function isDirectRun() {
@@ -123,11 +131,11 @@ if (isDirectRun()) {
   try {
     const changedPaths = listChangedPaths(args.base, args.head);
     if (changedPaths.length === 0) {
-      writeGitHubOutput({ runNode: true, runMacos: true, runAndroid: true });
+      writeGitHubOutput({ runNode: true, runMacos: true, runAndroid: true, runWindows: true });
       process.exit(0);
     }
     writeGitHubOutput(detectChangedScope(changedPaths));
   } catch {
-    writeGitHubOutput({ runNode: true, runMacos: true, runAndroid: true });
+    writeGitHubOutput({ runNode: true, runMacos: true, runAndroid: true, runWindows: true });
   }
 }

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -1,0 +1,133 @@
+import { execSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+
+/** @typedef {{ runNode: boolean; runMacos: boolean; runAndroid: boolean }} ChangedScope */
+
+const DOCS_PATH_RE = /^(docs\/|.*\.mdx?$)/;
+const MACOS_PROTOCOL_GEN_RE =
+  /^(apps\/macos\/Sources\/OpenClawProtocol\/|apps\/shared\/OpenClawKit\/Sources\/OpenClawProtocol\/)/;
+const MACOS_NATIVE_RE = /^(apps\/macos\/|apps\/ios\/|apps\/shared\/|Swabble\/)/;
+const ANDROID_NATIVE_RE = /^(apps\/android\/|apps\/shared\/)/;
+const NODE_SCOPE_RE =
+  /^(src\/|test\/|extensions\/|packages\/|scripts\/|ui\/|\.github\/|openclaw\.mjs$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig.*\.json$|vitest.*\.ts$|tsdown\.config\.ts$|\.oxlintrc\.json$|\.oxfmtrc\.jsonc$)/;
+const NATIVE_ONLY_RE =
+  /^(apps\/android\/|apps\/ios\/|apps\/macos\/|apps\/shared\/|Swabble\/|appcast\.xml$)/;
+
+/**
+ * @param {string[]} changedPaths
+ * @returns {ChangedScope}
+ */
+export function detectChangedScope(changedPaths) {
+  if (!Array.isArray(changedPaths) || changedPaths.length === 0) {
+    return { runNode: true, runMacos: true, runAndroid: true };
+  }
+
+  let runNode = false;
+  let runMacos = false;
+  let runAndroid = false;
+  let hasNonDocs = false;
+  let hasNonNativeNonDocs = false;
+
+  for (const rawPath of changedPaths) {
+    const path = String(rawPath).trim();
+    if (!path) {
+      continue;
+    }
+
+    if (DOCS_PATH_RE.test(path)) {
+      continue;
+    }
+
+    hasNonDocs = true;
+
+    if (!MACOS_PROTOCOL_GEN_RE.test(path) && MACOS_NATIVE_RE.test(path)) {
+      runMacos = true;
+    }
+
+    if (ANDROID_NATIVE_RE.test(path)) {
+      runAndroid = true;
+    }
+
+    if (NODE_SCOPE_RE.test(path)) {
+      runNode = true;
+    }
+
+    if (!NATIVE_ONLY_RE.test(path)) {
+      hasNonNativeNonDocs = true;
+    }
+  }
+
+  if (!runNode && hasNonDocs && hasNonNativeNonDocs) {
+    runNode = true;
+  }
+
+  return { runNode, runMacos, runAndroid };
+}
+
+/**
+ * @param {string} base
+ * @param {string} [head]
+ * @returns {string[]}
+ */
+export function listChangedPaths(base, head = "HEAD") {
+  if (!base) {
+    return [];
+  }
+  const output = execSync(`git diff --name-only ${base} ${head}`, {
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  });
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * @param {ChangedScope} scope
+ * @param {string} [outputPath]
+ */
+export function writeGitHubOutput(scope, outputPath = process.env.GITHUB_OUTPUT) {
+  if (!outputPath) {
+    throw new Error("GITHUB_OUTPUT is required");
+  }
+  appendFileSync(outputPath, `run_node=${scope.runNode}\n`, "utf8");
+  appendFileSync(outputPath, `run_macos=${scope.runMacos}\n`, "utf8");
+  appendFileSync(outputPath, `run_android=${scope.runAndroid}\n`, "utf8");
+}
+
+function isDirectRun() {
+  const direct = process.argv[1];
+  return Boolean(direct && import.meta.url.endsWith(direct));
+}
+
+/** @param {string[]} argv */
+function parseArgs(argv) {
+  const args = { base: "", head: "HEAD" };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--base") {
+      args.base = argv[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+    if (argv[i] === "--head") {
+      args.head = argv[i + 1] ?? "HEAD";
+      i += 1;
+    }
+  }
+  return args;
+}
+
+if (isDirectRun()) {
+  const args = parseArgs(process.argv.slice(2));
+  try {
+    const changedPaths = listChangedPaths(args.base, args.head);
+    if (changedPaths.length === 0) {
+      writeGitHubOutput({ runNode: true, runMacos: true, runAndroid: true });
+      process.exit(0);
+    }
+    writeGitHubOutput(detectChangedScope(changedPaths));
+  } catch {
+    writeGitHubOutput({ runNode: true, runMacos: true, runAndroid: true });
+  }
+}

--- a/scripts/e2e/Dockerfile
+++ b/scripts/e2e/Dockerfile
@@ -16,6 +16,7 @@ COPY patches ./patches
 COPY ui ./ui
 COPY extensions/memory-core ./extensions/memory-core
 COPY vendor/a2ui/renderers/lit ./vendor/a2ui/renderers/lit
+COPY apps/shared/RemoteClawKit/Sources/RemoteClawKit/Resources ./apps/shared/RemoteClawKit/Sources/RemoteClawKit/Resources
 COPY apps/shared/RemoteClawKit/Tools/CanvasA2UI ./apps/shared/RemoteClawKit/Tools/CanvasA2UI
 
 RUN pnpm install --frozen-lockfile

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -27,4 +27,10 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain('find "$dir" -type d -exec chmod 755 {} +');
     expect(dockerfile).toContain('find "$dir" -type f -exec chmod 644 {} +');
   });
+
+  it("Docker GPG fingerprint awk uses correct quoting for OPENCLAW_SANDBOX=1 build", async () => {
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+    expect(dockerfile).toContain('== "fpr" {');
+    expect(dockerfile).not.toContain('\\"fpr\\"');
+  });
 });

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { detectChangedScope } from "../../scripts/ci-changed-scope.mjs";
+
+describe("detectChangedScope", () => {
+  it("fails safe when no paths are provided", () => {
+    expect(detectChangedScope([])).toEqual({
+      runNode: true,
+      runMacos: true,
+      runAndroid: true,
+    });
+  });
+
+  it("keeps all lanes off for docs-only changes", () => {
+    expect(detectChangedScope(["docs/ci.md", "README.md"])).toEqual({
+      runNode: false,
+      runMacos: false,
+      runAndroid: false,
+    });
+  });
+
+  it("enables node lane for node-relevant files", () => {
+    expect(detectChangedScope(["src/plugins/runtime/index.ts"])).toEqual({
+      runNode: true,
+      runMacos: false,
+      runAndroid: false,
+    });
+  });
+
+  it("keeps node lane off for native-only changes", () => {
+    expect(detectChangedScope(["apps/macos/Sources/Foo.swift"])).toEqual({
+      runNode: false,
+      runMacos: true,
+      runAndroid: false,
+    });
+    expect(detectChangedScope(["apps/shared/OpenClawKit/Sources/Foo.swift"])).toEqual({
+      runNode: false,
+      runMacos: true,
+      runAndroid: true,
+    });
+  });
+
+  it("does not force macOS for generated protocol model-only changes", () => {
+    expect(detectChangedScope(["apps/macos/Sources/OpenClawProtocol/GatewayModels.swift"])).toEqual(
+      {
+        runNode: false,
+        runMacos: false,
+        runAndroid: false,
+      },
+    );
+  });
+
+  it("enables node lane for non-native non-doc files by fallback", () => {
+    expect(detectChangedScope(["README.md"])).toEqual({
+      runNode: false,
+      runMacos: false,
+      runAndroid: false,
+    });
+
+    expect(detectChangedScope(["assets/icon.png"])).toEqual({
+      runNode: true,
+      runMacos: false,
+      runAndroid: false,
+    });
+  });
+});

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { detectChangedScope } from "../../scripts/ci-changed-scope.mjs";
+
+const require = createRequire(import.meta.url);
+const { detectChangedScope } = require("../../scripts/ci-changed-scope.mjs") as {
+  detectChangedScope: (paths: string[]) => {
+    runNode: boolean;
+    runMacos: boolean;
+    runAndroid: boolean;
+    runWindows: boolean;
+  };
+};
 
 describe("detectChangedScope", () => {
   it("fails safe when no paths are provided", () => {
@@ -7,6 +16,7 @@ describe("detectChangedScope", () => {
       runNode: true,
       runMacos: true,
       runAndroid: true,
+      runWindows: true,
     });
   });
 
@@ -15,6 +25,7 @@ describe("detectChangedScope", () => {
       runNode: false,
       runMacos: false,
       runAndroid: false,
+      runWindows: false,
     });
   });
 
@@ -23,6 +34,7 @@ describe("detectChangedScope", () => {
       runNode: true,
       runMacos: false,
       runAndroid: false,
+      runWindows: true,
     });
   });
 
@@ -31,11 +43,13 @@ describe("detectChangedScope", () => {
       runNode: false,
       runMacos: true,
       runAndroid: false,
+      runWindows: false,
     });
     expect(detectChangedScope(["apps/shared/OpenClawKit/Sources/Foo.swift"])).toEqual({
       runNode: false,
       runMacos: true,
       runAndroid: true,
+      runWindows: false,
     });
   });
 
@@ -45,6 +59,7 @@ describe("detectChangedScope", () => {
         runNode: false,
         runMacos: false,
         runAndroid: false,
+        runWindows: false,
       },
     );
   });
@@ -54,12 +69,23 @@ describe("detectChangedScope", () => {
       runNode: false,
       runMacos: false,
       runAndroid: false,
+      runWindows: false,
     });
 
     expect(detectChangedScope(["assets/icon.png"])).toEqual({
       runNode: true,
       runMacos: false,
       runAndroid: false,
+      runWindows: false,
+    });
+  });
+
+  it("keeps windows lane off for non-runtime GitHub metadata files", () => {
+    expect(detectChangedScope([".github/labeler.yml"])).toEqual({
+      runNode: true,
+      runMacos: false,
+      runAndroid: false,
+      runWindows: false,
     });
   });
 });

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import { describe, expect, it } from "vitest";
 
 const require = createRequire(import.meta.url);


### PR DESCRIPTION
## Cherry-picks from upstream (issue #789)

See issue #789 for full commit list and triage details.

11 commits picked, 13 skipped (empty after fork-intentional divergence resolution — fork has simplified CI without upstream's Windows/macOS/Docker-release/install-smoke/sandbox-smoke workflows).

### Picked commits
- ci: move changed-scope logic into tested script (RESOLVED)
- ci: scale Windows CI runner and test workers (RESOLVED)
- CI: add sticky-disk toggle to setup node action
- CI: add sticky-disk mode to pnpm cache action
- CI: gate Windows checks by windows-relevant scope (#32456) (RESOLVED)
- CI: add exact-key mode for pnpm cache restore
- fix(ci): avoid shell interpolation in changed-scope git diff
- CI: add toggle to skip pnpm actions cache restore
- CI: make node deps install optional in setup action
- fix(docker): correct awk quoting in Docker GPG fingerprint check (#32153) (RESOLVED)
- fix(e2e): include shared tool display resource in onboard docker build (RESOLVED)

### Skipped (empty after resolution)
- CI: enable sticky-disk pnpm cache on Linux CI jobs
- CI: optimize Windows lane by splitting bundle and dropping duplicate lanes
- CI: reduce pre-test Windows setup latency
- CI: increase checks-windows test shards to 3
- CI: increase checks-windows test shards to 4
- CI: shard Windows tests into sixths and skip cache restore
- CI: speed up Windows dependency warmup
- CI: reduce critical path for check build and windows jobs
- ci: use valid Blacksmith Windows runner label
- CI: migrate docker release build cache to Blacksmith
- CI: use Blacksmith docker builder in install smoke
- CI: use Blacksmith docker builder in sandbox smoke
- CI: allow blacksmith 32 vCPU Windows runner in actionlint