### PR TITLE
fix(security): harden device-token rotation IDOR + scope + token echo (#2643)

### DIFF
--- a/src/gateway/android-node.capabilities.live.test.ts
+++ b/src/gateway/android-node.capabilities.live.test.ts
@@ -281,7 +281,7 @@ async function connectGatewayClient(params: {
       url: params.url,
       token: params.token,
       password: params.password,
-      connectDelayMs: 0,
+      connectChallengeTimeoutMs: 0,
       clientName: GATEWAY_CLIENT_NAMES.TEST,
       clientDisplayName: "android-live-test",
       clientVersion: "dev",

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -77,7 +77,7 @@ class GatewayClientRequestError extends Error {
 
 export type GatewayClientOptions = {
   url?: string; // ws://127.0.0.1:18789
-  connectDelayMs?: number;
+  connectChallengeTimeoutMs?: number;
   tickWatchMinIntervalMs?: number;
   requestTimeoutMs?: number;
   token?: string;
@@ -697,10 +697,11 @@ export class GatewayClient {
   private queueConnect() {
     this.connectNonce = null;
     this.connectSent = false;
-    const rawConnectDelayMs = this.opts.connectDelayMs;
+    const rawConnectChallengeTimeoutMs = this.opts.connectChallengeTimeoutMs;
     const connectChallengeTimeoutMs =
-      typeof rawConnectDelayMs === "number" && Number.isFinite(rawConnectDelayMs)
-        ? Math.max(250, Math.min(10_000, rawConnectDelayMs))
+      typeof rawConnectChallengeTimeoutMs === "number" &&
+      Number.isFinite(rawConnectChallengeTimeoutMs)
+        ? Math.max(250, Math.min(10_000, rawConnectChallengeTimeoutMs))
         : 2_000;
     if (this.connectTimer) {
       clearTimeout(this.connectTimer);

--- a/src/gateway/client.watchdog.test.ts
+++ b/src/gateway/client.watchdog.test.ts
@@ -69,7 +69,7 @@ describe("GatewayClient", () => {
     const closed = new Promise<{ code: number; reason: string }>((resolve) => {
       const client = new GatewayClient({
         url: `ws://127.0.0.1:${port}`,
-        connectDelayMs: 0,
+        connectChallengeTimeoutMs: 0,
         tickWatchMinIntervalMs: 5,
         onClose: (code, reason) => resolve({ code, reason }),
       });
@@ -320,7 +320,7 @@ r1USnb+wUdA7Zoj/mQ==
       }, 2000);
       client = new GatewayClient({
         url: `wss://127.0.0.1:${port}`,
-        connectDelayMs: 0,
+        connectChallengeTimeoutMs: 0,
         tlsFingerprint: "deadbeef",
         onConnectError: (err) => {
           clearTimeout(timeout);

--- a/src/gateway/device-authz.test-helpers.ts
+++ b/src/gateway/device-authz.test-helpers.ts
@@ -1,0 +1,119 @@
+import os from "node:os";
+import path from "node:path";
+import { expect } from "vitest";
+import { WebSocket } from "ws";
+import {
+  loadOrCreateDeviceIdentity,
+  publicKeyRawBase64UrlFromPem,
+  type DeviceIdentity,
+} from "../infra/device-identity.js";
+import {
+  approveDevicePairing,
+  getPairedDevice,
+  requestDevicePairing,
+  rotateDeviceToken,
+} from "../infra/device-pairing.js";
+import { trackConnectChallengeNonce } from "./test-helpers.js";
+
+export function resolveDeviceIdentityPath(name: string): string {
+  const root = process.env.REMOTECLAW_STATE_DIR ?? process.env.HOME ?? os.tmpdir();
+  return path.join(root, "test-device-identities", `${name}.json`);
+}
+
+export function loadDeviceIdentity(name: string): {
+  identityPath: string;
+  identity: DeviceIdentity;
+  publicKey: string;
+} {
+  const identityPath = resolveDeviceIdentityPath(name);
+  const identity = loadOrCreateDeviceIdentity(identityPath);
+  return {
+    identityPath,
+    identity,
+    publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+  };
+}
+
+export async function pairDeviceIdentity(params: {
+  name: string;
+  role: "node" | "operator";
+  scopes: string[];
+  clientId?: string;
+  clientMode?: string;
+}): Promise<{
+  identityPath: string;
+  identity: DeviceIdentity;
+  publicKey: string;
+}> {
+  const loaded = loadDeviceIdentity(params.name);
+  const request = await requestDevicePairing({
+    deviceId: loaded.identity.deviceId,
+    publicKey: loaded.publicKey,
+    role: params.role,
+    scopes: params.scopes,
+    clientId: params.clientId,
+    clientMode: params.clientMode,
+  });
+  await approveDevicePairing(request.request.requestId);
+  return loaded;
+}
+
+export async function issueOperatorToken(params: {
+  name: string;
+  approvedScopes: string[];
+  tokenScopes?: string[];
+  clientId?: string;
+  clientMode?: string;
+}): Promise<{
+  deviceId: string;
+  identityPath: string;
+  token: string;
+}> {
+  const paired = await pairDeviceIdentity({
+    name: params.name,
+    role: "operator",
+    scopes: params.approvedScopes,
+    clientId: params.clientId,
+    clientMode: params.clientMode,
+  });
+  if (params.tokenScopes) {
+    const rotated = await rotateDeviceToken({
+      deviceId: paired.identity.deviceId,
+      role: "operator",
+      scopes: params.tokenScopes,
+    });
+    expect(rotated?.token).toBeTruthy();
+    return {
+      deviceId: paired.identity.deviceId,
+      identityPath: paired.identityPath,
+      token: String(rotated?.token ?? ""),
+    };
+  }
+
+  const device = await getPairedDevice(paired.identity.deviceId);
+  const token = device?.tokens?.operator?.token ?? "";
+  expect(token).toBeTruthy();
+  expect(device?.approvedScopes).toEqual(params.approvedScopes);
+  return {
+    deviceId: paired.identity.deviceId,
+    identityPath: paired.identityPath,
+    token,
+  };
+}
+
+export async function openTrackedWs(port: number): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  trackConnectChallengeNonce(ws);
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("timeout waiting for ws open")), 5_000);
+    ws.once("open", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    ws.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+  return ws;
+}

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -10,7 +10,7 @@ import {
   summarizeDeviceTokens,
 } from "../../infra/device-pairing.js";
 import { normalizeDeviceAuthScopes } from "../../shared/device-auth.js";
-import { roleScopesAllow } from "../../shared/operator-scope-compat.js";
+import { resolveMissingRequestedScope } from "../../shared/operator-scope-compat.js";
 import {
   ErrorCodes,
   errorShape,
@@ -22,7 +22,20 @@ import {
   validateDeviceTokenRevokeParams,
   validateDeviceTokenRotateParams,
 } from "../protocol/index.js";
-import type { GatewayRequestHandlers } from "./types.js";
+import type { GatewayClient, GatewayRequestHandlers } from "./types.js";
+
+const DEVICE_TOKEN_ROTATION_DENIED_MESSAGE = "device token rotation denied";
+const DEVICE_TOKEN_REVOCATION_DENIED_MESSAGE = "device token revocation denied";
+
+type DeviceSessionAuthz = {
+  callerDeviceId: string | null;
+  callerScopes: string[];
+  isAdminCaller: boolean;
+};
+
+type DeviceManagementAuthz = DeviceSessionAuthz & {
+  normalizedTargetDeviceId: string;
+};
 
 function redactPairedDevice(
   device: { tokens?: Record<string, DeviceAuthToken> } & Record<string, unknown>,
@@ -34,23 +47,40 @@ function redactPairedDevice(
   };
 }
 
-function resolveMissingRequestedScope(params: {
-  role: string;
-  requestedScopes: readonly string[];
-  callerScopes: readonly string[];
-}): string | null {
-  for (const scope of params.requestedScopes) {
-    if (
-      !roleScopesAllow({
-        role: params.role,
-        requestedScopes: [scope],
-        allowedScopes: params.callerScopes,
-      })
-    ) {
-      return scope;
-    }
-  }
-  return null;
+function resolveDeviceSessionAuthz(client: GatewayClient | null): DeviceSessionAuthz {
+  const callerScopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
+  const rawCallerDeviceId = client?.connect?.device?.id;
+  const callerDeviceId =
+    client?.isDeviceTokenAuth && typeof rawCallerDeviceId === "string" && rawCallerDeviceId.trim()
+      ? rawCallerDeviceId.trim()
+      : null;
+  return {
+    callerDeviceId,
+    callerScopes,
+    isAdminCaller: callerScopes.includes("operator.admin"),
+  };
+}
+
+function resolveDeviceManagementAuthz(
+  client: GatewayClient | null,
+  targetDeviceId: string,
+): DeviceManagementAuthz {
+  return {
+    ...resolveDeviceSessionAuthz(client),
+    normalizedTargetDeviceId: targetDeviceId.trim(),
+  };
+}
+
+function isCrossDeviceManagementDenied(authz: DeviceManagementAuthz): boolean {
+  return Boolean(
+    authz.callerDeviceId &&
+    authz.callerDeviceId !== authz.normalizedTargetDeviceId &&
+    !authz.isAdminCaller,
+  );
+}
+
+function shouldReturnRotatedDeviceToken(authz: DeviceManagementAuthz): boolean {
+  return Boolean(authz.callerDeviceId && authz.callerDeviceId === authz.normalizedTargetDeviceId);
 }
 
 export const deviceHandlers: GatewayRequestHandlers = {
@@ -187,31 +217,64 @@ export const deviceHandlers: GatewayRequestHandlers = {
       role: string;
       scopes?: string[];
     };
-    const pairedDevice = await getPairedDevice(deviceId);
-    if (!pairedDevice) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown deviceId/role"));
+    const authz = resolveDeviceManagementAuthz(client, deviceId);
+    if (isCrossDeviceManagementDenied(authz)) {
+      context.logGateway.warn(
+        `device token rotation denied device=${deviceId} role=${role} reason=device-ownership-mismatch`,
+      );
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, DEVICE_TOKEN_ROTATION_DENIED_MESSAGE),
+      );
       return;
     }
-    const callerScopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
+    const pairedDevice = await getPairedDevice(deviceId);
+    if (!pairedDevice) {
+      context.logGateway.warn(
+        `device token rotation denied device=${deviceId} role=${role} reason=unknown-device-or-role`,
+      );
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, DEVICE_TOKEN_ROTATION_DENIED_MESSAGE),
+      );
+      return;
+    }
     const requestedScopes = normalizeDeviceAuthScopes(
       scopes ?? pairedDevice.tokens?.[role.trim()]?.scopes ?? pairedDevice.scopes,
     );
     const missingScope = resolveMissingRequestedScope({
       role,
       requestedScopes,
-      callerScopes,
+      allowedScopes: authz.callerScopes,
     });
     if (missingScope) {
+      context.logGateway.warn(
+        `device token rotation denied device=${deviceId} role=${role} reason=caller-missing-scope scope=${missingScope}`,
+      );
       respond(
         false,
         undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `missing scope: ${missingScope}`),
+        errorShape(ErrorCodes.INVALID_REQUEST, DEVICE_TOKEN_ROTATION_DENIED_MESSAGE),
       );
       return;
     }
-    const entry = await rotateDeviceToken({ deviceId, role, scopes });
+    const entry = await rotateDeviceToken({
+      deviceId,
+      role,
+      scopes,
+      callerScopes: authz.callerScopes,
+    });
     if (!entry) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown deviceId/role"));
+      context.logGateway.warn(
+        `device token rotation denied device=${deviceId} role=${role} reason=scope-outside-approved-baseline`,
+      );
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, DEVICE_TOKEN_ROTATION_DENIED_MESSAGE),
+      );
       return;
     }
     context.logGateway.info(
@@ -222,14 +285,14 @@ export const deviceHandlers: GatewayRequestHandlers = {
       {
         deviceId,
         role: entry.role,
-        token: entry.token,
+        ...(shouldReturnRotatedDeviceToken(authz) ? { token: entry.token } : {}),
         scopes: entry.scopes,
         rotatedAtMs: entry.rotatedAtMs ?? entry.createdAtMs,
       },
       undefined,
     );
   },
-  "device.token.revoke": async ({ params, respond, context }) => {
+  "device.token.revoke": async ({ params, respond, context, client }) => {
     if (!validateDeviceTokenRevokeParams(params)) {
       respond(
         false,
@@ -244,9 +307,28 @@ export const deviceHandlers: GatewayRequestHandlers = {
       return;
     }
     const { deviceId, role } = params as { deviceId: string; role: string };
-    const entry = await revokeDeviceToken({ deviceId, role });
+    const authz = resolveDeviceManagementAuthz(client, deviceId);
+    if (isCrossDeviceManagementDenied(authz)) {
+      context.logGateway.warn(
+        `device token revocation denied device=${deviceId} role=${role} reason=device-ownership-mismatch`,
+      );
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, DEVICE_TOKEN_REVOCATION_DENIED_MESSAGE),
+      );
+      return;
+    }
+    const entry = await revokeDeviceToken({ deviceId, role, callerScopes: authz.callerScopes });
     if (!entry) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown deviceId/role"));
+      context.logGateway.warn(
+        `device token revocation denied device=${deviceId} role=${role} reason=unknown-device-or-role`,
+      );
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, DEVICE_TOKEN_REVOCATION_DENIED_MESSAGE),
+      );
       return;
     }
     context.logGateway.info(`device token revoked device=${deviceId} role=${entry.role}`);

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -16,6 +16,7 @@ export type GatewayClient = {
   connect: ConnectParams;
   connId?: string;
   clientIp?: string;
+  isDeviceTokenAuth?: boolean;
   canvasHostUrl?: string;
   canvasCapability?: string;
   canvasCapabilityExpiresAtMs?: number;

--- a/src/gateway/server.device-token-rotate-authz.test.ts
+++ b/src/gateway/server.device-token-rotate-authz.test.ts
@@ -1,116 +1,22 @@
-import os from "node:os";
-import path from "node:path";
 import { describe, expect, test } from "vitest";
 import { WebSocket } from "ws";
-import {
-  loadOrCreateDeviceIdentity,
-  publicKeyRawBase64UrlFromPem,
-  type DeviceIdentity,
-} from "../infra/device-identity.js";
-import {
-  approveDevicePairing,
-  getPairedDevice,
-  requestDevicePairing,
-  rotateDeviceToken,
-} from "../infra/device-pairing.js";
+import { getPairedDevice } from "../infra/device-pairing.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
+import {
+  issueOperatorToken,
+  openTrackedWs,
+  pairDeviceIdentity,
+  resolveDeviceIdentityPath,
+} from "./device-authz.test-helpers.js";
 import {
   connectOk,
   installGatewayTestHooks,
   rpcReq,
   startServerWithClient,
-  trackConnectChallengeNonce,
 } from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
-
-function resolveDeviceIdentityPath(name: string): string {
-  const root = process.env.REMOTECLAW_STATE_DIR ?? process.env.HOME ?? os.tmpdir();
-  return path.join(root, "test-device-identities", `${name}.json`);
-}
-
-function loadDeviceIdentity(name: string): {
-  identityPath: string;
-  identity: DeviceIdentity;
-  publicKey: string;
-} {
-  const identityPath = resolveDeviceIdentityPath(name);
-  const identity = loadOrCreateDeviceIdentity(identityPath);
-  return {
-    identityPath,
-    identity,
-    publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
-  };
-}
-
-async function pairDevice(params: {
-  name: string;
-  role: "node" | "operator";
-  scopes: string[];
-  clientId?: string;
-  clientMode?: string;
-}): Promise<{
-  identityPath: string;
-  identity: DeviceIdentity;
-}> {
-  const loaded = loadDeviceIdentity(params.name);
-  const request = await requestDevicePairing({
-    deviceId: loaded.identity.deviceId,
-    publicKey: loaded.publicKey,
-    role: params.role,
-    scopes: params.scopes,
-    clientId: params.clientId,
-    clientMode: params.clientMode,
-  });
-  await approveDevicePairing(request.request.requestId);
-  return {
-    identityPath: loaded.identityPath,
-    identity: loaded.identity,
-  };
-}
-
-async function issuePairingScopedTokenForAdminApprovedDevice(name: string): Promise<{
-  deviceId: string;
-  identityPath: string;
-  pairingToken: string;
-}> {
-  const paired = await pairDevice({
-    name,
-    role: "operator",
-    scopes: ["operator.admin"],
-    clientId: GATEWAY_CLIENT_NAMES.TEST,
-    clientMode: GATEWAY_CLIENT_MODES.TEST,
-  });
-  const rotated = await rotateDeviceToken({
-    deviceId: paired.identity.deviceId,
-    role: "operator",
-    scopes: ["operator.pairing"],
-  });
-  expect(rotated?.token).toBeTruthy();
-  return {
-    deviceId: paired.identity.deviceId,
-    identityPath: paired.identityPath,
-    pairingToken: String(rotated?.token ?? ""),
-  };
-}
-
-async function openTrackedWs(port: number): Promise<WebSocket> {
-  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
-  trackConnectChallengeNonce(ws);
-  await new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("timeout waiting for ws open")), 5_000);
-    ws.once("open", () => {
-      clearTimeout(timer);
-      resolve();
-    });
-    ws.once("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
-  });
-  return ws;
-}
 
 async function connectPairingScopedOperator(params: {
   port: number;
@@ -132,7 +38,7 @@ async function connectApprovedNode(params: {
   name: string;
   onInvoke: (payload: unknown) => void;
 }): Promise<GatewayClient> {
-  const paired = await pairDevice({
+  const paired = await pairDeviceIdentity({
     name: params.name,
     role: "node",
     scopes: [],
@@ -147,7 +53,7 @@ async function connectApprovedNode(params: {
 
   const client = new GatewayClient({
     url: `ws://127.0.0.1:${params.port}`,
-    connectDelayMs: 2_000,
+    connectChallengeTimeoutMs: 2_000,
     token: "secret",
     role: "node",
     clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
@@ -202,17 +108,169 @@ async function waitForMacrotasks(): Promise<void> {
   await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
-describe("gateway device.token.rotate caller scope guard", () => {
+describe("gateway device.token.rotate/revoke ownership guard (IDOR)", () => {
+  test("rejects a device-token caller rotating or revoking another device's token", async () => {
+    const started = await startServerWithClient("secret");
+    const deviceA = await issueOperatorToken({
+      name: "idor-device-a",
+      approvedScopes: ["operator.admin"],
+      tokenScopes: ["operator.pairing"],
+      clientId: GATEWAY_CLIENT_NAMES.TEST,
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
+    const deviceB = await issueOperatorToken({
+      name: "idor-device-b",
+      approvedScopes: ["operator.admin"],
+      tokenScopes: ["operator.pairing"],
+      clientId: GATEWAY_CLIENT_NAMES.TEST,
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
+
+    let pairingWs: WebSocket | undefined;
+    try {
+      pairingWs = await connectPairingScopedOperator({
+        port: started.port,
+        identityPath: deviceA.identityPath,
+        deviceToken: deviceA.token,
+      });
+
+      const rotate = await rpcReq(pairingWs, "device.token.rotate", {
+        deviceId: deviceB.deviceId,
+        role: "operator",
+        scopes: ["operator.pairing"],
+      });
+      expect(rotate.ok).toBe(false);
+      expect(rotate.error?.message).toBe("device token rotation denied");
+
+      const pairedB = await getPairedDevice(deviceB.deviceId);
+      expect(pairedB?.tokens?.operator?.token).toBe(deviceB.token);
+
+      const revoke = await rpcReq(pairingWs, "device.token.revoke", {
+        deviceId: deviceB.deviceId,
+        role: "operator",
+      });
+      expect(revoke.ok).toBe(false);
+      expect(revoke.error?.message).toBe("device token revocation denied");
+
+      const pairedBAfterRevoke = await getPairedDevice(deviceB.deviceId);
+      expect(pairedBAfterRevoke?.tokens?.operator?.revokedAtMs).toBeUndefined();
+    } finally {
+      pairingWs?.close();
+      started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
+
+  test("allows an admin-scoped caller to rotate and revoke another device's token without echoing the new token", async () => {
+    const started = await startServerWithClient("secret");
+    const device = await issueOperatorToken({
+      name: "idor-admin-rotate-revoke",
+      approvedScopes: ["operator.pairing"],
+      clientId: GATEWAY_CLIENT_NAMES.TEST,
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
+
+    try {
+      await connectOk(started.ws);
+
+      const rotate = await rpcReq<{ rotatedAtMs?: number; token?: string }>(
+        started.ws,
+        "device.token.rotate",
+        {
+          deviceId: device.deviceId,
+          role: "operator",
+          scopes: ["operator.pairing"],
+        },
+      );
+      expect(rotate.ok).toBe(true);
+      expect(rotate.payload?.rotatedAtMs).toBeTypeOf("number");
+      // Cross-device rotation MUST NOT echo the new token in the response.
+      expect(rotate.payload?.token).toBeUndefined();
+      const pairedAfterRotate = await getPairedDevice(device.deviceId);
+      expect(pairedAfterRotate?.tokens?.operator?.token).toBeTruthy();
+
+      const revoke = await rpcReq<{ revokedAtMs?: number }>(started.ws, "device.token.revoke", {
+        deviceId: device.deviceId,
+        role: "operator",
+      });
+      expect(revoke.ok).toBe(true);
+      expect(revoke.payload?.revokedAtMs).toBeTypeOf("number");
+
+      const paired = await getPairedDevice(device.deviceId);
+      expect(paired?.tokens?.operator?.revokedAtMs).toBeTypeOf("number");
+    } finally {
+      started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
+});
+
+describe("gateway device.token.rotate/revoke caller scope guard", () => {
+  test("rejects shared-token callers rotating or revoking above their session scopes", async () => {
+    const started = await startServerWithClient("secret");
+    const target = await issueOperatorToken({
+      name: "shared-pairing-target",
+      approvedScopes: ["operator.admin"],
+      clientId: GATEWAY_CLIENT_NAMES.TEST,
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
+
+    let pairingWs: WebSocket | undefined;
+    try {
+      pairingWs = await openTrackedWs(started.port);
+      await connectOk(pairingWs, {
+        token: "secret",
+        scopes: ["operator.pairing"],
+        deviceIdentityPath: resolveDeviceIdentityPath("shared-pairing-caller"),
+      });
+
+      const rotate = await rpcReq(pairingWs, "device.token.rotate", {
+        deviceId: target.deviceId,
+        role: "operator",
+      });
+      expect(rotate.ok).toBe(false);
+      expect(rotate.error?.message).toBe("device token rotation denied");
+
+      const afterRotate = await getPairedDevice(target.deviceId);
+      expect(afterRotate?.tokens?.operator?.token).toBe(target.token);
+      expect(afterRotate?.tokens?.operator?.revokedAtMs).toBeUndefined();
+
+      const revoke = await rpcReq(pairingWs, "device.token.revoke", {
+        deviceId: target.deviceId,
+        role: "operator",
+      });
+      expect(revoke.ok).toBe(false);
+      expect(revoke.error?.message).toBe("device token revocation denied");
+
+      const afterRevoke = await getPairedDevice(target.deviceId);
+      expect(afterRevoke?.tokens?.operator?.token).toBe(target.token);
+      expect(afterRevoke?.tokens?.operator?.revokedAtMs).toBeUndefined();
+    } finally {
+      pairingWs?.close();
+      started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
+
   test("rejects rotating an admin-approved device token above the caller session scopes", async () => {
     const started = await startServerWithClient("secret");
-    const attacker = await issuePairingScopedTokenForAdminApprovedDevice("rotate-attacker");
+    const attacker = await issueOperatorToken({
+      name: "rotate-attacker",
+      approvedScopes: ["operator.admin"],
+      tokenScopes: ["operator.pairing"],
+      clientId: GATEWAY_CLIENT_NAMES.TEST,
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
 
     let pairingWs: WebSocket | undefined;
     try {
       pairingWs = await connectPairingScopedOperator({
         port: started.port,
         identityPath: attacker.identityPath,
-        deviceToken: attacker.pairingToken,
+        deviceToken: attacker.token,
       });
 
       const rotate = await rpcReq(pairingWs, "device.token.rotate", {
@@ -221,7 +279,7 @@ describe("gateway device.token.rotate caller scope guard", () => {
         scopes: ["operator.admin"],
       });
       expect(rotate.ok).toBe(false);
-      expect(rotate.error?.message).toBe("missing scope: operator.admin");
+      expect(rotate.error?.message).toBe("device token rotation denied");
 
       const paired = await getPairedDevice(attacker.deviceId);
       expect(paired?.tokens?.operator?.scopes).toEqual(["operator.pairing"]);
@@ -236,7 +294,13 @@ describe("gateway device.token.rotate caller scope guard", () => {
 
   test("blocks the pairing-token to admin-node-invoke escalation chain", async () => {
     const started = await startServerWithClient("secret");
-    const attacker = await issuePairingScopedTokenForAdminApprovedDevice("rotate-rce-attacker");
+    const attacker = await issueOperatorToken({
+      name: "rotate-rce-attacker",
+      approvedScopes: ["operator.admin"],
+      tokenScopes: ["operator.pairing"],
+      clientId: GATEWAY_CLIENT_NAMES.TEST,
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
 
     let sawInvoke = false;
     let pairingWs: WebSocket | undefined;
@@ -256,7 +320,7 @@ describe("gateway device.token.rotate caller scope guard", () => {
       pairingWs = await connectPairingScopedOperator({
         port: started.port,
         identityPath: attacker.identityPath,
-        deviceToken: attacker.pairingToken,
+        deviceToken: attacker.token,
       });
 
       const rotate = await rpcReq<{ token?: string }>(pairingWs, "device.token.rotate", {
@@ -266,16 +330,57 @@ describe("gateway device.token.rotate caller scope guard", () => {
       });
 
       expect(rotate.ok).toBe(false);
-      expect(rotate.error?.message).toBe("missing scope: operator.admin");
+      expect(rotate.error?.message).toBe("device token rotation denied");
       await waitForMacrotasks();
       expect(sawInvoke).toBe(false);
 
       const paired = await getPairedDevice(attacker.deviceId);
       expect(paired?.tokens?.operator?.scopes).toEqual(["operator.pairing"]);
-      expect(paired?.tokens?.operator?.token).toBe(attacker.pairingToken);
+      expect(paired?.tokens?.operator?.token).toBe(attacker.token);
     } finally {
       pairingWs?.close();
       nodeClient?.stop();
+      started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
+
+  test("returns the same public deny for unknown devices and caller scope failures", async () => {
+    const started = await startServerWithClient("secret");
+    const attacker = await issueOperatorToken({
+      name: "rotate-deny-shape",
+      approvedScopes: ["operator.admin"],
+      tokenScopes: ["operator.pairing"],
+      clientId: GATEWAY_CLIENT_NAMES.TEST,
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
+
+    let pairingWs: WebSocket | undefined;
+    try {
+      pairingWs = await connectPairingScopedOperator({
+        port: started.port,
+        identityPath: attacker.identityPath,
+        deviceToken: attacker.token,
+      });
+
+      const missingScope = await rpcReq(pairingWs, "device.token.rotate", {
+        deviceId: attacker.deviceId,
+        role: "operator",
+        scopes: ["operator.admin"],
+      });
+      const unknownDevice = await rpcReq(pairingWs, "device.token.rotate", {
+        deviceId: "missing-device",
+        role: "operator",
+        scopes: ["operator.pairing"],
+      });
+
+      expect(missingScope.ok).toBe(false);
+      expect(unknownDevice.ok).toBe(false);
+      expect(missingScope.error?.message).toBe("device token rotation denied");
+      expect(unknownDevice.error?.message).toBe("device token rotation denied");
+    } finally {
+      pairingWs?.close();
       started.ws.close();
       await started.server.close();
       started.envSnapshot.restore();

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1084,6 +1084,7 @@ export function attachGatewayWsMessageHandler(params: {
           socket,
           connect: connectParams,
           connId,
+          isDeviceTokenAuth: authMethod === "device-token",
           presenceKey,
           clientIp: reportedClientIp,
           canvasHostUrl,

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -5,6 +5,7 @@ export type GatewayWsClient = {
   socket: WebSocket;
   connect: ConnectParams;
   connId: string;
+  isDeviceTokenAuth?: boolean;
   presenceKey?: string;
   clientIp?: string;
   canvasHostUrl?: string;

--- a/src/gateway/test-helpers.e2e.ts
+++ b/src/gateway/test-helpers.e2e.ts
@@ -43,7 +43,7 @@ export async function connectGatewayClient(params: {
   instanceId?: string;
   deviceIdentity?: DeviceIdentity;
   onEvent?: (evt: { event?: string; payload?: unknown }) => void;
-  connectDelayMs?: number;
+  connectChallengeTimeoutMs?: number;
   timeoutMs?: number;
   timeoutMessage?: string;
 }) {
@@ -78,7 +78,7 @@ export async function connectGatewayClient(params: {
     const client = new GatewayClient({
       url: params.url,
       token: params.token,
-      connectDelayMs: params.connectDelayMs ?? 0,
+      connectChallengeTimeoutMs: params.connectChallengeTimeoutMs ?? 0,
       clientName: params.clientName ?? GATEWAY_CLIENT_NAMES.TEST,
       clientDisplayName: params.clientDisplayName ?? "vitest",
       clientVersion: params.clientVersion ?? "dev",

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { normalizeDeviceAuthScopes } from "../shared/device-auth.js";
-import { roleScopesAllow } from "../shared/operator-scope-compat.js";
+import { resolveMissingRequestedScope, roleScopesAllow } from "../shared/operator-scope-compat.js";
 import {
   createAsyncLock,
   pruneExpiredPending,
@@ -586,6 +586,7 @@ export async function rotateDeviceToken(params: {
   deviceId: string;
   role: string;
   scopes?: string[];
+  callerScopes?: readonly string[];
   baseDir?: string;
 }): Promise<DeviceAuthToken | null> {
   return await withLock(async () => {
@@ -612,6 +613,16 @@ export async function rotateDeviceToken(params: {
     ) {
       return null;
     }
+    if (params.callerScopes) {
+      const missingScope = resolveMissingRequestedScope({
+        role,
+        requestedScopes,
+        allowedScopes: params.callerScopes,
+      });
+      if (missingScope) {
+        return null;
+      }
+    }
     const now = Date.now();
     const next = buildDeviceAuthToken({
       role,
@@ -631,6 +642,7 @@ export async function rotateDeviceToken(params: {
 export async function revokeDeviceToken(params: {
   deviceId: string;
   role: string;
+  callerScopes?: readonly string[];
   baseDir?: string;
 }): Promise<DeviceAuthToken | null> {
   return await withLock(async () => {
@@ -643,8 +655,22 @@ export async function revokeDeviceToken(params: {
     if (!role) {
       return null;
     }
-    if (!device.tokens?.[role]) {
+    const existing = device.tokens?.[role];
+    if (!existing) {
       return null;
+    }
+    if (params.callerScopes) {
+      const targetScopes = normalizeDeviceAuthScopes(
+        Array.isArray(existing.scopes) ? existing.scopes : device.scopes,
+      );
+      const missingScope = resolveMissingRequestedScope({
+        role,
+        requestedScopes: targetScopes,
+        allowedScopes: params.callerScopes,
+      });
+      if (missingScope) {
+        return null;
+      }
     }
     const tokens = { ...device.tokens };
     const entry = { ...tokens[role], revokedAtMs: Date.now() };


### PR DESCRIPTION
## Summary

Closes #2643 (HIGH severity) — port four fork-relevant security hardenings for `device.token.rotate` / `device.token.revoke`. The token-echo regression at `devices.ts:225` is the primary fix (a real, exploitable defect — every rotation response leaked the new token to whoever requested it, including admins managing other devices). The IDOR guard, scope containment, error normalization, GatewayClient option rename, and test refactor ship together because they are tightly coupled at the authz boundary.

| Concern | Where | What |
|---------|-------|------|
| **Token-echo regression** | `src/gateway/server-methods/devices.ts` | Rotation response now includes `token` ONLY when caller is rotating their own device-token. Admin managing another device receives `rotatedAtMs` only. |
| **IDOR guard** | `src/gateway/server-methods/devices.ts`, `src/gateway/server-methods/types.ts`, `src/gateway/server/ws-types.ts`, `src/gateway/server/ws-connection/message-handler.ts` | New `isDeviceTokenAuth` field on `GatewayWsClient`/`GatewayClient` (set when `authMethod === "device-token"` at handshake). Routed through `resolveDeviceManagementAuthz` / `isCrossDeviceManagementDenied`. A device-token-authenticated caller without `operator.admin` cannot rotate/revoke another device's token. |
| **Scope containment (defense-in-depth)** | `src/infra/device-pairing.ts` | `rotateDeviceToken` / `revokeDeviceToken` accept optional `callerScopes` and refuse when requested scopes exceed caller's session scopes. Reuses the existing shared `resolveMissingRequestedScope` from `operator-scope-compat.ts`. |
| **Error normalization** | `src/gateway/server-methods/devices.ts` | All deny paths return `"device token rotation denied"` / `"device token revocation denied"` (was `"missing scope: ${scope}"` / `"unknown deviceId/role"`) — prevents information disclosure. Mirrors upstream. |
| **`connectChallengeTimeoutMs` rename** | `src/gateway/client.ts`, `src/gateway/test-helpers.e2e.ts`, `src/gateway/android-node.capabilities.live.test.ts`, `src/gateway/client.watchdog.test.ts` | `GatewayClientOptions.connectDelayMs` → `connectChallengeTimeoutMs`. The option was always a timeout, never a delay. |
| **Test refactor** | `src/gateway/device-authz.test-helpers.ts` (NEW), `src/gateway/server.device-token-rotate-authz.test.ts` | New shared helpers (`pairDeviceIdentity`, `issueOperatorToken`, `openTrackedWs`, `resolveDeviceIdentityPath`, `loadDeviceIdentity`). Suite rewritten to use them and adds IDOR, admin-rotate-without-echo, shared-token caller, and unified-deny-shape tests. |

## Why `null | DeviceAuthToken` retained at the infra layer

Upstream switched `rotateDeviceToken`/`revokeDeviceToken` to a structured `{ ok: true, entry } | { ok: false, reason, scope? }` return — that is a deeper refactor that ripples into many call sites and is out of issue #2643's scope. The fork keeps the existing `null | DeviceAuthToken` contract; defense-in-depth is achieved by honoring `callerScopes` inside `rotateDeviceToken`/`revokeDeviceToken` and returning `null` when the check fails. The handler-side preflight produces the precise log line; the infra layer is the fail-safe.

## Test plan

- [x] `pnpm tsgo` — clean
- [x] `pnpm lint` — 0 warnings, 0 errors (3406 files)
- [x] `pnpm format:check` — clean (5109 files)
- [x] `pnpm test` (`scripts/test-parallel.mjs`) — Test Files: 736 passed, 1 skipped; Tests: 6961 passed, 17 skipped, 0 failed
- [x] Fork-integrity gates: rebrand-leakage, zombie-imports, stub-debt (0 `@ts-expect-error`), throwing-stub-callers, css-class-drift — all clean
- [x] Polish: fresh-context subprocess review (claude-opus-4.7) → 1 MEDIUM (helper dedup) + 1 LOW (predicate naming) applied; 2 LOWs reviewer recommended LEAVE AS-IS deferred
- [ ] CI green on PR

New tests covering this PR's behavior:

```
gateway device.token.rotate/revoke ownership guard (IDOR)
  - rejects a device-token caller rotating or revoking another device's token
  - allows an admin-scoped caller to rotate and revoke another device's token without echoing the new token

gateway device.token.rotate/revoke caller scope guard
  - rejects shared-token callers rotating or revoking above their session scopes
  - rejects rotating an admin-approved device token above the caller session scopes
  - blocks the pairing-token to admin-node-invoke escalation chain
  - returns the same public deny for unknown devices and caller scope failures
```

Surfaced via #2636 (DIFF-SYNC v2026.3.28 adversarial audit, O4-G2). Issue body was the contract for this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)