### PR TITLE
Cherry-pick batch: Feishu adapter (2/2) (5 commits)

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -22,6 +22,45 @@ export type DownloadMessageResourceResult = {
   fileName?: string;
 };
 
+function createConfiguredFeishuMediaClient(params: { cfg: ClawdbotConfig; accountId?: string }): {
+  account: ReturnType<typeof resolveFeishuAccount>;
+  client: ReturnType<typeof createFeishuClient>;
+} {
+  const account = resolveFeishuAccount({ cfg: params.cfg, accountId: params.accountId });
+  if (!account.configured) {
+    throw new Error(`Feishu account "${account.accountId}" not configured`);
+  }
+
+  return {
+    account,
+    client: createFeishuClient({
+      ...account,
+      httpTimeoutMs: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
+    }),
+  };
+}
+
+function extractFeishuUploadKey(
+  response: unknown,
+  params: {
+    key: "image_key" | "file_key";
+    errorPrefix: string;
+  },
+): string {
+  // SDK v1.30+ returns data directly without code wrapper on success.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK response type
+  const responseAny = response as any;
+  if (responseAny.code !== undefined && responseAny.code !== 0) {
+    throw new Error(`${params.errorPrefix}: ${responseAny.msg || `code ${responseAny.code}`}`);
+  }
+
+  const key = responseAny[params.key] ?? responseAny.data?.[params.key];
+  if (!key) {
+    throw new Error(`${params.errorPrefix}: no ${params.key} returned`);
+  }
+  return key;
+}
+
 async function readFeishuResponseBuffer(params: {
   response: unknown;
   tmpDirPrefix: string;
@@ -94,12 +133,7 @@ export async function downloadImageFeishu(params: {
   if (!normalizedImageKey) {
     throw new Error("Feishu image download failed: invalid image_key");
   }
-  const account = resolveFeishuAccount({ cfg, accountId });
-  if (!account.configured) {
-    throw new Error(`Feishu account "${account.accountId}" not configured`);
-  }
-
-  const client = createFeishuClient(account);
+  const { client } = createConfiguredFeishuMediaClient({ cfg, accountId });
 
   const response = await client.im.image.get({
     path: { image_key: normalizedImageKey },
@@ -129,12 +163,7 @@ export async function downloadMessageResourceFeishu(params: {
   if (!normalizedFileKey) {
     throw new Error("Feishu message resource download failed: invalid file_key");
   }
-  const account = resolveFeishuAccount({ cfg, accountId });
-  if (!account.configured) {
-    throw new Error(`Feishu account "${account.accountId}" not configured`);
-  }
-
-  const client = createFeishuClient(account);
+  const { client } = createConfiguredFeishuMediaClient({ cfg, accountId });
 
   const response = await client.im.messageResource.get({
     path: { message_id: messageId, file_key: normalizedFileKey },
@@ -173,12 +202,7 @@ export async function uploadImageFeishu(params: {
   accountId?: string;
 }): Promise<UploadImageResult> {
   const { cfg, image, imageType = "message", accountId } = params;
-  const account = resolveFeishuAccount({ cfg, accountId });
-  if (!account.configured) {
-    throw new Error(`Feishu account "${account.accountId}" not configured`);
-  }
-
-  const client = createFeishuClient(account);
+  const { client } = createConfiguredFeishuMediaClient({ cfg, accountId });
 
   // SDK accepts Buffer directly or fs.ReadStream for file paths
   // Using Readable.from(buffer) causes issues with form-data library
@@ -193,20 +217,12 @@ export async function uploadImageFeishu(params: {
     },
   });
 
-  // SDK v1.30+ returns data directly without code wrapper on success
-  // On error, it throws or returns { code, msg }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK response type
-  const responseAny = response as any;
-  if (responseAny.code !== undefined && responseAny.code !== 0) {
-    throw new Error(`Feishu image upload failed: ${responseAny.msg || `code ${responseAny.code}`}`);
-  }
-
-  const imageKey = responseAny.image_key ?? responseAny.data?.image_key;
-  if (!imageKey) {
-    throw new Error("Feishu image upload failed: no image_key returned");
-  }
-
-  return { imageKey };
+  return {
+    imageKey: extractFeishuUploadKey(response, {
+      key: "image_key",
+      errorPrefix: "Feishu image upload failed",
+    }),
+  };
 }
 
 /**
@@ -236,12 +252,7 @@ export async function uploadFileFeishu(params: {
   accountId?: string;
 }): Promise<UploadFileResult> {
   const { cfg, file, fileName, fileType, duration, accountId } = params;
-  const account = resolveFeishuAccount({ cfg, accountId });
-  if (!account.configured) {
-    throw new Error(`Feishu account "${account.accountId}" not configured`);
-  }
-
-  const client = createFeishuClient(account);
+  const { client } = createConfiguredFeishuMediaClient({ cfg, accountId });
 
   // SDK accepts Buffer directly or fs.ReadStream for file paths
   // Using Readable.from(buffer) causes issues with form-data library
@@ -260,19 +271,12 @@ export async function uploadFileFeishu(params: {
     },
   });
 
-  // SDK v1.30+ returns data directly without code wrapper on success
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK response type
-  const responseAny = response as any;
-  if (responseAny.code !== undefined && responseAny.code !== 0) {
-    throw new Error(`Feishu file upload failed: ${responseAny.msg || `code ${responseAny.code}`}`);
-  }
-
-  const fileKey = responseAny.file_key ?? responseAny.data?.file_key;
-  if (!fileKey) {
-    throw new Error("Feishu file upload failed: no file_key returned");
-  }
-
-  return { fileKey };
+  return {
+    fileKey: extractFeishuUploadKey(response, {
+      key: "file_key",
+      errorPrefix: "Feishu file upload failed",
+    }),
+  };
 }
 
 /**

--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -25,6 +25,16 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
   const replyMock = vi.fn();
   const createMock = vi.fn();
 
+  async function expectFallbackResult(
+    send: () => Promise<{ messageId?: string }>,
+    expectedMessageId: string,
+  ) {
+    const result = await send();
+    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(result.messageId).toBe(expectedMessageId);
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     resolveFeishuSendTargetMock.mockReturnValue({
@@ -51,16 +61,16 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
       data: { message_id: "om_new" },
     });
 
-    const result = await sendMessageFeishu({
-      cfg: {} as never,
-      to: "user:ou_target",
-      text: "hello",
-      replyToMessageId: "om_parent",
-    });
-
-    expect(replyMock).toHaveBeenCalledTimes(1);
-    expect(createMock).toHaveBeenCalledTimes(1);
-    expect(result.messageId).toBe("om_new");
+    await expectFallbackResult(
+      () =>
+        sendMessageFeishu({
+          cfg: {} as never,
+          to: "user:ou_target",
+          text: "hello",
+          replyToMessageId: "om_parent",
+        }),
+      "om_new",
+    );
   });
 
   it("falls back to create for withdrawn card replies", async () => {
@@ -73,16 +83,16 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
       data: { message_id: "om_card_new" },
     });
 
-    const result = await sendCardFeishu({
-      cfg: {} as never,
-      to: "user:ou_target",
-      card: { schema: "2.0" },
-      replyToMessageId: "om_parent",
-    });
-
-    expect(replyMock).toHaveBeenCalledTimes(1);
-    expect(createMock).toHaveBeenCalledTimes(1);
-    expect(result.messageId).toBe("om_card_new");
+    await expectFallbackResult(
+      () =>
+        sendCardFeishu({
+          cfg: {} as never,
+          to: "user:ou_target",
+          card: { schema: "2.0" },
+          replyToMessageId: "om_parent",
+        }),
+      "om_card_new",
+    );
   });
 
   it("still throws for non-withdrawn reply failures", async () => {
@@ -111,16 +121,16 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
       data: { message_id: "om_thrown_fallback" },
     });
 
-    const result = await sendMessageFeishu({
-      cfg: {} as never,
-      to: "user:ou_target",
-      text: "hello",
-      replyToMessageId: "om_parent",
-    });
-
-    expect(replyMock).toHaveBeenCalledTimes(1);
-    expect(createMock).toHaveBeenCalledTimes(1);
-    expect(result.messageId).toBe("om_thrown_fallback");
+    await expectFallbackResult(
+      () =>
+        sendMessageFeishu({
+          cfg: {} as never,
+          to: "user:ou_target",
+          text: "hello",
+          replyToMessageId: "om_parent",
+        }),
+      "om_thrown_fallback",
+    );
   });
 
   it("falls back to create when card reply throws a not-found AxiosError", async () => {
@@ -133,16 +143,16 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
       data: { message_id: "om_axios_fallback" },
     });
 
-    const result = await sendCardFeishu({
-      cfg: {} as never,
-      to: "user:ou_target",
-      card: { schema: "2.0" },
-      replyToMessageId: "om_parent",
-    });
-
-    expect(replyMock).toHaveBeenCalledTimes(1);
-    expect(createMock).toHaveBeenCalledTimes(1);
-    expect(result.messageId).toBe("om_axios_fallback");
+    await expectFallbackResult(
+      () =>
+        sendCardFeishu({
+          cfg: {} as never,
+          to: "user:ou_target",
+          card: { schema: "2.0" },
+          replyToMessageId: "om_parent",
+        }),
+      "om_axios_fallback",
+    );
   });
 
   it("re-throws non-withdrawn thrown errors for text messages", async () => {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -58,6 +58,10 @@ function isWithdrawnReplyError(err: unknown): boolean {
 type FeishuCreateMessageClient = {
   im: {
     message: {
+      reply: (opts: {
+        path: { message_id: string };
+        data: { content: string; msg_type: string; reply_in_thread?: true };
+      }) => Promise<{ code?: number; msg?: string; data?: { message_id?: string } }>;
       create: (opts: {
         params: { receive_id_type: "chat_id" | "email" | "open_id" | "union_id" | "user_id" };
         data: { receive_id: string; content: string; msg_type: string };
@@ -112,6 +116,50 @@ async function sendFallbackDirect(
   });
   assertFeishuMessageApiSuccess(response, errorPrefix);
   return toFeishuSendResult(response, params.receiveId);
+}
+
+async function sendReplyOrFallbackDirect(
+  client: FeishuCreateMessageClient,
+  params: {
+    replyToMessageId?: string;
+    replyInThread?: boolean;
+    content: string;
+    msgType: string;
+    directParams: {
+      receiveId: string;
+      receiveIdType: "chat_id" | "email" | "open_id" | "union_id" | "user_id";
+      content: string;
+      msgType: string;
+    };
+    directErrorPrefix: string;
+    replyErrorPrefix: string;
+  },
+): Promise<FeishuSendResult> {
+  if (!params.replyToMessageId) {
+    return sendFallbackDirect(client, params.directParams, params.directErrorPrefix);
+  }
+
+  let response: { code?: number; msg?: string; data?: { message_id?: string } };
+  try {
+    response = await client.im.message.reply({
+      path: { message_id: params.replyToMessageId },
+      data: {
+        content: params.content,
+        msg_type: params.msgType,
+        ...(params.replyInThread ? { reply_in_thread: true } : {}),
+      },
+    });
+  } catch (err) {
+    if (!isWithdrawnReplyError(err)) {
+      throw err;
+    }
+    return sendFallbackDirect(client, params.directParams, params.directErrorPrefix);
+  }
+  if (shouldFallbackFromReplyTarget(response)) {
+    return sendFallbackDirect(client, params.directParams, params.directErrorPrefix);
+  }
+  assertFeishuMessageApiSuccess(response, params.replyErrorPrefix);
+  return toFeishuSendResult(response, params.directParams.receiveId);
 }
 
 function parseInteractiveCardContent(parsed: unknown): string {
@@ -400,32 +448,15 @@ export async function sendMessageFeishu(
   const { content, msgType } = buildFeishuPostMessagePayload({ messageText });
 
   const directParams = { receiveId, receiveIdType, content, msgType };
-
-  if (replyToMessageId) {
-    let response: { code?: number; msg?: string; data?: { message_id?: string } };
-    try {
-      response = await client.im.message.reply({
-        path: { message_id: replyToMessageId },
-        data: {
-          content,
-          msg_type: msgType,
-          ...(replyInThread ? { reply_in_thread: true } : {}),
-        },
-      });
-    } catch (err) {
-      if (!isWithdrawnReplyError(err)) {
-        throw err;
-      }
-      return sendFallbackDirect(client, directParams, "Feishu send failed");
-    }
-    if (shouldFallbackFromReplyTarget(response)) {
-      return sendFallbackDirect(client, directParams, "Feishu send failed");
-    }
-    assertFeishuMessageApiSuccess(response, "Feishu reply failed");
-    return toFeishuSendResult(response, receiveId);
-  }
-
-  return sendFallbackDirect(client, directParams, "Feishu send failed");
+  return sendReplyOrFallbackDirect(client, {
+    replyToMessageId,
+    replyInThread,
+    content,
+    msgType,
+    directParams,
+    directErrorPrefix: "Feishu send failed",
+    replyErrorPrefix: "Feishu reply failed",
+  });
 }
 
 export type SendFeishuCardParams = {
@@ -444,32 +475,15 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
   const content = JSON.stringify(card);
 
   const directParams = { receiveId, receiveIdType, content, msgType: "interactive" };
-
-  if (replyToMessageId) {
-    let response: { code?: number; msg?: string; data?: { message_id?: string } };
-    try {
-      response = await client.im.message.reply({
-        path: { message_id: replyToMessageId },
-        data: {
-          content,
-          msg_type: "interactive",
-          ...(replyInThread ? { reply_in_thread: true } : {}),
-        },
-      });
-    } catch (err) {
-      if (!isWithdrawnReplyError(err)) {
-        throw err;
-      }
-      return sendFallbackDirect(client, directParams, "Feishu card send failed");
-    }
-    if (shouldFallbackFromReplyTarget(response)) {
-      return sendFallbackDirect(client, directParams, "Feishu card send failed");
-    }
-    assertFeishuMessageApiSuccess(response, "Feishu card reply failed");
-    return toFeishuSendResult(response, receiveId);
-  }
-
-  return sendFallbackDirect(client, directParams, "Feishu card send failed");
+  return sendReplyOrFallbackDirect(client, {
+    replyToMessageId,
+    replyInThread,
+    content,
+    msgType: "interactive",
+    directParams,
+    directErrorPrefix: "Feishu card send failed",
+    replyErrorPrefix: "Feishu card reply failed",
+  });
 }
 
 export async function updateCardFeishu(params: {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -236,34 +236,7 @@ export async function getMessageFeishu(params: {
   try {
     const response = (await client.im.message.get({
       path: { message_id: messageId },
-    })) as {
-      code?: number;
-      msg?: string;
-      data?: {
-        items?: Array<{
-          message_id?: string;
-          chat_id?: string;
-          msg_type?: string;
-          body?: { content?: string };
-          sender?: {
-            id?: string;
-            id_type?: string;
-            sender_type?: string;
-          };
-          create_time?: string;
-        }>;
-        message_id?: string;
-        chat_id?: string;
-        msg_type?: string;
-        body?: { content?: string };
-        sender?: {
-          id?: string;
-          id_type?: string;
-          sender_type?: string;
-        };
-        create_time?: string;
-      };
-    };
+    })) as FeishuGetMessageResponse;
 
     if (response.code !== 0) {
       return null;


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #1876
**Commits**: 3 cherry-picked, 2 skipped (already applied)

| # | Hash | Subject | Result |
|---|------|---------|--------|
| 1 | `de9ea76b6c` | refactor: dedupe feishu send reply fallback helpers | RESOLVED |
| 2 | `e358d57fb5` | refactor: share feishu reply fallback flow | PICKED |
| 3 | `e5a42c0bec` | fix(feishu): keep sender-scoped thread bootstrap across id types (#46651) | SKIPPED |
| 4 | `f4a2bbe0c9` | fix(feishu): add early event-level dedup to prevent duplicate replies (#43762) | SKIPPED |
| 5 | `fb40b09157` | refactor: share feishu media client setup | RESOLVED |

Closes #1876

🤖 Generated with [Claude Code](https://claude.com/claude-code)