### PR TITLE
fix(ui): re-widen ToolCatalogEntry/Group source discriminator (#2543)

### DIFF
--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -353,7 +353,8 @@ export type ToolCatalogEntry = {
   id: string;
   label: string;
   description: string;
-  source: "core";
+  source: "core" | "plugin";
+  pluginId?: string;
   optional?: boolean;
   defaultProfiles: Array<"minimal" | "coding" | "messaging" | "full">;
 };
@@ -361,7 +362,8 @@ export type ToolCatalogEntry = {
 export type ToolCatalogGroup = {
   id: string;
   label: string;
-  source: "core";
+  source: "core" | "plugin";
+  pluginId?: string;
   tools: ToolCatalogEntry[];
 };
 


### PR DESCRIPTION
## Summary

Re-widens `ToolCatalogEntry.source` and `ToolCatalogGroup.source` in `ui/src/ui/types.ts` from `"core"` back to `"core" | "plugin"`, and restores the `pluginId?: string` optional field on both types. Corrects the narrowing introduced by #2534 (from #2522) which was authored on the false premise that the plugin subsystem was being gutted.

## Why safe

- **Plugin retention clarified** in #2544 (CLAUDE.md § Fork Context now explicitly lists plugins under "What stays").
- **Backend already emits `"plugin"`** via `buildPluginGroups` at `src/gateway/server-methods/tools-catalog.ts:99,110` (10 active `registerTool` calls across `extensions/feishu`, `extensions/voice-call`, `extensions/tlon`, `extensions/zalouser`).
- **Protocol schema already aligned** — `src/gateway/protocol/schema/agents-tools.ts:200,219` declares the full `"core" | "plugin"` union with `pluginId`. No schema change needed.
- **Type widening is backward-compatible** — existing test fixture at `ui/src/ui/controllers/agents.test.ts:124-125` uses `source: "core"` literal, which remains valid under the widened union.
- **No current UI consumer** branches on `.source` (panel body was removed in #2520), so there is no runtime behavior change — this corrects the latent type lie before any future tool-browsing UI inherits the wrong shape.

## Acceptance criteria (from #2543)

- [x] `ToolCatalogEntry.source` typed `"core" | "plugin"`
- [x] `ToolCatalogGroup.source` typed `"core" | "plugin"`
- [x] `pluginId?: string` present on both types
- [x] `pnpm check` green (pre-commit hook)
- [x] `pnpm test` green — 800 files / 7014 passed / 3 skipped
- [x] `pnpm test:ui:smoke` green — 2 files / 12 passed

## Test plan

- [x] Diff matches AC specification byte-for-byte (`git show` verified)
- [x] Type-widening does not break existing `source: "core"` test fixtures
- [x] Protocol schema contract reverified (no divergence after change)
- [ ] CI: `build`, `test`, `lint`, `docs`, `test-ui-smoke` green

Closes #2543