### PR TITLE
refactor(routing): add routing.unmatched policy for multi-agent configs (#2309)

### DIFF
--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -239,6 +239,10 @@ export function createDiagnosticsOtelService(): RemoteClawPluginService {
         unit: "1",
         description: "Run attempts",
       });
+      const routingDropsCounter = meter.createCounter("remoteclaw.routing.drops", {
+        unit: "1",
+        description: "Inbound messages silently dropped by routing policy",
+      });
 
       if (logsEnabled) {
         const logExporter = new OTLPLogExporter({
@@ -616,6 +620,15 @@ export function createDiagnosticsOtelService(): RemoteClawPluginService {
         queueDepthHistogram.record(evt.queued, { "remoteclaw.channel": "heartbeat" });
       };
 
+      const recordRoutingDrop = (
+        evt: Extract<DiagnosticEventPayload, { type: "routing.drop" }>,
+      ) => {
+        routingDropsCounter.add(1, {
+          "remoteclaw.channel": evt.channel,
+          "remoteclaw.reason": evt.reason,
+        });
+      };
+
       unsubscribe = onDiagnosticEvent((evt: DiagnosticEventPayload) => {
         try {
           switch (evt.type) {
@@ -654,6 +667,9 @@ export function createDiagnosticsOtelService(): RemoteClawPluginService {
               return;
             case "diagnostic.heartbeat":
               recordHeartbeat(evt);
+              return;
+            case "routing.drop":
+              recordRoutingDrop(evt);
               return;
           }
         } catch (err) {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1178,8 +1178,13 @@ export async function handleFeishuMessage(params: {
 
     // Dynamic agent creation for DM users
     // When enabled, creates a unique agent instance with its own workspace for each DM user.
+    // Triggers when the DM landed on a fallback route (sole-agent promotion or
+    // operator-configured catch-all) rather than a peer-specific binding.
     let effectiveCfg = cfg;
-    if (!isGroup && route.matchedBy === "default") {
+    if (
+      !isGroup &&
+      (route.matchedBy === "fallback.soleAgent" || route.matchedBy === "unmatched.catchAll")
+    ) {
       const dynamicCfg = feishuCfg?.dynamicAgentCreation as DynamicAgentCreationConfig | undefined;
       if (dynamicCfg?.enabled) {
         const runtime = getFeishuRuntime();

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -13,6 +13,7 @@ import {
   loadProviderUsageSummary,
   resolveUsageProviderId,
 } from "../../infra/provider-usage.js";
+import { getRoutingDropCounts } from "../../routing/routing-drops-accumulator.js";
 import { normalizeGroupActivation } from "../group-activation.js";
 import { buildStatusMessage } from "../status.js";
 import type { VerboseLevel } from "../thinking.js";
@@ -20,6 +21,19 @@ import type { ReplyPayload } from "../types.js";
 import type { CommandContext } from "./commands-types.js";
 import { getFollowupQueueDepth, resolveQueueSettings } from "./queue.js";
 import { resolveSubagentLabel } from "./subagents-utils.js";
+
+function formatRoutingDropsLine(): string | undefined {
+  const drops = getRoutingDropCounts();
+  if (drops.total === 0) {
+    return undefined;
+  }
+  const perChannel = Object.entries(drops.byChannel)
+    .toSorted((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([channel, count]) => `${channel}:${count}`)
+    .join(", ");
+  return `🚫 Drops: ${drops.total}${perChannel ? ` (${perChannel})` : ""}`;
+}
 
 export async function buildStatusReply(params: {
   cfg: RemoteClawConfig;
@@ -127,6 +141,7 @@ export async function buildStatusReply(params: {
     ? (normalizeGroupActivation(sessionEntry?.groupActivation) ?? defaultGroupActivation())
     : undefined;
   const agentDefaults = cfg.agents?.defaults ?? {};
+  const routingDropsLine = formatRoutingDropsLine();
   const statusText = await buildStatusMessage({
     config: cfg,
     agent: {
@@ -151,6 +166,7 @@ export async function buildStatusReply(params: {
       showDetails: queueOverrides,
     },
     subagentsLine,
+    routingDropsLine,
     includeTranscriptUsage: false,
   });
 

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -73,6 +73,7 @@ type StatusArgs = {
   timeLine?: string;
   queue?: QueueStatus;
   subagentsLine?: string;
+  routingDropsLine?: string;
   includeTranscriptUsage?: boolean;
   now?: number;
 };
@@ -438,6 +439,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     args.usageLine,
     `🧵 ${sessionLine}`,
     args.subagentsLine,
+    args.routingDropsLine,
     `⚙️ ${optionsLine}`,
     voiceLine,
     activationLine,

--- a/src/config/types.remoteclaw.ts
+++ b/src/config/types.remoteclaw.ts
@@ -89,6 +89,17 @@ export type RemoteClawConfig = {
   agents?: AgentsConfig;
   tools?: ToolsConfig;
   bindings?: AgentBinding[];
+  /**
+   * Routing policy for messages that match no binding in multi-agent configs.
+   *
+   * - omitted / `"reject"`: Silent drop with telemetry.
+   * - `{ agent: "id" }`: Route unmatched messages to the named agent (must exist in `agents.list`).
+   *
+   * Single-agent configs route to the sole agent regardless of this setting.
+   */
+  routing?: {
+    unmatched?: "reject" | { agent: string };
+  };
   broadcast?: BroadcastConfig;
   audio?: AudioConfig;
   messages?: MessagesConfig;

--- a/src/config/zod-schema.routing-unmatched.test.ts
+++ b/src/config/zod-schema.routing-unmatched.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { RemoteClawSchema } from "./zod-schema.js";
+
+describe("RemoteClawSchema routing.unmatched", () => {
+  it("accepts omitted routing field", () => {
+    expect(() =>
+      RemoteClawSchema.parse({
+        agents: { list: [{ id: "ops", workspace: "~/ops" }] },
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts routing.unmatched = 'reject'", () => {
+    expect(() =>
+      RemoteClawSchema.parse({
+        agents: {
+          list: [
+            { id: "ops", workspace: "~/ops" },
+            { id: "dev", workspace: "~/dev" },
+          ],
+        },
+        routing: { unmatched: "reject" },
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts routing.unmatched = { agent: 'id' } when agent exists", () => {
+    expect(() =>
+      RemoteClawSchema.parse({
+        agents: {
+          list: [
+            { id: "ops", workspace: "~/ops" },
+            { id: "triage", workspace: "~/triage" },
+          ],
+        },
+        routing: { unmatched: { agent: "triage" } },
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects routing.unmatched.agent referencing an unknown agent", () => {
+    expect(() =>
+      RemoteClawSchema.parse({
+        agents: {
+          list: [
+            { id: "ops", workspace: "~/ops" },
+            { id: "dev", workspace: "~/dev" },
+          ],
+        },
+        routing: { unmatched: { agent: "nonexistent" } },
+      }),
+    ).toThrow(/Unknown agent id.*nonexistent/);
+  });
+
+  it("rejects routing.unmatched with extra fields", () => {
+    expect(() =>
+      RemoteClawSchema.parse({
+        agents: { list: [{ id: "ops", workspace: "~/ops" }] },
+        routing: { unmatched: { agent: "ops", extra: "nope" } },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects routing with extra fields outside unmatched", () => {
+    expect(() =>
+      RemoteClawSchema.parse({
+        agents: { list: [{ id: "ops", workspace: "~/ops" }] },
+        routing: { unmatched: "reject", unknownField: "nope" },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects routing.unmatched as an arbitrary string other than 'reject'", () => {
+    expect(() =>
+      RemoteClawSchema.parse({
+        agents: { list: [{ id: "ops", workspace: "~/ops" }] },
+        routing: { unmatched: "custom" },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("RemoteClawSchema bindings agent validation", () => {
+  it("accepts binding referencing a configured agent", () => {
+    expect(() =>
+      RemoteClawSchema.parse({
+        agents: { list: [{ id: "ops", workspace: "~/ops" }] },
+        bindings: [
+          {
+            agentId: "ops",
+            match: { channel: "telegram", peer: { kind: "direct", id: "+1555" } },
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects binding referencing an unknown agent", () => {
+    expect(() =>
+      RemoteClawSchema.parse({
+        agents: { list: [{ id: "ops", workspace: "~/ops" }] },
+        bindings: [
+          {
+            agentId: "nonexistent",
+            match: { channel: "telegram", peer: { kind: "direct", id: "+1555" } },
+          },
+        ],
+      }),
+    ).toThrow(/Unknown agent id.*nonexistent/);
+  });
+
+  it("rejects empty agents.list (parent #2308 contract)", () => {
+    expect(() =>
+      RemoteClawSchema.parse({
+        agents: { list: [] },
+      }),
+    ).toThrow(/agents\.list must contain at least one entry/);
+  });
+});

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -411,6 +411,14 @@ export const RemoteClawSchema = z
     agents: AgentsSchema,
     tools: ToolsSchema,
     bindings: BindingsSchema,
+    routing: z
+      .object({
+        unmatched: z
+          .union([z.literal("reject"), z.object({ agent: z.string() }).strict()])
+          .optional(),
+      })
+      .strict()
+      .optional(),
     broadcast: BroadcastSchema,
     audio: AudioSchema,
     media: z
@@ -805,6 +813,35 @@ export const RemoteClawSchema = z
       return;
     }
     const agentIds = new Set(agents.map((agent) => agent.id));
+
+    const routingUnmatched = cfg.routing?.unmatched;
+    if (
+      routingUnmatched &&
+      typeof routingUnmatched === "object" &&
+      "agent" in routingUnmatched &&
+      !agentIds.has(routingUnmatched.agent)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["routing", "unmatched", "agent"],
+        message: `Unknown agent id "${routingUnmatched.agent}" (not in agents.list).`,
+      });
+    }
+
+    const bindings = cfg.bindings;
+    if (Array.isArray(bindings)) {
+      for (let idx = 0; idx < bindings.length; idx += 1) {
+        const binding = bindings[idx];
+        const agentId = binding?.agentId;
+        if (typeof agentId === "string" && agentId && !agentIds.has(agentId)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["bindings", idx, "agentId"],
+            message: `Unknown agent id "${agentId}" (not in agents.list).`,
+          });
+        }
+      }
+    }
 
     const broadcast = cfg.broadcast;
     if (!broadcast) {

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -350,6 +350,11 @@ export async function preflightDiscordMessage(
     }),
     parentConversationId: earlyThreadParentId,
   });
+  if (!route) {
+    // Silent drop: routing.unmatched policy says no catch-all. Telemetry
+    // already fired via handleUnmatched.
+    return null;
+  }
   let threadBinding: SessionBindingRecord | undefined;
   threadBinding =
     getSessionBindingService().resolveByConversation({

--- a/src/discord/monitor/route-resolution.test.ts
+++ b/src/discord/monitor/route-resolution.test.ts
@@ -31,7 +31,7 @@ describe("discord route resolution helpers", () => {
       sessionKey: "agent:main:discord:channel:c1",
       mainSessionKey: "agent:main:main",
       lastRoutePolicy: "session",
-      matchedBy: "default",
+      matchedBy: "binding.channel",
     };
 
     expect(
@@ -56,7 +56,7 @@ describe("discord route resolution helpers", () => {
       sessionKey: "agent:main:discord:channel:c1",
       mainSessionKey: "agent:main:main",
       lastRoutePolicy: "session",
-      matchedBy: "default",
+      matchedBy: "binding.channel",
     };
     const configuredRoute = {
       route: {

--- a/src/discord/monitor/route-resolution.ts
+++ b/src/discord/monitor/route-resolution.ts
@@ -2,6 +2,7 @@ import type { RemoteClawConfig } from "../../config/config.js";
 import {
   deriveLastRoutePolicy,
   resolveAgentRoute,
+  resolveAgentRouteWithPolicy,
   type ResolvedAgentRoute,
   type RoutePeer,
 } from "../../routing/resolve-route.js";
@@ -21,6 +22,11 @@ export function buildDiscordRoutePeer(params: {
   };
 }
 
+/**
+ * Resolve a Discord conversation route applying the operator `routing.unmatched`
+ * policy. Returns `null` when the policy drops the message (silent drop +
+ * telemetry) so the preflight handler can halt processing cleanly.
+ */
 export function resolveDiscordConversationRoute(params: {
   cfg: RemoteClawConfig;
   accountId?: string | null;
@@ -28,8 +34,8 @@ export function resolveDiscordConversationRoute(params: {
   memberRoleIds?: string[];
   peer: RoutePeer;
   parentConversationId?: string | null;
-}): ResolvedAgentRoute {
-  return resolveAgentRoute({
+}): ResolvedAgentRoute | null {
+  return resolveAgentRouteWithPolicy({
     cfg: params.cfg,
     channel: "discord",
     accountId: params.accountId,
@@ -42,6 +48,14 @@ export function resolveDiscordConversationRoute(params: {
   });
 }
 
+/**
+ * Resolve a Discord bound conversation route. Used by slash command handlers
+ * which must always receive a usable route — callers invoke this synchronously
+ * to pick an agent for command execution, and silent-drop is not appropriate
+ * UX for user-initiated commands. Uses the backward-compatible
+ * {@link resolveAgentRoute} which falls back to the first configured agent
+ * when no binding matches and no catch-all is configured.
+ */
 export function resolveDiscordBoundConversationRoute(params: {
   cfg: RemoteClawConfig;
   accountId?: string | null;
@@ -56,10 +70,11 @@ export function resolveDiscordBoundConversationRoute(params: {
   configuredRoute?: { route: ResolvedAgentRoute } | null;
   matchedBy?: ResolvedAgentRoute["matchedBy"];
 }): ResolvedAgentRoute {
-  const route = resolveDiscordConversationRoute({
+  const route = resolveAgentRoute({
     cfg: params.cfg,
+    channel: "discord",
     accountId: params.accountId,
-    guildId: params.guildId,
+    guildId: params.guildId ?? undefined,
     memberRoleIds: params.memberRoleIds,
     peer: buildDiscordRoutePeer({
       isDirectMessage: params.isDirectMessage,
@@ -67,7 +82,9 @@ export function resolveDiscordBoundConversationRoute(params: {
       directUserId: params.directUserId,
       conversationId: params.conversationId,
     }),
-    parentConversationId: params.parentConversationId,
+    parentPeer: params.parentConversationId
+      ? { kind: "channel", id: params.parentConversationId }
+      : undefined,
   });
   return resolveDiscordEffectiveRoute({
     route,

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -24,6 +24,7 @@ export function createGatewayCloseHandler(params: {
   mediaCleanup: ReturnType<typeof setInterval> | null;
   agentUnsub: (() => void) | null;
   heartbeatUnsub: (() => void) | null;
+  routingDropUnsub: (() => void) | null;
   chatRunState: { clear: () => void };
   clients: Set<{ socket: { close: (code: number, reason: string) => void } }>;
   configReloader: { stop: () => Promise<void> };
@@ -101,6 +102,13 @@ export function createGatewayCloseHandler(params: {
     if (params.heartbeatUnsub) {
       try {
         params.heartbeatUnsub();
+      } catch {
+        /* ignore */
+      }
+    }
+    if (params.routingDropUnsub) {
+      try {
+        params.routingDropUnsub();
       } catch {
         /* ignore */
       }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -26,7 +26,7 @@ import {
   resolveControlUiRootOverrideSync,
   resolveControlUiRootSync,
 } from "../infra/control-ui-assets.js";
-import { isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
+import { isDiagnosticsEnabled, onDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { logAcceptedEnvOption } from "../infra/env.js";
 import { createExecApprovalForwarder } from "../infra/exec-approval-forwarder.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
@@ -47,6 +47,7 @@ import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
+import { installRoutingDropsAccumulator } from "../routing/routing-drops-accumulator.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { runOnboardingWizard } from "../wizard/onboarding.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
@@ -592,6 +593,51 @@ export async function startGatewayServer(
         broadcast("heartbeat", evt, { dropIfSlow: true });
       });
 
+  // Install the rolling routing-drop accumulator. This subscribes to the
+  // diagnostic event bus so `/remoteclaw status` can surface drop counts in
+  // its reply. Idempotent — subsequent calls are no-ops.
+  const routingDropAccumulatorUnsub = minimalTestGateway ? null : installRoutingDropsAccumulator();
+
+  // Forward routing-drop diagnostic events to the Control UI. The same drop
+  // event also increments the OTel counter (in diagnostics-otel) and the
+  // in-memory rolling accumulator consumed by /remoteclaw status.
+  const routingDropBroadcastUnsub = minimalTestGateway
+    ? null
+    : onDiagnosticEvent((evt) => {
+        if (evt.type !== "routing.drop") {
+          return;
+        }
+        broadcast(
+          "route.drop",
+          {
+            channel: evt.channel,
+            reason: evt.reason,
+            scope: evt.scope,
+            configuredAgents: evt.configuredAgents,
+            target: evt.target,
+            ts: evt.ts,
+            seq: evt.seq,
+          },
+          { dropIfSlow: true },
+        );
+      });
+
+  const routingDropUnsub =
+    routingDropAccumulatorUnsub || routingDropBroadcastUnsub
+      ? () => {
+          try {
+            routingDropAccumulatorUnsub?.();
+          } catch {
+            /* ignore */
+          }
+          try {
+            routingDropBroadcastUnsub?.();
+          } catch {
+            /* ignore */
+          }
+        }
+      : null;
+
   let heartbeatRunner: HeartbeatRunner = minimalTestGateway
     ? {
         stop: () => {},
@@ -837,6 +883,7 @@ export async function startGatewayServer(
     mediaCleanup,
     agentUnsub,
     heartbeatUnsub,
+    routingDropUnsub,
     chatRunState,
     clients,
     configReloader,

--- a/src/imessage/monitor/inbound-processing.test.ts
+++ b/src/imessage/monitor/inbound-processing.test.ts
@@ -6,7 +6,7 @@ import {
 } from "./inbound-processing.js";
 
 describe("resolveIMessageInboundDecision echo detection", () => {
-  const cfg = {} as RemoteClawConfig;
+  const cfg = { agents: { list: [{ id: "main" }] } } as RemoteClawConfig;
 
   it("drops inbound messages when outbound message id matches echo cache", () => {
     const echoHas = vi.fn((_scope: string, lookup: { text?: string; messageId?: string }) => {
@@ -60,7 +60,7 @@ describe("describeIMessageEchoDropLog", () => {
 });
 
 describe("resolveIMessageInboundDecision command auth", () => {
-  const cfg = {} as RemoteClawConfig;
+  const cfg = { agents: { list: [{ id: "main" }] } } as RemoteClawConfig;
   const resolveDmCommandDecision = (params: { messageId: number; storeAllowFrom: string[] }) =>
     resolveIMessageInboundDecision({
       cfg,

--- a/src/imessage/monitor/inbound-processing.ts
+++ b/src/imessage/monitor/inbound-processing.ts
@@ -19,7 +19,10 @@ import {
   resolveChannelGroupPolicy,
   resolveChannelGroupRequireMention,
 } from "../../config/group-policy.js";
-import { resolveAgentRoute } from "../../routing/resolve-route.js";
+import {
+  resolveAgentRouteWithPolicy,
+  type ResolvedAgentRoute,
+} from "../../routing/resolve-route.js";
 import {
   DM_GROUP_ACCESS_REASON,
   resolveDmGroupAccessWithLists,
@@ -70,7 +73,7 @@ export type IMessageInboundDispatchDecision = {
   historyKey?: string;
   sender: string;
   senderNormalized: string;
-  route: ReturnType<typeof resolveAgentRoute>;
+  route: ResolvedAgentRoute;
   bodyText: string;
   createdAt?: number;
   replyContext: IMessageReplyContext | null;
@@ -199,7 +202,7 @@ export function resolveIMessageInboundDecision(params: {
     return { kind: "drop", reason: "group id not in allowlist" };
   }
 
-  const route = resolveAgentRoute({
+  const route = resolveAgentRouteWithPolicy({
     cfg: params.cfg,
     channel: "imessage",
     accountId: params.accountId,
@@ -208,6 +211,11 @@ export function resolveIMessageInboundDecision(params: {
       id: isGroup ? String(chatId ?? "unknown") : senderNormalized,
     },
   });
+  if (!route) {
+    // Silent drop: routing.unmatched policy dropped the message. Telemetry
+    // already fired via handleUnmatched.
+    return { kind: "drop", reason: "unmatched-binding" };
+  }
   const mentionRegexes = buildMentionRegexes(params.cfg, route.agentId);
   const messageText = params.messageText.trim();
   const bodyText = params.bodyText.trim();

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -147,6 +147,23 @@ export type DiagnosticToolLoopEvent = DiagnosticBaseEvent & {
   pairedToolName?: string;
 };
 
+export type DiagnosticRoutingDropScope = {
+  channel: string;
+  accountId: string | null;
+  peer: { kind: string; id: string } | null;
+  guildId: string | null;
+  teamId: string | null;
+};
+
+export type DiagnosticRoutingDropEvent = DiagnosticBaseEvent & {
+  type: "routing.drop";
+  channel: string;
+  reason: "unmatched";
+  scope: DiagnosticRoutingDropScope;
+  configuredAgents: string[];
+  target?: string;
+};
+
 export type DiagnosticEventPayload =
   | DiagnosticUsageEvent
   | DiagnosticWebhookReceivedEvent
@@ -160,7 +177,8 @@ export type DiagnosticEventPayload =
   | DiagnosticLaneDequeueEvent
   | DiagnosticRunAttemptEvent
   | DiagnosticHeartbeatEvent
-  | DiagnosticToolLoopEvent;
+  | DiagnosticToolLoopEvent
+  | DiagnosticRoutingDropEvent;
 
 export type DiagnosticEventInput = DiagnosticEventPayload extends infer Event
   ? Event extends DiagnosticEventPayload

--- a/src/routing/bindings.ts
+++ b/src/routing/bindings.ts
@@ -1,4 +1,4 @@
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveSoleAgentId } from "../agents/agent-scope.js";
 import { normalizeChatChannelId } from "../channels/registry.js";
 import { listRouteBindings } from "../config/bindings.js";
 import type { RemoteClawConfig } from "../config/config.js";
@@ -61,7 +61,14 @@ export function listBoundAccountIds(cfg: RemoteClawConfig, channelId: string): s
   return Array.from(ids).toSorted((a, b) => a.localeCompare(b));
 }
 
-export function resolveDefaultAgentBoundAccountId(
+/**
+ * Find the first account bound to the sole configured agent on a given channel.
+ *
+ * Returns `null` when there is no sole agent (zero or multiple agents configured)
+ * or when no binding targets that agent on the requested channel. Multi-agent
+ * configs have no implicit "default" agent — callers must disambiguate explicitly.
+ */
+export function resolveSoleAgentBoundAccountId(
   cfg: RemoteClawConfig,
   channelId: string,
 ): string | null {
@@ -69,13 +76,17 @@ export function resolveDefaultAgentBoundAccountId(
   if (!normalizedChannel) {
     return null;
   }
-  const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(cfg));
+  const soleAgentId = resolveSoleAgentId(cfg);
+  if (!soleAgentId) {
+    return null;
+  }
+  const normalizedSoleAgentId = normalizeAgentId(soleAgentId);
   for (const binding of listBindings(cfg)) {
     const resolved = resolveNormalizedBindingMatch(binding);
     if (
       !resolved ||
       resolved.channelId !== normalizedChannel ||
-      resolved.agentId !== defaultAgentId
+      resolved.agentId !== normalizedSoleAgentId
     ) {
       continue;
     }

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -8,6 +8,14 @@ import {
   resolveInboundLastRouteSessionKey,
 } from "./resolve-route.js";
 
+// Minimal sole-agent fixture used by tests that exercise the fallback path.
+// Supplying exactly one agent triggers sole-agent promotion, preserving the
+// pre-refactor behavior where unmatched messages landed on a "main" route.
+const makeSoleMainAgent = (): NonNullable<RemoteClawConfig["agents"]> => ({
+  list: [{ id: "main" }],
+});
+const SOLE_MAIN_AGENT = makeSoleMainAgent();
+
 describe("resolveAgentRoute", () => {
   const resolveDiscordGuildRoute = (cfg: RemoteClawConfig) =>
     resolveAgentRoute({
@@ -18,8 +26,8 @@ describe("resolveAgentRoute", () => {
       guildId: "g1",
     });
 
-  test("defaults to main/default when no bindings exist", () => {
-    const cfg: RemoteClawConfig = {};
+  test("sole-agent promotion applies when no binding matches", () => {
+    const cfg: RemoteClawConfig = { agents: SOLE_MAIN_AGENT };
     const route = resolveAgentRoute({
       cfg,
       channel: "whatsapp",
@@ -30,7 +38,7 @@ describe("resolveAgentRoute", () => {
     expect(route.accountId).toBe("default");
     expect(route.sessionKey).toBe("agent:main:main");
     expect(route.lastRoutePolicy).toBe("main");
-    expect(route.matchedBy).toBe("default");
+    expect(route.matchedBy).toBe("fallback.soleAgent");
   });
 
   test("dmScope controls direct-message session key isolation", () => {
@@ -43,6 +51,7 @@ describe("resolveAgentRoute", () => {
     ];
     for (const testCase of cases) {
       const cfg: RemoteClawConfig = {
+        agents: SOLE_MAIN_AGENT,
         session: { dmScope: testCase.dmScope },
       };
       const route = resolveAgentRoute({
@@ -110,6 +119,7 @@ describe("resolveAgentRoute", () => {
     ];
     for (const testCase of cases) {
       const cfg: RemoteClawConfig = {
+        agents: SOLE_MAIN_AGENT,
         session: {
           dmScope: testCase.dmScope,
           identityLinks: {
@@ -183,7 +193,7 @@ describe("resolveAgentRoute", () => {
   });
 
   test("coerces numeric peer ids to stable session keys", () => {
-    const cfg: RemoteClawConfig = {};
+    const cfg: RemoteClawConfig = { agents: SOLE_MAIN_AGENT };
     const route = resolveAgentRoute({
       cfg,
       channel: "discord",
@@ -337,6 +347,7 @@ describe("resolveAgentRoute", () => {
 
   test("missing accountId in binding matches default account only", () => {
     const cfg: RemoteClawConfig = {
+      agents: SOLE_MAIN_AGENT,
       bindings: [{ agentId: "defaultAcct", match: { channel: "whatsapp" } }],
     };
 
@@ -411,6 +422,7 @@ describe("resolveAgentRoute", () => {
 
 test("dmScope=per-account-channel-peer isolates DM sessions per account, channel and sender", () => {
   const cfg: RemoteClawConfig = {
+    agents: SOLE_MAIN_AGENT,
     session: { dmScope: "per-account-channel-peer" },
   };
   const route = resolveAgentRoute({
@@ -424,6 +436,7 @@ test("dmScope=per-account-channel-peer isolates DM sessions per account, channel
 
 test("dmScope=per-account-channel-peer uses default accountId when not provided", () => {
   const cfg: RemoteClawConfig = {
+    agents: SOLE_MAIN_AGENT,
     session: { dmScope: "per-account-channel-peer" },
   };
   const route = resolveAgentRoute({
@@ -521,20 +534,22 @@ describe("parentPeer binding inheritance (thread support)", () => {
 
   test("parentPeer with empty id is ignored", () => {
     const cfg: RemoteClawConfig = {
+      agents: SOLE_MAIN_AGENT,
       bindings: [makeDiscordPeerBinding("parent-agent", defaultParentPeer.id)],
     };
     const route = resolveDiscordThreadRoute({ cfg, parentPeer: { kind: "channel", id: "" } });
     expect(route.agentId).toBe("main");
-    expect(route.matchedBy).toBe("default");
+    expect(route.matchedBy).toBe("fallback.soleAgent");
   });
 
   test("null parentPeer is handled gracefully", () => {
     const cfg: RemoteClawConfig = {
+      agents: SOLE_MAIN_AGENT,
       bindings: [makeDiscordPeerBinding("parent-agent", defaultParentPeer.id)],
     };
     const route = resolveDiscordThreadRoute({ cfg, parentPeer: null });
     expect(route.agentId).toBe("main");
-    expect(route.matchedBy).toBe("default");
+    expect(route.matchedBy).toBe("fallback.soleAgent");
   });
 });
 
@@ -635,6 +650,7 @@ describe("backward compatibility: peer.kind group ↔ channel", () => {
 
   test("group/channel compatibility does not match direct peer kind", () => {
     const cfg: RemoteClawConfig = {
+      agents: SOLE_MAIN_AGENT,
       bindings: [
         {
           agentId: "group-only-agent",
@@ -652,7 +668,7 @@ describe("backward compatibility: peer.kind group ↔ channel", () => {
       peer: { kind: "direct", id: "C123456" },
     });
     expect(route.agentId).toBe("main");
-    expect(route.matchedBy).toBe("default");
+    expect(route.matchedBy).toBe("fallback.soleAgent");
   });
 });
 
@@ -687,7 +703,7 @@ describe("role-based agent routing", () => {
     expectedMatchedBy: string;
   }) {
     const route = resolveAgentRoute({
-      cfg: { bindings: params.bindings },
+      cfg: { agents: SOLE_MAIN_AGENT, bindings: params.bindings },
       channel: "discord",
       guildId: "g1",
       ...(params.memberRoleIds ? { memberRoleIds: params.memberRoleIds } : {}),
@@ -716,7 +732,7 @@ describe("role-based agent routing", () => {
       bindings: [makeDiscordRoleBinding("opus", { roles: ["r1"] })],
       memberRoleIds: ["r2"],
       expectedAgentId: "main",
-      expectedMatchedBy: "default",
+      expectedMatchedBy: "fallback.soleAgent",
     });
   });
 
@@ -765,7 +781,7 @@ describe("role-based agent routing", () => {
     expectDiscordRoleRoute({
       bindings: [makeDiscordRoleBinding("opus", { roles: ["r1"] })],
       expectedAgentId: "main",
-      expectedMatchedBy: "default",
+      expectedMatchedBy: "fallback.soleAgent",
     });
   });
 
@@ -795,7 +811,7 @@ describe("role-based agent routing", () => {
       bindings: [makeDiscordRoleBinding("opus", { roles: ["admin"] })],
       memberRoleIds: ["regular"],
       expectedAgentId: "main",
-      expectedMatchedBy: "default",
+      expectedMatchedBy: "fallback.soleAgent",
     });
   });
 

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -1,9 +1,8 @@
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { ChatType } from "../channels/chat-type.js";
 import { normalizeChatType } from "../channels/chat-type.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { shouldLogVerbose } from "../globals.js";
-import { logDebug } from "../logger.js";
+import { logDebug, logWarn } from "../logger.js";
 import { listBindings } from "./bindings.js";
 import {
   buildAgentMainSessionKey,
@@ -14,6 +13,7 @@ import {
   normalizeAgentId,
   sanitizeAgentId,
 } from "./session-key.js";
+import { handleUnmatched } from "./unmatched.js";
 
 /** @deprecated Use ChatType from channels/chat-type.js */
 export type RoutePeerKind = ChatType;
@@ -36,6 +36,27 @@ export type ResolveAgentRouteInput = {
   memberRoleIds?: string[];
 };
 
+export type MatchedByTier =
+  | "binding.peer"
+  | "binding.peer.parent"
+  | "binding.guild+roles"
+  | "binding.guild"
+  | "binding.team"
+  | "binding.account"
+  | "binding.channel"
+  | "fallback.soleAgent"
+  | "fallback.legacyRoute"
+  | "unmatched.catchAll";
+
+/**
+ * Backward-compatible shape used by downstream consumers (channel adapters,
+ * session builders, tests) that hold a successfully resolved route. This is
+ * the shape emitted by {@link resolveAgentRoute} on the `matched: true` branch
+ * and by {@link buildMatchedRoute}. Consumers that only read the route fields
+ * (`agentId`, `sessionKey`, ...) should type their variables as
+ * `ResolvedAgentRoute`. Code that invokes {@link resolveAgentRoute} directly
+ * and must handle unmatched results should use {@link AgentRouteOutcome}.
+ */
 export type ResolvedAgentRoute = {
   agentId: string;
   channel: string;
@@ -47,28 +68,43 @@ export type ResolvedAgentRoute = {
   /** Which session should receive inbound last-route updates. */
   lastRoutePolicy: "main" | "session";
   /** Match description for debugging/logging. */
-  matchedBy:
-    | "binding.peer"
-    | "binding.peer.parent"
-    | "binding.guild+roles"
-    | "binding.guild"
-    | "binding.team"
-    | "binding.account"
-    | "binding.channel"
-    | "default";
+  matchedBy: MatchedByTier;
 };
 
-export { DEFAULT_ACCOUNT_ID, DEFAULT_AGENT_ID } from "./session-key.js";
+export type MatchedAgentRoute = ResolvedAgentRoute & { matched: true };
+
+/**
+ * Normalized routing scope passed to unmatched handler / telemetry.
+ * Strings are post-normalization forms emitted by {@link resolveAgentRoute}.
+ */
+export type RouteScope = {
+  channel: string;
+  accountId: string;
+  peer: RoutePeer | null;
+  guildId: string | null;
+  teamId: string | null;
+};
+
+export type UnmatchedAgentRoute = {
+  matched: false;
+  reason: "unmatched";
+  scope: RouteScope;
+};
+
+/** Full discriminated return type of {@link resolveAgentRoute}. */
+export type AgentRouteOutcome = MatchedAgentRoute | UnmatchedAgentRoute;
+
+export { DEFAULT_ACCOUNT_ID } from "./session-key.js";
 
 export function deriveLastRoutePolicy(params: {
   sessionKey: string;
   mainSessionKey: string;
-}): ResolvedAgentRoute["lastRoutePolicy"] {
+}): MatchedAgentRoute["lastRoutePolicy"] {
   return params.sessionKey === params.mainSessionKey ? "main" : "session";
 }
 
 export function resolveInboundLastRouteSessionKey(params: {
-  route: Pick<ResolvedAgentRoute, "lastRoutePolicy" | "mainSessionKey">;
+  route: Pick<MatchedAgentRoute, "lastRoutePolicy" | "mainSessionKey">;
   sessionKey: string;
 }): string {
   return params.route.lastRoutePolicy === "main" ? params.route.mainSessionKey : params.sessionKey;
@@ -119,7 +155,6 @@ function listAgents(cfg: RemoteClawConfig) {
 type AgentLookupCache = {
   agentsRef: RemoteClawConfig["agents"] | undefined;
   byNormalizedId: Map<string, string>;
-  fallbackDefaultAgentId: string;
 };
 
 const agentLookupCacheByCfg = new WeakMap<RemoteClawConfig, AgentLookupCache>();
@@ -142,27 +177,30 @@ function resolveAgentLookupCache(cfg: RemoteClawConfig): AgentLookupCache {
   const next: AgentLookupCache = {
     agentsRef,
     byNormalizedId,
-    fallbackDefaultAgentId: sanitizeAgentId(resolveDefaultAgentId(cfg)),
   };
   agentLookupCacheByCfg.set(cfg, next);
   return next;
 }
 
+/**
+ * Resolve an agent id against `cfg.agents.list`, returning the sanitized canonical
+ * form when the id exists, or a sanitized passthrough when the list is empty or the
+ * id is not configured. Schema-level validation in `zod-schema.ts` ensures binding
+ * agent ids must exist in `agents.list`; this function is a runtime safety net for
+ * topic overrides and other operator-supplied ids that bypass the binding path.
+ */
 export function pickFirstExistingAgentId(cfg: RemoteClawConfig, agentId: string): string {
   const lookup = resolveAgentLookupCache(cfg);
   const trimmed = (agentId ?? "").trim();
   if (!trimmed) {
-    return lookup.fallbackDefaultAgentId;
+    return "";
   }
   const normalized = normalizeAgentId(trimmed);
-  if (lookup.byNormalizedId.size === 0) {
-    return sanitizeAgentId(trimmed);
-  }
   const resolved = lookup.byNormalizedId.get(normalized);
   if (resolved) {
     return resolved;
   }
-  return lookup.fallbackDefaultAgentId;
+  return sanitizeAgentId(trimmed);
 }
 
 type NormalizedPeerConstraint =
@@ -206,7 +244,7 @@ const resolvedRouteCacheByCfg = new WeakMap<
     bindingsRef: RemoteClawConfig["bindings"];
     agentsRef: RemoteClawConfig["agents"];
     sessionRef: RemoteClawConfig["session"];
-    byKey: Map<string, ResolvedAgentRoute>;
+    byKey: Map<string, MatchedAgentRoute>;
   }
 >();
 const MAX_RESOLVED_ROUTE_CACHE_KEYS = 4000;
@@ -505,7 +543,7 @@ function normalizeBindingMatch(
   };
 }
 
-function resolveRouteCacheForConfig(cfg: RemoteClawConfig): Map<string, ResolvedAgentRoute> {
+function resolveRouteCacheForConfig(cfg: RemoteClawConfig): Map<string, MatchedAgentRoute> {
   const existing = resolvedRouteCacheByCfg.get(cfg);
   if (
     existing &&
@@ -515,7 +553,7 @@ function resolveRouteCacheForConfig(cfg: RemoteClawConfig): Map<string, Resolved
   ) {
     return existing.byKey;
   }
-  const byKey = new Map<string, ResolvedAgentRoute>();
+  const byKey = new Map<string, MatchedAgentRoute>();
   resolvedRouteCacheByCfg.set(cfg, {
     bindingsRef: cfg.bindings,
     agentsRef: cfg.agents,
@@ -523,6 +561,45 @@ function resolveRouteCacheForConfig(cfg: RemoteClawConfig): Map<string, Resolved
     byKey,
   });
   return byKey;
+}
+
+/**
+ * Build a {@link MatchedAgentRoute} for a given agent/scope without going through
+ * binding resolution. Used by the catch-all unmatched path to produce a route for
+ * the operator-designated fallback agent.
+ */
+export function buildMatchedRoute(params: {
+  cfg: RemoteClawConfig;
+  agentId: string;
+  scope: RouteScope;
+  matchedBy: MatchedByTier;
+}): MatchedAgentRoute {
+  const { cfg, scope, matchedBy } = params;
+  const resolvedAgentId = pickFirstExistingAgentId(cfg, params.agentId);
+  const dmScope = cfg.session?.dmScope ?? "main";
+  const identityLinks = cfg.session?.identityLinks;
+  const sessionKey = buildAgentSessionKey({
+    agentId: resolvedAgentId,
+    channel: scope.channel,
+    accountId: scope.accountId,
+    peer: scope.peer,
+    dmScope,
+    identityLinks,
+  }).toLowerCase();
+  const mainSessionKey = buildAgentMainSessionKey({
+    agentId: resolvedAgentId,
+    mainKey: DEFAULT_MAIN_KEY,
+  }).toLowerCase();
+  return {
+    matched: true as const,
+    agentId: resolvedAgentId,
+    channel: scope.channel,
+    accountId: scope.accountId,
+    sessionKey,
+    mainSessionKey,
+    lastRoutePolicy: deriveLastRoutePolicy({ sessionKey, mainSessionKey }),
+    matchedBy,
+  };
 }
 
 function formatRouteCachePeer(peer: RoutePeer | null): string {
@@ -611,7 +688,13 @@ function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope)
   return true;
 }
 
-export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentRoute {
+/**
+ * Low-level route resolution returning the full discriminated outcome. Callers
+ * that want explicit control over unmatched handling (e.g. tests, the policy
+ * wrapper, telemetry) use this form. For the backward-compatible, always-matched
+ * variant, use {@link resolveAgentRoute}.
+ */
+export function resolveAgentRouteExplicit(input: ResolveAgentRouteInput): AgentRouteOutcome {
   const channel = normalizeToken(input.channel);
   const accountId = normalizeAccountId(input.accountId);
   const peer = input.peer
@@ -633,6 +716,14 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
         id: normalizeId(input.parentPeer.id),
       }
     : null;
+
+  const scope: RouteScope = {
+    channel,
+    accountId,
+    peer,
+    guildId: guildId || null,
+    teamId: teamId || null,
+  };
 
   const routeCache =
     !shouldLogDebug && !identityLinks ? resolveRouteCacheForConfig(input.cfg) : null;
@@ -658,29 +749,13 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const bindings = getEvaluatedBindingsForChannelAccount(input.cfg, channel, accountId);
   const bindingsIndex = getEvaluatedBindingIndexForChannelAccount(input.cfg, channel, accountId);
 
-  const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {
-    const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
-    const sessionKey = buildAgentSessionKey({
-      agentId: resolvedAgentId,
-      channel,
-      accountId,
-      peer,
-      dmScope,
-      identityLinks,
-    }).toLowerCase();
-    const mainSessionKey = buildAgentMainSessionKey({
-      agentId: resolvedAgentId,
-      mainKey: DEFAULT_MAIN_KEY,
-    }).toLowerCase();
-    const route = {
-      agentId: resolvedAgentId,
-      channel,
-      accountId,
-      sessionKey,
-      mainSessionKey,
-      lastRoutePolicy: deriveLastRoutePolicy({ sessionKey, mainSessionKey }),
+  const matchAndCache = (agentId: string, matchedBy: MatchedByTier): MatchedAgentRoute => {
+    const route = buildMatchedRoute({
+      cfg: input.cfg,
+      agentId,
+      scope,
       matchedBy,
-    };
+    });
     if (routeCache && routeCacheKey) {
       routeCache.set(routeCacheKey, route);
       if (routeCache.size > MAX_RESOLVED_ROUTE_CACHE_KEYS) {
@@ -721,7 +796,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   };
 
   const tiers: Array<{
-    matchedBy: Exclude<ResolvedAgentRoute["matchedBy"], "default">;
+    matchedBy: Exclude<MatchedByTier, "unmatched.catchAll">;
     enabled: boolean;
     scopePeer: RoutePeer | null;
     candidates: EvaluatedBinding[];
@@ -796,9 +871,122 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       if (shouldLogDebug) {
         logDebug(`[routing] match: matchedBy=${tier.matchedBy} agentId=${matched.binding.agentId}`);
       }
-      return choose(matched.binding.agentId, tier.matchedBy);
+      return matchAndCache(matched.binding.agentId, tier.matchedBy);
     }
   }
 
-  return choose(resolveDefaultAgentId(input.cfg), "default");
+  // Sole-agent promotion: when exactly one agent is configured, route to it
+  // regardless of bindings. This preserves single-agent behavior without
+  // reintroducing the phantom "default" agent fallback. Downstream consumers
+  // that need to distinguish "this landed on the only agent" from "this matched
+  // an explicit binding" check `matchedBy === "fallback.soleAgent"`.
+  const agents = listAgents(input.cfg);
+  if (agents.length === 1) {
+    const soleAgentId = agents[0]?.id?.trim();
+    if (soleAgentId) {
+      if (shouldLogDebug) {
+        logDebug(`[routing] match: matchedBy=fallback.soleAgent agentId=${soleAgentId}`);
+      }
+      return matchAndCache(soleAgentId, "fallback.soleAgent");
+    }
+  }
+
+  return {
+    matched: false,
+    reason: "unmatched",
+    scope,
+  };
+}
+
+/**
+ * Resolve an agent route, applying the operator `routing.unmatched` policy when
+ * no binding matches and no sole agent is configured. Returns `null` when the
+ * policy drops the message (silent drop + telemetry). Otherwise returns a
+ * {@link ResolvedAgentRoute}.
+ *
+ * This is the preferred entry point for channel adapters. Adapters migrate from
+ * `resolveAgentRoute` to this wrapper with a one-line change: add
+ * `if (!route) return;` after the call.
+ */
+export function resolveAgentRouteWithPolicy(
+  input: ResolveAgentRouteInput,
+): MatchedAgentRoute | null {
+  const outcome = resolveAgentRouteExplicit(input);
+  if (outcome.matched) {
+    return outcome;
+  }
+  const action = handleUnmatched(outcome.scope, input.cfg);
+  if (action.action === "drop") {
+    return null;
+  }
+  return buildMatchedRoute({
+    cfg: input.cfg,
+    agentId: action.agentId,
+    scope: outcome.scope,
+    matchedBy: "unmatched.catchAll",
+  });
+}
+
+/**
+ * Backward-compatible entry point for code paths that type their variable as
+ * {@link ResolvedAgentRoute} and can not tolerate a `null` return. Applies the
+ * operator `routing.unmatched` policy through {@link resolveAgentRouteWithPolicy}
+ * first — this fires the full operator telemetry stack (structured log, OTel
+ * counter, Control UI event, `/remoteclaw status` accrual) when the policy
+ * says drop.
+ *
+ * When the policy says "drop" and the caller is on the legacy path, there is
+ * no safe way to halt processing from inside this function. The wrapper falls
+ * back to the first configured agent and tags the route with
+ * `matchedBy = "fallback.legacyRoute"` so downstream consumers, operators, and
+ * telemetry can distinguish it from sole-agent promotion (a legitimate single-
+ * agent config) or catch-all routing (an explicit operator choice). A
+ * structured warn log fires on every fallback occurrence so the migration
+ * gap is visible in production.
+ *
+ * New adapters SHOULD prefer {@link resolveAgentRouteWithPolicy} for explicit
+ * silent-drop semantics — that form returns `null` instead of a fallback route,
+ * allowing adapters to halt message processing cleanly and honoring the drop
+ * telemetry as the sole outcome.
+ */
+export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentRoute {
+  const resolved = resolveAgentRouteWithPolicy(input);
+  if (resolved) {
+    return resolved;
+  }
+  // Silent-drop telemetry has already fired via handleUnmatched. The legacy
+  // caller path expects a usable route object — fall back to the first
+  // configured agent so message processing continues. Adapters that want to
+  // actually drop the message should migrate to resolveAgentRouteWithPolicy.
+  //
+  // When no agents are configured (unreachable in production because
+  // #2308/schema requires agents.list to be non-empty, but possible in test
+  // fixtures that predate the refactor), fall back to the legacy "main"
+  // sentinel so the function remains total. This preserves test-fixture
+  // semantics without reintroducing the phantom-default behavior in any
+  // production code path.
+  const agents = listAgents(input.cfg);
+  const fallbackAgentId = agents[0]?.id?.trim() || "main";
+  const routingChannel = normalizeToken(input.channel);
+  logWarn(
+    `[routing] legacy fallback: channel=${routingChannel} dropped by routing.unmatched policy but caller used resolveAgentRoute() — routing to "${fallbackAgentId}". Migrate to resolveAgentRouteWithPolicy() for clean drop handling.`,
+  );
+  const scope: RouteScope = {
+    channel: routingChannel,
+    accountId: normalizeAccountId(input.accountId),
+    peer: input.peer
+      ? {
+          kind: normalizeChatType(input.peer.kind) ?? input.peer.kind,
+          id: normalizeId(input.peer.id),
+        }
+      : null,
+    guildId: normalizeId(input.guildId) || null,
+    teamId: normalizeId(input.teamId) || null,
+  };
+  return buildMatchedRoute({
+    cfg: input.cfg,
+    agentId: fallbackAgentId,
+    scope,
+    matchedBy: "fallback.legacyRoute",
+  });
 }

--- a/src/routing/routing-drops-accumulator.test.ts
+++ b/src/routing/routing-drops-accumulator.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { emitDiagnosticEvent, resetDiagnosticEventsForTest } from "../infra/diagnostic-events.js";
+import {
+  getRoutingDropCounts,
+  installRoutingDropsAccumulator,
+  resetRoutingDropsAccumulatorForTest,
+} from "./routing-drops-accumulator.js";
+
+describe("routing-drops-accumulator", () => {
+  beforeEach(() => {
+    resetDiagnosticEventsForTest();
+    resetRoutingDropsAccumulatorForTest();
+  });
+
+  afterEach(() => {
+    resetRoutingDropsAccumulatorForTest();
+    resetDiagnosticEventsForTest();
+  });
+
+  test("starts with zero counts", () => {
+    installRoutingDropsAccumulator();
+    const counts = getRoutingDropCounts();
+    expect(counts.total).toBe(0);
+    expect(counts.byChannel).toEqual({});
+    expect(counts.byReason).toEqual({});
+  });
+
+  test("increments total on routing.drop diagnostic event", () => {
+    installRoutingDropsAccumulator();
+    emitDiagnosticEvent({
+      type: "routing.drop",
+      channel: "telegram",
+      reason: "unmatched",
+      scope: {
+        channel: "telegram",
+        accountId: "default",
+        peer: { kind: "direct", id: "+1555" },
+        guildId: null,
+        teamId: null,
+      },
+      configuredAgents: ["ops", "dev"],
+    });
+    const counts = getRoutingDropCounts();
+    expect(counts.total).toBe(1);
+    expect(counts.byChannel).toEqual({ telegram: 1 });
+    expect(counts.byReason).toEqual({ unmatched: 1 });
+  });
+
+  test("aggregates counts across channels and reasons", () => {
+    installRoutingDropsAccumulator();
+    const baseScope = {
+      accountId: "default",
+      peer: null,
+      guildId: null,
+      teamId: null,
+    };
+    emitDiagnosticEvent({
+      type: "routing.drop",
+      channel: "telegram",
+      reason: "unmatched",
+      scope: { channel: "telegram", ...baseScope },
+      configuredAgents: [],
+    });
+    emitDiagnosticEvent({
+      type: "routing.drop",
+      channel: "telegram",
+      reason: "unmatched",
+      scope: { channel: "telegram", ...baseScope },
+      configuredAgents: [],
+    });
+    emitDiagnosticEvent({
+      type: "routing.drop",
+      channel: "slack",
+      reason: "unmatched",
+      scope: { channel: "slack", ...baseScope },
+      configuredAgents: [],
+    });
+    const counts = getRoutingDropCounts();
+    expect(counts.total).toBe(3);
+    expect(counts.byChannel).toEqual({ telegram: 2, slack: 1 });
+    expect(counts.byReason).toEqual({ unmatched: 3 });
+  });
+
+  test("ignores unrelated diagnostic events", () => {
+    installRoutingDropsAccumulator();
+    emitDiagnosticEvent({
+      type: "webhook.received",
+      channel: "telegram",
+      updateType: "message",
+    });
+    const counts = getRoutingDropCounts();
+    expect(counts.total).toBe(0);
+  });
+
+  test("install is idempotent — multiple calls do not duplicate counting", () => {
+    installRoutingDropsAccumulator();
+    installRoutingDropsAccumulator();
+    installRoutingDropsAccumulator();
+    emitDiagnosticEvent({
+      type: "routing.drop",
+      channel: "discord",
+      reason: "unmatched",
+      scope: {
+        channel: "discord",
+        accountId: "default",
+        peer: null,
+        guildId: "g1",
+        teamId: null,
+      },
+      configuredAgents: [],
+    });
+    const counts = getRoutingDropCounts();
+    expect(counts.total).toBe(1);
+  });
+});

--- a/src/routing/routing-drops-accumulator.ts
+++ b/src/routing/routing-drops-accumulator.ts
@@ -1,0 +1,83 @@
+import { onDiagnosticEvent } from "../infra/diagnostic-events.js";
+
+export type RoutingDropCounts = {
+  total: number;
+  byChannel: Record<string, number>;
+  byReason: Record<string, number>;
+};
+
+type AccumulatorState = {
+  total: number;
+  byChannel: Map<string, number>;
+  byReason: Map<string, number>;
+  unsubscribe: (() => void) | null;
+};
+
+function getAccumulatorState(): AccumulatorState {
+  const globalStore = globalThis as typeof globalThis & {
+    __remoteclawRoutingDropsState?: AccumulatorState;
+  };
+  if (!globalStore.__remoteclawRoutingDropsState) {
+    globalStore.__remoteclawRoutingDropsState = {
+      total: 0,
+      byChannel: new Map<string, number>(),
+      byReason: new Map<string, number>(),
+      unsubscribe: null,
+    };
+  }
+  return globalStore.__remoteclawRoutingDropsState;
+}
+
+function incrementMap(map: Map<string, number>, key: string): void {
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+/**
+ * Subscribe the accumulator to the diagnostic event bus. Called once at
+ * application startup. Subsequent calls are no-ops (idempotent).
+ */
+export function installRoutingDropsAccumulator(): () => void {
+  const state = getAccumulatorState();
+  if (state.unsubscribe) {
+    return state.unsubscribe;
+  }
+  const unsubscribe = onDiagnosticEvent((evt) => {
+    if (evt.type !== "routing.drop") {
+      return;
+    }
+    state.total += 1;
+    incrementMap(state.byChannel, evt.channel || "unknown");
+    incrementMap(state.byReason, evt.reason || "unknown");
+  });
+  state.unsubscribe = () => {
+    unsubscribe();
+    state.unsubscribe = null;
+  };
+  return state.unsubscribe;
+}
+
+/**
+ * Snapshot of rolling routing-drop counts since process start (or last reset).
+ * Consumed by the `/remoteclaw status` command to surface operator-visible
+ * drop totals.
+ */
+export function getRoutingDropCounts(): RoutingDropCounts {
+  const state = getAccumulatorState();
+  return {
+    total: state.total,
+    byChannel: Object.fromEntries(state.byChannel),
+    byReason: Object.fromEntries(state.byReason),
+  };
+}
+
+/** @internal Reset accumulator for tests. */
+export function resetRoutingDropsAccumulatorForTest(): void {
+  const state = getAccumulatorState();
+  if (state.unsubscribe) {
+    state.unsubscribe();
+  }
+  state.total = 0;
+  state.byChannel.clear();
+  state.byReason.clear();
+  state.unsubscribe = null;
+}

--- a/src/routing/unmatched.test.ts
+++ b/src/routing/unmatched.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { RemoteClawConfig } from "../config/config.js";
+import * as diagnosticEvents from "../infra/diagnostic-events.js";
+import { resolveAgentRouteExplicit, resolveAgentRouteWithPolicy } from "./resolve-route.js";
+import { handleUnmatched } from "./unmatched.js";
+
+const SCOPE_MULTI = {
+  channel: "telegram",
+  accountId: "default",
+  peer: { kind: "direct" as const, id: "+1555" },
+  guildId: null,
+  teamId: null,
+};
+
+describe("handleUnmatched", () => {
+  let emitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    diagnosticEvents.resetDiagnosticEventsForTest();
+    emitSpy = vi.spyOn(diagnosticEvents, "emitDiagnosticEvent");
+  });
+
+  afterEach(() => {
+    emitSpy.mockRestore();
+    diagnosticEvents.resetDiagnosticEventsForTest();
+  });
+
+  test("drops when routing.unmatched is omitted", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "ops" }, { id: "dev" }] },
+    };
+    const result = handleUnmatched(SCOPE_MULTI, cfg);
+    expect(result).toEqual({ action: "drop" });
+  });
+
+  test("drops when routing.unmatched is literal 'reject'", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "ops" }, { id: "dev" }] },
+      routing: { unmatched: "reject" },
+    };
+    const result = handleUnmatched(SCOPE_MULTI, cfg);
+    expect(result).toEqual({ action: "drop" });
+  });
+
+  test("routes to catch-all agent when routing.unmatched.agent is set", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "ops" }, { id: "dev" }, { id: "triage" }] },
+      routing: { unmatched: { agent: "triage" } },
+    };
+    const result = handleUnmatched(SCOPE_MULTI, cfg);
+    expect(result).toEqual({ action: "route", agentId: "triage" });
+  });
+
+  test("emits routing.drop diagnostic event on silent drop", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "ops" }, { id: "dev" }] },
+    };
+    handleUnmatched(SCOPE_MULTI, cfg);
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    const payload = emitSpy.mock.calls[0]?.[0] as {
+      type: string;
+      channel: string;
+      reason: string;
+      configuredAgents: string[];
+      target?: string;
+    };
+    expect(payload.type).toBe("routing.drop");
+    expect(payload.channel).toBe("telegram");
+    expect(payload.reason).toBe("unmatched");
+    expect(payload.configuredAgents).toEqual(["ops", "dev"]);
+    expect(payload.target).toBe("direct:+1555");
+  });
+
+  test("does NOT emit diagnostic event on catch-all route", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "ops" }, { id: "triage" }] },
+      routing: { unmatched: { agent: "triage" } },
+    };
+    handleUnmatched(SCOPE_MULTI, cfg);
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
+  test("resolves target from accountId when peer is absent", () => {
+    const scope = {
+      channel: "discord",
+      accountId: "account-xyz",
+      peer: null,
+      guildId: null,
+      teamId: null,
+    };
+    const cfg: RemoteClawConfig = { agents: { list: [{ id: "ops" }, { id: "dev" }] } };
+    handleUnmatched(scope, cfg);
+    const payload = emitSpy.mock.calls[0]?.[0] as { target?: string };
+    expect(payload.target).toBe("account-xyz");
+  });
+});
+
+describe("resolveAgentRouteWithPolicy", () => {
+  beforeEach(() => {
+    diagnosticEvents.resetDiagnosticEventsForTest();
+  });
+
+  test("returns matched route when binding matches", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "ops" }, { id: "dev" }] },
+      bindings: [
+        {
+          agentId: "ops",
+          match: { channel: "telegram", peer: { kind: "direct", id: "+1555" } },
+        },
+      ],
+    };
+    const route = resolveAgentRouteWithPolicy({
+      cfg,
+      channel: "telegram",
+      accountId: null,
+      peer: { kind: "direct", id: "+1555" },
+    });
+    expect(route).not.toBeNull();
+    expect(route?.agentId).toBe("ops");
+    expect(route?.matchedBy).toBe("binding.peer");
+  });
+
+  test("returns null when no binding matches and routing.unmatched is omitted", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "ops" }, { id: "dev" }] },
+    };
+    const route = resolveAgentRouteWithPolicy({
+      cfg,
+      channel: "telegram",
+      accountId: null,
+      peer: { kind: "direct", id: "+1555" },
+    });
+    expect(route).toBeNull();
+  });
+
+  test("returns null when routing.unmatched is 'reject'", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "ops" }, { id: "dev" }] },
+      routing: { unmatched: "reject" },
+    };
+    const route = resolveAgentRouteWithPolicy({
+      cfg,
+      channel: "telegram",
+      accountId: null,
+      peer: { kind: "direct", id: "+1555" },
+    });
+    expect(route).toBeNull();
+  });
+
+  test("routes to catch-all agent when routing.unmatched.agent is set", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "ops" }, { id: "dev" }, { id: "triage" }] },
+      routing: { unmatched: { agent: "triage" } },
+    };
+    const route = resolveAgentRouteWithPolicy({
+      cfg,
+      channel: "telegram",
+      accountId: null,
+      peer: { kind: "direct", id: "+1555" },
+    });
+    expect(route).not.toBeNull();
+    expect(route?.agentId).toBe("triage");
+    expect(route?.matchedBy).toBe("unmatched.catchAll");
+  });
+
+  test("sole-agent promotion bypasses routing.unmatched entirely", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "only" }] },
+      routing: { unmatched: "reject" },
+    };
+    const route = resolveAgentRouteWithPolicy({
+      cfg,
+      channel: "telegram",
+      accountId: null,
+      peer: { kind: "direct", id: "+1555" },
+    });
+    expect(route).not.toBeNull();
+    expect(route?.agentId).toBe("only");
+    expect(route?.matchedBy).toBe("fallback.soleAgent");
+  });
+});
+
+describe("resolveAgentRouteExplicit", () => {
+  test("returns matched: true variant when binding matches", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "ops" }] },
+      bindings: [
+        {
+          agentId: "ops",
+          match: { channel: "telegram", peer: { kind: "direct", id: "+1555" } },
+        },
+      ],
+    };
+    const outcome = resolveAgentRouteExplicit({
+      cfg,
+      channel: "telegram",
+      accountId: null,
+      peer: { kind: "direct", id: "+1555" },
+    });
+    expect(outcome.matched).toBe(true);
+    if (outcome.matched) {
+      expect(outcome.agentId).toBe("ops");
+    }
+  });
+
+  test("returns matched: false variant when no binding matches in multi-agent config", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "ops" }, { id: "dev" }] },
+    };
+    const outcome = resolveAgentRouteExplicit({
+      cfg,
+      channel: "telegram",
+      accountId: null,
+      peer: { kind: "direct", id: "+1555" },
+    });
+    expect(outcome.matched).toBe(false);
+    if (!outcome.matched) {
+      expect(outcome.reason).toBe("unmatched");
+      expect(outcome.scope.channel).toBe("telegram");
+      expect(outcome.scope.peer).toEqual({ kind: "direct", id: "+1555" });
+    }
+  });
+});

--- a/src/routing/unmatched.ts
+++ b/src/routing/unmatched.ts
@@ -1,0 +1,92 @@
+import { logInboundDrop } from "../channels/logging.js";
+import type { RemoteClawConfig } from "../config/config.js";
+import { logVerbose } from "../globals.js";
+import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
+import type { RouteScope } from "./resolve-route.js";
+import { normalizeAgentId } from "./session-key.js";
+
+function listConfiguredAgentIds(cfg: RemoteClawConfig): string[] {
+  const agents = cfg.agents?.list;
+  if (!Array.isArray(agents)) {
+    return [];
+  }
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of agents) {
+    const id = typeof entry?.id === "string" ? entry.id.trim() : "";
+    if (!id) {
+      continue;
+    }
+    const normalized = normalizeAgentId(id);
+    if (seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    ids.push(normalized);
+  }
+  return ids;
+}
+
+export type UnmatchedAction = { action: "drop" } | { action: "route"; agentId: string };
+
+function normalizeConfiguredUnmatchedAgent(cfg: RemoteClawConfig): string | null {
+  const unmatched = cfg.routing?.unmatched;
+  if (unmatched && typeof unmatched === "object" && "agent" in unmatched) {
+    const trimmed = typeof unmatched.agent === "string" ? unmatched.agent.trim() : "";
+    return trimmed ? trimmed : null;
+  }
+  return null;
+}
+
+function resolveDropTarget(scope: RouteScope): string | undefined {
+  if (scope.peer?.id) {
+    return `${scope.peer.kind}:${scope.peer.id}`;
+  }
+  if (scope.accountId) {
+    return scope.accountId;
+  }
+  return undefined;
+}
+
+/**
+ * Centralized policy handler invoked when {@link resolveAgentRoute} returns an
+ * unmatched result. Decides whether to silently drop the message (default) or
+ * route it to an operator-configured catch-all agent (`routing.unmatched.agent`).
+ *
+ * For the drop path, fires operator-visible telemetry through the diagnostic
+ * event bus and the structured-log helper. Downstream listeners (OTel counter,
+ * Control UI broadcast, `/remoteclaw status` accumulator) react to the same
+ * diagnostic event — a single emission point keeps semantics aligned across
+ * every surface.
+ */
+export function handleUnmatched(scope: RouteScope, cfg: RemoteClawConfig): UnmatchedAction {
+  const catchAllAgent = normalizeConfiguredUnmatchedAgent(cfg);
+  if (catchAllAgent) {
+    return { action: "route", agentId: catchAllAgent };
+  }
+
+  const target = resolveDropTarget(scope);
+  logInboundDrop({
+    log: logVerbose,
+    channel: scope.channel,
+    reason: "unmatched-binding",
+    target,
+  });
+
+  emitDiagnosticEvent({
+    type: "routing.drop",
+    channel: scope.channel,
+    reason: "unmatched",
+    scope: {
+      channel: scope.channel,
+      accountId: scope.accountId || null,
+      peer: scope.peer ? { kind: scope.peer.kind, id: scope.peer.id } : null,
+      guildId: scope.guildId,
+      teamId: scope.teamId,
+    },
+    configuredAgents: listConfiguredAgentIds(cfg),
+    target,
+  });
+
+  return { action: "drop" };
+}

--- a/src/signal/monitor/event-handler.inbound-contract.test.ts
+++ b/src/signal/monitor/event-handler.inbound-contract.test.ts
@@ -60,8 +60,11 @@ describe("signal createSignalEventHandler inbound contract", () => {
   it("passes a finalized MsgContext to dispatchInboundMessage", async () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({
-        // oxlint-disable-next-line typescript/no-explicit-any
-        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        cfg: {
+          agents: { list: [{ id: "main" }] },
+          messages: { inbound: { debounceMs: 0 } },
+          // oxlint-disable-next-line typescript/no-explicit-any
+        } as any,
         historyLimit: 0,
       }),
     );
@@ -88,8 +91,11 @@ describe("signal createSignalEventHandler inbound contract", () => {
   it("normalizes direct chat To/OriginatingTo targets to canonical Signal ids", async () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({
-        // oxlint-disable-next-line typescript/no-explicit-any
-        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        cfg: {
+          agents: { list: [{ id: "main" }] },
+          messages: { inbound: { debounceMs: 0 } },
+          // oxlint-disable-next-line typescript/no-explicit-any
+        } as any,
         historyLimit: 0,
       }),
     );
@@ -117,6 +123,7 @@ describe("signal createSignalEventHandler inbound contract", () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({
         cfg: {
+          agents: { list: [{ id: "main" }] },
           messages: { inbound: { debounceMs: 0 } },
           channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
         },
@@ -148,6 +155,7 @@ describe("signal createSignalEventHandler inbound contract", () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({
         cfg: {
+          agents: { list: [{ id: "main" }] },
           messages: { inbound: { debounceMs: 0 } },
           channels: { signal: { dmPolicy: "open", allowFrom: [] } },
         },
@@ -177,6 +185,7 @@ describe("signal createSignalEventHandler inbound contract", () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({
         cfg: {
+          agents: { list: [{ id: "main" }] },
           messages: { inbound: { debounceMs: 0 } },
           channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
         },
@@ -211,6 +220,7 @@ describe("signal createSignalEventHandler inbound contract", () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({
         cfg: {
+          agents: { list: [{ id: "main" }] },
           messages: { inbound: { debounceMs: 0 } },
           channels: { signal: { dmPolicy: "open", allowFrom: ["*"], accountUuid: ownUuid } },
         },
@@ -239,6 +249,7 @@ describe("signal createSignalEventHandler inbound contract", () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({
         cfg: {
+          agents: { list: [{ id: "main" }] },
           messages: { inbound: { debounceMs: 0 } },
           channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
         },

--- a/src/signal/monitor/event-handler.mention-gating.test.ts
+++ b/src/signal/monitor/event-handler.mention-gating.test.ts
@@ -78,6 +78,7 @@ function createMentionGatedHistoryHandler() {
 
 function createSignalConfig(params: { requireMention: boolean; mentionPattern?: string }) {
   return {
+    agents: { list: [{ id: "main" }] },
     messages: {
       inbound: { debounceMs: 0 },
       groupChat: { mentionPatterns: [params.mentionPattern ?? "@bot"] },

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -30,7 +30,7 @@ import { readSessionUpdatedAt, resolveStorePath } from "../../config/sessions.js
 import { danger, logVerbose, shouldLogVerbose } from "../../globals.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { kindFromMime } from "../../media/mime.js";
-import { resolveAgentRoute } from "../../routing/resolve-route.js";
+import { resolveAgentRouteWithPolicy } from "../../routing/resolve-route.js";
 import {
   DM_GROUP_ACCESS_REASON,
   resolvePinnedMainDmOwnerFromAllowlist,
@@ -106,7 +106,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       directLabel: entry.senderName,
       directId: entry.senderDisplay,
     });
-    const route = resolveAgentRoute({
+    const route = resolveAgentRouteWithPolicy({
       cfg: deps.cfg,
       channel: "signal",
       accountId: deps.accountId,
@@ -115,6 +115,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         id: entry.isGroup ? (entry.groupId ?? "unknown") : entry.senderPeerId,
       },
     });
+    if (!route) {
+      // Silent drop: routing.unmatched policy dropped the message. Telemetry
+      // already fired via handleUnmatched.
+      return;
+    }
     const storePath = resolveStorePath(deps.cfg.session?.store, {
       agentId: route.agentId,
     });
@@ -412,7 +417,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     }
 
     const senderPeerId = resolveSignalPeerId(params.sender);
-    const route = resolveAgentRoute({
+    const route = resolveAgentRouteWithPolicy({
       cfg: deps.cfg,
       channel: "signal",
       accountId: deps.accountId,
@@ -421,6 +426,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         id: isGroup ? (groupId ?? "unknown") : senderPeerId,
       },
     });
+    if (!route) {
+      // Silent drop: reaction on a message routed to an unmatched agent.
+      return true;
+    }
     const groupLabel = isGroup ? `${groupName ?? "Signal Group"} id:${groupId}` : undefined;
     const messageId = params.reaction.targetSentTimestamp
       ? String(params.reaction.targetSentTimestamp)
@@ -610,7 +619,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       return;
     }
 
-    const route = resolveAgentRoute({
+    const route = resolveAgentRouteWithPolicy({
       cfg: deps.cfg,
       channel: "signal",
       accountId: deps.accountId,
@@ -619,6 +628,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         id: isGroup ? (groupId ?? "unknown") : senderPeerId,
       },
     });
+    if (!route) {
+      // Silent drop: routing.unmatched policy dropped the message. Telemetry
+      // already fired via handleUnmatched.
+      return;
+    }
     const mentionRegexes = buildMentionRegexes(deps.cfg, route.agentId);
     const wasMentioned = isGroup && matchesMentionPatterns(messageText, mentionRegexes);
     const requireMention =

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -42,6 +42,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
   function createDefaultSlackCtx() {
     const slackCtx = createInboundSlackCtx({
       cfg: {
+        agents: { list: [{ id: "main" }] },
         channels: { slack: { enabled: true } },
       } as RemoteClawConfig,
     });
@@ -134,6 +135,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
   function createDmScopeMainSlackCtx(): SlackMonitorContext {
     const slackCtx = createInboundSlackCtx({
       cfg: {
+        agents: { list: [{ id: "main" }] },
         channels: { slack: { enabled: true } },
         session: { dmScope: "main" },
       } as RemoteClawConfig,
@@ -177,6 +179,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
   }): SlackMonitorContext {
     const slackCtx = createInboundSlackCtx({
       cfg: {
+        agents: { list: [{ id: "main" }] },
         channels: {
           slack: {
             enabled: true,
@@ -270,6 +273,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
   it("extracts attachment text for bot messages with empty text when allowBots is true (#27616)", async () => {
     const slackCtx = createInboundSlackCtx({
       cfg: {
+        agents: { list: [{ id: "main" }] },
         channels: {
           slack: { enabled: true },
         },
@@ -300,6 +304,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
   it("keeps channel metadata out of GroupSystemPrompt", async () => {
     const slackCtx = createInboundSlackCtx({
       cfg: {
+        agents: { list: [{ id: "main" }] },
         channels: {
           slack: {
             enabled: true,
@@ -434,6 +439,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       });
     const slackCtx = createThreadSlackCtx({
       cfg: {
+        agents: { list: [{ id: "main" }] },
         session: { store: storePath },
         channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
       } as RemoteClawConfig,
@@ -460,6 +466,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
   it("skips loading thread history when thread session already exists in store (bloat fix)", async () => {
     const { storePath } = makeTmpStorePath();
     const cfg = {
+      agents: { list: [{ id: "main" }] },
       session: { store: storePath },
       channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
     } as RemoteClawConfig;
@@ -549,6 +556,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     const { storePath } = makeTmpStorePath();
     const slackCtx = createInboundSlackCtx({
       cfg: {
+        agents: { list: [{ id: "main" }] },
         session: { store: storePath },
         channels: { slack: { enabled: true, replyToMode: "all" } },
       } as RemoteClawConfig,
@@ -581,7 +589,10 @@ describe("prepareSlackMessage sender prefix", () => {
   }): SlackMonitorContext {
     return {
       cfg: {
-        agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/remoteclaw" } },
+        agents: {
+          list: [{ id: "main" }],
+          defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/remoteclaw" },
+        },
         channels: { slack: params.channels },
       },
       accountId: "default",

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -27,7 +27,7 @@ import { recordInboundSession } from "../../../channels/session.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../../config/sessions.js";
 import { logVerbose, shouldLogVerbose } from "../../../globals.js";
 import { enqueueSystemEvent } from "../../../infra/system-events.js";
-import { resolveAgentRoute } from "../../../routing/resolve-route.js";
+import { resolveAgentRouteWithPolicy } from "../../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../../routing/session-key.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../../../security/dm-policy-shared.js";
 import { resolveSlackReplyToMode, type ResolvedSlackAccount } from "../../accounts.js";
@@ -97,7 +97,7 @@ type SlackAuthorizationContext = {
 };
 
 type SlackRoutingContext = {
-  route: ReturnType<typeof resolveAgentRoute>;
+  route: NonNullable<ReturnType<typeof resolveAgentRouteWithPolicy>>;
   chatType: "direct" | "group" | "channel";
   replyToMode: ReturnType<typeof resolveSlackReplyToMode>;
   threadContext: ReturnType<typeof resolveSlackThreadContext>;
@@ -260,9 +260,9 @@ function resolveSlackRoutingContext(params: {
   isGroupDm: boolean;
   isRoom: boolean;
   isRoomish: boolean;
-}): SlackRoutingContext {
+}): SlackRoutingContext | null {
   const { ctx, account, message, isDirectMessage, isGroupDm, isRoom, isRoomish } = params;
-  const route = resolveAgentRoute({
+  const route = resolveAgentRouteWithPolicy({
     cfg: ctx.cfg,
     channel: "slack",
     accountId: account.accountId,
@@ -272,6 +272,9 @@ function resolveSlackRoutingContext(params: {
       id: isDirectMessage ? (message.user ?? "unknown") : message.channel,
     },
   });
+  if (!route) {
+    return null;
+  }
 
   const chatType = isDirectMessage ? "direct" : isGroupDm ? "group" : "channel";
   const replyToMode = resolveSlackReplyToMode(account, chatType);
@@ -352,6 +355,11 @@ export async function prepareSlackMessage(params: {
     isRoom,
     isRoomish,
   });
+  if (!routing) {
+    // Silent drop: routing.unmatched policy says no catch-all. Telemetry
+    // already fired via handleUnmatched.
+    return null;
+  }
   const {
     route,
     replyToMode,

--- a/src/telegram/accounts.ts
+++ b/src/telegram/accounts.ts
@@ -9,7 +9,7 @@ import {
   resolveAccountWithDefaultFallback,
 } from "../plugin-sdk/account-resolution.js";
 import { resolveAccountEntry } from "../routing/account-lookup.js";
-import { listBoundAccountIds, resolveDefaultAgentBoundAccountId } from "../routing/bindings.js";
+import { listBoundAccountIds, resolveSoleAgentBoundAccountId } from "../routing/bindings.js";
 import { formatSetExplicitDefaultInstruction } from "../routing/default-account-warnings.js";
 import {
   DEFAULT_ACCOUNT_ID,
@@ -72,9 +72,9 @@ export function resetMissingDefaultWarnFlag(): void {
 }
 
 export function resolveDefaultTelegramAccountId(cfg: RemoteClawConfig): string {
-  const boundDefault = resolveDefaultAgentBoundAccountId(cfg, "telegram");
-  if (boundDefault) {
-    return boundDefault;
+  const boundSoleAgent = resolveSoleAgentBoundAccountId(cfg, "telegram");
+  if (boundSoleAgent) {
+    return boundSoleAgent;
   }
   const preferred = normalizeOptionalAccountId(cfg.channels?.telegram?.defaultAccount);
   if (

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -458,7 +458,7 @@ export const registerTelegramNativeCommands = ({
   }): Promise<{
     chatId: number;
     threadSpec: ReturnType<typeof resolveTelegramThreadSpec>;
-    route: ReturnType<typeof resolveTelegramConversationRoute>["route"];
+    route: NonNullable<ReturnType<typeof resolveTelegramConversationRoute>>["route"];
     mediaLocalRoots: readonly string[] | undefined;
     tableMode: ReturnType<typeof resolveMarkdownTableMode>;
     chunkMode: ReturnType<typeof resolveChunkMode>;
@@ -471,7 +471,7 @@ export const registerTelegramNativeCommands = ({
       isForum,
       messageThreadId,
     });
-    let { route, configuredBinding } = resolveTelegramConversationRoute({
+    const conversationRoute = resolveTelegramConversationRoute({
       cfg,
       accountId,
       chatId,
@@ -481,6 +481,12 @@ export const registerTelegramNativeCommands = ({
       senderId,
       topicAgentId,
     });
+    if (!conversationRoute) {
+      // Silent drop: routing.unmatched policy dropped the message. Telemetry
+      // already fired via handleUnmatched.
+      return null;
+    }
+    let { route, configuredBinding } = conversationRoute;
     if (configuredBinding) {
       const ensured = await ensureConfiguredAcpRouteReady({
         cfg,

--- a/src/telegram/conversation-route.ts
+++ b/src/telegram/conversation-route.ts
@@ -6,7 +6,8 @@ import {
   buildAgentSessionKey,
   deriveLastRoutePolicy,
   pickFirstExistingAgentId,
-  resolveAgentRoute,
+  resolveAgentRouteWithPolicy,
+  type ResolvedAgentRoute,
 } from "../routing/resolve-route.js";
 import { buildAgentMainSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import {
@@ -25,10 +26,10 @@ export function resolveTelegramConversationRoute(params: {
   senderId?: string | number | null;
   topicAgentId?: string | null;
 }): {
-  route: ReturnType<typeof resolveAgentRoute>;
+  route: ResolvedAgentRoute;
   configuredBinding: ReturnType<typeof resolveConfiguredAcpRoute>["configuredBinding"];
   configuredBindingSessionKey: string;
-} {
+} | null {
   const peerId = params.isGroup
     ? buildTelegramGroupPeerId(params.chatId, params.resolvedThreadId)
     : resolveTelegramDirectPeerId({
@@ -40,7 +41,7 @@ export function resolveTelegramConversationRoute(params: {
     resolvedThreadId: params.resolvedThreadId,
     chatId: params.chatId,
   });
-  let route = resolveAgentRoute({
+  const initialRoute = resolveAgentRouteWithPolicy({
     cfg: params.cfg,
     channel: "telegram",
     accountId: params.accountId,
@@ -50,6 +51,12 @@ export function resolveTelegramConversationRoute(params: {
     },
     parentPeer,
   });
+  if (!initialRoute) {
+    // Silent drop: routing.unmatched policy says no catch-all. Telemetry
+    // already fired via handleUnmatched.
+    return null;
+  }
+  let route: ResolvedAgentRoute = initialRoute;
 
   const rawTopicAgentId = params.topicAgentId?.trim();
   if (rawTopicAgentId) {

--- a/src/web/auto-reply.web-auto-reply.compresses-common-formats-jpeg-cap.test.ts
+++ b/src/web/auto-reply.web-auto-reply.compresses-common-formats-jpeg-cap.test.ts
@@ -74,6 +74,7 @@ describe("web auto-reply", () => {
 
   async function withMediaCap<T>(mediaMaxMb: number, run: () => Promise<T>): Promise<T> {
     setLoadConfigMock(() => ({
+      agents: { list: [{ id: "main" }] },
       channels: {
         whatsapp: {
           allowFrom: ["*"],
@@ -257,6 +258,7 @@ describe("web auto-reply", () => {
     expect(bigPng.length).toBeGreaterThan(SMALL_MEDIA_CAP_BYTES);
 
     setLoadConfigMock(() => ({
+      agents: { list: [{ id: "main" }] },
       channels: {
         whatsapp: {
           allowFrom: ["*"],

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -216,6 +216,8 @@ export async function monitorWebChannel(
     emitStatus();
 
     // Surface a concise connection event for the next main-session turn/heartbeat.
+    // Resolution uses the backward-compat resolveAgentRoute because system-event
+    // emission targets the main session regardless of binding policy.
     const { e164: selfE164 } = readWebSelfId(account.authDir);
     const connectRoute = resolveAgentRoute({
       cfg,

--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -2,7 +2,7 @@ import type { getReplyFromConfig } from "../../../auto-reply/reply.js";
 import type { MsgContext } from "../../../auto-reply/templating.js";
 import { loadConfig } from "../../../config/config.js";
 import { logVerbose } from "../../../globals.js";
-import { resolveAgentRoute } from "../../../routing/resolve-route.js";
+import { resolveAgentRoute, type ResolvedAgentRoute } from "../../../routing/resolve-route.js";
 import { buildGroupHistoryKey } from "../../../routing/session-key.js";
 import { normalizeE164 } from "../../../utils.js";
 import type { MentionConfig } from "../mentions.js";
@@ -32,7 +32,7 @@ export function createWebOnMessageHandler(params: {
 }) {
   const processForRoute = async (
     msg: WebInboundMsg,
-    route: ReturnType<typeof resolveAgentRoute>,
+    route: ResolvedAgentRoute,
     groupHistoryKey: string,
     opts?: {
       groupHistory?: GroupHistoryEntry[];
@@ -64,6 +64,11 @@ export function createWebOnMessageHandler(params: {
     const conversationId = msg.conversationId ?? msg.from;
     const peerId = resolvePeerId(msg);
     // Fresh config for bindings lookup; other routing inputs are payload-derived.
+    // TODO(#2309 follow-up): migrate to resolveAgentRouteWithPolicy for explicit
+    // silent-drop semantics. The backward-compat resolveAgentRoute still fires
+    // handleUnmatched telemetry on drops but falls back to the first configured
+    // agent (tagged matchedBy=fallback.legacyRoute) so legacy web test fixtures
+    // that lack agents.list continue to exercise the handler.
     const route = resolveAgentRoute({
       cfg: loadConfig(),
       channel: "whatsapp",

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -21,7 +21,7 @@ import type { getChildLogger } from "../../../logging.js";
 import { getAgentScopedMediaLocalRoots } from "../../../media/local-roots.js";
 import {
   resolveInboundLastRouteSessionKey,
-  type resolveAgentRoute,
+  type ResolvedAgentRoute,
 } from "../../../routing/resolve-route.js";
 import {
   readStoreAllowFromForDmPolicy,
@@ -126,7 +126,7 @@ function resolvePinnedMainDmRecipient(params: {
 export async function processMessage(params: {
   cfg: ReturnType<typeof loadConfig>;
   msg: WebInboundMsg;
-  route: ReturnType<typeof resolveAgentRoute>;
+  route: ResolvedAgentRoute;
   groupHistoryKey: string;
   groupHistories: Map<string, GroupHistoryEntry[]>;
   groupMemberNames: Map<string, Map<string, string>>;

--- a/src/web/monitor-inbox.test-harness.ts
+++ b/src/web/monitor-inbox.test-harness.ts
@@ -12,6 +12,10 @@ type AnyMockFn = any;
 export const DEFAULT_ACCOUNT_ID = "default";
 
 export const DEFAULT_WEB_INBOX_CONFIG = {
+  // Sole-agent fixture so the web adapter's backward-compat resolveAgentRoute
+  // path (which still fires via monitor-inbox) does not throw on empty
+  // agents.list. The actual inbound processing uses this as the routed agent.
+  agents: { list: [{ id: "main" }] },
   channels: {
     whatsapp: {
       // Allow all in tests by default.

--- a/src/web/test-helpers.ts
+++ b/src/web/test-helpers.ts
@@ -5,6 +5,12 @@ import { createMockBaileys } from "../../test/mocks/baileys.js";
 // Use globalThis to store the mock config so it survives vi.mock hoisting
 const CONFIG_KEY = Symbol.for("remoteclaw:testConfigMock");
 const DEFAULT_CONFIG = {
+  // Sole-agent fixture so web tests that predate #2309's silent-drop policy
+  // continue to exercise their inbound paths. The web adapter still uses the
+  // backward-compat resolveAgentRoute (tagged matchedBy=fallback.legacyRoute
+  // on silent-drop fallback), but having at least one configured agent keeps
+  // the fallback branch from throwing on zero-agents configs.
+  agents: { list: [{ id: "main" }] },
   channels: {
     whatsapp: {
       // Tests can override; default remains open to avoid surprising fixtures
@@ -23,11 +29,26 @@ if (!(globalThis as Record<symbol, unknown>)[CONFIG_KEY]) {
 }
 
 export function setLoadConfigMock(fn: unknown) {
-  (globalThis as Record<symbol, unknown>)[CONFIG_KEY] = typeof fn === "function" ? fn : () => fn;
+  const raw = typeof fn === "function" ? (fn as () => unknown) : () => fn;
+  (globalThis as Record<symbol, unknown>)[CONFIG_KEY] = () => applyRoutingDefaults(raw());
 }
 
 export function resetLoadConfigMock() {
   (globalThis as Record<symbol, unknown>)[CONFIG_KEY] = () => DEFAULT_CONFIG;
+}
+
+function applyRoutingDefaults(cfg: unknown): unknown {
+  // Inject a sole-agent fixture when tests provide a cfg without agents.list.
+  // The web adapter uses backward-compat resolveAgentRoute which fires silent-
+  // drop telemetry then falls back to the first configured agent. Without at
+  // least one agent in the list, the fallback branch throws.
+  if (cfg && typeof cfg === "object") {
+    const typed = cfg as { agents?: { list?: unknown } };
+    if (!typed.agents || !Array.isArray(typed.agents.list) || typed.agents.list.length === 0) {
+      return { ...typed, agents: { list: [{ id: "main" }] } };
+    }
+  }
+  return cfg;
 }
 
 vi.mock("../config/config.js", async (importOriginal) => {
@@ -37,7 +58,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
     loadConfig: () => {
       const getter = (globalThis as Record<symbol, unknown>)[CONFIG_KEY];
       if (typeof getter === "function") {
-        return getter();
+        return applyRoutingDefaults(getter());
       }
       return DEFAULT_CONFIG;
     },
@@ -57,7 +78,7 @@ vi.mock("../../config/config.js", async (importOriginal) => {
     loadConfig: () => {
       const getter = (globalThis as Record<symbol, unknown>)[CONFIG_KEY];
       if (typeof getter === "function") {
-        return getter();
+        return applyRoutingDefaults(getter());
       }
       return DEFAULT_CONFIG;
     },


### PR DESCRIPTION
## Summary

Closes #2309. Wave 2/6 of the "eliminate default agent" initiative (Phase 2a).

Replaces the implicit phantom "main" agent fallback in routing with an explicit operator-controlled `routing.unmatched` policy. When no binding matches an inbound message in a multi-agent config, the operator chooses between silent drop (default, consistent with existing auth-rejection patterns) or routing to a catch-all agent.

## What changed

### Routing core (`src/routing/`)

- **`resolve-route.ts`** — Introduces `AgentRouteOutcome = MatchedAgentRoute | UnmatchedAgentRoute` discriminated union as the return type of `resolveAgentRouteExplicit()`. Adds ergonomic `resolveAgentRouteWithPolicy()` that returns `MatchedAgentRoute | null`, and a backward-compat `resolveAgentRoute()` that keeps the old shape for downstream consumers. Removes the phantom-default fallback (`resolveDefaultAgentId`, `DEFAULT_AGENT_ID` re-export). Adds sole-agent promotion (`fallback.soleAgent` tier) and a named legacy-wrapper tier (`fallback.legacyRoute`) so fallbacks are distinguishable in logs and telemetry.
- **`unmatched.ts`** (new) — `handleUnmatched(scope, cfg)` centralizes the policy decision. Returns `{action: "drop"}` for silent drop or `{action: "route", agentId}` for operator-configured catch-all. Fires `logInboundDrop()` and emits a `routing.drop` diagnostic event from a single emission point.
- **`routing-drops-accumulator.ts`** (new) — In-memory rolling counter subscribed to the diagnostic event bus. Exposes `getRoutingDropCounts()` for `/remoteclaw status` display. Installed at gateway startup and idempotent.
- **`bindings.ts`** — `resolveDefaultAgentBoundAccountId` → `resolveSoleAgentBoundAccountId`. Returns `null` when there is no sole agent. No longer imports `resolveDefaultAgentId`.

### Schema (`src/config/zod-schema.ts`)

- New `routing.unmatched` field accepting `"reject"` (explicit silent drop) or `{agent: string}` (catch-all).
- Root `superRefine` extended to validate: (a) `routing.unmatched.agent` exists in `agents.list`, (b) `bindings[].agentId` references exist in `agents.list` (bonus — closes a longstanding gap).

### Telemetry wiring (4 surfaces, single emission point)

Silent drops emit one `routing.drop` diagnostic event that fans out to:

1. **Structured log** — `logInboundDrop()` called directly in `handleUnmatched`
2. **OTel counter** — new `remoteclaw.routing.drops{channel, reason}` counter added to `extensions/diagnostics-otel/src/service.ts`
3. **Control UI event** — `src/gateway/server.impl.ts` subscribes and broadcasts `route.drop` to the Control UI; unsubscribe wired in `server-close.ts`
4. **Status command accrual** — new accumulator module consumed by `src/auto-reply/reply/commands-status.ts` and rendered in `buildStatusMessage` as the `Drops:` line

### Channel adapter migrations

Fully migrated to `resolveAgentRouteWithPolicy` (silent-drop via `null` return):
- **Slack** — `src/slack/monitor/message-handler/prepare.ts`
- **Discord inbound** — `src/discord/monitor/route-resolution.ts` + `message-handler.preflight.ts`
- **Telegram** — `src/telegram/conversation-route.ts` + `bot-native-commands.ts`
- **Signal** — `src/signal/monitor/event-handler.ts` (all 3 inbound call sites)
- **iMessage** — `src/imessage/monitor/inbound-processing.ts`

Kept on backward-compat (intentional):
- **Discord slash commands** — `resolveDiscordBoundConversationRoute` uses backward-compat because user-initiated commands should not silently drop
- **Web auto-reply** + plugin-SDK extensions (bluebubbles, feishu, matrix, mattermost, msteams, etc.) — deferred to follow-up. Silent-drop telemetry still fires through the wrapper's internal policy dispatch; fallback path is visible via `matchedBy=fallback.legacyRoute` and a structured warn log per occurrence.

## Exit criterion verified

\`\`\`bash
grep -n "resolveDefaultAgentId\|DEFAULT_AGENT_ID" \\
  src/routing/resolve-route.ts src/routing/bindings.ts
# (no matches)
\`\`\`

## Tests

- **New**: \`src/routing/unmatched.test.ts\` (13 tests), \`src/routing/routing-drops-accumulator.test.ts\` (5 tests), \`src/config/zod-schema.routing-unmatched.test.ts\` (10 tests).
- **Updated**: \`src/routing/resolve-route.test.ts\` — tests that relied on phantom "main" now inject a \`SOLE_MAIN_AGENT\` fixture for sole-agent promotion. Channel adapter tests updated with \`agents.list\` fixtures.
- \`pnpm check && pnpm test\` → 6415 passed, 2 skipped.

## Scope deferred (tracked as follow-up)

Web auto-reply and 10+ plugin-SDK channel extensions still use the backward-compat \`resolveAgentRoute\` wrapper. They continue to work correctly (telemetry fires, legacy fallback documented) but don't get the clean \`null\`-based silent-drop contract. This is Phase 2b work that will migrate along with #2310's broader caller migration.

## Test plan

- [x] \`pnpm check\` — format + tsgo + lint green
- [x] \`pnpm test\` — 6415 pass, 2 skipped
- [x] Exit criterion grep clean
- [x] All 4 telemetry surfaces wired via single emission point
- [x] Schema validation rejects unknown agent references (parse-time)
- [x] Sole-agent promotion path verified (single-agent configs work unchanged)
- [ ] Operator smoke test: deploy to multi-agent environment, send unmatched message, verify \`/remoteclaw status\` drop counter increments and Control UI receives \`route.drop\` event

Generated with [Claude Code](https://claude.com/claude-code)