### PR TITLE
refactor: clean up stale Pi/embedded naming (#2096)

### DIFF
--- a/src/agents/session-run-registry.ts
+++ b/src/agents/session-run-registry.ts
@@ -2,8 +2,8 @@
  * In-process registry tracking which sessions currently have an active
  * CLI agent subprocess (ChannelBridge turn).
  *
- * Replaces the conceptual role of the Pi engine's ACTIVE_EMBEDDED_RUNS Map
- * that was stubbed to false/0 during Pi removal (b27cecc795, #76/#77).
+ * Replaces the conceptual role of the former engine's active-runs map
+ * that was stubbed to false/0 during engine removal (b27cecc795, #76/#77).
  */
 
 export type SessionRunHandle = {

--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -995,7 +995,7 @@ describe("subagent announce formatting", () => {
   });
 
   it("steers announcements into an active run when queue mode is steer", async () => {
-    // pi-embedded steer path removed; queueMode "steer" now falls through to direct delivery.
+    // Steer path removed; queueMode "steer" now falls through to direct delivery.
     sessionStore = {
       "agent:main:main": {
         sessionId: "session-123",
@@ -1086,7 +1086,7 @@ describe("subagent announce formatting", () => {
   });
 
   it("returns failure for completion-mode when direct delivery fails and queue fallback is inactive", async () => {
-    // pi-embedded queue fallback removed; direct failure is terminal when no embedded run is active.
+    // Queue fallback removed; direct failure is terminal when no session run is active.
     sessionStore = {
       "agent:main:main": {
         sessionId: "session-collect",
@@ -1653,8 +1653,8 @@ describe("subagent announce formatting", () => {
     expect(sessionsDeleteSpy).not.toHaveBeenCalled();
   });
 
-  it("proceeds with announce when pi-embedded settle is no longer active", async () => {
-    // pi-embedded active check removed; announce no longer defers on embedded run activity.
+  it("proceeds with announce when no session run is active", async () => {
+    // Active-run check removed; announce no longer defers on session run activity.
     const cases = [
       {
         childRunId: "run-child-active",

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1179,7 +1179,7 @@ export async function runSubagentAnnounceFlow(params: {
       });
     }
 
-    // Session runs tracked via session-run-registry; no embedded run state to check here.
+    // Session runs tracked via session-run-registry; no run state to check here.
 
     if (isAnnounceSkip(reply)) {
       return true;

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -67,7 +67,7 @@ const MAX_ANNOUNCE_RETRY_COUNT = 3;
 const ANNOUNCE_EXPIRY_MS = 5 * 60_000; // 5 minutes
 type SubagentRunOrphanReason = "missing-session-entry" | "missing-session-id";
 /**
- * Embedded runs can emit transient lifecycle `error` events while provider/model
+ * Session runs can emit transient lifecycle `error` events while provider/model
  * retry is still in progress. Defer terminal error cleanup briefly so a
  * subsequent lifecycle `start` / `end` can cancel premature failure announces.
  */
@@ -939,7 +939,7 @@ export function registerSubagentRun(params: {
     startSweeper();
   }
   // Wait for subagent completion via gateway RPC (cross-process).
-  // The in-process lifecycle listener is a fallback for embedded runs.
+  // The in-process lifecycle listener is a fallback for session runs.
   void waitForSubagentCompletion(params.runId, waitTimeoutMs);
 }
 

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { FollowupRun } from "./queue.js";
 
-const { buildEmbeddedRunBaseParams, buildEmbeddedRunContexts, resolveModelFallbackOptions } =
+const { buildRunBaseParams, buildRunContexts, resolveModelFallbackOptions } =
   await import("./agent-runner-utils.js");
 
 function makeRun(overrides: Partial<FollowupRun["run"]> = {}): FollowupRun["run"] {
@@ -38,10 +38,10 @@ describe("agent-runner-utils", () => {
     });
   });
 
-  it("builds embedded run base params with run metadata", () => {
+  it("builds run base params with run metadata", () => {
     const run = makeRun({ enforceFinalTag: true });
 
-    const resolved = buildEmbeddedRunBaseParams({
+    const resolved = buildRunBaseParams({
       run,
       provider: "openai",
       model: "gpt-4.1-mini",
@@ -63,10 +63,10 @@ describe("agent-runner-utils", () => {
     });
   });
 
-  it("builds embedded contexts from run and session context", () => {
+  it("builds run contexts from run and session context", () => {
     const run = makeRun();
 
-    const resolved = buildEmbeddedRunContexts({
+    const resolved = buildRunContexts({
       run,
       sessionCtx: {
         Provider: "OpenAI",
@@ -77,7 +77,7 @@ describe("agent-runner-utils", () => {
       provider: "anthropic",
     });
 
-    expect(resolved.embeddedContext).toMatchObject({
+    expect(resolved.runContext).toMatchObject({
       sessionId: run.sessionId,
       sessionKey: run.sessionKey,
       agentId: run.agentId,
@@ -95,7 +95,7 @@ describe("agent-runner-utils", () => {
   it("prefers OriginatingChannel over Provider for messageProvider", () => {
     const run = makeRun();
 
-    const resolved = buildEmbeddedRunContexts({
+    const resolved = buildRunContexts({
       run,
       sessionCtx: {
         Provider: "heartbeat",
@@ -106,7 +106,7 @@ describe("agent-runner-utils", () => {
       provider: "openai",
     });
 
-    expect(resolved.embeddedContext.messageProvider).toBe("telegram");
-    expect(resolved.embeddedContext.messageTo).toBe("268300329");
+    expect(resolved.runContext.messageProvider).toBe("telegram");
+    expect(resolved.runContext.messageTo).toBe("268300329");
   });
 });

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -154,7 +154,7 @@ export function resolveModelFallbackOptions(run: FollowupRun["run"]) {
   };
 }
 
-export function buildEmbeddedRunBaseParams(params: {
+export function buildRunBaseParams(params: {
   run: FollowupRun["run"];
   provider: string;
   model: string;
@@ -176,7 +176,7 @@ export function buildEmbeddedRunBaseParams(params: {
   };
 }
 
-export function buildEmbeddedContextFromTemplate(params: {
+export function buildRunContextFromTemplate(params: {
   run: FollowupRun["run"];
   sessionCtx: TemplateContext;
   hasRepliedRef: { value: boolean } | undefined;
@@ -213,14 +213,14 @@ export function buildTemplateSenderContext(sessionCtx: TemplateContext) {
   };
 }
 
-export function buildEmbeddedRunContexts(params: {
+export function buildRunContexts(params: {
   run: FollowupRun["run"];
   sessionCtx: TemplateContext;
   hasRepliedRef: { value: boolean } | undefined;
   provider: string;
 }) {
   return {
-    embeddedContext: buildEmbeddedContextFromTemplate({
+    runContext: buildRunContextFromTemplate({
       run: params.run,
       sessionCtx: params.sessionCtx,
       hasRepliedRef: params.hasRepliedRef,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1039,7 +1039,7 @@ describe("runReplyAgent fallback provider routing", () => {
       },
     });
 
-    // Bridge was called at least once (main run; memory flush uses runEmbeddedPiAgent directly)
+    // Bridge was called at least once (main run; memory flush is gutted)
     expect(channelBridgeHandleMock).toHaveBeenCalled();
   });
 });

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -858,8 +858,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       await fs.writeFile(transcriptPath, "ok", "utf-8");
 
       // Return an AgentDeliveryResult with context overflow error.
-      // The production code maps this via mapToEmbeddedPiRunResult which
-      // produces meta.error.kind === "context_overflow".
+      // The production code maps this to meta.error.kind === "context_overflow".
       state.channelBridgeHandleMock.mockImplementationOnce(async () =>
         makeDeliveryResult({
           payloads: [{ text: "Context overflow: prompt too large", isError: true }],
@@ -906,31 +905,8 @@ describe("runReplyAgent typing (heartbeat)", () => {
       await fs.writeFile(transcriptPath, "ok", "utf-8");
 
       // Return an AgentDeliveryResult with role_ordering error.
-      // mapToEmbeddedPiRunResult does NOT map this to meta.error
-      // (only context_window maps to meta.error). But the production code
-      // in agent-runner-execution.ts checks delivery.error and delivery.payloads.
-      // Since payloads is non-empty, it won't throw. The error is surfaced
-      // via the mapped EmbeddedPiRunResult meta.error.kind === "role_ordering".
-      // Let's check what mapToEmbeddedPiRunResult does...
-      // Actually: mapToEmbeddedPiRunResult only sets meta.error for
-      // errorSubtype === "context_window". For role_ordering, the error
-      // needs to be thrown or handled differently.
-      // Looking at the production code again: the old mock returned
-      // meta.error.kind === "role_ordering". Let me check how the
-      // production code surfaces that.
-      // The old code: runEmbeddedPiAgent returned { payloads, meta: { error: { kind: "role_ordering", message } } }
-      // In the new code: mapToEmbeddedPiRunResult only maps context_window to meta.error.
-      // So role_ordering must come through a different path.
-      // Actually, looking at agent-runner-execution.ts lines 474: it checks
-      // bridgeError?.kind === "role_ordering". And bridgeError comes from
-      // runResult.meta?.error. So mapToEmbeddedPiRunResult must produce this.
-      // But looking at the code, only context_window errorSubtype maps to meta.error.
-      // Wait - let me re-read. The role_ordering may be thrown as an exception instead.
-      // Actually, if the bridge returns an error with no payloads, the production
-      // code at line 384-386 throws: throw new Error(delivery.error).
-      // Then the catch block at line 491-492 checks isRoleOrderingError.
-      // So for role ordering, the bridge should return error with empty payloads,
-      // which triggers the throw, which hits the catch.
+      // The bridge returns an error with empty payloads, which triggers a throw
+      // in the production code. The catch block then checks isRoleOrderingError.
       state.channelBridgeHandleMock.mockImplementationOnce(async () =>
         makeDeliveryResult({
           payloads: [],
@@ -1165,12 +1141,12 @@ describe("runReplyAgent memory flush", () => {
 
       // Main run goes through ChannelBridge
       expect(state.channelBridgeHandleMock).toHaveBeenCalledTimes(1);
-      // Memory flush does NOT run for CLI providers, so runEmbeddedPiAgent should not be called
+      // Memory flush does NOT run for CLI providers
       expect(state.runAgentMock).not.toHaveBeenCalled();
     });
   });
 
-  it("does not run memory flush (embedded engine removed)", async () => {
+  it("does not run memory flush (engine removed)", async () => {
     await withTempStore(async (storePath) => {
       const sessionKey = "main";
       const sessionEntry = {
@@ -1202,7 +1178,7 @@ describe("runReplyAgent memory flush", () => {
         commandBody: "hello",
       });
 
-      // Memory flush is gutted (#74) — runEmbeddedPiAgent should NOT be called
+      // Memory flush is gutted (#74) — no separate agent call expected
       expect(state.runAgentMock).not.toHaveBeenCalled();
       // Main run uses ChannelBridge
       expect(state.channelBridgeHandleMock).toHaveBeenCalledTimes(1);

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -278,7 +278,7 @@ export async function runPreparedReply(
     };
   }
   // When the user sends media without text, provide a minimal body so the agent
-  // run proceeds and the image/document is injected by the embedded runner.
+  // run proceeds and the image/document is injected by the agent runtime.
   const effectiveBaseBody = baseBodyTrimmed
     ? baseBodyForPrompt
     : "[User sent media without caption]";

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -2,7 +2,7 @@ import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.js"
 
 /**
  * OpenAI-compatible function-calling tool definition.
- * Previously imported from the pi-embedded-runner; inlined after engine
+ * OpenAI-compatible function-calling tool definition, inlined after engine
  * removal (#74).
  */
 export type ClientToolDefinition = {
@@ -70,7 +70,7 @@ export type AgentCommandOpts = {
   channel?: string; // delivery channel (whatsapp|telegram|...)
   /** Account ID for multi-account channel routing (e.g., WhatsApp account). */
   accountId?: string;
-  /** Context for embedded run routing (channel/account/thread). */
+  /** Context for session run routing (channel/account/thread). */
   runContext?: AgentRunContext;
   /** Group id for channel-level tool policy resolution. */
   groupId?: string | null;

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -30,7 +30,7 @@ export const FIELD_HELP: Record<string, string> = {
   "diagnostics.otel":
     "OpenTelemetry export settings for traces, metrics, and logs emitted by gateway components. Use this when integrating with centralized observability backends and distributed tracing pipelines.",
   "diagnostics.cacheTrace":
-    "Cache-trace logging settings for observing cache decisions and payload context in embedded runs. Enable this temporarily for debugging and disable afterward to reduce sensitive log footprint.",
+    "Cache-trace logging settings for observing cache decisions and payload context in session runs. Enable this temporarily for debugging and disable afterward to reduce sensitive log footprint.",
   logging:
     "Logging behavior controls for severity, output destinations, formatting, and sensitive-data redaction. Keep levels and redaction strict enough for production while preserving useful diagnostics.",
   "logging.level":
@@ -426,7 +426,7 @@ export const FIELD_HELP: Record<string, string> = {
   "diagnostics.otel.flushIntervalMs":
     "Interval in milliseconds for periodic telemetry flush from buffers to the collector. Increase to reduce export chatter, or lower for faster visibility during active incident response.",
   "diagnostics.cacheTrace.enabled":
-    "Log cache trace snapshots for embedded agent runs (default: false).",
+    "Log cache trace snapshots for agent session runs (default: false).",
   "diagnostics.cacheTrace.filePath":
     "JSONL output path for cache trace logs (default: $REMOTECLAW_STATE_DIR/logs/cache-trace.jsonl).",
   "diagnostics.cacheTrace.includeMessages":

--- a/src/cron/isolated-agent/run.channel-bridge.test.ts
+++ b/src/cron/isolated-agent/run.channel-bridge.test.ts
@@ -324,7 +324,7 @@ describe("runCronIsolatedAgentTurn — ChannelBridge wiring", () => {
     expect(abortSignal).toBe(controller.signal);
   });
 
-  it("maps AgentDeliveryResult payloads to EmbeddedPiRunResult format", async () => {
+  it("maps AgentDeliveryResult payloads to run result format", async () => {
     channelBridgeHandleMock.mockResolvedValue(
       makeDeliveryResult({
         payloads: [{ text: "Hello from cron" }],

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -486,14 +486,14 @@ export async function runCronIsolatedAgentTurn(params: {
     .toReversed()
     .find((payload) => payload?.isError === true && Boolean(payload?.text?.trim()))
     ?.text?.trim();
-  const embeddedRunError = hasErrorPayload
+  const runError = hasErrorPayload
     ? (lastErrorPayloadText ?? "cron isolated run returned an error payload")
     : undefined;
   const resolveRunOutcome = (params?: { delivered?: boolean; deliveryAttempted?: boolean }) =>
     withRunSession({
       status: hasErrorPayload ? "error" : "ok",
       ...(hasErrorPayload
-        ? { error: embeddedRunError ?? "cron isolated run returned an error payload" }
+        ? { error: runError ?? "cron isolated run returned an error payload" }
         : {}),
       summary,
       outputText,

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -2,7 +2,7 @@ import { onAgentEvent } from "../../infra/agent-events.js";
 
 const AGENT_RUN_CACHE_TTL_MS = 10 * 60_000;
 /**
- * Embedded runs can emit transient lifecycle `error` events while auth/model
+ * Session runs can emit transient lifecycle `error` events while auth/model
  * failover is still in progress. Give errors a short grace window so a
  * subsequent `start` event can cancel premature terminal snapshots.
  */

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -152,12 +152,12 @@ export function createGatewayReloadHandlers(params: {
     const getActiveCounts = () => {
       const queueSize = getTotalQueueSize();
       const pendingReplies = getTotalPendingReplies();
-      const embeddedRuns = getActiveSessionRunCount();
+      const sessionRuns = getActiveSessionRunCount();
       return {
         queueSize,
         pendingReplies,
-        embeddedRuns,
-        totalActive: queueSize + pendingReplies + embeddedRuns,
+        sessionRuns,
+        totalActive: queueSize + pendingReplies + sessionRuns,
       };
     };
     const formatActiveDetails = (counts: ReturnType<typeof getActiveCounts>) => {
@@ -168,8 +168,8 @@ export function createGatewayReloadHandlers(params: {
       if (counts.pendingReplies > 0) {
         details.push(`${counts.pendingReplies} reply(ies)`);
       }
-      if (counts.embeddedRuns > 0) {
-        details.push(`${counts.embeddedRuns} embedded run(s)`);
+      if (counts.sessionRuns > 0) {
+        details.push(`${counts.sessionRuns} session run(s)`);
       }
       return details;
     };

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -941,7 +941,7 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
-  // pi-embedded abort/wait was gutted (#76) — sessions.reset and sessions.delete
+  // Engine abort/wait was gutted (#76) — sessions.reset and sessions.delete
   // always succeed now; the "returns unavailable when active run does not stop"
   // error path no longer exists.
 


### PR DESCRIPTION
## Summary

- Renames `embeddedRuns`/`embeddedRunError` variables to `sessionRuns`/`runError`
- Renames `buildEmbeddedRunBaseParams` → `buildRunBaseParams`, `buildEmbeddedContextFromTemplate` → `buildRunContextFromTemplate`, `buildEmbeddedRunContexts` → `buildRunContexts`, and the `embeddedContext` return property → `runContext`
- Updates ~35 production comments, config help text, and test descriptions to remove Pi/embedded engine references in favor of current session-run-registry terminology
- Condenses verbose Pi-era analysis comments in test files
- No behavioral changes — pure rename/comment refactor

Closes #2096

## Test plan

- [x] All 128 tests in affected files pass
- [x] `pnpm check` (format + typecheck + lint) passes
- [x] No remaining `embeddedRun`/`pi-embedded`/`EmbeddedPiRun`/`runEmbeddedPi` references in production code (only valid negative assertion in system-prompt test remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)