### PR TITLE
fix: remove orphan directory scan and default-agent naming fossils from #1580

### DIFF
--- a/src/security/fix.test.ts
+++ b/src/security/fix.test.ts
@@ -209,7 +209,7 @@ describe("security fix", () => {
     const configPath = path.join(stateDir, "remoteclaw.json");
     await fs.writeFile(
       configPath,
-      `{ "$include": "./includes/extra.json5", channels: { whatsapp: { groupPolicy: "open" } } }\n`,
+      `{ "$include": "./includes/extra.json5", agents: { list: [{ id: "main" }] }, channels: { whatsapp: { groupPolicy: "open" } } }\n`,
       "utf-8",
     );
     await fs.chmod(configPath, 0o644);

--- a/src/security/fix.ts
+++ b/src/security/fix.ts
@@ -336,19 +336,6 @@ async function chmodCredentialsAndAgentState(params: {
       ids.add(id);
     }
   }
-  // Also scan the filesystem for any existing agent directories not in config
-  const agentsParentDir = path.join(params.stateDir, "agents");
-  try {
-    const agentDirEntries = await fs.readdir(agentsParentDir, { withFileTypes: true });
-    for (const entry of agentDirEntries) {
-      if (entry.isDirectory() && entry.name.trim()) {
-        ids.add(entry.name.trim());
-      }
-    }
-  } catch {
-    // agents/ directory may not exist yet
-  }
-
   for (const agentId of ids) {
     const normalizedAgentId = normalizeAgentId(agentId);
     const agentRoot = path.join(params.stateDir, "agents", normalizedAgentId);

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -103,7 +103,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     const items = state.agents.map((agent: AgentSummary) => ({
       value: agent.id,
       label: agent.name ? `${agent.id} (${agent.name})` : agent.id,
-      description: agent.id === state.agentDefaultId ? "default" : "",
+      description: "",
     }));
     const selector = createSearchableSelectList(items, 9);
     openSelector(selector, async (value) => {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -35,7 +35,7 @@ function createMockChatLog(): MockChatLog & HandlerChatLog {
 
 describe("tui-event-handlers: handleAgentEvent", () => {
   const makeState = (overrides?: Partial<TuiStateAccess>): TuiStateAccess => ({
-    agentDefaultId: "main",
+    firstAgentId: "main",
     sessionMainKey: "agent:main:main",
     sessionScope: "global",
     agents: [],

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -24,7 +24,7 @@ describe("tui session actions", () => {
       );
 
     const state: TuiStateAccess = {
-      agentDefaultId: "main",
+      firstAgentId: "main",
       sessionMainKey: "agent:main:main",
       sessionScope: "global",
       agents: [],

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -58,7 +58,7 @@ export function createSessionActions(context: SessionActionContext) {
   let lastSessionDefaults: SessionInfoDefaults | null = null;
 
   const applyAgentsResult = (result: GatewayAgentsList) => {
-    state.agentDefaultId = normalizeAgentId(result.defaultId);
+    state.firstAgentId = normalizeAgentId(result.defaultId);
     state.sessionMainKey = normalizeMainKey(result.mainKey);
     state.sessionScope = result.scope ?? state.sessionScope;
     state.agents = result.agents.map((agent) => ({

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -83,7 +83,7 @@ export type GatewayStatusSummary = {
 };
 
 export type TuiStateAccess = {
-  agentDefaultId: string;
+  firstAgentId: string;
   sessionMainKey: string;
   sessionScope: SessionScope;
   agents: AgentSummary[];

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -302,8 +302,8 @@ export async function runTui(opts: TuiOptions) {
   const initialSessionInput = (opts.session ?? "").trim();
   let sessionScope: SessionScope = (config.session?.scope ?? "per-sender") as SessionScope;
   let sessionMainKey = normalizeMainKey(config.session?.mainKey);
-  let agentDefaultId = listAgentEntries(config)[0]?.id ?? "default";
-  let currentAgentId = agentDefaultId;
+  let firstAgentId = listAgentEntries(config)[0]?.id ?? "default";
+  let currentAgentId = firstAgentId;
   let agents: AgentSummary[] = [];
   const agentNames = new Map<string, string>();
   let currentSessionKey = "";
@@ -332,11 +332,11 @@ export async function runTui(opts: TuiOptions) {
   let lastActivityStatus = activityStatus;
 
   const state: TuiStateAccess = {
-    get agentDefaultId() {
-      return agentDefaultId;
+    get firstAgentId() {
+      return firstAgentId;
     },
-    set agentDefaultId(value) {
-      agentDefaultId = value;
+    set firstAgentId(value) {
+      firstAgentId = value;
     },
     get sessionMainKey() {
       return sessionMainKey;


### PR DESCRIPTION
## Summary

Post-merge cleanup for #1580 (display ordering). Fixes two issues introduced by the subprocess:

- **Remove orphaned agent directory scan** in `security/fix.ts` — security hardening should only cover configured agents, not filesystem leftovers
- **Rename `agentDefaultId` → `firstAgentId`** across TUI — the "default agent" concept was removed in #1575; the variable name was a naming fossil
- **Remove "default" badge** from TUI agent selector — #1580 was supposed to remove all default badges but missed this one

## Test plan

- [ ] `pnpm check` passes
- [ ] TUI agent selector shows no "(default)" badge
- [ ] Security fix only iterates configured agent IDs