### PR TITLE
fix(ui): restore connectGeneration/serverVersion/chatStreamSegments on RemoteClawApp (#2493)

### DIFF
--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -122,6 +122,7 @@ export class RemoteClawApp extends LitElement {
   @state() theme: ThemeMode = this.settings.theme ?? "system";
   @state() themeResolved: ResolvedTheme = "dark";
   @state() hello: GatewayHelloOk | null = null;
+  @state() serverVersion: string | null = null;
   @state() lastError: string | null = null;
   @state() lastErrorCode: string | null = null;
   @state() eventLog: EventLogEntry[] = [];
@@ -141,6 +142,7 @@ export class RemoteClawApp extends LitElement {
   @state() chatToolMessages: unknown[] = [];
   @state() chatStream: string | null = null;
   @state() chatStreamStartedAt: number | null = null;
+  @state() chatStreamSegments: Array<{ text: string; ts: number }> = [];
   @state() chatRunId: string | null = null;
   @state() compactionStatus: CompactionStatus | null = null;
   @state() chatAvatarUrl: string | null = null;
@@ -304,6 +306,7 @@ export class RemoteClawApp extends LitElement {
   private chatScrollFrame: number | null = null;
   private chatScrollTimeout: number | null = null;
   private chatHasAutoScrolled = false;
+  private connectGeneration = 0;
   private chatUserNearBottom = true;
   @state() chatNewMessagesBelow = false;
   private nodesPollInterval: number | null = null;


### PR DESCRIPTION
Closes #2493.

## Summary

Adds three missing field initializers on `RemoteClawApp` (`ui/src/ui/app.ts`) that were dropped during partial-sync of upstream v2026.3.7 (`9ef18943dc`). The companion `app-lifecycle.ts` / `app-gateway.ts` / `app-tool-stream.ts` changes arrived (adding `connectGeneration`, `serverVersion`, `chatStreamSegments` to their host-shape types) but the class-level initializers silently conflicted with the `OpenClawApp → RemoteClawApp` rebrand and were dropped during merge resolution. The `as unknown as Parameters<typeof X>[0]` cast pattern in `app.ts` (21 occurrences) erased the structural type-check that would otherwise have flagged the missing fields.

## Symptoms (from #2493)

- **Fatal**: `connectGeneration` undefined → `++undefined → NaN` → `NaN !== NaN` is always `true` at `app-lifecycle.ts:55` → `connectGateway` never called → Health Offline / Version n/a / "Disconnected from gateway." banner on first load.
- **Latent crash**: `chatStreamSegments` undefined → `TypeError: not iterable` when a tool call interrupts streaming text (`app-tool-stream.ts:441` spreads it).
- **Cosmetic**: `serverVersion` undefined → incorrect client version in gateway handshake (optional-chained, no crash).

## Fix

Three field initializers in `RemoteClawApp`, matching upstream type signatures and existing declaration styles:

- `@state() serverVersion: string | null = null` — reactive, feeds Version pill (grouped with other nullable gateway state near `hello`/`lastError`).
- `@state() chatStreamSegments: Array<{ text: string; ts: number }> = []` — reactive, feeds chat streaming view (grouped with `chatStream`/`chatStreamStartedAt`).
- `private connectGeneration = 0` — non-reactive lifecycle counter (grouped with `chatHasAutoScrolled` in the private bookkeeping section).

No test changes. Synthetic-host fixtures in `app-lifecycle.node.test.ts` / `app-lifecycle-connect.node.test.ts` already hand-set these fields — the problem was only in the production class.

## Test plan

- [x] `pnpm tsgo` clean (0 errors)
- [x] `pnpm lint` clean (0 warnings, 0 errors)
- [x] `pnpm format:check` clean
- [x] `pnpm exec vitest run --config vitest.unit.config.ts ui/src/ui/app-tool-stream.node.test.ts` — 4/4 pass
- [ ] Full `pnpm test` — via CI
- [ ] Manual: chat dashboard connects on first load (Health=Online, Version populated) — deferred to post-merge smoke

## Follow-ups (already filed per issue comment)

- #2494 — audit and remove `as unknown as Parameters<typeof X>[0]` casts so TypeScript catches future regressions of this class
- #2495 — smoke test instantiating `RemoteClawApp` asserting required host-interface fields
- #2496 — audit other host-shape interfaces (Polling/Chat/Settings/Scroll/Compaction) for missing initializers