### PR TITLE
gut(config): config migration for deprecated `default: true` field (#1581)

### DIFF
--- a/src/commands/import.test.ts
+++ b/src/commands/import.test.ts
@@ -203,6 +203,28 @@ describe("materializeWorkspaceDefaults", () => {
     const result = JSON.parse(materializeWorkspaceDefaults(input));
     expect(result.agents.list[0].workspace).toBe("~/.remoteclaw/workspace");
   });
+
+  it("strips deprecated default field from agent entries", () => {
+    const input = JSON.stringify({
+      agents: { list: [{ id: "main", default: true }] },
+    });
+    const result = JSON.parse(materializeWorkspaceDefaults(input));
+    expect(result.agents.list[0].default).toBeUndefined();
+    expect(result.agents.list[0].workspace).toBe("~/.remoteclaw/workspace");
+  });
+
+  it("strips deprecated default field and assigns workspace by sole-agent rule", () => {
+    const input = JSON.stringify({
+      agents: {
+        list: [{ id: "alpha", default: true }, { id: "beta" }],
+      },
+    });
+    const result = JSON.parse(materializeWorkspaceDefaults(input));
+    expect(result.agents.list[0].default).toBeUndefined();
+    expect(result.agents.list[1].default).toBeUndefined();
+    expect(result.agents.list[0].workspace).toBe("~/.remoteclaw/workspace-alpha");
+    expect(result.agents.list[1].workspace).toBe("~/.remoteclaw/workspace-beta");
+  });
 });
 
 describe("stripUnrecognizedConfigKeys", () => {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -391,8 +391,13 @@ export function materializeWorkspaceDefaults(jsonContent: string): string {
     config.agents = newAgents;
     mutated = true;
   } else {
-    // Step 1: Materialize workspace on existing agents
+    // Step 1: Materialize workspace on existing agents and strip deprecated `default` field
     for (const entry of agentsList) {
+      // Strip deprecated `default` field (#1581)
+      if (entry.default !== undefined) {
+        delete entry.default;
+        mutated = true;
+      }
       if (typeof entry.workspace === "string" && entry.workspace.trim()) {
         continue;
       }
@@ -400,8 +405,7 @@ export function materializeWorkspaceDefaults(jsonContent: string): string {
         entry.workspace = defaultsWorkspace;
       } else {
         const id = typeof entry.id === "string" ? entry.id.trim() : "";
-        const isDefault =
-          entry.default === true || id === DEFAULT_AGENT_ID || agentsList.length === 1;
+        const isDefault = id === DEFAULT_AGENT_ID || agentsList.length === 1;
         entry.workspace = isDefault
           ? DEFAULT_WORKSPACE
           : `~/.remoteclaw/workspace-${id || DEFAULT_AGENT_ID}`;

--- a/src/config/legacy.default-field.test.ts
+++ b/src/config/legacy.default-field.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { findLegacyConfigIssues } from "./legacy.js";
+import { applyLegacyMigrations } from "./legacy.js";
+import { AgentEntrySchema } from "./zod-schema.agent-runtime.js";
+
+describe("deprecated agents.list[].default field (#1581)", () => {
+  describe("zod schema acceptance", () => {
+    it("accepts agent entry with default: true without parse error", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main", default: true });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts agent entry with default: false without parse error", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main", default: false });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts agent entry without default field", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main" });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("legacy rule detection", () => {
+    it("detects default: true on agent list entries", () => {
+      const raw = {
+        agents: { list: [{ id: "main", default: true }] },
+      };
+      const issues = findLegacyConfigIssues(raw);
+      expect(issues.length).toBe(1);
+      expect(issues[0].path).toBe("agents.list");
+      expect(issues[0].message).toContain("default");
+    });
+
+    it("does not flag agents.list without default field", () => {
+      const raw = {
+        agents: { list: [{ id: "main" }] },
+      };
+      const issues = findLegacyConfigIssues(raw);
+      expect(issues.length).toBe(0);
+    });
+
+    it("does not flag agents.list with default: false", () => {
+      const raw = {
+        agents: { list: [{ id: "main", default: false }] },
+      };
+      const issues = findLegacyConfigIssues(raw);
+      expect(issues.length).toBe(0);
+    });
+
+    it("detects default: true when only some entries have it", () => {
+      const raw = {
+        agents: {
+          list: [{ id: "main", default: true }, { id: "helper" }],
+        },
+      };
+      const issues = findLegacyConfigIssues(raw);
+      expect(issues.length).toBe(1);
+    });
+  });
+
+  describe("legacy migration", () => {
+    it("strips default field from agent entries", () => {
+      const raw = {
+        agents: { list: [{ id: "main", default: true }] },
+      };
+      const { next, changes } = applyLegacyMigrations(raw);
+      expect(next).not.toBeNull();
+      expect(changes.length).toBe(1);
+      expect(changes[0]).toContain("default");
+      const list = (next as Record<string, unknown>).agents as Record<string, unknown>;
+      const entries = list.list as Array<Record<string, unknown>>;
+      expect(entries[0].default).toBeUndefined();
+      expect(entries[0].id).toBe("main");
+    });
+
+    it("strips default from multiple entries", () => {
+      const raw = {
+        agents: {
+          list: [
+            { id: "main", default: true },
+            { id: "helper", default: false },
+          ],
+        },
+      };
+      const { next, changes } = applyLegacyMigrations(raw);
+      expect(next).not.toBeNull();
+      expect(changes.length).toBe(1);
+      const list = (next as Record<string, unknown>).agents as Record<string, unknown>;
+      const entries = list.list as Array<Record<string, unknown>>;
+      expect(entries[0].default).toBeUndefined();
+      expect(entries[1].default).toBeUndefined();
+    });
+
+    it("returns null when no default field present", () => {
+      const raw = {
+        agents: { list: [{ id: "main" }] },
+      };
+      const { next, changes } = applyLegacyMigrations(raw);
+      expect(next).toBeNull();
+      expect(changes.length).toBe(0);
+    });
+  });
+});

--- a/src/config/legacy.migrations.ts
+++ b/src/config/legacy.migrations.ts
@@ -1,3 +1,24 @@
-import type { LegacyConfigMigration } from "./legacy.shared.js";
+import { getAgentsList, getRecord, type LegacyConfigMigration } from "./legacy.shared.js";
 
-export const LEGACY_CONFIG_MIGRATIONS: LegacyConfigMigration[] = [];
+export const LEGACY_CONFIG_MIGRATIONS: LegacyConfigMigration[] = [
+  {
+    id: "strip-agent-default-field",
+    describe: "Strip deprecated agents.list[].default field (#1581)",
+    apply(raw, changes) {
+      const agents = getRecord(raw.agents);
+      const list = getAgentsList(agents);
+      let stripped = false;
+      for (const entry of list) {
+        if (getRecord(entry)?.default !== undefined) {
+          delete (entry as Record<string, unknown>).default;
+          stripped = true;
+        }
+      }
+      if (stripped) {
+        changes.push(
+          "Stripped deprecated agents.list[].default field — sole-agent auto-selection replaces explicit defaults.",
+        );
+      }
+    },
+  },
+];

--- a/src/config/legacy.rules.ts
+++ b/src/config/legacy.rules.ts
@@ -17,6 +17,13 @@ function hasLegacyThreadBindingTtlInAccounts(value: unknown): boolean {
   );
 }
 
+function hasLegacyAgentDefaultField(value: unknown): boolean {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.some((entry) => isRecord(entry) && entry.default === true);
+}
+
 function isLegacyGatewayBindHostAlias(value: unknown): boolean {
   if (typeof value !== "string") {
     return false;
@@ -203,5 +210,11 @@ export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
       "gateway.bind host aliases (for example 0.0.0.0/localhost) are legacy; use bind modes (lan/loopback/custom/tailnet/auto) instead (auto-migrated on load).",
     match: (value) => isLegacyGatewayBindHostAlias(value),
     requireSourceLiteral: true,
+  },
+  {
+    path: ["agents", "list"],
+    message:
+      "agents.list[].default was removed; sole-agent auto-selection replaces explicit defaults (auto-migrated on load).",
+    match: (value) => hasLegacyAgentDefaultField(value),
   },
 ];

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -727,6 +727,8 @@ export const AgentEntrySchema = z
       .optional(),
     runtimeArgs: z.array(z.string()).optional(),
     runtimeEnv: z.record(z.string(), z.string()).optional(),
+    // Deprecated: accepted for backward compat, stripped by legacy migration (#1581)
+    default: z.boolean().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

- Zod schema accepts `default` field on agent entries silently (no unrecognized key parse error)
- Legacy rule in `remoteclaw doctor` warns when `default: true` found in raw config
- Legacy migration strips the `default` field automatically on load
- Import command strips `default` field and uses sole-agent workspace rules (no longer checks `entry.default === true`)
- Config merge-patch handled via legacy migration in the gateway config flow

Closes #1581

## Test plan

- [x] New test file `src/config/legacy.default-field.test.ts` — schema acceptance, rule detection, migration stripping
- [x] New tests in `src/commands/import.test.ts` — import strips `default` field, workspace assignment uses sole-agent logic
- [x] All 694 test files pass (5933 tests)
- [x] Typecheck, lint, format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)