### PR TITLE
Cherry-pick issue #804: gateway-session-fixes

### DIFF
--- a/apps/macos/Sources/RemoteClawDiscovery/GatewayDiscoveryModel.swift
+++ b/apps/macos/Sources/RemoteClawDiscovery/GatewayDiscoveryModel.swift
@@ -76,6 +76,8 @@ public final class GatewayDiscoveryModel {
     private var pendingServiceResolvers: [String: GatewayServiceResolver] = [:]
     private var wideAreaFallbackTask: Task<Void, Never>?
     private var wideAreaFallbackGateways: [DiscoveredGateway] = []
+    private var tailscaleServeFallbackTask: Task<Void, Never>?
+    private var tailscaleServeFallbackGateways: [DiscoveredGateway] = []
     private let logger = Logger(subsystem: "org.remoteclaw", category: "gateway-discovery")
 
     public init(
@@ -120,6 +122,7 @@ public final class GatewayDiscoveryModel {
         }
 
         self.scheduleWideAreaFallback()
+        self.scheduleTailscaleServeFallback()
     }
 
     public func refreshWideAreaFallbackNow(timeoutSeconds: TimeInterval = 5.0) {
@@ -133,6 +136,23 @@ public final class GatewayDiscoveryModel {
                 self.recomputeGateways()
             }
         }
+    }
+
+    public func refreshTailscaleServeFallbackNow(timeoutSeconds: TimeInterval = 5.0) {
+        Task.detached(priority: .utility) { [weak self] in
+            guard let self else { return }
+            let beacons = await TailscaleServeGatewayDiscovery.discover(timeoutSeconds: timeoutSeconds)
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                self.tailscaleServeFallbackGateways = self.mapTailscaleServeBeacons(beacons)
+                self.recomputeGateways()
+            }
+        }
+    }
+
+    public func refreshRemoteFallbackNow(timeoutSeconds: TimeInterval = 5.0) {
+        self.refreshWideAreaFallbackNow(timeoutSeconds: timeoutSeconds)
+        self.refreshTailscaleServeFallbackNow(timeoutSeconds: timeoutSeconds)
     }
 
     public func stop() {
@@ -149,6 +169,9 @@ public final class GatewayDiscoveryModel {
         self.wideAreaFallbackTask?.cancel()
         self.wideAreaFallbackTask = nil
         self.wideAreaFallbackGateways = []
+        self.tailscaleServeFallbackTask?.cancel()
+        self.tailscaleServeFallbackTask = nil
+        self.tailscaleServeFallbackGateways = []
         self.gateways = []
         self.statusText = "Stopped"
     }
@@ -177,22 +200,45 @@ public final class GatewayDiscoveryModel {
         }
     }
 
+    private func mapTailscaleServeBeacons(
+        _ beacons: [TailscaleServeGatewayBeacon]) -> [DiscoveredGateway]
+    {
+        beacons.map { beacon in
+            let stableID = "tailscale-serve|\(beacon.tailnetDns.lowercased())"
+            let isLocal = Self.isLocalGateway(
+                lanHost: nil,
+                tailnetDns: beacon.tailnetDns,
+                displayName: beacon.displayName,
+                serviceName: nil,
+                local: self.localIdentity)
+            return DiscoveredGateway(
+                displayName: beacon.displayName,
+                serviceHost: beacon.host,
+                servicePort: beacon.port,
+                lanHost: nil,
+                tailnetDns: beacon.tailnetDns,
+                sshPort: 22,
+                gatewayPort: beacon.port,
+                cliPath: nil,
+                stableID: stableID,
+                debugID: "\(beacon.host):\(beacon.port)",
+                isLocal: isLocal)
+        }
+    }
+
     private func recomputeGateways() {
         let primary = self.sortedDeduped(gateways: self.gatewaysByDomain.values.flatMap(\.self))
         let primaryFiltered = self.filterLocalGateways ? primary.filter { !$0.isLocal } : primary
-        if !primaryFiltered.isEmpty {
-            self.gateways = primaryFiltered
-            return
-        }
 
         // Bonjour can return only "local" results for the wide-area domain (or no results at all),
-        // which makes onboarding look empty even though Tailscale DNS-SD can already see gateways.
-        guard !self.wideAreaFallbackGateways.isEmpty else {
+        // and cross-network setups may rely on Tailscale Serve without DNS-SD.
+        let fallback = self.wideAreaFallbackGateways + self.tailscaleServeFallbackGateways
+        guard !fallback.isEmpty else {
             self.gateways = primaryFiltered
             return
         }
 
-        let combined = self.sortedDeduped(gateways: primary + self.wideAreaFallbackGateways)
+        let combined = self.sortedDeduped(gateways: primary + fallback)
         self.gateways = self.filterLocalGateways ? combined.filter { !$0.isLocal } : combined
     }
 
@@ -293,6 +339,39 @@ public final class GatewayDiscoveryModel {
         }
     }
 
+    private func scheduleTailscaleServeFallback() {
+        if Self.isRunningTests { return }
+        guard self.tailscaleServeFallbackTask == nil else { return }
+        self.tailscaleServeFallbackTask = Task.detached(priority: .utility) { [weak self] in
+            guard let self else { return }
+            var attempt = 0
+            let startedAt = Date()
+            while !Task.isCancelled, Date().timeIntervalSince(startedAt) < 35.0 {
+                let hasResults = await MainActor.run {
+                    if self.filterLocalGateways {
+                        return !self.gateways.isEmpty
+                    }
+                    return self.gateways.contains(where: { !$0.isLocal })
+                }
+                if hasResults { return }
+
+                let beacons = await TailscaleServeGatewayDiscovery.discover(timeoutSeconds: 2.4)
+                if !beacons.isEmpty {
+                    await MainActor.run { [weak self] in
+                        guard let self else { return }
+                        self.tailscaleServeFallbackGateways = self.mapTailscaleServeBeacons(beacons)
+                        self.recomputeGateways()
+                    }
+                    return
+                }
+
+                attempt += 1
+                let backoff = min(8.0, 0.8 + (Double(attempt) * 0.8))
+                try? await Task.sleep(nanoseconds: UInt64(backoff * 1_000_000_000))
+            }
+        }
+    }
+
     private var hasUsableWideAreaResults: Bool {
         guard let domain = RemoteClawBonjour.wideAreaGatewayServiceDomain else { return false }
         guard let gateways = self.gatewaysByDomain[domain], !gateways.isEmpty else { return false }
@@ -300,11 +379,25 @@ public final class GatewayDiscoveryModel {
         return gateways.contains(where: { !$0.isLocal })
     }
 
+    static func dedupeKey(for gateway: DiscoveredGateway) -> String {
+        if let host = gateway.serviceHost?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+           !host.isEmpty,
+           let port = gateway.servicePort,
+           port > 0
+        {
+            return "endpoint|\(host):\(port)"
+        }
+        return "stable|\(gateway.stableID)"
+    }
+
     private func sortedDeduped(gateways: [DiscoveredGateway]) -> [DiscoveredGateway] {
         var seen = Set<String>()
         let deduped = gateways.filter { gateway in
-            if seen.contains(gateway.stableID) { return false }
-            seen.insert(gateway.stableID)
+            let key = Self.dedupeKey(for: gateway)
+            if seen.contains(key) { return false }
+            seen.insert(key)
             return true
         }
         return deduped.sorted {

--- a/apps/macos/Sources/RemoteClawDiscovery/TailscaleServeGatewayDiscovery.swift
+++ b/apps/macos/Sources/RemoteClawDiscovery/TailscaleServeGatewayDiscovery.swift
@@ -1,7 +1,7 @@
 import Foundation
 import RemoteClawKit
 
-struct TailscaleServeGatewayBeacon: Equatable {
+struct TailscaleServeGatewayBeacon: Sendable, Equatable {
     var displayName: String
     var tailnetDns: String
     var host: String
@@ -13,7 +13,7 @@ enum TailscaleServeGatewayDiscovery {
     private static let probeConcurrency = 6
     private static let defaultProbeTimeoutSeconds: TimeInterval = 1.6
 
-    struct DiscoveryContext {
+    struct DiscoveryContext: Sendable {
         var tailscaleStatus: @Sendable () async -> String?
         var probeHost: @Sendable (_ host: String, _ timeout: TimeInterval) async -> Bool
 
@@ -85,13 +85,13 @@ enum TailscaleServeGatewayDiscovery {
         }
     }
 
-    private struct Candidate {
+    private struct Candidate: Sendable {
         var dnsName: String
         var displayName: String
     }
 
     private static func collectCandidates(status: TailscaleStatus) -> [Candidate] {
-        let selfDns = self.normalizeDnsName(status.selfNode?.dnsName)
+        let selfDns = normalizeDnsName(status.selfNode?.dnsName)
         var out: [Candidate] = []
         var seen = Set<String>()
 
@@ -112,7 +112,7 @@ enum TailscaleServeGatewayDiscovery {
 
             out.append(Candidate(
                 dnsName: dnsName,
-                displayName: self.displayName(hostName: node.hostName, dnsName: dnsName)))
+                displayName: displayName(hostName: node.hostName, dnsName: dnsName)))
 
             if out.count >= self.maxCandidates {
                 break
@@ -203,7 +203,6 @@ enum TailscaleServeGatewayDiscovery {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: path)
         process.arguments = args
-        process.environment = self.commandEnvironment()
         let outPipe = Pipe()
         process.standardOutput = outPipe
         process.standardError = FileHandle.nullDevice
@@ -226,19 +225,6 @@ enum TailscaleServeGatewayDiscovery {
         let data = (try? outPipe.fileHandleForReading.readToEnd()) ?? Data()
         let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
         return output?.isEmpty == false ? output : nil
-    }
-
-    static func commandEnvironment(
-        base: [String: String] = ProcessInfo.processInfo.environment) -> [String: String]
-    {
-        var env = base
-        let term = env["TERM"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if term.isEmpty {
-            // The macOS Tailscale app binary exits with CLIError error 3 when TERM is missing,
-            // which is common for GUI-launched app environments.
-            env["TERM"] = "dumb"
-        }
-        return env
     }
 
     private static func parseStatus(_ raw: String) -> TailscaleStatus? {
@@ -271,7 +257,7 @@ enum TailscaleServeGatewayDiscovery {
                 operation: {
                     while true {
                         let message = try await task.receive()
-                        if self.isConnectChallenge(message: message) {
+                        if isConnectChallenge(message: message) {
                             return true
                         }
                     }

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -461,7 +461,9 @@ export class AcpGatewayAgent implements Agent {
     }
 
     if (state === "final") {
-      this.finishPrompt(pending.sessionId, pending, "end_turn");
+      const rawStopReason = payload.stopReason as string | undefined;
+      const stopReason: StopReason = rawStopReason === "max_tokens" ? "max_tokens" : "end_turn";
+      this.finishPrompt(pending.sessionId, pending, stopReason);
       return;
     }
     if (state === "aborted") {

--- a/src/agents/agent-messaging.ts
+++ b/src/agents/agent-messaging.ts
@@ -5,6 +5,7 @@ export type MessagingToolSend = {
   provider: string;
   accountId?: string;
   to?: string;
+  threadId?: string;
 };
 
 const CORE_MESSAGING_TOOLS = new Set(["sessions_send", "message"]);

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -25,7 +25,7 @@ import { buildInboundMetaSystemPrompt, buildInboundUserContextPrefix } from "./i
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { resolveQueueSettings } from "./queue.js";
 import { routeReply } from "./route-reply.js";
-import { BARE_SESSION_RESET_PROMPT } from "./session-reset-prompt.js";
+import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
 import { buildQueuedSystemPrompt } from "./session-updates.js";
 import { resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
@@ -253,7 +253,7 @@ export async function runPreparedReply(
   const isBareSessionReset =
     isNewSession &&
     ((baseBodyTrimmedRaw.length === 0 && rawBodyTrimmed.length > 0) || isBareNewOrReset);
-  const baseBodyFinal = isBareSessionReset ? BARE_SESSION_RESET_PROMPT : baseBody;
+  const baseBodyFinal = isBareSessionReset ? buildBareSessionResetPrompt(cfg) : baseBody;
   const inboundUserContext = buildInboundUserContextPrefix(
     isNewSession
       ? {

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { filterMessagingToolMediaDuplicates } from "./reply-payloads.js";
+import {
+  filterMessagingToolMediaDuplicates,
+  shouldSuppressMessagingToolReplies,
+} from "./reply-payloads.js";
 
 describe("filterMessagingToolMediaDuplicates", () => {
   it("strips mediaUrl when it matches sentMediaUrls", () => {
@@ -73,5 +76,81 @@ describe("filterMessagingToolMediaDuplicates", () => {
       sentMediaUrls: ["file:///tmp/photo%20one.jpg"],
     });
     expect(result).toEqual([{ text: "hello", mediaUrl: undefined, mediaUrls: undefined }]);
+  });
+});
+
+describe("shouldSuppressMessagingToolReplies", () => {
+  it("suppresses when target provider is missing but target matches current provider route", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "telegram",
+        originatingTo: "123",
+        messagingToolSentTargets: [{ tool: "message", provider: "", to: "123" }],
+      }),
+    ).toBe(true);
+  });
+
+  it('suppresses when target provider uses "message" placeholder and target matches', () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "telegram",
+        originatingTo: "123",
+        messagingToolSentTargets: [{ tool: "message", provider: "message", to: "123" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress when providerless target does not match origin route", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "telegram",
+        originatingTo: "123",
+        messagingToolSentTargets: [{ tool: "message", provider: "", to: "456" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("suppresses telegram topic-origin replies when explicit threadId matches", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "telegram",
+        originatingTo: "telegram:group:-100123:topic:77",
+        messagingToolSentTargets: [
+          { tool: "message", provider: "telegram", to: "-100123", threadId: "77" },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress telegram topic-origin replies when explicit threadId differs", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "telegram",
+        originatingTo: "telegram:group:-100123:topic:77",
+        messagingToolSentTargets: [
+          { tool: "message", provider: "telegram", to: "-100123", threadId: "88" },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("does not suppress telegram topic-origin replies when target omits topic metadata", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "telegram",
+        originatingTo: "telegram:group:-100123:topic:77",
+        messagingToolSentTargets: [{ tool: "message", provider: "telegram", to: "-100123" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("suppresses telegram replies when chatId matches but target forms differ", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "telegram",
+        originatingTo: "telegram:group:-100123",
+        messagingToolSentTargets: [{ tool: "message", provider: "telegram", to: "-100123" }],
+      }),
+    ).toBe(true);
   });
 });

--- a/src/auto-reply/reply/reply-payloads.ts
+++ b/src/auto-reply/reply/reply-payloads.ts
@@ -4,6 +4,7 @@ import { normalizeChannelId } from "../../channels/plugins/index.js";
 import type { ReplyToMode } from "../../config/types.js";
 import { normalizeTargetForProvider } from "../../infra/outbound/target-normalization.js";
 import { normalizeOptionalAccountId } from "../../routing/account-id.js";
+import { parseTelegramTarget } from "../../telegram/targets.js";
 import type { OriginatingChannelType } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import { extractReplyToTag } from "./reply-tags.js";
@@ -162,6 +163,62 @@ function normalizeProviderForComparison(value?: string): string | undefined {
   return PROVIDER_ALIAS_MAP[lowered] ?? lowered;
 }
 
+function normalizeThreadIdForComparison(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (/^-?\d+$/.test(trimmed)) {
+    return String(Number.parseInt(trimmed, 10));
+  }
+  return trimmed.toLowerCase();
+}
+
+function resolveTargetProviderForComparison(params: {
+  currentProvider: string;
+  targetProvider?: string;
+}): string {
+  const targetProvider = normalizeProviderForComparison(params.targetProvider);
+  if (!targetProvider || targetProvider === "message") {
+    return params.currentProvider;
+  }
+  return targetProvider;
+}
+
+function targetsMatchForSuppression(params: {
+  provider: string;
+  originTarget: string;
+  targetKey: string;
+  targetThreadId?: string;
+}): boolean {
+  if (params.provider !== "telegram") {
+    return params.targetKey === params.originTarget;
+  }
+
+  const origin = parseTelegramTarget(params.originTarget);
+  const target = parseTelegramTarget(params.targetKey);
+  const explicitTargetThreadId = normalizeThreadIdForComparison(params.targetThreadId);
+  const targetThreadId =
+    explicitTargetThreadId ??
+    (target.messageThreadId != null ? String(target.messageThreadId) : undefined);
+  const originThreadId =
+    origin.messageThreadId != null ? String(origin.messageThreadId) : undefined;
+  if (origin.chatId.trim().toLowerCase() !== target.chatId.trim().toLowerCase()) {
+    return false;
+  }
+  if (originThreadId && targetThreadId != null) {
+    return originThreadId === targetThreadId;
+  }
+  if (originThreadId && targetThreadId == null) {
+    return false;
+  }
+  if (!originThreadId && targetThreadId != null) {
+    return false;
+  }
+  // chatId already matched and neither side carries thread context.
+  return true;
+}
+
 export function shouldSuppressMessagingToolReplies(params: {
   messageProvider?: string;
   messagingToolSentTargets?: MessagingToolSend[];
@@ -182,16 +239,14 @@ export function shouldSuppressMessagingToolReplies(params: {
     return false;
   }
   return sentTargets.some((target) => {
-    const targetProvider = normalizeProviderForComparison(target?.provider);
-    if (!targetProvider) {
+    const targetProvider = resolveTargetProviderForComparison({
+      currentProvider: provider,
+      targetProvider: target?.provider,
+    });
+    if (targetProvider !== provider) {
       return false;
     }
-    const isGenericMessageProvider = targetProvider === "message";
-    if (!isGenericMessageProvider && targetProvider !== provider) {
-      return false;
-    }
-    const targetNormalizationProvider = isGenericMessageProvider ? provider : targetProvider;
-    const targetKey = normalizeTargetForProvider(targetNormalizationProvider, target.to);
+    const targetKey = normalizeTargetForProvider(targetProvider, target.to);
     if (!targetKey) {
       return false;
     }
@@ -199,6 +254,11 @@ export function shouldSuppressMessagingToolReplies(params: {
     if (originAccount && targetAccount && originAccount !== targetAccount) {
       return false;
     }
-    return targetKey === originTarget;
+    return targetsMatchForSuppression({
+      provider,
+      originTarget,
+      targetKey,
+      targetThreadId: target.threadId,
+    });
   });
 }

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -30,6 +30,14 @@ function resolveSessionKeyChannelHint(sessionKey?: string): string | undefined {
   return normalizeMessageChannel(head);
 }
 
+function isMainSessionKey(sessionKey?: string): boolean {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed) {
+    return (sessionKey ?? "").trim().toLowerCase() === "main";
+  }
+  return parsed.rest.trim().toLowerCase() === "main";
+}
+
 function isExternalRoutingChannel(channel?: string): channel is string {
   return Boolean(
     channel && channel !== INTERNAL_MESSAGE_CHANNEL && isDeliverableMessageChannel(channel),
@@ -42,6 +50,9 @@ export function resolveLastChannelRaw(params: {
   sessionKey?: string;
 }): string | undefined {
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
+  if (originatingChannel === INTERNAL_MESSAGE_CHANNEL && isMainSessionKey(params.sessionKey)) {
+    return params.originatingChannelRaw;
+  }
   const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);
   const sessionKeyChannelHint = resolveSessionKeyChannelHint(params.sessionKey);
   let resolved = params.originatingChannelRaw || params.persistedLastChannel;
@@ -66,6 +77,9 @@ export function resolveLastToRaw(params: {
   sessionKey?: string;
 }): string | undefined {
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
+  if (originatingChannel === INTERNAL_MESSAGE_CHANNEL && isMainSessionKey(params.sessionKey)) {
+    return params.originatingToRaw || params.toRaw;
+  }
   const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);
   const sessionKeyChannelHint = resolveSessionKeyChannelHint(params.sessionKey);
 

--- a/src/auto-reply/reply/session-reset-prompt.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
+
+describe("buildBareSessionResetPrompt", () => {
+  it("includes the core session startup instruction", () => {
+    const prompt = buildBareSessionResetPrompt();
+    expect(prompt).toContain("Execute your Session Startup sequence now");
+    expect(prompt).toContain("read the required files before responding to the user");
+  });
+
+  it("appends current time line so agents know the date", () => {
+    const cfg = {
+      agents: { defaults: { userTimezone: "America/New_York" } },
+    } as OpenClawConfig;
+    // 2026-03-03 14:00 UTC = 2026-03-03 09:00 EST
+    const nowMs = Date.UTC(2026, 2, 3, 14, 0, 0);
+    const prompt = buildBareSessionResetPrompt(cfg, nowMs);
+    expect(prompt).toContain("Current time:");
+    expect(prompt).toContain("America/New_York");
+  });
+
+  it("does not append a duplicate current time line", () => {
+    const nowMs = Date.UTC(2026, 2, 3, 14, 0, 0);
+    const prompt = buildBareSessionResetPrompt(undefined, nowMs);
+    expect((prompt.match(/Current time:/g) ?? []).length).toBe(1);
+  });
+
+  it("falls back to UTC when no timezone configured", () => {
+    const nowMs = Date.UTC(2026, 2, 3, 14, 0, 0);
+    const prompt = buildBareSessionResetPrompt(undefined, nowMs);
+    expect(prompt).toContain("Current time:");
+  });
+});

--- a/src/auto-reply/reply/session-reset-prompt.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { OpenClawConfig } from "../../config/config.js";
+import type { RemoteClawConfig } from "../../config/config.js";
 import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
 
 describe("buildBareSessionResetPrompt", () => {
@@ -12,7 +12,7 @@ describe("buildBareSessionResetPrompt", () => {
   it("appends current time line so agents know the date", () => {
     const cfg = {
       agents: { defaults: { userTimezone: "America/New_York" } },
-    } as OpenClawConfig;
+    } as RemoteClawConfig;
     // 2026-03-03 14:00 UTC = 2026-03-03 09:00 EST
     const nowMs = Date.UTC(2026, 2, 3, 14, 0, 0);
     const prompt = buildBareSessionResetPrompt(cfg, nowMs);

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -1,2 +1,21 @@
-export const BARE_SESSION_RESET_PROMPT =
+import { appendCronStyleCurrentTimeLine } from "../../agents/current-time.js";
+import type { RemoteClawConfig } from "../../config/config.js";
+
+const BARE_SESSION_RESET_PROMPT_BASE =
   "A new session was started via /new or /reset. Execute your Session Startup sequence now - read the required files before responding to the user. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
+
+/**
+ * Build the bare session reset prompt, appending the current date/time so agents
+ * know which daily memory files to read during their Session Startup sequence.
+ * Without this, agents on /new or /reset guess the date from their training cutoff.
+ */
+export function buildBareSessionResetPrompt(cfg?: RemoteClawConfig, nowMs?: number): string {
+  return appendCronStyleCurrentTimeLine(
+    BARE_SESSION_RESET_PROMPT_BASE,
+    cfg ?? {},
+    nowMs ?? Date.now(),
+  );
+}
+
+/** @deprecated Use buildBareSessionResetPrompt(cfg) instead */
+export const BARE_SESSION_RESET_PROMPT = BARE_SESSION_RESET_PROMPT_BASE;

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1477,4 +1477,69 @@ describe("initSessionState internal channel routing preservation", () => {
 
     expect(result.sessionEntry.lastChannel).toBe("webchat");
   });
+
+  it("does not reuse stale external lastTo for webchat/main turns without destination", async () => {
+    const storePath = await createStorePath("webchat-main-no-stale-lastto-");
+    const sessionKey = "agent:main:main";
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: "sess-webchat-main-1",
+        updatedAt: Date.now(),
+        lastChannel: "whatsapp",
+        lastTo: "+15555550123",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15555550123",
+        },
+      },
+    });
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "webchat follow-up",
+        SessionKey: sessionKey,
+        OriginatingChannel: "webchat",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionEntry.lastChannel).toBe("webchat");
+    expect(result.sessionEntry.lastTo).toBeUndefined();
+  });
+
+  it("prefers webchat route over persisted external route for main session turns", async () => {
+    const storePath = await createStorePath("prefer-webchat-main-route-");
+    const sessionKey = "agent:main:main";
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: "sess-webchat-main-2",
+        updatedAt: Date.now(),
+        lastChannel: "whatsapp",
+        lastTo: "+15555550123",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15555550123",
+        },
+      },
+    });
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "reply only here",
+        SessionKey: sessionKey,
+        OriginatingChannel: "webchat",
+        OriginatingTo: "session:webchat-main",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionEntry.lastChannel).toBe("webchat");
+    expect(result.sessionEntry.lastTo).toBe("session:webchat-main");
+    expect(result.sessionEntry.deliveryContext?.channel).toBe("webchat");
+    expect(result.sessionEntry.deliveryContext?.to).toBe("session:webchat-main");
+  });
 });

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1493,7 +1493,7 @@ describe("initSessionState internal channel routing preservation", () => {
         },
       },
     });
-    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const cfg = { session: { store: storePath } } as RemoteClawConfig;
 
     const result = await initSessionState({
       ctx: {
@@ -1524,7 +1524,7 @@ describe("initSessionState internal channel routing preservation", () => {
         },
       },
     });
-    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const cfg = { session: { store: storePath } } as RemoteClawConfig;
 
     const result = await initSessionState({
       ctx: {

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -330,6 +330,7 @@ export type ChannelMessageActionContext = {
 export type ChannelToolSend = {
   to: string;
   accountId?: string | null;
+  threadId?: string | null;
 };
 
 export type ChannelMessageActionAdapter = {

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -12,6 +12,7 @@ const forceFreePortAndWait = vi.fn(async (_port: number, _opts: unknown) => ({
   waitedMs: 0,
   escalatedToSigkill: false,
 }));
+const waitForPortBindable = vi.fn(async (_port: number, _opts?: unknown) => 0);
 const runGatewayLoop = vi.fn(async ({ start }: { start: () => Promise<unknown> }) => {
   await start();
 });
@@ -79,6 +80,7 @@ vi.mock("../command-format.js", () => ({
 
 vi.mock("../ports.js", () => ({
   forceFreePortAndWait: (port: number, opts: unknown) => forceFreePortAndWait(port, opts),
+  waitForPortBindable: (port: number, opts?: unknown) => waitForPortBindable(port, opts),
 }));
 
 vi.mock("./run-loop.js", () => ({
@@ -103,6 +105,7 @@ describe("gateway run option collisions", () => {
     setGatewayWsLogStyle.mockClear();
     setVerbose.mockClear();
     forceFreePortAndWait.mockClear();
+    waitForPortBindable.mockClear();
     runGatewayLoop.mockClear();
   });
 
@@ -134,6 +137,10 @@ describe("gateway run option collisions", () => {
     ]);
 
     expect(forceFreePortAndWait).toHaveBeenCalledWith(18789, expect.anything());
+    expect(waitForPortBindable).toHaveBeenCalledWith(
+      18789,
+      expect.objectContaining({ host: "127.0.0.1" }),
+    );
     expect(setGatewayWsLogStyle).toHaveBeenCalledWith("full");
     expect(startGatewayServer).toHaveBeenCalledWith(
       18789,

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -21,7 +21,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
 import { inheritOptionFromParent } from "../command-options.js";
-import { forceFreePortAndWait } from "../ports.js";
+import { forceFreePortAndWait, waitForPortBindable } from "../ports.js";
 import { runGatewayLoop } from "./run-loop.js";
 import {
   describeUnknownError,
@@ -169,6 +169,20 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     defaultRuntime.error("Invalid port");
     defaultRuntime.exit(1);
   }
+  const bindRaw = toOptionString(opts.bind) ?? cfg.gateway?.bind ?? "loopback";
+  const bind =
+    bindRaw === "loopback" ||
+    bindRaw === "lan" ||
+    bindRaw === "auto" ||
+    bindRaw === "custom" ||
+    bindRaw === "tailnet"
+      ? bindRaw
+      : null;
+  if (!bind) {
+    defaultRuntime.error('Invalid --bind (use "loopback", "lan", "tailnet", "auto", or "custom")');
+    defaultRuntime.exit(1);
+    return;
+  }
   if (opts.force) {
     try {
       const { killed, waitedMs, escalatedToSigkill } = await forceFreePortAndWait(port, {
@@ -190,6 +204,23 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
         if (waitedMs > 0) {
           gatewayLog.info(`force: waited ${waitedMs}ms for port ${port} to free`);
         }
+      }
+      // After killing, verify the port is actually bindable (handles TIME_WAIT).
+      const bindProbeHost =
+        bind === "loopback"
+          ? "127.0.0.1"
+          : bind === "lan"
+            ? "0.0.0.0"
+            : bind === "custom"
+              ? toOptionString(cfg.gateway?.customBindHost)
+              : undefined;
+      const bindWaitMs = await waitForPortBindable(port, {
+        timeoutMs: 3000,
+        intervalMs: 150,
+        host: bindProbeHost,
+      });
+      if (bindWaitMs > 0) {
+        gatewayLog.info(`force: waited ${bindWaitMs}ms for port ${port} to become bindable`);
       }
     } catch (err) {
       defaultRuntime.error(`Force: ${String(err)}`);
@@ -240,21 +271,6 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     defaultRuntime.exit(1);
     return;
   }
-  const bindRaw = toOptionString(opts.bind) ?? cfg.gateway?.bind ?? "loopback";
-  const bind =
-    bindRaw === "loopback" ||
-    bindRaw === "lan" ||
-    bindRaw === "auto" ||
-    bindRaw === "custom" ||
-    bindRaw === "tailnet"
-      ? bindRaw
-      : null;
-  if (!bind) {
-    defaultRuntime.error('Invalid --bind (use "loopback", "lan", "tailnet", "auto", or "custom")');
-    defaultRuntime.exit(1);
-    return;
-  }
-
   const miskeys = extractGatewayMiskeys(snapshot?.parsed);
   const authOverride =
     authMode || passwordRaw || tokenRaw || authModeRaw

--- a/src/cli/ports.test.ts
+++ b/src/cli/ports.test.ts
@@ -1,0 +1,124 @@
+import { EventEmitter } from "node:events";
+import net from "node:net";
+import { describe, expect, it, vi } from "vitest";
+
+// Hoist the factory so vi.mock can access it.
+const mockCreateServer = vi.hoisted(() => vi.fn());
+
+vi.mock("node:net", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:net")>();
+  return { ...actual, createServer: mockCreateServer };
+});
+
+import { probePortFree, waitForPortBindable } from "./ports.js";
+
+/** Build a minimal fake net.Server that emits a given error code on listen(). */
+function makeErrServer(code: string): net.Server {
+  const err = Object.assign(new Error(`bind error: ${code}`), {
+    code,
+  }) as NodeJS.ErrnoException;
+
+  const fake = new EventEmitter() as unknown as net.Server;
+  (fake as unknown as { close: (cb?: () => void) => net.Server }).close = (cb?: () => void) => {
+    cb?.();
+    return fake;
+  };
+  (fake as unknown as { unref: () => net.Server }).unref = () => fake;
+  (fake as unknown as { listen: (...args: unknown[]) => net.Server }).listen = (
+    ..._args: unknown[]
+  ) => {
+    setImmediate(() => fake.emit("error", err));
+    return fake;
+  };
+  return fake;
+}
+
+describe("probePortFree", () => {
+  it("resolves false (not rejects) when bind returns EADDRINUSE", async () => {
+    mockCreateServer.mockReturnValue(makeErrServer("EADDRINUSE"));
+    await expect(probePortFree(9999, "127.0.0.1")).resolves.toBe(false);
+  });
+
+  it("rejects immediately for EADDRNOTAVAIL (non-retryable: host address not on any interface)", async () => {
+    mockCreateServer.mockReturnValue(makeErrServer("EADDRNOTAVAIL"));
+    await expect(probePortFree(9999, "192.0.2.1")).rejects.toMatchObject({ code: "EADDRNOTAVAIL" });
+  });
+
+  it("rejects immediately for EACCES (non-retryable bind error)", async () => {
+    mockCreateServer.mockReturnValue(makeErrServer("EACCES"));
+    await expect(probePortFree(80, "0.0.0.0")).rejects.toMatchObject({ code: "EACCES" });
+  });
+
+  it("rejects immediately for other non-retryable errors", async () => {
+    mockCreateServer.mockReturnValue(makeErrServer("EINVAL"));
+    await expect(probePortFree(9999, "0.0.0.0")).rejects.toMatchObject({ code: "EINVAL" });
+  });
+
+  it("resolves true when the port is free", async () => {
+    // Mock a successful bind: the "listening" event fires immediately without
+    // acquiring a real socket, making this deterministic and avoiding TOCTOU races.
+    // (A real-socket approach would bind to :0, release, then reprobe — the OS can
+    // reassign the ephemeral port in between, causing a flaky EADDRINUSE failure.)
+    const fakeServer = new EventEmitter() as unknown as net.Server;
+    (fakeServer as unknown as { close: (cb?: () => void) => net.Server }).close = (
+      cb?: () => void,
+    ) => {
+      cb?.();
+      return fakeServer;
+    };
+    (fakeServer as unknown as { unref: () => net.Server }).unref = () => fakeServer;
+    (fakeServer as unknown as { listen: (...args: unknown[]) => net.Server }).listen = (
+      ..._args: unknown[]
+    ) => {
+      // Simulate a successful bind by firing the "listening" callback.
+      const callback = _args.find((a) => typeof a === "function") as (() => void) | undefined;
+      setImmediate(() => callback?.());
+      return fakeServer;
+    };
+    mockCreateServer.mockReturnValue(fakeServer);
+
+    const result = await probePortFree(9999, "127.0.0.1");
+    expect(result).toBe(true);
+  });
+});
+
+describe("waitForPortBindable", () => {
+  it("probes the provided host when waiting for bindability", async () => {
+    const listenCalls: Array<{ port: number; host: string }> = [];
+    const fakeServer = new EventEmitter() as unknown as net.Server;
+    (fakeServer as unknown as { close: (cb?: () => void) => net.Server }).close = (
+      cb?: () => void,
+    ) => {
+      cb?.();
+      return fakeServer;
+    };
+    (fakeServer as unknown as { unref: () => net.Server }).unref = () => fakeServer;
+    (fakeServer as unknown as { listen: (...args: unknown[]) => net.Server }).listen = (
+      ...args: unknown[]
+    ) => {
+      const [port, host] = args as [number, string];
+      listenCalls.push({ port, host });
+      const callback = args.find((a) => typeof a === "function") as (() => void) | undefined;
+      setImmediate(() => callback?.());
+      return fakeServer;
+    };
+    mockCreateServer.mockReturnValue(fakeServer);
+
+    await expect(
+      waitForPortBindable(9999, { timeoutMs: 100, intervalMs: 10, host: "127.0.0.1" }),
+    ).resolves.toBe(0);
+    expect(listenCalls[0]).toEqual({ port: 9999, host: "127.0.0.1" });
+  });
+
+  it("propagates EACCES rejection immediately without retrying", async () => {
+    // Every call to createServer will emit EACCES — so if waitForPortBindable retried,
+    // mockCreateServer would be called many times. We assert it's called exactly once.
+    mockCreateServer.mockClear();
+    mockCreateServer.mockReturnValue(makeErrServer("EACCES"));
+    await expect(
+      waitForPortBindable(80, { timeoutMs: 5000, intervalMs: 50 }),
+    ).rejects.toMatchObject({ code: "EACCES" });
+    // Only one probe should have been attempted — no spinning through the retry loop.
+    expect(mockCreateServer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createServer } from "node:net";
 import { resolveLsofCommandSync } from "../infra/ports-lsof.js";
 import { tryListenOnPort } from "../infra/ports-probe.js";
 import { sleep } from "../utils.js";
@@ -323,4 +324,64 @@ export async function forceFreePortAndWait(
   throw new Error(
     `port ${port} still has listeners after --force: ${still.map((p) => p.pid).join(", ")}`,
   );
+}
+
+/**
+ * Attempt a real TCP bind to verify the port is available at the OS level.
+ * Catches TIME_WAIT / kernel-level holds that lsof won't show.
+ *
+ * Resolves false only for EADDRINUSE — a genuinely transient condition
+ * (port still in TIME_WAIT after a --force kill) that the caller should retry.
+ *
+ * All other errors are non-retryable and are rejected immediately:
+ * - EADDRNOTAVAIL: the host address doesn't exist on any local interface
+ *   (hard misconfiguration, not a transient kernel hold).
+ * - EACCES: bind to a privileged port as non-root.
+ * - EINVAL, etc.: other unrecoverable OS errors.
+ */
+export function probePortFree(port: number, host = "0.0.0.0"): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.unref();
+    srv.once("error", (err: NodeJS.ErrnoException) => {
+      srv.close();
+      if (err.code === "EADDRINUSE") {
+        // Genuinely transient — port still in use or TIME_WAIT after a --force kill.
+        resolve(false);
+      } else {
+        // Non-retryable: EADDRNOTAVAIL (bad host address), EACCES (privileged port),
+        // EINVAL, and any other OS errors. Surface immediately; no retry loop.
+        reject(err);
+      }
+    });
+    srv.listen(port, host, () => {
+      srv.close(() => resolve(true));
+    });
+  });
+}
+
+/**
+ * Poll until a real test-bind succeeds, up to `timeoutMs`.
+ * Returns the number of ms waited, or throws if the port never freed.
+ */
+export async function waitForPortBindable(
+  port: number,
+  opts: { timeoutMs?: number; intervalMs?: number; host?: string } = {},
+): Promise<number> {
+  const timeoutMs = Math.max(opts.timeoutMs ?? 3000, 0);
+  const intervalMs = Math.max(opts.intervalMs ?? 150, 1);
+  const host = opts.host;
+  let waited = 0;
+  while (waited < timeoutMs) {
+    if (await probePortFree(port, host)) {
+      return waited;
+    }
+    await sleep(intervalMs);
+    waited += intervalMs;
+  }
+  // Final attempt
+  if (await probePortFree(port, host)) {
+    return waited;
+  }
+  throw new Error(`port ${port} still not bindable after ${waited}ms (TIME_WAIT or kernel hold)`);
 }

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -257,10 +257,10 @@ describe("restart-helper", () => {
 
       const { scriptPath, content } = await prepareAndReadScript({
         HOME: "/Users/testuser",
-        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.it's-a-test",
+        REMOTECLAW_LAUNCHD_LABEL: "org.remoteclaw.it's-a-test",
       });
       // The plist path must also shell-escape the label to prevent injection
-      expect(content).toContain("ai.openclaw.it'\\''s-a-test.plist");
+      expect(content).toContain("org.remoteclaw.it'\\''s-a-test.plist");
       await cleanupScript(scriptPath);
     });
 

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -98,6 +98,8 @@ describe("restart-helper", () => {
       expect(scriptPath.endsWith(".sh")).toBe(true);
       expect(content).toContain("#!/bin/sh");
       expect(content).toContain("launchctl kickstart -k 'gui/501/org.remoteclaw.gateway'");
+      // Should fall back to bootstrap when kickstart fails (service deregistered after bootout)
+      expect(content).toContain("launchctl bootstrap 'gui/501'");
       expect(content).toContain('rm -f "$0"');
       await cleanupScript(scriptPath);
     });
@@ -220,6 +222,45 @@ describe("restart-helper", () => {
       // Single quotes should be escaped with '\'' pattern
       expect(content).not.toContain("it's");
       expect(content).toContain("it'\\''s");
+      await cleanupScript(scriptPath);
+    });
+
+    it("expands HOME in plist path instead of leaving literal $HOME", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      process.getuid = () => 501;
+
+      const { scriptPath, content } = await prepareAndReadScript({
+        HOME: "/Users/testuser",
+        OPENCLAW_PROFILE: "default",
+      });
+      // The plist path must contain the resolved home dir, not literal $HOME
+      expect(content).toMatch(/[\\/]Users[\\/]testuser[\\/]Library[\\/]LaunchAgents[\\/]/);
+      expect(content).not.toContain("$HOME");
+      await cleanupScript(scriptPath);
+    });
+
+    it("prefers env parameter HOME over process.env.HOME for plist path", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      process.getuid = () => 502;
+
+      const { scriptPath, content } = await prepareAndReadScript({
+        HOME: "/Users/envhome",
+        OPENCLAW_PROFILE: "default",
+      });
+      expect(content).toMatch(/[\\/]Users[\\/]envhome[\\/]Library[\\/]LaunchAgents[\\/]/);
+      await cleanupScript(scriptPath);
+    });
+
+    it("shell-escapes the label in the plist path on macOS", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      process.getuid = () => 501;
+
+      const { scriptPath, content } = await prepareAndReadScript({
+        HOME: "/Users/testuser",
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.it's-a-test",
+      });
+      // The plist path must also shell-escape the label to prevent injection
+      expect(content).toContain("ai.openclaw.it'\\''s-a-test.plist");
       await cleanupScript(scriptPath);
     });
 

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -83,12 +83,22 @@ rm -f "$0"
       const escaped = shellEscape(label);
       // Fallback to 501 if getuid is not available (though it should be on macOS)
       const uid = process.getuid ? process.getuid() : 501;
+      // Resolve HOME at generation time via env/process.env to match launchd.ts,
+      // and shell-escape the label in the plist filename to prevent injection.
+      const home = env.HOME?.trim() || process.env.HOME || os.homedir();
+      const plistPath = path.join(home, "Library", "LaunchAgents", `${label}.plist`);
+      const escapedPlistPath = shellEscape(plistPath);
       filename = `remoteclaw-restart-${timestamp}.sh`;
       scriptContent = `#!/bin/sh
 # Standalone restart script — survives parent process termination.
 # Wait briefly to ensure file locks are released after update.
 sleep 1
-launchctl kickstart -k 'gui/${uid}/${escaped}'
+# Try kickstart first (works when the service is still registered).
+# If it fails (e.g. after bootout), re-register via bootstrap then kickstart.
+if ! launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null; then
+  launchctl bootstrap 'gui/${uid}' '${escapedPlistPath}' 2>/dev/null
+  launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null || true
+fi
 # Self-cleanup
 rm -f "$0"
 `;

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -51,6 +51,11 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     actions: ["restart-heartbeat"],
   },
   {
+    prefix: "agents.defaults.models",
+    kind: "hot",
+    actions: ["restart-heartbeat"],
+  },
+  {
     prefix: "agents.defaults.model",
     kind: "hot",
     actions: ["restart-heartbeat"],

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -159,6 +159,14 @@ describe("buildGatewayReloadPlan", () => {
     );
   });
 
+  it("restarts heartbeat when agents.defaults.models allowlist changes", () => {
+    const plan = buildGatewayReloadPlan(["agents.defaults.models"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartHeartbeat).toBe(true);
+    expect(plan.hotReasons).toContain("agents.defaults.models");
+    expect(plan.noopPaths).toEqual([]);
+  });
+
   it("hot-reloads health monitor when channelHealthCheckMinutes changes", () => {
     const plan = buildGatewayReloadPlan(["gateway.channelHealthCheckMinutes"]);
     expect(plan.restartGateway).toBe(false);

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -266,6 +266,89 @@ describe("agent event handler", () => {
     nowSpy?.mockRestore();
   });
 
+  it("flushes buffered text as delta before final when throttle suppresses the latest chunk", () => {
+    let now = 10_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-flush", {
+      sessionKey: "session-flush",
+      clientRunId: "client-flush",
+    });
+
+    handler({
+      runId: "run-flush",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello" },
+    });
+
+    now = 10_100;
+    handler({
+      runId: "run-flush",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello world" },
+    });
+
+    emitLifecycleEnd(handler, "run-flush");
+
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(3);
+    const firstPayload = chatCalls[0]?.[1] as { state?: string };
+    const secondPayload = chatCalls[1]?.[1] as {
+      state?: string;
+      message?: { content?: Array<{ text?: string }> };
+    };
+    const thirdPayload = chatCalls[2]?.[1] as { state?: string };
+    expect(firstPayload.state).toBe("delta");
+    expect(secondPayload.state).toBe("delta");
+    expect(secondPayload.message?.content?.[0]?.text).toBe("Hello world");
+    expect(thirdPayload.state).toBe("final");
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(3);
+    nowSpy.mockRestore();
+  });
+
+  it("does not flush an extra delta when the latest text already broadcast", () => {
+    let now = 11_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-no-dup-flush", {
+      sessionKey: "session-no-dup-flush",
+      clientRunId: "client-no-dup-flush",
+    });
+
+    handler({
+      runId: "run-no-dup-flush",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello" },
+    });
+
+    now = 11_200;
+    handler({
+      runId: "run-no-dup-flush",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello world" },
+    });
+
+    emitLifecycleEnd(handler, "run-no-dup-flush");
+
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(3);
+    expect(chatCalls.map(([, payload]) => (payload as { state?: string }).state)).toEqual([
+      "delta",
+      "delta",
+      "final",
+    ]);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(3);
+    nowSpy.mockRestore();
+  });
+
   it("cleans up agent run sequence tracking when lifecycle completes", () => {
     const { agentRunSeq, chatRunState, handler, nowSpy } = createHarness({ now: 2_500 });
     chatRunState.registry.add("run-cleanup", {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -273,6 +273,7 @@ export function createAgentEventHandler({
     seq: number,
     jobState: "done" | "error",
     error?: unknown,
+    stopReason?: string,
   ) => {
     const text = stripInlineDirectiveTagsForDisplay(
       chatRunState.buffers.get(clientRunId) ?? "",
@@ -319,6 +320,7 @@ export function createAgentEventHandler({
         sessionKey,
         seq,
         state: "final" as const,
+        ...(stopReason && { stopReason }),
         message:
           text && !shouldSuppressSilent
             ? {
@@ -440,6 +442,8 @@ export function createAgentEventHandler({
       if (!isAborted && evt.stream === "assistant" && typeof evt.data?.text === "string") {
         emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text);
       } else if (!isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {
+        const evtStopReason =
+          typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
         if (chatLink) {
           const finished = chatRunState.registry.shift(evt.runId);
           if (!finished) {
@@ -453,6 +457,7 @@ export function createAgentEventHandler({
             evt.seq,
             lifecyclePhase === "error" ? "error" : "done",
             evt.data?.error,
+            evtStopReason,
           );
         } else {
           emitChatFinal(
@@ -462,6 +467,7 @@ export function createAgentEventHandler({
             evt.seq,
             lifecyclePhase === "error" ? "error" : "done",
             evt.data?.error,
+            evtStopReason,
           );
         }
       } else if (isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -88,6 +88,8 @@ export type ChatRunState = {
   registry: ChatRunRegistry;
   buffers: Map<string, string>;
   deltaSentAt: Map<string, number>;
+  /** Length of text at the time of the last broadcast, used to avoid duplicate flushes. */
+  deltaLastBroadcastLen: Map<string, number>;
   abortedRuns: Map<string, number>;
   clear: () => void;
 };
@@ -96,12 +98,14 @@ export function createChatRunState(): ChatRunState {
   const registry = createChatRunRegistry();
   const buffers = new Map<string, string>();
   const deltaSentAt = new Map<string, number>();
+  const deltaLastBroadcastLen = new Map<string, number>();
   const abortedRuns = new Map<string, number>();
 
   const clear = () => {
     registry.clear();
     buffers.clear();
     deltaSentAt.clear();
+    deltaLastBroadcastLen.clear();
     abortedRuns.clear();
   };
 
@@ -109,6 +113,7 @@ export function createChatRunState(): ChatRunState {
     registry,
     buffers,
     deltaSentAt,
+    deltaLastBroadcastLen,
     abortedRuns,
     clear,
   };
@@ -245,6 +250,7 @@ export function createAgentEventHandler({
       return;
     }
     chatRunState.deltaSentAt.set(clientRunId, now);
+    chatRunState.deltaLastBroadcastLen.set(clientRunId, cleaned.length);
     const payload = {
       runId: clientRunId,
       sessionKey,
@@ -272,6 +278,39 @@ export function createAgentEventHandler({
       chatRunState.buffers.get(clientRunId) ?? "",
     ).text.trim();
     const shouldSuppressSilent = isSilentReplyText(text, SILENT_REPLY_TOKEN);
+    const shouldSuppressSilentLeadFragment = isSilentReplyLeadFragment(text);
+    const shouldSuppressHeartbeatStreaming = shouldHideHeartbeatChatOutput(
+      clientRunId,
+      sourceRunId,
+    );
+    // Flush any throttled delta so streaming clients receive the complete text
+    // before the final event.  The 150 ms throttle in emitChatDelta may have
+    // suppressed the most recent chunk, leaving the client with stale text.
+    // Only flush if the buffer has grown since the last broadcast to avoid duplicates.
+    if (
+      text &&
+      !shouldSuppressSilent &&
+      !shouldSuppressSilentLeadFragment &&
+      !shouldSuppressHeartbeatStreaming
+    ) {
+      const lastBroadcastLen = chatRunState.deltaLastBroadcastLen.get(clientRunId) ?? 0;
+      if (text.length > lastBroadcastLen) {
+        const flushPayload = {
+          runId: clientRunId,
+          sessionKey,
+          seq,
+          state: "delta" as const,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text }],
+            timestamp: Date.now(),
+          },
+        };
+        broadcast("chat", flushPayload, { dropIfSlow: true });
+        nodeSendToSession(sessionKey, "chat", flushPayload);
+      }
+    }
+    chatRunState.deltaLastBroadcastLen.delete(clientRunId);
     chatRunState.buffers.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
     if (jobState === "done") {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -280,20 +280,11 @@ export function createAgentEventHandler({
     ).text.trim();
     const shouldSuppressSilent = isSilentReplyText(text, SILENT_REPLY_TOKEN);
     const shouldSuppressSilentLeadFragment = isSilentReplyLeadFragment(text);
-    const shouldSuppressHeartbeatStreaming = shouldHideHeartbeatChatOutput(
-      clientRunId,
-      sourceRunId,
-    );
     // Flush any throttled delta so streaming clients receive the complete text
     // before the final event.  The 150 ms throttle in emitChatDelta may have
     // suppressed the most recent chunk, leaving the client with stale text.
     // Only flush if the buffer has grown since the last broadcast to avoid duplicates.
-    if (
-      text &&
-      !shouldSuppressSilent &&
-      !shouldSuppressSilentLeadFragment &&
-      !shouldSuppressHeartbeatStreaming
-    ) {
+    if (text && !shouldSuppressSilent && !shouldSuppressSilentLeadFragment) {
       const lastBroadcastLen = chatRunState.deltaLastBroadcastLen.get(clientRunId) ?? 0;
       if (text.length > lastBroadcastLen) {
         const flushPayload = {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -450,8 +450,13 @@ describe("gateway agent handler", () => {
       { reqId: "4" },
     );
 
-    const call = await expectResetCall(BARE_SESSION_RESET_PROMPT);
+    await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    expect(mocks.sessionsResetHandler).toHaveBeenCalledTimes(1);
+    const call = readLastAgentCommandCall();
+    // Message is now dynamically built with current date — check key substrings
     expect(call?.message).toContain("Execute your Session Startup sequence now");
+    expect(call?.message).toContain("Current time:");
+    expect(call?.message).not.toBe(BARE_SESSION_RESET_PROMPT);
     expect(call?.sessionId).toBe("reset-session-id");
   });
 

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { listAgentIds } from "../../agents/agent-scope.js";
-import { BARE_SESSION_RESET_PROMPT } from "../../auto-reply/reply/session-reset-prompt.js";
+import { buildBareSessionResetPrompt } from "../../auto-reply/reply/session-reset-prompt.js";
 import { CHANNEL_IDS, type ChatChannelId } from "../../channels/registry.js";
 import { agentCommandFromIngress } from "../../commands/agent.js";
 import { loadConfig } from "../../config/config.js";
@@ -345,7 +345,9 @@ export const agentHandlers: GatewayRequestHandlers = {
       } else {
         // Keep bare /new and /reset behavior aligned with chat.send:
         // reset first, then run a fresh-session greeting prompt in-place.
-        message = BARE_SESSION_RESET_PROMPT;
+        // Date is embedded in the prompt so agents read the correct daily
+        // memory files; skip further timestamp injection to avoid duplication.
+        message = buildBareSessionResetPrompt(cfg);
         skipTimestampInjection = true;
       }
     }

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -30,7 +30,7 @@ vi.mock("../session-utils.js", async (importOriginal) => {
   const original = await importOriginal<typeof import("../session-utils.js")>();
   return {
     ...original,
-    loadSessionEntry: () => ({
+    loadSessionEntry: (rawKey: string) => ({
       cfg: {},
       storePath: path.join(path.dirname(mockState.transcriptPath), "sessions.json"),
       entry: {
@@ -38,7 +38,7 @@ vi.mock("../session-utils.js", async (importOriginal) => {
         sessionFile: mockState.transcriptPath,
         ...mockState.sessionEntry,
       },
-      canonicalKey: "main",
+      canonicalKey: rawKey || "main",
     }),
   };
 });
@@ -147,6 +147,7 @@ async function runNonStreamingChatSend(params: {
   respond: ReturnType<typeof vi.fn>;
   idempotencyKey: string;
   message?: string;
+  sessionKey?: string;
   client?: unknown;
   expectBroadcast?: boolean;
   requestParams?: Record<string, unknown>;
@@ -154,7 +155,7 @@ async function runNonStreamingChatSend(params: {
 }) {
   await chatHandlers["chat.send"]({
     params: {
-      sessionKey: "main",
+      sessionKey: params.sessionKey ?? "main",
       message: params.message ?? "hello",
       idempotencyKey: params.idempotencyKey,
       ...params.requestParams,
@@ -446,6 +447,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       context,
       respond,
       idempotencyKey: "idem-origin-routing",
+      sessionKey: "agent:main:telegram:direct:6812765697",
       expectBroadcast: false,
     });
 
@@ -479,6 +481,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       context,
       respond,
       idempotencyKey: "idem-feishu-origin-routing",
+      sessionKey: "agent:main:feishu:direct:ou_feishu_direct_123",
       expectBroadcast: false,
     });
 
@@ -487,6 +490,105 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         OriginatingChannel: "feishu",
         OriginatingTo: "ou_feishu_direct_123",
         AccountId: "default",
+      }),
+    );
+  });
+
+  it("chat.send inherits routing metadata for per-account channel-peer session keys", async () => {
+    createTranscriptFixture("openclaw-chat-send-per-account-channel-peer-routing-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "telegram",
+        to: "telegram:6812765697",
+        accountId: "account-a",
+      },
+      lastChannel: "telegram",
+      lastTo: "telegram:6812765697",
+      lastAccountId: "account-a",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-per-account-channel-peer-routing",
+      sessionKey: "agent:main:telegram:account-a:direct:6812765697",
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:6812765697",
+        AccountId: "account-a",
+      }),
+    );
+  });
+
+  it("chat.send does not inherit external delivery context for shared main sessions", async () => {
+    createTranscriptFixture("openclaw-chat-send-main-no-cross-route-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "discord",
+        to: "discord:1234567890",
+        accountId: "default",
+      },
+      lastChannel: "discord",
+      lastTo: "discord:1234567890",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-main-no-cross-route",
+      sessionKey: "main",
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "webchat",
+        OriginatingTo: undefined,
+        AccountId: undefined,
+      }),
+    );
+  });
+
+  it("chat.send does not inherit external delivery context for non-channel custom sessions", async () => {
+    createTranscriptFixture("openclaw-chat-send-custom-no-cross-route-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "discord",
+        to: "discord:1234567890",
+        accountId: "default",
+      },
+      lastChannel: "discord",
+      lastTo: "discord:1234567890",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-custom-no-cross-route",
+      sessionKey: "agent:main:work",
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "webchat",
+        OriginatingTo: undefined,
+        AccountId: undefined,
       }),
     );
   });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -12,6 +12,7 @@ import { CURRENT_SESSION_VERSION } from "../../config/sessions/constants.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
+import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import {
   stripInlineDirectiveTagsForDisplay,
   stripInlineDirectiveTagsFromMessageForDisplay,
@@ -74,6 +75,20 @@ const CHAT_HISTORY_TEXT_MAX_CHARS = 12_000;
 const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
 let chatHistoryPlaceholderEmitCount = 0;
+const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
+  "main",
+  "direct",
+  "dm",
+  "group",
+  "channel",
+  "cron",
+  "run",
+  "subagent",
+  "acp",
+  "thread",
+  "topic",
+]);
+const CHANNEL_SCOPED_SESSION_SHAPES = new Set(["direct", "dm", "group", "channel"]);
 
 function stripDisallowedChatControlChars(message: string): string {
   let output = "";
@@ -888,7 +903,30 @@ export const chatHandlers: GatewayRequestHandlers = {
       const routeAccountIdCandidate =
         entry?.deliveryContext?.accountId ?? entry?.lastAccountId ?? undefined;
       const routeThreadIdCandidate = entry?.deliveryContext?.threadId ?? entry?.lastThreadId;
+      const parsedSessionKey = parseAgentSessionKey(sessionKey);
+      const sessionScopeParts = (parsedSessionKey?.rest ?? sessionKey).split(":").filter(Boolean);
+      const sessionScopeHead = sessionScopeParts[0];
+      const sessionChannelHint = normalizeMessageChannel(sessionScopeHead);
+      const sessionPeerShapeCandidates = [sessionScopeParts[1], sessionScopeParts[2]]
+        .map((part) => (part ?? "").trim().toLowerCase())
+        .filter(Boolean);
+      const isChannelAgnosticSessionScope = CHANNEL_AGNOSTIC_SESSION_SCOPES.has(
+        (sessionScopeHead ?? "").trim().toLowerCase(),
+      );
+      const isChannelScopedSession = sessionPeerShapeCandidates.some((part) =>
+        CHANNEL_SCOPED_SESSION_SHAPES.has(part),
+      );
+      // Only inherit prior external route metadata for channel-scoped sessions.
+      // Channel-agnostic sessions (main, direct:<peer>, etc.) can otherwise
+      // leak stale routes across surfaces.
+      const canInheritDeliverableRoute = Boolean(
+        sessionChannelHint &&
+        sessionChannelHint !== INTERNAL_MESSAGE_CHANNEL &&
+        !isChannelAgnosticSessionScope &&
+        isChannelScopedSession,
+      );
       const hasDeliverableRoute =
+        canInheritDeliverableRoute &&
         routeChannelCandidate &&
         routeChannelCandidate !== INTERNAL_MESSAGE_CHANNEL &&
         typeof routeToCandidate === "string" &&

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
 import { whatsappPlugin } from "../../extensions/whatsapp/src/channel.js";
-import { BARE_SESSION_RESET_PROMPT } from "../auto-reply/reply/session-reset-prompt.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { emitAgentEvent, registerAgentRunContext } from "../infra/agent-events.js";
 import { setRegistry } from "./server.agent.gateway-server-agent.mocks.js";
@@ -287,9 +286,9 @@ describe("gateway server agent", () => {
 
     await vi.waitFor(() => expect(calls.length).toBeGreaterThan(callsBefore));
     const call = (calls.at(-1)?.[0] ?? {}) as Record<string, unknown>;
-    expect(call.message).toBe(BARE_SESSION_RESET_PROMPT);
     expect(call.message).toBeTypeOf("string");
     expect(call.message).toContain("Execute your Session Startup sequence now");
+    expect(call.message).toContain("Current time:");
     expect(typeof call.sessionId).toBe("string");
     expect(call.sessionId).not.toBe("sess-main-before-reset");
   });

--- a/src/gateway/server.auth.default-token.suite.ts
+++ b/src/gateway/server.auth.default-token.suite.ts
@@ -112,7 +112,8 @@ export function registerDefaultAuthTokenSuite(): void {
       ws.close();
     });
 
-    test("connect (req) handshake resolves server version from env precedence", async () => {
+    test("connect (req) handshake resolves server version from runtime precedence", async () => {
+      const { VERSION } = await import("../version.js");
       for (const testCase of [
         {
           env: {
@@ -120,7 +121,7 @@ export function registerDefaultAuthTokenSuite(): void {
             OPENCLAW_SERVICE_VERSION: "2.4.6-service",
             npm_package_version: "1.0.0-package",
           },
-          expectedVersion: "2.4.6-service",
+          expectedVersion: VERSION,
         },
         {
           env: {
@@ -136,7 +137,7 @@ export function registerDefaultAuthTokenSuite(): void {
             OPENCLAW_SERVICE_VERSION: "\t",
             npm_package_version: "1.0.0-package",
           },
-          expectedVersion: "1.0.0-package",
+          expectedVersion: VERSION,
         },
       ]) {
         await withRuntimeVersionEnv(testCase.env, async () =>

--- a/src/gateway/server/http-listen.test.ts
+++ b/src/gateway/server/http-listen.test.ts
@@ -1,0 +1,100 @@
+import { EventEmitter } from "node:events";
+import type { Server as HttpServer } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { GatewayLockError } from "../../infra/gateway-lock.js";
+import { listenGatewayHttpServer } from "./http-listen.js";
+
+const sleepMock = vi.hoisted(() => vi.fn(async (_ms: number) => {}));
+
+vi.mock("../../utils.js", () => ({
+  sleep: (ms: number) => sleepMock(ms),
+}));
+
+type ListenOutcome = { kind: "error"; code: string } | { kind: "listening" };
+
+function createFakeHttpServer(outcomes: ListenOutcome[]) {
+  class FakeHttpServer extends EventEmitter {
+    public closeCalls = 0;
+    private attempt = 0;
+
+    listen(_port: number, _host: string) {
+      const outcome = outcomes[this.attempt] ?? { kind: "listening" };
+      this.attempt += 1;
+      setImmediate(() => {
+        if (outcome.kind === "error") {
+          const err = Object.assign(new Error(outcome.code), { code: outcome.code });
+          this.emit("error", err);
+        } else {
+          this.emit("listening");
+        }
+      });
+      return this;
+    }
+
+    close(cb?: () => void) {
+      this.closeCalls += 1;
+      setImmediate(() => cb?.());
+      return this;
+    }
+  }
+
+  return new FakeHttpServer();
+}
+
+describe("listenGatewayHttpServer", () => {
+  it("retries EADDRINUSE and closes server handle before retry", async () => {
+    sleepMock.mockClear();
+    const fake = createFakeHttpServer([
+      { kind: "error", code: "EADDRINUSE" },
+      { kind: "listening" },
+    ]);
+
+    await expect(
+      listenGatewayHttpServer({
+        httpServer: fake as unknown as HttpServer,
+        bindHost: "127.0.0.1",
+        port: 18789,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fake.closeCalls).toBe(1);
+    expect(sleepMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws GatewayLockError after EADDRINUSE retries are exhausted", async () => {
+    sleepMock.mockClear();
+    const fake = createFakeHttpServer([
+      { kind: "error", code: "EADDRINUSE" },
+      { kind: "error", code: "EADDRINUSE" },
+      { kind: "error", code: "EADDRINUSE" },
+      { kind: "error", code: "EADDRINUSE" },
+      { kind: "error", code: "EADDRINUSE" },
+      { kind: "error", code: "EADDRINUSE" },
+    ]);
+
+    await expect(
+      listenGatewayHttpServer({
+        httpServer: fake as unknown as HttpServer,
+        bindHost: "127.0.0.1",
+        port: 18789,
+      }),
+    ).rejects.toBeInstanceOf(GatewayLockError);
+
+    expect(fake.closeCalls).toBe(4);
+  });
+
+  it("wraps non-EADDRINUSE errors as GatewayLockError", async () => {
+    sleepMock.mockClear();
+    const fake = createFakeHttpServer([{ kind: "error", code: "EACCES" }]);
+
+    await expect(
+      listenGatewayHttpServer({
+        httpServer: fake as unknown as HttpServer,
+        bindHost: "127.0.0.1",
+        port: 18789,
+      }),
+    ).rejects.toBeInstanceOf(GatewayLockError);
+
+    expect(fake.closeCalls).toBe(0);
+  });
+});

--- a/src/gateway/server/http-listen.ts
+++ b/src/gateway/server/http-listen.ts
@@ -1,5 +1,19 @@
 import type { Server as HttpServer } from "node:http";
 import { GatewayLockError } from "../../infra/gateway-lock.js";
+import { sleep } from "../../utils.js";
+
+const EADDRINUSE_MAX_RETRIES = 4;
+const EADDRINUSE_RETRY_INTERVAL_MS = 500;
+
+async function closeServerQuietly(httpServer: HttpServer): Promise<void> {
+  await new Promise<void>((resolve) => {
+    try {
+      httpServer.close(() => resolve());
+    } catch {
+      resolve();
+    }
+  });
+}
 
 export async function listenGatewayHttpServer(params: {
   httpServer: HttpServer;
@@ -7,31 +21,41 @@ export async function listenGatewayHttpServer(params: {
   port: number;
 }) {
   const { httpServer, bindHost, port } = params;
-  try {
-    await new Promise<void>((resolve, reject) => {
-      const onError = (err: NodeJS.ErrnoException) => {
-        httpServer.off("listening", onListening);
-        reject(err);
-      };
-      const onListening = () => {
-        httpServer.off("error", onError);
-        resolve();
-      };
-      httpServer.once("error", onError);
-      httpServer.once("listening", onListening);
-      httpServer.listen(port, bindHost);
-    });
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "EADDRINUSE") {
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (err: NodeJS.ErrnoException) => {
+          httpServer.off("listening", onListening);
+          reject(err);
+        };
+        const onListening = () => {
+          httpServer.off("error", onError);
+          resolve();
+        };
+        httpServer.once("error", onError);
+        httpServer.once("listening", onListening);
+        httpServer.listen(port, bindHost);
+      });
+      return; // bound successfully
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "EADDRINUSE" && attempt < EADDRINUSE_MAX_RETRIES) {
+        // Port may still be in TIME_WAIT after a recent process exit; retry.
+        await closeServerQuietly(httpServer);
+        await sleep(EADDRINUSE_RETRY_INTERVAL_MS);
+        continue;
+      }
+      if (code === "EADDRINUSE") {
+        throw new GatewayLockError(
+          `another gateway instance is already listening on ws://${bindHost}:${port}`,
+          err,
+        );
+      }
       throw new GatewayLockError(
-        `another gateway instance is already listening on ws://${bindHost}:${port}`,
+        `failed to bind gateway socket on ws://${bindHost}:${port}: ${String(err)}`,
         err,
       );
     }
-    throw new GatewayLockError(
-      `failed to bind gateway socket on ws://${bindHost}:${port}: ${String(err)}`,
-      err,
-    );
   }
 }

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1031,7 +1031,7 @@ export function attachGatewayWsMessageHandler(params: {
           type: "hello-ok",
           protocol: PROTOCOL_VERSION,
           server: {
-            version: resolveRuntimeServiceVersion(process.env, "dev"),
+            version: resolveRuntimeServiceVersion(process.env),
             connId,
           },
           features: { methods: gatewayMethods, events },

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -4,12 +4,14 @@ import path from "node:path";
 import { describe, expect, test } from "vitest";
 import type { RemoteClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import {
   capArrayByJsonBytes,
   classifySessionKey,
   deriveSessionTitle,
   listAgentsForGateway,
   listSessionsFromStore,
+  loadCombinedSessionStoreForGateway,
   parseGroupKey,
   pruneLegacyStoreKeys,
   resolveGatewaySessionStoreTarget,
@@ -276,6 +278,21 @@ describe("gateway session utils", () => {
     expect(result.agents[0]?.identity?.avatarUrl).toBe(
       `data:image/png;base64,${Buffer.from("avatar").toString("base64")}`,
     );
+  });
+
+  test("listAgentsForGateway keeps explicit agents.list scope over disk-only agents (scope boundary)", async () => {
+    await withStateDirEnv("openclaw-agent-list-scope-", async ({ stateDir }) => {
+      fs.mkdirSync(path.join(stateDir, "agents", "main"), { recursive: true });
+      fs.mkdirSync(path.join(stateDir, "agents", "codex"), { recursive: true });
+
+      const cfg = {
+        session: { mainKey: "main" },
+        agents: { list: [{ id: "main", default: true }] },
+      } as OpenClawConfig;
+
+      const { agents } = listAgentsForGateway(cfg);
+      expect(agents.map((agent) => agent.id)).toEqual(["main"]);
+    });
   });
 });
 
@@ -824,5 +841,47 @@ describe("listSessionsFromStore search", () => {
     expect(stale?.totalTokensFresh).toBe(false);
     expect(missing?.totalTokens).toBeUndefined();
     expect(missing?.totalTokensFresh).toBe(false);
+  });
+});
+
+describe("loadCombinedSessionStoreForGateway includes disk-only agents (#32804)", () => {
+  test("ACP agent sessions are visible even when agents.list is configured", async () => {
+    await withStateDirEnv("openclaw-acp-vis-", async ({ stateDir }) => {
+      const agentsDir = path.join(stateDir, "agents");
+      const mainDir = path.join(agentsDir, "main", "sessions");
+      const codexDir = path.join(agentsDir, "codex", "sessions");
+      fs.mkdirSync(mainDir, { recursive: true });
+      fs.mkdirSync(codexDir, { recursive: true });
+
+      fs.writeFileSync(
+        path.join(mainDir, "sessions.json"),
+        JSON.stringify({
+          "agent:main:main": { sessionId: "s-main", updatedAt: 100 },
+        }),
+        "utf8",
+      );
+
+      fs.writeFileSync(
+        path.join(codexDir, "sessions.json"),
+        JSON.stringify({
+          "agent:codex:acp-task": { sessionId: "s-codex", updatedAt: 200 },
+        }),
+        "utf8",
+      );
+
+      const cfg = {
+        session: {
+          mainKey: "main",
+          store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+        },
+        agents: {
+          list: [{ id: "main", default: true }],
+        },
+      } as OpenClawConfig;
+
+      const { store } = loadCombinedSessionStoreForGateway(cfg);
+      expect(store["agent:main:main"]).toBeDefined();
+      expect(store["agent:codex:acp-task"]).toBeDefined();
+    });
   });
 });

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -288,7 +288,7 @@ describe("gateway session utils", () => {
       const cfg = {
         session: { mainKey: "main" },
         agents: { list: [{ id: "main", default: true }] },
-      } as OpenClawConfig;
+      } as RemoteClawConfig;
 
       const { agents } = listAgentsForGateway(cfg);
       expect(agents.map((agent) => agent.id)).toEqual(["main"]);
@@ -877,7 +877,7 @@ describe("loadCombinedSessionStoreForGateway includes disk-only agents (#32804)"
         agents: {
           list: [{ id: "main", default: true }],
         },
-      } as OpenClawConfig;
+      } as RemoteClawConfig;
 
       const { store } = loadCombinedSessionStoreForGateway(cfg);
       expect(store["agent:main:main"]).toBeDefined();

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -305,35 +305,25 @@ function listExistingAgentIdsFromDisk(): string[] {
 }
 
 function listConfiguredAgentIds(cfg: RemoteClawConfig): string[] {
-  const agents = cfg.agents?.list ?? [];
-  if (agents.length > 0) {
-    const ids = new Set<string>();
-    for (const entry of agents) {
-      if (entry?.id) {
-        ids.add(normalizeAgentId(entry.id));
-      }
-    }
-    const defaultId = normalizeAgentId(resolveDefaultAgentId(cfg));
-    ids.add(defaultId);
-    const sorted = Array.from(ids).filter(Boolean);
-    sorted.sort((a, b) => a.localeCompare(b));
-    return sorted.includes(defaultId)
-      ? [defaultId, ...sorted.filter((id) => id !== defaultId)]
-      : sorted;
-  }
-
   const ids = new Set<string>();
   const defaultId = normalizeAgentId(resolveDefaultAgentId(cfg));
   ids.add(defaultId);
+
+  for (const entry of cfg.agents?.list ?? []) {
+    if (entry?.id) {
+      ids.add(normalizeAgentId(entry.id));
+    }
+  }
+
   for (const id of listExistingAgentIdsFromDisk()) {
     ids.add(id);
   }
+
   const sorted = Array.from(ids).filter(Boolean);
   sorted.sort((a, b) => a.localeCompare(b));
-  if (sorted.includes(defaultId)) {
-    return [defaultId, ...sorted.filter((id) => id !== defaultId)];
-  }
-  return sorted;
+  return sorted.includes(defaultId)
+    ? [defaultId, ...sorted.filter((id) => id !== defaultId)]
+    : sorted;
 }
 
 export function listAgentsForGateway(cfg: RemoteClawConfig): {

--- a/src/infra/restart-stale-pids.test.ts
+++ b/src/infra/restart-stale-pids.test.ts
@@ -1,0 +1,810 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// This entire file tests lsof-based Unix port polling. The feature is a deliberate
+// no-op on Windows (findGatewayPidsOnPortSync returns [] immediately). Running these
+// tests on a Windows CI runner would require lsof which does not exist there, so we
+// skip the suite entirely and rely on the Linux/macOS runners for coverage.
+const isWindows = process.platform === "win32";
+
+const mockSpawnSync = vi.hoisted(() => vi.fn());
+const mockResolveGatewayPort = vi.hoisted(() => vi.fn(() => 18789));
+const mockRestartWarn = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  spawnSync: (...args: unknown[]) => mockSpawnSync(...args),
+  execFileSync: vi.fn(),
+}));
+
+vi.mock("../config/paths.js", () => ({
+  resolveGatewayPort: () => mockResolveGatewayPort(),
+}));
+
+vi.mock("./ports-lsof.js", () => ({
+  resolveLsofCommandSync: vi.fn(() => "lsof"),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: vi.fn(() => ({
+    warn: (...args: unknown[]) => mockRestartWarn(...args),
+    info: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+import { resolveLsofCommandSync } from "./ports-lsof.js";
+import {
+  __testing,
+  cleanStaleGatewayProcessesSync,
+  findGatewayPidsOnPortSync,
+} from "./restart-stale-pids.js";
+
+function lsofOutput(entries: Array<{ pid: number; cmd: string }>): string {
+  return entries.map(({ pid, cmd }) => `p${pid}\nc${cmd}`).join("\n") + "\n";
+}
+
+describe.skipIf(isWindows)("restart-stale-pids", () => {
+  beforeEach(() => {
+    mockSpawnSync.mockReset();
+    mockResolveGatewayPort.mockReset();
+    mockRestartWarn.mockReset();
+    mockResolveGatewayPort.mockReturnValue(18789);
+    __testing.setSleepSyncOverride(() => {});
+  });
+
+  afterEach(() => {
+    __testing.setSleepSyncOverride(null);
+    __testing.setDateNowOverride(null);
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // findGatewayPidsOnPortSync
+  // -------------------------------------------------------------------------
+  describe("findGatewayPidsOnPortSync", () => {
+    it("returns [] when lsof exits with non-zero status", () => {
+      mockSpawnSync.mockReturnValue({ error: null, status: 1, stdout: "", stderr: "" });
+      expect(findGatewayPidsOnPortSync(18789)).toEqual([]);
+    });
+
+    it("logs warning when initial lsof scan exits with status > 1", () => {
+      mockSpawnSync.mockReturnValue({ error: null, status: 2, stdout: "", stderr: "lsof error" });
+      expect(findGatewayPidsOnPortSync(18789)).toEqual([]);
+      expect(mockRestartWarn).toHaveBeenCalledWith(
+        expect.stringContaining("lsof exited with status 2"),
+      );
+    });
+
+    it("returns [] when lsof returns an error object (e.g. ENOENT)", () => {
+      mockSpawnSync.mockReturnValue({
+        error: new Error("ENOENT"),
+        status: null,
+        stdout: "",
+        stderr: "",
+      });
+      expect(findGatewayPidsOnPortSync(18789)).toEqual([]);
+      expect(mockRestartWarn).toHaveBeenCalledWith(
+        expect.stringContaining("lsof failed during initial stale-pid scan"),
+      );
+    });
+
+    it("parses openclaw-gateway pids and excludes the current process", () => {
+      const stalePid = process.pid + 1;
+      mockSpawnSync.mockReturnValue({
+        error: null,
+        status: 0,
+        stdout: lsofOutput([
+          { pid: stalePid, cmd: "openclaw-gateway" },
+          { pid: process.pid, cmd: "openclaw-gateway" },
+        ]),
+        stderr: "",
+      });
+      const pids = findGatewayPidsOnPortSync(18789);
+      expect(pids).toContain(stalePid);
+      expect(pids).not.toContain(process.pid);
+    });
+
+    it("excludes pids whose command does not include 'openclaw'", () => {
+      const otherPid = process.pid + 2;
+      mockSpawnSync.mockReturnValue({
+        error: null,
+        status: 0,
+        stdout: lsofOutput([{ pid: otherPid, cmd: "nginx" }]),
+        stderr: "",
+      });
+      expect(findGatewayPidsOnPortSync(18789)).toEqual([]);
+    });
+
+    it("forwards the spawnTimeoutMs argument to spawnSync", () => {
+      mockSpawnSync.mockReturnValue({ error: null, status: 0, stdout: "", stderr: "" });
+      findGatewayPidsOnPortSync(18789, 400);
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        "lsof",
+        expect.any(Array),
+        expect.objectContaining({ timeout: 400 }),
+      );
+    });
+
+    it("deduplicates pids from dual-stack listeners (IPv4+IPv6 emit same pid twice)", () => {
+      // Dual-stack listeners cause lsof to emit the same PID twice in -Fpc output
+      // (once for the IPv4 socket, once for IPv6). Without dedup, terminateStaleProcessesSync
+      // sends SIGTERM twice and returns killed=[pid, pid], corrupting the count.
+      const stalePid = process.pid + 600;
+      const stdout = `p${stalePid}\ncopenclaw-gateway\np${stalePid}\ncopenclaw-gateway\n`;
+      mockSpawnSync.mockReturnValue({ error: null, status: 0, stdout, stderr: "" });
+      const result = findGatewayPidsOnPortSync(18789);
+      expect(result).toEqual([stalePid]); // deduped — not [pid, pid]
+    });
+
+    it("returns [] and skips lsof on win32", () => {
+      // The entire describe block is skipped on Windows (isWindows guard at top),
+      // so this test only runs on Linux/macOS. It mocks platform to win32 for the
+      // single assertion without needing to restore — the suite-level skipIf means
+      // this will never run on an actual Windows runner where the mock could leak.
+      const origDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      try {
+        expect(findGatewayPidsOnPortSync(18789)).toEqual([]);
+        expect(mockSpawnSync).not.toHaveBeenCalled();
+      } finally {
+        if (origDescriptor) {
+          Object.defineProperty(process, "platform", origDescriptor);
+        }
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // parsePidsFromLsofOutput — pure unit tests (no I/O, driven via spawnSync mock)
+  // -------------------------------------------------------------------------
+  describe("parsePidsFromLsofOutput (via findGatewayPidsOnPortSync stdout path)", () => {
+    it("returns [] for empty lsof stdout (status 0, nothing listening)", () => {
+      mockSpawnSync.mockReturnValue({ error: null, status: 0, stdout: "", stderr: "" });
+      expect(findGatewayPidsOnPortSync(18789)).toEqual([]);
+    });
+
+    it("parses multiple openclaw pids from a single lsof output block", () => {
+      const pid1 = process.pid + 10;
+      const pid2 = process.pid + 11;
+      mockSpawnSync.mockReturnValue({
+        error: null,
+        status: 0,
+        stdout: lsofOutput([
+          { pid: pid1, cmd: "openclaw-gateway" },
+          { pid: pid2, cmd: "openclaw-gateway" },
+        ]),
+        stderr: "",
+      });
+      const result = findGatewayPidsOnPortSync(18789);
+      expect(result).toContain(pid1);
+      expect(result).toContain(pid2);
+    });
+
+    it("returns [] when status 0 but only non-openclaw pids present", () => {
+      // Port may be bound by an unrelated process. findGatewayPidsOnPortSync
+      // only tracks openclaw processes — non-openclaw listeners are ignored.
+      const otherPid = process.pid + 50;
+      mockSpawnSync.mockReturnValue({
+        error: null,
+        status: 0,
+        stdout: lsofOutput([{ pid: otherPid, cmd: "caddy" }]),
+        stderr: "",
+      });
+      expect(findGatewayPidsOnPortSync(18789)).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // pollPortOnce (via cleanStaleGatewayProcessesSync) — Codex P1 regression
+  // -------------------------------------------------------------------------
+  describe("pollPortOnce — no second lsof spawn (Codex P1 regression)", () => {
+    it("treats lsof exit status 1 as port-free (no listeners)", () => {
+      // lsof exits with status 1 when no matching processes are found — this is
+      // the canonical "port is free" signal, not an error.
+      const stalePid = process.pid + 500;
+      let call = 0;
+      mockSpawnSync.mockImplementation(() => {
+        call++;
+        if (call === 1) {
+          return {
+            error: null,
+            status: 0,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "",
+          };
+        }
+        // Poll returns status 1 — no listeners
+        return { error: null, status: 1, stdout: "", stderr: "" };
+      });
+      vi.spyOn(process, "kill").mockReturnValue(true);
+      // Should complete cleanly (port reported free on status 1)
+      expect(() => cleanStaleGatewayProcessesSync()).not.toThrow();
+    });
+
+    it("treats lsof exit status >1 as inconclusive, not port-free — Codex P2 regression", () => {
+      // Codex P2: non-zero lsof exits other than status 1 (e.g. permission denied,
+      // bad flag, runtime error) must not be mapped to free:true. They are
+      // inconclusive and should keep the polling loop running until budget expires.
+      const stalePid = process.pid + 501;
+      let call = 0;
+      const events: string[] = [];
+      mockSpawnSync.mockImplementation(() => {
+        call++;
+        if (call === 1) {
+          events.push("initial-find");
+          return {
+            error: null,
+            status: 0,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "",
+          };
+        }
+        if (call === 2) {
+          // Permission/runtime error — status 2, should NOT be treated as free
+          events.push("error-poll");
+          return { error: null, status: 2, stdout: "", stderr: "lsof: permission denied" };
+        }
+        // Eventually port is free
+        events.push("free-poll");
+        return { error: null, status: 1, stdout: "", stderr: "" };
+      });
+      vi.spyOn(process, "kill").mockReturnValue(true);
+      cleanStaleGatewayProcessesSync();
+
+      // Must have continued polling after the status-2 error, not exited early
+      expect(events).toContain("free-poll");
+    });
+
+    it("does not make a second lsof call when the first returns status 0", () => {
+      // The bug: pollPortOnce previously called findGatewayPidsOnPortSync as a
+      // second probe after getting status===0 from the first lsof. That second
+      // call collapses any error/timeout back into [], which maps to free:true —
+      // silently misclassifying an inconclusive result as "port is free".
+      //
+      // The fix: pollPortOnce now parses res.stdout directly from the first
+      // spawnSync call. Exactly ONE lsof invocation per poll cycle.
+      const stalePid = process.pid + 400;
+      let spawnCount = 0;
+      mockSpawnSync.mockImplementation(() => {
+        spawnCount++;
+        if (spawnCount === 1) {
+          // Initial findGatewayPidsOnPortSync — returns stale pid
+          return {
+            error: null,
+            status: 0,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "",
+          };
+        }
+        if (spawnCount === 2) {
+          // First waitForPortFreeSync poll — status 0, port busy (should parse inline, not spawn again)
+          return {
+            error: null,
+            status: 0,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "",
+          };
+        }
+        // Port free on third call
+        return { error: null, status: 0, stdout: "", stderr: "" };
+      });
+
+      vi.spyOn(process, "kill").mockReturnValue(true);
+      cleanStaleGatewayProcessesSync();
+
+      // If pollPortOnce made a second lsof call internally, spawnCount would
+      // be at least 4 (initial + 2 polls each doubled). With the fix, each poll
+      // is exactly one spawn: initial(1) + busy-poll(1) + free-poll(1) = 3.
+      expect(spawnCount).toBe(3);
+    });
+
+    it("lsof status 1 with non-empty openclaw stdout is treated as busy, not free (Linux container edge case)", () => {
+      // On Linux containers with restricted /proc (AppArmor, seccomp, user namespaces),
+      // lsof can exit 1 AND still emit output for processes it could read.
+      // status 1 + non-empty openclaw stdout must not be treated as port-free.
+      const stalePid = process.pid + 601;
+      let call = 0;
+      mockSpawnSync.mockImplementation(() => {
+        call++;
+        if (call === 1) {
+          // Initial scan: finds stale pid
+          return {
+            error: null,
+            status: 0,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "",
+          };
+        }
+        if (call === 2) {
+          // status 1 + openclaw pid in stdout — container-restricted lsof reports partial results
+          return {
+            error: null,
+            status: 1,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "lsof: WARNING: can't stat() fuse",
+          };
+        }
+        // Third poll: port is genuinely free
+        return { error: null, status: 1, stdout: "", stderr: "" };
+      });
+      vi.spyOn(process, "kill").mockReturnValue(true);
+      cleanStaleGatewayProcessesSync();
+      // Poll 2 returned busy (not free), so we must have polled at least 3 times
+      expect(call).toBeGreaterThanOrEqual(3);
+    });
+
+    it("pollPortOnce outer catch returns { free: null, permanent: false } when resolveLsofCommandSync throws", () => {
+      // If resolveLsofCommandSync throws (e.g. lsof resolution fails at runtime),
+      // pollPortOnce must catch it and return the transient-inconclusive result
+      // rather than propagating the exception.
+      const stalePid = process.pid + 402;
+      const mockedResolveLsof = vi.mocked(resolveLsofCommandSync);
+
+      mockedResolveLsof.mockImplementationOnce(() => {
+        // First call: initial findGatewayPidsOnPortSync — succeed normally
+        return "lsof";
+      });
+
+      mockSpawnSync.mockImplementationOnce(() => {
+        // Initial scan: finds stale pid
+        return {
+          error: null,
+          status: 0,
+          stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+          stderr: "",
+        };
+      });
+
+      // Second call: poll — resolveLsofCommandSync throws
+      mockedResolveLsof.mockImplementationOnce(() => {
+        throw new Error("lsof binary resolution failed");
+      });
+
+      // Third call: poll — port is free
+      mockedResolveLsof.mockImplementation(() => "lsof");
+      mockSpawnSync.mockImplementation(() => ({ error: null, status: 1, stdout: "", stderr: "" }));
+
+      vi.spyOn(process, "kill").mockReturnValue(true);
+      // Must not throw — the catch path returns transient inconclusive, loop continues
+      expect(() => cleanStaleGatewayProcessesSync()).not.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // cleanStaleGatewayProcessesSync
+  // -------------------------------------------------------------------------
+  describe("cleanStaleGatewayProcessesSync", () => {
+    it("returns [] and does not call process.kill when port has no listeners", () => {
+      mockSpawnSync.mockReturnValue({ error: null, status: 0, stdout: "", stderr: "" });
+      const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+      expect(cleanStaleGatewayProcessesSync()).toEqual([]);
+      expect(killSpy).not.toHaveBeenCalled();
+    });
+
+    it("sends SIGTERM to stale pids and returns them", () => {
+      const stalePid = process.pid + 100;
+      let call = 0;
+      mockSpawnSync.mockImplementation(() => {
+        call++;
+        if (call === 1) {
+          return {
+            error: null,
+            status: 0,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "",
+          };
+        }
+        // waitForPortFreeSync polls: port free immediately
+        return { error: null, status: 0, stdout: "", stderr: "" };
+      });
+
+      const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+      const result = cleanStaleGatewayProcessesSync();
+
+      expect(result).toContain(stalePid);
+      expect(killSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
+    });
+
+    it("escalates to SIGKILL when process survives the SIGTERM window", () => {
+      const stalePid = process.pid + 101;
+      let call = 0;
+      mockSpawnSync.mockImplementation(() => {
+        call++;
+        if (call <= 5) {
+          return {
+            error: null,
+            status: 0,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "",
+          };
+        }
+        return { error: null, status: 0, stdout: "", stderr: "" };
+      });
+
+      const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+      cleanStaleGatewayProcessesSync();
+
+      expect(killSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(stalePid, "SIGKILL");
+    });
+
+    it("polls until port is confirmed free before returning — regression for #33103", () => {
+      // Core regression: cleanStaleGatewayProcessesSync must not return while
+      // the port is still bound. Previously it returned after a fixed 500ms
+      // sleep regardless of port state, causing systemd's new process to hit
+      // EADDRINUSE and enter an unbounded restart loop.
+      const stalePid = process.pid + 200;
+      const events: string[] = [];
+      let call = 0;
+
+      mockSpawnSync.mockImplementation(() => {
+        call++;
+        if (call === 1) {
+          events.push("initial-find");
+          return {
+            error: null,
+            status: 0,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "",
+          };
+        }
+        if (call <= 4) {
+          events.push(`busy-poll-${call}`);
+          return {
+            error: null,
+            status: 0,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "",
+          };
+        }
+        events.push("port-free");
+        return { error: null, status: 0, stdout: "", stderr: "" };
+      });
+
+      vi.spyOn(process, "kill").mockReturnValue(true);
+      cleanStaleGatewayProcessesSync();
+
+      expect(events).toContain("port-free");
+      expect(events.filter((e) => e.startsWith("busy-poll")).length).toBeGreaterThan(0);
+    });
+
+    it("bails immediately when lsof is permanently unavailable (ENOENT) — Greptile edge case", () => {
+      // Regression for the edge case identified in PR review: lsof returning an
+      // error must not be treated as "port free". ENOENT means lsof is not
+      // installed — a permanent condition. The polling loop should bail
+      // immediately on ENOENT rather than spinning the full 2-second budget.
+      const stalePid = process.pid + 300;
+      const events: string[] = [];
+      let call = 0;
+
+      mockSpawnSync.mockImplementation(() => {
+        call++;
+        if (call === 1) {
+          events.push("initial-find");
+          return {
+            error: null,
+            status: 0,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "",
+          };
+        }
+        // Permanent ENOENT — lsof is not installed
+        events.push(`enoent-poll-${call}`);
+        const err = new Error("lsof not found") as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        return { error: err, status: null, stdout: "", stderr: "" };
+      });
+
+      vi.spyOn(process, "kill").mockReturnValue(true);
+      expect(() => cleanStaleGatewayProcessesSync()).not.toThrow();
+
+      // Must bail after first ENOENT poll — no point retrying a missing binary
+      const enoentPolls = events.filter((e) => e.startsWith("enoent-poll"));
+      expect(enoentPolls.length).toBe(1);
+    });
+
+    it("bails immediately when lsof is permanently unavailable (EPERM) — SELinux/AppArmor", () => {
+      // EPERM occurs when lsof exists but a MAC policy (SELinux/AppArmor) blocks
+      // execution. Like ENOENT/EACCES, this is permanent — retrying is pointless.
+      const stalePid = process.pid + 305;
+      let call = 0;
+      mockSpawnSync.mockImplementation(() => {
+        call++;
+        if (call === 1) {
+          return {
+            error: null,
+            status: 0,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "",
+          };
+        }
+        const err = new Error("lsof eperm") as NodeJS.ErrnoException;
+        err.code = "EPERM";
+        return { error: err, status: null, stdout: "", stderr: "" };
+      });
+      vi.spyOn(process, "kill").mockReturnValue(true);
+      expect(() => cleanStaleGatewayProcessesSync()).not.toThrow();
+      // Must bail after exactly 1 EPERM poll — same as ENOENT/EACCES
+      expect(call).toBe(2); // 1 initial find + 1 EPERM poll
+    });
+
+    it("bails immediately when lsof is permanently unavailable (EACCES) — same as ENOENT", () => {
+      // EACCES and EPERM are also permanent conditions — lsof exists but the
+      // process has no permission to run it. No point retrying.
+      const stalePid = process.pid + 302;
+      let call = 0;
+      mockSpawnSync.mockImplementation(() => {
+        call++;
+        if (call === 1) {
+          return {
+            error: null,
+            status: 0,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "",
+          };
+        }
+        const err = new Error("lsof permission denied") as NodeJS.ErrnoException;
+        err.code = "EACCES";
+        return { error: err, status: null, stdout: "", stderr: "" };
+      });
+      vi.spyOn(process, "kill").mockReturnValue(true);
+      expect(() => cleanStaleGatewayProcessesSync()).not.toThrow();
+      // Should have bailed after exactly 1 poll call (the EACCES one)
+      expect(call).toBe(2); // 1 initial find + 1 EACCES poll
+    });
+
+    it("proceeds with warning when polling budget is exhausted — fake clock, no real 2s wait", () => {
+      // Sub-agent audit HIGH finding: the original test relied on real wall-clock
+      // time (Date.now() + 2000ms deadline), burning 2 full seconds of CI time
+      // every run. Fix: expose dateNowOverride in __testing so the deadline can
+      // be synthesised instantly, keeping the test under 10ms.
+      const stalePid = process.pid + 303;
+      let fakeNow = 0;
+      __testing.setDateNowOverride(() => fakeNow);
+
+      mockSpawnSync.mockImplementation(() => {
+        // Advance clock by PORT_FREE_TIMEOUT_MS + 1ms on first poll to trip the deadline.
+        fakeNow += 2001;
+        return {
+          error: null,
+          status: 0,
+          stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+          stderr: "",
+        };
+      });
+
+      vi.spyOn(process, "kill").mockReturnValue(true);
+      // Must return without throwing (proceeds with warning after budget expires)
+      expect(() => cleanStaleGatewayProcessesSync()).not.toThrow();
+    });
+
+    it("still polls for port-free when all stale pids were already dead at SIGTERM time", () => {
+      // Sub-agent audit MEDIUM finding: if all pids from the initial scan are
+      // already dead before SIGTERM runs (race), terminateStaleProcessesSync
+      // returns killed=[] — but cleanStaleGatewayProcessesSync MUST still call
+      // waitForPortFreeSync. The process may have exited on its own while
+      // leaving its socket in TIME_WAIT / FIN_WAIT. Skipping the poll would
+      // silently recreate the EADDRINUSE race we are fixing.
+      const stalePid = process.pid + 304;
+      let call = 0;
+      const events: string[] = [];
+
+      mockSpawnSync.mockImplementation(() => {
+        call++;
+        if (call === 1) {
+          // Initial scan: finds stale pid
+          events.push("initial-find");
+          return {
+            error: null,
+            status: 0,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "",
+          };
+        }
+        // Port is already free on first poll — pid was dead before SIGTERM
+        events.push("poll-free");
+        return { error: null, status: 1, stdout: "", stderr: "" };
+      });
+
+      // All SIGTERMs throw ESRCH — pid already gone
+      vi.spyOn(process, "kill").mockImplementation(() => {
+        throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+      });
+
+      cleanStaleGatewayProcessesSync();
+
+      // waitForPortFreeSync must still have fired even though killed=[]
+      expect(events).toContain("poll-free");
+    });
+
+    it("continues polling on transient lsof errors (not ENOENT) — Codex P1 fix", () => {
+      // A transient lsof error (spawnSync timeout, status 2, etc.) must NOT abort
+      // the polling loop. The loop should keep retrying until the budget expires
+      // or a definitive result is returned. Bailing on the first transient error
+      // would recreate the EADDRINUSE race this PR is designed to prevent.
+      const stalePid = process.pid + 301;
+      const events: string[] = [];
+      let call = 0;
+
+      mockSpawnSync.mockImplementation(() => {
+        call++;
+        if (call === 1) {
+          events.push("initial-find");
+          return {
+            error: null,
+            status: 0,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "",
+          };
+        }
+        if (call === 2) {
+          // Transient: spawnSync timeout (no ENOENT code)
+          events.push("transient-error");
+          return { error: new Error("timeout"), status: null, stdout: "", stderr: "" };
+        }
+        // Port free on the next poll
+        events.push("port-free");
+        return { error: null, status: 1, stdout: "", stderr: "" };
+      });
+
+      vi.spyOn(process, "kill").mockReturnValue(true);
+      cleanStaleGatewayProcessesSync();
+
+      // Must have kept polling after the transient error and reached port-free
+      expect(events).toContain("transient-error");
+      expect(events).toContain("port-free");
+    });
+
+    it("returns gracefully when resolveGatewayPort throws", () => {
+      mockResolveGatewayPort.mockImplementationOnce(() => {
+        throw new Error("config read error");
+      });
+      expect(cleanStaleGatewayProcessesSync()).toEqual([]);
+    });
+
+    it("returns gracefully when lsof is unavailable from the start", () => {
+      mockSpawnSync.mockReturnValue({
+        error: new Error("ENOENT"),
+        status: null,
+        stdout: "",
+        stderr: "",
+      });
+      const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+      expect(cleanStaleGatewayProcessesSync()).toEqual([]);
+      expect(killSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // parsePidsFromLsofOutput — branch-coverage for mid-loop && short-circuits
+  // -------------------------------------------------------------------------
+  describe("parsePidsFromLsofOutput — branch coverage (lines 67-69)", () => {
+    it("skips a mid-loop entry when the command does not include 'openclaw'", () => {
+      // Exercises the false branch of currentCmd.toLowerCase().includes("openclaw")
+      // inside the mid-loop flush: a non-openclaw cmd between two entries must not
+      // be pushed, but the following openclaw entry still must be.
+      const stalePid = process.pid + 700;
+      // Mixed output: non-openclaw entry first, then openclaw entry
+      const stdout = `p${process.pid + 699}\ncnginx\np${stalePid}\ncopenclaw-gateway\n`;
+      mockSpawnSync.mockReturnValue({ error: null, status: 0, stdout, stderr: "" });
+      const result = findGatewayPidsOnPortSync(18789);
+      expect(result).toContain(stalePid);
+      expect(result).not.toContain(process.pid + 699);
+    });
+
+    it("skips a mid-loop entry when currentCmd is missing (two consecutive p-lines)", () => {
+      // Exercises currentCmd falsy branch mid-loop: two 'p' lines in a row
+      // (no 'c' line between them) — the first PID must be skipped, the second handled.
+      const stalePid = process.pid + 701;
+      // Two consecutive p-lines: first has no c-line before the next p-line
+      const stdout = `p${process.pid + 702}\np${stalePid}\ncopenclaw-gateway\n`;
+      mockSpawnSync.mockReturnValue({ error: null, status: 0, stdout, stderr: "" });
+      const result = findGatewayPidsOnPortSync(18789);
+      expect(result).toContain(stalePid);
+    });
+
+    it("ignores a p-line with an invalid (non-positive) PID — ternary false branch", () => {
+      // Exercises the `Number.isFinite(parsed) && parsed > 0 ? parsed : undefined`
+      // false branch: a malformed 'p' line (e.g. 'p0' or 'pNaN') must not corrupt
+      // currentPid and must not end up in the returned pids array.
+      const stalePid = process.pid + 703;
+      // p0 is invalid (not > 0); the following valid openclaw entry must still be found.
+      const stdout = `p0\ncopenclaw-gateway\np${stalePid}\ncopenclaw-gateway\n`;
+      mockSpawnSync.mockReturnValue({ error: null, status: 0, stdout, stderr: "" });
+      const result = findGatewayPidsOnPortSync(18789);
+      expect(result).toContain(stalePid);
+      expect(result).not.toContain(0);
+    });
+
+    it("silently skips lines that start with neither 'p' nor 'c' — else-if false branch", () => {
+      // lsof -Fpc only emits 'p' and 'c' lines, but defensive handling of
+      // unexpected output (e.g. 'f' for file descriptor in other lsof formats)
+      // must not throw or corrupt the pid list. Unknown lines are just skipped.
+      const stalePid = process.pid + 704;
+      // Intersperse an 'f' line (file descriptor marker) — not a 'p' or 'c' line
+      const stdout = `p${stalePid}\nf8\ncopenclaw-gateway\n`;
+      mockSpawnSync.mockReturnValue({ error: null, status: 0, stdout, stderr: "" });
+      const result = findGatewayPidsOnPortSync(18789);
+      // The 'f' line must not corrupt parsing; stalePid must still be found
+      // (the 'c' line after 'f' correctly sets currentCmd)
+      expect(result).toContain(stalePid);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // pollPortOnce branch — status 1 + non-empty stdout with zero openclaw pids
+  // -------------------------------------------------------------------------
+  describe("pollPortOnce — status 1 + non-empty non-openclaw stdout (line 145)", () => {
+    it("treats status 1 + non-openclaw stdout as port-free (not an openclaw process)", () => {
+      // status 1 + non-empty stdout where no openclaw pids are present:
+      // the port may be held by an unrelated process. From our perspective
+      // (we only kill openclaw pids) it is effectively free.
+      const stalePid = process.pid + 800;
+      let call = 0;
+      mockSpawnSync.mockImplementation(() => {
+        call++;
+        if (call === 1) {
+          return {
+            error: null,
+            status: 0,
+            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stderr: "",
+          };
+        }
+        // status 1 + non-openclaw output — should be treated as free:true for our purposes
+        return {
+          error: null,
+          status: 1,
+          stdout: lsofOutput([{ pid: process.pid + 801, cmd: "caddy" }]),
+          stderr: "",
+        };
+      });
+      vi.spyOn(process, "kill").mockReturnValue(true);
+      // Should complete cleanly — no openclaw pids in status-1 output → free
+      expect(() => cleanStaleGatewayProcessesSync()).not.toThrow();
+      // Completed in exactly 2 calls (initial find + 1 free poll)
+      expect(call).toBe(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // sleepSync — direct unit tests via __testing.callSleepSyncRaw
+  // -------------------------------------------------------------------------
+  describe("sleepSync — Atomics.wait paths", () => {
+    it("returns immediately when called with 0ms (timeoutMs <= 0 early return)", () => {
+      // sleepSync(0) must short-circuit before touching Atomics.wait.
+      // Verify it does not throw and returns synchronously.
+      __testing.setSleepSyncOverride(null); // bypass override so real path runs
+      expect(() => __testing.callSleepSyncRaw(0)).not.toThrow();
+    });
+
+    it("returns immediately when called with a negative value (Math.max(0,...) clamp)", () => {
+      __testing.setSleepSyncOverride(null);
+      expect(() => __testing.callSleepSyncRaw(-1)).not.toThrow();
+    });
+
+    it("executes the Atomics.wait path successfully when called with a positive timeout", () => {
+      // Verify the real Atomics.wait code path runs without error.
+      // Use 1ms to keep the test fast; Atomics.wait resolves immediately
+      // because the timeout expires in 1ms.
+      __testing.setSleepSyncOverride(null);
+      expect(() => __testing.callSleepSyncRaw(1)).not.toThrow();
+    });
+
+    it("falls back to busy-wait when Atomics.wait throws (Worker / sandboxed env)", () => {
+      // Atomics.wait throws in Worker threads and some sandboxed runtimes.
+      // The catch branch must handle this without propagating the exception.
+      const origWait = Atomics.wait;
+      Atomics.wait = () => {
+        throw new Error("not on main thread");
+      };
+      __testing.setSleepSyncOverride(null);
+      try {
+        // 1ms is enough to exercise the busy-wait loop without slowing CI.
+        expect(() => __testing.callSleepSyncRaw(1)).not.toThrow();
+      } finally {
+        Atomics.wait = origWait;
+        __testing.setSleepSyncOverride(() => {});
+      }
+    });
+  });
+});

--- a/src/infra/restart-stale-pids.test.ts
+++ b/src/infra/restart-stale-pids.test.ts
@@ -87,14 +87,14 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       );
     });
 
-    it("parses openclaw-gateway pids and excludes the current process", () => {
+    it("parses remoteclaw-gateway pids and excludes the current process", () => {
       const stalePid = process.pid + 1;
       mockSpawnSync.mockReturnValue({
         error: null,
         status: 0,
         stdout: lsofOutput([
-          { pid: stalePid, cmd: "openclaw-gateway" },
-          { pid: process.pid, cmd: "openclaw-gateway" },
+          { pid: stalePid, cmd: "remoteclaw-gateway" },
+          { pid: process.pid, cmd: "remoteclaw-gateway" },
         ]),
         stderr: "",
       });
@@ -103,7 +103,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       expect(pids).not.toContain(process.pid);
     });
 
-    it("excludes pids whose command does not include 'openclaw'", () => {
+    it("excludes pids whose command does not include 'remoteclaw'", () => {
       const otherPid = process.pid + 2;
       mockSpawnSync.mockReturnValue({
         error: null,
@@ -129,7 +129,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       // (once for the IPv4 socket, once for IPv6). Without dedup, terminateStaleProcessesSync
       // sends SIGTERM twice and returns killed=[pid, pid], corrupting the count.
       const stalePid = process.pid + 600;
-      const stdout = `p${stalePid}\ncopenclaw-gateway\np${stalePid}\ncopenclaw-gateway\n`;
+      const stdout = `p${stalePid}\ncremoteclaw-gateway\np${stalePid}\ncremoteclaw-gateway\n`;
       mockSpawnSync.mockReturnValue({ error: null, status: 0, stdout, stderr: "" });
       const result = findGatewayPidsOnPortSync(18789);
       expect(result).toEqual([stalePid]); // deduped — not [pid, pid]
@@ -162,15 +162,15 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       expect(findGatewayPidsOnPortSync(18789)).toEqual([]);
     });
 
-    it("parses multiple openclaw pids from a single lsof output block", () => {
+    it("parses multiple remoteclaw pids from a single lsof output block", () => {
       const pid1 = process.pid + 10;
       const pid2 = process.pid + 11;
       mockSpawnSync.mockReturnValue({
         error: null,
         status: 0,
         stdout: lsofOutput([
-          { pid: pid1, cmd: "openclaw-gateway" },
-          { pid: pid2, cmd: "openclaw-gateway" },
+          { pid: pid1, cmd: "remoteclaw-gateway" },
+          { pid: pid2, cmd: "remoteclaw-gateway" },
         ]),
         stderr: "",
       });
@@ -179,9 +179,9 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       expect(result).toContain(pid2);
     });
 
-    it("returns [] when status 0 but only non-openclaw pids present", () => {
+    it("returns [] when status 0 but only non-remoteclaw pids present", () => {
       // Port may be bound by an unrelated process. findGatewayPidsOnPortSync
-      // only tracks openclaw processes — non-openclaw listeners are ignored.
+      // only tracks remoteclaw processes — non-remoteclaw listeners are ignored.
       const otherPid = process.pid + 50;
       mockSpawnSync.mockReturnValue({
         error: null,
@@ -208,7 +208,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           return {
             error: null,
             status: 0,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "",
           };
         }
@@ -234,7 +234,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           return {
             error: null,
             status: 0,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "",
           };
         }
@@ -271,7 +271,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           return {
             error: null,
             status: 0,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "",
           };
         }
@@ -280,7 +280,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           return {
             error: null,
             status: 0,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "",
           };
         }
@@ -297,10 +297,10 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       expect(spawnCount).toBe(3);
     });
 
-    it("lsof status 1 with non-empty openclaw stdout is treated as busy, not free (Linux container edge case)", () => {
+    it("lsof status 1 with non-empty remoteclaw stdout is treated as busy, not free (Linux container edge case)", () => {
       // On Linux containers with restricted /proc (AppArmor, seccomp, user namespaces),
       // lsof can exit 1 AND still emit output for processes it could read.
-      // status 1 + non-empty openclaw stdout must not be treated as port-free.
+      // status 1 + non-empty remoteclaw stdout must not be treated as port-free.
       const stalePid = process.pid + 601;
       let call = 0;
       mockSpawnSync.mockImplementation(() => {
@@ -310,16 +310,16 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           return {
             error: null,
             status: 0,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "",
           };
         }
         if (call === 2) {
-          // status 1 + openclaw pid in stdout — container-restricted lsof reports partial results
+          // status 1 + remoteclaw pid in stdout — container-restricted lsof reports partial results
           return {
             error: null,
             status: 1,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "lsof: WARNING: can't stat() fuse",
           };
         }
@@ -349,7 +349,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
         return {
           error: null,
           status: 0,
-          stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+          stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
           stderr: "",
         };
       });
@@ -389,7 +389,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           return {
             error: null,
             status: 0,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "",
           };
         }
@@ -413,7 +413,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           return {
             error: null,
             status: 0,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "",
           };
         }
@@ -443,7 +443,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           return {
             error: null,
             status: 0,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "",
           };
         }
@@ -452,7 +452,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           return {
             error: null,
             status: 0,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "",
           };
         }
@@ -483,7 +483,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           return {
             error: null,
             status: 0,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "",
           };
         }
@@ -513,7 +513,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           return {
             error: null,
             status: 0,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "",
           };
         }
@@ -538,7 +538,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           return {
             error: null,
             status: 0,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "",
           };
         }
@@ -567,7 +567,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
         return {
           error: null,
           status: 0,
-          stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+          stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
           stderr: "",
         };
       });
@@ -596,7 +596,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           return {
             error: null,
             status: 0,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "",
           };
         }
@@ -632,7 +632,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           return {
             error: null,
             status: 0,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "",
           };
         }
@@ -678,13 +678,13 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
   // parsePidsFromLsofOutput — branch-coverage for mid-loop && short-circuits
   // -------------------------------------------------------------------------
   describe("parsePidsFromLsofOutput — branch coverage (lines 67-69)", () => {
-    it("skips a mid-loop entry when the command does not include 'openclaw'", () => {
-      // Exercises the false branch of currentCmd.toLowerCase().includes("openclaw")
-      // inside the mid-loop flush: a non-openclaw cmd between two entries must not
-      // be pushed, but the following openclaw entry still must be.
+    it("skips a mid-loop entry when the command does not include 'remoteclaw'", () => {
+      // Exercises the false branch of currentCmd.toLowerCase().includes("remoteclaw")
+      // inside the mid-loop flush: a non-remoteclaw cmd between two entries must not
+      // be pushed, but the following remoteclaw entry still must be.
       const stalePid = process.pid + 700;
-      // Mixed output: non-openclaw entry first, then openclaw entry
-      const stdout = `p${process.pid + 699}\ncnginx\np${stalePid}\ncopenclaw-gateway\n`;
+      // Mixed output: non-remoteclaw entry first, then remoteclaw entry
+      const stdout = `p${process.pid + 699}\ncnginx\np${stalePid}\ncremoteclaw-gateway\n`;
       mockSpawnSync.mockReturnValue({ error: null, status: 0, stdout, stderr: "" });
       const result = findGatewayPidsOnPortSync(18789);
       expect(result).toContain(stalePid);
@@ -696,7 +696,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       // (no 'c' line between them) — the first PID must be skipped, the second handled.
       const stalePid = process.pid + 701;
       // Two consecutive p-lines: first has no c-line before the next p-line
-      const stdout = `p${process.pid + 702}\np${stalePid}\ncopenclaw-gateway\n`;
+      const stdout = `p${process.pid + 702}\np${stalePid}\ncremoteclaw-gateway\n`;
       mockSpawnSync.mockReturnValue({ error: null, status: 0, stdout, stderr: "" });
       const result = findGatewayPidsOnPortSync(18789);
       expect(result).toContain(stalePid);
@@ -707,8 +707,8 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       // false branch: a malformed 'p' line (e.g. 'p0' or 'pNaN') must not corrupt
       // currentPid and must not end up in the returned pids array.
       const stalePid = process.pid + 703;
-      // p0 is invalid (not > 0); the following valid openclaw entry must still be found.
-      const stdout = `p0\ncopenclaw-gateway\np${stalePid}\ncopenclaw-gateway\n`;
+      // p0 is invalid (not > 0); the following valid remoteclaw entry must still be found.
+      const stdout = `p0\ncremoteclaw-gateway\np${stalePid}\ncremoteclaw-gateway\n`;
       mockSpawnSync.mockReturnValue({ error: null, status: 0, stdout, stderr: "" });
       const result = findGatewayPidsOnPortSync(18789);
       expect(result).toContain(stalePid);
@@ -721,7 +721,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       // must not throw or corrupt the pid list. Unknown lines are just skipped.
       const stalePid = process.pid + 704;
       // Intersperse an 'f' line (file descriptor marker) — not a 'p' or 'c' line
-      const stdout = `p${stalePid}\nf8\ncopenclaw-gateway\n`;
+      const stdout = `p${stalePid}\nf8\ncremoteclaw-gateway\n`;
       mockSpawnSync.mockReturnValue({ error: null, status: 0, stdout, stderr: "" });
       const result = findGatewayPidsOnPortSync(18789);
       // The 'f' line must not corrupt parsing; stalePid must still be found
@@ -731,13 +731,13 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
   });
 
   // -------------------------------------------------------------------------
-  // pollPortOnce branch — status 1 + non-empty stdout with zero openclaw pids
+  // pollPortOnce branch — status 1 + non-empty stdout with zero remoteclaw pids
   // -------------------------------------------------------------------------
-  describe("pollPortOnce — status 1 + non-empty non-openclaw stdout (line 145)", () => {
-    it("treats status 1 + non-openclaw stdout as port-free (not an openclaw process)", () => {
-      // status 1 + non-empty stdout where no openclaw pids are present:
+  describe("pollPortOnce — status 1 + non-empty non-remoteclaw stdout (line 145)", () => {
+    it("treats status 1 + non-remoteclaw stdout as port-free (not an remoteclaw process)", () => {
+      // status 1 + non-empty stdout where no remoteclaw pids are present:
       // the port may be held by an unrelated process. From our perspective
-      // (we only kill openclaw pids) it is effectively free.
+      // (we only kill remoteclaw pids) it is effectively free.
       const stalePid = process.pid + 800;
       let call = 0;
       mockSpawnSync.mockImplementation(() => {
@@ -746,11 +746,11 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           return {
             error: null,
             status: 0,
-            stdout: lsofOutput([{ pid: stalePid, cmd: "openclaw-gateway" }]),
+            stdout: lsofOutput([{ pid: stalePid, cmd: "remoteclaw-gateway" }]),
             stderr: "",
           };
         }
-        // status 1 + non-openclaw output — should be treated as free:true for our purposes
+        // status 1 + non-remoteclaw output — should be treated as free:true for our purposes
         return {
           error: null,
           status: 1,
@@ -759,7 +759,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
         };
       });
       vi.spyOn(process, "kill").mockReturnValue(true);
-      // Should complete cleanly — no openclaw pids in status-1 output → free
+      // Should complete cleanly — no remoteclaw pids in status-1 output → free
       expect(() => cleanStaleGatewayProcessesSync()).not.toThrow();
       // Completed in exactly 2 calls (initial find + 1 free poll)
       expect(call).toBe(2);

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -80,7 +80,7 @@ function parsePidsFromLsofOutput(stdout: string): number[] {
 
 /**
  * Find PIDs of gateway processes listening on the given port using synchronous lsof.
- * Returns only PIDs that belong to openclaw gateway processes (not the current process).
+ * Returns only PIDs that belong to RemoteClaw gateway processes (not the current process).
  */
 export function findGatewayPidsOnPortSync(
   port: number,

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -4,11 +4,31 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveLsofCommandSync } from "./ports-lsof.js";
 
 const SPAWN_TIMEOUT_MS = 2000;
-const STALE_SIGTERM_WAIT_MS = 300;
-const STALE_SIGKILL_WAIT_MS = 200;
+const STALE_SIGTERM_WAIT_MS = 600;
+const STALE_SIGKILL_WAIT_MS = 400;
+/**
+ * After SIGKILL, the kernel may not release the TCP port immediately.
+ * Poll until the port is confirmed free (or until the budget expires) before
+ * returning control to the caller (typically `triggerOpenClawRestart` →
+ * `systemctl restart`). Without this wait the new process races the dying
+ * process for the port and systemd enters an EADDRINUSE restart loop.
+ *
+ * POLL_SPAWN_TIMEOUT_MS is intentionally much shorter than SPAWN_TIMEOUT_MS
+ * so that a single slow or hung lsof invocation does not consume the entire
+ * polling budget. At 400 ms per call, up to five independent lsof attempts
+ * fit within PORT_FREE_TIMEOUT_MS = 2000 ms, each with a definitive outcome.
+ */
+const PORT_FREE_POLL_INTERVAL_MS = 50;
+const PORT_FREE_TIMEOUT_MS = 2000;
+const POLL_SPAWN_TIMEOUT_MS = 400;
 
 const restartLog = createSubsystemLogger("restart");
 let sleepSyncOverride: ((ms: number) => void) | null = null;
+let dateNowOverride: (() => number) | null = null;
+
+function getTimeMs(): number {
+  return dateNowOverride ? dateNowOverride() : Date.now();
+}
 
 function sleepSync(ms: number): void {
   const timeoutMs = Math.max(0, Math.floor(ms));
@@ -31,25 +51,14 @@ function sleepSync(ms: number): void {
 }
 
 /**
- * Find PIDs of gateway processes listening on the given port using synchronous lsof.
- * Returns only PIDs that belong to RemoteClaw gateway processes (not the current process).
+ * Parse RemoteClaw gateway PIDs from lsof -Fpc stdout.
+ * Pure function — no I/O. Excludes the current process.
  */
-export function findGatewayPidsOnPortSync(port: number): number[] {
-  if (process.platform === "win32") {
-    return [];
-  }
-  const lsof = resolveLsofCommandSync();
-  const res = spawnSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fpc"], {
-    encoding: "utf8",
-    timeout: SPAWN_TIMEOUT_MS,
-  });
-  if (res.error || res.status !== 0) {
-    return [];
-  }
+function parsePidsFromLsofOutput(stdout: string): number[] {
   const pids: number[] = [];
   let currentPid: number | undefined;
   let currentCmd: string | undefined;
-  for (const line of res.stdout.split(/\r?\n/).filter(Boolean)) {
+  for (const line of stdout.split(/\r?\n/).filter(Boolean)) {
     if (line.startsWith("p")) {
       if (currentPid != null && currentCmd && currentCmd.toLowerCase().includes("remoteclaw")) {
         pids.push(currentPid);
@@ -64,17 +73,117 @@ export function findGatewayPidsOnPortSync(port: number): number[] {
   if (currentPid != null && currentCmd && currentCmd.toLowerCase().includes("remoteclaw")) {
     pids.push(currentPid);
   }
-  return pids.filter((pid) => pid !== process.pid);
+  // Deduplicate: dual-stack listeners (IPv4 + IPv6) cause lsof to emit the
+  // same PID twice. Return each PID at most once to avoid double-killing.
+  return [...new Set(pids)].filter((pid) => pid !== process.pid);
+}
+
+/**
+ * Find PIDs of gateway processes listening on the given port using synchronous lsof.
+ * Returns only PIDs that belong to openclaw gateway processes (not the current process).
+ */
+export function findGatewayPidsOnPortSync(
+  port: number,
+  spawnTimeoutMs = SPAWN_TIMEOUT_MS,
+): number[] {
+  if (process.platform === "win32") {
+    return [];
+  }
+  const lsof = resolveLsofCommandSync();
+  const res = spawnSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fpc"], {
+    encoding: "utf8",
+    timeout: spawnTimeoutMs,
+  });
+  if (res.error) {
+    const code = (res.error as NodeJS.ErrnoException).code;
+    const detail =
+      code && code.trim().length > 0
+        ? code
+        : res.error instanceof Error
+          ? res.error.message
+          : "unknown error";
+    restartLog.warn(`lsof failed during initial stale-pid scan for port ${port}: ${detail}`);
+    return [];
+  }
+  if (res.status === 1) {
+    return [];
+  }
+  if (res.status !== 0) {
+    restartLog.warn(
+      `lsof exited with status ${res.status} during initial stale-pid scan for port ${port}; skipping stale pid check`,
+    );
+    return [];
+  }
+  return parsePidsFromLsofOutput(res.stdout);
+}
+
+/**
+ * Attempt a single lsof poll for the given port.
+ *
+ * Returns a discriminated union with four possible states:
+ *
+ *   { free: true }                      — port confirmed free
+ *   { free: false }                     — port confirmed busy
+ *   { free: null; permanent: false }    — transient error, keep retrying
+ *   { free: null; permanent: true }     — lsof unavailable (ENOENT / EACCES),
+ *                                         no point retrying
+ *
+ * Separating transient from permanent errors is critical so that:
+ *  1. A slow/timed-out lsof call (transient) does not abort the polling loop —
+ *     the caller retries until the wall-clock budget expires.
+ *  2. Non-zero lsof exits from runtime/permission failures (status > 1) are
+ *     not misclassified as "port free" — they are inconclusive and retried.
+ *  3. A missing lsof binary (permanent) short-circuits cleanly rather than
+ *     spinning the full budget pointlessly.
+ */
+type PollResult = { free: true } | { free: false } | { free: null; permanent: boolean };
+
+function pollPortOnce(port: number): PollResult {
+  try {
+    const lsof = resolveLsofCommandSync();
+    const res = spawnSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fpc"], {
+      encoding: "utf8",
+      timeout: POLL_SPAWN_TIMEOUT_MS,
+    });
+    if (res.error) {
+      // Spawn-level failure. ENOENT / EACCES means lsof is permanently
+      // unavailable on this system; other errors (e.g. timeout) are transient.
+      const code = (res.error as NodeJS.ErrnoException).code;
+      const permanent = code === "ENOENT" || code === "EACCES" || code === "EPERM";
+      return { free: null, permanent };
+    }
+    if (res.status === 1) {
+      // lsof canonical "no matching processes" exit — port is genuinely free.
+      // Guard: on Linux containers with restricted /proc (AppArmor, seccomp,
+      // user namespaces), lsof can exit 1 AND still emit some output for the
+      // processes it could read. Parse stdout when non-empty to avoid false-free.
+      if (res.stdout) {
+        const pids = parsePidsFromLsofOutput(res.stdout);
+        return pids.length === 0 ? { free: true } : { free: false };
+      }
+      return { free: true };
+    }
+    if (res.status !== 0) {
+      // status > 1: runtime/permission/flag error. Cannot confirm port state —
+      // treat as a transient failure and keep polling rather than falsely
+      // reporting the port as free (which would recreate the EADDRINUSE race).
+      return { free: null, permanent: false };
+    }
+    // status === 0: lsof found listeners. Parse pids from the stdout we
+    // already hold — no second lsof spawn, no new failure surface.
+    const pids = parsePidsFromLsofOutput(res.stdout);
+    return pids.length === 0 ? { free: true } : { free: false };
+  } catch {
+    return { free: null, permanent: false };
+  }
 }
 
 /**
  * Synchronously terminate stale gateway processes.
+ * Callers must pass a non-empty pids array.
  * Sends SIGTERM, waits briefly, then SIGKILL for survivors.
  */
 function terminateStaleProcessesSync(pids: number[]): number[] {
-  if (pids.length === 0) {
-    return [];
-  }
   const killed: number[] = [];
   for (const pid of pids) {
     try {
@@ -101,7 +210,47 @@ function terminateStaleProcessesSync(pids: number[]): number[] {
 }
 
 /**
+ * Poll the given port until it is confirmed free, lsof is confirmed unavailable,
+ * or the wall-clock budget expires.
+ *
+ * Each poll invocation uses POLL_SPAWN_TIMEOUT_MS (400 ms), which is
+ * significantly shorter than PORT_FREE_TIMEOUT_MS (2000 ms). This ensures
+ * that a single slow or hung lsof call cannot consume the entire polling
+ * budget and cause the function to exit prematurely with an inconclusive
+ * result. Up to five independent lsof attempts fit within the budget.
+ *
+ * Exit conditions:
+ *   - `pollPortOnce` returns `{ free: true }`                    → port confirmed free
+ *   - `pollPortOnce` returns `{ free: null, permanent: true }`   → lsof unavailable, bail
+ *   - `pollPortOnce` returns `{ free: false }`                   → port busy, sleep + retry
+ *   - `pollPortOnce` returns `{ free: null, permanent: false }`  → transient error, sleep + retry
+ *   - Wall-clock deadline exceeded                               → log warning, proceed anyway
+ */
+function waitForPortFreeSync(port: number): void {
+  const deadline = getTimeMs() + PORT_FREE_TIMEOUT_MS;
+  while (getTimeMs() < deadline) {
+    const result = pollPortOnce(port);
+    if (result.free === true) {
+      return;
+    }
+    if (result.free === null && result.permanent) {
+      // lsof is permanently unavailable (ENOENT / EACCES) — bail immediately,
+      // no point spinning the remaining budget.
+      return;
+    }
+    // result.free === false: port still bound.
+    // result.free === null && !permanent: transient lsof error — keep polling.
+    sleepSync(PORT_FREE_POLL_INTERVAL_MS);
+  }
+  restartLog.warn(`port ${port} still in use after ${PORT_FREE_TIMEOUT_MS}ms; proceeding anyway`);
+}
+
+/**
  * Inspect the gateway port and kill any stale gateway processes holding it.
+ * Blocks until the port is confirmed free (or the poll budget expires) so
+ * the supervisor (systemd / launchctl) does not race a zombie process for
+ * the port and enter an EADDRINUSE restart loop.
+ *
  * Called before service restart commands to prevent port conflicts.
  */
 export function cleanStaleGatewayProcessesSync(): number[] {
@@ -114,7 +263,14 @@ export function cleanStaleGatewayProcessesSync(): number[] {
     restartLog.warn(
       `killing ${stalePids.length} stale gateway process(es) before restart: ${stalePids.join(", ")}`,
     );
-    return terminateStaleProcessesSync(stalePids);
+    const killed = terminateStaleProcessesSync(stalePids);
+    // Wait for the port to be released before returning — called unconditionally
+    // even when `killed` is empty (all pids were already dead before SIGTERM).
+    // A process can exit before our signal arrives yet still leave its socket
+    // in TIME_WAIT / FIN_WAIT; polling is the only reliable way to confirm the
+    // kernel has fully released the port before systemd fires the new process.
+    waitForPortFreeSync(port);
+    return killed;
   } catch {
     return [];
   }
@@ -124,4 +280,9 @@ export const __testing = {
   setSleepSyncOverride(fn: ((ms: number) => void) | null) {
     sleepSyncOverride = fn;
   },
+  setDateNowOverride(fn: (() => number) | null) {
+    dateNowOverride = fn;
+  },
+  /** Invoke sleepSync directly (bypasses the override) for unit-testing the real Atomics path. */
+  callSleepSyncRaw: sleepSync,
 };

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
 import {
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
@@ -335,7 +337,8 @@ export function triggerRemoteClawRestart(): RestartAttempt {
     process.env.REMOTECLAW_LAUNCHD_LABEL ||
     resolveGatewayLaunchAgentLabel(process.env.REMOTECLAW_PROFILE);
   const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
-  const target = uid !== undefined ? `gui/${uid}/${label}` : label;
+  const domain = uid !== undefined ? `gui/${uid}` : "gui/501";
+  const target = `${domain}/${label}`;
   const args = ["kickstart", "-k", target];
   tried.push(`launchctl ${args.join(" ")}`);
   const res = spawnSync("launchctl", args, {
@@ -345,10 +348,39 @@ export function triggerRemoteClawRestart(): RestartAttempt {
   if (!res.error && res.status === 0) {
     return { ok: true, method: "launchctl", tried };
   }
+
+  // kickstart fails when the service was previously booted out (deregistered from launchd).
+  // Fall back to bootstrap (re-register from plist) + kickstart.
+  // Use env HOME to match how launchd.ts resolves the plist install path.
+  const home = process.env.HOME?.trim() || os.homedir();
+  const plistPath = path.join(home, "Library", "LaunchAgents", `${label}.plist`);
+  const bootstrapArgs = ["bootstrap", domain, plistPath];
+  tried.push(`launchctl ${bootstrapArgs.join(" ")}`);
+  const boot = spawnSync("launchctl", bootstrapArgs, {
+    encoding: "utf8",
+    timeout: SPAWN_TIMEOUT_MS,
+  });
+  if (boot.error || (boot.status !== 0 && boot.status !== null)) {
+    return {
+      ok: false,
+      method: "launchctl",
+      detail: formatSpawnDetail(boot),
+      tried,
+    };
+  }
+  const retryArgs = ["kickstart", "-k", target];
+  tried.push(`launchctl ${retryArgs.join(" ")}`);
+  const retry = spawnSync("launchctl", retryArgs, {
+    encoding: "utf8",
+    timeout: SPAWN_TIMEOUT_MS,
+  });
+  if (!retry.error && retry.status === 0) {
+    return { ok: true, method: "launchctl", tried };
+  }
   return {
     ok: false,
     method: "launchctl",
-    detail: formatSpawnDetail(res),
+    detail: formatSpawnDetail(retry),
     tried,
   };
 }

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -51,7 +51,7 @@ function resolvePrimaryIPv4(): string | undefined {
 function initSelfPresence() {
   const host = os.hostname();
   const ip = resolvePrimaryIPv4() ?? undefined;
-  const version = resolveRuntimeServiceVersion(process.env, "unknown");
+  const version = resolveRuntimeServiceVersion(process.env);
   const modelIdentifier = (() => {
     const p = os.platform();
     if (p === "darwin") {

--- a/src/infra/system-presence.version.test.ts
+++ b/src/infra/system-presence.version.test.ts
@@ -13,20 +13,21 @@ async function withPresenceModule<T>(
 }
 
 describe("system-presence version fallback", () => {
-  it("uses REMOTECLAW_SERVICE_VERSION when REMOTECLAW_VERSION is not set", async () => {
+  it("uses runtime VERSION when REMOTECLAW_VERSION is not set", async () => {
     await withPresenceModule(
       {
         REMOTECLAW_SERVICE_VERSION: "2.4.6-service",
         npm_package_version: "1.0.0-package",
       },
-      ({ listSystemPresence }) => {
+      async ({ listSystemPresence }) => {
+        const { VERSION } = await import("../version.js");
         const selfEntry = listSystemPresence().find((entry) => entry.reason === "self");
-        expect(selfEntry?.version).toBe("2.4.6-service");
+        expect(selfEntry?.version).toBe(VERSION);
       },
     );
   });
 
-  it("prefers REMOTECLAW_VERSION over REMOTECLAW_SERVICE_VERSION", async () => {
+  it("prefers REMOTECLAW_VERSION over runtime VERSION", async () => {
     await withPresenceModule(
       {
         REMOTECLAW_VERSION: "9.9.9-cli",
@@ -40,16 +41,17 @@ describe("system-presence version fallback", () => {
     );
   });
 
-  it("uses npm_package_version when REMOTECLAW_VERSION and REMOTECLAW_SERVICE_VERSION are blank", async () => {
+  it("uses runtime VERSION when REMOTECLAW_VERSION and REMOTECLAW_SERVICE_VERSION are blank", async () => {
     await withPresenceModule(
       {
         REMOTECLAW_VERSION: " ",
         REMOTECLAW_SERVICE_VERSION: "\t",
         npm_package_version: "1.0.0-package",
       },
-      ({ listSystemPresence }) => {
+      async ({ listSystemPresence }) => {
+        const { VERSION } = await import("../version.js");
         const selfEntry = listSystemPresence().find((entry) => entry.reason === "self");
-        expect(selfEntry?.version).toBe("1.0.0-package");
+        expect(selfEntry?.version).toBe(VERSION);
       },
     );
   });

--- a/src/plugin-sdk/tool-send.ts
+++ b/src/plugin-sdk/tool-send.ts
@@ -1,7 +1,7 @@
 export function extractToolSend(
   args: Record<string, unknown>,
   expectedAction = "sendMessage",
-): { to: string; accountId?: string } | null {
+): { to: string; accountId?: string; threadId?: string } | null {
   const action = typeof args.action === "string" ? args.action.trim() : "";
   if (action !== expectedAction) {
     return null;
@@ -11,5 +11,12 @@ export function extractToolSend(
     return null;
   }
   const accountId = typeof args.accountId === "string" ? args.accountId.trim() : undefined;
-  return { to, accountId };
+  const threadIdRaw =
+    typeof args.threadId === "string"
+      ? args.threadId.trim()
+      : typeof args.threadId === "number"
+        ? String(args.threadId)
+        : "";
+  const threadId = threadIdRaw.length > 0 ? threadIdRaw : undefined;
+  return { to, accountId, threadId };
 }

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -24,16 +24,45 @@ describe("delivery context helpers", () => {
     expect(normalizeDeliveryContext({ channel: "  " })).toBeUndefined();
   });
 
-  it("merges primary values over fallback", () => {
+  it("does not inherit route fields from fallback when channels conflict", () => {
     const merged = mergeDeliveryContext(
-      { channel: "whatsapp", to: "channel:abc" },
-      { channel: "slack", to: "channel:def", accountId: "acct" },
+      { channel: "telegram" },
+      { channel: "discord", to: "channel:def", accountId: "acct", threadId: "99" },
     );
 
     expect(merged).toEqual({
-      channel: "whatsapp",
-      to: "channel:abc",
+      channel: "telegram",
+      to: undefined,
+      accountId: undefined,
+    });
+    expect(merged?.threadId).toBeUndefined();
+  });
+
+  it("inherits missing route fields when channels match", () => {
+    const merged = mergeDeliveryContext(
+      { channel: "telegram" },
+      { channel: "telegram", to: "123", accountId: "acct", threadId: "99" },
+    );
+
+    expect(merged).toEqual({
+      channel: "telegram",
+      to: "123",
       accountId: "acct",
+      threadId: "99",
+    });
+  });
+
+  it("uses fallback route fields when fallback has no channel", () => {
+    const merged = mergeDeliveryContext(
+      { channel: "telegram" },
+      { to: "123", accountId: "acct", threadId: "99" },
+    );
+
+    expect(merged).toEqual({
+      channel: "telegram",
+      to: "123",
+      accountId: "acct",
+      threadId: "99",
     });
   });
 
@@ -103,7 +132,7 @@ describe("delivery context helpers", () => {
     });
   });
 
-  it("normalizes delivery fields and mirrors them on session entries", () => {
+  it("normalizes delivery fields, mirrors session fields, and avoids cross-channel carryover", () => {
     const normalized = normalizeSessionDeliveryFields({
       deliveryContext: {
         channel: " Slack ",
@@ -118,12 +147,11 @@ describe("delivery context helpers", () => {
     expect(normalized.deliveryContext).toEqual({
       channel: "whatsapp",
       to: "+1555",
-      accountId: "acct-2",
-      threadId: "444",
+      accountId: undefined,
     });
     expect(normalized.lastChannel).toBe("whatsapp");
     expect(normalized.lastTo).toBe("+1555");
-    expect(normalized.lastAccountId).toBe("acct-2");
-    expect(normalized.lastThreadId).toBe("444");
+    expect(normalized.lastAccountId).toBeUndefined();
+    expect(normalized.lastThreadId).toBeUndefined();
   });
 });

--- a/src/utils/delivery-context.ts
+++ b/src/utils/delivery-context.ts
@@ -121,11 +121,23 @@ export function mergeDeliveryContext(
   if (!normalizedPrimary && !normalizedFallback) {
     return undefined;
   }
+  const channelsConflict =
+    normalizedPrimary?.channel &&
+    normalizedFallback?.channel &&
+    normalizedPrimary.channel !== normalizedFallback.channel;
   return normalizeDeliveryContext({
     channel: normalizedPrimary?.channel ?? normalizedFallback?.channel,
-    to: normalizedPrimary?.to ?? normalizedFallback?.to,
-    accountId: normalizedPrimary?.accountId ?? normalizedFallback?.accountId,
-    threadId: normalizedPrimary?.threadId ?? normalizedFallback?.threadId,
+    // Keep route fields paired to their channel; avoid crossing fields between
+    // unrelated channels during session context merges.
+    to: channelsConflict
+      ? normalizedPrimary?.to
+      : (normalizedPrimary?.to ?? normalizedFallback?.to),
+    accountId: channelsConflict
+      ? normalizedPrimary?.accountId
+      : (normalizedPrimary?.accountId ?? normalizedFallback?.accountId),
+    threadId: channelsConflict
+      ? normalizedPrimary?.threadId
+      : (normalizedPrimary?.threadId ?? normalizedFallback?.threadId),
   });
 }
 

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -4,10 +4,12 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
+  VERSION,
   readVersionFromBuildInfoForModuleUrl,
   readVersionFromPackageJsonForModuleUrl,
   resolveBinaryVersion,
   resolveRuntimeServiceVersion,
+  resolveUsableRuntimeVersion,
   resolveVersionFromModuleUrl,
 } from "./version.js";
 
@@ -141,14 +143,24 @@ describe("version resolution", () => {
     ).toBe("9.9.9");
   });
 
-  it("uses service and package fallbacks and ignores blank env values", () => {
+  it("normalizes runtime version candidate for fallback handling", () => {
+    expect(resolveUsableRuntimeVersion(undefined)).toBeUndefined();
+    expect(resolveUsableRuntimeVersion("")).toBeUndefined();
+    expect(resolveUsableRuntimeVersion(" \t ")).toBeUndefined();
+    expect(resolveUsableRuntimeVersion("0.0.0")).toBeUndefined();
+    expect(resolveUsableRuntimeVersion(" 0.0.0 ")).toBeUndefined();
+    expect(resolveUsableRuntimeVersion("2026.3.2")).toBe("2026.3.2");
+    expect(resolveUsableRuntimeVersion(" 2026.3.2 ")).toBe("2026.3.2");
+  });
+
+  it("prefers runtime VERSION over service/package markers and ignores blank env values", () => {
     expect(
       resolveRuntimeServiceVersion({
         REMOTECLAW_VERSION: "   ",
         REMOTECLAW_SERVICE_VERSION: "  2.0.0  ",
         npm_package_version: "1.0.0",
       }),
-    ).toBe("2.0.0");
+    ).toBe(VERSION);
 
     expect(
       resolveRuntimeServiceVersion({
@@ -156,7 +168,7 @@ describe("version resolution", () => {
         REMOTECLAW_SERVICE_VERSION: "\t",
         npm_package_version: " 1.0.0-package ",
       }),
-    ).toBe("1.0.0-package");
+    ).toBe(VERSION);
 
     expect(
       resolveRuntimeServiceVersion(
@@ -167,6 +179,6 @@ describe("version resolution", () => {
         },
         "fallback",
       ),
-    ).toBe("fallback");
+    ).toBe(VERSION);
   });
 });

--- a/src/version.ts
+++ b/src/version.ts
@@ -90,13 +90,28 @@ export type RuntimeVersionEnv = {
   [key: string]: string | undefined;
 };
 
+export const RUNTIME_SERVICE_VERSION_FALLBACK = "unknown";
+
+export function resolveUsableRuntimeVersion(version: string | undefined): string | undefined {
+  const trimmed = version?.trim();
+  // "0.0.0" is the resolver's hard fallback when module metadata cannot be read.
+  // Prefer explicit service/package markers in that edge case.
+  if (!trimmed || trimmed === "0.0.0") {
+    return undefined;
+  }
+  return trimmed;
+}
+
 export function resolveRuntimeServiceVersion(
   env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,
-  fallback = "dev",
+  fallback = RUNTIME_SERVICE_VERSION_FALLBACK,
 ): string {
+  const runtimeVersion = resolveUsableRuntimeVersion(VERSION);
+
   return (
     firstNonEmpty(
       env["REMOTECLAW_VERSION"],
+      runtimeVersion,
       env["REMOTECLAW_SERVICE_VERSION"],
       env["npm_package_version"],
     ) ?? fallback


### PR DESCRIPTION
## Summary

Cherry-picks 8 upstream commits (1 skipped) for gateway, session, and routing fixes:

| Status | Commit | Subject | Author |
|--------|--------|---------|--------|
| PICKED | `a9ec75fe8` | fix(gateway): flush throttled delta before emitChatFinal (#24856) | [Viz](https://github.com/visionik) |
| SKIPPED | `094140bdb` | test(live): harden gateway model profile probes | [Peter Steinberger](https://github.com/steipete) |
| RESOLVED | `ae2984215` | Gateway: fix stale self version in status output (#32655) | [Liu Xiaopai](https://github.com/liuxiaopai-ai) |
| PICKED | `4aa548cf7` | macOS: add tailscale serve discovery fallback (#32860) | [Nimrod Gutman](https://github.com/nimrod-g) |
| RESOLVED | `3ad3a90db` | fix(gateway): include disk-scanned agent IDs in listConfiguredAgentIds (#32831) | [Sid](https://github.com/sidqin0410) |
| RESOLVED | `1be39d425` | fix(gateway): synthesize lifecycle robustness for restart and startup probes | [Tak Hoffman](https://github.com/Takhoffman) |
| RESOLVED | `53727c72f` | fix: substitute YYYY-MM-DD at session startup and post-compaction | [chengzhichao-xydt](https://github.com/chengzhichao-xydt) |
| PICKED | `7f2708a8c` | fix(routing): unify session delivery invariants for duplicate suppression | [Tak Hoffman](https://github.com/Takhoffman) |
| PICKED | `0b3bbfec0` | fix(gateway+acp): thread stopReason through final event to ACP bridge (#24867) | [Viz](https://github.com/visionik) |

### Conflict resolutions

- **CHANGELOG.md**: `git rm` on all commits (deleted in fork)
- **`a9ec75fe8`**: Discarded gutted `pi-embedded-runner/run.ts`; kept `agent.ts` (gutted fallback block stays removed); merged delta flush into `server-chat.ts` with fork's simplified heartbeat handling
- **`094140bdb`**: Skipped — entire commit modifies `gateway-models.profiles.live.test.ts` which was deleted in fork (tests Pi model infrastructure, gutted)
- **`ae2984215`**: Rebranded env vars (`REMOTECLAW_VERSION`/`REMOTECLAW_SERVICE_VERSION`) + inserted `runtimeVersion` in lookup priority; updated test descriptions to match new behavior
- **`4aa548cf7`**: Discarded rebranded test files; resolved `GatewayDiscoveryModel.swift` (added tailscale properties + kept rebranded logger); took upstream `TailscaleServeGatewayDiscovery.swift` with `OpenClawKit`→`RemoteClawKit` rebrand
- **`3ad3a90db`**: Type rename `OpenClawConfig`→`RemoteClawConfig` in `session-utils.ts`
- **`1be39d425`**: Added `waitForPortBindable` (the fix); kept gutted `ensureDevGatewayConfig` removed; rebranded `org.remoteclaw` in test assertions; added upstream's `home`/`plistPath` variables with rebranded filename
- **`53727c72f`**: Discarded gutted `post-compaction-context.{ts,test.ts}`; updated imports to `buildBareSessionResetPrompt` (the fix); removed gutted `ensureSkillSnapshot` import; rebranded `OpenClawConfig`→`RemoteClawConfig` in session-reset-prompt.ts
- **`7f2708a8c`**: Discarded gutted `pi-embedded-messaging.ts` (renamed to `agent-messaging.ts` in fork)

Resolves #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)