### PR TITLE
gut(docs): remove /think directive references — Area 6 of #2336 (#2466)

### DIFF
--- a/docs/channels/group-messages.md
+++ b/docs/channels/group-messages.md
@@ -15,7 +15,7 @@ Note: `agents.list[].groupChat.mentionPatterns` is now used by Telegram/Discord/
 
 - Activation modes: `mention` (default) or `always`. `mention` requires a ping (real WhatsApp @-mentions via `mentionedJids`, safe regex patterns, or the bot’s E.164 anywhere in the text). `always` wakes the agent on every message but it should reply only when it can add meaningful value; otherwise it returns the silent token `NO_REPLY`. Defaults can be set in config (`channels.whatsapp.groups`) and overridden per group via `/activation`. When `channels.whatsapp.groups` is set, it also acts as a group allowlist (include `"*"` to allow all).
 - Group policy: `channels.whatsapp.groupPolicy` controls whether group messages are accepted (`open|disabled|allowlist`). `allowlist` uses `channels.whatsapp.groupAllowFrom` (fallback: explicit `channels.whatsapp.allowFrom`). Default is `allowlist` (blocked until you add senders).
-- Per-group sessions: session keys look like `agent:<agentId>:whatsapp:group:<jid>` so commands such as `/verbose on` or `/think high` (sent as standalone messages) are scoped to that group; personal DM state is untouched. Heartbeats are skipped for group threads.
+- Per-group sessions: session keys look like `agent:<agentId>:whatsapp:group:<jid>` so commands such as `/verbose on` (sent as standalone messages) are scoped to that group; personal DM state is untouched. Heartbeats are skipped for group threads.
 - Context injection: **pending-only** group messages (default 50) that _did not_ trigger a run are prefixed under `[Chat messages since your last reply - for context]`, with the triggering line under `[Current message - respond to this]`. Messages already in the session are not re-injected.
 - Sender surfacing: every group batch now ends with `[from: Sender Name (+E164)]` so Pi knows who is speaking.
 - Ephemeral/view-once: we unwrap those before extracting text/mentions, so pings inside them still trigger.
@@ -67,7 +67,7 @@ Only the owner number (from `channels.whatsapp.allowFrom`, or the bot’s own E.
 1. Add your WhatsApp account (the one running RemoteClaw) to the group.
 2. Say `@remoteclaw …` (or include the number). Only allowlisted senders can trigger it unless you set `groupPolicy: "open"`.
 3. The agent prompt will include recent group context plus the trailing `[from: …]` marker so it can address the right person.
-4. Session-level directives (`/verbose on`, `/think high`, `/new` or `/reset`, `/compact`) apply only to that group’s session; send them as standalone messages so they register. Your personal DM session remains independent.
+4. Session-level directives (`/verbose on`, `/new` or `/reset`, `/compact`) apply only to that group’s session; send them as standalone messages so they register. Your personal DM session remains independent.
 
 ## Testing / verification
 

--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -136,7 +136,7 @@ Tools affect context in two ways:
 Slash commands are handled by the Gateway. There are a few different behaviors:
 
 - **Standalone commands**: a message that is only `/...` runs as a command.
-- **Directives**: `/think`, `/verbose`, `/reasoning`, `/elevated`, `/model`, `/queue` are stripped before the model sees the message.
+- **Directives**: `/verbose`, `/reasoning`, `/elevated`, `/model`, `/queue` are stripped before the model sees the message.
   - Directive-only messages persist session settings.
   - Inline directives in a normal message act as per-message hints.
 - **Inline shortcuts** (allowlisted senders only): certain `/...` tokens inside a normal message can run immediately (example: “hey /status”), and are stripped before the model sees the remaining text.

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -14,7 +14,7 @@ The host-only bash chat command uses `! <cmd>` (with `/bash <cmd>` as an alias).
 There are two related systems:
 
 - **Commands**: standalone `/...` messages.
-- **Directives**: `/think`, `/fast`, `/verbose`, `/reasoning`, `/elevated`, `/exec`, `/model`, `/queue`.
+- **Directives**: `/fast`, `/verbose`, `/reasoning`, `/elevated`, `/exec`, `/model`, `/queue`.
   - Directives are stripped from the message before the model sees it.
   - In normal chat messages (not directive-only), they are treated as “inline hints” and do **not** persist session settings.
   - In directive-only messages (the message contains only directives), they persist to the session and reply with an acknowledgement.
@@ -111,7 +111,6 @@ Text + native (when enabled):
 - `/activation mention|always` (groups only)
 - `/send on|off|inherit` (owner-only)
 - `/reset` or `/new [model]` (optional model hint; remainder is passed through)
-- `/think <off|minimal|low|medium|high|xhigh>` (dynamic choices by model/provider; aliases: `/thinking`, `/t`)
 - `/fast status|on|off` (omitting the arg shows the current effective fast-mode state)
 - `/verbose on|full|off` (alias: `/v`)
 - `/reasoning on|off|stream` (alias: `/reason`; when on, sends a separate message prefixed `Reasoning:`; `stream` = Telegram draft only)
@@ -130,7 +129,7 @@ Text-only:
 
 Notes:
 
-- Commands accept an optional `:` between the command and args (e.g. `/think: high`, `/send: on`, `/help:`).
+- Commands accept an optional `:` between the command and args (e.g. `/send: on`, `/help:`).
 - `/new <model>` accepts a model alias, `provider/model`, or a provider name (fuzzy match); if no match, the text is treated as the message body.
 - For full provider usage breakdown, use `remoteclaw status --usage`.
 - `/allowlist add|remove` requires `commands.config=true` and honors channel `configWrites`.

--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -91,7 +91,6 @@ Core:
 
 Session controls:
 
-- `/think <off|minimal|low|medium|high>`
 - `/fast <status|on|off>`
 - `/verbose <on|full|off>`
 - `/reasoning <on|off|stream>`


### PR DESCRIPTION
## Summary

- Area 6 of umbrella #2336 — removes the `/think` slash-command directive from user-facing docs.
- RemoteClaw does not control thinking levels; CLI runtimes (Claude, Gemini, Codex, OpenCode) own that decision. Advertising `/think` as a RemoteClaw directive is stale upstream surface.
- Sibling PR #2463 landed Areas 1+2+4 (runtime `/think` parsing, helpers, and passthrough plumbing). This completes the docs half.

## Changes

- `docs/tools/slash-commands.md` — remove `/think` from the directives list (L17), delete the `/think <off|minimal|low|medium|high|xhigh>` command entry (L114), and drop `/think: high` from the colon-separator example (L133).
- `docs/concepts/context.md:139` — remove `/think` from the directives list.
- `docs/web/tui.md:94` — delete the `/think <off|...>` TUI entry.
- `docs/channels/group-messages.md` — drop `or /think high` at L18 and `/think high` at L70 from the session-level-directives examples; `/verbose on` remains as the primary example in both spots.

## Verification

- `git grep "/think\b" docs/` → 0 hits (matches the parent #2336 AC).
- `cd docs && npm run build` → 296 pages built, no errors.
- `pnpm format:docs:check` → clean.
- `pnpm lint:docs` → no errors on the 4 edited files. Pre-existing lint errors on unrelated files (`docs/start/*.mdx`, `docs/node_modules/**`) are identical on `origin/main`.
- Fresh-context validate + polish subprocesses both returned **CLEAN**.

## Out of scope for Area 6 (tracked as informational)

Found during rescan, explicitly outside the 4-file scope defined by Area 6. Flag for future #2336 waves if not already covered elsewhere:

- `docs/help/faq.md:2354` — `set /thinking off for that agent` (alias of `/think`).
- `docs/help/faq.md:2901`, `docs/concepts/messages.md:145`, `docs/start/hubs.md:115` — links to `/tools/thinking`; the target page was gutted in an earlier wave (pre-existing broken links, not introduced here).
- `docs/web/tui.md:40` status-line string `model + think/fast/...` — UI indicator shorthand, not a slash command.
- `src/agents/agent-helpers/errors.ts` — error message still references `/think`; belongs to Areas 1/2/4 (src cleanup).

## AC interpretation note

Issue AC says `git grep "/think" docs/` returns zero hits. Taken literally (substring match), that would also flag `model/thinking` compound phrases and `/thinking off` alias references — none of which are the `/think` slash command. The parent umbrella #2336 AC uses `/think\b` (word boundary) to scope precisely to the directive. This PR matches `/think\b` behavior and documents the remaining substring matches as out-of-scope.

Closes #2466.

## Test plan

- [x] `git grep "/think\b" docs/` returns zero hits
- [x] `cd docs && npm run build` succeeds (296 pages)
- [x] `pnpm format:docs:check` clean
- [x] `pnpm lint:docs` shows no new errors on edited files
- [x] Page-level links to `/tools/slash-commands`, `/web/tui`, `/concepts/context`, `/channels/group-messages` survive (no `#think` anchors existed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)