### PR TITLE
feat(runtime): integrate session run registry at Pi stub replacement sites

### DIFF
--- a/src/agents/session-run-registry.test.ts
+++ b/src/agents/session-run-registry.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   getActiveSessionRunCount,
+  getSessionRunHandle,
   isSessionRunActive,
+  killSessionRun,
   registerSessionRun,
   resetSessionRunRegistryForTest,
   unregisterSessionRun,
+  waitForSessionRunEnd,
 } from "./session-run-registry.js";
 
 describe("session-run-registry", () => {
@@ -96,5 +99,82 @@ describe("session-run-registry", () => {
     });
     expect(getActiveSessionRunCount()).toBe(1);
     expect(isSessionRunActive("session-1")).toBe(true);
+  });
+
+  describe("getSessionRunHandle", () => {
+    it("returns undefined for unknown key", () => {
+      expect(getSessionRunHandle("unknown")).toBeUndefined();
+    });
+
+    it("returns the registered handle", () => {
+      registerSessionRun("session-1", {
+        startedAt: 1000,
+        sessionKey: "session-1",
+        agentId: "main",
+      });
+      const handle = getSessionRunHandle("session-1");
+      expect(handle).toBeDefined();
+      expect(handle!.startedAt).toBe(1000);
+      expect(handle!.agentId).toBe("main");
+    });
+  });
+
+  describe("killSessionRun", () => {
+    it("returns false for unknown key", () => {
+      expect(killSessionRun("unknown")).toBe(false);
+    });
+
+    it("aborts via AbortController when present", () => {
+      const ctrl = new AbortController();
+      registerSessionRun("session-1", {
+        startedAt: Date.now(),
+        sessionKey: "session-1",
+        agentId: "main",
+        abortController: ctrl,
+      });
+      expect(ctrl.signal.aborted).toBe(false);
+      expect(killSessionRun("session-1")).toBe(true);
+      expect(ctrl.signal.aborted).toBe(true);
+    });
+
+    it("returns false when AbortController is already aborted and no PID", () => {
+      const ctrl = new AbortController();
+      ctrl.abort();
+      registerSessionRun("session-1", {
+        startedAt: Date.now(),
+        sessionKey: "session-1",
+        agentId: "main",
+        abortController: ctrl,
+      });
+      expect(killSessionRun("session-1")).toBe(false);
+    });
+  });
+
+  describe("waitForSessionRunEnd", () => {
+    it("resolves true immediately when no active run", async () => {
+      const result = await waitForSessionRunEnd("unknown", 100);
+      expect(result).toBe(true);
+    });
+
+    it("resolves true when run is unregistered before timeout", async () => {
+      registerSessionRun("session-1", {
+        startedAt: Date.now(),
+        sessionKey: "session-1",
+        agentId: "main",
+      });
+      setTimeout(() => unregisterSessionRun("session-1"), 30);
+      const result = await waitForSessionRunEnd("session-1", 500);
+      expect(result).toBe(true);
+    });
+
+    it("resolves false on timeout", async () => {
+      registerSessionRun("session-1", {
+        startedAt: Date.now(),
+        sessionKey: "session-1",
+        agentId: "main",
+      });
+      const result = await waitForSessionRunEnd("session-1", 80);
+      expect(result).toBe(false);
+    });
   });
 });

--- a/src/agents/session-run-registry.ts
+++ b/src/agents/session-run-registry.ts
@@ -11,6 +11,7 @@ export type SessionRunHandle = {
   pid?: number;
   sessionKey: string;
   agentId: string;
+  abortController?: AbortController;
 };
 
 const ACTIVE_SESSION_RUNS = new Map<string, SessionRunHandle>();
@@ -33,6 +34,56 @@ export function registerSessionRun(sessionKey: string, handle: SessionRunHandle)
 /** Unregister a session run (on turn completion or crash). */
 export function unregisterSessionRun(sessionKey: string): void {
   ACTIVE_SESSION_RUNS.delete(sessionKey);
+}
+
+/** Retrieve the handle for an active session run, if any. */
+export function getSessionRunHandle(sessionKey: string): SessionRunHandle | undefined {
+  return ACTIVE_SESSION_RUNS.get(sessionKey);
+}
+
+/**
+ * Kill an active session run by aborting its controller or sending SIGTERM to its PID.
+ * Returns `true` if a kill signal was dispatched.
+ */
+export function killSessionRun(sessionKey: string): boolean {
+  const handle = ACTIVE_SESSION_RUNS.get(sessionKey);
+  if (!handle) {
+    return false;
+  }
+  if (handle.abortController && !handle.abortController.signal.aborted) {
+    handle.abortController.abort();
+    return true;
+  }
+  if (typeof handle.pid === "number") {
+    try {
+      process.kill(handle.pid, "SIGTERM");
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/**
+ * Wait (poll) for a session run to end.
+ * Resolves `true` if the run ended, `false` on timeout.
+ */
+export async function waitForSessionRunEnd(
+  sessionKey: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (!ACTIVE_SESSION_RUNS.has(sessionKey)) {
+    return true;
+  }
+  const deadline = Date.now() + timeoutMs;
+  while (ACTIVE_SESSION_RUNS.has(sessionKey)) {
+    if (Date.now() >= deadline) {
+      return false;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return true;
 }
 
 /** Reset registry — only for tests. */

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -27,6 +27,7 @@ import {
   buildAnnounceIdempotencyKey,
   resolveQueueAnnounceId,
 } from "./announce-idempotency.js";
+import { isSessionRunActive } from "./session-run-registry.js";
 import { type AnnounceQueueItem, enqueueAnnounce } from "./subagent-announce-queue.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.js";
@@ -664,7 +665,7 @@ async function maybeQueueSubagentAnnounce(params: {
     channel: entry?.channel ?? entry?.lastChannel,
     sessionEntry: entry,
   });
-  const isActive = false;
+  const isActive = isSessionRunActive(canonicalKey);
 
   const shouldFollowup =
     queueSettings.mode === "followup" ||
@@ -1128,7 +1129,7 @@ export async function runSubagentAnnounceFlow(params: {
     const settleTimeoutMs = Math.min(Math.max(params.timeoutMs, 1), 120_000);
     let reply = params.roundOneReply;
     let outcome: SubagentRunOutcome | undefined = params.outcome;
-    // Embedded engine removed (#74); no active runs to settle.
+    // Session runs tracked via session-run-registry; gateway handles waits for cross-process runs.
 
     if (!reply && params.waitForCompletion !== false) {
       const waitMs = settleTimeoutMs;
@@ -1178,7 +1179,7 @@ export async function runSubagentAnnounceFlow(params: {
       });
     }
 
-    // Embedded engine removed (#74); no active runs to check.
+    // Session runs tracked via session-run-registry; no embedded run state to check here.
 
     if (isAnnounceSkip(reply)) {
       return true;

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -1,4 +1,5 @@
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { killSessionRun } from "../../agents/session-run-registry.js";
 import {
   listSubagentRunsForRequester,
   markSubagentRunTerminated,
@@ -241,6 +242,7 @@ export function stopSubagentsForRequester(params: {
           childSessionKey: childKey,
           reason: "killed",
         }) > 0;
+      killSessionRun(childKey);
 
       if (markedTerminated || cleared.followupCleared > 0 || cleared.laneCleared > 0) {
         stopped += 1;
@@ -328,12 +330,18 @@ export async function tryFastAbortFromMessage(params: {
     } else if (abortKey) {
       setAbortMemory(abortKey, true);
     }
+    if (requesterSessionKey) {
+      killSessionRun(requesterSessionKey);
+    }
     const { stopped } = stopSubagentsForRequester({ cfg, requesterSessionKey });
     return { handled: true, aborted: false, stoppedSubagents: stopped };
   }
 
   if (abortKey) {
     setAbortMemory(abortKey, true);
+  }
+  if (requesterSessionKey) {
+    killSessionRun(requesterSessionKey);
   }
   const { stopped } = stopSubagentsForRequester({ cfg, requesterSessionKey });
   return { handled: true, aborted: false, stoppedSubagents: stopped };

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { isSessionRunActive } from "../../agents/session-run-registry.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import {
   resolveGroupSessionKey,
@@ -351,7 +352,7 @@ export async function runPreparedReply(
     logVerbose(`Interrupting ${sessionLaneKey} (cleared ${cleared})`);
   }
   const queueKey = sessionKey ?? sessionIdFinal;
-  const isActive = false;
+  const isActive = isSessionRunActive(queueKey);
   const shouldFollowup =
     resolvedQueue.mode === "followup" ||
     resolvedQueue.mode === "collect" ||

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { killSessionRun, waitForSessionRunEnd } from "../../agents/session-run-registry.js";
 import {
   listSubagentRunsForRequester,
   markSubagentRunTerminated,
@@ -189,7 +190,9 @@ async function ensureSessionRuntimeCleanup(params: {
     queueKeys.add(params.sessionId);
   }
   clearSessionQueues([...queueKeys]);
+  killSessionRun(params.target.canonicalKey);
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
+  await waitForSessionRunEnd(params.target.canonicalKey, 5_000);
   return undefined;
 }
 

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1,3 +1,4 @@
+import { getActiveSessionRunCount } from "../agents/session-run-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CliDeps } from "../cli/deps.js";
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
@@ -151,7 +152,7 @@ export function createGatewayReloadHandlers(params: {
     const getActiveCounts = () => {
       const queueSize = getTotalQueueSize();
       const pendingReplies = getTotalPendingReplies();
-      const embeddedRuns = 0;
+      const embeddedRuns = getActiveSessionRunCount();
       return {
         queueSize,
         pendingReplies,

--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -253,7 +253,7 @@ describe("ChannelBridge", () => {
       expect(params.workingDirectory).toBe("/my/workspace");
     });
 
-    it("forwards abortSignal to runtime", async () => {
+    it("forwards abortSignal to runtime (combined with internal controller)", async () => {
       const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
       mockRuntimeInstance = { execute: executeFn };
 
@@ -262,7 +262,11 @@ describe("ChannelBridge", () => {
       await bridge.handle(makeMessage(), undefined, controller.signal);
 
       const params = executeFn.mock.calls[0][0];
-      expect(params.abortSignal).toBe(controller.signal);
+      // Signal is combined via AbortSignal.any(); aborting external controller propagates.
+      expect(params.abortSignal).toBeDefined();
+      expect(params.abortSignal!.aborted).toBe(false);
+      controller.abort();
+      expect(params.abortSignal!.aborted).toBe(true);
     });
 
     it("includes MCP server config in runtime params", async () => {

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -160,11 +160,16 @@ export class ChannelBridge {
       let hookEnv: Record<string, string> | undefined;
       const runId = randomUUID();
       const sessionKeyStr = formatSessionKeyString(sessionKey);
+      const internalAbortCtrl = new AbortController();
       registerSessionRun(sessionKeyStr, {
         startedAt: Date.now(),
         sessionKey: sessionKeyStr,
         agentId: message.agentId ?? "default",
+        abortController: internalAbortCtrl,
       });
+      const combinedSignal = abortSignal
+        ? AbortSignal.any([abortSignal, internalAbortCtrl.signal])
+        : internalAbortCtrl.signal;
 
       // Hook: before_runtime_spawn — extensions can modify env and workspaceDir
       if (hookRunner?.hasHooks("before_runtime_spawn")) {
@@ -238,7 +243,7 @@ export class ChannelBridge {
             media: supportedMedia?.length ? supportedMedia : undefined,
             sessionId: existingSessionId,
             mcpServers,
-            abortSignal,
+            abortSignal: combinedSignal,
             workingDirectory: workspaceDir,
             env: this.#runtimeEnv || hookEnv ? { ...this.#runtimeEnv, ...hookEnv } : undefined,
             extraArgs: this.#runtimeArgs,


### PR DESCRIPTION
## Summary

Integrates the session run registry (#2090) at all Pi stub replacement sites identified in #2091.

- **Registry API additions**: `getSessionRunHandle`, `killSessionRun` (AbortController-first, SIGTERM fallback), `waitForSessionRunEnd` (poll-based), `AbortController` field on `SessionRunHandle`
- **ChannelBridge**: Internal `AbortController` stored on registry handle and combined with external signal via `AbortSignal.any()` — enables remote kill from abort/cleanup paths
- **Stub replacements**: `isActive = false` → `isSessionRunActive()` (sites 1, 3), `embeddedRuns = 0` → `getActiveSessionRunCount()` (site 10)
- **Abort integration**: `killSessionRun` wired into `stopSubagentsForRequester` cascade and `tryFastAbortFromMessage` (sites 4-6)
- **Session cleanup**: `killSessionRun` + `waitForSessionRunEnd` in `ensureSessionRuntimeCleanup` (sites 7, 9)
- **Comment updates**: Stale "Embedded engine removed" comments replaced with registry references (site 2)
- **Site 11**: N/A per issue — CLI subprocesses don't accept injected messages

## Test plan

- [x] New tests for `getSessionRunHandle`, `killSessionRun`, `waitForSessionRunEnd` (6 tests)
- [x] Updated channel-bridge test for combined abort signal behavior
- [x] All 15 session-run-registry tests pass
- [x] All 72 channel-bridge tests pass
- [x] Full unit suite: 8462 passed (3 pre-existing failures in update-cli.test.ts, unrelated)
- [x] `pnpm check` (format + typecheck + lint) passes

Closes #2091

🤖 Generated with [Claude Code](https://claude.com/claude-code)