### PR TITLE
Cherry-pick upstream changelog, docs, Docker & model fixes (#853)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,7 @@ Docs: https://docs.openclaw.ai
 - CLI/Docs memory help accuracy: clarify `openclaw memory status --deep` behavior and align memory command examples/docs with the current search options. (#31803) Thanks @JasonOA888 and @Avi974.
 - Auto-reply/allowlist store account scoping: keep `/allowlist ... --store` writes scoped to the selected account and clear legacy unscoped entries when removing default-account store access, preventing cross-account default allowlist bleed-through from legacy pairing-store reads. Thanks @tdjackey for reporting and @vincentkoc for the fix.
 - Security/Nostr: harden profile mutation/import loopback guards by failing closed on non-loopback forwarded client headers (`x-forwarded-for` / `x-real-ip`) and rejecting `sec-fetch-site: cross-site`; adds regression coverage for proxy-forwarded and browser cross-site mutation attempts.
+- Models/default provider fallback: when the hardcoded default provider is removed from `models.providers`, resolve defaults from configured providers instead of reporting stale removed-provider defaults in status output. (#38947) Thanks @davidemanuelDEV.
 
 ## 2026.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/hook policy: add `plugins.entries.<id>.hooks.allowPromptInjection`, validate unknown typed hook names at runtime, and preserve legacy `before_agent_start` model/provider overrides while stripping prompt-mutating fields when prompt injection is disabled. (#36567) thanks @gumadeiras.
 - Hooks/Compaction lifecycle: emit `session:compact:before` and `session:compact:after` internal events plus plugin compaction callbacks with session/count metadata, so automations can react to compaction runs consistently. (#16788) thanks @vincentkoc.
 - iOS/App Store Connect release prep: align iOS bundle identifiers under `ai.openclaw.client`, refresh Watch app icons, add Fastlane metadata/screenshot automation, and support Keychain-backed ASC auth for uploads. (#38936) Thanks @ngutman.
+- Docker/multi-stage build: restructure Dockerfile as a multi-stage build to produce a minimal runtime image without build tools, source code, or Bun; add `OPENCLAW_VARIANT=slim` build arg for a bookworm-slim variant. (#38479) Thanks @sallyom.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,9 @@ Docs: https://docs.openclaw.ai
 - Agents/reply MEDIA delivery: normalize local assistant `MEDIA:` paths before block/final delivery, keep media dedupe aligned with message-tool sends, and contain malformed media normalization failures so generated files send reliably instead of falling back to empty responses. (#38572) Thanks @obviyus.
 - Markdown/assistant image hardening: flatten remote markdown images to plain text across the Control UI, exported HTML, and shared Swift chat while keeping inline `data:image/...` markdown renderable, so model output no longer triggers automatic remote image fetches. (#38895) Thanks @obviyus.
 - Models/auth token prompts: guard cancelled manual token prompts so `Symbol(clack:cancel)` values cannot be persisted into auth profiles; adds regression coverage for cancelled `models auth paste-token`. (#38951) Thanks @MumuTW.
+- CLI/Docs memory help accuracy: clarify `openclaw memory status --deep` behavior and align memory command examples/docs with the current search options. (#31803) Thanks @JasonOA888 and @Avi974.
+- Auto-reply/allowlist store account scoping: keep `/allowlist ... --store` writes scoped to the selected account and clear legacy unscoped entries when removing default-account store access, preventing cross-account default allowlist bleed-through from legacy pairing-store reads. Thanks @tdjackey for reporting and @vincentkoc for the fix.
+- Security/Nostr: harden profile mutation/import loopback guards by failing closed on non-loopback forwarded client headers (`x-forwarded-for` / `x-real-ip`) and rejecting `sec-fetch-site: cross-site`; adds regression coverage for proxy-forwarded and browser cross-site mutation attempts.
 
 ## 2026.3.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,27 @@
 # Opt-in extension dependencies at build time (space-separated directory names).
 # Example: docker build --build-arg OPENCLAW_EXTENSIONS="diagnostics-otel matrix" .
 #
-# A multi-stage build is used instead of `RUN --mount=type=bind` because
-# bind mounts require BuildKit, which is not available in plain Docker.
-# This stage extracts only the package.json files we need from extensions/,
-# so the main build layer is not invalidated by unrelated extension source changes.
+# Multi-stage build produces a minimal runtime image without build tools,
+# source code, or Bun. Works with Docker, Buildx, and Podman.
+# The ext-deps stage extracts only the package.json files we need from
+# extensions/, so the main build layer is not invalidated by unrelated
+# extension source changes.
+#
+# Two runtime variants:
+#   Default (bookworm):      docker build .
+#   Slim (bookworm-slim):    docker build --build-arg OPENCLAW_VARIANT=slim .
 ARG OPENCLAW_EXTENSIONS=""
-FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935 AS ext-deps
+ARG OPENCLAW_VARIANT=default
+
+# Base images are pinned to SHA256 digests for reproducible builds.
+# Trade-off: digests must be updated manually when upstream tags move.
+# To update, run: docker manifest inspect node:22-bookworm (or podman)
+# and replace the digest below with the current amd64 entry.
+
+FROM node:22-bookworm@sha256:6d735b4d33660225271fda0a412802746658c3a1b975507b2803ed299609760a AS ext-deps
 ARG OPENCLAW_EXTENSIONS
 COPY extensions /tmp/extensions
+# Copy package.json for opted-in extensions so pnpm resolves their deps.
 RUN mkdir -p /out && \
     for ext in $OPENCLAW_EXTENSIONS; do \
       if [ -f "/tmp/extensions/$ext/package.json" ]; then \
@@ -17,20 +30,8 @@ RUN mkdir -p /out && \
       fi; \
     done
 
-FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935
-
-# OCI base-image metadata for downstream image consumers.
-# If you change these annotations, also update:
-# - docs/install/docker.md ("Base image metadata" section)
-# - https://docs.remoteclaw.org/install/docker
-LABEL org.opencontainers.image.base.name="docker.io/library/node:22-bookworm" \
-  org.opencontainers.image.base.digest="sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935" \
-  org.opencontainers.image.source="https://github.com/remoteclaw/remoteclaw" \
-  org.opencontainers.image.url="https://remoteclaw.org" \
-  org.opencontainers.image.documentation="https://docs.remoteclaw.org/install/docker" \
-  org.opencontainers.image.licenses="AGPL-3.0-only" \
-  org.opencontainers.image.title="RemoteClaw" \
-  org.opencontainers.image.description="RemoteClaw gateway and CLI runtime container image"
+# ── Stage 2: Build ──────────────────────────────────────────────
+FROM node:22-bookworm@sha256:6d735b4d33660225271fda0a412802746658c3a1b975507b2803ed299609760a AS build
 
 # Install Bun (required for build scripts)
 RUN curl -fsSL https://bun.sh/install | bash
@@ -39,8 +40,80 @@ ENV PATH="/root/.bun/bin:${PATH}"
 RUN corepack enable
 
 WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY ui/package.json ./ui/package.json
+COPY patches ./patches
+COPY scripts ./scripts
+
+COPY --from=ext-deps /out/ ./extensions/
+
+# Reduce OOM risk on low-memory hosts during dependency installation.
+# Docker builds on small VMs may otherwise fail with "Killed" (exit 137).
+RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm install --frozen-lockfile
+
+COPY . .
+
+# A2UI bundle may fail under QEMU cross-compilation (e.g. building amd64
+# on Apple Silicon). CI builds natively per-arch so this is a no-op there.
+# Stub it so local cross-arch builds still succeed.
+RUN pnpm canvas:a2ui:bundle || \
+    (echo "A2UI bundle: creating stub (non-fatal)" && \
+     mkdir -p src/canvas-host/a2ui && \
+     echo "/* A2UI bundle unavailable in this build */" > src/canvas-host/a2ui/a2ui.bundle.js && \
+     echo "stub" > src/canvas-host/a2ui/.bundle.hash && \
+     rm -rf vendor/a2ui apps/shared/OpenClawKit/Tools/CanvasA2UI)
+RUN pnpm build
+# Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
+ENV OPENCLAW_PREFER_PNPM=1
+RUN pnpm ui:build
+
+# ── Runtime base images ─────────────────────────────────────────
+FROM node:22-bookworm@sha256:6d735b4d33660225271fda0a412802746658c3a1b975507b2803ed299609760a AS base-default
+LABEL org.opencontainers.image.base.name="docker.io/library/node:22-bookworm" \
+  org.opencontainers.image.base.digest="sha256:6d735b4d33660225271fda0a412802746658c3a1b975507b2803ed299609760a"
+
+FROM node:22-bookworm-slim@sha256:b41c15b715b5d6e3f305e9c6480a2396dd5f130b63add98d3d45760376f20823 AS base-slim
+LABEL org.opencontainers.image.base.name="docker.io/library/node:22-bookworm-slim" \
+  org.opencontainers.image.base.digest="sha256:b41c15b715b5d6e3f305e9c6480a2396dd5f130b63add98d3d45760376f20823"
+
+# ── Stage 3: Runtime ────────────────────────────────────────────
+FROM base-${OPENCLAW_VARIANT}
+ARG OPENCLAW_VARIANT
+
+# OCI base-image metadata for downstream image consumers.
+# If you change these annotations, also update:
+# - docs/install/docker.md ("Base image metadata" section)
+# - https://docs.remoteclaw.org/install/docker
+LABEL org.opencontainers.image.source="https://github.com/remoteclaw/remoteclaw" \
+  org.opencontainers.image.url="https://remoteclaw.org" \
+  org.opencontainers.image.documentation="https://docs.remoteclaw.org/install/docker" \
+  org.opencontainers.image.licenses="AGPL-3.0-only" \
+  org.opencontainers.image.title="RemoteClaw" \
+  org.opencontainers.image.description="RemoteClaw gateway and CLI runtime container image"
+
+WORKDIR /app
+
+# Install system utilities present in bookworm but missing in bookworm-slim.
+# On the full bookworm image these are already installed (apt-get is a no-op).
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      procps hostname curl git openssl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
 RUN chown node:node /app
 
+COPY --from=build --chown=node:node /app/dist ./dist
+COPY --from=build --chown=node:node /app/node_modules ./node_modules
+COPY --from=build --chown=node:node /app/package.json .
+COPY --from=build --chown=node:node /app/remoteclaw.mjs .
+COPY --from=build --chown=node:node /app/extensions ./extensions
+COPY --from=build --chown=node:node /app/skills ./skills
+COPY --from=build --chown=node:node /app/docs ./docs
+
+# Install additional system packages needed by your skills or extensions.
+# Example: docker build --build-arg REMOTECLAW_DOCKER_APT_PACKAGES="python3 wget" .
 ARG REMOTECLAW_DOCKER_APT_PACKAGES=""
 RUN if [ -n "$REMOTECLAW_DOCKER_APT_PACKAGES" ]; then \
       apt-get update && \
@@ -49,24 +122,10 @@ RUN if [ -n "$REMOTECLAW_DOCKER_APT_PACKAGES" ]; then \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi
 
-COPY --chown=node:node package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
-COPY --chown=node:node ui/package.json ./ui/package.json
-COPY --chown=node:node patches ./patches
-COPY --chown=node:node scripts ./scripts
-
-COPY --from=ext-deps --chown=node:node /out/ ./extensions/
-
-USER node
-# Reduce OOM risk on low-memory hosts during dependency installation.
-# Docker builds on small VMs may otherwise fail with "Killed" (exit 137).
-ENV NODE_OPTIONS=--max-old-space-size=2048
-RUN pnpm install --frozen-lockfile
-
 # Optionally install Chromium and Xvfb for browser automation.
 # Build with: docker build --build-arg REMOTECLAW_INSTALL_BROWSER=1 ...
 # Adds ~300MB but eliminates the 60-90s Playwright install on every container start.
-# Must run after pnpm install so playwright-core is available in node_modules.
-USER root
+# Must run after node_modules COPY so playwright-core is available.
 ARG REMOTECLAW_INSTALL_BROWSER=""
 RUN if [ -n "$REMOTECLAW_INSTALL_BROWSER" ]; then \
       apt-get update && \
@@ -111,9 +170,7 @@ RUN if [ -n "$REMOTECLAW_INSTALL_DOCKER_CLI" ]; then \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi
 
-USER node
-COPY --chown=node:node . .
-# Normalize copied plugin/agent paths so plugin safety checks do not reject
+# Normalize extension paths so plugin safety checks do not reject
 # world-writable directories inherited from source file modes.
 RUN for dir in /app/extensions /app/.agent /app/.agents; do \
       if [ -d "$dir" ]; then \
@@ -121,13 +178,8 @@ RUN for dir in /app/extensions /app/.agent /app/.agents; do \
         find "$dir" -type f -exec chmod 644 {} +; \
       fi; \
     done
-RUN pnpm build
-# Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
-ENV REMOTECLAW_PREFER_PNPM=1
-RUN pnpm ui:build
 
 # Expose the CLI binary without requiring npm global writes as non-root.
-USER root
 RUN ln -sf /app/remoteclaw.mjs /usr/local/bin/remoteclaw \
  && chmod 755 /app/remoteclaw.mjs
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -170,7 +170,7 @@ The main Docker image currently uses:
 The docker image now publishes OCI base-image annotations (sha256 is an example):
 
 - `org.opencontainers.image.base.name=docker.io/library/node:22-bookworm`
-- `org.opencontainers.image.base.digest=sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935`
+- `org.opencontainers.image.base.digest=sha256:6d735b4d33660225271fda0a412802746658c3a1b975507b2803ed299609760a`
 - `org.opencontainers.image.source=https://github.com/remoteclaw/remoteclaw`
 - `org.opencontainers.image.url=https://remoteclaw.org`
 - `org.opencontainers.image.documentation=https://docs.remoteclaw.org/install/docker`

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -55,7 +55,7 @@ Use `remoteclaw configure --section web` to set up your API key and choose a pro
 
 ### Perplexity Search
 
-1. Create a Perplexity account at <https://www.perplexity.ai/settings/api>
+1. Create a Perplexity account at [perplexity.ai/settings/api](https://www.perplexity.ai/settings/api)
 2. Generate an API key in the dashboard
 3. Run `remoteclaw configure --section web` to store the key in config, or set `PERPLEXITY_API_KEY` in your environment.
 
@@ -63,7 +63,7 @@ See [Perplexity Search API Docs](https://docs.perplexity.ai/guides/search-quicks
 
 ### Brave Search
 
-1. Create a Brave Search API account at <https://brave.com/search/api/>
+1. Create a Brave Search API account at [brave.com/search/api](https://brave.com/search/api/)
 2. In the dashboard, choose the **Data for Search** plan (not "Data for AI") and generate an API key.
 3. Run `remoteclaw configure --section web` to store the key in config (recommended), or set `BRAVE_API_KEY` in your environment.
 

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -7,14 +7,16 @@ const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const dockerfilePath = join(repoRoot, "Dockerfile");
 
 describe("Dockerfile", () => {
-  it("installs optional browser dependencies after pnpm install", async () => {
+  it("installs optional browser dependencies after node_modules are available", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
-    const installIndex = dockerfile.indexOf("RUN pnpm install --frozen-lockfile");
+    const nodeModulesCopyIndex = dockerfile.indexOf(
+      "COPY --from=build --chown=node:node /app/node_modules ./node_modules",
+    );
     const browserArgIndex = dockerfile.indexOf("ARG REMOTECLAW_INSTALL_BROWSER");
 
-    expect(installIndex).toBeGreaterThan(-1);
+    expect(nodeModulesCopyIndex).toBeGreaterThan(-1);
     expect(browserArgIndex).toBeGreaterThan(-1);
-    expect(browserArgIndex).toBeGreaterThan(installIndex);
+    expect(browserArgIndex).toBeGreaterThan(nodeModulesCopyIndex);
     expect(dockerfile).toContain(
       "node /app/node_modules/playwright-core/cli.js install --with-deps chromium",
     );


### PR DESCRIPTION
Closes #853

## Cherry-picks from upstream

See issue for full commit list and triage details.

### Landed (4 commits)
- `b08337b90` docs(changelog): credit allowlist scoping report — RESOLVED (CHANGELOG conflict)
- `5290d9757` Docs: fix web tools MDX links — PICKED (clean)
- `231c1fa37` fix(models): land #38947 from @davidemanuelDEV — RESOLVED (discarded gutted model-selection files, CHANGELOG conflict)
- `499c1ee6e` reduce image size, offer slim image (#38479) — RESOLVED (discarded fork-deleted docker-release workflow, Dockerfile/CHANGELOG/docker.md conflicts resolved with fork branding)

### Skipped (7 commits — empty after fork conflict resolution)
- `46e324e26` docs(changelog): credit hook auth throttling — lines already removed from fork
- `61273c072` Docs: remove MDX-breaking secret markers — fork already has rebranded env vars without markers
- `729ee165e` docs(gateway): clarify trusted operator HTTP endpoints — security boundary section already removed from fork
- `0f5317797` fix(tests): stabilize diffs localReq headers — all files gutted (extensions/diffs + CHANGELOG entry)
- `537c97cce` fix(agents): apply contextTokens cap for compaction — all files gutted (pi-embedded-runner + CHANGELOG entry)
- `c06014d50` fix(agents): respect explicit provider baseUrl — all files gutted (models-config + CHANGELOG entry)
- `17ab46aed` fix(models): prevent plaintext apiKey writes — all files gutted (models-config.providers + CHANGELOG entry)