### PR TITLE
gut: fix heartbeat and cron agent resolution (#1579)

### DIFF
--- a/src/cron/isolated-agent/run.auth-retry.test.ts
+++ b/src/cron/isolated-agent/run.auth-retry.test.ts
@@ -49,7 +49,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentRuntimeEnv: resolveAgentRuntimeEnvMock,
   resolveAgentRuntimeOrThrow: vi.fn().mockReturnValue("claude"),
   resolveAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/workspace"),
-  resolveDefaultAgentId: vi.fn().mockReturnValue("default"),
+  resolveSoleAgentId: vi.fn().mockReturnValue("default"),
 }));
 
 vi.mock("../../agents/workspace.js", () => ({
@@ -327,7 +327,7 @@ describe("runCronIsolatedAgentTurn — auth key retry wiring", () => {
     expect(runtimeEnvPassedToBridge).toEqual(injectedEnv);
   });
 
-  it("default agentId falls back to resolveDefaultAgentId", async () => {
+  it("default agentId falls back to resolveSoleAgentId", async () => {
     await runCronIsolatedAgentTurn(makeParams());
 
     const options = withAuthKeyRetryMock.mock.calls[0][0];

--- a/src/cron/isolated-agent/run.channel-bridge.test.ts
+++ b/src/cron/isolated-agent/run.channel-bridge.test.ts
@@ -70,7 +70,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentRuntimeEnv: vi.fn().mockReturnValue(undefined),
   resolveAgentRuntimeOrThrow: vi.fn().mockReturnValue("claude"),
   resolveAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/workspace"),
-  resolveDefaultAgentId: vi.fn().mockReturnValue("default"),
+  resolveSoleAgentId: vi.fn().mockReturnValue("default"),
 }));
 
 vi.mock("../../agents/workspace.js", () => ({

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -44,7 +44,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentRuntimeEnv: vi.fn().mockReturnValue(undefined),
   resolveAgentRuntimeOrThrow: vi.fn().mockReturnValue("claude"),
   resolveAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/workspace"),
-  resolveDefaultAgentId: vi.fn().mockReturnValue("default"),
+  resolveSoleAgentId: vi.fn().mockReturnValue("default"),
   resolveAgentSkillsFilter: resolveAgentSkillsFilterMock,
 }));
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -6,7 +6,7 @@ import {
   resolveAgentRuntimeEnv,
   resolveAgentRuntimeOrThrow,
   resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
+  resolveSoleAgentId,
 } from "../../agents/agent-scope.js";
 import { resolveChannelMessageToolHints } from "../../agents/channel-tools.js";
 import { getCliSessionId, setCliSessionId } from "../../agents/cli-session.js";
@@ -30,7 +30,11 @@ import { withAuthKeyRetry } from "../../middleware/auth-key-retry.js";
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
 import type { SessionMap } from "../../middleware/session-map.js";
 import type { AgentDeliveryResult, ChannelMessage } from "../../middleware/types.js";
-import { buildAgentMainSessionKey, normalizeAgentId } from "../../routing/session-key.js";
+import {
+  DEFAULT_AGENT_ID,
+  buildAgentMainSessionKey,
+  normalizeAgentId,
+} from "../../routing/session-key.js";
 import {
   buildSafeExternalPrompt,
   detectSuspiciousPatterns,
@@ -156,7 +160,7 @@ export async function runCronIsolatedAgentTurn(params: {
       : "cron: job execution timed out";
   };
   const isFastTestEnv = process.env.REMOTECLAW_TEST_FAST === "1";
-  const defaultAgentId = resolveDefaultAgentId(params.cfg);
+  const soleAgentId = resolveSoleAgentId(params.cfg);
   const requestedAgentId =
     typeof params.agentId === "string" && params.agentId.trim()
       ? params.agentId
@@ -167,10 +171,10 @@ export async function runCronIsolatedAgentTurn(params: {
   const agentConfigOverride = normalizedRequested
     ? resolveAgentConfig(params.cfg, normalizedRequested)
     : undefined;
-  // Use the requested agentId even when there is no explicit agent config entry.
+  // Use the requested agentId, falling back to the sole configured agent.
   // This ensures auth-profiles, workspace, and agentDir all resolve to the
   // correct per-agent paths (e.g. ~/.remoteclaw/agents/<agentId>/agent/).
-  const agentId = normalizedRequested ?? defaultAgentId;
+  const agentId = normalizedRequested ?? soleAgentId ?? DEFAULT_AGENT_ID;
   const agentCfg: AgentDefaultsConfig = Object.assign(
     {},
     params.cfg.agents?.defaults,

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -356,16 +356,20 @@ describe("applyJobPatch", () => {
   });
 });
 
-function createMockState(now: number, opts?: { defaultAgentId?: string }): CronServiceState {
+function createMockState(
+  now: number,
+  opts?: { defaultAgentId?: string; soleAgentId?: string | null },
+): CronServiceState {
   return {
     deps: {
       nowMs: () => now,
       defaultAgentId: opts?.defaultAgentId,
+      soleAgentId: opts?.soleAgentId,
     },
   } as unknown as CronServiceState;
 }
 
-describe("createJob rejects sessionTarget main for non-default agents", () => {
+describe("createJob rejects sessionTarget main for non-sole agents", () => {
   const now = Date.parse("2026-02-28T12:00:00.000Z");
 
   const mainJobInput = (agentId?: string) => ({
@@ -378,33 +382,33 @@ describe("createJob rejects sessionTarget main for non-default agents", () => {
     ...(agentId !== undefined ? { agentId } : {}),
   });
 
-  it("allows creating a main-session job for the default agent", () => {
-    const state = createMockState(now, { defaultAgentId: "main" });
+  it("allows creating a main-session job for the sole agent", () => {
+    const state = createMockState(now, { soleAgentId: "main" });
     expect(() => createJob(state, mainJobInput())).not.toThrow();
     expect(() => createJob(state, mainJobInput("main"))).not.toThrow();
   });
 
-  it("allows creating a main-session job when defaultAgentId matches (case-insensitive)", () => {
-    const state = createMockState(now, { defaultAgentId: "Main" });
+  it("allows creating a main-session job when soleAgentId matches (case-insensitive)", () => {
+    const state = createMockState(now, { soleAgentId: "main" });
     expect(() => createJob(state, mainJobInput("MAIN"))).not.toThrow();
   });
 
-  it("rejects creating a main-session job for a non-default agentId", () => {
-    const state = createMockState(now, { defaultAgentId: "main" });
+  it("rejects creating a main-session job for a non-sole agentId", () => {
+    const state = createMockState(now, { soleAgentId: "main" });
     expect(() => createJob(state, mainJobInput("custom-agent"))).toThrow(
-      'cron: sessionTarget "main" is only valid for the default agent',
+      'cron: sessionTarget "main" is only valid for the sole configured agent "main"',
     );
   });
 
-  it("rejects main-session job for non-default agent even without explicit defaultAgentId", () => {
-    const state = createMockState(now);
+  it("rejects main-session job when no sole agent is configured", () => {
+    const state = createMockState(now, { soleAgentId: null });
     expect(() => createJob(state, mainJobInput("custom-agent"))).toThrow(
-      'cron: sessionTarget "main" is only valid for the default agent',
+      'cron: sessionTarget "main" requires exactly one configured agent',
     );
   });
 
-  it("allows isolated session job for non-default agents", () => {
-    const state = createMockState(now, { defaultAgentId: "main" });
+  it("allows isolated session job for non-sole agents", () => {
+    const state = createMockState(now, { soleAgentId: "main" });
     expect(() =>
       createJob(state, {
         name: "isolated-job",
@@ -419,7 +423,7 @@ describe("createJob rejects sessionTarget main for non-default agents", () => {
   });
 
   it("rejects failureDestination on main jobs without webhook delivery mode", () => {
-    const state = createMockState(now, { defaultAgentId: "main" });
+    const state = createMockState(now, { soleAgentId: "main" });
     expect(() =>
       createJob(state, {
         ...mainJobInput("main"),
@@ -455,22 +459,31 @@ describe("applyJobPatch rejects sessionTarget main for non-default agents", () =
     agentId,
   });
 
-  it("rejects patching agentId to non-default on a main-session job", () => {
+  it("rejects patching agentId to non-sole agent on a main-session job", () => {
     const job = createMainJob();
     expect(() =>
       applyJobPatch(job, { agentId: "custom-agent" } as CronJobPatch, {
-        defaultAgentId: "main",
+        soleAgentId: "main",
       }),
-    ).toThrow('cron: sessionTarget "main" is only valid for the default agent');
+    ).toThrow('cron: sessionTarget "main" is only valid for the sole configured agent "main"');
   });
 
-  it("allows patching agentId to the default agent on a main-session job", () => {
+  it("allows patching agentId to the sole agent on a main-session job", () => {
     const job = createMainJob();
     expect(() =>
       applyJobPatch(job, { agentId: "main" } as CronJobPatch, {
-        defaultAgentId: "main",
+        soleAgentId: "main",
       }),
     ).not.toThrow();
+  });
+
+  it("rejects patching agentId on main-session job when no sole agent", () => {
+    const job = createMainJob();
+    expect(() =>
+      applyJobPatch(job, { agentId: "main" } as CronJobPatch, {
+        soleAgentId: null,
+      }),
+    ).toThrow('cron: sessionTarget "main" requires exactly one configured agent');
   });
 });
 

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -109,7 +109,7 @@ export function assertSupportedJobSpec(job: Pick<CronJob, "sessionTarget" | "pay
 
 function assertMainSessionAgentId(
   job: Pick<CronJob, "sessionTarget" | "agentId">,
-  defaultAgentId: string | undefined,
+  soleAgentId: string | null | undefined,
 ) {
   if (job.sessionTarget !== "main") {
     return;
@@ -118,10 +118,14 @@ function assertMainSessionAgentId(
     return;
   }
   const normalized = normalizeAgentId(job.agentId);
-  const normalizedDefault = normalizeAgentId(defaultAgentId);
-  if (normalized !== normalizedDefault) {
+  if (soleAgentId == null) {
     throw new Error(
-      `cron: sessionTarget "main" is only valid for the default agent. Use sessionTarget "isolated" with payload.kind "agentTurn" for non-default agents (agentId: ${job.agentId})`,
+      `cron: sessionTarget "main" requires exactly one configured agent. Use sessionTarget "isolated" with payload.kind "agentTurn" for multi-agent setups (agentId: ${job.agentId})`,
+    );
+  }
+  if (normalized !== soleAgentId) {
+    throw new Error(
+      `cron: sessionTarget "main" is only valid for the sole configured agent "${soleAgentId}". Use sessionTarget "isolated" with payload.kind "agentTurn" for other agents (agentId: ${job.agentId})`,
     );
   }
 }
@@ -487,7 +491,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     },
   };
   assertSupportedJobSpec(job);
-  assertMainSessionAgentId(job, state.deps.defaultAgentId);
+  assertMainSessionAgentId(job, state.deps.soleAgentId);
   assertDeliverySupport(job);
   assertFailureDestinationSupport(job);
   job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
@@ -497,7 +501,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
 export function applyJobPatch(
   job: CronJob,
   patch: CronJobPatch,
-  opts?: { defaultAgentId?: string },
+  opts?: { defaultAgentId?: string; soleAgentId?: string | null },
 ) {
   if ("name" in patch) {
     job.name = normalizeRequiredName(patch.name);
@@ -577,7 +581,7 @@ export function applyJobPatch(
     job.sessionKey = normalizeOptionalSessionKey((patch as { sessionKey?: unknown }).sessionKey);
   }
   assertSupportedJobSpec(job);
-  assertMainSessionAgentId(job, opts?.defaultAgentId);
+  assertMainSessionAgentId(job, opts?.soleAgentId);
   assertDeliverySupport(job);
   assertFailureDestinationSupport(job);
 }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -270,7 +270,10 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
     await ensureLoaded(state, { skipRecompute: true });
     const job = findJobOrThrow(state, id);
     const now = state.deps.nowMs();
-    applyJobPatch(job, patch, { defaultAgentId: state.deps.defaultAgentId });
+    applyJobPatch(job, patch, {
+      defaultAgentId: state.deps.defaultAgentId,
+      soleAgentId: state.deps.soleAgentId,
+    });
     if (job.schedule.kind === "every") {
       const anchor = job.schedule.anchorMs;
       if (typeof anchor !== "number" || !Number.isFinite(anchor)) {

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -44,6 +44,8 @@ export type CronServiceDeps = {
   cronConfig?: CronConfig;
   /** Default agent id for jobs without an agent id. */
   defaultAgentId?: string;
+  /** Sole agent id when exactly one agent is configured, null otherwise. */
+  soleAgentId?: string | null;
   /** Resolve session store path for a given agent id. */
   resolveSessionStorePath?: (agentId?: string) => string;
   /** Path to the session store (sessions.json) for reaper use. */

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -603,15 +603,18 @@ export async function onTimer(state: CronServiceState) {
     // top of onTimer would otherwise skip the reaper indefinitely.
     const storePaths = new Set<string>();
     if (state.deps.resolveSessionStorePath) {
-      const defaultAgentId = state.deps.defaultAgentId ?? DEFAULT_AGENT_ID;
       if (state.store?.jobs?.length) {
         for (const job of state.store.jobs) {
-          const agentId =
-            typeof job.agentId === "string" && job.agentId.trim() ? job.agentId : defaultAgentId;
-          storePaths.add(state.deps.resolveSessionStorePath(agentId));
+          if (typeof job.agentId === "string" && job.agentId.trim()) {
+            storePaths.add(state.deps.resolveSessionStorePath(job.agentId));
+          }
         }
-      } else {
-        storePaths.add(state.deps.resolveSessionStorePath(defaultAgentId));
+      }
+      // Fall back to sole/default agent only when no job-specific paths were collected
+      if (storePaths.size === 0) {
+        const fallbackAgentId =
+          state.deps.soleAgentId ?? state.deps.defaultAgentId ?? DEFAULT_AGENT_ID;
+        storePaths.add(state.deps.resolveSessionStorePath(fallbackAgentId));
       }
     } else if (state.deps.sessionStorePath) {
       storePaths.add(state.deps.sessionStorePath);

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1,4 +1,4 @@
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveDefaultAgentId, resolveSoleAgentId } from "../agents/agent-scope.js";
 import type { CliDeps } from "../cli/deps.js";
 import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
 import { loadConfig } from "../config/config.js";
@@ -155,14 +155,25 @@ export function buildGatewayCronService(params: {
     const runtimeConfig = loadConfig();
     const normalized =
       typeof requested === "string" && requested.trim() ? normalizeAgentId(requested) : undefined;
-    const hasAgent =
-      normalized !== undefined &&
-      Array.isArray(runtimeConfig.agents?.list) &&
-      runtimeConfig.agents.list.some(
-        (entry) =>
-          entry && typeof entry.id === "string" && normalizeAgentId(entry.id) === normalized,
-      );
-    const agentId = hasAgent ? normalized : resolveDefaultAgentId(runtimeConfig);
+    if (normalized !== undefined) {
+      const hasAgent =
+        Array.isArray(runtimeConfig.agents?.list) &&
+        runtimeConfig.agents.list.some(
+          (entry) =>
+            entry && typeof entry.id === "string" && normalizeAgentId(entry.id) === normalized,
+        );
+      if (!hasAgent) {
+        cronLogger.warn(
+          { requestedAgentId: requested, normalized },
+          "cron: specified agentId not found in config — refusing silent fallback",
+        );
+        throw new Error(
+          `cron: agent "${requested}" is not configured. Check agents.list in your config.`,
+        );
+      }
+      return { agentId: normalized, cfg: runtimeConfig };
+    }
+    const agentId = resolveDefaultAgentId(runtimeConfig);
     return { agentId, cfg: runtimeConfig };
   };
 
@@ -221,6 +232,7 @@ export function buildGatewayCronService(params: {
   };
 
   const defaultAgentId = resolveDefaultAgentId(params.cfg);
+  const soleAgentId = resolveSoleAgentId(params.cfg);
   const runLogPrune = resolveCronRunLogPruneOptions(params.cfg.cron?.runLog);
   const resolveSessionStorePath = (agentId?: string) =>
     resolveStorePath(params.cfg.session?.store, {
@@ -234,6 +246,7 @@ export function buildGatewayCronService(params: {
     cronEnabled,
     cronConfig: params.cfg.cron,
     defaultAgentId,
+    soleAgentId,
     resolveSessionStorePath,
     sessionStorePath,
     enqueueSystemEvent: (text, opts) => {

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -184,18 +184,18 @@ describe("resolveHeartbeatPrompt", () => {
 });
 
 describe("isHeartbeatEnabledForAgent", () => {
-  it("enables only explicit heartbeat agents when configured", () => {
+  it("enables ALL agents when defaults.heartbeat is configured", () => {
     const cfg: RemoteClawConfig = {
       agents: {
         defaults: { heartbeat: { every: "30m" } },
         list: [{ id: "main" }, { id: "ops", heartbeat: { every: "1h" } }],
       },
     };
-    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(false);
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(true);
     expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
   });
 
-  it("falls back to default agent when no explicit heartbeat entries", () => {
+  it("enables ALL agents via defaults.heartbeat even without per-agent overrides", () => {
     const cfg: RemoteClawConfig = {
       agents: {
         defaults: { heartbeat: { every: "30m" } },
@@ -203,7 +203,32 @@ describe("isHeartbeatEnabledForAgent", () => {
       },
     };
     expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(true);
-    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(false);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
+  });
+
+  it("enables only per-agent heartbeat agents when no defaults", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main" }, { id: "ops", heartbeat: { every: "1h" } }],
+      },
+    };
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(false);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
+  });
+
+  it("returns false when no agents are configured", () => {
+    const cfg: RemoteClawConfig = {};
+    expect(isHeartbeatEnabledForAgent(cfg)).toBe(false);
+  });
+
+  it("returns false for an agent not in the list", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        defaults: { heartbeat: { every: "30m" } },
+        list: [{ id: "main" }],
+      },
+    };
+    expect(isHeartbeatEnabledForAgent(cfg, "unknown")).toBe(false);
   });
 });
 
@@ -479,9 +504,9 @@ describe("runHeartbeatOnce", () => {
   });
 
   it("skips when agent heartbeat is not enabled", async () => {
+    // No defaults.heartbeat and agent has no per-agent heartbeat
     const cfg: RemoteClawConfig = {
       agents: {
-        defaults: { heartbeat: { every: "30m" } },
         list: [{ id: "main" }, { id: "ops", heartbeat: { every: "1h" } }],
       },
     };
@@ -503,6 +528,7 @@ describe("runHeartbeatOnce", () => {
             activeHours: { start: "08:00", end: "24:00", timezone: "user" },
           },
         },
+        list: [{ id: "main" }],
       },
     };
 

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -7,7 +7,7 @@ describe("startHeartbeatRunner", () => {
   function startDefaultRunner(runOnce: Parameters<typeof startHeartbeatRunner>[0]["runOnce"]) {
     return startHeartbeatRunner({
       cfg: {
-        agents: { defaults: { heartbeat: { every: "30m" } } },
+        agents: { defaults: { heartbeat: { every: "30m" } }, list: [{ id: "main" }] },
       } as RemoteClawConfig,
       runOnce,
     });
@@ -96,7 +96,7 @@ describe("startHeartbeatRunner", () => {
     const runSpy2 = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
 
     const cfg = {
-      agents: { defaults: { heartbeat: { every: "30m" } } },
+      agents: { defaults: { heartbeat: { every: "30m" } }, list: [{ id: "main" }] },
     } as RemoteClawConfig;
 
     // Start runner A
@@ -149,7 +149,7 @@ describe("startHeartbeatRunner", () => {
 
     const runner = startHeartbeatRunner({
       cfg: {
-        agents: { defaults: { heartbeat: { every: "30m" } } },
+        agents: { defaults: { heartbeat: { every: "30m" } }, list: [{ id: "main" }] },
       } as RemoteClawConfig,
       runOnce: runSpy,
     });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -114,21 +114,25 @@ export type HeartbeatRunner = {
   updateConfig: (cfg: RemoteClawConfig) => void;
 };
 
-function hasExplicitHeartbeatAgents(cfg: RemoteClawConfig) {
-  const list = cfg.agents?.list ?? [];
-  return list.some((entry) => Boolean(entry?.heartbeat));
-}
-
 export function isHeartbeatEnabledForAgent(cfg: RemoteClawConfig, agentId?: string): boolean {
-  const resolvedAgentId = normalizeAgentId(agentId ?? resolveDefaultAgentId(cfg));
   const list = cfg.agents?.list ?? [];
-  const hasExplicit = hasExplicitHeartbeatAgents(cfg);
-  if (hasExplicit) {
-    return list.some(
-      (entry) => Boolean(entry?.heartbeat) && normalizeAgentId(entry?.id) === resolvedAgentId,
-    );
+  if (list.length === 0) {
+    return false;
   }
-  return resolvedAgentId === resolveDefaultAgentId(cfg);
+  const resolvedAgentId = normalizeAgentId(agentId ?? resolveDefaultAgentId(cfg));
+  const agentEntry = list.find(
+    (entry) =>
+      entry && typeof entry.id === "string" && normalizeAgentId(entry.id) === resolvedAgentId,
+  );
+  if (!agentEntry) {
+    return false;
+  }
+  // Per-agent heartbeat config takes precedence
+  if (agentEntry.heartbeat) {
+    return true;
+  }
+  // agents.defaults.heartbeat applies to ALL configured agents
+  return Boolean(cfg.agents?.defaults?.heartbeat);
 }
 
 function resolveHeartbeatConfig(
@@ -196,17 +200,21 @@ export function resolveHeartbeatSummaryForAgent(
 
 function resolveHeartbeatAgents(cfg: RemoteClawConfig): HeartbeatAgent[] {
   const list = cfg.agents?.list ?? [];
-  if (hasExplicitHeartbeatAgents(cfg)) {
-    return list
-      .filter((entry) => entry?.heartbeat)
-      .map((entry) => {
-        const id = normalizeAgentId(entry.id);
-        return { agentId: id, heartbeat: resolveHeartbeatConfig(cfg, id) };
-      })
-      .filter((entry) => entry.agentId);
+  if (list.length === 0) {
+    return [];
   }
-  const fallbackId = resolveDefaultAgentId(cfg);
-  return [{ agentId: fallbackId, heartbeat: resolveHeartbeatConfig(cfg, fallbackId) }];
+  return list
+    .filter((entry) => {
+      if (!entry || typeof entry.id !== "string") {
+        return false;
+      }
+      return isHeartbeatEnabledForAgent(cfg, entry.id);
+    })
+    .map((entry) => {
+      const id = normalizeAgentId(entry.id);
+      return { agentId: id, heartbeat: resolveHeartbeatConfig(cfg, id) };
+    })
+    .filter((entry) => entry.agentId);
 }
 
 export function resolveHeartbeatIntervalMs(


### PR DESCRIPTION
## Summary

- **Heartbeat**: Rewrite `isHeartbeatEnabledForAgent()` so `agents.defaults.heartbeat` applies to ALL configured agents as baseline, with per-agent overrides. No agents → skip heartbeat entirely. Removes the binary either/or logic from `hasExplicitHeartbeatAgents`.
- **Cron `resolveCronAgent`**: Throw on unknown `agentId` instead of silently falling back to default agent (catches typos like `agentId: "helpr"`).
- **Cron `assertMainSessionAgentId`**: Validate against sole agent (`resolveSoleAgentId`) instead of deprecated `resolveDefaultAgentId`.
- **Session reaper**: Use explicit agent from each job, not default fallback.
- **Isolated agent `run.ts`**: Three-level cascade uses `resolveSoleAgentId` instead of `resolveDefaultAgentId`.

Closes #1579

## Test plan

- [x] `isHeartbeatEnabledForAgent` tests rewritten — defaults.heartbeat enables all agents, per-agent override, no-agents returns false, unknown agent returns false
- [x] `resolveHeartbeatAgents` returns all agents with heartbeat enabled (not just explicit ones)
- [x] `assertMainSessionAgentId` tests updated for sole-agent validation (rejects non-sole, rejects when no sole agent, allows sole agent)
- [x] Session reaper test passes with explicit agent from jobs
- [x] All 427 heartbeat+cron tests pass
- [x] Type-check clean (`tsgo --noEmit`)
- [x] Lint clean (`oxlint --type-aware`)
- [x] Format clean (`oxfmt --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)