### PR TITLE
docs(fork): clarify openclaw.* artifacts are not RemoteClaw legacy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,18 @@ consumer onboarding UX.
 When encountering `openclaw` references in code, understand they are upstream
 artifacts. New code should use `remoteclaw` naming where possible.
 
+**User state boundary.** The fork boundary is also a user boundary. Users of
+upstream OpenClaw or pre-rebrand RemoteClaw are not RemoteClaw users — their
+persisted state (`openclaw.*` localStorage keys, config files, stored
+preferences, URL schemes, any artifact touched by the rebrand) is NOT
+RemoteClaw legacy. No migration path is owed; do not open issues proposing
+one. When auditing for "legacy values that need migration," filter each hit
+by asking: *was this artifact ever written by shipped, post-rebrand
+RemoteClaw code?* If the only writer is upstream OpenClaw or pre-rebrand
+internal state, classify as ACCURATE/HISTORICAL — not as "fragility" or
+"needs migration." The rebrand was a clean break, not a backward-compat
+lapse.
+
 ## PR Submission Workflow
 
 When submitting PRs on this project:

--- a/docs/experiments/plans/ui-stored-settings-legacy-migration.md
+++ b/docs/experiments/plans/ui-stored-settings-legacy-migration.md
@@ -1,143 +1,57 @@
 ---
-summary: "Spike audit of ui/ browser-local persisted state, classifying each field safe/fragile and proposing migration strategy for legacy openclaw.* keys"
+summary: "Spike audit of ui/ browser-local persisted state, classifying each field safe/fragile. Conclusion: zero fragility — `openclaw.*` keys are out of scope per the fork user-state boundary."
 owner: "remoteclaw"
-status: "draft"
+status: "final"
 last_updated: "2026-04-24"
-title: "UI Stored-Settings Legacy Migration Audit"
+title: "UI Stored-Settings Audit"
 ---
 
-# UI Stored-Settings Legacy Migration Audit
+# UI Stored-Settings Audit
 
 ## Context
 
-Spike output for #2531. The control-UI persists state in browser `localStorage` and `sessionStorage`. Legacy users — anyone who ran upstream OpenClaw or a pre-rebrand RemoteClaw build — may have stored values keyed by `openclaw.*` prefixes or carry field shapes that predate the current type system. On load, code must either migrate, validate-and-reset, or silently drop.
+Spike output for #2531. The control-UI persists state in browser `localStorage` and `sessionStorage`. This audit enumerates every persistence surface in `ui/src/**` and classifies each against the current type system.
 
-This audit enumerates every persistence surface in `ui/src/**`, classifies each, and proposes a migration strategy for the one real fragility found.
+**Scope boundary.** Per CLAUDE.md § Fork Context "User state boundary," `openclaw.*` persisted artifacts (from upstream OpenClaw or pre-rebrand RemoteClaw state) are NOT RemoteClaw legacy. No migration path is owed from them — the rebrand was a clean break. This audit therefore only considers `remoteclaw.*`-prefixed state written by shipped, post-rebrand RemoteClaw code.
 
-Per-field methodology: for each storage key, (1) locate its reader/writer, (2) identify the validator or default-applier, (3) reason about what happens when a legacy or malformed value is present.
+Per-field methodology: for each storage key, (1) locate its reader/writer, (2) identify the validator or default-applier, (3) reason about what happens when a malformed value is present.
 
 ## Inventory
 
-Eight distinct storage keys are read by the control UI. The fork owns the schemas; upstream OpenClaw owned an earlier `openclaw.*`-prefixed variant of the same schemas.
+Eight distinct storage keys are read by the control UI. All use the `remoteclaw.*` prefix.
 
-| #   | Key                                                                                       | Storage          | Reader                                                                                                 | Validation                                                                                                     | Classification                          |
-| --- | ----------------------------------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| 1   | `remoteclaw.control.settings.v1`                                                          | `localStorage`   | [`ui/src/ui/storage.ts`](../../../ui/src/ui/storage.ts) `loadSettings()`                               | Field-by-field type check + default fallback                                                                   | **Safe** (self-cleaning)                |
-| 2   | `remoteclaw.control.token.v1` and `remoteclaw.control.token.v1:{scope}`                   | `sessionStorage` | `ui/src/ui/storage.ts` `loadSessionToken()`                                                            | Trimmed string; legacy unscoped key explicitly removed on each read                                            | **Safe**                                |
-| 3   | `remoteclaw.device.auth.v1`                                                               | `localStorage`   | [`ui/src/ui/device-auth.ts`](../../../ui/src/ui/device-auth.ts) `readStore()`                          | `parsed.version === 1`, `deviceId` is string, `tokens` is object — else `null`                                 | **Safe**                                |
-| 4   | `remoteclaw-device-identity-v1`                                                           | `localStorage`   | [`ui/src/ui/device-identity.ts`](../../../ui/src/ui/device-identity.ts) `loadOrCreateDeviceIdentity()` | `parsed.version === 1`, `deviceId`/`publicKey`/`privateKey` are strings, fingerprint matches — else regenerate | **Safe**                                |
-| 5   | `remoteclaw.i18n.locale`                                                                  | `localStorage`   | [`ui/src/i18n/lib/translate.ts`](../../../ui/src/i18n/lib/translate.ts) `readStoredLocale()`           | `isSupportedLocale()`; unsupported values ignored, navigator fallback                                          | **Safe**                                |
-| 6   | `remoteclaw:pinned:{sessionKey}`                                                          | `localStorage`   | [`ui/src/ui/chat/pinned-messages.ts`](../../../ui/src/ui/chat/pinned-messages.ts) `load()`             | Array, filtered to numeric values                                                                              | **Safe**                                |
-| 7   | `remoteclaw:deleted:{sessionKey}`                                                         | `localStorage`   | [`ui/src/ui/chat/deleted-messages.ts`](../../../ui/src/ui/chat/deleted-messages.ts) `load()`           | Array, filtered to string values                                                                               | **Safe**                                |
-| 8   | Pre-boot theme read (no dedicated key; scans for `remoteclaw.control.settings.v1` prefix) | `localStorage`   | [`ui/public/theme-boot.js`](../../../ui/public/theme-boot.js) IIFE                                     | `s.theme` ∈ `{claw, knot, dash}`, `s.themeMode` ∈ `{system, light, dark}`, plus LEGACY mapping                 | **Fragile — dead code** (see Finding 2) |
+| #   | Key                                                                                       | Storage          | Reader                                                                                                 | Validation                                                                                                     | Classification                                                     |
+| --- | ----------------------------------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| 1   | `remoteclaw.control.settings.v1`                                                          | `localStorage`   | [`ui/src/ui/storage.ts`](../../../ui/src/ui/storage.ts) `loadSettings()`                               | Field-by-field type check + default fallback                                                                   | **Safe** (self-cleaning)                                           |
+| 2   | `remoteclaw.control.token.v1` and `remoteclaw.control.token.v1:{scope}`                   | `sessionStorage` | `ui/src/ui/storage.ts` `loadSessionToken()`                                                            | Trimmed string; legacy unscoped key explicitly removed on each read                                            | **Safe**                                                           |
+| 3   | `remoteclaw.device.auth.v1`                                                               | `localStorage`   | [`ui/src/ui/device-auth.ts`](../../../ui/src/ui/device-auth.ts) `readStore()`                          | `parsed.version === 1`, `deviceId` is string, `tokens` is object — else `null`                                 | **Safe**                                                           |
+| 4   | `remoteclaw-device-identity-v1`                                                           | `localStorage`   | [`ui/src/ui/device-identity.ts`](../../../ui/src/ui/device-identity.ts) `loadOrCreateDeviceIdentity()` | `parsed.version === 1`, `deviceId`/`publicKey`/`privateKey` are strings, fingerprint matches — else regenerate | **Safe**                                                           |
+| 5   | `remoteclaw.i18n.locale`                                                                  | `localStorage`   | [`ui/src/i18n/lib/translate.ts`](../../../ui/src/i18n/lib/translate.ts) `readStoredLocale()`           | `isSupportedLocale()`; unsupported values ignored, navigator fallback                                          | **Safe**                                                           |
+| 6   | `remoteclaw:pinned:{sessionKey}`                                                          | `localStorage`   | [`ui/src/ui/chat/pinned-messages.ts`](../../../ui/src/ui/chat/pinned-messages.ts) `load()`             | Array, filtered to numeric values                                                                              | **Safe**                                                           |
+| 7   | `remoteclaw:deleted:{sessionKey}`                                                         | `localStorage`   | [`ui/src/ui/chat/deleted-messages.ts`](../../../ui/src/ui/chat/deleted-messages.ts) `load()`           | Array, filtered to string values                                                                               | **Safe**                                                           |
+| 8   | Pre-boot theme read (no dedicated key; scans for `remoteclaw.control.settings.v1` prefix) | `localStorage`   | [`ui/public/theme-boot.js`](../../../ui/public/theme-boot.js) IIFE                                     | `s.theme` ∈ `{claw, knot, dash}`, `s.themeMode` ∈ `{system, light, dark}`, plus LEGACY mapping                 | **Code hygiene — dead OpenClaw multi-theme logic** (see Finding 2) |
 
-Every `remoteclaw.*` key has defensive validation on read and silently degrades on malformed input. None of these keys produce an unrecoverable runtime state when fed a legacy value.
+Every `remoteclaw.*` key has defensive validation on read and silently degrades on malformed input. None of these keys produce an unrecoverable runtime state when fed an unexpected value.
 
-The one real fragility is NOT a broken validator — it is the absence of a migration from the pre-rebrand `openclaw.*` key prefix to the current `remoteclaw.*` prefix.
+**No fragility exists within scope.** The `openclaw.*`-prefixed artifacts that earlier spike drafts flagged as a "migration gap" are out of scope per the fork user-state boundary (see CLAUDE.md § Fork Context and Finding 1 below).
 
 ## Findings
 
-### Finding 1 — No `openclaw.*` → `remoteclaw.*` migration. Silent reset on upgrade.
+### Finding 1 — `openclaw.*` localStorage artifacts are out of scope (non-finding).
 
-**Severity: High** for device-auth tokens; **Medium** for UI settings; **Low** for locale and device identity.
+**Severity: None** — misframed in the initial spike draft; corrected here.
 
-**Evidence.**
+**The premise is invalid.** Earlier drafts of this audit flagged the rebrand commit [`c7c81fe8ce`](https://github.com/remoteclaw/remoteclaw/commit/c7c81fe8ce73bb9e99dad0d3c8397b90cea8a52f) renaming every `openclaw.*` localStorage key to `remoteclaw.*` as a "missing migration shim," with Finding 1 proposing a bootstrap-time copy-and-delete. That framing assumed `openclaw.*` artifacts are RemoteClaw's legacy state. They are not.
 
-Commit [`c7c81fe8ce`](https://github.com/remoteclaw/remoteclaw/commit/c7c81fe8ce73bb9e99dad0d3c8397b90cea8a52f) ("rebrand: update UI layer from OpenClaw to RemoteClaw", merged 2026-03-03) renamed every `localStorage` key prefix across the UI layer without a migration shim:
+Per CLAUDE.md § Fork Context "User state boundary":
 
-- `openclaw.control.settings.v1` → `remoteclaw.control.settings.v1` ([`ui/src/ui/storage.ts`](../../../ui/src/ui/storage.ts):1)
-- `openclaw.device.auth.v1` → `remoteclaw.device.auth.v1` ([`ui/src/ui/device-auth.ts`](../../../ui/src/ui/device-auth.ts):10)
-- `openclaw-device-identity-v1` → `remoteclaw-device-identity-v1` ([`ui/src/ui/device-identity.ts`](../../../ui/src/ui/device-identity.ts):18)
-- `openclaw.i18n.locale` → `remoteclaw.i18n.locale` ([`ui/src/i18n/lib/translate.ts`](../../../ui/src/i18n/lib/translate.ts):31)
-- `openclaw.control.token.v1` and scoped variant — same pattern in `sessionStorage`
+> Users of upstream OpenClaw or pre-rebrand RemoteClaw are not RemoteClaw users — their persisted state (`openclaw.*` localStorage keys, config files, stored preferences, URL schemes, any artifact touched by the rebrand) is NOT RemoteClaw legacy. No migration path is owed; do not open issues proposing one. […] The rebrand was a clean break, not a backward-compat lapse.
 
-The commit message documents the rename; no code was added to copy old values under the new prefix, and no code was added to delete the old keys.
+Under that boundary, the five `openclaw.*` prefixes named in earlier drafts — `openclaw.control.settings.v1`, `openclaw.device.auth.v1`, `openclaw-device-identity-v1`, `openclaw.i18n.locale`, `openclaw.control.token.v1` (+ scoped variant) — are out of scope for this spike. No follow-up migration issue. No bootstrap shim.
 
-**Verification:**
+**Historical note**: a follow-up issue (#2546) was opened under the flawed premise and subsequently closed as invalid. This correction is recorded in PR #2553 and accompanies the addition of the explicit boundary rule to CLAUDE.md.
 
-```bash
-grep -rn "openclaw" ui/src/ ui/public/
-```
-
-returns zero matches on `main` as of this audit. Nothing reads `openclaw.*` anywhere in the fork.
-
-**Impact per key.**
-
-| Key                            | Loss on upgrade                                                                            | User-visible effect                                                                                                     |
-| ------------------------------ | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| `openclaw.control.settings.v1` | Gateway URL, theme, split ratio, nav collapse state, nav groups collapse map, session keys | User lands on defaults; must re-enter gateway URL and re-collapse/expand nav. Cosmetic-to-moderate friction.            |
-| `openclaw.device.auth.v1`      | Per-device role-scoped auth tokens                                                         | **User must re-pair every previously paired device.** Highest-friction loss.                                            |
-| `openclaw-device-identity-v1`  | Device's ed25519 keypair + deviceId                                                        | New identity generated; this device no longer matches any server-side pairing record, compounding the device-auth loss. |
-| `openclaw.i18n.locale`         | Selected locale                                                                            | Reverts to navigator locale or default. Minor.                                                                          |
-| `openclaw.control.token.v1`    | Gateway session token                                                                      | `sessionStorage` — already cleared on tab close, so impact is bounded to an open session straddling the upgrade. Minor. |
-
-For device auth + identity combined, the user experience is indistinguishable from a fresh install: the paired-devices list appears empty on the server too (different device fingerprint), and every device pairing must be redone.
-
-**Adversarial check.**
-
-Could the `openclaw.*` keys have been cleaned up at a different layer — cookie-style expiry, service-worker cache purge, gateway-side key rewrite? No.
-
-- `localStorage` has no expiry. Entries persist until explicitly removed.
-- No service worker is registered for the control UI ([`ui/src/ui/app.ts`](../../../ui/src/ui/app.ts) has no `navigator.serviceWorker` registration).
-- The gateway never touches client `localStorage`.
-
-So any user who ran OpenClaw or pre-2026-03-03 RemoteClaw still carries the `openclaw.*` payload in their browser. That payload is inert (nothing reads it) but recoverable.
-
-**Recommended strategy: explicit migration on first boot.**
-
-Trade-offs considered:
-
-| Strategy                                                                                                | Pros                                                   | Cons                                                                                                                                           | Verdict                         |
-| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| **Default-fallback** (current behavior)                                                                 | Zero code                                              | Silent data loss; users re-configure. High friction for device auth.                                                                           | Not acceptable for device auth. |
-| **Explicit migration** (read `openclaw.*`, copy to `remoteclaw.*` if target empty, delete `openclaw.*`) | One-time recovery, zero recurring cost after migration | Bounded one-time code. Safe: each storage reader already validates defensively, so a corrupted old payload falls through to existing defaults. | **Recommended.**                |
-| **Warn-and-reset**                                                                                      | User notified of loss                                  | Doesn't recover anything; strictly worse than migration for keys where shapes match.                                                           | Inferior.                       |
-| **Dual-read** (read both keys forever, prefer new)                                                      | No delete step                                         | Permanent code debt; `openclaw.*` never cleaned; every reader gains a branch.                                                                  | Rejected (permanent tax).       |
-
-The shapes match exactly — the rebrand was a prefix-only change, not a schema migration. Each `openclaw.*` payload, if it passes the existing `remoteclaw.*` validator, is byte-compatible. So explicit migration is a string-level rename with the existing validators as the safety net.
-
-**Implementation sketch.**
-
-A single migration module `ui/src/ui/legacy-migration.ts`, invoked once from the app bootstrap before any other `localStorage`/`sessionStorage` reader runs:
-
-```text
-const MIGRATIONS: Array<{ from: string; to: string; storage: "local" | "session" }> = [
-  { from: "openclaw.control.settings.v1",    to: "remoteclaw.control.settings.v1",    storage: "local" },
-  { from: "openclaw.device.auth.v1",          to: "remoteclaw.device.auth.v1",          storage: "local" },
-  { from: "openclaw-device-identity-v1",      to: "remoteclaw-device-identity-v1",      storage: "local" },
-  { from: "openclaw.i18n.locale",             to: "remoteclaw.i18n.locale",             storage: "local" },
-  { from: "openclaw.control.token.v1",        to: "remoteclaw.control.token.v1",        storage: "session" },
-  // token.v1:{scope} — iterate all keys with that prefix
-];
-
-export function runLegacyKeyMigration(): { migrated: number; skipped: number } { … }
-```
-
-Semantics per entry:
-
-1. If target (`remoteclaw.*`) already has a value, leave target alone; delete source (`openclaw.*`). User already upgraded-and-reconfigured since upgrade; don't clobber their new state.
-2. If target is empty and source has a value, copy source → target; delete source. One-time recovery.
-3. If neither has a value, no-op.
-
-Scoped-token keys (`openclaw.control.token.v1:{gateway-url}`) need a prefix scan — enumerate `sessionStorage` keys, rewrite the prefix.
-
-Idempotent by construction — a second invocation finds no `openclaw.*` keys and is a no-op. Safe to run unconditionally at every boot.
-
-**Where it should be invoked.** Earliest possible point in the UI boot sequence, before `storage.ts` / `translate.ts` / `device-auth.ts` / `device-identity.ts` initialize. The Lit element's constructor is too late because it runs after module top-level side effects. The natural home is either:
-
-- In the pre-hydration IIFE ([`ui/public/theme-boot.js`](../../../ui/public/theme-boot.js)) — plain JS, already runs before module load. Keeps the migration synchronous-pre-paint, but mixes theme code with storage migration.
-- In a new top-level bootstrap module imported first from the entry point. Cleaner separation; runs after theme-boot.js but before any other storage reader.
-
-Recommended: new bootstrap module. Theme-boot.js already has one subtle job and doesn't need another (see Finding 2).
-
-**Test plan.**
-
-Two integration tests in `ui/src/ui/` using the existing `@vitest/browser-playwright` harness:
-
-1. Seed `localStorage` with `openclaw.control.settings.v1 = {…}` + `openclaw.device.auth.v1 = {…}`. Mount the app. Assert migration: `remoteclaw.*` keys contain the same payloads, `openclaw.*` keys are gone.
-2. Seed both `openclaw.*` AND `remoteclaw.*` for the same logical key, with different payloads. Mount. Assert: `remoteclaw.*` is preserved as-is, `openclaw.*` is deleted. (User already upgraded-and-reconfigured case.)
-
-A third test should verify the migration is idempotent — run twice, both invocations succeed.
+**Status within audit scope**: with `openclaw.*` out of scope, the classified `remoteclaw.*` inventory above has zero fragile entries. Seven keys are safe (field-level validators with default fallbacks); key #8 — the pre-boot theme script — is code hygiene only, captured in Finding 2.
 
 ### Finding 2 — Pre-boot theme script carries dead OpenClaw multi-theme logic.
 
@@ -201,27 +115,27 @@ The issue flagged `settings.agentsPanel: "skills"` or `"tools"` as a suspected f
 
 Similarly, the plugin discriminator (issue #2522/#2534) and session/agent state referencing removed providers were inspected and found to be non-persisted. These live in ephemeral app state and server-originated data, not in browser storage.
 
-Conclusion: three of the four items flagged by the original spike brief do not interact with stored settings. The one real item — the `openclaw.*` prefix migration — is captured under Finding 1.
+Conclusion: three of the four items flagged by the original spike brief do not interact with stored settings, and the fourth (`openclaw.*` prefix migration, Finding 1) is out of scope per the fork user-state boundary.
 
 ## Proposal
 
-Open **one** follow-up issue implementing Finding 1:
+**No follow-up migration issue needed.** Finding 1 is a non-finding per the fork user-state boundary. No `remoteclaw.*` key in the inventory is fragile.
 
-- `fix(ui): migrate legacy openclaw.* localStorage keys to remoteclaw.* on boot`
-- AC: each of the five known `openclaw.*` prefixes (including scoped token variants) is migrated; existing `remoteclaw.*` values are not overwritten; old keys are deleted; migration is idempotent; tests seeded with `openclaw.*` payloads produce identical `remoteclaw.*` outcomes; tests seeded with both prefer `remoteclaw.*`.
-- Affects the same five files named in this audit, plus a new `ui/src/ui/legacy-migration.ts` module and its browser-mode tests.
+Finding 2 (theme-boot.js simplification) is an optional low-priority code hygiene cleanup — no dedicated issue is required; it can be rolled into any broader post-sync boot-sequence cleanup whenever convenient.
 
-Finding 2 (theme-boot.js simplification) and Finding 3 (no-op) do not require follow-up issues. Finding 2 can be rolled into any broader post-sync boot-sequence cleanup; Finding 3 is intended behavior.
+Finding 3 is intended behavior (no action).
 
 ## AC (this spike)
 
-- [x] Classified stored-settings inventory produced — see § Inventory (eight keys, seven safe, one dead-code, migration fragility captured as Finding 1).
-- [x] Migration strategy documented per fragile field — see Finding 1 (explicit migration with adversarial check and test plan) and Finding 2 (simplify dead code).
-- [x] Follow-up implementation issue opened for Finding 1 — tracked separately, linked in the closing comment on #2531.
+- [x] Classified stored-settings inventory produced — see § Inventory (eight keys, seven safe, one dead-code).
+- [x] Migration strategy documented per fragile field — zero fragile fields within the fork user-state boundary (see Finding 1 non-finding). Finding 2 is code hygiene, not data fragility.
+- [x] Follow-up implementation issue — none needed; closed as invalid (#2546).
 
 ## Related
 
 - Parent audit scope: #2336 (post-gut UI remnants sweep)
-- Rebrand commit (root cause of Finding 1): [`c7c81fe8ce`](https://github.com/remoteclaw/remoteclaw/commit/c7c81fe8ce73bb9e99dad0d3c8397b90cea8a52f)
-- Theme-boot externalization (externalized but did not modify Finding 2 logic): [`7c1c59e24d`](https://github.com/remoteclaw/remoteclaw/commit/7c1c59e24d)
+- Fork user-state boundary rule (primary authority): CLAUDE.md § Fork Context, added in PR #2553
+- Closed-invalid follow-up under the flawed premise: #2546
+- Rebrand commit that renamed the prefixes cleanly: [`c7c81fe8ce`](https://github.com/remoteclaw/remoteclaw/commit/c7c81fe8ce73bb9e99dad0d3c8397b90cea8a52f)
+- Theme-boot externalization (context for Finding 2): [`7c1c59e24d`](https://github.com/remoteclaw/remoteclaw/commit/7c1c59e24d)
 - Sibling spike pattern (comment-delivered audit): #2526


### PR DESCRIPTION
## Summary

- **CLAUDE.md § Fork Context** gains a "User state boundary" paragraph: the fork boundary is also a user boundary. `openclaw.*` persisted artifacts (localStorage keys, config files, URL schemes — anything the rebrand touched) are NOT RemoteClaw legacy. No migration path is owed. Audits hitting `openclaw.*` in upstream-derived state should classify as ACCURATE/HISTORICAL, not "fragility."
- **#2531 audit doc correction** (`docs/experiments/plans/ui-stored-settings-legacy-migration.md`): Finding 1 was misframed as a real migration gap and spawned #2546. Rewritten here as a non-finding citing the boundary rule. Proposal drops the follow-up; AC now reflects zero fragile fields. Findings 2/3/4 and the 7-keys-safe inventory stand unchanged — they were sound independent of the Finding 1 misframing.
- **#2546 already closed** as invalid (same user correction).

## Why

The fork-user-state boundary was implicit in § Fork Context (upstream artifacts are "upstream") but the user-state dimension wasn't spelled out. A spike audit (#2531) drifted into treating `openclaw.*` localStorage keys as RemoteClaw's legacy requiring migration, producing a follow-up issue (#2546) that shipped under a wrong premise. Making the rule explicit in CLAUDE.md prevents future audits from the same drift and documents the intent for all contributors — not just the session that hit the correction.

## Test plan

- [x] pnpm check passes (format + typecheck + lint + CSS drift) — ran via pre-commit hook
- [ ] CI green
- [ ] Human review of the boundary-rule wording in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)