### PR TITLE
test(docs): move slash-commands-doc test out of gutted src/docs/ (#2070)

### DIFF
--- a/test/slash-commands-doc.test.ts
+++ b/test/slash-commands-doc.test.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { listChatCommands } from "../auto-reply/commands-registry.js";
-import { setActivePluginRegistry } from "../plugins/runtime.js";
-import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { listChatCommands } from "../src/auto-reply/commands-registry.js";
+import { setActivePluginRegistry } from "../src/plugins/runtime.js";
+import { createTestRegistry } from "../src/test-utils/channel-plugins.js";
 
 beforeEach(() => {
   setActivePluginRegistry(createTestRegistry([]));


### PR DESCRIPTION
## Summary

Closes #2070 (partially — see findings below).

Moves `src/docs/slash-commands-doc.test.ts` → `test/slash-commands-doc.test.ts`
and updates the relative imports. Empties `src/docs/` so the corresponding
`EXCLUDE src/docs/` directory rule can be retired at the HQ disposition
registry level.

## Investigation findings (the issue premise was wrong)

Ran the 3 files classified as "orphaned tests" / "dead code" in #2070 — **all 28 tests pass**:

| File | Tests | Status |
|---|---|---|
| `src/docs/slash-commands-doc.test.ts` | 1 | ✅ pass — imports live `listChatCommands`, validates doc consistency |
| `src/infra/infra-store.test.ts` | 13 | ✅ pass — tests live `channel-activity`, `dedupe`, `diagnostic-events`, `voicewake` |
| `src/plugins/loader.test.ts` | 14 | ✅ pass — tests live `loader.ts` (28KB); also listed in `scripts/test-parallel.mjs` isolated suite |

`docs/providers/deepgram.md` is NOT dead either:
- Referenced by `docs/astro.config.mjs:376` (`{ slug: "providers/deepgram" }`) — Starlight build fails if the slug is missing
- Linked from `docs/nodes/audio.md:133`
- Documents a live feature (`src/stt/providers/deepgram/`)

All 8 `CHANGELOG.md` files contain RemoteClaw content (fork-maintained).

## Per-file decision

| File | Decision | Rationale |
|---|---|---|
| `src/docs/slash-commands-doc.test.ts` | **Moved to `test/`** | Preserves unique test coverage; empties `src/docs/` → EXCLUDE dir rule retirable |
| `docs/providers/deepgram.md` | **Keep** | Deletion breaks docs build (sidebar + audio.md). HQ: reclassify EXCLUDE → PROTECTED |
| 8× `CHANGELOG.md` | **Keep** | Fork-maintained RemoteClaw content. HQ: reclassify EXCLUDE → PROTECTED |
| `src/infra/infra-store.test.ts` | **Keep** | 13 passing tests on live modules. HQ: reclassify |
| `src/plugins/loader.test.ts` | **Keep** | 14 passing tests on live `loader.ts`; in CI isolated suite list. HQ: reclassify |

## HQ follow-ups (out of scope for this PR)

`upstream/disposition.tsv` is not in this repo; suggest the operator apply:

- Remove: `EXCLUDE src/docs/` (directory now empty after this PR merges)
- Reclassify EXCLUDE → PROTECTED:
  - `CHANGELOG.md`, `extensions/{matrix,msteams,nostr,twitch,voice-call,zalo,zalouser}/CHANGELOG.md`
  - `src/infra/infra-store.test.ts`, `src/plugins/loader.test.ts`
  - `docs/providers/deepgram.md` (and consider removing the `EXCLUDE docs/providers/` directory rule, keeping only this file)

## Test plan

- [x] `pnpm exec vitest run test/slash-commands-doc.test.ts` — 1 test passes at new location
- [x] `pnpm check` — format, tsgo, lint all green
- [ ] CI runs full unit suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)