### PR TITLE
gut(system-prompt): remove Identity section from buildSystemPrompt

### DIFF
--- a/src/middleware/system-prompt.test.ts
+++ b/src/middleware/system-prompt.test.ts
@@ -15,7 +15,6 @@ describe("buildSystemPrompt", () => {
       const result = buildSystemPrompt(
         makeParams({ userName: "Alice", timezone: "UTC", agentId: "agent-1" }),
       );
-      expect(result).toContain("RemoteClaw");
       expect(result).toContain("## Safety");
       expect(result).toContain("## Messaging");
       expect(result).toContain("## Reply Tags");
@@ -56,16 +55,14 @@ describe("buildSystemPrompt", () => {
   });
 
   describe("dynamic content", () => {
-    it("identity section includes channel name and user name", () => {
-      const result = buildSystemPrompt(makeParams({ channelName: "discord", userName: "Bob" }));
-      expect(result).toContain("Bob");
-      expect(result).toContain("discord");
+    it("runtime section includes user name when provided", () => {
+      const result = buildSystemPrompt(makeParams({ userName: "Bob" }));
+      expect(result).toContain("user=Bob");
     });
 
-    it("identity section handles missing user name gracefully", () => {
-      const result = buildSystemPrompt(makeParams({ channelName: "whatsapp" }));
-      expect(result).toContain("responding to a message on whatsapp");
-      expect(result).not.toContain("undefined");
+    it("runtime section omits user name when not provided", () => {
+      const result = buildSystemPrompt(makeParams());
+      expect(result).not.toContain("user=");
     });
 
     it("runtime section includes timezone and agent ID", () => {
@@ -217,7 +214,7 @@ describe("buildSystemPrompt", () => {
 
     it("sections are separated by double newlines", () => {
       const result = buildSystemPrompt(makeParams());
-      expect(result).toContain("\n\n## Safety");
+      expect(result).toMatch(/^## Safety/);
       expect(result).toContain("\n\n## Messaging");
       expect(result).toContain("\n\n## Reply Tags");
       expect(result).toContain("\n\n## Silent Replies");

--- a/src/middleware/system-prompt.ts
+++ b/src/middleware/system-prompt.ts
@@ -61,16 +61,11 @@ const SILENT_REPLIES_SECTION = [
 
 // ── Dynamic Section Builders ─────────────────────────────────────────────
 
-function buildIdentitySection(channelName: string, userName?: string): string {
-  const intro =
-    "You are running inside RemoteClaw, a middleware that connects AI agents to messaging channels.";
-  return userName
-    ? `${intro}\nYou are responding to a message from ${userName} on ${channelName}.`
-    : `${intro}\nYou are responding to a message on ${channelName}.`;
-}
-
 function buildRuntimeSection(params: SystemPromptParams): string {
   const parts = [`channel=${params.channelName}`];
+  if (params.userName) {
+    parts.push(`user=${params.userName}`);
+  }
   if (params.timezone) {
     parts.push(`timezone=${params.timezone}`);
   }
@@ -146,11 +141,7 @@ function buildReactionsSection(guidance?: {
  * no tool list (MCP handles), no skills/memory/sandbox sections.
  */
 export function buildSystemPrompt(params: SystemPromptParams): string {
-  const sections: string[] = [
-    buildIdentitySection(params.channelName, params.userName),
-    SAFETY_SECTION,
-    MESSAGING_SECTION,
-  ];
+  const sections: string[] = [SAFETY_SECTION, MESSAGING_SECTION];
 
   const hintsSection = buildMessageToolHintsSection(params.messageToolHints);
   if (hintsSection) {


### PR DESCRIPTION
## Summary

- Delete `buildIdentitySection()` and its call from the assembly block in `buildSystemPrompt()`
- Move `userName` to the Runtime section as `user=` field
- Update tests: replace identity-section tests with runtime-section userName tests, fix section-order assertions

Closes #2159

## Test plan

- [x] `system-prompt.test.ts` — all 25 tests pass
- [x] No type errors in `system-prompt.ts`
- [ ] CI `build`, `test`, `lint` jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)