### PR TITLE
Cherry-pick issue #922: tool-re-exposure-skill-roots-node24-tests

### DIFF
--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -105,11 +105,11 @@ const hostMemoryGiB = Math.floor(os.totalmem() / 1024 ** 3);
 const highMemLocalHost = !isCI && hostMemoryGiB >= 96;
 const lowMemLocalHost = !isCI && hostMemoryGiB < 64;
 const nodeMajor = Number.parseInt(process.versions.node.split(".")[0] ?? "", 10);
-// vmForks is a big win for transform/import heavy suites, but Node 24 had
-// regressions with Vitest's vm runtime in this repo, and low-memory local hosts
+// vmForks is a big win for transform/import heavy suites, but Node 24+
+// regressed with Vitest's vm runtime in this repo, and low-memory local hosts
 // are more likely to hit per-worker V8 heap ceilings. Keep it opt-out via
 // REMOTECLAW_TEST_VM_FORKS=0, and let users force-enable with =1.
-const supportsVmForks = Number.isFinite(nodeMajor) ? nodeMajor !== 24 : true;
+const supportsVmForks = Number.isFinite(nodeMajor) ? nodeMajor < 24 : true;
 const useVmForks =
   process.env.REMOTECLAW_TEST_VM_FORKS === "1" ||
   (process.env.REMOTECLAW_TEST_VM_FORKS !== "0" &&

--- a/src/agents/agent-helpers/errors.ts
+++ b/src/agents/agent-helpers/errors.ts
@@ -166,7 +166,7 @@ const HTTP_STATUS_PREFIX_RE = /^(?:http\s*)?(\d{3})\s+(.+)$/i;
 const HTTP_STATUS_CODE_PREFIX_RE = /^(?:http\s*)?(\d{3})(?:\s+([\s\S]+))?$/i;
 const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
 const CLOUDFLARE_HTML_ERROR_CODES = new Set([521, 522, 523, 524, 525, 526, 530]);
-const TRANSIENT_HTTP_ERROR_CODES = new Set([500, 502, 503, 504, 521, 522, 523, 524, 529]);
+const TRANSIENT_HTTP_ERROR_CODES = new Set([499, 500, 502, 503, 504, 521, 522, 523, 524, 529]);
 const HTTP_ERROR_HINTS = [
   "error",
   "bad request",
@@ -365,6 +365,12 @@ export function classifyFailoverReasonFromHttpStatus(
     return "timeout";
   }
   if (status === 503) {
+    if (message && isOverloadedErrorMessage(message)) {
+      return "overloaded";
+    }
+    return "timeout";
+  }
+  if (status === 499) {
     if (message && isOverloadedErrorMessage(message)) {
       return "overloaded";
     }

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -65,6 +65,7 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ statusCode: "429" })).toBe("rate_limit");
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ status: 499 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
     // Keep the status-only path behavior-preserving and conservative.
     expect(resolveFailoverReasonFromError({ status: 500 })).toBeNull();
@@ -88,6 +89,12 @@ describe("failover-error", () => {
     expect(
       resolveFailoverReasonFromError({
         status: 529,
+        message: ANTHROPIC_OVERLOADED_PAYLOAD,
+      }),
+    ).toBe("overloaded");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 499,
         message: ANTHROPIC_OVERLOADED_PAYLOAD,
       }),
     ).toBe("overloaded");

--- a/src/agents/subagent-registry.archive.e2e.test.ts
+++ b/src/agents/subagent-registry.archive.e2e.test.ts
@@ -17,11 +17,15 @@ vi.mock("../infra/agent-events.js", () => ({
   onAgentEvent: vi.fn((_handler: unknown) => noop),
 }));
 
-vi.mock("../config/config.js", () => ({
-  loadConfig: vi.fn(() => ({
-    agents: { defaults: { subagents: { archiveAfterMinutes: 60 } } },
-  })),
-}));
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: vi.fn(() => ({
+      agents: { defaults: { subagents: { archiveAfterMinutes: 60 } } },
+    })),
+  };
+});
 
 vi.mock("./subagent-announce.js", () => ({
   runSubagentAnnounceFlow: vi.fn(async () => true),

--- a/src/agents/subagent-registry.nested.e2e.test.ts
+++ b/src/agents/subagent-registry.nested.e2e.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import "./subagent-registry.mocks.shared.js";
 
-vi.mock("../config/config.js", () => ({
-  loadConfig: vi.fn(() => ({
-    agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
-  })),
-}));
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: vi.fn(() => ({
+      agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
+    })),
+  };
+});
 
 vi.mock("./subagent-announce.js", () => ({
   runSubagentAnnounceFlow: vi.fn(async () => true),

--- a/src/agents/tool-policy-resolution.test.ts
+++ b/src/agents/tool-policy-resolution.test.ts
@@ -179,7 +179,7 @@ describe("resolveEffectiveToolPolicy", () => {
         profile: "messaging",
         exec: { host: "sandbox" },
       },
-    } as OpenClawConfig;
+    } as RemoteClawConfig;
     const result = resolveEffectiveToolPolicy({ config: cfg });
     expect(result.profileAlsoAllow).toEqual(["exec", "process"]);
   });
@@ -190,7 +190,7 @@ describe("resolveEffectiveToolPolicy", () => {
         profile: "messaging",
         fs: { workspaceOnly: false },
       },
-    } as OpenClawConfig;
+    } as RemoteClawConfig;
     const result = resolveEffectiveToolPolicy({ config: cfg });
     expect(result.profileAlsoAllow).toEqual(["read", "write", "edit"]);
   });
@@ -202,7 +202,7 @@ describe("resolveEffectiveToolPolicy", () => {
         alsoAllow: ["web_search"],
         exec: { host: "sandbox" },
       },
-    } as OpenClawConfig;
+    } as RemoteClawConfig;
     const result = resolveEffectiveToolPolicy({ config: cfg });
     expect(result.profileAlsoAllow).toEqual(["web_search", "exec", "process"]);
   });
@@ -222,7 +222,7 @@ describe("resolveEffectiveToolPolicy", () => {
           },
         ],
       },
-    } as OpenClawConfig;
+    } as RemoteClawConfig;
     const result = resolveEffectiveToolPolicy({ config: cfg, agentId: "coder" });
     expect(result.profileAlsoAllow).toEqual(["read", "write", "edit"]);
   });

--- a/src/agents/tool-policy-resolution.test.ts
+++ b/src/agents/tool-policy-resolution.test.ts
@@ -4,6 +4,7 @@ import { createStubTool } from "./test-helpers/pi-tool-stubs.js";
 import {
   filterToolsByPolicy,
   isToolAllowedByPolicyName,
+  resolveEffectiveToolPolicy,
   resolveSubagentToolPolicy,
 } from "./tool-policy-resolution.js";
 
@@ -168,5 +169,61 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
     const policy = resolveSubagentToolPolicy(leafCfg);
     // Default depth=1, maxSpawnDepth=1 → leaf
     expect(isToolAllowedByPolicyName("sessions_spawn", policy)).toBe(false);
+  });
+});
+
+describe("resolveEffectiveToolPolicy", () => {
+  it("implicitly re-exposes exec and process when tools.exec is configured", () => {
+    const cfg = {
+      tools: {
+        profile: "messaging",
+        exec: { host: "sandbox" },
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg });
+    expect(result.profileAlsoAllow).toEqual(["exec", "process"]);
+  });
+
+  it("implicitly re-exposes read, write, and edit when tools.fs is configured", () => {
+    const cfg = {
+      tools: {
+        profile: "messaging",
+        fs: { workspaceOnly: false },
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg });
+    expect(result.profileAlsoAllow).toEqual(["read", "write", "edit"]);
+  });
+
+  it("merges explicit alsoAllow with implicit tool-section exposure", () => {
+    const cfg = {
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["web_search"],
+        exec: { host: "sandbox" },
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg });
+    expect(result.profileAlsoAllow).toEqual(["web_search", "exec", "process"]);
+  });
+
+  it("uses agent tool sections when resolving implicit exposure", () => {
+    const cfg = {
+      tools: {
+        profile: "messaging",
+      },
+      agents: {
+        list: [
+          {
+            id: "coder",
+            tools: {
+              fs: { workspaceOnly: true },
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg, agentId: "coder" });
+    expect(result.profileAlsoAllow).toEqual(["read", "write", "edit"]);
   });
 });

--- a/src/agents/tool-policy-resolution.ts
+++ b/src/agents/tool-policy-resolution.ts
@@ -207,7 +207,7 @@ function resolveProviderToolPolicy(params: {
   return undefined;
 }
 
-function resolveExplicitProfileAlsoAllow(tools?: OpenClawConfig["tools"]): string[] | undefined {
+function resolveExplicitProfileAlsoAllow(tools?: RemoteClawConfig["tools"]): string[] | undefined {
   return Array.isArray(tools?.alsoAllow) ? tools.alsoAllow : undefined;
 }
 
@@ -216,7 +216,7 @@ function hasExplicitToolSection(section: unknown): boolean {
 }
 
 function resolveImplicitProfileAlsoAllow(params: {
-  globalTools?: OpenClawConfig["tools"];
+  globalTools?: RemoteClawConfig["tools"];
   agentTools?: AgentToolsConfig;
 }): string[] | undefined {
   const implicit = new Set<string>();

--- a/src/agents/tool-policy-resolution.ts
+++ b/src/agents/tool-policy-resolution.ts
@@ -2,6 +2,7 @@ import { getChannelDock } from "../channels/dock.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { resolveChannelGroupToolsPolicy } from "../config/group-policy.js";
+import type { AgentToolsConfig } from "../config/types.tools.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveThreadParentSessionKey } from "../sessions/session-key-utils.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
@@ -206,6 +207,37 @@ function resolveProviderToolPolicy(params: {
   return undefined;
 }
 
+function resolveExplicitProfileAlsoAllow(tools?: OpenClawConfig["tools"]): string[] | undefined {
+  return Array.isArray(tools?.alsoAllow) ? tools.alsoAllow : undefined;
+}
+
+function hasExplicitToolSection(section: unknown): boolean {
+  return section !== undefined && section !== null;
+}
+
+function resolveImplicitProfileAlsoAllow(params: {
+  globalTools?: OpenClawConfig["tools"];
+  agentTools?: AgentToolsConfig;
+}): string[] | undefined {
+  const implicit = new Set<string>();
+  if (
+    hasExplicitToolSection(params.agentTools?.exec) ||
+    hasExplicitToolSection(params.globalTools?.exec)
+  ) {
+    implicit.add("exec");
+    implicit.add("process");
+  }
+  if (
+    hasExplicitToolSection(params.agentTools?.fs) ||
+    hasExplicitToolSection(params.globalTools?.fs)
+  ) {
+    implicit.add("read");
+    implicit.add("write");
+    implicit.add("edit");
+  }
+  return implicit.size > 0 ? Array.from(implicit) : undefined;
+}
+
 export function resolveEffectiveToolPolicy(params: {
   config?: RemoteClawConfig;
   sessionKey?: string;
@@ -236,6 +268,15 @@ export function resolveEffectiveToolPolicy(params: {
     modelProvider: params.modelProvider,
     modelId: params.modelId,
   });
+  const explicitProfileAlsoAllow =
+    resolveExplicitProfileAlsoAllow(agentTools) ?? resolveExplicitProfileAlsoAllow(globalTools);
+  const implicitProfileAlsoAllow = resolveImplicitProfileAlsoAllow({ globalTools, agentTools });
+  const profileAlsoAllow =
+    explicitProfileAlsoAllow || implicitProfileAlsoAllow
+      ? Array.from(
+          new Set([...(explicitProfileAlsoAllow ?? []), ...(implicitProfileAlsoAllow ?? [])]),
+        )
+      : undefined;
   return {
     agentId,
     globalPolicy: normalizeToolPolicy(globalTools),
@@ -245,11 +286,7 @@ export function resolveEffectiveToolPolicy(params: {
     profile,
     providerProfile: agentProviderPolicy?.profile ?? providerPolicy?.profile,
     // alsoAllow is applied at the profile stage (to avoid being filtered out early).
-    profileAlsoAllow: Array.isArray(agentTools?.alsoAllow)
-      ? agentTools?.alsoAllow
-      : Array.isArray(globalTools?.alsoAllow)
-        ? globalTools?.alsoAllow
-        : undefined,
+    profileAlsoAllow,
     providerProfileAlsoAllow: Array.isArray(agentProviderPolicy?.alsoAllow)
       ? agentProviderPolicy?.alsoAllow
       : Array.isArray(providerPolicy?.alsoAllow)

--- a/src/auth/usage.test.ts
+++ b/src/auth/usage.test.ts
@@ -577,6 +577,10 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
     });
   }
 
+  // When a cooldown/disabled window expires, the error count resets to prevent
+  // stale counters from escalating the next cooldown (the root cause of
+  // infinite cooldown loops — see #40989). The next failure should compute
+  // backoff from errorCount=1, not from the accumulated stale count.
   const expiredWindowCases = [
     {
       label: "cooldownUntil",
@@ -586,7 +590,8 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
         errorCount: 3,
         lastFailureAt: now - 60_000,
       }),
-      expectedUntil: (now: number) => now + 60 * 60 * 1000,
+      // errorCount resets → calculateAuthProfileCooldownMs(1) = 60_000
+      expectedUntil: (now: number) => now + 60_000,
       readUntil: (stats: WindowStats | undefined) => stats?.cooldownUntil,
     },
     {
@@ -599,7 +604,9 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
         failureCounts: { billing: 2 },
         lastFailureAt: now - 60_000,
       }),
-      expectedUntil: (now: number) => now + 20 * 60 * 60 * 1000,
+      // errorCount resets, billing count resets to 1 →
+      // calculateAuthProfileBillingDisableMsWithConfig(1, 5h, 24h) = 5h
+      expectedUntil: (now: number) => now + 5 * 60 * 60 * 1000,
       readUntil: (stats: WindowStats | undefined) => stats?.disabledUntil,
     },
   ];

--- a/src/auth/usage.ts
+++ b/src/auth/usage.ts
@@ -397,9 +397,19 @@ function computeNextProfileUsageStats(params: {
     params.existing.lastFailureAt > 0 &&
     params.now - params.existing.lastFailureAt > windowMs;
 
-  const baseErrorCount = windowExpired ? 0 : (params.existing.errorCount ?? 0);
+  // If the previous cooldown has already expired, reset error counters so the
+  // profile gets a fresh backoff window. clearExpiredCooldowns() does this
+  // in-memory during profile ordering, but the on-disk state may still carry
+  // the old counters when the lock-based updater reads a fresh store. Without
+  // this check, stale error counts from an expired cooldown cause the next
+  // failure to escalate to a much longer cooldown (e.g. 1 min → 25 min).
+  const unusableUntil = resolveProfileUnusableUntil(params.existing);
+  const previousCooldownExpired = typeof unusableUntil === "number" && params.now >= unusableUntil;
+
+  const shouldResetCounters = windowExpired || previousCooldownExpired;
+  const baseErrorCount = shouldResetCounters ? 0 : (params.existing.errorCount ?? 0);
   const nextErrorCount = baseErrorCount + 1;
-  const failureCounts = windowExpired ? {} : { ...params.existing.failureCounts };
+  const failureCounts = shouldResetCounters ? {} : { ...params.existing.failureCounts };
   failureCounts[params.reason] = (failureCounts[params.reason] ?? 0) + 1;
 
   const updatedStats: ProfileUsageStats = {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -9,6 +9,7 @@ import { shouldSkipRespawnForArgv } from "./cli/respawn-policy.js";
 import { normalizeWindowsArgv } from "./cli/windows-argv.js";
 import { isTruthyEnvValue, normalizeEnv } from "./infra/env.js";
 import { isMainModule } from "./infra/is-main.js";
+import { ensureRemoteClawExecMarkerOnProcess } from "./infra/remoteclaw-exec-env.js";
 import { installProcessWarningFilter } from "./infra/warning-filter.js";
 import { attachChildProcessBridge } from "./process/child-process-bridge.js";
 
@@ -31,6 +32,7 @@ if (
   // Imported as a dependency — skip all entry-point side effects.
 } else {
   process.title = "remoteclaw";
+  ensureRemoteClawExecMarkerOnProcess();
   installProcessWarningFilter();
   normalizeEnv();
   if (!isTruthyEnvValue(process.env.NODE_DISABLE_COMPILE_CACHE)) {

--- a/src/infra/host-env-security.test.ts
+++ b/src/infra/host-env-security.test.ts
@@ -10,6 +10,7 @@ import {
   sanitizeHostExecEnv,
   sanitizeSystemRunEnvOverrides,
 } from "./host-env-security.js";
+import { REMOTECLAW_CLI_ENV_VALUE } from "./remoteclaw-exec-env.js";
 
 describe("isDangerousHostEnvVarName", () => {
   it("matches dangerous keys and prefixes case-insensitively", () => {
@@ -40,6 +41,7 @@ describe("sanitizeHostExecEnv", () => {
     });
 
     expect(env).toEqual({
+      REMOTECLAW_CLI: REMOTECLAW_CLI_ENV_VALUE,
       PATH: "/usr/bin:/bin",
       OK: "1",
     });
@@ -68,6 +70,7 @@ describe("sanitizeHostExecEnv", () => {
     });
 
     expect(env.PATH).toBe("/usr/bin:/bin");
+    expect(env.REMOTECLAW_CLI).toBe(REMOTECLAW_CLI_ENV_VALUE);
     expect(env.BASH_ENV).toBeUndefined();
     expect(env.GIT_SSH_COMMAND).toBeUndefined();
     expect(env.EDITOR).toBeUndefined();
@@ -91,6 +94,7 @@ describe("sanitizeHostExecEnv", () => {
     });
 
     expect(env.PATH).toBe("/usr/bin:/bin");
+    expect(env.REMOTECLAW_CLI).toBe(REMOTECLAW_CLI_ENV_VALUE);
     expect(env.OK).toBe("1");
     expect(env.SHELLOPTS).toBeUndefined();
     expect(env.PS4).toBeUndefined();
@@ -109,6 +113,7 @@ describe("sanitizeHostExecEnv", () => {
     });
 
     expect(env.GOOD_KEY).toBe("ok");
+    expect(env.REMOTECLAW_CLI).toBe(REMOTECLAW_CLI_ENV_VALUE);
     expect(env[" BAD KEY"]).toBeUndefined();
     expect(env["NOT-PORTABLE"]).toBeUndefined();
   });

--- a/src/infra/host-env-security.ts
+++ b/src/infra/host-env-security.ts
@@ -1,4 +1,5 @@
 import HOST_ENV_SECURITY_POLICY_JSON from "./host-env-security-policy.json" with { type: "json" };
+import { markRemoteClawExecEnv } from "./remoteclaw-exec-env.js";
 
 const PORTABLE_ENV_VAR_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
@@ -101,7 +102,7 @@ export function sanitizeHostExecEnv(params?: {
   }
 
   if (!overrides) {
-    return merged;
+    return markRemoteClawExecEnv(merged);
   }
 
   for (const [rawKey, value] of Object.entries(overrides)) {
@@ -124,7 +125,7 @@ export function sanitizeHostExecEnv(params?: {
     merged[key] = value;
   }
 
-  return merged;
+  return markRemoteClawExecEnv(merged);
 }
 
 export function sanitizeSystemRunEnvOverrides(params?: {

--- a/src/infra/remoteclaw-exec-env.ts
+++ b/src/infra/remoteclaw-exec-env.ts
@@ -1,0 +1,16 @@
+export const REMOTECLAW_CLI_ENV_VAR = "REMOTECLAW_CLI";
+export const REMOTECLAW_CLI_ENV_VALUE = "1";
+
+export function markRemoteClawExecEnv<T extends Record<string, string | undefined>>(env: T): T {
+  return {
+    ...env,
+    [REMOTECLAW_CLI_ENV_VAR]: REMOTECLAW_CLI_ENV_VALUE,
+  };
+}
+
+export function ensureRemoteClawExecMarkerOnProcess(
+  env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  env[REMOTECLAW_CLI_ENV_VAR] = REMOTECLAW_CLI_ENV_VALUE;
+  return env;
+}

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
+import {
+  normalizePluginsConfig,
+  resolveEffectiveEnableState,
+  resolveEnableState,
+} from "./config-state.js";
 
 describe("resolveEffectiveEnableState", () => {
   it("enables bundled channels when channels.<id>.enabled=true", () => {
@@ -42,6 +46,37 @@ describe("resolveEffectiveEnableState", () => {
         },
       },
     });
+    expect(state).toEqual({ enabled: false, reason: "disabled in config" });
+  });
+});
+
+describe("resolveEnableState", () => {
+  it("keeps the selected memory slot plugin enabled even when omitted from plugins.allow", () => {
+    const state = resolveEnableState(
+      "memory-core",
+      "bundled",
+      normalizePluginsConfig({
+        allow: ["telegram"],
+        slots: { memory: "memory-core" },
+      }),
+    );
+    expect(state).toEqual({ enabled: true });
+  });
+
+  it("keeps explicit disable authoritative for the selected memory slot plugin", () => {
+    const state = resolveEnableState(
+      "memory-core",
+      "bundled",
+      normalizePluginsConfig({
+        allow: ["telegram"],
+        slots: { memory: "memory-core" },
+        entries: {
+          "memory-core": {
+            enabled: false,
+          },
+        },
+      }),
+    );
     expect(state).toEqual({ enabled: false, reason: "disabled in config" });
   });
 });

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -117,15 +117,15 @@ export function resolveEnableState(
   if (config.deny.includes(id)) {
     return { enabled: false, reason: "blocked by denylist" };
   }
+  const entry = config.entries[id];
+  if (entry?.enabled === false) {
+    return { enabled: false, reason: "disabled in config" };
+  }
   if (config.allow.length > 0 && !config.allow.includes(id)) {
     return { enabled: false, reason: "not in allowlist" };
   }
-  const entry = config.entries[id];
   if (entry?.enabled === true) {
     return { enabled: true };
-  }
-  if (entry?.enabled === false) {
-    return { enabled: false, reason: "disabled in config" };
   }
   if (origin === "bundled" && BUNDLED_ENABLED_BY_DEFAULT.has(id)) {
     return { enabled: true };

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -121,6 +121,9 @@ export function resolveEnableState(
   if (entry?.enabled === false) {
     return { enabled: false, reason: "disabled in config" };
   }
+  if (config.slots.memory === id) {
+    return { enabled: true };
+  }
   if (config.allow.length > 0 && !config.allow.includes(id)) {
     return { enabled: false, reason: "not in allowlist" };
   }

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -7,7 +7,7 @@ export type NormalizedPluginsConfig = {
   allow: string[];
   deny: string[];
   loadPaths: string[];
-  slots: Record<string, never>;
+  slots: { memory?: string };
   entries: Record<string, { enabled?: boolean; config?: unknown }>;
 };
 
@@ -54,7 +54,7 @@ export const normalizePluginsConfig = (
     allow: normalizeList(config?.allow),
     deny: normalizeList(config?.deny),
     loadPaths: normalizeList(config?.load?.paths),
-    slots: {} as Record<string, never>,
+    slots: { memory: config?.slots?.memory },
     entries: normalizePluginEntries(config?.entries),
   };
 };

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import process from "node:process";
 import { describe, expect, it, vi } from "vitest";
+import { REMOTECLAW_CLI_ENV_VALUE } from "../infra/remoteclaw-exec-env.js";
 import { attachChildProcessBridge } from "./child-process-bridge.js";
 import { resolveCommandEnv, runCommandWithTimeout, shouldSpawnWithShell } from "./exec.js";
 
@@ -31,6 +32,7 @@ describe("runCommandWithTimeout", () => {
     expect(resolved.REMOTECLAW_BASE_ENV).toBe("base");
     expect(resolved.REMOTECLAW_TEST_ENV).toBe("ok");
     expect(resolved.REMOTECLAW_TO_REMOVE).toBeUndefined();
+    expect(resolved.REMOTECLAW_CLI).toBe(REMOTECLAW_CLI_ENV_VALUE);
   });
 
   it("suppresses npm fund prompts for npm argv", async () => {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
 import { danger, shouldLogVerbose } from "../globals.js";
+import { markRemoteClawExecEnv } from "../infra/remoteclaw-exec-env.js";
 import { logDebug, logError } from "../logger.js";
 import { resolveCommandStdio } from "./spawn-utils.js";
 
@@ -212,7 +213,7 @@ export function resolveCommandEnv(params: {
       resolvedEnv.npm_config_fund = "false";
     }
   }
-  return resolvedEnv;
+  return markRemoteClawExecEnv(resolvedEnv);
 }
 
 export async function runCommandWithTimeout(


### PR DESCRIPTION
## Cherry-picks from upstream (issue #922)

8 commits triaged, 5 cherry-picked, 3 skipped (all changes in gutted files).

| Hash | Subject | Result |
|------|---------|--------|
| e8775cda9 | fix(agents): re-expose configured tools under restrictive profiles | RESOLVED — config-state.ts conflict (fork moved `const entry` up, kept new allowlist check) |
| 9abf014f3 | fix(skills): pin validated download roots | SKIPPED — all changes in deleted files (skills-install-download) |
| 8d2d6db9a | test: fix Node 24+ test runner and subagent registry mocks | RESOLVED — test-parallel.mjs conflict (kept fork rebrand, took `nodeMajor < 24` fix), removed deleted e2e test |
| 51bae7512 | fix(kimi-coding): fix kimi tool format | SKIPPED — all changes in gutted files (model provider schemas, pi-embedded tests) |
| 5f90883ad | fix(auth): reset cooldown error counters on expiry | RESOLVED — usage.test.ts conflict (kept fork's removal of auth_permanent test case), removed deleted auth-profiles test |
| 0669b0ddc | fix(agents): probe single-provider billing cooldowns | SKIPPED — all changes in gutted files (model-fallback, pi-embedded e2e) |
| c9a6c542e | Add HTTP 499 to transient error codes for model fallback | PICKED (partial) — kept alive files (errors.ts, failover-error.test.ts), discarded gutted pi-embedded test |
| b48291e01 | Exec: mark child command env with OPENCLAW_CLI | RESOLVED — rebranded OPENCLAW_CLI → REMOTECLAW_CLI, renamed openclaw-exec-env.ts → remoteclaw-exec-env.ts, updated all imports |

Closes #922