### PR TITLE
Cherry-pick 2131981230 (partial): move remaining WhatsApp files to extensions

### DIFF
--- a/extensions/whatsapp/src/normalize-target.test.ts
+++ b/extensions/whatsapp/src/normalize-target.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isWhatsAppGroupJid, isWhatsAppUserTarget, normalizeWhatsAppTarget } from "./normalize.js";
+import {
+  isWhatsAppGroupJid,
+  isWhatsAppUserTarget,
+  normalizeWhatsAppTarget,
+} from "./normalize-target.js";
 
 describe("normalizeWhatsAppTarget", () => {
   it("preserves group JIDs", () => {
@@ -15,11 +19,8 @@ describe("normalizeWhatsAppTarget", () => {
   });
 
   it("normalizes user JIDs with device suffix to E.164", () => {
-    // This is the bug fix: JIDs like "41796666864:0@s.whatsapp.net" should
-    // normalize to "+41796666864", not "+417966668640" (extra digit from ":0")
     expect(normalizeWhatsAppTarget("41796666864:0@s.whatsapp.net")).toBe("+41796666864");
     expect(normalizeWhatsAppTarget("1234567890:123@s.whatsapp.net")).toBe("+1234567890");
-    // Without device suffix still works
     expect(normalizeWhatsAppTarget("41796666864@s.whatsapp.net")).toBe("+41796666864");
   });
 

--- a/extensions/whatsapp/src/normalize-target.ts
+++ b/extensions/whatsapp/src/normalize-target.ts
@@ -1,4 +1,4 @@
-import { normalizeE164 } from "../utils.js";
+import { normalizeE164 } from "../../../src/utils.js";
 
 const WHATSAPP_USER_JID_RE = /^(\d+)(?::\d+)?@s\.whatsapp\.net$/i;
 const WHATSAPP_LID_RE = /^(\d+)@lid$/i;
@@ -27,19 +27,11 @@ export function isWhatsAppGroupJid(value: string): boolean {
   return /^[0-9]+(-[0-9]+)*$/.test(localPart);
 }
 
-/**
- * Check if value looks like a WhatsApp user target (e.g. "41796666864:0@s.whatsapp.net" or "123@lid").
- */
 export function isWhatsAppUserTarget(value: string): boolean {
   const candidate = stripWhatsAppTargetPrefixes(value);
   return WHATSAPP_USER_JID_RE.test(candidate) || WHATSAPP_LID_RE.test(candidate);
 }
 
-/**
- * Extract the phone number from a WhatsApp user JID.
- * "41796666864:0@s.whatsapp.net" -> "41796666864"
- * "123456@lid" -> "123456"
- */
 function extractUserJidPhone(jid: string): string | null {
   const userMatch = jid.match(WHATSAPP_USER_JID_RE);
   if (userMatch) {
@@ -61,7 +53,6 @@ export function normalizeWhatsAppTarget(value: string): string | null {
     const localPart = candidate.slice(0, candidate.length - "@g.us".length);
     return `${localPart}@g.us`;
   }
-  // Handle user JIDs (e.g. "41796666864:0@s.whatsapp.net")
   if (isWhatsAppUserTarget(candidate)) {
     const phone = extractUserJidPhone(candidate);
     if (!phone) {
@@ -70,8 +61,6 @@ export function normalizeWhatsAppTarget(value: string): string | null {
     const normalized = normalizeE164(phone);
     return normalized.length > 1 ? normalized : null;
   }
-  // If the caller passed a JID-ish string that we don't understand, fail fast.
-  // Otherwise normalizeE164 would happily treat "group:120@g.us" as a phone number.
   if (candidate.includes("@")) {
     return null;
   }

--- a/extensions/whatsapp/src/normalize.ts
+++ b/extensions/whatsapp/src/normalize.ts
@@ -2,7 +2,7 @@ import {
   looksLikeHandleOrPhoneTarget,
   trimMessagingTarget,
 } from "../../../src/channels/plugins/normalize/shared.js";
-import { normalizeWhatsAppTarget } from "../../../src/whatsapp/normalize.js";
+import { normalizeWhatsAppTarget } from "./normalize-target.js";
 
 export function normalizeWhatsAppMessagingTarget(raw: string): string | undefined {
   const trimmed = trimMessagingTarget(raw);

--- a/extensions/whatsapp/src/outbound-adapter.ts
+++ b/extensions/whatsapp/src/outbound-adapter.ts
@@ -2,7 +2,7 @@ import { chunkText } from "../../../src/auto-reply/chunk.js";
 import { sendTextMediaPayload } from "../../../src/channels/plugins/outbound/direct-text-media.js";
 import type { ChannelOutboundAdapter } from "../../../src/channels/plugins/types.js";
 import { shouldLogVerbose } from "../../../src/globals.js";
-import { resolveWhatsAppOutboundTarget } from "../../../src/whatsapp/resolve-outbound-target.js";
+import { resolveWhatsAppOutboundTarget } from "./resolve-outbound-target.js";
 import { sendPollWhatsApp } from "./send.js";
 
 function trimLeadingWhitespace(text: string | undefined): string {

--- a/extensions/whatsapp/src/resolve-outbound-target.test.ts
+++ b/extensions/whatsapp/src/resolve-outbound-target.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import * as normalize from "./normalize.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as normalize from "./normalize-target.js";
 
-vi.mock("./normalize.js");
-vi.mock("../infra/outbound/target-errors.js", () => ({
+vi.mock("./normalize-target.js");
+vi.mock("../../../src/infra/outbound/target-errors.js", () => ({
   missingTargetError: (platform: string, format: string) => new Error(`${platform}: ${format}`),
 }));
 
@@ -144,9 +144,9 @@ describe("resolveWhatsAppOutboundTarget", () => {
 
     it("handles mixed numeric and string allowList entries", () => {
       vi.mocked(normalize.normalizeWhatsAppTarget)
-        .mockReturnValueOnce("+11234567890") // for 'to' param
-        .mockReturnValueOnce("+11234567890") // for allowFrom[0]
-        .mockReturnValueOnce("+11234567890"); // for allowFrom[1]
+        .mockReturnValueOnce("+11234567890")
+        .mockReturnValueOnce("+11234567890")
+        .mockReturnValueOnce("+11234567890");
       vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
 
       expectAllowedForTarget({
@@ -157,9 +157,9 @@ describe("resolveWhatsAppOutboundTarget", () => {
 
     it("filters out invalid normalized entries from allowList", () => {
       vi.mocked(normalize.normalizeWhatsAppTarget)
-        .mockReturnValueOnce(null) // for allowFrom[0] "invalid" (processed first)
-        .mockReturnValueOnce("+11234567890") // for allowFrom[1] "+11234567890"
-        .mockReturnValueOnce("+11234567890"); // for 'to' param (processed last)
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce("+11234567890")
+        .mockReturnValueOnce("+11234567890");
       vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
 
       expectAllowedForTarget({

--- a/extensions/whatsapp/src/resolve-outbound-target.ts
+++ b/extensions/whatsapp/src/resolve-outbound-target.ts
@@ -1,5 +1,5 @@
-import { missingTargetError } from "../infra/outbound/target-errors.js";
-import { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "./normalize.js";
+import { missingTargetError } from "../../../src/infra/outbound/target-errors.js";
+import { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "./normalize-target.js";
 
 export type WhatsAppOutboundTargetResolution =
   | { ok: true; to: string }
@@ -31,8 +31,6 @@ export function resolveWhatsAppOutboundTarget(params: {
     if (isWhatsAppGroupJid(normalizedTo)) {
       return { ok: true, to: normalizedTo };
     }
-    // Enforce allowFrom for all direct-message send modes (including explicit).
-    // Group destinations are handled by group policy and are allowed above.
     if (hasWildcard || allowList.length === 0) {
       return { ok: true, to: normalizedTo };
     }

--- a/src/agents/tools/whatsapp-target-auth.ts
+++ b/src/agents/tools/whatsapp-target-auth.ts
@@ -1,6 +1,6 @@
+import { resolveWhatsAppOutboundTarget } from "../../../extensions/whatsapp/src/resolve-outbound-target.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import { resolveWhatsAppAccount } from "../../web/accounts.js";
-import { resolveWhatsAppOutboundTarget } from "../../whatsapp/resolve-outbound-target.js";
 import { ToolAuthorizationError } from "./common.js";
 
 export function resolveAuthorizedWhatsAppOutboundTarget(params: {

--- a/src/channels/plugins/directory-config.ts
+++ b/src/channels/plugins/directory-config.ts
@@ -1,10 +1,13 @@
+import {
+  isWhatsAppGroupJid,
+  normalizeWhatsAppTarget,
+} from "../../../extensions/whatsapp/src/normalize-target.js";
 import type { RemoteClawConfig } from "../../config/types.js";
 import { resolveDiscordAccount } from "../../discord/accounts.js";
 import { mapAllowFromEntries } from "../../plugin-sdk/channel-config-helpers.js";
 import { resolveSlackAccount } from "../../slack/accounts.js";
 import { resolveTelegramAccount } from "../../telegram/accounts.js";
 import { resolveWhatsAppAccount } from "../../web/accounts.js";
-import { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
 import { applyDirectoryQueryAndLimit, toDirectoryEntries } from "./directory-config-helpers.js";
 import { normalizeSlackMessagingTarget } from "./normalize/slack.js";
 import type { ChannelDirectoryEntry } from "./types.js";

--- a/src/channels/plugins/whatsapp-shared.ts
+++ b/src/channels/plugins/whatsapp-shared.ts
@@ -1,6 +1,6 @@
+import { resolveWhatsAppOutboundTarget } from "../../../extensions/whatsapp/src/resolve-outbound-target.js";
 import type { PluginRuntimeChannel } from "../../plugins/runtime/types-channel.js";
 import { escapeRegExp } from "../../utils.js";
-import { resolveWhatsAppOutboundTarget } from "../../whatsapp/resolve-outbound-target.js";
 import type { ChannelOutboundAdapter } from "./types.js";
 
 export const WHATSAPP_GROUP_INTRO_HINT =

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -1,3 +1,4 @@
+import { normalizeWhatsAppTarget } from "../../../extensions/whatsapp/src/normalize-target.js";
 import type { ChannelId } from "../../channels/plugins/types.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import {
@@ -15,7 +16,6 @@ import { readChannelAllowFromStoreSync } from "../../pairing/pairing-store.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAccountId, normalizeAgentId } from "../../routing/session-key.js";
 import { resolveWhatsAppAccount } from "../../web/accounts.js";
-import { normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
 
 export type DeliveryTargetResolution =
   | {

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -1,3 +1,7 @@
+import {
+  isWhatsAppGroupJid,
+  normalizeWhatsAppTarget,
+} from "../../../extensions/whatsapp/src/normalize-target.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
@@ -22,7 +26,6 @@ import { buildTelegramGroupPeerId } from "../../telegram/bot/helpers.js";
 import { resolveTelegramTargetChatType } from "../../telegram/inline-buttons.js";
 import { parseTelegramThreadId } from "../../telegram/outbound-params.js";
 import { parseTelegramTarget } from "../../telegram/targets.js";
-import { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
 import type { ResolvedMessagingTarget } from "./target-resolver.js";
 
 export type OutboundSessionRoute = {

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -1,3 +1,7 @@
+import {
+  isWhatsAppGroupJid,
+  normalizeWhatsAppTarget,
+} from "../../../extensions/whatsapp/src/normalize-target.js";
 import { normalizeChatType, type ChatType } from "../../channels/chat-type.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.js";
@@ -20,7 +24,6 @@ import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
-import { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import { missingTargetError } from "./target-errors.js";
 

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -677,8 +677,12 @@ export {
 } from "../channels/plugins/normalize/signal.js";
 
 // Channel: WhatsApp — WhatsApp-specific exports moved to extensions/whatsapp/src/
-export { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "../whatsapp/normalize.js";
-export { resolveWhatsAppOutboundTarget } from "../whatsapp/resolve-outbound-target.js";
+export {
+  isWhatsAppGroupJid,
+  isWhatsAppUserTarget,
+  normalizeWhatsAppTarget,
+} from "../../extensions/whatsapp/src/normalize-target.js";
+export { resolveWhatsAppOutboundTarget } from "../../extensions/whatsapp/src/resolve-outbound-target.js";
 
 // Channel: BlueBubbles
 export { collectBlueBubblesStatusIssues } from "../channels/plugins/status-issues/bluebubbles.js";

--- a/src/plugin-sdk/whatsapp-shared.ts
+++ b/src/plugin-sdk/whatsapp-shared.ts
@@ -6,4 +6,8 @@ export {
   resolveWhatsAppMentionStripPatterns,
 } from "../channels/plugins/whatsapp-shared.js";
 export { resolveWhatsAppHeartbeatRecipients } from "../channels/plugins/whatsapp-heartbeat.js";
-export { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "../whatsapp/normalize.js";
+export {
+  isWhatsAppGroupJid,
+  isWhatsAppUserTarget,
+  normalizeWhatsAppTarget,
+} from "../../extensions/whatsapp/src/normalize-target.js";

--- a/src/plugin-sdk/whatsapp.ts
+++ b/src/plugin-sdk/whatsapp.ts
@@ -25,7 +25,7 @@ export {
   listWhatsAppDirectoryGroupsFromConfig,
   listWhatsAppDirectoryPeersFromConfig,
 } from "../channels/plugins/directory-config.js";
-export { resolveWhatsAppOutboundTarget } from "../whatsapp/resolve-outbound-target.js";
+export { resolveWhatsAppOutboundTarget } from "../../extensions/whatsapp/src/resolve-outbound-target.js";
 
 export {
   resolveAllowlistProviderRuntimeGroupPolicy,


### PR DESCRIPTION
## Cherry-pick from upstream (partial)

**Upstream commit**: [`2131981230`](https://github.com/openclaw/openclaw/commit/2131981230) (11 of 143 files)
**Follow-up**: [`042669d8c8`](https://github.com/openclaw/openclaw/commit/042669d8c8) (4 file deletions)
**Tier**: HUMAN-REVIEW (mixed commit — WhatsApp files in a 143-file provider refactor)

> refactor(plugins): move remaining channel and provider ownership out of src

### What changed

Moves 4 residual `src/whatsapp/` files to `extensions/whatsapp/src/` and rewires all 11 importers:

**New files** (in `extensions/whatsapp/src/`):
- `normalize-target.ts` + tests — WhatsApp target normalization (isWhatsAppGroupJid, normalizeWhatsAppTarget, new isWhatsAppUserTarget)
- `resolve-outbound-target.ts` + tests — outbound target resolution

**Deleted** (from `src/whatsapp/`):
- `normalize.ts`, `normalize.test.ts`, `resolve-outbound-target.ts`, `resolve-outbound-target.test.ts`

**Import rewiring** (11 files):
- `extensions/whatsapp/src/normalize.ts`, `outbound-adapter.ts`
- `src/channels/plugins/whatsapp-shared.ts`, `directory-config.ts`
- `src/plugin-sdk/index.ts`, `whatsapp-shared.ts`, `whatsapp.ts`
- `src/cron/isolated-agent/delivery-target.ts`
- `src/infra/outbound/targets.ts`, `outbound-session.ts`
- `src/agents/tools/whatsapp-target-auth.ts`

### Exit criteria
- [x] `src/whatsapp/` directory empty
- [x] All importers rewired to `extensions/whatsapp/src/`
- [x] `pnpm typecheck` passes
- [x] New tests pass (29 tests: 8 normalize-target + 21 resolve-outbound-target)
- [x] No gutted layer references
- [x] No wrong domain/license references

### Adaptation notes
- `openclaw/plugin-sdk/account-resolution` → `../../../src/utils.js` (normalizeE164)
- `openclaw/plugin-sdk/channel-feedback` → `../../../src/infra/outbound/target-errors.js` (missingTargetError)
- Issue #2036 scope was 11 files; actual fork had 11 importers (not 7) — all rewired

Closes #2036

🤖 Generated with [Claude Code](https://claude.com/claude-code)