### PR TITLE
test(session): CLI session isolation — per-thread sessions and --resume

### DIFF
--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
+import { getCliSessionId, setCliSessionId } from "./cli-session.js";
+
+function makeEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    sessionId: "test-session",
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("getCliSessionId", () => {
+  it("returns undefined for undefined entry", () => {
+    expect(getCliSessionId(undefined, "claude")).toBeUndefined();
+  });
+
+  it("returns session ID keyed by provider", () => {
+    const entry = makeEntry({ cliSessionIds: { claude: "abc-123" } });
+    expect(getCliSessionId(entry, "claude")).toBe("abc-123");
+  });
+
+  it("normalizes provider name before lookup", () => {
+    const entry = makeEntry({ cliSessionIds: { claude: "abc-123" } });
+    expect(getCliSessionId(entry, " Claude ")).toBe("abc-123");
+  });
+
+  it("returns undefined when provider has no stored session", () => {
+    const entry = makeEntry({ cliSessionIds: { claude: "abc-123" } });
+    expect(getCliSessionId(entry, "gemini")).toBeUndefined();
+  });
+
+  it("returns undefined when cliSessionIds map is absent", () => {
+    const entry = makeEntry();
+    expect(getCliSessionId(entry, "claude")).toBeUndefined();
+  });
+
+  it("trims whitespace from stored session ID", () => {
+    const entry = makeEntry({ cliSessionIds: { claude: "  abc-123  " } });
+    expect(getCliSessionId(entry, "claude")).toBe("abc-123");
+  });
+
+  it("returns undefined for whitespace-only session ID", () => {
+    const entry = makeEntry({ cliSessionIds: { claude: "   " } });
+    expect(getCliSessionId(entry, "claude")).toBeUndefined();
+  });
+
+  it("falls back to legacy claudeCliSessionId for claude-cli provider", () => {
+    const entry = makeEntry({ claudeCliSessionId: "legacy-sess" });
+    expect(getCliSessionId(entry, "claude-cli")).toBe("legacy-sess");
+  });
+
+  it("prefers cliSessionIds map over legacy field", () => {
+    const entry = makeEntry({
+      cliSessionIds: { "claude-cli": "map-sess" },
+      claudeCliSessionId: "legacy-sess",
+    });
+    expect(getCliSessionId(entry, "claude-cli")).toBe("map-sess");
+  });
+
+  it("does not fall back to legacy field for non-claude-cli providers", () => {
+    const entry = makeEntry({ claudeCliSessionId: "legacy-sess" });
+    expect(getCliSessionId(entry, "claude")).toBeUndefined();
+  });
+});
+
+describe("setCliSessionId", () => {
+  it("stores session ID keyed by normalized provider", () => {
+    const entry = makeEntry();
+    setCliSessionId(entry, "claude", "new-sess-1");
+    expect(entry.cliSessionIds?.["claude"]).toBe("new-sess-1");
+  });
+
+  it("normalizes provider name before storing", () => {
+    const entry = makeEntry();
+    setCliSessionId(entry, " Gemini ", "gem-sess");
+    expect(entry.cliSessionIds?.["gemini"]).toBe("gem-sess");
+  });
+
+  it("creates cliSessionIds map if absent", () => {
+    const entry = makeEntry();
+    expect(entry.cliSessionIds).toBeUndefined();
+    setCliSessionId(entry, "claude", "new-sess");
+    expect(entry.cliSessionIds).toBeDefined();
+    expect(entry.cliSessionIds?.["claude"]).toBe("new-sess");
+  });
+
+  it("preserves existing entries for other providers", () => {
+    const entry = makeEntry({ cliSessionIds: { claude: "claude-sess" } });
+    setCliSessionId(entry, "gemini", "gem-sess");
+    expect(entry.cliSessionIds?.["claude"]).toBe("claude-sess");
+    expect(entry.cliSessionIds?.["gemini"]).toBe("gem-sess");
+  });
+
+  it("overwrites existing session ID for same provider", () => {
+    const entry = makeEntry({ cliSessionIds: { claude: "old-sess" } });
+    setCliSessionId(entry, "claude", "new-sess");
+    expect(entry.cliSessionIds?.["claude"]).toBe("new-sess");
+  });
+
+  it("does nothing for empty session ID", () => {
+    const entry = makeEntry();
+    setCliSessionId(entry, "claude", "");
+    expect(entry.cliSessionIds).toBeUndefined();
+  });
+
+  it("does nothing for whitespace-only session ID", () => {
+    const entry = makeEntry();
+    setCliSessionId(entry, "claude", "   ");
+    expect(entry.cliSessionIds).toBeUndefined();
+  });
+
+  it("trims whitespace from session ID before storing", () => {
+    const entry = makeEntry();
+    setCliSessionId(entry, "claude", "  trimmed-sess  ");
+    expect(entry.cliSessionIds?.["claude"]).toBe("trimmed-sess");
+  });
+
+  it("also sets legacy claudeCliSessionId for claude-cli provider", () => {
+    const entry = makeEntry();
+    setCliSessionId(entry, "claude-cli", "dual-sess");
+    expect(entry.cliSessionIds?.["claude-cli"]).toBe("dual-sess");
+    expect(entry.claudeCliSessionId).toBe("dual-sess");
+  });
+
+  it("does not set legacy field for non-claude-cli providers", () => {
+    const entry = makeEntry();
+    setCliSessionId(entry, "claude", "sess-123");
+    expect(entry.claudeCliSessionId).toBeUndefined();
+  });
+});
+
+describe("session isolation across providers", () => {
+  it("different runtimes get independent session IDs", () => {
+    const entry = makeEntry();
+    setCliSessionId(entry, "claude", "claude-sess-1");
+    setCliSessionId(entry, "gemini", "gemini-sess-1");
+    setCliSessionId(entry, "codex", "codex-sess-1");
+
+    expect(getCliSessionId(entry, "claude")).toBe("claude-sess-1");
+    expect(getCliSessionId(entry, "gemini")).toBe("gemini-sess-1");
+    expect(getCliSessionId(entry, "codex")).toBe("codex-sess-1");
+  });
+
+  it("updating one provider does not affect others", () => {
+    const entry = makeEntry();
+    setCliSessionId(entry, "claude", "claude-v1");
+    setCliSessionId(entry, "gemini", "gemini-v1");
+
+    setCliSessionId(entry, "claude", "claude-v2");
+
+    expect(getCliSessionId(entry, "claude")).toBe("claude-v2");
+    expect(getCliSessionId(entry, "gemini")).toBe("gemini-v1");
+  });
+});

--- a/src/auto-reply/reply/session-usage.test.ts
+++ b/src/auto-reply/reply/session-usage.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+
+const hoisted = vi.hoisted(() => {
+  const updateSessionStoreEntryMock = vi.fn();
+  return { updateSessionStoreEntryMock };
+});
+
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions.js")>();
+  return {
+    ...actual,
+    updateSessionStoreEntry: (...args: unknown[]) => hoisted.updateSessionStoreEntryMock(...args),
+  };
+});
+
+vi.mock("../../globals.js", () => ({
+  logVerbose: vi.fn(),
+}));
+
+const { persistSessionUsageUpdate } = await import("./session-usage.js");
+
+function makeEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    sessionId: "test-session",
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("persistSessionUsageUpdate — CLI session ID persistence", () => {
+  beforeEach(() => {
+    hoisted.updateSessionStoreEntryMock.mockReset();
+  });
+
+  it("writes cliSessionId keyed by providerUsed", async () => {
+    const entry = makeEntry({ modelProvider: "old-provider" });
+    hoisted.updateSessionStoreEntryMock.mockImplementation(
+      async (params: { update: (e: SessionEntry) => Promise<Partial<SessionEntry>> }) => {
+        return params.update(entry);
+      },
+    );
+
+    await persistSessionUsageUpdate({
+      storePath: "/tmp/store.json",
+      sessionKey: "test-key",
+      usage: { input: 100, output: 50 },
+      providerUsed: "claude",
+      cliSessionId: "sess-abc-123",
+    });
+
+    expect(hoisted.updateSessionStoreEntryMock).toHaveBeenCalledOnce();
+    const patch = await hoisted.updateSessionStoreEntryMock.mock.results[0].value;
+    expect(patch.cliSessionIds?.["claude"]).toBe("sess-abc-123");
+  });
+
+  it("uses entry.modelProvider when providerUsed is absent", async () => {
+    const entry = makeEntry({ modelProvider: "gemini" });
+    hoisted.updateSessionStoreEntryMock.mockImplementation(
+      async (params: { update: (e: SessionEntry) => Promise<Partial<SessionEntry>> }) => {
+        return params.update(entry);
+      },
+    );
+
+    await persistSessionUsageUpdate({
+      storePath: "/tmp/store.json",
+      sessionKey: "test-key",
+      usage: { input: 100, output: 50 },
+      cliSessionId: "gem-sess-456",
+    });
+
+    const patch = await hoisted.updateSessionStoreEntryMock.mock.results[0].value;
+    expect(patch.cliSessionIds?.["gemini"]).toBe("gem-sess-456");
+  });
+
+  it("does not write cliSessionIds when cliSessionId is absent", async () => {
+    const entry = makeEntry();
+    hoisted.updateSessionStoreEntryMock.mockImplementation(
+      async (params: { update: (e: SessionEntry) => Promise<Partial<SessionEntry>> }) => {
+        return params.update(entry);
+      },
+    );
+
+    await persistSessionUsageUpdate({
+      storePath: "/tmp/store.json",
+      sessionKey: "test-key",
+      usage: { input: 100, output: 50 },
+      providerUsed: "claude",
+    });
+
+    const patch = await hoisted.updateSessionStoreEntryMock.mock.results[0].value;
+    expect(patch.cliSessionIds).toBeUndefined();
+  });
+
+  it("does not write cliSessionIds when provider is absent", async () => {
+    const entry = makeEntry();
+    hoisted.updateSessionStoreEntryMock.mockImplementation(
+      async (params: { update: (e: SessionEntry) => Promise<Partial<SessionEntry>> }) => {
+        return params.update(entry);
+      },
+    );
+
+    await persistSessionUsageUpdate({
+      storePath: "/tmp/store.json",
+      sessionKey: "test-key",
+      usage: { input: 100, output: 50 },
+      cliSessionId: "sess-orphan",
+    });
+
+    const patch = await hoisted.updateSessionStoreEntryMock.mock.results[0].value;
+    expect(patch.cliSessionIds).toBeUndefined();
+  });
+
+  it("preserves existing cliSessionIds for other providers", async () => {
+    const entry = makeEntry({
+      cliSessionIds: { gemini: "existing-gem-sess" },
+    });
+    hoisted.updateSessionStoreEntryMock.mockImplementation(
+      async (params: { update: (e: SessionEntry) => Promise<Partial<SessionEntry>> }) => {
+        return params.update(entry);
+      },
+    );
+
+    await persistSessionUsageUpdate({
+      storePath: "/tmp/store.json",
+      sessionKey: "test-key",
+      usage: { input: 100, output: 50 },
+      providerUsed: "claude",
+      cliSessionId: "claude-sess-new",
+    });
+
+    const patch = await hoisted.updateSessionStoreEntryMock.mock.results[0].value;
+    expect(patch.cliSessionIds?.["claude"]).toBe("claude-sess-new");
+    expect(patch.cliSessionIds?.["gemini"]).toBe("existing-gem-sess");
+  });
+
+  it("persists cliSessionId via model/context path when no usage", async () => {
+    const entry = makeEntry({ modelProvider: "codex" });
+    hoisted.updateSessionStoreEntryMock.mockImplementation(
+      async (params: { update: (e: SessionEntry) => Promise<Partial<SessionEntry>> }) => {
+        return params.update(entry);
+      },
+    );
+
+    await persistSessionUsageUpdate({
+      storePath: "/tmp/store.json",
+      sessionKey: "test-key",
+      modelUsed: "codex-latest",
+      providerUsed: "codex",
+      cliSessionId: "codex-sess-789",
+    });
+
+    const patch = await hoisted.updateSessionStoreEntryMock.mock.results[0].value;
+    expect(patch.cliSessionIds?.["codex"]).toBe("codex-sess-789");
+  });
+
+  it("skips entirely when storePath is missing", async () => {
+    await persistSessionUsageUpdate({
+      sessionKey: "test-key",
+      usage: { input: 100, output: 50 },
+      providerUsed: "claude",
+      cliSessionId: "sess-should-not-persist",
+    });
+
+    expect(hoisted.updateSessionStoreEntryMock).not.toHaveBeenCalled();
+  });
+
+  it("skips entirely when sessionKey is missing", async () => {
+    await persistSessionUsageUpdate({
+      storePath: "/tmp/store.json",
+      usage: { input: 100, output: 50 },
+      providerUsed: "claude",
+      cliSessionId: "sess-should-not-persist",
+    });
+
+    expect(hoisted.updateSessionStoreEntryMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2109

- Add `cli-session.test.ts` (22 tests): `getCliSessionId`/`setCliSessionId` keying by normalized provider, legacy `claudeCliSessionId` fallback, whitespace handling, cross-provider isolation
- Add `session-usage.test.ts` (8 tests): `persistSessionUsageUpdate` round-trip with `cliSessionId`, provider keying via `providerUsed` vs `entry.modelProvider`, no-op when provider or sessionId absent, preservation of existing provider entries

## Test plan

- [x] `npx vitest run src/agents/cli-session.test.ts src/auto-reply/reply/session-usage.test.ts` — 30/30 pass
- [x] Format check clean (`oxfmt --check`)
- [x] Lint clean (`oxlint --type-aware`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)