### PR TITLE
fix: recover dropped upstream changes from v2026.2.26 sync (42 files)

### DIFF
--- a/apps/macos/Sources/RemoteClaw/HostEnvSanitizer.swift
+++ b/apps/macos/Sources/RemoteClaw/HostEnvSanitizer.swift
@@ -1,37 +1,11 @@
 import Foundation
 
 enum HostEnvSanitizer {
-    /// Keep in sync with src/infra/host-env-security-policy.json.
+    /// Generated from src/infra/host-env-security-policy.json via scripts/generate-host-env-security-policy-swift.mjs.
     /// Parity is validated by src/infra/host-env-security.policy-parity.test.ts.
-    private static let blockedKeys: Set<String> = [
-        "NODE_OPTIONS",
-        "NODE_PATH",
-        "PYTHONHOME",
-        "PYTHONPATH",
-        "PERL5LIB",
-        "PERL5OPT",
-        "RUBYLIB",
-        "RUBYOPT",
-        "BASH_ENV",
-        "ENV",
-        "GIT_EXTERNAL_DIFF",
-        "SHELL",
-        "SHELLOPTS",
-        "PS4",
-        "GCONV_PATH",
-        "IFS",
-        "SSLKEYLOGFILE",
-    ]
-
-    private static let blockedPrefixes: [String] = [
-        "DYLD_",
-        "LD_",
-        "BASH_FUNC_",
-    ]
-    private static let blockedOverrideKeys: Set<String> = [
-        "HOME",
-        "ZDOTDIR",
-    ]
+    private static let blockedKeys = HostEnvSecurityPolicy.blockedKeys
+    private static let blockedPrefixes = HostEnvSecurityPolicy.blockedPrefixes
+    private static let blockedOverrideKeys = HostEnvSecurityPolicy.blockedOverrideKeys
     private static let shellWrapperAllowedOverrideKeys: Set<String> = [
         "TERM",
         "LANG",

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -1,7 +1,8 @@
+import type * as Lark from "@larksuiteoapi/node-sdk";
 import { Type } from "@sinclair/typebox";
 import type { RemoteClawPluginApi } from "remoteclaw/plugin-sdk";
-import { createFeishuClient } from "./client.js";
-import type { FeishuConfig } from "./types.js";
+import { listEnabledFeishuAccounts } from "./accounts.js";
+import { createFeishuToolClient } from "./tool-account.js";
 
 // ============ Helpers ============
 
@@ -64,10 +65,7 @@ function parseBitableUrl(url: string): { token: string; tableId?: string; isWiki
 }
 
 /** Get app_token from wiki node_token */
-async function getAppTokenFromWiki(
-  client: ReturnType<typeof createFeishuClient>,
-  nodeToken: string,
-): Promise<string> {
+async function getAppTokenFromWiki(client: Lark.Client, nodeToken: string): Promise<string> {
   const res = await client.wiki.space.getNode({
     params: { token: nodeToken },
   });
@@ -87,7 +85,7 @@ async function getAppTokenFromWiki(
 }
 
 /** Get bitable metadata from URL (handles both /base/ and /wiki/ URLs) */
-async function getBitableMeta(client: ReturnType<typeof createFeishuClient>, url: string) {
+async function getBitableMeta(client: Lark.Client, url: string) {
   const parsed = parseBitableUrl(url);
   if (!parsed) {
     throw new Error("Invalid URL format. Expected /base/XXX or /wiki/XXX URL");
@@ -134,11 +132,7 @@ async function getBitableMeta(client: ReturnType<typeof createFeishuClient>, url
   };
 }
 
-async function listFields(
-  client: ReturnType<typeof createFeishuClient>,
-  appToken: string,
-  tableId: string,
-) {
+async function listFields(client: Lark.Client, appToken: string, tableId: string) {
   const res = await client.bitable.appTableField.list({
     path: { app_token: appToken, table_id: tableId },
   });
@@ -161,7 +155,7 @@ async function listFields(
 }
 
 async function listRecords(
-  client: ReturnType<typeof createFeishuClient>,
+  client: Lark.Client,
   appToken: string,
   tableId: string,
   pageSize?: number,
@@ -186,12 +180,7 @@ async function listRecords(
   };
 }
 
-async function getRecord(
-  client: ReturnType<typeof createFeishuClient>,
-  appToken: string,
-  tableId: string,
-  recordId: string,
-) {
+async function getRecord(client: Lark.Client, appToken: string, tableId: string, recordId: string) {
   const res = await client.bitable.appTableRecord.get({
     path: { app_token: appToken, table_id: tableId, record_id: recordId },
   });
@@ -205,7 +194,7 @@ async function getRecord(
 }
 
 async function createRecord(
-  client: ReturnType<typeof createFeishuClient>,
+  client: Lark.Client,
   appToken: string,
   tableId: string,
   fields: Record<string, unknown>,
@@ -235,7 +224,7 @@ const DEFAULT_CLEANUP_FIELD_TYPES = new Set([3, 5, 17]); // SingleSelect, DateTi
 
 /** Clean up default placeholder rows and fields in a newly created Bitable table */
 async function cleanupNewBitable(
-  client: ReturnType<typeof createFeishuClient>,
+  client: Lark.Client,
   appToken: string,
   tableId: string,
   tableName: string,
@@ -334,7 +323,7 @@ async function cleanupNewBitable(
 }
 
 async function createApp(
-  client: ReturnType<typeof createFeishuClient>,
+  client: Lark.Client,
   name: string,
   folderToken?: string,
   logger?: CleanupLogger,
@@ -389,7 +378,7 @@ async function createApp(
 }
 
 async function createField(
-  client: ReturnType<typeof createFeishuClient>,
+  client: Lark.Client,
   appToken: string,
   tableId: string,
   fieldName: string,
@@ -417,7 +406,7 @@ async function createField(
 }
 
 async function updateRecord(
-  client: ReturnType<typeof createFeishuClient>,
+  client: Lark.Client,
   appToken: string,
   tableId: string,
   recordId: string,
@@ -532,208 +521,193 @@ const UpdateRecordSchema = Type.Object({
 // ============ Tool Registration ============
 
 export function registerFeishuBitableTools(api: RemoteClawPluginApi) {
-  const feishuCfg = api.config?.channels?.feishu as FeishuConfig | undefined;
-  if (!feishuCfg?.appId || !feishuCfg?.appSecret) {
-    api.logger.debug?.("feishu_bitable: Feishu credentials not configured, skipping bitable tools");
+  if (!api.config) {
+    api.logger.debug?.("feishu_bitable: No config available, skipping bitable tools");
     return;
   }
 
-  const getClient = () => createFeishuClient(feishuCfg);
+  const accounts = listEnabledFeishuAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.("feishu_bitable: No Feishu accounts configured, skipping bitable tools");
+    return;
+  }
 
-  // Tool 0: feishu_bitable_get_meta (helper to parse URLs)
-  api.registerTool(
-    {
-      name: "feishu_bitable_get_meta",
-      label: "Feishu Bitable Get Meta",
-      description:
-        "Parse a Bitable URL and get app_token, table_id, and table list. Use this first when given a /wiki/ or /base/ URL.",
-      parameters: GetMetaSchema,
-      async execute(_toolCallId, params) {
-        const { url } = params as { url: string };
-        try {
-          const result = await getBitableMeta(getClient(), url);
-          return json(result);
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
-    },
-    { name: "feishu_bitable_get_meta" },
-  );
+  type AccountAwareParams = { accountId?: string };
 
-  // Tool 1: feishu_bitable_list_fields
-  api.registerTool(
-    {
-      name: "feishu_bitable_list_fields",
-      label: "Feishu Bitable List Fields",
-      description: "List all fields (columns) in a Bitable table with their types and properties",
-      parameters: ListFieldsSchema,
-      async execute(_toolCallId, params) {
-        const { app_token, table_id } = params as { app_token: string; table_id: string };
-        try {
-          const result = await listFields(getClient(), app_token, table_id);
-          return json(result);
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
-    },
-    { name: "feishu_bitable_list_fields" },
-  );
+  const getClient = (params: AccountAwareParams | undefined, defaultAccountId?: string) =>
+    createFeishuToolClient({ api, executeParams: params, defaultAccountId });
 
-  // Tool 2: feishu_bitable_list_records
-  api.registerTool(
-    {
-      name: "feishu_bitable_list_records",
-      label: "Feishu Bitable List Records",
-      description: "List records (rows) from a Bitable table with pagination support",
-      parameters: ListRecordsSchema,
-      async execute(_toolCallId, params) {
-        const { app_token, table_id, page_size, page_token } = params as {
-          app_token: string;
-          table_id: string;
-          page_size?: number;
-          page_token?: string;
-        };
-        try {
-          const result = await listRecords(getClient(), app_token, table_id, page_size, page_token);
-          return json(result);
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
-    },
-    { name: "feishu_bitable_list_records" },
-  );
+  const registerBitableTool = <TParams extends AccountAwareParams>(params: {
+    name: string;
+    label: string;
+    description: string;
+    parameters: unknown;
+    execute: (args: { params: TParams; defaultAccountId?: string }) => Promise<unknown>;
+  }) => {
+    api.registerTool(
+      (ctx) => ({
+        name: params.name,
+        label: params.label,
+        description: params.description,
+        parameters: params.parameters,
+        async execute(_toolCallId, rawParams) {
+          try {
+            return json(
+              await params.execute({
+                params: rawParams as TParams,
+                defaultAccountId: ctx.agentAccountId,
+              }),
+            );
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
+          }
+        },
+      }),
+      { name: params.name },
+    );
+  };
 
-  // Tool 3: feishu_bitable_get_record
-  api.registerTool(
-    {
-      name: "feishu_bitable_get_record",
-      label: "Feishu Bitable Get Record",
-      description: "Get a single record by ID from a Bitable table",
-      parameters: GetRecordSchema,
-      async execute(_toolCallId, params) {
-        const { app_token, table_id, record_id } = params as {
-          app_token: string;
-          table_id: string;
-          record_id: string;
-        };
-        try {
-          const result = await getRecord(getClient(), app_token, table_id, record_id);
-          return json(result);
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+  registerBitableTool<{ url: string; accountId?: string }>({
+    name: "feishu_bitable_get_meta",
+    label: "Feishu Bitable Get Meta",
+    description:
+      "Parse a Bitable URL and get app_token, table_id, and table list. Use this first when given a /wiki/ or /base/ URL.",
+    parameters: GetMetaSchema,
+    async execute({ params, defaultAccountId }) {
+      return getBitableMeta(getClient(params, defaultAccountId), params.url);
     },
-    { name: "feishu_bitable_get_record" },
-  );
+  });
 
-  // Tool 4: feishu_bitable_create_record
-  api.registerTool(
-    {
-      name: "feishu_bitable_create_record",
-      label: "Feishu Bitable Create Record",
-      description: "Create a new record (row) in a Bitable table",
-      parameters: CreateRecordSchema,
-      async execute(_toolCallId, params) {
-        const { app_token, table_id, fields } = params as {
-          app_token: string;
-          table_id: string;
-          fields: Record<string, unknown>;
-        };
-        try {
-          const result = await createRecord(getClient(), app_token, table_id, fields);
-          return json(result);
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+  registerBitableTool<{ app_token: string; table_id: string; accountId?: string }>({
+    name: "feishu_bitable_list_fields",
+    label: "Feishu Bitable List Fields",
+    description: "List all fields (columns) in a Bitable table with their types and properties",
+    parameters: ListFieldsSchema,
+    async execute({ params, defaultAccountId }) {
+      return listFields(getClient(params, defaultAccountId), params.app_token, params.table_id);
     },
-    { name: "feishu_bitable_create_record" },
-  );
+  });
 
-  // Tool 5: feishu_bitable_update_record
-  api.registerTool(
-    {
-      name: "feishu_bitable_update_record",
-      label: "Feishu Bitable Update Record",
-      description: "Update an existing record (row) in a Bitable table",
-      parameters: UpdateRecordSchema,
-      async execute(_toolCallId, params) {
-        const { app_token, table_id, record_id, fields } = params as {
-          app_token: string;
-          table_id: string;
-          record_id: string;
-          fields: Record<string, unknown>;
-        };
-        try {
-          const result = await updateRecord(getClient(), app_token, table_id, record_id, fields);
-          return json(result);
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+  registerBitableTool<{
+    app_token: string;
+    table_id: string;
+    page_size?: number;
+    page_token?: string;
+    accountId?: string;
+  }>({
+    name: "feishu_bitable_list_records",
+    label: "Feishu Bitable List Records",
+    description: "List records (rows) from a Bitable table with pagination support",
+    parameters: ListRecordsSchema,
+    async execute({ params, defaultAccountId }) {
+      return listRecords(
+        getClient(params, defaultAccountId),
+        params.app_token,
+        params.table_id,
+        params.page_size,
+        params.page_token,
+      );
     },
-    { name: "feishu_bitable_update_record" },
-  );
+  });
 
-  // Tool 6: feishu_bitable_create_app
-  api.registerTool(
-    {
-      name: "feishu_bitable_create_app",
-      label: "Feishu Bitable Create App",
-      description: "Create a new Bitable (multidimensional table) application",
-      parameters: CreateAppSchema,
-      async execute(_toolCallId, params) {
-        const { name, folder_token } = params as { name: string; folder_token?: string };
-        try {
-          const result = await createApp(getClient(), name, folder_token, {
-            debug: (msg) => api.logger.debug?.(msg),
-            warn: (msg) => api.logger.warn?.(msg),
-          });
-          return json(result);
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+  registerBitableTool<{
+    app_token: string;
+    table_id: string;
+    record_id: string;
+    accountId?: string;
+  }>({
+    name: "feishu_bitable_get_record",
+    label: "Feishu Bitable Get Record",
+    description: "Get a single record by ID from a Bitable table",
+    parameters: GetRecordSchema,
+    async execute({ params, defaultAccountId }) {
+      return getRecord(
+        getClient(params, defaultAccountId),
+        params.app_token,
+        params.table_id,
+        params.record_id,
+      );
     },
-    { name: "feishu_bitable_create_app" },
-  );
+  });
 
-  // Tool 7: feishu_bitable_create_field
-  api.registerTool(
-    {
-      name: "feishu_bitable_create_field",
-      label: "Feishu Bitable Create Field",
-      description: "Create a new field (column) in a Bitable table",
-      parameters: CreateFieldSchema,
-      async execute(_toolCallId, params) {
-        const { app_token, table_id, field_name, field_type, property } = params as {
-          app_token: string;
-          table_id: string;
-          field_name: string;
-          field_type: number;
-          property?: Record<string, unknown>;
-        };
-        try {
-          const result = await createField(
-            getClient(),
-            app_token,
-            table_id,
-            field_name,
-            field_type,
-            property,
-          );
-          return json(result);
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+  registerBitableTool<{
+    app_token: string;
+    table_id: string;
+    fields: Record<string, unknown>;
+    accountId?: string;
+  }>({
+    name: "feishu_bitable_create_record",
+    label: "Feishu Bitable Create Record",
+    description: "Create a new record (row) in a Bitable table",
+    parameters: CreateRecordSchema,
+    async execute({ params, defaultAccountId }) {
+      return createRecord(
+        getClient(params, defaultAccountId),
+        params.app_token,
+        params.table_id,
+        params.fields,
+      );
     },
-    { name: "feishu_bitable_create_field" },
-  );
+  });
+
+  registerBitableTool<{
+    app_token: string;
+    table_id: string;
+    record_id: string;
+    fields: Record<string, unknown>;
+    accountId?: string;
+  }>({
+    name: "feishu_bitable_update_record",
+    label: "Feishu Bitable Update Record",
+    description: "Update an existing record (row) in a Bitable table",
+    parameters: UpdateRecordSchema,
+    async execute({ params, defaultAccountId }) {
+      return updateRecord(
+        getClient(params, defaultAccountId),
+        params.app_token,
+        params.table_id,
+        params.record_id,
+        params.fields,
+      );
+    },
+  });
+
+  registerBitableTool<{ name: string; folder_token?: string; accountId?: string }>({
+    name: "feishu_bitable_create_app",
+    label: "Feishu Bitable Create App",
+    description: "Create a new Bitable (multidimensional table) application",
+    parameters: CreateAppSchema,
+    async execute({ params, defaultAccountId }) {
+      return createApp(getClient(params, defaultAccountId), params.name, params.folder_token, {
+        debug: (msg) => api.logger.debug?.(msg),
+        warn: (msg) => api.logger.warn?.(msg),
+      });
+    },
+  });
+
+  registerBitableTool<{
+    app_token: string;
+    table_id: string;
+    field_name: string;
+    field_type: number;
+    property?: Record<string, unknown>;
+    accountId?: string;
+  }>({
+    name: "feishu_bitable_create_field",
+    label: "Feishu Bitable Create Field",
+    description: "Create a new field (column) in a Bitable table",
+    parameters: CreateFieldSchema,
+    async execute({ params, defaultAccountId }) {
+      return createField(
+        getClient(params, defaultAccountId),
+        params.app_token,
+        params.table_id,
+        params.field_name,
+        params.field_type,
+        params.property,
+      );
+    },
+  });
 
   api.logger.info?.("feishu_bitable: Registered bitable tools");
 }

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -3,10 +3,13 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 import { Type } from "@sinclair/typebox";
 import type { RemoteClawPluginApi } from "remoteclaw/plugin-sdk";
 import { listEnabledFeishuAccounts } from "./accounts.js";
-import { createFeishuClient } from "./client.js";
 import { FeishuDocSchema, type FeishuDocParams } from "./doc-schema.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { resolveToolsConfig } from "./tools-config.js";
+import {
+  createFeishuToolClient,
+  resolveAnyEnabledFeishuToolsConfig,
+  resolveFeishuToolAccount,
+} from "./tool-account.js";
 
 // ============ Helpers ============
 
@@ -454,53 +457,80 @@ export function registerFeishuDocTools(api: RemoteClawPluginApi) {
     return;
   }
 
-  // Use first account's config for tools configuration
-  const firstAccount = accounts[0];
-  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
-  const mediaMaxBytes = (firstAccount.config?.mediaMaxMb ?? 30) * 1024 * 1024;
+  // Register if enabled on any account; account routing is resolved per execution.
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
 
-  // Helper to get client for the default account
-  const getClient = () => createFeishuClient(firstAccount);
   const registered: string[] = [];
+  type FeishuDocExecuteParams = FeishuDocParams & { accountId?: string };
+
+  const getClient = (params: { accountId?: string } | undefined, defaultAccountId?: string) =>
+    createFeishuToolClient({ api, executeParams: params, defaultAccountId });
+
+  const getMediaMaxBytes = (
+    params: { accountId?: string } | undefined,
+    defaultAccountId?: string,
+  ) =>
+    (resolveFeishuToolAccount({ api, executeParams: params, defaultAccountId }).config
+      ?.mediaMaxMb ?? 30) *
+    1024 *
+    1024;
 
   // Main document tool with action-based dispatch
   if (toolsCfg.doc) {
     api.registerTool(
-      {
-        name: "feishu_doc",
-        label: "Feishu Doc",
-        description:
-          "Feishu document operations. Actions: read, write, append, create, list_blocks, get_block, update_block, delete_block",
-        parameters: FeishuDocSchema,
-        async execute(_toolCallId, params) {
-          const p = params as FeishuDocParams;
-          try {
-            const client = getClient();
-            switch (p.action) {
-              case "read":
-                return json(await readDoc(client, p.doc_token));
-              case "write":
-                return json(await writeDoc(client, p.doc_token, p.content, mediaMaxBytes));
-              case "append":
-                return json(await appendDoc(client, p.doc_token, p.content, mediaMaxBytes));
-              case "create":
-                return json(await createDoc(client, p.title, p.folder_token));
-              case "list_blocks":
-                return json(await listBlocks(client, p.doc_token));
-              case "get_block":
-                return json(await getBlock(client, p.doc_token, p.block_id));
-              case "update_block":
-                return json(await updateBlock(client, p.doc_token, p.block_id, p.content));
-              case "delete_block":
-                return json(await deleteBlock(client, p.doc_token, p.block_id));
-              default:
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
-                return json({ error: `Unknown action: ${(p as any).action}` });
+      (ctx) => {
+        const defaultAccountId = ctx.agentAccountId;
+        return {
+          name: "feishu_doc",
+          label: "Feishu Doc",
+          description:
+            "Feishu document operations. Actions: read, write, append, create, list_blocks, get_block, update_block, delete_block",
+          parameters: FeishuDocSchema,
+          async execute(_toolCallId, params) {
+            const p = params as FeishuDocExecuteParams;
+            try {
+              const client = getClient(p, defaultAccountId);
+              switch (p.action) {
+                case "read":
+                  return json(await readDoc(client, p.doc_token));
+                case "write":
+                  return json(
+                    await writeDoc(
+                      client,
+                      p.doc_token,
+                      p.content,
+                      getMediaMaxBytes(p, defaultAccountId),
+                    ),
+                  );
+                case "append":
+                  return json(
+                    await appendDoc(
+                      client,
+                      p.doc_token,
+                      p.content,
+                      getMediaMaxBytes(p, defaultAccountId),
+                    ),
+                  );
+                case "create":
+                  return json(await createDoc(client, p.title, p.folder_token));
+                case "list_blocks":
+                  return json(await listBlocks(client, p.doc_token));
+                case "get_block":
+                  return json(await getBlock(client, p.doc_token, p.block_id));
+                case "update_block":
+                  return json(await updateBlock(client, p.doc_token, p.block_id, p.content));
+                case "delete_block":
+                  return json(await deleteBlock(client, p.doc_token, p.block_id));
+                default: {
+                  const exhaustiveCheck: never = p;
+                  return json({ error: `Unknown action: ${String(exhaustiveCheck)}` });
+                }
+              }
+            } catch (err) {
+              return json({ error: err instanceof Error ? err.message : String(err) });
             }
-          } catch (err) {
-            return json({ error: err instanceof Error ? err.message : String(err) });
-          }
-        },
+          },
+        };
       },
       { name: "feishu_doc" },
     );
@@ -510,7 +540,7 @@ export function registerFeishuDocTools(api: RemoteClawPluginApi) {
   // Keep feishu_app_scopes as independent tool
   if (toolsCfg.scopes) {
     api.registerTool(
-      {
+      (ctx) => ({
         name: "feishu_app_scopes",
         label: "Feishu App Scopes",
         description:
@@ -518,13 +548,13 @@ export function registerFeishuDocTools(api: RemoteClawPluginApi) {
         parameters: Type.Object({}),
         async execute() {
           try {
-            const result = await listAppScopes(getClient());
+            const result = await listAppScopes(getClient(undefined, ctx.agentAccountId));
             return json(result);
           } catch (err) {
             return json({ error: err instanceof Error ? err.message : String(err) });
           }
         },
-      },
+      }),
       { name: "feishu_app_scopes" },
     );
     registered.push("feishu_app_scopes");

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -1,9 +1,8 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { RemoteClawPluginApi } from "remoteclaw/plugin-sdk";
 import { listEnabledFeishuAccounts } from "./accounts.js";
-import { createFeishuClient } from "./client.js";
 import { FeishuDriveSchema, type FeishuDriveParams } from "./drive-schema.js";
-import { resolveToolsConfig } from "./tools-config.js";
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 
 // ============ Helpers ============
 
@@ -180,45 +179,51 @@ export function registerFeishuDriveTools(api: RemoteClawPluginApi) {
     return;
   }
 
-  const firstAccount = accounts[0];
-  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
   if (!toolsCfg.drive) {
     api.logger.debug?.("feishu_drive: drive tool disabled in config");
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
+  type FeishuDriveExecuteParams = FeishuDriveParams & { accountId?: string };
 
   api.registerTool(
-    {
-      name: "feishu_drive",
-      label: "Feishu Drive",
-      description:
-        "Feishu cloud storage operations. Actions: list, info, create_folder, move, delete",
-      parameters: FeishuDriveSchema,
-      async execute(_toolCallId, params) {
-        const p = params as FeishuDriveParams;
-        try {
-          const client = getClient();
-          switch (p.action) {
-            case "list":
-              return json(await listFolder(client, p.folder_token));
-            case "info":
-              return json(await getFileInfo(client, p.file_token));
-            case "create_folder":
-              return json(await createFolder(client, p.name, p.folder_token));
-            case "move":
-              return json(await moveFile(client, p.file_token, p.type, p.folder_token));
-            case "delete":
-              return json(await deleteFile(client, p.file_token, p.type));
-            default:
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
-              return json({ error: `Unknown action: ${(p as any).action}` });
+    (ctx) => {
+      const defaultAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_drive",
+        label: "Feishu Drive",
+        description:
+          "Feishu cloud storage operations. Actions: list, info, create_folder, move, delete",
+        parameters: FeishuDriveSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuDriveExecuteParams;
+          try {
+            const client = createFeishuToolClient({
+              api,
+              executeParams: p,
+              defaultAccountId,
+            });
+            switch (p.action) {
+              case "list":
+                return json(await listFolder(client, p.folder_token));
+              case "info":
+                return json(await getFileInfo(client, p.file_token));
+              case "create_folder":
+                return json(await createFolder(client, p.name, p.folder_token));
+              case "move":
+                return json(await moveFile(client, p.file_token, p.type, p.folder_token));
+              case "delete":
+                return json(await deleteFile(client, p.file_token, p.type));
+              default:
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
+                return json({ error: `Unknown action: ${(p as any).action}` });
+            }
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
           }
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+        },
+      };
     },
     { name: "feishu_drive" },
   );

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -1,9 +1,8 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { RemoteClawPluginApi } from "remoteclaw/plugin-sdk";
 import { listEnabledFeishuAccounts } from "./accounts.js";
-import { createFeishuClient } from "./client.js";
 import { FeishuPermSchema, type FeishuPermParams } from "./perm-schema.js";
-import { resolveToolsConfig } from "./tools-config.js";
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 
 // ============ Helpers ============
 
@@ -129,42 +128,50 @@ export function registerFeishuPermTools(api: RemoteClawPluginApi) {
     return;
   }
 
-  const firstAccount = accounts[0];
-  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
   if (!toolsCfg.perm) {
     api.logger.debug?.("feishu_perm: perm tool disabled in config (default: false)");
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
+  type FeishuPermExecuteParams = FeishuPermParams & { accountId?: string };
 
   api.registerTool(
-    {
-      name: "feishu_perm",
-      label: "Feishu Perm",
-      description: "Feishu permission management. Actions: list, add, remove",
-      parameters: FeishuPermSchema,
-      async execute(_toolCallId, params) {
-        const p = params as FeishuPermParams;
-        try {
-          const client = getClient();
-          switch (p.action) {
-            case "list":
-              return json(await listMembers(client, p.token, p.type));
-            case "add":
-              return json(
-                await addMember(client, p.token, p.type, p.member_type, p.member_id, p.perm),
-              );
-            case "remove":
-              return json(await removeMember(client, p.token, p.type, p.member_type, p.member_id));
-            default:
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
-              return json({ error: `Unknown action: ${(p as any).action}` });
+    (ctx) => {
+      const defaultAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_perm",
+        label: "Feishu Perm",
+        description: "Feishu permission management. Actions: list, add, remove",
+        parameters: FeishuPermSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuPermExecuteParams;
+          try {
+            const client = createFeishuToolClient({
+              api,
+              executeParams: p,
+              defaultAccountId,
+            });
+            switch (p.action) {
+              case "list":
+                return json(await listMembers(client, p.token, p.type));
+              case "add":
+                return json(
+                  await addMember(client, p.token, p.type, p.member_type, p.member_id, p.perm),
+                );
+              case "remove":
+                return json(
+                  await removeMember(client, p.token, p.type, p.member_type, p.member_id),
+                );
+              default:
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
+                return json({ error: `Unknown action: ${(p as any).action}` });
+            }
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
           }
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+        },
+      };
     },
     { name: "feishu_perm" },
   );

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -1,0 +1,58 @@
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import type { RemoteClawPluginApi } from "remoteclaw/plugin-sdk";
+import { resolveFeishuAccount } from "./accounts.js";
+import { createFeishuClient } from "./client.js";
+import { resolveToolsConfig } from "./tools-config.js";
+import type { FeishuToolsConfig, ResolvedFeishuAccount } from "./types.js";
+
+type AccountAwareParams = { accountId?: string };
+
+function normalizeOptionalAccountId(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function resolveFeishuToolAccount(params: {
+  api: Pick<RemoteClawPluginApi, "config">;
+  executeParams?: AccountAwareParams;
+  defaultAccountId?: string;
+}): ResolvedFeishuAccount {
+  if (!params.api.config) {
+    throw new Error("Feishu config unavailable");
+  }
+  return resolveFeishuAccount({
+    cfg: params.api.config,
+    accountId:
+      normalizeOptionalAccountId(params.executeParams?.accountId) ??
+      normalizeOptionalAccountId(params.defaultAccountId),
+  });
+}
+
+export function createFeishuToolClient(params: {
+  api: Pick<RemoteClawPluginApi, "config">;
+  executeParams?: AccountAwareParams;
+  defaultAccountId?: string;
+}): Lark.Client {
+  return createFeishuClient(resolveFeishuToolAccount(params));
+}
+
+export function resolveAnyEnabledFeishuToolsConfig(
+  accounts: ResolvedFeishuAccount[],
+): Required<FeishuToolsConfig> {
+  const merged: Required<FeishuToolsConfig> = {
+    doc: false,
+    wiki: false,
+    drive: false,
+    perm: false,
+    scopes: false,
+  };
+  for (const account of accounts) {
+    const cfg = resolveToolsConfig(account.config.tools);
+    merged.doc = merged.doc || cfg.doc;
+    merged.wiki = merged.wiki || cfg.wiki;
+    merged.drive = merged.drive || cfg.drive;
+    merged.perm = merged.perm || cfg.perm;
+    merged.scopes = merged.scopes || cfg.scopes;
+  }
+  return merged;
+}

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -1,8 +1,7 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { RemoteClawPluginApi } from "remoteclaw/plugin-sdk";
 import { listEnabledFeishuAccounts } from "./accounts.js";
-import { createFeishuClient } from "./client.js";
-import { resolveToolsConfig } from "./tools-config.js";
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 import { FeishuWikiSchema, type FeishuWikiParams } from "./wiki-schema.js";
 
 // ============ Helpers ============
@@ -168,62 +167,68 @@ export function registerFeishuWikiTools(api: RemoteClawPluginApi) {
     return;
   }
 
-  const firstAccount = accounts[0];
-  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
   if (!toolsCfg.wiki) {
     api.logger.debug?.("feishu_wiki: wiki tool disabled in config");
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
+  type FeishuWikiExecuteParams = FeishuWikiParams & { accountId?: string };
 
   api.registerTool(
-    {
-      name: "feishu_wiki",
-      label: "Feishu Wiki",
-      description:
-        "Feishu knowledge base operations. Actions: spaces, nodes, get, create, move, rename",
-      parameters: FeishuWikiSchema,
-      async execute(_toolCallId, params) {
-        const p = params as FeishuWikiParams;
-        try {
-          const client = getClient();
-          switch (p.action) {
-            case "spaces":
-              return json(await listSpaces(client));
-            case "nodes":
-              return json(await listNodes(client, p.space_id, p.parent_node_token));
-            case "get":
-              return json(await getNode(client, p.token));
-            case "search":
-              return json({
-                error:
-                  "Search is not available. Use feishu_wiki with action: 'nodes' to browse or action: 'get' to lookup by token.",
-              });
-            case "create":
-              return json(
-                await createNode(client, p.space_id, p.title, p.obj_type, p.parent_node_token),
-              );
-            case "move":
-              return json(
-                await moveNode(
-                  client,
-                  p.space_id,
-                  p.node_token,
-                  p.target_space_id,
-                  p.target_parent_token,
-                ),
-              );
-            case "rename":
-              return json(await renameNode(client, p.space_id, p.node_token, p.title));
-            default:
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
-              return json({ error: `Unknown action: ${(p as any).action}` });
+    (ctx) => {
+      const defaultAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_wiki",
+        label: "Feishu Wiki",
+        description:
+          "Feishu knowledge base operations. Actions: spaces, nodes, get, create, move, rename",
+        parameters: FeishuWikiSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuWikiExecuteParams;
+          try {
+            const client = createFeishuToolClient({
+              api,
+              executeParams: p,
+              defaultAccountId,
+            });
+            switch (p.action) {
+              case "spaces":
+                return json(await listSpaces(client));
+              case "nodes":
+                return json(await listNodes(client, p.space_id, p.parent_node_token));
+              case "get":
+                return json(await getNode(client, p.token));
+              case "search":
+                return json({
+                  error:
+                    "Search is not available. Use feishu_wiki with action: 'nodes' to browse or action: 'get' to lookup by token.",
+                });
+              case "create":
+                return json(
+                  await createNode(client, p.space_id, p.title, p.obj_type, p.parent_node_token),
+                );
+              case "move":
+                return json(
+                  await moveNode(
+                    client,
+                    p.space_id,
+                    p.node_token,
+                    p.target_space_id,
+                    p.target_parent_token,
+                  ),
+                );
+              case "rename":
+                return json(await renameNode(client, p.space_id, p.node_token, p.title));
+              default:
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
+                return json({ error: `Unknown action: ${(p as any).action}` });
+            }
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
           }
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+        },
+      };
     },
     { name: "feishu_wiki" },
   );

--- a/extensions/irc/src/inbound.policy.test.ts
+++ b/extensions/irc/src/inbound.policy.test.ts
@@ -7,6 +7,7 @@ describe("irc inbound policy", () => {
       configAllowFrom: ["owner"],
       configGroupAllowFrom: [],
       storeAllowList: ["paired-user"],
+      dmPolicy: "pairing",
     });
 
     expect(resolved.effectiveAllowFrom).toEqual(["owner", "paired-user"]);
@@ -17,6 +18,7 @@ describe("irc inbound policy", () => {
       configAllowFrom: ["owner"],
       configGroupAllowFrom: ["group-owner"],
       storeAllowList: ["paired-user"],
+      dmPolicy: "pairing",
     });
 
     expect(resolved.effectiveGroupAllowFrom).toEqual(["group-owner"]);
@@ -27,6 +29,7 @@ describe("irc inbound policy", () => {
       configAllowFrom: ["owner"],
       configGroupAllowFrom: [],
       storeAllowList: ["paired-user"],
+      dmPolicy: "pairing",
     });
 
     expect(resolved.effectiveGroupAllowFrom).toEqual([]);

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -1,14 +1,17 @@
 import {
   GROUP_POLICY_BLOCKED_LABEL,
+  createScopedPairingAccess,
   createNormalizedOutboundDeliverer,
   createReplyPrefixOptions,
   formatTextWithAttachmentLinks,
   logInboundDrop,
   isDangerousNameMatchingEnabled,
+  readStoreAllowFromForDmPolicy,
   resolveControlCommandGate,
   resolveOutboundMediaUrls,
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
+  resolveEffectiveAllowFromLists,
   warnMissingProviderGroupPolicyFallbackOnce,
   type OutboundReplyPayload,
   type RemoteClawConfig,
@@ -35,13 +38,19 @@ function resolveIrcEffectiveAllowlists(params: {
   configAllowFrom: string[];
   configGroupAllowFrom: string[];
   storeAllowList: string[];
+  dmPolicy: string;
 }): {
   effectiveAllowFrom: string[];
   effectiveGroupAllowFrom: string[];
 } {
-  const effectiveAllowFrom = [...params.configAllowFrom, ...params.storeAllowList].filter(Boolean);
-  // Pairing-store entries are DM approvals and must not widen group sender authorization.
-  const effectiveGroupAllowFrom = [...params.configGroupAllowFrom].filter(Boolean);
+  const { effectiveAllowFrom, effectiveGroupAllowFrom } = resolveEffectiveAllowFromLists({
+    allowFrom: params.configAllowFrom,
+    groupAllowFrom: params.configGroupAllowFrom,
+    storeAllowFrom: params.storeAllowList,
+    dmPolicy: params.dmPolicy,
+    // IRC intentionally requires explicit groupAllowFrom; do not fallback to allowFrom.
+    groupAllowFromFallbackToAllowFrom: false,
+  });
   return { effectiveAllowFrom, effectiveGroupAllowFrom };
 }
 
@@ -82,6 +91,11 @@ export async function handleIrcInbound(params: {
 }): Promise<void> {
   const { message, account, config, runtime, connectedNick, statusSink } = params;
   const core = getIrcRuntime();
+  const pairing = createScopedPairingAccess({
+    core,
+    channel: CHANNEL_ID,
+    accountId: account.accountId,
+  });
 
   const rawBody = message.text?.trim() ?? "";
   if (!rawBody) {
@@ -113,12 +127,12 @@ export async function handleIrcInbound(params: {
 
   const configAllowFrom = normalizeIrcAllowlist(account.config.allowFrom);
   const configGroupAllowFrom = normalizeIrcAllowlist(account.config.groupAllowFrom);
-  const storeAllowFrom =
-    dmPolicy === "allowlist"
-      ? []
-      : await core.channel.pairing
-          .readAllowFromStore({ channel: CHANNEL_ID, accountId: account.accountId })
-          .catch(() => []);
+  const storeAllowFrom = await readStoreAllowFromForDmPolicy({
+    provider: CHANNEL_ID,
+    accountId: account.accountId,
+    dmPolicy,
+    readStore: pairing.readStoreForDmPolicy,
+  });
   const storeAllowList = normalizeIrcAllowlist(storeAllowFrom);
 
   const groupMatch = resolveIrcGroupMatch({
@@ -143,6 +157,7 @@ export async function handleIrcInbound(params: {
     configAllowFrom,
     configGroupAllowFrom,
     storeAllowList,
+    dmPolicy,
   });
 
   const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
@@ -197,9 +212,7 @@ export async function handleIrcInbound(params: {
       }).allowed;
       if (!dmAllowed) {
         if (dmPolicy === "pairing") {
-          const { code, created } = await core.channel.pairing.upsertPairingRequest({
-            channel: CHANNEL_ID,
-            accountId: account.accountId,
+          const { code, created } = await pairing.upsertPairingRequest({
             id: senderDisplay.toLowerCase(),
             meta: { name: message.senderNick || undefined },
           });

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -1,10 +1,12 @@
 import {
   GROUP_POLICY_BLOCKED_LABEL,
+  createScopedPairingAccess,
   createNormalizedOutboundDeliverer,
   createReplyPrefixOptions,
   formatTextWithAttachmentLinks,
   logInboundDrop,
-  resolveControlCommandGate,
+  readStoreAllowFromForDmPolicy,
+  resolveDmGroupAccessWithCommandGate,
   resolveOutboundMediaUrls,
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
@@ -57,6 +59,11 @@ export async function handleNextcloudTalkInbound(params: {
 }): Promise<void> {
   const { message, account, config, runtime, statusSink } = params;
   const core = getNextcloudTalkRuntime();
+  const pairing = createScopedPairingAccess({
+    core,
+    channel: CHANNEL_ID,
+    accountId: account.accountId,
+  });
 
   const rawBody = message.text?.trim() ?? "";
   if (!rawBody) {
@@ -96,12 +103,12 @@ export async function handleNextcloudTalkInbound(params: {
 
   const configAllowFrom = normalizeNextcloudTalkAllowlist(account.config.allowFrom);
   const configGroupAllowFrom = normalizeNextcloudTalkAllowlist(account.config.groupAllowFrom);
-  const storeAllowFrom =
-    dmPolicy === "allowlist"
-      ? []
-      : await core.channel.pairing
-          .readAllowFromStore({ channel: CHANNEL_ID, accountId: account.accountId })
-          .catch(() => []);
+  const storeAllowFrom = await readStoreAllowFromForDmPolicy({
+    provider: CHANNEL_ID,
+    accountId: account.accountId,
+    dmPolicy,
+    readStore: pairing.readStoreForDmPolicy,
+  });
   const storeAllowList = normalizeNextcloudTalkAllowlist(storeAllowFrom);
 
   const roomMatch = resolveNextcloudTalkRoomMatch({
@@ -120,11 +127,6 @@ export async function handleNextcloudTalkInbound(params: {
   }
 
   const roomAllowFrom = normalizeNextcloudTalkAllowlist(roomConfig?.allowFrom);
-  const baseGroupAllowFrom =
-    configGroupAllowFrom.length > 0 ? configGroupAllowFrom : configAllowFrom;
-
-  const effectiveAllowFrom = [...configAllowFrom, ...storeAllowList].filter(Boolean);
-  const effectiveGroupAllowFrom = [...baseGroupAllowFrom].filter(Boolean);
 
   const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
     cfg: config as RemoteClawConfig,
@@ -132,28 +134,36 @@ export async function handleNextcloudTalkInbound(params: {
   });
   const useAccessGroups =
     (config.commands as Record<string, unknown> | undefined)?.useAccessGroups !== false;
-  const senderAllowedForCommands = resolveNextcloudTalkAllowlistMatch({
-    allowFrom: isGroup ? effectiveGroupAllowFrom : effectiveAllowFrom,
-    senderId,
-  }).allowed;
   const hasControlCommand = core.channel.text.hasControlCommand(
     rawBody,
     config as RemoteClawConfig,
   );
-  const commandGate = resolveControlCommandGate({
-    useAccessGroups,
-    authorizers: [
-      {
-        configured: (isGroup ? effectiveGroupAllowFrom : effectiveAllowFrom).length > 0,
-        allowed: senderAllowedForCommands,
-      },
-    ],
-    allowTextCommands,
-    hasControlCommand,
+  const access = resolveDmGroupAccessWithCommandGate({
+    isGroup,
+    dmPolicy,
+    groupPolicy,
+    allowFrom: configAllowFrom,
+    groupAllowFrom: configGroupAllowFrom,
+    storeAllowFrom: storeAllowList,
+    isSenderAllowed: (allowFrom) =>
+      resolveNextcloudTalkAllowlistMatch({
+        allowFrom,
+        senderId,
+      }).allowed,
+    command: {
+      useAccessGroups,
+      allowTextCommands,
+      hasControlCommand,
+    },
   });
-  const commandAuthorized = commandGate.commandAuthorized;
+  const commandAuthorized = access.commandAuthorized;
+  const effectiveGroupAllowFrom = access.effectiveGroupAllowFrom;
 
   if (isGroup) {
+    if (access.decision !== "allow") {
+      runtime.log?.(`nextcloud-talk: drop group sender ${senderId} (reason=${access.reason})`);
+      return;
+    }
     const groupAllow = resolveNextcloudTalkGroupAllow({
       groupPolicy,
       outerAllowFrom: effectiveGroupAllowFrom,
@@ -165,49 +175,35 @@ export async function handleNextcloudTalkInbound(params: {
       return;
     }
   } else {
-    if (dmPolicy === "disabled") {
-      runtime.log?.(`nextcloud-talk: drop DM sender=${senderId} (dmPolicy=disabled)`);
-      return;
-    }
-    if (dmPolicy !== "open") {
-      const dmAllowed = resolveNextcloudTalkAllowlistMatch({
-        allowFrom: effectiveAllowFrom,
-        senderId,
-      }).allowed;
-      if (!dmAllowed) {
-        if (dmPolicy === "pairing") {
-          const { code, created } = await core.channel.pairing.upsertPairingRequest({
-            channel: CHANNEL_ID,
-            accountId: account.accountId,
-            id: senderId,
-            meta: { name: senderName || undefined },
-          });
-          if (created) {
-            try {
-              await sendMessageNextcloudTalk(
-                roomToken,
-                core.channel.pairing.buildPairingReply({
-                  channel: CHANNEL_ID,
-                  idLine: `Your Nextcloud user id: ${senderId}`,
-                  code,
-                }),
-                { accountId: account.accountId },
-              );
-              statusSink?.({ lastOutboundAt: Date.now() });
-            } catch (err) {
-              runtime.error?.(
-                `nextcloud-talk: pairing reply failed for ${senderId}: ${String(err)}`,
-              );
-            }
+    if (access.decision !== "allow") {
+      if (access.decision === "pairing") {
+        const { code, created } = await pairing.upsertPairingRequest({
+          id: senderId,
+          meta: { name: senderName || undefined },
+        });
+        if (created) {
+          try {
+            await sendMessageNextcloudTalk(
+              roomToken,
+              core.channel.pairing.buildPairingReply({
+                channel: CHANNEL_ID,
+                idLine: `Your Nextcloud user id: ${senderId}`,
+                code,
+              }),
+              { accountId: account.accountId },
+            );
+            statusSink?.({ lastOutboundAt: Date.now() });
+          } catch (err) {
+            runtime.error?.(`nextcloud-talk: pairing reply failed for ${senderId}: ${String(err)}`);
           }
         }
-        runtime.log?.(`nextcloud-talk: drop DM sender ${senderId} (dmPolicy=${dmPolicy})`);
-        return;
       }
+      runtime.log?.(`nextcloud-talk: drop DM sender ${senderId} (reason=${access.reason})`);
+      return;
     }
   }
 
-  if (isGroup && commandGate.shouldBlock) {
+  if (access.shouldBlockControlCommand) {
     logInboundDrop({
       log: (message) => runtime.log?.(message),
       channel: CHANNEL_ID,

--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -423,6 +423,23 @@ describe("subagent announce formatting", () => {
     expect(sessionsDeleteSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("suppresses completion delivery when subagent reply is NO_REPLY", async () => {
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-direct-completion-no-reply",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: { channel: "slack", to: "channel:C123", accountId: "acct-1" },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      roundOneReply: " NO_REPLY ",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(agentSpy).not.toHaveBeenCalled();
+  });
+
   it("retries completion direct send on transient channel-unavailable errors", async () => {
     sendSpy
       .mockRejectedValueOnce(new Error("Error: No active WhatsApp Web listener (account: default)"))

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,5 +1,5 @@
 import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
 import {
@@ -966,6 +966,8 @@ export function buildSubagentSystemPrompt(params: {
   childSessionKey: string;
   label?: string;
   task?: string;
+  /** Whether ACP-specific routing guidance should be included. Defaults to true. */
+  acpEnabled?: boolean;
   /** Depth of the child being spawned (1 = sub-agent, 2 = sub-sub-agent). */
   childDepth?: number;
   /** Config value: max allowed spawn depth. */
@@ -980,6 +982,7 @@ export function buildSubagentSystemPrompt(params: {
     typeof params.maxSpawnDepth === "number"
       ? params.maxSpawnDepth
       : DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH;
+  const acpEnabled = params.acpEnabled !== false;
   const canSpawn = childDepth < maxSpawnDepth;
   const parentLabel = childDepth >= 2 ? "parent orchestrator" : "main agent";
 
@@ -1025,6 +1028,17 @@ export function buildSubagentSystemPrompt(params: {
       "Default workflow: spawn work, continue orchestrating, and wait for auto-announced completions.",
       "Do NOT repeatedly poll `subagents list` in a loop unless you are actively debugging or intervening.",
       "Coordinate their work and synthesize results before reporting back.",
+      ...(acpEnabled
+        ? [
+            'For ACP harness sessions (codex/claudecode/gemini), use `sessions_spawn` with `runtime: "acp"` (set `agentId` unless `acp.defaultAgent` is configured).',
+            '`agents_list` and `subagents` apply to RemoteClaw sub-agents (`runtime: "subagent"`); ACP harness ids are controlled by `acp.allowedAgents`.',
+            "Do not ask users to run slash commands or CLI when `sessions_spawn` can do it directly.",
+            "Do not use `exec` (`remoteclaw ...`, `acpx ...`) to spawn ACP sessions.",
+            'Use `subagents` only for RemoteClaw subagents (`runtime: "subagent"`).',
+            "Subagent results auto-announce back to you; ACP sessions continue in their bound thread.",
+            "Avoid polling loops; spawn, orchestrate, and synthesize results.",
+          ]
+        : []),
       "",
     );
   } else if (childDepth >= 2) {
@@ -1167,6 +1181,9 @@ export async function runSubagentAnnounceFlow(params: {
     // Embedded engine removed (#74); no active runs to check.
 
     if (isAnnounceSkip(reply)) {
+      return true;
+    }
+    if (isSilentReplyText(reply, SILENT_REPLY_TOKEN)) {
       return true;
     }
 

--- a/src/commands/agent.delivery.test.ts
+++ b/src/commands/agent.delivery.test.ts
@@ -60,6 +60,7 @@ describe("deliverAgentCommandResult", () => {
 
   async function runDelivery(params: {
     opts: Record<string, unknown>;
+    outboundSession?: { key?: string; agentId?: string };
     sessionEntry?: SessionEntry;
     runtime?: RuntimeEnv;
     resultText?: string;
@@ -74,6 +75,7 @@ describe("deliverAgentCommandResult", () => {
       deps,
       runtime,
       opts: params.opts as never,
+      outboundSession: params.outboundSession,
       sessionEntry: params.sessionEntry,
       result,
       payloads: result.payloads,
@@ -243,6 +245,30 @@ describe("deliverAgentCommandResult", () => {
 
     expect(mocks.resolveOutboundTarget).toHaveBeenCalledWith(
       expect.objectContaining({ channel: "whatsapp", to: undefined }),
+    );
+  });
+
+  it("uses caller-provided outbound session context when opts.sessionKey is absent", async () => {
+    await runDelivery({
+      opts: {
+        message: "hello",
+        deliver: true,
+        channel: "whatsapp",
+        to: "+15551234567",
+      },
+      outboundSession: {
+        key: "agent:exec:hook:gmail:thread-1",
+        agentId: "exec",
+      },
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({
+          key: "agent:exec:hook:gmail:thread-1",
+          agentId: "exec",
+        }),
+      }),
     );
   });
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -363,6 +363,7 @@ export async function agentCommand(
       deps,
       runtime,
       opts,
+      outboundSession: undefined,
       sessionEntry,
       result,
       payloads,

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -16,6 +16,7 @@ import {
   normalizeOutboundPayloads,
   normalizeOutboundPayloadsForJson,
 } from "../../infra/outbound/payloads.js";
+import type { OutboundSessionContext } from "../../infra/outbound/session-context.js";
 import type { AgentDeliveryResult } from "../../middleware/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
@@ -23,9 +24,9 @@ import type { AgentCommandOpts } from "./types.js";
 
 const NESTED_LOG_PREFIX = "[agent:nested]";
 
-function formatNestedLogPrefix(opts: AgentCommandOpts): string {
+function formatNestedLogPrefix(opts: AgentCommandOpts, sessionKey?: string): string {
   const parts = [NESTED_LOG_PREFIX];
-  const session = opts.sessionKey ?? opts.sessionId;
+  const session = sessionKey ?? opts.sessionKey ?? opts.sessionId;
   if (session) {
     parts.push(`session=${session}`);
   }
@@ -45,8 +46,13 @@ function formatNestedLogPrefix(opts: AgentCommandOpts): string {
   return parts.join(" ");
 }
 
-function logNestedOutput(runtime: RuntimeEnv, opts: AgentCommandOpts, output: string) {
-  const prefix = formatNestedLogPrefix(opts);
+function logNestedOutput(
+  runtime: RuntimeEnv,
+  opts: AgentCommandOpts,
+  output: string,
+  sessionKey?: string,
+) {
+  const prefix = formatNestedLogPrefix(opts, sessionKey);
   for (const line of output.split(/\r?\n/)) {
     if (!line) {
       continue;
@@ -60,11 +66,13 @@ export async function deliverAgentCommandResult(params: {
   deps: CliDeps;
   runtime: RuntimeEnv;
   opts: AgentCommandOpts;
+  outboundSession: OutboundSessionContext | undefined;
   sessionEntry: SessionEntry | undefined;
   result: AgentDeliveryResult;
   payloads: AgentDeliveryResult["payloads"];
 }) {
-  const { cfg, deps, runtime, opts, sessionEntry, payloads, result } = params;
+  const { cfg, deps, runtime, opts, outboundSession, sessionEntry, payloads, result } = params;
+  const effectiveSessionKey = outboundSession?.key ?? opts.sessionKey;
   // Derive a meta object for backward-compatible JSON envelope output.
   const resultMeta = {
     durationMs: result.run.durationMs,
@@ -205,7 +213,7 @@ export async function deliverAgentCommandResult(params: {
       return;
     }
     if (opts.lane === AGENT_LANE_NESTED) {
-      logNestedOutput(runtime, opts, output);
+      logNestedOutput(runtime, opts, output, effectiveSessionKey);
       return;
     }
     runtime.log(output);
@@ -223,6 +231,7 @@ export async function deliverAgentCommandResult(params: {
         to: deliveryTarget,
         accountId: resolvedAccountId,
         payloads: deliveryPayloads,
+        session: outboundSession,
         replyToId: resolvedReplyToId ?? null,
         threadId: resolvedThreadTarget ?? null,
         bestEffort: bestEffortDeliver,

--- a/src/commands/onboard-channels.test.ts
+++ b/src/commands/onboard-channels.test.ts
@@ -3,7 +3,10 @@ import type { RemoteClawConfig } from "../config/config.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
-import { setDefaultChannelPluginRegistryForTests } from "./channel-test-helpers.js";
+import {
+  patchChannelOnboardingAdapter,
+  setDefaultChannelPluginRegistryForTests,
+} from "./channel-test-helpers.js";
 import { setupChannels } from "./onboard-channels.js";
 import { createExitThrowingRuntime, createWizardPrompter } from "./test-wizard-helpers.js";
 
@@ -265,5 +268,325 @@ describe("setupChannels", () => {
 
     expect(select).toHaveBeenCalledWith(expect.objectContaining({ message: "Select a channel" }));
     expect(multiselect).not.toHaveBeenCalled();
+  });
+
+  it("uses configureInteractive skip without mutating selection/account state", async () => {
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select channel (QuickStart)") {
+        return "telegram";
+      }
+      return "__done__";
+    });
+    const selection = vi.fn();
+    const onAccountId = vi.fn();
+    const configureInteractive = vi.fn(async () => "skip" as const);
+    const restore = patchChannelOnboardingAdapter("telegram", {
+      getStatus: vi.fn(async ({ cfg }) => ({
+        channel: "telegram",
+        configured: Boolean(cfg.channels?.telegram?.botToken),
+        statusLines: [],
+      })),
+      configureInteractive,
+    });
+    const { multiselect, text } = createUnexpectedPromptGuards();
+
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      multiselect,
+      text,
+    });
+
+    const runtime = createExitThrowingRuntime();
+    try {
+      const cfg = await setupChannels(
+        {
+          agents: { list: [{ id: "main", workspace: "/tmp/test-workspace" }] },
+        } as RemoteClawConfig,
+        runtime,
+        prompter,
+        {
+          skipConfirm: true,
+          quickstartDefaults: true,
+          onSelection: selection,
+          onAccountId,
+        },
+      );
+
+      expect(configureInteractive).toHaveBeenCalledWith(
+        expect.objectContaining({ configured: false, label: expect.any(String) }),
+      );
+      expect(selection).toHaveBeenCalledWith([]);
+      expect(onAccountId).not.toHaveBeenCalled();
+      expect(cfg.channels?.telegram?.botToken).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it("applies configureInteractive result cfg/account updates", async () => {
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select channel (QuickStart)") {
+        return "telegram";
+      }
+      return "__done__";
+    });
+    const selection = vi.fn();
+    const onAccountId = vi.fn();
+    const configureInteractive = vi.fn(async ({ cfg }: { cfg: RemoteClawConfig }) => ({
+      cfg: {
+        ...cfg,
+        channels: {
+          ...cfg.channels,
+          telegram: { ...cfg.channels?.telegram, botToken: "new-token" },
+        },
+      } as RemoteClawConfig,
+      accountId: "acct-1",
+    }));
+    const configure = vi.fn(async () => {
+      throw new Error("configure should not be called when configureInteractive is present");
+    });
+    const restore = patchChannelOnboardingAdapter("telegram", {
+      getStatus: vi.fn(async ({ cfg }) => ({
+        channel: "telegram",
+        configured: Boolean(cfg.channels?.telegram?.botToken),
+        statusLines: [],
+      })),
+      configureInteractive,
+      configure,
+    });
+    const { multiselect, text } = createUnexpectedPromptGuards();
+
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      multiselect,
+      text,
+    });
+
+    const runtime = createExitThrowingRuntime();
+    try {
+      const cfg = await setupChannels(
+        {
+          agents: { list: [{ id: "main", workspace: "/tmp/test-workspace" }] },
+        } as RemoteClawConfig,
+        runtime,
+        prompter,
+        {
+          skipConfirm: true,
+          quickstartDefaults: true,
+          onSelection: selection,
+          onAccountId,
+        },
+      );
+
+      expect(configureInteractive).toHaveBeenCalledTimes(1);
+      expect(configure).not.toHaveBeenCalled();
+      expect(selection).toHaveBeenCalledWith(["telegram"]);
+      expect(onAccountId).toHaveBeenCalledWith("telegram", "acct-1");
+      expect(cfg.channels?.telegram?.botToken).toBe("new-token");
+    } finally {
+      restore();
+    }
+  });
+
+  it("uses configureWhenConfigured when channel is already configured", async () => {
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select channel (QuickStart)") {
+        return "telegram";
+      }
+      return "__done__";
+    });
+    const selection = vi.fn();
+    const onAccountId = vi.fn();
+    const configureWhenConfigured = vi.fn(async ({ cfg }: { cfg: RemoteClawConfig }) => ({
+      cfg: {
+        ...cfg,
+        channels: {
+          ...cfg.channels,
+          telegram: { ...cfg.channels?.telegram, botToken: "updated-token" },
+        },
+      } as RemoteClawConfig,
+      accountId: "acct-2",
+    }));
+    const configure = vi.fn(async () => {
+      throw new Error(
+        "configure should not be called when configureWhenConfigured handles updates",
+      );
+    });
+    const restore = patchChannelOnboardingAdapter("telegram", {
+      getStatus: vi.fn(async ({ cfg }) => ({
+        channel: "telegram",
+        configured: Boolean(cfg.channels?.telegram?.botToken),
+        statusLines: [],
+      })),
+      configureInteractive: undefined,
+      configureWhenConfigured,
+      configure,
+    });
+    const { multiselect, text } = createUnexpectedPromptGuards();
+
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      multiselect,
+      text,
+    });
+
+    const runtime = createExitThrowingRuntime();
+    try {
+      const cfg = await setupChannels(
+        {
+          agents: { list: [{ id: "main", workspace: "/tmp/test-workspace" }] },
+          channels: {
+            telegram: {
+              botToken: "old-token",
+            },
+          },
+        } as RemoteClawConfig,
+        runtime,
+        prompter,
+        {
+          skipConfirm: true,
+          quickstartDefaults: true,
+          onSelection: selection,
+          onAccountId,
+        },
+      );
+
+      expect(configureWhenConfigured).toHaveBeenCalledTimes(1);
+      expect(configureWhenConfigured).toHaveBeenCalledWith(
+        expect.objectContaining({ configured: true, label: expect.any(String) }),
+      );
+      expect(configure).not.toHaveBeenCalled();
+      expect(selection).toHaveBeenCalledWith(["telegram"]);
+      expect(onAccountId).toHaveBeenCalledWith("telegram", "acct-2");
+      expect(cfg.channels?.telegram?.botToken).toBe("updated-token");
+    } finally {
+      restore();
+    }
+  });
+
+  it("respects configureWhenConfigured skip without mutating selection or account state", async () => {
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select channel (QuickStart)") {
+        return "telegram";
+      }
+      throw new Error(`unexpected select prompt: ${message}`);
+    });
+    const selection = vi.fn();
+    const onAccountId = vi.fn();
+    const configureWhenConfigured = vi.fn(async () => "skip" as const);
+    const configure = vi.fn(async () => {
+      throw new Error("configure should not run when configureWhenConfigured handles skip");
+    });
+    const restore = patchChannelOnboardingAdapter("telegram", {
+      getStatus: vi.fn(async ({ cfg }) => ({
+        channel: "telegram",
+        configured: Boolean(cfg.channels?.telegram?.botToken),
+        statusLines: [],
+      })),
+      configureInteractive: undefined,
+      configureWhenConfigured,
+      configure,
+    });
+    const { multiselect, text } = createUnexpectedPromptGuards();
+
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      multiselect,
+      text,
+    });
+
+    const runtime = createExitThrowingRuntime();
+    try {
+      const cfg = await setupChannels(
+        {
+          agents: { list: [{ id: "main", workspace: "/tmp/test-workspace" }] },
+          channels: {
+            telegram: {
+              botToken: "old-token",
+            },
+          },
+        } as RemoteClawConfig,
+        runtime,
+        prompter,
+        {
+          skipConfirm: true,
+          quickstartDefaults: true,
+          onSelection: selection,
+          onAccountId,
+        },
+      );
+
+      expect(configureWhenConfigured).toHaveBeenCalledWith(
+        expect.objectContaining({ configured: true, label: expect.any(String) }),
+      );
+      expect(configure).not.toHaveBeenCalled();
+      expect(selection).toHaveBeenCalledWith([]);
+      expect(onAccountId).not.toHaveBeenCalled();
+      expect(cfg.channels?.telegram?.botToken).toBe("old-token");
+    } finally {
+      restore();
+    }
+  });
+
+  it("prefers configureInteractive over configureWhenConfigured when both hooks exist", async () => {
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select channel (QuickStart)") {
+        return "telegram";
+      }
+      throw new Error(`unexpected select prompt: ${message}`);
+    });
+    const selection = vi.fn();
+    const onAccountId = vi.fn();
+    const configureInteractive = vi.fn(async () => "skip" as const);
+    const configureWhenConfigured = vi.fn(async () => {
+      throw new Error("configureWhenConfigured should not run when configureInteractive exists");
+    });
+    const restore = patchChannelOnboardingAdapter("telegram", {
+      getStatus: vi.fn(async ({ cfg }) => ({
+        channel: "telegram",
+        configured: Boolean(cfg.channels?.telegram?.botToken),
+        statusLines: [],
+      })),
+      configureInteractive,
+      configureWhenConfigured,
+    });
+    const { multiselect, text } = createUnexpectedPromptGuards();
+
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      multiselect,
+      text,
+    });
+
+    const runtime = createExitThrowingRuntime();
+    try {
+      await setupChannels(
+        {
+          agents: { list: [{ id: "main", workspace: "/tmp/test-workspace" }] },
+          channels: {
+            telegram: {
+              botToken: "old-token",
+            },
+          },
+        } as RemoteClawConfig,
+        runtime,
+        prompter,
+        {
+          skipConfirm: true,
+          quickstartDefaults: true,
+          onSelection: selection,
+          onAccountId,
+        },
+      );
+
+      expect(configureInteractive).toHaveBeenCalledWith(
+        expect.objectContaining({ configured: true, label: expect.any(String) }),
+      );
+      expect(configureWhenConfigured).not.toHaveBeenCalled();
+      expect(selection).toHaveBeenCalledWith([]);
+      expect(onAccountId).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
   });
 });

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -87,6 +87,7 @@ export type TailscaleMode = "off" | "serve" | "funnel";
 export type ChannelChoice = ChannelId;
 // Legacy alias (pre-rename).
 export type ProviderChoice = ChannelChoice;
+export type SecretInputMode = "plaintext" | "ref";
 
 export type AgentRuntime = "claude" | "gemini" | "codex" | "opencode";
 
@@ -99,6 +100,7 @@ export type OnboardOptions = {
   /** Required for non-interactive onboarding; skips the interactive risk prompt when true. */
   acceptRisk?: boolean;
   reset?: boolean;
+  resetScope?: ResetScope;
   runtime?: AgentRuntime;
   anthropicApiKey?: string;
   openaiApiKey?: string;
@@ -106,6 +108,8 @@ export type OnboardOptions = {
   codexApiKey?: string;
   /** Auth token (e.g., CLAUDE_CODE_OAUTH_TOKEN for Claude). */
   authToken?: string;
+  /** API key persistence mode for onboarding flows (default: plaintext). */
+  secretInputMode?: SecretInputMode;
   // Provider API key fields (consumed by legacy auth-choice system via ONBOARD_PROVIDER_AUTH_FLAGS).
   mistralApiKey?: string;
   openrouterApiKey?: string;

--- a/src/config/includes.test.ts
+++ b/src/config/includes.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   CircularIncludeError,
   ConfigIncludeError,
+  MAX_INCLUDE_FILE_BYTES,
   deepMerge,
   type IncludeResolver,
   resolveConfigIncludes,
@@ -629,13 +630,66 @@ describe("security: path traversal protection (CWE-22)", () => {
           "{ logging: { redactSensitive: 'tools' } }\n",
           "utf-8",
         );
-        await fs.symlink(realRoot, linkRoot);
+        await fs.symlink(realRoot, linkRoot, process.platform === "win32" ? "junction" : undefined);
 
         const result = resolveConfigIncludes(
           { $include: "./includes/extra.json5" },
           path.join(linkRoot, "remoteclaw.json"),
         );
         expect(result).toEqual({ logging: { redactSensitive: "tools" } });
+      } finally {
+        await fs.rm(tempRoot, { recursive: true, force: true });
+      }
+    });
+
+    it("rejects include files that are hardlinked aliases", async () => {
+      if (process.platform === "win32") {
+        return;
+      }
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-includes-hardlink-"));
+      try {
+        const configDir = path.join(tempRoot, "config");
+        const outsideDir = path.join(tempRoot, "outside");
+        await fs.mkdir(configDir, { recursive: true });
+        await fs.mkdir(outsideDir, { recursive: true });
+        const includePath = path.join(configDir, "extra.json5");
+        const outsidePath = path.join(outsideDir, "secret.json5");
+        await fs.writeFile(outsidePath, '{"logging":{"redactSensitive":"tools"}}\n', "utf-8");
+        try {
+          await fs.link(outsidePath, includePath);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+            return;
+          }
+          throw err;
+        }
+
+        expect(() =>
+          resolveConfigIncludes(
+            { $include: "./extra.json5" },
+            path.join(configDir, "remoteclaw.json"),
+          ),
+        ).toThrow(/security checks|hardlink/i);
+      } finally {
+        await fs.rm(tempRoot, { recursive: true, force: true });
+      }
+    });
+
+    it("rejects oversized include files", async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-includes-big-"));
+      try {
+        const configDir = path.join(tempRoot, "config");
+        await fs.mkdir(configDir, { recursive: true });
+        const includePath = path.join(configDir, "big.json5");
+        const payload = "a".repeat(MAX_INCLUDE_FILE_BYTES + 1);
+        await fs.writeFile(includePath, `{"blob":"${payload}"}`, "utf-8");
+
+        expect(() =>
+          resolveConfigIncludes(
+            { $include: "./big.json5" },
+            path.join(configDir, "remoteclaw.json"),
+          ),
+        ).toThrow(/security checks|max/i);
       } finally {
         await fs.rm(tempRoot, { recursive: true, force: true });
       }

--- a/src/config/includes.ts
+++ b/src/config/includes.ts
@@ -13,12 +13,14 @@
 import fs from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
+import { canUseBoundaryFileOpen, openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { isPathInside } from "../security/scan-paths.js";
 import { isPlainObject } from "../utils.js";
 import { isBlockedObjectKey } from "./prototype-keys.js";
 
 export const INCLUDE_KEY = "$include";
 export const MAX_INCLUDE_DEPTH = 10;
+export const MAX_INCLUDE_FILE_BYTES = 2 * 1024 * 1024;
 
 // ============================================================================
 // Types
@@ -26,7 +28,16 @@ export const MAX_INCLUDE_DEPTH = 10;
 
 export type IncludeResolver = {
   readFile: (path: string) => string;
+  readFileWithGuards?: (params: IncludeFileReadParams) => string;
   parseJson: (raw: string) => unknown;
+};
+
+export type IncludeFileReadParams = {
+  includePath: string;
+  resolvedPath: string;
+  rootRealDir: string;
+  ioFs?: typeof fs;
+  maxBytes?: number;
 };
 
 // ============================================================================
@@ -227,8 +238,18 @@ class IncludeProcessor {
 
   private readFile(includePath: string, resolvedPath: string): string {
     try {
+      if (this.resolver.readFileWithGuards) {
+        return this.resolver.readFileWithGuards({
+          includePath,
+          resolvedPath,
+          rootRealDir: this.rootRealDir,
+        });
+      }
       return this.resolver.readFile(resolvedPath);
     } catch (err) {
+      if (err instanceof ConfigIncludeError) {
+        throw err;
+      }
       throw new ConfigIncludeError(
         `Failed to read include file: ${includePath} (resolved: ${resolvedPath})`,
         includePath,
@@ -265,12 +286,51 @@ function safeRealpath(target: string): string {
   }
 }
 
+export function readConfigIncludeFileWithGuards(params: IncludeFileReadParams): string {
+  const ioFs = params.ioFs ?? fs;
+  const maxBytes = params.maxBytes ?? MAX_INCLUDE_FILE_BYTES;
+  if (!canUseBoundaryFileOpen(ioFs)) {
+    return ioFs.readFileSync(params.resolvedPath, "utf-8");
+  }
+
+  const opened = openBoundaryFileSync({
+    absolutePath: params.resolvedPath,
+    rootPath: params.rootRealDir,
+    rootRealPath: params.rootRealDir,
+    boundaryLabel: "config directory",
+    skipLexicalRootCheck: true,
+    maxBytes,
+    ioFs,
+  });
+  if (!opened.ok) {
+    if (opened.reason === "validation") {
+      throw new ConfigIncludeError(
+        `Include file failed security checks (regular file, max ${maxBytes} bytes, no hardlinks): ${params.includePath}`,
+        params.includePath,
+      );
+    }
+    throw new ConfigIncludeError(
+      `Failed to read include file: ${params.includePath} (resolved: ${params.resolvedPath})`,
+      params.includePath,
+      opened.error instanceof Error ? opened.error : undefined,
+    );
+  }
+
+  try {
+    return ioFs.readFileSync(opened.fd, "utf-8");
+  } finally {
+    ioFs.closeSync(opened.fd);
+  }
+}
+
 // ============================================================================
 // Public API
 // ============================================================================
 
 const defaultResolver: IncludeResolver = {
   readFile: (p) => fs.readFileSync(p, "utf-8"),
+  readFileWithGuards: ({ includePath, resolvedPath, rootRealDir }) =>
+    readConfigIncludeFileWithGuards({ includePath, resolvedPath, rootRealDir }),
   parseJson: (raw) => JSON5.parse(raw),
 };
 

--- a/src/config/schema.hints.test.ts
+++ b/src/config/schema.hints.test.ts
@@ -131,6 +131,7 @@ describe("mapSensitivePaths", () => {
     const hints = mapSensitivePaths(RemoteClawSchema, "", {});
 
     expect(hints["channels.discord.accounts.*.token"]?.sensitive).toBe(true);
+    expect(hints["channels.googlechat.serviceAccount"]?.sensitive).toBe(true);
     expect(hints["gateway.auth.token"]?.sensitive).toBe(true);
     // skills.entries.*.apiKey removed: skills section was gutted from schema.
   });

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -522,7 +522,10 @@ export const GoogleChatAccountSchema = z
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groups: z.record(z.string(), GoogleChatGroupSchema.optional()).optional(),
     defaultTo: z.string().optional(),
-    serviceAccount: z.union([z.string(), z.record(z.string(), z.unknown())]).optional(),
+    serviceAccount: z
+      .union([z.string(), z.record(z.string(), z.unknown())])
+      .optional()
+      .register(sensitive),
     serviceAccountFile: z.string().optional(),
     audienceType: z.enum(["app-url", "project-number"]).optional(),
     audience: z.string().optional(),

--- a/src/gateway/server.roles-allowlist-update.test.ts
+++ b/src/gateway/server.roles-allowlist-update.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
+import type { DeviceIdentity } from "../infra/device-identity.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import type { GatewayClient } from "./client.js";
 
@@ -35,6 +36,9 @@ installConnectedControlUiServerSuite((started) => {
 const connectNodeClient = async (params: {
   port: number;
   commands: string[];
+  platform?: string;
+  deviceFamily?: string;
+  deviceIdentity?: DeviceIdentity;
   instanceId?: string;
   displayName?: string;
   onEvent?: (evt: { event?: string; payload?: unknown }) => void;
@@ -50,11 +54,13 @@ const connectNodeClient = async (params: {
     clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
     clientVersion: "1.0.0",
     clientDisplayName: params.displayName,
-    platform: "ios",
+    platform: params.platform ?? "ios",
+    deviceFamily: params.deviceFamily,
     mode: GATEWAY_CLIENT_MODES.NODE,
     instanceId: params.instanceId,
     scopes: [],
     commands: params.commands,
+    deviceIdentity: params.deviceIdentity,
     onEvent: params.onEvent,
     timeoutMessage: "timeout waiting for node to connect",
   });
@@ -308,6 +314,53 @@ describe("gateway node command allowlist", () => {
       systemClient?.stop();
       emptyClient?.stop();
       allowedClient?.stop();
+    }
+  });
+
+  test("rejects reconnect metadata spoof for paired node devices", async () => {
+    const { loadOrCreateDeviceIdentity } = await import("../infra/device-identity.js");
+    const deviceIdentityPath = path.join(
+      os.tmpdir(),
+      `remoteclaw-spoof-test-device-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+    );
+    const deviceIdentity = loadOrCreateDeviceIdentity(deviceIdentityPath);
+
+    let iosClient: GatewayClient | undefined;
+    try {
+      iosClient = await connectNodeClientWithPairing({
+        port,
+        commands: ["canvas.snapshot"],
+        platform: "ios",
+        deviceFamily: "iPhone",
+        instanceId: "node-platform-pin",
+        displayName: "node-platform-pin",
+        deviceIdentity,
+      });
+      iosClient.stop();
+      await expect
+        .poll(async () => {
+          const listRes = await rpcReq<{ nodes?: Array<{ connected?: boolean }> }>(
+            ws,
+            "node.list",
+            {},
+          );
+          return (listRes.payload?.nodes ?? []).filter((node) => node.connected).length;
+        }, FAST_WAIT_OPTS)
+        .toBe(0);
+
+      await expect(
+        connectNodeClient({
+          port,
+          commands: ["system.run"],
+          platform: "linux",
+          deviceFamily: "linux",
+          instanceId: "node-platform-pin",
+          displayName: "node-platform-pin",
+          deviceIdentity,
+        }),
+      ).rejects.toThrow(/pairing required/i);
+    } finally {
+      iosClient?.stop();
     }
   });
 });

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -281,5 +281,71 @@ describe("loader", () => {
       expect(count).toBe(0);
       expect(getRegisteredEventKeys()).not.toContain("command:new");
     });
+
+    it("rejects directory hook handlers that escape hook dir via hardlink", async () => {
+      if (process.platform === "win32") {
+        return;
+      }
+      const outsideHandlerPath = path.join(fixtureRoot, `outside-handler-hardlink-${caseId}.js`);
+      await fs.writeFile(outsideHandlerPath, "export default async function() {}", "utf-8");
+
+      const hookDir = path.join(tmpDir, "hooks", "hardlink-hook");
+      await fs.mkdir(hookDir, { recursive: true });
+      await fs.writeFile(
+        path.join(hookDir, "HOOK.md"),
+        [
+          "---",
+          "name: hardlink-hook",
+          "description: hardlink test",
+          'metadata: {"remoteclaw":{"events":["command:new"]}}',
+          "---",
+          "",
+          "# Hardlink Hook",
+        ].join("\n"),
+        "utf-8",
+      );
+      try {
+        await fs.link(outsideHandlerPath, path.join(hookDir, "handler.js"));
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+          return;
+        }
+        throw err;
+      }
+
+      const cfg = createEnabledHooksConfig();
+      const count = await loadInternalHooks(cfg, tmpDir);
+      expect(count).toBe(0);
+      expect(getRegisteredEventKeys()).not.toContain("command:new");
+    });
+
+    it("rejects legacy handler modules that escape workspace via hardlink", async () => {
+      if (process.platform === "win32") {
+        return;
+      }
+      const outsideHandlerPath = path.join(fixtureRoot, `outside-legacy-hardlink-${caseId}.js`);
+      await fs.writeFile(outsideHandlerPath, "export default async function() {}", "utf-8");
+
+      const linkedHandlerPath = path.join(tmpDir, "legacy-handler.js");
+      try {
+        await fs.link(outsideHandlerPath, linkedHandlerPath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+          return;
+        }
+        throw err;
+      }
+
+      const cfg = createEnabledHooksConfig([
+        {
+          event: "command:new",
+          module: "legacy-handler.js",
+        },
+      ]);
+
+      const count = await loadInternalHooks(cfg, tmpDir);
+      expect(count).toBe(0);
+      expect(getRegisteredEventKeys()).not.toContain("command:new");
+    });
   });
 });

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -5,10 +5,11 @@
  * and from directory-based discovery (bundled, managed, workspace)
  */
 
+import fs from "node:fs";
 import path from "node:path";
 import type { RemoteClawConfig } from "../config/config.js";
+import { openBoundaryFile } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { isPathInsideWithRealpath } from "../security/scan-paths.js";
 import { resolveHookConfig } from "./config.js";
 import { shouldIncludeHook } from "./config.js";
 import { buildImportUrl } from "./import-url.js";
@@ -73,18 +74,23 @@ export async function loadInternalHooks(
       }
 
       try {
-        if (
-          !isPathInsideWithRealpath(entry.hook.baseDir, entry.hook.handlerPath, {
-            requireRealpath: true,
-          })
-        ) {
+        const hookBaseDir = safeRealpathOrResolve(entry.hook.baseDir);
+        const opened = await openBoundaryFile({
+          absolutePath: entry.hook.handlerPath,
+          rootPath: hookBaseDir,
+          boundaryLabel: "hook directory",
+        });
+        if (!opened.ok) {
           log.error(
-            `Hook '${entry.hook.name}' handler path resolves outside hook directory: ${entry.hook.handlerPath}`,
+            `Hook '${entry.hook.name}' handler path fails boundary checks: ${entry.hook.handlerPath}`,
           );
           continue;
         }
+        const safeHandlerPath = opened.path;
+        fs.closeSync(opened.fd);
+
         // Import handler module — only cache-bust mutable (workspace/managed) hooks
-        const importUrl = buildImportUrl(entry.hook.handlerPath, entry.hook.source);
+        const importUrl = buildImportUrl(safeHandlerPath, entry.hook.source);
         const mod = (await import(importUrl)) as Record<string, unknown>;
 
         // Get handler function (default or named export)
@@ -144,24 +150,27 @@ export async function loadInternalHooks(
       }
       const baseDir = path.resolve(workspaceDir);
       const modulePath = path.resolve(baseDir, rawModule);
+      const baseDirReal = safeRealpathOrResolve(baseDir);
+      const modulePathSafe = safeRealpathOrResolve(modulePath);
       const rel = path.relative(baseDir, modulePath);
       if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {
         log.error(`Handler module path must stay within workspaceDir: ${rawModule}`);
         continue;
       }
-      if (
-        !isPathInsideWithRealpath(baseDir, modulePath, {
-          requireRealpath: true,
-        })
-      ) {
-        log.error(
-          `Handler module path resolves outside workspaceDir after symlink resolution: ${rawModule}`,
-        );
+      const opened = await openBoundaryFile({
+        absolutePath: modulePathSafe,
+        rootPath: baseDirReal,
+        boundaryLabel: "workspace directory",
+      });
+      if (!opened.ok) {
+        log.error(`Handler module path fails boundary checks under workspaceDir: ${rawModule}`);
         continue;
       }
+      const safeModulePath = opened.path;
+      fs.closeSync(opened.fd);
 
       // Legacy handlers are always workspace-relative, so use mtime-based cache busting
-      const importUrl = buildImportUrl(modulePath, "remoteclaw-workspace");
+      const importUrl = buildImportUrl(safeModulePath, "remoteclaw-workspace");
       const mod = (await import(importUrl)) as Record<string, unknown>;
 
       // Get the handler function
@@ -189,4 +198,12 @@ export async function loadInternalHooks(
   }
 
   return loadedCount;
+}
+
+function safeRealpathOrResolve(value: string): string {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return path.resolve(value);
+  }
 }

--- a/src/infra/boundary-file-read.ts
+++ b/src/infra/boundary-file-read.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveBoundaryPath, resolveBoundaryPathSync } from "./boundary-path.js";
+import type { PathAliasPolicy } from "./path-alias-guards.js";
+import { openVerifiedFileSync, type SafeOpenSyncFailureReason } from "./safe-open-sync.js";
+
+type BoundaryReadFs = Pick<
+  typeof fs,
+  | "closeSync"
+  | "constants"
+  | "fstatSync"
+  | "lstatSync"
+  | "openSync"
+  | "readFileSync"
+  | "realpathSync"
+>;
+
+export type BoundaryFileOpenFailureReason = SafeOpenSyncFailureReason | "validation";
+
+export type BoundaryFileOpenResult =
+  | { ok: true; path: string; fd: number; stat: fs.Stats; rootRealPath: string }
+  | { ok: false; reason: BoundaryFileOpenFailureReason; error?: unknown };
+
+export type OpenBoundaryFileSyncParams = {
+  absolutePath: string;
+  rootPath: string;
+  boundaryLabel: string;
+  rootRealPath?: string;
+  maxBytes?: number;
+  rejectHardlinks?: boolean;
+  skipLexicalRootCheck?: boolean;
+  ioFs?: BoundaryReadFs;
+};
+
+export type OpenBoundaryFileParams = OpenBoundaryFileSyncParams & {
+  aliasPolicy?: PathAliasPolicy;
+};
+
+export function canUseBoundaryFileOpen(ioFs: typeof fs): boolean {
+  return (
+    typeof ioFs.openSync === "function" &&
+    typeof ioFs.closeSync === "function" &&
+    typeof ioFs.fstatSync === "function" &&
+    typeof ioFs.lstatSync === "function" &&
+    typeof ioFs.realpathSync === "function" &&
+    typeof ioFs.readFileSync === "function" &&
+    typeof ioFs.constants === "object" &&
+    ioFs.constants !== null
+  );
+}
+
+export function openBoundaryFileSync(params: OpenBoundaryFileSyncParams): BoundaryFileOpenResult {
+  const ioFs = params.ioFs ?? fs;
+  const absolutePath = path.resolve(params.absolutePath);
+
+  let resolvedPath: string;
+  let rootRealPath: string;
+  try {
+    const resolved = resolveBoundaryPathSync({
+      absolutePath,
+      rootPath: params.rootPath,
+      rootCanonicalPath: params.rootRealPath,
+      boundaryLabel: params.boundaryLabel,
+      skipLexicalRootCheck: params.skipLexicalRootCheck,
+    });
+    resolvedPath = resolved.canonicalPath;
+    rootRealPath = resolved.rootCanonicalPath;
+  } catch (error) {
+    return { ok: false, reason: "validation", error };
+  }
+
+  const opened = openVerifiedFileSync({
+    filePath: absolutePath,
+    resolvedPath,
+    rejectHardlinks: params.rejectHardlinks ?? true,
+    maxBytes: params.maxBytes,
+    ioFs,
+  });
+  if (!opened.ok) {
+    return opened;
+  }
+  return {
+    ok: true,
+    path: opened.path,
+    fd: opened.fd,
+    stat: opened.stat,
+    rootRealPath,
+  };
+}
+
+export async function openBoundaryFile(
+  params: OpenBoundaryFileParams,
+): Promise<BoundaryFileOpenResult> {
+  try {
+    await resolveBoundaryPath({
+      absolutePath: params.absolutePath,
+      rootPath: params.rootPath,
+      rootCanonicalPath: params.rootRealPath,
+      boundaryLabel: params.boundaryLabel,
+      policy: params.aliasPolicy,
+      skipLexicalRootCheck: params.skipLexicalRootCheck,
+    });
+  } catch (error) {
+    return { ok: false, reason: "validation", error };
+  }
+  return openBoundaryFileSync(params);
+}

--- a/src/infra/boundary-path.ts
+++ b/src/infra/boundary-path.ts
@@ -1,0 +1,568 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { isNotFoundPathError, isPathInside } from "./path-guards.js";
+
+export type BoundaryPathIntent = "read" | "write" | "create" | "delete" | "stat";
+
+export type BoundaryPathAliasPolicy = {
+  allowFinalSymlinkForUnlink?: boolean;
+  allowFinalHardlinkForUnlink?: boolean;
+};
+
+export const BOUNDARY_PATH_ALIAS_POLICIES = {
+  strict: Object.freeze({
+    allowFinalSymlinkForUnlink: false,
+    allowFinalHardlinkForUnlink: false,
+  }),
+  unlinkTarget: Object.freeze({
+    allowFinalSymlinkForUnlink: true,
+    allowFinalHardlinkForUnlink: true,
+  }),
+} as const;
+
+export type ResolveBoundaryPathParams = {
+  absolutePath: string;
+  rootPath: string;
+  boundaryLabel: string;
+  intent?: BoundaryPathIntent;
+  policy?: BoundaryPathAliasPolicy;
+  skipLexicalRootCheck?: boolean;
+  rootCanonicalPath?: string;
+};
+
+export type ResolvedBoundaryPathKind = "missing" | "file" | "directory" | "symlink" | "other";
+
+export type ResolvedBoundaryPath = {
+  absolutePath: string;
+  canonicalPath: string;
+  rootPath: string;
+  rootCanonicalPath: string;
+  relativePath: string;
+  exists: boolean;
+  kind: ResolvedBoundaryPathKind;
+};
+
+export async function resolveBoundaryPath(
+  params: ResolveBoundaryPathParams,
+): Promise<ResolvedBoundaryPath> {
+  const rootPath = path.resolve(params.rootPath);
+  const absolutePath = path.resolve(params.absolutePath);
+  const rootCanonicalPath = params.rootCanonicalPath
+    ? path.resolve(params.rootCanonicalPath)
+    : await resolvePathViaExistingAncestor(rootPath);
+  const lexicalInside = isPathInside(rootPath, absolutePath);
+  const outsideLexicalCanonicalPath = lexicalInside
+    ? undefined
+    : await resolvePathViaExistingAncestor(absolutePath);
+  const canonicalOutsideLexicalPath = resolveCanonicalOutsideLexicalPath({
+    absolutePath,
+    outsideLexicalCanonicalPath,
+  });
+  assertLexicalBoundaryOrCanonicalAlias({
+    skipLexicalRootCheck: params.skipLexicalRootCheck,
+    lexicalInside,
+    canonicalOutsideLexicalPath,
+    rootCanonicalPath,
+    boundaryLabel: params.boundaryLabel,
+    rootPath,
+    absolutePath,
+  });
+
+  if (!lexicalInside) {
+    const canonicalPath = canonicalOutsideLexicalPath;
+    assertInsideBoundary({
+      boundaryLabel: params.boundaryLabel,
+      rootCanonicalPath,
+      candidatePath: canonicalPath,
+      absolutePath,
+    });
+    const kind = await getPathKind(absolutePath, false);
+    return buildResolvedBoundaryPath({
+      absolutePath,
+      canonicalPath,
+      rootPath,
+      rootCanonicalPath,
+      kind,
+    });
+  }
+
+  return resolveBoundaryPathLexicalAsync({
+    params,
+    absolutePath,
+    rootPath,
+    rootCanonicalPath,
+  });
+}
+
+export function resolveBoundaryPathSync(params: ResolveBoundaryPathParams): ResolvedBoundaryPath {
+  const rootPath = path.resolve(params.rootPath);
+  const absolutePath = path.resolve(params.absolutePath);
+  const rootCanonicalPath = params.rootCanonicalPath
+    ? path.resolve(params.rootCanonicalPath)
+    : resolvePathViaExistingAncestorSync(rootPath);
+  const lexicalInside = isPathInside(rootPath, absolutePath);
+  const outsideLexicalCanonicalPath = lexicalInside
+    ? undefined
+    : resolvePathViaExistingAncestorSync(absolutePath);
+  const canonicalOutsideLexicalPath = resolveCanonicalOutsideLexicalPath({
+    absolutePath,
+    outsideLexicalCanonicalPath,
+  });
+  assertLexicalBoundaryOrCanonicalAlias({
+    skipLexicalRootCheck: params.skipLexicalRootCheck,
+    lexicalInside,
+    canonicalOutsideLexicalPath,
+    rootCanonicalPath,
+    boundaryLabel: params.boundaryLabel,
+    rootPath,
+    absolutePath,
+  });
+
+  if (!lexicalInside) {
+    const canonicalPath = canonicalOutsideLexicalPath;
+    assertInsideBoundary({
+      boundaryLabel: params.boundaryLabel,
+      rootCanonicalPath,
+      candidatePath: canonicalPath,
+      absolutePath,
+    });
+    const kind = getPathKindSync(absolutePath, false);
+    return buildResolvedBoundaryPath({
+      absolutePath,
+      canonicalPath,
+      rootPath,
+      rootCanonicalPath,
+      kind,
+    });
+  }
+
+  return resolveBoundaryPathLexicalSync({
+    params,
+    absolutePath,
+    rootPath,
+    rootCanonicalPath,
+  });
+}
+
+async function resolveBoundaryPathLexicalAsync(params: {
+  params: ResolveBoundaryPathParams;
+  absolutePath: string;
+  rootPath: string;
+  rootCanonicalPath: string;
+}): Promise<ResolvedBoundaryPath> {
+  const relative = path.relative(params.rootPath, params.absolutePath);
+  const segments = relative.split(path.sep).filter(Boolean);
+  const allowFinalSymlink = params.params.policy?.allowFinalSymlinkForUnlink === true;
+  let canonicalCursor = params.rootCanonicalPath;
+  let lexicalCursor = params.rootPath;
+  let preserveFinalSymlink = false;
+
+  for (let idx = 0; idx < segments.length; idx += 1) {
+    const segment = segments[idx] ?? "";
+    const isLast = idx === segments.length - 1;
+    lexicalCursor = path.join(lexicalCursor, segment);
+
+    let stat: Awaited<ReturnType<typeof fsp.lstat>>;
+    try {
+      stat = await fsp.lstat(lexicalCursor);
+    } catch (error) {
+      if (isNotFoundPathError(error)) {
+        const missingSuffix = segments.slice(idx);
+        canonicalCursor = path.resolve(canonicalCursor, ...missingSuffix);
+        assertInsideBoundary({
+          boundaryLabel: params.params.boundaryLabel,
+          rootCanonicalPath: params.rootCanonicalPath,
+          candidatePath: canonicalCursor,
+          absolutePath: params.absolutePath,
+        });
+        break;
+      }
+      throw error;
+    }
+
+    if (!stat.isSymbolicLink()) {
+      canonicalCursor = path.resolve(canonicalCursor, segment);
+      assertInsideBoundary({
+        boundaryLabel: params.params.boundaryLabel,
+        rootCanonicalPath: params.rootCanonicalPath,
+        candidatePath: canonicalCursor,
+        absolutePath: params.absolutePath,
+      });
+      continue;
+    }
+
+    if (allowFinalSymlink && isLast) {
+      preserveFinalSymlink = true;
+      canonicalCursor = path.resolve(canonicalCursor, segment);
+      assertInsideBoundary({
+        boundaryLabel: params.params.boundaryLabel,
+        rootCanonicalPath: params.rootCanonicalPath,
+        candidatePath: canonicalCursor,
+        absolutePath: params.absolutePath,
+      });
+      break;
+    }
+
+    const linkCanonical = await resolveSymlinkHopPath(lexicalCursor);
+    if (!isPathInside(params.rootCanonicalPath, linkCanonical)) {
+      throw symlinkEscapeError({
+        boundaryLabel: params.params.boundaryLabel,
+        rootCanonicalPath: params.rootCanonicalPath,
+        symlinkPath: lexicalCursor,
+      });
+    }
+    canonicalCursor = linkCanonical;
+    lexicalCursor = linkCanonical;
+  }
+
+  assertInsideBoundary({
+    boundaryLabel: params.params.boundaryLabel,
+    rootCanonicalPath: params.rootCanonicalPath,
+    candidatePath: canonicalCursor,
+    absolutePath: params.absolutePath,
+  });
+  const kind = await getPathKind(params.absolutePath, preserveFinalSymlink);
+  return buildResolvedBoundaryPath({
+    absolutePath: params.absolutePath,
+    canonicalPath: canonicalCursor,
+    rootPath: params.rootPath,
+    rootCanonicalPath: params.rootCanonicalPath,
+    kind,
+  });
+}
+
+function resolveBoundaryPathLexicalSync(params: {
+  params: ResolveBoundaryPathParams;
+  absolutePath: string;
+  rootPath: string;
+  rootCanonicalPath: string;
+}): ResolvedBoundaryPath {
+  const relative = path.relative(params.rootPath, params.absolutePath);
+  const segments = relative.split(path.sep).filter(Boolean);
+  const allowFinalSymlink = params.params.policy?.allowFinalSymlinkForUnlink === true;
+  let canonicalCursor = params.rootCanonicalPath;
+  let lexicalCursor = params.rootPath;
+  let preserveFinalSymlink = false;
+
+  for (let idx = 0; idx < segments.length; idx += 1) {
+    const segment = segments[idx] ?? "";
+    const isLast = idx === segments.length - 1;
+    lexicalCursor = path.join(lexicalCursor, segment);
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(lexicalCursor);
+    } catch (error) {
+      if (isNotFoundPathError(error)) {
+        const missingSuffix = segments.slice(idx);
+        canonicalCursor = path.resolve(canonicalCursor, ...missingSuffix);
+        assertInsideBoundary({
+          boundaryLabel: params.params.boundaryLabel,
+          rootCanonicalPath: params.rootCanonicalPath,
+          candidatePath: canonicalCursor,
+          absolutePath: params.absolutePath,
+        });
+        break;
+      }
+      throw error;
+    }
+
+    if (!stat.isSymbolicLink()) {
+      canonicalCursor = path.resolve(canonicalCursor, segment);
+      assertInsideBoundary({
+        boundaryLabel: params.params.boundaryLabel,
+        rootCanonicalPath: params.rootCanonicalPath,
+        candidatePath: canonicalCursor,
+        absolutePath: params.absolutePath,
+      });
+      continue;
+    }
+
+    if (allowFinalSymlink && isLast) {
+      preserveFinalSymlink = true;
+      canonicalCursor = path.resolve(canonicalCursor, segment);
+      assertInsideBoundary({
+        boundaryLabel: params.params.boundaryLabel,
+        rootCanonicalPath: params.rootCanonicalPath,
+        candidatePath: canonicalCursor,
+        absolutePath: params.absolutePath,
+      });
+      break;
+    }
+
+    const linkCanonical = resolveSymlinkHopPathSync(lexicalCursor);
+    if (!isPathInside(params.rootCanonicalPath, linkCanonical)) {
+      throw symlinkEscapeError({
+        boundaryLabel: params.params.boundaryLabel,
+        rootCanonicalPath: params.rootCanonicalPath,
+        symlinkPath: lexicalCursor,
+      });
+    }
+    canonicalCursor = linkCanonical;
+    lexicalCursor = linkCanonical;
+  }
+
+  assertInsideBoundary({
+    boundaryLabel: params.params.boundaryLabel,
+    rootCanonicalPath: params.rootCanonicalPath,
+    candidatePath: canonicalCursor,
+    absolutePath: params.absolutePath,
+  });
+  const kind = getPathKindSync(params.absolutePath, preserveFinalSymlink);
+  return buildResolvedBoundaryPath({
+    absolutePath: params.absolutePath,
+    canonicalPath: canonicalCursor,
+    rootPath: params.rootPath,
+    rootCanonicalPath: params.rootCanonicalPath,
+    kind,
+  });
+}
+
+function resolveCanonicalOutsideLexicalPath(params: {
+  absolutePath: string;
+  outsideLexicalCanonicalPath?: string;
+}): string {
+  return params.outsideLexicalCanonicalPath ?? params.absolutePath;
+}
+
+function assertLexicalBoundaryOrCanonicalAlias(params: {
+  skipLexicalRootCheck?: boolean;
+  lexicalInside: boolean;
+  canonicalOutsideLexicalPath: string;
+  rootCanonicalPath: string;
+  boundaryLabel: string;
+  rootPath: string;
+  absolutePath: string;
+}): void {
+  if (params.skipLexicalRootCheck || params.lexicalInside) {
+    return;
+  }
+  if (isPathInside(params.rootCanonicalPath, params.canonicalOutsideLexicalPath)) {
+    return;
+  }
+  throw pathEscapeError({
+    boundaryLabel: params.boundaryLabel,
+    rootPath: params.rootPath,
+    absolutePath: params.absolutePath,
+  });
+}
+
+function buildResolvedBoundaryPath(params: {
+  absolutePath: string;
+  canonicalPath: string;
+  rootPath: string;
+  rootCanonicalPath: string;
+  kind: { exists: boolean; kind: ResolvedBoundaryPathKind };
+}): ResolvedBoundaryPath {
+  return {
+    absolutePath: params.absolutePath,
+    canonicalPath: params.canonicalPath,
+    rootPath: params.rootPath,
+    rootCanonicalPath: params.rootCanonicalPath,
+    relativePath: relativeInsideRoot(params.rootCanonicalPath, params.canonicalPath),
+    exists: params.kind.exists,
+    kind: params.kind.kind,
+  };
+}
+
+export async function resolvePathViaExistingAncestor(targetPath: string): Promise<string> {
+  const normalized = path.resolve(targetPath);
+  let cursor = normalized;
+  const missingSuffix: string[] = [];
+
+  while (!isFilesystemRoot(cursor) && !(await pathExists(cursor))) {
+    missingSuffix.unshift(path.basename(cursor));
+    const parent = path.dirname(cursor);
+    if (parent === cursor) {
+      break;
+    }
+    cursor = parent;
+  }
+
+  if (!(await pathExists(cursor))) {
+    return normalized;
+  }
+
+  try {
+    const resolvedAncestor = path.resolve(await fsp.realpath(cursor));
+    if (missingSuffix.length === 0) {
+      return resolvedAncestor;
+    }
+    return path.resolve(resolvedAncestor, ...missingSuffix);
+  } catch {
+    return normalized;
+  }
+}
+
+export function resolvePathViaExistingAncestorSync(targetPath: string): string {
+  const normalized = path.resolve(targetPath);
+  let cursor = normalized;
+  const missingSuffix: string[] = [];
+
+  while (!isFilesystemRoot(cursor) && !fs.existsSync(cursor)) {
+    missingSuffix.unshift(path.basename(cursor));
+    const parent = path.dirname(cursor);
+    if (parent === cursor) {
+      break;
+    }
+    cursor = parent;
+  }
+
+  if (!fs.existsSync(cursor)) {
+    return normalized;
+  }
+
+  try {
+    // Keep sync behavior aligned with async (`fsp.realpath`) to avoid
+    // platform-specific canonical alias drift (notably on Windows).
+    const resolvedAncestor = path.resolve(fs.realpathSync(cursor));
+    if (missingSuffix.length === 0) {
+      return resolvedAncestor;
+    }
+    return path.resolve(resolvedAncestor, ...missingSuffix);
+  } catch {
+    return normalized;
+  }
+}
+
+async function getPathKind(
+  absolutePath: string,
+  preserveFinalSymlink: boolean,
+): Promise<{ exists: boolean; kind: ResolvedBoundaryPathKind }> {
+  try {
+    const stat = preserveFinalSymlink
+      ? await fsp.lstat(absolutePath)
+      : await fsp.stat(absolutePath);
+    return { exists: true, kind: toResolvedKind(stat) };
+  } catch (error) {
+    if (isNotFoundPathError(error)) {
+      return { exists: false, kind: "missing" };
+    }
+    throw error;
+  }
+}
+
+function getPathKindSync(
+  absolutePath: string,
+  preserveFinalSymlink: boolean,
+): { exists: boolean; kind: ResolvedBoundaryPathKind } {
+  try {
+    const stat = preserveFinalSymlink ? fs.lstatSync(absolutePath) : fs.statSync(absolutePath);
+    return { exists: true, kind: toResolvedKind(stat) };
+  } catch (error) {
+    if (isNotFoundPathError(error)) {
+      return { exists: false, kind: "missing" };
+    }
+    throw error;
+  }
+}
+
+function toResolvedKind(stat: fs.Stats): ResolvedBoundaryPathKind {
+  if (stat.isFile()) {
+    return "file";
+  }
+  if (stat.isDirectory()) {
+    return "directory";
+  }
+  if (stat.isSymbolicLink()) {
+    return "symlink";
+  }
+  return "other";
+}
+
+function relativeInsideRoot(rootPath: string, targetPath: string): string {
+  const relative = path.relative(path.resolve(rootPath), path.resolve(targetPath));
+  if (!relative || relative === ".") {
+    return "";
+  }
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return "";
+  }
+  return relative;
+}
+
+function assertInsideBoundary(params: {
+  boundaryLabel: string;
+  rootCanonicalPath: string;
+  candidatePath: string;
+  absolutePath: string;
+}): void {
+  if (isPathInside(params.rootCanonicalPath, params.candidatePath)) {
+    return;
+  }
+  throw new Error(
+    `Path resolves outside ${params.boundaryLabel} (${shortPath(params.rootCanonicalPath)}): ${shortPath(params.absolutePath)}`,
+  );
+}
+
+function pathEscapeError(params: {
+  boundaryLabel: string;
+  rootPath: string;
+  absolutePath: string;
+}): Error {
+  return new Error(
+    `Path escapes ${params.boundaryLabel} (${shortPath(params.rootPath)}): ${shortPath(params.absolutePath)}`,
+  );
+}
+
+function symlinkEscapeError(params: {
+  boundaryLabel: string;
+  rootCanonicalPath: string;
+  symlinkPath: string;
+}): Error {
+  return new Error(
+    `Symlink escapes ${params.boundaryLabel} (${shortPath(params.rootCanonicalPath)}): ${shortPath(params.symlinkPath)}`,
+  );
+}
+
+function shortPath(value: string): string {
+  const home = os.homedir();
+  if (value.startsWith(home)) {
+    return `~${value.slice(home.length)}`;
+  }
+  return value;
+}
+
+function isFilesystemRoot(candidate: string): boolean {
+  return path.parse(candidate).root === candidate;
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fsp.lstat(targetPath);
+    return true;
+  } catch (error) {
+    if (isNotFoundPathError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function resolveSymlinkHopPath(symlinkPath: string): Promise<string> {
+  try {
+    return path.resolve(await fsp.realpath(symlinkPath));
+  } catch (error) {
+    if (!isNotFoundPathError(error)) {
+      throw error;
+    }
+    const linkTarget = await fsp.readlink(symlinkPath);
+    const linkAbsolute = path.resolve(path.dirname(symlinkPath), linkTarget);
+    return resolvePathViaExistingAncestor(linkAbsolute);
+  }
+}
+
+function resolveSymlinkHopPathSync(symlinkPath: string): string {
+  try {
+    return path.resolve(fs.realpathSync(symlinkPath));
+  } catch (error) {
+    if (!isNotFoundPathError(error)) {
+      throw error;
+    }
+    const linkTarget = fs.readlinkSync(symlinkPath);
+    const linkAbsolute = path.resolve(path.dirname(symlinkPath), linkTarget);
+    return resolvePathViaExistingAncestorSync(linkAbsolute);
+  }
+}

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -81,6 +81,33 @@ describe("fs-safe", () => {
     ).rejects.toMatchObject({ code: "invalid-path" });
   });
 
+  it.runIf(process.platform !== "win32")("blocks hardlink aliases under root", async () => {
+    const root = await tempDirs.make("remoteclaw-fs-safe-root-");
+    const outside = await tempDirs.make("remoteclaw-fs-safe-outside-");
+    const outsideFile = path.join(outside, "outside.txt");
+    const hardlinkPath = path.join(root, "link.txt");
+    await fs.writeFile(outsideFile, "outside");
+    try {
+      try {
+        await fs.link(outsideFile, hardlinkPath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+          return;
+        }
+        throw err;
+      }
+      await expect(
+        openFileWithinRoot({
+          rootDir: root,
+          relativePath: "link.txt",
+        }),
+      ).rejects.toMatchObject({ code: "invalid-path" });
+    } finally {
+      await fs.rm(hardlinkPath, { force: true });
+      await fs.rm(outsideFile, { force: true });
+    }
+  });
+
   it("returns not-found for missing files", async () => {
     const dir = await tempDirs.make("remoteclaw-fs-safe-");
     const missing = path.join(dir, "missing.txt");

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -41,7 +41,12 @@ const OPEN_READ_FLAGS = fsConstants.O_RDONLY | (SUPPORTS_NOFOLLOW ? fsConstants.
 
 const ensureTrailingSep = (value: string) => (value.endsWith(path.sep) ? value : value + path.sep);
 
-async function openVerifiedLocalFile(filePath: string): Promise<SafeOpenResult> {
+async function openVerifiedLocalFile(
+  filePath: string,
+  options?: {
+    rejectHardlinks?: boolean;
+  },
+): Promise<SafeOpenResult> {
   let handle: FileHandle;
   try {
     handle = await fs.open(filePath, OPEN_READ_FLAGS);
@@ -63,12 +68,18 @@ async function openVerifiedLocalFile(filePath: string): Promise<SafeOpenResult> 
     if (!stat.isFile()) {
       throw new SafeOpenError("not-file", "not a file");
     }
+    if (options?.rejectHardlinks && stat.nlink > 1) {
+      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+    }
     if (!sameFileIdentity(stat, lstat)) {
       throw new SafeOpenError("path-mismatch", "path changed during read");
     }
 
     const realPath = await fs.realpath(filePath);
     const realStat = await fs.stat(realPath);
+    if (options?.rejectHardlinks && realStat.nlink > 1) {
+      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+    }
     if (!sameFileIdentity(stat, realStat)) {
       throw new SafeOpenError("path-mismatch", "path mismatch");
     }
@@ -89,6 +100,7 @@ async function openVerifiedLocalFile(filePath: string): Promise<SafeOpenResult> 
 export async function openFileWithinRoot(params: {
   rootDir: string;
   relativePath: string;
+  rejectHardlinks?: boolean;
 }): Promise<SafeOpenResult> {
   let rootReal: string;
   try {
@@ -118,6 +130,11 @@ export async function openFileWithinRoot(params: {
       });
     }
     throw err;
+  }
+
+  if (params.rejectHardlinks !== false && opened.stat.nlink > 1) {
+    await opened.handle.close().catch(() => {});
+    throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
   }
 
   if (!isPathInside(rootWithSep, opened.realPath)) {

--- a/src/infra/hardlink-guards.ts
+++ b/src/infra/hardlink-guards.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import { isNotFoundPathError } from "./path-guards.js";
+
+export async function assertNoHardlinkedFinalPath(params: {
+  filePath: string;
+  root: string;
+  boundaryLabel: string;
+  allowFinalHardlinkForUnlink?: boolean;
+}): Promise<void> {
+  if (params.allowFinalHardlinkForUnlink) {
+    return;
+  }
+  let stat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    stat = await fs.stat(params.filePath);
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      return;
+    }
+    throw err;
+  }
+  if (!stat.isFile()) {
+    return;
+  }
+  if (stat.nlink > 1) {
+    throw new Error(
+      `Hardlinked path is not allowed under ${params.boundaryLabel} (${shortPath(params.root)}): ${shortPath(params.filePath)}`,
+    );
+  }
+}
+
+function shortPath(value: string) {
+  if (value.startsWith(os.homedir())) {
+    return `~${value.slice(os.homedir().length)}`;
+  }
+  return value;
+}

--- a/src/infra/host-env-security.policy-parity.test.ts
+++ b/src/infra/host-env-security.policy-parity.test.ts
@@ -19,26 +19,44 @@ function parseSwiftStringArray(source: string, marker: string): string[] {
 }
 
 describe("host env security policy parity", () => {
-  it("keeps macOS HostEnvSanitizer lists in sync with shared JSON policy", () => {
+  it("keeps generated macOS host env policy in sync with shared JSON policy", () => {
     const repoRoot = process.cwd();
     const policyPath = path.join(repoRoot, "src/infra/host-env-security-policy.json");
-    const swiftPath = path.join(repoRoot, "apps/macos/Sources/RemoteClaw/HostEnvSanitizer.swift");
+    const generatedSwiftPath = path.join(
+      repoRoot,
+      "apps/macos/Sources/RemoteClaw/HostEnvSecurityPolicy.generated.swift",
+    );
+    const sanitizerSwiftPath = path.join(
+      repoRoot,
+      "apps/macos/Sources/RemoteClaw/HostEnvSanitizer.swift",
+    );
 
     const policy = JSON.parse(fs.readFileSync(policyPath, "utf8")) as HostEnvSecurityPolicy;
-    const swiftSource = fs.readFileSync(swiftPath, "utf8");
+    const generatedSource = fs.readFileSync(generatedSwiftPath, "utf8");
+    const sanitizerSource = fs.readFileSync(sanitizerSwiftPath, "utf8");
 
-    const swiftBlockedKeys = parseSwiftStringArray(swiftSource, "private static let blockedKeys");
+    const swiftBlockedKeys = parseSwiftStringArray(generatedSource, "static let blockedKeys");
     const swiftBlockedOverrideKeys = parseSwiftStringArray(
-      swiftSource,
-      "private static let blockedOverrideKeys",
+      generatedSource,
+      "static let blockedOverrideKeys",
     );
     const swiftBlockedPrefixes = parseSwiftStringArray(
-      swiftSource,
-      "private static let blockedPrefixes",
+      generatedSource,
+      "static let blockedPrefixes",
     );
 
     expect(swiftBlockedKeys).toEqual(policy.blockedKeys);
     expect(swiftBlockedOverrideKeys).toEqual(policy.blockedOverrideKeys ?? []);
     expect(swiftBlockedPrefixes).toEqual(policy.blockedPrefixes);
+
+    expect(sanitizerSource).toContain(
+      "private static let blockedKeys = HostEnvSecurityPolicy.blockedKeys",
+    );
+    expect(sanitizerSource).toContain(
+      "private static let blockedOverrideKeys = HostEnvSecurityPolicy.blockedOverrideKeys",
+    );
+    expect(sanitizerSource).toContain(
+      "private static let blockedPrefixes = HostEnvSecurityPolicy.blockedPrefixes",
+    );
   });
 });

--- a/src/infra/path-alias-guards.ts
+++ b/src/infra/path-alias-guards.ts
@@ -1,0 +1,34 @@
+import {
+  BOUNDARY_PATH_ALIAS_POLICIES,
+  resolveBoundaryPath,
+  type BoundaryPathAliasPolicy,
+} from "./boundary-path.js";
+import { assertNoHardlinkedFinalPath } from "./hardlink-guards.js";
+
+export type PathAliasPolicy = BoundaryPathAliasPolicy;
+
+export const PATH_ALIAS_POLICIES = BOUNDARY_PATH_ALIAS_POLICIES;
+
+export async function assertNoPathAliasEscape(params: {
+  absolutePath: string;
+  rootPath: string;
+  boundaryLabel: string;
+  policy?: PathAliasPolicy;
+}): Promise<void> {
+  const resolved = await resolveBoundaryPath({
+    absolutePath: params.absolutePath,
+    rootPath: params.rootPath,
+    boundaryLabel: params.boundaryLabel,
+    policy: params.policy,
+  });
+  const allowFinalSymlink = params.policy?.allowFinalSymlinkForUnlink === true;
+  if (allowFinalSymlink && resolved.kind === "symlink") {
+    return;
+  }
+  await assertNoHardlinkedFinalPath({
+    filePath: resolved.absolutePath,
+    root: resolved.rootPath,
+    boundaryLabel: params.boundaryLabel,
+    allowFinalHardlinkForUnlink: params.policy?.allowFinalHardlinkForUnlink,
+  });
+}

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -375,6 +375,7 @@ export { formatDocsLink } from "../terminal/links.js";
 export {
   resolveDmAllowState,
   resolveDmGroupAccessDecision,
+  resolveDmGroupAccessWithCommandGate,
   resolveDmGroupAccessWithLists,
   resolveEffectiveAllowFromLists,
 } from "../security/dm-policy-shared.js";

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -172,6 +172,7 @@ describe("discoverRemoteClawPlugins", () => {
     const ids = candidates.map((c) => c.idHint);
     expect(ids).toContain("demo-plugin-dir");
   });
+
   it("blocks extension entries that escape package directory", async () => {
     const stateDir = makeTempDir();
     const globalExt = path.join(stateDir, "extensions", "escape-pack");
@@ -229,6 +230,82 @@ describe("discoverRemoteClawPlugins", () => {
     expect(diagnostics.some((entry) => entry.message.includes("escapes package directory"))).toBe(
       true,
     );
+  });
+
+  it("rejects package extension entries that are hardlinked aliases", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions", "pack");
+    const outsideDir = path.join(stateDir, "outside");
+    const outsideFile = path.join(outsideDir, "escape.ts");
+    const linkedFile = path.join(globalExt, "escape.ts");
+    fs.mkdirSync(globalExt, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(outsideFile, "export default {}", "utf-8");
+    try {
+      fs.linkSync(outsideFile, linkedFile);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    fs.writeFileSync(
+      path.join(globalExt, "package.json"),
+      JSON.stringify({
+        name: "@remoteclaw/pack",
+        remoteclaw: { extensions: ["./escape.ts"] },
+      }),
+      "utf-8",
+    );
+
+    const { candidates, diagnostics } = await withStateDir(stateDir, async () => {
+      return discoverRemoteClawPlugins({});
+    });
+
+    expect(candidates.some((candidate) => candidate.idHint === "pack")).toBe(false);
+    expect(diagnostics.some((entry) => entry.message.includes("escapes package directory"))).toBe(
+      true,
+    );
+  });
+
+  it("ignores package manifests that are hardlinked aliases", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions", "pack");
+    const outsideDir = path.join(stateDir, "outside");
+    const outsideManifest = path.join(outsideDir, "package.json");
+    const linkedManifest = path.join(globalExt, "package.json");
+    fs.mkdirSync(globalExt, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(path.join(globalExt, "entry.ts"), "export default {}", "utf-8");
+    fs.writeFileSync(
+      outsideManifest,
+      JSON.stringify({
+        name: "@remoteclaw/pack",
+        remoteclaw: { extensions: ["./entry.ts"] },
+      }),
+      "utf-8",
+    );
+    try {
+      fs.linkSync(outsideManifest, linkedManifest);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    const { candidates } = await withStateDir(stateDir, async () => {
+      return discoverRemoteClawPlugins({});
+    });
+
+    expect(candidates.some((candidate) => candidate.idHint === "pack")).toBe(false);
   });
 
   it.runIf(process.platform !== "win32")("blocks world-writable plugin paths", async () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -4,8 +4,8 @@ import { fileURLToPath } from "node:url";
 import { createJiti } from "jiti";
 import type { RemoteClawConfig } from "../config/config.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
+import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { isPathInsideWithRealpath } from "../security/scan-paths.js";
 import { resolveUserPath } from "../utils.js";
 import { clearPluginCommands } from "./commands.js";
 import {
@@ -47,20 +47,25 @@ const defaultLogger = () => createSubsystemLogger("plugins");
 const resolvePluginSdkAliasFile = (params: {
   srcFile: string;
   distFile: string;
+  modulePath?: string;
 }): string | null => {
   try {
-    const modulePath = fileURLToPath(import.meta.url);
+    const modulePath = params.modulePath ?? fileURLToPath(import.meta.url);
     const isProduction = process.env.NODE_ENV === "production";
     const isTest = process.env.VITEST || process.env.NODE_ENV === "test";
+    const normalizedModulePath = modulePath.replace(/\\/g, "/");
+    const isDistRuntime = normalizedModulePath.includes("/dist/");
     let cursor = path.dirname(modulePath);
     for (let i = 0; i < 6; i += 1) {
       const srcCandidate = path.join(cursor, "src", "plugin-sdk", params.srcFile);
       const distCandidate = path.join(cursor, "dist", "plugin-sdk", params.distFile);
-      const orderedCandidates = isProduction
-        ? isTest
-          ? [distCandidate, srcCandidate]
-          : [distCandidate]
-        : [srcCandidate, distCandidate];
+      const orderedCandidates = isDistRuntime
+        ? [distCandidate, srcCandidate]
+        : isProduction
+          ? isTest
+            ? [distCandidate, srcCandidate]
+            : [distCandidate]
+          : [srcCandidate, distCandidate];
       for (const candidate of orderedCandidates) {
         if (fs.existsSync(candidate)) {
           return candidate;
@@ -83,6 +88,10 @@ const resolvePluginSdkAlias = (): string | null =>
 
 const resolvePluginSdkAccountIdAlias = (): string | null => {
   return resolvePluginSdkAliasFile({ srcFile: "account-id.ts", distFile: "account-id.js" });
+};
+
+export const __testing = {
+  resolvePluginSdkAliasFile,
 };
 
 function buildCacheKey(params: {
@@ -513,13 +522,19 @@ export function loadRemoteClawPlugins(options: PluginLoadOptions = {}): PluginRe
       continue;
     }
 
-    if (
-      !isPathInsideWithRealpath(candidate.rootDir, candidate.source, {
-        requireRealpath: true,
-      })
-    ) {
+    const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
+    const opened = openBoundaryFileSync({
+      absolutePath: candidate.source,
+      rootPath: pluginRoot,
+      boundaryLabel: "plugin root",
+      // Discovery stores rootDir as realpath but source may still be a lexical alias
+      // (e.g. /var/... vs /private/var/... on macOS). Canonical boundary checks
+      // still enforce containment; skip lexical pre-check to avoid false escapes.
+      skipLexicalRootCheck: true,
+    });
+    if (!opened.ok) {
       record.status = "error";
-      record.error = "plugin entry path escapes plugin root";
+      record.error = "plugin entry path escapes plugin root or fails alias checks";
       registry.plugins.push(record);
       seenIds.set(pluginId, candidate.origin);
       registry.diagnostics.push({
@@ -530,10 +545,12 @@ export function loadRemoteClawPlugins(options: PluginLoadOptions = {}): PluginRe
       });
       continue;
     }
+    const safeSource = opened.path;
+    fs.closeSync(opened.fd);
 
     let mod: RemoteClawPluginModule | null = null;
     try {
-      mod = getJiti()(candidate.source) as RemoteClawPluginModule;
+      mod = getJiti()(safeSource) as RemoteClawPluginModule;
     } catch (err) {
       recordPluginError({
         logger,
@@ -663,4 +680,12 @@ export function loadRemoteClawPlugins(options: PluginLoadOptions = {}): PluginRe
   setActivePluginRegistry(registry, cacheKey);
   initializeGlobalHookRunner(registry);
   return registry;
+}
+
+function safeRealpathOrResolve(value: string): string {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return path.resolve(value);
+  }
 }

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -167,4 +167,70 @@ describe("loadPluginManifestRegistry", () => {
     expect(registry.plugins.length).toBe(1);
     expect(registry.plugins[0]?.origin).toBe("config");
   });
+
+  it("rejects manifest paths that escape plugin root via symlink", () => {
+    const rootDir = makeTempDir();
+    const outsideDir = makeTempDir();
+    const outsideManifest = path.join(outsideDir, "remoteclaw.plugin.json");
+    const linkedManifest = path.join(rootDir, "remoteclaw.plugin.json");
+    fs.writeFileSync(path.join(rootDir, "index.ts"), "export default function () {}", "utf-8");
+    fs.writeFileSync(
+      outsideManifest,
+      JSON.stringify({ id: "unsafe-symlink", configSchema: { type: "object" } }),
+      "utf-8",
+    );
+    try {
+      fs.symlinkSync(outsideManifest, linkedManifest);
+    } catch {
+      return;
+    }
+
+    const registry = loadRegistry([
+      createPluginCandidate({
+        idHint: "unsafe-symlink",
+        rootDir,
+        origin: "workspace",
+      }),
+    ]);
+    expect(registry.plugins).toHaveLength(0);
+    expect(
+      registry.diagnostics.some((diag) => diag.message.includes("unsafe plugin manifest path")),
+    ).toBe(true);
+  });
+
+  it("rejects manifest paths that escape plugin root via hardlink", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = makeTempDir();
+    const outsideDir = makeTempDir();
+    const outsideManifest = path.join(outsideDir, "remoteclaw.plugin.json");
+    const linkedManifest = path.join(rootDir, "remoteclaw.plugin.json");
+    fs.writeFileSync(path.join(rootDir, "index.ts"), "export default function () {}", "utf-8");
+    fs.writeFileSync(
+      outsideManifest,
+      JSON.stringify({ id: "unsafe-hardlink", configSchema: { type: "object" } }),
+      "utf-8",
+    );
+    try {
+      fs.linkSync(outsideManifest, linkedManifest);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    const registry = loadRegistry([
+      createPluginCandidate({
+        idHint: "unsafe-hardlink",
+        rootDir,
+        origin: "workspace",
+      }),
+    ]);
+    expect(registry.plugins).toHaveLength(0);
+    expect(
+      registry.diagnostics.some((diag) => diag.message.includes("unsafe plugin manifest path")),
+    ).toBe(true);
+  });
 });

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { isRecord } from "../utils.js";
 import type { PluginConfigUiHint, PluginKind } from "./types.js";
 
@@ -38,18 +39,32 @@ export function resolvePluginManifestPath(rootDir: string): string {
 
 export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
   const manifestPath = resolvePluginManifestPath(rootDir);
-  if (!fs.existsSync(manifestPath)) {
-    return { ok: false, error: `plugin manifest not found: ${manifestPath}`, manifestPath };
+  const opened = openBoundaryFileSync({
+    absolutePath: manifestPath,
+    rootPath: rootDir,
+    boundaryLabel: "plugin root",
+  });
+  if (!opened.ok) {
+    if (opened.reason === "path") {
+      return { ok: false, error: `plugin manifest not found: ${manifestPath}`, manifestPath };
+    }
+    return {
+      ok: false,
+      error: `unsafe plugin manifest path: ${manifestPath} (${opened.reason})`,
+      manifestPath,
+    };
   }
   let raw: unknown;
   try {
-    raw = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as unknown;
+    raw = JSON.parse(fs.readFileSync(opened.fd, "utf-8")) as unknown;
   } catch (err) {
     return {
       ok: false,
       error: `failed to parse plugin manifest: ${String(err)}`,
       manifestPath,
     };
+  } finally {
+    fs.closeSync(opened.fd);
   }
   if (!isRecord(raw)) {
     return { ok: false, error: "plugin manifest must be an object", manifestPath };

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1,11 +1,12 @@
-import fs from "node:fs/promises";
+import fsSync from "node:fs";
+import path from "node:path";
 import type { RemoteClawConfig } from "../config/config.js";
+import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import type { UpdateChannel } from "../infra/update-channels.js";
 import { resolveUserPath } from "../utils.js";
-import { discoverRemoteClawPlugins } from "./discovery.js";
+import { resolveBundledPluginSources } from "./bundled-sources.js";
 import { installPluginFromNpmSpec, resolvePluginInstallDir } from "./install.js";
 import { buildNpmResolutionInstallFields, recordPluginInstall } from "./installs.js";
-import { loadPluginManifest } from "./manifest.js";
 
 export type PluginUpdateLogger = {
   info?: (message: string) => void;
@@ -52,12 +53,6 @@ export type PluginChannelSyncResult = {
   summary: PluginChannelSyncSummary;
 };
 
-type BundledPluginSource = {
-  pluginId: string;
-  localPath: string;
-  npmSpec?: string;
-};
-
 type InstallIntegrityDrift = {
   spec: string;
   expectedIntegrity: string;
@@ -69,47 +64,24 @@ type InstallIntegrityDrift = {
 };
 
 async function readInstalledPackageVersion(dir: string): Promise<string | undefined> {
+  const manifestPath = path.join(dir, "package.json");
+  const opened = openBoundaryFileSync({
+    absolutePath: manifestPath,
+    rootPath: dir,
+    boundaryLabel: "installed plugin directory",
+  });
+  if (!opened.ok) {
+    return undefined;
+  }
   try {
-    const raw = await fs.readFile(`${dir}/package.json`, "utf-8");
+    const raw = fsSync.readFileSync(opened.fd, "utf-8");
     const parsed = JSON.parse(raw) as { version?: unknown };
     return typeof parsed.version === "string" ? parsed.version : undefined;
   } catch {
     return undefined;
+  } finally {
+    fsSync.closeSync(opened.fd);
   }
-}
-
-function resolveBundledPluginSources(params: {
-  workspaceDir?: string;
-}): Map<string, BundledPluginSource> {
-  const discovery = discoverRemoteClawPlugins({ workspaceDir: params.workspaceDir });
-  const bundled = new Map<string, BundledPluginSource>();
-
-  for (const candidate of discovery.candidates) {
-    if (candidate.origin !== "bundled") {
-      continue;
-    }
-    const manifest = loadPluginManifest(candidate.rootDir);
-    if (!manifest.ok) {
-      continue;
-    }
-    const pluginId = manifest.manifest.id;
-    if (bundled.has(pluginId)) {
-      continue;
-    }
-
-    const npmSpec =
-      candidate.packageManifest?.install?.npmSpec?.trim() ||
-      candidate.packageName?.trim() ||
-      undefined;
-
-    bundled.set(pluginId, {
-      pluginId,
-      localPath: candidate.rootDir,
-      npmSpec,
-    });
-  }
-
-  return bundled;
 }
 
 function pathsEqual(left?: string, right?: string): boolean {

--- a/src/telegram/bot-message-context.test-harness.ts
+++ b/src/telegram/bot-message-context.test-harness.ts
@@ -64,5 +64,6 @@ export async function buildTelegramMessageContextForTest(
         groupConfig: { requireMention: false },
         topicConfig: undefined,
       })),
+    sendChatActionHandler: { sendChatAction: vi.fn() } as never,
   });
 }

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -110,6 +110,8 @@ export type BuildTelegramMessageContextParams = {
   resolveGroupActivation: ResolveGroupActivation;
   resolveGroupRequireMention: ResolveGroupRequireMention;
   resolveTelegramGroupConfig: ResolveTelegramGroupConfig;
+  /** Global (per-account) handler for sendChatAction 401 backoff (#27092). */
+  sendChatActionHandler: import("./sendchataction-401-backoff.js").TelegramSendChatActionHandler;
 };
 
 export const buildTelegramMessageContext = async ({
@@ -130,6 +132,7 @@ export const buildTelegramMessageContext = async ({
   resolveGroupActivation,
   resolveGroupRequireMention,
   resolveTelegramGroupConfig,
+  sendChatActionHandler,
 }: BuildTelegramMessageContextParams) => {
   const msg = primaryCtx.message;
   const chatId = msg.chat.id;
@@ -217,7 +220,12 @@ export const buildTelegramMessageContext = async ({
   const sendTyping = async () => {
     await withTelegramApiErrorLogging({
       operation: "sendChatAction",
-      fn: () => bot.api.sendChatAction(chatId, "typing", buildTypingThreadParams(replyThreadId)),
+      fn: () =>
+        sendChatActionHandler.sendChatAction(
+          chatId,
+          "typing",
+          buildTypingThreadParams(replyThreadId),
+        ),
     });
   };
 
@@ -226,7 +234,11 @@ export const buildTelegramMessageContext = async ({
       await withTelegramApiErrorLogging({
         operation: "sendChatAction",
         fn: () =>
-          bot.api.sendChatAction(chatId, "record_voice", buildTypingThreadParams(replyThreadId)),
+          sendChatActionHandler.sendChatAction(
+            chatId,
+            "record_voice",
+            buildTypingThreadParams(replyThreadId),
+          ),
       });
     } catch (err) {
       logVerbose(`telegram record_voice cue failed for chat ${chatId}: ${String(err)}`);

--- a/src/telegram/bot-message.ts
+++ b/src/telegram/bot-message.ts
@@ -39,6 +39,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     resolveGroupActivation,
     resolveGroupRequireMention,
     resolveTelegramGroupConfig,
+    sendChatActionHandler,
     runtime,
     replyToMode,
     streamMode,
@@ -70,6 +71,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       resolveGroupActivation,
       resolveGroupRequireMention,
       resolveTelegramGroupConfig,
+      sendChatActionHandler,
     });
     if (!context) {
       return;

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -39,6 +39,7 @@ import {
   resolveTelegramStreamMode,
 } from "./bot/helpers.js";
 import { resolveTelegramFetch } from "./fetch.js";
+import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 
 export type TelegramBotOptions = {
   token: string;
@@ -342,6 +343,20 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     return { groupConfig, topicConfig };
   };
 
+  // Global sendChatAction handler with 401 backoff / circuit breaker (issue #27092).
+  // Created BEFORE the message processor so it can be injected into every message context.
+  // Shared across all message contexts for this account so that consecutive 401s
+  // from ANY chat are tracked together — prevents infinite retry storms.
+  const sendChatActionHandler = createTelegramSendChatActionHandler({
+    sendChatActionFn: (chatId, action, threadParams) =>
+      bot.api.sendChatAction(
+        chatId,
+        action,
+        threadParams as Parameters<typeof bot.api.sendChatAction>[2],
+      ),
+    logger: (message) => logVerbose(`telegram: ${message}`),
+  });
+
   const processMessage = createTelegramMessageProcessor({
     bot,
     cfg,
@@ -357,6 +372,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     resolveGroupActivation,
     resolveGroupRequireMention,
     resolveTelegramGroupConfig,
+    sendChatActionHandler,
     runtime,
     replyToMode,
     streamMode,


### PR DESCRIPTION
## Summary

Post-sync audit of the v2026.2.25→v2026.2.26 DIFF-SYNC batch found upstream changes dropped during the build-check phase. Independent validation identified 42 actionable files from 455 total dropped.

### Security
- **4 new infra files** (747 lines): `openBoundaryFileSync` chain — hardlink guards, path alias guards, boundary path resolution, boundary file read
- **4 plugin files hardened**: `discovery.ts`, `loader.ts`, `manifest.ts`, `update.ts` — replaced `isPathInsideWithRealpath` with `openBoundaryFileSync`
- **2 config/hooks files**: include file guards with `MAX_INCLUDE_FILE_BYTES`, hook loader escape prevention
- **fs-safe.ts**: hardlink `nlink>1` protection for `openVerifiedLocalFile` and `openFileWithinRoot` (6 production consumers)

### Bug fixes
- **Telegram sendChatAction 401 backoff** (5 files): circuit breaker for consecutive 401 errors, prevents infinite retry storms
- **Swift sanitizer delegation**: `HostEnvSanitizer.swift` delegates to `HostEnvSecurityPolicy.generated.swift`

### Features
- **Feishu account-aware tools** (6 files): new `tool-account.ts` factory + bitable/docx/drive/perm/wiki refactored
- **Cross-cutting allowlist refactor** (3 files): IRC + Nextcloud Talk updated to `resolveEffectiveAllowFromLists`
- **subagent-announce.ts**: `isSilentReplyText`, `acpEnabled` param, ACP routing guidance

### Other
- `agent/delivery.ts` outboundSession support, `onboard-types.ts` SecretInputMode, gateway DeviceIdentity + reconnect spoof test, onboard-channels configureInteractive tests, schema.hints serviceAccount sensitive marking

## Test plan

- [x] `pnpm check` passes (format + typecheck + lint + rebrand gate)
- [x] All new tests pass locally (113+ tests across 6 test files)
- [x] Zero `openclaw` leakage in changed files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)