### PR TITLE
Cherry-pick batch: Cron subsystem improvements (16 commits) (#1902)

### DIFF
--- a/src/cron/isolated-agent.delivery-target-thread-session.test.ts
+++ b/src/cron/isolated-agent.delivery-target-thread-session.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { parseTelegramTarget } from "../../extensions/telegram/src/targets.js";
 import type { RemoteClawConfig } from "../config/config.js";
 
 // Mock session store so we can control what entries exist.
@@ -19,6 +20,16 @@ vi.mock("../channels/plugins/index.js", () => ({
   getChannelPlugin: vi.fn(() => ({
     meta: { label: "Telegram" },
     config: {},
+    messaging: {
+      parseExplicitTarget: ({ raw }: { raw: string }) => {
+        const target = parseTelegramTarget(raw);
+        return {
+          to: target.chatId,
+          threadId: target.messageThreadId,
+          chatType: target.chatType === "unknown" ? undefined : target.chatType,
+        };
+      },
+    },
     outbound: {
       resolveTarget: ({ to }: { to?: string }) =>
         to ? { ok: true, to } : { ok: false, error: new Error("missing") },

--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { resolveCronPayloadOutcome } from "./isolated-agent/helpers.js";
+
+describe("resolveCronPayloadOutcome", () => {
+  it("uses the last non-empty non-error payload as summary and output", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [{ text: "first" }, { text: " " }, { text: " last " }],
+    });
+
+    expect(result.summary).toBe("last");
+    expect(result.outputText).toBe("last");
+    expect(result.hasFatalErrorPayload).toBe(false);
+  });
+
+  it("returns a fatal error from the last error payload when no success follows", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        {
+          text: "⚠️ 🛠️ Exec failed: /bin/bash: line 1: python: command not found",
+          isError: true,
+        },
+      ],
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(true);
+    expect(result.embeddedRunError).toContain("command not found");
+    expect(result.summary).toContain("Exec failed");
+  });
+
+  it("treats transient error payloads as non-fatal when a later success exists", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "⚠️ ✍️ Write: failed", isError: true },
+        { text: "Write completed successfully.", isError: false },
+      ],
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(false);
+    expect(result.summary).toBe("Write completed successfully.");
+  });
+
+  it("keeps error payloads fatal when the run also reported a run-level error", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "Model context overflow", isError: true },
+        { text: "Partial assistant text before error" },
+      ],
+      runLevelError: { kind: "context_overflow", message: "exceeded context window" },
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(true);
+    expect(result.embeddedRunError).toContain("Model context overflow");
+  });
+
+  it("truncates long summaries", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [{ text: "a".repeat(2001) }],
+    });
+
+    expect(String(result.summary ?? "")).toMatch(/…$/);
+  });
+});

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -59,6 +59,23 @@ function setMainSessionEntry(entry?: SessionStore[string]) {
   vi.mocked(loadSessionStore).mockReturnValue(store);
 }
 
+function setLastSessionEntry(params: {
+  sessionId: string;
+  lastChannel: string;
+  lastTo: string;
+  lastThreadId?: string;
+  lastAccountId?: string;
+}) {
+  setMainSessionEntry({
+    sessionId: params.sessionId,
+    updatedAt: 1000,
+    lastChannel: params.lastChannel,
+    lastTo: params.lastTo,
+    ...(params.lastThreadId ? { lastThreadId: params.lastThreadId } : {}),
+    ...(params.lastAccountId ? { lastAccountId: params.lastAccountId } : {}),
+  });
+}
+
 function setWhatsAppAllowFrom(allowFrom: string[]) {
   vi.mocked(resolveWhatsAppAccount).mockReturnValue({
     allowFrom,
@@ -81,11 +98,17 @@ async function resolveForAgent(params: {
   });
 }
 
+async function resolveLastTarget(cfg: OpenClawConfig) {
+  return resolveForAgent({
+    cfg,
+    target: { channel: "last", to: undefined },
+  });
+}
+
 describe("resolveDeliveryTarget", () => {
   it("reroutes implicit whatsapp delivery to authorized allowFrom recipient", async () => {
-    setMainSessionEntry({
+    setLastSessionEntry({
       sessionId: "sess-w1",
-      updatedAt: 1000,
       lastChannel: "whatsapp",
       lastTo: "+15550000099",
     });
@@ -93,16 +116,15 @@ describe("resolveDeliveryTarget", () => {
     setStoredWhatsAppAllowFrom(["+15550000001"]);
 
     const cfg = makeCfg({ bindings: [] });
-    const result = await resolveDeliveryTarget(cfg, AGENT_ID, { channel: "last", to: undefined });
+    const result = await resolveLastTarget(cfg);
 
     expect(result.channel).toBe("whatsapp");
     expect(result.to).toBe("+15550000001");
   });
 
   it("keeps explicit whatsapp target unchanged", async () => {
-    setMainSessionEntry({
+    setLastSessionEntry({
       sessionId: "sess-w2",
-      updatedAt: 1000,
       lastChannel: "whatsapp",
       lastTo: "+15550000099",
     });
@@ -191,9 +213,8 @@ describe("resolveDeliveryTarget", () => {
   });
 
   it("drops session threadId when destination does not match the previous recipient", async () => {
-    setMainSessionEntry({
+    setLastSessionEntry({
       sessionId: "sess-2",
-      updatedAt: 1000,
       lastChannel: "telegram",
       lastTo: "999999",
       lastThreadId: "thread-1",
@@ -204,9 +225,8 @@ describe("resolveDeliveryTarget", () => {
   });
 
   it("keeps session threadId when destination matches the previous recipient", async () => {
-    setMainSessionEntry({
+    setLastSessionEntry({
       sessionId: "sess-3",
-      updatedAt: 1000,
       lastChannel: "telegram",
       lastTo: "123456",
       lastThreadId: "thread-2",
@@ -219,10 +239,7 @@ describe("resolveDeliveryTarget", () => {
   it("uses single configured channel when neither explicit nor session channel exists", async () => {
     setMainSessionEntry(undefined);
 
-    const result = await resolveForAgent({
-      cfg: makeCfg({ bindings: [] }),
-      target: { channel: "last", to: undefined },
-    });
+    const result = await resolveLastTarget(makeCfg({ bindings: [] }));
     expect(result.channel).toBe("telegram");
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -239,10 +256,7 @@ describe("resolveDeliveryTarget", () => {
       new Error("Channel is required when multiple channels are configured: telegram, slack"),
     );
 
-    const result = await resolveForAgent({
-      cfg: makeCfg({ bindings: [] }),
-      target: { channel: "last", to: undefined },
-    });
+    const result = await resolveLastTarget(makeCfg({ bindings: [] }));
     expect(result.channel).toBeUndefined();
     expect(result.to).toBeUndefined();
     expect(result.ok).toBe(false);
@@ -279,17 +293,13 @@ describe("resolveDeliveryTarget", () => {
   });
 
   it("uses main session channel when channel=last and session route exists", async () => {
-    setMainSessionEntry({
+    setLastSessionEntry({
       sessionId: "sess-4",
-      updatedAt: 1000,
       lastChannel: "telegram",
       lastTo: "987654",
     });
 
-    const result = await resolveForAgent({
-      cfg: makeCfg({ bindings: [] }),
-      target: { channel: "last", to: undefined },
-    });
+    const result = await resolveLastTarget(makeCfg({ bindings: [] }));
 
     expect(result.channel).toBe("telegram");
     expect(result.to).toBe("987654");
@@ -297,9 +307,8 @@ describe("resolveDeliveryTarget", () => {
   });
 
   it("explicit delivery.accountId overrides session-derived accountId", async () => {
-    setMainSessionEntry({
+    setLastSessionEntry({
       sessionId: "sess-5",
-      updatedAt: 1000,
       lastChannel: "telegram",
       lastTo: "chat-999",
       lastAccountId: "default",

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -8,6 +8,17 @@ type DeliveryPayload = Pick<
   "text" | "mediaUrl" | "mediaUrls" | "channelData" | "isError"
 >;
 
+export type CronPayloadOutcome = {
+  summary?: string;
+  outputText?: string;
+  synthesizedText?: string;
+  deliveryPayload?: DeliveryPayload;
+  deliveryPayloads: DeliveryPayload[];
+  deliveryPayloadHasStructuredContent: boolean;
+  hasFatalErrorPayload: boolean;
+  embeddedRunError?: string;
+};
+
 export function pickSummaryFromOutput(text: string | undefined) {
   const clean = (text ?? "").trim();
   if (!clean) {
@@ -93,4 +104,53 @@ export function isHeartbeatOnlyResponse(payloads: DeliveryPayload[], ackMaxChars
 export function resolveHeartbeatAckMaxChars(agentCfg?: { heartbeat?: { ackMaxChars?: number } }) {
   const raw = agentCfg?.heartbeat?.ackMaxChars ?? DEFAULT_HEARTBEAT_ACK_MAX_CHARS;
   return Math.max(0, raw);
+}
+
+export function resolveCronPayloadOutcome(params: {
+  payloads: DeliveryPayload[];
+  runLevelError?: unknown;
+}): CronPayloadOutcome {
+  const firstText = params.payloads[0]?.text ?? "";
+  const summary = pickSummaryFromPayloads(params.payloads) ?? pickSummaryFromOutput(firstText);
+  const outputText = pickLastNonEmptyTextFromPayloads(params.payloads);
+  const synthesizedText = outputText?.trim() || summary?.trim() || undefined;
+  const deliveryPayload = pickLastDeliverablePayload(params.payloads);
+  const deliveryPayloads =
+    deliveryPayload !== undefined
+      ? [deliveryPayload]
+      : synthesizedText
+        ? [{ text: synthesizedText }]
+        : [];
+  const deliveryPayloadHasStructuredContent =
+    deliveryPayload?.mediaUrl !== undefined ||
+    (deliveryPayload?.mediaUrls?.length ?? 0) > 0 ||
+    (deliveryPayload?.interactive?.blocks?.length ?? 0) > 0 ||
+    Object.keys(deliveryPayload?.channelData ?? {}).length > 0;
+  const hasErrorPayload = params.payloads.some((payload) => payload?.isError === true);
+  const lastErrorPayloadIndex = params.payloads.findLastIndex(
+    (payload) => payload?.isError === true,
+  );
+  const hasSuccessfulPayloadAfterLastError =
+    !params.runLevelError &&
+    lastErrorPayloadIndex >= 0 &&
+    params.payloads
+      .slice(lastErrorPayloadIndex + 1)
+      .some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
+  const hasFatalErrorPayload = hasErrorPayload && !hasSuccessfulPayloadAfterLastError;
+  const lastErrorPayloadText = [...params.payloads]
+    .toReversed()
+    .find((payload) => payload?.isError === true && Boolean(payload?.text?.trim()))
+    ?.text?.trim();
+  return {
+    summary,
+    outputText,
+    synthesizedText,
+    deliveryPayload,
+    deliveryPayloads,
+    deliveryPayloadHasStructuredContent,
+    hasFatalErrorPayload,
+    embeddedRunError: hasFatalErrorPayload
+      ? (lastErrorPayloadText ?? "cron isolated run returned an error payload")
+      : undefined,
+  };
 }

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -43,6 +43,7 @@ export const logWarnMock = createMock();
 export const countActiveDescendantRunsMock = createMock();
 export const listDescendantRunsForRequesterMock = createMock();
 export const pickLastNonEmptyTextFromPayloadsMock = createMock();
+export const resolveCronPayloadOutcomeMock = createMock();
 export const resolveCronDeliveryPlanMock = createMock();
 export const resolveDeliveryTargetMock = createMock();
 
@@ -189,6 +190,7 @@ vi.mock("./helpers.js", () => ({
   pickLastNonEmptyTextFromPayloads: pickLastNonEmptyTextFromPayloadsMock,
   pickSummaryFromOutput: vi.fn().mockReturnValue("summary"),
   pickSummaryFromPayloads: vi.fn().mockReturnValue("summary"),
+  resolveCronPayloadOutcome: resolveCronPayloadOutcomeMock,
   resolveHeartbeatAckMaxChars: vi.fn().mockReturnValue(100),
 }));
 
@@ -287,6 +289,26 @@ export function resetRunCronIsolatedAgentTurnHarness(): void {
   listDescendantRunsForRequesterMock.mockReturnValue([]);
   pickLastNonEmptyTextFromPayloadsMock.mockReset();
   pickLastNonEmptyTextFromPayloadsMock.mockReturnValue("test output");
+  resolveCronPayloadOutcomeMock.mockReset();
+  resolveCronPayloadOutcomeMock.mockImplementation(
+    ({ payloads }: { payloads: Array<{ isError?: boolean }> }) => {
+      const outputText = pickLastNonEmptyTextFromPayloadsMock(payloads);
+      const synthesizedText = outputText?.trim() || "summary";
+      const hasFatalErrorPayload = payloads.some((payload) => payload?.isError === true);
+      return {
+        summary: "summary",
+        outputText,
+        synthesizedText,
+        deliveryPayload: undefined,
+        deliveryPayloads: synthesizedText ? [{ text: synthesizedText }] : [],
+        deliveryPayloadHasStructuredContent: false,
+        hasFatalErrorPayload,
+        embeddedRunError: hasFatalErrorPayload
+          ? "cron isolated run returned an error payload"
+          : undefined,
+      };
+    },
+  );
   resolveCronDeliveryPlanMock.mockReset();
   resolveCronDeliveryPlanMock.mockReturnValue({ requested: false, mode: "none" });
   resolveDeliveryTargetMock.mockReset();

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -48,10 +48,9 @@ import {
 } from "./delivery-dispatch.js";
 import { resolveDeliveryTarget } from "./delivery-target.js";
 import {
-  pickLastDeliverablePayload,
-  pickLastNonEmptyTextFromPayloads,
-  pickSummaryFromOutput,
-  pickSummaryFromPayloads,
+  isHeartbeatOnlyResponse,
+  resolveCronPayloadOutcome,
+  resolveHeartbeatAckMaxChars,
 } from "./helpers.js";
 import { resolveCronAgentSessionKey } from "./session-key.js";
 import { resolveCronSession } from "./session.js";
@@ -515,13 +514,16 @@ export async function runCronIsolatedAgentTurn(params: {
     // (e.g. "on it") and no descendants are active, run one focused follow-up
     // turn so the cron run returns an actual completion.
     if (!isAborted()) {
-      const interimPayloads = runResult.payloads ?? [];
-      const interimDeliveryPayload = pickLastDeliverablePayload(interimPayloads);
-      const interimPayloadHasStructuredContent =
-        Boolean(interimDeliveryPayload?.mediaUrl) ||
-        (interimDeliveryPayload?.mediaUrls?.length ?? 0) > 0 ||
-        Object.keys(interimDeliveryPayload?.channelData ?? {}).length > 0;
-      const interimText = pickLastNonEmptyTextFromPayloads(interimPayloads)?.trim() ?? "";
+      const interimRunResult = runResult;
+      const interimPayloads = interimRunResult.payloads ?? [];
+      const {
+        deliveryPayloadHasStructuredContent: interimPayloadHasStructuredContent,
+        outputText: interimOutputText,
+      } = resolveCronPayloadOutcome({
+        payloads: interimPayloads,
+        runLevelError: interimRunResult.meta?.error,
+      });
+      const interimText = interimOutputText?.trim() ?? "";
       const hasDescendantsSinceRunStart = listDescendantRunsForRequester(agentSessionKey).some(
         (entry) => {
           const descendantStartedAt =
@@ -635,42 +637,19 @@ export async function runCronIsolatedAgentTurn(params: {
   if (isAborted()) {
     return withRunSession({ status: "error", error: abortReason(), ...telemetry });
   }
-  const firstText = payloads[0]?.text ?? "";
-  let summary = pickSummaryFromPayloads(payloads) ?? pickSummaryFromOutput(firstText);
-  let outputText = pickLastNonEmptyTextFromPayloads(payloads);
-  let synthesizedText = outputText?.trim() || summary?.trim() || undefined;
-  const deliveryPayload = pickLastDeliverablePayload(payloads);
-  let deliveryPayloads =
-    deliveryPayload !== undefined
-      ? [deliveryPayload]
-      : synthesizedText
-        ? [{ text: synthesizedText }]
-        : [];
-  const deliveryPayloadHasStructuredContent =
-    Boolean(deliveryPayload?.mediaUrl) ||
-    (deliveryPayload?.mediaUrls?.length ?? 0) > 0 ||
-    Object.keys(deliveryPayload?.channelData ?? {}).length > 0;
+  let {
+    summary,
+    outputText,
+    synthesizedText,
+    deliveryPayloads,
+    deliveryPayloadHasStructuredContent,
+    hasFatalErrorPayload,
+    embeddedRunError,
+  } = resolveCronPayloadOutcome({
+    payloads,
+    runLevelError: finalRunResult.meta?.error,
+  });
   const deliveryBestEffort = resolveCronDeliveryBestEffort(params.job);
-  const hasErrorPayload = payloads.some((payload) => payload?.isError === true);
-  const runLevelError = runResult.error;
-  const lastErrorPayloadIndex = payloads.findLastIndex((payload) => payload?.isError === true);
-  const hasSuccessfulPayloadAfterLastError =
-    !runLevelError &&
-    lastErrorPayloadIndex >= 0 &&
-    payloads
-      .slice(lastErrorPayloadIndex + 1)
-      .some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
-  // Tool wrappers can emit transient/false-positive error payloads before a valid final
-  // assistant payload.  Only treat payload errors as recoverable when (a) the run itself
-  // did not report a model/context-level error and (b) a non-error payload follows.
-  const hasFatalErrorPayload = hasErrorPayload && !hasSuccessfulPayloadAfterLastError;
-  const lastErrorPayloadText = [...payloads]
-    .toReversed()
-    .find((payload) => payload?.isError === true && Boolean(payload?.text?.trim()))
-    ?.text?.trim();
-  const embeddedRunError = hasFatalErrorPayload
-    ? (lastErrorPayloadText ?? "cron isolated run returned an error payload")
-    : undefined;
   const resolveRunOutcome = (params?: { delivered?: boolean; deliveryAttempted?: boolean }) =>
     withRunSession({
       status: hasFatalErrorPayload ? "error" : "ok",

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -287,6 +287,13 @@ export async function runCronIsolatedAgentTurn(params: {
     ...params.cfg,
     agents: Object.assign({}, params.cfg.agents, { defaults: agentCfg }),
   };
+  let catalog: Awaited<ReturnType<typeof loadModelCatalog>> | undefined;
+  const loadCatalog = async () => {
+    if (!catalog) {
+      catalog = await loadModelCatalog({ config: cfgWithAgentDefaults });
+    }
+    return catalog;
+  };
 
   const baseSessionKey = (params.sessionKey?.trim() || `cron:${params.job.id}`).trim();
   const agentSessionKey = resolveCronAgentSessionKey({ sessionKey: baseSessionKey, agentId });

--- a/src/cron/isolated-agent/subagent-followup.test.ts
+++ b/src/cron/isolated-agent/subagent-followup.test.ts
@@ -33,6 +33,29 @@ async function resolveAfterAdvancingTimers<T>(promise: Promise<T>, advanceMs = 1
   return promise;
 }
 
+function createDescendantRun(params?: {
+  runId?: string;
+  childSessionKey?: string;
+  task?: string;
+  cleanup?: "keep" | "delete";
+  endedAt?: number;
+  frozenResultText?: string | null;
+}) {
+  return {
+    runId: params?.runId ?? "run-1",
+    childSessionKey: params?.childSessionKey ?? "child-1",
+    requesterSessionKey: "test-session",
+    requesterDisplayKey: "test-session",
+    task: params?.task ?? "task-1",
+    cleanup: params?.cleanup ?? "keep",
+    createdAt: 1000,
+    endedAt: params?.endedAt ?? 2000,
+    ...(params?.frozenResultText === undefined
+      ? {}
+      : { frozenResultText: params.frozenResultText }),
+  };
+}
+
 describe("isLikelyInterimCronMessage", () => {
   it("detects 'on it' as interim", () => {
     expect(isLikelyInterimCronMessage("on it")).toBe(true);
@@ -85,18 +108,7 @@ describe("readDescendantSubagentFallbackReply", () => {
   });
 
   it("reads reply from child session transcript", async () => {
-    vi.mocked(listDescendantRunsForRequester).mockReturnValue([
-      {
-        runId: "run-1",
-        childSessionKey: "child-1",
-        requesterSessionKey: "test-session",
-        requesterDisplayKey: "test-session",
-        task: "task-1",
-        cleanup: "keep",
-        createdAt: 1000,
-        endedAt: 2000,
-      },
-    ]);
+    vi.mocked(listDescendantRunsForRequester).mockReturnValue([createDescendantRun()]);
     vi.mocked(readLatestAssistantReply).mockResolvedValue("child output text");
     const result = await readDescendantSubagentFallbackReply({
       sessionKey: "test-session",
@@ -107,17 +119,10 @@ describe("readDescendantSubagentFallbackReply", () => {
 
   it("falls back to frozenResultText when session transcript unavailable", async () => {
     vi.mocked(listDescendantRunsForRequester).mockReturnValue([
-      {
-        runId: "run-1",
-        childSessionKey: "child-1",
-        requesterSessionKey: "test-session",
-        requesterDisplayKey: "test-session",
-        task: "task-1",
+      createDescendantRun({
         cleanup: "delete",
-        createdAt: 1000,
-        endedAt: 2000,
         frozenResultText: "frozen child output",
-      },
+      }),
     ]);
     vi.mocked(readLatestAssistantReply).mockResolvedValue(undefined);
     const result = await readDescendantSubagentFallbackReply({
@@ -129,17 +134,7 @@ describe("readDescendantSubagentFallbackReply", () => {
 
   it("prefers session transcript over frozenResultText", async () => {
     vi.mocked(listDescendantRunsForRequester).mockReturnValue([
-      {
-        runId: "run-1",
-        childSessionKey: "child-1",
-        requesterSessionKey: "test-session",
-        requesterDisplayKey: "test-session",
-        task: "task-1",
-        cleanup: "keep",
-        createdAt: 1000,
-        endedAt: 2000,
-        frozenResultText: "frozen text",
-      },
+      createDescendantRun({ frozenResultText: "frozen text" }),
     ]);
     vi.mocked(readLatestAssistantReply).mockResolvedValue("live transcript text");
     const result = await readDescendantSubagentFallbackReply({
@@ -151,28 +146,14 @@ describe("readDescendantSubagentFallbackReply", () => {
 
   it("joins replies from multiple descendants", async () => {
     vi.mocked(listDescendantRunsForRequester).mockReturnValue([
-      {
-        runId: "run-1",
-        childSessionKey: "child-1",
-        requesterSessionKey: "test-session",
-        requesterDisplayKey: "test-session",
-        task: "task-1",
-        cleanup: "keep",
-        createdAt: 1000,
-        endedAt: 2000,
-        frozenResultText: "first child output",
-      },
-      {
+      createDescendantRun({ frozenResultText: "first child output" }),
+      createDescendantRun({
         runId: "run-2",
         childSessionKey: "child-2",
-        requesterSessionKey: "test-session",
-        requesterDisplayKey: "test-session",
         task: "task-2",
-        cleanup: "keep",
-        createdAt: 1000,
         endedAt: 3000,
         frozenResultText: "second child output",
-      },
+      }),
     ]);
     vi.mocked(readLatestAssistantReply).mockResolvedValue(undefined);
     const result = await readDescendantSubagentFallbackReply({
@@ -184,27 +165,14 @@ describe("readDescendantSubagentFallbackReply", () => {
 
   it("skips SILENT_REPLY_TOKEN descendants", async () => {
     vi.mocked(listDescendantRunsForRequester).mockReturnValue([
-      {
-        runId: "run-1",
-        childSessionKey: "child-1",
-        requesterSessionKey: "test-session",
-        requesterDisplayKey: "test-session",
-        task: "task-1",
-        cleanup: "keep",
-        createdAt: 1000,
-        endedAt: 2000,
-      },
-      {
+      createDescendantRun(),
+      createDescendantRun({
         runId: "run-2",
         childSessionKey: "child-2",
-        requesterSessionKey: "test-session",
-        requesterDisplayKey: "test-session",
         task: "task-2",
-        cleanup: "keep",
-        createdAt: 1000,
         endedAt: 3000,
         frozenResultText: "useful output",
-      },
+      }),
     ]);
     vi.mocked(readLatestAssistantReply).mockImplementation(async (params) => {
       if (params.sessionKey === "child-1") {
@@ -221,17 +189,10 @@ describe("readDescendantSubagentFallbackReply", () => {
 
   it("returns undefined when frozenResultText is null", async () => {
     vi.mocked(listDescendantRunsForRequester).mockReturnValue([
-      {
-        runId: "run-1",
-        childSessionKey: "child-1",
-        requesterSessionKey: "test-session",
-        requesterDisplayKey: "test-session",
-        task: "task-1",
+      createDescendantRun({
         cleanup: "delete",
-        createdAt: 1000,
-        endedAt: 2000,
         frozenResultText: null,
-      },
+      }),
     ]);
     vi.mocked(readLatestAssistantReply).mockResolvedValue(undefined);
     const result = await readDescendantSubagentFallbackReply({

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -169,7 +169,7 @@ export async function waitForDescendantSubagentSummary(params: {
   // CRON_SUBAGENT_FINAL_REPLY_GRACE_MS) to capture that synthesis.
   const gracePeriodDeadline = Math.min(Date.now() + CRON_SUBAGENT_FINAL_REPLY_GRACE_MS, deadline);
 
-  while (Date.now() < gracePeriodDeadline) {
+  const resolveUsableLatestReply = async () => {
     const latest = (await readLatestAssistantReply({ sessionKey: params.sessionKey }))?.trim();
     if (
       latest &&
@@ -178,16 +178,20 @@ export async function waitForDescendantSubagentSummary(params: {
     ) {
       return latest;
     }
+    return undefined;
+  };
+
+  while (Date.now() < gracePeriodDeadline) {
+    const latest = await resolveUsableLatestReply();
+    if (latest) {
+      return latest;
+    }
     await new Promise<void>((resolve) => setTimeout(resolve, CRON_SUBAGENT_GRACE_POLL_MS));
   }
 
   // Final read after grace period expires.
-  const latest = (await readLatestAssistantReply({ sessionKey: params.sessionKey }))?.trim();
-  if (
-    latest &&
-    latest.toUpperCase() !== SILENT_REPLY_TOKEN.toUpperCase() &&
-    (latest !== initialReply || !isLikelyInterimCronMessage(latest))
-  ) {
+  const latest = await resolveUsableLatestReply();
+  if (latest) {
     return latest;
   }
 

--- a/src/cron/service.store-load-invalid-main-job.test.ts
+++ b/src/cron/service.store-load-invalid-main-job.test.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import {
+  createNoopLogger,
+  installCronTestHooks,
+  writeCronStoreSnapshot,
+} from "./service.test-harness.js";
+import type { CronJob } from "./types.js";
+
+const noopLogger = createNoopLogger();
+installCronTestHooks({ logger: noopLogger });
+
+async function makeStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-store-load-"));
+  return {
+    dir,
+    storePath: path.join(dir, "cron", "jobs.json"),
+  };
+}
+
+describe("CronService store load", () => {
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    if (!tempDir) {
+      return;
+    }
+    await fs.rm(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  });
+
+  it("skips invalid main jobs with agentTurn payloads loaded from disk", async () => {
+    const { dir, storePath } = await makeStorePath();
+    tempDir = dir;
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    const job = {
+      id: "job-1",
+      enabled: true,
+      createdAtMs: Date.parse("2025-12-13T00:00:00.000Z"),
+      updatedAtMs: Date.parse("2025-12-13T00:00:00.000Z"),
+      schedule: { kind: "at", at: "2025-12-13T00:00:01.000Z" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "bad" },
+      state: {},
+      name: "bad",
+    } satisfies CronJob;
+
+    await writeCronStoreSnapshot({ storePath, jobs: [job] });
+
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await cron.start();
+    vi.setSystemTime(new Date("2025-12-13T00:00:01.000Z"));
+    await cron.run("job-1", "due");
+
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(requestHeartbeatNow).not.toHaveBeenCalled();
+
+    const jobs = await cron.list({ includeDisabled: true });
+    expect(jobs[0]?.state.lastStatus).toBe("skipped");
+    expect(jobs[0]?.state.lastError).toMatch(/main job requires/i);
+
+    cron.stop();
+  });
+});

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -358,7 +358,53 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
       return { ok: true, ran: false, reason: "already-running" as const };
     }
     const now = state.deps.nowMs();
-    job.state.runningAtMs = now;
+    const due = isJobDue(job, now, { forced: mode === "force" });
+    if (!due) {
+      return { ok: true, ran: false, reason: "not-due" as const };
+    }
+    return { ok: true, runnable: true, job, now } as const;
+  });
+}
+
+async function inspectManualRunDisposition(
+  state: CronServiceState,
+  id: string,
+  mode?: "due" | "force",
+): Promise<ManualRunDisposition | { ok: false }> {
+  const result = await inspectManualRunPreflight(state, id, mode);
+  if (!result.ok) {
+    return result;
+  }
+  if ("reason" in result) {
+    return result;
+  }
+  return { ok: true, runnable: true } as const;
+}
+
+async function prepareManualRun(
+  state: CronServiceState,
+  id: string,
+  mode?: "due" | "force",
+): Promise<PreparedManualRun> {
+  const preflight = await inspectManualRunPreflight(state, id, mode);
+  if (!preflight.ok) {
+    return preflight;
+  }
+  if ("reason" in preflight) {
+    return {
+      ok: true,
+      ran: false,
+      reason: preflight.reason,
+    } as const;
+  }
+  return await locked(state, async () => {
+    // Reserve this run under lock, then execute outside lock so read ops
+    // (`list`, `status`) stay responsive while the run is in progress.
+    const job = findJobOrThrow(state, id);
+    if (typeof job.state.runningAtMs === "number") {
+      return { ok: true, ran: false, reason: "already-running" as const };
+    }
+    job.state.runningAtMs = preflight.now;
     job.state.lastError = undefined;
     // Persist the running marker before releasing lock so timer ticks that
     // force-reload from disk cannot start the same job concurrently.

--- a/src/hooks/gmail-watcher-errors.ts
+++ b/src/hooks/gmail-watcher-errors.ts
@@ -1,0 +1,5 @@
+const ADDRESS_IN_USE_RE = /address already in use|EADDRINUSE/i;
+
+export function isAddressInUseError(line: string): boolean {
+  return ADDRESS_IN_USE_RE.test(line);
+}

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -11,6 +11,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { hasBinary } from "../shared/config-eval.js";
 import { ensureTailscaleEndpoint } from "./gmail-setup-utils.js";
+import { isAddressInUseError } from "./gmail-watcher-errors.js";
 import {
   buildGogWatchServeArgs,
   buildGogWatchStartArgs,
@@ -19,12 +20,6 @@ import {
 } from "./gmail.js";
 
 const log = createSubsystemLogger("gmail-watcher");
-
-const ADDRESS_IN_USE_RE = /address already in use|EADDRINUSE/i;
-
-export function isAddressInUseError(line: string): boolean {
-  return ADDRESS_IN_USE_RE.test(line);
-}
 
 let watcherProcess: ChildProcess | null = null;
 let renewInterval: ReturnType<typeof setInterval> | null = null;

--- a/src/hooks/install.test.ts
+++ b/src/hooks/install.test.ts
@@ -10,7 +10,7 @@ import {
   expectUnsupportedNpmSpec,
   mockNpmPackMetadataResult,
 } from "../test-utils/npm-spec-install-test-helpers.js";
-import { isAddressInUseError } from "./gmail-watcher.js";
+import { isAddressInUseError } from "./gmail-watcher-errors.js";
 
 const fixtureRoot = path.join(os.tmpdir(), `remoteclaw-hook-install-${randomUUID()}`);
 const sharedArchiveDir = path.join(fixtureRoot, "_archives");

--- a/src/hooks/install.test.ts
+++ b/src/hooks/install.test.ts
@@ -381,10 +381,6 @@ describe("installHooksFromNpmSpec", () => {
     expect(fs.existsSync(packTmpDir)).toBe(false);
   });
 
-  it("rejects non-registry npm specs", async () => {
-    await expectUnsupportedNpmSpec((spec) => installHooksFromNpmSpec({ spec }));
-  });
-
   it("aborts when integrity drift callback rejects the fetched artifact", async () => {
     const run = vi.mocked(runCommandWithTimeout);
     mockNpmPackMetadataResult(run, {
@@ -410,7 +406,9 @@ describe("installHooksFromNpmSpec", () => {
     });
   });
 
-  it("rejects bare npm specs that resolve to prerelease versions", async () => {
+  it("rejects invalid npm spec shapes", async () => {
+    await expectUnsupportedNpmSpec((spec) => installHooksFromNpmSpec({ spec }));
+
     const run = vi.mocked(runCommandWithTimeout);
     mockNpmPackMetadataResult(run, {
       id: "@remoteclaw/test-hooks@0.0.2-beta.1",

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -65,23 +65,34 @@ describe("loader", () => {
   });
 
   describe("loadInternalHooks", () => {
-    it("should return 0 when hooks are not enabled", async () => {
-      const cfg: RemoteClawConfig = {
-        hooks: {
-          internal: {
-            enabled: false,
-          },
+    const createLegacyHandlerConfig = () =>
+      createEnabledHooksConfig([
+        {
+          event: "command:new",
+          module: "legacy-handler.js",
         },
-      };
+      ]);
 
+    const expectNoCommandHookRegistration = async (cfg: RemoteClawConfig) => {
       const count = await loadInternalHooks(cfg, tmpDir);
       expect(count).toBe(0);
-    });
+      expect(getRegisteredEventKeys()).not.toContain("command:new");
+    };
 
-    it("should return 0 when hooks config is missing", async () => {
-      const cfg: RemoteClawConfig = {};
-      const count = await loadInternalHooks(cfg, tmpDir);
-      expect(count).toBe(0);
+    it("should return 0 when hooks are disabled or missing", async () => {
+      for (const cfg of [
+        {
+          hooks: {
+            internal: {
+              enabled: false,
+            },
+          },
+        } satisfies RemoteClawConfig,
+        {} satisfies RemoteClawConfig,
+      ]) {
+        const count = await loadInternalHooks(cfg, tmpDir);
+        expect(count).toBe(0);
+      }
     });
 
     it("should load a handler from a module", async () => {
@@ -145,36 +156,29 @@ describe("loader", () => {
       expect(count).toBe(1);
     });
 
-    it("should handle module loading errors gracefully", async () => {
-      const cfg = createEnabledHooksConfig([
-        {
-          event: "command:new",
-          module: "missing-handler.js",
-        },
-      ]);
-
-      // Should not throw and should return 0 (handler failed to load)
-      const count = await loadInternalHooks(cfg, tmpDir);
-      expect(count).toBe(0);
-    });
-
-    it("should handle non-function exports", async () => {
-      // Create a module with a non-function export
-      const handlerPath = await writeHandlerModule(
+    it("should treat invalid handlers as non-loadable", async () => {
+      const badExportPath = await writeHandlerModule(
         "bad-export.js",
         'export default "not a function";',
       );
 
-      const cfg = createEnabledHooksConfig([
-        {
-          event: "command:new",
-          module: path.basename(handlerPath),
-        },
-      ]);
-
-      // Should not throw and should return 0 (handler is not a function)
-      const count = await loadInternalHooks(cfg, tmpDir);
-      expect(count).toBe(0);
+      for (const cfg of [
+        createEnabledHooksConfig([
+          {
+            event: "command:new",
+            module: "missing-handler.js",
+          },
+        ]),
+        createEnabledHooksConfig([
+          {
+            event: "command:new",
+            module: path.basename(badExportPath),
+          },
+        ]),
+      ]) {
+        const count = await loadInternalHooks(cfg, tmpDir);
+        expect(count).toBe(0);
+      }
     });
 
     it("should handle relative paths", async () => {

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -61,7 +61,7 @@ async function withOutsideHardlinkAlias(params: {
   aliasPath: string;
   run: (outsideFile: string) => Promise<void>;
 }): Promise<void> {
-  const outside = await tempDirs.make("openclaw-fs-safe-outside-");
+  const outside = await tempDirs.make("remoteclaw-fs-safe-outside-");
   const outsideFile = path.join(outside, "outside.txt");
   await fs.writeFile(outsideFile, "outside");
   try {
@@ -86,9 +86,9 @@ async function setupSymlinkWriteRaceFixture(options?: { seedInsideTarget?: boole
   slot: string;
   outsideTarget: string;
 }> {
-  const root = await tempDirs.make("openclaw-fs-safe-root-");
+  const root = await tempDirs.make("remoteclaw-fs-safe-root-");
   const inside = path.join(root, "inside");
-  const outside = await tempDirs.make("openclaw-fs-safe-outside-");
+  const outside = await tempDirs.make("remoteclaw-fs-safe-outside-");
   await fs.mkdir(inside, { recursive: true });
   if (options?.seedInsideTarget) {
     await fs.writeFile(path.join(inside, "target.txt"), "inside");
@@ -177,6 +177,32 @@ describe("fs-safe", () => {
     expect((err as SafeOpenError).message).not.toMatch(/EISDIR/i);
   });
 
+  it("reads files within root through all read helpers", async () => {
+    const root = await tempDirs.make("remoteclaw-fs-safe-root-");
+
+    await fs.writeFile(path.join(root, "inside.txt"), "inside");
+    const byRelativePath = await readFileWithinRoot({
+      rootDir: root,
+      relativePath: "inside.txt",
+    });
+    expect(byRelativePath.buffer.toString("utf8")).toBe("inside");
+    expect(byRelativePath.realPath).toContain("inside.txt");
+    expect(byRelativePath.stat.size).toBe(6);
+
+    const absolutePath = path.join(root, "absolute.txt");
+    await fs.writeFile(absolutePath, "absolute");
+    const byAbsolutePath = await readPathWithinRoot({
+      rootDir: root,
+      filePath: absolutePath,
+    });
+    expect(byAbsolutePath.buffer.toString("utf8")).toBe("absolute");
+
+    const scopedPath = path.join(root, "scoped.txt");
+    await fs.writeFile(scopedPath, "scoped");
+    const readScoped = createRootScopedReadFile({ rootDir: root });
+    await expect(readScoped(scopedPath)).resolves.toEqual(Buffer.from("scoped"));
+  });
+
   it.runIf(process.platform !== "win32")("blocks symlink escapes under root", async () => {
     const root = await tempDirs.make("remoteclaw-fs-safe-root-");
     const outside = await tempDirs.make("remoteclaw-fs-safe-outside-");
@@ -220,7 +246,7 @@ describe("fs-safe", () => {
   });
 
   it("appends to a file within root safely", async () => {
-    const root = await tempDirs.make("openclaw-fs-safe-root-");
+    const root = await tempDirs.make("remoteclaw-fs-safe-root-");
     const targetPath = path.join(root, "nested", "out.txt");
     await fs.mkdir(path.dirname(targetPath), { recursive: true });
     await fs.writeFile(targetPath, "seed");
@@ -238,7 +264,7 @@ describe("fs-safe", () => {
   // Pinned write helper (Python subprocess) now handles atomic rename internally —
   // JS-level fs.rename mocking cannot intercept the subprocess rename path.
   it.skip("does not truncate existing target when atomic rename fails", async () => {
-    const root = await tempDirs.make("openclaw-fs-safe-root-");
+    const root = await tempDirs.make("remoteclaw-fs-safe-root-");
     const targetPath = path.join(root, "nested", "out.txt");
     await fs.mkdir(path.dirname(targetPath), { recursive: true });
     await fs.writeFile(targetPath, "existing-content");
@@ -262,7 +288,7 @@ describe("fs-safe", () => {
   // Pinned write helper (Python subprocess) now handles atomic rename internally —
   // JS-level fs.rename mocking cannot intercept the subprocess rename path.
   it.skip("rejects when a hardlink appears after atomic write rename", async () => {
-    const root = await tempDirs.make("openclaw-fs-safe-root-");
+    const root = await tempDirs.make("remoteclaw-fs-safe-root-");
     const targetPath = path.join(root, "nested", "out.txt");
     const aliasPath = path.join(root, "nested", "alias.txt");
     await fs.mkdir(path.dirname(targetPath), { recursive: true });
@@ -293,8 +319,8 @@ describe("fs-safe", () => {
   // Pinned write helper (Python subprocess) now handles atomic rename internally —
   // JS-level fs.rename mocking cannot intercept the subprocess rename path.
   it.skip("does not truncate existing target when atomic copy rename fails", async () => {
-    const root = await tempDirs.make("openclaw-fs-safe-root-");
-    const sourceDir = await tempDirs.make("openclaw-fs-safe-source-");
+    const root = await tempDirs.make("remoteclaw-fs-safe-root-");
+    const sourceDir = await tempDirs.make("remoteclaw-fs-safe-source-");
     const sourcePath = path.join(sourceDir, "in.txt");
     const targetPath = path.join(root, "nested", "copied.txt");
     await fs.mkdir(path.dirname(targetPath), { recursive: true });
@@ -320,8 +346,8 @@ describe("fs-safe", () => {
   // Pinned write helper (Python subprocess) now handles atomic rename internally —
   // JS-level fs.rename mocking cannot intercept the subprocess rename path.
   it.skip("rejects when a hardlink appears after atomic copy rename", async () => {
-    const root = await tempDirs.make("openclaw-fs-safe-root-");
-    const sourceDir = await tempDirs.make("openclaw-fs-safe-source-");
+    const root = await tempDirs.make("remoteclaw-fs-safe-root-");
+    const sourceDir = await tempDirs.make("remoteclaw-fs-safe-source-");
     const sourcePath = path.join(sourceDir, "copy-source.txt");
     const targetPath = path.join(root, "nested", "copied.txt");
     const aliasPath = path.join(root, "nested", "alias.txt");
@@ -431,7 +457,7 @@ describe("fs-safe", () => {
   });
 
   it.runIf(process.platform !== "win32")("rejects appending through hardlink aliases", async () => {
-    const root = await tempDirs.make("openclaw-fs-safe-root-");
+    const root = await tempDirs.make("remoteclaw-fs-safe-root-");
     const hardlinkPath = path.join(root, "alias.txt");
     await withOutsideHardlinkAlias({
       aliasPath: hardlinkPath,

--- a/src/infra/outbound/channel-adapters.test.ts
+++ b/src/infra/outbound/channel-adapters.test.ts
@@ -1,9 +1,18 @@
 import { Separator, TextDisplay } from "@buape/carbon";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { discordPlugin } from "../../../extensions/discord/src/channel.js";
 import { DiscordUiContainer } from "../../discord/ui.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { getChannelMessageAdapter } from "./channel-adapters.js";
 
 describe("getChannelMessageAdapter", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "discord", plugin: discordPlugin, source: "test" }]),
+    );
+  });
+
   it("returns the default adapter for non-discord channels", () => {
     expect(getChannelMessageAdapter("telegram")).toEqual({
       supportsComponentsV2: false,

--- a/src/infra/outbound/outbound-policy.test.ts
+++ b/src/infra/outbound/outbound-policy.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { discordPlugin } from "../../../extensions/discord/src/channel.js";
 import type { RemoteClawConfig } from "../../config/config.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import {
   applyCrossContextDecoration,
   buildCrossContextDecoration,
@@ -23,6 +26,12 @@ const discordConfig = {
 } as RemoteClawConfig;
 
 describe("outbound policy helpers", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "discord", plugin: discordPlugin, source: "test" }]),
+    );
+  });
+
   it("allows cross-provider sends when enabled", () => {
     const cfg = {
       ...slackConfig,

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -2,8 +2,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { discordPlugin } from "../../../extensions/discord/src/channel.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { RemoteClawConfig } from "../../config/config.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { typedCases } from "../../test-utils/typed-cases.js";
 import {
   ackDelivery,
@@ -30,6 +33,12 @@ import {
   normalizeOutboundPayloadsForJson,
 } from "./payloads.js";
 import { runResolveOutboundTargetCoreTests } from "./targets.shared-test.js";
+
+beforeEach(() => {
+  setActivePluginRegistry(
+    createTestRegistry([{ pluginId: "discord", plugin: discordPlugin, source: "test" }]),
+  );
+});
 
 describe("delivery-queue", () => {
   let tmpDir: string;

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -47,58 +47,552 @@ const bundledExtensionSubpathLoaders = [
   { id: "zalouser", load: () => import("remoteclaw/plugin-sdk/zalouser") },
 ] as const;
 
+const importResolvedPluginSdkSubpath = async (specifier: string) =>
+  import(pathToFileURL(requireFromHere.resolve(specifier)).href);
+
+function readPluginSdkSource(subpath: string): string {
+  const file = resolve(PLUGIN_SDK_DIR, `${subpath}.ts`);
+  const cached = sourceCache.get(file);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const text = readFileSync(file, "utf8");
+  sourceCache.set(file, text);
+  return text;
+}
+
+function isIdentifierCode(code: number): boolean {
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122) ||
+    code === 36 ||
+    code === 95
+  );
+}
+
+function sourceMentionsIdentifier(source: string, name: string): boolean {
+  let fromIndex = 0;
+  while (true) {
+    const matchIndex = source.indexOf(name, fromIndex);
+    if (matchIndex === -1) {
+      return false;
+    }
+    const beforeCode = matchIndex === 0 ? -1 : source.charCodeAt(matchIndex - 1);
+    const afterIndex = matchIndex + name.length;
+    const afterCode = afterIndex >= source.length ? -1 : source.charCodeAt(afterIndex);
+    if (!isIdentifierCode(beforeCode) && !isIdentifierCode(afterCode)) {
+      return true;
+    }
+    fromIndex = matchIndex + 1;
+  }
+}
+
+function expectSourceMentions(subpath: string, names: readonly string[]) {
+  const source = readPluginSdkSource(subpath);
+  const missing = names.filter((name) => !sourceMentionsIdentifier(source, name));
+  expect(missing, `${subpath} missing exports`).toEqual([]);
+}
+
+function expectSourceOmits(subpath: string, names: readonly string[]) {
+  const source = readPluginSdkSource(subpath);
+  const present = names.filter((name) => sourceMentionsIdentifier(source, name));
+  expect(present, `${subpath} leaked exports`).toEqual([]);
+}
+
+function expectSourceContract(
+  subpath: string,
+  params: { mentions?: readonly string[]; omits?: readonly string[] },
+) {
+  const source = readPluginSdkSource(subpath);
+  const missing = (params.mentions ?? []).filter((name) => !sourceMentionsIdentifier(source, name));
+  const present = (params.omits ?? []).filter((name) => sourceMentionsIdentifier(source, name));
+  expect(missing, `${subpath} missing exports`).toEqual([]);
+  expect(present, `${subpath} leaked exports`).toEqual([]);
+}
+
+function expectSourceContains(subpath: string, snippet: string) {
+  expect(readPluginSdkSource(subpath)).toContain(snippet);
+}
+
 describe("plugin-sdk subpath exports", () => {
   it("exports compat helpers", () => {
     expect(typeof compatSdk.emptyPluginConfigSchema).toBe("function");
     expect(typeof compatSdk.resolveControlCommandGate).toBe("function");
   });
 
-  it("exports core routing helpers", () => {
-    expect(typeof coreSdk.buildAgentSessionKey).toBe("function");
-    expect(typeof coreSdk.resolveThreadSessionKeys).toBe("function");
+  it("keeps helper subpaths aligned", () => {
+    expectSourceMentions("core", [
+      "emptyPluginConfigSchema",
+      "definePluginEntry",
+      "defineChannelPluginEntry",
+      "defineSetupPluginEntry",
+      "createChatChannelPlugin",
+      "createChannelPluginBase",
+      "isSecretRef",
+      "optionalStringEnum",
+    ]);
+    expectSourceOmits("core", [
+      "runPassiveAccountLifecycle",
+      "createLoggerBackedRuntime",
+      "registerSandboxBackend",
+    ]);
+    expectSourceContract("routing", {
+      mentions: [
+        "buildAgentSessionKey",
+        "resolveThreadSessionKeys",
+        "normalizeMessageChannel",
+        "resolveGatewayMessageChannel",
+      ],
+    });
+    expectSourceMentions("reply-payload", [
+      "buildMediaPayload",
+      "deliverTextOrMediaReply",
+      "resolveOutboundMediaUrls",
+      "resolvePayloadMediaUrls",
+      "sendPayloadMediaSequenceAndFinalize",
+      "sendPayloadMediaSequenceOrFallback",
+      "sendTextMediaPayload",
+      "sendPayloadWithChunkedTextAndMedia",
+    ]);
+    expectSourceMentions("media-runtime", [
+      "createDirectTextMediaOutbound",
+      "createScopedChannelMediaMaxBytesResolver",
+    ]);
+    expectSourceMentions("reply-history", [
+      "buildPendingHistoryContextFromMap",
+      "clearHistoryEntriesIfEnabled",
+      "recordPendingHistoryEntryIfEnabled",
+    ]);
+    expectSourceContract("reply-runtime", {
+      omits: [
+        "buildPendingHistoryContextFromMap",
+        "clearHistoryEntriesIfEnabled",
+        "recordPendingHistoryEntryIfEnabled",
+        "DEFAULT_GROUP_HISTORY_LIMIT",
+      ],
+    });
+    expectSourceMentions("account-helpers", ["createAccountListHelpers"]);
+    expectSourceMentions("device-bootstrap", [
+      "approveDevicePairing",
+      "issueDeviceBootstrapToken",
+      "listDevicePairing",
+    ]);
+    expectSourceMentions("allowlist-config-edit", [
+      "buildDmGroupAccountAllowlistAdapter",
+      "createNestedAllowlistOverrideResolver",
+    ]);
+    expectSourceContract("allow-from", {
+      mentions: [
+        "addAllowlistUserEntriesFromConfigEntry",
+        "buildAllowlistResolutionSummary",
+        "canonicalizeAllowlistWithResolvedIds",
+        "mapAllowlistResolutionInputs",
+        "mergeAllowlist",
+        "patchAllowlistUsersInConfigEntries",
+        "summarizeMapping",
+        "compileAllowlist",
+        "firstDefined",
+        "formatAllowlistMatchMeta",
+        "isSenderIdAllowed",
+        "mergeDmAllowFromSources",
+        "resolveAllowlistMatchSimple",
+      ],
+    });
+    expectSourceMentions("runtime", ["createLoggerBackedRuntime"]);
+    expectSourceMentions("discord", [
+      "buildDiscordComponentMessage",
+      "editDiscordComponentMessage",
+      "registerBuiltDiscordComponentMessage",
+      "resolveDiscordAccount",
+    ]);
+    expectSourceMentions("conversation-runtime", [
+      "recordInboundSession",
+      "recordInboundSessionMetaSafe",
+      "resolveConversationLabel",
+    ]);
+    expectSourceMentions("directory-runtime", [
+      "createChannelDirectoryAdapter",
+      "createRuntimeDirectoryLiveAdapter",
+      "listDirectoryEntriesFromSources",
+      "listResolvedDirectoryEntriesFromSources",
+    ]);
   });
 
-  it("exports Discord helpers", () => {
-    expect(typeof discordSdk.resolveDiscordAccount).toBe("function");
-    expect(typeof discordSdk.discordOnboardingAdapter).toBe("object");
+  it("exports channel runtime helpers from the dedicated subpath", () => {
+    expectSourceOmits("channel-runtime", [
+      "applyChannelMatchMeta",
+      "createChannelDirectoryAdapter",
+      "createEmptyChannelDirectoryAdapter",
+      "createArmableStallWatchdog",
+      "createDraftStreamLoop",
+      "createLoggedPairingApprovalNotifier",
+      "createPairingPrefixStripper",
+      "createRunStateMachine",
+      "createRuntimeDirectoryLiveAdapter",
+      "createRuntimeOutboundDelegates",
+      "createStatusReactionController",
+      "createTextPairingAdapter",
+      "createFinalizableDraftLifecycle",
+      "DEFAULT_EMOJIS",
+      "logAckFailure",
+      "logTypingFailure",
+      "logInboundDrop",
+      "normalizeMessageChannel",
+      "removeAckReactionAfterReply",
+      "recordInboundSession",
+      "recordInboundSessionMetaSafe",
+      "resolveInboundSessionEnvelopeContext",
+      "resolveMentionGating",
+      "resolveMentionGatingWithBypass",
+      "resolveOutboundSendDep",
+      "resolveConversationLabel",
+      "shouldDebounceTextInbound",
+      "shouldAckReaction",
+      "shouldAckReactionForWhatsApp",
+      "toLocationContext",
+      "resolveThreadBindingConversationIdFromBindingId",
+      "resolveThreadBindingEffectiveExpiresAt",
+      "resolveThreadBindingFarewellText",
+      "resolveThreadBindingIdleTimeoutMs",
+      "resolveThreadBindingIdleTimeoutMsForChannel",
+      "resolveThreadBindingIntroText",
+      "resolveThreadBindingLifecycle",
+      "resolveThreadBindingMaxAgeMs",
+      "resolveThreadBindingMaxAgeMsForChannel",
+      "resolveThreadBindingSpawnPolicy",
+      "resolveThreadBindingThreadName",
+      "resolveThreadBindingsEnabled",
+      "formatThreadBindingDisabledError",
+      "DISCORD_THREAD_BINDING_CHANNEL",
+      "MATRIX_THREAD_BINDING_CHANNEL",
+      "resolveControlCommandGate",
+      "resolveCommandAuthorizedFromAuthorizers",
+      "resolveDualTextControlCommandGate",
+      "resolveNativeCommandSessionTargets",
+      "attachChannelToResult",
+      "buildComputedAccountStatusSnapshot",
+      "buildMediaPayload",
+      "createActionGate",
+      "jsonResult",
+      "normalizeInteractiveReply",
+      "PAIRING_APPROVED_MESSAGE",
+      "projectCredentialSnapshotFields",
+      "readStringParam",
+      "compileAllowlist",
+      "formatAllowlistMatchMeta",
+      "firstDefined",
+      "isSenderIdAllowed",
+      "mergeDmAllowFromSources",
+      "addAllowlistUserEntriesFromConfigEntry",
+      "buildAllowlistResolutionSummary",
+      "canonicalizeAllowlistWithResolvedIds",
+      "mergeAllowlist",
+      "patchAllowlistUsersInConfigEntries",
+      "resolveChannelConfigWrites",
+      "resolvePayloadMediaUrls",
+      "resolveScopedChannelMediaMaxBytes",
+      "sendPayloadMediaSequenceAndFinalize",
+      "sendPayloadMediaSequenceOrFallback",
+      "sendTextMediaPayload",
+      "createScopedChannelMediaMaxBytesResolver",
+      "runPassiveAccountLifecycle",
+      "buildChannelKeyCandidates",
+      "buildMessagingTarget",
+      "createDirectTextMediaOutbound",
+      "createMessageToolButtonsSchema",
+      "createMessageToolCardSchema",
+      "createScopedAccountReplyToModeResolver",
+      "createStaticReplyToModeResolver",
+      "createTopLevelChannelReplyToModeResolver",
+      "createUnionActionGate",
+      "ensureTargetId",
+      "listTokenSourcedAccounts",
+      "parseMentionPrefixOrAtUserTarget",
+      "requireTargetKind",
+      "resolveChannelEntryMatchWithFallback",
+      "resolveChannelMatchConfig",
+      "resolveReactionMessageId",
+      "resolveTargetsWithOptionalToken",
+      "appendMatchMetadata",
+      "asString",
+      "collectIssuesForEnabledAccounts",
+      "isRecord",
+      "resolveEnabledConfiguredAccountId",
+    ]);
+    expectSourceMentions("channel-inbound", [
+      "buildMentionRegexes",
+      "createChannelInboundDebouncer",
+      "createInboundDebouncer",
+      "formatInboundEnvelope",
+      "formatInboundFromLabel",
+      "formatLocationText",
+      "logInboundDrop",
+      "matchesMentionPatterns",
+      "matchesMentionWithExplicit",
+      "normalizeMentionText",
+      "resolveInboundDebounceMs",
+      "resolveEnvelopeFormatOptions",
+      "resolveInboundSessionEnvelopeContext",
+      "resolveMentionGating",
+      "resolveMentionGatingWithBypass",
+      "shouldDebounceTextInbound",
+      "toLocationContext",
+    ]);
+    expectSourceContract("reply-runtime", {
+      omits: [
+        "buildMentionRegexes",
+        "createInboundDebouncer",
+        "formatInboundEnvelope",
+        "formatInboundFromLabel",
+        "matchesMentionPatterns",
+        "matchesMentionWithExplicit",
+        "normalizeMentionText",
+        "resolveEnvelopeFormatOptions",
+        "resolveInboundDebounceMs",
+        "hasControlCommand",
+        "buildCommandTextFromArgs",
+        "buildCommandsPaginationKeyboard",
+        "buildModelsProviderData",
+        "listNativeCommandSpecsForConfig",
+        "listSkillCommandsForAgents",
+        "normalizeCommandBody",
+        "resolveCommandAuthorization",
+        "resolveStoredModelOverride",
+        "shouldComputeCommandAuthorized",
+        "shouldHandleTextCommands",
+      ],
+    });
+    expectSourceMentions("channel-setup", [
+      "createOptionalChannelSetupSurface",
+      "createTopLevelChannelDmPolicy",
+    ]);
+    expectSourceContract("channel-actions", {
+      mentions: [
+        "createUnionActionGate",
+        "listTokenSourcedAccounts",
+        "resolveReactionMessageId",
+        "createMessageToolButtonsSchema",
+        "createMessageToolCardSchema",
+      ],
+    });
+    expectSourceMentions("channel-targets", [
+      "applyChannelMatchMeta",
+      "buildChannelKeyCandidates",
+      "buildMessagingTarget",
+      "ensureTargetId",
+      "parseMentionPrefixOrAtUserTarget",
+      "requireTargetKind",
+      "resolveChannelEntryMatchWithFallback",
+      "resolveChannelMatchConfig",
+      "resolveTargetsWithOptionalToken",
+    ]);
+    expectSourceMentions("channel-config-helpers", [
+      "authorizeConfigWrite",
+      "canBypassConfigWritePolicy",
+      "formatConfigWriteDeniedMessage",
+      "resolveChannelConfigWrites",
+    ]);
+    expectSourceMentions("channel-feedback", [
+      "createStatusReactionController",
+      "logAckFailure",
+      "logTypingFailure",
+      "removeAckReactionAfterReply",
+      "shouldAckReaction",
+      "shouldAckReactionForWhatsApp",
+      "DEFAULT_EMOJIS",
+    ]);
+    expectSourceMentions("status-helpers", [
+      "appendMatchMetadata",
+      "asString",
+      "collectIssuesForEnabledAccounts",
+      "isRecord",
+      "resolveEnabledConfiguredAccountId",
+    ]);
+    expectSourceMentions("outbound-runtime", [
+      "createRuntimeOutboundDelegates",
+      "resolveOutboundSendDep",
+      "resolveAgentOutboundIdentity",
+    ]);
+    expectSourceMentions("command-auth", [
+      "buildCommandTextFromArgs",
+      "buildCommandsPaginationKeyboard",
+      "buildModelsProviderData",
+      "hasControlCommand",
+      "listNativeCommandSpecsForConfig",
+      "listSkillCommandsForAgents",
+      "normalizeCommandBody",
+      "resolveCommandAuthorization",
+      "resolveCommandAuthorizedFromAuthorizers",
+      "resolveControlCommandGate",
+      "resolveDualTextControlCommandGate",
+      "resolveNativeCommandSessionTargets",
+      "resolveStoredModelOverride",
+      "shouldComputeCommandAuthorized",
+      "shouldHandleTextCommands",
+    ]);
+    expectSourceMentions("channel-send-result", [
+      "attachChannelToResult",
+      "buildChannelSendResult",
+    ]);
+
+    expectSourceMentions("conversation-runtime", [
+      "DISCORD_THREAD_BINDING_CHANNEL",
+      "MATRIX_THREAD_BINDING_CHANNEL",
+      "formatThreadBindingDisabledError",
+      "resolveThreadBindingFarewellText",
+      "resolveThreadBindingConversationIdFromBindingId",
+      "resolveThreadBindingEffectiveExpiresAt",
+      "resolveThreadBindingIdleTimeoutMs",
+      "resolveThreadBindingIdleTimeoutMsForChannel",
+      "resolveThreadBindingIntroText",
+      "resolveThreadBindingLifecycle",
+      "resolveThreadBindingMaxAgeMs",
+      "resolveThreadBindingMaxAgeMsForChannel",
+      "resolveThreadBindingSpawnPolicy",
+      "resolveThreadBindingThreadName",
+      "resolveThreadBindingsEnabled",
+      "formatThreadBindingDurationLabel",
+      "createScopedAccountReplyToModeResolver",
+      "createStaticReplyToModeResolver",
+      "createTopLevelChannelReplyToModeResolver",
+    ]);
+
+    expectSourceMentions("thread-bindings-runtime", ["resolveThreadBindingLifecycle"]);
+    expectSourceMentions("matrix-runtime-shared", ["formatZonedTimestamp"]);
+    expectSourceMentions("ssrf-runtime", [
+      "closeDispatcher",
+      "createPinnedDispatcher",
+      "resolvePinnedHostnameWithPolicy",
+      "assertHttpUrlTargetsPrivateNetwork",
+      "ssrfPolicyFromAllowPrivateNetwork",
+    ]);
+
+    expectSourceMentions("provider-setup", [
+      "buildVllmProvider",
+      "discoverOpenAICompatibleSelfHostedProvider",
+    ]);
+    expectSourceMentions("provider-auth", [
+      "buildOauthProviderAuthResult",
+      "generatePkceVerifierChallenge",
+      "toFormUrlEncoded",
+    ]);
+    expectSourceOmits("core", ["buildOauthProviderAuthResult"]);
+    expectSourceContract("provider-models", {
+      mentions: ["applyOpenAIConfig", "buildKilocodeModelDefinition", "discoverHuggingfaceModels"],
+      omits: [
+        "buildMinimaxModelDefinition",
+        "buildMoonshotProvider",
+        "QIANFAN_BASE_URL",
+        "resolveZaiBaseUrl",
+      ],
+    });
+
+    expectSourceMentions("setup", [
+      "DEFAULT_ACCOUNT_ID",
+      "createAllowFromSection",
+      "createDelegatedSetupWizardProxy",
+      "createTopLevelChannelDmPolicy",
+      "mergeAllowFromEntries",
+    ]);
+    expectSourceMentions("lazy-runtime", ["createLazyRuntimeSurface", "createLazyRuntimeModule"]);
+    expectSourceMentions("self-hosted-provider-setup", [
+      "buildVllmProvider",
+      "buildSglangProvider",
+      "configureOpenAICompatibleSelfHostedProviderNonInteractive",
+    ]);
+    expectSourceMentions("ollama-setup", ["buildOllamaProvider", "configureOllamaNonInteractive"]);
+    expectSourceMentions("sandbox", ["registerSandboxBackend", "runPluginCommandWithTimeout"]);
+
+    expectSourceMentions("secret-input", [
+      "buildSecretInputSchema",
+      "buildOptionalSecretInputSchema",
+      "normalizeSecretInputString",
+    ]);
+    expectSourceOmits("config-runtime", [
+      "hasConfiguredSecretInput",
+      "normalizeResolvedSecretInputString",
+      "normalizeSecretInputString",
+    ]);
+    expectSourceMentions("webhook-ingress", [
+      "registerPluginHttpRoute",
+      "resolveWebhookPath",
+      "readRequestBodyWithLimit",
+      "readJsonWebhookBodyOrReject",
+      "requestBodyErrorToText",
+      "withResolvedWebhookRequestPipeline",
+    ]);
+    expectSourceMentions("testing", ["removeAckReactionAfterReply", "shouldAckReaction"]);
   });
 
-  it("exports Slack helpers", () => {
-    expect(typeof slackSdk.resolveSlackAccount).toBe("function");
-    expect(typeof slackSdk.handleSlackMessageAction).toBe("function");
+  it("keeps shared plugin-sdk types aligned", () => {
+    expectTypeOf<ContractBaseProbeResult>().toMatchTypeOf<BaseProbeResult>();
+    expectTypeOf<ContractBaseTokenResolution>().toMatchTypeOf<BaseTokenResolution>();
+    expectTypeOf<ContractChannelAgentTool>().toMatchTypeOf<ChannelAgentTool>();
+    expectTypeOf<ContractChannelAccountSnapshot>().toMatchTypeOf<ChannelAccountSnapshot>();
+    expectTypeOf<ContractChannelGroupContext>().toMatchTypeOf<ChannelGroupContext>();
+    expectTypeOf<ContractChannelMessageActionAdapter>().toMatchTypeOf<ChannelMessageActionAdapter>();
+    expectTypeOf<ContractChannelMessageActionContext>().toMatchTypeOf<ChannelMessageActionContext>();
+    expectTypeOf<ContractChannelMessageActionName>().toMatchTypeOf<ChannelMessageActionName>();
+    expectTypeOf<ContractChannelMessageToolDiscovery>().toMatchTypeOf<ChannelMessageToolDiscovery>();
+    expectTypeOf<ContractChannelStatusIssue>().toMatchTypeOf<ChannelStatusIssue>();
+    expectTypeOf<ContractChannelThreadingContext>().toMatchTypeOf<ChannelThreadingContext>();
+    expectTypeOf<ContractChannelThreadingToolContext>().toMatchTypeOf<ChannelThreadingToolContext>();
+    expectTypeOf<CoreOpenClawPluginApi>().toMatchTypeOf<OpenClawPluginApi>();
+    expectTypeOf<CorePluginRuntime>().toMatchTypeOf<PluginRuntime>();
+    expectTypeOf<CoreChannelMessageActionContext>().toMatchTypeOf<ChannelMessageActionContext>();
+    expectTypeOf<CoreOpenClawPluginApi>().toMatchTypeOf<SharedOpenClawPluginApi>();
+    expectTypeOf<CorePluginRuntime>().toMatchTypeOf<SharedPluginRuntime>();
+    expectTypeOf<CoreChannelMessageActionContext>().toMatchTypeOf<SharedChannelMessageActionContext>();
   });
 
-  it("exports Signal helpers", () => {
-    expect(typeof signalSdk.resolveSignalAccount).toBe("function");
-    expect(typeof signalSdk.signalOnboardingAdapter).toBe("object");
-  });
+  it("keeps runtime entry subpaths importable", async () => {
+    const [
+      coreSdk,
+      pluginEntrySdk,
+      channelLifecycleSdk,
+      channelPairingSdk,
+      channelReplyPipelineSdk,
+      ...representativeModules
+    ] = await Promise.all([
+      importResolvedPluginSdkSubpath("openclaw/plugin-sdk/core"),
+      importResolvedPluginSdkSubpath("openclaw/plugin-sdk/plugin-entry"),
+      importResolvedPluginSdkSubpath("openclaw/plugin-sdk/channel-lifecycle"),
+      importResolvedPluginSdkSubpath("openclaw/plugin-sdk/channel-pairing"),
+      importResolvedPluginSdkSubpath("openclaw/plugin-sdk/channel-reply-pipeline"),
+      ...representativeRuntimeSmokeSubpaths.map((id) =>
+        importResolvedPluginSdkSubpath(`openclaw/plugin-sdk/${id}`),
+      ),
+    ]);
 
-  it("exports iMessage helpers", () => {
-    expect(typeof imessageSdk.resolveIMessageAccount).toBe("function");
-    expect(typeof imessageSdk.imessageOnboardingAdapter).toBe("object");
-  });
+    expect(coreSdk.definePluginEntry).toBe(pluginEntrySdk.definePluginEntry);
 
-  it("exports WhatsApp helpers", () => {
-    // WhatsApp-specific functions (resolveWhatsAppAccount, whatsappOnboardingAdapter) moved to extensions/whatsapp/src/
-    expect(typeof whatsappSdk.WhatsAppConfigSchema).toBe("object");
-    expect(typeof whatsappSdk.resolveWhatsAppOutboundTarget).toBe("function");
-    expect(typeof whatsappSdk.resolveWhatsAppMentionStripPatterns).toBe("function");
-    expect("resolveWhatsAppMentionStripRegexes" in whatsappSdk).toBe(false);
-  });
+    expectSourceMentions("infra-runtime", ["createRuntimeOutboundDelegates"]);
+    expectSourceContains("infra-runtime", "../infra/outbound/send-deps.js");
 
-  it("exports LINE helpers", () => {
-    expect(typeof lineSdk.processLineMessage).toBe("function");
-    expect(typeof lineSdk.createInfoCard).toBe("function");
-  });
+    expect(typeof channelLifecycleSdk.createDraftStreamLoop).toBe("function");
+    expect(typeof channelLifecycleSdk.createFinalizableDraftLifecycle).toBe("function");
+    expect(typeof channelLifecycleSdk.runPassiveAccountLifecycle).toBe("function");
+    expect(typeof channelLifecycleSdk.createRunStateMachine).toBe("function");
+    expect(typeof channelLifecycleSdk.createArmableStallWatchdog).toBe("function");
 
-  it("exports Microsoft Teams helpers", () => {
-    expect(typeof msteamsSdk.resolveControlCommandGate).toBe("function");
-    expect(typeof msteamsSdk.loadOutboundMediaFromUrl).toBe("function");
-  });
+    expectSourceMentions("channel-pairing", [
+      "createChannelPairingController",
+      "createChannelPairingChallengeIssuer",
+      "createLoggedPairingApprovalNotifier",
+      "createPairingPrefixStripper",
+      "createTextPairingAdapter",
+    ]);
+    expect("createScopedPairingAccess" in channelPairingSdk).toBe(false);
 
-  it("resolves bundled extension subpaths", async () => {
-    for (const { id, load } of bundledExtensionSubpathLoaders) {
-      const mod = await load();
+    expectSourceMentions("channel-reply-pipeline", ["createChannelReplyPipeline"]);
+    expect("createTypingCallbacks" in channelReplyPipelineSdk).toBe(false);
+    expect("createReplyPrefixContext" in channelReplyPipelineSdk).toBe(false);
+    expect("createReplyPrefixOptions" in channelReplyPipelineSdk).toBe(false);
+
+    expect(pluginSdkSubpaths.length).toBeGreaterThan(representativeRuntimeSmokeSubpaths.length);
+    for (const [index, id] of representativeRuntimeSmokeSubpaths.entries()) {
+      const mod = representativeModules[index];
       expect(typeof mod).toBe("object");
       expect(mod, `subpath ${id} should resolve`).toBeTruthy();
     }

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -468,18 +468,13 @@ describe("installPluginFromArchive", () => {
     expect(manifest.version).toBe("0.0.2");
   });
 
-  it("rejects traversal-like plugin names", async () => {
-    await expectArchiveInstallReservedSegmentRejection({
-      packageName: "@evil/..",
-      outName: "traversal.tgz",
-    });
-  });
-
-  it("rejects reserved plugin ids", async () => {
-    await expectArchiveInstallReservedSegmentRejection({
-      packageName: "@evil/.",
-      outName: "reserved.tgz",
-    });
+  it("rejects reserved archive package ids", async () => {
+    for (const params of [
+      { packageName: "@evil/..", outName: "traversal.tgz" },
+      { packageName: "@evil/.", outName: "reserved.tgz" },
+    ]) {
+      await expectArchiveInstallReservedSegmentRejection(params);
+    }
   });
 
   it("rejects packages without remoteclaw.extensions", async () => {
@@ -615,19 +610,150 @@ describe("installPluginFromDir", () => {
     ).toBe(true);
   });
 
-  it("normalizes scoped manifest ids to unscoped install keys", async () => {
-    const { pluginDir, extensionsDir } = setupManifestInstallFixture({
-      manifestId: "@team/memory-cognee",
+  it("keeps scoped install ids aligned across manifest and package-name cases", async () => {
+    const scenarios = [
+      {
+        setup: () => setupManifestInstallFixture({ manifestId: "@team/memory-cognee" }),
+        expectedPluginId: "@team/memory-cognee",
+        install: (pluginDir: string, extensionsDir: string) =>
+          installPluginFromDir({
+            dirPath: pluginDir,
+            extensionsDir,
+            expectedPluginId: "@team/memory-cognee",
+            logger: { info: () => {}, warn: () => {} },
+          }),
+      },
+      {
+        setup: () => setupInstallPluginFromDirFixture(),
+        expectedPluginId: "@openclaw/test-plugin",
+        install: (pluginDir: string, extensionsDir: string) =>
+          installPluginFromDir({
+            dirPath: pluginDir,
+            extensionsDir,
+          }),
+      },
+      {
+        setup: () => setupInstallPluginFromDirFixture(),
+        expectedPluginId: "@openclaw/test-plugin",
+        install: (pluginDir: string, extensionsDir: string) =>
+          installPluginFromDir({
+            dirPath: pluginDir,
+            extensionsDir,
+            expectedPluginId: "test-plugin",
+          }),
+      },
+    ] as const;
+
+    for (const scenario of scenarios) {
+      const { pluginDir, extensionsDir } = scenario.setup();
+      const res = await scenario.install(pluginDir, extensionsDir);
+      expectInstalledWithPluginId(res, extensionsDir, scenario.expectedPluginId);
+    }
+  });
+
+  it("keeps scoped install-dir validation aligned", () => {
+    for (const invalidId of ["@", "@/name", "team/name"]) {
+      expect(() => resolvePluginInstallDir(invalidId)).toThrow(
+        "invalid plugin name: scoped ids must use @scope/name format",
+      );
+    }
+
+    const extensionsDir = path.join(makeTempDir(), "extensions");
+    const scopedTarget = resolvePluginInstallDir("@scope/name", extensionsDir);
+    const hashedFlatId = safePathSegmentHashed("@scope/name");
+    const flatTarget = resolvePluginInstallDir(hashedFlatId, extensionsDir);
+
+    expect(path.basename(scopedTarget)).toBe(`@${hashedFlatId}`);
+    expect(scopedTarget).not.toBe(flatTarget);
+  });
+
+  it("installs Codex bundles from a local directory", async () => {
+    const { pluginDir, extensionsDir } = setupBundleInstallFixture({
+      bundleFormat: "codex",
+      name: "Sample Bundle",
     });
 
     const res = await installPluginFromDir({
       dirPath: pluginDir,
       extensionsDir,
-      expectedPluginId: "memory-cognee",
-      logger: { info: () => {}, warn: () => {} },
     });
 
-    expectInstalledAsMemoryCognee(res, extensionsDir);
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expect(res.pluginId).toBe("sample-bundle");
+    expect(fs.existsSync(path.join(res.targetDir, ".codex-plugin", "plugin.json"))).toBe(true);
+    expect(fs.existsSync(path.join(res.targetDir, "skills", "SKILL.md"))).toBe(true);
+  });
+
+  it("prefers native package installs over bundle installs for dual-format directories", async () => {
+    const { pluginDir, extensionsDir } = setupDualFormatInstallFixture({
+      bundleFormat: "codex",
+    });
+
+    const run = vi.mocked(runCommandWithTimeout);
+    run.mockResolvedValue({
+      code: 0,
+      stdout: "",
+      stderr: "",
+      signal: null,
+      killed: false,
+      termination: "exit",
+    });
+
+    const res = await installPluginFromDir({
+      dirPath: pluginDir,
+      extensionsDir,
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expect(res.pluginId).toBe("native-dual");
+    expect(res.targetDir).toBe(path.join(extensionsDir, "native-dual"));
+    expectSingleNpmInstallIgnoreScriptsCall({
+      calls: run.mock.calls as Array<[unknown, { cwd?: string } | undefined]>,
+      expectedTargetDir: res.targetDir,
+    });
+  });
+
+  it("installs manifestless Claude bundles from a local directory", async () => {
+    const { pluginDir, extensionsDir } = setupManifestlessClaudeInstallFixture();
+
+    const res = await installPluginFromDir({
+      dirPath: pluginDir,
+      extensionsDir,
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expect(res.pluginId).toBe("claude-manifestless");
+    expect(fs.existsSync(path.join(res.targetDir, "commands", "review.md"))).toBe(true);
+    expect(fs.existsSync(path.join(res.targetDir, "settings.json"))).toBe(true);
+  });
+
+  it("installs Cursor bundles from a local directory", async () => {
+    const { pluginDir, extensionsDir } = setupBundleInstallFixture({
+      bundleFormat: "cursor",
+      name: "Cursor Sample",
+    });
+
+    const res = await installPluginFromDir({
+      dirPath: pluginDir,
+      extensionsDir,
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expect(res.pluginId).toBe("cursor-sample");
+    expect(fs.existsSync(path.join(res.targetDir, ".cursor-plugin", "plugin.json"))).toBe(true);
+    expect(fs.existsSync(path.join(res.targetDir, ".cursor", "commands", "review.md"))).toBe(true);
   });
 });
 
@@ -775,77 +901,74 @@ describe("installPluginFromNpmSpec", () => {
     }
   });
 
-  it("rejects bare npm specs that resolve to prerelease versions", async () => {
-    const run = vi.mocked(runCommandWithTimeout);
-    mockNpmPackMetadataResult(run, {
-      id: "@remoteclaw/voice-call@0.0.2-beta.1",
-      name: "@remoteclaw/voice-call",
+  it("handles prerelease npm specs correctly", async () => {
+    const prereleaseMetadata = {
+      id: "@openclaw/voice-call@0.0.2-beta.1",
+      name: "@openclaw/voice-call",
       version: "0.0.2-beta.1",
       filename: "voice-call-0.0.2-beta.1.tgz",
       integrity: "sha512-beta",
       shasum: "betashasum",
-    });
+    };
 
-    const result = await installPluginFromNpmSpec({
-      spec: "@remoteclaw/voice-call",
-      logger: { info: () => {}, warn: () => {} },
-    });
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toContain("prerelease version 0.0.2-beta.1");
-      expect(result.error).toContain('"@remoteclaw/voice-call@beta"');
-    }
-  });
+    {
+      const run = vi.mocked(runCommandWithTimeout);
+      mockNpmPackMetadataResult(run, prereleaseMetadata);
 
-  it("allows explicit prerelease npm tags", async () => {
-    const run = vi.mocked(runCommandWithTimeout);
-    let packTmpDir = "";
-    const packedName = "voice-call-0.0.2-beta.1.tgz";
-    const voiceCallArchiveBuffer = VOICE_CALL_ARCHIVE_V1_BUFFER;
-    run.mockImplementation(async (argv, opts) => {
-      if (argv[0] === "npm" && argv[1] === "pack") {
-        packTmpDir = String(typeof opts === "number" ? "" : (opts.cwd ?? ""));
-        fs.writeFileSync(path.join(packTmpDir, packedName), voiceCallArchiveBuffer);
-        return {
-          code: 0,
-          stdout: JSON.stringify([
-            {
-              id: "@remoteclaw/voice-call@0.0.2-beta.1",
-              name: "@remoteclaw/voice-call",
-              version: "0.0.2-beta.1",
-              filename: packedName,
-              integrity: "sha512-beta",
-              shasum: "betashasum",
-            },
-          ]),
-          stderr: "",
-          signal: null,
-          killed: false,
-          termination: "exit",
-        };
+      const result = await installPluginFromNpmSpec({
+        spec: "@openclaw/voice-call",
+        logger: { info: () => {}, warn: () => {} },
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain("prerelease version 0.0.2-beta.1");
+        expect(result.error).toContain('"@openclaw/voice-call@beta"');
       }
-      throw new Error(`unexpected command: ${argv.join(" ")}`);
-    });
-
-    const { extensionsDir } = await setupVoiceCallArchiveInstall({
-      outName: "voice-call-0.0.2-beta.1.tgz",
-      version: "0.0.1",
-    });
-    const result = await installPluginFromNpmSpec({
-      spec: "@remoteclaw/voice-call@beta",
-      extensionsDir,
-      logger: { info: () => {}, warn: () => {} },
-    });
-    expect(result.ok).toBe(true);
-    if (!result.ok) {
-      return;
     }
-    expect(result.npmResolution?.version).toBe("0.0.2-beta.1");
-    expect(result.npmResolution?.resolvedSpec).toBe("@remoteclaw/voice-call@0.0.2-beta.1");
-    expectSingleNpmPackIgnoreScriptsCall({
-      calls: run.mock.calls,
-      expectedSpec: "@remoteclaw/voice-call@beta",
-    });
-    expect(packTmpDir).not.toBe("");
+
+    vi.clearAllMocks();
+
+    {
+      const run = vi.mocked(runCommandWithTimeout);
+      let packTmpDir = "";
+      const packedName = "voice-call-0.0.2-beta.1.tgz";
+      const voiceCallArchiveBuffer = VOICE_CALL_ARCHIVE_V1_BUFFER;
+      run.mockImplementation(async (argv, opts) => {
+        if (argv[0] === "npm" && argv[1] === "pack") {
+          packTmpDir = String(typeof opts === "number" ? "" : (opts.cwd ?? ""));
+          fs.writeFileSync(path.join(packTmpDir, packedName), voiceCallArchiveBuffer);
+          return {
+            code: 0,
+            stdout: JSON.stringify([prereleaseMetadata]),
+            stderr: "",
+            signal: null,
+            killed: false,
+            termination: "exit",
+          };
+        }
+        throw new Error(`unexpected command: ${argv.join(" ")}`);
+      });
+
+      const { extensionsDir } = await setupVoiceCallArchiveInstall({
+        outName: "voice-call-0.0.2-beta.1.tgz",
+        version: "0.0.1",
+      });
+      const result = await installPluginFromNpmSpec({
+        spec: "@openclaw/voice-call@beta",
+        extensionsDir,
+        logger: { info: () => {}, warn: () => {} },
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        return;
+      }
+      expect(result.npmResolution?.version).toBe("0.0.2-beta.1");
+      expect(result.npmResolution?.resolvedSpec).toBe("@openclaw/voice-call@0.0.2-beta.1");
+      expectSingleNpmPackIgnoreScriptsCall({
+        calls: run.mock.calls,
+        expectedSpec: "@openclaw/voice-call@beta",
+      });
+      expect(packTmpDir).not.toBe("");
+    }
   });
 });

--- a/src/tui/tui-submit-test-helpers.ts
+++ b/src/tui/tui-submit-test-helpers.ts
@@ -1,5 +1,5 @@
 import { vi } from "vitest";
-import { createEditorSubmitHandler } from "./tui.js";
+import { createEditorSubmitHandler } from "./tui-submit.js";
 
 type MockFn = ReturnType<typeof vi.fn>;
 

--- a/src/tui/tui-submit.ts
+++ b/src/tui/tui-submit.ts
@@ -1,0 +1,143 @@
+export function createEditorSubmitHandler(params: {
+  editor: {
+    setText: (value: string) => void;
+    addToHistory: (value: string) => void;
+  };
+  handleCommand: (value: string) => Promise<void> | void;
+  sendMessage: (value: string) => Promise<void> | void;
+  handleBangLine: (value: string) => Promise<void> | void;
+}) {
+  return (text: string) => {
+    const raw = text;
+    const value = raw.trim();
+    params.editor.setText("");
+
+    // Keep previous behavior: ignore empty/whitespace-only submissions.
+    if (!value) {
+      return;
+    }
+
+    // Bash mode: only if the very first character is '!' and it's not just '!'.
+    // IMPORTANT: use the raw (untrimmed) text so leading spaces do NOT trigger.
+    // Per requirement: a lone '!' should be treated as a normal message.
+    if (raw.startsWith("!") && raw !== "!") {
+      params.editor.addToHistory(raw);
+      void params.handleBangLine(raw);
+      return;
+    }
+
+    // Enable built-in editor prompt history navigation (up/down).
+    params.editor.addToHistory(value);
+
+    if (value.startsWith("/")) {
+      void params.handleCommand(value);
+      return;
+    }
+
+    void params.sendMessage(value);
+  };
+}
+
+export function shouldEnableWindowsGitBashPasteFallback(params?: {
+  platform?: string;
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  const platform = params?.platform ?? process.platform;
+  const env = params?.env ?? process.env;
+  const termProgram = (env.TERM_PROGRAM ?? "").toLowerCase();
+
+  // Some macOS terminals emit multiline paste as rapid single-line submits.
+  // Enable burst coalescing so pasted blocks stay as one user message.
+  if (platform === "darwin") {
+    if (termProgram.includes("iterm") || termProgram.includes("apple_terminal")) {
+      return true;
+    }
+    return false;
+  }
+
+  if (platform !== "win32") {
+    return false;
+  }
+
+  const msystem = (env.MSYSTEM ?? "").toUpperCase();
+  const shell = env.SHELL ?? "";
+  if (msystem.startsWith("MINGW") || msystem.startsWith("MSYS")) {
+    return true;
+  }
+  if (shell.toLowerCase().includes("bash")) {
+    return true;
+  }
+  return termProgram.includes("mintty");
+}
+
+export function createSubmitBurstCoalescer(params: {
+  submit: (value: string) => void;
+  enabled: boolean;
+  burstWindowMs?: number;
+  now?: () => number;
+  setTimer?: typeof setTimeout;
+  clearTimer?: typeof clearTimeout;
+}) {
+  const windowMs = Math.max(1, params.burstWindowMs ?? 50);
+  const now = params.now ?? (() => Date.now());
+  const setTimer = params.setTimer ?? setTimeout;
+  const clearTimer = params.clearTimer ?? clearTimeout;
+  let pending: string | null = null;
+  let pendingAt = 0;
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearFlushTimer = () => {
+    if (!flushTimer) {
+      return;
+    }
+    clearTimer(flushTimer);
+    flushTimer = null;
+  };
+
+  const flushPending = () => {
+    if (pending === null) {
+      return;
+    }
+    const value = pending;
+    pending = null;
+    pendingAt = 0;
+    clearFlushTimer();
+    params.submit(value);
+  };
+
+  const scheduleFlush = () => {
+    clearFlushTimer();
+    flushTimer = setTimer(() => {
+      flushPending();
+    }, windowMs);
+  };
+
+  return (value: string) => {
+    if (!params.enabled) {
+      params.submit(value);
+      return;
+    }
+    if (value.includes("\n")) {
+      flushPending();
+      params.submit(value);
+      return;
+    }
+    const ts = now();
+    if (pending === null) {
+      pending = value;
+      pendingAt = ts;
+      scheduleFlush();
+      return;
+    }
+    if (ts - pendingAt <= windowMs) {
+      pending = `${pending}\n${value}`;
+      pendingAt = ts;
+      scheduleFlush();
+      return;
+    }
+    flushPending();
+    pending = value;
+    pendingAt = ts;
+    scheduleFlush();
+  };
+}

--- a/src/tui/tui.submit-handler.test.ts
+++ b/src/tui/tui.submit-handler.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { createSubmitHarness } from "./tui-submit-test-helpers.js";
-import { createSubmitBurstCoalescer, shouldEnableWindowsGitBashPasteFallback } from "./tui.js";
+import {
+  createSubmitBurstCoalescer,
+  shouldEnableWindowsGitBashPasteFallback,
+} from "./tui-submit.js";
 
 describe("createEditorSubmitHandler", () => {
   it("routes lines starting with ! to handleBangLine", () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -27,6 +27,11 @@ import { formatTokens } from "./tui-formatters.js";
 import { createLocalShellRunner } from "./tui-local-shell.js";
 import { createOverlayHandlers } from "./tui-overlays.js";
 import { createSessionActions } from "./tui-session-actions.js";
+import {
+  createEditorSubmitHandler,
+  createSubmitBurstCoalescer,
+  shouldEnableWindowsGitBashPasteFallback,
+} from "./tui-submit.js";
 import type {
   AgentSummary,
   SessionInfo,
@@ -38,150 +43,11 @@ import { buildWaitingStatusMessage, defaultWaitingPhrases } from "./tui-waiting.
 
 export { resolveFinalAssistantText } from "./tui-formatters.js";
 export type { TuiOptions } from "./tui-types.js";
-
-export function createEditorSubmitHandler(params: {
-  editor: {
-    setText: (value: string) => void;
-    addToHistory: (value: string) => void;
-  };
-  handleCommand: (value: string) => Promise<void> | void;
-  sendMessage: (value: string) => Promise<void> | void;
-  handleBangLine: (value: string) => Promise<void> | void;
-}) {
-  return (text: string) => {
-    const raw = text;
-    const value = raw.trim();
-    params.editor.setText("");
-
-    // Keep previous behavior: ignore empty/whitespace-only submissions.
-    if (!value) {
-      return;
-    }
-
-    // Bash mode: only if the very first character is '!' and it's not just '!'.
-    // IMPORTANT: use the raw (untrimmed) text so leading spaces do NOT trigger.
-    // Per requirement: a lone '!' should be treated as a normal message.
-    if (raw.startsWith("!") && raw !== "!") {
-      params.editor.addToHistory(raw);
-      void params.handleBangLine(raw);
-      return;
-    }
-
-    // Enable built-in editor prompt history navigation (up/down).
-    params.editor.addToHistory(value);
-
-    if (value.startsWith("/")) {
-      void params.handleCommand(value);
-      return;
-    }
-
-    void params.sendMessage(value);
-  };
-}
-
-export function shouldEnableWindowsGitBashPasteFallback(params?: {
-  platform?: string;
-  env?: NodeJS.ProcessEnv;
-}): boolean {
-  const platform = params?.platform ?? process.platform;
-  const env = params?.env ?? process.env;
-  const termProgram = (env.TERM_PROGRAM ?? "").toLowerCase();
-
-  // Some macOS terminals emit multiline paste as rapid single-line submits.
-  // Enable burst coalescing so pasted blocks stay as one user message.
-  if (platform === "darwin") {
-    if (termProgram.includes("iterm") || termProgram.includes("apple_terminal")) {
-      return true;
-    }
-    return false;
-  }
-
-  if (platform !== "win32") {
-    return false;
-  }
-
-  const msystem = (env.MSYSTEM ?? "").toUpperCase();
-  const shell = env.SHELL ?? "";
-  if (msystem.startsWith("MINGW") || msystem.startsWith("MSYS")) {
-    return true;
-  }
-  if (shell.toLowerCase().includes("bash")) {
-    return true;
-  }
-  return termProgram.includes("mintty");
-}
-
-export function createSubmitBurstCoalescer(params: {
-  submit: (value: string) => void;
-  enabled: boolean;
-  burstWindowMs?: number;
-  now?: () => number;
-  setTimer?: typeof setTimeout;
-  clearTimer?: typeof clearTimeout;
-}) {
-  const windowMs = Math.max(1, params.burstWindowMs ?? 50);
-  const now = params.now ?? (() => Date.now());
-  const setTimer = params.setTimer ?? setTimeout;
-  const clearTimer = params.clearTimer ?? clearTimeout;
-  let pending: string | null = null;
-  let pendingAt = 0;
-  let flushTimer: ReturnType<typeof setTimeout> | null = null;
-
-  const clearFlushTimer = () => {
-    if (!flushTimer) {
-      return;
-    }
-    clearTimer(flushTimer);
-    flushTimer = null;
-  };
-
-  const flushPending = () => {
-    if (pending === null) {
-      return;
-    }
-    const value = pending;
-    pending = null;
-    pendingAt = 0;
-    clearFlushTimer();
-    params.submit(value);
-  };
-
-  const scheduleFlush = () => {
-    clearFlushTimer();
-    flushTimer = setTimer(() => {
-      flushPending();
-    }, windowMs);
-  };
-
-  return (value: string) => {
-    if (!params.enabled) {
-      params.submit(value);
-      return;
-    }
-    if (value.includes("\n")) {
-      flushPending();
-      params.submit(value);
-      return;
-    }
-    const ts = now();
-    if (pending === null) {
-      pending = value;
-      pendingAt = ts;
-      scheduleFlush();
-      return;
-    }
-    if (ts - pendingAt <= windowMs) {
-      pending = `${pending}\n${value}`;
-      pendingAt = ts;
-      scheduleFlush();
-      return;
-    }
-    flushPending();
-    pending = value;
-    pendingAt = ts;
-    scheduleFlush();
-  };
-}
+export {
+  createEditorSubmitHandler,
+  createSubmitBurstCoalescer,
+  shouldEnableWindowsGitBashPasteFallback,
+} from "./tui-submit.js";
 
 export function resolveTuiSessionKey(params: {
   raw?: string;

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -115,7 +115,12 @@ export function loadSettings(): UiSettings {
   };
 
   try {
-    const raw = localStorage.getItem(KEY);
+    // First check for legacy key (no scope), then check for scoped key
+    const scopedKey = settingsKeyForGateway(defaults.gatewayUrl);
+    const raw =
+      storage?.getItem(scopedKey) ??
+      storage?.getItem(SETTINGS_KEY_PREFIX + "default") ??
+      storage?.getItem("openclaw.control.settings.v1");
     if (!raw) {
       return defaults;
     }
@@ -179,6 +184,37 @@ export function saveSettings(next: UiSettings) {
 
 function persistSettings(next: UiSettings) {
   persistSessionToken(next.gatewayUrl, next.token);
+  const storage = getSafeLocalStorage();
+  const scope = normalizeGatewayTokenScope(next.gatewayUrl);
+  const scopedKey = settingsKeyForGateway(next.gatewayUrl);
+  let existingSessionsByGateway: Record<string, ScopedSessionSelection> = {};
+  try {
+    // Try to migrate from legacy key or other scopes
+    const raw =
+      storage?.getItem(scopedKey) ??
+      storage?.getItem(SETTINGS_KEY_PREFIX + "default") ??
+      storage?.getItem("openclaw.control.settings.v1");
+    if (raw) {
+      const parsed = JSON.parse(raw) as PersistedUiSettings;
+      if (parsed.sessionsByGateway && typeof parsed.sessionsByGateway === "object") {
+        existingSessionsByGateway = parsed.sessionsByGateway;
+      }
+    }
+  } catch {
+    // best-effort
+  }
+  const sessionsByGateway = Object.fromEntries(
+    [
+      ...Object.entries(existingSessionsByGateway).filter(([key]) => key !== scope),
+      [
+        scope,
+        {
+          sessionKey: next.sessionKey,
+          lastActiveSessionKey: next.lastActiveSessionKey,
+        },
+      ],
+    ].slice(-MAX_SCOPED_SESSION_ENTRIES),
+  );
   const persisted: PersistedUiSettings = {
     gatewayUrl: next.gatewayUrl,
     sessionKey: next.sessionKey,


### PR DESCRIPTION
## Cherry-picks from upstream (issue #1902)

**Source**: openclaw/openclaw main branch
**Strategy**: staging branch (rebase-merge)

16 commits cherry-picked (7 already on base, 8 new picks, 1 skipped).

| Hash | Subject | Result |
|------|---------|--------|
| `11ca41f457` | fix(test): repair cron and loader regressions | SKIPPED (already on base) |
| `825a435709` | fix: avoid cron embedded lane deadlock | SKIPPED (already on base) |
| `8727338372` | perf: extract lightweight runtime seams | RESOLVED |
| `a8367bb0ec` | fix: stabilize ci gate | RESOLVED |
| `b70b7b0d94` | test: trim more local test startup overhead | RESOLVED |
| `e3ab0e174c` | style(core): normalize rebase fallout | RESOLVED |
| `0574ac23d0` | test: share delivery target session helpers | PICKED |
| `2201d533fd` | fix: enable fast mode for isolated cron runs | SKIPPED (already on base) |
| `49f3fbf726` | fix: restore cron manual run type narrowing | RESOLVED |
| `6c196c913f` | fix(cron): prevent duplicate proactive delivery on transient retry | SKIPPED (already on base) |
| `7b8e48ffb6` | refactor: share cron manual run preflight | SKIPPED (already on base) |
| `7fd21b6bc6` | refactor: share subagent followup reply helpers | PICKED |
| `9267e694f7` | perf: reduce cron persistence churn | SKIPPED (already on base) |
| `c95d1c101b` | fix(cron): avoid async context token warmup in isolated runs | SKIPPED (fork already avoids async context token lookup) |
| `f8d03022cf` | test: cover invalid main job store load | PICKED |
| `ff2368af57` | fix: stop false cron payload-kind warnings in doctor | SKIPPED (already on base) |

### Discarded files (fork-intentional)
- `src/cron/isolated-agent/model-selection.ts` — gutted model management
- `src/cron/isolated-agent.model-formatting.test.ts` — missing fork dependencies
- `src/hooks/bundled/session-memory/{handler,handler.test,transcript}.ts` — deleted in fork
- `src/cron/isolated-agent.test-setup.ts` — deleted in fork
- `src/cron/isolated-agent.helpers.test.ts` (some test files) — fork-deleted test helpers