### PR TITLE
fix(plugins): complete hook types for ChannelBridge — remove 5 suppressions

### DIFF
--- a/src/middleware/channel-bridge.ts
+++ b/src/middleware/channel-bridge.ts
@@ -117,12 +117,10 @@ export class ChannelBridge {
     const hookRunner = getGlobalHookRunner();
 
     // Hook: session_resumed — fires when reusing an existing session
-    // @ts-expect-error — upstream feature not available in RemoteClaw fork
     if (existingSessionId && hookRunner?.hasHooks("session_resumed")) {
       await hookRunner.runSessionResumed(
         {
           sessionId: existingSessionId,
-          // @ts-expect-error — upstream feature not available in RemoteClaw fork
           runtimeName: this.#provider,
           channelId: message.channelId,
           userId: message.from,
@@ -173,7 +171,6 @@ export class ChannelBridge {
       if (hookRunner?.hasHooks("before_runtime_spawn")) {
         const spawnResult = await hookRunner.runBeforeRuntimeSpawn(
           {
-            // @ts-expect-error — upstream feature not available in RemoteClaw fork
             runtimeName: this.#provider,
             sessionId: existingSessionId,
             command: "node",
@@ -324,7 +321,6 @@ export class ChannelBridge {
         if (hookRunner.hasHooks("agent_end")) {
           void hookRunner.runAgentEnd(
             {
-              // @ts-expect-error — upstream feature not available in RemoteClaw fork
               runId,
               sessionId: finalResult.sessionId,
               success: !finalResult.errorSubtype && !lastError,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -28,6 +28,7 @@ import type {
   PluginHookRegistration,
   PluginHookSessionContext,
   PluginHookSessionEndEvent,
+  PluginHookSessionResumedEvent,
   PluginHookSessionStartEvent,
   PluginHookSubagentContext,
   PluginHookSubagentDeliveryTargetEvent,
@@ -61,6 +62,7 @@ export type {
   PluginHookBeforeMessageWriteResult,
   PluginHookSessionContext,
   PluginHookSessionEndEvent,
+  PluginHookSessionResumedEvent,
   PluginHookSessionStartEvent,
   PluginHookSubagentContext,
   PluginHookSubagentDeliveryTargetEvent,
@@ -536,10 +538,9 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
    * Runs in parallel (fire-and-forget).
    */
   async function runSessionResumed(
-    event: PluginHookSessionEndEvent,
+    event: PluginHookSessionResumedEvent,
     ctx: PluginHookAgentContext,
   ): Promise<void> {
-    // @ts-expect-error — upstream feature not available in RemoteClaw fork
     return runVoidHook("session_resumed", event, ctx);
   }
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -330,6 +330,7 @@ export type PluginHookName =
   | "before_message_write"
   | "session_start"
   | "session_end"
+  | "session_resumed"
   | "subagent_spawning"
   | "subagent_delivery_target"
   | "subagent_spawned"
@@ -350,6 +351,8 @@ export type PluginHookAgentContext = {
   trigger?: string;
   /** Channel identifier (e.g. "telegram", "discord", "whatsapp"). */
   channelId?: string;
+  /** CLI runtime provider name (e.g. "claude", "gemini", "codex", "opencode"). */
+  runtimeName?: string;
 };
 
 // before_model_resolve hook
@@ -418,10 +421,12 @@ export type PluginHookLlmOutputEvent = {
 
 // agent_end hook
 export type PluginHookAgentEndEvent = {
-  messages: unknown[];
+  messages?: unknown[];
   success: boolean;
   error?: string;
   durationMs?: number;
+  runId?: string;
+  sessionId?: string;
 };
 
 // Compaction hooks
@@ -590,6 +595,15 @@ export type PluginHookSessionEndEvent = {
   durationMs?: number;
 };
 
+// session_resumed hook
+export type PluginHookSessionResumedEvent = {
+  sessionId: string;
+  runtimeName?: string;
+  channelId?: string;
+  userId?: string;
+  resumeMethod?: string;
+};
+
 // Subagent context
 export type PluginHookSubagentContext = {
   runId?: string;
@@ -688,6 +702,10 @@ export type PluginHookBeforeRuntimeSpawnEvent = {
   workspaceDir?: string;
   env?: Record<string, string | undefined>;
   args?: string[];
+  runtimeName?: string;
+  sessionId?: string;
+  command?: string;
+  channelId?: string;
 };
 
 export type PluginHookBeforeRuntimeSpawnResult = {
@@ -777,6 +795,10 @@ export type PluginHookHandlerMap = {
   session_end: (
     event: PluginHookSessionEndEvent,
     ctx: PluginHookSessionContext,
+  ) => Promise<void> | void;
+  session_resumed: (
+    event: PluginHookSessionResumedEvent,
+    ctx: PluginHookAgentContext,
   ) => Promise<void> | void;
   subagent_spawning: (
     event: PluginHookSubagentSpawningEvent,


### PR DESCRIPTION
## Summary

- Add `"session_resumed"` to `PluginHookName` union and `PluginHookHandlerMap`
- Define `PluginHookSessionResumedEvent` with `sessionId`, `runtimeName?`, `channelId?`, `userId?`, `resumeMethod?`
- Extend `PluginHookBeforeRuntimeSpawnEvent` with optional `runtimeName`, `sessionId`, `command`, `channelId`
- Extend `PluginHookAgentEndEvent`: make `messages` optional, add optional `runId`, `sessionId`
- Add optional `runtimeName` to `PluginHookAgentContext`
- Fix `runSessionResumed` in hooks.ts to use `PluginHookSessionResumedEvent`
- Remove 5 `@ts-expect-error` suppressions (4 in channel-bridge.ts, 1 in hooks.ts)

All new fields are optional — fully backward-compatible.

Closes #2221

## Test plan

- [x] `grep -c "@ts-expect-error" src/middleware/channel-bridge.ts` returns 0 (was 4)
- [x] `grep -c "@ts-expect-error" src/plugins/hooks.ts` returns 0 (was 1)
- [x] `PluginHookName` includes `"session_resumed"`
- [x] Typecheck passes (`tsgo --noEmit` — no errors in changed files)
- [x] Lint passes (`oxlint --type-aware` — 0 warnings, 0 errors)
- [x] All middleware tests pass (608/608)
- [x] Plugin hook session + dead-hooks tests pass (82/82)

🤖 Generated with [Claude Code](https://claude.com/claude-code)