### PR TITLE
gut(agent-runner): remove model-fallback pipeline vestiges

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -386,13 +386,3 @@ export function resolveAgentDir(cfg: RemoteClawConfig, agentId: string) {
   const root = resolveStateDir(process.env);
   return path.join(root, "agents", id, "agent");
 }
-
-// Gutted in RemoteClaw fork (Middleware Boundary Principle) — stub exports for upstream compat
-/** Stub: model fallbacks are not used in RemoteClaw (CLI agents manage their own models). */
-export function resolveEffectiveModelFallbacks(..._args: unknown[]): string[] {
-  return [];
-}
-/** Stub: skills filter not used in RemoteClaw fork. */
-export function resolveAgentSkillsFilter(..._args: unknown[]): unknown {
-  return undefined;
-}

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -41,23 +41,11 @@ import type { FollowupRun } from "./queue.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
 import type { TypingSignaler } from "./typing-mode.js";
 
-export type RuntimeFallbackAttempt = {
-  provider: string;
-  model: string;
-  error: string;
-  reason?: string;
-  status?: number;
-  code?: string;
-};
-
 export type AgentRunLoopResult =
   | {
       kind: "success";
       runId: string;
       runResult: AgentDeliveryResult;
-      fallbackProvider?: string;
-      fallbackModel?: string;
-      fallbackAttempts: RuntimeFallbackAttempt[];
       didLogHeartbeatStrip: boolean;
       autoCompactionCompleted?: boolean;
       /** Payload keys sent directly (not via pipeline) during tool flush. */
@@ -593,7 +581,6 @@ export async function runAgentTurnWithFallback(params: {
     kind: "success",
     runId,
     runResult,
-    fallbackAttempts: [],
     didLogHeartbeatStrip,
     directlySentBlockKeys: directlySentBlockKeys.size > 0 ? directlySentBlockKeys : undefined,
   };

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { FollowupRun } from "./queue.js";
 
-const { buildRunBaseParams, buildRunContexts, resolveModelFallbackOptions } =
-  await import("./agent-runner-utils.js");
+const { buildRunBaseParams, buildRunContexts } = await import("./agent-runner-utils.js");
 
 function makeRun(overrides: Partial<FollowupRun["run"]> = {}): FollowupRun["run"] {
   return {
@@ -24,20 +23,6 @@ function makeRun(overrides: Partial<FollowupRun["run"]> = {}): FollowupRun["run"
 }
 
 describe("agent-runner-utils", () => {
-  it("resolves model fallback options with undefined fallbacksOverride", () => {
-    const run = makeRun();
-
-    const resolved = resolveModelFallbackOptions(run);
-
-    expect(resolved).toEqual({
-      cfg: run.config,
-      provider: run.provider,
-      model: run.model,
-      agentDir: run.agentDir,
-      fallbacksOverride: undefined,
-    });
-  });
-
   it("builds run base params with run metadata", () => {
     const run = makeRun({ enforceFinalTag: true });
 

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -125,16 +125,6 @@ export const appendUsageLine = (payloads: ReplyPayload[], line: string): ReplyPa
 export const resolveEnforceFinalTag = (run: FollowupRun["run"], provider: string) =>
   Boolean(run.enforceFinalTag || isReasoningTagProvider(provider));
 
-export function resolveModelFallbackOptions(run: FollowupRun["run"]) {
-  return {
-    cfg: run.config,
-    provider: run.provider,
-    model: run.model,
-    agentDir: run.agentDir,
-    fallbacksOverride: undefined,
-  };
-}
-
 export function buildRunBaseParams(params: {
   run: FollowupRun["run"];
   provider: string;

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -568,9 +568,6 @@ describe("runReplyAgent typing (heartbeat)", () => {
         sessionId,
         updatedAt: Date.now(),
         sessionFile: transcriptPath,
-        fallbackNoticeSelectedModel: "fireworks/minimax-m2p5",
-        fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
-        fallbackNoticeReason: "rate limit",
       };
       const sessionStore = { main: sessionEntry };
 
@@ -603,15 +600,9 @@ describe("runReplyAgent typing (heartbeat)", () => {
       }
       expect(payload.text?.toLowerCase()).toContain("reset");
       expect(sessionStore.main.sessionId).not.toBe(sessionId);
-      expect(sessionStore.main.fallbackNoticeSelectedModel).toBeUndefined();
-      expect(sessionStore.main.fallbackNoticeActiveModel).toBeUndefined();
-      expect(sessionStore.main.fallbackNoticeReason).toBeUndefined();
 
       const persisted = JSON.parse(await fs.readFile(storePath, "utf-8"));
       expect(persisted.main.sessionId).toBe(sessionStore.main.sessionId);
-      expect(persisted.main.fallbackNoticeSelectedModel).toBeUndefined();
-      expect(persisted.main.fallbackNoticeActiveModel).toBeUndefined();
-      expect(persisted.main.fallbackNoticeReason).toBeUndefined();
     });
   });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,8 +1,7 @@
 import fs from "node:fs";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-const resolveModelAuthMode = (..._args: unknown[]) => "api-key" as string;
-const isCliProvider = (..._args: unknown[]) => false;
+import { isCliProvider } from "../../agents/provider-utils.js";
 import { hasNonzeroUsage, type NormalizedUsage } from "../../agents/usage.js";
+import { resolveModelAuthMode } from "../../auth/provider-auth.js";
 import {
   resolveAgentIdFromSessionKey,
   resolveSessionFilePath,
@@ -13,41 +12,10 @@ import {
   updateSessionStoreEntry,
 } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
-import { emitAgentEvent } from "../../infra/agent-events.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { defaultRuntime } from "../../runtime.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
-// Gutted in RemoteClaw fork (Middleware Boundary Principle) — fallback-state
-const buildFallbackClearedNotice = (..._args: unknown[]) => undefined as string | undefined;
-const buildFallbackNotice = (..._args: unknown[]) => undefined as string | undefined;
-type FallbackTransitionResult = {
-  stateChanged: boolean;
-  fallbackTransitioned: boolean;
-  fallbackCleared: boolean;
-  reasonSummary: string;
-  attemptSummaries: string[];
-  nextState: {
-    selectedModel?: string;
-    activeModel?: string;
-    reason?: string;
-  };
-  previousState: {
-    selectedModel?: string;
-    activeModel?: string;
-    reason?: string;
-  };
-};
-const resolveFallbackTransition = (..._args: unknown[]) =>
-  ({
-    stateChanged: false,
-    fallbackTransitioned: false,
-    fallbackCleared: false,
-    reasonSummary: "",
-    attemptSummaries: [],
-    nextState: {},
-    previousState: {},
-  }) as FallbackTransitionResult;
 import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -261,9 +229,6 @@ export async function runReplyAgent(params: {
       updatedAt: Date.now(),
       systemSent: false,
       abortedLastRun: false,
-      fallbackNoticeSelectedModel: undefined,
-      fallbackNoticeActiveModel: undefined,
-      fallbackNoticeReason: undefined,
     };
     const agentId = resolveAgentIdFromSessionKey(sessionKey);
     const nextSessionFile = resolveSessionTranscriptPath(
@@ -351,14 +316,7 @@ export async function runReplyAgent(params: {
       return finalizeWithFollowup(runOutcome.payload, queueKey, runFollowupTurn);
     }
 
-    const {
-      runId,
-      runResult,
-      fallbackProvider,
-      fallbackModel,
-      fallbackAttempts,
-      directlySentBlockKeys,
-    } = runOutcome;
+    const { runResult, directlySentBlockKeys } = runOutcome;
     let { didLogHeartbeatStrip, autoCompactionCompleted } = runOutcome;
 
     if (
@@ -397,45 +355,9 @@ export async function runReplyAgent(params: {
     const agentMeta = runResult.meta?.agentMeta;
     const usage = agentMeta?.usage as NormalizedUsage | undefined;
     const promptTokens = agentMeta?.promptTokens as number | undefined;
-    const modelUsed = (agentMeta?.model as string | undefined) ?? fallbackModel ?? defaultModel;
-    const providerUsed =
-      (agentMeta?.provider as string | undefined) ?? fallbackProvider ?? followupRun.run.provider;
+    const modelUsed = (agentMeta?.model as string | undefined) ?? defaultModel;
+    const providerUsed = (agentMeta?.provider as string | undefined) ?? followupRun.run.provider;
     const verboseEnabled = resolvedVerboseLevel !== "off";
-    const selectedProvider = followupRun.run.provider;
-    const selectedModel = followupRun.run.model;
-    const fallbackStateEntry =
-      activeSessionEntry ?? (sessionKey ? activeSessionStore?.[sessionKey] : undefined);
-    const fallbackTransition = resolveFallbackTransition({
-      selectedProvider,
-      selectedModel,
-      activeProvider: providerUsed,
-      activeModel: modelUsed,
-      attempts: fallbackAttempts,
-      state: fallbackStateEntry,
-    });
-    if (fallbackTransition.stateChanged) {
-      if (fallbackStateEntry) {
-        fallbackStateEntry.fallbackNoticeSelectedModel = fallbackTransition.nextState.selectedModel;
-        fallbackStateEntry.fallbackNoticeActiveModel = fallbackTransition.nextState.activeModel;
-        fallbackStateEntry.fallbackNoticeReason = fallbackTransition.nextState.reason;
-        fallbackStateEntry.updatedAt = Date.now();
-        activeSessionEntry = fallbackStateEntry;
-      }
-      if (sessionKey && fallbackStateEntry && activeSessionStore) {
-        activeSessionStore[sessionKey] = fallbackStateEntry;
-      }
-      if (sessionKey && storePath) {
-        await updateSessionStoreEntry({
-          storePath,
-          sessionKey,
-          update: async () => ({
-            fallbackNoticeSelectedModel: fallbackTransition.nextState.selectedModel,
-            fallbackNoticeActiveModel: fallbackTransition.nextState.activeModel,
-            fallbackNoticeReason: fallbackTransition.nextState.reason,
-          }),
-        });
-      }
-    }
     const cliSessionId = isCliProvider(providerUsed, cfg)
       ? (agentMeta?.sessionId as string | undefined)?.trim()
       : undefined;
@@ -581,60 +503,6 @@ export async function runReplyAgent(params: {
 
     if (verboseEnabled && activeIsNewSession) {
       verboseNotices.push({ text: `🧭 New session: ${followupRun.run.sessionId}` });
-    }
-
-    if (fallbackTransition.fallbackTransitioned) {
-      emitAgentEvent({
-        runId,
-        sessionKey,
-        stream: "lifecycle",
-        data: {
-          phase: "fallback",
-          selectedProvider,
-          selectedModel,
-          activeProvider: providerUsed,
-          activeModel: modelUsed,
-          reasonSummary: fallbackTransition.reasonSummary,
-          attemptSummaries: fallbackTransition.attemptSummaries,
-          attempts: fallbackAttempts,
-        },
-      });
-      if (verboseEnabled) {
-        const fallbackNotice = buildFallbackNotice({
-          selectedProvider,
-          selectedModel,
-          activeProvider: providerUsed,
-          activeModel: modelUsed,
-          attempts: fallbackAttempts,
-        });
-        if (fallbackNotice) {
-          verboseNotices.push({ text: fallbackNotice });
-        }
-      }
-    }
-    if (fallbackTransition.fallbackCleared) {
-      emitAgentEvent({
-        runId,
-        sessionKey,
-        stream: "lifecycle",
-        data: {
-          phase: "fallback_cleared",
-          selectedProvider,
-          selectedModel,
-          activeProvider: providerUsed,
-          activeModel: modelUsed,
-          previousActiveModel: fallbackTransition.previousState.activeModel,
-        },
-      });
-      if (verboseEnabled) {
-        verboseNotices.push({
-          text: buildFallbackClearedNotice({
-            selectedProvider,
-            selectedModel,
-            previousActiveModel: fallbackTransition.previousState.activeModel,
-          }),
-        });
-      }
     }
 
     if (autoCompactionCompleted) {

--- a/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
@@ -13,7 +13,6 @@ vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentRuntime: vi.fn(() => "claude"),
   resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
   resolveSessionAgentId: vi.fn(() => "main"),
-  resolveAgentSkillsFilter: vi.fn(() => undefined),
 }));
 vi.mock("../../agents/timeout.js", () => ({
   resolveAgentTimeoutMs: vi.fn(() => 60000),

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -56,9 +56,6 @@ type OverrideFieldClearedByDelete =
   | "authProfileOverride"
   | "authProfileOverrideSource"
   | "authProfileOverrideCompactionCount"
-  | "fallbackNoticeSelectedModel"
-  | "fallbackNoticeActiveModel"
-  | "fallbackNoticeReason"
   | "claudeCliSessionId";
 
 const OVERRIDE_FIELDS_CLEARED_BY_DELETE: OverrideFieldClearedByDelete[] = [
@@ -67,9 +64,6 @@ const OVERRIDE_FIELDS_CLEARED_BY_DELETE: OverrideFieldClearedByDelete[] = [
   "authProfileOverride",
   "authProfileOverrideSource",
   "authProfileOverrideCompactionCount",
-  "fallbackNoticeSelectedModel",
-  "fallbackNoticeActiveModel",
-  "fallbackNoticeReason",
   "claudeCliSessionId",
 ];
 
@@ -411,8 +405,6 @@ export async function agentCommand(
 
     const sessionEntryRef: SessionEntryRef = { current: sessionEntry };
     let result: AgentDeliveryResult;
-    const fallbackProvider = provider;
-    const fallbackModel = model;
     try {
       const runContext = resolveAgentRunContext(opts);
       const messageChannel = resolveMessageChannel(
@@ -494,8 +486,6 @@ export async function agentCommand(
         sessionStore,
         defaultProvider: provider,
         defaultModel: model,
-        fallbackProvider,
-        fallbackModel,
         result,
       });
     }

--- a/src/commands/agent/session-store.ts
+++ b/src/commands/agent/session-store.ts
@@ -14,8 +14,6 @@ export async function updateSessionStoreAfterAgentRun(params: {
   sessionStore: Record<string, SessionEntry>;
   defaultProvider: string;
   defaultModel: string;
-  fallbackProvider?: string;
-  fallbackModel?: string;
   result: AgentDeliveryResult;
 }) {
   const {
@@ -26,8 +24,6 @@ export async function updateSessionStoreAfterAgentRun(params: {
     sessionStore,
     defaultProvider,
     defaultModel,
-    fallbackProvider,
-    fallbackModel,
     result,
   } = params;
 
@@ -42,8 +38,8 @@ export async function updateSessionStoreAfterAgentRun(params: {
         cacheWrite: runUsage.cacheWriteTokens,
       }
     : undefined;
-  const modelUsed = fallbackModel ?? defaultModel;
-  const providerUsed = fallbackProvider ?? defaultProvider;
+  const modelUsed = defaultModel;
+  const providerUsed = defaultProvider;
   const entry = sessionStore[sessionKey] ?? {
     sessionId,
     updatedAt: Date.now(),

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -136,13 +136,6 @@ export type SessionEntry = {
   cacheWrite?: number;
   modelProvider?: string;
   model?: string;
-  /**
-   * Last selected/runtime model pair for which a fallback notice was emitted.
-   * Used to avoid repeating the same fallback notice every turn.
-   */
-  fallbackNoticeSelectedModel?: string;
-  fallbackNoticeActiveModel?: string;
-  fallbackNoticeReason?: string;
   compactionCount?: number;
   cliSessionIds?: Record<string, string>;
   claudeCliSessionId?: string;

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -26,7 +26,6 @@ function createMock(): Mock {
 export const buildWorkspaceSkillSnapshotMock = createMock();
 export const resolveAgentConfigMock = createMock();
 export const resolveAgentModelFallbacksOverrideMock = createMock();
-export const resolveAgentSkillsFilterMock = createMock();
 export const runAgentMock = createMock();
 export const runCliAgentMock = createMock();
 export const getCliSessionIdMock = createMock();
@@ -45,7 +44,6 @@ vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentRuntimeOrThrow: vi.fn().mockReturnValue("claude"),
   resolveAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/workspace"),
   resolveSoleAgentId: vi.fn().mockReturnValue("default"),
-  resolveAgentSkillsFilter: resolveAgentSkillsFilterMock,
 }));
 
 vi.mock("../../agents/skills.js", () => ({
@@ -198,8 +196,6 @@ export function resetRunCronIsolatedAgentTurnHarness(): void {
   });
   resolveAgentConfigMock.mockReturnValue(undefined);
   resolveAgentModelFallbacksOverrideMock.mockReturnValue(undefined);
-  resolveAgentSkillsFilterMock.mockReturnValue(undefined);
-
   runAgentMock.mockReset();
   runAgentMock.mockResolvedValue(makeDefaultEmbeddedResult());
 

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -46,35 +46,6 @@ function makeKimiSubagentCfg(params: {
 }
 
 describe("gateway sessions patch", () => {
-  test("clears fallback notice when model patch changes", async () => {
-    const store: Record<string, SessionEntry> = {
-      "agent:main:main": {
-        sessionId: "sess",
-        updatedAt: 1,
-        providerOverride: "anthropic",
-        modelOverride: "claude-opus-4-5",
-        fallbackNoticeSelectedModel: "anthropic/claude-opus-4-5",
-        fallbackNoticeActiveModel: "openai/gpt-5.2",
-        fallbackNoticeReason: "rate-limited",
-      } as SessionEntry,
-    };
-    const res = await applySessionsPatchToStore({
-      cfg: {} as RemoteClawConfig,
-      store,
-      storeKey: "agent:main:main",
-      patch: { key: "agent:main:main", model: "openai/gpt-5.2" },
-    });
-    expect(res.ok).toBe(true);
-    if (!res.ok) {
-      return;
-    }
-    expect(res.entry.providerOverride).toBe("openai");
-    expect(res.entry.modelOverride).toBe("gpt-5.2");
-    expect(res.entry.fallbackNoticeSelectedModel).toBeUndefined();
-    expect(res.entry.fallbackNoticeActiveModel).toBeUndefined();
-    expect(res.entry.fallbackNoticeReason).toBeUndefined();
-  });
-
   test("accepts explicit allowlisted provider/model refs from sessions.patch", async () => {
     const store: Record<string, SessionEntry> = {};
     const cfg = {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -129,8 +129,6 @@ export async function applySessionsPatchToStore(params: {
 
   if ("model" in patch) {
     const raw = patch.model;
-    const prevProvider = next.providerOverride;
-    const prevModel = next.modelOverride;
     if (raw === null) {
       // Reset to default — clear overrides.
       delete next.providerOverride;
@@ -153,12 +151,6 @@ export async function applySessionsPatchToStore(params: {
         next.providerOverride = parsed.provider;
         next.modelOverride = parsed.model;
       }
-    }
-    // Clear stale fallback notice when model overrides change.
-    if (next.providerOverride !== prevProvider || next.modelOverride !== prevModel) {
-      delete next.fallbackNoticeSelectedModel;
-      delete next.fallbackNoticeActiveModel;
-      delete next.fallbackNoticeReason;
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #2289.

Remove the dead OpenClaw model-fallback pipeline that was stubbed out during M2/M3 gutting but never fully excised:

- Remove 5 stub no-ops from `agent-runner.ts` (`resolveModelAuthMode`, `isCliProvider` local shadows, `buildFallbackNotice`, `buildFallbackClearedNotice`, `resolveFallbackTransition` + `FallbackTransitionResult` type) — replace the two shadow stubs with imports of the real functions from `auth/provider-auth.ts` and `agents/provider-utils.ts`
- Remove `RuntimeFallbackAttempt` type and dead `fallbackProvider`/`fallbackModel`/`fallbackAttempts` fields from `AgentRunLoopResult` in `agent-runner-execution.ts`
- Remove `resolveModelFallbackOptions()` from `agent-runner-utils.ts`
- Remove dead session state fields (`fallbackNoticeSelectedModel`, `fallbackNoticeActiveModel`, `fallbackNoticeReason`) from `SessionEntry` type
- Remove dead event emission blocks (fallback transition + fallback cleared) from `agent-runner.ts`
- Remove dead cleanup code from `sessions-patch.ts`, `commands/agent.ts`, `session-store.ts`
- Remove dead stub exports (`resolveEffectiveModelFallbacks`, `resolveAgentSkillsFilter`) from `agent-scope.ts`
- Update all affected tests (e2e test, unit tests, cron test harness mocks)

**Net: -260 lines across 13 files.**

Note: `runMemoryFlushIfNeeded` and `memoryFlushAt`/`memoryFlushCompactionCount` session fields were already removed by #2278 — confirmed and excluded from this PR per the scope update comment.

## What stays (live code, not touched)

- `resolveModelCostConfig()` / `estimateUsageCost()` in `utils/usage-format.ts` — live callers in usage tracking
- Real `isCliProvider` in `agents/provider-utils.ts` — alive (now imported by agent-runner.ts)
- Real `resolveModelAuthMode` in `auth/provider-auth.ts` — alive (now imported by agent-runner.ts)
- `resolveEffectiveModelFallbacks` in `ui/src/ui/views/agents-utils.ts` — separate live UI function
- `fallbackProvider`/`fallbackModel` in TTS and subagent code — different context, live

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm tsgo` passes (clean typecheck)
- [x] `pnpm check` passes (format + typecheck + lint)
- [x] `pnpm test` passes (5941 passed, 1 skipped, 1 pre-existing flaky unrelated to changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)