### PR TITLE
gut(config): remove plugins.slots.memory schema field (#2571)

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -22750,7 +22750,7 @@
       "sensitive": false,
       "tags": ["advanced"],
       "label": "Plugin Slots",
-      "help": "Selects which plugins own exclusive runtime slots such as memory so only one plugin provides that capability. Use explicit slot ownership to avoid overlapping providers with conflicting behavior.",
+      "help": "Selects which plugins own exclusive runtime slots so only one plugin provides that capability. Use explicit slot ownership to avoid overlapping providers with conflicting behavior.",
       "hasChildren": true
     },
     {
@@ -22763,18 +22763,6 @@
       "tags": ["advanced"],
       "label": "Context Engine Plugin",
       "help": "Selects the active context engine plugin by id so one plugin provides context orchestration behavior.",
-      "hasChildren": false
-    },
-    {
-      "path": "plugins.slots.memory",
-      "kind": "core",
-      "type": "string",
-      "required": false,
-      "deprecated": false,
-      "sensitive": false,
-      "tags": ["advanced"],
-      "label": "Memory Plugin",
-      "help": "Select the active memory plugin by id, or \"none\" to disable memory plugins.",
       "hasChildren": false
     },
     {

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -158,7 +158,6 @@ remoteclaw plugins uninstall <id> --keep-files
 
 `uninstall` removes plugin records from `plugins.entries`, `plugins.installs`,
 the plugin allowlist, and linked `plugins.load.paths` entries when applicable.
-For active memory plugins, the memory slot resets to `memory-core`.
 
 By default, uninstall also removes the plugin install directory under the active
 state dir extensions root (`$REMOTECLAW_STATE_DIR/extensions/<id>`). Use

--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -240,15 +240,11 @@ resolved for a given run or compaction operation. Other enabled
 code; `plugins.slots.contextEngine` only selects which registered engine id
 RemoteClaw resolves when it needs a context engine.
 
-## Relationship to compaction and memory
+## Relationship to compaction
 
 - **Compaction** is one responsibility of the context engine. The legacy engine
   delegates to RemoteClaw's built-in summarization. Plugin engines can implement
   any compaction strategy (DAG summaries, vector retrieval, etc.).
-- **Memory plugins** (`plugins.slots.memory`) are separate from context engines.
-  Memory plugins provide search/retrieval; context engines control what the
-  model sees. They can work together — a context engine might use memory
-  plugin data during assembly.
 - **Session pruning** (trimming old tool results in-memory) still runs
   regardless of which context engine is active.
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2425,7 +2425,6 @@ See [Local Models](/gateway/local-models). TL;DR: run MiniMax M2.5 via LM Studio
 - `plugins.entries.<id>.subagent.allowedModels`: optional allowlist of canonical `provider/model` targets for trusted subagent overrides. Use `"*"` only when you intentionally want to allow any model.
 - `plugins.entries.<id>.config`: plugin-defined config object (validated by native RemoteClaw plugin schema when available).
 - Enabled Claude bundle plugins can also contribute embedded Pi defaults from `settings.json`; RemoteClaw applies those as sanitized agent settings, not as raw RemoteClaw config patches.
-- `plugins.slots.memory`: pick the active memory plugin id, or `"none"` to disable memory plugins.
 - `plugins.slots.contextEngine`: pick the active context engine plugin id; defaults to `"legacy"` unless you install and select another engine.
 - `plugins.installs`: CLI-managed install metadata used by `remoteclaw plugins update`.
   - Includes `source`, `spec`, `sourcePath`, `installPath`, `version`, `resolvedName`, `resolvedVersion`, `resolvedSpec`, `integrity`, `shasum`, `resolvedAt`, `installedAt`.

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -117,21 +117,21 @@ Those belong in your plugin code and `package.json`.
 
 ## Top-level field reference
 
-| Field                 | Required | Type                             | What it means                                                                                                                |
-| --------------------- | -------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `id`                  | Yes      | `string`                         | Canonical plugin id. This is the id used in `plugins.entries.<id>`.                                                          |
-| `configSchema`        | Yes      | `object`                         | Inline JSON Schema for this plugin's config.                                                                                 |
-| `enabledByDefault`    | No       | `true`                           | Marks a bundled plugin as enabled by default. Omit it, or set any non-`true` value, to leave the plugin disabled by default. |
-| `kind`                | No       | `"memory"` \| `"context-engine"` | Declares an exclusive plugin kind used by `plugins.slots.*`.                                                                 |
-| `channels`            | No       | `string[]`                       | Channel ids owned by this plugin. Used for discovery and config validation.                                                  |
-| `providers`           | No       | `string[]`                       | Provider ids owned by this plugin.                                                                                           |
-| `providerAuthEnvVars` | No       | `Record<string, string[]>`       | Cheap provider-auth env metadata that RemoteClaw can inspect without loading plugin code.                                    |
-| `providerAuthChoices` | No       | `object[]`                       | Cheap auth-choice metadata for onboarding pickers, preferred-provider resolution, and simple CLI flag wiring.                |
-| `skills`              | No       | `string[]`                       | Skill directories to load, relative to the plugin root.                                                                      |
-| `name`                | No       | `string`                         | Human-readable plugin name.                                                                                                  |
-| `description`         | No       | `string`                         | Short summary shown in plugin surfaces.                                                                                      |
-| `version`             | No       | `string`                         | Informational plugin version.                                                                                                |
-| `uiHints`             | No       | `Record<string, object>`         | UI labels, placeholders, and sensitivity hints for config fields.                                                            |
+| Field                 | Required | Type                       | What it means                                                                                                                |
+| --------------------- | -------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `id`                  | Yes      | `string`                   | Canonical plugin id. This is the id used in `plugins.entries.<id>`.                                                          |
+| `configSchema`        | Yes      | `object`                   | Inline JSON Schema for this plugin's config.                                                                                 |
+| `enabledByDefault`    | No       | `true`                     | Marks a bundled plugin as enabled by default. Omit it, or set any non-`true` value, to leave the plugin disabled by default. |
+| `kind`                | No       | `"context-engine"`         | Declares an exclusive plugin kind used by `plugins.slots.*`.                                                                 |
+| `channels`            | No       | `string[]`                 | Channel ids owned by this plugin. Used for discovery and config validation.                                                  |
+| `providers`           | No       | `string[]`                 | Provider ids owned by this plugin.                                                                                           |
+| `providerAuthEnvVars` | No       | `Record<string, string[]>` | Cheap provider-auth env metadata that RemoteClaw can inspect without loading plugin code.                                    |
+| `providerAuthChoices` | No       | `object[]`                 | Cheap auth-choice metadata for onboarding pickers, preferred-provider resolution, and simple CLI flag wiring.                |
+| `skills`              | No       | `string[]`                 | Skill directories to load, relative to the plugin root.                                                                      |
+| `name`                | No       | `string`                   | Human-readable plugin name.                                                                                                  |
+| `description`         | No       | `string`                   | Short summary shown in plugin surfaces.                                                                                      |
+| `version`             | No       | `string`                   | Informational plugin version.                                                                                                |
+| `uiHints`             | No       | `Record<string, object>`   | UI labels, placeholders, and sensitivity hints for config fields.                                                            |
 
 ## providerAuthChoices reference
 
@@ -231,7 +231,6 @@ See [Configuration reference](/gateway/configuration) for the full `plugins.*` s
   metadata that requires provider code, see
   [Provider runtime hooks](/plugins/architecture#provider-runtime-hooks).
 - Exclusive plugin kinds are selected through `plugins.slots.*`.
-  - `kind: "memory"` is selected by `plugins.slots.memory`.
   - `kind: "context-engine"` is selected by `plugins.slots.contextEngine`
     (default: built-in `legacy`).
 - `channels`, `providers`, and `skills` can be omitted when a plugin does not

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -94,11 +94,6 @@ and the [Plugin SDK Overview](/plugins/sdk-overview).
     `vercel-ai-gateway`, `volcengine`, `xiaomi`, `zai`
   </Accordion>
 
-  <Accordion title="Memory plugins">
-    - `memory-core` — bundled memory search (default via `plugins.slots.memory`)
-    - `memory-lancedb` — install-on-demand long-term memory with auto-recall/capture (set `plugins.slots.memory = "memory-lancedb"`)
-  </Accordion>
-
   <Accordion title="Speech providers (enabled by default)">
     `elevenlabs`, `microsoft`
   </Accordion>
@@ -126,14 +121,14 @@ Looking for third-party plugins? See [Community Plugins](/plugins/community).
 }
 ```
 
-| Field            | Description                                               |
-| ---------------- | --------------------------------------------------------- |
-| `enabled`        | Master toggle (default: `true`)                           |
-| `allow`          | Plugin allowlist (optional)                               |
-| `deny`           | Plugin denylist (optional; deny wins)                     |
-| `load.paths`     | Extra plugin files/directories                            |
-| `slots`          | Exclusive slot selectors (e.g. `memory`, `contextEngine`) |
-| `entries.\<id\>` | Per-plugin toggles + config                               |
+| Field            | Description                                     |
+| ---------------- | ----------------------------------------------- |
+| `enabled`        | Master toggle (default: `true`)                 |
+| `allow`          | Plugin allowlist (optional)                     |
+| `deny`           | Plugin denylist (optional; deny wins)           |
+| `load.paths`     | Extra plugin files/directories                  |
+| `slots`          | Exclusive slot selectors (e.g. `contextEngine`) |
+| `entries.\<id\>` | Per-plugin toggles + config                     |
 
 Config changes **require a gateway restart**. If the Gateway is running with config
 watch + in-process restart enabled (the default `remoteclaw gateway` path), that
@@ -185,7 +180,6 @@ Some categories are exclusive (only one active at a time):
 {
   plugins: {
     slots: {
-      memory: "memory-core", // or "none" to disable
       contextEngine: "legacy", // or a plugin id
     },
   },
@@ -194,7 +188,6 @@ Some categories are exclusive (only one active at a time):
 
 | Slot            | What it controls      | Default             |
 | --------------- | --------------------- | ------------------- |
-| `memory`        | Active memory plugin  | `memory-core`       |
 | `contextEngine` | Active context engine | `legacy` (built-in) |
 
 ## CLI reference

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -639,9 +639,6 @@ export function registerPluginsCli(program: Command) {
       ) {
         preview.push("load path");
       }
-      if (cfg.plugins?.slots?.memory === pluginId) {
-        preview.push(`memory slot (will reset to "memory-core")`);
-      }
       const deleteTarget = !keepFiles
         ? resolveUninstallDirectoryTarget({
             pluginId,
@@ -702,9 +699,6 @@ export function registerPluginsCli(program: Command) {
       }
       if (result.actions.loadPath) {
         removed.push("load path");
-      }
-      if (result.actions.memorySlot) {
-        removed.push("memory slot");
       }
       if (result.actions.directory) {
         removed.push("directory");

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -399,8 +399,6 @@ describe("statusCommand", () => {
     const payload = JSON.parse(String(runtimeLogMock.mock.calls[0]?.[0]));
     expect(payload.linkChannel.linked).toBe(true);
     expect(payload.memory.agentId).toBe("test-agent");
-    expect(payload.memoryPlugin.enabled).toBe(true);
-    expect(payload.memoryPlugin.slot).toBe("memory-core");
     expect(payload.memory.vector.available).toBe(true);
     expect(payload.sessions.count).toBe(1);
     expect(payload.sessions.paths).toContain("/tmp/sessions.json");

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -131,7 +131,6 @@ describe("config plugin validation", () => {
         entries: { "missing-plugin": { enabled: true } },
         allow: ["missing-allow"],
         deny: ["missing-deny"],
-        slots: { memory: "missing-slot" },
       },
     });
     expect(res.ok).toBe(false);
@@ -146,7 +145,6 @@ describe("config plugin validation", () => {
         expect.arrayContaining([
           { path: "plugins.allow", message: "plugin not found: missing-allow" },
           { path: "plugins.deny", message: "plugin not found: missing-deny" },
-          { path: "plugins.slots.memory", message: "plugin not found: missing-slot" },
         ]),
       );
       expect(res.warnings).toContainEqual({
@@ -166,7 +164,6 @@ describe("config plugin validation", () => {
         entries: { [removedId]: { enabled: true } },
         allow: [removedId],
         deny: [removedId],
-        slots: { memory: removedId },
       },
     });
     expect(res.ok).toBe(true);
@@ -185,11 +182,6 @@ describe("config plugin validation", () => {
           },
           {
             path: "plugins.deny",
-            message:
-              "plugin removed: google-antigravity-auth (stale config entry ignored; remove it from plugins config)",
-          },
-          {
-            path: "plugins.slots.memory",
             message:
               "plugin removed: google-antigravity-auth (stale config entry ignored; remove it from plugins config)",
           },

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -9057,9 +9057,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
           slots: {
             type: "object",
             properties: {
-              memory: {
-                type: "string",
-              },
               contextEngine: {
                 type: "string",
               },
@@ -13228,12 +13225,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
     },
     "plugins.slots": {
       label: "Plugin Slots",
-      help: "Selects which plugins own exclusive runtime slots such as memory so only one plugin provides that capability. Use explicit slot ownership to avoid overlapping providers with conflicting behavior.",
-      tags: ["advanced"],
-    },
-    "plugins.slots.memory": {
-      label: "Memory Plugin",
-      help: 'Select the active memory plugin by id, or "none" to disable memory plugins.',
+      help: "Selects which plugins own exclusive runtime slots so only one plugin provides that capability. Use explicit slot ownership to avoid overlapping providers with conflicting behavior.",
       tags: ["advanced"],
     },
     "plugins.slots.contextEngine": {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -863,9 +863,7 @@ export const FIELD_HELP: Record<string, string> = {
   "plugins.load.paths":
     "Additional plugin files or directories scanned by the loader beyond built-in defaults. Use dedicated extension directories and avoid broad paths with unrelated executable content.",
   "plugins.slots":
-    "Selects which plugins own exclusive runtime slots such as memory so only one plugin provides that capability. Use explicit slot ownership to avoid overlapping providers with conflicting behavior.",
-  "plugins.slots.memory":
-    'Select the active memory plugin by id, or "none" to disable memory plugins.',
+    "Selects which plugins own exclusive runtime slots so only one plugin provides that capability. Use explicit slot ownership to avoid overlapping providers with conflicting behavior.",
   "plugins.slots.contextEngine":
     "Selects the active context engine plugin by id so one plugin provides context orchestration behavior.",
   "plugins.entries":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -785,7 +785,6 @@ export const FIELD_LABELS: Record<string, string> = {
   "plugins.load": "Plugin Loader",
   "plugins.load.paths": "Plugin Load Paths",
   "plugins.slots": "Plugin Slots",
-  "plugins.slots.memory": "Memory Plugin",
   "plugins.slots.contextEngine": "Context Engine Plugin",
   "plugins.entries": "Plugin Entries",
   "plugins.entries.*.enabled": "Plugin Enabled",

--- a/src/config/types.plugins.ts
+++ b/src/config/types.plugins.ts
@@ -17,8 +17,6 @@ export type PluginEntryConfig = {
 };
 
 export type PluginSlotsConfig = {
-  /** Select which plugin owns the memory slot ("none" disables memory plugins). */
-  memory?: string;
   /** Select which plugin owns the context-engine slot. */
   contextEngine?: string;
 };

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,11 +1,7 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { CHANNEL_IDS, normalizeChatChannelId } from "../channels/registry.js";
-import {
-  normalizePluginsConfig,
-  resolveEffectiveEnableState,
-  resolveMemorySlotDecision,
-} from "../plugins/config-state.js";
+import { normalizePluginsConfig, resolveEffectiveEnableState } from "../plugins/config-state.js";
 import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
 import {
@@ -530,12 +526,6 @@ function validateConfigObjectWithPluginsBase(
     }
   }
 
-  const memorySlot = normalizedPlugins.slots.memory;
-  if (typeof memorySlot === "string" && memorySlot.trim() && !knownIds.has(memorySlot)) {
-    pushMissingPluginIssue("plugins.slots.memory", memorySlot);
-  }
-
-  let selectedMemoryPluginId: string | null = null;
   const seenPlugins = new Set<string>();
   for (const record of registry.plugins) {
     const pluginId = record.id;
@@ -546,30 +536,12 @@ function validateConfigObjectWithPluginsBase(
     const entry = normalizedPlugins.entries[pluginId];
     const entryHasConfig = Boolean(entry?.config);
 
-    const enableState = resolveEffectiveEnableState({
+    const { enabled, reason } = resolveEffectiveEnableState({
       id: pluginId,
       origin: record.origin,
       config: normalizedPlugins,
       rootConfig: config,
     });
-    let enabled = enableState.enabled;
-    let reason = enableState.reason;
-
-    if (enabled) {
-      const memoryDecision = resolveMemorySlotDecision({
-        id: pluginId,
-        kind: record.kind,
-        slot: memorySlot,
-        selectedId: selectedMemoryPluginId,
-      });
-      if (!memoryDecision.enabled) {
-        enabled = false;
-        reason = memoryDecision.reason;
-      }
-      if (memoryDecision.selected && record.kind === "memory") {
-        selectedMemoryPluginId = pluginId;
-      }
-    }
 
     const shouldValidate = enabled || entryHasConfig;
     if (shouldValidate) {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -732,7 +732,6 @@ export const RemoteClawSchema = z
           .optional(),
         slots: z
           .object({
-            memory: z.string().optional(),
             contextEngine: z.string().optional(),
           })
           .strict()

--- a/src/gateway/tools-invoke-http.cron-regression.test.ts
+++ b/src/gateway/tools-invoke-http.cron-regression.test.ts
@@ -6,7 +6,6 @@ const TEST_GATEWAY_TOKEN = "test-gateway-token-1234567890";
 
 let cfg: Record<string, unknown> = {};
 const alwaysAuthorized = async () => ({ ok: true as const });
-const disableDefaultMemorySlot = () => false;
 const noPluginToolMeta = () => undefined;
 const noWarnLog = () => {};
 
@@ -24,10 +23,6 @@ vi.mock("./auth.js", () => ({
 
 vi.mock("../logger.js", () => ({
   logWarn: noWarnLog,
-}));
-
-vi.mock("../plugins/config-state.js", () => ({
-  isTestDefaultMemorySlotDisabled: disableDefaultMemorySlot,
 }));
 
 vi.mock("../plugins/tools.js", () => ({

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -42,10 +42,6 @@ vi.mock("../logger.js", () => ({
   logWarn: () => {},
 }));
 
-vi.mock("../plugins/config-state.js", () => ({
-  isTestDefaultMemorySlotDisabled: () => false,
-}));
-
 vi.mock("../plugins/tools.js", () => ({
   getPluginToolMeta: () => undefined,
 }));

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -18,7 +18,6 @@ import { ToolInputError } from "../agents/tools/common.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
 import { logWarn } from "../logger.js";
-import { isTestDefaultMemorySlotDisabled } from "../plugins/config-state.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { isSubagentSessionKey } from "../routing/session-key.js";
 import { DEFAULT_GATEWAY_HTTP_TOOL_DENY } from "../security/dangerous-tools.js";
@@ -35,7 +34,6 @@ import {
 import { getBearerToken, getHeader } from "./http-utils.js";
 
 const DEFAULT_BODY_BYTES = 2 * 1024 * 1024;
-const MEMORY_TOOL_NAMES = new Set(["memory_search", "memory_get"]);
 
 type ToolsInvokeBody = {
   tool?: unknown;
@@ -50,30 +48,6 @@ function resolveSessionKeyFromBody(body: ToolsInvokeBody): string | undefined {
     return body.sessionKey.trim();
   }
   return undefined;
-}
-
-function resolveMemoryToolDisableReasons(cfg: ReturnType<typeof loadConfig>): string[] {
-  if (!process.env.VITEST) {
-    return [];
-  }
-  const reasons: string[] = [];
-  const plugins = cfg.plugins;
-  const slotRaw = plugins?.slots?.memory;
-  const slotDisabled =
-    slotRaw === null || (typeof slotRaw === "string" && slotRaw.trim().toLowerCase() === "none");
-  const pluginsDisabled = plugins?.enabled === false;
-  const defaultDisabled = isTestDefaultMemorySlotDisabled(cfg);
-
-  if (pluginsDisabled) {
-    reasons.push("plugins.enabled=false");
-  }
-  if (slotDisabled) {
-    reasons.push(slotRaw === null ? "plugins.slots.memory=null" : 'plugins.slots.memory="none"');
-  }
-  if (!pluginsDisabled && !slotDisabled && defaultDisabled) {
-    reasons.push("memory plugin disabled by test default");
-  }
-  return reasons;
 }
 
 function mergeActionIntoArgsIfSupported(params: {
@@ -177,23 +151,6 @@ export async function handleToolsInvokeHttpRequest(
   if (!toolName) {
     sendInvalidRequest(res, "tools.invoke requires body.tool");
     return true;
-  }
-
-  if (process.env.VITEST && MEMORY_TOOL_NAMES.has(toolName)) {
-    const reasons = resolveMemoryToolDisableReasons(cfg);
-    if (reasons.length > 0) {
-      const suffix = reasons.length > 0 ? ` (${reasons.join(", ")})` : "";
-      sendJson(res, 400, {
-        ok: false,
-        error: {
-          type: "invalid_request",
-          message:
-            `memory tools are disabled in tests${suffix}. ` +
-            'Enable by setting plugins.slots.memory="memory-core" (and ensure plugins.enabled is not false).',
-        },
-      });
-      return true;
-    }
   }
 
   const action = typeof body.action === "string" ? body.action.trim() : undefined;

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  memoryRegister: vi.fn(),
+  conflictingRegister: vi.fn(),
   otherRegister: vi.fn(),
 }));
 
@@ -10,9 +10,9 @@ vi.mock("./loader.js", () => ({
   loadRemoteClawPlugins: () => ({
     cliRegistrars: [
       {
-        pluginId: "memory-core",
-        register: mocks.memoryRegister,
-        commands: ["memory"],
+        pluginId: "conflicting-plugin",
+        register: mocks.conflictingRegister,
+        commands: ["conflict-cmd"],
         source: "bundled",
       },
       {
@@ -29,13 +29,13 @@ import { registerPluginCliCommands } from "./cli.js";
 
 describe("registerPluginCliCommands", () => {
   beforeEach(() => {
-    mocks.memoryRegister.mockClear();
+    mocks.conflictingRegister.mockClear();
     mocks.otherRegister.mockClear();
   });
 
   it("skips plugin CLI registrars when commands already exist", () => {
     const program = new Command();
-    program.command("memory");
+    program.command("conflict-cmd");
 
     registerPluginCliCommands(
       program,
@@ -43,7 +43,7 @@ describe("registerPluginCliCommands", () => {
       { agents: { list: [{ id: "main", workspace: "/tmp/test-workspace" }] } } as any,
     );
 
-    expect(mocks.memoryRegister).not.toHaveBeenCalled();
+    expect(mocks.conflictingRegister).not.toHaveBeenCalled();
     expect(mocks.otherRegister).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -1,60 +1,7 @@
 import { describe, expect, it } from "vitest";
-import {
-  normalizePluginsConfig,
-  resolveEffectiveEnableState,
-  resolveEnableState,
-} from "./config-state.js";
+import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 
 describe("normalizePluginsConfig", () => {
-  it("uses default memory slot when not specified", () => {
-    const result = normalizePluginsConfig({});
-    // Memory gutted in RemoteClaw fork — default is "none" (resolves to null)
-    expect(result.slots.memory).toBeNull();
-  });
-
-  it("respects explicit memory slot value", () => {
-    const result = normalizePluginsConfig({
-      slots: { memory: "custom-memory" },
-    });
-    expect(result.slots.memory).toBe("custom-memory");
-  });
-
-  it("disables memory slot when set to 'none' (case insensitive)", () => {
-    expect(
-      normalizePluginsConfig({
-        slots: { memory: "none" },
-      }).slots.memory,
-    ).toBeNull();
-    expect(
-      normalizePluginsConfig({
-        slots: { memory: "None" },
-      }).slots.memory,
-    ).toBeNull();
-  });
-
-  it("trims whitespace from memory slot value", () => {
-    const result = normalizePluginsConfig({
-      slots: { memory: "  custom-memory  " },
-    });
-    expect(result.slots.memory).toBe("custom-memory");
-  });
-
-  it("uses default when memory slot is empty string", () => {
-    const result = normalizePluginsConfig({
-      slots: { memory: "" },
-    });
-    // Memory gutted in RemoteClaw fork — default is "none" (resolves to null)
-    expect(result.slots.memory).toBeNull();
-  });
-
-  it("uses default when memory slot is whitespace only", () => {
-    const result = normalizePluginsConfig({
-      slots: { memory: "   " },
-    });
-    // Memory gutted in RemoteClaw fork — default is "none" (resolves to null)
-    expect(result.slots.memory).toBeNull();
-  });
-
   it("normalizes plugin hook policy flags", () => {
     const result = normalizePluginsConfig({
       entries: {
@@ -115,37 +62,6 @@ describe("resolveEffectiveEnableState", () => {
         },
       },
     });
-    expect(state).toEqual({ enabled: false, reason: "disabled in config" });
-  });
-});
-
-describe("resolveEnableState", () => {
-  it("keeps the selected memory slot plugin enabled even when omitted from plugins.allow", () => {
-    const state = resolveEnableState(
-      "memory-core",
-      "bundled",
-      normalizePluginsConfig({
-        allow: ["telegram"],
-        slots: { memory: "memory-core" },
-      }),
-    );
-    expect(state).toEqual({ enabled: true });
-  });
-
-  it("keeps explicit disable authoritative for the selected memory slot plugin", () => {
-    const state = resolveEnableState(
-      "memory-core",
-      "bundled",
-      normalizePluginsConfig({
-        allow: ["telegram"],
-        slots: { memory: "memory-core" },
-        entries: {
-          "memory-core": {
-            enabled: false,
-          },
-        },
-      }),
-    );
     expect(state).toEqual({ enabled: false, reason: "disabled in config" });
   });
 });

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -1,16 +1,12 @@
 import { normalizeChatChannelId } from "../channels/registry.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import type { PluginRecord } from "./registry.js";
-import { defaultSlotIdForKey } from "./slots.js";
 
 export type NormalizedPluginsConfig = {
   enabled: boolean;
   allow: string[];
   deny: string[];
   loadPaths: string[];
-  slots: {
-    memory?: string | null;
-  };
   entries: Record<
     string,
     {
@@ -34,20 +30,6 @@ const normalizeList = (value: unknown): string[] => {
     return [];
   }
   return value.map((entry) => (typeof entry === "string" ? entry.trim() : "")).filter(Boolean);
-};
-
-const normalizeSlotValue = (value: unknown): string | null | undefined => {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  if (trimmed.toLowerCase() === "none") {
-    return null;
-  }
-  return trimmed;
 };
 
 const normalizePluginEntries = (entries: unknown): NormalizedPluginsConfig["entries"] => {
@@ -90,27 +72,14 @@ const normalizePluginEntries = (entries: unknown): NormalizedPluginsConfig["entr
 export const normalizePluginsConfig = (
   config?: RemoteClawConfig["plugins"],
 ): NormalizedPluginsConfig => {
-  const memorySlot = normalizeSlotValue(config?.slots?.memory);
   return {
     enabled: config?.enabled !== false,
     allow: normalizeList(config?.allow),
     deny: normalizeList(config?.deny),
     loadPaths: normalizeList(config?.load?.paths),
-    slots: {
-      memory:
-        memorySlot === undefined
-          ? (normalizeSlotValue(defaultSlotIdForKey("memory")) ?? null)
-          : memorySlot,
-    },
     entries: normalizePluginEntries(config?.entries),
   };
 };
-
-const hasExplicitMemorySlot = (plugins?: RemoteClawConfig["plugins"]) =>
-  Boolean(plugins?.slots && Object.prototype.hasOwnProperty.call(plugins.slots, "memory"));
-
-const hasExplicitMemoryEntry = (plugins?: RemoteClawConfig["plugins"]) =>
-  Boolean(plugins?.entries && Object.prototype.hasOwnProperty.call(plugins.entries, "memory-core"));
 
 const hasExplicitPluginConfig = (plugins?: RemoteClawConfig["plugins"]) => {
   if (!plugins) {
@@ -144,49 +113,16 @@ export function applyTestPluginDefaults(
   if (!env.VITEST) {
     return cfg;
   }
-  const plugins = cfg.plugins;
-  const explicitConfig = hasExplicitPluginConfig(plugins);
-  if (explicitConfig) {
-    if (hasExplicitMemorySlot(plugins) || hasExplicitMemoryEntry(plugins)) {
-      return cfg;
-    }
-    return {
-      ...cfg,
-      plugins: {
-        ...plugins,
-        slots: {
-          ...plugins?.slots,
-          memory: "none",
-        },
-      },
-    };
+  if (hasExplicitPluginConfig(cfg.plugins)) {
+    return cfg;
   }
-
   return {
     ...cfg,
     plugins: {
-      ...plugins,
+      ...cfg.plugins,
       enabled: false,
-      slots: {
-        ...plugins?.slots,
-        memory: "none",
-      },
     },
   };
-}
-
-export function isTestDefaultMemorySlotDisabled(
-  cfg: RemoteClawConfig,
-  env: NodeJS.ProcessEnv = process.env,
-): boolean {
-  if (!env.VITEST) {
-    return false;
-  }
-  const plugins = cfg.plugins;
-  if (hasExplicitMemorySlot(plugins) || hasExplicitMemoryEntry(plugins)) {
-    return false;
-  }
-  return true;
 }
 
 export function resolveEnableState(
@@ -203,9 +139,6 @@ export function resolveEnableState(
   const entry = config.entries[id];
   if (entry?.enabled === false) {
     return { enabled: false, reason: "disabled in config" };
-  }
-  if (config.slots.memory === id) {
-    return { enabled: true };
   }
   if (config.allow.length > 0 && !config.allow.includes(id)) {
     return { enabled: false, reason: "not in allowlist" };
@@ -256,34 +189,4 @@ export function resolveEffectiveEnableState(params: {
     return { enabled: true };
   }
   return base;
-}
-
-export function resolveMemorySlotDecision(params: {
-  id: string;
-  kind?: string;
-  slot: string | null | undefined;
-  selectedId: string | null;
-}): { enabled: boolean; reason?: string; selected?: boolean } {
-  if (params.kind !== "memory") {
-    return { enabled: true };
-  }
-  if (params.slot === null) {
-    return { enabled: false, reason: "memory slot disabled" };
-  }
-  if (typeof params.slot === "string") {
-    if (params.slot === params.id) {
-      return { enabled: true, selected: true };
-    }
-    return {
-      enabled: false,
-      reason: `memory slot set to "${params.slot}"`,
-    };
-  }
-  if (params.selectedId && params.selectedId !== params.id) {
-    return {
-      enabled: false,
-      reason: `memory slot already filled by "${params.selectedId}"`,
-    };
-  }
-  return { enabled: true, selected: true };
 }

--- a/src/plugins/enable.test.ts
+++ b/src/plugins/enable.test.ts
@@ -13,12 +13,12 @@ describe("enablePluginInConfig", () => {
   it("adds plugin to allowlist when allowlist is configured", () => {
     const cfg: RemoteClawConfig = {
       plugins: {
-        allow: ["memory-core"],
+        allow: ["voice-call"],
       },
     };
     const result = enablePluginInConfig(cfg, "google");
     expect(result.enabled).toBe(true);
-    expect(result.config.plugins?.allow).toEqual(["memory-core", "google"]);
+    expect(result.config.plugins?.allow).toEqual(["voice-call", "google"]);
   });
 
   it("refuses enable when plugin is denylisted", () => {
@@ -43,13 +43,13 @@ describe("enablePluginInConfig", () => {
   it("adds built-in channel id to allowlist when allowlist is configured", () => {
     const cfg: RemoteClawConfig = {
       plugins: {
-        allow: ["memory-core"],
+        allow: ["voice-call"],
       },
     };
     const result = enablePluginInConfig(cfg, "telegram");
     expect(result.enabled).toBe(true);
     expect(result.config.channels?.telegram?.enabled).toBe(true);
-    expect(result.config.plugins?.allow).toEqual(["memory-core", "telegram"]);
+    expect(result.config.plugins?.allow).toEqual(["voice-call", "telegram"]);
   });
 
   it("re-enables built-in channels after explicit plugin-level disable", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -13,7 +13,6 @@ import {
   applyTestPluginDefaults,
   normalizePluginsConfig,
   resolveEffectiveEnableState,
-  resolveMemorySlotDecision,
   type NormalizedPluginsConfig,
 } from "./config-state.js";
 import { discoverRemoteClawPlugins } from "./discovery.js";
@@ -562,9 +561,6 @@ export function loadRemoteClawPlugins(options: PluginLoadOptions = {}): PluginRe
   );
 
   const seenIds = new Map<string, PluginRecord["origin"]>();
-  const memorySlot = normalized.slots.memory;
-  let selectedMemoryPluginId: string | null = null;
-  let memorySlotMatched = false;
 
   for (const candidate of discovery.candidates) {
     const manifestRecord = manifestByRoot.get(candidate.rootDir);
@@ -633,25 +629,6 @@ export function loadRemoteClawPlugins(options: PluginLoadOptions = {}): PluginRe
       continue;
     }
 
-    // Fast-path bundled memory plugins that are guaranteed disabled by slot policy.
-    // This avoids opening/importing heavy memory plugin modules that will never register.
-    if (candidate.origin === "bundled" && manifestRecord.kind === "memory") {
-      const earlyMemoryDecision = resolveMemorySlotDecision({
-        id: record.id,
-        kind: "memory",
-        slot: memorySlot,
-        selectedId: selectedMemoryPluginId,
-      });
-      if (!earlyMemoryDecision.enabled) {
-        record.enabled = false;
-        record.status = "disabled";
-        record.error = earlyMemoryDecision.reason;
-        registry.plugins.push(record);
-        seenIds.set(pluginId, candidate.origin);
-        continue;
-      }
-    }
-
     if (!manifestRecord.configSchema) {
       pushPluginLoadError("missing config schema");
       continue;
@@ -718,30 +695,6 @@ export function loadRemoteClawPlugins(options: PluginLoadOptions = {}): PluginRe
     }
     record.kind = definition?.kind ?? record.kind;
 
-    if (record.kind === "memory" && memorySlot === record.id) {
-      memorySlotMatched = true;
-    }
-
-    const memoryDecision = resolveMemorySlotDecision({
-      id: record.id,
-      kind: record.kind,
-      slot: memorySlot,
-      selectedId: selectedMemoryPluginId,
-    });
-
-    if (!memoryDecision.enabled) {
-      record.enabled = false;
-      record.status = "disabled";
-      record.error = memoryDecision.reason;
-      registry.plugins.push(record);
-      seenIds.set(pluginId, candidate.origin);
-      continue;
-    }
-
-    if (memoryDecision.selected && record.kind === "memory") {
-      selectedMemoryPluginId = record.id;
-    }
-
     const validatedConfig = validatePluginConfig({
       schema: manifestRecord.configSchema,
       cacheKey: manifestRecord.schemaCacheKey,
@@ -797,13 +750,6 @@ export function loadRemoteClawPlugins(options: PluginLoadOptions = {}): PluginRe
         diagnosticMessagePrefix: "plugin failed during register: ",
       });
     }
-  }
-
-  if (typeof memorySlot === "string" && !memorySlotMatched) {
-    registry.diagnostics.push({
-      level: "warn",
-      message: `memory slot plugin not found or not marked as memory: ${memorySlot}`,
-    });
   }
 
   warnAboutUntrackedLoadedPlugins({

--- a/src/plugins/slots.ts
+++ b/src/plugins/slots.ts
@@ -10,14 +10,10 @@ type SlotPluginRecord = {
 };
 
 const SLOT_BY_KIND: Record<PluginKind, PluginSlotKey> = {
-  memory: "memory",
   "context-engine": "contextEngine",
 };
 
 const DEFAULT_SLOT_BY_KEY: Record<PluginSlotKey, string> = {
-  // Memory was gutted in RemoteClaw fork (Middleware Boundary Principle).
-  // Default to "none" so config validation doesn't look for a deleted plugin.
-  memory: "none",
   contextEngine: "legacy",
 };
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -35,7 +35,7 @@ export type PluginConfigUiHint = {
   placeholder?: string;
 };
 
-export type PluginKind = "memory" | "context-engine";
+export type PluginKind = "context-engine";
 
 export type PluginConfigValidation =
   | { ok: true; value?: unknown }

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -3,14 +3,12 @@ import path from "node:path";
 import type { RemoteClawConfig } from "../config/config.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { resolvePluginInstallDir } from "./install.js";
-import { defaultSlotIdForKey } from "./slots.js";
 
 export type UninstallActions = {
   entry: boolean;
   install: boolean;
   allowlist: boolean;
   loadPath: boolean;
-  memorySlot: boolean;
   directory: boolean;
 };
 
@@ -60,7 +58,7 @@ export function resolveUninstallDirectoryTarget(params: {
 
 /**
  * Remove plugin references from config (pure config mutation).
- * Returns a new config with the plugin removed from entries, installs, allow, load.paths, and slots.
+ * Returns a new config with the plugin removed from entries, installs, allow, and load.paths.
  */
 export function removePluginFromConfig(
   cfg: RemoteClawConfig,
@@ -71,7 +69,6 @@ export function removePluginFromConfig(
     install: false,
     allowlist: false,
     loadPath: false,
-    memorySlot: false,
   };
 
   const pluginsConfig = cfg.plugins ?? {};
@@ -115,16 +112,9 @@ export function removePluginFromConfig(
     }
   }
 
-  // Reset memory slot if this plugin was selected
+  // Drop slots if empty (slots may legitimately exist for contextEngine,
+  // but an empty {} should not leak into the config output).
   let slots = pluginsConfig.slots;
-  if (slots?.memory === pluginId) {
-    const defaultMemory = defaultSlotIdForKey("memory");
-    slots = {
-      ...slots,
-      ...(defaultMemory != null ? { memory: defaultMemory } : {}),
-    };
-    actions.memorySlot = true;
-  }
   if (slots && Object.keys(slots).length === 0) {
     slots = undefined;
   }


### PR DESCRIPTION
## Summary

Removes the `plugins.slots.memory` schema field and all in-fork callers. The slot was decorative dead code: it validated and labeled itself, but no plugin could fill it — `memory-core` (the only built-in memory plugin) was gutted by WI-118. Per the Middleware Boundary Principle, headless CLI agents bring their own memory; RemoteClaw should not carry a memory-plugin slot.

Closes #2571.

## Scope

- **Schema source + generated artifacts**: `zod-schema.ts`, `types.plugins.ts`, regenerated `schema.base.generated.ts` and `docs/.generated/config-baseline.json`, `schema.labels.ts`, `schema.help.ts` (parent help rewritten to drop "such as memory" example)
- **Validation**: `validation.ts` — drop the memorySlot validation block and per-plugin memoryDecision wiring
- **Plugin runtime**: narrowed `PluginKind = "context-engine"`; dropped memory entries from `slots.ts`; simplified `config-state.ts` (`applyTestPluginDefaults` now has a single branch); dropped memorySlot logic and bundled fast-path from `loader.ts`; dropped `UninstallActions.memorySlot`
- **CLI**: `plugins-cli.ts` — dropped "memory slot" preview/result text
- **Gateway**: `tools-invoke-http.ts` — dropped `MEMORY_TOOL_NAMES`, `resolveMemoryToolDisableReasons`, and the entire VITEST memory-tool-disable branch
- **Tests**: removed memory-slot-specific cases; replaced "memory-core" string fixtures with valid alternatives ("voice-call", "conflicting-plugin"); dropped dead `payload.memoryPlugin.{enabled,slot}` assertions; dropped `isTestDefaultMemorySlotDisabled` mocks
- **Docs**: updated `docs/tools/plugin.md`, `docs/plugins/manifest.md`, `docs/concepts/context-engine.md`, `docs/gateway/configuration-reference.md`, `docs/cli/plugins.md` to remove stale `plugins.slots.memory` references

26 files changed: +48 / -433.

## Out of scope (per issue)

- `plugins.slots.contextEngine` slot — separate gut decision required, retained
- `bundled-plugin-metadata.generated.ts` still has `memory-core`/`memory-lancedb` entries — pre-existing dead generated artifact (no consumers, generator script no longer exists), separate metadata regen concern
- `tsconfig.plugin-sdk.dts.json:47-48` references missing `src/plugin-sdk/memory-core.ts` and `memory-lancedb.ts` — pre-existing tsconfig staleness from earlier gut wave (TypeScript silently ignores missing includes)

## Verification

- `pnpm tsgo`: PASS
- `pnpm lint`: 0 warnings, 0 errors
- `pnpm format:check`: clean
- `pnpm check`: PASS (full pipeline including CSS class drift)
- `pnpm test`: 738 files / 6542 passed / 3 skipped / 0 failures
- `pnpm build`: PASS
- Schema generators (`generate-base-config-schema.ts --check` and `generate-config-doc-baseline.ts --check`): no drift

Adversarial validation (fresh-context dispatch): 5/5 AC PASS, 7/7 probes resolved (CLEAN/OUT_OF_SCOPE).

Polish (fresh-context dispatch): CLEAN.

## Test plan

- [ ] CI green on `build`, `test`, `test-ui-smoke`, `lint`, `docs`
- [ ] Manually verify config files using only `plugins.slots.contextEngine` still validate
- [ ] Manually verify config files containing `plugins.slots.memory` now fail with a "unrecognized key" zod error (proper rejection of removed schema field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)