### PR TITLE
fix(config): restore "next" in update.channel Zod schema

### DIFF
--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -423,7 +423,7 @@ const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "logging.consoleStyle": ['"pretty"', '"compact"', '"json"'],
   "logging.redactSensitive": ['"off"', '"tools"'],
   "cli.banner.taglineMode": ['"random"', '"default"', '"off"'],
-  "update.channel": ['"stable"', '"beta"', '"dev"'],
+  "update.channel": ['"stable"', '"beta"', '"next"', '"dev"'],
   "agents.defaults.compaction.mode": ['"default"', '"safeguard"'],
   "agents.defaults.compaction.identifierPolicy": ['"strict"', '"off"', '"custom"'],
 };

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -53,7 +53,7 @@ export const FIELD_HELP: Record<string, string> = {
     'Controls tagline style in the CLI startup banner: "random" (default) picks from the rotating tagline pool, "default" always shows the neutral default tagline, and "off" hides tagline text while keeping the banner version line.',
   update:
     "Update-channel and startup-check behavior for keeping RemoteClaw runtime versions current. Use conservative channels in production and more experimental channels only in controlled environments.",
-  "update.channel": 'Update channel for git + npm installs ("stable", "beta", or "dev").',
+  "update.channel": 'Update channel for git + npm installs ("stable", "beta", "next", or "dev").',
   "update.checkOnStart": "Check for npm updates when the gateway starts (default: true).",
   "update.auto.enabled": "Enable background auto-update for package installs (default: false).",
   "update.auto.stableDelayHours":

--- a/src/config/validation.allowed-values.test.ts
+++ b/src/config/validation.allowed-values.test.ts
@@ -11,8 +11,8 @@ describe("config validation allowed-values metadata", () => {
     if (!result.ok) {
       const issue = result.issues.find((entry) => entry.path === "update.channel");
       expect(issue).toBeDefined();
-      expect(issue?.message).toContain('(allowed: "stable", "beta", "dev")');
-      expect(issue?.allowedValues).toEqual(["stable", "beta", "dev"]);
+      expect(issue?.message).toContain('(allowed: "stable", "beta", "next", "dev")');
+      expect(issue?.allowedValues).toEqual(["stable", "beta", "next", "dev"]);
       expect(issue?.allowedValuesHiddenCount).toBe(0);
     }
   });

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -262,7 +262,9 @@ export const RemoteClawSchema = z
       .optional(),
     update: z
       .object({
-        channel: z.union([z.literal("stable"), z.literal("beta"), z.literal("dev")]).optional(),
+        channel: z
+          .union([z.literal("stable"), z.literal("beta"), z.literal("next"), z.literal("dev")])
+          .optional(),
         checkOnStart: z.boolean().optional(),
         auto: z
           .object({


### PR DESCRIPTION
Closes #2186

## Summary

- Add `z.literal("next")` to `update.channel` union in Zod schema — upstream sync `0241706c9d` reverted it to `["stable", "beta", "dev"]`, but the runtime normalizes `"dev"` → `"next"`, which then fails validation on config reload
- Update help text and test expectations across `schema.help.ts`, `schema.help.quality.test.ts`, and `validation.allowed-values.test.ts`

## Test plan

- [x] `validation.allowed-values.test.ts` — 4 tests pass (union includes `"next"`)
- [x] `schema.help.quality.test.ts` — 20 tests pass (enum expectations updated)
- [x] Pre-commit hooks pass (format, typecheck, lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)