### PR TITLE
test(ui): add smoke test instantiating RemoteClawApp and asserting required host-interface fields (#2495)

### DIFF
--- a/ui/src/ui/app.smoke.test.ts
+++ b/ui/src/ui/app.smoke.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import "./app.ts"; // registers the "remoteclaw-app" custom element
+
+// Defense-in-depth against the sync regression class fixed in #2493: fixtures
+// matched the LifecycleHost/GatewayHost/ToolStreamHost interfaces while the
+// production `RemoteClawApp` class did not. These smoke tests instantiate the
+// real class and assert every required host-interface field is defined.
+
+function createApp(): Record<string, unknown> {
+  return document.createElement("remoteclaw-app") as unknown as Record<string, unknown>;
+}
+
+function assertAllDefined(
+  instance: Record<string, unknown>,
+  fields: readonly string[],
+  label: string,
+) {
+  for (const field of fields) {
+    expect(instance[field], `missing ${label} field: ${field}`).not.toBeUndefined();
+  }
+}
+
+const LIFECYCLE_HOST_FIELDS = [
+  "basePath",
+  "connectGeneration",
+  "tab",
+  "assistantName",
+  "assistantAvatar",
+  "assistantAgentId",
+  "serverVersion",
+  "chatHasAutoScrolled",
+  "chatManualRefreshInFlight",
+  "chatLoading",
+  "chatMessages",
+  "chatToolMessages",
+  "chatStream",
+  "logsAutoFollow",
+  "logsAtBottom",
+  "logsEntries",
+  "popStateHandler",
+  "topbarObserver",
+] as const;
+
+const GATEWAY_HOST_FIELDS = [
+  "settings",
+  "password",
+  "clientInstanceId",
+  "client",
+  "connected",
+  "hello",
+  "lastError",
+  "lastErrorCode",
+  "eventLogBuffer",
+  "eventLog",
+  "tab",
+  "presenceEntries",
+  "presenceError",
+  "presenceStatus",
+  "agentsLoading",
+  "agentsList",
+  "agentsError",
+  "toolsCatalogLoading",
+  "toolsCatalogError",
+  "toolsCatalogResult",
+  "debugHealth",
+  "assistantName",
+  "assistantAvatar",
+  "assistantAgentId",
+  "serverVersion",
+  "sessionKey",
+  "chatRunId",
+  "refreshSessionsAfterChat",
+  "execApprovalQueue",
+  "execApprovalError",
+  "updateAvailable",
+] as const;
+
+const TOOL_STREAM_HOST_FIELDS = [
+  "sessionKey",
+  "chatRunId",
+  "chatStream",
+  "chatStreamStartedAt",
+  "chatStreamSegments",
+  "toolStreamById",
+  "toolStreamOrder",
+  "chatToolMessages",
+  "toolStreamSyncTimer",
+] as const;
+
+describe("RemoteClawApp instance — host interface compliance", () => {
+  it("initializes every required LifecycleHost field", () => {
+    const app = createApp();
+    assertAllDefined(app, LIFECYCLE_HOST_FIELDS, "LifecycleHost");
+  });
+
+  it("initializes every required GatewayHost field", () => {
+    const app = createApp();
+    assertAllDefined(app, GATEWAY_HOST_FIELDS, "GatewayHost");
+  });
+
+  it("initializes every required ToolStreamHost field", () => {
+    const app = createApp();
+    assertAllDefined(app, TOOL_STREAM_HOST_FIELDS, "ToolStreamHost");
+  });
+});


### PR DESCRIPTION
Closes #2495.

## Summary

Adds `ui/src/ui/app.smoke.test.ts` — a smoke test that instantiates the real `RemoteClawApp` Lit class via `document.createElement("remoteclaw-app")` and asserts every required field of `LifecycleHost`, `GatewayHost`, and `ToolStreamHost` is defined on the fresh instance.

## Problem this defends against

The gateway-disconnect regression in #2493 shipped because:
- All existing `app-*.node.test.ts` fixtures construct synthetic plain-object hosts that happen to match the three host interfaces.
- Zero tests instantiated the actual `RemoteClawApp` class.
- TypeScript assertions on `this as unknown as Parameters<typeof fn>[0]` (cast through `unknown`) erased the structural check between the class and the host types.

Result: fixtures passed, class was missing `connectGeneration`/`serverVersion`/`chatStreamSegments`, gateway connect silently broke, no test caught it.

## Approach

- Import `./app.ts` once → registers the `remoteclaw-app` custom element via `@customElement` decorator
- `document.createElement("remoteclaw-app")` → instantiates the real class (runs all property initializers)
- Three `it` blocks — one per host interface — assert every required field is `!== undefined`
- Field lists are enumerated statically from each host interface's required (non-optional) members; optional fields (`client?`, `connected?` in `LifecycleHost`; `onboarding?` in `GatewayHost`) are correctly excluded

`as unknown as Record<string, unknown>` cast (not `as any` — `typescript/no-explicit-any` is an oxlint error per `.oxlintrc.json`) enables dynamic field access without type-safety loss at the boundary we're testing.

## Acceptance criteria verification

- [x] New file `ui/src/ui/app.smoke.test.ts` exists — 105 LOC
- [x] Test asserts every required field of `LifecycleHost` (18), `GatewayHost` (31), `ToolStreamHost` (9)
- [x] Test PASSES on current HEAD (3 / 3 green)
- [x] Test FAILS if any restored field is removed — verified interactively for all three:
  - Removing `serverVersion` → 2 test failures (Lifecycle + Gateway)
  - Removing `chatStreamSegments` → 1 failure (ToolStream)
  - Removing `connectGeneration` → 1 failure (Lifecycle)
- [x] Test runs under the existing Playwright browser config (`ui/vitest.config.ts`) — the superset of the JSDOM environment the issue contemplated; no separate JSDOM plumbing was added
- [x] No Playwright-specific APIs used — the test only needs `document.createElement` and standard custom-element registration, and would run identically under a JSDOM config if one existed
- [x] `tsgo` clean, `oxfmt --check` clean, `oxlint --type-aware` clean

## Out of scope (future follow-ups)

The issue mentions a "stronger variant" that auto-derives the field list from the TypeScript interface via `tsc --emitDeclarationOnly` or type introspection. That would close the gap permanently (new host-interface fields auto-asserted without test updates). Explicitly deferred in the issue — worth a follow-up once this lands.

## References

- Defends against the regression class fixed in #2493
- Complements #2494 (cast removal eliminates the type-erasure that hid the bug)
- Extends naturally to cover findings from #2496

🤖 Generated with [Claude Code](https://claude.com/claude-code)
