### PR TITLE
feat(ci): add automated rebrand gate (CI + pre-commit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,18 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  rebrand-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Check rebrand leakage
+        run: bash scripts/ci/check-rebrand-leakage.sh
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -68,12 +80,12 @@ jobs:
 
   CI:
     if: always()
-    needs: [lint, build, test]
+    needs: [rebrand-gate, lint, build, test]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.test.result }}" != "success" ]]; then
+          if [[ "${{ needs.rebrand-gate.result }}" != "success" || "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.test.result }}" != "success" ]]; then
             echo "::error::One or more required jobs failed"
             exit 1
           fi

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -49,9 +49,15 @@ fi
 git add -- "${files[@]}"
 
 # This hook is also exercised from lightweight temp repos in tests, where the
-# staged-file safety behavior matters but the full OpenClaw workspace does not
+# staged-file safety behavior matters but the full RemoteClaw workspace does not
 # exist. Only run the repo-wide gate inside a real checkout.
 if [[ -f "$ROOT_DIR/package.json" ]] && [[ -f "$ROOT_DIR/pnpm-lock.yaml" ]]; then
   cd "$ROOT_DIR"
+
+  REBRAND_GATE="$ROOT_DIR/scripts/ci/check-rebrand-leakage.sh"
+  if [[ -x "$REBRAND_GATE" ]]; then
+    bash "$REBRAND_GATE" --staged
+  fi
+
   pnpm check
 fi

--- a/scripts/ci/check-rebrand-leakage.sh
+++ b/scripts/ci/check-rebrand-leakage.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Rebrand leakage gate — detects unrebranded openclaw references.
+#
+# Modes:
+#   --staged   Pre-commit: checks staged files only
+#   --all      Full scan: checks entire repo
+#   (default)  CI: checks files changed vs origin/main
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ALLOWLIST="$SCRIPT_DIR/rebrand-allowlist.txt"
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+cd "$ROOT"
+
+MODE="ci"
+case "${1:-}" in
+  --staged) MODE="staged" ;;
+  --all)    MODE="all" ;;
+  --help|-h)
+    echo "Usage: $(basename "$0") [--staged | --all]"
+    echo "  --staged  Check staged files only (pre-commit)"
+    echo "  --all     Full repo scan"
+    echo "  (default) CI: files changed vs origin/main"
+    exit 0
+    ;;
+esac
+
+# --- Collect target files (NUL-delimited to stdout) -------------------------
+
+list_files() {
+  case "$MODE" in
+    staged) git diff --cached --name-only --diff-filter=ACMR -z ;;
+    all)    git ls-files -z ;;
+    ci)     git diff --name-only --diff-filter=ACMR -z "origin/main...HEAD" 2>/dev/null \
+              || git diff --name-only --diff-filter=ACMR -z "main...HEAD" ;;
+  esac
+}
+
+# --- Load allowlist into temp files ------------------------------------------
+
+CLEANUP_DIR=$(mktemp -d)
+trap 'rm -rf "$CLEANUP_DIR"' EXIT
+
+EXEMPT_FILES="$CLEANUP_DIR/files.txt"
+EXEMPT_DIRS="$CLEANUP_DIR/dirs.txt"
+EXEMPT_PATTERNS="$CLEANUP_DIR/patterns.txt"
+: > "$EXEMPT_FILES"
+: > "$EXEMPT_DIRS"
+: > "$EXEMPT_PATTERNS"
+
+if [[ -f "$ALLOWLIST" ]]; then
+  while IFS= read -r line; do
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    if [[ "$line" =~ ^FILE: ]]; then
+      path="${line#FILE:}"
+      if [[ "$path" == */ ]]; then
+        echo "$path" >> "$EXEMPT_DIRS"
+      else
+        echo "$path" >> "$EXEMPT_FILES"
+      fi
+    else
+      echo "$line" >> "$EXEMPT_PATTERNS"
+    fi
+  done < "$ALLOWLIST"
+fi
+
+# --- Scan --------------------------------------------------------------------
+
+FILE_LIST="$CLEANUP_DIR/file-list.bin"
+list_files > "$FILE_LIST"
+
+if [[ ! -s "$FILE_LIST" ]]; then
+  echo "No files to check."
+  exit 0
+fi
+
+export EXEMPT_FILES EXEMPT_DIRS EXEMPT_PATTERNS
+
+violations=$(
+  xargs -0 grep -inIH 'openclaw' -- < "$FILE_LIST" 2>/dev/null \
+    | awk '
+        BEGIN {
+          while ((getline f < ENVIRON["EXEMPT_FILES"]) > 0) files[f] = 1
+          while ((getline d < ENVIRON["EXEMPT_DIRS"]) > 0) dirs[++nd] = d
+          while ((getline p < ENVIRON["EXEMPT_PATTERNS"]) > 0) pats[++np] = p
+        }
+        {
+          match($0, /^[^:]+/)
+          file = substr($0, RSTART, RLENGTH)
+          if (file in files) next
+          for (i = 1; i <= nd; i++)
+            if (index(file, dirs[i]) == 1) next
+          for (i = 1; i <= np; i++)
+            if (index($0, pats[i]) > 0) next
+          print
+        }
+      ' \
+    || true
+)
+
+if [[ -z "$violations" ]]; then
+  echo "No rebrand leakage detected."
+  exit 0
+fi
+
+count=$(printf '%s\n' "$violations" | wc -l | tr -d ' ')
+echo "Rebrand leakage detected ($count violation(s)):"
+echo ""
+printf '%s\n' "$violations" | sed 's/^/  /'
+echo ""
+echo "Fix: replace openclaw with remoteclaw, or add exemption to"
+echo "     scripts/ci/rebrand-allowlist.txt"
+exit 1

--- a/scripts/ci/rebrand-allowlist.txt
+++ b/scripts/ci/rebrand-allowlist.txt
@@ -1,0 +1,204 @@
+# Rebrand allowlist — intentional openclaw references exempt from the leakage gate.
+#
+# FILE:path   — exempt a single file (exact match, relative to repo root)
+# FILE:dir/   — exempt an entire directory (trailing slash = prefix match)
+# pattern     — exempt any match whose line contains this substring (case-sensitive)
+#
+# Validate: bash scripts/ci/check-rebrand-leakage.sh --all
+
+# ---------------------------------------------------------------------------
+# Gate infrastructure (self-referential)
+# ---------------------------------------------------------------------------
+FILE:scripts/ci/check-rebrand-leakage.sh
+FILE:scripts/ci/rebrand-allowlist.txt
+
+# ---------------------------------------------------------------------------
+# Upstream release workflow and compat scripts
+# ---------------------------------------------------------------------------
+FILE:.github/workflows/openclaw-npm-release.yml
+FILE:scripts/openclaw-npm-release-check.ts
+FILE:test/openclaw-npm-release-check.test.ts
+FILE:test/openclaw-launcher.e2e.test.ts
+FILE:test/openshell-sandbox.e2e.test.ts
+FILE:test/plugin-npm-release.test.ts
+FILE:test/scripts/check-no-conflict-markers.test.ts
+
+# ---------------------------------------------------------------------------
+# Legal attribution and fork context
+# ---------------------------------------------------------------------------
+FILE:NOTICE.md
+FILE:REUSE.toml
+FILE:CONTRIBUTING.md
+FILE:README.md
+FILE:VISION.md
+FILE:CLAUDE.md
+FILE:docs.acp.md
+
+# ---------------------------------------------------------------------------
+# Documentation (upstream refs pervasive in migration/comparison docs)
+# ---------------------------------------------------------------------------
+FILE:docs/
+
+# ---------------------------------------------------------------------------
+# Generated reference docs
+# ---------------------------------------------------------------------------
+FILE:docs/.generated/
+
+# ---------------------------------------------------------------------------
+# Config, build, and CI infrastructure with openclaw compat
+# ---------------------------------------------------------------------------
+FILE:knip.config.ts
+FILE:vitest.config.ts
+FILE:vitest.performance-config.ts
+FILE:tsdown.config.ts
+FILE:package.json
+FILE:ui/package.json
+FILE:.gitignore
+FILE:.dockerignore
+FILE:.detect-secrets.cfg
+FILE:.secrets.baseline
+FILE:.devcontainer/devcontainer.json
+FILE:.agents/
+
+# ---------------------------------------------------------------------------
+# Native apps (upstream compat references in config/tests)
+# ---------------------------------------------------------------------------
+FILE:apps/
+
+# ---------------------------------------------------------------------------
+# Upstream repo URL (github.com/openclaw/openclaw)
+# ---------------------------------------------------------------------------
+openclaw/openclaw
+
+# ---------------------------------------------------------------------------
+# @openclaw/ compat package scope
+# ---------------------------------------------------------------------------
+@openclaw/
+
+# ---------------------------------------------------------------------------
+# Gateway protocol paths (__openclaw__/cap/, __openclaw__/canvas/)
+# ---------------------------------------------------------------------------
+__openclaw__
+
+# ---------------------------------------------------------------------------
+# OPENCLAW_ environment variables (backwards-compat namespace)
+# ---------------------------------------------------------------------------
+OPENCLAW_
+
+# ---------------------------------------------------------------------------
+# OpenClaw brand name (PascalCase — compat code, migration, import wizard)
+# ---------------------------------------------------------------------------
+OpenClaw
+
+# ---------------------------------------------------------------------------
+# Gateway URL path segments (/openclaw/ base path)
+# ---------------------------------------------------------------------------
+/openclaw
+
+# ---------------------------------------------------------------------------
+# Hyphenated identifiers (docker images, temp dirs, CLI names, plugins)
+# ---------------------------------------------------------------------------
+openclaw-
+
+# ---------------------------------------------------------------------------
+# Dot-separated identifiers (Symbols, domains, config files, extensions)
+# ---------------------------------------------------------------------------
+openclaw.
+
+# ---------------------------------------------------------------------------
+# Config directory references (.openclaw/)
+# ---------------------------------------------------------------------------
+.openclaw
+
+# ---------------------------------------------------------------------------
+# Colon-separated compat keys, DOM events, and format strings
+# ---------------------------------------------------------------------------
+openclaw:
+
+# ---------------------------------------------------------------------------
+# Plugin SDK import specifier (openclaw/plugin-sdk/*)
+# ---------------------------------------------------------------------------
+openclaw/plugin-sdk
+
+# ---------------------------------------------------------------------------
+# Single-underscore context keys (__openclaw_channel_id etc.)
+# ---------------------------------------------------------------------------
+__openclaw_
+
+# ---------------------------------------------------------------------------
+# Third-party plugin references
+# ---------------------------------------------------------------------------
+opik-openclaw
+
+# ---------------------------------------------------------------------------
+# Upstream issue references (openclaw#31186 etc.)
+# ---------------------------------------------------------------------------
+openclaw#
+
+# ---------------------------------------------------------------------------
+# Double-underscore package path variant (@openclaw__matrix)
+# ---------------------------------------------------------------------------
+@openclaw__
+
+# ---------------------------------------------------------------------------
+# Windows path separators in test fixtures
+# ---------------------------------------------------------------------------
+openclaw\
+
+# ---------------------------------------------------------------------------
+# Fork attribution in commit trailers and comments
+# ---------------------------------------------------------------------------
+Cherry-picked-from:
+
+# ---------------------------------------------------------------------------
+# Quoted compat package/binary names
+# ---------------------------------------------------------------------------
+"openclaw"
+'openclaw'
+
+# ---------------------------------------------------------------------------
+# Source files with compat references (CLI command strings, variable names,
+# config fields, import wizard, probe strings, plugin fixtures). These are
+# existing upstream artifacts; new files are NOT exempt and will be caught.
+# ---------------------------------------------------------------------------
+FILE:remoteclaw.mjs
+FILE:scripts/ci-changed-scope.mjs
+FILE:scripts/e2e/parallels-macos-smoke.sh
+FILE:scripts/lib/plugin-npm-release.ts
+FILE:scripts/lib/plugin-sdk-doc-metadata.ts
+FILE:scripts/check-plugin-sdk-exports.mjs
+FILE:scripts/test-built-plugin-singleton.mjs
+FILE:scripts/check-cli-startup-memory.mjs
+FILE:scripts/check-gateway-watch-regression.mjs
+FILE:scripts/test-hotspots.mjs
+FILE:scripts/test-parallel.mjs
+FILE:scripts/test-perf-budget.mjs
+FILE:scripts/pr
+FILE:scripts/release-check.ts
+FILE:src/acp/client.test.ts
+FILE:src/auto-reply/reply/abort-primitives.ts
+FILE:src/auto-reply/reply/route-reply.test.ts
+FILE:src/channels/plugins/helpers.test.ts
+FILE:src/cli/daemon-cli/lifecycle-core.ts
+FILE:src/cli/daemon-cli/lifecycle.test.ts
+FILE:src/cli/daemon-cli/lifecycle.ts
+FILE:src/cli/daemon-cli/status.print.test.ts
+FILE:src/cli/daemon-cli/status.print.ts
+FILE:src/commands/doctor/shared/config-mutation-state.test.ts
+FILE:src/commands/import.test.ts
+FILE:src/commands/import.ts
+FILE:src/commands/onboard-search.ts
+FILE:src/config/doc-baseline.ts
+FILE:src/entry.ts
+FILE:src/gateway/android-node.capabilities.live.test.ts
+FILE:src/gateway/live-tool-probe-utils.ts
+FILE:src/infra/fs-safe.ts
+FILE:src/infra/install-safe-path.test.ts
+FILE:src/infra/path-env.test.ts
+FILE:src/node-host/invoke-browser.test.ts
+FILE:src/plugins/marketplace.test.ts
+FILE:src/plugins/update.test.ts
+FILE:src/wizard/onboarding.ts
+FILE:extensions/line/src/channel.ts
+FILE:extensions/mattermost/src/mattermost/monitor.ts
+FILE:extensions/zalouser/src/status-issues.ts


### PR DESCRIPTION
## Summary

- Add `scripts/ci/check-rebrand-leakage.sh` gate script with three modes: `--staged` (pre-commit), `--all` (full scan), default (CI diff vs origin/main)
- Add `scripts/ci/rebrand-allowlist.txt` with pattern-level exemptions (env vars, package scope, protocol paths, PascalCase brand, URL paths, storage keys) and file-level exemptions for existing compat code
- Wire `rebrand-gate` job into `.github/workflows/ci.yml` (runs parallel with lint/build/test, included in CI summary check)
- Wire `--staged` mode into `git-hooks/pre-commit` before `pnpm check`

Closes #2061

## Test plan

- [x] `scripts/ci/check-rebrand-leakage.sh --all` passes clean (zero violations on current codebase)
- [x] Gate correctly catches new openclaw references in unexempted files (verified with test file)
- [x] Exempted patterns (e.g. `OPENCLAW_` env vars) are correctly allowed
- [x] `--staged` mode works correctly with pre-commit hook
- [x] `--help` mode displays usage
- [ ] CI `rebrand-gate` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)