### PR TITLE
test(ui): computed-style smoke test — assert rendered DOM layout catches #2517-class regressions (#2519)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,31 @@ jobs:
           REMOTECLAW_TEST_WORKERS: 1
           REMOTECLAW_TEST_MAX_OLD_SPACE_SIZE_MB: 1536
 
+  test-ui-smoke:
+    # Browser-mode smoke lane for the RemoteClawApp host class. Scoped to
+    # the two sync-regression defense-in-depth suites — class-instance
+    # presence (#2495 / #2496) and computed-style layout (#2519). Kept
+    # separate from `pnpm test` because (a) browser-mode needs a real
+    # browser binary and (b) the rest of `ui/**/*.test.ts` has out-of-scope
+    # failures tracked separately from the sync-regression class.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Install Playwright Chromium
+        run: pnpm --dir ui exec playwright install --with-deps chromium
+
+      - name: UI smoke tests (browser-mode)
+        run: pnpm test:ui:smoke
+
   CI:
     if: always()
     needs:
@@ -179,12 +204,13 @@ jobs:
         lint,
         build,
         test,
+        test-ui-smoke,
       ]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.rebrand-gate.result }}" != "success" || "${{ needs.zombie-import-gate.result }}" != "success" || "${{ needs.stub-debt-gate.result }}" != "success" || "${{ needs.throwing-stub-callers-gate.result }}" != "success" || "${{ needs.obsolescence-audit-gate.result }}" != "success" || "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.test.result }}" != "success" ]]; then
+          if [[ "${{ needs.rebrand-gate.result }}" != "success" || "${{ needs.zombie-import-gate.result }}" != "success" || "${{ needs.stub-debt-gate.result }}" != "success" || "${{ needs.throwing-stub-callers-gate.result }}" != "success" || "${{ needs.obsolescence-audit-gate.result }}" != "success" || "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.test.result }}" != "success" || "${{ needs.test-ui-smoke.result }}" != "success" ]]; then
             echo "::error::One or more required jobs failed"
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,12 +109,37 @@ type(scope): imperative description (#issue)
   `vitest.gateway.config.ts`, `vitest.live.config.ts`
 - **CI env vars**: `REMOTECLAW_TEST_WORKERS=2`, `REMOTECLAW_TEST_MAX_OLD_SPACE_SIZE_MB=4096`
 
+### Browser-mode smoke tests
+
+`ui/src/ui/app.smoke.test.ts` (#2495, #2496) and `ui/src/ui/app.computed-style.test.ts`
+(#2519) form a defense-in-depth lane against the sync-regression class —
+production class drifts from fork-side markup/CSS contracts after an
+upstream migration. They run in real Chromium via
+`@vitest/browser-playwright` with `ui/vitest.config.ts`. The class-instance
+suite asserts every required host-interface field is initialized on the
+`RemoteClawApp` instance. The computed-style suite mounts the app, forces
+a desktop viewport (`page.viewport(1280, 720)` from `vitest/browser`),
+waits for layout (`updateComplete` + double `requestAnimationFrame`),
+and asserts `getBoundingClientRect` dimensions —
+catching "production renders but layout is broken" regressions like #2517.
+
+- **Run locally**: `pnpm test:ui:smoke` (root) or
+  `pnpm --dir ui exec vitest run --config vitest.config.ts src/ui/app.smoke.test.ts src/ui/app.computed-style.test.ts`
+- **CI**: scoped `test-ui-smoke` job; installs Chromium via
+  `pnpm --dir ui exec playwright install --with-deps chromium`
+- **Scope discipline**: scoped to the two smoke suites specifically —
+  other `ui/**/*.test.ts` suites are NOT run by this lane. `pnpm test:ui`
+  (the broader UI lane) is not in CI and has pre-existing failures
+  unrelated to the sync-regression class
+
 ## CI
 
 GitHub Actions (`.github/workflows/ci.yml`):
 - **build** job: checkout, setup Node env, `pnpm build`
 - **test** job: checkout, setup Node env, canvas bundle, `pnpm test`
-- Both run on `ubuntu-latest` with Node 22 and pnpm 10.23.0
+- **test-ui-smoke** job: browser-mode RemoteClawApp smoke lane (see
+  § Testing → Browser-mode smoke tests)
+- Jobs run on `ubuntu-latest` with Node 22 and pnpm 10.23.0
 - Branch protection requires `build`, `test`, `lint`, and `docs` to pass
 
 ### Fork-integrity gates

--- a/package.json
+++ b/package.json
@@ -312,6 +312,7 @@
     "test:live": "REMOTECLAW_LIVE_TEST=1 vitest run --config vitest.live.config.ts",
     "test:macmini": "REMOTECLAW_TEST_VM_FORKS=0 REMOTECLAW_TEST_PROFILE=serial node scripts/test-parallel.mjs",
     "test:ui": "pnpm lint:ui:no-raw-window-open && pnpm --dir ui test",
+    "test:ui:smoke": "pnpm --dir ui exec vitest run --config vitest.config.ts src/ui/app.smoke.test.ts src/ui/app.computed-style.test.ts",
     "test:voicecall:closedloop": "vitest run extensions/voice-call/src/manager.test.ts extensions/voice-call/src/media-stream.test.ts src/plugins/voice-call.plugin.test.ts --maxWorkers=1",
     "test:watch": "vitest",
     "tui": "node scripts/run-node.mjs tui",

--- a/ui/src/ui/app.computed-style.test.ts
+++ b/ui/src/ui/app.computed-style.test.ts
@@ -1,0 +1,121 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { page } from "vitest/browser";
+import "../styles.css";
+import type { RemoteClawApp } from "./app.ts";
+import { mountApp, registerAppMountHooks } from "./test-helpers/app-mount.ts";
+
+// Computed-style smoke tests: defense-in-depth against the regression class
+// demonstrated by #2517 — the production class is defined and renders, but
+// structural wrappers are missing so the shell grid places the sidebar in
+// the wrong cell, causing nav content to escape the visible area. The
+// class-instance smoke tests (#2495 / #2496 in app.smoke.test.ts) assert
+// every required field is initialized; these tests assert the rendered DOM
+// has the expected layout dimensions on key structural elements.
+//
+// Runs in browser-mode Vitest (ui/vitest.config.ts via
+// @vitest/browser-playwright) — real CSS is applied and
+// getBoundingClientRect returns real layout values. The default test
+// viewport is mobile-portrait (414x896), which triggers mobile breakpoints
+// (@media max-width: 1100px) that hide the sidebar. These tests run at a
+// desktop viewport so the #2517 regression class — which manifests only
+// when the desktop grid layout applies — is observable.
+
+const DESKTOP_WIDTH = 1280;
+const DESKTOP_HEIGHT = 720;
+
+registerAppMountHooks();
+
+beforeAll(async () => {
+  await page.viewport(DESKTOP_WIDTH, DESKTOP_HEIGHT);
+});
+
+async function waitForLayout(app: RemoteClawApp): Promise<void> {
+  await app.updateComplete;
+  // Two rAFs: first for Lit commit, second for layout flush after style apply.
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+describe("RemoteClawApp — computed-style smoke", () => {
+  it("sidebar fits within viewport (not expanded beyond grid cell)", async () => {
+    const app = mountApp("/chat");
+    await waitForLayout(app);
+
+    const sidebar = app.querySelector(".sidebar");
+    expect(sidebar, ".sidebar not found in rendered DOM").not.toBeNull();
+
+    const rect = sidebar!.getBoundingClientRect();
+    // The shell grid should constrain the sidebar to the viewport height
+    // (minus the topbar). Without the `.shell-nav` wrapper and internal
+    // `.sidebar-shell` / `.sidebar-nav` structure (#2517 regression shape),
+    // the sidebar lands outside its named grid-area and expands to fit all
+    // nav content — producing a height far larger than the viewport.
+    expect(rect.height, "sidebar must fit within the viewport").toBeLessThanOrEqual(
+      window.innerHeight,
+    );
+    expect(rect.height, "sidebar collapsed to zero height").toBeGreaterThan(300);
+    expect(rect.width, "sidebar collapsed to zero width").toBeGreaterThan(0);
+  });
+
+  it("topbar-status renders with non-zero width", async () => {
+    const app = mountApp("/chat");
+    await waitForLayout(app);
+
+    const status = app.querySelector(".topbar-status");
+    expect(status, ".topbar-status not found in rendered DOM").not.toBeNull();
+    expect(
+      status!.getBoundingClientRect().width,
+      ".topbar-status collapsed to zero width",
+    ).toBeGreaterThan(0);
+  });
+
+  it("all nav-section group headers are visible inside the sidebar", async () => {
+    const app = mountApp("/chat");
+    await waitForLayout(app);
+
+    const sidebar = app.querySelector(".sidebar");
+    expect(sidebar, ".sidebar not found in rendered DOM").not.toBeNull();
+    const sidebarRect = sidebar!.getBoundingClientRect();
+
+    const groups = app.querySelectorAll(".nav-section");
+    // TAB_GROUPS (chat/control/agent/settings = 4) + resources static = 5.
+    expect(groups.length, "unexpected .nav-section count").toBeGreaterThanOrEqual(4);
+
+    for (const group of groups) {
+      const rect = group.getBoundingClientRect();
+      expect(rect.height, ".nav-section clipped to zero height").toBeGreaterThan(0);
+      // Group HEADER must be within sidebar bounds — catches the #2517 shape
+      // where nav-sections escape to negative `top` coordinates because the
+      // sidebar landed in the wrong grid cell. 1px tolerance accommodates
+      // subpixel layout rounding in different browser versions.
+      const headerLabel = group.querySelector(".nav-section__label");
+      if (headerLabel) {
+        const headerRect = headerLabel.getBoundingClientRect();
+        expect(
+          headerRect.top,
+          ".nav-section header positioned above sidebar (sidebar in wrong grid cell?)",
+        ).toBeGreaterThanOrEqual(sidebarRect.top - 1);
+        expect(
+          headerRect.top,
+          ".nav-section header positioned below sidebar (sidebar height wrong?)",
+        ).toBeLessThanOrEqual(sidebarRect.bottom + 1);
+      }
+    }
+  });
+
+  it("chat panel renders with non-zero area on chat tab", async () => {
+    const app = mountApp("/chat");
+    await waitForLayout(app);
+
+    const chat = app.querySelector("section.chat");
+    expect(chat, "section.chat not found on chat tab").not.toBeNull();
+
+    const rect = chat!.getBoundingClientRect();
+    // Conservative thresholds: `mountApp` no-ops the WebSocket connect, so the
+    // chat renders in its disconnected state (smaller than a live-connected
+    // view). 50px catches "zero-height / not rendered" regressions while
+    // remaining robust across viewports and connection states.
+    expect(rect.height, "chat panel has zero height").toBeGreaterThan(50);
+    expect(rect.width, "chat panel has zero width").toBeGreaterThan(50);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ui/src/ui/app.computed-style.test.ts` — browser-mode smoke suite that mounts `<remoteclaw-app>` at a desktop viewport (1280×720), waits for layout, and asserts `getBoundingClientRect` on `.sidebar` / `.topbar-status` / `.nav-section` / `section.chat`. Catches the **#2517 regression class** (production class renders but structural wrappers are missing → sidebar lands in the wrong grid cell → nav content escapes visible area).
- Wires a dedicated `test-ui-smoke` CI job (scoped to the two sync-regression smoke suites) + `pnpm test:ui:smoke` root script + CLAUDE.md `§ Testing → Browser-mode smoke tests`.
- Complements `app.smoke.test.ts` (#2495 / #2496): the class-instance suite proves fields are initialized; the computed-style suite proves they end up positioned correctly.

Closes #2519.

## Acceptance criteria

- [x] **New test file** at `ui/src/ui/app.computed-style.test.ts`
- [x] **Tests run via** dedicated `pnpm test:ui:smoke` script (the AC's "or a dedicated `pnpm test:browser`" alternative — root-level script, CI job uses same)
- [x] **All 4 example assertions pass on a healthy build** (4 tests, 2.09s locally)
- [x] **Re-introducing the #2517 regression makes the sidebar-height test FAIL** — empirically verified in development: removing the `.shell-nav` / `.sidebar-shell` / `.sidebar-nav` wrapper hierarchy produces `expected 52 to be greater than 300` (sidebar) AND `expected 90.31 to be less than or equal to 53.31` (nav-section header position). Double-barrel regression catch.
- [x] **CI runs the browser-mode tests on PRs** — new `test-ui-smoke` job, installs Chromium via `pnpm --dir ui exec playwright install --with-deps chromium`, wired into `CI` aggregator `needs`
- [x] **Documented in CLAUDE.md** — new `§ Testing → Browser-mode smoke tests` subsection + CI section entry
- [x] **Test runtime overhead < 30s on CI** — 2.64s locally for both smoke suites combined; CI adds one-shot Chromium install

## Design notes

- **Desktop viewport is essential.** The default browser-mode viewport is mobile-portrait (414×896), which triggers `@media max-width: 1100px` and hides the sidebar. The suite forces `page.viewport(1280, 720)` in `beforeAll` via `vitest/browser`.
- **Explicit `../styles.css` import.** Matches `navigation.browser.test.ts`. Without it, CSS grid doesn't apply and assertions are meaningless.
- **Uses `mountApp` helper** rather than the issue's literal `document.createElement`+`innerHTML` — consistent with `chat-markdown.browser.test.ts` / `navigation.browser.test.ts` and benefits from `registerAppMountHooks` cleanup.
- **Assertions check layout outcomes, not wrapper existence** — robust to intentional refactors that preserve the grid contract.

## Scope discipline

The `test-ui-smoke` CI lane runs only `app.smoke.test.ts` + `app.computed-style.test.ts`. The broader `pnpm test:ui` has unrelated pre-existing failures (`cron.test.ts`, `sessions.test.ts`, `verbose=full` selector tests) that are out of scope for #2519 — documented in CLAUDE.md.

## Test plan

- [x] `pnpm test:ui:smoke` → 2 suites, 12 tests, pass in ~2.6s
- [x] `pnpm check` → format + typecheck + lint + CSS class drift audit pass
- [x] #2517 regression re-introduction → two assertion failures with clear messages
- [ ] CI `test-ui-smoke` job green on this PR
- [ ] CI `CI` aggregator green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)