### PR TITLE
fix(telegram): add missing nativeSkillsEnabled prop + remove dead replyMedia param

### DIFF
--- a/src/telegram/bot-message.ts
+++ b/src/telegram/bot-message.ts
@@ -52,13 +52,10 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     allMedia: TelegramMediaRef[],
     storeAllowFrom: string[],
     options?: { messageIdOverride?: string; forceWasMentioned?: boolean },
-    replyMedia?: TelegramMediaRef[],
   ) => {
     const context = await buildTelegramMessageContext({
       primaryCtx,
       allMedia,
-      // @ts-expect-error — upstream feature not available in RemoteClaw fork
-      replyMedia,
       storeAllowFrom,
       options,
       bot,

--- a/src/telegram/bot-native-commands.plugin-auth.test.ts
+++ b/src/telegram/bot-native-commands.plugin-auth.test.ts
@@ -43,7 +43,6 @@ describe("registerTelegramNativeCommands (plugin auth)", () => {
       },
     } as const;
 
-    // @ts-expect-error — upstream feature not available in RemoteClaw fork
     registerTelegramNativeCommands({
       bot: bot as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
       cfg: {
@@ -58,7 +57,7 @@ describe("registerTelegramNativeCommands (plugin auth)", () => {
       textLimit: 4000,
       useAccessGroups: false,
       nativeEnabled: false,
-
+      nativeSkillsEnabled: false,
       nativeDisabledExplicit: false,
       resolveGroupPolicy: () =>
         ({
@@ -111,7 +110,6 @@ describe("registerTelegramNativeCommands (plugin auth)", () => {
         allowed: true,
       }) as ChannelGroupPolicy;
 
-    // @ts-expect-error — upstream feature not available in RemoteClaw fork
     registerTelegramNativeCommands({
       bot: bot as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
       cfg,
@@ -124,7 +122,7 @@ describe("registerTelegramNativeCommands (plugin auth)", () => {
       textLimit: 4000,
       useAccessGroups: false,
       nativeEnabled: false,
-
+      nativeSkillsEnabled: false,
       nativeDisabledExplicit: false,
       resolveGroupPolicy,
       resolveTelegramGroupConfig: () => ({

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -109,7 +109,6 @@ export type RegisterTelegramHandlerParams = {
       messageIdOverride?: string;
       forceWasMentioned?: boolean;
     },
-    replyMedia?: TelegramMediaRef[],
   ) => Promise<void>;
   logger: ReturnType<typeof getChildLogger>;
 };


### PR DESCRIPTION
## Summary

- Add `nativeSkillsEnabled: false` to both `registerTelegramNativeCommands()` call sites in `bot-native-commands.plugin-auth.test.ts` — removes 2 `@ts-expect-error` suppressions
- Remove dead `replyMedia` parameter from `createTelegramMessageProcessor` closure and the `processMessage` type in `bot-native-commands.ts` — the param was silently discarded since `BuildTelegramMessageContextParams` never accepted it. Removes 1 `@ts-expect-error` suppression

Closes #2223

## Test plan

- [x] `grep -c "@ts-expect-error" src/telegram/bot-native-commands.plugin-auth.test.ts` = 0
- [x] `grep -c "@ts-expect-error" src/telegram/bot-message.ts` = 0
- [x] `grep -n "replyMedia" src/telegram/bot-message.ts` returns 0 matches
- [x] Telegram tests pass (4/4)
- [x] Typecheck clean (no new errors)
- [x] Lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)