### PR TITLE
ci(repo): detect throwing-stub-with-live-callers anti-pattern (closes #2410)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,22 @@ jobs:
       - name: Check stub debt
         run: node scripts/check-stub-debt.mjs
 
+  throwing-stub-callers-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Check throwing-stub-with-live-callers
+        run: node scripts/check-throwing-stub-callers.mjs
+
   obsolescence-audit-gate:
     runs-on: ubuntu-latest
     steps:
@@ -132,12 +148,21 @@ jobs:
   CI:
     if: always()
     needs:
-      [rebrand-gate, zombie-import-gate, stub-debt-gate, obsolescence-audit-gate, lint, build, test]
+      [
+        rebrand-gate,
+        zombie-import-gate,
+        stub-debt-gate,
+        throwing-stub-callers-gate,
+        obsolescence-audit-gate,
+        lint,
+        build,
+        test,
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.rebrand-gate.result }}" != "success" || "${{ needs.zombie-import-gate.result }}" != "success" || "${{ needs.stub-debt-gate.result }}" != "success" || "${{ needs.obsolescence-audit-gate.result }}" != "success" || "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.test.result }}" != "success" ]]; then
+          if [[ "${{ needs.rebrand-gate.result }}" != "success" || "${{ needs.zombie-import-gate.result }}" != "success" || "${{ needs.stub-debt-gate.result }}" != "success" || "${{ needs.throwing-stub-callers-gate.result }}" != "success" || "${{ needs.obsolescence-audit-gate.result }}" != "success" || "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.test.result }}" != "success" ]]; then
             echo "::error::One or more required jobs failed"
             exit 1
           fi

--- a/.throwing-stub-callers-allowlist
+++ b/.throwing-stub-callers-allowlist
@@ -1,0 +1,13 @@
+# Known throwing-stub-with-live-callers violations awaiting remediation.
+#
+# Each non-comment line: <file>::<symbol>  # <remediation-tracking-issue>
+#
+# The CI gate (scripts/check-throwing-stub-callers.mjs) passes these entries
+# through without failure but reports them in the inventory. Remove a line
+# once the stub has been either (a) replaced with a working implementation or
+# (b) deleted after migrating all callers.
+#
+# New entries require a tracking issue AND justification in the PR
+# description.
+
+src/agents/agent-scope.ts::resolveAgentRuntimeOrThrow  # #2408

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,20 @@ GitHub Actions (`.github/workflows/ci.yml`):
 - Both run on `ubuntu-latest` with Node 22 and pnpm 10.23.0
 - Branch protection requires `build`, `test`, `lint`, and `docs` to pass
 
+### Fork-integrity gates
+
+Standalone scripts in `scripts/` each run as their own CI job. They guard
+against regressions specific to the fork-sync lifecycle:
+
+- **rebrand-gate**: `openclaw`/`OpenClaw` leakage into files the fork owns.
+- **zombie-import-gate**: imports from modules that have been gutted.
+- **stub-debt-gate** (`.stub-debt-baseline`): bounds `@ts-expect-error`
+  suppressions so fork-sync type-assertion debt can't grow silently.
+- **throwing-stub-callers-gate** (`.throwing-stub-callers-allowlist`):
+  detects throwing stubs with live non-test callers — see § Fork Stub
+  Conventions.
+- **obsolescence-audit-gate**: retrospective audit sentinels for gut waves.
+
 ### Release publishing
 
 - **Trigger**: `publish-latest` runs on `release: [published]` event —
@@ -136,6 +150,58 @@ GitHub Actions (`.github/workflows/ci.yml`):
 - Dependency patching (pnpm patches, overrides, vendored changes) requires
   explicit approval
 - Any dependency in `pnpm.patchedDependencies` must use exact version (no `^`/`~`)
+
+## Fork Stub Conventions
+
+During upstream sync, functions whose implementation depends on gutted
+subsystems (Pi-era provider/model catalogs, skills marketplace, etc.) are
+replaced with **stubs** that throw at call time. Every stub is either:
+
+1. **Dead** — no live callers. Safe and idiomatic; typically paired with a
+   `// Gutted in RemoteClaw fork` marker comment for grep-ability.
+2. **Live regression** — has live non-test callers in production paths. Ships
+   the "unavailable in RemoteClaw fork" error to users. This is an outage
+   vector (see #2408) and the **throwing-stub-callers-gate** catches it.
+
+### Legitimate upstream-compat stub
+
+Use the pattern below for case (1). The CI gate accepts it because there are
+no callers outside of test files:
+
+```ts
+// Gutted in RemoteClaw fork — CLI runtimes own model selection.
+export function listProviderModels(..._args: unknown[]): never {
+  throw new Error("listProviderModels is not available in RemoteClaw fork");
+}
+```
+
+### Shipping a new caller of an existing stub
+
+Don't. Either migrate the stub to a working implementation first, or route
+the caller to a live alternative. If you genuinely need a short-lived window
+where a live regression exists, file a remediation issue and add a line to
+`.throwing-stub-callers-allowlist`:
+
+```text
+src/agents/agent-scope.ts::resolveAgentRuntimeOrThrow  # #2408
+```
+
+Do not add allowlist entries without a tracking issue — the allowlist is a
+debt ledger, not an escape hatch.
+
+### Detecting the pattern locally
+
+```bash
+# Reports known violations (same as CI default):
+node scripts/check-throwing-stub-callers.mjs
+
+# Strict mode — fails even on allowlisted entries (useful before closing a
+# remediation issue, to prove the allowlist line can be removed):
+node scripts/check-throwing-stub-callers.mjs --strict
+
+# Inventory only — never fails, lists every detected stub:
+node scripts/check-throwing-stub-callers.mjs --inventory
+```
 
 ## Fork Context
 

--- a/scripts/check-throwing-stub-callers.mjs
+++ b/scripts/check-throwing-stub-callers.mjs
@@ -1,0 +1,588 @@
+#!/usr/bin/env node
+
+/**
+ * Throwing-stub-with-live-callers gate — detects the anti-pattern that shipped
+ * in #2408 (unconditional-throw stub with live production callers) and related
+ * silent regressions in #2337.
+ *
+ * A "throwing stub" is an exported function whose body is a single throw
+ * statement AND that carries at least one calibration signal:
+ *   - Variadic-unknown signature:  (..._args: unknown[]) / (...args: unknown[])
+ *   - Fork-attributed throw message: "not available in RemoteClaw fork",
+ *     "gutted", "upstream-compat"
+ *   - A "// Gutted in RemoteClaw fork" marker comment immediately preceding
+ *     the declaration
+ *
+ * A "live caller" is an import of the stub symbol in any non-test TypeScript
+ * file in `src/`, `extensions/`, or `ui/` where the bound local name is
+ * referenced outside of the import declaration.
+ *
+ * Known violations are tracked in `.throwing-stub-callers-allowlist` with a
+ * remediation-issue reference. The check FAILS when a stub+live-caller pair
+ * is detected that is not on the allowlist.
+ *
+ * Reference: issues #2408 (evidence), #2409 (audit), #2410 (this gate).
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import {
+  collectTypeScriptFilesFromRoots,
+  isTestLikeTypeScriptFile,
+  resolveSourceRoots,
+  runAsScript,
+  toLine,
+} from "./lib/ts-guard-utils.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const sourceRoots = ["src", "extensions", "ui"];
+
+// Test-file suffixes beyond the base set in ts-guard-utils. Files matching
+// these are excluded from both stub-detection and caller-detection: mock
+// files and test helpers reference stubs but are not production callers.
+const extraTestSuffixes = [".test-helpers.ts", ".test-mocks.ts", ".e2e.test.ts", ".live.test.ts"];
+
+// Regex for fork-attributed throw messages (Patterns B and C from #2409).
+const forkMessagePattern = /not available in RemoteClaw fork|\bgutted\b|upstream-compat/i;
+
+// Marker-comment pattern for explicit upstream-compat stubs.
+const markerCommentPattern = /Gutted in RemoteClaw fork/i;
+
+function normalizePath(filePath) {
+  return path.relative(repoRoot, filePath).split(path.sep).join("/");
+}
+
+function isProductionFile(filePath) {
+  return !isTestLikeTypeScriptFile(filePath, { extraTestSuffixes });
+}
+
+/**
+ * Read source files from all roots once; return a map keyed by canonical
+ * normalized path. Avoids re-reading during caller resolution.
+ */
+async function loadSourceFiles({ includeTests }) {
+  const roots = resolveSourceRoots(repoRoot, sourceRoots);
+  const files = await collectTypeScriptFilesFromRoots(roots, {
+    includeTests,
+    extraTestSuffixes,
+  });
+  const out = new Map();
+  for (const filePath of files) {
+    const content = await fs.readFile(filePath, "utf8");
+    const sourceFile = ts.createSourceFile(
+      filePath,
+      content,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    out.set(normalizePath(filePath), { filePath, sourceFile });
+  }
+  return out;
+}
+
+/** Extract throw-message text from a throw statement, or null if not a literal string. */
+function throwMessageOf(throwStatement) {
+  const expr = throwStatement.expression;
+  if (!expr || !ts.isNewExpression(expr)) {
+    return null;
+  }
+  const args = expr.arguments ?? [];
+  if (args.length === 0) {
+    return null;
+  }
+  const first = args[0];
+  if (ts.isStringLiteral(first) || ts.isNoSubstitutionTemplateLiteral(first)) {
+    return first.text;
+  }
+  return null;
+}
+
+/** A function body is a "single throw" if it contains exactly one statement that is a ThrowStatement. */
+function isSingleThrowBody(body) {
+  if (!body || !ts.isBlock(body)) {
+    return false;
+  }
+  if (body.statements.length !== 1) {
+    return false;
+  }
+  return ts.isThrowStatement(body.statements[0]);
+}
+
+/** Does the parameter list declare variadic `...args: unknown[]` or `..._args: unknown[]`? */
+function hasVariadicUnknownArgs(parameters) {
+  for (const param of parameters) {
+    if (!param.dotDotDotToken) {
+      continue;
+    }
+    const type = param.type;
+    if (!type) {
+      continue;
+    }
+    // Accept `unknown[]` and `readonly unknown[]` and `Array<unknown>`.
+    if (ts.isArrayTypeNode(type) && type.elementType.kind === ts.SyntaxKind.UnknownKeyword) {
+      return true;
+    }
+    if (
+      ts.isTypeOperatorNode(type) &&
+      type.operator === ts.SyntaxKind.ReadonlyKeyword &&
+      ts.isArrayTypeNode(type.type) &&
+      type.type.elementType.kind === ts.SyntaxKind.UnknownKeyword
+    ) {
+      return true;
+    }
+    if (
+      ts.isTypeReferenceNode(type) &&
+      ts.isIdentifier(type.typeName) &&
+      type.typeName.text === "Array" &&
+      type.typeArguments?.length === 1 &&
+      type.typeArguments[0].kind === ts.SyntaxKind.UnknownKeyword
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Does the text immediately preceding `node` contain the "Gutted in RemoteClaw fork" marker? */
+function hasMarkerComment(sourceFile, node, fullText) {
+  const ranges = ts.getLeadingCommentRanges(fullText, node.getFullStart());
+  if (!ranges) {
+    return false;
+  }
+  for (const range of ranges) {
+    const commentText = fullText.slice(range.pos, range.end);
+    if (markerCommentPattern.test(commentText)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Build the candidate record if the function declaration matches a stub pattern. */
+function classifyStubFunction({ sourceFile, fullText, name, body, parameters, node }) {
+  if (!isSingleThrowBody(body)) {
+    return null;
+  }
+  const throwStatement = body.statements[0];
+  const message = throwMessageOf(throwStatement);
+
+  const variadicUnknown = hasVariadicUnknownArgs(parameters);
+  const forkMessage = message !== null && forkMessagePattern.test(message);
+  const markerComment = hasMarkerComment(sourceFile, node, fullText);
+
+  if (!variadicUnknown && !forkMessage && !markerComment) {
+    return null;
+  }
+
+  const signals = [];
+  if (variadicUnknown) {
+    signals.push("variadic-unknown");
+  }
+  if (forkMessage) {
+    signals.push("fork-message");
+  }
+  if (markerComment) {
+    signals.push("marker-comment");
+  }
+
+  return {
+    symbol: name,
+    line: toLine(sourceFile, node),
+    signals,
+    message,
+  };
+}
+
+/** Find every exported function declaration or exported const arrow/function expression that is a throwing stub. */
+function findStubsInFile({ filePath, sourceFile }) {
+  const stubs = [];
+  const fullText = sourceFile.text;
+
+  for (const statement of sourceFile.statements) {
+    const isExported = statement.modifiers?.some(
+      (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+    );
+    if (!isExported) {
+      continue;
+    }
+
+    if (ts.isFunctionDeclaration(statement) && statement.name && statement.body) {
+      const stub = classifyStubFunction({
+        sourceFile,
+        fullText,
+        name: statement.name.text,
+        body: statement.body,
+        parameters: statement.parameters,
+        node: statement,
+      });
+      if (stub) {
+        stubs.push({ ...stub, file: normalizePath(filePath) });
+      }
+      continue;
+    }
+
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (!ts.isIdentifier(declaration.name)) {
+          continue;
+        }
+        const initializer = declaration.initializer;
+        if (!initializer) {
+          continue;
+        }
+        if (
+          (ts.isArrowFunction(initializer) || ts.isFunctionExpression(initializer)) &&
+          initializer.body &&
+          ts.isBlock(initializer.body)
+        ) {
+          const stub = classifyStubFunction({
+            sourceFile,
+            fullText,
+            name: declaration.name.text,
+            body: initializer.body,
+            parameters: initializer.parameters,
+            node: statement,
+          });
+          if (stub) {
+            stubs.push({ ...stub, file: normalizePath(filePath) });
+          }
+        }
+      }
+    }
+  }
+
+  return stubs;
+}
+
+/**
+ * Resolve a module specifier from `importerFile` to a canonical repo-relative
+ * path. Returns null if the specifier is a bare package name or cannot be
+ * resolved to one of our source files.
+ */
+function resolveModuleSpecifier(specifier, importerFile, sourceFileIndex) {
+  if (!specifier.startsWith(".") && !specifier.startsWith("/")) {
+    return null;
+  }
+  const importerDir = path.dirname(importerFile);
+  const base = specifier.startsWith("/")
+    ? path.resolve(repoRoot, specifier.replace(/^\/+/, ""))
+    : path.resolve(importerDir, specifier);
+
+  // Strip a trailing .js/.mjs/.jsx for NodeNext module-resolution (TS files compile
+  // to those extensions and imports must reference the compiled form).
+  const stripped = base.replace(/\.(m?js|jsx)$/, "");
+
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.mts`,
+    `${base}.tsx`,
+    stripped,
+    `${stripped}.ts`,
+    `${stripped}.mts`,
+    `${stripped}.tsx`,
+    path.join(base, "index.ts"),
+    path.join(base, "index.mts"),
+    path.join(stripped, "index.ts"),
+    path.join(stripped, "index.mts"),
+  ];
+  for (const candidate of candidates) {
+    const normalized = normalizePath(candidate);
+    if (sourceFileIndex.has(normalized)) {
+      return normalized;
+    }
+  }
+  return null;
+}
+
+/**
+ * For each non-test file: build a set of { localName -> stubIdentity } bindings
+ * by walking import declarations, then walk the AST and count Identifier
+ * references (outside import/export clauses and type positions) to each bound
+ * name.
+ */
+function findCallersInFile({ sourceFile, filePath }, stubIndex, sourceFileIndex) {
+  const callers = [];
+  const bindings = new Map(); // localName -> { stubFile, stubSymbol }
+  const selfFile = normalizePath(filePath);
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement)) {
+      continue;
+    }
+    if (!statement.importClause || !statement.importClause.namedBindings) {
+      continue;
+    }
+    const namedBindings = statement.importClause.namedBindings;
+    if (!ts.isNamedImports(namedBindings)) {
+      continue;
+    }
+    if (!ts.isStringLiteral(statement.moduleSpecifier)) {
+      continue;
+    }
+
+    const resolved = resolveModuleSpecifier(
+      statement.moduleSpecifier.text,
+      filePath,
+      sourceFileIndex,
+    );
+    if (!resolved) {
+      continue;
+    }
+    const stubsInModule = stubIndex.get(resolved);
+    if (!stubsInModule || stubsInModule.length === 0) {
+      continue;
+    }
+
+    for (const element of namedBindings.elements) {
+      const importedName = (element.propertyName ?? element.name).text;
+      const localName = element.name.text;
+      const stub = stubsInModule.find((s) => s.symbol === importedName);
+      if (!stub) {
+        continue;
+      }
+      bindings.set(localName, { stubFile: resolved, stubSymbol: stub.symbol });
+    }
+  }
+
+  if (bindings.size === 0) {
+    return callers;
+  }
+
+  const visit = (node) => {
+    // Skip import/export clauses entirely — the bindings themselves aren't callers.
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      return;
+    }
+
+    if (ts.isIdentifier(node) && bindings.has(node.text)) {
+      const binding = bindings.get(node.text);
+      // A caller in the stub's own source file is a self-reference, not a live caller.
+      if (binding.stubFile === selfFile) {
+        return;
+      }
+      callers.push({
+        localName: node.text,
+        stubFile: binding.stubFile,
+        stubSymbol: binding.stubSymbol,
+        line: toLine(sourceFile, node),
+      });
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return callers;
+}
+
+async function readAllowlist() {
+  const allowlistPath = path.join(repoRoot, ".throwing-stub-callers-allowlist");
+  const entries = new Map(); // "file::symbol" -> comment/note
+  try {
+    const raw = await fs.readFile(allowlistPath, "utf8");
+    for (const rawLine of raw.split("\n")) {
+      const line = rawLine.trim();
+      if (line.length === 0 || line.startsWith("#")) {
+        continue;
+      }
+      const [key, note = ""] = line.split("#", 2).map((s) => s.trim());
+      if (key.length === 0) {
+        continue;
+      }
+      entries.set(key, note);
+    }
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return { path: allowlistPath, entries, exists: false };
+    }
+    throw error;
+  }
+  return { path: allowlistPath, entries, exists: true };
+}
+
+function formatInventory(violations) {
+  if (violations.length === 0) {
+    return "";
+  }
+  const lines = [];
+  for (const v of violations) {
+    lines.push(
+      `  ${v.stub.file}::${v.stub.symbol} (line ${v.stub.line}, signals: ${v.stub.signals.join(", ")})`,
+    );
+    const callerCount = v.callers.length;
+    const shown = v.callers.slice(0, 3);
+    lines.push(`    callers: ${callerCount} site${callerCount === 1 ? "" : "s"}`);
+    for (const c of shown) {
+      lines.push(`      - ${c.file}:${c.line}`);
+    }
+    if (callerCount > shown.length) {
+      lines.push(`      - ... and ${callerCount - shown.length} more`);
+    }
+  }
+  return lines.join("\n");
+}
+
+export async function runCheck({ strict = false } = {}) {
+  const sourceFileIndex = await loadSourceFiles({ includeTests: true });
+
+  // Stub detection scans production files only. A stub declared in a test file is not a concern.
+  const stubIndex = new Map(); // canonical file path -> stubs[]
+  for (const [key, record] of sourceFileIndex) {
+    if (!isProductionFile(record.filePath)) {
+      continue;
+    }
+    const stubs = findStubsInFile(record);
+    if (stubs.length > 0) {
+      stubIndex.set(key, stubs);
+    }
+  }
+
+  // Caller detection scans production files only.
+  const allStubs = [...stubIndex.values()].flat();
+  const perStubCallers = new Map(); // "file::symbol" -> callers[]
+  for (const stub of allStubs) {
+    perStubCallers.set(`${stub.file}::${stub.symbol}`, []);
+  }
+
+  for (const [, record] of sourceFileIndex) {
+    if (!isProductionFile(record.filePath)) {
+      continue;
+    }
+    const callers = findCallersInFile(record, stubIndex, sourceFileIndex);
+    for (const caller of callers) {
+      const key = `${caller.stubFile}::${caller.stubSymbol}`;
+      const list = perStubCallers.get(key);
+      if (list) {
+        list.push({ file: normalizePath(record.filePath), line: caller.line });
+      }
+    }
+  }
+
+  const violations = [];
+  for (const stub of allStubs) {
+    const key = `${stub.file}::${stub.symbol}`;
+    const callers = perStubCallers.get(key) ?? [];
+    if (callers.length > 0) {
+      callers.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
+      violations.push({ stub, callers, key });
+    }
+  }
+  violations.sort((a, b) => a.key.localeCompare(b.key));
+
+  const allowlist = await readAllowlist();
+  const unexpected = [];
+  const stale = [];
+  const matched = [];
+
+  for (const v of violations) {
+    if (strict || !allowlist.entries.has(v.key)) {
+      unexpected.push(v);
+    } else {
+      matched.push(v);
+    }
+  }
+  for (const [key] of allowlist.entries) {
+    if (!violations.some((v) => v.key === key)) {
+      stale.push(key);
+    }
+  }
+
+  return { stubs: allStubs, violations, unexpected, stale, matched, allowlist };
+}
+
+function writeLine(stream, text) {
+  stream.write(`${text}\n`);
+}
+
+export async function main(argv = process.argv.slice(2), io) {
+  const streams = io ?? { stdout: process.stdout, stderr: process.stderr };
+  const strict = argv.includes("--strict");
+  const inventoryOnly = argv.includes("--inventory");
+  const json = argv.includes("--json");
+
+  const result = await runCheck({ strict });
+
+  if (json) {
+    writeLine(streams.stdout, JSON.stringify(result, null, 2));
+    return result.unexpected.length > 0 && !inventoryOnly ? 1 : 0;
+  }
+
+  writeLine(
+    streams.stdout,
+    `Throwing-stub-with-live-callers inventory (${result.violations.length} violation${result.violations.length === 1 ? "" : "s"}):`,
+  );
+  if (result.violations.length > 0) {
+    writeLine(streams.stdout, formatInventory(result.violations));
+  } else {
+    writeLine(streams.stdout, "  (none)");
+  }
+
+  if (result.matched.length > 0) {
+    writeLine(streams.stdout, `\nAllowlisted (tracked for remediation): ${result.matched.length}`);
+    for (const v of result.matched) {
+      const note = result.allowlist.entries.get(v.key) || "";
+      writeLine(streams.stdout, `  ${v.key}${note ? ` — ${note}` : ""}`);
+    }
+  }
+
+  if (result.stale.length > 0) {
+    writeLine(
+      streams.stdout,
+      `\nStale allowlist entries (no longer violate): ${result.stale.length}`,
+    );
+    for (const key of result.stale.toSorted((a, b) => a.localeCompare(b))) {
+      writeLine(streams.stdout, `  ${key}`);
+    }
+    writeLine(streams.stdout, "  → remove these lines from .throwing-stub-callers-allowlist");
+  }
+
+  if (inventoryOnly) {
+    return 0;
+  }
+
+  if (result.unexpected.length > 0) {
+    writeLine(streams.stderr, "");
+    writeLine(
+      streams.stderr,
+      `FAIL: ${result.unexpected.length} throwing-stub${result.unexpected.length === 1 ? "" : "s"} with live callers not on allowlist:`,
+    );
+    writeLine(streams.stderr, formatInventory(result.unexpected));
+    writeLine(streams.stderr, "");
+    writeLine(
+      streams.stderr,
+      [
+        "This class of regression shipped in #2408 — an unconditional-throw stub",
+        "left with live production callers because unit tests mocked the stub.",
+        "",
+        "To resolve:",
+        "  1. Preferred: replace the stub with a working implementation OR",
+        "     migrate callers off the stub (then delete the stub).",
+        "  2. If the stub must stay temporarily, open a remediation issue and",
+        "     add a line to `.throwing-stub-callers-allowlist`:",
+        "       <file>::<symbol>  # #<issue>",
+        "",
+        "See `CLAUDE.md` § Fork Stub Conventions for the legitimate way to add",
+        "an upstream-compat stub (no callers) without tripping this gate.",
+      ].join("\n"),
+    );
+    return 1;
+  }
+
+  writeLine(
+    streams.stdout,
+    `\nThrowing-stub-callers check passed (${result.stubs.length} stub${result.stubs.length === 1 ? "" : "s"} scanned, ${result.matched.length} allowlisted, ${result.unexpected.length} unexpected).`,
+  );
+  return 0;
+}
+
+runAsScript(import.meta.url, async () => {
+  const exitCode = await main();
+  if (exitCode !== 0) {
+    process.exit(exitCode);
+  }
+});


### PR DESCRIPTION
## Summary

Adds a CI gate that detects exported throwing stubs (body is a single
`throw`) carrying any stub-calibration signal — variadic-unknown
signature, fork-attributed throw message, or `// Gutted in RemoteClaw
fork` marker comment — and flags symbols that have live non-test
callers. Prevents recurrence of the class shipped in #2408, where
`resolveAgentRuntimeOrThrow` was left as an unconditional-throw stub
with four live callers, crashing every agent dispatch in production
because unit tests mocked the stub.

Closes #2410.

## Detection strategy

**AST-based** (TypeScript compiler API), scanning `src/`, `extensions/`,
`ui/` for exported function declarations and exported `const` bindings
with arrow/function-expression initializers. A function is classified
as a "throwing stub" when **both**:

1. Body is a single statement: `throw new <Error>(...)`, **and**
2. At least one of these signals fires:
   - Variadic-unknown signature: `(...args: unknown[])` / `(..._args: unknown[])`
     (supports `unknown[]`, `readonly unknown[]`, `Array<unknown>` forms).
   - Throw message matches `/not available in RemoteClaw fork|\bgutted\b|upstream-compat/i`.
   - Leading comment matches `/Gutted in RemoteClaw fork/i`.

**Callers** are found by walking import declarations in every non-test
file, binding imported local names to their stub identities, then
scanning the AST for `Identifier` references outside import/export
clauses. Aliased imports (`import { foo as bar }`) are tracked by local
name.

**Legitimate typed error-throw helpers are not flagged.** The repo's
existing `exitHooksCliWithError(err: unknown): never`,
`throwPathEscapesBoundary(params: {…}): never`,
`throwGatewayAuthResolutionError(reason: string): never`, and
`throwUnresolvedGatewaySecretInput(path: string): never` all have typed
scalar/object parameters and non-fork throw messages — so the check
scans exactly one stub on `main`.

## Current baseline

Current inventory on `main`:

```
Throwing-stub-with-live-callers inventory (1 violation):
  src/agents/agent-scope.ts::resolveAgentRuntimeOrThrow (line 491, signals: variadic-unknown, fork-message, marker-comment)
    callers: 4 sites
      - src/auto-reply/reply/agent-runner-execution.ts:350
      - src/commands/agent.ts:189
      - src/cron/isolated-agent/run.ts:342
      - src/cron/isolated-agent/run.ts:389
```

Remediation for this entry is tracked in #2408. The allowlist mechanism
lets the gate ship now and start catching new regressions while the
known-violation fix lands separately.

## False-positive budget

`node scripts/check-throwing-stub-callers.mjs` on `main` → **exit 0**
(single violation allowlisted). Once #2408 fix merges, removing the
allowlist line will let the default check pass without `--strict`.

`--strict` mode exits 1 on `main` today, which is exactly the signal
that proves the gate will enforce after #2408 remediation.

## Self-test evidence

Synthetic stub+caller pair injected via temporary fixtures, detection
output captured, fixtures removed. From the execution transcript:

```
--- check output with fixture ---
Throwing-stub-with-live-callers inventory (2 violations):
  src/__self-test__/fake-stub.ts::fakeStubOrThrow (line 2, signals: variadic-unknown, fork-message)
    callers: 1 site
      - src/__self-test__/fake-caller.ts:3
  src/agents/agent-scope.ts::resolveAgentRuntimeOrThrow (line 491, signals: variadic-unknown, fork-message, marker-comment)
    callers: 4 sites
      …

Allowlisted (tracked for remediation): 1
  src/agents/agent-scope.ts::resolveAgentRuntimeOrThrow

FAIL: 1 throwing-stub with live callers not on allowlist:
  src/__self-test__/fake-stub.ts::fakeStubOrThrow (line 2, signals: variadic-unknown, fork-message)
    callers: 1 site
      - src/__self-test__/fake-caller.ts:3
```

Exit code 1 — the gate fires on the synthetic new violation while
continuing to allow the tracked one.

## CI integration

New job `throwing-stub-callers-gate` in `.github/workflows/ci.yml`,
added to the `CI` umbrella job's `needs` list and its result-check
shell conditional. Mirrors the existing `stub-debt-gate` shape.

## Documentation

New § Fork Stub Conventions in `CLAUDE.md`:

- The legitimate no-caller upstream-compat stub pattern (with marker
  comment, won't trip the gate).
- How to add an allowlist entry with a tracking issue when a temporary
  live regression window is unavoidable.
- Local detection commands (default, `--strict`, `--inventory`).

Also expanded § CI with a Fork-integrity gates subsection covering all
four gate jobs (rebrand, zombie-import, stub-debt, throwing-stub-callers,
obsolescence-audit).

## Known limitations

- **Barrel re-exports** (importing through `./index.ts` that re-exports
  the stub) are not traced — module resolution matches the imported
  path directly. Acceptable for MVP: current fork stubs are imported
  via direct relative paths. Tighten in a follow-up if a barrel pattern
  appears.
- **Cross-module identifier collisions**: the AST binding tracks local
  names scoped to the importing file, so collisions within a single
  file are impossible. The only residual concern is a future stub whose
  name collides with an unrelated identifier that happens to be
  re-declared locally — not a pattern in the current codebase.

## Test plan

- [x] `node scripts/check-throwing-stub-callers.mjs` on `main` state exits 0.
- [x] `--strict` mode exits 1 on `main` state (demonstrates detection).
- [x] Synthetic stub+caller fixture is detected (self-test transcript above).
- [x] `pnpm check` (format + typecheck + lint) passes.
- [x] Legitimate `: never` helpers not flagged (verified 4 existing helpers).
- [x] Mock/test-helper files excluded from caller count (verified 4 callers match live production sites only).
- [ ] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)