### PR TITLE
Cherry-pick issue #842: compaction-config-venice-kilocode-auth-nodes

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -779,6 +779,7 @@ Periodic heartbeat runs.
       compaction: {
         mode: "safeguard", // default | safeguard
         reserveTokensFloor: 24000,
+        postCompactionSections: ["Session Startup", "Red Lines"], // [] disables reinjection
         memoryFlush: {
           enabled: true,
           softThresholdTokens: 6000,
@@ -792,6 +793,7 @@ Periodic heartbeat runs.
 ```
 
 - `mode`: `default` or `safeguard` (chunked summarization for long histories). See [Session management — compaction](/reference/session-management-compaction).
+- `postCompactionSections`: optional AGENTS.md H2/H3 section names to re-inject after compaction. Defaults to `["Session Startup", "Red Lines"]`; set `[]` to disable reinjection. When unset or explicitly set to that default pair, older `Every Session`/`Safety` headings are also accepted as a legacy fallback.
 - `memoryFlush`: silent agentic turn before auto-compaction to store durable memories. Skipped when workspace is read-only.
 
 ### `agents.defaults.contextPruning`

--- a/extensions/googlechat/src/accounts.test.ts
+++ b/extensions/googlechat/src/accounts.test.ts
@@ -1,0 +1,131 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/googlechat";
+import { describe, expect, it } from "vitest";
+import { resolveGoogleChatAccount } from "./accounts.js";
+
+describe("resolveGoogleChatAccount", () => {
+  it("inherits shared defaults from accounts.default for named accounts", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        googlechat: {
+          accounts: {
+            default: {
+              audienceType: "app-url",
+              audience: "https://example.com/googlechat",
+              webhookPath: "/googlechat",
+            },
+            andy: {
+              serviceAccountFile: "/tmp/andy-sa.json",
+            },
+          },
+        },
+      },
+    };
+
+    const resolved = resolveGoogleChatAccount({ cfg, accountId: "andy" });
+    expect(resolved.config.audienceType).toBe("app-url");
+    expect(resolved.config.audience).toBe("https://example.com/googlechat");
+    expect(resolved.config.webhookPath).toBe("/googlechat");
+    expect(resolved.config.serviceAccountFile).toBe("/tmp/andy-sa.json");
+  });
+
+  it("prefers top-level and account overrides over accounts.default", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        googlechat: {
+          audienceType: "project-number",
+          audience: "1234567890",
+          accounts: {
+            default: {
+              audienceType: "app-url",
+              audience: "https://default.example.com/googlechat",
+              webhookPath: "/googlechat-default",
+            },
+            april: {
+              webhookPath: "/googlechat-april",
+            },
+          },
+        },
+      },
+    };
+
+    const resolved = resolveGoogleChatAccount({ cfg, accountId: "april" });
+    expect(resolved.config.audienceType).toBe("project-number");
+    expect(resolved.config.audience).toBe("1234567890");
+    expect(resolved.config.webhookPath).toBe("/googlechat-april");
+  });
+
+  it("does not inherit disabled state from accounts.default for named accounts", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        googlechat: {
+          accounts: {
+            default: {
+              enabled: false,
+              audienceType: "app-url",
+              audience: "https://example.com/googlechat",
+            },
+            andy: {
+              serviceAccountFile: "/tmp/andy-sa.json",
+            },
+          },
+        },
+      },
+    };
+
+    const resolved = resolveGoogleChatAccount({ cfg, accountId: "andy" });
+    expect(resolved.enabled).toBe(true);
+    expect(resolved.config.enabled).toBeUndefined();
+    expect(resolved.config.audienceType).toBe("app-url");
+  });
+
+  it("does not inherit default-account credentials into named accounts", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        googlechat: {
+          accounts: {
+            default: {
+              serviceAccountRef: {
+                source: "env",
+                provider: "test",
+                id: "default-sa",
+              },
+              audienceType: "app-url",
+              audience: "https://example.com/googlechat",
+            },
+            andy: {
+              serviceAccountFile: "/tmp/andy-sa.json",
+            },
+          },
+        },
+      },
+    };
+
+    const resolved = resolveGoogleChatAccount({ cfg, accountId: "andy" });
+    expect(resolved.credentialSource).toBe("file");
+    expect(resolved.credentialsFile).toBe("/tmp/andy-sa.json");
+    expect(resolved.config.audienceType).toBe("app-url");
+  });
+
+  it("does not inherit dangerous name matching from accounts.default", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        googlechat: {
+          accounts: {
+            default: {
+              dangerouslyAllowNameMatching: true,
+              audienceType: "app-url",
+              audience: "https://example.com/googlechat",
+            },
+            andy: {
+              serviceAccountFile: "/tmp/andy-sa.json",
+            },
+          },
+        },
+      },
+    };
+
+    const resolved = resolveGoogleChatAccount({ cfg, accountId: "andy" });
+    expect(resolved.config.dangerouslyAllowNameMatching).toBeUndefined();
+    expect(resolved.config.audienceType).toBe("app-url");
+  });
+});

--- a/extensions/googlechat/src/accounts.test.ts
+++ b/extensions/googlechat/src/accounts.test.ts
@@ -1,10 +1,10 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/googlechat";
+import type { RemoteClawConfig } from "remoteclaw/plugin-sdk/googlechat";
 import { describe, expect, it } from "vitest";
 import { resolveGoogleChatAccount } from "./accounts.js";
 
 describe("resolveGoogleChatAccount", () => {
   it("inherits shared defaults from accounts.default for named accounts", () => {
-    const cfg: OpenClawConfig = {
+    const cfg: RemoteClawConfig = {
       channels: {
         googlechat: {
           accounts: {
@@ -29,7 +29,7 @@ describe("resolveGoogleChatAccount", () => {
   });
 
   it("prefers top-level and account overrides over accounts.default", () => {
-    const cfg: OpenClawConfig = {
+    const cfg: RemoteClawConfig = {
       channels: {
         googlechat: {
           audienceType: "project-number",
@@ -55,7 +55,7 @@ describe("resolveGoogleChatAccount", () => {
   });
 
   it("does not inherit disabled state from accounts.default for named accounts", () => {
-    const cfg: OpenClawConfig = {
+    const cfg: RemoteClawConfig = {
       channels: {
         googlechat: {
           accounts: {
@@ -79,14 +79,13 @@ describe("resolveGoogleChatAccount", () => {
   });
 
   it("does not inherit default-account credentials into named accounts", () => {
-    const cfg: OpenClawConfig = {
+    const cfg: RemoteClawConfig = {
       channels: {
         googlechat: {
           accounts: {
             default: {
               serviceAccountRef: {
                 source: "env",
-                provider: "test",
                 id: "default-sa",
               },
               audienceType: "app-url",
@@ -107,7 +106,7 @@ describe("resolveGoogleChatAccount", () => {
   });
 
   it("does not inherit dangerous name matching from accounts.default", () => {
-    const cfg: OpenClawConfig = {
+    const cfg: RemoteClawConfig = {
       channels: {
         googlechat: {
           accounts: {

--- a/extensions/googlechat/src/accounts.ts
+++ b/extensions/googlechat/src/accounts.ts
@@ -70,8 +70,22 @@ function mergeGoogleChatAccountConfig(
 ): GoogleChatAccountConfig {
   const raw = cfg.channels?.["googlechat"] ?? {};
   const { accounts: _ignored, defaultAccount: _ignored2, ...base } = raw;
+  const defaultAccountConfig = resolveAccountConfig(cfg, DEFAULT_ACCOUNT_ID) ?? {};
   const account = resolveAccountConfig(cfg, accountId) ?? {};
-  return { ...base, ...account } as GoogleChatAccountConfig;
+  if (accountId === DEFAULT_ACCOUNT_ID) {
+    return { ...base, ...defaultAccountConfig } as GoogleChatAccountConfig;
+  }
+  const {
+    enabled: _ignoredEnabled,
+    dangerouslyAllowNameMatching: _ignoredDangerouslyAllowNameMatching,
+    serviceAccount: _ignoredServiceAccount,
+    serviceAccountRef: _ignoredServiceAccountRef,
+    serviceAccountFile: _ignoredServiceAccountFile,
+    ...defaultAccountShared
+  } = defaultAccountConfig;
+  // In multi-account setups, allow accounts.default to provide shared defaults
+  // (for example webhook/audience fields) while preserving top-level and account overrides.
+  return { ...defaultAccountShared, ...base, ...account } as GoogleChatAccountConfig;
 }
 
 function parseServiceAccount(value: unknown): Record<string, unknown> | null {

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -282,7 +282,7 @@ export function createSynologyChatPlugin() {
               Surface: CHANNEL_ID,
               ConversationLabel: msg.senderName || msg.from,
               Timestamp: Date.now(),
-              CommandAuthorized: true,
+              CommandAuthorized: msg.commandAuthorized,
             });
 
             // Dispatch via the SDK's buffered block dispatcher

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -237,6 +237,7 @@ describe("createWebhookHandler", () => {
         body: "Hello from json",
         from: "123",
         senderName: "json-user",
+        commandAuthorized: true,
       }),
     );
   });
@@ -396,6 +397,7 @@ describe("createWebhookHandler", () => {
         senderName: "testuser",
         provider: "synology-chat",
         chatType: "direct",
+        commandAuthorized: true,
       }),
     );
   });
@@ -422,6 +424,7 @@ describe("createWebhookHandler", () => {
     expect(deliver).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.stringContaining("[FILTERED]"),
+        commandAuthorized: true,
       }),
     );
   });

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -225,6 +225,7 @@ export interface WebhookHandlerDeps {
     chatType: string;
     sessionKey: string;
     accountId: string;
+    commandAuthorized: boolean;
     /** Chat API user_id for sending replies (may differ from webhook user_id) */
     chatUserId?: string;
   }) => Promise<string | null>;
@@ -364,6 +365,7 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
         chatType: "direct",
         sessionKey,
         accountId: account.accountId,
+        commandAuthorized: auth.allowed,
         chatUserId: replyUserId,
       });
 

--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -7,7 +7,7 @@ const gatewayMocks = vi.hoisted(() => ({
 
 const nodeUtilsMocks = vi.hoisted(() => ({
   resolveNodeId: vi.fn(async () => "node-1"),
-  listNodes: vi.fn(async () => []),
+  listNodes: vi.fn(async () => [] as Array<{ nodeId: string; commands?: string[] }>),
   resolveNodeIdFromList: vi.fn(() => "node-1"),
 }));
 

--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -74,4 +74,50 @@ describe("createNodesTool screen_record duration guardrails", () => {
       }),
     );
   });
+
+  it("omits rawCommand when preparing wrapped argv execution", async () => {
+    nodeUtilsMocks.listNodes.mockResolvedValue([
+      {
+        nodeId: "node-1",
+        commands: ["system.run"],
+      },
+    ]);
+    gatewayMocks.callGatewayTool.mockImplementation(async (_method, _opts, payload) => {
+      if (payload?.command === "system.run.prepare") {
+        return {
+          payload: {
+            cmdText: "echo hi",
+            plan: {
+              argv: ["bash", "-lc", "echo hi"],
+              cwd: null,
+              rawCommand: null,
+              agentId: null,
+              sessionKey: null,
+            },
+          },
+        };
+      }
+      if (payload?.command === "system.run") {
+        return { payload: { ok: true } };
+      }
+      throw new Error(`unexpected command: ${String(payload?.command)}`);
+    });
+    const tool = createNodesTool();
+
+    await tool.execute("call-1", {
+      action: "run",
+      node: "macbook",
+      command: ["bash", "-lc", "echo hi"],
+    });
+
+    const prepareCall = gatewayMocks.callGatewayTool.mock.calls.find(
+      (call) => call[2]?.command === "system.run.prepare",
+    )?.[2];
+    expect(prepareCall).toBeTruthy();
+    expect(prepareCall?.params).toMatchObject({
+      command: ["bash", "-lc", "echo hi"],
+      agentId: "main",
+    });
+    expect(prepareCall?.params).not.toHaveProperty("rawCommand");
+  });
 });

--- a/src/auth/usage.test.ts
+++ b/src/auth/usage.test.ts
@@ -28,6 +28,7 @@ function makeStore(usageStats: AuthProfileStore["usageStats"]): AuthProfileStore
       "anthropic:default": { type: "api_key", provider: "anthropic", key: "sk-test" },
       "openai:default": { type: "api_key", provider: "openai", key: "sk-test-2" },
       "openrouter:default": { type: "api_key", provider: "openrouter", key: "sk-or-test" },
+      "kilocode:default": { type: "api_key", provider: "kilocode", key: "sk-kc-test" },
     },
     usageStats,
   };
@@ -121,6 +122,17 @@ describe("isProfileInCooldown", () => {
       },
     });
     expect(isProfileInCooldown(store, "openrouter:default")).toBe(false);
+  });
+
+  it("returns false for Kilocode even when cooldown fields exist", () => {
+    const store = makeStore({
+      "kilocode:default": {
+        cooldownUntil: Date.now() + 60_000,
+        disabledUntil: Date.now() + 60_000,
+        disabledReason: "billing",
+      },
+    });
+    expect(isProfileInCooldown(store, "kilocode:default")).toBe(false);
   });
 });
 

--- a/src/auth/usage.ts
+++ b/src/auth/usage.ts
@@ -18,7 +18,8 @@ const FAILURE_REASON_ORDER = new Map<AuthProfileFailureReason, number>(
 );
 
 function isAuthCooldownBypassedForProvider(provider: string | undefined): boolean {
-  return normalizeProviderId(provider ?? "") === "openrouter";
+  const normalized = normalizeProviderId(provider ?? "");
+  return normalized === "openrouter" || normalized === "kilocode";
 }
 
 export function resolveProfileUnusableUntil(

--- a/src/auto-reply/command-auth.owner-default.test.ts
+++ b/src/auto-reply/command-auth.owner-default.test.ts
@@ -22,8 +22,8 @@ afterEach(() => {
   setActivePluginRegistry(createRegistry());
 });
 
-describe("senderIsOwner defaults to true when no owner allowlist configured (#26319)", () => {
-  it("senderIsOwner is true when no ownerAllowFrom is configured (single-user default)", () => {
+describe("senderIsOwner only reflects explicit owner authorization", () => {
+  it("does not treat direct-message senders as owners when no ownerAllowFrom is configured", () => {
     const cfg = {
       channels: { discord: {} },
     } as RemoteClawConfig;
@@ -42,12 +42,11 @@ describe("senderIsOwner defaults to true when no owner allowlist configured (#26
       commandAuthorized: true,
     });
 
-    // Without an explicit ownerAllowFrom list, the sole authorized user should
-    // be treated as owner so ownerOnly tools (cron, gateway) are available.
-    expect(auth.senderIsOwner).toBe(true);
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(true);
   });
 
-  it("senderIsOwner is false when no ownerAllowFrom is configured in a group chat", () => {
+  it("does not treat group-chat senders as owners when no ownerAllowFrom is configured", () => {
     const cfg = {
       channels: { discord: {} },
     } as RemoteClawConfig;
@@ -67,6 +66,7 @@ describe("senderIsOwner defaults to true when no owner allowlist configured (#26
     });
 
     expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(true);
   });
 
   it("senderIsOwner is false when ownerAllowFrom is configured and sender does not match", () => {

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -351,14 +351,7 @@ export function resolveCommandAuthorization(params: {
     Array.isArray(ctx.GatewayClientScopes) &&
     ctx.GatewayClientScopes.includes("operator.admin");
   const ownerAllowlistConfigured = ownerAllowAll || explicitOwners.length > 0;
-  const isDirectChat = (ctx.ChatType ?? "").trim().toLowerCase() === "direct";
-  // In the default single-user direct-chat setup, allow an identified sender to
-  // keep ownerOnly tools even without an explicit owner allowlist.
-  const senderIsOwner =
-    senderIsOwnerByIdentity ||
-    senderIsOwnerByScope ||
-    ownerAllowAll ||
-    (!ownerAllowlistConfigured && isDirectChat && Boolean(senderId));
+  const senderIsOwner = senderIsOwnerByIdentity || senderIsOwnerByScope || ownerAllowAll;
   const requireOwner = enforceOwner || ownerAllowlistConfigured;
   const isOwnerForCommands = !requireOwner
     ? true

--- a/src/commands/onboard-auth.config-core.kilocode.test.ts
+++ b/src/commands/onboard-auth.config-core.kilocode.test.ts
@@ -25,11 +25,11 @@ describe("Kilo Gateway provider config", () => {
     });
 
     it("KILOCODE_DEFAULT_MODEL_REF includes provider prefix", () => {
-      expect(KILOCODE_DEFAULT_MODEL_REF).toBe("kilocode/anthropic/claude-opus-4.6");
+      expect(KILOCODE_DEFAULT_MODEL_REF).toBe("kilocode/kilo/auto");
     });
 
-    it("KILOCODE_DEFAULT_MODEL_ID is anthropic/claude-opus-4.6", () => {
-      expect(KILOCODE_DEFAULT_MODEL_ID).toBe("anthropic/claude-opus-4.6");
+    it("KILOCODE_DEFAULT_MODEL_ID is kilo/auto", () => {
+      expect(KILOCODE_DEFAULT_MODEL_ID).toBe("kilo/auto");
     });
   });
 
@@ -37,7 +37,7 @@ describe("Kilo Gateway provider config", () => {
     it("returns correct model shape", () => {
       const model = buildKilocodeModelDefinition();
       expect(model.id).toBe(KILOCODE_DEFAULT_MODEL_ID);
-      expect(model.name).toBe("Claude Opus 4.6");
+      expect(model.name).toBe("Kilo Auto");
       expect(model.reasoning).toBe(true);
       expect(model.input).toEqual(["text", "image"]);
       expect(model.contextWindow).toBe(KILOCODE_DEFAULT_CONTEXT_WINDOW);

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -145,11 +145,11 @@ export function applyXiaomiConfig(cfg: RemoteClawConfig): RemoteClawConfig {
  * Registers Venice models and sets up the provider, but preserves existing model selection.
  */
 export function applyVeniceProviderConfig(cfg: RemoteClawConfig): RemoteClawConfig {
-  const veniceModelRef = "venice/llama-3.3-70b";
+  const veniceModelRef = "venice/kimi-k2-5";
   const models = { ...cfg.agents?.defaults?.models };
   models[veniceModelRef] = {
     ...models[veniceModelRef],
-    alias: models[veniceModelRef]?.alias ?? "Llama 3.3 70B",
+    alias: models[veniceModelRef]?.alias ?? "Kimi K2.5",
   };
 
   return applyOnboardAuthAgentModelsAndProviders(cfg, { agentModels: models });

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -12,6 +12,7 @@ export type ModelCompatConfig = {
   supportsDeveloperRole?: boolean;
   supportsReasoningEffort?: boolean;
   supportsUsageInStreaming?: boolean;
+  supportsTools?: boolean;
   supportsStrictMode?: boolean;
   maxTokensField?: "max_completion_tokens" | "max_tokens";
   thinkingFormat?: "openai" | "zai" | "qwen";

--- a/src/providers/kilocode-shared.ts
+++ b/src/providers/kilocode-shared.ts
@@ -1,7 +1,7 @@
 export const KILOCODE_BASE_URL = "https://api.kilo.ai/api/gateway/";
-export const KILOCODE_DEFAULT_MODEL_ID = "anthropic/claude-opus-4.6";
+export const KILOCODE_DEFAULT_MODEL_ID = "kilo/auto";
 export const KILOCODE_DEFAULT_MODEL_REF = `kilocode/${KILOCODE_DEFAULT_MODEL_ID}`;
-export const KILOCODE_DEFAULT_MODEL_NAME = "Claude Opus 4.6";
+export const KILOCODE_DEFAULT_MODEL_NAME = "Kilo Auto";
 export type KilocodeModelCatalogEntry = {
   id: string;
   name: string;
@@ -10,6 +10,12 @@ export type KilocodeModelCatalogEntry = {
   contextWindow?: number;
   maxTokens?: number;
 };
+/**
+ * Static fallback catalog — used by the sync onboarding path and as a
+ * fallback when dynamic model discovery from the gateway API fails.
+ * The full model list is fetched dynamically by {@link discoverKilocodeModels}
+ * in `src/agents/kilocode-models.ts`.
+ */
 export const KILOCODE_MODEL_CATALOG: KilocodeModelCatalogEntry[] = [
   {
     id: KILOCODE_DEFAULT_MODEL_ID,
@@ -18,70 +24,6 @@ export const KILOCODE_MODEL_CATALOG: KilocodeModelCatalogEntry[] = [
     input: ["text", "image"],
     contextWindow: 1000000,
     maxTokens: 128000,
-  },
-  {
-    id: "z-ai/glm-5:free",
-    name: "GLM-5 (Free)",
-    reasoning: true,
-    input: ["text"],
-    contextWindow: 202800,
-    maxTokens: 131072,
-  },
-  {
-    id: "minimax/minimax-m2.5:free",
-    name: "MiniMax M2.5 (Free)",
-    reasoning: true,
-    input: ["text"],
-    contextWindow: 204800,
-    maxTokens: 131072,
-  },
-  {
-    id: "anthropic/claude-sonnet-4.5",
-    name: "Claude Sonnet 4.5",
-    reasoning: true,
-    input: ["text", "image"],
-    contextWindow: 1000000,
-    maxTokens: 64000,
-  },
-  {
-    id: "openai/gpt-5.2",
-    name: "GPT-5.2",
-    reasoning: true,
-    input: ["text", "image"],
-    contextWindow: 400000,
-    maxTokens: 128000,
-  },
-  {
-    id: "google/gemini-3-pro-preview",
-    name: "Gemini 3 Pro Preview",
-    reasoning: true,
-    input: ["text", "image"],
-    contextWindow: 1048576,
-    maxTokens: 65536,
-  },
-  {
-    id: "google/gemini-3-flash-preview",
-    name: "Gemini 3 Flash Preview",
-    reasoning: true,
-    input: ["text", "image"],
-    contextWindow: 1048576,
-    maxTokens: 65535,
-  },
-  {
-    id: "x-ai/grok-code-fast-1",
-    name: "Grok Code Fast 1",
-    reasoning: true,
-    input: ["text"],
-    contextWindow: 256000,
-    maxTokens: 10000,
-  },
-  {
-    id: "moonshotai/kimi-k2.5",
-    name: "Kimi K2.5",
-    reasoning: true,
-    input: ["text", "image"],
-    contextWindow: 262144,
-    maxTokens: 65535,
   },
 ];
 export const KILOCODE_DEFAULT_CONTEXT_WINDOW = 1000000;


### PR DESCRIPTION
## Cherry-picks from upstream (issue #842)

See issue for full commit list and triage details.

### Picked (9 commits)
- `03b9abab8` feat(compaction): make post-compaction context sections configurable (#34556) — RESOLVED
- `5320ee773` fix(venice): harden discovery limits and tool support (#38306) — RESOLVED (partial: types.models.ts only)
- `3070fafec` fix(venice): switch default model to kimi-k2-5 (#38423) — RESOLVED (partial: onboard-auth.config-core.ts only)
- `15a5e39da` Fix owner-only auth and overlapping skill env regressions (#38548) — RESOLVED (partial: command-auth files only)
- `9d9937002` test(nodes): cover wrapped system.run prepare — PICKED
- `ac63f30cd` test(nodes): type wrapped prepare coverage mock — PICKED
- `33e739486` fix(providers): make all models available in kilocode provider (#32352) — RESOLVED (partial: kilocode-shared, auth/usage, kilocode test)
- `a01978ba9` fix(googlechat): inherit shared defaults for multi-account webhook auth (#38492) — RESOLVED (CHANGELOG only)
- `b393b9e8f` refactor(synology-chat): thread command authorization from webhook gate — PICKED

### Skipped (5 commits)
- `942c53e7f` fix(agents): prevent totalTokens crash — all files in gutted pi-embedded-runner layer
- `bf623a580` Agents: add skill API rate-limit guardrail — all files in gutted skills/system-prompt layer
- `fa69f836c` fix: increase maxTokens for tool probe — all files in gutted model-scan layer
- `3efafab21` fix(nodes): remove redundant rawCommand — empty after resolution (fork already removed the code)
- `4c0b873a4` Config/Compaction: expose safeguard preserve/quality settings — empty after resolution (compaction config gutted from fork)