### PR TITLE
fix: Feishu chat tool propagation + 3 small type fixes

### DIFF
--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -39,9 +39,9 @@ export function createFeishuToolClient(params: {
 export function resolveAnyEnabledFeishuToolsConfig(
   accounts: ResolvedFeishuAccount[],
 ): Required<FeishuToolsConfig> {
-  // @ts-expect-error — upstream feature not available in RemoteClaw fork
   const merged: Required<FeishuToolsConfig> = {
     doc: false,
+    chat: false,
     wiki: false,
     drive: false,
     perm: false,
@@ -50,6 +50,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
   for (const account of accounts) {
     const cfg = resolveToolsConfig(account.config.tools);
     merged.doc = merged.doc || cfg.doc;
+    merged.chat = merged.chat || cfg.chat;
     merged.wiki = merged.wiki || cfg.wiki;
     merged.drive = merged.drive || cfg.drive;
     merged.perm = merged.perm || cfg.perm;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -233,10 +233,10 @@ export async function runAgentTurnWithFallback(params: {
 
       // Notify that model selection is complete.
       // This allows responsePrefix template interpolation with the actual model.
-      // @ts-expect-error — upstream feature not available in RemoteClaw fork
       params.opts?.onModelSelected?.({
         provider,
         model,
+        thinkLevel: undefined,
       });
 
       const startedAt = Date.now();

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -752,8 +752,6 @@ export const nodeHandlers: GatewayRequestHandlers = {
         command,
         rawParams: p.params,
         client,
-        // @ts-expect-error — upstream feature not available in RemoteClaw fork
-        execApprovalManager: context.execApprovalManager,
       });
       if (!forwardedParams.ok) {
         respond(

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -87,8 +87,6 @@ function buildCtx(): NodeEventContext {
     agentRunSeq: new Map(),
     getHealthCache: () => null,
     refreshHealthSnapshot: async () => ({}) as HealthSummary,
-    // @ts-expect-error — upstream feature not available in RemoteClaw fork
-    loadGatewayModelCatalog: async () => [],
     logGateway: { warn: () => {} },
   };
 }


### PR DESCRIPTION
## Summary

- **Feishu `chat` tool propagation (bug)**: Add missing `chat` field to `resolveAnyEnabledFeishuToolsConfig` initializer and merge loop — accounts with `chat: true` were silently ignored
- **`thinkLevel` in `onModelSelected`**: Add missing `thinkLevel: undefined` to satisfy `ModelSelectedContext` type
- **Excess `execApprovalManager`**: Remove dead property passed to `sanitizeNodeInvokeParamsForForwarding`
- **Excess `loadGatewayModelCatalog` in test**: Remove property that doesn't exist on `NodeEventContext`

Closes #2217

## Test plan

- [x] `@ts-expect-error` count is 0 in all 4 files
- [x] Build passes (`pnpm build`)
- [x] Tests pass (`server-node-events.test.ts` — 20/20)
- [x] Pre-commit hooks pass (format, typecheck, lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)