### PR TITLE
chore(upstream): bump tracking metadata to v2026.4.5 + drop NEW MEDIUM orphan

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.com/package/remoteclaw"><img src="https://img.shields.io/npm/v/remoteclaw?style=for-the-badge" alt="npm version"></a>
   <a href="https://github.com/remoteclaw/remoteclaw/releases"><img src="https://img.shields.io/github/v/release/remoteclaw/remoteclaw?include_prereleases&display_name=release&style=for-the-badge&label=GITHUB" alt="GitHub release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0--only-blue.svg?style=for-the-badge" alt="AGPL-3.0-only License"></a>
-  <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.3.31"><img src="https://img.shields.io/badge/upstream-OpenClaw_v2026.3.31-teal?style=for-the-badge" alt="Upstream: OpenClaw v2026.3.31"></a>
+  <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.4.5"><img src="https://img.shields.io/badge/upstream-OpenClaw_v2026.4.5-teal?style=for-the-badge" alt="Upstream: OpenClaw v2026.4.5"></a>
 </p>
 
 **RemoteClaw** is AI agent middleware. It connects agent CLIs you already run — Claude Code, Gemini CLI, Codex, OpenCode — to the messaging channels you already use, so you can reach your agents from anywhere: your phone, your team Slack, your WhatsApp, anywhere.

--- a/package.json
+++ b/package.json
@@ -438,5 +438,5 @@
     ]
   },
   "upstreamRepo": "openclaw/openclaw",
-  "upstreamVersion": "2026.3.31"
+  "upstreamVersion": "2026.4.5"
 }

--- a/src/infra/openclaw-root.fs.runtime.ts
+++ b/src/infra/openclaw-root.fs.runtime.ts
@@ -1,2 +1,0 @@
-export { default as openClawRootFsSync } from "node:fs";
-export { default as openClawRootFs } from "node:fs/promises";


### PR DESCRIPTION
## Summary

Post-v2026.4.5 sync follow-up (HQ recording at remoteclaw/hq#117).

- `package.json`: `upstreamVersion` 2026.3.31 → 2026.4.5 (v2026.4.2 sync didn't include a separate bump; 2026.4.5 supersedes the missed step)
- `README.md`: upstream badge URL/text → v2026.4.5
- Remove `src/infra/openclaw-root.fs.runtime.ts` — D.7 NEW MEDIUM finding: 2-line orphan export wrapper introduced by upstream with OpenClaw-named aliases (`openClawRootFs`, `openClawRootFsSync`); sibling `openclaw-root.ts` already EXCLUDE-GUT; zero fork consumers. Disposition entry already added in hq#117.

## Test plan

- [x] `pnpm check` passes (format, tsgo, lint, no-random-messaging, no-remoteclaw-ai, no-css-class-drift)
- [x] Zero grep matches for `openclaw-root.fs.runtime` outside the deleted file's own self-reference
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)