### PR TITLE
gut(system-prompt): remove Workspace section from buildSystemPrompt

### DIFF
--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -740,7 +740,6 @@ describe("ChannelBridge", () => {
       expect(mockBuildSystemPrompt).toHaveBeenCalledOnce();
       const params = mockBuildSystemPrompt.mock.calls[0][0] as Record<string, unknown>;
       expect(params.channelName).toBe("discord");
-      expect(params.workspaceDir).toBe("/workspace");
       expect(params.messageToolHints).toEqual(["Use discord components."]);
       expect(params.userName).toBe("Bob");
       expect(params.agentId).toBe("agent-7");

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -139,7 +139,6 @@ export class ChannelBridge {
     // 2. System prompt
     const systemPrompt = buildSystemPrompt({
       channelName: message.provider,
-      workspaceDir: this.#workspaceDir,
       messageToolHints: message.messageToolHints,
       userName: message.userName,
       agentId: message.agentId,

--- a/src/middleware/system-prompt.test.ts
+++ b/src/middleware/system-prompt.test.ts
@@ -4,7 +4,6 @@ import { type SystemPromptParams, buildSystemPrompt } from "./system-prompt.js";
 function makeParams(overrides?: Partial<SystemPromptParams>): SystemPromptParams {
   return {
     channelName: "telegram",
-    workspaceDir: "/home/user/workspace",
     ...overrides,
   };
 }
@@ -20,7 +19,6 @@ describe("buildSystemPrompt", () => {
       expect(result).toContain("## Reply Tags");
       expect(result).toContain("## Silent Replies");
       expect(result).toContain("## Runtime");
-      expect(result).toContain("## Workspace");
     });
 
     it("includes messageToolHints section when hints are provided", () => {
@@ -70,11 +68,6 @@ describe("buildSystemPrompt", () => {
       expect(result).not.toContain("timezone=");
       expect(result).not.toContain("agent=");
       expect(result).toContain("channel=telegram");
-    });
-
-    it("workspace section includes working directory path", () => {
-      const result = buildSystemPrompt(makeParams({ workspaceDir: "/opt/my-project" }));
-      expect(result).toContain("/opt/my-project");
     });
 
     it("reactions section uses minimal guidance when level is minimal", () => {
@@ -188,7 +181,6 @@ describe("buildSystemPrompt", () => {
       expect(result).toContain("\n\n## Reply Tags");
       expect(result).toContain("\n\n## Silent Replies");
       expect(result).toContain("\n\n## Runtime");
-      expect(result).toContain("\n\n## Workspace");
     });
   });
 });

--- a/src/middleware/system-prompt.ts
+++ b/src/middleware/system-prompt.ts
@@ -10,8 +10,6 @@ export type SystemPromptParams = {
   agentId?: string | undefined;
   /** IANA timezone string (e.g., "America/New_York"). */
   timezone?: string | undefined;
-  /** Working directory for the CLI subprocess. */
-  workspaceDir: string;
   /** Channel-specific formatting hints (e.g., LINE directives, Discord component schema). */
   messageToolHints?: string[] | undefined;
   /** Reaction/emoji guidance level. */
@@ -67,14 +65,6 @@ function buildRuntimeSection(params: SystemPromptParams): string {
     parts.push(`agent=${params.agentId}`);
   }
   return `## Runtime\nRuntime: ${parts.join(" | ")}`;
-}
-
-function buildWorkspaceSection(workspaceDir: string): string {
-  return [
-    "## Workspace",
-    `Your working directory is: ${workspaceDir}`,
-    "Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.",
-  ].join("\n");
 }
 
 // ── Conditional Section Builders ─────────────────────────────────────────
@@ -143,7 +133,6 @@ export function buildSystemPrompt(params: SystemPromptParams): string {
   }
 
   sections.push(buildRuntimeSection(params));
-  sections.push(buildWorkspaceSection(params.workspaceDir));
 
   return sections.join("\n\n");
 }


### PR DESCRIPTION
## Summary

- Remove `buildWorkspaceSection()` function and its call from `buildSystemPrompt()`
- Remove `workspaceDir` from `SystemPromptParams` type (still used for CWD via `cwd: params.workingDirectory` in cli-runtime-base.ts)
- Update tests to remove workspace-related assertions

Closes #2167

## Test plan

- [x] `npx vitest run src/middleware/system-prompt.test.ts src/middleware/channel-bridge.test.ts` — 96 tests pass
- [x] `pnpm check` — format, typecheck, lint all clean
- [ ] CI build + test jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)