### PR TITLE
docs: add 0.1.0 changelog and release publishing conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,35 @@
 # Changelog
 
-All notable changes to RemoteClaw will be documented in this file.
+## 0.1.0
 
----
+First RemoteClaw release. Forked from [OpenClaw v2026.2.25](https://github.com/openclaw/openclaw/releases/tag/v2026.2.25)
+with significant changes — RemoteClaw is middleware, not a platform.
 
-Forked from [OpenClaw](https://github.com/openclaw/openclaw).
+### What changed from OpenClaw
+
+**Removed** (26 gut operations):
+
+- Skills marketplace and plugin system
+- Model provider ecosystem (replaced by CLI-native auth)
+- Consumer onboarding UX
+- Elevated mode infrastructure
+- Legacy migrations and bootstrap system
+
+**Replaced**:
+
+- Execution engine: Pi-based orchestrator → AgentRuntime supporting
+  CLI-only agents (Claude, Gemini, Codex, OpenCode)
+
+**Added** (highlights):
+
+- Multimodal I/O for Claude, Gemini, and Codex runtimes
+- Thinking/reasoning output propagation (middleware → gateway → UI)
+- Per-agent `runtimeArgs` and `runtimeEnv` configuration
+- Auth rate-limit retry with key rotation
+- Plugin SDK: custom STT/TTS provider registration
+- Slack setup wizard with manifest customization
+- Automated rebrand gate in CI
+- `next` npm channel (auto-publishes on every push to main)
+
+For the upstream changelog at the fork point, see
+[OpenClaw v2026.2.25](https://github.com/openclaw/openclaw/releases/tag/v2026.2.25).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,18 @@ GitHub Actions (`.github/workflows/ci.yml`):
 - Both run on `ubuntu-latest` with Node 22 and pnpm 10.23.0
 - Branch protection requires `build`, `test`, `lint`, and `docs` to pass
 
+### Release publishing
+
+- **Trigger**: `publish-latest` runs on `release: [published]` event —
+  create a GitHub release (which auto-creates the tag) to trigger it.
+  A bare `git tag` push does NOT trigger publishing.
+- **Version gate**: CI validates that the release tag (`v0.1.0`) matches
+  `package.json` version (`0.1.0`) before publishing.
+- **npm tag routing**: pre-release → `beta` tag; stable release → `latest` tag.
+- **`next` channel**: `publish-next` runs on every push to `main` — automatic,
+  no manual step.
+- **Checklist**: `docs/reference/RELEASING.md` (upstream-inherited, adapted).
+
 ## Security
 
 - Never commit real phone numbers, API keys, or live configuration values


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` for the 0.1.0 release — documents what changed from OpenClaw (removals, replacements, additions), anchored to upstream v2026.2.25
- Document release publishing conventions in `CLAUDE.md` § CI (trigger mechanism, version gate, npm tag routing, next channel)

## Test plan
- [ ] Verify CHANGELOG.md renders correctly on GitHub
- [ ] Verify CLAUDE.md release publishing section is accurate against `.github/workflows/ci.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)