### PR TITLE
Cherry-pick 44162e7ba: docs(contributing): require before/after screenshots for UI PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@
 - Keep PRs focused (one thing per PR; do not mix unrelated concerns)
 - Describe what & why
 - Reply to or resolve bot review conversations you addressed before asking for review again
+- **Include screenshots** — one showing the problem/before, one showing the fix/after (for UI or visual changes)
 
 ## Review Conversations Are Author-Owned
 


### PR DESCRIPTION
## Summary

Cherry-pick of upstream openclaw/openclaw@44162e7ba.

- Adds requirement for before/after screenshots in UI/visual change PRs to CONTRIBUTING.md

**Original author**: [Robin Waslander](https://github.com/robinwaslander)
**Upstream PR**: openclaw/openclaw#32206

## Conflict Resolution

- `CHANGELOG.md`: `git rm` — deleted in fork per convention
- `CONTRIBUTING.md`: merged upstream's new bullet point with fork's existing review-conversations section

## Test plan

- [ ] Verify CONTRIBUTING.md renders correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)