### PR TITLE
gut(providers): update docs and tests from *-cli to bare runtime names (#2128)

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -52,7 +52,7 @@ Notes:
 - `--allow-unconfigured`: allow gateway start without `gateway.mode=local` in config.
 - `--force`: kill any existing listener on the selected port before starting.
 - `--verbose`: verbose logs.
-- `--claude-cli-logs`: only show claude-cli logs in the console (and enable its stdout/stderr).
+- `--claude-logs`: only show claude logs in the console (and enable its stdout/stderr).
 - `--ws-log <auto|full|compact>`: websocket log style (default `auto`).
 - `--compact`: alias for `--ws-log compact`.
 - `--raw-stream`: log raw model stream events to jsonl.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -749,7 +749,7 @@ Options:
 - `--reset` (reset dev config + credentials + sessions + workspace)
 - `--force` (kill existing listener on port)
 - `--verbose`
-- `--claude-cli-logs`
+- `--claude-logs`
 - `--ws-log <auto|full|compact>`
 - `--compact` (alias for `--ws-log compact`)
 - `--raw-stream`

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -24,13 +24,13 @@ provides a text-only path through these CLIs:
 You can use Claude Code CLI **without any config** (RemoteClaw ships a built-in default):
 
 ```bash
-remoteclaw agent --message "hi" --model claude-cli/opus-4.6
+remoteclaw agent --message "hi" --model claude/opus-4.6
 ```
 
 Codex CLI also works out of the box:
 
 ```bash
-remoteclaw agent --message "hi" --model codex-cli/gpt-5.3-codex
+remoteclaw agent --message "hi" --model codex/gpt-5.3-codex
 ```
 
 If your gateway runs under launchd/systemd and PATH is minimal, add just the
@@ -41,7 +41,7 @@ command path:
   agents: {
     defaults: {
       cliBackends: {
-        "claude-cli": {
+        claude: {
           command: "/opt/homebrew/bin/claude",
         },
       },
@@ -60,7 +60,7 @@ All CLI backends live under:
 agents.defaults.cliBackends
 ```
 
-Each entry is keyed by a **provider id** (e.g. `claude-cli`, `my-cli`).
+Each entry is keyed by a **provider id** (e.g. `claude`, `my-cli`).
 The provider id becomes the left side of your model ref:
 
 ```
@@ -74,7 +74,7 @@ The provider id becomes the left side of your model ref:
   agents: {
     defaults: {
       cliBackends: {
-        "claude-cli": {
+        claude: {
           command: "/opt/homebrew/bin/claude",
         },
         "my-cli": {
@@ -105,7 +105,7 @@ The provider id becomes the left side of your model ref:
 
 ## How it works
 
-1. **Selects a backend** based on the provider prefix (`claude-cli/...`).
+1. **Selects a backend** based on the provider prefix (`claude/...`).
 2. **Builds a system prompt** using the same RemoteClaw prompt + workspace context.
 3. **Executes the CLI** with a session id (if supported) so history stays consistent.
 4. **Parses output** (JSON or plain text) and returns the final text.
@@ -153,7 +153,7 @@ Input modes:
 
 ## Defaults (built-in)
 
-RemoteClaw ships a default for `claude-cli`:
+RemoteClaw ships a default for `claude`:
 
 - `command: "claude"`
 - `args: ["-p", "--output-format", "json", "--dangerously-skip-permissions"]`
@@ -164,7 +164,7 @@ RemoteClaw ships a default for `claude-cli`:
 - `systemPromptWhen: "first"`
 - `sessionMode: "always"`
 
-RemoteClaw also ships a default for `codex-cli`:
+RemoteClaw also ships a default for `codex`:
 
 - `command: "codex"`
 - `args: ["exec","--json","--color","never","--sandbox","read-only","--skip-git-repo-check"]`

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -884,7 +884,7 @@ Optional CLI backends for text-only fallback runs (no tool calls). Useful as a b
   agents: {
     defaults: {
       cliBackends: {
-        "claude-cli": {
+        claude: {
           command: "/opt/homebrew/bin/claude",
         },
         "my-cli": {

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -217,12 +217,12 @@ REMOTECLAW_LIVE_SETUP_TOKEN=1 REMOTECLAW_LIVE_SETUP_TOKEN_PROFILE=anthropic:setu
   - `pnpm test:live` (or `REMOTECLAW_LIVE_TEST=1` if invoking Vitest directly)
   - `REMOTECLAW_LIVE_CLI_BACKEND=1`
 - Defaults:
-  - Model: `claude-cli/claude-sonnet-4-6`
+  - Model: `claude/claude-sonnet-4-6`
   - Command: `claude`
   - Args: `["-p","--output-format","json","--dangerously-skip-permissions"]`
 - Overrides (optional):
-  - `REMOTECLAW_LIVE_CLI_BACKEND_MODEL="claude-cli/claude-opus-4-6"`
-  - `REMOTECLAW_LIVE_CLI_BACKEND_MODEL="codex-cli/gpt-5.3-codex"`
+  - `REMOTECLAW_LIVE_CLI_BACKEND_MODEL="claude/claude-opus-4-6"`
+  - `REMOTECLAW_LIVE_CLI_BACKEND_MODEL="codex/gpt-5.3-codex"`
   - `REMOTECLAW_LIVE_CLI_BACKEND_COMMAND="/full/path/to/claude"`
   - `REMOTECLAW_LIVE_CLI_BACKEND_ARGS='["-p","--output-format","json","--permission-mode","bypassPermissions"]'`
   - `REMOTECLAW_LIVE_CLI_BACKEND_CLEAR_ENV='["ANTHROPIC_API_KEY","ANTHROPIC_API_KEY_OLD"]'`
@@ -236,7 +236,7 @@ Example:
 
 ```bash
 REMOTECLAW_LIVE_CLI_BACKEND=1 \
-  REMOTECLAW_LIVE_CLI_BACKEND_MODEL="claude-cli/claude-sonnet-4-6" \
+  REMOTECLAW_LIVE_CLI_BACKEND_MODEL="claude/claude-sonnet-4-6" \
   pnpm test:live src/gateway/gateway-cli-backend.live.test.ts
 ```
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -178,7 +178,7 @@ describe.skip("runReplyAgent onAgentRunStart", () => {
       payloads: [{ text: "ok" }],
       meta: {
         agentMeta: {
-          provider: "claude-cli",
+          provider: "claude",
           model: "opus-4.5",
         },
       },
@@ -186,7 +186,7 @@ describe.skip("runReplyAgent onAgentRunStart", () => {
     const onAgentRunStart = vi.fn();
 
     const result = await createRun({
-      provider: "claude-cli",
+      provider: "claude",
       model: "opus-4.5",
       opts: { runId: "run-started", onAgentRunStart },
     });
@@ -776,7 +776,7 @@ describe.skip("runReplyAgent block streaming", () => {
 
 // Skipped: tests gutted functionality (Middleware Boundary Principle)
 
-describe.skip("runReplyAgent claude-cli routing", () => {
+describe.skip("runReplyAgent claude routing", () => {
   function createRun() {
     const typing = createMockTypingController();
     const sessionCtx = {
@@ -798,7 +798,7 @@ describe.skip("runReplyAgent claude-cli routing", () => {
         workspaceDir: "/tmp",
         config: {},
         skillsSnapshot: {},
-        provider: "claude-cli",
+        provider: "claude",
         model: "opus-4.5",
         thinkLevel: "low",
         verboseLevel: "off",
@@ -834,7 +834,7 @@ describe.skip("runReplyAgent claude-cli routing", () => {
     });
   }
 
-  it("uses claude-cli runner for claude-cli provider", async () => {
+  it("uses claude runner for claude provider", async () => {
     const runId = "00000000-0000-0000-0000-000000000001";
     const randomSpy = vi.spyOn(crypto, "randomUUID").mockReturnValue(runId);
     const lifecyclePhases: string[] = [];
@@ -854,7 +854,7 @@ describe.skip("runReplyAgent claude-cli routing", () => {
       payloads: [{ text: "ok" }],
       meta: {
         agentMeta: {
-          provider: "claude-cli",
+          provider: "claude",
           model: "opus-4.5",
         },
       },

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -1115,8 +1115,8 @@ describe("runReplyAgent memory flush", () => {
       await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
 
       // The main execution path now goes through ChannelBridge for all providers
-      // (including CLI providers like codex-cli). Memory flush is skipped because
-      // isCliProvider("codex-cli") returns true in agent-runner-memory.ts.
+      // (including CLI providers like codex). Memory flush is skipped because
+      // isCliProvider("codex") returns true in agent-runner-memory.ts.
       state.channelBridgeHandleMock.mockResolvedValue(
         makeDeliveryResult({
           usage: { inputTokens: 1, outputTokens: 1 },
@@ -1126,7 +1126,7 @@ describe("runReplyAgent memory flush", () => {
       const baseRun = createBaseRun({
         storePath,
         sessionEntry,
-        runOverrides: { provider: "codex-cli" },
+        runOverrides: { provider: "codex" },
       });
 
       await runReplyAgentWithBase({

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -42,7 +42,7 @@ type GatewayRunOpts = {
   allowUnconfigured?: boolean;
   force?: boolean;
   verbose?: boolean;
-  claudeCliLogs?: boolean;
+  claudeLogs?: boolean;
   wsLog?: unknown;
   compact?: boolean;
   rawStream?: boolean;
@@ -67,7 +67,7 @@ const GATEWAY_RUN_BOOLEAN_KEYS = [
   "allowUnconfigured",
   "force",
   "verbose",
-  "claudeCliLogs",
+  "claudeLogs",
   "compact",
   "rawStream",
 ] as const;
@@ -132,9 +132,9 @@ function resolveGatewayRunOptions(opts: GatewayRunOpts, command?: Command): Gate
 async function runGatewayCommand(opts: GatewayRunOpts) {
   setConsoleTimestampPrefix(true);
   setVerbose(Boolean(opts.verbose));
-  if (opts.claudeCliLogs) {
-    setConsoleSubsystemFilter(["agent/claude-cli"]);
-    process.env.REMOTECLAW_CLAUDE_CLI_LOG_OUTPUT = "1";
+  if (opts.claudeLogs) {
+    setConsoleSubsystemFilter(["agent/claude"]);
+    process.env.REMOTECLAW_CLAUDE_LOG_OUTPUT = "1";
   }
   const wsLogRaw = (opts.compact ? "compact" : opts.wsLog) as string | undefined;
   const wsLogStyle: GatewayWsLogStyle =
@@ -399,11 +399,7 @@ export function addGatewayRunCommand(cmd: Command): Command {
     )
     .option("--force", "Kill any existing listener on the target port before starting", false)
     .option("--verbose", "Verbose logging to stdout/stderr", false)
-    .option(
-      "--claude-cli-logs",
-      "Only show claude-cli logs in the console (includes stdout/stderr)",
-      false,
-    )
+    .option("--claude-logs", "Only show claude logs in the console (includes stdout/stderr)", false)
     .option("--ws-log <style>", 'WebSocket log style ("auto"|"full"|"compact")', "auto")
     .option("--compact", 'Alias for "--ws-log compact"', false)
     .option("--raw-stream", "Log raw model stream events to jsonl", false)

--- a/src/commands/import.test.ts
+++ b/src/commands/import.test.ts
@@ -790,8 +790,8 @@ describe("materializeAuthDefaults", () => {
         list: [{ id: "main", workspace: "~/ws" }],
       },
     });
-    const result = JSON.parse(materializeAuthDefaults(input, ["openai-codex:codex-cli"]));
-    expect(result.agents.defaults.auth).toBe("openai-codex:codex-cli");
+    const result = JSON.parse(materializeAuthDefaults(input, ["openai-codex:default"]));
+    expect(result.agents.defaults.auth).toBe("openai-codex:default");
   });
 
   it("sets auth for opencode runtime with anthropic profile", () => {

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -20,7 +20,7 @@ const CLI_IMAGE = isTruthyEnvValue(process.env.REMOTECLAW_LIVE_CLI_BACKEND_IMAGE
 const CLI_RESUME = isTruthyEnvValue(process.env.REMOTECLAW_LIVE_CLI_BACKEND_RESUME_PROBE);
 const describeLive = LIVE && CLI_LIVE ? describe : describe.skip;
 
-const DEFAULT_MODEL = "claude-cli/claude-sonnet-4-6";
+const DEFAULT_MODEL = "claude/claude-sonnet-4-6";
 const DEFAULT_CLAUDE_ARGS = ["-p", "--output-format", "json", "--dangerously-skip-permissions"];
 const DEFAULT_CODEX_ARGS = [
   "exec",
@@ -176,7 +176,7 @@ describeLive("gateway live (cli backend)", () => {
     process.env.REMOTECLAW_GATEWAY_TOKEN = token;
 
     const rawModel = process.env.REMOTECLAW_LIVE_CLI_BACKEND_MODEL ?? DEFAULT_MODEL;
-    const parsed = parseModelRef(rawModel, "claude-cli");
+    const parsed = parseModelRef(rawModel, "claude");
     if (!parsed) {
       throw new Error(
         `REMOTECLAW_LIVE_CLI_BACKEND_MODEL must resolve to a CLI backend model. Got: ${rawModel}`,
@@ -186,9 +186,9 @@ describeLive("gateway live (cli backend)", () => {
     const modelKey = `${providerId}/${parsed.model}`;
 
     const providerDefaults =
-      providerId === "claude-cli"
+      providerId === "claude"
         ? { command: "claude", args: DEFAULT_CLAUDE_ARGS }
-        : providerId === "codex-cli"
+        : providerId === "codex"
           ? { command: "codex", args: DEFAULT_CODEX_ARGS }
           : null;
 
@@ -210,7 +210,7 @@ describeLive("gateway live (cli backend)", () => {
       parseJsonStringArray(
         "REMOTECLAW_LIVE_CLI_BACKEND_CLEAR_ENV",
         process.env.REMOTECLAW_LIVE_CLI_BACKEND_CLEAR_ENV,
-      ) ?? (providerId === "claude-cli" ? DEFAULT_CLEAR_ENV : []);
+      ) ?? (providerId === "claude" ? DEFAULT_CLEAR_ENV : []);
     const cliImageArg = process.env.REMOTECLAW_LIVE_CLI_BACKEND_IMAGE_ARG?.trim() || undefined;
     const cliImageMode = parseImageMode(process.env.REMOTECLAW_LIVE_CLI_BACKEND_IMAGE_MODE);
 
@@ -223,7 +223,7 @@ describeLive("gateway live (cli backend)", () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-live-cli-"));
     const disableMcpConfig = process.env.REMOTECLAW_LIVE_CLI_BACKEND_DISABLE_MCP_CONFIG !== "0";
     let cliArgs = baseCliArgs;
-    if (providerId === "claude-cli" && disableMcpConfig) {
+    if (providerId === "claude" && disableMcpConfig) {
       const mcpConfigPath = path.join(tempDir, "claude-mcp.json");
       await fs.writeFile(mcpConfigPath, `${JSON.stringify({ mcpServers: {} }, null, 2)}\n`);
       cliArgs = withMcpConfigOverrides(baseCliArgs, mcpConfigPath);
@@ -282,7 +282,7 @@ describeLive("gateway live (cli backend)", () => {
       const runId = randomUUID();
       const nonce = randomBytes(3).toString("hex").toUpperCase();
       const message =
-        providerId === "codex-cli"
+        providerId === "codex"
           ? `Please include the token CLI-BACKEND-${nonce} in your reply.`
           : `Reply with exactly: CLI backend OK ${nonce}.`;
       const payload = await client.request(
@@ -299,7 +299,7 @@ describeLive("gateway live (cli backend)", () => {
         throw new Error(`agent status=${String(payload?.status)}`);
       }
       const text = extractPayloadText(payload?.result);
-      if (providerId === "codex-cli") {
+      if (providerId === "codex") {
         expect(text).toContain(`CLI-BACKEND-${nonce}`);
       } else {
         expect(text).toContain(`CLI backend OK ${nonce}.`);
@@ -309,7 +309,7 @@ describeLive("gateway live (cli backend)", () => {
         const runIdResume = randomUUID();
         const resumeNonce = randomBytes(3).toString("hex").toUpperCase();
         const resumeMessage =
-          providerId === "codex-cli"
+          providerId === "codex"
             ? `Please include the token CLI-RESUME-${resumeNonce} in your reply.`
             : `Reply with exactly: CLI backend RESUME OK ${resumeNonce}.`;
         const resumePayload = await client.request(
@@ -326,7 +326,7 @@ describeLive("gateway live (cli backend)", () => {
           throw new Error(`resume status=${String(resumePayload?.status)}`);
         }
         const resumeText = extractPayloadText(resumePayload?.result);
-        if (providerId === "codex-cli") {
+        if (providerId === "codex") {
           expect(resumeText).toContain(`CLI-RESUME-${resumeNonce}`);
         } else {
           expect(resumeText).toContain(`CLI backend RESUME OK ${resumeNonce}.`);

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -266,7 +266,7 @@ describe("gateway agent handler", () => {
   });
 
   it("preserves cliSessionIds from existing session entry", async () => {
-    const existingCliSessionIds = { "claude-cli": "abc-123-def" };
+    const existingCliSessionIds = { claude: "abc-123-def" };
     const existingClaudeCliSessionId = "abc-123-def";
 
     mockMainSessionEntry({


### PR DESCRIPTION
## Summary

- Replace all `claude-cli`/`codex-cli` provider references with bare runtime names (`claude`/`codex`) in documentation, test fixtures, and CLI flag
- Rename `--claude-cli-logs` CLI flag to `--claude-logs` (including internal option name, subsystem filter, and env var)
- Only `normalizeProviderId` backward-compat rules and their tests retain `*-cli` strings

Closes #2128

## Test plan

- [x] `pnpm check` passes (format + typecheck + lint)
- [x] `pnpm test` passes (883 passed, 83 skipped)
- [x] `grep -r "claude-cli\|codex-cli"` only finds `normalizeProviderId` backward-compat rules and their tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)