### PR TITLE
fix(ui): resolve 9 unresolved CSS class orphans — triage per-orphan (#2511)

### DIFF
--- a/scripts/audit-css-class-drift.mjs
+++ b/scripts/audit-css-class-drift.mjs
@@ -238,14 +238,12 @@ function extractClassReferences(src, relPath, refs) {
     }
     // Template-literal form `class=${\`...\`}` — extract STATIC fragments of
     // the template (the ${...} interpolations inside are dynamic, out of
-    // scope). This mirrors how class="a ${x} b" handles static fragments.
+    // scope). This mirrors how class="a ${x} b" handles static fragments,
+    // including the adjacency rule that drops partial tokens touching an
+    // interpolation without separating whitespace.
     const templateFragments = matchSingleTemplateLiteralFragments(expr);
     if (templateFragments !== null) {
-      for (const frag of templateFragments) {
-        for (const t of tokenize(frag)) {
-          recordRef(refs, t, relPath, lineNo);
-        }
-      }
+      emitFragmentTokens(templateFragments, relPath, lineNo, refs);
     }
   }
 }
@@ -414,26 +412,76 @@ function skipTemplateLiteral(src, start) {
  * interpolations is scope-out per #2502 — the issue explicitly flags
  * dynamic class composition as too noisy for the first pass.
  *
- * Interpolation removal is brace-and-string-aware (not a naive regex)
+ * Interpolation splitting is brace-and-string-aware (not a naive regex)
  * so nested `${...}`, string literals containing `}`, and interpolations
  * inside template literals all skip correctly.
+ *
+ * Adjacency rule: a static fragment that touches an interpolation with no
+ * separating whitespace contributes a PARTIAL class name at the boundary
+ * (e.g. `class="language-${lang}"` — the static `language-` is a prefix,
+ * not a standalone class). Drop the adjacent boundary token so the audit
+ * does not report `.language-` as an orphan.
  */
 function addTokensFromLitClass(value, file, lineNo, refs) {
-  let stripped = "";
+  emitFragmentTokens(splitStaticFragments(value), file, lineNo, refs);
+}
+
+/**
+ * Emit class tokens from a sequence of static fragments (as produced by
+ * splitting around `${...}` interpolations), applying the adjacency rule:
+ * a boundary token on either end of a fragment is dropped when the
+ * fragment touches an interpolation without separating whitespace, because
+ * in that position the static text is a prefix/suffix of a dynamically
+ * composed class, not a standalone reference.
+ */
+function emitFragmentTokens(fragments, file, lineNo, refs) {
+  for (let f = 0; f < fragments.length; f += 1) {
+    const fragment = fragments[f];
+    const precededByInterp = f > 0;
+    const followedByInterp = f < fragments.length - 1;
+    const startsWithSpace = /^\s/.test(fragment);
+    const endsWithSpace = /\s$/.test(fragment);
+    const tokens = tokenize(fragment);
+    if (tokens.length === 0) {
+      continue;
+    }
+    let start = 0;
+    let end = tokens.length;
+    if (precededByInterp && !startsWithSpace) {
+      start += 1;
+    }
+    if (followedByInterp && !endsWithSpace) {
+      end -= 1;
+    }
+    for (let t = start; t < end; t += 1) {
+      recordRef(refs, tokens[t], file, lineNo);
+    }
+  }
+}
+
+/**
+ * Split a class-attribute value into the static fragments between its
+ * `${...}` interpolations, preserving each fragment verbatim so adjacency
+ * to an interpolation (no separating whitespace) can be detected. Returns
+ * an array with at least one entry; interpolations themselves are dropped.
+ */
+function splitStaticFragments(value) {
+  const fragments = [];
+  let current = "";
   let i = 0;
   while (i < value.length) {
     if (value[i] === "$" && value[i + 1] === "{") {
+      fragments.push(current);
+      current = "";
       const end = scanExpression(value, i + 2);
       i = end === -1 ? value.length : end;
-      stripped += " ";
       continue;
     }
-    stripped += value[i];
+    current += value[i];
     i += 1;
   }
-  for (const t of tokenize(stripped)) {
-    recordRef(refs, t, file, lineNo);
-  }
+  fragments.push(current);
+  return fragments;
 }
 
 function tokenize(value) {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -275,13 +275,13 @@ export function renderApp(state: AppViewState) {
             </div>
           `;
         })}
-        <div class="nav-section nav-section--links">
+        <div class="nav-section">
           <div class="nav-section__label nav-section__label--static">
             <span class="nav-section__label-text">${t("common.resources")}</span>
           </div>
           <div class="nav-section__items">
             <a
-              class="nav-item nav-item--external"
+              class="nav-item"
               href="https://docs.remoteclaw.org"
               target=${EXTERNAL_LINK_TARGET}
               rel=${buildExternalLinkRel()}

--- a/ui/src/ui/views/channels.nostr-profile-form.ts
+++ b/ui/src/ui/views/channels.nostr-profile-form.ts
@@ -91,7 +91,7 @@ export function renderNostrProfileForm(params: {
 
     if (type === "textarea") {
       return html`
-        <div class="form-field" style="margin-bottom: 12px;">
+        <div style="margin-bottom: 12px;">
           <label for="${inputId}" style="display: block; margin-bottom: 4px; font-weight: 500;">
             ${label}
           </label>
@@ -115,7 +115,7 @@ export function renderNostrProfileForm(params: {
     }
 
     return html`
-      <div class="form-field" style="margin-bottom: 12px;">
+      <div style="margin-bottom: 12px;">
         <label for="${inputId}" style="display: block; margin-bottom: 4px; font-weight: 500;">
           ${label}
         </label>
@@ -164,7 +164,7 @@ export function renderNostrProfileForm(params: {
   };
 
   return html`
-    <div class="nostr-profile-form" style="padding: 16px; background: var(--bg-secondary); border-radius: 8px; margin-top: 12px;">
+    <div style="padding: 16px; background: var(--bg-secondary); border-radius: 8px; margin-top: 12px;">
       <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
         <div style="font-weight: 600; font-size: 16px;">Edit Profile</div>
         <div style="font-size: 12px; color: var(--text-muted);">Account: ${accountId}</div>

--- a/ui/src/ui/views/channels.nostr.ts
+++ b/ui/src/ui/views/channels.nostr.ts
@@ -75,7 +75,7 @@ export function renderNostrCard(params: {
           </div>
           <div>
             <span class="label">Public Key</span>
-            <span class="monospace" title="${publicKey ?? ""}">${truncatePubkey(publicKey)}</span>
+            <span class="mono" title="${publicKey ?? ""}">${truncatePubkey(publicKey)}</span>
           </div>
           <div>
             <span class="label">Last inbound</span>
@@ -207,7 +207,7 @@ export function renderNostrCard(params: {
               </div>
               <div>
                 <span class="label">Public Key</span>
-                <span class="monospace" title="${summaryPublicKey ?? ""}"
+                <span class="mono" title="${summaryPublicKey ?? ""}"
                   >${truncatePubkey(summaryPublicKey)}</span
                 >
               </div>

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -1723,8 +1723,8 @@ function renderRun(entry: CronRunLogEntry, basePath: string) {
         : null;
   return html`
     <div class="list-item cron-run-entry">
-      <div class="list-main cron-run-entry__main">
-        <div class="list-title cron-run-entry__title">
+      <div class="list-main">
+        <div class="list-title">
           ${entry.jobName ?? entry.jobId}
           <span class="muted"> · ${status}</span>
         </div>

--- a/ui/src/ui/views/debug.ts
+++ b/ui/src/ui/views/debug.ts
@@ -125,7 +125,7 @@ export function renderDebug(props: DebugProps) {
               <div class="muted" style="margin-top: 12px">No events yet.</div>
             `
           : html`
-            <div class="list debug-event-log" style="margin-top: 12px;">
+            <div class="list" style="margin-top: 12px;">
               ${props.eventLog.map(
                 (evt) => html`
                   <div class="list-item debug-event-log__item">


### PR DESCRIPTION
Closes #2511. Part of the unresolved bucket from #2502's CSS class drift audit (complement to Wave 1: #2512 / #2513 / #2514).

## Summary

Per-orphan triage of the 9 orphans with no CSS-history removing-commit. Each required individual investigation because the dispositions span different bug classes — BEM hooks added without CSS, fork-owned hooks superseded by inline styles, near-miss typos, and one audit false positive.

## Per-orphan dispositions

| # | Class | Callsite(s) | Disposition | Rationale |
|---|---|---|---|---|
| 1 | `.cron-run-entry__main` | `views/cron.ts:1726` | REMOVE | `.list-main` (components.css:1440) handles all styling; siblings `__summary` / `__meta` keep their CSS-backed hooks |
| 2 | `.cron-run-entry__title` | `views/cron.ts:1727` | REMOVE | `.list-title` (components.css:1446) handles styling; same pattern as #1 |
| 3 | `.debug-event-log` | `views/debug.ts:128` | REMOVE | `.list` (components.css:1409) handles container CSS; children `__item` / `__meta` / `__payload` keep their CSS-backed hooks |
| 4 | `.form-field` | `views/channels.nostr-profile-form.ts:94, :118` | REMOVE | Element uses inline `style="margin-bottom: 12px"`; class is a pure hook with no CSS rule and no JS/test references |
| 5 | `.language-` | `markdown.ts:187` | SCOPE-OUT | Audit false positive from `` `class="language-${escapeHtml(lang)}"` ``; fixed at the tokenizer level (see audit script change below) |
| 6 | `.monospace` | `views/channels.nostr.ts:78, :210` | RENAME to `.mono` | `.mono` utility exists at `components.css:1187` (`font-family: var(--mono)`); fork markup picked a near-miss name |
| 7 | `.nav-item--external` | `app-render.ts:284` | REMOVE | Fork-added modifier never CSS-defined; external-link semantics fully via `target=${EXTERNAL_LINK_TARGET}` + `rel=${buildExternalLinkRel()}` |
| 8 | `.nav-section--links` | `app-render.ts:278` | REMOVE | Fork-added modifier never CSS-defined; `.nav-section` parent handles all styling |
| 9 | `.nostr-profile-form` | `views/channels.nostr-profile-form.ts:167` | REMOVE | Container hook on a form using inline styles; same pattern as #4 |

Result: 7 REMOVE, 1 RENAME, 1 SCOPE-OUT (via script fix).

## Audit script adjacency fix

`.language-` isn't a real orphan — it's a static prefix to a dynamic interpolation (``class="language-${escapeHtml(lang)}"``) that the original tokenizer captured as a standalone class name because it replaced `${...}` with a space before splitting on whitespace.

Fixed by introducing an adjacency rule in the tokenizer: a static fragment that touches an interpolation without separating whitespace contributes a PARTIAL class name at the boundary, which is dropped.

- New helper `splitStaticFragments` preserves each static fragment verbatim so adjacency can be detected.
- New helper `emitFragmentTokens` applies the adjacency rule uniformly, called from both `addTokensFromLitClass` (for `class="…"`) and the template-literal path (for ``class=${`…`}``) — previously the two paths had divergent tokenization.
- Scope verified: grep confirmed `markdown.ts:187` is the ONLY callsite in `ui/src/` using the class-prefix + adjacency pattern (`class="[a-zA-Z0-9_-]+${`). Template-literal forms (`chip ${x} chip-ok`, `cron-job-status-pill ${x}`) all use whitespace-separated static tokens, unaffected by the change.

## Caller-context note

The caller suggested `.nav-item--external` might want to rename to `.sidebar-item--external` for consistency with #2509's `.nav` → `.sidebar` rename. Investigation found that Wave 1 renamed only the container (`.nav` → `.sidebar`); the `.nav-section` / `.nav-item` vocabulary is stable upstream, and `.sidebar-section` / `.sidebar-item` do not exist. So the REMOVE disposition stands — the modifier was never CSS-defined regardless of container vocabulary.

## Closes #2502 unresolved bucket

With this PR merged, the audit runs clean (0 orphans) on main. The remaining drift sources (inverse direction: CSS rules defined but unused — e.g. upstream-inherited `.nav-item__external-icon`) are a separate category and out of scope here.

## Test plan

- [x] `pnpm format:check` — PASS (5110 files)
- [x] `pnpm tsgo` — PASS (exit 0, no errors)
- [x] `pnpm lint` — PASS (0 warnings, 0 errors, 3926 files)
- [x] `pnpm check` (format + tsgo + lint + lint:tmp:no-random-messaging + lint:no-remoteclaw-ai) — PASS
- [x] `pnpm canvas:a2ui:bundle` — PASS (457.15 kB, 53 ms)
- [x] `pnpm vitest run --config vitest.unit.config.ts ui/src/ui/` — PASS (4 files, 43 tests)
- [x] Fork-integrity gates: `check-no-zombie-imports.mjs`, `check-stub-debt.mjs` (126 baseline), `check-throwing-stub-callers.mjs` — all pass
- [x] `node scripts/audit-css-class-drift.mjs` — orphans 9 → 0, references 412 → 403
- [x] Adversarial: with script change stashed and markup changes applied, orphan count is 1 (just `.language-`), confirming the script fix is load-bearing for AC2
- [ ] Visual smoke (requires human browser pass): cron run log entries, debug event log, nostr profile form, nostr account card public-key rows, sidebar "Resources → Docs" link — all should render unchanged

## References

- Parent audit: #2502
- Wave 1 siblings: #2512 (cluster 3 `.btn-sm`), #2513 (cluster 1 config sidebar), #2514 (cluster 2 app-render nav+theme-toggle)
- Pattern post-mortem: `remoteclaw/hq#57`

🤖 Generated with [Claude Code](https://claude.com/claude-code)