### PR TITLE
ci: unify publish pipeline — sync, validate, publish (#2074)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,20 +117,22 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Publish next
+      - name: Stamp next version
         run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
           SHORT_SHA=$(git rev-parse --short HEAD)
           BUILD_TS=$(date -u +%Y%m%d%H%M%S)
           NEXT_VERSION="${PKG_VERSION}-next.${BUILD_TS}.${SHORT_SHA}"
-
-          if npm view "remoteclaw@${NEXT_VERSION}" version &>/dev/null; then
-            echo "Version ${NEXT_VERSION} already published, skipping"
-            exit 0
-          fi
-
           npm version "$NEXT_VERSION" --no-git-tag-version
-          npm publish --tag next --provenance --access public || true
+
+      - name: Sync extension versions
+        run: pnpm plugins:sync-version
+
+      - name: Validate release artifacts
+        run: pnpm release:check
+
+      - name: Publish next
+        run: npm publish --tag next --provenance --access public
 
   publish-latest:
     if: github.event_name == 'release'
@@ -156,9 +158,6 @@ jobs:
         with:
           registry-url: "https://registry.npmjs.org"
 
-      - name: Upgrade npm
-        run: npm install -g "npm@>=11.5.1"
-
       - name: Validate version matches tag
         run: |
           TAG="${{ github.event.release.tag_name }}"
@@ -172,11 +171,11 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Test
-        run: pnpm test
-        env:
-          REMOTECLAW_TEST_WORKERS: 1
-          REMOTECLAW_TEST_MAX_OLD_SPACE_SIZE_MB: 1536
+      - name: Sync extension versions
+        run: pnpm plugins:sync-version
+
+      - name: Validate release artifacts
+        run: pnpm release:check
 
       - name: Publish
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,12 @@ GitHub Actions (`.github/workflows/ci.yml`):
   `package.json` version (`0.1.0`) before publishing.
 - **npm tag routing**: pre-release → `beta` tag; stable release → `latest` tag.
 - **`next` channel**: `publish-next` runs on every push to `main` — automatic,
-  no manual step.
+  no manual step. Stamps dynamic version on root + all extensions.
+- **Version sync**: Both publish jobs run `pnpm release:check` which validates
+  extension versions match root. Extensions are synced automatically in CI.
+- **Post-release bump**: After a release is confirmed green, bump `package.json`
+  and all `extensions/*/package.json` to the next minor version (e.g.,
+  `0.1.0` → `0.2.0`) so `next` builds start on the new development version.
 - **Checklist**: `docs/reference/RELEASING.md` (upstream-inherited, adapted).
 
 ## Security

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "mac:open": "open dist/RemoteClaw.app",
     "mac:package": "bash scripts/package-mac-app.sh",
     "mac:restart": "bash scripts/restart-mac.sh",
+    "plugins:sync-version": "node --import tsx scripts/plugins-sync-version.ts",
     "prepack": "pnpm build && pnpm ui:build",
     "prepare": "command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath git-hooks || exit 0",
     "protocol:check": "pnpm protocol:gen && pnpm protocol:gen:swift && git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/RemoteClawProtocol/GatewayModels.swift",

--- a/scripts/plugins-sync-version.ts
+++ b/scripts/plugins-sync-version.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env -S node --import tsx
+
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+type PackageJson = {
+  name?: string;
+  version?: string;
+};
+
+function main() {
+  const rootPackagePath = resolve("package.json");
+  const rootPackage = JSON.parse(readFileSync(rootPackagePath, "utf8")) as PackageJson;
+  const targetVersion = rootPackage.version;
+
+  if (!targetVersion) {
+    console.error("plugins-sync-version: root package.json missing version.");
+    process.exit(1);
+  }
+
+  const extensionsDir = resolve("extensions");
+  const entries = readdirSync(extensionsDir, { withFileTypes: true }).filter((entry) =>
+    entry.isDirectory(),
+  );
+
+  let updated = 0;
+
+  for (const entry of entries) {
+    const packagePath = join(extensionsDir, entry.name, "package.json");
+    let pkg: PackageJson;
+    try {
+      pkg = JSON.parse(readFileSync(packagePath, "utf8")) as PackageJson;
+    } catch {
+      continue;
+    }
+
+    if (!pkg.name || !pkg.version) {
+      continue;
+    }
+
+    if (pkg.version !== targetVersion) {
+      pkg.version = targetVersion;
+      writeFileSync(packagePath, JSON.stringify(pkg, null, 2) + "\n");
+      updated++;
+    }
+  }
+
+  console.log(`plugins-sync-version: ${updated} extension(s) synced to ${targetVersion}.`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- Unify both publish jobs to identical post-build shape: **sync → validate → publish**
- Remove redundant `pnpm test` from `publish-latest` (gated by `needs:`)
- Remove `npm install -g "npm@>=11.5.1"` from `publish-latest`
- Remove fragile `npm view` pre-check and `|| true` error silencing from `publish-next`
- Add `plugins:sync-version` script to sync extension versions to root
- Add `pnpm release:check` to both publish jobs
- Document post-release version bump convention in CLAUDE.md

Closes #2074

## Test plan
- [ ] CI passes
- [ ] Both publish jobs follow: build → sync → validate → publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)