### PR TITLE
Cherry-pick issue #870: upstream cron/daemon updates

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for the double-announce bug in cron delivery dispatch.
+ *
+ * Bug: early return paths in deliverViaAnnounce (active subagent suppression
+ * and stale interim message suppression) returned without setting
+ * deliveryAttempted = true. The timer saw deliveryAttempted = false and
+ * fired enqueueSystemEvent as a fallback, causing a second announcement.
+ *
+ * Fix: both early return paths now set deliveryAttempted = true before
+ * returning so the timer correctly skips the system-event fallback.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Module mocks (must be hoisted before imports) ---
+
+vi.mock("../../agents/subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../../agents/subagent-registry.js", () => ({
+  countActiveDescendantRuns: vi.fn().mockReturnValue(0),
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  resolveAgentMainSessionKey: vi.fn().mockReturnValue("agent:main"),
+}));
+
+vi.mock("../../infra/outbound/outbound-session.js", () => ({
+  resolveOutboundSessionRoute: vi.fn().mockResolvedValue(null),
+  ensureOutboundSessionEntry: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../infra/outbound/deliver.js", () => ({
+  deliverOutboundPayloads: vi.fn().mockResolvedValue([{ ok: true }]),
+}));
+
+vi.mock("../../infra/outbound/identity.js", () => ({
+  resolveAgentOutboundIdentity: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../../infra/outbound/session-context.js", () => ({
+  buildOutboundSessionContext: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../../cli/outbound-send-deps.js", () => ({
+  createOutboundSendDeps: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../../logger.js", () => ({
+  logWarn: vi.fn(),
+}));
+
+vi.mock("./subagent-followup.js", () => ({
+  expectsSubagentFollowup: vi.fn().mockReturnValue(false),
+  isLikelyInterimCronMessage: vi.fn().mockReturnValue(false),
+  readDescendantSubagentFallbackReply: vi.fn().mockResolvedValue(undefined),
+  waitForDescendantSubagentSummary: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { runSubagentAnnounceFlow } from "../../agents/subagent-announce.js";
+// Import after mocks
+import { countActiveDescendantRuns } from "../../agents/subagent-registry.js";
+import { shouldEnqueueCronMainSummary } from "../heartbeat-policy.js";
+import { dispatchCronDelivery } from "./delivery-dispatch.js";
+import type { DeliveryTargetResolution } from "./delivery-target.js";
+import type { RunCronAgentTurnResult } from "./run.js";
+import {
+  expectsSubagentFollowup,
+  isLikelyInterimCronMessage,
+  readDescendantSubagentFallbackReply,
+  waitForDescendantSubagentSummary,
+} from "./subagent-followup.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeResolvedDelivery(): Extract<DeliveryTargetResolution, { ok: true }> {
+  return {
+    ok: true,
+    channel: "telegram",
+    to: "123456",
+    accountId: undefined,
+    threadId: undefined,
+  };
+}
+
+function makeWithRunSession() {
+  return (
+    result: Omit<RunCronAgentTurnResult, "sessionId" | "sessionKey">,
+  ): RunCronAgentTurnResult => ({
+    ...result,
+    sessionId: "test-session-id",
+    sessionKey: "test-session-key",
+  });
+}
+
+function makeBaseParams(overrides: { synthesizedText?: string; deliveryRequested?: boolean }) {
+  const resolvedDelivery = makeResolvedDelivery();
+  return {
+    cfg: {} as never,
+    cfgWithAgentDefaults: {} as never,
+    deps: {} as never,
+    job: {
+      id: "test-job",
+      name: "Test Job",
+      deleteAfterRun: false,
+      payload: { kind: "agentTurn", message: "hello" },
+    } as never,
+    agentId: "main",
+    agentSessionKey: "agent:main",
+    runSessionId: "run-123",
+    runStartedAt: Date.now(),
+    runEndedAt: Date.now(),
+    timeoutMs: 30_000,
+    resolvedDelivery,
+    deliveryRequested: overrides.deliveryRequested ?? true,
+    skipHeartbeatDelivery: false,
+    skipMessagingToolDelivery: false,
+    deliveryBestEffort: false,
+    deliveryPayloadHasStructuredContent: false,
+    deliveryPayloads: overrides.synthesizedText ? [{ text: overrides.synthesizedText }] : [],
+    synthesizedText: overrides.synthesizedText ?? "on it",
+    summary: overrides.synthesizedText ?? "on it",
+    outputText: overrides.synthesizedText ?? "on it",
+    telemetry: undefined,
+    abortSignal: undefined,
+    isAborted: () => false,
+    abortReason: () => "aborted",
+    withRunSession: makeWithRunSession(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("dispatchCronDelivery — double-announce guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(expectsSubagentFollowup).mockReturnValue(false);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+    vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
+    vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
+    vi.mocked(runSubagentAnnounceFlow).mockResolvedValue(true);
+  });
+
+  it("early return (active subagent) sets deliveryAttempted=true so timer skips enqueueSystemEvent", async () => {
+    // countActiveDescendantRuns returns >0 → enters wait block; still >0 after wait → early return
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(2);
+    vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
+    vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
+
+    const params = makeBaseParams({ synthesizedText: "on it" });
+    const state = await dispatchCronDelivery(params);
+
+    // deliveryAttempted must be true so timer does NOT fire enqueueSystemEvent
+    expect(state.deliveryAttempted).toBe(true);
+
+    // Verify timer guard agrees: shouldEnqueueCronMainSummary returns false
+    expect(
+      shouldEnqueueCronMainSummary({
+        summaryText: "on it",
+        deliveryRequested: true,
+        delivered: state.delivered,
+        deliveryAttempted: state.deliveryAttempted,
+        suppressMainSummary: false,
+        isCronSystemEvent: () => true,
+      }),
+    ).toBe(false);
+
+    // No announce should have been attempted (subagents still running)
+    expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+  });
+
+  it("early return (stale interim suppression) sets deliveryAttempted=true so timer skips enqueueSystemEvent", async () => {
+    // First countActiveDescendantRuns call returns >0 (had descendants), second returns 0
+    vi.mocked(countActiveDescendantRuns)
+      .mockReturnValueOnce(2) // initial check → hadDescendants=true, enters wait block
+      .mockReturnValueOnce(0); // second check after wait → activeSubagentRuns=0
+    vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
+    vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
+    // synthesizedText matches initialSynthesizedText & isLikelyInterimCronMessage → stale interim
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(true);
+
+    const params = makeBaseParams({ synthesizedText: "on it, pulling everything together" });
+    const state = await dispatchCronDelivery(params);
+
+    // deliveryAttempted must be true so timer does NOT fire enqueueSystemEvent
+    expect(state.deliveryAttempted).toBe(true);
+
+    // Verify timer guard agrees
+    expect(
+      shouldEnqueueCronMainSummary({
+        summaryText: "on it, pulling everything together",
+        deliveryRequested: true,
+        delivered: state.delivered,
+        deliveryAttempted: state.deliveryAttempted,
+        suppressMainSummary: false,
+        isCronSystemEvent: () => true,
+      }),
+    ).toBe(false);
+
+    // No announce or direct delivery should have been sent (stale interim suppressed)
+    expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+  });
+
+  it("normal announce success delivers exactly once and sets deliveryAttempted=true", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+    vi.mocked(runSubagentAnnounceFlow).mockResolvedValue(true);
+
+    const params = makeBaseParams({ synthesizedText: "Morning briefing complete." });
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(true);
+    // Announce called exactly once
+    expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+
+    // Timer should not fire enqueueSystemEvent (delivered=true)
+    expect(
+      shouldEnqueueCronMainSummary({
+        summaryText: "Morning briefing complete.",
+        deliveryRequested: true,
+        delivered: state.delivered,
+        deliveryAttempted: state.deliveryAttempted,
+        suppressMainSummary: false,
+        isCronSystemEvent: () => true,
+      }),
+    ).toBe(false);
+  });
+
+  it("announce failure falls back to direct delivery exactly once (no double-deliver)", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+    // Announce fails: runSubagentAnnounceFlow returns false
+    vi.mocked(runSubagentAnnounceFlow).mockResolvedValue(false);
+
+    const { deliverOutboundPayloads } = await import("../../infra/outbound/deliver.js");
+    vi.mocked(deliverOutboundPayloads).mockResolvedValue([{ ok: true } as never]);
+
+    const params = makeBaseParams({ synthesizedText: "Briefing ready." });
+    const state = await dispatchCronDelivery(params);
+
+    // Delivery was attempted; direct fallback picked up the slack
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(true);
+
+    // Announce was tried exactly once
+    expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+
+    // Direct fallback fired exactly once (not zero, not twice)
+    // This ensures one delivery total reaches the user, not two
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+  });
+
+  it("no delivery requested means deliveryAttempted stays false and runSubagentAnnounceFlow not called", async () => {
+    const params = makeBaseParams({
+      synthesizedText: "Task done.",
+      deliveryRequested: false,
+    });
+    const state = await dispatchCronDelivery(params);
+
+    expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+    // deliveryAttempted starts false (skipMessagingToolDelivery=false) and nothing runs
+    expect(state.deliveryAttempted).toBe(false);
+  });
+});

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -83,6 +83,7 @@ function makeResolvedDelivery(): Extract<DeliveryTargetResolution, { ok: true }>
     to: "123456",
     accountId: undefined,
     threadId: undefined,
+    mode: "explicit",
   };
 }
 

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -320,8 +320,16 @@ export async function dispatchCronDelivery(
     }
     if (activeSubagentRuns > 0) {
       // Parent orchestration is still in progress; avoid announcing a partial
-      // update to the main requester.
-      return params.withRunSession({ status: "ok", summary, outputText, ...params.telemetry });
+      // update to the main requester. Mark deliveryAttempted so the timer does
+      // not fire a redundant enqueueSystemEvent fallback (double-announce bug).
+      deliveryAttempted = true;
+      return params.withRunSession({
+        status: "ok",
+        summary,
+        outputText,
+        deliveryAttempted,
+        ...params.telemetry,
+      });
     }
     if (
       hadDescendants &&
@@ -331,8 +339,16 @@ export async function dispatchCronDelivery(
     ) {
       // Descendants existed but no post-orchestration synthesis arrived AND
       // no descendant fallback reply was available. Suppress stale parent
-      // text like "on it, pulling everything together".
-      return params.withRunSession({ status: "ok", summary, outputText, ...params.telemetry });
+      // text like "on it, pulling everything together". Mark deliveryAttempted
+      // so the timer does not fire a redundant enqueueSystemEvent fallback.
+      deliveryAttempted = true;
+      return params.withRunSession({
+        status: "ok",
+        summary,
+        outputText,
+        deliveryAttempted,
+        ...params.telemetry,
+      });
     }
     if (synthesizedText.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase()) {
       return params.withRunSession({

--- a/src/cron/isolated-agent/subagent-followup.test.ts
+++ b/src/cron/isolated-agent/subagent-followup.test.ts
@@ -1,12 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.hoisted runs before module imports, ensuring FAST_TEST_MODE is picked up.
+vi.hoisted(() => {
+  process.env.OPENCLAW_TEST_FAST = "1";
+});
+
 import {
   expectsSubagentFollowup,
   isLikelyInterimCronMessage,
   readDescendantSubagentFallbackReply,
+  waitForDescendantSubagentSummary,
 } from "./subagent-followup.js";
 
 vi.mock("../../agents/subagent-registry.js", () => ({
-  countActiveDescendantRuns: vi.fn().mockReturnValue(0),
   listDescendantRunsForRequester: vi.fn().mockReturnValue([]),
 }));
 
@@ -14,8 +20,18 @@ vi.mock("../../agents/tools/agent-step.js", () => ({
   readLatestAssistantReply: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: vi.fn().mockResolvedValue({ status: "ok" }),
+}));
+
 const { listDescendantRunsForRequester } = await import("../../agents/subagent-registry.js");
 const { readLatestAssistantReply } = await import("../../agents/tools/agent-step.js");
+const { callGateway } = await import("../../gateway/call.js");
+
+async function resolveAfterAdvancingTimers<T>(promise: Promise<T>, advanceMs = 100): Promise<T> {
+  await vi.advanceTimersByTimeAsync(advanceMs);
+  return promise;
+}
 
 describe("isLikelyInterimCronMessage", () => {
   it("detects 'on it' as interim", () => {
@@ -240,6 +256,249 @@ describe("readDescendantSubagentFallbackReply", () => {
       sessionKey: "test-session",
       runStartedAt,
     });
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("waitForDescendantSubagentSummary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    vi.mocked(listDescendantRunsForRequester).mockReturnValue([]);
+    vi.mocked(readLatestAssistantReply).mockResolvedValue(undefined);
+    vi.mocked(callGateway).mockResolvedValue({ status: "ok" });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns initialReply immediately when no active descendants and observedActiveDescendants=false", async () => {
+    vi.mocked(listDescendantRunsForRequester).mockReturnValue([]);
+    const result = await waitForDescendantSubagentSummary({
+      sessionKey: "cron-session",
+      initialReply: "on it",
+      timeoutMs: 100,
+      observedActiveDescendants: false,
+    });
+    expect(result).toBe("on it");
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+
+  it("awaits active descendants via agent.wait and returns synthesis after grace period", async () => {
+    // First call: active run; second call (after agent.wait resolves): no active runs
+    vi.mocked(listDescendantRunsForRequester)
+      .mockReturnValueOnce([
+        {
+          runId: "run-abc",
+          childSessionKey: "child-session",
+          requesterSessionKey: "cron-session",
+          requesterDisplayKey: "cron-session",
+          task: "morning briefing",
+          cleanup: "keep",
+          createdAt: 1000,
+          // no endedAt → active
+        },
+      ])
+      .mockReturnValue([]); // subsequent calls: all done
+
+    vi.mocked(callGateway).mockResolvedValue({ status: "ok" });
+    vi.mocked(readLatestAssistantReply).mockResolvedValue("Morning briefing complete!");
+
+    const result = await waitForDescendantSubagentSummary({
+      sessionKey: "cron-session",
+      initialReply: "on it",
+      timeoutMs: 30_000,
+      observedActiveDescendants: true,
+    });
+
+    expect(result).toBe("Morning briefing complete!");
+    // agent.wait should have been called with the active run's ID
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent.wait",
+        params: expect.objectContaining({ runId: "run-abc" }),
+      }),
+    );
+  });
+
+  it("returns undefined when descendants finish but only interim text remains after grace period", async () => {
+    vi.useFakeTimers();
+    // No active runs at call time, but observedActiveDescendants=true (saw them before)
+    vi.mocked(listDescendantRunsForRequester).mockReturnValue([]);
+    // readLatestAssistantReply keeps returning interim text
+    vi.mocked(readLatestAssistantReply).mockResolvedValue("on it");
+
+    const resultPromise = waitForDescendantSubagentSummary({
+      sessionKey: "cron-session",
+      initialReply: "on it",
+      timeoutMs: 100,
+      observedActiveDescendants: true,
+    });
+
+    const result = await resolveAfterAdvancingTimers(resultPromise);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns synthesis even if initial reply was undefined", async () => {
+    vi.mocked(listDescendantRunsForRequester)
+      .mockReturnValueOnce([
+        {
+          runId: "run-xyz",
+          childSessionKey: "child-2",
+          requesterSessionKey: "cron-session",
+          requesterDisplayKey: "cron-session",
+          task: "report",
+          cleanup: "keep",
+          createdAt: 1000,
+        },
+      ])
+      .mockReturnValue([]);
+
+    vi.mocked(callGateway).mockResolvedValue({ status: "ok" });
+    vi.mocked(readLatestAssistantReply).mockResolvedValue("Report generated successfully.");
+
+    const result = await waitForDescendantSubagentSummary({
+      sessionKey: "cron-session",
+      initialReply: undefined,
+      timeoutMs: 30_000,
+      observedActiveDescendants: true,
+    });
+
+    expect(result).toBe("Report generated successfully.");
+  });
+
+  it("uses agent.wait for each active run when multiple descendants exist", async () => {
+    vi.mocked(listDescendantRunsForRequester)
+      .mockReturnValueOnce([
+        {
+          runId: "run-1",
+          childSessionKey: "child-1",
+          requesterSessionKey: "cron-session",
+          requesterDisplayKey: "cron-session",
+          task: "task-1",
+          cleanup: "keep",
+          createdAt: 1000,
+        },
+        {
+          runId: "run-2",
+          childSessionKey: "child-2",
+          requesterSessionKey: "cron-session",
+          requesterDisplayKey: "cron-session",
+          task: "task-2",
+          cleanup: "keep",
+          createdAt: 1000,
+        },
+      ])
+      .mockReturnValue([]);
+
+    vi.mocked(callGateway).mockResolvedValue({ status: "ok" });
+    vi.mocked(readLatestAssistantReply).mockResolvedValue("All tasks complete.");
+
+    await waitForDescendantSubagentSummary({
+      sessionKey: "cron-session",
+      initialReply: "spawned a subagent",
+      timeoutMs: 30_000,
+      observedActiveDescendants: true,
+    });
+
+    // agent.wait called once for each active run
+    const waitCalls = vi
+      .mocked(callGateway)
+      .mock.calls.filter((c) => (c[0] as { method?: string }).method === "agent.wait");
+    expect(waitCalls).toHaveLength(2);
+    const runIds = waitCalls.map((c) => (c[0] as { params: { runId: string } }).params.runId);
+    expect(runIds).toContain("run-1");
+    expect(runIds).toContain("run-2");
+  });
+
+  it("waits for newly discovered active descendants after the first wait round", async () => {
+    vi.mocked(listDescendantRunsForRequester)
+      .mockReturnValueOnce([
+        {
+          runId: "run-1",
+          childSessionKey: "child-1",
+          requesterSessionKey: "cron-session",
+          requesterDisplayKey: "cron-session",
+          task: "task-1",
+          cleanup: "keep",
+          createdAt: 1000,
+        },
+      ])
+      .mockReturnValueOnce([
+        {
+          runId: "run-2",
+          childSessionKey: "child-2",
+          requesterSessionKey: "cron-session",
+          requesterDisplayKey: "cron-session",
+          task: "task-2",
+          cleanup: "keep",
+          createdAt: 1001,
+        },
+      ])
+      .mockReturnValue([]);
+
+    vi.mocked(callGateway).mockResolvedValue({ status: "ok" });
+    vi.mocked(readLatestAssistantReply).mockResolvedValue("Nested descendant work complete.");
+
+    const result = await waitForDescendantSubagentSummary({
+      sessionKey: "cron-session",
+      initialReply: "spawned a subagent",
+      timeoutMs: 30_000,
+      observedActiveDescendants: true,
+    });
+
+    expect(result).toBe("Nested descendant work complete.");
+    const waitedRunIds = vi
+      .mocked(callGateway)
+      .mock.calls.filter((c) => (c[0] as { method?: string }).method === "agent.wait")
+      .map((c) => (c[0] as { params: { runId: string } }).params.runId);
+    expect(waitedRunIds).toEqual(["run-1", "run-2"]);
+  });
+
+  it("handles agent.wait errors gracefully and still reads the synthesis", async () => {
+    vi.mocked(listDescendantRunsForRequester)
+      .mockReturnValueOnce([
+        {
+          runId: "run-err",
+          childSessionKey: "child-err",
+          requesterSessionKey: "cron-session",
+          requesterDisplayKey: "cron-session",
+          task: "task-err",
+          cleanup: "keep",
+          createdAt: 1000,
+        },
+      ])
+      .mockReturnValue([]);
+
+    vi.mocked(callGateway).mockRejectedValue(new Error("gateway unavailable"));
+    vi.mocked(readLatestAssistantReply).mockResolvedValue("Completed despite gateway error.");
+
+    const result = await waitForDescendantSubagentSummary({
+      sessionKey: "cron-session",
+      initialReply: "on it",
+      timeoutMs: 30_000,
+      observedActiveDescendants: true,
+    });
+
+    expect(result).toBe("Completed despite gateway error.");
+  });
+
+  it("skips NO_REPLY synthesis and returns undefined", async () => {
+    vi.useFakeTimers();
+    vi.mocked(listDescendantRunsForRequester).mockReturnValue([]);
+    vi.mocked(readLatestAssistantReply).mockResolvedValue("NO_REPLY");
+
+    const resultPromise = waitForDescendantSubagentSummary({
+      sessionKey: "cron-session",
+      initialReply: "on it",
+      timeoutMs: 100,
+      observedActiveDescendants: true,
+    });
+
+    const result = await resolveAfterAdvancingTimers(resultPromise);
+
     expect(result).toBeUndefined();
   });
 });

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -1,12 +1,14 @@
-import {
-  countActiveDescendantRuns,
-  listDescendantRunsForRequester,
-} from "../../agents/subagent-registry.js";
+import { listDescendantRunsForRequester } from "../../agents/subagent-registry.js";
 import { readLatestAssistantReply } from "../../agents/tools/agent-step.js";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
-const CRON_SUBAGENT_WAIT_POLL_MS = 500;
-const CRON_SUBAGENT_WAIT_MIN_MS = 30_000;
-const CRON_SUBAGENT_FINAL_REPLY_GRACE_MS = 5_000;
+import { callGateway } from "../../gateway/call.js";
+
+const FAST_TEST_MODE = process.env.OPENCLAW_TEST_FAST === "1";
+
+const CRON_SUBAGENT_WAIT_MIN_MS = FAST_TEST_MODE ? 10 : 30_000;
+const CRON_SUBAGENT_FINAL_REPLY_GRACE_MS = FAST_TEST_MODE ? 50 : 5_000;
+const CRON_SUBAGENT_GRACE_POLL_MS = FAST_TEST_MODE ? 8 : 200;
+
 const SUBAGENT_FOLLOWUP_HINTS = [
   "subagent spawned",
   "spawned a subagent",
@@ -14,6 +16,7 @@ const SUBAGENT_FOLLOWUP_HINTS = [
   "both subagents are running",
   "wait for them to report back",
 ] as const;
+
 const INTERIM_CRON_HINTS = [
   "on it",
   "pulling everything together",
@@ -103,6 +106,12 @@ export async function readDescendantSubagentFallbackReply(params: {
   return replies.join("\n\n");
 }
 
+/**
+ * Waits for descendant subagents to complete using a push-based approach:
+ * each active descendant run is awaited via `agent.wait` (gateway RPC) instead
+ * of a busy-poll loop.  After all active runs settle, a short grace period
+ * polls the cron agent's session for a post-orchestration synthesis message.
+ */
 export async function waitForDescendantSubagentSummary(params: {
   sessionKey: string;
   initialReply?: string;
@@ -111,22 +120,53 @@ export async function waitForDescendantSubagentSummary(params: {
 }): Promise<string | undefined> {
   const initialReply = params.initialReply?.trim();
   const deadline = Date.now() + Math.max(CRON_SUBAGENT_WAIT_MIN_MS, Math.floor(params.timeoutMs));
-  let sawActiveDescendants = params.observedActiveDescendants === true;
-  let drainedAtMs: number | undefined;
-  while (Date.now() < deadline) {
-    const activeDescendants = countActiveDescendantRuns(params.sessionKey);
-    if (activeDescendants > 0) {
-      sawActiveDescendants = true;
-      drainedAtMs = undefined;
-      await new Promise((resolve) => setTimeout(resolve, CRON_SUBAGENT_WAIT_POLL_MS));
-      continue;
-    }
-    if (!sawActiveDescendants) {
-      return initialReply;
-    }
-    if (!drainedAtMs) {
-      drainedAtMs = Date.now();
-    }
+
+  // Snapshot the currently active descendant run IDs.
+  const getActiveRuns = () =>
+    listDescendantRunsForRequester(params.sessionKey).filter(
+      (entry) => typeof entry.endedAt !== "number",
+    );
+
+  const initialActiveRuns = getActiveRuns();
+  const sawActiveDescendants =
+    params.observedActiveDescendants === true || initialActiveRuns.length > 0;
+
+  if (!sawActiveDescendants) {
+    // No active descendants and none were observed before the call – nothing to wait for.
+    return initialReply;
+  }
+
+  // --- Push-based wait for all active descendants ---
+  // We iterate in case first-level descendants spawn their own subagents while
+  // we wait, so new active runs can appear between rounds.
+  let pendingRunIds = new Set<string>(initialActiveRuns.map((e) => e.runId));
+
+  while (pendingRunIds.size > 0 && Date.now() < deadline) {
+    const remainingMs = Math.max(1, deadline - Date.now());
+    // Wait for all currently pending runs concurrently.  If any fails or times
+    // out, allSettled absorbs the error so we proceed to the next iteration.
+    await Promise.allSettled(
+      [...pendingRunIds].map((runId) =>
+        callGateway<{ status?: string }>({
+          method: "agent.wait",
+          params: { runId, timeoutMs: remainingMs },
+          timeoutMs: remainingMs + 2_000,
+        }).catch(() => undefined),
+      ),
+    );
+
+    // Refresh: check for newly created active descendants (e.g. spawned by
+    // the runs that just finished) and keep looping if any exist.
+    pendingRunIds = new Set<string>(getActiveRuns().map((e) => e.runId));
+  }
+
+  // --- Grace period: wait for the cron agent's synthesis ---
+  // After the subagent announces fire and the cron agent processes them, it
+  // produces a new assistant message.  Poll briefly (bounded by
+  // CRON_SUBAGENT_FINAL_REPLY_GRACE_MS) to capture that synthesis.
+  const gracePeriodDeadline = Math.min(Date.now() + CRON_SUBAGENT_FINAL_REPLY_GRACE_MS, deadline);
+
+  while (Date.now() < gracePeriodDeadline) {
     const latest = (await readLatestAssistantReply({ sessionKey: params.sessionKey }))?.trim();
     if (
       latest &&
@@ -135,11 +175,10 @@ export async function waitForDescendantSubagentSummary(params: {
     ) {
       return latest;
     }
-    if (Date.now() - drainedAtMs >= CRON_SUBAGENT_FINAL_REPLY_GRACE_MS) {
-      return undefined;
-    }
-    await new Promise((resolve) => setTimeout(resolve, CRON_SUBAGENT_WAIT_POLL_MS));
+    await new Promise<void>((resolve) => setTimeout(resolve, CRON_SUBAGENT_GRACE_POLL_MS));
   }
+
+  // Final read after grace period expires.
   const latest = (await readLatestAssistantReply({ sessionKey: params.sessionKey }))?.trim();
   if (
     latest &&
@@ -148,5 +187,6 @@ export async function waitForDescendantSubagentSummary(params: {
   ) {
     return latest;
   }
+
   return undefined;
 }

--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -133,4 +133,22 @@ describe("installScheduledTask", () => {
       ).rejects.toThrow(/Task description cannot contain CR or LF/);
     });
   });
+
+  it("does not persist a frozen PATH snapshot into the generated task script", async () => {
+    await withUserProfileDir(async (_tmpDir, env) => {
+      const { scriptPath } = await installScheduledTask({
+        env,
+        stdout: new PassThrough(),
+        programArguments: ["node", "gateway.js"],
+        environment: {
+          PATH: "C:\\Windows\\System32;C:\\Program Files\\Docker\\Docker\\resources\\bin",
+          OPENCLAW_GATEWAY_PORT: "18789",
+        },
+      });
+
+      const script = await fs.readFile(scriptPath, "utf8");
+      expect(script).not.toContain('set "PATH=');
+      expect(script).toContain('set "OPENCLAW_GATEWAY_PORT=18789"');
+    });
+  });
 });

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -63,6 +63,41 @@ describe("scheduled task runtime derivation", () => {
       detail: "Task reports Running but Last Run Result=0x0; treating as stale runtime state.",
     });
   });
+
+  it("detects running via result code when status is localized (German)", () => {
+    expect(
+      deriveScheduledTaskRuntimeStatus({
+        status: "Wird ausgeführt",
+        lastRunResult: "0x41301",
+      }),
+    ).toEqual({ status: "running" });
+  });
+
+  it("detects running via result code when status is localized (French)", () => {
+    expect(
+      deriveScheduledTaskRuntimeStatus({
+        status: "En cours",
+        lastRunResult: "267009",
+      }),
+    ).toEqual({ status: "running" });
+  });
+
+  it("treats localized status as stopped when result code is not a running code", () => {
+    expect(
+      deriveScheduledTaskRuntimeStatus({
+        status: "Wird ausgeführt",
+        lastRunResult: "0x0",
+      }),
+    ).toEqual({ status: "stopped" });
+  });
+
+  it("treats localized status without result code as stopped", () => {
+    expect(
+      deriveScheduledTaskRuntimeStatus({
+        status: "Wird ausgeführt",
+      }),
+    ).toEqual({ status: "stopped" });
+  });
 });
 
 describe("resolveTaskScriptPath", () => {

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -44,15 +44,18 @@ describe("scheduled task runtime derivation", () => {
     ).toEqual({ status: "running" });
   });
 
-  it("treats Running without last result as running", () => {
+  it("treats Running without numeric result as unknown", () => {
     expect(
       deriveScheduledTaskRuntimeStatus({
         status: "Running",
       }),
-    ).toEqual({ status: "running" });
+    ).toEqual({
+      status: "unknown",
+      detail: "Task status is locale-dependent and no numeric Last Run Result was available.",
+    });
   });
 
-  it("downgrades stale Running status when last result is not a running code", () => {
+  it("treats non-running result codes as stopped", () => {
     expect(
       deriveScheduledTaskRuntimeStatus({
         status: "Running",
@@ -60,7 +63,7 @@ describe("scheduled task runtime derivation", () => {
       }),
     ).toEqual({
       status: "stopped",
-      detail: "Task reports Running but Last Run Result=0x0; treating as stale runtime state.",
+      detail: "Task Last Run Result=0x0; treating as not running.",
     });
   });
 
@@ -88,15 +91,21 @@ describe("scheduled task runtime derivation", () => {
         status: "Wird ausgeführt",
         lastRunResult: "0x0",
       }),
-    ).toEqual({ status: "stopped" });
+    ).toEqual({
+      status: "stopped",
+      detail: "Task Last Run Result=0x0; treating as not running.",
+    });
   });
 
-  it("treats localized status without result code as stopped", () => {
+  it("treats localized status without result code as unknown", () => {
     expect(
       deriveScheduledTaskRuntimeStatus({
         status: "Wird ausgeführt",
       }),
-    ).toEqual({ status: "stopped" });
+    ).toEqual({
+      status: "unknown",
+      detail: "Task status is locale-dependent and no numeric Last Run Result was available.",
+    });
   });
 });
 

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -163,13 +163,23 @@ export function deriveScheduledTaskRuntimeStatus(parsed: ScheduledTaskInfo): {
   if (!statusRaw) {
     return { status: "unknown" };
   }
-  if (statusRaw !== "running") {
-    return { status: "stopped" };
-  }
 
   const normalizedResult = normalizeTaskResultCode(parsed.lastRunResult);
   const runningCodes = new Set(["0x41301"]);
-  if (normalizedResult && !runningCodes.has(normalizedResult)) {
+  const isRunningByCode = normalizedResult != null && runningCodes.has(normalizedResult);
+  const isRunningByStatus = statusRaw === "running";
+
+  // schtasks.exe localizes its Status field ("Running" in English,
+  // "Wird ausgeführt" in German, "En cours" in French, etc.).
+  // Prefer the locale-invariant Last Run Result code 0x41301
+  // ("task is currently running") over string matching. (#39057)
+  if (!isRunningByStatus && !isRunningByCode) {
+    return { status: "stopped" };
+  }
+
+  // Cross-check: if the English status says "running" but the result
+  // code disagrees, the runtime state is likely stale.
+  if (isRunningByStatus && normalizedResult && !isRunningByCode) {
     return {
       status: "stopped",
       detail: `Task reports Running but Last Run Result=${parsed.lastRunResult}; treating as stale runtime state.`,

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -209,6 +209,9 @@ function buildTaskScript({
       if (!value) {
         continue;
       }
+      if (key.toUpperCase() === "PATH") {
+        continue;
+      }
       lines.push(renderCmdSetAssignment(key, value));
     }
   }

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -152,41 +152,31 @@ function normalizeTaskResultCode(value?: string): string | null {
     }
   }
 
-  return raw;
+  return null;
 }
+
+const RUNNING_RESULT_CODES = new Set(["0x41301"]);
+const UNKNOWN_STATUS_DETAIL =
+  "Task status is locale-dependent and no numeric Last Run Result was available.";
 
 export function deriveScheduledTaskRuntimeStatus(parsed: ScheduledTaskInfo): {
   status: GatewayServiceRuntime["status"];
   detail?: string;
 } {
-  const statusRaw = parsed.status?.trim().toLowerCase();
-  if (!statusRaw) {
-    return { status: "unknown" };
-  }
-
   const normalizedResult = normalizeTaskResultCode(parsed.lastRunResult);
-  const runningCodes = new Set(["0x41301"]);
-  const isRunningByCode = normalizedResult != null && runningCodes.has(normalizedResult);
-  const isRunningByStatus = statusRaw === "running";
-
-  // schtasks.exe localizes its Status field ("Running" in English,
-  // "Wird ausgeführt" in German, "En cours" in French, etc.).
-  // Prefer the locale-invariant Last Run Result code 0x41301
-  // ("task is currently running") over string matching. (#39057)
-  if (!isRunningByStatus && !isRunningByCode) {
-    return { status: "stopped" };
-  }
-
-  // Cross-check: if the English status says "running" but the result
-  // code disagrees, the runtime state is likely stale.
-  if (isRunningByStatus && normalizedResult && !isRunningByCode) {
+  if (normalizedResult != null) {
+    if (RUNNING_RESULT_CODES.has(normalizedResult)) {
+      return { status: "running" };
+    }
     return {
       status: "stopped",
-      detail: `Task reports Running but Last Run Result=${parsed.lastRunResult}; treating as stale runtime state.`,
+      detail: `Task Last Run Result=${parsed.lastRunResult}; treating as not running.`,
     };
   }
-
-  return { status: "running" };
+  if (parsed.status?.trim()) {
+    return { status: "unknown", detail: UNKNOWN_STATUS_DETAIL };
+  }
+  return { status: "unknown" };
 }
 
 function buildTaskScript({

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -342,7 +342,7 @@ describe("buildServiceEnvironment", () => {
     });
 
     expect(env).not.toHaveProperty("PATH");
-    expect(env.OPENCLAW_WINDOWS_TASK_NAME).toBe("OpenClaw Gateway");
+    expect(env.REMOTECLAW_WINDOWS_TASK_NAME).toBe("RemoteClaw Gateway");
   });
 });
 

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -267,7 +267,7 @@ describe("buildServiceEnvironment", () => {
     });
     expect(env.HOME).toBe("/home/user");
     if (process.platform === "win32") {
-      expect(env.PATH).toBe("");
+      expect(env).not.toHaveProperty("PATH");
     } else {
       expect(env.PATH).toContain("/usr/bin");
     }
@@ -329,6 +329,20 @@ describe("buildServiceEnvironment", () => {
     expect(env.NO_PROXY).toBe("localhost,127.0.0.1");
     expect(env.http_proxy).toBe("http://proxy.local:7890");
     expect(env.all_proxy).toBe("socks5://proxy.local:1080");
+  });
+
+  it("omits PATH on Windows so Scheduled Tasks can inherit the current shell path", () => {
+    const env = buildServiceEnvironment({
+      env: {
+        HOME: "C:\\Users\\alice",
+        PATH: "C:\\Windows\\System32;C:\\Tools\\rg",
+      },
+      port: 18789,
+      platform: "win32",
+    });
+
+    expect(env).not.toHaveProperty("PATH");
+    expect(env.OPENCLAW_WINDOWS_TASK_NAME).toBe("OpenClaw Gateway");
   });
 });
 

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -30,7 +30,7 @@ type SharedServiceEnvironmentFields = {
   stateDir: string | undefined;
   configPath: string | undefined;
   tmpDir: string;
-  minimalPath: string;
+  minimalPath: string | undefined;
   proxyEnv: Record<string, string | undefined>;
   nodeCaCerts: string | undefined;
   nodeUseSystemCa: string | undefined;
@@ -295,16 +295,19 @@ function buildCommonServiceEnvironment(
   env: Record<string, string | undefined>,
   sharedEnv: SharedServiceEnvironmentFields,
 ): Record<string, string | undefined> {
-  return {
+  const serviceEnv: Record<string, string | undefined> = {
     HOME: env.HOME,
     TMPDIR: sharedEnv.tmpDir,
-    PATH: sharedEnv.minimalPath,
     ...sharedEnv.proxyEnv,
     NODE_EXTRA_CA_CERTS: sharedEnv.nodeCaCerts,
     NODE_USE_SYSTEM_CA: sharedEnv.nodeUseSystemCa,
     REMOTECLAW_STATE_DIR: sharedEnv.stateDir,
     REMOTECLAW_CONFIG_PATH: sharedEnv.configPath,
   };
+  if (sharedEnv.minimalPath) {
+    serviceEnv.PATH = sharedEnv.minimalPath;
+  }
+  return serviceEnv;
 }
 
 function resolveSharedServiceEnvironmentFields(
@@ -326,7 +329,9 @@ function resolveSharedServiceEnvironmentFields(
     stateDir,
     configPath,
     tmpDir,
-    minimalPath: buildMinimalServicePath({ env }),
+    // On Windows, Scheduled Tasks should inherit the current task PATH instead of
+    // freezing the install-time snapshot into gateway.cmd/node-host.cmd.
+    minimalPath: platform === "win32" ? undefined : buildMinimalServicePath({ env, platform }),
     proxyEnv,
     nodeCaCerts,
     nodeUseSystemCa,

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -464,4 +464,20 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.dropAssistant).toHaveBeenCalledWith("run-silent");
     expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
   });
+
+  it("reloads history when a local run ends without a displayable final message", () => {
+    const { state, loadHistory, noteLocalRunId, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-local-silent" },
+    });
+
+    noteLocalRunId("run-local-silent");
+
+    handleChatEvent({
+      runId: "run-local-silent",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+    });
+
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -136,10 +136,16 @@ export function createEventHandlers(context: EventHandlerContext) {
     return sessionRuns.has(activeRunId);
   };
 
-  const maybeRefreshHistoryForRun = (runId: string) => {
-    if (isLocalRunId?.(runId)) {
+  const maybeRefreshHistoryForRun = (
+    runId: string,
+    opts?: { allowLocalWithoutDisplayableFinal?: boolean },
+  ) => {
+    const isLocalRun = isLocalRunId?.(runId) ?? false;
+    if (isLocalRun) {
       forgetLocalRunId?.(runId);
-      return;
+      if (!opts?.allowLocalWithoutDisplayableFinal) {
+        return;
+      }
     }
     if (hasConcurrentActiveRun(runId)) {
       return;
@@ -202,7 +208,9 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (evt.state === "final") {
       const wasActiveRun = state.activeChatRunId === evt.runId;
       if (!evt.message) {
-        maybeRefreshHistoryForRun(evt.runId);
+        maybeRefreshHistoryForRun(evt.runId, {
+          allowLocalWithoutDisplayableFinal: true,
+        });
         chatLog.dropAssistant(evt.runId);
         finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle" });
         tui.requestRender();


### PR DESCRIPTION
Closes #870

## Cherry-picks from upstream

| Hash | Subject | Result |
|------|---------|--------|
| `80a6eb313` | fix(daemon): use locale-invariant schtasks running code detection (#39076) | RESOLVED (CHANGELOG conflict) |
| `e554c59aa` | fix(cron): eliminate double-announce and replace delivery polling with push-based flow (#39089) | RESOLVED (CHANGELOG conflict) |
| `b9dd6e99b` | fix(daemon): avoid freezing Windows PATH in task scripts (#39139) | RESOLVED (CHANGELOG conflict) |
| `eb616b709` | fix(test): normalize darwin runtime hint paths | SKIPPED (file deleted in fork) |
| `4dcd93092` | fix(test): strip windows drive prefix from darwin hints | SKIPPED (file + test deleted in fork) |
| `c934dd51c` | fix(daemon): normalize schtasks runtime from numeric result only (#39153) | RESOLVED (CHANGELOG conflict) |

**4 picked, 2 skipped** (skipped commits only touched `src/daemon/runtime-hints.ts` which was deleted in fork).

All CHANGELOG.md conflicts resolved by keeping fork version (fork doesn't track upstream changelog).

See issue for full commit list and triage details.