### PR TITLE
Cherry-pick bda035768: fix(plugins): fall back to src plugin-sdk aliases

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -924,7 +924,7 @@ describe("loadRemoteClawPlugins", () => {
     });
 
     const record = registry.plugins.find((entry) => entry.id === "legacy-root-import");
-    expect(record?.status).toBe("loaded");
+    expect({ status: record?.status, error: record?.error }).toMatchObject({ status: "loaded" });
   });
 
   it("prefers dist plugin-sdk alias when loader runs from dist", () => {
@@ -942,6 +942,20 @@ describe("loadRemoteClawPlugins", () => {
     const { root, srcFile } = createPluginSdkAliasFixture();
 
     const resolved = withEnv({ NODE_ENV: undefined }, () =>
+      __testing.resolvePluginSdkAliasFile({
+        srcFile: "index.ts",
+        distFile: "index.js",
+        modulePath: path.join(root, "src", "plugins", "loader.ts"),
+      }),
+    );
+    expect(resolved).toBe(srcFile);
+  });
+
+  it("falls back to src plugin-sdk alias when dist is missing in production", () => {
+    const { root, srcFile, distFile } = createPluginSdkAliasFixture();
+    fs.rmSync(distFile);
+
+    const resolved = withEnv({ NODE_ENV: "production", VITEST: undefined }, () =>
       __testing.resolvePluginSdkAliasFile({
         srcFile: "index.ts",
         distFile: "index.js",

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -53,19 +53,15 @@ const resolvePluginSdkAliasFile = (params: {
   try {
     const modulePath = params.modulePath ?? fileURLToPath(import.meta.url);
     const isProduction = process.env.NODE_ENV === "production";
-    const isTest = process.env.VITEST || process.env.NODE_ENV === "test";
     const normalizedModulePath = modulePath.replace(/\\/g, "/");
     const isDistRuntime = normalizedModulePath.includes("/dist/");
     let cursor = path.dirname(modulePath);
     for (let i = 0; i < 6; i += 1) {
       const srcCandidate = path.join(cursor, "src", "plugin-sdk", params.srcFile);
       const distCandidate = path.join(cursor, "dist", "plugin-sdk", params.distFile);
-      const orderedCandidates = isDistRuntime
-        ? [distCandidate, srcCandidate]
-        : isProduction
-          ? isTest
-            ? [distCandidate, srcCandidate]
-            : [distCandidate]
+      const orderedCandidates =
+        isDistRuntime || isProduction
+          ? [distCandidate, srcCandidate]
           : [srcCandidate, distCandidate];
       for (const candidate of orderedCandidates) {
         if (fs.existsSync(candidate)) {


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@bda035768f.

**fix(plugins): fall back to src plugin-sdk aliases**

Simplifies the plugin-sdk alias candidate resolution: when the dist candidate is missing, the loader now falls back to the src candidate regardless of runtime context. Removes the production-vs-test branching that previously prevented the fallback. Adds a dedicated test for the production fallback path.

**Conflict resolution**: `loader.test.ts` header — kept our refactored `importFreshPluginTestModules()` pattern (already incorporates the dynamic import and `vi.unmock("jiti")` from this commit). No upstream naming leaks.

<!-- upstream-issue: 885 -->