### PR TITLE
refactor(system-prompt): trim Runtime section — drop agent, keep user (#2166)

### DIFF
--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -687,7 +687,7 @@ describe("ChannelBridge", () => {
       expect(params.userName).toBe("Alice");
     });
 
-    it("passes agentId from ChannelMessage to buildSystemPrompt", async () => {
+    it("does not pass agentId to buildSystemPrompt", async () => {
       mockRuntimeInstance = mockRuntime([makeDone()]);
 
       const bridge = createBridge();
@@ -695,7 +695,7 @@ describe("ChannelBridge", () => {
 
       expect(mockBuildSystemPrompt).toHaveBeenCalledOnce();
       const params = mockBuildSystemPrompt.mock.calls[0][0] as Record<string, unknown>;
-      expect(params.agentId).toBe("agent-42");
+      expect(params.agentId).toBeUndefined();
     });
 
     it("passes timezone from ChannelMessage to buildSystemPrompt", async () => {
@@ -718,7 +718,6 @@ describe("ChannelBridge", () => {
           provider: "discord",
           messageToolHints: ["Use discord components."],
           userName: "Bob",
-          agentId: "agent-7",
           timezone: "Europe/Berlin",
         }),
       );
@@ -728,7 +727,7 @@ describe("ChannelBridge", () => {
       expect(params.channelName).toBe("discord");
       expect(params.messageToolHints).toEqual(["Use discord components."]);
       expect(params.userName).toBe("Bob");
-      expect(params.agentId).toBe("agent-7");
+      expect(params.agentId).toBeUndefined();
       expect(params.timezone).toBe("Europe/Berlin");
     });
 
@@ -741,7 +740,6 @@ describe("ChannelBridge", () => {
       expect(mockBuildSystemPrompt).toHaveBeenCalledOnce();
       const params = mockBuildSystemPrompt.mock.calls[0][0] as Record<string, unknown>;
       expect(params.userName).toBeUndefined();
-      expect(params.agentId).toBeUndefined();
       expect(params.timezone).toBeUndefined();
     });
   });

--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -141,7 +141,6 @@ export class ChannelBridge {
       channelName: message.provider,
       messageToolHints: message.messageToolHints,
       userName: message.userName,
-      agentId: message.agentId,
       timezone: message.timezone,
     });
 

--- a/src/middleware/system-prompt.test.ts
+++ b/src/middleware/system-prompt.test.ts
@@ -11,9 +11,7 @@ function makeParams(overrides?: Partial<SystemPromptParams>): SystemPromptParams
 describe("buildSystemPrompt", () => {
   describe("section inclusion", () => {
     it("includes all required sections in output", () => {
-      const result = buildSystemPrompt(
-        makeParams({ userName: "Alice", timezone: "UTC", agentId: "agent-1" }),
-      );
+      const result = buildSystemPrompt(makeParams({ userName: "Alice", timezone: "UTC" }));
       expect(result).toContain("## Messaging");
       expect(result).toContain("## Reply Tags");
       expect(result).toContain("## Silent Replies");
@@ -42,22 +40,20 @@ describe("buildSystemPrompt", () => {
       expect(result).not.toContain("user=");
     });
 
-    it("runtime section includes timezone and agent ID", () => {
-      const result = buildSystemPrompt(
-        makeParams({
-          timezone: "America/New_York",
-          agentId: "agent-42",
-        }),
-      );
+    it("runtime section includes timezone when provided", () => {
+      const result = buildSystemPrompt(makeParams({ timezone: "America/New_York" }));
       expect(result).toContain("timezone=America/New_York");
-      expect(result).toContain("agent=agent-42");
     });
 
-    it("runtime section omits timezone and agent ID when not provided", () => {
+    it("runtime section omits timezone when not provided", () => {
       const result = buildSystemPrompt(makeParams());
       expect(result).not.toContain("timezone=");
-      expect(result).not.toContain("agent=");
       expect(result).toContain("channel=telegram");
+    });
+
+    it("runtime section does not include agent ID", () => {
+      const result = buildSystemPrompt(makeParams());
+      expect(result).not.toContain("agent=");
     });
   });
 
@@ -75,9 +71,7 @@ describe("buildSystemPrompt", () => {
 
   describe("size budget", () => {
     it("base prompt (no hints, no optional sections) is under 4,000 chars", () => {
-      const result = buildSystemPrompt(
-        makeParams({ userName: "Alice", timezone: "UTC", agentId: "agent-1" }),
-      );
+      const result = buildSystemPrompt(makeParams({ userName: "Alice", timezone: "UTC" }));
       expect(result.length).toBeLessThan(4000);
     });
 
@@ -90,7 +84,6 @@ describe("buildSystemPrompt", () => {
         makeParams({
           userName: "Alice",
           timezone: "Asia/Tokyo",
-          agentId: "agent-1",
           messageToolHints: lineHints,
         }),
       );
@@ -120,7 +113,6 @@ describe("buildSystemPrompt", () => {
         makeParams({
           userName: "Alice",
           timezone: "UTC",
-          agentId: "agent-1",
           messageToolHints: ["some hint"],
         }),
       );

--- a/src/middleware/system-prompt.ts
+++ b/src/middleware/system-prompt.ts
@@ -6,8 +6,6 @@ export type SystemPromptParams = {
   channelName: string;
   /** Display name of the user sending the message. */
   userName?: string | undefined;
-  /** Agent identifier within RemoteClaw. */
-  agentId?: string | undefined;
   /** IANA timezone string (e.g., "America/New_York"). */
   timezone?: string | undefined;
   /** Channel-specific formatting hints (e.g., LINE directives, Discord component schema). */
@@ -50,9 +48,6 @@ function buildRuntimeSection(params: SystemPromptParams): string {
   }
   if (params.timezone) {
     parts.push(`timezone=${params.timezone}`);
-  }
-  if (params.agentId) {
-    parts.push(`agent=${params.agentId}`);
   }
   return `## Runtime\nRuntime: ${parts.join(" | ")}`;
 }


### PR DESCRIPTION
## Summary

- Remove `agentId` from `buildRuntimeSection()` output — the LLM has no actionable use for its own agent ID (no MCP tool accepts it, `sessions_send` uses session keys)
- Remove `agentId` from `SystemPromptParams` type (not used elsewhere in the system-prompt module)
- Remove `agentId` passthrough from `channel-bridge.ts` → `buildSystemPrompt()`
- Update tests in both `system-prompt.test.ts` and `channel-bridge.test.ts`

`userName` was already present in the Runtime section from prior work (absorbed from the removed Identity section per #2159).

Closes #2166

## Test plan

- [x] `system-prompt.test.ts` — 16 tests pass (agent removed, user/timezone verified)
- [x] `channel-bridge.test.ts` — 70 tests pass (agentId no longer forwarded to buildSystemPrompt)
- [x] No type errors in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)