### PR TITLE
test(live): cover real agent dispatch in LIVE smoke (#2411)

### DIFF
--- a/src/middleware/__smoke__/agent-dispatch.live.test.ts
+++ b/src/middleware/__smoke__/agent-dispatch.live.test.ts
@@ -1,0 +1,111 @@
+import { randomBytes } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { resolveAgentRuntimeOrThrow } from "../../agents/agent-scope.js";
+import type { RemoteClawConfig } from "../../config/config.js";
+import { isTruthyEnvValue } from "../../infra/env.js";
+import { ChannelBridge } from "../channel-bridge.js";
+import { SessionMap } from "../session-map.js";
+import type { ChannelMessage } from "../types.js";
+
+const LIVE = isTruthyEnvValue(process.env.LIVE);
+
+/**
+ * Regression coverage for #2408-class defects — a broken `resolveAgentRuntimeOrThrow`
+ * (e.g., unconditional-throw stub) must fail this test. Every other middleware smoke
+ * test hardcodes `provider: "claude"|"codex"|...`; this one derives `provider` via
+ * the real resolver, mirroring the production call chain at
+ * `src/auto-reply/reply/agent-runner-execution.ts:349-350`,
+ * `src/commands/agent.ts:189`, and `src/cron/isolated-agent/run.ts:342,389`.
+ */
+
+/** Env vars that Claude Code sets and that cause nesting rejection in `claude -p`. */
+const CLAUDE_CODE_ENV_KEYS = [
+  "CLAUDECODE",
+  "CLAUDE_CODE_ENTRYPOINT",
+  "CLAUDE_CODE_MAX_OUTPUT_TOKENS",
+];
+
+describe.skipIf(!LIVE)(
+  "agent dispatch live test (resolveAgentRuntimeOrThrow → ChannelBridge)",
+  () => {
+    let bridge: ChannelBridge;
+    let tempDir: string;
+    const savedEnv: Record<string, string | undefined> = {};
+
+    const channelId = "agent-dispatch-live";
+    const userId = "agent-dispatch-user";
+    const agentId = "main";
+
+    function makeMessage(text: string): ChannelMessage {
+      return {
+        id: randomBytes(4).toString("hex"),
+        text,
+        from: userId,
+        channelId,
+        provider: "test",
+        timestamp: Date.now(),
+      };
+    }
+
+    beforeAll(async () => {
+      for (const key of CLAUDE_CODE_ENV_KEYS) {
+        savedEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+
+      tempDir = await mkdtemp(join(tmpdir(), "rc-agent-dispatch-live-"));
+
+      // Write a no-op MCP server script so the ChannelBridge MCP config points to a valid file
+      const noopMcpServer = join(tempDir, "noop-mcp-server.js");
+      await writeFile(noopMcpServer, "// no-op MCP server for agent dispatch live test\n");
+
+      // Mirror the production call chain: resolver → ChannelBridge, not hardcoded string.
+      const cfg: RemoteClawConfig = {
+        agents: {
+          list: [{ id: agentId }],
+          defaults: { runtime: "claude" },
+        },
+      };
+      const provider = resolveAgentRuntimeOrThrow(cfg, agentId);
+
+      const sessionMap = new SessionMap(tempDir);
+      bridge = new ChannelBridge({
+        provider,
+        sessionMap,
+        gatewayUrl: "",
+        gatewayToken: "",
+        workspaceDir: tempDir,
+        mcpServerPath: noopMcpServer,
+      });
+    });
+
+    afterAll(async () => {
+      for (const key of CLAUDE_CODE_ENV_KEYS) {
+        if (savedEnv[key] !== undefined) {
+          process.env[key] = savedEnv[key];
+        } else {
+          delete process.env[key];
+        }
+      }
+
+      if (tempDir) {
+        await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      }
+    });
+
+    it("resolves runtime and dispatches through ChannelBridge to a real CLI", async () => {
+      const result = await bridge.handle(makeMessage("What is 2+2? Reply with just the number."));
+
+      expect(result.payloads.length).toBeGreaterThan(0);
+      expect(result.run.text).toBeTruthy();
+      expect(result.run.text).toContain("4");
+      expect(result.run.sessionId).toBeTruthy();
+      expect(result.run.aborted).toBe(false);
+      expect(result.run.durationMs).toBeGreaterThan(0);
+      expect(result.error).toBeUndefined();
+    }, 60_000);
+  },
+);


### PR DESCRIPTION
## Summary

Closes #2411.

Adds `src/middleware/__smoke__/agent-dispatch.live.test.ts` that derives the CLI provider via `resolveAgentRuntimeOrThrow(cfg, agentId)` and passes it to `ChannelBridge.handle` — mirroring the production call chain at `src/auto-reply/reply/agent-runner-execution.ts:349-350`, `src/commands/agent.ts:189`, and `src/cron/isolated-agent/run.ts:342,389`. Every other middleware smoke test hardcodes `provider: "claude"|"codex"|...`, so a broken resolver (as in #2408, where the function was an unconditional-throw stub) was invisible to LIVE coverage.

## LIVE test inventory (middleware / runtime paths)

| File | Coverage | Exercises resolver? |
|---|---|---|
| `src/middleware/__smoke__/claude.live.test.ts` | `claude -p` dispatch, image, session resume | No — `provider: "claude"` hardcoded |
| `src/middleware/__smoke__/codex.live.test.ts` | Codex dispatch, image, session resume | No — `provider: "codex"` hardcoded |
| `src/middleware/__smoke__/gemini.live.test.ts` | Gemini dispatch, image, audio, resume | No — `provider: "gemini"` hardcoded |
| `src/middleware/__smoke__/opencode.live.test.ts` | OpenCode dispatch | No — `provider: "opencode"` hardcoded |
| `src/middleware/__smoke__/integration.live.test.ts` | M2 session resumption | No — `provider: "claude"` hardcoded |
| `src/gateway/gateway-cli-backend.live.test.ts` | Gateway CLI backend | N/A (no ChannelBridge) |
| `src/gateway/android-node.capabilities.live.test.ts` | Gateway capabilities | N/A (no ChannelBridge) |
| **`src/middleware/__smoke__/agent-dispatch.live.test.ts`** (new) | `resolveAgentRuntimeOrThrow` → `ChannelBridge.handle` | **Yes — regression gate** |

## Regression-catch evidence

Simulated the pre-#2408 broken state by temporarily patching `src/agents/agent-scope.ts:494-502` back to the unconditional-throw stub:

```ts
export function resolveAgentRuntimeOrThrow(..._args: unknown[]): never {
  throw new Error("resolveAgentRuntimeOrThrow is not available in RemoteClaw fork");
}
```

### Against broken state

```
 ↓ src/middleware/__smoke__/agent-dispatch.live.test.ts > agent dispatch live test (resolveAgentRuntimeOrThrow → ChannelBridge) > resolves runtime and dispatches through ChannelBridge to a real CLI

⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/middleware/__smoke__/agent-dispatch.live.test.ts > agent dispatch live test (resolveAgentRuntimeOrThrow → ChannelBridge)
Error: resolveAgentRuntimeOrThrow is not available in RemoteClaw fork
 ❯ resolveAgentRuntimeOrThrow src/agents/agent-scope.ts:495:9
 ❯ src/middleware/__smoke__/agent-dispatch.live.test.ts:72:24

 Test Files  1 failed (1)
      Tests  1 skipped (1)
```

vitest exit: non-zero. Error string matches the exact user-facing message from #2408.

### Against current HEAD (fixed state, includes #2408)

```
 ✓ src/middleware/__smoke__/agent-dispatch.live.test.ts > agent dispatch live test (resolveAgentRuntimeOrThrow → ChannelBridge) > resolves runtime and dispatches through ChannelBridge to a real CLI  3924ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Real `claude -p` dispatch, ~4s.

## Wiring decision

**LIVE smoke remains a manual PR-author step**, per project `CLAUDE.md` § PR Submission Workflow:

> **LIVE smoke tests**: If the PR touches middleware or runtime code (`src/middleware/`), run `LIVE=1 pnpm test:live` before or during the PR drive loop. Report results in the PR description or as a comment.

This PR does NOT introduce CI enforcement of LIVE smoke — that would require hosted CI to have real CLI binaries and API credentials, and is tracked separately if desired. The new test follows the existing `describe.skipIf(!LIVE)` pattern so CI without `LIVE=1` continues to skip it.

## LIVE smoke — ran locally

`LIVE=1 pnpm vitest run --config vitest.live.config.ts src/middleware/__smoke__/agent-dispatch.live.test.ts` → 1 passed in 3.93s. See "Against current HEAD" excerpt above.

## Test plan

- [ ] CI (`build`, `test`, `lint`, `docs`) pass
- [ ] Reviewer runs `LIVE=1 pnpm vitest run --config vitest.live.config.ts src/middleware/__smoke__/agent-dispatch.live.test.ts` locally (optional — requires `claude` CLI + Claude credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)