### PR TITLE
Cherry-pick b52c9f257: fix(ci): handle disabled systemd units in docker doctor flow

### DIFF
--- a/scripts/e2e/doctor-install-switch-docker.sh
+++ b/scripts/e2e/doctor-install-switch-docker.sh
@@ -37,8 +37,10 @@ case "$cmd" in
     unit="${args[1]:-}"
     unit_path="$HOME/.config/systemd/user/${unit}"
     if [ -f "$unit_path" ]; then
+      echo "enabled"
       exit 0
     fi
+    echo "disabled" >&2
     exit 1
     ;;
   show)


### PR DESCRIPTION
Cherry-pick of upstream [`b52c9f257`](https://github.com/openclaw/openclaw/commit/b52c9f257) by [Peter Steinberger](https://github.com/steipete).

Fixes the docker doctor `systemctl is-enabled` shim to output `enabled`/`disabled` instead of silently exiting — prevents downstream callers from misinterpreting the exit status.

Part of #807.