### PR TITLE
sync(macos): cherry-pick v2026.3.22 to Cat A cluster A2 — 31 files (#2583)

### DIFF
--- a/apps/macos/Sources/RemoteClaw/AgentWorkspaceConfig.swift
+++ b/apps/macos/Sources/RemoteClaw/AgentWorkspaceConfig.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+enum AgentWorkspaceConfig {
+    static func workspace(from root: [String: Any]) -> String? {
+        let agents = root["agents"] as? [String: Any]
+        let defaults = agents?["defaults"] as? [String: Any]
+        return defaults?["workspace"] as? String
+    }
+
+    static func setWorkspace(in root: inout [String: Any], workspace: String?) {
+        var agents = root["agents"] as? [String: Any] ?? [:]
+        var defaults = agents["defaults"] as? [String: Any] ?? [:]
+        let trimmed = workspace?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if trimmed.isEmpty {
+            defaults.removeValue(forKey: "workspace")
+        } else {
+            defaults["workspace"] = trimmed
+        }
+        if defaults.isEmpty {
+            agents.removeValue(forKey: "defaults")
+        } else {
+            agents["defaults"] = defaults
+        }
+        if agents.isEmpty {
+            root.removeValue(forKey: "agents")
+        } else {
+            root["agents"] = agents
+        }
+    }
+}

--- a/apps/macos/Sources/RemoteClaw/AudioInputDeviceObserver.swift
+++ b/apps/macos/Sources/RemoteClaw/AudioInputDeviceObserver.swift
@@ -9,21 +9,7 @@ final class AudioInputDeviceObserver {
     private var defaultInputListener: AudioObjectPropertyListenerBlock?
 
     static func defaultInputDeviceUID() -> String? {
-        let systemObject = AudioObjectID(kAudioObjectSystemObject)
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultInputDevice,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain)
-        var deviceID = AudioObjectID(0)
-        var size = UInt32(MemoryLayout<AudioObjectID>.size)
-        let status = AudioObjectGetPropertyData(
-            systemObject,
-            &address,
-            0,
-            nil,
-            &size,
-            &deviceID)
-        guard status == noErr, deviceID != 0 else { return nil }
+        guard let deviceID = self.defaultInputDeviceID() else { return nil }
         return self.deviceUID(for: deviceID)
     }
 
@@ -63,6 +49,15 @@ final class AudioInputDeviceObserver {
     }
 
     static func defaultInputDeviceSummary() -> String {
+        guard let deviceID = self.defaultInputDeviceID() else {
+            return "defaultInput=unknown"
+        }
+        let uid = self.deviceUID(for: deviceID) ?? "unknown"
+        let name = self.deviceName(for: deviceID) ?? "unknown"
+        return "defaultInput=\(name) (\(uid))"
+    }
+
+    private static func defaultInputDeviceID() -> AudioObjectID? {
         let systemObject = AudioObjectID(kAudioObjectSystemObject)
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDefaultInputDevice,
@@ -77,12 +72,8 @@ final class AudioInputDeviceObserver {
             nil,
             &size,
             &deviceID)
-        guard status == noErr, deviceID != 0 else {
-            return "defaultInput=unknown"
-        }
-        let uid = self.deviceUID(for: deviceID) ?? "unknown"
-        let name = self.deviceName(for: deviceID) ?? "unknown"
-        return "defaultInput=\(name) (\(uid))"
+        guard status == noErr, deviceID != 0 else { return nil }
+        return deviceID
     }
 
     func start(onChange: @escaping @Sendable () -> Void) {

--- a/apps/macos/Sources/RemoteClaw/ConfigSettings.swift
+++ b/apps/macos/Sources/RemoteClaw/ConfigSettings.swift
@@ -72,7 +72,7 @@ extension ConfigSettings {
     }
 
     private var sidebar: some View {
-        ScrollView {
+        SettingsSidebarScroll {
             LazyVStack(alignment: .leading, spacing: 8) {
                 if self.sections.isEmpty {
                     Text("No config sections available.")
@@ -86,14 +86,7 @@ extension ConfigSettings {
                     }
                 }
             }
-            .padding(.vertical, 10)
-            .padding(.horizontal, 10)
         }
-        .frame(minWidth: 220, idealWidth: 240, maxWidth: 280, maxHeight: .infinity, alignment: .topLeading)
-        .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color(nsColor: .windowBackgroundColor)))
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 
     private var detail: some View {

--- a/apps/macos/Sources/RemoteClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/RemoteClaw/GatewayEndpointStore.swift
@@ -237,7 +237,7 @@ actor GatewayEndpointStore {
         if let modeRaw {
             initialMode = AppState.ConnectionMode(rawValue: modeRaw) ?? .local
         } else {
-            let seen = UserDefaults.standard.bool(forKey: "openclaw.onboardingSeen")
+            let seen = UserDefaults.standard.bool(forKey: "remoteclaw.onboardingSeen")
             initialMode = seen ? .local : .unconfigured
         }
 

--- a/apps/macos/Sources/RemoteClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/RemoteClaw/GatewayLaunchAgentManager.swift
@@ -180,25 +180,11 @@ extension GatewayLaunchAgentManager {
     }
 
     private static func parseDaemonJson(from raw: String) -> ParsedDaemonJson? {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let start = trimmed.firstIndex(of: "{"),
-              let end = trimmed.lastIndex(of: "}")
-        else {
-            return nil
-        }
-        let jsonText = String(trimmed[start...end])
-        guard let data = jsonText.data(using: .utf8) else { return nil }
-        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
-        return ParsedDaemonJson(text: jsonText, object: object)
+        guard let parsed = JSONObjectExtractionSupport.extract(from: raw) else { return nil }
+        return ParsedDaemonJson(text: parsed.text, object: parsed.object)
     }
 
     private static func summarize(_ text: String) -> String? {
-        let lines = text
-            .split(whereSeparator: \.isNewline)
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-        guard let last = lines.last else { return nil }
-        let normalized = last.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
-        return normalized.count > 200 ? String(normalized.prefix(199)) + "…" : normalized
+        TextSummarySupport.summarizeLastLine(text)
     }
 }

--- a/apps/macos/Sources/RemoteClaw/GatewayPushSubscription.swift
+++ b/apps/macos/Sources/RemoteClaw/GatewayPushSubscription.swift
@@ -1,0 +1,34 @@
+import RemoteClawKit
+
+enum GatewayPushSubscription {
+    @MainActor
+    static func consume(
+        bufferingNewest: Int? = nil,
+        onPush: @escaping @MainActor (GatewayPush) -> Void) async
+    {
+        let stream: AsyncStream<GatewayPush> = if let bufferingNewest {
+            await GatewayConnection.shared.subscribe(bufferingNewest: bufferingNewest)
+        } else {
+            await GatewayConnection.shared.subscribe()
+        }
+
+        for await push in stream {
+            if Task.isCancelled { return }
+            await MainActor.run {
+                onPush(push)
+            }
+        }
+    }
+
+    @MainActor
+    static func restartTask(
+        task: inout Task<Void, Never>?,
+        bufferingNewest: Int? = nil,
+        onPush: @escaping @MainActor (GatewayPush) -> Void)
+    {
+        task?.cancel()
+        task = Task {
+            await self.consume(bufferingNewest: bufferingNewest, onPush: onPush)
+        }
+    }
+}

--- a/apps/macos/Sources/RemoteClaw/InstancesSettings.swift
+++ b/apps/macos/Sources/RemoteClaw/InstancesSettings.swift
@@ -43,16 +43,8 @@ struct InstancesSettings: View {
                     .foregroundStyle(.secondary)
             }
             Spacer()
-            if self.store.isLoading {
-                ProgressView()
-            } else {
-                Button {
-                    Task { await self.store.refresh() }
-                } label: {
-                    Label("Refresh", systemImage: "arrow.clockwise")
-                }
-                .buttonStyle(.bordered)
-                .help("Refresh")
+            SettingsRefreshButton(isLoading: self.store.isLoading) {
+                Task { await self.store.refresh() }
             }
         }
     }
@@ -276,7 +268,7 @@ struct InstancesSettings: View {
     }
 
     private func platformIcon(_ raw: String) -> String {
-        let (prefix, _) = self.parsePlatform(raw)
+        let (prefix, _) = PlatformLabelFormatter.parse(raw)
         switch prefix {
         case "macos":
             return "laptopcomputer"
@@ -294,31 +286,7 @@ struct InstancesSettings: View {
     }
 
     private func prettyPlatform(_ raw: String) -> String? {
-        let (prefix, version) = self.parsePlatform(raw)
-        if prefix.isEmpty { return nil }
-        let name: String = switch prefix {
-        case "macos": "macOS"
-        case "ios": "iOS"
-        case "ipados": "iPadOS"
-        case "tvos": "tvOS"
-        case "watchos": "watchOS"
-        default: prefix.prefix(1).uppercased() + prefix.dropFirst()
-        }
-        guard let version, !version.isEmpty else { return name }
-        let parts = version.split(separator: ".").map(String.init)
-        if parts.count >= 2 {
-            return "\(name) \(parts[0]).\(parts[1])"
-        }
-        return "\(name) \(version)"
-    }
-
-    private func parsePlatform(_ raw: String) -> (prefix: String, version: String?) {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty { return ("", nil) }
-        let parts = trimmed.split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
-        let prefix = parts.first?.lowercased() ?? ""
-        let versionToken = parts.dropFirst().first
-        return (prefix, versionToken)
+        PlatformLabelFormatter.pretty(raw)
     }
 
     private func presenceUpdateSourceShortText(_ reason: String) -> String? {
@@ -450,8 +418,8 @@ extension InstancesSettings {
         _ = view.prettyPlatform("ipados 17.1")
         _ = view.prettyPlatform("linux")
         _ = view.prettyPlatform("   ")
-        _ = view.parsePlatform("macOS 14.1")
-        _ = view.parsePlatform(" ")
+        _ = PlatformLabelFormatter.parse("macOS 14.1")
+        _ = PlatformLabelFormatter.parse(" ")
         _ = view.presenceUpdateSourceShortText("self")
         _ = view.presenceUpdateSourceShortText("instances-refresh")
         _ = view.presenceUpdateSourceShortText("seq gap")

--- a/apps/macos/Sources/RemoteClaw/JSONObjectExtractionSupport.swift
+++ b/apps/macos/Sources/RemoteClaw/JSONObjectExtractionSupport.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum JSONObjectExtractionSupport {
+    static func extract(from raw: String) -> (text: String, object: [String: Any])? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let start = trimmed.firstIndex(of: "{"),
+              let end = trimmed.lastIndex(of: "}")
+        else {
+            return nil
+        }
+        let jsonText = String(trimmed[start...end])
+        guard let data = jsonText.data(using: .utf8) else { return nil }
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return (jsonText, object)
+    }
+}

--- a/apps/macos/Sources/RemoteClaw/MenuBar.swift
+++ b/apps/macos/Sources/RemoteClaw/MenuBar.swift
@@ -228,17 +228,7 @@ private final class StatusItemMouseHandlerView: NSView {
 
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
-        if let tracking {
-            self.removeTrackingArea(tracking)
-        }
-        let options: NSTrackingArea.Options = [
-            .mouseEnteredAndExited,
-            .activeAlways,
-            .inVisibleRect,
-        ]
-        let area = NSTrackingArea(rect: self.bounds, options: options, owner: self, userInfo: nil)
-        self.addTrackingArea(area)
-        self.tracking = area
+        TrackingAreaSupport.resetMouseTracking(on: self, tracking: &self.tracking, owner: self)
     }
 
     override func mouseEntered(with event: NSEvent) {

--- a/apps/macos/Sources/RemoteClaw/MicRefreshSupport.swift
+++ b/apps/macos/Sources/RemoteClaw/MicRefreshSupport.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftUI
+
+enum MicRefreshSupport {
+    private static let refreshDelayNs: UInt64 = 300_000_000
+
+    static func startObserver(_ observer: AudioInputDeviceObserver, triggerRefresh: @escaping @MainActor () -> Void) {
+        observer.start {
+            Task { @MainActor in
+                triggerRefresh()
+            }
+        }
+    }
+
+    @MainActor
+    static func schedule(
+        refreshTask: inout Task<Void, Never>?,
+        action: @escaping @MainActor () async -> Void)
+    {
+        refreshTask?.cancel()
+        refreshTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: self.refreshDelayNs)
+            guard !Task.isCancelled else { return }
+            await action()
+        }
+    }
+
+    static func selectedMicName<T>(
+        selectedID: String,
+        in devices: [T],
+        uid: KeyPath<T, String>,
+        name: KeyPath<T, String>) -> String
+    {
+        guard !selectedID.isEmpty else { return "" }
+        return devices.first(where: { $0[keyPath: uid] == selectedID })?[keyPath: name] ?? ""
+    }
+
+    @MainActor
+    static func voiceWakeBinding(for state: AppState) -> Binding<Bool> {
+        Binding(
+            get: { state.swabbleEnabled },
+            set: { newValue in
+                Task { await state.setVoiceWakeEnabled(newValue) }
+            })
+    }
+}

--- a/apps/macos/Sources/RemoteClaw/NodePairingApprovalPrompter.swift
+++ b/apps/macos/Sources/RemoteClaw/NodePairingApprovalPrompter.swift
@@ -32,9 +32,7 @@ final class NodePairingApprovalPrompter {
     private var queue: [PendingRequest] = []
     var pendingCount: Int = 0
     var pendingRepairCount: Int = 0
-    private var activeAlert: NSAlert?
-    private var activeRequestId: String?
-    private var alertHostWindow: NSWindow?
+    private let alertState = PairingAlertState()
     private var remoteResolutionsByRequestId: [String: PairingResolution] = [:]
     private var autoApproveAttempts: Set<String> = []
 
@@ -68,53 +66,41 @@ final class NodePairingApprovalPrompter {
         }
     }
 
-    private struct PairingResolvedEvent: Codable {
-        let requestId: String
-        let nodeId: String
-        let decision: String
-        let ts: Double
-    }
-
-    private enum PairingResolution: String {
-        case approved
-        case rejected
-    }
+    private typealias PairingResolvedEvent = PairingAlertSupport.PairingResolvedEvent
+    private typealias PairingResolution = PairingAlertSupport.PairingResolution
 
     func start() {
-        guard self.task == nil else { return }
-        self.isStopping = false
         self.reconcileTask?.cancel()
         self.reconcileTask = nil
-        self.task = Task { [weak self] in
-            guard let self else { return }
-            _ = try? await GatewayConnection.shared.refresh()
-            await self.loadPendingRequestsFromGateway()
-            let stream = await GatewayConnection.shared.subscribe(bufferingNewest: 200)
-            for await push in stream {
-                if Task.isCancelled { return }
-                await MainActor.run { [weak self] in self?.handle(push: push) }
-            }
-        }
+        self.startPushTask()
+    }
+
+    private func startPushTask() {
+        PairingAlertSupport.startPairingPushTask(
+            task: &self.task,
+            isStopping: &self.isStopping,
+            loadPending: self.loadPendingRequestsFromGateway,
+            handlePush: self.handle(push:))
     }
 
     func stop() {
-        self.isStopping = true
-        self.endActiveAlert()
-        self.task?.cancel()
-        self.task = nil
+        self.stopPushTask()
         self.reconcileTask?.cancel()
         self.reconcileTask = nil
         self.reconcileOnceTask?.cancel()
         self.reconcileOnceTask = nil
-        self.queue.removeAll(keepingCapacity: false)
         self.updatePendingCounts()
-        self.isPresenting = false
-        self.activeRequestId = nil
-        self.alertHostWindow?.orderOut(nil)
-        self.alertHostWindow?.close()
-        self.alertHostWindow = nil
         self.remoteResolutionsByRequestId.removeAll(keepingCapacity: false)
         self.autoApproveAttempts.removeAll(keepingCapacity: false)
+    }
+
+    private func stopPushTask() {
+        PairingAlertSupport.stopPairingPrompter(
+            isStopping: &self.isStopping,
+            task: &self.task,
+            queue: &self.queue,
+            isPresenting: &self.isPresenting,
+            state: self.alertState)
     }
 
     private func loadPendingRequestsFromGateway() async {
@@ -190,7 +176,7 @@ final class NodePairingApprovalPrompter {
             if pendingById[req.requestId] != nil { continue }
             let resolution = self.inferResolution(for: req, list: list)
 
-            if self.activeRequestId == req.requestId, self.activeAlert != nil {
+            if self.alertState.activeRequestId == req.requestId, self.alertState.activeAlert != nil {
                 self.remoteResolutionsByRequestId[req.requestId] = resolution
                 self.logger.info(
                     """
@@ -232,11 +218,7 @@ final class NodePairingApprovalPrompter {
     }
 
     private func endActiveAlert() {
-        PairingAlertSupport.endActiveAlert(activeAlert: &self.activeAlert, activeRequestId: &self.activeRequestId)
-    }
-
-    private func requireAlertHostWindow() -> NSWindow {
-        PairingAlertSupport.requireAlertHostWindow(alertHostWindow: &self.alertHostWindow)
+        PairingAlertSupport.endActiveAlert(state: self.alertState)
     }
 
     private func handle(push: GatewayPush) {
@@ -293,47 +275,13 @@ final class NodePairingApprovalPrompter {
 
     private func presentAlert(for req: PendingRequest) {
         self.logger.info("presenting node pairing alert requestId=\(req.requestId, privacy: .public)")
-        NSApp.activate(ignoringOtherApps: true)
-
-        let alert = NSAlert()
-        alert.alertStyle = .warning
-        alert.messageText = "Allow node to connect?"
-        alert.informativeText = Self.describe(req)
-        // Fail-safe ordering: if the dialog can't be presented, default to "Later".
-        alert.addButton(withTitle: "Later")
-        alert.addButton(withTitle: "Approve")
-        alert.addButton(withTitle: "Reject")
-        if #available(macOS 11.0, *), alert.buttons.indices.contains(2) {
-            alert.buttons[2].hasDestructiveAction = true
-        }
-
-        self.activeAlert = alert
-        self.activeRequestId = req.requestId
-        let hostWindow = self.requireAlertHostWindow()
-
-        // Position the hidden host window so the sheet appears centered on screen.
-        // (Sheets attach to the top edge of their parent window; if the parent is tiny, it looks "anchored".)
-        let sheetSize = alert.window.frame.size
-        if let screen = hostWindow.screen ?? NSScreen.main {
-            let bounds = screen.visibleFrame
-            let x = bounds.midX - (sheetSize.width / 2)
-            let sheetOriginY = bounds.midY - (sheetSize.height / 2)
-            let hostY = sheetOriginY + sheetSize.height - hostWindow.frame.height
-            hostWindow.setFrameOrigin(NSPoint(x: x, y: hostY))
-        } else {
-            hostWindow.center()
-        }
-
-        hostWindow.makeKeyAndOrderFront(nil)
-        alert.beginSheetModal(for: hostWindow) { [weak self] response in
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                self.activeRequestId = nil
-                self.activeAlert = nil
-                await self.handleAlertResponse(response, request: req)
-                hostWindow.orderOut(nil)
-            }
-        }
+        PairingAlertSupport.presentPairingAlert(
+            request: req,
+            requestId: req.requestId,
+            messageText: "Allow node to connect?",
+            informativeText: Self.describe(req),
+            state: self.alertState,
+            onResponse: self.handleAlertResponse)
     }
 
     private func handleAlertResponse(_ response: NSApplication.ModalResponse, request: PendingRequest) async {
@@ -373,24 +321,22 @@ final class NodePairingApprovalPrompter {
     }
 
     private func approve(requestId: String) async -> Bool {
-        do {
+        await PairingAlertSupport.approveRequest(
+            requestId: requestId,
+            kind: "node",
+            logger: self.logger)
+        {
             try await GatewayConnection.shared.nodePairApprove(requestId: requestId)
-            self.logger.info("approved node pairing requestId=\(requestId, privacy: .public)")
-            return true
-        } catch {
-            self.logger.error("approve failed requestId=\(requestId, privacy: .public)")
-            self.logger.error("approve failed: \(error.localizedDescription, privacy: .public)")
-            return false
         }
     }
 
     private func reject(requestId: String) async {
-        do {
+        await PairingAlertSupport.rejectRequest(
+            requestId: requestId,
+            kind: "node",
+            logger: self.logger)
+        {
             try await GatewayConnection.shared.nodePairReject(requestId: requestId)
-            self.logger.info("rejected node pairing requestId=\(requestId, privacy: .public)")
-        } catch {
-            self.logger.error("reject failed requestId=\(requestId, privacy: .public)")
-            self.logger.error("reject failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -419,8 +365,7 @@ final class NodePairingApprovalPrompter {
     private static func prettyPlatform(_ platform: String?) -> String? {
         let raw = platform?.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let raw, !raw.isEmpty else { return nil }
-        if raw.lowercased() == "ios" { return "iOS" }
-        if raw.lowercased() == "macos" { return "macOS" }
+        if let pretty = PlatformLabelFormatter.pretty(raw) { return pretty }
         return raw
     }
 
@@ -616,7 +561,7 @@ final class NodePairingApprovalPrompter {
         let resolution: PairingResolution =
             resolved.decision == PairingResolution.approved.rawValue ? .approved : .rejected
 
-        if self.activeRequestId == resolved.requestId, self.activeAlert != nil {
+        if self.alertState.activeRequestId == resolved.requestId, self.alertState.activeAlert != nil {
             self.remoteResolutionsByRequestId[resolved.requestId] = resolution
             self.logger.info(
                 """

--- a/apps/macos/Sources/RemoteClaw/NodesStore.swift
+++ b/apps/macos/Sources/RemoteClaw/NodesStore.swift
@@ -54,14 +54,8 @@ final class NodesStore {
     func start() {
         self.startCount += 1
         guard self.startCount == 1 else { return }
-        guard self.task == nil else { return }
-        self.task = Task.detached { [weak self] in
-            guard let self else { return }
-            await self.refresh()
-            while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: UInt64(self.interval * 1_000_000_000))
-                await self.refresh()
-            }
+        SimpleTaskSupport.startDetachedLoop(task: &self.task, interval: self.interval) { [weak self] in
+            await self?.refresh()
         }
     }
 

--- a/apps/macos/Sources/RemoteClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/RemoteClaw/OnboardingView+Layout.swift
@@ -189,19 +189,7 @@ extension OnboardingView {
     }
 
     func featureRow(title: String, subtitle: String, systemImage: String) -> some View {
-        HStack(alignment: .top, spacing: 12) {
-            Image(systemName: systemImage)
-                .font(.title3.weight(.semibold))
-                .foregroundStyle(Color.accentColor)
-                .frame(width: 26)
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title).font(.headline)
-                Text(subtitle)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .padding(.vertical, 4)
+        self.featureRowContent(title: title, subtitle: subtitle, systemImage: systemImage)
     }
 
     func featureActionRow(
@@ -210,6 +198,22 @@ extension OnboardingView {
         systemImage: String,
         buttonTitle: String,
         action: @escaping () -> Void) -> some View
+    {
+        self.featureRowContent(
+            title: title,
+            subtitle: subtitle,
+            systemImage: systemImage,
+            action: AnyView(
+                Button(buttonTitle, action: action)
+                    .buttonStyle(.link)
+                    .padding(.top, 2)))
+    }
+
+    private func featureRowContent(
+        title: String,
+        subtitle: String,
+        systemImage: String,
+        action: AnyView? = nil) -> some View
     {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: systemImage)
@@ -221,9 +225,9 @@ extension OnboardingView {
                 Text(subtitle)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
-                Button(buttonTitle, action: action)
-                    .buttonStyle(.link)
-                    .padding(.top, 2)
+                if let action {
+                    action
+                }
             }
             Spacer(minLength: 0)
         }

--- a/apps/macos/Sources/RemoteClaw/OnboardingView+Workspace.swift
+++ b/apps/macos/Sources/RemoteClaw/OnboardingView+Workspace.swift
@@ -69,9 +69,7 @@ extension OnboardingView {
 
     private func loadAgentWorkspace() async -> String? {
         let root = await ConfigStore.load()
-        let agents = root["agents"] as? [String: Any]
-        let defaults = agents?["defaults"] as? [String: Any]
-        return defaults?["workspace"] as? String
+        return AgentWorkspaceConfig.workspace(from: root)
     }
 
     @discardableResult
@@ -87,24 +85,7 @@ extension OnboardingView {
     @MainActor
     private static func buildAndSaveWorkspace(_ workspace: String?) async -> (Bool, String?) {
         var root = await ConfigStore.load()
-        var agents = root["agents"] as? [String: Any] ?? [:]
-        var defaults = agents["defaults"] as? [String: Any] ?? [:]
-        let trimmed = workspace?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if trimmed.isEmpty {
-            defaults.removeValue(forKey: "workspace")
-        } else {
-            defaults["workspace"] = trimmed
-        }
-        if defaults.isEmpty {
-            agents.removeValue(forKey: "defaults")
-        } else {
-            agents["defaults"] = defaults
-        }
-        if agents.isEmpty {
-            root.removeValue(forKey: "agents")
-        } else {
-            root["agents"] = agents
-        }
+        AgentWorkspaceConfig.setWorkspace(in: &root, workspace: workspace)
         do {
             try await ConfigStore.save(root)
             return (true, nil)

--- a/apps/macos/Sources/RemoteClaw/PairingAlertSupport.swift
+++ b/apps/macos/Sources/RemoteClaw/PairingAlertSupport.swift
@@ -1,4 +1,6 @@
 import AppKit
+import RemoteClawKit
+import OSLog
 
 final class PairingAlertHostWindow: NSWindow {
     override var canBecomeKey: Bool {
@@ -11,7 +13,25 @@ final class PairingAlertHostWindow: NSWindow {
 }
 
 @MainActor
+final class PairingAlertState {
+    var activeAlert: NSAlert?
+    var activeRequestId: String?
+    var alertHostWindow: NSWindow?
+}
+
+@MainActor
 enum PairingAlertSupport {
+    enum PairingResolution: String {
+        case approved
+        case rejected
+    }
+
+    struct PairingResolvedEvent: Codable {
+        let requestId: String
+        let decision: String
+        let ts: Double
+    }
+
     static func endActiveAlert(activeAlert: inout NSAlert?, activeRequestId: inout String?) {
         guard let alert = activeAlert else { return }
         if let parent = alert.window.sheetParent {
@@ -19,6 +39,10 @@ enum PairingAlertSupport {
         }
         activeAlert = nil
         activeRequestId = nil
+    }
+
+    static func endActiveAlert(state: PairingAlertState) {
+        self.endActiveAlert(activeAlert: &state.activeAlert, activeRequestId: &state.activeRequestId)
     }
 
     static func requireAlertHostWindow(alertHostWindow: inout NSWindow?) -> NSWindow {
@@ -42,5 +66,212 @@ enum PairingAlertSupport {
 
         alertHostWindow = window
         return window
+    }
+
+    static func configureDefaultPairingAlert(
+        _ alert: NSAlert,
+        messageText: String,
+        informativeText: String)
+    {
+        alert.alertStyle = .warning
+        alert.messageText = messageText
+        alert.informativeText = informativeText
+        alert.addButton(withTitle: "Later")
+        alert.addButton(withTitle: "Approve")
+        alert.addButton(withTitle: "Reject")
+        if #available(macOS 11.0, *), alert.buttons.indices.contains(2) {
+            alert.buttons[2].hasDestructiveAction = true
+        }
+    }
+
+    static func beginCenteredSheet(
+        alert: NSAlert,
+        hostWindow: NSWindow,
+        completionHandler: @escaping (NSApplication.ModalResponse) -> Void)
+    {
+        let sheetSize = alert.window.frame.size
+        if let screen = hostWindow.screen ?? NSScreen.main {
+            let bounds = screen.visibleFrame
+            let x = bounds.midX - (sheetSize.width / 2)
+            let sheetOriginY = bounds.midY - (sheetSize.height / 2)
+            let hostY = sheetOriginY + sheetSize.height - hostWindow.frame.height
+            hostWindow.setFrameOrigin(NSPoint(x: x, y: hostY))
+        } else {
+            hostWindow.center()
+        }
+        hostWindow.makeKeyAndOrderFront(nil)
+        alert.beginSheetModal(for: hostWindow, completionHandler: completionHandler)
+    }
+
+    static func runPairingPushTask(
+        bufferingNewest: Int = 200,
+        loadPending: @escaping @MainActor () async -> Void,
+        handlePush: @escaping @MainActor (GatewayPush) -> Void) async
+    {
+        _ = try? await GatewayConnection.shared.refresh()
+        await loadPending()
+        await GatewayPushSubscription.consume(bufferingNewest: bufferingNewest, onPush: handlePush)
+    }
+
+    static func startPairingPushTask(
+        task: inout Task<Void, Never>?,
+        isStopping: inout Bool,
+        bufferingNewest: Int = 200,
+        loadPending: @escaping @MainActor () async -> Void,
+        handlePush: @escaping @MainActor (GatewayPush) -> Void)
+    {
+        guard task == nil else { return }
+        isStopping = false
+        task = Task {
+            await self.runPairingPushTask(
+                bufferingNewest: bufferingNewest,
+                loadPending: loadPending,
+                handlePush: handlePush)
+        }
+    }
+
+    static func beginPairingAlert(
+        messageText: String,
+        informativeText: String,
+        alertHostWindow: inout NSWindow?,
+        completion: @escaping (NSApplication.ModalResponse, NSWindow) -> Void) -> NSAlert
+    {
+        NSApp.activate(ignoringOtherApps: true)
+
+        let alert = NSAlert()
+        self.configureDefaultPairingAlert(alert, messageText: messageText, informativeText: informativeText)
+
+        let hostWindow = self.requireAlertHostWindow(alertHostWindow: &alertHostWindow)
+        self.beginCenteredSheet(alert: alert, hostWindow: hostWindow) { response in
+            completion(response, hostWindow)
+        }
+        return alert
+    }
+
+    static func presentPairingAlert(
+        requestId: String,
+        messageText: String,
+        informativeText: String,
+        activeAlert: inout NSAlert?,
+        activeRequestId: inout String?,
+        alertHostWindow: inout NSWindow?,
+        completion: @escaping (NSApplication.ModalResponse, NSWindow) -> Void)
+    {
+        activeRequestId = requestId
+        activeAlert = self.beginPairingAlert(
+            messageText: messageText,
+            informativeText: informativeText,
+            alertHostWindow: &alertHostWindow,
+            completion: completion)
+    }
+
+    static func presentPairingAlert<Request>(
+        request: Request,
+        requestId: String,
+        messageText: String,
+        informativeText: String,
+        state: PairingAlertState,
+        onResponse: @escaping @MainActor (NSApplication.ModalResponse, Request) async -> Void)
+    {
+        self.presentPairingAlert(
+            requestId: requestId,
+            messageText: messageText,
+            informativeText: informativeText,
+            activeAlert: &state.activeAlert,
+            activeRequestId: &state.activeRequestId,
+            alertHostWindow: &state.alertHostWindow,
+            completion: { response, hostWindow in
+                Task { @MainActor in
+                    self.clearActivePairingAlert(state: state, hostWindow: hostWindow)
+                    await onResponse(response, request)
+                }
+            })
+    }
+
+    static func clearActivePairingAlert(
+        activeAlert: inout NSAlert?,
+        activeRequestId: inout String?,
+        hostWindow: NSWindow)
+    {
+        activeRequestId = nil
+        activeAlert = nil
+        hostWindow.orderOut(nil)
+    }
+
+    static func clearActivePairingAlert(state: PairingAlertState, hostWindow: NSWindow) {
+        self.clearActivePairingAlert(
+            activeAlert: &state.activeAlert,
+            activeRequestId: &state.activeRequestId,
+            hostWindow: hostWindow)
+    }
+
+    static func stopPairingPrompter(
+        isStopping: inout Bool,
+        activeAlert: inout NSAlert?,
+        activeRequestId: inout String?,
+        task: inout Task<Void, Never>?,
+        queue: inout [some Any],
+        isPresenting: inout Bool,
+        alertHostWindow: inout NSWindow?)
+    {
+        isStopping = true
+        self.endActiveAlert(activeAlert: &activeAlert, activeRequestId: &activeRequestId)
+        task?.cancel()
+        task = nil
+        queue.removeAll(keepingCapacity: false)
+        isPresenting = false
+        activeRequestId = nil
+        alertHostWindow?.orderOut(nil)
+        alertHostWindow?.close()
+        alertHostWindow = nil
+    }
+
+    static func stopPairingPrompter(
+        isStopping: inout Bool,
+        task: inout Task<Void, Never>?,
+        queue: inout [some Any],
+        isPresenting: inout Bool,
+        state: PairingAlertState)
+    {
+        self.stopPairingPrompter(
+            isStopping: &isStopping,
+            activeAlert: &state.activeAlert,
+            activeRequestId: &state.activeRequestId,
+            task: &task,
+            queue: &queue,
+            isPresenting: &isPresenting,
+            alertHostWindow: &state.alertHostWindow)
+    }
+
+    static func approveRequest(
+        requestId: String,
+        kind: String,
+        logger: Logger,
+        action: @escaping () async throws -> Void) async -> Bool
+    {
+        do {
+            try await action()
+            logger.info("approved \(kind, privacy: .public) pairing requestId=\(requestId, privacy: .public)")
+            return true
+        } catch {
+            logger.error("approve failed requestId=\(requestId, privacy: .public)")
+            logger.error("approve failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    static func rejectRequest(
+        requestId: String,
+        kind: String,
+        logger: Logger,
+        action: @escaping () async throws -> Void) async
+    {
+        do {
+            try await action()
+            logger.info("rejected \(kind, privacy: .public) pairing requestId=\(requestId, privacy: .public)")
+        } catch {
+            logger.error("reject failed requestId=\(requestId, privacy: .public)")
+            logger.error("reject failed: \(error.localizedDescription, privacy: .public)")
+        }
     }
 }

--- a/apps/macos/Sources/RemoteClaw/PeekabooBridgeHostCoordinator.swift
+++ b/apps/macos/Sources/RemoteClaw/PeekabooBridgeHostCoordinator.swift
@@ -13,12 +13,28 @@ final class PeekabooBridgeHostCoordinator {
 
     private var host: PeekabooBridgeHost?
     private var services: RemoteClawPeekabooBridgeServices?
+
+    private static let legacySocketDirectoryNames = ["clawdbot", "clawdis", "moltbot"]
+
     private static var remoteclawSocketPath: String {
         let fileManager = FileManager.default
         let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support")
-        let directory = base.appendingPathComponent("RemoteClaw", isDirectory: true)
-        return directory.appendingPathComponent(PeekabooBridgeConstants.socketName, isDirectory: false).path
+        return Self.makeSocketPath(for: "RemoteClaw", in: base)
+    }
+
+    private static func makeSocketPath(for directoryName: String, in baseDirectory: URL) -> String {
+        baseDirectory
+            .appendingPathComponent(directoryName, isDirectory: true)
+            .appendingPathComponent(PeekabooBridgeConstants.socketName, isDirectory: false)
+            .path
+    }
+
+    private static var legacySocketPaths: [String] {
+        let fileManager = FileManager.default
+        let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support")
+        return Self.legacySocketDirectoryNames.map { Self.makeSocketPath(for: $0, in: base) }
     }
 
     func setEnabled(_ enabled: Bool) async {
@@ -46,6 +62,8 @@ final class PeekabooBridgeHostCoordinator {
         }
         let allowlistedBundles: Set<String> = []
 
+        self.ensureLegacySocketSymlinks()
+
         let services = RemoteClawPeekabooBridgeServices()
         let server = PeekabooBridgeServer(
             services: services,
@@ -65,6 +83,44 @@ final class PeekabooBridgeHostCoordinator {
         await host.start()
         self.logger
             .info("PeekabooBridge host started at \(Self.remoteclawSocketPath, privacy: .public)")
+    }
+
+    private func ensureLegacySocketSymlinks() {
+        for legacyPath in Self.legacySocketPaths {
+            self.ensureLegacySocketSymlink(at: legacyPath)
+        }
+    }
+
+    private func ensureLegacySocketSymlink(at legacyPath: String) {
+        let fileManager = FileManager.default
+        let legacyDirectory = (legacyPath as NSString).deletingLastPathComponent
+        do {
+            let directoryAttributes: [FileAttributeKey: Any] = [
+                .posixPermissions: 0o700,
+            ]
+            try fileManager.createDirectory(
+                atPath: legacyDirectory,
+                withIntermediateDirectories: true,
+                attributes: directoryAttributes)
+            let linkURL = URL(fileURLWithPath: legacyPath)
+            let linkValues = try? linkURL.resourceValues(forKeys: [.isSymbolicLinkKey])
+            if linkValues?.isSymbolicLink == true {
+                let destination = try FileManager.default.destinationOfSymbolicLink(atPath: legacyPath)
+                let destinationURL = URL(fileURLWithPath: destination, relativeTo: linkURL.deletingLastPathComponent())
+                    .standardizedFileURL
+                if destinationURL.path == URL(fileURLWithPath: Self.remoteclawSocketPath).standardizedFileURL.path {
+                    return
+                }
+                try fileManager.removeItem(atPath: legacyPath)
+            } else if fileManager.fileExists(atPath: legacyPath) {
+                try fileManager.removeItem(atPath: legacyPath)
+            }
+            try fileManager.createSymbolicLink(atPath: legacyPath, withDestinationPath: Self.remoteclawSocketPath)
+        } catch {
+            let message = "Failed to create legacy PeekabooBridge socket symlink: \(error.localizedDescription)"
+            self.logger
+                .debug("\(message, privacy: .public)")
+        }
     }
 
     private static func currentTeamID() -> String? {

--- a/apps/macos/Sources/RemoteClaw/PermissionManager.swift
+++ b/apps/macos/Sources/RemoteClaw/PermissionManager.swift
@@ -229,61 +229,37 @@ enum PermissionManager {
 
 enum NotificationPermissionHelper {
     static func openSettings() {
-        let candidates = [
+        SystemSettingsURLSupport.openFirst([
             "x-apple.systempreferences:com.apple.Notifications-Settings.extension",
             "x-apple.systempreferences:com.apple.preference.notifications",
-        ]
-
-        for candidate in candidates {
-            if let url = URL(string: candidate), NSWorkspace.shared.open(url) {
-                return
-            }
-        }
+        ])
     }
 }
 
 enum MicrophonePermissionHelper {
     static func openSettings() {
-        let candidates = [
+        SystemSettingsURLSupport.openFirst([
             "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
             "x-apple.systempreferences:com.apple.preference.security",
-        ]
-
-        for candidate in candidates {
-            if let url = URL(string: candidate), NSWorkspace.shared.open(url) {
-                return
-            }
-        }
+        ])
     }
 }
 
 enum CameraPermissionHelper {
     static func openSettings() {
-        let candidates = [
+        SystemSettingsURLSupport.openFirst([
             "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera",
             "x-apple.systempreferences:com.apple.preference.security",
-        ]
-
-        for candidate in candidates {
-            if let url = URL(string: candidate), NSWorkspace.shared.open(url) {
-                return
-            }
-        }
+        ])
     }
 }
 
 enum LocationPermissionHelper {
     static func openSettings() {
-        let candidates = [
+        SystemSettingsURLSupport.openFirst([
             "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices",
             "x-apple.systempreferences:com.apple.preference.security",
-        ]
-
-        for candidate in candidates {
-            if let url = URL(string: candidate), NSWorkspace.shared.open(url) {
-                return
-            }
-        }
+        ])
     }
 }
 

--- a/apps/macos/Sources/RemoteClaw/PermissionMonitoringSupport.swift
+++ b/apps/macos/Sources/RemoteClaw/PermissionMonitoringSupport.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+@MainActor
+enum PermissionMonitoringSupport {
+    static func setMonitoring(_ shouldMonitor: Bool, monitoring: inout Bool) {
+        if shouldMonitor, !monitoring {
+            monitoring = true
+            PermissionMonitor.shared.register()
+        } else if !shouldMonitor, monitoring {
+            monitoring = false
+            PermissionMonitor.shared.unregister()
+        }
+    }
+
+    static func stopMonitoring(_ monitoring: inout Bool) {
+        guard monitoring else { return }
+        monitoring = false
+        PermissionMonitor.shared.unregister()
+    }
+}

--- a/apps/macos/Sources/RemoteClaw/PlatformLabelFormatter.swift
+++ b/apps/macos/Sources/RemoteClaw/PlatformLabelFormatter.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum PlatformLabelFormatter {
+    static func parse(_ raw: String) -> (prefix: String, version: String?) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return ("", nil) }
+        let parts = trimmed.split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
+        let prefix = parts.first?.lowercased() ?? ""
+        let versionToken = parts.dropFirst().first
+        return (prefix, versionToken)
+    }
+
+    static func pretty(_ raw: String) -> String? {
+        let (prefix, version) = self.parse(raw)
+        if prefix.isEmpty { return nil }
+        let name: String = switch prefix {
+        case "macos": "macOS"
+        case "ios": "iOS"
+        case "ipados": "iPadOS"
+        case "tvos": "tvOS"
+        case "watchos": "watchOS"
+        default: prefix.prefix(1).uppercased() + prefix.dropFirst()
+        }
+        guard let version, !version.isEmpty else { return name }
+        let parts = version.split(separator: ".").map(String.init)
+        if parts.count >= 2 {
+            return "\(name) \(parts[0]).\(parts[1])"
+        }
+        return "\(name) \(version)"
+    }
+}

--- a/apps/macos/Sources/RemoteClaw/RemotePortTunnel.swift
+++ b/apps/macos/Sources/RemoteClaw/RemotePortTunnel.swift
@@ -152,8 +152,8 @@ final class RemotePortTunnel {
         else {
             return nil
         }
-        let sshKey = Self.hostKey(sshHost)
-        let urlKey = Self.hostKey(host)
+        let sshKey = RemoteClawConfigFile.hostKey(sshHost)
+        let urlKey = RemoteClawConfigFile.hostKey(host)
         guard !sshKey.isEmpty, !urlKey.isEmpty else { return nil }
         guard sshKey == urlKey else {
             Self.logger.debug(
@@ -161,17 +161,6 @@ final class RemotePortTunnel {
             return nil
         }
         return port
-    }
-
-    private static func hostKey(_ host: String) -> String {
-        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !trimmed.isEmpty else { return "" }
-        if trimmed.contains(":") { return trimmed }
-        let digits = CharacterSet(charactersIn: "0123456789.")
-        if trimmed.rangeOfCharacter(from: digits.inverted) == nil {
-            return trimmed
-        }
-        return trimmed.split(separator: ".").first.map(String.init) ?? trimmed
     }
 
     private static func findPort(preferred: UInt16?, allowRandom: Bool) async throws -> UInt16 {

--- a/apps/macos/Sources/RemoteClaw/ScreenRecordService.swift
+++ b/apps/macos/Sources/RemoteClaw/ScreenRecordService.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Foundation
+import RemoteClawKit
 import OSLog
 @preconcurrency import ScreenCaptureKit
 
@@ -34,8 +35,8 @@ final class ScreenRecordService {
         includeAudio: Bool?,
         outPath: String?) async throws -> (path: String, hasAudio: Bool)
     {
-        let durationMs = Self.clampDurationMs(durationMs)
-        let fps = Self.clampFps(fps)
+        let durationMs = CaptureRateLimits.clampDurationMs(durationMs)
+        let fps = CaptureRateLimits.clampFps(fps, maxFps: 60)
         let includeAudio = includeAudio ?? false
 
         let outURL: URL = {
@@ -95,17 +96,6 @@ final class ScreenRecordService {
 
         try await recorder.finish()
         return (path: outURL.path, hasAudio: recorder.hasAudio)
-    }
-
-    private nonisolated static func clampDurationMs(_ ms: Int?) -> Int {
-        let v = ms ?? 10000
-        return min(60000, max(250, v))
-    }
-
-    private nonisolated static func clampFps(_ fps: Double?) -> Double {
-        let v = fps ?? 10
-        if !v.isFinite { return 10 }
-        return min(60, max(1, v))
     }
 }
 

--- a/apps/macos/Sources/RemoteClaw/SettingsRefreshButton.swift
+++ b/apps/macos/Sources/RemoteClaw/SettingsRefreshButton.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct SettingsRefreshButton: View {
+    let isLoading: Bool
+    let action: () -> Void
+
+    var body: some View {
+        if self.isLoading {
+            ProgressView()
+        } else {
+            Button(action: self.action) {
+                Label("Refresh", systemImage: "arrow.clockwise")
+            }
+            .buttonStyle(.bordered)
+            .help("Refresh")
+        }
+    }
+}

--- a/apps/macos/Sources/RemoteClaw/SettingsRootView.swift
+++ b/apps/macos/Sources/RemoteClaw/SettingsRootView.swift
@@ -52,6 +52,10 @@ struct SettingsRootView: View {
                     .tabItem { Label("Cron", systemImage: "calendar") }
                     .tag(SettingsTab.cron)
 
+                SkillsSettings(state: self.state)
+                    .tabItem { Label("Skills", systemImage: "sparkles") }
+                    .tag(SettingsTab.skills)
+
                 PermissionsSettings(
                     status: self.permissionMonitor.status,
                     refresh: self.refreshPerms,
@@ -159,31 +163,23 @@ struct SettingsRootView: View {
 
     private func updatePermissionMonitoring(for tab: SettingsTab) {
         guard !self.isPreview else { return }
-        let shouldMonitor = tab == .permissions
-        if shouldMonitor, !self.monitoringPermissions {
-            self.monitoringPermissions = true
-            PermissionMonitor.shared.register()
-        } else if !shouldMonitor, self.monitoringPermissions {
-            self.monitoringPermissions = false
-            PermissionMonitor.shared.unregister()
-        }
+        PermissionMonitoringSupport.setMonitoring(tab == .permissions, monitoring: &self.monitoringPermissions)
     }
 
     private func stopPermissionMonitoring() {
-        guard self.monitoringPermissions else { return }
-        self.monitoringPermissions = false
-        PermissionMonitor.shared.unregister()
+        PermissionMonitoringSupport.stopMonitoring(&self.monitoringPermissions)
     }
 }
 
 enum SettingsTab: CaseIterable {
-    case general, channels, sessions, cron, config, instances, voiceWake, permissions, debug, about
+    case general, channels, skills, sessions, cron, config, instances, voiceWake, permissions, debug, about
     static let windowWidth: CGFloat = 824 // wider
     static let windowHeight: CGFloat = 790 // +10% (more room)
     var title: String {
         switch self {
         case .general: "General"
         case .channels: "Channels"
+        case .skills: "Skills"
         case .sessions: "Sessions"
         case .cron: "Cron"
         case .config: "Config"
@@ -199,6 +195,7 @@ enum SettingsTab: CaseIterable {
         switch self {
         case .general: "gearshape"
         case .channels: "link"
+        case .skills: "sparkles"
         case .sessions: "clock.arrow.circlepath"
         case .cron: "calendar"
         case .config: "slider.horizontal.3"

--- a/apps/macos/Sources/RemoteClaw/SimpleTaskSupport.swift
+++ b/apps/macos/Sources/RemoteClaw/SimpleTaskSupport.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+@MainActor
+enum SimpleTaskSupport {
+    static func start(task: inout Task<Void, Never>?, operation: @escaping @Sendable () async -> Void) {
+        guard task == nil else { return }
+        task = Task {
+            await operation()
+        }
+    }
+
+    static func stop(task: inout Task<Void, Never>?) {
+        task?.cancel()
+        task = nil
+    }
+
+    static func startDetachedLoop(
+        task: inout Task<Void, Never>?,
+        interval: TimeInterval,
+        operation: @escaping @Sendable () async -> Void)
+    {
+        guard task == nil else { return }
+        task = Task.detached {
+            await operation()
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+                await operation()
+            }
+        }
+    }
+}

--- a/apps/macos/Sources/RemoteClaw/SystemSettingsURLSupport.swift
+++ b/apps/macos/Sources/RemoteClaw/SystemSettingsURLSupport.swift
@@ -1,0 +1,12 @@
+import AppKit
+import Foundation
+
+enum SystemSettingsURLSupport {
+    static func openFirst(_ candidates: [String]) {
+        for candidate in candidates {
+            if let url = URL(string: candidate), NSWorkspace.shared.open(url) {
+                return
+            }
+        }
+    }
+}

--- a/apps/macos/Sources/RemoteClaw/TextSummarySupport.swift
+++ b/apps/macos/Sources/RemoteClaw/TextSummarySupport.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum TextSummarySupport {
+    static func summarizeLastLine(_ text: String, maxLength: Int = 200) -> String? {
+        let lines = text
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard let last = lines.last else { return nil }
+        let normalized = last.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+        if normalized.count > maxLength {
+            return String(normalized.prefix(maxLength - 1)) + "…"
+        }
+        return normalized
+    }
+}

--- a/apps/macos/Sources/RemoteClaw/TrackingAreaSupport.swift
+++ b/apps/macos/Sources/RemoteClaw/TrackingAreaSupport.swift
@@ -1,0 +1,22 @@
+import AppKit
+
+enum TrackingAreaSupport {
+    @MainActor
+    static func resetMouseTracking(
+        on view: NSView,
+        tracking: inout NSTrackingArea?,
+        owner: AnyObject)
+    {
+        if let tracking {
+            view.removeTrackingArea(tracking)
+        }
+        let options: NSTrackingArea.Options = [
+            .mouseEnteredAndExited,
+            .activeAlways,
+            .inVisibleRect,
+        ]
+        let area = NSTrackingArea(rect: view.bounds, options: options, owner: owner, userInfo: nil)
+        view.addTrackingArea(area)
+        tracking = area
+    }
+}

--- a/apps/macos/Sources/RemoteClaw/VoiceOverlayTextFormatting.swift
+++ b/apps/macos/Sources/RemoteClaw/VoiceOverlayTextFormatting.swift
@@ -1,0 +1,27 @@
+import AppKit
+
+enum VoiceOverlayTextFormatting {
+    static func delta(after committed: String, current: String) -> String {
+        if current.hasPrefix(committed) {
+            let start = current.index(current.startIndex, offsetBy: committed.count)
+            return String(current[start...])
+        }
+        return current
+    }
+
+    static func makeAttributed(committed: String, volatile: String, isFinal: Bool) -> NSAttributedString {
+        let full = NSMutableAttributedString()
+        let committedAttr: [NSAttributedString.Key: Any] = [
+            .foregroundColor: NSColor.labelColor,
+            .font: NSFont.systemFont(ofSize: 13, weight: .regular),
+        ]
+        full.append(NSAttributedString(string: committed, attributes: committedAttr))
+        let volatileColor: NSColor = isFinal ? .labelColor : NSColor.tertiaryLabelColor
+        let volatileAttr: [NSAttributedString.Key: Any] = [
+            .foregroundColor: volatileColor,
+            .font: NSFont.systemFont(ofSize: 13, weight: .regular),
+        ]
+        full.append(NSAttributedString(string: volatile, attributes: volatileAttr))
+        return full
+    }
+}

--- a/apps/macos/Sources/RemoteClaw/VoicePushToTalk.swift
+++ b/apps/macos/Sources/RemoteClaw/VoicePushToTalk.swift
@@ -170,10 +170,11 @@ actor VoicePushToTalk {
         // Pause the always-on wake word recognizer so both pipelines don't fight over the mic tap.
         await VoiceWakeRuntime.shared.pauseForPushToTalk()
         let adoptedPrefix = self.adoptedPrefix
-        let adoptedAttributed: NSAttributedString? = adoptedPrefix.isEmpty ? nil : Self.makeAttributed(
-            committed: adoptedPrefix,
-            volatile: "",
-            isFinal: false)
+        let adoptedAttributed: NSAttributedString? = adoptedPrefix.isEmpty ? nil : VoiceOverlayTextFormatting
+            .makeAttributed(
+                committed: adoptedPrefix,
+                volatile: "",
+                isFinal: false)
         self.overlayToken = await MainActor.run {
             VoiceSessionCoordinator.shared.startSession(
                 source: .pushToTalk,
@@ -292,12 +293,15 @@ actor VoicePushToTalk {
             self.committed = transcript
             self.volatile = ""
         } else {
-            self.volatile = Self.delta(after: self.committed, current: transcript)
+            self.volatile = VoiceOverlayTextFormatting.delta(after: self.committed, current: transcript)
         }
 
         let committedWithPrefix = Self.join(self.adoptedPrefix, self.committed)
         let snapshot = Self.join(committedWithPrefix, self.volatile)
-        let attributed = Self.makeAttributed(committed: committedWithPrefix, volatile: self.volatile, isFinal: isFinal)
+        let attributed = VoiceOverlayTextFormatting.makeAttributed(
+            committed: committedWithPrefix,
+            volatile: self.volatile,
+            isFinal: isFinal)
         if let token = self.overlayToken {
             await MainActor.run {
                 VoiceSessionCoordinator.shared.updatePartial(
@@ -387,11 +391,11 @@ actor VoicePushToTalk {
     // MARK: - Test helpers
 
     static func _testDelta(committed: String, current: String) -> String {
-        self.delta(after: committed, current: current)
+        VoiceOverlayTextFormatting.delta(after: committed, current: current)
     }
 
     static func _testAttributedColors(isFinal: Bool) -> (NSColor, NSColor) {
-        let sample = self.makeAttributed(committed: "a", volatile: "b", isFinal: isFinal)
+        let sample = VoiceOverlayTextFormatting.makeAttributed(committed: "a", volatile: "b", isFinal: isFinal)
         let committedColor = sample.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor ?? .clear
         let volatileColor = sample.attribute(.foregroundColor, at: 1, effectiveRange: nil) as? NSColor ?? .clear
         return (committedColor, volatileColor)
@@ -401,29 +405,5 @@ actor VoicePushToTalk {
         if prefix.isEmpty { return suffix }
         if suffix.isEmpty { return prefix }
         return "\(prefix) \(suffix)"
-    }
-
-    private static func delta(after committed: String, current: String) -> String {
-        if current.hasPrefix(committed) {
-            let start = current.index(current.startIndex, offsetBy: committed.count)
-            return String(current[start...])
-        }
-        return current
-    }
-
-    private static func makeAttributed(committed: String, volatile: String, isFinal: Bool) -> NSAttributedString {
-        let full = NSMutableAttributedString()
-        let committedAttr: [NSAttributedString.Key: Any] = [
-            .foregroundColor: NSColor.labelColor,
-            .font: NSFont.systemFont(ofSize: 13, weight: .regular),
-        ]
-        full.append(NSAttributedString(string: committed, attributes: committedAttr))
-        let volatileColor: NSColor = isFinal ? .labelColor : NSColor.tertiaryLabelColor
-        let volatileAttr: [NSAttributedString.Key: Any] = [
-            .foregroundColor: volatileColor,
-            .font: NSFont.systemFont(ofSize: 13, weight: .regular),
-        ]
-        full.append(NSAttributedString(string: volatile, attributes: volatileAttr))
-        return full
     }
 }

--- a/apps/macos/Sources/RemoteClaw/VoiceWakeGlobalSettingsSync.swift
+++ b/apps/macos/Sources/RemoteClaw/VoiceWakeGlobalSettingsSync.swift
@@ -14,8 +14,7 @@ final class VoiceWakeGlobalSettingsSync {
     }
 
     func start() {
-        guard self.task == nil else { return }
-        self.task = Task { [weak self] in
+        SimpleTaskSupport.start(task: &self.task) { [weak self] in
             guard let self else { return }
             while !Task.isCancelled {
                 do {
@@ -39,8 +38,7 @@ final class VoiceWakeGlobalSettingsSync {
     }
 
     func stop() {
-        self.task?.cancel()
-        self.task = nil
+        SimpleTaskSupport.stop(task: &self.task)
     }
 
     private func refreshFromGateway() async {

--- a/apps/macos/Sources/RemoteClaw/VoiceWakeRecognitionDebugSupport.swift
+++ b/apps/macos/Sources/RemoteClaw/VoiceWakeRecognitionDebugSupport.swift
@@ -1,0 +1,62 @@
+import Foundation
+import SwabbleKit
+
+enum VoiceWakeRecognitionDebugSupport {
+    struct TranscriptSummary {
+        let textOnly: Bool
+        let timingCount: Int
+    }
+
+    static func shouldLogTranscript(
+        transcript: String,
+        isFinal: Bool,
+        loggerLevel: Logger.Level,
+        lastLoggedText: inout String?,
+        lastLoggedAt: inout Date?,
+        minRepeatInterval: TimeInterval = 0.25) -> Bool
+    {
+        guard !transcript.isEmpty else { return false }
+        guard loggerLevel == .debug || loggerLevel == .trace else { return false }
+        if transcript == lastLoggedText,
+           !isFinal,
+           let last = lastLoggedAt,
+           Date().timeIntervalSince(last) < minRepeatInterval
+        {
+            return false
+        }
+        lastLoggedText = transcript
+        lastLoggedAt = Date()
+        return true
+    }
+
+    static func textOnlyFallbackMatch(
+        transcript: String,
+        triggers: [String],
+        config: WakeWordGateConfig,
+        trimWake: (String, [String]) -> String) -> WakeWordGateMatch?
+    {
+        guard let command = VoiceWakeTextUtils.textOnlyCommand(
+            transcript: transcript,
+            triggers: triggers,
+            minCommandLength: config.minCommandLength,
+            trimWake: trimWake)
+        else { return nil }
+        return WakeWordGateMatch(triggerEndTime: 0, postGap: 0, command: command)
+    }
+
+    static func transcriptSummary(
+        transcript: String,
+        triggers: [String],
+        segments: [WakeWordSegment]) -> TranscriptSummary
+    {
+        TranscriptSummary(
+            textOnly: WakeWordGate.matchesTextOnly(text: transcript, triggers: triggers),
+            timingCount: segments.count(where: { $0.start > 0 || $0.duration > 0 }))
+    }
+
+    static func matchSummary(_ match: WakeWordGateMatch?) -> String {
+        match.map {
+            "match=true gap=\(String(format: "%.2f", $0.postGap))s cmdLen=\($0.command.count)"
+        } ?? "match=false"
+    }
+}

--- a/apps/macos/Sources/RemoteClaw/VoiceWakeRuntime.swift
+++ b/apps/macos/Sources/RemoteClaw/VoiceWakeRuntime.swift
@@ -312,10 +312,12 @@ actor VoiceWakeRuntime {
                     self.committedTranscript = trimmed
                     self.volatileTranscript = ""
                 } else {
-                    self.volatileTranscript = Self.delta(after: self.committedTranscript, current: trimmed)
+                    self.volatileTranscript = VoiceOverlayTextFormatting.delta(
+                        after: self.committedTranscript,
+                        current: trimmed)
                 }
 
-                let attributed = Self.makeAttributed(
+                let attributed = VoiceOverlayTextFormatting.makeAttributed(
                     committed: self.committedTranscript,
                     volatile: self.volatileTranscript,
                     isFinal: update.isFinal)
@@ -337,10 +339,11 @@ actor VoiceWakeRuntime {
         var usedFallback = false
         var match = WakeWordGate.match(transcript: transcript, segments: update.segments, config: gateConfig)
         if match == nil, update.isFinal {
-            match = self.textOnlyFallbackMatch(
+            match = VoiceWakeRecognitionDebugSupport.textOnlyFallbackMatch(
                 transcript: transcript,
                 triggers: config.triggers,
-                config: gateConfig)
+                config: gateConfig,
+                trimWake: Self.trimmedAfterTrigger)
             usedFallback = match != nil
         }
         self.maybeLogRecognition(
@@ -387,22 +390,19 @@ actor VoiceWakeRuntime {
         usedFallback: Bool,
         capturing: Bool)
     {
-        guard !transcript.isEmpty else { return }
-        let level = self.logger.logLevel
-        guard level == .debug || level == .trace else { return }
-        if transcript == self.lastLoggedText, !isFinal {
-            if let last = self.lastLoggedAt, Date().timeIntervalSince(last) < 0.25 {
-                return
-            }
-        }
-        self.lastLoggedText = transcript
-        self.lastLoggedAt = Date()
+        guard VoiceWakeRecognitionDebugSupport.shouldLogTranscript(
+            transcript: transcript,
+            isFinal: isFinal,
+            loggerLevel: self.logger.logLevel,
+            lastLoggedText: &self.lastLoggedText,
+            lastLoggedAt: &self.lastLoggedAt)
+        else { return }
 
-        let textOnly = WakeWordGate.matchesTextOnly(text: transcript, triggers: triggers)
-        let timingCount = segments.count(where: { $0.start > 0 || $0.duration > 0 })
-        let matchSummary = match.map {
-            "match=true gap=\(String(format: "%.2f", $0.postGap))s cmdLen=\($0.command.count)"
-        } ?? "match=false"
+        let summary = VoiceWakeRecognitionDebugSupport.transcriptSummary(
+            transcript: transcript,
+            triggers: triggers,
+            segments: segments)
+        let matchSummary = VoiceWakeRecognitionDebugSupport.matchSummary(match)
         let segmentSummary = segments.map { seg in
             let start = String(format: "%.2f", seg.start)
             let end = String(format: "%.2f", seg.end)
@@ -410,8 +410,8 @@ actor VoiceWakeRuntime {
         }.joined(separator: ", ")
 
         self.logger.debug(
-            "voicewake runtime transcript='\(transcript, privacy: .private)' textOnly=\(textOnly) " +
-                "isFinal=\(isFinal) timing=\(timingCount)/\(segments.count) " +
+            "voicewake runtime transcript='\(transcript, privacy: .private)' textOnly=\(summary.textOnly) " +
+                "isFinal=\(isFinal) timing=\(summary.timingCount)/\(segments.count) " +
                 "capturing=\(capturing) fallback=\(usedFallback) " +
                 "\(matchSummary) segments=[\(segmentSummary, privacy: .private)]")
     }
@@ -495,20 +495,6 @@ actor VoiceWakeRuntime {
         await self.beginCapture(command: "", triggerEndTime: nil, config: config)
     }
 
-    private func textOnlyFallbackMatch(
-        transcript: String,
-        triggers: [String],
-        config: WakeWordGateConfig) -> WakeWordGateMatch?
-    {
-        guard let command = VoiceWakeTextUtils.textOnlyCommand(
-            transcript: transcript,
-            triggers: triggers,
-            minCommandLength: config.minCommandLength,
-            trimWake: Self.trimmedAfterTrigger)
-        else { return nil }
-        return WakeWordGateMatch(triggerEndTime: 0, postGap: 0, command: command)
-    }
-
     private func isTriggerOnly(transcript: String, triggers: [String]) -> Bool {
         guard WakeWordGate.matchesTextOnly(text: transcript, triggers: triggers) else { return false }
         guard VoiceWakeTextUtils.startsWithTrigger(transcript: transcript, triggers: triggers) else { return false }
@@ -526,10 +512,11 @@ actor VoiceWakeRuntime {
         guard !self.isCapturing else { return }
         guard let lastSeenAt, let lastText else { return }
         guard self.lastTranscriptAt == lastSeenAt, self.lastTranscript == lastText else { return }
-        guard let match = self.textOnlyFallbackMatch(
+        guard let match = VoiceWakeRecognitionDebugSupport.textOnlyFallbackMatch(
             transcript: lastText,
             triggers: triggers,
-            config: gateConfig)
+            config: gateConfig,
+            trimWake: Self.trimmedAfterTrigger)
         else { return }
         if let cooldown = self.cooldownUntil, Date() < cooldown {
             return
@@ -564,7 +551,7 @@ actor VoiceWakeRuntime {
         }
 
         let snapshot = self.committedTranscript + self.volatileTranscript
-        let attributed = Self.makeAttributed(
+        let attributed = VoiceOverlayTextFormatting.makeAttributed(
             committed: self.committedTranscript,
             volatile: self.volatileTranscript,
             isFinal: false)
@@ -781,33 +768,9 @@ actor VoiceWakeRuntime {
     }
 
     static func _testAttributedColor(isFinal: Bool) -> NSColor {
-        self.makeAttributed(committed: "sample", volatile: "", isFinal: isFinal)
+        VoiceOverlayTextFormatting.makeAttributed(committed: "sample", volatile: "", isFinal: isFinal)
             .attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor ?? .clear
     }
 
     #endif
-
-    private static func delta(after committed: String, current: String) -> String {
-        if current.hasPrefix(committed) {
-            let start = current.index(current.startIndex, offsetBy: committed.count)
-            return String(current[start...])
-        }
-        return current
-    }
-
-    private static func makeAttributed(committed: String, volatile: String, isFinal: Bool) -> NSAttributedString {
-        let full = NSMutableAttributedString()
-        let committedAttr: [NSAttributedString.Key: Any] = [
-            .foregroundColor: NSColor.labelColor,
-            .font: NSFont.systemFont(ofSize: 13, weight: .regular),
-        ]
-        full.append(NSAttributedString(string: committed, attributes: committedAttr))
-        let volatileColor: NSColor = isFinal ? .labelColor : NSColor.tertiaryLabelColor
-        let volatileAttr: [NSAttributedString.Key: Any] = [
-            .foregroundColor: volatileColor,
-            .font: NSFont.systemFont(ofSize: 13, weight: .regular),
-        ]
-        full.append(NSAttributedString(string: volatile, attributes: volatileAttr))
-        return full
-    }
 }

--- a/apps/macos/Sources/RemoteClaw/WorkActivityStore.swift
+++ b/apps/macos/Sources/RemoteClaw/WorkActivityStore.swift
@@ -113,17 +113,15 @@ final class WorkActivityStore {
 
     private func setJobActive(_ activity: Activity) {
         self.jobs[activity.sessionKey] = activity
-        // Main session preempts immediately.
-        if activity.role == .main {
-            self.currentSessionKey = activity.sessionKey
-        } else if self.currentSessionKey == nil || !self.isActive(sessionKey: self.currentSessionKey!) {
-            self.currentSessionKey = activity.sessionKey
-        }
-        self.refreshDerivedState()
+        self.updateCurrentSession(with: activity)
     }
 
     private func setToolActive(_ activity: Activity) {
         self.tools[activity.sessionKey] = activity
+        self.updateCurrentSession(with: activity)
+    }
+
+    private func updateCurrentSession(with activity: Activity) {
         // Main session preempts immediately.
         if activity.role == .main {
             self.currentSessionKey = activity.sessionKey

--- a/apps/macos/Sources/RemoteClawMacCLI/CLIArgParsingSupport.swift
+++ b/apps/macos/Sources/RemoteClawMacCLI/CLIArgParsingSupport.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum CLIArgParsingSupport {
+    static func nextValue(_ args: [String], index: inout Int) -> String? {
+        guard index + 1 < args.count else { return nil }
+        index += 1
+        return args[index].trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/apps/macos/Tests/RemoteClawIPCTests/GatewayDiscoveryHelpersTests.swift
+++ b/apps/macos/Tests/RemoteClawIPCTests/GatewayDiscoveryHelpersTests.swift
@@ -20,7 +20,7 @@ struct GatewayDiscoveryHelpersTests {
             tailnetDns: tailnetDns,
             sshPort: sshPort,
             gatewayPort: gatewayPort,
-            cliPath: "/tmp/openclaw",
+            cliPath: "/tmp/remoteclaw",
             stableID: UUID().uuidString,
             debugID: UUID().uuidString,
             isLocal: false)

--- a/apps/shared/RemoteClawKit/Sources/RemoteClawKit/CaptureRateLimits.swift
+++ b/apps/shared/RemoteClawKit/Sources/RemoteClawKit/CaptureRateLimits.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public enum CaptureRateLimits {
+    public static func clampDurationMs(
+        _ ms: Int?,
+        defaultMs: Int = 10_000,
+        minMs: Int = 250,
+        maxMs: Int = 60_000) -> Int
+    {
+        let value = ms ?? defaultMs
+        return min(maxMs, max(minMs, value))
+    }
+
+    public static func clampFps(
+        _ fps: Double?,
+        defaultFps: Double = 10,
+        minFps: Double = 1,
+        maxFps: Double) -> Double
+    {
+        let value = fps ?? defaultFps
+        guard value.isFinite else { return defaultFps }
+        return min(maxFps, max(minFps, value))
+    }
+}


### PR DESCRIPTION
## Summary

Process Cat A cluster A2 of the v2026.3.22 upstream sync backlog: **35 fork files** under `apps/macos/` requiring per-file disposition. Mirrors the approach of merged Wave 1 PR #2595 (A1 Android cluster).

| Action | Count | Notes |
|--------|------:|-------|
| **CHERRY-PICK applied** (rebrand transform → fork content changes) | 27 | `git diff` shows real content changes |
| **CHERRY-PICK no-op** (already in sync after rebrand transform) | 4 | `CanvasWindowController.swift`, `GatewayDiscoverySelectionSupport.swift`, `NodeServiceManager.swift`, `GatewayDiscoveryModel.swift` |
| **EXCLUDE-DIVERGENT** (registered in `hq/upstream/disposition.tsv`) | 4 | All pre-classified by triage; see table below |
| **Sub-total — issue scope** | **35** | ✓ matches issue scope |
| Helper files imported (net-new upstream additions referenced by cluster cherry-picks) | 15 | See "Net-new helper files" |
| PairingAlertSupport refresh (refactored upstream — fork's older version replaced) | 1 | See "PairingAlertSupport refresh" |

Closes #2583.

## EXCLUDE-DIVERGENT classifications

| File | Reason |
|------|--------|
| `ContextUsageBar.swift` | gut #2277 removed vestigial contextTokens config and display denominator on fork; upstream still references contextTokens. |
| `SessionMenuLabelView.swift` | gut #2277 (same). |
| `SessionsSettings.swift` | gut #2277 (same). |
| `UsageMenuLabelView.swift` | gut #2277 (same). |

All four were pre-classified by triage. Per-file inspection confirmed the classifications; **0 reclassifications during execution** (vs Wave 1's 2 reclassifications). Issue body anticipated 5–10% — actual: 0%.

## Net-new helper files (15)

These are upstream-side additions referenced by the cluster's cherry-picked files but not present in fork. Adding them is necessary for the cherry-picks to compile. Each is a one-shot import (with rebrand transforms applied) — no fork-divergent specialization. None are in the Cat A audit clusters because the audit only flagged "rebrand-below-threshold renames" (paths with content drift), not net-new additions.

In `apps/macos/Sources/RemoteClaw/`:
1. `PlatformLabelFormatter.swift` — extracted by upstream from inline `parsePlatform/prettyPlatform` in `InstancesSettings.swift` and `NodePairingApprovalPrompter.swift`.
2. `SettingsRefreshButton.swift` — extracted by upstream from inline refresh-button logic in `InstancesSettings.swift`.
3. `GatewayPushSubscription.swift` — used by `CronJobsStore.swift`, `InstancesStore.swift`.
4. `JSONObjectExtractionSupport.swift` — used by `GatewayLaunchAgentManager.swift`.
5. `TextSummarySupport.swift` — used by `GatewayLaunchAgentManager.swift`.
6. `SimpleTaskSupport.swift` — used by `InstancesStore.swift`, `NodesStore.swift`, `VoiceWakeGlobalSettingsSync.swift`.
7. `TrackingAreaSupport.swift` — used by `MenuBar.swift`.
8. `MicRefreshSupport.swift` — used by `MenuContentView.swift`, `VoiceWakeSettings.swift`.
9. `AgentWorkspaceConfig.swift` — used by `OnboardingView+Workspace.swift`.
10. `SystemSettingsURLSupport.swift` — used by `PermissionManager.swift`.
11. `PermissionMonitoringSupport.swift` — used by `SettingsRootView.swift`.
12. `VoiceOverlayTextFormatting.swift` — used by `VoicePushToTalk.swift`, `VoiceWakeRuntime.swift`.
13. `VoiceWakeRecognitionDebugSupport.swift` — used by `VoiceWakeRuntime.swift`, `VoiceWakeTester.swift`.

In `apps/macos/Sources/RemoteClawMacCLI/`:
14. `CLIArgParsingSupport.swift` — used by `ConnectCommand.swift`.

In `apps/shared/RemoteClawKit/Sources/RemoteClawKit/`:
15. `CaptureRateLimits.swift` — used by `ScreenRecordService.swift`.

## PairingAlertSupport refresh

The fork's `PairingAlertSupport.swift` (46 lines) is older than upstream's refactored version (277 lines). Upstream introduced `PairingAlertState`, `PairingResolution`, `PairingResolvedEvent`, plus methods (`approveRequest`, `presentPairingAlert`, `rejectRequest`, `startPairingPushTask`, `stopPairingPrompter`, `endActiveAlert(state:)` overload) referenced by cherry-picked `NodePairingApprovalPrompter.swift`.

Upstream's version is a strict superset — fork's prior content (`PairingAlertHostWindow`, `endActiveAlert(activeAlert:activeRequestId:)`, `requireAlertHostWindow`) is preserved verbatim. Replacing fork's version with upstream's (with rebrand transforms applied) is necessary for the cluster cherry-pick to compile. No fork specialization is lost (`git log apps/macos/Sources/RemoteClaw/PairingAlertSupport.swift` shows fork only had a rebrand commit on this file).

## Approach

1. Read upstream@v2026.3.22 content via `git show v2026.3.22:{path}`.
2. Apply token-based rebrand transforms per `hq/upstream/rebrand-tokens.tsv`:
   - `OpenClaw → RemoteClaw`, `openclaw → remoteclaw`, `OPENCLAW → REMOTECLAW`, `OPENCLAW_ → REMOTECLAW_`
   - Reverse-domain: `ai.openclaw → org.remoteclaw`, `com.openclaw → org.remoteclaw`
   - Repo URLs: `github.com/openclaw/openclaw → github.com/remoteclaw/remoteclaw`, `openclaw/openclaw → remoteclaw/remoteclaw`
   - Domain: `openclaw.io → remoteclaw.com`, `openclaw.ai → remoteclaw.com`
   - Config dir: `~/.openclaw → ~/.remoteclaw`, `.openclaw → .remoteclaw`
   - Misc: `openclaw-mac → remoteclaw-mac`, `@openclaw/ → @remoteclaw/`
3. Cross-class API audit detected 16 net-new types referenced by cherry-pickees — 15 helper files imported (with rebrand transforms applied), plus PairingAlertSupport refreshed.
4. Symbol audit (post-import) verified zero unresolved cross-class references in cluster diffs.

## Disposition.tsv updates

Four `EXTRACT` entries added at `/Users/alexey-pelykh/RemoteClaw/hq/upstream/disposition.tsv` (HQ companion, not in repo):

```
EXTRACT  apps/macos/Sources/OpenClaw/ContextUsageBar.swift        fork-divergent: gut #2277 removed vestigial contextTokens config and display denominator on fork; upstream still references contextTokens (#2583)
EXTRACT  apps/macos/Sources/OpenClaw/SessionMenuLabelView.swift   fork-divergent: gut #2277 removed vestigial contextTokens config and display denominator on fork (#2583)
EXTRACT  apps/macos/Sources/OpenClaw/SessionsSettings.swift       fork-divergent: gut #2277 removed vestigial contextTokens config and display denominator on fork (#2583)
EXTRACT  apps/macos/Sources/OpenClaw/UsageMenuLabelView.swift     fork-divergent: gut #2277 removed vestigial contextTokens config and display denominator on fork (#2583)
```

## Validation

| Gate | Result |
|------|--------|
| `pnpm format:check` (oxfmt) | ✓ |
| `pnpm tsgo` (TypeScript) | ✓ |
| `pnpm lint` (oxlint) | ✓ |
| `pnpm lint:tmp:no-random-messaging` | ✓ |
| `pnpm lint:no-remoteclaw-ai` | ✓ |
| `pnpm lint:ui:no-css-class-drift` | ✓ |
| `bash scripts/ci/check-rebrand-leakage.sh --staged` | ✓ |
| `node scripts/check-no-zombie-imports.mjs` | ✓ |
| `node scripts/check-stub-debt.mjs` | ✓ (126 == baseline) |
| `node scripts/check-throwing-stub-callers.mjs` | ✓ (0 stubs) |
| `node scripts/check-obsolescence-audit.mjs` | ✓ (49 == baseline) |

Bulk verification: re-running cherry-pick script post-execution → `WROTE=0 NOOP=31 SKIP=4` → A2 residual = 0.

Note: Fork CI does not build macOS (per `CLAUDE.md`). Local Xcode build NOT verified — same caveat as merged Wave 1 PR #2595.

## Polish review

`workflow-polish` ran in fresh subprocess context (session `0647e3ea-8b4c-463f-b66e-29a64cb6782a`). Verdict: 🟢 **CLEAN ENOUGH** — no actionable findings. One informational note:

1. `PeekabooBridgeHostCoordinator.swift` cherry-pick adds compatibility code creating symlinks for upstream's pre-rebrand brand directory names (`clawdbot`, `clawdis`, `moltbot`). For fresh fork users these are no-op ghost directories. Reviewer agreed this is acceptable as literal upstream-parity (per CLAUDE.md "User state boundary": fork users have no pre-rebrand state to migrate). Optional follow-up if desired: gate symlink creation behind `fileExists` check. Not required for this PR.

## Test plan

- [x] `pnpm check` passes locally
- [x] Fork-integrity gates pass locally
- [x] Per-file inspection: 27 CHERRY-PICK + 4 NOOP + 4 EXCLUDE-DIVERGENT = 35 covered
- [x] Polish review: CLEAN ENOUGH
- [ ] CI green (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
