### PR TITLE
Cherry-pick upstream security and infra fixes (issue #867)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,7 @@ Docs: https://docs.openclaw.ai
 - Subagents/workspace inheritance: propagate parent workspace directory to spawned subagent runs so child sessions reliably inherit workspace-scoped instructions (`AGENTS.md`, `SOUL.md`, etc.) without exposing workspace override through tool-call arguments. (#39247) Thanks @jasonQin6.
 - Heartbeat/requests-in-flight scheduling: stop advancing `nextDueMs` and avoid immediate `scheduleNext()` timer overrides on requests-in-flight skips, so wake-layer retry cooldowns are honored and heartbeat cadence no longer drifts under sustained contention. (#39182) Thanks @MumuTW.
 - Outbound delivery replay safety: use two-phase delivery ACK markers (`.json` -> `.delivered` -> unlink) and startup marker cleanup so crash windows between send and cleanup do not replay already-delivered messages. (#38668) Thanks @Gundam98.
+- Nodes/system.run PowerShell wrapper parsing: treat `pwsh`/`powershell` `-EncodedCommand` forms as shell-wrapper payloads so allowlist mode still requires approval instead of falling back to plain argv analysis. Thanks @tdjackey for reporting.
 
 ## 2026.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,7 @@ Docs: https://docs.openclaw.ai
 - Nodes/system.run approval binding: carry prepared approval plans through gateway forwarding and bind interpreter-style script operands across approval to execution, so post-approval script rewrites are denied while unchanged approved script runs keep working. Thanks @tdjackey for reporting.
 - Subagents/workspace inheritance: propagate parent workspace directory to spawned subagent runs so child sessions reliably inherit workspace-scoped instructions (`AGENTS.md`, `SOUL.md`, etc.) without exposing workspace override through tool-call arguments. (#39247) Thanks @jasonQin6.
 - Heartbeat/requests-in-flight scheduling: stop advancing `nextDueMs` and avoid immediate `scheduleNext()` timer overrides on requests-in-flight skips, so wake-layer retry cooldowns are honored and heartbeat cadence no longer drifts under sustained contention. (#39182) Thanks @MumuTW.
+- Outbound delivery replay safety: use two-phase delivery ACK markers (`.json` -> `.delivered` -> unlink) and startup marker cleanup so crash windows between send and cleanup do not replay already-delivered messages. (#38668) Thanks @Gundam98.
 
 ## 2026.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,7 @@ Docs: https://docs.openclaw.ai
 - Heartbeat/requests-in-flight scheduling: stop advancing `nextDueMs` and avoid immediate `scheduleNext()` timer overrides on requests-in-flight skips, so wake-layer retry cooldowns are honored and heartbeat cadence no longer drifts under sustained contention. (#39182) Thanks @MumuTW.
 - Outbound delivery replay safety: use two-phase delivery ACK markers (`.json` -> `.delivered` -> unlink) and startup marker cleanup so crash windows between send and cleanup do not replay already-delivered messages. (#38668) Thanks @Gundam98.
 - Nodes/system.run PowerShell wrapper parsing: treat `pwsh`/`powershell` `-EncodedCommand` forms as shell-wrapper payloads so allowlist mode still requires approval instead of falling back to plain argv analysis. Thanks @tdjackey for reporting.
+- Nodes/system.run allow-always persistence: honor shell comment semantics during allowlist analysis so `#`-tailed payloads that never execute are not persisted as trusted follow-up commands. Thanks @tdjackey for reporting.
 
 ## 2026.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,7 @@ Docs: https://docs.openclaw.ai
 - Outbound delivery replay safety: use two-phase delivery ACK markers (`.json` -> `.delivered` -> unlink) and startup marker cleanup so crash windows between send and cleanup do not replay already-delivered messages. (#38668) Thanks @Gundam98.
 - Nodes/system.run PowerShell wrapper parsing: treat `pwsh`/`powershell` `-EncodedCommand` forms as shell-wrapper payloads so allowlist mode still requires approval instead of falling back to plain argv analysis. Thanks @tdjackey for reporting.
 - Nodes/system.run allow-always persistence: honor shell comment semantics during allowlist analysis so `#`-tailed payloads that never execute are not persisted as trusted follow-up commands. Thanks @tdjackey for reporting.
+- Nodes/system.run dispatch-wrapper boundary: keep shell-wrapper approval classification active at the depth boundary so `env` wrapper stacks cannot reach `/bin/sh -c` execution without the expected approval gate. Thanks @tdjackey for reporting.
 
 ## 2026.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/password auth startup diagnostics: detect unresolved provider-reference objects in `gateway.auth.password` and fail with a specific bootstrap-secrets error message instead of generic misconfiguration output. (#39230) Thanks @ademczuk.
 - Nodes/system.run approval binding: carry prepared approval plans through gateway forwarding and bind interpreter-style script operands across approval to execution, so post-approval script rewrites are denied while unchanged approved script runs keep working. Thanks @tdjackey for reporting.
 - Subagents/workspace inheritance: propagate parent workspace directory to spawned subagent runs so child sessions reliably inherit workspace-scoped instructions (`AGENTS.md`, `SOUL.md`, etc.) without exposing workspace override through tool-call arguments. (#39247) Thanks @jasonQin6.
+- Heartbeat/requests-in-flight scheduling: stop advancing `nextDueMs` and avoid immediate `scheduleNext()` timer overrides on requests-in-flight skips, so wake-layer retry cooldowns are honored and heartbeat cadence no longer drifts under sustained contention. (#39182) Thanks @MumuTW.
 
 ## 2026.3.2
 

--- a/package.json
+++ b/package.json
@@ -369,6 +369,7 @@
     "playwright-core": "1.58.2",
     "qrcode-terminal": "^0.12.0",
     "sharp": "^0.34.5",
+    "strip-ansi": "^7.2.0",
     "tar": "7.5.10",
     "tslog": "^4.10.2",
     "undici": "^7.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
+      strip-ansi:
+        specifier: ^7.2.0
+        version: 7.2.0
       tar:
         specifier: 7.5.10
         version: 7.5.10

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -16,6 +16,7 @@ import { setGatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setVerbose } from "../../globals.js";
 import { GatewayLockError } from "../../infra/gateway-lock.js";
 import { formatPortDiagnostics, inspectPortUsage } from "../../infra/ports.js";
+import { cleanStaleGatewayProcessesSync } from "../../infra/restart-stale-pids.js";
 import { setConsoleSubsystemFilter, setConsoleTimestampPrefix } from "../../logging/console.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -182,6 +183,14 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     defaultRuntime.error('Invalid --bind (use "loopback", "lan", "tailnet", "auto", or "custom")');
     defaultRuntime.exit(1);
     return;
+  }
+  if (process.env.OPENCLAW_SERVICE_MARKER?.trim()) {
+    const stale = cleanStaleGatewayProcessesSync(port);
+    if (stale.length > 0) {
+      gatewayLog.info(
+        `service-mode: cleared ${stale.length} stale gateway pid(s) before bind on port ${port}`,
+      );
+    }
   }
   if (opts.force) {
     try {

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -19,6 +19,9 @@ describe("buildSystemdUnit", () => {
       environment: {},
     });
     expect(unit).toContain("KillMode=control-group");
+    expect(unit).toContain("TimeoutStopSec=30");
+    expect(unit).toContain("TimeoutStartSec=30");
+    expect(unit).toContain("SuccessExitStatus=0 143");
   });
 
   it("rejects environment values with line breaks", () => {

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -14,8 +14,8 @@ describe("buildSystemdUnit", () => {
 
   it("renders control-group kill mode for child-process cleanup", () => {
     const unit = buildSystemdUnit({
-      description: "OpenClaw Gateway",
-      programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+      description: "RemoteClaw Gateway",
+      programArguments: ["/usr/bin/remoteclaw", "gateway", "run"],
       environment: {},
     });
     expect(unit).toContain("KillMode=control-group");

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -59,6 +59,9 @@ export function buildSystemdUnit({
     `ExecStart=${execStart}`,
     "Restart=always",
     "RestartSec=5",
+    "TimeoutStopSec=30",
+    "TimeoutStartSec=30",
+    "SuccessExitStatus=0 143",
     // Keep service children in the same lifecycle so restarts do not leave
     // orphan ACP/runtime workers behind.
     "KillMode=control-group",

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -158,9 +158,51 @@ describe("startHeartbeatRunner", () => {
     await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
     expect(runSpy).toHaveBeenCalledTimes(1);
 
-    // Timer should be rescheduled; next heartbeat should still fire
-    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    // The wake layer retries after DEFAULT_RETRY_MS (1 s).  No scheduleNext()
+    // is called inside runOnce, so we must wait for the full cooldown.
+    await vi.advanceTimersByTimeAsync(1_000);
     expect(runSpy).toHaveBeenCalledTimes(2);
+
+    runner.stop();
+  });
+
+  it("does not push nextDueMs forward on repeated requests-in-flight skips", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    // Simulate a long-running heartbeat: the first 5 calls return
+    // requests-in-flight (retries from the wake layer), then the 6th succeeds.
+    let callCount = 0;
+    const runSpy = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount <= 5) {
+        return { status: "skipped", reason: "requests-in-flight" };
+      }
+      return { status: "ran", durationMs: 1 };
+    });
+
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: { defaults: { heartbeat: { every: "30m" } } },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    // Trigger the first heartbeat at t=30m — returns requests-in-flight.
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    // Simulate 4 more retries at short intervals (wake layer retries).
+    for (let i = 0; i < 4; i++) {
+      requestHeartbeatNow({ reason: "retry", coalesceMs: 0 });
+      await vi.advanceTimersByTimeAsync(1_000);
+    }
+    expect(runSpy).toHaveBeenCalledTimes(5);
+
+    // The next interval tick at ~t=60m should still fire — the schedule
+    // must not have been pushed to t=30m * 6 = 180m by the 5 retries.
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+    expect(runSpy).toHaveBeenCalledTimes(6);
 
     runner.stop();
   });

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -184,7 +184,7 @@ describe("startHeartbeatRunner", () => {
     const runner = startHeartbeatRunner({
       cfg: {
         agents: { defaults: { heartbeat: { every: "30m" } } },
-      } as OpenClawConfig,
+      } as RemoteClawConfig,
       runOnce: runSpy,
     });
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1098,8 +1098,10 @@ export function startHeartbeatRunner(opts: {
         continue;
       }
       if (res.status === "skipped" && res.reason === "requests-in-flight") {
-        advanceAgentSchedule(agent, now);
-        scheduleNext();
+        // Do not advance the schedule — the main lane is busy and the wake
+        // layer will retry shortly (DEFAULT_RETRY_MS = 1 s).  Calling
+        // scheduleNext() here would register a 0 ms timer that races with
+        // the wake layer's 1 s retry and wins, bypassing the cooldown.
         return res;
       }
       if (res.status !== "skipped" || res.reason !== "disabled") {

--- a/src/infra/install-package-dir.test.ts
+++ b/src/infra/install-package-dir.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -15,6 +16,20 @@ function normalizeDarwinTmpPath(filePath: string): string {
   return process.platform === "darwin" && filePath.startsWith("/private/var/")
     ? filePath.slice("/private".length)
     : filePath;
+}
+
+function normalizeComparablePath(filePath: string): string {
+  const resolved = normalizeDarwinTmpPath(path.resolve(filePath));
+  const parent = normalizeDarwinTmpPath(path.dirname(resolved));
+  let comparableParent = parent;
+  try {
+    comparableParent = normalizeDarwinTmpPath(fsSync.realpathSync.native(parent));
+  } catch {
+    comparableParent = parent;
+  }
+  const basename =
+    process.platform === "win32" ? path.basename(resolved).toLowerCase() : path.basename(resolved);
+  return path.join(comparableParent, basename);
 }
 
 async function rebindInstallBasePath(params: {
@@ -37,13 +52,13 @@ async function withInstallBaseReboundOnRealpathCall<T>(params: {
   rebindAtCall: number;
   run: () => Promise<T>;
 }): Promise<T> {
-  const installBasePath = normalizeDarwinTmpPath(path.resolve(params.installBaseDir));
+  const installBasePath = normalizeComparablePath(params.installBaseDir);
   const realRealpath = fs.realpath.bind(fs);
   let installBaseRealpathCalls = 0;
   const realpathSpy = vi
     .spyOn(fs, "realpath")
     .mockImplementation(async (...args: Parameters<typeof fs.realpath>) => {
-      const filePath = normalizeDarwinTmpPath(path.resolve(String(args[0])));
+      const filePath = normalizeComparablePath(String(args[0]));
       if (filePath === installBasePath) {
         installBaseRealpathCalls += 1;
         if (installBaseRealpathCalls === params.rebindAtCall) {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -67,6 +67,34 @@ function resolveFailedDir(stateDir?: string): string {
   return path.join(resolveQueueDir(stateDir), FAILED_DIRNAME);
 }
 
+function resolveQueueEntryPaths(
+  id: string,
+  stateDir?: string,
+): {
+  jsonPath: string;
+  deliveredPath: string;
+} {
+  const queueDir = resolveQueueDir(stateDir);
+  return {
+    jsonPath: path.join(queueDir, `${id}.json`),
+    deliveredPath: path.join(queueDir, `${id}.delivered`),
+  };
+}
+
+function getErrnoCode(err: unknown): string | null {
+  return err && typeof err === "object" && "code" in err
+    ? String((err as { code?: unknown }).code)
+    : null;
+}
+
+async function unlinkBestEffort(filePath: string): Promise<void> {
+  try {
+    await fs.promises.unlink(filePath);
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
 /** Ensure the queue directory (and failed/ subdirectory) exist. */
 export async function ensureQueueDir(stateDir?: string): Promise<string> {
   const queueDir = resolveQueueDir(stateDir);
@@ -117,35 +145,22 @@ export async function enqueueDelivery(
  * by {@link loadPendingDeliveries} on the next startup without re-sending.
  */
 export async function ackDelivery(id: string, stateDir?: string): Promise<void> {
-  const queueDir = resolveQueueDir(stateDir);
-  const jsonPath = path.join(queueDir, `${id}.json`);
-  const deliveredPath = path.join(queueDir, `${id}.delivered`);
+  const { jsonPath, deliveredPath } = resolveQueueEntryPaths(id, stateDir);
   try {
     // Phase 1: atomic rename marks the delivery as complete.
     await fs.promises.rename(jsonPath, deliveredPath);
   } catch (err) {
-    const code =
-      err && typeof err === "object" && "code" in err
-        ? String((err as { code?: unknown }).code)
-        : null;
+    const code = getErrnoCode(err);
     if (code === "ENOENT") {
       // .json already gone — may have been renamed by a previous ack attempt.
       // Try to clean up a leftover .delivered marker if present.
-      try {
-        await fs.promises.unlink(deliveredPath);
-      } catch {
-        // marker already gone — no-op.
-      }
+      await unlinkBestEffort(deliveredPath);
       return;
     }
     throw err;
   }
   // Phase 2: remove the marker file.
-  try {
-    await fs.promises.unlink(deliveredPath);
-  } catch {
-    // Best-effort; loadPendingDeliveries will clean it up on next startup.
-  }
+  await unlinkBestEffort(deliveredPath);
 }
 
 /** Update a queue entry after a failed delivery attempt. */
@@ -171,10 +186,7 @@ export async function loadPendingDeliveries(stateDir?: string): Promise<QueuedDe
   try {
     files = await fs.promises.readdir(queueDir);
   } catch (err) {
-    const code =
-      err && typeof err === "object" && "code" in err
-        ? String((err as { code?: unknown }).code)
-        : null;
+    const code = getErrnoCode(err);
     if (code === "ENOENT") {
       return [];
     }
@@ -186,11 +198,7 @@ export async function loadPendingDeliveries(stateDir?: string): Promise<QueuedDe
     if (!file.endsWith(".delivered")) {
       continue;
     }
-    try {
-      await fs.promises.unlink(path.join(queueDir, file));
-    } catch {
-      // Best-effort cleanup.
-    }
+    await unlinkBestEffort(path.join(queueDir, file));
   }
 
   const entries: QueuedDelivery[] = [];

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -107,20 +107,44 @@ export async function enqueueDelivery(
   return id;
 }
 
-/** Remove a successfully delivered entry from the queue. */
+/** Remove a successfully delivered entry from the queue.
+ *
+ * Uses a two-phase approach so that a crash between delivery and cleanup
+ * does not cause the message to be replayed on the next recovery scan:
+ *   Phase 1: atomic rename  {id}.json → {id}.delivered
+ *   Phase 2: unlink the .delivered marker
+ * If the process dies between phase 1 and phase 2 the marker is cleaned up
+ * by {@link loadPendingDeliveries} on the next startup without re-sending.
+ */
 export async function ackDelivery(id: string, stateDir?: string): Promise<void> {
-  const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
+  const queueDir = resolveQueueDir(stateDir);
+  const jsonPath = path.join(queueDir, `${id}.json`);
+  const deliveredPath = path.join(queueDir, `${id}.delivered`);
   try {
-    await fs.promises.unlink(filePath);
+    // Phase 1: atomic rename marks the delivery as complete.
+    await fs.promises.rename(jsonPath, deliveredPath);
   } catch (err) {
     const code =
       err && typeof err === "object" && "code" in err
         ? String((err as { code?: unknown }).code)
         : null;
-    if (code !== "ENOENT") {
-      throw err;
+    if (code === "ENOENT") {
+      // .json already gone — may have been renamed by a previous ack attempt.
+      // Try to clean up a leftover .delivered marker if present.
+      try {
+        await fs.promises.unlink(deliveredPath);
+      } catch {
+        // marker already gone — no-op.
+      }
+      return;
     }
-    // Already removed — no-op.
+    throw err;
+  }
+  // Phase 2: remove the marker file.
+  try {
+    await fs.promises.unlink(deliveredPath);
+  } catch {
+    // Best-effort; loadPendingDeliveries will clean it up on next startup.
   }
 }
 
@@ -156,6 +180,19 @@ export async function loadPendingDeliveries(stateDir?: string): Promise<QueuedDe
     }
     throw err;
   }
+  // Clean up .delivered markers left by ackDelivery if the process crashed
+  // between the rename and the unlink.
+  for (const file of files) {
+    if (!file.endsWith(".delivered")) {
+      continue;
+    }
+    try {
+      await fs.promises.unlink(path.join(queueDir, file));
+    } catch {
+      // Best-effort cleanup.
+    }
+  }
+
   const entries: QueuedDelivery[] = [];
   for (const file of files) {
     if (!file.endsWith(".json")) {

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -253,9 +253,12 @@ function waitForPortFreeSync(port: number): void {
  *
  * Called before service restart commands to prevent port conflicts.
  */
-export function cleanStaleGatewayProcessesSync(): number[] {
+export function cleanStaleGatewayProcessesSync(portOverride?: number): number[] {
   try {
-    const port = resolveGatewayPort(undefined, process.env);
+    const port =
+      typeof portOverride === "number" && Number.isFinite(portOverride) && portOverride > 0
+        ? Math.floor(portOverride)
+        : resolveGatewayPort(undefined, process.env);
     const stalePids = findGatewayPidsOnPortSync(port);
     if (stalePids.length === 0) {
       return [];

--- a/src/infra/restart.test.ts
+++ b/src/infra/restart.test.ts
@@ -95,6 +95,27 @@ describe.runIf(process.platform !== "win32")("cleanStaleGatewayProcessesSync", (
     expect(killSpy).toHaveBeenCalledWith(6002, "SIGKILL");
   });
 
+  it("uses explicit port override when provided", () => {
+    spawnSyncMock.mockReturnValue({
+      error: undefined,
+      status: 0,
+      stdout: ["p7001", "copenclaw"].join("\n"),
+    });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const killed = cleanStaleGatewayProcessesSync(19999);
+
+    expect(killed).toEqual([7001]);
+    expect(resolveGatewayPortMock).not.toHaveBeenCalled();
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      "/usr/sbin/lsof",
+      ["-nP", "-iTCP:19999", "-sTCP:LISTEN", "-Fpc"],
+      expect.objectContaining({ encoding: "utf8", timeout: 2000 }),
+    );
+    expect(killSpy).toHaveBeenCalledWith(7001, "SIGTERM");
+    expect(killSpy).toHaveBeenCalledWith(7001, "SIGKILL");
+  });
+
   it("returns empty when no stale listeners are found", () => {
     spawnSyncMock.mockReturnValue({
       error: undefined,

--- a/src/infra/restart.test.ts
+++ b/src/infra/restart.test.ts
@@ -99,7 +99,7 @@ describe.runIf(process.platform !== "win32")("cleanStaleGatewayProcessesSync", (
     spawnSyncMock.mockReturnValue({
       error: undefined,
       status: 0,
-      stdout: ["p7001", "copenclaw"].join("\n"),
+      stdout: ["p7001", "cremoteclaw"].join("\n"),
     });
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -428,7 +428,8 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   // Tests for env -S shell payloads, semicolon-chained shell payloads, wrapper spoofs,
-  // skill-bin denial, and nested env depth in allowlist mode are not applicable: the fork
-  // gutted exec-approvals infrastructure (evaluateSystemRunPolicy, analyzeArgvCommand are
-  // stubs).  Upstream tests exercised the real allowlist/policy pipeline.
+  // skill-bin denial, PowerShell encoded commands, and nested env depth in allowlist mode
+  // are not applicable: the fork gutted exec-approvals infrastructure
+  // (evaluateSystemRunPolicy, analyzeArgvCommand are stubs).
+  // Upstream tests exercised the real allowlist/policy pipeline.
 });

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -428,8 +428,8 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   // Tests for env -S shell payloads, semicolon-chained shell payloads, wrapper spoofs,
-  // skill-bin denial, PowerShell encoded commands, and nested env depth in allowlist mode
-  // are not applicable: the fork gutted exec-approvals infrastructure
-  // (evaluateSystemRunPolicy, analyzeArgvCommand are stubs).
+  // skill-bin denial, PowerShell encoded commands, dispatch-wrapper boundary drift, and
+  // nested env depth in allowlist mode are not applicable: the fork gutted exec-approvals
+  // infrastructure (evaluateSystemRunPolicy, analyzeArgvCommand are stubs).
   // Upstream tests exercised the real allowlist/policy pipeline.
 });

--- a/src/test-utils/exec-assertions.ts
+++ b/src/test-utils/exec-assertions.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { expect } from "vitest";
 
@@ -5,6 +6,15 @@ function normalizeDarwinTmpPath(filePath: string): string {
   return process.platform === "darwin" && filePath.startsWith("/private/var/")
     ? filePath.slice("/private".length)
     : filePath;
+}
+
+function canonicalizeComparableDir(dirPath: string): string {
+  const normalized = normalizeDarwinTmpPath(path.resolve(dirPath));
+  try {
+    return normalizeDarwinTmpPath(fs.realpathSync.native(normalized));
+  } catch {
+    return normalized;
+  }
 }
 
 export function expectSingleNpmInstallIgnoreScriptsCall(params: {
@@ -27,9 +37,11 @@ export function expectSingleNpmInstallIgnoreScriptsCall(params: {
     "--ignore-scripts",
   ]);
   expect(opts?.cwd).toBeTruthy();
-  const cwd = normalizeDarwinTmpPath(String(opts?.cwd));
-  const expectedTargetDir = normalizeDarwinTmpPath(params.expectedTargetDir);
-  expect(path.dirname(cwd)).toBe(path.dirname(expectedTargetDir));
+  const cwd = String(opts?.cwd);
+  const expectedTargetDir = params.expectedTargetDir;
+  expect(canonicalizeComparableDir(path.dirname(cwd))).toBe(
+    canonicalizeComparableDir(path.dirname(expectedTargetDir)),
+  );
   expect(path.basename(cwd)).toMatch(/^\.remoteclaw-install-stage-/);
 }
 

--- a/src/utils/shell-argv.ts
+++ b/src/utils/shell-argv.ts
@@ -59,6 +59,10 @@ export function splitShellArgs(raw: string): string[] | null {
       inDouble = true;
       continue;
     }
+    // In POSIX shells, "#" starts a comment only when it begins a word.
+    if (ch === "#" && buf.length === 0) {
+      break;
+    }
     if (/\s/.test(ch)) {
       pushToken();
       continue;

--- a/src/utils/utils-misc.test.ts
+++ b/src/utils/utils-misc.test.ts
@@ -96,4 +96,10 @@ describe("splitShellArgs", () => {
     expect(splitShellArgs(`echo "oops`)).toBeNull();
     expect(splitShellArgs(`echo 'oops`)).toBeNull();
   });
+
+  it("stops at unquoted shell comments but keeps quoted hashes literal", () => {
+    expect(splitShellArgs(`echo hi # comment && whoami`)).toEqual(["echo", "hi"]);
+    expect(splitShellArgs(`echo "hi # still-literal"`)).toEqual(["echo", "hi # still-literal"]);
+    expect(splitShellArgs(`echo hi#tail`)).toEqual(["echo", "hi#tail"]);
+  });
 });


### PR DESCRIPTION
Closes #867

## Cherry-picks from upstream

| Hash | Subject | Result |
|------|---------|--------|
| `97f9e2552` | fix(ci): restore strip-ansi and typecheck fixtures (#39146) | RESOLVED |
| `cc7e61612` | fix(gateway): harden service-mode stale process cleanup (#38463) | PICKED |
| `733f7af92` | fix(heartbeat): keep requests-in-flight retries from drifting schedule (#39182) | RESOLVED |
| `708187f28` | fix(outbound): prevent replay after ack crash windows (#38668) | RESOLVED |
| `5b27b0cec` | refactor(outbound,agents): extract shared payload and queue helpers | RESOLVED |
| `1d1757b16` | fix(exec): recognize PowerShell encoded commands | RESOLVED |
| `939b18475` | fix(exec): honor shell comments in allow-always analysis | RESOLVED |
| `2fc95a7cf` | fix(exec): close dispatch-wrapper boundary drift | RESOLVED |

See issue for full commit list and triage details.