### PR TITLE
refactor(gateway): require explicit agent config at startup (#2308)

### DIFF
--- a/src/agents/defaults.ts
+++ b/src/agents/defaults.ts
@@ -1,5 +1,4 @@
 // Gutted in RemoteClaw fork (Middleware Boundary Principle)
-export const DEFAULT_AGENT_ID = "default";
-export const DEFAULT_CONTEXT_TOKENS = 200000; // Gutted in RemoteClaw fork (Middleware Boundary Principle)
-export const DEFAULT_MODEL = "default"; // Gutted in RemoteClaw fork (Middleware Boundary Principle)
-export const DEFAULT_PROVIDER = "default"; // Gutted in RemoteClaw fork (Middleware Boundary Principle)
+export const DEFAULT_CONTEXT_TOKENS = 200000;
+export const DEFAULT_MODEL = "default";
+export const DEFAULT_PROVIDER = "default";

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -274,7 +274,10 @@ describe("broadcast", () => {
   it("accepts a broadcast peer map with strategy", () => {
     const res = validateConfigObject({
       agents: {
-        list: [{ id: "alfred" }, { id: "baerbel" }],
+        list: [
+          { id: "alfred", workspace: "/tmp/alfred" },
+          { id: "baerbel", workspace: "/tmp/baerbel" },
+        ],
       },
       broadcast: {
         strategy: "parallel",

--- a/src/config/config.acp-binding-cutover.test.ts
+++ b/src/config/config.acp-binding-cutover.test.ts
@@ -6,9 +6,15 @@ describe("ACP binding cutover schema", () => {
     const parsed = RemoteClawSchema.safeParse({
       agents: {
         list: [
-          { id: "main", default: true, runtime: { type: "embedded" } },
+          {
+            id: "main",
+            workspace: "/tmp/main",
+            default: true,
+            runtime: { type: "embedded" },
+          },
           {
             id: "coding",
+            workspace: "/tmp/coding",
             runtime: {
               type: "acp",
               acp: {

--- a/src/config/config.agent-concurrency-defaults.test.ts
+++ b/src/config/config.agent-concurrency-defaults.test.ts
@@ -31,6 +31,7 @@ describe("agent concurrency defaults", () => {
   it("accepts subagent spawn depth and per-agent child limits", () => {
     const parsed = RemoteClawSchema.parse({
       agents: {
+        list: [{ id: "main", workspace: "/tmp/main" }],
         defaults: {
           subagents: {
             maxSpawnDepth: 2,
@@ -44,9 +45,24 @@ describe("agent concurrency defaults", () => {
     expect(parsed.agents?.defaults?.subagents?.maxChildrenPerAgent).toBe(7);
   });
 
-  it("injects defaults on load", async () => {
+  it("resolves defaults for configs with no agents declared", async () => {
     await withTempHome(async (home) => {
       await writeRemoteClawConfig(home, {});
+
+      const cfg = loadConfig();
+
+      // With agents.list required, empty configs do not auto-inject agents.defaults;
+      // runtime resolvers still fall back to the same constants.
+      expect(resolveAgentMaxConcurrent(cfg)).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+      expect(resolveSubagentMaxConcurrent(cfg)).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
+    });
+  });
+
+  it("injects defaults on load when agents are declared", async () => {
+    await withTempHome(async (home) => {
+      await writeRemoteClawConfig(home, {
+        agents: { list: [{ id: "main", workspace: "/tmp/main" }] },
+      });
 
       const cfg = loadConfig();
 

--- a/src/config/config.identity-defaults.test.ts
+++ b/src/config/config.identity-defaults.test.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { DEFAULT_AGENT_MAX_CONCURRENT, DEFAULT_SUBAGENT_MAX_CONCURRENT } from "./agent-limits.js";
+import {
+  DEFAULT_AGENT_MAX_CONCURRENT,
+  DEFAULT_SUBAGENT_MAX_CONCURRENT,
+  resolveAgentMaxConcurrent,
+  resolveSubagentMaxConcurrent,
+} from "./agent-limits.js";
 import { loadConfig } from "./config.js";
 import { withTempHome } from "./home-env.test-harness.js";
 
@@ -17,6 +22,7 @@ describe("config identity defaults", () => {
       list: [
         {
           id: "main",
+          workspace: "/tmp/main",
           identity: defaultIdentity,
         },
       ],
@@ -54,9 +60,11 @@ describe("config identity defaults", () => {
       expect(cfg.messages?.ackReactionScope).toBe("group-mentions");
       expect(cfg.messages?.responsePrefix).toBeUndefined();
       expect(cfg.messages?.groupChat?.mentionPatterns).toBeUndefined();
-      expect(cfg.agents?.list).toBeUndefined();
-      expect(cfg.agents?.defaults?.maxConcurrent).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
-      expect(cfg.agents?.defaults?.subagents?.maxConcurrent).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
+      // With agents.list required, empty configs leave cfg.agents undefined; runtime
+      // resolvers fall back to the same concurrency defaults.
+      expect(cfg.agents).toBeUndefined();
+      expect(resolveAgentMaxConcurrent(cfg)).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+      expect(resolveSubagentMaxConcurrent(cfg)).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
       expect(cfg.session).toBeUndefined();
     });
   });
@@ -68,6 +76,7 @@ describe("config identity defaults", () => {
           list: [
             {
               id: "main",
+              workspace: "/tmp/main",
               identity: {
                 name: "Samantha Sloth",
                 theme: "space lobster",

--- a/src/config/config.legacy-config-detection.accepts-imessage-dmpolicy.test.ts
+++ b/src/config/config.legacy-config-detection.accepts-imessage-dmpolicy.test.ts
@@ -232,6 +232,9 @@ describe("legacy config detection", () => {
   });
   it("migrates legacy model config to agent.models + model lists", async () => {
     const res = migrateLegacyConfig({
+      agents: {
+        list: [{ id: "main", workspace: "/tmp/main" }],
+      },
       agent: {
         model: "anthropic/claude-opus-4-5",
         modelFallbacks: ["openai/gpt-4.1-mini"],

--- a/src/config/config.multi-agent-agentdir-validation.test.ts
+++ b/src/config/config.multi-agent-agentdir-validation.test.ts
@@ -10,8 +10,8 @@ describe("multi-agent agentDir validation", () => {
     const res = validateConfigObject({
       agents: {
         list: [
-          { id: "a", agentDir: shared },
-          { id: "b", agentDir: shared },
+          { id: "a", workspace: "/tmp/a", agentDir: shared },
+          { id: "b", workspace: "/tmp/b", agentDir: shared },
         ],
       },
     });
@@ -27,8 +27,16 @@ describe("multi-agent agentDir validation", () => {
       {
         agents: {
           list: [
-            { id: "a", agentDir: "~/.remoteclaw/agents/shared/agent" },
-            { id: "b", agentDir: "~/.remoteclaw/agents/shared/agent" },
+            {
+              id: "a",
+              workspace: "~/.remoteclaw/workspaces/a",
+              agentDir: "~/.remoteclaw/agents/shared/agent",
+            },
+            {
+              id: "b",
+              workspace: "~/.remoteclaw/workspaces/b",
+              agentDir: "~/.remoteclaw/agents/shared/agent",
+            },
           ],
         },
         bindings: [{ agentId: "a", match: { channel: "telegram" } }],

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -134,7 +134,7 @@ describe("config plugin validation", () => {
   it("reports missing plugin refs across load paths, entries, and allowlist surfaces", async () => {
     const missingPath = path.join(suiteHome, "missing-plugin-dir");
     const res = validateInSuite({
-      agents: { list: [{ id: "pi" }] },
+      agents: { list: [{ id: "pi", workspace: "/tmp/pi" }] },
       plugins: {
         enabled: false,
         load: { paths: [missingPath] },
@@ -170,7 +170,7 @@ describe("config plugin validation", () => {
   it("warns for removed legacy plugin ids instead of failing validation", async () => {
     const removedId = "google-antigravity-auth";
     const res = validateInSuite({
-      agents: { list: [{ id: "pi" }] },
+      agents: { list: [{ id: "pi", workspace: "/tmp/pi" }] },
       plugins: {
         enabled: false,
         entries: { [removedId]: { enabled: true } },
@@ -210,7 +210,7 @@ describe("config plugin validation", () => {
 
   it("surfaces plugin config diagnostics", async () => {
     const res = validateInSuite({
-      agents: { list: [{ id: "pi" }] },
+      agents: { list: [{ id: "pi", workspace: "/tmp/pi" }] },
       plugins: {
         enabled: true,
         load: { paths: [badPluginDir] },
@@ -230,7 +230,7 @@ describe("config plugin validation", () => {
 
   it("surfaces allowed enum values for plugin config diagnostics", async () => {
     const res = validateInSuite({
-      agents: { list: [{ id: "pi" }] },
+      agents: { list: [{ id: "pi", workspace: "/tmp/pi" }] },
       plugins: {
         enabled: true,
         load: { paths: [enumPluginDir] },
@@ -251,7 +251,7 @@ describe("config plugin validation", () => {
 
   it("accepts voice-call webhookSecurity and streaming guard config fields", async () => {
     const res = validateInSuite({
-      agents: { list: [{ id: "pi" }] },
+      agents: { list: [{ id: "pi", workspace: "/tmp/pi" }] },
       plugins: {
         enabled: true,
         load: { paths: [voiceCallSchemaPluginDir] },
@@ -284,7 +284,7 @@ describe("config plugin validation", () => {
     const res = validateInSuite({
       agents: {
         defaults: { heartbeat: { target: "last", directPolicy: "block" } },
-        list: [{ id: "pi", heartbeat: { directPolicy: "allow" } }],
+        list: [{ id: "pi", workspace: "/tmp/pi", heartbeat: { directPolicy: "allow" } }],
       },
       channels: {
         modelByChannel: {
@@ -300,7 +300,10 @@ describe("config plugin validation", () => {
 
   it("accepts plugin heartbeat targets", async () => {
     const res = validateInSuite({
-      agents: { defaults: { heartbeat: { target: "bluebubbles" } }, list: [{ id: "pi" }] },
+      agents: {
+        defaults: { heartbeat: { target: "bluebubbles" } },
+        list: [{ id: "pi", workspace: "/tmp/pi" }],
+      },
       plugins: { enabled: false, load: { paths: [bluebubblesPluginDir] } },
     });
     expect(res.ok).toBe(true);
@@ -310,7 +313,7 @@ describe("config plugin validation", () => {
     const res = validateInSuite({
       agents: {
         defaults: { heartbeat: { target: "not-a-channel" } },
-        list: [{ id: "pi" }],
+        list: [{ id: "pi", workspace: "/tmp/pi" }],
       },
     });
     expect(res.ok).toBe(false);
@@ -326,7 +329,7 @@ describe("config plugin validation", () => {
     const res = validateInSuite({
       agents: {
         defaults: { heartbeat: { directPolicy: "maybe" } },
-        list: [{ id: "pi" }],
+        list: [{ id: "pi", workspace: "/tmp/pi" }],
       },
     });
     expect(res.ok).toBe(false);

--- a/src/config/config.pruning-defaults.test.ts
+++ b/src/config/config.pruning-defaults.test.ts
@@ -19,7 +19,9 @@ describe("config pruning defaults", () => {
   it("does not enable contextPruning by default", async () => {
     await withEnvAsync({ ANTHROPIC_API_KEY: "", ANTHROPIC_OAUTH_TOKEN: "" }, async () => {
       await withTempHome(async (home) => {
-        await writeConfigForTest(home, { agents: { defaults: {} } });
+        await writeConfigForTest(home, {
+          agents: { defaults: {}, list: [{ id: "main", workspace: "/tmp/main" }] },
+        });
 
         const cfg = loadConfig();
 
@@ -36,7 +38,7 @@ describe("config pruning defaults", () => {
             "anthropic:me": { provider: "anthropic", mode: "oauth", email: "me@example.com" },
           },
         },
-        agents: { defaults: {} },
+        agents: { defaults: {}, list: [{ id: "main", workspace: "/tmp/main" }] },
       });
 
       const cfg = loadConfig();
@@ -55,7 +57,7 @@ describe("config pruning defaults", () => {
             "anthropic:api": { provider: "anthropic", mode: "api_key" },
           },
         },
-        agents: { defaults: {} },
+        agents: { defaults: {}, list: [{ id: "main", workspace: "/tmp/main" }] },
       });
 
       const cfg = loadConfig();
@@ -68,7 +70,12 @@ describe("config pruning defaults", () => {
 
   it("does not override explicit contextPruning mode", async () => {
     await withTempHome(async (home) => {
-      await writeConfigForTest(home, { agents: { defaults: { contextPruning: { mode: "off" } } } });
+      await writeConfigForTest(home, {
+        agents: {
+          defaults: { contextPruning: { mode: "off" } },
+          list: [{ id: "main", workspace: "/tmp/main" }],
+        },
+      });
 
       const cfg = loadConfig();
 

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -33,6 +33,7 @@ describe("config schema regressions", () => {
   it("still parses legacy memorySearch fields without error (compat stub)", () => {
     const res = validateConfigObject({
       agents: {
+        list: [{ id: "main", workspace: "/tmp/main" }],
         defaults: {
           memorySearch: {
             fallback: "voyage",
@@ -100,6 +101,7 @@ describe("config schema regressions", () => {
   it("accepts string values for agents defaults model inputs", () => {
     const res = validateConfigObject({
       agents: {
+        list: [{ id: "main", workspace: "/tmp/main" }],
         defaults: {
           model: "anthropic/claude-opus-4-6",
           imageModel: "openai/gpt-4.1-mini",
@@ -113,6 +115,7 @@ describe("config schema regressions", () => {
   it("accepts pdf default model and limits", () => {
     const res = validateConfigObject({
       agents: {
+        list: [{ id: "main", workspace: "/tmp/main" }],
         defaults: {
           pdfModel: {
             primary: "anthropic/claude-opus-4-6",
@@ -130,6 +133,7 @@ describe("config schema regressions", () => {
   it("accepts legacy pdf limits (compat stubs)", () => {
     const res = validateConfigObject({
       agents: {
+        list: [{ id: "main", workspace: "/tmp/main" }],
         defaults: {
           pdfModel: { primary: "openai/gpt-5-mini" },
           pdfMaxBytesMb: 0,

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -348,7 +348,10 @@ export function applyModelDefaults(cfg: RemoteClawConfig): RemoteClawConfig {
 
 export function applyAgentDefaults(cfg: RemoteClawConfig): RemoteClawConfig {
   const agents = cfg.agents;
-  const defaults = agents?.defaults;
+  if (!agents) {
+    return cfg;
+  }
+  const defaults = agents.defaults;
   const hasMax =
     typeof defaults?.maxConcurrent === "number" && Number.isFinite(defaults.maxConcurrent);
   const hasSubMax =

--- a/src/config/io.compat.test.ts
+++ b/src/config/io.compat.test.ts
@@ -101,6 +101,7 @@ describe("config io paths", () => {
               list: [
                 {
                   id: "ops",
+                  workspace: "/tmp/ops",
                   tools: {
                     exec: {
                       safeBinTrustedDirs: [" /ops/bin ", "/ops/bin"],

--- a/src/config/io.validation-fails-closed.test.ts
+++ b/src/config/io.validation-fails-closed.test.ts
@@ -11,7 +11,7 @@ describe("config validation fail-closed behavior", () => {
   it("throws INVALID_CONFIG instead of returning an empty config", async () => {
     await withTempHomeConfig(
       {
-        agents: { list: [{ id: "main" }] },
+        agents: { list: [{ id: "main", workspace: "/tmp/main" }] },
         nope: true,
         channels: {
           whatsapp: {
@@ -39,7 +39,7 @@ describe("config validation fail-closed behavior", () => {
   it("still loads valid security settings unchanged", async () => {
     await withTempHomeConfig(
       {
-        agents: { list: [{ id: "main" }] },
+        agents: { list: [{ id: "main", workspace: "/tmp/main" }] },
         channels: {
           whatsapp: {
             dmPolicy: "allowlist",

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -289,6 +289,7 @@ describe("config io write", () => {
         env: { OPENAI_API_KEY: "sk-secret" } as NodeJS.ProcessEnv,
         initialConfig: {
           agents: {
+            list: [{ id: "main", workspace: "/tmp/main" }],
             defaults: {
               cliBackends: {
                 codex: {
@@ -372,6 +373,7 @@ describe("config io write", () => {
         JSON.stringify(
           {
             agents: {
+              list: [{ id: "main", workspace: "/tmp/main" }],
               defaults: {
                 cliBackends: {
                   codex: {

--- a/src/config/legacy.default-field.test.ts
+++ b/src/config/legacy.default-field.test.ts
@@ -6,17 +6,25 @@ import { AgentEntrySchema } from "./zod-schema.agent-runtime.js";
 describe("deprecated agents.list[].default field (#1581)", () => {
   describe("zod schema acceptance", () => {
     it("accepts agent entry with default: true without parse error", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", default: true });
+      const result = AgentEntrySchema.safeParse({
+        id: "main",
+        workspace: "/tmp/main",
+        default: true,
+      });
       expect(result.success).toBe(true);
     });
 
     it("accepts agent entry with default: false without parse error", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", default: false });
+      const result = AgentEntrySchema.safeParse({
+        id: "main",
+        workspace: "/tmp/main",
+        default: false,
+      });
       expect(result.success).toBe(true);
     });
 
     it("accepts agent entry without default field", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main" });
+      const result = AgentEntrySchema.safeParse({ id: "main", workspace: "/tmp/main" });
       expect(result.success).toBe(true);
     });
   });

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -711,7 +711,7 @@ export const AgentEntrySchema = z
     id: z.string(),
     default: z.boolean().optional(),
     name: z.string().optional(),
-    workspace: z.string().optional(),
+    workspace: z.string().trim().min(1, "agents.list[].workspace must be a non-empty string"),
     agentDir: z.string().optional(),
     model: AgentModelSchema.optional(),
     skills: z.array(z.string()).optional(),

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -6,7 +6,7 @@ import { TranscribeAudioSchema } from "./zod-schema.core.js";
 export const AgentsSchema = z
   .object({
     defaults: z.lazy(() => AgentDefaultsSchema).optional(),
-    list: z.array(AgentEntrySchema).optional(),
+    list: z.array(AgentEntrySchema).min(1, "agents.list must contain at least one entry"),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.auth-field.test.ts
+++ b/src/config/zod-schema.auth-field.test.ts
@@ -3,81 +3,93 @@ import { AgentDefaultsSchema } from "./zod-schema.agent-defaults.js";
 import { AgentEntrySchema } from "./zod-schema.agent-runtime.js";
 
 describe("per-agent fork-specific field schema validation", () => {
+  const baseAgent = { id: "main", workspace: "/tmp/main" };
+
   describe("AgentEntrySchema — auth", () => {
     it("accepts auth: false", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", auth: false });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, auth: false });
       expect(result.success).toBe(true);
     });
 
     it("accepts auth as a string", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", auth: "anthropic:default" });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, auth: "anthropic:default" });
       expect(result.success).toBe(true);
     });
 
     it("accepts auth as a string array", () => {
       const result = AgentEntrySchema.safeParse({
-        id: "main",
+        ...baseAgent,
         auth: ["anthropic:key1", "anthropic:key2"],
       });
       expect(result.success).toBe(true);
     });
 
     it("accepts omitted auth (undefined)", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main" });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent });
       expect(result.success).toBe(true);
       expect(((result.data ?? {}) as Record<string, unknown>)?.auth).toBeUndefined();
     });
 
     it("rejects auth: true", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", auth: true });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, auth: true });
       expect(result.success).toBe(false);
     });
 
     it("rejects auth: number", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", auth: 42 });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, auth: 42 });
       expect(result.success).toBe(false);
     });
 
     it("rejects auth: object", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", auth: { profile: "x" } });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, auth: { profile: "x" } });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects missing workspace", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects empty-string workspace", () => {
+      const result = AgentEntrySchema.safeParse({ id: "main", workspace: "   " });
       expect(result.success).toBe(false);
     });
   });
 
   describe("AgentEntrySchema — runtime", () => {
     it("accepts runtime: 'claude'", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", runtime: "claude" });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, runtime: "claude" });
       expect(result.success).toBe(true);
     });
 
     it("accepts runtime: 'gemini'", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", runtime: "gemini" });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, runtime: "gemini" });
       expect(result.success).toBe(true);
     });
 
     it("accepts runtime: 'codex'", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", runtime: "codex" });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, runtime: "codex" });
       expect(result.success).toBe(true);
     });
 
     it("accepts runtime: 'opencode'", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", runtime: "opencode" });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, runtime: "opencode" });
       expect(result.success).toBe(true);
     });
 
     it("accepts omitted runtime (undefined)", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main" });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent });
       expect(result.success).toBe(true);
       expect(((result.data ?? {}) as Record<string, unknown>)?.runtime).toBeUndefined();
     });
 
     it("rejects runtime: 'unsupported'", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", runtime: "unsupported" });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, runtime: "unsupported" });
       expect(result.success).toBe(false);
     });
 
     it("rejects runtime: number", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", runtime: 42 });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, runtime: 42 });
       expect(result.success).toBe(false);
     });
   });
@@ -85,30 +97,30 @@ describe("per-agent fork-specific field schema validation", () => {
   describe("AgentEntrySchema — runtimeArgs", () => {
     it("accepts runtimeArgs as a string array", () => {
       const result = AgentEntrySchema.safeParse({
-        id: "main",
+        ...baseAgent,
         runtimeArgs: ["--verbose", "--model", "sonnet"],
       });
       expect(result.success).toBe(true);
     });
 
     it("accepts runtimeArgs as an empty array", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", runtimeArgs: [] });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, runtimeArgs: [] });
       expect(result.success).toBe(true);
     });
 
     it("accepts omitted runtimeArgs (undefined)", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main" });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent });
       expect(result.success).toBe(true);
       expect(((result.data ?? {}) as Record<string, unknown>)?.runtimeArgs).toBeUndefined();
     });
 
     it("rejects runtimeArgs: string (not array)", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", runtimeArgs: "--verbose" });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, runtimeArgs: "--verbose" });
       expect(result.success).toBe(false);
     });
 
     it("rejects runtimeArgs: number array", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", runtimeArgs: [1, 2, 3] });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, runtimeArgs: [1, 2, 3] });
       expect(result.success).toBe(false);
     });
   });
@@ -116,30 +128,30 @@ describe("per-agent fork-specific field schema validation", () => {
   describe("AgentEntrySchema — runtimeEnv", () => {
     it("accepts runtimeEnv as a record of strings", () => {
       const result = AgentEntrySchema.safeParse({
-        id: "main",
+        ...baseAgent,
         runtimeEnv: { API_KEY: "sk-test", NODE_ENV: "production" },
       });
       expect(result.success).toBe(true);
     });
 
     it("accepts runtimeEnv as an empty record", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", runtimeEnv: {} });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, runtimeEnv: {} });
       expect(result.success).toBe(true);
     });
 
     it("accepts omitted runtimeEnv (undefined)", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main" });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent });
       expect(result.success).toBe(true);
       expect(((result.data ?? {}) as Record<string, unknown>)?.runtimeEnv).toBeUndefined();
     });
 
     it("rejects runtimeEnv: array", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", runtimeEnv: ["KEY=val"] });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, runtimeEnv: ["KEY=val"] });
       expect(result.success).toBe(false);
     });
 
     it("rejects runtimeEnv with non-string values", () => {
-      const result = AgentEntrySchema.safeParse({ id: "main", runtimeEnv: { PORT: 3000 } });
+      const result = AgentEntrySchema.safeParse({ ...baseAgent, runtimeEnv: { PORT: 3000 } });
       expect(result.success).toBe(false);
     });
   });

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveFirstAgentWorkspace } from "../agents/agent-scope.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
@@ -315,8 +315,12 @@ export async function startGatewayServer(
   });
 
   initSubagentRegistry();
-  const defaultAgentId = resolveDefaultAgentId(cfgAtStart);
-  const defaultWorkspaceDir = resolveAgentWorkspaceDir(cfgAtStart, defaultAgentId);
+  const defaultWorkspaceDir = resolveFirstAgentWorkspace(cfgAtStart);
+  if (!defaultWorkspaceDir) {
+    throw new Error(
+      "No agents configured — add at least one entry to agents.list in remoteclaw.json",
+    );
+  }
   const baseMethods = listGatewayMethods();
   const emptyPluginRegistry = createEmptyPluginRegistry();
   const { pluginRegistry, gatewayMethods: baseGatewayMethods } = minimalTestGateway

--- a/src/security/fix.test.ts
+++ b/src/security/fix.test.ts
@@ -209,7 +209,7 @@ describe("security fix", () => {
     const configPath = path.join(stateDir, "remoteclaw.json");
     await fs.writeFile(
       configPath,
-      `{ "$include": "./includes/extra.json5", agents: { list: [{ id: "main" }] }, channels: { whatsapp: { groupPolicy: "open" } } }\n`,
+      `{ "$include": "./includes/extra.json5", agents: { list: [{ id: "main", workspace: "/tmp/main" }] }, channels: { whatsapp: { groupPolicy: "open" } } }\n`,
       "utf-8",
     );
     await fs.chmod(configPath, 0o644);


### PR DESCRIPTION
## Summary

Phase 1/5 of the "eliminate default agent" initiative (#2308 → #2309 → #2310 → #2311 → #2312).

Gateway startup crashes when no agent named `main` is configured:
```
Gateway failed to start: Error: agent 'main' has no workspace configured
— set agents.list[].workspace in remoteclaw.json
```

The crash happens at `src/gateway/server.impl.ts:318-319`, where `resolveDefaultAgentId()` falls back to the hardcoded `DEFAULT_AGENT_ID = "main"` when no sole agent exists, then `resolveAgentWorkspaceDir()` throws because there is no agent with that id. This phantom-agent concept is architecturally wrong for multi-agent setups.

This PR fixes the boundary symptom (gateway startup), enforces the contract in schema (parse-time failure beats runtime crash), and removes one dead fossil — without touching the rest of the `resolveDefaultAgentId` callers yet. Phase 2b (#2310) migrates the remaining callers.

## Changes

- **`src/gateway/server.impl.ts`**: replace `resolveDefaultAgentId` + `resolveAgentWorkspaceDir` with `resolveFirstAgentWorkspace` + explicit error. Downstream plugin loader and sidecars only need the workspace dir, so no phantom agent id is computed at startup.
- **`src/config/zod-schema.agents.ts`**: `agents.list` becomes required with `.min(1, "agents.list must contain at least one entry")`.
- **`src/config/zod-schema.agent-runtime.ts`**: `AgentEntrySchema.workspace` becomes a required trimmed non-empty string, with error message pointing at `agents.list[].workspace`.
- **`src/agents/defaults.ts`**: drop the `DEFAULT_AGENT_ID = "default"` fossil. Zero importers (grep-verified); it conflicted with the canonical `"main"` in `src/routing/session-key.ts:19`.
- **`src/config/defaults.ts`**: `applyAgentDefaults` is now a no-op when `cfg.agents` is entirely absent. It previously synthesised `agents: { defaults: {…} }` without a list, which the tightened schema now rejects on write-back. Runtime resolvers (`resolveAgentMaxConcurrent`, `resolveSubagentMaxConcurrent`) already fall back to the same constants, so observable behaviour for empty configs is unchanged.
- **Tests** (14 files): add `workspace: "/tmp/..."` to fixtures that exercise `RemoteClawSchema` or `validateConfigObject` with agent lists. Two tests that asserted injected defaults on empty configs now use the runtime resolvers directly.

## Exit criteria (verified locally)

```bash
$ grep -n "resolveDefaultAgentId" src/gateway/server.impl.ts
# (no matches)

$ grep -rn "DEFAULT_AGENT_ID" src/agents/defaults.ts
# (no matches)

$ grep -n "\.min(1" src/config/zod-schema.agents.ts
9:    list: z.array(AgentEntrySchema).min(1, "agents.list must contain at least one entry"),

$ pnpm check    # format + tsgo + lint → clean
$ pnpm test     # 6387 passed | 2 skipped (737 test files)
```

## Blocks unblocked

- #2309 — routing `unmatched` policy (Phase 2a)
- #2310 — `resolveDefaultAgentId` caller migration (Phase 2b)
- #2311 — `normalizeAgentId` split (Phase 3a)
- #2312 — session key migration (Phase 3b)

## Test plan

- [x] `pnpm canvas:a2ui:bundle && pnpm check && pnpm test` locally green
- [ ] CI `build`, `test`, `lint`, `docs` checks pass
- [ ] Gateway smoke: start with a config that declares a single agent (any id, not "main") and a non-empty workspace → starts successfully
- [ ] Gateway smoke: start with a config whose `agents.list` is empty/missing → fails parse-time or gateway-startup with the new error message
- [ ] Gateway smoke: start with a multi-agent config where each entry has a workspace → starts successfully

Closes #2308

🤖 Generated with [Claude Code](https://claude.com/claude-code)