### PR TITLE
gut(usage): remove dead cost-estimation pipeline (#2292)

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -80,11 +80,7 @@ export const formatBunFetchSocketError = (message: string) => {
   ].join("\n");
 };
 
-export const formatResponseUsageLine = (params: {
-  usage?: NormalizedUsage;
-  showCost?: boolean;
-  costConfig?: { input: number; output: number; cacheRead: number; cacheWrite: number };
-}): string | null => {
+export const formatResponseUsageLine = (params: { usage?: NormalizedUsage }): string | null => {
   const usage = params.usage;
   if (!usage) {
     return null;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import { isCliProvider } from "../../agents/provider-utils.js";
 import { hasNonzeroUsage, type NormalizedUsage } from "../../agents/usage.js";
-import { resolveModelAuthMode } from "../../auth/provider-auth.js";
 import {
   resolveAgentIdFromSessionKey,
   resolveSessionFilePath,
@@ -15,7 +14,6 @@ import type { TypingMode } from "../../config/types.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { defaultRuntime } from "../../runtime.js";
-import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -443,12 +441,6 @@ export async function runReplyAgent(params: {
       const cacheWrite = usage.cacheWrite ?? 0;
       const promptTokens = input + cacheRead + cacheWrite;
       const totalTokens = usage.total ?? promptTokens + output;
-      const costConfig = resolveModelCostConfig({
-        provider: providerUsed,
-        model: modelUsed,
-        config: cfg,
-      });
-      const costUsd = estimateUsageCost({ usage, cost: costConfig });
       emitDiagnosticEvent({
         type: "model.usage",
         sessionKey,
@@ -465,7 +457,6 @@ export async function runReplyAgent(params: {
           total: totalTokens,
         },
         lastCallUsage: agentMeta?.lastCallUsage as NormalizedUsage | undefined,
-        costUsd,
         durationMs: Date.now() - runStartedAt,
       });
     }
@@ -475,20 +466,7 @@ export async function runReplyAgent(params: {
       (sessionKey ? activeSessionStore?.[sessionKey]?.responseUsage : undefined);
     const responseUsageMode = resolveResponseUsageMode(responseUsageRaw);
     if (responseUsageMode !== "off" && hasNonzeroUsage(usage)) {
-      const authMode = resolveModelAuthMode(providerUsed, cfg);
-      const showCost = authMode === "api-key";
-      const costConfig = showCost
-        ? resolveModelCostConfig({
-            provider: providerUsed,
-            model: modelUsed,
-            config: cfg,
-          })
-        : undefined;
-      let formatted = formatResponseUsageLine({
-        usage,
-        showCost,
-        costConfig,
-      });
+      let formatted = formatResponseUsageLine({ usage });
       if (formatted && responseUsageMode === "full" && sessionKey) {
         formatted = `${formatted} · session \`${sessionKey}\``;
       }

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -12,7 +12,6 @@ import {
 import type { SessionEntry } from "../config/sessions/types.js";
 import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
 import { countToolResults, extractToolCallNames } from "../utils/transcript-tools.js";
-import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
 import type {
   CostBreakdown,
   CostUsageTotals,
@@ -248,15 +247,6 @@ async function scanTranscriptFile(params: {
     const entry = parseTranscriptEntry(parsed);
     if (!entry) {
       continue;
-    }
-
-    if (entry.usage && entry.costTotal === undefined) {
-      const cost = resolveModelCostConfig({
-        provider: entry.provider,
-        model: entry.model,
-        config: params.config,
-      });
-      entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
     }
 
     params.onEntry(entry);
@@ -981,13 +971,6 @@ export async function loadSessionLogs(params: {
           const breakdown = extractCostBreakdown(usageRaw);
           if (breakdown?.total !== undefined) {
             cost = breakdown.total;
-          } else {
-            const costConfig = resolveModelCostConfig({
-              provider: message.provider as string | undefined,
-              model: message.model as string | undefined,
-              config: params.config,
-            });
-            cost = estimateUsageCost({ usage, cost: costConfig });
           }
         }
       }

--- a/src/utils/usage-format.test.ts
+++ b/src/utils/usage-format.test.ts
@@ -14,7 +14,4 @@ describe("usage-format", () => {
     expect(formatUsd(0.5)).toBe("$0.50");
     expect(formatUsd(0.0042)).toBe("$0.0042");
   });
-
-  // Test "resolves model cost config and estimates usage cost" removed:
-  // resolveModelCostConfig is now a no-op that always returns undefined.
 });

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -1,21 +1,3 @@
-import type { NormalizedUsage } from "../agents/usage.js";
-import type { RemoteClawConfig } from "../config/config.js";
-
-export type ModelCostConfig = {
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-};
-
-export type UsageTotals = {
-  input?: number;
-  output?: number;
-  cacheRead?: number;
-  cacheWrite?: number;
-  total?: number;
-};
-
 export function formatTokenCount(value?: number): string {
   if (value === undefined || !Number.isFinite(value)) {
     return "0";
@@ -41,41 +23,4 @@ export function formatUsd(value?: number): string | undefined {
     return `$${value.toFixed(2)}`;
   }
   return `$${value.toFixed(4)}`;
-}
-
-export function resolveModelCostConfig(_params: {
-  provider?: string;
-  model?: string;
-  config?: RemoteClawConfig;
-}): ModelCostConfig | undefined {
-  // Models config section has been removed — cost data is no longer available
-  // from config. CLI agents resolve model costs directly.
-  return undefined;
-}
-
-const toNumber = (value: number | undefined): number =>
-  typeof value === "number" && Number.isFinite(value) ? value : 0;
-
-export function estimateUsageCost(params: {
-  usage?: NormalizedUsage | UsageTotals | null;
-  cost?: ModelCostConfig;
-}): number | undefined {
-  const usage = params.usage;
-  const cost = params.cost;
-  if (!usage || !cost) {
-    return undefined;
-  }
-  const input = toNumber(usage.input);
-  const output = toNumber(usage.output);
-  const cacheRead = toNumber(usage.cacheRead);
-  const cacheWrite = toNumber(usage.cacheWrite);
-  const total =
-    input * cost.input +
-    output * cost.output +
-    cacheRead * cost.cacheRead +
-    cacheWrite * cost.cacheWrite;
-  if (!Number.isFinite(total)) {
-    return undefined;
-  }
-  return total / 1_000_000;
 }


### PR DESCRIPTION
## Summary

- Remove `resolveModelCostConfig` (always returned `undefined`), `estimateUsageCost` (always returned `undefined`/`0`), `ModelCostConfig` type, and `UsageTotals` type from `usage-format.ts`
- Remove dead cost-estimation fallback call sites in `session-cost-usage.ts` (`scanTranscriptFile` and `loadSessionLogs`)
- Remove dead cost computation from `agent-runner.ts` (diagnostic event `costUsd` from estimation, `showCost`/`costConfig` in response usage line)
- Clean up dead `showCost`/`costConfig` params from `formatResponseUsageLine` in `agent-runner-utils.ts`
- Transcript-level cost data (from CLI agents via `extractCostBreakdown`) and `formatUsd` remain alive

Closes #2292

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm tsgo` (type-check) passes
- [x] `pnpm test` passes (694 test files, 5942 tests)
- [x] `pnpm check` passes (format + typecheck + lint)
- [x] Token usage tracking preserved (formatTokenCount, usage aggregation untouched)
- [x] Cost data from transcript logs preserved (extractCostBreakdown, applyCostBreakdown, formatUsd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)