### PR TITLE
fix(discord): suppress connect-time /gateway/bot rejection — prevent gateway crash (#2692)

### DIFF
--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -34,9 +34,11 @@ import {
 import { danger, logVerbose, shouldLogVerbose, warn } from "../../../../src/globals.js";
 import { formatErrorMessage } from "../../../../src/infra/errors.js";
 import { createDiscordRetryRunner } from "../../../../src/infra/retry-policy.js";
+import { registerUnhandledRejectionHandler } from "../../../../src/infra/unhandled-rejections.js";
 import { createSubsystemLogger } from "../../../../src/logging/subsystem.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../../../src/runtime.js";
 import { resolveDiscordAccount } from "../accounts.js";
+import { getDiscordGatewayEmitter } from "../monitor.gateway.js";
 import { fetchDiscordApplicationId } from "../probe.js";
 import { normalizeDiscordToken } from "../token.js";
 import { createDiscordVoiceCommand } from "../voice/command.js";
@@ -171,6 +173,94 @@ function isDiscordDisallowedIntentsError(err: unknown): boolean {
   return message.includes(String(DISCORD_DISALLOWED_INTENTS_CODE));
 }
 
+// Window during which a gateway-metadata rejection is correlated with Discord connect/startup.
+const DISCORD_GATEWAY_REJECTION_WINDOW_MS = 10_000;
+
+// The wrapper message `createGatewayMetadataError` stamps on every gateway-metadata failure
+// (gateway-plugin.ts) — both the transient "...: fetch failed" and the non-transient detail variants.
+const DISCORD_GATEWAY_METADATA_ERROR_RE = /Failed to get gateway information from Discord/i;
+
+// A 401/403 from `/gateway/bot` means a bad / revoked / under-scoped bot token — retrying never
+// succeeds, so let it reach the fatal path (fail-fast) instead of silently spinning. Analogous to
+// Slack's `isNonRecoverableSlackAuthError`.
+const DISCORD_GATEWAY_AUTH_FAILURE_RE = /\/gateway\/bot failed \((?:401|403)\)/i;
+
+function isNonRecoverableDiscordGatewayError(reason: unknown): boolean {
+  const message =
+    reason instanceof Error ? reason.message : typeof reason === "string" ? reason : "";
+  return DISCORD_GATEWAY_AUTH_FAILURE_RE.test(message);
+}
+
+/**
+ * Register a Discord channel-scoped unhandled-rejection handler for the gateway-metadata fetch.
+ *
+ * `@buape/carbon`'s `Client` constructor calls `plugin.registerClient?.(this)` FLOATING — no
+ * `await`, no `.catch` (Client.js:122). The fork overrides `registerClient` as `async` and awaits
+ * `fetchDiscordGatewayInfo`, which `throw`s `createGatewayMetadataError({ transient: false })` on a
+ * non-transient `/gateway/bot` response (a `429`, or invalid JSON from a proxy/Cloudflare
+ * interstitial on a `2xx`). Because the override is async and called floating from the synchronous
+ * constructor, the rejection is neither awaited nor caught: it escapes to Node's `unhandledRejection`
+ * and the central handler — unable to classify the generic `Error` — crashes the WHOLE gateway via
+ * `process.exit(1)` (#2692). The existing `attachEarlyGatewayErrorGuard` only covers the EventEmitter
+ * `'error'` path, not a rejected Promise.
+ *
+ * Mirrors the channel-scoped handlers used by Slack (`slack/src/monitor/provider.ts`), Telegram, and
+ * WhatsApp: suppress the recoverable gateway-metadata rejection (429 / 5xx / invalid-JSON) within a
+ * short window stamped at `new Client()` construction and refreshed on the Carbon gateway emitter's
+ * `error`/`debug` events, while letting a clearly non-recoverable auth failure fall through to the
+ * fatal path. Tighter blast radius than globally widening "transient"; safe to remove once an
+ * upstream Carbon fix lands and is synced.
+ *
+ * @returns an unregister function that removes the handler and detaches the emitter listeners.
+ */
+function registerDiscordGatewayUnhandledRejectionHandler(opts: {
+  client: Client;
+  log?: (message: string) => void;
+  now?: () => number;
+}): () => void {
+  const now = opts.now ?? Date.now;
+  const emitter = getDiscordGatewayEmitter(opts.client.getPlugin("gateway"));
+  // Stamp the window at construction: the reject can fire before any emitter event does.
+  let lastGatewayActivityAt = now();
+  const trackGatewayActivity = () => {
+    lastGatewayActivityAt = now();
+  };
+  const trackedEvents = ["error", "debug"];
+  for (const event of trackedEvents) {
+    emitter?.on(event, trackGatewayActivity);
+  }
+
+  const withinConnectWindow = () =>
+    now() - lastGatewayActivityAt <= DISCORD_GATEWAY_REJECTION_WINDOW_MS;
+
+  const unregister = registerUnhandledRejectionHandler((reason) => {
+    if (!(reason instanceof Error)) {
+      return false;
+    }
+    if (!DISCORD_GATEWAY_METADATA_ERROR_RE.test(reason.message)) {
+      return false;
+    }
+    // A bad / revoked / under-scoped token will never recover — let it reach the fatal path.
+    if (isNonRecoverableDiscordGatewayError(reason)) {
+      return false;
+    }
+    if (!withinConnectWindow()) {
+      return false;
+    }
+    opts.log?.(
+      `discord gateway metadata fetch failed during connect (recoverable); continuing: ${reason.message}`,
+    );
+    return true;
+  });
+
+  return () => {
+    unregister();
+    for (const event of trackedEvents) {
+      emitter?.removeListener(event, trackGatewayActivity);
+    }
+  };
+}
+
 export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   const cfg = opts.config ?? loadConfig();
   const account = resolveDiscordAccount({
@@ -296,6 +386,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     : createNoopThreadBindingManager(account.accountId);
   let lifecycleStarted = false;
   let releaseEarlyGatewayErrorGuard = () => {};
+  let unregisterGatewayRejectionHandler = () => {};
   try {
     const commands: BaseCommand[] = commandSpecs.map((spec) =>
       createDiscordNativeCommand({
@@ -397,6 +488,15 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       },
       clientPlugins,
     );
+    // Carbon calls the fork's async `registerClient` floating from this synchronous `new Client()`
+    // (Client.js:122). A non-transient `/gateway/bot` failure (429 / invalid JSON on a 2xx) rejects
+    // with no `.catch` and would crash the whole gateway via the central handler's `process.exit(1)`
+    // (#2692). Register the scoped suppressor now — before the first `await` below — so it is in
+    // place when that floating promise rejects.
+    unregisterGatewayRejectionHandler = registerDiscordGatewayUnhandledRejectionHandler({
+      client,
+      log: (message) => runtime.log?.(warn(message)),
+    });
     const earlyGatewayErrorGuard = attachEarlyGatewayErrorGuard(client);
     releaseEarlyGatewayErrorGuard = earlyGatewayErrorGuard.release;
 
@@ -502,6 +602,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       releaseEarlyGatewayErrorGuard,
     });
   } finally {
+    unregisterGatewayRejectionHandler();
     releaseEarlyGatewayErrorGuard();
     if (!lifecycleStarted) {
       threadBindings.stop();
@@ -530,4 +631,5 @@ export const __testing = {
   resolveDefaultGroupPolicy,
   resolveDiscordRestFetch,
   resolveThreadBindingsEnabled,
+  registerDiscordGatewayUnhandledRejectionHandler,
 };

--- a/extensions/discord/src/monitor/provider.unhandled-rejection.test.ts
+++ b/extensions/discord/src/monitor/provider.unhandled-rejection.test.ts
@@ -1,0 +1,141 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it } from "vitest";
+import { isUnhandledRejectionHandled } from "../../../../src/infra/unhandled-rejections.js";
+import { __testing } from "./provider.js";
+
+const { registerDiscordGatewayUnhandledRejectionHandler } = __testing;
+
+// Mirror of the production constant (provider.ts DISCORD_GATEWAY_REJECTION_WINDOW_MS).
+const DISCORD_GATEWAY_REJECTION_WINDOW_MS = 10_000;
+
+/**
+ * Reconstructs the message `createGatewayMetadataError` stamps on a NON-transient `/gateway/bot`
+ * failure (gateway-plugin.ts) — the exact wrapper shape that escapes as an unhandled rejection from
+ * Carbon's floating `registerClient` call.
+ */
+function gatewayMetadataError(detail: string): Error {
+  return new Error(`Failed to get gateway information from Discord: ${detail}`);
+}
+
+/**
+ * Minimal stand-in for the Carbon `Client`. `registerDiscordGatewayUnhandledRejectionHandler` only
+ * needs `getPlugin("gateway")` to yield the gateway plugin's `emitter` (a real `EventEmitter`, as the
+ * Carbon GatewayPlugin exposes) — same shape `attachEarlyGatewayErrorGuard`'s test relies on.
+ */
+function setup(nowRef: { value: number }) {
+  const emitter = new EventEmitter();
+  const client = { getPlugin: () => ({ emitter }) };
+  const logs: string[] = [];
+  const unregister = registerDiscordGatewayUnhandledRejectionHandler({
+    client: client as never,
+    log: (message) => logs.push(message),
+    now: () => nowRef.value,
+  });
+  return { emitter, logs, unregister };
+}
+
+// The gateway's central handler runs `isUnhandledRejectionHandled(reason)` first and returns early —
+// never reaching `process.exit(1)` — when any registered handler suppresses the rejection
+// (src/infra/unhandled-rejections.ts). So `true` here means "the gateway does NOT crash" and `false`
+// means "the gateway crashes" (the #2692 symptom).
+describe("discord gateway-metadata unhandled rejection handler (#2692)", () => {
+  it("suppresses a non-transient 429 gateway-metadata rejection at connect", () => {
+    const nowRef = { value: 1_000 };
+    const { logs, unregister } = setup(nowRef);
+    try {
+      const reason = gatewayMetadataError("Discord API /gateway/bot failed (429): rate limited");
+      expect(isUnhandledRejectionHandled(reason)).toBe(true);
+      // Suppression must be observable.
+      expect(logs).toHaveLength(1);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("suppresses an invalid-JSON gateway-metadata rejection (proxy/Cloudflare interstitial)", () => {
+    const nowRef = { value: 1_000 };
+    const { unregister } = setup(nowRef);
+    try {
+      const reason = gatewayMetadataError(
+        "Discord API /gateway/bot returned invalid JSON: <!DOCTYPE html><html>...",
+      );
+      expect(isUnhandledRejectionHandled(reason)).toBe(true);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does NOT suppress a non-recoverable auth failure (401) — must reach the fatal path", () => {
+    const nowRef = { value: 1_000 };
+    const { unregister } = setup(nowRef);
+    try {
+      const reason = gatewayMetadataError(
+        "Discord API /gateway/bot failed (401): 401: Unauthorized",
+      );
+      expect(isUnhandledRejectionHandled(reason)).toBe(false);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does NOT suppress a 403 auth failure", () => {
+    const nowRef = { value: 1_000 };
+    const { unregister } = setup(nowRef);
+    try {
+      const reason = gatewayMetadataError("Discord API /gateway/bot failed (403): Missing Access");
+      expect(isUnhandledRejectionHandled(reason)).toBe(false);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does NOT suppress rejections without the gateway-metadata message (incl. reasonless)", () => {
+    const nowRef = { value: 1_000 };
+    const { unregister } = setup(nowRef);
+    try {
+      // Unrelated error — outside this handler's scope.
+      expect(isUnhandledRejectionHandled(new Error("some unrelated failure"))).toBe(false);
+      // Reasonless (undefined) rejections are Slack socket-mode's vector, not Discord's — this
+      // handler must ignore them so it does not poach a different adapter's classification.
+      expect(isUnhandledRejectionHandled(undefined)).toBe(false);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does NOT suppress once the connect window elapses with no further gateway activity", () => {
+    const nowRef = { value: 1_000 };
+    const { unregister } = setup(nowRef);
+    try {
+      nowRef.value = 1_000 + DISCORD_GATEWAY_REJECTION_WINDOW_MS + 1; // just past the window
+      const reason = gatewayMetadataError("Discord API /gateway/bot failed (429): rate limited");
+      expect(isUnhandledRejectionHandled(reason)).toBe(false);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("refreshes the window on a Carbon gateway emitter error/debug event", () => {
+    const nowRef = { value: 1_000 };
+    const { emitter, unregister } = setup(nowRef);
+    try {
+      // Past the construction window...
+      nowRef.value = 1_000 + DISCORD_GATEWAY_REJECTION_WINDOW_MS + 1;
+      // ...but a fresh gateway lifecycle event re-stamps the window (GatewayPlugin emits "debug" on
+      // reconnect, "error" on ws failure).
+      emitter.emit("debug", "Reconnecting with backoff: 1000ms");
+      const reason = gatewayMetadataError("Discord API /gateway/bot failed (429): rate limited");
+      expect(isUnhandledRejectionHandled(reason)).toBe(true);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("stops suppressing after unregister (finally-block cleanup)", () => {
+    const nowRef = { value: 1_000 };
+    const { unregister } = setup(nowRef);
+    unregister();
+    const reason = gatewayMetadataError("Discord API /gateway/bot failed (429): rate limited");
+    expect(isUnhandledRejectionHandled(reason)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Same crash class as #2652 (Slack), different adapter and trigger. During Discord gateway **startup**, a non-transient `/gateway/bot` HTTP error (a `429`, or invalid JSON from a proxy/Cloudflare interstitial on a `2xx`) produces an **unhandled promise rejection** the central rejection handler cannot classify, so it falls to the fatal default and calls `process.exit(1)` — taking down the **entire gateway (all channels), not just Discord**.

Closes #2692.

## Root cause

1. `@buape/carbon`'s `Client` constructor calls plugins **floating** — no `await`, no `.catch` (`Client.js:122`), invoked from the synchronous `new Client(...)` in `provider.ts`.
2. The fork's gateway plugin overrides `registerClient` as **`async`** and awaits a network fetch (`gateway-plugin.ts:154`).
3. `fetchDiscordGatewayInfo` `throw`s `createGatewayMetadataError({ transient: false })` on a non-transient `/gateway/bot` response. `isTransientDiscordGatewayResponse` returns `true` only for `status >= 500` (or specific bodies), so a **`429`** is non-transient, as is **invalid JSON on a `2xx`**.
4. Because the override is `async` and called floating from the **synchronous** constructor, the rejection is neither awaited nor `.catch`'d — it escapes to Node's `unhandledRejection`.
5. The central handler (`src/infra/unhandled-rejections.ts`) cannot classify the error (generic `Error`, no `code`/`errno`, no recognized transient snippet) → falls through to the fatal default → `process.exit(1)`.

### Why existing protection doesn't cover this

`attachEarlyGatewayErrorGuard` only handles the EventEmitter path (`emitter.on("error", ...)`) — it does **not** catch a rejected Promise. Discord registered no `registerUnhandledRejectionHandler` (unlike `slack`/`telegram`/`whatsapp`).

## Fix

Channel-scoped `registerUnhandledRejectionHandler` in `monitorDiscordProvider`, mirroring the sanctioned Slack fix (#2652 / #2691):

- Stamps a short (10s) suppression window at `new Client()` construction — the reject can fire at connect, **before any emitter event** — and refreshes it on the Carbon gateway emitter's `error`/`debug` events.
- Within the window, **suppresses** rejections whose message matches `/Failed to get gateway information from Discord/` (the `createGatewayMetadataError` wrapper) for recoverable statuses (`429` / `5xx` / invalid-JSON), letting the monitor's startup path recover.
- Lets a clearly **non-recoverable** auth failure (`401`/`403`) fall through to the fatal path (analogous to Slack's `isNonRecoverableSlackAuthError`).
- Registered right after `new Client()` (before the first `await`, so the handler is in place when the floating promise rejects); unregistered in the `finally` block.

Tighter blast radius than globally widening "transient"; safe to remove once an upstream Carbon fix lands and is synced.

> **Alternative considered:** tagging `429`/invalid-JSON as transient in `createGatewayMetadataError`'s non-transient branch — simpler, but widens "transient" semantics; the scoped handler is the closer mirror of the sanctioned #2652 fix.

## Test

New `extensions/discord/src/monitor/provider.unhandled-rejection.test.ts` — 8 cases at the `isUnhandledRejectionHandled` seam (the exact gate the central handler checks before `process.exit(1)`, so `true` = "gateway does not crash", `false` = the #2692 crash path):

- non-transient `429` and invalid-JSON gateway-metadata rejection → suppressed (+ observable log)
- non-recoverable `401` / `403` auth failure → **NOT** suppressed (reaches the fatal path)
- unrelated / reasonless (`undefined`) rejection → **NOT** suppressed (does not poach other adapters' vectors)
- window elapsed with no further gateway activity → **NOT** suppressed; a fresh emitter `error`/`debug` event refreshes the window
- stops suppressing after `unregister` (finally-block cleanup)

## Verification

- `pnpm check` (format + tsgo + oxlint type-aware + no-random-messaging + no-remoteclaw-ai + css-class-drift) — **green (exit 0)**.
- New regression suite — **8/8 passing**.
- Fork-integrity: no `@ts-expect-error`; stub-debt gate (`136 == baseline 136`); throwing-stub-callers 0 violations; zombie-import clean; fake placeholders only in the test.
- Pre-existing `provider.rest-proxy.test.ts` failures (proxy-env resolution) confirmed **identical on clean `origin/main`** (verified via stash) → pre-existing macOS-runner env artifacts, unrelated to this change.

This is an upstream-inherited bug class (Carbon's floating plugin registration), not fork-introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
