### PR TITLE
Cherry-pick issue #829: security auth hardening

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -3,7 +3,11 @@ import { getChannelDock, listChannelDocks } from "../channels/dock.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import { normalizeAnyChannelId } from "../channels/registry.js";
 import type { RemoteClawConfig } from "../config/config.js";
-import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../utils/message-channel.js";
+import {
+  INTERNAL_MESSAGE_CHANNEL,
+  isInternalMessageChannel,
+  normalizeMessageChannel,
+} from "../utils/message-channel.js";
 import type { MsgContext } from "./templating.js";
 
 export type CommandAuthorization = {
@@ -341,7 +345,12 @@ export function resolveCommandAuthorization(params: {
   const senderId = matchedSender ?? senderCandidates[0];
 
   const enforceOwner = Boolean(dock?.commands?.enforceOwnerForCommands);
-  const senderIsOwner = Boolean(matchedSender);
+  const senderIsOwnerByIdentity = Boolean(matchedSender);
+  const senderIsOwnerByScope =
+    isInternalMessageChannel(ctx.Provider) &&
+    Array.isArray(ctx.GatewayClientScopes) &&
+    ctx.GatewayClientScopes.includes("operator.admin");
+  const senderIsOwner = senderIsOwnerByIdentity || senderIsOwnerByScope;
   const ownerAllowlistConfigured = ownerAllowAll || explicitOwners.length > 0;
   const requireOwner = enforceOwner || ownerAllowlistConfigured;
   const isOwnerForCommands = !requireOwner

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -458,6 +458,52 @@ describe("resolveCommandAuthorization", () => {
       expect(deniedAuth.isAuthorizedSender).toBe(false);
     });
   });
+
+  it("grants senderIsOwner for internal channel with operator.admin scope", () => {
+    const cfg = {} as OpenClawConfig;
+    const ctx = {
+      Provider: "webchat",
+      Surface: "webchat",
+      GatewayClientScopes: ["operator.admin"],
+    } as MsgContext;
+    const auth = resolveCommandAuthorization({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+    expect(auth.senderIsOwner).toBe(true);
+  });
+
+  it("does not grant senderIsOwner for internal channel without admin scope", () => {
+    const cfg = {} as OpenClawConfig;
+    const ctx = {
+      Provider: "webchat",
+      Surface: "webchat",
+      GatewayClientScopes: ["operator.approvals"],
+    } as MsgContext;
+    const auth = resolveCommandAuthorization({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+    expect(auth.senderIsOwner).toBe(false);
+  });
+
+  it("does not grant senderIsOwner for external channel even with admin scope", () => {
+    const cfg = {} as OpenClawConfig;
+    const ctx = {
+      Provider: "telegram",
+      Surface: "telegram",
+      From: "telegram:12345",
+      GatewayClientScopes: ["operator.admin"],
+    } as MsgContext;
+    const auth = resolveCommandAuthorization({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+    expect(auth.senderIsOwner).toBe(false);
+  });
 });
 
 describe("control command parsing", () => {

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -460,7 +460,7 @@ describe("resolveCommandAuthorization", () => {
   });
 
   it("grants senderIsOwner for internal channel with operator.admin scope", () => {
-    const cfg = {} as OpenClawConfig;
+    const cfg = {} as RemoteClawConfig;
     const ctx = {
       Provider: "webchat",
       Surface: "webchat",
@@ -475,7 +475,7 @@ describe("resolveCommandAuthorization", () => {
   });
 
   it("does not grant senderIsOwner for internal channel without admin scope", () => {
-    const cfg = {} as OpenClawConfig;
+    const cfg = {} as RemoteClawConfig;
     const ctx = {
       Provider: "webchat",
       Surface: "webchat",
@@ -490,7 +490,7 @@ describe("resolveCommandAuthorization", () => {
   });
 
   it("does not grant senderIsOwner for external channel even with admin scope", () => {
-    const cfg = {} as OpenClawConfig;
+    const cfg = {} as RemoteClawConfig;
     const ctx = {
       Provider: "telegram",
       Surface: "telegram",

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -108,7 +108,7 @@ function hasExplicitProviderAccountConfig(
   if (!accounts || typeof accounts !== "object") {
     return false;
   }
-  return accountId in accounts;
+  return Object.hasOwn(accounts, accountId);
 }
 
 export async function collectChannelSecurityFindings(params: {

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1352,7 +1352,7 @@ describe("security audit", () => {
 
   it("does not treat prototype properties as explicit Discord account config paths", async () => {
     await withChannelSecurityStateDir(async () => {
-      const cfg: OpenClawConfig = {
+      const cfg: RemoteClawConfig = {
         channels: {
           discord: {
             enabled: true,

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1350,6 +1350,51 @@ describe("security audit", () => {
     });
   });
 
+  it("does not treat prototype properties as explicit Discord account config paths", async () => {
+    await withChannelSecurityStateDir(async () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          discord: {
+            enabled: true,
+            token: "t",
+            dangerouslyAllowNameMatching: true,
+            allowFrom: ["Alice#1234"],
+            accounts: {},
+          },
+        },
+      };
+
+      const pluginWithProtoDefaultAccount: ChannelPlugin = {
+        ...discordPlugin,
+        config: {
+          ...discordPlugin.config,
+          listAccountIds: () => [],
+          defaultAccountId: () => "toString",
+        },
+      };
+
+      const res = await runSecurityAudit({
+        config: cfg,
+        includeFilesystem: false,
+        includeChannelSecurity: true,
+        plugins: [pluginWithProtoDefaultAccount],
+      });
+
+      const dangerousMatchingFinding = res.findings.find(
+        (entry) => entry.checkId === "channels.discord.allowFrom.dangerous_name_matching_enabled",
+      );
+      expect(dangerousMatchingFinding).toBeDefined();
+      expect(dangerousMatchingFinding?.title).not.toContain("(account: toString)");
+
+      const nameBasedFinding = res.findings.find(
+        (entry) => entry.checkId === "channels.discord.allowFrom.name_based_entries",
+      );
+      expect(nameBasedFinding).toBeDefined();
+      expect(nameBasedFinding?.detail).toContain("channels.discord.allowFrom:Alice#1234");
+      expect(nameBasedFinding?.detail).not.toContain("channels.discord.accounts.toString");
+    });
+  });
+
   it("audits name-based allowlists on non-default Discord accounts", async () => {
     await withChannelSecurityStateDir(async () => {
       const cfg: RemoteClawConfig = {


### PR DESCRIPTION
## Cherry-picks from upstream (issue #829)

See issue for full commit list and triage details.

### Picked (2)
- `da0e245db` fix(security): avoid prototype-chain account path checks (#34982) — RESOLVED (CHANGELOG conflict)
- `60d33637d` fix(auth): grant senderIsOwner for internal channels with operator.admin scope — RESOLVED (CHANGELOG + import conflict)

### Skipped (3)
- `92b489212` fix(auth): harden openai-codex oauth login path — all files fork-deleted
- `fb289b7a7` Memory: handle SecretRef keys in doctor embeddings — all surviving files resolved to ours (gutted memory layer)
- `8088218f4` fix(openai-codex): request required oauth api scopes — all files fork-deleted