### PR TITLE
Cherry-pick: security hardening — ACP test dedupe (1 of 5)

### DIFF
--- a/src/acp/translator.cancel-scoping.test.ts
+++ b/src/acp/translator.cancel-scoping.test.ts
@@ -91,19 +91,45 @@ async function startPendingPrompt(
   };
 }
 
+async function cancelAndExpectAbortForPendingRun(
+  harness: Harness,
+  sessionId: string,
+  sessionKey: string,
+  pending: { promptPromise: Promise<PromptResponse>; runId: string },
+) {
+  await harness.agent.cancel({ sessionId } as CancelNotification);
+
+  expect(harness.requestSpy).toHaveBeenCalledWith("chat.abort", {
+    sessionKey,
+    runId: pending.runId,
+  });
+  await expect(pending.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+}
+
+async function deliverFinalChatEventAndExpectEndTurn(
+  harness: Harness,
+  sessionKey: string,
+  pending: { promptPromise: Promise<PromptResponse>; runId: string },
+  seq: number,
+) {
+  await harness.agent.handleGatewayEvent(
+    createChatEvent({
+      runId: pending.runId,
+      sessionKey,
+      seq,
+      state: "final",
+    }),
+  );
+  await expect(pending.promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+}
+
 describe("acp translator cancel and run scoping", () => {
   it("cancel passes active runId to chat.abort", async () => {
     const sessionKey = "agent:main:shared";
     const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
     const pending = await startPendingPrompt(harness, "session-1");
 
-    await harness.agent.cancel({ sessionId: "session-1" } as CancelNotification);
-
-    expect(harness.requestSpy).toHaveBeenCalledWith("chat.abort", {
-      sessionKey,
-      runId: pending.runId,
-    });
-    await expect(pending.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+    await cancelAndExpectAbortForPendingRun(harness, "session-1", sessionKey, pending);
   });
 
   it("cancel uses pending runId when there is no active run", async () => {
@@ -112,13 +138,7 @@ describe("acp translator cancel and run scoping", () => {
     const pending = await startPendingPrompt(harness, "session-1");
     harness.sessionStore.clearActiveRun("session-1");
 
-    await harness.agent.cancel({ sessionId: "session-1" } as CancelNotification);
-
-    expect(harness.requestSpy).toHaveBeenCalledWith("chat.abort", {
-      sessionKey,
-      runId: pending.runId,
-    });
-    await expect(pending.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+    await cancelAndExpectAbortForPendingRun(harness, "session-1", sessionKey, pending);
   });
 
   it("cancel skips chat.abort when there is no active run and no pending prompt", async () => {
@@ -145,15 +165,7 @@ describe("acp translator cancel and run scoping", () => {
     expect(abortCalls).toHaveLength(0);
     expect(harness.sessionStore.getSession("session-2")?.activeRunId).toBe(pending2.runId);
 
-    await harness.agent.handleGatewayEvent(
-      createChatEvent({
-        runId: pending2.runId,
-        sessionKey,
-        seq: 1,
-        state: "final",
-      }),
-    );
-    await expect(pending2.promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    await deliverFinalChatEventAndExpectEndTurn(harness, sessionKey, pending2, 1);
   });
 
   it("drops chat events when runId does not match the active prompt", async () => {
@@ -250,15 +262,7 @@ describe("acp translator cancel and run scoping", () => {
     );
     expect(harness.sessionUpdateSpy).toHaveBeenCalledTimes(1);
 
-    await harness.agent.handleGatewayEvent(
-      createChatEvent({
-        runId: pending2.runId,
-        sessionKey,
-        seq: 1,
-        state: "final",
-      }),
-    );
-    await expect(pending2.promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    await deliverFinalChatEventAndExpectEndTurn(harness, sessionKey, pending2, 1);
     expect(harness.sessionStore.getSession("session-1")?.activeRunId).toBe(pending1.runId);
 
     await harness.agent.handleGatewayEvent(


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #1917
**Commits**: 1 cherry-picked (4 blocked on missing prerequisites)

### Picked
| Hash | Subject | Result |
|------|---------|--------|
| `e4924a0134` | test: dedupe acp translator cancel scoping tests | PICKED (clean) |

### Blocked (missing prerequisite files)
| Hash | Subject | Blocker |
|------|---------|---------|
| `5231277163` | fix(acp): rehydrate restarted main ACP sessions (#43285) | `manager.core.ts`, `manager.test.ts`, `manager.utils.ts` don't exist — need ACP thread-bound agents (#23580) first |
| `732e075e92` | ACP: reproduce binding restart session reset (#49435) | Same + `runtime/session-identity.ts` missing |
| `8cac327c19` | ACP: recover hung bound turns (#51816) | `manager.core.ts`, `manager.test.ts` missing |
| `aa6b962a3a` | Discord/ACP: forward abort signals into ACP turns (#52148) | Same + `dispatch-acp.ts` missing |

All 4 blocked commits depend on upstream commit `a7d56e3554` (feat: ACP thread-bound agents) which split `manager.ts` into `manager.core.ts`/`manager.utils.ts`/`manager.test.ts`. The fork has a noop stub at `src/acp/control-plane/manager.ts` instead.

Closes #1917

🤖 Generated with [Claude Code](https://claude.com/claude-code)