### PR TITLE
Cherry-pick 7830366f3: fix(slack): propagate mediaLocalRoots through Slack send path

### DIFF
--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -50,6 +50,8 @@ export type SlackActionContext = {
   replyToMode?: "off" | "first" | "all";
   /** Mutable ref to track if a reply was sent (for "first" mode). */
   hasRepliedRef?: { value: boolean };
+  /** Allowed local media directories for file uploads. */
+  mediaLocalRoots?: readonly string[];
 };
 
 /**
@@ -209,6 +211,7 @@ export async function handleSlackAction(
         const result = await sendSlackMessage(to, content ?? "", {
           ...writeOpts,
           mediaUrl: mediaUrl ?? undefined,
+          mediaLocalRoots: context?.mediaLocalRoots,
           threadTs: threadTs ?? undefined,
           blocks,
         });

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -15,7 +15,10 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
         normalizeChannelId: resolveSlackChannelId,
         includeReadThreadId: true,
         invoke: async (action, cfg, toolContext) =>
-          await handleSlackAction(action, cfg, toolContext as SlackActionContext | undefined),
+          await handleSlackAction(action, cfg, {
+            ...(toolContext as SlackActionContext | undefined),
+            mediaLocalRoots: ctx.mediaLocalRoots,
+          }),
       });
     },
   };

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -159,6 +159,7 @@ export async function sendSlackMessage(
   content: string,
   opts: SlackActionClientOpts & {
     mediaUrl?: string;
+    mediaLocalRoots?: readonly string[];
     threadTs?: string;
     blocks?: (Block | KnownBlock)[];
   } = {},
@@ -167,6 +168,7 @@ export async function sendSlackMessage(
     accountId: opts.accountId,
     token: opts.token,
     mediaUrl: opts.mediaUrl,
+    mediaLocalRoots: opts.mediaLocalRoots,
     client: opts.client,
     threadTs: opts.threadTs,
     blocks: opts.blocks,


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: `7830366f3`
**Author**: 2233admin <57929895+2233admin@users.noreply.github.com>

> fix(slack): propagate mediaLocalRoots through Slack send path

Depends on #1706