### PR TITLE
gut(ui): strip residual skills stubs from shared UI files

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -989,7 +989,6 @@ export function renderApp(state: AppViewState) {
                 loading: state.debugLoading,
                 status: state.debugStatus,
                 health: state.debugHealth,
-                models: state.debugModels,
                 heartbeat: state.debugHeartbeat,
                 eventLog: state.eventLog,
                 callMethod: state.debugCallMethod,

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -232,7 +232,6 @@ export type AppViewState = {
   debugLoading: boolean;
   debugStatus: StatusSummary | null;
   debugHealth: HealthSnapshot | null;
-  debugModels: unknown[];
   debugHeartbeat: unknown;
   debugCallMethod: string;
   debugCallParams: string;
@@ -281,11 +280,6 @@ export type AppViewState = {
   handleConfigFormUpdate: (path: string, value: unknown) => void;
   handleConfigFormModeChange: (mode: "form" | "raw") => void;
   handleConfigRawChange: (raw: string) => void;
-  handleInstallSkill: (key: string) => Promise<void>;
-  handleUpdateSkill: (key: string) => Promise<void>;
-  handleToggleSkillEnabled: (key: string, enabled: boolean) => Promise<void>;
-  handleUpdateSkillEdit: (key: string, value: string) => void;
-  handleSaveSkillApiKey: (key: string, apiKey: string) => Promise<void>;
   handleCronToggle: (jobId: string, enabled: boolean) => Promise<void>;
   handleCronRun: (jobId: string) => Promise<void>;
   handleCronRemove: (jobId: string) => Promise<void>;
@@ -296,7 +290,6 @@ export type AppViewState = {
   handleSessionsPatch: (key: string, patch: unknown) => Promise<void>;
   handleLoadNodes: () => Promise<void>;
   handleLoadPresence: () => Promise<void>;
-  handleLoadSkills: () => Promise<void>;
   handleLoadDebug: () => Promise<void>;
   handleLoadLogs: () => Promise<void>;
   handleDebugCall: () => Promise<void>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -333,7 +333,6 @@ export class RemoteClawApp extends LitElement {
   @state() debugLoading = false;
   @state() debugStatus: StatusSummary | null = null;
   @state() debugHealth: HealthSnapshot | null = null;
-  @state() debugModels: unknown[] = [];
   @state() debugHeartbeat: unknown = null;
   @state() debugCallMethod = "";
   @state() debugCallParams = "{}";

--- a/ui/src/ui/views/debug.ts
+++ b/ui/src/ui/views/debug.ts
@@ -6,7 +6,6 @@ export type DebugProps = {
   loading: boolean;
   status: Record<string, unknown> | null;
   health: Record<string, unknown> | null;
-  models: unknown[];
   heartbeat: unknown;
   eventLog: EventLogEntry[];
   callMethod: string;
@@ -106,16 +105,6 @@ export function renderDebug(props: DebugProps) {
             : nothing
         }
       </div>
-    </section>
-
-    <section class="card" style="margin-top: 18px;">
-      <div class="card-title">Models</div>
-      <div class="card-sub">Catalog from models.list.</div>
-      <pre class="code-block" style="margin-top: 12px;">${JSON.stringify(
-        props.models ?? [],
-        null,
-        2,
-      )}</pre>
     </section>
 
     <section class="card" style="margin-top: 18px;">


### PR DESCRIPTION
## Summary

Closes #2193.

- Remove 6 orphaned skill handler method types from `AppViewState` (`handleInstallSkill`, `handleUpdateSkill`, `handleToggleSkillEnabled`, `handleUpdateSkillEdit`, `handleSaveSkillApiKey`, `handleLoadSkills`) — dead since the skills controllers were deleted in #2240
- Remove the never-populated `debugModels` state field from `AppViewState`, `RemoteClawApp`, and the render prop pass-through, plus the permanently-empty "Models" card from the debug view

## Test plan

- [x] `pnpm tsgo` — no new type errors in modified files
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format` — all files formatted
- [x] `pnpm test` — 694 test files pass (5949 tests), 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)