### PR TITLE
chore: update upstreamVersion to v2026.3.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.com/package/remoteclaw"><img src="https://img.shields.io/npm/v/remoteclaw?style=for-the-badge" alt="npm version"></a>
   <a href="https://github.com/remoteclaw/remoteclaw/releases"><img src="https://img.shields.io/github/v/release/remoteclaw/remoteclaw?include_prereleases&display_name=release&style=for-the-badge&label=GITHUB" alt="GitHub release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0--only-blue.svg?style=for-the-badge" alt="AGPL-3.0-only License"></a>
-  <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.3.24"><img src="https://img.shields.io/badge/upstream-OpenClaw_v2026.3.24-teal?style=for-the-badge" alt="Upstream: OpenClaw v2026.3.24"></a>
+  <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.3.28"><img src="https://img.shields.io/badge/upstream-OpenClaw_v2026.3.28-teal?style=for-the-badge" alt="Upstream: OpenClaw v2026.3.28"></a>
 </p>
 
 **RemoteClaw** is AI agent middleware. It connects agent CLIs you already run — Claude Code, Gemini CLI, Codex, OpenCode — to the messaging channels you already use, so you can reach your agents from anywhere: your phone, your team Slack, your WhatsApp, anywhere.

--- a/package.json
+++ b/package.json
@@ -438,5 +438,5 @@
     ]
   },
   "upstreamRepo": "openclaw/openclaw",
-  "upstreamVersion": "2026.3.24"
+  "upstreamVersion": "2026.3.28"
 }


### PR DESCRIPTION
Bump upstream version markers to follow PR #2634 (sync to v2026.3.28).

- package.json upstreamVersion: 2026.3.24 → 2026.3.28
- README.md upstream badge: v2026.3.24 → v2026.3.28

Standard post-sync chore. v2026.3.24 used the same pattern.

@claude please review this PR