### PR TITLE
gut(agents): remove `default` field from AgentConfig, introduce sole-agent auto-selection

### DIFF
--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -27,7 +27,7 @@ function resolveOwnershipAgent(config: RemoteClawConfig): { id: string; name: st
         Boolean(entry && typeof entry === "object"),
       )
     : [];
-  const selected = list.find((entry) => entry.default === true) ?? list[0];
+  const selected = list[0];
 
   const id =
     typeof selected?.id === "string" && selected.id.trim() ? selected.id.trim() : "unknown";

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RemoteClawConfig } from "../config/config.js";
 import {
+  requireSoleAgentId,
   resolveAgentAuth,
   resolveAgentConfig,
   resolveAgentDir,
@@ -10,6 +11,7 @@ import {
   resolveAgentRuntimeEnv,
   resolveAgentRuntimeOrThrow,
   resolveFallbackAgentId,
+  resolveSoleAgentId,
   resolveAgentWorkspaceDir,
   resolveAgentWorkspaceDirOrNull,
 } from "./agent-scope.js";
@@ -244,6 +246,70 @@ describe("resolveAgentConfig", () => {
     };
     const result = resolveAgentConfig(cfg, "main");
     expect(result?.runtime).toBe("gemini");
+  });
+});
+
+describe("resolveSoleAgentId", () => {
+  it("returns agent ID when exactly one agent is configured", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "home", workspace: "~/remoteclaw" }] },
+    };
+    expect(resolveSoleAgentId(cfg)).toBe("home");
+  });
+
+  it("returns null when no agents are configured", () => {
+    expect(resolveSoleAgentId({})).toBeNull();
+  });
+
+  it("returns null when agents list is empty", () => {
+    const cfg: RemoteClawConfig = { agents: { list: [] } };
+    expect(resolveSoleAgentId(cfg)).toBeNull();
+  });
+
+  it("returns null when multiple agents are configured", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "home" }, { id: "work" }] },
+    };
+    expect(resolveSoleAgentId(cfg)).toBeNull();
+  });
+
+  it("normalizes the agent ID", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "  MyAgent  " }] },
+    };
+    expect(resolveSoleAgentId(cfg)).toBe("myagent");
+  });
+});
+
+describe("requireSoleAgentId", () => {
+  it("returns agent ID when exactly one agent is configured", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "home", workspace: "~/remoteclaw" }] },
+    };
+    expect(requireSoleAgentId(cfg)).toBe("home");
+  });
+
+  it("throws when no agents are configured", () => {
+    expect(() => requireSoleAgentId({})).toThrow("No agents configured");
+  });
+
+  it("throws when agents list is empty", () => {
+    const cfg: RemoteClawConfig = { agents: { list: [] } };
+    expect(() => requireSoleAgentId(cfg)).toThrow("No agents configured");
+  });
+
+  it("throws when multiple agents are configured", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "home" }, { id: "work" }] },
+    };
+    expect(() => requireSoleAgentId(cfg)).toThrow("Multiple agents configured");
+  });
+
+  it("includes agent IDs in the multi-agent error message", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "home" }, { id: "work" }] },
+    };
+    expect(() => requireSoleAgentId(cfg)).toThrow("home, work");
   });
 });
 

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import type { RemoteClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
-import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   DEFAULT_AGENT_ID,
   normalizeAgentId,
@@ -9,7 +8,6 @@ import {
   resolveAgentIdFromSessionKey,
 } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
-const log = createSubsystemLogger("agent-scope");
 
 /** Strip null bytes from paths to prevent ENOTDIR errors. */
 function stripNullBytes(s: string): string {
@@ -39,8 +37,6 @@ type ResolvedAgentConfig = {
   runtimeEnv?: AgentEntry["runtimeEnv"];
 };
 
-let defaultAgentWarned = false;
-
 export function listAgentEntries(cfg: RemoteClawConfig): AgentEntry[] {
   const list = cfg.agents?.list;
   if (!Array.isArray(list)) {
@@ -67,18 +63,48 @@ export function listAgentIds(cfg: RemoteClawConfig): string[] {
   return ids.length > 0 ? ids : [DEFAULT_AGENT_ID];
 }
 
-export function resolveDefaultAgentId(cfg: RemoteClawConfig): string {
+/**
+ * Returns the sole agent's ID when exactly one agent is configured, or null otherwise.
+ *
+ * Use this instead of the deprecated `resolveDefaultAgentId` for new code.
+ */
+export function resolveSoleAgentId(cfg: RemoteClawConfig): string | null {
+  const agents = listAgentEntries(cfg);
+  if (agents.length !== 1) {
+    return null;
+  }
+  const id = agents[0]?.id?.trim();
+  return id ? normalizeAgentId(id) : null;
+}
+
+/**
+ * Returns the sole agent's ID when exactly one agent is configured, or throws.
+ *
+ * @throws {Error} when zero or multiple agents are configured.
+ */
+export function requireSoleAgentId(cfg: RemoteClawConfig): string {
   const agents = listAgentEntries(cfg);
   if (agents.length === 0) {
-    return DEFAULT_AGENT_ID;
+    throw new Error("No agents configured — add at least one entry to agents.list");
   }
-  const defaults = agents.filter((agent) => agent?.default);
-  if (defaults.length > 1 && !defaultAgentWarned) {
-    defaultAgentWarned = true;
-    log.warn("Multiple agents marked default=true; using the first entry as default.");
+  if (agents.length > 1) {
+    throw new Error(
+      `Multiple agents configured (${agents.map((a) => a.id).join(", ")}); sole-agent auto-selection requires exactly one`,
+    );
   }
-  const chosen = (defaults[0] ?? agents[0])?.id?.trim();
-  return normalizeAgentId(chosen || DEFAULT_AGENT_ID);
+  const id = agents[0]?.id?.trim();
+  if (!id) {
+    throw new Error("Agent entry has no id — every agents.list entry requires an id");
+  }
+  return normalizeAgentId(id);
+}
+
+/**
+ * @deprecated Use {@link resolveSoleAgentId} or {@link requireSoleAgentId} instead.
+ * Temporary shim — will be removed once all callers migrate (#1576–#1581).
+ */
+export function resolveDefaultAgentId(cfg: RemoteClawConfig): string {
+  return resolveSoleAgentId(cfg) ?? DEFAULT_AGENT_ID;
 }
 
 export function resolveSessionAgentIds(params: {

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -289,10 +289,7 @@ describe("agentCommand", () => {
           systemSent: true,
         },
       });
-      mockConfig(home, storePattern, undefined, undefined, [
-        { id: "dev" },
-        { id: "exec", default: true },
-      ]);
+      mockConfig(home, storePattern, undefined, undefined, [{ id: "dev" }, { id: "exec" }]);
 
       // Should not throw — session resolves through cross-agent store lookup.
       await agentCommand({ message: "resume me", sessionId: "session-exec-hook" }, runtime);

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -18,7 +18,7 @@ describe("agents helpers", () => {
           { id: "main", workspace: "/main-ws" },
           {
             id: "work",
-            default: true,
+
             name: "Work",
             workspace: "/work-ws",
             agentDir: "/state/agents/work/agent",
@@ -217,7 +217,7 @@ describe("agents helpers", () => {
     const cfg: RemoteClawConfig = {
       agents: {
         list: [
-          { id: "work", default: true, workspace: "/work-ws" },
+          { id: "work", workspace: "/work-ws" },
           { id: "home", workspace: "/home-ws" },
         ],
       },

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -232,10 +232,7 @@ describe("getHealthSnapshot", () => {
             target: "last",
           },
         },
-        list: [
-          { id: "main", default: true },
-          { id: "ops", heartbeat: { every: "1h", target: "whatsapp" } },
-        ],
+        list: [{ id: "main" }, { id: "ops", heartbeat: { every: "1h", target: "whatsapp" } }],
       },
     };
     testStore = {};

--- a/src/commands/import.test.ts
+++ b/src/commands/import.test.ts
@@ -109,7 +109,7 @@ describe("materializeWorkspaceDefaults", () => {
   it("sets workspace on non-default agent using id suffix", () => {
     const input = JSON.stringify({
       agents: {
-        list: [{ id: "main", default: true, workspace: "~/ws" }, { id: "helper" }],
+        list: [{ id: "main", workspace: "~/ws" }, { id: "helper" }],
       },
     });
     const result = JSON.parse(materializeWorkspaceDefaults(input));

--- a/src/commands/sessions.default-agent-store.test.ts
+++ b/src/commands/sessions.default-agent-store.test.ts
@@ -9,10 +9,7 @@ const loadConfigMock = vi.hoisted(() =>
         models: { "pi:opus": {} },
         contextTokens: 32000,
       },
-      list: [
-        { id: "main", default: false },
-        { id: "voice", default: true },
-      ],
+      list: [{ id: "main" }, { id: "voice" }],
     },
     session: {
       store: "/tmp/sessions-{agentId}.json",

--- a/src/config/agent-dirs.ts
+++ b/src/config/agent-dirs.ts
@@ -33,8 +33,7 @@ function collectReferencedAgentIds(cfg: RemoteClawConfig): string[] {
   const ids = new Set<string>();
 
   const agents = Array.isArray(cfg.agents?.list) ? cfg.agents?.list : [];
-  const defaultAgentId =
-    agents.find((agent) => agent?.default)?.id ?? agents[0]?.id ?? DEFAULT_AGENT_ID;
+  const defaultAgentId = agents[0]?.id ?? DEFAULT_AGENT_ID;
   ids.add(normalizeAgentId(defaultAgentId));
 
   for (const entry of agents) {

--- a/src/config/legacy.rules.ts
+++ b/src/config/legacy.rules.ts
@@ -109,7 +109,7 @@ export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
   {
     path: ["routing", "defaultAgentId"],
     message:
-      "routing.defaultAgentId was moved; use agents.list[].default instead (auto-migrated on load).",
+      "routing.defaultAgentId was removed; sole-agent auto-selection replaces explicit defaults (auto-migrated on load).",
   },
   {
     path: ["routing", "agentToAgent"],

--- a/src/config/legacy.shared.ts
+++ b/src/config/legacy.shared.ts
@@ -94,16 +94,14 @@ export const getAgentsList = (agents: Record<string, unknown> | null) => {
 export const resolveDefaultAgentIdFromRaw = (raw: Record<string, unknown>) => {
   const agents = getRecord(raw.agents);
   const list = getAgentsList(agents);
-  const defaultEntry = list.find(
-    (entry): entry is { id: string } =>
-      isRecord(entry) &&
-      entry.default === true &&
-      typeof entry.id === "string" &&
-      entry.id.trim() !== "",
-  );
-  if (defaultEntry) {
-    return defaultEntry.id.trim();
+  // Sole-agent auto-selection: use the agent's ID when exactly one is configured.
+  if (list.length === 1) {
+    const entry = list[0];
+    if (isRecord(entry) && typeof entry.id === "string" && entry.id.trim() !== "") {
+      return entry.id.trim();
+    }
   }
+  // Legacy fallback: routing.defaultAgentId (migrated on load).
   const routing = getRecord(raw.routing);
   const routingDefault =
     typeof routing?.defaultAgentId === "string" ? routing.defaultAgentId.trim() : "";

--- a/src/config/merge-patch.test.ts
+++ b/src/config/merge-patch.test.ts
@@ -86,7 +86,7 @@ describe("applyMergePatch", () => {
     const base = {
       agents: {
         list: [
-          { id: "main", default: true, workspace: "/home/main" },
+          { id: "main", workspace: "/home/main" },
           { id: "ota", workspace: "/home/ota" },
           { id: "trading", workspace: "/home/trading" },
           { id: "codex", workspace: "/home/codex" },
@@ -103,13 +103,12 @@ describe("applyMergePatch", () => {
       mergeObjectArraysById: true,
     }) as {
       agents?: {
-        list?: Array<{ id?: string; workspace?: string; model?: string; default?: boolean }>;
+        list?: Array<{ id?: string; workspace?: string; model?: string }>;
       };
     };
     expect(merged.agents?.list).toHaveLength(4);
     const main = merged.agents?.list?.find((entry) => entry.id === "main");
     expect(main?.model).toBe("claude-opus-4-20250918");
-    expect(main?.default).toBe(true);
     expect(main?.workspace).toBe("/home/main");
     expect(merged.agents?.list?.find((entry) => entry.id === "ota")?.workspace).toBe("/home/ota");
     expect(merged.agents?.list?.find((entry) => entry.id === "trading")?.workspace).toBe(

--- a/src/config/sessions/main-session.ts
+++ b/src/config/sessions/main-session.ts
@@ -10,14 +10,13 @@ import type { SessionScope } from "./types.js";
 
 export function resolveMainSessionKey(cfg?: {
   session?: { scope?: SessionScope; mainKey?: string };
-  agents?: { list?: Array<{ id?: string; default?: boolean }> };
+  agents?: { list?: Array<{ id?: string }> };
 }): string {
   if (cfg?.session?.scope === "global") {
     return "global";
   }
   const agents = cfg?.agents?.list ?? [];
-  const defaultAgentId =
-    agents.find((agent) => agent?.default)?.id ?? agents[0]?.id ?? DEFAULT_AGENT_ID;
+  const defaultAgentId = agents[0]?.id ?? DEFAULT_AGENT_ID;
   const agentId = normalizeAgentId(defaultAgentId);
   const mainKey = normalizeMainKey(cfg?.session?.mainKey);
   return buildAgentMainSessionKey({ agentId, mainKey });

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -7,7 +7,6 @@ import type { AgentToolsConfig } from "./types.tools.js";
 
 export type AgentConfig = {
   id: string;
-  default?: boolean;
   name?: string;
   workspace?: string;
   agentDir?: string;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -689,7 +689,6 @@ export { AgentModelSchema };
 export const AgentEntrySchema = z
   .object({
     id: z.string(),
-    default: z.boolean().optional(),
     name: z.string().optional(),
     workspace: z.string().optional(),
     agentDir: z.string().optional(),

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -33,7 +33,7 @@ describe("gateway hooks helpers", () => {
         allowedAgentIds,
       },
       agents: {
-        list: [{ id: "main", default: true }, { id: "hooks" }],
+        list: [{ id: "main" }, { id: "hooks" }],
       },
     }) as RemoteClawConfig;
 
@@ -162,7 +162,7 @@ describe("gateway hooks helpers", () => {
     const cfg = {
       hooks: { enabled: true, token: "secret" },
       agents: {
-        list: [{ id: "main", default: true }, { id: "hooks" }],
+        list: [{ id: "main" }, { id: "hooks" }],
       },
     } as RemoteClawConfig;
     const resolved = resolveHooksConfig(cfg);

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -472,7 +472,7 @@ describe("gateway agent handler", () => {
     mocks.loadSessionEntry.mockReturnValue({
       cfg: {
         session: { mainKey: "work" },
-        agents: { list: [{ id: "main", default: true }] },
+        agents: { list: [{ id: "main" }] },
       },
       storePath: "/tmp/sessions.json",
       entry: {

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -63,7 +63,7 @@ describe("gateway server sessions", () => {
       store: path.join(dir, "{agentId}", "sessions.json"),
     };
     testState.agentsConfig = {
-      list: [{ id: "home", default: true }, { id: "work" }],
+      list: [{ id: "home" }, { id: "work" }],
     };
     const homeDir = path.join(dir, "home");
     const workDir = path.join(dir, "work");

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -44,7 +44,7 @@ async function postHook(
 
 function setMainAndHooksAgents(): void {
   testState.agentsConfig = {
-    list: [{ id: "main", default: true }, { id: "hooks" }],
+    list: [{ id: "main" }, { id: "hooks" }],
   };
 }
 
@@ -337,7 +337,7 @@ describe("gateway server hooks", () => {
       allowedAgentIds: [],
     };
     testState.agentsConfig = {
-      list: [{ id: "main", default: true }, { id: "hooks" }],
+      list: [{ id: "main" }, { id: "hooks" }],
     };
     await withGatewayServer(async ({ port }) => {
       const resDenied = await postHook(port, "/hooks/agent", {

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -201,7 +201,7 @@ describe("gateway server sessions", () => {
 
   test("sessions.preview resolves legacy mixed-case main alias with custom mainKey", async () => {
     const { dir, storePath } = await createSessionStoreDir();
-    testState.agentsConfig = { list: [{ id: "ops", default: true }] };
+    testState.agentsConfig = { list: [{ id: "ops" }] };
     testState.sessionConfig = { mainKey: "work" };
     const sessionId = "sess-legacy-main";
     const transcriptPath = path.join(dir, `${sessionId}.jsonl`);

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -35,7 +35,7 @@ function createSingleAgentAvatarConfig(workspace: string): RemoteClawConfig {
   return {
     session: { mainKey: "main" },
     agents: {
-      list: [{ id: "main", default: true, workspace, identity: { avatar: "avatar-link.png" } }],
+      list: [{ id: "main", workspace, identity: { avatar: "avatar-link.png" } }],
     },
   } as RemoteClawConfig;
 }
@@ -105,7 +105,7 @@ describe("gateway session utils", () => {
   test("resolveSessionStoreKey maps main aliases to default agent main", () => {
     const cfg = {
       session: { mainKey: "work" },
-      agents: { list: [{ id: "ops", default: true }] },
+      agents: { list: [{ id: "ops" }] },
     } as RemoteClawConfig;
     expect(resolveSessionStoreKey({ cfg, sessionKey: "main" })).toBe("agent:ops:work");
     expect(resolveSessionStoreKey({ cfg, sessionKey: "work" })).toBe("agent:ops:work");
@@ -118,7 +118,7 @@ describe("gateway session utils", () => {
   test("resolveSessionStoreKey canonicalizes bare keys to default agent", () => {
     const cfg = {
       session: { mainKey: "main" },
-      agents: { list: [{ id: "ops", default: true }] },
+      agents: { list: [{ id: "ops" }] },
     } as RemoteClawConfig;
     expect(resolveSessionStoreKey({ cfg, sessionKey: "discord:group:123" })).toBe(
       "agent:ops:discord:group:123",
@@ -150,7 +150,7 @@ describe("gateway session utils", () => {
   test("resolveSessionStoreKey normalizes session key casing", () => {
     const cfg = {
       session: { mainKey: "main" },
-      agents: { list: [{ id: "ops", default: true }] },
+      agents: { list: [{ id: "ops" }] },
     } as RemoteClawConfig;
     // Bare keys with different casing must resolve to the same canonical key
     expect(resolveSessionStoreKey({ cfg, sessionKey: "CoP" })).toBe(
@@ -167,7 +167,7 @@ describe("gateway session utils", () => {
   test("resolveSessionStoreKey honors global scope", () => {
     const cfg = {
       session: { scope: "global", mainKey: "work" },
-      agents: { list: [{ id: "ops", default: true }] },
+      agents: { list: [{ id: "ops" }] },
     } as RemoteClawConfig;
     expect(resolveSessionStoreKey({ cfg, sessionKey: "main" })).toBe("global");
     const target = resolveGatewaySessionStoreTarget({ cfg, key: "main" });
@@ -184,7 +184,7 @@ describe("gateway session utils", () => {
     );
     const cfg = {
       session: { mainKey: "main", store: storeTemplate },
-      agents: { list: [{ id: "ops", default: true }] },
+      agents: { list: [{ id: "ops" }] },
     } as RemoteClawConfig;
     const target = resolveGatewaySessionStoreTarget({ cfg, key: "main" });
     expect(target.canonicalKey).toBe("agent:ops:main");
@@ -203,7 +203,7 @@ describe("gateway session utils", () => {
     );
     const cfg = {
       session: { mainKey: "main", store: storePath },
-      agents: { list: [{ id: "ops", default: true }] },
+      agents: { list: [{ id: "ops" }] },
     } as RemoteClawConfig;
     // Client passes the lowercased canonical key (as returned by sessions.list)
     const target = resolveGatewaySessionStoreTarget({ cfg, key: "agent:ops:mysession" });
@@ -232,7 +232,7 @@ describe("gateway session utils", () => {
     );
     const cfg = {
       session: { mainKey: "main", store: storePath },
-      agents: { list: [{ id: "ops", default: true }] },
+      agents: { list: [{ id: "ops" }] },
     } as RemoteClawConfig;
     const target = resolveGatewaySessionStoreTarget({ cfg, key: "agent:ops:mysession" });
     // storeKeys must include BOTH variants so delete/reset/patch can clean up all duplicates
@@ -252,7 +252,7 @@ describe("gateway session utils", () => {
     );
     const cfg = {
       session: { mainKey: "work", store: storePath },
-      agents: { list: [{ id: "ops", default: true }] },
+      agents: { list: [{ id: "ops" }] },
     } as RemoteClawConfig;
     const target = resolveGatewaySessionStoreTarget({ cfg, key: "agent:ops:main" });
     expect(target.canonicalKey).toBe("agent:ops:work");
@@ -530,7 +530,7 @@ describe("deriveSessionTitle", () => {
 describe("listSessionsFromStore search", () => {
   const baseCfg = {
     session: { mainKey: "main" },
-    agents: { list: [{ id: "main", default: true }] },
+    agents: { list: [{ id: "main" }] },
   } as RemoteClawConfig;
 
   const makeStore = (): Record<string, SessionEntry> => ({

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -218,7 +218,6 @@ const allowAgentsListForMain = () => {
       list: [
         {
           id: "main",
-          default: true,
           tools: {
             allow: ["agents_list"],
           },

--- a/src/hooks/bundled/boot/handler.gateway-startup.integration.test.ts
+++ b/src/hooks/bundled/boot/handler.gateway-startup.integration.test.ts
@@ -34,7 +34,7 @@ describe("boot startup hook integration", () => {
       agents: {
         defaults: { boot: bootConfig },
         list: [
-          { id: "main", default: true, workspace: "/ws/main" },
+          { id: "main", workspace: "/ws/main" },
           { id: "ops", workspace: "/ws/ops" },
         ],
       },

--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -134,7 +134,7 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
             },
           },
           list: [
-            { id: "main", default: true, workspace: tmpDir },
+            { id: "main", workspace: tmpDir },
             {
               id: "ops",
               workspace: tmpDir,

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -614,7 +614,7 @@ describe("runHeartbeatOnce", () => {
             heartbeat: { every: "30m", prompt: "Default prompt" },
           },
           list: [
-            { id: "main", default: true },
+            { id: "main" },
             {
               id: "ops",
               workspace: tmpDir,
@@ -684,7 +684,7 @@ describe("runHeartbeatOnce", () => {
             heartbeat: { every: "30m", prompt: "Default prompt" },
           },
           list: [
-            { id: "main", default: true },
+            { id: "main" },
             {
               id: agentId,
               workspace: tmpDir,
@@ -923,7 +923,7 @@ describe("runHeartbeatOnce", () => {
           defaults: {
             heartbeat: { every: "5m", target: "whatsapp", prompt: "Check health" },
           },
-          list: [{ id: "work", default: true, workspace: tmpDir }],
+          list: [{ id: "work", workspace: tmpDir }],
         },
         channels: { whatsapp: { allowFrom: ["*"] } },
         session: { store: storeTemplate },

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -351,7 +351,7 @@ describe("resolveAgentRoute", () => {
   test("defaultAgentId is used when no binding matches", () => {
     const cfg: RemoteClawConfig = {
       agents: {
-        list: [{ id: "home", default: true, workspace: "~/remoteclaw-home" }],
+        list: [{ id: "home", workspace: "~/remoteclaw-home" }],
       },
     };
     const route = resolveAgentRoute({

--- a/src/slack/monitor.tool-result.test.ts
+++ b/src/slack/monitor.tool-result.test.ts
@@ -160,7 +160,6 @@ describe("monitorSlackProvider tool results", () => {
         list: [
           {
             id: "main",
-            default: true,
             identity: { name: "Mainbot", theme: "space crab", emoji: "🦀" },
           },
           {

--- a/src/telegram/bot-native-commands.test.ts
+++ b/src/telegram/bot-native-commands.test.ts
@@ -177,7 +177,7 @@ describe("registerTelegramNativeCommands", () => {
     const cfg: RemoteClawConfig = {
       agents: {
         list: [
-          { id: "main", default: true, workspace: "/tmp/test-workspace" },
+          { id: "main", workspace: "/tmp/test-workspace" },
           { id: "work", workspace: "/tmp/test-workspace" },
         ],
       },

--- a/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
+++ b/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
@@ -195,7 +195,6 @@ describe("web processMessage inbound contract", () => {
             list: [
               {
                 id: "main",
-                default: true,
                 identity: { name: "Mainbot", emoji: "🦀", theme: "space crab" },
               },
             ],


### PR DESCRIPTION
## Summary

- Remove `default?: boolean` from `AgentConfig` type and zod schema
- Add `resolveSoleAgentId(cfg)` — returns agent ID when exactly one is configured, null otherwise
- Add `requireSoleAgentId(cfg)` — throws descriptive error for zero or multiple agents
- Deprecate `resolveDefaultAgentId()` as a temporary shim delegating to `resolveSoleAgentId` (removed once all callers migrate in #1576–#1581)
- Update inline default-resolution in `main-session.ts`, `legacy.shared.ts`, `legacy.rules.ts`, `agent-dirs.ts`, and `thread-ownership` extension
- Remove `default: true` from all test fixtures across 19 test files

## Test plan

- [x] New `resolveSoleAgentId` tests: returns ID for single agent, null for zero/empty/multiple
- [x] New `requireSoleAgentId` tests: returns ID for single, throws for zero/empty/multiple with descriptive messages
- [x] Existing tests updated to remove `default: true` from config fixtures
- [x] Full test suite passes (5926 tests, 693 files)
- [x] Build passes
- [x] Lint passes (oxlint type-aware)
- [x] Format passes (oxfmt)

Closes #1575

🤖 Generated with [Claude Code](https://claude.com/claude-code)