### PR TITLE
gut: decouple workspace resolution from agent identity

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -100,6 +100,32 @@ export function requireSoleAgentId(cfg: RemoteClawConfig): string {
 }
 
 /**
+ * Returns a workspace directory without requiring a specific agent ID.
+ *
+ * Resolution order:
+ * 1. `agents.defaults.workspace` if set
+ * 2. First agent entry's `workspace` if set
+ * 3. `null` when no workspace is available
+ *
+ * Use this for call sites that only need a workspace directory (plugin loading,
+ * config validation, CLI commands) and don't care which agent owns it.
+ */
+export function resolveFirstAgentWorkspace(cfg: RemoteClawConfig): string | null {
+  const defaultsWorkspace = cfg.agents?.defaults?.workspace?.trim();
+  if (defaultsWorkspace) {
+    return stripNullBytes(resolveUserPath(defaultsWorkspace));
+  }
+  const agents = listAgentEntries(cfg);
+  if (agents.length > 0) {
+    const firstWorkspace = agents[0]?.workspace?.trim();
+    if (firstWorkspace) {
+      return stripNullBytes(resolveUserPath(firstWorkspace));
+    }
+  }
+  return null;
+}
+
+/**
  * @deprecated Use {@link resolveSoleAgentId} or {@link requireSoleAgentId} instead.
  * Temporary shim — will be removed once all callers migrate (#1576–#1581).
  */

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import type { Command } from "commander";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveFirstAgentWorkspace } from "../agents/agent-scope.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { loadConfig, writeConfigFile } from "../config/io.js";
 import {
@@ -64,7 +64,10 @@ function mergeHookEntries(pluginEntries: HookEntry[], workspaceEntries: HookEntr
 }
 
 function buildHooksReport(config: RemoteClawConfig): HookStatusReport {
-  const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+  const workspaceDir = resolveFirstAgentWorkspace(config);
+  if (!workspaceDir) {
+    return { workspaceDir: "", managedHooksDir: "", hooks: [] };
+  }
   const workspaceEntries = loadWorkspaceHookEntries(workspaceDir, { config });
   const pluginReport = buildPluginStatusReport({ config, workspaceDir });
   const pluginEntries = pluginReport.hooks.map((hook) => hook.entry);

--- a/src/cli/plugin-registry.test.ts
+++ b/src/cli/plugin-registry.test.ts
@@ -2,8 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getActivePluginRegistryMock = vi.fn();
 const loadConfigMock = vi.fn();
-const resolveAgentWorkspaceDirOrNullMock = vi.fn();
-const resolveDefaultAgentIdMock = vi.fn();
+const resolveFirstAgentWorkspaceMock = vi.fn();
 const loadRemoteClawPluginsMock = vi.fn();
 
 vi.mock("../plugins/runtime.js", () => ({
@@ -15,8 +14,7 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
-  resolveAgentWorkspaceDirOrNull: resolveAgentWorkspaceDirOrNullMock,
-  resolveDefaultAgentId: resolveDefaultAgentIdMock,
+  resolveFirstAgentWorkspace: resolveFirstAgentWorkspaceMock,
   resolveAgentRuntime: () => "claude",
 }));
 
@@ -42,11 +40,10 @@ describe("ensurePluginRegistryLoaded", () => {
     ({ ensurePluginRegistryLoaded } = await import("./plugin-registry.js"));
     getActivePluginRegistryMock.mockReturnValue(null);
     loadConfigMock.mockReturnValue({});
-    resolveDefaultAgentIdMock.mockReturnValue("main");
   });
 
   it("does not throw when no workspace is configured (fresh install)", () => {
-    resolveAgentWorkspaceDirOrNullMock.mockReturnValue(null);
+    resolveFirstAgentWorkspaceMock.mockReturnValue(null);
 
     expect(() => ensurePluginRegistryLoaded()).not.toThrow();
     expect(loadRemoteClawPluginsMock).toHaveBeenCalledWith(
@@ -55,7 +52,7 @@ describe("ensurePluginRegistryLoaded", () => {
   });
 
   it("passes resolved workspace to plugin loader", () => {
-    resolveAgentWorkspaceDirOrNullMock.mockReturnValue("/home/user/workspace");
+    resolveFirstAgentWorkspaceMock.mockReturnValue("/home/user/workspace");
 
     ensurePluginRegistryLoaded();
 
@@ -83,7 +80,7 @@ describe("ensurePluginRegistryLoaded", () => {
       channels: [],
       tools: [],
     });
-    resolveAgentWorkspaceDirOrNullMock.mockReturnValue(null);
+    resolveFirstAgentWorkspaceMock.mockReturnValue(null);
 
     ensurePluginRegistryLoaded();
 
@@ -91,7 +88,7 @@ describe("ensurePluginRegistryLoaded", () => {
   });
 
   it("does not reload on subsequent calls", () => {
-    resolveAgentWorkspaceDirOrNullMock.mockReturnValue(null);
+    resolveFirstAgentWorkspaceMock.mockReturnValue(null);
 
     ensurePluginRegistryLoaded();
     ensurePluginRegistryLoaded();

--- a/src/cli/plugin-registry.ts
+++ b/src/cli/plugin-registry.ts
@@ -1,4 +1,4 @@
-import { resolveAgentWorkspaceDirOrNull, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveFirstAgentWorkspace } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging.js";
 import { loadRemoteClawPlugins } from "../plugins/loader.js";
@@ -23,7 +23,7 @@ export function ensurePluginRegistryLoaded(): void {
     return;
   }
   const config = loadConfig();
-  const workspaceDir = resolveAgentWorkspaceDirOrNull(config, resolveDefaultAgentId(config));
+  const workspaceDir = resolveFirstAgentWorkspace(config);
   const logger: PluginLogger = {
     info: (msg) => log.info(msg),
     warn: (msg) => log.warn(msg),

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -1,4 +1,4 @@
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { resolveDefaultAgentId, resolveFirstAgentWorkspace } from "../../agents/agent-scope.js";
 import { listChannelPluginCatalogEntries } from "../../channels/plugins/catalog.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { moveSingleAccountChannelSectionToDefaultAccount } from "../../channels/plugins/setup-helpers.js";
@@ -44,7 +44,7 @@ function resolveCatalogChannelEntry(raw: string, cfg: RemoteClawConfig | null) {
   if (!trimmed) {
     return undefined;
   }
-  const workspaceDir = cfg ? resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)) : undefined;
+  const workspaceDir = cfg ? (resolveFirstAgentWorkspace(cfg) ?? undefined) : undefined;
   return listChannelPluginCatalogEntries({ workspaceDir }).find((entry) => {
     if (entry.id.toLowerCase() === trimmed) {
       return true;
@@ -187,7 +187,7 @@ export async function channelsAddCommand(
 
   if (!channel && catalogEntry) {
     const prompter = createClackPrompter();
-    const workspaceDir = resolveAgentWorkspaceDir(nextConfig, resolveDefaultAgentId(nextConfig));
+    const workspaceDir = resolveFirstAgentWorkspace(nextConfig) ?? undefined;
     const result = await ensureOnboardingPluginInstalled({
       cfg: nextConfig,
       entry: catalogEntry,

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -1,11 +1,14 @@
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveFirstAgentWorkspace } from "../agents/agent-scope.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { loadRemoteClawPlugins } from "../plugins/loader.js";
 import { note } from "../terminal/note.js";
 import { detectLegacyWorkspaceDirs, formatLegacyWorkspaceWarning } from "./doctor-workspace.js";
 
 export function noteWorkspaceStatus(cfg: RemoteClawConfig) {
-  const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+  const workspaceDir = resolveFirstAgentWorkspace(cfg);
+  if (!workspaceDir) {
+    return { workspaceDir: undefined };
+  }
   const legacyWorkspace = detectLegacyWorkspaceDirs({ workspaceDir });
   if (legacyWorkspace.legacyDirs.length > 0) {
     note(formatLegacyWorkspaceWarning(legacyWorkspace), "Extra workspace");

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import { intro as clackIntro, outro as clackOutro } from "@clack/prompts";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveFirstAgentWorkspace } from "../agents/agent-scope.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { CONFIG_PATH, readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
@@ -257,8 +257,10 @@ export async function doctorCommand(
   }
 
   if (options.workspaceSuggestions !== false) {
-    const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
-    noteWorkspaceBackupTip(workspaceDir);
+    const workspaceDir = resolveFirstAgentWorkspace(cfg);
+    if (workspaceDir) {
+      noteWorkspaceBackupTip(workspaceDir);
+    }
   }
 
   const finalSnapshot = await readConfigFileSnapshot();

--- a/src/commands/onboard-channels.ts
+++ b/src/commands/onboard-channels.ts
@@ -1,4 +1,4 @@
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveFirstAgentWorkspace } from "../agents/agent-scope.js";
 import { listChannelPluginCatalogEntries } from "../channels/plugins/catalog.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { listChannelPlugins, getChannelPlugin } from "../channels/plugins/index.js";
@@ -117,7 +117,7 @@ async function collectChannelStatus(params: {
 }): Promise<ChannelStatusSummary> {
   const installedPlugins = listChannelPlugins();
   const installedIds = new Set(installedPlugins.map((plugin) => plugin.id));
-  const workspaceDir = resolveAgentWorkspaceDir(params.cfg, resolveDefaultAgentId(params.cfg));
+  const workspaceDir = resolveFirstAgentWorkspace(params.cfg) ?? undefined;
   const catalogEntries = listChannelPluginCatalogEntries({ workspaceDir }).filter(
     (entry) => !installedIds.has(entry.id),
   );
@@ -413,7 +413,7 @@ export async function setupChannels(
     const core = listChatChannels();
     const installed = listChannelPlugins();
     const installedIds = new Set(installed.map((plugin) => plugin.id));
-    const workspaceDir = resolveAgentWorkspaceDir(next, resolveDefaultAgentId(next));
+    const workspaceDir = resolveFirstAgentWorkspace(next) ?? undefined;
     const catalog = listChannelPluginCatalogEntries({ workspaceDir }).filter(
       (entry) => !installedIds.has(entry.id),
     );
@@ -462,7 +462,7 @@ export async function setupChannels(
       );
       return false;
     }
-    const workspaceDir = resolveAgentWorkspaceDir(next, resolveDefaultAgentId(next));
+    const workspaceDir = resolveFirstAgentWorkspace(next) ?? undefined;
     reloadOnboardingPluginRegistry({
       cfg: next,
       runtime,
@@ -623,7 +623,7 @@ export async function setupChannels(
     const { catalogById } = getChannelEntries();
     const catalogEntry = catalogById.get(channel);
     if (catalogEntry) {
-      const workspaceDir = resolveAgentWorkspaceDir(next, resolveDefaultAgentId(next));
+      const workspaceDir = resolveFirstAgentWorkspace(next) ?? undefined;
       const result = await ensureOnboardingPluginInstalled({
         cfg: next,
         entry: catalogEntry,

--- a/src/commands/onboarding/plugin-install.ts
+++ b/src/commands/onboarding/plugin-install.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { resolveFirstAgentWorkspace } from "../../agents/agent-scope.js";
 import type { ChannelPluginCatalogEntry } from "../../channels/plugins/catalog.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -206,8 +206,7 @@ export function reloadOnboardingPluginRegistry(params: {
   runtime: RuntimeEnv;
   workspaceDir?: string;
 }): void {
-  const workspaceDir =
-    params.workspaceDir ?? resolveAgentWorkspaceDir(params.cfg, resolveDefaultAgentId(params.cfg));
+  const workspaceDir = params.workspaceDir ?? resolveFirstAgentWorkspace(params.cfg) ?? undefined;
   const log = createSubsystemLogger("plugins");
   loadRemoteClawPlugins({
     config: params.cfg,

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,5 +1,9 @@
 import path from "node:path";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+  resolveFirstAgentWorkspace,
+} from "../agents/agent-scope.js";
 import { CHANNEL_IDS, normalizeChatChannelId } from "../channels/registry.js";
 import {
   normalizePluginsConfig,
@@ -361,7 +365,7 @@ function validateConfigObjectWithPluginsBase(
       return registryInfo;
     }
 
-    const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+    const workspaceDir = resolveFirstAgentWorkspace(config);
     const registry = loadPluginManifestRegistry({
       config,
       workspaceDir: workspaceDir ?? undefined,

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1,4 +1,4 @@
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { resolveFirstAgentWorkspace } from "../../agents/agent-scope.js";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import {
   CONFIG_PATH,
@@ -210,7 +210,7 @@ async function tryWriteRestartSentinelPayload(
 
 function loadSchemaWithPlugins(): ConfigSchemaResponse {
   const cfg = loadConfig();
-  const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+  const workspaceDir = resolveFirstAgentWorkspace(cfg) ?? undefined;
   const pluginRegistry = loadRemoteClawPlugins({
     config: cfg,
     cache: true,

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveFirstAgentWorkspace } from "../agents/agent-scope.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -10,7 +10,7 @@ const log = createSubsystemLogger("plugins");
 
 export function registerPluginCliCommands(program: Command, cfg?: RemoteClawConfig) {
   const config = cfg ?? loadConfig();
-  const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+  const workspaceDir = resolveFirstAgentWorkspace(config) ?? undefined;
   const logger: PluginLogger = {
     info: (msg: string) => log.info(msg),
     warn: (msg: string) => log.warn(msg),

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -1,4 +1,4 @@
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveFirstAgentWorkspace } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { loadRemoteClawPlugins } from "./loader.js";
@@ -18,7 +18,7 @@ export function buildPluginStatusReport(params?: {
   const config = params?.config ?? loadConfig();
   const workspaceDir = params?.workspaceDir
     ? params.workspaceDir
-    : resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+    : (resolveFirstAgentWorkspace(config) ?? undefined);
 
   const registry = loadRemoteClawPlugins({
     config,


### PR DESCRIPTION
## Summary

Closes #1577.

- Add `resolveFirstAgentWorkspace(cfg)` to `agent-scope.ts` — returns `agents.defaults.workspace` if set, else first agent's workspace, else `null`
- Migrate all 11 workspace-convenience files (15 call sites) from the two-step `resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg))` pattern to the new single-call function
- Callers handle `null` gracefully via early returns or `?? undefined` coercion
- Reclassified agent-identity sites (`doctor-state-integrity`, `plugin-tools`, `commands-status`, `channels/add:137`) left untouched — those need sole-agent migration per #1575

## Test plan

- [x] TypeScript type-check passes (zero errors in `src/`)
- [x] Lint passes (oxlint, 0 warnings/errors)
- [x] Format passes (oxfmt)
- [x] All 693 test files pass (5923 tests)
- [x] Pre-commit hooks pass (format, typecheck, lint, rebrand-leakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)