### PR TITLE
Cherry-pick issue #812: gateway-session-key-acp-reliability

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -156,8 +156,8 @@ Input modes:
 RemoteClaw ships a default for `claude-cli`:
 
 - `command: "claude"`
-- `args: ["-p", "--output-format", "json", "--dangerously-skip-permissions"]`
-- `resumeArgs: ["-p", "--output-format", "json", "--dangerously-skip-permissions", "--resume", "{sessionId}"]`
+- `args: ["-p", "--output-format", "json", "--permission-mode", "bypassPermissions"]`
+- `resumeArgs: ["-p", "--output-format", "json", "--permission-mode", "bypassPermissions", "--resume", "{sessionId}"]`
 - `modelArg: "--model"`
 - `systemPromptArg: "--append-system-prompt"`
 - `sessionArg: "--session-id"`

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -219,7 +219,7 @@ REMOTECLAW_LIVE_SETUP_TOKEN=1 REMOTECLAW_LIVE_SETUP_TOKEN_PROFILE=anthropic:setu
 - Defaults:
   - Model: `claude-cli/claude-sonnet-4-6`
   - Command: `claude`
-  - Args: `["-p","--output-format","json","--dangerously-skip-permissions"]`
+  - Args: `["-p","--output-format","json","--permission-mode","bypassPermissions"]`
 - Overrides (optional):
   - `REMOTECLAW_LIVE_CLI_BACKEND_MODEL="claude-cli/claude-opus-4-6"`
   - `REMOTECLAW_LIVE_CLI_BACKEND_MODEL="codex-cli/gpt-5.3-codex"`

--- a/src/agents/remoteclaw-tools.camera.test.ts
+++ b/src/agents/remoteclaw-tools.camera.test.ts
@@ -30,10 +30,18 @@ function unexpectedGatewayMethod(method: unknown): never {
   throw new Error(`unexpected method: ${String(method)}`);
 }
 
-function getNodesTool(options?: { modelHasVision?: boolean }) {
-  const tool = createRemoteClawTools(
-    options?.modelHasVision !== undefined ? { modelHasVision: options.modelHasVision } : {},
-  ).find((candidate) => candidate.name === "nodes");
+function getNodesTool(options?: { modelHasVision?: boolean; allowMediaInvokeCommands?: boolean }) {
+  const toolOptions: {
+    modelHasVision?: boolean;
+    allowMediaInvokeCommands?: boolean;
+  } = {};
+  if (options?.modelHasVision !== undefined) {
+    toolOptions.modelHasVision = options.modelHasVision;
+  }
+  if (options?.allowMediaInvokeCommands !== undefined) {
+    toolOptions.allowMediaInvokeCommands = options.allowMediaInvokeCommands;
+  }
+  const tool = createRemoteClawTools(toolOptions).find((candidate) => candidate.name === "nodes");
   if (!tool) {
     throw new Error("missing nodes tool");
   }
@@ -42,7 +50,7 @@ function getNodesTool(options?: { modelHasVision?: boolean }) {
 
 async function executeNodes(
   input: Record<string, unknown>,
-  options?: { modelHasVision?: boolean },
+  options?: { modelHasVision?: boolean; allowMediaInvokeCommands?: boolean },
 ) {
   return getNodesTool(options).execute("call1", input as never);
 }
@@ -807,5 +815,37 @@ describe("nodes invoke", () => {
         invokeParamsJson: '{"limit":1}',
       }),
     ).rejects.toThrow(/use action="photos_latest"/i);
+  });
+
+  it("allows media invoke commands when explicitly enabled", async () => {
+    setupNodeInvokeMock({
+      onInvoke: (invokeParams) => {
+        expect(invokeParams).toMatchObject({
+          command: "photos.latest",
+          params: { limit: 1 },
+        });
+        return {
+          payload: {
+            photos: [{ format: "jpg", base64: "aGVsbG8=", width: 1, height: 1 }],
+          },
+        };
+      },
+    });
+
+    const result = await executeNodes(
+      {
+        action: "invoke",
+        node: NODE_ID,
+        invokeCommand: "photos.latest",
+        invokeParamsJson: '{"limit":1}',
+      },
+      { allowMediaInvokeCommands: true },
+    );
+
+    expect(result.details).toMatchObject({
+      payload: {
+        photos: [{ format: "jpg", base64: "aGVsbG8=", width: 1, height: 1 }],
+      },
+    });
   });
 });

--- a/src/agents/remoteclaw-tools.ts
+++ b/src/agents/remoteclaw-tools.ts
@@ -50,6 +50,8 @@ export function createRemoteClawTools(options?: {
   hasRepliedRef?: { value: boolean };
   /** If true, the model has native vision capability */
   modelHasVision?: boolean;
+  /** If true, nodes action="invoke" can call media-returning commands directly. */
+  allowMediaInvokeCommands?: boolean;
   /** Explicit agent ID override for cron/hook sessions. */
   requesterAgentIdOverride?: string;
   /** Require explicit message targets (no implicit last-route sends). */
@@ -85,6 +87,7 @@ export function createRemoteClawTools(options?: {
       agentSessionKey: options?.agentSessionKey,
       config: options?.config,
       modelHasVision: options?.modelHasVision,
+      allowMediaInvokeCommands: options?.allowMediaInvokeCommands,
     }),
     createCronTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -159,6 +159,7 @@ export function createNodesTool(options?: {
   currentChannelId?: string;
   currentThreadTs?: string | number;
   modelHasVision?: boolean;
+  allowMediaInvokeCommands?: boolean;
 }): AnyAgentTool {
   const sessionKey = options?.agentSessionKey?.trim() || undefined;
   const agentId = resolveSessionAgentId({
@@ -721,7 +722,7 @@ export function createNodesTool(options?: {
             const invokeCommandNormalized = invokeCommand.trim().toLowerCase();
             const dedicatedAction =
               MEDIA_INVOKE_ACTIONS[invokeCommandNormalized as keyof typeof MEDIA_INVOKE_ACTIONS];
-            if (dedicatedAction) {
+            if (dedicatedAction && !options?.allowMediaInvokeCommands) {
               throw new Error(
                 `invokeCommand "${invokeCommand}" returns media payloads and is blocked to prevent base64 context bloat; use action="${dedicatedAction}"`,
               );

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -323,6 +323,15 @@ export type DiscordAccountConfig = {
   activityType?: 0 | 1 | 2 | 3 | 4 | 5;
   /** Streaming URL (Twitch/YouTube). Required when activityType=1. */
   activityUrl?: string;
+  /** Carbon EventQueue configuration for this Discord account. */
+  eventQueue?: {
+    /** Max time (ms) a single listener can run before being killed. Default: 120000. */
+    listenerTimeout?: number;
+    /** Max events queued before backpressure is applied. Default: 10000. */
+    maxQueueSize?: number;
+    /** Max concurrent event processing operations. Default: 50. */
+    maxConcurrency?: number;
+  };
 };
 
 export type DiscordConfig = {

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -12,6 +12,15 @@ describe("buildSystemdUnit", () => {
     expect(execStart).toBe('ExecStart=/usr/bin/remoteclaw gateway --name "My Bot"');
   });
 
+  it("renders control-group kill mode for child-process cleanup", () => {
+    const unit = buildSystemdUnit({
+      description: "OpenClaw Gateway",
+      programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+      environment: {},
+    });
+    expect(unit).toContain("KillMode=control-group");
+  });
+
   it("rejects environment values with line breaks", () => {
     expect(() =>
       buildSystemdUnit({

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -59,10 +59,9 @@ export function buildSystemdUnit({
     `ExecStart=${execStart}`,
     "Restart=always",
     "RestartSec=5",
-    // KillMode=process ensures systemd only waits for the main process to exit.
-    // Without this, podman's conmon (container monitor) processes block shutdown
-    // since they run as children of the gateway and stay in the same cgroup.
-    "KillMode=process",
+    // Keep service children in the same lifecycle so restarts do not leave
+    // orphan ACP/runtime workers behind.
+    "KillMode=control-group",
     workingDirLine,
     ...envLines,
     "",

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -197,9 +197,9 @@ describe("DiscordMessageListener", () => {
 
       // Release the background handler and allow slow-log finalizer to run.
       deferred.resolve();
-      await Promise.resolve();
-
-      expect(logger.warn).toHaveBeenCalled();
+      await vi.waitFor(() => {
+        expect(logger.warn).toHaveBeenCalled();
+      });
       const warnMock = logger.warn as unknown as { mock: { calls: unknown[][] } };
       const [, meta] = warnMock.mock.calls[0] ?? [];
       const durationMs = (meta as { durationMs?: number } | undefined)?.durationMs;

--- a/src/discord/monitor/listeners.test.ts
+++ b/src/discord/monitor/listeners.test.ts
@@ -121,4 +121,110 @@ describe("DiscordMessageListener", () => {
       );
     });
   });
+
+  it("continues same-channel processing after handler timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const never = new Promise<void>(() => {});
+      const handler = vi.fn(async () => {
+        if (handler.mock.calls.length === 1) {
+          await never;
+          return;
+        }
+      });
+      const logger = createLogger();
+      const listener = new DiscordMessageListener(handler as never, logger as never, undefined, {
+        timeoutMs: 50,
+      });
+
+      await listener.handle(fakeEvent("ch-1"), {} as never);
+      await listener.handle(fakeEvent("ch-1"), {} as never);
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(60);
+      await vi.waitFor(() => {
+        expect(handler).toHaveBeenCalledTimes(2);
+      });
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("timed out after"));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("aborts timed-out handlers and prevents late side effects", async () => {
+    vi.useFakeTimers();
+    try {
+      let abortReceived = false;
+      let lateSideEffect = false;
+      const handler = vi.fn(
+        async (
+          _data: unknown,
+          _client: unknown,
+          options?: {
+            abortSignal?: AbortSignal;
+          },
+        ) => {
+          await new Promise<void>((resolve) => {
+            if (options?.abortSignal?.aborted) {
+              abortReceived = true;
+              resolve();
+              return;
+            }
+            options?.abortSignal?.addEventListener(
+              "abort",
+              () => {
+                abortReceived = true;
+                resolve();
+              },
+              { once: true },
+            );
+          });
+          if (options?.abortSignal?.aborted) {
+            return;
+          }
+          lateSideEffect = true;
+        },
+      );
+      const logger = createLogger();
+      const listener = new DiscordMessageListener(handler as never, logger as never, undefined, {
+        timeoutMs: 50,
+      });
+
+      await listener.handle(fakeEvent("ch-1"), {} as never);
+      await listener.handle(fakeEvent("ch-1"), {} as never);
+
+      await vi.advanceTimersByTimeAsync(60);
+      await vi.waitFor(() => {
+        expect(handler).toHaveBeenCalledTimes(2);
+      });
+      expect(abortReceived).toBe(true);
+      expect(lateSideEffect).toBe(false);
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("timed out after"));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not emit slow-listener warnings when timeout already fired", async () => {
+    vi.useFakeTimers();
+    try {
+      const never = new Promise<void>(() => {});
+      const handler = vi.fn(async () => {
+        await never;
+      });
+      const logger = createLogger();
+      const listener = new DiscordMessageListener(handler as never, logger as never, undefined, {
+        timeoutMs: 31_000,
+      });
+
+      await listener.handle(fakeEvent("ch-1"), {} as never);
+      await vi.advanceTimersByTimeAsync(31_100);
+      await vi.waitFor(() => {
+        expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("timed out after"));
+      });
+      expect(logger.warn).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -41,7 +41,11 @@ type Logger = ReturnType<typeof import("../../logging/subsystem.js").createSubsy
 
 export type DiscordMessageEvent = Parameters<MessageCreateListener["handle"]>[0];
 
-export type DiscordMessageHandler = (data: DiscordMessageEvent, client: Client) => Promise<void>;
+export type DiscordMessageHandler = (
+  data: DiscordMessageEvent,
+  client: Client,
+  options?: { abortSignal?: AbortSignal },
+) => Promise<void>;
 
 type DiscordReactionEvent = Parameters<MessageReactionAddListener["handle"]>[0];
 
@@ -67,13 +71,50 @@ type DiscordReactionRoutingParams = {
 };
 
 const DISCORD_SLOW_LISTENER_THRESHOLD_MS = 30_000;
+const DISCORD_DEFAULT_LISTENER_TIMEOUT_MS = 120_000;
 const discordEventQueueLog = createSubsystemLogger("discord/event-queue");
+
+function normalizeDiscordListenerTimeoutMs(raw: number | undefined): number {
+  if (!Number.isFinite(raw) || (raw ?? 0) <= 0) {
+    return DISCORD_DEFAULT_LISTENER_TIMEOUT_MS;
+  }
+  return Math.max(1_000, Math.floor(raw!));
+}
+
+function formatListenerContextValue(value: unknown): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  return null;
+}
+
+function formatListenerContextSuffix(context?: Record<string, unknown>): string {
+  if (!context) {
+    return "";
+  }
+  const entries = Object.entries(context).flatMap(([key, value]) => {
+    const formatted = formatListenerContextValue(value);
+    return formatted ? [`${key}=${formatted}`] : [];
+  });
+  if (entries.length === 0) {
+    return "";
+  }
+  return ` (${entries.join(" ")})`;
+}
 
 function logSlowDiscordListener(params: {
   logger: Logger | undefined;
   listener: string;
   event: string;
   durationMs: number;
+  context?: Record<string, unknown>;
 }) {
   if (params.durationMs < DISCORD_SLOW_LISTENER_THRESHOLD_MS) {
     return;
@@ -89,7 +130,8 @@ function logSlowDiscordListener(params: {
     event: params.event,
     durationMs: params.durationMs,
     duration,
-    consoleMessage: message,
+    ...params.context,
+    consoleMessage: `${message}${formatListenerContextSuffix(params.context)}`,
   });
 }
 
@@ -97,12 +139,59 @@ async function runDiscordListenerWithSlowLog(params: {
   logger: Logger | undefined;
   listener: string;
   event: string;
-  run: () => Promise<void>;
+  run: (abortSignal: AbortSignal) => Promise<void>;
+  timeoutMs?: number;
+  context?: Record<string, unknown>;
   onError?: (err: unknown) => void;
 }) {
   const startedAt = Date.now();
+  const timeoutMs = normalizeDiscordListenerTimeoutMs(params.timeoutMs);
+  let timedOut = false;
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const logger = params.logger ?? discordEventQueueLog;
+  const abortController = new AbortController();
+  const runPromise = params.run(abortController.signal).catch((err) => {
+    if (timedOut) {
+      const errorName =
+        err && typeof err === "object" && "name" in err ? String(err.name) : undefined;
+      if (abortController.signal.aborted && errorName === "AbortError") {
+        logger.warn(
+          `discord handler canceled after timeout${formatListenerContextSuffix(params.context)}`,
+        );
+        return;
+      }
+      logger.error(
+        danger(
+          `discord handler failed after timeout: ${String(err)}${formatListenerContextSuffix(params.context)}`,
+        ),
+      );
+      return;
+    }
+    throw err;
+  });
+
   try {
-    await params.run();
+    const timeoutPromise = new Promise<"timeout">((resolve) => {
+      timeoutHandle = setTimeout(() => resolve("timeout"), timeoutMs);
+      timeoutHandle.unref?.();
+    });
+    const result = await Promise.race([
+      runPromise.then(() => "completed" as const),
+      timeoutPromise,
+    ]);
+    if (result === "timeout") {
+      timedOut = true;
+      abortController.abort();
+      logger.error(
+        danger(
+          `discord handler timed out after ${formatDurationSeconds(timeoutMs, {
+            decimals: 1,
+            unit: "seconds",
+          })}${formatListenerContextSuffix(params.context)}`,
+        ),
+      );
+      return;
+    }
   } catch (err) {
     if (params.onError) {
       params.onError(err);
@@ -110,12 +199,18 @@ async function runDiscordListenerWithSlowLog(params: {
     }
     throw err;
   } finally {
-    logSlowDiscordListener({
-      logger: params.logger,
-      listener: params.listener,
-      event: params.event,
-      durationMs: Date.now() - startedAt,
-    });
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+    if (!timedOut) {
+      logSlowDiscordListener({
+        logger: params.logger,
+        listener: params.listener,
+        event: params.event,
+        durationMs: Date.now() - startedAt,
+        context: params.context,
+      });
+    }
   }
 }
 
@@ -129,18 +224,26 @@ export function registerDiscordListener(listeners: Array<object>, listener: obje
 
 export class DiscordMessageListener extends MessageCreateListener {
   private readonly channelQueue = new KeyedAsyncQueue();
+  private readonly listenerTimeoutMs: number;
 
   constructor(
     private handler: DiscordMessageHandler,
     private logger?: Logger,
     private onEvent?: () => void,
+    options?: { timeoutMs?: number },
   ) {
     super();
+    this.listenerTimeoutMs = normalizeDiscordListenerTimeoutMs(options?.timeoutMs);
   }
 
   async handle(data: DiscordMessageEvent, client: Client) {
     this.onEvent?.();
     const channelId = data.channel_id;
+    const context = {
+      channelId,
+      messageId: (data as { message?: { id?: string } }).message?.id,
+      guildId: (data as { guild_id?: string }).guild_id,
+    } satisfies Record<string, unknown>;
     // Serialize messages within the same channel to preserve ordering,
     // but allow different channels to proceed in parallel so that
     // channel-bound agents are not blocked by each other.
@@ -149,7 +252,9 @@ export class DiscordMessageListener extends MessageCreateListener {
         logger: this.logger,
         listener: this.constructor.name,
         event: this.type,
-        run: () => this.handler(data, client),
+        timeoutMs: this.listenerTimeoutMs,
+        context,
+        run: (abortSignal) => this.handler(data, client, { abortSignal }),
         onError: (err) => {
           const logger = this.logger ?? discordEventQueueLog;
           logger.error(danger(`discord handler failed: ${String(err)}`));
@@ -207,7 +312,7 @@ async function runDiscordReactionHandler(params: {
     logger: params.handlerParams.logger,
     listener: params.listener,
     event: params.event,
-    run: () =>
+    run: async () =>
       handleDiscordReactionEvent({
         data: params.data,
         client: params.client,

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -67,6 +67,10 @@ export type {
 
 const DISCORD_BOUND_THREAD_SYSTEM_PREFIXES = ["⚙️", "🤖", "🧰"];
 
+function isPreflightAborted(abortSignal?: AbortSignal): boolean {
+  return Boolean(abortSignal?.aborted);
+}
+
 function isBoundThreadBotSystemMessage(params: {
   isBoundThreadSession: boolean;
   isBotAuthor: boolean;
@@ -120,6 +124,9 @@ export function shouldIgnoreBoundThreadWebhookMessage(params: {
 export async function preflightDiscordMessage(
   params: DiscordMessagePreflightParams,
 ): Promise<DiscordMessagePreflightContext | null> {
+  if (isPreflightAborted(params.abortSignal)) {
+    return null;
+  }
   const logger = getChildLogger({ module: "discord-auto-reply" });
   const message = params.data.message;
   const author = params.data.author;
@@ -153,6 +160,9 @@ export async function preflightDiscordMessage(
         messageId: message.id,
         config: pluralkitConfig,
       });
+      if (isPreflightAborted(params.abortSignal)) {
+        return null;
+      }
     } catch (err) {
       logVerbose(`discord: pluralkit lookup failed for ${message.id}: ${String(err)}`);
     }
@@ -172,6 +182,9 @@ export async function preflightDiscordMessage(
 
   const isGuildMessage = Boolean(params.data.guild_id);
   const channelInfo = await resolveDiscordChannelInfo(params.client, messageChannelId);
+  if (isPreflightAborted(params.abortSignal)) {
+    return null;
+  }
   const isDirectMessage = channelInfo?.type === ChannelType.DM;
   const isGroupDm = channelInfo?.type === ChannelType.GroupDM;
   logDebug(
@@ -209,6 +222,9 @@ export async function preflightDiscordMessage(
       allowNameMatching,
       useAccessGroups,
     });
+    if (isPreflightAborted(params.abortSignal)) {
+      return null;
+    }
     commandAuthorized = dmAccess.commandAuthorized;
     if (dmAccess.decision !== "allow") {
       const allowMatchMeta = formatAllowlistMatchMeta(
@@ -296,6 +312,9 @@ export async function preflightDiscordMessage(
       threadChannel: earlyThreadChannel,
       channelInfo,
     });
+    if (isPreflightAborted(params.abortSignal)) {
+      return null;
+    }
     earlyThreadParentId = parentInfo.id;
     earlyThreadParentName = parentInfo.name;
     earlyThreadParentType = parentInfo.type;
@@ -533,7 +552,11 @@ export async function preflightDiscordMessage(
       shouldRequireMention,
       mentionRegexes,
       cfg: params.cfg,
+      abortSignal: params.abortSignal,
     });
+  if (isPreflightAborted(params.abortSignal)) {
+    return null;
+  }
 
   const mentionText = hasTypedText ? baseText : "";
   const wasMentioned =
@@ -712,6 +735,7 @@ export async function preflightDiscordMessage(
     token: params.token,
     runtime: params.runtime,
     botUserId: params.botUserId,
+    abortSignal: params.abortSignal,
     guildHistories: params.guildHistories,
     historyLimit: params.historyLimit,
     mediaMaxBytes: params.mediaMaxBytes,

--- a/src/discord/monitor/message-handler.preflight.types.ts
+++ b/src/discord/monitor/message-handler.preflight.types.ts
@@ -24,6 +24,7 @@ export type DiscordMessagePreflightContext = {
   token: string;
   runtime: RuntimeEnv;
   botUserId?: string;
+  abortSignal?: AbortSignal;
   guildHistories: Map<string, HistoryEntry[]>;
   historyLimit: number;
   mediaMaxBytes: number;
@@ -94,6 +95,7 @@ export type DiscordMessagePreflightParams = {
   token: string;
   runtime: RuntimeEnv;
   botUserId?: string;
+  abortSignal?: AbortSignal;
   guildHistories: Map<string, HistoryEntry[]>;
   historyLimit: number;
   mediaMaxBytes: number;

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -341,6 +341,32 @@ describe("processDiscordMessage ack reactions", () => {
     expect(emojis).toContain("🟦");
     expect(emojis).toContain("🏁");
   });
+
+  it("clears status reactions when dispatch aborts and removeAckAfterReply is enabled", async () => {
+    const abortController = new AbortController();
+    dispatchInboundMessage.mockImplementationOnce(async () => {
+      abortController.abort();
+      throw new Error("aborted");
+    });
+
+    const ctx = await createBaseContext({
+      abortSignal: abortController.signal,
+      cfg: {
+        messages: {
+          ackReaction: "👀",
+          removeAckAfterReply: true,
+        },
+        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+      },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    await vi.waitFor(() => {
+      expect(sendMocks.removeReactionDiscord).toHaveBeenCalledWith("c1", "m1", "👀", { rest: {} });
+    });
+  });
 });
 
 describe("processDiscordMessage session routing", () => {

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -60,6 +60,10 @@ function sleep(ms: number): Promise<void> {
 
 const DISCORD_TYPING_MAX_DURATION_MS = 20 * 60_000;
 
+function isProcessAborted(abortSignal?: AbortSignal): boolean {
+  return Boolean(abortSignal?.aborted);
+}
+
 export async function processDiscordMessage(ctx: DiscordMessagePreflightContext) {
   const {
     cfg,
@@ -105,16 +109,26 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     route,
     commandAuthorized,
     discordRestFetch,
+    abortSignal,
   } = ctx;
+  if (isProcessAborted(abortSignal)) {
+    return;
+  }
 
   const ssrfPolicy = cfg.browser?.ssrfPolicy;
   const mediaList = await resolveMediaList(message, mediaMaxBytes, discordRestFetch, ssrfPolicy);
+  if (isProcessAborted(abortSignal)) {
+    return;
+  }
   const forwardedMediaList = await resolveForwardedMediaList(
     message,
     mediaMaxBytes,
     discordRestFetch,
     ssrfPolicy,
   );
+  if (isProcessAborted(abortSignal)) {
+    return;
+  }
   mediaList.push(...forwardedMediaList);
   const text = messageText;
   if (!text) {
@@ -584,6 +598,9 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
       typingCallbacks,
       deliver: async (payload: ReplyPayload, info) => {
+        if (isProcessAborted(abortSignal)) {
+          return;
+        }
         const isFinal = info.kind === "final";
         if (payload.isReasoning) {
           // Reasoning/thinking payloads should not be delivered to Discord.
@@ -606,6 +623,9 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
 
           if (canFinalizeViaPreviewEdit) {
             await draftStream.stop();
+            if (isProcessAborted(abortSignal)) {
+              return;
+            }
             try {
               await editMessageDiscord(
                 deliverChannelId,
@@ -626,6 +646,9 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           // Check if stop() flushed a message we can edit
           if (!finalizedViaPreviewMessage) {
             await draftStream.stop();
+            if (isProcessAborted(abortSignal)) {
+              return;
+            }
             const messageIdAfterStop = draftStream.messageId();
             if (
               typeof messageIdAfterStop === "string" &&
@@ -656,6 +679,9 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
             await draftStream.clear();
           }
         }
+        if (isProcessAborted(abortSignal)) {
+          return;
+        }
 
         const replyToId = replyReference.use();
         await deliverDiscordReply({
@@ -681,6 +707,9 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         runtime.error?.(danger(`discord ${info.kind} reply failed: ${String(err)}`));
       },
       onReplyStart: async () => {
+        if (isProcessAborted(abortSignal)) {
+          return;
+        }
         await typingCallbacks.onReplyStart();
         await statusReactions.setThinking();
       },
@@ -688,13 +717,19 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
 
   let dispatchResult: Awaited<ReturnType<typeof dispatchInboundMessage>> | null = null;
   let dispatchError = false;
+  let dispatchAborted = false;
   try {
+    if (isProcessAborted(abortSignal)) {
+      dispatchAborted = true;
+      return;
+    }
     dispatchResult = await dispatchInboundMessage({
       ctx: ctxPayload,
       cfg,
       dispatcher,
       replyOptions: {
         ...replyOptions,
+        abortSignal,
         disableBlockStreaming:
           disableBlockStreamingForDraft ??
           (typeof discordConfig?.blockStreaming === "boolean"
@@ -728,11 +763,22 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           await statusReactions.setThinking();
         },
         onToolStart: async (payload) => {
+          if (isProcessAborted(abortSignal)) {
+            return;
+          }
           await statusReactions.setTool(payload.name);
         },
       },
     });
+    if (isProcessAborted(abortSignal)) {
+      dispatchAborted = true;
+      return;
+    }
   } catch (err) {
+    if (isProcessAborted(abortSignal)) {
+      dispatchAborted = true;
+      return;
+    }
     dispatchError = true;
     throw err;
   } finally {
@@ -750,20 +796,31 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       markDispatchIdle();
     }
     if (statusReactionsEnabled) {
-      if (dispatchError) {
-        await statusReactions.setError();
+      if (dispatchAborted) {
+        if (removeAckAfterReply) {
+          void statusReactions.clear();
+        } else {
+          void statusReactions.restoreInitial();
+        }
       } else {
-        await statusReactions.setDone();
-      }
-      if (removeAckAfterReply) {
-        void (async () => {
-          await sleep(dispatchError ? DEFAULT_TIMING.errorHoldMs : DEFAULT_TIMING.doneHoldMs);
-          await statusReactions.clear();
-        })();
-      } else {
-        void statusReactions.restoreInitial();
+        if (dispatchError) {
+          await statusReactions.setError();
+        } else {
+          await statusReactions.setDone();
+        }
+        if (removeAckAfterReply) {
+          void (async () => {
+            await sleep(dispatchError ? DEFAULT_TIMING.errorHoldMs : DEFAULT_TIMING.doneHoldMs);
+            await statusReactions.clear();
+          })();
+        } else {
+          void statusReactions.restoreInitial();
+        }
       }
     }
+  }
+  if (dispatchAborted) {
+    return;
   }
 
   if (!dispatchResult?.queuedFinal) {

--- a/src/discord/monitor/message-handler.queue.test.ts
+++ b/src/discord/monitor/message-handler.queue.test.ts
@@ -26,6 +26,7 @@ function createDeferred<T = void>() {
 function createHandlerParams(overrides?: {
   setStatus?: (patch: Record<string, unknown>) => void;
   abortSignal?: AbortSignal;
+  listenerTimeoutMs?: number;
 }) {
   const cfg: RemoteClawConfig = {
     channels: {
@@ -64,6 +65,7 @@ function createHandlerParams(overrides?: {
     threadBindings: createNoopThreadBindingManager("default"),
     setStatus: overrides?.setStatus,
     abortSignal: overrides?.abortSignal,
+    listenerTimeoutMs: overrides?.listenerTimeoutMs,
   };
 }
 
@@ -165,6 +167,55 @@ describe("createDiscordMessageHandler queue behavior", () => {
         }),
       );
     });
+  });
+
+  it("applies listener timeout to queued runs so stalled runs do not block the queue", async () => {
+    vi.useFakeTimers();
+    try {
+      preflightDiscordMessageMock.mockReset();
+      processDiscordMessageMock.mockReset();
+
+      processDiscordMessageMock
+        .mockImplementationOnce(async (ctx: { abortSignal?: AbortSignal }) => {
+          await new Promise<void>((resolve) => {
+            if (ctx.abortSignal?.aborted) {
+              resolve();
+              return;
+            }
+            ctx.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+          });
+        })
+        .mockImplementationOnce(async () => undefined);
+      preflightDiscordMessageMock.mockImplementation(
+        async (params: { data: { channel_id: string } }) =>
+          createPreflightContext(params.data.channel_id),
+      );
+
+      const params = createHandlerParams({ listenerTimeoutMs: 50 });
+      const handler = createDiscordMessageHandler(params);
+
+      await expect(
+        handler(createMessageData("m-1") as never, {} as never),
+      ).resolves.toBeUndefined();
+      await expect(
+        handler(createMessageData("m-2") as never, {} as never),
+      ).resolves.toBeUndefined();
+
+      await vi.advanceTimersByTimeAsync(60);
+      await vi.waitFor(() => {
+        expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
+      });
+
+      const firstCtx = processDiscordMessageMock.mock.calls[0]?.[0] as
+        | { abortSignal?: AbortSignal }
+        | undefined;
+      expect(firstCtx?.abortSignal?.aborted).toBe(true);
+      expect(params.runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("discord queued run timed out after"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("refreshes run activity while active runs are in progress", async () => {

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -6,6 +6,7 @@ import {
 import { createRunStateMachine } from "../../channels/run-state-machine.js";
 import { resolveOpenProviderRuntimeGroupPolicy } from "../../config/runtime-group-policy.js";
 import { danger } from "../../globals.js";
+import { formatDurationSeconds } from "../../infra/format-time/format-duration.ts";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import type { DiscordMessageEvent, DiscordMessageHandler } from "./listeners.js";
 import { preflightDiscordMessage } from "./message-handler.preflight.js";
@@ -27,11 +28,141 @@ type DiscordMessageHandlerParams = Omit<
 > & {
   setStatus?: DiscordMonitorStatusSink;
   abortSignal?: AbortSignal;
+  listenerTimeoutMs?: number;
 };
 
 export type DiscordMessageHandlerWithLifecycle = DiscordMessageHandler & {
   deactivate: () => void;
 };
+
+const DEFAULT_DISCORD_RUN_TIMEOUT_MS = 120_000;
+const MAX_DISCORD_TIMEOUT_MS = 2_147_483_647;
+
+function normalizeDiscordRunTimeoutMs(timeoutMs?: number): number {
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return DEFAULT_DISCORD_RUN_TIMEOUT_MS;
+  }
+  return Math.max(1, Math.min(Math.floor(timeoutMs), MAX_DISCORD_TIMEOUT_MS));
+}
+
+function isAbortError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  return "name" in error && String((error as { name?: unknown }).name) === "AbortError";
+}
+
+function formatDiscordRunContextSuffix(ctx: DiscordMessagePreflightContext): string {
+  const eventData = ctx as {
+    data?: {
+      channel_id?: string;
+      message?: {
+        id?: string;
+      };
+    };
+  };
+  const channelId = ctx.messageChannelId?.trim() || eventData.data?.channel_id?.trim();
+  const messageId = eventData.data?.message?.id?.trim();
+  const details = [
+    channelId ? `channelId=${channelId}` : null,
+    messageId ? `messageId=${messageId}` : null,
+  ].filter((entry): entry is string => Boolean(entry));
+  if (details.length === 0) {
+    return "";
+  }
+  return ` (${details.join(", ")})`;
+}
+
+function mergeAbortSignals(signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
+  const activeSignals = signals.filter((signal): signal is AbortSignal => Boolean(signal));
+  if (activeSignals.length === 0) {
+    return undefined;
+  }
+  if (activeSignals.length === 1) {
+    return activeSignals[0];
+  }
+  if (typeof AbortSignal.any === "function") {
+    return AbortSignal.any(activeSignals);
+  }
+  const fallbackController = new AbortController();
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      fallbackController.abort();
+      return fallbackController.signal;
+    }
+  }
+  const abortFallback = () => {
+    fallbackController.abort();
+    for (const signal of activeSignals) {
+      signal.removeEventListener("abort", abortFallback);
+    }
+  };
+  for (const signal of activeSignals) {
+    signal.addEventListener("abort", abortFallback, { once: true });
+  }
+  return fallbackController.signal;
+}
+
+async function processDiscordRunWithTimeout(params: {
+  ctx: DiscordMessagePreflightContext;
+  runtime: DiscordMessagePreflightParams["runtime"];
+  lifecycleSignal?: AbortSignal;
+  timeoutMs?: number;
+}) {
+  const timeoutMs = normalizeDiscordRunTimeoutMs(params.timeoutMs);
+  const timeoutAbortController = new AbortController();
+  const combinedSignal = mergeAbortSignals([
+    params.ctx.abortSignal,
+    params.lifecycleSignal,
+    timeoutAbortController.signal,
+  ]);
+  const processCtx =
+    combinedSignal && combinedSignal !== params.ctx.abortSignal
+      ? { ...params.ctx, abortSignal: combinedSignal }
+      : params.ctx;
+  const contextSuffix = formatDiscordRunContextSuffix(params.ctx);
+  let timedOut = false;
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const processPromise = processDiscordMessage(processCtx).catch((error) => {
+    if (timedOut) {
+      if (timeoutAbortController.signal.aborted && isAbortError(error)) {
+        return;
+      }
+      params.runtime.error?.(
+        danger(`discord queued run failed after timeout: ${String(error)}${contextSuffix}`),
+      );
+      return;
+    }
+    throw error;
+  });
+
+  try {
+    const timeoutPromise = new Promise<"timeout">((resolve) => {
+      timeoutHandle = setTimeout(() => resolve("timeout"), timeoutMs);
+      timeoutHandle.unref?.();
+    });
+    const result = await Promise.race([
+      processPromise.then(() => "completed" as const),
+      timeoutPromise,
+    ]);
+    if (result === "timeout") {
+      timedOut = true;
+      timeoutAbortController.abort();
+      params.runtime.error?.(
+        danger(
+          `discord queued run timed out after ${formatDurationSeconds(timeoutMs, {
+            decimals: 1,
+            unit: "seconds",
+          })}${contextSuffix}`,
+        ),
+      );
+    }
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
 
 function resolveDiscordRunQueueKey(ctx: DiscordMessagePreflightContext): string {
   const sessionKey = ctx.route.sessionKey?.trim();
@@ -75,7 +206,12 @@ export function createDiscordMessageHandler(
           if (!runState.isActive()) {
             return;
           }
-          await processDiscordMessage(ctx);
+          await processDiscordRunWithTimeout({
+            ctx,
+            runtime: params.runtime,
+            lifecycleSignal: params.abortSignal,
+            timeoutMs: params.listenerTimeoutMs,
+          });
         } finally {
           runState.onRunEnd();
         }
@@ -88,6 +224,7 @@ export function createDiscordMessageHandler(
   const { debouncer } = createChannelInboundDebouncer<{
     data: DiscordMessageEvent;
     client: Client;
+    abortSignal?: AbortSignal;
   }>({
     cfg: params.cfg,
     channel: "discord",
@@ -126,11 +263,16 @@ export function createDiscordMessageHandler(
       if (!last) {
         return;
       }
+      const abortSignal = last.abortSignal;
+      if (abortSignal?.aborted) {
+        return;
+      }
       if (entries.length === 1) {
         const ctx = await preflightDiscordMessage({
           ...params,
           ackReactionScope,
           groupPolicy,
+          abortSignal,
           data: last.data,
           client: last.client,
         });
@@ -162,6 +304,7 @@ export function createDiscordMessageHandler(
         ...params,
         ackReactionScope,
         groupPolicy,
+        abortSignal,
         data: syntheticData,
         client: last.client,
       });
@@ -188,19 +331,22 @@ export function createDiscordMessageHandler(
     },
   });
 
-  const handler: DiscordMessageHandlerWithLifecycle = async (data, client) => {
-    // Filter bot-own messages before they enter the debounce queue.
-    // The same check exists in preflightDiscordMessage(), but by that point
-    // the message has already consumed debounce capacity and blocked
-    // legitimate user messages. On active servers this causes cumulative
-    // slowdown (see #15874).
-    const msgAuthorId = data.message?.author?.id ?? data.author?.id;
-    if (params.botUserId && msgAuthorId === params.botUserId) {
-      return;
-    }
-
+  const handler: DiscordMessageHandlerWithLifecycle = async (data, client, options) => {
     try {
-      await debouncer.enqueue({ data, client });
+      if (options?.abortSignal?.aborted) {
+        return;
+      }
+      // Filter bot-own messages before they enter the debounce queue.
+      // The same check exists in preflightDiscordMessage(), but by that point
+      // the message has already consumed debounce capacity and blocked
+      // legitimate user messages. On active servers this causes cumulative
+      // slowdown (see #15874).
+      const msgAuthorId = data.message?.author?.id ?? data.author?.id;
+      if (params.botUserId && msgAuthorId === params.botUserId) {
+        return;
+      }
+
+      await debouncer.enqueue({ data, client, abortSignal: options?.abortSignal });
     } catch (err) {
       params.runtime.error?.(danger(`handler failed: ${String(err)}`));
     }

--- a/src/discord/monitor/preflight-audio.ts
+++ b/src/discord/monitor/preflight-audio.ts
@@ -24,6 +24,7 @@ export async function resolveDiscordPreflightAudioMentionContext(params: {
   shouldRequireMention: boolean;
   mentionRegexes: RegExp[];
   cfg: RemoteClawConfig;
+  abortSignal?: AbortSignal;
 }): Promise<{
   hasAudioAttachment: boolean;
   hasTypedText: boolean;
@@ -42,8 +43,20 @@ export async function resolveDiscordPreflightAudioMentionContext(params: {
 
   let transcript: string | undefined;
   if (needsPreflightTranscription) {
+    if (params.abortSignal?.aborted) {
+      return {
+        hasAudioAttachment,
+        hasTypedText,
+      };
+    }
     try {
       const { transcribeFirstAudio } = await import("../../stt/preflight.js");
+      if (params.abortSignal?.aborted) {
+        return {
+          hasAudioAttachment,
+          hasTypedText,
+        };
+      }
       const audioUrls = audioAttachments
         .map((att) => att.url)
         .filter((url): url is string => typeof url === "string" && url.length > 0);
@@ -58,6 +71,9 @@ export async function resolveDiscordPreflightAudioMentionContext(params: {
           cfg: params.cfg,
           agentDir: undefined,
         });
+        if (params.abortSignal?.aborted) {
+          transcript = undefined;
+        }
       }
     } catch (err) {
       logVerbose(`discord: audio preflight transcription failed: ${String(err)}`);

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -500,6 +500,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       runtime,
       setStatus: opts.setStatus,
       abortSignal: opts.abortSignal,
+      listenerTimeoutMs: eventQueueOpts.listenerTimeout,
       botUserId,
       guildHistories,
       historyLimit,
@@ -524,7 +525,9 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
 
     registerDiscordListener(
       client.listeners,
-      new DiscordMessageListener(messageHandler, logger, trackInboundEvent),
+      new DiscordMessageListener(messageHandler, logger, trackInboundEvent, {
+        timeoutMs: eventQueueOpts.listenerTimeout,
+      }),
     );
     const reactionListenerOptions = {
       cfg,

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -424,6 +424,12 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     if (voiceEnabled) {
       clientPlugins.push(new VoicePlugin());
     }
+    // Pass eventQueue config to Carbon so the listener timeout can be tuned.
+    // Default listenerTimeout is 120s (Carbon defaults to 30s which is too short for LLM calls).
+    const eventQueueOpts = {
+      listenerTimeout: 120_000,
+      ...discordCfg.eventQueue,
+    };
     const client = new Client(
       {
         baseUrl: "http://localhost",
@@ -432,6 +438,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         publicKey: "a",
         token,
         autoDeploy: false,
+        eventQueue: eventQueueOpts,
       },
       {
         commands,

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -21,7 +21,13 @@ const CLI_RESUME = isTruthyEnvValue(process.env.REMOTECLAW_LIVE_CLI_BACKEND_RESU
 const describeLive = LIVE && CLI_LIVE ? describe : describe.skip;
 
 const DEFAULT_MODEL = "claude-cli/claude-sonnet-4-6";
-const DEFAULT_CLAUDE_ARGS = ["-p", "--output-format", "json", "--dangerously-skip-permissions"];
+const DEFAULT_CLAUDE_ARGS = [
+  "-p",
+  "--output-format",
+  "json",
+  "--permission-mode",
+  "bypassPermissions",
+];
 const DEFAULT_CODEX_ARGS = [
   "exec",
   "--json",

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -144,20 +144,23 @@ function getCachedAgentRun(runId: string) {
 export async function waitForAgentJob(params: {
   runId: string;
   timeoutMs: number;
+  signal?: AbortSignal;
+  ignoreCachedSnapshot?: boolean;
 }): Promise<AgentRunSnapshot | null> {
-  const { runId, timeoutMs } = params;
+  const { runId, timeoutMs, signal, ignoreCachedSnapshot = false } = params;
   ensureAgentRunListener();
-  const cached = getCachedAgentRun(runId);
+  const cached = ignoreCachedSnapshot ? undefined : getCachedAgentRun(runId);
   if (cached) {
     return cached;
   }
-  if (timeoutMs <= 0) {
+  if (timeoutMs <= 0 || signal?.aborted) {
     return null;
   }
 
   return await new Promise((resolve) => {
     let settled = false;
     let pendingErrorTimer: NodeJS.Timeout | undefined;
+    let onAbort: (() => void) | undefined;
 
     const clearPendingErrorTimer = () => {
       if (!pendingErrorTimer) {
@@ -175,6 +178,9 @@ export async function waitForAgentJob(params: {
       clearTimeout(timer);
       clearPendingErrorTimer();
       unsubscribe();
+      if (onAbort) {
+        signal?.removeEventListener("abort", onAbort);
+      }
       resolve(entry);
     };
 
@@ -185,7 +191,7 @@ export async function waitForAgentJob(params: {
       clearPendingErrorTimer();
       const effectiveDelay = Math.max(1, Math.min(Math.floor(delayMs), 2_147_483_647));
       pendingErrorTimer = setTimeout(() => {
-        const latest = getCachedAgentRun(runId);
+        const latest = ignoreCachedSnapshot ? undefined : getCachedAgentRun(runId);
         if (latest) {
           finish(latest);
           return;
@@ -196,9 +202,11 @@ export async function waitForAgentJob(params: {
       pendingErrorTimer.unref?.();
     };
 
-    const pending = getPendingAgentRunError(runId);
-    if (pending) {
-      scheduleErrorFinish(pending.snapshot, pending.dueAt - Date.now());
+    if (!ignoreCachedSnapshot) {
+      const pending = getPendingAgentRunError(runId);
+      if (pending) {
+        scheduleErrorFinish(pending.snapshot, pending.dueAt - Date.now());
+      }
     }
 
     const unsubscribe = onAgentEvent((evt) => {
@@ -216,7 +224,7 @@ export async function waitForAgentJob(params: {
       if (phase !== "end" && phase !== "error") {
         return;
       }
-      const latest = getCachedAgentRun(runId);
+      const latest = ignoreCachedSnapshot ? undefined : getCachedAgentRun(runId);
       if (latest) {
         finish(latest);
         return;
@@ -236,6 +244,8 @@ export async function waitForAgentJob(params: {
 
     const timerDelayMs = Math.max(1, Math.min(Math.floor(timeoutMs), 2_147_483_647));
     const timer = setTimeout(() => finish(null), timerDelayMs);
+    onAbort = () => finish(null);
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
 }
 

--- a/src/gateway/server-methods/agent-wait-dedupe.test.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing,
+  readTerminalSnapshotFromGatewayDedupe,
+  setGatewayDedupeEntry,
+  waitForTerminalGatewayDedupe,
+} from "./agent-wait-dedupe.js";
+
+describe("agent wait dedupe helper", () => {
+  beforeEach(() => {
+    __testing.resetWaiters();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    __testing.resetWaiters();
+    vi.useRealTimers();
+  });
+
+  it("unblocks waiters when a terminal chat dedupe entry is written", async () => {
+    const dedupe = new Map();
+    const runId = "run-chat-terminal";
+    const waiter = waitForTerminalGatewayDedupe({
+      dedupe,
+      runId,
+      timeoutMs: 1_000,
+    });
+
+    await Promise.resolve();
+    expect(__testing.getWaiterCount(runId)).toBe(1);
+
+    setGatewayDedupeEntry({
+      dedupe,
+      key: `chat:${runId}`,
+      entry: {
+        ts: Date.now(),
+        ok: true,
+        payload: {
+          runId,
+          status: "ok",
+          startedAt: 100,
+          endedAt: 200,
+        },
+      },
+    });
+
+    await expect(waiter).resolves.toEqual({
+      status: "ok",
+      startedAt: 100,
+      endedAt: 200,
+      error: undefined,
+    });
+    expect(__testing.getWaiterCount(runId)).toBe(0);
+  });
+
+  it("keeps stale chat dedupe blocked while agent dedupe is in-flight", async () => {
+    const dedupe = new Map();
+    const runId = "run-stale-chat";
+    setGatewayDedupeEntry({
+      dedupe,
+      key: `chat:${runId}`,
+      entry: {
+        ts: Date.now(),
+        ok: true,
+        payload: {
+          runId,
+          status: "ok",
+        },
+      },
+    });
+    setGatewayDedupeEntry({
+      dedupe,
+      key: `agent:${runId}`,
+      entry: {
+        ts: Date.now(),
+        ok: true,
+        payload: {
+          runId,
+          status: "accepted",
+        },
+      },
+    });
+
+    const snapshot = readTerminalSnapshotFromGatewayDedupe({
+      dedupe,
+      runId,
+    });
+    expect(snapshot).toBeNull();
+
+    const blockedWait = waitForTerminalGatewayDedupe({
+      dedupe,
+      runId,
+      timeoutMs: 25,
+    });
+    await vi.advanceTimersByTimeAsync(30);
+    await expect(blockedWait).resolves.toBeNull();
+    expect(__testing.getWaiterCount(runId)).toBe(0);
+  });
+
+  it("uses newer terminal chat snapshot when agent entry is non-terminal", () => {
+    const dedupe = new Map();
+    const runId = "run-nonterminal-agent-with-newer-chat";
+    setGatewayDedupeEntry({
+      dedupe,
+      key: `agent:${runId}`,
+      entry: {
+        ts: 100,
+        ok: true,
+        payload: {
+          runId,
+          status: "accepted",
+        },
+      },
+    });
+    setGatewayDedupeEntry({
+      dedupe,
+      key: `chat:${runId}`,
+      entry: {
+        ts: 200,
+        ok: true,
+        payload: {
+          runId,
+          status: "ok",
+          startedAt: 1,
+          endedAt: 2,
+        },
+      },
+    });
+
+    expect(
+      readTerminalSnapshotFromGatewayDedupe({
+        dedupe,
+        runId,
+      }),
+    ).toEqual({
+      status: "ok",
+      startedAt: 1,
+      endedAt: 2,
+      error: undefined,
+    });
+  });
+
+  it("ignores stale agent snapshots when waiting for an active chat run", async () => {
+    const dedupe = new Map();
+    const runId = "run-chat-active-ignore-agent";
+    setGatewayDedupeEntry({
+      dedupe,
+      key: `agent:${runId}`,
+      entry: {
+        ts: Date.now(),
+        ok: true,
+        payload: {
+          runId,
+          status: "ok",
+        },
+      },
+    });
+
+    expect(
+      readTerminalSnapshotFromGatewayDedupe({
+        dedupe,
+        runId,
+        ignoreAgentTerminalSnapshot: true,
+      }),
+    ).toBeNull();
+
+    const wait = waitForTerminalGatewayDedupe({
+      dedupe,
+      runId,
+      timeoutMs: 1_000,
+      ignoreAgentTerminalSnapshot: true,
+    });
+    await Promise.resolve();
+    expect(__testing.getWaiterCount(runId)).toBe(1);
+
+    setGatewayDedupeEntry({
+      dedupe,
+      key: `chat:${runId}`,
+      entry: {
+        ts: Date.now(),
+        ok: true,
+        payload: {
+          runId,
+          status: "ok",
+          startedAt: 123,
+          endedAt: 456,
+        },
+      },
+    });
+
+    await expect(wait).resolves.toEqual({
+      status: "ok",
+      startedAt: 123,
+      endedAt: 456,
+      error: undefined,
+    });
+  });
+
+  it("prefers the freshest terminal snapshot when agent/chat dedupe keys collide", () => {
+    const runId = "run-collision";
+    const dedupe = new Map();
+
+    setGatewayDedupeEntry({
+      dedupe,
+      key: `agent:${runId}`,
+      entry: {
+        ts: 100,
+        ok: true,
+        payload: { runId, status: "ok", startedAt: 10, endedAt: 20 },
+      },
+    });
+    setGatewayDedupeEntry({
+      dedupe,
+      key: `chat:${runId}`,
+      entry: {
+        ts: 200,
+        ok: false,
+        payload: { runId, status: "error", startedAt: 30, endedAt: 40, error: "chat failed" },
+      },
+    });
+
+    expect(
+      readTerminalSnapshotFromGatewayDedupe({
+        dedupe,
+        runId,
+      }),
+    ).toEqual({
+      status: "error",
+      startedAt: 30,
+      endedAt: 40,
+      error: "chat failed",
+    });
+
+    const dedupeReverse = new Map();
+    setGatewayDedupeEntry({
+      dedupe: dedupeReverse,
+      key: `chat:${runId}`,
+      entry: {
+        ts: 100,
+        ok: true,
+        payload: { runId, status: "ok", startedAt: 1, endedAt: 2 },
+      },
+    });
+    setGatewayDedupeEntry({
+      dedupe: dedupeReverse,
+      key: `agent:${runId}`,
+      entry: {
+        ts: 200,
+        ok: true,
+        payload: { runId, status: "timeout", startedAt: 3, endedAt: 4, error: "still running" },
+      },
+    });
+
+    expect(
+      readTerminalSnapshotFromGatewayDedupe({
+        dedupe: dedupeReverse,
+        runId,
+      }),
+    ).toEqual({
+      status: "timeout",
+      startedAt: 3,
+      endedAt: 4,
+      error: "still running",
+    });
+  });
+
+  it("resolves multiple waiters for the same run id", async () => {
+    const dedupe = new Map();
+    const runId = "run-multi";
+    const first = waitForTerminalGatewayDedupe({
+      dedupe,
+      runId,
+      timeoutMs: 1_000,
+    });
+    const second = waitForTerminalGatewayDedupe({
+      dedupe,
+      runId,
+      timeoutMs: 1_000,
+    });
+
+    await Promise.resolve();
+    expect(__testing.getWaiterCount(runId)).toBe(2);
+
+    setGatewayDedupeEntry({
+      dedupe,
+      key: `chat:${runId}`,
+      entry: {
+        ts: Date.now(),
+        ok: true,
+        payload: { runId, status: "ok" },
+      },
+    });
+
+    await expect(first).resolves.toEqual(
+      expect.objectContaining({
+        status: "ok",
+      }),
+    );
+    await expect(second).resolves.toEqual(
+      expect.objectContaining({
+        status: "ok",
+      }),
+    );
+    expect(__testing.getWaiterCount(runId)).toBe(0);
+  });
+
+  it("cleans up waiter registration on timeout", async () => {
+    const dedupe = new Map();
+    const runId = "run-timeout";
+    const wait = waitForTerminalGatewayDedupe({
+      dedupe,
+      runId,
+      timeoutMs: 20,
+    });
+
+    await Promise.resolve();
+    expect(__testing.getWaiterCount(runId)).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(25);
+    await expect(wait).resolves.toBeNull();
+    expect(__testing.getWaiterCount(runId)).toBe(0);
+  });
+});

--- a/src/gateway/server-methods/agent-wait-dedupe.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.ts
@@ -1,0 +1,244 @@
+import type { DedupeEntry } from "../server-shared.js";
+
+export type AgentWaitTerminalSnapshot = {
+  status: "ok" | "error" | "timeout";
+  startedAt?: number;
+  endedAt?: number;
+  error?: string;
+};
+
+const AGENT_WAITERS_BY_RUN_ID = new Map<string, Set<() => void>>();
+
+function parseRunIdFromDedupeKey(key: string): string | null {
+  if (key.startsWith("agent:")) {
+    return key.slice("agent:".length) || null;
+  }
+  if (key.startsWith("chat:")) {
+    return key.slice("chat:".length) || null;
+  }
+  return null;
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function addWaiter(runId: string, waiter: () => void): () => void {
+  const normalizedRunId = runId.trim();
+  if (!normalizedRunId) {
+    return () => {};
+  }
+  const existing = AGENT_WAITERS_BY_RUN_ID.get(normalizedRunId);
+  if (existing) {
+    existing.add(waiter);
+    return () => {
+      const waiters = AGENT_WAITERS_BY_RUN_ID.get(normalizedRunId);
+      if (!waiters) {
+        return;
+      }
+      waiters.delete(waiter);
+      if (waiters.size === 0) {
+        AGENT_WAITERS_BY_RUN_ID.delete(normalizedRunId);
+      }
+    };
+  }
+  AGENT_WAITERS_BY_RUN_ID.set(normalizedRunId, new Set([waiter]));
+  return () => {
+    const waiters = AGENT_WAITERS_BY_RUN_ID.get(normalizedRunId);
+    if (!waiters) {
+      return;
+    }
+    waiters.delete(waiter);
+    if (waiters.size === 0) {
+      AGENT_WAITERS_BY_RUN_ID.delete(normalizedRunId);
+    }
+  };
+}
+
+function notifyWaiters(runId: string): void {
+  const normalizedRunId = runId.trim();
+  if (!normalizedRunId) {
+    return;
+  }
+  const waiters = AGENT_WAITERS_BY_RUN_ID.get(normalizedRunId);
+  if (!waiters || waiters.size === 0) {
+    return;
+  }
+  for (const waiter of waiters) {
+    waiter();
+  }
+}
+
+export function readTerminalSnapshotFromDedupeEntry(
+  entry: DedupeEntry,
+): AgentWaitTerminalSnapshot | null {
+  const payload = entry.payload as
+    | {
+        status?: unknown;
+        startedAt?: unknown;
+        endedAt?: unknown;
+        error?: unknown;
+        summary?: unknown;
+      }
+    | undefined;
+  const status = typeof payload?.status === "string" ? payload.status : undefined;
+  if (status === "accepted" || status === "started" || status === "in_flight") {
+    return null;
+  }
+
+  const startedAt = asFiniteNumber(payload?.startedAt);
+  const endedAt = asFiniteNumber(payload?.endedAt) ?? entry.ts;
+  const errorMessage =
+    typeof payload?.error === "string"
+      ? payload.error
+      : typeof payload?.summary === "string"
+        ? payload.summary
+        : entry.error?.message;
+
+  if (status === "ok" || status === "timeout") {
+    return {
+      status,
+      startedAt,
+      endedAt,
+      error: status === "timeout" ? errorMessage : undefined,
+    };
+  }
+  if (status === "error" || !entry.ok) {
+    return {
+      status: "error",
+      startedAt,
+      endedAt,
+      error: errorMessage,
+    };
+  }
+  return null;
+}
+
+export function readTerminalSnapshotFromGatewayDedupe(params: {
+  dedupe: Map<string, DedupeEntry>;
+  runId: string;
+  ignoreAgentTerminalSnapshot?: boolean;
+}): AgentWaitTerminalSnapshot | null {
+  if (params.ignoreAgentTerminalSnapshot) {
+    const chatEntry = params.dedupe.get(`chat:${params.runId}`);
+    if (!chatEntry) {
+      return null;
+    }
+    return readTerminalSnapshotFromDedupeEntry(chatEntry);
+  }
+
+  const chatEntry = params.dedupe.get(`chat:${params.runId}`);
+  const chatSnapshot = chatEntry ? readTerminalSnapshotFromDedupeEntry(chatEntry) : null;
+
+  const agentEntry = params.dedupe.get(`agent:${params.runId}`);
+  const agentSnapshot = agentEntry ? readTerminalSnapshotFromDedupeEntry(agentEntry) : null;
+  if (agentEntry) {
+    if (!agentSnapshot) {
+      // If agent is still in-flight, only trust chat if it was written after
+      // this agent entry (indicating a newer completed chat run reused runId).
+      if (chatSnapshot && chatEntry && chatEntry.ts > agentEntry.ts) {
+        return chatSnapshot;
+      }
+      return null;
+    }
+  }
+
+  if (agentSnapshot && chatSnapshot && agentEntry && chatEntry) {
+    // Reused idempotency keys can leave both records present. Prefer the
+    // freshest terminal snapshot so callers observe the latest run outcome.
+    return chatEntry.ts > agentEntry.ts ? chatSnapshot : agentSnapshot;
+  }
+
+  return agentSnapshot ?? chatSnapshot;
+}
+
+export async function waitForTerminalGatewayDedupe(params: {
+  dedupe: Map<string, DedupeEntry>;
+  runId: string;
+  timeoutMs: number;
+  signal?: AbortSignal;
+  ignoreAgentTerminalSnapshot?: boolean;
+}): Promise<AgentWaitTerminalSnapshot | null> {
+  const initial = readTerminalSnapshotFromGatewayDedupe(params);
+  if (initial) {
+    return initial;
+  }
+  if (params.timeoutMs <= 0 || params.signal?.aborted) {
+    return null;
+  }
+
+  return await new Promise((resolve) => {
+    let settled = false;
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    let onAbort: (() => void) | undefined;
+    let removeWaiter: (() => void) | undefined;
+
+    const finish = (snapshot: AgentWaitTerminalSnapshot | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+      if (onAbort) {
+        params.signal?.removeEventListener("abort", onAbort);
+      }
+      removeWaiter?.();
+      resolve(snapshot);
+    };
+
+    const onWake = () => {
+      const snapshot = readTerminalSnapshotFromGatewayDedupe(params);
+      if (snapshot) {
+        finish(snapshot);
+      }
+    };
+
+    removeWaiter = addWaiter(params.runId, onWake);
+    onWake();
+    if (settled) {
+      return;
+    }
+
+    const timeoutDelayMs = Math.max(1, Math.min(Math.floor(params.timeoutMs), 2_147_483_647));
+    timeoutHandle = setTimeout(() => finish(null), timeoutDelayMs);
+    timeoutHandle.unref?.();
+
+    onAbort = () => finish(null);
+    params.signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export function setGatewayDedupeEntry(params: {
+  dedupe: Map<string, DedupeEntry>;
+  key: string;
+  entry: DedupeEntry;
+}) {
+  params.dedupe.set(params.key, params.entry);
+  const runId = parseRunIdFromDedupeKey(params.key);
+  if (!runId) {
+    return;
+  }
+  const snapshot = readTerminalSnapshotFromDedupeEntry(params.entry);
+  if (!snapshot) {
+    return;
+  }
+  notifyWaiters(runId);
+}
+
+export const __testing = {
+  getWaiterCount(runId?: string): number {
+    if (runId) {
+      return AGENT_WAITERS_BY_RUN_ID.get(runId)?.size ?? 0;
+    }
+    let total = 0;
+    for (const waiters of AGENT_WAITERS_BY_RUN_ID.values()) {
+      total += waiters.size;
+    }
+    return total;
+  },
+  resetWaiters() {
+    AGENT_WAITERS_BY_RUN_ID.clear();
+  },
+};

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -52,6 +52,12 @@ import {
 import { formatForLog } from "../ws-log.js";
 import { waitForAgentJob } from "./agent-job.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
+import {
+  readTerminalSnapshotFromGatewayDedupe,
+  setGatewayDedupeEntry,
+  type AgentWaitTerminalSnapshot,
+  waitForTerminalGatewayDedupe,
+} from "./agent-wait-dedupe.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
 import { sessionsHandlers } from "./sessions.js";
 import type { GatewayRequestHandlerOptions, GatewayRequestHandlers } from "./types.js";
@@ -601,10 +607,14 @@ export const agentHandlers: GatewayRequestHandlers = {
       acceptedAt: Date.now(),
     };
     // Store an in-flight ack so retries do not spawn a second run.
-    context.dedupe.set(`agent:${idem}`, {
-      ts: Date.now(),
-      ok: true,
-      payload: accepted,
+    setGatewayDedupeEntry({
+      dedupe: context.dedupe,
+      key: `agent:${idem}`,
+      entry: {
+        ts: Date.now(),
+        ok: true,
+        payload: accepted,
+      },
     });
     respond(true, accepted, undefined, { runId });
 
@@ -654,10 +664,14 @@ export const agentHandlers: GatewayRequestHandlers = {
           summary: "completed",
           result,
         };
-        context.dedupe.set(`agent:${idem}`, {
-          ts: Date.now(),
-          ok: true,
-          payload,
+        setGatewayDedupeEntry({
+          dedupe: context.dedupe,
+          key: `agent:${idem}`,
+          entry: {
+            ts: Date.now(),
+            ok: true,
+            payload,
+          },
         });
         // Send a second res frame (same id) so TS clients with expectFinal can wait.
         // Swift clients will typically treat the first res as the result and ignore this.
@@ -670,11 +684,15 @@ export const agentHandlers: GatewayRequestHandlers = {
           status: "error" as const,
           summary: String(err),
         };
-        context.dedupe.set(`agent:${idem}`, {
-          ts: Date.now(),
-          ok: false,
-          payload,
-          error,
+        setGatewayDedupeEntry({
+          dedupe: context.dedupe,
+          key: `agent:${idem}`,
+          entry: {
+            ts: Date.now(),
+            ok: false,
+            payload,
+            error,
+          },
         });
         respond(false, payload, error, {
           runId,
@@ -736,7 +754,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       }) ?? identity.avatar;
     respond(true, { ...identity, avatar: avatarValue }, undefined);
   },
-  "agent.wait": async ({ params, respond }) => {
+  "agent.wait": async ({ params, respond, context }) => {
     if (!validateAgentWaitParams(params)) {
       respond(
         false,
@@ -754,11 +772,61 @@ export const agentHandlers: GatewayRequestHandlers = {
       typeof p.timeoutMs === "number" && Number.isFinite(p.timeoutMs)
         ? Math.max(0, Math.floor(p.timeoutMs))
         : 30_000;
+    const hasActiveChatRun = context.chatAbortControllers.has(runId);
 
-    const snapshot = await waitForAgentJob({
+    const cachedGatewaySnapshot = readTerminalSnapshotFromGatewayDedupe({
+      dedupe: context.dedupe,
+      runId,
+      ignoreAgentTerminalSnapshot: hasActiveChatRun,
+    });
+    if (cachedGatewaySnapshot) {
+      respond(true, {
+        runId,
+        status: cachedGatewaySnapshot.status,
+        startedAt: cachedGatewaySnapshot.startedAt,
+        endedAt: cachedGatewaySnapshot.endedAt,
+        error: cachedGatewaySnapshot.error,
+      });
+      return;
+    }
+
+    const lifecycleAbortController = new AbortController();
+    const dedupeAbortController = new AbortController();
+    const lifecyclePromise = waitForAgentJob({
       runId,
       timeoutMs,
+      signal: lifecycleAbortController.signal,
+      // When chat.send is active with the same runId, ignore cached lifecycle
+      // snapshots so stale agent results do not preempt the active chat run.
+      ignoreCachedSnapshot: hasActiveChatRun,
     });
+    const dedupePromise = waitForTerminalGatewayDedupe({
+      dedupe: context.dedupe,
+      runId,
+      timeoutMs,
+      signal: dedupeAbortController.signal,
+      ignoreAgentTerminalSnapshot: hasActiveChatRun,
+    });
+
+    const first = await Promise.race([
+      lifecyclePromise.then((snapshot) => ({ source: "lifecycle" as const, snapshot })),
+      dedupePromise.then((snapshot) => ({ source: "dedupe" as const, snapshot })),
+    ]);
+
+    let snapshot: AgentWaitTerminalSnapshot | Awaited<ReturnType<typeof waitForAgentJob>> =
+      first.snapshot;
+    if (snapshot) {
+      if (first.source === "lifecycle") {
+        dedupeAbortController.abort();
+      } else {
+        lifecycleAbortController.abort();
+      }
+    } else {
+      snapshot = first.source === "lifecycle" ? await dedupePromise : await lifecyclePromise;
+      lifecycleAbortController.abort();
+      dedupeAbortController.abort();
+    }
+
     if (!snapshot) {
       respond(true, {
         runId,

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -527,6 +527,75 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
   });
 
+  it("chat.send inherits routing metadata for legacy channel-peer session keys", async () => {
+    createTranscriptFixture("openclaw-chat-send-legacy-channel-peer-routing-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "telegram",
+        to: "telegram:6812765697",
+        accountId: "default",
+      },
+      lastChannel: "telegram",
+      lastTo: "telegram:6812765697",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-legacy-channel-peer-routing",
+      sessionKey: "agent:main:telegram:6812765697",
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:6812765697",
+        AccountId: "default",
+      }),
+    );
+  });
+
+  it("chat.send inherits routing metadata for legacy channel-peer thread session keys", async () => {
+    createTranscriptFixture("openclaw-chat-send-legacy-thread-channel-peer-routing-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "telegram",
+        to: "telegram:6812765697",
+        accountId: "default",
+        threadId: "42",
+      },
+      lastChannel: "telegram",
+      lastTo: "telegram:6812765697",
+      lastAccountId: "default",
+      lastThreadId: "42",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-legacy-thread-channel-peer-routing",
+      sessionKey: "agent:main:telegram:6812765697:thread:42",
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:6812765697",
+        AccountId: "default",
+        MessageThreadId: "42",
+      }),
+    );
+  });
+
   it("chat.send does not inherit external delivery context for shared main sessions", async () => {
     createTranscriptFixture("openclaw-chat-send-main-no-cross-route-");
     mockState.finalText = "ok";

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -649,7 +649,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       context,
       respond,
       idempotencyKey: "idem-custom-no-cross-route",
-      sessionKey: "agent:main:work",
+      // Keep a second custom scope token so legacy-shape detection is exercised.
+      // "agent:main:work" only yields one rest token and does not hit that path.
+      sessionKey: "agent:main:work:ticket-123",
       expectBroadcast: false,
     });
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -47,6 +47,7 @@ import { getMaxChatHistoryMessagesBytes } from "../server-constants.js";
 import { capArrayByJsonBytes, loadSessionEntry, readSessionMessages } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
+import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
 import { appendInjectedAssistantMessageToTranscript } from "./chat-transcript-inject.js";
 import type {
@@ -1102,23 +1103,31 @@ export const chatHandlers: GatewayRequestHandlers = {
               });
             }
           }
-          context.dedupe.set(`chat:${clientRunId}`, {
-            ts: Date.now(),
-            ok: true,
-            payload: { runId: clientRunId, status: "ok" as const },
+          setGatewayDedupeEntry({
+            dedupe: context.dedupe,
+            key: `chat:${clientRunId}`,
+            entry: {
+              ts: Date.now(),
+              ok: true,
+              payload: { runId: clientRunId, status: "ok" as const },
+            },
           });
         })
         .catch((err) => {
           const error = errorShape(ErrorCodes.UNAVAILABLE, String(err));
-          context.dedupe.set(`chat:${clientRunId}`, {
-            ts: Date.now(),
-            ok: false,
-            payload: {
-              runId: clientRunId,
-              status: "error" as const,
-              summary: String(err),
+          setGatewayDedupeEntry({
+            dedupe: context.dedupe,
+            key: `chat:${clientRunId}`,
+            entry: {
+              ts: Date.now(),
+              ok: false,
+              payload: {
+                runId: clientRunId,
+                status: "error" as const,
+                summary: String(err),
+              },
+              error,
             },
-            error,
           });
           broadcastChatError({
             context,
@@ -1137,11 +1146,15 @@ export const chatHandlers: GatewayRequestHandlers = {
         status: "error" as const,
         summary: String(err),
       };
-      context.dedupe.set(`chat:${clientRunId}`, {
-        ts: Date.now(),
-        ok: false,
-        payload,
-        error,
+      setGatewayDedupeEntry({
+        dedupe: context.dedupe,
+        key: `chat:${clientRunId}`,
+        entry: {
+          ts: Date.now(),
+          ok: false,
+          payload,
+          error,
+        },
       });
       respond(false, payload, error, {
         runId: clientRunId,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -917,7 +917,9 @@ export const chatHandlers: GatewayRequestHandlers = {
         CHANNEL_SCOPED_SESSION_SHAPES.has(part),
       );
       const hasLegacyChannelPeerShape =
-        !isChannelScopedSession && typeof sessionScopeParts[1] === "string";
+        !isChannelScopedSession &&
+        typeof sessionScopeParts[1] === "string" &&
+        sessionChannelHint === routeChannelCandidate;
       // Only inherit prior external route metadata for channel-scoped sessions.
       // Channel-agnostic sessions (main, direct:<peer>, etc.) can otherwise
       // leak stale routes across surfaces.

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -916,6 +916,8 @@ export const chatHandlers: GatewayRequestHandlers = {
       const isChannelScopedSession = sessionPeerShapeCandidates.some((part) =>
         CHANNEL_SCOPED_SESSION_SHAPES.has(part),
       );
+      const hasLegacyChannelPeerShape =
+        !isChannelScopedSession && typeof sessionScopeParts[1] === "string";
       // Only inherit prior external route metadata for channel-scoped sessions.
       // Channel-agnostic sessions (main, direct:<peer>, etc.) can otherwise
       // leak stale routes across surfaces.
@@ -923,7 +925,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         sessionChannelHint &&
         sessionChannelHint !== INTERNAL_MESSAGE_CHANNEL &&
         !isChannelAgnosticSessionScope &&
-        isChannelScopedSession,
+        (isChannelScopedSession || hasLegacyChannelPeerShape),
       );
       const hasDeliverableRoute =
         canInheritDeliverableRoute &&

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -49,6 +49,43 @@ describe("waitForAgentJob", () => {
     expect(snapshot?.startedAt).toBe(300);
     expect(snapshot?.endedAt).toBe(400);
   });
+
+  it("can ignore cached snapshots and wait for fresh lifecycle events", async () => {
+    const runId = `run-ignore-cache-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 100, endedAt: 110 },
+    });
+
+    const cached = await waitForAgentJob({ runId, timeoutMs: 1_000 });
+    expect(cached?.status).toBe("ok");
+    expect(cached?.startedAt).toBe(100);
+    expect(cached?.endedAt).toBe(110);
+
+    const freshWait = waitForAgentJob({
+      runId,
+      timeoutMs: 1_000,
+      ignoreCachedSnapshot: true,
+    });
+    queueMicrotask(() => {
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 200 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "end", startedAt: 200, endedAt: 210 },
+      });
+    });
+
+    const fresh = await freshWait;
+    expect(fresh?.status).toBe("ok");
+    expect(fresh?.startedAt).toBe(200);
+    expect(fresh?.endedAt).toBe(210);
+  });
 });
 
 describe("injectTimestamp", () => {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -496,6 +496,245 @@ describe("gateway server chat", () => {
     ]);
   });
 
+  test("agent.wait resolves chat.send runs that finish without lifecycle events", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    try {
+      testState.sessionStorePath = path.join(dir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+
+      const runId = "idem-wait-chat-1";
+      const sendRes = await rpcReq(ws, "chat.send", {
+        sessionKey: "main",
+        message: "/context list",
+        idempotencyKey: runId,
+      });
+      expect(sendRes.ok).toBe(true);
+      expect(sendRes.payload?.status).toBe("started");
+
+      const waitRes = await rpcReq(ws, "agent.wait", {
+        runId,
+        timeoutMs: 1_000,
+      });
+      expect(waitRes.ok).toBe(true);
+      expect(waitRes.payload?.status).toBe("ok");
+    } finally {
+      testState.sessionStorePath = undefined;
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("agent.wait ignores stale chat dedupe when an agent run with the same runId is in flight", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    let resolveAgentRun: (() => void) | undefined;
+    const blockedAgentRun = new Promise<void>((resolve) => {
+      resolveAgentRun = resolve;
+    });
+    const agentSpy = vi.mocked(agentCommand);
+    agentSpy.mockImplementationOnce(async () => {
+      await blockedAgentRun;
+      return undefined;
+    });
+
+    try {
+      testState.sessionStorePath = path.join(dir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+
+      const runId = "idem-wait-chat-vs-agent";
+      const sendRes = await rpcReq(ws, "chat.send", {
+        sessionKey: "main",
+        message: "/context list",
+        idempotencyKey: runId,
+      });
+      expect(sendRes.ok).toBe(true);
+      expect(sendRes.payload?.status).toBe("started");
+
+      const chatWaitRes = await rpcReq(ws, "agent.wait", {
+        runId,
+        timeoutMs: 1_000,
+      });
+      expect(chatWaitRes.ok).toBe(true);
+      expect(chatWaitRes.payload?.status).toBe("ok");
+
+      const agentRes = await rpcReq(ws, "agent", {
+        sessionKey: "main",
+        message: "hold this run open",
+        idempotencyKey: runId,
+      });
+      expect(agentRes.ok).toBe(true);
+      expect(agentRes.payload?.status).toBe("accepted");
+
+      const waitWhileAgentInFlight = await rpcReq(ws, "agent.wait", {
+        runId,
+        timeoutMs: 40,
+      });
+      expectAgentWaitTimeout(waitWhileAgentInFlight);
+
+      resolveAgentRun?.();
+      const waitAfterAgentCompletion = await rpcReq(ws, "agent.wait", {
+        runId,
+        timeoutMs: 1_000,
+      });
+      expect(waitAfterAgentCompletion.ok).toBe(true);
+      expect(waitAfterAgentCompletion.payload?.status).toBe("ok");
+    } finally {
+      resolveAgentRun?.();
+      testState.sessionStorePath = undefined;
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("agent.wait ignores stale agent snapshots while same-runId chat.send is active", async () => {
+    await withMainSessionStore(async () => {
+      const runId = "idem-wait-chat-active-vs-stale-agent";
+      const seedAgentRes = await rpcReq(ws, "agent", {
+        sessionKey: "main",
+        message: "seed stale agent snapshot",
+        idempotencyKey: runId,
+      });
+      expect(seedAgentRes.ok).toBe(true);
+      expect(seedAgentRes.payload?.status).toBe("accepted");
+
+      const seedWaitRes = await rpcReq(ws, "agent.wait", {
+        runId,
+        timeoutMs: 1_000,
+      });
+      expect(seedWaitRes.ok).toBe(true);
+      expect(seedWaitRes.payload?.status).toBe("ok");
+
+      let releaseBlockedReply: (() => void) | undefined;
+      const blockedReply = new Promise<void>((resolve) => {
+        releaseBlockedReply = resolve;
+      });
+      const replySpy = vi.mocked(getReplyFromConfig);
+      replySpy.mockImplementationOnce(async (_ctx, opts) => {
+        await new Promise<void>((resolve) => {
+          let settled = false;
+          const finish = () => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            resolve();
+          };
+          void blockedReply.then(finish);
+          if (opts?.abortSignal?.aborted) {
+            finish();
+            return;
+          }
+          opts?.abortSignal?.addEventListener("abort", finish, { once: true });
+        });
+        return undefined;
+      });
+
+      try {
+        const chatRes = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "hold chat run open",
+          idempotencyKey: runId,
+        });
+        expect(chatRes.ok).toBe(true);
+        expect(chatRes.payload?.status).toBe("started");
+
+        const waitWhileChatActive = await rpcReq(ws, "agent.wait", {
+          runId,
+          timeoutMs: 40,
+        });
+        expectAgentWaitTimeout(waitWhileChatActive);
+
+        const abortRes = await rpcReq(ws, "chat.abort", {
+          sessionKey: "main",
+          runId,
+        });
+        expect(abortRes.ok).toBe(true);
+      } finally {
+        releaseBlockedReply?.();
+      }
+    });
+  });
+
+  test("agent.wait keeps lifecycle wait active while same-runId chat.send is active", async () => {
+    await withMainSessionStore(async () => {
+      const runId = "idem-wait-chat-active-with-agent-lifecycle";
+      let releaseBlockedReply: (() => void) | undefined;
+      const blockedReply = new Promise<void>((resolve) => {
+        releaseBlockedReply = resolve;
+      });
+      const replySpy = vi.mocked(getReplyFromConfig);
+      replySpy.mockImplementationOnce(async (_ctx, opts) => {
+        await new Promise<void>((resolve) => {
+          let settled = false;
+          const finish = () => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            resolve();
+          };
+          void blockedReply.then(finish);
+          if (opts?.abortSignal?.aborted) {
+            finish();
+            return;
+          }
+          opts?.abortSignal?.addEventListener("abort", finish, { once: true });
+        });
+        return undefined;
+      });
+
+      try {
+        const chatRes = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "hold chat run open",
+          idempotencyKey: runId,
+        });
+        expect(chatRes.ok).toBe(true);
+        expect(chatRes.payload?.status).toBe("started");
+
+        const waitP = rpcReq(ws, "agent.wait", {
+          runId,
+          timeoutMs: 1_000,
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: { phase: "start", startedAt: 1 },
+        });
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: { phase: "end", startedAt: 1, endedAt: 2 },
+        });
+
+        const waitRes = await waitP;
+        expect(waitRes.ok).toBe(true);
+        expect(waitRes.payload?.status).toBe("ok");
+
+        const abortRes = await rpcReq(ws, "chat.abort", {
+          sessionKey: "main",
+          runId,
+        });
+        expect(abortRes.ok).toBe(true);
+      } finally {
+        releaseBlockedReply?.();
+      }
+    });
+  });
+
   test("agent events include sessionKey and agent.wait covers lifecycle flows", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-gw-"));
     testState.sessionStorePath = path.join(dir, "sessions.json");

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -335,6 +335,7 @@ describe("POST /tools/invoke", () => {
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body).toHaveProperty("result");
+    expect(lastCreateOpenClawToolsContext?.allowMediaInvokeCommands).toBe(true);
   });
 
   it("supports tools.alsoAllow in profile and implicit modes", async () => {

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -335,7 +335,7 @@ describe("POST /tools/invoke", () => {
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body).toHaveProperty("result");
-    expect(lastCreateOpenClawToolsContext?.allowMediaInvokeCommands).toBe(true);
+    expect(lastCreateRemoteClawToolsContext?.allowMediaInvokeCommands).toBe(true);
   });
 
   it("supports tools.alsoAllow in profile and implicit modes", async () => {

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -208,6 +208,8 @@ export async function handleToolsInvokeHttpRequest(
     agentAccountId: accountId,
     agentTo,
     agentThreadId,
+    // HTTP callers consume tool output directly; preserve raw media invoke payloads.
+    allowMediaInvokeCommands: true,
     config: cfg,
     pluginToolAllowlist: collectExplicitAllowlist([
       profilePolicy,

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -65,6 +65,27 @@ describe("resolveTuiSessionKey", () => {
       }),
     ).toBe("agent:ops:incident");
   });
+
+  it("lowercases session keys with uppercase characters", () => {
+    // Uppercase in agent-prefixed form
+    expect(
+      resolveTuiSessionKey({
+        raw: "agent:main:Test1",
+        sessionScope: "global",
+        currentAgentId: "main",
+        sessionMainKey: "agent:main:main",
+      }),
+    ).toBe("agent:main:test1");
+    // Uppercase in bare form (prefixed by currentAgentId)
+    expect(
+      resolveTuiSessionKey({
+        raw: "Test1",
+        sessionScope: "global",
+        currentAgentId: "main",
+        sessionMainKey: "agent:main:main",
+      }),
+    ).toBe("agent:main:test1");
+  });
 });
 
 describe("resolveInitialTuiAgentId", () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -203,9 +203,9 @@ export function resolveTuiSessionKey(params: {
     return trimmed;
   }
   if (trimmed.startsWith("agent:")) {
-    return trimmed;
+    return trimmed.toLowerCase();
   }
-  return `agent:${params.currentAgentId}:${trimmed}`;
+  return `agent:${params.currentAgentId}:${trimmed.toLowerCase()}`;
 }
 
 export function resolveInitialTuiAgentId(params: {


### PR DESCRIPTION
Cherry-picks from upstream (issue #812).

## Commits

| Commit | Result | Notes |
|--------|--------|-------|
| `8a7d1aa97` fix(gateway): preserve route inheritance for legacy channel session keys | RESOLVED | CHANGELOG.md delete conflict |
| `b4e4e25e7` fix(gateway): narrow legacy route inheritance for custom session keys | RESOLVED | CHANGELOG.md delete conflict |
| `4d183af0c` fix: code/cli acpx reliability 20260304 | PICKED | Partial: discarded gutted acpx runtime, agents, skills files (9 files) |
| `9d941949c` fix(tui): normalize session key to lowercase | RESOLVED | CHANGELOG.md delete conflict |
| `61f7cea48` fix: kill stuck ACP child processes on startup and harden discord threads | PICKED | Partial: discarded gutted ACP runtime/control-plane deps, removed orphaned probe functions and ACP reconciliation tests |
| `7b5e64ef2` fix: preserve raw media invoke for HTTP tool clients | RESOLVED | Rebrand conflict in camera test (createOpenClawTools→createRemoteClawTools) |

## Adaptation Details

- **Commit 3** (`4d183af0c`): 9 files discarded (acpx runtime, agents cli-backends/cli-runner, skills/coding-agent, CHANGELOG) — all gutted in fork. 3 files landed (docs, gateway live test).
- **Commit 5** (`61f7cea48`): Discarded ACP control-plane/runtime files + plugin-sdk/root-alias.cjs. Removed `probeDiscordAcpBindingHealth`, `classifyAcpStatusProbeError`, reconciliation startup block, and 5 ACP health-probe test cases from provider — all depend on gutted `src/acp/runtime/` and `src/acp/control-plane/`. Kept: discord abort signal propagation, message handler hardening, gateway agent-wait-dedupe, systemd unit changes (20 files, +1562/-84).