### PR TITLE
gut(ui): strip residual 'default' agent pill badge — #2529 F3 (#2550)

### DIFF
--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -101,10 +101,6 @@ export function resolveAgentEmoji(
   return "";
 }
 
-export function agentBadgeText(agentId: string, defaultId: string | null) {
-  return defaultId && agentId === defaultId ? "default" : null;
-}
-
 export function formatBytes(bytes?: number) {
   if (bytes == null || !Number.isFinite(bytes)) {
     return "-";
@@ -144,7 +140,6 @@ export function buildAgentContext(
   agent: AgentsListResult["agents"][number],
   configForm: Record<string, unknown> | null,
   agentFilesList: AgentsFilesListResult | null,
-  defaultId: string | null,
   agentIdentity?: AgentIdentityResult | null,
 ): AgentContext {
   const config = resolveAgentConfig(configForm, agent.id);

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -14,7 +14,6 @@ import {
   renderAgentCron,
 } from "./agents-panels-status-files.ts";
 import {
-  agentBadgeText,
   buildAgentContext,
   buildModelOptions,
   normalizeAgentLabel,
@@ -117,7 +116,6 @@ export function renderAgents(props: AgentsProps) {
                   <div class="muted">No agents found.</div>
                 `
               : agents.map((agent) => {
-                  const badge = agentBadgeText(agent.id, defaultId);
                   const emoji = resolveAgentEmoji(agent, props.agentIdentityById[agent.id] ?? null);
                   return html`
                     <button
@@ -130,7 +128,6 @@ export function renderAgents(props: AgentsProps) {
                         <div class="agent-title">${normalizeAgentLabel(agent)}</div>
                         <div class="agent-sub mono">${agent.id}</div>
                       </div>
-                      ${badge ? html`<span class="agent-pill">${badge}</span>` : nothing}
                     </button>
                   `;
                 })
@@ -149,7 +146,6 @@ export function renderAgents(props: AgentsProps) {
             : html`
                 ${renderAgentHeader(
                   selectedAgent,
-                  defaultId,
                   props.agentIdentityById[selectedAgent.id] ?? null,
                 )}
                 ${renderAgentTabs(props.activePanel, (panel) => props.onSelectPanel(panel))}
@@ -157,7 +153,6 @@ export function renderAgents(props: AgentsProps) {
                   props.activePanel === "overview"
                     ? renderAgentOverview({
                         agent: selectedAgent,
-                        defaultId,
                         configForm: props.configForm,
                         agentFilesList: props.agentFilesList,
                         agentIdentity: props.agentIdentityById[selectedAgent.id] ?? null,
@@ -199,7 +194,6 @@ export function renderAgents(props: AgentsProps) {
                           selectedAgent,
                           props.configForm,
                           props.agentFilesList,
-                          defaultId,
                           props.agentIdentityById[selectedAgent.id] ?? null,
                         ),
                         configForm: props.configForm,
@@ -218,7 +212,6 @@ export function renderAgents(props: AgentsProps) {
                           selectedAgent,
                           props.configForm,
                           props.agentFilesList,
-                          defaultId,
                           props.agentIdentityById[selectedAgent.id] ?? null,
                         ),
                         agentId: selectedAgent.id,
@@ -239,10 +232,8 @@ export function renderAgents(props: AgentsProps) {
 
 function renderAgentHeader(
   agent: AgentsListResult["agents"][number],
-  defaultId: string | null,
   agentIdentity: AgentIdentityResult | null,
 ) {
-  const badge = agentBadgeText(agent.id, defaultId);
   const displayName = normalizeAgentLabel(agent);
   const subtitle = agent.identity?.theme?.trim() || "Agent workspace and routing.";
   const emoji = resolveAgentEmoji(agent, agentIdentity);
@@ -257,7 +248,6 @@ function renderAgentHeader(
       </div>
       <div class="agent-header-meta">
         <div class="mono">${agent.id}</div>
-        ${badge ? html`<span class="agent-pill">${badge}</span>` : nothing}
       </div>
     </section>
   `;
@@ -289,7 +279,6 @@ function renderAgentTabs(active: AgentsPanel, onSelect: (panel: AgentsPanel) => 
 
 function renderAgentOverview(params: {
   agent: AgentsListResult["agents"][number];
-  defaultId: string | null;
   configForm: Record<string, unknown> | null;
   agentFilesList: AgentsFilesListResult | null;
   agentIdentity: AgentIdentityResult | null;


### PR DESCRIPTION
## Summary

Fixes #2550. Removes the residual bare-text `.agent-pill` rendering the
word "default" in the agents sidebar list and agent header, completing
the dead-code strip that #2286 started. #2286 stripped the
`(default)` / `[default]` bracketed forms but left this pill variant in
place.

## Changes

- Delete `agentBadgeText()` from `ui/src/ui/views/agents-utils.ts`
- Remove the two call sites in `ui/src/ui/views/agents.ts` that
  consumed its output (agents list iteration + agent header meta row)
- Remove the now-dead `defaultId` parameter from `buildAgentContext`,
  `renderAgentHeader`, and `renderAgentOverview` (pure pass-through —
  only fed `agentBadgeText`)

**Preserved (explicit — per #2550 caveats):**
- `.agent-pill` base CSS class and `.agent-pill.warn` variant — still
  used at `agents-panels-status-files.ts:447` for the "missing"
  indicator
- Backend `defaultId` data flow for agent pre-selection —
  `app-settings.ts:220`, `app-render.ts:117/155/569`, `app-chat.ts`,
  `src/commands/status.agent-local.ts` are untouched
- Selection-fallback use of `defaultId` at `agents.ts:89-90`

## Scope note

Issue #2550's scope table references `agents-utils.ts:242` for `defaultId`
param removal, but line 242 there is `defaultModel?: unknown` in
`resolveEffectiveModelFallbacks` — unrelated and live. Treated as a
line-number typo; the intended second `defaultId` param is
`renderAgentHeader`'s at `agents.ts:242`. Handled.

Diff: **16 deletions, 0 additions** across 2 files.

## Test plan

- [x] `pnpm check` — format, tsgo, oxlint, CSS class drift audit all pass
- [x] `pnpm test:ui:smoke` — 12/12 browser-mode Chromium smoke tests pass
      (catches the regression class that motivated #2495, #2496, #2519)
- [x] `grep agentBadgeText ui/src` → 0 matches
- [x] `grep 'class=\"agent-pill\"' ui/src` → only `.warn` variant remains
      (missing indicator) as intended
- [x] No LIVE smoke tests needed (changes do not touch `src/middleware/`)

Related: #2529 (parent audit), #2286 (prior partial gut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)