### PR TITLE
fix(test-ui-smoke): Playwright 1.60.0 fixes Node 24.16+ install hang (+ browser cache) (#2684)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,11 +215,29 @@ jobs:
         with:
           install-bun: "false"
 
+      - name: Resolve Playwright version
+        id: pw-version
+        run: |
+          echo "version=$(pnpm --dir ui exec playwright --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        # Cache the downloaded browser bundle so the flaky cdn.playwright.dev
+        # download (#2684) is skipped on the common path (cache hit). Keyed on
+        # the resolved Playwright version so a version bump invalidates cleanly.
+        # First run on a new version is a miss (the install step below seeds it);
+        # every subsequent run restores from cache and skips the CDN entirely.
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.version }}
+
       - name: Install Playwright Chromium
-        # Bound + retry the Chromium / system-deps install so a transient
-        # Playwright-CDN or apt stall fails fast and self-heals instead of
-        # holding the runner for the 6h job default (#2684). Each attempt is
-        # capped by `timeout`; step-level timeout-minutes is the hard backstop.
+        # Cache-miss populator + on-hit no-op (browser already present from the
+        # cache step above); always runs `--with-deps` to ensure OS deps. Bound +
+        # retry the install so a transient Playwright-CDN or apt stall fails fast
+        # and self-heals instead of holding the runner for the 6h job default
+        # (#2684). Each attempt is capped by `timeout`; step-level
+        # timeout-minutes is the hard backstop.
         timeout-minutes: 15
         run: |
           for attempt in 1 2 3; do

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,13 +503,13 @@ importers:
     devDependencies:
       '@vitest/browser-playwright':
         specifier: 4.1.2
-        version: 4.1.2(playwright@1.59.1)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.2)
+        version: 4.1.2(playwright@1.60.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.2)
       jsdom:
         specifier: ^29.0.1
         version: 29.0.2(@noble/hashes@2.0.1)
       playwright:
-        specifier: ^1.59.1
-        version: 1.59.1
+        specifier: ^1.60.0
+        version: 1.60.0
       vite:
         specifier: 8.0.5
         version: 8.0.5(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -4662,13 +4662,13 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -8348,11 +8348,11 @@ snapshots:
       - '@cypress/request'
       - supports-color
 
-  '@vitest/browser-playwright@4.1.2(playwright@1.59.1)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.2)':
+  '@vitest/browser-playwright@4.1.2(playwright@1.60.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.2)':
     dependencies:
       '@vitest/browser': 4.1.2(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.2)
       '@vitest/mocker': 4.1.2(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
-      playwright: 1.59.1
+      playwright: 1.60.0
       tinyrainbow: 3.1.0
       vitest: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
@@ -10380,11 +10380,11 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.59.1:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -11171,7 +11171,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.5.0
-      '@vitest/browser-playwright': 4.1.2(playwright@1.59.1)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.2)
+      '@vitest/browser-playwright': 4.1.2(playwright@1.60.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.2)
       jsdom: 29.0.2(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - msw

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@vitest/browser-playwright": "4.1.2",
     "jsdom": "^29.0.1",
-    "playwright": "^1.59.1",
+    "playwright": "^1.60.0",
     "vite": "8.0.5",
     "vitest": "4.1.2"
   }


### PR DESCRIPTION
## Root cause (revised — it was never the CDN)

`main` went red at the v2026.4.12 sync. The only failing job is **`test-ui-smoke`**, failing on the *Playwright browser install*, which **hangs ~4 min then times out** across all 3 retries.

The original theory (flaky `cdn.playwright.dev` download) was **wrong**. Investigation:

- **The download is healthy.** `cdn.playwright.dev` just `307`-redirects to `storage.googleapis.com` (Google Cloud Storage); the 170 MB Chrome-for-Testing zip pulls at **11–15 MB/s** measured directly. Not a network problem.
- **It's a known upstream regression.** Playwright **1.55.1 – <1.60.0** hang during browser **extraction** (not download) on **Node 24.16+** — [microsoft/playwright#40998](https://github.com/microsoft/playwright/issues/40998), fixed in **1.60.0** ([#40747](https://github.com/microsoft/playwright/pull/40747)). The log's `Downloading…` → ~4 min silence → timeout-kill is the *extraction* hang, not a slow download.
- **Why it broke now:** `setup-node-env` floats Node at **`"24.x"`** (unpinned). Node **24.16.0** landed between the last green run (2026-05-17) and the sync, flipping CI into the buggy combination. Playwright stayed `1.59.1` the whole time; the Node minor moved underneath us.

## Fix

**Bump `playwright` `^1.59.1` → `^1.60.0`** (`ui/package.json` + lockfile via pnpm 10.23.0). 1.60.0 is the current npm `latest`; `@vitest/browser-playwright@4.1.2` peers `playwright: "*"`, so no peer conflict. The lockfile diff is playwright-only.

**Browser cache retained** (the `actions/cache` step from this PR's first commit): it was failing to seed *because* the install hung. With the install now succeeding, the cache seeds on the first run and skips the ~170 MB download on subsequent runs — a genuine speedup, no longer load-bearing for correctness.

## Scope

`ui/package.json` (1 line) + `pnpm-lock.yaml` (playwright / playwright-core / `@vitest/browser-playwright` resolution) + the `.github/workflows/ci.yml` cache steps from the first commit. No source or test changes. The #2687 install-bounding (timeout + retry) stays as a backstop but is no longer the operative fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
