### PR TITLE
fix(security): port synology-chat InvalidTokenRateLimiter (#2649 BROAD re-triage)

### DIFF
--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -445,7 +445,12 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
       // Synology Chat outgoing webhooks use a per-integration user_id that may
       // differ from the global Chat API user_id required by method=chatbot.
       // We resolve via the user_list API, matching by nickname/username.
-      const chatUserId = await resolveChatUserId(account.incomingUrl, payload.username, account.allowInsecureSsl, log);
+      const chatUserId = await resolveChatUserId(
+        account.incomingUrl,
+        payload.username,
+        account.allowInsecureSsl,
+        log,
+      );
       if (chatUserId !== undefined) {
         replyUserId = String(chatUserId);
       } else {

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -450,7 +450,8 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
         replyUserId = String(chatUserId);
       } else {
         log?.warn(
-          `Could not resolve Chat API user_id for "${payload.username}" — falling back to webhook user_id ${payload.user_id}. Reply delivery may fail.`,
+          `Could not resolve Chat API user_id for "${payload.username}" — ` +
+            `falling back to webhook user_id ${payload.user_id}. Reply delivery may fail.`,
         );
       }
 

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -263,25 +263,33 @@ function parsePayload(req: IncomingMessage, body: string): SynologyWebhookPayloa
   const queryFields = parseQueryParams(req);
   const headerToken = extractTokenFromHeaders(req);
 
-  const token = pickAlias(bodyFields, ["token"]) ?? pickAlias(queryFields, ["token"]) ?? headerToken;
+  const token =
+    pickAlias(bodyFields, ["token"]) ?? pickAlias(queryFields, ["token"]) ?? headerToken;
   const userId =
-    pickAlias(bodyFields, ["user_id", "userId", "user"]) ?? pickAlias(queryFields, ["user_id", "userId", "user"]);
+    pickAlias(bodyFields, ["user_id", "userId", "user"]) ??
+    pickAlias(queryFields, ["user_id", "userId", "user"]);
   const text =
-    pickAlias(bodyFields, ["text", "message", "content"]) ?? pickAlias(queryFields, ["text", "message", "content"]);
+    pickAlias(bodyFields, ["text", "message", "content"]) ??
+    pickAlias(queryFields, ["text", "message", "content"]);
 
   if (!token || !userId || !text) return null;
 
   return {
     token,
-    channel_id: pickAlias(bodyFields, ["channel_id"]) ?? pickAlias(queryFields, ["channel_id"]) ?? undefined,
-    channel_name: pickAlias(bodyFields, ["channel_name"]) ?? pickAlias(queryFields, ["channel_name"]) ?? undefined,
+    channel_id:
+      pickAlias(bodyFields, ["channel_id"]) ?? pickAlias(queryFields, ["channel_id"]) ?? undefined,
+    channel_name:
+      pickAlias(bodyFields, ["channel_name"]) ??
+      pickAlias(queryFields, ["channel_name"]) ??
+      undefined,
     user_id: userId,
     username:
       pickAlias(bodyFields, ["username", "user_name", "name"]) ??
       pickAlias(queryFields, ["username", "user_name", "name"]) ??
       "unknown",
     post_id: pickAlias(bodyFields, ["post_id"]) ?? pickAlias(queryFields, ["post_id"]) ?? undefined,
-    timestamp: pickAlias(bodyFields, ["timestamp"]) ?? pickAlias(queryFields, ["timestamp"]) ?? undefined,
+    timestamp:
+      pickAlias(bodyFields, ["timestamp"]) ?? pickAlias(queryFields, ["timestamp"]) ?? undefined,
     text,
     trigger_word:
       pickAlias(bodyFields, ["trigger_word", "triggerWord"]) ??

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -16,6 +16,82 @@ import type { SynologyWebhookPayload, ResolvedSynologyChatAccount } from "./type
 
 // One rate limiter per account, created lazily
 const rateLimiters = new Map<string, RateLimiter>();
+const invalidTokenRateLimiters = new Map<string, InvalidTokenRateLimiter>();
+
+const PREAUTH_MAX_REQUESTS_PER_MINUTE = 10;
+const INVALID_TOKEN_WINDOW_MS = 60_000;
+const INVALID_TOKEN_MAX_TRACKED_KEYS = 5_000;
+
+type InvalidTokenRateLimitState = {
+  count: number;
+  windowStartMs: number;
+};
+
+/**
+ * Pre-authentication rate limiter that locks out remote IPs after repeated
+ * invalid-token attempts within a sliding window. Defends against brute-force
+ * token guessing without affecting authenticated users (post-auth budget is
+ * still enforced separately by `RateLimiter`).
+ */
+class InvalidTokenRateLimiter {
+  private readonly limit: number;
+  private readonly state = new Map<string, InvalidTokenRateLimitState>();
+
+  constructor(limit: number) {
+    this.limit = limit;
+  }
+
+  private normalizeState(key: string, nowMs: number): InvalidTokenRateLimitState | undefined {
+    const existing = this.state.get(key);
+    if (!existing) {
+      return undefined;
+    }
+    if (nowMs - existing.windowStartMs >= INVALID_TOKEN_WINDOW_MS) {
+      this.state.delete(key);
+      return undefined;
+    }
+    return existing;
+  }
+
+  private touch(key: string, value: InvalidTokenRateLimitState): void {
+    this.state.delete(key);
+    this.state.set(key, value);
+    while (this.state.size > INVALID_TOKEN_MAX_TRACKED_KEYS) {
+      const oldestKey = this.state.keys().next().value;
+      if (!oldestKey) {
+        break;
+      }
+      this.state.delete(oldestKey);
+    }
+  }
+
+  isLocked(key: string, nowMs = Date.now()): boolean {
+    if (!key) {
+      return false;
+    }
+    const existing = this.normalizeState(key, nowMs);
+    return (existing?.count ?? 0) > this.limit;
+  }
+
+  recordFailure(key: string, nowMs = Date.now()): boolean {
+    if (!key) {
+      return false;
+    }
+    const existing = this.normalizeState(key, nowMs);
+    const nextCount = (existing?.count ?? 0) + 1;
+    const windowStartMs = existing?.windowStartMs ?? nowMs;
+    this.touch(key, { count: nextCount, windowStartMs });
+    return nextCount > this.limit;
+  }
+
+  clear(): void {
+    this.state.clear();
+  }
+
+  maxRequests(): number {
+    return this.limit;
+  }
+}
 
 function getRateLimiter(account: ResolvedSynologyChatAccount): RateLimiter {
   let rl = rateLimiters.get(account.accountId);
@@ -27,15 +103,34 @@ function getRateLimiter(account: ResolvedSynologyChatAccount): RateLimiter {
   return rl;
 }
 
+function getInvalidTokenRateLimiter(account: ResolvedSynologyChatAccount): InvalidTokenRateLimiter {
+  const limit = Math.min(account.rateLimitPerMinute, PREAUTH_MAX_REQUESTS_PER_MINUTE);
+  let rl = invalidTokenRateLimiters.get(account.accountId);
+  if (!rl || rl.maxRequests() !== limit) {
+    rl?.clear();
+    rl = new InvalidTokenRateLimiter(limit);
+    invalidTokenRateLimiters.set(account.accountId, rl);
+  }
+  return rl;
+}
+
+function getSynologyWebhookInvalidTokenRateLimitKey(req: IncomingMessage): string {
+  return req.socket?.remoteAddress ?? "unknown";
+}
+
 export function clearSynologyWebhookRateLimiterStateForTest(): void {
   for (const limiter of rateLimiters.values()) {
     limiter.clear();
   }
   rateLimiters.clear();
+  for (const limiter of invalidTokenRateLimiters.values()) {
+    limiter.clear();
+  }
+  invalidTokenRateLimiters.clear();
 }
 
 export function getSynologyWebhookRateLimiterCountForTest(): number {
-  return rateLimiters.size;
+  return rateLimiters.size + invalidTokenRateLimiters.size;
 }
 
 /** Read the full request body as a string. */
@@ -168,33 +263,25 @@ function parsePayload(req: IncomingMessage, body: string): SynologyWebhookPayloa
   const queryFields = parseQueryParams(req);
   const headerToken = extractTokenFromHeaders(req);
 
-  const token =
-    pickAlias(bodyFields, ["token"]) ?? pickAlias(queryFields, ["token"]) ?? headerToken;
+  const token = pickAlias(bodyFields, ["token"]) ?? pickAlias(queryFields, ["token"]) ?? headerToken;
   const userId =
-    pickAlias(bodyFields, ["user_id", "userId", "user"]) ??
-    pickAlias(queryFields, ["user_id", "userId", "user"]);
+    pickAlias(bodyFields, ["user_id", "userId", "user"]) ?? pickAlias(queryFields, ["user_id", "userId", "user"]);
   const text =
-    pickAlias(bodyFields, ["text", "message", "content"]) ??
-    pickAlias(queryFields, ["text", "message", "content"]);
+    pickAlias(bodyFields, ["text", "message", "content"]) ?? pickAlias(queryFields, ["text", "message", "content"]);
 
   if (!token || !userId || !text) return null;
 
   return {
     token,
-    channel_id:
-      pickAlias(bodyFields, ["channel_id"]) ?? pickAlias(queryFields, ["channel_id"]) ?? undefined,
-    channel_name:
-      pickAlias(bodyFields, ["channel_name"]) ??
-      pickAlias(queryFields, ["channel_name"]) ??
-      undefined,
+    channel_id: pickAlias(bodyFields, ["channel_id"]) ?? pickAlias(queryFields, ["channel_id"]) ?? undefined,
+    channel_name: pickAlias(bodyFields, ["channel_name"]) ?? pickAlias(queryFields, ["channel_name"]) ?? undefined,
     user_id: userId,
     username:
       pickAlias(bodyFields, ["username", "user_name", "name"]) ??
       pickAlias(queryFields, ["username", "user_name", "name"]) ??
       "unknown",
     post_id: pickAlias(bodyFields, ["post_id"]) ?? pickAlias(queryFields, ["post_id"]) ?? undefined,
-    timestamp:
-      pickAlias(bodyFields, ["timestamp"]) ?? pickAlias(queryFields, ["timestamp"]) ?? undefined,
+    timestamp: pickAlias(bodyFields, ["timestamp"]) ?? pickAlias(queryFields, ["timestamp"]) ?? undefined,
     text,
     trigger_word:
       pickAlias(bodyFields, ["trigger_word", "triggerWord"]) ??
@@ -251,11 +338,22 @@ export interface WebhookHandlerDeps {
 export function createWebhookHandler(deps: WebhookHandlerDeps) {
   const { account, deliver, log } = deps;
   const rateLimiter = getRateLimiter(account);
+  const invalidTokenRateLimiter = getInvalidTokenRateLimiter(account);
 
   return async (req: IncomingMessage, res: ServerResponse) => {
     // Only accept POST
     if (req.method !== "POST") {
       respondJson(res, 405, { error: "Method not allowed" });
+      return;
+    }
+
+    // Pre-auth IP-based rate limit: once a source IP has exhausted its
+    // invalid-token budget within the sliding window, reject all further
+    // requests until the window expires. Prevents brute-force token guessing.
+    const invalidTokenRateLimitKey = getSynologyWebhookInvalidTokenRateLimitKey(req);
+    if (invalidTokenRateLimiter.isLocked(invalidTokenRateLimitKey)) {
+      log?.warn(`Rate limit exceeded for remote IP: ${invalidTokenRateLimitKey}`);
+      respondJson(res, 429, { error: "Rate limit exceeded" });
       return;
     }
 
@@ -283,6 +381,11 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
 
     // Token validation
     if (!validateToken(payload.token, account.token)) {
+      if (invalidTokenRateLimiter.recordFailure(invalidTokenRateLimitKey)) {
+        log?.warn(`Rate limit exceeded for remote IP: ${invalidTokenRateLimitKey}`);
+        respondJson(res, 429, { error: "Rate limit exceeded" });
+        return;
+      }
       log?.warn(`Invalid token from ${req.socket?.remoteAddress}`);
       respondJson(res, 401, { error: "Invalid token" });
       return;
@@ -342,12 +445,7 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
       // Synology Chat outgoing webhooks use a per-integration user_id that may
       // differ from the global Chat API user_id required by method=chatbot.
       // We resolve via the user_list API, matching by nickname/username.
-      const chatUserId = await resolveChatUserId(
-        account.incomingUrl,
-        payload.username,
-        account.allowInsecureSsl,
-        log,
-      );
+      const chatUserId = await resolveChatUserId(account.incomingUrl, payload.username, account.allowInsecureSsl, log);
       if (chatUserId !== undefined) {
         replyUserId = String(chatUserId);
       } else {


### PR DESCRIPTION
## Summary

BROAD re-triage execution under the new fork-sync § Phase D.4 EXTRACT Triage Re-Calibration Protocol. v2026.3.28's adversarial audit returned 5/50 = 10% miss rate → BROAD bucket → re-triage of the entire deferred pile.

This PR is the first-deliverable port from that re-triage: the synology-chat InvalidTokenRateLimiter — a defense against brute-force token guessing — was deferred in v2026.3.28 because the file was bucketed COMPLEX-by-divergence (110+/5- diff size, fork has heavy structural divergence from upstream). Per-hunk content reading reveals the security additions are cleanly separable.

## What changed

`extensions/synology-chat/src/webhook-handler.ts`: new `InvalidTokenRateLimiter` class + integration into the existing monolithic handler (preserves fork's structural divergence from upstream). Locks out remote IPs after exceeding their pre-auth invalid-token budget within a 60s sliding window, with bounded state tracking (5000 keys max per account).

The divergence record at `upstream/divergence/extensions/synology-chat/src/webhook-handler.ts.md` (HQ) explicitly recommended this port.

## What did NOT port (preserved as fork divergence)

- Upstream's decomposition into 6 named functions (fork keeps monolithic handler — stated fork intent)
- Body-size tightening (64 KB / 5 s upstream vs fork's 1 MB / 30 s)
- `dangerouslyAllowNameMatching` gating (would require new account field — scope creep)
- `synologyClient` namespace import refactor (cosmetic)

## BROAD re-triage scope

| Scope | Count |
|-------|-------|
| Files in cost-deferred subset (MINOR + COMPLEX buckets) | 456 |
| Files with security-keyword grep hits | 100 |
| Files already ported (W findings via #2640/#2642/#2645/#2648) | 8 |
| Files re-triaged for content classification | 92 |
| Tier A — PORTABLE candidates surfaced | 5 (this PR ports 1) |
| Tier B — NO-OP-confirmed (false positives) | 7 |
| Tier C — SKIP-confirmed (gutted-infra-tied) | ~52 |
| Tier D — Lower-value extension refactors | ~28 |

Detailed re-triage results: `.tmp/sync-v2026.3.28/2649-results.md` (HQ).

## Tier A candidates surfaced for follow-up port-PRs

These were all confirmed PORTABLE during re-triage but were not ported in this PR due to either (a) larger surgical effort needed, or (b) cost-cap discipline:

| File | Pattern | Port effort |
|------|---------|-------------|
| `extensions/telegram/src/webhook.ts` | Trusted-proxy IP resolution + rate limiting (W2-equiv pattern) | ~150 LOC port — fork uses relative `src/...` imports, divergence from upstream's `openclaw/plugin-sdk/*` pattern; needs surgical adaptation |
| `extensions/telegram/src/webhook.test.ts` | Companion test for above | ~150 LOC test port |
| `extensions/synology-chat/src/webhook-handler.test.ts` | New test cases for InvalidTokenRateLimiter | Port new test cases inline (existing 14 tests still pass post-port) |
| `extensions/mattermost/src/mattermost/client.ts` | `fetchWithSsrFGuard` SSRF guard + Zod payload schema validation | ~60 LOC port + Zod schema migration |

These should be ported in a follow-up PR (or split into smaller PRs).

## Test plan

- [x] `pnpm vitest run extensions/synology-chat/src/webhook-handler.test.ts` — 14/14 pass
- [x] `pnpm tsgo` — clean (no type errors)
- [ ] Full CI suite — watch for regressions on merge
- [ ] Auto-merge on green per project convention

## Audit miss-rate calibration

Original v2026.3.28 audit miss rate: **5/50 = 10%** (BROAD bucket).

Final post-port-and-confirm miss rate after this PR + the documented Tier A/B/C classifications: TBD on next adversarial audit run.

For the present submission, the residual 4 PORTABLE candidates are tracked but unported, so they would still be flagged WRONG on any audit that samples them. The follow-up PRs above resolve that.

## Background

- Parent issue: remoteclaw#2637 (v2026.3.28 deferred EXTRACT pile)
- Calibration trigger: remoteclaw#2649 (BROAD re-triage retroactive obligation)
- Original W findings: remoteclaw#2636 (closed, ports landed via #2640/#2642/#2645/#2648)
- Protocol source: `~/.claude/skills/fork-sync/SKILL.md` § Phase D.4 § EXTRACT Triage Re-Calibration Protocol

Closes #2649