### PR TITLE
fix(security): port pre-auth connection budget + 1009 close + diagnostic events (#2644)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,35 @@ jobs:
           REMOTECLAW_TEST_WORKERS: 1
           REMOTECLAW_TEST_MAX_OLD_SPACE_SIZE_MB: 1536
 
+  test-gateway-preauth:
+    # Scoped gateway lane for the pre-auth hardening defense-in-depth
+    # suite (#2644). The full gateway suite is gated behind
+    # REMOTECLAW_TEST_INCLUDE_GATEWAY=1 because of orthogonal pre-existing
+    # failures unrelated to this slice; running only the hardening file
+    # gives the new 1009 close-code + diagnostic event + connection budget
+    # behavior continuous CI coverage without enabling the full suite.
+    # Tracked separately from `test` so a hardening regression surfaces
+    # cleanly.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Build canvas bundle
+        run: pnpm canvas:a2ui:bundle
+
+      - name: Run pre-auth hardening tests
+        run: pnpm exec vitest run --config vitest.gateway.config.ts --pool=forks src/gateway/server.preauth-hardening.test.ts
+        env:
+          REMOTECLAW_TEST_INCLUDE_GATEWAY: "1"
+
   test-ui-smoke:
     # Browser-mode smoke lane for the RemoteClawApp host class. Scoped to
     # the two sync-regression defense-in-depth suites — class-instance
@@ -204,13 +233,14 @@ jobs:
         lint,
         build,
         test,
+        test-gateway-preauth,
         test-ui-smoke,
       ]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.rebrand-gate.result }}" != "success" || "${{ needs.zombie-import-gate.result }}" != "success" || "${{ needs.stub-debt-gate.result }}" != "success" || "${{ needs.throwing-stub-callers-gate.result }}" != "success" || "${{ needs.obsolescence-audit-gate.result }}" != "success" || "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.test.result }}" != "success" || "${{ needs.test-ui-smoke.result }}" != "success" ]]; then
+          if [[ "${{ needs.rebrand-gate.result }}" != "success" || "${{ needs.zombie-import-gate.result }}" != "success" || "${{ needs.stub-debt-gate.result }}" != "success" || "${{ needs.throwing-stub-callers-gate.result }}" != "success" || "${{ needs.obsolescence-audit-gate.result }}" != "success" || "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.test.result }}" != "success" || "${{ needs.test-gateway-preauth.result }}" != "success" || "${{ needs.test-ui-smoke.result }}" != "success" ]]; then
             echo "::error::One or more required jobs failed"
             exit 1
           fi

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -450,4 +450,14 @@ export type GatewayConfig = {
    * the rolling window expires. Default: 10.
    */
   channelMaxRestartsPerHour?: number;
+  /**
+   * Maximum time in milliseconds an unauthenticated WebSocket connection
+   * may remain idle before being closed. Defaults to
+   * DEFAULT_HANDSHAKE_TIMEOUT_MS (10 000) if unset. The
+   * `REMOTECLAW_HANDSHAKE_TIMEOUT_MS` env var (and the
+   * `REMOTECLAW_TEST_HANDSHAKE_TIMEOUT_MS` test-only override under VITEST)
+   * are honored as fallbacks for backward compatibility — config takes
+   * precedence when both are set.
+   */
+  handshakeTimeoutMs?: number;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -611,6 +611,7 @@ export const RemoteClawSchema = z
           .strict()
           .optional(),
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
+        handshakeTimeoutMs: z.number().int().positive().optional(),
         tailscale: z
           .object({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -22,7 +22,29 @@ export const __setMaxChatHistoryMessagesBytesForTest = (value?: number) => {
   }
 };
 export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10_000;
-export const getHandshakeTimeoutMs = () => {
+
+type GatewayHandshakeTimeoutSource = {
+  gateway?: { handshakeTimeoutMs?: number };
+};
+
+const isPositiveFinite = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value > 0;
+
+/**
+ * Resolve the pre-auth handshake timeout (ms) for idle unauthenticated
+ * sockets.
+ *
+ * Order of precedence:
+ *   1. `config.gateway.handshakeTimeoutMs`, when supplied and positive.
+ *   2. `REMOTECLAW_HANDSHAKE_TIMEOUT_MS` (user-facing env var, all envs).
+ *   3. `REMOTECLAW_TEST_HANDSHAKE_TIMEOUT_MS` (test-only, gated by VITEST).
+ *   4. `DEFAULT_HANDSHAKE_TIMEOUT_MS` (10 000 ms).
+ */
+export const getHandshakeTimeoutMs = (config?: GatewayHandshakeTimeoutSource) => {
+  const fromConfig = config?.gateway?.handshakeTimeoutMs;
+  if (isPositiveFinite(fromConfig)) {
+    return fromConfig;
+  }
   // User-facing env var (works in all environments); test-only var gated behind VITEST
   const envKey =
     process.env.REMOTECLAW_HANDSHAKE_TIMEOUT_MS ||

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -52,6 +52,7 @@ import {
 } from "./hooks.js";
 import { sendGatewayAuthFailure, setDefaultSecurityHeaders } from "./http-common.js";
 import { getBearerToken } from "./http-utils.js";
+import { resolveRequestClientIp } from "./net.js";
 import { handleOpenAiHttpRequest } from "./openai-http.js";
 import { handleOpenResponsesHttpRequest } from "./openresponses-http.js";
 import {
@@ -60,6 +61,7 @@ import {
   type PluginHttpRequestHandler,
   type PluginRoutePathContext,
 } from "./server/plugins-http.js";
+import type { PreauthConnectionBudget } from "./server/preauth-connection-budget.js";
 import type { ReadinessChecker } from "./server/readiness.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { handleToolsInvokeHttpRequest } from "./tools-invoke-http.js";
@@ -257,6 +259,22 @@ function writeUpgradeAuthFailure(
     return;
   }
   socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+}
+
+function writeUpgradeServiceUnavailable(
+  socket: { write: (chunk: string) => void },
+  message: string,
+) {
+  socket.write(
+    [
+      "HTTP/1.1 503 Service Unavailable",
+      "Content-Type: text/plain; charset=utf-8",
+      `Content-Length: ${Buffer.byteLength(message)}`,
+      "Connection: close",
+      "",
+      message,
+    ].join("\r\n"),
+  );
 }
 
 export type HooksRequestHandler = (req: IncomingMessage, res: ServerResponse) => Promise<boolean>;
@@ -755,11 +773,18 @@ export function attachGatewayUpgradeHandler(opts: {
   wss: WebSocketServer;
   canvasHost: CanvasHostHandler | null;
   clients: Set<GatewayWsClient>;
+  /**
+   * Per-IP budget that bounds the number of in-flight pre-auth WebSocket
+   * connections. A new upgrade is rejected with 503 once the limit is
+   * reached; the budget is released when the socket closes (whether the
+   * handshake completes or fails).
+   */
+  preauthConnectionBudget: PreauthConnectionBudget;
   resolvedAuth: ResolvedGatewayAuth;
   /** Optional rate limiter for auth brute-force protection. */
   rateLimiter?: AuthRateLimiter;
 }) {
-  const { httpServer, wss, canvasHost } = opts;
+  const { httpServer, wss, canvasHost, preauthConnectionBudget } = opts;
   httpServer.on("upgrade", (req, socket, head) => {
     void (async () => {
       const scopedCanvas = normalizeCanvasScopedUrl(req.url ?? "/");
@@ -786,9 +811,54 @@ export function attachGatewayUpgradeHandler(opts: {
           return;
         }
       }
-      wss.handleUpgrade(req, socket, head, (ws) => {
-        wss.emit("connection", ws, req);
-      });
+      // Reject the upgrade if the WSS has not yet attached its connection
+      // listener — handlers are wired in `attachGatewayWsConnectionHandler`,
+      // which runs after `server-runtime-state` finishes assembly. Without
+      // this gate we would silently 1006 on the racing connection.
+      if (wss.listenerCount("connection") === 0) {
+        writeUpgradeServiceUnavailable(socket, "Gateway websocket handlers unavailable");
+        socket.destroy();
+        return;
+      }
+      const cfgSnapshot = (() => {
+        try {
+          return loadConfig();
+        } catch {
+          return undefined;
+        }
+      })();
+      const trustedProxies = cfgSnapshot?.gateway?.trustedProxies ?? [];
+      const allowRealIpFallback = cfgSnapshot?.gateway?.allowRealIpFallback === true;
+      const preauthBudgetKey = resolveRequestClientIp(req, trustedProxies, allowRealIpFallback);
+      if (!preauthConnectionBudget.acquire(preauthBudgetKey)) {
+        writeUpgradeServiceUnavailable(socket, "Too many unauthenticated sockets");
+        socket.destroy();
+        return;
+      }
+      let budgetReleased = false;
+      const releasePreauthBudget = () => {
+        if (budgetReleased) {
+          return;
+        }
+        budgetReleased = true;
+        preauthConnectionBudget.release(preauthBudgetKey);
+      };
+      socket.once("close", releasePreauthBudget);
+      try {
+        wss.handleUpgrade(req, socket, head, (ws) => {
+          // Hand off budget release to the WS lifecycle: the WS `close` event
+          // fires whether or not the handshake succeeds, so removing the raw
+          // socket listener here avoids a double-release.
+          socket.off("close", releasePreauthBudget);
+          ws.once("close", releasePreauthBudget);
+          wss.emit("connection", ws, req);
+        });
+      } catch (err) {
+        socket.off("close", releasePreauthBudget);
+        releasePreauthBudget();
+        socket.destroy();
+        throw err;
+      }
     })().catch(() => {
       socket.destroy();
     });

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -32,6 +32,10 @@ import {
   shouldEnforceGatewayAuthForPluginPath,
   type PluginRoutePathContext,
 } from "./server/plugins-http.js";
+import {
+  createPreauthConnectionBudget,
+  type PreauthConnectionBudget,
+} from "./server/preauth-connection-budget.js";
 import type { ReadinessChecker } from "./server/readiness.js";
 import type { GatewayTlsRuntime } from "./server/tls.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
@@ -187,12 +191,14 @@ export async function createGatewayRuntimeState(params: {
     noServer: true,
     maxPayload: MAX_PAYLOAD_BYTES,
   });
+  const preauthConnectionBudget: PreauthConnectionBudget = createPreauthConnectionBudget();
   for (const server of httpServers) {
     attachGatewayUpgradeHandler({
       httpServer: server,
       wss,
       canvasHost,
       clients,
+      preauthConnectionBudget,
       resolvedAuth: params.resolvedAuth,
       rateLimiter: params.rateLimiter,
     });

--- a/src/gateway/server.canvas-auth.test.ts
+++ b/src/gateway/server.canvas-auth.test.ts
@@ -6,6 +6,7 @@ import { createAuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import { CANVAS_CAPABILITY_PATH_PREFIX } from "./canvas-capability.js";
 import { attachGatewayUpgradeHandler, createGatewayHttpServer } from "./server-http.js";
+import { createPreauthConnectionBudget } from "./server/preauth-connection-budget.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { withTempConfig } from "./test-temp-config.js";
 
@@ -158,6 +159,7 @@ async function withCanvasGatewayHarness(params: {
     wss,
     canvasHost,
     clients,
+    preauthConnectionBudget: createPreauthConnectionBudget(),
     resolvedAuth: params.resolvedAuth,
     rateLimiter: params.rateLimiter,
   });

--- a/src/gateway/server.preauth-hardening.test.ts
+++ b/src/gateway/server.preauth-hardening.test.ts
@@ -1,6 +1,24 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import {
+  type DiagnosticEventPayload,
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+} from "../infra/diagnostic-events.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
 import { MAX_PREAUTH_PAYLOAD_BYTES } from "./server-constants.js";
+import { attachGatewayUpgradeHandler, createGatewayHttpServer } from "./server-http.js";
+import { createPreauthConnectionBudget } from "./server/preauth-connection-budget.js";
+import type { GatewayWsClient } from "./server/ws-types.js";
+import { setTestConfigRoot, testState } from "./test-helpers.mocks.js";
 import { createGatewaySuiteHarness, readConnectChallengeNonce } from "./test-helpers.server.js";
+import { withTempConfig } from "./test-temp-config.js";
+
+const PREAUTH_HANDSHAKE_TEST_CLOSE_LIMIT_MS = 5_000;
 
 let cleanupEnv: Array<() => void> = [];
 
@@ -10,19 +28,109 @@ afterEach(async () => {
   }
 });
 
+function setEnvForTest(name: string, value: string) {
+  const previous = process.env[name];
+  process.env[name] = value;
+  cleanupEnv.push(() => {
+    if (previous === undefined) {
+      delete process.env[name];
+      return;
+    }
+    process.env[name] = previous;
+  });
+}
+
+function setGatewayAuthNoneForTest() {
+  const previousAuth = testState.gatewayAuth;
+  testState.gatewayAuth = { mode: "none" };
+  cleanupEnv.push(() => {
+    testState.gatewayAuth = previousAuth;
+  });
+}
+
+async function requestUpgradeRejection(port: number): Promise<{ status: number; body: string }> {
+  return await new Promise<{ status: number; body: string }>((resolve, reject) => {
+    const req = http.request({
+      host: "127.0.0.1",
+      port,
+      path: "/",
+      headers: {
+        Connection: "Upgrade",
+        Upgrade: "websocket",
+        "Sec-WebSocket-Key": "dGVzdC1rZXktMDEyMzQ1Ng==",
+        "Sec-WebSocket-Version": "13",
+      },
+    });
+    req.once("upgrade", (_res, socket) => {
+      socket.destroy();
+      reject(new Error("expected websocket upgrade to be rejected"));
+    });
+    req.once("response", (res) => {
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        body += chunk;
+      });
+      res.once("end", () => {
+        resolve({ status: res.statusCode ?? 0, body });
+      });
+    });
+    req.once("error", reject);
+    req.end();
+  });
+}
+
 describe("gateway pre-auth hardening", () => {
-  it("closes idle unauthenticated sockets after the handshake timeout", async () => {
-    const previous = process.env.REMOTECLAW_TEST_HANDSHAKE_TIMEOUT_MS;
-    process.env.REMOTECLAW_TEST_HANDSHAKE_TIMEOUT_MS = "200";
-    cleanupEnv.push(() => {
-      if (previous === undefined) {
-        delete process.env.REMOTECLAW_TEST_HANDSHAKE_TIMEOUT_MS;
-      } else {
-        process.env.REMOTECLAW_TEST_HANDSHAKE_TIMEOUT_MS = previous;
-      }
+  it("rejects upgrades before websocket handlers attach (pre-auth budget enforced, then released)", async () => {
+    const clients = new Set<GatewayWsClient>();
+    const resolvedAuth: ResolvedGatewayAuth = { mode: "none", allowTailscale: false };
+    const httpServer = createGatewayHttpServer({
+      canvasHost: null,
+      clients,
+      controlUiEnabled: false,
+      controlUiBasePath: "/__control__",
+      openAiChatCompletionsEnabled: false,
+      openResponsesEnabled: false,
+      handleHooksRequest: async () => false,
+      resolvedAuth,
+    });
+    const wss = new WebSocketServer({ noServer: true });
+    attachGatewayUpgradeHandler({
+      httpServer,
+      wss,
+      canvasHost: null,
+      clients,
+      preauthConnectionBudget: createPreauthConnectionBudget(1),
+      resolvedAuth,
     });
 
-    const harness = await createGatewaySuiteHarness();
+    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+    const address = httpServer.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+
+    try {
+      await expect(requestUpgradeRejection(port)).resolves.toEqual({
+        status: 503,
+        body: "Gateway websocket handlers unavailable",
+      });
+      await expect(requestUpgradeRejection(port)).resolves.toEqual({
+        status: 503,
+        body: "Gateway websocket handlers unavailable",
+      });
+    } finally {
+      wss.close();
+      await new Promise<void>((resolve, reject) =>
+        httpServer.close((err) => (err ? reject(err) : resolve())),
+      );
+    }
+  });
+
+  it("closes idle unauthenticated sockets after the handshake timeout", async () => {
+    setEnvForTest("REMOTECLAW_TEST_HANDSHAKE_TIMEOUT_MS", "200");
+
+    const harness = await createGatewaySuiteHarness({
+      serverOptions: { auth: { mode: "none" } },
+    });
     try {
       const ws = await harness.openWs();
       await readConnectChallengeNonce(ws);
@@ -34,13 +142,75 @@ describe("gateway pre-auth hardening", () => {
       });
       expect(close.code).toBe(1000);
       expect(close.elapsedMs).toBeGreaterThan(0);
-      expect(close.elapsedMs).toBeLessThan(1_000);
+      expect(close.elapsedMs).toBeLessThan(PREAUTH_HANDSHAKE_TEST_CLOSE_LIMIT_MS);
     } finally {
       await harness.close();
     }
   });
 
+  it("uses gateway.handshakeTimeoutMs for idle unauthenticated sockets", async () => {
+    // The mocked `loadConfig` reads from `testConfigRoot.value` (set via
+    // `setTestConfigRoot`); `withTempConfig` only mutates the env var, so
+    // we set both manually here to keep the assertion paths aligned.
+    const previousConfigPath = process.env.REMOTECLAW_CONFIG_PATH;
+    const previousDisableCache = process.env.REMOTECLAW_DISABLE_CONFIG_CACHE;
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "remoteclaw-preauth-handshake-cfg-"));
+    setTestConfigRoot(tempDir);
+    process.env.REMOTECLAW_DISABLE_CONFIG_CACHE = "1";
+    cleanupEnv.push(() => {
+      if (previousConfigPath === undefined) {
+        delete process.env.REMOTECLAW_CONFIG_PATH;
+      } else {
+        process.env.REMOTECLAW_CONFIG_PATH = previousConfigPath;
+      }
+      if (previousDisableCache === undefined) {
+        delete process.env.REMOTECLAW_DISABLE_CONFIG_CACHE;
+      } else {
+        process.env.REMOTECLAW_DISABLE_CONFIG_CACHE = previousDisableCache;
+      }
+    });
+    try {
+      await writeFile(
+        path.join(tempDir, "remoteclaw.json"),
+        JSON.stringify(
+          {
+            gateway: {
+              handshakeTimeoutMs: 250,
+              auth: { mode: "none" },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+      const harness = await createGatewaySuiteHarness({
+        serverOptions: { auth: { mode: "none" } },
+      });
+      try {
+        const ws = await harness.openWs();
+        await readConnectChallengeNonce(ws);
+        const close = await new Promise<{ code: number; elapsedMs: number }>((resolve) => {
+          const startedAt = Date.now();
+          ws.once("close", (code) => {
+            resolve({ code, elapsedMs: Date.now() - startedAt });
+          });
+        });
+        expect(close.code).toBe(1000);
+        expect(close.elapsedMs).toBeGreaterThan(0);
+        expect(close.elapsedMs).toBeLessThan(PREAUTH_HANDSHAKE_TEST_CLOSE_LIMIT_MS);
+      } finally {
+        await harness.close();
+      }
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects oversized pre-auth connect frames before application-level auth responses", async () => {
+    resetDiagnosticEventsForTest();
+    const events: DiagnosticEventPayload[] = [];
+    const stopDiagnostics = onDiagnosticEvent((event) => events.push(event));
     const harness = await createGatewaySuiteHarness();
     try {
       const ws = await harness.openWs();
@@ -70,8 +240,97 @@ describe("gateway pre-auth hardening", () => {
 
       const result = await closed;
       expect(result.code).toBe(1009);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "payload.large",
+          surface: "gateway.ws.preauth",
+          action: "rejected",
+          limitBytes: MAX_PREAUTH_PAYLOAD_BYTES,
+          reason: "preauth_frame_limit",
+        }),
+      );
+    } finally {
+      stopDiagnostics();
+      resetDiagnosticEventsForTest();
+      await harness.close();
+    }
+  });
+
+  it("rejects excess simultaneous unauthenticated sockets from the same client ip", async () => {
+    setEnvForTest("REMOTECLAW_TEST_MAX_PREAUTH_CONNECTIONS_PER_IP", "1");
+    setGatewayAuthNoneForTest();
+
+    const harness = await createGatewaySuiteHarness({
+      serverOptions: { auth: { mode: "none" } },
+    });
+    try {
+      const firstWs = await harness.openWs();
+      await readConnectChallengeNonce(firstWs);
+
+      const rejectedStatus = await new Promise<number>((resolve, reject) => {
+        const req = http.request({
+          host: "127.0.0.1",
+          port: harness.port,
+          path: "/",
+          headers: {
+            Connection: "Upgrade",
+            Upgrade: "websocket",
+            "Sec-WebSocket-Key": "dGVzdC1rZXktMDEyMzQ1Ng==",
+            "Sec-WebSocket-Version": "13",
+          },
+        });
+        req.once("upgrade", (_res, socket) => {
+          socket.destroy();
+          reject(new Error("expected websocket upgrade to be rejected"));
+        });
+        req.once("response", (res) => {
+          res.resume();
+          res.once("end", () => {
+            resolve(res.statusCode ?? 0);
+          });
+        });
+        req.once("error", reject);
+        req.end();
+      });
+      expect(rejectedStatus).toBe(503);
+
+      firstWs.close();
     } finally {
       await harness.close();
     }
+  });
+
+  it("rejects excess simultaneous unauthenticated sockets when trusted proxy headers are missing", async () => {
+    setEnvForTest("REMOTECLAW_TEST_MAX_PREAUTH_CONNECTIONS_PER_IP", "1");
+    setGatewayAuthNoneForTest();
+
+    await withTempConfig({
+      cfg: {
+        gateway: {
+          trustedProxies: ["127.0.0.1"],
+          auth: { mode: "none" },
+        },
+      },
+      prefix: "remoteclaw-preauth-proxy-",
+      run: async () => {
+        const harness = await createGatewaySuiteHarness({
+          serverOptions: { auth: { mode: "none" } },
+        });
+        try {
+          const firstWs = await harness.openWs();
+          await readConnectChallengeNonce(firstWs);
+
+          const rejected = await requestUpgradeRejection(harness.port);
+          expect(rejected).toEqual({
+            status: 503,
+            body: "Too many unauthenticated sockets",
+          });
+
+          firstWs.close();
+        } finally {
+          await harness.close();
+        }
+      },
+    });
   });
 });

--- a/src/gateway/server/preauth-connection-budget.ts
+++ b/src/gateway/server/preauth-connection-budget.ts
@@ -1,0 +1,58 @@
+const DEFAULT_MAX_PREAUTH_CONNECTIONS_PER_IP = 32;
+const UNKNOWN_CLIENT_IP_BUDGET_KEY = "__remoteclaw_unknown_client_ip__";
+
+export function getMaxPreauthConnectionsPerIpFromEnv(env: NodeJS.ProcessEnv = process.env): number {
+  const configured =
+    env.REMOTECLAW_MAX_PREAUTH_CONNECTIONS_PER_IP ||
+    (env.VITEST && env.REMOTECLAW_TEST_MAX_PREAUTH_CONNECTIONS_PER_IP);
+  if (!configured) {
+    return DEFAULT_MAX_PREAUTH_CONNECTIONS_PER_IP;
+  }
+  const parsed = Number(configured);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return DEFAULT_MAX_PREAUTH_CONNECTIONS_PER_IP;
+  }
+  return Math.floor(parsed);
+}
+
+export type PreauthConnectionBudget = {
+  acquire(clientIp: string | undefined): boolean;
+  release(clientIp: string | undefined): void;
+};
+
+export function createPreauthConnectionBudget(
+  limit = getMaxPreauthConnectionsPerIpFromEnv(),
+): PreauthConnectionBudget {
+  const counts = new Map<string, number>();
+  const normalizeBudgetKey = (clientIp: string | undefined) => {
+    const ip = clientIp?.trim();
+    // Trusted-proxy mode can intentionally leave client IP unresolved when
+    // forwarded headers are missing or invalid; keep those upgrades capped
+    // under a shared fallback bucket instead of failing open.
+    return ip || UNKNOWN_CLIENT_IP_BUDGET_KEY;
+  };
+
+  return {
+    acquire(clientIp) {
+      const ip = normalizeBudgetKey(clientIp);
+      const next = (counts.get(ip) ?? 0) + 1;
+      if (next > limit) {
+        return false;
+      }
+      counts.set(ip, next);
+      return true;
+    },
+    release(clientIp) {
+      const ip = normalizeBudgetKey(clientIp);
+      const current = counts.get(ip);
+      if (current === undefined) {
+        return;
+      }
+      if (current <= 1) {
+        counts.delete(ip);
+        return;
+      }
+      counts.set(ip, current - 1);
+    },
+  };
+}

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { WebSocket, WebSocketServer } from "ws";
+import { loadConfig } from "../../config/config.js";
 import { resolveCanvasHostUrl } from "../../infra/canvas-host-url.js";
 import { upsertPresence } from "../../infra/system-presence.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -262,7 +263,14 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       close();
     });
 
-    const handshakeTimeoutMs = getHandshakeTimeoutMs();
+    let cfgForHandshake: ReturnType<typeof loadConfig> | undefined;
+    try {
+      cfgForHandshake = loadConfig();
+    } catch {
+      // Config load can fail during early boot or in tests with malformed
+      // fixtures; fall back to env + default.
+    }
+    const handshakeTimeoutMs = getHandshakeTimeoutMs(cfgForHandshake);
     const handshakeTimer = setTimeout(() => {
       if (!client) {
         handshakeState = "failed";

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -15,6 +15,7 @@ import {
   updatePairedDeviceMetadata,
   verifyDeviceToken,
 } from "../../../infra/device-pairing.js";
+import { emitDiagnosticEvent } from "../../../infra/diagnostic-events.js";
 import { updatePairedNodeMetadata } from "../../../infra/node-pairing.js";
 import { upsertPresence } from "../../../infra/system-presence.js";
 import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
@@ -61,7 +62,12 @@ import {
   validateRequestFrame,
 } from "../../protocol/index.js";
 import { parseGatewayRole } from "../../role-policy.js";
-import { MAX_BUFFERED_BYTES, MAX_PAYLOAD_BYTES, TICK_INTERVAL_MS } from "../../server-constants.js";
+import {
+  MAX_BUFFERED_BYTES,
+  MAX_PAYLOAD_BYTES,
+  MAX_PREAUTH_PAYLOAD_BYTES,
+  TICK_INTERVAL_MS,
+} from "../../server-constants.js";
 import { handleGatewayRequest } from "../../server-methods.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../../server-methods/types.js";
 import { formatError } from "../../server-utils.js";
@@ -362,6 +368,31 @@ export function attachGatewayWsMessageHandler(params: {
   socket.on("message", async (data) => {
     if (isClosed()) {
       return;
+    }
+    // Defense-in-depth: cap inbound frame size on the pre-auth path before
+    // attempting JSON parse / schema validation. Surfaces a structured
+    // `payload.large` diagnostic event and closes with code 1009 (Message
+    // Too Big) so operators can distinguish oversized frames from generic
+    // policy violations (1008).
+    if (!getClient()) {
+      const preauthPayloadBytes = getRawDataByteLength(data);
+      if (preauthPayloadBytes > MAX_PREAUTH_PAYLOAD_BYTES) {
+        emitDiagnosticEvent({
+          type: "payload.large",
+          surface: "gateway.ws.preauth",
+          action: "rejected",
+          bytes: preauthPayloadBytes,
+          limitBytes: MAX_PREAUTH_PAYLOAD_BYTES,
+          reason: "preauth_frame_limit",
+        });
+        setHandshakeState("failed");
+        setCloseCause("preauth-payload-too-large", {
+          payloadBytes: preauthPayloadBytes,
+          limitBytes: MAX_PREAUTH_PAYLOAD_BYTES,
+        });
+        close(1009, "preauth payload too large");
+        return;
+      }
     }
     const text = rawDataToString(data);
     try {
@@ -1219,4 +1250,25 @@ export function attachGatewayWsMessageHandler(params: {
       }
     }
   });
+}
+
+function getRawDataByteLength(data: unknown): number {
+  if (Buffer.isBuffer(data)) {
+    return data.byteLength;
+  }
+  if (Array.isArray(data)) {
+    return data.reduce<number>((total, chunk) => {
+      if (Buffer.isBuffer(chunk)) {
+        return total + chunk.byteLength;
+      }
+      if (chunk instanceof ArrayBuffer) {
+        return total + chunk.byteLength;
+      }
+      return total + Buffer.byteLength(String(chunk));
+    }, 0);
+  }
+  if (data instanceof ArrayBuffer) {
+    return data.byteLength;
+  }
+  return Buffer.byteLength(String(data));
 }

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -164,6 +164,26 @@ export type DiagnosticRoutingDropEvent = DiagnosticBaseEvent & {
   target?: string;
 };
 
+export type DiagnosticPayloadLargeEvent = DiagnosticBaseEvent & {
+  type: "payload.large";
+  /** Origin surface for the oversized payload (e.g. "gateway.ws.preauth"). */
+  surface: string;
+  /** What the surface did with the payload. */
+  action: "rejected" | "truncated" | "chunked";
+  /** Observed payload size, when known. */
+  bytes?: number;
+  /** Configured limit that triggered the action, when known. */
+  limitBytes?: number;
+  /** Cumulative count of similar events on this surface, when tracked. */
+  count?: number;
+  /** Channel id (chat-extension contexts), when applicable. */
+  channel?: string;
+  /** Plugin id, when applicable. */
+  pluginId?: string;
+  /** Stable reason code (e.g. "preauth_frame_limit"). */
+  reason?: string;
+};
+
 export type DiagnosticEventPayload =
   | DiagnosticUsageEvent
   | DiagnosticWebhookReceivedEvent
@@ -178,7 +198,8 @@ export type DiagnosticEventPayload =
   | DiagnosticRunAttemptEvent
   | DiagnosticHeartbeatEvent
   | DiagnosticToolLoopEvent
-  | DiagnosticRoutingDropEvent;
+  | DiagnosticRoutingDropEvent
+  | DiagnosticPayloadLargeEvent;
 
 export type DiagnosticEventInput = DiagnosticEventPayload extends infer Event
   ? Event extends DiagnosticEventPayload


### PR DESCRIPTION
## Summary

Defense-in-depth port from upstream — surfaced by PR #2641's adversarial
audit of #2636 (DIFF-SYNC v2026.3.28). The fork already rejects oversized
pre-auth frames; this hardens the rejection mechanism with better close
codes, structured diagnostics, and connection-budget enforcement before
pre-auth completes.

Resolves: part of #2636 (O4-G1). Closes #2644.

## What changed

| Concern | Before | After |
|---|---|---|
| `createPreauthConnectionBudget` module | Not present | NEW `src/gateway/server/preauth-connection-budget.ts` (env vars adapted to `REMOTECLAW_*`) |
| `gateway.handshakeTimeoutMs` config | Not present (only `REMOTECLAW_HANDSHAKE_TIMEOUT_MS` env) | Added to `types.gateway.ts` + `zod-schema.ts`; `getHandshakeTimeoutMs(cfg?)` consults config first, env as fallback |
| Oversized pre-auth close code | `1008 (Policy Violation)` | `1009 (Message Too Big)` |
| Diagnostic event on oversized pre-auth | None | `payload.large` with `surface: "gateway.ws.preauth"`, `action: "rejected"`, `limitBytes`, `reason: "preauth_frame_limit"` |
| `attachGatewayUpgradeHandler` | No connection budget | Requires `preauthConnectionBudget`; per-IP enforcement before WS handoff; budget release tracked through socket→WS lifecycle |
| Tests | 2 cases (handshake timeout + oversized frame) | 6 cases (upstream's full set, ports adapted to fork conventions) |

### Files (1 NEW + 11 MODIFIED)

- **NEW** `src/gateway/server/preauth-connection-budget.ts` — verbatim port; default 32; trusted-proxy fallback bucket prevents fail-open when forwarded headers are missing.
- `src/config/types.gateway.ts` — `+handshakeTimeoutMs?: number` on `GatewayConfig`.
- `src/config/zod-schema.ts` — `handshakeTimeoutMs: z.number().int().positive().optional()` in gateway block.
- `src/gateway/server-constants.ts` — `getHandshakeTimeoutMs(cfg?)` precedence-aware resolver (config → env → default).
- `src/gateway/server/ws-connection.ts` — call resolver with `loadConfig()` (cached); failure caught so early-boot/malformed test fixtures fall through.
- `src/infra/diagnostic-events.ts` — `+DiagnosticPayloadLargeEvent` variant added to `DiagnosticEventPayload` union (matches upstream shape).
- `src/gateway/server/ws-connection/message-handler.ts` — pre-auth size check + `payload.large` emit + `close(1009, …)` + `getRawDataByteLength` helper.
- `src/gateway/server-http.ts` — `attachGatewayUpgradeHandler` accepts `preauthConnectionBudget`; enforces budget after listener-count check; lifecycle handoff prevents double-release; `+writeUpgradeServiceUnavailable` 503 helper.
- `src/gateway/server-runtime-state.ts` — instantiate `createPreauthConnectionBudget()` once, pass to all bound HTTP servers.
- `src/gateway/server.canvas-auth.test.ts` — pass `preauthConnectionBudget` to keep call site type-clean.
- `src/gateway/server.preauth-hardening.test.ts` — port the upstream 6-test file with REMOTECLAW_* env adaptations.
- `.github/workflows/ci.yml` — new `test-gateway-preauth` scoped job; wired into `CI` aggregate.

## Decisions

### `REMOTECLAW_TEST_INCLUDE_GATEWAY` gate (item 5 in scope)

**Decision: scoped CI job.** Added `test-gateway-preauth` that runs ONLY `src/gateway/server.preauth-hardening.test.ts` with `REMOTECLAW_TEST_INCLUDE_GATEWAY=1`. Wired into the `CI` aggregate so the new defense-in-depth behavior gets continuous coverage.

**Empirical justification.** Tried enabling the gate globally first (set `REMOTECLAW_TEST_INCLUDE_GATEWAY: "1"` in the global `test` job env). Result: ~128 PRE-EXISTING failures across `server.auth.*` / `server.config-apply` / `server.cron` / etc. — verified by stashing this PR and re-running on clean main → same failures. Those are orthogonal to #2644's scope and tracked separately.

**Why not the alternative** ("update the assertion to match current fork behavior") suggested by the issue body: the existing fork test for oversized frames already expected `1009`, so updating the assertion to `1008` would have meant abandoning the security improvement that's the whole point of the port. The scoped CI lane is the right shape — it gives the new behavior coverage without enabling broken sibling files.

### Application-level vs WSS-level oversized-frame check

Did NOT lower the WSS-level `maxPayload` to `MAX_PREAUTH_PAYLOAD_BYTES` (upstream's belt-and-suspenders). The application-level check inside the message handler (gated on `!getClient()`, fires BEFORE `JSON.parse(text)`) satisfies the issue's "switch close code 1008 → 1009 + diagnostic event" requirement and avoids the per-socket `setSocketMaxPayload` upgrade-after-auth machinery. The WSS-level cap is a future hardening pass.

### Schema regeneration

Did NOT regenerate `src/config/schema.base.generated.ts`. That file is editor-tooling-only — the `validateConfigObject` runtime path uses `RemoteClawSchema.safeParse`, and the generator's diff test is `.skip`'d. Regeneration produced 3839 lines of orthogonal drift on main; scoped out of this PR.

## Test plan

- [x] `vitest run --config vitest.gateway.config.ts --pool=forks src/gateway/server.preauth-hardening.test.ts` with `REMOTECLAW_TEST_INCLUDE_GATEWAY=1` — **6/6 passing** in ~8 s.
- [x] `pnpm test` (full unit) — 7226/7243 passing, 17 pre-existing skips, 0 new failures.
- [x] `pnpm check` — clean (format + tsgo + lint + tmp/random-messaging + no-remoteclaw-ai + ui:no-css-class-drift).
- [x] `node scripts/check-throwing-stub-callers.mjs` — clean.
- [x] `node scripts/check-no-zombie-imports.mjs` — clean.
- [x] Adversarial AC validation in fresh subprocess: all 5 ACs PASS (preauth-connection-budget module, gateway.handshakeTimeoutMs config, 1008→1009 close + diagnostic event, port upstream tests, REMOTECLAW_TEST_INCLUDE_GATEWAY decision).
- [x] Fresh-context polish dispatch: CHANGED, two redundancies removed (dead `Math.max(1, …)` wrapper; gratuitous `const body = message` indirection); 10 files clean; tests still 6/6.
- [ ] CI green on this branch (`build`, `test`, `lint`, `docs`, `test-ui-smoke`, `test-gateway-preauth`, fork-integrity gates).

Auto-merge intentionally NOT enabled — the orchestrator handles merging (per caller context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)