### PR TITLE
fix(security): port nextcloud-talk webhook auth rate limiting (#2645)

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -3,6 +3,7 @@ import { createMockIncomingRequest } from "../../../test/helpers/mock-incoming-r
 import { readNextcloudTalkWebhookBody } from "./monitor.js";
 import { createSignedCreateMessageRequest } from "./monitor.test-fixtures.js";
 import { startWebhookServer } from "./monitor.test-harness.js";
+import { generateNextcloudTalkSignature } from "./signature.js";
 import type { NextcloudTalkInboundMessage } from "./types.js";
 
 describe("readNextcloudTalkWebhookBody", () => {
@@ -102,5 +103,103 @@ describe("createNextcloudTalkWebhookServer replay handling", () => {
     expect(second.status).toBe(200);
     expect(shouldProcessMessage).toHaveBeenCalledTimes(2);
     expect(onMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createNextcloudTalkWebhookServer payload validation", () => {
+  it("rejects malformed webhook payloads after signature verification", async () => {
+    const payload = {
+      type: "Create",
+      actor: { type: "Person", id: "alice", name: "Alice" },
+      object: {
+        type: "Note",
+        id: "msg-1",
+        name: "hello",
+        content: "hello",
+        mediaType: "text/plain",
+      },
+      target: { type: "Collection", id: "", name: "Room 1" },
+    };
+    const body = JSON.stringify(payload);
+    const { random, signature } = generateNextcloudTalkSignature({
+      body,
+      secret: "nextcloud-secret", // pragma: allowlist secret
+    });
+    const harness = await startWebhookServer({
+      path: "/nextcloud-invalid-payload",
+      onMessage: vi.fn(),
+    });
+
+    const response = await fetch(harness.webhookUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-nextcloud-talk-random": random,
+        "x-nextcloud-talk-signature": signature,
+        "x-nextcloud-talk-backend": "https://nextcloud.example",
+      },
+      body,
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid payload format" });
+  });
+});
+
+describe("createNextcloudTalkWebhookServer auth rate limiting", () => {
+  it("rate limits repeated invalid signature attempts from the same source", async () => {
+    const maxRequests = 1;
+    const harness = await startWebhookServer({
+      path: "/nextcloud-auth-rate-limit",
+      authRateLimit: { maxRequests },
+      onMessage: vi.fn(),
+    });
+    const { body, headers } = createSignedCreateMessageRequest();
+    const invalidHeaders = {
+      ...headers,
+      "x-nextcloud-talk-signature": "invalid-signature",
+    };
+
+    let firstResponse: Response | undefined;
+    let lastResponse: Response | undefined;
+    for (let attempt = 0; attempt <= maxRequests; attempt += 1) {
+      const response = await fetch(harness.webhookUrl, {
+        method: "POST",
+        headers: invalidHeaders,
+        body,
+      });
+      if (attempt === 0) {
+        firstResponse = response;
+      }
+      lastResponse = response;
+    }
+
+    expect(firstResponse).toBeDefined();
+    expect(firstResponse?.status).toBe(401);
+    expect(lastResponse).toBeDefined();
+    expect(lastResponse?.status).toBe(429);
+    expect(await lastResponse?.text()).toBe("Too Many Requests");
+  });
+
+  it("does not rate limit valid signed webhook bursts from the same source", async () => {
+    const maxRequests = 1;
+    const harness = await startWebhookServer({
+      path: "/nextcloud-auth-rate-limit-valid",
+      authRateLimit: { maxRequests },
+      onMessage: vi.fn(),
+    });
+    const { body, headers } = createSignedCreateMessageRequest();
+
+    let lastResponse: Response | undefined;
+    for (let attempt = 0; attempt <= maxRequests; attempt += 1) {
+      lastResponse = await fetch(harness.webhookUrl, {
+        method: "POST",
+        headers,
+        body,
+      });
+    }
+
+    expect(lastResponse).toBeDefined();
+    expect(lastResponse?.status).toBe(200);
   });
 });

--- a/extensions/nextcloud-talk/src/monitor.ts
+++ b/extensions/nextcloud-talk/src/monitor.ts
@@ -2,6 +2,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import os from "node:os";
 import {
   type RuntimeEnv,
+  createAuthRateLimiter,
   isRequestBodyLimitError,
   readRequestBodyWithLimit,
   requestBodyErrorToText,
@@ -25,6 +26,9 @@ const DEFAULT_WEBHOOK_HOST = "0.0.0.0";
 const DEFAULT_WEBHOOK_PATH = "/nextcloud-talk-webhook";
 const DEFAULT_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const DEFAULT_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
+const DEFAULT_AUTH_RATE_LIMIT_MAX_REQUESTS = 120;
+const DEFAULT_AUTH_RATE_LIMIT_WINDOW_MS = 60_000;
+const WEBHOOK_AUTH_RATE_LIMIT_SCOPE = "nextcloud-talk-webhook-auth";
 const HEALTH_PATH = "/healthz";
 const WEBHOOK_ERRORS = {
   missingSignatureHeaders: "Missing signature headers",
@@ -115,6 +119,8 @@ function verifyWebhookSignature(params: {
   body: string;
   secret: string;
   res: ServerResponse;
+  clientIp: string;
+  authRateLimiter: ReturnType<typeof createAuthRateLimiter>;
 }): boolean {
   const isValid = verifyNextcloudTalkSignature({
     signature: params.headers.signature,
@@ -123,9 +129,11 @@ function verifyWebhookSignature(params: {
     secret: params.secret,
   });
   if (!isValid) {
+    params.authRateLimiter.recordFailure(params.clientIp, WEBHOOK_AUTH_RATE_LIMIT_SCOPE);
     writeWebhookError(params.res, 401, WEBHOOK_ERRORS.invalidSignature);
     return false;
   }
+  params.authRateLimiter.reset(params.clientIp, WEBHOOK_AUTH_RATE_LIMIT_SCOPE);
   return true;
 }
 
@@ -191,6 +199,25 @@ export function createNextcloudTalkWebhookServer(opts: NextcloudTalkWebhookServe
   const readBody = opts.readBody ?? readNextcloudTalkWebhookBody;
   const isBackendAllowed = opts.isBackendAllowed;
   const shouldProcessMessage = opts.shouldProcessMessage;
+  const authRateLimitMaxRequests =
+    typeof opts.authRateLimit?.maxRequests === "number"
+      ? opts.authRateLimit.maxRequests
+      : DEFAULT_AUTH_RATE_LIMIT_MAX_REQUESTS;
+  const authRateLimitWindowMs =
+    typeof opts.authRateLimit?.windowMs === "number"
+      ? opts.authRateLimit.windowMs
+      : DEFAULT_AUTH_RATE_LIMIT_WINDOW_MS;
+  // exemptLoopback: false — in production a same-host reverse proxy forwards
+  // webhook traffic with socket.remoteAddress=127.0.0.1, so loopback cannot be
+  // treated as trusted local-CLI traffic; exempting it would let abusive
+  // requests bypass rate limiting via the proxy.
+  const webhookAuthRateLimiter = createAuthRateLimiter({
+    maxAttempts: authRateLimitMaxRequests,
+    windowMs: authRateLimitWindowMs,
+    lockoutMs: authRateLimitWindowMs,
+    exemptLoopback: false,
+    pruneIntervalMs: authRateLimitWindowMs,
+  });
 
   const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
     if (req.url === HEALTH_PATH) {
@@ -202,6 +229,13 @@ export function createNextcloudTalkWebhookServer(opts: NextcloudTalkWebhookServe
     if (req.url !== path || req.method !== "POST") {
       res.writeHead(404);
       res.end();
+      return;
+    }
+
+    const clientIp = req.socket.remoteAddress ?? "unknown";
+    if (!webhookAuthRateLimiter.check(clientIp, WEBHOOK_AUTH_RATE_LIMIT_SCOPE).allowed) {
+      res.writeHead(429);
+      res.end("Too Many Requests");
       return;
     }
 
@@ -222,6 +256,8 @@ export function createNextcloudTalkWebhookServer(opts: NextcloudTalkWebhookServe
         body,
         secret,
         res,
+        clientIp,
+        authRateLimiter: webhookAuthRateLimiter,
       });
       if (!hasValidSignature) {
         return;
@@ -287,6 +323,7 @@ export function createNextcloudTalkWebhookServer(opts: NextcloudTalkWebhookServe
     } catch {
       // ignore close races while shutting down
     }
+    webhookAuthRateLimiter.dispose();
   };
 
   if (abortSignal) {

--- a/extensions/nextcloud-talk/src/types.ts
+++ b/extensions/nextcloud-talk/src/types.ts
@@ -172,6 +172,10 @@ export type NextcloudTalkWebhookServerOptions = {
   path: string;
   secret: string;
   maxBodyBytes?: number;
+  authRateLimit?: {
+    maxRequests?: number;
+    windowMs?: number;
+  };
   readBody?: (req: import("node:http").IncomingMessage, maxBodyBytes: number) => Promise<string>;
   isBackendAllowed?: (backend: string) => boolean;
   shouldProcessMessage?: (message: NextcloudTalkInboundMessage) => boolean | Promise<boolean>;

--- a/src/plugin-sdk/nextcloud-talk.ts
+++ b/src/plugin-sdk/nextcloud-talk.ts
@@ -72,6 +72,7 @@ export {
   ReplyRuntimeConfigSchemaShape,
   requireOpenAllowFrom,
 } from "../config/zod-schema.core.js";
+export { createAuthRateLimiter } from "../gateway/auth-rate-limit.js";
 export {
   isRequestBodyLimitError,
   readRequestBodyWithLimit,


### PR DESCRIPTION
## Summary

Adopts the chat-extension HTTP boundary hardening pattern (already established for bluebubbles + thread-ownership in PR #2640) to the nextcloud-talk extension's webhook server.

This PR is the **W5** slice of issue #2636 (DIFF-SYNC v2026.3.28 adversarial audit), tracked under #2645.

### Mechanism choice

Uses `createAuthRateLimiter` (failures-only, lenient on legitimate traffic) rather than `createFixedWindowRateLimiter` (every-request throttle) used by other webhook extensions. **Rationale**: upstream nextcloud-talk's `monitor.ts` specifically uses `createAuthRateLimiter`; the port matches that. This intentionally diverges from PR #2640's bluebubbles fixed-window pattern. The trade-off: legitimate traffic doesn't accrete toward the limit, but a single valid HMAC signature can be replayed indefinitely against the rate limiter (replay-guard catches the duplicate `messageId`, but each replay still incurs HMAC + parse + dedup-lookup work).

### Changes

#### `extensions/nextcloud-talk/src/monitor.ts`
- Wires `createAuthRateLimiter` (already in fork at `src/gateway/auth-rate-limit.ts`) into the webhook server.
- Pre-handler `check()` returns `429 "Too Many Requests"` when the source IP is locked out.
- `recordFailure(clientIp)` on invalid signature; `reset(clientIp)` on valid signature.
- `exemptLoopback: false` — production webhook traffic reaches via same-host reverse proxies with `socket.remoteAddress=127.0.0.1`; exempting loopback would let abusive requests bypass the limiter via the proxy.
- `dispose()` called from server `stop()` to clear the prune timer.

#### `extensions/nextcloud-talk/src/types.ts`
- Adds `authRateLimit?: { maxRequests?: number; windowMs?: number; }` option to `NextcloudTalkWebhookServerOptions` (additive, defaults to `120 req / 60s window`).

#### `extensions/nextcloud-talk/src/monitor.replay.test.ts`
- Ports 3 tests from upstream (matches upstream behavior, naming, and structure):
  - `payload validation › rejects malformed webhook payloads after signature verification` (covers fork's existing `parseWebhookPayload` against `target.id: ""`).
  - `auth rate limiting › rate limits repeated invalid signature attempts from the same source` (`maxRequests: 1`, second attempt → 429).
  - `auth rate limiting › does not rate limit valid signed webhook bursts from the same source` (`maxRequests: 1`, valid signatures don't increment counter).

#### `src/plugin-sdk/nextcloud-talk.ts`
- Re-exports `createAuthRateLimiter` (single line — narrow surface preserved, matches PR #2640's additive-only pattern).

### Out of scope (deliberate, surfaced as non-portable)

These were evaluated and excluded because the fork has diverged from upstream in load-bearing ways:

1. **`NextcloudTalkRetryableWebhookError` + `processNextcloudTalkReplayGuardedMessage` exports + their corresponding retry tests.** Fork's `replay-guard.ts` uses the simpler `shouldProcessMessage`-only API atop `createPersistentDedupe`. Upstream uses `claimMessage`/`commitMessage`/`releaseMessage` atop `createClaimableDedupe`. Porting requires expanding the replay-guard API and migrating to a different dedupe primitive — outside HTTP boundary hardening.
2. **Pre-auth body budget reduction (1 MB → 64 KB; 30 s → 5 s)** — defense-in-depth improvement; worth a follow-up but not strictly required for the cited test cases.
3. **Zod schema validation (`safeParseJsonWithSchema`)** — the fork's hand-rolled `parseWebhookPayload` covers all cited test cases via truthiness checks. Upstream's stricter Zod schema rejects edge cases (whitespace `target.id`, wrong literals like `actor.type: "Bot"`, non-enum `type` values). Refactor without security delta against the AC; flag for follow-up.

### Test plan

- [x] `pnpm vitest run extensions/nextcloud-talk/` — 9/9 pass
- [x] `pnpm tsgo` — clean
- [x] `pnpm format:check` — clean (5108 files)
- [x] `pnpm lint` — 0 warnings, 0 errors (3405 files)
- [x] `pnpm check` — full pre-commit suite green
- [x] Fork-integrity gates: rebrand-leakage, no-zombie-imports, throwing-stub-callers, stub-debt, obsolescence-audit, css-class-drift — all green
- [x] Adversarial AC validation in fresh-context subprocess: 9/9 ACs DEFENDED, 8/8 attack vectors evaluated (6 ✅ defended, 2 inherited-from-upstream-design noted as non-blocking)
- [x] Fresh-context polish dispatch: IMPROVED — corrected misleading `exemptLoopback: false` rationale comment
- [ ] CI green (`build`, `test`, `lint`, `docs`, `test-ui-smoke`, fork-integrity gates)

### Follow-up findings (non-blocking, surfaced for awareness)

1. **Pre-auth body budget divergence vs upstream** (1 MB / 30 s vs 64 KB / 5 s) — recommend a follow-up issue.
2. **Zod schema validation gap** — whitespace `target.id`, wrong literal types pass through; recommend a follow-up.
3. **Auth-rate-limiter unbounded Map** in `src/gateway/auth-rate-limit.ts` — cross-cutting concern affecting all `createAuthRateLimiter` callers (gateway auth, hooks, this webhook). Mirror `createFixedWindowRateLimiter`'s `maxTrackedKeys` cap. Worth a separate cross-cutting issue.

Resolves: #2645. Concludes the W5 slice of #2636.

🤖 Generated with [Claude Code](https://claude.com/claude-code)