### PR TITLE
gut(backend+docs): remove autoAllowSkills from exec-approvals (#2538)

### DIFF
--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -169,11 +169,6 @@ The Gateway treats these as **claims** and enforces server-side allowlists.
 - Presence entries include `deviceId`, `roles`, and `scopes` so UIs can show a single row per device
   even when it connects as both **operator** and **node**.
 
-### Node helper methods
-
-- Nodes may call `skills.bins` to fetch the current list of skill executables
-  for auto-allow checks.
-
 ### Operator helper methods
 
 - Operators may call `tools.catalog` (`operator.read`) to fetch the runtime tool catalog for an

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -185,7 +185,7 @@ If more than one person can DM your bot:
 
 - **Inbound access** (DM policies, group policies, allowlists): can strangers trigger the bot?
 - **Tool blast radius** (elevated tools + open rooms): could prompt injection turn into shell/file/network actions?
-- **Exec approval drift** (`security=full`, `autoAllowSkills`, interpreter allowlists without `strictInlineEval`): are host-exec guardrails still doing what you think they are?
+- **Exec approval drift** (`security=full`, interpreter allowlists without `strictInlineEval`): are host-exec guardrails still doing what you think they are?
 - **Network exposure** (Gateway bind/auth, Tailscale Serve/Funnel, weak/short auth tokens).
 - **Browser control exposure** (remote nodes, relay ports, remote CDP endpoints).
 - **Local disk hygiene** (permissions, symlinks, config includes, “synced folder” paths).
@@ -256,7 +256,6 @@ High-signal `checkId` values you will most likely see in real deployments (not e
 | `tools.exec.host_sandbox_no_sandbox_defaults`                 | warn          | `exec host=sandbox` resolves to host exec when sandbox is off                        | `tools.exec.host`, `agents.defaults.sandbox.mode`                                                    | no       |
 | `tools.exec.host_sandbox_no_sandbox_agents`                   | warn          | Per-agent `exec host=sandbox` resolves to host exec when sandbox is off              | `agents.list[].tools.exec.host`, `agents.list[].sandbox.mode`                                        | no       |
 | `tools.exec.security_full_configured`                         | warn/critical | Host exec is running with `security="full"`                                          | `tools.exec.security`, `agents.list[].tools.exec.security`                                           | no       |
-| `tools.exec.auto_allow_skills_enabled`                        | warn          | Exec approvals trust skill bins implicitly                                           | `~/.remoteclaw/exec-approvals.json`                                                                  | no       |
 | `tools.exec.allowlist_interpreter_without_strict_inline_eval` | warn          | Interpreter allowlists permit inline eval without forced reapproval                  | `tools.exec.strictInlineEval`, `agents.list[].tools.exec.strictInlineEval`, exec approvals allowlist | no       |
 | `tools.exec.safe_bins_interpreter_unprofiled`                 | warn          | Interpreter/runtime bins in `safeBins` without explicit profiles broaden exec risk   | `tools.exec.safeBins`, `tools.exec.safeBinProfiles`, `agents.list[].tools.exec.*`                    | no       |
 | `tools.exec.safe_bins_broad_behavior`                         | warn          | Broad-behavior tools in `safeBins` weaken the low-risk stdin-filter trust model      | `tools.exec.safeBins`, `agents.list[].tools.exec.safeBins`                                           | no       |

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -62,15 +62,13 @@ Example schema:
   "defaults": {
     "security": "deny",
     "ask": "on-miss",
-    "askFallback": "deny",
-    "autoAllowSkills": false
+    "askFallback": "deny"
   },
   "agents": {
     "main": {
       "security": "allowlist",
       "ask": "on-miss",
       "askFallback": "deny",
-      "autoAllowSkills": true,
       "allowlist": [
         {
           "id": "B0C8C0B3-2C2D-4F8A-9A3C-5A4B3C2D1E0F",
@@ -127,18 +125,6 @@ Each allowlist entry tracks:
 - **last used command**
 - **last resolved path**
 
-## Auto-allow skill CLIs
-
-When **Auto-allow skill CLIs** is enabled, executables referenced by known skills
-are treated as allowlisted on nodes (macOS node or headless node host). This uses
-`skills.bins` over the Gateway RPC to fetch the skill bin list. Disable this if you want strict manual allowlists.
-
-Important trust notes:
-
-- This is an **implicit convenience allowlist**, separate from manual path allowlist entries.
-- It is intended for trusted operator environments where Gateway and node are in the same trust boundary.
-- If you require strict explicit trust, keep `autoAllowSkills: false` and use manual path allowlist entries only.
-
 ## Safe bins (stdin-only)
 
 `tools.exec.safeBins` defines a small list of **stdin-only** binaries (for example `jq`)
@@ -180,7 +166,7 @@ to `tools.exec.safeBinTrustedDirs`.
 Shell chaining and redirections are not auto-allowed in allowlist mode.
 
 Shell chaining (`&&`, `||`, `;`) is allowed when every top-level segment satisfies the allowlist
-(including safe bins or skill auto-allow). Redirections remain unsupported in allowlist mode.
+(including safe bins). Redirections remain unsupported in allowlist mode.
 Command substitution (`$()` / backticks) is rejected during allowlist parsing, including inside
 double quotes; use single quotes if you need literal `$()` text.
 On macOS companion-app approvals, raw shell text containing shell control or expansion syntax

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -132,9 +132,6 @@ allowlisted or a safe bin. Chaining (`;`, `&&`, `||`) and redirections are rejec
 allowlist mode unless every top-level segment satisfies the allowlist (including safe bins).
 Redirections remain unsupported.
 
-`autoAllowSkills` is a separate convenience path in exec approvals. It is not the same as
-manual path allowlist entries. For strict explicit trust, keep `autoAllowSkills` disabled.
-
 Use the two controls for different jobs:
 
 - `tools.exec.safeBins`: small, stdin-only stream filters.

--- a/src/gateway/protocol/schema/exec-approvals.ts
+++ b/src/gateway/protocol/schema/exec-approvals.ts
@@ -16,7 +16,6 @@ const ExecApprovalsPolicyFields = {
   security: Type.Optional(Type.String()),
   ask: Type.Optional(Type.String()),
   askFallback: Type.Optional(Type.String()),
-  autoAllowSkills: Type.Optional(Type.Boolean()),
 };
 
 export const ExecApprovalsDefaultsSchema = Type.Object(ExecApprovalsPolicyFields, {


### PR DESCRIPTION
## Summary

Closes #2538. Follow-up to #2524 / #2535 (UI side, merged at `b13e053c7d`). The skills marketplace is gutted per CLAUDE.md § Fork Context ("What's being removed"); `autoAllowSkills` is dead weight — runtime no longer reads it, UI no longer sends it. This PR strips the residual backend schema field and the user-facing docs surface.

**Pure subtraction: 3 insertions, 27 deletions across 5 files.**

## Scope

**In scope** (per issue):
- Backend TypeBox schema field
- 3 user-facing doc files (`docs/tools/exec.md`, `docs/tools/exec-approvals.md`, `docs/gateway/security/index.md`)

**In scope** (surfaced during polish review, same-feature orphans):
- `docs/gateway/protocol.md` — "Node helper methods" subsection documenting the gutted `skills.bins` RPC "for auto-allow checks". The RPC itself was gutted in #2413/#2448; this doc line was missed.

**Out of scope** (explicitly deferred):
- `apps/macos/Sources/RemoteClaw/*.swift` — 19 hits across `SystemRunSettingsView.swift`, `ExecApprovals.swift`, `ExecApprovalEvaluation.swift`. Native gut is coordinated under #2527 (native-release policy).
- `docs/refactor/*.md` — historical audit docs tracking the gut work itself (`docs-gutted-feature-audit.md` explicitly references #2538 as the tracker). These are meta-documentation; their references describe the cleanup, not a feature surface, and are preserved by design.

## Changes

| File | Change |
|------|--------|
| `src/gateway/protocol/schema/exec-approvals.ts` | Drop `autoAllowSkills` from `ExecApprovalsPolicyFields` (spreads into both `ExecApprovalsDefaultsSchema` + `ExecApprovalsAgentSchema`) |
| `docs/tools/exec.md` | Remove the 3-line "`autoAllowSkills` is a separate convenience path..." paragraph |
| `docs/tools/exec-approvals.md` | Drop 2 `autoAllowSkills` keys from JSON schema example; remove entire `## Auto-allow skill CLIs` section (12 lines); trim "or skill auto-allow" from allowlist-chaining prose |
| `docs/gateway/security/index.md` | Drop `autoAllowSkills` from exec-drift parenthetical; delete `tools.exec.auto_allow_skills_enabled` audit-code table row (no `src/` emitter — verified via grep) |
| `docs/gateway/protocol.md` | Delete the now-empty `### Node helper methods` subsection documenting `skills.bins` RPC "for auto-allow checks" |

## Risk assessment

**Low.** Pure subtraction; no runtime behavior change.

**On-disk `~/.remoteclaw/exec-approvals.json` with `autoAllowSkills`**: Existing files that still carry the field will be gracefully ignored. The field is dropped on first UI round-trip because the UI's typed state (`ExecApprovalsDefaults` / `ExecApprovalsAgent` in `ui/src/ui/controllers/exec-approvals.ts`) no longer declares `autoAllowSkills` after #2535, and no code path in `src/` validates the stored file against `ExecApprovalsFileSchema` on load (verified: zero `validateExecApprovalsSet`/`ExecApprovalsFileSchema` consumers outside the protocol export barrel). The strict `additionalProperties: false` validator only runs against incoming RPC params, not the stored file at rest.

## Acceptance criteria

- [x] `grep -rn 'autoAllowSkills' src/ docs/` returns zero hits *in user-facing surfaces* (macOS native + audit docs excluded per scope — see above)
- [x] `pnpm check` green — format (5113 files) + lint (3926 files) + typecheck + CSS class drift: 0 warnings, 0 errors
- [x] `pnpm test` green — 7010 passed, 3 skipped across 799 test files; 288 passed in parallel suite
- [x] `pnpm test:ui:smoke` green — 12 passed, 2 suites
- [x] No existing config files in the repo tree carry the field (verified via grep excluding `apps/macos/` and `docs/refactor/`)

## AC interpretation note on `grep -rn 'autoAllowSkills' src/ docs/`

After issue #2538 was filed, PR #2551 (`docs(audit): inventory docs/** refs to gutted features`) merged `docs/refactor/docs-gutted-feature-audit.md` and `docs/refactor/ui-test-fixture-audit-2528.md`, which are historical/meta audit documents cataloging the gut work. Those files mention `autoAllowSkills` *to describe the removal being tracked* — they are not feature surface. The audit doc explicitly classifies the three user-facing hits as STALE and links to #2538 as the tracker; those hits are what this PR eliminates. Interpreting the AC's "zero hits in `docs/`" strictly would require stripping the very word `autoAllowSkills` from the entries that track the PR itself, which would break the audit trail. The semantic intent (purge the feature from user-facing documentation) is met.

## Verification

- Fork-integrity gates: `throwing-stub-callers` 0 violations; `zombie-imports` clean; `stub-debt` baseline `126 == 126` unchanged; `obsolescence-audit` baseline `49 == 49` unchanged
- Polish converged in 3 fresh-context iterations (iter-1 found 2 orphans using snake_case + prose variants; iter-2 found 1 same-feature orphan in `docs/gateway/protocol.md` documenting the gutted `skills.bins` RPC; iter-3 CLEAN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)