### PR TITLE
Cherry-pick issue #929: brave-snippets-memory-flush-web-search-oauth

### DIFF
--- a/docs/channels/discord.mdx
+++ b/docs/channels/discord.mdx
@@ -168,6 +168,7 @@ You will need to create a new application with a bot, add the bot to your server
 
 :::note
 Token resolution is account-aware. Config token values win over env fallback. `DISCORD_BOT_TOKEN` is only used for the default account.
+For advanced outbound calls (message tool/channel actions), an explicit per-call `token` is used for that call. Account policy/retry settings still come from the selected account in the active runtime snapshot.
 :::
 
 ## Recommended: Set up a guild workspace

--- a/docs/channels/telegram.mdx
+++ b/docs/channels/telegram.mdx
@@ -430,6 +430,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `channels.telegram.actions.sticker` (default: disabled)
 
     Note: `edit` and `topic-create` are currently enabled by default and do not have separate `channels.telegram.actions.*` toggles.
+    Runtime sends use the active config/secrets snapshot (startup/reload), so action paths do not perform ad-hoc SecretRef re-resolution per send.
 
     Reaction removal semantics: [/tools/reactions](/tools/reactions)
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -257,6 +257,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 ```
 
 - Token: `channels.discord.token`, with `DISCORD_BOT_TOKEN` as fallback for the default account.
+- Direct outbound calls that provide an explicit Discord `token` use that token for the call; account retry/policy settings still come from the selected account in the active runtime snapshot.
 - Optional `channels.discord.defaultAccount` overrides default account selection when it matches a configured account id.
 - Use `user:<id>` (DM) or `channel:<id>` (guild channel) for delivery targets; bare numeric IDs are rejected.
 - Guild slugs are lowercase with spaces replaced by `-`; channel keys use the slugged name (no `#`). Prefer guild IDs.

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -31,6 +31,7 @@ Scope intent:
 - `talk.providers.*.apiKey`
 - `messages.tts.elevenlabs.apiKey`
 - `messages.tts.openai.apiKey`
+- `tools.web.fetch.firecrawl.apiKey`
 - `tools.web.search.apiKey`
 - `tools.web.search.gemini.apiKey`
 - `tools.web.search.grok.apiKey`
@@ -101,7 +102,8 @@ Notes:
 - For SecretRef-managed model providers, generated `agents/*/agent/models.json` entries persist non-secret markers (not resolved secret values) for `apiKey`/header surfaces.
 - For web search:
   - In explicit provider mode (`tools.web.search.provider` set), only the selected provider key is active.
-  - In auto mode (`tools.web.search.provider` unset), `tools.web.search.apiKey` and provider-specific keys are active.
+  - In auto mode (`tools.web.search.provider` unset), only the first provider key that resolves by precedence is active.
+  - In auto mode, non-selected provider refs are treated as inactive until selected.
 
 ## Unsupported credentials
 

--- a/docs/tools/firecrawl.md
+++ b/docs/tools/firecrawl.md
@@ -40,7 +40,8 @@ with JS-heavy sites or pages that block plain HTTP fetches.
 
 Notes:
 
-- `firecrawl.enabled` defaults to true when an API key is present.
+- `firecrawl.enabled` defaults to `true` unless explicitly set to `false`.
+- Firecrawl fallback attempts run only when an API key is available (`tools.web.fetch.firecrawl.apiKey` or `FIRECRAWL_API_KEY`).
 - `maxAgeMs` controls how old cached results can be (ms). Default is 2 days.
 
 ## Stealth / bot circumvention

--- a/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMention } from "./monitor-helpers.js";
+
+describe("normalizeMention", () => {
+  it("returns trimmed text when no mention provided", () => {
+    expect(normalizeMention("  hello world  ", undefined)).toBe("hello world");
+  });
+
+  it("strips bot mention from text", () => {
+    expect(normalizeMention("@echobot hello", "echobot")).toBe("hello");
+  });
+
+  it("strips mention case-insensitively", () => {
+    expect(normalizeMention("@EchoBot hello", "echobot")).toBe("hello");
+  });
+
+  it("preserves newlines in multi-line messages", () => {
+    const input = "@echobot\nline1\nline2\nline3";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toBe("line1\nline2\nline3");
+  });
+
+  it("preserves Markdown headings", () => {
+    const input = "@echobot\n# Heading\n\nSome text";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("# Heading");
+    expect(result).toContain("\n");
+  });
+
+  it("preserves Markdown blockquotes", () => {
+    const input = "@echobot\n> quoted line\n> second line";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("> quoted line");
+    expect(result).toContain("> second line");
+  });
+
+  it("preserves Markdown lists", () => {
+    const input = "@echobot\n- item A\n- item B\n  - sub B1";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("- item A");
+    expect(result).toContain("- item B");
+  });
+
+  it("preserves task lists", () => {
+    const input = "@echobot\n- [ ] todo\n- [x] done";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("- [ ] todo");
+    expect(result).toContain("- [x] done");
+  });
+
+  it("handles mention in middle of text", () => {
+    const input = "hey @echobot check this\nout";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toBe("hey check this\nout");
+  });
+
+  it("preserves leading indentation for nested lists", () => {
+    const input = "@echobot\n- item\n  - nested\n    - deep";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("  - nested");
+    expect(result).toContain("    - deep");
+  });
+
+  it("preserves first-line indentation for nested list items", () => {
+    const input = "@echobot\n  - nested\n    - deep";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toBe("  - nested\n    - deep");
+  });
+
+  it("preserves indented code blocks", () => {
+    const input = "@echobot\ntext\n    code line 1\n    code line 2";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("    code line 1");
+    expect(result).toContain("    code line 2");
+  });
+
+  it("preserves first-line indentation for indented code blocks", () => {
+    const input = "@echobot\n    code line 1\n    code line 2";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toBe("    code line 1\n    code line 2");
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor-helpers.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.ts
@@ -69,3 +69,38 @@ export function resolveThreadSessionKeys(params: {
     normalizeThreadId: (threadId) => threadId,
   });
 }
+
+/**
+ * Strip bot mention from message text while preserving newlines and
+ * block-level Markdown formatting (headings, lists, blockquotes).
+ */
+export function normalizeMention(text: string, mention: string | undefined): string {
+  if (!mention) {
+    return text.trim();
+  }
+  const escaped = mention.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const hasMentionRe = new RegExp(`@${escaped}\\b`, "i");
+  const leadingMentionRe = new RegExp(`^([\\t ]*)@${escaped}\\b[\\t ]*`, "i");
+  const trailingMentionRe = new RegExp(`[\\t ]*@${escaped}\\b[\\t ]*$`, "i");
+  const normalizedLines = text.split("\n").map((line) => {
+    const hadMention = hasMentionRe.test(line);
+    const normalizedLine = line
+      .replace(leadingMentionRe, "$1")
+      .replace(trailingMentionRe, "")
+      .replace(new RegExp(`@${escaped}\\b`, "gi"), "")
+      .replace(/(\S)[ \t]{2,}/g, "$1 ");
+    return {
+      text: normalizedLine,
+      mentionOnlyBlank: hadMention && normalizedLine.trim() === "",
+    };
+  });
+
+  while (normalizedLines[0]?.mentionOnlyBlank) {
+    normalizedLines.shift();
+  }
+  while (normalizedLines.at(-1)?.text.trim() === "") {
+    normalizedLines.pop();
+  }
+
+  return normalizedLines.map((line) => line.text).join("\n");
+}

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -69,6 +69,7 @@ import {
 import {
   createDedupeCache,
   formatInboundFromLabel,
+  normalizeMention,
   resolveThreadSessionKeys,
 } from "./monitor-helpers.js";
 import { resolveOncharPrefixes, stripOncharPrefix } from "./monitor-onchar.js";
@@ -140,15 +141,6 @@ function resolveRuntime(opts: MonitorMattermostOpts): RuntimeEnv {
       },
     }
   );
-}
-
-function normalizeMention(text: string, mention: string | undefined): string {
-  if (!mention) {
-    return text.trim();
-  }
-  const escaped = mention.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const re = new RegExp(`@${escaped}\\b`, "gi");
-  return text.replace(re, " ").replace(/\s+/g, " ").trim();
 }
 
 function isSystemPost(post: MattermostPost): boolean {

--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -57,18 +57,38 @@ function installGatewayRuntime(params?: { probeOk?: boolean; botUsername?: strin
   const probeTelegram = vi.fn(async () =>
     params?.probeOk ? { ok: true, bot: { username: params.botUsername ?? "bot" } } : { ok: false },
   );
+  const collectUnmentionedGroupIds = vi.fn(() => ({
+    groupIds: [] as string[],
+    unresolvedGroups: 0,
+    hasWildcardUnmentionedGroups: false,
+  }));
+  const auditGroupMembership = vi.fn(async () => ({
+    ok: true,
+    checkedGroups: 0,
+    unresolvedGroups: 0,
+    hasWildcardUnmentionedGroups: false,
+    groups: [],
+    elapsedMs: 0,
+  }));
   setTelegramRuntime({
     channel: {
       telegram: {
         monitorTelegramProvider,
         probeTelegram,
+        collectUnmentionedGroupIds,
+        auditGroupMembership,
       },
     },
     logging: {
       shouldLogVerbose: () => false,
     },
   } as unknown as PluginRuntime);
-  return { monitorTelegramProvider, probeTelegram };
+  return {
+    monitorTelegramProvider,
+    probeTelegram,
+    collectUnmentionedGroupIds,
+    auditGroupMembership,
+  };
 }
 
 describe("telegramPlugin duplicate token guard", () => {
@@ -147,6 +167,85 @@ describe("telegramPlugin duplicate token guard", () => {
         webhookPort: 9876,
       }),
     );
+  });
+
+  it("passes account proxy and network settings into Telegram probes", async () => {
+    const { probeTelegram } = installGatewayRuntime({
+      probeOk: true,
+      botUsername: "opsbot",
+    });
+
+    const cfg = createCfg();
+    cfg.channels!.telegram!.accounts!.ops = {
+      ...cfg.channels!.telegram!.accounts!.ops,
+      proxy: "http://127.0.0.1:8888",
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    };
+    const account = telegramPlugin.config.resolveAccount(cfg, "ops");
+
+    await telegramPlugin.status!.probeAccount!({
+      account,
+      timeoutMs: 5000,
+      cfg,
+    });
+
+    expect(probeTelegram).toHaveBeenCalledWith("token-ops", 5000, {
+      accountId: "ops",
+      proxyUrl: "http://127.0.0.1:8888",
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+  });
+
+  it("passes account proxy and network settings into Telegram membership audits", async () => {
+    const { collectUnmentionedGroupIds, auditGroupMembership } = installGatewayRuntime({
+      probeOk: true,
+      botUsername: "opsbot",
+    });
+
+    collectUnmentionedGroupIds.mockReturnValue({
+      groupIds: ["-100123"],
+      unresolvedGroups: 0,
+      hasWildcardUnmentionedGroups: false,
+    });
+
+    const cfg = createCfg();
+    cfg.channels!.telegram!.accounts!.ops = {
+      ...cfg.channels!.telegram!.accounts!.ops,
+      proxy: "http://127.0.0.1:8888",
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+      groups: {
+        "-100123": { requireMention: false },
+      },
+    };
+    const account = telegramPlugin.config.resolveAccount(cfg, "ops");
+
+    await telegramPlugin.status!.auditAccount!({
+      account,
+      timeoutMs: 5000,
+      probe: { ok: true, bot: { id: 123 }, elapsedMs: 1 },
+      cfg,
+    });
+
+    expect(auditGroupMembership).toHaveBeenCalledWith({
+      token: "token-ops",
+      botId: 123,
+      groupIds: ["-100123"],
+      proxyUrl: "http://127.0.0.1:8888",
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+      timeoutMs: 5000,
+    });
   });
 
   it("forwards mediaLocalRoots to sendMessageTelegram for outbound media sends", async () => {

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -386,11 +386,11 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
     collectStatusIssues: collectTelegramStatusIssues,
     buildChannelSummary: ({ snapshot }) => buildTokenChannelStatusSummary(snapshot),
     probeAccount: async ({ account, timeoutMs }) =>
-      getTelegramRuntime().channel.telegram.probeTelegram(
-        account.token,
-        timeoutMs,
-        account.config.proxy,
-      ),
+      getTelegramRuntime().channel.telegram.probeTelegram(account.token, timeoutMs, {
+        accountId: account.accountId,
+        proxyUrl: account.config.proxy,
+        network: account.config.network,
+      }),
     auditAccount: async ({ account, timeoutMs, probe, cfg }) => {
       const groups =
         cfg.channels?.telegram?.accounts?.[account.accountId]?.groups ??
@@ -416,6 +416,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         botId,
         groupIds,
         proxyUrl: account.config.proxy,
+        network: account.config.network,
         timeoutMs,
       });
       return { ...audit, unresolvedGroups, hasWildcardUnmentionedGroups };
@@ -477,11 +478,11 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
       const token = (account.token ?? "").trim();
       let telegramBotLabel = "";
       try {
-        const probe = await getTelegramRuntime().channel.telegram.probeTelegram(
-          token,
-          2500,
-          account.config.proxy,
-        );
+        const probe = await getTelegramRuntime().channel.telegram.probeTelegram(token, 2500, {
+          accountId: account.accountId,
+          proxyUrl: account.config.proxy,
+          network: account.config.network,
+        });
         const username = probe.ok ? probe.bot?.username?.trim() : null;
         if (username) {
           telegramBotLabel = ` (@${username})`;

--- a/src/agents/agent-utils.ts
+++ b/src/agents/agent-utils.ts
@@ -33,6 +33,32 @@ export function stripMinimaxToolCallXml(text: string): string {
 }
 
 /**
+ * Strip model control tokens leaked into assistant text output.
+ *
+ * Models like GLM-5 and DeepSeek sometimes emit internal delimiter tokens
+ * (e.g. `<|assistant|>`, `<|tool_call_result_begin|>`, `<｜begin▁of▁sentence｜>`)
+ * in their responses. These use the universal `<|...|>` convention (ASCII or
+ * full-width pipe variants) and should never reach end users.
+ *
+ * This is a provider bug — no upstream fix tracked yet.
+ * Remove this function when upstream providers stop leaking tokens.
+ * @see https://github.com/openclaw/openclaw/issues/40020
+ */
+// Match both ASCII pipe <|...|> and full-width pipe <｜...｜> (U+FF5C) variants.
+const MODEL_SPECIAL_TOKEN_RE = /<[|｜][^|｜]*[|｜]>/g;
+
+export function stripModelSpecialTokens(text: string): string {
+  if (!text) {
+    return text;
+  }
+  if (!MODEL_SPECIAL_TOKEN_RE.test(text)) {
+    return text;
+  }
+  MODEL_SPECIAL_TOKEN_RE.lastIndex = 0;
+  return text.replace(MODEL_SPECIAL_TOKEN_RE, " ").replace(/  +/g, " ").trim();
+}
+
+/**
  * Strip downgraded tool call text representations that leak into text content.
  * When replaying history to Gemini, tool calls without `thought_signature` are
  * downgraded to text blocks like `[Tool Call: name (ID: ...)]`. These should
@@ -211,7 +237,7 @@ export function extractAssistantText(msg: AssistantMessage): string {
     extractTextFromChatContent(msg.content, {
       sanitizeText: (text) =>
         stripThinkingTagsFromText(
-          stripDowngradedToolCallText(stripMinimaxToolCallXml(text)),
+          stripDowngradedToolCallText(stripModelSpecialTokens(stripMinimaxToolCallXml(text))),
         ).trim(),
       joinWith: "\n",
       normalizeText: (text) => text.trim(),

--- a/src/agents/remoteclaw-tools.ts
+++ b/src/agents/remoteclaw-tools.ts
@@ -59,9 +59,19 @@ export function createRemoteClawTools(
     senderIsOwner?: boolean;
     /** Ephemeral session UUID — regenerated on /new and /reset. */
     sessionId?: string;
+    /**
+     * Workspace directory to pass to spawned subagents for inheritance.
+     * Defaults to workspaceDir. Use this to pass the actual agent workspace when the
+     * session itself is running in a copied-workspace sandbox (`ro` or `none`) so
+     * subagents inherit the real workspace path instead of the sandbox copy.
+     */
+    spawnWorkspaceDir?: string;
   } & SpawnedToolContext,
 ): AnyAgentTool[] {
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir);
+  const spawnWorkspaceDir = resolveWorkspaceRoot(
+    options?.spawnWorkspaceDir ?? options?.workspaceDir,
+  );
   const messageTool = options?.disableMessageTool
     ? null
     : createMessageTool({
@@ -121,7 +131,7 @@ export function createRemoteClawTools(
       agentGroupSpace: options?.agentGroupSpace,
       sandboxed: options?.sandboxed,
       requesterAgentIdOverride: options?.requesterAgentIdOverride,
-      workspaceDir,
+      workspaceDir: spawnWorkspaceDir,
     }),
     createSubagentsTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -32,6 +32,7 @@ import { sanitizeUserFacingText } from "../agent-helpers.js";
 import {
   stripDowngradedToolCallText,
   stripMinimaxToolCallXml,
+  stripModelSpecialTokens,
   stripThinkingTagsFromText,
 } from "../agent-utils.js";
 
@@ -141,7 +142,9 @@ export function sanitizeTextContent(text: string): string {
   if (!text) {
     return text;
   }
-  return stripThinkingTagsFromText(stripDowngradedToolCallText(stripMinimaxToolCallXml(text)));
+  return stripThinkingTagsFromText(
+    stripDowngradedToolCallText(stripModelSpecialTokens(stripMinimaxToolCallXml(text))),
+  );
 }
 
 export function extractAssistantText(message: unknown): string | undefined {

--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -18,6 +18,16 @@ const sendStickerTelegram = vi.fn(async () => ({
   chatId: "123",
 }));
 const deleteMessageTelegram = vi.fn(async () => ({ ok: true }));
+const editMessageTelegram = vi.fn(async () => ({
+  ok: true,
+  messageId: "456",
+  chatId: "123",
+}));
+const createForumTopicTelegram = vi.fn(async () => ({
+  topicId: 99,
+  name: "Topic",
+  chatId: "123",
+}));
 let envSnapshot: ReturnType<typeof captureEnv>;
 
 vi.mock("../../telegram/send.js", () => ({
@@ -30,6 +40,10 @@ vi.mock("../../telegram/send.js", () => ({
     sendStickerTelegram(...args),
   deleteMessageTelegram: (...args: Parameters<typeof deleteMessageTelegram>) =>
     deleteMessageTelegram(...args),
+  editMessageTelegram: (...args: Parameters<typeof editMessageTelegram>) =>
+    editMessageTelegram(...args),
+  createForumTopicTelegram: (...args: Parameters<typeof createForumTopicTelegram>) =>
+    createForumTopicTelegram(...args),
 }));
 
 describe("handleTelegramAction", () => {
@@ -92,6 +106,8 @@ describe("handleTelegramAction", () => {
     sendPollTelegram.mockClear();
     sendStickerTelegram.mockClear();
     deleteMessageTelegram.mockClear();
+    editMessageTelegram.mockClear();
+    createForumTopicTelegram.mockClear();
     process.env.TELEGRAM_BOT_TOKEN = "tok";
   });
 
@@ -379,6 +395,85 @@ describe("handleTelegramAction", () => {
       "Hello with local media",
       expect.objectContaining({ mediaLocalRoots: ["/tmp/agent-root"] }),
     );
+  });
+
+  it.each([
+    {
+      name: "react",
+      params: { action: "react", chatId: "123", messageId: 456, emoji: "✅" },
+      cfg: reactionConfig("minimal"),
+      assertCall: (
+        readCallOpts: (calls: unknown[][], argIndex: number) => Record<string, unknown>,
+      ) => readCallOpts(reactMessageTelegram.mock.calls as unknown[][], 3),
+    },
+    {
+      name: "sendMessage",
+      params: { action: "sendMessage", to: "123", content: "hello" },
+      cfg: telegramConfig(),
+      assertCall: (
+        readCallOpts: (calls: unknown[][], argIndex: number) => Record<string, unknown>,
+      ) => readCallOpts(sendMessageTelegram.mock.calls as unknown[][], 2),
+    },
+    {
+      name: "poll",
+      params: {
+        action: "poll",
+        to: "123",
+        question: "Q?",
+        answers: ["A", "B"],
+      },
+      cfg: telegramConfig(),
+      assertCall: (
+        readCallOpts: (calls: unknown[][], argIndex: number) => Record<string, unknown>,
+      ) => readCallOpts(sendPollTelegram.mock.calls as unknown[][], 2),
+    },
+    {
+      name: "deleteMessage",
+      params: { action: "deleteMessage", chatId: "123", messageId: 1 },
+      cfg: telegramConfig(),
+      assertCall: (
+        readCallOpts: (calls: unknown[][], argIndex: number) => Record<string, unknown>,
+      ) => readCallOpts(deleteMessageTelegram.mock.calls as unknown[][], 2),
+    },
+    {
+      name: "editMessage",
+      params: { action: "editMessage", chatId: "123", messageId: 1, content: "updated" },
+      cfg: telegramConfig(),
+      assertCall: (
+        readCallOpts: (calls: unknown[][], argIndex: number) => Record<string, unknown>,
+      ) => readCallOpts(editMessageTelegram.mock.calls as unknown[][], 3),
+    },
+    {
+      name: "sendSticker",
+      params: { action: "sendSticker", to: "123", fileId: "sticker-1" },
+      cfg: telegramConfig({ actions: { sticker: true } }),
+      assertCall: (
+        readCallOpts: (calls: unknown[][], argIndex: number) => Record<string, unknown>,
+      ) => readCallOpts(sendStickerTelegram.mock.calls as unknown[][], 2),
+    },
+    {
+      name: "createForumTopic",
+      params: { action: "createForumTopic", chatId: "123", name: "Topic" },
+      cfg: telegramConfig({ actions: { createForumTopic: true } }),
+      assertCall: (
+        readCallOpts: (calls: unknown[][], argIndex: number) => Record<string, unknown>,
+      ) => readCallOpts(createForumTopicTelegram.mock.calls as unknown[][], 2),
+    },
+  ])("forwards resolved cfg for $name action", async ({ params, cfg, assertCall }) => {
+    const readCallOpts = (calls: unknown[][], argIndex: number): Record<string, unknown> => {
+      const args = calls[0];
+      if (!Array.isArray(args)) {
+        throw new Error("Expected Telegram action call args");
+      }
+      const opts = args[argIndex];
+      if (!opts || typeof opts !== "object") {
+        throw new Error("Expected Telegram action options object");
+      }
+      return opts as Record<string, unknown>;
+    };
+    await handleTelegramAction(params as Record<string, unknown>, cfg);
+    const opts = assertCall(readCallOpts);
+    expect(opts.cfg).toBe(cfg);
   });
 
   it.each([

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -149,6 +149,7 @@ export async function handleTelegramAction(
     let reactionResult: Awaited<ReturnType<typeof reactMessageTelegram>>;
     try {
       reactionResult = await reactMessageTelegram(chatId ?? "", messageId ?? 0, emoji ?? "", {
+        cfg,
         token,
         remove,
         accountId: accountId ?? undefined,
@@ -232,6 +233,7 @@ export async function handleTelegramAction(
       );
     }
     const result = await sendMessageTelegram(to, content, {
+      cfg,
       token,
       accountId: accountId ?? undefined,
       mediaUrl: mediaUrl || undefined,
@@ -288,6 +290,7 @@ export async function handleTelegramAction(
         durationHours: durationHours ?? undefined,
       },
       {
+        cfg,
         token,
         accountId: accountId ?? undefined,
         replyToMessageId: replyToMessageId ?? undefined,
@@ -322,6 +325,7 @@ export async function handleTelegramAction(
       );
     }
     await deleteMessageTelegram(chatId ?? "", messageId ?? 0, {
+      cfg,
       token,
       accountId: accountId ?? undefined,
     });
@@ -362,6 +366,7 @@ export async function handleTelegramAction(
       );
     }
     const result = await editMessageTelegram(chatId ?? "", messageId ?? 0, content, {
+      cfg,
       token,
       accountId: accountId ?? undefined,
       buttons,
@@ -394,6 +399,7 @@ export async function handleTelegramAction(
       );
     }
     const result = await sendStickerTelegram(to, fileId, {
+      cfg,
       token,
       accountId: accountId ?? undefined,
       replyToMessageId: replyToMessageId ?? undefined,
@@ -449,6 +455,7 @@ export async function handleTelegramAction(
       );
     }
     const result = await createForumTopicTelegram(chatId ?? "", name, {
+      cfg,
       token,
       accountId: accountId ?? undefined,
       iconColor: iconColor ?? undefined,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -2,6 +2,7 @@ export {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
   createConfigIO,
+  getRuntimeConfigSnapshot,
   loadConfig,
   readBestEffortConfig,
   parseConfigJson5,

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1326,6 +1326,10 @@ export function clearConfigCache(): void {
   configCache = null;
 }
 
+export function getRuntimeConfigSnapshot(): RemoteClawConfig | null {
+  return runtimeConfigSnapshot;
+}
+
 export function setRuntimeConfigSnapshot(config: RemoteClawConfig): void {
   runtimeConfigSnapshot = config;
   clearConfigCache();

--- a/src/config/markdown-tables.test.ts
+++ b/src/config/markdown-tables.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_TABLE_MODES } from "./markdown-tables.js";
+
+describe("DEFAULT_TABLE_MODES", () => {
+  it("mattermost mode is off", () => {
+    expect(DEFAULT_TABLE_MODES.get("mattermost")).toBe("off");
+  });
+
+  it("signal mode is bullets", () => {
+    expect(DEFAULT_TABLE_MODES.get("signal")).toBe("bullets");
+  });
+
+  it("whatsapp mode is bullets", () => {
+    expect(DEFAULT_TABLE_MODES.get("whatsapp")).toBe("bullets");
+  });
+});

--- a/src/config/markdown-tables.ts
+++ b/src/config/markdown-tables.ts
@@ -14,9 +14,10 @@ type MarkdownConfigSection = MarkdownConfigEntry & {
   accounts?: Record<string, MarkdownConfigEntry>;
 };
 
-const DEFAULT_TABLE_MODES = new Map<string, MarkdownTableMode>([
+export const DEFAULT_TABLE_MODES = new Map<string, MarkdownTableMode>([
   ["signal", "bullets"],
   ["whatsapp", "bullets"],
+  ["mattermost", "off"],
 ]);
 
 const isMarkdownTableMode = (value: unknown): value is MarkdownTableMode =>

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -290,7 +290,7 @@ export type ToolsConfig = {
         /** Enable Firecrawl fallback (default: true when apiKey is set). */
         enabled?: boolean;
         /** Firecrawl API key (optional; defaults to FIRECRAWL_API_KEY env var). */
-        apiKey?: string;
+        apiKey?: SecretInput;
         /** Firecrawl base URL (default: https://api.firecrawl.dev). */
         baseUrl?: string;
         /** Whether to keep only main content (default: true). */

--- a/src/cron/cron-protocol-conformance.test.ts
+++ b/src/cron/cron-protocol-conformance.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { CronDeliverySchema } from "../gateway/protocol/schema.js";
+import { CronDeliverySchema, CronJobStateSchema } from "../gateway/protocol/schema.js";
 
 type SchemaLike = {
   anyOf?: Array<SchemaLike>;
@@ -26,6 +26,16 @@ function extractDeliveryModes(schema: SchemaLike): string[] {
     .filter((value): value is string => typeof value === "string");
 
   return Array.from(new Set(unionModes));
+}
+
+function extractConstUnionValues(schema: SchemaLike): string[] {
+  return Array.from(
+    new Set(
+      (schema.anyOf ?? [])
+        .map((entry) => entry?.const)
+        .filter((value): value is string => typeof value === "string"),
+    ),
+  );
 }
 
 const UI_FILES = ["ui/src/ui/types.ts", "ui/src/ui/ui-types.ts", "ui/src/ui/views/cron.ts"];
@@ -86,5 +96,20 @@ describe("cron protocol conformance", () => {
     const swift = await fs.readFile(swiftPath, "utf-8");
     expect(swift.includes("struct CronSchedulerStatus")).toBe(true);
     expect(swift.includes("let jobs:")).toBe(true);
+  });
+
+  it("cron job state schema keeps the full failover reason set", () => {
+    const properties = (CronJobStateSchema as SchemaLike).properties ?? {};
+    const lastErrorReason = properties.lastErrorReason as SchemaLike | undefined;
+    expect(lastErrorReason).toBeDefined();
+    expect(extractConstUnionValues(lastErrorReason ?? {})).toEqual([
+      "auth",
+      "format",
+      "rate_limit",
+      "billing",
+      "timeout",
+      "model_not_found",
+      "unknown",
+    ]);
   });
 });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1,3 +1,4 @@
+import { resolveFailoverReasonFromError } from "../../agents/failover-error.js";
 import type { CronConfig, CronRetryOn } from "../../config/types.cron.js";
 import { isCronSystemEvent } from "../../infra/heartbeat-events-filter.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
@@ -326,6 +327,10 @@ export function applyJobResult(
   job.state.lastStatus = result.status;
   job.state.lastDurationMs = Math.max(0, result.endedAt - result.startedAt);
   job.state.lastError = result.error;
+  job.state.lastErrorReason =
+    result.status === "error" && typeof result.error === "string"
+      ? (resolveFailoverReasonFromError(result.error) ?? undefined)
+      : undefined;
   job.state.lastDelivered = result.delivered;
   const deliveryStatus = resolveDeliveryStatus({ job, delivered: result.delivered });
   job.state.lastDeliveryStatus = deliveryStatus;
@@ -673,7 +678,6 @@ export async function onTimer(state: CronServiceState) {
     if (completedResults.length > 0) {
       await locked(state, async () => {
         await ensureLoaded(state, { forceReload: true, skipRecompute: true });
-
         for (const result of completedResults) {
           applyOutcomeToStoredJob(state, result);
         }

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -1,3 +1,4 @@
+import type { FailoverReason } from "../agents/pi-embedded-helpers.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 
 export type CronSchedule =
@@ -102,7 +103,6 @@ type CronAgentTurnPayload = {
 type CronAgentTurnPayloadPatch = {
   kind: "agentTurn";
 } & Partial<CronAgentTurnPayloadFields>;
-
 export type CronJobState = {
   nextRunAtMs?: number;
   runningAtMs?: number;
@@ -112,6 +112,8 @@ export type CronJobState = {
   /** Back-compat alias for lastRunStatus. */
   lastStatus?: "ok" | "error" | "skipped";
   lastError?: string;
+  /** Classified reason for the last error (when available). */
+  lastErrorReason?: FailoverReason;
   lastDurationMs?: number;
   /** Number of consecutive execution errors (reset on success). Used for backoff. */
   consecutiveErrors?: number;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -1,5 +1,16 @@
-import type { FailoverReason } from "../agents/pi-embedded-helpers.js";
 import type { ChannelId } from "../channels/plugins/types.js";
+
+type FailoverReason =
+  | "auth"
+  | "auth_permanent"
+  | "format"
+  | "rate_limit"
+  | "overloaded"
+  | "billing"
+  | "timeout"
+  | "model_not_found"
+  | "session_expired"
+  | "unknown";
 
 export type CronSchedule =
   | { kind: "at"; at: string }

--- a/src/discord/client.test.ts
+++ b/src/discord/client.test.ts
@@ -1,0 +1,91 @@
+import type { RequestClient } from "@buape/carbon";
+import { describe, expect, it } from "vitest";
+import type { RemoteClawConfig } from "../config/config.js";
+import { createDiscordRestClient } from "./client.js";
+
+describe("createDiscordRestClient", () => {
+  const fakeRest = {} as RequestClient;
+
+  it("uses explicit token without resolving config token SecretRefs", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          token: {
+            source: "exec",
+            provider: "vault",
+            id: "discord/bot-token",
+          },
+        },
+      },
+    } as RemoteClawConfig;
+
+    const result = createDiscordRestClient(
+      {
+        token: "Bot explicit-token",
+        rest: fakeRest,
+      },
+      cfg,
+    );
+
+    expect(result.token).toBe("explicit-token");
+    expect(result.rest).toBe(fakeRest);
+    expect(result.account.accountId).toBe("default");
+  });
+
+  it("keeps account retry config when explicit token is provided", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          accounts: {
+            ops: {
+              token: {
+                source: "exec",
+                provider: "vault",
+                id: "discord/ops-token",
+              },
+              retry: {
+                attempts: 7,
+              },
+            },
+          },
+        },
+      },
+    } as RemoteClawConfig;
+
+    const result = createDiscordRestClient(
+      {
+        accountId: "ops",
+        token: "Bot explicit-account-token",
+        rest: fakeRest,
+      },
+      cfg,
+    );
+
+    expect(result.token).toBe("explicit-account-token");
+    expect(result.account.accountId).toBe("ops");
+    expect(result.account.config.retry).toMatchObject({ attempts: 7 });
+  });
+
+  it("still throws when no explicit token is provided and config token is unresolved", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          token: {
+            source: "file",
+            provider: "default",
+            id: "/discord/token",
+          },
+        },
+      },
+    } as RemoteClawConfig;
+
+    expect(() =>
+      createDiscordRestClient(
+        {
+          rest: fakeRest,
+        },
+        cfg,
+      ),
+    ).toThrow(/unresolved SecretRef/i);
+  });
+});

--- a/src/discord/client.test.ts
+++ b/src/discord/client.test.ts
@@ -17,7 +17,7 @@ describe("createDiscordRestClient", () => {
           },
         },
       },
-    } as RemoteClawConfig;
+    } as unknown as RemoteClawConfig;
 
     const result = createDiscordRestClient(
       {
@@ -50,7 +50,7 @@ describe("createDiscordRestClient", () => {
           },
         },
       },
-    } as RemoteClawConfig;
+    } as unknown as RemoteClawConfig;
 
     const result = createDiscordRestClient(
       {
@@ -77,7 +77,7 @@ describe("createDiscordRestClient", () => {
           },
         },
       },
-    } as RemoteClawConfig;
+    } as unknown as RemoteClawConfig;
 
     expect(() =>
       createDiscordRestClient(

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -56,7 +56,7 @@ export function createDiscordRestClient(
   cfg?: ReturnType<typeof loadConfig>,
 ) {
   const resolvedCfg = opts.cfg ?? cfg ?? loadConfig();
-  const explicitToken = normalizeDiscordToken(opts.token, "channels.discord.token");
+  const explicitToken = normalizeDiscordToken(opts.token);
   const account = explicitToken
     ? resolveAccountWithoutToken({ cfg: resolvedCfg, accountId: opts.accountId })
     : resolveDiscordAccount({ cfg: resolvedCfg, accountId: opts.accountId });

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -2,10 +2,16 @@ import { RequestClient } from "@buape/carbon";
 import { loadConfig } from "../config/config.js";
 import { createDiscordRetryRunner, type RetryRunner } from "../infra/retry-policy.js";
 import type { RetryConfig } from "../infra/retry.js";
-import { resolveDiscordAccount } from "./accounts.js";
+import { normalizeAccountId } from "../routing/session-key.js";
+import {
+  mergeDiscordAccountConfig,
+  resolveDiscordAccount,
+  type ResolvedDiscordAccount,
+} from "./accounts.js";
 import { normalizeDiscordToken } from "./token.js";
 
 export type DiscordClientOpts = {
+  cfg?: ReturnType<typeof loadConfig>;
   token?: string;
   accountId?: string;
   rest?: RequestClient;
@@ -13,11 +19,7 @@ export type DiscordClientOpts = {
   verbose?: boolean;
 };
 
-function resolveToken(params: { explicit?: string; accountId: string; fallbackToken?: string }) {
-  const explicit = normalizeDiscordToken(params.explicit);
-  if (explicit) {
-    return explicit;
-  }
+function resolveToken(params: { accountId: string; fallbackToken?: string }) {
   const fallback = normalizeDiscordToken(params.fallbackToken);
   if (!fallback) {
     throw new Error(
@@ -31,22 +33,48 @@ function resolveRest(token: string, rest?: RequestClient) {
   return rest ?? new RequestClient(token);
 }
 
-export function createDiscordRestClient(opts: DiscordClientOpts, cfg = loadConfig()) {
-  const account = resolveDiscordAccount({ cfg, accountId: opts.accountId });
-  const token = resolveToken({
-    explicit: opts.token,
-    accountId: account.accountId,
-    fallbackToken: account.token,
-  });
+function resolveAccountWithoutToken(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  accountId?: string;
+}): ResolvedDiscordAccount {
+  const accountId = normalizeAccountId(params.accountId);
+  const merged = mergeDiscordAccountConfig(params.cfg, accountId);
+  const baseEnabled = params.cfg.channels?.discord?.enabled !== false;
+  const accountEnabled = merged.enabled !== false;
+  return {
+    accountId,
+    enabled: baseEnabled && accountEnabled,
+    name: merged.name?.trim() || undefined,
+    token: "",
+    tokenSource: "none",
+    config: merged,
+  };
+}
+
+export function createDiscordRestClient(
+  opts: DiscordClientOpts,
+  cfg?: ReturnType<typeof loadConfig>,
+) {
+  const resolvedCfg = opts.cfg ?? cfg ?? loadConfig();
+  const explicitToken = normalizeDiscordToken(opts.token, "channels.discord.token");
+  const account = explicitToken
+    ? resolveAccountWithoutToken({ cfg: resolvedCfg, accountId: opts.accountId })
+    : resolveDiscordAccount({ cfg: resolvedCfg, accountId: opts.accountId });
+  const token =
+    explicitToken ??
+    resolveToken({
+      accountId: account.accountId,
+      fallbackToken: account.token,
+    });
   const rest = resolveRest(token, opts.rest);
   return { token, rest, account };
 }
 
 export function createDiscordClient(
   opts: DiscordClientOpts,
-  cfg = loadConfig(),
+  cfg?: ReturnType<typeof loadConfig>,
 ): { token: string; rest: RequestClient; request: RetryRunner } {
-  const { token, rest, account } = createDiscordRestClient(opts, cfg);
+  const { token, rest, account } = createDiscordRestClient(opts, opts.cfg ?? cfg);
   const request = createDiscordRetryRunner({
     retry: opts.retry,
     configRetry: account.config.retry,
@@ -56,5 +84,5 @@ export function createDiscordClient(
 }
 
 export function resolveDiscordRest(opts: DiscordClientOpts) {
-  return createDiscordRestClient(opts).rest;
+  return createDiscordRestClient(opts, opts.cfg).rest;
 }

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -990,6 +990,7 @@ async function dispatchDiscordComponentEvent(params: {
       deliver: async (payload) => {
         const replyToId = replyReference.use();
         await deliverDiscordReply({
+          cfg: ctx.cfg,
           replies: [payload],
           target: deliverTarget,
           token,

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -683,6 +683,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
 
         const replyToId = replyReference.use();
         await deliverDiscordReply({
+          cfg,
           replies: [payload],
           target: deliverTarget,
           token,

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -325,6 +325,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     ? createThreadBindingManager({
         accountId: account.accountId,
         token,
+        cfg,
         idleTimeoutMs: threadBindingIdleTimeoutMs,
         maxAgeMs: threadBindingMaxAgeMs,
       })

--- a/src/discord/monitor/reply-delivery.test.ts
+++ b/src/discord/monitor/reply-delivery.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RemoteClawConfig } from "../../config/config.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
 import {
@@ -23,6 +24,9 @@ vi.mock("../send.shared.js", () => ({
 
 describe("deliverDiscordReply", () => {
   const runtime = {} as RuntimeEnv;
+  const cfg = {
+    channels: { discord: { token: "test-token" } },
+  } as RemoteClawConfig;
   const createBoundThreadBindings = async (
     overrides: Partial<{
       threadId: string;
@@ -86,6 +90,7 @@ describe("deliverDiscordReply", () => {
       target: "channel:123",
       token: "token",
       runtime,
+      cfg,
       textLimit: 2000,
       replyToId: "reply-1",
     });
@@ -128,6 +133,7 @@ describe("deliverDiscordReply", () => {
       target: "channel:456",
       token: "token",
       runtime,
+      cfg,
       textLimit: 2000,
     });
 
@@ -147,6 +153,7 @@ describe("deliverDiscordReply", () => {
       target: "channel:654",
       token: "token",
       runtime,
+      cfg,
       textLimit: 2000,
       mediaLocalRoots,
     });
@@ -174,6 +181,19 @@ describe("deliverDiscordReply", () => {
     );
   });
 
+  it("forwards cfg to Discord send helpers", async () => {
+    await deliverDiscordReply({
+      replies: [{ text: "cfg path" }],
+      target: "channel:101",
+      token: "token",
+      runtime,
+      cfg,
+      textLimit: 2000,
+    });
+
+    expect(sendMessageDiscordMock.mock.calls[0]?.[2]?.cfg).toBe(cfg);
+  });
+
   it("uses replyToId only for the first chunk when replyToMode is first", async () => {
     await deliverDiscordReply({
       replies: [
@@ -184,6 +204,7 @@ describe("deliverDiscordReply", () => {
       target: "channel:789",
       token: "token",
       runtime,
+      cfg,
       textLimit: 5,
       replyToId: "reply-1",
       replyToMode: "first",
@@ -200,6 +221,7 @@ describe("deliverDiscordReply", () => {
       target: "channel:789",
       token: "token",
       runtime,
+      cfg,
       textLimit: 2000,
       replyToId: "reply-1",
       replyToMode: "first",
@@ -219,6 +241,7 @@ describe("deliverDiscordReply", () => {
       target: "channel:789",
       token: "token",
       runtime,
+      cfg,
       textLimit: 2000,
     });
 
@@ -246,6 +269,7 @@ describe("deliverDiscordReply", () => {
       token: "token",
       rest: fakeRest,
       runtime,
+      cfg,
       textLimit: 5,
     });
 
@@ -265,6 +289,7 @@ describe("deliverDiscordReply", () => {
       token: "token",
       rest: fakeRest,
       runtime,
+      cfg,
       textLimit: 2000,
       maxLinesPerMessage: 120,
       chunkMode: "newline",
@@ -285,6 +310,7 @@ describe("deliverDiscordReply", () => {
       target: "channel:789",
       token: "token",
       runtime,
+      cfg,
       textLimit: 2000,
     });
 
@@ -303,6 +329,7 @@ describe("deliverDiscordReply", () => {
       target: "channel:123",
       token: "token",
       runtime,
+      cfg,
       textLimit: 2000,
     });
 
@@ -320,6 +347,7 @@ describe("deliverDiscordReply", () => {
       target: "channel:123",
       token: "token",
       runtime,
+      cfg,
       textLimit: 2000,
     });
 
@@ -336,6 +364,7 @@ describe("deliverDiscordReply", () => {
         target: "channel:123",
         token: "token",
         runtime,
+        cfg,
         textLimit: 2000,
       }),
     ).rejects.toThrow("bad request");
@@ -353,6 +382,7 @@ describe("deliverDiscordReply", () => {
         target: "channel:123",
         token: "token",
         runtime,
+        cfg,
         textLimit: 2000,
       }),
     ).rejects.toThrow("rate limited");
@@ -372,6 +402,7 @@ describe("deliverDiscordReply", () => {
       target: "channel:123",
       token: "token",
       runtime,
+      cfg,
       textLimit: 2,
     });
 
@@ -386,6 +417,7 @@ describe("deliverDiscordReply", () => {
       target: "channel:thread-1",
       token: "token",
       runtime,
+      cfg,
       textLimit: 2000,
       replyToId: "reply-1",
       sessionKey: "agent:main:subagent:child",
@@ -396,6 +428,7 @@ describe("deliverDiscordReply", () => {
     expect(sendWebhookMessageDiscordMock).toHaveBeenCalledWith(
       "Hello from subagent",
       expect.objectContaining({
+        cfg,
         webhookId: "wh_1",
         webhookToken: "tok_1",
         accountId: "default",
@@ -418,6 +451,7 @@ describe("deliverDiscordReply", () => {
         target: "channel:thread-1",
         token: "token",
         runtime,
+        cfg,
         textLimit: 2000,
         sessionKey: "agent:main:subagent:child",
         threadBindings,
@@ -441,12 +475,14 @@ describe("deliverDiscordReply", () => {
       token: "token",
       accountId: "default",
       runtime,
+      cfg,
       textLimit: 2000,
       sessionKey: "agent:main:subagent:child",
       threadBindings,
     });
 
     expect(sendWebhookMessageDiscordMock).toHaveBeenCalledTimes(1);
+    expect(sendWebhookMessageDiscordMock.mock.calls[0]?.[1]?.cfg).toBe(cfg);
     expect(sendMessageDiscordMock).toHaveBeenCalledTimes(1);
     expect(sendMessageDiscordMock).toHaveBeenCalledWith(
       "channel:thread-1",
@@ -464,6 +500,7 @@ describe("deliverDiscordReply", () => {
       token: "token",
       accountId: "default",
       runtime,
+      cfg,
       textLimit: 2000,
       sessionKey: "agent:main:subagent:child",
       threadBindings,

--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -2,7 +2,7 @@ import type { RequestClient } from "@buape/carbon";
 import { resolveAgentAvatar } from "../../agents/identity-avatar.js";
 import type { ChunkMode } from "../../auto-reply/chunk.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
-import { loadConfig } from "../../config/config.js";
+import type { RemoteClawConfig } from "../../config/config.js";
 import type { MarkdownTableMode, ReplyToMode } from "../../config/types.base.js";
 import { createDiscordRetryRunner, type RetryRunner } from "../../infra/retry-policy.js";
 import { resolveRetryConfig, retryAsync, type RetryConfig } from "../../infra/retry.js";
@@ -90,7 +90,10 @@ function resolveBoundThreadBinding(params: {
   return bindings.find((entry) => entry.threadId === targetChannelId);
 }
 
-function resolveBindingPersona(binding: ThreadBindingRecord | undefined): {
+function resolveBindingPersona(
+  cfg: RemoteClawConfig,
+  binding: ThreadBindingRecord | undefined,
+): {
   username?: string;
   avatarUrl?: string;
 } {
@@ -102,7 +105,7 @@ function resolveBindingPersona(binding: ThreadBindingRecord | undefined): {
 
   let avatarUrl: string | undefined;
   try {
-    const avatar = resolveAgentAvatar(loadConfig(), binding.agentId);
+    const avatar = resolveAgentAvatar(cfg, binding.agentId);
     if (avatar.kind === "remote") {
       avatarUrl = avatar.url;
     }
@@ -113,6 +116,7 @@ function resolveBindingPersona(binding: ThreadBindingRecord | undefined): {
 }
 
 async function sendDiscordChunkWithFallback(params: {
+  cfg: RemoteClawConfig;
   target: string;
   text: string;
   token: string;
@@ -139,6 +143,7 @@ async function sendDiscordChunkWithFallback(params: {
   if (binding?.webhookId && binding?.webhookToken) {
     try {
       await sendWebhookMessageDiscord(text, {
+        cfg: params.cfg,
         webhookId: binding.webhookId,
         webhookToken: binding.webhookToken,
         accountId: binding.accountId,
@@ -177,6 +182,7 @@ async function sendDiscordChunkWithFallback(params: {
   await sendWithRetry(
     () =>
       sendMessageDiscord(params.target, text, {
+        cfg: params.cfg,
         token: params.token,
         rest: params.rest,
         accountId: params.accountId,
@@ -187,6 +193,7 @@ async function sendDiscordChunkWithFallback(params: {
 }
 
 async function sendAdditionalDiscordMedia(params: {
+  cfg: RemoteClawConfig;
   target: string;
   token: string;
   rest?: RequestClient;
@@ -201,6 +208,7 @@ async function sendAdditionalDiscordMedia(params: {
     await sendWithRetry(
       () =>
         sendMessageDiscord(params.target, "", {
+          cfg: params.cfg,
           token: params.token,
           rest: params.rest,
           mediaUrl,
@@ -214,6 +222,7 @@ async function sendAdditionalDiscordMedia(params: {
 }
 
 export async function deliverDiscordReply(params: {
+  cfg: RemoteClawConfig;
   replies: ReplyPayload[];
   target: string;
   token: string;
@@ -254,12 +263,12 @@ export async function deliverDiscordReply(params: {
     sessionKey: params.sessionKey,
     target: params.target,
   });
-  const persona = resolveBindingPersona(binding);
+  const persona = resolveBindingPersona(params.cfg, binding);
   // Pre-resolve channel ID and retry runner once to avoid per-chunk overhead.
   // This eliminates redundant channel-type GET requests and client creation that
   // can cause ordering issues when multiple chunks share the RequestClient queue.
   const channelId = resolveTargetChannelId(params.target);
-  const account = resolveDiscordAccount({ cfg: loadConfig(), accountId: params.accountId });
+  const account = resolveDiscordAccount({ cfg: params.cfg, accountId: params.accountId });
   const retryConfig = resolveDeliveryRetryConfig(account.config.retry);
   const request: RetryRunner | undefined = channelId
     ? createDiscordRetryRunner({ configRetry: account.config.retry })
@@ -289,6 +298,7 @@ export async function deliverDiscordReply(params: {
         }
         const replyTo = resolveReplyTo();
         await sendDiscordChunkWithFallback({
+          cfg: params.cfg,
           target: params.target,
           text: chunk,
           token: params.token,
@@ -318,6 +328,7 @@ export async function deliverDiscordReply(params: {
     if (payload.audioAsVoice) {
       const replyTo = resolveReplyTo();
       await sendVoiceMessageDiscord(params.target, firstMedia, {
+        cfg: params.cfg,
         token: params.token,
         rest: params.rest,
         accountId: params.accountId,
@@ -326,6 +337,7 @@ export async function deliverDiscordReply(params: {
       deliveredAny = true;
       // Voice messages cannot include text; send remaining text separately if present.
       await sendDiscordChunkWithFallback({
+        cfg: params.cfg,
         target: params.target,
         text,
         token: params.token,
@@ -343,6 +355,7 @@ export async function deliverDiscordReply(params: {
       });
       // Additional media items are sent as regular attachments (voice is single-file only).
       await sendAdditionalDiscordMedia({
+        cfg: params.cfg,
         target: params.target,
         token: params.token,
         rest: params.rest,
@@ -357,6 +370,7 @@ export async function deliverDiscordReply(params: {
 
     const replyTo = resolveReplyTo();
     await sendMessageDiscord(params.target, text, {
+      cfg: params.cfg,
       token: params.token,
       rest: params.rest,
       mediaUrl: firstMedia,
@@ -366,6 +380,7 @@ export async function deliverDiscordReply(params: {
     });
     deliveredAny = true;
     await sendAdditionalDiscordMedia({
+      cfg: params.cfg,
       target: params.target,
       token: params.token,
       rest: params.rest,

--- a/src/discord/monitor/thread-bindings.discord-api.test.ts
+++ b/src/discord/monitor/thread-bindings.discord-api.test.ts
@@ -1,8 +1,12 @@
 import { ChannelType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RemoteClawConfig } from "../../config/config.js";
+import type { ThreadBindingRecord } from "./thread-bindings.types.js";
 
 const hoisted = vi.hoisted(() => {
   const restGet = vi.fn();
+  const sendMessageDiscord = vi.fn();
+  const sendWebhookMessageDiscord = vi.fn();
   const createDiscordRestClient = vi.fn(() => ({
     rest: {
       get: restGet,
@@ -10,6 +14,8 @@ const hoisted = vi.hoisted(() => {
   }));
   return {
     restGet,
+    sendMessageDiscord,
+    sendWebhookMessageDiscord,
     createDiscordRestClient,
   };
 });
@@ -18,12 +24,20 @@ vi.mock("../client.js", () => ({
   createDiscordRestClient: hoisted.createDiscordRestClient,
 }));
 
-const { resolveChannelIdForBinding } = await import("./thread-bindings.discord-api.js");
+vi.mock("../send.js", () => ({
+  sendMessageDiscord: (...args: unknown[]) => hoisted.sendMessageDiscord(...args),
+  sendWebhookMessageDiscord: (...args: unknown[]) => hoisted.sendWebhookMessageDiscord(...args),
+}));
+
+const { maybeSendBindingMessage, resolveChannelIdForBinding } =
+  await import("./thread-bindings.discord-api.js");
 
 describe("resolveChannelIdForBinding", () => {
   beforeEach(() => {
     hoisted.restGet.mockClear();
     hoisted.createDiscordRestClient.mockClear();
+    hoisted.sendMessageDiscord.mockClear().mockResolvedValue({});
+    hoisted.sendWebhookMessageDiscord.mockClear().mockResolvedValue({});
   });
 
   it("returns explicit channelId without resolving route", async () => {
@@ -51,6 +65,26 @@ describe("resolveChannelIdForBinding", () => {
     });
 
     expect(resolved).toBe("channel-parent");
+  });
+
+  it("forwards cfg when resolving channel id through Discord client", async () => {
+    const cfg = {
+      channels: { discord: { token: "tok" } },
+    } as RemoteClawConfig;
+    hoisted.restGet.mockResolvedValueOnce({
+      id: "thread-1",
+      type: ChannelType.PublicThread,
+      parent_id: "channel-parent",
+    });
+
+    await resolveChannelIdForBinding({
+      cfg,
+      accountId: "default",
+      threadId: "thread-1",
+    });
+
+    const createDiscordRestClientCalls = hoisted.createDiscordRestClient.mock.calls as unknown[][];
+    expect(createDiscordRestClientCalls[0]?.[1]).toBe(cfg);
   });
 
   it("keeps non-thread channel id even when parent_id exists", async () => {
@@ -81,5 +115,47 @@ describe("resolveChannelIdForBinding", () => {
     });
 
     expect(resolved).toBe("forum-1");
+  });
+});
+
+describe("maybeSendBindingMessage", () => {
+  beforeEach(() => {
+    hoisted.sendMessageDiscord.mockClear().mockResolvedValue({});
+    hoisted.sendWebhookMessageDiscord.mockClear().mockResolvedValue({});
+  });
+
+  it("forwards cfg to webhook send path", async () => {
+    const cfg = {
+      channels: { discord: { token: "tok" } },
+    } as RemoteClawConfig;
+    const record = {
+      accountId: "default",
+      channelId: "parent-1",
+      threadId: "thread-1",
+      targetKind: "subagent",
+      targetSessionKey: "agent:main:subagent:test",
+      agentId: "main",
+      boundBy: "test",
+      boundAt: Date.now(),
+      lastActivityAt: Date.now(),
+      webhookId: "wh_1",
+      webhookToken: "tok_1",
+    } satisfies ThreadBindingRecord;
+
+    await maybeSendBindingMessage({
+      cfg,
+      record,
+      text: "hello webhook",
+    });
+
+    expect(hoisted.sendWebhookMessageDiscord).toHaveBeenCalledTimes(1);
+    expect(hoisted.sendWebhookMessageDiscord.mock.calls[0]?.[1]).toMatchObject({
+      cfg,
+      webhookId: "wh_1",
+      webhookToken: "tok_1",
+      accountId: "default",
+      threadId: "thread-1",
+    });
+    expect(hoisted.sendMessageDiscord).not.toHaveBeenCalled();
   });
 });

--- a/src/discord/monitor/thread-bindings.discord-api.ts
+++ b/src/discord/monitor/thread-bindings.discord-api.ts
@@ -1,4 +1,5 @@
 import { ChannelType, Routes } from "discord-api-types/v10";
+import type { RemoteClawConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
 import { createDiscordRestClient } from "../client.js";
 import { sendMessageDiscord, sendWebhookMessageDiscord } from "../send.js";
@@ -122,6 +123,7 @@ export function isDiscordThreadGoneError(err: unknown): boolean {
 }
 
 export async function maybeSendBindingMessage(params: {
+  cfg?: RemoteClawConfig;
   record: ThreadBindingRecord;
   text: string;
   preferWebhook?: boolean;
@@ -134,6 +136,7 @@ export async function maybeSendBindingMessage(params: {
   if (params.preferWebhook !== false && record.webhookId && record.webhookToken) {
     try {
       await sendWebhookMessageDiscord(text, {
+        cfg: params.cfg,
         webhookId: record.webhookId,
         webhookToken: record.webhookToken,
         accountId: record.accountId,
@@ -147,6 +150,7 @@ export async function maybeSendBindingMessage(params: {
   }
   try {
     await sendMessageDiscord(buildThreadTarget(record.threadId), text, {
+      cfg: params.cfg,
       accountId: record.accountId,
     });
   } catch (err) {
@@ -155,15 +159,19 @@ export async function maybeSendBindingMessage(params: {
 }
 
 export async function createWebhookForChannel(params: {
+  cfg?: RemoteClawConfig;
   accountId: string;
   token?: string;
   channelId: string;
 }): Promise<{ webhookId?: string; webhookToken?: string }> {
   try {
-    const rest = createDiscordRestClient({
-      accountId: params.accountId,
-      token: params.token,
-    }).rest;
+    const rest = createDiscordRestClient(
+      {
+        accountId: params.accountId,
+        token: params.token,
+      },
+      params.cfg,
+    ).rest;
     const created = (await rest.post(Routes.channelWebhooks(params.channelId), {
       body: {
         name: "RemoteClaw Agents",
@@ -218,6 +226,7 @@ export function findReusableWebhook(params: { accountId: string; channelId: stri
 }
 
 export async function resolveChannelIdForBinding(params: {
+  cfg?: RemoteClawConfig;
   accountId: string;
   token?: string;
   threadId: string;
@@ -228,10 +237,13 @@ export async function resolveChannelIdForBinding(params: {
     return explicit;
   }
   try {
-    const rest = createDiscordRestClient({
-      accountId: params.accountId,
-      token: params.token,
-    }).rest;
+    const rest = createDiscordRestClient(
+      {
+        accountId: params.accountId,
+        token: params.token,
+      },
+      params.cfg,
+    ).rest;
     const channel = (await rest.get(Routes.channel(params.threadId))) as {
       id?: string;
       type?: number;
@@ -261,6 +273,7 @@ export async function resolveChannelIdForBinding(params: {
 }
 
 export async function createThreadForBinding(params: {
+  cfg?: RemoteClawConfig;
   accountId: string;
   token?: string;
   channelId: string;
@@ -274,6 +287,7 @@ export async function createThreadForBinding(params: {
         autoArchiveMinutes: 60,
       },
       {
+        cfg: params.cfg,
         accountId: params.accountId,
         token: params.token,
       },

--- a/src/discord/monitor/thread-bindings.lifecycle.test.ts
+++ b/src/discord/monitor/thread-bindings.lifecycle.test.ts
@@ -2,6 +2,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+  type RemoteClawConfig,
+} from "../../config/config.js";
 
 const hoisted = vi.hoisted(() => {
   const sendMessageDiscord = vi.fn(async (_to: string, _text: string, _opts?: unknown) => ({}));
@@ -60,6 +65,7 @@ const {
 describe("thread binding lifecycle", () => {
   beforeEach(() => {
     __testing.resetThreadBindingsForTests();
+    clearRuntimeConfigSnapshot();
     hoisted.sendMessageDiscord.mockClear();
     hoisted.sendWebhookMessageDiscord.mockClear();
     hoisted.restGet.mockClear();
@@ -618,9 +624,13 @@ describe("thread binding lifecycle", () => {
   });
 
   it("passes manager token when resolving parent channels for auto-bind", async () => {
+    const cfg = {
+      channels: { discord: { token: "tok" } },
+    } as RemoteClawConfig;
     createThreadBindingManager({
       accountId: "runtime",
       token: "runtime-token",
+      cfg,
       persist: false,
       enableSweeper: false,
       idleTimeoutMs: 24 * 60 * 60 * 1000,
@@ -638,6 +648,7 @@ describe("thread binding lifecycle", () => {
     hoisted.createThreadDiscord.mockResolvedValueOnce({ id: "thread-created-runtime" });
 
     const childBinding = await autoBindSpawnedDiscordSubagent({
+      cfg,
       accountId: "runtime",
       channel: "discord",
       to: "channel:thread-runtime",
@@ -653,6 +664,73 @@ describe("thread binding lifecycle", () => {
       accountId: "runtime",
       token: "runtime-token",
     });
+    const usedCfg = hoisted.createDiscordRestClient.mock.calls.some((call) => {
+      if (call?.[1] === cfg) {
+        return true;
+      }
+      const first = call?.[0];
+      return (
+        typeof first === "object" && first !== null && (first as { cfg?: unknown }).cfg === cfg
+      );
+    });
+    expect(usedCfg).toBe(true);
+  });
+
+  it("uses the active runtime snapshot cfg for manager operations", async () => {
+    const startupCfg = {
+      channels: { discord: { token: "startup-token" } },
+    } as RemoteClawConfig;
+    const refreshedCfg = {
+      channels: { discord: { token: "refreshed-token" } },
+    } as RemoteClawConfig;
+    const manager = createThreadBindingManager({
+      accountId: "runtime",
+      token: "runtime-token",
+      cfg: startupCfg,
+      persist: false,
+      enableSweeper: false,
+      idleTimeoutMs: 24 * 60 * 60 * 1000,
+      maxAgeMs: 0,
+    });
+
+    setRuntimeConfigSnapshot(refreshedCfg);
+    hoisted.createDiscordRestClient.mockClear();
+    hoisted.createThreadDiscord.mockClear();
+    hoisted.createThreadDiscord.mockResolvedValueOnce({ id: "thread-created-runtime-cfg" });
+
+    const bound = await manager.bindTarget({
+      createThread: true,
+      channelId: "parent-runtime",
+      targetKind: "subagent",
+      targetSessionKey: "agent:main:subagent:runtime-cfg",
+      agentId: "main",
+    });
+
+    expect(bound).not.toBeNull();
+    const usedRefreshedCfg = hoisted.createDiscordRestClient.mock.calls.some((call) => {
+      if (call?.[1] === refreshedCfg) {
+        return true;
+      }
+      const first = call?.[0];
+      return (
+        typeof first === "object" &&
+        first !== null &&
+        (first as { cfg?: unknown }).cfg === refreshedCfg
+      );
+    });
+    expect(usedRefreshedCfg).toBe(true);
+    const usedStartupCfg = hoisted.createDiscordRestClient.mock.calls.some((call) => {
+      if (call?.[1] === startupCfg) {
+        return true;
+      }
+      const first = call?.[0];
+      return (
+        typeof first === "object" &&
+        first !== null &&
+        (first as { cfg?: unknown }).cfg === startupCfg
+      );
+    });
+    expect(usedStartupCfg).toBe(false);
   });
 
   it("refreshes manager token when an existing manager is reused", async () => {

--- a/src/discord/monitor/thread-bindings.lifecycle.ts
+++ b/src/discord/monitor/thread-bindings.lifecycle.ts
@@ -1,3 +1,4 @@
+import type { RemoteClawConfig } from "../../config/config.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
 import { parseDiscordTarget } from "../targets.js";
 import { resolveChannelIdForBinding } from "./thread-bindings.discord-api.js";

--- a/src/discord/monitor/thread-bindings.lifecycle.ts
+++ b/src/discord/monitor/thread-bindings.lifecycle.ts
@@ -66,6 +66,7 @@ export function listThreadBindingsBySessionKey(params: {
 }
 
 export async function autoBindSpawnedDiscordSubagent(params: {
+  cfg?: RemoteClawConfig;
   accountId?: string;
   channel?: string;
   to?: string;
@@ -94,6 +95,7 @@ export async function autoBindSpawnedDiscordSubagent(params: {
     } else {
       channelId =
         (await resolveChannelIdForBinding({
+          cfg: params.cfg,
           accountId: manager.accountId,
           token: managerToken,
           threadId: requesterThreadId,
@@ -112,6 +114,7 @@ export async function autoBindSpawnedDiscordSubagent(params: {
       }
       channelId =
         (await resolveChannelIdForBinding({
+          cfg: params.cfg,
           accountId: manager.accountId,
           token: managerToken,
           threadId: target.id,

--- a/src/discord/monitor/thread-bindings.manager.ts
+++ b/src/discord/monitor/thread-bindings.manager.ts
@@ -1,5 +1,6 @@
 import { Routes } from "discord-api-types/v10";
 import { resolveThreadBindingConversationIdFromBindingId } from "../../channels/thread-binding-id.js";
+import { getRuntimeConfigSnapshot, type RemoteClawConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
 import {
   registerSessionBindingAdapter,
@@ -162,6 +163,7 @@ export function createThreadBindingManager(
   params: {
     accountId?: string;
     token?: string;
+    cfg?: RemoteClawConfig;
     persist?: boolean;
     enableSweeper?: boolean;
     idleTimeoutMs?: number;
@@ -188,6 +190,7 @@ export function createThreadBindingManager(
     params.maxAgeMs,
     DEFAULT_THREAD_BINDING_MAX_AGE_MS,
   );
+  const resolveCurrentCfg = () => getRuntimeConfigSnapshot() ?? params.cfg;
   const resolveCurrentToken = () => getThreadBindingToken(accountId) ?? params.token;
 
   let sweepTimer: NodeJS.Timeout | null = null;
@@ -255,6 +258,7 @@ export function createThreadBindingManager(
       return nextRecord;
     },
     bindTarget: async (bindParams) => {
+      const cfg = resolveCurrentCfg();
       let threadId = normalizeThreadId(bindParams.threadId);
       let channelId = bindParams.channelId?.trim() || "";
 
@@ -268,6 +272,7 @@ export function createThreadBindingManager(
         });
         threadId =
           (await createThreadForBinding({
+            cfg,
             accountId,
             token: resolveCurrentToken(),
             channelId,
@@ -282,6 +287,7 @@ export function createThreadBindingManager(
       if (!channelId) {
         channelId =
           (await resolveChannelIdForBinding({
+            cfg,
             accountId,
             token: resolveCurrentToken(),
             threadId,
@@ -307,6 +313,7 @@ export function createThreadBindingManager(
       }
       if (!webhookId || !webhookToken) {
         const createdWebhook = await createWebhookForChannel({
+          cfg,
           accountId,
           token: resolveCurrentToken(),
           channelId,
@@ -340,7 +347,7 @@ export function createThreadBindingManager(
 
       const introText = bindParams.introText?.trim();
       if (introText) {
-        void maybeSendBindingMessage({ record, text: introText });
+        void maybeSendBindingMessage({ cfg, record, text: introText });
       }
       return record;
     },
@@ -365,6 +372,7 @@ export function createThreadBindingManager(
         saveBindingsToDisk();
       }
       if (unbindParams.sendFarewell !== false) {
+        const cfg = resolveCurrentCfg();
         const farewell = resolveThreadBindingFarewellText({
           reason: unbindParams.reason,
           farewellText: unbindParams.farewellText,
@@ -379,7 +387,12 @@ export function createThreadBindingManager(
         });
         // Use bot send path for farewell messages so unbound threads don't process
         // webhook echoes as fresh inbound turns when allowBots is enabled.
-        void maybeSendBindingMessage({ record: removed, text: farewell, preferWebhook: false });
+        void maybeSendBindingMessage({
+          cfg,
+          record: removed,
+          text: farewell,
+          preferWebhook: false,
+        });
       }
       return removed;
     },
@@ -433,10 +446,14 @@ export function createThreadBindingManager(
         }
         let rest;
         try {
-          rest = createDiscordRestClient({
-            accountId,
-            token: resolveCurrentToken(),
-          }).rest;
+          const cfg = resolveCurrentCfg();
+          rest = createDiscordRestClient(
+            {
+              accountId,
+              token: resolveCurrentToken(),
+            },
+            cfg,
+          ).rest;
         } catch {
           return;
         }

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -54,6 +54,15 @@ const CronDeliveryStatusSchema = Type.Union([
   Type.Literal("unknown"),
   Type.Literal("not-requested"),
 ]);
+const CronFailoverReasonSchema = Type.Union([
+  Type.Literal("auth"),
+  Type.Literal("format"),
+  Type.Literal("rate_limit"),
+  Type.Literal("billing"),
+  Type.Literal("timeout"),
+  Type.Literal("model_not_found"),
+  Type.Literal("unknown"),
+]);
 const CronCommonOptionalFields = {
   agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
   sessionKey: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
@@ -217,6 +226,7 @@ export const CronJobStateSchema = Type.Object(
     lastRunStatus: Type.Optional(CronRunStatusSchema),
     lastStatus: Type.Optional(CronRunStatusSchema),
     lastError: Type.Optional(Type.String()),
+    lastErrorReason: Type.Optional(CronFailoverReasonSchema),
     lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
     consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
     lastDelivered: Type.Optional(Type.Boolean()),

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../test-utils/symlink-rebind-race.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import {
+  appendFileWithinRoot,
   copyFileWithinRoot,
   SafeOpenError,
   openFileWithinRoot,
@@ -212,6 +213,22 @@ describe("fs-safe", () => {
     await expect(fs.readFile(path.join(root, "nested", "out.txt"), "utf8")).resolves.toBe("hello");
   });
 
+  it("appends to a file within root safely", async () => {
+    const root = await tempDirs.make("openclaw-fs-safe-root-");
+    const targetPath = path.join(root, "nested", "out.txt");
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.writeFile(targetPath, "seed");
+
+    await appendFileWithinRoot({
+      rootDir: root,
+      relativePath: "nested/out.txt",
+      data: "next",
+      prependNewlineIfNeeded: true,
+    });
+
+    await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("seed\nnext");
+  });
+
   it("does not truncate existing target when atomic rename fails", async () => {
     const root = await tempDirs.make("openclaw-fs-safe-root-");
     const targetPath = path.join(root, "nested", "out.txt");
@@ -405,6 +422,25 @@ describe("fs-safe", () => {
     });
   });
 
+  it.runIf(process.platform !== "win32")("rejects appending through hardlink aliases", async () => {
+    const root = await tempDirs.make("openclaw-fs-safe-root-");
+    const hardlinkPath = path.join(root, "alias.txt");
+    await withOutsideHardlinkAlias({
+      aliasPath: hardlinkPath,
+      run: async (outsideFile) => {
+        await expect(
+          appendFileWithinRoot({
+            rootDir: root,
+            relativePath: "alias.txt",
+            data: "pwned",
+            prependNewlineIfNeeded: true,
+          }),
+        ).rejects.toMatchObject({ code: "invalid-path" });
+        await expect(fs.readFile(outsideFile, "utf8")).resolves.toBe("outside");
+      },
+    });
+  });
+
   it("does not truncate out-of-root file when symlink retarget races write open", async () => {
     const { root, outside, slot, outsideTarget } = await setupSymlinkWriteRaceFixture({
       seedInsideTarget: true,
@@ -419,6 +455,27 @@ describe("fs-safe", () => {
           relativePath,
           data: "new-content",
           mkdir: false,
+        }),
+    });
+
+    await expect(fs.readFile(outsideTarget, "utf8")).resolves.toBe("X".repeat(4096));
+  });
+
+  it("does not clobber out-of-root file when symlink retarget races append open", async () => {
+    const { root, outside, slot, outsideTarget } = await setupSymlinkWriteRaceFixture({
+      seedInsideTarget: true,
+    });
+
+    await expectSymlinkWriteRaceRejectsOutside({
+      slotPath: slot,
+      outsideDir: outside,
+      runWrite: async (relativePath) =>
+        await appendFileWithinRoot({
+          rootDir: root,
+          relativePath,
+          data: "new-content",
+          mkdir: false,
+          prependNewlineIfNeeded: true,
         }),
     });
 

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -56,6 +56,14 @@ const OPEN_WRITE_CREATE_FLAGS =
   fsConstants.O_CREAT |
   fsConstants.O_EXCL |
   (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+const OPEN_APPEND_EXISTING_FLAGS =
+  fsConstants.O_RDWR | fsConstants.O_APPEND | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+const OPEN_APPEND_CREATE_FLAGS =
+  fsConstants.O_RDWR |
+  fsConstants.O_APPEND |
+  fsConstants.O_CREAT |
+  fsConstants.O_EXCL |
+  (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
 
 const ensureTrailingSep = (value: string) => (value.endsWith(path.sep) ? value : value + path.sep);
 
@@ -356,6 +364,7 @@ export async function openWritableFileWithinRoot(params: {
   mkdir?: boolean;
   mode?: number;
   truncateExisting?: boolean;
+  append?: boolean;
 }): Promise<SafeWritableOpenResult> {
   const { rootReal, rootWithSep, resolved } = await resolvePathWithinRoot(params);
   try {
@@ -391,14 +400,16 @@ export async function openWritableFileWithinRoot(params: {
 
   let handle: FileHandle;
   let createdForWrite = false;
+  const existingFlags = params.append ? OPEN_APPEND_EXISTING_FLAGS : OPEN_WRITE_EXISTING_FLAGS;
+  const createFlags = params.append ? OPEN_APPEND_CREATE_FLAGS : OPEN_WRITE_CREATE_FLAGS;
   try {
     try {
-      handle = await fs.open(ioPath, OPEN_WRITE_EXISTING_FLAGS, fileMode);
+      handle = await fs.open(ioPath, existingFlags, fileMode);
     } catch (err) {
       if (!isNotFoundPathError(err)) {
         throw err;
       }
-      handle = await fs.open(ioPath, OPEN_WRITE_CREATE_FLAGS, fileMode);
+      handle = await fs.open(ioPath, createFlags, fileMode);
       createdForWrite = true;
     }
   } catch (err) {
@@ -450,7 +461,7 @@ export async function openWritableFileWithinRoot(params: {
 
     // Truncate only after boundary and identity checks complete. This avoids
     // irreversible side effects if a symlink target changes before validation.
-    if (params.truncateExisting !== false && !createdForWrite) {
+    if (params.append !== true && params.truncateExisting !== false && !createdForWrite) {
       await handle.truncate(0);
     }
     return {
@@ -467,6 +478,50 @@ export async function openWritableFileWithinRoot(params: {
       await fs.rm(cleanupPath, { force: true }).catch(() => {});
     }
     throw err;
+  }
+}
+
+export async function appendFileWithinRoot(params: {
+  rootDir: string;
+  relativePath: string;
+  data: string | Buffer;
+  encoding?: BufferEncoding;
+  mkdir?: boolean;
+  prependNewlineIfNeeded?: boolean;
+}): Promise<void> {
+  const target = await openWritableFileWithinRoot({
+    rootDir: params.rootDir,
+    relativePath: params.relativePath,
+    mkdir: params.mkdir,
+    truncateExisting: false,
+    append: true,
+  });
+  try {
+    let prefix = "";
+    if (
+      params.prependNewlineIfNeeded === true &&
+      !target.createdForWrite &&
+      target.openedStat.size > 0 &&
+      ((typeof params.data === "string" && !params.data.startsWith("\n")) ||
+        (Buffer.isBuffer(params.data) && params.data.length > 0 && params.data[0] !== 0x0a))
+    ) {
+      const lastByte = Buffer.alloc(1);
+      const { bytesRead } = await target.handle.read(lastByte, 0, 1, target.openedStat.size - 1);
+      if (bytesRead === 1 && lastByte[0] !== 0x0a) {
+        prefix = "\n";
+      }
+    }
+
+    if (typeof params.data === "string") {
+      await target.handle.appendFile(`${prefix}${params.data}`, params.encoding ?? "utf8");
+      return;
+    }
+
+    const payload =
+      prefix.length > 0 ? Buffer.concat([Buffer.from(prefix, "utf8"), params.data]) : params.data;
+    await target.handle.appendFile(payload);
+  } finally {
+    await target.handle.close().catch(() => {});
   }
 }
 

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -48,6 +48,7 @@ describe("makeProxyFetch", () => {
     undiciFetch.mockResolvedValue({ ok: true });
 
     const proxyFetch = makeProxyFetch(proxyUrl);
+    expect(proxyAgentSpy).not.toHaveBeenCalled();
     await proxyFetch("https://api.example.com/v1/audio");
 
     expect(proxyAgentSpy).toHaveBeenCalledWith(proxyUrl);

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -1,19 +1,46 @@
 import { EnvHttpProxyAgent, ProxyAgent, fetch as undiciFetch } from "undici";
 import { logWarn } from "../../logger.js";
 
+export const PROXY_FETCH_PROXY_URL = Symbol.for("openclaw.proxyFetch.proxyUrl");
+type ProxyFetchWithMetadata = typeof fetch & {
+  [PROXY_FETCH_PROXY_URL]?: string;
+};
+
 /**
  * Create a fetch function that routes requests through the given HTTP proxy.
  * Uses undici's ProxyAgent under the hood.
  */
 export function makeProxyFetch(proxyUrl: string): typeof fetch {
-  const agent = new ProxyAgent(proxyUrl);
+  let agent: ProxyAgent | null = null;
+  const resolveAgent = (): ProxyAgent => {
+    if (!agent) {
+      agent = new ProxyAgent(proxyUrl);
+    }
+    return agent;
+  };
   // undici's fetch is runtime-compatible with global fetch but the types diverge
   // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
-  return ((input: RequestInfo | URL, init?: RequestInit) =>
+  const proxyFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
     undiciFetch(input as string | URL, {
       ...(init as Record<string, unknown>),
-      dispatcher: agent,
-    }) as unknown as Promise<Response>) as typeof fetch;
+      dispatcher: resolveAgent(),
+    }) as unknown as Promise<Response>) as ProxyFetchWithMetadata;
+  Object.defineProperty(proxyFetch, PROXY_FETCH_PROXY_URL, {
+    value: proxyUrl,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return proxyFetch;
+}
+
+export function getProxyUrlFromFetch(fetchImpl?: typeof fetch): string | undefined {
+  const proxyUrl = (fetchImpl as ProxyFetchWithMetadata | undefined)?.[PROXY_FETCH_PROXY_URL];
+  if (typeof proxyUrl !== "string") {
+    return undefined;
+  }
+  const trimmed = proxyUrl.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 /**

--- a/src/infra/outbound/cfg-threading.guard.test.ts
+++ b/src/infra/outbound/cfg-threading.guard.test.ts
@@ -59,6 +59,15 @@ function listExtensionFiles(): {
   };
 }
 
+function listHighRiskRuntimeCfgFiles(): string[] {
+  return [
+    "src/agents/tools/telegram-actions.ts",
+    "src/discord/monitor/reply-delivery.ts",
+    "src/discord/monitor/thread-bindings.discord-api.ts",
+    "src/discord/monitor/thread-bindings.manager.ts",
+  ];
+}
+
 function extractOutboundBlock(source: string, file: string): string {
   const outboundKeyIndex = source.indexOf("outbound:");
   expect(outboundKeyIndex, `${file} should define outbound:`).toBeGreaterThanOrEqual(0);
@@ -174,6 +183,14 @@ describe("outbound cfg-threading guard", () => {
       expect(outboundBlock, `${file} outbound block must not call loadConfig`).not.toMatch(
         loadConfigPattern,
       );
+    }
+  });
+
+  it("keeps high-risk runtime delivery paths free of loadConfig calls", () => {
+    const runtimeFiles = listHighRiskRuntimeCfgFiles();
+    for (const file of runtimeFiles) {
+      const source = readRepoFile(file);
+      expect(source, `${file} must not call loadConfig`).not.toMatch(loadConfigPattern);
     }
   });
 });

--- a/src/security/external-content.ts
+++ b/src/security/external-content.ts
@@ -127,6 +127,8 @@ const ANGLE_BRACKET_MAP: Record<number, string> = {
   0x276d: ">", // medium right-pointing angle bracket ornament
   0x276e: "<", // heavy left-pointing angle quotation mark ornament
   0x276f: ">", // heavy right-pointing angle quotation mark ornament
+  0x02c2: "<", // modifier letter left arrowhead
+  0x02c3: ">", // modifier letter right arrowhead
 };
 
 function foldMarkerChar(char: string): string {
@@ -146,25 +148,27 @@ function foldMarkerChar(char: string): string {
 
 function foldMarkerText(input: string): string {
   return input.replace(
-    /[\uFF21-\uFF3A\uFF41-\uFF5A\uFF1C\uFF1E\u2329\u232A\u3008\u3009\u2039\u203A\u27E8\u27E9\uFE64\uFE65\u00AB\u00BB\u300A\u300B\u27EA\u27EB\u27EC\u27ED\u27EE\u27EF\u276C\u276D\u276E\u276F]/g,
+    /[\uFF21-\uFF3A\uFF41-\uFF5A\uFF1C\uFF1E\u2329\u232A\u3008\u3009\u2039\u203A\u27E8\u27E9\uFE64\uFE65\u00AB\u00BB\u300A\u300B\u27EA\u27EB\u27EC\u27ED\u27EE\u27EF\u276C\u276D\u276E\u276F\u02C2\u02C3]/g,
     (char) => foldMarkerChar(char),
   );
 }
 
 function replaceMarkers(content: string): string {
   const folded = foldMarkerText(content);
-  if (!/external_untrusted_content/i.test(folded)) {
+  // Intentionally catch whitespace-delimited spoof variants (space, tab, newline) in addition
+  // to the legacy underscore form because LLMs may still parse them as trusted boundary markers.
+  if (!/external[\s_]+untrusted[\s_]+content/i.test(folded)) {
     return content;
   }
   const replacements: Array<{ start: number; end: number; value: string }> = [];
   // Match markers with or without id attribute (handles both legacy and spoofed markers)
   const patterns: Array<{ regex: RegExp; value: string }> = [
     {
-      regex: /<<<EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]{1,128}")?\s*>>>/gi,
+      regex: /<<<\s*EXTERNAL[\s_]+UNTRUSTED[\s_]+CONTENT(?:\s+id="[^"]{1,128}")?\s*>>>/gi,
       value: "[[MARKER_SANITIZED]]",
     },
     {
-      regex: /<<<END_EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]{1,128}")?\s*>>>/gi,
+      regex: /<<<\s*END[\s_]+EXTERNAL[\s_]+UNTRUSTED[\s_]+CONTENT(?:\s+id="[^"]{1,128}")?\s*>>>/gi,
       value: "[[END_MARKER_SANITIZED]]",
     },
   ];

--- a/src/telegram/audit-membership-runtime.ts
+++ b/src/telegram/audit-membership-runtime.ts
@@ -5,6 +5,7 @@ import type {
   TelegramGroupMembershipAudit,
   TelegramGroupMembershipAuditEntry,
 } from "./audit.js";
+import { resolveTelegramFetch } from "./fetch.js";
 import { makeProxyFetch } from "./proxy.js";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
@@ -16,7 +17,8 @@ type TelegramGroupMembershipAuditData = Omit<TelegramGroupMembershipAudit, "elap
 export async function auditTelegramGroupMembershipImpl(
   params: AuditTelegramGroupMembershipParams,
 ): Promise<TelegramGroupMembershipAuditData> {
-  const fetcher = params.proxyUrl ? makeProxyFetch(params.proxyUrl) : fetch;
+  const proxyFetch = params.proxyUrl ? makeProxyFetch(params.proxyUrl) : undefined;
+  const fetcher = resolveTelegramFetch(proxyFetch, { network: params.network });
   const base = `${TELEGRAM_API_BASE}/bot${params.token}`;
   const groups: TelegramGroupMembershipAuditEntry[] = [];
 

--- a/src/telegram/audit.test.ts
+++ b/src/telegram/audit.test.ts
@@ -2,16 +2,22 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 let collectTelegramUnmentionedGroupIds: typeof import("./audit.js").collectTelegramUnmentionedGroupIds;
 let auditTelegramGroupMembership: typeof import("./audit.js").auditTelegramGroupMembership;
+const undiciFetch = vi.hoisted(() => vi.fn());
+
+vi.mock("undici", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("undici")>();
+  return {
+    ...actual,
+    fetch: undiciFetch,
+  };
+});
 
 function mockGetChatMemberStatus(status: string) {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn().mockResolvedValueOnce(
-      new Response(JSON.stringify({ ok: true, result: { status } }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    ),
+  undiciFetch.mockResolvedValueOnce(
+    new Response(JSON.stringify({ ok: true, result: { status } }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
   );
 }
 
@@ -31,7 +37,7 @@ describe("telegram audit", () => {
   });
 
   beforeEach(() => {
-    vi.unstubAllGlobals();
+    undiciFetch.mockReset();
   });
 
   it("collects unmentioned numeric group ids and flags wildcard", async () => {

--- a/src/telegram/audit.ts
+++ b/src/telegram/audit.ts
@@ -1,4 +1,5 @@
 import type { TelegramGroupConfig } from "../config/types.js";
+import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 
 export type TelegramGroupMembershipAuditEntry = {
   chatId: string;
@@ -64,6 +65,7 @@ export type AuditTelegramGroupMembershipParams = {
   botId: number;
   groupIds: string[];
   proxyUrl?: string;
+  network?: TelegramNetworkConfig;
   timeoutMs: number;
 };
 

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -89,6 +89,7 @@ export const registerTelegramHandlers = ({
   accountId,
   bot,
   opts,
+  telegramFetchImpl,
   runtime,
   mediaMaxBytes,
   telegramCfg,
@@ -266,7 +267,7 @@ export const registerTelegramHandlers = ({
       for (const { ctx } of entry.messages) {
         let media;
         try {
-          media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+          media = await resolveMedia(ctx, mediaMaxBytes, opts.token, telegramFetchImpl);
         } catch (mediaErr) {
           if (!isRecoverableMediaGroupError(mediaErr)) {
             throw mediaErr;
@@ -370,7 +371,7 @@ export const registerTelegramHandlers = ({
         },
         mediaMaxBytes,
         opts.token,
-        opts.proxyFetch,
+        telegramFetchImpl,
       );
       if (!media) {
         return [];
@@ -852,7 +853,7 @@ export const registerTelegramHandlers = ({
 
     let media: Awaited<ReturnType<typeof resolveMedia>> = null;
     try {
-      media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+      media = await resolveMedia(ctx, mediaMaxBytes, opts.token, telegramFetchImpl);
     } catch (mediaErr) {
       if (isMediaSizeLimitError(mediaErr)) {
         if (sendOversizeWarning) {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -90,6 +90,7 @@ export type RegisterTelegramHandlerParams = {
   bot: Bot;
   mediaMaxBytes: number;
   opts: TelegramBotOptions;
+  telegramFetchImpl?: typeof fetch;
   runtime: RuntimeEnv;
   telegramCfg: TelegramAccountConfig;
   allowFrom?: Array<string | number>;

--- a/src/telegram/bot.media.e2e-harness.ts
+++ b/src/telegram/bot.media.e2e-harness.ts
@@ -6,6 +6,9 @@ export const middlewareUseSpy: Mock = vi.fn();
 export const onSpy: Mock = vi.fn();
 export const stopSpy: Mock = vi.fn();
 export const sendChatActionSpy: Mock = vi.fn();
+export const undiciFetchSpy: Mock = vi.fn((input: RequestInfo | URL, init?: RequestInit) =>
+  globalThis.fetch(input, init),
+);
 
 async function defaultSaveMediaBuffer(buffer: Buffer, contentType?: string) {
   return {
@@ -80,6 +83,14 @@ const throttlerSpy = vi.fn(() => "throttler");
 vi.mock("@grammyjs/transformer-throttler", () => ({
   apiThrottler: () => throttlerSpy(),
 }));
+
+vi.mock("undici", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("undici")>();
+  return {
+    ...actual,
+    fetch: (...args: Parameters<typeof undiciFetchSpy>) => undiciFetchSpy(...args),
+  };
+});
 
 vi.mock("../media/store.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../media/store.js")>();

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -423,6 +423,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     accountId: account.accountId,
     bot,
     opts,
+    telegramFetchImpl: fetchImpl as unknown as typeof fetch | undefined,
     runtime,
     mediaMaxBytes,
     telegramCfg,

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -293,6 +293,62 @@ describe("resolveMedia getFile retry", () => {
     expect(getFile).toHaveBeenCalledTimes(3);
     expect(result).toBeNull();
   });
+
+  it("uses caller-provided fetch impl for file downloads", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "documents/file_42.pdf" });
+    const callerFetch = vi.fn() as unknown as typeof fetch;
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("pdf-data"),
+      contentType: "application/pdf",
+      fileName: "file_42.pdf",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_42---uuid.pdf",
+      contentType: "application/pdf",
+    });
+
+    const result = await resolveMedia(
+      makeCtx("document", getFile),
+      MAX_MEDIA_BYTES,
+      BOT_TOKEN,
+      callerFetch,
+    );
+
+    expect(result).not.toBeNull();
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fetchImpl: callerFetch,
+      }),
+    );
+  });
+
+  it("uses caller-provided fetch impl for sticker downloads", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "stickers/file_0.webp" });
+    const callerFetch = vi.fn() as unknown as typeof fetch;
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("sticker-data"),
+      contentType: "image/webp",
+      fileName: "file_0.webp",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_0.webp",
+      contentType: "image/webp",
+    });
+
+    const result = await resolveMedia(
+      makeCtx("sticker", getFile),
+      MAX_MEDIA_BYTES,
+      BOT_TOKEN,
+      callerFetch,
+    );
+
+    expect(result).not.toBeNull();
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fetchImpl: callerFetch,
+      }),
+    );
+  });
 });
 
 describe("resolveMedia original filename preservation", () => {

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -92,12 +92,20 @@ async function resolveTelegramFileWithRetry(
   }
 }
 
-function resolveRequiredFetchImpl(proxyFetch?: typeof fetch): typeof fetch {
-  const fetchImpl = proxyFetch ?? globalThis.fetch;
-  if (!fetchImpl) {
+function resolveRequiredFetchImpl(fetchImpl?: typeof fetch): typeof fetch {
+  const resolved = fetchImpl ?? globalThis.fetch;
+  if (!resolved) {
     throw new Error("fetch is not available; set channels.telegram.proxy in config");
   }
-  return fetchImpl;
+  return resolved;
+}
+
+function resolveOptionalFetchImpl(fetchImpl?: typeof fetch): typeof fetch | null {
+  try {
+    return resolveRequiredFetchImpl(fetchImpl);
+  } catch {
+    return null;
+  }
 }
 
 /** Default idle timeout for Telegram media downloads (30 seconds). */
@@ -134,7 +142,7 @@ async function resolveStickerMedia(params: {
   ctx: TelegramContext;
   maxBytes: number;
   token: string;
-  proxyFetch?: typeof fetch;
+  fetchImpl?: typeof fetch;
 }): Promise<
   | {
       path: string;
@@ -145,7 +153,7 @@ async function resolveStickerMedia(params: {
   | null
   | undefined
 > {
-  const { msg, ctx, maxBytes, token, proxyFetch } = params;
+  const { msg, ctx, maxBytes, token, fetchImpl } = params;
   if (!msg.sticker) {
     return undefined;
   }
@@ -165,15 +173,15 @@ async function resolveStickerMedia(params: {
       logVerbose("telegram: getFile returned no file_path for sticker");
       return null;
     }
-    const fetchImpl = proxyFetch ?? globalThis.fetch;
-    if (!fetchImpl) {
+    const resolvedFetchImpl = resolveOptionalFetchImpl(fetchImpl);
+    if (!resolvedFetchImpl) {
       logVerbose("telegram: fetch not available for sticker download");
       return null;
     }
     const saved = await downloadAndSaveTelegramFile({
       filePath: file.file_path,
       token,
-      fetchImpl,
+      fetchImpl: resolvedFetchImpl,
       maxBytes,
     });
 
@@ -229,7 +237,7 @@ export async function resolveMedia(
   ctx: TelegramContext,
   maxBytes: number,
   token: string,
-  proxyFetch?: typeof fetch,
+  fetchImpl?: typeof fetch,
 ): Promise<{
   path: string;
   contentType?: string;
@@ -242,7 +250,7 @@ export async function resolveMedia(
     ctx,
     maxBytes,
     token,
-    proxyFetch,
+    fetchImpl,
   });
   if (stickerResolved !== undefined) {
     return stickerResolved;
@@ -263,7 +271,7 @@ export async function resolveMedia(
   const saved = await downloadAndSaveTelegramFile({
     filePath: file.file_path,
     token,
-    fetchImpl: resolveRequiredFetchImpl(proxyFetch),
+    fetchImpl: resolveRequiredFetchImpl(fetchImpl),
     maxBytes,
     telegramFileName: resolveTelegramFileName(msg),
   });

--- a/src/telegram/fetch.env-proxy-runtime.test.ts
+++ b/src/telegram/fetch.env-proxy-runtime.test.ts
@@ -1,0 +1,58 @@
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const EnvHttpProxyAgent = require("undici/lib/dispatcher/env-http-proxy-agent.js") as {
+  new (opts?: Record<string, unknown>): Record<PropertyKey, unknown>;
+};
+const { kHttpsProxyAgent, kNoProxyAgent } = require("undici/lib/core/symbols.js") as {
+  kHttpsProxyAgent: symbol;
+  kNoProxyAgent: symbol;
+};
+
+function getOwnSymbolValue(
+  target: Record<PropertyKey, unknown>,
+  description: string,
+): Record<string, unknown> | undefined {
+  const symbol = Object.getOwnPropertySymbols(target).find(
+    (entry) => entry.description === description,
+  );
+  const value = symbol ? target[symbol] : undefined;
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("undici env proxy semantics", () => {
+  it("uses proxyTls rather than connect for proxied HTTPS transport settings", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    const connect = {
+      family: 4,
+      autoSelectFamily: false,
+    };
+
+    const withoutProxyTls = new EnvHttpProxyAgent({ connect });
+    const noProxyAgent = withoutProxyTls[kNoProxyAgent] as Record<PropertyKey, unknown>;
+    const httpsProxyAgent = withoutProxyTls[kHttpsProxyAgent] as Record<PropertyKey, unknown>;
+
+    expect(getOwnSymbolValue(noProxyAgent, "options")?.connect).toEqual(
+      expect.objectContaining(connect),
+    );
+    expect(getOwnSymbolValue(httpsProxyAgent, "proxy tls settings")).toBeUndefined();
+
+    const withProxyTls = new EnvHttpProxyAgent({
+      connect,
+      proxyTls: connect,
+    });
+    const httpsProxyAgentWithProxyTls = withProxyTls[kHttpsProxyAgent] as Record<
+      PropertyKey,
+      unknown
+    >;
+
+    expect(getOwnSymbolValue(httpsProxyAgentWithProxyTls, "proxy tls settings")).toEqual(
+      expect.objectContaining(connect),
+    );
+  });
+});

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -1,25 +1,36 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveFetch } from "../infra/fetch.js";
-import { resetTelegramFetchStateForTests, resolveTelegramFetch } from "./fetch.js";
+import { resolveTelegramFetch } from "./fetch.js";
 
-const setDefaultAutoSelectFamily = vi.hoisted(() => vi.fn());
 const setDefaultResultOrder = vi.hoisted(() => vi.fn());
+const setDefaultAutoSelectFamily = vi.hoisted(() => vi.fn());
+
+const undiciFetch = vi.hoisted(() => vi.fn());
 const setGlobalDispatcher = vi.hoisted(() => vi.fn());
-const getGlobalDispatcherState = vi.hoisted(() => ({ value: undefined as unknown }));
-const getGlobalDispatcher = vi.hoisted(() => vi.fn(() => getGlobalDispatcherState.value));
-const EnvHttpProxyAgentCtor = vi.hoisted(() =>
-  vi.fn(function MockEnvHttpProxyAgent(this: { options: unknown }, options: unknown) {
+const AgentCtor = vi.hoisted(() =>
+  vi.fn(function MockAgent(
+    this: { options?: Record<string, unknown> },
+    options?: Record<string, unknown>,
+  ) {
     this.options = options;
   }),
 );
-
-vi.mock("node:net", async () => {
-  const actual = await vi.importActual<typeof import("node:net")>("node:net");
-  return {
-    ...actual,
-    setDefaultAutoSelectFamily,
-  };
-});
+const EnvHttpProxyAgentCtor = vi.hoisted(() =>
+  vi.fn(function MockEnvHttpProxyAgent(
+    this: { options?: Record<string, unknown> },
+    options?: Record<string, unknown>,
+  ) {
+    this.options = options;
+  }),
+);
+const ProxyAgentCtor = vi.hoisted(() =>
+  vi.fn(function MockProxyAgent(
+    this: { options?: Record<string, unknown> | string },
+    options?: Record<string, unknown> | string,
+  ) {
+    this.options = options;
+  }),
+);
 
 vi.mock("node:dns", async () => {
   const actual = await vi.importActual<typeof import("node:dns")>("node:dns");
@@ -29,266 +40,655 @@ vi.mock("node:dns", async () => {
   };
 });
 
+vi.mock("node:net", async () => {
+  const actual = await vi.importActual<typeof import("node:net")>("node:net");
+  return {
+    ...actual,
+    setDefaultAutoSelectFamily,
+  };
+});
+
 vi.mock("undici", () => ({
+  Agent: AgentCtor,
   EnvHttpProxyAgent: EnvHttpProxyAgentCtor,
-  getGlobalDispatcher,
+  ProxyAgent: ProxyAgentCtor,
+  fetch: undiciFetch,
   setGlobalDispatcher,
 }));
 
-const originalFetch = globalThis.fetch;
-
-function expectEnvProxyAgentConstructorCall(params: { nth: number; autoSelectFamily: boolean }) {
-  expect(EnvHttpProxyAgentCtor).toHaveBeenNthCalledWith(params.nth, {
-    connect: {
-      autoSelectFamily: params.autoSelectFamily,
-      autoSelectFamilyAttemptTimeout: 300,
-    },
-  });
+function resolveTelegramFetchOrThrow(
+  proxyFetch?: typeof fetch,
+  options?: { network?: { autoSelectFamily?: boolean; dnsResultOrder?: "ipv4first" | "verbatim" } },
+) {
+  return resolveTelegramFetch(proxyFetch, options);
 }
 
-function resolveTelegramFetchOrThrow() {
-  const resolved = resolveTelegramFetch();
-  if (!resolved) {
-    throw new Error("expected resolved fetch");
+function getDispatcherFromUndiciCall(nth: number) {
+  const call = undiciFetch.mock.calls[nth - 1] as [RequestInfo | URL, RequestInit?] | undefined;
+  if (!call) {
+    throw new Error(`missing undici fetch call #${nth}`);
   }
-  return resolved;
+  const init = call[1] as (RequestInit & { dispatcher?: unknown }) | undefined;
+  return init?.dispatcher as
+    | {
+        options?: {
+          connect?: Record<string, unknown>;
+          proxyTls?: Record<string, unknown>;
+        };
+      }
+    | undefined;
+}
+
+function buildFetchFallbackError(code: string) {
+  const connectErr = Object.assign(new Error(`connect ${code} api.telegram.org:443`), {
+    code,
+  });
+  return Object.assign(new TypeError("fetch failed"), {
+    cause: connectErr,
+  });
 }
 
 afterEach(() => {
-  resetTelegramFetchStateForTests();
-  setDefaultAutoSelectFamily.mockReset();
-  setDefaultResultOrder.mockReset();
+  undiciFetch.mockReset();
   setGlobalDispatcher.mockReset();
-  getGlobalDispatcher.mockClear();
-  getGlobalDispatcherState.value = undefined;
+  AgentCtor.mockClear();
   EnvHttpProxyAgentCtor.mockClear();
+  ProxyAgentCtor.mockClear();
+  setDefaultResultOrder.mockReset();
+  setDefaultAutoSelectFamily.mockReset();
   vi.unstubAllEnvs();
   vi.clearAllMocks();
-  if (originalFetch) {
-    globalThis.fetch = originalFetch;
-  } else {
-    delete (globalThis as { fetch?: typeof fetch }).fetch;
-  }
 });
 
 describe("resolveTelegramFetch", () => {
-  it("returns wrapped global fetch when available", async () => {
-    const fetchMock = vi.fn(async () => ({}));
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  it("wraps proxy fetches and leaves retry policy to caller-provided fetch", async () => {
+    const proxyFetch = vi.fn(async () => ({ ok: true }) as Response) as unknown as typeof fetch;
 
-    const resolved = resolveTelegramFetch();
+    const resolved = resolveTelegramFetchOrThrow(proxyFetch);
 
-    expect(resolved).toBeTypeOf("function");
-    expect(resolved).not.toBe(fetchMock);
-  });
+    await resolved("https://api.telegram.org/botx/getMe");
 
-  it("wraps proxy fetches and normalizes foreign signals once", async () => {
-    let seenSignal: AbortSignal | undefined;
-    const proxyFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      seenSignal = init?.signal as AbortSignal | undefined;
-      return {} as Response;
-    });
-
-    const resolved = resolveTelegramFetch(proxyFetch as unknown as typeof fetch);
-    expect(resolved).toBeTypeOf("function");
-
-    let abortHandler: (() => void) | null = null;
-    const addEventListener = vi.fn((event: string, handler: () => void) => {
-      if (event === "abort") {
-        abortHandler = handler;
-      }
-    });
-    const removeEventListener = vi.fn((event: string, handler: () => void) => {
-      if (event === "abort" && abortHandler === handler) {
-        abortHandler = null;
-      }
-    });
-    const fakeSignal = {
-      aborted: false,
-      addEventListener,
-      removeEventListener,
-    } as unknown as AbortSignal;
-
-    if (!resolved) {
-      throw new Error("expected resolved proxy fetch");
-    }
-    await resolved("https://example.com", { signal: fakeSignal });
-
-    expect(proxyFetch).toHaveBeenCalledOnce();
-    expect(seenSignal).toBeInstanceOf(AbortSignal);
-    expect(seenSignal).not.toBe(fakeSignal);
-    expect(addEventListener).toHaveBeenCalledTimes(1);
-    expect(removeEventListener).toHaveBeenCalledTimes(1);
+    expect(proxyFetch).toHaveBeenCalledTimes(1);
+    expect(undiciFetch).not.toHaveBeenCalled();
   });
 
   it("does not double-wrap an already wrapped proxy fetch", async () => {
     const proxyFetch = vi.fn(async () => ({ ok: true }) as Response) as unknown as typeof fetch;
-    const alreadyWrapped = resolveFetch(proxyFetch);
+    const wrapped = resolveFetch(proxyFetch);
 
-    const resolved = resolveTelegramFetch(alreadyWrapped);
+    const resolved = resolveTelegramFetch(wrapped);
 
-    expect(resolved).toBe(alreadyWrapped);
+    expect(resolved).toBe(wrapped);
   });
 
-  it("honors env enable override", async () => {
-    vi.stubEnv("REMOTECLAW_TELEGRAM_ENABLE_AUTO_SELECT_FAMILY", "1");
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch();
-    expect(setDefaultAutoSelectFamily).toHaveBeenCalledWith(true);
-  });
+  it("uses resolver-scoped Agent dispatcher with configured transport policy", async () => {
+    undiciFetch.mockResolvedValue({ ok: true } as Response);
 
-  it("uses config override when provided", async () => {
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-    expect(setDefaultAutoSelectFamily).toHaveBeenCalledWith(true);
-  });
-
-  it("env disable override wins over config", async () => {
-    vi.stubEnv("REMOTECLAW_TELEGRAM_ENABLE_AUTO_SELECT_FAMILY", "0");
-    vi.stubEnv("REMOTECLAW_TELEGRAM_DISABLE_AUTO_SELECT_FAMILY", "1");
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-    expect(setDefaultAutoSelectFamily).toHaveBeenCalledWith(false);
-  });
-
-  it("applies dns result order from config", async () => {
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch(undefined, { network: { dnsResultOrder: "verbatim" } });
-    expect(setDefaultResultOrder).toHaveBeenCalledWith("verbatim");
-  });
-
-  it("retries dns setter on next call when previous attempt threw", async () => {
-    setDefaultResultOrder.mockImplementationOnce(() => {
-      throw new Error("dns setter failed once");
-    });
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-
-    resolveTelegramFetch(undefined, { network: { dnsResultOrder: "ipv4first" } });
-    resolveTelegramFetch(undefined, { network: { dnsResultOrder: "ipv4first" } });
-
-    expect(setDefaultResultOrder).toHaveBeenCalledTimes(2);
-  });
-
-  it("replaces global undici dispatcher with proxy-aware EnvHttpProxyAgent", async () => {
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    expectEnvProxyAgentConstructorCall({ nth: 1, autoSelectFamily: true });
-  });
-
-  it("keeps an existing proxy-like global dispatcher", async () => {
-    getGlobalDispatcherState.value = {
-      constructor: { name: "ProxyAgent" },
-    };
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-
-    expect(setGlobalDispatcher).not.toHaveBeenCalled();
-    expect(EnvHttpProxyAgentCtor).not.toHaveBeenCalled();
-  });
-
-  it("updates proxy-like dispatcher when proxy env is configured", async () => {
-    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
-    getGlobalDispatcherState.value = {
-      constructor: { name: "ProxyAgent" },
-    };
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
-  });
-
-  it("sets global dispatcher only once across repeated equal decisions", async () => {
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-  });
-
-  it("updates global dispatcher when autoSelectFamily decision changes", async () => {
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: false } });
-
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
-    expectEnvProxyAgentConstructorCall({ nth: 1, autoSelectFamily: true });
-    expectEnvProxyAgentConstructorCall({ nth: 2, autoSelectFamily: false });
-  });
-
-  it("retries once with ipv4 fallback when fetch fails with network timeout/unreachable", async () => {
-    const timeoutErr = Object.assign(new Error("connect ETIMEDOUT 149.154.166.110:443"), {
-      code: "ETIMEDOUT",
-    });
-    const unreachableErr = Object.assign(
-      new Error("connect ENETUNREACH 2001:67c:4e8:f004::9:443"),
-      {
-        code: "ENETUNREACH",
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "verbatim",
       },
-    );
-    const fetchError = Object.assign(new TypeError("fetch failed"), {
-      cause: Object.assign(new Error("aggregate"), {
-        errors: [timeoutErr, unreachableErr],
-      }),
     });
-    const fetchMock = vi
-      .fn()
-      .mockRejectedValueOnce(fetchError)
-      .mockResolvedValueOnce({ ok: true } as Response);
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    const resolved = resolveTelegramFetchOrThrow();
+    await resolved("https://api.telegram.org/botx/getMe");
 
-    await resolved("https://api.telegram.org/file/botx/photos/file_1.jpg");
+    expect(AgentCtor).toHaveBeenCalledTimes(1);
+    expect(EnvHttpProxyAgentCtor).not.toHaveBeenCalled();
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
-    expectEnvProxyAgentConstructorCall({ nth: 1, autoSelectFamily: true });
-    expectEnvProxyAgentConstructorCall({ nth: 2, autoSelectFamily: false });
+    const dispatcher = getDispatcherFromUndiciCall(1);
+    expect(dispatcher).toBeDefined();
+    expect(dispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+    expect(typeof dispatcher?.options?.connect?.lookup).toBe("function");
   });
 
-  it("retries with ipv4 fallback once per request, not once per process", async () => {
-    const timeoutErr = Object.assign(new Error("connect ETIMEDOUT 149.154.166.110:443"), {
-      code: "ETIMEDOUT",
+  it("uses EnvHttpProxyAgent dispatcher when proxy env is configured", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    undiciFetch.mockResolvedValue({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
     });
-    const fetchError = Object.assign(new TypeError("fetch failed"), {
-      cause: timeoutErr,
+
+    await resolved("https://api.telegram.org/botx/getMe");
+
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
+    expect(AgentCtor).not.toHaveBeenCalled();
+
+    const dispatcher = getDispatcherFromUndiciCall(1);
+    expect(dispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: false,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+    expect(dispatcher?.options?.proxyTls).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: false,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+  });
+
+  it("pins env-proxy transport policy onto proxyTls for proxied HTTPS requests", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    undiciFetch.mockResolvedValue({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
     });
-    const fetchMock = vi
-      .fn()
+
+    await resolved("https://api.telegram.org/botx/getMe");
+
+    const dispatcher = getDispatcherFromUndiciCall(1);
+    expect(dispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+    expect(dispatcher?.options?.proxyTls).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+  });
+
+  it("keeps resolver-scoped transport policy for OpenClaw proxy fetches", async () => {
+    const { makeProxyFetch } = await import("./proxy.js");
+    const proxyFetch = makeProxyFetch("http://127.0.0.1:7890");
+    ProxyAgentCtor.mockClear();
+    undiciFetch.mockResolvedValue({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(proxyFetch, {
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/getMe");
+
+    expect(ProxyAgentCtor).toHaveBeenCalledTimes(1);
+    expect(EnvHttpProxyAgentCtor).not.toHaveBeenCalled();
+    expect(AgentCtor).not.toHaveBeenCalled();
+    const dispatcher = getDispatcherFromUndiciCall(1);
+    expect(dispatcher?.options).toEqual(
+      expect.objectContaining({
+        uri: "http://127.0.0.1:7890",
+      }),
+    );
+    expect(dispatcher?.options?.proxyTls).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: false,
+      }),
+    );
+  });
+
+  it("does not blind-retry when sticky IPv4 fallback is disallowed for explicit proxy paths", async () => {
+    const { makeProxyFetch } = await import("./proxy.js");
+    const proxyFetch = makeProxyFetch("http://127.0.0.1:7890");
+    ProxyAgentCtor.mockClear();
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch.mockRejectedValueOnce(fetchError).mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(proxyFetch, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await expect(resolved("https://api.telegram.org/botx/sendMessage")).rejects.toThrow(
+      "fetch failed",
+    );
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(undiciFetch).toHaveBeenCalledTimes(2);
+    expect(ProxyAgentCtor).toHaveBeenCalledTimes(1);
+
+    const firstDispatcher = getDispatcherFromUndiciCall(1);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+
+    expect(firstDispatcher).toBe(secondDispatcher);
+    expect(firstDispatcher?.options?.proxyTls).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+    expect(firstDispatcher?.options?.proxyTls?.family).not.toBe(4);
+  });
+
+  it("does not blind-retry when sticky IPv4 fallback is disallowed for env proxy paths", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch.mockRejectedValueOnce(fetchError).mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await expect(resolved("https://api.telegram.org/botx/sendMessage")).rejects.toThrow(
+      "fetch failed",
+    );
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(undiciFetch).toHaveBeenCalledTimes(2);
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
+
+    const firstDispatcher = getDispatcherFromUndiciCall(1);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+
+    expect(firstDispatcher).toBe(secondDispatcher);
+    expect(firstDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+    expect(firstDispatcher?.options?.connect?.family).not.toBe(4);
+  });
+
+  it("treats ALL_PROXY-only env as direct transport and arms sticky IPv4 fallback", async () => {
+    vi.stubEnv("ALL_PROXY", "socks5://127.0.0.1:1080");
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch
       .mockRejectedValueOnce(fetchError)
       .mockResolvedValueOnce({ ok: true } as Response)
-      .mockRejectedValueOnce(fetchError)
       .mockResolvedValueOnce({ ok: true } as Response);
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    const resolved = resolveTelegramFetchOrThrow();
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
 
-    await resolved("https://api.telegram.org/file/botx/photos/file_1.jpg");
-    await resolved("https://api.telegram.org/file/botx/photos/file_2.jpg");
+    await resolved("https://api.telegram.org/botx/sendMessage");
+    await resolved("https://api.telegram.org/botx/sendChatAction");
 
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(EnvHttpProxyAgentCtor).not.toHaveBeenCalled();
+    expect(AgentCtor).toHaveBeenCalledTimes(2);
+
+    const firstDispatcher = getDispatcherFromUndiciCall(1);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+    const thirdDispatcher = getDispatcherFromUndiciCall(3);
+
+    expect(firstDispatcher).not.toBe(secondDispatcher);
+    expect(secondDispatcher).toBe(thirdDispatcher);
+    expect(secondDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        family: 4,
+        autoSelectFamily: false,
+      }),
+    );
   });
 
-  it("does not retry when fetch fails without fallback network error codes", async () => {
-    const fetchError = Object.assign(new TypeError("fetch failed"), {
-      cause: Object.assign(new Error("connect ECONNRESET"), {
-        code: "ECONNRESET",
-      }),
+  it("arms sticky IPv4 fallback when env proxy init falls back to direct Agent", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    EnvHttpProxyAgentCtor.mockImplementationOnce(function ThrowingEnvProxyAgent() {
+      throw new Error("invalid proxy config");
     });
-    const fetchMock = vi.fn().mockRejectedValue(fetchError);
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch
+      .mockRejectedValueOnce(fetchError)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
 
-    const resolved = resolveTelegramFetchOrThrow();
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
 
-    await expect(resolved("https://api.telegram.org/file/botx/photos/file_3.jpg")).rejects.toThrow(
+    await resolved("https://api.telegram.org/botx/sendMessage");
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(undiciFetch).toHaveBeenCalledTimes(3);
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
+    expect(AgentCtor).toHaveBeenCalledTimes(2);
+
+    const firstDispatcher = getDispatcherFromUndiciCall(1);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+    const thirdDispatcher = getDispatcherFromUndiciCall(3);
+
+    expect(firstDispatcher).not.toBe(secondDispatcher);
+    expect(secondDispatcher).toBe(thirdDispatcher);
+    expect(secondDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        family: 4,
+        autoSelectFamily: false,
+      }),
+    );
+  });
+
+  it("arms sticky IPv4 fallback when NO_PROXY bypasses telegram under env proxy", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    vi.stubEnv("NO_PROXY", "api.telegram.org");
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch
+      .mockRejectedValueOnce(fetchError)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/sendMessage");
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(undiciFetch).toHaveBeenCalledTimes(3);
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(2);
+    expect(AgentCtor).not.toHaveBeenCalled();
+
+    const firstDispatcher = getDispatcherFromUndiciCall(1);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+    const thirdDispatcher = getDispatcherFromUndiciCall(3);
+
+    expect(firstDispatcher).not.toBe(secondDispatcher);
+    expect(secondDispatcher).toBe(thirdDispatcher);
+    expect(secondDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        family: 4,
+        autoSelectFamily: false,
+      }),
+    );
+  });
+
+  it("uses no_proxy over NO_PROXY when deciding env-proxy bypass", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    vi.stubEnv("NO_PROXY", "");
+    vi.stubEnv("no_proxy", "api.telegram.org");
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch
+      .mockRejectedValueOnce(fetchError)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/sendMessage");
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(2);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+    expect(secondDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        family: 4,
+        autoSelectFamily: false,
+      }),
+    );
+  });
+
+  it("matches whitespace and wildcard no_proxy entries like EnvHttpProxyAgent", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    vi.stubEnv("no_proxy", "localhost *.telegram.org");
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch
+      .mockRejectedValueOnce(fetchError)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/sendMessage");
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(2);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+    expect(secondDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        family: 4,
+        autoSelectFamily: false,
+      }),
+    );
+  });
+
+  it("fails closed when explicit proxy dispatcher initialization fails", async () => {
+    const { makeProxyFetch } = await import("./proxy.js");
+    const proxyFetch = makeProxyFetch("http://127.0.0.1:7890");
+    ProxyAgentCtor.mockClear();
+    ProxyAgentCtor.mockImplementationOnce(function ThrowingProxyAgent() {
+      throw new Error("invalid proxy config");
+    });
+
+    expect(() =>
+      resolveTelegramFetchOrThrow(proxyFetch, {
+        network: {
+          autoSelectFamily: true,
+          dnsResultOrder: "ipv4first",
+        },
+      }),
+    ).toThrow("explicit proxy dispatcher init failed: invalid proxy config");
+  });
+
+  it("falls back to Agent when env proxy dispatcher initialization fails", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    EnvHttpProxyAgentCtor.mockImplementationOnce(function ThrowingEnvProxyAgent() {
+      throw new Error("invalid proxy config");
+    });
+    undiciFetch.mockResolvedValue({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: false,
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/getMe");
+
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
+    expect(AgentCtor).toHaveBeenCalledTimes(1);
+
+    const dispatcher = getDispatcherFromUndiciCall(1);
+    expect(dispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: false,
+      }),
+    );
+  });
+
+  it("retries once and then keeps sticky IPv4 dispatcher for subsequent requests", async () => {
+    const fetchError = buildFetchFallbackError("ETIMEDOUT");
+    undiciFetch
+      .mockRejectedValueOnce(fetchError)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/sendMessage");
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(undiciFetch).toHaveBeenCalledTimes(3);
+
+    const firstDispatcher = getDispatcherFromUndiciCall(1);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+    const thirdDispatcher = getDispatcherFromUndiciCall(3);
+
+    expect(firstDispatcher).toBeDefined();
+    expect(secondDispatcher).toBeDefined();
+    expect(thirdDispatcher).toBeDefined();
+
+    expect(firstDispatcher).not.toBe(secondDispatcher);
+    expect(secondDispatcher).toBe(thirdDispatcher);
+
+    expect(firstDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+    expect(secondDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        family: 4,
+        autoSelectFamily: false,
+      }),
+    );
+  });
+
+  it("preserves caller-provided dispatcher across fallback retry", async () => {
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch.mockRejectedValueOnce(fetchError).mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+      },
+    });
+
+    const callerDispatcher = { name: "caller" };
+
+    await resolved("https://api.telegram.org/botx/sendMessage", {
+      dispatcher: callerDispatcher,
+    } as RequestInit);
+
+    expect(undiciFetch).toHaveBeenCalledTimes(2);
+
+    const firstCallInit = undiciFetch.mock.calls[0]?.[1] as
+      | (RequestInit & { dispatcher?: unknown })
+      | undefined;
+    const secondCallInit = undiciFetch.mock.calls[1]?.[1] as
+      | (RequestInit & { dispatcher?: unknown })
+      | undefined;
+
+    expect(firstCallInit?.dispatcher).toBe(callerDispatcher);
+    expect(secondCallInit?.dispatcher).toBe(callerDispatcher);
+  });
+
+  it("does not arm sticky fallback from caller-provided dispatcher failures", async () => {
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch
+      .mockRejectedValueOnce(fetchError)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+      },
+    });
+
+    const callerDispatcher = { name: "caller" };
+
+    await resolved("https://api.telegram.org/botx/sendMessage", {
+      dispatcher: callerDispatcher,
+    } as RequestInit);
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(undiciFetch).toHaveBeenCalledTimes(3);
+
+    const firstCallInit = undiciFetch.mock.calls[0]?.[1] as
+      | (RequestInit & { dispatcher?: unknown })
+      | undefined;
+    const secondCallInit = undiciFetch.mock.calls[1]?.[1] as
+      | (RequestInit & { dispatcher?: unknown })
+      | undefined;
+    const thirdDispatcher = getDispatcherFromUndiciCall(3);
+
+    expect(firstCallInit?.dispatcher).toBe(callerDispatcher);
+    expect(secondCallInit?.dispatcher).toBe(callerDispatcher);
+    expect(thirdDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+    expect(thirdDispatcher?.options?.connect?.family).not.toBe(4);
+  });
+
+  it("does not retry when error codes do not match fallback rules", async () => {
+    const fetchError = buildFetchFallbackError("ECONNRESET");
+    undiciFetch.mockRejectedValue(fetchError);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+      },
+    });
+
+    await expect(resolved("https://api.telegram.org/botx/sendMessage")).rejects.toThrow(
       "fetch failed",
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(undiciFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps per-resolver transport policy isolated across multiple accounts", async () => {
+    undiciFetch.mockResolvedValue({ ok: true } as Response);
+
+    const resolverA = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+    const resolverB = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "verbatim",
+      },
+    });
+
+    await resolverA("https://api.telegram.org/botA/getMe");
+    await resolverB("https://api.telegram.org/botB/getMe");
+
+    const dispatcherA = getDispatcherFromUndiciCall(1);
+    const dispatcherB = getDispatcherFromUndiciCall(2);
+
+    expect(dispatcherA).toBeDefined();
+    expect(dispatcherB).toBeDefined();
+    expect(dispatcherA).not.toBe(dispatcherB);
+
+    expect(dispatcherA?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: false,
+      }),
+    );
+    expect(dispatcherB?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+      }),
+    );
+
+    // Core guarantee: Telegram transport no longer mutates process-global defaults.
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+    expect(setDefaultResultOrder).not.toHaveBeenCalled();
+    expect(setDefaultAutoSelectFamily).not.toHaveBeenCalled();
   });
 });

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -1,23 +1,43 @@
 import * as dns from "node:dns";
-import * as net from "node:net";
-import { EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
+import { Agent, EnvHttpProxyAgent, ProxyAgent, fetch as undiciFetch } from "undici";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
-import { hasProxyEnvConfigured } from "../infra/net/proxy-env.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   resolveTelegramAutoSelectFamilyDecision,
   resolveTelegramDnsResultOrderDecision,
 } from "./network-config.js";
+import { getProxyUrlFromFetch } from "./proxy.js";
 
-let appliedAutoSelectFamily: boolean | null = null;
-let appliedDnsResultOrder: string | null = null;
-let appliedGlobalDispatcherAutoSelectFamily: boolean | null = null;
 const log = createSubsystemLogger("telegram/network");
-function isProxyLikeDispatcher(dispatcher: unknown): boolean {
-  const ctorName = (dispatcher as { constructor?: { name?: string } })?.constructor?.name;
-  return typeof ctorName === "string" && ctorName.includes("ProxyAgent");
-}
+
+const TELEGRAM_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS = 300;
+const TELEGRAM_API_HOSTNAME = "api.telegram.org";
+
+type RequestInitWithDispatcher = RequestInit & {
+  dispatcher?: unknown;
+};
+
+type TelegramDispatcher = Agent | EnvHttpProxyAgent | ProxyAgent;
+
+type TelegramDispatcherMode = "direct" | "env-proxy" | "explicit-proxy";
+
+type TelegramDnsResultOrder = "ipv4first" | "verbatim";
+
+type LookupCallback =
+  | ((err: NodeJS.ErrnoException | null, address: string, family: number) => void)
+  | ((err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void);
+
+type LookupOptions = (dns.LookupOneOptions | dns.LookupAllOptions) & {
+  order?: TelegramDnsResultOrder;
+  verbatim?: boolean;
+};
+
+type LookupFunction = (
+  hostname: string,
+  options: number | dns.LookupOneOptions | dns.LookupAllOptions | undefined,
+  callback: LookupCallback,
+) => void;
 
 const FALLBACK_RETRY_ERROR_CODES = [
   "ETIMEDOUT",
@@ -48,72 +68,215 @@ const IPV4_FALLBACK_RULES: readonly Ipv4FallbackRule[] = [
   },
 ];
 
-// Node 22 workaround: enable autoSelectFamily to allow IPv4 fallback on broken IPv6 networks.
-// Many networks have IPv6 configured but not routed, causing "Network is unreachable" errors.
-// See: https://github.com/nodejs/node/issues/54359
-function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void {
-  // Apply autoSelectFamily workaround
-  const autoSelectDecision = resolveTelegramAutoSelectFamilyDecision({ network });
-  if (autoSelectDecision.value !== null && autoSelectDecision.value !== appliedAutoSelectFamily) {
-    if (typeof net.setDefaultAutoSelectFamily === "function") {
-      try {
-        net.setDefaultAutoSelectFamily(autoSelectDecision.value);
-        appliedAutoSelectFamily = autoSelectDecision.value;
-        const label = autoSelectDecision.source ? ` (${autoSelectDecision.source})` : "";
-        log.info(`autoSelectFamily=${autoSelectDecision.value}${label}`);
-      } catch {
-        // ignore if unsupported by the runtime
-      }
-    }
+function normalizeDnsResultOrder(value: string | null): TelegramDnsResultOrder | null {
+  if (value === "ipv4first" || value === "verbatim") {
+    return value;
+  }
+  return null;
+}
+
+function createDnsResultOrderLookup(
+  order: TelegramDnsResultOrder | null,
+): LookupFunction | undefined {
+  if (!order) {
+    return undefined;
+  }
+  const lookup = dns.lookup as unknown as (
+    hostname: string,
+    options: LookupOptions,
+    callback: LookupCallback,
+  ) => void;
+  return (hostname, options, callback) => {
+    const baseOptions: LookupOptions =
+      typeof options === "number"
+        ? { family: options }
+        : options
+          ? { ...(options as LookupOptions) }
+          : {};
+    const lookupOptions: LookupOptions = {
+      ...baseOptions,
+      order,
+      // Keep `verbatim` for compatibility with Node runtimes that ignore `order`.
+      verbatim: order === "verbatim",
+    };
+    lookup(hostname, lookupOptions, callback);
+  };
+}
+
+function buildTelegramConnectOptions(params: {
+  autoSelectFamily: boolean | null;
+  dnsResultOrder: TelegramDnsResultOrder | null;
+  forceIpv4: boolean;
+}): {
+  autoSelectFamily?: boolean;
+  autoSelectFamilyAttemptTimeout?: number;
+  family?: number;
+  lookup?: LookupFunction;
+} | null {
+  const connect: {
+    autoSelectFamily?: boolean;
+    autoSelectFamilyAttemptTimeout?: number;
+    family?: number;
+    lookup?: LookupFunction;
+  } = {};
+
+  if (params.forceIpv4) {
+    connect.family = 4;
+    connect.autoSelectFamily = false;
+  } else if (typeof params.autoSelectFamily === "boolean") {
+    connect.autoSelectFamily = params.autoSelectFamily;
+    connect.autoSelectFamilyAttemptTimeout = TELEGRAM_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS;
   }
 
-  // Node 22's built-in globalThis.fetch uses undici's internal Agent whose
-  // connect options are frozen at construction time. Calling
-  // net.setDefaultAutoSelectFamily() after that agent is created has no
-  // effect on it. Replace the global dispatcher with one that carries the
-  // current autoSelectFamily setting so subsequent globalThis.fetch calls
-  // inherit the same decision.
-  // See: https://github.com/remoteclaw/remoteclaw/issues/25676
-  if (
-    autoSelectDecision.value !== null &&
-    autoSelectDecision.value !== appliedGlobalDispatcherAutoSelectFamily
-  ) {
-    const existingGlobalDispatcher = getGlobalDispatcher();
-    const shouldPreserveExistingProxy =
-      isProxyLikeDispatcher(existingGlobalDispatcher) && !hasProxyEnvConfigured();
-    if (!shouldPreserveExistingProxy) {
-      try {
-        setGlobalDispatcher(
-          new EnvHttpProxyAgent({
-            connect: {
-              autoSelectFamily: autoSelectDecision.value,
-              autoSelectFamilyAttemptTimeout: 300,
-            },
-          }),
-        );
-        appliedGlobalDispatcherAutoSelectFamily = autoSelectDecision.value;
-        log.info(`global undici dispatcher autoSelectFamily=${autoSelectDecision.value}`);
-      } catch {
-        // ignore if setGlobalDispatcher is unavailable
-      }
-    }
+  const lookup = createDnsResultOrderLookup(params.dnsResultOrder);
+  if (lookup) {
+    connect.lookup = lookup;
   }
 
-  // Apply DNS result order workaround for IPv4/IPv6 issues.
-  // Some APIs (including Telegram) may fail with IPv6 on certain networks.
-  // See: https://github.com/remoteclaw/remoteclaw/issues/5311
-  const dnsDecision = resolveTelegramDnsResultOrderDecision({ network });
-  if (dnsDecision.value !== null && dnsDecision.value !== appliedDnsResultOrder) {
-    if (typeof dns.setDefaultResultOrder === "function") {
-      try {
-        dns.setDefaultResultOrder(dnsDecision.value as "ipv4first" | "verbatim");
-        appliedDnsResultOrder = dnsDecision.value;
-        const label = dnsDecision.source ? ` (${dnsDecision.source})` : "";
-        log.info(`dnsResultOrder=${dnsDecision.value}${label}`);
-      } catch {
-        // ignore if unsupported by the runtime
-      }
+  return Object.keys(connect).length > 0 ? connect : null;
+}
+
+function shouldBypassEnvProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env): boolean {
+  // We need this classification before dispatch to decide whether sticky IPv4 fallback
+  // can safely arm. EnvHttpProxyAgent does not expose route decisions (proxy vs direct
+  // NO_PROXY bypass), so we mirror undici's parsing/matching behavior for this host.
+  // Match EnvHttpProxyAgent behavior (undici):
+  // - lower-case no_proxy takes precedence over NO_PROXY
+  // - entries split by comma or whitespace
+  // - wildcard handling is exact-string "*" only
+  // - leading "." and "*." are normalized the same way
+  const noProxyValue = env.no_proxy ?? env.NO_PROXY ?? "";
+  if (!noProxyValue) {
+    return false;
+  }
+  if (noProxyValue === "*") {
+    return true;
+  }
+  const targetHostname = TELEGRAM_API_HOSTNAME.toLowerCase();
+  const targetPort = 443;
+  const noProxyEntries = noProxyValue.split(/[,\s]/);
+  for (let i = 0; i < noProxyEntries.length; i++) {
+    const entry = noProxyEntries[i];
+    if (!entry) {
+      continue;
     }
+    const parsed = entry.match(/^(.+):(\d+)$/);
+    const entryHostname = (parsed ? parsed[1] : entry).replace(/^\*?\./, "").toLowerCase();
+    const entryPort = parsed ? Number.parseInt(parsed[2], 10) : 0;
+    if (entryPort && entryPort !== targetPort) {
+      continue;
+    }
+    if (
+      targetHostname === entryHostname ||
+      targetHostname.slice(-(entryHostname.length + 1)) === `.${entryHostname}`
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasEnvHttpProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env): boolean {
+  // Match EnvHttpProxyAgent behavior (undici) for HTTPS requests:
+  // - lower-case env vars take precedence over upper-case
+  // - HTTPS requests use https_proxy/HTTPS_PROXY first, then fall back to http_proxy/HTTP_PROXY
+  // - ALL_PROXY is ignored by EnvHttpProxyAgent
+  const httpProxy = env.http_proxy ?? env.HTTP_PROXY;
+  const httpsProxy = env.https_proxy ?? env.HTTPS_PROXY;
+  return Boolean(httpProxy) || Boolean(httpsProxy);
+}
+
+function createTelegramDispatcher(params: {
+  autoSelectFamily: boolean | null;
+  dnsResultOrder: TelegramDnsResultOrder | null;
+  useEnvProxy: boolean;
+  forceIpv4: boolean;
+  proxyUrl?: string;
+}): { dispatcher: TelegramDispatcher; mode: TelegramDispatcherMode } {
+  const connect = buildTelegramConnectOptions({
+    autoSelectFamily: params.autoSelectFamily,
+    dnsResultOrder: params.dnsResultOrder,
+    forceIpv4: params.forceIpv4,
+  });
+  const explicitProxyUrl = params.proxyUrl?.trim();
+  if (explicitProxyUrl) {
+    const proxyOptions = connect
+      ? ({
+          uri: explicitProxyUrl,
+          proxyTls: connect,
+        } satisfies ConstructorParameters<typeof ProxyAgent>[0])
+      : explicitProxyUrl;
+    try {
+      return {
+        dispatcher: new ProxyAgent(proxyOptions),
+        mode: "explicit-proxy",
+      };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(`explicit proxy dispatcher init failed: ${reason}`, { cause: err });
+    }
+  }
+  if (params.useEnvProxy) {
+    const proxyOptions = connect
+      ? ({
+          connect,
+          // undici's EnvHttpProxyAgent passes `connect` only to the no-proxy Agent.
+          // Real proxied HTTPS traffic reads transport settings from ProxyAgent.proxyTls.
+          proxyTls: connect,
+        } satisfies ConstructorParameters<typeof EnvHttpProxyAgent>[0])
+      : undefined;
+    try {
+      return {
+        dispatcher: new EnvHttpProxyAgent(proxyOptions),
+        mode: "env-proxy",
+      };
+    } catch (err) {
+      log.warn(
+        `env proxy dispatcher init failed; falling back to direct dispatcher: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  const agentOptions = connect
+    ? ({
+        connect,
+      } satisfies ConstructorParameters<typeof Agent>[0])
+    : undefined;
+  return {
+    dispatcher: new Agent(agentOptions),
+    mode: "direct",
+  };
+}
+
+function withDispatcherIfMissing(
+  init: RequestInit | undefined,
+  dispatcher: TelegramDispatcher,
+): RequestInitWithDispatcher {
+  const withDispatcher = init as RequestInitWithDispatcher | undefined;
+  if (withDispatcher?.dispatcher) {
+    return init ?? {};
+  }
+  return init ? { ...init, dispatcher } : { dispatcher };
+}
+
+function resolveWrappedFetch(fetchImpl: typeof fetch): typeof fetch {
+  return resolveFetch(fetchImpl) ?? fetchImpl;
+}
+
+function logResolverNetworkDecisions(params: {
+  autoSelectDecision: ReturnType<typeof resolveTelegramAutoSelectFamilyDecision>;
+  dnsDecision: ReturnType<typeof resolveTelegramDnsResultOrderDecision>;
+}): void {
+  if (params.autoSelectDecision.value !== null) {
+    const sourceLabel = params.autoSelectDecision.source
+      ? ` (${params.autoSelectDecision.source})`
+      : "";
+    log.info(`autoSelectFamily=${params.autoSelectDecision.value}${sourceLabel}`);
+  }
+  if (params.dnsDecision.value !== null) {
+    const sourceLabel = params.dnsDecision.source ? ` (${params.dnsDecision.source})` : "";
+    log.info(`dnsResultOrder=${params.dnsDecision.value}${sourceLabel}`);
   }
 }
 
@@ -151,6 +314,11 @@ function collectErrorCodes(err: unknown): Set<string> {
   return codes;
 }
 
+function formatErrorCodes(err: unknown): string {
+  const codes = [...collectErrorCodes(err)];
+  return codes.length > 0 ? codes.join(",") : "none";
+}
+
 function shouldRetryWithIpv4Fallback(err: unknown): boolean {
   const ctx: Ipv4FallbackContext = {
     message:
@@ -165,44 +333,97 @@ function shouldRetryWithIpv4Fallback(err: unknown): boolean {
   return true;
 }
 
-function applyTelegramIpv4Fallback(): void {
-  applyTelegramNetworkWorkarounds({
-    autoSelectFamily: false,
-    dnsResultOrder: "ipv4first",
-  });
-  log.warn("fetch fallback: forcing autoSelectFamily=false + dnsResultOrder=ipv4first");
-}
-
 // Prefer wrapped fetch when available to normalize AbortSignal across runtimes.
 export function resolveTelegramFetch(
   proxyFetch?: typeof fetch,
   options?: { network?: TelegramNetworkConfig },
-): typeof fetch | undefined {
-  applyTelegramNetworkWorkarounds(options?.network);
-  const sourceFetch = proxyFetch ? resolveFetch(proxyFetch) : resolveFetch();
-  if (!sourceFetch) {
-    throw new Error("fetch is not available; set channels.telegram.proxy in config");
-  }
-  // When Telegram media fetch hits dual-stack edge cases (ENETUNREACH/ETIMEDOUT),
-  // switch to IPv4-safe network mode and retry once.
-  if (proxyFetch) {
+): typeof fetch {
+  const autoSelectDecision = resolveTelegramAutoSelectFamilyDecision({
+    network: options?.network,
+  });
+  const dnsDecision = resolveTelegramDnsResultOrderDecision({
+    network: options?.network,
+  });
+  logResolverNetworkDecisions({
+    autoSelectDecision,
+    dnsDecision,
+  });
+
+  const explicitProxyUrl = proxyFetch ? getProxyUrlFromFetch(proxyFetch) : undefined;
+  const undiciSourceFetch = resolveWrappedFetch(undiciFetch as unknown as typeof fetch);
+  const sourceFetch = explicitProxyUrl
+    ? undiciSourceFetch
+    : proxyFetch
+      ? resolveWrappedFetch(proxyFetch)
+      : undiciSourceFetch;
+
+  // Preserve fully caller-owned custom fetch implementations.
+  // OpenClaw proxy fetches are metadata-tagged and continue into resolver-scoped policy.
+  if (proxyFetch && !explicitProxyUrl) {
     return sourceFetch;
   }
+
+  const dnsResultOrder = normalizeDnsResultOrder(dnsDecision.value);
+  const useEnvProxy = !explicitProxyUrl && hasEnvHttpProxyForTelegramApi();
+  const defaultDispatcherResolution = createTelegramDispatcher({
+    autoSelectFamily: autoSelectDecision.value,
+    dnsResultOrder,
+    useEnvProxy,
+    forceIpv4: false,
+    proxyUrl: explicitProxyUrl,
+  });
+  const defaultDispatcher = defaultDispatcherResolution.dispatcher;
+  const shouldBypassEnvProxy = shouldBypassEnvProxyForTelegramApi();
+  const allowStickyIpv4Fallback =
+    defaultDispatcherResolution.mode === "direct" ||
+    (defaultDispatcherResolution.mode === "env-proxy" && shouldBypassEnvProxy);
+  const stickyShouldUseEnvProxy = defaultDispatcherResolution.mode === "env-proxy";
+
+  let stickyIpv4FallbackEnabled = false;
+  let stickyIpv4Dispatcher: TelegramDispatcher | null = null;
+  const resolveStickyIpv4Dispatcher = () => {
+    if (!stickyIpv4Dispatcher) {
+      stickyIpv4Dispatcher = createTelegramDispatcher({
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+        useEnvProxy: stickyShouldUseEnvProxy,
+        forceIpv4: true,
+        proxyUrl: explicitProxyUrl,
+      }).dispatcher;
+    }
+    return stickyIpv4Dispatcher;
+  };
+
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const callerProvidedDispatcher = Boolean(
+      (init as RequestInitWithDispatcher | undefined)?.dispatcher,
+    );
+    const initialInit = withDispatcherIfMissing(
+      init,
+      stickyIpv4FallbackEnabled ? resolveStickyIpv4Dispatcher() : defaultDispatcher,
+    );
     try {
-      return await sourceFetch(input, init);
+      return await sourceFetch(input, initialInit);
     } catch (err) {
       if (shouldRetryWithIpv4Fallback(err)) {
-        applyTelegramIpv4Fallback();
-        return sourceFetch(input, init);
+        // Preserve caller-owned dispatchers on retry.
+        if (callerProvidedDispatcher) {
+          return sourceFetch(input, init ?? {});
+        }
+        // Proxy routes should not arm sticky IPv4 mode; `family=4` would constrain
+        // proxy-connect behavior instead of Telegram endpoint selection.
+        if (!allowStickyIpv4Fallback) {
+          throw err;
+        }
+        if (!stickyIpv4FallbackEnabled) {
+          stickyIpv4FallbackEnabled = true;
+          log.warn(
+            `fetch fallback: enabling sticky IPv4-only dispatcher (codes=${formatErrorCodes(err)})`,
+          );
+        }
+        return sourceFetch(input, withDispatcherIfMissing(init, resolveStickyIpv4Dispatcher()));
       }
       throw err;
     }
   }) as typeof fetch;
-}
-
-export function resetTelegramFetchStateForTests(): void {
-  appliedAutoSelectFamily = null;
-  appliedDnsResultOrder = null;
-  appliedGlobalDispatcherAutoSelectFamily = null;
 }

--- a/src/telegram/probe.test.ts
+++ b/src/telegram/probe.test.ts
@@ -1,14 +1,28 @@
-import { type Mock, describe, expect, it, vi } from "vitest";
+import { afterEach, type Mock, describe, expect, it, vi } from "vitest";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
-import { probeTelegram } from "./probe.js";
+import { probeTelegram, resetTelegramProbeFetcherCacheForTests } from "./probe.js";
+
+const resolveTelegramFetch = vi.hoisted(() => vi.fn());
+const makeProxyFetch = vi.hoisted(() => vi.fn());
+
+vi.mock("./fetch.js", () => ({
+  resolveTelegramFetch,
+}));
+
+vi.mock("./proxy.js", () => ({
+  makeProxyFetch,
+}));
 
 describe("probeTelegram retry logic", () => {
   const token = "test-token";
   const timeoutMs = 5000;
+  const originalFetch = global.fetch;
 
   const installFetchMock = (): Mock => {
     const fetchMock = vi.fn();
     global.fetch = withFetchPreconnect(fetchMock);
+    resolveTelegramFetch.mockImplementation((proxyFetch?: typeof fetch) => proxyFetch ?? fetch);
+    makeProxyFetch.mockImplementation(() => fetchMock as unknown as typeof fetch);
     return fetchMock;
   };
 
@@ -40,6 +54,19 @@ describe("probeTelegram retry logic", () => {
     expect(fetchMock).toHaveBeenCalledTimes(expectedCalls);
     expect(result.bot?.username).toBe("test_bot");
   }
+
+  afterEach(() => {
+    resetTelegramProbeFetcherCacheForTests();
+    resolveTelegramFetch.mockReset();
+    makeProxyFetch.mockReset();
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete (globalThis as { fetch?: typeof fetch }).fetch;
+    }
+  });
 
   it.each([
     {
@@ -95,6 +122,35 @@ describe("probeTelegram retry logic", () => {
     }
   });
 
+  it("respects timeout budget across retries", async () => {
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (signal?.aborted) {
+          reject(new Error("Request aborted"));
+          return;
+        }
+        signal?.addEventListener("abort", () => reject(new Error("Request aborted")), {
+          once: true,
+        });
+      });
+    });
+    global.fetch = withFetchPreconnect(fetchMock as unknown as typeof fetch);
+    resolveTelegramFetch.mockImplementation((proxyFetch?: typeof fetch) => proxyFetch ?? fetch);
+    makeProxyFetch.mockImplementation(() => fetchMock as unknown as typeof fetch);
+    vi.useFakeTimers();
+    try {
+      const probePromise = probeTelegram(`${token}-budget`, 500);
+      await vi.advanceTimersByTimeAsync(600);
+      const result = await probePromise;
+
+      expect(result.ok).toBe(false);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("should NOT retry if getMe returns a 401 Unauthorized", async () => {
     const fetchMock = installFetchMock();
     const mockResponse = {
@@ -113,5 +169,107 @@ describe("probeTelegram retry logic", () => {
     expect(result.status).toBe(401);
     expect(result.error).toBe("Unauthorized");
     expect(fetchMock).toHaveBeenCalledTimes(1); // Should not retry
+  });
+
+  it("uses resolver-scoped Telegram fetch with probe network options", async () => {
+    const fetchMock = installFetchMock();
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+
+    await probeTelegram(token, timeoutMs, {
+      proxyUrl: "http://127.0.0.1:8888",
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    expect(makeProxyFetch).toHaveBeenCalledWith("http://127.0.0.1:8888");
+    expect(resolveTelegramFetch).toHaveBeenCalledWith(fetchMock, {
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+  });
+
+  it("reuses probe fetcher across repeated probes for the same account transport settings", async () => {
+    const fetchMock = installFetchMock();
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "production");
+
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+    await probeTelegram(`${token}-cache`, timeoutMs, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+    await probeTelegram(`${token}-cache`, timeoutMs, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    expect(resolveTelegramFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reuse probe fetcher cache when network settings differ", async () => {
+    const fetchMock = installFetchMock();
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "production");
+
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+    await probeTelegram(`${token}-cache-variant`, timeoutMs, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+    await probeTelegram(`${token}-cache-variant`, timeoutMs, {
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    expect(resolveTelegramFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses probe fetcher cache across token rotation when accountId is stable", async () => {
+    const fetchMock = installFetchMock();
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "production");
+
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+    await probeTelegram(`${token}-old`, timeoutMs, {
+      accountId: "main",
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+    await probeTelegram(`${token}-new`, timeoutMs, {
+      accountId: "main",
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    expect(resolveTelegramFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -1,5 +1,7 @@
 import type { BaseProbeResult } from "../channels/plugins/types.js";
+import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { fetchWithTimeout } from "../utils/fetch-timeout.js";
+import { resolveTelegramFetch } from "./fetch.js";
 import { makeProxyFetch } from "./proxy.js";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
@@ -17,15 +19,90 @@ export type TelegramProbe = BaseProbeResult & {
   webhook?: { url?: string | null; hasCustomCert?: boolean | null };
 };
 
+export type TelegramProbeOptions = {
+  proxyUrl?: string;
+  network?: TelegramNetworkConfig;
+  accountId?: string;
+};
+
+const probeFetcherCache = new Map<string, typeof fetch>();
+const MAX_PROBE_FETCHER_CACHE_SIZE = 64;
+
+export function resetTelegramProbeFetcherCacheForTests(): void {
+  probeFetcherCache.clear();
+}
+
+function resolveProbeOptions(
+  proxyOrOptions?: string | TelegramProbeOptions,
+): TelegramProbeOptions | undefined {
+  if (!proxyOrOptions) {
+    return undefined;
+  }
+  if (typeof proxyOrOptions === "string") {
+    return { proxyUrl: proxyOrOptions };
+  }
+  return proxyOrOptions;
+}
+
+function shouldUseProbeFetcherCache(): boolean {
+  return !process.env.VITEST && process.env.NODE_ENV !== "test";
+}
+
+function buildProbeFetcherCacheKey(token: string, options?: TelegramProbeOptions): string {
+  const cacheIdentity = options?.accountId?.trim() || token;
+  const cacheIdentityKind = options?.accountId?.trim() ? "account" : "token";
+  const proxyKey = options?.proxyUrl?.trim() ?? "";
+  const autoSelectFamily = options?.network?.autoSelectFamily;
+  const autoSelectFamilyKey =
+    typeof autoSelectFamily === "boolean" ? String(autoSelectFamily) : "default";
+  const dnsResultOrderKey = options?.network?.dnsResultOrder ?? "default";
+  return `${cacheIdentityKind}:${cacheIdentity}::${proxyKey}::${autoSelectFamilyKey}::${dnsResultOrderKey}`;
+}
+
+function setCachedProbeFetcher(cacheKey: string, fetcher: typeof fetch): typeof fetch {
+  probeFetcherCache.set(cacheKey, fetcher);
+  if (probeFetcherCache.size > MAX_PROBE_FETCHER_CACHE_SIZE) {
+    const oldestKey = probeFetcherCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      probeFetcherCache.delete(oldestKey);
+    }
+  }
+  return fetcher;
+}
+
+function resolveProbeFetcher(token: string, options?: TelegramProbeOptions): typeof fetch {
+  const cacheEnabled = shouldUseProbeFetcherCache();
+  const cacheKey = cacheEnabled ? buildProbeFetcherCacheKey(token, options) : null;
+  if (cacheKey) {
+    const cachedFetcher = probeFetcherCache.get(cacheKey);
+    if (cachedFetcher) {
+      return cachedFetcher;
+    }
+  }
+
+  const proxyUrl = options?.proxyUrl?.trim();
+  const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : undefined;
+  const resolved = resolveTelegramFetch(proxyFetch, { network: options?.network });
+
+  if (cacheKey) {
+    return setCachedProbeFetcher(cacheKey, resolved);
+  }
+  return resolved;
+}
+
 export async function probeTelegram(
   token: string,
   timeoutMs: number,
-  proxyUrl?: string,
+  proxyOrOptions?: string | TelegramProbeOptions,
 ): Promise<TelegramProbe> {
   const started = Date.now();
-  const fetcher = proxyUrl ? makeProxyFetch(proxyUrl) : fetch;
+  const timeoutBudgetMs = Math.max(1, Math.floor(timeoutMs));
+  const deadlineMs = started + timeoutBudgetMs;
+  const options = resolveProbeOptions(proxyOrOptions);
+  const fetcher = resolveProbeFetcher(token, options);
   const base = `${TELEGRAM_API_BASE}/bot${token}`;
-  const retryDelayMs = Math.max(50, Math.min(1000, timeoutMs));
+  const retryDelayMs = Math.max(50, Math.min(1000, Math.floor(timeoutBudgetMs / 5)));
+  const resolveRemainingBudgetMs = () => Math.max(0, deadlineMs - Date.now());
 
   const result: TelegramProbe = {
     ok: false,
@@ -40,19 +117,35 @@ export async function probeTelegram(
 
     // Retry loop for initial connection (handles network/DNS startup races)
     for (let i = 0; i < 3; i++) {
+      const remainingBudgetMs = resolveRemainingBudgetMs();
+      if (remainingBudgetMs <= 0) {
+        break;
+      }
       try {
-        meRes = await fetchWithTimeout(`${base}/getMe`, {}, timeoutMs, fetcher);
+        meRes = await fetchWithTimeout(
+          `${base}/getMe`,
+          {},
+          Math.max(1, Math.min(timeoutBudgetMs, remainingBudgetMs)),
+          fetcher,
+        );
         break;
       } catch (err) {
         fetchError = err;
         if (i < 2) {
-          await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+          const remainingAfterAttemptMs = resolveRemainingBudgetMs();
+          if (remainingAfterAttemptMs <= 0) {
+            break;
+          }
+          const delayMs = Math.min(retryDelayMs, remainingAfterAttemptMs);
+          if (delayMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+          }
         }
       }
     }
 
     if (!meRes) {
-      throw fetchError;
+      throw fetchError ?? new Error(`probe timed out after ${timeoutBudgetMs}ms`);
     }
 
     const meJson = (await meRes.json()) as {
@@ -89,16 +182,24 @@ export async function probeTelegram(
 
     // Try to fetch webhook info, but don't fail health if it errors.
     try {
-      const webhookRes = await fetchWithTimeout(`${base}/getWebhookInfo`, {}, timeoutMs, fetcher);
-      const webhookJson = (await webhookRes.json()) as {
-        ok?: boolean;
-        result?: { url?: string; has_custom_certificate?: boolean };
-      };
-      if (webhookRes.ok && webhookJson?.ok) {
-        result.webhook = {
-          url: webhookJson.result?.url ?? null,
-          hasCustomCert: webhookJson.result?.has_custom_certificate ?? null,
+      const webhookRemainingBudgetMs = resolveRemainingBudgetMs();
+      if (webhookRemainingBudgetMs > 0) {
+        const webhookRes = await fetchWithTimeout(
+          `${base}/getWebhookInfo`,
+          {},
+          Math.max(1, Math.min(timeoutBudgetMs, webhookRemainingBudgetMs)),
+          fetcher,
+        );
+        const webhookJson = (await webhookRes.json()) as {
+          ok?: boolean;
+          result?: { url?: string; has_custom_certificate?: boolean };
         };
+        if (webhookRes.ok && webhookJson?.ok) {
+          result.webhook = {
+            url: webhookJson.result?.url ?? null,
+            hasCustomCert: webhookJson.result?.has_custom_certificate ?? null,
+          };
+        }
       }
     } catch {
       // ignore webhook errors for probe

--- a/src/telegram/proxy.test.ts
+++ b/src/telegram/proxy.test.ts
@@ -29,7 +29,7 @@ vi.mock("undici", () => ({
   setGlobalDispatcher: mocks.setGlobalDispatcher,
 }));
 
-import { makeProxyFetch } from "./proxy.js";
+import { getProxyUrlFromFetch, makeProxyFetch } from "./proxy.js";
 
 describe("makeProxyFetch", () => {
   it("uses undici fetch with ProxyAgent dispatcher", async () => {
@@ -45,5 +45,12 @@ describe("makeProxyFetch", () => {
       expect.objectContaining({ dispatcher: mocks.getLastAgent() }),
     );
     expect(mocks.setGlobalDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("attaches proxy metadata for resolver transport handling", () => {
+    const proxyUrl = "http://proxy.test:8080";
+    const proxyFetch = makeProxyFetch(proxyUrl);
+
+    expect(getProxyUrlFromFetch(proxyFetch)).toBe(proxyUrl);
   });
 });

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -1,1 +1,1 @@
-export { makeProxyFetch } from "../infra/net/proxy-fetch.js";
+export { getProxyUrlFromFetch, makeProxyFetch } from "../infra/net/proxy-fetch.js";

--- a/src/telegram/send.proxy.test.ts
+++ b/src/telegram/send.proxy.test.ts
@@ -51,7 +51,12 @@ vi.mock("grammy", () => ({
   InputFile: class {},
 }));
 
-import { deleteMessageTelegram, reactMessageTelegram, sendMessageTelegram } from "./send.js";
+import {
+  deleteMessageTelegram,
+  reactMessageTelegram,
+  resetTelegramClientOptionsCacheForTests,
+  sendMessageTelegram,
+} from "./send.js";
 
 describe("telegram proxy client", () => {
   const proxyUrl = "http://proxy.test:8080";
@@ -76,6 +81,8 @@ describe("telegram proxy client", () => {
   };
 
   beforeEach(() => {
+    resetTelegramClientOptionsCacheForTests();
+    vi.unstubAllEnvs();
     botApi.sendMessage.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
     botApi.setMessageReaction.mockResolvedValue(undefined);
     botApi.deleteMessage.mockResolvedValue(true);
@@ -85,6 +92,33 @@ describe("telegram proxy client", () => {
     });
     makeProxyFetch.mockClear();
     resolveTelegramFetch.mockClear();
+  });
+
+  it("reuses cached Telegram client options for repeated sends with same account transport settings", async () => {
+    const { fetchImpl } = prepareProxyFetch();
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "production");
+
+    await sendMessageTelegram("123", "first", { token: "tok", accountId: "foo" });
+    await sendMessageTelegram("123", "second", { token: "tok", accountId: "foo" });
+
+    expect(makeProxyFetch).toHaveBeenCalledTimes(1);
+    expect(resolveTelegramFetch).toHaveBeenCalledTimes(1);
+    expect(botCtorSpy).toHaveBeenCalledTimes(2);
+    expect(botCtorSpy).toHaveBeenNthCalledWith(
+      1,
+      "tok",
+      expect.objectContaining({
+        client: expect.objectContaining({ fetch: fetchImpl }),
+      }),
+    );
+    expect(botCtorSpy).toHaveBeenNthCalledWith(
+      2,
+      "tok",
+      expect.objectContaining({
+        client: expect.objectContaining({ fetch: fetchImpl }),
+      }),
+    );
   });
 
   it.each([

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -96,6 +96,12 @@ const MESSAGE_NOT_MODIFIED_RE =
 const CHAT_NOT_FOUND_RE = /400: Bad Request: chat not found/i;
 const sendLogger = createSubsystemLogger("telegram/send");
 const diagLogger = createSubsystemLogger("telegram/diagnostic");
+const telegramClientOptionsCache = new Map<string, ApiClientOptions | undefined>();
+const MAX_TELEGRAM_CLIENT_OPTIONS_CACHE_SIZE = 64;
+
+export function resetTelegramClientOptionsCacheForTests(): void {
+  telegramClientOptionsCache.clear();
+}
 
 function createTelegramHttpLogger(cfg: ReturnType<typeof loadConfig>) {
   const enabled = isDiagnosticFlagEnabled("telegram.http", cfg);
@@ -111,25 +117,74 @@ function createTelegramHttpLogger(cfg: ReturnType<typeof loadConfig>) {
   };
 }
 
+function shouldUseTelegramClientOptionsCache(): boolean {
+  return !process.env.VITEST && process.env.NODE_ENV !== "test";
+}
+
+function buildTelegramClientOptionsCacheKey(params: {
+  account: ResolvedTelegramAccount;
+  timeoutSeconds?: number;
+}): string {
+  const proxyKey = params.account.config.proxy?.trim() ?? "";
+  const autoSelectFamily = params.account.config.network?.autoSelectFamily;
+  const autoSelectFamilyKey =
+    typeof autoSelectFamily === "boolean" ? String(autoSelectFamily) : "default";
+  const dnsResultOrderKey = params.account.config.network?.dnsResultOrder ?? "default";
+  const timeoutSecondsKey =
+    typeof params.timeoutSeconds === "number" ? String(params.timeoutSeconds) : "default";
+  return `${params.account.accountId}::${proxyKey}::${autoSelectFamilyKey}::${dnsResultOrderKey}::${timeoutSecondsKey}`;
+}
+
+function setCachedTelegramClientOptions(
+  cacheKey: string,
+  clientOptions: ApiClientOptions | undefined,
+): ApiClientOptions | undefined {
+  telegramClientOptionsCache.set(cacheKey, clientOptions);
+  if (telegramClientOptionsCache.size > MAX_TELEGRAM_CLIENT_OPTIONS_CACHE_SIZE) {
+    const oldestKey = telegramClientOptionsCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      telegramClientOptionsCache.delete(oldestKey);
+    }
+  }
+  return clientOptions;
+}
+
 function resolveTelegramClientOptions(
   account: ResolvedTelegramAccount,
 ): ApiClientOptions | undefined {
-  const proxyUrl = account.config.proxy?.trim();
-  const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : undefined;
-  const fetchImpl = resolveTelegramFetch(proxyFetch, {
-    network: account.config.network,
-  });
   const timeoutSeconds =
     typeof account.config.timeoutSeconds === "number" &&
     Number.isFinite(account.config.timeoutSeconds)
       ? Math.max(1, Math.floor(account.config.timeoutSeconds))
       : undefined;
-  return fetchImpl || timeoutSeconds
-    ? {
-        ...(fetchImpl ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] } : {}),
-        ...(timeoutSeconds ? { timeoutSeconds } : {}),
-      }
-    : undefined;
+
+  const cacheEnabled = shouldUseTelegramClientOptionsCache();
+  const cacheKey = cacheEnabled
+    ? buildTelegramClientOptionsCacheKey({
+        account,
+        timeoutSeconds,
+      })
+    : null;
+  if (cacheKey && telegramClientOptionsCache.has(cacheKey)) {
+    return telegramClientOptionsCache.get(cacheKey);
+  }
+
+  const proxyUrl = account.config.proxy?.trim();
+  const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : undefined;
+  const fetchImpl = resolveTelegramFetch(proxyFetch, {
+    network: account.config.network,
+  });
+  const clientOptions =
+    fetchImpl || timeoutSeconds
+      ? {
+          ...(fetchImpl ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] } : {}),
+          ...(timeoutSeconds ? { timeoutSeconds } : {}),
+        }
+      : undefined;
+  if (cacheKey) {
+    return setCachedTelegramClientOptions(cacheKey, clientOptions);
+  }
+  return clientOptions;
 }
 
 function resolveToken(explicit: string | undefined, params: { accountId: string; token: string }) {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -80,6 +80,7 @@ type TelegramMessageLike = {
 };
 
 type TelegramReactionOpts = {
+  cfg?: ReturnType<typeof loadConfig>;
   token?: string;
   accountId?: string;
   api?: TelegramApiOverride;
@@ -821,6 +822,7 @@ export async function reactMessageTelegram(
 }
 
 type TelegramDeleteOpts = {
+  cfg?: ReturnType<typeof loadConfig>;
   token?: string;
   accountId?: string;
   verbose?: boolean;
@@ -980,6 +982,7 @@ function inferFilename(kind: MediaKind) {
 }
 
 type TelegramStickerOpts = {
+  cfg?: ReturnType<typeof loadConfig>;
   token?: string;
   accountId?: string;
   verbose?: boolean;
@@ -1178,9 +1181,10 @@ export async function sendPollTelegram(
 // ---------------------------------------------------------------------------
 
 type TelegramCreateForumTopicOpts = {
+  cfg?: ReturnType<typeof loadConfig>;
   token?: string;
   accountId?: string;
-  api?: Bot["api"];
+  api?: TelegramApiOverride;
   verbose?: boolean;
   retry?: RetryConfig;
   /** Icon color for the topic (must be one of 0x6FB9F0, 0xFFD67E, 0xCB86DB, 0x8EEE98, 0xFF93B2, 0xFB6F5F). */
@@ -1216,16 +1220,9 @@ export async function createForumTopicTelegram(
     throw new Error("Forum topic name must be 128 characters or fewer");
   }
 
-  const cfg = loadConfig();
-  const account = resolveTelegramAccount({
-    cfg,
-    accountId: opts.accountId,
-  });
-  const token = resolveToken(opts.token, account);
+  const { cfg, account, api } = resolveTelegramApiContext(opts);
   // Accept topic-qualified targets (e.g. telegram:group:<id>:topic:<thread>)
   // but createForumTopic must always target the base supergroup chat id.
-  const client = resolveTelegramClientOptions(account);
-  const api = opts.api ?? new Bot(token, client ? { client } : undefined).api;
   const target = parseTelegramTarget(chatId);
   const normalizedChatId = await resolveAndPersistChatId({
     cfg,


### PR DESCRIPTION
## Cherry-picks from upstream (issue #929)

9 commits cherry-picked, 8 skipped (all substantive changes in gutted layers).

| Hash | Subject | Result |
|------|---------|--------|
| 25c2facc2 | fix(agents): fix Brave llm-context empty snippets | SKIPPED — web-search files gutted |
| 96e497592 | fix: protect bootstrap files during memory flush | PICKED (partial) — fs-safe append support |
| cf9db91b6 | fix(web-search): recover OpenRouter Perplexity citations | SKIPPED — web-search files gutted |
| 3495563cf | fix(sandbox): pass real workspace to sessions_spawn | PICKED (partial) — spawnWorkspaceDir in remoteclaw-tools |
| aca216bfc | feat(acp): add resumeSessionId to sessions_spawn | SKIPPED — ACP subsystem gutted |
| 048e25c2b | fix(agents): avoid duplicate cooldown probes | SKIPPED — model-fallback files gutted |
| 309162f9a | fix: strip leaked model control tokens | PICKED (partial) — agent-utils + sessions-helpers |
| bfeea5d23 | fix(agents): prevent /v1beta duplication in Gemini PDF URL | SKIPPED — PDF tool files gutted |
| c2d938679 | fix: log auth profile resolution failures | SKIPPED — model-auth files gutted |
| 0687e0476 | fix: thread runtime config through Discord/Telegram sends | RESOLVED — OpenClawConfig→RemoteClawConfig, conflicts in client.ts/reply-delivery.ts/manager.ts |
| bda63c3c7 | fix(mattermost): preserve markdown formatting and native tables | RESOLVED — CHANGELOG conflict only |
| f0eb67923 | fix(secrets): resolve web tool SecretRefs atomically | PICKED (partial) — types.tools.ts SecretInput + docs |
| 382287026 | cron: record lastErrorReason in job state | RESOLVED — import conflict in conformance test |
| d1a59557b | fix(security): harden replaceMarkers() boundary markers | RESOLVED — CHANGELOG + gutted wrapWebContent tests |
| 45b74fb56 | fix(telegram): move network fallback to resolver-scoped dispatchers | RESOLVED — took theirs for refactored fetch.ts |
| 59bc3c663 | Agents: align onPayload callback and OAuth imports | SKIPPED — all alive files gutted |
| ac88a39ac | fix: align pi-ai 0.57.1 oauth imports and payload hooks | SKIPPED — all alive files gutted |

Closes #929