### PR TITLE
fix(infra): zod-validate device-auth store contents (#2636 PR-3 O4)

### DIFF
--- a/src/infra/device-auth-store.ts
+++ b/src/infra/device-auth-store.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { z } from "zod";
 import { resolveStateDir } from "../config/paths.js";
 import {
   clearDeviceAuthTokenFromStore,
@@ -8,8 +9,14 @@ import {
   storeDeviceAuthTokenInStore,
 } from "../shared/device-auth-store.js";
 import type { DeviceAuthStore } from "../shared/device-auth.js";
+import { safeParseJsonWithSchema } from "../utils/zod-parse.js";
 
 const DEVICE_AUTH_FILE = "device-auth.json";
+const DeviceAuthStoreSchema = z.object({
+  version: z.literal(1),
+  deviceId: z.string(),
+  tokens: z.record(z.string(), z.unknown()),
+}) as z.ZodType<DeviceAuthStore>;
 
 function resolveDeviceAuthPath(env: NodeJS.ProcessEnv = process.env): string {
   return path.join(resolveStateDir(env), "identity", DEVICE_AUTH_FILE);
@@ -21,14 +28,7 @@ function readStore(filePath: string): DeviceAuthStore | null {
       return null;
     }
     const raw = fs.readFileSync(filePath, "utf8");
-    const parsed = JSON.parse(raw) as DeviceAuthStore;
-    if (parsed?.version !== 1 || typeof parsed.deviceId !== "string") {
-      return null;
-    }
-    if (!parsed.tokens || typeof parsed.tokens !== "object") {
-      return null;
-    }
-    return parsed;
+    return safeParseJsonWithSchema(DeviceAuthStoreSchema, raw);
   } catch {
     return null;
   }

--- a/src/utils/zod-parse.ts
+++ b/src/utils/zod-parse.ts
@@ -1,0 +1,14 @@
+import type { ZodType } from "zod";
+
+export function safeParseWithSchema<T>(schema: ZodType<T>, value: unknown): T | null {
+  const parsed = schema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export function safeParseJsonWithSchema<T>(schema: ZodType<T>, raw: string): T | null {
+  try {
+    return safeParseWithSchema(schema, JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Adopts the upstream zod-schema validation hardening for the device-auth
store that the v2026.3.28 sync adversarial audit flagged as a
pre-existing fork regression in #2636. This is **PR-3 of 3**, the
gateway/infra slice. PR #2640 already merged W2 + W3 chat-extension
hardening; PR-2 (extensions slice) is running in parallel.

### What changed

- **NEW**: `src/utils/zod-parse.ts` — verbatim port of upstream's
  `safeParseWithSchema` / `safeParseJsonWithSchema` helpers (~14 LOC).
- **MODIFIED**: `src/infra/device-auth-store.ts` — replaces hand-rolled
  `version === 1 / typeof string / typeof object` gating with a zod
  schema parsed via `safeParseJsonWithSchema`. Defense-in-depth: zod
  validates the inner shape (`tokens` as a record, `version` as the
  literal `1`) at runtime, where the prior `typeof === "object"` check
  silently accepted malformed payloads such as `tokens: []` or
  `tokens: null` if you squinted at the type system.

Both edits are verbatim ports — keeping API surface and shape aligned
with upstream so future syncs don't drift.

### Issue scope vs PR scope

Issue #2636 catalogs 12 findings (5 WRONG + 7 O4). This PR-3 was
scoped to the three gateway/infra entries:

| File | Status | Rationale |
|---|---|---|
| `src/infra/device-auth-store.ts` | ✅ Ported | Self-contained zod hardening. |
| `src/gateway/server.preauth-hardening.test.ts` | ⏸️ Deferred | Inseparable from missing infra. |
| `src/gateway/server.device-token-rotate-authz.test.ts` | ⏸️ Deferred | Requires source-code security fixes outside this slice. |

Per the issue's approach guidance ("examine upstream's version,
identify the security-additive hunks, port hunks that are
fork-applicable. Skip hunks that are inseparable from gutted
plugin-sdk / model-selection infrastructure"), the two deferrals
below are surfaced for follow-up rather than forced into this PR.

### Why the two test files were deferred

#### `server.preauth-hardening.test.ts`

Upstream added 4 new tests requiring infrastructure that is not present
in the fork:

- `createPreauthConnectionBudget` — new file
  `src/gateway/server/preauth-connection-budget.ts` not present.
- `gateway.handshakeTimeoutMs` config field — fork only honors the
  `REMOTECLAW_HANDSHAKE_TIMEOUT_MS` env var, not a config-schema field.
- `payload.large` / `gateway.ws.preauth` diagnostic events — fork emits
  WS close-code `1008` (Policy Violation) on oversized pre-auth frames,
  not `1009` (Message Too Big) with a structured diagnostic event.
  Notably the **existing fork test for oversized frames already fails
  with `1008 vs 1009`** — but the gateway suite is gated behind
  `REMOTECLAW_TEST_INCLUDE_GATEWAY=1`, which CI does not set, so it
  passes silently. This is a pre-existing gap independent of #2636.

Porting these tests in isolation would require porting the entire
pre-auth connection budget module, schema additions, and diagnostic
event emission in the production code — substantially out of this PR's
file scope.

#### `server.device-token-rotate-authz.test.ts`

Upstream's test refactor uses a new shared `device-authz.test-helpers.ts`
(absent in fork) and asserts behavior that requires source-code
security changes:

- New IDOR guard (one device's token cannot rotate another device's
  token) — requires changes in `src/gateway/server-methods/devices.ts`.
- Error message change from `"missing scope: \${missingScope}"` →
  `"device token rotation denied"` — source change.
- `device.token.rotate` response with the rotated token field omitted
  (`expect(rotate.payload?.token).toBeUndefined()`) — fork still echoes
  `token: entry.token` in the rotation response (line 225 of
  `server-methods/devices.ts`), which IS a real security regression but
  fixing it requires source-code changes outside this PR's slice.
- Scope containment in `src/infra/device-pairing.ts` — source change.
- `connectChallengeTimeoutMs` GatewayClient option rename — source
  change.

These are all real security-additive improvements, but none can be
landed via test-file edits alone. Recommend filing a follow-up issue
for the device-token-rotate source-code hardening (IDOR + no-echo +
scope containment + error-message normalization) as one cohesive port,
with the test refactor delivered alongside it.

### Verification

- `pnpm exec vitest run src/infra/device-auth-store.test.ts` — 3/3
  passing. The "returns null for missing, invalid, or mismatched
  stores" test specifically exercises the schema rejection paths
  (version=2 → null, deviceId mismatch → null) so the zod swap is
  guarded by existing assertions.
- `pnpm tsgo` — clean exit 0.
- `pnpm check` — clean (format + tsgo + lint + tmp/random-messaging +
  no-remoteclaw-ai + ui:no-css-class-drift).

### Caller notes

Per the orchestrator: this PR creates the artifact but does not merge
itself. Auto-merge is intentionally NOT enabled — the orchestrator
handles ordering with the parallel PR-2 (extensions slice).

## Test plan

- [x] `pnpm exec vitest run src/infra/device-auth-store.test.ts` (3/3 passing)
- [x] `pnpm tsgo` (clean)
- [x] `pnpm check` (format + lint + drift gate clean)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)