### PR TITLE
gut(ui): remove dead skills UI code tree

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -7,9 +7,6 @@ import { renderChatControls, renderTab, renderThemeToggle } from "./app-render.h
 import type { AppViewState } from "./app-view-state.ts";
 import { loadAgentFileContent, loadAgentFiles, saveAgentFile } from "./controllers/agent-files.ts";
 import { loadAgentIdentities, loadAgentIdentity } from "./controllers/agent-identity.ts";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "./controllers/agent-skills.ts";
-const loadAgentSkills = (..._args: unknown[]) => undefined as unknown;
 import { loadAgents, loadToolsCatalog } from "./controllers/agents.ts";
 import { loadChannels } from "./controllers/channels.ts";
 import { loadChatHistory } from "./controllers/chat.ts";
@@ -58,13 +55,6 @@ import { loadLogs } from "./controllers/logs.ts";
 import { loadNodes } from "./controllers/nodes.ts";
 import { loadPresence } from "./controllers/presence.ts";
 import { deleteSessionAndRefresh, loadSessions, patchSession } from "./controllers/sessions.ts";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "./controllers/skills.ts";
-const installSkill = (..._args: unknown[]) => undefined as unknown;
-const loadSkills = (..._args: unknown[]) => undefined as unknown;
-const saveSkillApiKey = (..._args: unknown[]) => undefined as unknown;
-const updateSkillEdit = (..._args: unknown[]) => undefined as unknown;
-const updateSkillEnabled = (..._args: unknown[]) => undefined as unknown;
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { icons } from "./icons.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
@@ -82,9 +72,6 @@ import { renderLogs } from "./views/logs.ts";
 import { renderNodes } from "./views/nodes.ts";
 import { renderOverview } from "./views/overview.ts";
 import { renderSessions } from "./views/sessions.ts";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "./views/skills.ts";
-const renderSkills = (..._args: unknown[]) => undefined as unknown;
 const AVATAR_DATA_RE = /^data:/i;
 const AVATAR_HTTP_RE = /^https?:\/\//i;
 const CRON_THINKING_SUGGESTIONS = ["off", "minimal", "low", "medium", "high"];
@@ -567,14 +554,9 @@ export function renderApp(state: AppViewState) {
                 agentIdentityLoading: state.agentIdentityLoading,
                 agentIdentityError: state.agentIdentityError,
                 agentIdentityById: state.agentIdentityById,
-                agentSkillsLoading: state.agentSkillsLoading,
-                agentSkillsReport: state.agentSkillsReport,
-                agentSkillsError: state.agentSkillsError,
-                agentSkillsAgentId: state.agentSkillsAgentId,
                 toolsCatalogLoading: state.toolsCatalogLoading,
                 toolsCatalogError: state.toolsCatalogError,
                 toolsCatalogResult: state.toolsCatalogResult,
-                skillsFilter: state.skillsFilter,
                 onRefresh: async () => {
                   await loadAgents(state);
                   const nextSelected =
@@ -599,18 +581,12 @@ export function renderApp(state: AppViewState) {
                   state.agentFileActive = null;
                   state.agentFileContents = {};
                   state.agentFileDrafts = {};
-                  state.agentSkillsReport = null;
-                  state.agentSkillsError = null;
-                  state.agentSkillsAgentId = null;
                   void loadAgentIdentity(state, agentId);
                   if (state.agentsPanel === "tools") {
                     void loadToolsCatalog(state, agentId);
                   }
                   if (state.agentsPanel === "files") {
                     void loadAgentFiles(state, agentId);
-                  }
-                  if (state.agentsPanel === "skills") {
-                    void loadAgentSkills(state, agentId);
                   }
                 },
                 onSelectPanel: (panel) => {
@@ -627,11 +603,6 @@ export function renderApp(state: AppViewState) {
                   }
                   if (panel === "tools") {
                     void loadToolsCatalog(state, resolvedAgentId);
-                  }
-                  if (panel === "skills") {
-                    if (resolvedAgentId) {
-                      void loadAgentSkills(state, resolvedAgentId);
-                    }
                   }
                   if (panel === "channels") {
                     void loadChannels(state, false);
@@ -725,94 +696,6 @@ export function renderApp(state: AppViewState) {
                 onConfigSave: () => saveConfig(state),
                 onChannelsRefresh: () => loadChannels(state, false),
                 onCronRefresh: () => state.loadCron(),
-                // oxlint-disable-next-line typescript/no-explicit-any
-                onSkillsFilterChange: (next: any) => (state.skillsFilter = next),
-                onSkillsRefresh: () => {
-                  if (resolvedAgentId) {
-                    void loadAgentSkills(state, resolvedAgentId);
-                  }
-                },
-                // oxlint-disable-next-line typescript/no-explicit-any
-                onAgentSkillToggle: (agentId: any, skillName: any, enabled: any) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
-                  const entry = list[index] as { skills?: unknown };
-                  const normalizedSkill = skillName.trim();
-                  if (!normalizedSkill) {
-                    return;
-                  }
-                  const allSkills =
-                    state.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
-                    [];
-                  const existing = Array.isArray(entry.skills)
-                    ? entry.skills.map((name) => String(name).trim()).filter(Boolean)
-                    : undefined;
-                  const base = existing ?? allSkills;
-                  const next = new Set(base);
-                  if (enabled) {
-                    next.add(normalizedSkill);
-                  } else {
-                    next.delete(normalizedSkill);
-                  }
-                  updateConfigFormValue(state, ["agents", "list", index, "skills"], [...next]);
-                },
-                // oxlint-disable-next-line typescript/no-explicit-any
-                onAgentSkillsClear: (agentId: any) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
-                  removeConfigFormValue(state, ["agents", "list", index, "skills"]);
-                },
-                // oxlint-disable-next-line typescript/no-explicit-any
-                onAgentSkillsDisableAll: (agentId: any) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
-                  updateConfigFormValue(state, ["agents", "list", index, "skills"], []);
-                },
                 onModelChange: (agentId, modelId) => {
                   if (!configValue) {
                     return;
@@ -898,33 +781,6 @@ export function renderApp(state: AppViewState) {
                     : { fallbacks: normalized };
                   updateConfigFormValue(state, basePath, next);
                 },
-              })
-            : nothing
-        }
-
-        ${
-          // @ts-expect-error — upstream feature not available in RemoteClaw fork
-          state.tab === "skills"
-            ? renderSkills({
-                loading: state.skillsLoading,
-                report: state.skillsReport,
-                error: state.skillsError,
-                filter: state.skillsFilter,
-                edits: state.skillEdits,
-                messages: state.skillMessages,
-                busyKey: state.skillsBusyKey,
-                // oxlint-disable-next-line typescript/no-explicit-any
-                onFilterChange: (next: any) => (state.skillsFilter = next),
-                onRefresh: () => loadSkills(state, { clearMessages: true }),
-                // oxlint-disable-next-line typescript/no-explicit-any
-                onToggle: (key: any, enabled: any) => updateSkillEnabled(state, key, enabled),
-                // oxlint-disable-next-line typescript/no-explicit-any
-                onEdit: (key: any, value: any) => updateSkillEdit(state, key, value),
-                // oxlint-disable-next-line typescript/no-explicit-any
-                onSaveKey: (key: any) => saveSkillApiKey(state, key),
-                // oxlint-disable-next-line typescript/no-explicit-any
-                onInstall: (skillKey: any, name: any, installId: any) =>
-                  installSkill(state, skillKey, name, installId),
               })
             : nothing
         }

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -8,9 +8,6 @@ import type {
 import type { DevicePairingList } from "./controllers/devices.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "./controllers/skills.ts";
-type SkillMessage = Record<string, unknown>;
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
 import type { UiSettings } from "./storage.ts";
@@ -42,7 +39,6 @@ import type {
   CostUsageSummary,
   SessionUsageTimeSeries,
   SessionsListResult,
-  SkillStatusReport,
   ToolsCatalogResult,
   StatusSummary,
 } from "./types.ts";
@@ -146,7 +142,7 @@ export type AppViewState = {
   toolsCatalogLoading: boolean;
   toolsCatalogError: string | null;
   toolsCatalogResult: ToolsCatalogResult | null;
-  agentsPanel: "overview" | "files" | "tools" | "skills" | "channels" | "cron";
+  agentsPanel: "overview" | "files" | "tools" | "channels" | "cron";
   agentFilesLoading: boolean;
   agentFilesError: string | null;
   agentFilesList: AgentsFilesListResult | null;
@@ -157,10 +153,6 @@ export type AppViewState = {
   agentIdentityLoading: boolean;
   agentIdentityError: string | null;
   agentIdentityById: Record<string, AgentIdentityResult>;
-  agentSkillsLoading: boolean;
-  agentSkillsError: string | null;
-  agentSkillsReport: SkillStatusReport | null;
-  agentSkillsAgentId: string | null;
   sessionsLoading: boolean;
   sessionsResult: SessionsListResult | null;
   sessionsError: string | null;
@@ -237,13 +229,6 @@ export type AppViewState = {
   cronRunsSortDir: CronSortDir;
   cronModelSuggestions: string[];
   cronBusy: boolean;
-  skillsLoading: boolean;
-  skillsReport: SkillStatusReport | null;
-  skillsError: string | null;
-  skillsFilter: string;
-  skillEdits: Record<string, string>;
-  skillMessages: Record<string, SkillMessage>;
-  skillsBusyKey: string | null;
   debugLoading: boolean;
   debugStatus: StatusSummary | null;
   debugHealth: HealthSnapshot | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -56,9 +56,6 @@ import type { CronFieldErrors } from "./controllers/cron.ts";
 import type { DevicePairingList } from "./controllers/devices.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "./controllers/skills.ts";
-type SkillMessage = Record<string, unknown>;
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
 import { loadSettings, type UiSettings } from "./storage.ts";
@@ -78,7 +75,6 @@ import type {
   PresenceEntry,
   ChannelsStatusSnapshot,
   SessionsListResult,
-  SkillStatusReport,
   ToolsCatalogResult,
   StatusSummary,
   NostrProfile,
@@ -221,8 +217,7 @@ export class RemoteClawApp extends LitElement {
   @state() toolsCatalogLoading = false;
   @state() toolsCatalogError: string | null = null;
   @state() toolsCatalogResult: ToolsCatalogResult | null = null;
-  @state() agentsPanel: "overview" | "files" | "tools" | "skills" | "channels" | "cron" =
-    "overview";
+  @state() agentsPanel: "overview" | "files" | "tools" | "channels" | "cron" = "overview";
   @state() agentFilesLoading = false;
   @state() agentFilesError: string | null = null;
   @state() agentFilesList: AgentsFilesListResult | null = null;
@@ -233,11 +228,6 @@ export class RemoteClawApp extends LitElement {
   @state() agentIdentityLoading = false;
   @state() agentIdentityError: string | null = null;
   @state() agentIdentityById: Record<string, AgentIdentityResult> = {};
-  @state() agentSkillsLoading = false;
-  @state() agentSkillsError: string | null = null;
-  @state() agentSkillsReport: SkillStatusReport | null = null;
-  @state() agentSkillsAgentId: string | null = null;
-
   @state() sessionsLoading = false;
   @state() sessionsResult: SessionsListResult | null = null;
   @state() sessionsError: string | null = null;
@@ -339,14 +329,6 @@ export class RemoteClawApp extends LitElement {
   @state() cronBusy = false;
 
   @state() updateAvailable: import("./types.js").UpdateAvailable | null = null;
-
-  @state() skillsLoading = false;
-  @state() skillsReport: SkillStatusReport | null = null;
-  @state() skillsError: string | null = null;
-  @state() skillsFilter = "";
-  @state() skillEdits: Record<string, string> = {};
-  @state() skillsBusyKey: string | null = null;
-  @state() skillMessages: Record<string, SkillMessage> = {};
 
   @state() debugLoading = false;
   @state() debugStatus: StatusSummary | null = null;

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -590,55 +590,6 @@ export type CronRunsResult = {
   nextOffset?: number | null;
 };
 
-export type SkillsStatusConfigCheck = {
-  path: string;
-  satisfied: boolean;
-};
-
-export type SkillInstallOption = {
-  id: string;
-  kind: "brew" | "node" | "go" | "uv";
-  label: string;
-  bins: string[];
-};
-
-export type SkillStatusEntry = {
-  name: string;
-  description: string;
-  source: string;
-  filePath: string;
-  baseDir: string;
-  skillKey: string;
-  bundled?: boolean;
-  primaryEnv?: string;
-  emoji?: string;
-  homepage?: string;
-  always: boolean;
-  disabled: boolean;
-  blockedByAllowlist: boolean;
-  eligible: boolean;
-  requirements: {
-    bins: string[];
-    env: string[];
-    config: string[];
-    os: string[];
-  };
-  missing: {
-    bins: string[];
-    env: string[];
-    config: string[];
-    os: string[];
-  };
-  configChecks: SkillsStatusConfigCheck[];
-  install: SkillInstallOption[];
-};
-
-export type SkillStatusReport = {
-  workspaceDir: string;
-  managedSkillsDir: string;
-  skills: SkillStatusEntry[];
-};
-
 export type StatusSummary = Record<string, unknown>;
 
 export type HealthSnapshot = Record<string, unknown>;

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -27,7 +27,7 @@ import {
   resolveModelPrimary,
 } from "./agents-utils.ts";
 
-export type AgentsPanel = "overview" | "files" | "tools" | "channels" | "cron" | "skills";
+export type AgentsPanel = "overview" | "files" | "tools" | "channels" | "cron";
 
 export type AgentsProps = {
   loading: boolean;
@@ -57,14 +57,9 @@ export type AgentsProps = {
   agentIdentityLoading: boolean;
   agentIdentityError: string | null;
   agentIdentityById: Record<string, AgentIdentityResult>;
-  agentSkillsLoading: boolean;
-  agentSkillsReport: unknown;
-  agentSkillsError: string | null;
-  agentSkillsAgentId: string | null;
   toolsCatalogLoading: boolean;
   toolsCatalogError: string | null;
   toolsCatalogResult: ToolsCatalogResult | null;
-  skillsFilter: string;
   onRefresh: () => void;
   onSelectAgent: (agentId: string) => void;
   onSelectPanel: (panel: AgentsPanel) => void;
@@ -81,11 +76,6 @@ export type AgentsProps = {
   onModelFallbacksChange: (agentId: string, fallbacks: string[]) => void;
   onChannelsRefresh: () => void;
   onCronRefresh: () => void;
-  onSkillsFilterChange: (next: string) => void;
-  onSkillsRefresh: () => void;
-  onAgentSkillToggle: (agentId: string, skillName: string, enabled: boolean) => void;
-  onAgentSkillsClear: (agentId: string) => void;
-  onAgentSkillsDisableAll: (agentId: string) => void;
 };
 
 export type AgentContext = {


### PR DESCRIPTION
## Summary

- Remove ~240 lines of unreachable skills UI dead code across 5 files
- Dead code includes no-op stubs, `@ts-expect-error` render branch, orphaned state/type properties, and skill-related types
- The `"skills"` tab was never reachable (not in `Tab` union), making all skill render paths, state, and types dead

## Files changed

| File | Removals |
|------|----------|
| `ui/src/ui/app-render.ts` | No-op stubs (`loadAgentSkills`, `installSkill`, `loadSkills`, `saveSkillApiKey`, `updateSkillEdit`, `updateSkillEnabled`, `renderSkills`), dead `state.tab === "skills"` render branch with `@ts-expect-error`, dead skills wiring in agents view |
| `ui/src/ui/app.ts` | Dead `agentSkills*` and `skills*` `@state()` properties, `SkillMessage` type stub |
| `ui/src/ui/app-view-state.ts` | Dead `agentSkills*` and `skills*` type properties, `SkillMessage` type stub |
| `ui/src/ui/views/agents.ts` | Dead skill props in `AgentsProps` interface, `"skills"` from `AgentsPanel` union |
| `ui/src/ui/types.ts` | `SkillStatusReport`, `SkillStatusEntry`, `SkillInstallOption`, `SkillsStatusConfigCheck` types (no consumers outside dead code) |

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Type-check passes (`pnpm tsgo` via pre-commit hook)
- [x] Lint passes (`oxlint --type-aware` via pre-commit hook)
- [x] Format passes (`oxfmt --check` via pre-commit hook)
- [x] No remaining skill references in `ui/src/ui/` (verified via grep)
- [ ] CI passes

Closes #2224

🤖 Generated with [Claude Code](https://claude.com/claude-code)