### PR TITLE
test(middleware): assert ChannelBridge plumbing across all AgentRuntime entry points

### DIFF
--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -21,6 +21,17 @@ const channelBridgeHandleMock = vi.fn();
 const runWithModelFallbackMock = vi.fn();
 const runtimeErrorMock = vi.fn();
 
+type BridgeConstructorOpts = {
+  provider: string;
+  sessionMap: unknown;
+  gatewayUrl: string;
+  gatewayToken: string;
+  workspaceDir?: string;
+  runtimeArgs?: string[];
+  runtimeEnv?: Record<string, string>;
+};
+const bridgeConstructorCalls: BridgeConstructorOpts[] = [];
+
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: (params: {
     provider: string;
@@ -31,6 +42,9 @@ vi.mock("../../agents/model-fallback.js", () => ({
 
 vi.mock("../../middleware/channel-bridge.js", () => ({
   ChannelBridge: class MockChannelBridge {
+    constructor(opts: BridgeConstructorOpts) {
+      bridgeConstructorCalls.push(opts);
+    }
     handle(message: ChannelMessage, callbacks?: BridgeCallbacks, abortSignal?: AbortSignal) {
       return channelBridgeHandleMock(message, callbacks, abortSignal);
     }
@@ -124,6 +138,7 @@ beforeEach(() => {
   channelBridgeHandleMock.mockClear();
   runWithModelFallbackMock.mockClear();
   runtimeErrorMock.mockClear();
+  bridgeConstructorCalls.length = 0;
 
   // Default: no provider switch; execute the chosen provider+model.
   runWithModelFallbackMock.mockImplementation(
@@ -876,6 +891,173 @@ describe("runReplyAgent messaging tool suppression", () => {
     const store = loadSessionStore(storePath, { skipCache: true });
     expect(store[sessionKey]?.inputTokens).toBe(111);
     expect(store[sessionKey]?.outputTokens).toBe(22);
+  });
+});
+
+describe("runReplyAgent ChannelBridge constructor args", () => {
+  function createRun(overrides?: {
+    runtime?: string;
+    runtimeArgs?: string[];
+    workspaceDir?: string;
+    agentId?: string;
+  }) {
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "webchat",
+      OriginatingTo: "session:1",
+      AccountId: "primary",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const agentId = overrides?.agentId ?? "main";
+    const config: Record<string, unknown> = {
+      agents: {
+        defaults: {
+          runtime: overrides?.runtime ?? "claude",
+          ...(overrides?.runtimeArgs ? { runtimeArgs: overrides.runtimeArgs } : {}),
+        },
+      },
+    };
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        agentId,
+        sessionId: "session",
+        sessionKey: "main",
+        messageProvider: "webchat",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: overrides?.workspaceDir ?? "/tmp/workspace",
+        config,
+        provider: "anthropic",
+        model: "claude",
+
+        verboseLevel: "off",
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    return runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      defaultModel: "anthropic/claude-opus-4-5",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+  }
+
+  it("passes provider from resolveAgentRuntimeOrThrow", async () => {
+    channelBridgeHandleMock.mockResolvedValueOnce(
+      makeDeliveryResult({ payloads: [{ text: "ok" }] }),
+    );
+
+    await createRun({ runtime: "claude" });
+
+    expect(bridgeConstructorCalls).toHaveLength(1);
+    expect(bridgeConstructorCalls[0].provider).toBe("claude");
+  });
+
+  it("passes workspaceDir from followupRun", async () => {
+    channelBridgeHandleMock.mockResolvedValueOnce(
+      makeDeliveryResult({ payloads: [{ text: "ok" }] }),
+    );
+
+    await createRun({ workspaceDir: "/custom/workspace" });
+
+    expect(bridgeConstructorCalls).toHaveLength(1);
+    expect(bridgeConstructorCalls[0].workspaceDir).toBe("/custom/workspace");
+  });
+
+  it("passes runtimeArgs from resolveAgentRuntimeArgs", async () => {
+    channelBridgeHandleMock.mockResolvedValueOnce(
+      makeDeliveryResult({ payloads: [{ text: "ok" }] }),
+    );
+
+    await createRun({ runtimeArgs: ["--verbose", "--max-tokens=1000"] });
+
+    expect(bridgeConstructorCalls).toHaveLength(1);
+    expect(bridgeConstructorCalls[0].runtimeArgs).toEqual(["--verbose", "--max-tokens=1000"]);
+  });
+
+  it("passes undefined runtimeArgs when config omits them", async () => {
+    channelBridgeHandleMock.mockResolvedValueOnce(
+      makeDeliveryResult({ payloads: [{ text: "ok" }] }),
+    );
+
+    await createRun();
+
+    expect(bridgeConstructorCalls).toHaveLength(1);
+    expect(bridgeConstructorCalls[0].runtimeArgs).toBeUndefined();
+  });
+
+  it("passes runtimeEnv from auth-key-retry callback", async () => {
+    channelBridgeHandleMock.mockResolvedValueOnce(
+      makeDeliveryResult({ payloads: [{ text: "ok" }] }),
+    );
+
+    await createRun();
+
+    expect(bridgeConstructorCalls).toHaveLength(1);
+    // runtimeEnv is the merged env from withAuthKeyRetry — without auth
+    // profiles configured it will be the base runtime env (empty or minimal).
+    expect(bridgeConstructorCalls[0].runtimeEnv).toBeDefined();
+    expect(typeof bridgeConstructorCalls[0].runtimeEnv).toBe("object");
+  });
+
+  it("passes a functional sessionMap", async () => {
+    channelBridgeHandleMock.mockResolvedValueOnce(
+      makeDeliveryResult({ payloads: [{ text: "ok" }] }),
+    );
+
+    await createRun();
+
+    expect(bridgeConstructorCalls).toHaveLength(1);
+    expect(bridgeConstructorCalls[0].sessionMap).toBeDefined();
+    // sessionMap should have get and delete methods
+    const sessionMap = bridgeConstructorCalls[0].sessionMap as {
+      get: () => unknown;
+      delete: () => unknown;
+    };
+    expect(typeof sessionMap.get).toBe("function");
+    expect(typeof sessionMap.delete).toBe("function");
+  });
+
+  it("passes gatewayUrl derived from config port", async () => {
+    channelBridgeHandleMock.mockResolvedValueOnce(
+      makeDeliveryResult({ payloads: [{ text: "ok" }] }),
+    );
+
+    await createRun();
+
+    expect(bridgeConstructorCalls).toHaveLength(1);
+    // resolveGatewayPort is mocked to return 9999
+    expect(bridgeConstructorCalls[0].gatewayUrl).toBe("ws://127.0.0.1:9999");
+  });
+
+  it("passes gatewayToken from credentials config", async () => {
+    channelBridgeHandleMock.mockResolvedValueOnce(
+      makeDeliveryResult({ payloads: [{ text: "ok" }] }),
+    );
+
+    await createRun();
+
+    expect(bridgeConstructorCalls).toHaveLength(1);
+    // resolveGatewayCredentialsFromConfig is mocked to return { token: "test-token" }
+    expect(bridgeConstructorCalls[0].gatewayToken).toBe("test-token");
   });
 });
 

--- a/src/auto-reply/reply/followup-runner.channel-bridge.test.ts
+++ b/src/auto-reply/reply/followup-runner.channel-bridge.test.ts
@@ -1,0 +1,343 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelMessage } from "../../middleware/types.js";
+
+// ---------- captured constructor opts & handle mock ----------
+
+type BridgeConstructorOpts = {
+  provider: string;
+  workspaceDir?: string;
+  sessionMap?: unknown;
+  gatewayUrl?: string;
+  gatewayToken?: string;
+  runtimeArgs?: string[];
+  runtimeEnv?: Record<string, string>;
+};
+
+const bridgeConstructorCalls: BridgeConstructorOpts[] = [];
+const bridgeHandleMock = vi.fn<
+  (message: ChannelMessage, callbacks?: unknown, abortSignal?: AbortSignal) => Promise<void>
+>();
+
+// ---------- mocks ----------
+
+vi.mock("../../middleware/channel-bridge.js", () => ({
+  ChannelBridge: class MockChannelBridge {
+    constructor(opts: BridgeConstructorOpts) {
+      bridgeConstructorCalls.push(opts);
+    }
+
+    handle(message: ChannelMessage, callbacks?: unknown, abortSignal?: AbortSignal) {
+      return bridgeHandleMock(message, callbacks, abortSignal);
+    }
+  },
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentRuntimeOrThrow: vi.fn().mockReturnValue("claude"),
+  resolveAgentRuntimeArgs: vi.fn().mockReturnValue(["--flag-a"]),
+  resolveAgentRuntimeEnv: vi.fn().mockReturnValue({ CUSTOM_VAR: "value-1" }),
+}));
+
+vi.mock("../../agents/channel-tools.js", () => ({
+  resolveChannelMessageToolHints: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("../../config/paths.js", () => ({
+  resolveGatewayPort: vi.fn().mockReturnValue(4567),
+}));
+
+vi.mock("../../gateway/credentials.js", () => ({
+  resolveGatewayCredentialsFromConfig: vi.fn().mockReturnValue({ token: "gw-test-token" }),
+}));
+
+vi.mock("../../globals.js", () => ({
+  logVerbose: vi.fn(),
+}));
+
+vi.mock("./typing-mode.js", () => ({
+  createTypingSignaler: vi.fn().mockReturnValue({
+    signalRunStart: vi.fn().mockResolvedValue(undefined),
+    signalRunEnd: vi.fn().mockResolvedValue(undefined),
+    signalTextDelta: vi.fn().mockResolvedValue(undefined),
+    signalReasoningDelta: vi.fn().mockResolvedValue(undefined),
+    signalToolStart: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+const { createFollowupRunner } = await import("./followup-runner.js");
+
+// ---------- helpers ----------
+
+function makeTyping() {
+  return {
+    onReplyStart: vi.fn().mockResolvedValue(undefined),
+    startTypingLoop: vi.fn().mockResolvedValue(undefined),
+    startTypingOnText: vi.fn().mockResolvedValue(undefined),
+    refreshTypingTtl: vi.fn(),
+    isActive: vi.fn().mockReturnValue(false),
+    markRunComplete: vi.fn(),
+    markDispatchIdle: vi.fn(),
+    cleanup: vi.fn(),
+  };
+}
+
+function makeQueued(overrides?: Record<string, unknown>) {
+  return {
+    prompt: "followup prompt",
+    messageId: "msg-001",
+    summaryLine: "summary",
+    enqueuedAt: Date.now(),
+    originatingChannel: "telegram",
+    originatingTo: "chat-42",
+    originatingAccountId: "acct-7",
+    originatingThreadId: "thread-99",
+    run: {
+      agentId: "agent-1",
+      agentDir: "/agents/agent-1",
+      sessionId: "sess-abc",
+      sessionFile: "/sessions/sess-abc.json",
+      workspaceDir: "/workspace/proj",
+      config: { agents: { defaults: { runtime: "claude" } } },
+      provider: "claude",
+      model: "claude-sonnet-4-5",
+      timeoutMs: 60_000,
+      blockReplyBreak: "text_end" as const,
+    },
+    ...overrides,
+  };
+}
+
+// ---------- tests ----------
+
+describe("followup-runner — ChannelBridge wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    bridgeConstructorCalls.length = 0;
+    bridgeHandleMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes resolved provider to ChannelBridge constructor", async () => {
+    const runner = createFollowupRunner({
+      typing: makeTyping(),
+      typingMode: "never",
+      defaultModel: "claude-sonnet-4-5",
+    });
+
+    await runner(makeQueued() as never);
+
+    expect(bridgeConstructorCalls).toHaveLength(1);
+    // resolveAgentRuntimeOrThrow is mocked to return "claude"
+    expect(bridgeConstructorCalls[0].provider).toBe("claude");
+  });
+
+  it("passes workspaceDir from queued.run to ChannelBridge constructor", async () => {
+    const runner = createFollowupRunner({
+      typing: makeTyping(),
+      typingMode: "never",
+      defaultModel: "claude-sonnet-4-5",
+    });
+
+    await runner(makeQueued() as never);
+
+    expect(bridgeConstructorCalls[0].workspaceDir).toBe("/workspace/proj");
+  });
+
+  it("passes runtimeArgs from resolveAgentRuntimeArgs to ChannelBridge constructor", async () => {
+    const runner = createFollowupRunner({
+      typing: makeTyping(),
+      typingMode: "never",
+      defaultModel: "claude-sonnet-4-5",
+    });
+
+    await runner(makeQueued() as never);
+
+    expect(bridgeConstructorCalls[0].runtimeArgs).toEqual(["--flag-a"]);
+  });
+
+  it("passes runtimeEnv from resolveAgentRuntimeEnv to ChannelBridge constructor", async () => {
+    const runner = createFollowupRunner({
+      typing: makeTyping(),
+      typingMode: "never",
+      defaultModel: "claude-sonnet-4-5",
+    });
+
+    await runner(makeQueued() as never);
+
+    expect(bridgeConstructorCalls[0].runtimeEnv).toEqual({ CUSTOM_VAR: "value-1" });
+  });
+
+  it("passes gatewayUrl built from resolveGatewayPort to ChannelBridge constructor", async () => {
+    const runner = createFollowupRunner({
+      typing: makeTyping(),
+      typingMode: "never",
+      defaultModel: "claude-sonnet-4-5",
+    });
+
+    await runner(makeQueued() as never);
+
+    // resolveGatewayPort mocked to 4567
+    expect(bridgeConstructorCalls[0].gatewayUrl).toBe("ws://127.0.0.1:4567");
+  });
+
+  it("passes gatewayToken from resolveGatewayCredentialsFromConfig to ChannelBridge constructor", async () => {
+    const runner = createFollowupRunner({
+      typing: makeTyping(),
+      typingMode: "never",
+      defaultModel: "claude-sonnet-4-5",
+    });
+
+    await runner(makeQueued() as never);
+
+    // resolveGatewayCredentialsFromConfig mocked to { token: "gw-test-token" }
+    expect(bridgeConstructorCalls[0].gatewayToken).toBe("gw-test-token");
+  });
+
+  it("builds sessionMap that reads CLI session ID from session store via provider key", async () => {
+    const sessionStore: Record<string, { cliSessionIds?: Record<string, string> }> = {
+      "my-key": { cliSessionIds: { claude: "cli-sess-xyz" } },
+    };
+
+    const runner = createFollowupRunner({
+      typing: makeTyping(),
+      typingMode: "never",
+      defaultModel: "claude-sonnet-4-5",
+      sessionStore: sessionStore as never,
+      sessionKey: "my-key",
+    });
+
+    await runner(makeQueued() as never);
+
+    expect(bridgeConstructorCalls).toHaveLength(1);
+    const sessionMap = bridgeConstructorCalls[0].sessionMap as {
+      get(): Promise<string | undefined>;
+    };
+    const cliSessionId = await sessionMap.get();
+    expect(cliSessionId).toBe("cli-sess-xyz");
+  });
+
+  it("sessionMap returns undefined when sessionKey is not set", async () => {
+    const runner = createFollowupRunner({
+      typing: makeTyping(),
+      typingMode: "never",
+      defaultModel: "claude-sonnet-4-5",
+      // no sessionKey or sessionStore
+    });
+
+    await runner(makeQueued() as never);
+
+    const sessionMap = bridgeConstructorCalls[0].sessionMap as {
+      get(): Promise<string | undefined>;
+    };
+    const result = await sessionMap.get();
+    expect(result).toBeUndefined();
+  });
+
+  it("calls handle() with a correctly built ChannelMessage", async () => {
+    const runner = createFollowupRunner({
+      typing: makeTyping(),
+      typingMode: "never",
+      defaultModel: "claude-sonnet-4-5",
+    });
+
+    await runner(makeQueued() as never);
+
+    expect(bridgeHandleMock).toHaveBeenCalledOnce();
+    const message = bridgeHandleMock.mock.calls[0][0] as ChannelMessage;
+    expect(message.id).toBe("msg-001");
+    expect(message.text).toBe("followup prompt");
+    expect(message.from).toBe("acct-7");
+    expect(message.channelId).toBe("chat-42");
+    expect(message.provider).toBe("telegram");
+    expect(message.replyToId).toBe("thread-99");
+    expect(message.timestamp).toBeTypeOf("number");
+  });
+
+  it("passes BridgeCallbacks wired from opts to handle()", async () => {
+    const onPartialReply = vi.fn();
+    const onBlockReply = vi.fn();
+    const onToolResult = vi.fn();
+
+    const runner = createFollowupRunner({
+      opts: { onPartialReply, onBlockReply, onToolResult },
+      typing: makeTyping(),
+      typingMode: "never",
+      defaultModel: "claude-sonnet-4-5",
+    });
+
+    await runner(makeQueued() as never);
+
+    const callbacks = bridgeHandleMock.mock.calls[0][1] as {
+      onPartialReply?: unknown;
+      onBlockReply?: unknown;
+      onToolResult?: unknown;
+    };
+    expect(callbacks.onPartialReply).toBe(onPartialReply);
+    expect(callbacks.onBlockReply).toBe(onBlockReply);
+    expect(callbacks.onToolResult).toBe(onToolResult);
+  });
+
+  it("passes abortSignal from opts to handle()", async () => {
+    const controller = new AbortController();
+
+    const runner = createFollowupRunner({
+      opts: { abortSignal: controller.signal },
+      typing: makeTyping(),
+      typingMode: "never",
+      defaultModel: "claude-sonnet-4-5",
+    });
+
+    await runner(makeQueued() as never);
+
+    const abortSignal = bridgeHandleMock.mock.calls[0][2];
+    expect(abortSignal).toBe(controller.signal);
+  });
+
+  it("generates a UUID for message.id when queued.messageId is absent", async () => {
+    const runner = createFollowupRunner({
+      typing: makeTyping(),
+      typingMode: "never",
+      defaultModel: "claude-sonnet-4-5",
+    });
+
+    await runner(makeQueued({ messageId: undefined }) as never);
+
+    const message = bridgeHandleMock.mock.calls[0][0] as ChannelMessage;
+    // crypto.randomUUID() produces a UUID v4 pattern
+    expect(message.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  it("calls markRunComplete and markDispatchIdle on the typing controller in finally block", async () => {
+    const typing = makeTyping();
+
+    const runner = createFollowupRunner({
+      typing,
+      typingMode: "never",
+      defaultModel: "claude-sonnet-4-5",
+    });
+
+    await runner(makeQueued() as never);
+
+    expect(typing.markRunComplete).toHaveBeenCalledOnce();
+    expect(typing.markDispatchIdle).toHaveBeenCalledOnce();
+  });
+
+  it("calls typing cleanup even when handle() throws", async () => {
+    bridgeHandleMock.mockRejectedValueOnce(new Error("bridge failure"));
+    const typing = makeTyping();
+
+    const runner = createFollowupRunner({
+      typing,
+      typingMode: "never",
+      defaultModel: "claude-sonnet-4-5",
+    });
+
+    await expect(runner(makeQueued() as never)).rejects.toThrow("bridge failure");
+
+    expect(typing.markRunComplete).toHaveBeenCalledOnce();
+    expect(typing.markDispatchIdle).toHaveBeenCalledOnce();
+  });
+});

--- a/src/auto-reply/reply/followup-runner.channel-bridge.test.ts
+++ b/src/auto-reply/reply/followup-runner.channel-bridge.test.ts
@@ -247,7 +247,7 @@ describe("followup-runner — ChannelBridge wiring", () => {
     await runner(makeQueued() as never);
 
     expect(bridgeHandleMock).toHaveBeenCalledOnce();
-    const message = bridgeHandleMock.mock.calls[0][0] as ChannelMessage;
+    const message = bridgeHandleMock.mock.calls[0][0];
     expect(message.id).toBe("msg-001");
     expect(message.text).toBe("followup prompt");
     expect(message.from).toBe("acct-7");
@@ -306,7 +306,7 @@ describe("followup-runner — ChannelBridge wiring", () => {
 
     await runner(makeQueued({ messageId: undefined }) as never);
 
-    const message = bridgeHandleMock.mock.calls[0][0] as ChannelMessage;
+    const message = bridgeHandleMock.mock.calls[0][0];
     // crypto.randomUUID() produces a UUID v4 pattern
     expect(message.id).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,

--- a/src/auto-reply/reply/followup-runner.channel-bridge.test.ts
+++ b/src/auto-reply/reply/followup-runner.channel-bridge.test.ts
@@ -14,9 +14,10 @@ type BridgeConstructorOpts = {
 };
 
 const bridgeConstructorCalls: BridgeConstructorOpts[] = [];
-const bridgeHandleMock = vi.fn<
-  (message: ChannelMessage, callbacks?: unknown, abortSignal?: AbortSignal) => Promise<void>
->();
+const bridgeHandleMock =
+  vi.fn<
+    (message: ChannelMessage, callbacks?: unknown, abortSignal?: AbortSignal) => Promise<void>
+  >();
 
 // ---------- mocks ----------
 
@@ -307,7 +308,9 @@ describe("followup-runner — ChannelBridge wiring", () => {
 
     const message = bridgeHandleMock.mock.calls[0][0] as ChannelMessage;
     // crypto.randomUUID() produces a UUID v4 pattern
-    expect(message.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    expect(message.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
   });
 
   it("calls markRunComplete and markDispatchIdle on the typing controller in finally block", async () => {

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -28,6 +28,7 @@ type BridgeConstructorOpts = {
   gatewayUrl: string;
   gatewayToken: string;
   workspaceDir?: string;
+  runtimeArgs?: string[];
   runtimeEnv?: Record<string, string>;
 };
 
@@ -115,7 +116,7 @@ vi.mock("../agents/workspace.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../agents/workspace.js")>();
   return {
     ...actual,
-    ensureAgentWorkspace: vi.fn(async (dir: string) => dir),
+    ensureAgentWorkspace: vi.fn(async (dir: string) => ({ dir })),
   };
 });
 
@@ -758,6 +759,66 @@ describe("agentCommand", () => {
 
       const lastBridgeOpts = bridgeConstructorCalls.at(-1);
       expect(lastBridgeOpts?.runtimeEnv).toEqual(injectedEnv);
+    });
+  });
+
+  it("passes workspaceDir from ensureAgentWorkspace to ChannelBridge", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+
+      await agentCommand({ message: "hi", to: "+1555" }, runtime);
+
+      const lastBridgeOpts = bridgeConstructorCalls.at(-1);
+      expect(lastBridgeOpts?.workspaceDir).toBe(path.join(home, "remoteclaw"));
+    });
+  });
+
+  it("passes runtimeArgs from config to ChannelBridge", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { runtimeArgs: ["--verbose", "--model", "sonnet"] });
+
+      await agentCommand({ message: "hi", to: "+1555" }, runtime);
+
+      const lastBridgeOpts = bridgeConstructorCalls.at(-1);
+      expect(lastBridgeOpts?.runtimeArgs).toEqual(["--verbose", "--model", "sonnet"]);
+    });
+  });
+
+  it("passes sessionMap to ChannelBridge", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+
+      await agentCommand({ message: "hi", to: "+1555" }, runtime);
+
+      const lastBridgeOpts = bridgeConstructorCalls.at(-1);
+      expect(lastBridgeOpts?.sessionMap).toBeDefined();
+    });
+  });
+
+  it("passes gateway ws:// URL to ChannelBridge", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+
+      await agentCommand({ message: "hi", to: "+1555" }, runtime);
+
+      const lastBridgeOpts = bridgeConstructorCalls.at(-1);
+      expect(lastBridgeOpts?.gatewayUrl).toMatch(/^ws:\/\//);
+    });
+  });
+
+  it("passes gatewayToken to ChannelBridge", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+
+      await agentCommand({ message: "hi", to: "+1555" }, runtime);
+
+      const lastBridgeOpts = bridgeConstructorCalls.at(-1);
+      expect(lastBridgeOpts?.gatewayToken).toBeDefined();
     });
   });
 

--- a/src/cron/isolated-agent/run.channel-bridge.test.ts
+++ b/src/cron/isolated-agent/run.channel-bridge.test.ts
@@ -7,6 +7,12 @@ import type { ChannelMessage } from "../../middleware/types.js";
 
 const channelBridgeHandleMock = vi.fn();
 let capturedSessionMap: import("../../middleware/session-map.js").SessionMap | undefined;
+let capturedProvider: string | undefined;
+let capturedWorkspaceDir: string | undefined;
+let capturedRuntimeArgs: string[] | undefined;
+let capturedRuntimeEnv: Record<string, string> | undefined;
+let capturedGatewayUrl: string | undefined;
+let capturedGatewayToken: string | undefined;
 
 vi.mock("../../middleware/channel-bridge.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../middleware/channel-bridge.js")>();
@@ -16,9 +22,23 @@ vi.mock("../../middleware/channel-bridge.js", async (importOriginal) => {
       readonly provider: string;
       readonly workspaceDir?: string;
 
-      constructor(opts: { provider: string; workspaceDir?: string; sessionMap?: unknown }) {
+      constructor(opts: {
+        provider: string;
+        workspaceDir?: string;
+        sessionMap?: unknown;
+        runtimeArgs?: string[];
+        runtimeEnv?: Record<string, string>;
+        gatewayUrl?: string;
+        gatewayToken?: string;
+      }) {
         this.provider = opts.provider;
         this.workspaceDir = opts.workspaceDir;
+        capturedProvider = opts.provider;
+        capturedWorkspaceDir = opts.workspaceDir;
+        capturedRuntimeArgs = opts.runtimeArgs;
+        capturedRuntimeEnv = opts.runtimeEnv;
+        capturedGatewayUrl = opts.gatewayUrl;
+        capturedGatewayToken = opts.gatewayToken;
         capturedSessionMap = opts.sessionMap as
           | import("../../middleware/session-map.js").SessionMap
           | undefined;
@@ -263,6 +283,12 @@ describe("runCronIsolatedAgentTurn — ChannelBridge wiring", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedSessionMap = undefined;
+    capturedProvider = undefined;
+    capturedWorkspaceDir = undefined;
+    capturedRuntimeArgs = undefined;
+    capturedRuntimeEnv = undefined;
+    capturedGatewayUrl = undefined;
+    capturedGatewayToken = undefined;
     previousFastTestEnv = process.env.REMOTECLAW_TEST_FAST;
     delete process.env.REMOTECLAW_TEST_FAST;
     resolveCronSessionMock.mockReturnValue(makeFreshSession());
@@ -447,5 +473,48 @@ describe("runCronIsolatedAgentTurn — ChannelBridge wiring", () => {
 
     expect(result.status).toBe("ok");
     expect(result.runtime).toBe("claude");
+  });
+
+  describe("ChannelBridge constructor arguments", () => {
+    it("passes provider from resolveAgentRuntimeOrThrow", async () => {
+      await runCronIsolatedAgentTurn(makeParams());
+
+      expect(capturedProvider).toBe("claude");
+    });
+
+    it("passes workspaceDir from resolved agent workspace", async () => {
+      await runCronIsolatedAgentTurn(makeParams());
+
+      // ensureAgentWorkspace mock returns "/tmp/workspace"
+      expect(capturedWorkspaceDir).toBe("/tmp/workspace");
+    });
+
+    it("passes runtimeArgs from resolveAgentRuntimeArgs", async () => {
+      await runCronIsolatedAgentTurn(makeParams());
+
+      // resolveAgentRuntimeArgs mock returns undefined
+      expect(capturedRuntimeArgs).toBeUndefined();
+    });
+
+    it("passes runtimeEnv from withAuthKeyRetry callback", async () => {
+      await runCronIsolatedAgentTurn(makeParams());
+
+      // withAuthKeyRetry mock calls execute with {}
+      expect(capturedRuntimeEnv).toEqual({});
+    });
+
+    it("passes gatewayUrl resolved from config port", async () => {
+      await runCronIsolatedAgentTurn(makeParams());
+
+      // resolveGatewayPort mock returns 3579
+      expect(capturedGatewayUrl).toBe("ws://127.0.0.1:3579");
+    });
+
+    it("passes gatewayToken resolved from gateway credentials", async () => {
+      await runCronIsolatedAgentTurn(makeParams());
+
+      // resolveGatewayCredentialsFromConfig mock returns { token: "test-token" }
+      expect(capturedGatewayToken).toBe("test-token");
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Add ChannelBridge constructor arg assertions to all four production call sites — the fork's replacement for upstream `runEmbeddedPiAgent()`
- New test file for `followup-runner` (14 tests) — previously had zero coverage
- Extended existing tests for `agent-runner-execution` (8 new), `cron isolated-agent` (6 new), and `agent-command` (5 new)
- All 7 ChannelBridge constructor properties (`provider`, `workspaceDir`, `runtimeArgs`, `runtimeEnv`, `sessionMap`, `gatewayUrl`, `gatewayToken`) are now explicitly asserted at every call site

Closes #2196, closes #2197, closes #2198, closes #2199

## Test plan

- [x] `vitest run src/auto-reply/reply/followup-runner.channel-bridge.test.ts` — 14 passed
- [x] `vitest run src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts` — 8 new passed (9 pre-existing failures unchanged)
- [x] `vitest run src/cron/isolated-agent/run.channel-bridge.test.ts` — 18 passed
- [x] `vitest run src/commands/agent.test.ts` — 32 passed
- [x] oxlint: 0 errors, 0 warnings
- [x] oxfmt: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)