### PR TITLE
fix(agents): restore resolveAgentRuntimeOrThrow body — unblock agent dispatch (#2408)

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -13,6 +13,7 @@ import {
   resolveEffectiveModelFallbacks,
   resolveAgentModelFallbacksOverride,
   resolveAgentModelPrimary,
+  resolveAgentRuntimeOrThrow,
   resolveRunModelFallbacksOverride,
   resolveAgentWorkspaceDir,
   resolveAgentIdByWorkspacePath,
@@ -519,5 +520,52 @@ describe("resolveAgentIdsByWorkspacePath", () => {
       "ops",
       "main",
     ]);
+  });
+});
+
+describe("resolveAgentRuntimeOrThrow", () => {
+  it("returns runtime string when per-agent runtime is configured", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", runtime: "gemini" }],
+      },
+    };
+    expect(resolveAgentRuntimeOrThrow(cfg, "main")).toBe("gemini");
+  });
+
+  it("returns runtime string when only defaults.runtime is configured", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main" }],
+        defaults: { runtime: "claude" },
+      },
+    };
+    expect(resolveAgentRuntimeOrThrow(cfg, "main")).toBe("claude");
+  });
+
+  it("prefers per-agent runtime over defaults.runtime", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "main", runtime: "codex" }],
+        defaults: { runtime: "claude" },
+      },
+    };
+    expect(resolveAgentRuntimeOrThrow(cfg, "main")).toBe("codex");
+  });
+
+  it("throws when no runtime is configured", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "main" }] },
+    };
+    expect(() => resolveAgentRuntimeOrThrow(cfg, "main")).toThrow(
+      /No runtime configured for agent "main"/,
+    );
+  });
+
+  it("throws message names the agent id and points to agents.defaults.runtime", () => {
+    const cfg: RemoteClawConfig = {};
+    expect(() => resolveAgentRuntimeOrThrow(cfg, "worker-42")).toThrow(
+      /agent "worker-42".*agents\.defaults\.runtime/s,
+    );
   });
 });

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -434,7 +434,7 @@ export function resolveAgentWorkspaceDirOrNull(
   }
 }
 
-// ── Upstream-compat stubs (gutted in fork) ───────────────────────────
+// ── Fork-native runtime & auth resolvers ─────────────────────────────
 
 /** Resolve per-agent runtime (fork-specific CLI runtime identifier). */
 export function resolveAgentRuntime(cfg: RemoteClawConfig, agentId: string): string | undefined {
@@ -487,9 +487,18 @@ export function resolveAgentRuntimeEnv(
   return undefined;
 }
 
-/** Stub: agent runtime-or-throw gutted in RemoteClaw fork. */
-export function resolveAgentRuntimeOrThrow(..._args: unknown[]): never {
-  throw new Error("resolveAgentRuntimeOrThrow is not available in RemoteClaw fork");
+/**
+ * Resolve per-agent runtime (CLI identifier) — throws if neither per-agent
+ * config nor defaults define a runtime.
+ */
+export function resolveAgentRuntimeOrThrow(cfg: RemoteClawConfig, agentId: string): string {
+  const runtime = resolveAgentRuntime(cfg, agentId);
+  if (!runtime) {
+    throw new Error(
+      `No runtime configured for agent "${agentId}". Set agents.defaults.runtime to one of: claude, gemini, codex, opencode`,
+    );
+  }
+  return runtime;
 }
 
 /** Resolve per-agent auth profile (fork-specific auth profile reference). */


### PR DESCRIPTION
## Summary

Fixes #2408. `src/agents/agent-scope.ts:491-493` was an unconditional-throw stub introduced by the sync in #2360 (upstream v2026.3.7 → v2026.3.8). It crashed every agent dispatch across three call sites — Slack auto-reply, `/agent` CLI, and cron isolated-agent runs. Users saw:

```
⚠️ Agent failed before reply: resolveAgentRuntimeOrThrow is not available in RemoteClaw fork.
```

This PR restores the prescribed semantics: delegate to the non-throwing sibling `resolveAgentRuntime`, throw only when no runtime is configured, with a message that names the agent id and points to `agents.defaults.runtime`.

## Changes

- **`src/agents/agent-scope.ts:491-502`** — replaced throwing stub with real body. Return type `string` (not literal union) matches `resolveAgentRuntime`'s shape and avoids over-constraining fork-native runtime names.
- **`src/agents/agent-scope.ts:437`** — header comment changed from `"Upstream-compat stubs (gutted in fork)"` to `"Fork-native runtime & auth resolvers"`. Every function in this section is fork-native; the old header was already misleading and becomes actively wrong after this fix.
- **`src/agents/agent-scope.test.ts`** — added `describe("resolveAgentRuntimeOrThrow")` with 5 regression cases covering both paths (configured → return, missing → throw) and throw-message format.

No call-site changes required — all 3 live callers already pass `(cfg, agentId)` positionally and use the return where a `string` is expected.

## Verification

- `pnpm check` → format / tsgo / lint all clean.
- `pnpm vitest run src/agents/agent-scope.test.ts -t "resolveAgentRuntimeOrThrow"` → 5/5 passed.
- `pnpm vitest run --config vitest.unit.config.ts src/cron/isolated-agent/run.auth-retry.test.ts src/cron/isolated-agent/run.channel-bridge.test.ts` → 27/27 passed (existing mocks at `run.auth-retry.test.ts:50` and `run.channel-bridge.test.ts:71` remain valid — they return `"claude"`, which is compatible with the new `() => string` signature).
- `pnpm test` → 795 files / 6996 tests / 3 skipped / 0 failed.

## Acceptance criteria (from #2408)

- [x] `resolveAgentRuntimeOrThrow(cfg, agentId)` returns the runtime string when `resolveAgentRuntime` resolves a value.
- [x] Throws with a clear message naming the agent id and pointing to `agents.defaults.runtime` when no runtime configured.
- [x] Regression test asserts both paths (configured → return; missing → throw).
- [x] `pnpm check` passes (format + typecheck + lint).
- [x] `pnpm test` passes (existing call-site mocks remain valid).
- [x] Header comment at `agent-scope.ts:437` relocated.
- N/A — LIVE smoke (`LIVE=1 pnpm test:live`): CLAUDE.md § PR Submission Workflow requires LIVE only for `src/middleware/` changes. This PR touches `src/agents/agent-scope.ts` only — LIVE smoke is not in scope for this change.

## Test plan

- [x] Unit tests pass locally
- [x] Type-check + lint clean
- [ ] CI green on PR