### PR TITLE
fix(session): replace shadow isCliProvider stubs with real import and gut dead model lookup stubs

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,16 +1,5 @@
 import fs from "node:fs";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "../../agents/context.js";
-// oxlint-disable-next-line typescript/no-explicit-any
-const lookupContextTokens = (..._args: unknown[]) => undefined as any;
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "../../agents/defaults.js";
-// oxlint-disable-next-line typescript/no-explicit-any
-const DEFAULT_CONTEXT_TOKENS = undefined as any;
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "../../agents/model-selection.js";
-// oxlint-disable-next-line typescript/no-explicit-any
-const isCliProvider = (..._args: unknown[]) => undefined as any;
+import { isCliProvider } from "../../agents/provider-utils.js";
 // Gutted in RemoteClaw fork (Middleware Boundary Principle)
 // import ... from "../../agents/pi-embedded.js";
 // oxlint-disable-next-line typescript/no-explicit-any
@@ -438,15 +427,11 @@ export async function runReplyAgent(params: {
     const modelUsed = runResult.meta?.agentMeta?.model ?? followupRun.run.model;
     const providerUsed = runResult.meta?.agentMeta?.provider ?? followupRun.run.provider;
     const verboseEnabled = resolvedVerboseLevel !== "off";
-    const cliSessionId = isCliProvider(providerUsed, cfg)
+    const cliSessionId = isCliProvider(providerUsed as string, cfg)
       ? // @ts-expect-error — upstream feature not available in RemoteClaw fork
         runResult.meta?.agentMeta?.sessionId?.trim()
       : undefined;
-    const contextTokensUsed =
-      agentCfgContextTokens ??
-      lookupContextTokens(modelUsed) ??
-      activeSessionEntry?.contextTokens ??
-      DEFAULT_CONTEXT_TOKENS;
+    const contextTokensUsed = agentCfgContextTokens ?? activeSessionEntry?.contextTokens ?? 200_000;
 
     await persistRunSessionUsage({
       storePath,

--- a/src/commands/agent/session-store.ts
+++ b/src/commands/agent/session-store.ts
@@ -1,16 +1,5 @@
 import { setCliSessionId } from "../../agents/cli-session.js";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "../../agents/context.js";
-// oxlint-disable-next-line typescript/no-explicit-any
-const resolveContextTokensForModel = (..._args: unknown[]) => undefined as any;
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "../../agents/defaults.js";
-// oxlint-disable-next-line typescript/no-explicit-any
-const DEFAULT_CONTEXT_TOKENS = undefined as any;
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "../../agents/model-selection.js";
-// oxlint-disable-next-line typescript/no-explicit-any
-const isCliProvider = (..._args: unknown[]) => undefined as any;
+import { isCliProvider } from "../../agents/provider-utils.js";
 import { deriveSessionTotalTokens, hasNonzeroUsage } from "../../agents/usage.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import {
@@ -64,14 +53,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
   const modelUsed = result.meta.agentMeta?.model ?? defaultModel;
   // @ts-expect-error — upstream feature not available in RemoteClaw fork
   const providerUsed = result.meta.agentMeta?.provider ?? defaultProvider;
-  const contextTokens =
-    resolveContextTokensForModel({
-      cfg,
-      provider: providerUsed,
-      model: modelUsed,
-      contextTokensOverride: params.contextTokensOverride,
-      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
-    }) ?? DEFAULT_CONTEXT_TOKENS;
+  const contextTokens = params.contextTokensOverride ?? 200_000;
 
   const entry = sessionStore[sessionKey] ?? {
     sessionId,
@@ -87,7 +69,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
     provider: providerUsed,
     model: modelUsed,
   });
-  if (isCliProvider(providerUsed, cfg)) {
+  if (isCliProvider(providerUsed as string, cfg)) {
     // @ts-expect-error — upstream feature not available in RemoteClaw fork
     const cliSessionId = result.meta.agentMeta?.sessionId?.trim();
     if (cliSessionId) {


### PR DESCRIPTION
## Summary

Closes #2145.

- **Replace `isCliProvider` shadow stubs** in `agent-runner.ts` and `session-store.ts` with real imports from `provider-utils.ts` — fixes CLI session IDs never being extracted/persisted (stub returned `undefined`, always falsy)
- **Remove dead `lookupContextTokens` + `DEFAULT_CONTEXT_TOKENS` stubs** in `agent-runner.ts` — collapse chain to `agentCfgContextTokens ?? activeSessionEntry?.contextTokens ?? 200_000`
- **Remove dead `resolveContextTokensForModel` + `DEFAULT_CONTEXT_TOKENS` stubs** in `session-store.ts` — simplify to `params.contextTokensOverride ?? 200_000`

## Test plan

- [x] `pnpm check` passes (format, typecheck, lint)
- [x] `pnpm test` passes (11195 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)