### PR TITLE
fix(ci): remove usage.css import — gutted web UI styles (B10-post)

### DIFF
--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -4,4 +4,3 @@
 @import "./styles/components.css";
 @import "./styles/chat.css";
 @import "./styles/config.css";
-@import "./styles/usage.css";


### PR DESCRIPTION
## Why

B10 sync (PR #2400) applied upstream's \`ui/src/styles.css\` wholesale, which added \`@import "./styles/usage.css"\`. The \`usage.css\` file itself is \`EXCLUDE-GUT\` (web UI usage feature outside fork scope per Middleware Boundary).

\`publish-next\` catches this failure (rolldown postcss \`ENOENT: no such file or directory\`) but PR CI doesn't exercise \`publish-next\` paths.

## Fix

Remove the \`@import "./styles/usage.css";\` line. Aligns with fork HEAD's 5-import structure (pre-\`chat.css\` + pre-\`usage.css\`).

## Validation

- \`pnpm build\` passes
- \`pnpm test\` 6996/6996 pass
- \`node --import tsx scripts/release-check.ts\` passes

## Disposition follow-up

Per the third B10 lesson (see \`project_diff_sync_b10.md\`), \`ui/src/styles.css\` should be reclassified to \`EXTRACT\` in \`upstream/disposition.tsv\` so future syncs port \`@import\` additions hunk-by-hunk. (HQ update in a follow-up commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)