### PR TITLE
fix(ui): migrate app-render.ts to upstream nav-section + topbar class vocabulary (#2501)

### DIFF
--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1,5 +1,6 @@
 @import "./styles/base.css";
 @import "./styles/layout.css";
+@import "./styles/topbar-brand.css";
 @import "./styles/layout.mobile.css";
 @import "./styles/components.css";
 @import "./styles/chat.css";

--- a/ui/src/styles/topbar-brand.css
+++ b/ui/src/styles/topbar-brand.css
@@ -1,0 +1,77 @@
+/* ===========================================
+   Fork-owned: Topbar brand block
+   ===========================================
+   Restores rules for `.topbar-left` / `.brand*` that upstream removed
+   in the v2026.3.13-1 sync (commit 04a7853f0f). Upstream deleted them
+   as part of a dashboard-v2 redesign that does not include a brand
+   block; the fork's topbar still renders REMOTECLAW + Gateway
+   Dashboard, so these rules live in a fork-owned file to stay
+   conflict-free against future syncs of `layout.css`.
+
+   Also defines `.nav-section__label--static` (fork-owned modifier) for
+   the Resources section's non-interactive label.
+*/
+
+.topbar {
+  justify-content: space-between;
+}
+
+.topbar-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.brand-logo {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+}
+
+.brand-logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.brand-title {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+  color: var(--text-strong);
+}
+
+.brand-sub {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--muted);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  line-height: 1;
+}
+
+/* Static (non-clickable) nav section labels — used for the Resources
+   group that has external links instead of in-app tabs. Upstream's
+   `.nav-section__label` is styled as a button; this modifier strips the
+   interactive affordances without duplicating the full rule set. */
+.nav-section__label--static {
+  cursor: default;
+}
+
+.nav-section__label--static:hover {
+  color: color-mix(in srgb, var(--muted) 72%, var(--text) 28%);
+  background: transparent;
+}

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -253,9 +253,9 @@ export function renderApp(state: AppViewState) {
           const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
           const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
           return html`
-            <div class="nav-group ${isGroupCollapsed && !hasActiveTab ? "nav-group--collapsed" : ""}">
+            <div class="nav-section ${isGroupCollapsed && !hasActiveTab ? "nav-section--collapsed" : ""}">
               <button
-                class="nav-label"
+                class="nav-section__label"
                 @click=${() => {
                   const next = { ...state.settings.navGroupsCollapsed };
                   next[group.label] = !isGroupCollapsed;
@@ -266,20 +266,20 @@ export function renderApp(state: AppViewState) {
                 }}
                 aria-expanded=${!isGroupCollapsed}
               >
-                <span class="nav-label__text">${t(`nav.${group.label}`)}</span>
-                <span class="nav-label__chevron">${isGroupCollapsed ? "+" : "−"}</span>
+                <span class="nav-section__label-text">${t(`nav.${group.label}`)}</span>
+                <span class="nav-section__chevron">${icons.chevronDown}</span>
               </button>
-              <div class="nav-group__items">
+              <div class="nav-section__items">
                 ${group.tabs.map((tab) => renderTab(state, tab))}
               </div>
             </div>
           `;
         })}
-        <div class="nav-group nav-group--links">
-          <div class="nav-label nav-label--static">
-            <span class="nav-label__text">${t("common.resources")}</span>
+        <div class="nav-section nav-section--links">
+          <div class="nav-section__label nav-section__label--static">
+            <span class="nav-section__label-text">${t("common.resources")}</span>
           </div>
-          <div class="nav-group__items">
+          <div class="nav-section__items">
             <a
               class="nav-item nav-item--external"
               href="https://docs.remoteclaw.org"


### PR DESCRIPTION
Closes #2501.

## Summary

Sync `04a7853f0f` (v2026.3.13-1) brought upstream's `ui/src/styles/layout.css` wholesale, renaming `.nav-group`/`.nav-label` families to `.nav-section`/`.nav-section__label` and removing `.topbar-left`/`.brand*` entirely as part of a dashboard-v2 refactor. The fork's `ui/src/ui/app-render.ts` was not paired-updated (heavily fork-diverged), so render code emitted classes with no defining CSS rule:

- **Sidebar nav groups** rendered raw `+`/`−` glyphs instead of styled chevrons (CSS expected an SVG child at `.nav-section__chevron svg`).
- **Topbar** lost its flex layout — the REMOTECLAW / Gateway Dashboard brand block collided with the status pills because `.topbar { justify-content: space-between }` was removed alongside `.topbar-left`.

Second confirmed instance (within hours of #2493 post-mortem) of the "definition-site sync without paired call-site update" variant documented in HQ #57.

## Approach

Option 2 from the issue (hybrid): migrate nav to upstream vocabulary; add fork-owned CSS for the brand block that upstream removed without replacement.

- `ui/src/ui/app-render.ts`: migrated `nav-group`/`nav-label` → `nav-section`/`nav-section__label`; replaced text chevron with `icons.chevronDown` SVG (upstream CSS handles collapse rotation via `.nav-section--collapsed .nav-section__chevron { transform: rotate(-90deg) }`); added `nav-section__label--static` modifier for the Resources static label.
- `ui/src/styles/topbar-brand.css` (new, fork-owned): restored the exact pre-sync `.topbar-left` / `.brand` / `.brand-logo` / `.brand-text` / `.brand-title` / `.brand-sub` rules (recovered from `04a7853f0f^:ui/src/styles/layout.css`); restored `.topbar { justify-content: space-between }`; defined `.nav-section__label--static` hover suppression.
- `ui/src/styles.css`: imported `topbar-brand.css` **between** `layout.css` and `layout.mobile.css` so that mobile's `.brand-title` override still takes effect (caught during polish).

Fork-owned CSS file is conflict-free against future upstream syncs of `layout.css`.

## Scope notes

- AC3 (theme toggle `.theme-orb__trigger` migration) is explicitly scoped "if migrating" in the issue. Not migrated in this PR — `app-render.helpers.ts` `renderThemeToggle` still uses `.theme-toggle*` classes which have no CSS rules on `main` (pre-existing regression from the same v2026.3.13-1 sync). Deferred as a follow-up candidate.
- Peer PRs in this wave: #2496 (ui/src/ui/app.ts), #2497 (ui/index.html, ui/public/theme-boot.js) — different files, no conflict.
- Not LIVE-smoke-test triggering: touches `ui/` only, no `src/middleware/` changes.

## Test plan

- [x] `pnpm check` (format:check + tsgo + lint + lint:tmp:no-random-messaging + lint:no-remoteclaw-ai) — all pass
- [x] `pnpm vitest run --config vitest.unit.config.ts ui/src/ui/` — 4 files / 43 tests pass
- [x] `pnpm canvas:a2ui:bundle` — builds clean
- [x] Fork-integrity gates: `check-no-zombie-imports.mjs`, `check-stub-debt.mjs`, `check-throwing-stub-callers.mjs`, `check-rebrand-leakage.sh` — all pass
- [x] Grep for residual `.nav-group|.nav-label|.topbar-left|.brand-text|.brand-sub` in `ui/` — 0 hits outside the intentional new file
- [ ] Visual smoke — load `/overview`, `/chat`, `/agents` in light + dark themes (requires human browser pass)

## References

- Closes #2501
- Same regression class (type/class variant): #2493
- Audit for other instances: #2502
- Build-time CSS drift gate: #2503
- HQ post-mortem: remoteclaw/hq#57 (now 2 confirmed instances)