### PR TITLE
fix(security): re-apply lost v2026.3.1/v2026.3.2 security improvements

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import * as readline from "node:readline";
 import { Readable, Writable } from "node:stream";
@@ -20,11 +21,16 @@ import {
 } from "../plugin-sdk/windows-spawn.js";
 import { DANGEROUS_ACP_TOOLS } from "../security/dangerous-tools.js";
 
-const SAFE_AUTO_APPROVE_TOOL_IDS = new Set(["search"]);
+const SAFE_AUTO_APPROVE_TOOL_IDS = new Set(["read", "search", "web_search"]);
 const TRUSTED_SAFE_TOOL_ALIASES = new Set(["search"]);
+const READ_TOOL_PATH_KEYS = ["path", "file_path", "filePath"];
 const TOOL_NAME_MAX_LENGTH = 128;
 const TOOL_NAME_PATTERN = /^[a-z0-9._-]+$/;
-const TOOL_KIND_BY_ID = new Map<string, string>([["search", "search"]]);
+const TOOL_KIND_BY_ID = new Map<string, string>([
+  ["read", "read"],
+  ["search", "search"],
+  ["web_search", "search"],
+]);
 
 type PermissionOption = RequestPermissionRequest["options"][number];
 
@@ -96,12 +102,105 @@ function resolveToolNameForPermission(params: RequestPermissionRequest): string 
   return normalizeToolName(fromMeta ?? fromRawInput ?? fromTitle ?? "");
 }
 
-function shouldAutoApproveToolCall(toolName: string | undefined): boolean {
+function extractPathFromToolTitle(
+  toolTitle: string | undefined,
+  toolName: string | undefined,
+): string | undefined {
+  if (!toolTitle) {
+    return undefined;
+  }
+  const separator = toolTitle.indexOf(":");
+  if (separator < 0) {
+    return undefined;
+  }
+  const tail = toolTitle.slice(separator + 1).trim();
+  if (!tail) {
+    return undefined;
+  }
+  const keyedMatch = tail.match(/(?:^|,\s*)(?:path|file_path|filePath)\s*:\s*([^,]+)/);
+  if (keyedMatch?.[1]) {
+    return keyedMatch[1].trim();
+  }
+  if (toolName === "read") {
+    return tail;
+  }
+  return undefined;
+}
+
+function resolveToolPathCandidate(
+  params: RequestPermissionRequest,
+  toolName: string | undefined,
+  toolTitle: string | undefined,
+): string | undefined {
+  const rawInput = asRecord(params.toolCall?.rawInput);
+  const fromRawInput = readFirstStringValue(rawInput, READ_TOOL_PATH_KEYS);
+  const fromTitle = extractPathFromToolTitle(toolTitle, toolName);
+  return fromRawInput ?? fromTitle;
+}
+
+function resolveAbsoluteScopedPath(value: string, cwd: string): string | undefined {
+  let candidate = value.trim();
+  if (!candidate) {
+    return undefined;
+  }
+  if (candidate.startsWith("file://")) {
+    try {
+      const parsed = new URL(candidate);
+      candidate = decodeURIComponent(parsed.pathname || "");
+    } catch {
+      return undefined;
+    }
+  }
+  if (candidate === "~") {
+    candidate = homedir();
+  } else if (candidate.startsWith("~/")) {
+    candidate = path.join(homedir(), candidate.slice(2));
+  }
+  const absolute = path.isAbsolute(candidate)
+    ? path.normalize(candidate)
+    : path.resolve(cwd, candidate);
+  return absolute;
+}
+
+function isPathWithinRoot(candidatePath: string, root: string): boolean {
+  const relative = path.relative(root, candidatePath);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function isReadToolCallScopedToCwd(
+  params: RequestPermissionRequest,
+  toolName: string | undefined,
+  toolTitle: string | undefined,
+  cwd: string,
+): boolean {
+  if (toolName !== "read") {
+    return false;
+  }
+  const rawPath = resolveToolPathCandidate(params, toolName, toolTitle);
+  if (!rawPath) {
+    return false;
+  }
+  const absolutePath = resolveAbsoluteScopedPath(rawPath, cwd);
+  if (!absolutePath) {
+    return false;
+  }
+  return isPathWithinRoot(absolutePath, path.resolve(cwd));
+}
+
+function shouldAutoApproveToolCall(
+  params: RequestPermissionRequest,
+  toolName: string | undefined,
+  toolTitle: string | undefined,
+  cwd: string,
+): boolean {
   const isTrustedToolId =
     typeof toolName === "string" &&
     (isKnownCoreToolId(toolName) || TRUSTED_SAFE_TOOL_ALIASES.has(toolName));
   if (!toolName || !isTrustedToolId || !SAFE_AUTO_APPROVE_TOOL_IDS.has(toolName)) {
     return false;
+  }
+  if (toolName === "read") {
+    return isReadToolCallScopedToCwd(params, toolName, toolTitle, cwd);
   }
   return true;
 }
@@ -173,6 +272,7 @@ export async function resolvePermissionRequest(
 ): Promise<RequestPermissionResponse> {
   const log = deps.log ?? ((line: string) => console.error(line));
   const prompt = deps.prompt ?? promptUserPermission;
+  const cwd = deps.cwd ?? process.cwd();
   const options = params.options ?? [];
   const toolTitle = params.toolCall?.title ?? "tool";
   const toolName = resolveToolNameForPermission(params);
@@ -185,7 +285,7 @@ export async function resolvePermissionRequest(
 
   const allowOption = pickOption(options, ["allow_once", "allow_always"]);
   const rejectOption = pickOption(options, ["reject_once", "reject_always"]);
-  const autoApproveAllowed = shouldAutoApproveToolCall(toolName);
+  const autoApproveAllowed = shouldAutoApproveToolCall(params, toolName, toolTitle, cwd);
   const promptRequired = !toolName || !autoApproveAllowed || DANGEROUS_ACP_TOOLS.has(toolName);
 
   if (!promptRequired) {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { ZodIssue } from "zod";
+import { normalizeChatChannelId } from "../channels/registry.js";
 import {
   isNumericTelegramUserId,
   normalizeTelegramAllowFromEntry,
@@ -13,6 +14,8 @@ import { collectProviderDangerousNameMatchingScopes } from "../config/dangerous-
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { parseToolsBySenderTypedKey } from "../config/types.tools.js";
 import { RemoteClawSchema } from "../config/zod-schema.js";
+import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/account-id.js";
 import {
   isDiscordMutableAllowEntry,
   isGoogleChatMutableAllowEntry,
@@ -1065,6 +1068,290 @@ function maybeRepairLegacyToolsBySenderKeys(cfg: RemoteClawConfig): {
   return { config: next, changes };
 }
 
+function hasAllowFromEntries(list?: Array<string | number>) {
+  return Array.isArray(list) && list.map((v) => String(v).trim()).filter(Boolean).length > 0;
+}
+
+async function maybeRepairAllowlistPolicyAllowFrom(cfg: RemoteClawConfig): Promise<{
+  config: RemoteClawConfig;
+  changes: string[];
+}> {
+  const channels = cfg.channels;
+  if (!channels || typeof channels !== "object") {
+    return { config: cfg, changes: [] };
+  }
+
+  type AllowFromMode = "topOnly" | "topOrNested" | "nestedOnly";
+
+  const resolveAllowFromMode = (channelName: string): AllowFromMode => {
+    if (channelName === "googlechat") {
+      return "nestedOnly";
+    }
+    if (channelName === "discord" || channelName === "slack") {
+      return "topOrNested";
+    }
+    return "topOnly";
+  };
+
+  const next = structuredClone(cfg);
+  const changes: string[] = [];
+
+  const applyRecoveredAllowFrom = (params: {
+    account: Record<string, unknown>;
+    allowFrom: string[];
+    mode: AllowFromMode;
+    prefix: string;
+  }) => {
+    const count = params.allowFrom.length;
+    const noun = count === 1 ? "entry" : "entries";
+
+    if (params.mode === "nestedOnly") {
+      const dmEntry = params.account.dm;
+      const dm =
+        dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
+          ? (dmEntry as Record<string, unknown>)
+          : {};
+      dm.allowFrom = params.allowFrom;
+      params.account.dm = dm;
+      changes.push(
+        `- ${params.prefix}.dm.allowFrom: restored ${count} sender ${noun} from pairing store (dmPolicy="allowlist").`,
+      );
+      return;
+    }
+
+    if (params.mode === "topOrNested") {
+      const dmEntry = params.account.dm;
+      const dm =
+        dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
+          ? (dmEntry as Record<string, unknown>)
+          : undefined;
+      const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
+      if (dm && !Array.isArray(params.account.allowFrom) && Array.isArray(nestedAllowFrom)) {
+        dm.allowFrom = params.allowFrom;
+        changes.push(
+          `- ${params.prefix}.dm.allowFrom: restored ${count} sender ${noun} from pairing store (dmPolicy="allowlist").`,
+        );
+        return;
+      }
+    }
+
+    params.account.allowFrom = params.allowFrom;
+    changes.push(
+      `- ${params.prefix}.allowFrom: restored ${count} sender ${noun} from pairing store (dmPolicy="allowlist").`,
+    );
+  };
+
+  const recoverAllowFromForAccount = async (params: {
+    channelName: string;
+    account: Record<string, unknown>;
+    accountId?: string;
+    prefix: string;
+  }) => {
+    const dmEntry = params.account.dm;
+    const dm =
+      dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
+        ? (dmEntry as Record<string, unknown>)
+        : undefined;
+    const dmPolicy =
+      (params.account.dmPolicy as string | undefined) ?? (dm?.policy as string | undefined);
+    if (dmPolicy !== "allowlist") {
+      return;
+    }
+
+    const topAllowFrom = params.account.allowFrom as Array<string | number> | undefined;
+    const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
+    if (hasAllowFromEntries(topAllowFrom) || hasAllowFromEntries(nestedAllowFrom)) {
+      return;
+    }
+
+    const normalizedChannelId = (normalizeChatChannelId(params.channelName) ?? params.channelName)
+      .trim()
+      .toLowerCase();
+    if (!normalizedChannelId) {
+      return;
+    }
+    const normalizedAccountId = normalizeAccountId(params.accountId) || DEFAULT_ACCOUNT_ID;
+    const fromStore = await readChannelAllowFromStore(
+      normalizedChannelId,
+      process.env,
+      normalizedAccountId,
+    ).catch(() => []);
+    const recovered = Array.from(new Set(fromStore.map((entry) => String(entry).trim()))).filter(
+      Boolean,
+    );
+    if (recovered.length === 0) {
+      return;
+    }
+
+    applyRecoveredAllowFrom({
+      account: params.account,
+      allowFrom: recovered,
+      mode: resolveAllowFromMode(params.channelName),
+      prefix: params.prefix,
+    });
+  };
+
+  const nextChannels = next.channels as Record<string, Record<string, unknown>>;
+  for (const [channelName, channelConfig] of Object.entries(nextChannels)) {
+    if (!channelConfig || typeof channelConfig !== "object") {
+      continue;
+    }
+    await recoverAllowFromForAccount({
+      channelName,
+      account: channelConfig,
+      prefix: `channels.${channelName}`,
+    });
+
+    const accounts = channelConfig.accounts as Record<string, Record<string, unknown>> | undefined;
+    if (!accounts || typeof accounts !== "object") {
+      continue;
+    }
+    for (const [accountId, accountConfig] of Object.entries(accounts)) {
+      if (!accountConfig || typeof accountConfig !== "object") {
+        continue;
+      }
+      await recoverAllowFromForAccount({
+        channelName,
+        account: accountConfig,
+        accountId,
+        prefix: `channels.${channelName}.accounts.${accountId}`,
+      });
+    }
+  }
+
+  if (changes.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+  return { config: next, changes };
+}
+
+/**
+ * Scan all channel configs for dmPolicy="allowlist" without any allowFrom entries.
+ * This configuration blocks all DMs because no sender can match the empty
+ * allowlist. Common after upgrades that remove external allowlist
+ * file support.
+ */
+function detectEmptyAllowlistPolicy(cfg: RemoteClawConfig): string[] {
+  const channels = cfg.channels;
+  if (!channels || typeof channels !== "object") {
+    return [];
+  }
+
+  const warnings: string[] = [];
+
+  const usesSenderBasedGroupAllowlist = (channelName?: string): boolean => {
+    if (!channelName) {
+      return true;
+    }
+    return !(channelName === "discord" || channelName === "slack" || channelName === "googlechat");
+  };
+
+  const allowsGroupAllowFromFallback = (channelName?: string): boolean => {
+    if (!channelName) {
+      return true;
+    }
+    return !(
+      channelName === "googlechat" ||
+      channelName === "imessage" ||
+      channelName === "matrix" ||
+      channelName === "msteams" ||
+      channelName === "irc"
+    );
+  };
+
+  const checkAccount = (
+    account: Record<string, unknown>,
+    prefix: string,
+    parent?: Record<string, unknown>,
+    channelName?: string,
+  ) => {
+    const dmEntry = account.dm;
+    const dm =
+      dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
+        ? (dmEntry as Record<string, unknown>)
+        : undefined;
+    const parentDmEntry = parent?.dm;
+    const parentDm =
+      parentDmEntry && typeof parentDmEntry === "object" && !Array.isArray(parentDmEntry)
+        ? (parentDmEntry as Record<string, unknown>)
+        : undefined;
+    const dmPolicy =
+      (account.dmPolicy as string | undefined) ??
+      (dm?.policy as string | undefined) ??
+      (parent?.dmPolicy as string | undefined) ??
+      (parentDm?.policy as string | undefined) ??
+      undefined;
+
+    const topAllowFrom =
+      (account.allowFrom as Array<string | number> | undefined) ??
+      (parent?.allowFrom as Array<string | number> | undefined);
+    const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
+    const parentNestedAllowFrom = parentDm?.allowFrom as Array<string | number> | undefined;
+    const effectiveAllowFrom = topAllowFrom ?? nestedAllowFrom ?? parentNestedAllowFrom;
+
+    if (dmPolicy === "allowlist" && !hasAllowFromEntries(effectiveAllowFrom)) {
+      warnings.push(
+        `- ${prefix}.dmPolicy is "allowlist" but allowFrom is empty — all DMs will be blocked. Add sender IDs to ${prefix}.allowFrom, or run "${formatCliCommand("remoteclaw doctor --fix")}" to auto-migrate from pairing store when entries exist.`,
+      );
+    }
+
+    const groupPolicy =
+      (account.groupPolicy as string | undefined) ??
+      (parent?.groupPolicy as string | undefined) ??
+      undefined;
+
+    if (groupPolicy === "allowlist" && usesSenderBasedGroupAllowlist(channelName)) {
+      const rawGroupAllowFrom =
+        (account.groupAllowFrom as Array<string | number> | undefined) ??
+        (parent?.groupAllowFrom as Array<string | number> | undefined);
+      const groupAllowFrom = hasAllowFromEntries(rawGroupAllowFrom) ? rawGroupAllowFrom : undefined;
+      const fallbackToAllowFrom = allowsGroupAllowFromFallback(channelName);
+      const effectiveGroupAllowFrom =
+        groupAllowFrom ?? (fallbackToAllowFrom ? effectiveAllowFrom : undefined);
+
+      if (!hasAllowFromEntries(effectiveGroupAllowFrom)) {
+        if (fallbackToAllowFrom) {
+          warnings.push(
+            `- ${prefix}.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to ${prefix}.groupAllowFrom or ${prefix}.allowFrom, or set groupPolicy to "open".`,
+          );
+        } else {
+          warnings.push(
+            `- ${prefix}.groupPolicy is "allowlist" but groupAllowFrom is empty — this channel does not fall back to allowFrom, so all group messages will be silently dropped. Add sender IDs to ${prefix}.groupAllowFrom, or set groupPolicy to "open".`,
+          );
+        }
+      }
+    }
+  };
+
+  for (const [channelName, channelConfig] of Object.entries(
+    channels as Record<string, Record<string, unknown>>,
+  )) {
+    if (!channelConfig || typeof channelConfig !== "object") {
+      continue;
+    }
+    checkAccount(channelConfig, `channels.${channelName}`, undefined, channelName);
+
+    const accounts = channelConfig.accounts;
+    if (accounts && typeof accounts === "object") {
+      for (const [accountId, account] of Object.entries(
+        accounts as Record<string, Record<string, unknown>>,
+      )) {
+        if (!account || typeof account !== "object") {
+          continue;
+        }
+        checkAccount(
+          account,
+          `channels.${channelName}.accounts.${accountId}`,
+          channelConfig,
+          channelName,
+        );
+      }
+    }
+  }
+
+  return warnings;
+}
+
 async function maybeMigrateLegacyConfig(): Promise<string[]> {
   const changes: string[] = [];
   const home = resolveHomeDir();
@@ -1221,6 +1508,19 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       cfg = allowFromRepair.config;
     }
 
+    const allowlistRepair = await maybeRepairAllowlistPolicyAllowFrom(candidate);
+    if (allowlistRepair.changes.length > 0) {
+      note(allowlistRepair.changes.join("\n"), "Doctor changes");
+      candidate = allowlistRepair.config;
+      pendingChanges = true;
+      cfg = allowlistRepair.config;
+    }
+
+    const emptyAllowlistWarnings = detectEmptyAllowlistPolicy(candidate);
+    if (emptyAllowlistWarnings.length > 0) {
+      note(emptyAllowlistWarnings.join("\n"), "Doctor warnings");
+    }
+
     const toolsBySenderRepair = maybeRepairLegacyToolsBySenderKeys(candidate);
     if (toolsBySenderRepair.changes.length > 0) {
       note(toolsBySenderRepair.changes.join("\n"), "Doctor changes");
@@ -1260,6 +1560,11 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
         ].join("\n"),
         "Doctor warnings",
       );
+    }
+
+    const emptyAllowlistWarnings = detectEmptyAllowlistPolicy(candidate);
+    if (emptyAllowlistWarnings.length > 0) {
+      note(emptyAllowlistWarnings.join("\n"), "Doctor warnings");
     }
 
     const toolsBySenderHits = scanLegacyToolsBySenderKeys(candidate);

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -7,6 +7,7 @@ import {
   resolveTalkApiKey,
 } from "./talk.js";
 import type { RemoteClawConfig } from "./types.js";
+import { hasConfiguredSecretInput } from "./types.secrets.js";
 
 type WarnState = { warned: boolean };
 
@@ -127,10 +128,9 @@ export function applyTalkApiKey(config: RemoteClawConfig): RemoteClawConfig {
     return normalized;
   }
 
-  const existingProviderApiKey =
-    typeof active.config?.apiKey === "string" ? active.config.apiKey.trim() : "";
-  const existingLegacyApiKey = typeof talk?.apiKey === "string" ? talk.apiKey.trim() : "";
-  if (existingProviderApiKey || existingLegacyApiKey) {
+  const existingProviderApiKeyConfigured = hasConfiguredSecretInput(active.config?.apiKey);
+  const existingLegacyApiKeyConfigured = hasConfiguredSecretInput(talk?.apiKey);
+  if (existingProviderApiKeyConfigured || existingLegacyApiKeyConfigured) {
     return normalized;
   }
 


### PR DESCRIPTION
## Summary

Re-applies 3 upstream security improvements that were silently discarded when PR #2191 wholesale-restored files from pre-v2026.3.1.

Closes #2201

### Changes

- **`src/acp/client.ts`** — Scoped read-tool auto-approval (~90 LoC). Auto-approves `read` calls only when the target path resolves within `cwd`, preventing unrestricted filesystem access. Adds `web_search` to safe auto-approve set. Excludes `memory_search` (gutted subsystem). New functions: `extractPathFromToolTitle`, `resolveToolPathCandidate`, `resolveAbsoluteScopedPath`, `isPathWithinRoot`, `isReadToolCallScopedToCwd`.

- **`src/commands/doctor-config-flow.ts`** — Allowlist policy detection + repair (~260 LoC). `detectEmptyAllowlistPolicy` warns when an empty allowlist silently blocks all DMs/group messages. `maybeRepairAllowlistPolicyAllowFrom` auto-recovers sender entries from the pairing store. Wired into both `--fix` and read-only doctor flows.

- **`src/config/defaults.ts`** — Replaces naive string-based API key check with `hasConfiguredSecretInput()` to properly handle secret references (`$ENV_VAR`, `op://vault/item`), preventing false negatives.

### Not included (already present)

- **`src/commands/agent.ts`** — `agentCommandFromIngress` with `senderIsOwner` enforcement was already in the current codebase (not lost during #2191 restoration).

## Test plan

- [x] TypeScript type-check passes (0 errors in src/)
- [x] oxlint passes (0 warnings, 0 errors)
- [x] oxfmt format check passes
- [x] `src/acp/client.test.ts` — 31/31 tests pass (including scoped read auto-approval tests)
- [x] `src/commands/doctor-config-flow.test.ts` — 17/17 tests pass
- [x] Full test suite: 12166 passed, 1 skipped (1 infra flake — worker fork crash, not related)
- [x] No new `@ts-expect-error` suppressions introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)