### PR TITLE
fix(ui): migrate app-render nav + theme-toggle to upstream sidebar + theme-orb — resolve v2026.3.13-1 sync drift (#2509)

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -483,51 +483,102 @@ function countHiddenCronSessions(sessionKey: string, sessions: SessionsListResul
   return sessions.sessions.filter((s) => isCronSessionKey(s.key) && s.key !== sessionKey).length;
 }
 
-const THEME_ORDER: ThemeMode[] = ["system", "light", "dark"];
+type ThemeModeOption = { id: ThemeMode; label: string };
+
+const THEME_MODE_OPTIONS: ThemeModeOption[] = [
+  { id: "system", label: "System" },
+  { id: "light", label: "Light" },
+  { id: "dark", label: "Dark" },
+];
+
+function renderThemeModeIcon(mode: ThemeMode) {
+  if (mode === "light") {
+    return renderSunIcon();
+  }
+  if (mode === "dark") {
+    return renderMoonIcon();
+  }
+  return renderMonitorIcon();
+}
 
 export function renderThemeToggle(state: AppViewState) {
-  const index = Math.max(0, THEME_ORDER.indexOf(state.theme));
-  const applyTheme = (next: ThemeMode) => (event: MouseEvent) => {
-    const element = event.currentTarget as HTMLElement;
+  const setOpen = (orb: HTMLElement, nextOpen: boolean) => {
+    orb.classList.toggle("theme-orb--open", nextOpen);
+    const trigger = orb.querySelector<HTMLButtonElement>(".theme-orb__trigger");
+    const menu = orb.querySelector<HTMLElement>(".theme-orb__menu");
+    if (trigger) {
+      trigger.setAttribute("aria-expanded", nextOpen ? "true" : "false");
+    }
+    if (menu) {
+      menu.setAttribute("aria-hidden", nextOpen ? "false" : "true");
+    }
+  };
+
+  const toggleOpen = (event: MouseEvent) => {
+    const orb = (event.currentTarget as HTMLElement).closest<HTMLElement>(".theme-orb");
+    if (!orb) {
+      return;
+    }
+    const isOpen = orb.classList.contains("theme-orb--open");
+    if (isOpen) {
+      setOpen(orb, false);
+      return;
+    }
+    setOpen(orb, true);
+    const close = (evt: MouseEvent) => {
+      if (!orb.contains(evt.target as Node)) {
+        setOpen(orb, false);
+        document.removeEventListener("click", close);
+      }
+    };
+    requestAnimationFrame(() => document.addEventListener("click", close));
+  };
+
+  const pickMode = (mode: ThemeMode) => (event: MouseEvent) => {
+    const orb = (event.currentTarget as HTMLElement).closest<HTMLElement>(".theme-orb");
+    if (orb) {
+      setOpen(orb, false);
+    }
+    if (mode === state.theme) {
+      return;
+    }
+    const element = orb ?? (event.currentTarget as HTMLElement);
     const context: ThemeTransitionContext = { element };
     if (event.clientX || event.clientY) {
       context.pointerClientX = event.clientX;
       context.pointerClientY = event.clientY;
     }
-    state.setTheme(next, context);
+    state.setTheme(mode, context);
   };
 
   return html`
-    <div class="theme-toggle" style="--theme-index: ${index};">
-      <div class="theme-toggle__track" role="group" aria-label="Theme">
-        <span class="theme-toggle__indicator"></span>
-        <button
-          class="theme-toggle__button ${state.theme === "system" ? "active" : ""}"
-          @click=${applyTheme("system")}
-          aria-pressed=${state.theme === "system"}
-          aria-label="System theme"
-          title="System"
-        >
-          ${renderMonitorIcon()}
-        </button>
-        <button
-          class="theme-toggle__button ${state.theme === "light" ? "active" : ""}"
-          @click=${applyTheme("light")}
-          aria-pressed=${state.theme === "light"}
-          aria-label="Light theme"
-          title="Light"
-        >
-          ${renderSunIcon()}
-        </button>
-        <button
-          class="theme-toggle__button ${state.theme === "dark" ? "active" : ""}"
-          @click=${applyTheme("dark")}
-          aria-pressed=${state.theme === "dark"}
-          aria-label="Dark theme"
-          title="Dark"
-        >
-          ${renderMoonIcon()}
-        </button>
+    <div class="theme-orb" aria-label="Theme">
+      <button
+        type="button"
+        class="theme-orb__trigger"
+        title="Theme"
+        aria-haspopup="menu"
+        aria-expanded="false"
+        @click=${toggleOpen}
+      >
+        ${renderThemeModeIcon(state.theme)}
+      </button>
+      <div class="theme-orb__menu" role="menu" aria-hidden="true">
+        ${THEME_MODE_OPTIONS.map(
+          (opt) => html`
+            <button
+              type="button"
+              class="theme-orb__option ${opt.id === state.theme ? "theme-orb__option--active" : ""}"
+              title=${opt.label}
+              role="menuitemradio"
+              aria-checked=${opt.id === state.theme}
+              aria-label="${opt.label} theme"
+              @click=${pickMode(opt.id)}
+            >
+              ${renderThemeModeIcon(opt.id)}
+            </button>
+          `,
+        )}
       </div>
     </div>
   `;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -248,7 +248,7 @@ export function renderApp(state: AppViewState) {
           ${renderThemeToggle(state)}
         </div>
       </header>
-      <aside class="nav ${state.settings.navCollapsed ? "nav--collapsed" : ""}">
+      <aside class="sidebar ${state.settings.navCollapsed ? "sidebar--collapsed" : ""}">
         ${TAB_GROUPS.map((group) => {
           const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
           const hasActiveTab = group.tabs.some((tab) => tab === state.tab);


### PR DESCRIPTION
## Summary

Cluster 2 of #2502 CSS class drift. The v2026.3.13-1 upstream sync (`04a7853f0f`, #2398) renamed `.nav*` → `.sidebar*` and replaced the `.theme-toggle*` segmented-button with `.theme-orb*` trigger + dropdown. Fork-diverged files missed the paired call-site update; #2501/#2506 covered the `.nav-section` / `.topbar` / `.brand*` subset — this PR covers the residue.

Fixes #2509. Part of the cluster filed by #2502.

## Changes

- **`ui/src/ui/app-render.ts:251`**: `<aside class="nav …nav--collapsed">` → `.sidebar …sidebar--collapsed`. The `.nav` rule was removed upstream; `.sidebar` at `layout.css:324` + `.sidebar--collapsed` at `layout.css:350` (plus 20+ descendant selectors at `layout.css:630-801`) drive the collapsed visual.
- **`ui/src/ui/app-render.helpers.ts`**: replace `renderThemeToggle` segmented-button implementation with theme-orb trigger + dropdown menu pattern mirroring upstream `f76a3c5225`. New helpers: `setOpen` / `toggleOpen` / `pickMode` / `renderThemeModeIcon` / `THEME_MODE_OPTIONS`. Preserves fork's pointer-coord `ThemeTransitionContext` for the ripple theme transition (upstream's `pick` targets skins, not modes — fork needs the fine-grained origin). Keeps local `renderSunIcon` / `renderMoonIcon` / `renderMonitorIcon` helpers (still live via `renderThemeModeIcon`).

### Rename table

| Render code emitted | Upstream CSS now has | Defining line |
|---|---|---|
| `.nav` | `.sidebar` | `layout.css:324` |
| `.nav--collapsed` | `.sidebar--collapsed` | `layout.css:350` |
| `.theme-toggle` | `.theme-orb` | `components.css:391` |
| `.theme-toggle__track` | `.theme-orb__menu` | `components.css:427` |
| `.theme-toggle__indicator` | (removed — orb uses `__option--active` instead) | n/a |
| `.theme-toggle__button` | `.theme-orb__option` | `components.css:455` |
| `.theme-toggle__button.active` | `.theme-orb__option--active` | `components.css:479` |
| (new structural concept) | `.theme-orb__trigger` + `.theme-orb--open` | `components.css:397, 448` |

## Test plan

- [x] `pnpm tsgo` (0 errors)
- [x] `pnpm lint` (0 warnings, 0 errors across 3926 files)
- [x] `pnpm format` — idempotent
- [x] `pnpm canvas:a2ui:bundle` + `pnpm test` (800 test files, 7014 tests passing, 3 pre-existing skips)
- [x] Fork-integrity gates: `check-no-zombie-imports.mjs`, `check-stub-debt.mjs` (126 baseline), `check-throwing-stub-callers.mjs` — all pass
- [x] `node scripts/audit-css-class-drift.mjs`: cluster `04a7853f0f` is gone from the report (orphans 36→31, clusters 3→2); remaining clusters (`0667aa5596`: 21 `config-*`, `21ac4b9a8a`: 1 `.btn-sm`) are out of scope per #2502's per-cluster routing
- [ ] Visual smoke: load `/overview`, `/chat`, `/agents`; toggle sidebar collapse; cycle Light / Dark / System from the theme orb

## Pattern class

Third instance of the definition-site-sync-without-paired-call-site-update variant documented in HQ #57. #2493 (type/class variant) and #2501 (CSS nav-section/topbar/brand subset) were the first two. Build-time gate tracked in #2503; per-cluster routing in #2502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)