### PR TITLE
chore: remove dead _-prefixed params from skill commands gutting

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -115,7 +115,6 @@ export async function resolveReplyDirectives(params: {
   cfg: RemoteClawConfig;
   agentId: string;
   agentDir: string;
-  workspaceDir: string;
   agentCfg: AgentDefaults;
   sessionCtx: TemplateContext;
   sessionEntry: SessionEntry;
@@ -136,7 +135,6 @@ export async function resolveReplyDirectives(params: {
   hasResolvedHeartbeatModelOverride?: boolean;
   typing: TypingController;
   opts?: GetReplyOptions;
-  skillFilter?: string[];
 }): Promise<ReplyDirectiveResult> {
   const {
     ctx,
@@ -144,7 +142,6 @@ export async function resolveReplyDirectives(params: {
     agentId,
     agentCfg,
     agentDir,
-    workspaceDir: _workspaceDir,
     sessionCtx,
     sessionEntry,
     sessionStore,
@@ -158,7 +155,6 @@ export async function resolveReplyDirectives(params: {
     runtimeId: _runtimeId,
     typing,
     opts,
-    skillFilter: _skillFilter,
   } = params;
   // Model selection: use new upstream params if available, fall back to runtimeId for back-compat.
   const defaultProvider = params.defaultProvider ?? params.runtimeId ?? "anthropic";

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -60,7 +60,6 @@ export async function handleInlineActions(params: {
   contextTokens: number;
   directiveAck?: ReplyPayload;
   abortedLastRun: boolean;
-  skillFilter?: string[];
 }): Promise<InlineActionResult> {
   const {
     ctx,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -2,7 +2,6 @@ import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveSessionAgentId,
-  resolveAgentSkillsFilter,
 } from "../../agents/agent-scope.js";
 // Gutted in RemoteClaw fork (Middleware Boundary Principle)
 const resolveModelRefFromString = (..._args: unknown[]) =>
@@ -40,31 +39,6 @@ import { initSessionState } from "./session.js";
 const stageSandboxMedia = async (..._args: unknown[]) => {};
 import { createTypingController } from "./typing.js";
 
-function mergeSkillFilters(channelFilter?: string[], agentFilter?: string[]): string[] | undefined {
-  const normalize = (list?: string[]) => {
-    if (!Array.isArray(list)) {
-      return undefined;
-    }
-    return list.map((entry) => String(entry).trim()).filter(Boolean);
-  };
-  const channel = normalize(channelFilter);
-  const agent = normalize(agentFilter);
-  if (!channel && !agent) {
-    return undefined;
-  }
-  if (!channel) {
-    return agent;
-  }
-  if (!agent) {
-    return channel;
-  }
-  if (channel.length === 0 || agent.length === 0) {
-    return [];
-  }
-  const agentSet = new Set(agent);
-  return channel.filter((name) => agentSet.has(name));
-}
-
 export async function getReplyFromConfig(
   ctx: MsgContext,
   opts?: GetReplyOptions,
@@ -79,12 +53,6 @@ export async function getReplyFromConfig(
     sessionKey: agentSessionKey,
     config: cfg,
   });
-  const mergedSkillFilter = mergeSkillFilters(
-    opts?.skillFilter,
-    resolveAgentSkillsFilter(cfg, agentId) as string[] | undefined,
-  );
-  const resolvedOpts =
-    mergedSkillFilter !== undefined ? { ...opts, skillFilter: mergedSkillFilter } : opts;
   const agentCfg = cfg.agents?.defaults;
   const sessionCfg = cfg.session;
   const { defaultProvider, defaultModel, aliasIndex } = resolveDefaultModel({
@@ -234,7 +202,6 @@ export async function getReplyFromConfig(
     cfg,
     agentId,
     agentDir,
-    workspaceDir,
     agentCfg,
     sessionCtx,
     sessionEntry,
@@ -253,8 +220,7 @@ export async function getReplyFromConfig(
     model,
     hasResolvedHeartbeatModelOverride,
     typing,
-    opts: resolvedOpts,
-    skillFilter: mergedSkillFilter,
+    opts,
   });
   if (directiveResult.kind === "reply") {
     return directiveResult.reply;
@@ -325,7 +291,7 @@ export async function getReplyFromConfig(
     sessionScope,
     workspaceDir,
     isGroup,
-    opts: resolvedOpts,
+    opts,
     typing,
     allowTextCommands,
     inlineStatusRequested,
@@ -346,7 +312,6 @@ export async function getReplyFromConfig(
     contextTokens,
     directiveAck,
     abortedLastRun,
-    skillFilter: mergedSkillFilter,
   });
   if (inlineActionResult.kind === "reply") {
     await maybeEmitMissingResetHooks();
@@ -394,7 +359,7 @@ export async function getReplyFromConfig(
     perMessageQueueMode,
     perMessageQueueOptions,
     typing,
-    opts: resolvedOpts,
+    opts,
     defaultProvider,
     defaultModel,
     timeoutMs,

--- a/src/telegram/bot-native-commands.plugin-auth.test.ts
+++ b/src/telegram/bot-native-commands.plugin-auth.test.ts
@@ -57,7 +57,6 @@ describe("registerTelegramNativeCommands (plugin auth)", () => {
       textLimit: 4000,
       useAccessGroups: false,
       nativeEnabled: false,
-      nativeSkillsEnabled: false,
       nativeDisabledExplicit: false,
       resolveGroupPolicy: () =>
         ({
@@ -122,7 +121,6 @@ describe("registerTelegramNativeCommands (plugin auth)", () => {
       textLimit: 4000,
       useAccessGroups: false,
       nativeEnabled: false,
-      nativeSkillsEnabled: false,
       nativeDisabledExplicit: false,
       resolveGroupPolicy,
       resolveTelegramGroupConfig: () => ({

--- a/src/telegram/bot-native-commands.skills-allowlist.test.ts
+++ b/src/telegram/bot-native-commands.skills-allowlist.test.ts
@@ -89,7 +89,6 @@ describe.skip("registerTelegramNativeCommands skill allowlist integration", () =
         cfg,
         accountId: "bot-a",
         telegramCfg: {} as TelegramAccountConfig,
-        nativeSkillsEnabled: true,
       }),
     });
 

--- a/src/telegram/bot-native-commands.test-helpers.ts
+++ b/src/telegram/bot-native-commands.test-helpers.ts
@@ -17,7 +17,6 @@ export function createNativeCommandTestParams(params: {
   textLimit?: number;
   useAccessGroups?: boolean;
   nativeEnabled?: boolean;
-  nativeSkillsEnabled?: boolean;
   nativeDisabledExplicit?: boolean;
   opts?: RegisterTelegramNativeCommandParams["opts"];
 }): RegisterTelegramNativeCommandParams {
@@ -33,7 +32,6 @@ export function createNativeCommandTestParams(params: {
     textLimit: params.textLimit ?? 4096,
     useAccessGroups: params.useAccessGroups ?? false,
     nativeEnabled: params.nativeEnabled ?? true,
-    nativeSkillsEnabled: params.nativeSkillsEnabled ?? false,
     nativeDisabledExplicit: params.nativeDisabledExplicit ?? false,
     resolveGroupPolicy: () => ({ allowlistEnabled: false, allowed: true }),
     resolveTelegramGroupConfig: () => ({

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -124,7 +124,6 @@ type RegisterTelegramNativeCommandsParams = {
   textLimit: number;
   useAccessGroups: boolean;
   nativeEnabled: boolean;
-  nativeSkillsEnabled: boolean;
   nativeDisabledExplicit: boolean;
   resolveGroupPolicy: (chatId: string | number) => ChannelGroupPolicy;
   resolveTelegramGroupConfig: (
@@ -316,7 +315,6 @@ export const registerTelegramNativeCommands = ({
   textLimit,
   useAccessGroups,
   nativeEnabled,
-  nativeSkillsEnabled: _nativeSkillsEnabled,
   nativeDisabledExplicit,
   resolveGroupPolicy,
   resolveTelegramGroupConfig,

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -8,7 +8,6 @@ import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "../auto-reply/re
 import {
   isNativeCommandsExplicitlyDisabled,
   resolveNativeCommandsEnabled,
-  resolveNativeSkillsEnabled,
 } from "../config/commands.js";
 import type { RemoteClawConfig, ReplyToMode } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
@@ -224,11 +223,6 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     providerSetting: telegramCfg.commands?.native,
     globalSetting: cfg.commands?.native,
   });
-  const nativeSkillsEnabled = resolveNativeSkillsEnabled({
-    providerId: "telegram",
-    providerSetting: telegramCfg.commands?.nativeSkills,
-    globalSetting: cfg.commands?.nativeSkills,
-  });
   const nativeDisabledExplicit = isNativeCommandsExplicitlyDisabled({
     providerSetting: telegramCfg.commands?.native,
     globalSetting: cfg.commands?.native,
@@ -354,7 +348,6 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     textLimit,
     useAccessGroups,
     nativeEnabled,
-    nativeSkillsEnabled,
     nativeDisabledExplicit,
     resolveGroupPolicy,
     resolveTelegramGroupConfig,


### PR DESCRIPTION
## Summary
- Remove `workspaceDir`, `skillFilter`, and `nativeSkillsEnabled` parameters left as `_`-prefixed unused destructures by PR #2241
- Full removal from types, destructures, callers, imports, and test helpers
- Remove dead `mergeSkillFilters` function and `resolveAgentSkillsFilter` import

Closes #2243

## Test plan
- [x] `grep -rn "_workspaceDir\|_skillFilter\|_nativeSkillsEnabled" src/` = 0
- [x] `grep -rn "mergeSkillFilters" src/` = 0
- [x] Build passes
- [x] 694 test files pass, 5949 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)