### PR TITLE
chore(ui): externalize theme-flash IIFE — resolve CSP script-src 'self' block (#2497)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -8,59 +8,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <script>
-      (function () {
-        var THEMES = { claw: 1, knot: 1, dash: 1 };
-        var MODES = { system: 1, light: 1, dark: 1 };
-        var LEGACY = {
-          dark: "claw:dark",
-          light: "claw:light",
-          openknot: "knot:dark",
-          fieldmanual: "dash:dark",
-          clawdash: "dash:light",
-          system: "claw:system",
-        };
-        try {
-          var keys = Object.keys(localStorage);
-          var raw;
-          for (var i = 0; i < keys.length; i++) {
-            if (keys[i].indexOf("remoteclaw.control.settings.v1") === 0) {
-              raw = localStorage.getItem(keys[i]);
-              if (raw) break;
-            }
-          }
-          if (!raw) return;
-          var s = JSON.parse(raw);
-          var t = s && s.theme;
-          var m = s && s.themeMode;
-          if (typeof t !== "string") t = "";
-          if (typeof m !== "string") m = "";
-          var legacy = LEGACY[t];
-          var theme = THEMES[t] ? t : legacy ? legacy.split(":")[0] : "claw";
-          var mode = MODES[m] ? m : legacy ? legacy.split(":")[1] : "system";
-          if (mode === "system") {
-            mode = window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
-          }
-          var resolved =
-            theme === "knot"
-              ? mode === "light"
-                ? "openknot-light"
-                : "openknot"
-              : theme === "dash"
-                ? mode === "light"
-                  ? "dash-light"
-                  : "dash"
-                : mode === "light"
-                  ? "light"
-                  : "dark";
-          document.documentElement.setAttribute("data-theme", resolved);
-          document.documentElement.setAttribute(
-            "data-theme-mode",
-            resolved.indexOf("light") !== -1 ? "light" : "dark",
-          );
-        } catch (e) {}
-      })();
-    </script>
+    <script src="/theme-boot.js"></script>
   </head>
   <body>
     <remoteclaw-app></remoteclaw-app>

--- a/ui/public/theme-boot.js
+++ b/ui/public/theme-boot.js
@@ -1,0 +1,62 @@
+// Theme-flash prevention. Runs synchronously from <head> before the ESM
+// bundle loads, so it sets data-theme on <html> pre-paint. Keep as plain
+// JS served from /public/ — do NOT port to TS or a module.
+(function () {
+  var THEMES = { claw: 1, knot: 1, dash: 1 };
+  var MODES = { system: 1, light: 1, dark: 1 };
+  var LEGACY = {
+    dark: "claw:dark",
+    light: "claw:light",
+    openknot: "knot:dark",
+    fieldmanual: "dash:dark",
+    clawdash: "dash:light",
+    system: "claw:system",
+  };
+  try {
+    var keys = Object.keys(localStorage);
+    var raw;
+    for (var i = 0; i < keys.length; i++) {
+      if (keys[i].indexOf("remoteclaw.control.settings.v1") === 0) {
+        raw = localStorage.getItem(keys[i]);
+        if (raw) {
+          break;
+        }
+      }
+    }
+    if (!raw) {
+      return;
+    }
+    var s = JSON.parse(raw);
+    var t = s && s.theme;
+    var m = s && s.themeMode;
+    if (typeof t !== "string") {
+      t = "";
+    }
+    if (typeof m !== "string") {
+      m = "";
+    }
+    var legacy = LEGACY[t];
+    var theme = THEMES[t] ? t : legacy ? legacy.split(":")[0] : "claw";
+    var mode = MODES[m] ? m : legacy ? legacy.split(":")[1] : "system";
+    if (mode === "system") {
+      mode = window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+    }
+    var resolved =
+      theme === "knot"
+        ? mode === "light"
+          ? "openknot-light"
+          : "openknot"
+        : theme === "dash"
+          ? mode === "light"
+            ? "dash-light"
+            : "dash"
+          : mode === "light"
+            ? "light"
+            : "dark";
+    document.documentElement.setAttribute("data-theme", resolved);
+    document.documentElement.setAttribute(
+      "data-theme-mode",
+      resolved.indexOf("light") !== -1 ? "light" : "dark",
+    );
+  } catch {}
+})();


### PR DESCRIPTION
## Summary

- Move the inline `<script>` at `ui/index.html:11-63` into `ui/public/theme-boot.js`, referenced as `<script src="/theme-boot.js"></script>`.
- Same-origin external file satisfies the gateway CSP `script-src 'self'` (`src/gateway/control-ui-csp.ts:11`), which was blocking the inline script on every page load — resolving a cosmetic theme-flash and a noisy Console warning.
- CSP header untouched. IIFE behavior preserved; script still runs from `<head>` before the bundled ESM module, so `data-theme` is applied pre-paint.

Closes #2497.

## Changes

- `ui/public/theme-boot.js` (new): theme-boot IIFE, plain JS served from `publicDir` (3-line guard comment on top explaining why it intentionally diverges from project defaults — do NOT port to TS or a module).
- `ui/index.html`: inline IIFE replaced by `<script src="/theme-boot.js"></script>`.

## Verification

- [x] `ui/index.html` has no inline `<script>` content.
- [x] Built `dist/control-ui/index.html` has `./theme-boot.js` BEFORE the bundled module (verified pre-paint order preserved).
- [x] CSP `script-src 'self'` unchanged — `git diff origin/main -- src/gateway/control-ui-csp.ts` empty.
- [x] `pnpm --filter remoteclaw-control-ui build` succeeds; `dist/control-ui/theme-boot.js` produced by Vite public-dir copy.
- [x] `pnpm format:check` / `pnpm lint` clean on both files.
- [x] Pre-existing UI test failures (8 files / 18 tests under `ui/src/ui/*`, `ui/src/i18n/*`) verified to fail identically on clean `origin/main` — unrelated to this change.

## Test plan

- [ ] CI green (build + test + lint + docs + fork-integrity gates)
- [ ] Auto-merge enabled via `gh pr merge --auto --squash`