### PR TITLE
fix(deps): mirror tlon @aws-sdk/* deps to root — unblock publish-next

### DIFF
--- a/package.json
+++ b/package.json
@@ -321,6 +321,8 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "0.16.1",
+    "@aws-sdk/client-s3": "3.1000.0",
+    "@aws-sdk/s3-request-presigner": "3.1000.0",
     "@buape/carbon": "0.0.0-beta-20260216184201",
     "@clack/prompts": "^1.1.0",
     "@discordjs/voice": "^0.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,12 @@ importers:
       '@agentclientprotocol/sdk':
         specifier: 0.16.1
         version: 0.16.1(zod@4.3.6)
+      '@aws-sdk/client-s3':
+        specifier: 3.1000.0
+        version: 3.1000.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: 3.1000.0
+        version: 3.1000.0
       '@buape/carbon':
         specifier: 0.0.0-beta-20260216184201
         version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.8)(opusscript@0.1.1)


### PR DESCRIPTION
## Summary

Closes #2403.

Cherry-pick #2402 added `@aws-sdk/client-s3@3.1000.0` and `@aws-sdk/s3-request-presigner@3.1000.0` to `extensions/tlon/package.json` (replacing the removed `@tloncorp/api` git dep) but did not mirror them in root `package.json`. `pnpm release:check` enforces that bundled-extension deps must exist in root, so `publish-next` has been failing on every push to main since commit `f4c70a29` (2026-04-18 21:24 UTC).

## Changes

- Add `@aws-sdk/client-s3@3.1000.0` and `@aws-sdk/s3-request-presigner@3.1000.0` to root `package.json` `dependencies` (alphabetical order).
- Regenerate `pnpm-lock.yaml`.

Diff is minimal — 2 files, 8 line insertions.

## Local verification

```
$ pnpm install   # Done in 13s
$ pnpm build     # succeeded
$ pnpm release:check
release-check: npm pack contents look OK.   # exit 0
```

Pre-commit hooks also passed: `format:check`, `tsgo`, `lint`, `lint:tmp:no-random-messaging`, `lint:no-remoteclaw-ai`.

## Test plan

- [ ] CI passes (`build`, `test`, `lint`, `docs`).
- [ ] Post-merge `publish-next` run succeeds (verifies the gap is closed end-to-end).

## Precedent

Same class of fix as #2361, #2384, #2399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)