### PR TITLE
Cherry-pick issue #1906: Build system and dependencies (1/2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -283,7 +283,7 @@
     "docs:spellcheck:fix": "bash scripts/docs-spellcheck.sh --write",
     "format": "oxfmt --write",
     "format:all": "pnpm format && pnpm format:swift",
-    "format:check": "oxfmt --check",
+    "format:check": "oxfmt --check --threads=1",
     "format:diff": "oxfmt --write && git --no-pager diff",
     "format:docs": "git ls-files 'docs/**/*.md' 'docs/**/*.mdx' 'README.md' | xargs oxfmt --write",
     "format:docs:check": "git ls-files 'docs/**/*.md' 'docs/**/*.mdx' 'README.md' | xargs oxfmt --check",

--- a/scripts/bundle-a2ui.sh
+++ b/scripts/bundle-a2ui.sh
@@ -86,7 +86,7 @@ if [[ -f "$HASH_FILE" ]]; then
 fi
 
 pnpm -s exec tsc -p "$A2UI_RENDERER_DIR/tsconfig.json"
-if command -v rolldown >/dev/null 2>&1; then
+if command -v rolldown >/dev/null 2>&1 && rolldown --version >/dev/null 2>&1; then
   rolldown -c "$A2UI_APP_DIR/rolldown.config.mjs"
 elif [[ -f "$ROOT_DIR/node_modules/.pnpm/node_modules/rolldown/bin/cli.mjs" ]]; then
   node "$ROOT_DIR/node_modules/.pnpm/node_modules/rolldown/bin/cli.mjs" -c "$A2UI_APP_DIR/rolldown.config.mjs"

--- a/scripts/check-architecture-smells.mjs
+++ b/scripts/check-architecture-smells.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import {
+  collectTypeScriptFilesFromRoots,
+  resolveSourceRoots,
+  runAsScript,
+  toLine,
+} from "./lib/ts-guard-utils.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const scanRoots = resolveSourceRoots(repoRoot, ["src/plugin-sdk", "src/plugins/runtime"]);
+
+function normalizePath(filePath) {
+  return path.relative(repoRoot, filePath).split(path.sep).join("/");
+}
+
+function compareEntries(left, right) {
+  return (
+    left.category.localeCompare(right.category) ||
+    left.file.localeCompare(right.file) ||
+    left.line - right.line ||
+    left.kind.localeCompare(right.kind) ||
+    left.specifier.localeCompare(right.specifier) ||
+    left.reason.localeCompare(right.reason)
+  );
+}
+
+function resolveSpecifier(specifier, importerFile) {
+  if (specifier.startsWith(".")) {
+    return normalizePath(path.resolve(path.dirname(importerFile), specifier));
+  }
+  if (specifier.startsWith("/")) {
+    return normalizePath(specifier);
+  }
+  return null;
+}
+
+function pushEntry(entries, entry) {
+  entries.push(entry);
+}
+
+function scanPluginSdkExtensionFacadeSmells(sourceFile, filePath) {
+  const relativeFile = normalizePath(filePath);
+  if (!relativeFile.startsWith("src/plugin-sdk/")) {
+    return [];
+  }
+
+  const entries = [];
+
+  function visit(node) {
+    if (
+      ts.isExportDeclaration(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      const specifier = node.moduleSpecifier.text;
+      const resolvedPath = resolveSpecifier(specifier, filePath);
+      if (resolvedPath?.startsWith("extensions/")) {
+        pushEntry(entries, {
+          category: "plugin-sdk-extension-facade",
+          file: relativeFile,
+          line: toLine(sourceFile, node.moduleSpecifier),
+          kind: "export",
+          specifier,
+          resolvedPath,
+          reason: "plugin-sdk public surface re-exports extension-owned implementation",
+        });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return entries;
+}
+
+function scanRuntimeTypeImplementationSmells(sourceFile, filePath) {
+  const relativeFile = normalizePath(filePath);
+  if (!/^src\/plugins\/runtime\/types(?:-[^/]+)?\.ts$/.test(relativeFile)) {
+    return [];
+  }
+
+  const entries = [];
+
+  function visit(node) {
+    if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      ts.isStringLiteral(node.argument.literal)
+    ) {
+      const specifier = node.argument.literal.text;
+      const resolvedPath = resolveSpecifier(specifier, filePath);
+      if (
+        resolvedPath &&
+        (/^src\/plugins\/runtime\/runtime-[^/]+\.ts$/.test(resolvedPath) ||
+          /^extensions\/[^/]+\/runtime-api\.[^/]+$/.test(resolvedPath))
+      ) {
+        pushEntry(entries, {
+          category: "runtime-type-implementation-edge",
+          file: relativeFile,
+          line: toLine(sourceFile, node.argument.literal),
+          kind: "import-type",
+          specifier,
+          resolvedPath,
+          reason: "runtime type file references implementation shim directly",
+        });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return entries;
+}
+
+function scanRuntimeServiceLocatorSmells(sourceFile, filePath) {
+  const relativeFile = normalizePath(filePath);
+  if (
+    !relativeFile.startsWith("src/plugin-sdk/") &&
+    !relativeFile.startsWith("src/plugins/runtime/")
+  ) {
+    return [];
+  }
+
+  const entries = [];
+  const exportedNames = new Set();
+  const runtimeStoreCalls = [];
+  const mutableStateNodes = [];
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isFunctionDeclaration(statement) && statement.name) {
+      const isExported = statement.modifiers?.some(
+        (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+      );
+      if (isExported) {
+        exportedNames.add(statement.name.text);
+      }
+    } else if (ts.isVariableStatement(statement)) {
+      const isExported = statement.modifiers?.some(
+        (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+      );
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name) && isExported) {
+          exportedNames.add(declaration.name.text);
+        }
+        if (
+          !isExported &&
+          (statement.declarationList.flags & ts.NodeFlags.Let) !== 0 &&
+          ts.isIdentifier(declaration.name)
+        ) {
+          mutableStateNodes.push(declaration.name);
+        }
+      }
+    }
+  }
+
+  function visit(node) {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "createPluginRuntimeStore"
+    ) {
+      runtimeStoreCalls.push(node.expression);
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  const getterNames = [...exportedNames].filter((name) => /^get[A-Z]/.test(name));
+  const setterNames = [...exportedNames].filter((name) => /^set[A-Z]/.test(name));
+
+  if (runtimeStoreCalls.length > 0 && getterNames.length > 0 && setterNames.length > 0) {
+    for (const callNode of runtimeStoreCalls) {
+      pushEntry(entries, {
+        category: "runtime-service-locator",
+        file: relativeFile,
+        line: toLine(sourceFile, callNode),
+        kind: "runtime-store",
+        specifier: "createPluginRuntimeStore",
+        resolvedPath: relativeFile,
+        reason: `exports paired runtime accessors (${getterNames.join(", ")} / ${setterNames.join(", ")}) over module-global store state`,
+      });
+    }
+  }
+
+  if (mutableStateNodes.length > 0 && getterNames.length > 0 && setterNames.length > 0) {
+    for (const identifier of mutableStateNodes) {
+      pushEntry(entries, {
+        category: "runtime-service-locator",
+        file: relativeFile,
+        line: toLine(sourceFile, identifier),
+        kind: "mutable-state",
+        specifier: identifier.text,
+        resolvedPath: relativeFile,
+        reason: `module-global mutable state backs exported runtime accessors (${getterNames.join(", ")} / ${setterNames.join(", ")})`,
+      });
+    }
+  }
+
+  return entries;
+}
+
+export async function collectArchitectureSmells() {
+  const files = (await collectTypeScriptFilesFromRoots(scanRoots)).toSorted((left, right) =>
+    normalizePath(left).localeCompare(normalizePath(right)),
+  );
+
+  const inventory = [];
+  for (const filePath of files) {
+    const source = await fs.readFile(filePath, "utf8");
+    const sourceFile = ts.createSourceFile(
+      filePath,
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    inventory.push(...scanPluginSdkExtensionFacadeSmells(sourceFile, filePath));
+    inventory.push(...scanRuntimeTypeImplementationSmells(sourceFile, filePath));
+    inventory.push(...scanRuntimeServiceLocatorSmells(sourceFile, filePath));
+  }
+
+  return inventory.toSorted(compareEntries);
+}
+
+function formatInventoryHuman(inventory) {
+  if (inventory.length === 0) {
+    return "No architecture smells found for the configured checks.";
+  }
+
+  const lines = ["Architecture smell inventory:"];
+  let activeCategory = "";
+  let activeFile = "";
+  for (const entry of inventory) {
+    if (entry.category !== activeCategory) {
+      activeCategory = entry.category;
+      activeFile = "";
+      lines.push(entry.category);
+    }
+    if (entry.file !== activeFile) {
+      activeFile = entry.file;
+      lines.push(`  ${activeFile}`);
+    }
+    lines.push(`    - line ${entry.line} [${entry.kind}] ${entry.reason}`);
+    lines.push(`      specifier: ${entry.specifier}`);
+    lines.push(`      resolved: ${entry.resolvedPath}`);
+  }
+  return lines.join("\n");
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const json = argv.includes("--json");
+  const inventory = await collectArchitectureSmells();
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(inventory, null, 2)}\n`);
+    return;
+  }
+
+  console.log(formatInventoryHuman(inventory));
+  console.log(`${inventory.length} smell${inventory.length === 1 ? "" : "s"} found.`);
+}
+
+runAsScript(import.meta.url, main);

--- a/scripts/committer
+++ b/scripts/committer
@@ -39,7 +39,47 @@ if [ "$#" -eq 0 ]; then
   usage
 fi
 
-files=("$@")
+path_exists_or_tracked() {
+  local candidate=$1
+  [ -e "$candidate" ] || git ls-files --error-unmatch -- "$candidate" >/dev/null 2>&1
+}
+
+append_normalized_file_arg() {
+  local raw=$1
+
+  if path_exists_or_tracked "$raw"; then
+    files+=("$raw")
+    return
+  fi
+
+  if [[ "$raw" == *$'\n'* || "$raw" == *$'\r'* ]]; then
+    local normalized=${raw//$'\r'/}
+    while IFS= read -r line; do
+      if [[ "$line" == *[![:space:]]* ]]; then
+        files+=("$line")
+      fi
+    done <<< "$normalized"
+    return
+  fi
+
+  if [[ "$raw" == *[[:space:]]* ]]; then
+    local split_paths=()
+    # Intentional IFS split for callers that pass a single shell-expanded path blob.
+    # shellcheck disable=SC2206
+    split_paths=($raw)
+    if [ "${#split_paths[@]}" -gt 1 ]; then
+      files+=("${split_paths[@]}")
+      return
+    fi
+  fi
+
+  files+=("$raw")
+}
+
+files=()
+for raw_arg in "$@"; do
+  append_normalized_file_arg "$raw_arg"
+done
 
 # Disallow "." because it stages the entire repository and defeats the helper's safety guardrails.
 for file in "${files[@]}"; do
@@ -129,11 +169,9 @@ run_git_with_lock_retry() {
 }
 
 for file in "${files[@]}"; do
-  if [ ! -e "$file" ]; then
-    if ! git ls-files --error-unmatch -- "$file" >/dev/null 2>&1; then
-      printf 'Error: file not found: %s\n' "$file" >&2
-      exit 1
-    fi
+  if ! path_exists_or_tracked "$file"; then
+    printf 'Error: file not found: %s\n' "$file" >&2
+    exit 1
   fi
 done
 

--- a/scripts/docs-i18n/translator.go
+++ b/scripts/docs-i18n/translator.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -14,6 +13,7 @@ import (
 const (
 	translateMaxAttempts = 3
 	translateBaseDelay   = 15 * time.Second
+	translatePromptTimeout = 2 * time.Minute
 )
 
 var errEmptyTranslation = errors.New("empty translation")
@@ -145,96 +145,31 @@ func (t *PiTranslator) Close() {
 	}
 }
 
-type agentEndPayload struct {
-	Messages []agentMessage `json:"messages"`
+type promptRunner interface {
+	Run(context.Context, string) (pi.RunResult, error)
+	Stderr() string
 }
 
-type agentMessage struct {
-	Role         string          `json:"role"`
-	Content      json.RawMessage `json:"content"`
-	StopReason   string          `json:"stopReason,omitempty"`
-	ErrorMessage string          `json:"errorMessage,omitempty"`
-}
-
-type contentBlock struct {
-	Type string `json:"type"`
-	Text string `json:"text,omitempty"`
-}
-
-func runPrompt(ctx context.Context, client *pi.OneShotClient, message string) (string, error) {
-	events, cancel := client.Subscribe(256)
+func runPrompt(ctx context.Context, client promptRunner, message string) (string, error) {
+	promptCtx, cancel := context.WithTimeout(ctx, translatePromptTimeout)
 	defer cancel()
 
-	if err := client.Prompt(ctx, message); err != nil {
-		return "", err
+	result, err := client.Run(promptCtx, message)
+	if err != nil {
+		return "", decoratePromptError(err, client.Stderr())
 	}
-
-	for {
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		case event, ok := <-events:
-			if !ok {
-				return "", errors.New("event stream closed")
-			}
-			if event.Type == "agent_end" {
-				return extractTranslationResult(event.Raw)
-			}
-		}
-	}
+	return result.Text, nil
 }
 
-func extractTranslationResult(raw json.RawMessage) (string, error) {
-	var payload agentEndPayload
-	if err := json.Unmarshal(raw, &payload); err != nil {
-		return "", err
+func decoratePromptError(err error, stderr string) error {
+	if err == nil {
+		return nil
 	}
-	for index := len(payload.Messages) - 1; index >= 0; index-- {
-		message := payload.Messages[index]
-		if message.Role != "assistant" {
-			continue
-		}
-		if message.ErrorMessage != "" || strings.EqualFold(message.StopReason, "error") {
-			msg := strings.TrimSpace(message.ErrorMessage)
-			if msg == "" {
-				msg = "unknown error"
-			}
-			return "", fmt.Errorf("pi error: %s", msg)
-		}
-		text, err := extractContentText(message.Content)
-		if err != nil {
-			return "", err
-		}
-		return text, nil
-	}
-	return "", errors.New("assistant message not found")
-}
-
-func extractContentText(content json.RawMessage) (string, error) {
-	trimmed := strings.TrimSpace(string(content))
+	trimmed := strings.TrimSpace(stderr)
 	if trimmed == "" {
-		return "", nil
+		return err
 	}
-	if strings.HasPrefix(trimmed, "\"") {
-		var text string
-		if err := json.Unmarshal(content, &text); err != nil {
-			return "", err
-		}
-		return text, nil
-	}
-
-	var blocks []contentBlock
-	if err := json.Unmarshal(content, &blocks); err != nil {
-		return "", err
-	}
-
-	var parts []string
-	for _, block := range blocks {
-		if block.Type == "text" && block.Text != "" {
-			parts = append(parts, block.Text)
-		}
-	}
-	return strings.Join(parts, ""), nil
+	return fmt.Errorf("%w (pi stderr: %s)", err, trimmed)
 }
 
 func normalizeThinking(value string) string {

--- a/scripts/docs-i18n/translator_test.go
+++ b/scripts/docs-i18n/translator_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	pi "github.com/joshp123/pi-golang"
+)
+
+type fakePromptRunner struct {
+	run    func(context.Context, string) (pi.RunResult, error)
+	stderr string
+}
+
+func (runner fakePromptRunner) Run(ctx context.Context, message string) (pi.RunResult, error) {
+	return runner.run(ctx, message)
+}
+
+func (runner fakePromptRunner) Stderr() string {
+	return runner.stderr
+}
+
+func TestRunPromptAddsTimeout(t *testing.T) {
+	t.Parallel()
+
+	var deadline time.Time
+	client := fakePromptRunner{
+		run: func(ctx context.Context, message string) (pi.RunResult, error) {
+			var ok bool
+			deadline, ok = ctx.Deadline()
+			if !ok {
+				t.Fatal("expected prompt deadline")
+			}
+			if message != "Translate me" {
+				t.Fatalf("unexpected message %q", message)
+			}
+			return pi.RunResult{Text: "translated"}, nil
+		},
+	}
+
+	got, err := runPrompt(context.Background(), client, "Translate me")
+	if err != nil {
+		t.Fatalf("runPrompt returned error: %v", err)
+	}
+	if got != "translated" {
+		t.Fatalf("unexpected translation %q", got)
+	}
+
+	remaining := time.Until(deadline)
+	if remaining <= time.Minute || remaining > translatePromptTimeout {
+		t.Fatalf("unexpected timeout window %s", remaining)
+	}
+}
+
+func TestRunPromptIncludesStderr(t *testing.T) {
+	t.Parallel()
+
+	rootErr := errors.New("context deadline exceeded")
+	client := fakePromptRunner{
+		run: func(context.Context, string) (pi.RunResult, error) {
+			return pi.RunResult{}, rootErr
+		},
+		stderr: "boom",
+	}
+
+	_, err := runPrompt(context.Background(), client, "Translate me")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, rootErr) {
+		t.Fatalf("expected wrapped root error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "pi stderr: boom") {
+		t.Fatalf("expected stderr in error, got %v", err)
+	}
+}
+
+func TestDecoratePromptErrorLeavesCleanErrorsAlone(t *testing.T) {
+	t.Parallel()
+
+	rootErr := errors.New("plain failure")
+	got := decoratePromptError(rootErr, "  ")
+	if !errors.Is(got, rootErr) {
+		t.Fatalf("expected original error, got %v", got)
+	}
+	if got.Error() != rootErr.Error() {
+		t.Fatalf("expected unchanged message, got %v", got)
+	}
+}

--- a/scripts/lib/ts-guard-utils.mjs
+++ b/scripts/lib/ts-guard-utils.mjs
@@ -1,7 +1,15 @@
 import { promises as fs } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import ts from "typescript";
+
+const require = createRequire(import.meta.url);
+let tsCache;
+
+function getTypeScript() {
+  tsCache ??= require("typescript");
+  return tsCache;
+}
 
 const baseTestSuffixes = [".test.ts", ".test-utils.ts", ".test-harness.ts", ".e2e-harness.ts"];
 
@@ -113,6 +121,7 @@ export function toLine(sourceFile, node) {
 }
 
 export function getPropertyNameText(name) {
+  const ts = getTypeScript();
   if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
     return name.text;
   }
@@ -120,6 +129,7 @@ export function getPropertyNameText(name) {
 }
 
 export function unwrapExpression(expression) {
+  const ts = getTypeScript();
   let current = expression;
   while (true) {
     if (ts.isParenthesizedExpression(current)) {

--- a/scripts/test-runner-manifest.mjs
+++ b/scripts/test-runner-manifest.mjs
@@ -35,7 +35,11 @@ const normalizeManifestEntries = (entries) =>
 export function loadTestRunnerBehavior() {
   const raw = readJson(behaviorManifestPath, {});
   const unit = raw.unit ?? {};
+  const base = raw.base ?? {};
   return {
+    base: {
+      threadSingleton: normalizeManifestEntries(base.threadSingleton ?? []),
+    },
     unit: {
       isolated: normalizeManifestEntries(unit.isolated ?? []),
       singletonIsolated: normalizeManifestEntries(unit.singletonIsolated ?? []),

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../../runtime.js";
 
 const loadAndMaybeMigrateDoctorConfigMock = vi.hoisted(() => vi.fn());
@@ -11,6 +11,8 @@ vi.mock("../../commands/doctor-config-flow.js", () => ({
 vi.mock("../../config/config.js", () => ({
   readConfigFileSnapshot: readConfigFileSnapshotMock,
 }));
+
+const mockedModuleIds = ["../../commands/doctor-config-preflight.js", "../../config/config.js"];
 
 function makeSnapshot() {
   return {
@@ -72,6 +74,13 @@ describe("ensureConfigReady", () => {
       ensureConfigReady,
       __test__: { resetConfigGuardStateForTests },
     } = await import("./config-guard.js"));
+  });
+
+  afterAll(() => {
+    for (const id of mockedModuleIds) {
+      vi.doUnmock(id);
+    }
+    vi.resetModules();
   });
 
   beforeEach(() => {

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const agentCliCommandMock = vi.fn();
 const agentsAddCommandMock = vi.fn();
@@ -50,10 +50,25 @@ vi.mock("../../runtime.js", () => ({
   defaultRuntime: runtime,
 }));
 
+const mockedModuleIds = [
+  "../../commands/agent-via-gateway.js",
+  "../../commands/agents.js",
+  "../../globals.js",
+  "../deps.js",
+  "../../runtime.js",
+];
+
 let registerAgentCommands: typeof import("./register.agent.js").registerAgentCommands;
 
 beforeAll(async () => {
   ({ registerAgentCommands } = await import("./register.agent.js"));
+});
+
+afterAll(() => {
+  for (const id of mockedModuleIds) {
+    vi.doUnmock(id);
+  }
+  vi.resetModules();
 });
 
 describe("registerAgentCommands", () => {

--- a/src/cli/program/register.configure.test.ts
+++ b/src/cli/program/register.configure.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const configureCommandFromSectionsArgMock = vi.fn();
 const runtime = {
@@ -17,10 +17,19 @@ vi.mock("../../runtime.js", () => ({
   defaultRuntime: runtime,
 }));
 
+const mockedModuleIds = ["../../commands/configure.js", "../../runtime.js"];
+
 let registerConfigureCommand: typeof import("./register.configure.js").registerConfigureCommand;
 
 beforeAll(async () => {
   ({ registerConfigureCommand } = await import("./register.configure.js"));
+});
+
+afterAll(() => {
+  for (const id of mockedModuleIds) {
+    vi.doUnmock(id);
+  }
+  vi.resetModules();
 });
 
 describe("registerConfigureCommand", () => {

--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const doctorCommand = vi.fn();
 const dashboardCommand = vi.fn();
@@ -32,10 +32,25 @@ vi.mock("../../runtime.js", () => ({
   defaultRuntime: runtime,
 }));
 
+const mockedModuleIds = [
+  "../../commands/doctor.js",
+  "../../commands/dashboard.js",
+  "../../commands/reset.js",
+  "../../commands/uninstall.js",
+  "../../runtime.js",
+];
+
 let registerMaintenanceCommands: typeof import("./register.maintenance.js").registerMaintenanceCommands;
 
 beforeAll(async () => {
   ({ registerMaintenanceCommands } = await import("./register.maintenance.js"));
+});
+
+afterAll(() => {
+  for (const id of mockedModuleIds) {
+    vi.doUnmock(id);
+  }
+  vi.resetModules();
 });
 
 describe("registerMaintenanceCommands doctor action", () => {

--- a/src/cli/program/register.message.test.ts
+++ b/src/cli/program/register.message.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProgramContext } from "./context.js";
 
 const createMessageCliHelpersMock = vi.fn(() => ({ helper: true }));
@@ -62,10 +62,31 @@ vi.mock("./message/register.discord-admin.js", () => ({
   registerMessageDiscordAdminCommands: registerMessageDiscordAdminCommandsMock,
 }));
 
+const mockedModuleIds = [
+  "./message/helpers.js",
+  "./message/register.send.js",
+  "./message/register.broadcast.js",
+  "./message/register.poll.js",
+  "./message/register.reactions.js",
+  "./message/register.read-edit-delete.js",
+  "./message/register.pins.js",
+  "./message/register.permissions-search.js",
+  "./message/register.thread.js",
+  "./message/register.emoji-sticker.js",
+  "./message/register.discord-admin.js",
+];
+
 let registerMessageCommands: typeof import("./register.message.js").registerMessageCommands;
 
 beforeAll(async () => {
   ({ registerMessageCommands } = await import("./register.message.js"));
+});
+
+afterAll(() => {
+  for (const id of mockedModuleIds) {
+    vi.doUnmock(id);
+  }
+  vi.resetModules();
 });
 
 describe("registerMessageCommands", () => {

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const onboardCommandMock = vi.fn();
 
@@ -27,10 +27,26 @@ vi.mock("../../runtime.js", () => ({
   defaultRuntime: runtime,
 }));
 
+const mockedModuleIds = [
+  "../../commands/auth-choice-options.static.js",
+  "../../commands/auth-choice-options.js",
+  "../../commands/onboard-core-auth-flags.js",
+  "../../plugins/provider-auth-choices.js",
+  "../../commands/onboard.js",
+  "../../runtime.js",
+];
+
 let registerOnboardCommand: typeof import("./register.onboard.js").registerOnboardCommand;
 
 beforeAll(async () => {
   ({ registerOnboardCommand } = await import("./register.onboard.js"));
+});
+
+afterAll(() => {
+  for (const id of mockedModuleIds) {
+    vi.doUnmock(id);
+  }
+  vi.resetModules();
 });
 
 describe("registerOnboardCommand", () => {

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const setupCommandMock = vi.fn();
 const onboardCommandMock = vi.fn();
@@ -21,10 +21,23 @@ vi.mock("../../runtime.js", () => ({
   defaultRuntime: runtime,
 }));
 
+const mockedModuleIds = [
+  "../../commands/setup.js",
+  "../../commands/onboard.js",
+  "../../runtime.js",
+];
+
 let registerSetupCommand: typeof import("./register.setup.js").registerSetupCommand;
 
 beforeAll(async () => {
   ({ registerSetupCommand } = await import("./register.setup.js"));
+});
+
+afterAll(() => {
+  for (const id of mockedModuleIds) {
+    vi.doUnmock(id);
+  }
+  vi.resetModules();
 });
 
 describe("registerSetupCommand", () => {

--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { acpAction, registerAcpCli } = vi.hoisted(() => {
   const action = vi.fn();
@@ -27,8 +27,17 @@ vi.mock("../acp-cli.js", () => ({ registerAcpCli }));
 vi.mock("../nodes-cli.js", () => ({ registerNodesCli }));
 vi.mock("../../config/config.js", () => configModule);
 
+const mockedModuleIds = ["../acp-cli.js", "../nodes-cli.js", "../../config/config.js"];
+
 const { loadValidatedConfigForPluginRegistration, registerSubCliByName, registerSubCliCommands } =
   await import("./register.subclis.js");
+
+afterAll(() => {
+  for (const id of mockedModuleIds) {
+    vi.doUnmock(id);
+  }
+  vi.resetModules();
+});
 
 describe("registerSubCliCommands", () => {
   const originalArgv = process.argv;

--- a/src/cron/service.issue-regressions.test-helpers.ts
+++ b/src/cron/service.issue-regressions.test-helpers.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
 import { useFrozenTime, useRealTime } from "../test-utils/frozen-time.js";
 import type { CronService } from "./service.js";
 import type { CronJob, CronJobState } from "./types.js";
@@ -31,6 +31,15 @@ export function setupCronIssueRegressionFixtures() {
     useFrozenTime("2026-02-06T10:05:00.000Z");
   });
 
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.restoreAllMocks();
+    useRealTime();
+    clearSessionStoreCacheForTest();
+    resetAgentRunContextForTest();
+    clearAllBootstrapSnapshots();
+    vi.resetModules();
+  });
   afterAll(async () => {
     useRealTime();
     await fs.rm(fixtureRoot, { recursive: true, force: true });

--- a/src/cron/service.issue-regressions.test-helpers.ts
+++ b/src/cron/service.issue-regressions.test-helpers.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, vi } from "vitest";
 import { useFrozenTime, useRealTime } from "../test-utils/frozen-time.js";
 import type { CronService } from "./service.js";
 import type { CronJob, CronJobState } from "./types.js";
@@ -31,15 +31,6 @@ export function setupCronIssueRegressionFixtures() {
     useFrozenTime("2026-02-06T10:05:00.000Z");
   });
 
-  afterEach(() => {
-    vi.clearAllTimers();
-    vi.restoreAllMocks();
-    useRealTime();
-    clearSessionStoreCacheForTest();
-    resetAgentRunContextForTest();
-    clearAllBootstrapSnapshots();
-    vi.resetModules();
-  });
   afterAll(async () => {
     useRealTime();
     await fs.rm(fixtureRoot, { recursive: true, force: true });

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -35,6 +35,15 @@ const FAST_TIMEOUT_SECONDS = 1;
 describe("Cron issue regressions", () => {
   const { makeStorePath } = setupCronIssueRegressionFixtures();
 
+  afterEach(() => {
+    // Shared-state runs can begin collecting the next file before runner-level
+    // cleanup unwinds this suite's fake timers or command-lane mutations.
+    vi.clearAllTimers();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    clearCommandLane(CommandLane.Cron);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+  });
   it("covers schedule updates and payload patching", async () => {
     const store = makeStorePath();
     const cron = await startCronForStore({
@@ -1120,6 +1129,10 @@ describe("Cron issue regressions", () => {
       requestHeartbeatNow: vi.fn(),
       runIsolatedAgentJob: vi.fn(async (params) => {
         const abortSignal = params.abortSignal;
+        if (abortSignal?.aborted) {
+          now += 100;
+          throw new Error("aborted");
+        }
         await new Promise<void>((resolve, reject) => {
           const onAbort = () => {
             abortSignal?.removeEventListener("abort", onAbort);

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -35,15 +35,6 @@ const FAST_TIMEOUT_SECONDS = 1;
 describe("Cron issue regressions", () => {
   const { makeStorePath } = setupCronIssueRegressionFixtures();
 
-  afterEach(() => {
-    // Shared-state runs can begin collecting the next file before runner-level
-    // cleanup unwinds this suite's fake timers or command-lane mutations.
-    vi.clearAllTimers();
-    vi.restoreAllMocks();
-    vi.useRealTimers();
-    clearCommandLane(CommandLane.Cron);
-    setCommandLaneConcurrency(CommandLane.Cron, 1);
-  });
   it("covers schedule updates and payload patching", async () => {
     const store = makeStorePath();
     const cron = await startCronForStore({
@@ -1129,10 +1120,6 @@ describe("Cron issue regressions", () => {
       requestHeartbeatNow: vi.fn(),
       runIsolatedAgentJob: vi.fn(async (params) => {
         const abortSignal = params.abortSignal;
-        if (abortSignal?.aborted) {
-          now += 100;
-          throw new Error("aborted");
-        }
         await new Promise<void>((resolve, reject) => {
           const onAbort = () => {
             abortSignal?.removeEventListener("abort", onAbort);

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -1,4 +1,3 @@
-import { EnvHttpProxyAgent } from "undici";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchWithSsrFGuard, GUARDED_FETCH_MODE } from "./fetch-guard.js";
 
@@ -11,6 +10,14 @@ function redirectResponse(location: string): Response {
 
 function okResponse(body = "ok"): Response {
   return new Response(body, { status: 200 });
+}
+
+function getDispatcherClassName(value: unknown): string | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const ctor = (value as { constructor?: unknown }).constructor;
+  return typeof ctor === "function" && ctor.name ? ctor.name : null;
 }
 
 function getSecondRequestHeaders(fetchImpl: ReturnType<typeof vi.fn>): Headers {
@@ -70,10 +77,10 @@ describe("fetchWithSsrFGuard hardening", () => {
     const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const requestInit = init as RequestInit & { dispatcher?: unknown };
       if (params.expectEnvProxy) {
-        expect(requestInit.dispatcher).toBeInstanceOf(EnvHttpProxyAgent);
+        expect(getDispatcherClassName(requestInit.dispatcher)).toBe("EnvHttpProxyAgent");
       } else {
         expect(requestInit.dispatcher).toBeDefined();
-        expect(requestInit.dispatcher).not.toBeInstanceOf(EnvHttpProxyAgent);
+        expect(getDispatcherClassName(requestInit.dispatcher)).not.toBe("EnvHttpProxyAgent");
       }
       return okResponse();
     });

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { ProxyAgent, EnvHttpProxyAgent, undiciFetch, proxyAgentSpy, envAgentSpy, getLastAgent } =
   vi.hoisted(() => {
@@ -31,6 +31,8 @@ const { ProxyAgent, EnvHttpProxyAgent, undiciFetch, proxyAgentSpy, envAgentSpy, 
       getLastAgent: () => ProxyAgent.lastCreated,
     };
   });
+
+const mockedModuleIds = ["undici"] as const;
 
 vi.mock("undici", () => ({
   ProxyAgent,
@@ -169,4 +171,11 @@ describe("resolveProxyFetchFromEnv", () => {
     const fetchFn = resolveProxyFetchFromEnv();
     expect(fetchFn).toBeUndefined();
   });
+});
+
+afterAll(() => {
+  for (const id of mockedModuleIds) {
+    vi.doUnmock(id);
+  }
+  vi.resetModules();
 });

--- a/test/architecture-smells.test.ts
+++ b/test/architecture-smells.test.ts
@@ -1,0 +1,36 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { collectArchitectureSmells } from "../scripts/check-architecture-smells.mjs";
+
+const repoRoot = process.cwd();
+const scriptPath = path.join(repoRoot, "scripts", "check-architecture-smells.mjs");
+
+describe("architecture smell inventory", () => {
+  it("produces stable sorted output", async () => {
+    const first = await collectArchitectureSmells();
+    const second = await collectArchitectureSmells();
+
+    expect(second).toEqual(first);
+    expect(
+      [...first].toSorted(
+        (left, right) =>
+          left.category.localeCompare(right.category) ||
+          left.file.localeCompare(right.file) ||
+          left.line - right.line ||
+          left.kind.localeCompare(right.kind) ||
+          left.specifier.localeCompare(right.specifier) ||
+          left.reason.localeCompare(right.reason),
+      ),
+    ).toEqual(first);
+  });
+
+  it("script json output matches the collector", async () => {
+    const stdout = execFileSync(process.execPath, [scriptPath, "--json"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+
+    expect(JSON.parse(stdout)).toEqual(await collectArchitectureSmells());
+  });
+});

--- a/test/scripts/committer.test.ts
+++ b/test/scripts/committer.test.ts
@@ -1,0 +1,89 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const scriptPath = path.join(process.cwd(), "scripts", "committer");
+const tempRepos: string[] = [];
+
+function run(cwd: string, command: string, args: string[]) {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+  }).trim();
+}
+
+function git(cwd: string, ...args: string[]) {
+  return run(cwd, "git", args);
+}
+
+function createRepo() {
+  const repo = mkdtempSync(path.join(tmpdir(), "committer-test-"));
+  tempRepos.push(repo);
+
+  git(repo, "init", "-q");
+  git(repo, "config", "user.email", "test@example.com");
+  git(repo, "config", "user.name", "Test User");
+  writeFileSync(path.join(repo, "seed.txt"), "seed\n");
+  git(repo, "add", "seed.txt");
+  git(repo, "commit", "-qm", "seed");
+
+  return repo;
+}
+
+function writeRepoFile(repo: string, relativePath: string, contents: string) {
+  const fullPath = path.join(repo, relativePath);
+  mkdirSync(path.dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, contents);
+}
+
+function commitWithHelper(repo: string, commitMessage: string, ...args: string[]) {
+  return run(repo, "bash", [scriptPath, commitMessage, ...args]);
+}
+
+function committedPaths(repo: string) {
+  const output = git(repo, "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD");
+  return output.split("\n").filter(Boolean).toSorted();
+}
+
+afterEach(() => {
+  while (tempRepos.length > 0) {
+    const repo = tempRepos.pop();
+    if (repo) {
+      rmSync(repo, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("scripts/committer", () => {
+  it("keeps plain argv paths working", () => {
+    const repo = createRepo();
+    writeRepoFile(repo, "alpha.txt", "alpha\n");
+    writeRepoFile(repo, "nested/file with spaces.txt", "beta\n");
+
+    commitWithHelper(repo, "test: plain argv", "alpha.txt", "nested/file with spaces.txt");
+
+    expect(committedPaths(repo)).toEqual(["alpha.txt", "nested/file with spaces.txt"]);
+  });
+
+  it("accepts a single space-delimited path blob", () => {
+    const repo = createRepo();
+    writeRepoFile(repo, "alpha.txt", "alpha\n");
+    writeRepoFile(repo, "beta.txt", "beta\n");
+
+    commitWithHelper(repo, "test: space blob", "alpha.txt beta.txt");
+
+    expect(committedPaths(repo)).toEqual(["alpha.txt", "beta.txt"]);
+  });
+
+  it("accepts a single newline-delimited path blob", () => {
+    const repo = createRepo();
+    writeRepoFile(repo, "alpha.txt", "alpha\n");
+    writeRepoFile(repo, "nested/file with spaces.txt", "beta\n");
+
+    commitWithHelper(repo, "test: newline blob", "alpha.txt\nnested/file with spaces.txt");
+
+    expect(committedPaths(repo)).toEqual(["alpha.txt", "nested/file with spaces.txt"]);
+  });
+});

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -633,6 +633,13 @@
   line-height: 1.55;
 }
 
+.config-raw-field .config-raw-toggle {
+  width: 32px;
+  height: 32px;
+  padding: 6px;
+  min-width: 32px;
+}
+
 /* Loading State */
 .config-loading {
   display: flex;


### PR DESCRIPTION
## Cherry-picks from upstream (issue #1906)

9 of 50 commits cherry-picked. 41 skipped due to conflicts with fork-divergent files (scripts/test-parallel.mjs, package.json, plugin-sdk entrypoints, and gutted layers).

### Picked commits
- `047a01f9e2` build: serialize formatter checks in CI
- `091b811a61` fix(ci): lazy-load TypeScript in ts guard utils
- `0a136f1b90` fix(docs): harden i18n prompt failures
- `0aa79fc4d3` fix(build): restore full gate
- `2773f33084` test: stabilize vitest no-isolate suites
- `5f89897df1` plugins: dist node_modules symlink + config raw-toggle UI fix
- `600f57c979` test: add architecture smell detector
- `60a55c9cbe` fix(committer): accept argv and shell path blobs
- `8e09568bc7` perf: expand base vitest thread lanes

### Conflict patterns
Most conflicts stem from:
- `scripts/test-parallel.mjs` — significantly restructured on fork (REMOTECLAW env vars, different runner config)
- `package.json` — fork-protected (name=remoteclaw, different scripts)
- Plugin SDK entrypoints — fork uses different subpath structure
- Files in gutted layers (pi-agent-core, memory, secrets, etc.)

See issue #1906 for full commit list.

Closes #1906