### PR TITLE
Cherry-pick dfb4cb87f: plugins: avoid peer auto-install dependency bloat (#34017)

### DIFF
--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -10,6 +10,11 @@
   "peerDependencies": {
     "remoteclaw": "workspace:*"
   },
+  "peerDependenciesMeta": {
+    "remoteclaw": {
+      "optional": true
+    }
+  },
   "remoteclaw": {
     "extensions": [
       "./index.ts"

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -126,7 +126,7 @@ export async function installPackageDir(params: {
     await sanitizeManifestForNpmInstall(params.targetDir);
     params.logger?.info?.(params.depsLogMessage);
     const npmRes = await runCommandWithTimeout(
-      ["npm", "install", "--omit=dev", "--silent", "--ignore-scripts"],
+      ["npm", "install", "--omit=dev", "--omit=peer", "--silent", "--ignore-scripts"],
       {
         timeoutMs: Math.max(params.timeoutMs, 300_000),
         cwd: params.targetDir,

--- a/src/test-utils/exec-assertions.ts
+++ b/src/test-utils/exec-assertions.ts
@@ -11,7 +11,14 @@ export function expectSingleNpmInstallIgnoreScriptsCall(params: {
     throw new Error("expected npm install call");
   }
   const [argv, opts] = first;
-  expect(argv).toEqual(["npm", "install", "--omit=dev", "--silent", "--ignore-scripts"]);
+  expect(argv).toEqual([
+    "npm",
+    "install",
+    "--omit=dev",
+    "--omit=peer",
+    "--silent",
+    "--ignore-scripts",
+  ]);
   expect(opts?.cwd).toBe(params.expectedCwd);
 }
 


### PR DESCRIPTION
Cherry-pick of upstream dfb4cb87f.

## Conflicts resolved
- `extensions/googlechat/package.json`: added `peerDependenciesMeta` with `remoteclaw` (rebranded from upstream `openclaw`)
- `extensions/memory-core/package.json`: dropped — gutted layer (memory subsystem)

Part of #816.