### PR TITLE
Cherry-pick issue #919: model context, telegram timeout, web search, gateway fixes

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -43,9 +43,9 @@ If no `provider` is explicitly set, RemoteClaw auto-detects which provider to us
 
 1. **Brave** — `BRAVE_API_KEY` env var or `tools.web.search.apiKey` config
 2. **Gemini** — `GEMINI_API_KEY` env var or `tools.web.search.gemini.apiKey` config
-3. **Kimi** — `KIMI_API_KEY` / `MOONSHOT_API_KEY` env var or `tools.web.search.kimi.apiKey` config
-4. **Perplexity** — `PERPLEXITY_API_KEY` env var or `tools.web.search.perplexity.apiKey` config
-5. **Grok** — `XAI_API_KEY` env var or `tools.web.search.grok.apiKey` config
+3. **Grok** — `XAI_API_KEY` env var or `tools.web.search.grok.apiKey` config
+4. **Kimi** — `KIMI_API_KEY` / `MOONSHOT_API_KEY` env var or `tools.web.search.kimi.apiKey` config
+5. **Perplexity** — `PERPLEXITY_API_KEY` env var or `tools.web.search.perplexity.apiKey` config
 
 If no keys are found, it falls back to Brave (you'll get a missing-key error prompting you to configure one).
 
@@ -163,10 +163,10 @@ Search the web using your configured provider.
 - `tools.web.search.enabled` must not be `false` (default: enabled)
 - API key for your chosen provider:
   - **Brave**: `BRAVE_API_KEY` or `tools.web.search.apiKey`
-  - **Perplexity**: `PERPLEXITY_API_KEY` or `tools.web.search.perplexity.apiKey`
   - **Gemini**: `GEMINI_API_KEY` or `tools.web.search.gemini.apiKey`
   - **Grok**: `XAI_API_KEY` or `tools.web.search.grok.apiKey`
   - **Kimi**: `KIMI_API_KEY`, `MOONSHOT_API_KEY`, or `tools.web.search.kimi.apiKey`
+  - **Perplexity**: `PERPLEXITY_API_KEY` or `tools.web.search.perplexity.apiKey`
 
 ### Config
 

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -1,0 +1,19 @@
+/**
+ * Stub for gutted pi-embedded-runner — no embedded runs exist in this fork.
+ * Provides the API surface needed by gateway run-loop drain logic.
+ */
+
+export function getActiveEmbeddedRunCount(): number {
+  return 0;
+}
+
+export function abortEmbeddedPiRun(
+  _sessionId?: string,
+  _opts?: { mode?: "all" | "compacting" },
+): boolean {
+  return false;
+}
+
+export async function waitForActiveEmbeddedRuns(_timeoutMs: number): Promise<{ drained: boolean }> {
+  return { drained: true };
+}

--- a/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
@@ -1,0 +1,145 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const readConfigFileSnapshotMock = vi.fn();
+const loadConfig = vi.fn(() => ({}));
+
+const runtimeLogs: string[] = [];
+const defaultRuntime = {
+  log: (message: string) => runtimeLogs.push(message),
+  error: vi.fn(),
+  exit: (code: number) => {
+    throw new Error(`__exit__:${code}`);
+  },
+};
+
+const service = {
+  label: "TestService",
+  loadedText: "loaded",
+  notLoadedText: "not loaded",
+  install: vi.fn(),
+  uninstall: vi.fn(),
+  stop: vi.fn(),
+  isLoaded: vi.fn(),
+  readCommand: vi.fn(),
+  readRuntime: vi.fn(),
+  restart: vi.fn(),
+};
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => loadConfig(),
+  readConfigFileSnapshot: () => readConfigFileSnapshotMock(),
+}));
+
+vi.mock("../../config/issue-format.js", () => ({
+  formatConfigIssueLines: (
+    issues: Array<{ path: string; message: string }>,
+    _prefix: string,
+    _opts?: unknown,
+  ) => issues.map((i) => `${i.path}: ${i.message}`),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime,
+}));
+
+describe("runServiceRestart config pre-flight (#35862)", () => {
+  let runServiceRestart: typeof import("./lifecycle-core.js").runServiceRestart;
+
+  beforeAll(async () => {
+    ({ runServiceRestart } = await import("./lifecycle-core.js"));
+  });
+
+  beforeEach(() => {
+    runtimeLogs.length = 0;
+    readConfigFileSnapshotMock.mockReset();
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {},
+      issues: [],
+    });
+    loadConfig.mockReset();
+    loadConfig.mockReturnValue({});
+    service.isLoaded.mockClear();
+    service.readCommand.mockClear();
+    service.restart.mockClear();
+    service.isLoaded.mockResolvedValue(true);
+    service.readCommand.mockResolvedValue({ environment: {} });
+    service.restart.mockResolvedValue(undefined);
+    vi.unstubAllEnvs();
+    vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", "");
+    vi.stubEnv("CLAWDBOT_GATEWAY_TOKEN", "");
+  });
+
+  it("aborts restart when config is invalid", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: false,
+      config: {},
+      issues: [{ path: "agents.defaults.pdfModel", message: "Unrecognized key" }],
+    });
+
+    await expect(
+      runServiceRestart({
+        serviceNoun: "Gateway",
+        service,
+        renderStartHints: () => [],
+        opts: { json: true },
+      }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("proceeds with restart when config is valid", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {},
+      issues: [],
+    });
+
+    const result = await runServiceRestart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+    });
+
+    expect(result).toBe(true);
+    expect(service.restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("proceeds with restart when config file does not exist", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: false,
+      valid: true,
+      config: {},
+      issues: [],
+    });
+
+    const result = await runServiceRestart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+    });
+
+    expect(result).toBe(true);
+    expect(service.restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("proceeds with restart when snapshot read throws", async () => {
+    readConfigFileSnapshotMock.mockRejectedValue(new Error("read failed"));
+
+    const result = await runServiceRestart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+    });
+
+    expect(result).toBe(true);
+    expect(service.restart).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
@@ -143,3 +143,64 @@ describe("runServiceRestart config pre-flight (#35862)", () => {
     expect(service.restart).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("runServiceStart config pre-flight (#35862)", () => {
+  let runServiceStart: typeof import("./lifecycle-core.js").runServiceStart;
+
+  beforeAll(async () => {
+    ({ runServiceStart } = await import("./lifecycle-core.js"));
+  });
+
+  beforeEach(() => {
+    runtimeLogs.length = 0;
+    readConfigFileSnapshotMock.mockReset();
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {},
+      issues: [],
+    });
+    service.isLoaded.mockClear();
+    service.restart.mockClear();
+    service.isLoaded.mockResolvedValue(true);
+    service.restart.mockResolvedValue(undefined);
+  });
+
+  it("aborts start when config is invalid", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: false,
+      config: {},
+      issues: [{ path: "agents.defaults.pdfModel", message: "Unrecognized key" }],
+    });
+
+    await expect(
+      runServiceStart({
+        serviceNoun: "Gateway",
+        service,
+        renderStartHints: () => [],
+        opts: { json: true },
+      }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("proceeds with start when config is valid", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {},
+      issues: [],
+    });
+
+    await runServiceStart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+    });
+
+    expect(service.restart).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -332,6 +332,19 @@ export async function runServiceRestart(params: {
   if (loaded === null) {
     return false;
   }
+
+  // Pre-flight config validation: check before any restart action (including
+  // onNotLoaded which may send SIGUSR1 to an unmanaged process). (#35862)
+  {
+    const configError = await getConfigValidationError();
+    if (configError) {
+      fail(
+        `${params.serviceNoun} aborted: config is invalid.\n${configError}\nFix the config and retry, or run "openclaw doctor" to repair.`,
+      );
+      return false;
+    }
+  }
+
   if (!loaded) {
     try {
       handledNotLoaded = (await params.onNotLoaded?.({ json, stdout, fail })) ?? null;
@@ -377,17 +390,6 @@ export async function runServiceRestart(params: {
       }
     } catch {
       // Non-fatal: token drift check is best-effort
-    }
-  }
-
-  // Pre-flight config validation (#35862)
-  {
-    const configError = await getConfigValidationError();
-    if (configError) {
-      fail(
-        `${params.serviceNoun} aborted: config is invalid.\n${configError}\nFix the config and retry, or run "openclaw doctor" to repair.`,
-      );
-      return false;
     }
   }
 

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -110,7 +110,11 @@ async function resolveServiceLoadedOrFail(params: {
 /**
  * Best-effort config validation. Returns a string describing the issues if
  * config exists and is invalid, or null if config is valid/missing/unreadable.
- * (#35862)
+ *
+ * Note: This reads the config file snapshot in the current CLI environment.
+ * Configs using env vars only available in the service context (launchd/systemd)
+ * may produce false positives, but the check is intentionally best-effort —
+ * a false positive here is safer than a crash on startup. (#35862)
  */
 async function getConfigValidationError(): Promise<string | null> {
   try {
@@ -213,7 +217,7 @@ export async function runServiceStart(params: {
       fail(
         `${params.serviceNoun} aborted: config is invalid.\n${configError}\nFix the config and retry, or run "openclaw doctor" to repair.`,
       );
-      return false;
+      return;
     }
   }
 

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -1,5 +1,6 @@
 import type { Writable } from "node:stream";
-import { readBestEffortConfig } from "../../config/config.js";
+import { readBestEffortConfig, readConfigFileSnapshot } from "../../config/config.js";
+import { formatConfigIssueLines } from "../../config/issue-format.js";
 import { resolveIsNixMode } from "../../config/paths.js";
 import { checkTokenDrift } from "../../daemon/service-audit.js";
 import type { GatewayService } from "../../daemon/service.js";
@@ -106,6 +107,25 @@ async function resolveServiceLoadedOrFail(params: {
   }
 }
 
+/**
+ * Best-effort config validation. Returns a string describing the issues if
+ * config exists and is invalid, or null if config is valid/missing/unreadable.
+ * (#35862)
+ */
+async function getConfigValidationError(): Promise<string | null> {
+  try {
+    const snapshot = await readConfigFileSnapshot();
+    if (!snapshot.exists || snapshot.valid) {
+      return null;
+    }
+    return snapshot.issues.length > 0
+      ? formatConfigIssueLines(snapshot.issues, "", { normalizeRoot: true }).join("\n")
+      : "Unknown validation issue.";
+  } catch {
+    return null;
+  }
+}
+
 export async function runServiceUninstall(params: {
   serviceNoun: string;
   service: GatewayService;
@@ -186,6 +206,17 @@ export async function runServiceStart(params: {
     });
     return;
   }
+  // Pre-flight config validation (#35862)
+  {
+    const configError = await getConfigValidationError();
+    if (configError) {
+      fail(
+        `${params.serviceNoun} aborted: config is invalid.\n${configError}\nFix the config and retry, or run "openclaw doctor" to repair.`,
+      );
+      return false;
+    }
+  }
+
   try {
     await params.service.restart({ env: process.env, stdout });
   } catch (err) {
@@ -342,6 +373,17 @@ export async function runServiceRestart(params: {
       }
     } catch {
       // Non-fatal: token drift check is best-effort
+    }
+  }
+
+  // Pre-flight config validation (#35862)
+  {
+    const configError = await getConfigValidationError();
+    if (configError) {
+      fail(
+        `${params.serviceNoun} aborted: config is invalid.\n${configError}\nFix the config and retry, or run "openclaw doctor" to repair.`,
+      );
+      return false;
     }
   }
 

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -15,6 +15,11 @@ const resetAllLanes = vi.fn();
 const restartGatewayProcessWithFreshPid = vi.fn<
   () => { mode: "spawned" | "supervised" | "disabled" | "failed"; pid?: number; detail?: string }
 >(() => ({ mode: "disabled" }));
+const abortEmbeddedPiRun = vi.fn(
+  (_sessionId?: string, _opts?: { mode?: "all" | "compacting" }) => false,
+);
+const getActiveEmbeddedRunCount = vi.fn(() => 0);
+const waitForActiveEmbeddedRuns = vi.fn(async (_timeoutMs: number) => ({ drained: true }));
 const DRAIN_TIMEOUT_LOG = "drain timeout reached; proceeding with restart";
 const gatewayLog = {
   info: vi.fn(),
@@ -41,6 +46,13 @@ vi.mock("../../process/command-queue.js", () => ({
   markGatewayDraining: () => markGatewayDraining(),
   waitForActiveTasks: (timeoutMs: number) => waitForActiveTasks(timeoutMs),
   resetAllLanes: () => resetAllLanes(),
+}));
+
+vi.mock("../../agents/pi-embedded-runner/runs.js", () => ({
+  abortEmbeddedPiRun: (sessionId?: string, opts?: { mode?: "all" | "compacting" }) =>
+    abortEmbeddedPiRun(sessionId, opts),
+  getActiveEmbeddedRunCount: () => getActiveEmbeddedRunCount(),
+  waitForActiveEmbeddedRuns: (timeoutMs: number) => waitForActiveEmbeddedRuns(timeoutMs),
 }));
 
 vi.mock("../../logging/subsystem.js", () => ({
@@ -186,7 +198,9 @@ describe("runGatewayLoop", () => {
 
     await withIsolatedSignals(async ({ captureSignal }) => {
       getActiveTaskCount.mockReturnValueOnce(2).mockReturnValueOnce(0);
+      getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValueOnce(0);
       waitForActiveTasks.mockResolvedValueOnce({ drained: false });
+      waitForActiveEmbeddedRuns.mockResolvedValueOnce({ drained: true });
 
       type StartServer = () => Promise<{
         close: (opts: { reason: string; restartExpectedMs: number | null }) => Promise<void>;
@@ -243,7 +257,10 @@ describe("runGatewayLoop", () => {
       expect(start).toHaveBeenCalledTimes(2);
       await new Promise<void>((resolve) => setImmediate(resolve));
 
-      expect(waitForActiveTasks).toHaveBeenCalledWith(30_000);
+      expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "compacting" });
+      expect(waitForActiveTasks).toHaveBeenCalledWith(90_000);
+      expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(90_000);
+      expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "all" });
       expect(markGatewayDraining).toHaveBeenCalledTimes(1);
       expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
       expect(closeFirst).toHaveBeenCalledWith({

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -59,20 +59,41 @@ function removeNewSignalListeners(
   }
 }
 
-async function withIsolatedSignals(run: () => Promise<void>) {
-  const beforeSigterm = new Set(
-    process.listeners("SIGTERM") as Array<(...args: unknown[]) => void>,
-  );
-  const beforeSigint = new Set(process.listeners("SIGINT") as Array<(...args: unknown[]) => void>);
-  const beforeSigusr1 = new Set(
-    process.listeners("SIGUSR1") as Array<(...args: unknown[]) => void>,
-  );
+function addedSignalListener(
+  signal: NodeJS.Signals,
+  existing: Set<(...args: unknown[]) => void>,
+): (() => void) | null {
+  const listeners = process.listeners(signal) as Array<(...args: unknown[]) => void>;
+  for (let i = listeners.length - 1; i >= 0; i -= 1) {
+    const listener = listeners[i];
+    if (listener && !existing.has(listener)) {
+      return listener as () => void;
+    }
+  }
+  return null;
+}
+
+async function withIsolatedSignals(
+  run: (helpers: { captureSignal: (signal: NodeJS.Signals) => () => void }) => Promise<void>,
+) {
+  const existingListeners = {
+    SIGTERM: new Set(process.listeners("SIGTERM") as Array<(...args: unknown[]) => void>),
+    SIGINT: new Set(process.listeners("SIGINT") as Array<(...args: unknown[]) => void>),
+    SIGUSR1: new Set(process.listeners("SIGUSR1") as Array<(...args: unknown[]) => void>),
+  } satisfies Record<NodeJS.Signals, Set<(...args: unknown[]) => void>>;
+  const captureSignal = (signal: NodeJS.Signals) => {
+    const listener = addedSignalListener(signal, existingListeners[signal]);
+    if (!listener) {
+      throw new Error(`expected new ${signal} listener`);
+    }
+    return () => listener();
+  };
   try {
-    await run();
+    await run({ captureSignal });
   } finally {
-    removeNewSignalListeners("SIGTERM", beforeSigterm);
-    removeNewSignalListeners("SIGINT", beforeSigint);
-    removeNewSignalListeners("SIGUSR1", beforeSigusr1);
+    removeNewSignalListeners("SIGTERM", existingListeners.SIGTERM);
+    removeNewSignalListeners("SIGINT", existingListeners.SIGINT);
+    removeNewSignalListeners("SIGUSR1", existingListeners.SIGUSR1);
   }
 }
 
@@ -144,10 +165,11 @@ describe("runGatewayLoop", () => {
   it("exits 0 on SIGTERM after graceful close", async () => {
     vi.clearAllMocks();
 
-    await withIsolatedSignals(async () => {
+    await withIsolatedSignals(async ({ captureSignal }) => {
       const { close, runtime, exited } = await createSignaledLoopHarness();
+      const sigterm = captureSignal("SIGTERM");
 
-      process.emit("SIGTERM");
+      sigterm();
 
       await expect(exited).resolves.toBe(0);
       expect(close).toHaveBeenCalledWith({
@@ -161,7 +183,7 @@ describe("runGatewayLoop", () => {
   it("restarts after SIGUSR1 even when drain times out, and resets lanes for the new iteration", async () => {
     vi.clearAllMocks();
 
-    await withIsolatedSignals(async () => {
+    await withIsolatedSignals(async ({ captureSignal }) => {
       getActiveTaskCount.mockReturnValueOnce(2).mockReturnValueOnce(0);
       waitForActiveTasks.mockResolvedValueOnce({ drained: false });
 
@@ -171,6 +193,8 @@ describe("runGatewayLoop", () => {
 
       const closeFirst = vi.fn(async () => {});
       const closeSecond = vi.fn(async () => {});
+      const closeThird = vi.fn(async () => {});
+      const { runtime, exited } = createRuntimeWithExitSignal();
 
       const start = vi.fn<StartServer>();
       let resolveFirst: (() => void) | null = null;
@@ -191,24 +215,28 @@ describe("runGatewayLoop", () => {
         return { close: closeSecond };
       });
 
-      start.mockRejectedValueOnce(new Error("stop-loop"));
+      let resolveThird: (() => void) | null = null;
+      const startedThird = new Promise<void>((resolve) => {
+        resolveThird = resolve;
+      });
+      start.mockImplementationOnce(async () => {
+        resolveThird?.();
+        return { close: closeThird };
+      });
 
       const { runGatewayLoop } = await import("./run-loop.js");
-      const runtime = {
-        log: vi.fn(),
-        error: vi.fn(),
-        exit: vi.fn(),
-      };
-      const loopPromise = runGatewayLoop({
+      void runGatewayLoop({
         start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
         runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
       });
 
       await startedFirst;
+      const sigusr1 = captureSignal("SIGUSR1");
+      const sigterm = captureSignal("SIGTERM");
       expect(start).toHaveBeenCalledTimes(1);
       await new Promise<void>((resolve) => setImmediate(resolve));
 
-      process.emit("SIGUSR1");
+      sigusr1();
 
       await startedSecond;
       expect(start).toHaveBeenCalledTimes(2);
@@ -224,9 +252,10 @@ describe("runGatewayLoop", () => {
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
       expect(resetAllLanes).toHaveBeenCalledTimes(1);
 
-      process.emit("SIGUSR1");
+      sigusr1();
 
-      await expect(loopPromise).rejects.toThrow("stop-loop");
+      await startedThird;
+      await new Promise<void>((resolve) => setImmediate(resolve));
       expect(closeSecond).toHaveBeenCalledWith({
         reason: "gateway restarting",
         restartExpectedMs: 1500,
@@ -235,13 +264,20 @@ describe("runGatewayLoop", () => {
       expect(markGatewayDraining).toHaveBeenCalledTimes(2);
       expect(resetAllLanes).toHaveBeenCalledTimes(2);
       expect(acquireGatewayLock).toHaveBeenCalledTimes(3);
+
+      sigterm();
+      await expect(exited).resolves.toBe(0);
+      expect(closeThird).toHaveBeenCalledWith({
+        reason: "gateway stopping",
+        restartExpectedMs: null,
+      });
     });
   });
 
   it("releases the lock before exiting on spawned restart", async () => {
     vi.clearAllMocks();
 
-    await withIsolatedSignals(async () => {
+    await withIsolatedSignals(async ({ captureSignal }) => {
       const lockRelease = vi.fn(async () => {});
       acquireGatewayLock.mockResolvedValueOnce({
         release: lockRelease,
@@ -255,11 +291,12 @@ describe("runGatewayLoop", () => {
 
       const exitCallOrder: string[] = [];
       const { runtime, exited } = await createSignaledLoopHarness(exitCallOrder);
+      const sigusr1 = captureSignal("SIGUSR1");
       lockRelease.mockImplementation(async () => {
         exitCallOrder.push("lockRelease");
       });
 
-      process.emit("SIGUSR1");
+      sigusr1();
 
       await exited;
       expect(lockRelease).toHaveBeenCalled();
@@ -271,40 +308,45 @@ describe("runGatewayLoop", () => {
   it("forwards lockPort to initial and restart lock acquisitions", async () => {
     vi.clearAllMocks();
 
-    await withIsolatedSignals(async () => {
+    await withIsolatedSignals(async ({ captureSignal }) => {
       const closeFirst = vi.fn(async () => {});
       const closeSecond = vi.fn(async () => {});
-      restartGatewayProcessWithFreshPid.mockReturnValueOnce({ mode: "disabled" });
+      const closeThird = vi.fn(async () => {});
+      const { runtime, exited } = createRuntimeWithExitSignal();
 
       const start = vi
         .fn()
         .mockResolvedValueOnce({ close: closeFirst })
         .mockResolvedValueOnce({ close: closeSecond })
-        .mockRejectedValueOnce(new Error("stop-loop"));
-      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+        .mockResolvedValueOnce({ close: closeThird });
       const { runGatewayLoop } = await import("./run-loop.js");
-      const loopPromise = runGatewayLoop({
+      void runGatewayLoop({
         start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
         runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
         lockPort: 18789,
       });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const sigusr1 = captureSignal("SIGUSR1");
+      const sigterm = captureSignal("SIGTERM");
+
+      sigusr1();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      sigusr1();
 
       await new Promise<void>((resolve) => setImmediate(resolve));
-      process.emit("SIGUSR1");
-      await new Promise<void>((resolve) => setImmediate(resolve));
-      process.emit("SIGUSR1");
-
-      await expect(loopPromise).rejects.toThrow("stop-loop");
       expect(acquireGatewayLock).toHaveBeenNthCalledWith(1, { port: 18789 });
       expect(acquireGatewayLock).toHaveBeenNthCalledWith(2, { port: 18789 });
       expect(acquireGatewayLock).toHaveBeenNthCalledWith(3, { port: 18789 });
+
+      sigterm();
+      await expect(exited).resolves.toBe(0);
     });
   });
 
   it("exits when lock reacquire fails during in-process restart fallback", async () => {
     vi.clearAllMocks();
 
-    await withIsolatedSignals(async () => {
+    await withIsolatedSignals(async ({ captureSignal }) => {
       const lockRelease = vi.fn(async () => {});
       acquireGatewayLock
         .mockResolvedValueOnce({
@@ -317,7 +359,8 @@ describe("runGatewayLoop", () => {
       });
 
       const { start, exited } = await createSignaledLoopHarness();
-      process.emit("SIGUSR1");
+      const sigusr1 = captureSignal("SIGUSR1");
+      sigusr1();
 
       await expect(exited).resolves.toBe(1);
       expect(acquireGatewayLock).toHaveBeenCalledTimes(2);

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -47,10 +47,10 @@ vi.mock("../../logging/subsystem.js", () => ({
   createSubsystemLogger: () => gatewayLog,
 }));
 
-function removeNewSignalListeners(
-  signal: NodeJS.Signals,
-  existing: Set<(...args: unknown[]) => void>,
-) {
+const LOOP_SIGNALS = ["SIGTERM", "SIGINT", "SIGUSR1"] as const;
+type LoopSignal = (typeof LOOP_SIGNALS)[number];
+
+function removeNewSignalListeners(signal: LoopSignal, existing: Set<(...args: unknown[]) => void>) {
   for (const listener of process.listeners(signal)) {
     const fn = listener as (...args: unknown[]) => void;
     if (!existing.has(fn)) {
@@ -60,7 +60,7 @@ function removeNewSignalListeners(
 }
 
 function addedSignalListener(
-  signal: NodeJS.Signals,
+  signal: LoopSignal,
   existing: Set<(...args: unknown[]) => void>,
 ): (() => void) | null {
   const listeners = process.listeners(signal) as Array<(...args: unknown[]) => void>;
@@ -74,14 +74,15 @@ function addedSignalListener(
 }
 
 async function withIsolatedSignals(
-  run: (helpers: { captureSignal: (signal: NodeJS.Signals) => () => void }) => Promise<void>,
+  run: (helpers: { captureSignal: (signal: LoopSignal) => () => void }) => Promise<void>,
 ) {
-  const existingListeners = {
-    SIGTERM: new Set(process.listeners("SIGTERM") as Array<(...args: unknown[]) => void>),
-    SIGINT: new Set(process.listeners("SIGINT") as Array<(...args: unknown[]) => void>),
-    SIGUSR1: new Set(process.listeners("SIGUSR1") as Array<(...args: unknown[]) => void>),
-  } satisfies Record<NodeJS.Signals, Set<(...args: unknown[]) => void>>;
-  const captureSignal = (signal: NodeJS.Signals) => {
+  const existingListeners = Object.fromEntries(
+    LOOP_SIGNALS.map((signal) => [
+      signal,
+      new Set(process.listeners(signal) as Array<(...args: unknown[]) => void>),
+    ]),
+  ) as Record<LoopSignal, Set<(...args: unknown[]) => void>>;
+  const captureSignal = (signal: LoopSignal) => {
     const listener = addedSignalListener(signal, existingListeners[signal]);
     if (!listener) {
       throw new Error(`expected new ${signal} listener`);
@@ -91,9 +92,9 @@ async function withIsolatedSignals(
   try {
     await run({ captureSignal });
   } finally {
-    removeNewSignalListeners("SIGTERM", existingListeners.SIGTERM);
-    removeNewSignalListeners("SIGINT", existingListeners.SIGINT);
-    removeNewSignalListeners("SIGUSR1", existingListeners.SIGUSR1);
+    for (const signal of LOOP_SIGNALS) {
+      removeNewSignalListeners(signal, existingListeners[signal]);
+    }
   }
 }
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -206,6 +206,11 @@ export async function runGatewayLoop(params: {
           throw err;
         }
         server = null;
+        // Release the gateway lock so that `daemon restart/stop` (which
+        // discovers PIDs via the gateway port) can still manage the process.
+        // Without this, the process holds the lock but is not listening,
+        // forcing manual cleanup. (#35862)
+        await releaseLockIfHeld();
         const errMsg = err instanceof Error ? err.message : String(err);
         const errStack = err instanceof Error && err.stack ? `\n${err.stack}` : "";
         gatewayLog.error(

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -106,7 +106,10 @@ export async function runGatewayLoop(params: {
     const forceExitMs = isRestart ? DRAIN_TIMEOUT_MS + SHUTDOWN_TIMEOUT_MS : SHUTDOWN_TIMEOUT_MS;
     const forceExitTimer = setTimeout(() => {
       gatewayLog.error("shutdown timed out; exiting without full cleanup");
-      exitProcess(0);
+      // Exit non-zero on restart timeout so launchd/systemd treats it as a
+      // failure and triggers a clean process restart instead of assuming the
+      // shutdown was intentional. Stop-timeout stays at 0 (graceful). (#36822)
+      exitProcess(isRestart ? 1 : 0);
     }, forceExitMs);
 
     void (async () => {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -193,7 +193,19 @@ export async function runGatewayLoop(params: {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       onIteration();
-      server = await params.start();
+      try {
+        server = await params.start();
+      } catch (err) {
+        // If startup fails (e.g., invalid config after a config-triggered
+        // restart), keep the process alive and wait for the next SIGUSR1
+        // instead of crashing. A crash here would respawn a new process that
+        // loses macOS Full Disk Access (TCC permissions are PID-bound). (#35862)
+        server = null;
+        gatewayLog.error(
+          `gateway startup failed: ${err instanceof Error ? err.message : String(err)}. ` +
+            "Process will stay alive; fix the issue and restart.",
+        );
+      }
       await new Promise<void>((resolve) => {
         restartResolver = resolve;
       });

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,3 +1,8 @@
+import {
+  abortEmbeddedPiRun,
+  getActiveEmbeddedRunCount,
+  waitForActiveEmbeddedRuns,
+} from "../../agents/pi-embedded-runner/runs.js";
 import type { startGatewayServer } from "../../gateway/server.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
 import { restartGatewayProcessWithFreshPid } from "../../infra/process-respawn.js";
@@ -90,7 +95,7 @@ export async function runGatewayLoop(params: {
     exitProcess(0);
   };
 
-  const DRAIN_TIMEOUT_MS = 30_000;
+  const DRAIN_TIMEOUT_MS = 90_000;
   const SHUTDOWN_TIMEOUT_MS = 5_000;
 
   const request = (action: GatewayRunSignalAction, signal: string) => {
@@ -121,15 +126,33 @@ export async function runGatewayLoop(params: {
           // sessions get an explicit restart error instead of silent task loss.
           markGatewayDraining();
           const activeTasks = getActiveTaskCount();
-          if (activeTasks > 0) {
+          const activeRuns = getActiveEmbeddedRunCount();
+
+          // Best-effort abort for compacting runs so long compaction operations
+          // don't hold session write locks across restart boundaries.
+          if (activeRuns > 0) {
+            abortEmbeddedPiRun(undefined, { mode: "compacting" });
+          }
+
+          if (activeTasks > 0 || activeRuns > 0) {
             gatewayLog.info(
-              `draining ${activeTasks} active task(s) before restart (timeout ${DRAIN_TIMEOUT_MS}ms)`,
+              `draining ${activeTasks} active task(s) and ${activeRuns} active embedded run(s) before restart (timeout ${DRAIN_TIMEOUT_MS}ms)`,
             );
-            const { drained } = await waitForActiveTasks(DRAIN_TIMEOUT_MS);
-            if (drained) {
-              gatewayLog.info("all active tasks drained");
+            const [tasksDrain, runsDrain] = await Promise.all([
+              activeTasks > 0
+                ? waitForActiveTasks(DRAIN_TIMEOUT_MS)
+                : Promise.resolve({ drained: true }),
+              activeRuns > 0
+                ? waitForActiveEmbeddedRuns(DRAIN_TIMEOUT_MS)
+                : Promise.resolve({ drained: true }),
+            ]);
+            if (tasksDrain.drained && runsDrain.drained) {
+              gatewayLog.info("all active work drained");
             } else {
               gatewayLog.warn("drain timeout reached; proceeding with restart");
+              // Final best-effort abort to avoid carrying active runs into the
+              // next lifecycle when drain time budget is exhausted.
+              abortEmbeddedPiRun(undefined, { mode: "all" });
             }
           }
         }

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -190,20 +190,27 @@ export async function runGatewayLoop(params: {
 
     // Keep process alive; SIGUSR1 triggers an in-process restart (no supervisor required).
     // SIGTERM/SIGINT still exit after a graceful shutdown.
+    let isFirstStart = true;
     // eslint-disable-next-line no-constant-condition
     while (true) {
       onIteration();
       try {
         server = await params.start();
+        isFirstStart = false;
       } catch (err) {
-        // If startup fails (e.g., invalid config after a config-triggered
-        // restart), keep the process alive and wait for the next SIGUSR1
-        // instead of crashing. A crash here would respawn a new process that
-        // loses macOS Full Disk Access (TCC permissions are PID-bound). (#35862)
+        // On initial startup, let the error propagate so the outer handler
+        // can report "Gateway failed to start" and exit non-zero. Only
+        // swallow errors on subsequent in-process restarts to keep the
+        // process alive (a crash would lose macOS TCC permissions). (#35862)
+        if (isFirstStart) {
+          throw err;
+        }
         server = null;
+        const errMsg = err instanceof Error ? err.message : String(err);
+        const errStack = err instanceof Error && err.stack ? `\n${err.stack}` : "";
         gatewayLog.error(
-          `gateway startup failed: ${err instanceof Error ? err.message : String(err)}. ` +
-            "Process will stay alive; fix the issue and restart.",
+          `gateway startup failed: ${errMsg}. ` +
+            `Process will stay alive; fix the issue and restart.${errStack}`,
         );
       }
       await new Promise<void>((resolve) => {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,8 +1,8 @@
-import {
-  abortEmbeddedPiRun,
-  getActiveEmbeddedRunCount,
-  waitForActiveEmbeddedRuns,
-} from "../../agents/pi-embedded-runner/runs.js";
+// Stubs for gutted pi-embedded-runner — no embedded runs exist in this fork.
+const getActiveEmbeddedRunCount = (): number => 0;
+const abortEmbeddedPiRun = (_id: unknown, _opts: unknown): void => {};
+const waitForActiveEmbeddedRuns = (_timeoutMs: number): Promise<{ drained: boolean }> =>
+  Promise.resolve({ drained: true });
 import type { startGatewayServer } from "../../gateway/server.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
 import { restartGatewayProcessWithFreshPid } from "../../infra/process-respawn.js";

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,8 +1,8 @@
-// Stubs for gutted pi-embedded-runner — no embedded runs exist in this fork.
-const getActiveEmbeddedRunCount = (): number => 0;
-const abortEmbeddedPiRun = (_id: unknown, _opts: unknown): void => {};
-const waitForActiveEmbeddedRuns = (_timeoutMs: number): Promise<{ drained: boolean }> =>
-  Promise.resolve({ drained: true });
+import {
+  abortEmbeddedPiRun,
+  getActiveEmbeddedRunCount,
+  waitForActiveEmbeddedRuns,
+} from "../../agents/pi-embedded-runner/runs.js";
 import type { startGatewayServer } from "../../gateway/server.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
 import { restartGatewayProcessWithFreshPid } from "../../infra/process-respawn.js";

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -6,6 +6,7 @@ const loadDotEnvMock = vi.hoisted(() => vi.fn());
 const normalizeEnvMock = vi.hoisted(() => vi.fn());
 const ensurePathMock = vi.hoisted(() => vi.fn());
 const assertRuntimeMock = vi.hoisted(() => vi.fn());
+const closeAllMemorySearchManagersMock = vi.hoisted(() => vi.fn(async () => {}));
 
 vi.mock("./route.js", () => ({
   tryRouteCli: tryRouteCliMock,
@@ -27,6 +28,10 @@ vi.mock("../infra/runtime-guard.js", () => ({
   assertSupportedRuntime: assertRuntimeMock,
 }));
 
+vi.mock("../memory/search-manager.js", () => ({
+  closeAllMemorySearchManagers: closeAllMemorySearchManagersMock,
+}));
+
 const { runCli } = await import("./run-main.js");
 
 describe("runCli exit behavior", () => {
@@ -43,6 +48,7 @@ describe("runCli exit behavior", () => {
     await runCli(["node", "remoteclaw", "status"]);
 
     expect(tryRouteCliMock).toHaveBeenCalledWith(["node", "remoteclaw", "status"]);
+    expect(closeAllMemorySearchManagersMock).toHaveBeenCalledTimes(1);
     expect(exitSpy).not.toHaveBeenCalled();
     exitSpy.mockRestore();
   });

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -6,8 +6,6 @@ const loadDotEnvMock = vi.hoisted(() => vi.fn());
 const normalizeEnvMock = vi.hoisted(() => vi.fn());
 const ensurePathMock = vi.hoisted(() => vi.fn());
 const assertRuntimeMock = vi.hoisted(() => vi.fn());
-const closeAllMemorySearchManagersMock = vi.hoisted(() => vi.fn(async () => {}));
-
 vi.mock("./route.js", () => ({
   tryRouteCli: tryRouteCliMock,
 }));
@@ -28,10 +26,6 @@ vi.mock("../infra/runtime-guard.js", () => ({
   assertSupportedRuntime: assertRuntimeMock,
 }));
 
-vi.mock("../memory/search-manager.js", () => ({
-  closeAllMemorySearchManagers: closeAllMemorySearchManagersMock,
-}));
-
 const { runCli } = await import("./run-main.js");
 
 describe("runCli exit behavior", () => {
@@ -48,7 +42,6 @@ describe("runCli exit behavior", () => {
     await runCli(["node", "remoteclaw", "status"]);
 
     expect(tryRouteCliMock).toHaveBeenCalledWith(["node", "remoteclaw", "status"]);
-    expect(closeAllMemorySearchManagersMock).toHaveBeenCalledTimes(1);
     expect(exitSpy).not.toHaveBeenCalled();
     exitSpy.mockRestore();
   });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -13,6 +13,15 @@ import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
 import { tryRouteCli } from "./route.js";
 import { normalizeWindowsArgv } from "./windows-argv.js";
 
+async function closeCliMemoryManagers(): Promise<void> {
+  try {
+    const { closeAllMemorySearchManagers } = await import("../memory/search-manager.js");
+    await closeAllMemorySearchManagers();
+  } catch {
+    // Best-effort teardown for short-lived CLI processes.
+  }
+}
+
 export function rewriteUpdateFlagArgv(argv: string[]): string[] {
   const index = argv.indexOf("--update");
   if (index === -1) {
@@ -82,59 +91,63 @@ export async function runCli(argv: string[] = process.argv) {
   // Enforce the minimum supported runtime before doing any work.
   assertSupportedRuntime();
 
-  if (await tryRouteCli(normalizedArgv)) {
-    return;
-  }
-
-  // Capture all console output into structured logs while keeping stdout/stderr behavior.
-  enableConsoleCapture();
-
-  const { buildProgram } = await import("./program.js");
-  const program = buildProgram();
-
-  // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
-  // These log the error and exit gracefully instead of crashing without trace.
-  installUnhandledRejectionHandler();
-
-  process.on("uncaughtException", (error) => {
-    console.error("[remoteclaw] Uncaught exception:", formatUncaughtError(error));
-    process.exit(1);
-  });
-
-  const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
-  // Register the primary command (builtin or subcli) so help and command parsing
-  // are correct even with lazy command registration.
-  const primary = getPrimaryCommand(parseArgv);
-  if (primary) {
-    const { getProgramContext } = await import("./program/program-context.js");
-    const ctx = getProgramContext(program);
-    if (ctx) {
-      const { registerCoreCliByName } = await import("./program/command-registry.js");
-      await registerCoreCliByName(program, ctx, primary, parseArgv);
+  try {
+    if (await tryRouteCli(normalizedArgv)) {
+      return;
     }
-    const { registerSubCliByName } = await import("./program/register.subclis.js");
-    await registerSubCliByName(program, primary);
-  }
 
-  const hasBuiltinPrimary =
-    primary !== null && program.commands.some((command) => command.name() === primary);
-  const shouldSkipPluginRegistration = shouldSkipPluginCommandRegistration({
-    argv: parseArgv,
-    primary,
-    hasBuiltinPrimary,
-  });
-  if (!shouldSkipPluginRegistration) {
-    // Register plugin CLI commands before parsing
-    const { registerPluginCliCommands } = await import("../plugins/cli.js");
-    const { loadValidatedConfigForPluginRegistration } =
-      await import("./program/register.subclis.js");
-    const config = await loadValidatedConfigForPluginRegistration();
-    if (config) {
-      registerPluginCliCommands(program, config);
+    // Capture all console output into structured logs while keeping stdout/stderr behavior.
+    enableConsoleCapture();
+
+    const { buildProgram } = await import("./program.js");
+    const program = buildProgram();
+
+    // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
+    // These log the error and exit gracefully instead of crashing without trace.
+    installUnhandledRejectionHandler();
+
+    process.on("uncaughtException", (error) => {
+      console.error("[remoteclaw] Uncaught exception:", formatUncaughtError(error));
+      process.exit(1);
+    });
+
+    const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
+    // Register the primary command (builtin or subcli) so help and command parsing
+    // are correct even with lazy command registration.
+    const primary = getPrimaryCommand(parseArgv);
+    if (primary) {
+      const { getProgramContext } = await import("./program/program-context.js");
+      const ctx = getProgramContext(program);
+      if (ctx) {
+        const { registerCoreCliByName } = await import("./program/command-registry.js");
+        await registerCoreCliByName(program, ctx, primary, parseArgv);
+      }
+      const { registerSubCliByName } = await import("./program/register.subclis.js");
+      await registerSubCliByName(program, primary);
     }
-  }
 
-  await program.parseAsync(parseArgv);
+    const hasBuiltinPrimary =
+      primary !== null && program.commands.some((command) => command.name() === primary);
+    const shouldSkipPluginRegistration = shouldSkipPluginCommandRegistration({
+      argv: parseArgv,
+      primary,
+      hasBuiltinPrimary,
+    });
+    if (!shouldSkipPluginRegistration) {
+      // Register plugin CLI commands before parsing
+      const { registerPluginCliCommands } = await import("../plugins/cli.js");
+      const { loadValidatedConfigForPluginRegistration } =
+        await import("./program/register.subclis.js");
+      const config = await loadValidatedConfigForPluginRegistration();
+      if (config) {
+        registerPluginCliCommands(program, config);
+      }
+    }
+
+    await program.parseAsync(parseArgv);
+  } finally {
+    await closeCliMemoryManagers();
+  }
 }
 
 export function isCliMainModule(): boolean {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -13,14 +13,8 @@ import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
 import { tryRouteCli } from "./route.js";
 import { normalizeWindowsArgv } from "./windows-argv.js";
 
-async function closeCliMemoryManagers(): Promise<void> {
-  try {
-    const { closeAllMemorySearchManagers } = await import("../memory/search-manager.js");
-    await closeAllMemorySearchManagers();
-  } catch {
-    // Best-effort teardown for short-lived CLI processes.
-  }
-}
+// No-op: memory search managers are gutted in this fork.
+async function closeCliMemoryManagers(): Promise<void> {}
 
 export function rewriteUpdateFlagArgv(argv: string[]): string[] {
   const index = argv.indexOf("--update");

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -98,7 +98,8 @@ describe("restart-helper", () => {
       expect(scriptPath.endsWith(".sh")).toBe(true);
       expect(content).toContain("#!/bin/sh");
       expect(content).toContain("launchctl kickstart -k 'gui/501/org.remoteclaw.gateway'");
-      // Should fall back to bootstrap when kickstart fails (service deregistered after bootout)
+      // Should clear disabled state and fall back to bootstrap when kickstart fails.
+      expect(content).toContain("launchctl enable 'gui/501/org.remoteclaw.gateway'");
       expect(content).toContain("launchctl bootstrap 'gui/501'");
       expect(content).toContain('rm -f "$0"');
       await cleanupScript(scriptPath);

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -95,8 +95,10 @@ rm -f "$0"
 # Wait briefly to ensure file locks are released after update.
 sleep 1
 # Try kickstart first (works when the service is still registered).
-# If it fails (e.g. after bootout), re-register via bootstrap then kickstart.
+# If it fails (e.g. after bootout), clear any persisted disabled state,
+# then re-register via bootstrap and kickstart.
 if ! launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null; then
+  launchctl enable 'gui/${uid}/${escaped}' 2>/dev/null
   launchctl bootstrap 'gui/${uid}' '${escapedPlistPath}' 2>/dev/null
   launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null || true
 fi

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -155,7 +155,10 @@ async function promptWebToolsConfig(
     if (stored && SEARCH_PROVIDER_OPTIONS.some((e) => e.value === stored)) {
       return stored;
     }
-    return SEARCH_PROVIDER_OPTIONS.find((e) => hasKeyForProvider(e.value))?.value ?? "perplexity";
+    return (
+      SEARCH_PROVIDER_OPTIONS.find((e) => hasKeyForProvider(e.value))?.value ??
+      SEARCH_PROVIDER_OPTIONS[0].value
+    );
   })();
 
   note(

--- a/src/commands/doctor-cron.test.ts
+++ b/src/commands/doctor-cron.test.ts
@@ -155,4 +155,115 @@ describe("maybeRepairLegacyCronStore", () => {
       "Doctor warnings",
     );
   });
+
+  it("does not auto-repair in non-interactive mode without explicit repair approval", async () => {
+    const storePath = await makeTempStorePath();
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              jobId: "legacy-job",
+              name: "Legacy job",
+              notify: true,
+              createdAtMs: Date.parse("2026-02-01T00:00:00.000Z"),
+              updatedAtMs: Date.parse("2026-02-02T00:00:00.000Z"),
+              schedule: { kind: "cron", cron: "0 7 * * *", tz: "UTC" },
+              payload: {
+                kind: "systemEvent",
+                text: "Morning brief",
+              },
+              state: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+    const prompter = makePrompter(false);
+
+    await maybeRepairLegacyCronStore({
+      cfg: {
+        cron: {
+          store: storePath,
+          webhook: "https://example.invalid/cron-finished",
+        },
+      },
+      options: { nonInteractive: true },
+      prompter,
+    });
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+    expect(prompter.confirm).toHaveBeenCalledWith({
+      message: "Repair legacy cron jobs now?",
+      initialValue: true,
+    });
+    expect(persisted.jobs[0]?.jobId).toBe("legacy-job");
+    expect(persisted.jobs[0]?.notify).toBe(true);
+    expect(noteSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("Cron store normalized"),
+      "Doctor changes",
+    );
+  });
+
+  it("migrates notify fallback none delivery jobs to cron.webhook", async () => {
+    const storePath = await makeTempStorePath();
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              id: "notify-none",
+              name: "Notify none",
+              notify: true,
+              createdAtMs: Date.parse("2026-02-01T00:00:00.000Z"),
+              updatedAtMs: Date.parse("2026-02-02T00:00:00.000Z"),
+              schedule: { kind: "every", everyMs: 60_000 },
+              payload: {
+                kind: "systemEvent",
+                text: "Status",
+              },
+              delivery: { mode: "none", to: "123456789" },
+              state: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    await maybeRepairLegacyCronStore({
+      cfg: {
+        cron: {
+          store: storePath,
+          webhook: "https://example.invalid/cron-finished",
+        },
+      },
+      options: {},
+      prompter: makePrompter(true),
+    });
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+    expect(persisted.jobs[0]?.notify).toBeUndefined();
+    expect(persisted.jobs[0]?.delivery).toMatchObject({
+      mode: "webhook",
+      to: "https://example.invalid/cron-finished",
+    });
+  });
 });

--- a/src/commands/doctor-cron.ts
+++ b/src/commands/doctor-cron.ts
@@ -96,7 +96,7 @@ function migrateLegacyNotifyFallback(params: {
       raw.delivery = {
         ...delivery,
         mode: "webhook",
-        to: to ?? params.legacyWebhook,
+        to: mode === "none" ? params.legacyWebhook : (to ?? params.legacyWebhook),
       };
       delete raw.notify;
       changed = true;
@@ -152,13 +152,10 @@ export async function maybeRepairLegacyCronStore(params: {
     "Cron",
   );
 
-  const shouldRepair =
-    params.options.nonInteractive === true
-      ? true
-      : await params.prompter.confirm({
-          message: "Repair legacy cron jobs now?",
-          initialValue: true,
-        });
+  const shouldRepair = await params.prompter.confirm({
+    message: "Repair legacy cron jobs now?",
+    initialValue: true,
+  });
   if (!shouldRepair) {
     return;
   }

--- a/src/commands/onboard-non-interactive.ts
+++ b/src/commands/onboard-non-interactive.ts
@@ -20,7 +20,11 @@ export async function runNonInteractiveOnboarding(
     return;
   }
 
-  const baseConfig: RemoteClawConfig = snapshot.valid ? snapshot.config : {};
+  const baseConfig: RemoteClawConfig = snapshot.valid
+    ? snapshot.exists
+      ? snapshot.config
+      : {}
+    : {};
   const mode = opts.mode ?? "local";
   if (mode !== "local" && mode !== "remote") {
     runtime.error(`Invalid --mode "${String(mode)}" (use local|remote).`);

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -9,7 +9,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import type { SecretInputMode } from "./onboard-types.js";
 
-export type SearchProvider = "perplexity" | "brave" | "gemini" | "grok" | "kimi";
+export type SearchProvider = "brave" | "gemini" | "grok" | "kimi" | "perplexity";
 
 type SearchProviderEntry = {
   value: SearchProvider;
@@ -72,14 +72,14 @@ function rawKeyValue(config: RemoteClawConfig, provider: SearchProvider): unknow
   switch (provider) {
     case "brave":
       return search?.apiKey;
-    case "perplexity":
-      return search?.perplexity?.apiKey;
     case "gemini":
       return search?.gemini?.apiKey;
     case "grok":
       return search?.grok?.apiKey;
     case "kimi":
       return search?.kimi?.apiKey;
+    case "perplexity":
+      return search?.perplexity?.apiKey;
   }
 }
 
@@ -131,9 +131,6 @@ export function applySearchKey(
     case "brave":
       search.apiKey = key;
       break;
-    case "perplexity":
-      search.perplexity = { ...search.perplexity, apiKey: key };
-      break;
     case "gemini":
       search.gemini = { ...search.gemini, apiKey: key };
       break;
@@ -142,6 +139,9 @@ export function applySearchKey(
       break;
     case "kimi":
       search.kimi = { ...search.kimi, apiKey: key };
+      break;
+    case "perplexity":
+      search.perplexity = { ...search.perplexity, apiKey: key };
       break;
   }
   return {
@@ -224,7 +224,7 @@ export async function setupSearch(
     if (detected) {
       return detected.value;
     }
-    return "perplexity";
+    return SEARCH_PROVIDER_OPTIONS[0].value;
   })();
 
   type PickerValue = SearchProvider | "__skip__";

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -219,8 +219,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). */
-      provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi";
+      /** Search provider ("brave", "gemini", "grok", "kimi", or "perplexity"). */
+      provider?: "brave" | "gemini" | "grok" | "kimi" | "perplexity";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: SecretInput;
       /** Default search results count (1-10). */
@@ -229,13 +229,16 @@ export type ToolsConfig = {
       timeoutSeconds?: number;
       /** Cache TTL in minutes for search results. */
       cacheTtlMinutes?: number;
-      /** Perplexity-specific configuration (used when provider="perplexity"). */
-      perplexity?: {
-        /** API key for Perplexity (defaults to PERPLEXITY_API_KEY env var). */
+      /** Brave-specific configuration (used when provider="brave"). */
+      brave?: {
+        /** Brave Search mode: "web" (standard results) or "llm-context" (pre-extracted page content). Default: "web". */
+        mode?: "web" | "llm-context";
+      };
+      /** Gemini-specific configuration (used when provider="gemini"). */
+      gemini?: {
+        /** Gemini API key (defaults to GEMINI_API_KEY env var). */
         apiKey?: SecretInput;
-        /** @deprecated Legacy Sonar/OpenRouter field. Ignored by Search API. */
-        baseUrl?: string;
-        /** @deprecated Legacy Sonar/OpenRouter field. Ignored by Search API. */
+        /** Model to use for grounded search (defaults to "gemini-2.5-flash"). */
         model?: string;
       };
       /** Grok-specific configuration (used when provider="grok"). */
@@ -246,13 +249,6 @@ export type ToolsConfig = {
         model?: string;
         /** Include inline citations in response text as markdown links (default: false). */
         inlineCitations?: boolean;
-      };
-      /** Gemini-specific configuration (used when provider="gemini"). */
-      gemini?: {
-        /** Gemini API key (defaults to GEMINI_API_KEY env var). */
-        apiKey?: SecretInput;
-        /** Model to use for grounded search (defaults to "gemini-2.5-flash"). */
-        model?: string;
       };
       /** Kimi-specific configuration (used when provider="kimi"). */
       kimi?: {

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -259,6 +259,15 @@ export type ToolsConfig = {
         /** Model to use (defaults to "moonshot-v1-128k"). */
         model?: string;
       };
+      /** Perplexity-specific configuration (used when provider="perplexity"). */
+      perplexity?: {
+        /** API key for Perplexity (defaults to PERPLEXITY_API_KEY env var). */
+        apiKey?: SecretInput;
+        /** @deprecated Legacy Sonar/OpenRouter field. Ignored by Search API. */
+        baseUrl?: string;
+        /** @deprecated Legacy Sonar/OpenRouter field. Ignored by Search API. */
+        model?: string;
+      };
     };
     fetch?: {
       /** Enable web fetch tool (default: true). */

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -244,8 +244,8 @@ describe("infra runtime", () => {
         await vi.advanceTimersByTimeAsync(0);
         expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
 
-        // Advance past the 30s max deferral wait
-        await vi.advanceTimersByTimeAsync(30_000);
+        // Advance past the 90s max deferral wait
+        await vi.advanceTimersByTimeAsync(90_000);
         expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
       } finally {
         process.removeListener("SIGUSR1", handler);

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -19,7 +19,8 @@ export type RestartAttempt = {
 const SPAWN_TIMEOUT_MS = 2000;
 const SIGUSR1_AUTH_GRACE_MS = 5000;
 const DEFAULT_DEFERRAL_POLL_MS = 500;
-const DEFAULT_DEFERRAL_MAX_WAIT_MS = 30_000;
+// Cover slow in-flight embedded compaction work before forcing restart.
+const DEFAULT_DEFERRAL_MAX_WAIT_MS = 90_000;
 const RESTART_COOLDOWN_MS = 30_000;
 
 const restartLog = createSubsystemLogger("restart");

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -12,6 +12,19 @@ function makeStream(chunks: Uint8Array[]) {
   });
 }
 
+function makeStallingFetch(firstChunk: Uint8Array) {
+  return vi.fn(async () => {
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(firstChunk);
+        },
+      }),
+      { status: 200 },
+    );
+  });
+}
+
 describe("fetchRemoteMedia", () => {
   type LookupFn = NonNullable<Parameters<typeof fetchRemoteMedia>[0]["lookupFn"]>;
 
@@ -53,6 +66,26 @@ describe("fetchRemoteMedia", () => {
       }),
     ).rejects.toThrow("exceeds maxBytes");
   });
+
+  it("aborts stalled body reads when idle timeout expires", async () => {
+    const lookupFn = vi.fn(async () => [
+      { address: "93.184.216.34", family: 4 },
+    ]) as unknown as LookupFn;
+    const fetchImpl = makeStallingFetch(new Uint8Array([1, 2]));
+
+    await expect(
+      fetchRemoteMedia({
+        url: "https://example.com/file.bin",
+        fetchImpl,
+        lookupFn,
+        maxBytes: 1024,
+        readIdleTimeoutMs: 20,
+      }),
+    ).rejects.toMatchObject({
+      code: "fetch_failed",
+      name: "MediaFetchError",
+    });
+  }, 5_000);
 
   it("blocks private IP literals before fetching", async () => {
     const fetchImpl = vi.fn();

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -31,6 +31,8 @@ type FetchMediaOptions = {
   filePathHint?: string;
   maxBytes?: number;
   maxRedirects?: number;
+  /** Abort if the response body stops yielding data for this long (ms). */
+  readIdleTimeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
   lookupFn?: LookupFn;
 };
@@ -87,6 +89,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     filePathHint,
     maxBytes,
     maxRedirects,
+    readIdleTimeoutMs,
     ssrfPolicy,
     lookupFn,
   } = options;
@@ -142,15 +145,27 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
       }
     }
 
-    const buffer = maxBytes
-      ? await readResponseWithLimit(res, maxBytes, {
-          onOverflow: ({ maxBytes, res }) =>
-            new MediaFetchError(
-              "max_bytes",
-              `Failed to fetch media from ${res.url || url}: payload exceeds maxBytes ${maxBytes}`,
-            ),
-        })
-      : Buffer.from(await res.arrayBuffer());
+    let buffer: Buffer;
+    try {
+      buffer = maxBytes
+        ? await readResponseWithLimit(res, maxBytes, {
+            onOverflow: ({ maxBytes, res }) =>
+              new MediaFetchError(
+                "max_bytes",
+                `Failed to fetch media from ${res.url || url}: payload exceeds maxBytes ${maxBytes}`,
+              ),
+            chunkTimeoutMs: readIdleTimeoutMs,
+          })
+        : Buffer.from(await res.arrayBuffer());
+    } catch (err) {
+      if (err instanceof MediaFetchError) {
+        throw err;
+      }
+      throw new MediaFetchError(
+        "fetch_failed",
+        `Failed to fetch media from ${res.url || url}: ${String(err)}`,
+      );
+    }
     let fileNameFromUrl: string | undefined;
     try {
       const parsed = new URL(finalUrl);

--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { readResponseWithLimit } from "./read-response-with-limit.js";
+
+function makeStream(chunks: Uint8Array[], delayMs?: number) {
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      for (const chunk of chunks) {
+        if (delayMs) {
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+function makeStallingStream(initialChunks: Uint8Array[]) {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of initialChunks) {
+        controller.enqueue(chunk);
+      }
+    },
+  });
+}
+
+describe("readResponseWithLimit", () => {
+  it("reads all chunks within the limit", async () => {
+    const body = makeStream([new Uint8Array([1, 2]), new Uint8Array([3, 4])]);
+    const res = new Response(body);
+    const buf = await readResponseWithLimit(res, 100);
+    expect(buf).toEqual(Buffer.from([1, 2, 3, 4]));
+  });
+
+  it("throws when total exceeds maxBytes", async () => {
+    const body = makeStream([new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])]);
+    const res = new Response(body);
+    await expect(readResponseWithLimit(res, 4)).rejects.toThrow(/too large/i);
+  });
+
+  it("calls custom onOverflow", async () => {
+    const body = makeStream([new Uint8Array(10)]);
+    const res = new Response(body);
+    await expect(
+      readResponseWithLimit(res, 5, {
+        onOverflow: ({ size, maxBytes }) => new Error(`custom: ${size} > ${maxBytes}`),
+      }),
+    ).rejects.toThrow("custom: 10 > 5");
+  });
+
+  it("times out when no new chunk arrives before idle timeout", async () => {
+    const body = makeStallingStream([new Uint8Array([1, 2])]);
+    const res = new Response(body);
+    await expect(readResponseWithLimit(res, 1024, { chunkTimeoutMs: 50 })).rejects.toThrow(
+      /stalled/i,
+    );
+  }, 5_000);
+
+  it("does not time out while chunks keep arriving", async () => {
+    const body = makeStream([new Uint8Array([1]), new Uint8Array([2])], 10);
+    const res = new Response(body);
+    const buf = await readResponseWithLimit(res, 100, { chunkTimeoutMs: 500 });
+    expect(buf).toEqual(Buffer.from([1, 2]));
+  });
+});

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -1,14 +1,55 @@
+async function readChunkWithIdleTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  chunkTimeoutMs: number,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+
+  return await new Promise((resolve, reject) => {
+    const clear = () => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+    };
+
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      clear();
+      void reader.cancel().catch(() => undefined);
+      reject(new Error(`Media download stalled: no data received for ${chunkTimeoutMs}ms`));
+    }, chunkTimeoutMs);
+
+    void reader.read().then(
+      (result) => {
+        clear();
+        if (!timedOut) {
+          resolve(result);
+        }
+      },
+      (err) => {
+        clear();
+        if (!timedOut) {
+          reject(err);
+        }
+      },
+    );
+  });
+}
+
 export async function readResponseWithLimit(
   res: Response,
   maxBytes: number,
   opts?: {
     onOverflow?: (params: { size: number; maxBytes: number; res: Response }) => Error;
+    chunkTimeoutMs?: number;
   },
 ): Promise<Buffer> {
   const onOverflow =
     opts?.onOverflow ??
     ((params: { size: number; maxBytes: number }) =>
       new Error(`Content too large: ${params.size} bytes (limit: ${params.maxBytes} bytes)`));
+  const chunkTimeoutMs = opts?.chunkTimeoutMs;
 
   const body = res.body;
   if (!body || typeof body.getReader !== "function") {
@@ -24,7 +65,9 @@ export async function readResponseWithLimit(
   let total = 0;
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = chunkTimeoutMs
+        ? await readChunkWithIdleTimeout(reader, chunkTimeoutMs)
+        : await reader.read();
       if (done) {
         break;
       }

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -100,6 +100,9 @@ function resolveRequiredFetchImpl(proxyFetch?: typeof fetch): typeof fetch {
   return fetchImpl;
 }
 
+/** Default idle timeout for Telegram media downloads (30 seconds). */
+const TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS = 30_000;
+
 async function downloadAndSaveTelegramFile(params: {
   filePath: string;
   token: string;
@@ -113,6 +116,7 @@ async function downloadAndSaveTelegramFile(params: {
     fetchImpl: params.fetchImpl,
     filePathHint: params.filePath,
     maxBytes: params.maxBytes,
+    readIdleTimeoutMs: TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS,
     ssrfPolicy: TELEGRAM_MEDIA_SSRF_POLICY,
   });
   const originalName = params.telegramFileName ?? fetched.fileName ?? params.filePath;

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -331,7 +331,7 @@ export async function runOnboardingWizard(
   }
 
   const snapshot = await readConfigFileSnapshot();
-  let baseConfig: RemoteClawConfig = snapshot.valid ? snapshot.config : {};
+  let baseConfig: RemoteClawConfig = snapshot.valid ? (snapshot.exists ? snapshot.config : {}) : {};
 
   if (snapshot.exists && !snapshot.valid) {
     await prompter.note(onboardHelpers.summarizeExistingConfig(baseConfig), "Invalid config");


### PR DESCRIPTION
Closes #919

## Commits

| Hash | Subject | Result |
|------|---------|--------|
| `f6243916b` | fix(models): use 1M context for openai-codex gpt-5.4 (#37876) | SKIPPED — all changes in gutted files |
| `4d501e4cc` | fix(telegram): add download timeout to prevent polling loop hang (#40098) | RESOLVED — CHANGELOG conflict |
| `adec8b28b` | alphabetize web search providers (#40259) | RESOLVED — gutted/rebranded file conflicts |
| `1d6a2d016` | fix(gateway): exit non-zero on restart shutdown timeout | PICKED |
| `eea925b12` | fix(gateway): validate config before restart to prevent crash + macOS permission | PICKED |
| `6740cdf16` | fix(gateway): catch startup failure in run loop to prevent process exit (#35862) | PICKED |
| `335223af3` | test: add runServiceStart config pre-flight tests (#35862) | PICKED |
| `c79a0dbdb` | fix: address bot review feedback on #35862 | PICKED |
| `f184e7811` | fix: move config pre-flight before onNotLoaded in runServiceRestart (Codex P2) | PICKED |
| `f84adcbe8` | fix: release gateway lock on restart failure + reply to Codex reviews | PICKED |
| `2e79d8219` | build: update app deps except carbon | SKIPPED — all alive changes in gutted/rebranded files |
| `cc0f30f5f` | test: fix windows runtime and restart loop harnesses | RESOLVED — gutted test conflict |
| `1d3dde8d2` | fix(update): re-enable launchd service before updater bootstrap | RESOLVED — rebrand conflict in test |
| `3caab9260` | test: narrow gateway loop signal harness | PICKED |
| `7217b9765` | fix(onboard): avoid persisting talk fallback on fresh setup | RESOLVED — rebrand conflicts |
| `54be30ef8` | fix(agents): bound compaction retry wait and drain embedded runs on restart (#40324) | RESOLVED — gutted pi-embedded-runner files |
| `d86647d7d` | Doctor: fix non-interactive cron repair gating (#41386) | PICKED |
| `c0cba7fb7` | Fix one-shot exit hangs by tearing down cached memory managers (#40389) | RESOLVED — gutted memory files, rebrand conflicts |