### PR TITLE
docs(sessions): PROTECTED divergence for session-key-utils — channelHint approach kept (#2666)

### DIFF
--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -1,3 +1,42 @@
+// PROTECTED fork divergence — do not port upstream `bea53d7a3f` (#58400).
+//
+// Upstream moved bootstrap session-grammar parsing out of this module and into
+// plugin-owned `session-key-api.ts` / `session-conversation.ts` surfaces, with
+// dispatch through `src/channels/plugins/session-conversation.ts` and the
+// `loadBundledPluginPublicSurfaceModuleSync` plugin-SDK facade-runtime loader.
+// RemoteClaw cannot adopt that pattern as-is:
+//
+//   1. `src/plugin-sdk/facade-runtime.ts` and
+//      `src/plugins/bundled-plugin-metadata.ts` (the loader + path resolver
+//      the upstream dispatch relies on) are gutted in this fork as part of
+//      the Pi-era plugin-marketplace removal. The fork retains only
+//      `bundled-plugin-metadata.generated.ts`, which exposes a different
+//      surface that does not back the plugin-public-surface loader.
+//
+//   2. `ChannelMessagingAdapter` (`src/channels/plugins/types.core.ts`) is
+//      deliberately minimal in this fork (`normalizeTarget`, `targetResolver`,
+//      `formatTargetDisplay`). Upstream's port adds
+//      `resolveSessionConversation` and `resolveParentConversationCandidates`
+//      hooks plus a per-plugin `session-key-api.ts` artifact, neither of
+//      which has an analogue here.
+//
+//   3. `parseSessionConversationRef` (the function upstream renames to
+//      `parseRawSessionConversationRef`) has no fork callers. Only
+//      `parseThreadSessionSuffix` is used (by `config/sessions/reset.ts` and
+//      `config/sessions/delivery-info.ts`), and the channelHint-based
+//      implementation correctly handles Telegram's `:topic:` marker (see
+//      `src/routing/session-key.test.ts`).
+//
+// Net: porting `bea53d7a3f` would require resurrecting gutted plugin-SDK
+// infrastructure, expanding the channel-plugin adapter surface, and adding
+// a per-adapter session-grammar artifact — all for zero functional gain
+// over the existing channelHint approach. The disposition is PROTECTED in
+// `hq/upstream/disposition.tsv`; future syncs MUST NOT re-port this file
+// from upstream without first either (a) reversing the plugin-SDK gut, or
+// (b) re-evaluating this rationale.
+//
+// Tracked-by: remoteclaw#2666. Paired sync revert: 477212d342 (sync v2026.4.2).
+
 export type ParsedAgentSessionKey = {
   agentId: string;
   rest: string;


### PR DESCRIPTION
## Summary

Closes #2666. Adopts the **PROTECTED** path from the issue's decision matrix: keep the fork's channelHint-based `parseThreadSessionSuffix`; reject the upstream `bea53d7a3f` plugin-owned session-grammar refactor; document the divergence rationale in a header comment block.

## Decision: PROTECTED (over port)

The fork's plugin-SDK divergence makes the port path unworkable. Specifically:

| Dependency upstream needs | Fork state |
|---|---|
| `src/plugin-sdk/facade-runtime.ts` (`loadBundledPluginPublicSurfaceModuleSync`) | **Gutted** (Pi-era plugin marketplace removal) |
| `src/plugins/bundled-plugin-metadata.ts` (`resolveBundledPluginPublicSurfacePath`) | **Gutted**; only `.generated.ts` exposes a different surface |
| `ChannelMessagingAdapter.resolveSessionConversation` + `resolveParentConversationCandidates` | **Not in fork types**; adapter is intentionally minimal (`normalizeTarget` / `targetResolver` / `formatTargetDisplay` only) |
| Per-plugin `session-key-api.ts` + `session-conversation.ts` artifacts | **Not in fork**; none of the 31 extensions in `extensions/` have these |

### Functional analysis

- `parseSessionConversationRef` (the function upstream renames to `parseRawSessionConversationRef`) has **zero fork callers**.
- Only `parseThreadSessionSuffix` is consumed: by `src/config/sessions/reset.ts` and `src/config/sessions/delivery-info.ts`.
- Telegram's `:topic:` marker — the only channel-specific grammar currently in play — is correctly handled by the existing channelHint approach and verified by `src/routing/session-key.test.ts` (45 tests pass).

### Cost asymmetry

| Path | Concrete work |
|---|---|
| **Port** | Resurrect `facade-runtime.ts` + `bundled-plugin-metadata.ts`; expand `ChannelMessagingAdapter` surface; create `src/channels/plugins/session-conversation.ts` (~277 lines); add `session-conversation.ts` + `session-key-api.ts` artifacts to each channel adapter that needs custom grammar; update tests. Net architectural alignment gain only; zero functional gain. |
| **PROTECTED (this PR)** | Header comment block + paired registry entry in `hq/upstream/disposition.tsv`. |

Per the merge note in `477212d342`: _"Without the plugin registry refactor in fork, the simplified upstream version drops Telegram :topic: parsing. ... leave plugin-registry port for follow-up."_ This PR resolves that follow-up by formalizing the keep decision.

## Changes

- `src/sessions/session-key-utils.ts`: 39-line header comment block documenting the divergence rationale, the specific upstream commit (`bea53d7a3f` / #58400), the specific fork artifacts that are gutted, and the conditions under which a future port could be re-considered. References `src/routing/session-key.test.ts` for behavioral coverage.

## Follow-up (out of this PR's repo scope)

The sibling **`hq/upstream/disposition.tsv`** registry needs a paired row:

\`\`\`
PROTECTED	src/sessions/session-key-utils.ts	fork-only: channelHint parseThreadSessionSuffix kept; upstream bea53d7a3f plugin-owned grammar needs gutted plugin-SDK infrastructure (#2666)
\`\`\`

Suggested insertion: alongside the existing \`EXTRACT src/sessions/types.ts\` row in the "De-forking audit — gutted subsystem re-introduction prevention" section (line ~133). This blocks future syncs from auto-classifying the file as INCLUDE under the directory-level \`INCLUDE src/sessions/\` rule (file-level beats directory per \`hq/scripts/classify.py\` precedence rules).

## Test plan

- [x] \`pnpm tsgo\` — passes (no new type errors)
- [x] \`pnpm vitest run src/routing/session-key.test.ts\` — 45/45 tests pass (channelHint behavior unchanged; comment-only addition)
- [x] \`pnpm format src/sessions/session-key-utils.ts\` — clean
- [x] \`pnpm canvas:a2ui:bundle\` — successful
- [ ] CI on push (build, test, lint, docs, fork-integrity gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)