### PR TITLE
Cherry-pick issue #796: security audit cache + acp install hints

### DIFF
--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -3,7 +3,7 @@ import { resolveBrowserConfig, resolveProfile } from "../browser/config.js";
 import { resolveBrowserControlAuth } from "../browser/control-auth.js";
 import { listChannelPlugins } from "../channels/plugins/index.js";
 import { formatCliCommand } from "../cli/command-format.js";
-import type { RemoteClawConfig } from "../config/config.js";
+import type { ConfigFileSnapshot, RemoteClawConfig } from "../config/config.js";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { buildGatewayConnectionDetails } from "../gateway/call.js";
@@ -92,6 +92,10 @@ export type SecurityAuditOptions = {
   probeGatewayFn?: typeof probeGateway;
   /** Dependency injection for tests (Windows ACL checks). */
   execIcacls?: ExecFn;
+  /** Optional preloaded config snapshot to skip audit-time config file reads. */
+  configSnapshot?: ConfigFileSnapshot | null;
+  /** Optional cache for code-safety summaries across repeated deep audits. */
+  codeSafetySummaryCache?: Map<string, Promise<unknown>>;
 };
 
 function countBySeverity(findings: SecurityAuditFinding[]): SecurityAuditSummary {
@@ -787,11 +791,14 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
 
   const configSnapshot =
     opts.includeFilesystem !== false
-      ? await readConfigSnapshotForAudit({ env, configPath }).catch(() => null)
+      ? opts.configSnapshot !== undefined
+        ? opts.configSnapshot
+        : await readConfigSnapshotForAudit({ env, configPath }).catch(() => null)
       : null;
 
   if (opts.includeFilesystem !== false) {
-    const codeSafetySummaryCache = new Map<string, Promise<unknown>>();
+    const codeSafetySummaryCache =
+      opts.codeSafetySummaryCache ?? new Map<string, Promise<unknown>>();
     findings.push(
       ...(await collectFilesystemFindings({
         stateDir,

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -98,6 +98,23 @@ export type SecurityAuditOptions = {
   codeSafetySummaryCache?: Map<string, Promise<unknown>>;
 };
 
+type AuditExecutionContext = {
+  cfg: RemoteClawConfig;
+  env: NodeJS.ProcessEnv;
+  platform: NodeJS.Platform;
+  includeFilesystem: boolean;
+  includeChannelSecurity: boolean;
+  deep: boolean;
+  deepTimeoutMs: number;
+  stateDir: string;
+  configPath: string;
+  execIcacls?: ExecFn;
+  probeGatewayFn?: typeof probeGateway;
+  plugins?: ReturnType<typeof listChannelPlugins>;
+  configSnapshot: ConfigFileSnapshot | null;
+  codeSafetySummaryCache: Map<string, Promise<unknown>>;
+};
+
 function countBySeverity(findings: SecurityAuditFinding[]): SecurityAuditSummary {
   let critical = 0;
   let warn = 0;
@@ -759,14 +776,45 @@ async function maybeProbeGateway(params: {
   };
 }
 
-export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<SecurityAuditReport> {
-  const findings: SecurityAuditFinding[] = [];
+async function createAuditExecutionContext(
+  opts: SecurityAuditOptions,
+): Promise<AuditExecutionContext> {
   const cfg = opts.config;
   const env = opts.env ?? process.env;
   const platform = opts.platform ?? process.platform;
-  const execIcacls = opts.execIcacls;
+  const includeFilesystem = opts.includeFilesystem !== false;
+  const includeChannelSecurity = opts.includeChannelSecurity !== false;
+  const deep = opts.deep === true;
+  const deepTimeoutMs = Math.max(250, opts.deepTimeoutMs ?? 5000);
   const stateDir = opts.stateDir ?? resolveStateDir(env);
   const configPath = opts.configPath ?? resolveConfigPath(env, stateDir);
+  const configSnapshot = includeFilesystem
+    ? opts.configSnapshot !== undefined
+      ? opts.configSnapshot
+      : await readConfigSnapshotForAudit({ env, configPath }).catch(() => null)
+    : null;
+  return {
+    cfg,
+    env,
+    platform,
+    includeFilesystem,
+    includeChannelSecurity,
+    deep,
+    deepTimeoutMs,
+    stateDir,
+    configPath,
+    execIcacls: opts.execIcacls,
+    probeGatewayFn: opts.probeGatewayFn,
+    plugins: opts.plugins,
+    configSnapshot,
+    codeSafetySummaryCache: opts.codeSafetySummaryCache ?? new Map<string, Promise<unknown>>(),
+  };
+}
+
+export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<SecurityAuditReport> {
+  const findings: SecurityAuditFinding[] = [];
+  const context = await createAuditExecutionContext(opts);
+  const { cfg, env, platform, stateDir, configPath } = context;
 
   findings.push(...collectAttackSurfaceSummaryFindings(cfg));
   findings.push(...collectSyncedFolderFindings({ stateDir, configPath }));
@@ -789,59 +837,60 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   findings.push(...collectExposureMatrixFindings(cfg));
   findings.push(...collectLikelyMultiUserSetupFindings(cfg));
 
-  const configSnapshot =
-    opts.includeFilesystem !== false
-      ? opts.configSnapshot !== undefined
-        ? opts.configSnapshot
-        : await readConfigSnapshotForAudit({ env, configPath }).catch(() => null)
-      : null;
-
-  if (opts.includeFilesystem !== false) {
-    const codeSafetySummaryCache =
-      opts.codeSafetySummaryCache ?? new Map<string, Promise<unknown>>();
+  if (context.includeFilesystem) {
     findings.push(
       ...(await collectFilesystemFindings({
         stateDir,
         configPath,
         env,
         platform,
-        execIcacls,
+        execIcacls: context.execIcacls,
       })),
     );
-    if (configSnapshot) {
+    if (context.configSnapshot) {
       findings.push(
-        ...(await collectIncludeFilePermFindings({ configSnapshot, env, platform, execIcacls })),
+        ...(await collectIncludeFilePermFindings({
+          configSnapshot: context.configSnapshot,
+          env,
+          platform,
+          execIcacls: context.execIcacls,
+        })),
       );
     }
     findings.push(
-      ...(await collectStateDeepFilesystemFindings({ cfg, env, stateDir, platform, execIcacls })),
+      ...(await collectStateDeepFilesystemFindings({
+        cfg,
+        env,
+        stateDir,
+        platform,
+        execIcacls: context.execIcacls,
+      })),
     );
     findings.push(...(await collectWorkspaceSkillSymlinkEscapeFindings({ cfg })));
     findings.push(...(await collectPluginsTrustFindings({ cfg, stateDir })));
-    if (opts.deep === true) {
+    if (context.deep) {
       findings.push(
         ...(await collectPluginsCodeSafetyFindings({
           stateDir,
-          summaryCache: codeSafetySummaryCache,
+          summaryCache: context.codeSafetySummaryCache,
         })),
       );
     }
   }
 
-  if (opts.includeChannelSecurity !== false) {
-    const plugins = opts.plugins ?? listChannelPlugins();
+  if (context.includeChannelSecurity) {
+    const plugins = context.plugins ?? listChannelPlugins();
     findings.push(...(await collectChannelSecurityFindings({ cfg, plugins })));
   }
 
-  const deep =
-    opts.deep === true
-      ? await maybeProbeGateway({
-          cfg,
-          env,
-          timeoutMs: Math.max(250, opts.deepTimeoutMs ?? 5000),
-          probe: opts.probeGatewayFn ?? probeGateway,
-        })
-      : undefined;
+  const deep = context.deep
+    ? await maybeProbeGateway({
+        cfg,
+        env,
+        timeoutMs: context.deepTimeoutMs,
+        probe: context.probeGatewayFn ?? probeGateway,
+      })
+    : undefined;
 
   if (deep?.gateway?.attempted && !deep.gateway.ok) {
     findings.push({


### PR DESCRIPTION
## Cherry-picks from upstream (issue #796)

| Hash | Subject | Result |
|------|---------|--------|
| `895abc5a6` | perf(security): allow audit snapshot and summary cache reuse | RESOLVED |
| `8ac924c76` | refactor(security): centralize audit execution context | RESOLVED |
| `04ac688df` | fix(acp): use publishable acpx install hint | SKIPPED (gutted) |
| `fa4ff5f3d` | refactor(acp): extract install hint resolver | SKIPPED (gutted) |
| `884ca65dc` | refactor(acp): dedupe runtime option command plumbing | SKIPPED (gutted) |

**2 picked**, **3 skipped** (all ACP commits touch only gutted `commands-acp` directory).

Conflict resolutions:
- `src/security/audit.ts`: Fork rename `OpenClawConfig` → `RemoteClawConfig` preserved; fork removal of `execDockerRawFn`/Docker audit calls preserved; upstream's new `ConfigFileSnapshot` import, `configSnapshot`/`codeSafetySummaryCache` fields, and `AuditExecutionContext` type applied with fork adaptations.

See #796 for full commit list and triage details.