### PR TITLE
Cherry-pick batch: Telegram adapter (1/2) — 5 of 50 commits

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -877,6 +877,7 @@ export const registerTelegramHandlers = ({
             fn: () =>
               bot.api.sendMessage(chatId, `⚠️ File too large. Maximum size is ${limitMb}MB.`, {
                 reply_to_message_id: msg.message_id,
+                allow_sending_without_reply: true,
               }),
           }).catch(() => {});
         }
@@ -890,6 +891,7 @@ export const registerTelegramHandlers = ({
         fn: () =>
           bot.api.sendMessage(chatId, "⚠️ Failed to download media. Please try again.", {
             reply_to_message_id: msg.message_id,
+            allow_sending_without_reply: true,
           }),
       }).catch(() => {});
       return;

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -877,7 +877,7 @@ export const registerTelegramHandlers = ({
             fn: () =>
               bot.api.sendMessage(chatId, `⚠️ File too large. Maximum size is ${limitMb}MB.`, {
                 reply_to_message_id: msg.message_id,
-                allow_sending_without_reply: true,
+                ...({ allow_sending_without_reply: true } as Record<string, unknown>),
               }),
           }).catch(() => {});
         }
@@ -891,7 +891,7 @@ export const registerTelegramHandlers = ({
         fn: () =>
           bot.api.sendMessage(chatId, "⚠️ Failed to download media. Please try again.", {
             reply_to_message_id: msg.message_id,
-            allow_sending_without_reply: true,
+            ...({ allow_sending_without_reply: true } as Record<string, unknown>),
           }),
       }).catch(() => {});
       return;

--- a/src/telegram/bot/delivery.send.ts
+++ b/src/telegram/bot/delivery.send.ts
@@ -82,6 +82,7 @@ export function buildTelegramSendParams(opts?: {
   const params: Record<string, unknown> = {};
   if (opts?.replyToMessageId) {
     params.reply_to_message_id = opts.replyToMessageId;
+    params.allow_sending_without_reply = true;
   }
   if (threadParams) {
     params.message_thread_id = threadParams.message_thread_id;

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -247,6 +247,25 @@ describe("describeReplyTarget", () => {
     expect(result?.kind).toBe("reply");
   });
 
+  it("handles non-string reply text gracefully (issue #27201)", () => {
+    const result = describeReplyTarget({
+      message_id: 2,
+      date: 1000,
+      chat: { id: 1, type: "private" },
+      reply_to_message: {
+        message_id: 1,
+        date: 900,
+        chat: { id: 1, type: "private" },
+        // Simulate edge case where text is an unexpected non-string value
+        text: { some: "object" },
+        from: { id: 42, first_name: "Alice", is_bot: false },
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+    // Should not produce "[object Object]" — should return null (no valid body)
+    expect(result).toBeNull();
+  });
+
   it("extracts forwarded context from reply_to_message (issue #9619)", () => {
     // When user forwards a message with a comment, the comment message has
     // reply_to_message pointing to the forwarded message. We should extract

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -389,7 +389,8 @@ export function describeReplyTarget(msg: Message): TelegramReplyTarget | null {
 
   const replyLike = reply ?? externalReply;
   if (!body && replyLike) {
-    const replyBody = (replyLike.text ?? replyLike.caption ?? "").trim();
+    const rawText = replyLike.text ?? replyLike.caption ?? "";
+    const replyBody = (typeof rawText === "string" ? rawText : "").trim();
     body = replyBody;
     if (!body) {
       body = resolveTelegramMediaPlaceholder(replyLike) ?? "";

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -116,7 +116,7 @@ export function createTelegramDraftStream(params: {
   const threadParams = buildTelegramThreadParams(params.thread);
   const replyParams =
     params.replyToMessageId != null
-      ? { ...threadParams, reply_to_message_id: params.replyToMessageId }
+      ? { ...threadParams, reply_to_message_id: params.replyToMessageId, allow_sending_without_reply: true }
       : threadParams;
   const resolvedDraftApi = prefersDraftTransport
     ? resolveSendMessageDraftApi(params.api)

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -116,7 +116,11 @@ export function createTelegramDraftStream(params: {
   const threadParams = buildTelegramThreadParams(params.thread);
   const replyParams =
     params.replyToMessageId != null
-      ? { ...threadParams, reply_to_message_id: params.replyToMessageId, allow_sending_without_reply: true }
+      ? {
+          ...threadParams,
+          reply_to_message_id: params.replyToMessageId,
+          allow_sending_without_reply: true,
+        }
       : threadParams;
   const resolvedDraftApi = prefersDraftTransport
     ? resolveSendMessageDraftApi(params.api)

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -289,10 +289,12 @@ describe("sendMessageTelegram", () => {
           parse_mode: "HTML",
           message_thread_id: 271,
           reply_to_message_id: 100,
+          allow_sending_without_reply: true,
         },
         secondCall: {
           message_thread_id: 271,
           reply_to_message_id: 100,
+          allow_sending_without_reply: true,
         },
       },
     ] as const;
@@ -696,10 +698,11 @@ describe("sendMessageTelegram", () => {
         options: {
           replyToMessageId: 999,
         },
-        expectedVideoNote: { reply_to_message_id: 999 },
+        expectedVideoNote: { reply_to_message_id: 999, allow_sending_without_reply: true },
         expectedMessage: {
           parse_mode: "HTML",
           reply_to_message_id: 999,
+          allow_sending_without_reply: true,
         },
       },
     ];
@@ -892,6 +895,7 @@ describe("sendMessageTelegram", () => {
           parse_mode: "HTML",
           message_thread_id: 271,
           reply_to_message_id: 500,
+          allow_sending_without_reply: true,
         },
       },
       {
@@ -1421,6 +1425,7 @@ describe("shared send behaviors", () => {
           expect(sendMessage).toHaveBeenCalledWith(chatId, "reply text", {
             parse_mode: "HTML",
             reply_to_message_id: 100,
+            allow_sending_without_reply: true,
           });
         },
       },
@@ -1443,6 +1448,7 @@ describe("shared send behaviors", () => {
           });
           expect(sendSticker).toHaveBeenCalledWith(chatId, fileId, {
             reply_to_message_id: 500,
+            allow_sending_without_reply: true,
           });
         },
       },

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -336,9 +336,11 @@ function buildTelegramThreadReplyParams(params: {
       threadParams.reply_parameters = {
         message_id: replyToMessageId,
         quote: params.quoteText.trim(),
+        allow_sending_without_reply: true,
       };
     } else {
       threadParams.reply_to_message_id = replyToMessageId;
+      threadParams.allow_sending_without_reply = true;
     }
   }
   return threadParams;

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -44,6 +44,10 @@ vi.mock("grammy", async (importOriginal) => {
   const actual = await importOriginal<typeof import("grammy")>();
   return {
     ...actual,
+    API_CONSTANTS: actual.API_CONSTANTS ?? {
+      DEFAULT_UPDATE_TYPES: ["message"],
+      ALL_UPDATE_TYPES: ["message"],
+    },
     webhookCallback: webhookCallbackSpy,
   };
 });

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -40,6 +40,35 @@ function collectResponseBody(
   });
 }
 
+function createSingleSettlement<T>(params: {
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+  clear: () => void;
+}) {
+  let settled = false;
+  return {
+    isSettled() {
+      return settled;
+    },
+    resolve(value: T) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      params.clear();
+      params.resolve(value);
+    },
+    reject(error: unknown) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      params.clear();
+      params.reject(error);
+    },
+  };
+}
+
 vi.mock("grammy", async (importOriginal) => {
   const actual = await importOriginal<typeof import("grammy")>();
   return {
@@ -100,23 +129,11 @@ async function postWebhookHeadersOnly(params: {
   timeoutMs?: number;
 }): Promise<{ statusCode: number; body: string }> {
   return await new Promise((resolve, reject) => {
-    let settled = false;
-    const finishResolve = (value: { statusCode: number; body: string }) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeout);
-      resolve(value);
-    };
-    const finishReject = (error: unknown) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeout);
-      reject(error);
-    };
+    const settle = createSingleSettlement({
+      resolve,
+      reject,
+      clear: () => clearTimeout(timeout),
+    });
 
     const req = request(
       {
@@ -132,7 +149,7 @@ async function postWebhookHeadersOnly(params: {
       },
       (res) => {
         collectResponseBody(res, (payload) => {
-          finishResolve(payload);
+          settle.resolve(payload);
           req.destroy();
         });
       },
@@ -142,14 +159,14 @@ async function postWebhookHeadersOnly(params: {
       req.destroy(
         new Error(`webhook header-only post timed out after ${params.timeoutMs ?? 5_000}ms`),
       );
-      finishReject(new Error("timed out waiting for webhook response"));
+      settle.reject(new Error("timed out waiting for webhook response"));
     }, params.timeoutMs ?? 5_000);
 
     req.on("error", (error) => {
-      if (settled && (error as NodeJS.ErrnoException).code === "ECONNRESET") {
+      if (settle.isSettled() && (error as NodeJS.ErrnoException).code === "ECONNRESET") {
         return;
       }
-      finishReject(error);
+      settle.reject(error);
     });
 
     req.flushHeaders();
@@ -177,23 +194,11 @@ async function postWebhookPayloadWithChunkPlan(params: {
     let bytesQueued = 0;
     let chunksQueued = 0;
     let phase: "writing" | "awaiting-response" = "writing";
-    let settled = false;
-    const finishResolve = (value: { statusCode: number; body: string }) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeout);
-      resolve(value);
-    };
-    const finishReject = (error: unknown) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeout);
-      reject(error);
-    };
+    const settle = createSingleSettlement({
+      resolve,
+      reject,
+      clear: () => clearTimeout(timeout),
+    });
 
     const req = request(
       {
@@ -208,12 +213,12 @@ async function postWebhookPayloadWithChunkPlan(params: {
         },
       },
       (res) => {
-        collectResponseBody(res, finishResolve);
+        collectResponseBody(res, settle.resolve);
       },
     );
 
     const timeout = setTimeout(() => {
-      finishReject(
+      settle.reject(
         new Error(
           `webhook post timed out after ${params.timeoutMs ?? 15_000}ms (phase=${phase}, bytesQueued=${bytesQueued}, chunksQueued=${chunksQueued}, totalBytes=${payloadBuffer.length})`,
         ),
@@ -222,7 +227,7 @@ async function postWebhookPayloadWithChunkPlan(params: {
     }, params.timeoutMs ?? 15_000);
 
     req.on("error", (error) => {
-      finishReject(error);
+      settle.reject(error);
     });
 
     const writeAll = async () => {
@@ -255,7 +260,7 @@ async function postWebhookPayloadWithChunkPlan(params: {
     };
 
     void writeAll().catch((error) => {
-      finishReject(error);
+      settle.reject(error);
     });
   });
 }

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -213,7 +213,7 @@ async function postWebhookPayloadWithChunkPlan(params: {
         },
       },
       (res) => {
-        collectResponseBody(res, settle.resolve);
+        collectResponseBody(res, (body) => settle.resolve(body));
       },
     );
 


### PR DESCRIPTION
## Cherry-pick batch from upstream

**Issue**: #1920
**Commits**: 5 cherry-picked cleanly, 7 already on branch, 38 conflict (blocked by missing prerequisites)

### Successfully picked
| Hash | Subject |
|------|---------|
| `988bd782f7` | fix: restore Telegram topic announce delivery (#51688) |
| `b12dc4d04d` | fix(telegram): update test expectations for allow_sending_without_reply |
| `c11f95eced` | test(telegram): align webhook grammy mock |
| `d264c761cb` | fix(telegram): add allow_sending_without_reply to prevent lost messages |
| `e1ca5d9cc4` | refactor(telegram-tests): share webhook settlement helper |

### Already on branch (7)
`4e45a663e7`, `6a8f5bc12f`, `6b4c24c2e5`, `8139f83175`, `8b438a308b`, `a90c5092f2`, `ac5e97097e`

### Conflicts (38)
All 38 remaining commits conflict due to missing prerequisite cherry-picks in the telegram extension layer (`extensions/telegram/src/`). These files have diverged significantly between fork and upstream.

### Adaptation
- Fixed `allow_sending_without_reply` type error — grammy v1.41 types don't expose this deprecated Bot API property; used spread assertion.

Closes #1920

🤖 Generated with [Claude Code](https://claude.com/claude-code)