### PR TITLE
chore(obsolescence-audit): drop stale commands-models.ts pattern entries (#2452)

### DIFF
--- a/scripts/data/obsolescence-known-patterns.json
+++ b/scripts/data/obsolescence-known-patterns.json
@@ -1,19 +1,4 @@
 {
   "description": "Known decorative wiring and broken contract patterns. Each entry describes a specific code pattern where values flow to dead ends or registration APIs have no dispatch. Entries are checked by the obsolescence audit gate (scripts/check-obsolescence-audit.mjs). Remove entries when the pattern is fixed; add entries when manual audits discover new instances.",
-  "patterns": [
-    {
-      "category": "broken_contract",
-      "file": "src/auto-reply/reply/commands-models.ts",
-      "identifier": "buildModelsProviderData",
-      "description": "Stub returns {} but Discord/Mattermost model-picker UI still calls it — users see empty model lists",
-      "issue": "https://github.com/remoteclaw/remoteclaw/issues/2337"
-    },
-    {
-      "category": "broken_contract",
-      "file": "src/auto-reply/reply/commands-models.ts",
-      "identifier": "handleModelsCommand",
-      "description": "Stub returns undefined but /models slash command is registered in commands-core.ts handler array — command silently does nothing",
-      "issue": "https://github.com/remoteclaw/remoteclaw/issues/2337"
-    }
-  ]
+  "patterns": []
 }


### PR DESCRIPTION
## Summary

- Remove both inert pattern entries (`buildModelsProviderData` and `handleModelsCommand`) from `scripts/data/obsolescence-known-patterns.json`. Both referenced the deleted file `src/auto-reply/reply/commands-models.ts` (tombstoned in #2373, commit `c61609dc26`).
- The audit script (`scripts/check-obsolescence-audit.mjs:294`) treats patterns whose files don't exist as "resolved", so both entries were already inert. Removing them cleans up dead tracking data without changing audit coverage.
- Total findings unchanged at 50 (50 stubs + 0 known patterns, baseline 134).

## Root cause

The issue title names only `buildModelsProviderData`, but the sibling entry `handleModelsCommand` in the same file had the identical problem. Both entries became inert in #2373 when their referenced file was deleted. The description staleness called out in #2452 was a downstream symptom — the entries had actually been resolving to ENOENT on the audit script for weeks.

Confirmed with the reporter that both should be removed under the same PR (Option 2 from the issue).

## Test plan

- [x] `node scripts/check-obsolescence-audit.mjs` → exit 0 (local)
- [x] `Array.isArray(patterns) === true` (structural check — script requires it at line 164)
- [x] Full-repo grep for both identifiers in `src/ extensions/ ui/` → zero hits
- [x] No coupled changes required (single-file diff)
- [ ] CI green: build + test + lint + obsolescence-audit-gate
- [ ] Auto-merge enabled per project convention (squash)

## Out of scope (noted, not addressed)

- `.obsolescence-baseline = 134` vs actual `50` — pre-existing drift, not caused by this PR. Audit script's "debt decreased" message is informational, not a gate failure. Belongs in a separate cleanup.
- `docs/.generated/plugin-sdk-api-baseline.json` still references the deleted file for 4 exports. `scripts/generate-plugin-sdk-api-baseline.ts` is not wired into any npm script or CI workflow, so that artifact has drifted separately. Belongs in its own issue.

Closes #2452.