### PR TITLE
fix(security): port adapter auth/access hunks (#2636 W1+O4-M)

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-auth.ts
+++ b/extensions/mattermost/src/mattermost/monitor-auth.ts
@@ -198,10 +198,11 @@ export function authorizeMattermostCommandInvocation(params: {
     hasControlCommand: allowTextCommands && hasControlCommand,
   });
 
+  // Direct command authorization always requires a sender-allowlist match; the prior
+  // `dmPolicy === "open"` permissive bypass was withdrawn upstream (#74112) because an
+  // open DM policy does not imply that any sender may invoke control commands.
   const commandAuthorized =
-    kind === "direct"
-      ? dmPolicy === "open" || senderAllowedForCommands
-      : commandGate.commandAuthorized;
+    kind === "direct" ? senderAllowedForCommands : commandGate.commandAuthorized;
 
   if (kind === "direct") {
     if (dmPolicy === "disabled") {
@@ -218,7 +219,7 @@ export function authorizeMattermostCommandInvocation(params: {
       };
     }
 
-    if (dmPolicy !== "open" && !senderAllowedForCommands) {
+    if (!senderAllowedForCommands) {
       return {
         ok: false,
         denyReason: dmPolicy === "pairing" ? "dm-pairing" : "unauthorized",

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -177,10 +177,17 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       channelName,
       allowNameMatching: isDangerousNameMatchingEnabled(msteamsCfg),
     });
-    const senderGroupPolicy = resolveSenderScopedGroupPolicy({
-      groupPolicy,
-      groupAllowFrom: effectiveGroupAllowFrom,
-    });
+    // When a route-level (team/channel) allowlist is configured but the sender allowlist is
+    // empty, resolveSenderScopedGroupPolicy would otherwise downgrade the policy to "open",
+    // allowing any sender. To close this bypass (GHSA-g7cr-9h7q-4qxq), treat an empty sender
+    // allowlist as deny-all whenever the route allowlist is active.
+    const senderGroupPolicy =
+      channelGate.allowlistConfigured && effectiveGroupAllowFrom.length === 0
+        ? groupPolicy
+        : resolveSenderScopedGroupPolicy({
+            groupPolicy,
+            groupAllowFrom: effectiveGroupAllowFrom,
+          });
     const access = resolveDmGroupAccessWithLists({
       isGroup: !isDirectMessage,
       dmPolicy,


### PR DESCRIPTION
## Summary

PR-2 follow-up of #2636 (PR #2640 already covered W2+W3). Adopts two upstream security/correctness improvements that the v2026.3.28 adversarial audit flagged as pre-existing fork regressions in the **adapter auth/access** slice.

### W1 — msteams GHSA-g7cr-9h7q-4qxq sender-policy guard

`extensions/msteams/src/monitor-handler/message-handler.ts`:
- When a route-level (team/channel) allowlist is configured but the sender allowlist is empty, `resolveSenderScopedGroupPolicy` would downgrade the policy to `"open"` and let any sender through the channel route.
- Adds the explicit guard that preserves the original `groupPolicy` whenever the route allowlist is active and the sender allowlist is empty (deny-all).
- Mirrors upstream `access.ts` extraction inline because the fork keeps `message-handler.ts` monolithic.
- Defense-in-depth: existing test "does not widen sender auth when only a teams route allowlist is configured" already covers the scenario behaviorally via the downstream `evaluateSenderGroupAccessForPolicy` empty-allowlist drop, but the guard closes the bypass at the policy-derivation site before any downstream consumer can act on the downgraded policy.

### O4-M — mattermost open-DM allowlist tightening

`extensions/mattermost/src/mattermost/monitor-auth.ts`:
- Removes the `dmPolicy === "open"` permissive bypass from `commandAuthorized` and from the deny condition in `authorizeMattermostCommandInvocation`.
- Direct command authorization now always requires a sender-allowlist match, regardless of DM policy.
- Aligns with upstream commit `bd1d1f0f2b` (PR #74112): an open DM policy permits messaging, not command invocation.

### Skipped from this slice (with rationale)

| Finding | Verdict | Rationale |
|---------|---------|-----------|
| **W4** matrix env-secret allowlist | SKIP — non-portable | Fork's matrix config rejects `SecretRef` objects entirely (via `assertSecretInputResolved` throwing in `src/config/types.secrets.ts`); no SecretRef→env resolution path to guard. Recent upstream activity is pure refactor. |
| **O4-D** discord/provider.allowlist.ts | SKIP — no security hunk | Recent upstream commit since sync is `4336a7f3a9 refactor(plugin-sdk): narrow config runtime imports` — 1-line import path change. |
| **O4-T** msteams/message-handler.authz.test.ts | SKIP — no security hunk | Recent upstream commits are test-infrastructure refactors only; fork's existing test already covers the GHSA scenario behaviorally. |

### Out of scope

- **PR-3** (gateway/infra: `src/gateway/*`, `src/infra/*`) runs in parallel.
- **W5** (nextcloud-talk monitor) deferred — paired with the fork-side monitor.ts implementation work.

## Test plan

- [x] `pnpm tsgo` — clean
- [x] `pnpm format:check` — clean (5107 files)
- [x] `pnpm lint` — 0 warnings, 0 errors (3404 files)
- [x] `pnpm check` — full suite green (format + tsgo + lint + lint:tmp:no-random-messaging + lint:no-remoteclaw-ai + lint:ui:no-css-class-drift)
- [x] Targeted tests: msteams authz (2/2), mattermost monitor-auth-related suites (12/12 across `monitor`, `slash-http`, `monitor-helpers`)
- [x] Adversarial AC validation in fresh subprocess: 3/3 ACs PASS, no findings (validates W1 guard mirrors upstream `access.ts:72-77` and O4-M tightens to upstream `bd1d1f0f2b`)
- [x] Fresh-context polish dispatch: CLEAN, 0 changes
- [ ] CI green (`build`, `test`, `lint`, `docs`, `test-ui-smoke`, fork-integrity gates)

Pre-existing failures in `extensions/msteams/src/probe.test.ts` and `extensions/mattermost/src/mattermost/{interactions,reply-delivery}.test.ts` are unrelated to this slice (verified by stashing changes and re-running on clean origin/main).

Resolves: part of #2636 (W1 + O4-M). Remaining slices (PR-3 + W5) tracked in #2636.

🤖 Generated with [Claude Code](https://claude.com/claude-code)