### PR TITLE
Cherry-pick issue #923: plugin-sdk-matrix-dm-msteams-allowlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+<<<<<<< ours
+
 - macOS/LaunchAgent install: tighten LaunchAgent directory and plist permissions during install so launchd bootstrap does not fail when the target home path or generated plist inherited group/world-writable modes.
 - Gateway/Control UI: keep dashboard auth tokens in session-scoped browser storage so same-tab refreshes preserve remote token auth without restoring long-lived localStorage token persistence, while scoping tokens to the selected gateway URL and fragment-only bootstrap flow. (#40892) thanks @velvet-shark.
 - Models/Kimi Coding: send `anthropic-messages` tools in native Anthropic format again so `kimi-coding` stops degrading tool calls into XML/plain-text pseudo invocations instead of real `tool_use` blocks. (#38669, #39907, #40552) Thanks @opriz.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-<<<<<<< ours
-
 - macOS/LaunchAgent install: tighten LaunchAgent directory and plist permissions during install so launchd bootstrap does not fail when the target home path or generated plist inherited group/world-writable modes.
 - Gateway/Control UI: keep dashboard auth tokens in session-scoped browser storage so same-tab refreshes preserve remote token auth without restoring long-lived localStorage token persistence, while scoping tokens to the selected gateway URL and fragment-only bootstrap flow. (#40892) thanks @velvet-shark.
 - Models/Kimi Coding: send `anthropic-messages` tools in native Anthropic format again so `kimi-coding` stops degrading tool calls into XML/plain-text pseudo invocations instead of real `tool_use` blocks. (#38669, #39907, #40552) Thanks @opriz.
@@ -37,6 +35,7 @@ Docs: https://docs.openclaw.ai
 - Agents/billing recovery: probe single-provider billing cooldowns on the existing throttle so topping up credits can recover without a manual gateway restart. (#41422) thanks @altaywtf.
 - ACP/follow-up hardening: make session restore and prompt completion degrade gracefully on transcript/update failures, enforce bounded tool-location traversal, and skip non-image ACPX turns the runtime cannot serialize. (#41464) Thanks @mbelinky.
 - Agents/fallback observability: add structured, sanitized model-fallback decision and auth-profile failure-state events with correlated run IDs so cooldown probes and failover paths are easier to trace in logs. (#41337) thanks @altaywtf.
+- Plugins/context-engine model auth: expose `runtime.modelAuth` and plugin-sdk auth helpers so plugins can resolve provider/model API keys through the normal auth pipeline. (#41090) thanks @xinhuagu.
 
 ## 2026.3.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Docs: https://docs.openclaw.ai
 - MS Teams/authz: keep `groupPolicy: "allowlist"` enforcing sender allowlists even when a team/channel route allowlist is configured, so route matches no longer widen group access to every sender in that route. Thanks @zpbrent.
 - Security/system.run: bind approved `bun` and `deno run` script operands to on-disk file snapshots so post-approval script rewrites are denied before execution.
 - Skills/download installs: pin the validated per-skill tools root before writing downloaded archives, so rebinding the lexical tools path cannot redirect download writes outside the intended tools directory. Thanks @tdjackey.
+- Matrix/DM routing: add safer fallback detection for broken `m.direct` homeservers, honor explicit room bindings over DM classification, and preserve room-bound agent selection for Matrix DM rooms. (#19736) Thanks @derbronko.
 
 ## 2026.3.7
 

--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -1,4 +1,4 @@
-import { parseFiniteNumber } from "../../../src/infra/parse-finite-number.js";
+import { parseFiniteNumber } from "openclaw/plugin-sdk/bluebubbles";
 import { extractHandleFromChatGuid, normalizeBlueBubblesHandle } from "./targets.js";
 import type { BlueBubblesAttachment } from "./types.js";
 

--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -1,4 +1,4 @@
-import { parseFiniteNumber } from "openclaw/plugin-sdk/bluebubbles";
+import { parseFiniteNumber } from "remoteclaw/plugin-sdk/bluebubbles";
 import { extractHandleFromChatGuid, normalizeBlueBubblesHandle } from "./targets.js";
 import type { BlueBubblesAttachment } from "./types.js";
 

--- a/extensions/matrix/src/matrix/monitor/direct.test.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.test.ts
@@ -1,65 +1,400 @@
-import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import { describe, expect, it, vi } from "vitest";
 import { createDirectRoomTracker } from "./direct.js";
 
-function createMockClient(params: {
-  isDm?: boolean;
-  senderDirect?: boolean;
-  selfDirect?: boolean;
-  members?: string[];
+// ---------------------------------------------------------------------------
+// Helpers -- minimal MatrixClient stub
+// ---------------------------------------------------------------------------
+
+type StateEvent = Record<string, unknown>;
+type DmMap = Record<string, boolean>;
+
+function createMockClient(opts: {
+  dmRooms?: DmMap;
+  membersByRoom?: Record<string, string[]>;
+  stateEvents?: Record<string, StateEvent>;
+  selfUserId?: string;
 }) {
-  const members = params.members ?? ["@alice:example.org", "@bot:example.org"];
+  const {
+    dmRooms = {},
+    membersByRoom = {},
+    stateEvents = {},
+    selfUserId = "@bot:example.org",
+  } = opts;
+
   return {
     dms: {
+      isDm: (roomId: string) => dmRooms[roomId] ?? false,
       update: vi.fn().mockResolvedValue(undefined),
-      isDm: vi.fn().mockReturnValue(params.isDm === true),
     },
-    getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
-    getJoinedRoomMembers: vi.fn().mockResolvedValue(members),
+    getUserId: vi.fn().mockResolvedValue(selfUserId),
+    getJoinedRoomMembers: vi.fn().mockImplementation(async (roomId: string) => {
+      return membersByRoom[roomId] ?? [];
+    }),
     getRoomStateEvent: vi
       .fn()
-      .mockImplementation(async (_roomId: string, _event: string, stateKey: string) => {
-        if (stateKey === "@alice:example.org") {
-          return { is_direct: params.senderDirect === true };
+      .mockImplementation(async (roomId: string, eventType: string, stateKey: string) => {
+        const key = `${roomId}|${eventType}|${stateKey}`;
+        const ev = stateEvents[key];
+        if (ev === undefined) {
+          // Simulate real homeserver M_NOT_FOUND response (matches MatrixError shape)
+          const err = new Error(`State event not found: ${key}`) as Error & {
+            errcode?: string;
+            statusCode?: number;
+          };
+          err.errcode = "M_NOT_FOUND";
+          err.statusCode = 404;
+          throw err;
         }
-        if (stateKey === "@bot:example.org") {
-          return { is_direct: params.selfDirect === true };
-        }
-        return {};
+        return ev;
       }),
-  } as unknown as MatrixClient;
+  };
 }
 
+// ---------------------------------------------------------------------------
+// Tests -- isDirectMessage
+// ---------------------------------------------------------------------------
+
 describe("createDirectRoomTracker", () => {
-  it("treats m.direct rooms as DMs", async () => {
-    const tracker = createDirectRoomTracker(createMockClient({ isDm: true }));
-    await expect(
-      tracker.isDirectMessage({
-        roomId: "!room:example.org",
+  describe("m.direct detection (SDK DM cache)", () => {
+    it("returns true when SDK DM cache marks room as DM", async () => {
+      const client = createMockClient({
+        dmRooms: { "!dm:example.org": true },
+      });
+      const tracker = createDirectRoomTracker(client as never);
+
+      const result = await tracker.isDirectMessage({
+        roomId: "!dm:example.org",
         senderId: "@alice:example.org",
-      }),
-    ).resolves.toBe(true);
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false for rooms not in SDK DM cache (with >2 members)", async () => {
+      const client = createMockClient({
+        dmRooms: {},
+        membersByRoom: {
+          "!group:example.org": ["@alice:example.org", "@bob:example.org", "@carol:example.org"],
+        },
+      });
+      const tracker = createDirectRoomTracker(client as never);
+
+      const result = await tracker.isDirectMessage({
+        roomId: "!group:example.org",
+        senderId: "@alice:example.org",
+      });
+
+      expect(result).toBe(false);
+    });
   });
 
-  it("does not classify 2-member rooms as DMs without direct flags", async () => {
-    const client = createMockClient({ isDm: false });
-    const tracker = createDirectRoomTracker(client);
-    await expect(
-      tracker.isDirectMessage({
+  describe("is_direct state flag detection", () => {
+    it("returns true when sender's membership has is_direct=true", async () => {
+      const client = createMockClient({
+        dmRooms: {},
+        membersByRoom: { "!room:example.org": ["@alice:example.org", "@bot:example.org"] },
+        stateEvents: {
+          "!room:example.org|m.room.member|@alice:example.org": { is_direct: true },
+          "!room:example.org|m.room.member|@bot:example.org": { is_direct: false },
+        },
+      });
+      const tracker = createDirectRoomTracker(client as never);
+
+      const result = await tracker.isDirectMessage({
         roomId: "!room:example.org",
         senderId: "@alice:example.org",
-      }),
-    ).resolves.toBe(false);
-    expect(client.getJoinedRoomMembers).not.toHaveBeenCalled();
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("returns true when bot's own membership has is_direct=true", async () => {
+      const client = createMockClient({
+        dmRooms: {},
+        membersByRoom: { "!room:example.org": ["@alice:example.org", "@bot:example.org"] },
+        stateEvents: {
+          "!room:example.org|m.room.member|@alice:example.org": { is_direct: false },
+          "!room:example.org|m.room.member|@bot:example.org": { is_direct: true },
+        },
+      });
+      const tracker = createDirectRoomTracker(client as never);
+
+      const result = await tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+        selfUserId: "@bot:example.org",
+      });
+
+      expect(result).toBe(true);
+    });
   });
 
-  it("uses is_direct member flags when present", async () => {
-    const tracker = createDirectRoomTracker(createMockClient({ senderDirect: true }));
-    await expect(
-      tracker.isDirectMessage({
+  describe("conservative fallback (memberCount + room name)", () => {
+    it("returns true for 2-member room WITHOUT a room name (broken flags)", async () => {
+      const client = createMockClient({
+        dmRooms: {},
+        membersByRoom: {
+          "!broken-dm:example.org": ["@alice:example.org", "@bot:example.org"],
+        },
+        stateEvents: {
+          // is_direct not set on either member (e.g. Continuwuity bug)
+          "!broken-dm:example.org|m.room.member|@alice:example.org": {},
+          "!broken-dm:example.org|m.room.member|@bot:example.org": {},
+          // No m.room.name -> getRoomStateEvent will throw (event not found)
+        },
+      });
+      const tracker = createDirectRoomTracker(client as never);
+
+      const result = await tracker.isDirectMessage({
+        roomId: "!broken-dm:example.org",
+        senderId: "@alice:example.org",
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("returns true for 2-member room with empty room name", async () => {
+      const client = createMockClient({
+        dmRooms: {},
+        membersByRoom: {
+          "!broken-dm:example.org": ["@alice:example.org", "@bot:example.org"],
+        },
+        stateEvents: {
+          "!broken-dm:example.org|m.room.member|@alice:example.org": {},
+          "!broken-dm:example.org|m.room.member|@bot:example.org": {},
+          "!broken-dm:example.org|m.room.name|": { name: "" },
+        },
+      });
+      const tracker = createDirectRoomTracker(client as never);
+
+      const result = await tracker.isDirectMessage({
+        roomId: "!broken-dm:example.org",
+        senderId: "@alice:example.org",
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false for 2-member room WITH a room name (named group)", async () => {
+      const client = createMockClient({
+        dmRooms: {},
+        membersByRoom: {
+          "!named-group:example.org": ["@alice:example.org", "@bob:example.org"],
+        },
+        stateEvents: {
+          "!named-group:example.org|m.room.member|@alice:example.org": {},
+          "!named-group:example.org|m.room.member|@bob:example.org": {},
+          "!named-group:example.org|m.room.name|": { name: "Project Alpha" },
+        },
+      });
+      const tracker = createDirectRoomTracker(client as never);
+
+      const result = await tracker.isDirectMessage({
+        roomId: "!named-group:example.org",
+        senderId: "@alice:example.org",
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false for 3+ member room without any DM signals", async () => {
+      const client = createMockClient({
+        dmRooms: {},
+        membersByRoom: {
+          "!group:example.org": ["@alice:example.org", "@bob:example.org", "@carol:example.org"],
+        },
+        stateEvents: {
+          "!group:example.org|m.room.member|@alice:example.org": {},
+          "!group:example.org|m.room.member|@bob:example.org": {},
+          "!group:example.org|m.room.member|@carol:example.org": {},
+        },
+      });
+      const tracker = createDirectRoomTracker(client as never);
+
+      const result = await tracker.isDirectMessage({
+        roomId: "!group:example.org",
+        senderId: "@alice:example.org",
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false for 1-member room (self-chat)", async () => {
+      const client = createMockClient({
+        dmRooms: {},
+        membersByRoom: {
+          "!solo:example.org": ["@bot:example.org"],
+        },
+        stateEvents: {
+          "!solo:example.org|m.room.member|@bot:example.org": {},
+        },
+      });
+      const tracker = createDirectRoomTracker(client as never);
+
+      const result = await tracker.isDirectMessage({
+        roomId: "!solo:example.org",
+        senderId: "@bot:example.org",
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("detection priority", () => {
+    it("m.direct takes priority -- skips state and fallback checks", async () => {
+      const client = createMockClient({
+        dmRooms: { "!dm:example.org": true },
+        membersByRoom: {
+          "!dm:example.org": ["@alice:example.org", "@bob:example.org", "@carol:example.org"],
+        },
+        stateEvents: {
+          "!dm:example.org|m.room.name|": { name: "Named Room" },
+        },
+      });
+      const tracker = createDirectRoomTracker(client as never);
+
+      const result = await tracker.isDirectMessage({
+        roomId: "!dm:example.org",
+        senderId: "@alice:example.org",
+      });
+
+      expect(result).toBe(true);
+      // Should not have checked member state or room name
+      expect(client.getRoomStateEvent).not.toHaveBeenCalled();
+      expect(client.getJoinedRoomMembers).not.toHaveBeenCalled();
+    });
+
+    it("is_direct takes priority over fallback -- skips member count", async () => {
+      const client = createMockClient({
+        dmRooms: {},
+        stateEvents: {
+          "!room:example.org|m.room.member|@alice:example.org": { is_direct: true },
+        },
+      });
+      const tracker = createDirectRoomTracker(client as never);
+
+      const result = await tracker.isDirectMessage({
         roomId: "!room:example.org",
         senderId: "@alice:example.org",
-      }),
-    ).resolves.toBe(true);
+      });
+
+      expect(result).toBe(true);
+      // Should not have checked member count
+      expect(client.getJoinedRoomMembers).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles member count API failure gracefully", async () => {
+      const client = createMockClient({
+        dmRooms: {},
+        stateEvents: {
+          "!failing:example.org|m.room.member|@alice:example.org": {},
+          "!failing:example.org|m.room.member|@bot:example.org": {},
+        },
+      });
+      client.getJoinedRoomMembers.mockRejectedValue(new Error("API unavailable"));
+      const tracker = createDirectRoomTracker(client as never);
+
+      const result = await tracker.isDirectMessage({
+        roomId: "!failing:example.org",
+        senderId: "@alice:example.org",
+      });
+
+      // Cannot determine member count -> conservative: classify as group
+      expect(result).toBe(false);
+    });
+
+    it("treats M_NOT_FOUND for room name as no name (DM)", async () => {
+      const client = createMockClient({
+        dmRooms: {},
+        membersByRoom: {
+          "!no-name:example.org": ["@alice:example.org", "@bot:example.org"],
+        },
+        stateEvents: {
+          "!no-name:example.org|m.room.member|@alice:example.org": {},
+          "!no-name:example.org|m.room.member|@bot:example.org": {},
+          // m.room.name not in stateEvents -> mock throws generic Error
+        },
+      });
+      // Override to throw M_NOT_FOUND like a real homeserver
+      const originalImpl = client.getRoomStateEvent.getMockImplementation()!;
+      client.getRoomStateEvent.mockImplementation(
+        async (roomId: string, eventType: string, stateKey: string) => {
+          if (eventType === "m.room.name") {
+            const err = new Error("not found") as Error & {
+              errcode?: string;
+              statusCode?: number;
+            };
+            err.errcode = "M_NOT_FOUND";
+            err.statusCode = 404;
+            throw err;
+          }
+          return originalImpl(roomId, eventType, stateKey);
+        },
+      );
+      const tracker = createDirectRoomTracker(client as never);
+
+      const result = await tracker.isDirectMessage({
+        roomId: "!no-name:example.org",
+        senderId: "@alice:example.org",
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("treats non-404 room name errors as unknown (falls through to group)", async () => {
+      const client = createMockClient({
+        dmRooms: {},
+        membersByRoom: {
+          "!error-room:example.org": ["@alice:example.org", "@bot:example.org"],
+        },
+        stateEvents: {
+          "!error-room:example.org|m.room.member|@alice:example.org": {},
+          "!error-room:example.org|m.room.member|@bot:example.org": {},
+        },
+      });
+      // Simulate a network/auth error (not M_NOT_FOUND)
+      const originalImpl = client.getRoomStateEvent.getMockImplementation()!;
+      client.getRoomStateEvent.mockImplementation(
+        async (roomId: string, eventType: string, stateKey: string) => {
+          if (eventType === "m.room.name") {
+            throw new Error("Connection refused");
+          }
+          return originalImpl(roomId, eventType, stateKey);
+        },
+      );
+      const tracker = createDirectRoomTracker(client as never);
+
+      const result = await tracker.isDirectMessage({
+        roomId: "!error-room:example.org",
+        senderId: "@alice:example.org",
+      });
+
+      // Network error -> don't assume DM, classify as group
+      expect(result).toBe(false);
+    });
+
+    it("whitespace-only room name is treated as no name", async () => {
+      const client = createMockClient({
+        dmRooms: {},
+        membersByRoom: {
+          "!ws-name:example.org": ["@alice:example.org", "@bot:example.org"],
+        },
+        stateEvents: {
+          "!ws-name:example.org|m.room.member|@alice:example.org": {},
+          "!ws-name:example.org|m.room.member|@bot:example.org": {},
+          "!ws-name:example.org|m.room.name|": { name: "   " },
+        },
+      });
+      const tracker = createDirectRoomTracker(client as never);
+
+      const result = await tracker.isDirectMessage({
+        roomId: "!ws-name:example.org",
+        senderId: "@alice:example.org",
+      });
+
+      expect(result).toBe(true);
+    });
   });
 });

--- a/extensions/matrix/src/matrix/monitor/direct.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.ts
@@ -13,14 +13,22 @@ type DirectRoomTrackerOptions = {
 
 const DM_CACHE_TTL_MS = 30_000;
 
+/**
+ * Check if an error is a Matrix M_NOT_FOUND response (missing state event).
+ * The bot-sdk throws MatrixError with errcode/statusCode on the error object.
+ */
+function isMatrixNotFoundError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { errcode?: string; statusCode?: number };
+  return e.errcode === "M_NOT_FOUND" || e.statusCode === 404;
+}
+
 export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTrackerOptions = {}) {
   const log = opts.log ?? (() => {});
   const includeMemberCountInLogs = opts.includeMemberCountInLogs === true;
   let lastDmUpdateMs = 0;
   let cachedSelfUserId: string | null = null;
-  const memberCountCache = includeMemberCountInLogs
-    ? new Map<string, { count: number; ts: number }>()
-    : undefined;
+  const memberCountCache = new Map<string, { count: number; ts: number }>();
 
   const ensureSelfUserId = async (): Promise<string | null> => {
     if (cachedSelfUserId) {
@@ -48,9 +56,6 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
   };
 
   const resolveMemberCount = async (roomId: string): Promise<number | null> => {
-    if (!memberCountCache) {
-      return null;
-    }
     const cached = memberCountCache.get(roomId);
     const now = Date.now();
     if (cached && now - cached.ts < DM_CACHE_TTL_MS) {
@@ -91,7 +96,6 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
         return true;
       }
 
-      // Check m.room.member state for is_direct flag
       const selfUserId = params.selfUserId ?? (await ensureSelfUserId());
       const directViaState =
         (await hasDirectFlag(roomId, senderId)) || (await hasDirectFlag(roomId, selfUserId ?? ""));
@@ -100,16 +104,47 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
         return true;
       }
 
-      // Member count alone is NOT a reliable DM indicator.
-      // Explicitly configured group rooms with 2 members (e.g. bot + one user)
-      // were being misclassified as DMs, causing messages to be routed through
-      // DM policy instead of group policy and silently dropped.
-      // See: https://github.com/openclaw/openclaw/issues/20145
+      // Conservative fallback: 2-member rooms without an explicit room name are likely
+      // DMs with broken m.direct / is_direct flags. This has been observed on Continuwuity
+      // where m.direct pointed to the wrong room and is_direct was never set on the invite.
+      // Unlike the removed heuristic, this requires two signals (member count + no name)
+      // to avoid false positives on named 2-person group rooms.
+      //
+      // Performance: member count is cached (resolveMemberCount). The room name state
+      // check is not cached but only runs for the subset of 2-member rooms that reach
+      // this fallback path (no m.direct, no is_direct). In typical deployments this is
+      // a small minority of rooms.
+      //
+      // Note: there is a narrow race where a room name is being set concurrently with
+      // this check. The consequence is a one-time misclassification that self-corrects
+      // on the next message (once the state event is synced). This is acceptable given
+      // the alternative of an additional API call on every message.
+      const memberCount = await resolveMemberCount(roomId);
+      if (memberCount === 2) {
+        try {
+          const nameState = await client.getRoomStateEvent(roomId, "m.room.name", "");
+          if (!nameState?.name?.trim()) {
+            log(`matrix: dm detected via fallback (2 members, no room name) room=${roomId}`);
+            return true;
+          }
+        } catch (err: unknown) {
+          // Missing state events (M_NOT_FOUND) are expected for unnamed rooms and
+          // strongly indicate a DM. Any other error (network, auth) is ambiguous,
+          // so we fall through to classify as group rather than guess.
+          if (isMatrixNotFoundError(err)) {
+            log(`matrix: dm detected via fallback (2 members, no room name) room=${roomId}`);
+            return true;
+          }
+          log(
+            `matrix: dm fallback skipped (room name check failed: ${String(err)}) room=${roomId}`,
+          );
+        }
+      }
+
       if (!includeMemberCountInLogs) {
         log(`matrix: dm check room=${roomId} result=group`);
         return false;
       }
-      const memberCount = await resolveMemberCount(roomId);
       log(`matrix: dm check room=${roomId} result=group members=${memberCount ?? "unknown"}`);
       return false;
     },

--- a/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
@@ -1,7 +1,11 @@
 import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import type { PluginRuntime, RuntimeEnv, RuntimeLogger } from "remoteclaw/plugin-sdk";
 import { describe, expect, it, vi } from "vitest";
-import { createMatrixRoomMessageHandler } from "./handler.js";
+import {
+  createMatrixRoomMessageHandler,
+  resolveMatrixBaseRouteSession,
+  shouldOverrideMatrixDmToGroup,
+} from "./handler.js";
 import { EventType, type MatrixRawEvent } from "./types.js";
 
 describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
@@ -18,8 +22,15 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
       channel: {
         pairing: {
           readAllowFromStore: vi.fn().mockResolvedValue([]),
+          upsertPairingRequest: vi.fn().mockResolvedValue(undefined),
         },
         routing: {
+          buildAgentSessionKey: vi
+            .fn()
+            .mockImplementation(
+              (params: { agentId: string; channel: string; peer?: { kind: string; id: string } }) =>
+                `agent:${params.agentId}:${params.channel}:${params.peer?.kind ?? "direct"}:${params.peer?.id ?? "unknown"}`,
+            ),
           resolveAgentRoute: vi.fn().mockReturnValue({
             agentId: "main",
             accountId: undefined,
@@ -138,5 +149,48 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
         }),
       }),
     );
+  });
+
+  it("uses room-scoped session keys for DM rooms matched via parentPeer binding", () => {
+    const buildAgentSessionKey = vi
+      .fn()
+      .mockReturnValue("agent:main:matrix:channel:!dmroom:example.org");
+
+    const resolved = resolveMatrixBaseRouteSession({
+      buildAgentSessionKey,
+      baseRoute: {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        mainSessionKey: "agent:main:main",
+        matchedBy: "binding.peer.parent",
+      },
+      isDirectMessage: true,
+      roomId: "!dmroom:example.org",
+      accountId: undefined,
+    });
+
+    expect(buildAgentSessionKey).toHaveBeenCalledWith({
+      agentId: "main",
+      channel: "matrix",
+      accountId: undefined,
+      peer: { kind: "channel", id: "!dmroom:example.org" },
+    });
+    expect(resolved).toEqual({
+      sessionKey: "agent:main:matrix:channel:!dmroom:example.org",
+      lastRoutePolicy: "session",
+    });
+  });
+
+  it("does not override DMs to groups for explicit allow:false room config", () => {
+    expect(
+      shouldOverrideMatrixDmToGroup({
+        isDirectMessage: true,
+        roomConfigInfo: {
+          config: { allow: false },
+          allowed: false,
+          matchSource: "direct",
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -75,6 +75,56 @@ export type MatrixMonitorHandlerParams = {
   accountId?: string | null;
 };
 
+export function resolveMatrixBaseRouteSession(params: {
+  buildAgentSessionKey: (params: {
+    agentId: string;
+    channel: string;
+    accountId?: string | null;
+    peer?: { kind: "direct" | "channel"; id: string } | null;
+  }) => string;
+  baseRoute: {
+    agentId: string;
+    sessionKey: string;
+    mainSessionKey: string;
+    matchedBy?: string;
+  };
+  isDirectMessage: boolean;
+  roomId: string;
+  accountId?: string | null;
+}): { sessionKey: string; lastRoutePolicy: "main" | "session" } {
+  const sessionKey =
+    params.isDirectMessage && params.baseRoute.matchedBy === "binding.peer.parent"
+      ? params.buildAgentSessionKey({
+          agentId: params.baseRoute.agentId,
+          channel: "matrix",
+          accountId: params.accountId,
+          peer: { kind: "channel", id: params.roomId },
+        })
+      : params.baseRoute.sessionKey;
+  return {
+    sessionKey,
+    lastRoutePolicy: sessionKey === params.baseRoute.mainSessionKey ? "main" : "session",
+  };
+}
+
+export function shouldOverrideMatrixDmToGroup(params: {
+  isDirectMessage: boolean;
+  roomConfigInfo?:
+    | {
+        config?: MatrixRoomConfig;
+        allowed: boolean;
+        matchSource?: string;
+      }
+    | undefined;
+}): boolean {
+  return (
+    params.isDirectMessage === true &&
+    params.roomConfigInfo?.config !== undefined &&
+    params.roomConfigInfo.allowed === true &&
+    params.roomConfigInfo.matchSource === "direct"
+  );
+}
+
 export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParams) {
   const {
     client,
@@ -186,22 +236,37 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         }
       }
 
-      const isDirectMessage = await directTracker.isDirectMessage({
+      let isDirectMessage = await directTracker.isDirectMessage({
         roomId,
         senderId,
         selfUserId,
       });
+
+      // Resolve room config early so explicitly configured rooms can override DM classification.
+      // This ensures rooms in the groups config are always treated as groups regardless of
+      // member count or protocol-level DM flags. Only explicit matches (not wildcards) trigger
+      // the override to avoid breaking DM routing when a wildcard entry exists. (See #9106)
+      const roomConfigInfo = resolveMatrixRoomConfig({
+        rooms: roomsConfig,
+        roomId,
+        aliases: roomAliases,
+        name: roomName,
+      });
+      if (shouldOverrideMatrixDmToGroup({ isDirectMessage, roomConfigInfo })) {
+        logVerboseMessage(
+          `matrix: overriding DM to group for configured room=${roomId} (${roomConfigInfo.matchKey})`,
+        );
+        isDirectMessage = false;
+      }
+
       const isRoom = !isDirectMessage;
 
-      const roomConfigInfo = isRoom
-        ? resolveMatrixRoomConfig({
-            rooms: roomsConfig,
-            roomId,
-            aliases: roomAliases,
-            name: roomName,
-          })
-        : undefined;
-      const roomConfig = roomConfigInfo?.config;
+      if (isRoom && groupPolicy === "disabled") {
+        return;
+      }
+      // Only expose room config for confirmed group rooms. DMs should never inherit
+      // group settings (skills, systemPrompt, autoReply) even when a wildcard entry exists.
+      const roomConfig = isRoom ? roomConfigInfo?.config : undefined;
       const roomMatchMeta = roomConfigInfo
         ? `matchKey=${roomConfigInfo.matchKey ?? "none"} matchSource=${
             roomConfigInfo.matchSource ?? "none"
@@ -433,13 +498,24 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           kind: isDirectMessage ? "direct" : "channel",
           id: isDirectMessage ? senderId : roomId,
         },
+        // For DMs, pass roomId as parentPeer so the conversation is bindable by room ID
+        // while preserving DM trust semantics (secure 1:1, no group restrictions).
+        parentPeer: isDirectMessage ? { kind: "channel", id: roomId } : undefined,
+      });
+      const baseRouteSession = resolveMatrixBaseRouteSession({
+        buildAgentSessionKey: core.channel.routing.buildAgentSessionKey,
+        baseRoute,
+        isDirectMessage,
+        roomId,
+        accountId,
       });
 
       const route = {
         ...baseRoute,
+        lastRoutePolicy: baseRouteSession.lastRoutePolicy,
         sessionKey: threadRootId
-          ? `${baseRoute.sessionKey}:thread:${threadRootId}`
-          : baseRoute.sessionKey,
+          ? `${baseRouteSession.sessionKey}:thread:${threadRootId}`
+          : baseRouteSession.sessionKey,
       };
 
       let threadStarterBody: string | undefined;

--- a/extensions/matrix/src/matrix/monitor/rooms.test.ts
+++ b/extensions/matrix/src/matrix/monitor/rooms.test.ts
@@ -36,4 +36,89 @@ describe("resolveMatrixRoomConfig", () => {
     expect(byName.allowed).toBe(false);
     expect(byName.config).toBeUndefined();
   });
+
+  describe("matchSource classification", () => {
+    it('returns matchSource="direct" for exact room ID match', () => {
+      const result = resolveMatrixRoomConfig({
+        rooms: { "!room:example.org": { allow: true } },
+        roomId: "!room:example.org",
+        aliases: [],
+      });
+      expect(result.matchSource).toBe("direct");
+      expect(result.config).toBeDefined();
+    });
+
+    it('returns matchSource="direct" for alias match', () => {
+      const result = resolveMatrixRoomConfig({
+        rooms: { "#alias:example.org": { allow: true } },
+        roomId: "!room:example.org",
+        aliases: ["#alias:example.org"],
+      });
+      expect(result.matchSource).toBe("direct");
+      expect(result.config).toBeDefined();
+    });
+
+    it('returns matchSource="wildcard" for wildcard match', () => {
+      const result = resolveMatrixRoomConfig({
+        rooms: { "*": { allow: true } },
+        roomId: "!any:example.org",
+        aliases: [],
+      });
+      expect(result.matchSource).toBe("wildcard");
+      expect(result.config).toBeDefined();
+    });
+
+    it("returns undefined matchSource when no match", () => {
+      const result = resolveMatrixRoomConfig({
+        rooms: { "!other:example.org": { allow: true } },
+        roomId: "!room:example.org",
+        aliases: [],
+      });
+      expect(result.matchSource).toBeUndefined();
+      expect(result.config).toBeUndefined();
+    });
+
+    it("direct match takes priority over wildcard", () => {
+      const result = resolveMatrixRoomConfig({
+        rooms: {
+          "!room:example.org": { allow: true, systemPrompt: "room-specific" },
+          "*": { allow: true, systemPrompt: "generic" },
+        },
+        roomId: "!room:example.org",
+        aliases: [],
+      });
+      expect(result.matchSource).toBe("direct");
+      expect(result.config?.systemPrompt).toBe("room-specific");
+    });
+  });
+
+  describe("DM override safety (matchSource distinction)", () => {
+    // These tests verify the matchSource property that handler.ts uses
+    // to decide whether a configured room should override DM classification.
+    // Only "direct" matches should trigger the override -- never "wildcard".
+
+    it("wildcard config should NOT be usable to override DM classification", () => {
+      const result = resolveMatrixRoomConfig({
+        rooms: { "*": { allow: true, skills: ["general"] } },
+        roomId: "!dm-room:example.org",
+        aliases: [],
+      });
+      // handler.ts checks: matchSource === "direct" -> this is "wildcard", so no override
+      expect(result.matchSource).not.toBe("direct");
+      expect(result.matchSource).toBe("wildcard");
+    });
+
+    it("explicitly configured room should be usable to override DM classification", () => {
+      const result = resolveMatrixRoomConfig({
+        rooms: {
+          "!configured-room:example.org": { allow: true },
+          "*": { allow: true },
+        },
+        roomId: "!configured-room:example.org",
+        aliases: [],
+      });
+      // handler.ts checks: matchSource === "direct" -> this IS "direct", so override is safe
+      expect(result.matchSource).toBe("direct");
+    });
+  });
 });

--- a/extensions/matrix/src/types.ts
+++ b/extensions/matrix/src/types.ts
@@ -25,6 +25,8 @@ export type MatrixRoomConfig = {
   autoReply?: boolean;
   /** Optional allowlist for room senders (matrix user IDs). */
   users?: Array<string | number>;
+  /** Optional skills for this room. */
+  skills?: string[];
   /** Optional system prompt snippet for this room. */
   systemPrompt?: string;
 };

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_GROUP_HISTORY_LIMIT,
   recordPendingHistoryEntryIfEnabled,
   isDangerousNameMatchingEnabled,
+  parseStrictPositiveInteger,
   registerPluginHttpRoute,
   resolveControlCommandGate,
   readStoreAllowFromForDmPolicy,
@@ -29,7 +30,6 @@ import {
   warnMissingProviderGroupPolicyFallbackOnce,
   type HistoryEntry,
 } from "remoteclaw/plugin-sdk";
-import { parseStrictPositiveInteger } from "../../../../src/infra/parse-finite-number.js";
 import { getMattermostRuntime } from "../runtime.js";
 import { resolveMattermostAccount } from "./accounts.js";
 import {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -19,7 +19,6 @@ import {
   DEFAULT_GROUP_HISTORY_LIMIT,
   recordPendingHistoryEntryIfEnabled,
   isDangerousNameMatchingEnabled,
-  parseStrictPositiveInteger,
   registerPluginHttpRoute,
   resolveControlCommandGate,
   readStoreAllowFromForDmPolicy,
@@ -30,6 +29,7 @@ import {
   warnMissingProviderGroupPolicyFallbackOnce,
   type HistoryEntry,
 } from "remoteclaw/plugin-sdk";
+import { parseStrictPositiveInteger } from "remoteclaw/plugin-sdk/mattermost";
 import { getMattermostRuntime } from "../runtime.js";
 import { resolveMattermostAccount } from "./accounts.js";
 import {

--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -5,7 +5,7 @@ import { setMSTeamsRuntime } from "../runtime.js";
 import { createMSTeamsMessageHandler } from "./message-handler.js";
 
 describe("msteams monitor handler authz", () => {
-  it("does not treat DM pairing-store entries as group allowlist entries", async () => {
+  function createDeps(cfg: RemoteClawConfig) {
     const readAllowFromStore = vi.fn(async () => ["attacker-aad"]);
     setMSTeamsRuntime({
       logging: { shouldLogVerbose: () => false },
@@ -35,16 +35,7 @@ describe("msteams monitor handler authz", () => {
     };
 
     const deps: MSTeamsMessageHandlerDeps = {
-      cfg: {
-        channels: {
-          msteams: {
-            dmPolicy: "pairing",
-            allowFrom: [],
-            groupPolicy: "allowlist",
-            groupAllowFrom: [],
-          },
-        },
-      } as RemoteClawConfig,
+      cfg,
       runtime: { error: vi.fn() } as unknown as RuntimeEnv,
       appId: "test-app",
       adapter: {} as MSTeamsMessageHandlerDeps["adapter"],
@@ -64,6 +55,21 @@ describe("msteams monitor handler authz", () => {
         error: vi.fn(),
       } as unknown as MSTeamsMessageHandlerDeps["log"],
     };
+
+    return { conversationStore, deps, readAllowFromStore };
+  }
+
+  it("does not treat DM pairing-store entries as group allowlist entries", async () => {
+    const { conversationStore, deps, readAllowFromStore } = createDeps({
+      channels: {
+        msteams: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+        },
+      },
+    } as OpenClawConfig);
 
     const handler = createMSTeamsMessageHandler(deps);
     await handler({
@@ -91,6 +97,56 @@ describe("msteams monitor handler authz", () => {
     } as unknown as Parameters<typeof handler>[0]);
 
     expect(readAllowFromStore).toHaveBeenCalledWith({ channel: "msteams", accountId: "default" });
+    expect(conversationStore.upsert).not.toHaveBeenCalled();
+  });
+
+  it("does not widen sender auth when only a teams route allowlist is configured", async () => {
+    const { conversationStore, deps } = createDeps({
+      channels: {
+        msteams: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+          teams: {
+            team123: {
+              channels: {
+                "19:group@thread.tacv2": { requireMention: false },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig);
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler({
+      activity: {
+        id: "msg-1",
+        type: "message",
+        text: "hello",
+        from: {
+          id: "attacker-id",
+          aadObjectId: "attacker-aad",
+          name: "Attacker",
+        },
+        recipient: {
+          id: "bot-id",
+          name: "Bot",
+        },
+        conversation: {
+          id: "19:group@thread.tacv2",
+          conversationType: "groupChat",
+        },
+        channelData: {
+          team: { id: "team123", name: "Team 123" },
+          channel: { name: "General" },
+        },
+        attachments: [],
+      },
+      sendActivity: vi.fn(async () => undefined),
+    } as unknown as Parameters<typeof handler>[0]);
+
     expect(conversationStore.upsert).not.toHaveBeenCalled();
   });
 });

--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -69,7 +69,7 @@ describe("msteams monitor handler authz", () => {
           groupAllowFrom: [],
         },
       },
-    } as OpenClawConfig);
+    } as RemoteClawConfig);
 
     const handler = createMSTeamsMessageHandler(deps);
     await handler({
@@ -117,7 +117,7 @@ describe("msteams monitor handler authz", () => {
           },
         },
       },
-    } as OpenClawConfig);
+    } as RemoteClawConfig);
 
     const handler = createMSTeamsMessageHandler(deps);
     await handler({

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -242,10 +242,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       }
       const senderGroupAccess = evaluateSenderGroupAccessForPolicy({
         groupPolicy,
-        groupAllowFrom:
-          effectiveGroupAllowFrom.length > 0 || !channelGate.allowlistConfigured
-            ? effectiveGroupAllowFrom
-            : ["*"],
+        groupAllowFrom: effectiveGroupAllowFrom,
         senderId,
         isSenderAllowed: (_senderId, allowFrom) =>
           resolveMSTeamsAllowlistMatch({

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -15,11 +15,11 @@ import {
   mapAllowFromEntries,
   normalizeAccountId,
   setAccountEnabledInConfigSection,
+  waitForAbortSignal,
   type ChannelPlugin,
   type RemoteClawConfig,
   type ChannelSetupInput,
 } from "remoteclaw/plugin-sdk";
-import { waitForAbortSignal } from "../../../src/infra/abort-signal.js";
 import {
   listNextcloudTalkAccountIds,
   resolveDefaultNextcloudTalkAccountId,

--- a/extensions/test-utils/plugin-runtime-mock.ts
+++ b/extensions/test-utils/plugin-runtime-mock.ts
@@ -265,9 +265,6 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       getSession: vi.fn() as unknown as PluginRuntime["subagent"]["getSession"],
       deleteSession: vi.fn() as unknown as PluginRuntime["subagent"]["deleteSession"],
     },
-    state: {
-      resolveStateDir: vi.fn(() => "/tmp/remoteclaw"),
-    },
   };
 
   return mergeDeep(base, overrides);

--- a/extensions/test-utils/plugin-runtime-mock.ts
+++ b/extensions/test-utils/plugin-runtime-mock.ts
@@ -250,6 +250,14 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
         debug: vi.fn(),
       })),
     },
+    state: {
+      resolveStateDir: vi.fn(() => "/tmp/remoteclaw"),
+    },
+    modelAuth: {
+      getApiKeyForModel: vi.fn() as unknown as PluginRuntime["modelAuth"]["getApiKeyForModel"],
+      resolveApiKeyForProvider:
+        vi.fn() as unknown as PluginRuntime["modelAuth"]["resolveApiKeyForProvider"],
+    },
     subagent: {
       run: vi.fn() as unknown as PluginRuntime["subagent"]["run"],
       waitForRun: vi.fn() as unknown as PluginRuntime["subagent"]["waitForRun"],

--- a/extensions/twitch/src/types.ts
+++ b/extensions/twitch/src/types.ts
@@ -12,7 +12,6 @@ import type {
   ChannelLogSink,
   ChannelMessageActionAdapter,
   ChannelMessageActionContext,
-  ChannelMeta,
   ChannelOutboundAdapter,
   ChannelOutboundContext,
   ChannelPlugin,

--- a/extensions/twitch/src/types.ts
+++ b/extensions/twitch/src/types.ts
@@ -12,6 +12,7 @@ import type {
   ChannelLogSink,
   ChannelMessageActionAdapter,
   ChannelMessageActionContext,
+  ChannelMeta,
   ChannelOutboundAdapter,
   ChannelOutboundContext,
   ChannelPlugin,

--- a/src/auth/provider-auth.ts
+++ b/src/auth/provider-auth.ts
@@ -346,6 +346,16 @@ export function resolveModelAuthMode(
   return "unknown";
 }
 
+export async function getApiKeyForModel(params: {
+  model: { provider: string };
+  cfg?: RemoteClawConfig;
+}): Promise<ResolvedProviderAuth> {
+  return resolveApiKeyForProvider({
+    provider: params.model.provider,
+    cfg: params.cfg,
+  });
+}
+
 export function requireApiKey(auth: ResolvedProviderAuth, provider: string): string {
   const key = normalizeSecretInput(auth.apiKey);
   if (key) {

--- a/src/plugin-sdk/bluebubbles.ts
+++ b/src/plugin-sdk/bluebubbles.ts
@@ -71,6 +71,7 @@ export {
   resolveServicePrefixedTarget,
 } from "../imessage/target-parsing-helpers.js";
 export { stripMarkdown } from "../line/markdown-to-line.js";
+export { parseFiniteNumber } from "../infra/parse-finite-number.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export type { PluginRuntime } from "../plugins/runtime/types.js";
 export type { RemoteClawPluginApi } from "../plugins/types.js";

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -725,5 +725,11 @@ export type { ProcessedLineMessage } from "../line/markdown-to-line.js";
 // Media utilities
 export { loadWebMedia, type WebMediaResult } from "../web/media.js";
 
+// Model authentication types for plugins.
+// Plugins should use runtime.modelAuth (which strips unsafe overrides like
+// agentDir/store) rather than importing raw helpers directly.
+export { requireApiKey } from "../auth/provider-auth.js";
+export type { ResolvedProviderAuth } from "../auth/provider-auth.js";
+
 // Security utilities
 export { redactSensitiveText } from "../logging/redact.js";

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -65,6 +65,7 @@ export {
   requireOpenAllowFrom,
 } from "../config/zod-schema.core.js";
 export { createDedupeCache } from "../infra/dedupe.js";
+export { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 export { rawDataToString } from "../infra/ws.js";
 export { isLoopbackHost, isTrustedProxyAddress, resolveClientIp } from "../gateway/net.js";
 export { normalizeProviderId } from "../agents/provider-utils.js";

--- a/src/plugin-sdk/nextcloud-talk.ts
+++ b/src/plugin-sdk/nextcloud-talk.ts
@@ -69,6 +69,7 @@ export {
   readRequestBodyWithLimit,
   requestBodyErrorToText,
 } from "../infra/http-body.js";
+export { waitForAbortSignal } from "../infra/abort-signal.js";
 export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export type { PluginRuntime } from "../plugins/runtime/types.js";

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -96,16 +96,16 @@ describe("plugin-sdk subpath exports", () => {
   });
 
   it("keeps the newly added bundled plugin-sdk contracts available", async () => {
-    const bluebubbles = await import("openclaw/plugin-sdk/bluebubbles");
+    const bluebubbles = await import("remoteclaw/plugin-sdk/bluebubbles");
     expect(typeof bluebubbles.parseFiniteNumber).toBe("function");
 
-    const mattermost = await import("openclaw/plugin-sdk/mattermost");
+    const mattermost = await import("remoteclaw/plugin-sdk/mattermost");
     expect(typeof mattermost.parseStrictPositiveInteger).toBe("function");
 
-    const nextcloudTalk = await import("openclaw/plugin-sdk/nextcloud-talk");
+    const nextcloudTalk = await import("remoteclaw/plugin-sdk/nextcloud-talk");
     expect(typeof nextcloudTalk.waitForAbortSignal).toBe("function");
 
-    const twitch = await import("openclaw/plugin-sdk/twitch");
+    const twitch = await import("remoteclaw/plugin-sdk/twitch");
     expect(typeof twitch.DEFAULT_ACCOUNT_ID).toBe("string");
     expect(typeof twitch.normalizeAccountId).toBe("function");
   });

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -94,4 +94,19 @@ describe("plugin-sdk subpath exports", () => {
       expect(mod, `subpath ${id} should resolve`).toBeTruthy();
     }
   });
+
+  it("keeps the newly added bundled plugin-sdk contracts available", async () => {
+    const bluebubbles = await import("openclaw/plugin-sdk/bluebubbles");
+    expect(typeof bluebubbles.parseFiniteNumber).toBe("function");
+
+    const mattermost = await import("openclaw/plugin-sdk/mattermost");
+    expect(typeof mattermost.parseStrictPositiveInteger).toBe("function");
+
+    const nextcloudTalk = await import("openclaw/plugin-sdk/nextcloud-talk");
+    expect(typeof nextcloudTalk.waitForAbortSignal).toBe("function");
+
+    const twitch = await import("openclaw/plugin-sdk/twitch");
+    expect(typeof twitch.DEFAULT_ACCOUNT_ID).toBe("string");
+    expect(typeof twitch.normalizeAccountId).toBe("function");
+  });
 });

--- a/src/plugin-sdk/twitch.ts
+++ b/src/plugin-sdk/twitch.ts
@@ -4,16 +4,37 @@
 export type { ReplyPayload } from "../auto-reply/types.js";
 export { buildChannelConfigSchema } from "../channels/plugins/config-schema.js";
 export type {
+  ChannelGatewayContext,
+  ChannelOutboundAdapter,
+  ChannelOutboundContext,
+  ChannelResolveKind,
+  ChannelResolveResult,
+  ChannelStatusAdapter,
+} from "../channels/plugins/types.adapters.js";
+export type {
+  BaseProbeResult,
+  ChannelAccountSnapshot,
+  ChannelCapabilities,
+  ChannelLogSink,
+  ChannelMessageActionAdapter,
+  ChannelMessageActionContext,
+  ChannelMeta,
+  ChannelStatusIssue,
+} from "../channels/plugins/types.js";
+export type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+export type {
   ChannelOnboardingAdapter,
   ChannelOnboardingDmPolicy,
 } from "../channels/plugins/onboarding-types.js";
 export { promptChannelAccessConfig } from "../channels/plugins/onboarding/channel-access.js";
-export type { BaseProbeResult, ChannelStatusIssue } from "../channels/plugins/types.js";
 export { createReplyPrefixOptions } from "../channels/reply-prefix.js";
 export type { RemoteClawConfig } from "../config/config.js";
 export { MarkdownConfigSchema } from "../config/zod-schema.core.js";
+export type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
+export { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "./account-id.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export type { PluginRuntime } from "../plugins/runtime/types.js";
 export type { RemoteClawPluginApi } from "../plugins/types.js";
+export type { RuntimeEnv } from "../runtime.js";
 export { formatDocsLink } from "../terminal/links.js";
 export type { WizardPrompter } from "../wizard/prompts.js";

--- a/src/plugins/hook-runner-global.test.ts
+++ b/src/plugins/hook-runner-global.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMockPluginRegistry } from "./hooks.test-helpers.js";
+
+async function importHookRunnerGlobalModule() {
+  return import("./hook-runner-global.js");
+}
+
+afterEach(async () => {
+  const mod = await importHookRunnerGlobalModule();
+  mod.resetGlobalHookRunner();
+  vi.resetModules();
+});
+
+describe("hook-runner-global", () => {
+  it("preserves the initialized runner across module reloads", async () => {
+    const modA = await importHookRunnerGlobalModule();
+    const registry = createMockPluginRegistry([{ hookName: "message_received", handler: vi.fn() }]);
+
+    modA.initializeGlobalHookRunner(registry);
+    expect(modA.getGlobalHookRunner()?.hasHooks("message_received")).toBe(true);
+
+    vi.resetModules();
+
+    const modB = await importHookRunnerGlobalModule();
+    expect(modB.getGlobalHookRunner()).not.toBeNull();
+    expect(modB.getGlobalHookRunner()?.hasHooks("message_received")).toBe(true);
+    expect(modB.getGlobalPluginRegistry()).toBe(registry);
+  });
+
+  it("clears the shared state across module reloads", async () => {
+    const modA = await importHookRunnerGlobalModule();
+    const registry = createMockPluginRegistry([{ hookName: "message_received", handler: vi.fn() }]);
+
+    modA.initializeGlobalHookRunner(registry);
+
+    vi.resetModules();
+
+    const modB = await importHookRunnerGlobalModule();
+    modB.resetGlobalHookRunner();
+    expect(modB.getGlobalHookRunner()).toBeNull();
+    expect(modB.getGlobalPluginRegistry()).toBeNull();
+
+    vi.resetModules();
+
+    const modC = await importHookRunnerGlobalModule();
+    expect(modC.getGlobalHookRunner()).toBeNull();
+    expect(modC.getGlobalPluginRegistry()).toBeNull();
+  });
+});

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -12,16 +12,31 @@ import type { PluginHookGatewayContext, PluginHookGatewayStopEvent } from "./typ
 
 const log = createSubsystemLogger("plugins");
 
-let globalHookRunner: HookRunner | null = null;
-let globalRegistry: PluginRegistry | null = null;
+type HookRunnerGlobalState = {
+  hookRunner: HookRunner | null;
+  registry: PluginRegistry | null;
+};
+
+const hookRunnerGlobalStateKey = Symbol.for("openclaw.plugins.hook-runner-global-state");
+
+function getHookRunnerGlobalState(): HookRunnerGlobalState {
+  const globalStore = globalThis as typeof globalThis & {
+    [hookRunnerGlobalStateKey]?: HookRunnerGlobalState;
+  };
+  return (globalStore[hookRunnerGlobalStateKey] ??= {
+    hookRunner: null,
+    registry: null,
+  });
+}
 
 /**
  * Initialize the global hook runner with a plugin registry.
  * Called once when plugins are loaded during gateway startup.
  */
 export function initializeGlobalHookRunner(registry: PluginRegistry): void {
-  globalRegistry = registry;
-  globalHookRunner = createHookRunner(registry, {
+  const state = getHookRunnerGlobalState();
+  state.registry = registry;
+  state.hookRunner = createHookRunner(registry, {
     logger: {
       debug: (msg) => log.debug(msg),
       warn: (msg) => log.warn(msg),
@@ -41,7 +56,7 @@ export function initializeGlobalHookRunner(registry: PluginRegistry): void {
  * Returns null if plugins haven't been loaded yet.
  */
 export function getGlobalHookRunner(): HookRunner | null {
-  return globalHookRunner;
+  return getHookRunnerGlobalState().hookRunner;
 }
 
 /**
@@ -49,14 +64,14 @@ export function getGlobalHookRunner(): HookRunner | null {
  * Returns null if plugins haven't been loaded yet.
  */
 export function getGlobalPluginRegistry(): PluginRegistry | null {
-  return globalRegistry;
+  return getHookRunnerGlobalState().registry;
 }
 
 /**
  * Check if any hooks are registered for a given hook name.
  */
 export function hasGlobalHooks(hookName: Parameters<HookRunner["hasHooks"]>[0]): boolean {
-  return globalHookRunner?.hasHooks(hookName) ?? false;
+  return getHookRunnerGlobalState().hookRunner?.hasHooks(hookName) ?? false;
 }
 
 export async function runGlobalGatewayStopSafely(params: {
@@ -83,6 +98,7 @@ export async function runGlobalGatewayStopSafely(params: {
  * Reset the global hook runner (for testing).
  */
 export function resetGlobalHookRunner(): void {
-  globalHookRunner = null;
-  globalRegistry = null;
+  const state = getHookRunnerGlobalState();
+  state.hookRunner = null;
+  state.registry = null;
 }

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -53,4 +53,21 @@ describe("plugin runtime command execution", () => {
     const runtime = createPluginRuntime();
     expect(runtime.system.requestHeartbeatNow).toBe(requestHeartbeatNow);
   });
+
+  it("exposes runtime.modelAuth with getApiKeyForModel and resolveApiKeyForProvider", () => {
+    const runtime = createPluginRuntime();
+    expect(runtime.modelAuth).toBeDefined();
+    expect(typeof runtime.modelAuth.getApiKeyForModel).toBe("function");
+    expect(typeof runtime.modelAuth.resolveApiKeyForProvider).toBe("function");
+  });
+
+  it("modelAuth wrappers strip agentDir and store to prevent credential steering", async () => {
+    // The wrappers should not forward agentDir or store from plugin callers.
+    // We verify this by checking the wrapper functions exist and are not the
+    // raw implementations (they are wrapped, not direct references).
+    const { getApiKeyForModel: rawGetApiKey } = await import("../../auth/provider-auth.js");
+    const runtime = createPluginRuntime();
+    // Wrappers should NOT be the same reference as the raw functions
+    expect(runtime.modelAuth.getApiKeyForModel).not.toBe(rawGetApiKey);
+  });
 });

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,4 +1,8 @@
 import { createRequire } from "node:module";
+import {
+  getApiKeyForModel as getApiKeyForModelRaw,
+  resolveApiKeyForProvider as resolveApiKeyForProviderRaw,
+} from "../../auth/provider-auth.js";
 import { resolveStateDir } from "../../config/paths.js";
 import { textToSpeechTelephony } from "../../tts/tts.js";
 import { createRuntimeChannel } from "./runtime-channel.js";
@@ -60,6 +64,24 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     channel: createRuntimeChannel(),
     logging: createRuntimeLogging(),
     state: { resolveStateDir },
+    modelAuth: {
+      // Wrap model-auth helpers so plugins cannot steer credential lookups:
+      // - agentDir / store: stripped (prevents reading other agents' stores)
+      // - profileId / preferredProfile: stripped (prevents cross-provider
+      //   credential access via profile steering)
+      // Plugins only specify provider/model; the core auth pipeline picks
+      // the appropriate credential automatically.
+      getApiKeyForModel: (params) =>
+        getApiKeyForModelRaw({
+          model: params.model,
+          cfg: params.cfg,
+        }),
+      resolveApiKeyForProvider: (params) =>
+        resolveApiKeyForProviderRaw({
+          provider: params.provider,
+          cfg: params.cfg,
+        }),
+    },
   } satisfies PluginRuntime;
 
   return runtime;

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -53,4 +53,16 @@ export type PluginRuntimeCore = {
   state: {
     resolveStateDir: typeof import("../../config/paths.js").resolveStateDir;
   };
+  modelAuth: {
+    /** Resolve auth for a model. Only provider/model and optional cfg are used. */
+    getApiKeyForModel: (params: {
+      model: { provider: string };
+      cfg?: import("../../config/config.js").RemoteClawConfig;
+    }) => Promise<import("../../auth/provider-auth.js").ResolvedProviderAuth>;
+    /** Resolve auth for a provider by name. Only provider and optional cfg are used. */
+    resolveApiKeyForProvider: (params: {
+      provider: string;
+      cfg?: import("../../config/config.js").RemoteClawConfig;
+    }) => Promise<import("../../auth/provider-auth.js").ResolvedProviderAuth>;
+  };
 };


### PR DESCRIPTION
## Cherry-picks from upstream (issue #923)

5 commits cherry-picked, 2 skipped (version bumps only).

| Hash | Subject | Result |
|------|---------|--------|
| a438ff439 | fix(plugin-sdk): remove remaining bundled plugin src imports | RESOLVED — import path conflicts (ours=remoteclaw/plugin-sdk, theirs=openclaw/plugin-sdk) |
| d4a960fcc | fix(matrix): restore robust DM routing | RESOLVED — CHANGELOG conflict |
| 88aee9161 | fix(msteams): enforce sender allowlists with route allowlists | RESOLVED — CHANGELOG + test refactor (OpenClawConfig→RemoteClawConfig) |
| 5fca4c0de | chore: prepare 2026.3.8-beta.1 release | SKIPPED — all changes are version bumps for fork-maintained packages |
| f6d0712f5 | build: sync plugin versions for 2026.3.9 | SKIPPED — all changes are version bumps for fork-maintained packages |
| 12702e11a | plugins: harden global hook runner state | PICKED — clean apply |
| 4790e40ac | fix(plugins): expose model auth API to context-engine plugins | RESOLVED — adapted model-auth imports (agents/model-auth→auth/provider-auth), replaced pi-ai Model type with {provider:string}, added getApiKeyForModel to provider-auth, rebranded OpenClawConfig→RemoteClawConfig |

Closes #923