### PR TITLE
gut(ui): remove dead thinkingLevel display plumbing (#2336 Area 7)

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -884,7 +884,6 @@ export function renderApp(state: AppViewState) {
                   void loadChatHistory(state);
                   void refreshChatAvatar(state);
                 },
-                thinkingLevel: state.chatThinkingLevel,
                 showThinking,
                 loading: state.chatLoading,
                 sending: state.chatSending,

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -61,7 +61,6 @@ export type AppViewState = {
   compactionStatus: CompactionStatus | null;
   fallbackStatus: FallbackStatus | null;
   chatAvatarUrl: string | null;
-  chatThinkingLevel: string | null;
   chatQueue: ChatQueueItem[];
   chatManualRefreshInFlight: boolean;
   nodesLoading: boolean;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -144,7 +144,6 @@ export class RemoteClawApp extends LitElement {
   @state() chatRunId: string | null = null;
   @state() compactionStatus: CompactionStatus | null = null;
   @state() chatAvatarUrl: string | null = null;
-  @state() chatThinkingLevel: string | null = null;
   @state() chatQueue: ChatQueueItem[] = [];
   @state() chatAttachments: ChatAttachment[] = [];
   @state() chatManualRefreshInFlight = false;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -11,7 +11,6 @@ function createState(overrides: Partial<ChatState> = {}): ChatState {
     chatSending: false,
     chatStream: null,
     chatStreamStartedAt: null,
-    chatThinkingLevel: null,
     client: null,
     connected: true,
     lastError: null,
@@ -503,7 +502,7 @@ describe("loadChatHistory", () => {
       { role: "assistant", text: "  NO_REPLY  " },
     ];
     const mockClient = {
-      request: vi.fn().mockResolvedValue({ messages, thinkingLevel: "low" }),
+      request: vi.fn().mockResolvedValue({ messages }),
     };
     const state = createState({
       client: mockClient as unknown as ChatState["client"],
@@ -515,7 +514,6 @@ describe("loadChatHistory", () => {
     expect(state.chatMessages).toHaveLength(2);
     expect(state.chatMessages[0]).toEqual(messages[0]);
     expect(state.chatMessages[1]).toEqual(messages[2]);
-    expect(state.chatThinkingLevel).toBe("low");
     expect(state.chatLoading).toBe(false);
   });
 
@@ -544,7 +542,6 @@ describe("loadChatHistory", () => {
         { role: "assistant", content: [{ type: "text", text: "visible answer" }] },
         { role: "user", content: [{ type: "text", text: "NO_REPLY" }] },
       ],
-      thinkingLevel: "low",
     });
     const state = createState({
       connected: true,
@@ -561,7 +558,6 @@ describe("loadChatHistory", () => {
       { role: "assistant", content: [{ type: "text", text: "visible answer" }] },
       { role: "user", content: [{ type: "text", text: "NO_REPLY" }] },
     ]);
-    expect(state.chatThinkingLevel).toBe("low");
     expect(state.chatLoading).toBe(false);
     expect(state.lastError).toBeNull();
   });

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -33,7 +33,6 @@ export type ChatState = {
   sessionKey: string;
   chatLoading: boolean;
   chatMessages: unknown[];
-  chatThinkingLevel: string | null;
   chatSending: boolean;
   chatMessage: string;
   chatAttachments: ChatAttachment[];
@@ -70,16 +69,12 @@ export async function loadChatHistory(state: ChatState) {
   state.chatLoading = true;
   state.lastError = null;
   try {
-    const res = await state.client.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
-      "chat.history",
-      {
-        sessionKey: state.sessionKey,
-        limit: 200,
-      },
-    );
+    const res = await state.client.request<{ messages?: Array<unknown> }>("chat.history", {
+      sessionKey: state.sessionKey,
+      limit: 200,
+    });
     const messages = Array.isArray(res.messages) ? res.messages : [];
     state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
-    state.chatThinkingLevel = res.thinkingLevel ?? null;
     // Clear all streaming state — history includes tool results and text
     // inline, so keeping streaming artifacts would cause duplicates.
     maybeResetToolStream(state);

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -423,7 +423,6 @@ export type GatewaySessionRow = {
   sessionId?: string;
   systemSent?: boolean;
   abortedLastRun?: boolean;
-  thinkingLevel?: string;
   verboseLevel?: string;
   reasoningLevel?: string;
   elevatedLevel?: string;
@@ -449,7 +448,6 @@ export type SessionsPatchResult = {
   entry: {
     sessionId: string;
     updatedAt?: number;
-    thinkingLevel?: string;
     verboseLevel?: string;
     reasoningLevel?: string;
     elevatedLevel?: string;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -17,7 +17,6 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
   return {
     sessionKey: "main",
     onSessionKeyChange: () => undefined,
-    thinkingLevel: null,
     showThinking: false,
     loading: false,
     sending: false,

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -34,7 +34,6 @@ export type FallbackIndicatorStatus = {
 export type ChatProps = {
   sessionKey: string;
   onSessionKeyChange: (next: string) => void;
-  thinkingLevel: string | null;
   showThinking: boolean;
   loading: boolean;
   sending: boolean;


### PR DESCRIPTION
## Summary

Follow-up to #2336 (umbrella) / #2463 (Areas 1+2+4). Completes **Area 7**
for the **Web UI** surface only. Native-app state-drivers deferred per
the umbrella issue's "Do NOT touch native apps without confirming"
guidance — full classification report below so that work can be scoped
separately.

- **Web UI** (`ui/src/ui/`): 8 files, +5/-21 — all dead display plumbing.
- **Native apps**: classified below, NOT modified (release coordination
  required).
- **False positives in issue file list** identified: `format.test.ts` /
  `AssistantTextParserTests.swift` only touch `<think>` XML tag parsing
  (CLI output display), unrelated to `thinkingLevel` field — kept as-is.

## Why this is safe

Web UI `thinkingLevel` was dead display plumbing:

- Read from `chat.history` response into `state.chatThinkingLevel`.
- Passed through `ChatProps.thinkingLevel` to `renderChat`.
- **But the view body never read the prop** — `renderChat` uses
  `activeSession?.reasoningLevel` for its single reasoning branch
  (`ui/src/ui/views/chat.ts:246`), not `thinkingLevel`.
- No UI code sends `thinkingLevel` — `patchSession` in
  `ui/src/ui/controllers/sessions.ts:60-84` only handles
  `label` / `verboseLevel`.

Removing a read-only field that's never rendered and never sent has
zero runtime effect.

## Changes

| File | Change |
|------|--------|
| `ui/src/ui/types.ts` | Drop phantom \`thinkingLevel?\` from \`GatewaySessionRow\` (426) and \`SessionsPatchResult.entry\` (452) |
| `ui/src/ui/controllers/chat.ts` | Drop \`chatThinkingLevel\` from \`ChatState\`, narrow \`chat.history\` response type, drop state assignment |
| `ui/src/ui/app-view-state.ts` | Drop \`chatThinkingLevel\` from \`AppViewState\` |
| `ui/src/ui/app.ts` | Drop \`@state() chatThinkingLevel\` |
| `ui/src/ui/app-render.ts` | Drop \`thinkingLevel\` from \`ChatProps\` pass-through |
| `ui/src/ui/views/chat.ts` | Drop unused \`thinkingLevel: string \| null\` prop from \`ChatProps\` |
| `ui/src/ui/views/chat.test.ts`, `ui/src/ui/controllers/chat.test.ts` | Drop test fixtures/assertions for removed plumbing |

## Native-app audit report (deferred — informational only)

All native-app files classified as STATE-DRIVERS: they compose
mutable \`thinkingLevel\` state AND send it to the backend via
\`sessions.patch({thinkingLevel})\` and/or \`chat.send(thinking:)\`.
Require release coordination.

### Android (4 files)

| File | Classification | Evidence |
|------|----------------|----------|
| `apps/android/.../app/chat/ChatController.kt` | **STATE-DRIVER** | \`MutableStateFlow("off")\` (42-43); \`setThinkingLevel()\` mutator (98); \`sendMessage(thinkingLevel=...)\` sends to backend (114-129) |
| `apps/android/.../app/chat/ChatModels.kt` | DATA MODEL | \`ChatHistory.thinkingLevel: String?\` (35) — parsed from \`chat.history\` |
| `apps/android/.../android/chat/ChatController.kt` | **STATE-DRIVER** | Parallel path to above |
| `apps/android/.../android/NodeRuntime.kt` | **STATE-DRIVER EXPOSURE** | \`chatThinkingLevel: StateFlow<String>\` (536); \`sendChat()\` forwards to \`ChatController.sendMessage(thinkingLevel=thinking)\` (879) |

### iOS / macOS / shared (RemoteClawKit) (6 files)

| File | Classification | Evidence |
|------|----------------|----------|
| `RemoteClawChatUI/ChatViewModel.swift` | **STATE-DRIVER** | Mutable \`thinkingLevel\` (22); \`sendMessage(thinking: thinkingLevel)\` (440); \`setSessionThinking\` → \`transport.setSessionThinking(thinkingLevel:)\` (515, 519) |
| `RemoteClawChatUI/ChatSessions.swift` | DATA MODEL | \`thinkingLevel: String?\` on session row (53) |
| `RemoteClawChatUI/ChatComposer.swift` | **STATE-DRIVER UI** | Picker bound to \`viewModel.selectThinkingLevel(next)\` (95-96) |
| `RemoteClawChatUI/ChatTransport.swift` | **STATE-DRIVER PROTOCOL** | \`setSessionThinking(sessionKey:, thinkingLevel:)\` (24) → \`sessions.patch(thinkingLevel)\` |
| `RemoteClawChatUI/ChatModels.swift` | DATA MODEL | \`thinkingLevel: String?\` on response model (235) |
| `OpenClawChatUI/ChatComposer.swift` | **STATE-DRIVER UI** (upstream-inherited, not in Package.swift) | Picker bound to \`\$viewModel.thinkingLevel\` (86) |
| `Tests/RemoteClawKitTests/ChatViewModelTests.swift` | TEST (state-driver behavior) | Tests for \`thinkingLevel\`/\`selectThinkingLevel\` flow |

### macOS-only (3 files — 2 unlisted in issue)

| File | Classification | Evidence |
|------|----------------|----------|
| `apps/macos/Sources/RemoteClaw/WebChatSwiftUI.swift` | **STATE-DRIVER** | \`webChatThinkingLevelDefaultsKey\` persistence (11); \`setSessionThinking()\` → \`sessions.patch({thinkingLevel})\` (76-82) |
| `apps/macos/Sources/RemoteClaw/MenuSessionsInjector.swift` (unlisted) | MIXED (display + state-driver) | Reads \`row.thinkingLevel\` to build menu (841); \`patchThinking(_:)\` action sends to backend |
| `apps/macos/Tests/RemoteClawIPCTests/SessionDataTests.swift` (unlisted) | TEST FIXTURE | \`thinkingLevel: "high"\` in session row fixture (36) |

### False positives in issue file list

| File | Why it's a false positive |
|------|---------------------------|
| `ui/src/ui/format.test.ts` | Only tests \`stripThinkingTags\` — strips \`<think>\` XML blocks from assistant output. Unrelated to \`thinkingLevel\` field. |
| `apps/shared/RemoteClawKit/Tests/OpenClawKitTests/AssistantTextParserTests.swift` | Only tests \`<think>\`/\`<thinking>\` XML tag parsing. Same story. |

Both preserved unchanged (legitimate display of CLI assistant output).

## Sequencing for #2464

#2464 removes backend \`SessionEntry.thinkingLevel\` + gateway schema.
Reader-before-writer ordering:

1. **This PR** (#2467) — UI reader of \`thinkingLevel\` from \`chat.history\`
   removed. Safe: backend continues to send it, UI ignores.
2. **#2464 next** — backend stops sending the field. Safe: UI already
   doesn't read it.
3. Native-app state-drivers remain — they'll break on
   \`sessions.patch({thinkingLevel})\` once backend removes schema
   validation. Coordination required with native release pipelines
   before #2464 lands.

## Verification

- [x] \`grep thinkingLevel|chatThinkingLevel|thinkLevel\` in \`ui/\` → **0**
  matches
- [x] \`pnpm check\` (format + tsgo + lint + 2× project-specific linters)
  → exit 0
- [x] \`pnpm test src/ui/controllers/chat.test.ts src/ui/views/chat.test.ts\`
  → **35/35** passed
- [x] Other UI test failures match \`origin/main\` baseline (18 pre-existing,
  unrelated to \`thinkingLevel\`)
- [ ] CI green on all required checks (pending this PR's run)

## Test plan

- [x] \`pnpm check\` locally
- [x] Targeted tests for modified files
- [ ] CI: build, test, lint, docs, rebrand-gate, zombie-import-gate,
  stub-debt-gate, throwing-stub-callers-gate, obsolescence-audit-gate

## Context

- Parent umbrella: #2336
- Sibling shipped: #2463 (Areas 1+2+4)
- Next in chain: #2464 (Area 3 — backend \`SessionEntry.thinkingLevel\`
  removal) — this PR unblocks that by removing the UI reader first.

Closes #2467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)