### PR TITLE
gut(routing): replace routing fallback with explicit failure

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1156,7 +1156,7 @@ export async function handleFeishuMessage(params: {
     // Dynamic agent creation for DM users
     // When enabled, creates a unique agent instance with its own workspace for each DM user.
     let effectiveCfg = cfg;
-    if (!isGroup && route.matchedBy === "default") {
+    if (!isGroup && route.matchedBy === "sole-agent") {
       const dynamicCfg = feishuCfg?.dynamicAgentCreation as DynamicAgentCreationConfig | undefined;
       if (dynamicCfg?.enabled) {
         const runtime = getFeishuRuntime();

--- a/src/imessage/monitor.gating.test.ts
+++ b/src/imessage/monitor.gating.test.ts
@@ -9,6 +9,7 @@ import type { IMessagePayload } from "./monitor/types.js";
 
 function baseCfg(): RemoteClawConfig {
   return {
+    agents: { list: [{ id: "main", workspace: "~/test" }] },
     channels: {
       imessage: {
         dmPolicy: "open",

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -13,18 +13,20 @@ describe("resolveAgentRoute", () => {
       guildId: "g1",
     });
 
-  test("defaults to main/default when no bindings exist", () => {
-    const cfg: RemoteClawConfig = {};
+  test("sole-agent config with no bindings auto-routes to the sole agent", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "home", workspace: "~/test" }] },
+    };
     const route = resolveAgentRoute({
       cfg,
       channel: "whatsapp",
       accountId: null,
       peer: { kind: "direct", id: "+15551234567" },
     });
-    expect(route.agentId).toBe("main");
+    expect(route.agentId).toBe("home");
     expect(route.accountId).toBe("default");
-    expect(route.sessionKey).toBe("agent:main:main");
-    expect(route.matchedBy).toBe("default");
+    expect(route.sessionKey).toBe("agent:home:main");
+    expect(route.matchedBy).toBe("sole-agent");
   });
 
   test("dmScope controls direct-message session key isolation", () => {
@@ -37,6 +39,7 @@ describe("resolveAgentRoute", () => {
     ];
     for (const testCase of cases) {
       const cfg: RemoteClawConfig = {
+        agents: { list: [{ id: "main", workspace: "~/test" }] },
         session: { dmScope: testCase.dmScope },
       };
       const route = resolveAgentRoute({
@@ -66,6 +69,7 @@ describe("resolveAgentRoute", () => {
     ];
     for (const testCase of cases) {
       const cfg: RemoteClawConfig = {
+        agents: { list: [{ id: "main", workspace: "~/test" }] },
         session: {
           dmScope: testCase.dmScope,
           identityLinks: {
@@ -139,7 +143,9 @@ describe("resolveAgentRoute", () => {
   });
 
   test("coerces numeric peer ids to stable session keys", () => {
-    const cfg: RemoteClawConfig = {};
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
+    };
     const route = resolveAgentRoute({
       cfg,
       channel: "discord",
@@ -293,7 +299,8 @@ describe("resolveAgentRoute", () => {
 
   test("missing accountId in binding matches default account only", () => {
     const cfg: RemoteClawConfig = {
-      bindings: [{ agentId: "defaultAcct", match: { channel: "whatsapp" } }],
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
+      bindings: [{ agentId: "main", match: { channel: "whatsapp" } }],
     };
 
     const defaultRoute = resolveAgentRoute({
@@ -302,7 +309,7 @@ describe("resolveAgentRoute", () => {
       accountId: undefined,
       peer: { kind: "direct", id: "+1000" },
     });
-    expect(defaultRoute.agentId).toBe("defaultacct");
+    expect(defaultRoute.agentId).toBe("main");
     expect(defaultRoute.matchedBy).toBe("binding.account");
 
     const otherRoute = resolveAgentRoute({
@@ -312,6 +319,7 @@ describe("resolveAgentRoute", () => {
       peer: { kind: "direct", id: "+1000" },
     });
     expect(otherRoute.agentId).toBe("main");
+    expect(otherRoute.matchedBy).toBe("sole-agent");
   });
 
   test("accountId=* matches any account as a channel fallback", () => {
@@ -348,7 +356,7 @@ describe("resolveAgentRoute", () => {
     expect(route.accountId).toBe("biz");
   });
 
-  test("defaultAgentId is used when no binding matches", () => {
+  test("sole agent is used when no binding matches", () => {
     const cfg: RemoteClawConfig = {
       agents: {
         list: [{ id: "home", workspace: "~/remoteclaw-home" }],
@@ -367,6 +375,7 @@ describe("resolveAgentRoute", () => {
 
 test("dmScope=per-account-channel-peer isolates DM sessions per account, channel and sender", () => {
   const cfg: RemoteClawConfig = {
+    agents: { list: [{ id: "main", workspace: "~/test" }] },
     session: { dmScope: "per-account-channel-peer" },
   };
   const route = resolveAgentRoute({
@@ -380,6 +389,7 @@ test("dmScope=per-account-channel-peer isolates DM sessions per account, channel
 
 test("dmScope=per-account-channel-peer uses default accountId when not provided", () => {
   const cfg: RemoteClawConfig = {
+    agents: { list: [{ id: "main", workspace: "~/test" }] },
     session: { dmScope: "per-account-channel-peer" },
   };
   const route = resolveAgentRoute({
@@ -477,20 +487,22 @@ describe("parentPeer binding inheritance (thread support)", () => {
 
   test("parentPeer with empty id is ignored", () => {
     const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
       bindings: [makeDiscordPeerBinding("parent-agent", defaultParentPeer.id)],
     };
     const route = resolveDiscordThreadRoute({ cfg, parentPeer: { kind: "channel", id: "" } });
     expect(route.agentId).toBe("main");
-    expect(route.matchedBy).toBe("default");
+    expect(route.matchedBy).toBe("sole-agent");
   });
 
   test("null parentPeer is handled gracefully", () => {
     const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
       bindings: [makeDiscordPeerBinding("parent-agent", defaultParentPeer.id)],
     };
     const route = resolveDiscordThreadRoute({ cfg, parentPeer: null });
     expect(route.agentId).toBe("main");
-    expect(route.matchedBy).toBe("default");
+    expect(route.matchedBy).toBe("sole-agent");
   });
 });
 
@@ -591,6 +603,7 @@ describe("backward compatibility: peer.kind group ↔ channel", () => {
 
   test("group/channel compatibility does not match direct peer kind", () => {
     const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
       bindings: [
         {
           agentId: "group-only-agent",
@@ -608,7 +621,7 @@ describe("backward compatibility: peer.kind group ↔ channel", () => {
       peer: { kind: "direct", id: "C123456" },
     });
     expect(route.agentId).toBe("main");
-    expect(route.matchedBy).toBe("default");
+    expect(route.matchedBy).toBe("sole-agent");
   });
 });
 
@@ -636,6 +649,7 @@ describe("role-based agent routing", () => {
 
   function expectDiscordRoleRoute(params: {
     bindings: DiscordBinding[];
+    agents?: NonNullable<RemoteClawConfig["agents"]>["list"];
     memberRoleIds?: string[];
     peerId?: string;
     parentPeerId?: string;
@@ -643,7 +657,10 @@ describe("role-based agent routing", () => {
     expectedMatchedBy: string;
   }) {
     const route = resolveAgentRoute({
-      cfg: { bindings: params.bindings },
+      cfg: {
+        bindings: params.bindings,
+        ...(params.agents ? { agents: { list: params.agents } } : {}),
+      },
       channel: "discord",
       guildId: "g1",
       ...(params.memberRoleIds ? { memberRoleIds: params.memberRoleIds } : {}),
@@ -670,9 +687,10 @@ describe("role-based agent routing", () => {
   test("guild+roles binding skipped when no matching role", () => {
     expectDiscordRoleRoute({
       bindings: [makeDiscordRoleBinding("opus", { roles: ["r1"] })],
+      agents: [{ id: "main", workspace: "~/test" }],
       memberRoleIds: ["r2"],
       expectedAgentId: "main",
-      expectedMatchedBy: "default",
+      expectedMatchedBy: "sole-agent",
     });
   });
 
@@ -720,8 +738,9 @@ describe("role-based agent routing", () => {
   test("no memberRoleIds means guild+roles doesn't match", () => {
     expectDiscordRoleRoute({
       bindings: [makeDiscordRoleBinding("opus", { roles: ["r1"] })],
+      agents: [{ id: "main", workspace: "~/test" }],
       expectedAgentId: "main",
-      expectedMatchedBy: "default",
+      expectedMatchedBy: "sole-agent",
     });
   });
 
@@ -749,9 +768,10 @@ describe("role-based agent routing", () => {
   test("guild+roles binding does not match as guild-only when roles do not match", () => {
     expectDiscordRoleRoute({
       bindings: [makeDiscordRoleBinding("opus", { roles: ["admin"] })],
+      agents: [{ id: "main", workspace: "~/test" }],
       memberRoleIds: ["regular"],
       expectedAgentId: "main",
-      expectedMatchedBy: "default",
+      expectedMatchedBy: "sole-agent",
     });
   });
 
@@ -766,5 +786,114 @@ describe("role-based agent routing", () => {
       expectedAgentId: "guild-roles",
       expectedMatchedBy: "binding.guild+roles",
     });
+  });
+});
+
+describe("routing error routes", () => {
+  test("no agents configured returns error route", () => {
+    const cfg: RemoteClawConfig = {};
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "whatsapp",
+      accountId: null,
+      peer: { kind: "direct", id: "+15551234567" },
+    });
+    expect(route.matchedBy).toBe("error");
+    expect(route.error).toContain("No agents configured");
+    expect(route.agentId).toBe("");
+  });
+
+  test("multi-agent config with no matching binding returns error route", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "home", workspace: "~/home" },
+          { id: "work", workspace: "~/work" },
+        ],
+      },
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "whatsapp",
+      accountId: null,
+      peer: { kind: "direct", id: "+15551234567" },
+    });
+    expect(route.matchedBy).toBe("error");
+    expect(route.error).toContain("No binding matched");
+    expect(route.error).toContain("2 configured agents");
+    expect(route.agentId).toBe("");
+  });
+
+  test("binding referencing unknown agent ID returns error route", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "home", workspace: "~/home" },
+          { id: "work", workspace: "~/work" },
+        ],
+      },
+      bindings: [
+        {
+          agentId: "typo-agent",
+          match: { channel: "whatsapp", accountId: "*" },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "whatsapp",
+      accountId: null,
+      peer: { kind: "direct", id: "+15551234567" },
+    });
+    expect(route.matchedBy).toBe("error");
+    expect(route.error).toContain("unknown agent");
+    expect(route.error).toContain("typo-agent");
+    expect(route.agentId).toBe("");
+  });
+
+  test("binding with empty agentId returns error route", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "home", workspace: "~/home" }] },
+      bindings: [
+        {
+          agentId: "",
+          match: { channel: "whatsapp", accountId: "*" },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "whatsapp",
+      accountId: null,
+      peer: { kind: "direct", id: "+15551234567" },
+    });
+    expect(route.matchedBy).toBe("error");
+    expect(route.agentId).toBe("");
+  });
+
+  test("multi-agent config with matching binding and known agent routes normally", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "home", workspace: "~/home" },
+          { id: "work", workspace: "~/work" },
+        ],
+      },
+      bindings: [
+        {
+          agentId: "work",
+          match: { channel: "slack", accountId: "*" },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "slack",
+      accountId: "biz",
+      peer: { kind: "channel", id: "C123" },
+    });
+    expect(route.agentId).toBe("work");
+    expect(route.matchedBy).toBe("binding.channel");
+    expect(route.error).toBeUndefined();
   });
 });

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -1,9 +1,9 @@
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveSoleAgentId } from "../agents/agent-scope.js";
 import type { ChatType } from "../channels/chat-type.js";
 import { normalizeChatType } from "../channels/chat-type.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { shouldLogVerbose } from "../globals.js";
-import { logDebug } from "../logger.js";
+import { logDebug, logWarn } from "../logger.js";
 import { listBindings } from "./bindings.js";
 import {
   buildAgentMainSessionKey,
@@ -53,7 +53,10 @@ export type ResolvedAgentRoute = {
     | "binding.team"
     | "binding.account"
     | "binding.channel"
-    | "default";
+    | "sole-agent"
+    | "error";
+  /** Present when matchedBy is "error" — describes the routing failure and suggests config fixes. */
+  error?: string;
 };
 
 export { DEFAULT_ACCOUNT_ID, DEFAULT_AGENT_ID } from "./session-key.js";
@@ -114,7 +117,7 @@ function listAgents(cfg: RemoteClawConfig) {
 type AgentLookupCache = {
   agentsRef: RemoteClawConfig["agents"] | undefined;
   byNormalizedId: Map<string, string>;
-  fallbackDefaultAgentId: string;
+  soleAgentId: string | null;
 };
 
 const agentLookupCacheByCfg = new WeakMap<RemoteClawConfig, AgentLookupCache>();
@@ -137,27 +140,24 @@ function resolveAgentLookupCache(cfg: RemoteClawConfig): AgentLookupCache {
   const next: AgentLookupCache = {
     agentsRef,
     byNormalizedId,
-    fallbackDefaultAgentId: sanitizeAgentId(resolveDefaultAgentId(cfg)),
+    soleAgentId: resolveSoleAgentId(cfg),
   };
   agentLookupCacheByCfg.set(cfg, next);
   return next;
 }
 
-function pickFirstExistingAgentId(cfg: RemoteClawConfig, agentId: string): string {
+function resolveExistingAgentId(cfg: RemoteClawConfig, agentId: string): string | null {
   const lookup = resolveAgentLookupCache(cfg);
   const trimmed = (agentId ?? "").trim();
   if (!trimmed) {
-    return lookup.fallbackDefaultAgentId;
+    return null;
   }
   const normalized = normalizeAgentId(trimmed);
   if (lookup.byNormalizedId.size === 0) {
+    // No agents list configured — accept the binding's agent ID as-is.
     return sanitizeAgentId(trimmed);
   }
-  const resolved = lookup.byNormalizedId.get(normalized);
-  if (resolved) {
-    return resolved;
-  }
-  return lookup.fallbackDefaultAgentId;
+  return lookup.byNormalizedId.get(normalized) ?? null;
 }
 
 function matchesChannel(
@@ -574,8 +574,33 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const bindings = getEvaluatedBindingsForChannelAccount(input.cfg, channel, accountId);
   const bindingsIndex = getEvaluatedBindingIndexForChannelAccount(input.cfg, channel, accountId);
 
+  const cacheRoute = (route: ResolvedAgentRoute): ResolvedAgentRoute => {
+    if (routeCache && routeCacheKey) {
+      routeCache.set(routeCacheKey, route);
+      if (routeCache.size > MAX_RESOLVED_ROUTE_CACHE_KEYS) {
+        routeCache.clear();
+        routeCache.set(routeCacheKey, route);
+      }
+    }
+    return route;
+  };
+
   const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {
-    const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
+    const resolvedAgentId = resolveExistingAgentId(input.cfg, agentId);
+    if (!resolvedAgentId) {
+      logWarn(
+        `[routing] binding references unknown agent '${agentId}' — check agents.list in your config`,
+      );
+      return cacheRoute({
+        agentId: "",
+        channel,
+        accountId,
+        sessionKey: "",
+        mainSessionKey: "",
+        matchedBy: "error",
+        error: `Binding references unknown agent '${agentId}' — check agents.list in your config`,
+      });
+    }
     const sessionKey = buildAgentSessionKey({
       agentId: resolvedAgentId,
       channel,
@@ -588,22 +613,14 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       agentId: resolvedAgentId,
       mainKey: DEFAULT_MAIN_KEY,
     }).toLowerCase();
-    const route = {
+    return cacheRoute({
       agentId: resolvedAgentId,
       channel,
       accountId,
       sessionKey,
       mainSessionKey,
       matchedBy,
-    };
-    if (routeCache && routeCacheKey) {
-      routeCache.set(routeCacheKey, route);
-      if (routeCache.size > MAX_RESOLVED_ROUTE_CACHE_KEYS) {
-        routeCache.clear();
-        routeCache.set(routeCacheKey, route);
-      }
-    }
-    return route;
+    });
   };
 
   const formatPeer = (value?: RoutePeer | null) =>
@@ -636,7 +653,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   };
 
   const tiers: Array<{
-    matchedBy: Exclude<ResolvedAgentRoute["matchedBy"], "default">;
+    matchedBy: Exclude<ResolvedAgentRoute["matchedBy"], "sole-agent" | "error">;
     enabled: boolean;
     scopePeer: RoutePeer | null;
     candidates: EvaluatedBinding[];
@@ -715,5 +732,29 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     }
   }
 
-  return choose(resolveDefaultAgentId(input.cfg), "default");
+  // Final fallback: sole-agent auto-selection or explicit error.
+  const lookup = resolveAgentLookupCache(input.cfg);
+  if (lookup.soleAgentId) {
+    if (shouldLogDebug) {
+      logDebug(`[routing] no binding match — auto-routing to sole agent: ${lookup.soleAgentId}`);
+    }
+    return choose(lookup.soleAgentId, "sole-agent");
+  }
+  const agentCount = lookup.byNormalizedId.size;
+  const error =
+    agentCount === 0
+      ? "No agents configured — add at least one entry to agents.list"
+      : `No binding matched for channel '${channel}' — add a binding to route messages to one of your ${agentCount} configured agents`;
+  if (shouldLogDebug) {
+    logDebug(`[routing] ${error}`);
+  }
+  return cacheRoute({
+    agentId: "",
+    channel,
+    accountId,
+    sessionKey: "",
+    mainSessionKey: "",
+    matchedBy: "error",
+    error,
+  });
 }

--- a/src/signal/monitor.tool-result.test-harness.ts
+++ b/src/signal/monitor.tool-result.test-harness.ts
@@ -120,6 +120,7 @@ export function installSignalToolResultTestHooks() {
   beforeEach(() => {
     resetInboundDedupe();
     config = {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
       messages: { responsePrefix: "PFX" },
       channels: {
         signal: { autoStart: false, dmPolicy: "open", allowFrom: ["*"] },

--- a/src/slack/monitor.test-helpers.ts
+++ b/src/slack/monitor.test-helpers.ts
@@ -121,6 +121,7 @@ export async function runSlackMessageOnce(
 }
 
 export const defaultSlackTestConfig = () => ({
+  agents: { list: [{ id: "main", workspace: "~/test" }] },
   messages: {
     responsePrefix: "PFX",
     ackReaction: "👀",

--- a/src/slack/monitor.tool-result.test.ts
+++ b/src/slack/monitor.tool-result.test.ts
@@ -49,6 +49,7 @@ describe("monitorSlackProvider tool results", () => {
 
   function setDirectMessageReplyMode(replyToMode: "off" | "all" | "first") {
     slackTestState.config = {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
       messages: {
         responsePrefix: "PFX",
         ackReaction: "👀",
@@ -69,6 +70,7 @@ describe("monitorSlackProvider tool results", () => {
 
   function setRequireMentionChannelConfig(mentionPatterns?: string[]) {
     slackTestState.config = {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
       ...(mentionPatterns
         ? {
             messages: {
@@ -195,6 +197,7 @@ describe("monitorSlackProvider tool results", () => {
 
   it("preserves RawBody without injecting processed room history", async () => {
     slackTestState.config = {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
       messages: { ackReactionScope: "group-mentions" },
       channels: {
         slack: {
@@ -248,6 +251,7 @@ describe("monitorSlackProvider tool results", () => {
 
   it("scopes thread history to the thread by default", async () => {
     slackTestState.config = {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
       messages: { ackReactionScope: "group-mentions" },
       channels: {
         slack: {
@@ -385,6 +389,7 @@ describe("monitorSlackProvider tool results", () => {
 
   it("accepts channel messages without mention when channels.slack.requireMention is false", async () => {
     slackTestState.config = {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
       channels: {
         slack: {
           dm: { enabled: true, policy: "open", allowFrom: ["*"] },
@@ -423,6 +428,7 @@ describe("monitorSlackProvider tool results", () => {
   it("threads replies when incoming message is in a thread", async () => {
     replyMock.mockResolvedValue({ text: "thread reply" });
     slackTestState.config = {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
       messages: {
         responsePrefix: "PFX",
         ackReaction: "👀",
@@ -446,6 +452,7 @@ describe("monitorSlackProvider tool results", () => {
   it("ignores replyToId directive when replyToMode is off", async () => {
     replyMock.mockResolvedValue({ text: "forced reply", replyToId: "555" });
     slackTestState.config = {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
       messages: {
         responsePrefix: "PFX",
         ackReaction: "👀",
@@ -578,6 +585,7 @@ describe("monitorSlackProvider tool results", () => {
     replyMock.mockResolvedValue({ text: "thread reply" });
 
     slackTestState.config = {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
       messages: { responsePrefix: "PFX" },
       channels: {
         slack: {
@@ -620,6 +628,7 @@ describe("monitorSlackProvider tool results", () => {
     }
 
     slackTestState.config = {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
       messages: { responsePrefix: "PFX" },
       channels: {
         slack: {
@@ -647,6 +656,7 @@ describe("monitorSlackProvider tool results", () => {
   it("scopes thread session keys to the routed agent", async () => {
     replyMock.mockResolvedValue({ text: "ok" });
     slackTestState.config = {
+      agents: { list: [{ id: "support", workspace: "~/test" }] },
       messages: { responsePrefix: "PFX" },
       channels: {
         slack: {

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -41,6 +41,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
   function createDefaultSlackCtx() {
     const slackCtx = createInboundSlackCtx({
       cfg: {
+        agents: { list: [{ id: "main", workspace: "~/test" }] },
         channels: { slack: { enabled: true } },
       } as RemoteClawConfig,
     });
@@ -133,6 +134,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
   function createDmScopeMainSlackCtx(): SlackMonitorContext {
     const slackCtx = createInboundSlackCtx({
       cfg: {
+        agents: { list: [{ id: "main", workspace: "~/test" }] },
         channels: { slack: { enabled: true } },
         session: { dmScope: "main" },
       } as RemoteClawConfig,
@@ -176,6 +178,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
   }): SlackMonitorContext {
     const slackCtx = createInboundSlackCtx({
       cfg: {
+        agents: { list: [{ id: "main", workspace: "~/test" }] },
         channels: {
           slack: {
             enabled: true,
@@ -269,6 +272,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
   it("extracts attachment text for bot messages with empty text when allowBots is true (#27616)", async () => {
     const slackCtx = createInboundSlackCtx({
       cfg: {
+        agents: { list: [{ id: "main", workspace: "~/test" }] },
         channels: {
           slack: { enabled: true },
         },
@@ -299,6 +303,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
   it("keeps channel metadata out of GroupSystemPrompt", async () => {
     const slackCtx = createInboundSlackCtx({
       cfg: {
+        agents: { list: [{ id: "main", workspace: "~/test" }] },
         channels: {
           slack: {
             enabled: true,
@@ -433,6 +438,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       });
     const slackCtx = createThreadSlackCtx({
       cfg: {
+        agents: { list: [{ id: "main", workspace: "~/test" }] },
         session: { store: storePath },
         channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
       } as RemoteClawConfig,
@@ -460,6 +466,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
   it("skips loading thread history when thread session already exists in store (bloat fix)", async () => {
     const { storePath } = makeTmpStorePath();
     const cfg = {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
       session: { store: storePath },
       channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
     } as RemoteClawConfig;
@@ -550,6 +557,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     const { storePath } = makeTmpStorePath();
     const slackCtx = createInboundSlackCtx({
       cfg: {
+        agents: { list: [{ id: "main", workspace: "~/test" }] },
         session: { store: storePath },
         channels: { slack: { enabled: true, replyToMode: "all" } },
       } as RemoteClawConfig,
@@ -582,7 +590,10 @@ describe("prepareSlackMessage sender prefix", () => {
   }): SlackMonitorContext {
     return {
       cfg: {
-        agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/remoteclaw" } },
+        agents: {
+          list: [{ id: "main", workspace: "~/test" }],
+          defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/remoteclaw" },
+        },
         channels: { slack: params.channels },
       },
       accountId: "default",

--- a/src/slack/monitor/message-handler/prepare.thread-session-key.test.ts
+++ b/src/slack/monitor/message-handler/prepare.thread-session-key.test.ts
@@ -9,6 +9,7 @@ function buildCtx(overrides?: { replyToMode?: "all" | "first" | "off" }) {
   const replyToMode = overrides?.replyToMode ?? "all";
   return createInboundSlackTestContext({
     cfg: {
+      agents: { list: [{ id: "main", workspace: "~/test" }] },
       channels: {
         slack: { enabled: true, replyToMode },
       },


### PR DESCRIPTION
## Summary

- Replaces the silent default-agent fallback in `resolveAgentRoute()` with explicit sole-agent auto-selection and error routes
- Rewrites `pickFirstExistingAgentId()` → `resolveExistingAgentId()` that returns `null` when an agent ID is not found in config (no more silent remap to default)
- Single-agent config with no binding match → auto-routes to sole agent (`matchedBy: "sole-agent"`); multi-agent config with no binding match → returns error route with config guidance
- Updates all test configs across routing, slack, signal, imessage, and feishu to include an agents list where routing is exercised

Closes #1576

## Test plan

- [x] All 43 resolve-route tests pass (5 new tests for error routes and sole-agent auto-selection)
- [x] Full unit test suite passes (5927 pass, 1 pre-existing canvas-host failure)
- [x] TypeScript type check passes (`tsgo --noEmit`)
- [x] Lint passes (`oxlint --type-aware`: 0 warnings, 0 errors)
- [x] Format check passes (`oxfmt --check`)
- [ ] CI build passes
- [ ] CI test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)