### PR TITLE
fix(gateway): wire auth profile env injection into agentCommand (#2100)

### DIFF
--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -28,6 +28,7 @@ type BridgeConstructorOpts = {
   gatewayUrl: string;
   gatewayToken: string;
   workspaceDir?: string;
+  runtimeEnv?: Record<string, string>;
 };
 
 const bridgeHandleMock =
@@ -77,6 +78,15 @@ vi.mock("../middleware/channel-bridge.js", () => ({
       return bridgeHandleMock(message, callbacks, abortSignal);
     }
   },
+}));
+
+// ── withAuthKeyRetry mock ──────────────────────────────────────────────
+
+const { withAuthKeyRetryMock } = vi.hoisted(() => ({
+  withAuthKeyRetryMock: vi.fn(),
+}));
+vi.mock("../middleware/auth-key-retry.js", () => ({
+  withAuthKeyRetry: withAuthKeyRetryMock,
 }));
 
 vi.mock("../config/paths.js", async (importOriginal) => {
@@ -205,6 +215,14 @@ beforeEach(() => {
   bridgeConstructorCalls.length = 0;
   bridgeHandleMock.mockResolvedValue(defaultBridgeResult());
   loadModelCatalogMock?.mockResolvedValue([]);
+
+  // Default: withAuthKeyRetry passes through to the execute callback
+  withAuthKeyRetryMock.mockImplementation(
+    async (
+      options: { baseEnv?: Record<string, string> },
+      execute: (env: Record<string, string>) => Promise<unknown>,
+    ) => execute(options.baseEnv ?? {}),
+  );
 });
 
 describe("agentCommand", () => {
@@ -668,6 +686,100 @@ describe("agentCommand", () => {
       });
 
       expect(runtime.log).toHaveBeenCalledWith("ok");
+    });
+  });
+
+  it("wraps bridge execution with withAuthKeyRetry", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+
+      await agentCommand({ message: "hi", to: "+1555" }, runtime);
+
+      expect(withAuthKeyRetryMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("passes agentId to withAuthKeyRetry options", async () => {
+    await withTempHome(async (home) => {
+      await runWithDefaultAgentConfig({
+        home,
+        args: { message: "hi", agentId: "ops" },
+        agentsList: [{ id: "ops" }],
+      });
+
+      const options = withAuthKeyRetryMock.mock.calls[0][0];
+      expect(options.agentId).toBe("ops");
+    });
+  });
+
+  it("passes cfg to withAuthKeyRetry options", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+
+      await agentCommand({ message: "hi", to: "+1555" }, runtime);
+
+      const options = withAuthKeyRetryMock.mock.calls[0][0];
+      expect(options.cfg).toBeDefined();
+      expect(options.cfg.agents).toBeDefined();
+    });
+  });
+
+  it("provides error extractor that reads result.error", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+
+      await agentCommand({ message: "hi", to: "+1555" }, runtime);
+
+      const getErrorMessage = withAuthKeyRetryMock.mock.calls[0][2];
+      expect(getErrorMessage({ error: "rate limit exceeded" })).toBe("rate limit exceeded");
+      expect(getErrorMessage({ error: undefined })).toBeUndefined();
+    });
+  });
+
+  it("creates ChannelBridge with runtimeEnv from withAuthKeyRetry callback", async () => {
+    const injectedEnv = {
+      CLAUDE_CONFIG_DIR: "/custom/config",
+      ANTHROPIC_API_KEY: "sk-test-injected",
+    };
+
+    withAuthKeyRetryMock.mockImplementation(
+      async (_options: unknown, execute: (env: Record<string, string>) => Promise<unknown>) =>
+        execute(injectedEnv),
+    );
+
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+
+      await agentCommand({ message: "hi", to: "+1555" }, runtime);
+
+      const lastBridgeOpts = bridgeConstructorCalls.at(-1);
+      expect(lastBridgeOpts?.runtimeEnv).toEqual(injectedEnv);
+    });
+  });
+
+  it("re-throws bridge errors with no payloads for auth retry eligibility", async () => {
+    withAuthKeyRetryMock.mockImplementation(
+      async (_options: unknown, execute: (env: Record<string, string>) => Promise<unknown>) => {
+        return execute({});
+      },
+    );
+    bridgeHandleMock.mockResolvedValueOnce({
+      ...defaultBridgeResult(),
+      payloads: [],
+      error: "Not logged in",
+    });
+
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+
+      await expect(agentCommand({ message: "hi", to: "+1555" }, runtime)).rejects.toThrow(
+        "Not logged in",
+      );
     });
   });
 });

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -31,6 +31,7 @@ import {
   emitAgentEvent,
   registerAgentRunContext,
 } from "../infra/agent-events.js";
+import { withAuthKeyRetry } from "../middleware/auth-key-retry.js";
 import { ChannelBridge } from "../middleware/channel-bridge.js";
 import type { SessionMap } from "../middleware/session-map.js";
 import type { AgentDeliveryResult, ChannelMessage } from "../middleware/types.js";
@@ -288,15 +289,7 @@ export async function agentCommand(
         getSessionId: () => getCliSessionId(sessionEntry, provider),
       });
 
-      const bridge = new ChannelBridge({
-        provider: resolveAgentRuntimeOrThrow(cfg, sessionAgentId),
-        sessionMap,
-        gatewayUrl: resolveGatewayUrlFromConfig(cfg),
-        gatewayToken: resolveGatewayTokenFromConfig(cfg),
-        workspaceDir,
-        runtimeArgs: resolveAgentRuntimeArgs(cfg, sessionAgentId),
-        runtimeEnv: resolveAgentRuntimeEnv(cfg, sessionAgentId),
-      });
+      const baseRuntimeEnv = resolveAgentRuntimeEnv(cfg, sessionAgentId);
 
       const messageToolHints = resolveChannelMessageToolHints({
         cfg,
@@ -315,7 +308,30 @@ export async function agentCommand(
         messageToolHints,
       });
 
-      result = await bridge.handle(message, undefined, opts.abortSignal);
+      // Execute with auth key retry — rotates to next profile on rate-limit/auth errors.
+      result = await withAuthKeyRetry<AgentDeliveryResult>(
+        { cfg, agentId: sessionAgentId, baseEnv: baseRuntimeEnv },
+        async (runtimeEnv) => {
+          const bridge = new ChannelBridge({
+            provider: resolveAgentRuntimeOrThrow(cfg, sessionAgentId),
+            sessionMap,
+            gatewayUrl: resolveGatewayUrlFromConfig(cfg),
+            gatewayToken: resolveGatewayTokenFromConfig(cfg),
+            workspaceDir,
+            runtimeArgs: resolveAgentRuntimeArgs(cfg, sessionAgentId),
+            runtimeEnv,
+          });
+
+          const bridgeResult = await bridge.handle(message, undefined, opts.abortSignal);
+
+          if (bridgeResult.error && bridgeResult.payloads.length === 0) {
+            throw new Error(bridgeResult.error);
+          }
+
+          return bridgeResult;
+        },
+        (bridgeResult) => bridgeResult.error,
+      );
       emitAgentEvent({
         runId,
         stream: "lifecycle",


### PR DESCRIPTION
## Summary

- Wrap `ChannelBridge` execution in `agentCommand()` with `withAuthKeyRetry`, mirroring the auto-reply path at `agent-runner-execution.ts:376-403`
- Announce-triggered main session turns now receive auth credentials via `resolveAuthEnv()`
- Re-throws on complete runtime failure (no payloads) for retry eligibility, same as auto-reply path

## Context

The gateway `agent` method (used by the announce flow for cron delivery) called `agentCommand()` which created a `ChannelBridge` with `resolveAgentRuntimeEnv()` only — providing `CLAUDE_CONFIG_DIR` but not auth tokens. The `withAuthKeyRetry` wrapper that injects `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` was never invoked, causing `[CLI_ERROR] Not logged in` on announce-triggered turns.

Interactive messages worked because the auto-reply path already uses `withAuthKeyRetry`.

Closes #2100

## Test plan

- [x] Type-check passes (`pnpm tsgo`)
- [x] `src/middleware/auth-key-retry.test.ts` — 10 tests pass
- [x] `src/gateway/server-methods/agent.test.ts` — 11 tests pass
- [ ] LIVE: Configure agent with `auth: "claude:profile"`, create isolated cron job with `--announce`, verify main session turn receives auth credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)