### PR TITLE
ci(publish): stamp version from release tag — enable patch releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,15 +158,17 @@ jobs:
         with:
           registry-url: "https://registry.npmjs.org"
 
-      - name: Validate version matches tag
+      - name: Stamp version from tag
         run: |
           TAG="${{ github.event.release.tag_name }}"
           VERSION="${TAG#v}"
           PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "Release tag: $TAG (version: $VERSION)"
+          echo "package.json version: $PKG_VERSION"
           if [ "$VERSION" != "$PKG_VERSION" ]; then
-            echo "::error::Tag $TAG does not match package.json version $PKG_VERSION"
-            exit 1
+            echo "::notice::Stamping version from tag: $PKG_VERSION → $VERSION"
           fi
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
## Summary

- Replace the strict version gate in `publish-latest` (tag must exactly match `package.json` version) with tag-based version stamping via `npm version --no-git-tag-version --allow-same-version`
- Enables creating patch releases (e.g. `v0.1.1`) even when `main` has already moved to `0.2.0`
- Mirrors the existing `publish-next` stamping pattern; emits a `::notice::` annotation when stamping a different version for visibility

## Test plan

- [ ] Verify CI passes (format, lint, build, test)
- [ ] Create a test prerelease to confirm the stamp step runs correctly
- [ ] Verify normal release flow (tag matches package.json) still works via `--allow-same-version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)