### PR TITLE
fix(abort): wire /abort + sessions.reset/delete to killSessionRun — actually terminate CLI subprocesses

### DIFF
--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -1,4 +1,5 @@
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { killSessionRun } from "../../agents/session-run-registry.js";
 import {
   listSubagentRunsForController,
   markSubagentRunTerminated,
@@ -245,7 +246,7 @@ export function stopSubagentsForRequester(params: {
         store = loadSessionStore(storePath);
         storeCache.set(storePath, store);
       }
-      const aborted = false;
+      const aborted = killSessionRun(childKey);
       const markedTerminated =
         markSubagentRunTerminated({
           runId: run.runId,
@@ -326,7 +327,7 @@ export async function tryFastAbortFromMessage(params: {
       }
     }
     const sessionId = entry?.sessionId;
-    const aborted = false;
+    const aborted = killSessionRun(resolvedTargetKey);
     const cleared = clearSessionQueues([resolvedTargetKey, sessionId]);
     if (cleared.followupCleared > 0 || cleared.laneCleared > 0) {
       logVerbose(

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { resolveSessionKeyAgentId } from "../../agents/agent-scope.js";
+import { killSessionRun, waitForSessionRunEnd } from "../../agents/session-run-registry.js";
 import { stopSubagentsForRequester } from "../../auto-reply/reply/abort.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue.js";
 import { loadConfig } from "../../config/config.js";
@@ -174,6 +175,9 @@ async function emitSessionUnboundLifecycleEvent(params: {
   );
 }
 
+const SESSION_RUN_TERMINATION_TIMEOUT_MS = 15_000;
+const ACP_RUNTIME_CLEANUP_TIMEOUT_MS = 15_000;
+
 async function ensureSessionRuntimeCleanup(params: {
   cfg: ReturnType<typeof loadConfig>;
   key: string;
@@ -187,10 +191,11 @@ async function ensureSessionRuntimeCleanup(params: {
   }
   clearSessionQueues([...queueKeys]);
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
-  if (!params.sessionId) {
-    return undefined;
-  }
-  const ended = true;
+  killSessionRun(params.target.canonicalKey);
+  const ended = await waitForSessionRunEnd(
+    params.target.canonicalKey,
+    SESSION_RUN_TERMINATION_TIMEOUT_MS,
+  );
   if (ended) {
     return undefined;
   }
@@ -199,8 +204,6 @@ async function ensureSessionRuntimeCleanup(params: {
     `Session ${params.key} is still active; try again in a moment.`,
   );
 }
-
-const ACP_RUNTIME_CLEANUP_TIMEOUT_MS = 15_000;
 
 async function runAcpCleanupStep(params: {
   op: () => Promise<void>;


### PR DESCRIPTION
## Summary

The user-facing `/abort` command and the gateway `sessions.reset` / `sessions.delete` methods lost their subprocess-termination semantics in the pi-embedded gut (`b27cecc795`, #76/#77). Both call sites were rewiring points for ChannelBridge; replacements (`killSessionRun` + `waitForSessionRunEnd`) exist in `src/agents/session-run-registry.ts` but were never wired to them — they left behind three `const aborted = false;` / `const ended = true;` dead placeholders.

This PR wires the three call sites. Same family as #2460 (gateway capacity accounting) and #2461 (subagent kill/steer), completing the trio of `session-run-registry` integrations that were outstanding after the gut.

## Changes

| File | Site | Change |
|------|------|--------|
| `src/auto-reply/reply/abort.ts` | `stopSubagentsForRequester` inner loop (line ~248) | `const aborted = false;` → `const aborted = killSessionRun(childKey);` (flows into `killed` aggregate) |
| `src/auto-reply/reply/abort.ts` | `tryFastAbortFromMessage` (line ~329) | `const aborted = false;` → `const aborted = killSessionRun(resolvedTargetKey);` (now returned in the `aborted` field of the public result) |
| `src/gateway/server-methods/sessions.ts` | `ensureSessionRuntimeCleanup` (line ~178) | Replace `const ended = true;` placeholder with `killSessionRun(canonicalKey)` + `await waitForSessionRunEnd(canonicalKey, SESSION_RUN_TERMINATION_TIMEOUT_MS)`. Return `UNAVAILABLE` on timeout. Also removes obsolete `if (!params.sessionId) return undefined;` early-exit (termination operates on `canonicalKey`, not `sessionId`). |

Plus one import per file and a new `SESSION_RUN_TERMINATION_TIMEOUT_MS = 15_000` constant grouped with the sibling `ACP_RUNTIME_CLEANUP_TIMEOUT_MS`.

## Note on stale AC3

Issue #2343 lists three regression sites. The third (`commands-session.ts::applyAbortTarget`) **does not exist in the current tree** — `git grep applyAbortTarget` returns zero hits. The `/session abort` pathway was consolidated into `abort.ts::tryFastAbortFromMessage` at some earlier point, so no duplicate wiring is needed. AC3 marked N/A.

## Behavior change (intended, per AC)

`sessions.reset` / `sessions.delete`:
- **Before**: returned success instantly regardless of active subprocess (`const ended = true;` placeholder).
- **After**: wait up to 15s for the CLI subprocess to terminate. On success → returns `undefined` (success). On timeout → `UNAVAILABLE` error with the pre-gut message `"Session ${params.key} is still active; try again in a moment."`.

`/abort` command (non-ACP sessions):
- **Before**: marked `abortedLastRun = true` and cleared queues, but the CLI subprocess kept running until natural completion.
- **After**: dispatches `abortController.abort()` or `process.kill(pid, "SIGTERM")` via `killSessionRun`; the `aborted` field in the return value now reflects reality.

## Key-format alignment

`killSessionRun` keys on canonical `sessionKey`. All three call sites already operate in canonical space:
- `abort.ts` subagent loop: `childKey` from `parseAgentSessionKey` (canonical)
- `abort.ts` fast-abort: `resolvedTargetKey = key ?? targetKey` from `resolveSessionEntryForKey` (canonical)
- `sessions.ts`: `params.target.canonicalKey` (canonical by construction via `resolveGatewaySessionStoreTarget`)

No conversion risk. Inherits the registration-vs-kill key discipline established in PRs #2460 / #2461.

## Verification

- `pnpm check` (format + tsgo + lint + project-specific lints) → exit 0
- `pnpm test` (full parallel suite) → **800 files / 7010 passed / 3 skipped** — no regression
- Rescans:
  - `git grep "const aborted = false"` → zero hits (combined sweep of #2344 + this PR)
  - `git grep "abortEmbeddedPiRun"` → only test-mock contexts; production has no remaining references
- Adversarial validation (fresh-context subclaude, 7 AC + 9 adversarial checks): **CLEAN**. Confirmations:
  - `waitForSessionRunEnd` is LIVE (50ms poll tick, max 15s wall-clock, non-blocking async)
  - `ensureSessionRuntimeCleanup` callers always pass a valid `canonicalKey`
  - No user-facing surface depends on the old always-false `aborted` field (callers read `.handled` and `.stoppedSubagents` only)
  - `killSessionRun` never throws (internal try/catch around `process.kill`)
  - Zero new `@ts-expect-error` / `@ts-ignore` / `as any` introduced

## Test plan

- [x] `pnpm check` exit 0
- [x] `pnpm test` full suite green (7010 / 800 files)
- [x] Rescans clean
- [ ] CI green on all required checks

## Context

- Parent: #2089 (ChannelBridge compatibility audit)
- Sibling PRs (already merged): #2460 (gateway capacity via `getActiveSessionRunCount`) + #2461 (subagents via `killSessionRun`)
- Regression introduced by: #76/#77 (pi-embedded gut, `b27cecc795`)
- Replacement module: `src/agents/session-run-registry.ts`

Closes #2343

Refs: #2089, #2344, #2460, #2461

🤖 Generated with [Claude Code](https://claude.com/claude-code)