### PR TITLE
d.4(v2026.3.24): port zod-schema displayName field (1/45 safe-intersection)

### DIFF
--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -271,6 +271,7 @@ export const RemoteClawSchema = z
                 provider: z.string(),
                 mode: z.union([z.literal("api_key"), z.literal("oauth"), z.literal("token")]),
                 email: z.string().optional(),
+                displayName: z.string().optional(),
               })
               .strict(),
           )


### PR DESCRIPTION
## Summary

Partial close of remoteclaw/remoteclaw#2628 — D.4 EXTRACT porting for v2026.3.24 batch.

**Scope**: 45-file "safe intersection" subset of 368 deferred EXTRACT files (intersection of SAFE_NO_API ∩ (DIVERGED_CLEAN ∪ FORK_PRE_CLEAN)).

**Result**: 1 file ported + 44 documented SKIPs.

| Verdict | Count |
|---------|------:|
| PORT | 1 |
| SKIP — out-of-scope file dependency | 4 |
| SKIP — false-positive classification | 1 |
| SKIP — client.ts API rename coupling | 4 |
| SKIP — REVIEW with deeper coupling | 35 |

## Single PORT

`src/config/zod-schema.ts` — adds `displayName: z.string().optional()` to `RemoteClawSchema.providerCredentials` (mirroring upstream OpenClawSchema). Pure 1-line addition, no dependencies.

## Why only 1 ported

The "safe intersection" heuristic filtered for files where (a) upstream diff doesn't add new imports/exports, (b) fork content matches upstream-pre or has only clean differences. In practice, 44/45 had cross-file API coupling that the heuristic missed:

- 4 files depend on out-of-scope changes to `subagent-registry.ts`, `tools/common.ts`, `service.ts`
- 4 files use `connectChallengeTimeoutMs` option that fork's `client.ts` doesn't accept (still uses `connectDelayMs`)
- 1 file (`extensions/matrix/package.json`) was actually FORK_POST already (classifier false positive)
- 35 REVIEW-class files have cross-file coupling (CSS class additions, GatewayService.stage method, mock signature drift, etc.)

Per-file SKIP rationale documented in `hq/upstream/d4-v2026.3.24-skip-log.md` (separate HQ commit).

## Implication for future syncs

The bucket analysis (preserved at `hq/.tmp/d4-buckets/`) is valuable as a STARTING POINT but the "safe intersection" needs refinement — cross-file API coupling isn't captured by import-graph analysis. Future L+ batches should pre-decompose into "coupling units" rather than per-file porting. Tracked as a strategic improvement.

## Other 323 deferred files

Processed in a separate metadata-closure HQ commit — divergence record SHA updates + bucket-derived skip rationale for each. No carry-forward.

## Hard rule adherence

- No `git stash`, no `git reset --hard`, no blanket `git checkout HEAD --`
- No EXCLUDE-GUT → INCLUDE registry mutations
- Single WIP commit (this PR is squashed at merge time)
- Binary exit: PR created + this body documents the verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)