### PR TITLE
Cherry-pick issue #893: upstream discord, sessions, gemini fixes

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -2175,7 +2175,7 @@ Yes. RemoteClaw ships a few default shorthands (only applied when the model exis
 - `sonnet` → `anthropic/claude-sonnet-4-6`
 - `gpt` → `openai/gpt-5.4`
 - `gpt-mini` → `openai/gpt-5-mini`
-- `gemini` → `google/gemini-3-pro-preview`
+- `gemini` → `google/gemini-3.1-pro-preview`
 - `gemini-flash` → `google/gemini-3-flash-preview`
 - `gemini-flash-lite` → `google/gemini-3.1-flash-lite-preview`
 

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -277,13 +277,13 @@ This is the “common models” run we expect to keep working:
 - OpenAI (non-Codex): `openai/gpt-5.2` (optional: `openai/gpt-5.1`)
 - OpenAI Codex: `openai-codex/gpt-5.4`
 - Anthropic: `anthropic/claude-opus-4-6` (or `anthropic/claude-sonnet-4-5`)
-- Google (Gemini API): `google/gemini-3-pro-preview` and `google/gemini-3-flash-preview` (avoid older Gemini 2.x models)
+- Google (Gemini API): `google/gemini-3.1-pro-preview` and `google/gemini-3-flash-preview` (avoid older Gemini 2.x models)
 - Google (Antigravity): `google-antigravity/claude-opus-4-6-thinking` and `google-antigravity/gemini-3-flash`
 - Z.AI (GLM): `zai/glm-4.7`
 - MiniMax: `minimax/minimax-m2.1`
 
 Run gateway smoke with tools + image:
-`REMOTECLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.2,openai-codex/gpt-5.4,anthropic/claude-opus-4-6,google/gemini-3-pro-preview,google/gemini-3-flash-preview,google-antigravity/claude-opus-4-6-thinking,google-antigravity/gemini-3-flash,zai/glm-4.7,minimax/minimax-m2.1" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
+`REMOTECLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.2,openai-codex/gpt-5.4,anthropic/claude-opus-4-6,google/gemini-3.1-pro-preview,google/gemini-3-flash-preview,google-antigravity/claude-opus-4-6-thinking,google-antigravity/gemini-3-flash,zai/glm-4.7,minimax/minimax-m2.1" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
 
 ### Baseline: tool calling (Read + optional Exec)
 
@@ -291,7 +291,7 @@ Pick at least one per provider family:
 
 - OpenAI: `openai/gpt-5.2` (or `openai/gpt-5-mini`)
 - Anthropic: `anthropic/claude-opus-4-6` (or `anthropic/claude-sonnet-4-5`)
-- Google: `google/gemini-3-flash-preview` (or `google/gemini-3-pro-preview`)
+- Google: `google/gemini-3-flash-preview` (or `google/gemini-3.1-pro-preview`)
 - Z.AI (GLM): `zai/glm-4.7`
 - MiniMax: `minimax/minimax-m2.1`
 

--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -333,7 +333,7 @@ When `mode: "all"`, outputs are labeled `[Image 1/2]`, `[Audio 2/2]`, etc.
         models: [
           {
             provider: "google",
-            model: "gemini-3-pro-preview",
+            model: "gemini-3.1-pro-preview",
             capabilities: ["image", "video", "audio"],
           },
         ],
@@ -342,7 +342,7 @@ When `mode: "all"`, outputs are labeled `[Image 1/2]`, `[Audio 2/2]`, etc.
         models: [
           {
             provider: "google",
-            model: "gemini-3-pro-preview",
+            model: "gemini-3.1-pro-preview",
             capabilities: ["image", "video", "audio"],
           },
         ],
@@ -351,7 +351,7 @@ When `mode: "all"`, outputs are labeled `[Image 1/2]`, `[Audio 2/2]`, etc.
         models: [
           {
             provider: "google",
-            model: "gemini-3-pro-preview",
+            model: "gemini-3.1-pro-preview",
             capabilities: ["image", "video", "audio"],
           },
         ],

--- a/src/config/config.discord-agent-components.test.ts
+++ b/src/config/config.discord-agent-components.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+describe("discord agentComponents config", () => {
+  it("accepts channels.discord.agentComponents.enabled", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          agentComponents: {
+            enabled: true,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts channels.discord.accounts.<id>.agentComponents.enabled", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          accounts: {
+            work: {
+              agentComponents: {
+                enabled: false,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects unknown fields under channels.discord.agentComponents", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          agentComponents: {
+            enabled: true,
+            invalidField: true,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(
+        res.issues.some(
+          (issue) =>
+            issue.path === "channels.discord.agentComponents" &&
+            issue.message.toLowerCase().includes("unrecognized"),
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -25,7 +25,7 @@ const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
 
   // Google Gemini (3.x are preview ids in the catalog)
   gemini: "google/gemini-3.1-pro-preview",
-  "gemini-flash": "google/gemini-3.1-flash-preview",
+  "gemini-flash": "google/gemini-3-flash-preview",
   "gemini-flash-lite": "google/gemini-3.1-flash-lite-preview",
 };
 

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -42,7 +42,7 @@ describe("applyModelDefaults", () => {
         defaults: {
           models: {
             "google/gemini-3.1-pro-preview": { alias: "" },
-            "google/gemini-3.1-flash-preview": {},
+            "google/gemini-3-flash-preview": {},
             "google/gemini-3.1-flash-lite-preview": {},
           },
         },
@@ -52,7 +52,7 @@ describe("applyModelDefaults", () => {
     const next = applyModelDefaults(cfg);
 
     expect(next.agents?.defaults?.models?.["google/gemini-3.1-pro-preview"]?.alias).toBe("");
-    expect(next.agents?.defaults?.models?.["google/gemini-3.1-flash-preview"]?.alias).toBe(
+    expect(next.agents?.defaults?.models?.["google/gemini-3-flash-preview"]?.alias).toBe(
       "gemini-flash",
     );
     expect(next.agents?.defaults?.models?.["google/gemini-3.1-flash-lite-preview"]?.alias).toBe(

--- a/src/config/sessions/explicit-session-key-normalization.test.ts
+++ b/src/config/sessions/explicit-session-key-normalization.test.ts
@@ -39,6 +39,19 @@ describe("normalizeExplicitSessionKey", () => {
     ).toBe("discord:direct:123456");
   });
 
+  it("uses Provider when Surface is absent", () => {
+    expect(
+      normalizeExplicitSessionKey(
+        "agent:fina:discord:dm:123456",
+        makeCtx({
+          Provider: "Discord",
+          ChatType: "direct",
+          SenderId: "123456",
+        }),
+      ),
+    ).toBe("agent:fina:discord:direct:123456");
+  });
+
   it("lowercases and passes through unknown providers unchanged", () => {
     expect(
       normalizeExplicitSessionKey(

--- a/src/config/sessions/explicit-session-key-normalization.test.ts
+++ b/src/config/sessions/explicit-session-key-normalization.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { MsgContext } from "../../auto-reply/templating.js";
+import { normalizeExplicitSessionKey } from "./explicit-session-key-normalization.js";
+
+function makeCtx(overrides: Partial<MsgContext>): MsgContext {
+  return {
+    Body: "",
+    From: "",
+    To: "",
+    ...overrides,
+  } as MsgContext;
+}
+
+describe("normalizeExplicitSessionKey", () => {
+  it("dispatches discord keys through the provider normalizer", () => {
+    expect(
+      normalizeExplicitSessionKey(
+        "agent:fina:discord:channel:123456",
+        makeCtx({
+          Surface: "discord",
+          ChatType: "direct",
+          From: "discord:123456",
+          SenderId: "123456",
+        }),
+      ),
+    ).toBe("agent:fina:discord:direct:123456");
+  });
+
+  it("infers the provider from From when explicit provider fields are absent", () => {
+    expect(
+      normalizeExplicitSessionKey(
+        "discord:dm:123456",
+        makeCtx({
+          ChatType: "direct",
+          From: "discord:123456",
+          SenderId: "123456",
+        }),
+      ),
+    ).toBe("discord:direct:123456");
+  });
+
+  it("lowercases and passes through unknown providers unchanged", () => {
+    expect(
+      normalizeExplicitSessionKey(
+        "Agent:Fina:Slack:DM:ABC",
+        makeCtx({
+          Surface: "slack",
+          From: "slack:U123",
+        }),
+      ),
+    ).toBe("agent:fina:slack:dm:abc");
+  });
+});

--- a/src/config/sessions/explicit-session-key-normalization.ts
+++ b/src/config/sessions/explicit-session-key-normalization.ts
@@ -1,0 +1,35 @@
+import type { MsgContext } from "../../auto-reply/templating.js";
+import { normalizeExplicitDiscordSessionKey } from "../../discord/session-key-normalization.js";
+
+type ExplicitSessionKeyNormalizer = (sessionKey: string, ctx: MsgContext) => string;
+
+const EXPLICIT_SESSION_KEY_NORMALIZERS: Record<string, ExplicitSessionKeyNormalizer> = {
+  discord: normalizeExplicitDiscordSessionKey,
+};
+
+function resolveExplicitSessionKeyProvider(
+  sessionKey: string,
+  ctx: Pick<MsgContext, "From" | "Provider" | "Surface">,
+): string | undefined {
+  const explicitProvider = [ctx.Surface, ctx.Provider]
+    .map((entry) => entry?.trim().toLowerCase())
+    .find((entry) => entry && entry in EXPLICIT_SESSION_KEY_NORMALIZERS);
+  if (explicitProvider) {
+    return explicitProvider;
+  }
+
+  const from = (ctx.From ?? "").trim().toLowerCase();
+  if (from.startsWith("discord:")) {
+    return "discord";
+  }
+  if (sessionKey.startsWith("discord:") || sessionKey.includes(":discord:")) {
+    return "discord";
+  }
+  return undefined;
+}
+
+export function normalizeExplicitSessionKey(sessionKey: string, ctx: MsgContext): string {
+  const normalized = sessionKey.trim().toLowerCase();
+  const provider = resolveExplicitSessionKeyProvider(normalized, ctx);
+  return provider ? EXPLICIT_SESSION_KEY_NORMALIZERS[provider](normalized, ctx) : normalized;
+}

--- a/src/config/sessions/explicit-session-key-normalization.ts
+++ b/src/config/sessions/explicit-session-key-normalization.ts
@@ -2,34 +2,49 @@ import type { MsgContext } from "../../auto-reply/templating.js";
 import { normalizeExplicitDiscordSessionKey } from "../../discord/session-key-normalization.js";
 
 type ExplicitSessionKeyNormalizer = (sessionKey: string, ctx: MsgContext) => string;
-
-const EXPLICIT_SESSION_KEY_NORMALIZERS: Record<string, ExplicitSessionKeyNormalizer> = {
-  discord: normalizeExplicitDiscordSessionKey,
+type ExplicitSessionKeyNormalizerEntry = {
+  provider: string;
+  normalize: ExplicitSessionKeyNormalizer;
+  matches: (params: {
+    sessionKey: string;
+    provider?: string;
+    surface?: string;
+    from: string;
+  }) => boolean;
 };
 
-function resolveExplicitSessionKeyProvider(
+const EXPLICIT_SESSION_KEY_NORMALIZERS: ExplicitSessionKeyNormalizerEntry[] = [
+  {
+    provider: "discord",
+    normalize: normalizeExplicitDiscordSessionKey,
+    matches: ({ sessionKey, provider, surface, from }) =>
+      surface === "discord" ||
+      provider === "discord" ||
+      from.startsWith("discord:") ||
+      sessionKey.startsWith("discord:") ||
+      sessionKey.includes(":discord:"),
+  },
+];
+
+function resolveExplicitSessionKeyNormalizer(
   sessionKey: string,
   ctx: Pick<MsgContext, "From" | "Provider" | "Surface">,
-): string | undefined {
-  const explicitProvider = [ctx.Surface, ctx.Provider]
-    .map((entry) => entry?.trim().toLowerCase())
-    .find((entry) => entry && entry in EXPLICIT_SESSION_KEY_NORMALIZERS);
-  if (explicitProvider) {
-    return explicitProvider;
-  }
-
-  const from = (ctx.From ?? "").trim().toLowerCase();
-  if (from.startsWith("discord:")) {
-    return "discord";
-  }
-  if (sessionKey.startsWith("discord:") || sessionKey.includes(":discord:")) {
-    return "discord";
-  }
-  return undefined;
+): ExplicitSessionKeyNormalizer | undefined {
+  const normalizedProvider = ctx.Provider?.trim().toLowerCase();
+  const normalizedSurface = ctx.Surface?.trim().toLowerCase();
+  const normalizedFrom = (ctx.From ?? "").trim().toLowerCase();
+  return EXPLICIT_SESSION_KEY_NORMALIZERS.find((entry) =>
+    entry.matches({
+      sessionKey,
+      provider: normalizedProvider,
+      surface: normalizedSurface,
+      from: normalizedFrom,
+    }),
+  )?.normalize;
 }
 
 export function normalizeExplicitSessionKey(sessionKey: string, ctx: MsgContext): string {
   const normalized = sessionKey.trim().toLowerCase();
-  const provider = resolveExplicitSessionKeyProvider(normalized, ctx);
-  return provider ? EXPLICIT_SESSION_KEY_NORMALIZERS[provider](normalized, ctx) : normalized;
+  const normalize = resolveExplicitSessionKeyNormalizer(normalized, ctx);
+  return normalize ? normalize(normalized, ctx) : normalized;
 }

--- a/src/config/sessions/session-key.ts
+++ b/src/config/sessions/session-key.ts
@@ -1,5 +1,5 @@
 import type { MsgContext } from "../../auto-reply/templating.js";
-import { normalizeChatType } from "../../channels/chat-type.js";
+import { normalizeExplicitDiscordSessionKey } from "../../discord/session-key-normalization.js";
 import {
   buildAgentMainSessionKey,
   DEFAULT_AGENT_ID,
@@ -29,24 +29,7 @@ export function deriveSessionKey(scope: SessionScope, ctx: MsgContext) {
 export function resolveSessionKey(scope: SessionScope, ctx: MsgContext, mainKey?: string) {
   const explicit = ctx.SessionKey?.trim();
   if (explicit) {
-    let normalized = explicit.toLowerCase();
-    if (normalizeChatType(ctx.ChatType) === "direct") {
-      normalized = normalized.replace(/^(agent:[^:]+:discord:)dm:/, "$1direct:");
-      const match = normalized.match(/^((?:agent:[^:]+:)?)discord:channel:([^:]+)$/);
-      if (match) {
-        const from = (ctx.From ?? "").trim().toLowerCase();
-        const senderId = (ctx.SenderId ?? "").trim().toLowerCase();
-        const fromDiscordId =
-          from.startsWith("discord:") && !from.includes(":channel:") && !from.includes(":group:")
-            ? from.slice("discord:".length)
-            : "";
-        const directId = senderId || fromDiscordId;
-        if (directId && directId === match[2]) {
-          normalized = `${match[1]}discord:direct:${match[2]}`;
-        }
-      }
-    }
-    return normalized;
+    return normalizeExplicitDiscordSessionKey(explicit, ctx);
   }
   const raw = deriveSessionKey(scope, ctx);
   if (scope === "global") {

--- a/src/config/sessions/session-key.ts
+++ b/src/config/sessions/session-key.ts
@@ -1,11 +1,11 @@
 import type { MsgContext } from "../../auto-reply/templating.js";
-import { normalizeExplicitDiscordSessionKey } from "../../discord/session-key-normalization.js";
 import {
   buildAgentMainSessionKey,
   DEFAULT_AGENT_ID,
   normalizeMainKey,
 } from "../../routing/session-key.js";
 import { normalizeE164 } from "../../utils.js";
+import { normalizeExplicitSessionKey } from "./explicit-session-key-normalization.js";
 import { resolveGroupSessionKey } from "./group.js";
 import type { SessionScope } from "./types.js";
 
@@ -29,7 +29,7 @@ export function deriveSessionKey(scope: SessionScope, ctx: MsgContext) {
 export function resolveSessionKey(scope: SessionScope, ctx: MsgContext, mainKey?: string) {
   const explicit = ctx.SessionKey?.trim();
   if (explicit) {
-    return normalizeExplicitDiscordSessionKey(explicit, ctx);
+    return normalizeExplicitSessionKey(explicit, ctx);
   }
   const raw = deriveSessionKey(scope, ctx);
   if (scope === "global") {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -494,6 +494,12 @@ export const DiscordAccountSchema = z
       })
       .strict()
       .optional(),
+    agentComponents: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     ui: DiscordUiSchema,
     slashCommand: z
       .object({

--- a/src/discord/session-key-normalization.test.ts
+++ b/src/discord/session-key-normalization.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from "vitest";
 import { normalizeExplicitDiscordSessionKey } from "./session-key-normalization.js";
 
 describe("normalizeExplicitDiscordSessionKey", () => {
+  it("rewrites bare discord:dm keys for direct chats", () => {
+    expect(
+      normalizeExplicitDiscordSessionKey("discord:dm:123456", {
+        ChatType: "direct",
+        From: "discord:123456",
+        SenderId: "123456",
+      }),
+    ).toBe("discord:direct:123456");
+  });
+
   it("rewrites legacy discord:dm keys for direct chats", () => {
     expect(
       normalizeExplicitDiscordSessionKey("agent:fina:discord:dm:123456", {

--- a/src/discord/session-key-normalization.test.ts
+++ b/src/discord/session-key-normalization.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { normalizeExplicitDiscordSessionKey } from "./session-key-normalization.js";
+
+describe("normalizeExplicitDiscordSessionKey", () => {
+  it("rewrites legacy discord:dm keys for direct chats", () => {
+    expect(
+      normalizeExplicitDiscordSessionKey("agent:fina:discord:dm:123456", {
+        ChatType: "direct",
+        From: "discord:123456",
+        SenderId: "123456",
+      }),
+    ).toBe("agent:fina:discord:direct:123456");
+  });
+
+  it("rewrites phantom discord:channel keys when sender matches", () => {
+    expect(
+      normalizeExplicitDiscordSessionKey("discord:channel:123456", {
+        ChatType: "direct",
+        From: "discord:123456",
+        SenderId: "123456",
+      }),
+    ).toBe("discord:direct:123456");
+  });
+
+  it("leaves non-direct channel keys unchanged", () => {
+    expect(
+      normalizeExplicitDiscordSessionKey("agent:fina:discord:channel:123456", {
+        ChatType: "channel",
+        From: "discord:channel:123456",
+        SenderId: "789",
+      }),
+    ).toBe("agent:fina:discord:channel:123456");
+  });
+});

--- a/src/discord/session-key-normalization.ts
+++ b/src/discord/session-key-normalization.ts
@@ -10,6 +10,7 @@ export function normalizeExplicitDiscordSessionKey(
     return normalized;
   }
 
+  normalized = normalized.replace(/^(discord:)dm:/, "$1direct:");
   normalized = normalized.replace(/^(agent:[^:]+:discord:)dm:/, "$1direct:");
   const match = normalized.match(/^((?:agent:[^:]+:)?)discord:channel:([^:]+)$/);
   if (!match) {

--- a/src/discord/session-key-normalization.ts
+++ b/src/discord/session-key-normalization.ts
@@ -1,0 +1,27 @@
+import type { MsgContext } from "../auto-reply/templating.js";
+import { normalizeChatType } from "../channels/chat-type.js";
+
+export function normalizeExplicitDiscordSessionKey(
+  sessionKey: string,
+  ctx: Pick<MsgContext, "ChatType" | "From" | "SenderId">,
+): string {
+  let normalized = sessionKey.trim().toLowerCase();
+  if (normalizeChatType(ctx.ChatType) !== "direct") {
+    return normalized;
+  }
+
+  normalized = normalized.replace(/^(agent:[^:]+:discord:)dm:/, "$1direct:");
+  const match = normalized.match(/^((?:agent:[^:]+:)?)discord:channel:([^:]+)$/);
+  if (!match) {
+    return normalized;
+  }
+
+  const from = (ctx.From ?? "").trim().toLowerCase();
+  const senderId = (ctx.SenderId ?? "").trim().toLowerCase();
+  const fromDiscordId =
+    from.startsWith("discord:") && !from.includes(":channel:") && !from.includes(":group:")
+      ? from.slice("discord:".length)
+      : "";
+  const directId = senderId || fromDiscordId;
+  return directId && directId === match[2] ? `${match[1]}discord:direct:${match[2]}` : normalized;
+}


### PR DESCRIPTION
## Summary
- Cherry-pick 5 upstream commits: discord session key normalization, provider key normalizers, provider normalizer simplification, gemini flash model ID fix, discord agentComponents validation
- AUTO-PARTIAL on `100da9f45c`: discarded gutted files (`models-config.providers.ts`, `models-config.providers.google-antigravity.test.ts`, `docs/concepts/model-providers.md`)
- Resolved merge conflicts preserving fork additions (gemini-flash-lite alias, REMOTECLAW env vars, minimax-m2.1)

## Commits
| Hash | Subject | Result |
|------|---------|--------|
| `74e3c071b` | refactor(discord): extract session key normalization | PICKED |
| `ad7399b6e` | refactor(sessions): add provider key normalizers | PICKED |
| `8cc477b87` | refactor(sessions): simplify provider normalizer matching | PICKED |
| `100da9f45` | fix: correct gemini flash model id | RESOLVED |
| `d902bae55` | fix(discord): validate agentComponents config | PICKED |

Closes #893