### PR TITLE
Cherry-pick issue #794: gateway fixes, chat history, browser dedup

### DIFF
--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -10,14 +10,44 @@ import {
 } from "./pw-session.js";
 import { normalizeTimeoutMs, requireRef, toAIFriendlyError } from "./pw-tools-core.shared.js";
 
+type TargetOpts = {
+  cdpUrl: string;
+  targetId?: string;
+};
+
+async function getRestoredPageForTarget(opts: TargetOpts) {
+  const page = await getPageForTargetId(opts);
+  ensurePageState(page);
+  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  return page;
+}
+
+function resolveInteractionTimeoutMs(timeoutMs?: number): number {
+  return Math.max(500, Math.min(60_000, Math.floor(timeoutMs ?? 8000)));
+}
+
+async function awaitEvalWithAbort<T>(
+  evalPromise: Promise<T>,
+  abortPromise?: Promise<never>,
+): Promise<T> {
+  if (!abortPromise) {
+    return await evalPromise;
+  }
+  try {
+    return await Promise.race([evalPromise, abortPromise]);
+  } catch (err) {
+    // If abort wins the race, evaluate may reject later; avoid unhandled rejections.
+    void evalPromise.catch(() => {});
+    throw err;
+  }
+}
+
 export async function highlightViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   ref: string;
 }): Promise<void> {
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  const page = await getRestoredPageForTarget(opts);
   const ref = requireRef(opts.ref);
   try {
     await refLocator(page, ref).highlight();
@@ -35,15 +65,10 @@ export async function clickViaPlaywright(opts: {
   modifiers?: Array<"Alt" | "Control" | "ControlOrMeta" | "Meta" | "Shift">;
   timeoutMs?: number;
 }): Promise<void> {
-  const page = await getPageForTargetId({
-    cdpUrl: opts.cdpUrl,
-    targetId: opts.targetId,
-  });
-  ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  const page = await getRestoredPageForTarget(opts);
   const ref = requireRef(opts.ref);
   const locator = refLocator(page, ref);
-  const timeout = Math.max(500, Math.min(60_000, Math.floor(opts.timeoutMs ?? 8000)));
+  const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
   try {
     if (opts.doubleClick) {
       await locator.dblclick({
@@ -70,12 +95,10 @@ export async function hoverViaPlaywright(opts: {
   timeoutMs?: number;
 }): Promise<void> {
   const ref = requireRef(opts.ref);
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  const page = await getRestoredPageForTarget(opts);
   try {
     await refLocator(page, ref).hover({
-      timeout: Math.max(500, Math.min(60_000, opts.timeoutMs ?? 8000)),
+      timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
     });
   } catch (err) {
     throw toAIFriendlyError(err, ref);
@@ -94,12 +117,10 @@ export async function dragViaPlaywright(opts: {
   if (!startRef || !endRef) {
     throw new Error("startRef and endRef are required");
   }
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  const page = await getRestoredPageForTarget(opts);
   try {
     await refLocator(page, startRef).dragTo(refLocator(page, endRef), {
-      timeout: Math.max(500, Math.min(60_000, opts.timeoutMs ?? 8000)),
+      timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
     });
   } catch (err) {
     throw toAIFriendlyError(err, `${startRef} -> ${endRef}`);
@@ -117,12 +138,10 @@ export async function selectOptionViaPlaywright(opts: {
   if (!opts.values?.length) {
     throw new Error("values are required");
   }
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  const page = await getRestoredPageForTarget(opts);
   try {
     await refLocator(page, ref).selectOption(opts.values, {
-      timeout: Math.max(500, Math.min(60_000, opts.timeoutMs ?? 8000)),
+      timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
     });
   } catch (err) {
     throw toAIFriendlyError(err, ref);
@@ -156,12 +175,10 @@ export async function typeViaPlaywright(opts: {
   timeoutMs?: number;
 }): Promise<void> {
   const text = String(opts.text ?? "");
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  const page = await getRestoredPageForTarget(opts);
   const ref = requireRef(opts.ref);
   const locator = refLocator(page, ref);
-  const timeout = Math.max(500, Math.min(60_000, opts.timeoutMs ?? 8000));
+  const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
   try {
     if (opts.slowly) {
       await locator.click({ timeout });
@@ -183,10 +200,8 @@ export async function fillFormViaPlaywright(opts: {
   fields: BrowserFormField[];
   timeoutMs?: number;
 }): Promise<void> {
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
-  const timeout = Math.max(500, Math.min(60_000, opts.timeoutMs ?? 8000));
+  const page = await getRestoredPageForTarget(opts);
+  const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
   for (const field of opts.fields) {
     const ref = field.ref.trim();
     const type = (field.type || DEFAULT_FILL_FIELD_TYPE).trim() || DEFAULT_FILL_FIELD_TYPE;
@@ -231,9 +246,7 @@ export async function evaluateViaPlaywright(opts: {
   if (!fnText) {
     throw new Error("function is required");
   }
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  const page = await getRestoredPageForTarget(opts);
   // Clamp evaluate timeout to prevent permanently blocking Playwright's command queue.
   // Without this, a long-running async evaluate blocks all subsequent page operations
   // because Playwright serializes CDP commands per page.
@@ -313,17 +326,7 @@ export async function evaluateViaPlaywright(opts: {
         fnBody: fnText,
         timeoutMs: evaluateTimeout,
       });
-      if (!abortPromise) {
-        return await evalPromise;
-      }
-      try {
-        return await Promise.race([evalPromise, abortPromise]);
-      } catch (err) {
-        // If abort wins the race, the underlying evaluate may reject later; ensure we don't
-        // surface it as an unhandled rejection.
-        void evalPromise.catch(() => {});
-        throw err;
-      }
+      return await awaitEvalWithAbort(evalPromise, abortPromise);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-implied-eval -- required for browser-context eval
@@ -353,15 +356,7 @@ export async function evaluateViaPlaywright(opts: {
       fnBody: fnText,
       timeoutMs: evaluateTimeout,
     });
-    if (!abortPromise) {
-      return await evalPromise;
-    }
-    try {
-      return await Promise.race([evalPromise, abortPromise]);
-    } catch (err) {
-      void evalPromise.catch(() => {});
-      throw err;
-    }
+    return await awaitEvalWithAbort(evalPromise, abortPromise);
   } finally {
     if (signal && abortListener) {
       signal.removeEventListener("abort", abortListener);
@@ -375,9 +370,7 @@ export async function scrollIntoViewViaPlaywright(opts: {
   ref: string;
   timeoutMs?: number;
 }): Promise<void> {
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  const page = await getRestoredPageForTarget(opts);
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
 
   const ref = requireRef(opts.ref);

--- a/src/gateway/live-tool-probe-utils.test.ts
+++ b/src/gateway/live-tool-probe-utils.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { hasExpectedToolNonce, shouldRetryToolReadProbe } from "./live-tool-probe-utils.js";
+import {
+  hasExpectedSingleNonce,
+  hasExpectedToolNonce,
+  shouldRetryExecReadProbe,
+  shouldRetryToolReadProbe,
+} from "./live-tool-probe-utils.js";
 
 describe("live tool probe utils", () => {
   it("matches nonce pair when both are present", () => {
     expect(hasExpectedToolNonce("value a-1 and b-2", "a-1", "b-2")).toBe(true);
     expect(hasExpectedToolNonce("value a-1 only", "a-1", "b-2")).toBe(false);
+  });
+
+  it("matches single nonce when present", () => {
+    expect(hasExpectedSingleNonce("value nonce-1", "nonce-1")).toBe(true);
+    expect(hasExpectedSingleNonce("value nonce-2", "nonce-1")).toBe(false);
   });
 
   it("retries malformed tool output when attempts remain", () => {
@@ -92,6 +102,39 @@ describe("live tool probe utils", () => {
         nonceA: "nonce-a",
         nonceB: "nonce-b",
         provider: "openai",
+        attempt: 0,
+        maxAttempts: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it("retries malformed exec+read output when attempts remain", () => {
+    expect(
+      shouldRetryExecReadProbe({
+        text: "read[object Object]",
+        nonce: "nonce-c",
+        attempt: 0,
+        maxAttempts: 3,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not retry exec+read once max attempts are exhausted", () => {
+    expect(
+      shouldRetryExecReadProbe({
+        text: "read[object Object]",
+        nonce: "nonce-c",
+        attempt: 2,
+        maxAttempts: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not retry exec+read when nonce is present", () => {
+    expect(
+      shouldRetryExecReadProbe({
+        text: "nonce-c",
+        nonce: "nonce-c",
         attempt: 0,
         maxAttempts: 3,
       }),

--- a/src/gateway/live-tool-probe-utils.ts
+++ b/src/gateway/live-tool-probe-utils.ts
@@ -2,6 +2,25 @@ export function hasExpectedToolNonce(text: string, nonceA: string, nonceB: strin
   return text.includes(nonceA) && text.includes(nonceB);
 }
 
+export function hasExpectedSingleNonce(text: string, nonce: string): boolean {
+  return text.includes(nonce);
+}
+
+function hasMalformedToolOutput(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return true;
+  }
+  const lower = trimmed.toLowerCase();
+  if (trimmed.includes("[object Object]")) {
+    return true;
+  }
+  if (/\bread\s*\[/.test(lower) || /\btool\b/.test(lower) || /\bfunction\b/.test(lower)) {
+    return true;
+  }
+  return false;
+}
+
 export function shouldRetryToolReadProbe(params: {
   text: string;
   nonceA: string;
@@ -16,19 +35,27 @@ export function shouldRetryToolReadProbe(params: {
   if (hasExpectedToolNonce(params.text, params.nonceA, params.nonceB)) {
     return false;
   }
-  const trimmed = params.text.trim();
-  if (!trimmed) {
+  if (hasMalformedToolOutput(params.text)) {
     return true;
   }
-  const lower = trimmed.toLowerCase();
-  if (trimmed.includes("[object Object]")) {
-    return true;
-  }
-  if (/\bread\s*\[/.test(lower) || /\btool\b/.test(lower) || /\bfunction\b/.test(lower)) {
-    return true;
-  }
+  const lower = params.text.trim().toLowerCase();
   if (params.provider === "mistral" && (lower.includes("noncea=") || lower.includes("nonceb="))) {
     return true;
   }
   return false;
+}
+
+export function shouldRetryExecReadProbe(params: {
+  text: string;
+  nonce: string;
+  attempt: number;
+  maxAttempts: number;
+}): boolean {
+  if (params.attempt + 1 >= params.maxAttempts) {
+    return false;
+  }
+  if (hasExpectedSingleNonce(params.text, params.nonce)) {
+    return false;
+  }
+  return hasMalformedToolOutput(params.text);
 }

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -341,7 +341,11 @@ function resolveOptionalStringParam(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
-function respondInvalidMethodParams(respond: RespondFn, method: string, errors: unknown): void {
+function respondInvalidMethodParams(
+  respond: RespondFn,
+  method: string,
+  errors: Parameters<typeof formatValidationErrors>[0],
+): void {
   respond(
     false,
     undefined,

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -95,6 +95,42 @@ const OPEN_WRITE_FLAGS =
   fsConstants.O_TRUNC |
   (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
 
+type ResolvedWorkspaceFilePath = Exclude<ResolvedAgentWorkspaceFilePath, { kind: "invalid" }>;
+
+function resolveNotFoundWorkspaceFilePathResult(params: {
+  error: unknown;
+  allowMissing: boolean;
+  requestPath: string;
+  ioPath: string;
+  workspaceReal: string;
+}): Extract<ResolvedAgentWorkspaceFilePath, { kind: "missing" | "invalid" }> | undefined {
+  if (!isNotFoundPathError(params.error)) {
+    return undefined;
+  }
+  if (params.allowMissing) {
+    return {
+      kind: "missing",
+      requestPath: params.requestPath,
+      ioPath: params.ioPath,
+      workspaceReal: params.workspaceReal,
+    };
+  }
+  return { kind: "invalid", requestPath: params.requestPath, reason: "file not found" };
+}
+
+function resolveWorkspaceFilePathResultOrThrow(params: {
+  error: unknown;
+  allowMissing: boolean;
+  requestPath: string;
+  ioPath: string;
+  workspaceReal: string;
+}): Extract<ResolvedAgentWorkspaceFilePath, { kind: "missing" | "invalid" }> {
+  const notFoundResult = resolveNotFoundWorkspaceFilePathResult(params);
+  if (notFoundResult) {
+    return notFoundResult;
+  }
+  throw params.error;
+}
 async function resolveWorkspaceRealPath(workspaceDir: string): Promise<string> {
   try {
     return await fs.realpath(workspaceDir);
@@ -115,17 +151,21 @@ async function resolveAgentWorkspaceFilePath(params: {
     return { kind: "invalid", requestPath, reason: "path escapes workspace root" };
   }
 
+  const notFoundContext = {
+    allowMissing: params.allowMissing,
+    requestPath,
+    workspaceReal,
+  } as const;
+
   let candidateLstat: Awaited<ReturnType<typeof fs.lstat>>;
   try {
     candidateLstat = await fs.lstat(candidatePath);
   } catch (err) {
-    if (isNotFoundPathError(err)) {
-      if (params.allowMissing) {
-        return { kind: "missing", requestPath, ioPath: candidatePath, workspaceReal };
-      }
-      return { kind: "invalid", requestPath, reason: "file not found" };
-    }
-    throw err;
+    return resolveWorkspaceFilePathResultOrThrow({
+      error: err,
+      ...notFoundContext,
+      ioPath: candidatePath,
+    });
   }
 
   if (candidateLstat.isSymbolicLink()) {
@@ -133,13 +173,11 @@ async function resolveAgentWorkspaceFilePath(params: {
     try {
       targetReal = await fs.realpath(candidatePath);
     } catch (err) {
-      if (isNotFoundPathError(err)) {
-        if (params.allowMissing) {
-          return { kind: "missing", requestPath, ioPath: candidatePath, workspaceReal };
-        }
-        return { kind: "invalid", requestPath, reason: "symlink target not found" };
-      }
-      throw err;
+      return resolveWorkspaceFilePathResultOrThrow({
+        error: err,
+        ...notFoundContext,
+        ioPath: candidatePath,
+      });
     }
     if (!isPathInside(workspaceReal, targetReal)) {
       return { kind: "invalid", requestPath, reason: "symlink target escapes workspace root" };
@@ -150,10 +188,11 @@ async function resolveAgentWorkspaceFilePath(params: {
         return { kind: "invalid", requestPath, reason: "symlink target is not a file" };
       }
     } catch (err) {
-      if (isNotFoundPathError(err) && params.allowMissing) {
-        return { kind: "missing", requestPath, ioPath: targetReal, workspaceReal };
-      }
-      throw err;
+      return resolveWorkspaceFilePathResultOrThrow({
+        error: err,
+        ...notFoundContext,
+        ioPath: targetReal,
+      });
     }
     return { kind: "ready", requestPath, ioPath: targetReal, workspaceReal };
   }
@@ -302,6 +341,25 @@ function resolveOptionalStringParam(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function respondInvalidMethodParams(respond: RespondFn, method: string, errors: unknown): void {
+  respond(
+    false,
+    undefined,
+    errorShape(
+      ErrorCodes.INVALID_REQUEST,
+      `invalid ${method} params: ${formatValidationErrors(errors)}`,
+    ),
+  );
+}
+
+function isConfiguredAgent(cfg: ReturnType<typeof loadConfig>, agentId: string): boolean {
+  return findAgentEntryIndex(listAgentEntries(cfg), agentId) >= 0;
+}
+
+function respondAgentNotFound(respond: RespondFn, agentId: string): void {
+  respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, `agent "${agentId}" not found`));
+}
+
 async function moveToTrashBestEffort(pathname: string): Promise<void> {
   if (!pathname) {
     return;
@@ -330,10 +388,7 @@ async function resolveWorkspaceFilePathOrRespond(params: {
   respond: RespondFn;
   workspaceDir: string;
   name: string;
-}): Promise<
-  | Exclude<Awaited<ReturnType<typeof resolveAgentWorkspaceFilePath>>, { kind: "invalid" }>
-  | undefined
-> {
+}): Promise<ResolvedWorkspaceFilePath | undefined> {
   const resolvedPath = await resolveAgentWorkspaceFilePath({
     workspaceDir: params.workspaceDir,
     name: params.name,
@@ -458,27 +513,14 @@ export const agentsHandlers: GatewayRequestHandlers = {
   },
   "agents.update": async ({ params, respond }) => {
     if (!validateAgentsUpdateParams(params)) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          `invalid agents.update params: ${formatValidationErrors(
-            validateAgentsUpdateParams.errors,
-          )}`,
-        ),
-      );
+      respondInvalidMethodParams(respond, "agents.update", validateAgentsUpdateParams.errors);
       return;
     }
 
     const cfg = loadConfig();
     const agentId = normalizeAgentId(String(params.agentId ?? ""));
-    if (findAgentEntryIndex(listAgentEntries(cfg), agentId) < 0) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `agent "${agentId}" not found`),
-      );
+    if (!isConfiguredAgent(cfg, agentId)) {
+      respondAgentNotFound(respond, agentId);
       return;
     }
 
@@ -510,16 +552,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
   },
   "agents.delete": async ({ params, respond }) => {
     if (!validateAgentsDeleteParams(params)) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          `invalid agents.delete params: ${formatValidationErrors(
-            validateAgentsDeleteParams.errors,
-          )}`,
-        ),
-      );
+      respondInvalidMethodParams(respond, "agents.delete", validateAgentsDeleteParams.errors);
       return;
     }
 
@@ -533,12 +566,8 @@ export const agentsHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    if (findAgentEntryIndex(listAgentEntries(cfg), agentId) < 0) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `agent "${agentId}" not found`),
-      );
+    if (!isConfiguredAgent(cfg, agentId)) {
+      respondAgentNotFound(respond, agentId);
       return;
     }
 
@@ -612,16 +641,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
   },
   "agents.files.get": async ({ params, respond }) => {
     if (!validateAgentsFilesGetParams(params)) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          `invalid agents.files.get params: ${formatValidationErrors(
-            validateAgentsFilesGetParams.errors,
-          )}`,
-        ),
-      );
+      respondInvalidMethodParams(respond, "agents.files.get", validateAgentsFilesGetParams.errors);
       return;
     }
     const cfg = loadConfig();
@@ -703,16 +723,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
   },
   "agents.files.set": async ({ params, respond }) => {
     if (!validateAgentsFilesSetParams(params)) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          `invalid agents.files.set params: ${formatValidationErrors(
-            validateAgentsFilesSetParams.errors,
-          )}`,
-        ),
-      );
+      respondInvalidMethodParams(respond, "agents.files.set", validateAgentsFilesSetParams.errors);
       return;
     }
     const cfg = loadConfig();

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -57,6 +57,105 @@ async function waitFor(condition: () => boolean, timeoutMs = 250) {
 }
 
 describe("gateway server chat", () => {
+  const buildNoReplyHistoryFixture = (includeMixedAssistant = false) => [
+    {
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: 1,
+    },
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "NO_REPLY" }],
+      timestamp: 2,
+    },
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "real reply" }],
+      timestamp: 3,
+    },
+    {
+      role: "assistant",
+      text: "real text field reply",
+      content: "NO_REPLY",
+      timestamp: 4,
+    },
+    {
+      role: "user",
+      content: [{ type: "text", text: "NO_REPLY" }],
+      timestamp: 5,
+    },
+    ...(includeMixedAssistant
+      ? [
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "NO_REPLY" },
+              { type: "image", source: { type: "base64", media_type: "image/png", data: "abc" } },
+            ],
+            timestamp: 6,
+          },
+        ]
+      : []),
+  ];
+
+  const loadChatHistoryWithMessages = async (
+    messages: Array<Record<string, unknown>>,
+  ): Promise<unknown[]> => {
+    return withMainSessionStore(async (dir) => {
+      const lines = messages.map((message) => JSON.stringify({ message }));
+      await fs.writeFile(path.join(dir, "sess-main.jsonl"), lines.join("\n"), "utf-8");
+
+      const res = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
+        sessionKey: "main",
+      });
+      expect(res.ok).toBe(true);
+      return res.payload?.messages ?? [];
+    });
+  };
+
+  const withMainSessionStore = async <T>(run: (dir: string) => Promise<T>): Promise<T> => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    try {
+      testState.sessionStorePath = path.join(dir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+      return await run(dir);
+    } finally {
+      testState.sessionStorePath = undefined;
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  };
+
+  const collectHistoryTextValues = (historyMessages: unknown[]) =>
+    historyMessages
+      .map((message) => {
+        if (message && typeof message === "object") {
+          const entry = message as { text?: unknown };
+          if (typeof entry.text === "string") {
+            return entry.text;
+          }
+        }
+        return extractFirstTextBlock(message);
+      })
+      .filter((value): value is string => typeof value === "string");
+
+  const expectAgentWaitTimeout = (res: Awaited<ReturnType<typeof rpcReq>>) => {
+    expect(res.ok).toBe(true);
+    expect(res.payload?.status).toBe("timeout");
+  };
+
+  const expectAgentWaitStartedAt = (res: Awaited<ReturnType<typeof rpcReq>>, startedAt: number) => {
+    expect(res.ok).toBe(true);
+    expect(res.payload?.status).toBe("ok");
+    expect(res.payload?.startedAt).toBe(startedAt);
+  };
+
   test("sanitizes inbound chat.send message text and rejects null bytes", async () => {
     const nullByteRes = await rpcReq(ws, "chat.send", {
       sessionKey: "main",
@@ -335,89 +434,17 @@ describe("gateway server chat", () => {
   });
 
   test("chat.history hides assistant NO_REPLY-only entries", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
-    try {
-      testState.sessionStorePath = path.join(dir, "sessions.json");
-      await writeSessionStore({
-        entries: {
-          main: {
-            sessionId: "sess-main",
-            updatedAt: Date.now(),
-          },
-        },
-      });
-
-      const messages = [
-        {
-          role: "user",
-          content: [{ type: "text", text: "hello" }],
-          timestamp: 1,
-        },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "NO_REPLY" }],
-          timestamp: 2,
-        },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "real reply" }],
-          timestamp: 3,
-        },
-        {
-          role: "assistant",
-          text: "real text field reply",
-          content: "NO_REPLY",
-          timestamp: 4,
-        },
-        {
-          role: "user",
-          content: [{ type: "text", text: "NO_REPLY" }],
-          timestamp: 5,
-        },
-      ];
-      const lines = messages.map((message) => JSON.stringify({ message }));
-      await fs.writeFile(path.join(dir, "sess-main.jsonl"), lines.join("\n"), "utf-8");
-
-      const res = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
-        sessionKey: "main",
-      });
-      expect(res.ok).toBe(true);
-      const historyMessages = res.payload?.messages ?? [];
-      const textValues = historyMessages
-        .map((message) => {
-          if (message && typeof message === "object") {
-            const entry = message as { text?: unknown };
-            if (typeof entry.text === "string") {
-              return entry.text;
-            }
-          }
-          return extractFirstTextBlock(message);
-        })
-        .filter((value): value is string => typeof value === "string");
-      // The NO_REPLY assistant message (content block) should be dropped.
-      // The assistant with text="real text field reply" + content="NO_REPLY" stays
-      // because entry.text takes precedence over entry.content for the silent check.
-      // The user message with NO_REPLY text is preserved (only assistant filtered).
-      expect(textValues).toEqual(["hello", "real reply", "real text field reply", "NO_REPLY"]);
-    } finally {
-      testState.sessionStorePath = undefined;
-      await fs.rm(dir, { recursive: true, force: true });
-    }
+    const historyMessages = await loadChatHistoryWithMessages(buildNoReplyHistoryFixture());
+    const textValues = collectHistoryTextValues(historyMessages);
+    // The NO_REPLY assistant message (content block) should be dropped.
+    // The assistant with text="real text field reply" + content="NO_REPLY" stays
+    // because entry.text takes precedence over entry.content for the silent check.
+    // The user message with NO_REPLY text is preserved (only assistant filtered).
+    expect(textValues).toEqual(["hello", "real reply", "real text field reply", "NO_REPLY"]);
   });
 
   test("routes chat.send slash commands without agent runs", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-gw-"));
-    try {
-      testState.sessionStorePath = path.join(dir, "sessions.json");
-      await writeSessionStore({
-        entries: {
-          main: {
-            sessionId: "sess-main",
-            updatedAt: Date.now(),
-          },
-        },
-      });
-
+    await withMainSessionStore(async () => {
       const spy = vi.mocked(agentCommand);
       const callsBefore = spy.mock.calls.length;
       const eventPromise = onceMessage(
@@ -437,98 +464,36 @@ describe("gateway server chat", () => {
       expect(res.ok).toBe(true);
       await eventPromise;
       expect(spy.mock.calls.length).toBe(callsBefore);
-    } finally {
-      testState.sessionStorePath = undefined;
-      await fs.rm(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   test("chat.history hides assistant NO_REPLY-only entries and keeps mixed-content assistant entries", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
-    try {
-      testState.sessionStorePath = path.join(dir, "sessions.json");
-      await writeSessionStore({
-        entries: {
-          main: {
-            sessionId: "sess-main",
-            updatedAt: Date.now(),
-          },
-        },
-      });
+    const historyMessages = await loadChatHistoryWithMessages(buildNoReplyHistoryFixture(true));
+    const roleAndText = historyMessages
+      .map((message) => {
+        const role =
+          message &&
+          typeof message === "object" &&
+          typeof (message as { role?: unknown }).role === "string"
+            ? (message as { role: string }).role
+            : "unknown";
+        const text =
+          message &&
+          typeof message === "object" &&
+          typeof (message as { text?: unknown }).text === "string"
+            ? (message as { text: string }).text
+            : (extractFirstTextBlock(message) ?? "");
+        return `${role}:${text}`;
+      })
+      .filter((entry) => entry !== "unknown:");
 
-      const messages = [
-        {
-          role: "user",
-          content: [{ type: "text", text: "hello" }],
-          timestamp: 1,
-        },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "NO_REPLY" }],
-          timestamp: 2,
-        },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "real reply" }],
-          timestamp: 3,
-        },
-        {
-          role: "assistant",
-          text: "real text field reply",
-          content: "NO_REPLY",
-          timestamp: 4,
-        },
-        {
-          role: "user",
-          content: [{ type: "text", text: "NO_REPLY" }],
-          timestamp: 5,
-        },
-        {
-          role: "assistant",
-          content: [
-            { type: "text", text: "NO_REPLY" },
-            { type: "image", source: { type: "base64", media_type: "image/png", data: "abc" } },
-          ],
-          timestamp: 6,
-        },
-      ];
-      const lines = messages.map((message) => JSON.stringify({ message }));
-      await fs.writeFile(path.join(dir, "sess-main.jsonl"), lines.join("\n"), "utf-8");
-
-      const res = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
-        sessionKey: "main",
-      });
-      expect(res.ok).toBe(true);
-      const historyMessages = res.payload?.messages ?? [];
-      const roleAndText = historyMessages
-        .map((message) => {
-          const role =
-            message &&
-            typeof message === "object" &&
-            typeof (message as { role?: unknown }).role === "string"
-              ? (message as { role: string }).role
-              : "unknown";
-          const text =
-            message &&
-            typeof message === "object" &&
-            typeof (message as { text?: unknown }).text === "string"
-              ? (message as { text: string }).text
-              : (extractFirstTextBlock(message) ?? "");
-          return `${role}:${text}`;
-        })
-        .filter((entry) => entry !== "unknown:");
-
-      expect(roleAndText).toEqual([
-        "user:hello",
-        "assistant:real reply",
-        "assistant:real text field reply",
-        "user:NO_REPLY",
-        "assistant:NO_REPLY",
-      ]);
-    } finally {
-      testState.sessionStorePath = undefined;
-      await fs.rm(dir, { recursive: true, force: true });
-    }
+    expect(roleAndText).toEqual([
+      "user:hello",
+      "assistant:real reply",
+      "assistant:real text field reply",
+      "user:NO_REPLY",
+      "assistant:NO_REPLY",
+    ]);
   });
 
   test("agent events include sessionKey and agent.wait covers lifecycle flows", async () => {
@@ -598,9 +563,7 @@ describe("gateway server chat", () => {
         });
 
         const res = await waitP;
-        expect(res.ok).toBe(true);
-        expect(res.payload?.status).toBe("ok");
-        expect(res.payload?.startedAt).toBe(200);
+        expectAgentWaitStartedAt(res, 200);
       }
 
       {
@@ -624,8 +587,7 @@ describe("gateway server chat", () => {
           runId: "run-wait-3",
           timeoutMs: 30,
         });
-        expect(res.ok).toBe(true);
-        expect(res.payload?.status).toBe("timeout");
+        expectAgentWaitTimeout(res);
       }
 
       {
@@ -643,8 +605,7 @@ describe("gateway server chat", () => {
         });
 
         const res = await waitP;
-        expect(res.ok).toBe(true);
-        expect(res.payload?.status).toBe("timeout");
+        expectAgentWaitTimeout(res);
       }
 
       {
@@ -668,9 +629,7 @@ describe("gateway server chat", () => {
         });
 
         const res = await waitP;
-        expect(res.ok).toBe(true);
-        expect(res.payload?.status).toBe("ok");
-        expect(res.payload?.startedAt).toBe(123);
+        expectAgentWaitStartedAt(res, 123);
         expect(res.payload?.endedAt).toBe(456);
       }
     } finally {

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -156,7 +156,9 @@ describe("update-startup", () => {
   }
 
   async function runStableUpdateCheck(params: {
-    onUpdateAvailableChange?: (updateAvailable: unknown) => void;
+    onUpdateAvailableChange?: Parameters<
+      typeof runGatewayUpdateCheck
+    >[0]["onUpdateAvailableChange"];
   }) {
     await runGatewayUpdateCheck({
       cfg: { update: { channel: "stable" } },


### PR DESCRIPTION
## Cherry-picks from upstream (issue #794)

See issue #794 for full commit list and triage details.

**Commits picked (5 of 6):**
- `5c18ba6f6` refactor(tests): dedupe gateway chat history fixtures (RESOLVED — conflict in test file)
- `b8181e594` refactor(gateway): dedupe agents server-method handlers (RESOLVED — 3 conflicts)
- `f7f0caa5c` fix(ci): tighten type signatures in gateway params validation (RESOLVED — type conflict)
- `92c4a2a29` fix(gateway): retry exec-read live tool probe (RESOLVED — DU on fork-deleted file)
- `3460aa4de` refactor(browser): dedupe playwright interaction helpers (PICKED — clean)

**Skipped (1):**
- `524fb1661` fix(gateway): skip google rate limits in live suite — only touches fork-deleted file (gateway-models.profiles.live.test.ts)