### PR TITLE
gut(ui): remove dead Tools tab from Agents view (#2520)

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -587,9 +587,6 @@ export function renderApp(state: AppViewState) {
                   state.agentFileContents = {};
                   state.agentFileDrafts = {};
                   void loadAgentIdentity(state, agentId);
-                  if (state.agentsPanel === "tools") {
-                    void loadToolsCatalog(state, agentId);
-                  }
                   if (state.agentsPanel === "files") {
                     void loadAgentFiles(state, agentId);
                   }
@@ -605,9 +602,6 @@ export function renderApp(state: AppViewState) {
                       state.agentFileDrafts = {};
                       void loadAgentFiles(state, resolvedAgentId);
                     }
-                  }
-                  if (panel === "tools") {
-                    void loadToolsCatalog(state, resolvedAgentId);
                   }
                   if (panel === "channels") {
                     void loadChannels(state, false);

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -50,7 +50,7 @@ export type SettingsHost = PollingHost &
     eventLogBuffer: unknown[];
     agentsList?: AgentsListResult | null;
     agentsSelectedId?: string | null;
-    agentsPanel?: "overview" | "files" | "tools" | "channels" | "cron";
+    agentsPanel?: "overview" | "files" | "channels" | "cron";
     themeMedia: MediaQueryList | null;
     themeMediaHandler: ((event: MediaQueryListEvent) => void) | null;
     pendingGatewayUrl?: string | null;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -128,7 +128,7 @@ export type AppViewState = {
   toolsCatalogLoading: boolean;
   toolsCatalogError: string | null;
   toolsCatalogResult: ToolsCatalogResult | null;
-  agentsPanel: "overview" | "files" | "tools" | "skills" | "channels" | "cron";
+  agentsPanel: "overview" | "files" | "skills" | "channels" | "cron";
   agentFilesLoading: boolean;
   agentFilesError: string | null;
   agentFilesList: AgentsFilesListResult | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -219,7 +219,7 @@ export class RemoteClawApp extends LitElement {
   @state() toolsCatalogLoading = false;
   @state() toolsCatalogError: string | null = null;
   @state() toolsCatalogResult: ToolsCatalogResult | null = null;
-  @state() agentsPanel: "overview" | "files" | "tools" | "channels" | "cron" = "overview";
+  @state() agentsPanel: "overview" | "files" | "channels" | "cron" = "overview";
   @state() agentFilesLoading = false;
   @state() agentFilesError: string | null = null;
   @state() agentFilesList: AgentsFilesListResult | null = null;

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -27,7 +27,7 @@ import {
   resolveModelPrimary,
 } from "./agents-utils.ts";
 
-export type AgentsPanel = "overview" | "files" | "tools" | "skills" | "channels" | "cron";
+export type AgentsPanel = "overview" | "files" | "skills" | "channels" | "cron";
 
 export type AgentsProps = {
   loading: boolean;
@@ -192,7 +192,6 @@ export function renderAgents(props: AgentsProps) {
                       })
                     : nothing
                 }
-                ${nothing /* tools panel removed — skills/tools UI gutted */}
                 ${
                   props.activePanel === "channels"
                     ? renderAgentChannels({
@@ -268,7 +267,6 @@ function renderAgentTabs(active: AgentsPanel, onSelect: (panel: AgentsPanel) => 
   const tabs: Array<{ id: AgentsPanel; label: string }> = [
     { id: "overview", label: "Overview" },
     { id: "files", label: "Files" },
-    { id: "tools", label: "Tools" },
     { id: "channels", label: "Channels" },
     { id: "cron", label: "Cron Jobs" },
   ];


### PR DESCRIPTION
## Summary

Removes the **Tools** tab from the Agents view — the only user-visible dead control remaining from the post-#2336 audit. The panel body was already gutted by #2240 / #2245; only the tab button itself stayed behind, rendering empty when clicked.

Closes #2520.

## Changes (5 files, +4/-12)

- `ui/src/ui/views/agents.ts`: drop `"tools"` from `AgentsPanel` type union, delete `{ id: "tools", label: "Tools" }` tab entry, delete the `${nothing /* tools panel removed */}` placeholder.
- `ui/src/ui/app.ts`, `app-settings.ts`, `app-view-state.ts`: narrow each `agentsPanel` literal union to drop `"tools"`.
- `ui/src/ui/app-render.ts`: delete two now-impossible `panel === "tools"` blocks that lazy-loaded the tools catalog on tab activation.

## Out of scope (deferred)

- Orphan `onToolsProfileChange` / `onToolsOverridesChange` props/handlers in `views/agents.ts` and `app-render.ts` — distinct dead-code pattern from the visible tab; warrants its own gut wave.
- `"skills"` literal in `AgentsPanel` type union — no consumer, but AC silent.

## Why this is safe

- `loadToolsCatalog` and `toolsCatalog*` host state remain live via the gateway connect path (`app-gateway.ts:216`), settings apply path (`app-settings.ts:213`), and the refresh handler (`app-render.ts:572`).
- `app.smoke.test.ts:64-66` asserts the `toolsCatalog*` host fields exist — those fields are NOT removed.

## Test plan

- [x] `grep -rn '"tools"' ui/src/ui/views/agents.ts` returns no matches
- [x] `grep -rn 'id: "tools"' ui/src/` returns no matches
- [x] `pnpm check` green (oxfmt, tsgo, oxlint, no-random-messaging, no-remoteclaw-ai, css-class-drift)
- [x] `pnpm test` green (7,302 tests)
- [x] `pnpm test:ui:smoke` green (12 tests, browser-mode Chromium)
- [x] Visual: tab bar at `agents.ts:267-272` = Overview / Files / Channels / Cron Jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)