### PR TITLE
fix(security): port webhook rate limiting + SSRF guard hunks (#2636 W2+W3)

### DIFF
--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -1,9 +1,12 @@
 import { timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
+  createFixedWindowRateLimiter,
   createWebhookInFlightLimiter,
   registerWebhookTargetWithPluginRoute,
   readWebhookBodyOrReject,
+  resolveRequestClientIp,
   resolveWebhookTargetWithAuthOrRejectSync,
   withResolvedWebhookRequestPipeline,
 } from "remoteclaw/plugin-sdk/bluebubbles";
@@ -25,8 +28,18 @@ import { fetchBlueBubblesServerInfo } from "./probe.js";
 import { getBlueBubblesRuntime } from "./runtime.js";
 
 const webhookTargets = new Map<string, WebhookTarget[]>();
+const webhookRateLimiter = createFixedWindowRateLimiter({
+  windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs,
+  maxRequests: WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests,
+  maxTrackedKeys: WEBHOOK_RATE_LIMIT_DEFAULTS.maxTrackedKeys,
+});
 const webhookInFlightLimiter = createWebhookInFlightLimiter();
 const debounceRegistry = createBlueBubblesDebounceRegistry({ processMessage });
+
+export function clearBlueBubblesWebhookSecurityStateForTest(): void {
+  webhookRateLimiter.clear();
+  webhookInFlightLimiter.clear();
+}
 
 export function registerBlueBubblesWebhookTarget(target: WebhookTarget): () => void {
   const registered = registerWebhookTargetWithPluginRoute({
@@ -117,18 +130,63 @@ function safeEqualSecret(aRaw: string, bRaw: string): boolean {
   return timingSafeEqual(bufA, bufB);
 }
 
+function collectTrustedProxies(targets: readonly WebhookTarget[]): string[] {
+  const proxies = new Set<string>();
+  for (const target of targets) {
+    for (const proxy of target.config.gateway?.trustedProxies ?? []) {
+      const normalized = proxy.trim();
+      if (normalized) {
+        proxies.add(normalized);
+      }
+    }
+  }
+  return [...proxies];
+}
+
+function resolveWebhookAllowRealIpFallback(targets: readonly WebhookTarget[]): boolean {
+  return targets.some((target) => target.config.gateway?.allowRealIpFallback === true);
+}
+
+function resolveWebhookClientIp(
+  req: IncomingMessage,
+  trustedProxies: readonly string[],
+  allowRealIpFallback: boolean,
+): string {
+  if (!req.headers["x-forwarded-for"] && !(allowRealIpFallback && req.headers["x-real-ip"])) {
+    return req.socket.remoteAddress ?? "unknown";
+  }
+
+  // Mirror gateway client-IP trust rules so limiter buckets follow configured proxy hops.
+  return (
+    resolveRequestClientIp(req, [...trustedProxies], allowRealIpFallback) ??
+    req.socket.remoteAddress ??
+    "unknown"
+  );
+}
+
 export async function handleBlueBubblesWebhookRequest(
   req: IncomingMessage,
   res: ServerResponse,
 ): Promise<boolean> {
+  const requestUrl = new URL(req.url ?? "/", "http://localhost");
+  const normalizedPath = normalizeWebhookPath(requestUrl.pathname);
+  const pathTargets = webhookTargets.get(normalizedPath) ?? [];
+  const trustedProxies = collectTrustedProxies(pathTargets);
+  const allowRealIpFallback = resolveWebhookAllowRealIpFallback(pathTargets);
+  const clientIp = resolveWebhookClientIp(req, trustedProxies, allowRealIpFallback);
+  // Both limiters partition by (path, client IP) — share one key so the buckets stay aligned.
+  const clientKey = `${normalizedPath}:${clientIp}`;
   return await withResolvedWebhookRequestPipeline({
     req,
     res,
     targetsByPath: webhookTargets,
     allowMethods: ["POST"],
+    rateLimiter: webhookRateLimiter,
+    rateLimitKey: clientKey,
     inFlightLimiter: webhookInFlightLimiter,
+    inFlightKey: clientKey,
     handle: async ({ path, targets }) => {
-      const url = new URL(req.url ?? "/", "http://localhost");
+      const url = requestUrl;
       const guidParam = url.searchParams.get("guid") ?? url.searchParams.get("password");
       const headerToken =
         req.headers["x-guid"] ??

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -1,4 +1,9 @@
-import type { RemoteClawConfig, RemoteClawPluginApi } from "remoteclaw/plugin-sdk/thread-ownership";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromAllowPrivateNetwork,
+  type RemoteClawConfig,
+  type RemoteClawPluginApi,
+} from "remoteclaw/plugin-sdk/thread-ownership";
 
 type ThreadOwnershipConfig = {
   forwarderUrl?: string;
@@ -102,29 +107,40 @@ export default function register(api: RemoteClawPluginApi) {
 
     // Try to claim ownership via the forwarder HTTP API.
     try {
-      const resp = await fetch(`${forwarderUrl}/api/v1/ownership/${channelId}/${threadTs}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ agent_id: agentId }),
-        signal: AbortSignal.timeout(3000),
+      // The forwarder is an internal service (e.g. a Docker container); allow private-network
+      // access but pin DNS so DNS-rebinding attacks cannot pivot to a different internal host.
+      const { response: resp, release } = await fetchWithSsrFGuard({
+        url: `${forwarderUrl}/api/v1/ownership/${channelId}/${threadTs}`,
+        init: {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agent_id: agentId }),
+        },
+        timeoutMs: 3000,
+        policy: ssrfPolicyFromAllowPrivateNetwork(true),
+        auditContext: "thread-ownership",
       });
 
-      if (resp.ok) {
-        // We own it (or just claimed it), proceed.
-        return;
-      }
+      try {
+        if (resp.ok) {
+          // We own it (or just claimed it), proceed.
+          return;
+        }
 
-      if (resp.status === 409) {
-        // Another agent owns this thread — cancel the send.
-        const body = (await resp.json()) as { owner?: string };
-        api.logger.info?.(
-          `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${body.owner}`,
-        );
-        return { cancel: true };
-      }
+        if (resp.status === 409) {
+          // Another agent owns this thread — cancel the send.
+          const body = (await resp.json()) as { owner?: string };
+          api.logger.info?.(
+            `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${body.owner}`,
+          );
+          return { cancel: true };
+        }
 
-      // Unexpected status — fail open.
-      api.logger.warn?.(`thread-ownership: unexpected status ${resp.status}, allowing send`);
+        // Unexpected status — fail open.
+        api.logger.warn?.(`thread-ownership: unexpected status ${resp.status}, allowing send`);
+      } finally {
+        await release();
+      }
     } catch (err) {
       // Network error — fail open.
       api.logger.warn?.(`thread-ownership: ownership check failed (${String(err)}), allowing send`);

--- a/src/plugin-sdk/bluebubbles.ts
+++ b/src/plugin-sdk/bluebubbles.ts
@@ -111,3 +111,8 @@ export {
   resolveWebhookTargetWithAuthOrRejectSync,
   withResolvedWebhookRequestPipeline,
 } from "./webhook-targets.js";
+export {
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
+  createFixedWindowRateLimiter,
+} from "./webhook-memory-guards.js";
+export { resolveRequestClientIp } from "../gateway/net.js";

--- a/src/plugin-sdk/thread-ownership.ts
+++ b/src/plugin-sdk/thread-ownership.ts
@@ -3,3 +3,5 @@
 
 export type { RemoteClawConfig } from "../config/config.js";
 export type { RemoteClawPluginApi } from "../plugins/types.js";
+export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+export { ssrfPolicyFromAllowPrivateNetwork } from "./ssrf-policy.js";


### PR DESCRIPTION
## Summary

Adopts two security-additive upstream improvements that the v2026.3.28 sync adversarial audit flagged as pre-existing fork regressions in #2636. Each was a defensive improvement upstream made and the fork's GUT classification accidentally discarded.

This PR covers **W2** (bluebubbles webhook rate limiting) + **W3** (thread-ownership SSRF guard) — the chat-extension HTTP boundary hardening slice. Issue #2636 catalogs 12 findings; the issue body recommends 2–3 focused PRs by adapter family. The remaining slices (W1 msteams access, W4 matrix env-secret allowlist, W5 nextcloud-talk webhook tests, 7×O4 auth/gateway items) are deliberately left for follow-up PRs.

### W2 — bluebubbles webhook rate limiting

`extensions/bluebubbles/src/monitor.ts`:
- Wires `createFixedWindowRateLimiter` + `WEBHOOK_RATE_LIMIT_DEFAULTS` into the inbound webhook handler so abusive bursts are dropped before auth/processing.
- Resolves client IP via gateway `trustedProxies` + `allowRealIpFallback` rules, so limiter buckets follow configured proxy hops (not the proxy IP).
- Shares one `(path, client-IP)` key across rate-limiter and in-flight limiter (`clientKey`).
- Adds `clearBlueBubblesWebhookSecurityStateForTest` for module-scoped reset.

### W3 — thread-ownership outbound forwarder fetch

`extensions/thread-ownership/index.ts`:
- Replaces raw `fetch()` with `fetchWithSsrFGuard()` (DNS-pinned, redirect-cap, per-redirect re-validation) so a compromised forwarder hostname cannot pivot to a different internal host via DNS-rebinding mid-flight.
- `allowPrivateNetwork: true` because the Slack forwarder is an internal service.
- Awaits `release()` in `finally` to free pinned-dispatcher resources on every code path.

### Plugin-SDK surface (additive)

- `src/plugin-sdk/bluebubbles.ts` — re-exports `WEBHOOK_RATE_LIMIT_DEFAULTS`, `createFixedWindowRateLimiter`, `resolveRequestClientIp`.
- `src/plugin-sdk/thread-ownership.ts` — re-exports `fetchWithSsrFGuard`, `ssrfPolicyFromAllowPrivateNetwork`.

Both narrow surfaces remain narrow — additive only.

## Test plan

- [x] `pnpm tsgo` — clean
- [x] `pnpm format:check` — clean (5107 files)
- [x] `pnpm lint` — 0 warnings, 0 errors (3404 files)
- [x] `pnpm vitest run extensions/bluebubbles/src/monitor.webhook-auth.test.ts extensions/bluebubbles/src/monitor.test.ts` — 69/69
- [x] `pnpm vitest run extensions/thread-ownership/index.test.ts` — 9/9
- [x] Fork-integrity gates: rebrand-leakage, no-zombie-imports, stub-debt, throwing-stub-callers, obsolescence-audit — all green
- [x] Adversarial AC validation in fresh subprocess: 17/17 ACs pass, 12 attack vectors all defended
- [x] Fresh-context polish dispatch: IMPROVED — extracted shared `clientKey` for both rate-limit and in-flight keys
- [ ] CI green (`build`, `test`, `lint`, `docs`, `test-ui-smoke`, fork-integrity gates)

Resolves: part of #2636 (W2 + W3). Other findings tracked in #2636 for follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)