### PR TITLE
ci: add CI gate job to satisfy branch protection required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,18 @@ jobs:
           REMOTECLAW_TEST_WORKERS: 1
           REMOTECLAW_TEST_MAX_OLD_SPACE_SIZE_MB: 1536
 
+  CI:
+    if: always()
+    needs: [lint, build, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.test.result }}" != "success" ]]; then
+            echo "::error::One or more required jobs failed"
+            exit 1
+          fi
+
   publish-next:
     if: github.event_name == 'push'
     needs: [lint, build, test]


### PR DESCRIPTION
## Summary

- Branch protection requires a status check named `CI`, but no workflow job has ever provided it (pre-existing misconfiguration discovered in #2047)
- Add a gate job with `if: always()` that depends on `lint`, `build`, and `test` — reports success only when all three pass
- Enables auto-merge to work without admin bypass

## Test plan

- [ ] CI `CI` gate job appears in check runs and passes
- [ ] Auto-merge triggers after all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)