### PR TITLE
chore: use glob pattern for local files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,8 +80,7 @@ apps/ios/*.mobileprovision
 # Local untracked files
 .local/
 docs/.local/
-IDENTITY.md
-USER.md
+*.local.*
 .tgz
 .idea
 


### PR DESCRIPTION
## Summary
- Replace explicit `IDENTITY.md` and `USER.md` entries in `.gitignore` with `*.local.*` glob pattern
- Catches all local-convention files without needing per-file entries

## Test plan
- [ ] CI passes (format, typecheck, lint)
- [ ] No previously-ignored files become tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)