### PR TITLE
gut(session): remove vestigial model cost calculation (#2107)

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -4,7 +4,7 @@ import type { ChannelId, ChannelThreadingToolContext } from "../../channels/plug
 import { normalizeAnyChannelId, normalizeChannelId } from "../../channels/registry.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
-import { estimateUsageCost, formatTokenCount, formatUsd } from "../../utils/usage-format.js";
+import { formatTokenCount } from "../../utils/usage-format.js";
 import type { TemplateContext } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
@@ -80,16 +80,7 @@ export const formatBunFetchSocketError = (message: string) => {
   ].join("\n");
 };
 
-export const formatResponseUsageLine = (params: {
-  usage?: NormalizedUsage;
-  showCost: boolean;
-  costConfig?: {
-    input: number;
-    output: number;
-    cacheRead: number;
-    cacheWrite: number;
-  };
-}): string | null => {
+export const formatResponseUsageLine = (params: { usage?: NormalizedUsage }): string | null => {
   const usage = params.usage;
   if (!usage) {
     return null;
@@ -101,21 +92,7 @@ export const formatResponseUsageLine = (params: {
   }
   const inputLabel = typeof input === "number" ? formatTokenCount(input) : "?";
   const outputLabel = typeof output === "number" ? formatTokenCount(output) : "?";
-  const cost =
-    params.showCost && typeof input === "number" && typeof output === "number"
-      ? estimateUsageCost({
-          usage: {
-            input,
-            output,
-            cacheRead: usage.cacheRead,
-            cacheWrite: usage.cacheWrite,
-          },
-          cost: params.costConfig,
-        })
-      : undefined;
-  const costLabel = params.showCost ? formatUsd(cost) : undefined;
-  const suffix = costLabel ? ` · est ${costLabel}` : "";
-  return `Usage: ${inputLabel} in / ${outputLabel} out${suffix}`;
+  return `Usage: ${inputLabel} in / ${outputLabel} out`;
 };
 
 export const appendUsageLine = (payloads: ReplyPayload[], line: string): ReplyPayload[] => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -8,10 +8,6 @@ const lookupContextTokens = (..._args: unknown[]) => undefined as any;
 // oxlint-disable-next-line typescript/no-explicit-any
 const DEFAULT_CONTEXT_TOKENS = undefined as any;
 // Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "../../agents/model-auth.js";
-// oxlint-disable-next-line typescript/no-explicit-any
-const resolveModelAuthMode = (..._args: unknown[]) => undefined as any;
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
 // import ... from "../../agents/model-selection.js";
 // oxlint-disable-next-line typescript/no-explicit-any
 const isCliProvider = (..._args: unknown[]) => undefined as any;
@@ -34,7 +30,6 @@ import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnosti
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { defaultRuntime } from "../../runtime.js";
-import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -533,14 +528,6 @@ export async function runReplyAgent(params: {
       const cacheWrite = usage.cacheWrite ?? 0;
       const promptTokens = input + cacheRead + cacheWrite;
       const totalTokens = usage.total ?? promptTokens + output;
-      const costConfig = resolveModelCostConfig({
-        // @ts-expect-error — upstream feature not available in RemoteClaw fork
-        provider: providerUsed,
-        // @ts-expect-error — upstream feature not available in RemoteClaw fork
-        model: modelUsed,
-        config: cfg,
-      });
-      const costUsd = estimateUsageCost({ usage, cost: costConfig });
       emitDiagnosticEvent({
         type: "model.usage",
         sessionKey,
@@ -564,7 +551,6 @@ export async function runReplyAgent(params: {
           limit: contextTokensUsed,
           used: totalTokens,
         },
-        costUsd,
         durationMs: Date.now() - runStartedAt,
       });
     }
@@ -575,21 +561,8 @@ export async function runReplyAgent(params: {
     const responseUsageMode = resolveResponseUsageMode(responseUsageRaw);
     // @ts-expect-error — upstream feature not available in RemoteClaw fork
     if (responseUsageMode !== "off" && hasNonzeroUsage(usage)) {
-      const authMode = resolveModelAuthMode(providerUsed, cfg);
-      const showCost = authMode === "api-key";
-      const costConfig = showCost
-        ? resolveModelCostConfig({
-            // @ts-expect-error — upstream feature not available in RemoteClaw fork
-            provider: providerUsed,
-            // @ts-expect-error — upstream feature not available in RemoteClaw fork
-            model: modelUsed,
-            config: cfg,
-          })
-        : undefined;
       let formatted = formatResponseUsageLine({
         usage,
-        showCost,
-        costConfig,
       });
       if (formatted && responseUsageMode === "full" && sessionKey) {
         formatted = `${formatted} · session \`${sessionKey}\``;

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -82,7 +82,6 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Model: anthropic/pi:opus");
     expect(normalized).toContain("api-key");
     expect(normalized).toContain("Tokens: 1.2k in / 800 out");
-    expect(normalized).toContain("Cost: $0.0020");
     expect(normalized).toContain("Context: 16k/32k (50%)");
     expect(normalized).toContain("Compactions: 2");
     expect(normalized).toContain("Session: agent:main:main");
@@ -397,33 +396,14 @@ describe("buildStatusMessage", () => {
     expect(lines[contextIndex + 1]).toContain("Usage: Claude 80% left (5h)");
   });
 
-  it("hides cost when not using an API key", () => {
+  it("never shows cost line — cost calculation removed", () => {
     const text = buildStatusMessage({
-      config: {
-        models: {
-          providers: {
-            anthropic: {
-              models: [
-                {
-                  id: "claude-opus-4-5",
-                  cost: {
-                    input: 1,
-                    output: 1,
-                    cacheRead: 0,
-                    cacheWrite: 0,
-                  },
-                },
-              ],
-            },
-          },
-        },
-      } as unknown as RemoteClawConfig,
       agent: { model: "anthropic/claude-opus-4-5" },
       sessionEntry: { sessionId: "c1", updatedAt: 0, inputTokens: 10 },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
       queue: { mode: "collect", depth: 0 },
-      modelAuth: "oauth",
+      modelAuth: "api-key",
     });
 
     expect(text).not.toContain("💵 Cost:");

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -12,10 +12,6 @@ const DEFAULT_MODEL = "default";
 // oxlint-disable-next-line typescript/no-explicit-any
 const DEFAULT_PROVIDER = "cli";
 // Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "../agents/model-auth.js";
-// oxlint-disable-next-line typescript/no-explicit-any
-const resolveModelAuthMode = (..._args: unknown[]) => undefined as any;
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
 // import ... from "../agents/model-selection.js";
 // oxlint-disable-next-line typescript/no-explicit-any
 const buildModelAliasIndex = (..._args: unknown[]) => undefined as any;
@@ -59,12 +55,7 @@ import {
   resolveTtsConfig,
   resolveTtsPrefsPath,
 } from "../tts/tts.js";
-import {
-  estimateUsageCost,
-  formatTokenCount as formatTokenCountShared,
-  formatUsd,
-  resolveModelCostConfig,
-} from "../utils/usage-format.js";
+import { formatTokenCount as formatTokenCountShared } from "../utils/usage-format.js";
 import { VERSION } from "../version.js";
 import {
   listChatCommands,
@@ -611,35 +602,11 @@ export function buildStatusMessage(args: StatusArgs): string {
   ];
   const activationLine = activationParts.filter(Boolean).join(" · ");
 
-  const selectedAuthMode =
-    normalizeAuthMode(args.modelAuth) ?? resolveModelAuthMode(selectedProvider, args.config);
+  const selectedAuthMode = normalizeAuthMode(args.modelAuth);
   const selectedAuthLabelValue =
     args.modelAuth ??
     (selectedAuthMode && selectedAuthMode !== "unknown" ? selectedAuthMode : undefined);
-  const activeAuthMode =
-    normalizeAuthMode(args.activeModelAuth) ?? resolveModelAuthMode(activeProvider, args.config);
   const selectedModelLabel = modelRefs.selected.label || "unknown";
-  const effectiveCostAuthMode = selectedAuthMode ?? activeAuthMode;
-  const showCost = effectiveCostAuthMode === "api-key" || effectiveCostAuthMode === "mixed";
-  const costConfig = showCost
-    ? resolveModelCostConfig({
-        provider: activeProvider,
-        model: activeModel,
-        config: args.config,
-      })
-    : undefined;
-  const hasUsage = typeof inputTokens === "number" || typeof outputTokens === "number";
-  const cost =
-    showCost && hasUsage
-      ? estimateUsageCost({
-          usage: {
-            input: inputTokens ?? undefined,
-            output: outputTokens ?? undefined,
-          },
-          cost: costConfig,
-        })
-      : undefined;
-  const costLabel = showCost && hasUsage ? formatUsd(cost) : undefined;
 
   const selectedAuthLabel = selectedAuthLabelValue ? ` · 🔑 ${selectedAuthLabelValue}` : "";
   const channelModelNote = (() => {
@@ -686,9 +653,6 @@ export function buildStatusMessage(args: StatusArgs): string {
   const versionLine = `🦞 RemoteClaw ${VERSION}${commit ? ` (${commit})` : ""}`;
   const usagePair = formatUsagePair(inputTokens, outputTokens);
   const cacheLine = formatCacheLine(inputTokens, cacheRead, cacheWrite);
-  const costLine = costLabel ? `💵 Cost: ${costLabel}` : null;
-  const usageCostLine =
-    usagePair && costLine ? `${usagePair} · ${costLine}` : (usagePair ?? costLine);
   const mediaLine = formatMediaUnderstandingLine(args.mediaDecisions);
   const voiceLine = formatVoiceModeLine(args.config, args.sessionEntry);
 
@@ -696,7 +660,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     versionLine,
     args.timeLine,
     modelLine,
-    usageCostLine,
+    usagePair,
     cacheLine,
     `📚 ${contextLine}`,
     mediaLine,


### PR DESCRIPTION
## Summary

- Remove `resolveModelCostConfig()` and `resolveModelAuthMode()` calls from agent runner and status display
- Remove `showCost` conditionals and cost estimation from response usage formatting
- Remove `costUsd` from diagnostic event emission in agent runner
- Remove cost line from `/status` output — usage tokens still displayed

Closes #2107

## Test plan

- [x] `pnpm check` passes (format, typecheck, lint)
- [x] `src/auto-reply/status.test.ts` — 14 passing, 10 skipped (pre-existing)
- [x] `src/utils/usage-format.test.ts` — 2 passing
- [x] `src/infra/session-cost-usage.test.ts` — 9 passing
- [x] Updated test: verifies cost line never appears even with `modelAuth: "api-key"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)