### PR TITLE
Cherry-pick issue #859: upstream cron/daemon refactors

### DIFF
--- a/src/cron/service.issue-13992-regression.test.ts
+++ b/src/cron/service.issue-13992-regression.test.ts
@@ -46,21 +46,14 @@ describe("issue #13992 regression - cron jobs skip execution", () => {
     const now = Date.now();
     const pastDue = now - 60_000;
 
-    const job: CronJob = {
-      id: "test-job",
-      name: "test job",
-      enabled: true,
-      schedule: { kind: "cron", expr: "0 8 * * *", tz: "UTC" },
-      payload: { kind: "systemEvent", text: "test" },
-      sessionTarget: "main",
-      wakeMode: "next-heartbeat",
+    const job = createCronSystemEventJob(now, {
       createdAtMs: now - 3600_000,
       updatedAtMs: now - 3600_000,
       state: {
         nextRunAtMs: pastDue,
         lastRunAtMs: pastDue + 1000,
       },
-    };
+    });
 
     const state = createMockCronStateForJobs({ jobs: [job], nowMs: now });
     recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
@@ -73,21 +66,14 @@ describe("issue #13992 regression - cron jobs skip execution", () => {
     const now = Date.now();
     const pastDue = now - 60_000;
 
-    const job: CronJob = {
-      id: "test-job",
-      name: "test job",
-      enabled: true,
-      schedule: { kind: "cron", expr: "0 8 * * *", tz: "UTC" },
-      payload: { kind: "systemEvent", text: "test" },
-      sessionTarget: "main",
-      wakeMode: "next-heartbeat",
+    const job = createCronSystemEventJob(now, {
       createdAtMs: now - 3600_000,
       updatedAtMs: now - 3600_000,
       state: {
         nextRunAtMs: pastDue,
         runningAtMs: now - 500,
       },
-    };
+    });
 
     const state = createMockCronStateForJobs({ jobs: [job], nowMs: now });
     recomputeNextRunsForMaintenance(state, { recomputeExpired: true });

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -118,6 +118,24 @@ describe("checkTokenDrift", () => {
     expect(result).toBeNull();
   });
 
+  it("returns null when tokens match but service token has trailing newline", () => {
+    const result = checkTokenDrift({ serviceToken: "same-token\n", configToken: "same-token" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when tokens match but have surrounding whitespace", () => {
+    const result = checkTokenDrift({ serviceToken: "  same-token  ", configToken: "same-token" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when both tokens have different whitespace padding", () => {
+    const result = checkTokenDrift({
+      serviceToken: "same-token\r\n",
+      configToken: " same-token ",
+    });
+    expect(result).toBeNull();
+  });
+
   it("detects drift when config has token but service has different token", () => {
     const result = checkTokenDrift({ serviceToken: "old-token", configToken: "new-token" });
     expect(result).not.toBeNull();

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -362,13 +362,19 @@ export function checkTokenDrift(params: {
 }): ServiceConfigIssue | null {
   const { serviceToken, configToken } = params;
 
+  // Normalise both tokens before comparing: service-file parsers (systemd,
+  // launchd) can return values with trailing newlines or whitespace that
+  // cause a false-positive mismatch against the config value.
+  const normService = serviceToken?.trim() || undefined;
+  const normConfig = configToken?.trim() || undefined;
+
   // No drift if both are undefined/empty
-  if (!serviceToken && !configToken) {
+  if (!normService && !normConfig) {
     return null;
   }
 
   // Drift: config has token, service has different or no token
-  if (configToken && serviceToken !== configToken) {
+  if (normConfig && normService !== normConfig) {
     return {
       code: SERVICE_AUDIT_CODES.gatewayTokenDrift,
       message:

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -17,6 +17,38 @@ import {
   stopSystemdService,
 } from "./systemd.js";
 
+type ExecFileError = Error & {
+  stderr?: string;
+  code?: string | number;
+};
+
+const createExecFileError = (
+  message: string,
+  options: { stderr?: string; code?: string | number } = {},
+): ExecFileError => {
+  const err = new Error(message) as ExecFileError;
+  err.code = options.code ?? 1;
+  if (options.stderr) {
+    err.stderr = options.stderr;
+  }
+  return err;
+};
+
+const createWritableStreamMock = () => {
+  const write = vi.fn();
+  return {
+    write,
+    stdout: { write } as unknown as NodeJS.WritableStream,
+  };
+};
+
+const assertRestartSuccess = async (env: NodeJS.ProcessEnv) => {
+  const { write, stdout } = createWritableStreamMock();
+  await restartSystemdService({ stdout, env });
+  expect(write).toHaveBeenCalledTimes(1);
+  expect(String(write.mock.calls[0]?.[0])).toContain("Restarted systemd service");
+};
+
 describe("systemd availability", () => {
   beforeEach(() => {
     execFileMock.mockReset();
@@ -46,15 +78,10 @@ describe("systemd availability", () => {
     execFileMock
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         expect(args).toEqual(["--user", "status"]);
-        const err = new Error(
-          "Failed to connect to user scope bus via local transport",
-        ) as Error & {
-          stderr?: string;
-          code?: number;
-        };
-        err.stderr =
-          "Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined";
-        err.code = 1;
+        const err = createExecFileError("Failed to connect to user scope bus via local transport", {
+          stderr:
+            "Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
+        });
         cb(err, "", "");
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
@@ -271,6 +298,16 @@ describe("parseSystemdExecStart", () => {
 });
 
 describe("systemd service control", () => {
+  const assertMachineRestartArgs = (args: string[]) => {
+    expect(args).toEqual([
+      "--machine",
+      "debian@",
+      "--user",
+      "restart",
+      "remoteclaw-gateway.service",
+    ]);
+  };
+
   beforeEach(() => {
     execFileMock.mockReset();
   });
@@ -298,13 +335,7 @@ describe("systemd service control", () => {
         expect(args).toEqual(["--user", "restart", "remoteclaw-gateway-work.service"]);
         cb(null, "", "");
       });
-    const write = vi.fn();
-    const stdout = { write } as unknown as NodeJS.WritableStream;
-
-    await restartSystemdService({ stdout, env: { REMOTECLAW_PROFILE: "work" } });
-
-    expect(write).toHaveBeenCalledTimes(1);
-    expect(String(write.mock.calls[0]?.[0])).toContain("Restarted systemd service");
+    await assertRestartSuccess({ REMOTECLAW_PROFILE: "work" });
   });
 
   it("surfaces stop failures with systemctl detail", async () => {
@@ -331,22 +362,10 @@ describe("systemd service control", () => {
         cb(null, "", "");
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual([
-          "--machine",
-          "debian@",
-          "--user",
-          "restart",
-          "remoteclaw-gateway.service",
-        ]);
+        assertMachineRestartArgs(args);
         cb(null, "", "");
       });
-    const write = vi.fn();
-    const stdout = { write } as unknown as NodeJS.WritableStream;
-
-    await restartSystemdService({ stdout, env: { SUDO_USER: "debian" } });
-
-    expect(write).toHaveBeenCalledTimes(1);
-    expect(String(write.mock.calls[0]?.[0])).toContain("Restarted systemd service");
+    await assertRestartSuccess({ SUDO_USER: "debian" });
   });
 
   it("keeps direct --user scope when SUDO_USER is root", async () => {
@@ -359,26 +378,17 @@ describe("systemd service control", () => {
         expect(args).toEqual(["--user", "restart", "remoteclaw-gateway.service"]);
         cb(null, "", "");
       });
-    const write = vi.fn();
-    const stdout = { write } as unknown as NodeJS.WritableStream;
-
-    await restartSystemdService({ stdout, env: { SUDO_USER: "root", USER: "root" } });
-
-    expect(write).toHaveBeenCalledTimes(1);
-    expect(String(write.mock.calls[0]?.[0])).toContain("Restarted systemd service");
+    await assertRestartSuccess({ SUDO_USER: "root", USER: "root" });
   });
 
   it("falls back to machine user scope for restart when user bus env is missing", async () => {
     execFileMock
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         expect(args).toEqual(["--user", "status"]);
-        const err = new Error("Failed to connect to user scope bus") as Error & {
-          stderr?: string;
-          code?: number;
-        };
-        err.stderr =
-          "Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined";
-        err.code = 1;
+        const err = createExecFileError("Failed to connect to user scope bus", {
+          stderr:
+            "Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
+        });
         cb(err, "", "");
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
@@ -387,30 +397,15 @@ describe("systemd service control", () => {
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         expect(args).toEqual(["--user", "restart", "remoteclaw-gateway.service"]);
-        const err = new Error("Failed to connect to user scope bus") as Error & {
-          stderr?: string;
-          code?: number;
-        };
-        err.stderr = "Failed to connect to user scope bus";
-        err.code = 1;
+        const err = createExecFileError("Failed to connect to user scope bus", {
+          stderr: "Failed to connect to user scope bus",
+        });
         cb(err, "", "");
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual([
-          "--machine",
-          "debian@",
-          "--user",
-          "restart",
-          "remoteclaw-gateway.service",
-        ]);
+        assertMachineRestartArgs(args);
         cb(null, "", "");
       });
-    const write = vi.fn();
-    const stdout = { write } as unknown as NodeJS.WritableStream;
-
-    await restartSystemdService({ stdout, env: { USER: "debian" } });
-
-    expect(write).toHaveBeenCalledTimes(1);
-    expect(String(write.mock.calls[0]?.[0])).toContain("Restarted systemd service");
+    await assertRestartSuccess({ USER: "debian" });
   });
 });


### PR DESCRIPTION
Closes #859

## Cherry-picks from upstream

See issue for full commit list and triage details.

| Hash | Subject | Result |
|------|---------|--------|
| `8fd043aba` | refactor(cron): dedupe interim retry fallback assertions | SKIPPED (file deleted in fork) |
| `1fc11ea7d` | refactor(daemon): dedupe systemd restart test scaffolding | RESOLVED (rebrand + dedupe merge) |
| `41e0c35b6` | refactor(cron): reuse cron job builder in issue-13992 tests | PICKED |
| `c5bb6db85` | refactor(cron): share isolated-agent turn core test setup | SKIPPED (file deleted in fork) |
| `70be8ce15` | fix(daemon): normalise whitespace in checkTokenDrift | PICKED |