### PR TITLE
fix(tui): remove undefined openModelSelector binding that crashes Ctrl+L

### DIFF
--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -798,8 +798,7 @@ export async function runTui(opts: TuiOptions) {
     process.exit(0);
   };
 
-  // @ts-expect-error — upstream feature not available in RemoteClaw fork
-  const { handleCommand, sendMessage, openModelSelector, openAgentSelector, openSessionSelector } =
+  const { handleCommand, sendMessage, openAgentSelector, openSessionSelector } =
     createCommandHandlers({
       client,
       chatLog,
@@ -875,9 +874,6 @@ export async function runTui(opts: TuiOptions) {
     chatLog.setToolsExpanded(toolsExpanded);
     setActivityStatus(toolsExpanded ? "tools expanded" : "tools collapsed");
     tui.requestRender();
-  };
-  editor.onCtrlL = () => {
-    void openModelSelector();
   };
   editor.onCtrlG = () => {
     void openAgentSelector();


### PR DESCRIPTION
## Summary

- Remove `openModelSelector` from destructure in `tui.ts` — `createCommandHandlers()` doesn't return it (model management gutted per Middleware Boundary Principle)
- Remove the `editor.onCtrlL` binding that called the undefined function, causing a `TypeError` crash
- Remove the `@ts-expect-error` suppression that was masking the missing return property

Closes #2215

## Test plan

- [x] `grep -n "openModelSelector" src/tui/tui.ts` returns 0 matches
- [x] Build passes (`pnpm build`)
- [x] Type-check passes (`pnpm tsgo`)
- [x] All pre-commit hooks pass (format, lint, type-check)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)