### PR TITLE
fix(types): complete InlineDirectives type ecosystem — remove 7 suppressions

### DIFF
--- a/src/auto-reply/reply/directive-handling.fast-lane.ts
+++ b/src/auto-reply/reply/directive-handling.fast-lane.ts
@@ -45,7 +45,6 @@ export async function applyInlineDirectivesFastLane(
   }
 
   const agentCfg = params.agentCfg;
-  // @ts-expect-error — upstream feature not available in RemoteClaw fork
   const { currentVerboseLevel } = await resolveCurrentDirectiveLevels({
     sessionEntry,
     agentCfg,

--- a/src/auto-reply/reply/directive-handling.levels.ts
+++ b/src/auto-reply/reply/directive-handling.levels.ts
@@ -12,7 +12,7 @@ export async function resolveCurrentDirectiveLevels(params: {
     verboseDefault?: unknown;
     elevatedDefault?: unknown;
   };
-  resolveDefaultThinkingLevel: () => Promise<ThinkLevel | undefined>;
+  resolveDefaultThinkingLevel?: () => Promise<ThinkLevel | undefined>;
 }): Promise<{
   currentThinkLevel: ThinkLevel | undefined;
   currentVerboseLevel: VerboseLevel | undefined;

--- a/src/auto-reply/reply/directive-handling.parse.ts
+++ b/src/auto-reply/reply/directive-handling.parse.ts
@@ -1,6 +1,7 @@
 import type { RemoteClawConfig } from "../../config/config.js";
 import { extractModelDirective } from "../model.js";
 import type { MsgContext } from "../templating.js";
+import type { ElevatedLevel, ReasoningLevel } from "../thinking.js";
 import type { VerboseLevel } from "./directives.js";
 import { extractStatusDirective, extractVerboseDirective } from "./directives.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
@@ -31,10 +32,10 @@ export type InlineDirectives = {
   thinkLevel?: string;
   hasThinkDirective?: boolean;
   /** Upstream feature: reasoning level directive. */
-  reasoningLevel?: string;
+  reasoningLevel?: ReasoningLevel;
   hasReasoningDirective?: boolean;
   /** Upstream feature: elevated security level directive. */
-  elevatedLevel?: string;
+  elevatedLevel?: ElevatedLevel;
   rawElevatedLevel?: string;
   hasElevatedDirective?: boolean;
   /** Upstream feature: exec directives. */
@@ -42,6 +43,8 @@ export type InlineDirectives = {
   execHost?: string;
   execNode?: string;
   execSecurity?: string;
+  /** Upstream feature: whether any exec directive was detected. */
+  hasExecDirective?: boolean;
 };
 
 export function parseInlineDirectives(

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -141,7 +141,6 @@ export async function applyInlineDirectiveOverrides(params: {
       typing.cleanup();
       return { kind: "reply", reply: undefined };
     }
-    // @ts-expect-error — upstream feature not available in RemoteClaw fork
     const { currentVerboseLevel } = await resolveCurrentDirectiveLevels({
       sessionEntry,
       agentCfg,

--- a/src/auto-reply/reply/get-reply-directives-utils.ts
+++ b/src/auto-reply/reply/get-reply-directives-utils.ts
@@ -1,8 +1,9 @@
 import type { InlineDirectives } from "./directive-handling.js";
 
-export function clearInlineDirectives(cleaned: string): InlineDirectives {
+export function clearInlineDirectives(cleaned: string | InlineDirectives): InlineDirectives {
+  const cleanedText = typeof cleaned === "string" ? cleaned : cleaned.cleaned;
   return {
-    cleaned,
+    cleaned: cleanedText,
     hasVerboseDirective: false,
     verboseLevel: undefined,
     rawVerboseLevel: undefined,

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -254,10 +254,8 @@ export async function resolveReplyDirectives(params: {
       };
     }
   }
-  // @ts-expect-error — upstream feature not available in RemoteClaw fork
   if (isGroup && ctx.WasMentioned !== true && parsedDirectives.hasExecDirective) {
     if (parsedDirectives.execSecurity !== "deny") {
-      // @ts-expect-error — upstream feature not available in RemoteClaw fork
       parsedDirectives = clearInlineDirectives(parsedDirectives);
     }
   }
@@ -266,7 +264,6 @@ export async function resolveReplyDirectives(params: {
     parsedDirectives.hasVerboseDirective ||
     parsedDirectives.hasReasoningDirective ||
     parsedDirectives.hasElevatedDirective ||
-    // @ts-expect-error — upstream feature not available in RemoteClaw fork
     parsedDirectives.hasExecDirective ||
     parsedDirectives.hasModelDirective ||
     parsedDirectives.hasQueueDirective;
@@ -383,7 +380,6 @@ export async function resolveReplyDirectives(params: {
     directives.verboseLevel ??
     (sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
     (agentCfg?.verboseDefault as VerboseLevel | undefined);
-  // @ts-expect-error — upstream feature not available in RemoteClaw fork
   let resolvedReasoningLevel: ReasoningLevel =
     directives.reasoningLevel ??
     (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
@@ -511,7 +507,6 @@ export async function resolveReplyDirectives(params: {
       resolvedThinkLevel: resolvedThinkLevelWithDefault,
       resolvedVerboseLevel,
       resolvedReasoningLevel,
-      // @ts-expect-error — upstream feature not available in RemoteClaw fork
       resolvedElevatedLevel,
       execOverrides,
       blockStreamingEnabled,


### PR DESCRIPTION
## Summary

- Add missing `hasExecDirective` boolean to `InlineDirectives` type
- Narrow `reasoningLevel` from `string` to `ReasoningLevel` and `elevatedLevel` from `string` to `ElevatedLevel`
- Widen `clearInlineDirectives` to accept `string | InlineDirectives` (extract `.cleaned` when object passed)
- Make `resolveDefaultThinkingLevel` optional in `resolveCurrentDirectiveLevels` params (implementation already uses `?.()`)
- Remove all 7 `@ts-expect-error` suppressions across 4 files

Closes #2220

## Test plan

- [x] `tsgo` type-check passes with zero errors in `src/auto-reply/`
- [x] Pre-commit hook passes (format, tsgo, lint)
- [x] Full test suite: 692 passed (2 pre-existing failures unrelated to this change)
- [ ] CI build + test jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)