### PR TITLE
chore: bump upstreamVersion to 2026.4.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -455,5 +455,5 @@
     ]
   },
   "upstreamRepo": "openclaw/openclaw",
-  "upstreamVersion": "2026.4.15"
+  "upstreamVersion": "2026.4.20"
 }


### PR DESCRIPTION
## Summary

The v2026.4.20 upstream sync (#2700) bumped the README upstream badge to `v2026.4.20` but left `package.json`'s `upstreamVersion` field at `2026.4.15`. Every prior sync bumped this field inside the sync squash; this PR realigns the provenance metadata with the actual synced upstream version.

## Detail

- `package.json` `upstreamVersion`: `2026.4.15` → `2026.4.20` (one line).
- The README badge already reads `v2026.4.20` (embedded in the sync squash), so this only closes the gap between the two indicators.
- No behavior change — `upstreamVersion` is provenance metadata; the package's own `name` (`remoteclaw`) and `version` (`0.8.0`) are unaffected.

## Verification

- `package.json` remains valid JSON (single value edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)