### PR TITLE
Cherry-pick #1919: Channel infrastructure (3 of 22 commits)

### DIFF
--- a/src/channels/plugins/contracts/registry.contract.test.ts
+++ b/src/channels/plugins/contracts/registry.contract.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  actionContractRegistry,
+  pluginContractRegistry,
+  setupContractRegistry,
+  statusContractRegistry,
+  surfaceContractRegistry,
+  type ChannelPluginSurface,
+} from "./registry.js";
+
+const orderedSurfaceKeys = [
+  "actions",
+  "setup",
+  "status",
+  "outbound",
+  "messaging",
+  "threading",
+  "directory",
+  "gateway",
+] as const satisfies readonly ChannelPluginSurface[];
+
+describe("channel contract registry", () => {
+  it("does not duplicate channel plugin ids", () => {
+    const ids = pluginContractRegistry.map((entry) => entry.id);
+    expect(ids).toEqual([...new Set(ids)]);
+  });
+
+  it("keeps the surface registry aligned with the plugin registry", () => {
+    expect(surfaceContractRegistry.map((entry) => entry.id).toSorted()).toEqual(
+      pluginContractRegistry.map((entry) => entry.id).toSorted(),
+    );
+  });
+
+  it("declares the actual owned channel plugin surfaces explicitly", () => {
+    for (const entry of surfaceContractRegistry) {
+      const actual = orderedSurfaceKeys.filter((surface) => Boolean(entry.plugin[surface]));
+      expect([...entry.surfaces].toSorted()).toEqual(actual.toSorted());
+    }
+  });
+
+  it("only installs deep action coverage for plugins that declare actions", () => {
+    const actionSurfaceIds = new Set(
+      surfaceContractRegistry
+        .filter((entry) => entry.surfaces.includes("actions"))
+        .map((entry) => entry.id),
+    );
+    for (const entry of actionContractRegistry) {
+      expect(actionSurfaceIds.has(entry.id)).toBe(true);
+    }
+  });
+
+  it("only installs deep setup coverage for plugins that declare setup", () => {
+    const setupSurfaceIds = new Set(
+      surfaceContractRegistry
+        .filter((entry) => entry.surfaces.includes("setup"))
+        .map((entry) => entry.id),
+    );
+    for (const entry of setupContractRegistry) {
+      expect(setupSurfaceIds.has(entry.id)).toBe(true);
+    }
+  });
+
+  it("only installs deep status coverage for plugins that declare status", () => {
+    const statusSurfaceIds = new Set(
+      surfaceContractRegistry
+        .filter((entry) => entry.surfaces.includes("status"))
+        .map((entry) => entry.id),
+    );
+    for (const entry of statusContractRegistry) {
+      expect(statusSurfaceIds.has(entry.id)).toBe(true);
+    }
+  });
+});

--- a/src/channels/plugins/contracts/registry.ts
+++ b/src/channels/plugins/contracts/registry.ts
@@ -79,6 +79,38 @@ type StatusContractEntry = {
   }>;
 };
 
+export type ChannelPluginSurface =
+  | "actions"
+  | "setup"
+  | "status"
+  | "outbound"
+  | "messaging"
+  | "threading"
+  | "directory"
+  | "gateway";
+
+// Widen to ChannelPlugin's default params — needed because concrete plugins
+// instantiate with specific ResolvedAccount/Probe generics whose
+// contravariant method parameters aren't assignable to narrower picks.
+type AnyChannelPlugin = ChannelPlugin;
+
+type SurfaceContractEntry = {
+  id: string;
+  plugin: Pick<
+    AnyChannelPlugin,
+    | "id"
+    | "actions"
+    | "setup"
+    | "status"
+    | "outbound"
+    | "messaging"
+    | "threading"
+    | "directory"
+    | "gateway"
+  >;
+  surfaces: readonly ChannelPluginSurface[];
+};
+
 const telegramListActionsMock = vi.fn();
 const telegramGetCapabilitiesMock = vi.fn();
 const discordListActionsMock = vi.fn();
@@ -480,6 +512,190 @@ export const statusContractRegistry: StatusContractEntry[] = [
           expect(snapshot.mode).toBe("webhook");
         },
       },
+    ],
+  },
+];
+
+export const surfaceContractRegistry: SurfaceContractEntry[] = [
+  {
+    id: "bluebubbles",
+    plugin: bluebubblesPlugin,
+    surfaces: ["actions", "setup", "status", "outbound", "messaging", "threading", "gateway"],
+  },
+  {
+    id: "discord",
+    plugin: discordPlugin,
+    surfaces: [
+      "actions",
+      "setup",
+      "status",
+      "outbound",
+      "messaging",
+      "threading",
+      "directory",
+      "gateway",
+    ],
+  },
+  {
+    id: "feishu",
+    plugin: feishuPlugin,
+    surfaces: ["actions", "setup", "status", "outbound", "messaging", "directory", "gateway"],
+  },
+  {
+    id: "googlechat",
+    plugin: googlechatPlugin,
+    surfaces: [
+      "actions",
+      "setup",
+      "status",
+      "outbound",
+      "messaging",
+      "threading",
+      "directory",
+      "gateway",
+    ],
+  },
+  {
+    id: "imessage",
+    plugin: imessagePlugin,
+    surfaces: ["setup", "status", "outbound", "messaging", "gateway"],
+  },
+  {
+    id: "irc",
+    plugin: ircPlugin as AnyChannelPlugin,
+    surfaces: ["setup", "status", "outbound", "messaging", "directory", "gateway"],
+  },
+  {
+    id: "line",
+    plugin: linePlugin,
+    surfaces: ["setup", "status", "outbound", "messaging", "directory", "gateway"],
+  },
+  {
+    id: "matrix",
+    plugin: matrixPlugin,
+    surfaces: [
+      "actions",
+      "setup",
+      "status",
+      "outbound",
+      "messaging",
+      "threading",
+      "directory",
+      "gateway",
+    ],
+  },
+  {
+    id: "mattermost",
+    plugin: mattermostPlugin,
+    surfaces: [
+      "actions",
+      "setup",
+      "status",
+      "outbound",
+      "messaging",
+      "threading",
+      "directory",
+      "gateway",
+    ],
+  },
+  {
+    id: "msteams",
+    plugin: msteamsPlugin,
+    surfaces: [
+      "actions",
+      "setup",
+      "status",
+      "outbound",
+      "messaging",
+      "threading",
+      "directory",
+      "gateway",
+    ],
+  },
+  {
+    id: "nextcloud-talk",
+    plugin: nextcloudTalkPlugin,
+    surfaces: ["setup", "status", "outbound", "messaging", "gateway"],
+  },
+  {
+    id: "nostr",
+    plugin: nostrPlugin,
+    surfaces: ["setup", "status", "outbound", "messaging", "gateway"],
+  },
+  {
+    id: "signal",
+    plugin: signalPlugin,
+    surfaces: ["actions", "setup", "status", "outbound", "messaging", "gateway"],
+  },
+  {
+    id: "slack",
+    plugin: slackPlugin,
+    surfaces: [
+      "actions",
+      "setup",
+      "status",
+      "outbound",
+      "messaging",
+      "threading",
+      "directory",
+      "gateway",
+    ],
+  },
+  {
+    id: "synology-chat",
+    plugin: createSynologyChatPlugin(),
+    surfaces: ["setup", "outbound", "messaging", "directory", "gateway"],
+  },
+  {
+    id: "telegram",
+    plugin: telegramPlugin as AnyChannelPlugin,
+    surfaces: [
+      "actions",
+      "setup",
+      "status",
+      "outbound",
+      "messaging",
+      "threading",
+      "directory",
+      "gateway",
+    ],
+  },
+  {
+    id: "tlon",
+    plugin: tlonPlugin,
+    surfaces: ["setup", "status", "outbound", "messaging", "gateway"],
+  },
+  {
+    id: "whatsapp",
+    plugin: whatsappPlugin,
+    surfaces: ["actions", "setup", "status", "outbound", "messaging", "directory", "gateway"],
+  },
+  {
+    id: "zalo",
+    plugin: zaloPlugin,
+    surfaces: [
+      "actions",
+      "setup",
+      "status",
+      "outbound",
+      "messaging",
+      "threading",
+      "directory",
+      "gateway",
+    ],
+  },
+  {
+    id: "zalouser",
+    plugin: zalouserPlugin,
+    surfaces: [
+      "actions",
+      "setup",
+      "status",
+      "outbound",
+      "messaging",
+      "threading",
+      "directory",
+      "gateway",
     ],
   },
 ];

--- a/src/channels/plugins/contracts/suites.ts
+++ b/src/channels/plugins/contracts/suites.ts
@@ -1,5 +1,13 @@
-import { expect, it } from "vitest";
+import { expect, it, type Mock } from "vitest";
+import type { MsgContext } from "../../../auto-reply/templating.js";
 import type { RemoteClawConfig } from "../../../config/config.js";
+import type {
+  ResolveProviderRuntimeGroupPolicyParams,
+  RuntimeGroupPolicyResolution,
+} from "../../../config/runtime-group-policy.js";
+import { normalizeChatType } from "../../chat-type.js";
+import { resolveConversationLabel } from "../../conversation-label.js";
+import { validateSenderIdentity } from "../../sender-identity.js";
 import type {
   ChannelAccountSnapshot,
   ChannelAccountState,
@@ -84,6 +92,143 @@ export function installChannelActionsContractSuite(params: {
       }
     });
   }
+}
+
+export function installChannelSurfaceContractSuite(params: {
+  plugin: Pick<
+    ChannelPlugin,
+    | "id"
+    | "actions"
+    | "setup"
+    | "status"
+    | "outbound"
+    | "messaging"
+    | "threading"
+    | "directory"
+    | "gateway"
+  >;
+  surface:
+    | "actions"
+    | "setup"
+    | "status"
+    | "outbound"
+    | "messaging"
+    | "threading"
+    | "directory"
+    | "gateway";
+}) {
+  const { plugin, surface } = params;
+
+  it(`exposes the ${surface} surface contract`, () => {
+    if (surface === "actions") {
+      expect(plugin.actions).toBeDefined();
+      expect(typeof plugin.actions?.listActions).toBe("function");
+      return;
+    }
+
+    if (surface === "setup") {
+      expect(plugin.setup).toBeDefined();
+      expect(typeof plugin.setup?.applyAccountConfig).toBe("function");
+      return;
+    }
+
+    if (surface === "status") {
+      expect(plugin.status).toBeDefined();
+      expect(typeof plugin.status?.buildAccountSnapshot).toBe("function");
+      return;
+    }
+
+    if (surface === "outbound") {
+      const outbound = plugin.outbound as Record<string, unknown> | undefined;
+      expect(outbound).toBeDefined();
+      expect(["direct", "gateway", "hybrid"]).toContain(outbound?.deliveryMode);
+      expect(
+        [
+          outbound?.sendPayload,
+          outbound?.sendFormattedText,
+          outbound?.sendFormattedMedia,
+          outbound?.sendText,
+          outbound?.sendMedia,
+          outbound?.sendPoll,
+        ].some((value) => typeof value === "function"),
+      ).toBe(true);
+      return;
+    }
+
+    if (surface === "messaging") {
+      const messaging = plugin.messaging as Record<string, unknown> | undefined;
+      expect(messaging).toBeDefined();
+      expect(
+        [
+          messaging?.normalizeTarget,
+          messaging?.parseExplicitTarget,
+          messaging?.inferTargetChatType,
+          messaging?.buildCrossContextComponents,
+          messaging?.enableInteractiveReplies,
+          messaging?.hasStructuredReplyPayload,
+          messaging?.formatTargetDisplay,
+          messaging?.resolveOutboundSessionRoute,
+        ].some((value) => typeof value === "function"),
+      ).toBe(true);
+      const targetResolver = messaging?.targetResolver as Record<string, unknown> | undefined;
+      if (targetResolver) {
+        if (targetResolver.looksLikeId) {
+          expect(typeof targetResolver.looksLikeId).toBe("function");
+        }
+        if (targetResolver.hint !== undefined) {
+          expect(typeof targetResolver.hint).toBe("string");
+          expect((targetResolver.hint as string).trim()).not.toBe("");
+        }
+        if (targetResolver.resolveTarget) {
+          expect(typeof targetResolver.resolveTarget).toBe("function");
+        }
+      }
+      return;
+    }
+
+    if (surface === "threading") {
+      const threading = plugin.threading as Record<string, unknown> | undefined;
+      expect(threading).toBeDefined();
+      expect(
+        [
+          threading?.resolveReplyToMode,
+          threading?.buildToolContext,
+          threading?.resolveAutoThreadId,
+          threading?.resolveReplyTransport,
+          threading?.resolveFocusedBinding,
+        ].some((value) => typeof value === "function"),
+      ).toBe(true);
+      return;
+    }
+
+    if (surface === "directory") {
+      const directory = plugin.directory;
+      expect(directory).toBeDefined();
+      expect(
+        [
+          directory?.self,
+          directory?.listPeers,
+          directory?.listPeersLive,
+          directory?.listGroups,
+          directory?.listGroupsLive,
+          directory?.listGroupMembers,
+        ].some((value) => typeof value === "function"),
+      ).toBe(true);
+      return;
+    }
+
+    const gateway = plugin.gateway;
+    expect(gateway).toBeDefined();
+    expect(
+      [
+        gateway?.startAccount,
+        gateway?.stopAccount,
+        gateway?.loginWithQrStart,
+        gateway?.loginWithQrWait,
+        gateway?.logoutAccount,
+      ].some((value) => typeof value === "function"),
+    ).toBe(true);
+  });
 }
 
 type ChannelSetupContractCase<ResolvedAccount> = {
@@ -214,5 +359,193 @@ export function installChannelStatusContractSuite<ResolvedAccount, Probe = unkno
         expect(state).toBe(testCase.expectedState);
       }
     });
+  }
+}
+
+type PayloadLike = {
+  mediaUrl?: string;
+  mediaUrls?: string[];
+  text?: string;
+};
+
+type SendResultLike = {
+  messageId: string;
+  [key: string]: unknown;
+};
+
+type ChunkingMode =
+  | {
+      longTextLength: number;
+      maxChunkLength: number;
+      mode: "split";
+    }
+  | {
+      longTextLength: number;
+      mode: "passthrough";
+    };
+
+export function installChannelOutboundPayloadContractSuite(params: {
+  channel: string;
+  chunking: ChunkingMode;
+  createHarness: (params: { payload: PayloadLike; sendResults?: SendResultLike[] }) => {
+    run: () => Promise<Record<string, unknown>>;
+    sendMock: Mock;
+    to: string;
+  };
+}) {
+  it("text-only delegates to sendText", async () => {
+    const { run, sendMock, to } = params.createHarness({
+      payload: { text: "hello" },
+    });
+    const result = await run();
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith(to, "hello", expect.any(Object));
+    expect(result).toMatchObject({ channel: params.channel });
+  });
+
+  it("single media delegates to sendMedia", async () => {
+    const { run, sendMock, to } = params.createHarness({
+      payload: { text: "cap", mediaUrl: "https://example.com/a.jpg" },
+    });
+    const result = await run();
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith(
+      to,
+      "cap",
+      expect.objectContaining({ mediaUrl: "https://example.com/a.jpg" }),
+    );
+    expect(result).toMatchObject({ channel: params.channel });
+  });
+
+  it("multi-media iterates URLs with caption on first", async () => {
+    const { run, sendMock, to } = params.createHarness({
+      payload: {
+        text: "caption",
+        mediaUrls: ["https://example.com/1.jpg", "https://example.com/2.jpg"],
+      },
+      sendResults: [{ messageId: "m-1" }, { messageId: "m-2" }],
+    });
+    const result = await run();
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(sendMock).toHaveBeenNthCalledWith(
+      1,
+      to,
+      "caption",
+      expect.objectContaining({ mediaUrl: "https://example.com/1.jpg" }),
+    );
+    expect(sendMock).toHaveBeenNthCalledWith(
+      2,
+      to,
+      "",
+      expect.objectContaining({ mediaUrl: "https://example.com/2.jpg" }),
+    );
+    expect(result).toMatchObject({ channel: params.channel, messageId: "m-2" });
+  });
+
+  it("empty payload returns no-op", async () => {
+    const { run, sendMock } = params.createHarness({ payload: {} });
+    const result = await run();
+
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ channel: params.channel, messageId: "" });
+  });
+
+  if (params.chunking.mode === "passthrough") {
+    it("text exceeding chunk limit is sent as-is when chunker is null", async () => {
+      const text = "a".repeat(params.chunking.longTextLength);
+      const { run, sendMock, to } = params.createHarness({ payload: { text } });
+      const result = await run();
+
+      expect(sendMock).toHaveBeenCalledTimes(1);
+      expect(sendMock).toHaveBeenCalledWith(to, text, expect.any(Object));
+      expect(result).toMatchObject({ channel: params.channel });
+    });
+    return;
+  }
+
+  const chunking = params.chunking;
+
+  it("chunking splits long text", async () => {
+    const text = "a".repeat(chunking.longTextLength);
+    const { run, sendMock } = params.createHarness({
+      payload: { text },
+      sendResults: [{ messageId: "c-1" }, { messageId: "c-2" }],
+    });
+    const result = await run();
+
+    expect(sendMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    for (const call of sendMock.mock.calls) {
+      expect((call[1] as string).length).toBeLessThanOrEqual(chunking.maxChunkLength);
+    }
+    expect(result).toMatchObject({ channel: params.channel });
+  });
+}
+
+export function primeChannelOutboundSendMock(
+  sendMock: Mock,
+  fallbackResult: Record<string, unknown>,
+  sendResults: SendResultLike[] = [],
+) {
+  sendMock.mockReset();
+  if (sendResults.length === 0) {
+    sendMock.mockResolvedValue(fallbackResult);
+    return;
+  }
+  for (const result of sendResults) {
+    sendMock.mockResolvedValueOnce(result);
+  }
+}
+
+type RuntimeGroupPolicyResolver = (
+  params: ResolveProviderRuntimeGroupPolicyParams,
+) => RuntimeGroupPolicyResolution;
+
+export function installChannelRuntimeGroupPolicyFallbackSuite(params: {
+  configuredLabel: string;
+  defaultGroupPolicyUnderTest: "allowlist" | "disabled" | "open";
+  missingConfigLabel: string;
+  missingDefaultLabel: string;
+  resolve: RuntimeGroupPolicyResolver;
+}) {
+  it(params.missingConfigLabel, () => {
+    const resolved = params.resolve({
+      providerConfigPresent: false,
+    });
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
+
+  it(params.configuredLabel, () => {
+    const resolved = params.resolve({
+      providerConfigPresent: true,
+    });
+    expect(resolved.groupPolicy).toBe("open");
+    expect(resolved.providerMissingFallbackApplied).toBe(false);
+  });
+
+  it(params.missingDefaultLabel, () => {
+    const resolved = params.resolve({
+      providerConfigPresent: false,
+      defaultGroupPolicy: params.defaultGroupPolicyUnderTest,
+    });
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
+}
+
+export function expectChannelInboundContextContract(ctx: MsgContext) {
+  expect(validateSenderIdentity(ctx)).toEqual([]);
+
+  expect(ctx.Body).toBeTypeOf("string");
+  expect(ctx.BodyForAgent).toBeTypeOf("string");
+  expect(ctx.BodyForCommands).toBeTypeOf("string");
+
+  const chatType = normalizeChatType(ctx.ChatType);
+  if (chatType && chatType !== "direct") {
+    const label = ctx.ConversationLabel?.trim() || resolveConversationLabel(ctx);
+    expect(label).toBeTruthy();
   }
 }

--- a/src/channels/plugins/contracts/surface.contract.test.ts
+++ b/src/channels/plugins/contracts/surface.contract.test.ts
@@ -1,0 +1,14 @@
+import { describe } from "vitest";
+import { surfaceContractRegistry } from "./registry.js";
+import { installChannelSurfaceContractSuite } from "./suites.js";
+
+for (const entry of surfaceContractRegistry) {
+  for (const surface of entry.surfaces) {
+    describe(`${entry.id} ${surface} surface contract`, () => {
+      installChannelSurfaceContractSuite({
+        plugin: entry.plugin,
+        surface,
+      });
+    });
+  }
+}

--- a/src/channels/plugins/target-parsing.test.ts
+++ b/src/channels/plugins/target-parsing.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { parseExplicitTargetForChannel } from "./target-parsing.js";
+
+describe("parseExplicitTargetForChannel", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
+  it("parses bundled Telegram targets without an active Telegram registry entry", () => {
+    expect(parseExplicitTargetForChannel("telegram", "telegram:group:-100123:topic:77")).toEqual({
+      to: "-100123",
+      threadId: 77,
+      chatType: "group",
+    });
+    expect(parseExplicitTargetForChannel("telegram", "-100123")).toEqual({
+      to: "-100123",
+      chatType: "group",
+    });
+  });
+
+  it("parses registered non-bundled channel targets via the active plugin contract", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "msteams",
+          source: "test",
+          plugin: {
+            id: "msteams",
+            meta: {
+              id: "msteams",
+              label: "Microsoft Teams",
+              selectionLabel: "Microsoft Teams",
+              docsPath: "/channels/msteams",
+              blurb: "test stub",
+            },
+            capabilities: { chatTypes: ["direct"] },
+            config: {
+              listAccountIds: () => [],
+              resolveAccount: () => ({}),
+            },
+            messaging: {
+              parseExplicitTarget: ({ raw }: { raw: string }) => ({
+                to: raw.trim().toUpperCase(),
+                chatType: "direct" as const,
+              }),
+            },
+          },
+        },
+      ]),
+    );
+
+    expect(parseExplicitTargetForChannel("msteams", "team-room")).toEqual({
+      to: "TEAM-ROOM",
+      chatType: "direct",
+    });
+  });
+});

--- a/src/channels/plugins/target-parsing.ts
+++ b/src/channels/plugins/target-parsing.ts
@@ -1,4 +1,7 @@
+import { parseDiscordTarget } from "../../../extensions/discord/src/targets.js";
+import { parseTelegramTarget } from "../../../extensions/telegram/src/targets.js";
 import type { ChatType } from "../chat-type.js";
+import { normalizeChatChannelId } from "../registry.js";
 import { getChannelPlugin, normalizeChannelId } from "./registry.js";
 
 export type ParsedChannelExplicitTarget = {
@@ -11,9 +14,27 @@ function parseWithPlugin(
   rawChannel: string,
   rawTarget: string,
 ): ParsedChannelExplicitTarget | null {
-  const channel = normalizeChannelId(rawChannel);
+  const channel = normalizeChatChannelId(rawChannel) ?? normalizeChannelId(rawChannel);
   if (!channel) {
     return null;
+  }
+  if (channel === "telegram") {
+    const target = parseTelegramTarget(rawTarget);
+    return {
+      to: target.chatId,
+      ...(target.messageThreadId != null ? { threadId: target.messageThreadId } : {}),
+      ...(target.chatType === "unknown" ? {} : { chatType: target.chatType }),
+    };
+  }
+  if (channel === "discord") {
+    const target = parseDiscordTarget(rawTarget, { defaultKind: "channel" });
+    if (!target) {
+      return null;
+    }
+    return {
+      to: target.id,
+      chatType: target.kind === "user" ? "direct" : "channel",
+    };
   }
   return getChannelPlugin(channel)?.messaging?.parseExplicitTarget?.({ raw: rawTarget }) ?? null;
 }


### PR DESCRIPTION
## Cherry-picks from upstream (issue #1919)

3 of 22 commits cherry-picked from the Channel infrastructure batch.

| # | Hash | Subject | Author | Result |
|---|------|---------|--------|--------|
| 1 | `5cd206f780` | Channels: expand contract suites | Vincent Koc | PICKED (adapted) |
| 2 | `429144d9f1` | Channels: add contract surface coverage | Vincent Koc | PICKED (adapted) |
| 3 | `55f6d2d1ad` | fix(channels): parse bundled targets without plugin registry | Ayaan Zaidi | PICKED (clean) |

### Adaptations

**5cd206f780** — `installChannelSurfaceContractSuite`: cast outbound/messaging/threading surface objects to `Record<string, unknown>` to handle properties not yet on fork types (`sendFormattedText`, `inferTargetChatType`, etc.).

**429144d9f1** — `surfaceContractRegistry`: added `AnyChannelPlugin` type alias to handle probe type variance (IRC/Telegram use non-default `Probe` generic). Used `createSynologyChatPlugin()` factory instead of `synologyChatPlugin` direct reference.

### Blocked commits (19 of 22)

The remaining 19 commits are blocked by:
- **`requireBundledChannelPlugin`** function not in fork (1cf544ffbc, 382640e674, and downstream)
- **Missing types**: `SessionBindingCapabilities`, `ChannelFocusedBindingContext`, `ChannelReplyTransport`, `resolveAutoThreadId`, `resolveReplyTransport` (0f013575f8)
- **Missing files**: files being modified that don't exist in fork (setup-wizard-helpers.ts, message-capability-matrix.test.ts, inbound.contract.test.ts, bundle-mcp.test.ts, etc.)
- **Deep architectural divergence**: setup-wizard.ts (fork simplified from multi-credential to single-credential)

Resolves part of #1919.