### PR TITLE
Cherry-pick #2051: channel plugin foundation files (3 of 3)

### DIFF
--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -376,3 +376,5 @@ export function createSynologyChatPlugin() {
     },
   };
 }
+
+export const synologyChatPlugin = createSynologyChatPlugin();

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -1,0 +1,60 @@
+import { bluebubblesPlugin } from "../../../extensions/bluebubbles/src/channel.js";
+import { discordPlugin } from "../../../extensions/discord/src/channel.js";
+import { feishuPlugin } from "../../../extensions/feishu/src/channel.js";
+import { googlechatPlugin } from "../../../extensions/googlechat/src/channel.js";
+import { imessagePlugin } from "../../../extensions/imessage/src/channel.js";
+import { ircPlugin } from "../../../extensions/irc/src/channel.js";
+import { linePlugin } from "../../../extensions/line/src/channel.js";
+import { matrixPlugin } from "../../../extensions/matrix/src/channel.js";
+import { mattermostPlugin } from "../../../extensions/mattermost/src/channel.js";
+import { msteamsPlugin } from "../../../extensions/msteams/src/channel.js";
+import { nextcloudTalkPlugin } from "../../../extensions/nextcloud-talk/src/channel.js";
+import { nostrPlugin } from "../../../extensions/nostr/src/channel.js";
+import { signalPlugin } from "../../../extensions/signal/src/channel.js";
+import { slackPlugin } from "../../../extensions/slack/src/channel.js";
+import { synologyChatPlugin } from "../../../extensions/synology-chat/src/channel.js";
+import { telegramPlugin } from "../../../extensions/telegram/src/channel.js";
+import { tlonPlugin } from "../../../extensions/tlon/src/channel.js";
+import { whatsappPlugin } from "../../../extensions/whatsapp/src/channel.js";
+import { zaloPlugin } from "../../../extensions/zalo/src/channel.js";
+import { zalouserPlugin } from "../../../extensions/zalouser/src/channel.js";
+import type { ChannelId, ChannelPlugin } from "./types.js";
+
+export const bundledChannelPlugins = [
+  bluebubblesPlugin,
+  discordPlugin,
+  feishuPlugin,
+  googlechatPlugin,
+  imessagePlugin,
+  ircPlugin,
+  linePlugin,
+  matrixPlugin,
+  mattermostPlugin,
+  msteamsPlugin,
+  nextcloudTalkPlugin,
+  nostrPlugin,
+  signalPlugin,
+  slackPlugin,
+  synologyChatPlugin,
+  telegramPlugin,
+  tlonPlugin,
+  whatsappPlugin,
+  zaloPlugin,
+  zalouserPlugin,
+] as ChannelPlugin[];
+
+const bundledChannelPluginsById = new Map(
+  bundledChannelPlugins.map((plugin) => [plugin.id, plugin] as const),
+);
+
+export function getBundledChannelPlugin(id: ChannelId): ChannelPlugin | undefined {
+  return bundledChannelPluginsById.get(id);
+}
+
+export function requireBundledChannelPlugin(id: ChannelId): ChannelPlugin {
+  const plugin = getBundledChannelPlugin(id);
+  if (!plugin) {
+    throw new Error(`missing bundled channel plugin: ${id}`);
+  }
+  return plugin;
+}

--- a/src/channels/plugins/onboarding/helpers.ts
+++ b/src/channels/plugins/onboarding/helpers.ts
@@ -509,6 +509,86 @@ export async function promptSingleChannelToken(params: {
   return { useEnv: false, token: await promptToken() };
 }
 
+/**
+ * Unified secret step that builds prompt state, shows optional help,
+ * prompts for a credential (plaintext-only), and applies the result.
+ *
+ * Adapted from upstream's runSingleChannelSecretStep — the "ref" (external
+ * secret provider) code path is omitted because the fork does not have the
+ * secret-provider infrastructure. The secretInputMode parameter is accepted
+ * for signature compatibility but ignored.
+ */
+export async function runSingleChannelSecretStep(params: {
+  cfg: RemoteClawConfig;
+  prompter: Pick<WizardPrompter, "confirm" | "text" | "select" | "note">;
+  providerHint: string;
+  credentialLabel: string;
+  secretInputMode?: "plaintext" | "ref";
+  accountConfigured: boolean;
+  hasConfigToken: boolean;
+  allowEnv: boolean;
+  envValue?: string;
+  envPrompt: string;
+  keepPrompt: string;
+  inputPrompt: string;
+  preferredEnvVar?: string;
+  onMissingConfigured?: () => Promise<void>;
+  applyUseEnv?: (cfg: RemoteClawConfig) => RemoteClawConfig | Promise<RemoteClawConfig>;
+  applySet?: (
+    cfg: RemoteClawConfig,
+    value: string,
+    resolvedValue: string,
+  ) => RemoteClawConfig | Promise<RemoteClawConfig>;
+}): Promise<{
+  cfg: RemoteClawConfig;
+  action: "use-env" | "set" | "keep";
+  resolvedValue?: string;
+}> {
+  const promptState = buildSingleChannelSecretPromptState({
+    accountConfigured: params.accountConfigured,
+    hasConfigToken: params.hasConfigToken,
+    allowEnv: params.allowEnv,
+    envValue: params.envValue,
+  });
+
+  if (!promptState.accountConfigured && params.onMissingConfigured) {
+    await params.onMissingConfigured();
+  }
+
+  const result = await promptSingleChannelToken({
+    prompter: params.prompter,
+    accountConfigured: promptState.accountConfigured,
+    canUseEnv: promptState.canUseEnv,
+    hasConfigToken: promptState.hasConfigToken,
+    envPrompt: params.envPrompt,
+    keepPrompt: params.keepPrompt,
+    inputPrompt: params.inputPrompt,
+  });
+
+  if (result.useEnv) {
+    return {
+      cfg: params.applyUseEnv ? await params.applyUseEnv(params.cfg) : params.cfg,
+      action: "use-env",
+      resolvedValue: params.envValue?.trim() || undefined,
+    };
+  }
+
+  if (result.token) {
+    return {
+      cfg: params.applySet
+        ? await params.applySet(params.cfg, result.token, result.token)
+        : params.cfg,
+      action: "set",
+      resolvedValue: result.token,
+    };
+  }
+
+  return {
+    cfg: params.cfg,
+    action: "keep",
+  };
+}
+
 type ParsedAllowFromResult = { entries: string[]; error?: string };
 
 export async function promptParsedAllowFromForScopedChannel(params: {

--- a/src/channels/plugins/setup-wizard.ts
+++ b/src/channels/plugins/setup-wizard.ts
@@ -1,0 +1,289 @@
+import type { RemoteClawConfig } from "../../config/config.js";
+import { resolveChannelDefaultAccountId } from "./helpers.js";
+import type {
+  ChannelOnboardingAdapter,
+  ChannelOnboardingDmPolicy,
+  ChannelOnboardingStatus,
+  ChannelOnboardingStatusContext,
+} from "./onboarding-types.js";
+import {
+  promptResolvedAllowFrom,
+  resolveAccountIdForConfigure,
+  runSingleChannelSecretStep,
+  splitOnboardingEntries,
+} from "./onboarding/helpers.js";
+import type { ChannelSetupInput } from "./types.core.js";
+import type { ChannelPlugin } from "./types.js";
+
+export type ChannelSetupWizardStatus = {
+  configuredLabel: string;
+  unconfiguredLabel: string;
+  configuredHint?: string;
+  unconfiguredHint?: string;
+  configuredScore?: number;
+  unconfiguredScore?: number;
+  resolveConfigured: (params: { cfg: RemoteClawConfig }) => boolean | Promise<boolean>;
+};
+
+export type ChannelSetupWizardCredentialState = {
+  accountConfigured: boolean;
+  hasConfiguredValue: boolean;
+  resolvedValue?: string;
+  envValue?: string;
+};
+
+export type ChannelSetupWizardCredential = {
+  inputKey: keyof ChannelSetupInput;
+  providerHint: string;
+  credentialLabel: string;
+  preferredEnvVar?: string;
+  helpTitle?: string;
+  helpLines?: string[];
+  envPrompt: string;
+  keepPrompt: string;
+  inputPrompt: string;
+  allowEnv?: (params: { cfg: RemoteClawConfig; accountId: string }) => boolean;
+  inspect: (params: {
+    cfg: RemoteClawConfig;
+    accountId: string;
+  }) => ChannelSetupWizardCredentialState;
+};
+
+export type ChannelSetupWizardAllowFromEntry = {
+  input: string;
+  resolved: boolean;
+  id: string | null;
+};
+
+export type ChannelSetupWizardAllowFrom = {
+  helpTitle?: string;
+  helpLines?: string[];
+  message: string;
+  placeholder?: string;
+  invalidWithoutCredentialNote?: string;
+  parseInputs?: (raw: string) => string[];
+  parseId: (raw: string) => string | null;
+  resolveEntries?: (params: {
+    cfg: RemoteClawConfig;
+    accountId: string;
+    credentialValue?: string;
+    entries: string[];
+  }) => Promise<ChannelSetupWizardAllowFromEntry[]>;
+  apply: (params: {
+    cfg: RemoteClawConfig;
+    accountId: string;
+    allowFrom: string[];
+  }) => RemoteClawConfig | Promise<RemoteClawConfig>;
+};
+
+export type ChannelSetupWizard = {
+  channel: string;
+  status: ChannelSetupWizardStatus;
+  credential: ChannelSetupWizardCredential;
+  dmPolicy?: ChannelOnboardingDmPolicy;
+  allowFrom?: ChannelSetupWizardAllowFrom;
+  disable?: (cfg: RemoteClawConfig) => RemoteClawConfig;
+  onAccountRecorded?: ChannelOnboardingAdapter["onAccountRecorded"];
+};
+
+type ChannelSetupWizardPlugin = Pick<
+  ChannelPlugin,
+  "id" | "meta" | "config" | "setup" | "capabilities"
+>;
+
+async function buildStatus(
+  plugin: ChannelSetupWizardPlugin,
+  wizard: ChannelSetupWizard,
+  ctx: ChannelOnboardingStatusContext,
+): Promise<ChannelOnboardingStatus> {
+  const configured = await wizard.status.resolveConfigured({ cfg: ctx.cfg });
+  return {
+    channel: plugin.id,
+    configured,
+    statusLines: [
+      `${plugin.meta.label}: ${configured ? wizard.status.configuredLabel : wizard.status.unconfiguredLabel}`,
+    ],
+    selectionHint: configured ? wizard.status.configuredHint : wizard.status.unconfiguredHint,
+    quickstartScore: configured ? wizard.status.configuredScore : wizard.status.unconfiguredScore,
+  };
+}
+
+function applySetupInput(params: {
+  plugin: ChannelSetupWizardPlugin;
+  cfg: RemoteClawConfig;
+  accountId: string;
+  input: ChannelSetupInput;
+}) {
+  const setup = params.plugin.setup;
+  if (!setup?.applyAccountConfig) {
+    throw new Error(`${params.plugin.id} does not support setup`);
+  }
+  const resolvedAccountId =
+    setup.resolveAccountId?.({
+      cfg: params.cfg,
+      accountId: params.accountId,
+      input: params.input,
+    }) ?? params.accountId;
+  const validationError = setup.validateInput?.({
+    cfg: params.cfg,
+    accountId: resolvedAccountId,
+    input: params.input,
+  });
+  if (validationError) {
+    throw new Error(validationError);
+  }
+  let next = setup.applyAccountConfig({
+    cfg: params.cfg,
+    accountId: resolvedAccountId,
+    input: params.input,
+  });
+  if (params.input.name?.trim() && setup.applyAccountName) {
+    next = setup.applyAccountName({
+      cfg: next,
+      accountId: resolvedAccountId,
+      name: params.input.name,
+    });
+  }
+  return {
+    cfg: next,
+    accountId: resolvedAccountId,
+  };
+}
+
+export function buildChannelOnboardingAdapterFromSetupWizard(params: {
+  plugin: ChannelSetupWizardPlugin;
+  wizard: ChannelSetupWizard;
+}): ChannelOnboardingAdapter {
+  const { plugin, wizard } = params;
+  return {
+    channel: plugin.id,
+    getStatus: async (ctx) => buildStatus(plugin, wizard, ctx),
+    configure: async ({
+      cfg,
+      prompter,
+      accountOverrides,
+      shouldPromptAccountIds,
+      forceAllowFrom,
+    }) => {
+      const defaultAccountId = resolveChannelDefaultAccountId({ plugin, cfg });
+      const accountId = await resolveAccountIdForConfigure({
+        cfg,
+        prompter,
+        label: plugin.meta.label,
+        accountOverride: accountOverrides[plugin.id],
+        shouldPromptAccountIds,
+        listAccountIds: plugin.config.listAccountIds,
+        defaultAccountId,
+      });
+
+      let next = cfg;
+      let credentialState = wizard.credential.inspect({ cfg: next, accountId });
+      let resolvedCredentialValue = credentialState.resolvedValue?.trim() || undefined;
+      const allowEnv = wizard.credential.allowEnv?.({ cfg: next, accountId }) ?? false;
+
+      const credentialResult = await runSingleChannelSecretStep({
+        cfg: next,
+        prompter,
+        providerHint: wizard.credential.providerHint,
+        credentialLabel: wizard.credential.credentialLabel,
+        secretInputMode: undefined,
+        accountConfigured: credentialState.accountConfigured,
+        hasConfigToken: credentialState.hasConfiguredValue,
+        allowEnv,
+        envValue: credentialState.envValue,
+        envPrompt: wizard.credential.envPrompt,
+        keepPrompt: wizard.credential.keepPrompt,
+        inputPrompt: wizard.credential.inputPrompt,
+        preferredEnvVar: wizard.credential.preferredEnvVar,
+        onMissingConfigured:
+          wizard.credential.helpLines && wizard.credential.helpLines.length > 0
+            ? async () => {
+                await prompter.note(
+                  wizard.credential.helpLines!.join("\n"),
+                  wizard.credential.helpTitle ?? wizard.credential.credentialLabel,
+                );
+              }
+            : undefined,
+        applyUseEnv: async (currentCfg) =>
+          applySetupInput({
+            plugin,
+            cfg: currentCfg,
+            accountId,
+            input: {
+              [wizard.credential.inputKey]: undefined,
+              useEnv: true,
+            },
+          }).cfg,
+        applySet: async (currentCfg, value, resolvedValue) => {
+          resolvedCredentialValue = resolvedValue;
+          return applySetupInput({
+            plugin,
+            cfg: currentCfg,
+            accountId,
+            input: {
+              [wizard.credential.inputKey]: value,
+              useEnv: false,
+            },
+          }).cfg;
+        },
+      });
+
+      next = credentialResult.cfg;
+      credentialState = wizard.credential.inspect({ cfg: next, accountId });
+      resolvedCredentialValue =
+        credentialResult.resolvedValue?.trim() ||
+        credentialState.resolvedValue?.trim() ||
+        undefined;
+
+      if (forceAllowFrom && wizard.allowFrom) {
+        if (wizard.allowFrom.helpLines && wizard.allowFrom.helpLines.length > 0) {
+          await prompter.note(
+            wizard.allowFrom.helpLines.join("\n"),
+            wizard.allowFrom.helpTitle ?? `${plugin.meta.label} allowlist`,
+          );
+        }
+        const existingAllowFrom =
+          plugin.config.resolveAllowFrom?.({
+            cfg: next,
+            accountId,
+          }) ?? [];
+        const unique = await promptResolvedAllowFrom({
+          prompter,
+          existing: existingAllowFrom,
+          token: resolvedCredentialValue,
+          message: wizard.allowFrom.message,
+          placeholder: wizard.allowFrom.placeholder ?? "",
+          label: wizard.allowFrom.helpTitle ?? `${plugin.meta.label} allowlist`,
+          parseInputs: wizard.allowFrom.parseInputs ?? splitOnboardingEntries,
+          parseId: wizard.allowFrom.parseId,
+          invalidWithoutTokenNote: wizard.allowFrom.invalidWithoutCredentialNote ?? "",
+          resolveEntries: wizard.allowFrom.resolveEntries
+            ? async ({ entries }) =>
+                (
+                  await wizard.allowFrom!.resolveEntries!({
+                    cfg: next,
+                    accountId,
+                    credentialValue: resolvedCredentialValue,
+                    entries,
+                  })
+                ).map((e) => ({
+                  input: e.input,
+                  resolved: e.resolved,
+                  id: e.id,
+                }))
+            : async () => [],
+        });
+        next = await wizard.allowFrom.apply({
+          cfg: next,
+          accountId,
+          allowFrom: unique,
+        });
+      }
+
+      return { cfg: next, accountId };
+    },
+    dmPolicy: wizard.dmPolicy,
+    disable: wizard.disable,
+    onAccountRecorded: wizard.onAccountRecorded,
+  };
+}

--- a/src/channels/plugins/target-parsing.ts
+++ b/src/channels/plugins/target-parsing.ts
@@ -1,0 +1,26 @@
+import type { ChatType } from "../chat-type.js";
+import { getChannelPlugin, normalizeChannelId } from "./registry.js";
+
+export type ParsedChannelExplicitTarget = {
+  to: string;
+  threadId?: string | number;
+  chatType?: ChatType;
+};
+
+function parseWithPlugin(
+  rawChannel: string,
+  rawTarget: string,
+): ParsedChannelExplicitTarget | null {
+  const channel = normalizeChannelId(rawChannel);
+  if (!channel) {
+    return null;
+  }
+  return getChannelPlugin(channel)?.messaging?.parseExplicitTarget?.({ raw: rawTarget }) ?? null;
+}
+
+export function parseExplicitTargetForChannel(
+  channel: string,
+  rawTarget: string,
+): ParsedChannelExplicitTarget | null {
+  return parseWithPlugin(channel, rawTarget);
+}

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -302,6 +302,11 @@ export type ChannelMessagingAdapter = {
     display?: string;
     kind?: ChannelDirectoryEntryKind;
   }) => string;
+  parseExplicitTarget?: (params: { raw: string }) => {
+    to: string;
+    threadId?: string | number;
+    chatType?: ChatType;
+  } | null;
 };
 
 export type ChannelAgentPromptAdapter = {


### PR DESCRIPTION
## Cherry-pick from upstream

**Issue**: #2051
**Upstream commits**: [`7964563299`](https://github.com/openclaw/openclaw/commit/7964563299), [`f11589b311`](https://github.com/openclaw/openclaw/commit/f11589b311), [`a4047bf148`](https://github.com/openclaw/openclaw/commit/a4047bf148)
**Authors**: openclaw contributors
**Tier**: HUMAN-REVIEW (partial picks, re-implemented for fork)

> refactor: finish plugin-owned channel runtime seams
> refactor: tighten plugin sdk channel seams
> refactor: move telegram onboarding to setup wizard

### New files

| File | Purpose | Source |
|------|---------|--------|
| `src/channels/plugins/target-parsing.ts` | Parse explicit channel targets via plugin messaging adapter | `7964563299` |
| `src/channels/plugins/bundled.ts` | Centralized registry of all 20 bundled channel plugins | `f11589b311` |
| `src/channels/plugins/setup-wizard.ts` | Build ChannelOnboardingAdapter from declarative wizard definition | `a4047bf148` |

### Modified files

| File | Change |
|------|--------|
| `src/channels/plugins/types.core.ts` | Add `parseExplicitTarget` to `ChannelMessagingAdapter` type |
| `extensions/synology-chat/src/channel.ts` | Export const plugin instance for bundled.ts import |
| `src/channels/plugins/onboarding/helpers.ts` | Add `runSingleChannelSecretStep` (plaintext-only adaptation) |

### Adaptation notes

- **setup-wizard.ts**: Upstream's `runSingleChannelSecretStep` depends on a secret ref infrastructure chain that doesn't exist in our fork. Adapted with plaintext-only implementation that delegates to existing `buildSingleChannelSecretPromptState` + `promptSingleChannelToken`.
- **bundled.ts**: Omits `bundledChannelSetupPlugins` and `bundledChannelRuntimeSetters` (depend on missing `channel.setup.ts` files from earlier upstream commits).
- **secretInputMode**: Accepted but set to `undefined` — the upstream type at commit `a4047bf148` didn't include it on `SetupChannelsOptions` either (added by a later commit).

### Why re-implementation instead of cherry-pick

The upstream commits heavily refactor extension channel files to use infrastructure that doesn't exist in our fork (read-only account inspect layer, channel setup-core files, exec-approval infrastructure). Direct cherry-pick produces 16+ conflicts. Re-implementing the 3 key files against our current architecture is cleaner.

### Unblocks

- #1919 (22 commits: channel infrastructure)
- Transitively: #1920-#1926, #1927-#1955

Closes #2051.