### PR TITLE
Cherry-pick issue #851: upstream CLI commands & test deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@ Docs: https://docs.openclaw.ai
 - Feishu/reply delivery reliability: disable block streaming in Feishu reply options so plain-text auto-render replies are no longer silently dropped before final delivery. (#38258) Thanks @xinhuagu.
 - Agents/reply MEDIA delivery: normalize local assistant `MEDIA:` paths before block/final delivery, keep media dedupe aligned with message-tool sends, and contain malformed media normalization failures so generated files send reliably instead of falling back to empty responses. (#38572) Thanks @obviyus.
 - Markdown/assistant image hardening: flatten remote markdown images to plain text across the Control UI, exported HTML, and shared Swift chat while keeping inline `data:image/...` markdown renderable, so model output no longer triggers automatic remote image fetches. (#38895) Thanks @obviyus.
+- Models/auth token prompts: guard cancelled manual token prompts so `Symbol(clack:cancel)` values cannot be persisted into auth profiles; adds regression coverage for cancelled `models auth paste-token`. (#38951) Thanks @MumuTW.
 
 ## 2026.3.2
 

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -20,6 +20,26 @@ vi.mock("../../gateway/probe.js", () => ({
 
 const originalPlatform = process.platform;
 
+async function inspectAmbiguousOwnershipWithProbe(
+  probeResult: Awaited<ReturnType<typeof probeGateway>>,
+) {
+  const service = {
+    readRuntime: vi.fn(async () => ({ status: "running", pid: 8000 })),
+  } as unknown as GatewayService;
+
+  inspectPortUsage.mockResolvedValue({
+    port: 18789,
+    status: "busy",
+    listeners: [{ commandLine: "" }],
+    hints: [],
+  });
+  classifyPortListener.mockReturnValue("unknown");
+  probeGateway.mockResolvedValue(probeResult);
+
+  const { inspectGatewayRestart } = await import("./restart-health.js");
+  return inspectGatewayRestart({ service, port: 18789 });
+}
+
 describe("inspectGatewayRestart", () => {
   beforeEach(() => {
     inspectPortUsage.mockReset();
@@ -181,24 +201,10 @@ describe("inspectGatewayRestart", () => {
   });
 
   it("uses a local gateway probe when ownership is ambiguous", async () => {
-    const service = {
-      readRuntime: vi.fn(async () => ({ status: "running", pid: 8000 })),
-    } as unknown as GatewayService;
-
-    inspectPortUsage.mockResolvedValue({
-      port: 18789,
-      status: "busy",
-      listeners: [{ commandLine: "" }],
-      hints: [],
-    });
-    classifyPortListener.mockReturnValue("unknown");
-    probeGateway.mockResolvedValue({
+    const snapshot = await inspectAmbiguousOwnershipWithProbe({
       ok: true,
       close: null,
     });
-
-    const { inspectGatewayRestart } = await import("./restart-health.js");
-    const snapshot = await inspectGatewayRestart({ service, port: 18789 });
 
     expect(snapshot.healthy).toBe(true);
     expect(probeGateway).toHaveBeenCalledWith(
@@ -207,24 +213,10 @@ describe("inspectGatewayRestart", () => {
   });
 
   it("treats auth-closed probe as healthy gateway reachability", async () => {
-    const service = {
-      readRuntime: vi.fn(async () => ({ status: "running", pid: 8000 })),
-    } as unknown as GatewayService;
-
-    inspectPortUsage.mockResolvedValue({
-      port: 18789,
-      status: "busy",
-      listeners: [{ commandLine: "" }],
-      hints: [],
-    });
-    classifyPortListener.mockReturnValue("unknown");
-    probeGateway.mockResolvedValue({
+    const snapshot = await inspectAmbiguousOwnershipWithProbe({
       ok: false,
       close: { code: 1008, reason: "auth required" },
     });
-
-    const { inspectGatewayRestart } = await import("./restart-health.js");
-    const snapshot = await inspectGatewayRestart({ service, port: 18789 });
 
     expect(snapshot.healthy).toBe(true);
   });

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -379,6 +379,9 @@ export async function agentCommand(
   return await agentCommandInternal(
     {
       ...opts,
+      // agentCommand is the trusted-operator entrypoint used by CLI/local flows.
+      // Ingress callers must opt into owner semantics explicitly via
+      // agentCommandFromIngress so network-facing paths cannot inherit this default by accident.
       senderIsOwner: opts.senderIsOwner ?? true,
     },
     runtime,
@@ -392,6 +395,8 @@ export async function agentCommandFromIngress(
   deps: CliDeps = createDefaultDeps(),
 ) {
   if (typeof opts.senderIsOwner !== "boolean") {
+    // HTTP/WS ingress must declare the trust level explicitly at the boundary.
+    // This keeps network-facing callers from silently picking up the local trusted default.
     throw new Error("senderIsOwner must be explicitly set for ingress agent runs.");
   }
   return await agentCommandInternal(

--- a/src/commands/message.test.ts
+++ b/src/commands/message.test.ts
@@ -185,26 +185,94 @@ const createTelegramPollPluginRegistration = () => ({
 
 const { messageCommand } = await import("./message.js");
 
+function createTelegramSecretRawConfig() {
+  return {
+    channels: {
+      telegram: {
+        token: { $secret: "vault://telegram/token" },
+      },
+    },
+  };
+}
+
+function createTelegramResolvedTokenConfig(token: string) {
+  return {
+    channels: {
+      telegram: {
+        token,
+      },
+    },
+  };
+}
+
+function mockResolvedCommandConfig(params: {
+  rawConfig: Record<string, unknown>;
+  resolvedConfig: Record<string, unknown>;
+  diagnostics?: string[];
+}) {
+  testConfig = params.rawConfig;
+  resolveCommandSecretRefsViaGateway.mockResolvedValueOnce({
+    resolvedConfig: params.resolvedConfig,
+    diagnostics: params.diagnostics ?? ["resolved channels.telegram.token"],
+  });
+}
+
+async function runTelegramDirectOutboundSend(params: {
+  rawConfig: Record<string, unknown>;
+  resolvedConfig: Record<string, unknown>;
+  diagnostics?: string[];
+}) {
+  mockResolvedCommandConfig(params);
+  const sendText = vi.fn(async (_ctx: { cfg?: unknown; to?: string; text?: string }) => ({
+    channel: "telegram" as const,
+    messageId: "msg-1",
+    chatId: "123456",
+  }));
+  const sendMedia = vi.fn(async (_ctx: { cfg?: unknown }) => ({
+    channel: "telegram" as const,
+    messageId: "msg-2",
+    chatId: "123456",
+  }));
+  await setRegistry(
+    createTestRegistry([
+      {
+        pluginId: "telegram",
+        source: "test",
+        plugin: createStubPlugin({
+          id: "telegram",
+          label: "Telegram",
+          outbound: {
+            deliveryMode: "direct",
+            sendText,
+            sendMedia,
+          },
+        }),
+      },
+    ]),
+  );
+
+  const deps = makeDeps();
+  await messageCommand(
+    {
+      action: "send",
+      channel: "telegram",
+      target: "123456",
+      message: "hi",
+    },
+    deps,
+    runtime,
+  );
+
+  return { sendText };
+}
+
 describe("messageCommand", () => {
   it("threads resolved SecretRef config into outbound send actions", async () => {
-    const rawConfig = {
-      channels: {
-        telegram: {
-          token: { $secret: "vault://telegram/token" },
-        },
-      },
-    };
-    const resolvedConfig = {
-      channels: {
-        telegram: {
-          token: "12345:resolved-token",
-        },
-      },
-    };
-    testConfig = rawConfig;
-    resolveCommandSecretRefsViaGateway.mockResolvedValueOnce({
+    const rawConfig = createTelegramSecretRawConfig();
+    const resolvedConfig = createTelegramResolvedTokenConfig("12345:resolved-token");
+    mockResolvedCommandConfig({
+      rawConfig: rawConfig as unknown as Record<string, unknown>,
       resolvedConfig: resolvedConfig as unknown as Record<string, unknown>,
-      diagnostics: ["resolved channels.telegram.token"],
     });
     await setRegistry(
       createTestRegistry([
@@ -239,64 +307,12 @@ describe("messageCommand", () => {
   });
 
   it("threads resolved SecretRef config into outbound adapter sends", async () => {
-    const rawConfig = {
-      channels: {
-        telegram: {
-          token: { $secret: "vault://telegram/token" },
-        },
-      },
-    };
-    const resolvedConfig = {
-      channels: {
-        telegram: {
-          token: "12345:resolved-token",
-        },
-      },
-    };
-    testConfig = rawConfig;
-    resolveCommandSecretRefsViaGateway.mockResolvedValueOnce({
+    const rawConfig = createTelegramSecretRawConfig();
+    const resolvedConfig = createTelegramResolvedTokenConfig("12345:resolved-token");
+    const { sendText } = await runTelegramDirectOutboundSend({
+      rawConfig: rawConfig as unknown as Record<string, unknown>,
       resolvedConfig: resolvedConfig as unknown as Record<string, unknown>,
-      diagnostics: ["resolved channels.telegram.token"],
     });
-    const sendText = vi.fn(async (_ctx: { cfg?: unknown; to: string; text: string }) => ({
-      channel: "telegram" as const,
-      messageId: "msg-1",
-      chatId: "123456",
-    }));
-    const sendMedia = vi.fn(async (_ctx: { cfg?: unknown }) => ({
-      channel: "telegram" as const,
-      messageId: "msg-2",
-      chatId: "123456",
-    }));
-    await setRegistry(
-      createTestRegistry([
-        {
-          pluginId: "telegram",
-          source: "test",
-          plugin: createStubPlugin({
-            id: "telegram",
-            label: "Telegram",
-            outbound: {
-              deliveryMode: "direct",
-              sendText,
-              sendMedia,
-            },
-          }),
-        },
-      ]),
-    );
-
-    const deps = makeDeps();
-    await messageCommand(
-      {
-        action: "send",
-        channel: "telegram",
-        target: "123456",
-        message: "hi",
-      },
-      deps,
-      runtime,
-    );
 
     expect(sendText).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -323,50 +339,11 @@ describe("messageCommand", () => {
         },
       },
     };
-    testConfig = rawConfig;
-    resolveCommandSecretRefsViaGateway.mockResolvedValueOnce({
+    const { sendText } = await runTelegramDirectOutboundSend({
+      rawConfig: rawConfig as unknown as Record<string, unknown>,
       resolvedConfig: locallyResolvedConfig as unknown as Record<string, unknown>,
       diagnostics: ["gateway secrets.resolve unavailable; used local resolver fallback."],
     });
-    const sendText = vi.fn(async (_ctx: { cfg?: unknown }) => ({
-      channel: "telegram" as const,
-      messageId: "msg-3",
-      chatId: "123456",
-    }));
-    const sendMedia = vi.fn(async (_ctx: { cfg?: unknown }) => ({
-      channel: "telegram" as const,
-      messageId: "msg-4",
-      chatId: "123456",
-    }));
-    await setRegistry(
-      createTestRegistry([
-        {
-          pluginId: "telegram",
-          source: "test",
-          plugin: createStubPlugin({
-            id: "telegram",
-            label: "Telegram",
-            outbound: {
-              deliveryMode: "direct",
-              sendText,
-              sendMedia,
-            },
-          }),
-        },
-      ]),
-    );
-
-    const deps = makeDeps();
-    await messageCommand(
-      {
-        action: "send",
-        channel: "telegram",
-        target: "123456",
-        message: "hi",
-      },
-      deps,
-      runtime,
-    );
 
     expect(sendText).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -34,6 +34,44 @@ function createPrompter(params: { selectValue?: string; textValue?: string }): {
   return { prompter, notes };
 }
 
+function createPerplexityConfig(apiKey: string, enabled?: boolean): RemoteClawConfig {
+  return {
+    tools: {
+      web: {
+        search: {
+          provider: "perplexity",
+          ...(enabled === undefined ? {} : { enabled }),
+          perplexity: { apiKey },
+        },
+      },
+    },
+  };
+}
+
+async function runBlankPerplexityKeyEntry(
+  apiKey: string,
+  enabled?: boolean,
+): Promise<RemoteClawConfig> {
+  const cfg = createPerplexityConfig(apiKey, enabled);
+  const { prompter } = createPrompter({
+    selectValue: "perplexity",
+    textValue: "",
+  });
+  return setupSearch(cfg, runtime, prompter);
+}
+
+async function runQuickstartPerplexitySetup(
+  apiKey: string,
+  enabled?: boolean,
+): Promise<{ result: RemoteClawConfig; prompter: WizardPrompter }> {
+  const cfg = createPerplexityConfig(apiKey, enabled);
+  const { prompter } = createPrompter({ selectValue: "perplexity" });
+  const result = await setupSearch(cfg, runtime, prompter, {
+    quickstartDefaults: true,
+  });
+  return { result, prompter };
+}
+
 describe("setupSearch", () => {
   it("returns config unchanged when user skips", async () => {
     const cfg: RemoteClawConfig = {};
@@ -103,74 +141,49 @@ describe("setupSearch", () => {
   });
 
   it("shows missing-key note when no key is provided and no env var", async () => {
-    const cfg: RemoteClawConfig = {};
-    const { prompter, notes } = createPrompter({
-      selectValue: "brave",
-      textValue: "",
-    });
-    const result = await setupSearch(cfg, runtime, prompter);
-    expect(result.tools?.web?.search?.provider).toBe("brave");
-    expect(result.tools?.web?.search?.enabled).toBeUndefined();
-    const missingNote = notes.find((n) => n.message.includes("No API key stored"));
-    expect(missingNote).toBeDefined();
+    const original = process.env.BRAVE_API_KEY;
+    delete process.env.BRAVE_API_KEY;
+    try {
+      const cfg: RemoteClawConfig = {};
+      const { prompter, notes } = createPrompter({
+        selectValue: "brave",
+        textValue: "",
+      });
+      const result = await setupSearch(cfg, runtime, prompter);
+      expect(result.tools?.web?.search?.provider).toBe("brave");
+      expect(result.tools?.web?.search?.enabled).toBeUndefined();
+      const missingNote = notes.find((n) => n.message.includes("No API key stored"));
+      expect(missingNote).toBeDefined();
+    } finally {
+      if (original === undefined) {
+        delete process.env.BRAVE_API_KEY;
+      } else {
+        process.env.BRAVE_API_KEY = original;
+      }
+    }
   });
 
   it("keeps existing key when user leaves input blank", async () => {
-    const cfg: RemoteClawConfig = {
-      tools: {
-        web: {
-          search: {
-            provider: "perplexity",
-            perplexity: { apiKey: "existing-key" }, // pragma: allowlist secret
-          },
-        },
-      },
-    };
-    const { prompter } = createPrompter({
-      selectValue: "perplexity",
-      textValue: "",
-    });
-    const result = await setupSearch(cfg, runtime, prompter);
+    const result = await runBlankPerplexityKeyEntry(
+      "existing-key", // pragma: allowlist secret
+    );
     expect(result.tools?.web?.search?.perplexity?.apiKey).toBe("existing-key");
     expect(result.tools?.web?.search?.enabled).toBe(true);
   });
 
   it("advanced preserves enabled:false when keeping existing key", async () => {
-    const cfg: RemoteClawConfig = {
-      tools: {
-        web: {
-          search: {
-            provider: "perplexity",
-            enabled: false,
-            perplexity: { apiKey: "existing-key" }, // pragma: allowlist secret
-          },
-        },
-      },
-    };
-    const { prompter } = createPrompter({
-      selectValue: "perplexity",
-      textValue: "",
-    });
-    const result = await setupSearch(cfg, runtime, prompter);
+    const result = await runBlankPerplexityKeyEntry(
+      "existing-key", // pragma: allowlist secret
+      false,
+    );
     expect(result.tools?.web?.search?.perplexity?.apiKey).toBe("existing-key");
     expect(result.tools?.web?.search?.enabled).toBe(false);
   });
 
   it("quickstart skips key prompt when config key exists", async () => {
-    const cfg: RemoteClawConfig = {
-      tools: {
-        web: {
-          search: {
-            provider: "perplexity",
-            perplexity: { apiKey: "stored-pplx-key" }, // pragma: allowlist secret
-          },
-        },
-      },
-    };
-    const { prompter } = createPrompter({ selectValue: "perplexity" });
-    const result = await setupSearch(cfg, runtime, prompter, {
-      quickstartDefaults: true,
-    });
+    const { result, prompter } = await runQuickstartPerplexitySetup(
+      "stored-pplx-key", // pragma: allowlist secret
+    );
     expect(result.tools?.web?.search?.provider).toBe("perplexity");
     expect(result.tools?.web?.search?.perplexity?.apiKey).toBe("stored-pplx-key");
     expect(result.tools?.web?.search?.enabled).toBe(true);
@@ -178,21 +191,10 @@ describe("setupSearch", () => {
   });
 
   it("quickstart preserves enabled:false when search was intentionally disabled", async () => {
-    const cfg: RemoteClawConfig = {
-      tools: {
-        web: {
-          search: {
-            provider: "perplexity",
-            enabled: false,
-            perplexity: { apiKey: "stored-pplx-key" }, // pragma: allowlist secret
-          },
-        },
-      },
-    };
-    const { prompter } = createPrompter({ selectValue: "perplexity" });
-    const result = await setupSearch(cfg, runtime, prompter, {
-      quickstartDefaults: true,
-    });
+    const { result, prompter } = await runQuickstartPerplexitySetup(
+      "stored-pplx-key", // pragma: allowlist secret
+      false,
+    );
     expect(result.tools?.web?.search?.provider).toBe("perplexity");
     expect(result.tools?.web?.search?.perplexity?.apiKey).toBe("stored-pplx-key");
     expect(result.tools?.web?.search?.enabled).toBe(false);
@@ -200,14 +202,24 @@ describe("setupSearch", () => {
   });
 
   it("quickstart falls through to key prompt when no key and no env var", async () => {
-    const cfg: RemoteClawConfig = {};
-    const { prompter } = createPrompter({ selectValue: "grok", textValue: "" });
-    const result = await setupSearch(cfg, runtime, prompter, {
-      quickstartDefaults: true,
-    });
-    expect(prompter.text).toHaveBeenCalled();
-    expect(result.tools?.web?.search?.provider).toBe("grok");
-    expect(result.tools?.web?.search?.enabled).toBeUndefined();
+    const original = process.env.XAI_API_KEY;
+    delete process.env.XAI_API_KEY;
+    try {
+      const cfg: RemoteClawConfig = {};
+      const { prompter } = createPrompter({ selectValue: "grok", textValue: "" });
+      const result = await setupSearch(cfg, runtime, prompter, {
+        quickstartDefaults: true,
+      });
+      expect(prompter.text).toHaveBeenCalled();
+      expect(result.tools?.web?.search?.provider).toBe("grok");
+      expect(result.tools?.web?.search?.enabled).toBeUndefined();
+    } finally {
+      if (original === undefined) {
+        delete process.env.XAI_API_KEY;
+      } else {
+        process.env.XAI_API_KEY = original;
+      }
+    }
   });
 
   it("quickstart skips key prompt when env var is available", async () => {

--- a/src/commands/status-all/channels.mattermost-token-summary.test.ts
+++ b/src/commands/status-all/channels.mattermost-token-summary.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.js";
+import { makeDirectPlugin } from "../../test-utils/channel-plugin-test-fixtures.js";
 import { buildChannelsTable } from "./channels.js";
 
 vi.mock("../../channels/plugins/index.js", () => ({
@@ -59,29 +60,6 @@ function makeSlackPlugin(params?: { botToken?: string; appToken?: string }): Cha
       isConfigured: () => true,
       isEnabled: () => true,
     },
-    actions: {
-      listActions: () => ["send"],
-    },
-  };
-}
-
-function makeDirectPlugin(params: {
-  id: string;
-  label: string;
-  docsPath: string;
-  config: ChannelPlugin["config"];
-}): ChannelPlugin {
-  return {
-    id: params.id,
-    meta: {
-      id: params.id,
-      label: params.label,
-      selectionLabel: params.label,
-      docsPath: params.docsPath,
-      blurb: "test",
-    },
-    capabilities: { chatTypes: ["direct"] },
-    config: params.config,
     actions: {
       listActions: () => ["send"],
     },

--- a/src/commands/status-all/channels.mattermost-token-summary.test.ts
+++ b/src/commands/status-all/channels.mattermost-token-summary.test.ts
@@ -65,17 +65,34 @@ function makeSlackPlugin(params?: { botToken?: string; appToken?: string }): Cha
   };
 }
 
-function makeTokenPlugin(): ChannelPlugin {
+function makeDirectPlugin(params: {
+  id: string;
+  label: string;
+  docsPath: string;
+  config: ChannelPlugin["config"];
+}): ChannelPlugin {
   return {
-    id: "token-only",
+    id: params.id,
     meta: {
-      id: "token-only",
-      label: "TokenOnly",
-      selectionLabel: "TokenOnly",
-      docsPath: "/channels/token-only",
+      id: params.id,
+      label: params.label,
+      selectionLabel: params.label,
+      docsPath: params.docsPath,
       blurb: "test",
     },
     capabilities: { chatTypes: ["direct"] },
+    config: params.config,
+    actions: {
+      listActions: () => ["send"],
+    },
+  };
+}
+
+function makeTokenPlugin(): ChannelPlugin {
+  return makeDirectPlugin({
+    id: "token-only",
+    label: "TokenOnly",
+    docsPath: "/channels/token-only",
     config: {
       listAccountIds: () => ["primary"],
       defaultAccountId: () => "primary",
@@ -87,10 +104,7 @@ function makeTokenPlugin(): ChannelPlugin {
       isConfigured: () => true,
       isEnabled: () => true,
     },
-    actions: {
-      listActions: () => ["send"],
-    },
-  };
+  });
 }
 
 describe("buildChannelsTable - mattermost token summary", () => {

--- a/src/test-utils/channel-plugin-test-fixtures.ts
+++ b/src/test-utils/channel-plugin-test-fixtures.ts
@@ -1,0 +1,24 @@
+import type { ChannelPlugin } from "../channels/plugins/types.js";
+
+export function makeDirectPlugin(params: {
+  id: string;
+  label: string;
+  docsPath: string;
+  config: ChannelPlugin["config"];
+}): ChannelPlugin {
+  return {
+    id: params.id,
+    meta: {
+      id: params.id,
+      label: params.label,
+      selectionLabel: params.label,
+      docsPath: params.docsPath,
+      blurb: "test",
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: params.config,
+    actions: {
+      listActions: () => ["send"],
+    },
+  };
+}


### PR DESCRIPTION
Closes #851

## Cherry-picks from upstream

See issue for full commit list and triage details.

**8 commits picked, 6 skipped** (touched only fork-deleted files).

### Picked
- `0a7332805` refactor(cli): dedupe restart health probe setup tests (RESOLVED)
- `8e6acded8` refactor(commands): dedupe message command secret-config tests (PICKED)
- `6f3990ddc` refactor(commands): dedupe onboard search perplexity test setup (RESOLVED)
- `c1a8f8150` refactor(commands): dedupe gateway status token secret fixtures (RESOLVED)
- `bcb587a3b` refactor(commands): dedupe channel plugin test fixture builders (RESOLVED)
- `ce9719c65` refactor(test-utils): share direct channel plugin test fixture (RESOLVED)
- `02f99c0ff` docs: clarify agent owner trust defaults (PICKED)
- `2ada1b71b` fix(models-auth): land #38951 from @MumuTW (RESOLVED)

### Skipped (fork-deleted files)
- `d10391889` refactor(commands): dedupe model probe target test fixtures
- `4e8fcc1d3` refactor(cli): dedupe command secret gateway env fixtures
- `5f5633301` refactor(commands): dedupe config-only channel status fixtures
- `3acf46ed4` Tests: fix doctor gateway auth token formatting
- `fbb9bb08c` style(test): format gateway auth token coverage
- `0848a47c9` refactor: dedupe anthropic probe target test setup