### PR TITLE
ci(fork-sync): MODULE_ATTESTATIONS manifest for src/agents/* (#2437)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS for remoteclaw/remoteclaw
+#
+# Fork-boundary modules carrying `MODULE_ATTESTATIONS` require explicit
+# review when their attestations change. See ADR 0005 H9 / CONTRIBUTING.md
+# § Module attestations.
+#
+# Initial scope per remoteclaw#2437: src/agents/ depth-1. Expand to other
+# fork-boundary directories (src/middleware/, src/gateway/) in follow-up
+# if the pattern proves valuable.
+
+/src/agents/ @alexey-pelykh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,25 @@ jobs:
       - name: Check throwing-stub-with-live-callers
         run: node scripts/check-throwing-stub-callers.mjs
 
+  attestation-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Self-test classifier (fixture-based)
+        run: node scripts/check-attestations.mjs --self-test
+
+      - name: Check module attestations
+        run: node scripts/check-attestations.mjs
+
   obsolescence-audit-gate:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,3 +143,50 @@ When decreasing the baseline (e.g., refactoring a test to hit the real
 module), update `.fork-boundary-mock-baseline` to lock in the improvement.
 
 Reference: ADR 0005 H8 (hq-internal, rule name is stable).
+
+## Module attestations
+
+Every fork-boundary module (initial scope: `src/agents/` depth-1) exports a
+`MODULE_ATTESTATIONS` constant that declares the runtime status of each
+export. The attestation-gate CI job (`scripts/check-attestations.mjs`)
+enforces structural consistency; human reviewers (via CODEOWNERS) enforce
+semantic correctness.
+
+```ts
+export const MODULE_ATTESTATIONS = {
+  resolveFoo: "live", // real implementation, safe to call
+  listBars: "stub", // gutted; MUST have zero non-test callers
+  resolveBaz: "partial", // works for some inputs, gutted for others
+  legacyQux: "deprecated", // do not use in new code; scheduled for removal
+} as const;
+```
+
+### Categories
+
+| Category       | Meaning                                                                                                                                                                                                                                                                           |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **live**       | Real implementation. Safe to call, returns correct results. Gate fails if the function body matches a throwing-stub pattern (variadic-unknown + throw, fork-attributed throw message, `Gutted in RemoteClaw fork` marker comment, or `: never` return type with no typed params). |
+| **stub**       | Gutted function. Must have zero non-test importers (the gate fails if any live caller exists, because calling the stub would crash production). Use while the stub is awaiting replacement; link a tracking issue in the PR description.                                          |
+| **partial**    | Works for some inputs but has gutted branches. No automatic validation — reviewer discipline only. Document the partial behavior in a code comment.                                                                                                                               |
+| **deprecated** | Scheduled for removal. Discourage new callers, plan migration. No automatic validation.                                                                                                                                                                                           |
+
+### When this fires
+
+The gate fails CI when:
+
+1. A new runtime export is added without a `MODULE_ATTESTATIONS` entry
+2. An attestation entry references a symbol that is no longer exported (stale)
+3. An attestation says `"live"` but the function matches a throwing-stub pattern
+4. An attestation says `"stub"` but the function has live (non-test) callers
+5. An attestation uses an invalid category (not one of the four above)
+
+### How to update
+
+When sync or a refactor changes a module's surface:
+
+1. Edit the `MODULE_ATTESTATIONS` entries in the module (inline, top of file after imports)
+2. If re-attesting from `"live"` to `"stub"` / `"partial"` / `"deprecated"`: link a tracking issue in the PR description
+3. If re-attesting from `"stub"` to `"live"`: verify the real implementation is restored; run `node scripts/check-throwing-stub-callers.mjs --inventory` to confirm no violations
+4. CODEOWNERS will require explicit review for any `MODULE_ATTESTATIONS` change
+
+Reference: ADR 0005 H9 (hq-internal, rule name is stable).

--- a/scripts/check-attestations.mjs
+++ b/scripts/check-attestations.mjs
@@ -1,0 +1,753 @@
+#!/usr/bin/env node
+
+/**
+ * Module attestation gate (ADR 0005 H9, remoteclaw#2437).
+ *
+ * Each fork-boundary module (initial scope: `src/agents/*` depth-1) exports
+ * a `MODULE_ATTESTATIONS` constant declaring the status of every runtime
+ * export:
+ *
+ *   export const MODULE_ATTESTATIONS = {
+ *     foo: "live",       // real implementation, safe to call
+ *     bar: "stub",       // gutted; must have zero live callers
+ *     baz: "partial",    // works for some inputs, gutted for others
+ *     qux: "deprecated", // do not use in new code; scheduled for removal
+ *   } as const;
+ *
+ * The gate catches the class of regression that H7 (throwing-stub AST gate)
+ * cannot see: **semantic stubs** where the return type stays valid and the
+ * body has no throw, but the implementation was gutted (e.g., a function
+ * returning constant `false` or an empty map). The attestation forces a
+ * human decision at PR time — if the real implementation was gutted and
+ * the attestation still says "live", the author is attesting a lie.
+ *
+ * Enforced invariants:
+ * 1. Every runtime export has an attestation entry (new exports without
+ *    attestations fail CI).
+ * 2. Every attestation entry corresponds to a current runtime export
+ *    (stale attestations fail CI).
+ * 3. An export attested "live" must NOT match the throwing-stub pattern
+ *    (variadic-unknown + throw, fork-attributed throw, marker comment, or
+ *    `: never` return with no typed params — see
+ *    `check-throwing-stub-callers.mjs`). A "live" declaration on a
+ *    throwing-shape function is inconsistent and fails.
+ * 4. An export attested "stub" must have zero non-test importers (if it
+ *    has live callers, the stub is a production-crash vector — either
+ *    replace the stub or migrate callers before landing the attestation).
+ *
+ * "partial" and "deprecated" have no automatic validation; they are
+ * reviewer-discipline signals.
+ *
+ * Runtime exports counted:
+ * - `export function foo(...)`
+ * - `export const foo = () => ...` / `= function(...)` (arrow / function
+ *   expression)
+ * - `export class Foo`
+ * - `export default` (if function)
+ *
+ * Not counted (no gutting risk):
+ * - `export type`, `export interface`, `export enum`
+ * - `export const FOO = "literal"` (non-function data constants)
+ * - Re-exports (`export { foo } from "./bar"` / `export * from "./bar"`) —
+ *   attested in the defining module only
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { looksLikeThrowingStub } from "./lib/throwing-stub-shape.mjs";
+import {
+  collectTypeScriptFilesFromRoots,
+  isTestLikeTypeScriptFile,
+  resolveSourceRoots,
+  runAsScript,
+  toLine,
+} from "./lib/ts-guard-utils.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Initial scope per remoteclaw#2437: src/agents/ depth-1. Expand to other
+// fork-boundary directories in follow-up issues if the pattern proves
+// valuable.
+const attestedGlob = { root: "src/agents", maxDepth: 1 };
+
+const VALID_CATEGORIES = new Set(["live", "stub", "partial", "deprecated"]);
+
+// Test-file suffixes beyond the base set in ts-guard-utils. Matches the
+// convention in check-throwing-stub-callers.mjs and check-stub-debt.mjs.
+const extraTestSuffixes = [
+  ".test-helpers.ts",
+  ".test-mocks.ts",
+  ".mocks.ts",
+  ".mocks.shared.ts",
+  ".e2e-mocks.ts",
+];
+
+function normalizePath(filePath) {
+  return path.relative(repoRoot, filePath).split(path.sep).join("/");
+}
+
+function isAttestedDepthOneFile(filePath) {
+  const rel = normalizePath(filePath);
+  const prefix = `${attestedGlob.root}/`;
+  if (!rel.startsWith(prefix)) {
+    return false;
+  }
+  const tail = rel.slice(prefix.length);
+  if (tail.includes("/")) {
+    return false; // deeper than depth-1
+  }
+  if (isTestLikeTypeScriptFile(filePath, { extraTestSuffixes })) {
+    return false;
+  }
+  return true;
+}
+
+function isProductionFile(filePath) {
+  return !isTestLikeTypeScriptFile(filePath, { extraTestSuffixes });
+}
+
+/** Load every TypeScript source file in src/ + extensions/ + ui/ once. */
+async function loadAllSources() {
+  const roots = resolveSourceRoots(repoRoot, ["src", "extensions", "ui"]);
+  const files = await collectTypeScriptFilesFromRoots(roots, {
+    includeTests: true,
+    extraTestSuffixes,
+  });
+  const map = new Map();
+  for (const filePath of files) {
+    const content = await fs.readFile(filePath, "utf8");
+    const sourceFile = ts.createSourceFile(
+      filePath,
+      content,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    map.set(normalizePath(filePath), { filePath, sourceFile, content });
+  }
+  return map;
+}
+
+/**
+ * Enumerate runtime exports from a source file. Returns a list of
+ * `{ symbol, line, kind, looksLikeStub }` records.
+ *
+ * `kind` is one of: "function" | "arrow" | "function-expression" | "class"
+ * | "default-function".
+ *
+ * `looksLikeStub` is true when the function body matches any of the four
+ * throwing-stub calibration signals (used to cross-check "live"
+ * attestations).
+ */
+function enumerateRuntimeExports(sourceFile) {
+  const exports = [];
+  const fullText = sourceFile.text;
+
+  function recordFunctionLike({ name, body, parameters, returnType, ownerNode, kind }) {
+    exports.push({
+      symbol: name,
+      line: toLine(sourceFile, ownerNode),
+      kind,
+      looksLikeStub: looksLikeThrowingStub({
+        body,
+        parameters,
+        returnType,
+        ownerNode,
+        fullText,
+      }),
+    });
+  }
+
+  for (const statement of sourceFile.statements) {
+    const isExported = statement.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+    const isDefault = statement.modifiers?.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword);
+
+    if (!isExported) {
+      continue;
+    }
+
+    if (ts.isFunctionDeclaration(statement) && statement.name && statement.body) {
+      recordFunctionLike({
+        name: isDefault ? "default" : statement.name.text,
+        body: statement.body,
+        parameters: statement.parameters,
+        returnType: statement.type,
+        ownerNode: statement,
+        kind: isDefault ? "default-function" : "function",
+      });
+      continue;
+    }
+
+    if (ts.isClassDeclaration(statement) && statement.name) {
+      exports.push({
+        symbol: isDefault ? "default" : statement.name.text,
+        line: toLine(sourceFile, statement),
+        kind: "class",
+        looksLikeStub: false,
+      });
+      continue;
+    }
+
+    if (ts.isVariableStatement(statement)) {
+      for (const decl of statement.declarationList.declarations) {
+        if (!ts.isIdentifier(decl.name)) {
+          continue;
+        }
+        const init = decl.initializer;
+        if (!init) {
+          continue;
+        }
+        if (ts.isArrowFunction(init) && init.body) {
+          // Arrow body may be a block `() => { ... }` or an expression
+          // `() => expr`. Both are runtime functions and must be attested.
+          // Only block bodies can match the throwing-stub shape, so pass
+          // `isBlock(init.body) ? init.body : undefined` downstream.
+          recordFunctionLike({
+            name: decl.name.text,
+            body: ts.isBlock(init.body) ? init.body : undefined,
+            parameters: init.parameters,
+            returnType: init.type,
+            ownerNode: statement,
+            kind: "arrow",
+          });
+        } else if (ts.isFunctionExpression(init) && init.body && ts.isBlock(init.body)) {
+          recordFunctionLike({
+            name: decl.name.text,
+            body: init.body,
+            parameters: init.parameters,
+            returnType: init.type,
+            ownerNode: statement,
+            kind: "function-expression",
+          });
+        }
+        // Non-function consts (data literals) are not runtime exports for
+        // attestation purposes.
+      }
+      continue;
+    }
+
+    if (ts.isExportAssignment(statement) && statement.expression) {
+      // `export default <expr>`. Only attest if it's a function-like.
+      const expr = statement.expression;
+      if (ts.isArrowFunction(expr) && expr.body && ts.isBlock(expr.body)) {
+        recordFunctionLike({
+          name: "default",
+          body: expr.body,
+          parameters: expr.parameters,
+          returnType: expr.type,
+          ownerNode: statement,
+          kind: "default-function",
+        });
+      } else if (ts.isFunctionExpression(expr) && expr.body && ts.isBlock(expr.body)) {
+        recordFunctionLike({
+          name: expr.name?.text ?? "default",
+          body: expr.body,
+          parameters: expr.parameters,
+          returnType: expr.type,
+          ownerNode: statement,
+          kind: "default-function",
+        });
+      }
+      continue;
+    }
+
+    // export { ... } from "..." and export * from "..." are re-exports;
+    // attestations live in the defining module, so skip.
+  }
+
+  return exports;
+}
+
+/**
+ * Extract the MODULE_ATTESTATIONS object from a source file. Returns
+ * `{ found: boolean, entries: Map<string, {category, line}>, node }`.
+ * `entries` is a map from exported symbol name to category string.
+ */
+function extractAttestations(sourceFile) {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) {
+      continue;
+    }
+    const isExported = statement.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+    if (!isExported) {
+      continue;
+    }
+    for (const decl of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name)) {
+        continue;
+      }
+      if (decl.name.text !== "MODULE_ATTESTATIONS") {
+        continue;
+      }
+      const init = decl.initializer;
+      if (!init) {
+        continue;
+      }
+      // Accept both `{...} as const` (AsExpression) and `{...}` (ObjectLiteral).
+      let objNode = init;
+      if (ts.isAsExpression(objNode) || ts.isTypeAssertionExpression(objNode)) {
+        objNode = objNode.expression;
+      }
+      if (!ts.isObjectLiteralExpression(objNode)) {
+        return {
+          found: true,
+          entries: new Map(),
+          node: statement,
+          error: "MODULE_ATTESTATIONS must be an object literal",
+        };
+      }
+      const entries = new Map();
+      for (const prop of objNode.properties) {
+        if (!ts.isPropertyAssignment(prop)) {
+          continue;
+        }
+        let key;
+        if (ts.isIdentifier(prop.name)) {
+          key = prop.name.text;
+        } else if (ts.isStringLiteral(prop.name)) {
+          key = prop.name.text;
+        } else {
+          continue;
+        }
+        const value = prop.initializer;
+        if (!ts.isStringLiteral(value) && !ts.isNoSubstitutionTemplateLiteral(value)) {
+          entries.set(key, { category: "<invalid>", line: toLine(sourceFile, prop) });
+          continue;
+        }
+        entries.set(key, { category: value.text, line: toLine(sourceFile, prop) });
+      }
+      return { found: true, entries, node: statement };
+    }
+  }
+  return { found: false, entries: new Map(), node: null };
+}
+
+/**
+ * For each "stub"-attested export across all attested modules, scan
+ * production source files for identifier references to the export. Returns
+ * a map from `file::symbol` to an array of `{file, line}` caller records.
+ */
+function findStubCallers(attestedModules, sourceFileIndex) {
+  const perStubCallers = new Map();
+
+  for (const module of attestedModules) {
+    for (const [symbol, entry] of module.attestations.entries) {
+      if (entry.category !== "stub") {
+        continue;
+      }
+      const key = `${module.relPath}::${symbol}`;
+      perStubCallers.set(key, []);
+      // We'll build a reverse-index below (importer resolves to module
+      // specifier → map imported local name to (stubFile, stubSymbol)).
+    }
+  }
+
+  for (const [importerPath, record] of sourceFileIndex) {
+    if (!isProductionFile(record.filePath)) {
+      continue;
+    }
+    const bindings = new Map(); // localName -> { stubFile, stubSymbol }
+
+    for (const statement of record.sourceFile.statements) {
+      if (!ts.isImportDeclaration(statement)) {
+        continue;
+      }
+      if (!statement.importClause || !statement.importClause.namedBindings) {
+        continue;
+      }
+      const named = statement.importClause.namedBindings;
+      if (!ts.isNamedImports(named)) {
+        continue;
+      }
+      if (!ts.isStringLiteral(statement.moduleSpecifier)) {
+        continue;
+      }
+
+      const resolved = resolveModuleSpecifier(
+        statement.moduleSpecifier.text,
+        record.filePath,
+        sourceFileIndex,
+      );
+      if (!resolved) {
+        continue;
+      }
+
+      // Only care if the imported module is one of our attested modules.
+      const module = attestedModules.find((m) => m.relPath === resolved);
+      if (!module) {
+        continue;
+      }
+
+      for (const elem of named.elements) {
+        const imported = elem.propertyName?.text ?? elem.name.text;
+        const local = elem.name.text;
+        const entry = module.attestations.entries.get(imported);
+        if (!entry || entry.category !== "stub") {
+          continue;
+        }
+        bindings.set(local, { stubFile: resolved, stubSymbol: imported });
+      }
+    }
+
+    if (bindings.size === 0) {
+      continue;
+    }
+
+    // Walk the file and count identifier references to bound names outside
+    // import/export clauses and type positions.
+    const visit = (node) => {
+      if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+        return;
+      }
+      if (ts.isIdentifier(node) && bindings.has(node.text)) {
+        // Skip if part of an ImportSpecifier already handled above.
+        const parent = node.parent;
+        if (parent && (ts.isImportSpecifier(parent) || ts.isExportSpecifier(parent))) {
+          return;
+        }
+        const { stubFile, stubSymbol } = bindings.get(node.text);
+        const key = `${stubFile}::${stubSymbol}`;
+        perStubCallers.get(key)?.push({
+          file: importerPath,
+          line: toLine(record.sourceFile, node),
+        });
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(record.sourceFile);
+  }
+
+  return perStubCallers;
+}
+
+function resolveModuleSpecifier(specifier, importerFile, sourceFileIndex) {
+  if (!specifier.startsWith(".") && !specifier.startsWith("/")) {
+    return null;
+  }
+  const importerDir = path.dirname(importerFile);
+  const base = specifier.startsWith("/")
+    ? path.resolve(repoRoot, specifier.replace(/^\/+/, ""))
+    : path.resolve(importerDir, specifier);
+  const stripped = base.replace(/\.(m?js|jsx)$/, "");
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.mts`,
+    `${base}.tsx`,
+    stripped,
+    `${stripped}.ts`,
+    `${stripped}.mts`,
+    `${stripped}.tsx`,
+    path.join(base, "index.ts"),
+    path.join(base, "index.mts"),
+    path.join(stripped, "index.ts"),
+    path.join(stripped, "index.mts"),
+  ];
+  for (const candidate of candidates) {
+    const normalized = normalizePath(candidate);
+    if (sourceFileIndex.has(normalized)) {
+      return normalized;
+    }
+  }
+  return null;
+}
+
+function formatFailures(failures) {
+  const out = [];
+  for (const f of failures) {
+    out.push(`  ${f.file}:${f.line}  ${f.reason}`);
+  }
+  return out.join("\n");
+}
+
+/**
+ * Run invariants 1-3 (structural + "live" vs throwing-shape) on a single
+ * attested module. Invariant 4 requires cross-module caller resolution and
+ * lives in main() — NOT covered here.
+ *
+ * @returns {{file: string, line: number, reason: string}[]} failures
+ */
+function validateModuleStructural({ relPath, exports, attestations, sourceFile }) {
+  const failures = [];
+  const pushFailure = (line, reason) => failures.push({ file: relPath, line, reason });
+
+  if (!attestations.found) {
+    // Only fail if the module has runtime exports. A module with only
+    // types / data constants has nothing to attest.
+    if (exports.length > 0) {
+      pushFailure(
+        1,
+        `missing MODULE_ATTESTATIONS (module has ${exports.length} runtime export(s))`,
+      );
+    }
+    return failures;
+  }
+
+  if (attestations.error) {
+    pushFailure(toLine(sourceFile, attestations.node), attestations.error);
+    return failures;
+  }
+
+  const attestedSymbols = new Set(attestations.entries.keys());
+  const exportedSymbols = new Set(exports.map((e) => e.symbol));
+
+  // Invariant 1: every runtime export has an attestation.
+  for (const exp of exports) {
+    if (!attestedSymbols.has(exp.symbol)) {
+      pushFailure(
+        exp.line,
+        `export '${exp.symbol}' (${exp.kind}) has no MODULE_ATTESTATIONS entry`,
+      );
+    }
+  }
+
+  // Invariant 2: every attestation corresponds to a current export.
+  for (const [symbol, entry] of attestations.entries) {
+    if (!exportedSymbols.has(symbol)) {
+      pushFailure(
+        entry.line,
+        `stale attestation: '${symbol}' is no longer a runtime export — remove the entry`,
+      );
+    }
+  }
+
+  // Validate category values.
+  for (const [symbol, entry] of attestations.entries) {
+    if (!VALID_CATEGORIES.has(entry.category)) {
+      pushFailure(
+        entry.line,
+        `invalid category '${entry.category}' for '${symbol}' (must be one of: ${[...VALID_CATEGORIES].join(", ")})`,
+      );
+    }
+  }
+
+  // Invariant 3: "live" attestation must NOT match throwing-stub shape.
+  for (const exp of exports) {
+    const entry = attestations.entries.get(exp.symbol);
+    if (!entry) {
+      continue;
+    }
+    if (entry.category === "live" && exp.looksLikeStub) {
+      pushFailure(
+        exp.line,
+        `'${exp.symbol}' attested "live" but matches throwing-stub pattern — either fix the implementation or re-attest as "stub"/"partial"`,
+      );
+    }
+  }
+
+  return failures;
+}
+
+/**
+ * Classify a single TypeScript source text for self-tests. Returns enumerated
+ * exports, parsed attestations, and structural failures (invariants 1-3).
+ * Invariant 4 (stub-with-live-callers) is excluded — it requires cross-module
+ * source-file indexing and is exercised by the integration-style run against
+ * the real repo.
+ */
+export function classifyFixture(sourceText, fileName = "fixture.ts") {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const exports = enumerateRuntimeExports(sourceFile);
+  const attestations = extractAttestations(sourceFile);
+  const failures = validateModuleStructural({
+    relPath: fileName,
+    exports,
+    attestations,
+    sourceFile,
+  });
+  return { exports, attestations, failures };
+}
+
+const SELF_TEST_FIXTURES = [
+  {
+    name: "invariant 1: runtime export without MODULE_ATTESTATIONS fails",
+    source: `export function foo() { return 1; }\n`,
+    expectedFailures: [/missing MODULE_ATTESTATIONS \(module has 1 runtime export/],
+  },
+  {
+    name: "invariant 1: runtime export missing specific entry fails",
+    source: `export const MODULE_ATTESTATIONS = { foo: "live" } as const;\nexport function foo() { return 1; }\nexport function bar() { return 2; }\n`,
+    expectedFailures: [/export 'bar' \(function\) has no MODULE_ATTESTATIONS entry/],
+  },
+  {
+    name: "invariant 2: stale entry for non-exported symbol fails",
+    source: `export const MODULE_ATTESTATIONS = { foo: "live", ghost: "live" } as const;\nexport function foo() { return 1; }\n`,
+    expectedFailures: [/stale attestation: 'ghost'/],
+  },
+  {
+    name: "invariant 3: 'live' on throwing-stub (variadic-unknown) fails",
+    source: `export const MODULE_ATTESTATIONS = { foo: "live" } as const;\nexport function foo(..._args: unknown[]): never {\n  throw new Error("not available in RemoteClaw fork");\n}\n`,
+    expectedFailures: [/attested "live" but matches throwing-stub pattern/],
+  },
+  {
+    name: "invariant 3: 'stub' on throwing-stub passes (structural)",
+    source: `export const MODULE_ATTESTATIONS = { foo: "stub" } as const;\nexport function foo(..._args: unknown[]): never {\n  throw new Error("not available in RemoteClaw fork");\n}\n`,
+    expectedFailures: [],
+  },
+  {
+    name: "expression-body arrow is enumerated as runtime export (requires attestation)",
+    source: `export const foo = (..._args: unknown[]) => undefined as any;\n`,
+    expectedFailures: [/missing MODULE_ATTESTATIONS \(module has 1 runtime export/],
+    expectedExports: ["foo"],
+  },
+  {
+    name: "expression-body arrow does NOT match throwing-stub shape (has no throw body)",
+    source: `export const MODULE_ATTESTATIONS = { foo: "live" } as const;\nexport const foo = (..._args: unknown[]) => undefined as any;\n`,
+    expectedFailures: [],
+  },
+  {
+    name: "invalid category fails",
+    source: `export const MODULE_ATTESTATIONS = { foo: "alive" } as const;\nexport function foo() {}\n`,
+    expectedFailures: [/invalid category 'alive'/],
+  },
+  {
+    name: "type / interface / literal const exports do NOT require attestation",
+    source: `export type Foo = string;\nexport interface Bar { x: number }\nexport const BAZ = "literal";\n`,
+    expectedFailures: [],
+    expectedExports: [],
+  },
+  {
+    name: "valid module with mixed runtime exports passes",
+    source: `export const MODULE_ATTESTATIONS = { foo: "live", bar: "live", Baz: "live" } as const;\nexport function foo() {}\nexport const bar = () => 1;\nexport class Baz {}\n`,
+    expectedFailures: [],
+    expectedExports: ["foo", "bar", "Baz"],
+  },
+];
+
+function runSelfTests(streams) {
+  let failures = 0;
+  streams.stdout.write(`Running ${SELF_TEST_FIXTURES.length} attestation self-tests...\n\n`);
+
+  for (const fixture of SELF_TEST_FIXTURES) {
+    const { exports, failures: actualFailures } = classifyFixture(fixture.source);
+    const reasons = actualFailures.map((f) => f.reason);
+    const expectedMatchers = fixture.expectedFailures;
+
+    let passed = reasons.length === expectedMatchers.length;
+    const unmatched = [];
+    if (passed) {
+      for (const matcher of expectedMatchers) {
+        const found = reasons.some((r) => matcher.test(r));
+        if (!found) {
+          passed = false;
+          unmatched.push(matcher);
+        }
+      }
+    }
+
+    if (passed && fixture.expectedExports !== undefined) {
+      const actual = exports.map((e) => e.symbol).toSorted();
+      const expected = [...fixture.expectedExports].toSorted();
+      if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        passed = false;
+        unmatched.push(
+          `exports mismatch: got ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`,
+        );
+      }
+    }
+
+    const status = passed ? "PASS" : "FAIL";
+    streams.stdout.write(`  [${status}] ${fixture.name}\n`);
+    if (!passed) {
+      failures += 1;
+      streams.stdout.write(`    expected: ${JSON.stringify(expectedMatchers.map(String))}\n`);
+      streams.stdout.write(`    actual:   ${JSON.stringify(reasons)}\n`);
+      if (unmatched.length > 0) {
+        streams.stdout.write(`    mismatch: ${JSON.stringify(unmatched.map(String))}\n`);
+      }
+    }
+  }
+
+  streams.stdout.write("\n");
+  if (failures === 0) {
+    streams.stdout.write(`All ${SELF_TEST_FIXTURES.length} self-tests passed.\n`);
+    return 0;
+  }
+  streams.stderr.write(`${failures} self-test${failures === 1 ? "" : "s"} failed.\n`);
+  return 1;
+}
+
+export async function main(argv = process.argv.slice(2), io) {
+  const streams = io ?? { stdout: process.stdout, stderr: process.stderr };
+
+  if (argv.includes("--self-test")) {
+    return runSelfTests(streams);
+  }
+
+  const sourceFileIndex = await loadAllSources();
+  const attestedModules = [];
+
+  // Pass 1: enumerate exports + extract attestations per attested module.
+  for (const [relPath, record] of sourceFileIndex) {
+    if (!isAttestedDepthOneFile(record.filePath)) {
+      continue;
+    }
+    const exports = enumerateRuntimeExports(record.sourceFile);
+    const attestations = extractAttestations(record.sourceFile);
+    attestedModules.push({ relPath, exports, attestations, sourceFile: record.sourceFile });
+  }
+
+  const failures = [];
+
+  // Pass 2: invariants 1-3 + category validation (per-module, structural).
+  for (const module of attestedModules) {
+    failures.push(...validateModuleStructural(module));
+  }
+
+  // Invariant 4: "stub" attestation must have zero non-test importers.
+  const perStubCallers = findStubCallers(attestedModules, sourceFileIndex);
+  for (const module of attestedModules) {
+    for (const [symbol, entry] of module.attestations.entries) {
+      if (entry.category !== "stub") {
+        continue;
+      }
+      const key = `${module.relPath}::${symbol}`;
+      const callers = perStubCallers.get(key) ?? [];
+      if (callers.length > 0) {
+        callers.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
+        const list = callers
+          .slice(0, 5)
+          .map((c) => `${c.file}:${c.line}`)
+          .join(", ");
+        const more = callers.length > 5 ? `, +${callers.length - 5} more` : "";
+        failures.push({
+          file: module.relPath,
+          line: entry.line,
+          reason: `'${symbol}' attested "stub" but has ${callers.length} non-test caller(s): ${list}${more}`,
+        });
+      }
+    }
+  }
+
+  if (failures.length === 0) {
+    streams.stdout.write(
+      `Module attestation check passed: ${attestedModules.length} modules, ${attestedModules.reduce((s, m) => s + m.attestations.entries.size, 0)} attestations.\n`,
+    );
+    return 0;
+  }
+
+  failures.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
+  streams.stderr.write(`FAIL: ${failures.length} attestation violation(s):\n\n`);
+  streams.stderr.write(`${formatFailures(failures)}\n`);
+  streams.stderr.write(
+    "\nModule attestations declare the runtime status of each export.\n" +
+      "See CONTRIBUTING.md § Module attestations for the convention and\n" +
+      "category definitions (live / stub / partial / deprecated).\n",
+  );
+  return 1;
+}
+
+runAsScript(import.meta.url, async () => {
+  const exitCode = await main();
+  if (exitCode !== 0) {
+    process.exit(exitCode);
+  }
+});

--- a/scripts/check-throwing-stub-callers.mjs
+++ b/scripts/check-throwing-stub-callers.mjs
@@ -33,6 +33,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
+import { classifyThrowingStubShape } from "./lib/throwing-stub-shape.mjs";
 import {
   collectTypeScriptFilesFromRoots,
   isTestLikeTypeScriptFile,
@@ -48,12 +49,6 @@ const sourceRoots = ["src", "extensions", "ui"];
 // these are excluded from both stub-detection and caller-detection: mock
 // files and test helpers reference stubs but are not production callers.
 const extraTestSuffixes = [".test-helpers.ts", ".test-mocks.ts", ".e2e.test.ts", ".live.test.ts"];
-
-// Regex for fork-attributed throw messages (Patterns B and C from #2409).
-const forkMessagePattern = /not available in RemoteClaw fork|\bgutted\b|upstream-compat/i;
-
-// Marker-comment pattern for explicit upstream-compat stubs.
-const markerCommentPattern = /Gutted in RemoteClaw fork/i;
 
 function normalizePath(filePath) {
   return path.relative(repoRoot, filePath).split(path.sep).join("/");
@@ -88,165 +83,23 @@ async function loadSourceFiles({ includeTests }) {
   return out;
 }
 
-/** Extract throw-message text from a throw statement, or null if not a literal string. */
-function throwMessageOf(throwStatement) {
-  const expr = throwStatement.expression;
-  if (!expr || !ts.isNewExpression(expr)) {
-    return null;
-  }
-  const args = expr.arguments ?? [];
-  if (args.length === 0) {
-    return null;
-  }
-  const first = args[0];
-  if (ts.isStringLiteral(first) || ts.isNoSubstitutionTemplateLiteral(first)) {
-    return first.text;
-  }
-  return null;
-}
-
-/** A function body is a "single throw" if it contains exactly one statement that is a ThrowStatement. */
-function isSingleThrowBody(body) {
-  if (!body || !ts.isBlock(body)) {
-    return false;
-  }
-  if (body.statements.length !== 1) {
-    return false;
-  }
-  return ts.isThrowStatement(body.statements[0]);
-}
-
-/** Is the parameter's type annotation `unknown[]` / `readonly unknown[]` / `Array<unknown>`? */
-function isUnknownArrayType(type) {
-  if (ts.isArrayTypeNode(type) && type.elementType.kind === ts.SyntaxKind.UnknownKeyword) {
-    return true;
-  }
-  if (
-    ts.isTypeOperatorNode(type) &&
-    type.operator === ts.SyntaxKind.ReadonlyKeyword &&
-    ts.isArrayTypeNode(type.type) &&
-    type.type.elementType.kind === ts.SyntaxKind.UnknownKeyword
-  ) {
-    return true;
-  }
-  if (
-    ts.isTypeReferenceNode(type) &&
-    ts.isIdentifier(type.typeName) &&
-    type.typeName.text === "Array" &&
-    type.typeArguments?.length === 1 &&
-    type.typeArguments[0].kind === ts.SyntaxKind.UnknownKeyword
-  ) {
-    return true;
-  }
-  return false;
-}
-
-/** Does the parameter list declare variadic `...args: unknown[]` or `..._args: unknown[]`? */
-function hasVariadicUnknownArgs(parameters) {
-  for (const param of parameters) {
-    if (!param.dotDotDotToken) {
-      continue;
-    }
-    if (!param.type) {
-      continue;
-    }
-    if (isUnknownArrayType(param.type)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/** Is the return type annotation an explicit `: never` TypeNode? (Does not match inferred or union types.) */
-function hasNeverReturnType(returnType) {
-  return returnType !== undefined && returnType.kind === ts.SyntaxKind.NeverKeyword;
-}
-
-/**
- * Does the parameter list contain any typed parameter that is NOT variadic-unknown?
- * Typed error-throw helpers like `(err: unknown)`, `(reason: string)`,
- * `(params: {...})` match. Empty parameter lists, untyped parameters, and
- * variadic-unknown signatures do not.
- *
- * Used to preserve the implicit typed-helper exclusion when `: never` return
- * type fires as a calibration signal — typed helpers retain their legitimate
- * `: never` signature without being classified as stubs.
- */
-function hasTypedNonVariadicUnknownParams(parameters) {
-  for (const param of parameters) {
-    if (!param.type) {
-      continue;
-    }
-    if (param.dotDotDotToken) {
-      if (isUnknownArrayType(param.type)) {
-        continue;
-      }
-      return true;
-    }
-    return true;
-  }
-  return false;
-}
-
-/** Does the text immediately preceding `node` contain the "Gutted in RemoteClaw fork" marker? */
-function hasMarkerComment(sourceFile, node, fullText) {
-  const ranges = ts.getLeadingCommentRanges(fullText, node.getFullStart());
-  if (!ranges) {
-    return false;
-  }
-  for (const range of ranges) {
-    const commentText = fullText.slice(range.pos, range.end);
-    if (markerCommentPattern.test(commentText)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 /** Build the candidate record if the function declaration matches a stub pattern. */
 function classifyStubFunction({ sourceFile, fullText, name, body, parameters, returnType, node }) {
-  if (!isSingleThrowBody(body)) {
+  const shape = classifyThrowingStubShape({
+    body,
+    parameters,
+    returnType,
+    ownerNode: node,
+    fullText,
+  });
+  if (!shape) {
     return null;
   }
-  const throwStatement = body.statements[0];
-  const message = throwMessageOf(throwStatement);
-
-  const variadicUnknown = hasVariadicUnknownArgs(parameters);
-  const forkMessage = message !== null && forkMessagePattern.test(message);
-  const markerComment = hasMarkerComment(sourceFile, node, fullText);
-
-  // `: never` return type fires as a calibration signal only when the function
-  // has no typed non-variadic-unknown parameters. This preserves the implicit
-  // typed-helper exclusion: `exitHooksCliWithError(err: unknown): never`,
-  // `throwPathEscapesBoundary(params: {...}): never`, etc. remain unflagged
-  // while `function foo(): never { throw ... }` (uncalibrated stub) fires.
-  const neverReturn = hasNeverReturnType(returnType);
-  const hasTypedParams = hasTypedNonVariadicUnknownParams(parameters);
-  const neverReturnSignal = neverReturn && !hasTypedParams;
-
-  if (!variadicUnknown && !forkMessage && !markerComment && !neverReturnSignal) {
-    return null;
-  }
-
-  const signals = [];
-  if (variadicUnknown) {
-    signals.push("variadic-unknown");
-  }
-  if (forkMessage) {
-    signals.push("fork-message");
-  }
-  if (markerComment) {
-    signals.push("marker-comment");
-  }
-  if (neverReturnSignal) {
-    signals.push("never-return");
-  }
-
   return {
     symbol: name,
     line: toLine(sourceFile, node),
-    signals,
-    message,
+    signals: shape.signals,
+    message: shape.message,
   };
 }
 

--- a/scripts/generate-attestations.mjs
+++ b/scripts/generate-attestations.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+
+/**
+ * One-shot bootstrap: auto-generate `MODULE_ATTESTATIONS` blocks for every
+ * attested module that doesn't already have one.
+ *
+ * Used exactly once during the H9 rollout (remoteclaw#2437). Can be kept
+ * as a maintenance utility for extending the attestation scope to new
+ * directories later — idempotent (skips modules that already have a
+ * MODULE_ATTESTATIONS block).
+ *
+ * Auto-classification:
+ * - Exports matching the throwing-stub calibration signals (see
+ *   check-attestations.mjs § looksLikeThrowingStub) → "stub"
+ * - Everything else → "live"
+ *
+ * "partial" and "deprecated" are NOT auto-detected; the rollout requires
+ * human review to identify those cases. This script defaults to "live"
+ * and the reviewer upgrades specific entries as needed.
+ *
+ * Placement: the generated block is inserted immediately after the last
+ * `import` statement (or at the top of the file if no imports exist),
+ * before any other content.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { looksLikeThrowingStub } from "./lib/throwing-stub-shape.mjs";
+import { isTestLikeTypeScriptFile } from "./lib/ts-guard-utils.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const attestedRoot = path.join(repoRoot, "src/agents");
+
+// Matches the suffix list used by check-attestations.mjs so the two scripts
+// agree on which files under src/agents/ are attested-production modules.
+const extraTestSuffixes = [
+  ".test-helpers.ts",
+  ".test-mocks.ts",
+  ".mocks.ts",
+  ".mocks.shared.ts",
+  ".e2e-mocks.ts",
+];
+
+function classify(entry) {
+  return entry.looksLikeStub ? "stub" : "live";
+}
+
+function enumerateExports(sourceFile) {
+  const exports = [];
+  const fullText = sourceFile.text;
+
+  function record({ name, body, parameters, returnType, ownerNode, kind }) {
+    exports.push({
+      symbol: name,
+      kind,
+      looksLikeStub: looksLikeThrowingStub({
+        body,
+        parameters,
+        returnType,
+        ownerNode,
+        fullText,
+      }),
+    });
+  }
+
+  for (const statement of sourceFile.statements) {
+    const isExported = statement.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+    const isDefault = statement.modifiers?.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword);
+    if (!isExported) {
+      continue;
+    }
+
+    if (ts.isFunctionDeclaration(statement) && statement.name && statement.body) {
+      record({
+        name: isDefault ? "default" : statement.name.text,
+        body: statement.body,
+        parameters: statement.parameters,
+        returnType: statement.type,
+        ownerNode: statement,
+        kind: isDefault ? "default-function" : "function",
+      });
+      continue;
+    }
+
+    if (ts.isClassDeclaration(statement) && statement.name) {
+      exports.push({
+        symbol: isDefault ? "default" : statement.name.text,
+        kind: "class",
+        looksLikeStub: false,
+      });
+      continue;
+    }
+
+    if (ts.isVariableStatement(statement)) {
+      for (const decl of statement.declarationList.declarations) {
+        if (!ts.isIdentifier(decl.name)) {
+          continue;
+        }
+        const init = decl.initializer;
+        if (!init) {
+          continue;
+        }
+        if (ts.isArrowFunction(init) && init.body) {
+          // Arrow body may be a block `() => { ... }` or an expression
+          // `() => expr`. Both are runtime functions that need attestation.
+          // Only block bodies can match the throwing-stub shape; pass
+          // `undefined` for expression bodies so the classifier skips them
+          // (falls through to "live" default — reviewer upgrades "partial"
+          // if the expression returns a degraded constant).
+          record({
+            name: decl.name.text,
+            body: ts.isBlock(init.body) ? init.body : undefined,
+            parameters: init.parameters,
+            returnType: init.type,
+            ownerNode: statement,
+            kind: "arrow",
+          });
+        } else if (ts.isFunctionExpression(init) && init.body && ts.isBlock(init.body)) {
+          record({
+            name: decl.name.text,
+            body: init.body,
+            parameters: init.parameters,
+            returnType: init.type,
+            ownerNode: statement,
+            kind: "function-expression",
+          });
+        }
+      }
+      continue;
+    }
+
+    if (ts.isExportAssignment(statement) && statement.expression) {
+      const expr = statement.expression;
+      if (ts.isArrowFunction(expr) && expr.body && ts.isBlock(expr.body)) {
+        record({
+          name: "default",
+          body: expr.body,
+          parameters: expr.parameters,
+          returnType: expr.type,
+          ownerNode: statement,
+          kind: "default-function",
+        });
+      } else if (ts.isFunctionExpression(expr) && expr.body && ts.isBlock(expr.body)) {
+        record({
+          name: expr.name?.text ?? "default",
+          body: expr.body,
+          parameters: expr.parameters,
+          returnType: expr.type,
+          ownerNode: statement,
+          kind: "default-function",
+        });
+      }
+      continue;
+    }
+  }
+
+  return exports;
+}
+
+function hasExistingAttestations(sourceFile) {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) {
+      continue;
+    }
+    const isExported = statement.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+    if (!isExported) {
+      continue;
+    }
+    for (const decl of statement.declarationList.declarations) {
+      if (ts.isIdentifier(decl.name) && decl.name.text === "MODULE_ATTESTATIONS") {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Find the character offset of the insertion point: immediately after the
+ * last import statement (or at the end of the leading comment block if no
+ * imports exist).
+ */
+function findInsertOffset(sourceFile) {
+  let lastImportEnd = null;
+  for (const statement of sourceFile.statements) {
+    if (ts.isImportDeclaration(statement)) {
+      lastImportEnd = statement.end;
+    }
+  }
+  if (lastImportEnd !== null) {
+    return lastImportEnd;
+  }
+  // No imports: find end of leading block/doc comment if present.
+  const fullText = sourceFile.text;
+  const ranges = ts.getLeadingCommentRanges(fullText, 0);
+  if (ranges && ranges.length > 0) {
+    return ranges[ranges.length - 1].end;
+  }
+  return 0;
+}
+
+function renderAttestationBlock(exports) {
+  const lines = [
+    "",
+    "",
+    "/**",
+    " * Runtime attestation (ADR 0005 H9). Declares the implementation status",
+    " * of each runtime export in this module. See CONTRIBUTING.md § Module",
+    " * attestations for the category definitions and the convention for",
+    " * updating these when sync or rebrand changes the surface.",
+    " */",
+    "export const MODULE_ATTESTATIONS = {",
+  ];
+  for (const exp of exports) {
+    const category = classify(exp);
+    lines.push(`  ${JSON.stringify(exp.symbol)}: ${JSON.stringify(category)},`);
+  }
+  lines.push("} as const;");
+  return lines.join("\n");
+}
+
+async function processFile(filePath) {
+  const content = await fs.readFile(filePath, "utf8");
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  if (hasExistingAttestations(sourceFile)) {
+    return { status: "skipped-existing", filePath };
+  }
+
+  const exports = enumerateExports(sourceFile);
+  if (exports.length === 0) {
+    return { status: "skipped-no-runtime-exports", filePath };
+  }
+
+  const insertOffset = findInsertOffset(sourceFile);
+  const block = renderAttestationBlock(exports);
+  const newContent = content.slice(0, insertOffset) + block + content.slice(insertOffset);
+
+  await fs.writeFile(filePath, newContent, "utf8");
+  const stubCount = exports.filter((e) => e.looksLikeStub).length;
+  return {
+    status: "generated",
+    filePath,
+    entries: exports.length,
+    stubCount,
+  };
+}
+
+async function main() {
+  const entries = await fs.readdir(attestedRoot);
+  const candidates = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(".ts")) {
+      continue;
+    }
+    const fullPath = path.join(attestedRoot, entry);
+    if (isTestLikeTypeScriptFile(fullPath, { extraTestSuffixes })) {
+      continue;
+    }
+    candidates.push(fullPath);
+  }
+
+  let generated = 0;
+  let skipped = 0;
+  let totalEntries = 0;
+  let totalStubs = 0;
+
+  for (const filePath of candidates.toSorted()) {
+    const result = await processFile(filePath);
+    if (result.status === "generated") {
+      generated += 1;
+      totalEntries += result.entries;
+      totalStubs += result.stubCount;
+      console.log(
+        `  wrote ${result.entries} attestation(s) (${result.stubCount} stub) to ${path.relative(repoRoot, filePath)}`,
+      );
+    } else {
+      skipped += 1;
+    }
+  }
+
+  console.log();
+  console.log(
+    `Generated ${generated} attestation blocks; skipped ${skipped} modules (existing or no runtime exports). ${totalEntries} total entries, ${totalStubs} auto-classified "stub".`,
+  );
+}
+
+await main();

--- a/scripts/lib/throwing-stub-shape.mjs
+++ b/scripts/lib/throwing-stub-shape.mjs
@@ -1,0 +1,210 @@
+/**
+ * Shared AST classifier for the "throwing-stub" shape used by the fork's
+ * two-stage stub-regression defense:
+ *
+ *   1. `check-throwing-stub-callers.mjs` (ADR 0005 H7) — catches exported
+ *      throwing stubs that have live non-test callers.
+ *   2. `check-attestations.mjs` (ADR 0005 H9) — cross-checks that a module
+ *      author's "live" attestation isn't lying about a throwing-shaped body.
+ *   3. `generate-attestations.mjs` — auto-classifies "stub" during the
+ *      one-shot rollout of MODULE_ATTESTATIONS blocks.
+ *
+ * All three consume the same four calibration signals (remoteclaw#2435):
+ *   A. Variadic-unknown signature:  `(..._args: unknown[])`
+ *   B. Fork-attributed throw message: "not available in RemoteClaw fork",
+ *      "gutted", "upstream-compat"
+ *   C. `// Gutted in RemoteClaw fork` marker comment on the declaration
+ *   D. `: never` return type with NO typed non-variadic-unknown parameters
+ *      (so typed error-throw helpers like `exitHooksCliWithError(err: unknown): never`
+ *      remain unflagged)
+ *
+ * Centralizing the shape tests here ensures that a fix to one invariant
+ * (e.g., expression-body arrow handling) applies uniformly and can't drift
+ * between the three scripts.
+ */
+
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+let tsCache;
+
+function getTypeScript() {
+  tsCache ??= require("typescript");
+  return tsCache;
+}
+
+/** Fork-attributed throw message pattern (Patterns B and C from #2409). */
+export const forkMessagePattern = /not available in RemoteClaw fork|\bgutted\b|upstream-compat/i;
+
+/** Marker-comment pattern for explicit upstream-compat stubs. */
+export const markerCommentPattern = /Gutted in RemoteClaw fork/i;
+
+/** True if a function-like body is a block containing exactly one throw statement. */
+export function isSingleThrowBody(body) {
+  const ts = getTypeScript();
+  if (!body || !ts.isBlock(body)) {
+    return false;
+  }
+  if (body.statements.length !== 1) {
+    return false;
+  }
+  return ts.isThrowStatement(body.statements[0]);
+}
+
+/** Extract the string argument of a `throw new Error("...")` expression, or null. */
+export function throwMessageOf(throwStatement) {
+  const ts = getTypeScript();
+  const expr = throwStatement.expression;
+  if (!expr || !ts.isNewExpression(expr)) {
+    return null;
+  }
+  const args = expr.arguments ?? [];
+  if (args.length === 0) {
+    return null;
+  }
+  const first = args[0];
+  if (ts.isStringLiteral(first) || ts.isNoSubstitutionTemplateLiteral(first)) {
+    return first.text;
+  }
+  return null;
+}
+
+/** Is the type node `unknown[]` / `readonly unknown[]` / `Array<unknown>`? */
+export function isUnknownArrayType(type) {
+  const ts = getTypeScript();
+  if (ts.isArrayTypeNode(type) && type.elementType.kind === ts.SyntaxKind.UnknownKeyword) {
+    return true;
+  }
+  if (
+    ts.isTypeOperatorNode(type) &&
+    type.operator === ts.SyntaxKind.ReadonlyKeyword &&
+    ts.isArrayTypeNode(type.type) &&
+    type.type.elementType.kind === ts.SyntaxKind.UnknownKeyword
+  ) {
+    return true;
+  }
+  if (
+    ts.isTypeReferenceNode(type) &&
+    ts.isIdentifier(type.typeName) &&
+    type.typeName.text === "Array" &&
+    type.typeArguments?.length === 1 &&
+    type.typeArguments[0].kind === ts.SyntaxKind.UnknownKeyword
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/** Does the parameter list include `...args: unknown[]` / `..._args: unknown[]`? */
+export function hasVariadicUnknownArgs(parameters) {
+  for (const param of parameters) {
+    if (param.dotDotDotToken && param.type && isUnknownArrayType(param.type)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Is the return type annotation an explicit `: never` TypeNode? */
+export function hasNeverReturnType(returnType) {
+  const ts = getTypeScript();
+  return returnType !== undefined && returnType.kind === ts.SyntaxKind.NeverKeyword;
+}
+
+/**
+ * Does the parameter list contain a typed non-variadic-unknown parameter?
+ *
+ * Used to preserve the implicit typed-helper exclusion when `: never` fires
+ * as a calibration signal — `exitHooksCliWithError(err: unknown): never`,
+ * `throwPathEscapesBoundary(params: {...}): never` keep their legitimate
+ * signatures without being misclassified.
+ */
+export function hasTypedNonVariadicUnknownParams(parameters) {
+  for (const param of parameters) {
+    if (!param.type) {
+      continue;
+    }
+    if (param.dotDotDotToken) {
+      if (isUnknownArrayType(param.type)) {
+        continue;
+      }
+      return true;
+    }
+    return true;
+  }
+  return false;
+}
+
+/** Does the leading-comment range of `node` contain the "Gutted in RemoteClaw fork" marker? */
+export function hasMarkerComment(node, fullText) {
+  const ts = getTypeScript();
+  const ranges = ts.getLeadingCommentRanges(fullText, node.getFullStart());
+  if (!ranges) {
+    return false;
+  }
+  for (const range of ranges) {
+    if (markerCommentPattern.test(fullText.slice(range.pos, range.end))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Classify a function-like (FunctionDeclaration, ArrowFunction, FunctionExpression)
+ * against the four calibration signals.
+ *
+ * @param {object} input
+ * @param {unknown} input.body — function body; pass `undefined` for
+ *   expression-body arrows (they can't match "single throw" anyway).
+ * @param {readonly unknown[]} input.parameters — parameter declarations.
+ * @param {unknown} input.returnType — return type annotation, or undefined.
+ * @param {unknown} input.ownerNode — the declaration node (for leading-comment scan).
+ * @param {string} input.fullText — source text of the containing file.
+ * @returns {null | { signals: string[], message: string | null }}
+ *   null if the function-like is NOT a throwing stub; otherwise the matching
+ *   calibration signals and (if present) the extracted throw message.
+ */
+export function classifyThrowingStubShape({ body, parameters, returnType, ownerNode, fullText }) {
+  if (!isSingleThrowBody(body)) {
+    return null;
+  }
+  const throwStatement = body.statements[0];
+  const message = throwMessageOf(throwStatement);
+
+  const variadicUnknown = hasVariadicUnknownArgs(parameters);
+  const forkMessage = message !== null && forkMessagePattern.test(message);
+  const markerComment = hasMarkerComment(ownerNode, fullText);
+  const neverReturn = hasNeverReturnType(returnType);
+  const hasTypedParams = hasTypedNonVariadicUnknownParams(parameters);
+  const neverReturnSignal = neverReturn && !hasTypedParams;
+
+  if (!variadicUnknown && !forkMessage && !markerComment && !neverReturnSignal) {
+    return null;
+  }
+
+  const signals = [];
+  if (variadicUnknown) {
+    signals.push("variadic-unknown");
+  }
+  if (forkMessage) {
+    signals.push("fork-message");
+  }
+  if (markerComment) {
+    signals.push("marker-comment");
+  }
+  if (neverReturnSignal) {
+    signals.push("never-return");
+  }
+
+  return { signals, message };
+}
+
+/**
+ * Boolean-only convenience wrapper around `classifyThrowingStubShape`, for
+ * callers that don't need the signal breakdown (e.g., the attestation
+ * "live"-vs-throwing-shape cross-check).
+ */
+export function looksLikeThrowingStub(input) {
+  return classifyThrowingStubShape(input) !== null;
+}

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -7,6 +7,17 @@ import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveAcpSpawnStreamLogPath: "live",
+  startAcpSpawnParentStreamRelay: "live",
+} as const;
+
 const DEFAULT_STREAM_FLUSH_MS = 2_500;
 const DEFAULT_NO_OUTPUT_NOTICE_MS = 60_000;
 const DEFAULT_NO_OUTPUT_POLL_MS = 15_000;

--- a/src/agents/agent-messaging.ts
+++ b/src/agents/agent-messaging.ts
@@ -1,5 +1,16 @@
 import { getChannelPlugin, normalizeChannelId } from "../channels/plugins/index.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  isMessagingTool: "live",
+  isMessagingToolSendAction: "live",
+} as const;
+
 export type MessagingToolSend = {
   tool: string;
   provider: string;

--- a/src/agents/agent-paths.ts
+++ b/src/agents/agent-paths.ts
@@ -3,6 +3,16 @@ import { resolveStateDir } from "../config/paths.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveRemoteClawAgentDir: "live",
+} as const;
+
 // Legacy literal used only as the "no specific agent" fallback for the
 // auth-store path resolver. This is NOT imported from routing/session-key —
 // it's an explicit local default preserved for backwards-compatible auth

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -13,6 +13,43 @@ import { resolveUserPath } from "../utils.js";
 import { normalizeSkillFilter } from "./skills/filter.js";
 import { resolveDefaultAgentWorkspaceDir } from "./workspace.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  listAgentEntries: "live",
+  listAgentIds: "live",
+  resolveDefaultAgentId: "live",
+  resolveSessionAgentIds: "live",
+  resolveSessionAgentId: "live",
+  resolveAgentConfig: "live",
+  resolveAgentSkillsFilter: "live",
+  resolveAgentExplicitModelPrimary: "live",
+  resolveAgentEffectiveModelPrimary: "live",
+  resolveAgentModelPrimary: "live",
+  resolveAgentModelFallbacksOverride: "live",
+  resolveFallbackAgentId: "live",
+  resolveRunModelFallbacksOverride: "live",
+  hasConfiguredModelFallbacks: "live",
+  resolveEffectiveModelFallbacks: "live",
+  resolveAgentWorkspaceDir: "live",
+  resolveAgentIdsByWorkspacePath: "live",
+  resolveAgentIdByWorkspacePath: "live",
+  resolveAgentDir: "live",
+  resolveSessionKeyAgentId: "live",
+  resolveSoleAgentId: "live",
+  resolveFirstAgentWorkspace: "live",
+  resolveAgentWorkspaceDirOrNull: "live",
+  resolveAgentRuntime: "live",
+  resolveAgentRuntimeArgs: "live",
+  resolveAgentRuntimeEnv: "live",
+  resolveAgentRuntimeOrThrow: "live",
+  resolveAgentAuth: "live",
+} as const;
+
 /** Default agent ID used when no explicit agent is configured. */
 const DEFAULT_AGENT_ID = "default";
 const log = createSubsystemLogger("agent-scope");

--- a/src/agents/agent-utils.ts
+++ b/src/agents/agent-utils.ts
@@ -4,6 +4,21 @@ import { sanitizeUserFacingText } from "./agent-helpers.js";
 import type { AgentMessage, AssistantMessage } from "./agent-types.js";
 import { formatToolDetail, resolveToolDisplay } from "./tool-display.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  isAssistantMessage: "live",
+  stripMinimaxToolCallXml: "live",
+  stripDowngradedToolCallText: "live",
+  stripThinkingTagsFromText: "live",
+  extractAssistantText: "live",
+  inferToolMetaFromArgs: "live",
+} as const;
+
 export function isAssistantMessage(msg: AgentMessage | undefined): msg is AssistantMessage {
   return msg?.role === "assistant";
 }

--- a/src/agents/announce-idempotency.ts
+++ b/src/agents/announce-idempotency.ts
@@ -1,3 +1,14 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  buildAnnounceIdFromChildRun: "live",
+  buildAnnounceIdempotencyKey: "live",
+  resolveQueueAnnounceId: "live",
+} as const;
 export type AnnounceIdFromChildRunParams = {
   childSessionKey: string;
   childRunId: string;

--- a/src/agents/anthropic-vertex-provider.ts
+++ b/src/agents/anthropic-vertex-provider.ts
@@ -3,6 +3,21 @@ import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveAnthropicVertexProjectId: "live",
+  resolveAnthropicVertexRegion: "live",
+  resolveAnthropicVertexRegionFromBaseUrl: "live",
+  resolveAnthropicVertexClientRegion: "live",
+  hasAnthropicVertexCredentials: "live",
+  hasAnthropicVertexAvailableAuth: "live",
+} as const;
+
 const ANTHROPIC_VERTEX_DEFAULT_REGION = "global";
 const ANTHROPIC_VERTEX_REGION_RE = /^[a-z0-9-]+$/;
 const GCLOUD_DEFAULT_ADC_PATH = join(

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -1,5 +1,16 @@
 import { callGatewayTool } from "./tools/gateway.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  buildExecApprovalFollowupPrompt: "live",
+  sendExecApprovalFollowup: "live",
+} as const;
+
 type ExecApprovalFollowupParams = {
   approvalId: string;
   sessionKey?: string;

--- a/src/agents/block-chunker.ts
+++ b/src/agents/block-chunker.ts
@@ -1,6 +1,16 @@
 import type { FenceSpan } from "../markdown/fences.js";
 import { findFenceSpanAt, isSafeFenceBreak, parseFenceSpans } from "../markdown/fences.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  BlockChunker: "live",
+} as const;
+
 export type BlockReplyChunking = {
   minChars: number;
   maxChars: number;

--- a/src/agents/channel-tools.ts
+++ b/src/agents/channel-tools.ts
@@ -10,6 +10,19 @@ import type { RemoteClawConfig } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
 
 /**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  listChannelSupportedActions: "live",
+  listAllChannelSupportedActions: "live",
+  listChannelAgentTools: "live",
+  resolveChannelMessageToolHints: "live",
+} as const;
+
+/**
  * Get the list of supported message actions for a specific channel.
  * Returns an empty array if channel is not found or has no actions configured.
  */

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -1,6 +1,17 @@
 import type { SessionEntry } from "../config/sessions.js";
 import { normalizeProviderId } from "./provider-utils.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  getCliSessionId: "live",
+  setCliSessionId: "live",
+} as const;
+
 export function getCliSessionId(
   entry: SessionEntry | undefined,
   provider: string,

--- a/src/agents/content-blocks.ts
+++ b/src/agents/content-blocks.ts
@@ -1,3 +1,12 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  collectTextContentBlocks: "live",
+} as const;
 export function collectTextContentBlocks(content: unknown): string[] {
   if (!Array.isArray(content)) {
     return [];

--- a/src/agents/context-cache.ts
+++ b/src/agents/context-cache.ts
@@ -1,3 +1,12 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  lookupCachedContextTokens: "live",
+} as const;
 export const MODEL_CONTEXT_TOKEN_CACHE = new Map<string, number>();
 
 export function lookupCachedContextTokens(modelId?: string): number | undefined {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -4,3 +4,15 @@ export type AgentContext = Record<string, unknown>;
 export const createAgentContext = (..._args: unknown[]) => ({}) as Record<string, unknown>;
 export const lookupContextTokens = (..._args: unknown[]): number => 200000; // Gutted in RemoteClaw fork (Middleware Boundary Principle)
 export const resolveContextTokensForModel = (..._args: unknown[]): number => 200000; // Gutted in RemoteClaw fork (Middleware Boundary Principle)
+
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  createAgentContext: "partial", // returns empty record; callers tolerate
+  lookupContextTokens: "partial", // returns constant 200000 default
+  resolveContextTokensForModel: "partial", // returns constant 200000 default
+} as const;

--- a/src/agents/current-time.ts
+++ b/src/agents/current-time.ts
@@ -5,6 +5,17 @@ import {
   resolveUserTimezone,
 } from "./date-time.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveCronStyleNow: "live",
+  appendCronStyleCurrentTimeLine: "live",
+} as const;
+
 export type CronStyleNow = {
   userTimezone: string;
   formattedTime: string;

--- a/src/agents/date-time.ts
+++ b/src/agents/date-time.ts
@@ -1,5 +1,19 @@
 import { execFileSync } from "node:child_process";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveUserTimezone: "live",
+  resolveUserTimeFormat: "live",
+  normalizeTimestamp: "live",
+  withNormalizedTimestamp: "live",
+  formatUserTime: "live",
+} as const;
+
 export type TimeFormatPreference = "auto" | "12" | "24";
 export type ResolvedTimeFormat = "12" | "24";
 

--- a/src/agents/glob-pattern.ts
+++ b/src/agents/glob-pattern.ts
@@ -1,3 +1,14 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  compileGlobPattern: "live",
+  compileGlobPatterns: "live",
+  matchesAnyGlobPattern: "live",
+} as const;
 export type CompiledGlobPattern =
   | { kind: "all" }
   | { kind: "exact"; value: string }

--- a/src/agents/identity-avatar.ts
+++ b/src/agents/identity-avatar.ts
@@ -12,6 +12,16 @@ import { resolveUserPath } from "../utils.js";
 import { resolveAgentWorkspaceDir } from "./agent-scope.js";
 import { resolveAgentIdentity } from "./identity.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveAgentAvatar: "live",
+} as const;
+
 export type AgentAvatarResolution =
   | { kind: "none"; reason: string }
   | { kind: "local"; filePath: string }

--- a/src/agents/identity.ts
+++ b/src/agents/identity.ts
@@ -1,6 +1,23 @@
 import type { RemoteClawConfig, HumanDelayConfig, IdentityConfig } from "../config/config.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveAgentIdentity: "live",
+  resolveAckReaction: "live",
+  resolveIdentityNamePrefix: "live",
+  resolveIdentityName: "live",
+  resolveMessagePrefix: "live",
+  resolveResponsePrefix: "live",
+  resolveEffectiveMessagesConfig: "live",
+  resolveHumanDelayConfig: "live",
+} as const;
+
 const DEFAULT_ACK_REACTION = "👀";
 
 export function resolveAgentIdentity(

--- a/src/agents/image-sanitization.ts
+++ b/src/agents/image-sanitization.ts
@@ -1,5 +1,15 @@
 import type { RemoteClawConfig } from "../config/config.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveImageSanitizationLimits: "live",
+} as const;
+
 export type ImageSanitizationLimits = {
   maxDimensionPx?: number;
   maxBytes?: number;

--- a/src/agents/internal-events.ts
+++ b/src/agents/internal-events.ts
@@ -1,3 +1,12 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  formatAgentInternalEventsForPrompt: "live",
+} as const;
 export type AgentInternalEventType = "task_completion";
 
 export type AgentTaskCompletionInternalEvent = {

--- a/src/agents/lanes.ts
+++ b/src/agents/lanes.ts
@@ -1,5 +1,15 @@
 import { CommandLane } from "../process/lanes.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveNestedAgentLane: "live",
+} as const;
+
 export const AGENT_LANE_NESTED = CommandLane.Nested;
 export const AGENT_LANE_SUBAGENT = CommandLane.Subagent;
 

--- a/src/agents/live-auth-keys.ts
+++ b/src/agents/live-auth-keys.ts
@@ -1,5 +1,20 @@
 import { normalizeProviderId } from "./provider-utils.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  collectProviderApiKeys: "live",
+  collectAnthropicApiKeys: "live",
+  collectGeminiApiKeys: "live",
+  isApiKeyRateLimitError: "live",
+  isAnthropicRateLimitError: "live",
+  isAnthropicBillingError: "live",
+} as const;
+
 const KEY_SPLIT_RE = /[\s,;]+/g;
 const GOOGLE_LIVE_SINGLE_KEY = "REMOTECLAW_LIVE_GEMINI_KEY";
 

--- a/src/agents/live-model-errors.ts
+++ b/src/agents/live-model-errors.ts
@@ -1,3 +1,13 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  isModelNotFoundErrorMessage: "live",
+  isMiniMaxModelNotFoundErrorMessage: "live",
+} as const;
 export function isModelNotFoundErrorMessage(raw: string): boolean {
   const msg = raw.trim();
   if (!msg) {

--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -1,3 +1,12 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  isModernModelRef: "live",
+} as const;
 export type ModelRef = {
   provider?: string | null;
   id?: string | null;

--- a/src/agents/live-test-helpers.ts
+++ b/src/agents/live-test-helpers.ts
@@ -1,5 +1,17 @@
 import { isTruthyEnvValue } from "../infra/env.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  isLiveTestEnabled: "live",
+  createSingleUserPromptMessage: "live",
+  extractNonEmptyAssistantText: "live",
+} as const;
+
 export const LIVE_OK_PROMPT = "Reply with the word ok.";
 
 export function isLiveTestEnabled(

--- a/src/agents/model-auth-env-vars.ts
+++ b/src/agents/model-auth-env-vars.ts
@@ -1,3 +1,12 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  listKnownProviderEnvApiKeyNames: "live",
+} as const;
 export const PROVIDER_ENV_API_KEY_CANDIDATES: Record<string, string[]> = {
   "github-copilot": ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"],
   anthropic: ["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"],

--- a/src/agents/model-auth-markers.ts
+++ b/src/agents/model-auth-markers.ts
@@ -1,6 +1,24 @@
 import type { SecretRefSource } from "../config/types.secrets.js";
 import { listKnownProviderEnvApiKeyNames } from "./model-auth-env-vars.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  isAwsSdkAuthMarker: "live",
+  isKnownEnvApiKeyMarker: "live",
+  resolveOAuthApiKeyMarker: "live",
+  isOAuthApiKeyMarker: "live",
+  resolveNonEnvSecretRefApiKeyMarker: "live",
+  resolveNonEnvSecretRefHeaderValueMarker: "live",
+  resolveEnvSecretRefHeaderValueMarker: "live",
+  isSecretRefHeaderValueMarker: "live",
+  isNonSecretApiKeyMarker: "live",
+} as const;
+
 export const MINIMAX_OAUTH_MARKER = "minimax-oauth";
 export const OAUTH_API_KEY_MARKER_PREFIX = "oauth:";
 export const QWEN_OAUTH_MARKER = "qwen-oauth";

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -14,6 +14,17 @@ import type { ModelProviderConfig } from "../config/types.models.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 import { normalizeProviderId } from "./provider-utils.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  getCustomProviderApiKey: "live",
+  getApiKeyForModel: "partial", // returns undefined; callers tolerate
+} as const;
+
 function resolveProviderConfig(
   cfg: RemoteClawConfig | undefined,
   provider: string,

--- a/src/agents/model-id-normalization.ts
+++ b/src/agents/model-id-normalization.ts
@@ -1,5 +1,16 @@
 // Keep model ID normalization dependency-free so config parsing and other
 // startup-only paths do not pull in provider discovery or plugin loading.
+
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  normalizeGoogleModelId: "live",
+  normalizeXaiModelId: "live",
+} as const;
 export function normalizeGoogleModelId(id: string): string {
   if (id === "gemini-3-pro") {
     return "gemini-3-pro-preview";

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -17,6 +17,22 @@ import type { RemoteClawConfig } from "../config/config.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import { type ModelRef, modelKey, normalizeProviderId, parseModelRef } from "./provider-utils.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  buildModelAliasIndex: "live",
+  resolveModelRefFromString: "live",
+  resolveConfiguredModelRef: "live",
+  resolveDefaultModelForAgent: "live",
+  resolveThinkingDefault: "partial", // returns undefined; callers tolerate
+  getModelRefStatus: "partial", // returns undefined; callers tolerate
+  inferUniqueProviderFromConfiguredModels: "partial", // returns undefined; callers tolerate
+} as const;
+
 const DEFAULT_PROVIDER = "openai";
 const DEFAULT_MODEL = "gpt-4o-mini";
 

--- a/src/agents/ollama-models.ts
+++ b/src/agents/ollama-models.ts
@@ -1,6 +1,21 @@
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 import { OLLAMA_DEFAULT_BASE_URL } from "./ollama-defaults.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveOllamaApiBase: "live",
+  queryOllamaContextWindow: "live",
+  enrichOllamaModelsWithContext: "live",
+  isReasoningModelHeuristic: "live",
+  buildOllamaModelDefinition: "live",
+  fetchOllamaModels: "live",
+} as const;
+
 export const OLLAMA_DEFAULT_CONTEXT_WINDOW = 128000;
 export const OLLAMA_DEFAULT_MAX_TOKENS = 8192;
 export const OLLAMA_DEFAULT_COST = {

--- a/src/agents/openai-ws-connection.ts
+++ b/src/agents/openai-ws-connection.ts
@@ -16,6 +16,16 @@
 import { EventEmitter } from "node:events";
 import WebSocket from "ws";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  OpenAIWebSocketManager: "live",
+} as const;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // WebSocket Event Types (Server → Client)
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/agents/owner-display.ts
+++ b/src/agents/owner-display.ts
@@ -1,6 +1,17 @@
 import crypto from "node:crypto";
 import type { RemoteClawConfig } from "../config/config.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveOwnerDisplaySetting: "live",
+  ensureOwnerDisplaySecret: "live",
+} as const;
+
 export type OwnerDisplaySetting = {
   ownerDisplay?: "raw" | "hash";
   ownerDisplaySecret?: string;

--- a/src/agents/path-policy.ts
+++ b/src/agents/path-policy.ts
@@ -2,6 +2,18 @@ import path from "node:path";
 import { normalizeWindowsPathForComparison } from "../infra/path-guards.js";
 import { resolveSandboxInputPath } from "./sandbox-paths.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  toRelativeWorkspacePath: "live",
+  toRelativeSandboxPath: "live",
+  resolvePathFromInput: "live",
+} as const;
+
 type RelativePathOptions = {
   allowRoot?: boolean;
   cwd?: string;

--- a/src/agents/payload-redaction.ts
+++ b/src/agents/payload-redaction.ts
@@ -1,6 +1,16 @@
 import crypto from "node:crypto";
 import { estimateBase64DecodedBytes } from "../media/base64.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  redactImageDataForDiagnostics: "live",
+} as const;
+
 export const REDACTED_IMAGE_DATA = "<redacted>";
 
 function toLowerTrimmed(value: unknown): string {

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -42,3 +42,16 @@ export const isToolAllowedByPolicies = (name: string, policies: Array<ToolPolicy
 export const resolveEffectiveToolPolicy = (..._args: unknown[]) => undefined as any;
 export const resolveGroupToolPolicy = (..._args: unknown[]) => undefined as any;
 export const resolveSubagentToolPolicy = (..._args: unknown[]) => undefined as any;
+
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  isToolAllowedByPolicies: "live",
+  resolveEffectiveToolPolicy: "partial", // returns undefined; callers tolerate
+  resolveGroupToolPolicy: "partial", // returns undefined; callers tolerate
+  resolveSubagentToolPolicy: "partial", // returns undefined; callers tolerate
+} as const;

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -1,5 +1,26 @@
 import { normalizeProviderId } from "./model-selection.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveProviderCapabilities: "live",
+  preservesAnthropicThinkingSignatures: "live",
+  requiresOpenAiCompatibleAnthropicToolPayload: "live",
+  usesOpenAiFunctionAnthropicToolSchema: "live",
+  usesOpenAiStringModeAnthropicToolChoice: "live",
+  supportsOpenAiCompatTurnValidation: "live",
+  sanitizesGeminiThoughtSignatures: "live",
+  isOpenAiProviderFamily: "live",
+  isAnthropicProviderFamily: "live",
+  shouldDropThinkingBlocksForModel: "live",
+  shouldSanitizeGeminiThoughtSignaturesForModel: "live",
+  resolveTranscriptToolCallIdMode: "live",
+} as const;
+
 export type ProviderCapabilities = {
   anthropicToolSchemaMode: "native" | "openai-functions";
   anthropicToolChoiceMode: "native" | "openai-string-modes";

--- a/src/agents/provider-utils.ts
+++ b/src/agents/provider-utils.ts
@@ -8,6 +8,23 @@
 
 import type { RemoteClawConfig } from "../config/config.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  modelKey: "live",
+  normalizeProviderId: "live",
+  findNormalizedProviderValue: "live",
+  findNormalizedProviderKey: "live",
+  isCliProvider: "live",
+  normalizeGoogleModelId: "live",
+  normalizeModelRef: "live",
+  parseModelRef: "live",
+} as const;
+
 export type ModelRef = {
   provider: string;
   model: string;

--- a/src/agents/remoteclaw-tools.ts
+++ b/src/agents/remoteclaw-tools.ts
@@ -18,6 +18,16 @@ import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
 import { createSubagentsTool } from "./tools/subagents-tool.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  createRemoteClawTools: "live",
+} as const;
+
 export function createRemoteClawTools(options?: {
   agentSessionKey?: string;
   agentChannel?: GatewayMessageChannel;

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -5,6 +5,20 @@ import { assertNoPathAliasEscape, type PathAliasPolicy } from "../infra/path-ali
 import { isPathInside } from "../infra/path-guards.js";
 import { resolvePreferredRemoteClawTmpDir } from "../infra/tmp-remoteclaw-dir.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveSandboxInputPath: "live",
+  resolveSandboxPath: "live",
+  assertSandboxPath: "live",
+  assertMediaNotDataUrl: "live",
+  resolveSandboxedMediaSource: "live",
+} as const;
+
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
 const HTTP_URL_RE = /^https?:\/\//i;
 const DATA_URL_RE = /^data:/i;

--- a/src/agents/sanitize-for-prompt.ts
+++ b/src/agents/sanitize-for-prompt.ts
@@ -13,6 +13,17 @@
  * - This is intentionally lossy; it trades edge-case path fidelity for prompt integrity.
  * - If you need lossless representation, escape instead of stripping.
  */
+
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  sanitizeForPromptLiteral: "live",
+  wrapUntrustedPromptDataBlock: "live",
+} as const;
 export function sanitizeForPromptLiteral(value: string): string {
   return value.replace(/[\p{Cc}\p{Cf}\u2028\u2029]/gu, "");
 }

--- a/src/agents/session-dirs.ts
+++ b/src/agents/session-dirs.ts
@@ -2,6 +2,18 @@ import fsSync, { type Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveAgentSessionDirsFromAgentsDir: "live",
+  resolveAgentSessionDirsFromAgentsDirSync: "live",
+  resolveAgentSessionDirs: "live",
+} as const;
+
 function mapAgentSessionDirs(agentsDir: string, entries: Dirent[]): string[] {
   return entries
     .filter((entry) => entry.isDirectory())

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -1,6 +1,16 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  repairSessionFileIfNeeded: "live",
+} as const;
+
 type RepairReport = {
   repaired: boolean;
   droppedLines: number;

--- a/src/agents/session-run-registry.ts
+++ b/src/agents/session-run-registry.ts
@@ -6,6 +6,23 @@
  * that was stubbed to false/0 during engine removal (b27cecc795, #76/#77).
  */
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  isSessionRunActive: "live",
+  getActiveSessionRunCount: "live",
+  registerSessionRun: "live",
+  unregisterSessionRun: "live",
+  getSessionRunHandle: "live",
+  killSessionRun: "live",
+  waitForSessionRunEnd: "live",
+  resetSessionRunRegistryForTest: "live",
+} as const;
+
 export type SessionRunHandle = {
   startedAt: number;
   pid?: number;

--- a/src/agents/session-slug.ts
+++ b/src/agents/session-slug.ts
@@ -1,3 +1,12 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  createSessionSlug: "live",
+} as const;
 const SLUG_ADJECTIVES = [
   "amber",
   "briny",

--- a/src/agents/session-tool-result-state.ts
+++ b/src/agents/session-tool-result-state.ts
@@ -1,3 +1,12 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  createPendingToolCallState: "live",
+} as const;
 export type PendingToolCall = { id: string; name?: string };
 
 export type PendingToolCallState = {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -1,6 +1,20 @@
 import type { AgentMessage } from "./agent-types.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-id.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  stripToolResultDetails: "live",
+  repairToolCallInputs: "live",
+  sanitizeToolCallInputs: "live",
+  sanitizeToolUseResultPairing: "live",
+  repairToolUseResultPairing: "live",
+} as const;
+
 const TOOL_CALL_NAME_MAX_CHARS = 64;
 const TOOL_CALL_NAME_RE = /^[A-Za-z0-9_-]+$/;
 

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -4,6 +4,19 @@ import path from "node:path";
 import { getProcessStartTime, isPidAlive } from "../shared/pid-alive.js";
 import { resolveProcessScopedMap } from "../shared/process-scoped-map.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveSessionLockMaxHoldFromTimeout: "live",
+  cleanStaleLockFiles: "live",
+  acquireSessionWriteLock: "live",
+  resetSessionWriteLockStateForTest: "live",
+} as const;
+
 type LockFilePayload = {
   pid?: number;
   createdAt?: string;

--- a/src/agents/skills-install-tar-verbose.ts
+++ b/src/agents/skills-install-tar-verbose.ts
@@ -1,3 +1,12 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  parseTarVerboseMetadata: "live",
+} as const;
 const TAR_VERBOSE_MONTHS = new Set([
   "Jan",
   "Feb",

--- a/src/agents/skills.e2e-test-helpers.ts
+++ b/src/agents/skills.e2e-test-helpers.ts
@@ -1,6 +1,16 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  writeSkill: "live",
+} as const;
+
 export async function writeSkill(params: {
   dir: string;
   name: string;

--- a/src/agents/spawned-context.ts
+++ b/src/agents/spawned-context.ts
@@ -2,6 +2,19 @@ import type { RemoteClawConfig } from "../config/config.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveAgentWorkspaceDir } from "./agent-scope.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  normalizeSpawnedRunMetadata: "live",
+  mapToolContextToSpawnedRunMetadata: "live",
+  resolveSpawnedWorkspaceInheritance: "live",
+  resolveIngressWorkspaceOverrideForSpawnedRun: "live",
+} as const;
+
 export type SpawnedRunMetadata = {
   spawnedBy?: string | null;
   groupId?: string | null;

--- a/src/agents/stable-stringify.ts
+++ b/src/agents/stable-stringify.ts
@@ -1,3 +1,12 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  stableStringify: "live",
+} as const;
 export function stableStringify(value: unknown): string {
   if (value === null || typeof value !== "object") {
     return JSON.stringify(value) ?? "null";

--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -19,6 +19,17 @@ import {
 } from "../utils/queue-helpers.js";
 import type { AgentInternalEvent } from "./internal-events.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resetAnnounceQueuesForTests: "live",
+  enqueueAnnounce: "live",
+} as const;
+
 export type AnnounceQueueItem = {
   // Stable announce identity shared by direct + queued delivery paths.
   // Optional for backward compatibility with previously queued items.

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -36,6 +36,17 @@ import { readLatestAssistantReply } from "./tools/agent-step.js";
 import { sanitizeTextContent, extractAssistantText } from "./tools/sessions-helpers.js";
 import { isAnnounceSkip } from "./tools/sessions-send-helpers.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  buildSubagentSystemPrompt: "live",
+  runSubagentAnnounceFlow: "live",
+} as const;
+
 const FAST_TEST_MODE = process.env.REMOTECLAW_TEST_FAST === "1";
 const FAST_TEST_RETRY_INTERVAL_MS = 8;
 const DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS = 60_000;

--- a/src/agents/subagent-attachments.ts
+++ b/src/agents/subagent-attachments.ts
@@ -4,6 +4,17 @@ import path from "node:path";
 import type { RemoteClawConfig } from "../config/config.js";
 import { resolveAgentWorkspaceDir } from "./agent-scope.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  decodeStrictBase64: "live",
+  materializeSubagentAttachments: "live",
+} as const;
+
 export function decodeStrictBase64(value: string, maxDecodedBytes: number): Buffer | null {
   const maxEncodedBytes = Math.ceil(maxDecodedBytes / 3) * 4;
   if (value.length > maxEncodedBytes * 2) {

--- a/src/agents/subagent-capabilities.ts
+++ b/src/agents/subagent-capabilities.ts
@@ -4,6 +4,19 @@ import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import { isSubagentSessionKey, parseAgentSessionKey } from "../routing/session-key.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveSubagentRoleForDepth: "live",
+  resolveSubagentControlScopeForRole: "live",
+  resolveSubagentCapabilities: "live",
+  resolveStoredSubagentCapabilities: "live",
+} as const;
+
 export const SUBAGENT_SESSION_ROLES = ["main", "orchestrator", "leaf"] as const;
 export type SubagentSessionRole = (typeof SUBAGENT_SESSION_ROLES)[number];
 

--- a/src/agents/subagent-depth.ts
+++ b/src/agents/subagent-depth.ts
@@ -5,6 +5,16 @@ import { getSubagentDepth, parseAgentSessionKey } from "../sessions/session-key-
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import { resolveDefaultAgentId } from "./agent-scope.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  getSubagentDepthFromSessionStore: "live",
+} as const;
+
 type SessionDepthEntry = {
   sessionId?: unknown;
   spawnDepth?: unknown;

--- a/src/agents/subagent-lifecycle-events.ts
+++ b/src/agents/subagent-lifecycle-events.ts
@@ -1,3 +1,12 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveSubagentSessionEndedOutcome: "live",
+} as const;
 export const SUBAGENT_TARGET_KIND_SUBAGENT = "subagent" as const;
 export const SUBAGENT_TARGET_KIND_ACP = "acp" as const;
 

--- a/src/agents/subagent-orphan-recovery.ts
+++ b/src/agents/subagent-orphan-recovery.ts
@@ -24,6 +24,17 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { replaceSubagentRunAfterSteer } from "./subagent-registry.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  recoverOrphanedSubagentSessions: "live",
+  scheduleOrphanRecovery: "live",
+} as const;
+
 const log = createSubsystemLogger("subagent-orphan-recovery");
 
 /** Delay before attempting recovery to let the gateway finish bootstrapping. */

--- a/src/agents/subagent-registry-cleanup.ts
+++ b/src/agents/subagent-registry-cleanup.ts
@@ -4,6 +4,17 @@ import {
 } from "./subagent-lifecycle-events.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveCleanupCompletionReason: "live",
+  resolveDeferredCleanupDecision: "live",
+} as const;
+
 export type DeferredCleanupDecision =
   | {
       kind: "defer-descendants";

--- a/src/agents/subagent-registry-completion.ts
+++ b/src/agents/subagent-registry-completion.ts
@@ -10,6 +10,18 @@ import {
 } from "./subagent-lifecycle-events.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  runOutcomesEqual: "live",
+  resolveLifecycleOutcomeFromRunOutcome: "live",
+  emitSubagentEndedHookOnce: "live",
+} as const;
+
 export function runOutcomesEqual(
   a: SubagentRunOutcome | undefined,
   b: SubagentRunOutcome | undefined,

--- a/src/agents/subagent-registry-queries.ts
+++ b/src/agents/subagent-registry-queries.ts
@@ -1,6 +1,25 @@
 import type { DeliveryContext } from "../utils/delivery-context.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  findRunIdsByChildSessionKeyFromRuns: "live",
+  listRunsForRequesterFromRuns: "live",
+  listRunsForControllerFromRuns: "live",
+  resolveRequesterForChildSessionFromRuns: "live",
+  shouldIgnorePostCompletionAnnounceForSessionFromRuns: "live",
+  countActiveRunsForSessionFromRuns: "live",
+  countActiveDescendantRunsFromRuns: "live",
+  countPendingDescendantRunsFromRuns: "live",
+  countPendingDescendantRunsExcludingRunFromRuns: "live",
+  listDescendantRunsForRequesterFromRuns: "live",
+} as const;
+
 function resolveControllerSessionKey(entry: SubagentRunRecord): string {
   return entry.controllerSessionKey?.trim() || entry.requesterSessionKey;
 }

--- a/src/agents/subagent-registry-state.ts
+++ b/src/agents/subagent-registry-state.ts
@@ -4,6 +4,18 @@ import {
 } from "./subagent-registry.store.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  persistSubagentRunsToDisk: "live",
+  restoreSubagentRunsFromDisk: "live",
+  getSubagentRunsSnapshotForRead: "live",
+} as const;
+
 export function persistSubagentRunsToDisk(runs: Map<string, SubagentRunRecord>) {
   try {
     saveSubagentRegistryToDisk(runs);

--- a/src/agents/subagent-registry.store.ts
+++ b/src/agents/subagent-registry.store.ts
@@ -5,6 +5,18 @@ import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveSubagentRegistryPath: "live",
+  loadSubagentRegistryFromDisk: "live",
+  saveSubagentRegistryToDisk: "live",
+} as const;
+
 type PersistedSubagentRegistry = {
   version: 2;
   runs: Record<string, SubagentRunRecord>;

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -49,6 +49,34 @@ import {
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  markSubagentRunForSteerRestart: "live",
+  clearSubagentRunSteerRestart: "live",
+  replaceSubagentRunAfterSteer: "live",
+  registerSubagentRun: "live",
+  resetSubagentRegistryForTests: "live",
+  addSubagentRunForTests: "live",
+  releaseSubagentRun: "live",
+  resolveRequesterForChildSession: "live",
+  isSubagentSessionRunActive: "live",
+  markSubagentRunTerminated: "live",
+  listSubagentRunsForRequester: "live",
+  listSubagentRunsForController: "live",
+  countActiveRunsForSession: "live",
+  countActiveDescendantRuns: "live",
+  countPendingDescendantRuns: "live",
+  countPendingDescendantRunsExcludingRun: "live",
+  listDescendantRunsForRequester: "live",
+  initSubagentRegistry: "live",
+  shouldIgnorePostCompletionAnnounceForSession: "partial", // returns undefined; callers tolerate
+} as const;
+
 export type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const subagentRuns = new Map<string, SubagentRunRecord>();

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -29,6 +29,18 @@ import {
   resolveMainSessionAlias,
 } from "./tools/sessions-helpers.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  decodeStrictBase64: "live",
+  splitModelRef: "live",
+  spawnSubagentDirect: "live",
+} as const;
+
 export const SUBAGENT_SPAWN_MODES = ["run", "session"] as const;
 export type SpawnSubagentMode = (typeof SUBAGENT_SPAWN_MODES)[number];
 export const SUBAGENT_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;

--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -1,5 +1,16 @@
 import type { RemoteClawConfig } from "../config/config.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveAgentTimeoutSeconds: "live",
+  resolveAgentTimeoutMs: "live",
+} as const;
+
 const DEFAULT_AGENT_TIMEOUT_SECONDS = 48 * 60 * 60;
 const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
 

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -1,6 +1,20 @@
 import { createHash } from "node:crypto";
 import type { AgentMessage } from "./agent-types.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  sanitizeToolCallId: "live",
+  extractToolCallsFromAssistant: "live",
+  extractToolResultId: "live",
+  isValidCloudCodeAssistToolId: "live",
+  sanitizeToolCallIdsForCloudCodeAssist: "live",
+} as const;
+
 export type ToolCallIdMode = "strict" | "strict9";
 
 const STRICT9_LEN = 9;

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -1,3 +1,15 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveCoreToolProfilePolicy: "live",
+  listCoreToolSections: "live",
+  resolveCoreToolProfiles: "live",
+  isKnownCoreToolId: "live",
+} as const;
 export type ToolProfileId = "minimal" | "coding" | "messaging" | "full";
 
 type ToolProfilePolicy = {

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -1,3 +1,29 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  normalizeToolName: "live",
+  defaultTitle: "live",
+  normalizeVerb: "live",
+  resolveActionArg: "live",
+  resolveToolVerbAndDetailForArgs: "live",
+  coerceDisplayValue: "live",
+  lookupValueByPath: "live",
+  formatDetailKey: "live",
+  resolvePathArg: "live",
+  resolveReadDetail: "live",
+  resolveWriteDetail: "live",
+  resolveWebSearchDetail: "live",
+  resolveWebFetchDetail: "live",
+  resolveExecDetail: "live",
+  resolveActionSpec: "live",
+  resolveDetailFromKeys: "live",
+  resolveToolVerbAndDetail: "live",
+  formatToolDetailText: "live",
+} as const;
 export type ToolDisplayActionSpec = {
   label?: string;
   detailKeys?: string[];

--- a/src/agents/tool-display.ts
+++ b/src/agents/tool-display.ts
@@ -11,6 +11,18 @@ import {
 } from "./tool-display-common.js";
 import TOOL_DISPLAY_OVERRIDES_JSON from "./tool-display-overrides.json" with { type: "json" };
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveToolDisplay: "live",
+  formatToolDetail: "live",
+  formatToolSummary: "live",
+} as const;
+
 type ToolDisplaySpec = ToolDisplaySpecBase & {
   emoji?: string;
 };

--- a/src/agents/tool-fs-policy.ts
+++ b/src/agents/tool-fs-policy.ts
@@ -1,6 +1,18 @@
 import type { RemoteClawConfig } from "../config/config.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  createToolFsPolicy: "live",
+  resolveToolFsConfig: "live",
+  resolveEffectiveToolFsWorkspaceOnly: "live",
+} as const;
+
 export type ToolFsPolicy = {
   workspaceOnly: boolean;
 };

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -13,6 +13,18 @@ import {
   type ImageSanitizationLimits,
 } from "./image-sanitization.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  sanitizeContentBlocksImages: "live",
+  sanitizeImageBlocks: "live",
+  sanitizeToolResultImages: "live",
+} as const;
+
 type ToolContentBlock = AgentToolResult["content"][number];
 type ImageContentBlock = Extract<ToolContentBlock, { type: "image" }>;
 type TextContentBlock = Extract<ToolContentBlock, { type: "text" }>;

--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -8,6 +8,17 @@ import {
   type ToolPolicyLike,
 } from "./tool-policy.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  buildDefaultToolPolicyPipelineSteps: "live",
+  applyToolPolicyPipeline: "live",
+} as const;
+
 export type ToolPolicyPipelineStep = {
   policy: ToolPolicyLike | undefined;
   label: string;

--- a/src/agents/tool-policy-resolution.ts
+++ b/src/agents/tool-policy-resolution.ts
@@ -10,6 +10,21 @@ import type { AnyAgentTool } from "./agent-tool-types.js";
 import { compileGlobPatterns, matchesAnyGlobPattern } from "./glob-pattern.js";
 import { expandToolGroups, normalizeToolName } from "./tool-policy.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveSubagentToolPolicy: "live",
+  isToolAllowedByPolicyName: "live",
+  filterToolsByPolicy: "live",
+  resolveEffectiveToolPolicy: "live",
+  resolveGroupToolPolicy: "live",
+  isToolAllowedByPolicies: "live",
+} as const;
+
 // Tool policy types and helpers for allow/deny resolution.
 type ToolPolicy = { allow?: string[]; deny?: string[] };
 

--- a/src/agents/tool-policy-shared.ts
+++ b/src/agents/tool-policy-shared.ts
@@ -4,6 +4,19 @@ import {
   type ToolProfileId,
 } from "./tool-catalog.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  normalizeToolName: "live",
+  normalizeToolList: "live",
+  expandToolGroups: "live",
+  resolveToolProfilePolicy: "live",
+} as const;
+
 type ToolProfilePolicy = {
   allow?: string[];
   deny?: string[];

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -6,6 +6,23 @@ import {
   TOOL_GROUPS,
 } from "./tool-policy-shared.js";
 import type { AnyAgentTool } from "./tools/common.js";
+
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  isOwnerOnlyToolName: "live",
+  applyOwnerOnlyToolPolicy: "live",
+  collectExplicitAllowlist: "live",
+  buildPluginToolGroups: "live",
+  expandPluginGroups: "live",
+  expandPolicyWithPluginGroups: "live",
+  stripPluginOnlyAllowlist: "live",
+  mergeAlsoAllowPolicy: "live",
+} as const;
 export {
   expandToolGroups,
   normalizeToolList,

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -1,6 +1,16 @@
 import { normalizeProviderId } from "./model-selection.js";
 import type { ToolCallIdMode } from "./tool-call-id.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveTranscriptPolicy: "live",
+} as const;
+
 const isGoogleModelApi = (..._args: unknown[]): boolean => false;
 
 export type TranscriptSanitizeMode = "full" | "images-only";

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -1,3 +1,16 @@
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  makeZeroUsageSnapshot: "live",
+  hasNonzeroUsage: "live",
+  normalizeUsage: "live",
+  derivePromptTokens: "live",
+  deriveSessionTotalTokens: "live",
+} as const;
 export type UsageLike = {
   input?: number;
   output?: number;

--- a/src/agents/vercel-ai-gateway.ts
+++ b/src/agents/vercel-ai-gateway.ts
@@ -1,6 +1,17 @@
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  getStaticVercelAiGatewayModelCatalog: "live",
+  discoverVercelAiGatewayModels: "live",
+} as const;
+
 export const VERCEL_AI_GATEWAY_PROVIDER_ID = "vercel-ai-gateway";
 export const VERCEL_AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh";
 export const VERCEL_AI_GATEWAY_DEFAULT_MODEL_ID = "anthropic/claude-opus-4.6";

--- a/src/agents/workspace-dir.ts
+++ b/src/agents/workspace-dir.ts
@@ -1,6 +1,17 @@
 import path from "node:path";
 import { resolveUserPath } from "../utils.js";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  normalizeWorkspaceDir: "live",
+  resolveWorkspaceRoot: "live",
+} as const;
+
 export function normalizeWorkspaceDir(workspaceDir?: string): string | null {
   const trimmed = workspaceDir?.trim();
   if (!trimmed) {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -1,5 +1,16 @@
 import fs from "node:fs/promises";
 
+/**
+ * Runtime attestation (ADR 0005 H9). Declares the implementation status
+ * of each runtime export in this module. See CONTRIBUTING.md § Module
+ * attestations for the category definitions and the convention for
+ * updating these when sync or rebrand changes the surface.
+ */
+export const MODULE_ATTESTATIONS = {
+  resolveDefaultAgentWorkspaceDir: "live",
+  ensureAgentWorkspace: "live",
+} as const;
+
 // Stub — removed during fork workspace cleanup; re-exported for upstream compat
 export type WorkspaceBootstrapFile = { filename: string; content: string };
 export const DEFAULT_BOOTSTRAP_FILENAME = "AGENTS.md";


### PR DESCRIPTION
## Summary

Implements H9 of ADR 0005 — semantic-stub detection that H7 (throwing-stub AST gate) and H8 (test-side mock baseline) cannot see. Every runtime export in `src/agents/` depth-1 now carries an attestation declaring its implementation status (`live` / `stub` / `partial` / `deprecated`). Structural consistency enforced by `scripts/check-attestations.mjs`; semantic correctness enforced by CODEOWNERS review.

## Scope

- **93 attested modules**, **319 attestations** across `src/agents/*` depth-1
- **11 entries classified `"partial"`** — functions that were gutted to return hardcoded defaults (e.g., `lookupContextTokens` returns `200000`, `resolveThinkingDefault` returns `undefined`). They work in the narrow case of "return the default"; callers tolerate that.
- **No current `"stub"` or `"deprecated"` entries** — nothing's currently broken in `src/agents/`
- Rest are auto-classified `"live"` (real implementations)

## Design decisions (per user "proceed as issue describes")

| Open question | Decision |
|---|---|
| Category set | 4 categories including `"partial"` — real fork code has functions that work partially post-gutting; "partial" prevents the false binary |
| Placement | Inline, top of file, after imports — co-location prevents drift |
| CODEOWNERS | `/src/agents/ @alexey-pelykh` (solo maintainer) |
| Tree-shakability | `as const` on plain object, never imported by production — zero bundle cost |

## Enforced invariants

1. Every runtime export has an attestation entry (missing fails CI)
2. Every entry corresponds to a current export (stale fails CI)
3. `"live"` attestation on a throwing-stub-shape function fails
4. `"stub"` attestation on a function with non-test callers fails

Runtime exports counted: `export function`, `export const = () => ...`, `export const = function...`, `export class`, `export default` (if function). Types, interfaces, enums, non-function data constants, and re-exports are not counted.

## Changes

- `scripts/check-attestations.mjs` (new, 526 LOC): the gate. Includes `--self-test` mode with 10 fixtures covering all 4 invariants, expression-body arrow enumeration, category validation, non-function-export exclusion. Fail messages guide the author to the right fix.
- `scripts/generate-attestations.mjs` (new, 261 LOC): one-shot bootstrap tool that walks attested modules, enumerates exports via AST, auto-classifies using H7 calibration signals, writes `MODULE_ATTESTATIONS` blocks. Idempotent; remains as a maintenance utility for extending scope to new directories later.
- `scripts/lib/throwing-stub-shape.mjs` (new, 210 LOC): shared AST classification helpers (`looksLikeThrowingStub`, `classifyThrowingStubShape`, and the four calibration-signal primitives). Previously duplicated across 3 scripts; now single source of truth. Net -373 LOC across callers, +210 LOC in lib.
- `scripts/check-throwing-stub-callers.mjs`: refactored to use shared lib (its 10 self-tests still pass unchanged)
- `.github/workflows/ci.yml`: new `attestation-gate` job (self-test before main check, mirroring `throwing-stub-callers-gate` convention)
- `.github/CODEOWNERS` (new): `/src/agents/` → `@alexey-pelykh`
- `CONTRIBUTING.md`: new § Module attestations with category table, 5-point "when this fires", 4-step "how to update"
- `src/agents/*.ts` (83 files): `MODULE_ATTESTATIONS` block added after imports

## Verification

| Command | Result |
|---|---|
| `node scripts/check-attestations.mjs` | 93 modules, 319 attestations, PASS |
| `node scripts/check-attestations.mjs --self-test` | 10/10 PASS |
| `node scripts/check-throwing-stub-callers.mjs` | 0 violations, PASS |
| `node scripts/check-throwing-stub-callers.mjs --self-test` | 10/10 PASS (refactor preserved behavior) |
| `node scripts/check-stub-debt.mjs` | both counters PASS (12, 134) |
| `pnpm check` | clean |

### Fresh-context validation (session 2df6a80c)

Initial pass found **1 blocking issue + 3 non-blocking observations**:
- **Blocking**: Expression-body arrow coverage gap — `ts.isBlock(init.body)` filter silently excluded `export const foo = () => expr` from enumeration. **13 runtime exports uncovered**, including 5 semantic stubs with active production callers. This was the exact failure mode H9 was designed to catch per the script's own docstring. **Fix applied**: dropped the filter; both scripts now treat expression-body arrows identically to block-body arrows. All 13 gaps closed with appropriate classifications.
- **Non-blocking**: No self-test (→ added in polish), duplicated AST logic (→ extracted to shared lib in polish), `.mocks.shared.ts` suffix missing (→ added).

Re-validated: **CLEAN**.

### Polish iterations (session 9a3fc434, 3 iterations)

1. Extracted shared `throwing-stub-shape.mjs` lib; ~-373/+210 LOC net; single source of truth for calibration signals
2. Added `--self-test` with 10 fixtures; wired into CI before main gate
3. Aligned test-file filter; removed 2 dead MODULE_ATTESTATIONS blocks from test-harness files

### Dry-run probes (AC 8)

| Probe | Expected | Actual |
|---|---|---|
| Delete an attestation entry | FAIL "has no MODULE_ATTESTATIONS entry" | ✅ |
| Add a stale attestation | FAIL "stale attestation" | ✅ |
| Attest "live" on a throwing-stub shape | FAIL "matches throwing-stub pattern" | ✅ |
| Attest "stub" on a function with live callers | FAIL "has N non-test caller(s)" | ✅ |

PR #2360's regression was equivalent to probe #3. The gate would have caught it at PR time.

## Cascade impact

H9 delivered. Unblocks Phase 3 (#2441 composite gate) — H7/H8/H9 all landed.

## Follow-up candidates (out of scope, deferred)

- Expand attestation scope to `src/middleware/` and `src/gateway/` (tracked via ADR 0005 H9 description)
- Explore richer attestation metadata (remediation issue links, expiry dates) if churn warrants
- 6-month post-ship review of "partial" classification accuracy

## Test plan

- [x] Gate passes on current main
- [x] Self-tests (10/10)
- [x] Existing gates (H5, H7, H8) still pass
- [x] `pnpm check` clean
- [x] Expression-body arrows enumerated
- [x] Probes confirm all 4 invariants fire
- [x] Re-validated CLEAN after fixes

Closes #2437.