### PR TITLE
gut(session): remove vestigial contextTokens config and display denominator

### DIFF
--- a/apps/macos/Sources/RemoteClaw/ContextMenuCardView.swift
+++ b/apps/macos/Sources/RemoteClaw/ContextMenuCardView.swift
@@ -10,7 +10,6 @@ struct ContextMenuCardView: View {
     private let paddingBottom: CGFloat = 8
     private let paddingTrailing: CGFloat = 10
     private let paddingLeading: CGFloat = 20
-    private let barHeight: CGFloat = 3
 
     init(
         rows: [SessionRow],
@@ -73,9 +72,7 @@ struct ContextMenuCardView: View {
     private func sessionRow(_ row: SessionRow) -> some View {
         VStack(alignment: .leading, spacing: 5) {
             ContextUsageBar(
-                usedTokens: row.tokens.total,
-                contextTokens: row.tokens.contextTokens,
-                height: self.barHeight)
+                usedTokens: row.tokens.total)
 
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text(row.label)
@@ -98,9 +95,7 @@ struct ContextMenuCardView: View {
     private var placeholderRow: some View {
         VStack(alignment: .leading, spacing: 5) {
             ContextUsageBar(
-                usedTokens: 0,
-                contextTokens: 200_000,
-                height: self.barHeight)
+                usedTokens: 0)
 
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text("main")
@@ -108,7 +103,7 @@ struct ContextMenuCardView: View {
                     .lineLimit(1)
                     .layoutPriority(1)
                 Spacer(minLength: 8)
-                Text("000k/000k")
+                Text("000k used")
                     .font(.caption.monospacedDigit())
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: true, vertical: false)

--- a/apps/macos/Sources/RemoteClaw/ContextUsageBar.swift
+++ b/apps/macos/Sources/RemoteClaw/ContextUsageBar.swift
@@ -2,92 +2,12 @@ import SwiftUI
 
 struct ContextUsageBar: View {
     let usedTokens: Int
-    let contextTokens: Int
-    var width: CGFloat?
-    var height: CGFloat = 6
-
-    private static let okGreen: NSColor = .init(name: nil) { appearance in
-        let base = NSColor.systemGreen
-        let match = appearance.bestMatch(from: [.aqua, .darkAqua])
-        if match == .darkAqua { return base }
-        return base.blended(withFraction: 0.24, of: .black) ?? base
-    }
-
-    private static let trackFill: NSColor = .init(name: nil) { appearance in
-        let match = appearance.bestMatch(from: [.aqua, .darkAqua])
-        if match == .darkAqua { return NSColor.white.withAlphaComponent(0.14) }
-        return NSColor.black.withAlphaComponent(0.12)
-    }
-
-    private static let trackStroke: NSColor = .init(name: nil) { appearance in
-        let match = appearance.bestMatch(from: [.aqua, .darkAqua])
-        if match == .darkAqua { return NSColor.white.withAlphaComponent(0.22) }
-        return NSColor.black.withAlphaComponent(0.2)
-    }
-
-    private var clampedFractionUsed: Double {
-        guard self.contextTokens > 0 else { return 0 }
-        return min(1, max(0, Double(self.usedTokens) / Double(self.contextTokens)))
-    }
-
-    private var percentUsed: Int? {
-        guard self.contextTokens > 0, self.usedTokens > 0 else { return nil }
-        return min(100, Int(round(self.clampedFractionUsed * 100)))
-    }
-
-    private var tint: Color {
-        guard let pct = self.percentUsed else { return .secondary }
-        if pct >= 95 { return Color(nsColor: .systemRed) }
-        if pct >= 80 { return Color(nsColor: .systemOrange) }
-        if pct >= 60 { return Color(nsColor: .systemYellow) }
-        return Color(nsColor: Self.okGreen)
-    }
 
     var body: some View {
-        let fraction = self.clampedFractionUsed
-        Group {
-            if let width = self.width, width > 0 {
-                self.barBody(width: width, fraction: fraction)
-                    .frame(width: width, height: self.height)
-            } else {
-                GeometryReader { proxy in
-                    self.barBody(width: proxy.size.width, fraction: fraction)
-                        .frame(width: proxy.size.width, height: self.height)
-                }
-                .frame(height: self.height)
-            }
-        }
-        .accessibilityLabel("Context usage")
-        .accessibilityValue(self.accessibilityValue)
-    }
-
-    private var accessibilityValue: String {
-        if self.contextTokens <= 0 { return "Unknown context window" }
-        let pct = Int(round(self.clampedFractionUsed * 100))
-        return "\(pct) percent used"
-    }
-
-    @ViewBuilder
-    private func barBody(width: CGFloat, fraction: Double) -> some View {
-        let radius = self.height / 2
-        let trackFill = Color(nsColor: Self.trackFill)
-        let trackStroke = Color(nsColor: Self.trackStroke)
-        let fillWidth = max(1, floor(width * CGFloat(fraction)))
-
-        ZStack(alignment: .leading) {
-            RoundedRectangle(cornerRadius: radius, style: .continuous)
-                .fill(trackFill)
-                .overlay {
-                    RoundedRectangle(cornerRadius: radius, style: .continuous)
-                        .strokeBorder(trackStroke, lineWidth: 0.75)
-                }
-
-            RoundedRectangle(cornerRadius: radius, style: .continuous)
-                .fill(self.tint)
-                .frame(width: fillWidth)
-                .mask {
-                    RoundedRectangle(cornerRadius: radius, style: .continuous)
-                }
-        }
+        Text(SessionTokenStats.formatKTokens(self.usedTokens) + " used")
+            .font(.caption.monospacedDigit())
+            .foregroundStyle(.secondary)
+            .accessibilityLabel("Context usage")
+            .accessibilityValue("\(self.usedTokens) tokens used")
     }
 }

--- a/apps/macos/Sources/RemoteClaw/SessionData.swift
+++ b/apps/macos/Sources/RemoteClaw/SessionData.swift
@@ -3,7 +3,6 @@ import SwiftUI
 
 struct GatewaySessionDefaultsRecord: Codable {
     let model: String?
-    let contextTokens: Int?
 }
 
 struct GatewaySessionEntryRecord: Codable {
@@ -22,7 +21,6 @@ struct GatewaySessionEntryRecord: Codable {
     let outputTokens: Int?
     let totalTokens: Int?
     let model: String?
-    let contextTokens: Int?
 }
 
 struct GatewaySessionsListResponse: Codable {
@@ -37,24 +35,13 @@ struct SessionTokenStats {
     let input: Int
     let output: Int
     let total: Int
-    let contextTokens: Int
 
     var contextSummaryShort: String {
-        "\(Self.formatKTokens(self.total))/\(Self.formatKTokens(self.contextTokens))"
-    }
-
-    var percentUsed: Int? {
-        guard self.contextTokens > 0, self.total > 0 else { return nil }
-        return min(100, Int(round((Double(self.total) / Double(self.contextTokens)) * 100)))
+        "\(Self.formatKTokens(self.total)) used"
     }
 
     var summary: String {
-        let parts = ["in \(input)", "out \(output)", "total \(total)"]
-        var text = parts.joined(separator: " | ")
-        if let percentUsed {
-            text += " (\(percentUsed)% of \(self.contextTokens))"
-        }
-        return text
+        ["in \(input)", "out \(output)", "total \(total)"].joined(separator: " | ")
     }
 
     static func formatKTokens(_ value: Int) -> String {
@@ -132,7 +119,6 @@ enum SessionKind {
 
 struct SessionDefaults {
     let model: String
-    let contextTokens: Int
 }
 
 extension SessionRow {
@@ -152,7 +138,7 @@ extension SessionRow {
                 verboseLevel: "info",
                 systemSent: false,
                 abortedLastRun: false,
-                tokens: SessionTokenStats(input: 320, output: 680, total: 1000, contextTokens: 200_000),
+                tokens: SessionTokenStats(input: 320, output: 680, total: 1000),
                 model: "claude-3.5-sonnet"),
             SessionRow(
                 id: "group-1",
@@ -168,7 +154,7 @@ extension SessionRow {
                 verboseLevel: nil,
                 systemSent: true,
                 abortedLastRun: true,
-                tokens: SessionTokenStats(input: 5000, output: 1200, total: 6200, contextTokens: 200_000),
+                tokens: SessionTokenStats(input: 5000, output: 1200, total: 6200),
                 model: "claude-opus-4-6"),
             SessionRow(
                 id: "global",
@@ -184,7 +170,7 @@ extension SessionRow {
                 verboseLevel: nil,
                 systemSent: false,
                 abortedLastRun: false,
-                tokens: SessionTokenStats(input: 150, output: 220, total: 370, contextTokens: 200_000),
+                tokens: SessionTokenStats(input: 150, output: 220, total: 370),
                 model: "gpt-4.1-mini"),
         ]
     }
@@ -242,7 +228,6 @@ struct SessionStoreSnapshot {
 @MainActor
 enum SessionLoader {
     static let fallbackModel = "claude-opus-4-6"
-    static let fallbackContextTokens = 200_000
 
     static let defaultStorePath = standardize(
         RemoteClawPaths.stateDirURL
@@ -281,15 +266,13 @@ enum SessionLoader {
         }
 
         let defaults = SessionDefaults(
-            model: decoded.defaults?.model ?? self.fallbackModel,
-            contextTokens: decoded.defaults?.contextTokens ?? self.fallbackContextTokens)
+            model: decoded.defaults?.model ?? self.fallbackModel)
 
         let rows = decoded.sessions.map { entry -> SessionRow in
             let updated = entry.updatedAt.map { Date(timeIntervalSince1970: $0 / 1000) }
             let input = entry.inputTokens ?? 0
             let output = entry.outputTokens ?? 0
             let total = entry.totalTokens ?? input + output
-            let context = entry.contextTokens ?? defaults.contextTokens
             let model = entry.model ?? defaults.model
 
             return SessionRow(
@@ -309,8 +292,7 @@ enum SessionLoader {
                 tokens: SessionTokenStats(
                     input: input,
                     output: output,
-                    total: total,
-                    contextTokens: context),
+                    total: total),
                 model: model)
         }.sorted { ($0.updatedAt ?? .distantPast) > ($1.updatedAt ?? .distantPast) }
 

--- a/apps/macos/Sources/RemoteClaw/SessionMenuLabelView.swift
+++ b/apps/macos/Sources/RemoteClaw/SessionMenuLabelView.swift
@@ -10,7 +10,6 @@ struct SessionMenuLabelView: View {
     @Environment(\.menuItemHighlighted) private var isHighlighted
     private let paddingLeading: CGFloat = 22
     private let paddingTrailing: CGFloat = 14
-    private let barHeight: CGFloat = 6
 
     private var primaryTextColor: Color {
         self.isHighlighted ? Color(nsColor: .selectedMenuItemTextColor) : .primary
@@ -23,10 +22,7 @@ struct SessionMenuLabelView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             ContextUsageBar(
-                usedTokens: self.row.tokens.total,
-                contextTokens: self.row.tokens.contextTokens,
-                width: max(1, self.width - (self.paddingLeading + self.paddingTrailing)),
-                height: self.barHeight)
+                usedTokens: self.row.tokens.total)
 
             HStack(alignment: .firstTextBaseline, spacing: 2) {
                 Text(self.row.label)

--- a/apps/macos/Sources/RemoteClaw/SessionsSettings.swift
+++ b/apps/macos/Sources/RemoteClaw/SessionsSettings.swift
@@ -120,9 +120,7 @@ struct SessionsSettings: View {
                         .foregroundStyle(.secondary)
                 }
                 ContextUsageBar(
-                    usedTokens: row.tokens.total,
-                    contextTokens: row.tokens.contextTokens,
-                    width: nil)
+                    usedTokens: row.tokens.total)
             }
 
             HStack(spacing: 10) {

--- a/apps/macos/Sources/RemoteClaw/UsageMenuLabelView.swift
+++ b/apps/macos/Sources/RemoteClaw/UsageMenuLabelView.swift
@@ -7,7 +7,6 @@ struct UsageMenuLabelView: View {
     @Environment(\.menuItemHighlighted) private var isHighlighted
     private let paddingLeading: CGFloat = 22
     private let paddingTrailing: CGFloat = 14
-    private let barHeight: CGFloat = 6
 
     private var primaryTextColor: Color {
         self.isHighlighted ? Color(nsColor: .selectedMenuItemTextColor) : .primary
@@ -19,14 +18,6 @@ struct UsageMenuLabelView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            if let used = row.usedPercent {
-                ContextUsageBar(
-                    usedTokens: Int(round(used)),
-                    contextTokens: 100,
-                    width: max(1, self.width - (self.paddingLeading + self.paddingTrailing)),
-                    height: self.barHeight)
-            }
-
             HStack(alignment: .firstTextBaseline, spacing: 6) {
                 Text(self.row.titleText)
                     .font(.caption.weight(.semibold))

--- a/apps/macos/Sources\/RemoteClaw/SessionMenuLabelView.swift
+++ b/apps/macos/Sources\/RemoteClaw/SessionMenuLabelView.swift
@@ -10,15 +10,11 @@ struct SessionMenuLabelView: View {
     @Environment(\.menuItemHighlighted) private var isHighlighted
     private let paddingLeading: CGFloat = 22
     private let paddingTrailing: CGFloat = 14
-    private let barHeight: CGFloat = 6
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             ContextUsageBar(
-                usedTokens: self.row.tokens.total,
-                contextTokens: self.row.tokens.contextTokens,
-                width: max(1, self.width - (self.paddingLeading + self.paddingTrailing)),
-                height: self.barHeight)
+                usedTokens: self.row.tokens.total)
 
             HStack(alignment: .firstTextBaseline, spacing: 2) {
                 Text(self.row.label)

--- a/apps/macos/Sources\/RemoteClaw/SessionsSettings.swift
+++ b/apps/macos/Sources\/RemoteClaw/SessionsSettings.swift
@@ -112,9 +112,7 @@ struct SessionsSettings: View {
                         .foregroundStyle(.secondary)
                 }
                 ContextUsageBar(
-                    usedTokens: row.tokens.total,
-                    contextTokens: row.tokens.contextTokens,
-                    width: nil)
+                    usedTokens: row.tokens.total)
             }
 
             HStack(spacing: 10) {

--- a/apps/macos/Sources\/RemoteClaw/UsageMenuLabelView.swift
+++ b/apps/macos/Sources\/RemoteClaw/UsageMenuLabelView.swift
@@ -7,18 +7,9 @@ struct UsageMenuLabelView: View {
     @Environment(\.menuItemHighlighted) private var isHighlighted
     private let paddingLeading: CGFloat = 22
     private let paddingTrailing: CGFloat = 14
-    private let barHeight: CGFloat = 6
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            if let used = row.usedPercent {
-                ContextUsageBar(
-                    usedTokens: Int(round(used)),
-                    contextTokens: 100,
-                    width: max(1, self.width - (self.paddingLeading + self.paddingTrailing)),
-                    height: self.barHeight)
-            }
-
             HStack(alignment: .firstTextBaseline, spacing: 6) {
                 Text(self.row.titleText)
                     .font(.caption.weight(.semibold))

--- a/apps/macos/Tests/RemoteClawIPCTests/MenuSessionsInjectorTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/MenuSessionsInjectorTests.swift
@@ -23,7 +23,7 @@ struct MenuSessionsInjectorTests {
         let injector = MenuSessionsInjector()
         injector.setTestingControlChannelConnected(true)
 
-        let defaults = SessionDefaults(model: "anthropic/claude-opus-4-6", contextTokens: 200_000)
+        let defaults = SessionDefaults(model: "anthropic/claude-opus-4-6")
         let rows = [
             SessionRow(
                 id: "main",
@@ -39,7 +39,7 @@ struct MenuSessionsInjectorTests {
                 verboseLevel: nil,
                 systemSent: false,
                 abortedLastRun: false,
-                tokens: SessionTokenStats(input: 10, output: 20, total: 30, contextTokens: 200_000),
+                tokens: SessionTokenStats(input: 10, output: 20, total: 30),
                 model: "claude-opus-4-6"),
             SessionRow(
                 id: "discord:group:alpha",
@@ -55,7 +55,7 @@ struct MenuSessionsInjectorTests {
                 verboseLevel: "debug",
                 systemSent: true,
                 abortedLastRun: true,
-                tokens: SessionTokenStats(input: 50, output: 50, total: 100, contextTokens: 200_000),
+                tokens: SessionTokenStats(input: 50, output: 50, total: 100),
                 model: "claude-opus-4-6"),
         ]
         let snapshot = SessionStoreSnapshot(

--- a/apps/macos/Tests/RemoteClawIPCTests/SessionDataTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/SessionDataTests.swift
@@ -17,11 +17,6 @@ struct SessionDataTests {
         #expect(SessionTokenStats.formatKTokens(12340) == "12k")
     }
 
-    @Test func sessionTokenStatsPercentUsedClampsTo100() {
-        let stats = SessionTokenStats(input: 0, output: 0, total: 250_000, contextTokens: 200_000)
-        #expect(stats.percentUsed == 100)
-    }
-
     @Test func sessionRowFlagLabelsIncludeNonDefaultFlags() {
         let row = SessionRow(
             id: "x",
@@ -37,7 +32,7 @@ struct SessionDataTests {
             verboseLevel: "debug",
             systemSent: true,
             abortedLastRun: true,
-            tokens: SessionTokenStats(input: 1, output: 2, total: 3, contextTokens: 10),
+            tokens: SessionTokenStats(input: 1, output: 2, total: 3),
             model: nil)
         #expect(row.flagLabels.contains("verbose debug"))
         #expect(row.flagLabels.contains("system sent"))

--- a/apps/shared/RemoteClawKit/Sources/RemoteClawChatUI/ChatSessions.swift
+++ b/apps/shared/RemoteClawKit/Sources/RemoteClawChatUI/ChatSessions.swift
@@ -2,7 +2,6 @@ import Foundation
 
 public struct RemoteClawChatSessionsDefaults: Codable, Sendable {
     public let model: String?
-    public let contextTokens: Int?
 }
 
 public struct RemoteClawChatSessionEntry: Codable, Identifiable, Sendable, Hashable {
@@ -28,7 +27,6 @@ public struct RemoteClawChatSessionEntry: Codable, Identifiable, Sendable, Hasha
     public let totalTokens: Int?
 
     public let model: String?
-    public let contextTokens: Int?
 }
 
 public struct RemoteClawChatSessionsListResponse: Codable, Sendable {

--- a/apps/shared/RemoteClawKit/Sources/RemoteClawChatUI/ChatViewModel.swift
+++ b/apps/shared/RemoteClawKit/Sources/RemoteClawChatUI/ChatViewModel.swift
@@ -453,8 +453,7 @@ public final class RemoteClawChatViewModel {
             inputTokens: nil,
             outputTokens: nil,
             totalTokens: nil,
-            model: nil,
-            contextTokens: nil)
+            model: nil)
     }
 
     private func handleTransportEvent(_ evt: RemoteClawChatTransportEvent) {

--- a/apps/shared/RemoteClawKit/Tests/RemoteClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/RemoteClawKit/Tests/RemoteClawKitTests/ChatViewModelTests.swift
@@ -491,8 +491,7 @@ extension TestChatTransportState {
                     inputTokens: nil,
                     outputTokens: nil,
                     totalTokens: nil,
-                    model: nil,
-                    contextTokens: nil),
+                    model: nil),
                 RemoteClawChatSessionEntry(
                     key: "main",
                     kind: nil,
@@ -510,8 +509,7 @@ extension TestChatTransportState {
                     inputTokens: nil,
                     outputTokens: nil,
                     totalTokens: nil,
-                    model: nil,
-                    contextTokens: nil),
+                    model: nil),
                 RemoteClawChatSessionEntry(
                     key: "recent-2",
                     kind: nil,
@@ -529,8 +527,7 @@ extension TestChatTransportState {
                     inputTokens: nil,
                     outputTokens: nil,
                     totalTokens: nil,
-                    model: nil,
-                    contextTokens: nil),
+                    model: nil),
                 RemoteClawChatSessionEntry(
                     key: "old-1",
                     kind: nil,
@@ -548,8 +545,7 @@ extension TestChatTransportState {
                     inputTokens: nil,
                     outputTokens: nil,
                     totalTokens: nil,
-                    model: nil,
-                    contextTokens: nil),
+                    model: nil),
             ])
 
         let transport = TestChatTransport(
@@ -594,8 +590,7 @@ extension TestChatTransportState {
                     inputTokens: nil,
                     outputTokens: nil,
                     totalTokens: nil,
-                    model: nil,
-                    contextTokens: nil),
+                    model: nil),
             ])
 
         let transport = TestChatTransport(

--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -42,10 +42,9 @@ Session pruning trims **old tool results** from the in-memory context before pas
 
 Pruning uses an estimated context window (chars ≈ tokens × 4). The base window is resolved in this order:
 
-1. `agents.defaults.contextTokens` (if set).
-2. Default `200000` tokens.
+Default `200000` tokens.
 
-Context window limits are determined by the CLI agent's own configuration; RemoteClaw uses the configured value as a pruning budget estimate.
+Context window limits are determined by the CLI agent's own configuration; RemoteClaw uses this default as a pruning budget estimate.
 
 ## Mode
 

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -51,7 +51,7 @@ Row shape (JSON):
 - `displayName` (group display label if available)
 - `updatedAt` (ms)
 - `sessionId`
-- `model`, `contextTokens`, `totalTokens`
+- `model`, `totalTokens`
 - `thinkingLevel`, `verboseLevel`, `systemSent`, `abortedLastRun`
 - `sendPolicy` (session override if set)
 - `lastChannel`, `lastTo`

--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -59,7 +59,7 @@ Notes:
 All session state is **owned by the gateway** (the “master” RemoteClaw). UI clients (macOS app, WebChat, etc.) must query the gateway for session lists and token counts instead of reading local files.
 
 - In **remote mode**, the session store you care about lives on the remote gateway host, not your Mac.
-- Token counts shown in UIs come from the gateway’s store fields (`inputTokens`, `outputTokens`, `totalTokens`, `contextTokens`). Clients do not parse JSONL transcripts to “fix up” totals.
+- Token counts shown in UIs come from the gateway’s store fields (`inputTokens`, `outputTokens`, `totalTokens`). Clients do not parse JSONL transcripts to “fix up” totals.
 
 ## Where state lives
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -310,7 +310,6 @@ Configure agent defaults and define multiple agents:
     defaults: {
       runtime: "claude",
       workspace: "~/projects",
-      contextTokens: 200000,
     },
     list: [
       {
@@ -334,7 +333,6 @@ Key agent default options:
 | --------------------------------- | ------ | ----------------------------------------------------------- |
 | `agents.defaults.runtime`         | string | Default agent CLI (`claude`, `gemini`, `codex`, `opencode`) |
 | `agents.defaults.workspace`       | string | Workspace root directory                                    |
-| `agents.defaults.contextTokens`   | number | Context window size                                         |
 | `agents.defaults.timeoutSeconds`  | number | Agent response timeout                                      |
 | `agents.defaults.maxConcurrent`   | number | Max concurrent sessions                                     |
 | `agents.defaults.typingMode`      | string | Typing indicator: `never`, `instant`, `thinking`, `message` |

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -846,7 +846,6 @@ Time format in system prompt. Default: `auto` (OS preference).
       elevatedDefault: "on",
       timeoutSeconds: 600,
       mediaMaxMb: 5,
-      contextTokens: 200000,
       maxConcurrent: 3,
     },
   },

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -149,7 +149,7 @@ Key fields (not exhaustive):
   - `modelOverride`: model to pass to the CLI runtime (e.g. `--model` flag)
   - `providerOverride`: which provider to route to (e.g. `anthropic`, `openai`)
 - Token counters (best-effort / provider-dependent):
-  - `inputTokens`, `outputTokens`, `totalTokens`, `contextTokens`
+  - `inputTokens`, `outputTokens`, `totalTokens`
 
 The store is safe to edit, but the Gateway is the authority: it may rewrite or rehydrate entries as sessions run.
 
@@ -185,8 +185,7 @@ Two different concepts matter:
 
 If you’re tuning limits:
 
-- The context window is determined by the CLI runtime (e.g., the model the CLI agent is using) and can be overridden via config.
-- `contextTokens` in the store is a runtime estimate/reporting value; don’t treat it as a strict guarantee.
+- The context window is determined by the CLI runtime (e.g., the model the CLI agent is using).
 
 For more, see [/token-use](/reference/token-use).
 

--- a/src/agents/defaults.ts
+++ b/src/agents/defaults.ts
@@ -1,4 +1,2 @@
 // Gutted in RemoteClaw fork (Middleware Boundary Principle)
 export const DEFAULT_AGENT_ID = "default";
-
-export const DEFAULT_CONTEXT_TOKENS = 200000;

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -53,7 +53,6 @@ export type SessionListRow = {
   updatedAt?: number | null;
   sessionId?: string;
   model?: string;
-  contextTokens?: number | null;
   totalTokens?: number | null;
   thinkingLevel?: string;
   verboseLevel?: string;

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -202,7 +202,6 @@ export function createSessionsListTool(opts?: {
           updatedAt: typeof entry.updatedAt === "number" ? entry.updatedAt : undefined,
           sessionId,
           model: typeof entry.model === "string" ? entry.model : undefined,
-          contextTokens: typeof entry.contextTokens === "number" ? entry.contextTokens : undefined,
           totalTokens: typeof entry.totalTokens === "number" ? entry.totalTokens : undefined,
           thinkingLevel: typeof entry.thinkingLevel === "string" ? entry.thinkingLevel : undefined,
           verboseLevel: typeof entry.verboseLevel === "string" ? entry.verboseLevel : undefined,

--- a/src/agents/usage.normalization.test.ts
+++ b/src/agents/usage.normalization.test.ts
@@ -56,7 +56,6 @@ describe("normalizeUsage", () => {
           cacheWrite: 0,
           total: 2_402_300,
         },
-        contextTokens: 200_000,
       }),
     ).toBe(2_400_027);
   });
@@ -70,7 +69,6 @@ describe("normalizeUsage", () => {
           cacheWrite: 50,
           total: 2_000,
         },
-        contextTokens: 200_000,
       }),
     ).toBe(1_550);
   });
@@ -85,7 +83,6 @@ describe("normalizeUsage", () => {
           total: 9_999,
         },
         promptTokens: 65_000,
-        contextTokens: 200_000,
       }),
     ).toBe(65_000);
   });

--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -189,7 +189,6 @@ describe("deriveSessionTotalTokens", () => {
         cacheRead: 500,
         cacheWrite: 200,
       },
-      contextTokens: 4000,
     });
     expect(totalTokens).toBe(1700); // 1000 + 500 + 200
   });
@@ -201,7 +200,6 @@ describe("deriveSessionTotalTokens", () => {
         cacheRead: 500,
         cacheWrite: 200,
       },
-      contextTokens: 4000,
       promptTokens: 2500, // Override
     });
     expect(totalTokens).toBe(2500);

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -158,7 +158,6 @@ export function deriveSessionTotalTokens(params: {
     cacheRead?: number;
     cacheWrite?: number;
   };
-  contextTokens?: number;
   promptTokens?: number;
 }): number | undefined {
   const promptOverride = params.promptTokens;

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -342,7 +342,7 @@ describe("runReplyAgent token update", () => {
       sessionKey,
       storePath,
       defaultModel: "anthropic/claude-opus-4-5",
-      agentCfgContextTokens: 200_000,
+
       resolvedVerboseLevel: "off",
       isNewSession: false,
       blockStreamingEnabled: false,
@@ -396,7 +396,7 @@ describe("runReplyAgent token update", () => {
       sessionKey,
       storePath,
       defaultModel: "anthropic/claude-opus-4-5",
-      agentCfgContextTokens: 200_000,
+
       resolvedVerboseLevel: "off",
       isNewSession: false,
       blockStreamingEnabled: false,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -249,7 +249,6 @@ async function runReplyAgentWithBase(params: {
     sessionKey: params.sessionKey,
     storePath: params.storePath,
     defaultModel: "anthropic/claude-opus-4-5",
-    agentCfgContextTokens: 100_000,
     resolvedVerboseLevel: "off",
     isNewSession: false,
     blockStreamingEnabled: false,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,7 +1,5 @@
 import fs from "node:fs";
 // Gutted in RemoteClaw fork (Middleware Boundary Principle)
-const lookupContextTokens = (..._args: unknown[]) => undefined as number | undefined;
-const DEFAULT_CONTEXT_TOKENS = 128_000;
 const resolveModelAuthMode = (..._args: unknown[]) => "api-key" as string;
 const isCliProvider = (..._args: unknown[]) => false;
 const queueEmbeddedPiMessage = (..._args: unknown[]) => false;
@@ -104,7 +102,6 @@ export async function runReplyAgent(params: {
   sessionKey?: string;
   storePath?: string;
   defaultModel: string;
-  agentCfgContextTokens?: number;
   resolvedVerboseLevel: VerboseLevel;
   isNewSession: boolean;
   blockStreamingEnabled: boolean;
@@ -135,7 +132,7 @@ export async function runReplyAgent(params: {
     sessionKey,
     storePath,
     defaultModel,
-    agentCfgContextTokens,
+
     resolvedVerboseLevel,
     isNewSession,
     blockStreamingEnabled,
@@ -254,7 +251,7 @@ export async function runReplyAgent(params: {
     sessionCtx,
     opts,
     defaultModel,
-    agentCfgContextTokens,
+
     resolvedVerboseLevel,
     sessionEntry: activeSessionEntry,
     sessionStore: activeSessionStore,
@@ -272,7 +269,6 @@ export async function runReplyAgent(params: {
     sessionKey,
     storePath,
     defaultModel,
-    agentCfgContextTokens,
   });
 
   let responseUsageLine: string | undefined;
@@ -479,12 +475,6 @@ export async function runReplyAgent(params: {
     const cliSessionId = isCliProvider(providerUsed, cfg)
       ? (agentMeta?.sessionId as string | undefined)?.trim()
       : undefined;
-    const contextTokensUsed =
-      agentCfgContextTokens ??
-      lookupContextTokens(modelUsed) ??
-      activeSessionEntry?.contextTokens ??
-      DEFAULT_CONTEXT_TOKENS;
-
     await persistRunSessionUsage({
       storePath,
       sessionKey,
@@ -493,7 +483,6 @@ export async function runReplyAgent(params: {
       promptTokens,
       modelUsed,
       providerUsed,
-      contextTokensUsed,
       systemPromptReport: (runResult.meta as Record<string, unknown> | undefined)
         ?.systemPromptReport as
         | import("../../config/sessions/types.js").SessionSystemPromptReport
@@ -590,10 +579,6 @@ export async function runReplyAgent(params: {
           total: totalTokens,
         },
         lastCallUsage: agentMeta?.lastCallUsage as NormalizedUsage | undefined,
-        context: {
-          limit: contextTokensUsed,
-          used: totalTokens,
-        },
         costUsd,
         durationMs: Date.now() - runStartedAt,
       });
@@ -695,7 +680,6 @@ export async function runReplyAgent(params: {
         sessionKey,
         storePath,
         lastCallUsage: agentMeta?.lastCallUsage as NormalizedUsage | undefined,
-        contextTokensUsed,
       });
 
       // Inject post-compaction workspace context for the next agent turn

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -136,7 +136,6 @@ export const handleStatusCommand: CommandHandler = async (params, allowTextComma
     sessionScope: params.sessionScope,
     provider: params.provider,
     model: params.model,
-    contextTokens: params.contextTokens,
     resolvedVerboseLevel: params.resolvedVerboseLevel,
     isGroup: params.isGroup,
     defaultGroupActivation: params.defaultGroupActivation,

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -31,7 +31,6 @@ export async function buildStatusReply(params: {
   storePath?: string;
   provider: string;
   model: string;
-  contextTokens: number;
   resolvedVerboseLevel: VerboseLevel;
   isGroup: boolean;
   defaultGroupActivation: () => "always" | "mention";
@@ -46,7 +45,6 @@ export async function buildStatusReply(params: {
     storePath,
     provider,
     model: _model,
-    contextTokens,
     resolvedVerboseLevel,
     isGroup,
     defaultGroupActivation,
@@ -127,7 +125,6 @@ export async function buildStatusReply(params: {
     config: cfg,
     agent: {
       ...agentDefaults,
-      contextTokens,
       verboseDefault: agentDefaults.verboseDefault,
     },
     agentId: statusAgentId,

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -41,7 +41,6 @@ export type HandleCommandsParams = {
   resolvedVerboseLevel: VerboseLevel;
   provider: string;
   model: string;
-  contextTokens: number;
   isGroup: boolean;
   /** Elevated tool config (upstream feature). */
   elevated?: unknown;

--- a/src/auto-reply/reply/commands.test-harness.ts
+++ b/src/auto-reply/reply/commands.test-harness.ts
@@ -41,7 +41,6 @@ export function buildCommandTestParams(
     resolvedVerboseLevel: "off",
     provider: "whatsapp",
     model: "test-model",
-    contextTokens: 0,
     isGroup: false,
   };
   return params;

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -298,7 +298,6 @@ function buildPolicyParams(
     resolvedVerboseLevel: "off",
     provider: "telegram",
     model: "test-model",
-    contextTokens: 0,
     isGroup: false,
   };
   return params;

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -10,9 +10,8 @@ export async function persistInlineDirectives(params: {
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
   storePath?: string;
-  agentCfg: NonNullable<RemoteClawConfig["agents"]>["defaults"] | undefined;
-}): Promise<{ contextTokens: number }> {
-  const { directives, sessionEntry, sessionStore, sessionKey, storePath, agentCfg } = params;
+}): Promise<void> {
+  const { directives, sessionEntry, sessionStore, sessionKey, storePath } = params;
   if (sessionEntry && sessionStore && sessionKey) {
     let updated = false;
 
@@ -41,9 +40,4 @@ export async function persistInlineDirectives(params: {
       }
     }
   }
-
-  return {
-    // Context token lookup from model catalog gutted in RemoteClaw — CLI agents manage their own context.
-    contextTokens: agentCfg?.contextTokens ?? 200_000,
-  };
 }

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -24,7 +24,6 @@ export type ApplyDirectiveResult =
       directives: InlineDirectives;
       provider: string;
       model: string;
-      contextTokens: number;
       directiveAck?: ReplyPayload;
       perMessageQueueMode?: InlineDirectives["queueMode"];
       perMessageQueueOptions?: {
@@ -59,7 +58,6 @@ export async function applyInlineDirectiveOverrides(params: {
   defaultActivation: () => ReturnType<
     Parameters<typeof buildStatusReply>[0]["defaultGroupActivation"]
   >;
-  contextTokens: number;
   /** Upstream feature: whether elevated security is enabled. */
   elevatedEnabled?: boolean;
   /** Upstream feature: elevated security allowed for this context. */
@@ -93,7 +91,6 @@ export async function applyInlineDirectiveOverrides(params: {
   } = params;
   let { directives } = params;
   let { provider, model } = params;
-  let { contextTokens } = params;
   // Model selection gutted in RemoteClaw — derive from runtimeId.
   const defaultProvider = runtimeId;
   const defaultModel = "default";
@@ -161,7 +158,6 @@ export async function applyInlineDirectiveOverrides(params: {
         sessionScope,
         provider,
         model,
-        contextTokens,
         resolvedVerboseLevel: currentVerboseLevel ?? "off",
         isGroup,
         defaultGroupActivation: defaultActivation,
@@ -214,17 +210,14 @@ export async function applyInlineDirectiveOverrides(params: {
     model = fastLane.model;
   }
 
-  const persisted = await persistInlineDirectives({
+  await persistInlineDirectives({
     directives,
     cfg,
     sessionEntry,
     sessionStore,
     sessionKey,
     storePath,
-    agentCfg,
   });
-  contextTokens = persisted.contextTokens;
-
   const perMessageQueueMode =
     directives.hasQueueDirective && !directives.queueReset ? directives.queueMode : undefined;
   const perMessageQueueOptions =
@@ -241,7 +234,6 @@ export async function applyInlineDirectiveOverrides(params: {
     directives,
     provider,
     model,
-    contextTokens,
     directiveAck,
     perMessageQueueMode,
     perMessageQueueOptions,

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { listChatCommands, shouldHandleTextCommands } from "../commands-registry.js";
@@ -22,7 +21,6 @@ export const createModelSelectionState = (..._args: unknown[]) => ({
   model: "default" as string,
   resolveDefaultThinkingLevel: async (): Promise<ThinkLevel | undefined> => undefined,
   resolveDefaultReasoningLevel: async (): Promise<ReasoningLevel> => "off" as ReasoningLevel,
-  contextTokens: DEFAULT_CONTEXT_TOKENS,
   aliasIndex: new Map<string, { provider: string; model: string }>(),
   allowedModelKeys: new Set<string>(),
   allowedModelCatalog: [] as Array<{ id: string; provider: string }>,
@@ -68,7 +66,6 @@ export type ReplyDirectiveContinuation = {
   provider: string;
   model: string;
   modelState: Awaited<ReturnType<typeof createModelSelectionState>>;
-  contextTokens: number;
   inlineStatusRequested: boolean;
   directiveAck?: ReplyPayload;
   perMessageQueueMode?: InlineDirectives["queueMode"];
@@ -404,8 +401,6 @@ export async function resolveReplyDirectives(params: {
     resolvedReasoningLevel = await modelState.resolveDefaultReasoningLevel();
   }
 
-  let contextTokens = agentCfg?.contextTokens ?? DEFAULT_CONTEXT_TOKENS;
-
   const initialModelLabel = `${provider}/${model}`;
   const formatModelSwitchEvent = (label: string, alias?: string) =>
     alias ? `Model switched to ${alias} (${label}).` : `Model switched to ${label}.`;
@@ -438,7 +433,6 @@ export async function resolveReplyDirectives(params: {
     formatModelSwitchEvent,
     resolvedElevatedLevel,
     defaultActivation: () => defaultActivation,
-    contextTokens,
     typing,
   });
   if (applyResult.kind === "reply") {
@@ -447,7 +441,6 @@ export async function resolveReplyDirectives(params: {
   directives = applyResult.directives;
   provider = applyResult.provider;
   model = applyResult.model;
-  contextTokens = applyResult.contextTokens;
   const { directiveAck, perMessageQueueMode, perMessageQueueOptions } = applyResult;
   const execOverrides = resolveExecOverrides({ directives, sessionEntry });
 
@@ -475,7 +468,6 @@ export async function resolveReplyDirectives(params: {
       provider,
       model,
       modelState,
-      contextTokens,
       inlineStatusRequested,
       directiveAck,
       perMessageQueueMode,

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -70,7 +70,6 @@ const createHandleInlineActionsInput = (params: {
     resolvedVerboseLevel: undefined,
     provider: "openai",
     model: "gpt-4o-mini",
-    contextTokens: 0,
     abortedLastRun: false,
     sessionScope: "per-sender",
     ...params.overrides,

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -57,7 +57,6 @@ export async function handleInlineActions(params: {
   elevatedFailures?: unknown[];
   provider: string;
   model: string;
-  contextTokens: number;
   directiveAck?: ReplyPayload;
   abortedLastRun: boolean;
 }): Promise<InlineActionResult> {
@@ -86,7 +85,6 @@ export async function handleInlineActions(params: {
     resolvedVerboseLevel,
     provider,
     model,
-    contextTokens,
     directiveAck,
     abortedLastRun: initialAbortedLastRun,
   } = params;
@@ -160,7 +158,6 @@ export async function handleInlineActions(params: {
       sessionScope,
       provider,
       model,
-      contextTokens,
       resolvedVerboseLevel: resolvedVerboseLevel ?? "off",
       isGroup,
       defaultGroupActivation: defaultActivation,
@@ -188,7 +185,6 @@ export async function handleInlineActions(params: {
       resolvedVerboseLevel: resolvedVerboseLevel ?? "off",
       provider,
       model,
-      contextTokens,
       isGroup,
     });
 

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -538,7 +538,6 @@ export async function runPreparedReply(
     sessionKey,
     storePath,
     defaultModel,
-    agentCfgContextTokens: agentCfg?.contextTokens,
     resolvedVerboseLevel: resolvedVerboseLevel ?? "off",
     isNewSession,
     blockStreamingEnabled,

--- a/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
@@ -140,7 +140,6 @@ function createContinueDirectivesResult(resetHookTriggered: boolean) {
       modelState: {
         resolveDefaultThinkingLevel: async () => undefined,
       },
-      contextTokens: 0,
       inlineStatusRequested: false,
       directiveAck: undefined,
       perMessageQueueMode: undefined,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -148,7 +148,7 @@ export async function getReplyFromConfig(
     provider: resolvedProvider,
     model: resolvedModel,
     modelState,
-    contextTokens,
+
     inlineStatusRequested,
     directiveAck,
     perMessageQueueMode,
@@ -210,7 +210,7 @@ export async function getReplyFromConfig(
     resolveDefaultThinkingLevel: modelState.resolveDefaultThinkingLevel,
     provider,
     model,
-    contextTokens,
+
     directiveAck,
     abortedLastRun,
   });

--- a/src/auto-reply/reply/session-run-accounting.ts
+++ b/src/auto-reply/reply/session-run-accounting.ts
@@ -9,7 +9,6 @@ type IncrementRunCompactionCountParams = Omit<
   "tokensAfter"
 > & {
   lastCallUsage?: NormalizedUsage;
-  contextTokensUsed?: number;
 };
 
 export async function persistRunSessionUsage(params: PersistRunSessionUsageParams): Promise<void> {
@@ -22,7 +21,6 @@ export async function incrementRunCompactionCount(
   const tokensAfterCompaction = params.lastCallUsage
     ? deriveSessionTotalTokens({
         usage: params.lastCallUsage,
-        contextTokens: params.contextTokensUsed,
       })
     : undefined;
   return incrementCompactionCount({

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -45,7 +45,6 @@ export async function persistSessionUsageUpdate(params: {
   lastCallUsage?: NormalizedUsage;
   modelUsed?: string;
   providerUsed?: string;
-  contextTokensUsed?: number;
   promptTokens?: number;
   systemPromptReport?: SessionSystemPromptReport;
   cliSessionId?: string;
@@ -70,7 +69,6 @@ export async function persistSessionUsageUpdate(params: {
         storePath,
         sessionKey,
         update: async (entry) => {
-          const resolvedContextTokens = params.contextTokensUsed ?? entry.contextTokens;
           // Use last-call usage for totalTokens when available. The accumulated
           // `usage.input` sums input tokens from every API call in the run
           // (tool-use loops, compaction retries), overstating actual context.
@@ -79,14 +77,12 @@ export async function persistSessionUsageUpdate(params: {
           const totalTokens = hasFreshContextSnapshot
             ? deriveSessionTotalTokens({
                 usage: usageForContext,
-                contextTokens: resolvedContextTokens,
                 promptTokens: params.promptTokens,
               })
             : undefined;
           const patch: Partial<SessionEntry> = {
             modelProvider: params.providerUsed ?? entry.modelProvider,
             model: params.modelUsed ?? entry.model,
-            contextTokens: resolvedContextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
             updatedAt: Date.now(),
           };
@@ -112,7 +108,7 @@ export async function persistSessionUsageUpdate(params: {
     return;
   }
 
-  if (params.modelUsed || params.contextTokensUsed) {
+  if (params.modelUsed) {
     try {
       await updateSessionStoreEntry({
         storePath,
@@ -121,7 +117,6 @@ export async function persistSessionUsageUpdate(params: {
           const patch: Partial<SessionEntry> = {
             modelProvider: params.providerUsed ?? entry.modelProvider,
             model: params.modelUsed ?? entry.model,
-            contextTokens: params.contextTokensUsed ?? entry.contextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
             updatedAt: Date.now(),
           };
@@ -129,7 +124,7 @@ export async function persistSessionUsageUpdate(params: {
         },
       });
     } catch (err) {
-      logVerbose(`failed to persist ${label}model/context update: ${String(err)}`);
+      logVerbose(`failed to persist ${label}model update: ${String(err)}`);
     }
   }
 }

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -931,7 +931,6 @@ describe("persistSessionUsageUpdate", () => {
       sessionKey,
       usage: accumulatedUsage,
       lastCallUsage,
-      contextTokensUsed: 200_000,
     });
 
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
@@ -965,7 +964,6 @@ describe("persistSessionUsageUpdate", () => {
         cacheRead: 18_000,
         cacheWrite: 4_000,
       },
-      contextTokensUsed: 200_000,
     });
 
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
@@ -988,7 +986,6 @@ describe("persistSessionUsageUpdate", () => {
       storePath,
       sessionKey,
       usage: { input: 50_000, output: 5_000, total: 55_000 },
-      contextTokensUsed: 200_000,
     });
 
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
@@ -1010,7 +1007,6 @@ describe("persistSessionUsageUpdate", () => {
       sessionKey,
       usage: { input: 50_000, output: 5_000, total: 55_000 },
       promptTokens: 42_000,
-      contextTokensUsed: 200_000,
     });
 
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
@@ -1037,7 +1033,6 @@ describe("persistSessionUsageUpdate", () => {
       sessionKey,
       usage: undefined,
       promptTokens: 39_000,
-      contextTokensUsed: 200_000,
     });
 
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
@@ -1061,7 +1056,6 @@ describe("persistSessionUsageUpdate", () => {
       sessionKey,
       usage: { input: 300_000, output: 10_000, total: 310_000 },
       lastCallUsage: { input: 250_000, output: 5_000, total: 255_000 },
-      contextTokensUsed: 200_000,
     });
 
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -387,7 +387,6 @@ export async function initSessionState(params: {
     sessionEntry.totalTokens = undefined;
     sessionEntry.inputTokens = undefined;
     sessionEntry.outputTokens = undefined;
-    sessionEntry.contextTokens = undefined;
   }
   // Preserve per-session overrides while resetting compaction state on /new.
   sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -87,7 +87,7 @@ describe("buildStatusMessage", () => {
 
     const normalized = normalizeTestText(text);
     expect(normalized).toContain("Model:");
-    expect(normalized).toContain("Context:");
+    expect(normalized).toContain("Tokens:");
     expect(normalized).toContain("Queue: collect");
   });
 
@@ -131,7 +131,7 @@ describe("buildStatusMessage", () => {
 
   it("inserts usage summary beneath context line", () => {
     const text = buildStatusMessage({
-      agent: { model: "anthropic/claude-opus-4-5", contextTokens: 32_000 },
+      agent: { model: "anthropic/claude-opus-4-5" },
       sessionEntry: { sessionId: "u1", updatedAt: 0, totalTokens: 1000 },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -141,9 +141,9 @@ describe("buildStatusMessage", () => {
     });
 
     const lines = normalizeTestText(text).split("\n");
-    const contextIndex = lines.findIndex((line) => line.includes("Context:"));
-    expect(contextIndex).toBeGreaterThan(-1);
-    expect(lines[contextIndex + 1]).toContain("Usage: Claude 80% left (5h)");
+    const tokensIndex = lines.findIndex((line) => line.includes("Tokens:"));
+    expect(tokensIndex).toBeGreaterThan(-1);
+    expect(lines[tokensIndex + 1]).toContain("Usage: Claude 80% left (5h)");
   });
 
   it("never shows cost line — cost calculation removed", () => {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../agents/usage.js";
 
 // Gutted in RemoteClaw fork — CLI runtimes manage their own model selection
@@ -144,22 +143,12 @@ function resolveRuntimeLabel(
   return `${runtime}/${sandboxMode}`;
 }
 
-const formatTokens = (total: number | null | undefined, contextTokens: number | null) => {
-  const ctx = contextTokens ?? null;
+const formatTokens = (total: number | null | undefined) => {
   if (total == null) {
-    const ctxLabel = ctx ? formatTokenCount(ctx) : "?";
-    return `?/${ctxLabel}`;
+    return "unknown";
   }
-  const pct = ctx ? Math.min(999, Math.round((total / ctx) * 100)) : null;
-  const totalLabel = formatTokenCount(total);
-  const ctxLabel = ctx ? formatTokenCount(ctx) : "?";
-  return `${totalLabel}/${ctxLabel}${pct !== null ? ` (${pct}%)` : ""}`;
+  return `${formatTokenCount(total)} used`;
 };
-
-export const formatContextUsageShort = (
-  total: number | null | undefined,
-  contextTokens: number | null | undefined,
-) => `Context ${formatTokens(total, contextTokens ?? null)}`;
 
 const formatQueueDetails = (queue?: QueueStatus) => {
   if (!queue) {
@@ -356,10 +345,6 @@ export function buildStatusMessage(args: StatusArgs): string {
     selectedModel,
     sessionEntry: entry,
   });
-  let _activeProvider = modelRefs.active.provider;
-  let _activeModel = modelRefs.active.model;
-  let contextTokens = entry?.contextTokens ?? args.agent?.contextTokens ?? DEFAULT_CONTEXT_TOKENS;
-
   let inputTokens = entry?.inputTokens;
   let outputTokens = entry?.outputTokens;
   let cacheRead = entry?.cacheRead;
@@ -393,9 +378,6 @@ export function buildStatusMessage(args: StatusArgs): string {
         } else {
           _activeModel = logUsage.model;
         }
-      }
-      if (!contextTokens) {
-        contextTokens = DEFAULT_CONTEXT_TOKENS;
       }
       if (!inputTokens || inputTokens === 0) {
         inputTokens = logUsage.input;
@@ -437,7 +419,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     : undefined;
 
   const contextLine = [
-    `Context: ${formatTokens(totalTokens, contextTokens ?? null)}`,
+    `Tokens: ${formatTokens(totalTokens)}`,
     `🧹 Compactions: ${entry?.compactionCount ?? 0}`,
   ]
     .filter(Boolean)

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -366,19 +366,6 @@ export function buildStatusMessage(args: StatusArgs): string {
       if (!totalTokens || totalTokens === 0 || candidate > totalTokens) {
         totalTokens = candidate;
       }
-      if (!entry?.model && logUsage.model) {
-        const slashIndex = logUsage.model.indexOf("/");
-        if (slashIndex > 0) {
-          const provider = logUsage.model.slice(0, slashIndex).trim();
-          const model = logUsage.model.slice(slashIndex + 1).trim();
-          if (provider && model) {
-            _activeProvider = provider;
-            _activeModel = model;
-          }
-        } else {
-          _activeModel = logUsage.model;
-        }
-      }
       if (!inputTokens || inputTokens === 0) {
         inputTokens = logUsage.input;
       }

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -131,9 +131,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
           ["remoteclaw sessions --active 120", "Only last 2 hours."],
           ["remoteclaw sessions --json", "Machine-readable output."],
           ["remoteclaw sessions --store ./tmp/sessions.json", "Use a specific session store."],
-        ])}\n\n${theme.muted(
-          "Shows token usage per session when the agent reports it; set agents.defaults.contextTokens to cap the window and show %.",
-        )}`,
+        ])}\n\n${theme.muted("Shows token usage per session when the agent reports it.")}`,
     )
     .addHelpText(
       "after",

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -488,7 +488,6 @@ export async function agentCommand(
     if (sessionStore && sessionKey) {
       await updateSessionStoreAfterAgentRun({
         cfg,
-        contextTokensOverride: agentCfg?.contextTokens,
         sessionId,
         sessionKey,
         storePath,

--- a/src/commands/agent/session-store.ts
+++ b/src/commands/agent/session-store.ts
@@ -8,7 +8,6 @@ import type { AgentDeliveryResult } from "../../middleware/types.js";
 
 export async function updateSessionStoreAfterAgentRun(params: {
   cfg: RemoteClawConfig;
-  contextTokensOverride?: number;
   sessionId: string;
   sessionKey: string;
   storePath: string;
@@ -45,8 +44,6 @@ export async function updateSessionStoreAfterAgentRun(params: {
     : undefined;
   const modelUsed = fallbackModel ?? defaultModel;
   const providerUsed = fallbackProvider ?? defaultProvider;
-  const contextTokens = params.contextTokensOverride ?? 200_000;
-
   const entry = sessionStore[sessionKey] ?? {
     sessionId,
     updatedAt: Date.now(),
@@ -55,7 +52,6 @@ export async function updateSessionStoreAfterAgentRun(params: {
     ...entry,
     sessionId,
     updatedAt: Date.now(),
-    contextTokens,
   };
   next.modelProvider = providerUsed;
   next.model = modelUsed;
@@ -72,7 +68,6 @@ export async function updateSessionStoreAfterAgentRun(params: {
     const totalTokens =
       deriveSessionTotalTokens({
         usage,
-        contextTokens,
       }) ?? input;
     next.inputTokens = input;
     next.outputTokens = output;

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -24,7 +24,6 @@ export type SessionDisplayRow = {
   modelProvider?: string;
   providerOverride?: string;
   modelOverride?: string;
-  contextTokens?: number;
 };
 
 export type SessionDisplayDefaults = {
@@ -57,7 +56,6 @@ export function toSessionDisplayRows(store: Record<string, SessionEntry>): Sessi
         modelProvider: entry?.modelProvider,
         providerOverride: entry?.providerOverride,
         modelOverride: entry?.modelOverride,
-        contextTokens: entry?.contextTokens,
       } satisfies SessionDisplayRow;
     })
     .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));

--- a/src/commands/sessions.default-agent-store.test.ts
+++ b/src/commands/sessions.default-agent-store.test.ts
@@ -7,7 +7,6 @@ const loadConfigMock = vi.hoisted(() =>
       defaults: {
         model: { primary: "pi:opus" },
         models: { "pi:opus": {} },
-        contextTokens: 32000,
       },
       list: [{ id: "main" }, { id: "voice" }],
     },

--- a/src/commands/sessions.test-helpers.ts
+++ b/src/commands/sessions.test-helpers.ts
@@ -15,7 +15,6 @@ export function mockSessionsConfig() {
           defaults: {
             model: { primary: "pi:opus" },
             models: { "pi:opus": {} },
-            contextTokens: 32000,
           },
         },
       }),

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -42,12 +42,11 @@ describe("sessionsCommand", () => {
 
     fs.rmSync(store);
 
-    const tableHeader = logs.find((line) => line.includes("Tokens (ctx %"));
+    const tableHeader = logs.find((line) => line.includes("Tokens"));
     expect(tableHeader).toBeTruthy();
 
     const row = logs.find((line) => line.includes("+15555550123")) ?? "";
-    // Config sets contextTokens: 32000 → 2000/32000 = 6%
-    expect(row).toContain("2.0k/32k (6%)");
+    expect(row).toContain("2.0k");
     expect(row).toContain("45m ago");
     expect(row).toContain("pi:opus");
   });
@@ -66,8 +65,7 @@ describe("sessionsCommand", () => {
     fs.rmSync(store);
 
     const row = logs.find((line) => line.includes("discord:group:demo")) ?? "";
-    // Config sets contextTokens: 32000
-    expect(row).toContain("unknown/32k (?%)");
+    expect(row).toContain("unknown");
     expect(row).toContain("5m ago");
   });
 

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import { loadConfig } from "../config/config.js";
 import { loadSessionStore, resolveFreshSessionTotalTokens } from "../config/sessions.js";
 import { classifySessionKey } from "../gateway/session-utils.js";
@@ -32,38 +31,13 @@ const TOKENS_PAD = 20;
 
 const formatKTokens = (value: number) => `${(value / 1000).toFixed(value >= 10_000 ? 0 : 1)}k`;
 
-const colorByPct = (label: string, pct: number | null, rich: boolean) => {
-  if (!rich || pct === null) {
-    return label;
-  }
-  if (pct >= 95) {
-    return theme.error(label);
-  }
-  if (pct >= 80) {
-    return theme.warn(label);
-  }
-  if (pct >= 60) {
-    return theme.success(label);
-  }
-  return theme.muted(label);
-};
-
-const formatTokensCell = (
-  total: number | undefined,
-  contextTokens: number | null,
-  rich: boolean,
-) => {
+const formatTokensCell = (total: number | undefined, rich: boolean) => {
   if (total === undefined) {
-    const ctxLabel = contextTokens ? formatKTokens(contextTokens) : "?";
-    const label = `unknown/${ctxLabel} (?%)`;
+    const label = "unknown";
     return rich ? theme.muted(label.padEnd(TOKENS_PAD)) : label.padEnd(TOKENS_PAD);
   }
-  const totalLabel = formatKTokens(total);
-  const ctxLabel = contextTokens ? formatKTokens(contextTokens) : "?";
-  const pct = contextTokens ? Math.min(999, Math.round((total / contextTokens) * 100)) : null;
-  const label = `${totalLabel}/${ctxLabel} (${pct ?? "?"}%)`;
-  const padded = label.padEnd(TOKENS_PAD);
-  return colorByPct(padded, pct, rich);
+  const label = formatKTokens(total);
+  return label.padEnd(TOKENS_PAD);
 };
 
 const formatKindCell = (kind: SessionRow["kind"], rich: boolean) => {
@@ -90,7 +64,6 @@ export async function sessionsCommand(
   const aggregateAgents = opts.allAgents === true;
   const cfg = loadConfig();
   const displayDefaults = resolveSessionDisplayDefaults(cfg);
-  const configContextTokens = cfg.agents?.defaults?.contextTokens ?? DEFAULT_CONTEXT_TOKENS;
   const targets = resolveSessionStoreTargetsOrExit({
     cfg,
     opts: {
@@ -158,7 +131,6 @@ export async function sessionsCommand(
               totalTokens: resolveFreshSessionTotalTokens(r) ?? null,
               totalTokensFresh:
                 typeof r.totalTokens === "number" ? r.totalTokensFresh !== false : false,
-              contextTokens: r.contextTokens ?? configContextTokens ?? null,
               model,
             };
           }),
@@ -194,7 +166,7 @@ export async function sessionsCommand(
     "Key".padEnd(SESSION_KEY_PAD),
     "Age".padEnd(SESSION_AGE_PAD),
     "Model".padEnd(SESSION_MODEL_PAD),
-    "Tokens (ctx %)".padEnd(TOKENS_PAD),
+    "Tokens".padEnd(TOKENS_PAD),
     "Flags",
   ].join(" ");
 
@@ -202,7 +174,6 @@ export async function sessionsCommand(
 
   for (const row of rows) {
     const model = resolveSessionDisplayModel(cfg, row, displayDefaults);
-    const contextTokens = row.contextTokens ?? configContextTokens;
     const total = resolveFreshSessionTotalTokens(row);
 
     const line = [
@@ -213,7 +184,7 @@ export async function sessionsCommand(
       formatSessionKeyCell(row.key, rich),
       formatSessionAgeCell(row.updatedAt, rich),
       formatSessionModelCell(model, rich),
-      formatTokensCell(total, contextTokens ?? null, rich),
+      formatTokensCell(total, rich),
       formatSessionFlagsCell(row, rich),
     ].join(" ");
 

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -18,12 +18,7 @@ import { statusAllCommand } from "./status-all.js";
 import { groupChannelIssuesByChannel } from "./status-all/channel-issues.js";
 import { formatGatewayAuthUsed } from "./status-all/format.js";
 import { getDaemonStatusSummary, getNodeDaemonStatusSummary } from "./status.daemon.js";
-import {
-  formatDuration,
-  formatKTokens,
-  formatTokensCompact,
-  shortenText,
-} from "./status.format.js";
+import { formatDuration, formatTokensCompact, shortenText } from "./status.format.js";
 import { resolveGatewayProbeAuth } from "./status.gateway-probe.js";
 import { scanStatus } from "./status.scan.js";
 import {
@@ -292,9 +287,6 @@ export async function statusCommand(
   })();
 
   const defaults = summary.sessions.defaults;
-  const defaultCtx = defaults.contextTokens
-    ? ` (${formatKTokens(defaults.contextTokens)} ctx)`
-    : "";
   const eventsValue =
     summary.queuedSystemEvents.length > 0 ? `${summary.queuedSystemEvents.length} queued` : "none";
 
@@ -366,7 +358,7 @@ export async function statusCommand(
     ...(lastHeartbeatValue ? [{ Item: "Last heartbeat", Value: lastHeartbeatValue }] : []),
     {
       Item: "Sessions",
-      Value: `${summary.sessions.count} active · default ${defaults.model ?? "unknown"}${defaultCtx} · ${storeLabel}`,
+      Value: `${summary.sessions.count} active · default ${defaults.model ?? "unknown"} · ${storeLabel}`,
     },
   ];
 

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -14,25 +14,13 @@ export const formatDuration = (ms: number | null | undefined) => {
 };
 
 export const formatTokensCompact = (
-  sess: Pick<
-    SessionStatus,
-    "totalTokens" | "contextTokens" | "percentUsed" | "cacheRead" | "cacheWrite"
-  >,
+  sess: Pick<SessionStatus, "totalTokens" | "cacheRead" | "cacheWrite">,
 ) => {
   const used = sess.totalTokens;
-  const ctx = sess.contextTokens;
   const cacheRead = sess.cacheRead;
   const cacheWrite = sess.cacheWrite;
 
-  let result = "";
-  if (used == null) {
-    result = ctx ? `unknown/${formatKTokens(ctx)} (?%)` : "unknown used";
-  } else if (!ctx) {
-    result = `${formatKTokens(used)} used`;
-  } else {
-    const pctLabel = sess.percentUsed != null ? `${sess.percentUsed}%` : "?%";
-    result = `${formatKTokens(used)}/${formatKTokens(ctx)} (${pctLabel})`;
-  }
+  let result = used == null ? "unknown used" : `${formatKTokens(used)} used`;
 
   // Add cache hit rate if there are cached reads
   if (typeof cacheRead === "number" && cacheRead > 0) {

--- a/src/commands/status.summary.redaction.test.ts
+++ b/src/commands/status.summary.redaction.test.ts
@@ -11,10 +11,7 @@ function createRecentSessionRow() {
     age: 2,
     totalTokens: 3,
     totalTokensFresh: true,
-    remainingTokens: 4,
-    percentUsed: 5,
     model: "gpt-5",
-    contextTokens: 200_000,
     flags: ["id:sess-1"],
   };
 }
@@ -31,7 +28,7 @@ describe("redactSensitiveStatusSummary", () => {
       sessions: {
         paths: ["/tmp/remoteclaw/sessions.json"],
         count: 1,
-        defaults: { model: "gpt-5", contextTokens: 200_000 },
+        defaults: { model: "gpt-5" },
         recent: [createRecentSessionRow()],
         byAgent: [
           {
@@ -46,7 +43,7 @@ describe("redactSensitiveStatusSummary", () => {
 
     const redacted = redactSensitiveStatusSummary(input);
     expect(redacted.sessions.paths).toEqual([]);
-    expect(redacted.sessions.defaults).toEqual({ model: null, contextTokens: null });
+    expect(redacted.sessions.defaults).toEqual({ model: null });
     expect(redacted.sessions.recent).toEqual([]);
     expect(redacted.sessions.byAgent[0]?.path).toBe("[redacted]");
     expect(redacted.sessions.byAgent[0]?.recent).toEqual([]);

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import {
@@ -62,7 +61,6 @@ export function redactSensitiveStatusSummary(summary: StatusSummary): StatusSumm
       paths: [],
       defaults: {
         model: null,
-        contextTokens: null,
       },
       recent: [],
       byAgent: summary.sessions.byAgent.map((entry) => ({
@@ -99,8 +97,6 @@ export async function getStatusSummary(
 
   // Gutted in RemoteClaw fork — CLI runtimes manage their own model selection
   const configModel = null;
-  const configContextTokens = cfg.agents?.defaults?.contextTokens ?? DEFAULT_CONTEXT_TOKENS;
-
   const now = Date.now();
   const storeCache = new Map<string, Record<string, SessionEntry | undefined>>();
   const loadStore = (storePath: string) => {
@@ -123,16 +119,9 @@ export async function getStatusSummary(
         const age = updatedAt ? now - updatedAt : null;
         const resolvedModel = resolveSessionModelRef(cfg, entry, opts.agentIdOverride);
         const model = resolvedModel.model ?? configModel ?? null;
-        const contextTokens = entry?.contextTokens ?? configContextTokens ?? null;
         const total = resolveFreshSessionTotalTokens(entry);
         const totalTokensFresh =
           typeof entry?.totalTokens === "number" ? entry?.totalTokensFresh !== false : false;
-        const remaining =
-          contextTokens != null && total !== undefined ? Math.max(0, contextTokens - total) : null;
-        const pct =
-          contextTokens && contextTokens > 0 && total !== undefined
-            ? Math.min(999, Math.round((total / contextTokens) * 100))
-            : null;
         const parsedAgentId = parseAgentSessionKey(key)?.agentId;
         const agentId = opts.agentIdOverride ?? parsedAgentId;
 
@@ -155,10 +144,7 @@ export async function getStatusSummary(
           cacheWrite: entry?.cacheWrite,
           totalTokens: total ?? null,
           totalTokensFresh,
-          remainingTokens: remaining,
-          percentUsed: pct,
           model,
-          contextTokens,
           flags: buildFlags(entry),
         } satisfies SessionStatus;
       })
@@ -204,7 +190,6 @@ export async function getStatusSummary(
       count: totalSessions,
       defaults: {
         model: configModel ?? null,
-        contextTokens: configContextTokens ?? null,
       },
       recent,
       byAgent,

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -23,7 +23,6 @@ function createDefaultSessionStoreEntry() {
     cacheRead: 2_000,
     cacheWrite: 1_000,
     totalTokens: 5_000,
-    contextTokens: 10_000,
     model: "pi:opus",
     sessionId: "abc123",
     systemSent: true,
@@ -36,7 +35,6 @@ function createUnknownUsageSessionStore() {
       updatedAt: Date.now() - 60_000,
       inputTokens: 2_000,
       outputTokens: 3_000,
-      contextTokens: 10_000,
       model: "pi:opus",
     },
   };
@@ -369,16 +367,9 @@ describe("statusCommand", () => {
     expect(payload.sessions.paths).toContain("/tmp/sessions.json");
     // Gutted in RemoteClaw fork — model defaults may be empty
     expect(payload.sessions.defaults).toBeDefined();
-    // resolveContextTokensForModel gutted to return 200000 as config default
-    expect(payload.sessions.defaults.contextTokens).toBe(200000);
-    // Session entry has contextTokens: 10_000, totalTokens: 5_000
-    // 5000/10000 * 100 = 50
-    expect(payload.sessions.recent[0].percentUsed).toBe(50);
     expect(payload.sessions.recent[0].cacheRead).toBe(2_000);
     expect(payload.sessions.recent[0].cacheWrite).toBe(1_000);
     expect(payload.sessions.recent[0].totalTokensFresh).toBe(true);
-    // 10000 - 5000 = 5000
-    expect(payload.sessions.recent[0].remainingTokens).toBe(5000);
     expect(payload.sessions.recent[0].flags).toContain("verbose:on");
     expect(payload.securityAudit.summary.critical).toBe(1);
     expect(payload.securityAudit.summary.warn).toBe(1);
@@ -393,15 +384,13 @@ describe("statusCommand", () => {
       const payload = JSON.parse(String(runtimeLogMock.mock.calls.at(-1)?.[0]));
       expect(payload.sessions.recent[0].totalTokens).toBeNull();
       expect(payload.sessions.recent[0].totalTokensFresh).toBe(false);
-      expect(payload.sessions.recent[0].percentUsed).toBeNull();
-      expect(payload.sessions.recent[0].remainingTokens).toBeNull();
     });
   });
 
   it("prints unknown usage in formatted output when totalTokens is missing", async () => {
     await withUnknownUsageStore(async () => {
       const logs = await runStatusAndGetLogs();
-      expect(logs.some((line) => line.includes("unknown/") && line.includes("(?%)"))).toBe(true);
+      expect(logs.some((line) => line.includes("unknown"))).toBe(true);
     });
   });
 
@@ -423,8 +412,6 @@ describe("statusCommand", () => {
       // "bootstrap files",
       "Sessions",
       "+1000",
-      // Session entry contextTokens: 10_000, totalTokens: 5_000 → 50%
-      "50%",
       // 3000 cache out of 5000 total = 60% cached (not 40%)
       // The cache display may differ due to context token changes
       "cached",
@@ -575,7 +562,6 @@ describe("statusCommand", () => {
             inputTokens: 1_000,
             outputTokens: 1_000,
             totalTokens: 2_000,
-            contextTokens: 10_000,
             model: "pi:opus",
           },
         };

--- a/src/commands/status.types.ts
+++ b/src/commands/status.types.ts
@@ -19,10 +19,7 @@ export type SessionStatus = {
   totalTokensFresh: boolean;
   cacheRead?: number;
   cacheWrite?: number;
-  remainingTokens: number | null;
-  percentUsed: number | null;
   model: string | null;
-  contextTokens: number | null;
   flags: string[];
 };
 
@@ -49,7 +46,7 @@ export type StatusSummary = {
   sessions: {
     paths: string[];
     count: number;
-    defaults: { model: string | null; contextTokens: number | null };
+    defaults: { model: string | null };
     recent: SessionStatus[];
     byAgent: Array<{
       agentId: string;

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -173,7 +173,6 @@ describe("redactConfigSnapshot", () => {
               {
                 id: "gpt-5",
                 maxTokens: 65536,
-                contextTokens: 200000,
                 maxTokensField: "max_completion_tokens",
               },
             ],
@@ -182,7 +181,6 @@ describe("redactConfigSnapshot", () => {
             maxTokens: 8192,
             maxOutputTokens: 4096,
             maxCompletionTokens: 2048,
-            contextTokens: 128000,
             tokenCount: 500,
             tokenLimit: 100000,
             tokenBudget: 50000,
@@ -199,7 +197,6 @@ describe("redactConfigSnapshot", () => {
       (models.providers as Record<string, unknown>).openai as Record<string, unknown>
     ).models ?? []) as Array<Record<string, unknown>>;
     expect(providerList[0]?.maxTokens).toBe(65536);
-    expect(providerList[0]?.contextTokens).toBe(200000);
     expect(providerList[0]?.maxTokensField).toBe("max_completion_tokens");
 
     const providers = (models.providers as Record<string, Record<string, unknown>>) ?? {};
@@ -208,7 +205,6 @@ describe("redactConfigSnapshot", () => {
     expect(providers.openai.maxTokens).toBe(8192);
     expect(providers.openai.maxOutputTokens).toBe(4096);
     expect(providers.openai.maxCompletionTokens).toBe(2048);
-    expect(providers.openai.contextTokens).toBe(128000);
     expect(providers.openai.tokenCount).toBe(500);
     expect(providers.openai.tokenLimit).toBe(100000);
     expect(providers.openai.tokenBudget).toBe(50000);

--- a/src/config/schema.hints.test.ts
+++ b/src/config/schema.hints.test.ts
@@ -13,7 +13,6 @@ describe("isSensitiveConfigPath", () => {
       "maxOutputTokens",
       "maxInputTokens",
       "maxCompletionTokens",
-      "contextTokens",
       "totalTokens",
       "tokenCount",
       "tokenLimit",

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -143,7 +143,6 @@ export type SessionEntry = {
   fallbackNoticeSelectedModel?: string;
   fallbackNoticeActiveModel?: string;
   fallbackNoticeReason?: string;
-  contextTokens?: number;
   compactionCount?: number;
   memoryFlushAt?: number;
   memoryFlushCompactionCount?: number;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -170,8 +170,6 @@ export type AgentDefaultsConfig = {
    * Include elapsed time in message envelopes ("on" | "off", default: "on").
    */
   envelopeElapsed?: "on" | "off";
-  /** Optional context window cap (used for runtime estimates + status %). */
-  contextTokens?: number;
   /** Optional CLI backends for text-only fallback (claude-cli, etc.). */
   cliBackends?: Record<string, CliBackendConfig>;
   /** Opt-in: prune old tool results from the LLM context to reduce token usage. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -46,7 +46,6 @@ export const AgentDefaultsSchema = z
     envelopeTimezone: z.string().optional(),
     envelopeTimestamp: z.union([z.literal("on"), z.literal("off")]).optional(),
     envelopeElapsed: z.union([z.literal("on"), z.literal("off")]).optional(),
-    contextTokens: z.number().int().positive().optional(),
     cliBackends: z.record(z.string(), CliBackendSchema).optional(),
     memorySearch: MemorySearchSchema,
     contextPruning: z

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -164,7 +164,6 @@ vi.mock("./session.js", () => ({
 
 vi.mock("../../agents/defaults.js", () => ({
   DEFAULT_AGENT_ID: "default",
-  DEFAULT_CONTEXT_TOKENS: 128000,
 }));
 
 export function makeCronSessionEntry(overrides?: Record<string, unknown>): CronSessionEntry {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -421,11 +421,9 @@ export async function runCronIsolatedAgentTurn(params: {
       : undefined;
     const modelUsed = model;
     const providerUsed = provider;
-    const contextTokens = agentCfg?.contextTokens ?? 200_000;
 
     cronSession.sessionEntry.modelProvider = providerUsed;
     cronSession.sessionEntry.model = modelUsed;
-    cronSession.sessionEntry.contextTokens = contextTokens;
     if (isCliProvider(providerUsed, cfgWithAgentDefaults)) {
       const cliSessionId = runResult.run.sessionId?.trim();
       if (cliSessionId) {
@@ -438,7 +436,6 @@ export async function runCronIsolatedAgentTurn(params: {
       const totalTokens =
         deriveSessionTotalTokens({
           usage,
-          contextTokens,
         }) ?? input;
       cronSession.sessionEntry.inputTokens = input;
       cronSession.sessionEntry.outputTokens = output;

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -383,7 +383,6 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         responseUsage: entry?.responseUsage,
         model: entry?.model,
         modelProvider: entry?.modelProvider,
-        contextTokens: entry?.contextTokens,
         sendPolicy: entry?.sendPolicy,
         label: entry?.label,
         origin: snapshotSessionOrigin(entry),

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -612,11 +612,10 @@ export function loadCombinedSessionStoreForGateway(cfg: RemoteClawConfig): {
   return { storePath, store: combined };
 }
 
-export function getSessionDefaults(cfg: RemoteClawConfig): GatewaySessionsDefaults {
+export function getSessionDefaults(_cfg: RemoteClawConfig): GatewaySessionsDefaults {
   return {
     modelProvider: "unknown",
     model: "unknown",
-    contextTokens: cfg.agents?.defaults?.contextTokens ?? 200_000,
   };
 }
 
@@ -814,7 +813,6 @@ export function listSessionsFromStore(params: {
         responseUsage: entry?.responseUsage,
         modelProvider,
         model,
-        contextTokens: entry?.contextTokens,
         deliveryContext: deliveryFields.deliveryContext,
         lastChannel: deliveryFields.lastChannel ?? entry?.lastChannel,
         lastTo: deliveryFields.lastTo ?? entry?.lastTo,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -10,7 +10,6 @@ import type { DeliveryContext } from "../utils/delivery-context.js";
 export type GatewaySessionsDefaults = {
   modelProvider: string | null;
   model: string | null;
-  contextTokens: number | null;
 };
 
 export type GatewaySessionRow = {
@@ -42,7 +41,6 @@ export type GatewaySessionRow = {
   responseUsage?: "on" | "off" | "tokens" | "full";
   modelProvider?: string;
   model?: string;
-  contextTokens?: number;
   deliveryContext?: DeliveryContext;
   lastChannel?: SessionEntry["lastChannel"];
   lastTo?: string;

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -46,14 +46,12 @@ export type GatewaySessionList = {
   defaults?: {
     model?: string | null;
     modelProvider?: string | null;
-    contextTokens?: number | null;
   };
   sessions: Array<
     Pick<
       SessionInfo,
       | "verboseLevel"
       | "model"
-      | "contextTokens"
       | "inputTokens"
       | "outputTokens"
       | "totalTokens"

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -341,20 +341,9 @@ export function formatTokens(total?: number | null, context?: number | null) {
   return `tokens ${totalLabel}/${formatTokenCount(context)}${pct !== null ? ` (${pct}%)` : ""}`;
 }
 
-export function formatContextUsageLine(params: {
-  total?: number | null;
-  context?: number | null;
-  remaining?: number | null;
-  percent?: number | null;
-}) {
-  const totalLabel = typeof params.total === "number" ? formatTokenCount(params.total) : "?";
-  const ctxLabel = typeof params.context === "number" ? formatTokenCount(params.context) : "?";
-  const pct = typeof params.percent === "number" ? Math.min(999, Math.round(params.percent)) : null;
-  const remainingLabel =
-    typeof params.remaining === "number" ? `${formatTokenCount(params.remaining)} left` : null;
-  const pctLabel = pct !== null ? `${pct}%` : null;
-  const extra = [remainingLabel, pctLabel].filter(Boolean).join(", ");
-  return `tokens ${totalLabel}/${ctxLabel}${extra ? ` (${extra})` : ""}`;
+export function formatContextUsageLine(params: { total?: number | null }) {
+  const totalLabel = typeof params.total === "number" ? formatTokenCount(params.total) : "unknown";
+  return `tokens ${totalLabel} used`;
 }
 
 export function asString(value: unknown, fallback = ""): string {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -30,7 +30,6 @@ type SessionActionContext = {
 type SessionInfoDefaults = {
   model?: string | null;
   modelProvider?: string | null;
-  contextTokens?: number | null;
 };
 
 type SessionInfoEntry = SessionInfo & {
@@ -138,12 +137,10 @@ export function createSessionActions(context: SessionActionContext) {
     force?: boolean;
   }) => {
     const entry = params.entry ?? undefined;
-    const defaults = params.defaults ?? lastSessionDefaults ?? undefined;
     const previousDefaults = lastSessionDefaults;
     const defaultsChanged = params.defaults
       ? previousDefaults?.model !== params.defaults.model ||
-        previousDefaults?.modelProvider !== params.defaults.modelProvider ||
-        previousDefaults?.contextTokens !== params.defaults.contextTokens
+        previousDefaults?.modelProvider !== params.defaults.modelProvider
       : false;
     if (params.defaults) {
       lastSessionDefaults = params.defaults;
@@ -181,10 +178,6 @@ export function createSessionActions(context: SessionActionContext) {
     }
     if (entry?.totalTokens !== undefined) {
       next.totalTokens = entry.totalTokens;
-    }
-    if (entry?.contextTokens !== undefined || defaults?.contextTokens !== undefined) {
-      next.contextTokens =
-        entry?.contextTokens ?? defaults?.contextTokens ?? state.sessionInfo.contextTokens;
     }
     if (entry?.displayName !== undefined) {
       next.displayName = entry.displayName;

--- a/src/tui/tui-status-summary.ts
+++ b/src/tui/tui-status-summary.ts
@@ -1,5 +1,4 @@
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
-import { formatTokenCount } from "../utils/usage-format.js";
 import { formatContextUsageLine } from "./tui-formatters.js";
 import type { GatewayStatusSummary } from "./tui-types.js";
 
@@ -50,11 +49,7 @@ export function formatStatusSummary(summary: GatewayStatusSummary) {
 
   const defaults = summary.sessions?.defaults;
   const defaultModel = defaults?.model ?? "unknown";
-  const defaultCtx =
-    typeof defaults?.contextTokens === "number"
-      ? ` (${formatTokenCount(defaults.contextTokens)} ctx)`
-      : "";
-  lines.push(`Default model: ${defaultModel}${defaultCtx}`);
+  lines.push(`Default model: ${defaultModel}`);
 
   const sessionCount = summary.sessions?.count ?? 0;
   lines.push(`Active sessions: ${sessionCount}`);
@@ -67,9 +62,6 @@ export function formatStatusSummary(summary: GatewayStatusSummary) {
       const model = entry.model ?? "unknown";
       const usage = formatContextUsageLine({
         total: entry.totalTokens ?? null,
-        context: entry.contextTokens ?? null,
-        remaining: entry.remainingTokens ?? null,
-        percent: entry.percentUsed ?? null,
       });
       const flags = entry.flags?.length ? ` | flags: ${entry.flags.join(", ")}` : "";
       lines.push(

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -32,7 +32,6 @@ export type SessionInfo = {
   reasoningLevel?: string;
   model?: string;
   modelProvider?: string;
-  contextTokens?: number | null;
   inputTokens?: number | null;
   outputTokens?: number | null;
   totalTokens?: number | null;
@@ -69,7 +68,7 @@ export type GatewayStatusSummary = {
   sessions?: {
     paths?: string[];
     count?: number;
-    defaults?: { model?: string | null; contextTokens?: number | null };
+    defaults?: { model?: string | null };
     recent?: Array<{
       agentId?: string;
       key: string;
@@ -78,9 +77,6 @@ export type GatewayStatusSummary = {
       age?: number | null;
       model?: string | null;
       totalTokens?: number | null;
-      contextTokens?: number | null;
-      remainingTokens?: number | null;
-      percentUsed?: number | null;
       flags?: string[];
     }>;
   };

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -723,7 +723,7 @@ export async function runTui(opts: TuiOptions) {
         ? `${sessionInfo.modelProvider}/${sessionInfo.model}`
         : sessionInfo.model
       : "unknown";
-    const tokens = formatTokens(sessionInfo.totalTokens ?? null, sessionInfo.contextTokens ?? null);
+    const tokens = formatTokens(sessionInfo.totalTokens ?? null);
     const think = sessionInfo.thinkingLevel ?? "off";
     const verbose = sessionInfo.verboseLevel ?? "off";
     const reasoning = sessionInfo.reasoningLevel ?? "off";

--- a/ui/src/ui/presenter.ts
+++ b/ui/src/ui/presenter.ts
@@ -27,8 +27,7 @@ export function formatSessionTokens(row: GatewaySessionRow) {
     return "n/a";
   }
   const total = row.totalTokens ?? 0;
-  const ctx = row.contextTokens ?? 0;
-  return ctx ? `${total} / ${ctx}` : String(total);
+  return String(total);
 }
 
 export function formatEventPayload(payload: unknown): string {

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -323,7 +323,6 @@ export type PresenceEntry = {
 
 export type GatewaySessionsDefaults = {
   model: string | null;
-  contextTokens: number | null;
 };
 
 export type GatewayAgentRow = {
@@ -431,7 +430,6 @@ export type GatewaySessionRow = {
   totalTokens?: number;
   model?: string;
   modelProvider?: string;
-  contextTokens?: number;
 };
 
 export type SessionsListResult = {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -8,7 +8,7 @@ function createSessions(): SessionsListResult {
     ts: 0,
     path: "",
     count: 0,
-    defaults: { model: null, contextTokens: null },
+    defaults: { model: null },
     sessions: [],
   };
 }

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -8,7 +8,7 @@ function buildResult(session: SessionsListResult["sessions"][number]): SessionsL
     ts: Date.now(),
     path: "(multiple)",
     count: 1,
-    defaults: { model: null, contextTokens: null },
+    defaults: { model: null },
     sessions: [session],
   };
 }


### PR DESCRIPTION
## Summary

- Remove `contextTokens` field from `SessionEntry`, `AgentDefaultsConfig`, Zod schema, and all downstream types (status, gateway, TUI, UI, native apps)
- Delete `DEFAULT_CONTEXT_TOKENS` constant, `lookupContextTokens` stub, `resolveContextTokens` stub, and the `contextTokensUsed` resolution chain in agent-runner
- Remove derived fields `remainingTokens` and `percentUsed` from `SessionStatus` and all consumers
- Simplify token display from `"45k/200k (22%)"` to `"45k used"` across status output, sessions list, TUI, macOS app, and shared kit

## Rationale

The `contextTokens` denominator defaulted to 200k regardless of actual runtime context window (Gemini has 1M, some Claude models have 1M). The lookup stubs were gutted in the RemoteClaw fork, making the resolution chain always fall through to hardcoded values. Removing the misleading percentage is better than displaying an inaccurate one.

Real token counting infrastructure (`totalTokens`, `inputTokens`, `outputTokens`, `cacheRead`, `cacheWrite`) is fully preserved.

Closes #2133

## Test plan

- [x] `pnpm check` passes (format, typecheck, lint)
- [x] All 12,129 tests pass (1374/1375 test files — 1 pre-existing timeout in `server.roles-allowlist-update.test.ts`)
- [x] `grep -r contextTokens src/ ui/ apps/ docs/` returns no matches
- [x] `grep -r DEFAULT_CONTEXT_TOKENS` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)