### PR TITLE
test(routing): regression coverage for normalizeAgentId split (#2315)

### DIFF
--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -178,7 +178,7 @@ describe("agents add command", () => {
     expect(outroMock).toHaveBeenCalledWith(expect.stringContaining("myagent"));
   });
 
-  it("validates the editable agent id rejects reserved and invalid values", async () => {
+  it("validates the editable agent id rejects invalid values (but not 'main')", async () => {
     const cfg = { ...baseConfigSnapshot };
     readConfigFileSnapshotMock.mockResolvedValue(cfg);
     setupChannelsMock.mockImplementation((c: unknown) => Promise.resolve(c));
@@ -215,7 +215,9 @@ describe("agents add command", () => {
 
     expect(capturedValidate).toBeDefined();
     expect(capturedValidate!("")).toBe("Required");
-    expect(capturedValidate!("main")).toContain("reserved");
+    // Regression guard for #2311: "main" is no longer a reserved agent name.
+    // The validator must accept it like any other syntactically valid id.
+    expect(capturedValidate!("main")).toBeUndefined();
     expect(capturedValidate!("!!!")).toContain("Must start");
     expect(capturedValidate!("valid-id")).toBeUndefined();
   });

--- a/src/commands/agents.commands.add.test.ts
+++ b/src/commands/agents.commands.add.test.ts
@@ -1,0 +1,170 @@
+// Regression coverage for #2311: the `"main"` agent-name reservation was
+// removed from `agentsAddCommand`. These tests exercise the non-interactive
+// flag path (CLI form) and pin the post-#2311 behavior so nothing silently
+// re-introduces a reservation check.
+//
+// The existing `agents.add.test.ts` covers the interactive wizard path and
+// validator; this file focuses on the non-interactive command-level semantics
+// that `"main"` is now a normal agent name.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RemoteClawConfig } from "../config/config.js";
+import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
+
+const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
+const writeConfigFileMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+const wizardMocks = vi.hoisted(() => ({
+  createClackPrompter: vi.fn(),
+}));
+
+const setupChannelsMock = vi.hoisted(() => vi.fn());
+const ensureWorkspaceAndSessionsMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/config.js")>()),
+  readConfigFileSnapshot: readConfigFileSnapshotMock,
+  writeConfigFile: writeConfigFileMock,
+}));
+
+vi.mock("../wizard/clack-prompter.js", () => ({
+  createClackPrompter: wizardMocks.createClackPrompter,
+}));
+
+vi.mock("./onboard-channels.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./onboard-channels.js")>()),
+  setupChannels: setupChannelsMock,
+}));
+
+vi.mock("./onboard-helpers.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./onboard-helpers.js")>()),
+  ensureWorkspaceAndSessions: ensureWorkspaceAndSessionsMock,
+}));
+
+import { agentsAddCommand } from "./agents.commands.add.js";
+
+const runtime = createTestRuntime();
+
+function lastWrittenConfig(): RemoteClawConfig {
+  const calls = writeConfigFileMock.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1]?.[0] as RemoteClawConfig;
+}
+
+describe("agents add command (non-interactive) — 'main' reservation removal", () => {
+  beforeEach(() => {
+    readConfigFileSnapshotMock.mockClear();
+    writeConfigFileMock.mockClear();
+    wizardMocks.createClackPrompter.mockClear();
+    setupChannelsMock.mockClear();
+    ensureWorkspaceAndSessionsMock.mockClear();
+    ensureWorkspaceAndSessionsMock.mockResolvedValue(undefined);
+    runtime.log.mockClear();
+    runtime.error.mockClear();
+    runtime.exit.mockClear();
+  });
+
+  it("accepts an agent named 'main' without a 'reserved' error", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({ ...baseConfigSnapshot });
+
+    await agentsAddCommand({ name: "main", workspace: "/tmp/ws-main" }, runtime, {
+      hasFlags: true,
+    });
+
+    // No error path: the command must not reject "main" as reserved.
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+    expect(writeConfigFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes a config entry with id 'main' when --name main is used", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({ ...baseConfigSnapshot });
+
+    await agentsAddCommand({ name: "main", workspace: "/tmp/ws-main" }, runtime, {
+      hasFlags: true,
+    });
+
+    const written = lastWrittenConfig();
+    const list = written.agents?.list ?? [];
+    expect(list).toHaveLength(1);
+    expect(list[0]?.id).toBe("main");
+    expect(list[0]?.name).toBe("main");
+  });
+
+  it("adds 'main' alongside an existing agent without special-casing", async () => {
+    // Simulate a pre-existing config with one non-"main" agent. Adding
+    // "main" as a second agent must produce a valid multi-agent config
+    // with both entries — no reservation or collision logic for "main".
+    const preExistingConfig: RemoteClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "assistant",
+            name: "Assistant",
+            workspace: "/tmp/ws-assistant",
+          },
+        ],
+      },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: preExistingConfig,
+    });
+
+    await agentsAddCommand({ name: "main", workspace: "/tmp/ws-main" }, runtime, {
+      hasFlags: true,
+    });
+
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+    const written = lastWrittenConfig();
+    const list = written.agents?.list ?? [];
+    const ids = list.map((entry) => entry?.id);
+    expect(ids).toContain("assistant");
+    expect(ids).toContain("main");
+    expect(list).toHaveLength(2);
+  });
+
+  it("rejects adding 'main' when an agent with id 'main' already exists", async () => {
+    // This is the normal duplicate-id rejection path — not a reservation.
+    // Covered here to show the rejection is about duplication, not about
+    // the name "main" itself being special.
+    const preExistingConfig: RemoteClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "main",
+            name: "main",
+            workspace: "/tmp/ws-main-original",
+          },
+        ],
+      },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: preExistingConfig,
+    });
+
+    await agentsAddCommand({ name: "main", workspace: "/tmp/ws-main-duplicate" }, runtime, {
+      hasFlags: true,
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("already exists"));
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(writeConfigFileMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts any other valid agent name (regression baseline)", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({ ...baseConfigSnapshot });
+
+    await agentsAddCommand({ name: "ops", workspace: "/tmp/ws-ops" }, runtime, { hasFlags: true });
+
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+    const written = lastWrittenConfig();
+    const list = written.agents?.list ?? [];
+    expect(list).toHaveLength(1);
+    expect(list[0]?.id).toBe("ops");
+    expect(list[0]?.name).toBe("ops");
+  });
+});

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -5,8 +5,13 @@ import {
   isCronSessionKey,
 } from "../sessions/session-key-utils.js";
 import {
+  buildAgentMainSessionKey,
   classifySessionKeyShape,
+  DEFAULT_MAIN_KEY,
   isValidAgentId,
+  normalizeAgentId,
+  normalizeAgentIdOrNull,
+  normalizeMainKey,
   parseAgentSessionKey,
   toAgentStoreSessionKey,
 } from "./session-key.js";
@@ -128,5 +133,153 @@ describe("isValidAgentId", () => {
     expect(isValidAgentId("Agent not found: xyz")).toBe(false);
     expect(isValidAgentId("../../../etc/passwd")).toBe(false);
     expect(isValidAgentId("a".repeat(65))).toBe(false);
+  });
+});
+
+// Regression coverage for #2311: normalizeAgentId split into strict + nullable
+// variants, DEFAULT_AGENT_ID deleted. These tests pin the post-split semantics
+// so the phantom-agent fallback cannot silently return.
+describe("normalizeAgentId (strict)", () => {
+  it("returns the normalized form for a valid id", () => {
+    expect(normalizeAgentId("valid-id")).toBe("valid-id");
+    expect(normalizeAgentId("my_agent01")).toBe("my_agent01");
+  });
+
+  it("throws on an empty string", () => {
+    expect(() => normalizeAgentId("")).toThrow();
+  });
+
+  it("throws on a whitespace-only string", () => {
+    expect(() => normalizeAgentId("   ")).toThrow();
+    expect(() => normalizeAgentId("\t\n")).toThrow();
+  });
+
+  it("lowers uppercase input", () => {
+    expect(normalizeAgentId("UPPER")).toBe("upper");
+    expect(normalizeAgentId("MixedCase")).toBe("mixedcase");
+  });
+
+  it("collapses invalid characters to '-' when the input is otherwise salvageable", () => {
+    expect(normalizeAgentId("INVALID!")).toBe("invalid");
+    expect(normalizeAgentId("foo bar")).toBe("foo-bar");
+    expect(normalizeAgentId("foo@bar!baz")).toBe("foo-bar-baz");
+  });
+
+  it("strips leading and trailing dashes from the normalized form", () => {
+    expect(normalizeAgentId("---valid---")).toBe("valid");
+    expect(normalizeAgentId("!!!valid!!!")).toBe("valid");
+  });
+
+  it("truncates the normalized form to 64 characters", () => {
+    const long = "a".repeat(100);
+    expect(normalizeAgentId(long)).toBe("a".repeat(64));
+  });
+
+  it("throws when the input normalizes to an empty string (all-invalid)", () => {
+    // Post-#2311 semantics: there is no DEFAULT_AGENT_ID fallback anymore.
+    // An input like "!!!" previously returned the phantom default; the strict
+    // variant must now throw because the result would be empty.
+    expect(() => normalizeAgentId("!!!")).toThrow();
+    expect(() => normalizeAgentId("---")).toThrow();
+  });
+});
+
+describe("normalizeAgentIdOrNull", () => {
+  it("returns null for undefined", () => {
+    expect(normalizeAgentIdOrNull(undefined)).toBeNull();
+  });
+
+  it("returns null for null", () => {
+    expect(normalizeAgentIdOrNull(null)).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(normalizeAgentIdOrNull("")).toBeNull();
+  });
+
+  it("returns null for a whitespace-only string", () => {
+    expect(normalizeAgentIdOrNull("   ")).toBeNull();
+    expect(normalizeAgentIdOrNull("\t\n")).toBeNull();
+  });
+
+  it("returns the normalized string for a valid input", () => {
+    expect(normalizeAgentIdOrNull("valid")).toBe("valid");
+    expect(normalizeAgentIdOrNull("UPPER")).toBe("upper");
+  });
+
+  it("returns a sanitized string (not null) for a non-empty input with invalid chars", () => {
+    expect(normalizeAgentIdOrNull("INVALID!")).toBe("invalid");
+    expect(normalizeAgentIdOrNull("foo bar")).toBe("foo-bar");
+  });
+
+  it("returns null when sanitization collapses to an empty string", () => {
+    expect(normalizeAgentIdOrNull("!!!")).toBeNull();
+    expect(normalizeAgentIdOrNull("---")).toBeNull();
+  });
+});
+
+// Regression guard for DEFAULT_MAIN_KEY.
+//
+// IMPORTANT: Do NOT delete DEFAULT_MAIN_KEY alongside DEFAULT_AGENT_ID.
+//
+// DEFAULT_AGENT_ID (the phantom default agent identity) was deleted in #2311.
+// DEFAULT_MAIN_KEY (the session-key segment `"main"` in `agent:{id}:{mainKey}`)
+// was intentionally preserved. Both constants used to live adjacent to each
+// other in this file and both equal the literal string `"main"`, which makes
+// them easy to conflate. They are different concepts:
+//
+//   - DEFAULT_AGENT_ID: the deleted phantom default agent. Gone.
+//   - DEFAULT_MAIN_KEY: the default main-session segment used to build the
+//     canonical session key for direct chats. Still needed.
+//
+// A future contributor seeing `DEFAULT_MAIN_KEY = "main"` next to recently
+// deleted `DEFAULT_AGENT_ID = "main"` history may assume both were phantom
+// defaults and delete DEFAULT_MAIN_KEY as a follow-up cleanup. This test
+// exists to make that mistake loud: deleting DEFAULT_MAIN_KEY will fail here
+// before it can break session-key construction across the runtime.
+describe("DEFAULT_MAIN_KEY preservation (do not delete — see comment)", () => {
+  it("is exported as the literal 'main'", () => {
+    expect(DEFAULT_MAIN_KEY).toBe("main");
+  });
+
+  it("is used as the default mainKey by buildAgentMainSessionKey", () => {
+    expect(buildAgentMainSessionKey({ agentId: "ops" })).toBe("agent:ops:main");
+    expect(buildAgentMainSessionKey({ agentId: "ops" })).toBe(`agent:ops:${DEFAULT_MAIN_KEY}`);
+  });
+
+  it("can be overridden by an explicit mainKey parameter", () => {
+    expect(buildAgentMainSessionKey({ agentId: "ops", mainKey: "primary" })).toBe(
+      "agent:ops:primary",
+    );
+  });
+
+  it("normalizes the agent id when building a main session key", () => {
+    expect(buildAgentMainSessionKey({ agentId: "OPS" })).toBe("agent:ops:main");
+  });
+
+  it("is the fallback when normalizeMainKey receives undefined or empty input", () => {
+    expect(normalizeMainKey(undefined)).toBe(DEFAULT_MAIN_KEY);
+    expect(normalizeMainKey(null)).toBe(DEFAULT_MAIN_KEY);
+    expect(normalizeMainKey("")).toBe(DEFAULT_MAIN_KEY);
+    expect(normalizeMainKey("   ")).toBe(DEFAULT_MAIN_KEY);
+  });
+
+  it("drives the main-key collapse branch in toAgentStoreSessionKey", () => {
+    // When the caller passes a raw requestKey that equals DEFAULT_MAIN_KEY
+    // (case-insensitive), toAgentStoreSessionKey must produce the canonical
+    // `agent:{id}:main` form via buildAgentMainSessionKey — that branch is
+    // what relies on DEFAULT_MAIN_KEY surviving.
+    expect(
+      toAgentStoreSessionKey({
+        agentId: "ops",
+        requestKey: DEFAULT_MAIN_KEY,
+      }),
+    ).toBe("agent:ops:main");
+    expect(
+      toAgentStoreSessionKey({
+        agentId: "ops",
+        requestKey: "MAIN",
+      }),
+    ).toBe("agent:ops:main");
   });
 });


### PR DESCRIPTION
## Summary

Closes #2315. Pin the post-#2311 semantics of `normalizeAgentId` / `normalizeAgentIdOrNull` and guard `DEFAULT_MAIN_KEY` from being deleted alongside `DEFAULT_AGENT_ID` (both formerly equal to `"main"` — easy to conflate).

Three files touched:

### `src/routing/session-key.test.ts` (+21 tests)

- **`normalizeAgentId` (strict, 8 tests)** — pins the throw-on-empty-or-empty-result contract:
  - valid input returns normalized form
  - empty / whitespace-only input throws
  - uppercase is lowered
  - invalid chars collapse to `-`
  - leading/trailing dashes stripped
  - 64-char truncation
  - all-invalid input (`"!!!"`, `"---"`) now throws (pre-#2311 behavior returned the phantom `DEFAULT_AGENT_ID`)
- **`normalizeAgentIdOrNull` (7 tests)** — pins the nullable variant:
  - `undefined` / `null` / empty / whitespace-only return `null`
  - valid input returns normalized string
  - salvageable invalid-char inputs return a non-null sanitized string
  - unsalvageable inputs return `null`
- **`DEFAULT_MAIN_KEY` preservation (6 tests)** — carries a prominent explanatory comment (per #2315 notes for implementers):
  > Do NOT delete DEFAULT_MAIN_KEY alongside DEFAULT_AGENT_ID. A future contributor seeing `DEFAULT_MAIN_KEY = "main"` next to recently deleted `DEFAULT_AGENT_ID = "main"` may conflate them. The test exists to make that mistake loud.
  - `DEFAULT_MAIN_KEY === "main"`
  - `buildAgentMainSessionKey({ agentId })` uses it as default
  - `buildAgentMainSessionKey({ agentId, mainKey })` override works
  - `normalizeMainKey(undefined/null/"")` falls back to it
  - `toAgentStoreSessionKey` collapses raw `"main"` / `"MAIN"` request keys via it

### `src/commands/agents.commands.add.test.ts` (new file, +5 tests)

Exercises the non-interactive flag path of `agentsAddCommand` to pin the `"main"`-is-no-longer-reserved semantic at the command level:

- adding `"main"` succeeds without a reserved error
- the resulting config has an agent entry with `id: "main"`
- `"main"` can be added alongside an existing non-`"main"` agent (multi-agent, no special-casing)
- adding `"main"` when an agent `"main"` already exists still rejects — via the normal duplicate-id path, not via any reservation
- regression baseline: any other valid name still works

Uses the same mock setup pattern as the existing `agents.add.test.ts` (`vi.hoisted` mocks for `config/config.js`, `wizard/clack-prompter.js`, `onboard-channels.js`, `onboard-helpers.js`).

### `src/commands/agents.add.test.ts` (stale-test fix)

The existing interactive-wizard validator test (`validates the editable agent id rejects reserved and invalid values`) still asserted `expect(capturedValidate!("main")).toContain("reserved")`. After #2311 the validator no longer returns anything for `"main"`, so that assertion was broken on main — but `src/commands/**` is excluded from the default `pnpm test` unit lane so it never surfaced in CI.

Fixed the assertion to `.toBeUndefined()` and retitled the test to `rejects invalid values (but not 'main')`. Added an inline regression-guard comment explaining why `"main"` must now be accepted.

## Exit criterion from #2315

```bash
# Strict normalizer signature present
$ grep -nE "export function normalizeAgentId\(value: string\): string" src/routing/session-key.ts
103:export function normalizeAgentId(value: string): string {

# Nullable variant present
$ grep -nE "export function normalizeAgentIdOrNull" src/routing/session-key.ts
111:export function normalizeAgentIdOrNull(value: string | undefined | null): string | null {

# DEFAULT_MAIN_KEY preserved
$ grep -n "export const DEFAULT_MAIN_KEY" src/routing/session-key.ts
22:export const DEFAULT_MAIN_KEY = "main";

# Targeted tests pass
$ pnpm test -- --run src/routing/session-key.test.ts src/commands/agents.commands.add.test.ts src/commands/agents.add.test.ts
Test Files  3 passed (3)
     Tests  51 passed (51)
```

The `DEFAULT_AGENT_ID` word-boundary grep returns only **comments** (both pre-existing and newly added in these regression tests) — no symbol remains. #2311 merged with the same "only historical comments remain" state.

## Notes for reviewers

- **CI lane coverage**: The 21 `session-key.test.ts` additions run in CI's default lane (`src/routing/` is not excluded). The 5 `agents.commands.add.test.ts` tests and the `agents.add.test.ts` fix are in `src/commands/` which `vitest.unit.config.ts` excludes from the default lane — they run locally via `pnpm test -- --run <files>` and are a second line of defense for when that exclude is eventually lifted. The normalizer contract (which is the load-bearing post-#2311 behavior) is fully covered by the routing-side tests.
- **Parallel PR coordination**: #2312 (session-key migration + test fixture sweep) is running in parallel and may touch these test files during its sweep. I kept the `agents.add.test.ts` change minimal (single assertion + title + comment) to reduce the conflict surface. Happy to rebase if needed.
- **The `DEFAULT_MAIN_KEY` regression-guard test is the critical one** — it's the explicit safeguard #2315 calls out. The comment is deliberately verbose because the risk is real and the two constants are syntactically identical.

## Test plan

- [x] `pnpm check` passes (format + tsgo + lint)
- [x] `pnpm test` passes (full suite, 6469 tests)
- [x] Targeted exit-criterion command passes (51 tests across 3 files)
- [ ] CI `build`, `test`, `lint`, `docs` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)