### PR TITLE
fix(gateway): count active CLI runs in restart deferral — prevents mid-turn termination

### DIFF
--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1,3 +1,4 @@
+import { getActiveSessionRunCount } from "../agents/session-run-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CliDeps } from "../cli/deps.js";
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
@@ -150,10 +151,12 @@ export function createGatewayReloadHandlers(params: {
     const getActiveCounts = () => {
       const queueSize = getTotalQueueSize();
       const pendingReplies = getTotalPendingReplies();
+      const activeCliRuns = getActiveSessionRunCount();
       return {
         queueSize,
         pendingReplies,
-        totalActive: queueSize + pendingReplies,
+        activeCliRuns,
+        totalActive: queueSize + pendingReplies + activeCliRuns,
       };
     };
     const formatActiveDetails = (counts: ReturnType<typeof getActiveCounts>) => {
@@ -163,6 +166,9 @@ export function createGatewayReloadHandlers(params: {
       }
       if (counts.pendingReplies > 0) {
         details.push(`${counts.pendingReplies} reply(ies)`);
+      }
+      if (counts.activeCliRuns > 0) {
+        details.push(`${counts.activeCliRuns} active CLI run(s)`);
       }
       return details;
     };

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { resolveFirstAgentWorkspace } from "../agents/agent-scope.js";
+import { getActiveSessionRunCount } from "../agents/session-run-registry.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CanvasHostServer } from "../canvas-host/server.js";
@@ -290,7 +291,9 @@ export async function startGatewayServer(
     startDiagnosticHeartbeat();
   }
   setGatewaySigusr1RestartPolicy({ allowExternal: isRestartEnabled(cfgAtStart) });
-  setPreRestartDeferralCheck(() => getTotalQueueSize() + getTotalPendingReplies());
+  setPreRestartDeferralCheck(
+    () => getTotalQueueSize() + getTotalPendingReplies() + getActiveSessionRunCount(),
+  );
   initSubagentRegistry();
   const defaultWorkspaceDir = resolveFirstAgentWorkspace(cfgAtStart);
   if (!defaultWorkspaceDir) {


### PR DESCRIPTION
## Summary

`server-reload-handlers.ts::getActiveCounts()` and `server.impl.ts::setPreRestartDeferralCheck()` both computed gateway capacity as `queueSize + pendingReplies`, silently omitting active CLI agent subprocess runs. Result: a config reload or SIGUSR1-triggered restart would fire while CLI agents were mid-turn, killing live subprocess runs.

This PR adds `getActiveSessionRunCount()` (from the already-live `src/agents/session-run-registry.ts`, populated by `ChannelBridge`) to both capacity sums.

## ⚠ Note on stale issue body

Issue #2345's prescriptive text quotes code (`embeddedRuns = 0` hardcode, `getActiveEmbeddedRunCount()` import + call, `pi-embedded-runner/runs.ts` stub file) that was already removed by prior PRs:

- `f749ed3fb6` / #2146 / #2273 — gut: remove vestigial embedded Pi orchestrator stubs
- `028566c42b` / #2442 — cherry-pick B1-B10 audit real gaps (last touch of both gateway files)

The **semantic bug** (capacity sums miscount active CLI runs as zero) is still present — now as an *omission* from the sum rather than a hardcoded literal — and this PR fixes it. The issue's prescriptive AC items (delete stub file, rename `embeddedRuns`→`activeRuns`, update test mocks of `getActiveEmbeddedRunCount`) are all N/A because those code shapes no longer exist.

## Changes

| File | What |
|------|------|
| `src/gateway/server-reload-handlers.ts` | Import `getActiveSessionRunCount`. Add `activeCliRuns` field to `getActiveCounts()` return; fold into `totalActive` sum. Extend `formatActiveDetails()` with `activeCliRuns > 0` branch so deferral log reports `"N active CLI run(s)"` alongside operations and replies. |
| `src/gateway/server.impl.ts` | Import `getActiveSessionRunCount`. Add `+ getActiveSessionRunCount()` to the `setPreRestartDeferralCheck` callback. |

**Field name `activeCliRuns`** (not `activeRuns`) to disambiguate from the per-channel `activeRuns` concept used in `channels/run-state-machine.ts`, `gateway/channel-health-policy.ts`, `gateway/protocol/schema/channels.ts`, and `discord/monitor/status.ts` — different semantics, gateway-wide vs. per-channel.

## Behavior change

**Before**: A config reload arriving while CLI agents are mid-turn proceeds immediately. `deferGatewayRestartUntilIdle({getPendingCount: () => getActiveCounts().totalActive})` polls a sum that doesn't include CLI runs, so `totalActive === 0` even when runs are in flight. Restart fires, CLI subprocess receives SIGTERM, run dies.

**After**: `totalActive` includes `getActiveSessionRunCount()`. Reload defers via `deferGatewayRestartUntilIdle(...)` until the registry drains OR the configured `gateway.reload.deferralTimeoutMs` fires (existing safety net). Log surface: `"config change requires gateway restart — deferring until 3 active CLI run(s) complete"` instead of silent mid-turn termination.

## Verification

- `pnpm check` (format + tsgo + lint + `lint:tmp:no-random-messaging` + `lint:no-remoteclaw-ai`) → exit 0
- `pnpm vitest run --config vitest.unit.config.ts src/infra/restart src/infra/infra-runtime src/agents/session-run-registry src/gateway/server.impl` → **5 files, 71 tests, all passed**
- Rescan: `git grep "getTotalQueueSize() + getTotalPendingReplies"` — only the one line I updated; no other sum sites in the codebase
- Adversarial validation (fresh-context subclaude, 8 AC + 11 adversarial checks): **CLEAN**. Key confirmations:
  - `getActiveSessionRunCount` is LIVE (`ACTIVE_SESSION_RUNS.size`, not a stub)
  - Registry is populated by `ChannelBridge` at `channel-bridge.ts:160` (register in a `try`) + `:349` (unregister in `finally`)
  - `session-run-registry.ts` has zero imports — no cycle possible
  - `formatActiveDetails()` correctly produces comma-separated list with all three counters when each `> 0`
  - Both callers of `getActiveCounts()` inside `server-reload-handlers.ts` use the corrected `totalActive` struct

## Test plan

- [x] `pnpm check` exit 0
- [x] Targeted unit tests green (restart, infra-runtime, session-run-registry, gateway/server.impl)
- [x] No test mocks of `getActiveEmbeddedRunCount` to update (verified zero hits pre-commit)
- [ ] CI green on `build`, `test`, `lint`, `docs`, `rebrand-gate`, `zombie-import-gate`, `stub-debt-gate`, `throwing-stub-callers-gate`, `obsolescence-audit-gate`, `attestation-gate`

## Context

- Parent tracker: #2089 (ChannelBridge compatibility audit)
- Replacement module: `src/agents/session-run-registry.ts` (live; already used by `ChannelBridge`)
- Stale prescriptions now N/A: #2146/#2273 (stub deletions), #2442 (cherry-pick cleanup)

Closes #2345

Refs: #2089

🤖 Generated with [Claude Code](https://claude.com/claude-code)