### PR TITLE
test(ui): extend app smoke test to PollingHost/ChatHost/SettingsHost/ScrollHost/CompactionHost (#2496)

### DIFF
--- a/ui/src/ui/app.smoke.test.ts
+++ b/ui/src/ui/app.smoke.test.ts
@@ -5,6 +5,8 @@ import "./app.ts"; // registers the "remoteclaw-app" custom element
 // matched the LifecycleHost/GatewayHost/ToolStreamHost interfaces while the
 // production `RemoteClawApp` class did not. These smoke tests instantiate the
 // real class and assert every required host-interface field is defined.
+// Extended in #2496 to cover PollingHost / ChatHost / ScrollHost / SettingsHost
+// / CompactionHost — the remaining interfaces the class is asserted against.
 
 function createApp(): Record<string, unknown> {
   return document.createElement("remoteclaw-app") as unknown as Record<string, unknown>;
@@ -87,6 +89,72 @@ const TOOL_STREAM_HOST_FIELDS = [
   "toolStreamSyncTimer",
 ] as const;
 
+// Extended coverage (#2496): audit scope broadened to the remaining host
+// interfaces the class is asserted against. After #2494 removed the
+// `as unknown as Parameters<typeof X>[0]` casts, tsc surfaces missing fields
+// as compile errors — but runtime assertions still catch regressions in
+// fixture-based tests that bypass the class.
+
+const POLLING_HOST_FIELDS = [
+  "nodesPollInterval",
+  "logsPollInterval",
+  "debugPollInterval",
+  "tab",
+] as const;
+
+const CHAT_HOST_FIELDS = [
+  "connected",
+  "chatMessage",
+  "chatAttachments",
+  "chatQueue",
+  "chatRunId",
+  "chatSending",
+  "sessionKey",
+  "basePath",
+  "hello",
+  "chatAvatarUrl",
+  "refreshSessionsAfterChat",
+] as const;
+
+const SCROLL_HOST_FIELDS = [
+  "updateComplete",
+  "querySelector",
+  "style",
+  "chatScrollFrame",
+  "chatScrollTimeout",
+  "chatHasAutoScrolled",
+  "chatUserNearBottom",
+  "chatNewMessagesBelow",
+  "logsScrollFrame",
+  "logsAtBottom",
+  "topbarObserver",
+] as const;
+
+// SettingsHost = PollingHost & ScrollHost & ChatHost plus its own required
+// fields. Listing all non-optional members gives a clear failure message
+// per-field, matching the pattern used for GatewayHost above.
+const SETTINGS_HOST_FIELDS = [
+  ...POLLING_HOST_FIELDS,
+  ...SCROLL_HOST_FIELDS,
+  ...CHAT_HOST_FIELDS,
+  "settings",
+  "theme",
+  "themeResolved",
+  "applySessionKey",
+  "eventLog",
+  "eventLogBuffer",
+  "themeMedia",
+  "themeMediaHandler",
+] as const;
+
+// CompactionHost extends ToolStreamHost with four optional fields
+// (compactionStatus, compactionClearTimer, fallbackStatus, fallbackClearTimer).
+// Only the inherited ToolStreamHost members are required — asserting those
+// via the existing TOOL_STREAM_HOST_FIELDS would duplicate a test, so the
+// CompactionHost-specific case exists to document that the interface was
+// audited and has no non-optional additions.
+const COMPACTION_HOST_REQUIRED_FIELDS = TOOL_STREAM_HOST_FIELDS;
+
 describe("RemoteClawApp instance — host interface compliance", () => {
   it("initializes every required LifecycleHost field", () => {
     const app = createApp();
@@ -101,5 +169,30 @@ describe("RemoteClawApp instance — host interface compliance", () => {
   it("initializes every required ToolStreamHost field", () => {
     const app = createApp();
     assertAllDefined(app, TOOL_STREAM_HOST_FIELDS, "ToolStreamHost");
+  });
+
+  it("initializes every required PollingHost field", () => {
+    const app = createApp();
+    assertAllDefined(app, POLLING_HOST_FIELDS, "PollingHost");
+  });
+
+  it("initializes every required ChatHost field", () => {
+    const app = createApp();
+    assertAllDefined(app, CHAT_HOST_FIELDS, "ChatHost");
+  });
+
+  it("initializes every required ScrollHost field", () => {
+    const app = createApp();
+    assertAllDefined(app, SCROLL_HOST_FIELDS, "ScrollHost");
+  });
+
+  it("initializes every required SettingsHost field", () => {
+    const app = createApp();
+    assertAllDefined(app, SETTINGS_HOST_FIELDS, "SettingsHost");
+  });
+
+  it("initializes every required CompactionHost field", () => {
+    const app = createApp();
+    assertAllDefined(app, COMPACTION_HOST_REQUIRED_FIELDS, "CompactionHost");
   });
 });


### PR DESCRIPTION
## Summary

Extends the host-interface smoke test added in #2495 to cover the five
additional interfaces flagged in #2496 — PollingHost, ChatHost, ScrollHost,
SettingsHost, and CompactionHost. No production code changes.

## Audit result

**All required fields of every audited interface are already present on
`RemoteClawApp`.** The class is structurally compliant — no field
initializers needed restoration.

Verification:

- `./node_modules/.bin/tsgo -p tsconfig.json` exits 0 with zero output on
  the current tree.
- Sanity check: removing `@state() chatMessage = "";` from `app.ts:140`
  triggered 30+ `tsgo` errors including
  `Property 'chatMessage' is missing in type 'RemoteClawApp' but required in type 'ChatHost'`
  across `app-chat.ts` and `app-gateway.node.test.ts` — confirming the
  structural checks enforced after #2494 are active.
- Second sanity check: removing `nodesPollInterval: number | null = null;`
  from `app.ts:312` was caught by the new `PollingHost` + `SettingsHost`
  smoke assertions with clear per-interface labels.

This matches the prediction in #2496's own note:

> If Issue B is merged first, this issue may auto-close (the audit
> becomes "fix the new tsc errors").

#2494 (Issue B) merged first. No tsc errors surfaced. The remaining
deliverable is AC #4 — extending the smoke test for defense-in-depth
against fixture-based regressions (the same motivation as #2495).

## Findings per interface

| Interface | Required fields | Missing on class | Severity |
|-----------|-----------------|------------------|----------|
| PollingHost | 4 | 0 | — |
| ChatHost | 11 | 0 | — |
| ScrollHost | 11 (incl. HTMLElement inherited) | 0 | — |
| SettingsHost | PollingHost ∪ ScrollHost ∪ ChatHost + 8 own required | 0 | — |
| CompactionHost | ToolStreamHost (all 4 own additions are `?:` optional) | 0 | — |

Optional fields excluded from assertions per issue guidance
(cosmetic-severity deferred): `password`, `agentsList`, `agentsSelectedId`,
`agentsPanel`, `pendingGatewayUrl`, `pendingGatewayToken` on `SettingsHost`;
`compactionStatus`, `compactionClearTimer`, `fallbackStatus`,
`fallbackClearTimer` on `CompactionHost`.

## Changes

Only `ui/src/ui/app.smoke.test.ts`:

- Header comment extended to reference #2496's scope expansion.
- Five new `*_HOST_FIELDS` constants: `POLLING_HOST_FIELDS`,
  `CHAT_HOST_FIELDS`, `SCROLL_HOST_FIELDS`, `SETTINGS_HOST_FIELDS`,
  `COMPACTION_HOST_REQUIRED_FIELDS`.
- `SETTINGS_HOST_FIELDS` composed via spread over Polling/Scroll/Chat +
  own required members to mirror the interface's `&` composition.
- `COMPACTION_HOST_REQUIRED_FIELDS` aliases `TOOL_STREAM_HOST_FIELDS` (all
  CompactionHost additions are optional); the separate test case documents
  the explicit audit and guards against future required additions.
- Five new `it(...)` cases following the existing pattern.

Test count: 3 → 8 passing.

## CI gates (local verification)

- `pnpm check` → ✅ (format, tsgo, lint, script lints all clean)
- `pnpm test` → ✅ 7014 pass / 3 skip across 800 files; UI suite 288 pass
  across 17 files
- `pnpm canvas:a2ui:bundle` → ✅ 457 kB chunk generated

## Test plan

- [x] `pnpm tsgo` green
- [x] `pnpm lint` green
- [x] `pnpm format:check` green
- [x] `pnpm check` green (includes all of the above plus script lints)
- [x] `pnpm test` green (full suite, node + ui)
- [x] UI smoke test: 8 tests pass (was 3)
- [x] Sanity-check #1: field removal surfaces via `tsgo` (structural)
- [x] Sanity-check #2: field removal surfaces via new smoke test (runtime)

Closes #2496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)