### PR TITLE
gut(config): remove embeddedPi Pi-era config stub (#2479)

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -1320,17 +1320,6 @@
       "hasChildren": false
     },
     {
-      "path": "agents.defaults.embeddedPi",
-      "kind": "core",
-      "required": false,
-      "deprecated": false,
-      "sensitive": false,
-      "tags": ["advanced"],
-      "label": "Embedded Pi",
-      "help": "Embedded Pi runner hardening controls for how workspace-local Pi settings are trusted and applied in RemoteClaw sessions.",
-      "hasChildren": false
-    },
-    {
       "path": "agents.defaults.envelopeElapsed",
       "kind": "core",
       "type": "string",

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -5,7 +5,7 @@ import {
   setConfigValueAtPath,
   unsetConfigValueAtPath,
 } from "./config-paths.js";
-import { readConfigFileSnapshot, validateConfigObject } from "./config.js";
+import { migrateLegacyConfig, readConfigFileSnapshot, validateConfigObject } from "./config.js";
 import {
   buildWebSearchProviderConfig,
   withTempHome,
@@ -333,6 +333,42 @@ describe("model api/compat legacy fields (compat stubs)", () => {
     });
 
     expect(res.ok).toBe(true);
+  });
+});
+
+describe("agents.defaults.embeddedPi legacy field (#2479)", () => {
+  // The Pi orchestrator was replaced by AgentRuntime; the config stub was removed.
+  // These tests guard the rule+migration channel that lets pre-gut configs still load.
+  it("flags agents.defaults.embeddedPi as a legacy issue", async () => {
+    await withTempHome(async (home) => {
+      await writeRemoteClawConfig(home, {
+        agents: {
+          list: [{ id: "pi" }],
+          defaults: { embeddedPi: { projectSettingsPolicy: "sanitize" } },
+        },
+      });
+
+      const snap = await readConfigFileSnapshot();
+
+      expect(snap.legacyIssues.some((i) => i.path === "agents.defaults.embeddedPi")).toBe(true);
+    });
+  });
+
+  it("auto-migration strips agents.defaults.embeddedPi and the migrated config validates", () => {
+    const res = migrateLegacyConfig({
+      agents: {
+        list: [{ id: "pi", workspace: "/tmp/pi" }],
+        defaults: { embeddedPi: { projectSettingsPolicy: "sanitize" } },
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Stripped obsolete agents.defaults.embeddedPi field — the Pi orchestrator was replaced by AgentRuntime.",
+    );
+    expect(res.config).not.toBeNull();
+    expect(
+      (res.config?.agents?.defaults as { embeddedPi?: unknown } | undefined)?.embeddedPi,
+    ).toBeUndefined();
   });
 });
 

--- a/src/config/legacy.migrations.ts
+++ b/src/config/legacy.migrations.ts
@@ -27,6 +27,21 @@ export const LEGACY_CONFIG_MIGRATIONS: LegacyConfigMigration[] = [
     },
   },
   {
+    id: "strip-agents-defaults-embedded-pi",
+    describe: "Strip obsolete agents.defaults.embeddedPi field (#2479)",
+    apply(raw, changes) {
+      const agents = getRecord(raw.agents);
+      const defaults = agents ? getRecord(agents.defaults) : null;
+      if (!defaults || !Object.prototype.hasOwnProperty.call(defaults, "embeddedPi")) {
+        return;
+      }
+      delete defaults.embeddedPi;
+      changes.push(
+        "Stripped obsolete agents.defaults.embeddedPi field — the Pi orchestrator was replaced by AgentRuntime.",
+      );
+    },
+  },
+  {
     id: "telegram-require-mention",
     describe: "Move telegram.requireMention to channels.telegram.groups.*.requireMention",
     apply(raw, changes) {

--- a/src/config/legacy.rules.ts
+++ b/src/config/legacy.rules.ts
@@ -217,4 +217,9 @@ export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
           entry.default === true,
       ),
   },
+  {
+    path: ["agents", "defaults", "embeddedPi"],
+    message:
+      "agents.defaults.embeddedPi is obsolete and ignored — the Pi orchestrator was replaced by AgentRuntime. Remove it from your config (auto-migrated on load).",
+  },
 ];

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -1857,7 +1857,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                 },
                 additionalProperties: false,
               },
-              embeddedPi: {},
               verboseDefault: {
                 anyOf: [
                   {
@@ -12162,16 +12161,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
       label: "Compaction Memory Flush System Prompt",
       help: "System-prompt override for the pre-compaction memory flush turn to control extraction style and safety constraints. Use carefully so custom instructions do not reduce memory quality or leak sensitive context.",
       tags: ["advanced"],
-    },
-    "agents.defaults.embeddedPi": {
-      label: "Embedded Pi",
-      help: "Embedded Pi runner hardening controls for how workspace-local Pi settings are trusted and applied in RemoteClaw sessions.",
-      tags: ["advanced"],
-    },
-    "agents.defaults.embeddedPi.projectSettingsPolicy": {
-      label: "Embedded Pi Project Settings Policy",
-      help: 'How embedded Pi handles workspace-local `.pi/config/settings.json`: "sanitize" (default) strips shellPath/shellCommandPrefix, "ignore" disables project settings entirely, and "trusted" applies project settings as-is.',
-      tags: ["access"],
     },
     "agents.defaults.heartbeat.directPolicy": {
       label: "Heartbeat Direct Policy",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1055,10 +1055,6 @@ export const FIELD_HELP: Record<string, string> = {
     "User-prompt template used for the pre-compaction memory flush turn when generating memory candidates. Use this only when you need custom extraction instructions beyond the default memory flush behavior.",
   "agents.defaults.compaction.memoryFlush.systemPrompt":
     "System-prompt override for the pre-compaction memory flush turn to control extraction style and safety constraints. Use carefully so custom instructions do not reduce memory quality or leak sensitive context.",
-  "agents.defaults.embeddedPi":
-    "Embedded Pi runner hardening controls for how workspace-local Pi settings are trusted and applied in RemoteClaw sessions.",
-  "agents.defaults.embeddedPi.projectSettingsPolicy":
-    'How embedded Pi handles workspace-local `.pi/config/settings.json`: "sanitize" (default) strips shellPath/shellCommandPrefix, "ignore" disables project settings entirely, and "trusted" applies project settings as-is.',
   "agents.defaults.humanDelay.mode": 'Delay style for block replies ("off", "natural", "custom").',
   "agents.defaults.humanDelay.minMs": "Minimum delay in ms for custom humanDelay (default: 800).",
   "agents.defaults.humanDelay.maxMs": "Maximum delay in ms for custom humanDelay (default: 2500).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -481,8 +481,6 @@ export const FIELD_LABELS: Record<string, string> = {
     "Compaction Memory Flush Transcript Size Threshold",
   "agents.defaults.compaction.memoryFlush.prompt": "Compaction Memory Flush Prompt",
   "agents.defaults.compaction.memoryFlush.systemPrompt": "Compaction Memory Flush System Prompt",
-  "agents.defaults.embeddedPi": "Embedded Pi",
-  "agents.defaults.embeddedPi.projectSettingsPolicy": "Embedded Pi Project Settings Policy",
   "agents.defaults.heartbeat.directPolicy": "Heartbeat Direct Policy",
   "agents.list.*.heartbeat.directPolicy": "Heartbeat Direct Policy",
   "agents.defaults.heartbeat.suppressToolErrorWarnings": "Heartbeat Suppress Tool Error Warnings",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -170,8 +170,6 @@ export type AgentDefaultsConfig = {
   contextPruning?: AgentContextPruningConfig;
   /** Compaction tuning and pre-compaction memory flush behavior. */
   compaction?: AgentCompactionConfig;
-  /** @deprecated Embedded Pi config gutted — parsed but ignored. */
-  embeddedPi?: unknown;
   /** @deprecated Memory search config gutted — parsed but ignored. */
   memorySearch?: unknown;
   /** Default verbose level when no /verbose directive is present. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -126,9 +126,6 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
-    // Embedded Pi config gutted — Pi orchestrator replaced by AgentRuntime.
-    // Stub kept for config parse compatibility (existing configs still parse).
-    embeddedPi: z.unknown().optional(),
     verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])


### PR DESCRIPTION
## Summary

Remove the `embeddedPi: z.unknown().optional()` passthrough stub from `AgentDefaultsSchema`. The Pi orchestrator was replaced by AgentRuntime early in the fork; this stub was kept so existing user configs could parse during the transition window. That window has closed.

Closes #2479.

## Migration choice — Option B (rule + auto-migration)

#2478 chose Option A (silent passthrough) for `memorySearch` / `pdfModel` because users had no action to take. **#2479 is different:** the issue explicitly directs us to *remove* the stub, which means strict-schema configs carrying `embeddedPi` would reject without a migration. We add a rule + auto-migration so the warning surfaces once and the config keeps loading:

- `legacy.rules.ts` — new rule at `agents.defaults.embeddedPi` with message `"agents.defaults.embeddedPi is obsolete and ignored — the Pi orchestrator was replaced by AgentRuntime. Remove it from your config (auto-migrated on load)."`
- `legacy.migrations.ts` — new migration `strip-agents-defaults-embedded-pi` (sibling of `strip-agent-default-field` from #1581). Strips the field and pushes a change line.
- Gateway startup (`server.impl.ts:206-226`) already calls `migrateLegacyConfig` when `legacyIssues.length > 0`, writes the migrated config back, and re-reads — so users see the warning once, their config is cleaned up, and subsequent loads are silent.

## Changes

### Schema surface
- `src/config/zod-schema.agent-defaults.ts` — remove the 3-line stub (comment + field).
- `src/config/types.agent-defaults.ts` — remove the 2-line `@deprecated` type mirror.
- `src/config/schema.help.ts` — remove the two `agents.defaults.embeddedPi[.projectSettingsPolicy]` help entries.
- `src/config/schema.labels.ts` — remove the two matching label entries.

### Legacy channel
- `src/config/legacy.rules.ts` — add the detection rule.
- `src/config/legacy.migrations.ts` — add the stripping migration.

### Tests
- `src/config/config-misc.test.ts` — new describe block with two AC-bound tests:
  1. `flags agents.defaults.embeddedPi as a legacy issue` — loading a config with `embeddedPi: {...}` populates `snap.legacyIssues` with the path.
  2. `auto-migration strips agents.defaults.embeddedPi and the migrated config validates` — `migrateLegacyConfig` returns a non-null config (= passed strict validation) with the field stripped and the change line recorded.

### Generated
- `src/config/schema.base.generated.ts` — regenerated via `node --import tsx scripts/generate-base-config-schema.ts --write`.
- `docs/.generated/config-baseline.json` + `.jsonl` — regenerated via `node --import tsx scripts/generate-config-doc-baseline.ts --write`.

### Not touched (deliberately out of scope)
- Runtime identifiers `runEmbeddedPiAgent`, `isEmbeddedPiRunActive`, `queueEmbeddedPiMessage`, etc. in `src/auto-reply/`, `src/agents/`, `src/commands/agent.test.ts` — these use CamelCase `EmbeddedPi` and refer to the Pi agent runner subsystem, which is orthogonal to the config stub. Issue scopes #2479 explicitly to the config stub.
- `memorySearch` and `pdfModel` passthrough stubs — #2478 chose Option A for these; they stay.

## Acceptance criteria

- [x] `rg "embeddedPi" src/` returns hits only from the migration-warning message text. Remaining hits: `legacy.rules.ts` (rule text), `legacy.migrations.ts` (migration code + change message), `config-misc.test.ts` (regression test fixtures). Per the #2484 interpretation, these are "inside the migration shim."
- [x] A test exercises: loading a config containing `embeddedPi: {...}` emits the migration warning AND the config loads successfully (no schema error). Two tests cover both sides.
- [x] `tsc --noEmit` clean — `pnpm tsgo` exit 0.
- [x] Test suite passes — `pnpm vitest run src/config src/middleware` = 129 files / 1396 tests pass.

## Test plan

- [x] `pnpm check` (format:check + tsgo + lint + tmp-no-random-messaging + no-remoteclaw-ai) — all pass.
- [x] `pnpm canvas:a2ui:bundle` — ok.
- [x] `pnpm vitest run src/config` — 103 files / 788 tests pass.
- [x] `pnpm vitest run src/config src/middleware` — 129 files / 1396 tests pass.
- [x] Fork-integrity gates run locally — all pass:
  - zombie-import gate: clean
  - stub-debt gate: 132 == baseline 132
  - throwing-stub-callers gate: 0 violations, 0 allowlisted, 0 unexpected
  - obsolescence-audit gate: 49 == baseline 49

## Notes

- The stash-and-rerun check confirmed that the ~55 gateway test file failures observed in a broad local `pnpm vitest run src/gateway` are pre-existing on `main` (error: `Cannot resolve main session key: no agents configured` in `test-helpers.server.ts:164`). Unrelated to this diff. CI's environment runs these test files successfully.
- Following the fork's "gut" convention: commit prefix `gut(config):`; branch `gut/embedded-pi-config-2479`; migration sibling to `strip-agent-default-field` (#1581).

🤖 Generated with [Claude Code](https://claude.com/claude-code)