### PR TITLE
gut(acp): remove vestigial ACP stubs and dead call sites

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -1,14 +1,11 @@
 import { Type } from "@sinclair/typebox";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-const ACP_SPAWN_MODES: readonly string[] = ["run", "session"] as const;
-const spawnAcpDirect = (..._args: unknown[]) => undefined as unknown;
 import { optionalStringEnum } from "../schema/typebox.js";
 import { SUBAGENT_SPAWN_MODES, spawnSubagentDirect } from "../subagent-spawn.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam, ToolInputError } from "./common.js";
 
-const SESSIONS_SPAWN_RUNTIMES = ["subagent", "acp"] as const;
+const SESSIONS_SPAWN_RUNTIMES = ["subagent"] as const;
 const SESSIONS_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
 const UNSUPPORTED_SESSIONS_SPAWN_PARAM_KEYS = [
   "target",
@@ -28,7 +25,6 @@ const SessionsSpawnToolSchema = Type.Object({
   agentId: Type.Optional(Type.String()),
   model: Type.Optional(Type.String()),
   thinking: Type.Optional(Type.String()),
-  cwd: Type.Optional(Type.String()),
   runTimeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
   // Back-compat: older callers used timeoutSeconds for this tool.
   timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
@@ -76,7 +72,7 @@ export function createSessionsSpawnTool(opts?: {
     label: "Sessions",
     name: "sessions_spawn",
     description:
-      'Spawn an isolated session (runtime="subagent" or runtime="acp"). mode="run" is one-shot and mode="session" is persistent/thread-bound.',
+      'Spawn an isolated session. mode="run" is one-shot and mode="session" is persistent/thread-bound.',
     parameters: SessionsSpawnToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args;
@@ -90,11 +86,9 @@ export function createSessionsSpawnTool(opts?: {
       }
       const task = readStringParam(params, "task", { required: true });
       const label = typeof params.label === "string" ? params.label.trim() : "";
-      const runtime = params.runtime === "acp" ? "acp" : "subagent";
       const requestedAgentId = readStringParam(params, "agentId");
       const modelOverride = readStringParam(params, "model");
       const thinkingOverrideRaw = readStringParam(params, "thinking");
-      const cwd = readStringParam(params, "cwd");
       const mode = params.mode === "run" || params.mode === "session" ? params.mode : undefined;
       const cleanup =
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
@@ -119,36 +113,6 @@ export function createSessionsSpawnTool(opts?: {
             mimeType?: string;
           }>)
         : undefined;
-
-      if (runtime === "acp") {
-        if (Array.isArray(attachments) && attachments.length > 0) {
-          return jsonResult({
-            status: "error",
-            error:
-              "attachments are currently unsupported for runtime=acp; use runtime=subagent or remove attachments",
-          });
-        }
-        const result = await spawnAcpDirect(
-          {
-            task,
-            label: label || undefined,
-            agentId: requestedAgentId,
-            cwd,
-            mode: mode && ACP_SPAWN_MODES.includes(mode) ? mode : undefined,
-            thread,
-            sandbox,
-          },
-          {
-            agentSessionKey: opts?.agentSessionKey,
-            agentChannel: opts?.agentChannel,
-            agentAccountId: opts?.agentAccountId,
-            agentTo: opts?.agentTo,
-            agentThreadId: opts?.agentThreadId,
-            sandboxed: opts?.sandboxed,
-          },
-        );
-        return jsonResult(result);
-      }
 
       const result = await spawnSubagentDirect(
         {

--- a/src/auto-reply/reply/commands-subagents-focus.test.ts
+++ b/src/auto-reply/reply/commands-subagents-focus.test.ts
@@ -11,7 +11,6 @@ const hoisted = vi.hoisted(() => {
   const callGatewayMock = vi.fn();
   const getThreadBindingManagerMock = vi.fn();
   const resolveThreadBindingThreadNameMock = vi.fn(() => "🤖 codex");
-  const readAcpSessionEntryMock = vi.fn();
   const sessionBindingCapabilitiesMock = vi.fn();
   const sessionBindingBindMock = vi.fn();
   const sessionBindingResolveByConversationMock = vi.fn();
@@ -21,7 +20,6 @@ const hoisted = vi.hoisted(() => {
     callGatewayMock,
     getThreadBindingManagerMock,
     resolveThreadBindingThreadNameMock,
-    readAcpSessionEntryMock,
     sessionBindingCapabilitiesMock,
     sessionBindingBindMock,
     sessionBindingResolveByConversationMock,
@@ -54,10 +52,6 @@ function buildFocusSessionBindingService() {
 
 vi.mock("../../gateway/call.js", () => ({
   callGateway: hoisted.callGatewayMock,
-}));
-
-vi.mock("../../acp/runtime/session-meta.js", () => ({
-  readAcpSessionEntry: (params: unknown) => hoisted.readAcpSessionEntryMock(params),
 }));
 
 vi.mock("../../discord/monitor/thread-bindings.js", async (importOriginal) => {
@@ -298,7 +292,6 @@ describe("/focus, /unfocus, /agents", () => {
     hoisted.callGatewayMock.mockClear();
     hoisted.getThreadBindingManagerMock.mockClear().mockReturnValue(null);
     hoisted.resolveThreadBindingThreadNameMock.mockClear().mockReturnValue("🤖 codex");
-    hoisted.readAcpSessionEntryMock.mockReset().mockReturnValue(null);
     hoisted.sessionBindingCapabilitiesMock
       .mockReset()
       .mockReturnValue(createSessionBindingCapabilities());

--- a/src/auto-reply/reply/commands-subagents/action-focus.ts
+++ b/src/auto-reply/reply/commands-subagents/action-focus.ts
@@ -1,13 +1,3 @@
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "../../../acp/runtime/session-identifiers.js";
-// oxlint-disable-next-line typescript/no-explicit-any
-const resolveAcpSessionCwd = (..._args: unknown[]) => undefined as any;
-// oxlint-disable-next-line typescript/no-explicit-any
-const resolveAcpThreadSessionDetailLines = (..._args: unknown[]) => undefined as any;
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "../../../acp/runtime/session-meta.js";
-// oxlint-disable-next-line typescript/no-explicit-any
-const readAcpSessionEntry = (..._args: unknown[]) => undefined as any;
 import {
   resolveDiscordThreadBindingIdleTimeoutMs,
   resolveDiscordThreadBindingMaxAgeMs,
@@ -77,13 +67,6 @@ export async function handleSubagentsFocusAction(
   }
 
   const label = focusTarget.label || token;
-  const acpMeta =
-    focusTarget.targetKind === "acp"
-      ? readAcpSessionEntry({
-          cfg: params.cfg,
-          sessionKey: focusTarget.targetSessionKey,
-        })?.acp
-      : undefined;
   const placement = currentThreadId ? "current" : "child";
   if (!capabilities.placements.includes(placement)) {
     return stopWithText("⚠️ Discord thread bindings are unavailable for this account.");
@@ -123,14 +106,6 @@ export async function handleSubagentsFocusAction(
             cfg: params.cfg,
             accountId,
           }),
-          sessionCwd: focusTarget.targetKind === "acp" ? resolveAcpSessionCwd(acpMeta) : undefined,
-          sessionDetails:
-            focusTarget.targetKind === "acp"
-              ? resolveAcpThreadSessionDetailLines({
-                  sessionKey: focusTarget.targetSessionKey,
-                  meta: acpMeta,
-                })
-              : [],
         }),
       },
     });

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -31,12 +31,6 @@ const internalHookMocks = vi.hoisted(() => ({
   createInternalHookEvent: vi.fn(),
   triggerInternalHook: vi.fn(async () => {}),
 }));
-const acpMocks = vi.hoisted(() => ({
-  listAcpSessionEntries: vi.fn(async () => []),
-  readAcpSessionEntry: vi.fn<() => unknown>(() => null),
-  upsertAcpSessionMeta: vi.fn(async () => null),
-  requireAcpRuntimeBackend: vi.fn<() => unknown>(),
-}));
 const sessionBindingMocks = vi.hoisted(() => ({
   listBySession: vi.fn<(targetSessionKey: string) => SessionBindingRecord[]>(() => []),
 }));
@@ -107,14 +101,6 @@ vi.mock("../../hooks/internal-hooks.js", () => ({
   createInternalHookEvent: internalHookMocks.createInternalHookEvent,
   triggerInternalHook: internalHookMocks.triggerInternalHook,
 }));
-vi.mock("../../acp/runtime/session-meta.js", () => ({
-  listAcpSessionEntries: acpMocks.listAcpSessionEntries,
-  readAcpSessionEntry: acpMocks.readAcpSessionEntry,
-  upsertAcpSessionMeta: acpMocks.upsertAcpSessionMeta,
-}));
-vi.mock("../../acp/runtime/registry.js", () => ({
-  requireAcpRuntimeBackend: acpMocks.requireAcpRuntimeBackend,
-}));
 vi.mock("../../infra/outbound/session-binding-service.js", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../../infra/outbound/session-binding-service.js")>();
@@ -146,7 +132,6 @@ vi.mock("../../tts/tts.js", () => ({
 
 const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
 const { resetInboundDedupe } = await import("./inbound-dedupe.js");
-const acpManagerTesting = { resetForTest: () => {} } as Record<string, unknown>;
 
 const noAbortResult = { handled: false, aborted: false } as const;
 const emptyConfig = {} as RemoteClawConfig;
@@ -165,26 +150,6 @@ function createDispatcher(): ReplyDispatcher {
 
 function setNoAbort() {
   mocks.tryFastAbortFromMessage.mockResolvedValue(noAbortResult);
-}
-
-function createAcpRuntime(events: Array<Record<string, unknown>>) {
-  return {
-    ensureSession: vi.fn(
-      async (input: { sessionKey: string; mode: string; agent: string }) =>
-        ({
-          sessionKey: input.sessionKey,
-          backend: "acpx",
-          runtimeSessionName: `${input.sessionKey}:${input.mode}`,
-        }) as { sessionKey: string; backend: string; runtimeSessionName: string },
-    ),
-    runTurn: vi.fn(async function* () {
-      for (const event of events) {
-        yield event;
-      }
-    }),
-    cancel: vi.fn(async () => {}),
-    close: vi.fn(async () => {}),
-  };
 }
 
 function firstToolResultPayload(dispatcher: ReplyDispatcher): ReplyPayload | undefined {
@@ -206,11 +171,9 @@ async function dispatchTwiceWithFreshDispatchers(params: Omit<DispatchReplyArgs,
 
 describe("dispatchReplyFromConfig", () => {
   beforeEach(() => {
-    (acpManagerTesting as Record<string, () => void>).resetAcpSessionManagerForTests?.();
     resetInboundDedupe();
     mocks.routeReply.mockReset();
     mocks.routeReply.mockResolvedValue({ ok: true, messageId: "mock" });
-    acpMocks.listAcpSessionEntries.mockReset().mockResolvedValue([]);
     diagnosticMocks.logMessageQueued.mockClear();
     diagnosticMocks.logMessageProcessed.mockClear();
     diagnosticMocks.logSessionStateChange.mockClear();
@@ -220,11 +183,6 @@ describe("dispatchReplyFromConfig", () => {
     internalHookMocks.createInternalHookEvent.mockClear();
     internalHookMocks.createInternalHookEvent.mockImplementation(createInternalHookEventPayload);
     internalHookMocks.triggerInternalHook.mockClear();
-    acpMocks.readAcpSessionEntry.mockReset();
-    acpMocks.readAcpSessionEntry.mockReturnValue(null);
-    acpMocks.upsertAcpSessionMeta.mockReset();
-    acpMocks.upsertAcpSessionMeta.mockResolvedValue(null);
-    acpMocks.requireAcpRuntimeBackend.mockReset();
     sessionBindingMocks.listBySession.mockReset();
     sessionBindingMocks.listBySession.mockReturnValue([]);
     ttsMocks.state.synthesizeFinalAudio = false;
@@ -591,60 +549,6 @@ describe("dispatchReplyFromConfig", () => {
 
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({
       text: "⚙️ Agent was aborted. Stopped 2 sub-agents.",
-    });
-  });
-
-  it("routes ACP slash commands through the normal command pipeline", async () => {
-    setNoAbort();
-    const runtime = createAcpRuntime([{ type: "done" }]);
-    acpMocks.readAcpSessionEntry.mockReturnValue({
-      sessionKey: "agent:codex-acp:session-1",
-      storeSessionKey: "agent:codex-acp:session-1",
-      cfg: {},
-      storePath: "/tmp/mock-sessions.json",
-      entry: {},
-      acp: {
-        backend: "acpx",
-        agent: "codex",
-        runtimeSessionName: "runtime:1",
-        mode: "persistent",
-        state: "idle",
-        lastActivityAt: Date.now(),
-      },
-    });
-    acpMocks.requireAcpRuntimeBackend.mockReturnValue({
-      id: "acpx",
-      runtime,
-    });
-
-    const cfg = {
-      acp: {
-        enabled: true,
-        dispatch: { enabled: true },
-      },
-      session: {
-        sendPolicy: {
-          default: "deny",
-        },
-      },
-    } as RemoteClawConfig;
-    const dispatcher = createDispatcher();
-    const ctx = buildTestCtx({
-      Provider: "discord",
-      Surface: "discord",
-      SessionKey: "agent:codex-acp:session-1",
-      CommandBody: "/acp cancel",
-      BodyForCommands: "/acp cancel",
-      BodyForAgent: "/acp cancel",
-    });
-    const replyResolver = vi.fn(async () => ({ text: "command output" }) as ReplyPayload);
-
-    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
-
-    expect(replyResolver).toHaveBeenCalledTimes(1);
-    expect(runtime.runTurn).not.toHaveBeenCalled();
-    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({
-      text: "command output",
     });
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -17,17 +17,12 @@ import {
   logSessionStateChange,
 } from "../../logging/diagnostic.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { getReplyFromConfig } from "../reply.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { formatAbortReplyText, tryFastAbortFromMessage } from "./abort.js";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-const shouldBypassAcpDispatchForCommand = (..._args: unknown[]) => true;
-const tryDispatchAcpReply = async (..._args: unknown[]) =>
-  undefined as { queuedFinal: boolean; counts: Record<string, number> } | undefined;
 import { shouldSkipDuplicateInbound } from "./inbound-dedupe.js";
 import type { ReplyDispatcher, ReplyDispatchKind } from "./reply-dispatcher.js";
 import { shouldSuppressReasoningPayload } from "./reply-payloads.js";
@@ -302,51 +297,7 @@ export async function dispatchReplyFromConfig(params: {
       return { queuedFinal, counts };
     }
 
-    const bypassAcpForCommand = shouldBypassAcpDispatchForCommand(ctx, cfg);
-
-    const sendPolicy = resolveSendPolicy({
-      cfg,
-      entry: sessionStoreEntry.entry,
-      sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
-      channel:
-        sessionStoreEntry.entry?.channel ??
-        ctx.OriginatingChannel ??
-        ctx.Surface ??
-        ctx.Provider ??
-        undefined,
-      chatType: sessionStoreEntry.entry?.chatType,
-    });
-    if (sendPolicy === "deny" && !bypassAcpForCommand) {
-      logVerbose(
-        `Send blocked by policy for session ${sessionStoreEntry.sessionKey ?? sessionKey ?? "unknown"}`,
-      );
-      const counts = dispatcher.getQueuedCounts();
-      recordProcessed("completed", { reason: "send_policy_deny" });
-      markIdle("message_completed");
-      return { queuedFinal: false, counts };
-    }
-
     const shouldSendToolSummaries = ctx.ChatType !== "group" && ctx.CommandSource !== "native";
-    const acpDispatch = await tryDispatchAcpReply({
-      ctx,
-      cfg,
-      dispatcher,
-      sessionKey,
-      inboundAudio,
-      sessionTtsAuto,
-      ttsChannel,
-      shouldRouteToOriginating,
-      originatingChannel,
-      originatingTo,
-      shouldSendToolSummaries,
-      bypassForCommand: bypassAcpForCommand,
-      onReplyStart: params.replyOptions?.onReplyStart,
-      recordProcessed,
-      markIdle,
-    });
-    if (acpDispatch) {
-      return acpDispatch;
-    }
 
     // Track accumulated block text for TTS generation after streaming completes.
     // When block streaming succeeds, there's no final reply, so we need to generate

--- a/src/discord/monitor/thread-bindings.discord-api.ts
+++ b/src/discord/monitor/thread-bindings.discord-api.ts
@@ -3,9 +3,6 @@ import { logVerbose } from "../../globals.js";
 import { createDiscordRestClient } from "../client.js";
 import { sendMessageDiscord, sendWebhookMessageDiscord } from "../send.js";
 import { createThreadDiscord } from "../send.messages.js";
-// import { summarizeBindingPersona } from "./thread-bindings.messages.js"; // Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// oxlint-disable-next-line typescript/no-explicit-any
-const summarizeBindingPersona = (..._args: unknown[]) => undefined as any;
 import {
   BINDINGS_BY_THREAD_ID,
   REUSABLE_WEBHOOKS_BY_ACCOUNT_CHANNEL,
@@ -140,7 +137,7 @@ export async function maybeSendBindingMessage(params: {
         webhookToken: record.webhookToken,
         accountId: record.accountId,
         threadId: record.threadId,
-        username: summarizeBindingPersona(record),
+        username: undefined,
       });
       return;
     } catch (err) {

--- a/src/discord/monitor/thread-bindings.lifecycle.test.ts
+++ b/src/discord/monitor/thread-bindings.lifecycle.test.ts
@@ -22,7 +22,6 @@ const hoisted = vi.hoisted(() => {
     },
   }));
   const createThreadDiscord = vi.fn(async (..._args: unknown[]) => ({ id: "thread-created" }));
-  const readAcpSessionEntry = vi.fn();
   return {
     sendMessageDiscord,
     sendWebhookMessageDiscord,
@@ -30,7 +29,6 @@ const hoisted = vi.hoisted(() => {
     restPost,
     createDiscordRestClient,
     createThreadDiscord,
-    readAcpSessionEntry,
   };
 });
 
@@ -45,10 +43,6 @@ vi.mock("../client.js", () => ({
 
 vi.mock("../send.messages.js", () => ({
   createThreadDiscord: hoisted.createThreadDiscord,
-}));
-
-vi.mock("../../acp/runtime/session-meta.js", () => ({
-  readAcpSessionEntry: hoisted.readAcpSessionEntry,
 }));
 
 const {
@@ -71,7 +65,6 @@ describe("thread binding lifecycle", () => {
     hoisted.restPost.mockClear();
     hoisted.createDiscordRestClient.mockClear();
     hoisted.createThreadDiscord.mockClear();
-    hoisted.readAcpSessionEntry.mockReset().mockReturnValue(null);
     vi.useRealTimers();
   });
 

--- a/src/discord/monitor/thread-bindings.lifecycle.ts
+++ b/src/discord/monitor/thread-bindings.lifecycle.ts
@@ -1,7 +1,3 @@
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-// import ... from "../../acp/runtime/session-meta.js";
-// oxlint-disable-next-line typescript/no-explicit-any
-const readAcpSessionEntry = (..._args: unknown[]) => undefined as any;
 import type { RemoteClawConfig } from "../../config/config.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
 import { parseDiscordTarget } from "../targets.js";
@@ -277,21 +273,8 @@ export function reconcileAcpThreadBindingsOnStartup(params: {
   }
 
   const acpBindings = manager.listBindings().filter((binding) => binding.targetKind === "acp");
-  const staleBindings = acpBindings.filter((binding) => {
-    const sessionKey = binding.targetSessionKey.trim();
-    if (!sessionKey) {
-      return true;
-    }
-    const session = readAcpSessionEntry({
-      cfg: params.cfg,
-      sessionKey,
-    });
-    // Session store read failures are transient; never auto-unbind on uncertain reads.
-    if (session?.storeReadFailed) {
-      return false;
-    }
-    return !session?.acp;
-  });
+  // ACP runtime was removed — all ACP-kind bindings are stale by definition.
+  const staleBindings = acpBindings;
   if (staleBindings.length === 0) {
     return {
       checked: acpBindings.length,

--- a/src/discord/monitor/thread-bindings.ts
+++ b/src/discord/monitor/thread-bindings.ts
@@ -9,11 +9,6 @@ export {
   resolveThreadBindingIntroText,
   resolveThreadBindingThreadName,
 } from "./thread-bindings.messages.js";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle) — thread-bindings.persona removed
-// oxlint-disable-next-line typescript/no-explicit-any
-export const resolveThreadBindingPersona = (..._args: unknown[]) => undefined as any;
-// oxlint-disable-next-line typescript/no-explicit-any
-export const resolveThreadBindingPersonaFromRecord = (..._args: unknown[]) => undefined as any;
 
 export {
   resolveDiscordThreadBindingIdleTimeoutMs,


### PR DESCRIPTION
## Summary

Closes #2148

- Remove 10 ACP stubs across 6 source files and the dead code paths they guarded
- Clean up ACP mocks in 3 test files to match production stub removal
- `src/acp/` and `src/plugin-sdk/index.ts` ACP re-exports are untouched (alive infrastructure)
- Net: **-250 lines** across 9 files

### Source files (6)

| File | Stubs removed | Dead code removed |
|------|--------------|-------------------|
| `dispatch-from-config.ts` | `shouldBypassAcpDispatchForCommand`, `tryDispatchAcpReply` | send-policy-deny block, ACP dispatch block |
| `action-focus.ts` | `resolveAcpSessionCwd`, `resolveAcpThreadSessionDetailLines`, `readAcpSessionEntry` | `acpMeta` variable, ACP-specific intro text params |
| `thread-bindings.lifecycle.ts` | `readAcpSessionEntry` | Simplified reconciliation (all ACP bindings now stale by definition) |
| `sessions-spawn-tool.ts` | `spawnAcpDirect`, `ACP_SPAWN_MODES` | `runtime="acp"` branch, `cwd` schema field (ACP-only) |
| `thread-bindings.ts` | `resolveThreadBindingPersona`, `resolveThreadBindingPersonaFromRecord` | — |
| `thread-bindings.discord-api.ts` | `summarizeBindingPersona` | — |

### Test files (3)

| File | Changes |
|------|---------|
| `dispatch-from-config.test.ts` | Remove ACP module mocks, ACP runtime helper, ACP-specific test case |
| `commands-subagents-focus.test.ts` | Remove `readAcpSessionEntry` mock |
| `thread-bindings.lifecycle.test.ts` | Remove `readAcpSessionEntry` mock |

## Test plan

- [x] `pnpm check` passes (format + typecheck + lint)
- [x] All 3 affected test files pass (44 tests total)
- [ ] CI build + test jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)