### PR TITLE
test(cron): update cron telemetry tests for runtime field

### DIFF
--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -1,64 +1,80 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "../../agents/model-fallback.js";
-// oxlint-disable-next-line typescript/no-explicit-any
-const _runWithModelFallback = (..._args: unknown[]) => undefined as any;
+
 // ---------- mocks ----------
 
-const resolveAgentConfigMock = vi.fn();
+const channelBridgeHandleMock = vi.fn();
+
+vi.mock("../../middleware/channel-bridge.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../middleware/channel-bridge.js")>();
+  return {
+    ...actual,
+    ChannelBridge: class MockChannelBridge {
+      readonly provider: string;
+      readonly workspaceDir?: string;
+
+      constructor(opts: { provider: string; workspaceDir?: string }) {
+        this.provider = opts.provider;
+        this.workspaceDir = opts.workspaceDir;
+      }
+
+      handle(
+        message: import("../../middleware/types.js").ChannelMessage,
+        callbacks?: unknown,
+        abortSignal?: AbortSignal,
+      ) {
+        return channelBridgeHandleMock(message, callbacks, abortSignal);
+      }
+    },
+  };
+});
+
+vi.mock("../../middleware/auth-key-retry.js", () => ({
+  withAuthKeyRetry: vi.fn(
+    async (_options: unknown, execute: (env: Record<string, string>) => Promise<unknown>) =>
+      execute({}),
+  ),
+}));
+
+vi.mock("../../agents/channel-tools.js", () => ({
+  resolveChannelMessageToolHints: vi.fn().mockReturnValue([]),
+}));
 
 vi.mock("../../agents/agent-scope.js", () => ({
-  resolveAgentConfig: resolveAgentConfigMock,
+  resolveAgentConfig: vi.fn().mockReturnValue(undefined),
   resolveAgentDir: vi.fn().mockReturnValue("/tmp/agent-dir"),
-  resolveAgentModelFallbacksOverride: vi.fn().mockReturnValue(undefined),
+  resolveAgentRuntimeArgs: vi.fn().mockReturnValue(undefined),
+  resolveAgentRuntimeEnv: vi.fn().mockReturnValue(undefined),
+  resolveAgentRuntimeOrThrow: vi.fn().mockReturnValue("claude"),
   resolveAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/workspace"),
   resolveDefaultAgentId: vi.fn().mockReturnValue("default"),
-  resolveAgentSkillsFilter: vi.fn().mockReturnValue(undefined),
-}));
-
-vi.mock("../../agents/skills.js", () => ({
-  buildWorkspaceSkillSnapshot: vi.fn().mockReturnValue({
-    prompt: "<available_skills></available_skills>",
-    resolvedSkills: [],
-    version: 42,
-  }),
-}));
-
-vi.mock("../../agents/skills/refresh.js", () => ({
-  getSkillsSnapshotVersion: vi.fn().mockReturnValue(42),
 }));
 
 vi.mock("../../agents/workspace.js", () => ({
-  ensureAgentWorkspace: vi.fn().mockResolvedValue({ dir: "/tmp/workspace" }),
+  ensureAgentWorkspace: vi.fn().mockResolvedValue("/tmp/workspace"),
 }));
 
 vi.mock("../../agents/model-catalog.js", () => ({
   loadModelCatalog: vi.fn().mockResolvedValue({ models: [] }),
 }));
 
-const resolveAllowedModelRefMock = vi.fn();
-const resolveConfiguredModelRefMock = vi.fn();
-
-// Gutted in RemoteClaw fork (Middleware Boundary Principle) — model-selection mock removed
 vi.mock("../../agents/model-selection.js", () => ({
   getModelRefStatus: vi.fn().mockReturnValue({ allowed: false }),
-  isCliProvider: vi.fn().mockReturnValue(false),
-  resolveAllowedModelRef: resolveAllowedModelRefMock,
-  resolveConfiguredModelRef: resolveConfiguredModelRefMock,
+  resolveAllowedModelRef: vi
+    .fn()
+    .mockReturnValue({ ref: { provider: "claude", model: "claude-sonnet-4-5" } }),
+  resolveConfiguredModelRef: vi
+    .fn()
+    .mockReturnValue({ provider: "claude", model: "claude-sonnet-4-5" }),
   resolveHooksGmailModel: vi.fn().mockReturnValue(null),
-  resolveThinkingDefault: vi.fn().mockReturnValue(undefined),
 }));
 
-vi.mock("../../agents/model-fallback.js", () => ({
-  runWithModelFallback: vi.fn(),
-}));
-
-const { runWithModelFallback: _rwmf } = await import("../../agents/model-fallback.js");
-const runWithModelFallbackMock = vi.mocked(_rwmf);
-
-vi.mock("../../agents/pi-embedded.js", () => ({
-  runEmbeddedPiAgent: vi.fn(),
-}));
+vi.mock("../../agents/provider-utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/provider-utils.js")>();
+  return {
+    ...actual,
+    isCliProvider: vi.fn().mockReturnValue(true),
+  };
+});
 
 vi.mock("../../agents/context.js", () => ({
   lookupContextTokens: vi.fn().mockReturnValue(128000),
@@ -79,36 +95,30 @@ vi.mock("../../agents/usage.js", () => ({
   hasNonzeroUsage: vi.fn().mockReturnValue(false),
 }));
 
-vi.mock("../../agents/subagent-announce.js", () => ({
-  runSubagentAnnounceFlow: vi.fn().mockResolvedValue(true),
-}));
-
-vi.mock("../../agents/cli-runner.js", () => ({
-  runCliAgent: vi.fn(),
-}));
-
 vi.mock("../../agents/cli-session.js", () => ({
-  getCliSessionId: vi.fn().mockReturnValue(undefined),
+  getCliSessionId: vi.fn().mockReturnValue("cli-session-123"),
   setCliSessionId: vi.fn(),
 }));
 
 vi.mock("../../auto-reply/thinking.js", () => ({
-  normalizeThinkLevel: vi.fn().mockReturnValue(undefined),
   normalizeVerboseLevel: vi.fn().mockReturnValue("off"),
-  supportsXHighThinking: vi.fn().mockReturnValue(false),
 }));
 
 vi.mock("../../cli/outbound-send-deps.js", () => ({
   createOutboundSendDeps: vi.fn().mockReturnValue({}),
 }));
 
-const updateSessionStoreMock = vi.fn().mockResolvedValue(undefined);
-
 vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
-  resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
-  setSessionRuntimeModel: vi.fn(),
-  updateSessionStore: updateSessionStoreMock,
+  updateSessionStore: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../config/paths.js", () => ({
+  resolveGatewayPort: vi.fn().mockReturnValue(3579),
+}));
+
+vi.mock("../../gateway/credentials.js", () => ({
+  resolveGatewayCredentialsFromConfig: vi.fn().mockReturnValue({ token: "test-token" }),
 }));
 
 vi.mock("../../routing/session-key.js", async (importOriginal) => {
@@ -128,13 +138,8 @@ vi.mock("../../infra/outbound/deliver.js", () => ({
   deliverOutboundPayloads: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("../../infra/skills-remote.js", () => ({
-  getRemoteSkillEligibility: vi.fn().mockReturnValue({}),
-}));
-
-const logWarnMock = vi.fn();
 vi.mock("../../logger.js", () => ({
-  logWarn: logWarnMock,
+  logWarn: vi.fn(),
 }));
 
 vi.mock("../../security/external-content.js", () => ({
@@ -150,31 +155,34 @@ vi.mock("../delivery.js", () => ({
 
 vi.mock("./delivery-target.js", () => ({
   resolveDeliveryTarget: vi.fn().mockResolvedValue({
-    channel: "discord",
-    to: undefined,
-    accountId: undefined,
-    error: undefined,
+    ok: true,
+    channel: "telegram",
+    to: "chat-123",
+    accountId: "bot-456",
+    mode: "explicit",
   }),
 }));
 
 vi.mock("./helpers.js", () => ({
-  isHeartbeatOnlyResponse: vi.fn().mockReturnValue(false),
   pickLastDeliverablePayload: vi.fn().mockReturnValue(undefined),
   pickLastNonEmptyTextFromPayloads: vi.fn().mockReturnValue("test output"),
   pickSummaryFromOutput: vi.fn().mockReturnValue("summary"),
   pickSummaryFromPayloads: vi.fn().mockReturnValue("summary"),
-  resolveHeartbeatAckMaxChars: vi.fn().mockReturnValue(100),
+}));
+
+vi.mock("./delivery-dispatch.js", () => ({
+  dispatchCronDelivery: vi.fn().mockResolvedValue({
+    delivered: false,
+    summary: "summary",
+    outputText: "test output",
+  }),
+  matchesMessagingToolDeliveryTarget: vi.fn().mockReturnValue(false),
+  resolveCronDeliveryBestEffort: vi.fn().mockReturnValue(false),
 }));
 
 const resolveCronSessionMock = vi.fn();
 vi.mock("./session.js", () => ({
   resolveCronSession: resolveCronSessionMock,
-}));
-
-vi.mock("../../agents/defaults.js", () => ({
-  DEFAULT_CONTEXT_TOKENS: 128000,
-  DEFAULT_MODEL: "gpt-4",
-  DEFAULT_PROVIDER: "openai",
 }));
 
 const { runCronIsolatedAgentTurn } = await import("./run.js");
@@ -183,100 +191,92 @@ const { runCronIsolatedAgentTurn } = await import("./run.js");
 
 function makeJob(overrides?: Record<string, unknown>) {
   return {
-    id: "digest-job",
-    name: "Daily Digest",
+    id: "cron-job-1",
+    name: "Daily Summary",
     schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
     sessionTarget: "isolated",
-    payload: {
-      kind: "agentTurn",
-      message: "run daily digest",
-      model: "anthropic/claude-sonnet-4-6",
-    },
+    sessionKey: "cron:cron-job-1",
+    payload: { kind: "agentTurn", message: "generate summary" },
     ...overrides,
   } as never;
 }
 
 function makeParams(overrides?: Record<string, unknown>) {
   return {
-    cfg: {},
+    cfg: { agents: { defaults: { runtime: "claude" as const } } },
     deps: {} as never,
     job: makeJob(),
-    message: "run daily digest",
-    sessionKey: "cron:digest",
+    message: "generate daily summary",
+    sessionKey: "cron:test",
     ...overrides,
   };
 }
 
-function makeFreshSessionEntry(overrides?: Record<string, unknown>) {
-  return {
-    sessionId: "test-session-id",
-    updatedAt: 0,
-    systemSent: false,
-    skillsSnapshot: undefined,
-    // Crucially: no model or modelProvider — simulates a brand-new session
-    model: undefined as string | undefined,
-    modelProvider: undefined as string | undefined,
-    ...overrides,
+function makeFreshSession(sessionEntryOverrides?: Record<string, unknown>): {
+  storePath: string;
+  store: Record<string, unknown>;
+  sessionEntry: {
+    sessionId: string;
+    updatedAt: number;
+    systemSent: boolean;
+    model?: string;
+    modelProvider?: string;
+    modelOverride?: string;
+    providerOverride?: string;
+    [k: string]: unknown;
   };
-}
-
-function makeSuccessfulRunResult(overrides?: Record<string, unknown>) {
+  systemSent: boolean;
+  isNewSession: boolean;
+} {
   return {
-    result: {
-      payloads: [{ text: "digest complete" }],
-      meta: {
-        agentMeta: {
-          model: "claude-sonnet-4-6",
-          provider: "anthropic",
-          usage: { input: 100, output: 50 },
-        },
-      },
+    storePath: "/tmp/store.json",
+    store: {},
+    sessionEntry: {
+      sessionId: "test-session-id",
+      updatedAt: 0,
+      systemSent: false,
+      ...sessionEntryOverrides,
     },
-    provider: "anthropic",
-    model: "claude-sonnet-4-6",
-    attempts: [],
+    systemSent: false,
+    isNewSession: true,
+  };
+}
+
+function makeDeliveryResult(overrides?: Record<string, unknown>) {
+  return {
+    payloads: [{ text: "Agent response" }],
+    run: {
+      text: "Agent response",
+      sessionId: "cli-session-new",
+      durationMs: 1500,
+      usage: { inputTokens: 100, outputTokens: 50, cacheReadTokens: 10, cacheWriteTokens: 5 },
+      aborted: false,
+      stopReason: "end_turn",
+    },
+    mcp: {
+      sentTexts: [],
+      sentMediaUrls: [],
+      sentTargets: [],
+      cronAdds: 0,
+    },
+    error: undefined,
     ...overrides,
   };
 }
 
 // ---------- tests ----------
 
-// Skipped: tests gutted functionality (Middleware Boundary Principle)
-
-describe.skip("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
+describe("runCronIsolatedAgentTurn — cron model override (telemetry vs session entry)", () => {
   let previousFastTestEnv: string | undefined;
-  // Hold onto the cron session *object* — the code may reassign its
-  // `sessionEntry` property (e.g. during skills snapshot refresh), so
-  // checking a stale reference would give a false negative.
-  let cronSession: { sessionEntry: ReturnType<typeof makeFreshSessionEntry>; [k: string]: unknown };
+  let cronSession: ReturnType<typeof makeFreshSession>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     previousFastTestEnv = process.env.REMOTECLAW_TEST_FAST;
     delete process.env.REMOTECLAW_TEST_FAST;
-
-    // Agent default model is Opus
-    resolveConfiguredModelRefMock.mockReturnValue({
-      provider: "anthropic",
-      model: "claude-opus-4-6",
-    });
-
-    // Cron payload model override resolves to Sonnet
-    resolveAllowedModelRefMock.mockReturnValue({
-      ref: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    });
-
-    resolveAgentConfigMock.mockReturnValue(undefined);
-    updateSessionStoreMock.mockResolvedValue(undefined);
-
-    cronSession = {
-      storePath: "/tmp/store.json",
-      store: {},
-      sessionEntry: makeFreshSessionEntry(),
-      systemSent: false,
-      isNewSession: true,
-    };
+    cronSession = makeFreshSession();
     resolveCronSessionMock.mockReturnValue(cronSession);
+    channelBridgeHandleMock.mockResolvedValue(makeDeliveryResult());
   });
 
   afterEach(() => {
@@ -287,143 +287,134 @@ describe.skip("runCronIsolatedAgentTurn — cron model override (#21057)", () =>
     process.env.REMOTECLAW_TEST_FAST = previousFastTestEnv;
   });
 
-  it("persists cron payload model on session entry even when the run throws", async () => {
-    // Simulate the agent run throwing (e.g. LLM provider timeout)
-    runWithModelFallbackMock.mockRejectedValueOnce(new Error("LLM provider timeout"));
-
-    const result = await runCronIsolatedAgentTurn(makeParams());
-
-    expect(result.status).toBe("error");
-
-    // The session entry should record the intended cron model override (Sonnet)
-    // so that sessions_list does not fall back to the agent default (Opus).
-    //
-    // BUG (#21057): before the fix, the model was only written to the session
-    // entry AFTER a successful run (in the post-run telemetry block), so it
-    // remained undefined when the run threw in the catch block.
-    expect(cronSession.sessionEntry.model).toBe("claude-sonnet-4-6");
-    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
-    expect(cronSession.sessionEntry.systemSent).toBe(true);
-  });
-
-  it("session entry already carries cron model at pre-run persist time (race condition)", async () => {
-    // Capture a deep snapshot of the session entry at each persist call so we
-    // can inspect what sessions_list would see mid-run — before the post-run
-    // persist overwrites the entry with the actual model from agentMeta.
-    const persistedSnapshots: Array<{
-      model?: string;
-      modelProvider?: string;
-      systemSent?: boolean;
-    }> = [];
-    updateSessionStoreMock.mockImplementation(
-      async (_path: string, cb: (s: Record<string, unknown>) => void) => {
-        const store: Record<string, unknown> = {};
-        cb(store);
-        const entry = Object.values(store)[0] as
-          | { model?: string; modelProvider?: string; systemSent?: boolean }
-          | undefined;
-        if (entry) {
-          persistedSnapshots.push(JSON.parse(JSON.stringify(entry)));
-        }
-      },
+  it("telemetry uses runtime field, session entry uses model/modelProvider", async () => {
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        job: makeJob({
+          payload: {
+            kind: "agentTurn",
+            message: "generate summary",
+            model: "anthropic/claude-sonnet-4-6",
+          },
+        }),
+      }),
     );
 
-    runWithModelFallbackMock.mockResolvedValueOnce(makeSuccessfulRunResult());
+    expect(result.status).toBe("ok");
 
-    await runCronIsolatedAgentTurn(makeParams());
+    // Telemetry: runtime comes from resolveAgentRuntimeOrThrow (mocked → "claude"),
+    // not from the model override
+    expect(result.runtime).toBe("claude");
 
-    // Persist ordering: [0] skills snapshot, [1] pre-run model+systemSent,
-    // [2] post-run telemetry.  Index 1 is what a concurrent sessions_list
-    // would read while the agent run is in flight.
-    expect(persistedSnapshots.length).toBeGreaterThanOrEqual(3);
-    const preRunSnapshot = persistedSnapshots[1];
-    expect(preRunSnapshot.model).toBe("claude-sonnet-4-6");
-    expect(preRunSnapshot.modelProvider).toBe("anthropic");
-    expect(preRunSnapshot.systemSent).toBe(true);
+    // Result does NOT carry model/provider — those are session-entry-only fields
+    expect("model" in result).toBe(false);
+    expect("provider" in result).toBe(false);
+
+    // Session entry: model/modelProvider reflect the payload override
+    expect(cronSession.sessionEntry.model).toBe("claude-sonnet-4-6");
+    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
   });
 
-  it("returns error without persisting model when payload model is disallowed", async () => {
-    resolveAllowedModelRefMock.mockReturnValueOnce({
-      error: "Model not allowed: anthropic/claude-sonnet-4-6",
-    });
+  it("persists payload model override on session entry after successful run", async () => {
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        job: makeJob({
+          payload: {
+            kind: "agentTurn",
+            message: "generate summary",
+            model: "anthropic/claude-sonnet-4-6",
+          },
+        }),
+      }),
+    );
 
-    const result = await runCronIsolatedAgentTurn(makeParams());
+    expect(result.status).toBe("ok");
+    expect(cronSession.sessionEntry.model).toBe("claude-sonnet-4-6");
+    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
+  });
+
+  it("defaults model to 'unknown' on session entry when no override is present", async () => {
+    // Job has no model override
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        job: makeJob({
+          payload: { kind: "agentTurn", message: "generate summary" },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(result.runtime).toBe("claude");
+    // Without model override, defaults from normalizeModelRef("unknown", "unknown")
+    expect(cronSession.sessionEntry.model).toBe("unknown");
+    expect(cronSession.sessionEntry.modelProvider).toBe("unknown");
+  });
+
+  it("returns error for unparseable model in payload", async () => {
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        job: makeJob({
+          payload: {
+            kind: "agentTurn",
+            message: "generate summary",
+            model: "/",
+          },
+        }),
+      }),
+    );
 
     expect(result.status).toBe("error");
-    expect(result.error).toContain("Model not allowed");
-    // Model should remain undefined — the early return happens before the
-    // pre-run persist block, so neither the session entry nor the store
-    // should be touched with a rejected model.
+    expect(result.error).toContain("Unrecognized model");
+    // ChannelBridge was never called
+    expect(channelBridgeHandleMock).not.toHaveBeenCalled();
+    // Session entry model was never set (early return before execution)
     expect(cronSession.sessionEntry.model).toBeUndefined();
     expect(cronSession.sessionEntry.modelProvider).toBeUndefined();
   });
 
-  it("persists session-level /model override on session entry before the run", async () => {
-    // No cron payload model — the job has no model field
-    const jobWithoutModel = makeJob({
-      payload: { kind: "agentTurn", message: "run daily digest" },
-    });
-
-    // Session-level /model override set by user (e.g. via /model command)
-    cronSession.sessionEntry = makeFreshSessionEntry({
+  it("honors session-level model override when no payload model is present", async () => {
+    cronSession = makeFreshSession({
       modelOverride: "claude-haiku-4-5",
       providerOverride: "anthropic",
     });
     resolveCronSessionMock.mockReturnValue(cronSession);
 
-    // resolveAllowedModelRef is called for the session override path too
-    resolveAllowedModelRefMock.mockReturnValue({
-      ref: { provider: "anthropic", model: "claude-haiku-4-5" },
-    });
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        job: makeJob({
+          payload: { kind: "agentTurn", message: "generate summary" },
+        }),
+      }),
+    );
 
-    runWithModelFallbackMock.mockRejectedValueOnce(new Error("LLM provider timeout"));
-
-    const result = await runCronIsolatedAgentTurn(makeParams({ job: jobWithoutModel }));
-
-    expect(result.status).toBe("error");
-    // Even though the run failed, the session-level model override should
-    // be persisted on the entry — not the agent default (Opus).
+    expect(result.status).toBe("ok");
+    expect(result.runtime).toBe("claude");
+    // Session entry reflects the session-level override
     expect(cronSession.sessionEntry.model).toBe("claude-haiku-4-5");
     expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
   });
 
-  it("logs warning and continues when pre-run persist fails", async () => {
-    // Persist ordering: [1] skills snapshot, [2] pre-run, [3] post-run.
-    // Only the pre-run persist (call 2) should fail — the skills snapshot
-    // persist is pre-existing code without a try-catch guard.
-    let callCount = 0;
-    updateSessionStoreMock.mockImplementation(async () => {
-      callCount++;
-      if (callCount === 2) {
-        throw new Error("ENOSPC: no space left on device");
-      }
-    });
+  it("does not persist model on session entry when ChannelBridge throws", async () => {
+    channelBridgeHandleMock.mockRejectedValueOnce(new Error("LLM provider timeout"));
 
-    runWithModelFallbackMock.mockResolvedValueOnce(makeSuccessfulRunResult());
-
-    const result = await runCronIsolatedAgentTurn(makeParams());
-
-    // The run should still complete successfully despite the persist failure
-    expect(result.status).toBe("ok");
-    expect(logWarnMock).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to persist pre-run session entry"),
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        job: makeJob({
+          payload: {
+            kind: "agentTurn",
+            message: "generate summary",
+            model: "anthropic/claude-sonnet-4-6",
+          },
+        }),
+      }),
     );
-  });
-
-  it("persists default model pre-run when no payload override is present", async () => {
-    // No cron payload model override
-    const jobWithoutModel = makeJob({
-      payload: { kind: "agentTurn", message: "run daily digest" },
-    });
-
-    runWithModelFallbackMock.mockRejectedValueOnce(new Error("LLM provider timeout"));
-
-    const result = await runCronIsolatedAgentTurn(makeParams({ job: jobWithoutModel }));
 
     expect(result.status).toBe("error");
-    // With no override, the default model (Opus) should still be persisted
-    // on the session entry rather than left undefined.
-    expect(cronSession.sessionEntry.model).toBe("claude-opus-4-6");
-    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
+    expect(result.error).toContain("LLM provider timeout");
+    // Post-run model persistence never reached (catch block returns early)
+    expect(cronSession.sessionEntry.model).toBeUndefined();
+    expect(cronSession.sessionEntry.modelProvider).toBeUndefined();
+    // No telemetry on error path
+    expect(result.runtime).toBeUndefined();
   });
 });

--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -228,6 +228,50 @@ describe("cron run log", () => {
     });
   });
 
+  it("parses old JSONL entries with model/provider fields without error", async () => {
+    await withRunLogDir("remoteclaw-cron-log-compat-", async (dir) => {
+      const logPath = path.join(dir, "runs", "job-1.jsonl");
+      await fs.mkdir(path.dirname(logPath), { recursive: true });
+      await fs.writeFile(
+        logPath,
+        [
+          // Old-format entry with model/provider (no runtime)
+          JSON.stringify({
+            ts: 1,
+            jobId: "job-1",
+            action: "finished",
+            status: "ok",
+            model: "claude-sonnet-4-5",
+            provider: "anthropic",
+            usage: { input_tokens: 100, output_tokens: 50 },
+          }),
+          // New-format entry with runtime
+          JSON.stringify({
+            ts: 2,
+            jobId: "job-1",
+            action: "finished",
+            status: "ok",
+            runtime: "claude",
+            usage: { input_tokens: 200, output_tokens: 100 },
+          }),
+        ].join("\n") + "\n",
+        "utf-8",
+      );
+
+      const entries = await readCronRunLogEntries(logPath, { limit: 10, jobId: "job-1" });
+      expect(entries).toHaveLength(2);
+
+      // Old entry: model/provider are silently ignored, runtime is undefined
+      expect(entries[0]?.runtime).toBeUndefined();
+      expect(entries[0]?.usage?.input_tokens).toBe(100);
+      expect(entries[0]?.status).toBe("ok");
+
+      // New entry: runtime is present
+      expect(entries[1]?.runtime).toBe("claude");
+      expect(entries[1]?.usage?.input_tokens).toBe(200);
+    });
+  });
+
   it("cleans up pending-write bookkeeping after appends complete", async () => {
     await withRunLogDir("remoteclaw-cron-log-pending-", async (dir) => {
       const logPath = path.join(dir, "runs", "job-cleanup.jsonl");


### PR DESCRIPTION
## Summary

- Add backward compat test for old JSONL entries with `model`/`provider` fields in `run-log.test.ts` — verifies legacy entries parse without error and `runtime` is `undefined`
- Rewrite `run.cron-model-override.test.ts` from `describe.skip` to active tests using ChannelBridge execution path (the old `runWithModelFallback` path was gutted in #2121)
- New model override tests verify the session-entry vs telemetry distinction: session entry carries `model`/`modelProvider`, telemetry result carries `runtime`

Closes #2111

## Test plan

- [x] All 10 run-log tests pass (including new backward compat test)
- [x] All 6 cron-model-override tests pass (previously 6 skipped → 6 active)
- [x] Full cron test suite: 273 tests pass across 39 files
- [x] Type-check clean (`tsc --noEmit`)
- [x] Format + lint pass (`pnpm check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)