### PR TITLE
ci(rebrand): clean up 61 REBRAND_LEAKAGE entries from v2026.3.22 audit

### DIFF
--- a/apps/macos/Sources/RemoteClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/RemoteClaw/GatewayConnection.swift
@@ -4,7 +4,7 @@ import RemoteClawKit
 import RemoteClawProtocol
 import OSLog
 
-private let gatewayConnectionLogger = Logger(subsystem: "ai.openclaw", category: "gateway.connection")
+private let gatewayConnectionLogger = Logger(subsystem: "org.remoteclaw", category: "gateway.connection")
 
 enum GatewayAgentChannel: String, Codable, CaseIterable {
     case last

--- a/apps/macos/Sources/RemoteClaw/GatewayEnvironment.swift
+++ b/apps/macos/Sources/RemoteClaw/GatewayEnvironment.swift
@@ -70,7 +70,7 @@ struct GatewayCommandResolution {
 }
 
 enum GatewayEnvironment {
-    private static let logger = Logger(subsystem: "ai.openclaw", category: "gateway.env")
+    private static let logger = Logger(subsystem: "org.remoteclaw", category: "gateway.env")
     private static let supportedBindModes: Set<String> = ["loopback", "tailnet", "lan", "auto"]
 
     static func gatewayPort() -> Int {
@@ -125,7 +125,7 @@ enum GatewayEnvironment {
                 requiredGateway: expectedString,
                 message: RuntimeLocator.describeFailure(err))
         case let .success(runtime):
-            let gatewayBin = CommandResolver.openclawExecutable()
+            let gatewayBin = CommandResolver.remoteclawExecutable()
 
             if gatewayBin == nil, projectEntrypoint == nil {
                 return GatewayEnvironmentStatus(
@@ -133,7 +133,7 @@ enum GatewayEnvironment {
                     nodeVersion: runtime.version.description,
                     gatewayVersion: nil,
                     requiredGateway: expectedString,
-                    message: "openclaw CLI not found in PATH; install the CLI.")
+                    message: "remoteclaw CLI not found in PATH; install the CLI.")
             }
 
             let installed = gatewayBin.flatMap { self.readGatewayVersion(binary: $0) }
@@ -183,7 +183,7 @@ enum GatewayEnvironment {
         let projectRoot = CommandResolver.projectRoot()
         let projectEntrypoint = CommandResolver.gatewayEntrypoint(in: projectRoot)
         let status = self.check()
-        let gatewayBin = CommandResolver.openclawExecutable()
+        let gatewayBin = CommandResolver.remoteclawExecutable()
         let runtime = RuntimeLocator.resolve(searchPaths: CommandResolver.preferredPaths())
 
         guard case .ok = status.kind else {
@@ -249,16 +249,16 @@ enum GatewayEnvironment {
         let bun = CommandResolver.findExecutable(named: "bun")
         let (label, cmd): (String, [String]) =
             if let npm {
-                ("npm", [npm, "install", "-g", "openclaw@\(target)"])
+                ("npm", [npm, "install", "-g", "remoteclaw@\(target)"])
             } else if let pnpm {
-                ("pnpm", [pnpm, "add", "-g", "openclaw@\(target)"])
+                ("pnpm", [pnpm, "add", "-g", "remoteclaw@\(target)"])
             } else if let bun {
-                ("bun", [bun, "add", "-g", "openclaw@\(target)"])
+                ("bun", [bun, "add", "-g", "remoteclaw@\(target)"])
             } else {
-                ("npm", ["npm", "install", "-g", "openclaw@\(target)"])
+                ("npm", ["npm", "install", "-g", "remoteclaw@\(target)"])
             }
 
-        statusHandler("Installing openclaw@\(target) via \(label)…")
+        statusHandler("Installing remoteclaw@\(target) via \(label)…")
 
         func summarize(_ text: String) -> String? {
             let lines = text
@@ -272,7 +272,7 @@ enum GatewayEnvironment {
 
         let response = await ShellExecutor.runDetailed(command: cmd, cwd: nil, env: ["PATH": preferred], timeout: 300)
         if response.success {
-            statusHandler("Installed openclaw@\(target)")
+            statusHandler("Installed remoteclaw@\(target)")
         } else {
             if response.timedOut {
                 statusHandler("Install failed: timed out. Check your internet connection and try again.")

--- a/apps/macos/Sources/RemoteClaw/HealthStore.swift
+++ b/apps/macos/Sources/RemoteClaw/HealthStore.swift
@@ -72,7 +72,7 @@ enum HealthState: Equatable {
 final class HealthStore {
     static let shared = HealthStore()
 
-    private static let logger = Logger(subsystem: "ai.openclaw", category: "health")
+    private static let logger = Logger(subsystem: "org.remoteclaw", category: "health")
 
     private(set) var snapshot: HealthSnapshot?
     private(set) var lastSuccess: Date?
@@ -221,9 +221,9 @@ final class HealthStore {
             if let fallback = self.resolveFallbackChannel(snap, excluding: link.id) {
                 let fallbackLabel = snap.channelLabels?[fallback.id] ?? fallback.id.capitalized
                 let fallbackState = (fallback.summary.probe?.ok ?? true) ? "ok" : "degraded"
-                return "\(fallbackLabel) \(fallbackState) · Not linked — run openclaw login"
+                return "\(fallbackLabel) \(fallbackState) · Not linked — run remoteclaw login"
             }
-            return "Not linked — run openclaw login"
+            return "Not linked — run remoteclaw login"
         }
         let auth = link.summary.authAgeMs.map { msToAge($0) } ?? "unknown"
         if let probe = link.summary.probe, probe.ok == false {
@@ -253,7 +253,7 @@ final class HealthStore {
 
     func describeFailure(from snap: HealthSnapshot, fallback: String?) -> String {
         if let link = self.resolveLinkChannel(snap), link.summary.linked != true {
-            return "Not linked — run openclaw login"
+            return "Not linked — run remoteclaw login"
         }
         if let link = self.resolveLinkChannel(snap), let probe = link.summary.probe, probe.ok == false {
             return Self.describeProbeFailure(probe)

--- a/apps/macos/Sources/RemoteClaw/SessionMenuPreviewView.swift
+++ b/apps/macos/Sources/RemoteClaw/SessionMenuPreviewView.swift
@@ -219,7 +219,7 @@ struct SessionMenuPreviewView: View {
 }
 
 enum SessionMenuPreviewLoader {
-    private static let logger = Logger(subsystem: "ai.openclaw", category: "SessionPreview")
+    private static let logger = Logger(subsystem: "org.remoteclaw", category: "SessionPreview")
     private static let previewTimeoutSeconds: Double = 4
     private static let cacheMaxAgeSeconds: TimeInterval = 30
     private static let previewMaxChars = 240

--- a/apps/macos/Sources/RemoteClaw/TalkAudioPlayer.swift
+++ b/apps/macos/Sources/RemoteClaw/TalkAudioPlayer.swift
@@ -6,7 +6,7 @@ import OSLog
 final class TalkAudioPlayer: NSObject, @preconcurrency AVAudioPlayerDelegate {
     static let shared = TalkAudioPlayer()
 
-    private let logger = Logger(subsystem: "ai.openclaw", category: "talk.tts")
+    private let logger = Logger(subsystem: "org.remoteclaw", category: "talk.tts")
     private var player: AVAudioPlayer?
     private var playback: Playback?
 

--- a/apps/macos/Sources/RemoteClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/RemoteClaw/TalkModeRuntime.swift
@@ -8,8 +8,8 @@ import Speech
 actor TalkModeRuntime {
     static let shared = TalkModeRuntime()
 
-    private let logger = Logger(subsystem: "ai.openclaw", category: "talk.runtime")
-    private let ttsLogger = Logger(subsystem: "ai.openclaw", category: "talk.tts")
+    private let logger = Logger(subsystem: "org.remoteclaw", category: "talk.runtime")
+    private let ttsLogger = Logger(subsystem: "org.remoteclaw", category: "talk.tts")
     private static let defaultModelIdFallback = "eleven_v3"
     private static let defaultTalkProvider = "elevenlabs"
     private static let defaultSilenceTimeoutMs = TalkDefaults.silenceTimeoutMs

--- a/apps/macos/Sources/RemoteClaw/VoiceWakeChime.swift
+++ b/apps/macos/Sources/RemoteClaw/VoiceWakeChime.swift
@@ -43,7 +43,7 @@ enum VoiceWakeChimeCatalog {
 
 @MainActor
 enum VoiceWakeChimePlayer {
-    private static let logger = Logger(subsystem: "ai.openclaw", category: "voicewake.chime")
+    private static let logger = Logger(subsystem: "org.remoteclaw", category: "voicewake.chime")
     private static var lastSound: NSSound?
 
     static func play(_ chime: VoiceWakeChime, reason: String? = nil) {

--- a/apps/macos/Sources/RemoteClaw/VoiceWakeForwarder.swift
+++ b/apps/macos/Sources/RemoteClaw/VoiceWakeForwarder.swift
@@ -2,7 +2,7 @@ import Foundation
 import OSLog
 
 enum VoiceWakeForwarder {
-    private static let logger = Logger(subsystem: "ai.openclaw", category: "voicewake.forward")
+    private static let logger = Logger(subsystem: "org.remoteclaw", category: "voicewake.forward")
 
     static func prefixedTranscript(_ transcript: String, machineName: String? = nil) -> String {
         let resolvedMachine = machineName

--- a/apps/shared/RemoteClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/RemoteClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -57,7 +57,7 @@ func canonicalizeCanvasHostUrl(raw: String?, activeURL: URL?) -> String? {
 
 
 public actor GatewayNodeSession {
-    private let logger = Logger(subsystem: "ai.openclaw", category: "node.gateway")
+    private let logger = Logger(subsystem: "org.remoteclaw", category: "node.gateway")
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
     private static let defaultInvokeTimeoutMs = 30_000
@@ -80,7 +80,7 @@ public actor GatewayNodeSession {
         timeoutMs: Int?,
         onInvoke: @escaping @Sendable (BridgeInvokeRequest) async -> BridgeInvokeResponse
     ) async -> BridgeInvokeResponse {
-        let timeoutLogger = Logger(subsystem: "ai.openclaw", category: "node.gateway")
+        let timeoutLogger = Logger(subsystem: "org.remoteclaw", category: "node.gateway")
         let timeout: Int = {
             if let timeoutMs { return max(0, timeoutMs) }
             return Self.defaultInvokeTimeoutMs


### PR DESCRIPTION
## Summary

Per-file triage of 61 REBRAND_LEAKAGE entries flagged by the
`scripts/ci/check-rebrand-leakage.sh` gate after the v2026.3.22 sync.

**Triage breakdown**:
- **47 files allowlisted** (intentional retains; allowlist unchanged)
- **9 files fixed** (genuine missed renames in macOS native app — 23 lines)
- **1 follow-up** (orphaned `OpenClawKit/` + `OpenClawChatUI/` directories)

## Allowlisted (intentional retains, ~47 files)

All covered by EXISTING patterns/FILE: entries in `scripts/ci/rebrand-allowlist.txt`:

| Category | Pattern/Source | Files |
|----------|----------------|-------|
| Fork-attribution | `FILE:README.md`, `FILE:NOTICE.md`, `FILE:VISION.md`, `FILE:CLAUDE.md`, `FILE:REUSE.toml`, pattern `OpenClaw` | README.md, CHANGELOG.md, CLAUDE.md, NOTICE.md, REUSE.toml, VISION.md |
| Migration docs | `FILE:docs/` blanket | docs/install/from-openclaw.mdx, docs/install/breaking-changes-from-openclaw.md, docs/start/openclaw-or-remoteclaw.mdx, docs/start/nanoclaw-or-remoteclaw.mdx, docs/install/index.mdx, docs/landscape.md, docs/concepts/* |
| Sync audit docs | `FILE:docs/` blanket | docs/refactor/sync-cat-* (8 files), docs/refactor/{agentruntime-credential-injection,docs-gutted-feature-audit}.md |
| Migration code | `FILE:src/commands/import.ts`, `FILE:src/commands/import.test.ts` | src/commands/import.ts, src/commands/import.test.ts (OPENCLAW_ env-var migration helper) |
| Self-references | `FILE:scripts/ci/check-rebrand-leakage.sh`, `FILE:scripts/ci/rebrand-allowlist.txt` | gate infrastructure |
| Test asserting absence | pattern `"openclaw"` / `OpenClaw` | src/middleware/system-prompt.test.ts (asserts result `.not.toContain("openclaw")`) |
| Compat env vars | pattern `OPENCLAW_` | apps/macos test fixtures referencing OPENCLAW_GATEWAY_PORT etc. |
| Test fixture paths | patterns `openclaw-`, `"openclaw"`, `openclaw.`, `/openclaw`, `.openclaw` | apps/macos/Tests/RemoteClawIPCTests/* (12 files) |
| UserDefaults compat | pattern `openclaw.` | apps/macos ConnectionModeResolver.swift (`openclaw.onboardingSeen`) |
| Bonjour service | pattern `openclaw-` | apps/macos WideAreaGatewayDiscovery.swift (`_openclaw-gw._tcp`) |
| Build/CI compat | `FILE:package.json`, `FILE:scripts/audit-css-class-drift.mjs`, etc. | package.json (upstreamRepo), scripts/audit-css-class-drift.mjs (comment), scripts/lib/format-generated-module.mjs (temp dir prefix) |

**No allowlist changes** — existing patterns already cover all 47 files.

## Fixed (genuine missed renames, 9 files / 23 lines)

| Fix | Sites | Rationale |
|-----|-------|-----------|
| Logger subsystem `ai.openclaw` → `org.remoteclaw` | 9 occurrences across 8 files | Matches project-wide convention (29 healthy occurrences in Sources; bundle ID is `org.remoteclaw.mac` per `apps/macos/Sources/RemoteClaw/Resources/Info.plist:10`) |
| `CommandResolver.openclawExecutable()` → `remoteclawExecutable()` | 2 callers in `GatewayEnvironment.swift` | **Fixes latent compile error**: method was renamed at `CommandResolver.swift:196` but callers were never updated (Swift build is not in CI per CLAUDE.md, so the error was undetected) |
| `npm/pnpm/bun install -g openclaw@<target>` → `remoteclaw@<target>` | 4 occurrences in `GatewayEnvironment.swift` | **Fixes latent bug**: published npm package is `remoteclaw` per `package.json` `"name"`; previous code installed wrong/non-existent package |
| User-facing strings | "run openclaw login" ×3 (HealthStore.swift), "openclaw CLI not found" ×1 (GatewayEnvironment.swift), "Installing/Installed openclaw@" ×2 (GatewayEnvironment.swift) | CLI binary name is `remoteclaw` per `CommandResolver.swift:5` `helperName = "remoteclaw"` |

**Affected files**:
- `apps/macos/Sources/RemoteClaw/GatewayConnection.swift`
- `apps/macos/Sources/RemoteClaw/GatewayEnvironment.swift`
- `apps/macos/Sources/RemoteClaw/HealthStore.swift`
- `apps/macos/Sources/RemoteClaw/SessionMenuPreviewView.swift`
- `apps/macos/Sources/RemoteClaw/TalkAudioPlayer.swift`
- `apps/macos/Sources/RemoteClaw/TalkModeRuntime.swift`
- `apps/macos/Sources/RemoteClaw/VoiceWakeChime.swift`
- `apps/macos/Sources/RemoteClaw/VoiceWakeForwarder.swift`
- `apps/shared/RemoteClawKit/Sources/OpenClawKit/GatewayNodeSession.swift` (orphaned dir; see follow-up below)

## Follow-up issue (out of scope for this PR)

`apps/shared/RemoteClawKit/Sources/OpenClawKit/` and `apps/shared/RemoteClawKit/Sources/OpenClawChatUI/` are orphaned dead directories — not referenced in `apps/shared/RemoteClawKit/Package.swift` and superseded by the live `RemoteClawKit/` and `RemoteClawChatUI/` directories (renamed in v2026.3.7→8 sync, the live counterparts have newer content like `bootstrapToken` field).

These directories should be deleted in a follow-up issue, matching the pattern of #2611 and #2613 (stale Swift file removal). 11 files total (6 + 5).

Per the request, the directory rename/deletion is **proposed here but not executed** — path renames span imports across iOS/macOS/shared targets and warrant a dedicated cleanup PR.

## Verification

- ✅ `bash scripts/ci/check-rebrand-leakage.sh --all` → `No rebrand leakage detected.` (exit 0)
- ✅ Pre-commit hook passed: `pnpm format:check`, `pnpm tsgo`, `pnpm lint`, `pnpm lint:tmp:no-random-messaging`, `pnpm lint:no-remoteclaw-ai`, `pnpm lint:ui:no-css-class-drift`
- ⚠️ `cd apps/macos && swift build` — fails on **pre-existing** errors (`LoopbackHost`, `GatewayDeviceAuthPayload`, `GatewayConnectChallengeSupport`, `ThrowingContinuationSupport` undefined in `apps/shared/RemoteClawKit/Sources/RemoteClawKit/`); introduced by sync v2026.3.12 (commit b9747cd5fa), unrelated to this PR. Swift build is not in CI per CLAUDE.md.
- ✅ This PR fixes a latent compile error (`CommandResolver.openclawExecutable()` callers — method had been renamed but callers were not).

## Test plan

- [x] Run `bash scripts/ci/check-rebrand-leakage.sh --all` locally — exits 0
- [x] Run `pnpm check` (format + typecheck + lint + drift audit) — passes
- [ ] CI build job passes (no Swift in CI; Node/TypeScript lanes only)
- [ ] CI test job passes
- [ ] CI lint job passes
- [ ] CI docs job passes

Closes #2620

🤖 Generated with [Claude Code](https://claude.com/claude-code)