### PR TITLE
ci(rebrand-gate): assert native binary-name fork identity in Package.swift (#2697)

### DIFF
--- a/scripts/ci/check-rebrand-leakage.sh
+++ b/scripts/ci/check-rebrand-leakage.sh
@@ -23,6 +23,17 @@
 #                       v2026.4.12 sync reverted apps/android/app/build.gradle.kts
 #                       to `ai.openclaw.app` and scan 1 stayed GREEN.
 #
+#   3. Positive-presence — some fork identities are NAMES, not reverse-domains:
+#                       apps/macos/Package.swift declares the `remoteclaw-mac`
+#                       executable and the `RemoteClawMacCLI` target. A wholesale
+#                       revert to upstream's binary names is invisible to scan 1
+#                       (apps/ is broadly allowlisted) and scan 2 (Package.swift
+#                       is not a reverse-domain manifest), so assert PRESENCE of
+#                       the fork name directly. Unlike scans 1 & 2, this scan runs
+#                       UNCONDITIONALLY (independent of the changed-file set) so a
+#                       latent reversion already on the base branch is caught too;
+#                       a missing anchor file is tolerated. See issue #2697.
+#
 # Modes:
 #   --staged   Pre-commit: checks staged files only
 #   --all      Full scan: checks entire repo
@@ -137,8 +148,10 @@ FILE_LIST="$CLEANUP_DIR/file-list.bin"
 list_files > "$FILE_LIST"
 
 if [[ ! -s "$FILE_LIST" ]]; then
-  echo "No files to check."
-  exit 0
+  # No changed/listed files for the diff-scoped leakage scans (1 & 2) — but the
+  # positive-presence anchor scan (3) below runs UNCONDITIONALLY, so do not exit
+  # here. Scans 1 & 2 no-op safely on an empty file list.
+  echo "No changed files to scan for leakage."
 fi
 
 # --- Scan 1: generic openclaw leakage (broad allowlist) ----------------------
@@ -170,6 +183,32 @@ REV_PATTERNS="$CLEANUP_DIR/rev-patterns.txt"
 load_allowlist "$REVERSE_DOMAIN_ALLOWLIST" "$REV_FILES" "$REV_DIRS" "$REV_PATTERNS"
 reverse_domain_violations=$(scan 'ai.openclaw' "$MANIFEST_LIST" "$REV_FILES" "$REV_DIRS" "$REV_PATTERNS")
 
+# --- Scan 3: positive-presence fork-identity anchors -------------------------
+#
+# Assert that fork identities expressed as NAMES (not reverse-domains) are still
+# present in the manifest that must carry them. Each anchor is "<file>|<required>"
+# — the file is read on disk at HEAD, independent of the changed-file set, so a
+# latent reversion already on the base branch is caught too. A MISSING anchor
+# file is tolerated (the macOS app may be legitimately gutted — RemoteClaw is
+# CLI-only middleware); only a present-but-reverted file is a violation. To
+# extend coverage (e.g. an org.remoteclaw.* Info.plist identity), add a row.
+
+ANCHORS=(
+  "apps/macos/Package.swift|remoteclaw-mac"
+  "apps/macos/Package.swift|RemoteClawMacCLI"
+)
+
+anchor_violations=""
+for entry in "${ANCHORS[@]}"; do
+  anchor_file="${entry%%|*}"
+  anchor_required="${entry#*|}"
+  [[ -f "$anchor_file" ]] || continue
+  if ! grep -qF -- "$anchor_required" "$anchor_file"; then
+    anchor_violations+="$anchor_file: missing required fork identity '$anchor_required'"$'\n'
+  fi
+done
+anchor_violations="${anchor_violations%$'\n'}"
+
 # --- Report ------------------------------------------------------------------
 
 status=0
@@ -197,6 +236,24 @@ if [[ -n "$reverse_domain_violations" ]]; then
   echo "Fix: replace ai.openclaw* with org.remoteclaw.*, or — only for a verified"
   echo "     migration-compat case — add an exemption to"
   echo "     scripts/ci/rebrand-reverse-domain-allowlist.txt"
+  status=1
+fi
+
+if [[ -n "$anchor_violations" ]]; then
+  [[ $status -ne 0 ]] && echo ""
+  count=$(printf '%s\n' "$anchor_violations" | wc -l | tr -d ' ')
+  echo "Fork-identity anchor missing ($count violation(s)):"
+  echo ""
+  printf '%s\n' "$anchor_violations" | sed 's/^/  /'
+  echo ""
+  echo "A required fork-identity NAME is absent from a manifest that must carry it"
+  echo "(e.g. the remoteclaw-mac executable / RemoteClawMacCLI target in"
+  echo "apps/macos/Package.swift). This is the binary-name analogue of a reverse-domain"
+  echo "identity reversion — invisible to scan 1 (apps/ is allowlisted) and scan 2"
+  echo "(Package.swift is not a reverse-domain manifest). See #2697."
+  echo "Fix: restore the fork-identity name; or — only if the subsystem was"
+  echo "     intentionally removed — drop the stale anchor from"
+  echo "     scripts/ci/check-rebrand-leakage.sh."
   status=1
 fi
 

--- a/scripts/ci/rebrand-allowlist.txt
+++ b/scripts/ci/rebrand-allowlist.txt
@@ -12,6 +12,9 @@
 FILE:scripts/ci/check-rebrand-leakage.sh
 FILE:scripts/ci/rebrand-allowlist.txt
 FILE:scripts/ci/rebrand-reverse-domain-allowlist.txt
+# The gate's own test fixtures carry upstream-style names (`openclaw-mac`,
+# `OpenClawMacCLI`, bare `openclaw` in prose) by design — see issue #2697.
+FILE:test/scripts/check-rebrand-leakage.test.ts
 
 # ---------------------------------------------------------------------------
 # Upstream release workflow and compat scripts

--- a/test/scripts/check-rebrand-leakage.test.ts
+++ b/test/scripts/check-rebrand-leakage.test.ts
@@ -1,0 +1,136 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+// Exercises scripts/ci/check-rebrand-leakage.sh "scan 3" (positive-presence
+// fork-identity anchors). The macOS Package.swift carries the fork's binary
+// identity as NAMES (`remoteclaw-mac` executable + `RemoteClawMacCLI` target)
+// rather than a reverse-domain string, so a wholesale revert to upstream's
+// names is invisible to scan 1 (apps/ is broadly allowlisted) and scan 2
+// (Package.swift is not a reverse-domain manifest). See issue #2697.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+
+const GATE_REL = "scripts/ci/check-rebrand-leakage.sh";
+const GATE_FILES = [
+  GATE_REL,
+  "scripts/ci/rebrand-allowlist.txt",
+  "scripts/ci/rebrand-reverse-domain-allowlist.txt",
+];
+const PACKAGE_REL = "apps/macos/Package.swift";
+
+// Minimal but representative SwiftPM manifest carrying both fork-identity names.
+const FORK_PACKAGE = [
+  "// swift-tools-version: 6.2",
+  "import PackageDescription",
+  "let package = Package(",
+  '    name: "RemoteClaw",',
+  "    products: [",
+  '        .executable(name: "remoteclaw-mac", targets: ["RemoteClawMacCLI"]),',
+  "    ],",
+  "    targets: [",
+  '        .executableTarget(name: "RemoteClawMacCLI", path: "Sources/RemoteClawMacCLI"),',
+  "    ])",
+  "",
+].join("\n");
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+// Builds a throwaway git repo containing the REAL gate + its REAL allowlists, so
+// the test exercises the actual apps/ exemption that lets a binary-name revert
+// slip past scans 1 & 2. `packageBody === null` omits Package.swift entirely.
+function makeRepo(packageBody: string | null): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-rebrand-gate-"));
+  tempDirs.push(dir);
+  git(dir, "init", "-q");
+  git(dir, "config", "user.email", "test@example.com");
+  git(dir, "config", "user.name", "Test User");
+
+  const tracked: string[] = [];
+  for (const rel of GATE_FILES) {
+    const dest = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(path.join(repoRoot, rel), dest);
+    tracked.push(rel);
+  }
+  if (packageBody !== null) {
+    const dest = path.join(dir, PACKAGE_REL);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, packageBody);
+    tracked.push(PACKAGE_REL);
+  }
+
+  git(dir, "add", "--", ...tracked);
+  git(dir, "commit", "-q", "-m", "fixture");
+  return dir;
+}
+
+// Runs the gate in --all mode; returns exit status + combined output.
+function runGate(repo: string): { status: number; output: string } {
+  try {
+    const stdout = execFileSync("bash", [GATE_REL, "--all"], {
+      cwd: repo,
+      encoding: "utf8",
+    });
+    return { status: 0, output: stdout };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { status: e.status ?? 1, output: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+  }
+}
+
+describe("check-rebrand-leakage scan 3 (fork-identity anchors)", () => {
+  it("passes when Package.swift carries both fork-identity names", () => {
+    const { status, output } = runGate(makeRepo(FORK_PACKAGE));
+    expect(status).toBe(0);
+    expect(output).toContain("No rebrand leakage detected.");
+  });
+
+  it("fails when the remoteclaw-mac executable name is absent", () => {
+    // Neutral replacement (no `openclaw` substring) isolates scan 3 from scan 1.
+    const reverted = FORK_PACKAGE.replaceAll("remoteclaw-mac", "binary-mac");
+    const { status, output } = runGate(makeRepo(reverted));
+    expect(status).toBe(1);
+    expect(output).toContain(PACKAGE_REL);
+    expect(output).toContain("missing required fork identity 'remoteclaw-mac'");
+  });
+
+  it("fails when the RemoteClawMacCLI target name is absent", () => {
+    const reverted = FORK_PACKAGE.replaceAll("RemoteClawMacCLI", "BinaryMacCLI");
+    const { status, output } = runGate(makeRepo(reverted));
+    expect(status).toBe(1);
+    expect(output).toContain("missing required fork identity 'RemoteClawMacCLI'");
+  });
+
+  it("catches a realistic upstream revert that scan 1's apps/ allowlist masks", () => {
+    // `openclaw-mac` / `OpenClawMacCLI` DO contain `openclaw`, but live under
+    // apps/ which scan 1 broadly exempts — so only scan 3 can catch this.
+    const reverted = FORK_PACKAGE.replaceAll("remoteclaw-mac", "openclaw-mac").replaceAll(
+      "RemoteClawMacCLI",
+      "OpenClawMacCLI",
+    );
+    const { status, output } = runGate(makeRepo(reverted));
+    expect(status).toBe(1);
+    expect(output).toContain("missing required fork identity 'remoteclaw-mac'");
+  });
+
+  it("tolerates a legitimately-absent anchor file (subsystem gutted)", () => {
+    const { status, output } = runGate(makeRepo(null));
+    expect(status).toBe(0);
+    expect(output).toContain("No rebrand leakage detected.");
+  });
+});


### PR DESCRIPTION
Closes #2697.

## Problem

The rebrand leakage gate (`scripts/ci/check-rebrand-leakage.sh`) has two scans:

1. **Scan 1** — generic `openclaw` leakage, but it **broadly allowlists `apps/`** (`FILE:apps/` in `rebrand-allowlist.txt`).
2. **Scan 2** — reverse-domain `ai.openclaw` reversion, scoped to `*.gradle.kts / *.pbxproj / *.entitlements / *Info.plist / *AndroidManifest.xml`.

`apps/macos/Package.swift` carries the fork's identity as a **binary name** — the `remoteclaw-mac` executable and `RemoteClawMacCLI` target — not a reverse-domain string. A wholesale revert to upstream's names therefore falls through **both** scans: scan 2 has no `ai.openclaw` string to match (and `Package.swift` isn't even in its file list), and scan 1's `apps/` allowlist exempts the `openclaw`-bearing reverted names.

Verified empirically before the fix — a reverted `Package.swift` (`openclaw-mac` / `OpenClawMacCLI`) passed the gate with exit 0.

## Fix

Adds **Scan 3 — positive-presence fork-identity anchors**: assert the fork-identity *names* are present (presence-of-fork-name, not absence-of-upstream-reverse-domain), so it's robust regardless of what the upstream name is.

- Runs **unconditionally** (independent of the changed-file set) so a latent reversion already on the base branch is caught too.
- **Tolerates a missing anchor file** (the macOS app may be legitimately gutted — RemoteClaw is CLI-only middleware); only a *present-but-reverted* file is a violation.
- Driven by a small extensible `ANCHORS` table (`<file>|<required>`); anchors: `apps/macos/Package.swift` → `remoteclaw-mac` + `RemoteClawMacCLI`.

### Deferred (issue's *optional* extension)

The Info.plist `org.remoteclaw.*` positive-presence anchors are **deferred**: scan 2 already catches the likely reversion (`ai.openclaw.*`) for those manifests, and plist bundle-IDs are less structurally stable than SwiftPM product/target names (they can migrate to xcconfig/pbxproj). The `ANCHORS` table makes adding them a one-line change if a concrete need arises.

## Testing

New vitest `test/scripts/check-rebrand-leakage.test.ts` (5 cases, modeled on the existing `check-no-conflict-markers.test.ts` sibling), each running the real gate against a throwaway git repo built from the **real** script + allowlists:

- ✅ passes when both fork-identity names present
- ✅ fails when `remoteclaw-mac` absent (neutral replacement — isolates Scan 3 from Scan 1)
- ✅ fails when `RemoteClawMacCLI` absent
- ✅ catches a realistic upstream revert that Scan 1's `apps/` allowlist masks
- ✅ tolerates a legitimately-absent anchor file

Local verification: vitest 5/5 · `shellcheck` clean · `pnpm check` (format + tsgo + oxlint type-aware + drift gates) clean · real gate `--all` and `--staged` exit 0.

## Files

- `scripts/ci/check-rebrand-leakage.sh` — Scan 3 + run-unconditionally on empty diff
- `test/scripts/check-rebrand-leakage.test.ts` — new coverage
- `scripts/ci/rebrand-allowlist.txt` — self-exempt the gate's own test fixtures (they carry upstream-style names by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
