### PR TITLE
fix(slack): suppress socket-mode reasonless promise rejection — prevent gateway crash (#2652)

### DIFF
--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -22,6 +22,7 @@ import { createConnectedChannelStatusPatch } from "../../../../src/gateway/chann
 import { warn } from "../../../../src/globals.js";
 import { computeBackoff, sleepWithAbort } from "../../../../src/infra/backoff.js";
 import { installRequestBodyLimitGuard } from "../../../../src/infra/http-body.js";
+import { registerUnhandledRejectionHandler } from "../../../../src/infra/unhandled-rejections.js";
 import { normalizeMainKey } from "../../../../src/routing/session-key.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../../../src/runtime.js";
 import { normalizeStringEntries } from "../../../../src/shared/string-normalization.js";
@@ -92,6 +93,78 @@ function publishSlackDisconnectedStatus(
     lastDisconnect: message ? { at, error: message } : { at },
     lastError: message ?? null,
   });
+}
+
+// Suppress reasonless rejections only when they correlate with recent socket churn (in ms).
+const SLACK_SOCKET_REJECTION_WINDOW_MS = 10_000;
+// WebSocket upgrade failures surface as e.g. "Unexpected server response: 408".
+const SLACK_WS_UPGRADE_FAILURE_RE = /unexpected server response: \d{3}/i;
+
+/**
+ * Register a channel-scoped unhandled-rejection handler for Slack socket mode.
+ *
+ * The `@slack/socket-mode` SDK schedules reconnects as `delayReconnectAttempt(this.start).then(res)`
+ * with no `.catch` (SocketModeClient.js:210). When an internal reconnect attempt fails it emits
+ * `State.Disconnected` with no argument (SocketModeClient.js:120), whose `disconnectedCallback`
+ * rejects with `undefined` (SocketModeClient.js:161-163). That `Promise.reject(undefined)` carries
+ * no `code`/`name`/`message`, so it bypasses every classifier in the central handler and crashes
+ * the gateway via `process.exit(1)` (#2652).
+ *
+ * Mirrors the channel-scoped handlers used by Telegram (`telegram/src/monitor.ts`) and WhatsApp
+ * (`whatsapp/src/auto-reply/monitor.ts`): correlate reasonless (undefined/null) rejections with
+ * recent SocketModeClient lifecycle events, and treat WebSocket-upgrade HTTP errors as transient —
+ * while still letting genuine non-recoverable auth failures fall through to the fatal path. The
+ * monitor's own reconnect loop below recovers. Tighter blast radius than globally treating
+ * `undefined` as transient; safe to remove once an upstream fix lands and is synced.
+ *
+ * @returns an unregister function that removes the handler and detaches the socket listeners.
+ */
+function registerSlackSocketUnhandledRejectionHandler(opts: {
+  app: unknown;
+  log?: (message: string) => void;
+  now?: () => number;
+}): () => void {
+  const now = opts.now ?? Date.now;
+  const emitter = getSocketEmitter(opts.app);
+  const trackedEvents = ["disconnected", "unable_to_socket_mode_start", "error"];
+  let lastSocketEventAt: number | null = null;
+  const trackSocketEvent = () => {
+    lastSocketEventAt = now();
+  };
+  for (const event of trackedEvents) {
+    emitter?.on(event, trackSocketEvent);
+  }
+
+  const hadRecentSocketEvent = () =>
+    lastSocketEventAt !== null && now() - lastSocketEventAt <= SLACK_SOCKET_REJECTION_WINDOW_MS;
+
+  const unregister = registerUnhandledRejectionHandler((reason) => {
+    // Reasonless rejections (undefined/null) are the SDK's un-`.catch()`'d reconnect chain
+    // surfacing. Scope suppression to the window right after a SocketModeClient lifecycle event so
+    // unrelated reasonless rejections elsewhere still crash as before.
+    if ((reason === undefined || reason === null) && hadRecentSocketEvent()) {
+      opts.log?.("slack socket-mode reconnect produced a reasonless rejection; continuing");
+      return true;
+    }
+    // WebSocket upgrade failures (e.g. "Unexpected server response: 408") are transient, but a
+    // genuine non-recoverable auth failure must still reach the fatal path.
+    if (
+      reason instanceof Error &&
+      SLACK_WS_UPGRADE_FAILURE_RE.test(reason.message) &&
+      !isNonRecoverableSlackAuthError(reason)
+    ) {
+      opts.log?.(`slack socket-mode transient rejection suppressed: ${reason.message}`);
+      return true;
+    }
+    return false;
+  });
+
+  return () => {
+    unregister();
+    for (const event of trackedEvents) {
+      emitter?.off(event, trackSocketEvent);
+    }
+  };
 }
 
 export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
@@ -230,6 +303,15 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
         }
       : null;
   let unregisterHttpHandler: (() => void) | null = null;
+  // Socket mode only: the SDK's un-`.catch()`'d reconnect chain can surface a reasonless
+  // `Promise.reject(undefined)` that would otherwise crash the gateway (#2652).
+  const unregisterSlackSocketRejection =
+    slackMode === "socket"
+      ? registerSlackSocketUnhandledRejectionHandler({
+          app,
+          log: (message) => runtime.log?.(warn(message)),
+        })
+      : null;
 
   let botUserId = "";
   let teamId = "";
@@ -504,6 +586,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   } finally {
     opts.abortSignal?.removeEventListener("abort", stopOnAbort);
     unregisterHttpHandler?.();
+    unregisterSlackSocketRejection?.();
     await app.stop().catch(() => undefined);
   }
 }
@@ -517,4 +600,5 @@ export const __testing = {
   resolveDefaultGroupPolicy,
   getSocketEmitter,
   waitForSlackSocketDisconnect,
+  registerSlackSocketUnhandledRejectionHandler,
 };

--- a/extensions/slack/src/monitor/provider.unhandled-rejection.test.ts
+++ b/extensions/slack/src/monitor/provider.unhandled-rejection.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { isUnhandledRejectionHandled } from "../../../../src/infra/unhandled-rejections.js";
+import { __testing } from "./provider.js";
+
+const { registerSlackSocketUnhandledRejectionHandler } = __testing;
+
+// Mirror of the production constant (provider.ts SLACK_SOCKET_REJECTION_WINDOW_MS).
+const SLACK_REJECTION_WINDOW_MS = 10_000;
+
+/**
+ * Minimal stand-in for the SocketModeClient (`app.receiver.client`) — same shape the existing
+ * reconnect test uses. `getSocketEmitter` only needs `on`/`off`.
+ */
+class FakeSocketClient {
+  private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  on(event: string, listener: (...args: unknown[]) => void) {
+    const bucket = this.listeners.get(event) ?? new Set<(...args: unknown[]) => void>();
+    bucket.add(listener);
+    this.listeners.set(event, bucket);
+  }
+
+  off(event: string, listener: (...args: unknown[]) => void) {
+    this.listeners.get(event)?.delete(listener);
+  }
+
+  emit(event: string, ...args: unknown[]) {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+}
+
+function setup(nowRef: { value: number }) {
+  const client = new FakeSocketClient();
+  const app = { receiver: { client } };
+  const logs: string[] = [];
+  const unregister = registerSlackSocketUnhandledRejectionHandler({
+    app,
+    log: (message) => logs.push(message),
+    now: () => nowRef.value,
+  });
+  return { client, logs, unregister };
+}
+
+// The gateway's central handler runs `isUnhandledRejectionHandled(reason)` first and returns
+// early — never reaching `process.exit(1)` — when any registered handler suppresses the rejection
+// (src/infra/unhandled-rejections.ts). So `true` here means "the gateway does NOT crash" and
+// `false` means "the gateway crashes" (the #2652 symptom).
+describe("slack socket-mode unhandled rejection handler (#2652)", () => {
+  it("suppresses a reasonless (undefined) rejection right after a socket disconnect", () => {
+    const nowRef = { value: 1_000 };
+    const { client, logs, unregister } = setup(nowRef);
+    try {
+      // The SDK emits State.Disconnected with no argument, then rejects with `undefined`.
+      client.emit("disconnected");
+      expect(isUnhandledRejectionHandled(undefined)).toBe(true);
+      // Suppression must be observable.
+      expect(logs).toHaveLength(1);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("suppresses a reasonless (null) rejection right after an error event", () => {
+    const nowRef = { value: 1_000 };
+    const { client, unregister } = setup(nowRef);
+    try {
+      client.emit("error", new Error("Unexpected server response: 408"));
+      expect(isUnhandledRejectionHandled(null)).toBe(true);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("also tracks unable_to_socket_mode_start events", () => {
+    const nowRef = { value: 1_000 };
+    const { client, unregister } = setup(nowRef);
+    try {
+      client.emit("unable_to_socket_mode_start");
+      expect(isUnhandledRejectionHandled(undefined)).toBe(true);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does NOT suppress a reasonless rejection with no recent socket event", () => {
+    const nowRef = { value: 1_000 };
+    const { unregister } = setup(nowRef);
+    try {
+      // No socket lifecycle event fired — an unrelated reasonless rejection must still crash
+      // (this is the pre-fix global behavior the tight scoping preserves).
+      expect(isUnhandledRejectionHandled(undefined)).toBe(false);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does NOT suppress a reasonless rejection once the correlation window elapses", () => {
+    const nowRef = { value: 1_000 };
+    const { client, unregister } = setup(nowRef);
+    try {
+      client.emit("disconnected");
+      nowRef.value = 1_000 + SLACK_REJECTION_WINDOW_MS + 1; // just past the window
+      expect(isUnhandledRejectionHandled(undefined)).toBe(false);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("suppresses a transient WebSocket upgrade error even without a recent socket event", () => {
+    const nowRef = { value: 1_000 };
+    const { unregister } = setup(nowRef);
+    try {
+      expect(isUnhandledRejectionHandled(new Error("Unexpected server response: 408"))).toBe(true);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does NOT suppress a non-recoverable auth error wearing a WebSocket-upgrade message", () => {
+    const nowRef = { value: 1_000 };
+    const { unregister } = setup(nowRef);
+    try {
+      // Matches the upgrade regex (401) but is a permanent auth failure — must reach the fatal path.
+      expect(
+        isUnhandledRejectionHandled(new Error("Unexpected server response: 401 not_authed")),
+      ).toBe(false);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("stops suppressing after unregister (finally-block cleanup)", () => {
+    const nowRef = { value: 1_000 };
+    const { client, unregister } = setup(nowRef);
+    client.emit("disconnected");
+    unregister();
+    expect(isUnhandledRejectionHandled(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`monitorSlackProvider` was the only socket-driven adapter without a `registerUnhandledRejectionHandler`. A transient `@slack/socket-mode` reconnect failure (e.g. HTTP 408 on the WebSocket upgrade after a pong-timeout terminate) surfaces as `Promise.reject(undefined)` from the SDK's un-`.catch()`'d reconnect chain, bypasses every classifier in the central handler, and crashes the gateway via `process.exit(1)`.

Closes #2652.

## Root cause (verified at source level)

- `@slack/socket-mode@2.0.5` `SocketModeClient.js:120` emits `this.emit(State.Disconnected)` **with no argument** when an internal reconnect attempt fails; the `disconnectedCallback` at `:161-163` then calls `reject(err)` with `err === undefined`.
- That promise was scheduled via `delayReconnectAttempt(this.start).then(res)` at `:210` — **no `.catch`** — so the `undefined` rejection bubbles to Node's `unhandledRejection`.
- `src/infra/unhandled-rejections.ts`: `isAbortError`/`isFatalError`/`isConfigError`/`isTransientUnhandledRejectionError` all return `false` for a `reason` with no `code`/`name`/`message`, so it falls through to the final branch → `process.exit(1)`.

## Fix

Channel-scoped `registerUnhandledRejectionHandler` in `monitorSlackProvider`, mirroring the existing Telegram (`telegram/src/monitor.ts:77-96`) and WhatsApp (`whatsapp/src/auto-reply/monitor.ts:232-247`) handlers:

- Tracks timestamps of SocketModeClient lifecycle events (`disconnected` / `unable_to_socket_mode_start` / `error`) via the existing `getSocketEmitter`.
- Suppresses **reasonless** (`undefined`/`null`) rejections only when they fall within 10s of such an event — the gateway logs and continues; the monitor's own reconnect loop recovers.
- Also classifies WebSocket-upgrade errors (`/unexpected server response: \d{3}/i`, e.g. 408) as transient — **but** lets genuine non-recoverable auth failures fall through to the fatal path (`!isNonRecoverableSlackAuthError`).
- Registered in socket mode after `app` construction; unregistered in the `finally` block.

Tighter blast radius than globally treating `undefined` as transient (cf. upstream openclaw#60137). Safe to remove once an upstream fix lands and is synced.

> **Event-name note:** the linked issue says track `close`, but the SocketModeClient's actual state vocabulary (and what `getSocketEmitter`/`waitForSlackSocketDisconnect` already use) is `disconnected` — `close` is the lower-level `ws` event, not the SocketModeClient `State.Disconnected`. Verified against `SocketModeClient.js` (`State.Disconnected = "disconnected"`, emitted at `:120`).

## Test

New `extensions/slack/src/monitor/provider.unhandled-rejection.test.ts` — 8 cases at the `isUnhandledRejectionHandled` seam (the exact gate the central handler checks before `process.exit(1)`, so `true` = "gateway does not crash"):

- reasonless `undefined`/`null` rejection within the socket-event window → suppressed (+ observable log)
- tracks `disconnected` / `unable_to_socket_mode_start` / `error`
- **no over-suppression**: reasonless rejection with no recent socket event, or once the 10s window elapses → NOT suppressed
- WS-upgrade 408 `Error` → suppressed; auth error wearing a 401 upgrade message → NOT suppressed
- handler stops suppressing after `unregister` (finally-block cleanup)

## Verification

- `pnpm check` (format + tsgo typecheck + oxlint type-aware + css-class-drift) — **green**.
- Targeted run (new + `provider.reconnect` + `provider.auth-errors`) — **34 passed**.
- Full `extensions/slack/` suite — failure set **identical** to clean `origin/main` (7 files / 13 tests, all pre-existing macOS-runner env artifacts: proxy/account-resolution), with my change adding **+8 passing** tests → **zero regressions**.
- Fork-integrity: no `@ts-expect-error`; `throwing-stub-callers` gate 0 violations; fake placeholders only in the test.

This is an upstream-inherited bug (also present on `openclaw/main`), not fork-introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
