### PR TITLE
Cherry-pick issue #898: upstream misc root updates

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -183,7 +183,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
-        "hashed_secret": "abb0380989460de3f211d60628b439de7ebcd482",
+        "hashed_secret": "5e1b354be110a63154f710e31bf13f2b70431217",
         "is_verified": false,
         "line_number": 364
       },
@@ -9795,63 +9795,63 @@
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "1188d5a8ed7edcff5144a9472af960243eacf12e",
         "is_verified": false,
-        "line_number": 1611
+        "line_number": 1612
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "bde4db9b4c3be4049adc3b9a69851d7c35119770",
         "is_verified": false,
-        "line_number": 1627
+        "line_number": 1628
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "7f8aaf142ce0552c260f2e546dda43ddd7c9aef3",
         "is_verified": false,
-        "line_number": 1812
+        "line_number": 1813
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "22af290a1a3d5e941193a41a3d3a9e4ca8da5e27",
         "is_verified": false,
-        "line_number": 1985
+        "line_number": 1986
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 2041
+        "line_number": 2042
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 2273
+        "line_number": 2274
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2401
+        "line_number": 2402
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 2654
+        "line_number": 2655
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 2656
+        "line_number": 2657
       }
     ],
     "docs/gateway/configuration.md": [
@@ -9945,7 +9945,7 @@
         "filename": "docs/help/faq.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2489
+        "line_number": 2490
       }
     ],
     "docs/install/macos-vm.md": [
@@ -10033,14 +10033,14 @@
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 70
+        "line_number": 69
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 148
       }
     ],
     "docs/providers/moonshot.md": [

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -9619,14 +9619,14 @@
         "filename": "docs/channels/feishu.md",
         "hashed_secret": "b60d121b438a380c343d5ec3c2037564b82ffef3",
         "is_verified": false,
-        "line_number": 189
+        "line_number": 187
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/channels/feishu.md",
         "hashed_secret": "186154712b2d5f6791d85b9a0987b98fa231779c",
         "is_verified": false,
-        "line_number": 501
+        "line_number": 499
       }
     ],
     "docs/channels/irc.md": [
@@ -13034,5 +13034,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T18:12:38Z"
+  "generated_at": "2026-03-08T18:14:00Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -183,23 +183,23 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
-        "hashed_secret": "5e1b354be110a63154f710e31bf13f2b70431217",
+        "hashed_secret": "7afea670e53d801f1f881c99c40aa177e3395bfa",
         "is_verified": false,
-        "line_number": 364
+        "line_number": 365
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
         "hashed_secret": "6e1ba26139ac4e73427e68a7eec2abf96bcf1fd4",
         "is_verified": false,
-        "line_number": 583
+        "line_number": 584
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
         "hashed_secret": "c0baa9660a8d3b11874c63a535d8369f4a8fa8fa",
         "is_verified": false,
-        "line_number": 722
+        "line_number": 723
       }
     ],
     "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -11583,7 +11583,7 @@
         "filename": "src/agents/pi-embedded-runner/model.ts",
         "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
         "is_verified": false,
-        "line_number": 267
+        "line_number": 272
       }
     ],
     "src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts": [

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -10255,14 +10255,14 @@
         "filename": "docs/zh-CN/channels/feishu.md",
         "hashed_secret": "b60d121b438a380c343d5ec3c2037564b82ffef3",
         "is_verified": false,
-        "line_number": 195
+        "line_number": 191
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/zh-CN/channels/feishu.md",
         "hashed_secret": "186154712b2d5f6791d85b9a0987b98fa231779c",
         "is_verified": false,
-        "line_number": 509
+        "line_number": 505
       }
     ],
     "docs/zh-CN/channels/line.md": [
@@ -13034,5 +13034,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T17:49:19Z"
+  "generated_at": "2026-03-08T18:12:38Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -9972,7 +9972,7 @@
         "filename": "docs/perplexity.md",
         "hashed_secret": "6b26c117c66a0c030e239eef595c1e18865132a8",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 43
       }
     ],
     "docs/plugins/voice-call.md": [
@@ -13034,5 +13034,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T01:23:32Z"
+  "generated_at": "2026-03-08T17:49:19Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - macOS app/chat UI: route browser proxy through the local node browser service, preserve plain-text paste semantics, strip completed assistant trace/debug wrapper noise from transcripts, refresh permission state after returning from System Settings, and tolerate malformed cron rows in the macOS tab. (#39516) Thanks @Imhermes1.
+- Mattermost replies: keep `root_id` pinned to the existing thread root when an agent replies inside a thread, while still using reply-target threading for top-level posts. (#27744) thanks @hnykda.
+- Agents/failover: detect Amazon Bedrock `Too many tokens per day` quota errors as rate limits across fallback, cron retry, and memory embeddings while keeping context-window `too many tokens per request` errors out of the rate-limit lane. (#39377) Thanks @gambletan.
+- Android/Play distribution: remove self-update, background location, `screen.record`, and background mic capture from the Android app, narrow the foreground service to `dataSync` only, and clean up the legacy `location.enabledMode=always` preference migration. (#39660) Thanks @obviyus.
+- Telegram/DM partial streaming: keep DM preview lanes on real message edits instead of native draft materialization so final replies no longer flash a second duplicate copy before collapsing back to one.
+- macOS overlays: fix VoiceWake, Talk, and Notify overlay exclusivity crashes by removing shared `inout` visibility mutation from `OverlayPanelFactory.present`, and add a repeated Talk overlay smoke test. (#39275, #39321) Thanks @fellanH.
+- macOS Talk Mode: set the speech recognition request `taskHint` to `.dictation` for mic capture, and add regression coverage for the request defaults. (#38445) Thanks @dmiv.
+- macOS release packaging: default `scripts/package-mac-app.sh` to universal binaries for `BUILD_CONFIG=release`, and clarify that `scripts/package-mac-dist.sh` already produces the release zip + DMG. (#33891) Thanks @cgdusek.
+- Tools/web search: restore Perplexity OpenRouter/Sonar compatibility for legacy `OPENROUTER_API_KEY`, `sk-or-...`, and explicit `perplexity.baseUrl` / `model` setups while keeping direct Perplexity keys on the native Search API path. (#39937) Thanks @obviyus.
+- Hooks/session-memory: keep `/new` and `/reset` memory artifacts in the bound agent workspace and align saved reset session keys with that workspace when stale main-agent keys leak into the hook path. (#39875) thanks @rbutera.
 
 ## 2026.3.7
 

--- a/docs/channels/telegram.mdx
+++ b/docs/channels/telegram.mdx
@@ -243,11 +243,11 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 ## Feature reference
 
   <details>
-<summary>Live stream preview (native drafts + message edits)</summary>
+<summary>Live stream preview (message edits)</summary>
 
     RemoteClaw can stream partial replies in real time:
 
-    - direct chats: Telegram native draft streaming via `sendMessageDraft`
+    - direct chats: preview message + `editMessageText`
     - groups/topics: preview message + `editMessageText`
 
     Requirement:
@@ -256,11 +256,9 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `progress` maps to `partial` on Telegram (compat with cross-channel naming)
     - legacy `channels.telegram.streamMode` and boolean `streaming` values are auto-mapped
 
-    Telegram enabled `sendMessageDraft` for all bots in Bot API 9.5 (March 1, 2026).
-
     For text-only replies:
 
-    - DM: RemoteClaw updates the draft in place (no extra preview message)
+    - DM: RemoteClaw keeps the same preview message and performs a final edit in place (no second message)
     - group/topic: RemoteClaw keeps the same preview message and performs a final edit in place (no second message)
 
     For complex replies (for example media payloads), RemoteClaw falls back to normal final delivery and then cleans up the preview message.
@@ -909,7 +907,7 @@ Primary reference:
 - `channels.telegram.textChunkLimit`: outbound chunk size (chars).
 - `channels.telegram.chunkMode`: `length` (default) or `newline` to split on blank lines (paragraph boundaries) before length chunking.
 - `channels.telegram.linkPreview`: toggle link previews for outbound messages (default: true).
-- `channels.telegram.streaming`: `off | partial | block | progress` (live stream preview; default: `partial`; `progress` maps to `partial`; `block` is legacy preview mode compatibility). In DMs, `partial` uses native `sendMessageDraft` when available.
+- `channels.telegram.streaming`: `off | partial | block | progress` (live stream preview; default: `partial`; `progress` maps to `partial`; `block` is legacy preview mode compatibility). Telegram preview streaming uses a single preview message that is edited in place.
 - `channels.telegram.mediaMaxMb`: inbound/outbound Telegram media cap (MB, default: 100).
 - `channels.telegram.retry`: retry policy for Telegram send helpers (CLI/tools/actions) on recoverable outbound API errors (attempts, minDelayMs, maxDelayMs, jitter).
 - `channels.telegram.network.autoSelectFamily`: override Node autoSelectFamily (true=enable, false=disable). Defaults to enabled on Node 22+, with WSL2 defaulting to disabled.

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -138,7 +138,7 @@ Legacy key migration:
 
 Telegram:
 
-- Uses Bot API `sendMessageDraft` in DMs when available, and `sendMessage` + `editMessageText` for group/topic preview updates.
+- Uses `sendMessage` + `editMessageText` preview updates across DMs and group/topics.
 - Preview streaming is skipped when Telegram block streaming is explicitly enabled (to avoid double-streaming).
 - `/reasoning stream` can write reasoning to preview.
 

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { resolveMattermostAccount } from "./accounts.js";
 import {
   evaluateMattermostMentionGate,
+  resolveMattermostReplyRootId,
   type MattermostMentionGateInput,
   type MattermostRequireMentionResolverInput,
 } from "./monitor.js";
@@ -105,5 +106,28 @@ describe("mattermost mention gating", () => {
     expect(account.requireMention).toBe(true);
     expect(decision.shouldRequireMention).toBe(true);
     expect(decision.dropReason).toBe("missing-mention");
+  });
+});
+
+describe("resolveMattermostReplyRootId", () => {
+  it("uses replyToId for top-level replies", () => {
+    expect(
+      resolveMattermostReplyRootId({
+        replyToId: "inbound-post-123",
+      }),
+    ).toBe("inbound-post-123");
+  });
+
+  it("keeps the thread root when replying inside an existing thread", () => {
+    expect(
+      resolveMattermostReplyRootId({
+        threadRootId: "thread-root-456",
+        replyToId: "child-post-789",
+      }),
+    ).toBe("thread-root-456");
+  });
+
+  it("falls back to undefined when neither reply target is available", () => {
+    expect(resolveMattermostReplyRootId({})).toBeUndefined();
   });
 });

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -315,6 +315,17 @@ export function evaluateMattermostMentionGate(
     dropReason: null,
   };
 }
+
+export function resolveMattermostReplyRootId(params: {
+  threadRootId?: string;
+  replyToId?: string;
+}): string | undefined {
+  const threadRootId = params.threadRootId?.trim();
+  if (threadRootId) {
+    return threadRootId;
+  }
+  return params.replyToId?.trim() || undefined;
+}
 type MattermostMediaInfo = {
   path: string;
   contentType?: string;
@@ -1694,7 +1705,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               }
               await sendMessageMattermost(to, chunk, {
                 accountId: account.accountId,
-                replyToId: threadRootId,
+                replyToId: resolveMattermostReplyRootId({
+                  threadRootId,
+                  replyToId: payload.replyToId,
+                }),
               });
             }
           } else {
@@ -1705,7 +1719,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               await sendMessageMattermost(to, caption, {
                 accountId: account.accountId,
                 mediaUrl,
-                replyToId: threadRootId,
+                replyToId: resolveMattermostReplyRootId({
+                  threadRootId,
+                  replyToId: payload.replyToId,
+                }),
               });
             }
           }

--- a/extensions/zalo/src/api.test.ts
+++ b/extensions/zalo/src/api.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { deleteWebhook, getWebhookInfo, sendChatAction, type ZaloFetch } from "./api.js";
+
+describe("Zalo API request methods", () => {
+  it("uses POST for getWebhookInfo", async () => {
+    const fetcher = vi.fn<ZaloFetch>(
+      async () => new Response(JSON.stringify({ ok: true, result: {} })),
+    );
+
+    await getWebhookInfo("test-token", fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const [, init] = fetcher.mock.calls[0] ?? [];
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toEqual({ "Content-Type": "application/json" });
+  });
+
+  it("keeps POST for deleteWebhook", async () => {
+    const fetcher = vi.fn<ZaloFetch>(
+      async () => new Response(JSON.stringify({ ok: true, result: {} })),
+    );
+
+    await deleteWebhook("test-token", fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const [, init] = fetcher.mock.calls[0] ?? [];
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toEqual({ "Content-Type": "application/json" });
+  });
+
+  it("aborts sendChatAction when the typing timeout elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetcher = vi.fn<ZaloFetch>(
+        (_, init) =>
+          new Promise<Response>((_, reject) => {
+            init?.signal?.addEventListener("abort", () => reject(new Error("aborted")), {
+              once: true,
+            });
+          }),
+      );
+
+      const promise = sendChatAction(
+        "test-token",
+        {
+          chat_id: "chat-123",
+          action: "typing",
+        },
+        fetcher,
+        25,
+      );
+      const rejected = expect(promise).rejects.toThrow("aborted");
+
+      await vi.advanceTimersByTimeAsync(25);
+
+      await rejected;
+      const [, init] = fetcher.mock.calls[0] ?? [];
+      expect(init?.signal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/extensions/zalo/src/api.ts
+++ b/extensions/zalo/src/api.ts
@@ -58,9 +58,20 @@ export type ZaloSendPhotoParams = {
   caption?: string;
 };
 
+export type ZaloSendChatActionParams = {
+  chat_id: string;
+  action: "typing" | "upload_photo";
+};
+
 export type ZaloSetWebhookParams = {
   url: string;
   secret_token: string;
+};
+
+export type ZaloWebhookInfo = {
+  url?: string;
+  updated_at?: number;
+  has_custom_certificate?: boolean;
 };
 
 export type ZaloGetUpdatesParams = {
@@ -162,6 +173,21 @@ export async function sendPhoto(
 }
 
 /**
+ * Send a temporary chat action such as typing.
+ */
+export async function sendChatAction(
+  token: string,
+  params: ZaloSendChatActionParams,
+  fetcher?: ZaloFetch,
+  timeoutMs?: number,
+): Promise<ZaloApiResponse<boolean>> {
+  return callZaloApi<boolean>("sendChatAction", token, params, {
+    timeoutMs,
+    fetch: fetcher,
+  });
+}
+
+/**
  * Get updates using long polling (dev/testing only)
  * Note: Zalo returns a single update per call, not an array like Telegram
  */
@@ -183,8 +209,8 @@ export async function setWebhook(
   token: string,
   params: ZaloSetWebhookParams,
   fetcher?: ZaloFetch,
-): Promise<ZaloApiResponse<boolean>> {
-  return callZaloApi<boolean>("setWebhook", token, params, { fetch: fetcher });
+): Promise<ZaloApiResponse<ZaloWebhookInfo>> {
+  return callZaloApi<ZaloWebhookInfo>("setWebhook", token, params, { fetch: fetcher });
 }
 
 /**
@@ -193,8 +219,12 @@ export async function setWebhook(
 export async function deleteWebhook(
   token: string,
   fetcher?: ZaloFetch,
-): Promise<ZaloApiResponse<boolean>> {
-  return callZaloApi<boolean>("deleteWebhook", token, undefined, { fetch: fetcher });
+  timeoutMs?: number,
+): Promise<ZaloApiResponse<ZaloWebhookInfo>> {
+  return callZaloApi<ZaloWebhookInfo>("deleteWebhook", token, undefined, {
+    timeoutMs,
+    fetch: fetcher,
+  });
 }
 
 /**
@@ -203,6 +233,6 @@ export async function deleteWebhook(
 export async function getWebhookInfo(
   token: string,
   fetcher?: ZaloFetch,
-): Promise<ZaloApiResponse<{ url?: string; has_custom_certificate?: boolean }>> {
-  return callZaloApi("getWebhookInfo", token, undefined, { fetch: fetcher });
+): Promise<ZaloApiResponse<ZaloWebhookInfo>> {
+  return callZaloApi<ZaloWebhookInfo>("getWebhookInfo", token, undefined, { fetch: fetcher });
 }

--- a/extensions/zalo/src/channel.startup.test.ts
+++ b/extensions/zalo/src/channel.startup.test.ts
@@ -1,0 +1,100 @@
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/zalo";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createStartAccountContext } from "../../test-utils/start-account-context.js";
+import type { ResolvedZaloAccount } from "./accounts.js";
+
+const hoisted = vi.hoisted(() => ({
+  monitorZaloProvider: vi.fn(),
+  probeZalo: vi.fn(async () => ({
+    ok: false as const,
+    error: "probe failed",
+    elapsedMs: 1,
+  })),
+}));
+
+vi.mock("./monitor.js", async () => {
+  const actual = await vi.importActual<typeof import("./monitor.js")>("./monitor.js");
+  return {
+    ...actual,
+    monitorZaloProvider: hoisted.monitorZaloProvider,
+  };
+});
+
+vi.mock("./probe.js", async () => {
+  const actual = await vi.importActual<typeof import("./probe.js")>("./probe.js");
+  return {
+    ...actual,
+    probeZalo: hoisted.probeZalo,
+  };
+});
+
+import { zaloPlugin } from "./channel.js";
+
+function buildAccount(): ResolvedZaloAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    token: "test-token",
+    tokenSource: "config",
+    config: {},
+  };
+}
+
+describe("zaloPlugin gateway.startAccount", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps startAccount pending until abort", async () => {
+    hoisted.monitorZaloProvider.mockImplementationOnce(
+      async ({ abortSignal }: { abortSignal: AbortSignal }) =>
+        await new Promise<void>((resolve) => {
+          if (abortSignal.aborted) {
+            resolve();
+            return;
+          }
+          abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        }),
+    );
+
+    const patches: ChannelAccountSnapshot[] = [];
+    const abort = new AbortController();
+    const task = zaloPlugin.gateway!.startAccount!(
+      createStartAccountContext({
+        account: buildAccount(),
+        abortSignal: abort.signal,
+        statusPatchSink: (next) => patches.push({ ...next }),
+      }),
+    );
+
+    let settled = false;
+    void task.then(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() => {
+      expect(hoisted.probeZalo).toHaveBeenCalledOnce();
+      expect(hoisted.monitorZaloProvider).toHaveBeenCalledOnce();
+    });
+
+    expect(settled).toBe(false);
+    expect(patches).toContainEqual(
+      expect.objectContaining({
+        accountId: "default",
+      }),
+    );
+
+    abort.abort();
+    await task;
+
+    expect(settled).toBe(true);
+    expect(hoisted.monitorZaloProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: "test-token",
+        account: expect.objectContaining({ accountId: "default" }),
+        abortSignal: abort.signal,
+        useWebhook: false,
+      }),
+    );
+  });
+});

--- a/extensions/zalo/src/channel.startup.test.ts
+++ b/extensions/zalo/src/channel.startup.test.ts
@@ -1,4 +1,4 @@
-import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/zalo";
+import type { ChannelAccountSnapshot } from "remoteclaw/plugin-sdk/zalo";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createStartAccountContext } from "../../test-utils/start-account-context.js";
 import type { ResolvedZaloAccount } from "./accounts.js";

--- a/extensions/zalo/src/channel.ts
+++ b/extensions/zalo/src/channel.ts
@@ -333,6 +333,7 @@ export const zaloPlugin: ChannelPlugin<ResolvedZaloAccount> = {
     startAccount: async (ctx) => {
       const account = ctx.account;
       const token = account.token.trim();
+      const mode = account.config.webhookUrl ? "webhook" : "polling";
       let zaloBotLabel = "";
       const fetcher = resolveZaloProxyFetch(account.config.proxy);
       try {
@@ -341,14 +342,21 @@ export const zaloPlugin: ChannelPlugin<ResolvedZaloAccount> = {
         if (name) {
           zaloBotLabel = ` (${name})`;
         }
+        if (!probe.ok) {
+          ctx.log?.warn?.(
+            `[${account.accountId}] Zalo probe failed before provider start (${String(probe.elapsedMs)}ms): ${probe.error}`,
+          );
+        }
         ctx.setStatus({
           accountId: account.accountId,
           bot: probe.bot,
         });
-      } catch {
-        // ignore probe errors
+      } catch (err) {
+        ctx.log?.warn?.(
+          `[${account.accountId}] Zalo probe threw before provider start: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
+        );
       }
-      ctx.log?.info(`[${account.accountId}] starting provider${zaloBotLabel}`);
+      ctx.log?.info(`[${account.accountId}] starting provider${zaloBotLabel} mode=${mode}`);
       const { monitorZaloProvider } = await import("./monitor.js");
       return monitorZaloProvider({
         token,

--- a/extensions/zalo/src/monitor.lifecycle.test.ts
+++ b/extensions/zalo/src/monitor.lifecycle.test.ts
@@ -1,0 +1,213 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/zalo";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../../../src/plugins/registry.js";
+import { setActivePluginRegistry } from "../../../src/plugins/runtime.js";
+import type { ResolvedZaloAccount } from "./accounts.js";
+
+const getWebhookInfoMock = vi.fn(async () => ({ ok: true, result: { url: "" } }));
+const deleteWebhookMock = vi.fn(async () => ({ ok: true, result: { url: "" } }));
+const getUpdatesMock = vi.fn(() => new Promise(() => {}));
+const setWebhookMock = vi.fn(async () => ({ ok: true, result: { url: "" } }));
+
+vi.mock("./api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./api.js")>();
+  return {
+    ...actual,
+    deleteWebhook: deleteWebhookMock,
+    getWebhookInfo: getWebhookInfoMock,
+    getUpdates: getUpdatesMock,
+    setWebhook: setWebhookMock,
+  };
+});
+
+vi.mock("./runtime.js", () => ({
+  getZaloRuntime: () => ({
+    logging: {
+      shouldLogVerbose: () => false,
+    },
+  }),
+}));
+
+async function waitForPollingLoopStart(): Promise<void> {
+  await vi.waitFor(() => expect(getUpdatesMock).toHaveBeenCalledTimes(1));
+}
+
+describe("monitorZaloProvider lifecycle", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("stays alive in polling mode until abort", async () => {
+    const { monitorZaloProvider } = await import("./monitor.js");
+    const abort = new AbortController();
+    const runtime = {
+      log: vi.fn<(message: string) => void>(),
+      error: vi.fn<(message: string) => void>(),
+    };
+    const account = {
+      accountId: "default",
+      config: {},
+    } as unknown as ResolvedZaloAccount;
+    const config = {} as OpenClawConfig;
+
+    let settled = false;
+    const run = monitorZaloProvider({
+      token: "test-token",
+      account,
+      config,
+      runtime,
+      abortSignal: abort.signal,
+    }).then(() => {
+      settled = true;
+    });
+
+    await waitForPollingLoopStart();
+
+    expect(getWebhookInfoMock).toHaveBeenCalledTimes(1);
+    expect(deleteWebhookMock).not.toHaveBeenCalled();
+    expect(getUpdatesMock).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+
+    abort.abort();
+    await run;
+
+    expect(settled).toBe(true);
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("Zalo provider stopped mode=polling"),
+    );
+  });
+
+  it("deletes an existing webhook before polling", async () => {
+    getWebhookInfoMock.mockResolvedValueOnce({
+      ok: true,
+      result: { url: "https://example.com/hooks/zalo" },
+    });
+
+    const { monitorZaloProvider } = await import("./monitor.js");
+    const abort = new AbortController();
+    const runtime = {
+      log: vi.fn<(message: string) => void>(),
+      error: vi.fn<(message: string) => void>(),
+    };
+    const account = {
+      accountId: "default",
+      config: {},
+    } as unknown as ResolvedZaloAccount;
+    const config = {} as OpenClawConfig;
+
+    const run = monitorZaloProvider({
+      token: "test-token",
+      account,
+      config,
+      runtime,
+      abortSignal: abort.signal,
+    });
+
+    await waitForPollingLoopStart();
+
+    expect(getWebhookInfoMock).toHaveBeenCalledTimes(1);
+    expect(deleteWebhookMock).toHaveBeenCalledTimes(1);
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("Zalo polling mode ready (webhook disabled)"),
+    );
+
+    abort.abort();
+    await run;
+  });
+
+  it("continues polling when webhook inspection returns 404", async () => {
+    const { ZaloApiError } = await import("./api.js");
+    getWebhookInfoMock.mockRejectedValueOnce(new ZaloApiError("Not Found", 404, "Not Found"));
+
+    const { monitorZaloProvider } = await import("./monitor.js");
+    const abort = new AbortController();
+    const runtime = {
+      log: vi.fn<(message: string) => void>(),
+      error: vi.fn<(message: string) => void>(),
+    };
+    const account = {
+      accountId: "default",
+      config: {},
+    } as unknown as ResolvedZaloAccount;
+    const config = {} as OpenClawConfig;
+
+    const run = monitorZaloProvider({
+      token: "test-token",
+      account,
+      config,
+      runtime,
+      abortSignal: abort.signal,
+    });
+
+    await waitForPollingLoopStart();
+
+    expect(getWebhookInfoMock).toHaveBeenCalledTimes(1);
+    expect(deleteWebhookMock).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("webhook inspection unavailable; continuing without webhook cleanup"),
+    );
+    expect(runtime.error).not.toHaveBeenCalled();
+
+    abort.abort();
+    await run;
+  });
+
+  it("waits for webhook deletion before finishing webhook shutdown", async () => {
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+
+    let resolveDeleteWebhook: (() => void) | undefined;
+    deleteWebhookMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveDeleteWebhook = () => resolve({ ok: true, result: { url: "" } });
+        }),
+    );
+
+    const { monitorZaloProvider } = await import("./monitor.js");
+    const abort = new AbortController();
+    const runtime = {
+      log: vi.fn<(message: string) => void>(),
+      error: vi.fn<(message: string) => void>(),
+    };
+    const account = {
+      accountId: "default",
+      config: {},
+    } as unknown as ResolvedZaloAccount;
+    const config = {} as OpenClawConfig;
+
+    let settled = false;
+    const run = monitorZaloProvider({
+      token: "test-token",
+      account,
+      config,
+      runtime,
+      abortSignal: abort.signal,
+      useWebhook: true,
+      webhookUrl: "https://example.com/hooks/zalo",
+      webhookSecret: "supersecret", // pragma: allowlist secret
+    }).then(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() => expect(setWebhookMock).toHaveBeenCalledTimes(1));
+    expect(registry.httpRoutes).toHaveLength(1);
+
+    abort.abort();
+
+    await vi.waitFor(() => expect(deleteWebhookMock).toHaveBeenCalledTimes(1));
+    expect(deleteWebhookMock).toHaveBeenCalledWith("test-token", undefined, 5000);
+    expect(settled).toBe(false);
+    expect(registry.httpRoutes).toHaveLength(1);
+
+    resolveDeleteWebhook?.();
+    await run;
+
+    expect(settled).toBe(true);
+    expect(registry.httpRoutes).toHaveLength(0);
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("Zalo provider stopped mode=webhook"),
+    );
+  });
+});

--- a/extensions/zalo/src/monitor.lifecycle.test.ts
+++ b/extensions/zalo/src/monitor.lifecycle.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/zalo";
+import type { RemoteClawConfig } from "remoteclaw/plugin-sdk/zalo";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../../../src/plugins/registry.js";
 import { setActivePluginRegistry } from "../../../src/plugins/runtime.js";
@@ -49,7 +49,7 @@ describe("monitorZaloProvider lifecycle", () => {
       accountId: "default",
       config: {},
     } as unknown as ResolvedZaloAccount;
-    const config = {} as OpenClawConfig;
+    const config = {} as RemoteClawConfig;
 
     let settled = false;
     const run = monitorZaloProvider({
@@ -94,7 +94,7 @@ describe("monitorZaloProvider lifecycle", () => {
       accountId: "default",
       config: {},
     } as unknown as ResolvedZaloAccount;
-    const config = {} as OpenClawConfig;
+    const config = {} as RemoteClawConfig;
 
     const run = monitorZaloProvider({
       token: "test-token",
@@ -130,7 +130,7 @@ describe("monitorZaloProvider lifecycle", () => {
       accountId: "default",
       config: {},
     } as unknown as ResolvedZaloAccount;
-    const config = {} as OpenClawConfig;
+    const config = {} as RemoteClawConfig;
 
     const run = monitorZaloProvider({
       token: "test-token",
@@ -175,7 +175,7 @@ describe("monitorZaloProvider lifecycle", () => {
       accountId: "default",
       config: {},
     } as unknown as ResolvedZaloAccount;
-    const config = {} as OpenClawConfig;
+    const config = {} as RemoteClawConfig;
 
     let settled = false;
     const run = monitorZaloProvider({

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -738,7 +738,17 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
         mediaMaxMb: effectiveMediaMaxMb,
         fetcher,
       });
+      const unregisterRoute = registerPluginHttpRoute({
+        path,
+        auth: "plugin",
+        match: "exact",
+        pluginId: "zalo",
+        accountId: account.accountId,
+        log: (message) => logVerbose(core, runtime, message),
+        handler: handleZaloWebhookRequest,
+      });
       stopHandlers.push(unregister);
+      stopHandlers.push(unregisterRoute);
       await waitForAbortSignal(abortSignal);
       return;
     }
@@ -786,16 +796,6 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
       statusSink,
       fetcher,
     });
-    const unregisterRoute = registerPluginHttpRoute({
-      path,
-      auth: "plugin",
-      match: "exact",
-      pluginId: "zalo",
-      accountId: account.accountId,
-      log: (message) => logVerbose(core, runtime, message),
-      handler: handleZaloWebhookRequest,
-    });
-    stopHandlers.push(unregisterRoute);
 
     await waitForAbortSignal(abortSignal);
   } catch (err) {

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -5,9 +5,11 @@ import type {
   OutboundReplyPayload,
 } from "remoteclaw/plugin-sdk";
 import {
+  createTypingCallbacks,
   createScopedPairingAccess,
   createReplyPrefixOptions,
   issuePairingChallenge,
+  logTypingFailure,
   registerPluginHttpRoute,
   resolveDirectDmAuthorizationOutcome,
   resolveSenderCommandAuthorizationWithRuntime,
@@ -16,13 +18,16 @@ import {
   resolveInboundRouteEnvelopeBuilderWithRuntime,
   sendMediaWithLeadingCaption,
   resolveWebhookPath,
+  waitForAbortSignal,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "remoteclaw/plugin-sdk";
 import type { ResolvedZaloAccount } from "./accounts.js";
 import {
   ZaloApiError,
   deleteWebhook,
+  getWebhookInfo,
   getUpdates,
+  sendChatAction,
   sendMessage,
   sendPhoto,
   setWebhook,
@@ -65,14 +70,33 @@ export type ZaloMonitorOptions = {
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
 };
 
-export type ZaloMonitorResult = {
-  stop: () => void;
-};
-
 const ZALO_TEXT_LIMIT = 2000;
 const DEFAULT_MEDIA_MAX_MB = 5;
+const WEBHOOK_CLEANUP_TIMEOUT_MS = 5_000;
+const ZALO_TYPING_TIMEOUT_MS = 5_000;
 
 type ZaloCoreRuntime = ReturnType<typeof getZaloRuntime>;
+
+function formatZaloError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? `${error.name}: ${error.message}`;
+  }
+  return String(error);
+}
+
+function describeWebhookTarget(rawUrl: string): string {
+  try {
+    const parsed = new URL(rawUrl);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return rawUrl;
+  }
+}
+
+function normalizeWebhookUrl(url: string | undefined): string | undefined {
+  const trimmed = url?.trim();
+  return trimmed ? trimmed : undefined;
+}
 
 function logVerbose(core: ZaloCoreRuntime, runtime: ZaloRuntimeEnv, message: string): void {
   if (core.logging.shouldLogVerbose()) {
@@ -152,6 +176,8 @@ function startPollingLoop(params: {
   } = params;
   const pollTimeout = 30;
 
+  runtime.log?.(`[${account.accountId}] Zalo polling loop started timeout=${String(pollTimeout)}s`);
+
   const poll = async () => {
     if (isStopped() || abortSignal.aborted) {
       return;
@@ -177,7 +203,7 @@ function startPollingLoop(params: {
       if (err instanceof ZaloApiError && err.isPollingTimeout) {
         // no updates
       } else if (!isStopped() && !abortSignal.aborted) {
-        runtime.error?.(`[${account.accountId}] Zalo polling error: ${String(err)}`);
+        runtime.error?.(`[${account.accountId}] Zalo polling error: ${formatZaloError(err)}`);
         await new Promise((resolve) => setTimeout(resolve, 5000));
       }
     }
@@ -523,12 +549,35 @@ async function processMessageWithPipeline(params: {
     channel: "zalo",
     accountId: account.accountId,
   });
+  const typingCallbacks = createTypingCallbacks({
+    start: async () => {
+      await sendChatAction(
+        token,
+        {
+          chat_id: chatId,
+          action: "typing",
+        },
+        fetcher,
+        ZALO_TYPING_TIMEOUT_MS,
+      );
+    },
+    onStartError: (err) => {
+      logTypingFailure({
+        log: (message) => logVerbose(core, runtime, message),
+        channel: "zalo",
+        action: "start",
+        target: chatId,
+        error: err,
+      });
+    },
+  });
 
   await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
     ctx: ctxPayload,
     cfg: config,
     dispatcherOptions: {
       ...prefixOptions,
+      typingCallbacks,
       deliver: async (payload: any) => {
         await deliverZaloReply({
           payload,
@@ -568,7 +617,6 @@ async function deliverZaloReply(params: {
   const { payload, token, chatId, runtime, core, config, accountId, statusSink, fetcher } = params;
   const tableMode = params.tableMode ?? "code";
   const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
-
   const sentMedia = await sendMediaWithLeadingCaption({
     mediaUrls: resolveOutboundMediaUrls(payload),
     caption: text,
@@ -598,7 +646,7 @@ async function deliverZaloReply(params: {
   }
 }
 
-export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<ZaloMonitorResult> {
+export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<void> {
   const {
     token,
     account,
@@ -616,45 +664,126 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
   const core = getZaloRuntime();
   const effectiveMediaMaxMb = account.config.mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;
   const fetcher = fetcherOverride ?? resolveZaloProxyFetch(account.config.proxy);
+  const mode = useWebhook ? "webhook" : "polling";
 
   let stopped = false;
   const stopHandlers: Array<() => void> = [];
+  let cleanupWebhook: (() => Promise<void>) | undefined;
 
   const stop = () => {
+    if (stopped) {
+      return;
+    }
     stopped = true;
     for (const handler of stopHandlers) {
       handler();
     }
   };
 
-  if (useWebhook) {
-    if (!webhookUrl || !webhookSecret) {
-      throw new Error("Zalo webhookUrl and webhookSecret are required for webhook mode");
-    }
-    if (!webhookUrl.startsWith("https://")) {
-      throw new Error("Zalo webhook URL must use HTTPS");
-    }
-    if (webhookSecret.length < 8 || webhookSecret.length > 256) {
-      throw new Error("Zalo webhook secret must be 8-256 characters");
+  runtime.log?.(
+    `[${account.accountId}] Zalo provider init mode=${mode} mediaMaxMb=${String(effectiveMediaMaxMb)}`,
+  );
+
+  try {
+    if (useWebhook) {
+      if (!webhookUrl || !webhookSecret) {
+        throw new Error("Zalo webhookUrl and webhookSecret are required for webhook mode");
+      }
+      if (!webhookUrl.startsWith("https://")) {
+        throw new Error("Zalo webhook URL must use HTTPS");
+      }
+      if (webhookSecret.length < 8 || webhookSecret.length > 256) {
+        throw new Error("Zalo webhook secret must be 8-256 characters");
+      }
+
+      const path = resolveWebhookPath({ webhookPath, webhookUrl, defaultPath: null });
+      if (!path) {
+        throw new Error("Zalo webhookPath could not be derived");
+      }
+
+      runtime.log?.(
+        `[${account.accountId}] Zalo configuring webhook path=${path} target=${describeWebhookTarget(webhookUrl)}`,
+      );
+      await setWebhook(token, { url: webhookUrl, secret_token: webhookSecret }, fetcher);
+      let webhookCleanupPromise: Promise<void> | undefined;
+      cleanupWebhook = async () => {
+        if (!webhookCleanupPromise) {
+          webhookCleanupPromise = (async () => {
+            runtime.log?.(`[${account.accountId}] Zalo stopping; deleting webhook`);
+            try {
+              await deleteWebhook(token, fetcher, WEBHOOK_CLEANUP_TIMEOUT_MS);
+              runtime.log?.(`[${account.accountId}] Zalo webhook deleted`);
+            } catch (err) {
+              const detail =
+                err instanceof Error && err.name === "AbortError"
+                  ? `timed out after ${String(WEBHOOK_CLEANUP_TIMEOUT_MS)}ms`
+                  : formatZaloError(err);
+              runtime.error?.(`[${account.accountId}] Zalo webhook delete failed: ${detail}`);
+            }
+          })();
+        }
+        await webhookCleanupPromise;
+      };
+      runtime.log?.(`[${account.accountId}] Zalo webhook registered path=${path}`);
+
+      const unregister = registerZaloWebhookTarget({
+        token,
+        account,
+        config,
+        runtime,
+        core,
+        path,
+        secret: webhookSecret,
+        statusSink: (patch) => statusSink?.(patch),
+        mediaMaxMb: effectiveMediaMaxMb,
+        fetcher,
+      });
+      stopHandlers.push(unregister);
+      await waitForAbortSignal(abortSignal);
+      return;
     }
 
-    const path = resolveWebhookPath({ webhookPath, webhookUrl, defaultPath: null });
-    if (!path) {
-      throw new Error("Zalo webhookPath could not be derived");
+    runtime.log?.(`[${account.accountId}] Zalo polling mode: clearing webhook before startup`);
+    try {
+      try {
+        const currentWebhookUrl = normalizeWebhookUrl(
+          (await getWebhookInfo(token, fetcher)).result?.url,
+        );
+        if (!currentWebhookUrl) {
+          runtime.log?.(`[${account.accountId}] Zalo polling mode ready (no webhook configured)`);
+        } else {
+          runtime.log?.(
+            `[${account.accountId}] Zalo polling mode disabling existing webhook ${describeWebhookTarget(currentWebhookUrl)}`,
+          );
+          await deleteWebhook(token, fetcher);
+          runtime.log?.(`[${account.accountId}] Zalo polling mode ready (webhook disabled)`);
+        }
+      } catch (err) {
+        if (err instanceof ZaloApiError && err.errorCode === 404) {
+          // Some Zalo environments do not expose webhook inspection for polling bots.
+          runtime.log?.(
+            `[${account.accountId}] Zalo polling mode webhook inspection unavailable; continuing without webhook cleanup`,
+          );
+        } else {
+          throw err;
+        }
+      }
+    } catch (err) {
+      runtime.error?.(
+        `[${account.accountId}] Zalo polling startup could not clear webhook: ${formatZaloError(err)}`,
+      );
     }
 
-    await setWebhook(token, { url: webhookUrl, secret_token: webhookSecret }, fetcher);
-
-    const unregister = registerZaloWebhookTarget({
+    startPollingLoop({
       token,
       account,
       config,
       runtime,
       core,
-      path,
-      secret: webhookSecret,
-      statusSink: (patch) => statusSink?.(patch),
+      abortSignal,
+      isStopped: () => stopped,
       mediaMaxMb: effectiveMediaMaxMb,
+      statusSink,
       fetcher,
     });
     const unregisterRoute = registerPluginHttpRoute({
@@ -666,38 +795,19 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
       log: (message) => logVerbose(core, runtime, message),
       handler: handleZaloWebhookRequest,
     });
-    stopHandlers.push(unregister);
     stopHandlers.push(unregisterRoute);
-    abortSignal.addEventListener(
-      "abort",
-      () => {
-        void deleteWebhook(token, fetcher).catch(() => {});
-      },
-      { once: true },
+
+    await waitForAbortSignal(abortSignal);
+  } catch (err) {
+    runtime.error?.(
+      `[${account.accountId}] Zalo provider startup failed mode=${mode}: ${formatZaloError(err)}`,
     );
-    return { stop };
+    throw err;
+  } finally {
+    await cleanupWebhook?.();
+    stop();
+    runtime.log?.(`[${account.accountId}] Zalo provider stopped mode=${mode}`);
   }
-
-  try {
-    await deleteWebhook(token, fetcher);
-  } catch {
-    // ignore
-  }
-
-  startPollingLoop({
-    token,
-    account,
-    config,
-    runtime,
-    core,
-    abortSignal,
-    isStopped: () => stopped,
-    mediaMaxMb: effectiveMediaMaxMb,
-    statusSink,
-    fetcher,
-  });
-
-  return { stop };
 }
 
 export const __testing = {

--- a/package.json
+++ b/package.json
@@ -369,7 +369,6 @@
     "playwright-core": "1.58.2",
     "qrcode-terminal": "^0.12.0",
     "sharp": "^0.34.5",
-    "strip-ansi": "^7.2.0",
     "tar": "7.5.10",
     "tslog": "^4.10.2",
     "undici": "^7.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,9 +147,6 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
-      strip-ansi:
-        specifier: ^7.2.0
-        version: 7.2.0
       tar:
         specifier: 7.5.10
         version: 7.5.10

--- a/scripts/pr
+++ b/scripts/pr
@@ -220,29 +220,39 @@ checkout_prep_branch() {
   # shellcheck disable=SC1091
   source .local/prep-context.env
 
+  local prep_branch
+  prep_branch=$(resolve_prep_branch_name "$pr")
+  git checkout "$prep_branch"
+}
+
+resolve_prep_branch_name() {
+  local pr="$1"
+  require_artifact .local/prep-context.env
+  # shellcheck disable=SC1091
+  source .local/prep-context.env
+
   local prep_branch="${PREP_BRANCH:-pr-$pr-prep}"
   if ! git show-ref --verify --quiet "refs/heads/$prep_branch"; then
     echo "Expected prep branch $prep_branch not found. Run prepare-init first."
     exit 1
   fi
 
-  git checkout "$prep_branch"
+  printf '%s\n' "$prep_branch"
 }
 
 verify_prep_branch_matches_prepared_head() {
   local pr="$1"
   local prepared_head_sha="$2"
 
-  require_artifact .local/prep-context.env
-  checkout_prep_branch "$pr"
-
+  local prep_branch
+  prep_branch=$(resolve_prep_branch_name "$pr")
   local prep_branch_head_sha
-  prep_branch_head_sha=$(git rev-parse HEAD)
+  prep_branch_head_sha=$(git rev-parse "refs/heads/$prep_branch")
   if [ "$prep_branch_head_sha" = "$prepared_head_sha" ]; then
     return 0
   fi
 
-  echo "Local prep branch moved after prepare-push (expected $prepared_head_sha, got $prep_branch_head_sha)."
+  echo "Local prep branch moved after prepare-push (branch=$prep_branch expected $prepared_head_sha, got $prep_branch_head_sha)."
   if git merge-base --is-ancestor "$prepared_head_sha" "$prep_branch_head_sha" 2>/dev/null; then
     echo "Unpushed local commits on prep branch:"
     git log --oneline "${prepared_head_sha}..${prep_branch_head_sha}" | sed 's/^/  /' || true

--- a/scripts/pr
+++ b/scripts/pr
@@ -423,6 +423,163 @@ resolve_head_push_url_https() {
   return 1
 }
 
+verify_pr_head_branch_matches_expected() {
+  local pr="$1"
+  local expected_head="$2"
+
+  local current_head
+  current_head=$(gh pr view "$pr" --json headRefName --jq .headRefName)
+  if [ "$current_head" != "$expected_head" ]; then
+    echo "PR head branch changed from $expected_head to $current_head. Re-run prepare-init."
+    exit 1
+  fi
+}
+
+setup_prhead_remote() {
+  local push_url
+  push_url=$(resolve_head_push_url) || {
+    echo "Unable to resolve PR head repo push URL."
+    exit 1
+  }
+
+  # Always set prhead to the correct fork URL for this PR.
+  # The remote is repo-level (shared across worktrees), so a previous
+  # prepare-pr run for a different fork PR can leave a stale URL.
+  git remote remove prhead 2>/dev/null || true
+  git remote add prhead "$push_url"
+}
+
+resolve_prhead_remote_sha() {
+  local pr_head="$1"
+
+  local remote_sha
+  remote_sha=$(git ls-remote prhead "refs/heads/$pr_head" 2>/dev/null | awk '{print $1}' || true)
+  if [ -z "$remote_sha" ]; then
+    local https_url
+    https_url=$(resolve_head_push_url_https 2>/dev/null) || true
+    local current_push_url
+    current_push_url=$(git remote get-url prhead 2>/dev/null || true)
+    if [ -n "$https_url" ] && [ "$https_url" != "$current_push_url" ]; then
+      echo "SSH remote failed; falling back to HTTPS..."
+      git remote set-url prhead "$https_url"
+      git remote set-url --push prhead "$https_url"
+      remote_sha=$(git ls-remote prhead "refs/heads/$pr_head" 2>/dev/null | awk '{print $1}' || true)
+    fi
+    if [ -z "$remote_sha" ]; then
+      echo "Remote branch refs/heads/$pr_head not found on prhead"
+      exit 1
+    fi
+  fi
+
+  printf '%s\n' "$remote_sha"
+}
+
+run_prepare_push_retry_gates() {
+  local docs_only="${1:-false}"
+
+  bootstrap_deps_if_needed
+  run_quiet_logged "pnpm build (lease-retry)" ".local/lease-retry-build.log" pnpm build
+  run_quiet_logged "pnpm check (lease-retry)" ".local/lease-retry-check.log" pnpm check
+  if [ "$docs_only" != "true" ]; then
+    run_quiet_logged "pnpm test (lease-retry)" ".local/lease-retry-test.log" pnpm test
+  fi
+}
+
+PUSH_PREP_HEAD_SHA=""
+PUSHED_FROM_SHA=""
+PR_HEAD_SHA_AFTER_PUSH=""
+
+push_prep_head_to_pr_branch() {
+  local pr="$1"
+  local pr_head="$2"
+  local prep_head_sha="$3"
+  local lease_sha="$4"
+  local rerun_gates_on_lease_retry="${5:-false}"
+  local docs_only="${6:-false}"
+
+  setup_prhead_remote
+
+  local remote_sha
+  remote_sha=$(resolve_prhead_remote_sha "$pr_head")
+
+  local pushed_from_sha="$remote_sha"
+  if [ "$remote_sha" = "$prep_head_sha" ]; then
+    echo "Remote branch already at local prep HEAD; skipping push."
+  else
+    if [ "$remote_sha" != "$lease_sha" ]; then
+      echo "Remote SHA $remote_sha differs from PR head SHA $lease_sha. Refreshing lease SHA from remote."
+      lease_sha="$remote_sha"
+    fi
+    pushed_from_sha="$lease_sha"
+    local push_output
+    if ! push_output=$(
+      git push --force-with-lease=refs/heads/$pr_head:$lease_sha prhead HEAD:$pr_head 2>&1
+    ); then
+      echo "Push failed: $push_output"
+
+      if printf '%s' "$push_output" | grep -qiE '(permission|denied|403|forbidden)'; then
+        echo "Permission denied on git push; trying GraphQL createCommitOnBranch fallback..."
+        if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ]; then
+          local graphql_oid
+          graphql_oid=$(graphql_push_to_fork "${PR_HEAD_OWNER}/${PR_HEAD_REPO_NAME}" "$pr_head" "$lease_sha")
+          prep_head_sha="$graphql_oid"
+        else
+          echo "Git push permission denied and no fork owner/repo info for GraphQL fallback."
+          exit 1
+        fi
+      else
+        echo "Lease push failed, retrying once with fresh PR head..."
+        lease_sha=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
+        pushed_from_sha="$lease_sha"
+
+        if [ "$rerun_gates_on_lease_retry" = "true" ]; then
+          git fetch origin "pull/$pr/head:pr-$pr-latest" --force
+          git rebase "pr-$pr-latest"
+          prep_head_sha=$(git rev-parse HEAD)
+          run_prepare_push_retry_gates "$docs_only"
+        fi
+
+        if ! push_output=$(
+          git push --force-with-lease=refs/heads/$pr_head:$lease_sha prhead HEAD:$pr_head 2>&1
+        ); then
+          echo "Retry push failed: $push_output"
+          if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ]; then
+            echo "Retry failed; trying GraphQL createCommitOnBranch fallback..."
+            local graphql_oid
+            graphql_oid=$(graphql_push_to_fork "${PR_HEAD_OWNER}/${PR_HEAD_REPO_NAME}" "$pr_head" "$lease_sha")
+            prep_head_sha="$graphql_oid"
+          else
+            echo "Git push failed and no fork owner/repo info for GraphQL fallback."
+            exit 1
+          fi
+        fi
+      fi
+    fi
+  fi
+
+  if ! wait_for_pr_head_sha "$pr" "$prep_head_sha" 8 3; then
+    local observed_sha
+    observed_sha=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
+    echo "Pushed head SHA propagation timed out. expected=$prep_head_sha observed=$observed_sha"
+    exit 1
+  fi
+
+  local pr_head_sha_after
+  pr_head_sha_after=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
+
+  git fetch origin main
+  git fetch origin "pull/$pr/head:pr-$pr-verify" --force
+  git merge-base --is-ancestor origin/main "pr-$pr-verify" || {
+    echo "PR branch is behind main after push."
+    exit 1
+  }
+  git branch -D "pr-$pr-verify" 2>/dev/null || true
+
+  PUSH_PREP_HEAD_SHA="$prep_head_sha"
+  PUSHED_FROM_SHA="$pushed_from_sha"
+  PR_HEAD_SHA_AFTER_PUSH="$pr_head_sha_after"
+}
+
 set_review_mode() {
   local mode="$1"
   cat > .local/review-mode.env <<EOF_ENV
@@ -1295,121 +1452,14 @@ prepare_push() {
   local prep_head_sha
   prep_head_sha=$(git rev-parse HEAD)
 
-  local current_head
-  current_head=$(gh pr view "$pr" --json headRefName --jq .headRefName)
   local lease_sha
   lease_sha=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
 
-  if [ "$current_head" != "$PR_HEAD" ]; then
-    echo "PR head branch changed from $PR_HEAD to $current_head. Re-run prepare-init."
-    exit 1
-  fi
-
-  local push_url
-  push_url=$(resolve_head_push_url) || {
-    echo "Unable to resolve PR head repo push URL."
-    exit 1
-  }
-
-  # Always set prhead to the correct fork URL for this PR.
-  # The remote is repo-level (shared across worktrees), so a previous
-  # prepare-pr run for a different fork PR can leave a stale URL.
-  git remote remove prhead 2>/dev/null || true
-  git remote add prhead "$push_url"
-
-  local remote_sha
-  remote_sha=$(git ls-remote prhead "refs/heads/$PR_HEAD" 2>/dev/null | awk '{print $1}' || true)
-  if [ -z "$remote_sha" ]; then
-    local https_url
-    https_url=$(resolve_head_push_url_https 2>/dev/null) || true
-    if [ -n "$https_url" ] && [ "$https_url" != "$push_url" ]; then
-      echo "SSH remote failed; falling back to HTTPS..."
-      git remote set-url prhead "$https_url"
-      git remote set-url --push prhead "$https_url"
-      push_url="$https_url"
-      remote_sha=$(git ls-remote prhead "refs/heads/$PR_HEAD" 2>/dev/null | awk '{print $1}' || true)
-    fi
-    if [ -z "$remote_sha" ]; then
-      echo "Remote branch refs/heads/$PR_HEAD not found on prhead"
-      exit 1
-    fi
-  fi
-
-  local pushed_from_sha="$remote_sha"
-  if [ "$remote_sha" = "$prep_head_sha" ]; then
-    echo "Remote branch already at local prep HEAD; skipping push."
-  else
-    if [ "$remote_sha" != "$lease_sha" ]; then
-      echo "Remote SHA $remote_sha differs from PR head SHA $lease_sha. Refreshing lease SHA from remote."
-      lease_sha="$remote_sha"
-    fi
-    pushed_from_sha="$lease_sha"
-    local push_output
-    if ! push_output=$(git push --force-with-lease=refs/heads/$PR_HEAD:$lease_sha prhead HEAD:$PR_HEAD 2>&1); then
-      echo "Push failed: $push_output"
-
-      # Check if this is a permission error (fork PR) vs a lease conflict.
-      # Permission errors go straight to GraphQL; lease conflicts retry with rebase.
-      if printf '%s' "$push_output" | grep -qiE '(permission|denied|403|forbidden)'; then
-        echo "Permission denied on git push; trying GraphQL createCommitOnBranch fallback..."
-        if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ]; then
-          local graphql_oid
-          graphql_oid=$(graphql_push_to_fork "${PR_HEAD_OWNER}/${PR_HEAD_REPO_NAME}" "$PR_HEAD" "$lease_sha")
-          prep_head_sha="$graphql_oid"
-        else
-          echo "Git push permission denied and no fork owner/repo info for GraphQL fallback."
-          exit 1
-        fi
-      else
-        echo "Lease push failed, retrying once with fresh PR head..."
-
-        lease_sha=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
-        pushed_from_sha="$lease_sha"
-
-        git fetch origin "pull/$pr/head:pr-$pr-latest" --force
-        git rebase "pr-$pr-latest"
-        prep_head_sha=$(git rev-parse HEAD)
-
-        bootstrap_deps_if_needed
-        run_quiet_logged "pnpm build (lease-retry)" ".local/lease-retry-build.log" pnpm build
-        run_quiet_logged "pnpm check (lease-retry)" ".local/lease-retry-check.log" pnpm check
-        if [ "${DOCS_ONLY:-false}" != "true" ]; then
-          run_quiet_logged "pnpm test (lease-retry)" ".local/lease-retry-test.log" pnpm test
-        fi
-
-        if ! git push --force-with-lease=refs/heads/$PR_HEAD:$lease_sha prhead HEAD:$PR_HEAD; then
-          # Retry also failed — try GraphQL as last resort.
-          if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ]; then
-            echo "Git push retry failed; trying GraphQL createCommitOnBranch fallback..."
-            local graphql_oid
-            graphql_oid=$(graphql_push_to_fork "${PR_HEAD_OWNER}/${PR_HEAD_REPO_NAME}" "$PR_HEAD" "$lease_sha")
-            prep_head_sha="$graphql_oid"
-          else
-            echo "Git push failed and no fork owner/repo info for GraphQL fallback."
-            exit 1
-          fi
-        fi
-      fi
-    fi
-  fi
-
-  if ! wait_for_pr_head_sha "$pr" "$prep_head_sha" 8 3; then
-    local observed_sha
-    observed_sha=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
-    echo "Pushed head SHA propagation timed out. expected=$prep_head_sha observed=$observed_sha"
-    exit 1
-  fi
-
-  local pr_head_sha_after
-  pr_head_sha_after=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
-
-  git fetch origin main
-  git fetch origin "pull/$pr/head:pr-$pr-verify" --force
-  git merge-base --is-ancestor origin/main "pr-$pr-verify" || {
-    echo "PR branch is behind main after push."
-    exit 1
-  }
-  git branch -D "pr-$pr-verify" 2>/dev/null || true
+  verify_pr_head_branch_matches_expected "$pr" "$PR_HEAD"
+  push_prep_head_to_pr_branch "$pr" "$PR_HEAD" "$prep_head_sha" "$lease_sha" true "${DOCS_ONLY:-false}"
+  prep_head_sha="$PUSH_PREP_HEAD_SHA"
+  local pushed_from_sha="$PUSHED_FROM_SHA"
+  local pr_head_sha_after="$PR_HEAD_SHA_AFTER_PUSH"
 
   local contrib="${PR_AUTHOR:-}"
   if [ -z "$contrib" ]; then
@@ -1460,107 +1510,14 @@ prepare_sync_head() {
   local prep_head_sha
   prep_head_sha=$(git rev-parse HEAD)
 
-  local current_head
-  current_head=$(gh pr view "$pr" --json headRefName --jq .headRefName)
   local lease_sha
   lease_sha=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
 
-  if [ "$current_head" != "$PR_HEAD" ]; then
-    echo "PR head branch changed from $PR_HEAD to $current_head. Re-run prepare-init."
-    exit 1
-  fi
-
-  local push_url
-  push_url=$(resolve_head_push_url) || {
-    echo "Unable to resolve PR head repo push URL."
-    exit 1
-  }
-
-  # Always set prhead to the correct fork URL for this PR.
-  # The remote is repo-level (shared across worktrees), so a previous
-  # run for a different fork PR can leave a stale URL.
-  git remote remove prhead 2>/dev/null || true
-  git remote add prhead "$push_url"
-
-  local remote_sha
-  remote_sha=$(git ls-remote prhead "refs/heads/$PR_HEAD" 2>/dev/null | awk '{print $1}' || true)
-  if [ -z "$remote_sha" ]; then
-    local https_url
-    https_url=$(resolve_head_push_url_https 2>/dev/null) || true
-    if [ -n "$https_url" ] && [ "$https_url" != "$push_url" ]; then
-      echo "SSH remote failed; falling back to HTTPS..."
-      git remote set-url prhead "$https_url"
-      git remote set-url --push prhead "$https_url"
-      push_url="$https_url"
-      remote_sha=$(git ls-remote prhead "refs/heads/$PR_HEAD" 2>/dev/null | awk '{print $1}' || true)
-    fi
-    if [ -z "$remote_sha" ]; then
-      echo "Remote branch refs/heads/$PR_HEAD not found on prhead"
-      exit 1
-    fi
-  fi
-
-  local pushed_from_sha="$remote_sha"
-  if [ "$remote_sha" = "$prep_head_sha" ]; then
-    echo "Remote branch already at local prep HEAD; skipping push."
-  else
-    if [ "$remote_sha" != "$lease_sha" ]; then
-      echo "Remote SHA $remote_sha differs from PR head SHA $lease_sha. Refreshing lease SHA from remote."
-      lease_sha="$remote_sha"
-    fi
-    pushed_from_sha="$lease_sha"
-    local push_output
-    if ! push_output=$(git push --force-with-lease=refs/heads/$PR_HEAD:$lease_sha prhead HEAD:$PR_HEAD 2>&1); then
-      echo "Push failed: $push_output"
-
-      if printf '%s' "$push_output" | grep -qiE '(permission|denied|403|forbidden)'; then
-        echo "Permission denied on git push; trying GraphQL createCommitOnBranch fallback..."
-        if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ]; then
-          local graphql_oid
-          graphql_oid=$(graphql_push_to_fork "${PR_HEAD_OWNER}/${PR_HEAD_REPO_NAME}" "$PR_HEAD" "$lease_sha")
-          prep_head_sha="$graphql_oid"
-        else
-          echo "Git push permission denied and no fork owner/repo info for GraphQL fallback."
-          exit 1
-        fi
-      else
-        echo "Lease push failed, retrying once with fresh PR head lease..."
-        lease_sha=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
-        pushed_from_sha="$lease_sha"
-
-        if ! push_output=$(git push --force-with-lease=refs/heads/$PR_HEAD:$lease_sha prhead HEAD:$PR_HEAD 2>&1); then
-          echo "Retry push failed: $push_output"
-          if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ]; then
-            echo "Retry failed; trying GraphQL createCommitOnBranch fallback..."
-            local graphql_oid
-            graphql_oid=$(graphql_push_to_fork "${PR_HEAD_OWNER}/${PR_HEAD_REPO_NAME}" "$PR_HEAD" "$lease_sha")
-            prep_head_sha="$graphql_oid"
-          else
-            echo "Git push failed and no fork owner/repo info for GraphQL fallback."
-            exit 1
-          fi
-        fi
-      fi
-    fi
-  fi
-
-  if ! wait_for_pr_head_sha "$pr" "$prep_head_sha" 8 3; then
-    local observed_sha
-    observed_sha=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
-    echo "Pushed head SHA propagation timed out. expected=$prep_head_sha observed=$observed_sha"
-    exit 1
-  fi
-
-  local pr_head_sha_after
-  pr_head_sha_after=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
-
-  git fetch origin main
-  git fetch origin "pull/$pr/head:pr-$pr-verify" --force
-  git merge-base --is-ancestor origin/main "pr-$pr-verify" || {
-    echo "PR branch is behind main after push."
-    exit 1
-  }
-  git branch -D "pr-$pr-verify" 2>/dev/null || true
+  verify_pr_head_branch_matches_expected "$pr" "$PR_HEAD"
+  push_prep_head_to_pr_branch "$pr" "$PR_HEAD" "$prep_head_sha" "$lease_sha"
+  prep_head_sha="$PUSH_PREP_HEAD_SHA"
+  local pushed_from_sha="$PUSHED_FROM_SHA"
+  local pr_head_sha_after="$PR_HEAD_SHA_AFTER_PUSH"
 
   local contrib="${PR_AUTHOR:-}"
   if [ -z "$contrib" ]; then

--- a/scripts/pr
+++ b/scripts/pr
@@ -485,10 +485,6 @@ run_prepare_push_retry_gates() {
   fi
 }
 
-PUSH_PREP_HEAD_SHA=""
-PUSHED_FROM_SHA=""
-PR_HEAD_SHA_AFTER_PUSH=""
-
 push_prep_head_to_pr_branch() {
   local pr="$1"
   local pr_head="$2"
@@ -496,6 +492,7 @@ push_prep_head_to_pr_branch() {
   local lease_sha="$4"
   local rerun_gates_on_lease_retry="${5:-false}"
   local docs_only="${6:-false}"
+  local result_env_path="${7:-.local/push-result.env}"
 
   setup_prhead_remote
 
@@ -574,10 +571,11 @@ push_prep_head_to_pr_branch() {
     exit 1
   }
   git branch -D "pr-$pr-verify" 2>/dev/null || true
-
-  PUSH_PREP_HEAD_SHA="$prep_head_sha"
-  PUSHED_FROM_SHA="$pushed_from_sha"
-  PR_HEAD_SHA_AFTER_PUSH="$pr_head_sha_after"
+  cat > "$result_env_path" <<EOF_ENV
+PUSH_PREP_HEAD_SHA=$prep_head_sha
+PUSHED_FROM_SHA=$pushed_from_sha
+PR_HEAD_SHA_AFTER_PUSH=$pr_head_sha_after
+EOF_ENV
 }
 
 set_review_mode() {
@@ -1454,9 +1452,12 @@ prepare_push() {
 
   local lease_sha
   lease_sha=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
+  local push_result_env=".local/prepare-push-result.env"
 
   verify_pr_head_branch_matches_expected "$pr" "$PR_HEAD"
-  push_prep_head_to_pr_branch "$pr" "$PR_HEAD" "$prep_head_sha" "$lease_sha" true "${DOCS_ONLY:-false}"
+  push_prep_head_to_pr_branch "$pr" "$PR_HEAD" "$prep_head_sha" "$lease_sha" true "${DOCS_ONLY:-false}" "$push_result_env"
+  # shellcheck disable=SC1090
+  source "$push_result_env"
   prep_head_sha="$PUSH_PREP_HEAD_SHA"
   local pushed_from_sha="$PUSHED_FROM_SHA"
   local pr_head_sha_after="$PR_HEAD_SHA_AFTER_PUSH"
@@ -1512,9 +1513,12 @@ prepare_sync_head() {
 
   local lease_sha
   lease_sha=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
+  local push_result_env=".local/prepare-sync-result.env"
 
   verify_pr_head_branch_matches_expected "$pr" "$PR_HEAD"
-  push_prep_head_to_pr_branch "$pr" "$PR_HEAD" "$prep_head_sha" "$lease_sha"
+  push_prep_head_to_pr_branch "$pr" "$PR_HEAD" "$prep_head_sha" "$lease_sha" false false "$push_result_env"
+  # shellcheck disable=SC1090
+  source "$push_result_env"
   prep_head_sha="$PUSH_PREP_HEAD_SHA"
   local pushed_from_sha="$PUSHED_FROM_SHA"
   local pr_head_sha_after="$PR_HEAD_SHA_AFTER_PUSH"

--- a/src/auto-reply/reply/reply-plumbing.test.ts
+++ b/src/auto-reply/reply/reply-plumbing.test.ts
@@ -230,6 +230,46 @@ describe("applyReplyThreading auto-threading", () => {
     expect(result[0].replyToId).toBe("42");
     expect(result[0].replyToTag).toBe(true);
   });
+
+  it("resolves [[reply_to_current]] to currentMessageId when replyToMode is 'all'", () => {
+    // Mattermost-style scenario: agent responds with [[reply_to_current]] and replyToMode
+    // is "all". The tag should resolve to the inbound message id.
+    const result = applyReplyThreading({
+      payloads: [{ text: "[[reply_to_current]] some reply text" }],
+      replyToMode: "all",
+      currentMessageId: "mm-post-abc123",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].replyToId).toBe("mm-post-abc123");
+    expect(result[0].replyToTag).toBe(true);
+    expect(result[0].text).toBe("some reply text");
+  });
+
+  it("resolves [[reply_to:<id>]] to explicit id when replyToMode is 'all'", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "[[reply_to:mm-post-xyz789]] threaded reply" }],
+      replyToMode: "all",
+      currentMessageId: "mm-post-abc123",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].replyToId).toBe("mm-post-xyz789");
+    expect(result[0].text).toBe("threaded reply");
+  });
+
+  it("sets replyToId via implicit threading when replyToMode is 'all'", () => {
+    // Even without explicit tags, replyToMode "all" should set replyToId
+    // to currentMessageId for threading.
+    const result = applyReplyThreading({
+      payloads: [{ text: "hello" }],
+      replyToMode: "all",
+      currentMessageId: "mm-post-abc123",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].replyToId).toBe("mm-post-abc123");
+  });
 });
 
 const baseRun: SubagentRunRecord = {

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -343,6 +343,7 @@ export {
   listDevicePairing,
   rejectDevicePairing,
 } from "../infra/device-pairing.js";
+export { waitForAbortSignal } from "../infra/abort-signal.js";
 export { createDedupeCache } from "../infra/dedupe.js";
 export type { DedupeCache } from "../infra/dedupe.js";
 export { createPersistentDedupe } from "./persistent-dedupe.js";

--- a/src/plugin-sdk/zalo.ts
+++ b/src/plugin-sdk/zalo.ts
@@ -41,6 +41,8 @@ export type {
 } from "../channels/plugins/types.js";
 export type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 export { createReplyPrefixOptions } from "../channels/reply-prefix.js";
+export { logTypingFailure } from "../channels/logging.js";
+export { createTypingCallbacks } from "../channels/typing.js";
 export type { RemoteClawConfig } from "../config/config.js";
 export {
   resolveDefaultGroupPolicy,
@@ -52,6 +54,7 @@ export type { SecretInput } from "../config/types.secrets.js";
 export { normalizeSecretInputString } from "../config/types.secrets.js";
 export { buildSecretInputSchema } from "./secret-input-schema.js";
 export { MarkdownConfigSchema } from "../config/zod-schema.core.js";
+export { waitForAbortSignal } from "../infra/abort-signal.js";
 export { createDedupeCache } from "../infra/dedupe.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export type { PluginRuntime } from "../plugins/runtime/types.js";

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1171,7 +1171,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     },
   );
 
-  it("uses message preview transport for DM reasoning lane when answer preview lane is active", async () => {
+  it("uses message preview transport for all DM lanes when streaming is active", async () => {
     setupDraftStreams({ answerMessageId: 999, reasoningMessageId: 111 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
@@ -1190,7 +1190,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
-        previewTransport: "auto",
+        previewTransport: "message",
       }),
     );
     expect(createTelegramDraftStream.mock.calls[1]?.[0]).toEqual(
@@ -1201,9 +1201,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
-  it("materializes DM answer draft final without sending a duplicate final message", async () => {
-    const answerDraftStream = createTestDraftStream({ previewMode: "draft" });
-    answerDraftStream.materialize.mockResolvedValue(321);
+  it("finalizes DM answer preview in place without materializing or sending a duplicate", async () => {
+    const answerDraftStream = createDraftStream(321);
     const reasoningDraftStream = createDraftStream(111);
     createTelegramDraftStream
       .mockImplementationOnce(() => answerDraftStream)
@@ -1222,12 +1221,17 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
-        previewTransport: "auto",
+        previewTransport: "message",
       }),
     );
-    expect(answerDraftStream.materialize).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.materialize).not.toHaveBeenCalled();
     expect(deliverReplies).not.toHaveBeenCalled();
-    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      321,
+      "Checking the directory...",
+      expect.any(Object),
+    );
   });
 
   it("keeps reasoning and answer streaming in separate preview lanes", async () => {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -126,18 +126,20 @@ export const dispatchTelegramMessage = async ({
   const draftReplyToMessageId =
     replyToMode !== "off" && typeof msg.message_id === "number" ? msg.message_id : undefined;
   const draftMinInitialChars = DRAFT_MIN_INITIAL_CHARS;
+  // Keep DM preview lanes on real message transport. Native draft previews still
+  // require a draft->message materialize hop, and that overlap keeps reintroducing
+  // a visible duplicate flash at finalize time.
+  const useMessagePreviewTransportForDm = threadSpec?.scope === "dm" && canStreamAnswerDraft;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
-    const useMessagePreviewTransportForDmReasoning =
-      laneName === "reasoning" && threadSpec?.scope === "dm" && canStreamAnswerDraft;
     const stream = enabled
       ? createTelegramDraftStream({
           api: bot.api,
           chatId,
           maxChars: draftMaxChars,
           thread: threadSpec,
-          previewTransport: useMessagePreviewTransportForDmReasoning ? "message" : "auto",
+          previewTransport: useMessagePreviewTransportForDm ? "message" : "auto",
           replyToMessageId: draftReplyToMessageId,
           minInitialChars: draftMinInitialChars,
           renderText: renderDraftPreview,

--- a/test-fixtures/talk-config-contract.json
+++ b/test-fixtures/talk-config-contract.json
@@ -86,7 +86,7 @@
       },
       "talk": {
         "voiceId": "voice-legacy",
-        "apiKey": "legacy-key"
+        "apiKey": "xxxxx"
       }
     }
   ],


### PR DESCRIPTION
Closes #898

## Commits

| Hash | Subject | Result |
|------|---------|--------|
| `6477da623` | chore(secrets): sync detect-secrets baseline | PICKED |
| `4db634964` | chore(secrets): sync appcast baseline | PICKED |
| `c1b914026` | fix: add missing strip-ansi dep for pi-coding-agent (#38999) | SKIPPED — gutted layer (pi-coding-agent), empty after resolution |
| `f73778e9b` | fix: remove redundant root strip-ansi dependency (#39652) | RESOLVED — lockfile + package.json conflicts |
| `b38f37163` | fix: add @tloncorp/api to pnpm onlyBuiltDependencies allowlist (#39027) | SKIPPED — already present in fork |
| `6e086a5b3` | chore: update secrets baseline line numbers | PICKED |
| `38f4ac5e3` | fix(feishu): restore @larksuiteoapi/node-sdk in root dependencies | SKIPPED — already present in fork |
| `ba2d580c4` | docs: note /landpr merge process | SKIPPED — AGENTS.md deleted in fork |
| `032778fb2` | refactor: avoid checkout during prep head verification | PICKED |
| `fa00b1d0c` | refactor: dedupe prep branch push flow | PICKED |
| `1ec1f0f1f` | refactor: scope prep push results to env artifacts | PICKED |
| `2ae58542a` | Fixtures: normalize talk config API key placeholder | PICKED |
| `e19b3679d` | Chore: widen xxxxx detect-secrets allowlist | SKIPPED — already present in fork |
| `aebfce7a3` | Chore: refresh detect-secrets baseline | RESOLVED — timestamp conflict |
| `3b68d3fde` | Chore: refresh detect-secrets baseline after docs line changes | SKIPPED — fork has different doc line numbers |
| `c5bba6628` | Chore: refresh detect-secrets baseline after final scan | RESOLVED — line number + timestamp conflicts |
| `4c71176c9` | Chore: refresh detect-secrets baseline for Feishu docs | PICKED |
| `d4ab73174` | fix(telegram): use message previews in DMs | RESOLVED — CHANGELOG + telegram.mdx formatting/branding conflicts |
| `942520960` | fix(mattermost): pass payload.replyToId as root_id for threaded replies (#27744) | RESOLVED — CHANGELOG conflict |
| `67b2e8136` | Zalo: fix provider lifecycle restarts (#39892) | RESOLVED — monitor.ts lifecycle + plugin-sdk typing/branding conflicts |