### PR TITLE
chore(config): re-apply v2026.4.2 schema.help/labels additions lost in sync revert (#2665)

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -307,7 +307,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.exec":
     "Exec-tool policy grouping for shell execution host, security mode, approval behavior, and runtime bindings. Keep conservative defaults in production and tighten elevated execution paths.",
   "tools.exec.host":
-    "Selects execution host strategy for shell commands, typically controlling local vs delegated execution environment. Use the safest host mode that still satisfies your automation requirements.",
+    'Selects execution target strategy for shell commands. Use "auto" for runtime-aware behavior (sandbox when available, otherwise gateway), or pin sandbox/gateway/node explicitly when you need a fixed surface.',
   "tools.exec.security":
     "Execution security posture selector controlling sandbox/approval expectations for command execution. Keep strict security mode for untrusted prompts and relax only for trusted operator workflows.",
   "tools.exec.ask":
@@ -432,6 +432,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Extra node.invoke commands to allow beyond the gateway defaults (array of command strings). Enabling dangerous commands here is a security-sensitive override and is flagged by `remoteclaw security audit`.",
   "gateway.nodes.denyCommands":
     "Node command names to block even if present in node claims or default allowlist (exact command-name matching only, e.g. `system.run`; does not inspect shell text inside that command).",
+  "gateway.webchat.chatHistoryMaxChars":
+    "Max characters per text field in chat.history responses before truncation (default: 12000).",
   nodeHost:
     "Node host controls for features exposed from this gateway node to other nodes or clients. Keep defaults unless you intentionally proxy local capabilities across your node network.",
   "nodeHost.browserProxy":
@@ -639,13 +641,30 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.message.crossContext.marker.suffix":
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
-  "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
+  "tools.web.search.enabled":
+    "Enable managed web_search and optional Codex-native search for eligible models.",
   "tools.web.search.provider":
     'Search provider ("brave", "gemini", "grok", "kimi", or "perplexity"). Auto-detected from available API keys if omitted.',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
   "tools.web.search.cacheTtlMinutes": "Cache TTL in minutes for web_search results.",
+  "tools.web.search.openaiCodex.enabled":
+    "Enable native Codex web search for Codex-capable models.",
+  "tools.web.search.openaiCodex.mode":
+    'Native Codex web search mode: "cached" (default) or "live".',
+  "tools.web.search.openaiCodex.allowedDomains":
+    "Optional domain allowlist passed to the native Codex web_search tool.",
+  "tools.web.search.openaiCodex.contextSize":
+    'Native Codex search context size hint: "low", "medium", or "high".',
+  "tools.web.search.openaiCodex.userLocation.country":
+    "Approximate country sent to native Codex web search.",
+  "tools.web.search.openaiCodex.userLocation.region":
+    "Approximate region/state sent to native Codex web search.",
+  "tools.web.search.openaiCodex.userLocation.city":
+    "Approximate city sent to native Codex web search.",
+  "tools.web.search.openaiCodex.userLocation.timezone":
+    "Approximate timezone sent to native Codex web search.",
   "tools.web.search.brave.mode":
     'Brave Search mode: "web" (URL results) or "llm-context" (pre-extracted page content for LLM grounding).',
   "tools.web.search.gemini.apiKey":
@@ -668,6 +687,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.fetch.maxChars": "Max characters returned by web_fetch (truncated).",
   "tools.web.fetch.maxCharsCap":
     "Hard cap for web_fetch maxChars (applies to config and tool calls).",
+  "tools.web.fetch.provider": "Web fetch fallback provider id.",
   "tools.web.fetch.timeoutSeconds": "Timeout in seconds for web_fetch requests.",
   "tools.web.fetch.cacheTtlMinutes": "Cache TTL in minutes for web_fetch results.",
   "tools.web.fetch.maxRedirects": "Maximum redirects allowed for web_fetch (default: 3).",
@@ -745,6 +765,12 @@ export const FIELD_HELP: Record<string, string> = {
     "Optional per-provider overrides for billing backoff (hours).",
   "auth.cooldowns.billingMaxHours": "Cap (hours) for billing backoff (default: 24).",
   "auth.cooldowns.failureWindowHours": "Failure window (hours) for backoff counters (default: 24).",
+  "auth.cooldowns.overloadedProfileRotations":
+    "Maximum same-provider auth-profile rotations allowed for overloaded errors before switching to model fallback (default: 1).",
+  "auth.cooldowns.overloadedBackoffMs":
+    "Fixed delay in milliseconds before retrying an overloaded provider/profile rotation (default: 0).",
+  "auth.cooldowns.rateLimitedProfileRotations":
+    "Maximum same-provider auth-profile rotations allowed for rate-limit errors before switching to model fallback (default: 1).",
   "agents.defaults.workspace":
     "Default workspace path exposed to agent runtime tools for filesystem context and repo-aware behavior. Set this explicitly when running from wrappers so path resolution stays deterministic.",
   "agents.defaults.bootstrapMaxChars":
@@ -777,6 +803,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Automatically starts the mcporter daemon when mcporter-backed QMD mode is enabled (default: true). Keep enabled unless process lifecycle is managed externally by your service supervisor.",
   "memory.qmd.searchMode":
     'Selects the QMD retrieval path: "query" uses standard query flow, "search" uses search-oriented retrieval, and "vsearch" emphasizes vector retrieval. Keep default unless tuning relevance quality.',
+  "memory.qmd.searchTool":
+    "Overrides the exact mcporter tool name used for QMD searches while preserving `searchMode` as the semantic retrieval mode. Use this only when your QMD MCP server exposes a custom tool such as `hybrid_search` and keep it unset for the normal built-in tool mapping.",
   "memory.qmd.includeDefaultMemory":
     "Automatically indexes default memory files (MEMORY.md and memory/**/*.md) into QMD collections. Keep enabled unless you want indexing controlled only through explicit custom paths.",
   "memory.qmd.paths":
@@ -919,6 +947,8 @@ export const FIELD_HELP: Record<string, string> = {
     'AGENTS.md H2/H3 section names re-injected after compaction so the agent reruns critical startup guidance. Leave unset to use "Session Startup"/"Red Lines" with legacy fallback to "Every Session"/"Safety"; set to [] to disable reinjection entirely.',
   "agents.defaults.compaction.model":
     "Optional provider/model override used only for compaction summarization. Set this when you want compaction to run on a different model than the session default, and leave it unset to keep using the primary agent model.",
+  "agents.defaults.compaction.notifyUser":
+    "When enabled, sends a brief compaction notice to the user (e.g. '🧹 Compacting context...') when compaction starts. Disabled by default to keep compaction silent and non-intrusive.",
   "agents.defaults.compaction.memoryFlush":
     "Pre-compaction memory flush settings that run an agentic memory write before heavy compaction. Keep enabled for long sessions so salient context is persisted before aggressive trimming.",
   "agents.defaults.compaction.memoryFlush.enabled":
@@ -1235,24 +1265,38 @@ export const FIELD_HELP: Record<string, string> = {
     "Text-to-speech policy for reading agent replies aloud on supported voice or audio surfaces. Keep disabled unless voice playback is part of your operator/user workflow.",
   channels:
     "Channel provider configurations plus shared defaults that control access policies, heartbeat visibility, and per-surface behavior. Keep defaults centralized and override per provider only where required.",
+  // fork-keep block — the per-channel anchor entries below
+  // (telegram, slack, discord, whatsapp, signal, imessage, bluebubbles, msteams, irc)
+  // are fork-retained KEEP-layer rows. Upstream has removed these or may remove
+  // them in future syncs; the fork restores/maintains them. See #2665.
+  // Any upstream sync MUST preserve these rows (and their per-row `// fork-keep` markers).
+  // fork-keep #2665
   "channels.telegram":
     "Telegram channel provider configuration including auth tokens, retry behavior, and message rendering controls. Use this section to tune bot behavior for Telegram-specific API semantics.",
+  // fork-keep #2665
   "channels.slack":
     "Slack channel provider configuration for bot/app tokens, streaming behavior, and DM policy controls. Keep token handling and thread behavior explicit to avoid noisy workspace interactions.",
+  // fork-keep #2665
   "channels.discord":
     "Discord channel provider configuration for bot auth, retry policy, streaming, thread bindings, and optional voice capabilities. Keep privileged intents and advanced features disabled unless needed.",
+  // fork-keep #2665
   "channels.whatsapp":
     "WhatsApp channel provider configuration for access policy and message batching behavior. Use this section to tune responsiveness and direct-message routing safety for WhatsApp chats.",
+  // fork-keep #2665
   "channels.signal":
     "Signal channel provider configuration including account identity and DM policy behavior. Keep account mapping explicit so routing remains stable across multi-device setups.",
+  // fork-keep #2665
   "channels.imessage":
     "iMessage channel provider configuration for CLI integration and DM access policy handling. Use explicit CLI paths when runtime environments have non-standard binary locations.",
+  // fork-keep #2665
   "channels.bluebubbles":
     "BlueBubbles channel provider configuration used for Apple messaging bridge integrations. Keep DM policy aligned with your trusted sender model in shared deployments.",
+  // fork-keep #2665
   "channels.msteams":
     "Microsoft Teams channel provider configuration and provider-specific policy toggles. Use this section to isolate Teams behavior from other enterprise chat providers.",
   "channels.mattermost":
     "Mattermost channel provider configuration for bot credentials, base URL, and message trigger modes. Keep mention/trigger rules strict in high-volume team channels.",
+  // fork-keep #2665
   "channels.irc":
     "IRC channel provider configuration and compatibility settings for classic IRC transport workflows. Use this section when bridging legacy chat infrastructure into RemoteClaw.",
   "channels.defaults":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -176,7 +176,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.exec.notifyOnExit": "Exec Notify On Exit",
   "tools.exec.notifyOnExitEmptySuccess": "Exec Notify On Empty Success",
   "tools.exec.approvalRunningNoticeMs": "Exec Approval Running Notice (ms)",
-  "tools.exec.host": "Exec Host",
+  "tools.exec.host": "Exec Target",
   "tools.exec.security": "Exec Security",
   "tools.exec.ask": "Exec Ask",
   "tools.exec.node": "Exec Node Binding",
@@ -207,6 +207,14 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.web.search.maxResults": "Web Search Max Results",
   "tools.web.search.timeoutSeconds": "Web Search Timeout (sec)",
   "tools.web.search.cacheTtlMinutes": "Web Search Cache TTL (min)",
+  "tools.web.search.openaiCodex.enabled": "Enable Native Codex Web Search",
+  "tools.web.search.openaiCodex.mode": "Codex Web Search Mode",
+  "tools.web.search.openaiCodex.allowedDomains": "Codex Allowed Domains",
+  "tools.web.search.openaiCodex.contextSize": "Codex Search Context Size",
+  "tools.web.search.openaiCodex.userLocation.country": "Codex User Country",
+  "tools.web.search.openaiCodex.userLocation.region": "Codex User Region",
+  "tools.web.search.openaiCodex.userLocation.city": "Codex User City",
+  "tools.web.search.openaiCodex.userLocation.timezone": "Codex User Timezone",
   "tools.web.search.brave.mode": "Brave Search Mode",
   "tools.web.search.gemini.apiKey": "Gemini Search API Key", // pragma: allowlist secret
   "tools.web.search.gemini.model": "Gemini Search Model",
@@ -221,6 +229,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.web.fetch.enabled": "Enable Web Fetch Tool",
   "tools.web.fetch.maxChars": "Web Fetch Max Chars",
   "tools.web.fetch.maxCharsCap": "Web Fetch Hard Max Chars",
+  "tools.web.fetch.provider": "Web Fetch Provider",
   "tools.web.fetch.timeoutSeconds": "Web Fetch Timeout (sec)",
   "tools.web.fetch.cacheTtlMinutes": "Web Fetch Cache TTL (min)",
   "tools.web.fetch.maxRedirects": "Web Fetch Max Redirects",
@@ -269,6 +278,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.nodes.browser.node": "Gateway Node Browser Pin",
   "gateway.nodes.allowCommands": "Gateway Node Allowlist (Extra Commands)",
   "gateway.nodes.denyCommands": "Gateway Node Denylist",
+  "gateway.webchat.chatHistoryMaxChars": "WebChat History Max Chars",
   nodeHost: "Node Host",
   "nodeHost.browserProxy": "Node Browser Proxy",
   "nodeHost.browserProxy.enabled": "Node Browser Proxy Enabled",
@@ -318,6 +328,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "memory.qmd.mcporter.serverName": "QMD MCPorter Server Name",
   "memory.qmd.mcporter.startDaemon": "QMD MCPorter Start Daemon",
   "memory.qmd.searchMode": "QMD Search Mode",
+  "memory.qmd.searchTool": "QMD Search Tool Override",
   "memory.qmd.includeDefaultMemory": "QMD Include Default Memory",
   "memory.qmd.paths": "QMD Extra Paths",
   "memory.qmd.paths.path": "QMD Path",
@@ -382,6 +393,9 @@ export const FIELD_LABELS: Record<string, string> = {
   "auth.cooldowns.billingBackoffHoursByProvider": "Billing Backoff Overrides",
   "auth.cooldowns.billingMaxHours": "Billing Backoff Cap (hours)",
   "auth.cooldowns.failureWindowHours": "Failover Window (hours)",
+  "auth.cooldowns.overloadedProfileRotations": "Overloaded Profile Rotations",
+  "auth.cooldowns.overloadedBackoffMs": "Overloaded Backoff (ms)",
+  "auth.cooldowns.rateLimitedProfileRotations": "Rate-Limited Profile Rotations",
   "agents.defaults.models": "Models",
   "agents.defaults.model.primary": "Primary Model",
   "agents.defaults.model.fallbacks": "Model Fallbacks",
@@ -407,6 +421,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.compaction.postIndexSync": "Compaction Post-Index Sync",
   "agents.defaults.compaction.postCompactionSections": "Post-Compaction Context Sections",
   "agents.defaults.compaction.model": "Compaction Model Override",
+  "agents.defaults.compaction.notifyUser": "Compaction Notify User",
   "agents.defaults.compaction.memoryFlush": "Compaction Memory Flush",
   "agents.defaults.compaction.memoryFlush.enabled": "Compaction Memory Flush Enabled",
   "agents.defaults.compaction.memoryFlush.softThresholdTokens":
@@ -638,17 +653,31 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.defaults.heartbeat.showOk": "Heartbeat Show OK",
   "channels.defaults.heartbeat.showAlerts": "Heartbeat Show Alerts",
   "channels.defaults.heartbeat.useIndicator": "Heartbeat Use Indicator",
+  // fork-keep block — the per-channel anchor labels below
+  // (whatsapp, telegram, discord, slack, signal, imessage, bluebubbles, msteams, plus
+  // IRC via ...IRC_FIELD_LABELS) are fork-retained KEEP-layer rows. Upstream has
+  // removed these or may remove them in future syncs; the fork restores/maintains them.
+  // See #2665. Any upstream sync MUST preserve these rows (and per-row `// fork-keep` markers).
+  // fork-keep #2665
   "channels.whatsapp": "WhatsApp",
+  // fork-keep #2665
   "channels.telegram": "Telegram",
   "channels.telegram.customCommands": "Telegram Custom Commands",
+  // fork-keep #2665
   "channels.discord": "Discord",
+  // fork-keep #2665
   "channels.slack": "Slack",
   "channels.mattermost": "Mattermost",
+  // fork-keep #2665
   "channels.signal": "Signal",
+  // fork-keep #2665
   "channels.imessage": "iMessage",
+  // fork-keep #2665
   "channels.bluebubbles": "BlueBubbles",
+  // fork-keep #2665
   "channels.msteams": "MS Teams",
   "channels.modelByChannel": "Channel Model Overrides",
+  // fork-keep #2665 — IRC anchor + retained IRC.* labels live in schema.irc.ts
   ...IRC_FIELD_LABELS,
   "channels.telegram.botToken": "Telegram Bot Token",
   "channels.telegram.dmPolicy": "Telegram DM Policy",


### PR DESCRIPTION
## Summary

Closes #2665.

Re-apply legitimate upstream additions to `src/config/schema.help.ts` and `src/config/schema.labels.ts` that were lost when the v2026.4.2 sync's wholesale revert restored fork KEEP-layer channel rows. Add per-row `// fork-keep #2665` markers + block comments above the 9 fork-retained channel anchors to flag them for future sync triage.

## What's in scope

**Selective re-application of upstream range `f9b1079283..d74a12264a` (v2026.3.28 → v2026.4.2), restricted to the two target files:**

| Disposition | Entry | Rationale |
|---|---|---|
| Apply (wording) | `tools.exec.host` | Refresh for the new auto/sandbox/gateway/node modes |
| Apply (wording) | `tools.web.search.enabled` | Mention Codex-native search alongside managed search |
| Apply (add) | `gateway.webchat.chatHistoryMaxChars` | Key is in fork zod schema |
| Apply (add ×9) | `tools.web.search.openaiCodex.{enabled,mode,allowedDomains,contextSize,userLocation.{country,region,city,timezone}}` | Parity with upstream; harmless help/label addition |
| Apply (add) | `tools.web.fetch.provider` | Parity |
| Apply (add ×3) | `auth.cooldowns.{overloadedProfileRotations,overloadedBackoffMs,rateLimitedProfileRotations}` | Keys are in fork zod schema |
| Apply (add) | `memory.qmd.searchTool` | Consistent with existing `memory.qmd.*` help entries (e.g., `searchMode`) |
| Apply (add) | `agents.defaults.compaction.notifyUser` | Key is in fork zod schema (`zod-schema.agent-defaults.ts:120`) |
| **Skip** | `agents.defaults.memorySearch.qmd.*` (5 entries) | Would resurrect fork-gutted `memorySearch` tree (commit `f1d68f0f51` — `gut(config): remove dead memorySearch config tree (#2291)`). FIELD_HELP currently has zero `memorySearch.*` entries; re-introducing `memorySearch.qmd.*` would partially un-gut a deliberately-gutted subsystem. |
| Skip (already in fork) | `tools.web.search.brave.mode` | Brought in by earlier sync (v2026.3.7→v2026.3.8) |
| Skip (already removed) | `tools.web.fetch.firecrawl.*` | Upstream removed; fork retains (out-of-scope per issue framing — additions only) |
| Skip (already removed) | `tools.web.x_search.*` | Upstream removed; fork already accepted earlier in `refactor(xai): move x_search behind plugin boundary` |
| Keep fork wording | `plugins.installs.*.installPath` | Fork keeps `~/.remoteclaw/extensions/<id>` hint; upstream removed the path reference for genericity |

## KEEP-layer markers

Each of the 9 fork-retained channel rows now carries a per-row `// fork-keep #2665` marker plus a cluster-head block comment explaining the convention:

- `channels.{telegram,slack,discord,whatsapp,signal,imessage,bluebubbles,msteams,irc}` in `schema.help.ts`
- `channels.{whatsapp,telegram,discord,slack,signal,imessage,bluebubbles,msteams}` in `schema.labels.ts` (IRC anchor lives in `schema.irc.ts` via `...IRC_FIELD_LABELS` spread — marker on the spread line)

The block comments explicitly call out that future syncs must preserve these rows and their per-row markers.

## Test plan

- [x] `pnpm test:fast src/config/schema.help.quality.test.ts` → 19 passed (covers the `FIELD_HELP` ↔ `FIELD_LABELS` parity invariant)
- [x] `pnpm test:fast src/config/plugins-runtime-boundary.test.ts src/config/schema.help.quality.test.ts` → 22 passed
- [x] `pnpm tsgo` → clean
- [x] `pnpm format:check` / `pnpm lint` → clean
- [x] `pnpm lint:tmp:no-random-messaging` / `pnpm lint:no-remoteclaw-ai` / `pnpm lint:ui:no-css-class-drift` → clean
- [x] `bash scripts/ci/check-rebrand-leakage.sh` → no openclaw leakage
- [x] `node scripts/check-no-zombie-imports.mjs` → clean
- [x] `node scripts/check-stub-debt.mjs` → fork-boundary-mock baseline preserved (134 == 134)
- [x] `node scripts/check-throwing-stub-callers.mjs` → 0 violations
- [x] `node scripts/check-obsolescence-audit.mjs` → 48 == baseline 48
- [ ] Full CI run (GitHub Actions)

## Notes

- The issue's "~267 lines" estimate is approximate; the actual upstream diff for these two files is `+67/-37` net. After excluding deletions (out-of-scope), excluding the already-in-fork `brave.mode`, and excluding the gutted `memorySearch.qmd.*` block, applied delta is +76 lines / -3 lines.
- This is a data-only change (TypeScript object literal records) with no runtime behavior impact. The `schema.help.quality.test.ts` parity test guards against missing labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)