### PR TITLE
fix(heartbeat): restore file-based prompt resolution and workspace dir

### DIFF
--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -1,24 +1,68 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveHeartbeatPrompt } from "./heartbeat.js";
 
+vi.mock("node:fs/promises");
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("resolveHeartbeatPrompt", () => {
-  it("returns empty string when prompt is undefined", () => {
-    expect(resolveHeartbeatPrompt(undefined)).toBe("");
-    expect(resolveHeartbeatPrompt()).toBe("");
+  it("returns empty string when nothing is configured", async () => {
+    expect(await resolveHeartbeatPrompt({})).toBe("");
+    expect(await resolveHeartbeatPrompt({ prompt: undefined })).toBe("");
   });
 
-  it("returns empty string when prompt is empty or whitespace", () => {
-    expect(resolveHeartbeatPrompt("")).toBe("");
-    expect(resolveHeartbeatPrompt("   ")).toBe("");
-    expect(resolveHeartbeatPrompt("  \n\t  ")).toBe("");
+  it("returns empty string when prompt is empty or whitespace", async () => {
+    expect(await resolveHeartbeatPrompt({ prompt: "" })).toBe("");
+    expect(await resolveHeartbeatPrompt({ prompt: "   " })).toBe("");
+    expect(await resolveHeartbeatPrompt({ prompt: "  \n\t  " })).toBe("");
   });
 
-  it("returns trimmed prompt when set", () => {
-    expect(resolveHeartbeatPrompt("  ping  ")).toBe("ping");
-    expect(resolveHeartbeatPrompt("Check health")).toBe("Check health");
+  it("returns trimmed prompt when set", async () => {
+    expect(await resolveHeartbeatPrompt({ prompt: "  ping  " })).toBe("ping");
+    expect(await resolveHeartbeatPrompt({ prompt: "Check health" })).toBe("Check health");
   });
 
-  it("returns prompt with internal whitespace preserved", () => {
-    expect(resolveHeartbeatPrompt("line 1\nline 2")).toBe("line 1\nline 2");
+  it("returns prompt with internal whitespace preserved", async () => {
+    expect(await resolveHeartbeatPrompt({ prompt: "line 1\nline 2" })).toBe("line 1\nline 2");
+  });
+
+  it("prompt takes precedence over file", async () => {
+    expect(await resolveHeartbeatPrompt({ prompt: "inline", file: "heartbeat.txt" })).toBe(
+      "inline",
+    );
+  });
+
+  it("reads file when prompt is empty", async () => {
+    vi.mocked(fs.readFile).mockResolvedValue("file prompt content");
+    expect(
+      await resolveHeartbeatPrompt({ file: "heartbeat.txt", workspaceDir: "/workspace" }),
+    ).toBe("file prompt content");
+    expect(fs.readFile).toHaveBeenCalledWith(path.join("/workspace", "heartbeat.txt"), "utf-8");
+  });
+
+  it("uses absolute file path as-is", async () => {
+    vi.mocked(fs.readFile).mockResolvedValue("absolute content");
+    expect(
+      await resolveHeartbeatPrompt({ file: "/etc/heartbeat.txt", workspaceDir: "/workspace" }),
+    ).toBe("absolute content");
+    expect(fs.readFile).toHaveBeenCalledWith("/etc/heartbeat.txt", "utf-8");
+  });
+
+  it("returns empty string when file is missing", async () => {
+    vi.mocked(fs.readFile).mockRejectedValue(new Error("ENOENT"));
+    expect(await resolveHeartbeatPrompt({ file: "missing.txt", workspaceDir: "/workspace" })).toBe(
+      "",
+    );
+  });
+
+  it("returns empty string when file content is empty", async () => {
+    vi.mocked(fs.readFile).mockResolvedValue("   ");
+    expect(await resolveHeartbeatPrompt({ file: "empty.txt", workspaceDir: "/workspace" })).toBe(
+      "",
+    );
   });
 });

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -1,22 +1,50 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { escapeRegExp } from "../utils.js";
 import { HEARTBEAT_TOKEN } from "./tokens.js";
 
 /** Non-configurable suffix appended by the middleware to every heartbeat prompt. */
 export const HEARTBEAT_TOOL_SUFFIX = " Report the result using the heartbeat_report tool.";
 
-// Stub — removed during fork workspace cleanup (WI-179); re-exported for upstream compat
-export const HEARTBEAT_PROMPT = undefined as string | undefined;
-
 export const DEFAULT_HEARTBEAT_EVERY = "30m";
 export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
 
 /**
- * Resolve the heartbeat prompt from a raw config value.
- * Returns the trimmed prompt or empty string if not configured.
+ * Resolve the heartbeat prompt from config.
+ *
+ * Resolution order:
+ * - `prompt` takes precedence if set (non-empty after trim)
+ * - `file` is read at runtime (path relative to workspaceDir)
+ * - Returns empty string when neither is configured (caller should skip heartbeat)
  */
-export function resolveHeartbeatPrompt(raw?: string): string {
-  const trimmed = typeof raw === "string" ? raw.trim() : "";
-  return trimmed;
+export async function resolveHeartbeatPrompt(opts: {
+  prompt?: string;
+  file?: string;
+  workspaceDir?: string;
+}): Promise<string> {
+  const trimmedPrompt = opts.prompt?.trim();
+  if (trimmedPrompt) {
+    return trimmedPrompt;
+  }
+
+  const trimmedFile = opts.file?.trim();
+  if (trimmedFile) {
+    const filePath =
+      opts.workspaceDir && !path.isAbsolute(trimmedFile)
+        ? path.join(opts.workspaceDir, trimmedFile)
+        : trimmedFile;
+    try {
+      const content = await fs.readFile(filePath, "utf-8");
+      const trimmedContent = content.trim();
+      if (trimmedContent) {
+        return trimmedContent;
+      }
+    } catch {
+      // File missing or unreadable — treat as unconfigured.
+    }
+  }
+
+  return "";
 }
 
 export type StripHeartbeatMode = "heartbeat" | "message";

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -251,6 +251,8 @@ export type AgentDefaultsConfig = {
     accountId?: string;
     /** Override the heartbeat prompt body (default: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK."). */
     prompt?: string;
+    /** Path to a file containing the heartbeat prompt (relative to agent workspace dir, or absolute). `prompt` takes precedence if both are set. */
+    file?: string;
     /** Max chars allowed after HEARTBEAT_OK before delivery (default: 30). */
     ackMaxChars?: number;
     /** Suppress tool error warning payloads during heartbeat runs. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -31,6 +31,7 @@ export const HeartbeatSchema = z
     to: z.string().optional(),
     accountId: z.string().optional(),
     prompt: z.string().optional(),
+    file: z.string().optional(),
     ackMaxChars: z.number().int().nonnegative().optional(),
     suppressToolErrorWarnings: z.boolean().optional(),
     lightContext: z.boolean().optional(),

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1,10 +1,17 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { resolveAgentConfig, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveAgentConfig,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
 import { appendCronStyleCurrentTimeLine } from "../agents/current-time.js";
 import { resolveEffectiveMessagesConfig } from "../agents/identity.js";
 import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
-import { DEFAULT_HEARTBEAT_EVERY } from "../auto-reply/heartbeat.js";
+import {
+  DEFAULT_HEARTBEAT_EVERY,
+  resolveHeartbeatPrompt as resolveHeartbeatPromptFromConfig,
+} from "../auto-reply/heartbeat.js";
 import { getReplyFromConfig } from "../auto-reply/reply.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import { getChannelPlugin } from "../channels/plugins/index.js";
@@ -143,7 +150,7 @@ export function resolveHeartbeatSummaryForAgent(
       enabled: false,
       every: "disabled",
       everyMs: null,
-      prompt: defaults?.prompt?.trim() || "",
+      prompt: defaults?.prompt?.trim() || (defaults?.file ? `[file: ${defaults.file}]` : ""),
       target: defaults?.target ?? DEFAULT_HEARTBEAT_TARGET,
       model: defaults?.model,
     };
@@ -153,7 +160,8 @@ export function resolveHeartbeatSummaryForAgent(
   const every = merged?.every ?? defaults?.every ?? overrides?.every ?? DEFAULT_HEARTBEAT_EVERY;
   const everyMs = resolveHeartbeatIntervalMs(cfg, undefined, merged);
   const rawPrompt = merged?.prompt ?? defaults?.prompt ?? overrides?.prompt;
-  const prompt = rawPrompt?.trim() || "";
+  const rawFile = merged?.file ?? defaults?.file ?? overrides?.file;
+  const prompt = rawPrompt?.trim() || (rawFile ? `[file: ${rawFile}]` : "");
   const target =
     merged?.target ?? defaults?.target ?? overrides?.target ?? DEFAULT_HEARTBEAT_TARGET;
   const model = merged?.model ?? defaults?.model ?? overrides?.model;
@@ -215,11 +223,14 @@ export function resolveHeartbeatIntervalMs(
 export async function resolveHeartbeatPrompt(
   cfg: RemoteClawConfig,
   heartbeat?: HeartbeatConfig,
-  _agentId?: string,
+  agentId?: string,
 ): Promise<string> {
   const defaults = cfg.agents?.defaults?.heartbeat;
   const prompt = heartbeat?.prompt ?? defaults?.prompt;
-  return prompt?.trim() || "";
+  const file = heartbeat?.file ?? defaults?.file;
+  const resolvedAgentId = agentId ?? resolveDefaultAgentId(cfg);
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, resolvedAgentId);
+  return resolveHeartbeatPromptFromConfig({ prompt, file, workspaceDir });
 }
 
 function resolveHeartbeatSession(

--- a/src/web/auto-reply/heartbeat-runner.ts
+++ b/src/web/auto-reply/heartbeat-runner.ts
@@ -1,4 +1,3 @@
-// Heartbeat file resolution removed (upstream simplified to string prompt)
 import { appendCronStyleCurrentTimeLine } from "../../agents/current-time.js";
 import { resolveHeartbeatReplyPayload } from "../../auto-reply/heartbeat-reply-payload.js";
 import { resolveHeartbeatPrompt } from "../../auto-reply/heartbeat.js";
@@ -157,7 +156,7 @@ export async function runWebHeartbeatOnce(opts: {
     }
 
     const defaults = cfg.agents?.defaults?.heartbeat;
-    const heartbeatPrompt = resolveHeartbeatPrompt(defaults?.prompt);
+    const heartbeatPrompt = await resolveHeartbeatPrompt({ prompt: defaults?.prompt });
     if (!heartbeatPrompt) {
       heartbeatLogger.info({ to: redactedTo, reason: "no-prompt" }, "heartbeat skipped");
       emitHeartbeatEvent({


### PR DESCRIPTION
## Summary

- Restores the file-based heartbeat prompt resolution that was lost during workspace cleanup (WI-179) and DIFF-SYNC
- Adds `file` field to `HeartbeatSchema` and `HeartbeatConfig` type so heartbeat prompts can be loaded from a file path relative to the agent workspace
- Updates `resolveHeartbeatPrompt` to async with `{ prompt, file, workspaceDir }` options — `prompt` takes precedence, `file` is read at runtime, gracefully falls back on missing/empty files
- Wires `resolveAgentWorkspaceDir` into the heartbeat-runner prompt resolution pipeline
- Updates `resolveHeartbeatSummaryForAgent` to show `[file: ...]` indicator in the summary when file-based prompt is configured
- Updates web heartbeat-runner caller for the new async signature

Closes #2194

## Test plan

- [x] Core `resolveHeartbeatPrompt` tests: empty, whitespace, trimmed prompt, prompt precedence over file, file reading, absolute paths, missing files, empty file content
- [x] Heartbeat-runner integration tests pass (23 tests)
- [x] All heartbeat test files pass (47 tests, 1 pre-existing skip)
- [x] Type-check clean (no new errors in changed files)
- [x] Lint clean, format clean
- [x] Pre-commit hook passes (`pnpm check` green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)