### PR TITLE
fix(session): CLI session key mismatch — provider 'unknown' vs runtime name

### DIFF
--- a/src/agents/provider-utils.test.ts
+++ b/src/agents/provider-utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import type { RemoteClawConfig } from "../config/config.js";
+import { isCliProvider } from "./provider-utils.js";
+
+describe("isCliProvider", () => {
+  it("recognizes legacy CLI provider names", () => {
+    expect(isCliProvider("claude-cli")).toBe(true);
+    expect(isCliProvider("codex-cli")).toBe(true);
+  });
+
+  it("recognizes agent runtime names as CLI providers", () => {
+    expect(isCliProvider("claude")).toBe(true);
+    expect(isCliProvider("gemini")).toBe(true);
+    expect(isCliProvider("codex")).toBe(true);
+    expect(isCliProvider("opencode")).toBe(true);
+  });
+
+  it("recognizes cliBackends entries", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "custom-cli": { command: "custom" },
+          },
+        },
+      },
+    };
+    expect(isCliProvider("custom-cli", cfg)).toBe(true);
+  });
+
+  it("returns false for unknown providers", () => {
+    expect(isCliProvider("unknown")).toBe(false);
+    expect(isCliProvider("some-api")).toBe(false);
+  });
+});

--- a/src/agents/provider-utils.ts
+++ b/src/agents/provider-utils.ts
@@ -68,12 +68,21 @@ export function findNormalizedProviderKey(
   return Object.keys(entries).find((key) => normalizeProviderId(key) === providerKey);
 }
 
+/**
+ * Known agent runtime names. In RemoteClaw all runtimes are CLI-based, so
+ * these are always considered CLI providers regardless of cliBackends config.
+ */
+const CLI_RUNTIME_NAMES = new Set(["claude", "gemini", "codex", "opencode"]);
+
 export function isCliProvider(provider: string, cfg?: RemoteClawConfig): boolean {
   const normalized = normalizeProviderId(provider);
   if (normalized === "claude-cli") {
     return true;
   }
   if (normalized === "codex-cli") {
+    return true;
+  }
+  if (CLI_RUNTIME_NAMES.has(normalized)) {
     return true;
   }
   const backends = cfg?.agents?.defaults?.cliBackends ?? {};

--- a/src/auto-reply/reply/directive-handling.persist.test.ts
+++ b/src/auto-reply/reply/directive-handling.persist.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { RemoteClawConfig } from "../../config/config.js";
+import { resolveDefaultModel } from "./directive-handling.persist.js";
+
+describe("resolveDefaultModel", () => {
+  it("returns configured runtime as defaultProvider", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { runtime: "claude" },
+      },
+    };
+    const result = resolveDefaultModel({ cfg, agentId: "main" });
+    expect(result.defaultProvider).toBe("claude");
+  });
+
+  it("returns per-agent runtime when configured", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { runtime: "claude" },
+        list: [{ id: "gemini-agent", runtime: "gemini", workspace: "~/ws" }],
+      },
+    };
+    const result = resolveDefaultModel({ cfg, agentId: "gemini-agent" });
+    expect(result.defaultProvider).toBe("gemini");
+  });
+
+  it("falls back to defaults.runtime when agent has no runtime override", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { runtime: "codex" },
+        list: [{ id: "my-agent", workspace: "~/ws" }],
+      },
+    };
+    const result = resolveDefaultModel({ cfg, agentId: "my-agent" });
+    expect(result.defaultProvider).toBe("codex");
+  });
+
+  it("falls back to 'unknown' when no runtime is configured", () => {
+    const cfg: RemoteClawConfig = {};
+    const result = resolveDefaultModel({ cfg });
+    expect(result.defaultProvider).toBe("unknown");
+  });
+
+  it("uses defaults.runtime when agentId is not provided", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { runtime: "opencode" },
+      },
+    };
+    const result = resolveDefaultModel({ cfg });
+    expect(result.defaultProvider).toBe("opencode");
+  });
+
+  it("returns an empty aliasIndex", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { defaults: { runtime: "claude" } },
+    };
+    const result = resolveDefaultModel({ cfg });
+    expect(result.aliasIndex.size).toBe(0);
+  });
+});

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -1,3 +1,4 @@
+import { resolveAgentRuntime } from "../../agents/agent-scope.js";
 import { modelKey, parseModelRef } from "../../agents/provider-utils.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import { type SessionEntry, updateSessionStore } from "../../config/sessions.js";
@@ -116,12 +117,17 @@ export async function persistInlineDirectives(params: {
   };
 }
 
-export function resolveDefaultModel(_params: { cfg: RemoteClawConfig; agentId?: string }): {
+export function resolveDefaultModel(params: { cfg: RemoteClawConfig; agentId?: string }): {
   defaultProvider: string;
   defaultModel: string;
   aliasIndex: Map<string, { provider: string; model: string }>;
 } {
   // Model selection/alias infrastructure gutted in RemoteClaw — CLIs own model selection.
+  // Use the configured agent runtime as the provider identifier so that CLI session
+  // IDs are keyed by the actual runtime name (e.g. "claude") instead of "unknown".
   const aliasIndex = new Map<string, { provider: string; model: string }>();
-  return { defaultProvider: "unknown", defaultModel: "unknown", aliasIndex };
+  const runtime = params.agentId
+    ? resolveAgentRuntime(params.cfg, params.agentId)
+    : params.cfg.agents?.defaults?.runtime;
+  return { defaultProvider: runtime ?? "unknown", defaultModel: "default", aliasIndex };
 }

--- a/src/cron/isolated-agent/run.auth-retry.test.ts
+++ b/src/cron/isolated-agent/run.auth-retry.test.ts
@@ -44,6 +44,7 @@ const resolveAgentRuntimeEnvMock = vi.fn();
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentConfig: vi.fn().mockReturnValue(undefined),
   resolveAgentDir: vi.fn().mockReturnValue("/tmp/agent-dir"),
+  resolveAgentRuntime: vi.fn().mockReturnValue("claude"),
   resolveAgentRuntimeArgs: vi.fn().mockReturnValue(undefined),
   resolveAgentRuntimeEnv: resolveAgentRuntimeEnvMock,
   resolveAgentRuntimeOrThrow: vi.fn().mockReturnValue("claude"),

--- a/src/cron/isolated-agent/run.channel-bridge.test.ts
+++ b/src/cron/isolated-agent/run.channel-bridge.test.ts
@@ -40,6 +40,7 @@ vi.mock("../../agents/channel-tools.js", () => ({
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentConfig: vi.fn().mockReturnValue(undefined),
   resolveAgentDir: vi.fn().mockReturnValue("/tmp/agent-dir"),
+  resolveAgentRuntime: vi.fn().mockReturnValue("claude"),
   resolveAgentRuntimeArgs: vi.fn().mockReturnValue(undefined),
   resolveAgentRuntimeEnv: vi.fn().mockReturnValue(undefined),
   resolveAgentRuntimeOrThrow: vi.fn().mockReturnValue("claude"),

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -42,6 +42,7 @@ vi.mock("../../agents/channel-tools.js", () => ({
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentConfig: vi.fn().mockReturnValue(undefined),
   resolveAgentDir: vi.fn().mockReturnValue("/tmp/agent-dir"),
+  resolveAgentRuntime: vi.fn().mockReturnValue("claude"),
   resolveAgentRuntimeArgs: vi.fn().mockReturnValue(undefined),
   resolveAgentRuntimeEnv: vi.fn().mockReturnValue(undefined),
   resolveAgentRuntimeOrThrow: vi.fn().mockReturnValue("claude"),
@@ -345,9 +346,9 @@ describe("runCronIsolatedAgentTurn — cron model override (telemetry vs session
 
     expect(result.status).toBe("ok");
     expect(result.runtime).toBe("claude");
-    // Without model override, defaults from normalizeModelRef("unknown", "unknown")
-    expect(cronSession.sessionEntry.model).toBe("unknown");
-    expect(cronSession.sessionEntry.modelProvider).toBe("unknown");
+    // Without model override, defaults from the configured agent runtime.
+    expect(cronSession.sessionEntry.model).toBe("default");
+    expect(cronSession.sessionEntry.modelProvider).toBe("claude");
   });
 
   it("returns error for unparseable model in payload", async () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import {
   resolveAgentConfig,
+  resolveAgentRuntime,
   resolveAgentRuntimeArgs,
   resolveAgentRuntimeEnv,
   resolveAgentRuntimeOrThrow,
@@ -12,7 +13,7 @@ import { getCliSessionId, setCliSessionId } from "../../agents/cli-session.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { resolveUserTimezone } from "../../agents/date-time.js";
 // Model management defaults gutted in RemoteClaw — CLI runtimes own model selection.
-import { isCliProvider, normalizeModelRef, parseModelRef } from "../../agents/provider-utils.js";
+import { isCliProvider, parseModelRef } from "../../agents/provider-utils.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { deriveSessionTotalTokens, hasNonzeroUsage } from "../../agents/usage.js";
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
@@ -189,14 +190,16 @@ export async function runCronIsolatedAgentTurn(params: {
   const workspaceDirRaw = resolveAgentWorkspaceDir(params.cfg, agentId);
   const workspaceDir = await ensureAgentWorkspace(workspaceDirRaw);
 
-  const resolvedDefault = normalizeModelRef("unknown", "unknown");
-  let provider = resolvedDefault.provider;
-  let model = resolvedDefault.model;
+  // Use agent runtime as the default provider so CLI session IDs are keyed
+  // by the actual runtime name (e.g. "claude") instead of "unknown".
+  const runtimeProvider = resolveAgentRuntime(cfgWithAgentDefaults, agentId) ?? "unknown";
+  let provider = runtimeProvider;
+  let model = "default";
   const modelOverrideRaw =
     params.job.payload.kind === "agentTurn" ? params.job.payload.model : undefined;
   const modelOverride = typeof modelOverrideRaw === "string" ? modelOverrideRaw.trim() : undefined;
   if (modelOverride !== undefined && modelOverride.length > 0) {
-    const parsed = parseModelRef(modelOverride, resolvedDefault.provider);
+    const parsed = parseModelRef(modelOverride, runtimeProvider);
     if (!parsed) {
       return { status: "error", error: `Unrecognized model "${modelOverride}".` };
     }
@@ -253,10 +256,10 @@ export async function runCronIsolatedAgentTurn(params: {
     const sessionModelOverride = cronSession.sessionEntry.modelOverride?.trim();
     if (sessionModelOverride) {
       const sessionProviderOverride =
-        cronSession.sessionEntry.providerOverride?.trim() || resolvedDefault.provider;
+        cronSession.sessionEntry.providerOverride?.trim() || runtimeProvider;
       const parsed = parseModelRef(
         `${sessionProviderOverride}/${sessionModelOverride}`,
-        resolvedDefault.provider,
+        runtimeProvider,
       );
       if (parsed) {
         provider = parsed.provider;


### PR DESCRIPTION
## Summary

Fixes #2105.

- `resolveDefaultModel()` now returns the configured agent runtime (e.g. `"claude"`) as `defaultProvider` instead of the hardcoded `"unknown"` — this flows through to `providerUsed` in the session usage pipeline
- `isCliProvider()` recognizes the four agent runtime names (`claude`, `gemini`, `codex`, `opencode`) as CLI providers, so CLI session IDs are correctly extracted and persisted
- The cron isolated-agent path uses the same runtime-based provider resolution

**Root cause**: The gutted `resolveDefaultModel()` stub returned `"unknown"`, causing `isCliProvider("unknown")` to return `false`, which meant CLI session IDs were never persisted — `--resume` was never passed on subsequent messages in the same thread.

## Test plan

- [x] New unit tests for `isCliProvider()` runtime name recognition
- [x] New unit tests for `resolveDefaultModel()` runtime-based resolution
- [x] Updated cron test mocks to include `resolveAgentRuntime`
- [x] Updated cron test assertion (provider/model now reflect runtime)
- [x] `pnpm check` passes (format + typecheck + lint)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)