### PR TITLE
feat(ui): add SECTION_META entries for uncategorized user-relevant schema sections (#2541)

### DIFF
--- a/ui/src/ui/views/config-form.render.ts
+++ b/ui/src/ui/views/config-form.render.ts
@@ -242,6 +242,31 @@ export const SECTION_META: Record<string, { label: string; description: string }
   discovery: { label: "Discovery", description: "Service discovery and networking" },
   talk: { label: "Talk", description: "Voice and speech settings" },
   plugins: { label: "Plugins", description: "Plugin management and extensions" },
+  acp: {
+    label: "ACP",
+    description: "Agent Client Protocol sessions for external coding harnesses",
+  },
+  approvals: {
+    label: "Approvals",
+    description: "Execution approval forwarding for sensitive actions",
+  },
+  canvasHost: {
+    label: "Canvas Host",
+    description: "Canvas host server for UI and live-reload delivery",
+  },
+  cli: { label: "CLI", description: "CLI banner and tagline preferences" },
+  diagnostics: {
+    label: "Diagnostics",
+    description: "Diagnostic flags, OpenTelemetry export, and cache tracing",
+  },
+  media: {
+    label: "Media",
+    description: "Attachment handling (filename preservation, retention)",
+  },
+  nodeHost: {
+    label: "Node Host",
+    description: "Node.js host runtime (browser proxy settings)",
+  },
 };
 
 function getSectionIcon(key: string) {


### PR DESCRIPTION
Closes #2541

## Summary

Adds explicit `SECTION_META` entries for the 7 user-relevant schema sections that were previously rendering with fallback metadata (title-cased key + empty description + default icon):

- `acp` — Agent Client Protocol sessions
- `approvals` — Execution approval forwarding
- `canvasHost` — Canvas host server
- `cli` — CLI banner preferences
- `diagnostics` — Diagnostic flags, OTEL export, cache tracing
- `media` — Attachment handling
- `nodeHost` — Node.js host runtime

## Out of scope (by design)

- `routing`, `secrets`, `wizard` — internal/sensitive; should not surface to end users
- `skills` — deferred pending #2523 plugin/skills subsystem decision

## Semantic verification

Each description was derived from reading the corresponding Zod schema node in `src/config/zod-schema.ts`:

| Key | Schema location | Description basis |
|-----|-----------------|-------------------|
| `acp` | zod-schema.ts:292 | `dispatch`, `backend`, `allowedAgents`, `stream`, `runtime` — ACP sessions |
| `approvals` | zod-schema.approvals.ts:23 | `ExecApprovalForwarding` — forwarding for sensitive actions |
| `canvasHost` | zod-schema.ts:490 | `enabled`, `root`, `port`, `liveReload` — UI/canvas server |
| `cli` | zod-schema.ts:173 | `banner.taglineMode` — banner/tagline preferences |
| `diagnostics` | zod-schema.ts:126 | `flags`, `otel`, `cacheTrace` — diagnostic logging |
| `media` | zod-schema.ts:350 | `preserveFilenames`, `ttlHours` — attachment retention |
| `nodeHost` | zod-schema.ts:26 | `browserProxy.{enabled, allowProfiles}` — browser proxy |

**ACP canonical form**: verified against `docs/tools/acp-agents.md` (= "Agent Client Protocol", not "Agent Control Plane" as the issue suggested).

## Style

Matches the existing 24 SECTION_META entries: declarative phrases, parenthesized detail lists where appropriate, no em-dashes.

## Test plan

- [x] `pnpm check` — oxfmt/oxlint/CSS drift all green
- [x] `pnpm test` — 7010 passed, 3 skipped (799 files)
- [x] `pnpm test:ui:smoke` — 12 passed (2 browser-mode files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)