### PR TITLE
fix(ui): migrate channels.nostr btn-sm reference to btn--sm — cluster 3 (#2510)

### DIFF
--- a/ui/src/ui/views/channels.nostr.ts
+++ b/ui/src/ui/views/channels.nostr.ts
@@ -128,7 +128,7 @@ export function renderNostrCard(params: {
             summaryConfigured
               ? html`
                 <button
-                  class="btn btn-sm"
+                  class="btn btn--sm"
                   @click=${onEditProfile}
                   style="font-size: 12px; padding: 4px 8px;"
                 >


### PR DESCRIPTION
## Summary

- Migrates the lone remaining `.btn-sm` reference in `ui/src/ui/views/channels.nostr.ts:131` to `.btn--sm` (BEM modifier convention).
- Resolves **cluster 3** of the CSS class drift audit (issue #2502) — attributed to upstream commit `21ac4b9a8a` (style(ui) clarity pass, upstream #53272).
- The CSS rule `.btn--sm` is already defined at `ui/src/styles/components.css:625`; all other fork-owned call-sites (app-render, agents, nodes, config, etc.) were already migrated. This was the last remaining holdout.

## Evidence

**Baseline audit** (pre-fix):
- Total orphans: 36 across 3 clusters
- Cluster 3: 1 orphan (`.btn-sm` at `channels.nostr.ts:131`) attributed to `21ac4b9a8a`

**Post-fix audit**:
- Total orphans: **35** across **2 clusters**
- Cluster 3: **eliminated entirely**

Reproduce: `node scripts/audit-css-class-drift.mjs`.

## Diff scope

1 file, 1 line changed — `btn-sm` → `btn--sm` on line 131 only.

## Test plan

- [x] `pnpm check` (format + tsgo + lint + linter guards) — PASS
- [x] `node scripts/audit-css-class-drift.mjs` — cluster 3 absent from report
- [ ] Manual verification in `pnpm dev`: nostr channel settings "Edit Profile" button renders with small-variant styling (deferred to reviewer — pure CSS class rename; structurally equivalent to the 20+ sibling call-sites already using `btn--sm`)

## References

- Parent audit: #2502
- Drift-audit script PR: #2507
- Upstream rename commit: `21ac4b9a8a` (#53272, style(ui) clarity pass)

Closes #2510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)