### PR TITLE
chore: rebrand OpenClaw* function/test-mock symbols to RemoteClaw* (#2659)

### DIFF
--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -94,7 +94,7 @@ function hasGatewayServiceMarker(content: string): boolean {
   );
 }
 
-function isOpenClawGatewayLaunchdService(label: string, contents: string): boolean {
+function isRemoteClawGatewayLaunchdService(label: string, contents: string): boolean {
   if (hasGatewayServiceMarker(contents)) {
     return true;
   }
@@ -105,7 +105,7 @@ function isOpenClawGatewayLaunchdService(label: string, contents: string): boole
   return label.startsWith("org.remoteclaw.");
 }
 
-function isOpenClawGatewaySystemdService(name: string, contents: string): boolean {
+function isRemoteClawGatewaySystemdService(name: string, contents: string): boolean {
   if (hasGatewayServiceMarker(contents)) {
     return true;
   }
@@ -115,7 +115,7 @@ function isOpenClawGatewaySystemdService(name: string, contents: string): boolea
   return contents.toLowerCase().includes("gateway");
 }
 
-function isOpenClawGatewayTaskName(name: string): boolean {
+function isRemoteClawGatewayTaskName(name: string): boolean {
   const normalized = name.trim().toLowerCase();
   if (!normalized) {
     return false;
@@ -225,7 +225,7 @@ async function scanLaunchdDir(params: {
     if (isIgnoredLaunchdLabel(label)) {
       continue;
     }
-    if (marker === "remoteclaw" && isOpenClawGatewayLaunchdService(label, contents)) {
+    if (marker === "remoteclaw" && isRemoteClawGatewayLaunchdService(label, contents)) {
       continue;
     }
     results.push({
@@ -257,7 +257,7 @@ async function scanSystemdDir(params: {
     if (!marker) {
       continue;
     }
-    if (marker === "remoteclaw" && isOpenClawGatewaySystemdService(name, contents)) {
+    if (marker === "remoteclaw" && isRemoteClawGatewaySystemdService(name, contents)) {
       continue;
     }
     results.push({
@@ -410,7 +410,7 @@ export async function findExtraGatewayServices(
       if (!name) {
         continue;
       }
-      if (isOpenClawGatewayTaskName(name)) {
+      if (isRemoteClawGatewayTaskName(name)) {
         continue;
       }
       const lowerName = name.toLowerCase();

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => ({
   resolveMessageChannelSelection: vi.fn(),
   sendPoll: vi.fn(async () => ({ messageId: "poll-1" })),
   getChannelPlugin: vi.fn(),
-  loadOpenClawPlugins: vi.fn(),
+  loadRemoteClawPlugins: vi.fn(),
   applyPluginAutoEnable: vi.fn(),
 }));
 
@@ -64,7 +64,7 @@ vi.mock("../../config/plugin-auto-enable.js", () => ({
 }));
 
 vi.mock("../../plugins/loader.js", () => ({
-  loadOpenClawPlugins: mocks.loadOpenClawPlugins,
+  loadRemoteClawPlugins: mocks.loadRemoteClawPlugins,
 }));
 
 vi.mock("../../infra/outbound/targets.js", () => ({

--- a/src/shared/node-match.ts
+++ b/src/shared/node-match.ts
@@ -36,7 +36,7 @@ function formatNodeCandidateLabel(node: NodeMatchCandidate): string {
   return `${label} [${details.join(", ")}]`;
 }
 
-function isCurrentOpenClawClient(clientId: string | undefined): boolean {
+function isCurrentRemoteClawClient(clientId: string | undefined): boolean {
   const normalized = clientId?.trim().toLowerCase() ?? "";
   return normalized.startsWith("remoteclaw-");
 }
@@ -49,7 +49,7 @@ function isLegacyClawdbotClient(clientId: string | undefined): boolean {
 function pickPreferredLegacyMigrationMatch(
   matches: NodeMatchCandidate[],
 ): NodeMatchCandidate | undefined {
-  const current = matches.filter((match) => isCurrentOpenClawClient(match.clientId));
+  const current = matches.filter((match) => isCurrentRemoteClawClient(match.clientId));
   if (current.length !== 1) {
     return undefined;
   }
@@ -86,7 +86,7 @@ function scoreNodeCandidate(node: NodeMatchCandidate, matchScore: number): numbe
   if (node.connected === true) {
     score += 100;
   }
-  if (isCurrentOpenClawClient(node.clientId)) {
+  if (isCurrentRemoteClawClient(node.clientId)) {
     score += 10;
   } else if (isLegacyClawdbotClient(node.clientId)) {
     score -= 10;


### PR DESCRIPTION
Three function/mock symbols introduced by upstream sync v2026.3.31 carried upstream OpenClaw naming despite checking RemoteClaw values in their bodies. Rebrands the symbol names to match the body semantics + production exports.

## Changes

| File | Symbol | Issue |
|------|--------|-------|
| \`src/daemon/inspect.ts\` | \`isOpenClawGatewayLaunchdService\` → \`isRemoteClawGatewayLaunchdService\` | body checks \`org.remoteclaw.\` prefix |
| \`src/daemon/inspect.ts\` | \`isOpenClawGatewaySystemdService\` → \`isRemoteClawGatewaySystemdService\` | body checks \`remoteclaw-gateway\` prefix |
| \`src/daemon/inspect.ts\` | \`isOpenClawGatewayTaskName\` → \`isRemoteClawGatewayTaskName\` | body checks \`remoteclaw gateway\` prefix |
| \`src/shared/node-match.ts\` | \`isCurrentOpenClawClient\` → \`isCurrentRemoteClawClient\` | body checks \`remoteclaw-\` prefix |
| \`src/gateway/server-methods/send.test.ts\` | \`loadOpenClawPlugins\` → \`loadRemoteClawPlugins\` | **functional bug** — mock targeted wrong export name; production exports \`loadRemoteClawPlugins\` (per \`src/plugins/loader.ts:450\`) |

## Verification

- \`pnpm tsgo\`: 0 errors
- \`pnpm lint\`: 0 warnings, 0 errors

## Impact

\`send.test.ts\` was a functional bug: the mock replaced \`../../plugins/loader.js\` exports with only \`loadOpenClawPlugins\`, but the real module exports \`loadRemoteClawPlugins\`. Code under test importing \`loadRemoteClawPlugins\` from this module would have resolved to \`undefined\` — the test was silently broken (or relying on the mock not actually being needed by the code path under test).

The other 4 rebrand misses (inspect.ts × 3, node-match.ts × 1) are non-functional but inconsistent: function NAMES say \`OpenClaw\` while function BODIES check \`RemoteClaw\` values. Cleanup harmonizes naming with the rest of the fork.

## D.7 Baseline Cleanup

The corresponding D.7 baseline entries D1-011, D1-012, D1-013 in \`upstream/audit-baseline.tsv\` (HQ) can now be removed in the next D.7 invocation as CLEARED.

Closes #2659