### PR TITLE
fix: strengthen config providers type + fix ws.dir usage (#2219)

### DIFF
--- a/src/commands/onboard-auth.config-minimax.ts
+++ b/src/commands/onboard-auth.config-minimax.ts
@@ -1,6 +1,5 @@
 import type { RemoteClawConfig } from "../config/config.js";
 import { toAgentModelListLike } from "../config/model-input.js";
-import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.models.js";
 import {
   applyAgentDefaultModelPrimary,
   applyOnboardAuthAgentModelsAndProviders,
@@ -70,17 +69,11 @@ export function applyMinimaxHostedProviderConfig(
     maxTokens: DEFAULT_MINIMAX_MAX_TOKENS,
   });
   const existingProvider = providers.minimax;
-  const existingModels = Array.isArray(
-    ((existingProvider ?? {}) as Record<string, unknown>)?.models,
-  )
-    ? (((existingProvider ?? {}) as Record<string, unknown>).models as Record<string, unknown>[])
-    : [];
-  const hasHostedModel = existingModels.some(
-    (model: Record<string, unknown>) => model.id === MINIMAX_HOSTED_MODEL_ID,
-  );
+  const existingModels = Array.isArray(existingProvider?.models) ? existingProvider.models : [];
+  const hasHostedModel = existingModels.some((model) => model.id === MINIMAX_HOSTED_MODEL_ID);
   const mergedModels = hasHostedModel ? existingModels : [...existingModels, hostedModel];
   providers.minimax = {
-    ...((existingProvider ?? {}) as Record<string, unknown>),
+    ...existingProvider,
     baseUrl: params?.baseUrl?.trim() || DEFAULT_MINIMAX_BASE_URL,
     apiKey: "minimax",
     api: "openai-completions",
@@ -171,14 +164,11 @@ function applyMinimaxApiProviderConfigWithBaseUrl(
   cfg: RemoteClawConfig,
   params: MinimaxApiProviderConfigParams,
 ): RemoteClawConfig {
-  const providers = { ...cfg.models?.providers } as Record<string, ModelProviderConfig>;
+  const providers = { ...cfg.models?.providers };
   const existingProvider = providers[params.providerId];
-  const existingModels = (((existingProvider ?? {}) as Record<string, unknown>)?.models ??
-    []) as Record<string, unknown>[];
+  const existingModels = Array.isArray(existingProvider?.models) ? existingProvider.models : [];
   const apiModel = buildMinimaxApiModelDefinition(params.modelId);
-  const hasApiModel = existingModels.some(
-    (model: Record<string, unknown>) => model.id === params.modelId,
-  );
+  const hasApiModel = existingModels.some((model) => model.id === params.modelId);
   const mergedModels = hasApiModel ? existingModels : [...existingModels, apiModel];
   const { apiKey: existingApiKey, ...existingProviderRest } = existingProvider ?? {
     baseUrl: params.baseUrl,
@@ -192,7 +182,7 @@ function applyMinimaxApiProviderConfigWithBaseUrl(
     api: "anthropic-messages",
     authHeader: true,
     ...(normalizedApiKey?.trim() ? { apiKey: normalizedApiKey } : {}),
-    models: (mergedModels.length > 0 ? mergedModels : [apiModel]) as ModelDefinitionConfig[],
+    models: mergedModels.length > 0 ? mergedModels : [apiModel],
   };
 
   const models = { ...cfg.agents?.defaults?.models };

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -528,7 +528,6 @@ export function resolveCustomProviderId(
   const providerIdResult = resolveUniqueEndpointId({
     requestedId: requestedProviderId,
     baseUrl,
-    // @ts-expect-error — upstream feature not available in RemoteClaw fork
     providers,
   });
 
@@ -617,7 +616,6 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
   }
 
   const existingProvider = providers[providerId];
-  // @ts-expect-error — upstream feature not available in RemoteClaw fork
   const existingModels = Array.isArray(existingProvider?.models) ? existingProvider.models : [];
   // oxlint-disable-next-line typescript/no-explicit-any
   const hasModel = existingModels.some((model: any) => model.id === modelId);
@@ -641,7 +639,6 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
           : model,
       )
     : [...existingModels, nextModel];
-  // @ts-expect-error — upstream feature not available in RemoteClaw fork
   const { apiKey: existingApiKey, ...existingProviderRest } = existingProvider ?? {};
   const normalizedApiKey =
     normalizeOptionalProviderApiKey(params.apiKey) ??
@@ -822,7 +819,6 @@ export async function promptCustomApiConfig(params: {
       const providerIdResult = resolveUniqueEndpointId({
         requestedId,
         baseUrl,
-        // @ts-expect-error — upstream feature not available in RemoteClaw fork
         providers,
       });
       const modelRef = modelKey(providerIdResult.providerId, modelId);

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -278,8 +278,7 @@ export async function ensureWorkspaceAndSessions(
   options?: { agentId?: string },
 ) {
   const ws = await ensureAgentWorkspace(workspaceDir);
-  // @ts-expect-error — upstream feature not available in RemoteClaw fork
-  runtime.log(`Workspace OK: ${shortenHomePath(ws)}`);
+  runtime.log(`Workspace OK: ${shortenHomePath(ws.dir)}`);
   const sessionsDir = resolveSessionTranscriptsDirForAgent(options?.agentId);
   await fs.mkdir(sessionsDir, { recursive: true });
   runtime.log(`Sessions OK: ${shortenHomePath(sessionsDir)}`);

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -47,8 +47,7 @@ export async function setupCommand(
 
   if (desiredWorkspace) {
     const ws = await ensureAgentWorkspace(desiredWorkspace);
-    // @ts-expect-error — upstream feature not available in RemoteClaw fork
-    runtime.log(`Workspace OK: ${shortenHomePath(ws)}`);
+    runtime.log(`Workspace OK: ${shortenHomePath(ws.dir)}`);
   }
 
   const sessionsDir = resolveSessionTranscriptsDir();

--- a/src/config/types.remoteclaw.ts
+++ b/src/config/types.remoteclaw.ts
@@ -18,6 +18,7 @@ import type {
   CommandsConfig,
   MessagesConfig,
 } from "./types.messages.js";
+import type { ModelsConfig } from "./types.models.js";
 import type { NodeHostConfig } from "./types.node-host.js";
 import type { PluginsConfig } from "./types.plugins.js";
 import type { ToolsConfig } from "./types.tools.js";
@@ -103,10 +104,7 @@ export type RemoteClawConfig = {
   talk?: TalkConfig;
   gateway?: GatewayConfig;
   /** Model catalog configuration (upstream feature). */
-  models?: {
-    providers?: Record<string, unknown>;
-    [key: string]: unknown;
-  };
+  models?: ModelsConfig;
   /** Access control policy configuration (upstream feature). */
   acp?: unknown;
   /** Secrets configuration (upstream feature). */


### PR DESCRIPTION
## Summary
- Use `ModelsConfig` from `types.models.ts` for `RemoteClawConfig.models` instead of inline `Record<string, unknown>` — removes 4 `@ts-expect-error` suppressions in `onboard-custom.ts`
- Fix `ensureAgentWorkspace` call sites to pass `ws.dir` to `shortenHomePath` — removes 2 `@ts-expect-error` suppressions in `onboard-helpers.ts` and `setup.ts`
- Clean up stale `Record<string, unknown>` casts in `onboard-auth.config-minimax.ts` that the stronger type made unnecessary

Closes #2219

## Test plan
- [x] `pnpm tsgo` passes clean (0 errors)
- [x] `pnpm lint` passes clean (0 errors)
- [x] `pnpm build` succeeds
- [x] `pnpm test` — `onboard-custom.test.ts` passes (6 passed, 14 skipped)
- [x] Verified `grep -c "@ts-expect-error"` counts match acceptance criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)