### PR TITLE
ci(build): run release:check inside build job — gate dep-mirror drift on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Validate release artifact (early signal — runs again in publish-next)
+        run: pnpm release:check
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Closes #2404.

Append a **Validate release artifact** step to the `build` job that runs `pnpm release:check` immediately after `pnpm build`. This shifts the release invariant check (bundled-extension dep mirroring, plugin-version sync, plugin-sdk exports, appcast versions, npm pack contents) from post-merge `publish-next`/`publish-latest` to per-PR CI.

Dep-mirror drift and similar classes of release-blocking regressions now fail on the PR's own `build` job instead of breaking the `next` channel after merge.

- Recurring fork-sync failure mode — #2361, #2384, #2399, #2402, #2403 all fell into this class post-merge.
- `publish-next` and `publish-latest` retain their `release:check` step as defense in depth.
- `release:check` keeps its name — most invariants it checks are about publishability, not build correctness; renaming creates upstream-merge friction.

**Path C selection rationale** — see #2404 decision table (Paths A/B/D/F deferred pending cost/flexibility triggers).

## Changes

- `.github/workflows/ci.yml` — add `Validate release artifact` step to `build` job (+3 lines)

## Test plan

- [x] Inspect diff — additive-only, 3 lines
- [x] YAML syntax valid (parsed with `node yaml` module)
- [x] `pnpm check` passes (pre-commit hook)
- [ ] CI `build` job runs new step successfully on this PR (observable once CI completes)
- [ ] Step duration <30 s on clean PR (observable in CI logs; issue estimates ~5 s)
- [ ] `publish-next` / `publish-latest` still retain `release:check` step (verified in diff — both untouched)

## Acceptance criteria

All AC from #2404 are satisfied or pending CI observation:

- [x] `build` job has `Validate release artifact` step running `pnpm release:check` immediately after `pnpm build`
- [x] Inline rationale ("runs again in publish-next") embedded in step name per issue body's own example
- [ ] Intentional-drift smoke test — **deferred to follow-up smoke PR** per AC option B ("or a follow-up smoke PR")
- [ ] <30 s overhead on clean PR — pending CI observation
- [x] `publish-next` / `publish-latest` still run `release:check` (no removal — diff is additive only)
- [x] `CI` summary status check continues to gate merges (`build` is in `CI.needs`; structure preserved)

## References

- Issue: #2404
- Investigation + 360 evaluation: referenced in issue body
- Branch protection state: `gh api repos/remoteclaw/remoteclaw/branches/main/protection` — `required_status_checks.contexts: ["CI"]`
- `release:check` script: `scripts/release-check.ts`
- Failing precedent: https://github.com/remoteclaw/remoteclaw/actions/runs/24614211935
- Wave 1 dependency (merged): #2403

🤖 Generated with [Claude Code](https://claude.com/claude-code)