### PR TITLE
Cherry-pick issue #921: android-talk-config-pnpm-secrets-release

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12910,14 +12910,14 @@
         "filename": "src/telegram/monitor.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 450
+        "line_number": 497
       },
       {
         "type": "Secret Keyword",
         "filename": "src/telegram/monitor.test.ts",
         "hashed_secret": "5934c4d4a4fa5d66ddb3d3fc0bba84996c17a5b7",
         "is_verified": false,
-        "line_number": 641
+        "line_number": 688
       }
     ],
     "src/telegram/webhook.test.ts": [

--- a/.swiftformat
+++ b/.swiftformat
@@ -48,4 +48,4 @@
 --allman false
 
 # Exclusions
---exclude .build,.swiftpm,DerivedData,node_modules,dist,coverage,xcuserdata,Peekaboo,Swabble,apps/android,apps/ios,apps/shared,apps/macos/Sources/RemoteClawProtocol
+--exclude .build,.swiftpm,DerivedData,node_modules,dist,coverage,xcuserdata,Peekaboo,Swabble,apps/android,apps/ios,apps/shared,apps/macos/Sources/RemoteClawProtocol,apps/macos/Sources/RemoteClaw/HostEnvSecurityPolicy.generated.swift

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,6 +19,8 @@ excluded:
   - "*.playground"
   # Generated (protocol-gen-swift.ts)
   - apps/macos/Sources/RemoteClawProtocol/GatewayModels.swift
+  # Generated (generate-host-env-security-policy-swift.mjs)
+  - apps/macos/Sources/RemoteClaw/HostEnvSecurityPolicy.generated.swift
 
 analyzer_rules:
   - unused_declaration

--- a/test-fixtures/talk-config-contract.json
+++ b/test-fixtures/talk-config-contract.json
@@ -82,7 +82,7 @@
         "provider": "elevenlabs",
         "normalizedPayload": false,
         "voiceId": "voice-legacy",
-        "apiKey": "legacy-key"
+        "apiKey": "xxxxx"
       },
       "talk": {
         "voiceId": "voice-legacy",


### PR DESCRIPTION
## Cherry-picks from upstream (issue #921)

8 commits processed (3 landed, 5 skipped).

| Hash | Subject | Result |
|------|---------|--------|
| f114a5c63 | test: fix android talk config contract fixture | PICKED |
| e2a1a4a3d | build: sync pnpm lockfile | SKIPPED — fork overrides mismatch, upstream lockfile incompatible |
| 9631f4665 | chore: refresh secrets baseline | RESOLVED |
| 250d3c949 | chore: update appcast for 2026.3.8-beta.1 | SKIPPED — appcast.xml deleted in fork |
| 98ea71aca | fix(swiftformat): exclude HostEnvSecurityPolicy.generated.swift | RESOLVED |
| 258b7902a | Update CONTRIBUTING.md | SKIPPED — fork-protected file |
| 2cce45962 | Add Robin Waslander to maintainers | SKIPPED — fork-protected CONTRIBUTING.md |
| 4815dc060 | Update CONTRIBUTING.md | SKIPPED — fork-protected file |

Closes #921