### PR TITLE
fix(cron): clear cliSessionIds on isolated session reset (#2112)

### DIFF
--- a/src/cron/isolated-agent/run.channel-bridge.test.ts
+++ b/src/cron/isolated-agent/run.channel-bridge.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getCliSessionId } from "../../agents/cli-session.js";
 import { buildSessionKey } from "../../middleware/channel-bridge.js";
 import type { ChannelMessage } from "../../middleware/types.js";
 
 // ---------- mocks ----------
 
 const channelBridgeHandleMock = vi.fn();
+let capturedSessionMap: import("../../middleware/session-map.js").SessionMap | undefined;
 
 vi.mock("../../middleware/channel-bridge.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../middleware/channel-bridge.js")>();
@@ -14,9 +16,12 @@ vi.mock("../../middleware/channel-bridge.js", async (importOriginal) => {
       readonly provider: string;
       readonly workspaceDir?: string;
 
-      constructor(opts: { provider: string; workspaceDir?: string }) {
+      constructor(opts: { provider: string; workspaceDir?: string; sessionMap?: unknown }) {
         this.provider = opts.provider;
         this.workspaceDir = opts.workspaceDir;
+        capturedSessionMap = opts.sessionMap as
+          | import("../../middleware/session-map.js").SessionMap
+          | undefined;
       }
 
       handle(message: ChannelMessage, callbacks?: unknown, abortSignal?: AbortSignal) {
@@ -257,6 +262,7 @@ describe("runCronIsolatedAgentTurn — ChannelBridge wiring", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    capturedSessionMap = undefined;
     previousFastTestEnv = process.env.REMOTECLAW_TEST_FAST;
     delete process.env.REMOTECLAW_TEST_FAST;
     resolveCronSessionMock.mockReturnValue(makeFreshSession());
@@ -391,6 +397,37 @@ describe("runCronIsolatedAgentTurn — ChannelBridge wiring", () => {
     // Partial success: has payloads despite error, so should not re-throw
     expect(channelBridgeHandleMock).toHaveBeenCalledOnce();
     expect(result.status).toBe("ok");
+  });
+
+  it("returns undefined from session map when isNewSession is true", async () => {
+    resolveCronSessionMock.mockReturnValue(makeFreshSession());
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    expect(capturedSessionMap).toBeDefined();
+    const sessionId = await capturedSessionMap!.get({ channelId: "", userId: "" });
+    expect(sessionId).toBeUndefined();
+    expect(getCliSessionId).not.toHaveBeenCalled();
+  });
+
+  it("returns CLI session ID from session map when isNewSession is false", async () => {
+    resolveCronSessionMock.mockReturnValue({
+      ...makeFreshSession(),
+      isNewSession: false,
+      sessionEntry: {
+        sessionId: "existing-session-id",
+        updatedAt: 0,
+        systemSent: true,
+        cliSessionIds: { claude: "cli-session-123" },
+      },
+    });
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    expect(capturedSessionMap).toBeDefined();
+    const sessionId = await capturedSessionMap!.get({ channelId: "", userId: "" });
+    expect(sessionId).toBe("cli-session-123");
+    expect(getCliSessionId).toHaveBeenCalled();
   });
 
   it("maps token usage from AgentDeliveryResult to telemetry", async () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -353,7 +353,8 @@ export async function runCronIsolatedAgentTurn(params: {
     }
 
     const sessionMap = createSessionMapAdapter({
-      getSessionId: () => getCliSessionId(cronSession.sessionEntry, provider),
+      getSessionId: () =>
+        cronSession.isNewSession ? undefined : getCliSessionId(cronSession.sessionEntry, provider),
     });
 
     const messageToolHints = resolveChannelMessageToolHints({

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -231,6 +231,60 @@ describe("resolveCronSession", () => {
       });
     });
 
+    it("clears cliSessionIds and claudeCliSessionId when forceNew is true", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "existing-session-id",
+          updatedAt: NOW_MS - 1000,
+          systemSent: true,
+          cliSessionIds: { claude: "cli-sess-old", openai: "cli-sess-openai" },
+          claudeCliSessionId: "cli-sess-old",
+          modelOverride: "sonnet-4",
+        },
+        fresh: true,
+        forceNew: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.cliSessionIds).toBeUndefined();
+      expect(result.sessionEntry.claudeCliSessionId).toBeUndefined();
+      // Per-session overrides must be preserved
+      expect(result.sessionEntry.modelOverride).toBe("sonnet-4");
+    });
+
+    it("clears cliSessionIds and claudeCliSessionId when session is stale", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "old-session-id",
+          updatedAt: NOW_MS - 86_400_000,
+          cliSessionIds: { claude: "cli-sess-stale" },
+          claudeCliSessionId: "cli-sess-stale",
+        },
+        fresh: false,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.cliSessionIds).toBeUndefined();
+      expect(result.sessionEntry.claudeCliSessionId).toBeUndefined();
+    });
+
+    it("preserves cliSessionIds when reusing fresh session", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "existing-session-id",
+          updatedAt: NOW_MS - 1000,
+          systemSent: true,
+          cliSessionIds: { claude: "cli-sess-active" },
+          claudeCliSessionId: "cli-sess-active",
+        },
+        fresh: true,
+      });
+
+      expect(result.isNewSession).toBe(false);
+      expect(result.sessionEntry.cliSessionIds).toEqual({ claude: "cli-sess-active" });
+      expect(result.sessionEntry.claudeCliSessionId).toBe("cli-sess-active");
+    });
+
     it("creates new sessionId when entry exists but has no sessionId", () => {
       const result = resolveWithStoredEntry({
         entry: {

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -77,6 +77,8 @@ export function resolveCronSession(params: {
       lastAccountId: undefined,
       lastThreadId: undefined,
       deliveryContext: undefined,
+      cliSessionIds: undefined,
+      claudeCliSessionId: undefined,
     }),
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession };


### PR DESCRIPTION
## Summary

- **Data integrity** (`session.ts`): Add `cliSessionIds: undefined` and `claudeCliSessionId: undefined` to the `isNewSession` cleanup block in `resolveCronSession`, preventing stale CLI session IDs from leaking through the `...entry` spread
- **Semantic intent** (`run.ts`): Guard `getCliSessionId` with `cronSession.isNewSession` so the session map adapter explicitly returns `undefined` for new sessions, expressing "don't resume" as intent rather than relying on empty data
- **Tests**: 5 new tests covering both the session factory cleanup and the runtime guard

## Test plan

- [x] `resolveCronSession` with `forceNew: true` and stored `cliSessionIds` → entry has no `cliSessionIds`
- [x] `resolveCronSession` with stale session → `cliSessionIds` cleared
- [x] `resolveCronSession` with fresh session → `cliSessionIds` preserved
- [x] Session map returns `undefined` when `isNewSession` is true
- [x] Session map returns stored CLI session ID when `isNewSession` is false
- [x] All 278 cron tests pass, type-check clean

Closes #2112

🤖 Generated with [Claude Code](https://claude.com/claude-code)