### PR TITLE
chore: update upstreamVersion to v2026.4.7-1 (D.5.5 follow-up)

### DIFF
--- a/package.json
+++ b/package.json
@@ -446,5 +446,5 @@
     ]
   },
   "upstreamRepo": "openclaw/openclaw",
-  "upstreamVersion": "2026.4.5"
+  "upstreamVersion": "2026.4.7-1"
 }


### PR DESCRIPTION
## Summary

Bump `package.json` `upstreamVersion` from `2026.4.5` to `2026.4.7-1`, matching the upstream tag merged in #2675.

This is the standard D.5.5 follow-up tracking-metadata bump — same pattern as #2673 (v2026.4.5), #2656 (v2026.3.31), #2635 (v2026.3.28).

## Test plan

- [ ] CI green (build, test, lint, docs, all fork-integrity gates)
- [ ] No related changes needed in `extensions/*/package.json` (extensions don't carry the field)