### PR TITLE
fix(types): add heartbeatReport to ReplyPayload type

### DIFF
--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -1,6 +1,7 @@
 // Gutted in RemoteClaw fork (Middleware Boundary Principle)
 // import ... from "@mariozechner/pi-ai";
 type ImageContent = Record<string, unknown>;
+import type { McpHeartbeatReport } from "../middleware/types.js";
 import type { TypingController } from "./reply/typing.js";
 
 export type BlockReplyContext = {
@@ -86,4 +87,6 @@ export type ReplyPayload = {
   isReasoning?: boolean;
   /** Channel-specific payload data (per-channel envelope). */
   channelData?: Record<string, unknown>;
+  /** Structured heartbeat report from the heartbeat_report MCP tool. */
+  heartbeatReport?: McpHeartbeatReport | undefined;
 };

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -388,7 +388,6 @@ async function captureTranscriptState(params: {
 }
 
 function normalizeHeartbeatReply(payload: ReplyPayload, responsePrefix: string | undefined) {
-  // @ts-expect-error — heartbeatReport flows at runtime via McpSideEffects, not on ReplyPayload
   const report = payload.heartbeatReport;
   const rawText = typeof payload.text === "string" ? payload.text.trim() : "";
   const hasMedia = Boolean(payload.mediaUrl || (payload.mediaUrls?.length ?? 0) > 0);
@@ -672,7 +671,6 @@ export async function runHeartbeatOnce(opts: {
       (!replyPayload.text &&
         !replyPayload.mediaUrl &&
         !replyPayload.mediaUrls?.length &&
-        // @ts-expect-error — heartbeatReport flows at runtime via McpSideEffects, not on ReplyPayload
         !replyPayload.heartbeatReport)
     ) {
       await restoreHeartbeatUpdatedAt({

--- a/src/web/auto-reply/heartbeat-runner.ts
+++ b/src/web/auto-reply/heartbeat-runner.ts
@@ -205,7 +205,6 @@ export async function runWebHeartbeatOnce(opts: {
     }
 
     const hasMedia = Boolean(replyPayload.mediaUrl || (replyPayload.mediaUrls?.length ?? 0) > 0);
-    // @ts-expect-error — upstream feature not available in RemoteClaw fork
     const report = replyPayload.heartbeatReport;
     // When heartbeat_report says nothing done, skip delivery (restore session timestamp).
     if (report && !report.anythingDone && !hasMedia) {


### PR DESCRIPTION
## Summary

- Add `heartbeatReport?: McpHeartbeatReport | undefined` to `ReplyPayload` type in `src/auto-reply/types.ts`
- Remove 3 `@ts-expect-error` suppressions that were needed because the property was missing from the static type
- Import `McpHeartbeatReport` from `../middleware/types.js`

Closes #2222

## Test plan

- [x] Type-check passes (verified via pre-commit hook `pnpm tsgo`)
- [x] Lint passes (verified via pre-commit hook `pnpm lint`)
- [x] Format passes (verified via pre-commit hook `pnpm format:check`)
- [ ] CI build + test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)