### PR TITLE
ci: run `pnpm check` in CI instead of cherry-picked individual steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,8 @@ jobs:
         with:
           install-bun: "false"
 
-      - name: Format check
-        run: pnpm format:check
-
-      - name: Lint
-        run: pnpm lint
-
-      - name: Lint no-random-messaging
-        run: pnpm lint:tmp:no-random-messaging
+      - name: Check
+        run: pnpm check
 
   build:
     runs-on: ubuntu-latest
@@ -46,9 +40,6 @@ jobs:
         uses: ./.github/actions/setup-node-env
         with:
           install-bun: "false"
-
-      - name: Type-check
-        run: pnpm tsgo
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
## Summary

- Replace 3 individual lint steps (`format:check`, `lint`, `lint:tmp:no-random-messaging`) in the `lint` job with a single `pnpm check` invocation
- Remove redundant `tsgo` step from `build` job (now covered by `pnpm check`)
- Ensures CI enforces the same checks as the pre-commit hook — adding a new check to `pnpm check` automatically includes it in CI

Closes #2040

## Test plan

- [ ] CI `lint` job passes with `pnpm check`
- [ ] CI `build` job passes without separate `tsgo` step
- [ ] All 12 checks in `pnpm check` are now enforced in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)