### PR TITLE
Cherry-pick c8ebd48e0: fix(node-host): sync rawCommand with hardened argv after executable path pinning (#33137)

### DIFF
--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -60,11 +60,11 @@ describe("hardenApprovedExecutionPaths", () => {
       expectedArgvChanged: false,
     },
     {
-      name: "rawCommand matches hardened argv after executable path pinning",
+      name: "rawCommand matches argv when executable is not path-pinned",
       mode: "build-plan",
       argv: ["poccmd", "hello"],
       withPathToken: true,
-      expectedArgv: ({ pathToken }) => [pathToken!.expected, "hello"],
+      expectedArgv: () => ["poccmd", "hello"],
       checkRawCommandMatchesArgv: true,
     },
   ];

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -6,6 +6,7 @@ import {
   buildSystemRunApprovalPlan,
   hardenApprovedExecutionPaths,
 } from "./invoke-system-run-plan.js";
+import { formatExecCommand } from "./invoke-system-run.js";
 
 type PathTokenSetup = {
   expected: string;
@@ -18,7 +19,9 @@ type HardeningCase = {
   shellCommand?: string | null;
   withPathToken?: boolean;
   expectedArgv: (ctx: { pathToken: PathTokenSetup | null }) => string[];
+  expectedArgvChanged?: boolean;
   expectedCmdText?: string;
+  checkRawCommandMatchesArgv?: boolean;
 };
 
 describe("hardenApprovedExecutionPaths", () => {
@@ -36,6 +39,7 @@ describe("hardenApprovedExecutionPaths", () => {
       argv: ["env", "tr", "a", "b"],
       shellCommand: null,
       expectedArgv: () => ["env", "tr", "a", "b"],
+      expectedArgvChanged: false,
     },
     {
       name: "pins direct PATH-token executable during approval hardening",
@@ -44,6 +48,7 @@ describe("hardenApprovedExecutionPaths", () => {
       shellCommand: null,
       withPathToken: true,
       expectedArgv: () => ["poccmd", "SAFE"],
+      expectedArgvChanged: false,
     },
     {
       name: "preserves env-wrapper PATH-token argv during approval hardening",
@@ -52,6 +57,15 @@ describe("hardenApprovedExecutionPaths", () => {
       shellCommand: null,
       withPathToken: true,
       expectedArgv: () => ["env", "poccmd", "SAFE"],
+      expectedArgvChanged: false,
+    },
+    {
+      name: "rawCommand matches hardened argv after executable path pinning",
+      mode: "build-plan",
+      argv: ["poccmd", "hello"],
+      withPathToken: true,
+      expectedArgv: ({ pathToken }) => [pathToken!.expected, "hello"],
+      checkRawCommandMatchesArgv: true,
     },
   ];
 
@@ -82,6 +96,9 @@ describe("hardenApprovedExecutionPaths", () => {
           if (testCase.expectedCmdText) {
             expect(prepared.cmdText).toBe(testCase.expectedCmdText);
           }
+          if (testCase.checkRawCommandMatchesArgv) {
+            expect(prepared.plan.rawCommand).toBe(formatExecCommand(prepared.plan.argv));
+          }
           return;
         }
 
@@ -96,6 +113,9 @@ describe("hardenApprovedExecutionPaths", () => {
           throw new Error("unreachable");
         }
         expect(hardened.argv).toEqual(testCase.expectedArgv({ pathToken }));
+        if (typeof testCase.expectedArgvChanged === "boolean") {
+          expect(hardened.argvChanged).toBe(testCase.expectedArgvChanged);
+        }
       } finally {
         if (testCase.withPathToken) {
           if (oldPath === undefined) {

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -263,6 +263,7 @@ export function hardenApprovedExecutionPaths(params: {
   | {
       ok: true;
       argv: string[];
+      argvChanged: boolean;
       cwd: string | undefined;
       approvedCwdSnapshot: ApprovedCwdSnapshot | undefined;
     }
@@ -271,6 +272,7 @@ export function hardenApprovedExecutionPaths(params: {
     return {
       ok: true,
       argv: params.argv,
+      argvChanged: false,
       cwd: params.cwd,
       approvedCwdSnapshot: undefined,
     };
@@ -288,28 +290,62 @@ export function hardenApprovedExecutionPaths(params: {
   }
 
   if (params.shellCommand !== null || params.argv.length === 0) {
-    return { ok: true, argv: params.argv, cwd: hardenedCwd, approvedCwdSnapshot };
+    return {
+      ok: true,
+      argv: params.argv,
+      argvChanged: false,
+      cwd: hardenedCwd,
+      approvedCwdSnapshot,
+    };
   }
 
   const argv = [...params.argv];
   const rawExecutable = argv[0] ?? "";
   if (!isPathLikeExecutableToken(rawExecutable)) {
-    return { ok: true, argv, cwd: hardenedCwd, approvedCwdSnapshot };
+    return { ok: true, argv, argvChanged: false, cwd: hardenedCwd, approvedCwdSnapshot };
   }
 
   const base = hardenedCwd ?? process.cwd();
   const candidate = path.isAbsolute(rawExecutable)
     ? rawExecutable
     : path.resolve(base, rawExecutable);
+  let pinnedExecutable: string;
   try {
-    argv[0] = fs.realpathSync(candidate);
+    pinnedExecutable = fs.realpathSync(candidate);
   } catch {
     return {
       ok: false,
       message: "SYSTEM_RUN_DENIED: approval requires a stable executable path",
     };
   }
-  return { ok: true, argv, cwd: hardenedCwd, approvedCwdSnapshot };
+
+  if (pinnedExecutable === params.argv[0]) {
+    return {
+      ok: true,
+      argv: params.argv,
+      argvChanged: false,
+      cwd: hardenedCwd,
+      approvedCwdSnapshot,
+    };
+  }
+
+  argv[0] = pinnedExecutable;
+  return { ok: true, argv, argvChanged: true, cwd: hardenedCwd, approvedCwdSnapshot };
+}
+
+export function formatExecCommand(argv: string[]): string {
+  return argv
+    .map((arg) => {
+      if (arg.length === 0) {
+        return '""';
+      }
+      const needsQuotes = /\s|"/.test(arg);
+      if (!needsQuotes) {
+        return arg;
+      }
+      return `"${arg.replace(/"/g, '\\"')}"`;
+    })
+    .join(" ");
 }
 
 export function buildSystemRunApprovalPlanV2(params: {
@@ -338,13 +374,16 @@ export function buildSystemRunApprovalPlanV2(params: {
   if (!hardening.ok) {
     return { ok: false, message: hardening.message };
   }
+  const rawCommand = hardening.argvChanged
+    ? formatExecCommand(hardening.argv) || null
+    : command.cmdText.trim() || null;
   return {
     ok: true,
     plan: {
       version: 2,
       argv: hardening.argv,
       cwd: hardening.cwd ?? null,
-      rawCommand: command.cmdText.trim() || null,
+      rawCommand,
       agentId: normalizeString(params.agentId),
       sessionKey: normalizeString(params.sessionKey),
     },


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@c8ebd48e0.

Syncs `rawCommand` with hardened `argv` after executable path pinning in `buildSystemRunApprovalPlanV2`. Adds `argvChanged` boolean to `hardenApprovedExecutionPaths` return type so callers know when to regenerate `rawCommand`. Adds `formatExecCommand` helper for argv-to-command-string formatting.

Adaptation: applied changes to fork's `invoke-system-run.ts` (upstream has a separate `invoke-system-run-plan.ts` module; fork uses a thin re-export shim). Test import adjusted to source `formatExecCommand` from the correct module. `invoke-system-run.test.ts` kept fork's version (exec-approvals infrastructure is gutted).

Closes #817 (partial — commit 3 of 3)