### PR TITLE
feat(doctor,acp,routes): re-apply remaining medium-priority upstream improvements (#2208)

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -410,12 +410,24 @@ export async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpC
   const entryPath = resolveSelfEntryPath();
   const serverCommand = opts.serverCommand ?? (entryPath ? process.execPath : "remoteclaw");
   const effectiveArgs = opts.serverCommand || !entryPath ? serverArgs : [entryPath, ...serverArgs];
+  const spawnEnv = resolveAcpClientSpawnEnv();
+  const spawnInvocation = resolveAcpClientSpawnInvocation(
+    { serverCommand, serverArgs: effectiveArgs },
+    {
+      platform: process.platform,
+      env: spawnEnv,
+      execPath: process.execPath,
+    },
+  );
 
-  log(`spawning: ${serverCommand} ${effectiveArgs.join(" ")}`);
+  log(`spawning: ${spawnInvocation.command} ${spawnInvocation.args.join(" ")}`);
 
-  const agent = spawn(serverCommand, effectiveArgs, {
+  const agent = spawn(spawnInvocation.command, spawnInvocation.args, {
     stdio: ["pipe", "pipe", "inherit"],
     cwd,
+    env: spawnEnv,
+    shell: spawnInvocation.shell,
+    windowsHide: spawnInvocation.windowsHide,
   });
 
   if (!agent.stdin || !agent.stdout) {

--- a/src/cli/program/routes.ts
+++ b/src/cli/program/routes.ts
@@ -9,13 +9,13 @@ import {
 
 export type RouteSpec = {
   match: (path: string[]) => boolean;
-  loadPlugins?: boolean;
+  loadPlugins?: boolean | ((argv: string[]) => boolean);
   run: (argv: string[]) => Promise<boolean>;
 };
 
 const routeHealth: RouteSpec = {
   match: (path) => path[0] === "health",
-  loadPlugins: true,
+  loadPlugins: (argv) => !hasFlag(argv, "--json"),
   run: async (argv) => {
     const json = hasFlag(argv, "--json");
     const verbose = getVerboseFlag(argv, { includeDebug: true });

--- a/src/commands/doctor-legacy-config.ts
+++ b/src/commands/doctor-legacy-config.ts
@@ -1,6 +1,8 @@
 import { shouldMoveSingleAccountChannelKey } from "../channels/plugins/setup-helpers.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import {
+  formatSlackStreamingBooleanMigrationMessage,
+  formatSlackStreamModeMigrationMessage,
   resolveDiscordPreviewStreamMode,
   resolveSlackNativeStreaming,
   resolveSlackStreamingMode,
@@ -175,13 +177,11 @@ export function normalizeCompatibilityConfigValues(cfg: RemoteClawConfig): {
       const { streamMode: _ignored, ...rest } = updated;
       updated = rest;
       changed = true;
-      changes.push(
-        `Moved ${params.pathPrefix}.streamMode → ${params.pathPrefix}.streaming (${resolvedStreaming}).`,
-      );
+      changes.push(formatSlackStreamModeMigrationMessage(params.pathPrefix, resolvedStreaming));
     }
     if (typeof legacyStreaming === "boolean") {
       changes.push(
-        `Moved ${params.pathPrefix}.streaming (boolean) → ${params.pathPrefix}.nativeStreaming (${resolvedNativeStreaming}).`,
+        formatSlackStreamingBooleanMigrationMessage(params.pathPrefix, resolvedNativeStreaming),
       );
     } else if (typeof legacyStreaming === "string" && legacyStreaming !== resolvedStreaming) {
       changes.push(

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -32,6 +32,7 @@ import {
   noteMacLaunchAgentOverrides,
   noteMacLaunchctlGatewayEnvOverrides,
   noteDeprecatedLegacyEnvVars,
+  noteStartupOptimizationHints,
 } from "./doctor-platform-notes.js";
 import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
 import { noteSecurityWarnings } from "./doctor-security.js";
@@ -45,6 +46,7 @@ import { maybeRepairUiProtocolFreshness } from "./doctor-ui.js";
 import { maybeOfferUpdateBeforeDoctor } from "./doctor-update.js";
 import { noteVoiceChannelHealth } from "./doctor-voice.js";
 import { noteWorkspaceStatus } from "./doctor-workspace-status.js";
+import { noteOpenAIOAuthTlsPrerequisites } from "./oauth-tls-preflight.js";
 import { applyWizardMetadata, printWizardHeader, randomToken } from "./onboard-helpers.js";
 import { ensureSystemdUserLingerInteractive } from "./systemd-linger.js";
 
@@ -83,6 +85,7 @@ export async function doctorCommand(
   await maybeRepairUiProtocolFreshness(runtime, prompter);
   noteSourceInstallIssues(root);
   noteDeprecatedLegacyEnvVars();
+  noteStartupOptimizationHints();
 
   const configResult = await loadAndMaybeMigrateDoctorConfig({
     options,
@@ -187,6 +190,10 @@ export async function doctorCommand(
   await noteMacLaunchctlGatewayEnvOverrides(cfg);
 
   await noteSecurityWarnings(cfg);
+  await noteOpenAIOAuthTlsPrerequisites({
+    cfg,
+    deep: options.deep === true,
+  });
 
   if (
     options.nonInteractive !== true &&


### PR DESCRIPTION
## Summary

Re-applies 5 medium-priority upstream improvements from v2026.3.1/v2026.3.2 that were lost during PR #2191 wholesale file restoration.

Closes #2208

### Applied (5 of 7)

- **doctor.ts**: Import + call `noteStartupOptimizationHints()` — startup optimization doctor check (module `doctor-platform-notes.ts` exists)
- **doctor.ts**: Import + call `noteOpenAIOAuthTlsPrerequisites()` — OpenAI OAuth TLS prerequisites check (module `oauth-tls-preflight.ts` exists)
- **routes.ts**: Conditional `loadPlugins` for `health --json` — changes type from `boolean` to `boolean | function`, skips local plugin metadata loading for JSON health checks (consumer at `route.ts` already handles function type)
- **acp/client.ts**: Wire `resolveAcpClientSpawnInvocation` into `createAcpClient` — function existed but was unused; enables Windows `.cmd` shim handling and `windowsHide`
- **doctor-legacy-config.ts**: Replace inline Slack migration message strings with `formatSlackStreamModeMigrationMessage()` / `formatSlackStreamingBooleanMigrationMessage()` from `discord-preview-streaming.ts` (DRY refactor)

### Skipped (2 of 7)

- **config/defaults.ts `cacheRetention: "short"`** — already present in current code (lines 291-324)
- **sessions.ts CONTROL_UI filter** — not present in upstream v2026.3.1/v2026.3.2 diffs (`fdcbc3bd86~1..0241706c9d`); the improvement is not attributable to the B3/B4 sync

## Test plan

- [x] TypeScript type-check passes (zero errors in changed files)
- [x] Lint passes (oxlint --type-aware: 0 warnings, 0 errors)
- [x] Format check passes
- [x] All 694 test files pass (5949 tests)
- [ ] CI passes (build + test + lint + docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)