### PR TITLE
test(config): un-skip U5b tilde-expansion assertion — defensive sync skip

### DIFF
--- a/src/config/config.nix-integration-u3-u5-u9.test.ts
+++ b/src/config/config.nix-integration-u3-u5-u9.test.ts
@@ -126,7 +126,7 @@ describe("Nix integration (U3, U5, U9)", () => {
   });
 
   describe("U5b: tilde expansion for config paths", () => {
-    it.skip("expands ~ in common path-ish config fields", async () => {
+    it("expands ~ in common path-ish config fields", async () => {
       await withTempHome(async (home) => {
         const configDir = path.join(home, ".remoteclaw");
         await fs.mkdir(configDir, { recursive: true });


### PR DESCRIPTION
## Summary

Closes #2667. The v2026.4.2 upstream sync (`477212d342`) defensively marked the `U5b` assertion in `src/config/config.nix-integration-u3-u5-u9.test.ts` as `it.skip`, citing tightened plugin discovery rejecting the fixture's plugin directory. Forensics show the skip was unnecessary — the fixture already includes a `remoteclaw.plugin.json` manifest (since `22bdcde16f`, April 8 2026) and an `index.js` entry point that satisfies the fallback in `discoverFromPath`. The test passes deterministically when un-skipped.

## Forensic detail

- `git show 477212d342 -- src/config/config.nix-integration-u3-u5-u9.test.ts` reveals the sync commit changed **only** `it(...)` → `it.skip(...)` — the fixture body was unchanged.
- `discoverFromPath` (`src/plugins/discovery.ts:524-638`) for a directory:
  1. Reads `package.json` for `remoteclaw.extensions[]` (absent here → null).
  2. Falls back to scanning `DEFAULT_PLUGIN_ENTRY_CANDIDATES` (`index.{ts,js,mjs,cjs}`) — fixture's `index.js` satisfies this.
- `remoteclaw.plugin.json` is consumed at plugin LOAD time via `loadPluginManifest` (`src/plugins/manifest.ts:45-119`), not during the config-load that this test exercises. So the manifest contract was orthogonal to the test all along.
- The error message cited in the issue (`extension entry escapes package directory: ./index.ts`) is only produced when `package.json` declares `remoteclaw.extensions[]` and an entry escapes the package root. Our fixture has no `package.json`, so that code path cannot fire.

## What changed

One line: `it.skip("expands ~ in common path-ish config fields", ...)` → `it(...)`.

## Test plan

- [x] `pnpm exec vitest run --config vitest.unit.config.ts src/config/config.nix-integration-u3-u5-u9.test.ts` → 19/19 pass.
- [x] Same with `REMOTECLAW_TEST_WORKERS=2` → 19/19 pass.
- [x] 5 consecutive single-test runs → 5/5 pass (no flakiness).
- [x] Full `src/config/` suite (784 tests, 4 unrelated skips) → all pass.
- [x] `pnpm check` (format + tsgo + oxlint + sentinels + css-drift) → clean.
- [ ] CI: \`build\`, \`test\`, \`test-ui-smoke\`, \`lint\`, \`docs\`, fork-integrity gates.

## Out of scope

- Documenting the `remoteclaw.plugin.json` contract in plugin-authoring docs (issue AC #4): plugin-authoring docs are gutted per CLAUDE.md § Fork Context. The contract is internal; the fixture itself serves as test-level documentation.

---

Dispatched by `/do-all` batch `20260513-46ba` (track 2667).