### PR TITLE
refactor(routing): split normalizeAgentId and delete DEFAULT_AGENT_ID (#2311)

### DIFF
--- a/src/agents/agent-paths.ts
+++ b/src/agents/agent-paths.ts
@@ -1,14 +1,21 @@
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
-import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
 
-export function resolveRemoteClawAgentDir(): string {
+// Legacy literal used only as the "no specific agent" fallback for the
+// auth-store path resolver. This is NOT imported from routing/session-key —
+// it's an explicit local default preserved for backwards-compatible auth
+// profile lookup across agent directories.
+const LEGACY_DEFAULT_AGENT_DIR_NAME = "main";
+
+export function resolveRemoteClawAgentDir(agentId?: string): string {
   const override =
     process.env.REMOTECLAW_AGENT_DIR?.trim() || process.env.PI_CODING_AGENT_DIR?.trim();
   if (override) {
     return resolveUserPath(override);
   }
-  const defaultAgentDir = path.join(resolveStateDir(), "agents", DEFAULT_AGENT_ID, "agent");
-  return resolveUserPath(defaultAgentDir);
+  const id = agentId ? normalizeAgentId(agentId) : LEGACY_DEFAULT_AGENT_DIR_NAME;
+  const agentDir = path.join(resolveStateDir(), "agents", id, "agent");
+  return resolveUserPath(agentDir);
 }

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -340,9 +340,16 @@ export async function spawnSubagentDirect(
     };
   }
 
-  const requesterAgentId = normalizeAgentId(
-    ctx.requesterAgentIdOverride ?? parseAgentSessionKey(requesterInternalKey)?.agentId,
-  );
+  const rawRequesterAgentId =
+    ctx.requesterAgentIdOverride ?? parseAgentSessionKey(requesterInternalKey)?.agentId;
+  if (!rawRequesterAgentId) {
+    return {
+      status: "forbidden",
+      error:
+        "sessions_spawn: cannot resolve requester agent id — tool must run inside an agent session",
+    };
+  }
+  const requesterAgentId = normalizeAgentId(rawRequesterAgentId);
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
   if (targetAgentId !== requesterAgentId) {
     const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -1,10 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import { loadConfig } from "../../config/config.js";
-import {
-  DEFAULT_AGENT_ID,
-  normalizeAgentId,
-  parseAgentSessionKey,
-} from "../../routing/session-key.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveAgentConfig } from "../agent-scope.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult } from "./common.js";
@@ -40,11 +36,14 @@ export function createAgentsListTool(opts?: {
               mainKey,
             })
           : alias;
-      const requesterAgentId = normalizeAgentId(
-        opts?.requesterAgentIdOverride ??
-          parseAgentSessionKey(requesterInternalKey)?.agentId ??
-          DEFAULT_AGENT_ID,
-      );
+      const rawRequesterAgentId =
+        opts?.requesterAgentIdOverride ?? parseAgentSessionKey(requesterInternalKey)?.agentId;
+      if (!rawRequesterAgentId) {
+        throw new Error(
+          "agents_list tool: cannot resolve requester agent id — tool must run inside an agent session",
+        );
+      }
+      const requesterAgentId = normalizeAgentId(rawRequesterAgentId);
 
       const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
       const allowAny = allowAgents.some((value) => value.trim() === "*");

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -19,7 +19,6 @@ import {
 } from "../../infra/provider-usage.js";
 import {
   buildAgentMainSessionKey,
-  DEFAULT_AGENT_ID,
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
 // Model override infrastructure gutted in RemoteClaw — inline override logic.
@@ -45,6 +44,7 @@ function resolveSessionEntry(params: {
   keyRaw: string;
   alias: string;
   mainKey: string;
+  agentId: string;
 }): { key: string; entry: SessionEntry } | null {
   const keyRaw = params.keyRaw.trim();
   if (!keyRaw) {
@@ -58,13 +58,13 @@ function resolveSessionEntry(params: {
 
   const candidates = new Set<string>([keyRaw, internal]);
   if (!keyRaw.startsWith("agent:")) {
-    candidates.add(`agent:${DEFAULT_AGENT_ID}:${keyRaw}`);
-    candidates.add(`agent:${DEFAULT_AGENT_ID}:${internal}`);
+    candidates.add(`agent:${params.agentId}:${keyRaw}`);
+    candidates.add(`agent:${params.agentId}:${internal}`);
   }
   if (keyRaw === "main") {
     candidates.add(
       buildAgentMainSessionKey({
-        agentId: DEFAULT_AGENT_ID,
+        agentId: params.agentId,
         mainKey: params.mainKey,
       }),
     );
@@ -196,6 +196,7 @@ export function createSessionStatusTool(opts?: {
         keyRaw: requestedKeyRaw,
         alias,
         mainKey,
+        agentId,
       });
 
       if (!resolved && shouldResolveSessionIdInput(requestedKeyRaw)) {
@@ -216,6 +217,7 @@ export function createSessionStatusTool(opts?: {
             keyRaw: requestedKeyRaw,
             alias,
             mainKey,
+            agentId,
           });
         }
       }

--- a/src/auto-reply/reply.triggers.trigger-handling.filters-usage-summary-current-model-provider.cases.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.filters-usage-summary-current-model-provider.cases.ts
@@ -177,11 +177,15 @@ export function registerTriggerHandlingUsageSummaryCases(params: {
             ),
           );
 
-          const sessionKey = resolveSessionKey("per-sender", {
-            From: "+1002",
-            To: "+2000",
-            Provider: "whatsapp",
-          } as Parameters<typeof resolveSessionKey>[1]);
+          const sessionKey = resolveSessionKey(
+            "per-sender",
+            {
+              From: "+1002",
+              To: "+2000",
+              Provider: "whatsapp",
+            } as Parameters<typeof resolveSessionKey>[1],
+            "main",
+          );
           await writeFile(
             requireSessionStorePath(cfg),
             JSON.stringify(

--- a/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts
@@ -298,7 +298,7 @@ describe("trigger handling", () => {
         expect(text?.startsWith("⚙️ Compacted")).toBe(true);
         expect(getCompactSessionMock()).toHaveBeenCalledOnce();
         const store = loadSessionStore(storePath);
-        const sessionKey = resolveSessionKey("per-sender", request);
+        const sessionKey = resolveSessionKey("per-sender", request, "main");
         expect(store[sessionKey]?.compactionCount).toBe(1);
       }
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -31,6 +31,7 @@ import type {
   BridgeCallbacks,
   ChannelMessage,
 } from "../../middleware/types.js";
+import { resolveAgentIdFromSessionKeyOrNull } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
@@ -500,11 +501,14 @@ export async function runAgentTurnWithFallback(params: {
         try {
           // Delete transcript file if it exists
           if (corruptedSessionId) {
-            const transcriptPath = resolveSessionTranscriptPath(corruptedSessionId);
-            try {
-              fs.unlinkSync(transcriptPath);
-            } catch {
-              // Ignore if file doesn't exist
+            const agentId = resolveAgentIdFromSessionKeyOrNull(params.sessionKey) ?? undefined;
+            if (agentId) {
+              const transcriptPath = resolveSessionTranscriptPath(corruptedSessionId, agentId);
+              try {
+                fs.unlinkSync(transcriptPath);
+              } catch {
+                // Ignore if file doesn't exist
+              }
             }
           }
 

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -362,7 +362,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf-8");
     }
 
-    const transcriptPath = sessions.resolveSessionTranscriptPath(params.sessionId);
+    const transcriptPath = sessions.resolveSessionTranscriptPath(params.sessionId, "main");
     await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
     await fs.writeFile(transcriptPath, "bad", "utf-8");
 
@@ -1116,7 +1116,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     await withTempStateDir(async (stateDir) => {
       const sessionId = "session";
       const storePath = path.join(stateDir, "sessions", "sessions.json");
-      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId);
+      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId, "main");
       const sessionEntry: SessionEntry = {
         sessionId,
         updatedAt: Date.now(),
@@ -1172,7 +1172,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     await withTempStateDir(async (stateDir) => {
       const sessionId = "session";
       const storePath = path.join(stateDir, "sessions", "sessions.json");
-      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId);
+      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId, "main");
       const sessionEntry = { sessionId, updatedAt: Date.now(), sessionFile: transcriptPath };
       const sessionStore = { main: sessionEntry };
 
@@ -1268,7 +1268,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     await withTempStateDir(async (stateDir) => {
       const sessionId = "session";
       const storePath = path.join(stateDir, "sessions", "sessions.json");
-      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId);
+      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId, "main");
       const sessionEntry = { sessionId, updatedAt: Date.now(), sessionFile: transcriptPath };
       const sessionStore = { main: sessionEntry };
 
@@ -1356,7 +1356,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       await fs.mkdir(path.dirname(storePath), { recursive: true });
       await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf-8");
 
-      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId);
+      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId, "main");
       await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
       await fs.writeFile(transcriptPath, "ok", "utf-8");
 

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -2,7 +2,7 @@ import { resolveAgentDir, resolveAgentWorkspaceDirOrNull } from "../agents/agent
 import { upsertAuthProfile } from "../auth/index.js";
 import { writeConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
-import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { resolveUserPath, shortenHomePath } from "../utils.js";
@@ -67,11 +67,6 @@ export async function agentsAddCommand(
       return;
     }
     const agentId = normalizeAgentId(nameInput);
-    if (agentId === DEFAULT_AGENT_ID) {
-      runtime.error(`"${DEFAULT_AGENT_ID}" is reserved. Choose another name.`);
-      runtime.exit(1);
-      return;
-    }
     if (agentId !== nameInput) {
       runtime.log(`Normalized agent id to "${agentId}".`);
     }
@@ -167,10 +162,6 @@ export async function agentsAddCommand(
           if (!value?.trim()) {
             return "Required";
           }
-          const normalized = normalizeAgentId(value);
-          if (normalized === DEFAULT_AGENT_ID) {
-            return `"${DEFAULT_AGENT_ID}" is reserved. Choose another name.`;
-          }
           return undefined;
         },
       }));
@@ -191,9 +182,6 @@ export async function agentsAddCommand(
             return "Must start with a letter or digit and contain only letters, digits, hyphens, and underscores (max 64 chars).";
           }
           const normalized = trimmed.toLowerCase();
-          if (normalized === DEFAULT_AGENT_ID) {
-            return `"${DEFAULT_AGENT_ID}" is reserved. Choose another id.`;
-          }
           if (existingIds.has(normalized)) {
             return `Agent "${normalized}" already exists.`;
           }

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -2,7 +2,7 @@ import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope
 import { writeConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
-import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { createClackPrompter } from "../wizard/clack-prompter.js";
@@ -35,11 +35,6 @@ export async function agentsDeleteCommand(
   const agentId = normalizeAgentId(input);
   if (agentId !== input) {
     runtime.log(`Normalized agent id to "${agentId}".`);
-  }
-  if (agentId === DEFAULT_AGENT_ID) {
-    runtime.error(`"${DEFAULT_AGENT_ID}" cannot be deleted.`);
-    runtime.exit(1);
-    return;
   }
 
   if (findAgentEntryIndex(listAgentEntries(cfg), agentId) < 0) {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -24,9 +24,11 @@ const OPENCLAW_CONFIG_FILENAME = "openclaw.json";
 const REMOTECLAW_CONFIG_FILENAME = "remoteclaw.json";
 
 /**
- * Default agent id used by OpenClaw when no explicit id is set.
+ * Legacy agent id used by OpenClaw when no explicit id was set. Used here
+ * only for backwards-compatible imports of pre-RemoteClaw configs — this is
+ * NOT a phantom agent default at runtime.
  */
-const DEFAULT_AGENT_ID = "main";
+const LEGACY_OPENCLAW_DEFAULT_AGENT_ID = "main";
 
 /**
  * Default workspace path for the default agent.
@@ -387,7 +389,7 @@ export function materializeWorkspaceDefaults(jsonContent: string): string {
   if (agentsList.length === 0 && hasSubstantiveContent) {
     // Step 2: Create default agent entry when config has real content
     const newAgents = agents ?? {};
-    newAgents.list = [{ id: DEFAULT_AGENT_ID, workspace: DEFAULT_WORKSPACE }];
+    newAgents.list = [{ id: LEGACY_OPENCLAW_DEFAULT_AGENT_ID, workspace: DEFAULT_WORKSPACE }];
     config.agents = newAgents;
     mutated = true;
   } else {
@@ -405,10 +407,10 @@ export function materializeWorkspaceDefaults(jsonContent: string): string {
         entry.workspace = defaultsWorkspace;
       } else {
         const id = typeof entry.id === "string" ? entry.id.trim() : "";
-        const isDefault = id === DEFAULT_AGENT_ID || agentsList.length === 1;
+        const isDefault = id === LEGACY_OPENCLAW_DEFAULT_AGENT_ID || agentsList.length === 1;
         entry.workspace = isDefault
           ? DEFAULT_WORKSPACE
-          : `~/.remoteclaw/workspace-${id || DEFAULT_AGENT_ID}`;
+          : `~/.remoteclaw/workspace-${id || LEGACY_OPENCLAW_DEFAULT_AGENT_ID}`;
       }
       mutated = true;
     }

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -6,6 +6,7 @@ import { cancel, isCancel } from "@clack/prompts";
 import { ensureAgentWorkspace } from "../agents/workspace.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { CONFIG_PATH } from "../config/config.js";
+import { resolveStateDir } from "../config/paths.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
 import { normalizeControlUiBasePath } from "../gateway/control-ui-shared.js";
@@ -307,7 +308,9 @@ export async function handleReset(scope: ResetScope, workspaceDir: string, runti
     return;
   }
   await moveToTrash(path.join(CONFIG_DIR, "credentials"), runtime);
-  await moveToTrash(resolveSessionTranscriptsDirForAgent(), runtime);
+  // Reset removes the entire agents tree (every agent's sessions, workspace cache, etc.).
+  // Per-agent dirs are created by setup/add commands, so this is the correct scope.
+  await moveToTrash(path.join(resolveStateDir(), "agents"), runtime);
   if (scope === "full") {
     await moveToTrash(workspaceDir, runtime);
   }

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -3,7 +3,8 @@ import JSON5 from "json5";
 import { ensureAgentWorkspace } from "../agents/workspace.js";
 import { type RemoteClawConfig, createConfigIO, writeConfigFile } from "../config/config.js";
 import { formatConfigPath } from "../config/logging.js";
-import { resolveSessionTranscriptsDir } from "../config/sessions.js";
+import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
@@ -50,7 +51,10 @@ export async function setupCommand(
     runtime.log(`Workspace OK: ${shortenHomePath(ws.dir)}`);
   }
 
-  const sessionsDir = resolveSessionTranscriptsDir();
-  await fs.mkdir(sessionsDir, { recursive: true });
-  runtime.log(`Sessions OK: ${shortenHomePath(sessionsDir)}`);
+  const firstAgentId = cfg.agents?.list?.[0]?.id;
+  if (firstAgentId) {
+    const sessionsDir = resolveSessionTranscriptsDirForAgent(normalizeAgentId(firstAgentId));
+    await fs.mkdir(sessionsDir, { recursive: true });
+    runtime.log(`Sessions OK: ${shortenHomePath(sessionsDir)}`);
+  }
 }

--- a/src/config/agent-dirs.ts
+++ b/src/config/agent-dirs.ts
@@ -1,7 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
-import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveStateDir } from "./paths.js";
 import type { RemoteClawConfig } from "./types.js";
@@ -33,9 +33,6 @@ function collectReferencedAgentIds(cfg: RemoteClawConfig): string[] {
   const ids = new Set<string>();
 
   const agents = Array.isArray(cfg.agents?.list) ? cfg.agents?.list : [];
-  const defaultAgentId = agents[0]?.id ?? DEFAULT_AGENT_ID;
-  ids.add(normalizeAgentId(defaultAgentId));
-
   for (const entry of agents) {
     if (entry?.id) {
       ids.add(normalizeAgentId(entry.id));

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -11,7 +11,7 @@ import {
   resolveSessionFilePathOptions,
   resolveSessionKey,
   resolveSessionTranscriptPath,
-  resolveSessionTranscriptsDir,
+  resolveSessionTranscriptsDirForAgent,
   updateLastRoute,
   updateSessionStore,
   updateSessionStoreEntry,
@@ -208,7 +208,7 @@ describe("sessions", () => {
 
   for (const testCase of resolveSessionKeyCases) {
     it(testCase.name, () => {
-      expect(resolveSessionKey(testCase.scope, testCase.ctx, testCase.mainKey)).toBe(
+      expect(resolveSessionKey(testCase.scope, testCase.ctx, "main", testCase.mainKey)).toBe(
         testCase.expected,
       );
     });
@@ -540,7 +540,8 @@ describe("sessions", () => {
   });
 
   it("derives session transcripts dir from REMOTECLAW_STATE_DIR", () => {
-    const dir = resolveSessionTranscriptsDir(
+    const dir = resolveSessionTranscriptsDirForAgent(
+      "main",
       { REMOTECLAW_STATE_DIR: "/custom/state" } as NodeJS.ProcessEnv,
       () => "/home/ignored",
     );

--- a/src/config/sessions/main-session.ts
+++ b/src/config/sessions/main-session.ts
@@ -1,6 +1,5 @@
 import {
   buildAgentMainSessionKey,
-  DEFAULT_AGENT_ID,
   normalizeAgentId,
   normalizeMainKey,
   resolveAgentIdFromSessionKey,
@@ -15,9 +14,11 @@ export function resolveMainSessionKey(cfg?: {
   if (cfg?.session?.scope === "global") {
     return "global";
   }
-  const agents = cfg?.agents?.list ?? [];
-  const defaultAgentId = agents[0]?.id ?? DEFAULT_AGENT_ID;
-  const agentId = normalizeAgentId(defaultAgentId);
+  const firstAgentId = cfg?.agents?.list?.[0]?.id;
+  if (!firstAgentId) {
+    throw new Error("Cannot resolve main session key: no agents configured (agents.list is empty)");
+  }
+  const agentId = normalizeAgentId(firstAgentId);
   const mainKey = normalizeMainKey(cfg?.session?.mainKey);
   return buildAgentMainSessionKey({ agentId, mainKey });
 }

--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -2,35 +2,31 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { expandHomePrefix, resolveRequiredHomeDir } from "../../infra/home-dir.js";
-import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 import { resolveStateDir } from "../paths.js";
 
 function resolveAgentSessionsDir(
-  agentId?: string,
+  agentId: string | undefined,
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = () => resolveRequiredHomeDir(env, os.homedir),
 ): string {
+  if (!agentId) {
+    throw new Error("resolveAgentSessionsDir: agentId is required — no phantom default agent");
+  }
   const root = resolveStateDir(env, homedir);
-  const id = normalizeAgentId(agentId ?? DEFAULT_AGENT_ID);
+  const id = normalizeAgentId(agentId);
   return path.join(root, "agents", id, "sessions");
 }
 
-export function resolveSessionTranscriptsDir(
-  env: NodeJS.ProcessEnv = process.env,
-  homedir: () => string = () => resolveRequiredHomeDir(env, os.homedir),
-): string {
-  return resolveAgentSessionsDir(DEFAULT_AGENT_ID, env, homedir);
-}
-
 export function resolveSessionTranscriptsDirForAgent(
-  agentId?: string,
+  agentId: string | undefined,
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = () => resolveRequiredHomeDir(env, os.homedir),
 ): string {
   return resolveAgentSessionsDir(agentId, env, homedir);
 }
 
-export function resolveDefaultSessionStorePath(agentId?: string): string {
+export function resolveDefaultSessionStorePath(agentId: string | undefined): string {
   return path.join(resolveAgentSessionsDir(agentId), "sessions.json");
 }
 
@@ -72,7 +68,10 @@ function resolveSessionsDir(opts?: SessionFilePathOptions): string {
   if (sessionsDir) {
     return path.resolve(sessionsDir);
   }
-  return resolveAgentSessionsDir(opts?.agentId);
+  if (!opts?.agentId) {
+    throw new Error("resolveSessionsDir requires opts.sessionsDir or opts.agentId");
+  }
+  return resolveAgentSessionsDir(opts.agentId);
 }
 
 function resolvePathFromAgentSessionsDir(
@@ -253,7 +252,7 @@ export function resolveSessionTranscriptPathInDir(
 
 export function resolveSessionTranscriptPath(
   sessionId: string,
-  agentId?: string,
+  agentId: string | undefined,
   topicId?: string | number,
 ): string {
   return resolveSessionTranscriptPathInDir(sessionId, resolveAgentSessionsDir(agentId), topicId);
@@ -277,11 +276,17 @@ export function resolveSessionFilePath(
 }
 
 export function resolveStorePath(store?: string, opts?: { agentId?: string }) {
-  const agentId = normalizeAgentId(opts?.agentId ?? DEFAULT_AGENT_ID);
-  if (!store) {
-    return resolveDefaultSessionStorePath(agentId);
-  }
-  if (store.includes("{agentId}")) {
+  const requiresAgentId = !store || store.includes("{agentId}");
+  if (requiresAgentId) {
+    if (!opts?.agentId) {
+      throw new Error(
+        "resolveStorePath: opts.agentId is required when store is unset or contains the {agentId} template",
+      );
+    }
+    const agentId = normalizeAgentId(opts.agentId);
+    if (!store) {
+      return resolveDefaultSessionStorePath(agentId);
+    }
     const expanded = store.replaceAll("{agentId}", agentId);
     if (expanded.startsWith("~")) {
       return path.resolve(

--- a/src/config/sessions/session-key.test.ts
+++ b/src/config/sessions/session-key.test.ts
@@ -20,7 +20,7 @@ describe("resolveSessionKey", () => {
         From: "discord:123456",
         SenderId: "123456",
       });
-      expect(resolveSessionKey("per-sender", ctx)).toBe("agent:fina:discord:direct:123456");
+      expect(resolveSessionKey("per-sender", ctx, "main")).toBe("agent:fina:discord:direct:123456");
     });
 
     it("migrates legacy discord:dm: keys to discord:direct:", () => {
@@ -30,7 +30,7 @@ describe("resolveSessionKey", () => {
         From: "discord:123456",
         SenderId: "123456",
       });
-      expect(resolveSessionKey("per-sender", ctx)).toBe("agent:fina:discord:direct:123456");
+      expect(resolveSessionKey("per-sender", ctx, "main")).toBe("agent:fina:discord:direct:123456");
     });
 
     it("fixes phantom discord:channel:USERID keys when sender matches", () => {
@@ -40,7 +40,7 @@ describe("resolveSessionKey", () => {
         From: "discord:123456",
         SenderId: "123456",
       });
-      expect(resolveSessionKey("per-sender", ctx)).toBe("agent:fina:discord:direct:123456");
+      expect(resolveSessionKey("per-sender", ctx, "main")).toBe("agent:fina:discord:direct:123456");
     });
 
     it("does not rewrite discord:channel: keys for non-direct chats", () => {
@@ -50,7 +50,9 @@ describe("resolveSessionKey", () => {
         From: "discord:channel:123456",
         SenderId: "789",
       });
-      expect(resolveSessionKey("per-sender", ctx)).toBe("agent:fina:discord:channel:123456");
+      expect(resolveSessionKey("per-sender", ctx, "main")).toBe(
+        "agent:fina:discord:channel:123456",
+      );
     });
 
     it("does not rewrite discord:channel: keys when sender does not match", () => {
@@ -60,7 +62,9 @@ describe("resolveSessionKey", () => {
         From: "discord:789",
         SenderId: "789",
       });
-      expect(resolveSessionKey("per-sender", ctx)).toBe("agent:fina:discord:channel:123456");
+      expect(resolveSessionKey("per-sender", ctx, "main")).toBe(
+        "agent:fina:discord:channel:123456",
+      );
     });
 
     it("handles keys without an agent prefix", () => {
@@ -70,7 +74,7 @@ describe("resolveSessionKey", () => {
         From: "discord:123456",
         SenderId: "123456",
       });
-      expect(resolveSessionKey("per-sender", ctx)).toBe("discord:direct:123456");
+      expect(resolveSessionKey("per-sender", ctx, "main")).toBe("discord:direct:123456");
     });
   });
 });

--- a/src/config/sessions/session-key.ts
+++ b/src/config/sessions/session-key.ts
@@ -1,7 +1,7 @@
 import type { MsgContext } from "../../auto-reply/templating.js";
 import {
   buildAgentMainSessionKey,
-  DEFAULT_AGENT_ID,
+  normalizeAgentId,
   normalizeMainKey,
 } from "../../routing/session-key.js";
 import { normalizeE164 } from "../../utils.js";
@@ -23,10 +23,15 @@ export function deriveSessionKey(scope: SessionScope, ctx: MsgContext) {
 }
 
 /**
- * Resolve the session key with a canonical direct-chat bucket (default: "main").
+ * Resolve the session key with a canonical direct-chat bucket for the given agent.
  * All non-group direct chats collapse to this bucket; groups stay isolated.
  */
-export function resolveSessionKey(scope: SessionScope, ctx: MsgContext, mainKey?: string) {
+export function resolveSessionKey(
+  scope: SessionScope,
+  ctx: MsgContext,
+  agentId: string,
+  mainKey?: string,
+) {
   const explicit = ctx.SessionKey?.trim();
   if (explicit) {
     return normalizeExplicitSessionKey(explicit, ctx);
@@ -35,14 +40,15 @@ export function resolveSessionKey(scope: SessionScope, ctx: MsgContext, mainKey?
   if (scope === "global") {
     return raw;
   }
+  const normalizedAgentId = normalizeAgentId(agentId);
   const canonicalMainKey = normalizeMainKey(mainKey);
   const canonical = buildAgentMainSessionKey({
-    agentId: DEFAULT_AGENT_ID,
+    agentId: normalizedAgentId,
     mainKey: canonicalMainKey,
   });
   const isGroup = raw.includes(":group:") || raw.includes(":channel:");
   if (!isGroup) {
     return canonical;
   }
-  return `agent:${DEFAULT_AGENT_ID}:${raw}`;
+  return `agent:${normalizedAgentId}:${raw}`;
 }

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -353,6 +353,7 @@ describe("resolveAndPersistSessionFile", () => {
       storePath: fixture.storePath(),
       sessionEntry: sessionStore[sessionKey],
       fallbackSessionFile,
+      agentId: "main",
     });
 
     expect(result.sessionFile).toBe(fallbackSessionFile);
@@ -374,6 +375,7 @@ describe("resolveAndPersistSessionFile", () => {
       sessionStore,
       storePath: fixture.storePath(),
       fallbackSessionFile,
+      agentId: "main",
     });
 
     expect(result.sessionFile).toBe(fallbackSessionFile);

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -30,11 +30,7 @@ import { withAuthKeyRetry } from "../../middleware/auth-key-retry.js";
 import { ChannelBridge } from "../../middleware/channel-bridge.js";
 import type { SessionMap } from "../../middleware/session-map.js";
 import type { AgentDeliveryResult, ChannelMessage } from "../../middleware/types.js";
-import {
-  DEFAULT_AGENT_ID,
-  buildAgentMainSessionKey,
-  normalizeAgentId,
-} from "../../routing/session-key.js";
+import { buildAgentMainSessionKey, normalizeAgentId } from "../../routing/session-key.js";
 import {
   buildSafeExternalPrompt,
   detectSuspiciousPatterns,
@@ -174,7 +170,14 @@ export async function runCronIsolatedAgentTurn(params: {
   // Use the requested agentId, falling back to the sole configured agent.
   // This ensures auth-profiles, workspace, and agentDir all resolve to the
   // correct per-agent paths (e.g. ~/.remoteclaw/agents/<agentId>/agent/).
-  const agentId = normalizedRequested ?? soleAgentId ?? DEFAULT_AGENT_ID;
+  const agentId = normalizedRequested ?? soleAgentId;
+  if (!agentId) {
+    return {
+      status: "error",
+      error:
+        "cron isolated run: cannot resolve agent id — no agent specified and no sole agent configured",
+    };
+  }
   const agentCfg: AgentDefaultsConfig = Object.assign(
     {},
     params.cfg.agents?.defaults,

--- a/src/cron/service.session-reaper-in-finally.test.ts
+++ b/src/cron/service.session-reaper-in-finally.test.ts
@@ -105,6 +105,7 @@ describe("CronService - session reaper runs in finally block (#31946)", () => {
       enqueueSystemEvent: vi.fn(),
       requestHeartbeatNow: vi.fn(),
       runIsolatedAgentJob: vi.fn().mockResolvedValue({ status: "ok", summary: "done" }),
+      soleAgentId: "main",
       resolveSessionStorePath: (agentId) => {
         const p = path.join(path.dirname(store.storePath), `${agentId}-sessions`, "sessions.json");
         resolvedPaths.push(p);

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -150,6 +150,11 @@ function assertMainSessionAgentId(
   if (!job.agentId) {
     return;
   }
+  if (!defaultAgentId) {
+    throw new Error(
+      `cron: sessionTarget "main" is only valid for the default agent, but no default agent is configured (agentId: ${job.agentId})`,
+    );
+  }
   const normalized = normalizeAgentId(job.agentId);
   const normalizedDefault = normalizeAgentId(defaultAgentId);
   if (normalized !== normalizedDefault) {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1,7 +1,6 @@
 import type { CronConfig, CronRetryOn } from "../../config/types.cron.js";
 import { isCronSystemEvent } from "../../infra/heartbeat-events-filter.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
-import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
 import { shouldEnqueueCronMainSummary } from "../heartbeat-policy.js";
 import { sweepCronRunSessions } from "../session-reaper.js";
@@ -656,11 +655,14 @@ export async function onTimer(state: CronServiceState) {
           }
         }
       }
-      // Fall back to sole/default agent only when no job-specific paths were collected
+      // Fall back to sole/default agent only when no job-specific paths were collected.
+      // If neither is available, skip the reaper sweep — no agent means no session store
+      // to sweep, and inventing a default here would reintroduce the phantom-agent pattern.
       if (storePaths.size === 0) {
-        const fallbackAgentId =
-          state.deps.soleAgentId ?? state.deps.defaultAgentId ?? DEFAULT_AGENT_ID;
-        storePaths.add(state.deps.resolveSessionStorePath(fallbackAgentId));
+        const fallbackAgentId = state.deps.soleAgentId ?? state.deps.defaultAgentId;
+        if (fallbackAgentId) {
+          storePaths.add(state.deps.resolveSessionStorePath(fallbackAgentId));
+        }
       }
     } else if (state.deps.sessionStorePath) {
       storePaths.add(state.deps.sessionStorePath);

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -20,7 +20,7 @@ import { resolveSessionTranscriptsDirForAgent } from "../../config/sessions/path
 import { sameFileIdentity } from "../../infra/file-identity.js";
 import { SafeOpenError, readLocalFileSafely } from "../../infra/fs-safe.js";
 import { isNotFoundPathError, isPathInside } from "../../infra/path-guards.js";
-import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 import { resolveUserPath } from "../../utils.js";
 import {
   ErrorCodes,
@@ -479,14 +479,6 @@ export const agentsHandlers: GatewayRequestHandlers = {
     const cfg = loadConfig();
     const rawName = String(params.name ?? "").trim();
     const agentId = normalizeAgentId(rawName);
-    if (agentId === DEFAULT_AGENT_ID) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `"${DEFAULT_AGENT_ID}" is reserved`),
-      );
-      return;
-    }
 
     if (findAgentEntryIndex(listAgentEntries(cfg), agentId) >= 0) {
       respond(
@@ -574,14 +566,6 @@ export const agentsHandlers: GatewayRequestHandlers = {
 
     const cfg = loadConfig();
     const agentId = normalizeAgentId(String(params.agentId ?? ""));
-    if (agentId === DEFAULT_AGENT_ID) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `"${DEFAULT_AGENT_ID}" cannot be deleted`),
-      );
-      return;
-    }
     if (!isConfiguredAgent(cfg, agentId)) {
       respondAgentNotFound(respond, agentId);
       return;

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -50,7 +50,7 @@ async function emitLifecycleAssistantReply(params: {
   };
   const sessionId = commandParams.sessionId ?? params.defaultSessionId;
   const runId = commandParams.runId ?? sessionId;
-  const sessionFile = resolveSessionTranscriptPath(sessionId);
+  const sessionFile = resolveSessionTranscriptPath(sessionId, "main");
   await fs.mkdir(path.dirname(sessionFile), { recursive: true });
 
   const startedAt = Date.now();

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -14,7 +14,7 @@ import {
 import { drainSystemEvents, peekSystemEvents } from "../infra/system-events.js";
 import { rawDataToString } from "../infra/ws.js";
 import { resetLogger, setLoggerOverride } from "../logging.js";
-import { DEFAULT_AGENT_ID, toAgentStoreSessionKey } from "../routing/session-key.js";
+import { toAgentStoreSessionKey } from "../routing/session-key.js";
 import { captureEnv } from "../test-utils/env.js";
 import { getDeterministicFreePortBlock } from "../test-utils/ports.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
@@ -73,7 +73,10 @@ export async function writeSessionStore(params: {
   if (!storePath) {
     throw new Error("writeSessionStore requires testState.sessionStorePath");
   }
-  const agentId = params.agentId ?? DEFAULT_AGENT_ID;
+  // Test helpers use a literal default agent id for fixtures when the caller
+  // doesn't supply one. This is NOT a phantom fallback — it's explicit test
+  // setup data.
+  const agentId = params.agentId ?? "main";
   const store: Record<string, Partial<SessionEntry>> = {};
   for (const [requestKey, entry] of Object.entries(params.entries)) {
     const rawKey = requestKey.trim();

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -842,6 +842,7 @@ describe("runHeartbeatOnce", () => {
     try {
       const cfg: RemoteClawConfig = {
         agents: {
+          list: [{ id: "main", workspace: tmpDir }],
           defaults: {
             workspace: tmpDir,
             heartbeat: { every: "5m", target: "whatsapp" },

--- a/src/infra/heartbeat-runner.transcript-prune.test.ts
+++ b/src/infra/heartbeat-runner.transcript-prune.test.ts
@@ -47,7 +47,9 @@ describe("heartbeat transcript pruning", () => {
   }) {
     await withTempTelegramHeartbeatSandbox(
       async ({ tmpDir, storePath, replySpy }) => {
-        const sessionKey = resolveMainSessionKey(undefined);
+        const sessionKey = resolveMainSessionKey({
+          agents: { list: [{ id: "main" }] },
+        });
         const transcriptPath = path.join(tmpDir, `${params.sessionId}.jsonl`);
         const originalContent = await createTranscriptWithContent(transcriptPath, params.sessionId);
         const originalSize = (await fs.stat(transcriptPath)).size;

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -85,7 +85,7 @@ describe("session cost usage", () => {
     const config = {} as unknown as RemoteClawConfig;
 
     await withStateDir(root, async () => {
-      const summary = await loadCostUsageSummary({ days: 30, config });
+      const summary = await loadCostUsageSummary({ days: 30, config, agentId: "main" });
       expect(summary.daily.length).toBe(1);
       expect(summary.totals.totalTokens).toBe(50);
       // Only explicit cost.total from log entries counts; pricing fallback no longer works
@@ -207,6 +207,7 @@ describe("session cost usage", () => {
 
     await withStateDir(root, async () => {
       const sessions = await discoverAllSessions({
+        agentId: "main",
         startMs: now - 7 * 24 * 60 * 60 * 1000,
         endMs: now - 24 * 60 * 60 * 1000,
       });

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline";
+import { listAgentIds } from "../agents/agent-scope.js";
 import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
 import { normalizeUsage } from "../agents/usage.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
@@ -303,26 +304,38 @@ export async function loadCostUsageSummary(params?: {
   const dailyMap = new Map<string, CostUsageTotals>();
   const totals = emptyTotals();
 
-  const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
-  const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
-  const files = (
-    await Promise.all(
-      entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
-        .map(async (entry) => {
-          const filePath = path.join(sessionsDir, entry.name);
-          const stats = await fs.promises.stat(filePath).catch(() => null);
-          if (!stats) {
-            return null;
-          }
-          // Include file if it was modified after our start time
-          if (stats.mtimeMs < sinceTime) {
-            return null;
-          }
-          return filePath;
-        }),
-    )
-  ).filter((filePath): filePath is string => Boolean(filePath));
+  // Resolve the list of agents to scan. Explicit agentId scopes to one agent;
+  // otherwise iterate every configured agent. Empty config + no agentId yields
+  // an empty summary (no phantom "main" fallback).
+  const agentsToScan: string[] = params?.agentId
+    ? [params.agentId]
+    : params?.config
+      ? listAgentIds(params.config)
+      : [];
+
+  const files: string[] = [];
+  for (const agentId of agentsToScan) {
+    const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
+    const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
+    const agentFiles = (
+      await Promise.all(
+        entries
+          .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+          .map(async (entry) => {
+            const filePath = path.join(sessionsDir, entry.name);
+            const stats = await fs.promises.stat(filePath).catch(() => null);
+            if (!stats) {
+              return null;
+            }
+            if (stats.mtimeMs < sinceTime) {
+              return null;
+            }
+            return filePath;
+          }),
+      )
+    ).filter((filePath): filePath is string => Boolean(filePath));
+    files.push(...agentFiles);
+  }
 
   for (const filePath of files) {
     await scanUsageFile({
@@ -371,13 +384,18 @@ export async function loadCostUsageSummary(params?: {
 /**
  * Scan all transcript files to discover sessions not in the session store.
  * Returns basic metadata for each discovered session.
+ *
+ * Requires an explicit agentId — the caller is responsible for iterating
+ * agents if the scan should span multiple configured agents (see
+ * `discoverAllSessionsForUsage` in gateway/server-methods/usage.ts for the
+ * multi-agent pattern).
  */
-export async function discoverAllSessions(params?: {
-  agentId?: string;
+export async function discoverAllSessions(params: {
+  agentId: string;
   startMs?: number;
   endMs?: number;
 }): Promise<DiscoveredSession[]> {
-  const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(params.agentId);
   const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
 
   const discovered: DiscoveredSession[] = [];

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -5,7 +5,7 @@ import { resolveMainSessionKey } from "../config/sessions.js";
 import { isCronSystemEvent } from "./heartbeat-runner.js";
 import { enqueueSystemEvent, peekSystemEvents, resetSystemEventsForTest } from "./system-events.js";
 
-const cfg = {} as unknown as RemoteClawConfig;
+const cfg = { agents: { list: [{ id: "main" }] } } as unknown as RemoteClawConfig;
 const mainKey = resolveMainSessionKey(cfg);
 
 describe("system events (session routing)", () => {

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -16,7 +16,9 @@ export {
   normalizeOptionalAccountId,
 } from "./account-id.js";
 
-export const DEFAULT_AGENT_ID = "main";
+// The main session-key segment used to construct the canonical session key for
+// direct chats (format: `agent:{agentId}:{mainKey}`). Unrelated to the phantom
+// agent concept — this is a SESSION-KEY SEGMENT, not a default agent identity.
 export const DEFAULT_MAIN_KEY = "main";
 export type SessionKeyShape = "missing" | "agent" | "legacy_or_alias" | "malformed_agent";
 
@@ -71,8 +73,20 @@ export function toAgentStoreSessionKey(params: {
 }
 
 export function resolveAgentIdFromSessionKey(sessionKey: string | undefined | null): string {
+  const agentId = resolveAgentIdFromSessionKeyOrNull(sessionKey);
+  if (agentId === null) {
+    throw new Error(
+      `Cannot resolve agent id: session key has no agent segment (got ${sessionKey ?? "null"})`,
+    );
+  }
+  return agentId;
+}
+
+export function resolveAgentIdFromSessionKeyOrNull(
+  sessionKey: string | undefined | null,
+): string | null {
   const parsed = parseAgentSessionKey(sessionKey);
-  return normalizeAgentId(parsed?.agentId ?? DEFAULT_AGENT_ID);
+  return normalizeAgentIdOrNull(parsed?.agentId);
 }
 
 export function classifySessionKeyShape(sessionKey: string | undefined | null): SessionKeyShape {
@@ -86,24 +100,31 @@ export function classifySessionKeyShape(sessionKey: string | undefined | null): 
   return raw.toLowerCase().startsWith("agent:") ? "malformed_agent" : "legacy_or_alias";
 }
 
-export function normalizeAgentId(value: string | undefined | null): string {
+export function normalizeAgentId(value: string): string {
+  const result = normalizeAgentIdOrNull(value);
+  if (result === null) {
+    throw new Error("Agent id is required and cannot be empty");
+  }
+  return result;
+}
+
+export function normalizeAgentIdOrNull(value: string | undefined | null): string | null {
   const trimmed = (value ?? "").trim();
   if (!trimmed) {
-    return DEFAULT_AGENT_ID;
+    return null;
   }
   // Keep it path-safe + shell-friendly.
   if (VALID_ID_RE.test(trimmed)) {
     return trimmed.toLowerCase();
   }
   // Best-effort fallback: collapse invalid characters to "-"
-  return (
-    trimmed
-      .toLowerCase()
-      .replace(INVALID_CHARS_RE, "-")
-      .replace(LEADING_DASH_RE, "")
-      .replace(TRAILING_DASH_RE, "")
-      .slice(0, 64) || DEFAULT_AGENT_ID
-  );
+  const sanitized = trimmed
+    .toLowerCase()
+    .replace(INVALID_CHARS_RE, "-")
+    .replace(LEADING_DASH_RE, "")
+    .replace(TRAILING_DASH_RE, "")
+    .slice(0, 64);
+  return sanitized || null;
 }
 
 export function isValidAgentId(value: string | undefined | null): boolean {
@@ -111,7 +132,7 @@ export function isValidAgentId(value: string | undefined | null): boolean {
   return Boolean(trimmed) && VALID_ID_RE.test(trimmed);
 }
 
-export function sanitizeAgentId(value: string | undefined | null): string {
+export function sanitizeAgentId(value: string): string {
   return normalizeAgentId(value);
 }
 

--- a/src/web/auto-reply/heartbeat-runner.test.ts
+++ b/src/web/auto-reply/heartbeat-runner.test.ts
@@ -45,7 +45,6 @@ vi.mock("../../config/config.js", () => ({
 
 vi.mock("../../routing/session-key.js", () => ({
   normalizeMainKey: () => null,
-  DEFAULT_AGENT_ID: "default",
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({


### PR DESCRIPTION
## Summary

Phase 3a — deep cleanup eliminating the phantom agent at the root by making `normalizeAgentId` honest about nullability and deleting the `DEFAULT_AGENT_ID` constant.

Closes #2311.

## What changed

### `src/routing/session-key.ts` — core refactor

- **Split `normalizeAgentId`** into a strict + nullable pair:
  ```ts
  normalizeAgentId(value: string): string          // throws on empty
  normalizeAgentIdOrNull(value: string | undefined | null): string | null
  ```
- **`resolveAgentIdFromSessionKey`** now **throws** when the session key has no agent segment instead of silently returning `"main"`. A new `resolveAgentIdFromSessionKeyOrNull` variant is available for callers that legitimately may not have an agent.
- **Deleted `DEFAULT_AGENT_ID`**. Its only remaining role was the phantom fallback inside `normalizeAgentId` itself.
- **Preserved `DEFAULT_MAIN_KEY`** with a clarifying comment — it is a session-key *segment*, not a default agent identity.
- Narrowed `sanitizeAgentId(value: string): string` to match.

### Reservation guards deleted

`"main"` is now a normal agent name with no special meaning:

- `src/commands/agents.commands.add.ts` — 3 call sites (non-interactive flag path + 2 wizard validators)
- `src/commands/agents.commands.delete.ts`
- `src/gateway/server-methods/agents.ts` — create + delete

### Compiler-flagged call sites migrated

Every production consumer of `DEFAULT_AGENT_ID` and every caller passing `undefined`/`null` to the old `normalizeAgentId` was migrated:

| File | Fix |
|---|---|
| `src/agents/agent-paths.ts` | Require `agentId`, keep env-var override; local literal `LEGACY_DEFAULT_AGENT_DIR_NAME` for the pre-config fallback used by auth-profile resolution. |
| `src/agents/tools/agents-list-tool.ts` | Throw if requester agent unresolvable (tool must run inside an agent session). |
| `src/agents/tools/session-status-tool.ts` | `resolveSessionEntry` takes explicit `agentId`; candidate keys built for that agent only. |
| `src/agents/subagent-spawn.ts` | Return `forbidden` if requester agent unresolvable. |
| `src/cron/service/timer.ts` | Drop reaper fallback; skip sweep when no sole/default agent is available. |
| `src/cron/isolated-agent/run.ts` | Error out if `agentId` cannot be resolved from job or sole agent. |
| `src/cron/service/jobs.ts` | `assertMainSessionAgentId` surfaces "no default agent configured" explicitly. |
| `src/config/sessions/session-key.ts` | `resolveSessionKey` now requires an `agentId` parameter. |
| `src/config/sessions/paths.ts` | `resolveAgentSessionsDir` / `resolveSessionTranscriptsDirForAgent` / `resolveStorePath` / `resolveSessionTranscriptPath` reject phantom defaults at runtime; `resolveSessionTranscriptsDir` (no-arg) removed. |
| `src/config/sessions/main-session.ts` | `resolveMainSessionKey` throws when `agents.list` is empty instead of inventing a main agent. |
| `src/config/agent-dirs.ts` | `collectReferencedAgentIds` no longer seeds an unconditional "main" entry. |
| `src/infra/session-cost-usage.ts` | `loadCostUsageSummary` iterates `listAgentIds(config)` when no `agentId` is given; `discoverAllSessions` requires explicit `agentId` (multi-agent aggregation stays in `gateway/server-methods/usage.ts`). |
| `src/commands/setup.ts` / `onboard-helpers.ts` | Create per-agent sessions dirs only when an agent is configured; `/reset` clears `.remoteclaw/agents/` instead of a phantom "main" subdirectory. |
| `src/gateway/test-helpers.server.ts` | Retain a literal `"main"` default for test fixtures (explicit, not a phantom import). |
| `src/commands/import.ts` | Rename local OpenClaw-import fallback to `LEGACY_OPENCLAW_DEFAULT_AGENT_ID` for clarity. |

Regression tests updated to pass an explicit `agentId` (or an `agents.list` entry) where the phantom used to supply one.

## Exit criteria

All satisfied:

```bash
grep -rnE "\bDEFAULT_AGENT_ID\b" src/   # only a historical comment remains
grep -rn  "DEFAULT_MAIN_KEY"     src/   # preserved — 11 legitimate references
grep -n   "export function normalizeAgentId" src/routing/session-key.ts
# → export function normalizeAgentId(value: string): string
```

`pnpm check && pnpm test` → **6448 passed, 2 skipped** locally.

## Dependencies

- Builds on #2310 (merged) and #2314 (merged).
- Unblocks #2312 (session-key migration for persisted `agent:main:*` keys) and #2315 (regression tests for the normalizer split).

## Test plan

- [x] `pnpm check` passes (format + tsgo + lint)
- [x] `pnpm test` passes (6448 / 6448)
- [ ] CI `build`, `test`, `lint`, `docs` green

Generated with [Claude Code](https://claude.com/claude-code)
