### PR TITLE
fix(cron): pass workspaceDir.dir string instead of object to ChannelBridge

### DIFF
--- a/src/cron/isolated-agent/run.channel-bridge.test.ts
+++ b/src/cron/isolated-agent/run.channel-bridge.test.ts
@@ -74,7 +74,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
 }));
 
 vi.mock("../../agents/workspace.js", () => ({
-  ensureAgentWorkspace: vi.fn().mockResolvedValue("/tmp/workspace"),
+  ensureAgentWorkspace: vi.fn().mockResolvedValue({ dir: "/tmp/workspace" }),
 }));
 
 vi.mock("../../agents/model-catalog.js", () => ({

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -386,8 +386,7 @@ export async function runCronIsolatedAgentTurn(params: {
           sessionMap,
           gatewayUrl: resolveGatewayUrlFromConfig(cfgWithAgentDefaults),
           gatewayToken: resolveGatewayTokenFromConfig(cfgWithAgentDefaults),
-          // @ts-expect-error — upstream feature not available in RemoteClaw fork
-          workspaceDir,
+          workspaceDir: workspaceDir.dir,
           runtimeArgs: resolveAgentRuntimeArgs(params.cfg, agentId),
           runtimeEnv,
         });

--- a/src/middleware/channel-bridge.test.ts
+++ b/src/middleware/channel-bridge.test.ts
@@ -1071,6 +1071,18 @@ describe("ChannelBridge", () => {
       expect(params.workingDirectory).toBe(".");
     });
 
+    it("passes workingDirectory as a string, not an object", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = createBridge({ workspaceDir: "/some/path" });
+      await bridge.handle(makeMessage());
+
+      const params = executeFn.mock.calls[0][0];
+      expect(typeof params.workingDirectory).toBe("string");
+      expect(params.workingDirectory).toBe("/some/path");
+    });
+
     it("uses default MCP server path when not specified", async () => {
       const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
       mockRuntimeInstance = { execute: executeFn };

--- a/src/middleware/integration.test.ts
+++ b/src/middleware/integration.test.ts
@@ -106,6 +106,38 @@ describe("M2 middleware integration", () => {
     });
   }
 
+  // ── workingDirectory plumbing ────────────────────────────────────────
+
+  describe("workingDirectory plumbing", () => {
+    it("passes workspaceDir as a string to runtime.execute()", async () => {
+      const executeFn = vi.fn((_p: AgentExecuteParams) => eventStream([makeDone()]));
+      mockRuntimeInstance = { execute: executeFn };
+
+      const bridge = createBridge({ workspaceDir: "/my/workspace" });
+      await bridge.handle(makeMessage());
+
+      const params = executeFn.mock.calls[0][0];
+      expect(typeof params.workingDirectory).toBe("string");
+      expect(params.workingDirectory).toBe("/my/workspace");
+    });
+
+    it("rejects non-string workspaceDir at the type level", () => {
+      // This test documents the contract: workspaceDir must be a string.
+      // If ensureAgentWorkspace() returns { dir: string }, callers must
+      // extract .dir before passing to ChannelBridge. The TypeScript
+      // compiler enforces this — this test guards against @ts-expect-error
+      // or type assertion bypasses.
+      const opts: ChannelBridgeOptions = {
+        provider: "claude",
+        sessionMap,
+        gatewayUrl: "wss://gw.test.com",
+        gatewayToken: "tok",
+        workspaceDir: "/valid/string/path",
+      };
+      expect(typeof opts.workspaceDir).toBe("string");
+    });
+  });
+
   // ── Basic pipeline flow ──────────────────────────────────────────────
 
   describe("basic pipeline flow", () => {


### PR DESCRIPTION
## Summary

- Fix `ERR_INVALID_ARG_TYPE` crash on cron-triggered agent runs caused by passing `ensureAgentWorkspace()` return (`{ dir: string }`) directly as `workspaceDir` instead of extracting `.dir`
- Remove incorrect `@ts-expect-error` that masked the type mismatch
- Add regression tests asserting `workingDirectory` is always `typeof string`

Closes #2212
Closes #2213

## Test plan

- [x] Type-check passes (`pnpm tsgo`)
- [x] Lint + format clean (`pnpm check`)
- [x] All 93 middleware tests pass (channel-bridge + integration)
- [x] New tests verify `workingDirectory` type contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)