### PR TITLE
docs: ice exec-approvals-architecture, refine middleware-arch boundary (#2618)

### DIFF
--- a/docs/concepts/exec-approvals-architecture.md
+++ b/docs/concepts/exec-approvals-architecture.md
@@ -10,8 +10,23 @@ title: "Exec-approvals architecture (decision record)"
 
 # Exec-approvals architecture
 
+> ⚠️ **ICED 2026-04-27** — The architecture described here is **not currently
+> implemented**. The gateway handlers for `exec.approval.{request,waitDecision,resolve}`
+> were deleted by [PR #2375](https://github.com/remoteclaw/remoteclaw/pull/2375)
+> in 2026-04-16; the macOS-mediated path is broken (verified by
+> [#2606](https://github.com/remoteclaw/remoteclaw/issues/2606) audit, see
+> [`docs/refactor/exec-approval-singular-audit-2606.md`](../refactor/exec-approval-singular-audit-2606.md)).
+> The cleanup of stranded callers + protocol declarations is tracked in
+> [#2618](https://github.com/remoteclaw/remoteclaw/issues/2618).
+>
+> RemoteClaw is committing to a future channel-mediated approval surface for
+> node-host exec (sister to the AgentRuntime tool-approval routing being
+> designed separately in [#2616](https://github.com/remoteclaw/remoteclaw/issues/2616)).
+> This doc is preserved for historical context only and will be replaced when
+> the new approach ships.
+
 Decision: 2026-04-26 (issue [#2573](https://github.com/remoteclaw/remoteclaw/issues/2573)).
-Status: **Accepted** — Path A.
+Status: **Iced** (was: Accepted — Path A; superseded by ongoing redesign).
 
 ## Context
 

--- a/docs/concepts/middleware-architecture.md
+++ b/docs/concepts/middleware-architecture.md
@@ -89,18 +89,29 @@ injection, and MCP tool bridging to the gateway.
 RemoteClaw documents and provides capabilities that **require RemoteClaw
 infrastructure**:
 
-| RemoteClaw's responsibility         | Agent's responsibility                       |
-| ----------------------------------- | -------------------------------------------- |
-| Session persistence across messages | Conversation memory within a session         |
-| Message delivery to channels        | Deciding what to say                         |
-| System prompt with channel context  | Tool execution (web search, file I/O, shell) |
-| MCP tools bridging to the gateway   | Model selection and inference                |
-| Cron scheduling                     | Code generation and analysis                 |
-| Cross-channel message routing       | Any capability the CLI provides natively     |
+| RemoteClaw's responsibility                                          | Agent's responsibility                                           |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Session persistence across messages                                  | Conversation memory within a session                             |
+| Message delivery to channels                                         | Deciding what to say                                             |
+| System prompt with channel context                                   | Tool execution (web search, file I/O, shell)                     |
+| MCP tools bridging to the gateway                                    | Model selection and inference                                    |
+| Cron scheduling                                                      | Code generation and analysis                                     |
+| Cross-channel message routing                                        | Any capability the CLI provides natively                         |
+| AgentRuntime tool-approval routing (capture and surface to channels) | Tool-execution decisions and the actual invocation post-approval |
 
 This principle governs what belongs in RemoteClaw's codebase and
 documentation. If a capability works without RemoteClaw infrastructure, it
 belongs to the agent CLI, not to RemoteClaw.
+
+**Approval routing is the same principle, applied to permission UX.** The
+agent decides which tool to invoke; RemoteClaw routes the resulting
+permission request through the user's chat for approval. Tool execution
+itself (the actual call to web search / file I/O / shell / etc.) remains
+the agent CLI's responsibility — RemoteClaw only mediates the approval UX.
+The "requires RemoteClaw infrastructure?" test is satisfied because the
+user is reachable only via RemoteClaw's channel adapters
+(see [#2616](https://github.com/remoteclaw/remoteclaw/issues/2616) for
+the implementation tracking).
 
 ## Key Components
 


### PR DESCRIPTION
## Summary

Two doc-only changes anticipating the broader cleanup tracked in #2618:

1. **ICED banner on `docs/concepts/exec-approvals-architecture.md`** — the architecture described is **not currently implemented**. The gateway handlers for `exec.approval.{request,waitDecision,resolve}` were deleted by PR #2375 (2026-04-16); the macOS-mediated path is broken (verified by the audit in PR #2609 — see `docs/refactor/exec-approval-singular-audit-2606.md`). Status changed: Accepted → Iced. Doc preserved for historical context only; will be replaced when the new approach ships. Banner links to #2606 (audit), #2618 (cleanup), #2616 (the new AgentRuntime tool-approval routing direction).

2. **`docs/concepts/middleware-architecture.md` § The Middleware Boundary Principle table** gains a row clarifying the boundary for tool-approval routing:
   - **LEFT (RemoteClaw)**: AgentRuntime tool-approval routing (capture and surface to channels)
   - **RIGHT (Agent)**: Tool-execution decisions and the actual invocation post-approval

   Plus a clarifying paragraph: routing is RemoteClaw's because the user is reachable only via RemoteClaw's channel adapters (the "requires RemoteClaw infrastructure?" test is satisfied); tool execution itself remains the agent CLI's responsibility. Paragraph links to #2616 for implementation tracking.

## Why now

The broader code cleanup (gut 4 stranded callers + protocol declarations + tests) is in #2618 and will land separately. The doc updates land here because:

- They're independent of the code surgery (no schema changes, no code changes — just docs)
- They're worth getting in front of any contributor reading the docs today, who would otherwise be misled about the singular `exec.approval.*` path being functional
- The boundary-table refinement signals the architectural commitment ahead of the implementation work in #2616

## Test plan

- [x] `pnpm check` clean (format:check, tsgo, lint, lint:tmp:no-random-messaging, lint:no-remoteclaw-ai, lint:ui:no-css-class-drift) — ran via pre-commit hook
- [x] Doc-only changes; no source/schema/test changes
- [x] All issue/PR references in the new content resolve to existing remoteclaw issues (#2375, #2606, #2609, #2616, #2618)

🤖 Generated with [Claude Code](https://claude.com/claude-code)