### PR TITLE
chore(tests): remove 6 dead pi-embedded vi.mock shims

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -155,8 +155,6 @@ vi.mock("../config/sessions.js", async (importOriginal) => {
   };
 });
 
-vi.mock("./pi-embedded.js", () => embeddedRunMock);
-
 vi.mock("./subagent-registry.js", () => subagentRegistryMock);
 vi.mock("../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: () => hookRunnerMock,

--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -53,12 +53,6 @@ vi.mock("./subagent-depth.js", () => ({
   getSubagentDepthFromSessionStore: (sessionKey?: string) => requesterDepthResolver(sessionKey),
 }));
 
-vi.mock("./pi-embedded.js", () => ({
-  isEmbeddedPiRunActive: () => false,
-  queueEmbeddedPiMessage: () => false,
-  waitForEmbeddedPiRunEnd: async () => true,
-}));
-
 vi.mock("./subagent-registry.js", () => ({
   countActiveDescendantRuns: () => 0,
   countPendingDescendantRuns: () => pendingDescendantRuns,

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -20,11 +20,6 @@ import { enqueueFollowupRun, getFollowupQueueDepth, type FollowupRun } from "./q
 import { initSessionState } from "./session.js";
 import { buildTestCtx } from "./test-ctx.js";
 
-vi.mock("../../agents/pi-embedded.js", () => ({
-  abortEmbeddedPiRun: vi.fn().mockReturnValue(true),
-  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "test-agent"}`,
-}));
-
 const commandQueueMocks = vi.hoisted(() => ({
   clearCommandLane: vi.fn(),
 }));

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -5,13 +5,6 @@ vi.mock("../../agents/auth-profiles/session-override.js", () => ({
   resolveSessionAuthProfileOverride: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("../../agents/pi-embedded.js", () => ({
-  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
-  isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
-  isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
-  resolveEmbeddedSessionLane: vi.fn().mockReturnValue("session:session-key"),
-}));
-
 vi.mock("../../config/sessions.js", () => ({
   resolveGroupSessionKey: vi.fn().mockReturnValue(undefined),
   resolveSessionFilePath: vi.fn().mockReturnValue("/tmp/session.jsonl"),

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -15,11 +15,6 @@ const resetAllLanes = vi.fn();
 const restartGatewayProcessWithFreshPid = vi.fn<
   () => { mode: "spawned" | "supervised" | "disabled" | "failed"; pid?: number; detail?: string }
 >(() => ({ mode: "disabled" }));
-const abortEmbeddedPiRun = vi.fn(
-  (_sessionId?: string, _opts?: { mode?: "all" | "compacting" }) => false,
-);
-const getActiveEmbeddedRunCount = vi.fn(() => 0);
-const waitForActiveEmbeddedRuns = vi.fn(async (_timeoutMs: number) => ({ drained: true }));
 const DRAIN_TIMEOUT_LOG = "drain timeout reached; proceeding with restart";
 const gatewayLog = {
   info: vi.fn(),
@@ -46,13 +41,6 @@ vi.mock("../../process/command-queue.js", () => ({
   markGatewayDraining: () => markGatewayDraining(),
   waitForActiveTasks: (timeoutMs: number) => waitForActiveTasks(timeoutMs),
   resetAllLanes: () => resetAllLanes(),
-}));
-
-vi.mock("../../agents/pi-embedded-runner/runs.js", () => ({
-  abortEmbeddedPiRun: (sessionId?: string, opts?: { mode?: "all" | "compacting" }) =>
-    abortEmbeddedPiRun(sessionId, opts),
-  getActiveEmbeddedRunCount: () => getActiveEmbeddedRunCount(),
-  waitForActiveEmbeddedRuns: (timeoutMs: number) => waitForActiveEmbeddedRuns(timeoutMs),
 }));
 
 vi.mock("../../logging/subsystem.js", () => ({
@@ -198,9 +186,7 @@ describe("runGatewayLoop", () => {
 
     await withIsolatedSignals(async ({ captureSignal }) => {
       getActiveTaskCount.mockReturnValueOnce(2).mockReturnValueOnce(0);
-      getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValueOnce(0);
       waitForActiveTasks.mockResolvedValueOnce({ drained: false });
-      waitForActiveEmbeddedRuns.mockResolvedValueOnce({ drained: true });
 
       type StartServer = () => Promise<{
         close: (opts: { reason: string; restartExpectedMs: number | null }) => Promise<void>;
@@ -257,9 +243,6 @@ describe("runGatewayLoop", () => {
       expect(start).toHaveBeenCalledTimes(2);
       await new Promise<void>((resolve) => setImmediate(resolve));
 
-      // Embedded Pi runner is gutted in the RemoteClaw fork — no
-      // abortEmbeddedPiRun or waitForActiveEmbeddedRuns hooks exist in
-      // the drain pipeline. Only the task queue drain is exercised.
       expect(waitForActiveTasks).toHaveBeenCalledWith(90_000);
       expect(markGatewayDraining).toHaveBeenCalledTimes(1);
       expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -34,7 +34,6 @@ export const resolveConfiguredModelRefMock = createMock();
 export const resolveHooksGmailModelMock = createMock();
 export const resolveThinkingDefaultMock = createMock();
 export const runWithModelFallbackMock = createMock();
-export const runEmbeddedPiAgentMock = createMock();
 export const runCliAgentMock = createMock();
 export const getCliSessionIdMock = createMock();
 export const updateSessionStoreMock = createMock();
@@ -83,10 +82,6 @@ vi.mock("../../agents/model-selection.js", async (importOriginal) => {
 
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: runWithModelFallbackMock,
-}));
-
-vi.mock("../../agents/pi-embedded.js", () => ({
-  runEmbeddedPiAgent: runEmbeddedPiAgentMock,
 }));
 
 vi.mock("../../agents/context.js", () => ({
@@ -234,13 +229,6 @@ function makeDefaultModelFallbackResult() {
   };
 }
 
-function makeDefaultEmbeddedResult() {
-  return {
-    payloads: [{ text: "test output" }],
-    meta: { agentMeta: { usage: { input: 10, output: 20 } } },
-  };
-}
-
 export function resetRunCronIsolatedAgentTurnHarness(): void {
   vi.clearAllMocks();
 
@@ -262,8 +250,6 @@ export function resetRunCronIsolatedAgentTurnHarness(): void {
 
   runWithModelFallbackMock.mockReset();
   runWithModelFallbackMock.mockResolvedValue(makeDefaultModelFallbackResult());
-  runEmbeddedPiAgentMock.mockReset();
-  runEmbeddedPiAgentMock.mockResolvedValue(makeDefaultEmbeddedResult());
 
   runCliAgentMock.mockReset();
   getCliSessionIdMock.mockReturnValue(undefined);


### PR DESCRIPTION
## Summary

Production code no longer imports `pi-embedded.js` or `pi-embedded-runner/runs.js` — they were removed by prior gut commits (#2146/#2273, #2367, #2377). The 6 `vi.mock` calls identified in remoteclaw/hq#35 registered mock factories against paths nothing resolves; vitest never invoked them, and the mock state those tests configured had zero effect on production behavior.

This PR deletes all 6 dead `vi.mock` shims and the local state each one was paired with.

## Files touched

| File | What was deleted |
|---|---|
| `src/agents/subagent-announce.timeout.test.ts` | `vi.mock("./pi-embedded.js", ...)` (3-function shim) |
| `src/agents/subagent-announce.format.e2e.test.ts` | `vi.mock("./pi-embedded.js", () => embeddedRunMock)` only (see §Out of scope below) |
| `src/auto-reply/reply/abort.test.ts` | `vi.mock("../../agents/pi-embedded.js", ...)` (2-function shim) |
| `src/auto-reply/reply/get-reply-run.media-only.test.ts` | `vi.mock("../../agents/pi-embedded.js", ...)` (4-function shim) |
| `src/cli/gateway-cli/run-loop.test.ts` | `vi.mock("../../agents/pi-embedded-runner/runs.js", ...)` + local `abortEmbeddedPiRun` / `getActiveEmbeddedRunCount` / `waitForActiveEmbeddedRuns` `vi.fn()`s + their setup calls in the SIGUSR1 restart test + obsolete comment |
| `src/cron/isolated-agent/run.test-harness.ts` | `vi.mock("../../agents/pi-embedded.js", ...)` + exported `runEmbeddedPiAgentMock` + `makeDefaultEmbeddedResult()` helper + harness reset lines |

Diffstat: 6 files changed, 51 deletions, 0 additions.

## Verification

- `grep -rn "vi.mock.*pi-embedded" src/` returns 0 matches (was 6)
- `pnpm lint`: 0 warnings, 0 errors
- `pnpm tsgo`: exit 0
- `pnpm test:fast`: 761 files / 6829 passed / 2 skipped / **0 failed**
- Directly-affected tests: `run-loop.test.ts` 8/8 pass; `src/cron/isolated-agent/` 118/118 pass

## Out of scope

Four of the touched files have pre-existing failures unrelated to this PR (session routing, ACP cancel flow, think-level extraction, message content format). Pass/fail counts are **identical before and after this change**:

| File | Before | After |
|---|---|---|
| `subagent-announce.timeout.test.ts` | 4F/4P | 4F/4P |
| `abort.test.ts` | 9F/10P | 9F/10P |
| `get-reply-run.media-only.test.ts` | 1F/11P | 1F/11P |
| `subagent-announce.format.e2e.test.ts` (e2e, excluded from CI) | 44F/25P | 44F/25P |

`subagent-announce.format.e2e.test.ts` still references a dead `embeddedRunMock` object throughout its body. Deleting those ~42 references would be a ~200-line refactor touching pre-existing-failing tests — deferred as out of scope.

## Follow-up

After this merges, HQ will ratchet `.claude/skills/fork-openclaw/SKILL.md` § Semantic Invariants § Test Infrastructure from "≤6 matches" back to "0 matches" to restore the stricter check (tracked alongside remoteclaw/hq#35).

## Test plan

- [x] Local: `pnpm lint` clean
- [x] Local: `pnpm tsgo` clean
- [x] Local: `pnpm test:fast` 6829 passed / 0 failed
- [x] Local: directly-affected test files green (run-loop, cron isolated-agent)
- [ ] CI: full `pnpm test` (parallel lanes) green

Refs: remoteclaw/hq#35

🤖 Generated with [Claude Code](https://claude.com/claude-code)