### PR TITLE
fix(logging): correct levelToMinLevel mapping for tslog v4

### DIFF
--- a/src/logging/level-filter.test.ts
+++ b/src/logging/level-filter.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { readLoggingConfigMock, shouldSkipMutatingLoggingConfigReadMock } = vi.hoisted(() => ({
+  readLoggingConfigMock: vi.fn(() => undefined),
+  shouldSkipMutatingLoggingConfigReadMock: vi.fn(() => false),
+}));
+
+vi.mock("./config.js", () => ({
+  readLoggingConfig: readLoggingConfigMock,
+  shouldSkipMutatingLoggingConfigRead: shouldSkipMutatingLoggingConfigReadMock,
+}));
+
+vi.mock("./node-require.js", () => ({
+  resolveNodeRequireFromMeta: () => () => {
+    throw new Error("config fallback not used");
+  },
+}));
+
+let logging: typeof import("../logging.js");
+
+beforeAll(async () => {
+  logging = await import("../logging.js");
+});
+
+beforeEach(() => {
+  delete process.env.REMOTECLAW_TEST_FILE_LOG;
+  delete process.env.REMOTECLAW_LOG_LEVEL;
+  readLoggingConfigMock.mockClear();
+  shouldSkipMutatingLoggingConfigReadMock.mockReset();
+  shouldSkipMutatingLoggingConfigReadMock.mockReturnValue(false);
+  logging.resetLogger();
+  logging.setLoggerOverride(null);
+});
+
+afterEach(() => {
+  delete process.env.REMOTECLAW_TEST_FILE_LOG;
+  delete process.env.REMOTECLAW_LOG_LEVEL;
+  logging.resetLogger();
+  logging.setLoggerOverride(null);
+  vi.restoreAllMocks();
+});
+
+describe("isFileLogLevelEnabled", () => {
+  it("returns false for all levels when configured as silent", () => {
+    logging.setLoggerOverride({ level: "silent" });
+    expect(logging.isFileLogLevelEnabled("fatal")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("error")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("warn")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("info")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("debug")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("trace")).toBe(false);
+  });
+
+  it("passes only fatal when configured as fatal", () => {
+    logging.setLoggerOverride({ level: "fatal" });
+    expect(logging.isFileLogLevelEnabled("fatal")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("error")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("warn")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("info")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("debug")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("trace")).toBe(false);
+  });
+
+  it("passes fatal and error when configured as error", () => {
+    logging.setLoggerOverride({ level: "error" });
+    expect(logging.isFileLogLevelEnabled("fatal")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("error")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("warn")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("info")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("debug")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("trace")).toBe(false);
+  });
+
+  it("passes fatal, error, warn, info when configured as info", () => {
+    logging.setLoggerOverride({ level: "info" });
+    expect(logging.isFileLogLevelEnabled("fatal")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("error")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("warn")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("info")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("debug")).toBe(false);
+    expect(logging.isFileLogLevelEnabled("trace")).toBe(false);
+  });
+
+  it("passes all levels when configured as trace", () => {
+    logging.setLoggerOverride({ level: "trace" });
+    expect(logging.isFileLogLevelEnabled("fatal")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("error")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("warn")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("info")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("debug")).toBe(true);
+    expect(logging.isFileLogLevelEnabled("trace")).toBe(true);
+  });
+
+  it("never treats silent as an emittable file level", () => {
+    logging.setLoggerOverride({ level: "info" });
+    expect(logging.isFileLogLevelEnabled("silent")).toBe(false);
+  });
+});
+
+describe("getChildLogger minLevel inheritance", () => {
+  it("child logger inherits parent minLevel when no level is specified", () => {
+    logging.setLoggerOverride({ level: "warn" });
+    const child = logging.getChildLogger({ component: "test" });
+    expect(child.settings.minLevel).toBe(logging.levelToMinLevel("warn"));
+  });
+
+  it("child logger uses its own level when explicitly specified", () => {
+    logging.setLoggerOverride({ level: "warn" });
+    const child = logging.getChildLogger({ component: "test" }, { level: "error" });
+    expect(child.settings.minLevel).toBe(logging.levelToMinLevel("error"));
+  });
+
+  it("child logger does not default to minLevel=0 (allow-all) when no level given", () => {
+    logging.setLoggerOverride({ level: "fatal" });
+    const child = logging.getChildLogger({ component: "test" });
+    expect(child.settings.minLevel).not.toBe(0);
+    expect(child.settings.minLevel).toBe(logging.levelToMinLevel("fatal"));
+  });
+
+  it("pino child logger propagates the parent minLevel", () => {
+    logging.setLoggerOverride({ level: "error" });
+    const base = logging.getLogger();
+    const getSubLoggerSpy = vi.spyOn(base, "getSubLogger");
+
+    logging.toPinoLikeLogger(base, "info").child({ component: "test" });
+
+    expect(getSubLoggerSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        minLevel: logging.levelToMinLevel("error"),
+      }),
+    );
+  });
+});

--- a/src/logging/levels.test.ts
+++ b/src/logging/levels.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { levelToMinLevel } from "./levels.js";
+
+describe("levelToMinLevel", () => {
+  it("returns tslog v4 logLevelId values in ascending order", () => {
+    expect(levelToMinLevel("trace")).toBe(1);
+    expect(levelToMinLevel("debug")).toBe(2);
+    expect(levelToMinLevel("info")).toBe(3);
+    expect(levelToMinLevel("warn")).toBe(4);
+    expect(levelToMinLevel("error")).toBe(5);
+    expect(levelToMinLevel("fatal")).toBe(6);
+  });
+
+  it("maps silent to Infinity to suppress all logs", () => {
+    expect(levelToMinLevel("silent")).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("fatal has a higher value than trace (not inverted)", () => {
+    expect(levelToMinLevel("fatal")).toBeGreaterThan(levelToMinLevel("trace"));
+  });
+
+  it("each level is strictly more restrictive than the one below it", () => {
+    const ordered = ["trace", "debug", "info", "warn", "error", "fatal"] as const;
+    for (let i = 1; i < ordered.length; i++) {
+      expect(levelToMinLevel(ordered[i])).toBeGreaterThan(levelToMinLevel(ordered[i - 1]));
+    }
+  });
+});

--- a/src/logging/levels.ts
+++ b/src/logging/levels.ts
@@ -23,14 +23,15 @@ export function normalizeLogLevel(level?: string, fallback: LogLevel = "info") {
 }
 
 export function levelToMinLevel(level: LogLevel): number {
-  // tslog level ordering: fatal=0, error=1, warn=2, info=3, debug=4, trace=5
+  // tslog v4 logLevelId (src/index.ts): silly=0, trace=1, debug=2, info=3, warn=4, error=5, fatal=6
+  // tslog filters: logLevelId < minLevel is dropped, so higher minLevel = more restrictive.
   const map: Record<LogLevel, number> = {
-    fatal: 0,
-    error: 1,
-    warn: 2,
+    trace: 1,
+    debug: 2,
     info: 3,
-    debug: 4,
-    trace: 5,
+    warn: 4,
+    error: 5,
+    fatal: 6,
     silent: Number.POSITIVE_INFINITY,
   };
   return map[level];

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -119,10 +119,13 @@ export function isFileLogLevelEnabled(level: LogLevel): boolean {
   if (!loggingState.cachedSettings) {
     loggingState.cachedSettings = settings;
   }
+  if (level === "silent") {
+    return false;
+  }
   if (settings.level === "silent") {
     return false;
   }
-  return levelToMinLevel(level) <= levelToMinLevel(settings.level);
+  return levelToMinLevel(level) >= levelToMinLevel(settings.level);
 }
 
 function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
@@ -225,7 +228,7 @@ export function getChildLogger(
   opts?: { level?: LogLevel },
 ): TsLogger<LogObj> {
   const base = getLogger();
-  const minLevel = opts?.level ? levelToMinLevel(opts.level) : undefined;
+  const minLevel = opts?.level ? levelToMinLevel(opts.level) : base.settings.minLevel;
   const name = bindings ? JSON.stringify(bindings) : undefined;
   return base.getSubLogger({
     name,
@@ -240,6 +243,7 @@ export function toPinoLikeLogger(logger: TsLogger<LogObj>, level: LogLevel): Pin
     toPinoLikeLogger(
       logger.getSubLogger({
         name: bindings ? JSON.stringify(bindings) : undefined,
+        minLevel: logger.settings.minLevel,
       }),
       level,
     );

--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -28,6 +28,26 @@ describe("createSubsystemLogger().isEnabled", () => {
     expect(log.isEnabled("debug", "file")).toBe(false);
   });
 
+  it("uses threshold ordering for non-equal console levels", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "fatal" });
+    const fatalOnly = createSubsystemLogger("agent/embedded");
+
+    expect(fatalOnly.isEnabled("error", "console")).toBe(false);
+    expect(fatalOnly.isEnabled("fatal", "console")).toBe(true);
+
+    setLoggerOverride({ level: "silent", consoleLevel: "trace" });
+    const traceLogger = createSubsystemLogger("agent/embedded");
+
+    expect(traceLogger.isEnabled("debug", "console")).toBe(true);
+  });
+
+  it("never treats silent as an emittable console level", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "info" });
+    const log = createSubsystemLogger("agent/embedded");
+
+    expect(log.isEnabled("silent", "console")).toBe(false);
+  });
+
   it("returns false when neither console nor file logging would emit", () => {
     setLoggerOverride({ level: "silent", consoleLevel: "silent" });
     const log = createSubsystemLogger("agent/embedded");

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -24,12 +24,15 @@ export type SubsystemLogger = {
 };
 
 function shouldLogToConsole(level: LogLevel, settings: { level: LogLevel }): boolean {
+  if (level === "silent") {
+    return false;
+  }
   if (settings.level === "silent") {
     return false;
   }
   const current = levelToMinLevel(level);
   const min = levelToMinLevel(settings.level);
-  return current <= min;
+  return current >= min;
 }
 
 type ChalkInstance = InstanceType<typeof Chalk>;


### PR DESCRIPTION
## Summary

- Cherry-pick of upstream openclaw/openclaw#44646 (`f6bf8c72`), adapted for RemoteClaw env var naming
- Fixes inverted `levelToMinLevel` mapping that caused `logDebug()` calls to be silently dropped by the root tslog logger when `logging.level` was set to `"debug"`
- Corrects `isFileLogLevelEnabled` and `shouldLogToConsole` comparison direction (`<=` to `>=`), propagates `minLevel` to child and pino-like sub-loggers, treats `"silent"` as non-emittable in both filter paths

## Test plan

- [x] New `levels.test.ts` — verifies tslog v4 mapping values and strict ascending order
- [x] New `level-filter.test.ts` — verifies `isFileLogLevelEnabled` threshold behavior for all levels, silent guard, and child/pino logger `minLevel` inheritance
- [x] Extended `subsystem.test.ts` — verifies `shouldLogToConsole` threshold ordering and silent-as-emittable guard
- [x] All 78 logging tests pass (`pnpm vitest run src/logging/`)
- [x] Full pre-commit checks pass (format, typecheck, lint)

Closes #2158

🤖 Generated with [Claude Code](https://claude.com/claude-code)