### PR TITLE
Cherry-pick batch: Gateway fixes (3 of 8 commits)

### DIFF
--- a/src/gateway/server-methods/chat.abort-authorization.test.ts
+++ b/src/gateway/server-methods/chat.abort-authorization.test.ts
@@ -54,6 +54,29 @@ async function invokeChatAbort(params: {
   return respond;
 }
 
+async function invokeSingleRunAbort({
+  context,
+  runId = "run-1",
+  connId,
+  deviceId,
+  scopes,
+}: {
+  context: ReturnType<typeof createContext>;
+  runId?: string;
+  connId: string;
+  deviceId: string;
+  scopes: string[];
+}) {
+  return await invokeChatAbort({
+    context,
+    request: { sessionKey: "main", runId },
+    client: {
+      connId,
+      connect: { device: { id: deviceId }, scopes },
+    },
+  });
+}
+
 describe("chat.abort authorization", () => {
   it("rejects explicit run aborts from other clients", async () => {
     const context = createContext({
@@ -62,13 +85,11 @@ describe("chat.abort authorization", () => {
       ]),
     });
 
-    const respond = await invokeChatAbort({
+    const respond = await invokeSingleRunAbort({
       context,
-      request: { sessionKey: "main", runId: "run-1" },
-      client: {
-        connId: "conn-other",
-        connect: { device: { id: "dev-other" }, scopes: ["operator.write"] },
-      },
+      connId: "conn-other",
+      deviceId: "dev-other",
+      scopes: ["operator.write"],
     });
 
     const [ok, payload, error] = respond.mock.calls.at(-1) ?? [];
@@ -131,13 +152,11 @@ describe("chat.abort authorization", () => {
       ]),
     });
 
-    const respond = await invokeChatAbort({
+    const respond = await invokeSingleRunAbort({
       context,
-      request: { sessionKey: "main", runId: "run-1" },
-      client: {
-        connId: "conn-admin",
-        connect: { device: { id: "dev-admin" }, scopes: ["operator.admin"] },
-      },
+      connId: "conn-admin",
+      deviceId: "dev-admin",
+      scopes: ["operator.admin"],
     });
 
     const [ok, payload] = respond.mock.calls.at(-1) ?? [];

--- a/src/gateway/server-methods/chat.abort.test-helpers.ts
+++ b/src/gateway/server-methods/chat.abort.test-helpers.ts
@@ -1,5 +1,5 @@
 import { type Mock, vi } from "vitest";
-import type { GatewayRequestHandler } from "./types.js";
+import type { GatewayRequestHandler, RespondFn } from "./types.js";
 
 export function createActiveRun(
   sessionKey: string,
@@ -20,7 +20,7 @@ export function createActiveRun(
   };
 }
 
-export function createChatAbortContext(overrides: Record<string, unknown> = {}): {
+export type ChatAbortTestContext = {
   chatAbortControllers: Map<string, unknown>;
   chatRunBuffers: Map<string, string>;
   chatDeltaSentAt: Map<string, number>;
@@ -33,7 +33,13 @@ export function createChatAbortContext(overrides: Record<string, unknown> = {}):
   logGateway: { warn: Mock };
   dedupe?: { get: Mock };
   [key: string]: unknown;
-} {
+};
+
+export type ChatAbortRespondMock = Mock<RespondFn>;
+
+export function createChatAbortContext(
+  overrides: Record<string, unknown> = {},
+): ChatAbortTestContext {
   return {
     chatAbortControllers: new Map(),
     chatRunBuffers: new Map(),
@@ -53,7 +59,7 @@ export function createChatAbortContext(overrides: Record<string, unknown> = {}):
 
 export async function invokeChatAbortHandler(params: {
   handler: GatewayRequestHandler;
-  context: ReturnType<typeof createChatAbortContext>;
+  context: ChatAbortTestContext;
   request: { sessionKey: string; runId?: string };
   client?: {
     connId?: string;
@@ -62,8 +68,8 @@ export async function invokeChatAbortHandler(params: {
       scopes?: string[];
     };
   } | null;
-  respond?: Mock;
-}): Promise<Mock> {
+  respond?: ChatAbortRespondMock;
+}): Promise<ChatAbortRespondMock> {
   const respond = params.respond ?? vi.fn();
   await params.handler({
     params: params.request,

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -10,24 +10,21 @@ import {
   shouldSkipBackendSelfPairing,
 } from "./handshake-auth-helpers.js";
 
+function createRateLimiter(): AuthRateLimiter {
+  return {
+    check: () => ({ allowed: true, remaining: 1, retryAfterMs: 0 }),
+    reset: () => {},
+    recordFailure: () => {},
+    size: () => 0,
+    prune: () => {},
+    dispose: () => {},
+  };
+}
+
 describe("handshake auth helpers", () => {
   it("pins browser-origin loopback clients to the synthetic rate-limit ip", () => {
-    const rateLimiter: AuthRateLimiter = {
-      check: () => ({ allowed: true, remaining: 1, retryAfterMs: 0 }),
-      reset: () => {},
-      recordFailure: () => {},
-      size: () => 0,
-      prune: () => {},
-      dispose: () => {},
-    };
-    const browserRateLimiter: AuthRateLimiter = {
-      check: () => ({ allowed: true, remaining: 1, retryAfterMs: 0 }),
-      reset: () => {},
-      recordFailure: () => {},
-      size: () => 0,
-      prune: () => {},
-      dispose: () => {},
-    };
+    const rateLimiter = createRateLimiter();
+    const browserRateLimiter = createRateLimiter();
     const resolved = resolveHandshakeBrowserSecurityContext({
       requestOrigin: "https://app.example",
       clientIp: "127.0.0.1",

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -88,6 +88,23 @@ function resolveSignatureToken(connectParams: ConnectParams): string | null {
   return connectParams.auth?.token ?? connectParams.auth?.deviceToken ?? null;
 }
 
+function buildUnauthorizedHandshakeContext(params: {
+  authProvided: AuthProvidedKind;
+  canRetryWithDeviceToken: boolean;
+  recommendedNextStep:
+    | "retry_with_device_token"
+    | "update_auth_configuration"
+    | "update_auth_credentials"
+    | "wait_then_retry"
+    | "review_auth_configuration";
+}) {
+  return {
+    authProvided: params.authProvided,
+    canRetryWithDeviceToken: params.canRetryWithDeviceToken,
+    recommendedNextStep: params.recommendedNextStep,
+  };
+}
+
 export function resolveDeviceSignaturePayloadVersion(params: {
   device: {
     id: string;
@@ -101,7 +118,7 @@ export function resolveDeviceSignaturePayloadVersion(params: {
   nonce: string;
 }): "v3" | "v2" | null {
   const signatureToken = resolveSignatureToken(params.connectParams);
-  const payloadV3 = buildDeviceAuthPayloadV3({
+  const basePayload = {
     deviceId: params.device.id,
     clientId: params.connectParams.client.id,
     clientMode: params.connectParams.client.mode,
@@ -110,6 +127,9 @@ export function resolveDeviceSignaturePayloadVersion(params: {
     signedAtMs: params.signedAtMs,
     token: signatureToken,
     nonce: params.nonce,
+  };
+  const payloadV3 = buildDeviceAuthPayloadV3({
+    ...basePayload,
     platform: params.connectParams.client.platform,
     deviceFamily: params.connectParams.client.deviceFamily,
   });
@@ -117,16 +137,7 @@ export function resolveDeviceSignaturePayloadVersion(params: {
     return "v3";
   }
 
-  const payloadV2 = buildDeviceAuthPayload({
-    deviceId: params.device.id,
-    clientId: params.connectParams.client.id,
-    clientMode: params.connectParams.client.mode,
-    role: params.role,
-    scopes: params.scopes,
-    signedAtMs: params.signedAtMs,
-    token: signatureToken,
-    nonce: params.nonce,
-  });
+  const payloadV2 = buildDeviceAuthPayload(basePayload);
   if (verifyDeviceSignature(params.device.publicKey, payloadV2, params.device.signature)) {
     return "v2";
   }
@@ -166,41 +177,41 @@ export function resolveUnauthorizedHandshakeContext(params: {
     authProvided === "token" &&
     !params.connectAuth?.deviceToken;
   if (canRetryWithDeviceToken) {
-    return {
+    return buildUnauthorizedHandshakeContext({
       authProvided,
       canRetryWithDeviceToken,
       recommendedNextStep: "retry_with_device_token",
-    };
+    });
   }
   switch (params.failedAuth.reason) {
     case "token_missing":
     case "token_missing_config":
     case "password_missing":
     case "password_missing_config":
-      return {
+      return buildUnauthorizedHandshakeContext({
         authProvided,
         canRetryWithDeviceToken,
         recommendedNextStep: "update_auth_configuration",
-      };
+      });
     case "token_mismatch":
     case "password_mismatch":
     case "device_token_mismatch":
-      return {
+      return buildUnauthorizedHandshakeContext({
         authProvided,
         canRetryWithDeviceToken,
         recommendedNextStep: "update_auth_credentials",
-      };
+      });
     case "rate_limited":
-      return {
+      return buildUnauthorizedHandshakeContext({
         authProvided,
         canRetryWithDeviceToken,
         recommendedNextStep: "wait_then_retry",
-      };
+      });
     default:
-      return {
+      return buildUnauthorizedHandshakeContext({
         authProvided,
         canRetryWithDeviceToken,
         recommendedNextStep: "review_auth_configuration",
-      };
+      });
   }
 }


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #1918
**Commits picked**: 3 of 8 (5 skipped — files not present in fork)

### Picked
| Hash | Subject | Notes |
|------|---------|-------|
| `1fe261f92f` | refactor: share chat abort auth invocation | Resolved — adapted `invokeSingleRunAbort` to wrap fork's inline `invokeChatAbort` |
| `4674fbf923` | refactor: share handshake auth helper builders | Clean pick |
| `987c254eea` | test: annotate chat abort helper exports (#45346) | Resolved — merged upstream type aliases with fork's `Mock` types and extra fields |

### Skipped
| Hash | Subject | Reason |
|------|---------|--------|
| `2504cb6a1e` | Security: escape invisible exec approval format chars | exec-approval infrastructure not in fork (removed in restructuring) |
| `2592eb0796` | fix(gateway): guard openrouter auto pricing recursion | model-pricing-cache is gutted layer |
| `6a1ba52ad5` | refactor: share gateway probe auth warnings | probe-auth.test.ts not in fork (prerequisite commits not picked) |
| `944a2c93e3` | refactor: share gateway connection auth options | connection-auth files not in fork |
| `afa95fade0` | Tests: align fixtures with current gateway and model types | session/history test files not in fork |

Closes #1918

🤖 Generated with [Claude Code](https://claude.com/claude-code)