### PR TITLE
ci: bound + retry test-ui-smoke Playwright install — prevent 6h hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,26 @@ jobs:
           install-bun: "false"
 
       - name: Install Playwright Chromium
-        run: pnpm --dir ui exec playwright install --with-deps chromium
+        # Bound + retry the Chromium / system-deps install so a transient
+        # Playwright-CDN or apt stall fails fast and self-heals instead of
+        # holding the runner for the 6h job default (#2684). Each attempt is
+        # capped by `timeout`; step-level timeout-minutes is the hard backstop.
+        timeout-minutes: 15
+        run: |
+          for attempt in 1 2 3; do
+            echo "::group::playwright install (attempt ${attempt}/3)"
+            if timeout --kill-after=30s 4m pnpm --dir ui exec playwright install --with-deps chromium; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "::warning::playwright install attempt ${attempt}/3 did not succeed"
+            if [ "${attempt}" -lt 3 ]; then
+              sleep "$((attempt * 15))"
+            fi
+          done
+          echo "::error::playwright Chromium install failed after 3 attempts"
+          exit 1
 
       - name: UI smoke tests (browser-mode)
         run: pnpm test:ui:smoke


### PR DESCRIPTION
## Problem

The `test-ui-smoke` job's **"Install Playwright Chromium"** step had no
`timeout-minutes`, so a transient Playwright-CDN / `apt` stall in
`playwright install --with-deps chromium` held the runner until GitHub's
**6-hour** job default instead of failing fast. Because `test-ui-smoke` is a
**required** check (in the `CI` aggregate `needs` list), a stall blocks all
merges for the duration. A healthy run completes in ~54s, so the multi-minute /
multi-hour durations were purely the install step failing to make progress.

## Fix (minimal — only the one step)

Bound the install step and let it self-heal transients, without touching the
rest of the workflow:

- **`timeout-minutes: 15`** on the step — a GitHub-enforced hard cap so the
  step can never hold a runner for 6h.
- **3-attempt retry loop**, each attempt wrapped in
  `timeout --kill-after=30s 4m` so a *hung* download (the documented failure
  mode) is killed and retried instead of consuming the whole budget; 15s/30s
  backoff between attempts.

No new third-party action, no caching, no container change — deliberately scoped
to the single step the issue concerns (caching / prebuilt-container approaches
from the issue are left out as larger refactors).

## Validation

- **`actionlint` 1.7.12**: PASS (validates the workflow YAML *and* runs
  shellcheck on the `run:` block) — zero findings.
- **Behavioral simulation** (the exact loop, with `timeout`/`sleep` stubbed),
  exit-code + attempt-count asserted:
  - healthy → exit 0 on attempt 1, no backoff (happy path unchanged)
  - transient fast-fail then recover → exit 0 on attempt 2
  - all fast-fail → exit 1 after 3 attempts (no needless backoff after the last)
  - **hang-killed (124) ×2 then recover → exit 0** (a timeout-killed attempt is retried)
  - **all hang-killed → exit 1 (bounded)** — the 6h hang becomes a fast, bounded failure
- Real GNU coreutils `timeout` 9.11 confirms `--kill-after=30s 4m` semantics
  (budget-exceeded → 124, fast cmd → 0, non-zero exit propagates). The CI runner
  ships the same GNU coreutils.
- **Self-validating**: this PR's own `test-ui-smoke` run exercises the new step —
  a healthy install passes; a transient now fails fast instead of hanging.

`src/middleware/` is untouched, so the LIVE smoke-test lane is N/A for this PR.

## Acceptance criteria

- [x] `test-ui-smoke` cannot hold a runner longer than its `timeout-minutes` budget.
- [x] A transient Playwright-CDN/apt blip no longer blocks merges indefinitely (retries / fails fast).
- [x] Healthy-path runtime stays in the ~1-minute range (first attempt succeeds, no added latency).

Closes #2684
