### PR TITLE
fix(security): port 4 deferred Tier A security candidates (#2651, #2649 BROAD re-triage)

### DIFF
--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -1,13 +1,22 @@
 import type { RemoteClawConfig } from "remoteclaw/plugin-sdk/mattermost";
 import { createReplyPrefixOptions } from "remoteclaw/plugin-sdk/mattermost";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-const { sendMessageMattermostMock } = vi.hoisted(() => ({
+const { sendMessageMattermostMock, mockFetchGuard } = vi.hoisted(() => ({
   sendMessageMattermostMock: vi.fn(),
+  mockFetchGuard: vi.fn(async (p: { url: string; init?: RequestInit }) => {
+    const response = await globalThis.fetch(p.url, p.init);
+    return { response, release: async () => {}, finalUrl: p.url };
+  }),
 }));
 
 vi.mock("./mattermost/send.js", () => ({
   sendMessageMattermost: sendMessageMattermostMock,
 }));
+
+vi.mock("../../../src/infra/net/fetch-guard.js", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return { ...original, fetchWithSsrFGuard: mockFetchGuard };
+});
 
 import { mattermostPlugin } from "./channel.js";
 import { resetMattermostReactionBotUserCacheForTests } from "./mattermost/reactions.js";

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -1,8 +1,15 @@
+import { z } from "zod";
+import { fetchWithSsrFGuard } from "../../../../src/infra/net/fetch-guard.js";
+
+export type MattermostFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
 export type MattermostClient = {
   baseUrl: string;
   apiBaseUrl: string;
   token: string;
   request: <T>(path: string, init?: RequestInit) => Promise<T>;
+  /** Guarded fetch implementation; use in place of raw fetch for outbound requests. */
+  fetchImpl: MattermostFetch;
 };
 
 export type MattermostUser = {
@@ -21,17 +28,21 @@ export type MattermostChannel = {
   team_id?: string | null;
 };
 
-export type MattermostPost = {
-  id: string;
-  user_id?: string | null;
-  channel_id?: string | null;
-  message?: string | null;
-  file_ids?: string[] | null;
-  type?: string | null;
-  root_id?: string | null;
-  create_at?: number | null;
-  props?: Record<string, unknown> | null;
-};
+export const MattermostPostSchema = z
+  .object({
+    id: z.string(),
+    user_id: z.string().nullable().optional(),
+    channel_id: z.string().nullable().optional(),
+    message: z.string().nullable().optional(),
+    file_ids: z.array(z.string()).nullable().optional(),
+    type: z.string().nullable().optional(),
+    root_id: z.string().nullable().optional(),
+    create_at: z.number().nullable().optional(),
+    props: z.record(z.string(), z.unknown()).nullable().optional(),
+  })
+  .passthrough();
+
+export type MattermostPost = z.infer<typeof MattermostPostSchema>;
 
 export type MattermostFileInfo = {
   id: string;
@@ -73,7 +84,9 @@ export async function readMattermostError(res: Response): Promise<string> {
 export function createMattermostClient(params: {
   baseUrl: string;
   botToken: string;
-  fetchImpl?: typeof fetch;
+  fetchImpl?: MattermostFetch;
+  /** Allow requests to private/internal IPs (self-hosted/LAN deployments). */
+  allowPrivateNetwork?: boolean;
 }): MattermostClient {
   const baseUrl = normalizeMattermostBaseUrl(params.baseUrl);
   if (!baseUrl) {
@@ -81,7 +94,40 @@ export function createMattermostClient(params: {
   }
   const apiBaseUrl = `${baseUrl}/api/v4`;
   const token = params.botToken.trim();
-  const fetchImpl = params.fetchImpl ?? fetch;
+  // When no custom fetchImpl is provided (production path), use an SSRF-guarded wrapper
+  // that validates the target URL before making the request (DNS rebinding protection etc.).
+  // A custom fetchImpl is accepted for testing and special cases.
+  const externalFetchImpl = params.fetchImpl;
+
+  // Guarded fetch adapter: calls fetchWithSsrFGuard and returns a plain Response.
+  // Body is buffered before releasing the dispatcher so callers get a complete Response.
+  // Null-body status codes per Fetch spec — Response constructor rejects a body for these.
+  const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
+
+  const guardedFetchImpl: MattermostFetch = async (input, init) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const { response, release } = await fetchWithSsrFGuard({
+      url,
+      init,
+      auditContext: "mattermost-api",
+      policy: params.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
+    });
+    try {
+      const bodyBytes = NULL_BODY_STATUSES.has(response.status)
+        ? null
+        : await response.arrayBuffer();
+      return new Response(bodyBytes, { status: response.status, headers: response.headers });
+    } finally {
+      await release();
+    }
+  };
+
+  const fetchImpl = externalFetchImpl ?? guardedFetchImpl;
 
   const request = async <T>(path: string, init?: RequestInit): Promise<T> => {
     const url = buildMattermostApiUrl(baseUrl, path);
@@ -110,7 +156,7 @@ export function createMattermostClient(params: {
     return (await res.text()) as T;
   };
 
-  return { baseUrl, apiBaseUrl, token, request };
+  return { baseUrl, apiBaseUrl, token, request, fetchImpl };
 }
 
 export async function fetchMattermostMe(client: MattermostClient): Promise<MattermostUser> {
@@ -513,7 +559,7 @@ export async function uploadMattermostFile(
   form.append("files", blob, fileName);
   form.append("channel_id", params.channelId);
 
-  const res = await fetch(`${client.apiBaseUrl}/files`, {
+  const res = await client.fetchImpl(`${client.apiBaseUrl}/files`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${client.token}`,

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -208,6 +208,125 @@ describe("createWebhookHandler", () => {
     expect(res._status).toBe(401);
   });
 
+  it("rate limits repeated invalid token guesses before the correct token can succeed", async () => {
+    const weakToken = "00000129";
+    const deliver = vi.fn().mockResolvedValue(null);
+    const handler = createWebhookHandler({
+      account: makeAccount({
+        accountId: "weak-token-bruteforce-" + Date.now(),
+        token: weakToken,
+        rateLimitPerMinute: 5,
+      }),
+      deliver,
+      log,
+    });
+
+    let guessedToken: string | null = null;
+    let saw429 = false;
+
+    for (let i = 0; i < 130; i += 1) {
+      const candidate = String(i).padStart(8, "0");
+      const req = makeReq(
+        "POST",
+        makeFormBody({
+          token: candidate,
+          user_id: "123",
+          username: "testuser",
+          text: "Hello bot",
+        }),
+      );
+      (req.socket as { remoteAddress?: string }).remoteAddress = "203.0.113.10";
+      const res = makeRes();
+      await handler(req, res);
+
+      if (res._status === 429) {
+        saw429 = true;
+        break;
+      }
+
+      if (res._status === 204) {
+        guessedToken = candidate;
+        break;
+      }
+
+      expect(res._status).toBe(401);
+    }
+
+    expect(saw429).toBe(true);
+    expect(guessedToken).toBeNull();
+    const lockedReq = makeReq(
+      "POST",
+      makeFormBody({
+        token: weakToken,
+        user_id: "123",
+        username: "testuser",
+        text: "Hello bot",
+      }),
+    );
+    (lockedReq.socket as { remoteAddress?: string }).remoteAddress = "203.0.113.10";
+    const lockedRes = makeRes();
+    await handler(lockedReq, lockedRes);
+
+    expect(lockedRes._status).toBe(429);
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("keeps pre-auth throttling scoped to the remote IP", async () => {
+    const deliver = vi.fn().mockResolvedValue(null);
+    const handler = createWebhookHandler({
+      account: makeAccount({
+        accountId: "preauth-ip-scope-" + Date.now(),
+        rateLimitPerMinute: 1,
+      }),
+      deliver,
+      log,
+    });
+
+    const invalidReq = makeReq(
+      "POST",
+      makeFormBody({
+        token: "wrong-token",
+        user_id: "123",
+        username: "testuser",
+        text: "Hello",
+      }),
+    );
+    (invalidReq.socket as { remoteAddress?: string }).remoteAddress = "203.0.113.10";
+    const invalidRes = makeRes();
+    await handler(invalidReq, invalidRes);
+    expect(invalidRes._status).toBe(401);
+
+    const validReq = makeReq("POST", validBody);
+    (validReq.socket as { remoteAddress?: string }).remoteAddress = "203.0.113.11";
+    const validRes = makeRes();
+    await handler(validReq, validRes);
+
+    expect(validRes._status).toBe(204);
+    expect(deliver).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not spend invalid-token budget on successful requests", async () => {
+    const deliver = vi.fn().mockResolvedValue(null);
+    const handler = createWebhookHandler({
+      account: makeAccount({
+        accountId: "invalid-token-budget-" + Date.now(),
+        rateLimitPerMinute: 30,
+      }),
+      deliver,
+      log,
+    });
+
+    for (let i = 0; i < 11; i += 1) {
+      const req = makeReq("POST", validBody);
+      (req.socket as { remoteAddress?: string }).remoteAddress = "203.0.113.20";
+      const res = makeRes();
+      await handler(req, res);
+      expect(res._status).toBe(204);
+    }
+
+    expect(deliver).toHaveBeenCalledTimes(11);
+  });
+
   it("accepts application/json with alias fields", async () => {
     const deliver = vi.fn().mockResolvedValue(null);
     const handler = createWebhookHandler({

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -3,6 +3,7 @@ import { once } from "node:events";
 import { request, type IncomingMessage } from "node:http";
 import { setTimeout as sleep } from "node:timers/promises";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { WEBHOOK_RATE_LIMIT_DEFAULTS } from "../../../src/plugin-sdk/webhook-memory-guards.js";
 
 const handlerSpy = vi.hoisted(() => vi.fn((..._args: unknown[]): unknown => undefined));
 const setWebhookSpy = vi.hoisted(() => vi.fn());
@@ -24,6 +25,7 @@ const TELEGRAM_SECRET = "secret";
 const TELEGRAM_WEBHOOK_PATH = "/hook";
 const WEBHOOK_TEST_YIELD_MS = 0;
 const WEBHOOK_DRAIN_GUARD_MS = 5;
+const TELEGRAM_WEBHOOK_RATE_LIMIT_BURST = WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests + 10;
 
 function collectResponseBody(
   res: IncomingMessage,
@@ -556,6 +558,148 @@ describe("startTelegramWebhook", () => {
         expect(handlerSpy).not.toHaveBeenCalled();
       },
     );
+  });
+
+  it("rate limits repeated invalid secret guesses before authentication succeeds", async () => {
+    handlerSpy.mockClear();
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+      },
+      async ({ port }) => {
+        let saw429 = false;
+
+        for (let i = 0; i < TELEGRAM_WEBHOOK_RATE_LIMIT_BURST; i += 1) {
+          const response = await postWebhookJson({
+            url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+            payload: JSON.stringify({ update_id: i, message: { text: `guess ${i}` } }),
+            secret: `wrong-secret-${String(i).padStart(3, "0")}`,
+          });
+
+          if (response.status === 429) {
+            saw429 = true;
+            expect(await response.text()).toBe("Too Many Requests");
+            break;
+          }
+
+          expect(response.status).toBe(401);
+          expect(await response.text()).toBe("unauthorized");
+        }
+
+        expect(saw429).toBe(true);
+
+        const validResponse = await postWebhookJson({
+          url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+          payload: JSON.stringify({ update_id: 999, message: { text: "hello" } }),
+          secret: TELEGRAM_SECRET,
+        });
+        expect(validResponse.status).toBe(429);
+        expect(await validResponse.text()).toBe("Too Many Requests");
+        expect(handlerSpy).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it("uses the forwarded client ip when trusted proxies are configured", async () => {
+    handlerSpy.mockClear();
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+        config: {
+          gateway: {
+            trustedProxies: ["127.0.0.1"],
+          },
+        },
+      },
+      async ({ port }) => {
+        for (let i = 0; i < TELEGRAM_WEBHOOK_RATE_LIMIT_BURST; i += 1) {
+          const response = await fetchWithTimeout(
+            webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+            {
+              method: "POST",
+              headers: {
+                "content-type": "application/json",
+                "x-forwarded-for": "198.51.100.10",
+                "x-telegram-bot-api-secret-token": `wrong-secret-${String(i).padStart(3, "0")}`,
+              },
+              body: JSON.stringify({ update_id: i, message: { text: `guess ${i}` } }),
+            },
+            5_000,
+          );
+          if (response.status === 429) {
+            break;
+          }
+          expect(response.status).toBe(401);
+        }
+
+        const isolatedClient = await fetchWithTimeout(
+          webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "x-forwarded-for": "203.0.113.20",
+              "x-telegram-bot-api-secret-token": TELEGRAM_SECRET,
+            },
+            body: JSON.stringify({ update_id: 201, message: { text: "hello" } }),
+          },
+          5_000,
+        );
+
+        expect(isolatedClient.status).toBe(200);
+        expect(handlerSpy).toHaveBeenCalledTimes(1);
+      },
+    );
+  });
+
+  it("keeps rate-limit state isolated per webhook listener", async () => {
+    handlerSpy.mockClear();
+    const firstAbort = new AbortController();
+    const secondAbort = new AbortController();
+    const first = await startTelegramWebhook({
+      token: TELEGRAM_TOKEN,
+      port: 0,
+      abortSignal: firstAbort.signal,
+      secret: TELEGRAM_SECRET,
+      path: TELEGRAM_WEBHOOK_PATH,
+    });
+    const second = await startTelegramWebhook({
+      token: TELEGRAM_TOKEN,
+      port: 0,
+      abortSignal: secondAbort.signal,
+      secret: TELEGRAM_SECRET,
+      path: TELEGRAM_WEBHOOK_PATH,
+    });
+
+    try {
+      const firstPort = getServerPort(first.server);
+      const secondPort = getServerPort(second.server);
+
+      for (let i = 0; i < TELEGRAM_WEBHOOK_RATE_LIMIT_BURST; i += 1) {
+        const response = await postWebhookJson({
+          url: webhookUrl(firstPort, TELEGRAM_WEBHOOK_PATH),
+          payload: JSON.stringify({ update_id: i, message: { text: `guess ${i}` } }),
+          secret: `wrong-secret-${String(i).padStart(3, "0")}`,
+        });
+        if (response.status === 429) {
+          break;
+        }
+      }
+
+      const secondResponse = await postWebhookJson({
+        url: webhookUrl(secondPort, TELEGRAM_WEBHOOK_PATH),
+        payload: JSON.stringify({ update_id: 301, message: { text: "hello" } }),
+        secret: TELEGRAM_SECRET,
+      });
+
+      expect(secondResponse.status).toBe(200);
+      expect(handlerSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      firstAbort.abort();
+      secondAbort.abort();
+    }
   });
 
   it("rejects startup when webhook secret is missing", async () => {

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -1,7 +1,9 @@
 import { timingSafeEqual } from "node:crypto";
 import { createServer } from "node:http";
+import type { IncomingMessage } from "node:http";
 import { InputFile, webhookCallback } from "grammy";
 import type { RemoteClawConfig } from "../../../src/config/config.js";
+import { resolveRequestClientIp } from "../../../src/gateway/net.js";
 import { isDiagnosticsEnabled } from "../../../src/infra/diagnostic-events.js";
 import { formatErrorMessage } from "../../../src/infra/errors.js";
 import { readJsonBodyWithLimit } from "../../../src/infra/http-body.js";
@@ -12,6 +14,11 @@ import {
   startDiagnosticHeartbeat,
   stopDiagnosticHeartbeat,
 } from "../../../src/logging/diagnostic.js";
+import {
+  createFixedWindowRateLimiter,
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
+} from "../../../src/plugin-sdk/webhook-memory-guards.js";
+import { applyBasicWebhookRequestGuards } from "../../../src/plugin-sdk/webhook-request-guards.js";
 import type { RuntimeEnv } from "../../../src/runtime.js";
 import { defaultRuntime } from "../../../src/runtime.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
@@ -97,6 +104,20 @@ function hasValidTelegramWebhookSecret(
   return actual.length === expected.length && timingSafeEqual(actual, expected);
 }
 
+function resolveTelegramWebhookRateLimitKey(
+  req: IncomingMessage,
+  path: string,
+  config?: RemoteClawConfig,
+): string {
+  const clientIp =
+    resolveRequestClientIp(
+      req,
+      config?.gateway?.trustedProxies,
+      config?.gateway?.allowRealIpFallback === true,
+    ) ?? "unknown";
+  return `${path}:${clientIp}`;
+}
+
 export async function startTelegramWebhook(opts: {
   token: string;
   accountId?: string;
@@ -137,6 +158,11 @@ export async function startTelegramWebhook(opts: {
     runtime,
     abortSignal: opts.abortSignal,
   });
+  const telegramWebhookRateLimiter = createFixedWindowRateLimiter({
+    windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs,
+    maxRequests: WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests,
+    maxTrackedKeys: WEBHOOK_RATE_LIMIT_DEFAULTS.maxTrackedKeys,
+  });
   const handler = webhookCallback(bot, "callback", {
     secretToken: secret,
     onTimeout: "return",
@@ -164,6 +190,18 @@ export async function startTelegramWebhook(opts: {
     if (req.url !== path || req.method !== "POST") {
       res.writeHead(404);
       res.end();
+      return;
+    }
+    // Apply the per-source limit before auth so invalid secret guesses consume budget
+    // in the same window as any later request from that source.
+    if (
+      !applyBasicWebhookRequestGuards({
+        req,
+        res,
+        rateLimiter: telegramWebhookRateLimiter,
+        rateLimitKey: resolveTelegramWebhookRateLimitKey(req, path, opts.config),
+      })
+    ) {
       return;
     }
     const startTime = Date.now();


### PR DESCRIPTION
## Summary

Lands the 4 remaining Tier A security ports surfaced by #2649's BROAD re-triage. Item 1 (synology-chat `InvalidTokenRateLimiter`) was ported in #2650 (merged 2026-05-01 09:21Z); this PR completes items 2-5.

| # | File | Pattern |
|---|------|---------|
| A | `extensions/synology-chat/src/webhook-handler.test.ts` | Companion tests for #2650's port |
| B | `extensions/telegram/src/webhook.ts` | Trusted-proxy IP resolution + rate limiting |
| C | `extensions/telegram/src/webhook.test.ts` | Companion test for B |
| D | `extensions/mattermost/src/mattermost/client.ts` (+ `extensions/mattermost/src/channel.test.ts`) | `fetchWithSsrFGuard` + Zod payload schema; companion test mock so `withMockedGlobalFetch` continues to work |

## Audit miss-rate impact

After this PR: 4 → 0 of 50 = **0% (ACCEPT band)** for v2026.3.28's BROAD re-triage. Closes #2649's miss-rate calibration cycle and resolves #2651.

## Notes

- One commit per port for review clarity (matches #2650 precedent).
- Telegram webhook port adapts `openclaw/plugin-sdk/*` imports to fork's relative `../../../src/...` convention. Reuses fork's existing `resolveRequestClientIp` from `src/gateway/net.ts` instead of duplicating upstream's inline IP-parsing helpers.
- Mattermost client port migrates the payload type to a Zod schema (`MattermostPostSchema`) and routes outbound API fetches through the fork's existing `fetchWithSsrFGuard` (`src/infra/net/fetch-guard.js`).
- Mattermost `channel.test.ts` gets a companion mock for `fetchWithSsrFGuard` that delegates back to `globalThis.fetch` — required because the existing reactions tests already mock `globalThis.fetch` via `withMockedGlobalFetch`. Mirrors upstream commit f92c92515b's test adaptation.
- All 4 commits use `--no-verify` to work around oxfmt 0.38.0 platform-divergence (#2653); files were formatted via `docker linux/amd64 oxfmt --write` and verified with `oxfmt --check`. CI is the authoritative format gate.
- Verified locally in linux/amd64 docker: `tsgo` clean, `oxfmt --check` clean on all 4 files, all per-extension tests pass (synology-chat 17/17, telegram webhook 16/16, mattermost client 19/19, mattermost channel 18/18). Broader mattermost suite shows 3 failures pre-existing on origin/main (interactions.test.ts × 2, reply-delivery.test.ts × 1), unrelated to this PR.

Closes #2651
Closes #2649

🤖 Generated with [Claude Code](https://claude.com/claude-code)