### PR TITLE
gut(ui): remove plugin discriminator from tool catalog types (#2522)

### DIFF
--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -353,8 +353,7 @@ export type ToolCatalogEntry = {
   id: string;
   label: string;
   description: string;
-  source: "core" | "plugin";
-  pluginId?: string;
+  source: "core";
   optional?: boolean;
   defaultProfiles: Array<"minimal" | "coding" | "messaging" | "full">;
 };
@@ -362,8 +361,7 @@ export type ToolCatalogEntry = {
 export type ToolCatalogGroup = {
   id: string;
   label: string;
-  source: "core" | "plugin";
-  pluginId?: string;
+  source: "core";
   tools: ToolCatalogEntry[];
 };
 


### PR DESCRIPTION
## Summary

Narrow `source: "core" | "plugin"` → `source: "core"` and delete optional
`pluginId?: string` on `ToolCatalogEntry` and `ToolCatalogGroup` in
`ui/src/ui/types.ts`. UI has zero consumers of either field (no branches on
`source`, no reads of `pluginId`), so the discriminator is dead weight from
the gutted plugin system.

Closes #2522.

## Changes

- `ui/src/ui/types.ts` (L352-367): 2 literals narrowed, 2 optional fields deleted.

## Backend coordination note

Backend (`src/gateway/server-methods/tools-catalog.ts:99,110`) still emits
`source: "plugin"` via `buildPluginGroups` — the plugin subsystem is not
fully gutted yet. This is **out of scope** for #2522, which per its title/AC
is UI-only.

Narrowing is safe at the UI type level because the UI consumes the response
via an untyped generic cast (`request<ToolsCatalogResult>`) with no runtime
schema validation. The narrowed type is declarative-only: it documents that
UI code should not branch on `"plugin"`, and since no UI code does, the
runtime shape of the response is immaterial.

If/when the backend-side gut is done, the protocol schema at
`src/gateway/protocol/schema/agents-tools.ts` and the handler at
`src/gateway/server-methods/tools-catalog.ts` will need a matching narrowing —
tracked as a follow-up, not in this PR.

## AC evidence

- `grep -rn 'pluginId' ui/src/` → zero hits ✅
- `grep -rn 'source: "plugin"\|source:"plugin"' ui/src/` → zero hits ✅
- `pnpm check` → green (format, tsgo, lint, CSS class drift) ✅
- `pnpm test` → green (7014 passed, 3 skipped) ✅
- `pnpm test:ui:smoke` → green (12 passed across 2 files) ✅

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm test` passes
- [x] `pnpm test:ui:smoke` passes
- [ ] CI all green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)