### PR TITLE
fix(subagents): wire kill and steer to killSessionRun — actually terminate CLI subprocesses

### DIFF
--- a/src/agents/tools/subagents-tool.ts
+++ b/src/agents/tools/subagents-tool.ts
@@ -27,6 +27,7 @@ import {
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import { AGENT_LANE_SUBAGENT } from "../lanes.js";
 import { optionalStringEnum } from "../schema/typebox.js";
+import { killSessionRun } from "../session-run-registry.js";
 import { getSubagentDepthFromSessionStore } from "../subagent-depth.js";
 import {
   clearSubagentRunSteerRestart,
@@ -248,7 +249,7 @@ async function killSubagentRun(params: {
     cache: params.cache,
   });
   const sessionId = resolved.entry?.sessionId;
-  const aborted = false;
+  const aborted = killSessionRun(childSessionKey);
   const cleared = clearSessionQueues([childSessionKey, sessionId]);
   if (cleared.followupCleared > 0 || cleared.laneCleared > 0) {
     logVerbose(
@@ -619,6 +620,8 @@ export function createSubagentsTool(opts?: { agentSessionKey?: string }): AnyAge
           typeof targetSession.entry?.sessionId === "string" && targetSession.entry.sessionId.trim()
             ? targetSession.entry.sessionId.trim()
             : undefined;
+
+        killSessionRun(resolved.entry.childSessionKey);
 
         const cleared = clearSessionQueues([resolved.entry.childSessionKey, sessionId]);
         if (cleared.followupCleared > 0 || cleared.laneCleared > 0) {

--- a/src/auto-reply/reply/commands-subagents/action-kill.ts
+++ b/src/auto-reply/reply/commands-subagents/action-kill.ts
@@ -1,3 +1,4 @@
+import { killSessionRun } from "../../../agents/session-run-registry.js";
 import { markSubagentRunTerminated } from "../../../agents/subagent-registry.js";
 import {
   loadSessionStore,
@@ -49,6 +50,7 @@ export async function handleSubagentsKillAction(
     loadSessionStore,
     resolveStorePath,
   });
+  killSessionRun(childKey);
   const cleared = clearSessionQueues([childKey, entry?.sessionId]);
   if (cleared.followupCleared > 0 || cleared.laneCleared > 0) {
     logVerbose(

--- a/src/auto-reply/reply/commands-subagents/action-send.ts
+++ b/src/auto-reply/reply/commands-subagents/action-send.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { AGENT_LANE_SUBAGENT } from "../../../agents/lanes.js";
+import { killSessionRun } from "../../../agents/session-run-registry.js";
 import {
   clearSubagentRunSteerRestart,
   replaceSubagentRunAfterSteer,
@@ -63,6 +64,8 @@ export async function handleSubagentsSendAction(
 
   if (steerRequested) {
     markSubagentRunForSteerRestart(targetResolution.entry.runId);
+
+    killSessionRun(targetResolution.entry.childSessionKey);
 
     const cleared = clearSessionQueues([targetResolution.entry.childSessionKey, targetSessionId]);
     if (cleared.followupCleared > 0 || cleared.laneCleared > 0) {


### PR DESCRIPTION
## Summary

The subagent `kill` and `steer` actions (exposed via the `subagents` agent tool and `/subagents kill` / `/subagents steer` chat commands) lost their subprocess-termination semantics during the pi-embedded gut (`b27cecc795`, #76/#77):

- **Kill**: marked the registry entry as terminated and cleared queues, but the CLI subprocess kept running until natural completion. Tokens, API costs, and work continued even though `killed: true` was returned.
- **Steer**: queued a replacement run via `agent`, then waited via `agent.wait` for the existing run to finish naturally before the replacement started. Pre-gut behavior aborted the existing run first so the replacement started immediately with combined context. Post-gut, "steer" was effectively a followup with a 5-second delay.

This PR wires `killSessionRun` (from the already-live `src/agents/session-run-registry.ts`, populated by `ChannelBridge`) into all four affected call sites.

## Changes

| File | Site | Change |
|------|------|--------|
| `src/agents/tools/subagents-tool.ts` | kill (`killSubagentRun`, line 252) | Replace `const aborted = false;` dead var with `const aborted = killSessionRun(childSessionKey);` |
| `src/agents/tools/subagents-tool.ts` | steer (line ~624) | Insert `killSessionRun(resolved.entry.childSessionKey);` before `clearSessionQueues` / `agent.wait` settlement |
| `src/auto-reply/reply/commands-subagents/action-kill.ts` | `/subagents kill` | Insert `killSessionRun(childKey);` between `loadSubagentSessionEntry` and `clearSessionQueues` |
| `src/auto-reply/reply/commands-subagents/action-send.ts` | `/subagents steer` branch | Insert `killSessionRun(targetResolution.entry.childSessionKey);` between `markSubagentRunForSteerRestart` and `clearSessionQueues` |

Plus three imports of `killSessionRun`.

`cascadeKillChildren` propagates the fix automatically — it delegates to `killSubagentRun`, which now terminates the subprocess.

## Why `killSessionRun` is the right replacement

- **Live, not a stub**: `session-run-registry.ts:65-83` dispatches either `abortController.abort()` OR `process.kill(pid, "SIGTERM")`. Module attestation is `"live"`.
- **Actively populated**: `ChannelBridge` registers at `channel-bridge.ts:160` (in a `try`) and unregisters at `:349` (in a `finally`). CLI subprocess runtime registers `pid` at dispatch time.
- **Idempotent + safe**: returns `false` on unknown/already-aborted keys; internal `try/catch` around `process.kill` means it never throws.
- **Key-type match**: `childSessionKey` (from `SubagentRunRecord`) is the canonical ChannelBridge sessionKey the registry keys on. No conversion needed. `entry.sessionId` (Pi-era UUID) is preserved for `clearSessionQueues` / session-store lookups only.

## Out of scope (per issue body)

- `abort.ts::stopSubagentsForRequester` carries the same `const aborted = false;` dead-var pattern — tracked under the `/abort` user command + gateway `sessions.reset` sub-issue.
- Auto-reply queue mode regressions — separate sub-issue.
- Test-mock cleanup of `abortEmbeddedPiRun` (`reply.block-streaming.test.ts`, `reply/abort.test.ts`) — tracked under #2089 cascade sweep.
- `pi-embedded.ts` stub barrel deletion — #2089 cascade sweep.

## Verification

- `pnpm check` (format + tsgo + lint + lint:tmp + lint:no-remoteclaw-ai) → exit 0
- `pnpm test` (full parallel suite) → **800 files / 7010 passed / 3 skipped** — no regression
- Rescan: `git grep "killSessionRun"` returns registry definition + registry tests + the 3 PR-touched files; no stale or unwired references
- Rescan: `git grep "abortEmbeddedPiRun"` returns only test-mock contexts (2 files); production paths have no stray references
- Adversarial validation (fresh-context subclaude, 6 AC + 11 adversarial checks): **CLEAN**. Key confirmations:
  - `killSessionRun` is LIVE (abort or SIGTERM, not a stub)
  - `killed` aggregate `marked > 0 || aborted || cleared...` — `aborted` transitioning from constant-false to possibly-true only ADDS truthy cases; no previously-true scenario regresses
  - No double-kill in `action-kill.ts` (subsequent `stopSubagentsForRequester` targets children of `childKey`, not `childKey` itself; `killSessionRun` is idempotent anyway)
  - Order `markSteerRestart → killSessionRun → clearQueues → agent.wait → dispatch` is race-free (all sync within one event-loop tick)
  - Import sort matches oxfmt convention; zero new `@ts-expect-error` / `@ts-ignore` / `as any` introduced (stub-debt gate zero-tolerance since #2459)

## Test plan

- [x] `pnpm check` exit 0
- [x] `pnpm test` full suite green (7010 / 800 files)
- [x] Rescans clean
- [ ] CI green on all 11 required checks

## Context

- Parent: #2089 (ChannelBridge compatibility audit)
- Replacement module: `src/agents/session-run-registry.ts`
- Regression introduced by: #76/#77 (pi-embedded gut, `b27cecc795`)

Closes #2344

Refs: #2089

🤖 Generated with [Claude Code](https://claude.com/claude-code)