### PR TITLE
gut: remove IRC dead test + skill commands dead body

### DIFF
--- a/extensions/irc/src/policy.test.ts
+++ b/extensions/irc/src/policy.test.ts
@@ -1,4 +1,3 @@
-import { resolveDefaultGroupPolicy } from "remoteclaw/plugin-sdk";
 import { describe, expect, it } from "vitest";
 import {
   resolveIrcGroupAccessGate,
@@ -115,42 +114,5 @@ describe("irc policy", () => {
       commandAuthorized: true,
     });
     expect(gate.shouldSkip).toBe(false);
-  });
-
-  // Skipped: tests gutted functionality (Middleware Boundary Principle)
-
-  it.skip("keeps case-insensitive group matching aligned with shared channel policy resolution", () => {
-    const groups = {
-      "#Ops": { requireMention: false },
-      "#Hidden": { enabled: false },
-      "*": { requireMention: true },
-    };
-
-    const inboundDirect = resolveIrcGroupMatch({ groups, target: "#ops" });
-    const sharedDirect = resolveDefaultGroupPolicy({
-      // @ts-expect-error — upstream feature not available in RemoteClaw fork
-      cfg: { channels: { irc: { groups } } },
-      channel: "irc",
-      groupId: "#ops",
-      groupIdCaseInsensitive: true,
-    });
-    // @ts-expect-error — upstream feature not available in RemoteClaw fork
-    expect(sharedDirect.allowed).toBe(inboundDirect.allowed);
-    // @ts-expect-error — upstream feature not available in RemoteClaw fork
-    expect(sharedDirect.groupConfig?.requireMention).toBe(
-      inboundDirect.groupConfig?.requireMention,
-    );
-
-    const inboundDisabled = resolveIrcGroupMatch({ groups, target: "#hidden" });
-    const sharedDisabled = resolveDefaultGroupPolicy({
-      // @ts-expect-error — upstream feature not available in RemoteClaw fork
-      cfg: { channels: { irc: { groups } } },
-      channel: "irc",
-      groupId: "#hidden",
-      groupIdCaseInsensitive: true,
-    });
-    // @ts-expect-error — upstream feature not available in RemoteClaw fork
-    expect(sharedDisabled.allowed).toBe(inboundDisabled.allowed);
-    expect(inboundDisabled.groupConfig?.enabled).toBe(false);
   });
 });

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -77,29 +77,6 @@ describe("commands registry", () => {
     expect(commands.find((spec) => spec.key === "bash")).toBeFalsy();
   });
 
-  it("appends skill commands when provided", () => {
-    const skillCommands = [
-      {
-        name: "demo_skill",
-        skillName: "demo-skill",
-        description: "Demo skill",
-      },
-    ];
-    const commands = listChatCommandsForConfig(
-      {
-        commands: { config: false, debug: false },
-      },
-      { skillCommands },
-    );
-    expect(commands.find((spec) => spec.nativeName === "demo_skill")).toBeTruthy();
-
-    const native = listNativeCommandSpecsForConfig(
-      { commands: { config: false, debug: false, native: true } },
-      { skillCommands },
-    );
-    expect(native.find((spec) => spec.name === "demo_skill")).toBeTruthy();
-  });
-
   it("applies provider-specific native names", () => {
     const native = listNativeCommandSpecsForConfig(
       { commands: { native: true } },

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -78,22 +78,10 @@ function getTextAliasMap(): Map<string, TextAliasSpec> {
   return map;
 }
 
-function buildSkillCommandDefinitions(skillCommands?: SkillCommandSpec[]): ChatCommandDefinition[] {
-  if (!skillCommands || skillCommands.length === 0) {
-    return [];
-  }
-  // @ts-expect-error — upstream feature not available in RemoteClaw fork
-  return skillCommands.map((spec) => ({
-    // oxlint-disable-next-line
-    key: `skill:${spec.skillName}`,
-    nativeName: spec.name,
-    description: spec.description,
-    // oxlint-disable-next-line
-    textAliases: [`/${spec.name}`],
-    acceptsArgs: true,
-    argsParsing: "none",
-    scope: "both",
-  }));
+function buildSkillCommandDefinitions(
+  _skillCommands?: SkillCommandSpec[],
+): ChatCommandDefinition[] {
+  return [];
 }
 
 export function listChatCommands(params?: {


### PR DESCRIPTION
## Summary

- Remove skip'd IRC test (`extensions/irc/src/policy.test.ts`) that calls `resolveDefaultGroupPolicy` with upstream's expanded signature — coverage already exists in `runtime-group-policy.test.ts`
- Collapse `buildSkillCommandDefinitions` body to `return []` — `SkillCommandSpec` is a stub and no skills subsystem produces specs
- Remove corresponding dead test in `commands-registry.test.ts`

Closes #2226

## Test plan

- [x] `grep -c "@ts-expect-error" extensions/irc/src/policy.test.ts` = 0
- [x] `grep -c "@ts-expect-error" src/auto-reply/commands-registry.ts` = 0
- [x] No `it.skip` block in IRC test
- [x] `buildSkillCommandDefinitions` body is just `return [];`
- [x] Pre-commit hooks pass (format, typecheck, lint)
- [ ] CI build + test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)