### PR TITLE
gut(auto-reply): remove directive-handling model-state internals — Area 5 of #2336

### DIFF
--- a/src/auto-reply/reply/directive-handling.fast-lane.ts
+++ b/src/auto-reply/reply/directive-handling.fast-lane.ts
@@ -6,7 +6,7 @@ import { isDirectiveOnly } from "./directive-handling.parse.js";
 
 export async function applyInlineDirectivesFastLane(
   params: ApplyInlineDirectivesFastLaneParams,
-): Promise<{ directiveAck?: ReplyPayload; provider: string; model: string }> {
+): Promise<{ directiveAck?: ReplyPayload }> {
   const {
     directives,
     commandAuthorized,
@@ -19,16 +19,8 @@ export async function applyInlineDirectivesFastLane(
     sessionKey,
     storePath,
     messageProviderKey,
-    defaultProvider,
-    defaultModel,
-    aliasIndex,
-    allowedModelKeys,
-    allowedModelCatalog,
-    resetModelOverride,
-    formatModelSwitchEvent,
   } = params;
 
-  let { provider, model } = params;
   if (
     !commandAuthorized ||
     isDirectiveOnly({
@@ -40,7 +32,7 @@ export async function applyInlineDirectivesFastLane(
       isGroup,
     })
   ) {
-    return { directiveAck: undefined, provider, model };
+    return { directiveAck: undefined };
   }
 
   const agentCfg = params.agentCfg;
@@ -56,25 +48,8 @@ export async function applyInlineDirectivesFastLane(
     sessionKey,
     storePath,
     messageProviderKey,
-    defaultProvider,
-    defaultModel,
-    aliasIndex,
-    allowedModelKeys,
-    allowedModelCatalog,
-    resetModelOverride,
-    provider,
-    model,
-    initialModelLabel: params.initialModelLabel,
-    formatModelSwitchEvent,
     currentVerboseLevel,
   });
 
-  if (sessionEntry?.providerOverride) {
-    provider = sessionEntry.providerOverride;
-  }
-  if (sessionEntry?.modelOverride) {
-    model = sessionEntry.modelOverride;
-  }
-
-  return { directiveAck, provider, model };
+  return { directiveAck };
 }

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -26,7 +26,7 @@ export async function handleDirectiveOnly(
   const queueAck = maybeHandleQueueDirective({
     directives,
     cfg: params.cfg,
-    channel: params.provider,
+    channel: params.messageProviderKey ?? "",
     sessionEntry,
   });
   if (queueAck) {

--- a/src/auto-reply/reply/directive-handling.params.ts
+++ b/src/auto-reply/reply/directive-handling.params.ts
@@ -12,21 +12,10 @@ export type HandleDirectiveOnlyCoreParams = {
   sessionKey: string;
   storePath?: string;
   messageProviderKey?: string;
-  defaultProvider: string;
-  defaultModel: string;
-  aliasIndex: Map<string, { provider: string; model: string }>;
-  allowedModelKeys: Set<string>;
-  allowedModelCatalog: Array<{ id: string; provider: string }>;
-  resetModelOverride: boolean;
-  provider: string;
-  model: string;
-  initialModelLabel: string;
-  formatModelSwitchEvent: (label: string, alias?: string) => string;
 };
 
 export type HandleDirectiveOnlyParams = HandleDirectiveOnlyCoreParams & {
   currentVerboseLevel?: VerboseLevel;
-  surface?: string;
 };
 
 export type ApplyInlineDirectivesFastLaneParams = HandleDirectiveOnlyCoreParams & {

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -20,8 +20,6 @@ export type ApplyDirectiveResult =
   | {
       kind: "continue";
       directives: InlineDirectives;
-      provider: string;
-      model: string;
       directiveAck?: ReplyPayload;
       perMessageQueueMode?: InlineDirectives["queueMode"];
       perMessageQueueOptions?: {
@@ -50,8 +48,6 @@ export async function applyInlineDirectiveOverrides(params: {
   runtimeId: string;
   provider: string;
   model: string;
-  initialModelLabel: string;
-  formatModelSwitchEvent: (label: string, alias?: string) => string;
   defaultActivation: () => ReturnType<
     Parameters<typeof buildStatusReply>[0]["defaultGroupActivation"]
   >;
@@ -77,40 +73,11 @@ export async function applyInlineDirectiveOverrides(params: {
     allowTextCommands,
     command,
     messageProviderKey,
-    runtimeId,
-    initialModelLabel,
-    formatModelSwitchEvent,
     defaultActivation,
     typing,
   } = params;
   let { directives } = params;
-  let { provider, model } = params;
-  // Model selection gutted in RemoteClaw — derive from runtimeId and pass empty lookups.
-  const defaultProvider = runtimeId;
-  const defaultModel = "default";
-  const aliasIndex = new Map<string, { provider: string; model: string }>();
-  const directiveModelState = {
-    allowedModelKeys: new Set<string>(),
-    allowedModelCatalog: [] as Array<{ id: string; provider: string }>,
-    resetModelOverride: false,
-  };
-  const createDirectiveHandlingBase = () => ({
-    cfg,
-    directives,
-    sessionEntry,
-    sessionStore,
-    sessionKey,
-    storePath,
-    messageProviderKey,
-    defaultProvider,
-    defaultModel,
-    aliasIndex,
-    ...directiveModelState,
-    provider,
-    model,
-    initialModelLabel,
-    formatModelSwitchEvent,
-  });
+  const { provider, model } = params;
 
   let directiveAck: ReplyPayload | undefined;
 
@@ -136,9 +103,14 @@ export async function applyInlineDirectiveOverrides(params: {
       (sessionEntry?.verboseLevel as import("../thinking.js").VerboseLevel | undefined) ??
       (agentCfg?.verboseDefault as import("../thinking.js").VerboseLevel | undefined);
     const directiveReply = await handleDirectiveOnly({
-      ...createDirectiveHandlingBase(),
+      cfg,
+      directives,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      messageProviderKey,
       currentVerboseLevel,
-      surface: ctx.Surface,
     });
     let statusReply: ReplyPayload | undefined;
     if (directives.hasStatusDirective && allowTextCommands && command.isAuthorizedSender) {
@@ -182,19 +154,9 @@ export async function applyInlineDirectiveOverrides(params: {
       sessionKey,
       storePath,
       messageProviderKey,
-      defaultProvider,
-      defaultModel,
-      aliasIndex,
-      ...directiveModelState,
-      provider,
-      model,
-      initialModelLabel,
-      formatModelSwitchEvent,
       agentCfg,
     });
     directiveAck = fastLane.directiveAck;
-    provider = fastLane.provider;
-    model = fastLane.model;
   }
 
   await persistInlineDirectives({
@@ -219,8 +181,6 @@ export async function applyInlineDirectiveOverrides(params: {
   return {
     kind: "continue",
     directives,
-    provider,
-    model,
     directiveAck,
     perMessageQueueMode,
     perMessageQueueOptions,

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -119,8 +119,8 @@ export async function resolveReplyDirectives(params: {
   // Model selection: use new upstream params if available, fall back to runtimeId for back-compat.
   const defaultProvider = params.defaultProvider ?? params.runtimeId ?? "anthropic";
   const defaultModel = params.defaultModel ?? "default";
-  let provider = params.provider ?? params.runtimeId ?? defaultProvider;
-  let model = defaultModel;
+  const provider = params.provider ?? params.runtimeId ?? defaultProvider;
+  const model = defaultModel;
 
   // Prefer CommandBody/RawBody (clean message without structural context) for directive parsing.
   // Keep `Body`/`BodyStripped` as the best-available prompt text (may include context).
@@ -284,9 +284,6 @@ export async function resolveReplyDirectives(params: {
     ? resolveBlockStreamingChunking(cfg, sessionCtx.Provider, sessionCtx.AccountId)
     : undefined;
 
-  const initialModelLabel = `${provider}/${model}`;
-  const formatModelSwitchEvent = (label: string, alias?: string) =>
-    alias ? `Model switched to ${alias} (${label}).` : `Model switched to ${label}.`;
   const inlineStatusRequested = hasInlineStatus && allowTextCommands && command.isAuthorizedSender;
 
   const applyResult = await applyInlineDirectiveOverrides({
@@ -311,8 +308,6 @@ export async function resolveReplyDirectives(params: {
     runtimeId: params.runtimeId ?? defaultProvider,
     provider,
     model,
-    initialModelLabel,
-    formatModelSwitchEvent,
     defaultActivation: () => defaultActivation,
     typing,
   });
@@ -320,8 +315,6 @@ export async function resolveReplyDirectives(params: {
     return { kind: "reply", reply: applyResult.reply };
   }
   directives = applyResult.directives;
-  provider = applyResult.provider;
-  model = applyResult.model;
   const { directiveAck, perMessageQueueMode, perMessageQueueOptions } = applyResult;
   const execOverrides = resolveExecOverrides({ directives, sessionEntry });
 


### PR DESCRIPTION
## Summary

Follow-up to PR #2463 (Areas 1+2+4 of #2336). Completes the directive-handling portion of the sweep by removing model-state plumbing that was already empty/trivial after #2335's `createModelSelectionState` removal.

Per the Middleware Boundary Principle: RemoteClaw does NOT control model selection — CLI runtimes (Claude, Gemini, Codex, OpenCode) own those decisions. `handleDirectiveOnly` and `applyInlineDirectivesFastLane` carried 10 fields (`aliasIndex`, `allowedModelKeys`, `allowedModelCatalog`, `resetModelOverride`, `defaultProvider`, `defaultModel`, `initialModelLabel`, `formatModelSwitchEvent`, `provider`, `model`) that are now fully dead.

Closes #2465.

## Changes

- **`src/auto-reply/reply/directive-handling.params.ts`**: delete all 10 model-state fields from `HandleDirectiveOnlyCoreParams`; delete unused `surface?: string` from `HandleDirectiveOnlyParams`.
- **`src/auto-reply/reply/directive-handling.impl.ts`**: queue-validation `channel` semantic fix — switch from misused `params.provider` (AI provider, e.g. `anthropic`) to `params.messageProviderKey ?? ""` (actual message channel, e.g. `telegram`). Aligns with `get-reply-run.ts:382` which already passes `sessionCtx.Provider` correctly. User-visible effect is limited to channel-specific queue config display when running `/queue` without args.
- **`src/auto-reply/reply/directive-handling.fast-lane.ts`**: drop model-state destructures; drop dead `sessionEntry.providerOverride`/`modelOverride` reads; simplify return type `{directiveAck?; provider; model}` → `{directiveAck?}`. _Note_: `providerOverride`/`modelOverride` ARE written by `src/gateway/sessions-patch.ts:213-214` and `src/agents/tools/session-status-tool.ts:254-255`, but their downstream consumption via this fast-lane path reaches only `isReasoningTagProvider` at `get-reply-run.ts:453` (`enforceFinalTag` for google/google-gemini-cli/minimax) — vestigial Pi-era plumbing per #2336's gut thesis.
- **`src/auto-reply/reply/get-reply-directives-apply.ts`**: delete inline empty-default `directiveModelState` compat shim (introduced in #2335); delete `aliasIndex`/`initialModelLabel`/`formatModelSwitchEvent` threading; inline single-call `createDirectiveHandlingBase` factory; drop `provider`/`model` from `ApplyDirectiveResult.continue` variant (pure pass-through of inputs post-gut).
- **`src/auto-reply/reply/get-reply-directives.ts`** (required cascade): delete dead `initialModelLabel`/`formatModelSwitchEvent` constructions and their two param passes (orphaned by the scope reduction in apply.ts); collapse `let provider`/`let model` to `const` (no longer reassigned).

## Deferred

- `resolveDefaultModel` stub in `directive-handling.ts` still returns `allowedModelKeys`/`allowedModelCatalog`/`resetModelOverride` — never read by callers. Separate cleanup wave.
- `aliasIndex` still threaded through `get-reply.ts` → `resolveReplyDirectives` (dead throughout). Separate cleanup wave.
- Adjacent Areas 3 (`SessionEntry.thinkingLevel`), 6 (docs), 7 (display audit), 8 (test-layer hardening) of #2336 remain as separate follow-ups.

## Verification

- `pnpm check`: exit 0 (format + tsgo + oxlint + project-specific lints)
- `pnpm test`: **800 files / 7010 passed / 3 skipped** — matches #2463 baseline
- Grep across the 4 target files: zero hits for all 10 gutted symbols
- `git diff --stat`: 5 files changed, 14 insertions(+), 97 deletions(-)

## Test plan

- [x] `pnpm check` green
- [x] `pnpm test` green (no regression vs #2463 baseline)
- [x] Grep rescan: no empty-default compat shims remain in the 4 in-scope files
- [ ] CI green on this PR

Refs: #2465, #2336, #2335, #2463

🤖 Generated with [Claude Code](https://claude.com/claude-code)