### PR TITLE
test(config): add schema regression tests for per-agent fork-specific fields

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, it } from "vitest";
+import {
+  resolveAgentAuth,
+  resolveAgentRuntime,
+  resolveAgentRuntimeArgs,
+  resolveAgentRuntimeEnv,
+} from "../agents/agent-scope.js";
 import { validateConfigObject } from "./config.js";
 
 describe("config schema regressions", () => {
@@ -183,5 +189,96 @@ describe("config schema regressions", () => {
     });
 
     expect(res.ok).toBe(false);
+  });
+
+  it("accepts per-agent auth/runtime/runtimeArgs/runtimeEnv fields", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          {
+            id: "main",
+            workspace: "~/remoteclaw",
+            auth: "anthropic:custom",
+            runtime: "gemini",
+            runtimeArgs: ["--model", "pro"],
+            runtimeEnv: { API_KEY: "sk-test" },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts per-agent fork-specific fields alongside defaults", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          auth: "anthropic:default",
+          runtime: "claude",
+          runtimeArgs: ["--verbose"],
+          runtimeEnv: { SHARED: "yes" },
+        },
+        list: [
+          {
+            id: "main",
+            workspace: "~/remoteclaw",
+            auth: false,
+            runtime: "codex",
+            runtimeArgs: [],
+            runtimeEnv: { API_KEY: "sk-agent" },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("round-trip: full config through Zod parse then resolver functions", () => {
+    const raw = {
+      agents: {
+        defaults: {
+          auth: "anthropic:default",
+          runtime: "claude" as const,
+          runtimeArgs: ["--verbose"],
+          runtimeEnv: { SHARED: "yes" },
+        },
+        list: [
+          {
+            id: "main",
+            workspace: "~/remoteclaw",
+            auth: "anthropic:custom",
+            runtime: "gemini" as const,
+            runtimeArgs: ["--model", "pro"],
+            runtimeEnv: { API_KEY: "sk-test" },
+          },
+          {
+            id: "secondary",
+            workspace: "~/remoteclaw-secondary",
+          },
+        ],
+      },
+    };
+
+    const res = validateConfigObject(raw);
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+
+    const cfg = res.config;
+
+    // Agent "main" — per-agent fields override defaults
+    expect(resolveAgentAuth(cfg, "main")).toBe("anthropic:custom");
+    expect(resolveAgentRuntime(cfg, "main")).toBe("gemini");
+    expect(resolveAgentRuntimeArgs(cfg, "main")).toEqual(["--model", "pro"]);
+    expect(resolveAgentRuntimeEnv(cfg, "main")).toEqual({ API_KEY: "sk-test" });
+
+    // Agent "secondary" — inherits from defaults
+    expect(resolveAgentAuth(cfg, "secondary")).toBe("anthropic:default");
+    expect(resolveAgentRuntime(cfg, "secondary")).toBe("claude");
+    expect(resolveAgentRuntimeArgs(cfg, "secondary")).toEqual(["--verbose"]);
+    expect(resolveAgentRuntimeEnv(cfg, "secondary")).toEqual({ SHARED: "yes" });
   });
 });

--- a/src/config/zod-schema.auth-field.test.ts
+++ b/src/config/zod-schema.auth-field.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { AgentDefaultsSchema } from "./zod-schema.agent-defaults.js";
 import { AgentEntrySchema } from "./zod-schema.agent-runtime.js";
 
-describe("auth field schema validation", () => {
-  describe("AgentEntrySchema", () => {
+describe("per-agent fork-specific field schema validation", () => {
+  describe("AgentEntrySchema — auth", () => {
     it("accepts auth: false", () => {
       const result = AgentEntrySchema.safeParse({ id: "main", auth: false });
       expect(result.success).toBe(true);
@@ -40,6 +40,106 @@ describe("auth field schema validation", () => {
 
     it("rejects auth: object", () => {
       const result = AgentEntrySchema.safeParse({ id: "main", auth: { profile: "x" } });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("AgentEntrySchema — runtime", () => {
+    it("accepts runtime: 'claude'", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main", runtime: "claude" });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts runtime: 'gemini'", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main", runtime: "gemini" });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts runtime: 'codex'", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main", runtime: "codex" });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts runtime: 'opencode'", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main", runtime: "opencode" });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts omitted runtime (undefined)", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main" });
+      expect(result.success).toBe(true);
+      expect(((result.data ?? {}) as Record<string, unknown>)?.runtime).toBeUndefined();
+    });
+
+    it("rejects runtime: 'unsupported'", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main", runtime: "unsupported" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects runtime: number", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main", runtime: 42 });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("AgentEntrySchema — runtimeArgs", () => {
+    it("accepts runtimeArgs as a string array", () => {
+      const result = AgentEntrySchema.safeParse({
+        id: "main",
+        runtimeArgs: ["--verbose", "--model", "sonnet"],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts runtimeArgs as an empty array", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main", runtimeArgs: [] });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts omitted runtimeArgs (undefined)", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main" });
+      expect(result.success).toBe(true);
+      expect(((result.data ?? {}) as Record<string, unknown>)?.runtimeArgs).toBeUndefined();
+    });
+
+    it("rejects runtimeArgs: string (not array)", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main", runtimeArgs: "--verbose" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects runtimeArgs: number array", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main", runtimeArgs: [1, 2, 3] });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("AgentEntrySchema — runtimeEnv", () => {
+    it("accepts runtimeEnv as a record of strings", () => {
+      const result = AgentEntrySchema.safeParse({
+        id: "main",
+        runtimeEnv: { API_KEY: "sk-test", NODE_ENV: "production" },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts runtimeEnv as an empty record", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main", runtimeEnv: {} });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts omitted runtimeEnv (undefined)", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main" });
+      expect(result.success).toBe(true);
+      expect(((result.data ?? {}) as Record<string, unknown>)?.runtimeEnv).toBeUndefined();
+    });
+
+    it("rejects runtimeEnv: array", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main", runtimeEnv: ["KEY=val"] });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects runtimeEnv with non-string values", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main", runtimeEnv: { PORT: 3000 } });
       expect(result.success).toBe(false);
     });
   });


### PR DESCRIPTION
## Summary

- Add `AgentEntrySchema.safeParse()` tests for `runtime`, `runtimeArgs`, and `runtimeEnv` fields (acceptance and rejection cases)
- Add round-trip integration test: full config → `validateConfigObject()` (Zod parse) → resolver functions (`resolveAgentAuth/Runtime/RuntimeArgs/RuntimeEnv`) — validates both schema acceptance AND resolver output
- Rename top-level describe to reflect all fork-specific fields, not just auth

## Test plan

- [ ] CI passes (unit tests, lint, type-check)
- [ ] If a future upstream sync strips `runtime`/`runtimeArgs`/`runtimeEnv` from `AgentEntrySchema`, safeParse tests fail immediately
- [ ] If Zod schema accepts fields but resolvers don't propagate them, the round-trip test catches it

Closes #2176

🤖 Generated with [Claude Code](https://claude.com/claude-code)