### PR TITLE
gut(system-prompt): remove Reactions section from buildSystemPrompt

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -102,29 +102,6 @@ function resolveGatewayTokenFromConfig(cfg: FollowupRun["run"]["config"]): strin
   return resolveGatewayCredentialsFromConfig({ cfg, env: process.env }).token ?? "";
 }
 
-/**
- * Resolve reaction guidance for the system prompt from channel config.
- *
- * Reads the channel's `reactionLevel` from config and returns guidance
- * only when the level enables agent-controlled reactions ("minimal" or "extensive").
- */
-function resolveChannelReactionGuidance(
-  cfg: FollowupRun["run"]["config"],
-  channel: string | undefined,
-): { level: "minimal" | "extensive"; channel: string } | undefined {
-  if (!cfg || !channel) {
-    return undefined;
-  }
-  const channelConfig = (cfg.channels as Record<string, Record<string, unknown>> | undefined)?.[
-    channel
-  ];
-  const level = channelConfig?.reactionLevel;
-  if (level === "minimal" || level === "extensive") {
-    return { level, channel };
-  }
-  return undefined;
-}
-
 /** Build a ChannelMessage from the auto-reply's template context. */
 function buildChannelMessage(params: {
   commandBody: string;
@@ -137,7 +114,6 @@ function buildChannelMessage(params: {
   agentId?: string;
   timezone?: string;
   authorizedSenders?: string[];
-  reactionGuidance?: { level: "minimal" | "extensive"; channel: string };
 }): ChannelMessage {
   return {
     id: params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid ?? crypto.randomUUID(),
@@ -156,7 +132,6 @@ function buildChannelMessage(params: {
     agentId: params.agentId || undefined,
     timezone: params.timezone || undefined,
     authorizedSenders: params.authorizedSenders?.length ? params.authorizedSenders : undefined,
-    reactionGuidance: params.reactionGuidance,
   };
 }
 
@@ -292,7 +267,6 @@ export async function runAgentTurnWithFallback(params: {
           accountId: params.sessionCtx.AccountId?.trim(),
         });
 
-        const channel = params.sessionCtx.Provider?.trim();
         const message = buildChannelMessage({
           commandBody: params.commandBody,
           sessionCtx: params.sessionCtx,
@@ -304,7 +278,6 @@ export async function runAgentTurnWithFallback(params: {
           agentId: params.followupRun.run.agentId,
           timezone: resolveUserTimezone(cfg?.agents?.defaults?.userTimezone),
           authorizedSenders: params.followupRun.run.ownerNumbers,
-          reactionGuidance: resolveChannelReactionGuidance(cfg, channel),
         });
 
         // Build BridgeCallbacks that wrap the existing typing/normalization logic.

--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -709,20 +709,7 @@ describe("ChannelBridge", () => {
       expect(params.timezone).toBe("America/New_York");
     });
 
-    it("passes reactionGuidance from ChannelMessage to buildSystemPrompt", async () => {
-      mockRuntimeInstance = mockRuntime([makeDone()]);
-
-      const bridge = createBridge();
-      await bridge.handle(
-        makeMessage({ reactionGuidance: { level: "minimal", channel: "telegram" } }),
-      );
-
-      expect(mockBuildSystemPrompt).toHaveBeenCalledOnce();
-      const params = mockBuildSystemPrompt.mock.calls[0][0] as Record<string, unknown>;
-      expect(params.reactionGuidance).toEqual({ level: "minimal", channel: "telegram" });
-    });
-
-    it("passes all 7 params when ChannelMessage is fully populated", async () => {
+    it("passes all params when ChannelMessage is fully populated", async () => {
       mockRuntimeInstance = mockRuntime([makeDone()]);
 
       const bridge = createBridge();
@@ -733,7 +720,6 @@ describe("ChannelBridge", () => {
           userName: "Bob",
           agentId: "agent-7",
           timezone: "Europe/Berlin",
-          reactionGuidance: { level: "extensive", channel: "discord" },
         }),
       );
 
@@ -744,7 +730,6 @@ describe("ChannelBridge", () => {
       expect(params.userName).toBe("Bob");
       expect(params.agentId).toBe("agent-7");
       expect(params.timezone).toBe("Europe/Berlin");
-      expect(params.reactionGuidance).toEqual({ level: "extensive", channel: "discord" });
     });
 
     it("passes undefined for optional params when not set on ChannelMessage", async () => {
@@ -758,7 +743,6 @@ describe("ChannelBridge", () => {
       expect(params.userName).toBeUndefined();
       expect(params.agentId).toBeUndefined();
       expect(params.timezone).toBeUndefined();
-      expect(params.reactionGuidance).toBeUndefined();
     });
   });
 

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -143,7 +143,6 @@ export class ChannelBridge {
       userName: message.userName,
       agentId: message.agentId,
       timezone: message.timezone,
-      reactionGuidance: message.reactionGuidance,
     });
 
     // 3. MCP config: temp dir for side effects file

--- a/src/middleware/system-prompt.test.ts
+++ b/src/middleware/system-prompt.test.ts
@@ -29,15 +29,6 @@ describe("buildSystemPrompt", () => {
       expect(result).toContain("## Message Formatting");
       expect(result).toContain("Use rich text formatting for LINE messages.");
     });
-
-    it("includes reactions section when reactionGuidance is provided", () => {
-      const result = buildSystemPrompt(
-        makeParams({
-          reactionGuidance: { level: "minimal", channel: "telegram" },
-        }),
-      );
-      expect(result).toContain("## Reactions");
-    });
   });
 
   describe("dynamic content", () => {
@@ -68,26 +59,6 @@ describe("buildSystemPrompt", () => {
       expect(result).not.toContain("agent=");
       expect(result).toContain("channel=telegram");
     });
-
-    it("reactions section uses minimal guidance when level is minimal", () => {
-      const result = buildSystemPrompt(
-        makeParams({
-          reactionGuidance: { level: "minimal", channel: "telegram" },
-        }),
-      );
-      expect(result).toContain("MINIMAL mode");
-      expect(result).toContain("React ONLY when truly relevant");
-    });
-
-    it("reactions section uses extensive guidance when level is extensive", () => {
-      const result = buildSystemPrompt(
-        makeParams({
-          reactionGuidance: { level: "extensive", channel: "discord" },
-        }),
-      );
-      expect(result).toContain("EXTENSIVE mode");
-      expect(result).toContain("Feel free to react liberally");
-    });
   });
 
   describe("conditional omission", () => {
@@ -99,11 +70,6 @@ describe("buildSystemPrompt", () => {
     it("omits messageToolHints section when messageToolHints is empty", () => {
       const result = buildSystemPrompt(makeParams({ messageToolHints: [] }));
       expect(result).not.toContain("## Message Formatting");
-    });
-
-    it("omits reactions section when reactionGuidance is undefined", () => {
-      const result = buildSystemPrompt(makeParams());
-      expect(result).not.toContain("## Reactions");
     });
   });
 
@@ -126,7 +92,6 @@ describe("buildSystemPrompt", () => {
           timezone: "Asia/Tokyo",
           agentId: "agent-1",
           messageToolHints: lineHints,
-          reactionGuidance: { level: "extensive", channel: "line" },
         }),
       );
       expect(result.length).toBeLessThan(6000);
@@ -157,7 +122,6 @@ describe("buildSystemPrompt", () => {
           timezone: "UTC",
           agentId: "agent-1",
           messageToolHints: ["some hint"],
-          reactionGuidance: { level: "minimal", channel: "telegram" },
         }),
       );
       expect(result).not.toContain("OpenClaw");

--- a/src/middleware/system-prompt.ts
+++ b/src/middleware/system-prompt.ts
@@ -12,8 +12,6 @@ export type SystemPromptParams = {
   timezone?: string | undefined;
   /** Channel-specific formatting hints (e.g., LINE directives, Discord component schema). */
   messageToolHints?: string[] | undefined;
-  /** Reaction/emoji guidance level. */
-  reactionGuidance?: { level: "minimal" | "extensive"; channel: string } | undefined;
 };
 
 // ── Static Sections ──────────────────────────────────────────────────────
@@ -68,37 +66,6 @@ function buildMessageToolHintsSection(hints?: string[]): string | undefined {
   return `## Message Formatting\n${hints.join("\n")}`;
 }
 
-function buildReactionsSection(guidance?: {
-  level: "minimal" | "extensive";
-  channel: string;
-}): string | undefined {
-  if (!guidance) {
-    return undefined;
-  }
-  const { level, channel } = guidance;
-  if (level === "minimal") {
-    return [
-      "## Reactions",
-      `Reactions are enabled for ${channel} in MINIMAL mode.`,
-      "React ONLY when truly relevant:",
-      "- Acknowledge important user requests or confirmations",
-      "- Express genuine sentiment (humor, appreciation) sparingly",
-      "- Avoid reacting to routine messages or your own replies",
-      "Guideline: at most 1 reaction per 5-10 exchanges.",
-    ].join("\n");
-  }
-  return [
-    "## Reactions",
-    `Reactions are enabled for ${channel} in EXTENSIVE mode.`,
-    "Feel free to react liberally:",
-    "- Acknowledge messages with appropriate emojis",
-    "- Express sentiment and personality through reactions",
-    "- React to interesting content, humor, or notable events",
-    "- Use reactions to confirm understanding or agreement",
-    "Guideline: react whenever it feels natural.",
-  ].join("\n");
-}
-
 // ── Assembly ─────────────────────────────────────────────────────────────
 
 /**
@@ -118,11 +85,6 @@ export function buildSystemPrompt(params: SystemPromptParams): string {
 
   sections.push(REPLY_TAGS_SECTION);
   sections.push(SILENT_REPLIES_SECTION);
-
-  const reactionsSection = buildReactionsSection(params.reactionGuidance);
-  if (reactionsSection) {
-    sections.push(reactionsSection);
-  }
 
   sections.push(buildRuntimeSection(params));
 

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -276,8 +276,6 @@ export type ChannelMessage = {
   timezone?: string | undefined;
   /** Phone numbers / IDs of authorized senders (owner allowlist). */
   authorizedSenders?: string[] | undefined;
-  /** Reaction/emoji guidance level for the system prompt. */
-  reactionGuidance?: { level: "minimal" | "extensive"; channel: string } | undefined;
 };
 
 // ── Bridge Callbacks ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Remove `buildReactionsSection()` and its call from the system prompt assembly
- Remove `reactionGuidance` from `SystemPromptParams`, `ChannelMessage` type, and all callers
- Remove `resolveChannelReactionGuidance()` helper from agent-runner-execution
- Remove related tests (reactions inclusion, minimal/extensive modes, omission)

The `message_react` MCP tool is self-describing via tool listing — the system prompt section was redundant. Reaction frequency coaching belongs in per-channel `systemPrompt` config, not core middleware.

Closes #2165

## Test plan

- [x] `pnpm check` passes (format, typecheck, lint)
- [x] `pnpm test` passes (692 files, 5953 tests)
- [x] No remaining references to `reactionGuidance`, `buildReactionsSection`, or `resolveChannelReactionGuidance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)