### PR TITLE
Cherry-pick issue #825: discord-mattermost-slash-dedup-tts-buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -702,6 +702,7 @@ Docs: https://docs.openclaw.ai
 - Channels/Multi-account config: when adding a non-default channel account to a single-account top-level channel setup, move existing account-scoped top-level single-account values into `channels.<channel>.accounts.default` before writing the new account so the original account keeps working without duplicated account values at channel root; `openclaw doctor --fix` now repairs previously mixed channel account shapes the same way. (#27334) thanks @gumadeiras.
 - iOS/Talk mode: stop injecting the voice directive hint into iOS Talk prompts and remove the Voice Directive Hint setting, reducing model bias toward tool-style TTS directives and keeping relay responses text-first by default. (#27543) thanks @ngutman.
 - CI/Windows: shard the Windows `checks-windows` test lane into two matrix jobs and honor explicit shard index overrides in `scripts/test-parallel.mjs` to reduce CI critical-path wall time. (#27234) Thanks @joshavant.
+- Mattermost/mention gating: honor `chatmode: "onmessage"` account override in inbound group/channel mention-gate resolution, while preserving explicit group `requireMention` config precedence and adding verbose drop diagnostics for skipped inbound posts. (#27160) thanks @turian.
 
 ## 2026.2.25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ Docs: https://docs.openclaw.ai
 - LINE cleanup/test follow-ups: fold cleanup/test learnings into the synthesis review path while keeping runtime changes focused on regression fixes. (from #17630, #17289) Thanks @Clawborn and @davidahmann.
 - Mattermost/interactive buttons: add interactive button send/callback support with directory-based channel/user target resolution, and harden callbacks via account-scoped HMAC verification plus sender-scoped DM routing. (#19957) thanks @tonydehnke.
 
+- Mattermost/plugin SDK import policy: replace remaining monolithic `openclaw/plugin-sdk` imports in Mattermost mention-gating paths/tests with scoped subpaths (`openclaw/plugin-sdk/compat` and `openclaw/plugin-sdk/mattermost`) so `pnpm check` passes `lint:plugins:no-monolithic-plugin-sdk-entry-imports` on baseline. (#36480) Thanks @Takhoffman.
+
 ## 2026.3.2
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Docs: https://docs.openclaw.ai
 - LINE/context and routing synthesis: fix group/room peer routing and command-authorization context propagation, and keep processing later events in mixed-success webhook batches. (from #21955, #24475, #27035, #28286) Thanks @lailoo, @mcaxtr, @jervyclaw, @Glucksberg, and @Takhoffman.
 - LINE/status/config/webhook synthesis: fix status false positives from snapshot/config state and accept LINE webhook HEAD probes for compatibility. (from #10487, #25726, #27537, #27908, #31387) Thanks @BlueBirdBack, @stakeswky, @loiie45e, @puritysb, and @mcaxtr.
 - LINE cleanup/test follow-ups: fold cleanup/test learnings into the synthesis review path while keeping runtime changes focused on regression fixes. (from #17630, #17289) Thanks @Clawborn and @davidahmann.
+- Mattermost/interactive buttons: add interactive button send/callback support with directory-based channel/user target resolution, and harden callbacks via account-scoped HMAC verification plus sender-scoped DM routing. (#19957) thanks @tonydehnke.
 
 ## 2026.3.2
 

--- a/docs/channels/discord.mdx
+++ b/docs/channels/discord.mdx
@@ -1056,11 +1056,18 @@ remoteclaw logs --follow
 
     - `Listener DiscordMessageListener timed out after 30000ms for event MESSAGE_CREATE`
     - `Slow listener detected ...`
+    - `discord inbound worker timed out after ...`
 
-    Canonical knob:
+    Listener budget knob:
 
     - single-account: `channels.discord.eventQueue.listenerTimeout`
     - multi-account: `channels.discord.accounts.<accountId>.eventQueue.listenerTimeout`
+
+    Worker run timeout knob:
+
+    - single-account: `channels.discord.inboundWorker.runTimeoutMs`
+    - multi-account: `channels.discord.accounts.<accountId>.inboundWorker.runTimeoutMs`
+    - default: `1800000` (30 minutes); set `0` to disable
 
     Recommended baseline:
 
@@ -1073,6 +1080,9 @@ remoteclaw logs --follow
           eventQueue: {
             listenerTimeout: 120000,
           },
+          inboundWorker: {
+            runTimeoutMs: 1800000,
+          },
         },
       },
     },
@@ -1080,7 +1090,8 @@ remoteclaw logs --follow
 }
 ```
 
-    Tune this first before adding alternate timeout controls elsewhere.
+    Use `eventQueue.listenerTimeout` for slow listener setup and `inboundWorker.runTimeoutMs`
+    only if you want a separate safety valve for queued agent turns.
 
 </details>
 
@@ -1136,7 +1147,8 @@ High-signal Discord fields:
 - startup/auth: `enabled`, `token`, `accounts.*`, `allowBots`
 - policy: `groupPolicy`, `dm.*`, `guilds.*`, `guilds.*.channels.*`
 - command: `commands.native`, `commands.useAccessGroups`, `configWrites`, `slashCommand.*`
-- event queue: `eventQueue.listenerTimeout` (canonical), `eventQueue.maxQueueSize`, `eventQueue.maxConcurrency`
+- event queue: `eventQueue.listenerTimeout` (listener budget), `eventQueue.maxQueueSize`, `eventQueue.maxConcurrency`
+- inbound worker: `inboundWorker.runTimeoutMs`
 - reply/history: `replyToMode`, `historyLimit`, `dmHistoryLimit`, `dms.*.historyLimit`
 - delivery: `textChunkLimit`, `chunkMode`, `maxLinesPerMessage`
 - streaming: `streaming` (legacy alias: `streamMode`), `draftChunk`, `blockStreaming`, `blockStreamingCoalesce`

--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -175,6 +175,151 @@ Config:
 - `channels.mattermost.actions.reactions`: enable/disable reaction actions (default true).
 - Per-account override: `channels.mattermost.accounts.<id>.actions.reactions`.
 
+## Interactive buttons (message tool)
+
+Send messages with clickable buttons. When a user clicks a button, the agent receives the
+selection and can respond.
+
+Enable buttons by adding `inlineButtons` to the channel capabilities:
+
+```json5
+{
+  channels: {
+    mattermost: {
+      capabilities: ["inlineButtons"],
+    },
+  },
+}
+```
+
+Use `message action=send` with a `buttons` parameter. Buttons are a 2D array (rows of buttons):
+
+```
+message action=send channel=mattermost target=channel:<channelId> buttons=[[{"text":"Yes","callback_data":"yes"},{"text":"No","callback_data":"no"}]]
+```
+
+Button fields:
+
+- `text` (required): display label.
+- `callback_data` (required): value sent back on click (used as the action ID).
+- `style` (optional): `"default"`, `"primary"`, or `"danger"`.
+
+When a user clicks a button:
+
+1. All buttons are replaced with a confirmation line (e.g., "✓ **Yes** selected by @user").
+2. The agent receives the selection as an inbound message and responds.
+
+Notes:
+
+- Button callbacks use HMAC-SHA256 verification (automatic, no config needed).
+- Mattermost strips callback data from its API responses (security feature), so all buttons
+  are removed on click — partial removal is not possible.
+- Action IDs containing hyphens or underscores are sanitized automatically
+  (Mattermost routing limitation).
+
+Config:
+
+- `channels.mattermost.capabilities`: array of capability strings. Add `"inlineButtons"` to
+  enable the buttons tool description in the agent system prompt.
+
+### Direct API integration (external scripts)
+
+External scripts and webhooks can post buttons directly via the Mattermost REST API
+instead of going through the agent's `message` tool. Use `buildButtonAttachments()` from
+the extension when possible; if posting raw JSON, follow these rules:
+
+**Payload structure:**
+
+```json5
+{
+  channel_id: "<channelId>",
+  message: "Choose an option:",
+  props: {
+    attachments: [
+      {
+        actions: [
+          {
+            id: "mybutton01", // alphanumeric only — see below
+            type: "button", // required, or clicks are silently ignored
+            name: "Approve", // display label
+            style: "primary", // optional: "default", "primary", "danger"
+            integration: {
+              url: "http://localhost:18789/mattermost/interactions/default",
+              context: {
+                action_id: "mybutton01", // must match button id (for name lookup)
+                action: "approve",
+                // ... any custom fields ...
+                _token: "<hmac>", // see HMAC section below
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+```
+
+**Critical rules:**
+
+1. Attachments go in `props.attachments`, not top-level `attachments` (silently ignored).
+2. Every action needs `type: "button"` — without it, clicks are swallowed silently.
+3. Every action needs an `id` field — Mattermost ignores actions without IDs.
+4. Action `id` must be **alphanumeric only** (`[a-zA-Z0-9]`). Hyphens and underscores break
+   Mattermost's server-side action routing (returns 404). Strip them before use.
+5. `context.action_id` must match the button's `id` so the confirmation message shows the
+   button name (e.g., "Approve") instead of a raw ID.
+6. `context.action_id` is required — the interaction handler returns 400 without it.
+
+**HMAC token generation:**
+
+The gateway verifies button clicks with HMAC-SHA256. External scripts must generate tokens
+that match the gateway's verification logic:
+
+1. Derive the secret from the bot token:
+   `HMAC-SHA256(key="openclaw-mattermost-interactions", data=botToken)`
+2. Build the context object with all fields **except** `_token`.
+3. Serialize with **sorted keys** and **no spaces** (the gateway uses `JSON.stringify`
+   with sorted keys, which produces compact output).
+4. Sign: `HMAC-SHA256(key=secret, data=serializedContext)`
+5. Add the resulting hex digest as `_token` in the context.
+
+Python example:
+
+```python
+import hmac, hashlib, json
+
+secret = hmac.new(
+    b"openclaw-mattermost-interactions",
+    bot_token.encode(), hashlib.sha256
+).hexdigest()
+
+ctx = {"action_id": "mybutton01", "action": "approve"}
+payload = json.dumps(ctx, sort_keys=True, separators=(",", ":"))
+token = hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()
+
+context = {**ctx, "_token": token}
+```
+
+Common HMAC pitfalls:
+
+- Python's `json.dumps` adds spaces by default (`{"key": "val"}`). Use
+  `separators=(",", ":")` to match JavaScript's compact output (`{"key":"val"}`).
+- Always sign **all** context fields (minus `_token`). The gateway strips `_token` then
+  signs everything remaining. Signing a subset causes silent verification failure.
+- Use `sort_keys=True` — the gateway sorts keys before signing, and Mattermost may
+  reorder context fields when storing the payload.
+- Derive the secret from the bot token (deterministic), not random bytes. The secret
+  must be the same across the process that creates buttons and the gateway that verifies.
+
+## Directory adapter
+
+The Mattermost plugin includes a directory adapter that resolves channel and user names
+via the Mattermost API. This enables `#channel-name` and `@username` targets in
+`openclaw message send` and cron/webhook deliveries.
+
+No configuration is needed — the adapter uses the bot token from the account config.
+
 ## Multi-account
 
 Mattermost supports multiple accounts under `channels.mattermost.accounts`:
@@ -197,3 +342,10 @@ Mattermost supports multiple accounts under `channels.mattermost.accounts`:
 - No replies in channels: ensure the bot is in the channel and mention it (oncall), use a trigger prefix (onchar), or set `chatmode: "onmessage"`.
 - Auth errors: check the bot token, base URL, and whether the account is enabled.
 - Multi-account issues: env vars only apply to the `default` account.
+- Buttons appear as white boxes: the agent may be sending malformed button data. Check that each button has both `text` and `callback_data` fields.
+- Buttons render but clicks do nothing: verify `AllowedUntrustedInternalConnections` in Mattermost server config includes `127.0.0.1 localhost`, and that `EnablePostActionIntegration` is `true` in ServiceSettings.
+- Buttons return 404 on click: the button `id` likely contains hyphens or underscores. Mattermost's action router breaks on non-alphanumeric IDs. Use `[a-zA-Z0-9]` only.
+- Gateway logs `invalid _token`: HMAC mismatch. Check that you sign all context fields (not a subset), use sorted keys, and use compact JSON (no spaces). See the HMAC section above.
+- Gateway logs `missing _token in context`: the `_token` field is not in the button's context. Ensure it is included when building the integration payload.
+- Confirmation shows raw ID instead of button name: `context.action_id` does not match the button's `id`. Set both to the same sanitized value.
+- Agent doesn't know about buttons: add `capabilities: ["inlineButtons"]` to the Mattermost channel config.

--- a/docs/experiments/plans/discord-async-inbound-worker.md
+++ b/docs/experiments/plans/discord-async-inbound-worker.md
@@ -1,0 +1,337 @@
+---
+summary: "Status and next steps for decoupling Discord gateway listeners from long-running agent turns with a Discord-specific inbound worker"
+owner: "openclaw"
+status: "in_progress"
+last_updated: "2026-03-05"
+title: "Discord Async Inbound Worker Plan"
+---
+
+# Discord Async Inbound Worker Plan
+
+## Objective
+
+Remove Discord listener timeout as a user-facing failure mode by making inbound Discord turns asynchronous:
+
+1. Gateway listener accepts and normalizes inbound events quickly.
+2. A Discord run queue stores serialized jobs keyed by the same ordering boundary we use today.
+3. A worker executes the actual agent turn outside the Carbon listener lifetime.
+4. Replies are delivered back to the originating channel or thread after the run completes.
+
+This is the long-term fix for queued Discord runs timing out at `channels.discord.eventQueue.listenerTimeout` while the agent run itself is still making progress.
+
+## Current status
+
+This plan is partially implemented.
+
+Already done:
+
+- Discord listener timeout and Discord run timeout are now separate settings.
+- Accepted inbound Discord turns are enqueued into `src/discord/monitor/inbound-worker.ts`.
+- The worker now owns the long-running turn instead of the Carbon listener.
+- Existing per-route ordering is preserved by queue key.
+- Timeout regression coverage exists for the Discord worker path.
+
+What this means in plain language:
+
+- the production timeout bug is fixed
+- the long-running turn no longer dies just because the Discord listener budget expires
+- the worker architecture is not finished yet
+
+What is still missing:
+
+- `DiscordInboundJob` is still only partially normalized and still carries live runtime references
+- command semantics (`stop`, `new`, `reset`, future session controls) are not yet fully worker-native
+- worker observability and operator status are still minimal
+- there is still no restart durability
+
+## Why this exists
+
+Current behavior ties the full agent turn to the listener lifetime:
+
+- `src/discord/monitor/listeners.ts` applies the timeout and abort boundary.
+- `src/discord/monitor/message-handler.ts` keeps the queued run inside that boundary.
+- `src/discord/monitor/message-handler.process.ts` performs media loading, routing, dispatch, typing, draft streaming, and final reply delivery inline.
+
+That architecture has two bad properties:
+
+- long but healthy turns can be aborted by the listener watchdog
+- users can see no reply even when the downstream runtime would have produced one
+
+Raising the timeout helps but does not change the failure mode.
+
+## Non-goals
+
+- Do not redesign non-Discord channels in this pass.
+- Do not broaden this into a generic all-channel worker framework in the first implementation.
+- Do not extract a shared cross-channel inbound worker abstraction yet; only share low-level primitives when duplication is obvious.
+- Do not add durable crash recovery in the first pass unless needed to land safely.
+- Do not change route selection, binding semantics, or ACP policy in this plan.
+
+## Current constraints
+
+The current Discord processing path still depends on some live runtime objects that should not stay inside the long-term job payload:
+
+- Carbon `Client`
+- raw Discord event shapes
+- in-memory guild history map
+- thread binding manager callbacks
+- live typing and draft stream state
+
+We already moved execution onto a worker queue, but the normalization boundary is still incomplete. Right now the worker is "run later in the same process with some of the same live objects," not a fully data-only job boundary.
+
+## Target architecture
+
+### 1. Listener stage
+
+`DiscordMessageListener` remains the ingress point, but its job becomes:
+
+- run preflight and policy checks
+- normalize accepted input into a serializable `DiscordInboundJob`
+- enqueue the job into a per-session or per-channel async queue
+- return immediately to Carbon once the enqueue succeeds
+
+The listener should no longer own the end-to-end LLM turn lifetime.
+
+### 2. Normalized job payload
+
+Introduce a serializable job descriptor that contains only the data needed to run the turn later.
+
+Minimum shape:
+
+- route identity
+  - `agentId`
+  - `sessionKey`
+  - `accountId`
+  - `channel`
+- delivery identity
+  - destination channel id
+  - reply target message id
+  - thread id if present
+- sender identity
+  - sender id, label, username, tag
+- channel context
+  - guild id
+  - channel name or slug
+  - thread metadata
+  - resolved system prompt override
+- normalized message body
+  - base text
+  - effective message text
+  - attachment descriptors or resolved media references
+- gating decisions
+  - mention requirement outcome
+  - command authorization outcome
+  - bound session or agent metadata if applicable
+
+The job payload must not contain live Carbon objects or mutable closures.
+
+Current implementation status:
+
+- partially done
+- `src/discord/monitor/inbound-job.ts` exists and defines the worker handoff
+- the payload still contains live Discord runtime context and should be reduced further
+
+### 3. Worker stage
+
+Add a Discord-specific worker runner responsible for:
+
+- reconstructing the turn context from `DiscordInboundJob`
+- loading media and any additional channel metadata needed for the run
+- dispatching the agent turn
+- delivering final reply payloads
+- updating status and diagnostics
+
+Recommended location:
+
+- `src/discord/monitor/inbound-worker.ts`
+- `src/discord/monitor/inbound-job.ts`
+
+### 4. Ordering model
+
+Ordering must remain equivalent to today for a given route boundary.
+
+Recommended key:
+
+- use the same queue key logic as `resolveDiscordRunQueueKey(...)`
+
+This preserves existing behavior:
+
+- one bound agent conversation does not interleave with itself
+- different Discord channels can still progress independently
+
+### 5. Timeout model
+
+After cutover, there are two separate timeout classes:
+
+- listener timeout
+  - only covers normalization and enqueue
+  - should be short
+- run timeout
+  - optional, worker-owned, explicit, and user-visible
+  - should not be inherited accidentally from Carbon listener settings
+
+This removes the current accidental coupling between "Discord gateway listener stayed alive" and "agent run is healthy."
+
+## Recommended implementation phases
+
+### Phase 1: normalization boundary
+
+- Status: partially implemented
+- Done:
+  - extracted `buildDiscordInboundJob(...)`
+  - added worker handoff tests
+- Remaining:
+  - make `DiscordInboundJob` plain data only
+  - move live runtime dependencies to worker-owned services instead of per-job payload
+  - stop rebuilding process context by stitching live listener refs back into the job
+
+### Phase 2: in-memory worker queue
+
+- Status: implemented
+- Done:
+  - added `DiscordInboundWorkerQueue` keyed by resolved run queue key
+  - listener enqueues jobs instead of directly awaiting `processDiscordMessage(...)`
+  - worker executes jobs in-process, in memory only
+
+This is the first functional cutover.
+
+### Phase 3: process split
+
+- Status: not started
+- Move delivery, typing, and draft streaming ownership behind worker-facing adapters.
+- Replace direct use of live preflight context with worker context reconstruction.
+- Keep `processDiscordMessage(...)` temporarily as a facade if needed, then split it.
+
+### Phase 4: command semantics
+
+- Status: not started
+  Make sure native Discord commands still behave correctly when work is queued:
+
+- `stop`
+- `new`
+- `reset`
+- any future session-control commands
+
+The worker queue must expose enough run state for commands to target the active or queued turn.
+
+### Phase 5: observability and operator UX
+
+- Status: not started
+- emit queue depth and active worker counts into monitor status
+- record enqueue time, start time, finish time, and timeout or cancellation reason
+- surface worker-owned timeout or delivery failures clearly in logs
+
+### Phase 6: optional durability follow-up
+
+- Status: not started
+  Only after the in-memory version is stable:
+
+- decide whether queued Discord jobs should survive gateway restart
+- if yes, persist job descriptors and delivery checkpoints
+- if no, document the explicit in-memory boundary
+
+This should be a separate follow-up unless restart recovery is required to land.
+
+## File impact
+
+Current primary files:
+
+- `src/discord/monitor/listeners.ts`
+- `src/discord/monitor/message-handler.ts`
+- `src/discord/monitor/message-handler.preflight.ts`
+- `src/discord/monitor/message-handler.process.ts`
+- `src/discord/monitor/status.ts`
+
+Current worker files:
+
+- `src/discord/monitor/inbound-job.ts`
+- `src/discord/monitor/inbound-worker.ts`
+- `src/discord/monitor/inbound-job.test.ts`
+- `src/discord/monitor/message-handler.queue.test.ts`
+
+Likely next touch points:
+
+- `src/auto-reply/dispatch.ts`
+- `src/discord/monitor/reply-delivery.ts`
+- `src/discord/monitor/thread-bindings.ts`
+- `src/discord/monitor/native-command.ts`
+
+## Next step now
+
+The next step is to make the worker boundary real instead of partial.
+
+Do this next:
+
+1. Move live runtime dependencies out of `DiscordInboundJob`
+2. Keep those dependencies on the Discord worker instance instead
+3. Reduce queued jobs to plain Discord-specific data:
+   - route identity
+   - delivery target
+   - sender info
+   - normalized message snapshot
+   - gating and binding decisions
+4. Reconstruct worker execution context from that plain data inside the worker
+
+In practice, that means:
+
+- `client`
+- `threadBindings`
+- `guildHistories`
+- `discordRestFetch`
+- other mutable runtime-only handles
+
+should stop living on each queued job and instead live on the worker itself or behind worker-owned adapters.
+
+After that lands, the next follow-up should be command-state cleanup for `stop`, `new`, and `reset`.
+
+## Testing plan
+
+Keep the existing timeout repro coverage in:
+
+- `src/discord/monitor/message-handler.queue.test.ts`
+
+Add new tests for:
+
+1. listener returns after enqueue without awaiting full turn
+2. per-route ordering is preserved
+3. different channels still run concurrently
+4. replies are delivered to the original message destination
+5. `stop` cancels the active worker-owned run
+6. worker failure produces visible diagnostics without blocking later jobs
+7. ACP-bound Discord channels still route correctly under worker execution
+
+## Risks and mitigations
+
+- Risk: command semantics drift from current synchronous behavior
+  Mitigation: land command-state plumbing in the same cutover, not later
+
+- Risk: reply delivery loses thread or reply-to context
+  Mitigation: make delivery identity first-class in `DiscordInboundJob`
+
+- Risk: duplicate sends during retries or queue restarts
+  Mitigation: keep first pass in-memory only, or add explicit delivery idempotency before persistence
+
+- Risk: `message-handler.process.ts` becomes harder to reason about during migration
+  Mitigation: split into normalization, execution, and delivery helpers before or during worker cutover
+
+## Acceptance criteria
+
+The plan is complete when:
+
+1. Discord listener timeout no longer aborts healthy long-running turns.
+2. Listener lifetime and agent-turn lifetime are separate concepts in code.
+3. Existing per-session ordering is preserved.
+4. ACP-bound Discord channels work through the same worker path.
+5. `stop` targets the worker-owned run instead of the old listener-owned call stack.
+6. Timeout and delivery failures become explicit worker outcomes, not silent listener drops.
+
+## Remaining landing strategy
+
+Finish this in follow-up PRs:
+
+1. make `DiscordInboundJob` plain-data only and move live runtime refs onto the worker
+2. clean up command-state ownership for `stop`, `new`, and `reset`
+3. add worker observability and operator status
+4. decide whether durability is needed or explicitly document the in-memory boundary
+
+This is still a bounded follow-up if kept Discord-only and if we continue to avoid a premature cross-channel worker abstraction.

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -102,8 +102,9 @@ describe("mattermostPlugin", () => {
 
       const actions = mattermostPlugin.actions?.listActions?.({ cfg }) ?? [];
       expect(actions).toContain("react");
-      expect(actions).not.toContain("send");
+      expect(actions).toContain("send");
       expect(mattermostPlugin.actions?.supportsAction?.({ action: "react" })).toBe(true);
+      expect(mattermostPlugin.actions?.supportsAction?.({ action: "send" })).toBe(true);
     });
 
     it("hides react when mattermost is not configured", () => {
@@ -133,7 +134,7 @@ describe("mattermostPlugin", () => {
 
       const actions = mattermostPlugin.actions?.listActions?.({ cfg }) ?? [];
       expect(actions).not.toContain("react");
-      expect(actions).not.toContain("send");
+      expect(actions).toContain("send");
     });
 
     it("respects per-account actions.reactions in listActions", () => {

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -22,6 +22,15 @@ import {
   type ResolvedMattermostAccount,
 } from "./mattermost/accounts.js";
 import { normalizeMattermostBaseUrl } from "./mattermost/client.js";
+import {
+  listMattermostDirectoryGroups,
+  listMattermostDirectoryPeers,
+} from "./mattermost/directory.js";
+import {
+  buildButtonAttachments,
+  resolveInteractionCallbackUrl,
+  setInteractionSecret,
+} from "./mattermost/interactions.js";
 import { monitorMattermostProvider } from "./mattermost/monitor.js";
 import { probeMattermost } from "./mattermost/probe.js";
 import { addMattermostReaction, removeMattermostReaction } from "./mattermost/reactions.js";
@@ -32,62 +41,91 @@ import { getMattermostRuntime } from "./runtime.js";
 
 const mattermostMessageActions: ChannelMessageActionAdapter = {
   listActions: ({ cfg }) => {
-    const actionsConfig = cfg.channels?.mattermost?.actions as { reactions?: boolean } | undefined;
-    const baseReactions = actionsConfig?.reactions;
-    const hasReactionCapableAccount = listMattermostAccountIds(cfg)
+    const enabledAccounts = listMattermostAccountIds(cfg)
       .map((accountId) => resolveMattermostAccount({ cfg, accountId }))
       .filter((account) => account.enabled)
-      .filter((account) => Boolean(account.botToken?.trim() && account.baseUrl?.trim()))
-      .some((account) => {
-        const accountActions = account.config.actions as { reactions?: boolean } | undefined;
-        return (accountActions?.reactions ?? baseReactions ?? true) !== false;
-      });
+      .filter((account) => Boolean(account.botToken?.trim() && account.baseUrl?.trim()));
 
-    if (!hasReactionCapableAccount) {
-      return [];
+    const actions: ChannelMessageActionName[] = [];
+
+    // Send (buttons) is available whenever there's at least one enabled account
+    if (enabledAccounts.length > 0) {
+      actions.push("send");
     }
 
-    return ["react"];
+    // React requires per-account reactions config check
+    const actionsConfig = cfg.channels?.mattermost?.actions as { reactions?: boolean } | undefined;
+    const baseReactions = actionsConfig?.reactions;
+    const hasReactionCapableAccount = enabledAccounts.some((account) => {
+      const accountActions = account.config.actions as { reactions?: boolean } | undefined;
+      return (accountActions?.reactions ?? baseReactions ?? true) !== false;
+    });
+    if (hasReactionCapableAccount) {
+      actions.push("react");
+    }
+
+    return actions;
   },
   supportsAction: ({ action }) => {
-    return action === "react";
+    return action === "send" || action === "react";
+  },
+  supportsButtons: ({ cfg }) => {
+    const accounts = listMattermostAccountIds(cfg)
+      .map((id) => resolveMattermostAccount({ cfg, accountId: id }))
+      .filter((a) => a.enabled && a.botToken?.trim() && a.baseUrl?.trim());
+    return accounts.length > 0;
   },
   handleAction: async ({ action, params, cfg, accountId }) => {
-    if (action !== "react") {
-      throw new Error(`Mattermost action ${action} not supported`);
-    }
-    // Check reactions gate: per-account config takes precedence over base config
-    const mmBase = cfg?.channels?.mattermost as Record<string, unknown> | undefined;
-    const accounts = mmBase?.accounts as Record<string, Record<string, unknown>> | undefined;
-    const resolvedAccountId = accountId ?? resolveDefaultMattermostAccountId(cfg);
-    const acctConfig = accounts?.[resolvedAccountId];
-    const acctActions = acctConfig?.actions as { reactions?: boolean } | undefined;
-    const baseActions = mmBase?.actions as { reactions?: boolean } | undefined;
-    const reactionsEnabled = acctActions?.reactions ?? baseActions?.reactions ?? true;
-    if (!reactionsEnabled) {
-      throw new Error("Mattermost reactions are disabled in config");
-    }
+    if (action === "react") {
+      // Check reactions gate: per-account config takes precedence over base config
+      const mmBase = cfg?.channels?.mattermost as Record<string, unknown> | undefined;
+      const accounts = mmBase?.accounts as Record<string, Record<string, unknown>> | undefined;
+      const resolvedAccountId = accountId ?? resolveDefaultMattermostAccountId(cfg);
+      const acctConfig = accounts?.[resolvedAccountId];
+      const acctActions = acctConfig?.actions as { reactions?: boolean } | undefined;
+      const baseActions = mmBase?.actions as { reactions?: boolean } | undefined;
+      const reactionsEnabled = acctActions?.reactions ?? baseActions?.reactions ?? true;
+      if (!reactionsEnabled) {
+        throw new Error("Mattermost reactions are disabled in config");
+      }
 
-    const postIdRaw =
-      typeof (params as any)?.messageId === "string"
-        ? (params as any).messageId
-        : typeof (params as any)?.postId === "string"
-          ? (params as any).postId
-          : "";
-    const postId = postIdRaw.trim();
-    if (!postId) {
-      throw new Error("Mattermost react requires messageId (post id)");
-    }
+      const postIdRaw =
+        typeof (params as any)?.messageId === "string"
+          ? (params as any).messageId
+          : typeof (params as any)?.postId === "string"
+            ? (params as any).postId
+            : "";
+      const postId = postIdRaw.trim();
+      if (!postId) {
+        throw new Error("Mattermost react requires messageId (post id)");
+      }
 
-    const emojiRaw = typeof (params as any)?.emoji === "string" ? (params as any).emoji : "";
-    const emojiName = emojiRaw.trim().replace(/^:+|:+$/g, "");
-    if (!emojiName) {
-      throw new Error("Mattermost react requires emoji");
-    }
+      const emojiRaw = typeof (params as any)?.emoji === "string" ? (params as any).emoji : "";
+      const emojiName = emojiRaw.trim().replace(/^:+|:+$/g, "");
+      if (!emojiName) {
+        throw new Error("Mattermost react requires emoji");
+      }
 
-    const remove = (params as any)?.remove === true;
-    if (remove) {
-      const result = await removeMattermostReaction({
+      const remove = (params as any)?.remove === true;
+      if (remove) {
+        const result = await removeMattermostReaction({
+          cfg,
+          postId,
+          emojiName,
+          accountId: resolvedAccountId,
+        });
+        if (!result.ok) {
+          throw new Error(result.error);
+        }
+        return {
+          content: [
+            { type: "text" as const, text: `Removed reaction :${emojiName}: from ${postId}` },
+          ],
+          details: {},
+        };
+      }
+
+      const result = await addMattermostReaction({
         cfg,
         postId,
         emojiName,
@@ -96,26 +134,92 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       if (!result.ok) {
         throw new Error(result.error);
       }
+
       return {
-        content: [
-          { type: "text" as const, text: `Removed reaction :${emojiName}: from ${postId}` },
-        ],
+        content: [{ type: "text" as const, text: `Reacted with :${emojiName}: on ${postId}` }],
         details: {},
       };
     }
 
-    const result = await addMattermostReaction({
-      cfg,
-      postId,
-      emojiName,
-      accountId: resolvedAccountId,
-    });
-    if (!result.ok) {
-      throw new Error(result.error);
+    if (action !== "send") {
+      throw new Error(`Unsupported Mattermost action: ${action}`);
     }
 
+    // Send action with optional interactive buttons
+    const to =
+      typeof params.to === "string"
+        ? params.to.trim()
+        : typeof params.target === "string"
+          ? params.target.trim()
+          : "";
+    if (!to) {
+      throw new Error("Mattermost send requires a target (to).");
+    }
+
+    const message = typeof params.message === "string" ? params.message : "";
+    const replyToId = typeof params.replyToId === "string" ? params.replyToId : undefined;
+    const resolvedAccountId = accountId || undefined;
+
+    // Build props with button attachments if buttons are provided
+    let props: Record<string, unknown> | undefined;
+    if (params.buttons && Array.isArray(params.buttons)) {
+      const account = resolveMattermostAccount({ cfg, accountId: resolvedAccountId });
+      if (account.botToken) setInteractionSecret(account.accountId, account.botToken);
+      const callbackUrl = resolveInteractionCallbackUrl(account.accountId, cfg);
+
+      // Flatten 2D array (rows of buttons) to 1D — core schema sends Array<Array<Button>>
+      // but Mattermost doesn't have row layout, so we flatten all rows into a single list.
+      // Also supports 1D arrays for backward compatibility.
+      const rawButtons = (params.buttons as Array<unknown>).flatMap((item) =>
+        Array.isArray(item) ? item : [item],
+      ) as Array<Record<string, unknown>>;
+
+      const buttons = rawButtons
+        .map((btn) => ({
+          id: String(btn.id ?? btn.callback_data ?? ""),
+          name: String(btn.text ?? btn.name ?? btn.label ?? ""),
+          style: (btn.style as "default" | "primary" | "danger") ?? "default",
+          context:
+            typeof btn.context === "object" && btn.context !== null
+              ? (btn.context as Record<string, unknown>)
+              : undefined,
+        }))
+        .filter((btn) => btn.id && btn.name);
+
+      const attachmentText =
+        typeof params.attachmentText === "string" ? params.attachmentText : undefined;
+      props = {
+        attachments: buildButtonAttachments({
+          callbackUrl,
+          accountId: account.accountId,
+          buttons,
+          text: attachmentText,
+        }),
+      };
+    }
+
+    const mediaUrl =
+      typeof params.media === "string" ? params.media.trim() || undefined : undefined;
+
+    const result = await sendMessageMattermost(to, message, {
+      accountId: resolvedAccountId,
+      replyToId,
+      props,
+      mediaUrl,
+    });
+
     return {
-      content: [{ type: "text" as const, text: `Reacted with :${emojiName}: on ${postId}` }],
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            ok: true,
+            channel: "mattermost",
+            messageId: result.messageId,
+            channelId: result.channelId,
+          }),
+        },
+      ],
       details: {},
     };
   },
@@ -249,6 +353,12 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
     resolveRequireMention: resolveMattermostGroupRequireMention,
   },
   actions: mattermostMessageActions,
+  directory: {
+    listGroups: async (params) => listMattermostDirectoryGroups(params),
+    listGroupsLive: async (params) => listMattermostDirectoryGroups(params),
+    listPeers: async (params) => listMattermostDirectoryPeers(params),
+    listPeersLive: async (params) => listMattermostDirectoryPeers(params),
+  },
   messaging: {
     normalizeTarget: normalizeMattermostMessagingTarget,
     targetResolver: {

--- a/extensions/mattermost/src/config-schema.ts
+++ b/extensions/mattermost/src/config-schema.ts
@@ -49,6 +49,11 @@ const MattermostAccountSchemaBase = z
       })
       .optional(),
     commands: MattermostSlashCommandsSchema,
+    interactions: z
+      .object({
+        callbackBaseUrl: z.string().optional(),
+      })
+      .optional(),
   })
   .strict();
 

--- a/extensions/mattermost/src/group-mentions.test.ts
+++ b/extensions/mattermost/src/group-mentions.test.ts
@@ -1,0 +1,46 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { describe, expect, it } from "vitest";
+import { resolveMattermostGroupRequireMention } from "./group-mentions.js";
+
+describe("resolveMattermostGroupRequireMention", () => {
+  it("defaults to requiring mention when no override is configured", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        mattermost: {},
+      },
+    };
+
+    const requireMention = resolveMattermostGroupRequireMention({ cfg, accountId: "default" });
+    expect(requireMention).toBe(true);
+  });
+
+  it("respects chatmode-derived account override", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          chatmode: "onmessage",
+        },
+      },
+    };
+
+    const requireMention = resolveMattermostGroupRequireMention({ cfg, accountId: "default" });
+    expect(requireMention).toBe(false);
+  });
+
+  it("prefers an explicit runtime override when provided", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          chatmode: "oncall",
+        },
+      },
+    };
+
+    const requireMention = resolveMattermostGroupRequireMention({
+      cfg,
+      accountId: "default",
+      requireMentionOverride: false,
+    });
+    expect(requireMention).toBe(false);
+  });
+});

--- a/extensions/mattermost/src/group-mentions.test.ts
+++ b/extensions/mattermost/src/group-mentions.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it } from "vitest";
 import { resolveMattermostGroupRequireMention } from "./group-mentions.js";
 

--- a/extensions/mattermost/src/group-mentions.test.ts
+++ b/extensions/mattermost/src/group-mentions.test.ts
@@ -1,10 +1,10 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
+import type { RemoteClawConfig } from "remoteclaw/plugin-sdk";
 import { describe, expect, it } from "vitest";
 import { resolveMattermostGroupRequireMention } from "./group-mentions.js";
 
 describe("resolveMattermostGroupRequireMention", () => {
   it("defaults to requiring mention when no override is configured", () => {
-    const cfg: OpenClawConfig = {
+    const cfg: RemoteClawConfig = {
       channels: {
         mattermost: {},
       },
@@ -15,7 +15,7 @@ describe("resolveMattermostGroupRequireMention", () => {
   });
 
   it("respects chatmode-derived account override", () => {
-    const cfg: OpenClawConfig = {
+    const cfg: RemoteClawConfig = {
       channels: {
         mattermost: {
           chatmode: "onmessage",
@@ -28,7 +28,7 @@ describe("resolveMattermostGroupRequireMention", () => {
   });
 
   it("prefers an explicit runtime override when provided", () => {
-    const cfg: OpenClawConfig = {
+    const cfg: RemoteClawConfig = {
       channels: {
         mattermost: {
           chatmode: "oncall",

--- a/extensions/mattermost/src/group-mentions.ts
+++ b/extensions/mattermost/src/group-mentions.ts
@@ -1,15 +1,22 @@
-import type { ChannelGroupContext } from "remoteclaw/plugin-sdk";
+import { resolveChannelGroupRequireMention, type ChannelGroupContext } from "remoteclaw/plugin-sdk";
 import { resolveMattermostAccount } from "./mattermost/accounts.js";
 
 export function resolveMattermostGroupRequireMention(
-  params: ChannelGroupContext,
+  params: ChannelGroupContext & { requireMentionOverride?: boolean },
 ): boolean | undefined {
   const account = resolveMattermostAccount({
     cfg: params.cfg,
     accountId: params.accountId,
   });
-  if (typeof account.requireMention === "boolean") {
-    return account.requireMention;
-  }
-  return true;
+  const requireMentionOverride =
+    typeof params.requireMentionOverride === "boolean"
+      ? params.requireMentionOverride
+      : account.requireMention;
+  return resolveChannelGroupRequireMention({
+    cfg: params.cfg,
+    channel: "mattermost",
+    groupId: params.groupId,
+    accountId: params.accountId,
+    requireMentionOverride,
+  });
 }

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -1,19 +1,298 @@
 import { describe, expect, it, vi } from "vitest";
-import { createMattermostClient } from "./client.js";
+import {
+  createMattermostClient,
+  createMattermostPost,
+  normalizeMattermostBaseUrl,
+  updateMattermostPost,
+} from "./client.js";
 
-describe("mattermost client", () => {
-  it("request returns undefined on 204 responses", async () => {
+// ── Helper: mock fetch that captures requests ────────────────────────
+
+function createMockFetch(response?: { status?: number; body?: unknown; contentType?: string }) {
+  const status = response?.status ?? 200;
+  const body = response?.body ?? {};
+  const contentType = response?.contentType ?? "application/json";
+
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+
+  const mockFetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const urlStr = typeof url === "string" ? url : url.toString();
+    calls.push({ url: urlStr, init });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": contentType },
+    });
+  });
+
+  return { mockFetch: mockFetch as unknown as typeof fetch, calls };
+}
+
+// ── normalizeMattermostBaseUrl ────────────────────────────────────────
+
+describe("normalizeMattermostBaseUrl", () => {
+  it("strips trailing slashes", () => {
+    expect(normalizeMattermostBaseUrl("http://localhost:8065/")).toBe("http://localhost:8065");
+  });
+
+  it("strips /api/v4 suffix", () => {
+    expect(normalizeMattermostBaseUrl("http://localhost:8065/api/v4")).toBe(
+      "http://localhost:8065",
+    );
+  });
+
+  it("returns undefined for empty input", () => {
+    expect(normalizeMattermostBaseUrl("")).toBeUndefined();
+    expect(normalizeMattermostBaseUrl(null)).toBeUndefined();
+    expect(normalizeMattermostBaseUrl(undefined)).toBeUndefined();
+  });
+
+  it("preserves valid base URL", () => {
+    expect(normalizeMattermostBaseUrl("http://mm.example.com")).toBe("http://mm.example.com");
+  });
+});
+
+// ── createMattermostClient ───────────────────────────────────────────
+
+describe("createMattermostClient", () => {
+  it("creates a client with normalized baseUrl", () => {
+    const { mockFetch } = createMockFetch();
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065/",
+      botToken: "tok",
+      fetchImpl: mockFetch,
+    });
+    expect(client.baseUrl).toBe("http://localhost:8065");
+    expect(client.apiBaseUrl).toBe("http://localhost:8065/api/v4");
+  });
+
+  it("throws on empty baseUrl", () => {
+    expect(() => createMattermostClient({ baseUrl: "", botToken: "tok" })).toThrow(
+      "baseUrl is required",
+    );
+  });
+
+  it("sends Authorization header with Bearer token", async () => {
+    const { mockFetch, calls } = createMockFetch({ body: { id: "u1" } });
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "my-secret-token",
+      fetchImpl: mockFetch,
+    });
+    await client.request("/users/me");
+    const headers = new Headers(calls[0].init?.headers);
+    expect(headers.get("Authorization")).toBe("Bearer my-secret-token");
+  });
+
+  it("sets Content-Type for string bodies", async () => {
+    const { mockFetch, calls } = createMockFetch({ body: { id: "p1" } });
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "tok",
+      fetchImpl: mockFetch,
+    });
+    await client.request("/posts", { method: "POST", body: JSON.stringify({ message: "hi" }) });
+    const headers = new Headers(calls[0].init?.headers);
+    expect(headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("throws on non-ok responses", async () => {
+    const { mockFetch } = createMockFetch({
+      status: 404,
+      body: { message: "Not Found" },
+    });
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "tok",
+      fetchImpl: mockFetch,
+    });
+    await expect(client.request("/missing")).rejects.toThrow("Mattermost API 404");
+  });
+
+  it("returns undefined on 204 responses", async () => {
     const fetchImpl = vi.fn(async () => {
       return new Response(null, { status: 204 });
     });
-
     const client = createMattermostClient({
       baseUrl: "https://chat.example.com",
       botToken: "test-token",
       fetchImpl: fetchImpl as any,
     });
-
     const result = await client.request<unknown>("/anything", { method: "DELETE" });
     expect(result).toBeUndefined();
+  });
+});
+
+// ── createMattermostPost ─────────────────────────────────────────────
+
+describe("createMattermostPost", () => {
+  it("sends channel_id and message", async () => {
+    const { mockFetch, calls } = createMockFetch({ body: { id: "post1" } });
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "tok",
+      fetchImpl: mockFetch,
+    });
+
+    await createMattermostPost(client, {
+      channelId: "ch123",
+      message: "Hello world",
+    });
+
+    const body = JSON.parse(calls[0].init?.body as string);
+    expect(body.channel_id).toBe("ch123");
+    expect(body.message).toBe("Hello world");
+  });
+
+  it("includes rootId when provided", async () => {
+    const { mockFetch, calls } = createMockFetch({ body: { id: "post2" } });
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "tok",
+      fetchImpl: mockFetch,
+    });
+
+    await createMattermostPost(client, {
+      channelId: "ch123",
+      message: "Reply",
+      rootId: "root456",
+    });
+
+    const body = JSON.parse(calls[0].init?.body as string);
+    expect(body.root_id).toBe("root456");
+  });
+
+  it("includes fileIds when provided", async () => {
+    const { mockFetch, calls } = createMockFetch({ body: { id: "post3" } });
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "tok",
+      fetchImpl: mockFetch,
+    });
+
+    await createMattermostPost(client, {
+      channelId: "ch123",
+      message: "With file",
+      fileIds: ["file1", "file2"],
+    });
+
+    const body = JSON.parse(calls[0].init?.body as string);
+    expect(body.file_ids).toEqual(["file1", "file2"]);
+  });
+
+  it("includes props when provided (for interactive buttons)", async () => {
+    const { mockFetch, calls } = createMockFetch({ body: { id: "post4" } });
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "tok",
+      fetchImpl: mockFetch,
+    });
+
+    const props = {
+      attachments: [
+        {
+          text: "Choose:",
+          actions: [{ id: "btn1", type: "button", name: "Click" }],
+        },
+      ],
+    };
+
+    await createMattermostPost(client, {
+      channelId: "ch123",
+      message: "Pick an option",
+      props,
+    });
+
+    const body = JSON.parse(calls[0].init?.body as string);
+    expect(body.props).toEqual(props);
+    expect(body.props.attachments[0].actions[0].type).toBe("button");
+  });
+
+  it("omits props when not provided", async () => {
+    const { mockFetch, calls } = createMockFetch({ body: { id: "post5" } });
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "tok",
+      fetchImpl: mockFetch,
+    });
+
+    await createMattermostPost(client, {
+      channelId: "ch123",
+      message: "No props",
+    });
+
+    const body = JSON.parse(calls[0].init?.body as string);
+    expect(body.props).toBeUndefined();
+  });
+});
+
+// ── updateMattermostPost ─────────────────────────────────────────────
+
+describe("updateMattermostPost", () => {
+  it("sends PUT to /posts/{id}", async () => {
+    const { mockFetch, calls } = createMockFetch({ body: { id: "post1" } });
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "tok",
+      fetchImpl: mockFetch,
+    });
+
+    await updateMattermostPost(client, "post1", { message: "Updated" });
+
+    expect(calls[0].url).toContain("/posts/post1");
+    expect(calls[0].init?.method).toBe("PUT");
+  });
+
+  it("includes post id in the body", async () => {
+    const { mockFetch, calls } = createMockFetch({ body: { id: "post1" } });
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "tok",
+      fetchImpl: mockFetch,
+    });
+
+    await updateMattermostPost(client, "post1", { message: "Updated" });
+
+    const body = JSON.parse(calls[0].init?.body as string);
+    expect(body.id).toBe("post1");
+    expect(body.message).toBe("Updated");
+  });
+
+  it("includes props for button completion updates", async () => {
+    const { mockFetch, calls } = createMockFetch({ body: { id: "post1" } });
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "tok",
+      fetchImpl: mockFetch,
+    });
+
+    await updateMattermostPost(client, "post1", {
+      message: "Original message",
+      props: {
+        attachments: [{ text: "✓ **do_now** selected by @tony" }],
+      },
+    });
+
+    const body = JSON.parse(calls[0].init?.body as string);
+    expect(body.message).toBe("Original message");
+    expect(body.props.attachments[0].text).toContain("✓");
+    expect(body.props.attachments[0].text).toContain("do_now");
+  });
+
+  it("omits message when not provided", async () => {
+    const { mockFetch, calls } = createMockFetch({ body: { id: "post1" } });
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "tok",
+      fetchImpl: mockFetch,
+    });
+
+    await updateMattermostPost(client, "post1", {
+      props: { attachments: [] },
+    });
+
+    const body = JSON.parse(calls[0].init?.body as string);
+    expect(body.id).toBe("post1");
+    expect(body.message).toBeUndefined();
+    expect(body.props).toEqual({ attachments: [] });
   });
 });

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -138,6 +138,16 @@ export async function fetchMattermostChannel(
   return await client.request<MattermostChannel>(`/channels/${channelId}`);
 }
 
+export async function fetchMattermostChannelByName(
+  client: MattermostClient,
+  teamId: string,
+  channelName: string,
+): Promise<MattermostChannel> {
+  return await client.request<MattermostChannel>(
+    `/teams/${teamId}/channels/name/${encodeURIComponent(channelName)}`,
+  );
+}
+
 export async function sendMattermostTyping(
   client: MattermostClient,
   params: { channelId: string; parentId?: string },
@@ -172,9 +182,10 @@ export async function createMattermostPost(
     message: string;
     rootId?: string;
     fileIds?: string[];
+    props?: Record<string, unknown>;
   },
 ): Promise<MattermostPost> {
-  const payload: Record<string, string> = {
+  const payload: Record<string, unknown> = {
     channel_id: params.channelId,
     message: params.message,
   };
@@ -182,7 +193,10 @@ export async function createMattermostPost(
     payload.root_id = params.rootId;
   }
   if (params.fileIds?.length) {
-    (payload as Record<string, unknown>).file_ids = params.fileIds;
+    payload.file_ids = params.fileIds;
+  }
+  if (params.props) {
+    payload.props = params.props;
   }
   return await client.request<MattermostPost>("/posts", {
     method: "POST",
@@ -201,6 +215,27 @@ export async function fetchMattermostUserTeams(
   userId: string,
 ): Promise<MattermostTeam[]> {
   return await client.request<MattermostTeam[]>(`/users/${userId}/teams`);
+}
+
+export async function updateMattermostPost(
+  client: MattermostClient,
+  postId: string,
+  params: {
+    message?: string;
+    props?: Record<string, unknown>;
+  },
+): Promise<MattermostPost> {
+  const payload: Record<string, unknown> = { id: postId };
+  if (params.message !== undefined) {
+    payload.message = params.message;
+  }
+  if (params.props !== undefined) {
+    payload.props = params.props;
+  }
+  return await client.request<MattermostPost>(`/posts/${postId}`, {
+    method: "PUT",
+    body: JSON.stringify(payload),
+  });
 }
 
 export async function uploadMattermostFile(

--- a/extensions/mattermost/src/mattermost/directory.ts
+++ b/extensions/mattermost/src/mattermost/directory.ts
@@ -1,0 +1,172 @@
+import type {
+  ChannelDirectoryEntry,
+  OpenClawConfig,
+  RuntimeEnv,
+} from "openclaw/plugin-sdk/mattermost";
+import { listMattermostAccountIds, resolveMattermostAccount } from "./accounts.js";
+import {
+  createMattermostClient,
+  fetchMattermostMe,
+  type MattermostChannel,
+  type MattermostClient,
+  type MattermostUser,
+} from "./client.js";
+
+export type MattermostDirectoryParams = {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  query?: string | null;
+  limit?: number | null;
+  runtime: RuntimeEnv;
+};
+
+function buildClient(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): MattermostClient | null {
+  const account = resolveMattermostAccount({ cfg: params.cfg, accountId: params.accountId });
+  if (!account.enabled || !account.botToken || !account.baseUrl) {
+    return null;
+  }
+  return createMattermostClient({ baseUrl: account.baseUrl, botToken: account.botToken });
+}
+
+/**
+ * Build clients from ALL enabled accounts (deduplicated by token).
+ *
+ * We always scan every account because:
+ * - Private channels are only visible to bots that are members
+ * - The requesting agent's account may have an expired/invalid token
+ *
+ * This means a single healthy bot token is enough for directory discovery.
+ */
+function buildClients(params: MattermostDirectoryParams): MattermostClient[] {
+  const accountIds = listMattermostAccountIds(params.cfg);
+  const seen = new Set<string>();
+  const clients: MattermostClient[] = [];
+  for (const id of accountIds) {
+    const client = buildClient({ cfg: params.cfg, accountId: id });
+    if (client && !seen.has(client.token)) {
+      seen.add(client.token);
+      clients.push(client);
+    }
+  }
+  return clients;
+}
+
+/**
+ * List channels (public + private) visible to any configured bot account.
+ *
+ * NOTE: Uses per_page=200 which covers most instances. Mattermost does not
+ * return a "has more" indicator, so very large instances (200+ channels per bot)
+ * may see incomplete results. Pagination can be added if needed.
+ */
+export async function listMattermostDirectoryGroups(
+  params: MattermostDirectoryParams,
+): Promise<ChannelDirectoryEntry[]> {
+  const clients = buildClients(params);
+  if (!clients.length) {
+    return [];
+  }
+  const q = params.query?.trim().toLowerCase() || "";
+  const seenIds = new Set<string>();
+  const entries: ChannelDirectoryEntry[] = [];
+
+  for (const client of clients) {
+    try {
+      const me = await fetchMattermostMe(client);
+      const channels = await client.request<MattermostChannel[]>(
+        `/users/${me.id}/channels?per_page=200`,
+      );
+      for (const ch of channels) {
+        if (ch.type !== "O" && ch.type !== "P") continue;
+        if (seenIds.has(ch.id)) continue;
+        if (q) {
+          const name = (ch.name ?? "").toLowerCase();
+          const display = (ch.display_name ?? "").toLowerCase();
+          if (!name.includes(q) && !display.includes(q)) continue;
+        }
+        seenIds.add(ch.id);
+        entries.push({
+          kind: "group" as const,
+          id: `channel:${ch.id}`,
+          name: ch.name ?? undefined,
+          handle: ch.display_name ?? undefined,
+        });
+      }
+    } catch (err) {
+      // Token may be expired/revoked — skip this account and try others
+      console.debug?.(
+        "[mattermost-directory] listGroups: skipping account:",
+        (err as Error)?.message,
+      );
+      continue;
+    }
+  }
+  return params.limit && params.limit > 0 ? entries.slice(0, params.limit) : entries;
+}
+
+/**
+ * List team members as peer directory entries.
+ *
+ * Uses only the first available client since all bots in a team see the same
+ * user list (unlike channels where membership varies). Uses the first team
+ * returned — multi-team setups will only see members from that team.
+ *
+ * NOTE: per_page=200 for member listing; same pagination caveat as groups.
+ */
+export async function listMattermostDirectoryPeers(
+  params: MattermostDirectoryParams,
+): Promise<ChannelDirectoryEntry[]> {
+  const clients = buildClients(params);
+  if (!clients.length) {
+    return [];
+  }
+  // All bots see the same user list, so one client suffices (unlike channels
+  // where private channel membership varies per bot).
+  const client = clients[0];
+  try {
+    const me = await fetchMattermostMe(client);
+    const teams = await client.request<{ id: string }[]>("/users/me/teams");
+    if (!teams.length) {
+      return [];
+    }
+    // Uses first team — multi-team setups may need iteration in the future
+    const teamId = teams[0].id;
+    const q = params.query?.trim().toLowerCase() || "";
+
+    let users: MattermostUser[];
+    if (q) {
+      users = await client.request<MattermostUser[]>("/users/search", {
+        method: "POST",
+        body: JSON.stringify({ term: q, team_id: teamId }),
+      });
+    } else {
+      const members = await client.request<{ user_id: string }[]>(
+        `/teams/${teamId}/members?per_page=200`,
+      );
+      const userIds = members.map((m) => m.user_id).filter((id) => id !== me.id);
+      if (!userIds.length) {
+        return [];
+      }
+      users = await client.request<MattermostUser[]>("/users/ids", {
+        method: "POST",
+        body: JSON.stringify(userIds),
+      });
+    }
+
+    const entries = users
+      .filter((u) => u.id !== me.id)
+      .map((u) => ({
+        kind: "user" as const,
+        id: `user:${u.id}`,
+        name: u.username ?? undefined,
+        handle:
+          [u.first_name, u.last_name].filter(Boolean).join(" ").trim() || u.nickname || undefined,
+      }));
+    return params.limit && params.limit > 0 ? entries.slice(0, params.limit) : entries;
+  } catch (err) {
+    console.debug?.("[mattermost-directory] listPeers failed:", (err as Error)?.message);
+    return [];
+  }
+}

--- a/extensions/mattermost/src/mattermost/directory.ts
+++ b/extensions/mattermost/src/mattermost/directory.ts
@@ -1,8 +1,4 @@
-import type {
-  ChannelDirectoryEntry,
-  OpenClawConfig,
-  RuntimeEnv,
-} from "openclaw/plugin-sdk/mattermost";
+import type { ChannelDirectoryEntry, RemoteClawConfig, RuntimeEnv } from "remoteclaw/plugin-sdk";
 import { listMattermostAccountIds, resolveMattermostAccount } from "./accounts.js";
 import {
   createMattermostClient,
@@ -13,7 +9,7 @@ import {
 } from "./client.js";
 
 export type MattermostDirectoryParams = {
-  cfg: OpenClawConfig;
+  cfg: RemoteClawConfig;
   accountId?: string | null;
   query?: string | null;
   limit?: number | null;
@@ -21,7 +17,7 @@ export type MattermostDirectoryParams = {
 };
 
 function buildClient(params: {
-  cfg: OpenClawConfig;
+  cfg: RemoteClawConfig;
   accountId?: string | null;
 }): MattermostClient | null {
   const account = resolveMattermostAccount({ cfg: params.cfg, accountId: params.accountId });

--- a/extensions/mattermost/src/mattermost/interactions.test.ts
+++ b/extensions/mattermost/src/mattermost/interactions.test.ts
@@ -1,0 +1,335 @@
+import { type IncomingMessage } from "node:http";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import {
+  buildButtonAttachments,
+  generateInteractionToken,
+  getInteractionCallbackUrl,
+  getInteractionSecret,
+  isLocalhostRequest,
+  resolveInteractionCallbackUrl,
+  setInteractionCallbackUrl,
+  setInteractionSecret,
+  verifyInteractionToken,
+} from "./interactions.js";
+
+// ── HMAC token management ────────────────────────────────────────────
+
+describe("setInteractionSecret / getInteractionSecret", () => {
+  beforeEach(() => {
+    setInteractionSecret("test-bot-token");
+  });
+
+  it("derives a deterministic secret from the bot token", () => {
+    setInteractionSecret("token-a");
+    const secretA = getInteractionSecret();
+    setInteractionSecret("token-a");
+    const secretA2 = getInteractionSecret();
+    expect(secretA).toBe(secretA2);
+  });
+
+  it("produces different secrets for different tokens", () => {
+    setInteractionSecret("token-a");
+    const secretA = getInteractionSecret();
+    setInteractionSecret("token-b");
+    const secretB = getInteractionSecret();
+    expect(secretA).not.toBe(secretB);
+  });
+
+  it("returns a hex string", () => {
+    expect(getInteractionSecret()).toMatch(/^[0-9a-f]+$/);
+  });
+});
+
+// ── Token generation / verification ──────────────────────────────────
+
+describe("generateInteractionToken / verifyInteractionToken", () => {
+  beforeEach(() => {
+    setInteractionSecret("test-bot-token");
+  });
+
+  it("generates a hex token", () => {
+    const token = generateInteractionToken({ action_id: "click" });
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("verifies a valid token", () => {
+    const context = { action_id: "do_now", item_id: "123" };
+    const token = generateInteractionToken(context);
+    expect(verifyInteractionToken(context, token)).toBe(true);
+  });
+
+  it("rejects a tampered token", () => {
+    const context = { action_id: "do_now" };
+    const token = generateInteractionToken(context);
+    const tampered = token.replace(/.$/, token.endsWith("0") ? "1" : "0");
+    expect(verifyInteractionToken(context, tampered)).toBe(false);
+  });
+
+  it("rejects a token generated with different context", () => {
+    const token = generateInteractionToken({ action_id: "a" });
+    expect(verifyInteractionToken({ action_id: "b" }, token)).toBe(false);
+  });
+
+  it("rejects tokens with wrong length", () => {
+    const context = { action_id: "test" };
+    expect(verifyInteractionToken(context, "short")).toBe(false);
+  });
+
+  it("is deterministic for the same context", () => {
+    const context = { action_id: "test", x: 1 };
+    const t1 = generateInteractionToken(context);
+    const t2 = generateInteractionToken(context);
+    expect(t1).toBe(t2);
+  });
+
+  it("produces the same token regardless of key order", () => {
+    const contextA = { action_id: "do_now", tweet_id: "123", action: "do" };
+    const contextB = { action: "do", action_id: "do_now", tweet_id: "123" };
+    const contextC = { tweet_id: "123", action: "do", action_id: "do_now" };
+    const tokenA = generateInteractionToken(contextA);
+    const tokenB = generateInteractionToken(contextB);
+    const tokenC = generateInteractionToken(contextC);
+    expect(tokenA).toBe(tokenB);
+    expect(tokenB).toBe(tokenC);
+  });
+
+  it("verifies a token when Mattermost reorders context keys", () => {
+    // Simulate: token generated with keys in one order, verified with keys in another
+    // (Mattermost reorders context keys when storing/returning interactive message payloads)
+    const originalContext = { action_id: "bm_do", tweet_id: "999", action: "do" };
+    const token = generateInteractionToken(originalContext);
+
+    // Mattermost returns keys in alphabetical order (or any arbitrary order)
+    const reorderedContext = { action: "do", action_id: "bm_do", tweet_id: "999" };
+    expect(verifyInteractionToken(reorderedContext, token)).toBe(true);
+  });
+
+  it("scopes tokens per account when account secrets differ", () => {
+    setInteractionSecret("acct-a", "bot-token-a");
+    setInteractionSecret("acct-b", "bot-token-b");
+    const context = { action_id: "do_now", item_id: "123" };
+    const tokenA = generateInteractionToken(context, "acct-a");
+
+    expect(verifyInteractionToken(context, tokenA, "acct-a")).toBe(true);
+    expect(verifyInteractionToken(context, tokenA, "acct-b")).toBe(false);
+  });
+});
+
+// ── Callback URL registry ────────────────────────────────────────────
+
+describe("callback URL registry", () => {
+  it("stores and retrieves callback URLs", () => {
+    setInteractionCallbackUrl("acct1", "http://localhost:18789/mattermost/interactions/acct1");
+    expect(getInteractionCallbackUrl("acct1")).toBe(
+      "http://localhost:18789/mattermost/interactions/acct1",
+    );
+  });
+
+  it("returns undefined for unknown account", () => {
+    expect(getInteractionCallbackUrl("nonexistent-account-id")).toBeUndefined();
+  });
+});
+
+describe("resolveInteractionCallbackUrl", () => {
+  afterEach(() => {
+    setInteractionCallbackUrl("resolve-test", "");
+  });
+
+  it("prefers cached URL from registry", () => {
+    setInteractionCallbackUrl("cached", "http://cached:1234/path");
+    expect(resolveInteractionCallbackUrl("cached")).toBe("http://cached:1234/path");
+  });
+
+  it("falls back to computed URL from gateway port config", () => {
+    const url = resolveInteractionCallbackUrl("default", { gateway: { port: 9999 } });
+    expect(url).toBe("http://localhost:9999/mattermost/interactions/default");
+  });
+
+  it("uses default port 18789 when no config provided", () => {
+    const url = resolveInteractionCallbackUrl("myaccount");
+    expect(url).toBe("http://localhost:18789/mattermost/interactions/myaccount");
+  });
+
+  it("uses default port when gateway config has no port", () => {
+    const url = resolveInteractionCallbackUrl("acct", { gateway: {} });
+    expect(url).toBe("http://localhost:18789/mattermost/interactions/acct");
+  });
+});
+
+// ── buildButtonAttachments ───────────────────────────────────────────
+
+describe("buildButtonAttachments", () => {
+  beforeEach(() => {
+    setInteractionSecret("test-bot-token");
+  });
+
+  it("returns an array with one attachment containing all buttons", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost:18789/mattermost/interactions/default",
+      buttons: [
+        { id: "btn1", name: "Click Me" },
+        { id: "btn2", name: "Skip", style: "danger" },
+      ],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].actions).toHaveLength(2);
+  });
+
+  it("sets type to 'button' on every action", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost:18789/cb",
+      buttons: [{ id: "a", name: "A" }],
+    });
+
+    expect(result[0].actions![0].type).toBe("button");
+  });
+
+  it("includes HMAC _token in integration context", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost:18789/cb",
+      buttons: [{ id: "test", name: "Test" }],
+    });
+
+    const action = result[0].actions![0];
+    expect(action.integration.context._token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("includes sanitized action_id in integration context", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost:18789/cb",
+      buttons: [{ id: "my_action", name: "Do It" }],
+    });
+
+    const action = result[0].actions![0];
+    // sanitizeActionId strips hyphens and underscores (Mattermost routing bug #25747)
+    expect(action.integration.context.action_id).toBe("myaction");
+    expect(action.id).toBe("myaction");
+  });
+
+  it("merges custom context into integration context", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost:18789/cb",
+      buttons: [{ id: "btn", name: "Go", context: { tweet_id: "123", batch: true } }],
+    });
+
+    const ctx = result[0].actions![0].integration.context;
+    expect(ctx.tweet_id).toBe("123");
+    expect(ctx.batch).toBe(true);
+    expect(ctx.action_id).toBe("btn");
+    expect(ctx._token).toBeDefined();
+  });
+
+  it("passes callback URL to each button integration", () => {
+    const url = "http://localhost:18789/mattermost/interactions/default";
+    const result = buildButtonAttachments({
+      callbackUrl: url,
+      buttons: [
+        { id: "a", name: "A" },
+        { id: "b", name: "B" },
+      ],
+    });
+
+    for (const action of result[0].actions!) {
+      expect(action.integration.url).toBe(url);
+    }
+  });
+
+  it("preserves button style", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost/cb",
+      buttons: [
+        { id: "ok", name: "OK", style: "primary" },
+        { id: "no", name: "No", style: "danger" },
+      ],
+    });
+
+    expect(result[0].actions![0].style).toBe("primary");
+    expect(result[0].actions![1].style).toBe("danger");
+  });
+
+  it("uses provided text for the attachment", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost/cb",
+      buttons: [{ id: "x", name: "X" }],
+      text: "Choose an action:",
+    });
+
+    expect(result[0].text).toBe("Choose an action:");
+  });
+
+  it("defaults to empty string text when not provided", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost/cb",
+      buttons: [{ id: "x", name: "X" }],
+    });
+
+    expect(result[0].text).toBe("");
+  });
+
+  it("generates verifiable tokens", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost/cb",
+      buttons: [{ id: "verify_me", name: "V", context: { extra: "data" } }],
+    });
+
+    const ctx = result[0].actions![0].integration.context;
+    const token = ctx._token as string;
+    const { _token, ...contextWithoutToken } = ctx;
+    expect(verifyInteractionToken(contextWithoutToken, token)).toBe(true);
+  });
+
+  it("generates tokens that verify even when Mattermost reorders context keys", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost/cb",
+      buttons: [{ id: "do_action", name: "Do", context: { tweet_id: "42", category: "ai" } }],
+    });
+
+    const ctx = result[0].actions![0].integration.context;
+    const token = ctx._token as string;
+
+    // Simulate Mattermost returning context with keys in a different order
+    const reordered: Record<string, unknown> = {};
+    const keys = Object.keys(ctx).filter((k) => k !== "_token");
+    // Reverse the key order to simulate reordering
+    for (const key of keys.reverse()) {
+      reordered[key] = ctx[key];
+    }
+    expect(verifyInteractionToken(reordered, token)).toBe(true);
+  });
+});
+
+// ── isLocalhostRequest ───────────────────────────────────────────────
+
+describe("isLocalhostRequest", () => {
+  function fakeReq(remoteAddress?: string): IncomingMessage {
+    return {
+      socket: { remoteAddress },
+    } as unknown as IncomingMessage;
+  }
+
+  it("accepts 127.0.0.1", () => {
+    expect(isLocalhostRequest(fakeReq("127.0.0.1"))).toBe(true);
+  });
+
+  it("accepts ::1", () => {
+    expect(isLocalhostRequest(fakeReq("::1"))).toBe(true);
+  });
+
+  it("accepts ::ffff:127.0.0.1", () => {
+    expect(isLocalhostRequest(fakeReq("::ffff:127.0.0.1"))).toBe(true);
+  });
+
+  it("rejects external addresses", () => {
+    expect(isLocalhostRequest(fakeReq("10.0.0.1"))).toBe(false);
+    expect(isLocalhostRequest(fakeReq("192.168.1.1"))).toBe(false);
+  });
+
+  it("rejects when socket has no remote address", () => {
+    expect(isLocalhostRequest(fakeReq(undefined))).toBe(false);
+  });
+
+  it("rejects when socket is missing", () => {
+    expect(isLocalhostRequest({} as IncomingMessage)).toBe(false);
+  });
+});

--- a/extensions/mattermost/src/mattermost/interactions.ts
+++ b/extensions/mattermost/src/mattermost/interactions.ts
@@ -1,0 +1,429 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { getMattermostRuntime } from "../runtime.js";
+import { updateMattermostPost, type MattermostClient } from "./client.js";
+
+const INTERACTION_MAX_BODY_BYTES = 64 * 1024;
+const INTERACTION_BODY_TIMEOUT_MS = 10_000;
+
+/**
+ * Mattermost interactive message callback payload.
+ * Sent by Mattermost when a user clicks an action button.
+ * See: https://developers.mattermost.com/integrate/plugins/interactive-messages/
+ */
+export type MattermostInteractionPayload = {
+  user_id: string;
+  user_name?: string;
+  channel_id: string;
+  team_id?: string;
+  post_id: string;
+  trigger_id?: string;
+  type?: string;
+  data_source?: string;
+  context?: Record<string, unknown>;
+};
+
+export type MattermostInteractionResponse = {
+  update?: {
+    message: string;
+    props?: Record<string, unknown>;
+  };
+  ephemeral_text?: string;
+};
+
+// ── Callback URL registry ──────────────────────────────────────────────
+
+const callbackUrls = new Map<string, string>();
+
+export function setInteractionCallbackUrl(accountId: string, url: string): void {
+  callbackUrls.set(accountId, url);
+}
+
+export function getInteractionCallbackUrl(accountId: string): string | undefined {
+  return callbackUrls.get(accountId);
+}
+
+/**
+ * Resolve the interaction callback URL for an account.
+ * Prefers the in-memory registered URL (set by the gateway monitor).
+ * Falls back to computing it from the gateway port in config (for CLI callers).
+ */
+export function resolveInteractionCallbackUrl(
+  accountId: string,
+  cfg?: { gateway?: { port?: number } },
+): string {
+  const cached = callbackUrls.get(accountId);
+  if (cached) {
+    return cached;
+  }
+  const port = typeof cfg?.gateway?.port === "number" ? cfg.gateway.port : 18789;
+  return `http://localhost:${port}/mattermost/interactions/${accountId}`;
+}
+
+// ── HMAC token management ──────────────────────────────────────────────
+// Secret is derived from the bot token so it's stable across CLI and gateway processes.
+
+const interactionSecrets = new Map<string, string>();
+let defaultInteractionSecret: string | undefined;
+
+function deriveInteractionSecret(botToken: string): string {
+  return createHmac("sha256", "openclaw-mattermost-interactions").update(botToken).digest("hex");
+}
+
+export function setInteractionSecret(accountIdOrBotToken: string, botToken?: string): void {
+  if (typeof botToken === "string") {
+    interactionSecrets.set(accountIdOrBotToken, deriveInteractionSecret(botToken));
+    return;
+  }
+  // Backward-compatible fallback for call sites/tests that only pass botToken.
+  defaultInteractionSecret = deriveInteractionSecret(accountIdOrBotToken);
+}
+
+export function getInteractionSecret(accountId?: string): string {
+  const scoped = accountId ? interactionSecrets.get(accountId) : undefined;
+  if (scoped) {
+    return scoped;
+  }
+  if (defaultInteractionSecret) {
+    return defaultInteractionSecret;
+  }
+  // Fallback for single-account runtimes that only registered scoped secrets.
+  if (interactionSecrets.size === 1) {
+    const first = interactionSecrets.values().next().value;
+    if (typeof first === "string") {
+      return first;
+    }
+  }
+  throw new Error(
+    "Interaction secret not initialized — call setInteractionSecret(accountId, botToken) first",
+  );
+}
+
+export function generateInteractionToken(
+  context: Record<string, unknown>,
+  accountId?: string,
+): string {
+  const secret = getInteractionSecret(accountId);
+  // Sort keys for stable serialization — Mattermost may reorder context keys
+  const payload = JSON.stringify(context, Object.keys(context).sort());
+  return createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+export function verifyInteractionToken(
+  context: Record<string, unknown>,
+  token: string,
+  accountId?: string,
+): boolean {
+  const expected = generateInteractionToken(context, accountId);
+  if (expected.length !== token.length) {
+    return false;
+  }
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(token));
+}
+
+// ── Button builder helpers ─────────────────────────────────────────────
+
+export type MattermostButton = {
+  id: string;
+  type: "button" | "select";
+  name: string;
+  style?: "default" | "primary" | "danger";
+  integration: {
+    url: string;
+    context: Record<string, unknown>;
+  };
+};
+
+export type MattermostAttachment = {
+  text?: string;
+  actions?: MattermostButton[];
+  [key: string]: unknown;
+};
+
+/**
+ * Build Mattermost `props.attachments` with interactive buttons.
+ *
+ * Each button includes an HMAC token in its integration context so the
+ * callback handler can verify the request originated from a legitimate
+ * button click (Mattermost's recommended security pattern).
+ */
+/**
+ * Sanitize a button ID so Mattermost's action router can match it.
+ * Mattermost uses the action ID in the URL path `/api/v4/posts/{id}/actions/{actionId}`
+ * and IDs containing hyphens or underscores break the server-side routing.
+ * See: https://github.com/mattermost/mattermost/issues/25747
+ */
+function sanitizeActionId(id: string): string {
+  return id.replace(/[-_]/g, "");
+}
+
+export function buildButtonAttachments(params: {
+  callbackUrl: string;
+  accountId?: string;
+  buttons: Array<{
+    id: string;
+    name: string;
+    style?: "default" | "primary" | "danger";
+    context?: Record<string, unknown>;
+  }>;
+  text?: string;
+}): MattermostAttachment[] {
+  const actions: MattermostButton[] = params.buttons.map((btn) => {
+    const safeId = sanitizeActionId(btn.id);
+    const context: Record<string, unknown> = {
+      action_id: safeId,
+      ...btn.context,
+    };
+    const token = generateInteractionToken(context, params.accountId);
+    return {
+      id: safeId,
+      type: "button" as const,
+      name: btn.name,
+      style: btn.style,
+      integration: {
+        url: params.callbackUrl,
+        context: {
+          ...context,
+          _token: token,
+        },
+      },
+    };
+  });
+
+  return [
+    {
+      text: params.text ?? "",
+      actions,
+    },
+  ];
+}
+
+// ── Localhost validation ───────────────────────────────────────────────
+
+const LOCALHOST_ADDRESSES = new Set(["127.0.0.1", "::1", "::ffff:127.0.0.1"]);
+
+export function isLocalhostRequest(req: IncomingMessage): boolean {
+  const addr = req.socket?.remoteAddress;
+  if (!addr) {
+    return false;
+  }
+  return LOCALHOST_ADDRESSES.has(addr);
+}
+
+// ── Request body reader ────────────────────────────────────────────────
+
+function readInteractionBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+
+    const timer = setTimeout(() => {
+      req.destroy();
+      reject(new Error("Request body read timeout"));
+    }, INTERACTION_BODY_TIMEOUT_MS);
+
+    req.on("data", (chunk: Buffer) => {
+      totalBytes += chunk.length;
+      if (totalBytes > INTERACTION_MAX_BODY_BYTES) {
+        req.destroy();
+        clearTimeout(timer);
+        reject(new Error("Request body too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+
+    req.on("end", () => {
+      clearTimeout(timer);
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+
+    req.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+// ── HTTP handler ───────────────────────────────────────────────────────
+
+export function createMattermostInteractionHandler(params: {
+  client: MattermostClient;
+  botUserId: string;
+  accountId: string;
+  callbackUrl: string;
+  resolveSessionKey?: (channelId: string, userId: string) => Promise<string>;
+  dispatchButtonClick?: (opts: {
+    channelId: string;
+    userId: string;
+    userName: string;
+    actionId: string;
+    actionName: string;
+    postId: string;
+  }) => Promise<void>;
+  log?: (message: string) => void;
+}): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
+  const { client, accountId, log } = params;
+  const core = getMattermostRuntime();
+
+  return async (req: IncomingMessage, res: ServerResponse) => {
+    // Only accept POST
+    if (req.method !== "POST") {
+      res.statusCode = 405;
+      res.setHeader("Allow", "POST");
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Method Not Allowed" }));
+      return;
+    }
+
+    // Verify request is from localhost
+    if (!isLocalhostRequest(req)) {
+      log?.(
+        `mattermost interaction: rejected non-localhost request from ${req.socket?.remoteAddress}`,
+      );
+      res.statusCode = 403;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Forbidden" }));
+      return;
+    }
+
+    let payload: MattermostInteractionPayload;
+    try {
+      const raw = await readInteractionBody(req);
+      payload = JSON.parse(raw) as MattermostInteractionPayload;
+    } catch (err) {
+      log?.(`mattermost interaction: failed to parse body: ${String(err)}`);
+      res.statusCode = 400;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Invalid request body" }));
+      return;
+    }
+
+    const context = payload.context;
+    if (!context) {
+      res.statusCode = 400;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Missing context" }));
+      return;
+    }
+
+    // Verify HMAC token
+    const token = context._token;
+    if (typeof token !== "string") {
+      log?.("mattermost interaction: missing _token in context");
+      res.statusCode = 403;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Missing token" }));
+      return;
+    }
+
+    // Strip _token before verification (it wasn't in the original context)
+    const { _token, ...contextWithoutToken } = context;
+    if (!verifyInteractionToken(contextWithoutToken, token, accountId)) {
+      log?.("mattermost interaction: invalid _token");
+      res.statusCode = 403;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Invalid token" }));
+      return;
+    }
+
+    const actionId = context.action_id;
+    if (typeof actionId !== "string") {
+      res.statusCode = 400;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Missing action_id in context" }));
+      return;
+    }
+
+    log?.(
+      `mattermost interaction: action=${actionId} user=${payload.user_name ?? payload.user_id} ` +
+        `post=${payload.post_id} channel=${payload.channel_id}`,
+    );
+
+    // Dispatch as system event so the agent can handle it.
+    // Wrapped in try/catch — the post update below must still run even if
+    // system event dispatch fails (e.g. missing sessionKey or channel lookup).
+    try {
+      const eventLabel =
+        `Mattermost button click: action="${actionId}" ` +
+        `by ${payload.user_name ?? payload.user_id} ` +
+        `in channel ${payload.channel_id}`;
+
+      const sessionKey = params.resolveSessionKey
+        ? await params.resolveSessionKey(payload.channel_id, payload.user_id)
+        : `agent:main:mattermost:${accountId}:${payload.channel_id}`;
+
+      core.system.enqueueSystemEvent(eventLabel, {
+        sessionKey,
+        contextKey: `mattermost:interaction:${payload.post_id}:${actionId}`,
+      });
+    } catch (err) {
+      log?.(`mattermost interaction: system event dispatch failed: ${String(err)}`);
+    }
+
+    // Fetch the original post to preserve its message and find the clicked button name.
+    const userName = payload.user_name ?? payload.user_id;
+    let originalMessage = "";
+    let clickedButtonName = actionId; // fallback to action ID if we can't find the name
+    try {
+      const originalPost = await client.request<{
+        message?: string;
+        props?: Record<string, unknown>;
+      }>(`/posts/${payload.post_id}`);
+      originalMessage = originalPost?.message ?? "";
+
+      // Find the clicked button's display name from the original attachments
+      const postAttachments = Array.isArray(originalPost?.props?.attachments)
+        ? (originalPost.props.attachments as Array<{
+            actions?: Array<{ id?: string; name?: string }>;
+          }>)
+        : [];
+      for (const att of postAttachments) {
+        const match = att.actions?.find((a) => a.id === actionId);
+        if (match?.name) {
+          clickedButtonName = match.name;
+          break;
+        }
+      }
+    } catch (err) {
+      log?.(`mattermost interaction: failed to fetch post ${payload.post_id}: ${String(err)}`);
+    }
+
+    // Update the post via API to replace buttons with a completion indicator.
+    try {
+      await updateMattermostPost(client, payload.post_id, {
+        message: originalMessage,
+        props: {
+          attachments: [
+            {
+              text: `✓ **${clickedButtonName}** selected by @${userName}`,
+            },
+          ],
+        },
+      });
+    } catch (err) {
+      log?.(`mattermost interaction: failed to update post ${payload.post_id}: ${String(err)}`);
+    }
+
+    // Respond with empty JSON — the post update is handled above
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/json");
+    res.end("{}");
+
+    // Dispatch a synthetic inbound message so the agent responds to the button click.
+    if (params.dispatchButtonClick) {
+      try {
+        await params.dispatchButtonClick({
+          channelId: payload.channel_id,
+          userId: payload.user_id,
+          userName,
+          actionId,
+          actionName: clickedButtonName,
+          postId: payload.post_id,
+        });
+      } catch (err) {
+        log?.(`mattermost interaction: dispatchButtonClick failed: ${String(err)}`);
+      }
+    }
+  };
+}

--- a/extensions/mattermost/src/mattermost/interactions.ts
+++ b/extensions/mattermost/src/mattermost/interactions.ts
@@ -67,7 +67,7 @@ const interactionSecrets = new Map<string, string>();
 let defaultInteractionSecret: string | undefined;
 
 function deriveInteractionSecret(botToken: string): string {
-  return createHmac("sha256", "openclaw-mattermost-interactions").update(botToken).digest("hex");
+  return createHmac("sha256", "remoteclaw-mattermost-interactions").update(botToken).digest("hex");
 }
 
 export function setInteractionSecret(accountIdOrBotToken: string, botToken?: string): void {

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1,0 +1,109 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { resolveMattermostAccount } from "./accounts.js";
+import {
+  evaluateMattermostMentionGate,
+  type MattermostMentionGateInput,
+  type MattermostRequireMentionResolverInput,
+} from "./monitor.js";
+
+function resolveRequireMentionForTest(params: MattermostRequireMentionResolverInput): boolean {
+  const root = params.cfg.channels?.mattermost;
+  const accountGroups = root?.accounts?.[params.accountId]?.groups;
+  const groups = accountGroups ?? root?.groups;
+  const groupConfig = params.groupId ? groups?.[params.groupId] : undefined;
+  const defaultGroupConfig = groups?.["*"];
+  const configMention =
+    typeof groupConfig?.requireMention === "boolean"
+      ? groupConfig.requireMention
+      : typeof defaultGroupConfig?.requireMention === "boolean"
+        ? defaultGroupConfig.requireMention
+        : undefined;
+  if (typeof configMention === "boolean") {
+    return configMention;
+  }
+  if (typeof params.requireMentionOverride === "boolean") {
+    return params.requireMentionOverride;
+  }
+  return true;
+}
+
+function evaluateMentionGateForMessage(params: { cfg: OpenClawConfig; threadRootId?: string }) {
+  const account = resolveMattermostAccount({ cfg: params.cfg, accountId: "default" });
+  const resolver = vi.fn(resolveRequireMentionForTest);
+  const input: MattermostMentionGateInput = {
+    kind: "channel",
+    cfg: params.cfg,
+    accountId: account.accountId,
+    channelId: "chan-1",
+    threadRootId: params.threadRootId,
+    requireMentionOverride: account.requireMention,
+    resolveRequireMention: resolver,
+    wasMentioned: false,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharEnabled: false,
+    oncharTriggered: false,
+    canDetectMention: true,
+  };
+  const decision = evaluateMattermostMentionGate(input);
+  return { account, resolver, decision };
+}
+
+describe("mattermost mention gating", () => {
+  it("accepts unmentioned root channel posts in onmessage mode", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          chatmode: "onmessage",
+          groupPolicy: "open",
+        },
+      },
+    };
+    const { resolver, decision } = evaluateMentionGateForMessage({ cfg });
+    expect(decision.dropReason).toBeNull();
+    expect(decision.shouldRequireMention).toBe(false);
+    expect(resolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        groupId: "chan-1",
+        requireMentionOverride: false,
+      }),
+    );
+  });
+
+  it("accepts unmentioned thread replies in onmessage mode", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          chatmode: "onmessage",
+          groupPolicy: "open",
+        },
+      },
+    };
+    const { resolver, decision } = evaluateMentionGateForMessage({
+      cfg,
+      threadRootId: "thread-root-1",
+    });
+    expect(decision.dropReason).toBeNull();
+    expect(decision.shouldRequireMention).toBe(false);
+    const resolverCall = resolver.mock.calls.at(-1)?.[0];
+    expect(resolverCall?.groupId).toBe("chan-1");
+    expect(resolverCall?.groupId).not.toBe("thread-root-1");
+  });
+
+  it("rejects unmentioned channel posts in oncall mode", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          chatmode: "oncall",
+          groupPolicy: "open",
+        },
+      },
+    };
+    const { decision, account } = evaluateMentionGateForMessage({ cfg });
+    expect(account.requireMention).toBe(true);
+    expect(decision.shouldRequireMention).toBe(true);
+    expect(decision.dropReason).toBe("missing-mention");
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it, vi } from "vitest";
 import { resolveMattermostAccount } from "./accounts.js";
 import {

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
+import type { RemoteClawConfig } from "remoteclaw/plugin-sdk";
 import { describe, expect, it, vi } from "vitest";
 import { resolveMattermostAccount } from "./accounts.js";
 import {
@@ -28,7 +28,7 @@ function resolveRequireMentionForTest(params: MattermostRequireMentionResolverIn
   return true;
 }
 
-function evaluateMentionGateForMessage(params: { cfg: OpenClawConfig; threadRootId?: string }) {
+function evaluateMentionGateForMessage(params: { cfg: RemoteClawConfig; threadRootId?: string }) {
   const account = resolveMattermostAccount({ cfg: params.cfg, accountId: "default" });
   const resolver = vi.fn(resolveRequireMentionForTest);
   const input: MattermostMentionGateInput = {
@@ -52,7 +52,7 @@ function evaluateMentionGateForMessage(params: { cfg: OpenClawConfig; threadRoot
 
 describe("mattermost mention gating", () => {
   it("accepts unmentioned root channel posts in onmessage mode", () => {
-    const cfg: OpenClawConfig = {
+    const cfg: RemoteClawConfig = {
       channels: {
         mattermost: {
           chatmode: "onmessage",
@@ -73,7 +73,7 @@ describe("mattermost mention gating", () => {
   });
 
   it("accepts unmentioned thread replies in onmessage mode", () => {
-    const cfg: OpenClawConfig = {
+    const cfg: RemoteClawConfig = {
       channels: {
         mattermost: {
           chatmode: "onmessage",
@@ -93,7 +93,7 @@ describe("mattermost mention gating", () => {
   });
 
   it("rejects unmentioned channel posts in oncall mode", () => {
-    const cfg: OpenClawConfig = {
+    const cfg: RemoteClawConfig = {
       channels: {
         mattermost: {
           chatmode: "oncall",

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_GROUP_HISTORY_LIMIT,
   recordPendingHistoryEntryIfEnabled,
   isDangerousNameMatchingEnabled,
+  registerPluginHttpRoute,
   resolveControlCommandGate,
   readStoreAllowFromForDmPolicy,
   resolveDmGroupAccessWithLists,
@@ -41,6 +42,11 @@ import {
   type MattermostPost,
   type MattermostUser,
 } from "./client.js";
+import {
+  createMattermostInteractionHandler,
+  setInteractionCallbackUrl,
+  setInteractionSecret,
+} from "./interactions.js";
 import {
   createDedupeCache,
   formatInboundFromLabel,
@@ -361,12 +367,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       // a different port.
       const envPortRaw = process.env.OPENCLAW_GATEWAY_PORT?.trim();
       const envPort = envPortRaw ? Number.parseInt(envPortRaw, 10) : NaN;
-      const gatewayPort =
+      const slashGatewayPort =
         Number.isFinite(envPort) && envPort > 0 ? envPort : (cfg.gateway?.port ?? 18789);
 
-      const callbackUrl = resolveCallbackUrl({
+      const slashCallbackUrl = resolveCallbackUrl({
         config: slashConfig,
-        gatewayPort,
+        gatewayPort: slashGatewayPort,
         gatewayHost: cfg.gateway?.customBindHost ?? undefined,
       });
 
@@ -375,7 +381,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
 
       try {
         const mmHost = new URL(baseUrl).hostname;
-        const callbackHost = new URL(callbackUrl).hostname;
+        const callbackHost = new URL(slashCallbackUrl).hostname;
 
         // NOTE: We cannot infer network reachability from hostnames alone.
         // Mattermost might be accessed via a public domain while still running on the same
@@ -383,7 +389,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         // So treat loopback callback URLs as an advisory warning only.
         if (isLoopbackHost(callbackHost) && !isLoopbackHost(mmHost)) {
           runtime.error?.(
-            `mattermost: slash commands callbackUrl resolved to ${callbackUrl} (loopback) while baseUrl is ${baseUrl}. This MAY be unreachable depending on your deployment. If native slash commands don't work, set channels.mattermost.commands.callbackUrl to a URL reachable from the Mattermost server (e.g. your public reverse proxy URL).`,
+            `mattermost: slash commands callbackUrl resolved to ${slashCallbackUrl} (loopback) while baseUrl is ${baseUrl}. This MAY be unreachable depending on your deployment. If native slash commands don't work, set channels.mattermost.commands.callbackUrl to a URL reachable from the Mattermost server (e.g. your public reverse proxy URL).`,
           );
         }
       } catch {
@@ -434,7 +440,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             client,
             teamId: team.id,
             creatorUserId: botUserId,
-            callbackUrl,
+            callbackUrl: slashCallbackUrl,
             commands: dedupedCommands,
             log: (msg) => runtime.log?.(msg),
           });
@@ -476,13 +482,189 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         });
 
         runtime.log?.(
-          `mattermost: slash commands registered (${allRegistered.length} commands across ${teams.length} teams, callback=${callbackUrl})`,
+          `mattermost: slash commands registered (${allRegistered.length} commands across ${teams.length} teams, callback=${slashCallbackUrl})`,
         );
       }
     } catch (err) {
       runtime.error?.(`mattermost: failed to register slash commands: ${String(err)}`);
     }
   }
+
+  // ─── Interactive buttons registration ──────────────────────────────────────
+  // Derive a stable HMAC secret from the bot token so CLI and gateway share it.
+  setInteractionSecret(account.accountId, botToken);
+
+  // Register HTTP callback endpoint for interactive button clicks.
+  // Mattermost POSTs to this URL when a user clicks a button action.
+  const gatewayPort = typeof cfg.gateway?.port === "number" ? cfg.gateway.port : 18789;
+  const interactionPath = `/mattermost/interactions/${account.accountId}`;
+  const callbackUrl = `http://localhost:${gatewayPort}${interactionPath}`;
+  setInteractionCallbackUrl(account.accountId, callbackUrl);
+  const unregisterInteractions = registerPluginHttpRoute({
+    path: interactionPath,
+    fallbackPath: "/mattermost/interactions/default",
+    auth: "plugin",
+    handler: createMattermostInteractionHandler({
+      client,
+      botUserId,
+      accountId: account.accountId,
+      callbackUrl,
+      resolveSessionKey: async (channelId: string, userId: string) => {
+        const channelInfo = await resolveChannelInfo(channelId);
+        const kind = mapMattermostChannelTypeToChatType(channelInfo?.type);
+        const teamId = channelInfo?.team_id ?? undefined;
+        const route = core.channel.routing.resolveAgentRoute({
+          cfg,
+          channel: "mattermost",
+          accountId: account.accountId,
+          teamId,
+          peer: {
+            kind,
+            id: kind === "direct" ? userId : channelId,
+          },
+        });
+        return route.sessionKey;
+      },
+      dispatchButtonClick: async (opts) => {
+        const channelInfo = await resolveChannelInfo(opts.channelId);
+        const kind = mapMattermostChannelTypeToChatType(channelInfo?.type);
+        const chatType = channelChatType(kind);
+        const teamId = channelInfo?.team_id ?? undefined;
+        const channelName = channelInfo?.name ?? undefined;
+        const channelDisplay = channelInfo?.display_name ?? channelName ?? opts.channelId;
+        const route = core.channel.routing.resolveAgentRoute({
+          cfg,
+          channel: "mattermost",
+          accountId: account.accountId,
+          teamId,
+          peer: {
+            kind,
+            id: kind === "direct" ? opts.userId : opts.channelId,
+          },
+        });
+        const to = kind === "direct" ? `user:${opts.userId}` : `channel:${opts.channelId}`;
+        const bodyText = `[Button click: user @${opts.userName} selected "${opts.actionName}"]`;
+        const ctxPayload = core.channel.reply.finalizeInboundContext({
+          Body: bodyText,
+          BodyForAgent: bodyText,
+          RawBody: bodyText,
+          CommandBody: bodyText,
+          From:
+            kind === "direct"
+              ? `mattermost:${opts.userId}`
+              : kind === "group"
+                ? `mattermost:group:${opts.channelId}`
+                : `mattermost:channel:${opts.channelId}`,
+          To: to,
+          SessionKey: route.sessionKey,
+          AccountId: route.accountId,
+          ChatType: chatType,
+          ConversationLabel: `mattermost:${opts.userName}`,
+          GroupSubject: kind !== "direct" ? channelDisplay : undefined,
+          GroupChannel: channelName ? `#${channelName}` : undefined,
+          GroupSpace: teamId,
+          SenderName: opts.userName,
+          SenderId: opts.userId,
+          Provider: "mattermost" as const,
+          Surface: "mattermost" as const,
+          MessageSid: `interaction:${opts.postId}:${opts.actionId}`,
+          WasMentioned: true,
+          CommandAuthorized: true,
+          OriginatingChannel: "mattermost" as const,
+          OriginatingTo: to,
+        });
+
+        const textLimit = core.channel.text.resolveTextChunkLimit(
+          cfg,
+          "mattermost",
+          account.accountId,
+          { fallbackLimit: account.textChunkLimit ?? 4000 },
+        );
+        const tableMode = core.channel.text.resolveMarkdownTableMode({
+          cfg,
+          channel: "mattermost",
+          accountId: account.accountId,
+        });
+        const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+          cfg,
+          agentId: route.agentId,
+          channel: "mattermost",
+          accountId: account.accountId,
+        });
+        const typingCallbacks = createTypingCallbacks({
+          start: () => sendTypingIndicator(opts.channelId),
+          onStartError: (err) => {
+            logTypingFailure({
+              log: (message) => logger.debug?.(message),
+              channel: "mattermost",
+              target: opts.channelId,
+              error: err,
+            });
+          },
+        });
+        const { dispatcher, replyOptions, markDispatchIdle } =
+          core.channel.reply.createReplyDispatcherWithTyping({
+            ...prefixOptions,
+            humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
+            deliver: async (payload: ReplyPayload) => {
+              const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+              const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
+              if (mediaUrls.length === 0) {
+                const chunkMode = core.channel.text.resolveChunkMode(
+                  cfg,
+                  "mattermost",
+                  account.accountId,
+                );
+                const chunks = core.channel.text.chunkMarkdownTextWithMode(
+                  text,
+                  textLimit,
+                  chunkMode,
+                );
+                for (const chunk of chunks.length > 0 ? chunks : [text]) {
+                  if (!chunk) continue;
+                  await sendMessageMattermost(to, chunk, {
+                    accountId: account.accountId,
+                  });
+                }
+              } else {
+                let first = true;
+                for (const mediaUrl of mediaUrls) {
+                  const caption = first ? text : "";
+                  first = false;
+                  await sendMessageMattermost(to, caption, {
+                    accountId: account.accountId,
+                    mediaUrl,
+                  });
+                }
+              }
+              runtime.log?.(`delivered button-click reply to ${to}`);
+            },
+            onError: (err, info) => {
+              runtime.error?.(`mattermost button-click ${info.kind} reply failed: ${String(err)}`);
+            },
+            onReplyStart: typingCallbacks.onReplyStart,
+          });
+
+        await core.channel.reply.dispatchReplyFromConfig({
+          ctx: ctxPayload,
+          cfg,
+          dispatcher,
+          replyOptions: {
+            ...replyOptions,
+            disableBlockStreaming:
+              typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
+            onModelSelected,
+          },
+        });
+        markDispatchIdle();
+      },
+      log: (msg) => runtime.log?.(msg),
+    }),
+    pluginId: "mattermost",
+    source: "mattermost-interactions",
+    accountId: account.accountId,
+    log: (msg: string) => runtime.log?.(msg),
+  });
 
   const channelCache = new Map<string, { value: MattermostChannel | null; expiresAt: number }>();
   const userCache = new Map<string, { value: MattermostUser | null; expiresAt: number }>();
@@ -537,6 +719,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           },
           filePathHint: fileId,
           maxBytes: mediaMaxBytes,
+          // Allow fetching from the Mattermost server host (may be localhost or
+          // a private IP). Without this, SSRF guards block media downloads.
+          // Credit: #22594 (@webclerk)
+          ssrfPolicy: { allowedHostnames: [new URL(client.baseUrl).hostname] },
         });
         const saved = await core.channel.media.saveMediaBuffer(
           fetched.buffer,
@@ -1338,17 +1524,21 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     }
   }
 
-  await runWithReconnect(connectOnce, {
-    abortSignal: opts.abortSignal,
-    jitterRatio: 0.2,
-    onError: (err) => {
-      runtime.error?.(`mattermost connection failed: ${String(err)}`);
-      opts.statusSink?.({ lastError: String(err), connected: false });
-    },
-    onReconnect: (delayMs) => {
-      runtime.log?.(`mattermost reconnecting in ${Math.round(delayMs / 1000)}s`);
-    },
-  });
+  try {
+    await runWithReconnect(connectOnce, {
+      abortSignal: opts.abortSignal,
+      jitterRatio: 0.2,
+      onError: (err) => {
+        runtime.error?.(`mattermost connection failed: ${String(err)}`);
+        opts.statusSink?.({ lastError: String(err), connected: false });
+      },
+      onReconnect: (delayMs) => {
+        runtime.log?.(`mattermost reconnecting in ${Math.round(delayMs / 1000)}s`);
+      },
+    });
+  } finally {
+    unregisterInteractions?.();
+  }
 
   if (slashShutdownCleanup) {
     await slashShutdownCleanup;

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -199,6 +199,89 @@ function isSenderAllowed(params: {
   });
 }
 
+export type MattermostRequireMentionResolverInput = {
+  cfg: RemoteClawConfig;
+  channel: "mattermost";
+  accountId: string;
+  groupId: string;
+  requireMentionOverride?: boolean;
+};
+
+export type MattermostMentionGateInput = {
+  kind: ChatType;
+  cfg: RemoteClawConfig;
+  accountId: string;
+  channelId: string;
+  threadRootId?: string;
+  requireMentionOverride?: boolean;
+  resolveRequireMention: (params: MattermostRequireMentionResolverInput) => boolean;
+  wasMentioned: boolean;
+  isControlCommand: boolean;
+  commandAuthorized: boolean;
+  oncharEnabled: boolean;
+  oncharTriggered: boolean;
+  canDetectMention: boolean;
+};
+
+type MattermostMentionGateDecision = {
+  shouldRequireMention: boolean;
+  shouldBypassMention: boolean;
+  effectiveWasMentioned: boolean;
+  dropReason: "onchar-not-triggered" | "missing-mention" | null;
+};
+
+export function evaluateMattermostMentionGate(
+  params: MattermostMentionGateInput,
+): MattermostMentionGateDecision {
+  const shouldRequireMention =
+    params.kind !== "direct" &&
+    params.resolveRequireMention({
+      cfg: params.cfg,
+      channel: "mattermost",
+      accountId: params.accountId,
+      groupId: params.channelId,
+      requireMentionOverride: params.requireMentionOverride,
+    });
+  const shouldBypassMention =
+    params.isControlCommand &&
+    shouldRequireMention &&
+    !params.wasMentioned &&
+    params.commandAuthorized;
+  const effectiveWasMentioned =
+    params.wasMentioned || shouldBypassMention || params.oncharTriggered;
+  if (
+    params.oncharEnabled &&
+    !params.oncharTriggered &&
+    !params.wasMentioned &&
+    !params.isControlCommand
+  ) {
+    return {
+      shouldRequireMention,
+      shouldBypassMention,
+      effectiveWasMentioned,
+      dropReason: "onchar-not-triggered",
+    };
+  }
+  if (
+    params.kind !== "direct" &&
+    shouldRequireMention &&
+    params.canDetectMention &&
+    !effectiveWasMentioned
+  ) {
+    return {
+      shouldRequireMention,
+      shouldBypassMention,
+      effectiveWasMentioned,
+      dropReason: "missing-mention",
+    };
+  }
+  return {
+    shouldRequireMention,
+    shouldBypassMention,
+    effectiveWasMentioned,
+    dropReason: null,
+  };
+}
 type MattermostMediaInfo = {
   path: string;
   contentType?: string;
@@ -529,28 +612,36 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
   ) => {
     const channelId = post.channel_id ?? payload.data?.channel_id ?? payload.broadcast?.channel_id;
     if (!channelId) {
+      logVerboseMessage("mattermost: drop post (missing channel id)");
       return;
     }
 
     const allMessageIds = messageIds?.length ? messageIds : post.id ? [post.id] : [];
     if (allMessageIds.length === 0) {
+      logVerboseMessage("mattermost: drop post (missing message id)");
       return;
     }
     const dedupeEntries = allMessageIds.map((id) =>
       recentInboundMessages.check(`${account.accountId}:${id}`),
     );
     if (dedupeEntries.length > 0 && dedupeEntries.every(Boolean)) {
+      logVerboseMessage(
+        `mattermost: drop post (dedupe account=${account.accountId} ids=${allMessageIds.length})`,
+      );
       return;
     }
 
     const senderId = post.user_id ?? payload.broadcast?.user_id;
     if (!senderId) {
+      logVerboseMessage("mattermost: drop post (missing sender id)");
       return;
     }
     if (senderId === botUserId) {
+      logVerboseMessage(`mattermost: drop post (self sender=${senderId})`);
       return;
     }
     if (isSystemPost(post)) {
+      logVerboseMessage(`mattermost: drop post (system post type=${post.type ?? "unknown"})`);
       return;
     }
 
@@ -749,30 +840,38 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       ? stripOncharPrefix(rawText, oncharPrefixes)
       : { triggered: false, stripped: rawText };
     const oncharTriggered = oncharResult.triggered;
-
-    const shouldRequireMention =
-      kind !== "direct" &&
-      core.channel.groups.resolveRequireMention({
-        cfg,
-        channel: "mattermost",
-        accountId: account.accountId,
-        groupId: channelId,
-      });
-    const shouldBypassMention =
-      isControlCommand && shouldRequireMention && !wasMentioned && commandAuthorized;
-    const effectiveWasMentioned = wasMentioned || shouldBypassMention || oncharTriggered;
     const canDetectMention = Boolean(botUsername) || mentionRegexes.length > 0;
+    const mentionDecision = evaluateMattermostMentionGate({
+      kind,
+      cfg,
+      accountId: account.accountId,
+      channelId,
+      threadRootId,
+      requireMentionOverride: account.requireMention,
+      resolveRequireMention: core.channel.groups.resolveRequireMention,
+      wasMentioned,
+      isControlCommand,
+      commandAuthorized,
+      oncharEnabled,
+      oncharTriggered,
+      canDetectMention,
+    });
+    const { shouldRequireMention, shouldBypassMention } = mentionDecision;
 
-    if (oncharEnabled && !oncharTriggered && !wasMentioned && !isControlCommand) {
+    if (mentionDecision.dropReason === "onchar-not-triggered") {
+      logVerboseMessage(
+        `mattermost: drop group message (onchar not triggered channel=${channelId} sender=${senderId})`,
+      );
       recordPendingHistory();
       return;
     }
 
-    if (kind !== "direct" && shouldRequireMention && canDetectMention) {
-      if (!effectiveWasMentioned) {
-        recordPendingHistory();
-        return;
-      }
+    if (mentionDecision.dropReason === "missing-mention") {
+      logVerboseMessage(
+        `mattermost: drop group message (missing mention channel=${channelId} sender=${senderId} requireMention=${shouldRequireMention} bypass=${shouldBypassMention} canDetectMention=${canDetectMention})`,
+      );
+      recordPendingHistory();
+      return;
     }
     const mediaList = await resolveMattermostMedia(post.file_ids);
     const mediaPlaceholder = buildMattermostAttachmentPlaceholder(mediaList);
@@ -780,6 +879,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     const baseText = [bodySource, mediaPlaceholder].filter(Boolean).join("\n").trim();
     const bodyText = normalizeMention(baseText, botUsername);
     if (!bodyText) {
+      logVerboseMessage(
+        `mattermost: drop group message (empty body after normalization channel=${channelId} sender=${senderId})`,
+      );
       return;
     }
 
@@ -883,7 +985,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       ReplyToId: threadRootId,
       MessageThreadId: threadRootId,
       Timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
-      WasMentioned: kind !== "direct" ? effectiveWasMentioned : undefined,
+      WasMentioned: kind !== "direct" ? mentionDecision.effectiveWasMentioned : undefined,
       CommandAuthorized: commandAuthorized,
       OriginatingChannel: "mattermost" as const,
       OriginatingTo: to,

--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { sendMessageMattermost } from "./send.js";
+import { parseMattermostTarget, sendMessageMattermost } from "./send.js";
 
 const mockState = vi.hoisted(() => ({
   loadConfig: vi.fn(() => ({})),
@@ -12,7 +12,9 @@ const mockState = vi.hoisted(() => ({
   createMattermostClient: vi.fn(),
   createMattermostDirectChannel: vi.fn(),
   createMattermostPost: vi.fn(),
+  fetchMattermostChannelByName: vi.fn(),
   fetchMattermostMe: vi.fn(),
+  fetchMattermostUserTeams: vi.fn(),
   fetchMattermostUserByUsername: vi.fn(),
   normalizeMattermostBaseUrl: vi.fn((input: string | undefined) => input?.trim() ?? ""),
   uploadMattermostFile: vi.fn(),
@@ -30,7 +32,9 @@ vi.mock("./client.js", () => ({
   createMattermostClient: mockState.createMattermostClient,
   createMattermostDirectChannel: mockState.createMattermostDirectChannel,
   createMattermostPost: mockState.createMattermostPost,
+  fetchMattermostChannelByName: mockState.fetchMattermostChannelByName,
   fetchMattermostMe: mockState.fetchMattermostMe,
+  fetchMattermostUserTeams: mockState.fetchMattermostUserTeams,
   fetchMattermostUserByUsername: mockState.fetchMattermostUserByUsername,
   normalizeMattermostBaseUrl: mockState.normalizeMattermostBaseUrl,
   uploadMattermostFile: mockState.uploadMattermostFile,
@@ -71,11 +75,16 @@ describe("sendMessageMattermost", () => {
     mockState.createMattermostClient.mockReset();
     mockState.createMattermostDirectChannel.mockReset();
     mockState.createMattermostPost.mockReset();
+    mockState.fetchMattermostChannelByName.mockReset();
     mockState.fetchMattermostMe.mockReset();
+    mockState.fetchMattermostUserTeams.mockReset();
     mockState.fetchMattermostUserByUsername.mockReset();
     mockState.uploadMattermostFile.mockReset();
     mockState.createMattermostClient.mockReturnValue({});
     mockState.createMattermostPost.mockResolvedValue({ id: "post-1" });
+    mockState.fetchMattermostMe.mockResolvedValue({ id: "bot-user" });
+    mockState.fetchMattermostUserTeams.mockResolvedValue([{ id: "team-1" }]);
+    mockState.fetchMattermostChannelByName.mockResolvedValue({ id: "town-square" });
     mockState.uploadMattermostFile.mockResolvedValue({ id: "file-1" });
   });
 
@@ -146,5 +155,88 @@ describe("sendMessageMattermost", () => {
         contentType: "image/png",
       }),
     );
+  });
+});
+
+describe("parseMattermostTarget", () => {
+  it("parses channel: prefix with valid ID as channel id", () => {
+    const target = parseMattermostTarget("channel:dthcxgoxhifn3pwh65cut3ud3w");
+    expect(target).toEqual({ kind: "channel", id: "dthcxgoxhifn3pwh65cut3ud3w" });
+  });
+
+  it("parses channel: prefix with non-ID as channel name", () => {
+    const target = parseMattermostTarget("channel:abc123");
+    expect(target).toEqual({ kind: "channel-name", name: "abc123" });
+  });
+
+  it("parses user: prefix as user id", () => {
+    const target = parseMattermostTarget("user:usr456");
+    expect(target).toEqual({ kind: "user", id: "usr456" });
+  });
+
+  it("parses mattermost: prefix as user id", () => {
+    const target = parseMattermostTarget("mattermost:usr789");
+    expect(target).toEqual({ kind: "user", id: "usr789" });
+  });
+
+  it("parses @ prefix as username", () => {
+    const target = parseMattermostTarget("@alice");
+    expect(target).toEqual({ kind: "user", username: "alice" });
+  });
+
+  it("parses # prefix as channel name", () => {
+    const target = parseMattermostTarget("#off-topic");
+    expect(target).toEqual({ kind: "channel-name", name: "off-topic" });
+  });
+
+  it("parses # prefix with spaces", () => {
+    const target = parseMattermostTarget("  #general  ");
+    expect(target).toEqual({ kind: "channel-name", name: "general" });
+  });
+
+  it("treats 26-char alphanumeric bare string as channel id", () => {
+    const target = parseMattermostTarget("dthcxgoxhifn3pwh65cut3ud3w");
+    expect(target).toEqual({ kind: "channel", id: "dthcxgoxhifn3pwh65cut3ud3w" });
+  });
+
+  it("treats non-ID bare string as channel name", () => {
+    const target = parseMattermostTarget("off-topic");
+    expect(target).toEqual({ kind: "channel-name", name: "off-topic" });
+  });
+
+  it("treats channel: with non-ID value as channel name", () => {
+    const target = parseMattermostTarget("channel:off-topic");
+    expect(target).toEqual({ kind: "channel-name", name: "off-topic" });
+  });
+
+  it("throws on empty string", () => {
+    expect(() => parseMattermostTarget("")).toThrow("Recipient is required");
+  });
+
+  it("throws on empty # prefix", () => {
+    expect(() => parseMattermostTarget("#")).toThrow("Channel name is required");
+  });
+
+  it("throws on empty @ prefix", () => {
+    expect(() => parseMattermostTarget("@")).toThrow("Username is required");
+  });
+
+  it("parses channel:#name as channel name", () => {
+    const target = parseMattermostTarget("channel:#off-topic");
+    expect(target).toEqual({ kind: "channel-name", name: "off-topic" });
+  });
+
+  it("parses channel:#name with spaces", () => {
+    const target = parseMattermostTarget("  channel: #general  ");
+    expect(target).toEqual({ kind: "channel-name", name: "general" });
+  });
+
+  it("is case-insensitive for prefixes", () => {
+    expect(parseMattermostTarget("CHANNEL:dthcxgoxhifn3pwh65cut3ud3w")).toEqual({
+      kind: "channel",
+      id: "dthcxgoxhifn3pwh65cut3ud3w",
+    });
+    expect(parseMattermostTarget("User:XYZ")).toEqual({ kind: "user", id: "XYZ" });
+    expect(parseMattermostTarget("Mattermost:QRS")).toEqual({ kind: "user", id: "QRS" });
   });
 });

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -5,8 +5,10 @@ import {
   createMattermostClient,
   createMattermostDirectChannel,
   createMattermostPost,
+  fetchMattermostChannelByName,
   fetchMattermostMe,
   fetchMattermostUserByUsername,
+  fetchMattermostUserTeams,
   normalizeMattermostBaseUrl,
   uploadMattermostFile,
   type MattermostUser,
@@ -20,6 +22,7 @@ export type MattermostSendOpts = {
   mediaUrl?: string;
   mediaLocalRoots?: readonly string[];
   replyToId?: string;
+  props?: Record<string, unknown>;
 };
 
 export type MattermostSendResult = {
@@ -29,10 +32,12 @@ export type MattermostSendResult = {
 
 type MattermostTarget =
   | { kind: "channel"; id: string }
+  | { kind: "channel-name"; name: string }
   | { kind: "user"; id?: string; username?: string };
 
 const botUserCache = new Map<string, MattermostUser>();
 const userByNameCache = new Map<string, MattermostUser>();
+const channelByNameCache = new Map<string, string>();
 
 const getCore = () => getMattermostRuntime();
 
@@ -50,7 +55,12 @@ function isHttpUrl(value: string): boolean {
   return /^https?:\/\//i.test(value);
 }
 
-function parseMattermostTarget(raw: string): MattermostTarget {
+/** Mattermost IDs are 26-character lowercase alphanumeric strings. */
+function isMattermostId(value: string): boolean {
+  return /^[a-z0-9]{26}$/.test(value);
+}
+
+export function parseMattermostTarget(raw: string): MattermostTarget {
   const trimmed = raw.trim();
   if (!trimmed) {
     throw new Error("Recipient is required for Mattermost sends");
@@ -60,6 +70,16 @@ function parseMattermostTarget(raw: string): MattermostTarget {
     const id = trimmed.slice("channel:".length).trim();
     if (!id) {
       throw new Error("Channel id is required for Mattermost sends");
+    }
+    if (id.startsWith("#")) {
+      const name = id.slice(1).trim();
+      if (!name) {
+        throw new Error("Channel name is required for Mattermost sends");
+      }
+      return { kind: "channel-name", name };
+    }
+    if (!isMattermostId(id)) {
+      return { kind: "channel-name", name: id };
     }
     return { kind: "channel", id };
   }
@@ -83,6 +103,16 @@ function parseMattermostTarget(raw: string): MattermostTarget {
       throw new Error("Username is required for Mattermost sends");
     }
     return { kind: "user", username };
+  }
+  if (trimmed.startsWith("#")) {
+    const name = trimmed.slice(1).trim();
+    if (!name) {
+      throw new Error("Channel name is required for Mattermost sends");
+    }
+    return { kind: "channel-name", name };
+  }
+  if (!isMattermostId(trimmed)) {
+    return { kind: "channel-name", name: trimmed };
   }
   return { kind: "channel", id: trimmed };
 }
@@ -116,6 +146,34 @@ async function resolveUserIdByUsername(params: {
   return user.id;
 }
 
+async function resolveChannelIdByName(params: {
+  baseUrl: string;
+  token: string;
+  name: string;
+}): Promise<string> {
+  const { baseUrl, token, name } = params;
+  const key = `${cacheKey(baseUrl, token)}::channel::${name.toLowerCase()}`;
+  const cached = channelByNameCache.get(key);
+  if (cached) {
+    return cached;
+  }
+  const client = createMattermostClient({ baseUrl, botToken: token });
+  const me = await fetchMattermostMe(client);
+  const teams = await fetchMattermostUserTeams(client, me.id);
+  for (const team of teams) {
+    try {
+      const channel = await fetchMattermostChannelByName(client, team.id, name);
+      if (channel?.id) {
+        channelByNameCache.set(key, channel.id);
+        return channel.id;
+      }
+    } catch {
+      // Channel not found in this team, try next
+    }
+  }
+  throw new Error(`Mattermost channel "#${name}" not found in any team the bot belongs to`);
+}
+
 async function resolveTargetChannelId(params: {
   target: MattermostTarget;
   baseUrl: string;
@@ -123,6 +181,13 @@ async function resolveTargetChannelId(params: {
 }): Promise<string> {
   if (params.target.kind === "channel") {
     return params.target.id;
+  }
+  if (params.target.kind === "channel-name") {
+    return await resolveChannelIdByName({
+      baseUrl: params.baseUrl,
+      token: params.token,
+      name: params.target.name,
+    });
   }
   const userId = params.target.id
     ? params.target.id
@@ -221,6 +286,7 @@ export async function sendMessageMattermost(
     message,
     rootId: opts.replyToId,
     fileIds,
+    props: opts.props,
   });
 
   core.channel.activity.record({

--- a/extensions/mattermost/src/normalize.test.ts
+++ b/extensions/mattermost/src/normalize.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { looksLikeMattermostTargetId, normalizeMattermostMessagingTarget } from "./normalize.js";
+
+describe("normalizeMattermostMessagingTarget", () => {
+  it("returns undefined for empty input", () => {
+    expect(normalizeMattermostMessagingTarget("")).toBeUndefined();
+    expect(normalizeMattermostMessagingTarget("  ")).toBeUndefined();
+  });
+
+  it("normalizes channel: prefix", () => {
+    expect(normalizeMattermostMessagingTarget("channel:abc123")).toBe("channel:abc123");
+    expect(normalizeMattermostMessagingTarget("Channel:ABC")).toBe("channel:ABC");
+  });
+
+  it("normalizes group: prefix to channel:", () => {
+    expect(normalizeMattermostMessagingTarget("group:abc123")).toBe("channel:abc123");
+  });
+
+  it("normalizes user: prefix", () => {
+    expect(normalizeMattermostMessagingTarget("user:abc123")).toBe("user:abc123");
+  });
+
+  it("normalizes mattermost: prefix to user:", () => {
+    expect(normalizeMattermostMessagingTarget("mattermost:abc123")).toBe("user:abc123");
+  });
+
+  it("keeps @username targets", () => {
+    expect(normalizeMattermostMessagingTarget("@alice")).toBe("@alice");
+    expect(normalizeMattermostMessagingTarget("@Alice")).toBe("@Alice");
+  });
+
+  it("returns undefined for #channel (triggers directory lookup)", () => {
+    expect(normalizeMattermostMessagingTarget("#bookmarks")).toBeUndefined();
+    expect(normalizeMattermostMessagingTarget("#off-topic")).toBeUndefined();
+    expect(normalizeMattermostMessagingTarget("# ")).toBeUndefined();
+  });
+
+  it("returns undefined for bare names (triggers directory lookup)", () => {
+    expect(normalizeMattermostMessagingTarget("bookmarks")).toBeUndefined();
+    expect(normalizeMattermostMessagingTarget("off-topic")).toBeUndefined();
+  });
+
+  it("returns undefined for empty prefixed values", () => {
+    expect(normalizeMattermostMessagingTarget("channel:")).toBeUndefined();
+    expect(normalizeMattermostMessagingTarget("user:")).toBeUndefined();
+    expect(normalizeMattermostMessagingTarget("@")).toBeUndefined();
+    expect(normalizeMattermostMessagingTarget("#")).toBeUndefined();
+  });
+});
+
+describe("looksLikeMattermostTargetId", () => {
+  it("returns false for empty input", () => {
+    expect(looksLikeMattermostTargetId("")).toBe(false);
+    expect(looksLikeMattermostTargetId("  ")).toBe(false);
+  });
+
+  it("recognizes prefixed targets", () => {
+    expect(looksLikeMattermostTargetId("channel:abc")).toBe(true);
+    expect(looksLikeMattermostTargetId("Channel:abc")).toBe(true);
+    expect(looksLikeMattermostTargetId("user:abc")).toBe(true);
+    expect(looksLikeMattermostTargetId("group:abc")).toBe(true);
+    expect(looksLikeMattermostTargetId("mattermost:abc")).toBe(true);
+  });
+
+  it("recognizes @username", () => {
+    expect(looksLikeMattermostTargetId("@alice")).toBe(true);
+  });
+
+  it("does NOT recognize #channel (should go to directory)", () => {
+    expect(looksLikeMattermostTargetId("#bookmarks")).toBe(false);
+    expect(looksLikeMattermostTargetId("#off-topic")).toBe(false);
+  });
+
+  it("recognizes 26-char alphanumeric Mattermost IDs", () => {
+    expect(looksLikeMattermostTargetId("abcdefghijklmnopqrstuvwxyz")).toBe(true);
+    expect(looksLikeMattermostTargetId("12345678901234567890123456")).toBe(true);
+    expect(looksLikeMattermostTargetId("AbCdEf1234567890abcdef1234")).toBe(true);
+  });
+
+  it("recognizes DM channel format (26__26)", () => {
+    expect(
+      looksLikeMattermostTargetId("abcdefghijklmnopqrstuvwxyz__12345678901234567890123456"),
+    ).toBe(true);
+  });
+
+  it("rejects short strings that are not Mattermost IDs", () => {
+    expect(looksLikeMattermostTargetId("password")).toBe(false);
+    expect(looksLikeMattermostTargetId("hi")).toBe(false);
+    expect(looksLikeMattermostTargetId("bookmarks")).toBe(false);
+    expect(looksLikeMattermostTargetId("off-topic")).toBe(false);
+  });
+
+  it("rejects strings longer than 26 chars that are not DM format", () => {
+    expect(looksLikeMattermostTargetId("abcdefghijklmnopqrstuvwxyz1")).toBe(false);
+  });
+});

--- a/extensions/mattermost/src/normalize.ts
+++ b/extensions/mattermost/src/normalize.ts
@@ -25,13 +25,16 @@ export function normalizeMattermostMessagingTarget(raw: string): string | undefi
     return id ? `@${id}` : undefined;
   }
   if (trimmed.startsWith("#")) {
-    const id = trimmed.slice(1).trim();
-    return id ? `channel:${id}` : undefined;
+    // Strip # prefix and fall through to directory lookup (same as bare names).
+    // The core's resolveMessagingTarget will use the directory adapter to
+    // resolve the channel name to its Mattermost ID.
+    return undefined;
   }
-  return `channel:${trimmed}`;
+  // Bare name without prefix — return undefined to allow directory lookup
+  return undefined;
 }
 
-export function looksLikeMattermostTargetId(raw: string): boolean {
+export function looksLikeMattermostTargetId(raw: string, normalized?: string): boolean {
   const trimmed = raw.trim();
   if (!trimmed) {
     return false;
@@ -39,8 +42,9 @@ export function looksLikeMattermostTargetId(raw: string): boolean {
   if (/^(user|channel|group|mattermost):/i.test(trimmed)) {
     return true;
   }
-  if (/^[@#]/.test(trimmed)) {
+  if (trimmed.startsWith("@")) {
     return true;
   }
-  return /^[a-z0-9]{8,}$/i.test(trimmed);
+  // Mattermost IDs: 26-char alnum, or DM channels like "abc123__xyz789" (53 chars)
+  return /^[a-z0-9]{26}$/i.test(trimmed) || /^[a-z0-9]{26}__[a-z0-9]{26}$/i.test(trimmed);
 }

--- a/extensions/mattermost/src/types.ts
+++ b/extensions/mattermost/src/types.ts
@@ -65,6 +65,10 @@ export type MattermostAccountConfig = {
     /** Explicit callback URL (e.g. behind reverse proxy). */
     callbackUrl?: string;
   };
+  interactions?: {
+    /** External base URL used for Mattermost interaction callbacks. */
+    callbackBaseUrl?: string;
+  };
 };
 
 export type MattermostConfig = {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1,3 +1,7 @@
+import {
+  DISCORD_DEFAULT_INBOUND_WORKER_TIMEOUT_MS,
+  DISCORD_DEFAULT_LISTENER_TIMEOUT_MS,
+} from "../discord/monitor/timeouts.js";
 import { IRC_FIELD_HELP } from "./schema.irc.js";
 import { describeTalkSilenceTimeoutDefaults } from "./talk-defaults.js";
 
@@ -1106,8 +1110,8 @@ export const FIELD_HELP: Record<string, string> = {
   "channels.discord.retry.maxDelayMs": "Maximum retry delay cap in ms for Discord outbound calls.",
   "channels.discord.retry.jitter": "Jitter factor (0-1) applied to Discord retry delays.",
   "channels.discord.maxLinesPerMessage": "Soft max line count per Discord message (default: 17).",
-  "channels.discord.eventQueue.listenerTimeout":
-    "Canonical Discord listener timeout control in ms for gateway event handlers. Default is 120000 in RemoteClaw; set per account via channels.discord.accounts.<id>.eventQueue.listenerTimeout.",
+  "channels.discord.inboundWorker.runTimeoutMs": `Optional queued Discord inbound worker timeout in ms. This is separate from Carbon listener timeouts; defaults to ${DISCORD_DEFAULT_INBOUND_WORKER_TIMEOUT_MS} and can be disabled with 0. Set per account via channels.discord.accounts.<id>.inboundWorker.runTimeoutMs.`,
+  "channels.discord.eventQueue.listenerTimeout": `Canonical Discord listener timeout control in ms for gateway normalization/enqueue handlers. Default is ${DISCORD_DEFAULT_LISTENER_TIMEOUT_MS} in RemoteClaw; set per account via channels.discord.accounts.<id>.eventQueue.listenerTimeout.`,
   "channels.discord.eventQueue.maxQueueSize":
     "Optional Discord EventQueue capacity override (max queued events before backpressure). Set per account via channels.discord.accounts.<id>.eventQueue.maxQueueSize.",
   "channels.discord.eventQueue.maxConcurrency":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -535,6 +535,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.discord.retry.maxDelayMs": "Discord Retry Max Delay (ms)",
   "channels.discord.retry.jitter": "Discord Retry Jitter",
   "channels.discord.maxLinesPerMessage": "Discord Max Lines Per Message",
+  "channels.discord.inboundWorker.runTimeoutMs": "Discord Inbound Worker Timeout (ms)",
   "channels.discord.eventQueue.listenerTimeout": "Discord EventQueue Listener Timeout (ms)",
   "channels.discord.eventQueue.maxQueueSize": "Discord EventQueue Max Queue Size",
   "channels.discord.eventQueue.maxConcurrency": "Discord EventQueue Max Concurrency",

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -323,7 +323,22 @@ export type DiscordAccountConfig = {
   activityType?: 0 | 1 | 2 | 3 | 4 | 5;
   /** Streaming URL (Twitch/YouTube). Required when activityType=1. */
   activityUrl?: string;
-  /** Carbon EventQueue configuration for this Discord account. */
+  /**
+   * In-process worker settings for queued inbound Discord runs.
+   * This is separate from Carbon's eventQueue listener budget.
+   */
+  inboundWorker?: {
+    /**
+     * Max time (ms) a queued inbound run may execute before RemoteClaw aborts it.
+     * Defaults to 1800000 (30 minutes). Set 0 to disable the worker-owned timeout.
+     */
+    runTimeoutMs?: number;
+  };
+  /**
+   * Carbon EventQueue configuration. Controls how Discord gateway events are processed.
+   * `listenerTimeout` only covers gateway listener work such as normalization and enqueue.
+   * It does not control the lifetime of queued inbound agent turns.
+   */
   eventQueue?: {
     /** Max time (ms) a single listener can run before being killed. Default: 120000. */
     listenerTimeout?: number;

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -57,6 +57,7 @@ export type TtsConfig = {
   /** OpenAI configuration. */
   openai?: {
     apiKey?: string;
+    baseUrl?: string;
     model?: string;
     voice?: string;
   };

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -214,6 +214,7 @@ export const TtsConfigSchema = z
     openai: z
       .object({
         apiKey: z.string().optional().register(sensitive),
+        baseUrl: z.string().optional(),
         model: z.string().optional(),
         voice: z.string().optional(),
       })

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -530,6 +530,20 @@ export const DiscordAccountSchema = z
       .union([z.literal(0), z.literal(1), z.literal(2), z.literal(3), z.literal(4), z.literal(5)])
       .optional(),
     activityUrl: z.string().url().optional(),
+    inboundWorker: z
+      .object({
+        runTimeoutMs: z.number().int().nonnegative().optional(),
+      })
+      .strict()
+      .optional(),
+    eventQueue: z
+      .object({
+        listenerTimeout: z.number().int().positive().optional(),
+        maxQueueSize: z.number().int().positive().optional(),
+        maxConcurrency: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .superRefine((value, ctx) => {

--- a/src/discord/monitor/inbound-job.test.ts
+++ b/src/discord/monitor/inbound-job.test.ts
@@ -1,0 +1,148 @@
+import { Message } from "@buape/carbon";
+import { describe, expect, it } from "vitest";
+import { buildDiscordInboundJob, materializeDiscordInboundJob } from "./inbound-job.js";
+import { createBaseDiscordMessageContext } from "./message-handler.test-harness.js";
+
+describe("buildDiscordInboundJob", () => {
+  it("keeps live runtime references out of the payload", async () => {
+    const ctx = await createBaseDiscordMessageContext({
+      message: {
+        id: "m1",
+        channelId: "thread-1",
+        timestamp: new Date().toISOString(),
+        attachments: [],
+        channel: {
+          id: "thread-1",
+          isThread: () => true,
+        },
+      },
+      data: {
+        guild: { id: "g1", name: "Guild" },
+        message: {
+          id: "m1",
+          channelId: "thread-1",
+          timestamp: new Date().toISOString(),
+          attachments: [],
+          channel: {
+            id: "thread-1",
+            isThread: () => true,
+          },
+        },
+      },
+      threadChannel: {
+        id: "thread-1",
+        name: "codex",
+        parentId: "forum-1",
+        parent: {
+          id: "forum-1",
+          name: "Forum",
+        },
+        ownerId: "user-1",
+      },
+    });
+
+    const job = buildDiscordInboundJob(ctx);
+
+    expect("runtime" in job.payload).toBe(false);
+    expect("client" in job.payload).toBe(false);
+    expect("threadBindings" in job.payload).toBe(false);
+    expect("discordRestFetch" in job.payload).toBe(false);
+    expect("channel" in job.payload.message).toBe(false);
+    expect("channel" in job.payload.data.message).toBe(false);
+    expect(job.runtime.client).toBe(ctx.client);
+    expect(job.runtime.threadBindings).toBe(ctx.threadBindings);
+    expect(job.payload.threadChannel).toEqual({
+      id: "thread-1",
+      name: "codex",
+      parentId: "forum-1",
+      parent: {
+        id: "forum-1",
+        name: "Forum",
+      },
+      ownerId: "user-1",
+    });
+    expect(() => JSON.stringify(job.payload)).not.toThrow();
+  });
+
+  it("re-materializes the process context with an overridden abort signal", async () => {
+    const ctx = await createBaseDiscordMessageContext();
+    const job = buildDiscordInboundJob(ctx);
+    const overrideAbortController = new AbortController();
+
+    const rematerialized = materializeDiscordInboundJob(job, overrideAbortController.signal);
+
+    expect(rematerialized.runtime).toBe(ctx.runtime);
+    expect(rematerialized.client).toBe(ctx.client);
+    expect(rematerialized.threadBindings).toBe(ctx.threadBindings);
+    expect(rematerialized.abortSignal).toBe(overrideAbortController.signal);
+    expect(rematerialized.message).toEqual(job.payload.message);
+    expect(rematerialized.data).toEqual(job.payload.data);
+  });
+
+  it("preserves Carbon message getters across queued jobs", async () => {
+    const ctx = await createBaseDiscordMessageContext();
+    const message = new Message(
+      ctx.client as never,
+      {
+        id: "m1",
+        channel_id: "c1",
+        content: "hello",
+        attachments: [{ id: "a1", filename: "note.txt" }],
+        timestamp: new Date().toISOString(),
+        author: {
+          id: "u1",
+          username: "alice",
+          discriminator: "0",
+          avatar: null,
+        },
+        referenced_message: {
+          id: "m0",
+          channel_id: "c1",
+          content: "earlier",
+          attachments: [],
+          timestamp: new Date().toISOString(),
+          author: {
+            id: "u2",
+            username: "bob",
+            discriminator: "0",
+            avatar: null,
+          },
+          type: 0,
+          tts: false,
+          mention_everyone: false,
+          pinned: false,
+          flags: 0,
+        },
+        type: 0,
+        tts: false,
+        mention_everyone: false,
+        pinned: false,
+        flags: 0,
+      } as ConstructorParameters<typeof Message>[1],
+    );
+    const runtimeChannel = { id: "c1", isThread: () => false };
+    Object.defineProperty(message, "channel", {
+      value: runtimeChannel,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    });
+
+    const job = buildDiscordInboundJob({
+      ...ctx,
+      message,
+      data: {
+        ...ctx.data,
+        message,
+      },
+    });
+    const rematerialized = materializeDiscordInboundJob(job);
+
+    expect(job.payload.message).toBeInstanceOf(Message);
+    expect("channel" in job.payload.message).toBe(false);
+    expect(rematerialized.message.content).toBe("hello");
+    expect(rematerialized.message.attachments).toHaveLength(1);
+    expect(rematerialized.message.timestamp).toBe(message.timestamp);
+    expect(rematerialized.message.referencedMessage?.content).toBe("earlier");
+  });
+});

--- a/src/discord/monitor/inbound-job.ts
+++ b/src/discord/monitor/inbound-job.ts
@@ -1,0 +1,111 @@
+import type { DiscordMessagePreflightContext } from "./message-handler.preflight.types.js";
+
+type DiscordInboundJobRuntimeField =
+  | "runtime"
+  | "abortSignal"
+  | "guildHistories"
+  | "client"
+  | "threadBindings"
+  | "discordRestFetch";
+
+export type DiscordInboundJobRuntime = Pick<
+  DiscordMessagePreflightContext,
+  DiscordInboundJobRuntimeField
+>;
+
+export type DiscordInboundJobPayload = Omit<
+  DiscordMessagePreflightContext,
+  DiscordInboundJobRuntimeField
+>;
+
+export type DiscordInboundJob = {
+  queueKey: string;
+  payload: DiscordInboundJobPayload;
+  runtime: DiscordInboundJobRuntime;
+};
+
+export function resolveDiscordInboundJobQueueKey(ctx: DiscordMessagePreflightContext): string {
+  const sessionKey = ctx.route.sessionKey?.trim();
+  if (sessionKey) {
+    return sessionKey;
+  }
+  const baseSessionKey = ctx.baseSessionKey?.trim();
+  if (baseSessionKey) {
+    return baseSessionKey;
+  }
+  return ctx.messageChannelId;
+}
+
+export function buildDiscordInboundJob(ctx: DiscordMessagePreflightContext): DiscordInboundJob {
+  const {
+    runtime,
+    abortSignal,
+    guildHistories,
+    client,
+    threadBindings,
+    discordRestFetch,
+    message,
+    data,
+    threadChannel,
+    ...payload
+  } = ctx;
+
+  const sanitizedMessage = sanitizeDiscordInboundMessage(message);
+  return {
+    queueKey: resolveDiscordInboundJobQueueKey(ctx),
+    payload: {
+      ...payload,
+      message: sanitizedMessage,
+      data: {
+        ...data,
+        message: sanitizedMessage,
+      },
+      threadChannel: normalizeDiscordThreadChannel(threadChannel),
+    },
+    runtime: {
+      runtime,
+      abortSignal,
+      guildHistories,
+      client,
+      threadBindings,
+      discordRestFetch,
+    },
+  };
+}
+
+export function materializeDiscordInboundJob(
+  job: DiscordInboundJob,
+  abortSignal?: AbortSignal,
+): DiscordMessagePreflightContext {
+  return {
+    ...job.payload,
+    ...job.runtime,
+    abortSignal: abortSignal ?? job.runtime.abortSignal,
+  };
+}
+
+function sanitizeDiscordInboundMessage<T extends object>(message: T): T {
+  const descriptors = Object.getOwnPropertyDescriptors(message);
+  delete descriptors.channel;
+  return Object.create(Object.getPrototypeOf(message), descriptors) as T;
+}
+
+function normalizeDiscordThreadChannel(
+  threadChannel: DiscordMessagePreflightContext["threadChannel"],
+): DiscordMessagePreflightContext["threadChannel"] {
+  if (!threadChannel) {
+    return null;
+  }
+  return {
+    id: threadChannel.id,
+    name: threadChannel.name,
+    parentId: threadChannel.parentId,
+    parent: threadChannel.parent
+      ? {
+          id: threadChannel.parent.id,
+          name: threadChannel.parent.name,
+        }
+      : undefined,
+    ownerId: threadChannel.ownerId,
+  };
+}

--- a/src/discord/monitor/inbound-worker.ts
+++ b/src/discord/monitor/inbound-worker.ts
@@ -1,0 +1,105 @@
+import { createRunStateMachine } from "../../channels/run-state-machine.js";
+import { danger } from "../../globals.js";
+import { formatDurationSeconds } from "../../infra/format-time/format-duration.ts";
+import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
+import { materializeDiscordInboundJob, type DiscordInboundJob } from "./inbound-job.js";
+import type { RuntimeEnv } from "./message-handler.preflight.types.js";
+import { processDiscordMessage } from "./message-handler.process.js";
+import type { DiscordMonitorStatusSink } from "./status.js";
+import { normalizeDiscordInboundWorkerTimeoutMs, runDiscordTaskWithTimeout } from "./timeouts.js";
+
+type DiscordInboundWorkerParams = {
+  runtime: RuntimeEnv;
+  setStatus?: DiscordMonitorStatusSink;
+  abortSignal?: AbortSignal;
+  runTimeoutMs?: number;
+};
+
+export type DiscordInboundWorker = {
+  enqueue: (job: DiscordInboundJob) => void;
+  deactivate: () => void;
+};
+
+function formatDiscordRunContextSuffix(job: DiscordInboundJob): string {
+  const channelId = job.payload.messageChannelId?.trim();
+  const messageId = job.payload.data?.message?.id?.trim();
+  const details = [
+    channelId ? `channelId=${channelId}` : null,
+    messageId ? `messageId=${messageId}` : null,
+  ].filter((entry): entry is string => Boolean(entry));
+  if (details.length === 0) {
+    return "";
+  }
+  return ` (${details.join(", ")})`;
+}
+
+async function processDiscordInboundJob(params: {
+  job: DiscordInboundJob;
+  runtime: RuntimeEnv;
+  lifecycleSignal?: AbortSignal;
+  runTimeoutMs?: number;
+}) {
+  const timeoutMs = normalizeDiscordInboundWorkerTimeoutMs(params.runTimeoutMs);
+  const contextSuffix = formatDiscordRunContextSuffix(params.job);
+  await runDiscordTaskWithTimeout({
+    run: async (abortSignal) => {
+      await processDiscordMessage(materializeDiscordInboundJob(params.job, abortSignal));
+    },
+    timeoutMs,
+    abortSignals: [params.job.runtime.abortSignal, params.lifecycleSignal],
+    onTimeout: (resolvedTimeoutMs) => {
+      params.runtime.error?.(
+        danger(
+          `discord inbound worker timed out after ${formatDurationSeconds(resolvedTimeoutMs, {
+            decimals: 1,
+            unit: "seconds",
+          })}${contextSuffix}`,
+        ),
+      );
+    },
+    onErrorAfterTimeout: (error) => {
+      params.runtime.error?.(
+        danger(`discord inbound worker failed after timeout: ${String(error)}${contextSuffix}`),
+      );
+    },
+  });
+}
+
+export function createDiscordInboundWorker(
+  params: DiscordInboundWorkerParams,
+): DiscordInboundWorker {
+  const runQueue = new KeyedAsyncQueue();
+  const runState = createRunStateMachine({
+    setStatus: params.setStatus,
+    abortSignal: params.abortSignal,
+  });
+
+  return {
+    enqueue(job) {
+      void runQueue
+        .enqueue(job.queueKey, async () => {
+          if (!runState.isActive()) {
+            return;
+          }
+          runState.onRunStart();
+          try {
+            if (!runState.isActive()) {
+              return;
+            }
+            await processDiscordInboundJob({
+              job,
+              runtime: params.runtime,
+              lifecycleSignal: params.abortSignal,
+              runTimeoutMs: params.runTimeoutMs,
+            });
+          } finally {
+            runState.onRunEnd();
+          }
+        })
+        .catch((error) => {
+          params.runtime.error?.(danger(`discord inbound worker failed: ${String(error)}`));
+        });
+    },
+    deactivate: runState.deactivate,
+  };
+}

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -34,6 +34,7 @@ import { resolveDiscordChannelInfo } from "./message-utils.js";
 import { setPresence } from "./presence-cache.js";
 import { isThreadArchived } from "./thread-bindings.discord-api.js";
 import { closeDiscordThreadSessions } from "./thread-session-close.js";
+import { normalizeDiscordListenerTimeoutMs, runDiscordTaskWithTimeout } from "./timeouts.js";
 
 type LoadedConfig = ReturnType<typeof import("../../config/config.js").loadConfig>;
 type RuntimeEnv = import("../../runtime.js").RuntimeEnv;
@@ -71,15 +72,7 @@ type DiscordReactionRoutingParams = {
 };
 
 const DISCORD_SLOW_LISTENER_THRESHOLD_MS = 30_000;
-const DISCORD_DEFAULT_LISTENER_TIMEOUT_MS = 120_000;
 const discordEventQueueLog = createSubsystemLogger("discord/event-queue");
-
-function normalizeDiscordListenerTimeoutMs(raw: number | undefined): number {
-  if (!Number.isFinite(raw) || (raw ?? 0) <= 0) {
-    return DISCORD_DEFAULT_LISTENER_TIMEOUT_MS;
-  }
-  return Math.max(1_000, Math.floor(raw!));
-}
 
 function formatListenerContextValue(value: unknown): string | null {
   if (value === undefined || value === null) {
@@ -139,57 +132,44 @@ async function runDiscordListenerWithSlowLog(params: {
   logger: Logger | undefined;
   listener: string;
   event: string;
-  run: (abortSignal: AbortSignal) => Promise<void>;
+  run: (abortSignal: AbortSignal | undefined) => Promise<void>;
   timeoutMs?: number;
   context?: Record<string, unknown>;
   onError?: (err: unknown) => void;
 }) {
   const startedAt = Date.now();
   const timeoutMs = normalizeDiscordListenerTimeoutMs(params.timeoutMs);
-  let timedOut = false;
-  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
   const logger = params.logger ?? discordEventQueueLog;
-  const abortController = new AbortController();
-  const runPromise = params.run(abortController.signal).catch((err) => {
-    if (timedOut) {
-      const errorName =
-        err && typeof err === "object" && "name" in err ? String(err.name) : undefined;
-      if (abortController.signal.aborted && errorName === "AbortError") {
+  let timedOut = false;
+
+  try {
+    timedOut = await runDiscordTaskWithTimeout({
+      run: params.run,
+      timeoutMs,
+      onTimeout: (resolvedTimeoutMs) => {
+        logger.error(
+          danger(
+            `discord handler timed out after ${formatDurationSeconds(resolvedTimeoutMs, {
+              decimals: 1,
+              unit: "seconds",
+            })}${formatListenerContextSuffix(params.context)}`,
+          ),
+        );
+      },
+      onAbortAfterTimeout: () => {
         logger.warn(
           `discord handler canceled after timeout${formatListenerContextSuffix(params.context)}`,
         );
-        return;
-      }
-      logger.error(
-        danger(
-          `discord handler failed after timeout: ${String(err)}${formatListenerContextSuffix(params.context)}`,
-        ),
-      );
-      return;
-    }
-    throw err;
-  });
-
-  try {
-    const timeoutPromise = new Promise<"timeout">((resolve) => {
-      timeoutHandle = setTimeout(() => resolve("timeout"), timeoutMs);
-      timeoutHandle.unref?.();
+      },
+      onErrorAfterTimeout: (err) => {
+        logger.error(
+          danger(
+            `discord handler failed after timeout: ${String(err)}${formatListenerContextSuffix(params.context)}`,
+          ),
+        );
+      },
     });
-    const result = await Promise.race([
-      runPromise.then(() => "completed" as const),
-      timeoutPromise,
-    ]);
-    if (result === "timeout") {
-      timedOut = true;
-      abortController.abort();
-      logger.error(
-        danger(
-          `discord handler timed out after ${formatDurationSeconds(timeoutMs, {
-            decimals: 1,
-            unit: "seconds",
-          })}${formatListenerContextSuffix(params.context)}`,
-        ),
-      );
+    if (timedOut) {
       return;
     }
   } catch (err) {
@@ -199,9 +179,6 @@ async function runDiscordListenerWithSlowLog(params: {
     }
     throw err;
   } finally {
-    if (timeoutHandle) {
-      clearTimeout(timeoutHandle);
-    }
     if (!timedOut) {
       logSlowDiscordListener({
         logger: params.logger,

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -1,4 +1,4 @@
-import { ChannelType } from "@buape/carbon";
+import { ChannelType, type RequestClient } from "@buape/carbon";
 import { BlockChunker } from "../../agents/block-chunker.js";
 import { resolveAckReaction, resolveHumanDelayConfig } from "../../agents/identity.js";
 import { resolveChunkMode } from "../../auto-reply/chunk.js";
@@ -161,15 +161,17 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       }),
     );
   const statusReactionsEnabled = shouldAckReaction();
+  // Discord outbound helpers expect Carbon's request client shape explicitly.
+  const discordRest = client.rest as unknown as RequestClient;
   const discordAdapter: StatusReactionAdapter = {
     setReaction: async (emoji) => {
       await reactMessageDiscord(messageChannelId, message.id, emoji, {
-        rest: client.rest as never,
+        rest: discordRest,
       });
     },
     removeReaction: async (emoji) => {
       await removeReactionDiscord(messageChannelId, message.id, emoji, {
-        rest: client.rest as never,
+        rest: discordRest,
       });
     },
   };

--- a/src/discord/monitor/message-handler.queue.test.ts
+++ b/src/discord/monitor/message-handler.queue.test.ts
@@ -4,6 +4,7 @@ import { createNoopThreadBindingManager } from "./thread-bindings.js";
 
 const preflightDiscordMessageMock = vi.hoisted(() => vi.fn());
 const processDiscordMessageMock = vi.hoisted(() => vi.fn());
+const eventualReplyDeliveredMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./message-handler.preflight.js", () => ({
   preflightDiscordMessage: preflightDiscordMessageMock,
@@ -26,7 +27,7 @@ function createDeferred<T = void>() {
 function createHandlerParams(overrides?: {
   setStatus?: (patch: Record<string, unknown>) => void;
   abortSignal?: AbortSignal;
-  listenerTimeoutMs?: number;
+  workerRunTimeoutMs?: number;
 }) {
   const cfg: RemoteClawConfig = {
     channels: {
@@ -65,7 +66,7 @@ function createHandlerParams(overrides?: {
     threadBindings: createNoopThreadBindingManager("default"),
     setStatus: overrides?.setStatus,
     abortSignal: overrides?.abortSignal,
-    listenerTimeoutMs: overrides?.listenerTimeoutMs,
+    workerRunTimeoutMs: overrides?.workerRunTimeoutMs,
   };
 }
 
@@ -85,6 +86,19 @@ function createMessageData(messageId: string, channelId = "ch-1") {
 
 function createPreflightContext(channelId = "ch-1") {
   return {
+    data: {
+      channel_id: channelId,
+      message: {
+        id: `msg-${channelId}`,
+        channel_id: channelId,
+        attachments: [],
+      },
+    },
+    message: {
+      id: `msg-${channelId}`,
+      channel_id: channelId,
+      attachments: [],
+    },
     route: {
       sessionKey: `agent:main:discord:channel:${channelId}`,
     },
@@ -169,7 +183,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
     });
   });
 
-  it("applies listener timeout to queued runs so stalled runs do not block the queue", async () => {
+  it("applies explicit inbound worker timeout to queued runs so stalled runs do not block the queue", async () => {
     vi.useFakeTimers();
     try {
       preflightDiscordMessageMock.mockReset();
@@ -191,7 +205,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
           createPreflightContext(params.data.channel_id),
       );
 
-      const params = createHandlerParams({ listenerTimeoutMs: 50 });
+      const params = createHandlerParams({ workerRunTimeoutMs: 50 });
       const handler = createDiscordMessageHandler(params);
 
       await expect(
@@ -211,7 +225,50 @@ describe("createDiscordMessageHandler queue behavior", () => {
         | undefined;
       expect(firstCtx?.abortSignal?.aborted).toBe(true);
       expect(params.runtime.error).toHaveBeenCalledWith(
-        expect.stringContaining("discord queued run timed out after"),
+        expect.stringContaining("discord inbound worker timed out after"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not time out queued runs when the inbound worker timeout is disabled", async () => {
+    vi.useFakeTimers();
+    try {
+      preflightDiscordMessageMock.mockReset();
+      processDiscordMessageMock.mockReset();
+      eventualReplyDeliveredMock.mockReset();
+
+      processDiscordMessageMock.mockImplementationOnce(
+        async (ctx: { abortSignal?: AbortSignal }) => {
+          await new Promise<void>((resolve) => {
+            setTimeout(() => {
+              if (!ctx.abortSignal?.aborted) {
+                eventualReplyDeliveredMock();
+              }
+              resolve();
+            }, 80);
+          });
+        },
+      );
+      preflightDiscordMessageMock.mockImplementation(
+        async (params: { data: { channel_id: string } }) =>
+          createPreflightContext(params.data.channel_id),
+      );
+
+      const params = createHandlerParams({ workerRunTimeoutMs: 0 });
+      const handler = createDiscordMessageHandler(params);
+
+      await expect(
+        handler(createMessageData("m-1") as never, {} as never),
+      ).resolves.toBeUndefined();
+
+      await vi.advanceTimersByTimeAsync(80);
+      await Promise.resolve();
+
+      expect(eventualReplyDeliveredMock).toHaveBeenCalledTimes(1);
+      expect(params.runtime.error).not.toHaveBeenCalledWith(
+        expect.stringContaining("discord inbound worker timed out after"),
       );
     } finally {
       vi.useRealTimers();

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -3,18 +3,13 @@ import {
   createChannelInboundDebouncer,
   shouldDebounceTextInbound,
 } from "../../channels/inbound-debounce-policy.js";
-import { createRunStateMachine } from "../../channels/run-state-machine.js";
 import { resolveOpenProviderRuntimeGroupPolicy } from "../../config/runtime-group-policy.js";
 import { danger } from "../../globals.js";
-import { formatDurationSeconds } from "../../infra/format-time/format-duration.ts";
-import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
+import { buildDiscordInboundJob } from "./inbound-job.js";
+import { createDiscordInboundWorker } from "./inbound-worker.js";
 import type { DiscordMessageEvent, DiscordMessageHandler } from "./listeners.js";
 import { preflightDiscordMessage } from "./message-handler.preflight.js";
-import type {
-  DiscordMessagePreflightContext,
-  DiscordMessagePreflightParams,
-} from "./message-handler.preflight.types.js";
-import { processDiscordMessage } from "./message-handler.process.js";
+import type { DiscordMessagePreflightParams } from "./message-handler.preflight.types.js";
 import {
   hasDiscordMessageStickers,
   resolveDiscordMessageChannelId,
@@ -28,153 +23,12 @@ type DiscordMessageHandlerParams = Omit<
 > & {
   setStatus?: DiscordMonitorStatusSink;
   abortSignal?: AbortSignal;
-  listenerTimeoutMs?: number;
+  workerRunTimeoutMs?: number;
 };
 
 export type DiscordMessageHandlerWithLifecycle = DiscordMessageHandler & {
   deactivate: () => void;
 };
-
-const DEFAULT_DISCORD_RUN_TIMEOUT_MS = 120_000;
-const MAX_DISCORD_TIMEOUT_MS = 2_147_483_647;
-
-function normalizeDiscordRunTimeoutMs(timeoutMs?: number): number {
-  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    return DEFAULT_DISCORD_RUN_TIMEOUT_MS;
-  }
-  return Math.max(1, Math.min(Math.floor(timeoutMs), MAX_DISCORD_TIMEOUT_MS));
-}
-
-function isAbortError(error: unknown): boolean {
-  if (typeof error !== "object" || error === null) {
-    return false;
-  }
-  return "name" in error && String((error as { name?: unknown }).name) === "AbortError";
-}
-
-function formatDiscordRunContextSuffix(ctx: DiscordMessagePreflightContext): string {
-  const eventData = ctx as {
-    data?: {
-      channel_id?: string;
-      message?: {
-        id?: string;
-      };
-    };
-  };
-  const channelId = ctx.messageChannelId?.trim() || eventData.data?.channel_id?.trim();
-  const messageId = eventData.data?.message?.id?.trim();
-  const details = [
-    channelId ? `channelId=${channelId}` : null,
-    messageId ? `messageId=${messageId}` : null,
-  ].filter((entry): entry is string => Boolean(entry));
-  if (details.length === 0) {
-    return "";
-  }
-  return ` (${details.join(", ")})`;
-}
-
-function mergeAbortSignals(signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
-  const activeSignals = signals.filter((signal): signal is AbortSignal => Boolean(signal));
-  if (activeSignals.length === 0) {
-    return undefined;
-  }
-  if (activeSignals.length === 1) {
-    return activeSignals[0];
-  }
-  if (typeof AbortSignal.any === "function") {
-    return AbortSignal.any(activeSignals);
-  }
-  const fallbackController = new AbortController();
-  for (const signal of activeSignals) {
-    if (signal.aborted) {
-      fallbackController.abort();
-      return fallbackController.signal;
-    }
-  }
-  const abortFallback = () => {
-    fallbackController.abort();
-    for (const signal of activeSignals) {
-      signal.removeEventListener("abort", abortFallback);
-    }
-  };
-  for (const signal of activeSignals) {
-    signal.addEventListener("abort", abortFallback, { once: true });
-  }
-  return fallbackController.signal;
-}
-
-async function processDiscordRunWithTimeout(params: {
-  ctx: DiscordMessagePreflightContext;
-  runtime: DiscordMessagePreflightParams["runtime"];
-  lifecycleSignal?: AbortSignal;
-  timeoutMs?: number;
-}) {
-  const timeoutMs = normalizeDiscordRunTimeoutMs(params.timeoutMs);
-  const timeoutAbortController = new AbortController();
-  const combinedSignal = mergeAbortSignals([
-    params.ctx.abortSignal,
-    params.lifecycleSignal,
-    timeoutAbortController.signal,
-  ]);
-  const processCtx =
-    combinedSignal && combinedSignal !== params.ctx.abortSignal
-      ? { ...params.ctx, abortSignal: combinedSignal }
-      : params.ctx;
-  const contextSuffix = formatDiscordRunContextSuffix(params.ctx);
-  let timedOut = false;
-  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
-  const processPromise = processDiscordMessage(processCtx).catch((error) => {
-    if (timedOut) {
-      if (timeoutAbortController.signal.aborted && isAbortError(error)) {
-        return;
-      }
-      params.runtime.error?.(
-        danger(`discord queued run failed after timeout: ${String(error)}${contextSuffix}`),
-      );
-      return;
-    }
-    throw error;
-  });
-
-  try {
-    const timeoutPromise = new Promise<"timeout">((resolve) => {
-      timeoutHandle = setTimeout(() => resolve("timeout"), timeoutMs);
-      timeoutHandle.unref?.();
-    });
-    const result = await Promise.race([
-      processPromise.then(() => "completed" as const),
-      timeoutPromise,
-    ]);
-    if (result === "timeout") {
-      timedOut = true;
-      timeoutAbortController.abort();
-      params.runtime.error?.(
-        danger(
-          `discord queued run timed out after ${formatDurationSeconds(timeoutMs, {
-            decimals: 1,
-            unit: "seconds",
-          })}${contextSuffix}`,
-        ),
-      );
-    }
-  } finally {
-    if (timeoutHandle) {
-      clearTimeout(timeoutHandle);
-    }
-  }
-}
-
-function resolveDiscordRunQueueKey(ctx: DiscordMessagePreflightContext): string {
-  const sessionKey = ctx.route.sessionKey?.trim();
-  if (sessionKey) {
-    return sessionKey;
-  }
-  const baseSessionKey = ctx.baseSessionKey?.trim();
-  if (baseSessionKey) {
-    return baseSessionKey;
-  }
-  return ctx.messageChannelId;
-}
 
 export function createDiscordMessageHandler(
   params: DiscordMessageHandlerParams,
@@ -188,38 +42,12 @@ export function createDiscordMessageHandler(
     params.discordConfig?.ackReactionScope ??
     params.cfg.messages?.ackReactionScope ??
     "group-mentions";
-  const runQueue = new KeyedAsyncQueue();
-  const runState = createRunStateMachine({
+  const inboundWorker = createDiscordInboundWorker({
+    runtime: params.runtime,
     setStatus: params.setStatus,
     abortSignal: params.abortSignal,
+    runTimeoutMs: params.workerRunTimeoutMs,
   });
-
-  const enqueueDiscordRun = (ctx: DiscordMessagePreflightContext) => {
-    const queueKey = resolveDiscordRunQueueKey(ctx);
-    void runQueue
-      .enqueue(queueKey, async () => {
-        if (!runState.isActive()) {
-          return;
-        }
-        runState.onRunStart();
-        try {
-          if (!runState.isActive()) {
-            return;
-          }
-          await processDiscordRunWithTimeout({
-            ctx,
-            runtime: params.runtime,
-            lifecycleSignal: params.abortSignal,
-            timeoutMs: params.listenerTimeoutMs,
-          });
-        } finally {
-          runState.onRunEnd();
-        }
-      })
-      .catch((err) => {
-        params.runtime.error?.(danger(`discord process failed: ${String(err)}`));
-      });
-  };
 
   const { debouncer } = createChannelInboundDebouncer<{
     data: DiscordMessageEvent;
@@ -279,7 +107,7 @@ export function createDiscordMessageHandler(
         if (!ctx) {
           return;
         }
-        enqueueDiscordRun(ctx);
+        inboundWorker.enqueue(buildDiscordInboundJob(ctx));
         return;
       }
       const combinedBaseText = entries
@@ -324,7 +152,7 @@ export function createDiscordMessageHandler(
           ctxBatch.MessageSidLast = ids[ids.length - 1];
         }
       }
-      enqueueDiscordRun(ctx);
+      inboundWorker.enqueue(buildDiscordInboundJob(ctx));
     },
     onError: (err) => {
       params.runtime.error?.(danger(`discord debounce flush failed: ${String(err)}`));
@@ -352,7 +180,7 @@ export function createDiscordMessageHandler(
     }
   };
 
-  handler.deactivate = runState.deactivate;
+  handler.deactivate = inboundWorker.deactivate;
 
   return handler;
 }

--- a/src/discord/monitor/provider.test.ts
+++ b/src/discord/monitor/provider.test.ts
@@ -20,6 +20,7 @@ const {
   clientGetPluginMock,
   createDiscordAutoPresenceControllerMock,
   createDiscordNativeCommandMock,
+  createDiscordMessageHandlerMock,
   createNoopThreadBindingManagerMock,
   createThreadBindingManagerMock,
   createdBindingManagers,
@@ -42,6 +43,14 @@ const {
     clientFetchUserMock: vi.fn(async (_target?: string) => ({ id: "bot-1" })),
     clientGetPluginMock: vi.fn((_name?: string): unknown => undefined),
     createDiscordNativeCommandMock: vi.fn(() => ({ name: "mock-command" })),
+    createDiscordMessageHandlerMock: vi.fn(() =>
+      Object.assign(
+        vi.fn(async () => undefined),
+        {
+          deactivate: vi.fn(),
+        },
+      ),
+    ),
     createNoopThreadBindingManagerMock: vi.fn(() => {
       const manager = { stop: vi.fn() };
       createdBindingManagers.push(manager);
@@ -215,7 +224,7 @@ vi.mock("./listeners.js", () => ({
 }));
 
 vi.mock("./message-handler.js", () => ({
-  createDiscordMessageHandler: () => ({ handle: vi.fn() }),
+  createDiscordMessageHandler: createDiscordMessageHandlerMock,
 }));
 
 vi.mock("./native-command.js", () => ({
@@ -276,6 +285,14 @@ describe("monitorDiscordProvider", () => {
       refresh: vi.fn(),
       runNow: vi.fn(),
     }));
+    createDiscordMessageHandlerMock.mockClear().mockImplementation(() =>
+      Object.assign(
+        vi.fn(async () => undefined),
+        {
+          deactivate: vi.fn(),
+        },
+      ),
+    );
     clientFetchUserMock.mockClear().mockResolvedValue({ id: "bot-1" });
     clientGetPluginMock.mockClear().mockReturnValue(undefined);
     createDiscordNativeCommandMock.mockClear().mockReturnValue({ name: "mock-command" });
@@ -350,6 +367,100 @@ describe("monitorDiscordProvider", () => {
     };
     expect(lifecycleArgs.pendingGatewayErrors).toHaveLength(1);
     expect(String(lifecycleArgs.pendingGatewayErrors?.[0])).toContain("4014");
+  });
+
+  it("passes default eventQueue.listenerTimeout of 120s to Carbon Client", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+    });
+
+    const eventQueue = getConstructedEventQueue();
+    expect(eventQueue).toBeDefined();
+    expect(eventQueue?.listenerTimeout).toBe(120_000);
+  });
+
+  it("forwards custom eventQueue config from discord config to Carbon Client", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+
+    resolveDiscordAccountMock.mockImplementation(() => ({
+      accountId: "default",
+      token: "cfg-token",
+      config: {
+        commands: { native: true, nativeSkills: false },
+        voice: { enabled: false },
+        agentComponents: { enabled: false },
+        execApprovals: { enabled: false },
+        eventQueue: { listenerTimeout: 300_000 },
+      },
+    }));
+
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+    });
+
+    const eventQueue = getConstructedEventQueue();
+    expect(eventQueue?.listenerTimeout).toBe(300_000);
+  });
+
+  it("does not reuse eventQueue.listenerTimeout as the queued inbound worker timeout", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+
+    resolveDiscordAccountMock.mockImplementation(() => ({
+      accountId: "default",
+      token: "cfg-token",
+      config: {
+        commands: { native: true, nativeSkills: false },
+        voice: { enabled: false },
+        agentComponents: { enabled: false },
+        execApprovals: { enabled: false },
+        eventQueue: { listenerTimeout: 50_000 },
+      },
+    }));
+
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+    });
+
+    expect(createDiscordMessageHandlerMock).toHaveBeenCalledTimes(1);
+    const firstCall = createDiscordMessageHandlerMock.mock.calls.at(0) as
+      | [{ workerRunTimeoutMs?: number; listenerTimeoutMs?: number }]
+      | undefined;
+    const params = firstCall?.[0];
+    expect(params?.workerRunTimeoutMs).toBeUndefined();
+    expect("listenerTimeoutMs" in (params ?? {})).toBe(false);
+  });
+
+  it("forwards inbound worker timeout config to the Discord message handler", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+
+    resolveDiscordAccountMock.mockImplementation(() => ({
+      accountId: "default",
+      token: "cfg-token",
+      config: {
+        commands: { native: true, nativeSkills: false },
+        voice: { enabled: false },
+        agentComponents: { enabled: false },
+        execApprovals: { enabled: false },
+        inboundWorker: { runTimeoutMs: 300_000 },
+      },
+    }));
+
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+    });
+
+    expect(createDiscordMessageHandlerMock).toHaveBeenCalledTimes(1);
+    const firstCall = createDiscordMessageHandlerMock.mock.calls.at(0) as
+      | [{ workerRunTimeoutMs?: number }]
+      | undefined;
+    const params = firstCall?.[0];
+    expect(params?.workerRunTimeoutMs).toBe(300_000);
   });
 
   it("registers plugin commands as native Discord commands", async () => {

--- a/src/discord/monitor/provider.test.ts
+++ b/src/discord/monitor/provider.test.ts
@@ -16,6 +16,7 @@ type PluginCommandSpecMock = {
 };
 
 const {
+  clientConstructorOptionsMock,
   clientFetchUserMock,
   clientGetPluginMock,
   createDiscordAutoPresenceControllerMock,
@@ -33,6 +34,7 @@ const {
 } = vi.hoisted(() => {
   const createdBindingManagers: Array<{ stop: ReturnType<typeof vi.fn> }> = [];
   return {
+    clientConstructorOptionsMock: vi.fn(),
     createDiscordAutoPresenceControllerMock: vi.fn(() => ({
       enabled: false,
       start: vi.fn(),
@@ -92,9 +94,12 @@ vi.mock("@buape/carbon", () => {
   class Client {
     listeners: unknown[];
     rest: { put: ReturnType<typeof vi.fn> };
-    constructor(_options: unknown, handlers: { listeners?: unknown[] }) {
+    options: unknown;
+    constructor(options: unknown, handlers: { listeners?: unknown[] }) {
+      this.options = options;
       this.listeners = handlers.listeners ?? [];
       this.rest = { put: vi.fn(async () => undefined) };
+      clientConstructorOptionsMock(options);
     }
     async handleDeployRequest() {
       return undefined;
@@ -276,6 +281,14 @@ describe("monitorDiscordProvider", () => {
         },
       },
     }) as RemoteClawConfig;
+
+  const getConstructedEventQueue = (): { listenerTimeout?: number } | undefined => {
+    expect(clientConstructorOptionsMock).toHaveBeenCalledTimes(1);
+    const opts = clientConstructorOptionsMock.mock.calls[0]?.[0] as {
+      eventQueue?: { listenerTimeout?: number };
+    };
+    return opts.eventQueue;
+  };
 
   beforeEach(() => {
     createDiscordAutoPresenceControllerMock.mockClear().mockImplementation(() => ({

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -424,8 +424,9 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     if (voiceEnabled) {
       clientPlugins.push(new VoicePlugin());
     }
-    // Pass eventQueue config to Carbon so the listener timeout can be tuned.
-    // Default listenerTimeout is 120s (Carbon defaults to 30s which is too short for LLM calls).
+    // Pass eventQueue config to Carbon so the gateway listener budget can be tuned.
+    // Default listenerTimeout is 120s (Carbon defaults to 30s, which is too short for some
+    // Discord normalization/enqueue work).
     const eventQueueOpts = {
       listenerTimeout: 120_000,
       ...discordCfg.eventQueue,
@@ -507,7 +508,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       runtime,
       setStatus: opts.setStatus,
       abortSignal: opts.abortSignal,
-      listenerTimeoutMs: eventQueueOpts.listenerTimeout,
+      workerRunTimeoutMs: discordCfg.inboundWorker?.runTimeoutMs,
       botUserId,
       guildHistories,
       historyLimit,

--- a/src/discord/monitor/timeouts.ts
+++ b/src/discord/monitor/timeouts.ts
@@ -1,0 +1,120 @@
+const MAX_DISCORD_TIMEOUT_MS = 2_147_483_647;
+
+export const DISCORD_DEFAULT_LISTENER_TIMEOUT_MS = 120_000;
+export const DISCORD_DEFAULT_INBOUND_WORKER_TIMEOUT_MS = 30 * 60_000;
+
+function clampDiscordTimeoutMs(timeoutMs: number, minimumMs: number): number {
+  return Math.max(minimumMs, Math.min(Math.floor(timeoutMs), MAX_DISCORD_TIMEOUT_MS));
+}
+
+export function normalizeDiscordListenerTimeoutMs(raw: number | undefined): number {
+  if (!Number.isFinite(raw) || (raw ?? 0) <= 0) {
+    return DISCORD_DEFAULT_LISTENER_TIMEOUT_MS;
+  }
+  return clampDiscordTimeoutMs(raw!, 1_000);
+}
+
+export function normalizeDiscordInboundWorkerTimeoutMs(
+  raw: number | undefined,
+): number | undefined {
+  if (raw === 0) {
+    return undefined;
+  }
+  if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 0) {
+    return DISCORD_DEFAULT_INBOUND_WORKER_TIMEOUT_MS;
+  }
+  return clampDiscordTimeoutMs(raw, 1);
+}
+
+export function isAbortError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  return "name" in error && String((error as { name?: unknown }).name) === "AbortError";
+}
+
+export function mergeAbortSignals(
+  signals: Array<AbortSignal | undefined>,
+): AbortSignal | undefined {
+  const activeSignals = signals.filter((signal): signal is AbortSignal => Boolean(signal));
+  if (activeSignals.length === 0) {
+    return undefined;
+  }
+  if (activeSignals.length === 1) {
+    return activeSignals[0];
+  }
+  if (typeof AbortSignal.any === "function") {
+    return AbortSignal.any(activeSignals);
+  }
+  const fallbackController = new AbortController();
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      fallbackController.abort();
+      return fallbackController.signal;
+    }
+  }
+  const abortFallback = () => {
+    fallbackController.abort();
+    for (const signal of activeSignals) {
+      signal.removeEventListener("abort", abortFallback);
+    }
+  };
+  for (const signal of activeSignals) {
+    signal.addEventListener("abort", abortFallback, { once: true });
+  }
+  return fallbackController.signal;
+}
+
+export async function runDiscordTaskWithTimeout(params: {
+  run: (abortSignal: AbortSignal | undefined) => Promise<void>;
+  timeoutMs?: number;
+  abortSignals?: Array<AbortSignal | undefined>;
+  onTimeout: (timeoutMs: number) => void;
+  onAbortAfterTimeout?: () => void;
+  onErrorAfterTimeout?: (error: unknown) => void;
+}): Promise<boolean> {
+  const timeoutAbortController = params.timeoutMs ? new AbortController() : undefined;
+  const mergedAbortSignal = mergeAbortSignals([
+    ...(params.abortSignals ?? []),
+    timeoutAbortController?.signal,
+  ]);
+
+  let timedOut = false;
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const runPromise = params.run(mergedAbortSignal).catch((error) => {
+    if (!timedOut) {
+      throw error;
+    }
+    if (timeoutAbortController?.signal.aborted && isAbortError(error)) {
+      params.onAbortAfterTimeout?.();
+      return;
+    }
+    params.onErrorAfterTimeout?.(error);
+  });
+
+  try {
+    if (!params.timeoutMs) {
+      await runPromise;
+      return false;
+    }
+    const timeoutPromise = new Promise<"timeout">((resolve) => {
+      timeoutHandle = setTimeout(() => resolve("timeout"), params.timeoutMs);
+      timeoutHandle.unref?.();
+    });
+    const result = await Promise.race([
+      runPromise.then(() => "completed" as const),
+      timeoutPromise,
+    ]);
+    if (result === "timeout") {
+      timedOut = true;
+      timeoutAbortController?.abort();
+      params.onTimeout(params.timeoutMs);
+      return true;
+    }
+    return false;
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}

--- a/src/discord/voice/manager.ts
+++ b/src/discord/voice/manager.ts
@@ -648,7 +648,11 @@ export class DiscordVoiceManager {
       cfg: this.params.cfg,
       override: this.params.discordConfig.voice?.tts,
     });
-    const directive = parseTtsDirectives(replyText, ttsConfig.modelOverrides);
+    const directive = parseTtsDirectives(
+      replyText,
+      ttsConfig.modelOverrides,
+      ttsConfig.openai.baseUrl,
+    );
     const speakText = directive.overrides.ttsText ?? directive.cleanedText.trim();
     if (!speakText) {
       logVoiceVerbose(

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -356,7 +356,7 @@ export type { ScopeTokenProvider } from "./fetch-auth.js";
 export { rawDataToString } from "../infra/ws.js";
 export { isWSLSync, isWSL2Sync, isWSLEnv } from "../infra/wsl.js";
 export { isTruthyEnvValue } from "../infra/env.js";
-export { resolveToolsBySender } from "../config/group-policy.js";
+export { resolveChannelGroupRequireMention, resolveToolsBySender } from "../config/group-policy.js";
 export {
   buildPendingHistoryContextFromMap,
   clearHistoryEntries,

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -37,6 +37,7 @@ export type {
   ChannelMessageActionAdapter,
   ChannelMessageActionName,
 } from "../channels/plugins/types.js";
+export type { ChannelDirectoryEntry } from "../channels/plugins/types.core.js";
 export type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 export { createReplyPrefixOptions } from "../channels/reply-prefix.js";
 export { createTypingCallbacks } from "../channels/typing.js";
@@ -59,6 +60,7 @@ export {
 } from "../config/zod-schema.core.js";
 export { createDedupeCache } from "../infra/dedupe.js";
 export { rawDataToString } from "../infra/ws.js";
+export { registerPluginHttpRoute } from "../plugins/http-registry.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export type { PluginRuntime } from "../plugins/runtime/types.js";
 export type { RemoteClawPluginApi } from "../plugins/types.js";

--- a/src/tts/providers/openai.ts
+++ b/src/tts/providers/openai.ts
@@ -9,6 +9,7 @@ export const openaiTtsProvider: TtsProviderImpl = {
     const buffer = await openaiTTS({
       text: req.text,
       apiKey: req.apiKey!,
+      baseUrl: req.baseUrl ?? "https://api.openai.com/v1",
       model: req.model ?? "gpt-4o-mini-tts",
       voice: req.voice ?? "alloy",
       responseFormat: format,

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -8,6 +8,7 @@ import type {
 } from "./tts.js";
 
 const DEFAULT_ELEVENLABS_BASE_URL = "https://api.elevenlabs.io";
+export const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 const TEMP_FILE_CLEANUP_DELAY_MS = 5 * 60 * 1000; // 5 minutes
 
 export function isValidVoiceId(voiceId: string): boolean {
@@ -18,6 +19,14 @@ function normalizeElevenLabsBaseUrl(baseUrl: string): string {
   const trimmed = baseUrl.trim();
   if (!trimmed) {
     return DEFAULT_ELEVENLABS_BASE_URL;
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+function normalizeOpenAITtsBaseUrl(baseUrl?: string): string {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return DEFAULT_OPENAI_BASE_URL;
   }
   return trimmed.replace(/\/+$/, "");
 }
@@ -89,6 +98,7 @@ function parseNumberValue(value: string): number | undefined {
 export function parseTtsDirectives(
   text: string,
   policy: ResolvedTtsModelOverrides,
+  openaiBaseUrl?: string,
 ): TtsDirectiveParseResult {
   if (!policy.enabled) {
     return { cleanedText: text, overrides: {}, warnings: [], hasDirective: false };
@@ -141,7 +151,7 @@ export function parseTtsDirectives(
             if (!policy.allowVoice) {
               break;
             }
-            if (isValidOpenAIVoice(rawValue)) {
+            if (isValidOpenAIVoice(rawValue, openaiBaseUrl)) {
               overrides.openai = { ...overrides.openai, voice: rawValue };
             } else {
               warnings.push(`invalid OpenAI voice "${rawValue}"`);
@@ -170,7 +180,7 @@ export function parseTtsDirectives(
             if (!policy.allowModelId) {
               break;
             }
-            if (isValidOpenAIModel(rawValue)) {
+            if (isValidOpenAIModel(rawValue, openaiBaseUrl)) {
               overrides.openai = { ...overrides.openai, model: rawValue };
             } else {
               overrides.elevenlabs = { ...overrides.elevenlabs, modelId: rawValue };
@@ -325,14 +335,14 @@ export const OPENAI_TTS_MODELS = ["gpt-4o-mini-tts", "tts-1", "tts-1-hd"] as con
  * Note: Read at runtime (not module load) to support config.env loading.
  */
 function getOpenAITtsBaseUrl(): string {
-  return (process.env.OPENAI_TTS_BASE_URL?.trim() || "https://api.openai.com/v1").replace(
-    /\/+$/,
-    "",
-  );
+  return normalizeOpenAITtsBaseUrl(process.env.OPENAI_TTS_BASE_URL);
 }
 
-function isCustomOpenAIEndpoint(): boolean {
-  return getOpenAITtsBaseUrl() !== "https://api.openai.com/v1";
+function isCustomOpenAIEndpoint(baseUrl?: string): boolean {
+  if (baseUrl != null) {
+    return normalizeOpenAITtsBaseUrl(baseUrl) !== DEFAULT_OPENAI_BASE_URL;
+  }
+  return getOpenAITtsBaseUrl() !== DEFAULT_OPENAI_BASE_URL;
 }
 export const OPENAI_TTS_VOICES = [
   "alloy",
@@ -353,17 +363,17 @@ export const OPENAI_TTS_VOICES = [
 
 type OpenAiTtsVoice = (typeof OPENAI_TTS_VOICES)[number];
 
-export function isValidOpenAIModel(model: string): boolean {
+export function isValidOpenAIModel(model: string, baseUrl?: string): boolean {
   // Allow any model when using custom endpoint (e.g., Kokoro, LocalAI)
-  if (isCustomOpenAIEndpoint()) {
+  if (isCustomOpenAIEndpoint(baseUrl)) {
     return true;
   }
   return OPENAI_TTS_MODELS.includes(model as (typeof OPENAI_TTS_MODELS)[number]);
 }
 
-export function isValidOpenAIVoice(voice: string): voice is OpenAiTtsVoice {
+export function isValidOpenAIVoice(voice: string, baseUrl?: string): voice is OpenAiTtsVoice {
   // Allow any voice when using custom endpoint (e.g., Kokoro Chinese voices)
-  if (isCustomOpenAIEndpoint()) {
+  if (isCustomOpenAIEndpoint(baseUrl)) {
     return true;
   }
   return OPENAI_TTS_VOICES.includes(voice as OpenAiTtsVoice);
@@ -463,17 +473,18 @@ export async function elevenLabsTTS(params: {
 export async function openaiTTS(params: {
   text: string;
   apiKey: string;
+  baseUrl: string;
   model: string;
   voice: string;
   responseFormat: "mp3" | "opus" | "pcm";
   timeoutMs: number;
 }): Promise<Buffer> {
-  const { text, apiKey, model, voice, responseFormat, timeoutMs } = params;
+  const { text, apiKey, baseUrl, model, voice, responseFormat, timeoutMs } = params;
 
-  if (!isValidOpenAIModel(model)) {
+  if (!isValidOpenAIModel(model, baseUrl)) {
     throw new Error(`Invalid model: ${model}`);
   }
-  if (!isValidOpenAIVoice(voice)) {
+  if (!isValidOpenAIVoice(voice, baseUrl)) {
     throw new Error(`Invalid voice: ${voice}`);
   }
 
@@ -481,7 +492,7 @@ export async function openaiTTS(params: {
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(`${getOpenAITtsBaseUrl()}/audio/speech`, {
+    const response = await fetch(`${baseUrl}/audio/speech`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${apiKey}`,

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -289,7 +289,7 @@ describe("tts", () => {
   });
 
   describe("resolveTtsConfig – openai.baseUrl", () => {
-    const baseCfg: OpenClawConfig = {
+    const baseCfg: RemoteClawConfig = {
       agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
       messages: { tts: {} },
     };
@@ -309,7 +309,7 @@ describe("tts", () => {
     });
 
     it("config baseUrl takes precedence over env var", () => {
-      const cfg: OpenClawConfig = {
+      const cfg: RemoteClawConfig = {
         ...baseCfg,
         messages: {
           tts: { openai: { baseUrl: "http://my-server:9000/v1" } },
@@ -322,7 +322,7 @@ describe("tts", () => {
     });
 
     it("strips trailing slashes from the resolved baseUrl", () => {
-      const cfg: OpenClawConfig = {
+      const cfg: RemoteClawConfig = {
         ...baseCfg,
         messages: {
           tts: { openai: { baseUrl: "http://my-server:9000/v1///" } },

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { RemoteClawConfig } from "../config/config.js";
-import { withEnvAsync } from "../test-utils/env.js";
+import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import * as tts from "./tts.js";
 
 const { _test, resolveTtsConfig, maybeApplyTtsToPayload, getTtsProvider } = tts;
@@ -290,7 +290,7 @@ describe("tts", () => {
 
   describe("resolveTtsConfig – openai.baseUrl", () => {
     const baseCfg: RemoteClawConfig = {
-      agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+      agents: { defaults: {} },
       messages: { tts: {} },
     };
 

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -60,6 +60,10 @@ describe("tts", () => {
       expect(isValidOpenAIVoice("alloy ")).toBe(false);
       expect(isValidOpenAIVoice(" alloy")).toBe(false);
     });
+
+    it("treats the default endpoint with trailing slash as the default endpoint", () => {
+      expect(isValidOpenAIVoice("kokoro-custom-voice", "https://api.openai.com/v1/")).toBe(false);
+    });
   });
 
   describe("isValidOpenAIModel", () => {
@@ -81,6 +85,10 @@ describe("tts", () => {
       for (const testCase of cases) {
         expect(isValidOpenAIModel(testCase.model), testCase.model).toBe(testCase.expected);
       }
+    });
+
+    it("treats the default endpoint with trailing slash as the default endpoint", () => {
+      expect(isValidOpenAIModel("kokoro-custom-model", "https://api.openai.com/v1/")).toBe(false);
     });
   });
 
@@ -208,6 +216,29 @@ describe("tts", () => {
       expect(result.cleanedText).toBe(input);
       expect(result.overrides.provider).toBeUndefined();
     });
+
+    it("accepts custom voices and models when openaiBaseUrl is a non-default endpoint", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true });
+      const input = "Hello [[tts:voice=kokoro-chinese model=kokoro-v1]] world";
+      const customBaseUrl = "http://localhost:8880/v1";
+
+      const result = parseTtsDirectives(input, policy, customBaseUrl);
+
+      expect(result.overrides.openai?.voice).toBe("kokoro-chinese");
+      expect(result.overrides.openai?.model).toBe("kokoro-v1");
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it("rejects unknown voices and models when openaiBaseUrl is the default OpenAI endpoint", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true });
+      const input = "Hello [[tts:voice=kokoro-chinese model=kokoro-v1]] world";
+      const defaultBaseUrl = "https://api.openai.com/v1";
+
+      const result = parseTtsDirectives(input, policy, defaultBaseUrl);
+
+      expect(result.overrides.openai?.voice).toBeUndefined();
+      expect(result.warnings).toContain('invalid OpenAI voice "kokoro-chinese"');
+    });
   });
 
   describe("getTtsProvider", () => {
@@ -254,6 +285,58 @@ describe("tts", () => {
         });
         expect(provider).toBe(testCase.expected);
       }
+    });
+  });
+
+  describe("resolveTtsConfig – openai.baseUrl", () => {
+    const baseCfg: OpenClawConfig = {
+      agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+      messages: { tts: {} },
+    };
+
+    it("defaults to the official OpenAI endpoint", () => {
+      withEnv({ OPENAI_TTS_BASE_URL: undefined }, () => {
+        const config = resolveTtsConfig(baseCfg);
+        expect(config.openai.baseUrl).toBe("https://api.openai.com/v1");
+      });
+    });
+
+    it("picks up OPENAI_TTS_BASE_URL env var when no config baseUrl is set", () => {
+      withEnv({ OPENAI_TTS_BASE_URL: "http://localhost:8880/v1" }, () => {
+        const config = resolveTtsConfig(baseCfg);
+        expect(config.openai.baseUrl).toBe("http://localhost:8880/v1");
+      });
+    });
+
+    it("config baseUrl takes precedence over env var", () => {
+      const cfg: OpenClawConfig = {
+        ...baseCfg,
+        messages: {
+          tts: { openai: { baseUrl: "http://my-server:9000/v1" } },
+        },
+      };
+      withEnv({ OPENAI_TTS_BASE_URL: "http://localhost:8880/v1" }, () => {
+        const config = resolveTtsConfig(cfg);
+        expect(config.openai.baseUrl).toBe("http://my-server:9000/v1");
+      });
+    });
+
+    it("strips trailing slashes from the resolved baseUrl", () => {
+      const cfg: OpenClawConfig = {
+        ...baseCfg,
+        messages: {
+          tts: { openai: { baseUrl: "http://my-server:9000/v1///" } },
+        },
+      };
+      const config = resolveTtsConfig(cfg);
+      expect(config.openai.baseUrl).toBe("http://my-server:9000/v1");
+    });
+
+    it("strips trailing slashes from env var baseUrl", () => {
+      withEnv({ OPENAI_TTS_BASE_URL: "http://localhost:8880/v1/" }, () => {
+        const config = resolveTtsConfig(baseCfg);
+        expect(config.openai.baseUrl).toBe("http://localhost:8880/v1");
+      });
     });
   });
 

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -32,6 +32,7 @@ import {
   getTtsProvider as lookupTtsProvider,
 } from "./providers/index.js";
 import {
+  DEFAULT_OPENAI_BASE_URL,
   edgeTTS,
   elevenLabsTTS,
   inferEdgeExtension,
@@ -117,6 +118,7 @@ export type ResolvedTtsConfig = {
   };
   openai: {
     apiKey?: string;
+    baseUrl: string;
     model: string;
     voice: string;
   };
@@ -292,6 +294,12 @@ export function resolveTtsConfig(cfg: RemoteClawConfig): ResolvedTtsConfig {
     },
     openai: {
       apiKey: raw.openai?.apiKey,
+      // Config > env var > default; strip trailing slashes for consistency.
+      baseUrl: (
+        raw.openai?.baseUrl?.trim() ||
+        process.env.OPENAI_TTS_BASE_URL?.trim() ||
+        DEFAULT_OPENAI_BASE_URL
+      ).replace(/\/+$/, ""),
       model: raw.openai?.model ?? DEFAULT_OPENAI_MODEL,
       voice: raw.openai?.voice ?? DEFAULT_OPENAI_VOICE,
     },
@@ -698,6 +706,7 @@ export async function textToSpeech(params: {
           audioBuffer = await openaiTTS({
             text: params.text,
             apiKey,
+            baseUrl: config.openai.baseUrl,
             model: openaiModelOverride ?? config.openai.model,
             voice: openaiVoiceOverride ?? config.openai.voice,
             responseFormat: output.openai,
@@ -933,7 +942,7 @@ export async function maybeApplyTtsToPayload(params: {
   }
 
   const text = params.payload.text ?? "";
-  const directives = parseTtsDirectives(text, config.modelOverrides);
+  const directives = parseTtsDirectives(text, config.modelOverrides, config.openai.baseUrl);
   if (directives.warnings.length > 0) {
     logVerbose(`TTS: ignored directive overrides (${directives.warnings.join("; ")})`);
   }

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -866,6 +866,7 @@ export async function textToSpeechTelephony(params: {
         const audioBuffer = await openaiTTS({
           text: params.text,
           apiKey,
+          baseUrl: config.openai.baseUrl,
           model: config.openai.model,
           voice: config.openai.voice,
           responseFormat: output.format,

--- a/src/tts/types.ts
+++ b/src/tts/types.ts
@@ -3,6 +3,7 @@ export type TtsSynthesisRequest = {
   voice?: string;
   model?: string;
   apiKey?: string;
+  baseUrl?: string;
   outputFormat?: string;
   speed?: number;
   timeoutMs: number;


### PR DESCRIPTION
Cherry-picks from upstream (issue #825).

## Commits
- `48decefbf` fix(skills): deduplicate slash commands by skillName across all interfaces — **RESOLVED** (gutted skills files removed, plugin command dedup kept)
- `fb4f52b71` style: fix formatting in skill-commands.test.ts and provider.ts — **SKIPPED** (empty after conflict resolution, all changes in gutted files)
- `b5a94d274` style(skills): align formatting cleanup for dedupe changes — **SKIPPED** (empty after conflict resolution, all changes in gutted files)
- `2c8ee593b` TTS: add baseUrl support to OpenAI TTS config (#34321) — **RESOLVED** (kept simplified apiKey, added baseUrl config/schema/runtime)
- `063e493d3` fix: decouple Discord inbound worker timeout from listener timeout (#36602) — **RESOLVED** (added inboundWorker config, restored eventQueue schema, fixed OpenClaw→RemoteClaw)
- `e5b6a4e19` Mattermost: honor onmessage mention override and add gating diagnostics tests (#27160) — **RESOLVED** (kept fork's allow-list helpers, added mention gate types, fixed OpenClawConfig→RemoteClawConfig)
- `136ca87f7` feat(mattermost): add interactive buttons support (#19957) — **RESOLVED** (added interactions import alongside fork's existing imports)
- `89b303c55` Mattermost: switch plugin-sdk imports to scoped subpaths (openclaw#36480) — **PICKED** (kept remoteclaw/plugin-sdk flat imports)

## Adaptation
- Rebranded OpenClawConfig → RemoteClawConfig in all new code
- Rebranded openclaw/plugin-sdk/mattermost → remoteclaw/plugin-sdk imports
- Rebranded openclaw-mattermost-interactions HMAC key → remoteclaw-mattermost-interactions
- Kept fork's gutted skills system (removed skill-commands.ts, provider.skill-dedupe.test.ts)
- Kept fork's simplified apiKey (string vs SecretInput) with new baseUrl addition
- Kept fork's plugin provider registry architecture with new baseUrl passthrough