### PR TITLE
Cherry-pick issue #852: channel adapter test dedup & discord fixes

### DIFF
--- a/src/discord/monitor/message-handler.bot-self-filter.test.ts
+++ b/src/discord/monitor/message-handler.bot-self-filter.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import type { RemoteClawConfig } from "../../config/types.js";
-import { createNoopThreadBindingManager } from "./thread-bindings.js";
+import {
+  DEFAULT_DISCORD_BOT_USER_ID,
+  createDiscordHandlerParams,
+  createDiscordPreflightContext,
+} from "./message-handler.test-helpers.js";
 
 const preflightDiscordMessageMock = vi.hoisted(() => vi.fn());
 const processDiscordMessageMock = vi.hoisted(() => vi.fn());
@@ -15,53 +18,12 @@ vi.mock("./message-handler.process.js", () => ({
 
 const { createDiscordMessageHandler } = await import("./message-handler.js");
 
-const BOT_USER_ID = "bot-123";
-
-function createHandlerParams(overrides?: Partial<{ botUserId: string }>) {
-  const cfg: RemoteClawConfig = {
-    channels: {
-      discord: {
-        enabled: true,
-        token: "test-token",
-        groupPolicy: "allowlist",
-      },
-    },
-    messages: {
-      inbound: {
-        debounceMs: 0,
-      },
-    },
-  };
-  return {
-    cfg,
-    discordConfig: cfg.channels?.discord,
-    accountId: "default",
-    token: "test-token",
-    runtime: {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: (code: number): never => {
-        throw new Error(`exit ${code}`);
-      },
-    },
-    botUserId: overrides?.botUserId ?? BOT_USER_ID,
-    guildHistories: new Map(),
-    historyLimit: 0,
-    mediaMaxBytes: 10_000,
-    textLimit: 2000,
-    replyToMode: "off" as const,
-    dmEnabled: true,
-    groupDmEnabled: false,
-    threadBindings: createNoopThreadBindingManager("default"),
-  };
-}
-
 function createMessageData(authorId: string, channelId = "ch-1") {
   return {
-    author: { id: authorId, bot: authorId === BOT_USER_ID },
+    author: { id: authorId, bot: authorId === DEFAULT_DISCORD_BOT_USER_ID },
     message: {
       id: "msg-1",
-      author: { id: authorId, bot: authorId === BOT_USER_ID },
+      author: { id: authorId, bot: authorId === DEFAULT_DISCORD_BOT_USER_ID },
       content: "hello",
       channel_id: channelId,
     },
@@ -70,26 +32,7 @@ function createMessageData(authorId: string, channelId = "ch-1") {
 }
 
 function createPreflightContext(channelId = "ch-1") {
-  return {
-    data: {
-      channel_id: channelId,
-      message: {
-        id: `msg-${channelId}`,
-        channel_id: channelId,
-        attachments: [],
-      },
-    },
-    message: {
-      id: `msg-${channelId}`,
-      channel_id: channelId,
-      attachments: [],
-    },
-    route: {
-      sessionKey: `agent:main:discord:channel:${channelId}`,
-    },
-    baseSessionKey: `agent:main:discord:channel:${channelId}`,
-    messageChannelId: channelId,
-  };
+  return createDiscordPreflightContext(channelId);
 }
 
 describe("createDiscordMessageHandler bot-self filter", () => {
@@ -97,10 +40,10 @@ describe("createDiscordMessageHandler bot-self filter", () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();
 
-    const handler = createDiscordMessageHandler(createHandlerParams());
+    const handler = createDiscordMessageHandler(createDiscordHandlerParams());
 
     await expect(
-      handler(createMessageData(BOT_USER_ID) as never, {} as never),
+      handler(createMessageData(DEFAULT_DISCORD_BOT_USER_ID) as never, {} as never),
     ).resolves.toBeUndefined();
 
     expect(preflightDiscordMessageMock).not.toHaveBeenCalled();
@@ -115,7 +58,7 @@ describe("createDiscordMessageHandler bot-self filter", () => {
         createPreflightContext(params.data.channel_id),
     );
 
-    const handler = createDiscordMessageHandler(createHandlerParams());
+    const handler = createDiscordMessageHandler(createDiscordHandlerParams());
 
     await expect(
       handler(createMessageData("user-456") as never, {} as never),

--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -164,6 +164,71 @@ function createMessage(params: {
   } as unknown as import("@buape/carbon").Message;
 }
 
+async function runThreadBoundPreflight(params: {
+  threadId: string;
+  parentId: string;
+  message: import("@buape/carbon").Message;
+  threadBinding: import("../../infra/outbound/session-binding-service.js").SessionBindingRecord;
+  discordConfig: DiscordConfig;
+  registerBindingAdapter?: boolean;
+}) {
+  if (params.registerBindingAdapter) {
+    registerSessionBindingAdapter({
+      channel: "discord",
+      accountId: "default",
+      listBySession: () => [],
+      resolveByConversation: (ref) =>
+        ref.conversationId === params.threadId ? params.threadBinding : null,
+    });
+  }
+
+  const client = createThreadClient({
+    threadId: params.threadId,
+    parentId: params.parentId,
+  });
+
+  return preflightDiscordMessage({
+    ...createPreflightArgs({
+      cfg: DEFAULT_CFG,
+      discordConfig: params.discordConfig,
+      data: createGuildEvent({
+        channelId: params.threadId,
+        guildId: "guild-1",
+        author: params.message.author,
+        message: params.message,
+      }),
+      client,
+    }),
+    threadBindings: {
+      getByThreadId: (id: string) => (id === params.threadId ? params.threadBinding : undefined),
+    } as import("./thread-bindings.js").ThreadBindingManager,
+  });
+}
+
+async function runGuildPreflight(params: {
+  channelId: string;
+  guildId: string;
+  message: import("@buape/carbon").Message;
+  discordConfig: DiscordConfig;
+  cfg?: import("../../config/config.js").OpenClawConfig;
+  guildEntries?: Parameters<typeof preflightDiscordMessage>[0]["guildEntries"];
+}) {
+  return preflightDiscordMessage({
+    ...createPreflightArgs({
+      cfg: params.cfg ?? DEFAULT_CFG,
+      discordConfig: params.discordConfig,
+      data: createGuildEvent({
+        channelId: params.channelId,
+        guildId: params.guildId,
+        author: params.message.author,
+        message: params.message,
+      }),
+      client: createGuildTextClient(params.channelId),
+    }),
+    guildEntries: params.guildEntries,
+  });
+}
+
 describe("resolvePreflightMentionRequirement", () => {
   it("requires mention when config requires mention and thread is not bound", () => {
     expect(
@@ -206,7 +271,6 @@ describe("preflightDiscordMessage", () => {
     });
     const threadId = "thread-system-1";
     const parentId = "channel-parent-1";
-    const client = createThreadClient({ threadId, parentId });
     const message = createMessage({
       id: "m-system-1",
       channelId: threadId,
@@ -219,23 +283,14 @@ describe("preflightDiscordMessage", () => {
       },
     });
 
-    const result = await preflightDiscordMessage({
-      ...createPreflightArgs({
-        cfg: DEFAULT_CFG,
-        discordConfig: {
-          allowBots: true,
-        } as DiscordConfig,
-        data: createGuildEvent({
-          channelId: threadId,
-          guildId: "guild-1",
-          author: message.author,
-          message,
-        }),
-        client,
-      }),
-      threadBindings: {
-        getByThreadId: (id: string) => (id === threadId ? threadBinding : undefined),
-      } as import("./thread-bindings.js").ThreadBindingManager,
+    const result = await runThreadBoundPreflight({
+      threadId,
+      parentId,
+      message,
+      threadBinding,
+      discordConfig: {
+        allowBots: true,
+      } as DiscordConfig,
     });
 
     expect(result).toBeNull();
@@ -248,7 +303,6 @@ describe("preflightDiscordMessage", () => {
     });
     const threadId = "thread-bot-regular-1";
     const parentId = "channel-parent-regular-1";
-    const client = createThreadClient({ threadId, parentId });
     const message = createMessage({
       id: "m-bot-regular-1",
       channelId: threadId,
@@ -260,33 +314,15 @@ describe("preflightDiscordMessage", () => {
       },
     });
 
-    registerSessionBindingAdapter({
-      channel: "discord",
-      accountId: "default",
-      listBySession: () => [],
-      resolveByConversation: (ref) =>
-        ref.conversationId === threadId
-          ? (threadBinding as unknown as import("../../infra/outbound/session-binding-service.js").SessionBindingRecord)
-          : null,
-    });
-
-    const result = await preflightDiscordMessage({
-      ...createPreflightArgs({
-        cfg: DEFAULT_CFG,
-        discordConfig: {
-          allowBots: true,
-        } as DiscordConfig,
-        data: createGuildEvent({
-          channelId: threadId,
-          guildId: "guild-1",
-          author: message.author,
-          message,
-        }),
-        client,
-      }),
-      threadBindings: {
-        getByThreadId: (id: string) => (id === threadId ? threadBinding : undefined),
-      } as import("./thread-bindings.js").ThreadBindingManager,
+    const result = await runThreadBoundPreflight({
+      threadId,
+      parentId,
+      message,
+      threadBinding,
+      discordConfig: {
+        allowBots: true,
+      } as DiscordConfig,
+      registerBindingAdapter: true,
     });
 
     expect(result).not.toBeNull();
@@ -335,7 +371,6 @@ describe("preflightDiscordMessage", () => {
   it("drops bot messages without mention when allowBots=mentions", async () => {
     const channelId = "channel-bot-mentions-off";
     const guildId = "guild-bot-mentions-off";
-    const client = createGuildTextClient(channelId);
     const message = createMessage({
       id: "m-bot-mentions-off",
       channelId,
@@ -347,20 +382,13 @@ describe("preflightDiscordMessage", () => {
       },
     });
 
-    const result = await preflightDiscordMessage({
-      ...createPreflightArgs({
-        cfg: DEFAULT_CFG,
-        discordConfig: {
-          allowBots: "mentions",
-        } as DiscordConfig,
-        data: createGuildEvent({
-          channelId,
-          guildId,
-          author: message.author,
-          message,
-        }),
-        client,
-      }),
+    const result = await runGuildPreflight({
+      channelId,
+      guildId,
+      message,
+      discordConfig: {
+        allowBots: "mentions",
+      } as DiscordConfig,
     });
 
     expect(result).toBeNull();
@@ -369,7 +397,6 @@ describe("preflightDiscordMessage", () => {
   it("allows bot messages with explicit mention when allowBots=mentions", async () => {
     const channelId = "channel-bot-mentions-on";
     const guildId = "guild-bot-mentions-on";
-    const client = createGuildTextClient(channelId);
     const message = createMessage({
       id: "m-bot-mentions-on",
       channelId,
@@ -382,20 +409,13 @@ describe("preflightDiscordMessage", () => {
       },
     });
 
-    const result = await preflightDiscordMessage({
-      ...createPreflightArgs({
-        cfg: DEFAULT_CFG,
-        discordConfig: {
-          allowBots: "mentions",
-        } as DiscordConfig,
-        data: createGuildEvent({
-          channelId,
-          guildId,
-          author: message.author,
-          message,
-        }),
-        client,
-      }),
+    const result = await runGuildPreflight({
+      channelId,
+      guildId,
+      message,
+      discordConfig: {
+        allowBots: "mentions",
+      } as DiscordConfig,
     });
 
     expect(result).not.toBeNull();
@@ -404,7 +424,6 @@ describe("preflightDiscordMessage", () => {
   it("drops guild messages that mention another user when ignoreOtherMentions=true", async () => {
     const channelId = "channel-other-mention-1";
     const guildId = "guild-other-mention-1";
-    const client = createGuildTextClient(channelId);
     const message = createMessage({
       id: "m-other-mention-1",
       channelId,
@@ -417,18 +436,11 @@ describe("preflightDiscordMessage", () => {
       },
     });
 
-    const result = await preflightDiscordMessage({
-      ...createPreflightArgs({
-        cfg: DEFAULT_CFG,
-        discordConfig: {} as DiscordConfig,
-        data: createGuildEvent({
-          channelId,
-          guildId,
-          author: message.author,
-          message,
-        }),
-        client,
-      }),
+    const result = await runGuildPreflight({
+      channelId,
+      guildId,
+      message,
+      discordConfig: {} as DiscordConfig,
       guildEntries: {
         [guildId]: {
           requireMention: false,
@@ -443,7 +455,6 @@ describe("preflightDiscordMessage", () => {
   it("does not drop @everyone messages when ignoreOtherMentions=true", async () => {
     const channelId = "channel-other-mention-everyone";
     const guildId = "guild-other-mention-everyone";
-    const client = createGuildTextClient(channelId);
     const message = createMessage({
       id: "m-other-mention-everyone",
       channelId,
@@ -456,18 +467,11 @@ describe("preflightDiscordMessage", () => {
       },
     });
 
-    const result = await preflightDiscordMessage({
-      ...createPreflightArgs({
-        cfg: DEFAULT_CFG,
-        discordConfig: {} as DiscordConfig,
-        data: createGuildEvent({
-          channelId,
-          guildId,
-          author: message.author,
-          message,
-        }),
-        client,
-      }),
+    const result = await runGuildPreflight({
+      channelId,
+      guildId,
+      message,
+      discordConfig: {} as DiscordConfig,
       guildEntries: {
         [guildId]: {
           requireMention: false,

--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -168,7 +168,7 @@ async function runThreadBoundPreflight(params: {
   threadId: string;
   parentId: string;
   message: import("@buape/carbon").Message;
-  threadBinding: import("../../infra/outbound/session-binding-service.js").SessionBindingRecord;
+  threadBinding: import("./thread-bindings.js").ThreadBindingRecord;
   discordConfig: DiscordConfig;
   registerBindingAdapter?: boolean;
 }) {
@@ -178,7 +178,7 @@ async function runThreadBoundPreflight(params: {
       accountId: "default",
       listBySession: () => [],
       resolveByConversation: (ref) =>
-        ref.conversationId === params.threadId ? params.threadBinding : null,
+        ref.conversationId === params.threadId ? (params.threadBinding as never) : null,
     });
   }
 
@@ -210,7 +210,7 @@ async function runGuildPreflight(params: {
   guildId: string;
   message: import("@buape/carbon").Message;
   discordConfig: DiscordConfig;
-  cfg?: import("../../config/config.js").OpenClawConfig;
+  cfg?: import("../../config/config.js").RemoteClawConfig;
   guildEntries?: Parameters<typeof preflightDiscordMessage>[0]["guildEntries"];
 }) {
   return preflightDiscordMessage({

--- a/src/discord/monitor/message-handler.queue.test.ts
+++ b/src/discord/monitor/message-handler.queue.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import type { RemoteClawConfig } from "../../config/types.js";
-import { createNoopThreadBindingManager } from "./thread-bindings.js";
+import {
+  createDiscordHandlerParams,
+  createDiscordPreflightContext,
+} from "./message-handler.test-helpers.js";
 
 const preflightDiscordMessageMock = vi.hoisted(() => vi.fn());
 const processDiscordMessageMock = vi.hoisted(() => vi.fn());
@@ -24,52 +26,6 @@ function createDeferred<T = void>() {
   return { promise, resolve };
 }
 
-function createHandlerParams(overrides?: {
-  setStatus?: (patch: Record<string, unknown>) => void;
-  abortSignal?: AbortSignal;
-  workerRunTimeoutMs?: number;
-}) {
-  const cfg: RemoteClawConfig = {
-    channels: {
-      discord: {
-        enabled: true,
-        token: "test-token",
-        groupPolicy: "allowlist",
-      },
-    },
-    messages: {
-      inbound: {
-        debounceMs: 0,
-      },
-    },
-  };
-  return {
-    cfg,
-    discordConfig: cfg.channels?.discord,
-    accountId: "default",
-    token: "test-token",
-    runtime: {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: (code: number): never => {
-        throw new Error(`exit ${code}`);
-      },
-    },
-    botUserId: "bot-123",
-    guildHistories: new Map(),
-    historyLimit: 0,
-    mediaMaxBytes: 10_000,
-    textLimit: 2_000,
-    replyToMode: "off" as const,
-    dmEnabled: true,
-    groupDmEnabled: false,
-    threadBindings: createNoopThreadBindingManager("default"),
-    setStatus: overrides?.setStatus,
-    abortSignal: overrides?.abortSignal,
-    workerRunTimeoutMs: overrides?.workerRunTimeoutMs,
-  };
-}
-
 function createMessageData(messageId: string, channelId = "ch-1") {
   return {
     channel_id: channelId,
@@ -85,25 +41,43 @@ function createMessageData(messageId: string, channelId = "ch-1") {
 }
 
 function createPreflightContext(channelId = "ch-1") {
+  return createDiscordPreflightContext(channelId);
+}
+
+async function createLifecycleStopScenario(params: {
+  createHandler: (status: ReturnType<typeof vi.fn>) => {
+    handler: (data: never, opts: never) => Promise<void>;
+    stop: () => void;
+  };
+}) {
+  const runInFlight = createDeferred();
+  processDiscordMessageMock.mockImplementation(async () => {
+    await runInFlight.promise;
+  });
+  preflightDiscordMessageMock.mockImplementation(
+    async (contextParams: { data: { channel_id: string } }) =>
+      createPreflightContext(contextParams.data.channel_id),
+  );
+
+  const setStatus = vi.fn();
+  const { handler, stop } = params.createHandler(setStatus);
+
+  await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
+  await vi.waitFor(() => {
+    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  const callsBeforeStop = setStatus.mock.calls.length;
+  stop();
+
   return {
-    data: {
-      channel_id: channelId,
-      message: {
-        id: `msg-${channelId}`,
-        channel_id: channelId,
-        attachments: [],
-      },
+    setStatus,
+    callsBeforeStop,
+    finish: async () => {
+      runInFlight.resolve();
+      await runInFlight.promise;
+      await Promise.resolve();
     },
-    message: {
-      id: `msg-${channelId}`,
-      channel_id: channelId,
-      attachments: [],
-    },
-    route: {
-      sessionKey: `agent:main:discord:channel:${channelId}`,
-    },
-    baseSessionKey: `agent:main:discord:channel:${channelId}`,
-    messageChannelId: channelId,
   };
 }
 
@@ -113,7 +87,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
     processDiscordMessageMock.mockReset();
 
     const setStatus = vi.fn();
-    createDiscordMessageHandler(createHandlerParams({ setStatus }));
+    createDiscordMessageHandler(createDiscordHandlerParams({ setStatus }));
 
     expect(setStatus).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -142,7 +116,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
     );
 
     const setStatus = vi.fn();
-    const handler = createDiscordMessageHandler(createHandlerParams({ setStatus }));
+    const handler = createDiscordMessageHandler(createDiscordHandlerParams({ setStatus }));
 
     await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
 
@@ -205,7 +179,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
           createPreflightContext(params.data.channel_id),
       );
 
-      const params = createHandlerParams({ workerRunTimeoutMs: 50 });
+      const params = createDiscordHandlerParams({ workerRunTimeoutMs: 50 });
       const handler = createDiscordMessageHandler(params);
 
       await expect(
@@ -256,7 +230,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
           createPreflightContext(params.data.channel_id),
       );
 
-      const params = createHandlerParams({ workerRunTimeoutMs: 0 });
+      const params = createDiscordHandlerParams({ workerRunTimeoutMs: 0 });
       const handler = createDiscordMessageHandler(params);
 
       await expect(
@@ -305,7 +279,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
 
     try {
       const setStatus = vi.fn();
-      const handler = createDiscordMessageHandler(createHandlerParams({ setStatus }));
+      const handler = createDiscordMessageHandler(createDiscordHandlerParams({ setStatus }));
       await expect(
         handler(createMessageData("m-1") as never, {} as never),
       ).resolves.toBeUndefined();
@@ -342,67 +316,35 @@ describe("createDiscordMessageHandler queue behavior", () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();
 
-    const runInFlight = createDeferred();
-    processDiscordMessageMock.mockImplementation(async () => {
-      await runInFlight.promise;
-    });
-    preflightDiscordMessageMock.mockImplementation(
-      async (params: { data: { channel_id: string } }) =>
-        createPreflightContext(params.data.channel_id),
-    );
-
-    const setStatus = vi.fn();
-    const abortController = new AbortController();
-    const handler = createDiscordMessageHandler(
-      createHandlerParams({ setStatus, abortSignal: abortController.signal }),
-    );
-
-    await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
-
-    await vi.waitFor(() => {
-      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+    const { setStatus, callsBeforeStop, finish } = await createLifecycleStopScenario({
+      createHandler: (status) => {
+        const abortController = new AbortController();
+        const handler = createDiscordMessageHandler(
+          createDiscordHandlerParams({ setStatus: status, abortSignal: abortController.signal }),
+        );
+        return { handler, stop: () => abortController.abort() };
+      },
     });
 
-    const callsBeforeAbort = setStatus.mock.calls.length;
-    abortController.abort();
-
-    runInFlight.resolve();
-    await runInFlight.promise;
-    await Promise.resolve();
-
-    expect(setStatus.mock.calls.length).toBe(callsBeforeAbort);
+    await finish();
+    expect(setStatus.mock.calls.length).toBe(callsBeforeStop);
   });
 
   it("stops status publishing after handler deactivation", async () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();
 
-    const runInFlight = createDeferred();
-    processDiscordMessageMock.mockImplementation(async () => {
-      await runInFlight.promise;
-    });
-    preflightDiscordMessageMock.mockImplementation(
-      async (params: { data: { channel_id: string } }) =>
-        createPreflightContext(params.data.channel_id),
-    );
-
-    const setStatus = vi.fn();
-    const handler = createDiscordMessageHandler(createHandlerParams({ setStatus }));
-
-    await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
-
-    await vi.waitFor(() => {
-      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+    const { setStatus, callsBeforeStop, finish } = await createLifecycleStopScenario({
+      createHandler: (status) => {
+        const handler = createDiscordMessageHandler(
+          createDiscordHandlerParams({ setStatus: status }),
+        );
+        return { handler, stop: () => handler.deactivate() };
+      },
     });
 
-    const callsBeforeDeactivate = setStatus.mock.calls.length;
-    handler.deactivate();
-
-    runInFlight.resolve();
-    await runInFlight.promise;
-    await Promise.resolve();
-
-    expect(setStatus.mock.calls.length).toBe(callsBeforeDeactivate);
+    await finish();
+    expect(setStatus.mock.calls.length).toBe(callsBeforeStop);
   });
 
   it("skips queued runs that have not started yet after deactivation", async () => {
@@ -420,7 +362,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
         createPreflightContext(params.data.channel_id),
     );
 
-    const handler = createDiscordMessageHandler(createHandlerParams());
+    const handler = createDiscordMessageHandler(createDiscordHandlerParams());
     await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
     await vi.waitFor(() => {
       expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
@@ -460,7 +402,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
       processedMessageIds.push(ctx.messageId ?? "unknown");
     });
 
-    const handler = createDiscordMessageHandler(createHandlerParams());
+    const handler = createDiscordMessageHandler(createDiscordHandlerParams());
 
     const sequentialDispatch = (async () => {
       await handler(createMessageData("m-1") as never, {} as never);
@@ -499,7 +441,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
     );
 
     const setStatus = vi.fn();
-    const handler = createDiscordMessageHandler(createHandlerParams({ setStatus }));
+    const handler = createDiscordMessageHandler(createDiscordHandlerParams({ setStatus }));
 
     await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
     await expect(handler(createMessageData("m-2") as never, {} as never)).resolves.toBeUndefined();

--- a/src/discord/monitor/message-handler.queue.test.ts
+++ b/src/discord/monitor/message-handler.queue.test.ts
@@ -320,7 +320,10 @@ describe("createDiscordMessageHandler queue behavior", () => {
       createHandler: (status) => {
         const abortController = new AbortController();
         const handler = createDiscordMessageHandler(
-          createDiscordHandlerParams({ setStatus: status, abortSignal: abortController.signal }),
+          createDiscordHandlerParams({
+            setStatus: status as never,
+            abortSignal: abortController.signal,
+          }),
         );
         return { handler, stop: () => abortController.abort() };
       },
@@ -337,7 +340,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
     const { setStatus, callsBeforeStop, finish } = await createLifecycleStopScenario({
       createHandler: (status) => {
         const handler = createDiscordMessageHandler(
-          createDiscordHandlerParams({ setStatus: status }),
+          createDiscordHandlerParams({ setStatus: status as never }),
         );
         return { handler, stop: () => handler.deactivate() };
       },

--- a/src/discord/monitor/message-handler.test-helpers.ts
+++ b/src/discord/monitor/message-handler.test-helpers.ts
@@ -30,8 +30,8 @@ export function createDiscordHandlerParams(overrides?: {
     accountId: "default",
     token: "test-token",
     runtime: {
-      log: vi.fn(),
-      error: vi.fn(),
+      log: vi.fn() as (...args: unknown[]) => void,
+      error: vi.fn() as (...args: unknown[]) => void,
       exit: (code: number): never => {
         throw new Error(`exit ${code}`);
       },

--- a/src/discord/monitor/message-handler.test-helpers.ts
+++ b/src/discord/monitor/message-handler.test-helpers.ts
@@ -1,0 +1,75 @@
+import { vi } from "vitest";
+import type { RemoteClawConfig } from "../../config/types.js";
+import { createNoopThreadBindingManager } from "./thread-bindings.js";
+
+export const DEFAULT_DISCORD_BOT_USER_ID = "bot-123";
+
+export function createDiscordHandlerParams(overrides?: {
+  botUserId?: string;
+  setStatus?: (patch: Record<string, unknown>) => void;
+  abortSignal?: AbortSignal;
+  workerRunTimeoutMs?: number;
+}) {
+  const cfg: RemoteClawConfig = {
+    channels: {
+      discord: {
+        enabled: true,
+        token: "test-token",
+        groupPolicy: "allowlist",
+      },
+    },
+    messages: {
+      inbound: {
+        debounceMs: 0,
+      },
+    },
+  };
+  return {
+    cfg,
+    discordConfig: cfg.channels?.discord,
+    accountId: "default",
+    token: "test-token",
+    runtime: {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: (code: number): never => {
+        throw new Error(`exit ${code}`);
+      },
+    },
+    botUserId: overrides?.botUserId ?? DEFAULT_DISCORD_BOT_USER_ID,
+    guildHistories: new Map(),
+    historyLimit: 0,
+    mediaMaxBytes: 10_000,
+    textLimit: 2_000,
+    replyToMode: "off" as const,
+    dmEnabled: true,
+    groupDmEnabled: false,
+    threadBindings: createNoopThreadBindingManager("default"),
+    setStatus: overrides?.setStatus,
+    abortSignal: overrides?.abortSignal,
+    workerRunTimeoutMs: overrides?.workerRunTimeoutMs,
+  };
+}
+
+export function createDiscordPreflightContext(channelId = "ch-1") {
+  return {
+    data: {
+      channel_id: channelId,
+      message: {
+        id: `msg-${channelId}`,
+        channel_id: channelId,
+        attachments: [],
+      },
+    },
+    message: {
+      id: `msg-${channelId}`,
+      channel_id: channelId,
+      attachments: [],
+    },
+    route: {
+      sessionKey: `agent:main:discord:channel:${channelId}`,
+    },
+    baseSessionKey: `agent:main:discord:channel:${channelId}`,
+    messageChannelId: channelId,
+  };
+}

--- a/src/discord/monitor/native-command.commands-allowfrom.test.ts
+++ b/src/discord/monitor/native-command.commands-allowfrom.test.ts
@@ -1,0 +1,245 @@
+import { ChannelType } from "@buape/carbon";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NativeCommandSpec } from "../../auto-reply/commands-registry.js";
+import * as dispatcherModule from "../../auto-reply/reply/provider-dispatcher.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import * as pluginCommandsModule from "../../plugins/commands.js";
+import { createDiscordNativeCommand } from "./native-command.js";
+import { createNoopThreadBindingManager } from "./thread-bindings.js";
+
+type MockCommandInteraction = {
+  user: { id: string; username: string; globalName: string };
+  channel: { type: ChannelType; id: string };
+  guild: { id: string; name?: string } | null;
+  rawData: { id: string; member: { roles: string[] } };
+  options: {
+    getString: ReturnType<typeof vi.fn>;
+    getNumber: ReturnType<typeof vi.fn>;
+    getBoolean: ReturnType<typeof vi.fn>;
+  };
+  reply: ReturnType<typeof vi.fn>;
+  followUp: ReturnType<typeof vi.fn>;
+  client: object;
+};
+
+function createInteraction(params?: {
+  userId?: string;
+  channelId?: string;
+  guildId?: string;
+  guildName?: string;
+}): MockCommandInteraction {
+  return {
+    user: {
+      id: params?.userId ?? "123456789012345678",
+      username: "discord-user",
+      globalName: "Discord User",
+    },
+    channel: {
+      type: ChannelType.GuildText,
+      id: params?.channelId ?? "234567890123456789",
+    },
+    guild: {
+      id: params?.guildId ?? "345678901234567890",
+      name: params?.guildName ?? "Test Guild",
+    },
+    rawData: {
+      id: "interaction-1",
+      member: { roles: [] },
+    },
+    options: {
+      getString: vi.fn().mockReturnValue(null),
+      getNumber: vi.fn().mockReturnValue(null),
+      getBoolean: vi.fn().mockReturnValue(null),
+    },
+    reply: vi.fn().mockResolvedValue({ ok: true }),
+    followUp: vi.fn().mockResolvedValue({ ok: true }),
+    client: {},
+  };
+}
+
+function createConfig(): OpenClawConfig {
+  return {
+    commands: {
+      allowFrom: {
+        discord: ["user:123456789012345678"],
+      },
+    },
+    channels: {
+      discord: {
+        groupPolicy: "allowlist",
+        guilds: {
+          "345678901234567890": {
+            channels: {
+              "234567890123456789": {
+                allow: true,
+                requireMention: false,
+              },
+            },
+          },
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+function createCommand(cfg: OpenClawConfig) {
+  const commandSpec: NativeCommandSpec = {
+    name: "status",
+    description: "Status",
+    acceptsArgs: false,
+  };
+  return createDiscordNativeCommand({
+    command: commandSpec,
+    cfg,
+    discordConfig: cfg.channels?.discord ?? {},
+    accountId: "default",
+    sessionPrefix: "discord:slash",
+    ephemeralDefault: true,
+    threadBindings: createNoopThreadBindingManager("default"),
+  });
+}
+
+describe("Discord native slash commands with commands.allowFrom", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("authorizes guild slash commands when commands.allowFrom.discord matches the sender", async () => {
+    const cfg = createConfig();
+    const command = createCommand(cfg);
+    const interaction = createInteraction();
+
+    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
+    const dispatchSpy = vi
+      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
+      .mockResolvedValue({
+        counts: {
+          final: 1,
+          block: 0,
+          tool: 0,
+        },
+      } as never);
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(interaction.reply).not.toHaveBeenCalledWith(
+      expect.objectContaining({ content: "You are not authorized to use this command." }),
+    );
+  });
+
+  it("authorizes guild slash commands from the global commands.allowFrom list when provider-specific allowFrom is missing", async () => {
+    const cfg = createConfig();
+    cfg.commands = {
+      allowFrom: {
+        "*": ["user:123456789012345678"],
+      },
+    };
+    const command = createCommand(cfg);
+    const interaction = createInteraction();
+
+    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
+    const dispatchSpy = vi
+      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
+      .mockResolvedValue({
+        counts: {
+          final: 1,
+          block: 0,
+          tool: 0,
+        },
+      } as never);
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(interaction.reply).not.toHaveBeenCalledWith(
+      expect.objectContaining({ content: "You are not authorized to use this command." }),
+    );
+  });
+
+  it("authorizes guild slash commands when commands.useAccessGroups is false and commands.allowFrom.discord matches the sender", async () => {
+    const cfg = createConfig();
+    cfg.commands = {
+      ...cfg.commands,
+      useAccessGroups: false,
+    };
+    const command = createCommand(cfg);
+    const interaction = createInteraction();
+
+    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
+    const dispatchSpy = vi
+      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
+      .mockResolvedValue({
+        counts: {
+          final: 1,
+          block: 0,
+          tool: 0,
+        },
+      } as never);
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(interaction.reply).not.toHaveBeenCalledWith(
+      expect.objectContaining({ content: "You are not authorized to use this command." }),
+    );
+  });
+
+  it("rejects guild slash commands when commands.allowFrom.discord does not match the sender", async () => {
+    const cfg = createConfig();
+    const command = createCommand(cfg);
+    const interaction = createInteraction({ userId: "999999999999999999" });
+
+    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
+    const dispatchSpy = vi
+      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
+      .mockResolvedValue({
+        counts: {
+          final: 1,
+          block: 0,
+          tool: 0,
+        },
+      } as never);
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "You are not authorized to use this command.",
+        ephemeral: true,
+      }),
+    );
+  });
+
+  it("rejects guild slash commands when commands.useAccessGroups is false and commands.allowFrom.discord does not match the sender", async () => {
+    const cfg = createConfig();
+    cfg.commands = {
+      ...cfg.commands,
+      useAccessGroups: false,
+    };
+    const command = createCommand(cfg);
+    const interaction = createInteraction({ userId: "999999999999999999" });
+
+    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
+    const dispatchSpy = vi
+      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
+      .mockResolvedValue({
+        counts: {
+          final: 1,
+          block: 0,
+          tool: 0,
+        },
+      } as never);
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "You are not authorized to use this command.",
+        ephemeral: true,
+      }),
+    );
+  });
+});

--- a/src/discord/monitor/native-command.commands-allowfrom.test.ts
+++ b/src/discord/monitor/native-command.commands-allowfrom.test.ts
@@ -1,60 +1,27 @@
-import { ChannelType } from "@buape/carbon";
+import { ChannelType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NativeCommandSpec } from "../../auto-reply/commands-registry.js";
 import * as dispatcherModule from "../../auto-reply/reply/provider-dispatcher.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import * as pluginCommandsModule from "../../plugins/commands.js";
 import { createDiscordNativeCommand } from "./native-command.js";
+import {
+  createMockCommandInteraction,
+  type MockCommandInteraction,
+} from "./native-command.test-helpers.js";
 import { createNoopThreadBindingManager } from "./thread-bindings.js";
 
-type MockCommandInteraction = {
-  user: { id: string; username: string; globalName: string };
-  channel: { type: ChannelType; id: string };
-  guild: { id: string; name?: string } | null;
-  rawData: { id: string; member: { roles: string[] } };
-  options: {
-    getString: ReturnType<typeof vi.fn>;
-    getNumber: ReturnType<typeof vi.fn>;
-    getBoolean: ReturnType<typeof vi.fn>;
-  };
-  reply: ReturnType<typeof vi.fn>;
-  followUp: ReturnType<typeof vi.fn>;
-  client: object;
-};
-
-function createInteraction(params?: {
-  userId?: string;
-  channelId?: string;
-  guildId?: string;
-  guildName?: string;
-}): MockCommandInteraction {
-  return {
-    user: {
-      id: params?.userId ?? "123456789012345678",
-      username: "discord-user",
-      globalName: "Discord User",
-    },
-    channel: {
-      type: ChannelType.GuildText,
-      id: params?.channelId ?? "234567890123456789",
-    },
-    guild: {
-      id: params?.guildId ?? "345678901234567890",
-      name: params?.guildName ?? "Test Guild",
-    },
-    rawData: {
-      id: "interaction-1",
-      member: { roles: [] },
-    },
-    options: {
-      getString: vi.fn().mockReturnValue(null),
-      getNumber: vi.fn().mockReturnValue(null),
-      getBoolean: vi.fn().mockReturnValue(null),
-    },
-    reply: vi.fn().mockResolvedValue({ ok: true }),
-    followUp: vi.fn().mockResolvedValue({ ok: true }),
-    client: {},
-  };
+function createInteraction(params?: { userId?: string }): MockCommandInteraction {
+  return createMockCommandInteraction({
+    userId: params?.userId ?? "123456789012345678",
+    username: "discord-user",
+    globalName: "Discord User",
+    channelType: ChannelType.GuildText,
+    channelId: "234567890123456789",
+    guildId: "345678901234567890",
+    guildName: "Test Guild",
+    interactionId: "interaction-1",
+  });
 }
 
 function createConfig(): OpenClawConfig {
@@ -99,147 +66,102 @@ function createCommand(cfg: OpenClawConfig) {
   });
 }
 
+function createDispatchSpy() {
+  return vi.spyOn(dispatcherModule, "dispatchReplyWithDispatcher").mockResolvedValue({
+    counts: {
+      final: 1,
+      block: 0,
+      tool: 0,
+    },
+  } as never);
+}
+
+async function runGuildSlashCommand(params?: {
+  userId?: string;
+  mutateConfig?: (cfg: OpenClawConfig) => void;
+}) {
+  const cfg = createConfig();
+  params?.mutateConfig?.(cfg);
+  const command = createCommand(cfg);
+  const interaction = createInteraction({ userId: params?.userId });
+  vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
+  const dispatchSpy = createDispatchSpy();
+  await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+  return { dispatchSpy, interaction };
+}
+
+function expectNotUnauthorizedReply(interaction: MockCommandInteraction) {
+  expect(interaction.reply).not.toHaveBeenCalledWith(
+    expect.objectContaining({ content: "You are not authorized to use this command." }),
+  );
+}
+
+function expectUnauthorizedReply(interaction: MockCommandInteraction) {
+  expect(interaction.reply).toHaveBeenCalledWith(
+    expect.objectContaining({
+      content: "You are not authorized to use this command.",
+      ephemeral: true,
+    }),
+  );
+}
+
 describe("Discord native slash commands with commands.allowFrom", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
 
   it("authorizes guild slash commands when commands.allowFrom.discord matches the sender", async () => {
-    const cfg = createConfig();
-    const command = createCommand(cfg);
-    const interaction = createInteraction();
-
-    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
-    const dispatchSpy = vi
-      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
-      .mockResolvedValue({
-        counts: {
-          final: 1,
-          block: 0,
-          tool: 0,
-        },
-      } as never);
-
-    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
-
+    const { dispatchSpy, interaction } = await runGuildSlashCommand();
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    expect(interaction.reply).not.toHaveBeenCalledWith(
-      expect.objectContaining({ content: "You are not authorized to use this command." }),
-    );
+    expectNotUnauthorizedReply(interaction);
   });
 
   it("authorizes guild slash commands from the global commands.allowFrom list when provider-specific allowFrom is missing", async () => {
-    const cfg = createConfig();
-    cfg.commands = {
-      allowFrom: {
-        "*": ["user:123456789012345678"],
+    const { dispatchSpy, interaction } = await runGuildSlashCommand({
+      mutateConfig: (cfg) => {
+        cfg.commands = {
+          allowFrom: {
+            "*": ["user:123456789012345678"],
+          },
+        };
       },
-    };
-    const command = createCommand(cfg);
-    const interaction = createInteraction();
-
-    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
-    const dispatchSpy = vi
-      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
-      .mockResolvedValue({
-        counts: {
-          final: 1,
-          block: 0,
-          tool: 0,
-        },
-      } as never);
-
-    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
-
+    });
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    expect(interaction.reply).not.toHaveBeenCalledWith(
-      expect.objectContaining({ content: "You are not authorized to use this command." }),
-    );
+    expectNotUnauthorizedReply(interaction);
   });
 
   it("authorizes guild slash commands when commands.useAccessGroups is false and commands.allowFrom.discord matches the sender", async () => {
-    const cfg = createConfig();
-    cfg.commands = {
-      ...cfg.commands,
-      useAccessGroups: false,
-    };
-    const command = createCommand(cfg);
-    const interaction = createInteraction();
-
-    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
-    const dispatchSpy = vi
-      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
-      .mockResolvedValue({
-        counts: {
-          final: 1,
-          block: 0,
-          tool: 0,
-        },
-      } as never);
-
-    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
-
+    const { dispatchSpy, interaction } = await runGuildSlashCommand({
+      mutateConfig: (cfg) => {
+        cfg.commands = {
+          ...cfg.commands,
+          useAccessGroups: false,
+        };
+      },
+    });
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    expect(interaction.reply).not.toHaveBeenCalledWith(
-      expect.objectContaining({ content: "You are not authorized to use this command." }),
-    );
+    expectNotUnauthorizedReply(interaction);
   });
 
   it("rejects guild slash commands when commands.allowFrom.discord does not match the sender", async () => {
-    const cfg = createConfig();
-    const command = createCommand(cfg);
-    const interaction = createInteraction({ userId: "999999999999999999" });
-
-    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
-    const dispatchSpy = vi
-      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
-      .mockResolvedValue({
-        counts: {
-          final: 1,
-          block: 0,
-          tool: 0,
-        },
-      } as never);
-
-    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
-
+    const { dispatchSpy, interaction } = await runGuildSlashCommand({
+      userId: "999999999999999999",
+    });
     expect(dispatchSpy).not.toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith(
-      expect.objectContaining({
-        content: "You are not authorized to use this command.",
-        ephemeral: true,
-      }),
-    );
+    expectUnauthorizedReply(interaction);
   });
 
   it("rejects guild slash commands when commands.useAccessGroups is false and commands.allowFrom.discord does not match the sender", async () => {
-    const cfg = createConfig();
-    cfg.commands = {
-      ...cfg.commands,
-      useAccessGroups: false,
-    };
-    const command = createCommand(cfg);
-    const interaction = createInteraction({ userId: "999999999999999999" });
-
-    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
-    const dispatchSpy = vi
-      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
-      .mockResolvedValue({
-        counts: {
-          final: 1,
-          block: 0,
-          tool: 0,
-        },
-      } as never);
-
-    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
-
+    const { dispatchSpy, interaction } = await runGuildSlashCommand({
+      userId: "999999999999999999",
+      mutateConfig: (cfg) => {
+        cfg.commands = {
+          ...cfg.commands,
+          useAccessGroups: false,
+        };
+      },
+    });
     expect(dispatchSpy).not.toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith(
-      expect.objectContaining({
-        content: "You are not authorized to use this command.",
-        ephemeral: true,
-      }),
-    );
+    expectUnauthorizedReply(interaction);
   });
 });

--- a/src/discord/monitor/native-command.commands-allowfrom.test.ts
+++ b/src/discord/monitor/native-command.commands-allowfrom.test.ts
@@ -2,7 +2,7 @@ import { ChannelType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NativeCommandSpec } from "../../auto-reply/commands-registry.js";
 import * as dispatcherModule from "../../auto-reply/reply/provider-dispatcher.js";
-import type { OpenClawConfig } from "../../config/config.js";
+import type { RemoteClawConfig } from "../../config/config.js";
 import * as pluginCommandsModule from "../../plugins/commands.js";
 import { createDiscordNativeCommand } from "./native-command.js";
 import {
@@ -24,7 +24,7 @@ function createInteraction(params?: { userId?: string }): MockCommandInteraction
   });
 }
 
-function createConfig(): OpenClawConfig {
+function createConfig(): RemoteClawConfig {
   return {
     commands: {
       allowFrom: {
@@ -46,10 +46,10 @@ function createConfig(): OpenClawConfig {
         },
       },
     },
-  } as OpenClawConfig;
+  } as RemoteClawConfig;
 }
 
-function createCommand(cfg: OpenClawConfig) {
+function createCommand(cfg: RemoteClawConfig) {
   const commandSpec: NativeCommandSpec = {
     name: "status",
     description: "Status",
@@ -78,7 +78,7 @@ function createDispatchSpy() {
 
 async function runGuildSlashCommand(params?: {
   userId?: string;
-  mutateConfig?: (cfg: OpenClawConfig) => void;
+  mutateConfig?: (cfg: RemoteClawConfig) => void;
 }) {
   const cfg = createConfig();
   params?.mutateConfig?.(cfg);

--- a/src/discord/monitor/native-command.plugin-dispatch.test.ts
+++ b/src/discord/monitor/native-command.plugin-dispatch.test.ts
@@ -5,6 +5,10 @@ import * as dispatcherModule from "../../auto-reply/reply/provider-dispatcher.js
 import type { RemoteClawConfig } from "../../config/config.js";
 import * as pluginCommandsModule from "../../plugins/commands.js";
 import { createDiscordNativeCommand } from "./native-command.js";
+import {
+  createMockCommandInteraction,
+  type MockCommandInteraction,
+} from "./native-command.test-helpers.js";
 import { createNoopThreadBindingManager } from "./thread-bindings.js";
 
 type ResolveConfiguredAcpBindingRecordFn =
@@ -29,52 +33,22 @@ vi.mock("../../acp/persistent-bindings.js", async (importOriginal) => {
   };
 });
 
-type MockCommandInteraction = {
-  user: { id: string; username: string; globalName: string };
-  channel: { type: ChannelType; id: string };
-  guild: { id: string; name?: string } | null;
-  rawData: { id: string; member: { roles: string[] } };
-  options: {
-    getString: ReturnType<typeof vi.fn>;
-    getNumber: ReturnType<typeof vi.fn>;
-    getBoolean: ReturnType<typeof vi.fn>;
-  };
-  reply: ReturnType<typeof vi.fn>;
-  followUp: ReturnType<typeof vi.fn>;
-  client: object;
-};
-
 function createInteraction(params?: {
   channelType?: ChannelType;
   channelId?: string;
   guildId?: string;
   guildName?: string;
 }): MockCommandInteraction {
-  const guild = params?.guildId ? { id: params.guildId, name: params.guildName } : null;
-  return {
-    user: {
-      id: "owner",
-      username: "tester",
-      globalName: "Tester",
-    },
-    channel: {
-      type: params?.channelType ?? ChannelType.DM,
-      id: params?.channelId ?? "dm-1",
-    },
-    guild,
-    rawData: {
-      id: "interaction-1",
-      member: { roles: [] },
-    },
-    options: {
-      getString: vi.fn().mockReturnValue(null),
-      getNumber: vi.fn().mockReturnValue(null),
-      getBoolean: vi.fn().mockReturnValue(null),
-    },
-    reply: vi.fn().mockResolvedValue({ ok: true }),
-    followUp: vi.fn().mockResolvedValue({ ok: true }),
-    client: {},
-  };
+  return createMockCommandInteraction({
+    userId: "owner",
+    username: "tester",
+    globalName: "Tester",
+    channelType: params?.channelType ?? ChannelType.DM,
+    channelId: params?.channelId ?? "dm-1",
+    guildId: params?.guildId ?? null,
+    guildName: params?.guildName,
+    interactionId: "interaction-1",
+  });
 }
 
 function createConfig(): RemoteClawConfig {

--- a/src/discord/monitor/native-command.plugin-dispatch.test.ts
+++ b/src/discord/monitor/native-command.plugin-dispatch.test.ts
@@ -87,6 +87,75 @@ function createConfig(): RemoteClawConfig {
   } as RemoteClawConfig;
 }
 
+function createStatusCommand(cfg: RemoteClawConfig) {
+  const commandSpec: NativeCommandSpec = {
+    name: "status",
+    description: "Status",
+    acceptsArgs: false,
+  };
+  return createDiscordNativeCommand({
+    command: commandSpec,
+    cfg,
+    discordConfig: cfg.channels?.discord ?? {},
+    accountId: "default",
+    sessionPrefix: "discord:slash",
+    ephemeralDefault: true,
+    threadBindings: createNoopThreadBindingManager("default"),
+  });
+}
+
+function setConfiguredBinding(channelId: string, boundSessionKey: string) {
+  persistentBindingMocks.resolveConfiguredAcpBindingRecord.mockReturnValue({
+    spec: {
+      channel: "discord",
+      accountId: "default",
+      conversationId: channelId,
+      agentId: "codex",
+      mode: "persistent",
+    },
+    record: {
+      bindingId: `config:acp:discord:default:${channelId}`,
+      targetSessionKey: boundSessionKey,
+      targetKind: "session",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: channelId,
+      },
+      status: "active",
+      boundAt: 0,
+    },
+  });
+  persistentBindingMocks.ensureConfiguredAcpBindingSession.mockResolvedValue({
+    ok: true,
+    sessionKey: boundSessionKey,
+  });
+}
+
+function createDispatchSpy() {
+  return vi.spyOn(dispatcherModule, "dispatchReplyWithDispatcher").mockResolvedValue({
+    counts: {
+      final: 1,
+      block: 0,
+      tool: 0,
+    },
+  } as never);
+}
+
+function expectBoundSessionDispatch(
+  dispatchSpy: ReturnType<typeof createDispatchSpy>,
+  boundSessionKey: string,
+) {
+  expect(dispatchSpy).toHaveBeenCalledTimes(1);
+  const dispatchCall = dispatchSpy.mock.calls[0]?.[0] as {
+    ctx?: { SessionKey?: string; CommandTargetSessionKey?: string };
+  };
+  expect(dispatchCall.ctx?.SessionKey).toBe(boundSessionKey);
+  expect(dispatchCall.ctx?.CommandTargetSessionKey).toBe(boundSessionKey);
+  expect(persistentBindingMocks.resolveConfiguredAcpBindingRecord).toHaveBeenCalledTimes(1);
+  expect(persistentBindingMocks.ensureConfiguredAcpBindingSession).toHaveBeenCalledTimes(1);
+}
+
 describe("Discord native plugin command dispatch", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -169,20 +238,7 @@ describe("Discord native plugin command dispatch", () => {
         },
       ],
     } as RemoteClawConfig;
-    const commandSpec: NativeCommandSpec = {
-      name: "status",
-      description: "Status",
-      acceptsArgs: false,
-    };
-    const command = createDiscordNativeCommand({
-      command: commandSpec,
-      cfg,
-      discordConfig: cfg.channels?.discord ?? {},
-      accountId: "default",
-      sessionPrefix: "discord:slash",
-      ephemeralDefault: true,
-      threadBindings: createNoopThreadBindingManager("default"),
-    });
+    const command = createStatusCommand(cfg);
     const interaction = createInteraction({
       channelType: ChannelType.GuildText,
       channelId,
@@ -190,53 +246,14 @@ describe("Discord native plugin command dispatch", () => {
       guildName: "Ops",
     });
 
-    persistentBindingMocks.resolveConfiguredAcpBindingRecord.mockReturnValue({
-      spec: {
-        channel: "discord",
-        accountId: "default",
-        conversationId: channelId,
-        agentId: "codex",
-        mode: "persistent",
-      },
-      record: {
-        bindingId: "config:acp:discord:default:1478836151241412759",
-        targetSessionKey: boundSessionKey,
-        targetKind: "session",
-        conversation: {
-          channel: "discord",
-          accountId: "default",
-          conversationId: channelId,
-        },
-        status: "active",
-        boundAt: 0,
-      },
-    });
-    persistentBindingMocks.ensureConfiguredAcpBindingSession.mockResolvedValue({
-      ok: true,
-      sessionKey: boundSessionKey,
-    });
+    setConfiguredBinding(channelId, boundSessionKey);
 
     vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
-    const dispatchSpy = vi
-      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
-      .mockResolvedValue({
-        counts: {
-          final: 1,
-          block: 0,
-          tool: 0,
-        },
-      } as never);
+    const dispatchSpy = createDispatchSpy();
 
     await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
 
-    expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    const dispatchCall = dispatchSpy.mock.calls[0]?.[0] as {
-      ctx?: { SessionKey?: string; CommandTargetSessionKey?: string };
-    };
-    expect(dispatchCall.ctx?.SessionKey).toBe(boundSessionKey);
-    expect(dispatchCall.ctx?.CommandTargetSessionKey).toBe(boundSessionKey);
-    expect(persistentBindingMocks.resolveConfiguredAcpBindingRecord).toHaveBeenCalledTimes(1);
-    expect(persistentBindingMocks.ensureConfiguredAcpBindingSession).toHaveBeenCalledTimes(1);
+    expectBoundSessionDispatch(dispatchSpy, boundSessionKey);
   });
 
   it("routes Discord DM native slash commands through configured ACP bindings", async () => {
@@ -266,71 +283,19 @@ describe("Discord native plugin command dispatch", () => {
         },
       },
     } as RemoteClawConfig;
-    const commandSpec: NativeCommandSpec = {
-      name: "status",
-      description: "Status",
-      acceptsArgs: false,
-    };
-    const command = createDiscordNativeCommand({
-      command: commandSpec,
-      cfg,
-      discordConfig: cfg.channels?.discord ?? {},
-      accountId: "default",
-      sessionPrefix: "discord:slash",
-      ephemeralDefault: true,
-      threadBindings: createNoopThreadBindingManager("default"),
-    });
+    const command = createStatusCommand(cfg);
     const interaction = createInteraction({
       channelType: ChannelType.DM,
       channelId,
     });
 
-    persistentBindingMocks.resolveConfiguredAcpBindingRecord.mockReturnValue({
-      spec: {
-        channel: "discord",
-        accountId: "default",
-        conversationId: channelId,
-        agentId: "codex",
-        mode: "persistent",
-      },
-      record: {
-        bindingId: "config:acp:discord:default:dm-1",
-        targetSessionKey: boundSessionKey,
-        targetKind: "session",
-        conversation: {
-          channel: "discord",
-          accountId: "default",
-          conversationId: channelId,
-        },
-        status: "active",
-        boundAt: 0,
-      },
-    });
-    persistentBindingMocks.ensureConfiguredAcpBindingSession.mockResolvedValue({
-      ok: true,
-      sessionKey: boundSessionKey,
-    });
+    setConfiguredBinding(channelId, boundSessionKey);
 
     vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
-    const dispatchSpy = vi
-      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
-      .mockResolvedValue({
-        counts: {
-          final: 1,
-          block: 0,
-          tool: 0,
-        },
-      } as never);
+    const dispatchSpy = createDispatchSpy();
 
     await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
 
-    expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    const dispatchCall = dispatchSpy.mock.calls[0]?.[0] as {
-      ctx?: { SessionKey?: string; CommandTargetSessionKey?: string };
-    };
-    expect(dispatchCall.ctx?.SessionKey).toBe(boundSessionKey);
-    expect(dispatchCall.ctx?.CommandTargetSessionKey).toBe(boundSessionKey);
-    expect(persistentBindingMocks.resolveConfiguredAcpBindingRecord).toHaveBeenCalledTimes(1);
-    expect(persistentBindingMocks.ensureConfiguredAcpBindingSession).toHaveBeenCalledTimes(1);
+    expectBoundSessionDispatch(dispatchSpy, boundSessionKey);
   });
 });

--- a/src/discord/monitor/native-command.test-helpers.ts
+++ b/src/discord/monitor/native-command.test-helpers.ts
@@ -1,0 +1,60 @@
+import { ChannelType } from "discord-api-types/v10";
+import { vi } from "vitest";
+
+export type MockCommandInteraction = {
+  user: { id: string; username: string; globalName: string };
+  channel: { type: ChannelType; id: string };
+  guild: { id: string; name?: string } | null;
+  rawData: { id: string; member: { roles: string[] } };
+  options: {
+    getString: ReturnType<typeof vi.fn>;
+    getNumber: ReturnType<typeof vi.fn>;
+    getBoolean: ReturnType<typeof vi.fn>;
+  };
+  reply: ReturnType<typeof vi.fn>;
+  followUp: ReturnType<typeof vi.fn>;
+  client: object;
+};
+
+type CreateMockCommandInteractionParams = {
+  userId?: string;
+  username?: string;
+  globalName?: string;
+  channelType?: ChannelType;
+  channelId?: string;
+  guildId?: string | null;
+  guildName?: string;
+  interactionId?: string;
+};
+
+export function createMockCommandInteraction(
+  params: CreateMockCommandInteractionParams = {},
+): MockCommandInteraction {
+  const guildId = params.guildId;
+  const guild =
+    guildId === null || guildId === undefined ? null : { id: guildId, name: params.guildName };
+  return {
+    user: {
+      id: params.userId ?? "owner",
+      username: params.username ?? "tester",
+      globalName: params.globalName ?? "Tester",
+    },
+    channel: {
+      type: params.channelType ?? ChannelType.DM,
+      id: params.channelId ?? "dm-1",
+    },
+    guild,
+    rawData: {
+      id: params.interactionId ?? "interaction-1",
+      member: { roles: [] },
+    },
+    options: {
+      getString: vi.fn().mockReturnValue(null),
+      getNumber: vi.fn().mockReturnValue(null),
+      getBoolean: vi.fn().mockReturnValue(null),
+    },
+    reply: vi.fn().mockResolvedValue({ ok: true }),
+    followUp: vi.fn().mockResolvedValue({ ok: true }),
+    client: {},
+  };
+}

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -17,6 +17,7 @@ import {
 } from "../../acp/persistent-bindings.route.js";
 import { resolveHumanDelayConfig } from "../../agents/identity.js";
 import { resolveChunkMode, resolveTextChunkLimit } from "../../auto-reply/chunk.js";
+import { resolveCommandAuthorization } from "../../auto-reply/command-auth.js";
 import type {
   ChatCommandDefinition,
   CommandArgDefinition,
@@ -70,6 +71,46 @@ import { resolveDiscordThreadParentInfo } from "./threading.js";
 
 type DiscordConfig = NonNullable<RemoteClawConfig["channels"]>["discord"];
 const log = createSubsystemLogger("discord/native-command");
+
+function resolveDiscordNativeCommandAllowlistAccess(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  sender: { id: string; name?: string; tag?: string };
+  chatType: "direct" | "group" | "thread" | "channel";
+  conversationId?: string;
+}) {
+  const commandsAllowFrom = params.cfg.commands?.allowFrom;
+  if (!commandsAllowFrom || typeof commandsAllowFrom !== "object") {
+    return { configured: false, allowed: false } as const;
+  }
+  const configured =
+    Array.isArray(commandsAllowFrom.discord) || Array.isArray(commandsAllowFrom["*"]);
+  if (!configured) {
+    return { configured: false, allowed: false } as const;
+  }
+
+  const from =
+    params.chatType === "direct"
+      ? `discord:${params.sender.id}`
+      : `discord:${params.chatType}:${params.conversationId ?? "unknown"}`;
+  const auth = resolveCommandAuthorization({
+    ctx: {
+      Provider: "discord",
+      Surface: "discord",
+      OriginatingChannel: "discord",
+      AccountId: params.accountId ?? undefined,
+      ChatType: params.chatType,
+      From: from,
+      SenderId: params.sender.id,
+      SenderUsername: params.sender.name,
+      SenderTag: params.sender.tag,
+    },
+    cfg: params.cfg,
+    // We only want explicit commands.allowFrom authorization here.
+    commandAuthorized: false,
+  });
+  return { configured: true, allowed: auth.isAuthorizedSender } as const;
+}
 
 function buildDiscordCommandOptions(params: {
   command: ChatCommandDefinition;
@@ -590,6 +631,23 @@ async function dispatchDiscordCommandInteraction(params: {
     },
     allowNameMatching,
   });
+  const commandsAllowFromAccess = resolveDiscordNativeCommandAllowlistAccess({
+    cfg,
+    accountId,
+    sender: {
+      id: sender.id,
+      name: sender.name,
+      tag: sender.tag,
+    },
+    chatType: isDirectMessage
+      ? "direct"
+      : isThreadChannel
+        ? "thread"
+        : interaction.guild
+          ? "channel"
+          : "group",
+    conversationId: rawChannelId || undefined,
+  });
   const guildInfo = resolveDiscordGuildEntry({
     guild: interaction.guild ?? undefined,
     guildEntries: discordConfig?.guilds,
@@ -711,10 +769,20 @@ async function dispatchDiscordCommandInteraction(params: {
     });
     const authorizers = useAccessGroups
       ? [
+          {
+            configured: commandsAllowFromAccess.configured,
+            allowed: commandsAllowFromAccess.allowed,
+          },
           { configured: ownerAllowList != null, allowed: ownerOk },
           { configured: hasAccessRestrictions, allowed: memberAllowed },
         ]
-      : [{ configured: hasAccessRestrictions, allowed: memberAllowed }];
+      : [
+          {
+            configured: commandsAllowFromAccess.configured,
+            allowed: commandsAllowFromAccess.allowed,
+          },
+          { configured: hasAccessRestrictions, allowed: memberAllowed },
+        ];
     commandAuthorized = resolveCommandAuthorizedFromAuthorizers({
       useAccessGroups,
       authorizers,

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -73,7 +73,7 @@ type DiscordConfig = NonNullable<RemoteClawConfig["channels"]>["discord"];
 const log = createSubsystemLogger("discord/native-command");
 
 function resolveDiscordNativeCommandAllowlistAccess(params: {
-  cfg: OpenClawConfig;
+  cfg: RemoteClawConfig;
   accountId?: string | null;
   sender: { id: string; name?: string; tag?: string };
   chatType: "direct" | "group" | "thread" | "channel";

--- a/src/discord/resolve-channels.test.ts
+++ b/src/discord/resolve-channels.test.ts
@@ -4,9 +4,11 @@ import { resolveDiscordChannelAllowlist } from "./resolve-channels.js";
 import { jsonResponse, urlToString } from "./test-http-helpers.js";
 
 describe("resolveDiscordChannelAllowlist", () => {
+  type DiscordChannel = { id: string; name: string; guild_id: string; type: number };
+
   async function resolveWithChannelLookup(params: {
     guilds: Array<{ id: string; name: string }>;
-    channel: { id: string; name: string; guild_id: string; type: number };
+    channel: DiscordChannel;
     entry: string;
   }) {
     const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
@@ -24,6 +26,44 @@ describe("resolveDiscordChannelAllowlist", () => {
       entries: [params.entry],
       fetcher,
     });
+  }
+
+  async function resolveGuild111Entry2024(params: {
+    channelLookup: () => Response;
+    guildChannels?: DiscordChannel[];
+  }) {
+    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url.endsWith("/users/@me/guilds")) {
+        return jsonResponse([{ id: "111", name: "Test Server" }]);
+      }
+      if (url.endsWith("/channels/2024")) {
+        return params.channelLookup();
+      }
+      if (url.endsWith("/guilds/111/channels")) {
+        return jsonResponse(
+          params.guildChannels ?? [
+            { id: "c1", name: "2024", guild_id: "111", type: 0 },
+            { id: "c2", name: "general", guild_id: "111", type: 0 },
+          ],
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    return resolveDiscordChannelAllowlist({
+      token: "test",
+      entries: ["111/2024"],
+      fetcher,
+    });
+  }
+
+  function expectUnresolved1112024(
+    res: Awaited<ReturnType<typeof resolveDiscordChannelAllowlist>>,
+  ) {
+    expect(res[0]?.resolved).toBe(false);
+    expect(res[0]?.channelId).toBe("2024");
+    expect(res[0]?.guildId).toBe("111");
   }
 
   it("resolves guild/channel by name", async () => {
@@ -210,27 +250,8 @@ describe("resolveDiscordChannelAllowlist", () => {
   });
 
   it("falls back to name matching when numeric channel name is not a valid ID", async () => {
-    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
-      const url = urlToString(input);
-      if (url.endsWith("/users/@me/guilds")) {
-        return jsonResponse([{ id: "111", name: "Test Server" }]);
-      }
-      if (url.endsWith("/channels/2024")) {
-        return new Response("not found", { status: 404 });
-      }
-      if (url.endsWith("/guilds/111/channels")) {
-        return jsonResponse([
-          { id: "c1", name: "2024", guild_id: "111", type: 0 },
-          { id: "c2", name: "general", guild_id: "111", type: 0 },
-        ]);
-      }
-      return new Response("not found", { status: 404 });
-    });
-
-    const res = await resolveDiscordChannelAllowlist({
-      token: "test",
-      entries: ["111/2024"],
-      fetcher,
+    const res = await resolveGuild111Entry2024({
+      channelLookup: () => new Response("not found", { status: 404 }),
     });
 
     expect(res[0]?.resolved).toBe(true);
@@ -240,58 +261,20 @@ describe("resolveDiscordChannelAllowlist", () => {
   });
 
   it("does not fall back to name matching when channel lookup returns 403", async () => {
-    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
-      const url = urlToString(input);
-      if (url.endsWith("/users/@me/guilds")) {
-        return jsonResponse([{ id: "111", name: "Test Server" }]);
-      }
-      if (url.endsWith("/channels/2024")) {
-        return new Response("Missing Access", { status: 403 });
-      }
-      if (url.endsWith("/guilds/111/channels")) {
-        return jsonResponse([
-          { id: "c1", name: "2024", guild_id: "111", type: 0 },
-          { id: "c2", name: "general", guild_id: "111", type: 0 },
-        ]);
-      }
-      return new Response("not found", { status: 404 });
+    const res = await resolveGuild111Entry2024({
+      channelLookup: () => new Response("Missing Access", { status: 403 }),
     });
 
-    const res = await resolveDiscordChannelAllowlist({
-      token: "test",
-      entries: ["111/2024"],
-      fetcher,
-    });
-
-    expect(res[0]?.resolved).toBe(false);
-    expect(res[0]?.channelId).toBe("2024");
-    expect(res[0]?.guildId).toBe("111");
+    expectUnresolved1112024(res);
   });
 
   it("does not fall back to name matching when channel payload is malformed", async () => {
-    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
-      const url = urlToString(input);
-      if (url.endsWith("/users/@me/guilds")) {
-        return jsonResponse([{ id: "111", name: "Test Server" }]);
-      }
-      if (url.endsWith("/channels/2024")) {
-        return jsonResponse({ id: "2024", name: "unknown", type: 0 });
-      }
-      if (url.endsWith("/guilds/111/channels")) {
-        return jsonResponse([{ id: "c1", name: "2024", guild_id: "111", type: 0 }]);
-      }
-      return new Response("not found", { status: 404 });
+    const res = await resolveGuild111Entry2024({
+      channelLookup: () => jsonResponse({ id: "2024", name: "unknown", type: 0 }),
+      guildChannels: [{ id: "c1", name: "2024", guild_id: "111", type: 0 }],
     });
 
-    const res = await resolveDiscordChannelAllowlist({
-      token: "test",
-      entries: ["111/2024"],
-      fetcher,
-    });
-
-    expect(res[0]?.resolved).toBe(false);
-    expect(res[0]?.channelId).toBe("2024");
-    expect(res[0]?.guildId).toBe("111");
+    expectUnresolved1112024(res);
   });
 
   it("resolves guild: prefixed id as guild (not channel)", async () => {

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -68,6 +68,46 @@ let createLineWebhookReplayCache: typeof import("./bot-handlers.js").createLineW
 
 const createRuntime = () => ({ log: vi.fn(), error: vi.fn(), exit: vi.fn() });
 
+function createReplayMessageEvent(params: {
+  messageId: string;
+  groupId: string;
+  userId: string;
+  webhookEventId: string;
+  isRedelivery: boolean;
+}) {
+  return {
+    type: "message",
+    message: { id: params.messageId, type: "text", text: "hello" },
+    replyToken: "reply-token",
+    timestamp: Date.now(),
+    source: { type: "group", groupId: params.groupId, userId: params.userId },
+    mode: "active",
+    webhookEventId: params.webhookEventId,
+    deliveryContext: { isRedelivery: params.isRedelivery },
+  } as MessageEvent;
+}
+
+function createOpenGroupReplayContext(
+  processMessage: ReturnType<typeof vi.fn>,
+  replayCache: ReturnType<typeof createLineWebhookReplayCache>,
+): Parameters<typeof handleLineWebhookEvents>[1] {
+  return {
+    cfg: { channels: { line: { groupPolicy: "open" } } },
+    account: {
+      accountId: "default",
+      enabled: true,
+      channelAccessToken: "token",
+      channelSecret: "secret",
+      tokenSource: "config",
+      config: { groupPolicy: "open" },
+    },
+    runtime: createRuntime(),
+    mediaMaxBytes: 1,
+    processMessage,
+    replayCache,
+  };
+}
+
 vi.mock("../pairing/pairing-store.js", () => ({
   readChannelAllowFromStore: readAllowFromStoreMock,
   upsertChannelPairingRequest: upsertPairingRequestMock,
@@ -377,32 +417,14 @@ describe("handleLineWebhookEvents", () => {
 
   it("deduplicates replayed webhook events by webhookEventId before processing", async () => {
     const processMessage = vi.fn();
-    const event = {
-      type: "message",
-      message: { id: "m-replay", type: "text", text: "hello" },
-      replyToken: "reply-token",
-      timestamp: Date.now(),
-      source: { type: "group", groupId: "group-replay", userId: "user-replay" },
-      mode: "active",
+    const event = createReplayMessageEvent({
+      messageId: "m-replay",
+      groupId: "group-replay",
+      userId: "user-replay",
       webhookEventId: "evt-replay-1",
-      deliveryContext: { isRedelivery: true },
-    } as MessageEvent;
-
-    const context: Parameters<typeof handleLineWebhookEvents>[1] = {
-      cfg: { channels: { line: { groupPolicy: "open" } } },
-      account: {
-        accountId: "default",
-        enabled: true,
-        channelAccessToken: "token",
-        channelSecret: "secret",
-        tokenSource: "config",
-        config: { groupPolicy: "open" },
-      },
-      runtime: createRuntime(),
-      mediaMaxBytes: 1,
-      processMessage,
-      replayCache: createLineWebhookReplayCache(),
-    };
+      isRedelivery: true,
+    });
+    const context = createOpenGroupReplayContext(processMessage, createLineWebhookReplayCache());
 
     await handleLineWebhookEvents([event], context);
     await handleLineWebhookEvents([event], context);
@@ -419,32 +441,14 @@ describe("handleLineWebhookEvents", () => {
     const processMessage = vi.fn(async () => {
       await firstDone;
     });
-    const event = {
-      type: "message",
-      message: { id: "m-inflight", type: "text", text: "hello" },
-      replyToken: "reply-token",
-      timestamp: Date.now(),
-      source: { type: "group", groupId: "group-inflight", userId: "user-inflight" },
-      mode: "active",
+    const event = createReplayMessageEvent({
+      messageId: "m-inflight",
+      groupId: "group-inflight",
+      userId: "user-inflight",
       webhookEventId: "evt-inflight-1",
-      deliveryContext: { isRedelivery: true },
-    } as MessageEvent;
-
-    const context: Parameters<typeof handleLineWebhookEvents>[1] = {
-      cfg: { channels: { line: { groupPolicy: "open" } } },
-      account: {
-        accountId: "default",
-        enabled: true,
-        channelAccessToken: "token",
-        channelSecret: "secret",
-        tokenSource: "config",
-        config: { groupPolicy: "open" },
-      },
-      runtime: createRuntime(),
-      mediaMaxBytes: 1,
-      processMessage,
-      replayCache: createLineWebhookReplayCache(),
-    };
+      isRedelivery: true,
+    });
+    const context = createOpenGroupReplayContext(processMessage, createLineWebhookReplayCache());
 
     const firstRun = handleLineWebhookEvents([event], context);
     await Promise.resolve();
@@ -464,32 +468,14 @@ describe("handleLineWebhookEvents", () => {
     const processMessage = vi.fn(async () => {
       await firstDone;
     });
-    const event = {
-      type: "message",
-      message: { id: "m-inflight-fail", type: "text", text: "hello" },
-      replyToken: "reply-token",
-      timestamp: Date.now(),
-      source: { type: "group", groupId: "group-inflight", userId: "user-inflight" },
-      mode: "active",
+    const event = createReplayMessageEvent({
+      messageId: "m-inflight-fail",
+      groupId: "group-inflight",
+      userId: "user-inflight",
       webhookEventId: "evt-inflight-fail-1",
-      deliveryContext: { isRedelivery: true },
-    } as MessageEvent;
-
-    const context: Parameters<typeof handleLineWebhookEvents>[1] = {
-      cfg: { channels: { line: { groupPolicy: "open" } } },
-      account: {
-        accountId: "default",
-        enabled: true,
-        channelAccessToken: "token",
-        channelSecret: "secret",
-        tokenSource: "config",
-        config: { groupPolicy: "open" },
-      },
-      runtime: createRuntime(),
-      mediaMaxBytes: 1,
-      processMessage,
-      replayCache: createLineWebhookReplayCache(),
-    };
+      isRedelivery: true,
+    });
+    const context = createOpenGroupReplayContext(processMessage, createLineWebhookReplayCache());
 
     const firstRun = handleLineWebhookEvents([event], context);
     await Promise.resolve();
@@ -604,32 +590,14 @@ describe("handleLineWebhookEvents", () => {
       .fn()
       .mockRejectedValueOnce(new Error("transient failure"))
       .mockResolvedValueOnce(undefined);
-    const event = {
-      type: "message",
-      message: { id: "m-fail-then-retry", type: "text", text: "hello" },
-      replyToken: "reply-token",
-      timestamp: Date.now(),
-      source: { type: "group", groupId: "group-retry", userId: "user-retry" },
-      mode: "active",
+    const event = createReplayMessageEvent({
+      messageId: "m-fail-then-retry",
+      groupId: "group-retry",
+      userId: "user-retry",
       webhookEventId: "evt-fail-then-retry",
-      deliveryContext: { isRedelivery: false },
-    } as MessageEvent;
-
-    const context: Parameters<typeof handleLineWebhookEvents>[1] = {
-      cfg: { channels: { line: { groupPolicy: "open" } } },
-      account: {
-        accountId: "default",
-        enabled: true,
-        channelAccessToken: "token",
-        channelSecret: "secret",
-        tokenSource: "config",
-        config: { groupPolicy: "open" },
-      },
-      runtime: createRuntime(),
-      mediaMaxBytes: 1,
-      processMessage,
-      replayCache: createLineWebhookReplayCache(),
-    };
+      isRedelivery: false,
+    });
+    const context = createOpenGroupReplayContext(processMessage, createLineWebhookReplayCache());
 
     await expect(handleLineWebhookEvents([event], context)).rejects.toThrow("transient failure");
     await handleLineWebhookEvents([event], context);

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -103,7 +103,7 @@ function createOpenGroupReplayContext(
     },
     runtime: createRuntime(),
     mediaMaxBytes: 1,
-    processMessage,
+    processMessage: processMessage as never,
     replayCache,
   };
 }

--- a/src/slack/monitor/message-handler.app-mention-race.test.ts
+++ b/src/slack/monitor/message-handler.app-mention-race.test.ts
@@ -67,6 +67,23 @@ function createMarkMessageSeen() {
   };
 }
 
+function createTestHandler() {
+  return createSlackMessageHandler({
+    ctx: {
+      cfg: {},
+      accountId: "default",
+      app: { client: {} },
+      runtime: {},
+      markMessageSeen: createMarkMessageSeen(),
+    } as Parameters<typeof createSlackMessageHandler>[0]["ctx"],
+    account: { accountId: "default" } as Parameters<typeof createSlackMessageHandler>[0]["account"],
+  });
+}
+
+function createSlackEvent(params: { type: "message" | "app_mention"; ts: string; text: string }) {
+  return { type: params.type, channel: "C1", ts: params.ts, text: params.text } as never;
+}
+
 describe("createSlackMessageHandler app_mention race handling", () => {
   beforeEach(() => {
     prepareSlackMessageMock.mockReset();
@@ -81,39 +98,25 @@ describe("createSlackMessageHandler app_mention race handling", () => {
       return { ctxPayload: {} };
     });
 
-    const handler = createSlackMessageHandler({
-      ctx: {
-        cfg: {},
-        accountId: "default",
-        app: { client: {} },
-        runtime: {},
-        markMessageSeen: createMarkMessageSeen(),
-      } as Parameters<typeof createSlackMessageHandler>[0]["ctx"],
-      account: { accountId: "default" } as Parameters<
-        typeof createSlackMessageHandler
-      >[0]["account"],
-    });
+    const handler = createTestHandler();
 
+    await handler(createSlackEvent({ type: "message", ts: "1700000000.000100", text: "hello" }), {
+      source: "message",
+    });
     await handler(
-      { type: "message", channel: "C1", ts: "1700000000.000100", text: "hello" } as never,
-      { source: "message" },
-    );
-    await handler(
-      {
+      createSlackEvent({
         type: "app_mention",
-        channel: "C1",
         ts: "1700000000.000100",
         text: "<@U_BOT> hello",
-      } as never,
+      }),
       { source: "app_mention", wasMentioned: true },
     );
     await handler(
-      {
+      createSlackEvent({
         type: "app_mention",
-        channel: "C1",
         ts: "1700000000.000100",
         text: "<@U_BOT> hello",
-      } as never,
+      }),
       { source: "app_mention", wasMentioned: true },
     );
 
@@ -133,32 +136,20 @@ describe("createSlackMessageHandler app_mention race handling", () => {
       return { ctxPayload: {} };
     });
 
-    const handler = createSlackMessageHandler({
-      ctx: {
-        cfg: {},
-        accountId: "default",
-        app: { client: {} },
-        runtime: {},
-        markMessageSeen: createMarkMessageSeen(),
-      } as Parameters<typeof createSlackMessageHandler>[0]["ctx"],
-      account: { accountId: "default" } as Parameters<
-        typeof createSlackMessageHandler
-      >[0]["account"],
-    });
+    const handler = createTestHandler();
 
     const messagePending = handler(
-      { type: "message", channel: "C1", ts: "1700000000.000150", text: "hello" } as never,
+      createSlackEvent({ type: "message", ts: "1700000000.000150", text: "hello" }),
       { source: "message" },
     );
     await Promise.resolve();
 
     await handler(
-      {
+      createSlackEvent({
         type: "app_mention",
-        channel: "C1",
         ts: "1700000000.000150",
         text: "<@U_BOT> hello",
-      } as never,
+      }),
       { source: "app_mention", wasMentioned: true },
     );
 
@@ -166,12 +157,11 @@ describe("createSlackMessageHandler app_mention race handling", () => {
     await messagePending;
 
     await handler(
-      {
+      createSlackEvent({
         type: "app_mention",
-        channel: "C1",
         ts: "1700000000.000150",
         text: "<@U_BOT> hello",
-      } as never,
+      }),
       { source: "app_mention", wasMentioned: true },
     );
 
@@ -191,32 +181,20 @@ describe("createSlackMessageHandler app_mention race handling", () => {
       return { ctxPayload: {} };
     });
 
-    const handler = createSlackMessageHandler({
-      ctx: {
-        cfg: {},
-        accountId: "default",
-        app: { client: {} },
-        runtime: {},
-        markMessageSeen: createMarkMessageSeen(),
-      } as Parameters<typeof createSlackMessageHandler>[0]["ctx"],
-      account: { accountId: "default" } as Parameters<
-        typeof createSlackMessageHandler
-      >[0]["account"],
-    });
+    const handler = createTestHandler();
 
     const messagePending = handler(
-      { type: "message", channel: "C1", ts: "1700000000.000175", text: "hello" } as never,
+      createSlackEvent({ type: "message", ts: "1700000000.000175", text: "hello" }),
       { source: "message" },
     );
     await Promise.resolve();
 
     await handler(
-      {
+      createSlackEvent({
         type: "app_mention",
-        channel: "C1",
         ts: "1700000000.000175",
         text: "<@U_BOT> hello",
-      } as never,
+      }),
       { source: "app_mention", wasMentioned: true },
     );
 
@@ -230,30 +208,17 @@ describe("createSlackMessageHandler app_mention race handling", () => {
   it("keeps app_mention deduped when message event already dispatched", async () => {
     prepareSlackMessageMock.mockResolvedValue({ ctxPayload: {} });
 
-    const handler = createSlackMessageHandler({
-      ctx: {
-        cfg: {},
-        accountId: "default",
-        app: { client: {} },
-        runtime: {},
-        markMessageSeen: createMarkMessageSeen(),
-      } as Parameters<typeof createSlackMessageHandler>[0]["ctx"],
-      account: { accountId: "default" } as Parameters<
-        typeof createSlackMessageHandler
-      >[0]["account"],
-    });
+    const handler = createTestHandler();
 
+    await handler(createSlackEvent({ type: "message", ts: "1700000000.000200", text: "hello" }), {
+      source: "message",
+    });
     await handler(
-      { type: "message", channel: "C1", ts: "1700000000.000200", text: "hello" } as never,
-      { source: "message" },
-    );
-    await handler(
-      {
+      createSlackEvent({
         type: "app_mention",
-        channel: "C1",
         ts: "1700000000.000200",
         text: "<@U_BOT> hello",
-      } as never,
+      }),
       { source: "app_mention", wasMentioned: true },
     );
 

--- a/src/slack/monitor/message-handler.app-mention-race.test.ts
+++ b/src/slack/monitor/message-handler.app-mention-race.test.ts
@@ -84,6 +84,38 @@ function createSlackEvent(params: { type: "message" | "app_mention"; ts: string;
   return { type: params.type, channel: "C1", ts: params.ts, text: params.text } as never;
 }
 
+async function sendMessageEvent(handler: ReturnType<typeof createTestHandler>, ts: string) {
+  await handler(createSlackEvent({ type: "message", ts, text: "hello" }), { source: "message" });
+}
+
+async function sendMentionEvent(handler: ReturnType<typeof createTestHandler>, ts: string) {
+  await handler(createSlackEvent({ type: "app_mention", ts, text: "<@U_BOT> hello" }), {
+    source: "app_mention",
+    wasMentioned: true,
+  });
+}
+
+async function createInFlightMessageScenario(ts: string) {
+  let resolveMessagePrepare: ((value: unknown) => void) | undefined;
+  const messagePrepare = new Promise<unknown>((resolve) => {
+    resolveMessagePrepare = resolve;
+  });
+  prepareSlackMessageMock.mockImplementation(async ({ opts }) => {
+    if (opts.source === "message") {
+      return messagePrepare;
+    }
+    return { ctxPayload: {} };
+  });
+
+  const handler = createTestHandler();
+  const messagePending = handler(createSlackEvent({ type: "message", ts, text: "hello" }), {
+    source: "message",
+  });
+  await Promise.resolve();
+
+  return { handler, messagePending, resolveMessagePrepare };
+}
+
 describe("createSlackMessageHandler app_mention race handling", () => {
   beforeEach(() => {
     prepareSlackMessageMock.mockReset();
@@ -100,103 +132,34 @@ describe("createSlackMessageHandler app_mention race handling", () => {
 
     const handler = createTestHandler();
 
-    await handler(createSlackEvent({ type: "message", ts: "1700000000.000100", text: "hello" }), {
-      source: "message",
-    });
-    await handler(
-      createSlackEvent({
-        type: "app_mention",
-        ts: "1700000000.000100",
-        text: "<@U_BOT> hello",
-      }),
-      { source: "app_mention", wasMentioned: true },
-    );
-    await handler(
-      createSlackEvent({
-        type: "app_mention",
-        ts: "1700000000.000100",
-        text: "<@U_BOT> hello",
-      }),
-      { source: "app_mention", wasMentioned: true },
-    );
+    await sendMessageEvent(handler, "1700000000.000100");
+    await sendMentionEvent(handler, "1700000000.000100");
+    await sendMentionEvent(handler, "1700000000.000100");
 
     expect(prepareSlackMessageMock).toHaveBeenCalledTimes(2);
     expect(dispatchPreparedSlackMessageMock).toHaveBeenCalledTimes(1);
   });
 
   it("allows app_mention while message handling is still in-flight, then keeps later duplicates deduped", async () => {
-    let resolveMessagePrepare: ((value: unknown) => void) | undefined;
-    const messagePrepare = new Promise<unknown>((resolve) => {
-      resolveMessagePrepare = resolve;
-    });
-    prepareSlackMessageMock.mockImplementation(async ({ opts }) => {
-      if (opts.source === "message") {
-        return messagePrepare;
-      }
-      return { ctxPayload: {} };
-    });
+    const { handler, messagePending, resolveMessagePrepare } =
+      await createInFlightMessageScenario("1700000000.000150");
 
-    const handler = createTestHandler();
-
-    const messagePending = handler(
-      createSlackEvent({ type: "message", ts: "1700000000.000150", text: "hello" }),
-      { source: "message" },
-    );
-    await Promise.resolve();
-
-    await handler(
-      createSlackEvent({
-        type: "app_mention",
-        ts: "1700000000.000150",
-        text: "<@U_BOT> hello",
-      }),
-      { source: "app_mention", wasMentioned: true },
-    );
+    await sendMentionEvent(handler, "1700000000.000150");
 
     resolveMessagePrepare?.(null);
     await messagePending;
 
-    await handler(
-      createSlackEvent({
-        type: "app_mention",
-        ts: "1700000000.000150",
-        text: "<@U_BOT> hello",
-      }),
-      { source: "app_mention", wasMentioned: true },
-    );
+    await sendMentionEvent(handler, "1700000000.000150");
 
     expect(prepareSlackMessageMock).toHaveBeenCalledTimes(2);
     expect(dispatchPreparedSlackMessageMock).toHaveBeenCalledTimes(1);
   });
 
   it("suppresses message dispatch when app_mention already dispatched during in-flight race", async () => {
-    let resolveMessagePrepare: ((value: unknown) => void) | undefined;
-    const messagePrepare = new Promise<unknown>((resolve) => {
-      resolveMessagePrepare = resolve;
-    });
-    prepareSlackMessageMock.mockImplementation(async ({ opts }) => {
-      if (opts.source === "message") {
-        return messagePrepare;
-      }
-      return { ctxPayload: {} };
-    });
+    const { handler, messagePending, resolveMessagePrepare } =
+      await createInFlightMessageScenario("1700000000.000175");
 
-    const handler = createTestHandler();
-
-    const messagePending = handler(
-      createSlackEvent({ type: "message", ts: "1700000000.000175", text: "hello" }),
-      { source: "message" },
-    );
-    await Promise.resolve();
-
-    await handler(
-      createSlackEvent({
-        type: "app_mention",
-        ts: "1700000000.000175",
-        text: "<@U_BOT> hello",
-      }),
-      { source: "app_mention", wasMentioned: true },
-    );
+    await sendMentionEvent(handler, "1700000000.000175");
 
     resolveMessagePrepare?.({ ctxPayload: {} });
     await messagePending;
@@ -210,17 +173,8 @@ describe("createSlackMessageHandler app_mention race handling", () => {
 
     const handler = createTestHandler();
 
-    await handler(createSlackEvent({ type: "message", ts: "1700000000.000200", text: "hello" }), {
-      source: "message",
-    });
-    await handler(
-      createSlackEvent({
-        type: "app_mention",
-        ts: "1700000000.000200",
-        text: "<@U_BOT> hello",
-      }),
-      { source: "app_mention", wasMentioned: true },
-    );
+    await sendMessageEvent(handler, "1700000000.000200");
+    await sendMentionEvent(handler, "1700000000.000200");
 
     expect(prepareSlackMessageMock).toHaveBeenCalledTimes(1);
     expect(dispatchPreparedSlackMessageMock).toHaveBeenCalledTimes(1);

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -7,12 +7,11 @@ import { expectInboundContextContract } from "../../../../test/helpers/inbound-c
 import type { RemoteClawConfig } from "../../../config/config.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../../routing/session-key.js";
-import type { RuntimeEnv } from "../../../runtime.js";
 import type { ResolvedSlackAccount } from "../../accounts.js";
 import type { SlackMessageEvent } from "../../types.js";
 import type { SlackMonitorContext } from "../context.js";
-import { createSlackMonitorContext } from "../context.js";
 import { prepareSlackMessage } from "./prepare.js";
+import { createInboundSlackTestContext, createSlackTestAccount } from "./prepare.test-helpers.js";
 
 describe("slack prepareSlackMessage inbound contract", () => {
   let fixtureRoot = "";
@@ -38,53 +37,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     }
   });
 
-  function createInboundSlackCtx(params: {
-    cfg: RemoteClawConfig;
-    appClient?: App["client"];
-    defaultRequireMention?: boolean;
-    replyToMode?: "off" | "all";
-    channelsConfig?: Record<string, { systemPrompt: string }>;
-  }) {
-    return createSlackMonitorContext({
-      cfg: params.cfg,
-      accountId: "default",
-      botToken: "token",
-      app: { client: params.appClient ?? {} } as App,
-      runtime: {} as RuntimeEnv,
-      botUserId: "B1",
-      teamId: "T1",
-      apiAppId: "A1",
-      historyLimit: 0,
-      sessionScope: "per-sender",
-      mainKey: "main",
-      dmEnabled: true,
-      dmPolicy: "open",
-      allowFrom: [],
-      allowNameMatching: false,
-      groupDmEnabled: true,
-      groupDmChannels: [],
-      defaultRequireMention: params.defaultRequireMention ?? true,
-      channelsConfig: params.channelsConfig,
-      groupPolicy: "open",
-      useAccessGroups: false,
-      reactionMode: "off",
-      reactionAllowlist: [],
-      replyToMode: params.replyToMode ?? "off",
-      threadHistoryScope: "thread",
-      threadInheritParent: false,
-      slashCommand: {
-        enabled: false,
-        name: "openclaw",
-        sessionPrefix: "slack:slash",
-        ephemeral: true,
-      },
-      textLimit: 4000,
-      ackReactionScope: "group-mentions",
-      typingReaction: "",
-      mediaMaxBytes: 1024,
-      removeAckAfterReply: false,
-    });
-  }
+  const createInboundSlackCtx = createInboundSlackTestContext;
 
   function createDefaultSlackCtx() {
     const slackCtx = createInboundSlackCtx({
@@ -115,19 +68,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     });
   }
 
-  function createSlackAccount(config: ResolvedSlackAccount["config"] = {}): ResolvedSlackAccount {
-    return {
-      accountId: "default",
-      enabled: true,
-      botTokenSource: "config",
-      appTokenSource: "config",
-      userTokenSource: "none",
-      config,
-      replyToMode: config.replyToMode,
-      replyToModeByChatType: config.replyToModeByChatType,
-      dm: config.dm,
-    };
-  }
+  const createSlackAccount = createSlackTestAccount;
 
   function createSlackMessage(overrides: Partial<SlackMessageEvent>): SlackMessageEvent {
     return {


### PR DESCRIPTION
Closes #852

## Cherry-picks from upstream

10 of 11 commits applied (1 skipped).

| Hash | Subject | Result |
|------|---------|--------|
| `5d37139ee` | refactor(line): dedupe replay webhook test fixtures | PICKED |
| `969b9029c` | refactor(slack): dedupe app mention race test setup | PICKED |
| `d33efeef1` | refactor(slack): reuse shared prepare test scaffolding | PICKED |
| `949beca0c` | refactor(slack): dedupe app mention in-flight race setup | PICKED |
| `3381efc5c` | refactor(discord): dedupe native command ACP routing test setup | PICKED |
| `9849ee839` | refactor(discord): share message handler test scaffolding | PICKED |
| `bffec0f5d` | refactor(discord): dedupe message preflight test runners | PICKED |
| `90a41aa1f` | refactor(discord): dedupe resolve channels fallback tests | PICKED |
| `262fef6ac` | fix(discord): honor commands.allowFrom in guild slash auth (#38794) | PICKED |
| `acf3ff91e` | refactor: dedupe discord native command test scaffolding | PICKED |
| `724d2d58f` | fix(discord): avoid false model picker mismatch warning (#39105) | SKIPPED — fork removed model picker code; both conflict hunks resolved to ours → empty commit |

### Adaptation

- `fix: adapt upstream OpenClawConfig refs to RemoteClawConfig` — cherry-picks introduced upstream `OpenClawConfig` type references; adapted to fork's `RemoteClawConfig`.