### PR TITLE
test(agents): regression coverage for resolveDefaultAgentId caller migration (#2314)

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RemoteClawConfig } from "../config/config.js";
 import {
+  listAgentIds,
   requireSoleAgentId,
   resolveAgentAuth,
   resolveAgentConfig,
@@ -11,6 +12,7 @@ import {
   resolveAgentRuntimeEnv,
   resolveAgentRuntimeOrThrow,
   resolveFallbackAgentId,
+  resolveFirstAgentWorkspace,
   resolveSoleAgentId,
   resolveAgentWorkspaceDir,
   resolveAgentWorkspaceDirOrNull,
@@ -576,5 +578,128 @@ describe("resolveAgentRuntimeEnv", () => {
       },
     };
     expect(resolveAgentRuntimeEnv(cfg, "main")).toEqual({ API_KEY: "sk-default" });
+  });
+});
+
+// Regression coverage for #2310 (Wave 3/6 — "eliminate default agent" initiative).
+// These tests pin the post-migration semantics of listAgentIds and
+// resolveFirstAgentWorkspace so that future refactors cannot silently
+// reintroduce a phantom "main" agent fallback. Fixtures use explicit agent
+// IDs (alpha/beta/gamma/solo) and intentionally never use "main", so a
+// regression that re-adds a DEFAULT_AGENT_ID=main fallback would fail these
+// assertions instead of being masked by the fixture name.
+describe("listAgentIds (regression: #2310)", () => {
+  it("returns empty array for empty config (no phantom main injection)", () => {
+    expect(listAgentIds({})).toEqual([]);
+  });
+
+  it("returns empty array when agents.list is an explicit empty array", () => {
+    const cfg: RemoteClawConfig = { agents: { list: [] } };
+    expect(listAgentIds(cfg)).toEqual([]);
+  });
+
+  it("returns empty array when agents is defined but list is absent", () => {
+    const cfg = { agents: {} } as unknown as RemoteClawConfig;
+    expect(listAgentIds(cfg)).toEqual([]);
+  });
+
+  it("returns all configured agent IDs in declaration order", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "alpha", workspace: "~/alpha" },
+          { id: "beta", workspace: "~/beta" },
+          { id: "gamma", workspace: "~/gamma" },
+        ],
+      },
+    };
+    expect(listAgentIds(cfg)).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("preserves declaration order when the first entry sorts last alphabetically", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "zulu", workspace: "~/zulu" },
+          { id: "alpha", workspace: "~/alpha" },
+        ],
+      },
+    };
+    expect(listAgentIds(cfg)).toEqual(["zulu", "alpha"]);
+  });
+
+  it("normalizes IDs and drops duplicates after normalization", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "Alpha", workspace: "~/a" },
+          { id: "  ALPHA  ", workspace: "~/a2" },
+          { id: "beta", workspace: "~/b" },
+        ],
+      },
+    };
+    expect(listAgentIds(cfg)).toEqual(["alpha", "beta"]);
+  });
+
+  it("skips entries with missing or empty id", () => {
+    const cfg = {
+      agents: {
+        list: [
+          { id: "alpha", workspace: "~/a" },
+          { workspace: "~/orphan" },
+          { id: "", workspace: "~/empty" },
+          { id: "beta", workspace: "~/b" },
+        ],
+      },
+    } as unknown as RemoteClawConfig;
+    expect(listAgentIds(cfg)).toEqual(["alpha", "beta"]);
+  });
+});
+
+describe("resolveFirstAgentWorkspace (regression: #2310)", () => {
+  it("returns the sole agent's workspace in a single-agent config without a 'main' entry", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "solo", workspace: "/tmp/solo" }] },
+    };
+    expect(resolveFirstAgentWorkspace(cfg)).toBe(path.resolve("/tmp/solo"));
+  });
+
+  it("returns the first agent's workspace in declaration order for multi-agent configs", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "alpha", workspace: "/tmp/alpha" },
+          { id: "beta", workspace: "/tmp/beta" },
+          { id: "gamma", workspace: "/tmp/gamma" },
+        ],
+      },
+    };
+    expect(resolveFirstAgentWorkspace(cfg)).toBe(path.resolve("/tmp/alpha"));
+  });
+
+  it("returns null for empty config", () => {
+    expect(resolveFirstAgentWorkspace({})).toBeNull();
+  });
+
+  it("returns null when agents.list is an explicit empty array", () => {
+    const cfg: RemoteClawConfig = { agents: { list: [] } };
+    expect(resolveFirstAgentWorkspace(cfg)).toBeNull();
+  });
+
+  it("does not depend on an agent named 'main'", () => {
+    // The pre-#2310 code could fall through to resolveAgentWorkspaceDir(cfg, "main")
+    // which would throw "agent 'main' has no workspace configured" for multi-agent
+    // configs without a "main" entry. This fixture is that exact shape.
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "alpha", workspace: "/tmp/alpha" },
+          { id: "beta", workspace: "/tmp/beta" },
+        ],
+      },
+    };
+    const resolved = resolveFirstAgentWorkspace(cfg);
+    expect(resolved).toBe(path.resolve("/tmp/alpha"));
+    expect(resolved).not.toContain("main");
   });
 });

--- a/src/infra/heartbeat-runner.per-agent-fanout.test.ts
+++ b/src/infra/heartbeat-runner.per-agent-fanout.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { listAgentIds, resolveSoleAgentId } from "../agents/agent-scope.js";
+import type { RemoteClawConfig } from "../config/config.js";
+import { startHeartbeatRunner } from "./heartbeat-runner.js";
+import { resetHeartbeatWakeStateForTests } from "./heartbeat-wake.js";
+
+// Regression coverage for #2310 (Wave 3/6 — "eliminate default agent" initiative).
+//
+// These assertions pin two invariants established by #2310:
+//
+//   1. `listAgentIds()` returns `[]` for empty configs (no phantom `"main"`
+//      injection). Pre-#2310 it returned `["main"]`, which caused
+//      `startHeartbeatRunner` to create a heartbeat for a phantom agent that
+//      wasn't in the config.
+//
+//   2. `startHeartbeatRunner` fans heartbeats out per configured agent using
+//      the actual agent IDs from `listAgentIds`, not a hardcoded `"main"`.
+//      With 3 agents configured, one heartbeat per agent fires in
+//      declaration order. With 0 agents configured, zero heartbeats fire.
+//
+// These tests intentionally use explicit agent IDs ("alpha", "beta", "gamma",
+// "solo") and never `"main"`. A test that used `"main"` as the fixture agent
+// ID would not catch a regression that re-introduced a `"main"` fallback —
+// the fixture name would mask the bug.
+//
+// Note: `src/agents/agent-scope.test.ts` is excluded from `vitest.unit.config.ts`
+// (pre-existing exclusion from the fork gut work), so direct unit tests on
+// `listAgentIds` in that file do not run under `pnpm test`. The direct
+// assertions below provide runnable coverage for the same regression.
+
+describe("listAgentIds (regression: #2310 — no phantom main injection)", () => {
+  it("returns empty array for empty config", () => {
+    expect(listAgentIds({})).toEqual([]);
+  });
+
+  it("returns empty array when agents.list is an explicit empty array", () => {
+    expect(listAgentIds({ agents: { list: [] } })).toEqual([]);
+  });
+
+  it("returns all configured agent IDs in declaration order", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "alpha", workspace: "~/alpha" },
+          { id: "beta", workspace: "~/beta" },
+          { id: "gamma", workspace: "~/gamma" },
+        ],
+      },
+    };
+    expect(listAgentIds(cfg)).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("resolveSoleAgentId returns null for empty config (not 'main')", () => {
+    expect(resolveSoleAgentId({})).toBeNull();
+  });
+
+  it("resolveSoleAgentId returns null for multi-agent config (not the first agent)", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "alpha" }, { id: "beta" }] },
+    };
+    expect(resolveSoleAgentId(cfg)).toBeNull();
+  });
+});
+
+describe("startHeartbeatRunner per-agent fanout (regression: #2310)", () => {
+  afterEach(() => {
+    resetHeartbeatWakeStateForTests();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("fires one heartbeat per agent in a 3-agent config, in declaration order", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: {
+          defaults: { heartbeat: { every: "30m" } },
+          list: [{ id: "alpha" }, { id: "beta" }, { id: "gamma" }],
+        },
+      } as RemoteClawConfig,
+      runOnce: runSpy,
+    });
+
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+
+    expect(runSpy).toHaveBeenCalledTimes(3);
+    const firedAgentIds = runSpy.mock.calls.map((call) => call[0]?.agentId);
+    expect(firedAgentIds).toEqual(["alpha", "beta", "gamma"]);
+    // Belt-and-braces: none of the calls fired for a phantom "main" agent.
+    expect(firedAgentIds).not.toContain("main");
+
+    runner.stop();
+  });
+
+  it("fires heartbeat with the explicit agent ID for a sole agent (not 'main')", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: {
+          defaults: { heartbeat: { every: "30m" } },
+          list: [{ id: "solo" }],
+        },
+      } as RemoteClawConfig,
+      runOnce: runSpy,
+    });
+
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(runSpy.mock.calls[0]?.[0]?.agentId).toBe("solo");
+    expect(runSpy.mock.calls[0]?.[0]?.agentId).not.toBe("main");
+
+    runner.stop();
+  });
+
+  it("fires zero heartbeats when agents.list is empty (no phantom main heartbeat)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: {
+          defaults: { heartbeat: { every: "30m" } },
+          list: [],
+        },
+      } as RemoteClawConfig,
+      runOnce: runSpy,
+    });
+
+    // Advance well beyond one interval: if any phantom agent was registered,
+    // its heartbeat would have fired by now.
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+
+    expect(runSpy).not.toHaveBeenCalled();
+
+    runner.stop();
+  });
+
+  it("fires zero heartbeats when agents config is entirely absent", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: {} as RemoteClawConfig,
+      runOnce: runSpy,
+    });
+
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+
+    expect(runSpy).not.toHaveBeenCalled();
+
+    runner.stop();
+  });
+});

--- a/src/security/audit-extra.workspace-iteration.test.ts
+++ b/src/security/audit-extra.workspace-iteration.test.ts
@@ -1,0 +1,164 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { RemoteClawConfig } from "../config/config.js";
+import { collectWorkspaceSkillSymlinkEscapeFindings } from "./audit-extra.async.js";
+
+// Regression coverage for #2310 (Wave 3/6 — "eliminate default agent" initiative).
+//
+// Pre-#2310, `src/security/audit-extra.async.ts`'s internal
+// `listAgentWorkspaceDirs` helper called `resolveDefaultAgentId(cfg)` which
+// produced `"main"` for empty configs and for configs without a `"main"`
+// agent. The security audit would then attempt to include a phantom `"main"`
+// workspace that didn't exist in the user's configuration.
+//
+// Post-#2310, `listAgentWorkspaceDirs` uses `resolveFirstAgentWorkspace(cfg)`
+// which returns the first actually-configured agent's workspace (respecting
+// declaration order and `agents.defaults.workspace`) and returns `null` for
+// empty configs instead of fabricating a `"main"` entry.
+//
+// These tests pin the observable consequences of that migration:
+//
+//   - A multi-agent config without a `"main"` entry scans every configured
+//     agent's workspace. The audit never touches a phantom `"main"` dir.
+//   - A sole-agent config named `"solo"` (not `"main"`) scans the solo
+//     workspace without crashing.
+//   - An empty `agents.list` scans zero workspaces. If a future refactor
+//     re-introduces a `"main"` fallback, this test would fail because the
+//     phantom workspace would be scanned and its symlink escape would be
+//     reported.
+//
+// Fixtures use explicit agent IDs (`alpha`, `beta`, `solo`) and never
+// `"main"`, so a regression that re-added a `"main"` fallback would not be
+// masked by the fixture name.
+
+// Canonical escape target used by the symlink-escape fixtures. This path is
+// outside every workspace we create, so pointing a skill file at it via a
+// symlink constitutes an "escape".
+let escapeTargetDir: string;
+let tmpRoot: string;
+
+async function createWorkspaceWithEscape(workspaceRoot: string, agentId: string): Promise<string> {
+  const workspaceDir = path.join(workspaceRoot, agentId);
+  const skillDir = path.join(workspaceDir, "skills", "escape-probe");
+  await fs.mkdir(skillDir, { recursive: true });
+  const skillLink = path.join(skillDir, "SKILL.md");
+  // Create a real file in the escape target, then symlink the in-workspace
+  // SKILL.md to it. This triggers the symlink-escape detection.
+  const escapeFile = path.join(escapeTargetDir, `${agentId}-escaped-skill.md`);
+  await fs.writeFile(escapeFile, "---\nname: escaped\n---\nescaped skill body", "utf-8");
+  await fs.symlink(escapeFile, skillLink);
+  return workspaceDir;
+}
+
+async function createWorkspaceWithoutEscape(
+  workspaceRoot: string,
+  agentId: string,
+): Promise<string> {
+  const workspaceDir = path.join(workspaceRoot, agentId);
+  await fs.mkdir(workspaceDir, { recursive: true });
+  return workspaceDir;
+}
+
+beforeEach(async () => {
+  const projectTmp = path.join(process.cwd(), ".tmp");
+  await fs.mkdir(projectTmp, { recursive: true });
+  tmpRoot = await fs.mkdtemp(path.join(projectTmp, "audit-workspace-iteration-"));
+  escapeTargetDir = path.join(tmpRoot, "__escape_target__");
+  await fs.mkdir(escapeTargetDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe("collectWorkspaceSkillSymlinkEscapeFindings (regression: #2310)", () => {
+  it("iterates every configured agent workspace in a multi-agent config without a 'main' entry", async () => {
+    const alphaWorkspace = await createWorkspaceWithEscape(tmpRoot, "alpha");
+    const betaWorkspace = await createWorkspaceWithEscape(tmpRoot, "beta");
+
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "alpha", workspace: alphaWorkspace },
+          { id: "beta", workspace: betaWorkspace },
+        ],
+      },
+    };
+
+    const findings = await collectWorkspaceSkillSymlinkEscapeFindings({ cfg });
+
+    expect(findings).toHaveLength(1);
+    const [finding] = findings;
+    expect(finding?.checkId).toBe("skills.workspace.symlink_escape");
+    // Both agent workspaces must appear in the finding's detail — proves the
+    // audit iterated BOTH alpha and beta, not just a phantom "main".
+    expect(finding?.detail).toContain(alphaWorkspace);
+    expect(finding?.detail).toContain(betaWorkspace);
+    // No phantom "main" workspace should appear in the detail. The fixture
+    // never configured an agent named "main"; if the detail mentions "main",
+    // a fallback reintroduced the phantom.
+    expect(finding?.detail).not.toMatch(/\bmain\b/);
+  });
+
+  it("scans the sole agent workspace by its explicit ID (not 'main')", async () => {
+    const soloWorkspace = await createWorkspaceWithEscape(tmpRoot, "solo");
+
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "solo", workspace: soloWorkspace }] },
+    };
+
+    const findings = await collectWorkspaceSkillSymlinkEscapeFindings({ cfg });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.detail).toContain(soloWorkspace);
+    expect(findings[0]?.detail).not.toMatch(/\bmain\b/);
+  });
+
+  it("does not crash when no agent is named 'main' in a multi-agent config", async () => {
+    // Clean workspaces (no escapes). The point is: the audit must not throw
+    // when there's no "main" entry to look up. Pre-#2310 the internal
+    // `listAgentWorkspaceDirs` called `resolveAgentWorkspaceDir(cfg, "main")`
+    // variants that could crash; post-#2310 it uses
+    // `resolveFirstAgentWorkspace` which gracefully returns the first agent.
+    const alphaWorkspace = await createWorkspaceWithoutEscape(tmpRoot, "alpha");
+    const betaWorkspace = await createWorkspaceWithoutEscape(tmpRoot, "beta");
+
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "alpha", workspace: alphaWorkspace },
+          { id: "beta", workspace: betaWorkspace },
+        ],
+      },
+    };
+
+    const findings = await collectWorkspaceSkillSymlinkEscapeFindings({ cfg });
+    expect(findings).toEqual([]);
+  });
+
+  it("scans zero workspaces for an empty agents.list (no phantom main workspace)", async () => {
+    // Create a workspace at tmpRoot/main with an escaped skill. If the audit
+    // reintroduces a "main" fallback, it will crash or report this workspace;
+    // a correctly migrated audit returns zero findings because agents.list
+    // is empty.
+    await createWorkspaceWithEscape(tmpRoot, "main");
+
+    const cfg: RemoteClawConfig = { agents: { list: [] } };
+
+    const findings = await collectWorkspaceSkillSymlinkEscapeFindings({ cfg });
+    expect(findings).toEqual([]);
+  });
+
+  it("scans zero workspaces for entirely missing agents config", async () => {
+    // Same sentinel: a workspace at tmpRoot/main that a regressed audit
+    // would discover and scan. An empty config must not fabricate a "main"
+    // workspace path.
+    await createWorkspaceWithEscape(tmpRoot, "main");
+
+    const cfg: RemoteClawConfig = {};
+
+    const findings = await collectWorkspaceSkillSymlinkEscapeFindings({ cfg });
+    expect(findings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Wave 4/6 Track 4 of the "eliminate default agent" initiative. Pins the post-#2310 semantics so a future refactor that re-introduces a phantom `"main"` agent fallback is caught by CI rather than by runtime.

Closes #2314.

## What this PR adds

### `src/agents/agent-scope.test.ts` — direct unit tests per AC

- **`listAgentIds`** — empty config, explicit empty list, missing list, 3-agent declaration order, case/whitespace normalization with duplicate collapsing, skipping entries with missing/empty id.
- **`resolveFirstAgentWorkspace`** — sole agent, multi-agent declaration order, empty config, explicit empty list, no-"main" fixture with belt-and-braces "not 'main'" assertion.

All fixtures use explicit agent IDs (`alpha`/`beta`/`gamma`/`solo`) and never `"main"` — a regression that re-added a `"main"` fallback would surface instead of being masked by the fixture name.

### `src/infra/heartbeat-runner.per-agent-fanout.test.ts` (new)

Runnable regression guards. See "Known gap" below for context on why this file exists alongside the `agent-scope.test.ts` additions.

- Direct `listAgentIds` and `resolveSoleAgentId` assertions (empty, sole, multi)
- `startHeartbeatRunner` with 3 agents (alpha/beta/gamma) fires `runOnce` once per agent in declaration order
- Sole agent `"solo"` fires heartbeat with explicit ID (asserts not `"main"`)
- Empty `agents.list` fires zero heartbeats — **the most important regression guard** (catches "someone added a fallback back")
- Missing `agents` config fires zero heartbeats

### `src/security/audit-extra.workspace-iteration.test.ts` (new)

- Multi-agent config without a `"main"` entry — audit iterates `alpha` and `beta` workspaces via real symlink-escape fixtures; no phantom `"main"` path appears in the finding detail
- Sole `"solo"` agent — audit scans the solo workspace, never `"main"`
- Multi-agent config with no escapes — no crash when no agent named `"main"` exists
- Empty `agents.list` with a sentinel `"main"` workspace on disk — zero findings (if a regressed audit reintroduced a `"main"` fallback, the sentinel workspace's symlink escape would be reported and fail this test)
- Missing `agents` config with the same sentinel — zero findings

Uses real temp directories under `.tmp/audit-workspace-iteration-*` (cleaned in `afterEach`).

## Known gap — pre-existing, not in scope

`src/agents/**` is excluded from `vitest.unit.config.ts` (line 25 — pre-existing fork exclusion from the upstream sync at #2172, not touched by this PR). This means the tests added to `src/agents/agent-scope.test.ts` verify correctly under `vitest.config.ts` **but are skipped under `pnpm test`**.

To ensure the regression guards actually gate CI, this PR mirrors the critical assertions into `src/infra/heartbeat-runner.per-agent-fanout.test.ts` (which directly imports `listAgentIds` / `resolveSoleAgentId`) and `src/security/audit-extra.workspace-iteration.test.ts`. Both files live under non-excluded directories and run under `pnpm test`.

I verified this by running:

```bash
pnpm exec vitest run --config vitest.unit.config.ts --pool=forks \
  src/infra/heartbeat-runner.per-agent-fanout.test.ts \
  src/security/audit-extra.workspace-iteration.test.ts \
  src/infra/outbound/channel-resolution.test.ts
# 26 passed
```

Narrowing the `src/agents/**` exclusion is a separate scope concern (10 test files in that directory have pre-existing failures from the fork gut work — verified by running the suite isolated). Tracking separately would be appropriate as a follow-up.

## Test plan

- [x] `pnpm check` (format:check + tsgo + lint + tmp:no-random-messaging) — clean
- [x] `pnpm exec vitest run --config vitest.config.ts src/agents/agent-scope.test.ts src/infra/heartbeat-runner.per-agent-fanout.test.ts src/security/audit-extra.workspace-iteration.test.ts` — 82 passed
- [x] `pnpm exec vitest run --config vitest.unit.config.ts --pool=forks src/infra/heartbeat-runner.per-agent-fanout.test.ts src/security/audit-extra.workspace-iteration.test.ts` — 14 passed (CI config path)
- [ ] CI green on this PR

## Dependencies

- Depends on #2310 (merged) — the migrated behavior this PR pins

## Related

- #2311 (parallel track — `normalizeAgentId` split and `DEFAULT_AGENT_ID` deletion; no file overlap with this PR)
- #2316 (end-to-end regression coverage; builds on unit/integration tests from this PR)