### PR TITLE
chore: bump to 0.8.0 for next development cycle

### DIFF
--- a/extensions/bluebubbles/package.json
+++ b/extensions/bluebubbles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/bluebubbles",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "RemoteClaw BlueBubbles channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/diagnostics-otel",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "RemoteClaw diagnostics OpenTelemetry exporter",
   "type": "module",
   "dependencies": {

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/discord",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "RemoteClaw Discord channel plugin",
   "type": "module",
   "remoteclaw": {

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/feishu",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "RemoteClaw Feishu/Lark channel plugin (community maintained by @m1heng)",
   "type": "module",
   "dependencies": {

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/googlechat",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "RemoteClaw Google Chat channel plugin",
   "type": "module",

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/imessage",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "RemoteClaw iMessage channel plugin",
   "type": "module",

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/irc",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "RemoteClaw IRC channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/line",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "RemoteClaw LINE channel plugin",
   "type": "module",

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/matrix",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "RemoteClaw Matrix channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/mattermost",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "RemoteClaw Mattermost channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/msteams",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "RemoteClaw Microsoft Teams channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/nextcloud-talk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "RemoteClaw Nextcloud Talk channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/nostr",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "RemoteClaw Nostr channel plugin for NIP-04 encrypted DMs",
   "type": "module",
   "dependencies": {

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/signal",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "RemoteClaw Signal channel plugin",
   "type": "module",

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/slack",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "RemoteClaw Slack channel plugin",
   "type": "module",

--- a/extensions/synology-chat/package.json
+++ b/extensions/synology-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/synology-chat",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Synology Chat channel plugin for RemoteClaw",
   "type": "module",
   "dependencies": {

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/telegram",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "RemoteClaw Telegram channel plugin",
   "type": "module",

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/tlon",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "RemoteClaw Tlon/Urbit channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/twitch",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "RemoteClaw Twitch channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/voice-call",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "RemoteClaw voice-call plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/whatsapp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "RemoteClaw WhatsApp channel plugin",
   "type": "module",

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/zalo",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "RemoteClaw Zalo channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteclaw/zalouser",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "RemoteClaw Zalo Personal Account plugin via native zca-js integration",
   "type": "module",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteclaw",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [
     "agent",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -13287,6 +13287,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
       tags: ["security", "auth"],
     },
   },
-  version: "0.7.0",
+  version: "0.8.0",
   generatedAt: "2026-03-22T21:17:33.302Z",
 } as const satisfies BaseConfigSchemaResponse;


### PR DESCRIPTION
## Summary

Post-release dev-cycle bump after [`v0.7.0`](https://github.com/remoteclaw/remoteclaw/releases/tag/v0.7.0) shipped to npm `latest`.

- Root `package.json` and 23 `extensions/*/package.json`: `0.7.0` → `0.8.0`
- `src/config/schema.base.generated.ts`: regenerated to match (avoids the `schema.base.generated.test.ts` break that hit main last cycle)

## Test plan

- [x] `pnpm check` (format + tsgo + lint + drift gates) green via pre-commit hook
- [ ] CI build/test/lint/docs green
- [ ] Auto-merge enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)