### PR TITLE
Cherry-pick 0bcddb3d4: iOS: reconnect gateway on foreground return

### DIFF
--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -362,7 +362,14 @@ final class NodeAppModel {
                         await MainActor.run {
                             self.operatorConnected = false
                             self.gatewayConnected = false
+                            // Foreground recovery must actively restart the saved gateway config.
+                            // Disconnecting stale sockets alone can leave us idle if the old
+                            // reconnect tasks were suppressed or otherwise got stuck in background.
+                            self.gatewayStatusText = "Reconnecting…"
                             self.talkMode.updateGatewayConnected(false)
+                            if let cfg = self.activeGatewayConnectConfig {
+                                self.applyGatewayConnectConfig(cfg)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Cherry-pick of upstream commit `0bcddb3d4` — iOS: reconnect gateway on foreground return.

CHANGELOG.md conflict resolved by keeping fork version.

upstream: openclaw/openclaw@0bcddb3d4

Closes #926