### PR TITLE
chore: set explicit printWidth in .oxfmtrc.jsonc (workaround oxfmt darwin-arm64 bug)

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -6,6 +6,14 @@
   "experimentalSortPackageJson": {
     "sortScripts": true,
   },
+  // printWidth is set explicitly to work around an oxfmt 0.38.0 darwin-arm64
+  // binding bug: the Mac native binding ignores the documented default (100)
+  // and leaves long lines unwrapped, while Linux bindings correctly wrap at
+  // 100. Without this explicit value, every sync from upstream forces a
+  // 2949-file format reflow on CI (Linux) that local Mac dev cannot reproduce.
+  // Setting the value matches the documented default, so Linux behavior is
+  // unchanged.
+  "printWidth": 100,
   "tabWidth": 2,
   "useTabs": false,
   "ignorePatterns": [


### PR DESCRIPTION
Workaround for an oxfmt 0.38.0 darwin-arm64 binding bug.

## Bug

Mac native binding (\`@oxfmt/binding-darwin-arm64@0.38.0\`) ignores the documented default \`printWidth: 100\` and leaves long lines unwrapped, while Linux bindings correctly wrap at 100.

## Impact (pre-fix)

Every upstream sync forces a ~2949-file format reflow on CI (Linux) that local Mac dev cannot reproduce. Confirmed during #2655: dispatch 1 squash committed Mac-formatted code; dispatch 3 spent a fixup commit (\`d8f2ba7204\`) reformatting 2949 files via Linux Docker because CI rejected them.

## Verification (on darwin-arm64)

- Without this fix: \`pnpm format:check\` fails on 2947 files
- With this fix: \`pnpm format:check\` passes (5131 files, all match)

## Linux behavior unchanged

100 IS the documented default; setting it explicitly only changes behavior on platforms where the binding default-handling is buggy.

## Trade-off

1-line fork divergence in \`.oxfmtrc.jsonc\` vs ~2949-file divergence per sync. Net win.

## Note

The \`upstreamVersion\` bump originally bundled into this PR was already applied via #2656; rebase dropped that hunk cleanly. This PR now contains only the printWidth fix.