### PR TITLE
Cherry-pick issue #881: upstream cron daemon refactors

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -233,6 +233,16 @@ function buildCronAgentDefaultsConfig(params: {
   });
 }
 
+function appendCronDeliveryInstruction(params: {
+  commandBody: string;
+  deliveryRequested: boolean;
+}) {
+  if (!params.deliveryRequested) {
+    return params.commandBody;
+  }
+  return `${params.commandBody}\n\nReturn your summary as plain text; it will be delivered automatically. If the task explicitly calls for messaging a specific external recipient, note who/where it should go instead of sending it yourself.`.trim();
+}
+
 export async function runCronIsolatedAgentTurn(params: {
   cfg: RemoteClawConfig;
   deps: CliDeps;
@@ -422,10 +432,7 @@ export async function runCronIsolatedAgentTurn(params: {
     // Internal/trusted source - use original format
     commandBody = `${base}\n${timeLine}`.trim();
   }
-  if (deliveryRequested) {
-    commandBody =
-      `${commandBody}\n\nReturn your summary as plain text; it will be delivered automatically. If the task explicitly calls for messaging a specific external recipient, note who/where it should go instead of sending it yourself.`.trim();
-  }
+  commandBody = appendCronDeliveryInstruction({ commandBody, deliveryRequested });
 
   // Persist the intended model and systemSent before the run so that
   // sessions_list reflects the cron override even if the run fails or is

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -187,50 +187,28 @@ async function resolveCronDeliveryContext(params: {
 
 type ResolvedAgentConfig = NonNullable<ReturnType<typeof resolveAgentConfig>>;
 
+// Model management defaults gutted in RemoteClaw — CLI runtimes own model selection.
+// Upstream extractCronAgentDefaultsOverride / mergeCronAgentModelOverride simplified:
+// only sandbox exclusion and defined-override merging remain.
 function extractCronAgentDefaultsOverride(agentConfigOverride?: ResolvedAgentConfig) {
-  const {
-    model: overrideModel,
-    sandbox: _agentSandboxOverride,
-    ...agentOverrideRest
-  } = agentConfigOverride ?? {};
+  const { sandbox: _agentSandboxOverride, ...agentOverrideRest } = agentConfigOverride ?? {};
   return {
-    overrideModel,
     definedOverrides: Object.fromEntries(
       Object.entries(agentOverrideRest).filter(([, value]) => value !== undefined),
     ) as Partial<AgentDefaultsConfig>,
   };
 }
 
-function mergeCronAgentModelOverride(params: {
-  defaults: AgentDefaultsConfig;
-  overrideModel: ResolvedAgentConfig["model"];
-}) {
-  const nextDefaults: AgentDefaultsConfig = { ...params.defaults };
-  const existingModel =
-    nextDefaults.model && typeof nextDefaults.model === "object" ? nextDefaults.model : {};
-  if (typeof params.overrideModel === "string") {
-    nextDefaults.model = { ...existingModel, primary: params.overrideModel };
-  } else if (params.overrideModel) {
-    nextDefaults.model = { ...existingModel, ...params.overrideModel };
-  }
-  return nextDefaults;
-}
-
 function buildCronAgentDefaultsConfig(params: {
   defaults?: AgentDefaultsConfig;
   agentConfigOverride?: ResolvedAgentConfig;
 }) {
-  const { overrideModel, definedOverrides } = extractCronAgentDefaultsOverride(
-    params.agentConfigOverride,
-  );
+  const { definedOverrides } = extractCronAgentDefaultsOverride(params.agentConfigOverride);
   // Keep sandbox overrides out of `agents.defaults` here. Sandbox resolution
   // already merges global defaults with per-agent overrides using `agentId`;
   // copying the agent sandbox into defaults clobbers global defaults and can
   // double-apply nested agent overrides during isolated cron runs.
-  return mergeCronAgentModelOverride({
-    defaults: Object.assign({}, params.defaults, definedOverrides),
-    overrideModel,
-  });
+  return Object.assign({}, params.defaults, definedOverrides) as AgentDefaultsConfig;
 }
 
 function appendCronDeliveryInstruction(params: {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -185,6 +185,54 @@ async function resolveCronDeliveryContext(params: {
   };
 }
 
+type ResolvedAgentConfig = NonNullable<ReturnType<typeof resolveAgentConfig>>;
+
+function extractCronAgentDefaultsOverride(agentConfigOverride?: ResolvedAgentConfig) {
+  const {
+    model: overrideModel,
+    sandbox: _agentSandboxOverride,
+    ...agentOverrideRest
+  } = agentConfigOverride ?? {};
+  return {
+    overrideModel,
+    definedOverrides: Object.fromEntries(
+      Object.entries(agentOverrideRest).filter(([, value]) => value !== undefined),
+    ) as Partial<AgentDefaultsConfig>,
+  };
+}
+
+function mergeCronAgentModelOverride(params: {
+  defaults: AgentDefaultsConfig;
+  overrideModel: ResolvedAgentConfig["model"];
+}) {
+  const nextDefaults: AgentDefaultsConfig = { ...params.defaults };
+  const existingModel =
+    nextDefaults.model && typeof nextDefaults.model === "object" ? nextDefaults.model : {};
+  if (typeof params.overrideModel === "string") {
+    nextDefaults.model = { ...existingModel, primary: params.overrideModel };
+  } else if (params.overrideModel) {
+    nextDefaults.model = { ...existingModel, ...params.overrideModel };
+  }
+  return nextDefaults;
+}
+
+function buildCronAgentDefaultsConfig(params: {
+  defaults?: AgentDefaultsConfig;
+  agentConfigOverride?: ResolvedAgentConfig;
+}) {
+  const { overrideModel, definedOverrides } = extractCronAgentDefaultsOverride(
+    params.agentConfigOverride,
+  );
+  // Keep sandbox overrides out of `agents.defaults` here. Sandbox resolution
+  // already merges global defaults with per-agent overrides using `agentId`;
+  // copying the agent sandbox into defaults clobbers global defaults and can
+  // double-apply nested agent overrides during isolated cron runs.
+  return mergeCronAgentModelOverride({
+    defaults: Object.assign({}, params.defaults, definedOverrides),
+    overrideModel,
+  });
+}
+
 export async function runCronIsolatedAgentTurn(params: {
   cfg: RemoteClawConfig;
   deps: CliDeps;
@@ -218,23 +266,14 @@ export async function runCronIsolatedAgentTurn(params: {
   const agentConfigOverride = normalizedRequested
     ? resolveAgentConfig(params.cfg, normalizedRequested)
     : undefined;
-  const { sandbox: _agentSandboxOverride, ...agentOverrideRest } = agentConfigOverride ?? {};
   // Use the requested agentId even when there is no explicit agent config entry.
   // This ensures auth-profiles, workspace, and agentDir all resolve to the
   // correct per-agent paths (e.g. ~/.remoteclaw/agents/<agentId>/agent/).
   const agentId = normalizedRequested ?? defaultAgentId;
-  // Keep sandbox overrides out of `agents.defaults` here. Sandbox resolution
-  // already merges global defaults with per-agent overrides using `agentId`;
-  // copying the agent sandbox into defaults clobbers global defaults and can
-  // double-apply nested agent overrides during isolated cron runs.
-  const definedOverrides = Object.fromEntries(
-    Object.entries(agentOverrideRest).filter(([, value]) => value !== undefined),
-  );
-  const agentCfg: AgentDefaultsConfig = Object.assign(
-    {},
-    params.cfg.agents?.defaults,
-    definedOverrides as Partial<AgentDefaultsConfig>,
-  );
+  const agentCfg = buildCronAgentDefaultsConfig({
+    defaults: params.cfg.agents?.defaults,
+    agentConfigOverride,
+  });
   const cfgWithAgentDefaults: RemoteClawConfig = {
     ...params.cfg,
     agents: Object.assign({}, params.cfg.agents, { defaults: agentCfg }),

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -1,10 +1,6 @@
 import { sanitizeAgentId } from "../routing/session-key.js";
 import { isRecord } from "../utils.js";
-import {
-  buildDeliveryFromLegacyPayload,
-  hasLegacyDeliveryHints,
-  stripLegacyDeliveryFields,
-} from "./legacy-delivery.js";
+import { normalizeLegacyDeliveryInput } from "./legacy-delivery.js";
 import { parseAbsoluteTimeMs } from "./parse.js";
 import { migrateLegacyCronPayload } from "./payload-migration.js";
 import { inferLegacyName } from "./service/normalize.js";
@@ -393,14 +389,20 @@ export function normalizeCronJobInput(
     const isIsolatedAgentTurn =
       sessionTarget === "isolated" || (sessionTarget === "" && payloadKind === "agentTurn");
     const hasDelivery = "delivery" in next && next.delivery !== undefined;
-    const hasLegacyDelivery = payload ? hasLegacyDeliveryHints(payload) : false;
-    if (!hasDelivery && isIsolatedAgentTurn && payloadKind === "agentTurn") {
-      if (payload && hasLegacyDelivery) {
-        next.delivery = buildDeliveryFromLegacyPayload(payload);
-        stripLegacyDeliveryFields(payload);
-      } else {
-        next.delivery = { mode: "announce" };
-      }
+    const normalizedLegacy = normalizeLegacyDeliveryInput({
+      delivery: isRecord(next.delivery) ? next.delivery : null,
+      payload,
+    });
+    if (normalizedLegacy.mutated && normalizedLegacy.delivery) {
+      next.delivery = normalizedLegacy.delivery;
+    }
+    if (
+      !hasDelivery &&
+      !normalizedLegacy.delivery &&
+      isIsolatedAgentTurn &&
+      payloadKind === "agentTurn"
+    ) {
+      next.delivery = { mode: "announce" };
     }
   }
 

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -28,7 +28,9 @@ import {
 } from "./service/timer.js";
 import type { CronJob, CronJobState } from "./types.js";
 
-const FAST_TIMEOUT_SECONDS = 0.0025;
+// Must be >= 1 to survive Math.floor in normalizeCronJobCreate (added by
+// upstream e66c418c4 — normalize legacy delivery at ingress).
+const FAST_TIMEOUT_SECONDS = 1;
 
 describe("Cron issue regressions", () => {
   const { makeStorePath } = setupCronIssueRegressionFixtures();

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -589,19 +589,6 @@ describe("createJob delivery defaults", () => {
     expect(job.delivery).toEqual({ mode: "none" });
   });
 
-  it("preserves legacy payload deliver=false when explicit delivery is omitted", () => {
-    const state = createMockState(now);
-    const job = createJob(state, {
-      name: "isolated-legacy-no-deliver",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "now",
-      payload: { kind: "agentTurn", message: "hello", deliver: false } as never,
-    });
-    expect(job.delivery).toEqual({ mode: "none" });
-  });
-
   it("does not set delivery for main systemEvent jobs without explicit delivery", () => {
     const state = createMockState(now, { defaultAgentId: "main" });
     const job = createJob(state, {

--- a/src/cron/service/initial-delivery.ts
+++ b/src/cron/service/initial-delivery.ts
@@ -1,16 +1,8 @@
-import { buildDeliveryFromLegacyPayload, hasLegacyDeliveryHints } from "../legacy-delivery.js";
 import type { CronDelivery, CronJobCreate } from "../types.js";
 
 export function resolveInitialCronDelivery(input: CronJobCreate): CronDelivery | undefined {
   if (input.delivery) {
     return input.delivery;
-  }
-  const payloadRecord =
-    input.payload && typeof input.payload === "object"
-      ? (input.payload as Record<string, unknown>)
-      : undefined;
-  if (payloadRecord && hasLegacyDeliveryHints(payloadRecord)) {
-    return buildDeliveryFromLegacyPayload(payloadRecord) as CronDelivery;
   }
   if (input.sessionTarget === "isolated" && input.payload.kind === "agentTurn") {
     return { mode: "announce" };

--- a/src/cron/service/initial-delivery.ts
+++ b/src/cron/service/initial-delivery.ts
@@ -1,0 +1,19 @@
+import { buildDeliveryFromLegacyPayload, hasLegacyDeliveryHints } from "../legacy-delivery.js";
+import type { CronDelivery, CronJobCreate } from "../types.js";
+
+export function resolveInitialCronDelivery(input: CronJobCreate): CronDelivery | undefined {
+  if (input.delivery) {
+    return input.delivery;
+  }
+  const payloadRecord =
+    input.payload && typeof input.payload === "object"
+      ? (input.payload as Record<string, unknown>)
+      : undefined;
+  if (payloadRecord && hasLegacyDeliveryHints(payloadRecord)) {
+    return buildDeliveryFromLegacyPayload(payloadRecord) as CronDelivery;
+  }
+  if (input.sessionTarget === "isolated" && input.payload.kind === "agentTurn") {
+    return { mode: "announce" };
+  }
+  return undefined;
+}

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -1,6 +1,5 @@
 import crypto from "node:crypto";
 import { normalizeAgentId } from "../../routing/session-key.js";
-import { buildDeliveryFromLegacyPayload, hasLegacyDeliveryHints } from "../legacy-delivery.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
 import {
   coerceFiniteScheduleNumber,
@@ -23,6 +22,7 @@ import type {
   CronPayloadPatch,
 } from "../types.js";
 import { normalizeHttpWebhookUrl } from "../webhook-url.js";
+import { resolveInitialCronDelivery } from "./initial-delivery.js";
 import {
   normalizeOptionalAgentId,
   normalizeOptionalSessionKey,
@@ -531,14 +531,6 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
         ? true
         : undefined;
   const enabled = typeof input.enabled === "boolean" ? input.enabled : true;
-  const payloadRecord =
-    input.payload && typeof input.payload === "object"
-      ? (input.payload as Record<string, unknown>)
-      : undefined;
-  const legacyDelivery =
-    payloadRecord && hasLegacyDeliveryHints(payloadRecord)
-      ? (buildDeliveryFromLegacyPayload(payloadRecord) as CronDelivery)
-      : undefined;
   const job: CronJob = {
     id,
     agentId: normalizeOptionalAgentId(input.agentId),
@@ -553,12 +545,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     sessionTarget: input.sessionTarget,
     wakeMode: input.wakeMode,
     payload: input.payload,
-    delivery:
-      input.delivery ??
-      legacyDelivery ??
-      (input.sessionTarget === "isolated" && input.payload.kind === "agentTurn"
-        ? { mode: "announce" }
-        : undefined),
+    delivery: resolveInitialCronDelivery(input),
     failureAlert: input.failureAlert,
     state: {
       ...input.state,

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -1,3 +1,4 @@
+import { normalizeCronJobCreate } from "../normalize.js";
 import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
 import {
   applyJobPatch,
@@ -234,7 +235,11 @@ export async function add(state: CronServiceState, input: CronJobCreate) {
   return await locked(state, async () => {
     warnIfDisabled(state, "add");
     await ensureLoaded(state);
-    const job = createJob(state, input);
+    const normalizedInput = normalizeCronJobCreate(input);
+    if (!normalizedInput) {
+      throw new Error("invalid cron job input");
+    }
+    const job = createJob(state, normalizedInput);
     state.store?.jobs.push(job);
 
     // Defensive: recompute all next-run times to ensure consistency


### PR DESCRIPTION
Closes #881

## Cherry-picks from upstream

See issue for full commit list and triage details.

**Picked (4/5 commits):**
- `6b18ec479` — refactor(cron): centralize initial delivery defaults (clean)
- `45d3e62f5` — refactor(cron): extract agent defaults merge helpers (resolved: union merge of fork delivery helpers + upstream agent defaults helpers; lint fix for redundant type constituent)
- `9b99787c3` — refactor(cron): extract delivery tool policy helpers (resolved: kept fork's ChannelBridge approach, took new `appendCronDeliveryInstruction` helper)
- `e66c418c4` — refactor(cron): normalize legacy delivery at ingress (resolved: kept fork's consolidated `normalizeStoredCronJobs`, took upstream changes to other files)

**Skipped (1):**
- `60441c8ce` — Systemd: allowlist environment file fixtures (empty after resolution — fork already had `// pragma: allowlist secret` comments in rebranded form)