### PR TITLE
ci: align publish-latest test config with CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,8 @@ jobs:
       - name: Test
         run: pnpm test
         env:
-          REMOTECLAW_TEST_WORKERS: 2
-          REMOTECLAW_TEST_MAX_OLD_SPACE_SIZE_MB: 4096
+          REMOTECLAW_TEST_WORKERS: 1
+          REMOTECLAW_TEST_MAX_OLD_SPACE_SIZE_MB: 1536
 
       - name: Publish
         run: |


### PR DESCRIPTION
## Summary
- Align `publish-latest` test env vars with the `test` job (workers: 2→1, memory: 4096→1536)
- Fixes deterministic test failures in `update-cli.test.ts` caused by a mock-identity split under 2 workers
- Unblocks the 0.1.0 release (publish-latest failed on the Test step)

## Test plan
- [ ] CI passes (same config as the `test` job which already passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)