### PR TITLE
Cherry-pick 44e7c1142: refactor(doctor): model legacy file copies as plans

### DIFF
--- a/src/commands/doctor.e2e-harness.ts
+++ b/src/commands/doctor.e2e-harness.ts
@@ -140,9 +140,8 @@ function createLegacyStateMigrationDetectionResult(params?: {
       hasLegacy: false,
     },
     pairingAllowFrom: {
-      legacyTelegramPath: "",
-      targetTelegramPath: "",
       hasLegacyTelegram: false,
+      copyPlans: [],
     },
     preview: params?.preview ?? [],
   };

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -26,11 +26,16 @@ export type LegacyStateDetection = {
     hasLegacy: boolean;
   };
   pairingAllowFrom: {
-    legacyTelegramPath: string;
-    targetTelegramPath: string;
     hasLegacyTelegram: boolean;
+    copyPlans: FileCopyPlan[];
   };
   preview: string[];
+};
+
+type FileCopyPlan = {
+  label: string;
+  sourcePath: string;
+  targetPath: string;
 };
 
 const EMPTY_RESULT = {
@@ -56,7 +61,7 @@ const EMPTY_DETECTION: LegacyStateDetection = {
   },
   agentDir: { legacyDir: "", targetDir: "", hasLegacy: false },
   whatsappAuth: { legacyDir: "", targetDir: "", hasLegacy: false },
-  pairingAllowFrom: { legacyTelegramPath: "", targetTelegramPath: "", hasLegacyTelegram: false },
+  pairingAllowFrom: { hasLegacyTelegram: false, copyPlans: [] },
   preview: [],
 };
 


### PR DESCRIPTION
## Cherry-pick from upstream

**Upstream commit**: `44e7c1142`
**Author**: human
**Tier**: AUTO-PICK

> refactor(doctor): model legacy file copies as plans

Conflicts resolved: fork has gutted state-migration internals into stubs. Kept fork stubs, added `FileCopyPlan` type needed by auto-merged `LegacyStateDetection` type, updated `EMPTY_DETECTION` to match new `pairingAllowFrom` shape. Removed deleted test file (DU conflict).

Depends on #1799