### PR TITLE
fix(config): restore lost per-agent auth/runtime/runtimeArgs/runtimeEnv fields

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -711,6 +711,12 @@ export const AgentEntrySchema = z
       .optional(),
     sandbox: AgentSandboxSchema,
     tools: AgentToolsSchema,
+    auth: z.union([z.literal(false), z.string(), z.array(z.string())]).optional(),
+    runtime: z
+      .union([z.literal("claude"), z.literal("gemini"), z.literal("codex"), z.literal("opencode")])
+      .optional(),
+    runtimeArgs: z.array(z.string()).optional(),
+    runtimeEnv: z.record(z.string(), z.string()).optional(),
   })
   .strict();
 

--- a/src/config/zod-schema.auth-field.test.ts
+++ b/src/config/zod-schema.auth-field.test.ts
@@ -3,10 +3,7 @@ import { AgentDefaultsSchema } from "./zod-schema.agent-defaults.js";
 import { AgentEntrySchema } from "./zod-schema.agent-runtime.js";
 
 describe("auth field schema validation", () => {
-  // Gutted in RemoteClaw fork: AgentEntrySchema no longer has an auth field
-  // (auth was removed from per-agent config upstream; only AgentDefaultsSchema has it).
-  // The schema uses .strict() so any auth value is rejected as an unrecognized key.
-  describe.skip("AgentEntrySchema", () => {
+  describe("AgentEntrySchema", () => {
     it("accepts auth: false", () => {
       const result = AgentEntrySchema.safeParse({ id: "main", auth: false });
       expect(result.success).toBe(true);


### PR DESCRIPTION
## Summary

- Restore 4 fork-specific fields (`auth`, `runtime`, `runtimeArgs`, `runtimeEnv`) to `AgentEntrySchema` in `zod-schema.agent-runtime.ts` — lost during v2026.3.2 upstream sync
- Re-enable 7 auth field validation tests that were incorrectly skipped with a "gutted" comment

Closes #2175

## Test plan

- [x] All 12 auth field schema tests pass (7 AgentEntrySchema + 5 AgentDefaultsSchema)
- [x] All 46 agent-scope resolver tests pass (resolveAgentAuth/Runtime/RuntimeArgs/RuntimeEnv)
- [x] Full test suite: 692 files, 5938 tests pass, 0 failures
- [x] Pre-commit hooks pass (format, typecheck, lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)