### PR TITLE
Cherry-pick 1efa7a88c: fix(slack): thread channel ID through inbound context for reactions (#34831)

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -57,6 +57,7 @@ export function buildThreadingToolContext(params: {
         ReplyToId: sessionCtx.ReplyToId,
         ThreadLabel: sessionCtx.ThreadLabel,
         MessageThreadId: sessionCtx.MessageThreadId,
+        NativeChannelId: sessionCtx.NativeChannelId,
       },
       hasRepliedRef,
     }) ?? {};

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -138,6 +138,8 @@ export type MsgContext = {
   GatewayClientScopes?: string[];
   /** Thread identifier (Telegram topic id or Matrix thread event id). */
   MessageThreadId?: string | number;
+  /** Platform-native channel/conversation id (e.g. Slack DM channel "D…" id). */
+  NativeChannelId?: string;
   /** Telegram forum supergroup marker. */
   IsForum?: boolean;
   /**

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -264,6 +264,8 @@ export type ChannelThreadingContext = {
   ReplyToIdFull?: string;
   ThreadLabel?: string;
   MessageThreadId?: string | number;
+  /** Platform-native channel/conversation id (e.g. Slack DM channel "D…" id). */
+  NativeChannelId?: string;
 };
 
 export type ChannelThreadingToolContext = {

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -727,6 +727,7 @@ export async function prepareSlackMessage(params: {
     CommandAuthorized: commandAuthorized,
     OriginatingChannel: "slack" as const,
     OriginatingTo: slackTo,
+    NativeChannelId: message.channel,
   }) satisfies FinalizedMsgContext;
   const pinnedMainDmOwner = isDirectMessage
     ? resolvePinnedMainDmOwnerFromAllowlist({

--- a/src/slack/threading-tool-context.test.ts
+++ b/src/slack/threading-tool-context.test.ts
@@ -144,4 +144,35 @@ describe("buildSlackThreadingToolContext", () => {
     });
     expect(result.replyToMode).toBe("off");
   });
+
+  it("extracts currentChannelId from channel: prefixed To", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: emptyCfg,
+      accountId: null,
+      context: { ChatType: "channel", To: "channel:C1234ABC" },
+    });
+    expect(result.currentChannelId).toBe("C1234ABC");
+  });
+
+  it("uses NativeChannelId for DM when To is user-prefixed", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: emptyCfg,
+      accountId: null,
+      context: {
+        ChatType: "direct",
+        To: "user:U8SUVSVGS",
+        NativeChannelId: "D8SRXRDNF",
+      },
+    });
+    expect(result.currentChannelId).toBe("D8SRXRDNF");
+  });
+
+  it("returns undefined currentChannelId when neither channel: To nor NativeChannelId is set", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: emptyCfg,
+      accountId: null,
+      context: { ChatType: "direct", To: "user:U8SUVSVGS" },
+    });
+    expect(result.currentChannelId).toBeUndefined();
+  });
 });

--- a/src/slack/threading-tool-context.ts
+++ b/src/slack/threading-tool-context.ts
@@ -19,10 +19,14 @@ export function buildSlackThreadingToolContext(params: {
   const hasExplicitThreadTarget = params.context.MessageThreadId != null;
   const effectiveReplyToMode = hasExplicitThreadTarget ? "all" : configuredReplyToMode;
   const threadId = params.context.MessageThreadId ?? params.context.ReplyToId;
+  // For channel messages, To is "channel:C…" — extract the bare ID.
+  // For DMs, To is "user:U…" which can't be used for reactions; fall back
+  // to NativeChannelId (the raw Slack channel id, e.g. "D…").
+  const currentChannelId = params.context.To?.startsWith("channel:")
+    ? params.context.To.slice("channel:".length)
+    : params.context.NativeChannelId?.trim() || undefined;
   return {
-    currentChannelId: params.context.To?.startsWith("channel:")
-      ? params.context.To.slice("channel:".length)
-      : undefined,
+    currentChannelId,
     currentThreadTs: threadId != null ? String(threadId) : undefined,
     replyToMode: effectiveReplyToMode,
     hasRepliedRef: params.hasRepliedRef,


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: `1efa7a88c`
**Author**: dunamismax <dunamismax@tutamail.com>

> fix(slack): thread channel ID through inbound context for reactions (#34831)

Depends on #1721