### PR TITLE
fix(cli): re-apply lost v2026.3.2 positional parsing fix for config routes

### DIFF
--- a/src/cli/program/routes.ts
+++ b/src/cli/program/routes.ts
@@ -1,5 +1,11 @@
 import { defaultRuntime } from "../../runtime.js";
-import { getFlagValue, getPositiveIntFlagValue, getVerboseFlag, hasFlag } from "../argv.js";
+import {
+  getCommandPositionalsWithRootOptions,
+  getFlagValue,
+  getPositiveIntFlagValue,
+  getVerboseFlag,
+  hasFlag,
+} from "../argv.js";
 
 export type RouteSpec = {
   match: (path: string[]) => boolean;
@@ -78,26 +84,17 @@ const routeAgentsList: RouteSpec = {
   },
 };
 
-function getCommandPositionals(argv: string[]): string[] {
-  const out: string[] = [];
-  const args = argv.slice(2);
-  for (const arg of args) {
-    if (!arg || arg === "--") {
-      break;
-    }
-    if (arg.startsWith("-")) {
-      continue;
-    }
-    out.push(arg);
-  }
-  return out;
-}
-
 const routeConfigGet: RouteSpec = {
   match: (path) => path[0] === "config" && path[1] === "get",
   run: async (argv) => {
-    const positionals = getCommandPositionals(argv);
-    const pathArg = positionals[2];
+    const positionals = getCommandPositionalsWithRootOptions(argv, {
+      commandPath: ["config", "get"],
+      booleanFlags: ["--json"],
+    });
+    if (!positionals || positionals.length !== 1) {
+      return false;
+    }
+    const pathArg = positionals[0];
     if (!pathArg) {
       return false;
     }
@@ -111,8 +108,13 @@ const routeConfigGet: RouteSpec = {
 const routeConfigUnset: RouteSpec = {
   match: (path) => path[0] === "config" && path[1] === "unset",
   run: async (argv) => {
-    const positionals = getCommandPositionals(argv);
-    const pathArg = positionals[2];
+    const positionals = getCommandPositionalsWithRootOptions(argv, {
+      commandPath: ["config", "unset"],
+    });
+    if (!positionals || positionals.length !== 1) {
+      return false;
+    }
+    const pathArg = positionals[0];
     if (!pathArg) {
       return false;
     }


### PR DESCRIPTION
## Summary

Re-applies the only applicable correctness fix from the post-remediation audit (#2202). Of the 4 findings identified:

- **Applied**: `routes.ts` — Replace naive `getCommandPositionals` with `getCommandPositionalsWithRootOptions` for `config get`/`config unset` routes. The old function skipped flags but didn't account for root options that take values (e.g. `--agent main`), causing `main` to be misparsed as a positional argument.
- **Not applicable (3)**: The remaining fixes target upstream code paths that don't exist in the fork:
  - `agent.ts` null safety (`result.meta?.agentMeta`/`result.meta?.aborted`) — fork uses `result.run.aborted` via ChannelBridge
  - `agent.ts` nullish coalescing (`fallbackProvider ?? provider`) — fork's `fallbackProvider` is const-assigned, never null
  - `heartbeat-runner.ts` regex word boundary — fork doesn't have `stripLeadingHeartbeatResponsePrefix` (only prepends, never strips)

Closes #2202

## Test plan

- [x] `routes.test.ts` — 9/9 passing (config get/unset validation cases)
- [x] `argv.test.ts` — 51/51 passing (includes `getCommandPositionalsWithRootOptions` with interleaved root options)
- [x] Full CLI test suite — 601/601 passing
- [x] Type-check, lint, format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)