### PR TITLE
Cherry-pick 4fb40497d: fix(daemon): handle systemctl is-enabled exit 4 (not-found) on Ubuntu (#33634)

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -90,6 +90,21 @@ describe("isSystemdServiceEnabled", () => {
       "systemctl is-enabled unavailable: Failed to connect to bus",
     );
   });
+
+  it("returns false when systemctl is-enabled exits with code 4 (not-found)", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      // On Ubuntu 24.04, `systemctl --user is-enabled <unit>` exits with
+      // code 4 and prints "not-found" to stdout when the unit doesn't exist.
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled remoteclaw-gateway.service",
+      ) as Error & { code?: number };
+      err.code = 4;
+      cb(err, "not-found\n", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
 });
 
 describe("systemd runtime parsing", () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -143,7 +143,10 @@ async function execSystemctl(
 }
 
 function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
-  return (result.stderr || result.stdout || "").trim();
+  // Concatenate both streams so pattern matchers (isSystemdUnitNotEnabled,
+  // isSystemctlMissing) can see the unit status from stdout even when
+  // execFileUtf8 populates stderr with the Node error message fallback.
+  return `${result.stderr} ${result.stdout}`.trim();
 }
 
 function isSystemctlMissing(detail: string): boolean {

--- a/src/plugin-sdk/root-alias.test.ts
+++ b/src/plugin-sdk/root-alias.test.ts
@@ -27,14 +27,14 @@ describe("plugin-sdk root alias", () => {
     expect(parsed.success).toBe(false);
   });
 
-  it("loads legacy root exports lazily through the proxy", () => {
+  it("loads legacy root exports lazily through the proxy", { timeout: 240_000 }, () => {
     expect(typeof rootSdk.resolveControlCommandGate).toBe("function");
     expect(typeof rootSdk.default).toBe("object");
     expect(rootSdk.default).toBe(rootSdk);
     expect(rootSdk.__esModule).toBe(true);
   });
 
-  it("preserves reflection semantics for lazily resolved exports", () => {
+  it("preserves reflection semantics for lazily resolved exports", { timeout: 240_000 }, () => {
     expect("resolveControlCommandGate" in rootSdk).toBe(true);
     const keys = Object.keys(rootSdk);
     expect(keys).toContain("resolveControlCommandGate");


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@4fb40497d.

Handles `systemctl is-enabled` exit code 4 (`not-found`) on Ubuntu 24.04, where the unit doesn't exist. Also concatenates both stderr and stdout in `readSystemctlDetail` so pattern matchers see the full output. Includes timeout bumps for plugin-sdk root-alias tests.

Rebrand: fixed `openclaw-gateway.service` → `remoteclaw-gateway.service` in new test case.

Closes #817 (partial — commit 2 of 3)