### PR TITLE
gut(providers): migrate cliBackends config keys from *-cli to bare runtime names

### DIFF
--- a/src/agents/provider-utils.test.ts
+++ b/src/agents/provider-utils.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, it } from "vitest";
 import type { RemoteClawConfig } from "../config/config.js";
-import { isCliProvider } from "./provider-utils.js";
+import { isCliProvider, normalizeProviderId } from "./provider-utils.js";
+
+describe("normalizeProviderId", () => {
+  it("maps *-cli suffixed names to bare runtime names", () => {
+    expect(normalizeProviderId("claude-cli")).toBe("claude");
+    expect(normalizeProviderId("codex-cli")).toBe("codex");
+  });
+
+  it("passes through bare runtime names unchanged", () => {
+    expect(normalizeProviderId("claude")).toBe("claude");
+    expect(normalizeProviderId("codex")).toBe("codex");
+    expect(normalizeProviderId("gemini")).toBe("gemini");
+    expect(normalizeProviderId("opencode")).toBe("opencode");
+  });
+});
 
 describe("isCliProvider", () => {
   it("recognizes agent runtime names as CLI providers", () => {
@@ -10,9 +24,9 @@ describe("isCliProvider", () => {
     expect(isCliProvider("opencode")).toBe(true);
   });
 
-  it("does not recognize legacy -cli suffixed names", () => {
-    expect(isCliProvider("claude-cli")).toBe(false);
-    expect(isCliProvider("codex-cli")).toBe(false);
+  it("normalizes -cli suffixed names to bare runtime names", () => {
+    expect(isCliProvider("claude-cli")).toBe(true);
+    expect(isCliProvider("codex-cli")).toBe(true);
   });
 
   it("recognizes cliBackends entries", () => {

--- a/src/agents/provider-utils.ts
+++ b/src/agents/provider-utils.ts
@@ -38,6 +38,13 @@ export function normalizeProviderId(provider: string): string {
   if (normalized === "bytedance" || normalized === "doubao") {
     return "volcengine";
   }
+  // Backward compatibility: *-cli config keys → bare runtime names.
+  if (normalized === "claude-cli") {
+    return "claude";
+  }
+  if (normalized === "codex-cli") {
+    return "codex";
+  }
   return normalized;
 }
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -924,7 +924,8 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.imageModel.fallbacks": "Ordered fallback image models (provider/model).",
   "agents.defaults.imageMaxDimensionPx":
     "Max image side length in pixels when sanitizing transcript/tool-result image payloads (default: 1200).",
-  "agents.defaults.cliBackends": "Optional CLI backends for text-only fallback (claude-cli, etc.).",
+  "agents.defaults.cliBackends":
+    "Optional CLI backends for text-only fallback (claude, codex, etc.).",
   "agents.defaults.compaction":
     "Compaction tuning for when context nears token limits, including history share, reserve headroom, and pre-compaction memory flush behavior. Use this when long-running sessions need stable continuity under tight context windows.",
   "agents.defaults.compaction.mode":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -162,7 +162,7 @@ export type AgentDefaultsConfig = {
   envelopeElapsed?: "on" | "off";
   /** Optional context window cap (used for runtime estimates + status %). */
   contextTokens?: number;
-  /** Optional CLI backends for text-only fallback (claude-cli, etc.). */
+  /** Optional CLI backends for text-only fallback (claude, codex, etc.). */
   cliBackends?: Record<string, CliBackendConfig>;
   /** Opt-in: prune old tool results from the LLM context to reduce token usage. */
   contextPruning?: AgentContextPruningConfig;


### PR DESCRIPTION
## Summary

- Add `normalizeProviderId` rules: `"claude-cli"` → `"claude"`, `"codex-cli"` → `"codex"` for backwards compatibility with existing user configs
- Update `schema.help.ts` and `types.agent-defaults.ts` comment examples to use bare runtime names
- Update `provider-utils.test.ts` to verify normalization and that `isCliProvider` recognizes `-cli` suffixed names via normalization

Closes #2126

## Test plan

- [x] `normalizeProviderId("claude-cli")` returns `"claude"`
- [x] `normalizeProviderId("codex-cli")` returns `"codex"`
- [x] `isCliProvider("claude-cli")` returns `true` (via normalization)
- [x] `isCliProvider("codex-cli")` returns `true` (via normalization)
- [x] `pnpm check` passes
- [x] `pnpm test` passes (883 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)