### PR TITLE
fix: reroute 2 stale openclaw identity references

### DIFF
--- a/src/acp/runtime/registry.ts
+++ b/src/acp/runtime/registry.ts
@@ -12,7 +12,7 @@ type AcpRuntimeRegistryGlobalState = {
   backendsById: Map<string, AcpRuntimeBackend>;
 };
 
-const ACP_RUNTIME_REGISTRY_STATE_KEY = Symbol.for("openclaw.acpRuntimeRegistryState");
+const ACP_RUNTIME_REGISTRY_STATE_KEY = Symbol.for("remoteclaw.acpRuntimeRegistryState");
 
 function resolveAcpRuntimeRegistryGlobalState(): AcpRuntimeRegistryGlobalState {
   return resolveGlobalSingleton<AcpRuntimeRegistryGlobalState>(

--- a/src/compat/legacy-names.ts
+++ b/src/compat/legacy-names.ts
@@ -10,6 +10,6 @@ export const LEGACY_PLUGIN_MANIFEST_FILENAMES = [] as const;
 
 export const LEGACY_CANVAS_HANDLER_NAMES = [] as const;
 
-export const MACOS_APP_SOURCES_DIR = "apps/macos/Sources/OpenClaw" as const;
+export const MACOS_APP_SOURCES_DIR = "apps/macos/Sources/RemoteClaw" as const;
 
 export const LEGACY_MACOS_APP_SOURCES_DIRS = [] as const;


### PR DESCRIPTION
## Summary

- `src/acp/runtime/registry.ts`: Symbol.for namespace `openclaw.acpRuntimeRegistryState` → `remoteclaw.acpRuntimeRegistryState`
- `src/compat/legacy-names.ts`: MACOS_APP_SOURCES_DIR from `apps/macos/Sources/OpenClaw` → `apps/macos/Sources/RemoteClaw` (directory already rebranded on disk)

## Test plan

- [x] `pnpm check` passes (typecheck + lint + format)
- [x] `git grep 'openclaw.acp'` returns 0 results
- [x] `git grep 'Sources/OpenClaw'` returns 0 results

Closes #2287

🤖 Generated with [Claude Code](https://claude.com/claude-code)