### PR TITLE
Cherry-pick c85bd2646: refactor(cli): extract plugin install plan helper

### DIFF
--- a/src/cli/plugin-install-plan.test.ts
+++ b/src/cli/plugin-install-plan.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { resolveBundledInstallPlanForCatalogEntry } from "./plugin-install-plan.js";
+import { PLUGIN_INSTALL_ERROR_CODE } from "../plugins/install.js";
+import {
+  resolveBundledInstallPlanBeforeNpm,
+  resolveBundledInstallPlanForCatalogEntry,
+  resolveBundledInstallPlanForNpmFailure,
+} from "./plugin-install-plan.js";
 
 describe("plugin install plan helpers", () => {
   it("prefers bundled catalog plugin by id before npm spec", () => {
@@ -46,6 +51,80 @@ describe("plugin install plan helpers", () => {
       findBundledSource,
     });
 
+    expect(result).toBeNull();
+  });
+
+  it("prefers bundled plugin for bare plugin-id specs", () => {
+    const findBundledSource = vi.fn().mockReturnValue({
+      pluginId: "voice-call",
+      localPath: "/tmp/extensions/voice-call",
+      npmSpec: "@remoteclaw/voice-call",
+    });
+
+    const result = resolveBundledInstallPlanBeforeNpm({
+      rawSpec: "voice-call",
+      findBundledSource,
+    });
+
+    expect(findBundledSource).toHaveBeenCalledWith({ kind: "pluginId", value: "voice-call" });
+    expect(result?.bundledSource.pluginId).toBe("voice-call");
+    expect(result?.warning).toContain('bare install spec "voice-call"');
+  });
+
+  it("skips bundled pre-plan for scoped npm specs", () => {
+    const findBundledSource = vi.fn();
+    const result = resolveBundledInstallPlanBeforeNpm({
+      rawSpec: "@remoteclaw/voice-call",
+      findBundledSource,
+    });
+
+    expect(findBundledSource).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it("uses npm-spec bundled fallback only for package-not-found", () => {
+    const findBundledSource = vi.fn().mockReturnValue({
+      pluginId: "voice-call",
+      localPath: "/tmp/extensions/voice-call",
+      npmSpec: "@remoteclaw/voice-call",
+    });
+    const result = resolveBundledInstallPlanForNpmFailure({
+      rawSpec: "@remoteclaw/voice-call",
+      code: PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND,
+      findBundledSource,
+    });
+
+    expect(findBundledSource).toHaveBeenCalledWith({
+      kind: "npmSpec",
+      value: "@remoteclaw/voice-call",
+    });
+    expect(result?.warning).toContain("npm package unavailable");
+  });
+
+  it("uses npm-spec bundled fallback for missing extensions", () => {
+    const findBundledSource = vi.fn().mockReturnValue({
+      pluginId: "voice-call",
+      localPath: "/tmp/extensions/voice-call",
+      npmSpec: "@remoteclaw/voice-call",
+    });
+    const result = resolveBundledInstallPlanForNpmFailure({
+      rawSpec: "@remoteclaw/voice-call",
+      code: PLUGIN_INSTALL_ERROR_CODE.MISSING_REMOTECLAW_EXTENSIONS,
+      findBundledSource,
+    });
+
+    expect(result?.warning).toContain("not a valid RemoteClaw plugin");
+  });
+
+  it("skips fallback for non-not-found npm failures", () => {
+    const findBundledSource = vi.fn();
+    const result = resolveBundledInstallPlanForNpmFailure({
+      rawSpec: "@remoteclaw/voice-call",
+      code: "INSTALL_FAILED",
+      findBundledSource,
+    });
+
+    expect(findBundledSource).not.toHaveBeenCalled();
     expect(result).toBeNull();
   });
 });

--- a/src/cli/plugin-install-plan.ts
+++ b/src/cli/plugin-install-plan.ts
@@ -1,4 +1,6 @@
 import type { BundledPluginSource } from "../plugins/bundled-sources.js";
+import { PLUGIN_INSTALL_ERROR_CODE } from "../plugins/install.js";
+import { shortenHomePath } from "../utils.js";
 
 type BundledLookup = (params: {
   kind: "pluginId" | "npmSpec";
@@ -33,4 +35,56 @@ export function resolveBundledInstallPlanForCatalogEntry(params: {
   }
 
   return null;
+}
+
+function isBareNpmPackageName(spec: string): boolean {
+  const trimmed = spec.trim();
+  return /^[a-z0-9][a-z0-9-._~]*$/.test(trimmed);
+}
+
+export function resolveBundledInstallPlanBeforeNpm(params: {
+  rawSpec: string;
+  findBundledSource: BundledLookup;
+}): { bundledSource: BundledPluginSource; warning: string } | null {
+  if (!isBareNpmPackageName(params.rawSpec)) {
+    return null;
+  }
+  const bundledSource = params.findBundledSource({
+    kind: "pluginId",
+    value: params.rawSpec,
+  });
+  if (!bundledSource) {
+    return null;
+  }
+  return {
+    bundledSource,
+    warning: `Using bundled plugin "${bundledSource.pluginId}" from ${shortenHomePath(bundledSource.localPath)} for bare install spec "${params.rawSpec}". To install an npm package with the same name, use a scoped package name (for example @scope/${params.rawSpec}).`,
+  };
+}
+
+export function resolveBundledInstallPlanForNpmFailure(params: {
+  rawSpec: string;
+  code?: string;
+  findBundledSource: BundledLookup;
+}): { bundledSource: BundledPluginSource; warning: string } | null {
+  const isNpmNotFound = params.code === PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND;
+  const isNotPlugin =
+    params.code === PLUGIN_INSTALL_ERROR_CODE.MISSING_REMOTECLAW_EXTENSIONS ||
+    params.code === PLUGIN_INSTALL_ERROR_CODE.EMPTY_REMOTECLAW_EXTENSIONS;
+  if (!isNpmNotFound && !isNotPlugin) {
+    return null;
+  }
+  const bundledSource = params.findBundledSource({
+    kind: "npmSpec",
+    value: params.rawSpec,
+  });
+  if (!bundledSource) {
+    return null;
+  }
+  return {
+    bundledSource,
+    warning: isNpmNotFound
+      ? `npm package unavailable for ${params.rawSpec}; using bundled plugin at ${shortenHomePath(bundledSource.localPath)}.`
+      : `npm package "${params.rawSpec}" is not a valid RemoteClaw plugin; using bundled plugin at ${shortenHomePath(bundledSource.localPath)}.`,
+  };
 }

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -8,11 +8,7 @@ import { resolveStateDir } from "../config/paths.js";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { type BundledPluginSource, findBundledPluginSource } from "../plugins/bundled-sources.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
-import {
-  installPluginFromNpmSpec,
-  installPluginFromPath,
-  PLUGIN_INSTALL_ERROR_CODE,
-} from "../plugins/install.js";
+import { installPluginFromNpmSpec, installPluginFromPath } from "../plugins/install.js";
 import { recordPluginInstall } from "../plugins/installs.js";
 import { clearPluginManifestRegistryCache } from "../plugins/manifest-registry.js";
 import type { PluginRecord } from "../plugins/registry.js";
@@ -27,6 +23,10 @@ import { renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
 import { resolveUserPath, shortenHomeInString, shortenHomePath } from "../utils.js";
 import { resolvePinnedNpmInstallRecordForCli } from "./npm-resolution.js";
+import {
+  resolveBundledInstallPlanBeforeNpm,
+  resolveBundledInstallPlanForNpmFailure,
+} from "./plugin-install-plan.js";
 import { setPluginEnabledInConfig } from "./plugins-config.js";
 import { promptYesNo } from "./prompt.js";
 
@@ -166,11 +166,6 @@ function logSlotWarnings(warnings: string[]) {
   for (const warning of warnings) {
     defaultRuntime.log(theme.warn(warning));
   }
-}
-
-function isBareNpmPackageName(spec: string): boolean {
-  const trimmed = spec.trim();
-  return /^[a-z0-9][a-z0-9-._~]*$/.test(trimmed);
 }
 
 async function installBundledPluginSource(params: {
@@ -320,17 +315,16 @@ async function runPluginInstallCommand(params: {
     process.exit(1);
   }
 
-  const bundledByPluginId = isBareNpmPackageName(raw)
-    ? findBundledPluginSource({
-        lookup: { kind: "pluginId", value: raw },
-      })
-    : undefined;
-  if (bundledByPluginId) {
+  const bundledPreNpmPlan = resolveBundledInstallPlanBeforeNpm({
+    rawSpec: raw,
+    findBundledSource: (lookup) => findBundledPluginSource({ lookup }),
+  });
+  if (bundledPreNpmPlan) {
     await installBundledPluginSource({
       config: cfg,
       rawSpec: raw,
-      bundledSource: bundledByPluginId,
-      warning: `Using bundled plugin "${bundledByPluginId.pluginId}" from ${shortenHomePath(bundledByPluginId.localPath)} for bare install spec "${raw}". To install an npm package with the same name, use a scoped package name (for example @scope/${raw}).`,
+      bundledSource: bundledPreNpmPlan.bundledSource,
+      warning: bundledPreNpmPlan.warning,
     });
     return;
   }
@@ -340,17 +334,12 @@ async function runPluginInstallCommand(params: {
     logger: createPluginInstallLogger(),
   });
   if (!result.ok) {
-    const isNpmNotFound = result.code === PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND;
-    const isNotPlugin =
-      result.code === PLUGIN_INSTALL_ERROR_CODE.MISSING_REMOTECLAW_EXTENSIONS ||
-      result.code === PLUGIN_INSTALL_ERROR_CODE.EMPTY_REMOTECLAW_EXTENSIONS;
-    const bundledFallback =
-      isNpmNotFound || isNotPlugin
-        ? findBundledPluginSource({
-            lookup: { kind: "npmSpec", value: raw },
-          })
-        : undefined;
-    if (!bundledFallback) {
+    const bundledFallbackPlan = resolveBundledInstallPlanForNpmFailure({
+      rawSpec: raw,
+      code: result.code,
+      findBundledSource: (lookup) => findBundledPluginSource({ lookup }),
+    });
+    if (!bundledFallbackPlan) {
       defaultRuntime.error(result.error);
       process.exit(1);
     }
@@ -358,10 +347,8 @@ async function runPluginInstallCommand(params: {
     await installBundledPluginSource({
       config: cfg,
       rawSpec: raw,
-      bundledSource: bundledFallback,
-      warning: isNpmNotFound
-        ? `npm package unavailable for ${raw}; using bundled plugin at ${shortenHomePath(bundledFallback.localPath)}.`
-        : `npm package "${raw}" is not a valid RemoteClaw plugin; using bundled plugin at ${shortenHomePath(bundledFallback.localPath)}.`,
+      bundledSource: bundledFallbackPlan.bundledSource,
+      warning: bundledFallbackPlan.warning,
     });
     return;
   }


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: `c85bd2646`
**Author**: Peter Steinberger

> refactor(cli): extract plugin install plan helper

Conflict resolution: union-merged fork's `resolveBundledInstallPlanForCatalogEntry` with upstream's extracted helpers. Enhanced `resolveBundledInstallPlanForNpmFailure` to preserve fork's expanded error code handling (`MISSING_REMOTECLAW_EXTENSIONS`, `EMPTY_REMOTECLAW_EXTENSIONS`).