### PR TITLE
fix(hooks): use --force in pre-commit re-stage (#2638)

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -46,7 +46,7 @@ if [ "${#format_files[@]}" -gt 0 ]; then
   "$RUN_NODE_TOOL" oxfmt --write --no-error-on-unmatched-pattern "${format_files[@]}"
 fi
 
-git add -- "${files[@]}"
+git add --force -- "${files[@]}"
 
 # This hook is also exercised from lightweight temp repos in tests, where the
 # staged-file safety behavior matters but the full RemoteClaw workspace does not


### PR DESCRIPTION
## Summary
- Add `--force` to the post-format `git add` re-stage in `git-hooks/pre-commit:49`
- Matches the canonical pattern at `scripts/committer:185` (`git add --force -- "${files[@]}"`)
- Unblocks pre-commit on tracked files inside gitignored dirs (e.g., `vendor/`)

## Why

The fork's pre-commit hook re-runs `git add` on the entire staged file list after lint-fix and format-write. Without `--force`, this exits 1 when ANY argument resolves to a path inside a gitignored directory — even when the file is force-tracked via `git add -f` initially. `vendor/` is gitignored but contains tracked files (e.g., `vendor/a2ui/renderers/lit/tsconfig.json`), so any sync touching those files blocks the commit.

The fix matches the initial `git add -f` semantics that the file-enumeration logic already assumes.

## Test plan
- [x] Existing tests in `test/git-hooks-pre-commit.test.ts` reviewed; `--` separator preserved, `--force` is a no-op for non-gitignored files (no regression to `--all`-as-filename safety test or FAST_COMMIT test)
- [x] Adversarial validation reproduced the bug in /tmp (`git add vendor/file.txt` exit 1 with "paths are ignored") and confirmed the fix resolves it
- [ ] CI green

## Out of scope (deferred)
- Regression test for the gitignored-tracked-files re-stage path — would require new test infrastructure (existing tests stub out `run-node-tool.sh`); follow-up if regression coverage is desired

Closes #2638