### PR TITLE
gut(config): remove dead agent params bags (#2481)

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -452,6 +452,68 @@ describe("thinking-level legacy fields (#2480)", () => {
   });
 });
 
+describe("agent params bag legacy fields (#2481)", () => {
+  // Per-agent and per-model params bags were placeholders for LLM request
+  // parameters (temperature, cacheRetention, etc.) that the middleware never
+  // read — CLI runtimes own those knobs. These tests guard the rule+migration
+  // channel that lets pre-gut configs still load (strict zod schemas would
+  // otherwise reject unknown keys).
+  it("flags agents.list[].params and agents.defaults.models[<id>].params as legacy issues", async () => {
+    await withTempHome(async (home) => {
+      await writeRemoteClawConfig(home, {
+        agents: {
+          list: [{ id: "ops", params: { temperature: 0.7 } }],
+          defaults: {
+            models: {
+              "gpt-4o": { alias: "gpt4o", params: { thinking: "medium" } },
+            },
+          },
+        },
+      });
+
+      const snap = await readConfigFileSnapshot();
+      const paths = snap.legacyIssues.map((i) => i.path);
+      expect(paths).toContain("agents.list");
+      expect(paths).toContain("agents.defaults.models");
+    });
+  });
+
+  it("auto-migration strips per-agent and per-model params fields", () => {
+    const res = migrateLegacyConfig({
+      agents: {
+        list: [
+          {
+            id: "ops",
+            workspace: "/tmp/ops",
+            params: { temperature: 0.7, cacheRetention: "5m" },
+          },
+        ],
+        defaults: {
+          models: {
+            "gpt-4o": { alias: "gpt4o", params: { thinking: "medium" } },
+            "claude-4-5": { params: { reasoning: "high" } },
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Stripped obsolete agents.list[].params field(s) — LLM request parameters are the CLI runtime's concern.",
+    );
+    expect(res.changes).toContain(
+      "Stripped obsolete agents.defaults.models[<id>].params field(s) — LLM request parameters are the CLI runtime's concern.",
+    );
+    expect(res.config).not.toBeNull();
+    const list = res.config?.agents?.list as Array<{ params?: unknown }> | undefined;
+    expect(list?.[0]?.params).toBeUndefined();
+    const models = (
+      res.config?.agents?.defaults as { models?: Record<string, { params?: unknown }> }
+    )?.models;
+    expect(models?.["gpt-4o"]?.params).toBeUndefined();
+    expect(models?.["claude-4-5"]?.params).toBeUndefined();
+  });
+});
+
 describe("config paths", () => {
   it("rejects empty and blocked paths", () => {
     expect(parseConfigPath("")).toEqual({

--- a/src/config/legacy.migrations.ts
+++ b/src/config/legacy.migrations.ts
@@ -109,6 +109,45 @@ export const LEGACY_CONFIG_MIGRATIONS: LegacyConfigMigration[] = [
     },
   },
   {
+    id: "strip-agent-params-bags",
+    describe:
+      "Strip obsolete agents.list[].params and agents.defaults.models[<id>].params fields (#2481)",
+    apply(raw, changes) {
+      const agents = getRecord(raw.agents);
+      const agentsList = getAgentsList(agents);
+      let strippedAgentParams = false;
+      for (const entry of agentsList) {
+        const entryRecord = getRecord(entry);
+        if (entryRecord && Object.prototype.hasOwnProperty.call(entryRecord, "params")) {
+          delete entryRecord.params;
+          strippedAgentParams = true;
+        }
+      }
+      if (strippedAgentParams) {
+        changes.push(
+          "Stripped obsolete agents.list[].params field(s) — LLM request parameters are the CLI runtime's concern.",
+        );
+      }
+      const defaults = agents ? getRecord(agents.defaults) : null;
+      const models = defaults ? getRecord(defaults.models) : null;
+      let strippedModelParams = false;
+      if (models) {
+        for (const entry of Object.values(models)) {
+          const entryRecord = getRecord(entry);
+          if (entryRecord && Object.prototype.hasOwnProperty.call(entryRecord, "params")) {
+            delete entryRecord.params;
+            strippedModelParams = true;
+          }
+        }
+      }
+      if (strippedModelParams) {
+        changes.push(
+          "Stripped obsolete agents.defaults.models[<id>].params field(s) — LLM request parameters are the CLI runtime's concern.",
+        );
+      }
+    },
+  },
+  {
     id: "telegram-require-mention",
     describe: "Move telegram.requireMention to channels.telegram.groups.*.requireMention",
     apply(raw, changes) {

--- a/src/config/legacy.rules.ts
+++ b/src/config/legacy.rules.ts
@@ -232,4 +232,24 @@ export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
     message:
       "agents.defaults.subagents.thinking is obsolete and ignored (#2480) — CLI runtimes own reasoning depth. Remove it from your config (auto-migrated on load).",
   },
+  {
+    path: ["agents", "list"],
+    message:
+      "agents.list[].params is obsolete and ignored (#2481) — LLM request parameters are the CLI runtime's concern, not middleware's. Remove it from your config (auto-migrated on load).",
+    match: (value) =>
+      Array.isArray(value) &&
+      value.some(
+        (entry) => isRecord(entry) && Object.prototype.hasOwnProperty.call(entry, "params"),
+      ),
+  },
+  {
+    path: ["agents", "defaults", "models"],
+    message:
+      "agents.defaults.models[<id>].params is obsolete and ignored (#2481) — LLM request parameters are the CLI runtime's concern, not middleware's. Remove it from your config (auto-migrated on load).",
+    match: (value) =>
+      isRecord(value) &&
+      Object.values(value).some(
+        (entry) => isRecord(entry) && Object.prototype.hasOwnProperty.call(entry, "params"),
+      ),
+  },
 ];

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -1299,13 +1299,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                     alias: {
                       type: "string",
                     },
-                    params: {
-                      type: "object",
-                      propertyNames: {
-                        type: "string",
-                      },
-                      additionalProperties: {},
-                    },
                     streaming: {
                       type: "boolean",
                     },

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -83,8 +83,6 @@ export type AgentConfig = {
   };
   /** Optional per-agent sandbox overrides. */
   sandbox?: AgentSandboxConfig;
-  /** Optional per-agent stream params (e.g. cacheRetention, temperature). */
-  params?: Record<string, unknown>;
   tools?: AgentToolsConfig;
   /** Optional runtime descriptor for this agent (object form or CLI runtime name). */
   runtime?: AgentRuntimeConfig | "claude" | "gemini" | "codex" | "opencode";

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -26,8 +26,6 @@ export const AgentDefaultsSchema = z
         z
           .object({
             alias: z.string().optional(),
-            /** Provider-specific API parameters (e.g., GLM-4.7 thinking mode). */
-            params: z.record(z.string(), z.unknown()).optional(),
             /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */
             streaming: z.boolean().optional(),
           })


### PR DESCRIPTION
## Summary

Per-agent `AgentConfig.params` and per-model `agents.defaults.models[<id>].params` were placeholders for LLM request parameters (temperature, cacheRetention, thinking mode, etc.) with **zero production readers**. RemoteClaw is middleware that delegates LLM execution to CLI runtimes (Claude, Gemini, Codex, OpenCode), so those knobs belong to the runtime, not middleware config.

Closes #2481.

### Changes

- **`src/config/types.agents.ts`**: remove `params?: Record<string, unknown>` field from `AgentConfig`. This field was TypeScript-only — it was never in the `AgentEntrySchema` zod schema (which is `.strict()`), so real configs with `agents.list[].params` were already being rejected at validation.
- **`src/config/zod-schema.agent-defaults.ts`**: remove per-model `params: z.record(z.string(), z.unknown()).optional()` from the models schema entry.
- **`src/config/schema.base.generated.ts`**: regenerated via `scripts/generate-base-config-schema.ts` — `params` key no longer appears under `agents.defaults.models.*.properties`.
- **`src/config/legacy.rules.ts`**: add two rules warning users about obsolete `agents.list[].params` and `agents.defaults.models[<id>].params` fields.
- **`src/config/legacy.migrations.ts`**: add `strip-agent-params-bags` migration that walks `agents.list[]` and `agents.defaults.models[<id>]` to remove `params` before strict zod validation.
- **`src/config/config-misc.test.ts`**: add regression tests for both the legacy-issue flagging path and the auto-strip migration path.

### Migration choice

**Option B (migration warning + strip)** — consistent with #2479 (embeddedPi gut) and #2480 (thinkingDefault gut). Users with `params` under an agent list entry or per-model section will see a `legacyIssues` diagnostic and the field is silently stripped before the strict zod schema runs, so existing configs continue to parse.

We rejected Option A (passthrough) because weakening `.strict()` to `.passthrough()` would silently swallow typos and leftover fields with no user-visible signal.

### Coordination

Issue #2481 flagged orphan tests in `src/commands/agent.test.ts` overlapping with #2480 and #2482. Since #2480 landed first, the `"prefers per-model thinking over global thinkingDefault"` test it referenced is already gone — no coordination needed with #2482.

The `runEmbeddedPiAgent = vi.fn()` mock identifiers remaining in test files are historical names for mocked module exports, not live calls, and are out of scope.

## Test plan

- [x] `pnpm tsgo` — no TypeScript errors
- [x] `pnpm lint` (oxlint --type-aware) — 0 warnings, 0 errors
- [x] `pnpm vitest run src/config/` — 96 test files, 740 tests, all pass (including 2 new regression tests for this PR)
- [x] `rg "AgentConfig.*params\?|config\.params|agent\.params" src/` — only pre-existing generic function-param refs (no production reads of the removed field)
- [x] `rg "models\.\w+\.params|model\.params|\.params\?\.thinking" src/` — 0 matches
- [x] Fork-integrity gates (rebrand-leakage, zombie-imports, stub-debt, throwing-stub-callers, obsolescence-audit, attestations) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)