### PR TITLE
Cherry-pick ae96a8191: fix: strip skill-injected env vars from ACP harness spawn env

### DIFF
--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -60,6 +60,49 @@ describe("resolveAcpClientSpawnEnv", () => {
     });
     expect(env.REMOTECLAW_SHELL).toBe("acp-client");
   });
+
+  it("strips skill-injected env keys when stripKeys is provided", () => {
+    const stripKeys = new Set(["OPENAI_API_KEY", "ELEVENLABS_API_KEY"]);
+    const env = resolveAcpClientSpawnEnv(
+      {
+        PATH: "/usr/bin",
+        OPENAI_API_KEY: "sk-leaked-from-skill",
+        ELEVENLABS_API_KEY: "el-leaked",
+        ANTHROPIC_API_KEY: "sk-keep-this",
+      },
+      { stripKeys },
+    );
+
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.REMOTECLAW_SHELL).toBe("acp-client");
+    expect(env.ANTHROPIC_API_KEY).toBe("sk-keep-this");
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.ELEVENLABS_API_KEY).toBeUndefined();
+  });
+
+  it("does not modify the original baseEnv when stripping keys", () => {
+    const baseEnv: NodeJS.ProcessEnv = {
+      OPENAI_API_KEY: "sk-original",
+      PATH: "/usr/bin",
+    };
+    const stripKeys = new Set(["OPENAI_API_KEY"]);
+    resolveAcpClientSpawnEnv(baseEnv, { stripKeys });
+
+    expect(baseEnv.OPENAI_API_KEY).toBe("sk-original");
+  });
+
+  it("preserves REMOTECLAW_SHELL even when stripKeys contains it", () => {
+    const env = resolveAcpClientSpawnEnv(
+      {
+        REMOTECLAW_SHELL: "skill-overridden",
+        OPENAI_API_KEY: "sk-leaked",
+      },
+      { stripKeys: new Set(["REMOTECLAW_SHELL", "OPENAI_API_KEY"]) },
+    );
+
+    expect(env.REMOTECLAW_SHELL).toBe("acp-client");
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+  });
 });
 
 describe("resolveAcpClientSpawnInvocation", () => {

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -247,8 +247,16 @@ function buildServerArgs(opts: AcpClientOptions): string[] {
 
 export function resolveAcpClientSpawnEnv(
   baseEnv: NodeJS.ProcessEnv = process.env,
+  options?: { stripKeys?: ReadonlySet<string> },
 ): NodeJS.ProcessEnv {
-  return { ...baseEnv, REMOTECLAW_SHELL: "acp-client" };
+  const env: NodeJS.ProcessEnv = { ...baseEnv };
+  if (options?.stripKeys) {
+    for (const key of options.stripKeys) {
+      delete env[key];
+    }
+  }
+  env.REMOTECLAW_SHELL = "acp-client";
+  return env;
 }
 
 type AcpSpawnRuntime = {
@@ -349,7 +357,7 @@ export async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpC
   const entryPath = resolveSelfEntryPath();
   const serverCommand = opts.serverCommand ?? (entryPath ? process.execPath : "remoteclaw");
   const effectiveArgs = opts.serverCommand || !entryPath ? serverArgs : [entryPath, ...serverArgs];
-  const spawnEnv = resolveAcpClientSpawnEnv();
+  const spawnEnv = resolveAcpClientSpawnEnv(process.env);
   const spawnInvocation = resolveAcpClientSpawnInvocation(
     { serverCommand, serverArgs: effectiveArgs },
     {


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: `ae96a8191649c5d1d44c6e06f8503015216cd880`
**Author**: Drew Wagner

> fix: strip skill-injected env vars from ACP harness spawn env (#36280) (#36316)

**Adaptation**: AUTO-PARTIAL — discarded gutted skills files (`src/agents/skills/*`), CHANGELOG.md. Kept ACP env-strip logic with fork naming (`REMOTECLAW_SHELL`). Removed dynamic import of deleted `env-overrides.runtime.js`.