### PR TITLE
gut(session): fix session key agent resolution for legacy keys

### DIFF
--- a/src/agents/agent-scope.resolve-session-key.test.ts
+++ b/src/agents/agent-scope.resolve-session-key.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RemoteClawConfig } from "../config/config.js";
+
+const { warnMock } = vi.hoisted(() => ({
+  warnMock: vi.fn(),
+}));
+
+vi.mock("../logging/subsystem.js", () => {
+  const makeLogger = () => ({
+    subsystem: "agents/scope",
+    isEnabled: () => true,
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: warnMock,
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: () => makeLogger(),
+  });
+  return { createSubsystemLogger: () => makeLogger() };
+});
+
+import { resolveSessionKeyAgentId } from "./agent-scope.js";
+
+describe("resolveSessionKeyAgentId", () => {
+  beforeEach(() => {
+    warnMock.mockClear();
+  });
+
+  describe("valid agent: prefix keys", () => {
+    it("returns parsed agent ID from canonical key", () => {
+      const cfg: RemoteClawConfig = {
+        agents: { list: [{ id: "main" }, { id: "work" }] },
+      };
+      expect(resolveSessionKeyAgentId("agent:work:main", cfg)).toBe("work");
+      expect(warnMock).not.toHaveBeenCalled();
+    });
+
+    it("normalizes agent ID case", () => {
+      const cfg: RemoteClawConfig = {
+        agents: { list: [{ id: "Main" }] },
+      };
+      expect(resolveSessionKeyAgentId("AGENT:Main:session", cfg)).toBe("main");
+      expect(warnMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("single-agent + legacy key", () => {
+    it("infers sole agent seamlessly without warning", () => {
+      const cfg: RemoteClawConfig = {
+        agents: { list: [{ id: "home" }] },
+      };
+      expect(resolveSessionKeyAgentId("main", cfg)).toBe("home");
+      expect(warnMock).not.toHaveBeenCalled();
+    });
+
+    it("infers sole agent for channel-style legacy keys", () => {
+      const cfg: RemoteClawConfig = {
+        agents: { list: [{ id: "ops" }] },
+      };
+      expect(resolveSessionKeyAgentId("discord:direct:user123", cfg)).toBe("ops");
+      expect(warnMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("multi-agent + legacy key", () => {
+    it("returns first configured agent and logs warning", () => {
+      const cfg: RemoteClawConfig = {
+        agents: { list: [{ id: "alpha" }, { id: "beta" }] },
+      };
+      const result = resolveSessionKeyAgentId("main", cfg);
+      expect(result).toBe("alpha");
+      expect(warnMock).toHaveBeenCalledOnce();
+      expect(warnMock).toHaveBeenCalledWith(
+        expect.stringContaining("legacy session key"),
+        expect.objectContaining({
+          sessionKey: "main",
+          chosenAgent: "alpha",
+        }),
+      );
+    });
+
+    it("warning includes the session key and chosen agent", () => {
+      const cfg: RemoteClawConfig = {
+        agents: { list: [{ id: "prod" }, { id: "staging" }] },
+      };
+      resolveSessionKeyAgentId("discord:direct:user456", cfg);
+      expect(warnMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          sessionKey: "discord:direct:user456",
+          chosenAgent: "prod",
+        }),
+      );
+    });
+  });
+
+  describe("malformed agent key", () => {
+    it("logs warning for malformed agent: prefix key", () => {
+      const cfg: RemoteClawConfig = {
+        agents: { list: [{ id: "main" }] },
+      };
+      resolveSessionKeyAgentId("agent::broken", cfg);
+      expect(warnMock).toHaveBeenCalledOnce();
+      expect(warnMock).toHaveBeenCalledWith(
+        expect.stringContaining("malformed session key"),
+        expect.objectContaining({ sessionKey: "agent::broken" }),
+      );
+    });
+
+    it("falls back to sole agent for malformed key in single-agent config", () => {
+      const cfg: RemoteClawConfig = {
+        agents: { list: [{ id: "home" }] },
+      };
+      expect(resolveSessionKeyAgentId("agent:main", cfg)).toBe("home");
+      expect(warnMock).toHaveBeenCalledOnce();
+    });
+
+    it("falls back to first agent for malformed key in multi-agent config", () => {
+      const cfg: RemoteClawConfig = {
+        agents: { list: [{ id: "alpha" }, { id: "beta" }] },
+      };
+      expect(resolveSessionKeyAgentId("agent::broken", cfg)).toBe("alpha");
+    });
+  });
+
+  describe("missing key", () => {
+    it("returns sole agent for undefined key without warning", () => {
+      const cfg: RemoteClawConfig = {
+        agents: { list: [{ id: "home" }] },
+      };
+      expect(resolveSessionKeyAgentId(undefined, cfg)).toBe("home");
+      expect(warnMock).not.toHaveBeenCalled();
+    });
+
+    it("returns sole agent for empty string without warning", () => {
+      const cfg: RemoteClawConfig = {
+        agents: { list: [{ id: "ops" }] },
+      };
+      expect(resolveSessionKeyAgentId("", cfg)).toBe("ops");
+      expect(warnMock).not.toHaveBeenCalled();
+    });
+
+    it("returns first agent for missing key in multi-agent config", () => {
+      const cfg: RemoteClawConfig = {
+        agents: { list: [{ id: "alpha" }, { id: "beta" }] },
+      };
+      expect(resolveSessionKeyAgentId(null, cfg)).toBe("alpha");
+      expect(warnMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("no agents configured", () => {
+    it("returns default agent ID for legacy key", () => {
+      const cfg: RemoteClawConfig = {};
+      expect(resolveSessionKeyAgentId("main", cfg)).toBe("main");
+    });
+
+    it("returns default agent ID for missing key", () => {
+      const cfg: RemoteClawConfig = {};
+      expect(resolveSessionKeyAgentId(undefined, cfg)).toBe("main");
+    });
+  });
+});

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -1,13 +1,17 @@
 import path from "node:path";
 import type { RemoteClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   DEFAULT_AGENT_ID,
+  classifySessionKeyShape,
   normalizeAgentId,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
 } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
+
+const log = createSubsystemLogger("agents/scope");
 
 /** Strip null bytes from paths to prevent ENOTDIR errors. */
 function stripNullBytes(s: string): string {
@@ -105,6 +109,58 @@ export function requireSoleAgentId(cfg: RemoteClawConfig): string {
  */
 export function resolveDefaultAgentId(cfg: RemoteClawConfig): string {
   return resolveSoleAgentId(cfg) ?? DEFAULT_AGENT_ID;
+}
+
+/**
+ * Resolve the agent ID for a session key with config-aware fallback.
+ *
+ * - Valid `agent:` prefix key → parsed agent ID.
+ * - Legacy/alias key (no prefix), single-agent config → sole agent inferred seamlessly.
+ * - Legacy/alias key, multi-agent config → first configured agent, warning logged.
+ * - Malformed `agent:` key → warning logged, best-effort fallback to sole/first agent.
+ * - Missing/empty key → sole/first agent (no warning).
+ */
+export function resolveSessionKeyAgentId(
+  sessionKey: string | undefined | null,
+  cfg: RemoteClawConfig,
+): string {
+  const shape = classifySessionKeyShape(sessionKey);
+
+  switch (shape) {
+    case "agent": {
+      const parsed = parseAgentSessionKey(sessionKey);
+      // classifySessionKeyShape returns "agent" only when parseAgentSessionKey succeeds
+      return normalizeAgentId(parsed!.agentId);
+    }
+
+    case "legacy_or_alias": {
+      const sole = resolveSoleAgentId(cfg);
+      if (sole) {
+        return sole;
+      }
+      const agents = listAgentIds(cfg);
+      const chosen = agents[0];
+      log.warn("legacy session key without agent: prefix in multi-agent config; inferring agent", {
+        sessionKey: (sessionKey ?? "").trim(),
+        chosenAgent: chosen,
+      });
+      return chosen;
+    }
+
+    case "malformed_agent": {
+      log.warn("malformed session key — cannot determine agent", {
+        sessionKey: (sessionKey ?? "").trim(),
+      });
+      const sole = resolveSoleAgentId(cfg);
+      return sole ?? listAgentIds(cfg)[0];
+    }
+
+    case "missing":
+    default: {
+      const sole = resolveSoleAgentId(cfg);
+      return sole ?? listAgentIds(cfg)[0];
+    }
+  }
 }
 
 export function resolveSessionAgentIds(params: {

--- a/src/agents/subagent-depth.ts
+++ b/src/agents/subagent-depth.ts
@@ -3,7 +3,7 @@ import JSON5 from "json5";
 import type { RemoteClawConfig } from "../config/config.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { getSubagentDepth, parseAgentSessionKey } from "../sessions/session-key-utils.js";
-import { resolveDefaultAgentId } from "./agent-scope.js";
+import { listAgentIds, resolveSoleAgentId } from "./agent-scope.js";
 
 type SessionDepthEntry = {
   sessionId?: unknown;
@@ -57,8 +57,8 @@ function buildKeyCandidates(rawKey: string, cfg?: RemoteClawConfig): string[] {
   if (parseAgentSessionKey(rawKey)) {
     return [rawKey];
   }
-  const defaultAgentId = resolveDefaultAgentId(cfg);
-  const prefixed = `agent:${defaultAgentId}:${rawKey}`;
+  const agentId = resolveSoleAgentId(cfg) ?? listAgentIds(cfg)[0];
+  const prefixed = `agent:${agentId}:${rawKey}`;
   return prefixed === rawKey ? [rawKey] : [rawKey, prefixed];
 }
 

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
-import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { resolveSessionKeyAgentId } from "../../agents/agent-scope.js";
 import { killSessionRun, waitForSessionRunEnd } from "../../agents/session-run-registry.js";
 import {
   listSubagentRunsForRequester,
@@ -20,11 +20,7 @@ import {
 import { unbindThreadBindingsBySessionKey } from "../../discord/monitor/thread-bindings.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import {
-  isSubagentSessionKey,
-  normalizeAgentId,
-  parseAgentSessionKey,
-} from "../../routing/session-key.js";
+import { isSubagentSessionKey } from "../../routing/session-key.js";
 import {
   ErrorCodes,
   errorShape,
@@ -319,8 +315,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       respond(false, undefined, applied.error);
       return;
     }
-    const parsed = parseAgentSessionKey(target.canonicalKey ?? key);
-    const agentId = normalizeAgentId(parsed?.agentId ?? resolveDefaultAgentId(cfg));
+    const agentId = resolveSessionKeyAgentId(target.canonicalKey ?? key, cfg);
     const resolved = resolveSessionModelRef(cfg, applied.entry, agentId);
     const result: SessionsPatchResult = {
       ok: true,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+  resolveSessionKeyAgentId,
+} from "../agents/agent-scope.js";
 // Model management defaults gutted in RemoteClaw — CLI runtimes own model selection.
 import { parseModelRef } from "../agents/provider-utils.js";
 import { type RemoteClawConfig, loadConfig } from "../config/config.js";
@@ -783,8 +787,7 @@ export function listSessionsFromStore(params: {
         entry?.label ??
         originLabel;
       const deliveryFields = normalizeSessionDeliveryFields(entry);
-      const parsedAgent = parseAgentSessionKey(key);
-      const sessionAgentId = normalizeAgentId(parsedAgent?.agentId ?? resolveDefaultAgentId(cfg));
+      const sessionAgentId = resolveSessionKeyAgentId(key, cfg);
       const resolvedModel = resolveSessionModelIdentityRef(cfg, entry, sessionAgentId);
       const modelProvider = resolvedModel.provider;
       const model = resolvedModel.model ?? "unknown";
@@ -844,9 +847,7 @@ export function listSessionsFromStore(params: {
     let lastMessagePreview: string | undefined;
     if (entry?.sessionId) {
       if (includeDerivedTitles || includeLastMessage) {
-        const parsed = parseAgentSessionKey(s.key);
-        const agentId =
-          parsed && parsed.agentId ? normalizeAgentId(parsed.agentId) : resolveDefaultAgentId(cfg);
+        const agentId = resolveSessionKeyAgentId(s.key, cfg);
         const fields = readSessionTitleFieldsFromTranscript(
           entry.sessionId,
           storePath,


### PR DESCRIPTION
## Summary

- Add `resolveSessionKeyAgentId()` — config-aware session key → agent ID resolution that replaces the `parsed?.agentId ?? resolveDefaultAgentId(cfg)` pattern at session fallback sites
- Single-agent + legacy key → sole agent inferred seamlessly (no warning)
- Multi-agent + legacy key → first configured agent chosen, warning logged with session key and chosen agent
- Malformed `agent:` key → warning logged, best-effort fallback
- Migrate `session-utils.ts` (2 sites), `sessions.ts` (1 site), `subagent-depth.ts` (1 site) away from `resolveDefaultAgentId`

Closes #1578

## Test plan

- [x] 14 new tests covering all session key shapes × agent config combinations
- [x] All 757 existing tests pass (no regressions)
- [x] TypeScript type-check clean
- [x] Lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)