### PR TITLE
Cherry-pick 17599a8ea: refactor: flatten supervisor marker hints

### DIFF
--- a/src/infra/supervisor-markers.ts
+++ b/src/infra/supervisor-markers.ts
@@ -1,23 +1,13 @@
-const LAUNCHD_SUPERVISOR_HINT_ENV_VARS = [
-  "LAUNCH_JOB_LABEL",
-  "LAUNCH_JOB_NAME",
-  "XPC_SERVICE_NAME",
-  "REMOTECLAW_LAUNCHD_LABEL",
-] as const;
-
-const SYSTEMD_SUPERVISOR_HINT_ENV_VARS = [
-  "REMOTECLAW_SYSTEMD_UNIT",
-  "INVOCATION_ID",
-  "SYSTEMD_EXEC_PID",
-  "JOURNAL_STREAM",
-] as const;
-
-const WINDOWS_TASK_SUPERVISOR_HINT_ENV_VARS = ["REMOTECLAW_WINDOWS_TASK_NAME"] as const;
+const SUPERVISOR_HINTS = {
+  launchd: ["LAUNCH_JOB_LABEL", "LAUNCH_JOB_NAME", "XPC_SERVICE_NAME", "REMOTECLAW_LAUNCHD_LABEL"],
+  systemd: ["REMOTECLAW_SYSTEMD_UNIT", "INVOCATION_ID", "SYSTEMD_EXEC_PID", "JOURNAL_STREAM"],
+  schtasks: ["REMOTECLAW_WINDOWS_TASK_NAME"],
+} as const;
 
 export const SUPERVISOR_HINT_ENV_VARS = [
-  ...LAUNCHD_SUPERVISOR_HINT_ENV_VARS,
-  ...SYSTEMD_SUPERVISOR_HINT_ENV_VARS,
-  ...WINDOWS_TASK_SUPERVISOR_HINT_ENV_VARS,
+  ...SUPERVISOR_HINTS.launchd,
+  ...SUPERVISOR_HINTS.systemd,
+  ...SUPERVISOR_HINTS.schtasks,
   "REMOTECLAW_SERVICE_MARKER",
   "REMOTECLAW_SERVICE_KIND",
 ] as const;
@@ -36,13 +26,13 @@ export function detectRespawnSupervisor(
   platform: NodeJS.Platform = process.platform,
 ): RespawnSupervisor | null {
   if (platform === "darwin") {
-    return hasAnyHint(env, LAUNCHD_SUPERVISOR_HINT_ENV_VARS) ? "launchd" : null;
+    return hasAnyHint(env, SUPERVISOR_HINTS.launchd) ? "launchd" : null;
   }
   if (platform === "linux") {
-    return hasAnyHint(env, SYSTEMD_SUPERVISOR_HINT_ENV_VARS) ? "systemd" : null;
+    return hasAnyHint(env, SUPERVISOR_HINTS.systemd) ? "systemd" : null;
   }
   if (platform === "win32") {
-    if (hasAnyHint(env, WINDOWS_TASK_SUPERVISOR_HINT_ENV_VARS)) {
+    if (hasAnyHint(env, SUPERVISOR_HINTS.schtasks)) {
       return "schtasks";
     }
     const marker = env.REMOTECLAW_SERVICE_MARKER?.trim();


### PR DESCRIPTION
Cherry-pick of upstream openclaw/openclaw@17599a8ea.

**refactor: flatten supervisor marker hints**

Replaces three separate `const` arrays (`LAUNCHD_SUPERVISOR_HINT_ENV_VARS`, `SYSTEMD_SUPERVISOR_HINT_ENV_VARS`, `WINDOWS_TASK_SUPERVISOR_HINT_ENV_VARS`) with a single `SUPERVISOR_HINTS` object keyed by supervisor type.

## Conflict Resolution

`supervisor-markers.ts`: upstream flattened arrays into `SUPERVISOR_HINTS` object using `OPENCLAW_*` names; our fork had already rebranded to `REMOTECLAW_*`. Accepted the flattened structure with rebranded names.

Part of #927