### PR TITLE
fix(ci): relax appcast zero-items check — restore fork behavior

### DIFF
--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -288,10 +288,6 @@ export function collectAppcastSparkleVersionErrors(xml: string): string[] {
   const calverItems: Array<{ title: string; sparkleBuild: number; floors: SparkleBuildFloors }> =
     [];
 
-  if (itemMatches.length === 0) {
-    errors.push("appcast.xml contains no <item> entries.");
-  }
-
   for (const [, item] of itemMatches) {
     const title = extractTag(item, "title") ?? "unknown";
     const shortVersion = extractTag(item, "sparkle:shortVersionString");


### PR DESCRIPTION
## Fix B8 post-merge CI regression

B8 DIFF-SYNC (#2395) inadvertently re-introduced upstream's strict `appcast.xml contains no <item> entries` validation in `scripts/release-check.ts`, breaking `publish-next` on main after merge.

**Why fork needs it relaxed**: Fork has a stub empty `appcast.xml` because macOS app updates aren't published yet (see #2119 and `6d51373c0e`). The upstream validator in v2026.3.12 restored the strict check that the fork had intentionally relaxed.

**Change**: Removes just the zero-items error line; preserves all other upstream improvements to the validator (new plugin-sdk required paths, `collectForbiddenPackPaths` extraction).

**Test**: `pnpm vitest run test/release-check.test.ts` 9/9 pass.

**Disposition**: `scripts/release-check.ts` should be reclassified as EXTRACT in `upstream/disposition.tsv` to prevent future re-introduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)