### PR TITLE
feat(runtime): add in-process session run registry

### DIFF
--- a/src/agents/session-run-registry.test.ts
+++ b/src/agents/session-run-registry.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getActiveSessionRunCount,
+  isSessionRunActive,
+  registerSessionRun,
+  resetSessionRunRegistryForTest,
+  unregisterSessionRun,
+} from "./session-run-registry.js";
+
+describe("session-run-registry", () => {
+  afterEach(() => {
+    resetSessionRunRegistryForTest();
+  });
+
+  it("returns false for unknown session key", () => {
+    expect(isSessionRunActive("unknown:key")).toBe(false);
+  });
+
+  it("returns true after registering a session run", () => {
+    registerSessionRun("session-1", {
+      startedAt: Date.now(),
+      sessionKey: "session-1",
+      agentId: "main",
+    });
+    expect(isSessionRunActive("session-1")).toBe(true);
+  });
+
+  it("returns false after unregistering a session run", () => {
+    registerSessionRun("session-1", {
+      startedAt: Date.now(),
+      sessionKey: "session-1",
+      agentId: "main",
+    });
+    unregisterSessionRun("session-1");
+    expect(isSessionRunActive("session-1")).toBe(false);
+  });
+
+  it("tracks correct count for multiple concurrent sessions", () => {
+    expect(getActiveSessionRunCount()).toBe(0);
+
+    registerSessionRun("session-a", {
+      startedAt: Date.now(),
+      sessionKey: "session-a",
+      agentId: "main",
+    });
+    expect(getActiveSessionRunCount()).toBe(1);
+
+    registerSessionRun("session-b", {
+      startedAt: Date.now(),
+      sessionKey: "session-b",
+      agentId: "claude",
+    });
+    expect(getActiveSessionRunCount()).toBe(2);
+
+    unregisterSessionRun("session-a");
+    expect(getActiveSessionRunCount()).toBe(1);
+
+    unregisterSessionRun("session-b");
+    expect(getActiveSessionRunCount()).toBe(0);
+  });
+
+  it("unregister is a no-op for unknown keys", () => {
+    unregisterSessionRun("nonexistent");
+    expect(getActiveSessionRunCount()).toBe(0);
+  });
+
+  it("cleanup works via finally pattern (simulated crash)", () => {
+    const sessionKey = "crash-test";
+    registerSessionRun(sessionKey, {
+      startedAt: Date.now(),
+      sessionKey,
+      agentId: "main",
+    });
+    expect(isSessionRunActive(sessionKey)).toBe(true);
+
+    try {
+      throw new Error("simulated crash");
+    } catch {
+      // swallow
+    } finally {
+      unregisterSessionRun(sessionKey);
+    }
+    expect(isSessionRunActive(sessionKey)).toBe(false);
+  });
+
+  it("overwrite on re-register with same key", () => {
+    registerSessionRun("session-1", {
+      startedAt: 1000,
+      sessionKey: "session-1",
+      agentId: "first",
+    });
+    registerSessionRun("session-1", {
+      startedAt: 2000,
+      sessionKey: "session-1",
+      agentId: "second",
+    });
+    expect(getActiveSessionRunCount()).toBe(1);
+    expect(isSessionRunActive("session-1")).toBe(true);
+  });
+});

--- a/src/agents/session-run-registry.ts
+++ b/src/agents/session-run-registry.ts
@@ -1,0 +1,41 @@
+/**
+ * In-process registry tracking which sessions currently have an active
+ * CLI agent subprocess (ChannelBridge turn).
+ *
+ * Replaces the conceptual role of the Pi engine's ACTIVE_EMBEDDED_RUNS Map
+ * that was stubbed to false/0 during Pi removal (b27cecc795, #76/#77).
+ */
+
+export type SessionRunHandle = {
+  startedAt: number;
+  pid?: number;
+  sessionKey: string;
+  agentId: string;
+};
+
+const ACTIVE_SESSION_RUNS = new Map<string, SessionRunHandle>();
+
+/** Check whether a session currently has an active CLI agent turn. */
+export function isSessionRunActive(sessionKey: string): boolean {
+  return ACTIVE_SESSION_RUNS.has(sessionKey);
+}
+
+/** Return the number of currently active session runs. */
+export function getActiveSessionRunCount(): number {
+  return ACTIVE_SESSION_RUNS.size;
+}
+
+/** Register an active session run. */
+export function registerSessionRun(sessionKey: string, handle: SessionRunHandle): void {
+  ACTIVE_SESSION_RUNS.set(sessionKey, handle);
+}
+
+/** Unregister a session run (on turn completion or crash). */
+export function unregisterSessionRun(sessionKey: string): void {
+  ACTIVE_SESSION_RUNS.delete(sessionKey);
+}
+
+/** Reset registry — only for tests. */
+export function resetSessionRunRegistryForTest(): void {
+  ACTIVE_SESSION_RUNS.clear();
+}

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { listAgentIds } from "../../agents/agent-scope.js";
+import { registerSessionRun, unregisterSessionRun } from "../../agents/session-run-registry.js";
 import { BARE_SESSION_RESET_PROMPT } from "../../auto-reply/reply/session-reset-prompt.js";
 import { CHANNEL_IDS, type ChatChannelId } from "../../channels/registry.js";
 import { agentCommand } from "../../commands/agent.js";
@@ -612,6 +613,15 @@ export const agentHandlers: GatewayRequestHandlers = {
 
     const resolvedThreadId = explicitThreadId ?? deliveryPlan.resolvedThreadId;
 
+    // Track active session run for concurrency visibility
+    if (resolvedSessionKey) {
+      registerSessionRun(resolvedSessionKey, {
+        startedAt: Date.now(),
+        sessionKey: resolvedSessionKey,
+        agentId: agentId ?? "main",
+      });
+    }
+
     void agentCommand(
       {
         message,
@@ -681,6 +691,11 @@ export const agentHandlers: GatewayRequestHandlers = {
           runId,
           error: formatForLog(err),
         });
+      })
+      .finally(() => {
+        if (resolvedSessionKey) {
+          unregisterSessionRun(resolvedSessionKey);
+        }
       });
   },
   "agent.identity.get": ({ params, respond }) => {

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { registerSessionRun, unregisterSessionRun } from "../agents/session-run-registry.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import { logDebug } from "../logger.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
@@ -158,6 +159,12 @@ export class ChannelBridge {
       let workspaceDir = this.#workspaceDir;
       let hookEnv: Record<string, string> | undefined;
       const runId = randomUUID();
+      const sessionKeyStr = formatSessionKeyString(sessionKey);
+      registerSessionRun(sessionKeyStr, {
+        startedAt: Date.now(),
+        sessionKey: sessionKeyStr,
+        agentId: message.agentId ?? "default",
+      });
 
       // Hook: before_runtime_spawn — extensions can modify env and workspaceDir
       if (hookRunner?.hasHooks("before_runtime_spawn")) {
@@ -333,6 +340,7 @@ export class ChannelBridge {
         error: lastError,
       };
     } finally {
+      unregisterSessionRun(formatSessionKeyString(sessionKey));
       // Cleanup temp directory
       await rm(invocationDir, { recursive: true, force: true }).catch(() => {});
     }


### PR DESCRIPTION
## Summary

- Add `src/agents/session-run-registry.ts` with `SessionRunHandle` type and in-memory `Map<string, SessionRunHandle>` registry exposing `isSessionRunActive()`, `getActiveSessionRunCount()`, `registerSessionRun()`, `unregisterSessionRun()`
- Instrument gateway `agent` method handler (`src/gateway/server-methods/agent.ts`) — register before `agentCommand()`, unregister in `.finally()` block
- Instrument `ChannelBridge.handle()` (`src/middleware/channel-bridge.ts`) — register after `runId` creation, unregister in existing `finally` block
- Add 7 unit tests covering all acceptance criteria

Closes #2090

## Test plan

- [x] `isSessionRunActive()` returns `true` for active sessions
- [x] `isSessionRunActive()` returns `false` for inactive sessions
- [x] Registry entry cleaned up on crash (finally block)
- [x] `getActiveSessionRunCount()` returns correct count for concurrent sessions
- [x] Overwrite semantics for same session key
- [x] No-op unregister for unknown keys
- [x] `pnpm check` passes (format + typecheck + lint)
- [x] `pnpm test` passes (988/989 files, pre-existing failure in update-cli.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)