### PR TITLE
gut(providers): collapse isCliProvider hardcoded *-cli checks into CLI_RUNTIME_NAMES

### DIFF
--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -44,24 +44,6 @@ describe("getCliSessionId", () => {
     const entry = makeEntry({ cliSessionIds: { claude: "   " } });
     expect(getCliSessionId(entry, "claude")).toBeUndefined();
   });
-
-  it("falls back to legacy claudeCliSessionId for claude-cli provider", () => {
-    const entry = makeEntry({ claudeCliSessionId: "legacy-sess" });
-    expect(getCliSessionId(entry, "claude-cli")).toBe("legacy-sess");
-  });
-
-  it("prefers cliSessionIds map over legacy field", () => {
-    const entry = makeEntry({
-      cliSessionIds: { "claude-cli": "map-sess" },
-      claudeCliSessionId: "legacy-sess",
-    });
-    expect(getCliSessionId(entry, "claude-cli")).toBe("map-sess");
-  });
-
-  it("does not fall back to legacy field for non-claude-cli providers", () => {
-    const entry = makeEntry({ claudeCliSessionId: "legacy-sess" });
-    expect(getCliSessionId(entry, "claude")).toBeUndefined();
-  });
 });
 
 describe("setCliSessionId", () => {
@@ -114,19 +96,6 @@ describe("setCliSessionId", () => {
     const entry = makeEntry();
     setCliSessionId(entry, "claude", "  trimmed-sess  ");
     expect(entry.cliSessionIds?.["claude"]).toBe("trimmed-sess");
-  });
-
-  it("also sets legacy claudeCliSessionId for claude-cli provider", () => {
-    const entry = makeEntry();
-    setCliSessionId(entry, "claude-cli", "dual-sess");
-    expect(entry.cliSessionIds?.["claude-cli"]).toBe("dual-sess");
-    expect(entry.claudeCliSessionId).toBe("dual-sess");
-  });
-
-  it("does not set legacy field for non-claude-cli providers", () => {
-    const entry = makeEntry();
-    setCliSessionId(entry, "claude", "sess-123");
-    expect(entry.claudeCliSessionId).toBeUndefined();
   });
 });
 

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -13,12 +13,6 @@ export function getCliSessionId(
   if (fromMap?.trim()) {
     return fromMap.trim();
   }
-  if (normalized === "claude-cli") {
-    const legacy = entry.claudeCliSessionId?.trim();
-    if (legacy) {
-      return legacy;
-    }
-  }
   return undefined;
 }
 
@@ -31,7 +25,4 @@ export function setCliSessionId(entry: SessionEntry, provider: string, sessionId
   const existing = entry.cliSessionIds ?? {};
   entry.cliSessionIds = { ...existing };
   entry.cliSessionIds[normalized] = trimmed;
-  if (normalized === "claude-cli") {
-    entry.claudeCliSessionId = trimmed;
-  }
 }

--- a/src/agents/provider-utils.test.ts
+++ b/src/agents/provider-utils.test.ts
@@ -3,16 +3,16 @@ import type { RemoteClawConfig } from "../config/config.js";
 import { isCliProvider } from "./provider-utils.js";
 
 describe("isCliProvider", () => {
-  it("recognizes legacy CLI provider names", () => {
-    expect(isCliProvider("claude-cli")).toBe(true);
-    expect(isCliProvider("codex-cli")).toBe(true);
-  });
-
   it("recognizes agent runtime names as CLI providers", () => {
     expect(isCliProvider("claude")).toBe(true);
     expect(isCliProvider("gemini")).toBe(true);
     expect(isCliProvider("codex")).toBe(true);
     expect(isCliProvider("opencode")).toBe(true);
+  });
+
+  it("does not recognize legacy -cli suffixed names", () => {
+    expect(isCliProvider("claude-cli")).toBe(false);
+    expect(isCliProvider("codex-cli")).toBe(false);
   });
 
   it("recognizes cliBackends entries", () => {

--- a/src/agents/provider-utils.ts
+++ b/src/agents/provider-utils.ts
@@ -76,12 +76,6 @@ const CLI_RUNTIME_NAMES = new Set(["claude", "gemini", "codex", "opencode"]);
 
 export function isCliProvider(provider: string, cfg?: RemoteClawConfig): boolean {
   const normalized = normalizeProviderId(provider);
-  if (normalized === "claude-cli") {
-    return true;
-  }
-  if (normalized === "codex-cli") {
-    return true;
-  }
   if (CLI_RUNTIME_NAMES.has(normalized)) {
     return true;
   }

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -668,12 +668,12 @@ describe.skip("agentCommand", () => {
     });
   });
 
-  it("clears stale Claude CLI legacy session IDs before retrying after session expiration", async () => {
+  it("clears stale CLI session IDs before retrying after session expiration", async () => {
     // @ts-ignore — gutted in RemoteClaw fork (skipped test block)
     vi.mocked(modelSelectionModule.isCliProvider).mockImplementation(
       // @ts-ignore — gutted in RemoteClaw fork (skipped test block)
       (provider: unknown) =>
-        typeof provider === "string" && provider.trim().toLowerCase() === "claude-cli",
+        typeof provider === "string" && provider.trim().toLowerCase() === "claude",
     );
     try {
       await withTempHome(async (home) => {
@@ -683,21 +683,20 @@ describe.skip("agentCommand", () => {
           [sessionKey]: {
             sessionId: "session-cli-123",
             updatedAt: Date.now(),
-            providerOverride: "claude-cli",
+            providerOverride: "claude",
             modelOverride: "opus",
-            cliSessionIds: { "claude-cli": "stale-cli-session" },
-            claudeCliSessionId: "stale-legacy-session",
+            cliSessionIds: { claude: "stale-cli-session" },
           },
         });
         mockConfig(home, store, {
-          model: { primary: "claude-cli/opus", fallbacks: [] },
-          models: { "claude-cli/opus": {} },
+          model: { primary: "claude/opus", fallbacks: [] },
+          models: { "claude/opus": {} },
         });
         runCliAgentSpy
           .mockRejectedValueOnce(
             new FailoverError("session expired", {
               reason: "session_expired",
-              provider: "claude-cli",
+              provider: "claude",
               model: "opus",
               status: 410,
             }),
@@ -720,11 +719,10 @@ describe.skip("agentCommand", () => {
 
         const saved = JSON.parse(fs.readFileSync(store, "utf-8")) as Record<
           string,
-          { cliSessionIds?: Record<string, string>; claudeCliSessionId?: string }
+          { cliSessionIds?: Record<string, string> }
         >;
         const entry = saved[sessionKey];
-        expect(entry?.cliSessionIds?.["claude-cli"]).toBeUndefined();
-        expect(entry?.claudeCliSessionId).toBeUndefined();
+        expect(entry?.cliSessionIds?.["claude"]).toBeUndefined();
       });
     } finally {
       // @ts-ignore — gutted in RemoteClaw fork (skipped test block)

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -276,9 +276,6 @@ function runAgentAttempt(params: {
         const entry = params.sessionStore[params.sessionKey];
         if (entry) {
           const updatedEntry = { ...entry };
-          if (params.providerOverride === "claude-cli") {
-            delete updatedEntry.claudeCliSessionId;
-          }
           if (updatedEntry.cliSessionIds) {
             const normalizedProvider = normalizeProviderId(params.providerOverride);
             const newCliSessionIds = { ...updatedEntry.cliSessionIds };


### PR DESCRIPTION
## Summary

Closes #2125

- Remove hardcoded `"claude-cli"` and `"codex-cli"` special-case branches from `isCliProvider()` — bare runtime names via `CLI_RUNTIME_NAMES` are now the only path
- Remove `"claude-cli"` legacy fallback from `getCliSessionId()` and dual-write from `setCliSessionId()` in `cli-session.ts`
- Remove `providerOverride === "claude-cli"` → `claudeCliSessionId` cleanup from the session expiration handler in `agent.ts`
- Update tests: `-cli` suffixed names now return `false` from `isCliProvider()`; legacy `claudeCliSessionId` test cases removed

## Test plan

- [x] `pnpm check` passes (format + typecheck + lint)
- [x] Unit tests pass (1028 files, 8765 tests)
- [x] `isCliProvider("claude")` → `true`, `isCliProvider("claude-cli")` → `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)