### PR TITLE
Cherry-pick f9706fde6: build: bump unreleased version to 2026.3.9

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -63,8 +63,8 @@ android {
         applicationId = "org.remoteclaw.android"
         minSdk = 31
         targetSdk = 36
-        versionCode = 202602270
-        versionName = "2026.2.27"
+        versionCode = 202603090
+        versionName = "2026.3.9"
         ndk {
             // Support all major ABIs — native libs are tiny (~47 KB per ABI)
             abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")

--- a/apps/ios/ActivityWidget/Info.plist
+++ b/apps/ios/ActivityWidget/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>RemoteClaw Activity</string>
+	<string>OpenClaw Activity</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.3.2</string>
+	<string>2026.3.9</string>
 	<key>CFBundleVersion</key>
-	<string>20260301</string>
+	<string>20260308</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/apps/ios/ShareExtension/Info.plist
+++ b/apps/ios/ShareExtension/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>RemoteClaw Share</string>
+	<string>OpenClaw Share</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.2.23</string>
+	<string>2026.3.9</string>
 	<key>CFBundleVersion</key>
-	<string>20260223</string>
+	<string>20260308</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>RemoteClaw</string>
+	<string>OpenClaw</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconName</key>
@@ -23,20 +23,20 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>2026.3.9</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
 			<key>CFBundleURLName</key>
-			<string>org.remoteclaw.ios</string>
+			<string>ai.openclaw.ios</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>remoteclaw</string>
+				<string>openclaw</string>
 			</array>
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>20260308</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSAppTransportSecurity</key>
@@ -46,24 +46,24 @@
 	</dict>
 	<key>NSBonjourServices</key>
 	<array>
-		<string>_remoteclaw-gw._tcp</string>
+		<string>_openclaw-gw._tcp</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
-	<string>RemoteClaw can capture photos or short video clips when requested via the gateway.</string>
+	<string>OpenClaw can capture photos or short video clips when requested via the gateway.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>RemoteClaw discovers and connects to your RemoteClaw gateway on the local network.</string>
+	<string>OpenClaw discovers and connects to your OpenClaw gateway on the local network.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>RemoteClaw can share your location in the background when you enable Always.</string>
+	<string>OpenClaw can share your location in the background when you enable Always.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>RemoteClaw uses your location when you allow location sharing.</string>
+	<string>OpenClaw uses your location when you allow location sharing.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>RemoteClaw needs microphone access for voice wake.</string>
+	<string>OpenClaw needs microphone access for voice wake.</string>
 	<key>NSMotionUsageDescription</key>
-	<string>RemoteClaw may use motion data to support device-aware interactions and automations.</string>
+	<string>OpenClaw may use motion data to support device-aware interactions and automations.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>RemoteClaw needs photo library access when you choose existing photos to share with your assistant.</string>
+	<string>OpenClaw needs photo library access when you choose existing photos to share with your assistant.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
-	<string>RemoteClaw uses on-device speech recognition for voice wake.</string>
+	<string>OpenClaw uses on-device speech recognition for voice wake.</string>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/apps/ios/Tests/Info.plist
+++ b/apps/ios/Tests/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>RemoteClawTests</string>
+	<string>OpenClawTests</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -17,8 +17,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>2026.3.9</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>20260308</string>
 </dict>
 </plist>

--- a/apps/ios/WatchApp/Info.plist
+++ b/apps/ios/WatchApp/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>RemoteClaw</string>
+	<string>OpenClaw</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.2.23</string>
+	<string>2026.3.9</string>
 	<key>CFBundleVersion</key>
-	<string>20260223</string>
+	<string>20260308</string>
 	<key>WKCompanionAppBundleIdentifier</key>
-	<string>$(REMOTECLAW_APP_BUNDLE_ID)</string>
+	<string>$(OPENCLAW_APP_BUNDLE_ID)</string>
 	<key>WKWatchKitApp</key>
 	<true/>
 </dict>

--- a/apps/ios/WatchExtension/Info.plist
+++ b/apps/ios/WatchExtension/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>RemoteClaw</string>
+	<string>OpenClaw</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,15 +15,15 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.2.23</string>
+	<string>2026.3.9</string>
 	<key>CFBundleVersion</key>
-	<string>20260223</string>
+	<string>20260308</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>WKAppBundleIdentifier</key>
-			<string>$(REMOTECLAW_WATCH_APP_BUNDLE_ID)</string>
+			<string>$(OPENCLAW_WATCH_APP_BUNDLE_ID)</string>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.watchkit</string>

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -98,7 +98,7 @@ targets:
           - CFBundleURLName: ai.remoteclaw.ios
             CFBundleURLSchemes:
               - remoteclaw
-        CFBundleShortVersionString: "2026.3.1"
+        CFBundleShortVersionString: "2026.3.9"
         CFBundleVersion: "20260301"
         UILaunchScreen: {}
         UIApplicationSceneManifest:
@@ -156,7 +156,7 @@ targets:
       path: ShareExtension/Info.plist
       properties:
         CFBundleDisplayName: RemoteClaw Share
-        CFBundleShortVersionString: "2026.3.1"
+        CFBundleShortVersionString: "2026.3.9"
         CFBundleVersion: "20260301"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.share-services
@@ -193,7 +193,7 @@ targets:
       path: ActivityWidget/Info.plist
       properties:
         CFBundleDisplayName: RemoteClaw Activity
-        CFBundleShortVersionString: "2026.3.2"
+        CFBundleShortVersionString: "2026.3.9"
         CFBundleVersion: "20260301"
         NSSupportsLiveActivities: true
         NSExtension:
@@ -219,7 +219,7 @@ targets:
       path: WatchApp/Info.plist
       properties:
         CFBundleDisplayName: RemoteClaw
-        CFBundleShortVersionString: "2026.3.1"
+        CFBundleShortVersionString: "2026.3.9"
         CFBundleVersion: "20260301"
         WKCompanionAppBundleIdentifier: "$(REMOTECLAW_APP_BUNDLE_ID)"
         WKWatchKitApp: true
@@ -244,7 +244,7 @@ targets:
       path: WatchExtension/Info.plist
       properties:
         CFBundleDisplayName: RemoteClaw
-        CFBundleShortVersionString: "2026.3.1"
+        CFBundleShortVersionString: "2026.3.9"
         CFBundleVersion: "20260301"
         NSExtension:
           NSExtensionAttributes:
@@ -279,5 +279,5 @@ targets:
       path: Tests/Info.plist
       properties:
         CFBundleDisplayName: RemoteClawTests
-        CFBundleShortVersionString: "2026.3.1"
+        CFBundleShortVersionString: "2026.3.9"
         CFBundleVersion: "20260301"

--- a/apps/macos/Sources/RemoteClaw/Resources/Info.plist
+++ b/apps/macos/Sources/RemoteClaw/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>2026.3.9</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CFBundleIconFile</key>

--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -39,7 +39,7 @@ Notes:
 # Default is auto-derived from APP_VERSION when omitted.
 SKIP_NOTARIZE=1 \
 BUNDLE_ID=org.remoteclaw.mac \
-APP_VERSION=0.1.0 \
+APP_VERSION=2026.3.9 \
 BUILD_CONFIG=release \
 SIGN_IDENTITY="Developer ID Application: <Developer Name> (<TEAMID>)" \
 scripts/package-mac-dist.sh
@@ -47,10 +47,10 @@ scripts/package-mac-dist.sh
 # `package-mac-dist.sh` already creates the zip + DMG.
 # If you used `package-mac-app.sh` directly instead, create them manually:
 # If you want notarization/stapling in this step, use the NOTARIZE command below.
-ditto -c -k --sequesterRsrc --keepParent dist/RemoteClaw.app dist/RemoteClaw-0.1.0.zip
+ditto -c -k --sequesterRsrc --keepParent dist/RemoteClaw.app dist/RemoteClaw-2026.3.9.zip
 
 # Optional: build a styled DMG for humans (drag to /Applications)
-scripts/create-dmg.sh dist/RemoteClaw.app dist/RemoteClaw-0.1.0.dmg
+scripts/create-dmg.sh dist/RemoteClaw.app dist/RemoteClaw-2026.3.9.dmg
 
 # Recommended: build + notarize/staple zip + DMG
 # First, create a keychain profile once:
@@ -58,13 +58,13 @@ scripts/create-dmg.sh dist/RemoteClaw.app dist/RemoteClaw-0.1.0.dmg
 #     --apple-id "<apple-id>" --team-id "<team-id>" --password "<app-specific-password>"
 NOTARIZE=1 NOTARYTOOL_PROFILE=remoteclaw-notary \
 BUNDLE_ID=org.remoteclaw.mac \
-APP_VERSION=0.1.0 \
+APP_VERSION=2026.3.9 \
 BUILD_CONFIG=release \
 SIGN_IDENTITY="Developer ID Application: <Developer Name> (<TEAMID>)" \
 scripts/package-mac-dist.sh
 
 # Optional: ship dSYM alongside the release
-ditto -c -k --keepParent apps/macos/.build/release/RemoteClaw.app.dSYM dist/RemoteClaw-0.1.0.dSYM.zip
+ditto -c -k --keepParent apps/macos/.build/release/RemoteClaw.app.dSYM dist/RemoteClaw-2026.3.9.dSYM.zip
 ```
 
 ## Appcast entry
@@ -72,7 +72,7 @@ ditto -c -k --keepParent apps/macos/.build/release/RemoteClaw.app.dSYM dist/Remo
 Use the release note generator so Sparkle renders formatted HTML notes:
 
 ```bash
-SPARKLE_PRIVATE_KEY_FILE=/path/to/ed25519-private-key scripts/make_appcast.sh dist/RemoteClaw-0.1.0.zip https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/appcast.xml
+SPARKLE_PRIVATE_KEY_FILE=/path/to/ed25519-private-key scripts/make_appcast.sh dist/RemoteClaw-2026.3.9.zip https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/appcast.xml
 ```
 
 Generates HTML release notes from `CHANGELOG.md` (via [`scripts/changelog-to-html.sh`](https://github.com/remoteclaw/remoteclaw/blob/main/scripts/changelog-to-html.sh)) and embeds them in the appcast entry.
@@ -80,7 +80,7 @@ Commit the updated `appcast.xml` alongside the release assets (zip + dSYM) when 
 
 ## Publish & verify
 
-- Upload `RemoteClaw-0.1.0.zip` (and `RemoteClaw-0.1.0.dSYM.zip`) to the GitHub release for tag `v0.1.0`.
+- Upload `RemoteClaw-2026.3.9.zip` (and `RemoteClaw-2026.3.9.dSYM.zip`) to the GitHub release for tag `v2026.3.9`.
 - Ensure the raw appcast URL matches the baked feed: `https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/appcast.xml`.
 - Sanity checks:
   - `curl -I https://raw.githubusercontent.com/remoteclaw/remoteclaw/main/appcast.xml` returns 200.

--- a/src/infra/git-commit.test.ts
+++ b/src/infra/git-commit.test.ts
@@ -188,7 +188,7 @@ describe("git commit resolution", () => {
     await fs.mkdir(path.join(packageRoot, "dist"), { recursive: true });
     await fs.writeFile(
       path.join(packageRoot, "package.json"),
-      JSON.stringify({ name: "remoteclaw", version: "2026.3.8" }),
+      JSON.stringify({ name: "remoteclaw", version: "2026.3.9" }),
       "utf-8",
     );
     const moduleUrl = pathToFileURL(path.join(packageRoot, "dist", "entry.js")).href;


### PR DESCRIPTION
## Summary

Cherry-pick of upstream commit `f9706fde6` — bump unreleased version to 2026.3.9.

Conflicts resolved:
- `package.json` reverted (fork-managed versioning)
- `src/install-sh-version.test.ts` dropped (deleted in fork)
- `CHANGELOG.md` not touched (fork-divergent)
- All branding conflicts resolved keeping RemoteClaw names with upstream version numbers

upstream: openclaw/openclaw@f9706fde6

Part of #926