### PR TITLE
fix(ui): restore shell-nav + sidebar-shell wrappers (#2517)

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -248,51 +248,59 @@ export function renderApp(state: AppViewState) {
           ${renderThemeToggle(state)}
         </div>
       </header>
-      <aside class="sidebar ${state.settings.navCollapsed ? "sidebar--collapsed" : ""}">
-        ${TAB_GROUPS.map((group) => {
-          const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
-          const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
-          return html`
-            <div class="nav-section ${isGroupCollapsed && !hasActiveTab ? "nav-section--collapsed" : ""}">
-              <button
-                class="nav-section__label"
-                @click=${() => {
-                  const next = { ...state.settings.navGroupsCollapsed };
-                  next[group.label] = !isGroupCollapsed;
-                  state.applySettings({
-                    ...state.settings,
-                    navGroupsCollapsed: next,
-                  });
-                }}
-                aria-expanded=${!isGroupCollapsed}
-              >
-                <span class="nav-section__label-text">${t(`nav.${group.label}`)}</span>
-                <span class="nav-section__chevron">${icons.chevronDown}</span>
-              </button>
-              <div class="nav-section__items">
-                ${group.tabs.map((tab) => renderTab(state, tab))}
-              </div>
+      <div class="shell-nav">
+        <aside class="sidebar ${state.settings.navCollapsed ? "sidebar--collapsed" : ""}">
+          <div class="sidebar-shell">
+            <div class="sidebar-shell__body">
+              <nav class="sidebar-nav">
+                ${TAB_GROUPS.map((group) => {
+                  const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
+                  const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
+                  return html`
+                    <div class="nav-section ${isGroupCollapsed && !hasActiveTab ? "nav-section--collapsed" : ""}">
+                      <button
+                        class="nav-section__label"
+                        @click=${() => {
+                          const next = { ...state.settings.navGroupsCollapsed };
+                          next[group.label] = !isGroupCollapsed;
+                          state.applySettings({
+                            ...state.settings,
+                            navGroupsCollapsed: next,
+                          });
+                        }}
+                        aria-expanded=${!isGroupCollapsed}
+                      >
+                        <span class="nav-section__label-text">${t(`nav.${group.label}`)}</span>
+                        <span class="nav-section__chevron">${icons.chevronDown}</span>
+                      </button>
+                      <div class="nav-section__items">
+                        ${group.tabs.map((tab) => renderTab(state, tab))}
+                      </div>
+                    </div>
+                  `;
+                })}
+                <div class="nav-section">
+                  <div class="nav-section__label nav-section__label--static">
+                    <span class="nav-section__label-text">${t("common.resources")}</span>
+                  </div>
+                  <div class="nav-section__items">
+                    <a
+                      class="nav-item"
+                      href="https://docs.remoteclaw.org"
+                      target=${EXTERNAL_LINK_TARGET}
+                      rel=${buildExternalLinkRel()}
+                      title="${t("common.docs")} (opens in new tab)"
+                    >
+                      <span class="nav-item__icon" aria-hidden="true">${icons.book}</span>
+                      <span class="nav-item__text">${t("common.docs")}</span>
+                    </a>
+                  </div>
+                </div>
+              </nav>
             </div>
-          `;
-        })}
-        <div class="nav-section">
-          <div class="nav-section__label nav-section__label--static">
-            <span class="nav-section__label-text">${t("common.resources")}</span>
           </div>
-          <div class="nav-section__items">
-            <a
-              class="nav-item"
-              href="https://docs.remoteclaw.org"
-              target=${EXTERNAL_LINK_TARGET}
-              rel=${buildExternalLinkRel()}
-              title="${t("common.docs")} (opens in new tab)"
-            >
-              <span class="nav-item__icon" aria-hidden="true">${icons.book}</span>
-              <span class="nav-item__text">${t("common.docs")}</span>
-            </a>
-          </div>
-        </div>
-      </aside>
+        </aside>
+      </div>
       <main class="content ${isChat ? "content--chat" : ""}">
         ${
           availableUpdate


### PR DESCRIPTION
## Summary

- Restore upstream-expected markup hierarchy around `<aside class="sidebar">` in `ui/src/ui/app-render.ts` to fix sidebar clipping on deployed builds after #2501 / #2509 migrations adopted CSS class names but not markup structure.
- Wraps `<aside>` in `<div class="shell-nav">` and restructures contents as `<div class="sidebar-shell"><div class="sidebar-shell__body"><nav class="sidebar-nav">...</nav></div></div>`.
- No CSS changes — all target rules already exist in `ui/src/styles/layout.css`.

## Rationale

Before the fix, `.sidebar`'s `flex: 1` had no flex parent (missing `.shell-nav`) and `.sidebar-nav`'s `overflow-y: auto` was absent, so `<aside class="sidebar">` was auto-placed into the wrong CSS grid cell and nav-sections were clipped by `overflow: hidden` — only the CHAT group header was visible. Topbar-right (Health/Version pills, theme toggle) and chat panel content were also missing as side-effects of the broken grid occupancy.

CSS rules (`.shell-nav` @ layout.css:311, `.sidebar-shell` @ :338, `.sidebar-shell__body` @ :370, `.sidebar-nav` @ :423) were already present in the repo — only the render markup was out of sync.

## Design notes

Minimum-viable fix. Optional upstream improvements explicitly deferred:

- Moving brand + nav-collapse-toggle into `.sidebar-shell__header` — non-minimal, out of scope for regression fix.
- `<section>` semantic swap for `<div class="nav-section">` — optional per issue body.
- `.nav-section--links` modifier on Resources section — REJECTED: class has no CSS rule in the repo and would fail the #2503 css-class-drift gate.

## Test plan

- [x] `pnpm tsgo`: clean (no output)
- [x] `pnpm check`: pass — format:check 5110 files OK, oxlint 0 warnings / 0 errors on 3926 files, css-class-drift 0 orphans / 0 clusters (all new wrapper classes resolve to layout.css rules)
- [x] `pnpm canvas:a2ui:bundle`: built successfully
- [x] `pnpm test`: 7014 passed / 3 skipped / 0 failed across 800 test files
- [ ] Visual smoke on deployed: load /chat, /overview, /agents in light + dark themes — full sidebar visible with all 4 groups (Chat / Control / Agent / Settings) + Resources; topbar-right pills and chat panel render correctly

Fixes #2517

🤖 Generated with [Claude Code](https://claude.com/claude-code)