### PR TITLE
docs: clarify plugin system is kept, not removed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,13 +252,14 @@ RemoteClaw is an active fork of OpenClaw. The codebase currently contains
 upstream OpenClaw naming (`openclaw` in package.json, env vars, paths).
 A comprehensive rebrand is planned but not yet executed.
 
-**What stays**: Channel adapters, gateway, messaging infrastructure.
+**What stays**: Channel adapters, gateway, messaging infrastructure, plugin
+system (plugin SDK plus bundled channel and tool plugins in `extensions/*`).
 
 **What's being replaced**: Execution engine (Pi-based orchestrator replaced
 with AgentRuntime supporting CLI-only agents: Claude, Gemini, Codex, OpenCode).
 
-**What's being removed**: Skills marketplace, plugin system, model provider
-ecosystem, consumer onboarding UX.
+**What's being removed**: Skills marketplace, model provider ecosystem,
+consumer onboarding UX.
 
 When encountering `openclaw` references in code, understand they are upstream
 artifacts. New code should use `remoteclaw` naming where possible.


### PR DESCRIPTION
## Summary

- Moves `plugin system` out of "What's being removed" and into "What stays" in `CLAUDE.md` § Fork Context — with a pointer to the plugin SDK location (`src/plugin-sdk/`) and bundled extensions (`extensions/*`).
- The stale "plugin system" entry misled multiple issue authors into filing gut-plugin follow-ups on a false premise: #2522 (UI type narrowing, already merged as #2534), #2523 (SECTION_META.plugins removal, now closed won't-do), #2537 (backend type narrowing, closed won't-do). #2543 tracks re-widening the UI types from #2534.
- Skills marketplace and Pi-era model provider ecosystem remain in the "removed" list unchanged.

## Evidence that plugin system is kept

- **Plugin SDK** at `src/plugin-sdk/` (~112 files) — published as part of the main `remoteclaw` npm package.
- **Plugin registrar API** at `src/plugins/types.ts:275-297` exposes 11 register methods (`registerTool`, `registerChannel`, `registerHook`, `registerHttpRoute`, `registerGatewayMethod`, `registerCli`, `registerCommand`, `registerService`, `registerProvider`, `registerContextEngine`, plus others).
- **29 bundled extensions** in `extensions/*`, all as `@remoteclaw/{name}` workspace packages with real versions. Active usage count across extensions: 21 `registerChannel`, 10 `registerTool`, 6 `registerGatewayMethod`, 4 `registerCommand`, 4 `registerService`, 2 `registerHttpRoute`, 1 `registerCli`.
- **Active loading path**: `src/cli/program/routes.ts:18` (`loadPlugins: (argv) => !hasFlag(argv, "--json")`), `src/plugins/loader.ts:442` (`activatePluginRegistry`).
- **Live config schema section**: `plugins.enabled`, `plugins.allow`, `plugins.deny`, `plugins.load`, `plugins.slots`, `plugins.entries`, `plugins.installs` — 7 properties + 29 uiHints per #2526 SPIKE audit.

## Test plan

- [ ] CI `docs` job passes (markdown-only change)
- [ ] CI `build`, `test`, `test-ui-smoke`, `lint` all pass (no code changes)