### PR TITLE
gut(ui): remove autoAllowSkills from exec-approvals config (#2524)

### DIFF
--- a/ui/src/ui/controllers/exec-approvals.ts
+++ b/ui/src/ui/controllers/exec-approvals.ts
@@ -5,7 +5,6 @@ export type ExecApprovalsDefaults = {
   security?: string;
   ask?: string;
   askFallback?: string;
-  autoAllowSkills?: boolean;
 };
 
 export type ExecApprovalsAllowlistEntry = {

--- a/ui/src/ui/views/nodes-exec-approvals.ts
+++ b/ui/src/ui/views/nodes-exec-approvals.ts
@@ -18,7 +18,6 @@ type ExecApprovalsResolvedDefaults = {
   security: ExecSecurity;
   ask: ExecAsk;
   askFallback: ExecSecurity;
-  autoAllowSkills: boolean;
 };
 
 type ExecApprovalsAgentOption = {
@@ -87,7 +86,6 @@ function resolveExecApprovalsDefaults(
     security: normalizeSecurity(defaults.security),
     ask: normalizeAsk(defaults.ask),
     askFallback: normalizeSecurity(defaults.askFallback ?? "deny"),
-    autoAllowSkills: Boolean(defaults.autoAllowSkills ?? false),
   };
 }
 
@@ -337,10 +335,6 @@ function renderExecApprovalsPolicy(state: ExecApprovalsState) {
   const securityValue = isDefaults ? defaults.security : (agentSecurity ?? "__default__");
   const askValue = isDefaults ? defaults.ask : (agentAsk ?? "__default__");
   const askFallbackValue = isDefaults ? defaults.askFallback : (agentAskFallback ?? "__default__");
-  const autoOverride =
-    typeof agent.autoAllowSkills === "boolean" ? agent.autoAllowSkills : undefined;
-  const autoEffective = autoOverride ?? defaults.autoAllowSkills;
-  const autoIsDefault = autoOverride == null;
 
   return html`
     <div class="list" style="margin-top: 16px;">
@@ -474,46 +468,6 @@ function renderExecApprovalsPolicy(state: ExecApprovalsState) {
               )}
             </select>
           </label>
-        </div>
-      </div>
-
-      <div class="list-item">
-        <div class="list-main">
-          <div class="list-title">Auto-allow skill CLIs</div>
-          <div class="list-sub">
-            ${
-              isDefaults
-                ? "Allow skill executables listed by the Gateway."
-                : autoIsDefault
-                  ? `Using default (${defaults.autoAllowSkills ? "on" : "off"}).`
-                  : `Override (${autoEffective ? "on" : "off"}).`
-            }
-          </div>
-        </div>
-        <div class="list-meta">
-          <label class="field">
-            <span>Enabled</span>
-            <input
-              type="checkbox"
-              ?disabled=${state.disabled}
-              .checked=${autoEffective}
-              @change=${(event: Event) => {
-                const target = event.target as HTMLInputElement;
-                state.onPatch([...basePath, "autoAllowSkills"], target.checked);
-              }}
-            />
-          </label>
-          ${
-            !isDefaults && !autoIsDefault
-              ? html`<button
-                class="btn btn--sm"
-                ?disabled=${state.disabled}
-                @click=${() => state.onRemove([...basePath, "autoAllowSkills"])}
-              >
-                Use default
-              </button>`
-              : nothing
-          }
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Closes #2524. Removes the OpenClaw-era "Auto-allow skill CLIs" toggle from the exec-approvals UI. RemoteClaw has no skills subsystem to gate, so the checkbox was UI dead weight — it patched a backend config key the runtime no longer reads.

## Scope

UI-only (per issue AC: `grep -rn 'autoAllowSkills' ui/` returns zero hits).

**Removed from `ui/`:**
- `ExecApprovalsDefaults.autoAllowSkills` (`controllers/exec-approvals.ts`)
- `ExecApprovalsResolvedDefaults.autoAllowSkills` (view-local type)
- `resolveExecApprovalsDefaults()` — `autoAllowSkills` default read
- `renderExecApprovalsPolicy()` — `autoOverride`/`autoEffective`/`autoIsDefault` locals
- "Auto-allow skill CLIs" list-item block (checkbox + override-clear button)

Pure subtraction: 47 lines removed, 0 added.

## Note on issue body staleness

Issue #2524 body claims `grep -rn 'autoAllowSkills' ui/` returns "only the two sites above" (`ui/src/ui/views/nodes-exec-approvals.ts:21,90`). Actual `ui/` grep at the time of this PR showed **8 hits across 2 files** (7 in the view, 1 in the controller type) — all part of the same dead UI control. The PR covers all 8 to satisfy the AC's "zero hits" criterion.

## Acceptance criteria

- [x] `grep -rn 'autoAllowSkills' ui/` returns zero hits
- [x] `pnpm check` green (format + tsgo + lint + CSS class drift)
- [x] `pnpm test` green (7014 passed, 3 skipped, across 800 test files — plus 288 tests across 17 parallel-suite files)
- [x] `pnpm test:ui:smoke` green (12 passed, 2 suites)

## Out-of-scope hits flagged for follow-up

Not `ui/`, so not under this issue's AC. Each is a separate cleanup lane:

| File | Why deferred |
|------|--------------|
| `src/gateway/protocol/schema/exec-approvals.ts:19` | Backend TypeBox schema still declares `autoAllowSkills: Type.Optional(Type.Boolean())`. Stored values silently ignored after this PR (no UI control writes it; runtime already doesn't read it), but the schema surface remains. **Recommend: separate issue to drop the backend schema field once confirmed no migration/serialization depends on it.** |
| `docs/tools/exec-approvals.md`, `docs/tools/exec.md`, `docs/gateway/security/index.md` | Still document `autoAllowSkills` as a feature / show JSON examples. Should trail the backend schema removal. |
| `apps/macos/Sources/RemoteClaw/*.swift` | Native macOS app has its own `autoAllowSkills` wiring (`SystemRunSettingsView.swift`, `ExecApprovalEvaluation.swift`, `ExecApprovals.swift`). Native gutting is a separate cleanup lane. |

## Risk

- **Low**. UI-only dead-code removal; no type surface consumed outside `ui/` changes; no tests touched `autoAllowSkills` in `ui/` (confirmed by grep).
- Stored configs with `autoAllowSkills` still load (backend schema still accepts the key); they're just no longer editable from the UI. That matches the gutting intent.

## Test plan

- [x] `pnpm check` — green
- [x] `pnpm test` — green
- [x] `pnpm test:ui:smoke` — green
- [x] Manual smoke: render `renderExecApprovalsPolicy` with both `isDefaults=true` and agent-scoped state — three list-items remain (Security / Ask / Ask fallback), no broken template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)