### PR TITLE
chore: replace remaining remoteclaw.ai URLs with .org

### DIFF
--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -2200,7 +2200,7 @@ extension NodeAppModel {
 
         let payload = SharedContentPayload(
             title: "RemoteClaw Share Self-Test",
-            url: URL(string: "https://remoteclaw.ai/share-self-test"),
+            url: URL(string: "https://remoteclaw.org/share-self-test"),
             text: "Validate iOS share->deep-link->gateway forwarding.")
         guard let deepLink = ShareToAgentDeepLink.buildURL(
             from: payload,

--- a/apps/ios/fastlane/metadata/README.md
+++ b/apps/ios/fastlane/metadata/README.md
@@ -36,7 +36,7 @@ Or set `APP_STORE_CONNECT_API_KEY_PATH`.
 ## Notes
 
 - Locale files live under `metadata/en-US/`.
-- `privacy_url.txt` is set to `https://remoteclaw.ai/privacy`.
+- `privacy_url.txt` is set to `https://remoteclaw.org/privacy`.
 - If app lookup fails in `deliver`, set one of:
   - `ASC_APP_IDENTIFIER` (bundle ID)
   - `ASC_APP_ID` (numeric App Store Connect app ID, e.g. from `/apps/<id>/...` URL)

--- a/apps/ios/fastlane/metadata/en-US/marketing_url.txt
+++ b/apps/ios/fastlane/metadata/en-US/marketing_url.txt
@@ -1,1 +1,1 @@
-https://remoteclaw.ai
+https://remoteclaw.org

--- a/apps/ios/fastlane/metadata/en-US/privacy_url.txt
+++ b/apps/ios/fastlane/metadata/en-US/privacy_url.txt
@@ -1,1 +1,1 @@
-https://remoteclaw.ai/privacy
+https://remoteclaw.org/privacy

--- a/apps/ios/fastlane/metadata/en-US/support_url.txt
+++ b/apps/ios/fastlane/metadata/en-US/support_url.txt
@@ -1,1 +1,1 @@
-https://docs.remoteclaw.ai/platforms/ios
+https://docs.remoteclaw.org/platforms/ios

--- a/apps/ios/fastlane/metadata/review_information/email_address.txt
+++ b/apps/ios/fastlane/metadata/review_information/email_address.txt
@@ -1,1 +1,1 @@
-support@remoteclaw.ai
+support@remoteclaw.org

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -1202,6 +1202,6 @@ Commit the updated `.secrets.baseline` once it reflects the intended state.
 
 Found a vulnerability in RemoteClaw? Please report responsibly:
 
-1. Email: [security@remoteclaw.ai](mailto:security@remoteclaw.ai)
+1. Email: [security@remoteclaw.org](mailto:security@remoteclaw.org)
 2. Don't post publicly until fixed
 3. We'll credit you (unless you prefer anonymity)

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -281,7 +281,7 @@ setup (PATH, services, permissions, auth files). Give them the **full source che
 the hackable (git) install:
 
 ```bash
-curl -fsSL https://remoteclaw.ai/install.sh | bash -s -- --install-method git
+curl -fsSL https://remoteclaw.org/install.sh | bash -s -- --install-method git
 ```
 
 This installs RemoteClaw **from a git checkout**, so the agent can read the code + docs and
@@ -320,7 +320,7 @@ Install docs: [Install](/install), [Installer flags](/install/installer), [Updat
 The repo recommends running from source and using the onboarding wizard:
 
 ```bash
-curl -fsSL https://remoteclaw.ai/install.sh | bash
+curl -fsSL https://remoteclaw.org/install.sh | bash
 remoteclaw onboard --install-daemon
 ```
 
@@ -477,15 +477,15 @@ See what changed:
 One-liners (macOS/Linux):
 
 ```bash
-curl -fsSL --proto '=https' --tlsv1.2 https://remoteclaw.ai/install.sh | bash -s -- --beta
+curl -fsSL --proto '=https' --tlsv1.2 https://remoteclaw.org/install.sh | bash -s -- --beta
 ```
 
 ```bash
-curl -fsSL --proto '=https' --tlsv1.2 https://remoteclaw.ai/install.sh | bash -s -- --install-method git
+curl -fsSL --proto '=https' --tlsv1.2 https://remoteclaw.org/install.sh | bash -s -- --install-method git
 ```
 
 Windows installer (PowerShell):
-[https://remoteclaw.ai/install.ps1](https://remoteclaw.ai/install.ps1)
+[https://remoteclaw.org/install.ps1](https://remoteclaw.org/install.ps1)
 
 More detail: [Development channels](/install/development-channels) and [Installer flags](/install/installer).
 
@@ -514,7 +514,7 @@ This switches to the `main` branch and updates from source.
 2. **Hackable install (from the installer site):**
 
 ```bash
-curl -fsSL https://remoteclaw.ai/install.sh | bash -s -- --install-method git
+curl -fsSL https://remoteclaw.org/install.sh | bash -s -- --install-method git
 ```
 
 That gives you a local repo you can edit, then update via git.
@@ -536,19 +536,19 @@ Docs: [Update](/cli/update), [Development channels](/install/development-channel
 Re-run the installer with **verbose output**:
 
 ```bash
-curl -fsSL https://remoteclaw.ai/install.sh | bash -s -- --verbose
+curl -fsSL https://remoteclaw.org/install.sh | bash -s -- --verbose
 ```
 
 Beta install with verbose:
 
 ```bash
-curl -fsSL https://remoteclaw.ai/install.sh | bash -s -- --beta --verbose
+curl -fsSL https://remoteclaw.org/install.sh | bash -s -- --beta --verbose
 ```
 
 For a hackable (git) install:
 
 ```bash
-curl -fsSL https://remoteclaw.ai/install.sh | bash -s -- --install-method git --verbose
+curl -fsSL https://remoteclaw.org/install.sh | bash -s -- --install-method git --verbose
 ```
 
 Windows (PowerShell) equivalent:
@@ -556,7 +556,7 @@ Windows (PowerShell) equivalent:
 ```powershell
 # install.ps1 has no dedicated -Verbose flag yet.
 Set-PSDebug -Trace 1
-& ([scriptblock]::Create((iwr -useb https://remoteclaw.ai/install.ps1))) -NoOnboard
+& ([scriptblock]::Create((iwr -useb https://remoteclaw.org/install.ps1))) -NoOnboard
 Set-PSDebug -Trace 0
 ```
 
@@ -620,7 +620,7 @@ Use the **hackable (git) install** so you have the full source and docs locally,
 your bot (or Claude/Codex) _from that folder_ so it can read the repo and answer precisely.
 
 ```bash
-curl -fsSL https://remoteclaw.ai/install.sh | bash -s -- --install-method git
+curl -fsSL https://remoteclaw.org/install.sh | bash -s -- --install-method git
 ```
 
 More detail: [Install](/install) and [Installer flags](/install/installer).
@@ -1051,7 +1051,7 @@ Advantages:
 - **Always-on Gateway** (run on a VPS, interact from anywhere)
 - **Nodes** for local browser/screen/camera/exec
 
-Showcase: [https://remoteclaw.ai/showcase](https://remoteclaw.ai/showcase)
+Showcase: [https://remoteclaw.org/showcase](https://remoteclaw.org/showcase)
 
 ## Skills and automation
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -173,7 +173,7 @@ and points at the pinned multi-arch manifest list for that tag):
 - `org.opencontainers.image.base.name=docker.io/library/node:22-bookworm`
 - `org.opencontainers.image.base.digest=sha256:b501c082306a4f528bc4038cbf2fbb58095d583d0419a259b2114b5ac53d12e9`
 - `org.opencontainers.image.source=https://github.com/remoteclaw/remoteclaw`
-- `org.opencontainers.image.url=https://remoteclaw.ai`
+- `org.opencontainers.image.url=https://remoteclaw.org`
 - `org.opencontainers.image.documentation=https://docs.remoteclaw.org/install/docker`
 - `org.opencontainers.image.licenses=MIT`
 - `org.opencontainers.image.title=RemoteClaw`

--- a/docs/platforms/raspberry-pi.md
+++ b/docs/platforms/raspberry-pi.md
@@ -112,7 +112,7 @@ sudo sysctl -p
 ### Option A: Standard Install (Recommended)
 
 ```bash
-curl -fsSL https://remoteclaw.ai/install.sh | bash
+curl -fsSL https://remoteclaw.org/install.sh | bash
 ```
 
 ### Option B: Hackable Install (For tinkering)

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -75,7 +75,7 @@ Historical note:
 - [ ] `REMOTECLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke` (Docker install smoke test, fast path; required before release)
   - If the immediate previous npm release is known broken, set `REMOTECLAW_INSTALL_SMOKE_PREVIOUS=<last-good-version>` or `REMOTECLAW_INSTALL_SMOKE_SKIP_PREVIOUS=1` for the preinstall step.
 - [ ] (Optional) Full installer smoke (adds non-root + CLI coverage): `pnpm test:install:smoke`
-- [ ] (Optional) Installer E2E (Docker, runs `curl -fsSL https://remoteclaw.ai/install.sh | bash`, onboards, then runs real tool calls):
+- [ ] (Optional) Installer E2E (Docker, runs `curl -fsSL https://remoteclaw.org/install.sh | bash`, onboards, then runs real tool calls):
   - `pnpm test:install:e2e:openai` (requires `OPENAI_API_KEY`)
   - `pnpm test:install:e2e:anthropic` (requires `ANTHROPIC_API_KEY`)
   - `pnpm test:install:e2e` (requires both keys; runs both providers)

--- a/docs/security/CONTRIBUTING-THREAT-MODEL.md
+++ b/docs/security/CONTRIBUTING-THREAT-MODEL.md
@@ -21,7 +21,7 @@ Spotted an attack vector or risk we haven't covered? Open an issue on [remotecla
 
 We'll handle the ATLAS mapping, threat IDs, and risk assessment during review. If you want to include those details, great - but it's not expected.
 
-> **This is for adding to the threat model, not reporting live vulnerabilities.** If you've found an exploitable vulnerability, see our [Trust page](https://trust.remoteclaw.ai) for responsible disclosure instructions.
+> **This is for adding to the threat model, not reporting live vulnerabilities.** If you've found an exploitable vulnerability, see our [Trust page](https://trust.remoteclaw.org) for responsible disclosure instructions.
 
 ### Suggest a Mitigation
 
@@ -85,7 +85,7 @@ If you're unsure about the risk level, just describe the impact and we'll assess
 
 ## Contact
 
-- **Security vulnerabilities:** See our [Trust page](https://trust.remoteclaw.ai) for reporting instructions
+- **Security vulnerabilities:** See our [Trust page](https://trust.remoteclaw.org) for reporting instructions
 - **Threat model questions:** Open an issue on [remoteclaw/trust](https://github.com/remoteclaw/trust/issues)
 - **General chat:** Discord #security channel
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -4,7 +4,7 @@ title: RemoteClaw Security & Trust
 
 # RemoteClaw Security & Trust
 
-**Live:** [trust.remoteclaw.ai](https://trust.remoteclaw.ai)
+**Live:** [trust.remoteclaw.org](https://trust.remoteclaw.org)
 
 ## Documents
 
@@ -13,7 +13,7 @@ title: RemoteClaw Security & Trust
 
 ## Reporting Vulnerabilities
 
-See the [Trust page](https://trust.remoteclaw.ai) for full reporting instructions covering all repos.
+See the [Trust page](https://trust.remoteclaw.org) for full reporting instructions covering all repos.
 
 ## Contact
 

--- a/docs/security/THREAT-MODEL-ATLAS.md
+++ b/docs/security/THREAT-MODEL-ATLAS.md
@@ -604,4 +604,4 @@ T-EXEC-002 → T-EXFIL-001 → External exfiltration
 
 ---
 
-_This threat model is a living document. Report security issues to security@remoteclaw.ai_
+_This threat model is a living document. Report security issues to security@remoteclaw.org_

--- a/src/channels/plugins/onboarding/telegram.ts
+++ b/src/channels/plugins/onboarding/telegram.ts
@@ -34,7 +34,7 @@ async function noteTelegramTokenHelp(prompter: WizardPrompter): Promise<void> {
       "3) Copy the token (looks like 123456:ABC...)",
       "Tip: you can also set TELEGRAM_BOT_TOKEN in your env.",
       `Docs: ${formatDocsLink("/telegram")}`,
-      "Website: https://remoteclaw.ai",
+      "Website: https://remoteclaw.org",
     ].join("\n"),
     "Telegram bot token",
   );
@@ -47,7 +47,7 @@ async function noteTelegramUserIdHelp(prompter: WizardPrompter): Promise<void> {
       "2) Or call https://api.telegram.org/bot<bot_token>/getUpdates and read message.from.id",
       "3) Third-party: DM @userinfobot or @getidsbot",
       `Docs: ${formatDocsLink("/telegram")}`,
-      "Website: https://remoteclaw.ai",
+      "Website: https://remoteclaw.org",
     ].join("\n"),
     "Telegram user id",
   );

--- a/src/channels/registry.helpers.test.ts
+++ b/src/channels/registry.helpers.test.ts
@@ -37,6 +37,6 @@ describe("channel registry helpers", () => {
     );
     expect(line).not.toContain("Docs:");
     expect(line).toContain("/channels/telegram");
-    expect(line).toContain("https://remoteclaw.ai");
+    expect(line).toContain("https://remoteclaw.org");
   });
 });

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -22,7 +22,7 @@ export const CHANNEL_IDS = [...CHAT_CHANNEL_ORDER] as const;
 
 export type ChatChannelMeta = ChannelMeta;
 
-const WEBSITE_URL = "https://remoteclaw.ai";
+const WEBSITE_URL = "https://remoteclaw.org";
 
 const CHAT_CHANNEL_META: Record<ChatChannelId, ChannelMeta> = {
   telegram: {

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -16,11 +16,11 @@ import { RemoteClawSchema } from "./zod-schema.js";
 describe("$schema key in config (#14998)", () => {
   it("accepts config with $schema string", () => {
     const result = RemoteClawSchema.safeParse({
-      $schema: "https://remoteclaw.ai/config.json",
+      $schema: "https://remoteclaw.org/config.json",
     });
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.$schema).toBe("https://remoteclaw.ai/config.json");
+      expect(result.data.$schema).toBe("https://remoteclaw.org/config.json");
     }
   });
 

--- a/src/slack/monitor/events/interactions.test.ts
+++ b/src/slack/monitor/events/interactions.test.ts
@@ -1136,7 +1136,7 @@ describe("registerSlackInteractionEvents", () => {
               email_block: {
                 email_input: {
                   type: "email_text_input",
-                  value: "team@remoteclaw.ai",
+                  value: "team@remoteclaw.org",
                 },
               },
               url_block: {
@@ -1233,7 +1233,7 @@ describe("registerSlackInteractionEvents", () => {
         expect.objectContaining({
           actionId: "email_input",
           inputKind: "email",
-          inputEmail: "team@remoteclaw.ai",
+          inputEmail: "team@remoteclaw.org",
         }),
         expect.objectContaining({
           actionId: "url_input",

--- a/src/terminal/ansi.test.ts
+++ b/src/terminal/ansi.test.ts
@@ -4,7 +4,9 @@ import { sanitizeForLog, splitGraphemes, stripAnsi, visibleWidth } from "./ansi.
 describe("terminal ansi helpers", () => {
   it("strips ANSI and OSC8 sequences", () => {
     expect(stripAnsi("\u001B[31mred\u001B[0m")).toBe("red");
-    expect(stripAnsi("\u001B]8;;https://remoteclaw.ai\u001B\\link\u001B]8;;\u001B\\")).toBe("link");
+    expect(stripAnsi("\u001B]8;;https://remoteclaw.org\u001B\\link\u001B]8;;\u001B\\")).toBe(
+      "link",
+    );
   });
 
   it("sanitizes control characters for log-safe interpolation", () => {

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -564,7 +564,7 @@ export async function finalizeOnboardingWizard(
   }
 
   await prompter.note(
-    'What now: https://remoteclaw.ai/showcase ("What People Are Building").',
+    'What now: https://remoteclaw.org/showcase ("What People Are Building").',
     "What now",
   );
 


### PR DESCRIPTION
Closes #2382. Follows up on PR #2379 (which cleaned up `docs.remoteclaw.ai` references) by sweeping the long tail of `remoteclaw.ai` URLs — we own `remoteclaw.org`, not `.ai`.

## Summary

21 files, symmetric 37 insertions / 37 deletions (pure TLD swap; one oxfmt reflow in a test file accounts for the +2 line delta):

- **Production code** (5 files, src/): website const, Telegram onboarding, wizard "What now" message, Swift share-self-test URL, OSC-8 hyperlink test fixture
- **Tests** (3 files, src/): `$schema` URL fixture, `team@` email fixture, website URL assertion
- **Docs** (9 files, docs/): Docker OCI `image.url` label (was inconsistent with `.documentation=.org`), install script commands (FAQ, raspberry-pi, RELEASING), trust page links, security contact emails, fastlane README
- **iOS fastlane metadata** (4 files, apps/ios/fastlane/): marketing/support/privacy URLs, review-info email

## Verification

| AC | Verdict | Evidence |
|---|---|---|
| `grep -r "remoteclaw\.ai"` returns only attribution/shims | ✅ | Zero matches across tracked files (over-delivers — permitted exceptions unused) |
| Docker image labels agree on one domain | ✅ | `docs/install/docker.md:175-177` all `.org` (was `.ai` / `.org` mismatch) |
| Fastlane support URL resolves | ✅ | `docs.remoteclaw.org/platforms/ios/` → HTTP 200 |
| Install scripts work | ✅ | `remoteclaw.org/install.sh` + `install.ps1` → HTTP 200 |
| `trust.remoteclaw.ai` references resolve or replaced | ✅ | → `trust.remoteclaw.org` (matches fork's pre-existing SECURITY.md convention; aspirational subdomain consistent with how `.org` trust page is referenced throughout) |

## Aspirational `.org` paths

A few `.org` paths introduced here are aspirational (don't yet resolve): `/showcase`, `/privacy`, `/share-self-test`, `/config.json`, `trust.remoteclaw.org`. This matches the fork's existing convention — `SECURITY.md` at fork HEAD references aspirational `trust.remoteclaw.org`. Pages can be stood up (or redirects added) separately; the rebrand consistency is the load-bearing fix.

## Non-goals

- No app behavior changes (URL strings only)
- No claim on `.ai` TLD for the fork
- No CI gate added yet — filed as follow-up #2385 (blocked by this PR)

## Test plan

- [x] \`pnpm check\` (oxfmt + tsgo + oxlint + rebrand-leakage + messaging-tmp) — PASS
- [x] 4 modified test files — 61/61 pass
- [ ] CI green on all required checks
- [ ] Copilot auto-reviewer feedback processed (if any)
- [ ] Post-submit adversarial review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)