### PR TITLE
fix: rebrand config files, scripts, and native apps (#2059)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "OpenClaw Dev",
+  "name": "RemoteClaw Dev",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
   "features": {
     "ghcr.io/devcontainers/features/sshd:1": {

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 .git
 .worktrees
 
-# Sensitive files – docker-setup.sh writes .env with OPENCLAW_GATEWAY_TOKEN
+# Sensitive files – docker-setup.sh writes .env with REMOTECLAW_GATEWAY_TOKEN
 # into the project root; keep it out of the build context.
 .env
 .env.*
@@ -56,14 +56,14 @@ vendor/
 # Needed for building the Canvas A2UI bundle during Docker image builds.
 # Keep the rest of apps/ and vendor/ excluded to avoid a large build context.
 !apps/shared/
-!apps/shared/OpenClawKit/
-!apps/shared/OpenClawKit/Sources/
-!apps/shared/OpenClawKit/Sources/OpenClawKit/
-!apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/
-!apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
-!apps/shared/OpenClawKit/Tools/
-!apps/shared/OpenClawKit/Tools/CanvasA2UI/
-!apps/shared/OpenClawKit/Tools/CanvasA2UI/**
+!apps/shared/RemoteClawKit/
+!apps/shared/RemoteClawKit/Sources/
+!apps/shared/RemoteClawKit/Sources/RemoteClawKit/
+!apps/shared/RemoteClawKit/Sources/RemoteClawKit/Resources/
+!apps/shared/RemoteClawKit/Sources/RemoteClawKit/Resources/tool-display.json
+!apps/shared/RemoteClawKit/Tools/
+!apps/shared/RemoteClawKit/Tools/CanvasA2UI/
+!apps/shared/RemoteClawKit/Tools/CanvasA2UI/**
 !vendor/a2ui/
 !vendor/a2ui/renderers/
 !vendor/a2ui/renderers/lit/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -113,8 +113,8 @@ jobs:
           cd apps/ios
           xcodegen generate
           xcodebuild build \
-            -project OpenClaw.xcodeproj \
-            -scheme OpenClaw \
+            -project RemoteClaw.xcodeproj \
+            -scheme RemoteClaw \
             -destination "generic/platform=iOS Simulator" \
             CODE_SIGNING_ALLOWED=NO
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -52,7 +52,7 @@ jobs:
             Please add updates or it will be closed.
           close-issue-message: |
             Closing due to inactivity.
-            If this is still an issue, please retry on the latest OpenClaw release and share updated details.
+            If this is still an issue, please retry on the latest RemoteClaw release and share updated details.
             If you are absolutely sure it still happens on the latest release, open a new issue with fresh repro steps.
           close-issue-reason: not_planned
           close-pr-message: |
@@ -108,7 +108,7 @@ jobs:
             Please add updates or it will be closed.
           close-issue-message: |
             Closing due to inactivity.
-            If this is still an issue, please retry on the latest OpenClaw release and share updated details.
+            If this is still an issue, please retry on the latest RemoteClaw release and share updated details.
             If you are absolutely sure it still happens on the latest release, open a new issue with fresh repro steps.
           close-issue-reason: not_planned
           close-pr-message: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ pnpm-lock.yaml
 bun.lock
 bun.lockb
 coverage
-__openclaw_vitest__/
+__remoteclaw_vitest__/
 __pycache__/
 *.pyc
 .tsbuildinfo

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -78,13 +78,13 @@ android {
     productFlavors {
         create("play") {
             dimension = "store"
-            buildConfigField("boolean", "OPENCLAW_ENABLE_SMS", "false")
-            buildConfigField("boolean", "OPENCLAW_ENABLE_CALL_LOG", "false")
+            buildConfigField("boolean", "REMOTECLAW_ENABLE_SMS", "false")
+            buildConfigField("boolean", "REMOTECLAW_ENABLE_CALL_LOG", "false")
         }
         create("thirdParty") {
             dimension = "store"
-            buildConfigField("boolean", "OPENCLAW_ENABLE_SMS", "true")
-            buildConfigField("boolean", "OPENCLAW_ENABLE_CALL_LOG", "true")
+            buildConfigField("boolean", "REMOTECLAW_ENABLE_SMS", "true")
+            buildConfigField("boolean", "REMOTECLAW_ENABLE_CALL_LOG", "true")
         }
     }
 

--- a/apps/android/app/src/main/java/org/remoteclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/gateway/GatewaySession.kt
@@ -183,13 +183,13 @@ class GatewaySession(
           timeoutMs = timeoutMs,
         )
       } catch (err: Throwable) {
-        Log.w("OpenClawGateway", "node.canvas.capability.refresh failed: ${err.message ?: err::class.java.simpleName}")
+        Log.w("RemoteClawGateway", "node.canvas.capability.refresh failed: ${err.message ?: err::class.java.simpleName}")
         return false
       }
     if (!response.ok) {
       val err = response.error
       Log.w(
-        "OpenClawGateway",
+        "RemoteClawGateway",
         "node.canvas.capability.refresh rejected: ${err?.code ?: "UNAVAILABLE"}: ${err?.message ?: "request failed"}",
       )
       return false
@@ -197,17 +197,17 @@ class GatewaySession(
     val payloadObj = response.payloadJson?.let(::parseJsonOrNull)?.asObjectOrNull()
     val refreshedCapability = payloadObj?.get("canvasCapability").asStringOrNull()?.trim().orEmpty()
     if (refreshedCapability.isEmpty()) {
-      Log.w("OpenClawGateway", "node.canvas.capability.refresh missing canvasCapability")
+      Log.w("RemoteClawGateway", "node.canvas.capability.refresh missing canvasCapability")
       return false
     }
     val scopedCanvasHostUrl = canvasHostUrl?.trim().orEmpty()
     if (scopedCanvasHostUrl.isEmpty()) {
-      Log.w("OpenClawGateway", "node.canvas.capability.refresh missing local canvasHostUrl")
+      Log.w("RemoteClawGateway", "node.canvas.capability.refresh missing local canvasHostUrl")
       return false
     }
     val refreshedUrl = replaceCanvasCapabilityInScopedHostUrl(scopedCanvasHostUrl, refreshedCapability)
     if (refreshedUrl == null) {
-      Log.w("OpenClawGateway", "node.canvas.capability.refresh unable to rewrite scoped canvas URL")
+      Log.w("RemoteClawGateway", "node.canvas.capability.refresh unable to rewrite scoped canvas URL")
       return false
     }
     canvasHostUrl = refreshedUrl

--- a/apps/android/app/src/main/java/org/remoteclaw/android/node/LocationHandler.kt
+++ b/apps/android/app/src/main/java/org/remoteclaw/android/node/LocationHandler.kt
@@ -36,7 +36,7 @@ class LocationHandler(
     if (!isForeground()) {
       return GatewaySession.InvokeResult.error(
         code = "LOCATION_BACKGROUND_UNAVAILABLE",
-        message = "LOCATION_BACKGROUND_UNAVAILABLE: location requires OpenClaw to stay open",
+        message = "LOCATION_BACKGROUND_UNAVAILABLE: location requires RemoteClaw to stay open",
       )
     }
     if (!hasFineLocationPermission() && !hasCoarseLocationPermission()) {

--- a/apps/ios/ActivityWidget/Info.plist
+++ b/apps/ios/ActivityWidget/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>OpenClaw Activity</string>
+	<string>RemoteClaw Activity</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/apps/ios/ShareExtension/Info.plist
+++ b/apps/ios/ShareExtension/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>OpenClaw Share</string>
+	<string>RemoteClaw Share</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/apps/ios/Sources/Screen/ScreenRecordService.swift
+++ b/apps/ios/Sources/Screen/ScreenRecordService.swift
@@ -1,5 +1,5 @@
 import AVFoundation
-import OpenClawKit
+import RemoteClawKit
 import ReplayKit
 
 final class ScreenRecordService: @unchecked Sendable {

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -65,7 +65,7 @@ struct SettingsTab: View {
                     DisclosureGroup(isExpanded: self.$gatewayExpanded) {
                         if !self.isGatewayConnected {
                             Text(
-                                "1. Open a chat with your OpenClaw agent and send /pair\n"
+                                "1. Open a chat with your RemoteClaw agent and send /pair\n"
                                     + "2. Copy the setup code it returns\n"
                                     + "3. Paste here and tap Connect\n"
                                     + "4. Back in that chat, run /pair approve")
@@ -896,7 +896,7 @@ struct SettingsTab: View {
         guard !trimmed.isEmpty else { return nil }
         let lower = trimmed.lowercased()
         if lower.contains("pairing required") {
-            return "Pairing required. Go back to your OpenClaw chat and run /pair approve, then tap Connect again."
+            return "Pairing required. Go back to your RemoteClaw chat and run /pair approve, then tap Connect again."
         }
         if lower.contains("device nonce required") || lower.contains("device nonce mismatch") {
             return "Secure handshake failed. Make sure Tailscale is connected, then tap Connect again."

--- a/apps/ios/Tests/Info.plist
+++ b/apps/ios/Tests/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>OpenClawTests</string>
+	<string>RemoteClawTests</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -53,7 +53,7 @@ end
 
 def read_asc_key_content_from_keychain
   service = ENV["ASC_KEYCHAIN_SERVICE"]
-  service = "openclaw-asc-key" unless env_present?(service)
+  service = "remoteclaw-asc-key" unless env_present?(service)
 
   account = ENV["ASC_KEYCHAIN_ACCOUNT"]
   account = ENV["USER"] unless env_present?(account)

--- a/apps/macos/Tests/RemoteClawIPCTests/VoiceWakeRuntimeTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/VoiceWakeRuntimeTests.swift
@@ -43,7 +43,7 @@ import Testing
 
     @Test func trimsAfterTriggerHandlesWidthInsensitiveForms() {
         let triggers = ["remoteclaw"]
-        let text = "ＯｐｅｎＣｌａｗ 请帮我"
+        let text = "ＲｅｍｏｔｅＣｌａｗ 请帮我"
         #expect(VoiceWakeRuntime._testTrimmedAfterTrigger(text, triggers: triggers) == "请帮我")
     }
 
@@ -76,12 +76,12 @@ import Testing
     }
 
     @Test func `gate command text handles foreign string ranges`() {
-        let transcript = "hey openclaw do thing"
+        let transcript = "hey remoteclaw do thing"
         let other = "do thing"
         let foreignRange = other.range(of: "do")
         let segments = [
             WakeWordSegment(text: "hey", start: 0.0, duration: 0.1, range: transcript.range(of: "hey")),
-            WakeWordSegment(text: "openclaw", start: 0.2, duration: 0.1, range: transcript.range(of: "openclaw")),
+            WakeWordSegment(text: "remoteclaw", start: 0.2, duration: 0.1, range: transcript.range(of: "remoteclaw")),
             WakeWordSegment(text: "do", start: 0.9, duration: 0.1, range: foreignRange),
             WakeWordSegment(text: "thing", start: 1.1, duration: 0.1, range: nil),
         ]

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -353,7 +353,7 @@ async function reannounceAttachedTabs() {
       setBadge(tabId, 'connecting')
       void chrome.action.setTitle({
         tabId,
-        title: 'OpenClaw Browser Relay: relay reconnecting…',
+        title: 'RemoteClaw Browser Relay: relay reconnecting…',
       })
     }
   }

--- a/extensions/irc/src/accounts.ts
+++ b/extensions/irc/src/accounts.ts
@@ -181,12 +181,12 @@ export function resolveIrcAccount(params: {
       merged.username?.trim() ||
       (accountId === DEFAULT_ACCOUNT_ID ? process.env.IRC_USERNAME?.trim() : "") ||
       nick ||
-      "openclaw"
+      "remoteclaw"
     ).trim();
     const realname = (
       merged.realname?.trim() ||
       (accountId === DEFAULT_ACCOUNT_ID ? process.env.IRC_REALNAME?.trim() : "") ||
-      "OpenClaw"
+      "RemoteClaw"
     ).trim();
 
     const passwordResolution = resolvePassword(accountId, merged);

--- a/extensions/nextcloud-talk/src/accounts.ts
+++ b/extensions/nextcloud-talk/src/accounts.ts
@@ -13,7 +13,7 @@ function isTruthyEnvValue(value?: string): boolean {
 }
 
 const debugAccounts = (...args: unknown[]) => {
-  if (isTruthyEnvValue(process.env.OPENCLAW_DEBUG_NEXTCLOUD_TALK_ACCOUNTS)) {
+  if (isTruthyEnvValue(process.env.REMOTECLAW_DEBUG_NEXTCLOUD_TALK_ACCOUNTS)) {
     console.warn("[nextcloud-talk:accounts]", ...args);
   }
 };

--- a/extensions/telegram/src/accounts.ts
+++ b/extensions/telegram/src/accounts.ts
@@ -129,7 +129,7 @@ export function mergeTelegramAccountConfig(
   // this failure disrupts message delivery for *all* accounts.
   // Single-account setups keep backward compat: channel-level groups still
   // applies when the account has no override.
-  // See: https://github.com/openclaw/openclaw/issues/30673
+  // See: https://github.com/remoteclaw/remoteclaw/issues/30673
   const configuredAccountIds = Object.keys(cfg.channels?.telegram?.accounts ?? {});
   const isMultiAccount = configuredAccountIds.length > 1;
   const groups = account.groups ?? (isMultiAccount ? undefined : channelGroups);

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -49,7 +49,7 @@ fi
 git add -- "${files[@]}"
 
 # This hook is also exercised from lightweight temp repos in tests, where the
-# staged-file safety behavior matters but the full OpenClaw workspace does not
+# staged-file safety behavior matters but the full RemoteClaw workspace does not
 # exist. Only run the repo-wide gate inside a real checkout.
 if [[ -f "$ROOT_DIR/package.json" ]] && [[ -f "$ROOT_DIR/pnpm-lock.yaml" ]]; then
   cd "$ROOT_DIR"

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,5 +1,5 @@
 const rootEntries = [
-  "openclaw.mjs!",
+  "remoteclaw.mjs!",
   "src/index.ts!",
   "src/entry.ts!",
   "src/cli/daemon-cli.ts!",
@@ -93,7 +93,7 @@ const config = {
     "extensions/*": {
       entry: ["index.ts!"],
       project: ["index.ts!", "src/**/*.ts!"],
-      ignoreDependencies: ["openclaw"],
+      ignoreDependencies: ["remoteclaw"],
     },
   },
 } as const;

--- a/remoteclaw.mjs
+++ b/remoteclaw.mjs
@@ -15,7 +15,7 @@ const ensureSupportedNodeVersion = () => {
   }
 
   process.stderr.write(
-    `openclaw: Node.js v${MIN_NODE_MAJOR}.${MIN_NODE_MINOR}+ is required (current: v${process.versions.node}).\n` +
+    `remoteclaw: Node.js v${MIN_NODE_MAJOR}.${MIN_NODE_MINOR}+ is required (current: v${process.versions.node}).\n` +
       "If you use nvm, run:\n" +
       `  nvm install ${MIN_NODE_MAJOR}\n` +
       `  nvm use ${MIN_NODE_MAJOR}\n` +

--- a/scripts/check-cli-startup-memory.mjs
+++ b/scripts/check-cli-startup-memory.mjs
@@ -14,10 +14,10 @@ if (!isLinux && !isMac) {
 }
 
 const repoRoot = process.cwd();
-const tmpHome = mkdtempSync(path.join(os.tmpdir(), "openclaw-startup-memory-"));
+const tmpHome = mkdtempSync(path.join(os.tmpdir(), "remoteclaw-startup-memory-"));
 const tmpDir = process.env.TMPDIR || process.env.TEMP || process.env.TMP || os.tmpdir();
 const rssHookPath = path.join(tmpHome, "measure-rss.mjs");
-const MAX_RSS_MARKER = "__OPENCLAW_MAX_RSS_KB__=";
+const MAX_RSS_MARKER = "__REMOTECLAW_MAX_RSS_KB__=";
 
 writeFileSync(
   rssHookPath,
@@ -41,23 +41,23 @@ const cases = [
   {
     id: "help",
     label: "--help",
-    args: ["openclaw.mjs", "--help"],
-    limitMb: Number(process.env.OPENCLAW_STARTUP_MEMORY_HELP_MB ?? DEFAULT_LIMITS_MB.help),
+    args: ["remoteclaw.mjs", "--help"],
+    limitMb: Number(process.env.REMOTECLAW_STARTUP_MEMORY_HELP_MB ?? DEFAULT_LIMITS_MB.help),
   },
   {
     id: "statusJson",
     label: "status --json",
-    args: ["openclaw.mjs", "status", "--json"],
+    args: ["remoteclaw.mjs", "status", "--json"],
     limitMb: Number(
-      process.env.OPENCLAW_STARTUP_MEMORY_STATUS_JSON_MB ?? DEFAULT_LIMITS_MB.statusJson,
+      process.env.REMOTECLAW_STARTUP_MEMORY_STATUS_JSON_MB ?? DEFAULT_LIMITS_MB.statusJson,
     ),
   },
   {
     id: "gatewayStatus",
     label: "gateway status",
-    args: ["openclaw.mjs", "gateway", "status"],
+    args: ["remoteclaw.mjs", "gateway", "status"],
     limitMb: Number(
-      process.env.OPENCLAW_STARTUP_MEMORY_GATEWAY_STATUS_MB ?? DEFAULT_LIMITS_MB.gatewayStatus,
+      process.env.REMOTECLAW_STARTUP_MEMORY_GATEWAY_STATUS_MB ?? DEFAULT_LIMITS_MB.gatewayStatus,
     ),
   },
 ];

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -8,13 +8,13 @@ const SKILLS_PYTHON_SCOPE_RE = /^skills\//;
 const CI_WORKFLOW_SCOPE_RE = /^\.github\/workflows\/ci\.yml$/;
 const INSTALL_SMOKE_WORKFLOW_SCOPE_RE = /^\.github\/workflows\/install-smoke\.yml$/;
 const MACOS_PROTOCOL_GEN_RE =
-  /^(apps\/macos\/Sources\/OpenClawProtocol\/|apps\/shared\/OpenClawKit\/Sources\/OpenClawProtocol\/)/;
+  /^(apps\/macos\/Sources\/RemoteClawProtocol\/|apps\/shared\/RemoteClawKit\/Sources\/RemoteClawProtocol\/)/;
 const MACOS_NATIVE_RE = /^(apps\/macos\/|apps\/ios\/|apps\/shared\/|Swabble\/)/;
 const ANDROID_NATIVE_RE = /^(apps\/android\/|apps\/shared\/)/;
 const NODE_SCOPE_RE =
-  /^(src\/|test\/|extensions\/|packages\/|scripts\/|ui\/|\.github\/|openclaw\.mjs$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig.*\.json$|vitest.*\.ts$|tsdown\.config\.ts$|\.oxlintrc\.json$|\.oxfmtrc\.jsonc$)/;
+  /^(src\/|test\/|extensions\/|packages\/|scripts\/|ui\/|\.github\/|remoteclaw\.mjs$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig.*\.json$|vitest.*\.ts$|tsdown\.config\.ts$|\.oxlintrc\.json$|\.oxfmtrc\.jsonc$)/;
 const WINDOWS_SCOPE_RE =
-  /^(src\/|test\/|extensions\/|packages\/|scripts\/|ui\/|openclaw\.mjs$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig.*\.json$|vitest.*\.ts$|tsdown\.config\.ts$|\.github\/workflows\/ci\.yml$|\.github\/actions\/setup-node-env\/action\.yml$|\.github\/actions\/setup-pnpm-store-cache\/action\.yml$)/;
+  /^(src\/|test\/|extensions\/|packages\/|scripts\/|ui\/|remoteclaw\.mjs$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig.*\.json$|vitest.*\.ts$|tsdown\.config\.ts$|\.github\/workflows\/ci\.yml$|\.github\/actions\/setup-node-env\/action\.yml$|\.github\/actions\/setup-pnpm-store-cache\/action\.yml$)/;
 const NATIVE_ONLY_RE =
   /^(apps\/android\/|apps\/ios\/|apps\/macos\/|apps\/shared\/|Swabble\/|appcast\.xml$)/;
 const CHANGED_SMOKE_SCOPE_RE =

--- a/scripts/copy-export-html-templates.ts
+++ b/scripts/copy-export-html-templates.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, "..");
-const verbose = process.env.OPENCLAW_BUILD_VERBOSE === "1";
+const verbose = process.env.REMOTECLAW_BUILD_VERBOSE === "1";
 
 const srcDir = path.join(projectRoot, "src", "auto-reply", "reply", "export-html");
 const distDir = path.join(projectRoot, "dist", "export-html");

--- a/scripts/copy-hook-metadata.ts
+++ b/scripts/copy-hook-metadata.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, "..");
-const verbose = process.env.OPENCLAW_BUILD_VERBOSE === "1";
+const verbose = process.env.REMOTECLAW_BUILD_VERBOSE === "1";
 
 const srcBundled = path.join(projectRoot, "src", "hooks", "bundled");
 const distBundled = path.join(projectRoot, "dist", "bundled");

--- a/scripts/run-remoteclaw-podman.sh
+++ b/scripts/run-remoteclaw-podman.sh
@@ -190,7 +190,7 @@ ENV_FILE_ARGS=()
 # On Linux with SELinux enforcing/permissive, add ,Z so Podman relabels the
 # bind-mounted directories and the container can access them.
 SELINUX_MOUNT_OPTS=""
-if [[ -z "${OPENCLAW_BIND_MOUNT_OPTIONS:-}" ]]; then
+if [[ -z "${REMOTECLAW_BIND_MOUNT_OPTIONS:-}" ]]; then
   if [[ "$(uname -s 2>/dev/null)" == "Linux" ]] && command -v getenforce >/dev/null 2>&1; then
     _selinux_mode="$(getenforce 2>/dev/null || true)"
     if [[ "$_selinux_mode" == "Enforcing" || "$_selinux_mode" == "Permissive" ]]; then
@@ -198,8 +198,8 @@ if [[ -z "${OPENCLAW_BIND_MOUNT_OPTIONS:-}" ]]; then
     fi
   fi
 else
-  # Honour explicit override (e.g. OPENCLAW_BIND_MOUNT_OPTIONS=":Z" → strip leading colon for inline use).
-  SELINUX_MOUNT_OPTS="${OPENCLAW_BIND_MOUNT_OPTIONS#:}"
+  # Honour explicit override (e.g. REMOTECLAW_BIND_MOUNT_OPTIONS=":Z" → strip leading colon for inline use).
+  SELINUX_MOUNT_OPTS="${REMOTECLAW_BIND_MOUNT_OPTIONS#:}"
   [[ -n "$SELINUX_MOUNT_OPTS" ]] && SELINUX_MOUNT_OPTS=",$SELINUX_MOUNT_OPTS"
 fi
 

--- a/src/browser/pw-session.page-cdp.ts
+++ b/src/browser/pw-session.page-cdp.ts
@@ -7,7 +7,7 @@ import {
 } from "./cdp.helpers.js";
 import { getChromeWebSocketUrl } from "./chrome.js";
 
-const OPENCLAW_EXTENSION_RELAY_BROWSER = "OpenClaw/extension-relay";
+const REMOTECLAW_EXTENSION_RELAY_BROWSER = "RemoteClaw/extension-relay";
 
 type PageCdpSend = (method: string, params?: Record<string, unknown>) => Promise<unknown>;
 
@@ -30,7 +30,7 @@ export async function isExtensionRelayCdpEndpoint(cdpUrl: string): Promise<boole
       appendCdpPath(cdpHttpBase, "/json/version"),
       2000,
     );
-    const isRelay = String(version?.Browser ?? "").trim() === OPENCLAW_EXTENSION_RELAY_BROWSER;
+    const isRelay = String(version?.Browser ?? "").trim() === REMOTECLAW_EXTENSION_RELAY_BROWSER;
     extensionRelayByCdpUrl.set(normalized, isRelay);
     return isRelay;
   } catch {

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -58,7 +58,7 @@ describe("detectChangedScope", () => {
       runSkillsPython: false,
       runChangedSmoke: false,
     });
-    expect(detectChangedScope(["apps/shared/OpenClawKit/Sources/Foo.swift"])).toEqual({
+    expect(detectChangedScope(["apps/shared/RemoteClawKit/Sources/Foo.swift"])).toEqual({
       runNode: false,
       runMacos: true,
       runAndroid: true,
@@ -69,16 +69,16 @@ describe("detectChangedScope", () => {
   });
 
   it("does not force macOS for generated protocol model-only changes", () => {
-    expect(detectChangedScope(["apps/macos/Sources/OpenClawProtocol/GatewayModels.swift"])).toEqual(
-      {
-        runNode: false,
-        runMacos: false,
-        runAndroid: false,
-        runWindows: false,
-        runSkillsPython: false,
-        runChangedSmoke: false,
-      },
-    );
+    expect(
+      detectChangedScope(["apps/macos/Sources/RemoteClawProtocol/GatewayModels.swift"]),
+    ).toEqual({
+      runNode: false,
+      runMacos: false,
+      runAndroid: false,
+      runWindows: false,
+      runSkillsPython: false,
+      runChangedSmoke: false,
+    });
   });
 
   it("enables node lane for non-native non-doc files by fallback", () => {
@@ -187,7 +187,7 @@ describe("detectChangedScope", () => {
   it("treats base and head as literal git args", () => {
     const markerPath = path.join(
       os.tmpdir(),
-      `openclaw-ci-changed-scope-${Date.now()}-${Math.random().toString(16).slice(2)}.tmp`,
+      `remoteclaw-ci-changed-scope-${Date.now()}-${Math.random().toString(16).slice(2)}.tmp`,
     );
     markerPaths.push(markerPath);
 


### PR DESCRIPTION
## Summary

- Rebrand 29 files across config/root (15), scripts (5), native apps (7+), and extension plugins (3) — replacing `openclaw`/`OpenClaw`/`OPENCLAW_` with `remoteclaw`/`RemoteClaw`/`REMOTECLAW_`
- Covers container names, display names (Info.plist), env var prefixes, import paths (`OpenClawKit` → `RemoteClawKit`), log tags, build config field names, CI path regexes, error messages, and test data
- Preserves gateway protocol paths (`__openclaw__/cap/`, `__openclaw__/canvas/`, `__openclaw__/a2ui/`) which are wire-format paths shared across clients

Closes #2059

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm format:check` passes
- [x] `pnpm tsgo` (typecheck) passes
- [x] `ci-changed-scope.test.ts` — 13/13 pass (test data paths updated to match new regexes)
- [x] Grep across changed files returns only the intentionally preserved `__openclaw__/cap/` protocol path
- [ ] CI (build, test, lint, docs) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)