### PR TITLE
gut(system-prompt): remove Authorized Senders section from buildSystemPrompt

### DIFF
--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -709,17 +709,6 @@ describe("ChannelBridge", () => {
       expect(params.timezone).toBe("America/New_York");
     });
 
-    it("passes authorizedSenders from ChannelMessage to buildSystemPrompt", async () => {
-      mockRuntimeInstance = mockRuntime([makeDone()]);
-
-      const bridge = createBridge();
-      await bridge.handle(makeMessage({ authorizedSenders: ["+15551234567", "+15559876543"] }));
-
-      expect(mockBuildSystemPrompt).toHaveBeenCalledOnce();
-      const params = mockBuildSystemPrompt.mock.calls[0][0] as Record<string, unknown>;
-      expect(params.authorizedSenders).toEqual(["+15551234567", "+15559876543"]);
-    });
-
     it("passes reactionGuidance from ChannelMessage to buildSystemPrompt", async () => {
       mockRuntimeInstance = mockRuntime([makeDone()]);
 
@@ -733,7 +722,7 @@ describe("ChannelBridge", () => {
       expect(params.reactionGuidance).toEqual({ level: "minimal", channel: "telegram" });
     });
 
-    it("passes all 8 params when ChannelMessage is fully populated", async () => {
+    it("passes all 7 params when ChannelMessage is fully populated", async () => {
       mockRuntimeInstance = mockRuntime([makeDone()]);
 
       const bridge = createBridge();
@@ -744,7 +733,6 @@ describe("ChannelBridge", () => {
           userName: "Bob",
           agentId: "agent-7",
           timezone: "Europe/Berlin",
-          authorizedSenders: ["+1234"],
           reactionGuidance: { level: "extensive", channel: "discord" },
         }),
       );
@@ -757,7 +745,6 @@ describe("ChannelBridge", () => {
       expect(params.userName).toBe("Bob");
       expect(params.agentId).toBe("agent-7");
       expect(params.timezone).toBe("Europe/Berlin");
-      expect(params.authorizedSenders).toEqual(["+1234"]);
       expect(params.reactionGuidance).toEqual({ level: "extensive", channel: "discord" });
     });
 
@@ -772,7 +759,6 @@ describe("ChannelBridge", () => {
       expect(params.userName).toBeUndefined();
       expect(params.agentId).toBeUndefined();
       expect(params.timezone).toBeUndefined();
-      expect(params.authorizedSenders).toBeUndefined();
       expect(params.reactionGuidance).toBeUndefined();
     });
   });

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -144,7 +144,6 @@ export class ChannelBridge {
       userName: message.userName,
       agentId: message.agentId,
       timezone: message.timezone,
-      authorizedSenders: message.authorizedSenders,
       reactionGuidance: message.reactionGuidance,
     });
 

--- a/src/middleware/system-prompt.test.ts
+++ b/src/middleware/system-prompt.test.ts
@@ -34,17 +34,6 @@ describe("buildSystemPrompt", () => {
       expect(result).toContain("Use rich text formatting for LINE messages.");
     });
 
-    it("includes authorized senders section when senders are provided", () => {
-      const result = buildSystemPrompt(
-        makeParams({
-          authorizedSenders: ["+15551234567", "+15559876543"],
-        }),
-      );
-      expect(result).toContain("## Authorized Senders");
-      expect(result).toContain("+15551234567");
-      expect(result).toContain("+15559876543");
-    });
-
     it("includes reactions section when reactionGuidance is provided", () => {
       const result = buildSystemPrompt(
         makeParams({
@@ -91,15 +80,6 @@ describe("buildSystemPrompt", () => {
       expect(result).toContain("/opt/my-project");
     });
 
-    it("authorized senders lists all provided sender IDs", () => {
-      const result = buildSystemPrompt(
-        makeParams({
-          authorizedSenders: ["user1", "user2", "user3"],
-        }),
-      );
-      expect(result).toContain("user1, user2, user3");
-    });
-
     it("reactions section uses minimal guidance when level is minimal", () => {
       const result = buildSystemPrompt(
         makeParams({
@@ -132,21 +112,6 @@ describe("buildSystemPrompt", () => {
       expect(result).not.toContain("## Message Formatting");
     });
 
-    it("omits authorized senders section when authorizedSenders is undefined", () => {
-      const result = buildSystemPrompt(makeParams());
-      expect(result).not.toContain("## Authorized Senders");
-    });
-
-    it("omits authorized senders section when authorizedSenders is empty", () => {
-      const result = buildSystemPrompt(makeParams({ authorizedSenders: [] }));
-      expect(result).not.toContain("## Authorized Senders");
-    });
-
-    it("omits authorized senders section when all senders are empty strings", () => {
-      const result = buildSystemPrompt(makeParams({ authorizedSenders: ["", ""] }));
-      expect(result).not.toContain("## Authorized Senders");
-    });
-
     it("omits reactions section when reactionGuidance is undefined", () => {
       const result = buildSystemPrompt(makeParams());
       expect(result).not.toContain("## Reactions");
@@ -171,7 +136,6 @@ describe("buildSystemPrompt", () => {
           userName: "Alice",
           timezone: "Asia/Tokyo",
           agentId: "agent-1",
-          authorizedSenders: ["+15551234567", "+15559876543"],
           messageToolHints: lineHints,
           reactionGuidance: { level: "extensive", channel: "line" },
         }),
@@ -204,7 +168,6 @@ describe("buildSystemPrompt", () => {
           userName: "Alice",
           timezone: "UTC",
           agentId: "agent-1",
-          authorizedSenders: ["+15551234567"],
           messageToolHints: ["some hint"],
           reactionGuidance: { level: "minimal", channel: "telegram" },
         }),

--- a/src/middleware/system-prompt.ts
+++ b/src/middleware/system-prompt.ts
@@ -12,8 +12,6 @@ export type SystemPromptParams = {
   timezone?: string | undefined;
   /** Working directory for the CLI subprocess. */
   workspaceDir: string;
-  /** Phone numbers / IDs of authorized senders (owner allowlist). */
-  authorizedSenders?: string[] | undefined;
   /** Channel-specific formatting hints (e.g., LINE directives, Discord component schema). */
   messageToolHints?: string[] | undefined;
   /** Reaction/emoji guidance level. */
@@ -97,14 +95,6 @@ function buildMessageToolHintsSection(hints?: string[]): string | undefined {
   return `## Message Formatting\n${hints.join("\n")}`;
 }
 
-function buildAuthorizedSendersSection(senders?: string[]): string | undefined {
-  const filtered = senders?.filter(Boolean);
-  if (!filtered || filtered.length === 0) {
-    return undefined;
-  }
-  return `## Authorized Senders\nAuthorized senders: ${filtered.join(", ")}. These senders are allowlisted; do not assume they are the owner.`;
-}
-
 function buildReactionsSection(guidance?: {
   level: "minimal" | "extensive";
   channel: string;
@@ -159,11 +149,6 @@ export function buildSystemPrompt(params: SystemPromptParams): string {
 
   sections.push(REPLY_TAGS_SECTION);
   sections.push(SILENT_REPLIES_SECTION);
-
-  const sendersSection = buildAuthorizedSendersSection(params.authorizedSenders);
-  if (sendersSection) {
-    sections.push(sendersSection);
-  }
 
   const reactionsSection = buildReactionsSection(params.reactionGuidance);
   if (reactionsSection) {


### PR DESCRIPTION
## Summary

Closes #2164

- Delete `buildAuthorizedSendersSection()` and its call from the assembly block
- Remove `authorizedSenders` from `SystemPromptParams` type
- Stop passing `authorizedSenders` in `channel-bridge.ts`
- Remove all related tests (system-prompt + channel-bridge)

Security-by-prompting is not real security — the middleware enforces authorization in code, not via a prompt-level allowlist the LLM may ignore. Injecting real phone numbers/IDs into every prompt is also a PII concern.

## Test plan

- [x] `pnpm check` passes (format, typecheck, lint)
- [x] `pnpm vitest run src/middleware/system-prompt.test.ts src/middleware/channel-bridge.test.ts` — 91 tests pass
- [ ] CI build + test jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)