### PR TITLE
Cherry-pick 9f691099d: fix(voice-call): harden webhook lifecycle cleanup and retries

### DIFF
--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -125,6 +125,7 @@ export async function createVoiceCallRuntime(params: {
   const webhookServer = new VoiceCallWebhookServer(config, manager, provider, coreConfig);
 
   const localUrl = await webhookServer.start();
+  let tunnelResult: TunnelResult | null = null;
 
   // Wrap remaining initialization in try/catch so the webhook server is
   // properly stopped if any subsequent step fails.  Without this, the server
@@ -133,7 +134,6 @@ export async function createVoiceCallRuntime(params: {
   try {
     // Determine public URL - priority: config.publicUrl > tunnel > legacy tailscale
     let publicUrl: string | null = config.publicUrl ?? null;
-    let tunnelResult: TunnelResult | null = null;
 
     if (!publicUrl && config.tunnel?.provider && config.tunnel.provider !== "none") {
       try {
@@ -217,8 +217,13 @@ export async function createVoiceCallRuntime(params: {
       stop,
     };
   } catch (err) {
-    // If any step after the server started fails, close the server to
-    // release the port so the next attempt doesn't hit EADDRINUSE.
+    // If any step after the server started fails, clean up every provisioned
+    // resource (tunnel, tailscale exposure, and webhook server) so retries
+    // don't leak processes or keep the port bound.
+    if (tunnelResult) {
+      await tunnelResult.stop().catch(() => {});
+    }
+    await cleanupTailscaleExposure(config).catch(() => {});
     await webhookServer.stop().catch(() => {});
     throw err;
   }

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -322,9 +322,11 @@ describe("VoiceCallWebhookServer start idempotency", () => {
       // Second call should return immediately without EADDRINUSE
       const secondUrl = await server.start();
 
-      // Both calls should return a valid URL (port may differ from config
-      // since we use port 0 for dynamic allocation, but paths must match)
+      // Dynamic port allocations should resolve to a real listening port.
       expect(firstUrl).toContain("/voice/webhook");
+      expect(firstUrl).not.toContain(":0/");
+      // Idempotent re-start should return the same already-bound URL.
+      expect(secondUrl).toBe(firstUrl);
       expect(secondUrl).toContain("/voice/webhook");
     } finally {
       await server.stop();

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -30,6 +30,7 @@ type WebhookResponsePayload = {
  */
 export class VoiceCallWebhookServer {
   private server: http.Server | null = null;
+  private listeningUrl: string | null = null;
   private config: VoiceCallConfig;
   private manager: CallManager;
   private provider: VoiceCallProvider;
@@ -195,7 +196,7 @@ export class VoiceCallWebhookServer {
     // This prevents EADDRINUSE when start() is called more than once on the
     // same instance (e.g. during config hot-reload or concurrent ensureRuntime).
     if (this.server?.listening) {
-      return `http://${bind}:${port}${webhookPath}`;
+      return this.listeningUrl ?? this.resolveListeningUrl(bind, webhookPath);
     }
 
     return new Promise((resolve, reject) => {
@@ -223,10 +224,16 @@ export class VoiceCallWebhookServer {
       this.server.on("error", reject);
 
       this.server.listen(port, bind, () => {
-        const url = `http://${bind}:${port}${webhookPath}`;
+        const url = this.resolveListeningUrl(bind, webhookPath);
+        this.listeningUrl = url;
         console.log(`[voice-call] Webhook server listening on ${url}`);
         if (this.mediaStreamHandler) {
-          console.log(`[voice-call] Media stream WebSocket on ws://${bind}:${port}${streamPath}`);
+          const address = this.server?.address();
+          const actualPort =
+            address && typeof address === "object" ? address.port : this.config.serve.port;
+          console.log(
+            `[voice-call] Media stream WebSocket on ws://${bind}:${actualPort}${streamPath}`,
+          );
         }
         resolve(url);
 
@@ -251,12 +258,24 @@ export class VoiceCallWebhookServer {
       if (this.server) {
         this.server.close(() => {
           this.server = null;
+          this.listeningUrl = null;
           resolve();
         });
       } else {
+        this.listeningUrl = null;
         resolve();
       }
     });
+  }
+
+  private resolveListeningUrl(bind: string, webhookPath: string): string {
+    const address = this.server?.address();
+    if (address && typeof address === "object") {
+      const host = address.address && address.address.length > 0 ? address.address : bind;
+      const normalizedHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+      return `http://${normalizedHost}:${address.port}${webhookPath}`;
+    }
+    return `http://${bind}:${this.config.serve.port}${webhookPath}`;
   }
 
   private getUpgradePathname(request: http.IncomingMessage): string | null {


### PR DESCRIPTION
## Cherry-pick from upstream

| Field | Value |
|-------|-------|
| Upstream commit | [`9f691099d`](https://github.com/openclaw/openclaw/commit/9f691099d) |
| Author | [steipete](https://github.com/steipete) (Peter Steinberger) |
| Tier | AUTO-PICK |

## Summary

Hardens the webhook lifecycle cleanup with retry logic in the voice-call extension. Improves reliability of webhook server teardown.

## Conflict Resolution

- `CHANGELOG.md`: deleted in fork, modified upstream — kept fork's deletion (fork-intentional divergence)

Part of #798