### PR TITLE
test(config): add schema regression test for update.channel fork-specific values

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -5,6 +5,7 @@ import {
   resolveAgentRuntimeArgs,
   resolveAgentRuntimeEnv,
 } from "../agents/agent-scope.js";
+import { normalizeUpdateChannel } from "../infra/update-channels.js";
 import { validateConfigObject } from "./config.js";
 
 describe("config schema regressions", () => {
@@ -233,6 +234,42 @@ describe("config schema regressions", () => {
     });
 
     expect(res.ok).toBe(true);
+  });
+
+  it('accepts update.channel "next"', () => {
+    const res = validateConfigObject({
+      update: {
+        channel: "next",
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it('accepts update.channel "dev" (backward compat)', () => {
+    const res = validateConfigObject({
+      update: {
+        channel: "dev",
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it('round-trip: normalizeUpdateChannel("dev") → "next" → validateConfigObject', () => {
+    const normalized = normalizeUpdateChannel("dev");
+    expect(normalized).toBe("next");
+
+    const res = validateConfigObject({
+      update: {
+        channel: normalized!,
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.update?.channel).toBe("next");
+    }
   });
 
   it("round-trip: full config through Zod parse then resolver functions", () => {


### PR DESCRIPTION
## Summary

- Add three schema regression tests for `update.channel` to prevent upstream sync regressions (#2187)
  - `"next"` accepted by `validateConfigObject`
  - `"dev"` accepted (backward compat alias)
  - Round-trip: `normalizeUpdateChannel("dev")` → `"next"` → validate → preserves value

Follows the established pattern from per-agent fork-specific field regression tests (commit `1284472b49`).

## Test plan

- [x] `npx vitest run src/config/config.schema-regressions.test.ts` — 19 tests pass (16 existing + 3 new)
- [ ] CI `test` job passes
- [ ] CI `lint` job passes

Closes #2187

🤖 Generated with [Claude Code](https://claude.com/claude-code)