### PR TITLE
chore: update upstreamVersion to v2026.3.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -438,5 +438,5 @@
     ]
   },
   "upstreamRepo": "openclaw/openclaw",
-  "upstreamVersion": "2026.3.28"
+  "upstreamVersion": "2026.3.31"
 }


### PR DESCRIPTION
Bump upstream version markers to follow PR #2655 (sync to v2026.3.31).

- `package.json` `upstreamVersion`: `2026.3.28` → `2026.3.31`

(README upstream badge was updated as part of PR #2655.)

Standard post-sync chore. v2026.3.28 used the same pattern (#2635).