### PR TITLE
gut(system-prompt): trim Messaging section to [System Message] line only

### DIFF
--- a/src/middleware/system-prompt.test.ts
+++ b/src/middleware/system-prompt.test.ts
@@ -193,6 +193,12 @@ describe("buildSystemPrompt", () => {
       expect(result).toContain("[[reply_to_current]]");
     });
 
+    it("messaging section documents [System Message] marker protocol", () => {
+      const result = buildSystemPrompt(makeParams());
+      expect(result).toContain("[System Message]");
+      expect(result).toContain("do not forward them to users");
+    });
+
     it("silent replies section contains NO_REPLY token", () => {
       const result = buildSystemPrompt(makeParams());
       expect(result).toContain("NO_REPLY");

--- a/src/middleware/system-prompt.ts
+++ b/src/middleware/system-prompt.ts
@@ -32,11 +32,7 @@ const SAFETY_SECTION = [
 
 const MESSAGING_SECTION = [
   "## Messaging",
-  "- Reply in current session: automatically routes to the source channel.",
-  "- Cross-session messaging: use sessions_send(sessionKey, message) to reach other channels.",
-  "- `[System Message] ...` blocks are internal context and are not user-visible.",
-  `- If a \`[System Message]\` reports completed work and asks for a user update, rewrite it in your normal assistant voice and send that update (do not forward raw system text or default to ${SILENT_REPLY_TOKEN}).`,
-  "- Never use exec/curl for provider messaging; RemoteClaw handles all routing internally.",
+  "`[System Message] ...` blocks are internal context injected by the middleware — do not forward them to users.",
 ].join("\n");
 
 const REPLY_TAGS_SECTION = [


### PR DESCRIPTION
## Summary

- Remove 4 non-actionable lines from `MESSAGING_SECTION`: routing auto-reply, cross-session `sessions_send` reference, behavioral coaching for system messages, and pre-emptive exec/curl prohibition
- Keep only the `[System Message]` marker protocol documentation — the one line the LLM needs to avoid forwarding internal context to users
- Add test coverage for the retained `[System Message]` content

Closes #2161

## Test plan

- [x] `system-prompt.test.ts` — 26 tests pass (25 existing + 1 new)
- [x] Pre-commit hook passes (oxlint, oxfmt, typecheck, rebrand gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)