### PR TITLE
gut(auto-reply): remove dead thinking-level resolution plumbing (#2334)

### DIFF
--- a/extensions/mattermost/src/mattermost/model-picker.ts
+++ b/extensions/mattermost/src/mattermost/model-picker.ts
@@ -1,9 +1,6 @@
 import { createHash } from "node:crypto";
 import {
-  loadSessionStore,
   normalizeProviderId,
-  resolveStorePath,
-  resolveStoredModelOverride,
   type ModelsProviderData,
   type RemoteClawConfig,
 } from "remoteclaw/plugin-sdk/mattermost";
@@ -220,28 +217,8 @@ export function resolveMattermostModelPickerCurrentModel(params: {
   data: ModelsProviderData;
   skipCache?: boolean;
 }): string {
-  const fallback = `${params.data.resolvedDefault.provider}/${params.data.resolvedDefault.model}`;
-  try {
-    const storePath = resolveStorePath(params.cfg.session?.store, {
-      agentId: params.route.agentId,
-    });
-    const sessionStore = params.skipCache
-      ? loadSessionStore(storePath, { skipCache: true })
-      : loadSessionStore(storePath);
-    const sessionEntry = sessionStore[params.route.sessionKey];
-    const override = resolveStoredModelOverride({
-      sessionEntry,
-      sessionStore,
-      sessionKey: params.route.sessionKey,
-    });
-    if (!override?.model) {
-      return fallback;
-    }
-    const provider = (override.provider || params.data.resolvedDefault.provider).trim();
-    return provider ? `${provider}/${override.model}` : fallback;
-  } catch {
-    return fallback;
-  }
+  // Model override resolution gutted in RemoteClaw fork — CLI runtimes own model state.
+  return `${params.data.resolvedDefault.provider}/${params.data.resolvedDefault.model}`;
 }
 
 export function renderMattermostModelSummaryView(params: {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -152,4 +152,3 @@ export function resolveDefaultModelForAgent(params: {
 export const resolveThinkingDefault = (..._args: unknown[]) => undefined as any;
 export const getModelRefStatus = (..._args: unknown[]) => undefined as any;
 export const inferUniqueProviderFromConfiguredModels = (..._args: unknown[]) => undefined as any;
-export const createModelSelectionState = (..._args: unknown[]) => ({}) as any;

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -47,7 +47,6 @@ export async function buildStatusReply(params: {
   resolvedThinkLevel?: unknown;
   resolvedReasoningLevel?: unknown;
   resolvedElevatedLevel?: unknown;
-  resolveDefaultThinkingLevel?: (...args: unknown[]) => unknown;
   mediaDecisions?: unknown;
 }): Promise<ReplyPayload | undefined> {
   const {

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -49,7 +49,6 @@ export type HandleCommandsParams = {
   resolvedVerboseLevel: VerboseLevel;
   resolvedReasoningLevel: ReasoningLevel;
   resolvedElevatedLevel?: ElevatedLevel;
-  resolveDefaultThinkingLevel: () => Promise<ThinkLevel | undefined>;
   provider: string;
   model: string;
   contextTokens: number;

--- a/src/auto-reply/reply/commands.test-harness.ts
+++ b/src/auto-reply/reply/commands.test-harness.ts
@@ -44,7 +44,6 @@ export function buildCommandTestParams(
     isGroup: false,
     elevated: { enabled: false, allowed: false, failures: [] },
     resolvedReasoningLevel: "off" as const,
-    resolveDefaultThinkingLevel: () => Promise.resolve(undefined),
     contextTokens: 0,
   };
   return params;

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -298,7 +298,6 @@ function buildPolicyParams(
     defaultGroupActivation: () => "mention",
     resolvedVerboseLevel: "off",
     resolvedReasoningLevel: "off",
-    resolveDefaultThinkingLevel: async () => undefined,
     provider: "telegram",
     model: "test-model",
     contextTokens: 0,

--- a/src/auto-reply/reply/directive-handling.fast-lane.ts
+++ b/src/auto-reply/reply/directive-handling.fast-lane.ts
@@ -26,7 +26,6 @@ export async function applyInlineDirectivesFastLane(
     allowedModelCatalog,
     resetModelOverride,
     formatModelSwitchEvent,
-    modelState: _modelState,
   } = params;
 
   let { provider, model } = params;

--- a/src/auto-reply/reply/directive-handling.params.ts
+++ b/src/auto-reply/reply/directive-handling.params.ts
@@ -35,9 +35,4 @@ export type ApplyInlineDirectivesFastLaneParams = HandleDirectiveOnlyCoreParams 
   agentId?: string;
   isGroup: boolean;
   agentCfg?: NonNullable<RemoteClawConfig["agents"]>["defaults"];
-  modelState: {
-    allowedModelKeys: Set<string>;
-    allowedModelCatalog: Array<{ id: string; provider: string }>;
-    resetModelOverride: boolean;
-  };
 };

--- a/src/auto-reply/reply/directive-handling.ts
+++ b/src/auto-reply/reply/directive-handling.ts
@@ -17,7 +17,6 @@ export const resolveDefaultModel = (
   allowedModelKeys: Set<string>;
   allowedModelCatalog: { id: string; provider: string }[];
   resetModelOverride: boolean;
-  resolveDefaultThinkingLevel?: () => string | undefined;
 } => ({
   provider: "default",
   model: "default",

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -11,7 +11,6 @@ import {
   persistInlineDirectives,
 } from "./directive-handling.js";
 import { clearInlineDirectives } from "./get-reply-directives-utils.js";
-import type { createModelSelectionState } from "./get-reply-directives.js";
 import type { TypingController } from "./typing.js";
 
 type AgentDefaults = NonNullable<RemoteClawConfig["agents"]>["defaults"];
@@ -51,7 +50,6 @@ export async function applyInlineDirectiveOverrides(params: {
   runtimeId: string;
   provider: string;
   model: string;
-  modelState: Awaited<ReturnType<typeof createModelSelectionState>>;
   initialModelLabel: string;
   formatModelSwitchEvent: (label: string, alias?: string) => string;
   defaultActivation: () => ReturnType<
@@ -80,7 +78,6 @@ export async function applyInlineDirectiveOverrides(params: {
     command,
     messageProviderKey,
     runtimeId,
-    modelState,
     initialModelLabel,
     formatModelSwitchEvent,
     defaultActivation,
@@ -88,14 +85,14 @@ export async function applyInlineDirectiveOverrides(params: {
   } = params;
   let { directives } = params;
   let { provider, model } = params;
-  // Model selection gutted in RemoteClaw — derive from runtimeId.
+  // Model selection gutted in RemoteClaw — derive from runtimeId and pass empty lookups.
   const defaultProvider = runtimeId;
   const defaultModel = "default";
   const aliasIndex = new Map<string, { provider: string; model: string }>();
   const directiveModelState = {
-    allowedModelKeys: modelState.allowedModelKeys,
-    allowedModelCatalog: modelState.allowedModelCatalog,
-    resetModelOverride: modelState.resetModelOverride,
+    allowedModelKeys: new Set<string>(),
+    allowedModelCatalog: [] as Array<{ id: string; provider: string }>,
+    resetModelOverride: false,
   };
   const createDirectiveHandlingBase = () => ({
     cfg,
@@ -194,9 +191,6 @@ export async function applyInlineDirectiveOverrides(params: {
       initialModelLabel,
       formatModelSwitchEvent,
       agentCfg,
-      modelState: {
-        ...directiveModelState,
-      },
     });
     directiveAck = fastLane.directiveAck;
     provider = fastLane.provider;

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -16,15 +16,6 @@ import { stripInlineStatus } from "./reply-inline.js";
 // Gutted in RemoteClaw fork — CLI runtimes manage their own model/sandbox/elevated state
 type ExecToolDefaults = Record<string, unknown>;
 
-export const createModelSelectionState = (..._args: unknown[]) => ({
-  provider: "cli" as string,
-  model: "default" as string,
-  aliasIndex: new Map<string, { provider: string; model: string }>(),
-  allowedModelKeys: new Set<string>(),
-  allowedModelCatalog: [] as Array<{ id: string; provider: string }>,
-  resetModelOverride: false,
-});
-
 import type { TypingController } from "./typing.js";
 
 type AgentDefaults = NonNullable<RemoteClawConfig["agents"]>["defaults"];
@@ -54,7 +45,6 @@ export type ReplyDirectiveContinuation = {
   resolvedBlockStreamingBreak: "text_end" | "message_end";
   provider: string;
   model: string;
-  modelState: Awaited<ReturnType<typeof createModelSelectionState>>;
   inlineStatusRequested: boolean;
   directiveAck?: ReplyPayload;
   perMessageQueueMode?: InlineDirectives["queueMode"];
@@ -68,7 +58,6 @@ export type ReplyDirectiveContinuation = {
   resolvedReasoningLevel?: ReasoningLevel;
   resolvedElevatedLevel?: ElevatedLevel;
   contextTokens?: number;
-  resolveDefaultThinkingLevel?: () => ThinkLevel | undefined;
 };
 
 function resolveExecOverrides(_params: {
@@ -298,22 +287,6 @@ export async function resolveReplyDirectives(params: {
     ? resolveBlockStreamingChunking(cfg, sessionCtx.Provider, sessionCtx.AccountId)
     : undefined;
 
-  const modelState = createModelSelectionState({
-    cfg,
-    agentCfg,
-    sessionEntry,
-    sessionStore,
-    sessionKey,
-    parentSessionKey: ctx.ParentSessionKey,
-    storePath,
-    defaultProvider,
-    defaultModel,
-    provider,
-    model,
-  });
-  provider = modelState.provider;
-  model = modelState.model;
-
   const initialModelLabel = `${provider}/${model}`;
   const formatModelSwitchEvent = (label: string, alias?: string) =>
     alias ? `Model switched to ${alias} (${label}).` : `Model switched to ${label}.`;
@@ -341,7 +314,6 @@ export async function resolveReplyDirectives(params: {
     runtimeId: params.runtimeId ?? defaultProvider,
     provider,
     model,
-    modelState,
     initialModelLabel,
     formatModelSwitchEvent,
     defaultActivation: () => defaultActivation,
@@ -376,7 +348,6 @@ export async function resolveReplyDirectives(params: {
       resolvedBlockStreamingBreak,
       provider,
       model,
-      modelState,
       inlineStatusRequested,
       directiveAck,
       perMessageQueueMode,

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -74,7 +74,6 @@ const createHandleInlineActionsInput = (params: {
     resolvedVerboseLevel: undefined,
     resolvedReasoningLevel: "off",
     resolvedElevatedLevel: "off",
-    resolveDefaultThinkingLevel: async () => undefined,
     provider: "openai",
     model: "gpt-4o-mini",
     contextTokens: 0,

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -26,7 +26,6 @@ import { getAbortMemory, isAbortRequestText } from "./abort.js";
 import { buildStatusReply, handleCommands } from "./commands.js";
 import type { InlineDirectives } from "./directive-handling.js";
 import { isDirectiveOnly } from "./directive-handling.js";
-import type { createModelSelectionState } from "./model-selection.js";
 import { extractInlineSimpleCommand } from "./reply-inline.js";
 import type { TypingController } from "./typing.js";
 
@@ -107,9 +106,6 @@ export async function handleInlineActions(params: {
   resolvedVerboseLevel: VerboseLevel | undefined;
   resolvedReasoningLevel: ReasoningLevel;
   resolvedElevatedLevel: ElevatedLevel;
-  resolveDefaultThinkingLevel: Awaited<
-    ReturnType<typeof createModelSelectionState>
-  >["resolveDefaultThinkingLevel"];
   provider: string;
   model: string;
   contextTokens: number;
@@ -146,7 +142,6 @@ export async function handleInlineActions(params: {
     resolvedVerboseLevel,
     resolvedReasoningLevel,
     resolvedElevatedLevel,
-    resolveDefaultThinkingLevel,
     provider,
     model,
     contextTokens,
@@ -319,7 +314,6 @@ export async function handleInlineActions(params: {
       resolvedVerboseLevel: resolvedVerboseLevel ?? "off",
       resolvedReasoningLevel,
       resolvedElevatedLevel,
-      resolveDefaultThinkingLevel,
       isGroup,
       defaultGroupActivation: defaultActivation,
       mediaDecisions: ctx.MediaUnderstandingDecisions,
@@ -356,7 +350,6 @@ export async function handleInlineActions(params: {
       resolvedVerboseLevel: resolvedVerboseLevel ?? "off",
       resolvedReasoningLevel,
       resolvedElevatedLevel,
-      resolveDefaultThinkingLevel,
       provider,
       model,
       contextTokens,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -134,9 +134,6 @@ function baseParams(
     elevatedAllowed: false,
     blockStreamingEnabled: false,
     resolvedBlockStreamingBreak: "message_end",
-    modelState: {
-      resolveDefaultThinkingLevel: async () => "medium",
-    } as never,
     provider: "anthropic",
     model: "claude-opus-4-1",
     typing: {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -13,7 +13,6 @@ import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
   type SessionEntry,
-  updateSessionStore,
 } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
@@ -24,10 +23,7 @@ import { buildInboundMediaNote } from "../media-note.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import {
   type ElevatedLevel,
-  formatXHighModelHint,
-  normalizeThinkLevel,
   type ReasoningLevel,
-  supportsXHighThinking,
   type ThinkLevel,
   type VerboseLevel,
 } from "../thinking.js";
@@ -39,7 +35,6 @@ import type { buildCommandContext } from "./commands.js";
 import type { InlineDirectives } from "./directive-handling.js";
 import { buildGroupChatContext, buildGroupIntro } from "./groups.js";
 import { buildInboundMetaSystemPrompt, buildInboundUserContextPrefix } from "./inbound-meta.js";
-import type { createModelSelectionState } from "./model-selection.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { resolveQueueSettings } from "./queue.js";
 import { routeReply } from "./route-reply.js";
@@ -152,7 +147,6 @@ type RunPreparedReplyParams = {
     flushOnParagraph?: boolean;
   };
   resolvedBlockStreamingBreak: "text_end" | "message_end";
-  modelState: Awaited<ReturnType<typeof createModelSelectionState>>;
   provider: string;
   model: string;
   perMessageQueueMode?: InlineDirectives["queueMode"];
@@ -193,14 +187,12 @@ export async function runPreparedReply(
     command,
     commandSource,
     allowTextCommands,
-    directives,
     defaultActivation,
     elevatedEnabled,
     elevatedAllowed,
     blockStreamingEnabled,
     blockReplyChunking,
     resolvedBlockStreamingBreak,
-    modelState,
     provider,
     model,
     perMessageQueueMode,
@@ -332,21 +324,9 @@ export async function runPreparedReply(
   });
   const isGroupSession = sessionEntry?.chatType === "group" || sessionEntry?.chatType === "channel";
   const isMainSession = !isGroupSession && sessionKey === normalizeMainKey(sessionCfg?.mainKey);
-  // Extract first-token think hint from the user body BEFORE prepending system events.
-  // If done after, the System: prefix becomes parts[0] and silently shadows any
-  // low|medium|high shorthand the user typed.
-  if (!resolvedThinkLevel && prefixedBodyBase) {
-    const parts = prefixedBodyBase.split(/\s+/);
-    const maybeLevel = normalizeThinkLevel(parts[0]);
-    if (maybeLevel && (maybeLevel !== "xhigh" || supportsXHighThinking(provider, model))) {
-      resolvedThinkLevel = maybeLevel;
-      prefixedBodyBase = parts.slice(1).join(" ").trim();
-    }
-  }
   // Drain system events once, then prepend to each path's body independently.
   // The queue/steer path uses effectiveBaseBody (unstripped, no session hints) to match
-  // main's pre-PR behavior; the immediate-run path uses prefixedBodyBase (post-hints,
-  // post-think-hint-strip) so the run sees the cleaned-up body.
+  // main's pre-PR behavior; the immediate-run path uses prefixedBodyBase (post-hints).
   const eventsBlock = await drainFormattedSystemEvents({
     cfg,
     sessionKey,
@@ -386,29 +366,6 @@ export async function runPreparedReply(
   let prefixedCommandBody = mediaNote
     ? [mediaNote, mediaReplyHint, prefixedBody ?? ""].filter(Boolean).join("\n").trim()
     : prefixedBody;
-  if (!resolvedThinkLevel) {
-    resolvedThinkLevel = await modelState.resolveDefaultThinkingLevel();
-  }
-  if (resolvedThinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
-    const explicitThink = directives.hasThinkDirective && directives.thinkLevel !== undefined;
-    if (explicitThink) {
-      typing.cleanup();
-      return {
-        text: `Thinking level "xhigh" is only supported for ${formatXHighModelHint()}. Use /think high or switch to one of those models.`,
-      };
-    }
-    resolvedThinkLevel = "high";
-    if (sessionEntry && sessionStore && sessionKey && sessionEntry.thinkingLevel === "xhigh") {
-      sessionEntry.thinkingLevel = "high";
-      sessionEntry.updatedAt = Date.now();
-      sessionStore[sessionKey] = sessionEntry;
-      if (storePath) {
-        await updateSessionStore(storePath, (store) => {
-          store[sessionKey] = sessionEntry;
-        });
-      }
-    }
-  }
   if (resetTriggered && command.isAuthorizedSender) {
     await sendResetSessionNotice({
       ctx,

--- a/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
@@ -87,9 +87,6 @@ function createContinueDirectivesResult(resetHookTriggered: boolean) {
       resolvedBlockStreamingBreak: undefined,
       provider: "openai",
       model: "gpt-4o-mini",
-      modelState: {
-        resolveDefaultThinkingLevel: async () => undefined,
-      },
       contextTokens: 0,
       inlineStatusRequested: false,
       directiveAck: undefined,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -274,7 +274,6 @@ export async function getReplyFromConfig(
     resolvedBlockStreamingBreak,
     provider: resolvedProvider,
     model: resolvedModel,
-    modelState,
     contextTokens,
     inlineStatusRequested,
     directiveAck,
@@ -335,9 +334,6 @@ export async function getReplyFromConfig(
     resolvedVerboseLevel,
     resolvedReasoningLevel: resolvedReasoningLevel ?? "off",
     resolvedElevatedLevel: resolvedElevatedLevel ?? "off",
-    resolveDefaultThinkingLevel:
-      (modelState as { resolveDefaultThinkingLevel?: () => string | undefined })
-        .resolveDefaultThinkingLevel ?? (() => undefined),
     provider,
     model,
     contextTokens: contextTokens ?? 0,
@@ -385,7 +381,6 @@ export async function getReplyFromConfig(
     blockStreamingEnabled,
     blockReplyChunking,
     resolvedBlockStreamingBreak,
-    modelState,
     provider,
     model,
     perMessageQueueMode,

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -1,4 +1,0 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-// Gutted in RemoteClaw fork (Middleware Boundary Principle)
-export const resolveStoredModelOverride = (..._args: unknown[]) => undefined as any;
-export const createModelSelectionState = (..._args: unknown[]) => ({}) as any;

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -37,7 +37,6 @@ import {
   resolveCommandArgMenu,
   serializeCommandArgs,
 } from "../../auto-reply/commands-registry.js";
-import { resolveStoredModelOverride } from "../../auto-reply/reply/model-selection.js";
 import { dispatchReplyWithDispatcher } from "../../auto-reply/reply/provider-dispatcher.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { resolveCommandAuthorizedFromAuthorizers } from "../../channels/command-gating.js";
@@ -46,7 +45,6 @@ import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import type { RemoteClawConfig, loadConfig } from "../../config/config.js";
 import { isDangerousNameMatchingEnabled } from "../../config/dangerous-name-matching.js";
 import { resolveOpenProviderRuntimeGroupPolicy } from "../../config/runtime-group-policy.js";
-import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
@@ -472,32 +470,11 @@ function resolveDiscordModelPickerCurrentModel(params: {
   route: ResolvedAgentRoute;
   data: Awaited<ReturnType<typeof loadDiscordModelPickerData>>;
 }): string {
-  const fallback = buildDiscordModelPickerCurrentModel(
+  // Model override resolution gutted in RemoteClaw fork — CLI runtimes own model state.
+  return buildDiscordModelPickerCurrentModel(
     params.data.resolvedDefault.provider,
     params.data.resolvedDefault.model,
   );
-  try {
-    const storePath = resolveStorePath(params.cfg.session?.store, {
-      agentId: params.route.agentId,
-    });
-    const sessionStore = loadSessionStore(storePath, { skipCache: true });
-    const sessionEntry = sessionStore[params.route.sessionKey];
-    const override = resolveStoredModelOverride({
-      sessionEntry,
-      sessionStore,
-      sessionKey: params.route.sessionKey,
-    });
-    if (!override?.model) {
-      return fallback;
-    }
-    const provider = (override.provider || params.data.resolvedDefault.provider).trim();
-    if (!provider) {
-      return fallback;
-    }
-    return `${provider}/${override.model}`;
-  } catch {
-    return fallback;
-  }
 }
 
 async function replyWithDiscordModelPickerProviders(params: {

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -20,7 +20,6 @@ export {
   buildModelsProviderData,
   type ModelsProviderData,
 } from "../auto-reply/reply/commands-models.js";
-export { resolveStoredModelOverride } from "../auto-reply/reply/model-selection.js";
 export {
   deleteAccountFromConfigSection,
   setAccountEnabledInConfigSection,


### PR DESCRIPTION
## Summary

Fix silent first-turn message crash on every channel (`modelState.resolveDefaultThinkingLevel is not a function`) by removing the dead call site and adjacent thinking-level / model-selection plumbing that prior gut sweeps had stubbed but never swept.

Closes #2334 (scope-bounded — deferred items tracked below).

## Root cause recap

- `createModelSelectionState` was stripped of `resolveDefaultThinkingLevel` in prior gut sweeps, but `runPreparedReply` still called it on the `modelState` object.
- TypeScript was blind because `src/auto-reply/reply/model-selection.ts` was a stub returning `({}) as any`, and `get-reply-run.ts` imported the type from there (not from the real factory in `get-reply-directives.ts`).
- Every test file fabricated `modelState` with an `async () => …` hook, so unit tests never exercised the production object shape. The only test that touched `runPreparedReply` hardcoded `resolvedThinkLevel: "high"`, so the `if (!resolvedThinkLevel)` branch that contained the crashing call was never entered.
- The error surfaces loudly in Slack's inbound debounce flush onError (`src/slack/monitor/message-handler.ts:172`) but fires on every channel that routes through `runPreparedReply` for a first-turn message without a `/think` directive.

See #2334 for the full five-shield test-layer analysis.

## What's changed

### Core deletions

- **`runPreparedReply`** (`src/auto-reply/reply/get-reply-run.ts`):
  - Delete the `modelState.resolveDefaultThinkingLevel()` call (the bug).
  - Delete the XHigh gating block and the `sessionEntry.thinkingLevel = "high"` downgrade mutation.
  - Delete the body-token auto-detect (`normalizeThinkLevel(parts[0])`) that parsed low/medium/high/xhigh from message prefixes.
  - Delete `modelState` param + `updateSessionStore` + unused `directives` destructure + XHigh helper imports.
- **`modelState` threading** across `get-reply.ts`, `get-reply-inline-actions.ts`, `get-reply-directives.ts`, `get-reply-directives-apply.ts`, `directive-handling.fast-lane.ts`, `directive-handling.params.ts`: removed the parameter, fields, and factory wiring. `get-reply-directives-apply.ts` now inlines empty `allowedModelKeys` / `allowedModelCatalog` / `resetModelOverride` defaults where downstream directive handlers still read them.
- **`resolveDefaultThinkingLevel`** removed from type declarations in `commands-types.ts`, `commands-status.ts`, `directive-handling.ts`.
- **Stub files**:
  - Delete `src/auto-reply/reply/model-selection.ts` entirely.
  - Delete orphan `createModelSelectionState` stub line from `src/agents/model-selection.ts`.
  - Delete `resolveStoredModelOverride` re-export from `src/plugin-sdk/mattermost.ts`.
- **Dead consumers**:
  - `src/discord/monitor/native-command.ts` — `resolveDiscordModelPickerCurrentModel` no longer loads the session store looking for a stored override; returns the resolved default.
  - `extensions/mattermost/src/mattermost/model-picker.ts` — `resolveMattermostModelPickerCurrentModel` same simplification.
- **Test fabrications deleted**:
  - `get-reply-run.media-only.test.ts` (lines 137-139)
  - `get-reply.reset-hooks-fallback.test.ts` (lines 90-92)
  - `get-reply-inline-actions.skip-when-config-empty.test.ts` (line 77)
  - `commands.test.ts` (line 301)
  - `commands.test-harness.ts` (line 47)

20 files changed, 9 insertions, 169 deletions.

## Deferred to follow-up (scope limit for reviewability)

The #2334 issue catalogs a broader sweep. These items are deliberately NOT in this PR:

- `/think` directive parsing (`directive-handling.parse.ts`), TUI handler (`tui-command-handlers.ts`), and gateway chat injection (`server-methods/chat.ts:976`).
- `supportsXHighThinking` / `normalizeThinkLevel` / `formatXHighModelHint` in `src/auto-reply/thinking.ts` — still consumed by `src/commands/agent/session.ts` and `src/cron/isolated-agent/run.test-harness.ts`.
- `sessionEntry.thinkingLevel` session state field + gateway schema.
- `thinkLevel` dead passthrough through `queue/types.ts`, `followup-runner.ts`, `agent-runner-utils.ts`, `agent-runner-execution.ts`.
- Display-layer audit in `apps/android`, `apps/shared/RemoteClawKit`, `ui/src/ui`.
- `/think` references in `docs/tools/slash-commands.md`, `docs/concepts/context.md`, `docs/web/tui.md`, `docs/channels/group-messages.md`.

I'll open a follow-up issue for these once this lands. The cut line was drawn where compile errors stopped cascading without touching the deeper directive-handling internals or the multi-platform display layers.

## Test plan

- [x] `pnpm tsgo` — green
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format` — clean
- [x] `pnpm canvas:a2ui:bundle` — green
- [x] `pnpm test` — 725 test files, 6341 tests pass, 2 skipped, 0 failures
- [ ] `LIVE=1 pnpm test:live` — **not run in this session** (no LIVE credentials configured). CI or reviewer should run this since the PR touches reply-path runtime code. If LIVE setup is expected for this reviewer, happy to re-run in a follow-up.
- [ ] Manual Slack first-turn message smoke test — recommend a reviewer validate on a dev account since the bug was specifically a first-turn/no-think case that no existing test covered.

## Follow-up commitments

- [ ] Open follow-up issue for the deferred sweep listed above.
- [ ] Add a regression test that drives `runPreparedReply` with `resolvedThinkLevel: undefined` through the real `resolveReplyDirectives` chain (rather than fabricated fixtures) — needs coordinated cleanup of `get-reply.test-mocks.ts`'s global `runPreparedReply` mock, which is outside the scope of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
