### PR TITLE
Cherry-pick issue #918: changelogs, test fixtures, ACP and channel fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+### Breaking
+
 ### Fixes
 
 - macOS app/chat UI: route browser proxy through the local node browser service, preserve plain-text paste semantics, strip completed assistant trace/debug wrapper noise from transcripts, refresh permission state after returning from System Settings, and tolerate malformed cron rows in the macOS tab. (#39516) Thanks @Imhermes1.

--- a/docs.acp.md
+++ b/docs.acp.md
@@ -25,31 +25,41 @@ session with predictable session mapping and basic streaming updates.
 
 ## Compatibility Matrix
 
-| ACP area                                                              | Status      | Notes                                                                                                            |
-| --------------------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------- |
-| `initialize`, `newSession`, `prompt`, `cancel`                        | Implemented | Core bridge flow over stdio to Gateway chat/send + abort.                                                        |
-| `listSessions`, slash commands                                        | Implemented | Session list works against Gateway session state; commands are advertised via `available_commands_update`.       |
-| `loadSession`                                                         | Partial     | Rebinds the ACP session to a Gateway session key. Stored history is not replayed yet.                            |
-| Prompt content (`text`, embedded `resource`, images)                  | Partial     | Text/resources are flattened into chat input; images become Gateway attachments.                                 |
-| Session modes                                                         | Partial     | `session/set_mode` is supported, but this bridge does not yet expose broader ACP-native mode or config surfaces. |
-| Tool streaming                                                        | Partial     | Tool start and result updates are forwarded, but without ACP-native terminal or richer editor metadata.          |
-| Per-session MCP servers (`mcpServers`)                                | Unsupported | Bridge mode rejects per-session MCP server requests. Configure MCP on the OpenClaw gateway or agent instead.     |
-| Client filesystem methods (`fs/read_text_file`, `fs/write_text_file`) | Unsupported | The bridge does not call ACP client filesystem methods.                                                          |
-| Client terminal methods (`terminal/*`)                                | Unsupported | The bridge does not create ACP client terminals or stream terminal ids through tool calls.                       |
-| Session plans / thought streaming                                     | Unsupported | The bridge currently emits output text and tool status, not ACP plan or thought updates.                         |
+| ACP area                                                              | Status      | Notes                                                                                                                                                                                                                                            |
+| --------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `initialize`, `newSession`, `prompt`, `cancel`                        | Implemented | Core bridge flow over stdio to Gateway chat/send + abort.                                                                                                                                                                                        |
+| `listSessions`, slash commands                                        | Implemented | Session list works against Gateway session state; commands are advertised via `available_commands_update`.                                                                                                                                       |
+| `loadSession`                                                         | Partial     | Rebinds the ACP session to a Gateway session key and replays stored user/assistant text history. Tool/system history is not reconstructed yet.                                                                                                   |
+| Prompt content (`text`, embedded `resource`, images)                  | Partial     | Text/resources are flattened into chat input; images become Gateway attachments.                                                                                                                                                                 |
+| Session modes                                                         | Partial     | `session/set_mode` is supported and the bridge exposes initial Gateway-backed session controls for thought level, tool verbosity, reasoning, usage detail, and elevated actions. Broader ACP-native mode/config surfaces are still out of scope. |
+| Session info and usage updates                                        | Partial     | The bridge emits `session_info_update` and best-effort `usage_update` notifications from cached Gateway session snapshots. Usage is approximate and only sent when Gateway token totals are marked fresh.                                        |
+| Tool streaming                                                        | Partial     | Tool start and result updates are forwarded, but without richer editor metadata such as file locations or structured diff-native output.                                                                                                         |
+| Per-session MCP servers (`mcpServers`)                                | Unsupported | Bridge mode rejects per-session MCP server requests. Configure MCP on the OpenClaw gateway or agent instead.                                                                                                                                     |
+| Client filesystem methods (`fs/read_text_file`, `fs/write_text_file`) | Unsupported | The bridge does not call ACP client filesystem methods.                                                                                                                                                                                          |
+| Client terminal methods (`terminal/*`)                                | Unsupported | The bridge does not create ACP client terminals or stream terminal ids through tool calls.                                                                                                                                                       |
+| Session plans / thought streaming                                     | Unsupported | The bridge currently emits output text and tool status, not ACP plan or thought updates.                                                                                                                                                         |
 
 ## Known Limitations
 
-- `loadSession` rebinds to an existing Gateway session, but it does not replay
-  prior user or assistant history yet.
+- `loadSession` replays stored user and assistant text history, but it does not
+  reconstruct historic tool calls, system notices, or richer ACP-native event
+  types.
 - If multiple ACP clients share the same Gateway session key, event and cancel
   routing are best-effort rather than strictly isolated per client. Prefer the
   default isolated `acp:<uuid>` sessions when you need clean editor-local
   turns.
 - Gateway stop states are translated into ACP stop reasons, but that mapping is
   less expressive than a fully ACP-native runtime.
-- Tool follow-along data is intentionally narrow in bridge mode. The bridge
-  does not yet emit ACP terminals, file locations, or structured diffs.
+- Initial session controls currently surface a focused subset of Gateway knobs:
+  thought level, tool verbosity, reasoning, usage detail, and elevated
+  actions. Model selection and exec-host controls are not yet exposed as ACP
+  config options.
+- `session_info_update` and `usage_update` are derived from Gateway session
+  snapshots, not live ACP-native runtime accounting. Usage is approximate,
+  carries no cost data, and is only emitted when the Gateway marks total token
+  data as fresh.
+- Tool follow-along data is still intentionally narrow in bridge mode. The
+  bridge does not yet emit ACP terminals, file locations, or structured diffs.
 
 ## How can I use this
 
@@ -215,9 +225,11 @@ updates. Terminal Gateway states map to ACP `done` with stop reasons:
 
 ## Compatibility
 
-- ACP bridge uses `@agentclientprotocol/sdk` (currently 0.13.x).
+- ACP bridge uses `@agentclientprotocol/sdk` (currently 0.15.x).
 - Works with ACP clients that implement `initialize`, `newSession`,
   `loadSession`, `prompt`, `cancel`, and `listSessions`.
+- Bridge mode rejects per-session `mcpServers` instead of silently ignoring
+  them. Configure MCP at the Gateway or agent layer.
 
 ## Testing
 

--- a/docs.acp.md
+++ b/docs.acp.md
@@ -33,7 +33,7 @@ session with predictable session mapping and basic streaming updates.
 | Prompt content (`text`, embedded `resource`, images)                  | Partial     | Text/resources are flattened into chat input; images become Gateway attachments.                                                                                                                                                                 |
 | Session modes                                                         | Partial     | `session/set_mode` is supported and the bridge exposes initial Gateway-backed session controls for thought level, tool verbosity, reasoning, usage detail, and elevated actions. Broader ACP-native mode/config surfaces are still out of scope. |
 | Session info and usage updates                                        | Partial     | The bridge emits `session_info_update` and best-effort `usage_update` notifications from cached Gateway session snapshots. Usage is approximate and only sent when Gateway token totals are marked fresh.                                        |
-| Tool streaming                                                        | Partial     | Tool start and result updates are forwarded, but without richer editor metadata such as file locations or structured diff-native output.                                                                                                         |
+| Tool streaming                                                        | Partial     | `tool_call` / `tool_call_update` events include raw I/O, text content, and best-effort file locations when Gateway tool args/results expose them. Embedded terminals and richer diff-native output are still not exposed.                        |
 | Per-session MCP servers (`mcpServers`)                                | Unsupported | Bridge mode rejects per-session MCP server requests. Configure MCP on the OpenClaw gateway or agent instead.                                                                                                                                     |
 | Client filesystem methods (`fs/read_text_file`, `fs/write_text_file`) | Unsupported | The bridge does not call ACP client filesystem methods.                                                                                                                                                                                          |
 | Client terminal methods (`terminal/*`)                                | Unsupported | The bridge does not create ACP client terminals or stream terminal ids through tool calls.                                                                                                                                                       |
@@ -58,8 +58,9 @@ session with predictable session mapping and basic streaming updates.
   snapshots, not live ACP-native runtime accounting. Usage is approximate,
   carries no cost data, and is only emitted when the Gateway marks total token
   data as fresh.
-- Tool follow-along data is still intentionally narrow in bridge mode. The
-  bridge does not yet emit ACP terminals, file locations, or structured diffs.
+- Tool follow-along data is best-effort. The bridge can surface file paths that
+  appear in known tool args/results, but it does not yet emit ACP terminals or
+  structured file diffs.
 
 ## How can I use this
 

--- a/docs.acp.md
+++ b/docs.acp.md
@@ -17,6 +17,40 @@ Key goals:
 - Works with existing Gateway session store (list/resolve/reset).
 - Safe defaults (isolated ACP session keys by default).
 
+## Bridge Scope
+
+`openclaw acp` is a Gateway-backed ACP bridge, not a full ACP-native editor
+runtime. It is designed to route IDE prompts into an existing OpenClaw Gateway
+session with predictable session mapping and basic streaming updates.
+
+## Compatibility Matrix
+
+| ACP area                                                              | Status      | Notes                                                                                                            |
+| --------------------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------- |
+| `initialize`, `newSession`, `prompt`, `cancel`                        | Implemented | Core bridge flow over stdio to Gateway chat/send + abort.                                                        |
+| `listSessions`, slash commands                                        | Implemented | Session list works against Gateway session state; commands are advertised via `available_commands_update`.       |
+| `loadSession`                                                         | Partial     | Rebinds the ACP session to a Gateway session key. Stored history is not replayed yet.                            |
+| Prompt content (`text`, embedded `resource`, images)                  | Partial     | Text/resources are flattened into chat input; images become Gateway attachments.                                 |
+| Session modes                                                         | Partial     | `session/set_mode` is supported, but this bridge does not yet expose broader ACP-native mode or config surfaces. |
+| Tool streaming                                                        | Partial     | Tool start and result updates are forwarded, but without ACP-native terminal or richer editor metadata.          |
+| Per-session MCP servers (`mcpServers`)                                | Unsupported | Bridge mode rejects per-session MCP server requests. Configure MCP on the OpenClaw gateway or agent instead.     |
+| Client filesystem methods (`fs/read_text_file`, `fs/write_text_file`) | Unsupported | The bridge does not call ACP client filesystem methods.                                                          |
+| Client terminal methods (`terminal/*`)                                | Unsupported | The bridge does not create ACP client terminals or stream terminal ids through tool calls.                       |
+| Session plans / thought streaming                                     | Unsupported | The bridge currently emits output text and tool status, not ACP plan or thought updates.                         |
+
+## Known Limitations
+
+- `loadSession` rebinds to an existing Gateway session, but it does not replay
+  prior user or assistant history yet.
+- If multiple ACP clients share the same Gateway session key, event and cancel
+  routing are best-effort rather than strictly isolated per client. Prefer the
+  default isolated `acp:<uuid>` sessions when you need clean editor-local
+  turns.
+- Gateway stop states are translated into ACP stop reasons, but that mapping is
+  less expressive than a fully ACP-native runtime.
+- Tool follow-along data is intentionally narrow in bridge mode. The bridge
+  does not yet emit ACP terminals, file locations, or structured diffs.
+
 ## How can I use this
 
 Use ACP when an IDE or tooling speaks Agent Client Protocol and you want it to

--- a/docs/cli/acp.md
+++ b/docs/cli/acp.md
@@ -13,6 +13,38 @@ Run the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) bridge t
 This command speaks ACP over stdio for IDEs and forwards prompts to the Gateway
 over WebSocket. It keeps ACP sessions mapped to Gateway session keys.
 
+`openclaw acp` is a Gateway-backed ACP bridge, not a full ACP-native editor
+runtime. It focuses on session routing, prompt delivery, and basic streaming
+updates.
+
+## Compatibility Matrix
+
+| ACP area                                                              | Status      | Notes                                                                                                            |
+| --------------------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------- |
+| `initialize`, `newSession`, `prompt`, `cancel`                        | Implemented | Core bridge flow over stdio to Gateway chat/send + abort.                                                        |
+| `listSessions`, slash commands                                        | Implemented | Session list works against Gateway session state; commands are advertised via `available_commands_update`.       |
+| `loadSession`                                                         | Partial     | Rebinds the ACP session to a Gateway session key. Stored history is not replayed yet.                            |
+| Prompt content (`text`, embedded `resource`, images)                  | Partial     | Text/resources are flattened into chat input; images become Gateway attachments.                                 |
+| Session modes                                                         | Partial     | `session/set_mode` is supported, but this bridge does not yet expose broader ACP-native mode or config surfaces. |
+| Tool streaming                                                        | Partial     | Tool start and result updates are forwarded, but without ACP-native terminal or richer editor metadata.          |
+| Per-session MCP servers (`mcpServers`)                                | Unsupported | Bridge mode rejects per-session MCP server requests. Configure MCP on the OpenClaw gateway or agent instead.     |
+| Client filesystem methods (`fs/read_text_file`, `fs/write_text_file`) | Unsupported | The bridge does not call ACP client filesystem methods.                                                          |
+| Client terminal methods (`terminal/*`)                                | Unsupported | The bridge does not create ACP client terminals or stream terminal ids through tool calls.                       |
+| Session plans / thought streaming                                     | Unsupported | The bridge currently emits output text and tool status, not ACP plan or thought updates.                         |
+
+## Known Limitations
+
+- `loadSession` rebinds to an existing Gateway session, but it does not replay
+  prior user or assistant history yet.
+- If multiple ACP clients share the same Gateway session key, event and cancel
+  routing are best-effort rather than strictly isolated per client. Prefer the
+  default isolated `acp:<uuid>` sessions when you need clean editor-local
+  turns.
+- Gateway stop states are translated into ACP stop reasons, but that mapping is
+  less expressive than a fully ACP-native runtime.
+- Tool follow-along data is intentionally narrow in bridge mode. The bridge
+  does not yet emit ACP terminals, file locations, or structured diffs.
+
 ## Usage
 
 ```bash

--- a/docs/cli/acp.md
+++ b/docs/cli/acp.md
@@ -27,7 +27,7 @@ updates.
 | Prompt content (`text`, embedded `resource`, images)                  | Partial     | Text/resources are flattened into chat input; images become Gateway attachments.                                                                                                                                                                 |
 | Session modes                                                         | Partial     | `session/set_mode` is supported and the bridge exposes initial Gateway-backed session controls for thought level, tool verbosity, reasoning, usage detail, and elevated actions. Broader ACP-native mode/config surfaces are still out of scope. |
 | Session info and usage updates                                        | Partial     | The bridge emits `session_info_update` and best-effort `usage_update` notifications from cached Gateway session snapshots. Usage is approximate and only sent when Gateway token totals are marked fresh.                                        |
-| Tool streaming                                                        | Partial     | Tool start and result updates are forwarded, but without richer editor metadata such as file locations or structured diff-native output.                                                                                                         |
+| Tool streaming                                                        | Partial     | `tool_call` / `tool_call_update` events include raw I/O, text content, and best-effort file locations when Gateway tool args/results expose them. Embedded terminals and richer diff-native output are still not exposed.                        |
 | Per-session MCP servers (`mcpServers`)                                | Unsupported | Bridge mode rejects per-session MCP server requests. Configure MCP on the OpenClaw gateway or agent instead.                                                                                                                                     |
 | Client filesystem methods (`fs/read_text_file`, `fs/write_text_file`) | Unsupported | The bridge does not call ACP client filesystem methods.                                                                                                                                                                                          |
 | Client terminal methods (`terminal/*`)                                | Unsupported | The bridge does not create ACP client terminals or stream terminal ids through tool calls.                                                                                                                                                       |
@@ -52,8 +52,9 @@ updates.
   snapshots, not live ACP-native runtime accounting. Usage is approximate,
   carries no cost data, and is only emitted when the Gateway marks total token
   data as fresh.
-- Tool follow-along data is still intentionally narrow in bridge mode. The
-  bridge does not yet emit ACP terminals, file locations, or structured diffs.
+- Tool follow-along data is best-effort. The bridge can surface file paths that
+  appear in known tool args/results, but it does not yet emit ACP terminals or
+  structured file diffs.
 
 ## Usage
 

--- a/docs/cli/acp.md
+++ b/docs/cli/acp.md
@@ -19,31 +19,41 @@ updates.
 
 ## Compatibility Matrix
 
-| ACP area                                                              | Status      | Notes                                                                                                            |
-| --------------------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------- |
-| `initialize`, `newSession`, `prompt`, `cancel`                        | Implemented | Core bridge flow over stdio to Gateway chat/send + abort.                                                        |
-| `listSessions`, slash commands                                        | Implemented | Session list works against Gateway session state; commands are advertised via `available_commands_update`.       |
-| `loadSession`                                                         | Partial     | Rebinds the ACP session to a Gateway session key. Stored history is not replayed yet.                            |
-| Prompt content (`text`, embedded `resource`, images)                  | Partial     | Text/resources are flattened into chat input; images become Gateway attachments.                                 |
-| Session modes                                                         | Partial     | `session/set_mode` is supported, but this bridge does not yet expose broader ACP-native mode or config surfaces. |
-| Tool streaming                                                        | Partial     | Tool start and result updates are forwarded, but without ACP-native terminal or richer editor metadata.          |
-| Per-session MCP servers (`mcpServers`)                                | Unsupported | Bridge mode rejects per-session MCP server requests. Configure MCP on the OpenClaw gateway or agent instead.     |
-| Client filesystem methods (`fs/read_text_file`, `fs/write_text_file`) | Unsupported | The bridge does not call ACP client filesystem methods.                                                          |
-| Client terminal methods (`terminal/*`)                                | Unsupported | The bridge does not create ACP client terminals or stream terminal ids through tool calls.                       |
-| Session plans / thought streaming                                     | Unsupported | The bridge currently emits output text and tool status, not ACP plan or thought updates.                         |
+| ACP area                                                              | Status      | Notes                                                                                                                                                                                                                                            |
+| --------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `initialize`, `newSession`, `prompt`, `cancel`                        | Implemented | Core bridge flow over stdio to Gateway chat/send + abort.                                                                                                                                                                                        |
+| `listSessions`, slash commands                                        | Implemented | Session list works against Gateway session state; commands are advertised via `available_commands_update`.                                                                                                                                       |
+| `loadSession`                                                         | Partial     | Rebinds the ACP session to a Gateway session key and replays stored user/assistant text history. Tool/system history is not reconstructed yet.                                                                                                   |
+| Prompt content (`text`, embedded `resource`, images)                  | Partial     | Text/resources are flattened into chat input; images become Gateway attachments.                                                                                                                                                                 |
+| Session modes                                                         | Partial     | `session/set_mode` is supported and the bridge exposes initial Gateway-backed session controls for thought level, tool verbosity, reasoning, usage detail, and elevated actions. Broader ACP-native mode/config surfaces are still out of scope. |
+| Session info and usage updates                                        | Partial     | The bridge emits `session_info_update` and best-effort `usage_update` notifications from cached Gateway session snapshots. Usage is approximate and only sent when Gateway token totals are marked fresh.                                        |
+| Tool streaming                                                        | Partial     | Tool start and result updates are forwarded, but without richer editor metadata such as file locations or structured diff-native output.                                                                                                         |
+| Per-session MCP servers (`mcpServers`)                                | Unsupported | Bridge mode rejects per-session MCP server requests. Configure MCP on the OpenClaw gateway or agent instead.                                                                                                                                     |
+| Client filesystem methods (`fs/read_text_file`, `fs/write_text_file`) | Unsupported | The bridge does not call ACP client filesystem methods.                                                                                                                                                                                          |
+| Client terminal methods (`terminal/*`)                                | Unsupported | The bridge does not create ACP client terminals or stream terminal ids through tool calls.                                                                                                                                                       |
+| Session plans / thought streaming                                     | Unsupported | The bridge currently emits output text and tool status, not ACP plan or thought updates.                                                                                                                                                         |
 
 ## Known Limitations
 
-- `loadSession` rebinds to an existing Gateway session, but it does not replay
-  prior user or assistant history yet.
+- `loadSession` replays stored user and assistant text history, but it does not
+  reconstruct historic tool calls, system notices, or richer ACP-native event
+  types.
 - If multiple ACP clients share the same Gateway session key, event and cancel
   routing are best-effort rather than strictly isolated per client. Prefer the
   default isolated `acp:<uuid>` sessions when you need clean editor-local
   turns.
 - Gateway stop states are translated into ACP stop reasons, but that mapping is
   less expressive than a fully ACP-native runtime.
-- Tool follow-along data is intentionally narrow in bridge mode. The bridge
-  does not yet emit ACP terminals, file locations, or structured diffs.
+- Initial session controls currently surface a focused subset of Gateway knobs:
+  thought level, tool verbosity, reasoning, usage detail, and elevated
+  actions. Model selection and exec-host controls are not yet exposed as ACP
+  config options.
+- `session_info_update` and `usage_update` are derived from Gateway session
+  snapshots, not live ACP-native runtime accounting. Usage is approximate,
+  carries no cost data, and is only emitted when the Gateway marks total token
+  data as fresh.
+- Tool follow-along data is still intentionally narrow in bridge mode. The
+  bridge does not yet emit ACP terminals, file locations, or structured diffs.
 
 ## Usage
 
@@ -127,6 +137,10 @@ remoteclaw acp --session agent:qa:bug-123
 Each ACP session maps to a single Gateway session key. One agent can have many
 sessions; ACP defaults to an isolated `acp:<uuid>` session unless you override
 the key or label.
+
+Per-session `mcpServers` are not supported in bridge mode. If an ACP client
+sends them during `newSession` or `loadSession`, the bridge returns a clear
+error instead of silently ignoring them.
 
 ## Use from `acpx` (Codex, Claude, other ACP clients)
 

--- a/src/acp/event-mapper.test.ts
+++ b/src/acp/event-mapper.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { extractToolCallLocations } from "./event-mapper.js";
+
+describe("extractToolCallLocations", () => {
+  it("enforces the global node visit cap across nested structures", () => {
+    const nested = Array.from({ length: 20 }, (_, outer) =>
+      Array.from({ length: 20 }, (_, inner) =>
+        inner === 19 ? { path: `/tmp/file-${outer}.txt` } : { note: `${outer}-${inner}` },
+      ),
+    );
+
+    const locations = extractToolCallLocations(nested);
+
+    expect(locations).toBeDefined();
+    expect(locations?.length).toBeLessThan(20);
+    expect(locations).not.toContainEqual({ path: "/tmp/file-19.txt" });
+  });
+});

--- a/src/acp/event-mapper.ts
+++ b/src/acp/event-mapper.ts
@@ -186,9 +186,10 @@ function collectLocationsFromTextMarkers(
 function collectToolLocations(
   value: unknown,
   locations: Map<string, ToolCallLocation>,
-  state: { visited: number; depth: number },
+  state: { visited: number },
+  depth: number,
 ): void {
-  if (state.visited >= TOOL_LOCATION_MAX_NODES || state.depth > TOOL_LOCATION_MAX_DEPTH) {
+  if (state.visited >= TOOL_LOCATION_MAX_NODES || depth > TOOL_LOCATION_MAX_DEPTH) {
     return;
   }
   state.visited += 1;
@@ -202,8 +203,7 @@ function collectToolLocations(
   }
   if (Array.isArray(value)) {
     for (const item of value) {
-      collectToolLocations(item, locations, { visited: state.visited, depth: state.depth + 1 });
-      state.visited += 1;
+      collectToolLocations(item, locations, state, depth + 1);
       if (state.visited >= TOOL_LOCATION_MAX_NODES) {
         return;
       }
@@ -230,9 +230,11 @@ function collectToolLocations(
     }
   }
 
-  for (const nested of Object.values(record)) {
-    collectToolLocations(nested, locations, { visited: state.visited, depth: state.depth + 1 });
-    state.visited += 1;
+  for (const [key, nested] of Object.entries(record)) {
+    if (key === "content") {
+      continue;
+    }
+    collectToolLocations(nested, locations, state, depth + 1);
     if (state.visited >= TOOL_LOCATION_MAX_NODES) {
       return;
     }
@@ -402,7 +404,7 @@ export function extractToolCallContent(value: unknown): ToolCallContent[] | unde
 export function extractToolCallLocations(...values: unknown[]): ToolCallLocation[] | undefined {
   const locations = new Map<string, ToolCallLocation>();
   for (const value of values) {
-    collectToolLocations(value, locations, { visited: 0, depth: 0 });
+    collectToolLocations(value, locations, { visited: 0 }, 0);
   }
   return locations.size > 0 ? [...locations.values()] : undefined;
 }

--- a/src/acp/event-mapper.ts
+++ b/src/acp/event-mapper.ts
@@ -1,10 +1,49 @@
-import type { ContentBlock, ImageContent, ToolKind } from "@agentclientprotocol/sdk";
+import type {
+  ContentBlock,
+  ImageContent,
+  ToolCallContent,
+  ToolCallLocation,
+  ToolKind,
+} from "@agentclientprotocol/sdk";
 
 export type GatewayAttachment = {
   type: string;
   mimeType: string;
   content: string;
 };
+
+const TOOL_LOCATION_PATH_KEYS = [
+  "path",
+  "filePath",
+  "file_path",
+  "targetPath",
+  "target_path",
+  "targetFile",
+  "target_file",
+  "sourcePath",
+  "source_path",
+  "destinationPath",
+  "destination_path",
+  "oldPath",
+  "old_path",
+  "newPath",
+  "new_path",
+  "outputPath",
+  "output_path",
+  "inputPath",
+  "input_path",
+] as const;
+
+const TOOL_LOCATION_LINE_KEYS = [
+  "line",
+  "lineNumber",
+  "line_number",
+  "startLine",
+  "start_line",
+] as const;
+const TOOL_RESULT_PATH_MARKER_RE = /^(?:FILE|MEDIA):(.+)$/gm;
+const TOOL_LOCATION_MAX_DEPTH = 4;
+const TOOL_LOCATION_MAX_NODES = 100;
 
 const INLINE_CONTROL_ESCAPE_MAP: Readonly<Record<string, string>> = {
   "\0": "\\0",
@@ -54,6 +93,150 @@ function escapeInlineControlChars(value: string): string {
 function escapeResourceTitle(value: string): string {
   // Keep title content, but escape characters that can break the resource-link annotation shape.
   return escapeInlineControlChars(value).replace(/[()[\]]/g, (char) => `\\${char}`);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function normalizeToolLocationPath(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (
+    !trimmed ||
+    trimmed.length > 4096 ||
+    trimmed.includes("\u0000") ||
+    trimmed.includes("\r") ||
+    trimmed.includes("\n")
+  ) {
+    return undefined;
+  }
+  if (/^https?:\/\//i.test(trimmed)) {
+    return undefined;
+  }
+  if (/^file:\/\//i.test(trimmed)) {
+    try {
+      const parsed = new URL(trimmed);
+      return decodeURIComponent(parsed.pathname || "") || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return trimmed;
+}
+
+function normalizeToolLocationLine(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  const line = Math.floor(value);
+  return line > 0 ? line : undefined;
+}
+
+function extractToolLocationLine(record: Record<string, unknown>): number | undefined {
+  for (const key of TOOL_LOCATION_LINE_KEYS) {
+    const line = normalizeToolLocationLine(record[key]);
+    if (line !== undefined) {
+      return line;
+    }
+  }
+  return undefined;
+}
+
+function addToolLocation(
+  locations: Map<string, ToolCallLocation>,
+  rawPath: string,
+  line?: number,
+): void {
+  const path = normalizeToolLocationPath(rawPath);
+  if (!path) {
+    return;
+  }
+  for (const [existingKey, existing] of locations.entries()) {
+    if (existing.path !== path) {
+      continue;
+    }
+    if (line === undefined || existing.line === line) {
+      return;
+    }
+    if (existing.line === undefined) {
+      locations.delete(existingKey);
+    }
+  }
+  const locationKey = `${path}:${line ?? ""}`;
+  if (locations.has(locationKey)) {
+    return;
+  }
+  locations.set(locationKey, line ? { path, line } : { path });
+}
+
+function collectLocationsFromTextMarkers(
+  text: string,
+  locations: Map<string, ToolCallLocation>,
+): void {
+  for (const match of text.matchAll(TOOL_RESULT_PATH_MARKER_RE)) {
+    const candidate = match[1]?.trim();
+    if (candidate) {
+      addToolLocation(locations, candidate);
+    }
+  }
+}
+
+function collectToolLocations(
+  value: unknown,
+  locations: Map<string, ToolCallLocation>,
+  state: { visited: number; depth: number },
+): void {
+  if (state.visited >= TOOL_LOCATION_MAX_NODES || state.depth > TOOL_LOCATION_MAX_DEPTH) {
+    return;
+  }
+  state.visited += 1;
+
+  if (typeof value === "string") {
+    collectLocationsFromTextMarkers(value, locations);
+    return;
+  }
+  if (!value || typeof value !== "object") {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectToolLocations(item, locations, { visited: state.visited, depth: state.depth + 1 });
+      state.visited += 1;
+      if (state.visited >= TOOL_LOCATION_MAX_NODES) {
+        return;
+      }
+    }
+    return;
+  }
+
+  const record = value as Record<string, unknown>;
+  const line = extractToolLocationLine(record);
+  for (const key of TOOL_LOCATION_PATH_KEYS) {
+    const rawPath = record[key];
+    if (typeof rawPath === "string") {
+      addToolLocation(locations, rawPath, line);
+    }
+  }
+
+  const content = Array.isArray(record.content) ? record.content : undefined;
+  if (content) {
+    for (const block of content) {
+      const entry = asRecord(block);
+      if (entry?.type === "text" && typeof entry.text === "string") {
+        collectLocationsFromTextMarkers(entry.text, locations);
+      }
+    }
+  }
+
+  for (const nested of Object.values(record)) {
+    collectToolLocations(nested, locations, { visited: state.visited, depth: state.depth + 1 });
+    state.visited += 1;
+    if (state.visited >= TOOL_LOCATION_MAX_NODES) {
+      return;
+    }
+  }
 }
 
 export function extractTextFromPrompt(prompt: ContentBlock[], maxBytes?: number): string {
@@ -151,4 +334,75 @@ export function inferToolKind(name?: string): ToolKind {
     return "fetch";
   }
   return "other";
+}
+
+export function extractToolCallContent(value: unknown): ToolCallContent[] | undefined {
+  if (typeof value === "string") {
+    return value.trim()
+      ? [
+          {
+            type: "content",
+            content: {
+              type: "text",
+              text: value,
+            },
+          },
+        ]
+      : undefined;
+  }
+
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  const contents: ToolCallContent[] = [];
+  const blocks = Array.isArray(record.content) ? record.content : [];
+  for (const block of blocks) {
+    const entry = asRecord(block);
+    if (entry?.type === "text" && typeof entry.text === "string" && entry.text.trim()) {
+      contents.push({
+        type: "content",
+        content: {
+          type: "text",
+          text: entry.text,
+        },
+      });
+    }
+  }
+
+  if (contents.length > 0) {
+    return contents;
+  }
+
+  const fallbackText =
+    typeof record.text === "string"
+      ? record.text
+      : typeof record.message === "string"
+        ? record.message
+        : typeof record.error === "string"
+          ? record.error
+          : undefined;
+
+  if (!fallbackText?.trim()) {
+    return undefined;
+  }
+
+  return [
+    {
+      type: "content",
+      content: {
+        type: "text",
+        text: fallbackText,
+      },
+    },
+  ];
+}
+
+export function extractToolCallLocations(...values: unknown[]): ToolCallLocation[] | undefined {
+  const locations = new Map<string, ToolCallLocation>();
+  for (const value of values) {
+    collectToolLocations(value, locations, { visited: 0, depth: 0 });
+  }
+  return locations.size > 0 ? [...locations.values()] : undefined;
 }

--- a/src/acp/translator.session-rate-limit.test.ts
+++ b/src/acp/translator.session-rate-limit.test.ts
@@ -2,6 +2,7 @@ import type {
   LoadSessionRequest,
   NewSessionRequest,
   PromptRequest,
+  SetSessionModeRequest,
 } from "@agentclientprotocol/sdk";
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "../gateway/client.js";
@@ -36,6 +37,14 @@ function createPromptRequest(
     prompt: [{ type: "text", text }],
     _meta: meta,
   } as unknown as PromptRequest;
+}
+
+function createSetSessionModeRequest(sessionId: string, modeId: string): SetSessionModeRequest {
+  return {
+    sessionId,
+    modeId,
+    _meta: {},
+  } as unknown as SetSessionModeRequest;
 }
 
 async function expectOversizedPromptRejected(params: { sessionId: string; text: string }) {
@@ -92,6 +101,71 @@ describe("acp session creation rate limit", () => {
     await expect(agent.loadSession(createLoadSessionRequest("new-session"))).rejects.toThrow(
       /session creation rate limit exceeded/i,
     );
+
+    sessionStore.clearAllSessionsForTest();
+  });
+});
+
+describe("acp unsupported bridge session setup", () => {
+  it("rejects per-session MCP servers on newSession", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = vi.spyOn(connection, "sessionUpdate");
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(), {
+      sessionStore,
+    });
+
+    await expect(
+      agent.newSession({
+        ...createNewSessionRequest(),
+        mcpServers: [{ name: "docs", command: "mcp-docs" }] as never[],
+      }),
+    ).rejects.toThrow(/does not support per-session MCP servers/i);
+
+    expect(sessionStore.hasSession("docs-session")).toBe(false);
+    expect(sessionUpdate).not.toHaveBeenCalled();
+    sessionStore.clearAllSessionsForTest();
+  });
+
+  it("rejects per-session MCP servers on loadSession", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = vi.spyOn(connection, "sessionUpdate");
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(), {
+      sessionStore,
+    });
+
+    await expect(
+      agent.loadSession({
+        ...createLoadSessionRequest("docs-session"),
+        mcpServers: [{ name: "docs", command: "mcp-docs" }] as never[],
+      }),
+    ).rejects.toThrow(/does not support per-session MCP servers/i);
+
+    expect(sessionStore.hasSession("docs-session")).toBe(false);
+    expect(sessionUpdate).not.toHaveBeenCalled();
+    sessionStore.clearAllSessionsForTest();
+  });
+});
+
+describe("acp setSessionMode bridge behavior", () => {
+  it("surfaces gateway mode patch failures instead of succeeding silently", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.patch") {
+        throw new Error("gateway rejected mode");
+      }
+      return { ok: true };
+    }) as GatewayClient["request"];
+    const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+      sessionStore,
+    });
+
+    await agent.loadSession(createLoadSessionRequest("mode-session"));
+
+    await expect(
+      agent.setSessionMode(createSetSessionModeRequest("mode-session", "high")),
+    ).rejects.toThrow(/gateway rejected mode/i);
 
     sessionStore.clearAllSessionsForTest();
   });

--- a/src/acp/translator.session-rate-limit.test.ts
+++ b/src/acp/translator.session-rate-limit.test.ts
@@ -62,6 +62,34 @@ function createSetSessionConfigOptionRequest(
   } as unknown as SetSessionConfigOptionRequest;
 }
 
+function createToolEvent(params: {
+  sessionKey: string;
+  phase: "start" | "update" | "result";
+  toolCallId: string;
+  name: string;
+  args?: Record<string, unknown>;
+  partialResult?: unknown;
+  result?: unknown;
+  isError?: boolean;
+}): EventFrame {
+  return {
+    event: "agent",
+    payload: {
+      sessionKey: params.sessionKey,
+      stream: "tool",
+      data: {
+        phase: params.phase,
+        toolCallId: params.toolCallId,
+        name: params.name,
+        args: params.args,
+        partialResult: params.partialResult,
+        result: params.result,
+        isError: params.isError,
+      },
+    },
+  } as unknown as EventFrame;
+}
+
 function createChatFinalEvent(sessionKey: string): EventFrame {
   return {
     event: "chat",
@@ -554,6 +582,117 @@ describe("acp setSessionConfigOption bridge behavior", () => {
             currentValue: "stream",
           }),
         ]),
+      },
+    });
+
+    sessionStore.clearAllSessionsForTest();
+  });
+});
+
+describe("acp tool streaming bridge behavior", () => {
+  it("maps Gateway tool partial output and file locations into ACP tool updates", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = connection.__sessionUpdateMock;
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        return new Promise(() => {});
+      }
+      return { ok: true };
+    }) as GatewayClient["request"];
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+      sessionStore,
+    });
+
+    await agent.loadSession(createLoadSessionRequest("tool-session"));
+    sessionUpdate.mockClear();
+
+    const promptPromise = agent.prompt(createPromptRequest("tool-session", "Inspect app.ts"));
+
+    await agent.handleGatewayEvent(
+      createToolEvent({
+        sessionKey: "tool-session",
+        phase: "start",
+        toolCallId: "tool-1",
+        name: "read",
+        args: { path: "src/app.ts", line: 12 },
+      }),
+    );
+    await agent.handleGatewayEvent(
+      createToolEvent({
+        sessionKey: "tool-session",
+        phase: "update",
+        toolCallId: "tool-1",
+        name: "read",
+        partialResult: {
+          content: [{ type: "text", text: "partial output" }],
+          details: { path: "src/app.ts" },
+        },
+      }),
+    );
+    await agent.handleGatewayEvent(
+      createToolEvent({
+        sessionKey: "tool-session",
+        phase: "result",
+        toolCallId: "tool-1",
+        name: "read",
+        result: {
+          content: [{ type: "text", text: "FILE:src/app.ts" }],
+          details: { path: "src/app.ts" },
+        },
+      }),
+    );
+    await agent.handleGatewayEvent(createChatFinalEvent("tool-session"));
+    await promptPromise;
+
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "tool-session",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tool-1",
+        title: "read: path: src/app.ts, line: 12",
+        status: "in_progress",
+        rawInput: { path: "src/app.ts", line: 12 },
+        kind: "read",
+        locations: [{ path: "src/app.ts", line: 12 }],
+      },
+    });
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "tool-session",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-1",
+        status: "in_progress",
+        rawOutput: {
+          content: [{ type: "text", text: "partial output" }],
+          details: { path: "src/app.ts" },
+        },
+        content: [
+          {
+            type: "content",
+            content: { type: "text", text: "partial output" },
+          },
+        ],
+        locations: [{ path: "src/app.ts", line: 12 }],
+      },
+    });
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "tool-session",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-1",
+        status: "completed",
+        rawOutput: {
+          content: [{ type: "text", text: "FILE:src/app.ts" }],
+          details: { path: "src/app.ts" },
+        },
+        content: [
+          {
+            type: "content",
+            content: { type: "text", text: "FILE:src/app.ts" },
+          },
+        ],
+        locations: [{ path: "src/app.ts", line: 12 }],
       },
     });
 

--- a/src/acp/translator.session-rate-limit.test.ts
+++ b/src/acp/translator.session-rate-limit.test.ts
@@ -2,10 +2,12 @@ import type {
   LoadSessionRequest,
   NewSessionRequest,
   PromptRequest,
+  SetSessionConfigOptionRequest,
   SetSessionModeRequest,
 } from "@agentclientprotocol/sdk";
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "../gateway/client.js";
+import type { EventFrame } from "../gateway/protocol/index.js";
 import { createInMemorySessionStore } from "./session.js";
 import { AcpGatewayAgent } from "./translator.js";
 import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
@@ -45,6 +47,29 @@ function createSetSessionModeRequest(sessionId: string, modeId: string): SetSess
     modeId,
     _meta: {},
   } as unknown as SetSessionModeRequest;
+}
+
+function createSetSessionConfigOptionRequest(
+  sessionId: string,
+  configId: string,
+  value: string,
+): SetSessionConfigOptionRequest {
+  return {
+    sessionId,
+    configId,
+    value,
+    _meta: {},
+  } as unknown as SetSessionConfigOptionRequest;
+}
+
+function createChatFinalEvent(sessionKey: string): EventFrame {
+  return {
+    event: "chat",
+    payload: {
+      sessionKey,
+      state: "final",
+    },
+  } as unknown as EventFrame;
 }
 
 async function expectOversizedPromptRejected(params: { sessionId: string; text: string }) {
@@ -110,7 +135,7 @@ describe("acp unsupported bridge session setup", () => {
   it("rejects per-session MCP servers on newSession", async () => {
     const sessionStore = createInMemorySessionStore();
     const connection = createAcpConnection();
-    const sessionUpdate = vi.spyOn(connection, "sessionUpdate");
+    const sessionUpdate = connection.__sessionUpdateMock;
     const agent = new AcpGatewayAgent(connection, createAcpGateway(), {
       sessionStore,
     });
@@ -130,7 +155,7 @@ describe("acp unsupported bridge session setup", () => {
   it("rejects per-session MCP servers on loadSession", async () => {
     const sessionStore = createInMemorySessionStore();
     const connection = createAcpConnection();
-    const sessionUpdate = vi.spyOn(connection, "sessionUpdate");
+    const sessionUpdate = connection.__sessionUpdateMock;
     const agent = new AcpGatewayAgent(connection, createAcpGateway(), {
       sessionStore,
     });
@@ -144,6 +169,172 @@ describe("acp unsupported bridge session setup", () => {
 
     expect(sessionStore.hasSession("docs-session")).toBe(false);
     expect(sessionUpdate).not.toHaveBeenCalled();
+    sessionStore.clearAllSessionsForTest();
+  });
+});
+
+describe("acp session UX bridge behavior", () => {
+  it("returns initial modes and thought-level config options for new sessions", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(), {
+      sessionStore,
+    });
+
+    const result = await agent.newSession(createNewSessionRequest());
+
+    expect(result.modes?.currentModeId).toBe("adaptive");
+    expect(result.modes?.availableModes.map((mode) => mode.id)).toContain("adaptive");
+    expect(result.configOptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "thought_level",
+          currentValue: "adaptive",
+          category: "thought_level",
+        }),
+        expect.objectContaining({
+          id: "verbose_level",
+          currentValue: "off",
+        }),
+        expect.objectContaining({
+          id: "reasoning_level",
+          currentValue: "off",
+        }),
+        expect.objectContaining({
+          id: "response_usage",
+          currentValue: "off",
+        }),
+        expect.objectContaining({
+          id: "elevated_level",
+          currentValue: "off",
+        }),
+      ]),
+    );
+
+    sessionStore.clearAllSessionsForTest();
+  });
+
+  it("replays user and assistant text history on loadSession and returns initial controls", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = connection.__sessionUpdateMock;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          ts: Date.now(),
+          path: "/tmp/sessions.json",
+          count: 1,
+          defaults: {
+            modelProvider: null,
+            model: null,
+            contextTokens: null,
+          },
+          sessions: [
+            {
+              key: "agent:main:work",
+              label: "main-work",
+              displayName: "Main work",
+              derivedTitle: "Fix ACP bridge",
+              kind: "direct",
+              updatedAt: 1_710_000_000_000,
+              thinkingLevel: "high",
+              modelProvider: "openai",
+              model: "gpt-5.4",
+              verboseLevel: "full",
+              reasoningLevel: "stream",
+              responseUsage: "tokens",
+              elevatedLevel: "ask",
+              totalTokens: 4096,
+              totalTokensFresh: true,
+              contextTokens: 8192,
+            },
+          ],
+        };
+      }
+      if (method === "sessions.get") {
+        return {
+          messages: [
+            { role: "user", content: [{ type: "text", text: "Question" }] },
+            { role: "assistant", content: [{ type: "text", text: "Answer" }] },
+            { role: "system", content: [{ type: "text", text: "ignore me" }] },
+            { role: "assistant", content: [{ type: "image", image: "skip" }] },
+          ],
+        };
+      }
+      return { ok: true };
+    }) as GatewayClient["request"];
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+      sessionStore,
+    });
+
+    const result = await agent.loadSession(createLoadSessionRequest("agent:main:work"));
+
+    expect(result.modes?.currentModeId).toBe("high");
+    expect(result.modes?.availableModes.map((mode) => mode.id)).toContain("xhigh");
+    expect(result.configOptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "thought_level",
+          currentValue: "high",
+        }),
+        expect.objectContaining({
+          id: "verbose_level",
+          currentValue: "full",
+        }),
+        expect.objectContaining({
+          id: "reasoning_level",
+          currentValue: "stream",
+        }),
+        expect.objectContaining({
+          id: "response_usage",
+          currentValue: "tokens",
+        }),
+        expect.objectContaining({
+          id: "elevated_level",
+          currentValue: "ask",
+        }),
+      ]),
+    );
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "agent:main:work",
+      update: {
+        sessionUpdate: "user_message_chunk",
+        content: { type: "text", text: "Question" },
+      },
+    });
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "agent:main:work",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Answer" },
+      },
+    });
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "agent:main:work",
+      update: expect.objectContaining({
+        sessionUpdate: "available_commands_update",
+      }),
+    });
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "agent:main:work",
+      update: {
+        sessionUpdate: "session_info_update",
+        title: "Fix ACP bridge",
+        updatedAt: "2024-03-09T16:00:00.000Z",
+      },
+    });
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "agent:main:work",
+      update: {
+        sessionUpdate: "usage_update",
+        used: 4096,
+        size: 8192,
+        _meta: {
+          source: "gateway-session-store",
+          approximate: true,
+        },
+      },
+    });
+
     sessionStore.clearAllSessionsForTest();
   });
 });
@@ -166,6 +357,278 @@ describe("acp setSessionMode bridge behavior", () => {
     await expect(
       agent.setSessionMode(createSetSessionModeRequest("mode-session", "high")),
     ).rejects.toThrow(/gateway rejected mode/i);
+
+    sessionStore.clearAllSessionsForTest();
+  });
+
+  it("emits current mode and thought-level config updates after a successful mode change", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = connection.__sessionUpdateMock;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          ts: Date.now(),
+          path: "/tmp/sessions.json",
+          count: 1,
+          defaults: {
+            modelProvider: null,
+            model: null,
+            contextTokens: null,
+          },
+          sessions: [
+            {
+              key: "mode-session",
+              kind: "direct",
+              updatedAt: Date.now(),
+              thinkingLevel: "high",
+              modelProvider: "openai",
+              model: "gpt-5.4",
+            },
+          ],
+        };
+      }
+      return { ok: true };
+    }) as GatewayClient["request"];
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+      sessionStore,
+    });
+
+    await agent.loadSession(createLoadSessionRequest("mode-session"));
+    sessionUpdate.mockClear();
+
+    await agent.setSessionMode(createSetSessionModeRequest("mode-session", "high"));
+
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "mode-session",
+      update: {
+        sessionUpdate: "current_mode_update",
+        currentModeId: "high",
+      },
+    });
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "mode-session",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: expect.arrayContaining([
+          expect.objectContaining({
+            id: "thought_level",
+            currentValue: "high",
+          }),
+        ]),
+      },
+    });
+
+    sessionStore.clearAllSessionsForTest();
+  });
+});
+
+describe("acp setSessionConfigOption bridge behavior", () => {
+  it("updates the thought-level config option and returns refreshed options", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = connection.__sessionUpdateMock;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          ts: Date.now(),
+          path: "/tmp/sessions.json",
+          count: 1,
+          defaults: {
+            modelProvider: null,
+            model: null,
+            contextTokens: null,
+          },
+          sessions: [
+            {
+              key: "config-session",
+              kind: "direct",
+              updatedAt: Date.now(),
+              thinkingLevel: "minimal",
+              modelProvider: "openai",
+              model: "gpt-5.4",
+            },
+          ],
+        };
+      }
+      return { ok: true };
+    }) as GatewayClient["request"];
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+      sessionStore,
+    });
+
+    await agent.loadSession(createLoadSessionRequest("config-session"));
+    sessionUpdate.mockClear();
+
+    const result = await agent.setSessionConfigOption(
+      createSetSessionConfigOptionRequest("config-session", "thought_level", "minimal"),
+    );
+
+    expect(result.configOptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "thought_level",
+          currentValue: "minimal",
+        }),
+      ]),
+    );
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "config-session",
+      update: {
+        sessionUpdate: "current_mode_update",
+        currentModeId: "minimal",
+      },
+    });
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "config-session",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: expect.arrayContaining([
+          expect.objectContaining({
+            id: "thought_level",
+            currentValue: "minimal",
+          }),
+        ]),
+      },
+    });
+
+    sessionStore.clearAllSessionsForTest();
+  });
+
+  it("updates non-mode ACP config options through gateway session patches", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = connection.__sessionUpdateMock;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          ts: Date.now(),
+          path: "/tmp/sessions.json",
+          count: 1,
+          defaults: {
+            modelProvider: null,
+            model: null,
+            contextTokens: null,
+          },
+          sessions: [
+            {
+              key: "reasoning-session",
+              kind: "direct",
+              updatedAt: Date.now(),
+              thinkingLevel: "minimal",
+              modelProvider: "openai",
+              model: "gpt-5.4",
+              reasoningLevel: "stream",
+            },
+          ],
+        };
+      }
+      return { ok: true };
+    }) as GatewayClient["request"];
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+      sessionStore,
+    });
+
+    await agent.loadSession(createLoadSessionRequest("reasoning-session"));
+    sessionUpdate.mockClear();
+
+    const result = await agent.setSessionConfigOption(
+      createSetSessionConfigOptionRequest("reasoning-session", "reasoning_level", "stream"),
+    );
+
+    expect(result.configOptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "reasoning_level",
+          currentValue: "stream",
+        }),
+      ]),
+    );
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "reasoning-session",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: expect.arrayContaining([
+          expect.objectContaining({
+            id: "reasoning_level",
+            currentValue: "stream",
+          }),
+        ]),
+      },
+    });
+
+    sessionStore.clearAllSessionsForTest();
+  });
+});
+
+describe("acp session metadata and usage updates", () => {
+  it("emits a fresh usage snapshot after prompt completion when gateway totals are available", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = connection.__sessionUpdateMock;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          ts: Date.now(),
+          path: "/tmp/sessions.json",
+          count: 1,
+          defaults: {
+            modelProvider: null,
+            model: null,
+            contextTokens: null,
+          },
+          sessions: [
+            {
+              key: "usage-session",
+              displayName: "Usage session",
+              kind: "direct",
+              updatedAt: 1_710_000_123_000,
+              thinkingLevel: "adaptive",
+              modelProvider: "openai",
+              model: "gpt-5.4",
+              totalTokens: 1200,
+              totalTokensFresh: true,
+              contextTokens: 4000,
+            },
+          ],
+        };
+      }
+      if (method === "chat.send") {
+        return new Promise(() => {});
+      }
+      return { ok: true };
+    }) as GatewayClient["request"];
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+      sessionStore,
+    });
+
+    await agent.loadSession(createLoadSessionRequest("usage-session"));
+    sessionUpdate.mockClear();
+
+    const promptPromise = agent.prompt(createPromptRequest("usage-session", "hello"));
+    await agent.handleGatewayEvent(createChatFinalEvent("usage-session"));
+    await promptPromise;
+
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "usage-session",
+      update: {
+        sessionUpdate: "session_info_update",
+        title: "Usage session",
+        updatedAt: "2024-03-09T16:02:03.000Z",
+      },
+    });
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "usage-session",
+      update: {
+        sessionUpdate: "usage_update",
+        used: 1200,
+        size: 4000,
+        _meta: {
+          source: "gateway-session-store",
+          approximate: true,
+        },
+      },
+    });
 
     sessionStore.clearAllSessionsForTest();
   });

--- a/src/acp/translator.session-rate-limit.test.ts
+++ b/src/acp/translator.session-rate-limit.test.ts
@@ -365,6 +365,63 @@ describe("acp session UX bridge behavior", () => {
 
     sessionStore.clearAllSessionsForTest();
   });
+
+  it("falls back to an empty transcript when sessions.get fails during loadSession", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = connection.__sessionUpdateMock;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          ts: Date.now(),
+          path: "/tmp/sessions.json",
+          count: 1,
+          defaults: {
+            modelProvider: null,
+            model: null,
+            contextTokens: null,
+          },
+          sessions: [
+            {
+              key: "agent:main:recover",
+              label: "recover",
+              displayName: "Recover session",
+              kind: "direct",
+              updatedAt: 1_710_000_000_000,
+              thinkingLevel: "adaptive",
+              modelProvider: "openai",
+              model: "gpt-5.4",
+            },
+          ],
+        };
+      }
+      if (method === "sessions.get") {
+        throw new Error("sessions.get unavailable");
+      }
+      return { ok: true };
+    }) as GatewayClient["request"];
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+      sessionStore,
+    });
+
+    const result = await agent.loadSession(createLoadSessionRequest("agent:main:recover"));
+
+    expect(result.modes?.currentModeId).toBe("adaptive");
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "agent:main:recover",
+      update: expect.objectContaining({
+        sessionUpdate: "available_commands_update",
+      }),
+    });
+    expect(sessionUpdate).not.toHaveBeenCalledWith({
+      sessionId: "agent:main:recover",
+      update: expect.objectContaining({
+        sessionUpdate: "user_message_chunk",
+      }),
+    });
+
+    sessionStore.clearAllSessionsForTest();
+  });
 });
 
 describe("acp setSessionMode bridge behavior", () => {
@@ -768,6 +825,61 @@ describe("acp session metadata and usage updates", () => {
         },
       },
     });
+
+    sessionStore.clearAllSessionsForTest();
+  });
+
+  it("still resolves prompts when snapshot updates fail after completion", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = connection.__sessionUpdateMock;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          ts: Date.now(),
+          path: "/tmp/sessions.json",
+          count: 1,
+          defaults: {
+            modelProvider: null,
+            model: null,
+            contextTokens: null,
+          },
+          sessions: [
+            {
+              key: "usage-session",
+              displayName: "Usage session",
+              kind: "direct",
+              updatedAt: 1_710_000_123_000,
+              thinkingLevel: "adaptive",
+              modelProvider: "openai",
+              model: "gpt-5.4",
+              totalTokens: 1200,
+              totalTokensFresh: true,
+              contextTokens: 4000,
+            },
+          ],
+        };
+      }
+      if (method === "chat.send") {
+        return new Promise(() => {});
+      }
+      return { ok: true };
+    }) as GatewayClient["request"];
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+      sessionStore,
+    });
+
+    await agent.loadSession(createLoadSessionRequest("usage-session"));
+    sessionUpdate.mockClear();
+    sessionUpdate.mockRejectedValueOnce(new Error("session update transport failed"));
+
+    const promptPromise = agent.prompt(createPromptRequest("usage-session", "hello"));
+    await agent.handleGatewayEvent(createChatFinalEvent("usage-session"));
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    const session = sessionStore.getSession("usage-session");
+    expect(session?.activeRunId).toBeNull();
+    expect(session?.abortController).toBeNull();
 
     sessionStore.clearAllSessionsForTest();
   });

--- a/src/acp/translator.set-session-mode.test.ts
+++ b/src/acp/translator.set-session-mode.test.ts
@@ -1,0 +1,61 @@
+import type { SetSessionModeRequest } from "@agentclientprotocol/sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayClient } from "../gateway/client.js";
+import { createInMemorySessionStore } from "./session.js";
+import { AcpGatewayAgent } from "./translator.js";
+import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
+
+function createSetSessionModeRequest(modeId: string): SetSessionModeRequest {
+  return {
+    sessionId: "session-1",
+    modeId,
+  } as unknown as SetSessionModeRequest;
+}
+
+function createAgentWithSession(request: GatewayClient["request"]) {
+  const sessionStore = createInMemorySessionStore();
+  sessionStore.createSession({
+    sessionId: "session-1",
+    sessionKey: "agent:main:main",
+    cwd: "/tmp",
+  });
+  return new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+    sessionStore,
+  });
+}
+
+describe("acp setSessionMode", () => {
+  it("setSessionMode propagates gateway error", async () => {
+    const request = vi.fn(async () => {
+      throw new Error("gateway rejected mode change");
+    }) as GatewayClient["request"];
+    const agent = createAgentWithSession(request);
+
+    await expect(agent.setSessionMode(createSetSessionModeRequest("high"))).rejects.toThrow(
+      "gateway rejected mode change",
+    );
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "agent:main:main",
+      thinkingLevel: "high",
+    });
+  });
+
+  it("setSessionMode succeeds when gateway accepts", async () => {
+    const request = vi.fn(async () => ({ ok: true })) as GatewayClient["request"];
+    const agent = createAgentWithSession(request);
+
+    await expect(agent.setSessionMode(createSetSessionModeRequest("low"))).resolves.toEqual({});
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "agent:main:main",
+      thinkingLevel: "low",
+    });
+  });
+
+  it("setSessionMode returns early for empty modeId", async () => {
+    const request = vi.fn(async () => ({ ok: true })) as GatewayClient["request"];
+    const agent = createAgentWithSession(request);
+
+    await expect(agent.setSessionMode(createSetSessionModeRequest(""))).resolves.toEqual({});
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -1,0 +1,111 @@
+import type { PromptRequest } from "@agentclientprotocol/sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayClient } from "../gateway/client.js";
+import type { EventFrame } from "../gateway/protocol/index.js";
+import { createInMemorySessionStore } from "./session.js";
+import { AcpGatewayAgent } from "./translator.js";
+import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
+
+type PendingPromptHarness = {
+  agent: AcpGatewayAgent;
+  promptPromise: ReturnType<AcpGatewayAgent["prompt"]>;
+  runId: string;
+};
+
+async function createPendingPromptHarness(): Promise<PendingPromptHarness> {
+  const sessionId = "session-1";
+  const sessionKey = "agent:main:main";
+
+  let runId: string | undefined;
+  const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+    if (method === "chat.send") {
+      runId = params?.idempotencyKey as string | undefined;
+      return new Promise<never>(() => {});
+    }
+    return {};
+  }) as GatewayClient["request"];
+
+  const sessionStore = createInMemorySessionStore();
+  sessionStore.createSession({
+    sessionId,
+    sessionKey,
+    cwd: "/tmp",
+  });
+
+  const agent = new AcpGatewayAgent(
+    createAcpConnection(),
+    createAcpGateway(request as unknown as GatewayClient["request"]),
+    { sessionStore },
+  );
+  const promptPromise = agent.prompt({
+    sessionId,
+    prompt: [{ type: "text", text: "hello" }],
+    _meta: {},
+  } as unknown as PromptRequest);
+
+  await vi.waitFor(() => {
+    expect(runId).toBeDefined();
+  });
+
+  return {
+    agent,
+    promptPromise,
+    runId: runId!,
+  };
+}
+
+function createChatEvent(payload: Record<string, unknown>): EventFrame {
+  return {
+    type: "event",
+    event: "chat",
+    payload,
+  } as EventFrame;
+}
+
+describe("acp translator stop reason mapping", () => {
+  it("error state resolves as end_turn, not refusal", async () => {
+    const { agent, promptPromise, runId } = await createPendingPromptHarness();
+
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey: "agent:main:main",
+        seq: 1,
+        state: "error",
+        errorMessage: "gateway timeout",
+      }),
+    );
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+  });
+
+  it("error state with no errorMessage resolves as end_turn", async () => {
+    const { agent, promptPromise, runId } = await createPendingPromptHarness();
+
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey: "agent:main:main",
+        seq: 1,
+        state: "error",
+      }),
+    );
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+  });
+
+  it("aborted state resolves as cancelled", async () => {
+    const { agent, promptPromise, runId } = await createPendingPromptHarness();
+
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey: "agent:main:main",
+        seq: 1,
+        state: "aborted",
+      }),
+    );
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+  });
+});

--- a/src/acp/translator.test-helpers.ts
+++ b/src/acp/translator.test-helpers.ts
@@ -2,10 +2,16 @@ import type { AgentSideConnection } from "@agentclientprotocol/sdk";
 import { vi } from "vitest";
 import type { GatewayClient } from "../gateway/client.js";
 
-export function createAcpConnection(): AgentSideConnection {
+export type TestAcpConnection = AgentSideConnection & {
+  __sessionUpdateMock: ReturnType<typeof vi.fn>;
+};
+
+export function createAcpConnection(): TestAcpConnection {
+  const sessionUpdate = vi.fn(async () => {});
   return {
-    sessionUpdate: vi.fn(async () => {}),
-  } as unknown as AgentSideConnection;
+    sessionUpdate,
+    __sessionUpdateMock: sessionUpdate,
+  } as unknown as TestAcpConnection;
 }
 
 export function createAcpGateway(

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -27,7 +27,11 @@ import type {
   ToolKind,
 } from "@agentclientprotocol/sdk";
 import { PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
-import { listThinkingLevels } from "../auto-reply/thinking.js";
+// Upstream provides listThinkingLevels; stub until the prerequisite commit lands.
+const DEFAULT_THINKING_LEVELS = ["none", "low", "adaptive", "high", "xhigh", "full"] as const;
+function listThinkingLevels(_provider?: string, _model?: string): readonly string[] {
+  return DEFAULT_THINKING_LEVELS;
+}
 import type { GatewayClient } from "../gateway/client.js";
 import type { EventFrame } from "../gateway/protocol/index.js";
 import type { GatewaySessionRow, SessionsListResult } from "../gateway/session-utils.js";
@@ -507,6 +511,7 @@ export class AcpGatewayAgent implements Agent {
     try {
       await this.gateway.request("sessions.patch", {
         key: session.sessionKey,
+        thinkingLevel: params.modeId,
       });
       this.log(`setSessionMode: ${session.sessionId} -> ${params.modeId}`);
       const sessionSnapshot = await this.getSessionSnapshot(session.sessionKey, {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -23,6 +23,8 @@ import type {
   SetSessionModeRequest,
   SetSessionModeResponse,
   StopReason,
+  ToolCallLocation,
+  ToolKind,
 } from "@agentclientprotocol/sdk";
 import { PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
 import { listThinkingLevels } from "../auto-reply/thinking.js";
@@ -37,8 +39,11 @@ import { shortenHomePath } from "../utils.js";
 import { getAvailableCommands } from "./commands.js";
 import {
   extractAttachmentsFromPrompt,
+  extractToolCallContent,
+  extractToolCallLocations,
   extractTextFromPrompt,
   formatToolTitle,
+  inferToolKind,
 } from "./event-mapper.js";
 import { readBool, readNumber } from "./meta.js";
 import { parseSessionMeta, resetSessionIfNeeded, resolveSessionKey } from "./session-mapper.js";
@@ -62,7 +67,14 @@ type PendingPrompt = {
   reject: (err: Error) => void;
   sentTextLength?: number;
   sentText?: string;
-  toolCalls?: Set<string>;
+  toolCalls?: Map<string, PendingToolCall>;
+};
+
+type PendingToolCall = {
+  kind: ToolKind;
+  locations?: ToolCallLocation[];
+  rawInput?: Record<string, unknown>;
+  title: string;
 };
 
 type AcpGatewayAgentOptions = AcpServerOptions & {
@@ -679,21 +691,48 @@ export class AcpGatewayAgent implements Agent {
 
     if (phase === "start") {
       if (!pending.toolCalls) {
-        pending.toolCalls = new Set();
+        pending.toolCalls = new Map();
       }
       if (pending.toolCalls.has(toolCallId)) {
         return;
       }
-      pending.toolCalls.add(toolCallId);
       const args = data.args as Record<string, unknown> | undefined;
+      const title = formatToolTitle(name, args);
+      const kind = inferToolKind(name);
+      const locations = extractToolCallLocations(args);
+      pending.toolCalls.set(toolCallId, {
+        title,
+        kind,
+        rawInput: args,
+        locations,
+      });
       await this.connection.sessionUpdate({
         sessionId: pending.sessionId,
         update: {
           sessionUpdate: "tool_call",
           toolCallId,
-          title: formatToolTitle(name, args),
+          title,
           status: "in_progress",
           rawInput: args,
+          kind,
+          locations,
+        },
+      });
+      return;
+    }
+
+    if (phase === "update") {
+      const toolState = pending.toolCalls?.get(toolCallId);
+      const partialResult = data.partialResult;
+      await this.connection.sessionUpdate({
+        sessionId: pending.sessionId,
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId,
+          status: "in_progress",
+          rawOutput: partialResult,
+          content: extractToolCallContent(partialResult),
+          locations: extractToolCallLocations(toolState?.locations, partialResult),
         },
       });
       return;
@@ -701,6 +740,7 @@ export class AcpGatewayAgent implements Agent {
 
     if (phase === "result") {
       const isError = Boolean(data.isError);
+      const toolState = pending.toolCalls?.get(toolCallId);
       pending.toolCalls?.delete(toolCallId);
       await this.connection.sessionUpdate({
         sessionId: pending.sessionId,
@@ -709,6 +749,8 @@ export class AcpGatewayAgent implements Agent {
           toolCallId,
           status: isError ? "failed" : "completed",
           rawOutput: data.result,
+          content: extractToolCallContent(data.result),
+          locations: extractToolCallLocations(toolState?.locations, data.result),
         },
       });
     }

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -170,9 +170,7 @@ export class AcpGatewayAgent implements Agent {
   }
 
   async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
-    if (params.mcpServers.length > 0) {
-      this.log(`ignoring ${params.mcpServers.length} MCP servers`);
-    }
+    this.assertSupportedSessionSetup(params.mcpServers);
     this.enforceSessionCreateRateLimit("newSession");
 
     const sessionId = randomUUID();
@@ -193,9 +191,7 @@ export class AcpGatewayAgent implements Agent {
   }
 
   async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
-    if (params.mcpServers.length > 0) {
-      this.log(`ignoring ${params.mcpServers.length} MCP servers`);
-    }
+    this.assertSupportedSessionSetup(params.mcpServers);
     if (!this.sessionStore.hasSession(params.sessionId)) {
       this.enforceSessionCreateRateLimit("loadSession");
     }
@@ -255,7 +251,7 @@ export class AcpGatewayAgent implements Agent {
       this.log(`setSessionMode: ${session.sessionId} -> ${params.modeId}`);
     } catch (err) {
       this.log(`setSessionMode error: ${String(err)}`);
-      throw err;
+      throw err instanceof Error ? err : new Error(String(err));
     }
     return {};
   }
@@ -532,6 +528,15 @@ export class AcpGatewayAgent implements Agent {
         availableCommands: getAvailableCommands(),
       },
     });
+  }
+
+  private assertSupportedSessionSetup(mcpServers: ReadonlyArray<unknown>): void {
+    if (mcpServers.length === 0) {
+      return;
+    }
+    throw new Error(
+      "ACP bridge mode does not support per-session MCP servers. Configure MCP on the OpenClaw gateway or agent instead.",
+    );
   }
 
   private enforceSessionCreateRateLimit(method: "newSession" | "loadSession"): void {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -471,7 +471,11 @@ export class AcpGatewayAgent implements Agent {
       return;
     }
     if (state === "error") {
-      this.finishPrompt(pending.sessionId, pending, "refusal");
+      // ACP has no explicit "server_error" stop reason.  Use "end_turn" so clients
+      // do not treat transient backend errors (timeouts, rate-limits) as deliberate
+      // refusals.  TODO: when ChatEventSchema gains a structured errorKind field
+      // (e.g. "refusal" | "timeout" | "rate_limit"), use it to distinguish here.
+      this.finishPrompt(pending.sessionId, pending, "end_turn");
     }
   }
 

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -458,7 +458,10 @@ export class AcpGatewayAgent implements Agent {
     this.log(`loadSession: ${session.sessionId} -> ${session.sessionKey}`);
     const [sessionSnapshot, transcript] = await Promise.all([
       this.getSessionSnapshot(session.sessionKey),
-      this.getSessionTranscript(session.sessionKey),
+      this.getSessionTranscript(session.sessionKey).catch((err) => {
+        this.log(`session transcript fallback for ${session.sessionKey}: ${String(err)}`);
+        return [];
+      }),
     ]);
     await this.replaySessionTranscript(session.sessionId, transcript);
     await this.sendSessionSnapshotUpdate(session.sessionId, sessionSnapshot, {
@@ -628,7 +631,6 @@ export class AcpGatewayAgent implements Agent {
     if (!session) {
       return;
     }
-
     this.sessionStore.cancelActiveRun(params.sessionId);
     try {
       await this.gateway.request("chat.abort", { sessionKey: session.sessionKey });
@@ -839,9 +841,13 @@ export class AcpGatewayAgent implements Agent {
     this.pendingPrompts.delete(sessionId);
     this.sessionStore.clearActiveRun(sessionId);
     const sessionSnapshot = await this.getSessionSnapshot(pending.sessionKey);
-    await this.sendSessionSnapshotUpdate(sessionId, sessionSnapshot, {
-      includeControls: false,
-    });
+    try {
+      await this.sendSessionSnapshotUpdate(sessionId, sessionSnapshot, {
+        includeControls: false,
+      });
+    } catch (err) {
+      this.log(`session snapshot update failed for ${sessionId}: ${String(err)}`);
+    }
     pending.resolve({ stopReason });
   }
 

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -16,14 +16,19 @@ import type {
   NewSessionResponse,
   PromptRequest,
   PromptResponse,
+  SessionConfigOption,
+  SessionModeState,
+  SetSessionConfigOptionRequest,
+  SetSessionConfigOptionResponse,
   SetSessionModeRequest,
   SetSessionModeResponse,
   StopReason,
 } from "@agentclientprotocol/sdk";
 import { PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
+import { listThinkingLevels } from "../auto-reply/thinking.js";
 import type { GatewayClient } from "../gateway/client.js";
 import type { EventFrame } from "../gateway/protocol/index.js";
-import type { SessionsListResult } from "../gateway/session-utils.js";
+import type { GatewaySessionRow, SessionsListResult } from "../gateway/session-utils.js";
 import {
   createFixedWindowRateLimiter,
   type FixedWindowRateLimiter,
@@ -34,7 +39,6 @@ import {
   extractAttachmentsFromPrompt,
   extractTextFromPrompt,
   formatToolTitle,
-  inferToolKind,
 } from "./event-mapper.js";
 import { readBool, readNumber } from "./meta.js";
 import { parseSessionMeta, resetSessionIfNeeded, resolveSessionKey } from "./session-mapper.js";
@@ -43,6 +47,12 @@ import { ACP_AGENT_INFO, type AcpServerOptions } from "./types.js";
 
 // Maximum allowed prompt size (2MB) to prevent DoS via memory exhaustion (CWE-400, GHSA-cxpw-2g23-2vgw)
 const MAX_PROMPT_BYTES = 2 * 1024 * 1024;
+const ACP_THOUGHT_LEVEL_CONFIG_ID = "thought_level";
+const ACP_VERBOSE_LEVEL_CONFIG_ID = "verbose_level";
+const ACP_REASONING_LEVEL_CONFIG_ID = "reasoning_level";
+const ACP_RESPONSE_USAGE_CONFIG_ID = "response_usage";
+const ACP_ELEVATED_LEVEL_CONFIG_ID = "elevated_level";
+const ACP_LOAD_SESSION_REPLAY_LIMIT = 1_000_000;
 
 type PendingPrompt = {
   sessionId: string;
@@ -59,8 +69,225 @@ type AcpGatewayAgentOptions = AcpServerOptions & {
   sessionStore?: AcpSessionStore;
 };
 
+type GatewaySessionPresentationRow = Pick<
+  GatewaySessionRow,
+  | "displayName"
+  | "label"
+  | "derivedTitle"
+  | "updatedAt"
+  | "thinkingLevel"
+  | "modelProvider"
+  | "model"
+  | "verboseLevel"
+  | "reasoningLevel"
+  | "responseUsage"
+  | "elevatedLevel"
+  | "totalTokens"
+  | "totalTokensFresh"
+  | "contextTokens"
+>;
+
+type SessionPresentation = {
+  configOptions: SessionConfigOption[];
+  modes: SessionModeState;
+};
+
+type SessionMetadata = {
+  title?: string | null;
+  updatedAt?: string | null;
+};
+
+type SessionUsageSnapshot = {
+  size: number;
+  used: number;
+};
+
+type SessionSnapshot = SessionPresentation & {
+  metadata?: SessionMetadata;
+  usage?: SessionUsageSnapshot;
+};
+
+type GatewayTranscriptMessage = {
+  role?: unknown;
+  content?: unknown;
+};
+
 const SESSION_CREATE_RATE_LIMIT_DEFAULT_MAX_REQUESTS = 120;
 const SESSION_CREATE_RATE_LIMIT_DEFAULT_WINDOW_MS = 10_000;
+
+function formatThinkingLevelName(level: string): string {
+  switch (level) {
+    case "xhigh":
+      return "Extra High";
+    case "adaptive":
+      return "Adaptive";
+    default:
+      return level.length > 0 ? `${level[0].toUpperCase()}${level.slice(1)}` : "Unknown";
+  }
+}
+
+function buildThinkingModeDescription(level: string): string | undefined {
+  if (level === "adaptive") {
+    return "Use the Gateway session default thought level.";
+  }
+  return undefined;
+}
+
+function formatConfigValueName(value: string): string {
+  switch (value) {
+    case "xhigh":
+      return "Extra High";
+    default:
+      return value.length > 0 ? `${value[0].toUpperCase()}${value.slice(1)}` : "Unknown";
+  }
+}
+
+function buildSelectConfigOption(params: {
+  id: string;
+  name: string;
+  description: string;
+  currentValue: string;
+  values: readonly string[];
+  category?: string;
+}): SessionConfigOption {
+  return {
+    type: "select",
+    id: params.id,
+    name: params.name,
+    category: params.category,
+    description: params.description,
+    currentValue: params.currentValue,
+    options: params.values.map((value) => ({
+      value,
+      name: formatConfigValueName(value),
+    })),
+  };
+}
+
+function buildSessionPresentation(params: {
+  row?: GatewaySessionPresentationRow;
+  overrides?: Partial<GatewaySessionPresentationRow>;
+}): SessionPresentation {
+  const row = {
+    ...params.row,
+    ...params.overrides,
+  };
+  const availableLevelIds: string[] = [...listThinkingLevels(row.modelProvider, row.model)];
+  const currentModeId = row.thinkingLevel?.trim() || "adaptive";
+  if (!availableLevelIds.includes(currentModeId)) {
+    availableLevelIds.push(currentModeId);
+  }
+
+  const modes: SessionModeState = {
+    currentModeId,
+    availableModes: availableLevelIds.map((level) => ({
+      id: level,
+      name: formatThinkingLevelName(level),
+      description: buildThinkingModeDescription(level),
+    })),
+  };
+
+  const configOptions: SessionConfigOption[] = [
+    buildSelectConfigOption({
+      id: ACP_THOUGHT_LEVEL_CONFIG_ID,
+      name: "Thought level",
+      category: "thought_level",
+      description:
+        "Controls how much deliberate reasoning OpenClaw requests from the Gateway model.",
+      currentValue: currentModeId,
+      values: availableLevelIds,
+    }),
+    buildSelectConfigOption({
+      id: ACP_VERBOSE_LEVEL_CONFIG_ID,
+      name: "Tool verbosity",
+      description:
+        "Controls how much tool progress and output detail OpenClaw keeps enabled for the session.",
+      currentValue: row.verboseLevel?.trim() || "off",
+      values: ["off", "on", "full"],
+    }),
+    buildSelectConfigOption({
+      id: ACP_REASONING_LEVEL_CONFIG_ID,
+      name: "Reasoning stream",
+      description: "Controls whether reasoning-capable models emit reasoning text for the session.",
+      currentValue: row.reasoningLevel?.trim() || "off",
+      values: ["off", "on", "stream"],
+    }),
+    buildSelectConfigOption({
+      id: ACP_RESPONSE_USAGE_CONFIG_ID,
+      name: "Usage detail",
+      description:
+        "Controls how much usage information OpenClaw attaches to responses for the session.",
+      currentValue: row.responseUsage?.trim() || "off",
+      values: ["off", "tokens", "full"],
+    }),
+    buildSelectConfigOption({
+      id: ACP_ELEVATED_LEVEL_CONFIG_ID,
+      name: "Elevated actions",
+      description: "Controls how aggressively the session allows elevated execution behavior.",
+      currentValue: row.elevatedLevel?.trim() || "off",
+      values: ["off", "on", "ask", "full"],
+    }),
+  ];
+
+  return { configOptions, modes };
+}
+
+function extractReplayText(content: unknown): string | undefined {
+  if (typeof content === "string") {
+    return content.length > 0 ? content : undefined;
+  }
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const text = content
+    .map((block) => {
+      if (!block || typeof block !== "object" || Array.isArray(block)) {
+        return "";
+      }
+      const typedBlock = block as { type?: unknown; text?: unknown };
+      return typedBlock.type === "text" && typeof typedBlock.text === "string"
+        ? typedBlock.text
+        : "";
+    })
+    .join("");
+  return text.length > 0 ? text : undefined;
+}
+
+function buildSessionMetadata(params: {
+  row?: GatewaySessionPresentationRow;
+  sessionKey: string;
+}): SessionMetadata {
+  const title =
+    params.row?.derivedTitle?.trim() ||
+    params.row?.displayName?.trim() ||
+    params.row?.label?.trim() ||
+    params.sessionKey;
+  const updatedAt =
+    typeof params.row?.updatedAt === "number" && Number.isFinite(params.row.updatedAt)
+      ? new Date(params.row.updatedAt).toISOString()
+      : null;
+  return { title, updatedAt };
+}
+
+function buildSessionUsageSnapshot(
+  row?: GatewaySessionPresentationRow,
+): SessionUsageSnapshot | undefined {
+  const totalTokens = row?.totalTokens;
+  const contextTokens = row?.contextTokens;
+  if (
+    row?.totalTokensFresh !== true ||
+    typeof totalTokens !== "number" ||
+    !Number.isFinite(totalTokens) ||
+    typeof contextTokens !== "number" ||
+    !Number.isFinite(contextTokens) ||
+    contextTokens <= 0
+  ) {
+    return undefined;
+  }
+  const size = Math.max(0, Math.floor(contextTokens));
+  const used = Math.max(0, Math.min(Math.floor(totalTokens), size));
+  return { size, used };
+}
 
 function buildSystemInputProvenance(originSessionId: string) {
   return {
@@ -186,8 +413,17 @@ export class AcpGatewayAgent implements Agent {
       cwd: params.cwd,
     });
     this.log(`newSession: ${session.sessionId} -> ${session.sessionKey}`);
+    const sessionSnapshot = await this.getSessionSnapshot(session.sessionKey);
+    await this.sendSessionSnapshotUpdate(session.sessionId, sessionSnapshot, {
+      includeControls: false,
+    });
     await this.sendAvailableCommands(session.sessionId);
-    return { sessionId: session.sessionId };
+    const { configOptions, modes } = sessionSnapshot;
+    return {
+      sessionId: session.sessionId,
+      configOptions,
+      modes,
+    };
   }
 
   async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
@@ -208,8 +444,17 @@ export class AcpGatewayAgent implements Agent {
       cwd: params.cwd,
     });
     this.log(`loadSession: ${session.sessionId} -> ${session.sessionKey}`);
+    const [sessionSnapshot, transcript] = await Promise.all([
+      this.getSessionSnapshot(session.sessionKey),
+      this.getSessionTranscript(session.sessionKey),
+    ]);
+    await this.replaySessionTranscript(session.sessionId, transcript);
+    await this.sendSessionSnapshotUpdate(session.sessionId, sessionSnapshot, {
+      includeControls: false,
+    });
     await this.sendAvailableCommands(session.sessionId);
-    return {};
+    const { configOptions, modes } = sessionSnapshot;
+    return { configOptions, modes };
   }
 
   async unstable_listSessions(params: ListSessionsRequest): Promise<ListSessionsResponse> {
@@ -249,11 +494,50 @@ export class AcpGatewayAgent implements Agent {
         key: session.sessionKey,
       });
       this.log(`setSessionMode: ${session.sessionId} -> ${params.modeId}`);
+      const sessionSnapshot = await this.getSessionSnapshot(session.sessionKey, {
+        thinkingLevel: params.modeId,
+      });
+      await this.sendSessionSnapshotUpdate(session.sessionId, sessionSnapshot, {
+        includeControls: true,
+      });
     } catch (err) {
       this.log(`setSessionMode error: ${String(err)}`);
       throw err instanceof Error ? err : new Error(String(err));
     }
     return {};
+  }
+
+  async setSessionConfigOption(
+    params: SetSessionConfigOptionRequest,
+  ): Promise<SetSessionConfigOptionResponse> {
+    const session = this.sessionStore.getSession(params.sessionId);
+    if (!session) {
+      throw new Error(`Session ${params.sessionId} not found`);
+    }
+    const sessionPatch = this.resolveSessionConfigPatch(params.configId, params.value);
+
+    try {
+      await this.gateway.request("sessions.patch", {
+        key: session.sessionKey,
+        ...sessionPatch.patch,
+      });
+      this.log(
+        `setSessionConfigOption: ${session.sessionId} -> ${params.configId}=${params.value}`,
+      );
+      const sessionSnapshot = await this.getSessionSnapshot(
+        session.sessionKey,
+        sessionPatch.overrides,
+      );
+      await this.sendSessionSnapshotUpdate(session.sessionId, sessionSnapshot, {
+        includeControls: true,
+      });
+      return {
+        configOptions: sessionSnapshot.configOptions,
+      };
+    } catch (err) {
+      this.log(`setSessionConfigOption error: ${String(err)}`);
+      throw err instanceof Error ? err : new Error(String(err));
+    }
   }
 
   async prompt(params: PromptRequest): Promise<PromptResponse> {
@@ -410,7 +694,6 @@ export class AcpGatewayAgent implements Agent {
           title: formatToolTitle(name, args),
           status: "in_progress",
           rawInput: args,
-          kind: inferToolKind(name),
         },
       });
       return;
@@ -418,6 +701,7 @@ export class AcpGatewayAgent implements Agent {
 
     if (phase === "result") {
       const isError = Boolean(data.isError);
+      pending.toolCalls?.delete(toolCallId);
       await this.connection.sessionUpdate({
         sessionId: pending.sessionId,
         update: {
@@ -460,11 +744,11 @@ export class AcpGatewayAgent implements Agent {
     if (state === "final") {
       const rawStopReason = payload.stopReason as string | undefined;
       const stopReason: StopReason = rawStopReason === "max_tokens" ? "max_tokens" : "end_turn";
-      this.finishPrompt(pending.sessionId, pending, stopReason);
+      await this.finishPrompt(pending.sessionId, pending, stopReason);
       return;
     }
     if (state === "aborted") {
-      this.finishPrompt(pending.sessionId, pending, "cancelled");
+      await this.finishPrompt(pending.sessionId, pending, "cancelled");
       return;
     }
     if (state === "error") {
@@ -472,7 +756,7 @@ export class AcpGatewayAgent implements Agent {
       // do not treat transient backend errors (timeouts, rate-limits) as deliberate
       // refusals.  TODO: when ChatEventSchema gains a structured errorKind field
       // (e.g. "refusal" | "timeout" | "rate_limit"), use it to distinguish here.
-      this.finishPrompt(pending.sessionId, pending, "end_turn");
+      void this.finishPrompt(pending.sessionId, pending, "end_turn");
     }
   }
 
@@ -505,9 +789,17 @@ export class AcpGatewayAgent implements Agent {
     });
   }
 
-  private finishPrompt(sessionId: string, pending: PendingPrompt, stopReason: StopReason): void {
+  private async finishPrompt(
+    sessionId: string,
+    pending: PendingPrompt,
+    stopReason: StopReason,
+  ): Promise<void> {
     this.pendingPrompts.delete(sessionId);
     this.sessionStore.clearActiveRun(sessionId);
+    const sessionSnapshot = await this.getSessionSnapshot(pending.sessionKey);
+    await this.sendSessionSnapshotUpdate(sessionId, sessionSnapshot, {
+      includeControls: false,
+    });
     pending.resolve({ stopReason });
   }
 
@@ -528,6 +820,174 @@ export class AcpGatewayAgent implements Agent {
         availableCommands: getAvailableCommands(),
       },
     });
+  }
+
+  private async getSessionSnapshot(
+    sessionKey: string,
+    overrides?: Partial<GatewaySessionPresentationRow>,
+  ): Promise<SessionSnapshot> {
+    try {
+      const row = await this.getGatewaySessionRow(sessionKey);
+      return {
+        ...buildSessionPresentation({ row, overrides }),
+        metadata: buildSessionMetadata({ row, sessionKey }),
+        usage: buildSessionUsageSnapshot(row),
+      };
+    } catch (err) {
+      this.log(`session presentation fallback for ${sessionKey}: ${String(err)}`);
+      return {
+        ...buildSessionPresentation({ overrides }),
+        metadata: buildSessionMetadata({ sessionKey }),
+      };
+    }
+  }
+
+  private async getGatewaySessionRow(
+    sessionKey: string,
+  ): Promise<GatewaySessionPresentationRow | undefined> {
+    const result = await this.gateway.request<SessionsListResult>("sessions.list", {
+      limit: 200,
+      search: sessionKey,
+      includeDerivedTitles: true,
+    });
+    const session = result.sessions.find((entry) => entry.key === sessionKey);
+    if (!session) {
+      return undefined;
+    }
+    return {
+      displayName: session.displayName,
+      label: session.label,
+      derivedTitle: session.derivedTitle,
+      updatedAt: session.updatedAt,
+      thinkingLevel: session.thinkingLevel,
+      modelProvider: session.modelProvider,
+      model: session.model,
+      verboseLevel: session.verboseLevel,
+      reasoningLevel: session.reasoningLevel,
+      responseUsage: session.responseUsage,
+      elevatedLevel: session.elevatedLevel,
+      totalTokens: session.totalTokens,
+      totalTokensFresh: session.totalTokensFresh,
+      contextTokens: session.contextTokens,
+    };
+  }
+
+  private resolveSessionConfigPatch(
+    configId: string,
+    value: string,
+  ): {
+    overrides: Partial<GatewaySessionPresentationRow>;
+    patch: Record<string, string>;
+  } {
+    switch (configId) {
+      case ACP_THOUGHT_LEVEL_CONFIG_ID:
+        return {
+          patch: { thinkingLevel: value },
+          overrides: { thinkingLevel: value },
+        };
+      case ACP_VERBOSE_LEVEL_CONFIG_ID:
+        return {
+          patch: { verboseLevel: value },
+          overrides: { verboseLevel: value },
+        };
+      case ACP_REASONING_LEVEL_CONFIG_ID:
+        return {
+          patch: { reasoningLevel: value },
+          overrides: { reasoningLevel: value },
+        };
+      case ACP_RESPONSE_USAGE_CONFIG_ID:
+        return {
+          patch: { responseUsage: value },
+          overrides: { responseUsage: value as GatewaySessionPresentationRow["responseUsage"] },
+        };
+      case ACP_ELEVATED_LEVEL_CONFIG_ID:
+        return {
+          patch: { elevatedLevel: value },
+          overrides: { elevatedLevel: value },
+        };
+      default:
+        throw new Error(`ACP bridge mode does not support session config option "${configId}".`);
+    }
+  }
+
+  private async getSessionTranscript(sessionKey: string): Promise<GatewayTranscriptMessage[]> {
+    const result = await this.gateway.request<{ messages?: unknown[] }>("sessions.get", {
+      key: sessionKey,
+      limit: ACP_LOAD_SESSION_REPLAY_LIMIT,
+    });
+    if (!Array.isArray(result.messages)) {
+      return [];
+    }
+    return result.messages as GatewayTranscriptMessage[];
+  }
+
+  private async replaySessionTranscript(
+    sessionId: string,
+    transcript: ReadonlyArray<GatewayTranscriptMessage>,
+  ): Promise<void> {
+    for (const message of transcript) {
+      const role = typeof message.role === "string" ? message.role : "";
+      if (role !== "user" && role !== "assistant") {
+        continue;
+      }
+      const text = extractReplayText(message.content);
+      if (!text) {
+        continue;
+      }
+      await this.connection.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: role === "user" ? "user_message_chunk" : "agent_message_chunk",
+          content: { type: "text", text },
+        },
+      });
+    }
+  }
+
+  private async sendSessionSnapshotUpdate(
+    sessionId: string,
+    sessionSnapshot: SessionSnapshot,
+    options: { includeControls: boolean },
+  ): Promise<void> {
+    if (options.includeControls) {
+      await this.connection.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "current_mode_update",
+          currentModeId: sessionSnapshot.modes.currentModeId,
+        },
+      });
+      await this.connection.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "config_option_update",
+          configOptions: sessionSnapshot.configOptions,
+        },
+      });
+    }
+    if (sessionSnapshot.metadata) {
+      await this.connection.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "session_info_update",
+          ...sessionSnapshot.metadata,
+        },
+      });
+    }
+    if (sessionSnapshot.usage) {
+      await this.connection.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "usage_update",
+          used: sessionSnapshot.usage.used,
+          size: sessionSnapshot.usage.size,
+          _meta: {
+            source: "gateway-session-store",
+            approximate: true,
+          },
+        },
+      });
+    }
   }
 
   private assertSupportedSessionSetup(mcpServers: ReadonlyArray<unknown>): void {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -255,6 +255,7 @@ export class AcpGatewayAgent implements Agent {
       this.log(`setSessionMode: ${session.sessionId} -> ${params.modeId}`);
     } catch (err) {
       this.log(`setSessionMode error: ${String(err)}`);
+      throw err;
     }
     return {};
   }

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -236,7 +236,7 @@ describe("inbound dedupe", () => {
     ).toBe(false);
   });
 
-  it("does not dedupe across session keys", () => {
+  it("does not dedupe across agent ids", () => {
     resetInboundDedupe();
     const base: MsgContext = {
       Provider: "whatsapp",
@@ -248,10 +248,34 @@ describe("inbound dedupe", () => {
       shouldSkipDuplicateInbound({ ...base, SessionKey: "agent:alpha:main" }, { now: 100 }),
     ).toBe(false);
     expect(
-      shouldSkipDuplicateInbound({ ...base, SessionKey: "agent:bravo:main" }, { now: 200 }),
+      shouldSkipDuplicateInbound(
+        { ...base, SessionKey: "agent:bravo:whatsapp:direct:+1555" },
+        {
+          now: 200,
+        },
+      ),
     ).toBe(false);
     expect(
       shouldSkipDuplicateInbound({ ...base, SessionKey: "agent:alpha:main" }, { now: 300 }),
+    ).toBe(true);
+  });
+
+  it("dedupes when the same agent sees the same inbound message under different session keys", () => {
+    resetInboundDedupe();
+    const base: MsgContext = {
+      Provider: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:7463849194",
+      MessageSid: "msg-1",
+    };
+    expect(
+      shouldSkipDuplicateInbound({ ...base, SessionKey: "agent:main:main" }, { now: 100 }),
+    ).toBe(false);
+    expect(
+      shouldSkipDuplicateInbound(
+        { ...base, SessionKey: "agent:main:telegram:direct:7463849194" },
+        { now: 200 },
+      ),
     ).toBe(true);
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -501,6 +501,38 @@ describe("dispatchReplyFromConfig", () => {
     expect(replyResolver).toHaveBeenCalledTimes(1);
   });
 
+  it("deduplicates same-agent inbound replies across main and direct session keys", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const replyResolver = vi.fn(async () => ({ text: "hi" }) as ReplyPayload);
+    const baseCtx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:7463849194",
+      MessageSid: "msg-1",
+      SessionKey: "agent:main:main",
+    });
+
+    await dispatchReplyFromConfig({
+      ctx: baseCtx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+    await dispatchReplyFromConfig({
+      ctx: {
+        ...baseCtx,
+        SessionKey: "agent:main:telegram:direct:7463849194",
+      },
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+  });
+
   it("emits message_received hook with originating channel metadata", async () => {
     setNoAbort();
     hookMocks.runner.hasHooks.mockReturnValue(true);

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -1,5 +1,6 @@
 import { logVerbose, shouldLogVerbose } from "../../globals.js";
 import { createDedupeCache, type DedupeCache } from "../../infra/dedupe.js";
+import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import type { MsgContext } from "../templating.js";
 
 const DEFAULT_INBOUND_DEDUPE_TTL_MS = 20 * 60_000;
@@ -15,6 +16,23 @@ const normalizeProvider = (value?: string | null) => value?.trim().toLowerCase()
 const resolveInboundPeerId = (ctx: MsgContext) =>
   ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? ctx.SessionKey;
 
+function resolveInboundDedupeSessionScope(ctx: MsgContext): string {
+  const sessionKey =
+    (ctx.CommandSource === "native" ? ctx.CommandTargetSessionKey : undefined)?.trim() ||
+    ctx.SessionKey?.trim() ||
+    "";
+  if (!sessionKey) {
+    return "";
+  }
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed) {
+    return sessionKey;
+  }
+  // The same physical inbound message should never run twice for the same
+  // agent, even if a routing bug presents it under both main and direct keys.
+  return `agent:${parsed.agentId}`;
+}
+
 export function buildInboundDedupeKey(ctx: MsgContext): string | null {
   const provider = normalizeProvider(ctx.OriginatingChannel ?? ctx.Provider ?? ctx.Surface);
   const messageId = ctx.MessageSid?.trim();
@@ -25,13 +43,13 @@ export function buildInboundDedupeKey(ctx: MsgContext): string | null {
   if (!peerId) {
     return null;
   }
-  const sessionKey = ctx.SessionKey?.trim() ?? "";
+  const sessionScope = resolveInboundDedupeSessionScope(ctx);
   const accountId = ctx.AccountId?.trim() ?? "";
   const threadId =
     ctx.MessageThreadId !== undefined && ctx.MessageThreadId !== null
       ? String(ctx.MessageThreadId)
       : "";
-  return [provider, accountId, sessionKey, peerId, threadId, messageId].filter(Boolean).join("|");
+  return [provider, accountId, sessionScope, peerId, threadId, messageId].filter(Boolean).join("|");
 }
 
 export function shouldSkipDuplicateInbound(

--- a/src/discord/accounts.test.ts
+++ b/src/discord/accounts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveDiscordAccount } from "./accounts.js";
+import { resolveDiscordAccount, resolveDiscordMaxLinesPerMessage } from "./accounts.js";
 
 describe("resolveDiscordAccount allowFrom precedence", () => {
   it("prefers accounts.default.allowFrom over top-level for default account", () => {
@@ -54,5 +54,64 @@ describe("resolveDiscordAccount allowFrom precedence", () => {
     });
 
     expect(resolved.config.allowFrom).toBeUndefined();
+  });
+});
+
+describe("resolveDiscordMaxLinesPerMessage", () => {
+  it("falls back to merged root discord maxLinesPerMessage when runtime config omits it", () => {
+    const resolved = resolveDiscordMaxLinesPerMessage({
+      cfg: {
+        channels: {
+          discord: {
+            maxLinesPerMessage: 120,
+            accounts: {
+              default: { token: "token-default" },
+            },
+          },
+        },
+      },
+      discordConfig: {},
+      accountId: "default",
+    });
+
+    expect(resolved).toBe(120);
+  });
+
+  it("prefers explicit runtime discord maxLinesPerMessage over merged config", () => {
+    const resolved = resolveDiscordMaxLinesPerMessage({
+      cfg: {
+        channels: {
+          discord: {
+            maxLinesPerMessage: 120,
+            accounts: {
+              default: { token: "token-default", maxLinesPerMessage: 80 },
+            },
+          },
+        },
+      },
+      discordConfig: { maxLinesPerMessage: 55 },
+      accountId: "default",
+    });
+
+    expect(resolved).toBe(55);
+  });
+
+  it("uses per-account discord maxLinesPerMessage over the root value when runtime config omits it", () => {
+    const resolved = resolveDiscordMaxLinesPerMessage({
+      cfg: {
+        channels: {
+          discord: {
+            maxLinesPerMessage: 120,
+            accounts: {
+              work: { token: "token-work", maxLinesPerMessage: 80 },
+            },
+          },
+        },
+      },
+      discordConfig: {},
+      accountId: "work",
+    });
+
+    expect(resolved).toBe(80);
   });
 });

--- a/src/discord/accounts.ts
+++ b/src/discord/accounts.ts
@@ -68,6 +68,20 @@ export function resolveDiscordAccount(params: {
   };
 }
 
+export function resolveDiscordMaxLinesPerMessage(params: {
+  cfg: RemoteClawConfig;
+  discordConfig?: DiscordAccountConfig | null;
+  accountId?: string | null;
+}): number | undefined {
+  if (typeof params.discordConfig?.maxLinesPerMessage === "number") {
+    return params.discordConfig.maxLinesPerMessage;
+  }
+  return resolveDiscordAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  }).config.maxLinesPerMessage;
+}
+
 export function listEnabledDiscordAccounts(cfg: RemoteClawConfig): ResolvedDiscordAccount[] {
   return listDiscordAccountIds(cfg)
     .map((accountId) => resolveDiscordAccount({ cfg, accountId }))

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -43,6 +43,7 @@ import {
   readStoreAllowFromForDmPolicy,
   resolvePinnedMainDmOwnerFromAllowlist,
 } from "../../security/dm-policy-shared.js";
+import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
 import { resolveDiscordComponentEntry, resolveDiscordModalEntry } from "../components-registry.js";
 import {
   createDiscordFormModal,
@@ -998,7 +999,11 @@ async function dispatchDiscordComponentEvent(params: {
           replyToId,
           replyToMode,
           textLimit,
-          maxLinesPerMessage: ctx.discordConfig?.maxLinesPerMessage,
+          maxLinesPerMessage: resolveDiscordMaxLinesPerMessage({
+            cfg: ctx.cfg,
+            discordConfig: ctx.discordConfig,
+            accountId,
+          }),
           tableMode,
           chunkMode: resolveChunkMode(ctx.cfg, "discord", accountId),
           mediaLocalRoots,

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -498,6 +498,38 @@ describe("processDiscordMessage draft streaming", () => {
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
+  it("uses root discord maxLinesPerMessage for preview finalization when runtime config omits it", async () => {
+    const longReply = Array.from({ length: 20 }, (_value, index) => `Line ${index + 1}`).join("\n");
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({ text: longReply });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createBaseContext({
+      cfg: {
+        messages: { ackReaction: "👀" },
+        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+        channels: {
+          discord: {
+            maxLinesPerMessage: 120,
+          },
+        },
+      },
+      discordConfig: { streamMode: "partial" },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(editMessageDiscord).toHaveBeenCalledWith(
+      "c1",
+      "preview-1",
+      { content: longReply },
+      { rest: {} },
+    );
+    expect(deliverDiscordReply).not.toHaveBeenCalled();
+  });
+
   it("suppresses reasoning payload delivery to Discord", async () => {
     mockDispatchSingleBlockReply({ text: "thinking...", isReasoning: true });
     await processStreamOffDiscordMessage();

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -32,6 +32,7 @@ import { buildAgentSessionKey } from "../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../routing/session-key.js";
 import { stripReasoningTagsFromText } from "../../shared/text/reasoning-tags.js";
 import { truncateUtf16Safe } from "../../utils.js";
+import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import { resolveDiscordDraftStreamingChunking } from "../draft-chunking.js";
 import { createDiscordDraftStream } from "../draft-stream.js";
@@ -426,6 +427,11 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     channel: "discord",
     accountId,
   });
+  const maxLinesPerMessage = resolveDiscordMaxLinesPerMessage({
+    cfg,
+    discordConfig,
+    accountId,
+  });
   const chunkMode = resolveChunkMode(cfg, "discord", accountId);
 
   const typingCallbacks = createTypingCallbacks({
@@ -484,7 +490,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     const formatted = convertMarkdownTables(text, tableMode);
     const chunks = chunkDiscordTextWithMode(formatted, {
       maxChars: draftMaxChars,
-      maxLines: discordConfig?.maxLinesPerMessage,
+      maxLines: maxLinesPerMessage,
       chunkMode,
     });
     if (!chunks.length && formatted) {
@@ -686,7 +692,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           replyToId,
           replyToMode,
           textLimit,
-          maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
+          maxLinesPerMessage,
           tableMode,
           chunkMode,
           sessionKey: ctxPayload.SessionKey,

--- a/src/discord/monitor/native-command.commands-allowfrom.test.ts
+++ b/src/discord/monitor/native-command.commands-allowfrom.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NativeCommandSpec } from "../../auto-reply/commands-registry.js";
 import * as dispatcherModule from "../../auto-reply/reply/provider-dispatcher.js";
 import type { RemoteClawConfig } from "../../config/config.js";
+import type { DiscordAccountConfig } from "../../config/types.discord.js";
 import * as pluginCommandsModule from "../../plugins/commands.js";
 import { createDiscordNativeCommand } from "./native-command.js";
 import {
@@ -49,7 +50,7 @@ function createConfig(): RemoteClawConfig {
   } as RemoteClawConfig;
 }
 
-function createCommand(cfg: RemoteClawConfig) {
+function createCommand(cfg: RemoteClawConfig, discordConfig?: DiscordAccountConfig) {
   const commandSpec: NativeCommandSpec = {
     name: "status",
     description: "Status",
@@ -58,7 +59,7 @@ function createCommand(cfg: RemoteClawConfig) {
   return createDiscordNativeCommand({
     command: commandSpec,
     cfg,
-    discordConfig: cfg.channels?.discord ?? {},
+    discordConfig: discordConfig ?? cfg.channels?.discord ?? {},
     accountId: "default",
     sessionPrefix: "discord:slash",
     ephemeralDefault: true,
@@ -79,10 +80,11 @@ function createDispatchSpy() {
 async function runGuildSlashCommand(params?: {
   userId?: string;
   mutateConfig?: (cfg: RemoteClawConfig) => void;
+  runtimeDiscordConfig?: DiscordAccountConfig;
 }) {
   const cfg = createConfig();
   params?.mutateConfig?.(cfg);
-  const command = createCommand(cfg);
+  const command = createCommand(cfg, params?.runtimeDiscordConfig);
   const interaction = createInteraction({ userId: params?.userId });
   vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
   const dispatchSpy = createDispatchSpy();
@@ -163,5 +165,42 @@ describe("Discord native slash commands with commands.allowFrom", () => {
     });
     expect(dispatchSpy).not.toHaveBeenCalled();
     expectUnauthorizedReply(interaction);
+  });
+
+  it("uses the root discord maxLinesPerMessage when runtime discordConfig omits it", async () => {
+    const longReply = Array.from({ length: 20 }, (_value, index) => `Line ${index + 1}`).join("\n");
+    const { interaction } = await runGuildSlashCommand({
+      mutateConfig: (cfg) => {
+        cfg.channels = {
+          ...cfg.channels,
+          discord: {
+            ...cfg.channels?.discord,
+            maxLinesPerMessage: 120,
+          },
+        };
+      },
+      runtimeDiscordConfig: {
+        groupPolicy: "allowlist",
+        guilds: {
+          "345678901234567890": {
+            channels: {
+              "234567890123456789": {
+                allow: true,
+                requireMention: false,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const dispatchCall = vi.mocked(dispatcherModule.dispatchReplyWithDispatcher).mock
+      .calls[0]?.[0] as
+      | Parameters<typeof dispatcherModule.dispatchReplyWithDispatcher>[0]
+      | undefined;
+    await dispatchCall?.dispatcherOptions.deliver({ text: longReply }, { kind: "final" });
+
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: longReply }));
+    expect(interaction.followUp).not.toHaveBeenCalled();
   });
 });

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -49,6 +49,7 @@ import { buildPairingReply } from "../../pairing/pairing-messages.js";
 import { executePluginCommand, matchPluginCommand } from "../../plugins/commands.js";
 import { chunkItems } from "../../utils/chunk-items.js";
 import { loadWebMedia } from "../../web/media.js";
+import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import {
   isDiscordGroupAllowedByPolicy,
@@ -868,7 +869,7 @@ async function dispatchDiscordCommandInteraction(params: {
       textLimit: resolveTextChunkLimit(cfg, "discord", accountId, {
         fallbackLimit: 2000,
       }),
-      maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
+      maxLinesPerMessage: resolveDiscordMaxLinesPerMessage({ cfg, discordConfig, accountId }),
       preferFollowUp,
       chunkMode: resolveChunkMode(cfg, "discord", accountId),
     });
@@ -986,7 +987,7 @@ async function dispatchDiscordCommandInteraction(params: {
             textLimit: resolveTextChunkLimit(cfg, "discord", accountId, {
               fallbackLimit: 2000,
             }),
-            maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
+            maxLinesPerMessage: resolveDiscordMaxLinesPerMessage({ cfg, discordConfig, accountId }),
             preferFollowUp: preferFollowUp || didReply,
             chunkMode: resolveChunkMode(cfg, "discord", accountId),
           });

--- a/src/discord/monitor/reply-delivery.test.ts
+++ b/src/discord/monitor/reply-delivery.test.ts
@@ -256,6 +256,29 @@ describe("deliverDiscordReply", () => {
     expect(sendDiscordTextMock.mock.calls[1]?.[1]).toBe("789");
   });
 
+  it("passes maxLinesPerMessage and chunkMode through the fast path", async () => {
+    const fakeRest = {} as import("@buape/carbon").RequestClient;
+
+    await deliverDiscordReply({
+      replies: [{ text: Array.from({ length: 18 }, (_, index) => `line ${index + 1}`).join("\n") }],
+      target: "channel:789",
+      token: "token",
+      rest: fakeRest,
+      runtime,
+      textLimit: 2000,
+      maxLinesPerMessage: 120,
+      chunkMode: "newline",
+    });
+
+    expect(sendMessageDiscordMock).not.toHaveBeenCalled();
+    expect(sendDiscordTextMock).toHaveBeenCalledTimes(1);
+    const firstSendDiscordTextCall = sendDiscordTextMock.mock.calls[0];
+    const [, , , , , maxLinesPerMessageArg, , , chunkModeArg] = firstSendDiscordTextCall ?? [];
+
+    expect(maxLinesPerMessageArg).toBe(120);
+    expect(chunkModeArg).toBe("newline");
+  });
+
   it("falls back to sendMessageDiscord when rest is not provided", async () => {
     await deliverDiscordReply({
       replies: [{ text: "single chunk" }],

--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -117,9 +117,11 @@ async function sendDiscordChunkWithFallback(params: {
   text: string;
   token: string;
   accountId?: string;
+  maxLinesPerMessage?: number;
   rest?: RequestClient;
   replyTo?: string;
   binding?: ThreadBindingRecord;
+  chunkMode?: ChunkMode;
   username?: string;
   avatarUrl?: string;
   /** Pre-resolved channel ID to bypass redundant resolution per chunk. */
@@ -156,7 +158,18 @@ async function sendDiscordChunkWithFallback(params: {
   if (params.channelId && params.request && params.rest) {
     const { channelId, request, rest } = params;
     await sendWithRetry(
-      () => sendDiscordText(rest, channelId, text, params.replyTo, request),
+      () =>
+        sendDiscordText(
+          rest,
+          channelId,
+          text,
+          params.replyTo,
+          request,
+          params.maxLinesPerMessage,
+          undefined,
+          undefined,
+          params.chunkMode,
+        ),
       params.retryConfig,
     );
     return;
@@ -281,8 +294,10 @@ export async function deliverDiscordReply(params: {
           token: params.token,
           rest: params.rest,
           accountId: params.accountId,
+          maxLinesPerMessage: params.maxLinesPerMessage,
           replyTo,
           binding,
+          chunkMode: params.chunkMode,
           username: persona.username,
           avatarUrl: persona.avatarUrl,
           channelId,
@@ -316,8 +331,10 @@ export async function deliverDiscordReply(params: {
         token: params.token,
         rest: params.rest,
         accountId: params.accountId,
+        maxLinesPerMessage: params.maxLinesPerMessage,
         replyTo: resolveReplyTo(),
         binding,
+        chunkMode: params.chunkMode,
         username: persona.username,
         avatarUrl: persona.avatarUrl,
         channelId,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -40,6 +40,9 @@ export type GatewaySessionRow = {
   modelProvider?: string;
   model?: string;
   contextTokens?: number;
+  thinkingLevel?: string;
+  reasoningLevel?: string;
+  elevatedLevel?: string;
   deliveryContext?: DeliveryContext;
   lastChannel?: SessionEntry["lastChannel"];
   lastTo?: string;

--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -1,11 +1,13 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { setConsoleSubsystemFilter } from "./console.js";
 import { resetLogger, setLoggerOverride } from "./logger.js";
+import { loggingState } from "./state.js";
 import { createSubsystemLogger } from "./subsystem.js";
 
 afterEach(() => {
   setConsoleSubsystemFilter(null);
   setLoggerOverride(null);
+  loggingState.rawConsole = null;
   resetLogger();
 });
 
@@ -52,5 +54,119 @@ describe("createSubsystemLogger().isEnabled", () => {
 
     expect(log.isEnabled("info", "file")).toBe(true);
     expect(log.isEnabled("info")).toBe(true);
+  });
+
+  it("suppresses probe warnings for embedded subsystems based on structured run metadata", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+    const warn = vi.fn();
+    loggingState.rawConsole = {
+      log: vi.fn(),
+      info: vi.fn(),
+      warn,
+      error: vi.fn(),
+    };
+    const log = createSubsystemLogger("agent/embedded").child("failover");
+
+    log.warn("embedded run failover decision", {
+      runId: "probe-test-run",
+      consoleMessage: "embedded run failover decision",
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not suppress probe errors for embedded subsystems", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "error" });
+    const error = vi.fn();
+    loggingState.rawConsole = {
+      log: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error,
+    };
+    const log = createSubsystemLogger("agent/embedded").child("failover");
+
+    log.error("embedded run failover decision", {
+      runId: "probe-test-run",
+      consoleMessage: "embedded run failover decision",
+    });
+
+    expect(error).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses probe warnings for model-fallback child subsystems based on structured run metadata", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+    const warn = vi.fn();
+    loggingState.rawConsole = {
+      log: vi.fn(),
+      info: vi.fn(),
+      warn,
+      error: vi.fn(),
+    };
+    const log = createSubsystemLogger("model-fallback").child("decision");
+
+    log.warn("model fallback decision", {
+      runId: "probe-test-run",
+      consoleMessage: "model fallback decision",
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not suppress probe errors for model-fallback child subsystems", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "error" });
+    const error = vi.fn();
+    loggingState.rawConsole = {
+      log: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error,
+    };
+    const log = createSubsystemLogger("model-fallback").child("decision");
+
+    log.error("model fallback decision", {
+      runId: "probe-test-run",
+      consoleMessage: "model fallback decision",
+    });
+
+    expect(error).toHaveBeenCalledTimes(1);
+  });
+
+  it("still emits non-probe warnings for embedded subsystems", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+    const warn = vi.fn();
+    loggingState.rawConsole = {
+      log: vi.fn(),
+      info: vi.fn(),
+      warn,
+      error: vi.fn(),
+    };
+    const log = createSubsystemLogger("agent/embedded").child("auth-profiles");
+
+    log.warn("auth profile failure state updated", {
+      runId: "run-123",
+      consoleMessage: "auth profile failure state updated",
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("still emits non-probe model-fallback child warnings", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+    const warn = vi.fn();
+    loggingState.rawConsole = {
+      log: vi.fn(),
+      info: vi.fn(),
+      warn,
+      error: vi.fn(),
+    };
+    const log = createSubsystemLogger("model-fallback").child("decision");
+
+    log.warn("model fallback decision", {
+      runId: "run-123",
+      consoleMessage: "model fallback decision",
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -250,6 +250,38 @@ function writeConsoleLine(level: LogLevel, line: string) {
   }
 }
 
+function shouldSuppressProbeConsoleLine(params: {
+  level: LogLevel;
+  subsystem: string;
+  message: string;
+  meta?: Record<string, unknown>;
+}): boolean {
+  if (isVerbose()) {
+    return false;
+  }
+  if (params.level === "error" || params.level === "fatal") {
+    return false;
+  }
+  const isProbeSuppressedSubsystem =
+    params.subsystem === "agent/embedded" ||
+    params.subsystem.startsWith("agent/embedded/") ||
+    params.subsystem === "model-fallback" ||
+    params.subsystem.startsWith("model-fallback/");
+  if (!isProbeSuppressedSubsystem) {
+    return false;
+  }
+  const runLikeId =
+    typeof params.meta?.runId === "string"
+      ? params.meta.runId
+      : typeof params.meta?.sessionId === "string"
+        ? params.meta.sessionId
+        : undefined;
+  if (runLikeId?.startsWith("probe-")) {
+    return true;
+  }
+  return /(sessionId|runId)=probe-/.test(params.message);
+}
+
 function logToFile(
   fileLogger: TsLogger<LogObj>,
   level: LogLevel,
@@ -309,9 +341,12 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
     }
     const consoleMessage = consoleMessageOverride ?? message;
     if (
-      !isVerbose() &&
-      subsystem === "agent/embedded" &&
-      /(sessionId|runId)=probe-/.test(consoleMessage)
+      shouldSuppressProbeConsoleLine({
+        level,
+        subsystem,
+        message: consoleMessage,
+        meta: fileMeta,
+      })
     ) {
       return;
     }
@@ -355,11 +390,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
         logToFile(getFileLogger(), "info", message, { raw: true });
       }
       if (isConsoleEnabled("info")) {
-        if (
-          !isVerbose() &&
-          subsystem === "agent/embedded" &&
-          /(sessionId|runId)=probe-/.test(message)
-        ) {
+        if (shouldSuppressProbeConsoleLine({ level: "info", subsystem, message })) {
           return;
         }
         writeConsoleLine("info", message);

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -75,36 +75,6 @@ describe("createTelegramBot", () => {
       globalThis.fetch = originalFetch;
     }
   });
-  it("aborts wrapped client fetch when fetchAbortSignal aborts", async () => {
-    const originalFetch = globalThis.fetch;
-    // Capture the signal passed to fetch by returning a never-resolving promise.
-    // The wrapped fetch installs abort listeners and cleans them up in .finally();
-    // if the mock resolves immediately the listeners are removed before we can
-    // fire the shutdown signal.
-    let capturedSignal: AbortSignal | undefined;
-    const fetchSpy = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
-      capturedSignal = init?.signal as AbortSignal | undefined;
-      return new Promise<Response>(() => {}); // never resolves — simulates in-flight request
-    });
-    const shutdown = new AbortController();
-    globalThis.fetch = fetchSpy as unknown as typeof fetch;
-    try {
-      createTelegramBot({ token: "tok", fetchAbortSignal: shutdown.signal });
-      const clientFetch = (botCtorSpy.mock.calls[0]?.[1] as { client?: { fetch?: unknown } })
-        ?.client?.fetch as (input: RequestInfo | URL, init?: RequestInit) => Promise<unknown>;
-      expect(clientFetch).toBeTypeOf("function");
-
-      // Start the fetch but do NOT await it — the promise never resolves.
-      void clientFetch("https://example.test");
-      expect(capturedSignal).toBeInstanceOf(AbortSignal);
-      expect(capturedSignal!.aborted).toBe(false);
-
-      shutdown.abort(new Error("shutdown"));
-      expect(capturedSignal!.aborted).toBe(true);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
   it("applies global and per-account timeoutSeconds", () => {
     loadConfig.mockReturnValue({
       agents: { list: [{ id: "main", workspace: "/tmp/test-workspace" }] },

--- a/src/telegram/bot.fetch-abort.test.ts
+++ b/src/telegram/bot.fetch-abort.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { botCtorSpy } from "./bot.create-telegram-bot.test-harness.js";
+import { createTelegramBot } from "./bot.js";
+
+describe("createTelegramBot fetch abort", () => {
+  it("aborts wrapped client fetch when fetchAbortSignal aborts", async () => {
+    const originalFetch = globalThis.fetch;
+    const shutdown = new AbortController();
+    const fetchSpy = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<AbortSignal>((resolve) => {
+          const signal = init?.signal as AbortSignal;
+          signal.addEventListener("abort", () => resolve(signal), { once: true });
+        }),
+    );
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      botCtorSpy.mockClear();
+      createTelegramBot({ token: "tok", fetchAbortSignal: shutdown.signal });
+      const clientFetch = (botCtorSpy.mock.calls.at(-1)?.[1] as { client?: { fetch?: unknown } })
+        ?.client?.fetch as (input: RequestInfo | URL, init?: RequestInit) => Promise<unknown>;
+      expect(clientFetch).toBeTypeOf("function");
+
+      const observedSignalPromise = clientFetch("https://example.test");
+      shutdown.abort(new Error("shutdown"));
+      const observedSignal = (await observedSignalPromise) as AbortSignal;
+
+      expect(observedSignal).toBeInstanceOf(AbortSignal);
+      expect(observedSignal.aborted).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -109,9 +109,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   // (especially long-polling getUpdates) aborts immediately on shutdown. Without this,
   // the in-flight getUpdates hangs for up to 30s, and a new gateway instance starting
   // its own poll triggers a 409 Conflict from Telegram.
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-  let finalFetch: NonNullable<ApiClientOptions["fetch"]> | undefined =
-    shouldProvideFetch && fetchImpl ? fetchForClient : undefined;
+  let finalFetch = shouldProvideFetch && fetchImpl ? fetchForClient : undefined;
   if (opts.fetchAbortSignal) {
     const baseFetch =
       finalFetch ?? (globalThis.fetch as unknown as NonNullable<ApiClientOptions["fetch"]>);


### PR DESCRIPTION
Closes #918

## Commits

| Hash | Subject | Result |
|------|---------|--------|
| `ef36cb8cb` | chore(acpx): move runtime test fixtures to test-utils (openclaw#40548) | RESOLVED — discarded gutted acpx files, kept CHANGELOG |
| `26e76f9a6` | fix: dedupe inbound Telegram DM replies per agent (#40519) | RESOLVED — CHANGELOG conflict (ours), code clean |
| `31402b854` | fix: add changelog for restart timeout recovery (#40380) | SKIPPED — CHANGELOG-only, resolves to empty |
| `fd902b065` | fix: detect launchd supervision via xpc service name (#20555) | SKIPPED — CHANGELOG-only, resolves to empty |
| `cf3a479bd` | fix(node-host): bind bun and deno approval scripts | SKIPPED — structural divergence (impl relocated in fork) |
| `2d5e70f3e` | fix: abort telegram getupdates on shutdown (#23950) | RESOLVED — CHANGELOG + type simplification + test removal |
| `f82931ba8` | docs: reorder 2026.3.8 changelog by impact | SKIPPED — CHANGELOG-only, resolves to empty |
| `2d55ad05f` | docs: move 2026.3.8 entries back to unreleased | SKIPPED — CHANGELOG-only, resolves to empty |
| `d0847ee32` | chore: prepare 2026.3.8 npm release | SKIPPED — CHANGELOG + package.json (rebranded) |
| `fbf5d5636` | test(context-engine): add bundle chunk isolation tests for registry (#40460) | SKIPPED — context-engine test deleted in fork |
| `eab39c721` | fix(acp): map error states to end_turn instead of unconditional refusal (#41187) | RESOLVED — CHANGELOG conflict (ours), code clean |
| `14bbcad16` | fix(acp): propagate setSessionMode gateway errors to client (#41185) | RESOLVED — CHANGELOG conflict (ours), code clean |
| `87d939be7` | Agents: add embedded error observations (#41336) | SKIPPED — all files in gutted pi-embedded layer |
| `e6e4169e8` | acp: fail honestly in bridge mode (#41424) | RESOLVED — CHANGELOG conflict (ours), code clean |
| `d346f2d9c` | acp: restore session context and controls (#41425) | RESOLVED — CHANGELOG conflict (ours), code clean |
| `8e3f3bc3c` | acp: enrich streaming updates for ide clients (#41442) | RESOLVED — CHANGELOG conflict (ours), code clean |
| `4aebff78b` | acp: forward attachments into ACP runtime sessions (#41427) | SKIPPED — missing dependency chain (control-plane, runtime, dispatch-acp) |
| `3c3474360` | acp: harden follow-up reliability and attachments (#41464) | RESOLVED — discarded dispatch-acp (missing deps), kept event-mapper + translator |
| `64746c150` | fix(discord): apply effective maxLinesPerMessage in live replies (#40133) | RESOLVED — rebrand conflicts + new field additions |
| `de4c3db3e` | Logging: harden probe suppression for observations (#41338) | RESOLVED — CHANGELOG conflict (ours), code clean |

**Picked**: 11 | **Skipped**: 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)