### PR TITLE
ci(fork-sync): strip dangling ADR path references (#2434)

### DIFF
--- a/scripts/check-obsolescence-audit.mjs
+++ b/scripts/check-obsolescence-audit.mjs
@@ -31,7 +31,7 @@
  *     wiring and broken contract instances
  *   .obsolescence-baseline — expected total finding count (stubs + known patterns)
  *
- * Reference: ADR 0005 H6 (engineering/decisions/0005-fork-sync-hardening.md)
+ * Reference: ADR 0005 H6
  */
 
 import { promises as fs } from "node:fs";
@@ -354,7 +354,7 @@ export async function main() {
         "  1. Fix the regression (delete/rewire the dead code)\n" +
         "  2. If the finding is tracked debt, update .obsolescence-baseline\n" +
         "     and justify the increase in your PR description\n\n" +
-        "Reference: ADR 0005 H6, engineering/notes/provider-model-obsolescence-audit.md\n",
+        "Reference: ADR 0005 H6\n",
     );
     hasFailure = true;
   } else if (totalFindings < baseline) {

--- a/scripts/check-stub-debt.mjs
+++ b/scripts/check-stub-debt.mjs
@@ -10,7 +10,7 @@
  * To add a legitimate new suppression: increment the number in
  * .stub-debt-baseline and justify the increase in your PR description.
  *
- * Reference: ADR 0005 H5 (engineering/decisions/0005-fork-sync-hardening.md)
+ * Reference: ADR 0005 H5
  */
 
 import { promises as fs } from "node:fs";


### PR DESCRIPTION
## Summary

CI scripts referenced an ADR file path that doesn't exist in this repo. Per the decision on #2434, ADRs stay in the private HQ and CI keeps only the stable rule names (`ADR 0005 H5`, `ADR 0005 H6`) — no broken paths.

## Changes

- `scripts/check-stub-debt.mjs:13` — strip ` (engineering/decisions/0005-fork-sync-hardening.md)` from header comment
- `scripts/check-obsolescence-audit.mjs:34` — strip ` (engineering/decisions/0005-fork-sync-hardening.md)` from header comment
- `scripts/check-obsolescence-audit.mjs:357` — strip `, engineering/notes/provider-model-obsolescence-audit.md` from FAIL error message

`scripts/check-stub-debt.mjs:108` was already correct (rule name only) and is not touched.

## Verification

- `node scripts/check-stub-debt.mjs` → exit 0, `Stub debt check passed: 12 == baseline 12.`
- `node scripts/check-obsolescence-audit.mjs` → exit 0
- `grep -rn "engineering/decisions\|engineering/notes" .` (excluding build dirs) → no matches; unrelated npm scope `@martian-engineering/*` correctly excluded
- Fresh-context adversarial validation: all 6 AC PASS (trace in `.tmp/validate-intent.task.jsonl`)
- `pnpm check` pre-commit hook: format + lint + custom gates all pass

## Cascade impact

Unblocks #2435, #2436, #2437 from the #2433 hardening epic — none require an ADR file to exist in this repo.

## Test plan

- [x] Both CI scripts still execute without errors after path stripping
- [x] Rule name references (`ADR 0005 H5`, `ADR 0005 H6`) preserved as stable identifiers
- [x] No stale references remain elsewhere in the repo

Closes #2434.