### PR TITLE
d.4(v2026.3.24): port 5 additional deferred EXTRACT files

### DIFF
--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -426,6 +426,18 @@ function main() {
       for (const path of missing) {
         console.error(`  - ${path}`);
       }
+      if (
+        missing.some(
+          (path) =>
+            path === "dist/build-info.json" ||
+            path === "dist/control-ui/index.html" ||
+            path.startsWith("dist/"),
+        )
+      ) {
+        console.error(
+          "release-check: build artifacts are missing. Run `pnpm build` before `pnpm release:check`.",
+        );
+      }
     }
     if (forbidden.length > 0) {
       console.error("release-check: forbidden files in npm pack:");

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -48,6 +48,25 @@ export async function resolveSessionKeyFromResolveParams(params: {
     const target = resolveGatewaySessionStoreTarget({ cfg, key });
     const store = loadSessionStore(target.storePath);
     if (store[target.canonicalKey]) {
+      if (typeof p.spawnedBy === "string" && p.spawnedBy.trim().length > 0) {
+        const visible = listSessionsFromStore({
+          cfg,
+          storePath: target.storePath,
+          store,
+          opts: {
+            includeGlobal: p.includeGlobal === true,
+            includeUnknown: p.includeUnknown === true,
+            spawnedBy: p.spawnedBy,
+            agentId: p.agentId,
+          },
+        }).sessions.some((session) => session.key === target.canonicalKey);
+        if (!visible) {
+          return {
+            ok: false,
+            error: errorShape(ErrorCodes.INVALID_REQUEST, `No session found: ${key}`),
+          };
+        }
+      }
       return { ok: true, key: target.canonicalKey };
     }
     const legacyKey = target.storeKeys.find((candidate) => store[candidate]);
@@ -66,6 +85,25 @@ export async function resolveSessionKeyFromResolveParams(params: {
       }
       pruneLegacyStoreKeys({ store: s, canonicalKey, candidates: liveTarget.storeKeys });
     });
+    if (typeof p.spawnedBy === "string" && p.spawnedBy.trim().length > 0) {
+      const visible = listSessionsFromStore({
+        cfg,
+        storePath: target.storePath,
+        store: loadSessionStore(target.storePath),
+        opts: {
+          includeGlobal: p.includeGlobal === true,
+          includeUnknown: p.includeUnknown === true,
+          spawnedBy: p.spawnedBy,
+          agentId: p.agentId,
+        },
+      }).sessions.some((session) => session.key === target.canonicalKey);
+      if (!visible) {
+        return {
+          ok: false,
+          error: errorShape(ErrorCodes.INVALID_REQUEST, `No session found: ${key}`),
+        };
+      }
+    }
     return { ok: true, key: target.canonicalKey };
   }
 
@@ -80,8 +118,6 @@ export async function resolveSessionKeyFromResolveParams(params: {
         includeUnknown: p.includeUnknown === true,
         spawnedBy: p.spawnedBy,
         agentId: p.agentId,
-        search: sessionId,
-        limit: 8,
       },
     });
     const matches = list.sessions.filter(

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -6,3 +6,13 @@
 @import "./styles/chat.css";
 @import "./styles/config.css";
 @import "./styles/config-sidebar.css";
+@import "@create-markdown/preview/themes/system.css";
+
+.cm-preview {
+  --cm-mono: var(--mono);
+  --cm-link: var(--accent);
+  --cm-info: var(--info);
+  --cm-warning: var(--warn);
+  --cm-success: var(--ok);
+  --cm-danger: var(--danger);
+}

--- a/ui/src/ui/views/channels.nostr-profile-form.ts
+++ b/ui/src/ui/views/channels.nostr-profile-form.ts
@@ -101,7 +101,7 @@ export function renderNostrProfileForm(params: {
             placeholder=${placeholder ?? ""}
             maxlength=${maxLength ?? 2000}
             rows="3"
-            style="width: 100%; padding: 8px; border: 1px solid var(--border-color); border-radius: 4px; resize: vertical; font-family: inherit;"
+            style="width: 100%; padding: 8px; border: 1px solid var(--border-color); border-radius: var(--radius-sm); resize: vertical; font-family: inherit;"
             @input=${(e: InputEvent) => {
               const target = e.target as HTMLTextAreaElement;
               callbacks.onFieldChange(field, target.value);
@@ -125,7 +125,7 @@ export function renderNostrProfileForm(params: {
           .value=${value}
           placeholder=${placeholder ?? ""}
           maxlength=${maxLength ?? 256}
-          style="width: 100%; padding: 8px; border: 1px solid var(--border-color); border-radius: 4px;"
+          style="width: 100%; padding: 8px; border: 1px solid var(--border-color); border-radius: var(--radius-sm);"
           @input=${(e: InputEvent) => {
             const target = e.target as HTMLInputElement;
             callbacks.onFieldChange(field, target.value);
@@ -164,7 +164,7 @@ export function renderNostrProfileForm(params: {
   };
 
   return html`
-    <div style="padding: 16px; background: var(--bg-secondary); border-radius: 8px; margin-top: 12px;">
+    <div style="padding: 16px; background: var(--bg-secondary); border-radius: var(--radius-md); margin-top: 12px;">
       <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
         <div style="font-weight: 600; font-size: 16px;">Edit Profile</div>
         <div style="font-size: 12px; color: var(--text-muted);">Account: ${accountId}</div>

--- a/ui/src/ui/views/config-form.render.ts
+++ b/ui/src/ui/views/config-form.render.ts
@@ -201,6 +201,40 @@ const sectionIcons = {
       <path d="m19.07 10.93-4.24 4.24"></path>
     </svg>
   `,
+  diagnostics: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+    </svg>
+  `,
+  cli: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <polyline points="4 17 10 11 4 5"></polyline>
+      <line x1="12" y1="19" x2="20" y2="19"></line>
+    </svg>
+  `,
+  secrets: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <path
+        d="m21 2-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0 3 3L22 7l-3-3m-3.5 3.5L19 4"
+      ></path>
+    </svg>
+  `,
+  acp: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+      <circle cx="9" cy="7" r="4"></circle>
+      <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+      <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+    </svg>
+  `,
+  mcp: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <rect x="2" y="2" width="20" height="8" rx="2" ry="2"></rect>
+      <rect x="2" y="14" width="20" height="8" rx="2" ry="2"></rect>
+      <line x1="6" y1="6" x2="6.01" y2="6"></line>
+      <line x1="6" y1="18" x2="6.01" y2="18"></line>
+    </svg>
+  `,
   default: html`
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
       <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>


### PR DESCRIPTION
## Summary

Closes remoteclaw/remoteclaw#2628 (alongside PR #2631 which ported `src/config/zod-schema.ts`).

This PR ships 5 additional ports from the v2026.3.24 D.4 deferred set that were committed locally during auto-resume but missed PR #2631's auto-merge window.

## Files

| File | Change |
|------|--------|
| `scripts/release-check.ts` | Hint that build artifacts are missing — directs the user to run `pnpm build` before `pnpm release:check` |
| `ui/src/styles.css` | Import `@create-markdown/preview` theme; bind `.cm-preview` CSS vars to fork's `--mono` / `--accent` / `--info` / `--warn` / `--ok` / `--danger` |
| `ui/src/ui/views/channels.nostr-profile-form.ts` | Replace inline `border-radius` with `var(--radius-1)` for theme consistency |
| `src/gateway/sessions-resolve.ts` | Enforce `spawnedBy` visibility check on canonical and legacy session-key resolution paths; drop search/limit args from `hasSessionId` list call (matches upstream API simplification) |
| `ui/src/ui/views/config-form.render.ts` | Add diagnostics / cli / secrets / acp / mcp section icons |

## Verification

- `pnpm tsgo`: clean
- `pnpm lint`: clean (oxlint, 0 warnings, 0 errors)
- HQ divergence records updated (commit hq@25220ef) with PORT verdicts and PR ref

## Context

Together with PR #2631, this lands 6 of 368 deferred EXTRACT files. The remaining 362 are documented decisions (SKIP / DEFER / NO-OP / RETAIN) per `hq/upstream/d4-v2026.3.24-closure.md`. Per-file divergence records are authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)