### PR TITLE
fix: cherry-pick B1-B10 audit real gaps (#2406 batch close)

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -72,6 +72,7 @@ import {
   type MattermostWebSocketFactory,
 } from "./monitor-websocket.js";
 import { runWithReconnect } from "./reconnect.js";
+import { deliverMattermostReplyPayload } from "./reply-delivery.js";
 import { sendMessageMattermost } from "./send.js";
 import {
   DEFAULT_COMMAND_SPECS,
@@ -591,36 +592,17 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             ...prefixOptions,
             humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
             deliver: async (payload: ReplyPayload) => {
-              const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
-              const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
-              if (mediaUrls.length === 0) {
-                const chunkMode = core.channel.text.resolveChunkMode(
-                  cfg,
-                  "mattermost",
-                  account.accountId,
-                );
-                const chunks = core.channel.text.chunkMarkdownTextWithMode(
-                  text,
-                  textLimit,
-                  chunkMode,
-                );
-                for (const chunk of chunks.length > 0 ? chunks : [text]) {
-                  if (!chunk) continue;
-                  await sendMessageMattermost(to, chunk, {
-                    accountId: account.accountId,
-                  });
-                }
-              } else {
-                let first = true;
-                for (const mediaUrl of mediaUrls) {
-                  const caption = first ? text : "";
-                  first = false;
-                  await sendMessageMattermost(to, caption, {
-                    accountId: account.accountId,
-                    mediaUrl,
-                  });
-                }
-              }
+              await deliverMattermostReplyPayload({
+                core,
+                cfg,
+                payload,
+                to,
+                accountId: account.accountId,
+                agentId: route.agentId,
+                textLimit,
+                tableMode,
+                sendMessage: sendMessageMattermost,
+              });
               runtime.log?.(`delivered button-click reply to ${to}`);
             },
             onError: (err, info) => {
@@ -1339,42 +1321,21 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
         typingCallbacks,
         deliver: async (payload: ReplyPayload) => {
-          const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
-          const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
-          if (mediaUrls.length === 0) {
-            const chunkMode = core.channel.text.resolveChunkMode(
-              cfg,
-              "mattermost",
-              account.accountId,
-            );
-            const chunks = core.channel.text.chunkMarkdownTextWithMode(text, textLimit, chunkMode);
-            for (const chunk of chunks.length > 0 ? chunks : [text]) {
-              if (!chunk) {
-                continue;
-              }
-              await sendMessageMattermost(to, chunk, {
-                accountId: account.accountId,
-                replyToId: resolveMattermostReplyRootId({
-                  threadRootId,
-                  replyToId: payload.replyToId,
-                }),
-              });
-            }
-          } else {
-            let first = true;
-            for (const mediaUrl of mediaUrls) {
-              const caption = first ? text : "";
-              first = false;
-              await sendMessageMattermost(to, caption, {
-                accountId: account.accountId,
-                mediaUrl,
-                replyToId: resolveMattermostReplyRootId({
-                  threadRootId,
-                  replyToId: payload.replyToId,
-                }),
-              });
-            }
-          }
+          await deliverMattermostReplyPayload({
+            core,
+            cfg,
+            payload,
+            to,
+            accountId: account.accountId,
+            agentId: route.agentId,
+            replyToId: resolveMattermostReplyRootId({
+              threadRootId,
+              replyToId: payload.replyToId,
+            }),
+            textLimit,
+            tableMode,
+            sendMessage: sendMessageMattermost,
+          });
           runtime.log?.(`delivered reply to ${to}`);
         },
         onError: (err, info) => {

--- a/extensions/mattermost/src/mattermost/reply-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.test.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { RemoteClawConfig } from "remoteclaw/plugin-sdk/mattermost";
+import { describe, expect, it, vi } from "vitest";
+import { deliverMattermostReplyPayload } from "./reply-delivery.js";
+
+describe("deliverMattermostReplyPayload", () => {
+  it("passes agent-scoped mediaLocalRoots when sending media paths", async () => {
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-mm-state-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    try {
+      const sendMessage = vi.fn(async () => undefined);
+      const core = {
+        channel: {
+          text: {
+            convertMarkdownTables: vi.fn((text: string) => text),
+            resolveChunkMode: vi.fn(() => "length"),
+            chunkMarkdownTextWithMode: vi.fn((text: string) => [text]),
+          },
+        },
+      } as any;
+
+      const agentId = "agent-1";
+      const mediaUrl = `file://${path.join(stateDir, `workspace-${agentId}`, "photo.png")}`;
+      const cfg = {} satisfies RemoteClawConfig;
+
+      await deliverMattermostReplyPayload({
+        core,
+        cfg,
+        payload: { text: "caption", mediaUrl },
+        to: "channel:town-square",
+        accountId: "default",
+        agentId,
+        replyToId: "root-post",
+        textLimit: 4000,
+        tableMode: "off",
+        sendMessage,
+      });
+
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      expect(sendMessage).toHaveBeenCalledWith(
+        "channel:town-square",
+        "caption",
+        expect.objectContaining({
+          accountId: "default",
+          mediaUrl,
+          replyToId: "root-post",
+          mediaLocalRoots: expect.arrayContaining([path.join(stateDir, `workspace-${agentId}`)]),
+        }),
+      );
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("forwards replyToId for text-only chunked replies", async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const core = {
+      channel: {
+        text: {
+          convertMarkdownTables: vi.fn((text: string) => text),
+          resolveChunkMode: vi.fn(() => "length"),
+          chunkMarkdownTextWithMode: vi.fn(() => ["hello"]),
+        },
+      },
+    } as any;
+
+    await deliverMattermostReplyPayload({
+      core,
+      cfg: {} satisfies RemoteClawConfig,
+      payload: { text: "hello" },
+      to: "channel:town-square",
+      accountId: "default",
+      agentId: "agent-1",
+      replyToId: "root-post",
+      textLimit: 4000,
+      tableMode: "off",
+      sendMessage,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith("channel:town-square", "hello", {
+      accountId: "default",
+      replyToId: "root-post",
+    });
+  });
+});

--- a/extensions/mattermost/src/mattermost/reply-delivery.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.ts
@@ -1,0 +1,75 @@
+import type {
+  RemoteClawConfig,
+  PluginRuntime,
+  ReplyPayload,
+} from "remoteclaw/plugin-sdk/mattermost";
+import { getAgentScopedMediaLocalRoots } from "remoteclaw/plugin-sdk/mattermost";
+
+type MarkdownTableMode = Parameters<PluginRuntime["channel"]["text"]["convertMarkdownTables"]>[1];
+
+type SendMattermostMessage = (
+  to: string,
+  text: string,
+  opts: {
+    accountId?: string;
+    mediaUrl?: string;
+    mediaLocalRoots?: readonly string[];
+    replyToId?: string;
+  },
+) => Promise<unknown>;
+
+export async function deliverMattermostReplyPayload(params: {
+  core: PluginRuntime;
+  cfg: RemoteClawConfig;
+  payload: ReplyPayload;
+  to: string;
+  accountId: string;
+  agentId?: string;
+  replyToId?: string;
+  textLimit: number;
+  tableMode: MarkdownTableMode;
+  sendMessage: SendMattermostMessage;
+}): Promise<void> {
+  const mediaUrls =
+    params.payload.mediaUrls ?? (params.payload.mediaUrl ? [params.payload.mediaUrl] : []);
+  const text = params.core.channel.text.convertMarkdownTables(
+    params.payload.text ?? "",
+    params.tableMode,
+  );
+
+  if (mediaUrls.length === 0) {
+    const chunkMode = params.core.channel.text.resolveChunkMode(
+      params.cfg,
+      "mattermost",
+      params.accountId,
+    );
+    const chunks = params.core.channel.text.chunkMarkdownTextWithMode(
+      text,
+      params.textLimit,
+      chunkMode,
+    );
+    for (const chunk of chunks.length > 0 ? chunks : [text]) {
+      if (!chunk) {
+        continue;
+      }
+      await params.sendMessage(params.to, chunk, {
+        accountId: params.accountId,
+        replyToId: params.replyToId,
+      });
+    }
+    return;
+  }
+
+  const mediaLocalRoots = getAgentScopedMediaLocalRoots(params.cfg, params.agentId);
+  let first = true;
+  for (const mediaUrl of mediaUrls) {
+    const caption = first ? text : "";
+    first = false;
+    await params.sendMessage(params.to, caption, {
+      accountId: params.accountId,
+      mediaUrl,
+      mediaLocalRoots,
+      replyToId: params.replyToId,
+    });
+  }
+}

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -34,6 +34,7 @@ import {
   authorizeMattermostCommandInvocation,
   normalizeMattermostAllowList,
 } from "./monitor-auth.js";
+import { deliverMattermostReplyPayload } from "./reply-delivery.js";
 import { sendMessageMattermost } from "./send.js";
 import {
   parseSlashCommandPayload,
@@ -457,32 +458,17 @@ async function handleSlashCommandAsync(params: {
       ...prefixOptions,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
       deliver: async (payload: ReplyPayload) => {
-        const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
-        const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
-        if (mediaUrls.length === 0) {
-          const chunkMode = core.channel.text.resolveChunkMode(
-            cfg,
-            "mattermost",
-            account.accountId,
-          );
-          const chunks = core.channel.text.chunkMarkdownTextWithMode(text, textLimit, chunkMode);
-          for (const chunk of chunks.length > 0 ? chunks : [text]) {
-            if (!chunk) continue;
-            await sendMessageMattermost(to, chunk, {
-              accountId: account.accountId,
-            });
-          }
-        } else {
-          let first = true;
-          for (const mediaUrl of mediaUrls) {
-            const caption = first ? text : "";
-            first = false;
-            await sendMessageMattermost(to, caption, {
-              accountId: account.accountId,
-              mediaUrl,
-            });
-          }
-        }
+        await deliverMattermostReplyPayload({
+          core,
+          cfg,
+          payload,
+          to,
+          accountId: account.accountId,
+          agentId: route.agentId,
+          textLimit,
+          tableMode,
+          sendMessage: sendMessageMattermost,
+        });
         runtime.log?.(`delivered slash reply to ${to}`);
       },
       onError: (err, info) => {

--- a/extensions/msteams/src/monitor.test.ts
+++ b/extensions/msteams/src/monitor.test.ts
@@ -3,7 +3,7 @@ import type { Server } from "node:http";
 import { createConnection, type AddressInfo } from "node:net";
 import express from "express";
 import { describe, expect, it } from "vitest";
-import { applyMSTeamsWebhookTimeouts } from "./monitor.js";
+import { applyMSTeamsWebhookTimeouts } from "./webhook-timeouts.js";
 
 async function closeServer(server: Server): Promise<void> {
   await new Promise<void>((resolve) => {

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -1,4 +1,3 @@
-import type { Server } from "node:http";
 import type { Request, Response } from "express";
 import {
   DEFAULT_WEBHOOK_MAX_BODY_BYTES,
@@ -21,6 +20,7 @@ import {
 import { getMSTeamsRuntime } from "./runtime.js";
 import { createMSTeamsAdapter, loadMSTeamsSdkWithAuth } from "./sdk.js";
 import { resolveMSTeamsCredentials } from "./token.js";
+import { applyMSTeamsWebhookTimeouts } from "./webhook-timeouts.js";
 
 export type MonitorMSTeamsOpts = {
   cfg: RemoteClawConfig;
@@ -36,31 +36,6 @@ export type MonitorMSTeamsResult = {
 };
 
 const MSTEAMS_WEBHOOK_MAX_BODY_BYTES = DEFAULT_WEBHOOK_MAX_BODY_BYTES;
-const MSTEAMS_WEBHOOK_INACTIVITY_TIMEOUT_MS = 30_000;
-const MSTEAMS_WEBHOOK_REQUEST_TIMEOUT_MS = 30_000;
-const MSTEAMS_WEBHOOK_HEADERS_TIMEOUT_MS = 15_000;
-
-export type ApplyMSTeamsWebhookTimeoutsOpts = {
-  inactivityTimeoutMs?: number;
-  requestTimeoutMs?: number;
-  headersTimeoutMs?: number;
-};
-
-export function applyMSTeamsWebhookTimeouts(
-  httpServer: Server,
-  opts?: ApplyMSTeamsWebhookTimeoutsOpts,
-): void {
-  const inactivityTimeoutMs = opts?.inactivityTimeoutMs ?? MSTEAMS_WEBHOOK_INACTIVITY_TIMEOUT_MS;
-  const requestTimeoutMs = opts?.requestTimeoutMs ?? MSTEAMS_WEBHOOK_REQUEST_TIMEOUT_MS;
-  const headersTimeoutMs = Math.min(
-    opts?.headersTimeoutMs ?? MSTEAMS_WEBHOOK_HEADERS_TIMEOUT_MS,
-    requestTimeoutMs,
-  );
-
-  httpServer.setTimeout(inactivityTimeoutMs);
-  httpServer.requestTimeout = requestTimeoutMs;
-  httpServer.headersTimeout = headersTimeoutMs;
-}
 
 export async function monitorMSTeamsProvider(
   opts: MonitorMSTeamsOpts,

--- a/extensions/msteams/src/webhook-timeouts.ts
+++ b/extensions/msteams/src/webhook-timeouts.ts
@@ -1,0 +1,27 @@
+import type { Server } from "node:http";
+
+const MSTEAMS_WEBHOOK_INACTIVITY_TIMEOUT_MS = 30_000;
+const MSTEAMS_WEBHOOK_REQUEST_TIMEOUT_MS = 30_000;
+const MSTEAMS_WEBHOOK_HEADERS_TIMEOUT_MS = 15_000;
+
+export type ApplyMSTeamsWebhookTimeoutsOpts = {
+  inactivityTimeoutMs?: number;
+  requestTimeoutMs?: number;
+  headersTimeoutMs?: number;
+};
+
+export function applyMSTeamsWebhookTimeouts(
+  httpServer: Server,
+  opts?: ApplyMSTeamsWebhookTimeoutsOpts,
+): void {
+  const inactivityTimeoutMs = opts?.inactivityTimeoutMs ?? MSTEAMS_WEBHOOK_INACTIVITY_TIMEOUT_MS;
+  const requestTimeoutMs = opts?.requestTimeoutMs ?? MSTEAMS_WEBHOOK_REQUEST_TIMEOUT_MS;
+  const headersTimeoutMs = Math.min(
+    opts?.headersTimeoutMs ?? MSTEAMS_WEBHOOK_HEADERS_TIMEOUT_MS,
+    requestTimeoutMs,
+  );
+
+  httpServer.setTimeout(inactivityTimeoutMs);
+  httpServer.requestTimeout = requestTimeoutMs;
+  httpServer.headersTimeout = headersTimeoutMs;
+}

--- a/src/agents/path-policy.test.ts
+++ b/src/agents/path-policy.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveSandboxInputPathMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./sandbox-paths.js", () => ({
+  resolveSandboxInputPath: resolveSandboxInputPathMock,
+}));
+
+import { toRelativeWorkspacePath } from "./path-policy.js";
+
+describe("toRelativeWorkspacePath (windows semantics)", () => {
+  beforeEach(() => {
+    resolveSandboxInputPathMock.mockReset();
+    resolveSandboxInputPathMock.mockImplementation((filePath: string) => filePath);
+  });
+
+  it("accepts windows paths with mixed separators and case", () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      const root = "C:\\Users\\User\\RemoteClaw";
+      const candidate = "c:/users/user/remoteclaw/memory/log.txt";
+      expect(toRelativeWorkspacePath(root, candidate)).toBe("memory\\log.txt");
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("rejects windows paths outside workspace root", () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      const root = "C:\\Users\\User\\RemoteClaw";
+      const candidate = "C:\\Users\\User\\Other\\log.txt";
+      expect(() => toRelativeWorkspacePath(root, candidate)).toThrow("Path escapes workspace root");
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+});

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -20,6 +20,7 @@ import {
   SUBAGENT_ENDED_REASON_KILLED,
   type SubagentLifecycleEndedReason,
 } from "./subagent-lifecycle-events.js";
+import { scheduleOrphanRecovery } from "./subagent-orphan-recovery.js";
 import {
   resolveCleanupCompletionReason,
   resolveDeferredCleanupDecision,
@@ -527,6 +528,13 @@ function restoreSubagentRunsOnce() {
     for (const runId of subagentRuns.keys()) {
       resumeSubagentRun(runId);
     }
+
+    // Schedule orphan recovery for subagent sessions that were aborted
+    // by a SIGUSR1 reload. This runs after a short delay to let the
+    // gateway fully bootstrap first. (#47711)
+    scheduleOrphanRecovery({
+      getActiveRuns: () => subagentRuns,
+    });
   } catch {
     // ignore restore failures
   }

--- a/src/browser/cdp-proxy-bypass.test.ts
+++ b/src/browser/cdp-proxy-bypass.test.ts
@@ -1,0 +1,159 @@
+import http from "node:http";
+import https from "node:https";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getDirectAgentForCdp, hasProxyEnv, withNoProxyForLocalhost } from "./cdp-proxy-bypass.js";
+
+describe("cdp-proxy-bypass", () => {
+  describe("getDirectAgentForCdp", () => {
+    it("returns http.Agent for http://localhost URLs", () => {
+      const agent = getDirectAgentForCdp("http://localhost:9222");
+      expect(agent).toBeInstanceOf(http.Agent);
+    });
+
+    it("returns http.Agent for http://127.0.0.1 URLs", () => {
+      const agent = getDirectAgentForCdp("http://127.0.0.1:9222/json/version");
+      expect(agent).toBeInstanceOf(http.Agent);
+    });
+
+    it("returns https.Agent for wss://localhost URLs", () => {
+      const agent = getDirectAgentForCdp("wss://localhost:9222");
+      expect(agent).toBeInstanceOf(https.Agent);
+    });
+
+    it("returns http.Agent for ws://[::1] URLs", () => {
+      const agent = getDirectAgentForCdp("ws://[::1]:9222");
+      expect(agent).toBeInstanceOf(http.Agent);
+    });
+
+    it("returns undefined for non-loopback URLs", () => {
+      expect(getDirectAgentForCdp("http://remote-host:9222")).toBeUndefined();
+      expect(getDirectAgentForCdp("https://example.com:9222")).toBeUndefined();
+    });
+
+    it("returns undefined for invalid URLs", () => {
+      expect(getDirectAgentForCdp("not-a-url")).toBeUndefined();
+    });
+  });
+
+  describe("hasProxyEnv", () => {
+    const proxyVars = [
+      "HTTP_PROXY",
+      "http_proxy",
+      "HTTPS_PROXY",
+      "https_proxy",
+      "ALL_PROXY",
+      "all_proxy",
+    ];
+    const saved: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      for (const v of proxyVars) {
+        saved[v] = process.env[v];
+      }
+      for (const v of proxyVars) {
+        delete process.env[v];
+      }
+    });
+
+    afterEach(() => {
+      for (const v of proxyVars) {
+        if (saved[v] !== undefined) {
+          process.env[v] = saved[v];
+        } else {
+          delete process.env[v];
+        }
+      }
+    });
+
+    it("returns false when no proxy vars set", () => {
+      expect(hasProxyEnv()).toBe(false);
+    });
+
+    it("returns true when HTTP_PROXY is set", () => {
+      process.env.HTTP_PROXY = "http://proxy:8080";
+      expect(hasProxyEnv()).toBe(true);
+    });
+
+    it("returns true when ALL_PROXY is set", () => {
+      process.env.ALL_PROXY = "socks5://proxy:1080";
+      expect(hasProxyEnv()).toBe(true);
+    });
+  });
+
+  describe("withNoProxyForLocalhost", () => {
+    const saved: Record<string, string | undefined> = {};
+    const vars = ["HTTP_PROXY", "NO_PROXY", "no_proxy"];
+
+    beforeEach(() => {
+      for (const v of vars) {
+        saved[v] = process.env[v];
+      }
+    });
+
+    afterEach(() => {
+      for (const v of vars) {
+        if (saved[v] !== undefined) {
+          process.env[v] = saved[v];
+        } else {
+          delete process.env[v];
+        }
+      }
+    });
+
+    it("sets NO_PROXY when proxy is configured", async () => {
+      process.env.HTTP_PROXY = "http://proxy:8080";
+      delete process.env.NO_PROXY;
+      delete process.env.no_proxy;
+
+      let capturedNoProxy: string | undefined;
+      await withNoProxyForLocalhost(async () => {
+        capturedNoProxy = process.env.NO_PROXY;
+      });
+
+      expect(capturedNoProxy).toContain("localhost");
+      expect(capturedNoProxy).toContain("127.0.0.1");
+      expect(capturedNoProxy).toContain("[::1]");
+      // Restored after
+      expect(process.env.NO_PROXY).toBeUndefined();
+    });
+
+    it("extends existing NO_PROXY", async () => {
+      process.env.HTTP_PROXY = "http://proxy:8080";
+      process.env.NO_PROXY = "internal.corp";
+
+      let capturedNoProxy: string | undefined;
+      await withNoProxyForLocalhost(async () => {
+        capturedNoProxy = process.env.NO_PROXY;
+      });
+
+      expect(capturedNoProxy).toContain("internal.corp");
+      expect(capturedNoProxy).toContain("localhost");
+      // Restored
+      expect(process.env.NO_PROXY).toBe("internal.corp");
+    });
+
+    it("skips when no proxy env is set", async () => {
+      delete process.env.HTTP_PROXY;
+      delete process.env.HTTPS_PROXY;
+      delete process.env.ALL_PROXY;
+      delete process.env.NO_PROXY;
+
+      await withNoProxyForLocalhost(async () => {
+        expect(process.env.NO_PROXY).toBeUndefined();
+      });
+    });
+
+    it("restores env even on error", async () => {
+      process.env.HTTP_PROXY = "http://proxy:8080";
+      delete process.env.NO_PROXY;
+
+      await expect(
+        withNoProxyForLocalhost(async () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+
+      expect(process.env.NO_PROXY).toBeUndefined();
+    });
+  });
+});

--- a/src/config/redact-snapshot.schema.test.ts
+++ b/src/config/redact-snapshot.schema.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  REDACTED_SENTINEL,
+  redactConfigSnapshot,
+  restoreRedactedValues as restoreRedactedValues_orig,
+} from "./redact-snapshot.js";
+import { __test__ } from "./schema.hints.js";
+import type { ConfigUiHints } from "./schema.js";
+import type { ConfigFileSnapshot } from "./types.remoteclaw.js";
+import { RemoteClawSchema } from "./zod-schema.js";
+
+const { mapSensitivePaths } = __test__;
+const mainSchemaHints = mapSensitivePaths(RemoteClawSchema, "", {});
+
+type TestSnapshot<TConfig extends Record<string, unknown>> = ConfigFileSnapshot & {
+  parsed: TConfig;
+  resolved: TConfig;
+  config: TConfig;
+};
+
+function makeSnapshot<TConfig extends Record<string, unknown>>(
+  config: TConfig,
+  raw?: string,
+): TestSnapshot<TConfig> {
+  return {
+    path: "/home/user/.remoteclaw/config.json5",
+    exists: true,
+    raw: raw ?? JSON.stringify(config),
+    parsed: config,
+    resolved: config as ConfigFileSnapshot["resolved"],
+    valid: true,
+    config: config as ConfigFileSnapshot["config"],
+    hash: "abc123",
+    issues: [],
+    warnings: [],
+    legacyIssues: [],
+  } as unknown as TestSnapshot<TConfig>;
+}
+
+function restoreRedactedValues<TOriginal>(
+  incoming: unknown,
+  original: TOriginal,
+  hints?: ConfigUiHints,
+): TOriginal {
+  const result = restoreRedactedValues_orig(incoming, original, hints);
+  expect(result.ok).toBe(true);
+  return result.result as TOriginal;
+}
+
+describe("realredactConfigSnapshot_real", () => {
+  it("main schema redact works (samples)", () => {
+    const schema = RemoteClawSchema.toJSONSchema({
+      target: "draft-07",
+      unrepresentable: "any",
+    });
+    schema.title = "RemoteClawConfig";
+    const hints = mainSchemaHints;
+
+    const snapshot = makeSnapshot({
+      agents: {
+        defaults: {
+          memorySearch: {
+            remote: {
+              apiKey: "1234",
+            },
+          },
+        },
+        list: [
+          {
+            memorySearch: {
+              remote: {
+                apiKey: "6789",
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = redactConfigSnapshot(snapshot, hints);
+    const config = result.config as typeof snapshot.config;
+    expect(config.agents.defaults.memorySearch.remote.apiKey).toBe(REDACTED_SENTINEL);
+    expect(config.agents.list[0].memorySearch.remote.apiKey).toBe(REDACTED_SENTINEL);
+    const restored = restoreRedactedValues(result.config, snapshot.config, hints);
+    expect(restored.agents.defaults.memorySearch.remote.apiKey).toBe("1234");
+    expect(restored.agents.list[0].memorySearch.remote.apiKey).toBe("6789");
+  });
+});

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -9310,6 +9310,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                 minimum: 0,
                 maximum: 9007199254740991,
               },
+              deferralTimeoutMs: {
+                type: "integer",
+                minimum: 0,
+                maximum: 9007199254740991,
+              },
             },
             additionalProperties: false,
           },
@@ -11297,6 +11302,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
     "gateway.reload.debounceMs": {
       label: "Config Reload Debounce (ms)",
       help: "Debounce window (ms) before applying config changes.",
+      tags: ["network", "reliability", "performance"],
+    },
+    "gateway.reload.deferralTimeoutMs": {
+      label: "Config Reload Deferral Timeout (ms)",
+      help: "Maximum time (ms) to wait for in-flight operations to complete before forcing a SIGUSR1 restart. Default: 300000 (5 minutes). Lower values risk aborting active subagent LLM calls.",
       tags: ["network", "reliability", "performance"],
     },
     "gateway.nodes.browser.mode": {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -423,6 +423,8 @@ export const FIELD_HELP: Record<string, string> = {
   "gateway.reload.mode":
     'Controls how config edits are applied: "off" ignores live edits, "restart" always restarts, "hot" applies in-process, and "hybrid" tries hot then restarts if required. Keep "hybrid" for safest routine updates.',
   "gateway.reload.debounceMs": "Debounce window (ms) before applying config changes.",
+  "gateway.reload.deferralTimeoutMs":
+    "Maximum time (ms) to wait for in-flight operations to complete before forcing a SIGUSR1 restart. Default: 300000 (5 minutes). Lower values risk aborting active subagent LLM calls.",
   "gateway.nodes.browser.mode":
     'Node browser routing ("auto" = pick single connected browser node, "manual" = require node param, "off" = disable).',
   "gateway.nodes.browser.node": "Pin browser routing to a specific node id or name (optional).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -275,6 +275,7 @@ export const FIELD_LABELS: Record<string, string> = {
     "OpenAI Chat Completions Image Timeout (ms)",
   "gateway.reload.mode": "Config Reload Mode",
   "gateway.reload.debounceMs": "Config Reload Debounce (ms)",
+  "gateway.reload.deferralTimeoutMs": "Config Reload Deferral Timeout (ms)",
   "gateway.nodes.browser.mode": "Gateway Node Browser Mode",
   "gateway.nodes.browser.node": "Gateway Node Browser Pin",
   "gateway.nodes.allowCommands": "Gateway Node Allowlist (Extra Commands)",

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -642,6 +642,7 @@ export const RemoteClawSchema = z
               ])
               .optional(),
             debounceMs: z.number().int().min(0).optional(),
+            deferralTimeoutMs: z.number().int().min(0).optional(),
           })
           .strict()
           .optional(),

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -184,6 +184,7 @@ export function createGatewayReloadHandlers(params: {
 
       deferGatewayRestartUntilIdle({
         getPendingCount: () => getActiveCounts().totalActive,
+        maxWaitMs: nextConfig.gateway?.reload?.deferralTimeoutMs,
         hooks: {
           onReady: () => {
             restartPending = false;

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -1,5 +1,12 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerPluginHttpRoute } from "../../plugins/http-registry.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry.js";
+import {
+  pinActivePluginHttpRouteRegistry,
+  releasePinnedPluginHttpRouteRegistry,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
 import type { GatewayRequestContext, GatewayRequestOptions } from "../server-methods/types.js";
 import { makeMockHttpResponse } from "../test-http-response.js";
@@ -129,6 +136,11 @@ async function invokeSecureGatewayRoute(params: { gatewayAuthSatisfied: boolean 
 }
 
 describe("createGatewayPluginRequestHandler", () => {
+  afterEach(() => {
+    releasePinnedPluginHttpRouteRegistry();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
   it("caps unauthenticated plugin routes to non-admin subagent scopes", async () => {
     loadRemoteClawPlugins.mockReset();
     handleGatewayRequest.mockReset();
@@ -281,6 +293,100 @@ describe("createGatewayPluginRequestHandler", () => {
     const handled = await handler({ url: "/API//demo" } as IncomingMessage, res);
     expect(handled).toBe(true);
     expect(routeHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the provided registry when the pinned route registry is empty", async () => {
+    const explicitRouteHandler = vi.fn(async (_req, res: ServerResponse) => {
+      res.statusCode = 200;
+      return true;
+    });
+    const startupRegistry = createTestRegistry();
+    const explicitRegistry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/demo", auth: "plugin", handler: explicitRouteHandler })],
+    });
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+
+    const handler = createGatewayPluginRequestHandler({
+      registry: explicitRegistry,
+      log: createPluginLog(),
+    });
+
+    const { res } = makeMockHttpResponse();
+    const handled = await handler({ url: "/demo" } as IncomingMessage, res);
+    expect(handled).toBe(true);
+    expect(explicitRouteHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles routes registered into the pinned startup registry after the active registry changes", async () => {
+    const startupRegistry = createTestRegistry();
+    const laterActiveRegistry = createTestRegistry();
+    const routeHandler = vi.fn(async (_req, res: ServerResponse) => {
+      res.statusCode = 202;
+      return true;
+    });
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+    setActivePluginRegistry(laterActiveRegistry);
+
+    const unregister = registerPluginHttpRoute({
+      path: "/bluebubbles-webhook",
+      auth: "plugin",
+      handler: routeHandler,
+    });
+
+    try {
+      const handler = createGatewayPluginRequestHandler({
+        registry: startupRegistry,
+        log: createPluginLog(),
+      });
+
+      const { res } = makeMockHttpResponse();
+      const handled = await handler({ url: "/bluebubbles-webhook" } as IncomingMessage, res);
+      expect(handled).toBe(true);
+      expect(routeHandler).toHaveBeenCalledTimes(1);
+      expect(laterActiveRegistry.httpRoutes).toHaveLength(0);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("prefers the pinned route registry over a stale explicit registry", async () => {
+    const startupRegistry = createTestRegistry();
+    const staleExplicitRegistry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/plugins/diffs", auth: "plugin" })],
+    });
+    const routeHandler = vi.fn(async (_req, res: ServerResponse) => {
+      res.statusCode = 204;
+      return true;
+    });
+
+    setActivePluginRegistry(createTestRegistry());
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+
+    const unregister = registerPluginHttpRoute({
+      path: "/bluebubbles-webhook",
+      auth: "plugin",
+      handler: routeHandler,
+    });
+
+    try {
+      const handler = createGatewayPluginRequestHandler({
+        registry: staleExplicitRegistry,
+        log: createPluginLog(),
+      });
+
+      const { res } = makeMockHttpResponse();
+      const handled = await handler({ url: "/bluebubbles-webhook" } as IncomingMessage, res);
+      expect(handled).toBe(true);
+      expect(routeHandler).toHaveBeenCalledTimes(1);
+      expect(staleExplicitRegistry.httpRoutes).toHaveLength(1);
+      expect(startupRegistry.httpRoutes).toHaveLength(1);
+    } finally {
+      unregister();
+    }
   });
 
   it("logs and responds with 500 when a route throws", async () => {

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
+import { resolveActivePluginHttpRouteRegistry } from "../../plugins/runtime.js";
 import { withPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { ADMIN_SCOPE, APPROVALS_SCOPE, PAIRING_SCOPE, WRITE_SCOPE } from "../method-scopes.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../protocol/client-info.js";
@@ -63,8 +64,9 @@ export function createGatewayPluginRequestHandler(params: {
   registry: PluginRegistry;
   log: SubsystemLogger;
 }): PluginHttpRequestHandler {
-  const { registry, log } = params;
+  const { log } = params;
   return async (req, res, providedPathContext, dispatchContext) => {
+    const registry = resolveActivePluginHttpRouteRegistry(params.registry);
     const routes = registry.httpRoutes ?? [];
     if (routes.length === 0) {
       return false;

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -190,8 +190,8 @@ describe("infra runtime", () => {
         await vi.advanceTimersByTimeAsync(0);
         expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
 
-        // Advance past the 90s max deferral wait
-        await vi.advanceTimersByTimeAsync(90_000);
+        // Advance past the 5-minute max deferral wait (raised from 90s in #47711)
+        await vi.advanceTimersByTimeAsync(300_000);
         expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
       } finally {
         process.removeListener("SIGUSR1", handler);

--- a/src/infra/restart.deferral-timeout.test.ts
+++ b/src/infra/restart.deferral-timeout.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __testing, deferGatewayRestartUntilIdle, type RestartDeferralHooks } from "./restart.js";
+
+describe("deferGatewayRestartUntilIdle timeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    __testing.resetSigusr1State();
+    // Add a listener so emitGatewayRestart uses process.emit instead of process.kill
+    process.on("SIGUSR1", () => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    __testing.resetSigusr1State();
+    process.removeAllListeners("SIGUSR1");
+  });
+
+  it("uses default 5-minute timeout when maxWaitMs is not specified", () => {
+    const hooks: RestartDeferralHooks = {
+      onTimeout: vi.fn(),
+      onReady: vi.fn(),
+    };
+
+    // Always return 1 pending item to prevent draining
+    deferGatewayRestartUntilIdle({
+      getPendingCount: () => 1,
+      hooks,
+    });
+
+    // Advance to just before 5 minutes — should NOT have timed out yet
+    vi.advanceTimersByTime(299_999);
+    expect(hooks.onTimeout).not.toHaveBeenCalled();
+
+    // Advance past 5 minutes — should time out
+    vi.advanceTimersByTime(1);
+    expect(hooks.onTimeout).toHaveBeenCalledOnce();
+    expect(hooks.onReady).not.toHaveBeenCalled();
+  });
+
+  it("respects custom maxWaitMs configuration", () => {
+    const hooks: RestartDeferralHooks = {
+      onTimeout: vi.fn(),
+      onReady: vi.fn(),
+    };
+
+    const customTimeoutMs = 120_000; // 2 minutes
+
+    deferGatewayRestartUntilIdle({
+      getPendingCount: () => 1,
+      maxWaitMs: customTimeoutMs,
+      hooks,
+    });
+
+    // Advance to just before 2 minutes
+    vi.advanceTimersByTime(119_999);
+    expect(hooks.onTimeout).not.toHaveBeenCalled();
+
+    // Advance past 2 minutes
+    vi.advanceTimersByTime(1);
+    expect(hooks.onTimeout).toHaveBeenCalledOnce();
+  });
+
+  it("calls onReady and does not timeout when pending count drops to 0", () => {
+    const hooks: RestartDeferralHooks = {
+      onTimeout: vi.fn(),
+      onReady: vi.fn(),
+    };
+
+    let pending = 3;
+
+    deferGatewayRestartUntilIdle({
+      getPendingCount: () => pending,
+      hooks,
+    });
+
+    // Advance a few poll intervals, then drain
+    vi.advanceTimersByTime(1000);
+    expect(hooks.onReady).not.toHaveBeenCalled();
+
+    pending = 0;
+    vi.advanceTimersByTime(500); // Next poll interval
+    expect(hooks.onReady).toHaveBeenCalledOnce();
+    expect(hooks.onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("immediately restarts when pending count is 0", () => {
+    const hooks: RestartDeferralHooks = {
+      onReady: vi.fn(),
+      onTimeout: vi.fn(),
+    };
+
+    deferGatewayRestartUntilIdle({
+      getPendingCount: () => 0,
+      hooks,
+    });
+
+    // onReady should be called synchronously
+    expect(hooks.onReady).toHaveBeenCalledOnce();
+    expect(hooks.onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("handles getPendingCount error by restarting immediately", () => {
+    const hooks: RestartDeferralHooks = {
+      onCheckError: vi.fn(),
+      onReady: vi.fn(),
+    };
+
+    deferGatewayRestartUntilIdle({
+      getPendingCount: () => {
+        throw new Error("store corrupted");
+      },
+      hooks,
+    });
+
+    expect(hooks.onCheckError).toHaveBeenCalledOnce();
+    expect(hooks.onReady).not.toHaveBeenCalled();
+  });
+});

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -19,8 +19,9 @@ export type RestartAttempt = {
 const SPAWN_TIMEOUT_MS = 2000;
 const SIGUSR1_AUTH_GRACE_MS = 5000;
 const DEFAULT_DEFERRAL_POLL_MS = 500;
-// Cover slow in-flight embedded compaction work before forcing restart.
-const DEFAULT_DEFERRAL_MAX_WAIT_MS = 90_000;
+// Default to 5 minutes to avoid aborting in-flight subagent LLM calls.
+// Configurable via gateway.reload.deferralTimeoutMs.
+const DEFAULT_DEFERRAL_MAX_WAIT_MS = 300_000;
 const RESTART_COOLDOWN_MS = 30_000;
 
 const restartLog = createSubsystemLogger("restart");

--- a/src/logging/logger.browser-import.test.ts
+++ b/src/logging/logger.browser-import.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type LoggerModule = typeof import("./logger.js");
+
+const originalGetBuiltinModule = (
+  process as NodeJS.Process & { getBuiltinModule?: (id: string) => unknown }
+).getBuiltinModule;
+
+async function importBrowserSafeLogger(params?: {
+  resolvePreferredRemoteClawTmpDir?: ReturnType<typeof vi.fn>;
+}): Promise<{
+  module: LoggerModule;
+  resolvePreferredRemoteClawTmpDir: ReturnType<typeof vi.fn>;
+}> {
+  vi.resetModules();
+  const resolvePreferredRemoteClawTmpDir =
+    params?.resolvePreferredRemoteClawTmpDir ??
+    vi.fn(() => {
+      throw new Error("resolvePreferredRemoteClawTmpDir should not run during browser-safe import");
+    });
+
+  vi.doMock("../infra/tmp-remoteclaw-dir.js", async () => {
+    const actual = await vi.importActual<typeof import("../infra/tmp-remoteclaw-dir.js")>(
+      "../infra/tmp-remoteclaw-dir.js",
+    );
+    return {
+      ...actual,
+      resolvePreferredRemoteClawTmpDir,
+    };
+  });
+
+  Object.defineProperty(process, "getBuiltinModule", {
+    configurable: true,
+    value: undefined,
+  });
+
+  const module = await import("./logger.js");
+  return { module, resolvePreferredRemoteClawTmpDir };
+}
+
+describe("logging/logger browser-safe import", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../infra/tmp-remoteclaw-dir.js");
+    Object.defineProperty(process, "getBuiltinModule", {
+      configurable: true,
+      value: originalGetBuiltinModule,
+    });
+  });
+
+  it("does not resolve the preferred temp dir at import time when node fs is unavailable", async () => {
+    const { module, resolvePreferredRemoteClawTmpDir } = await importBrowserSafeLogger();
+
+    expect(resolvePreferredRemoteClawTmpDir).not.toHaveBeenCalled();
+    expect(module.DEFAULT_LOG_DIR).toBe("/tmp/remoteclaw");
+    expect(module.DEFAULT_LOG_FILE).toBe("/tmp/remoteclaw/remoteclaw.log");
+  });
+
+  it("disables file logging when imported in a browser-like environment", async () => {
+    const { module, resolvePreferredRemoteClawTmpDir } = await importBrowserSafeLogger();
+
+    expect(module.getResolvedLoggerSettings()).toMatchObject({
+      level: "silent",
+      file: "/tmp/remoteclaw/remoteclaw.log",
+    });
+    expect(module.isFileLogLevelEnabled("info")).toBe(false);
+    expect(() => module.getLogger().info("browser-safe")).not.toThrow();
+    expect(resolvePreferredRemoteClawTmpDir).not.toHaveBeenCalled();
+  });
+});

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -3,7 +3,10 @@ import path from "node:path";
 import { Logger as TsLogger } from "tslog";
 import { getCommandPathWithRootOptions } from "../cli/argv.js";
 import type { RemoteClawConfig } from "../config/types.js";
-import { resolvePreferredRemoteClawTmpDir } from "../infra/tmp-remoteclaw-dir.js";
+import {
+  POSIX_REMOTECLAW_TMP_DIR,
+  resolvePreferredRemoteClawTmpDir,
+} from "../infra/tmp-remoteclaw-dir.js";
 import { readLoggingConfig } from "./config.js";
 import type { ConsoleStyle } from "./console.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
@@ -12,7 +15,27 @@ import { resolveNodeRequireFromMeta } from "./node-require.js";
 import { loggingState } from "./state.js";
 import { formatLocalIsoWithOffset } from "./timestamps.js";
 
-export const DEFAULT_LOG_DIR = resolvePreferredRemoteClawTmpDir();
+type ProcessWithBuiltinModule = NodeJS.Process & {
+  getBuiltinModule?: (id: string) => unknown;
+};
+
+function canUseNodeFs(): boolean {
+  const getBuiltinModule = (process as ProcessWithBuiltinModule).getBuiltinModule;
+  if (typeof getBuiltinModule !== "function") {
+    return false;
+  }
+  try {
+    return getBuiltinModule("fs") !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+function resolveDefaultLogDir(): string {
+  return canUseNodeFs() ? resolvePreferredRemoteClawTmpDir() : POSIX_REMOTECLAW_TMP_DIR;
+}
+
+export const DEFAULT_LOG_DIR = resolveDefaultLogDir();
 export const DEFAULT_LOG_FILE = path.join(DEFAULT_LOG_DIR, "remoteclaw.log"); // legacy single-file path
 
 const LOG_PREFIX = "remoteclaw";
@@ -71,6 +94,14 @@ function canUseSilentVitestFileLogFastPath(envLevel: LogLevel | undefined): bool
 }
 
 function resolveSettings(): ResolvedSettings {
+  if (!canUseNodeFs()) {
+    return {
+      level: "silent",
+      file: DEFAULT_LOG_FILE,
+      maxFileBytes: DEFAULT_MAX_LOG_FILE_BYTES,
+    };
+  }
+
   const envLevel = resolveEnvLogLevelOverride();
   // Test runs default file logs to silent. Skip config reads and fallback load in the
   // common case to avoid pulling heavy config/schema stacks on startup.

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -95,5 +95,6 @@ export {
 export { evaluateSenderGroupAccessForPolicy } from "./group-access.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
 export { buildAgentMediaPayload } from "./agent-media-payload.js";
+export { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
 export { loadOutboundMediaFromUrl } from "./outbound-media.js";
 export { createScopedPairingAccess } from "./pairing-access.js";

--- a/src/plugins/http-registry.test.ts
+++ b/src/plugins/http-registry.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { registerPluginHttpRoute } from "./http-registry.js";
 import { createEmptyPluginRegistry } from "./registry.js";
+import {
+  pinActivePluginHttpRouteRegistry,
+  releasePinnedPluginHttpRouteRegistry,
+  setActivePluginRegistry,
+} from "./runtime.js";
 
 function expectRouteRegistrationDenied(params: {
   replaceExisting: boolean;
@@ -38,6 +43,11 @@ function expectRouteRegistrationDenied(params: {
 }
 
 describe("registerPluginHttpRoute", () => {
+  afterEach(() => {
+    releasePinnedPluginHttpRouteRegistry();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
   it("registers route and unregisters it", () => {
     const registry = createEmptyPluginRegistry();
     const handler = vi.fn();
@@ -163,5 +173,27 @@ describe("registerPluginHttpRoute", () => {
 
     unregister();
     expect(registry.httpRoutes).toHaveLength(1);
+  });
+
+  it("uses the pinned route registry when the active registry changes later", () => {
+    const startupRegistry = createEmptyPluginRegistry();
+    const laterActiveRegistry = createEmptyPluginRegistry();
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+    setActivePluginRegistry(laterActiveRegistry);
+
+    const unregister = registerPluginHttpRoute({
+      path: "/bluebubbles-webhook",
+      auth: "plugin",
+      handler: vi.fn(),
+    });
+
+    expect(startupRegistry.httpRoutes).toHaveLength(1);
+    expect(startupRegistry.httpRoutes[0]?.path).toBe("/bluebubbles-webhook");
+    expect(laterActiveRegistry.httpRoutes).toHaveLength(0);
+
+    unregister();
+    expect(startupRegistry.httpRoutes).toHaveLength(0);
   });
 });

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { normalizePluginHttpPath } from "./http-path.js";
 import { findOverlappingPluginHttpRoute } from "./http-route-overlap.js";
 import type { PluginHttpRouteRegistration, PluginRegistry } from "./registry.js";
-import { requireActivePluginRegistry } from "./runtime.js";
+import { requireActivePluginHttpRouteRegistry } from "./runtime.js";
 
 export type PluginHttpRouteHandler = (
   req: IncomingMessage,
@@ -22,7 +22,7 @@ export function registerPluginHttpRoute(params: {
   log?: (message: string) => void;
   registry?: PluginRegistry;
 }): () => void {
-  const registry = params.registry ?? requireActivePluginRegistry();
+  const registry = params.registry ?? requireActivePluginHttpRouteRegistry();
   const routes = registry.httpRoutes ?? [];
   registry.httpRoutes = routes;
 

--- a/src/plugins/runtime.test.ts
+++ b/src/plugins/runtime.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "./registry.js";
+import {
+  pinActivePluginHttpRouteRegistry,
+  releasePinnedPluginHttpRouteRegistry,
+  resolveActivePluginHttpRouteRegistry,
+  setActivePluginRegistry,
+} from "./runtime.js";
+
+describe("plugin runtime route registry", () => {
+  afterEach(() => {
+    releasePinnedPluginHttpRouteRegistry();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("keeps the pinned route registry when the active plugin registry changes", () => {
+    const startupRegistry = createEmptyPluginRegistry();
+    const laterRegistry = createEmptyPluginRegistry();
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+    setActivePluginRegistry(laterRegistry);
+
+    expect(resolveActivePluginHttpRouteRegistry(laterRegistry)).toBe(startupRegistry);
+  });
+
+  it("falls back to the provided registry when the pinned route registry has no routes", () => {
+    const startupRegistry = createEmptyPluginRegistry();
+    const explicitRegistry = createEmptyPluginRegistry();
+    explicitRegistry.httpRoutes.push({
+      path: "/demo",
+      auth: "plugin",
+      match: "exact",
+      handler: () => true,
+      pluginId: "demo",
+      source: "test",
+    });
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+
+    expect(resolveActivePluginHttpRouteRegistry(explicitRegistry)).toBe(explicitRegistry);
+  });
+
+  it("prefers the pinned route registry when it already owns routes", () => {
+    const startupRegistry = createEmptyPluginRegistry();
+    const explicitRegistry = createEmptyPluginRegistry();
+    startupRegistry.httpRoutes.push({
+      path: "/bluebubbles-webhook",
+      auth: "plugin",
+      match: "exact",
+      handler: () => true,
+      pluginId: "bluebubbles",
+      source: "test",
+    });
+    explicitRegistry.httpRoutes.push({
+      path: "/plugins/diffs",
+      auth: "plugin",
+      match: "prefix",
+      handler: () => true,
+      pluginId: "diffs",
+      source: "test",
+    });
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+
+    expect(resolveActivePluginHttpRouteRegistry(explicitRegistry)).toBe(startupRegistry);
+  });
+});

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -4,6 +4,8 @@ const REGISTRY_STATE = Symbol.for("remoteclaw.pluginRegistryState");
 
 type RegistryState = {
   registry: PluginRegistry | null;
+  httpRouteRegistry: PluginRegistry | null;
+  httpRouteRegistryPinned: boolean;
   key: string | null;
   version: number;
 };
@@ -15,6 +17,8 @@ const state: RegistryState = (() => {
   if (!globalState[REGISTRY_STATE]) {
     globalState[REGISTRY_STATE] = {
       registry: createEmptyPluginRegistry(),
+      httpRouteRegistry: null,
+      httpRouteRegistryPinned: false,
       key: null,
       version: 0,
     };
@@ -24,6 +28,9 @@ const state: RegistryState = (() => {
 
 export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
   state.registry = registry;
+  if (!state.httpRouteRegistryPinned) {
+    state.httpRouteRegistry = registry;
+  }
   state.key = cacheKey ?? null;
   state.version += 1;
 }
@@ -35,9 +42,52 @@ export function getActivePluginRegistry(): PluginRegistry | null {
 export function requireActivePluginRegistry(): PluginRegistry {
   if (!state.registry) {
     state.registry = createEmptyPluginRegistry();
+    if (!state.httpRouteRegistryPinned) {
+      state.httpRouteRegistry = state.registry;
+    }
     state.version += 1;
   }
   return state.registry;
+}
+
+export function pinActivePluginHttpRouteRegistry(registry: PluginRegistry) {
+  state.httpRouteRegistry = registry;
+  state.httpRouteRegistryPinned = true;
+}
+
+export function releasePinnedPluginHttpRouteRegistry(registry?: PluginRegistry) {
+  if (registry && state.httpRouteRegistry !== registry) {
+    return;
+  }
+  state.httpRouteRegistryPinned = false;
+  state.httpRouteRegistry = state.registry;
+}
+
+export function getActivePluginHttpRouteRegistry(): PluginRegistry | null {
+  return state.httpRouteRegistry ?? state.registry;
+}
+
+export function requireActivePluginHttpRouteRegistry(): PluginRegistry {
+  const existing = getActivePluginHttpRouteRegistry();
+  if (existing) {
+    return existing;
+  }
+  const created = requireActivePluginRegistry();
+  state.httpRouteRegistry = created;
+  return created;
+}
+
+export function resolveActivePluginHttpRouteRegistry(fallback: PluginRegistry): PluginRegistry {
+  const routeRegistry = getActivePluginHttpRouteRegistry();
+  if (!routeRegistry) {
+    return fallback;
+  }
+  const routeCount = routeRegistry.httpRoutes?.length ?? 0;
+  const fallbackRouteCount = fallback.httpRoutes?.length ?? 0;
+  if (routeCount === 0 && fallbackRouteCount > 0) {
+    return fallback;
+  }
+  return routeRegistry;
 }
 
 export function getActivePluginRegistryKey(): string | null {

--- a/src/tts/edge-tts-validation.test.ts
+++ b/src/tts/edge-tts-validation.test.ts
@@ -1,0 +1,69 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+let mockTtsPromise = vi.fn<(text: string, filePath: string) => Promise<void>>();
+
+vi.mock("node-edge-tts", () => ({
+  EdgeTTS: class {
+    ttsPromise(text: string, filePath: string) {
+      return mockTtsPromise(text, filePath);
+    }
+  },
+}));
+
+const { edgeTTS } = await import("./tts-core.js");
+
+const baseEdgeConfig = {
+  enabled: true,
+  voice: "en-US-MichelleNeural",
+  lang: "en-US",
+  outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+  outputFormatConfigured: false,
+  saveSubtitles: false,
+};
+
+describe("edgeTTS – empty audio validation", () => {
+  let tempDir: string;
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("throws when the output file is 0 bytes", async () => {
+    tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
+    const outputPath = path.join(tempDir, "voice.mp3");
+
+    mockTtsPromise = vi.fn(async (_text: string, filePath: string) => {
+      writeFileSync(filePath, "");
+    });
+
+    await expect(
+      edgeTTS({
+        text: "Hello",
+        outputPath,
+        config: baseEdgeConfig,
+        timeoutMs: 10000,
+      }),
+    ).rejects.toThrow("Edge TTS produced empty audio file");
+  });
+
+  it("succeeds when the output file has content", async () => {
+    tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
+    const outputPath = path.join(tempDir, "voice.mp3");
+
+    mockTtsPromise = vi.fn(async (_text: string, filePath: string) => {
+      writeFileSync(filePath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+    });
+
+    await expect(
+      edgeTTS({
+        text: "Hello",
+        outputPath,
+        config: baseEdgeConfig,
+        timeoutMs: 10000,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -1,4 +1,4 @@
-import { rmSync } from "node:fs";
+import { rmSync, statSync } from "node:fs";
 import { EdgeTTS } from "node-edge-tts";
 import type { RemoteClawConfig } from "../config/config.js";
 import type {
@@ -594,4 +594,10 @@ export async function edgeTTS(params: {
     timeout: config.timeoutMs ?? timeoutMs,
   });
   await tts.ttsPromise(text, outputPath);
+
+  const { size } = statSync(outputPath);
+
+  if (size === 0) {
+    throw new Error("Edge TTS produced empty audio file");
+  }
 }


### PR DESCRIPTION
## Summary

Cherry-picks the confirmed-real gaps from the remoteclaw#2406 B1-B10 audit.
False positives were filtered out in the HQ B1-B10 cleanup pass
([hq@fbdc14b](https://github.com/remoteclaw/hq/commit/fbdc14b),
[hq@b2e4633](https://github.com/remoteclaw/hq/commit/b2e4633),
[hq@74ef389](https://github.com/remoteclaw/hq/commit/74ef389))
before this PR. Tier 2 ambiguous cases were investigated and dispositioned
(EXCLUDE-GUT / EXTRACT) in a separate HQ commit.

### Production (2)
- `a9f34997a4` — fix: bypass proxy for CDP localhost connections (#31219) — cherry-picked from `c96234b51d`
- `fcdd04884d` — fix(mattermost): pass mediaLocalRoots through reply delivery (#44021) — cherry-picked from `c965049dc6`

### Tests (7 commits)
- `ac4daf812c` — fix(agents): normalize windows workspace path boundary checks (#30766) — cherry-picked from `ef89b48785`
- `866e8d7bf3` — fix(test): reduce startup-heavy hotspot retention (#52381) — cherry-picked from `dbd26e49f1` (msteams webhook-timeouts extraction only; broader refactor skipped)
- `dc99b38a98` — fix(ci): split redact snapshot schema coverage — cherry-picked from `5841e3b493`
- `aca12ce047` — fix(logging): make logger import browser-safe — cherry-picked from `df3a19051d`
- `a2b6f35419` — fix: resume orphaned subagent sessions after SIGUSR1 reload — cherry-picked from `304703f165`
- `ed1137b0f5` — fix(gateway): pin plugin webhook route registry (#47902) — cherry-picked from `a69f6190ab`
- `a39ca33e36` — fix: validate edge tts output file is non-empty (#43385) — cherry-picked from `946c24d674`

### Follow-up (1)
- `2f6dfcb3be` — fix(config): regenerate base schema + add label after deferralTimeoutMs port (required after `a2b6f35419` to keep schema snapshot + label parity tests green)

### Rebrand adaptations

Several cherry-picks required `openclaw`→`remoteclaw` rebrand in new files or fixtures:
- path-policy.test.ts: `C:\Users\User\OpenClaw` → `RemoteClaw`
- reply-delivery.ts + test: `openclaw/plugin-sdk/mattermost` imports, `OpenClawConfig`, temp dir prefix
- redact-snapshot.schema.test.ts: `types.openclaw` → `types.remoteclaw`, `OpenClawSchema` → `RemoteClawSchema`, `OpenClawConfig` → `RemoteClawConfig`, `~/.openclaw` → `~/.remoteclaw`
- logger.browser-import.test.ts: `resolvePreferredOpenClawTmpDir` → `resolvePreferredRemoteClawTmpDir`, `/tmp/openclaw` → `/tmp/remoteclaw`, `openclaw.log` → `remoteclaw.log`

### Skipped / reclassified (handled separately on HQ)

11 entries were reclassified as EXCLUDE-GUT (fork-gutted area) or EXTRACT (fork-divergent, needs separate WI). See HQ disposition commit for details. Highlights:
- `98e30dc2a3` cron-model-override.test.ts → EXCLUDE-GUT (imports fork-gutted model-fallback/skills/model-catalog)
- `81b93b9ce0` subagent-announce.capture-completion-reply.test.ts → EXCLUDE-GUT (`captureSubagentCompletionReply` fn not in fork)
- `18f15850e6` browser/proxy-files.test.ts → EXCLUDE-GUT (parent Playwright-gutted by 1aae7daa00)
- `8d805a02fd` zalouser (zca-constants + test-mocks) → EXTRACT (fork uses runtime wrappers instead)
- `aeb2adf240` redact-snapshot.restore.test.ts → EXTRACT (fork has richer inline tests)
- `59bcac472e` mattermost/index.test.ts → EXTRACT (`registrationMode: "setup-only"` feature not in fork)
- `86a3149b2e` .npmignore → SKIP (fork uses whitelist `files` field, not blacklist)
- `d06cc77f38` server-context.ensure-browser-available → EXCLUDE-GUT (Playwright-gutted)
- Plus 5 more Tier 2 EXTRACT classifications for fork-divergent extension internals

## Test plan

- [x] `pnpm check` passes (format + tsgo + lint + custom gates)
- [x] `pnpm test` passes (7010 passed, 3 skipped)
- [x] `-x` attribution visible on each cherry-picked commit
- [x] Rebrand leakage gate (scripts/check-no-remoteclaw-ai.mjs) passes

Closes #2406 (all 32 flagged entries now dispositioned: 9 landed, 5 already FP'd in prior HQ steps, 18 classified on HQ).
