### PR TITLE
gut(auto-reply): remove media understanding dead code

### DIFF
--- a/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
@@ -34,9 +34,6 @@ vi.mock("../../config/config.js", () => ({
 vi.mock("../../link-understanding/apply.js", () => ({
   applyLinkUnderstanding: vi.fn(async () => undefined),
 }));
-vi.mock("../../media-understanding/apply.js", () => ({
-  applyMediaUnderstanding: vi.fn(async () => undefined),
-}));
 vi.mock("../../runtime.js", () => ({
   defaultRuntime: { log: vi.fn() },
 }));

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -4,10 +4,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { normalizeTestText } from "../../test/helpers/normalize-text.js";
 import { withTempHome } from "../../test/helpers/temp-home.js";
 import type { RemoteClawConfig } from "../config/config.js";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "./media-understanding.test-fixtures.js";
-// oxlint-disable-next-line typescript/no-explicit-any
-const createSuccessfulImageMediaDecision = (..._args: unknown[]) => undefined as any;
 import {
   buildCommandsMessage,
   buildCommandsMessagePaginated,
@@ -214,57 +210,6 @@ describe("buildStatusMessage", () => {
 
     expect(text).toContain("verbose");
     expect(text).toContain("elevated");
-  });
-
-  // Skipped: tests gutted functionality (Middleware Boundary Principle)
-
-  it.skip("includes media understanding decisions when present", () => {
-    const text = buildStatusMessage({
-      agent: { model: "anthropic/claude-opus-4-5" },
-      sessionEntry: { sessionId: "media", updatedAt: 0 },
-      sessionKey: "agent:main:main",
-      queue: { mode: "none" },
-      mediaDecisions: [
-        createSuccessfulImageMediaDecision() as unknown as NonNullable<
-          Parameters<typeof buildStatusMessage>[0]["mediaDecisions"]
-        >[number],
-        {
-          capability: "audio",
-          outcome: "skipped",
-          attachments: [
-            {
-              attachmentIndex: 1,
-              attempts: [
-                {
-                  type: "provider",
-                  outcome: "skipped",
-                  reason: "maxBytes: too large",
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    });
-
-    const normalized = normalizeTestText(text);
-    expect(normalized).toContain("Media: image ok (openai/gpt-5.2) · audio skipped (maxBytes)");
-  });
-
-  it("omits media line when all decisions are none", () => {
-    const text = buildStatusMessage({
-      agent: { model: "anthropic/claude-opus-4-5" },
-      sessionEntry: { sessionId: "media-none", updatedAt: 0 },
-      sessionKey: "agent:main:main",
-      queue: { mode: "none" },
-      mediaDecisions: [
-        { capability: "image", outcome: "no-attachment", attachments: [] },
-        { capability: "audio", outcome: "no-attachment", attachments: [] },
-        { capability: "video", outcome: "no-attachment", attachments: [] },
-      ],
-    });
-
-    expect(normalizeTestText(text)).not.toContain("Media:");
   });
 
   it("does not show elevated label when session explicitly disables it", () => {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -42,9 +42,6 @@ import {
 } from "../config/sessions.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
 import { resolveCommitHash } from "../infra/git-commit.js";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "../media-understanding/types.js";
-type MediaUnderstandingDecision = Record<string, unknown>;
 import { listPluginCommands } from "../plugins/commands.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import {
@@ -107,7 +104,6 @@ type StatusArgs = {
   usageLine?: string;
   timeLine?: string;
   queue?: QueueStatus;
-  mediaDecisions?: ReadonlyArray<MediaUnderstandingDecision>;
   subagentsLine?: string;
   includeTranscriptUsage?: boolean;
   now?: number;
@@ -364,62 +360,6 @@ const formatCacheLine = (
   return `🗄️ Cache: ${hitRate}% hit · ${cachedLabel} cached, ${newLabel} new`;
 };
 
-const formatMediaUnderstandingLine = (decisions?: ReadonlyArray<MediaUnderstandingDecision>) => {
-  if (!decisions || decisions.length === 0) {
-    return null;
-  }
-  const parts = decisions
-    .map((decision) => {
-      // @ts-expect-error — upstream feature not available in RemoteClaw fork
-      const count = decision.attachments.length;
-      const countLabel = count > 1 ? ` x${count}` : "";
-      if (decision.outcome === "success") {
-        // @ts-expect-error — upstream feature not available in RemoteClaw fork
-        // oxlint-disable-next-line typescript/no-explicit-any
-        const chosen = decision.attachments.find((entry: any) => entry.chosen)?.chosen;
-        const provider = chosen?.provider?.trim();
-        const model = chosen?.model?.trim();
-        const modelLabel = provider ? (model ? `${provider}/${model}` : provider) : null;
-        // oxlint-disable-next-line
-        return `${decision.capability}${countLabel} ok${modelLabel ? ` (${modelLabel})` : ""}`;
-      }
-      if (decision.outcome === "no-attachment") {
-        // oxlint-disable-next-line
-        return `${decision.capability} none`;
-      }
-      if (decision.outcome === "disabled") {
-        // oxlint-disable-next-line
-        return `${decision.capability} off`;
-      }
-      if (decision.outcome === "scope-deny") {
-        // oxlint-disable-next-line
-        return `${decision.capability} denied`;
-      }
-      if (decision.outcome === "skipped") {
-        // @ts-expect-error — upstream feature not available in RemoteClaw fork
-        const reason = decision.attachments
-          // oxlint-disable-next-line typescript/no-explicit-any
-          .flatMap((entry: any) =>
-            // oxlint-disable-next-line typescript/no-explicit-any
-            entry.attempts.map((attempt: any) => attempt.reason).filter(Boolean),
-          )
-          .find(Boolean);
-        const shortReason = reason ? reason.split(":")[0]?.trim() : undefined;
-        // oxlint-disable-next-line
-        return `${decision.capability} skipped${shortReason ? ` (${shortReason})` : ""}`;
-      }
-      return null;
-    })
-    .filter((part): part is string => part != null);
-  if (parts.length === 0) {
-    return null;
-  }
-  if (parts.every((part) => part.endsWith(" none"))) {
-    return null;
-  }
-  return `📎 Media: ${parts.join(" · ")}`;
-};
-
 const formatVoiceModeLine = (
   config?: RemoteClawConfig,
   sessionEntry?: SessionEntry,
@@ -653,7 +593,6 @@ export function buildStatusMessage(args: StatusArgs): string {
   const versionLine = `🦞 RemoteClaw ${VERSION}${commit ? ` (${commit})` : ""}`;
   const usagePair = formatUsagePair(inputTokens, outputTokens);
   const cacheLine = formatCacheLine(inputTokens, cacheRead, cacheWrite);
-  const mediaLine = formatMediaUnderstandingLine(args.mediaDecisions);
   const voiceLine = formatVoiceModeLine(args.config, args.sessionEntry);
 
   return [
@@ -663,7 +602,6 @@ export function buildStatusMessage(args: StatusArgs): string {
     usagePair,
     cacheLine,
     `📚 ${contextLine}`,
-    mediaLine,
     args.usageLine,
     `🧵 ${sessionLine}`,
     args.subagentsLine,

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -1,8 +1,4 @@
 import type { ChannelId } from "../channels/plugins/types.js";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "../media-understanding/types.js";
-type MediaUnderstandingDecision = Record<string, unknown>;
-type MediaUnderstandingOutput = Record<string, unknown>;
 import type { StickerMetadata } from "../telegram/bot/types.js";
 import type { InternalMessageChannel } from "../utils/message-channel.js";
 import type { CommandArgs } from "./commands-registry.types.js";
@@ -101,8 +97,6 @@ export type MsgContext = {
   /** Remote host for SCP when media lives on a different machine (e.g., remoteclaw@192.168.64.3). */
   MediaRemoteHost?: string;
   Transcript?: string;
-  MediaUnderstanding?: MediaUnderstandingOutput[];
-  MediaUnderstandingDecisions?: MediaUnderstandingDecision[];
   LinkUnderstanding?: string[];
   Prompt?: string;
   MaxChars?: number;


### PR DESCRIPTION
## Summary

- Remove ~126 lines of dead media-understanding code across 4 files
- Eliminate 3 `@ts-expect-error` suppressions from `status.ts`
- Remove `MediaUnderstandingDecision`/`MediaUnderstandingOutput` stub types, dead `formatMediaUnderstandingLine()` function, dead `mediaDecisions` interface member, dead test fixtures, and a dead mock for a module that's never imported
- Part of `@ts-expect-error` fork-sync remediation audit

Closes #2225

## Test plan

- [x] `grep -c "@ts-expect-error" src/auto-reply/status.ts` → 0 (was 3)
- [x] `grep "MediaUnderstandingDecision" src/auto-reply/status.ts` → no matches
- [x] `grep "formatMediaUnderstandingLine" src/auto-reply/status.ts` → no matches
- [x] `grep "mediaDecisions" src/auto-reply/status.ts` → no matches
- [x] Pre-commit checks pass (format, typecheck, lint)
- [x] Affected tests pass (pre-existing failure in `buildCommandsMessage` is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)