### PR TITLE
chore: bump upstream version badge to v2026.3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.com/package/remoteclaw"><img src="https://img.shields.io/npm/v/remoteclaw?style=for-the-badge" alt="npm version"></a>
   <a href="https://github.com/remoteclaw/remoteclaw/releases"><img src="https://img.shields.io/github/v/release/remoteclaw/remoteclaw?include_prereleases&display_name=release&style=for-the-badge&label=GITHUB" alt="GitHub release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0--only-blue.svg?style=for-the-badge" alt="AGPL-3.0-only License"></a>
-  <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.3.7"><img src="https://img.shields.io/badge/upstream-OpenClaw_v2026.3.7-teal?style=for-the-badge" alt="Upstream: OpenClaw v2026.3.7"></a>
+  <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.3.8"><img src="https://img.shields.io/badge/upstream-OpenClaw_v2026.3.8-teal?style=for-the-badge" alt="Upstream: OpenClaw v2026.3.8"></a>
 </p>
 
 **RemoteClaw** is AI agent middleware. It connects agent CLIs you already run — Claude Code, Gemini CLI, Codex, OpenCode — to the messaging channels you already use, so you can reach your agents from anywhere: your phone, your team Slack, your WhatsApp, anywhere.


### PR DESCRIPTION
## Summary

- Bumps README upstream badge from OpenClaw v2026.3.7 → v2026.3.8 to match the sync already merged in fc2cefeeab (#2360).
- Mirrors the follow-up bump done in ab24eafe3d after the v2026.3.2 → v2026.3.7 sync.

## Test plan

- [x] Diff is a single-line badge update (version + tag URL + alt text)
- [x] `pnpm check` passed locally (format, lint, no-random-messaging, rebrand leakage)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)