### PR TITLE
fix(commands): pass correct arg position to buildCommandsMessage (#2216)

### DIFF
--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -47,8 +47,7 @@ export const handleCommandsListCommand: CommandHandler = async (params, allowTex
   const surface = params.ctx.Surface;
 
   if (surface === "telegram") {
-    const result = buildCommandsMessagePaginated(params.cfg, {
-      // @ts-expect-error — upstream feature not available in RemoteClaw fork
+    const result = buildCommandsMessagePaginated(params.cfg, undefined, {
       page: 1,
       surface,
     });
@@ -79,8 +78,7 @@ export const handleCommandsListCommand: CommandHandler = async (params, allowTex
 
   return {
     shouldContinue: false,
-    // @ts-expect-error — upstream feature not available in RemoteClaw fork
-    reply: { text: buildCommandsMessage(params.cfg, { surface }) },
+    reply: { text: buildCommandsMessage(params.cfg, undefined, { surface }) },
   };
 };
 

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -929,8 +929,7 @@ export const registerTelegramHandlers = ({
         }
 
         const agentId = paginationMatch[2]?.trim() || resolveDefaultAgentId(cfg);
-        const result = buildCommandsMessagePaginated(cfg, {
-          // @ts-expect-error — upstream feature not available in RemoteClaw fork
+        const result = buildCommandsMessagePaginated(cfg, undefined, {
           page,
           surface: "telegram",
         });


### PR DESCRIPTION
## Summary

- Insert `undefined` as the 2nd argument (`skillCommands`) at 3 call sites of `buildCommandsMessage` / `buildCommandsMessagePaginated` so the options object (`{ page, surface }`) lands in the correct parameter position
- Removes 3 `@ts-expect-error` suppressions that masked the arg mismatch
- Fixes Telegram `/commands` pagination silently doing nothing because `page`/`surface` was parsed as `skillCommands`

Closes #2216

## Test plan

- [x] `grep -c "@ts-expect-error" src/auto-reply/reply/commands-info.ts` → 0 (decreased by 2)
- [x] `grep -c "@ts-expect-error" src/telegram/bot-handlers.ts` → decreased by 1
- [x] Build passes (`pnpm build`)
- [x] All 694 test files pass, 5949 tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)