### PR TITLE
fix(cron): clear unresolved next-run to stop refire loops (#2702)

### DIFF
--- a/src/cron/service.issue-66019-unresolved-next-run.test.ts
+++ b/src/cron/service.issue-66019-unresolved-next-run.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createDefaultIsolatedRunner,
+  createIsolatedRegressionJob,
+  noopLogger,
+  setupCronRegressionFixtures,
+  writeCronJobs,
+} from "../../test/helpers/cron/service-regression-fixtures.js";
+import * as schedule from "./schedule.js";
+import { createCronServiceState } from "./service/state.js";
+import { onTimer } from "./service/timer.js";
+
+// Regression coverage for the upstream "unresolved next-run" cron fix (#66083),
+// ported into the fork's consolidated cron service. When `computeNextRunAtMs`
+// cannot resolve a cron job's next run, `applyJobResult` must NOT synthesize a
+// phantom run time (the MIN_REFIRE_GAP_MS guard or the error backoff delay):
+// a synthesized time looks "due" on the next tick and refires the job forever.
+// Instead the schedule is cleared, and the existing maintenance recheck
+// (`armTimer` + `recomputeNextRunsForMaintenance`) re-arms the job so it fires
+// again once the next run becomes resolvable.
+const issue66019Fixtures = setupCronRegressionFixtures({ prefix: "cron-66019-" });
+
+function createIssue66019Job(params: { id: string; scheduledAt: number }) {
+  return createIsolatedRegressionJob({
+    id: params.id,
+    name: params.id,
+    scheduledAt: params.scheduledAt,
+    schedule: { kind: "cron", expr: "0 7 * * *", tz: "Asia/Shanghai" },
+    payload: { kind: "agentTurn", message: "ping" },
+    state: { nextRunAtMs: params.scheduledAt - 1_000 },
+  });
+}
+
+function createIssue66019State(params: {
+  storePath: string;
+  nowMs: () => number;
+  runIsolatedAgentJob: Parameters<typeof createCronServiceState>[0]["runIsolatedAgentJob"];
+}) {
+  return createCronServiceState({
+    cronEnabled: true,
+    storePath: params.storePath,
+    log: noopLogger,
+    nowMs: params.nowMs,
+    enqueueSystemEvent: vi.fn(),
+    requestHeartbeatNow: vi.fn(),
+    runIsolatedAgentJob: params.runIsolatedAgentJob,
+  });
+}
+
+function clearCronTimer(state: ReturnType<typeof createCronServiceState>) {
+  if (state.timer) {
+    clearTimeout(state.timer);
+    state.timer = null;
+  }
+}
+
+async function expectJobDoesNotRefireWhenNextRunIsUnresolved(params: {
+  state: ReturnType<typeof createCronServiceState>;
+  runIsolatedAgentJob: unknown;
+  advanceNow: () => void;
+}) {
+  await onTimer(params.state);
+  expect(params.runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+  expect(params.state.store?.jobs[0]?.state.nextRunAtMs).toBeUndefined();
+
+  params.advanceNow();
+  await onTimer(params.state);
+
+  expect(params.runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+  expect(params.state.store?.jobs[0]?.state.nextRunAtMs).toBeUndefined();
+}
+
+describe("#66019 unresolved next-run repro", () => {
+  it("does not refire a recurring cron job 2s later when next-run resolution returns undefined", async () => {
+    const store = issue66019Fixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-04-13T15:40:00.000Z");
+    let now = scheduledAt;
+
+    const cronJob = createIssue66019Job({
+      id: "cron-66019-minimal-success",
+      scheduledAt,
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    const runIsolatedAgentJob = createDefaultIsolatedRunner();
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockReturnValue(undefined);
+    const state = createIssue66019State({
+      storePath: store.storePath,
+      nowMs: () => now,
+      runIsolatedAgentJob,
+    });
+
+    try {
+      // Before the fix, applyJobResult would synthesize endedAt + 2_000 here,
+      // so a second tick a couple seconds later would refire the same job.
+      await expectJobDoesNotRefireWhenNextRunIsUnresolved({
+        state,
+        runIsolatedAgentJob,
+        advanceNow: () => {
+          now = scheduledAt + 2_001;
+        },
+      });
+    } finally {
+      nextRunSpy.mockRestore();
+      clearCronTimer(state);
+    }
+  });
+
+  it("does not refire a recurring errored cron job after the first backoff window when next-run resolution returns undefined", async () => {
+    const store = issue66019Fixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-04-13T15:45:00.000Z");
+    let now = scheduledAt;
+
+    const cronJob = createIssue66019Job({
+      id: "cron-66019-minimal-error",
+      scheduledAt,
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    const runIsolatedAgentJob = vi.fn().mockResolvedValue({
+      status: "error",
+      error: "synthetic failure",
+    });
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockReturnValue(undefined);
+    const state = createIssue66019State({
+      storePath: store.storePath,
+      nowMs: () => now,
+      runIsolatedAgentJob,
+    });
+
+    try {
+      // Before the fix, the error branch would synthesize the first backoff
+      // retry (30s), so the next tick after that window would rerun the job.
+      await expectJobDoesNotRefireWhenNextRunIsUnresolved({
+        state,
+        runIsolatedAgentJob,
+        advanceNow: () => {
+          now = scheduledAt + 30_001;
+        },
+      });
+    } finally {
+      nextRunSpy.mockRestore();
+      clearCronTimer(state);
+    }
+  });
+
+  it("reschedules and fires on a later tick once the next run becomes resolvable", async () => {
+    const store = issue66019Fixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-04-13T15:50:00.000Z");
+    let now = scheduledAt;
+
+    const cronJob = createIssue66019Job({
+      id: "cron-66019-recovers",
+      scheduledAt,
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    const runIsolatedAgentJob = createDefaultIsolatedRunner();
+    // The next run is unresolved until `resolvable` flips, then becomes a
+    // concrete future time. A flag-based mock keeps the test robust to the
+    // exact number of internal computeNextRunAtMs calls per tick. The
+    // `0 7 * * *` expression has no stagger offset, so the resolved value maps
+    // directly onto nextRunAtMs.
+    let resolvable = false;
+    const resolvedNext = scheduledAt + 60_000;
+    const nextRunSpy = vi
+      .spyOn(schedule, "computeNextRunAtMs")
+      .mockImplementation(() => (resolvable ? resolvedNext : undefined));
+    const state = createIssue66019State({
+      storePath: store.storePath,
+      nowMs: () => now,
+      runIsolatedAgentJob,
+    });
+
+    try {
+      // First tick: the job runs once, but its next run is unresolved, so the
+      // schedule is cleared instead of synthesizing a phantom refire time.
+      await onTimer(state);
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      expect(state.store?.jobs[0]?.state.nextRunAtMs).toBeUndefined();
+
+      // The next run becomes resolvable. A maintenance tick repairs the missing
+      // nextRunAtMs without firing the job (it is not due yet).
+      resolvable = true;
+      now = scheduledAt + 1;
+      await onTimer(state);
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      expect(state.store?.jobs[0]?.state.nextRunAtMs).toBe(resolvedNext);
+
+      // Once the repaired next run is due, the job fires again.
+      now = resolvedNext + 1;
+      await onTimer(state);
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
+    } finally {
+      nextRunSpy.mockRestore();
+      clearCronTimer(state);
+    }
+  });
+});

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1811,11 +1811,14 @@ describe("Cron issue regressions", () => {
     expect(job.state.lastStatus).toBe("ok");
     expect(job.state.scheduleErrorCount).toBe(1);
     expect(job.state.lastError).toMatch(/^schedule error:/);
-    expect(job.state.nextRunAtMs).toBe(endedAt + 2_000);
+    // An unresolvable cron next run clears the schedule rather than synthesizing
+    // a phantom MIN_REFIRE_GAP_MS retry; scheduleErrorCount tracks the throw and
+    // the maintenance recheck re-attempts on a later tick (#66019).
+    expect(job.state.nextRunAtMs).toBeUndefined();
     expect(job.enabled).toBe(true);
   });
 
-  it("falls back to backoff schedule when cron next-run computation throws on error path (#30905)", () => {
+  it("keeps state updates when cron next-run computation throws on error path (#30905)", () => {
     const startedAt = Date.parse("2026-03-02T12:05:00.000Z");
     const endedAt = startedAt + 25;
     const state = createCronServiceState({
@@ -1850,8 +1853,94 @@ describe("Cron issue regressions", () => {
     expect(job.state.consecutiveErrors).toBe(1);
     expect(job.state.scheduleErrorCount).toBe(1);
     expect(job.state.lastError).toMatch(/^schedule error:/);
-    expect(job.state.nextRunAtMs).toBe(endedAt + 30_000);
+    // An unresolvable cron next run clears the schedule rather than synthesizing
+    // a phantom backoff retry; scheduleErrorCount tracks the throw and the
+    // maintenance recheck re-attempts on a later tick (#66019).
+    expect(job.state.nextRunAtMs).toBeUndefined();
     expect(job.enabled).toBe(true);
+  });
+
+  it("does not synthesize a 2s retry when cron schedule computation returns undefined (#66019)", () => {
+    const startedAt = Date.parse("2026-04-13T15:40:00.000Z");
+    const endedAt = startedAt + 50;
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/tmp/cron-66019-success.json",
+      log: noopLogger,
+      nowMs: () => endedAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    const job = createIsolatedRegressionJob({
+      id: "cron-66019-success",
+      name: "cron-66019-success",
+      scheduledAt: startedAt,
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "Asia/Shanghai" },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: { nextRunAtMs: startedAt - 1_000, runningAtMs: startedAt - 500 },
+    });
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockReturnValue(undefined);
+
+    try {
+      const shouldDelete = applyJobResult(state, job, {
+        status: "ok",
+        delivered: true,
+        startedAt,
+        endedAt,
+      });
+
+      expect(shouldDelete).toBe(false);
+      expect(job.state.runningAtMs).toBeUndefined();
+      expect(job.state.lastRunAtMs).toBe(startedAt);
+      expect(job.state.lastStatus).toBe("ok");
+      expect(job.state.nextRunAtMs).toBeUndefined();
+      expect(job.enabled).toBe(true);
+    } finally {
+      nextRunSpy.mockRestore();
+    }
+  });
+
+  it("does not synthesize transient retries when cron schedule computation returns undefined (#66019)", () => {
+    const startedAt = Date.parse("2026-04-13T15:45:00.000Z");
+    const endedAt = startedAt + 25;
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/tmp/cron-66019-error.json",
+      log: noopLogger,
+      nowMs: () => endedAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    const job = createIsolatedRegressionJob({
+      id: "cron-66019-error",
+      name: "cron-66019-error",
+      scheduledAt: startedAt,
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "Asia/Shanghai" },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: { nextRunAtMs: startedAt - 1_000, runningAtMs: startedAt - 500 },
+    });
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockReturnValue(undefined);
+
+    try {
+      const shouldDelete = applyJobResult(state, job, {
+        status: "error",
+        error: "429 rate limit exceeded",
+        startedAt,
+        endedAt,
+      });
+
+      expect(shouldDelete).toBe(false);
+      expect(job.state.runningAtMs).toBeUndefined();
+      expect(job.state.lastRunAtMs).toBe(startedAt);
+      expect(job.state.lastStatus).toBe("error");
+      expect(job.state.consecutiveErrors).toBe(1);
+      expect(job.state.nextRunAtMs).toBeUndefined();
+      expect(job.enabled).toBe(true);
+    } finally {
+      nextRunSpy.mockRestore();
+    }
   });
 
   it("force run preserves 'every' anchor while recording manual lastRunAtMs", () => {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -150,6 +150,41 @@ function isTransientCronError(error: string | undefined, retryOn?: CronRetryOn[]
   return keys.some((k) => TRANSIENT_PATTERNS[k]?.test(error));
 }
 
+/**
+ * Resolve the next run time for a recurring `cron` job, clamped to a lower
+ * bound (the backoff delay or the MIN_REFIRE_GAP_MS spin-loop guard).
+ *
+ * When the natural next run cannot be resolved (`computeJobNextRunAtMs`
+ * returned `undefined` — e.g. a timezone/DST edge case or a temporarily
+ * unresolvable expression), DO NOT synthesize a phantom run time from the
+ * lower bound. A synthesized time looks "due" on the next tick and refires
+ * the job forever even though its schedule never actually resolved. Instead,
+ * clear the schedule (return `undefined`); `armTimer` keeps a maintenance
+ * recheck armed while enabled jobs exist, and `recomputeNextRunsForMaintenance`
+ * always repairs a missing nextRunAtMs, so the job fires again on a later tick
+ * once the next run becomes resolvable. (Ported from upstream #66083.)
+ */
+function resolveCronNextRunWithLowerBound(params: {
+  state: CronServiceState;
+  job: CronJob;
+  naturalNext: number | undefined;
+  lowerBoundMs: number;
+  context: "completion" | "error_backoff";
+}): number | undefined {
+  if (params.naturalNext === undefined) {
+    params.state.deps.log.warn(
+      {
+        jobId: params.job.id,
+        jobName: params.job.name,
+        context: params.context,
+      },
+      "cron: next run unresolved; clearing schedule to avoid a refire loop",
+    );
+    return undefined;
+  }
+  return Math.max(params.naturalNext, params.lowerBoundMs);
+}
+
 function resolveRetryConfig(cronConfig?: CronConfig) {
   const retry = cronConfig?.retry;
   return {
@@ -400,8 +435,21 @@ export function applyJobResult(
       }
       const backoffNext = result.endedAt + backoff;
       // Use whichever is later: the natural next run or the backoff delay.
+      // For `cron` jobs an unresolved natural next clears the schedule (so the
+      // backoff delay is not synthesized into a refire loop); `every` jobs keep
+      // the backoff-only fallback since their next run is derived arithmetically.
       job.state.nextRunAtMs =
-        normalNext !== undefined ? Math.max(normalNext, backoffNext) : backoffNext;
+        job.schedule.kind === "cron"
+          ? resolveCronNextRunWithLowerBound({
+              state,
+              job,
+              naturalNext: normalNext,
+              lowerBoundMs: backoffNext,
+              context: "error_backoff",
+            })
+          : normalNext !== undefined
+            ? Math.max(normalNext, backoffNext)
+            : backoffNext;
       state.deps.log.info(
         {
           jobId: job.id,
@@ -430,8 +478,13 @@ export function applyJobResult(
         // schedule computation lands in the same second due to
         // timezone/croner edge cases (see #17821).
         const minNext = result.endedAt + MIN_REFIRE_GAP_MS;
-        job.state.nextRunAtMs =
-          naturalNext !== undefined ? Math.max(naturalNext, minNext) : minNext;
+        job.state.nextRunAtMs = resolveCronNextRunWithLowerBound({
+          state,
+          job,
+          naturalNext,
+          lowerBoundMs: minNext,
+          context: "completion",
+        });
       } else {
         job.state.nextRunAtMs = naturalNext;
       }


### PR DESCRIPTION
## Summary

Ports the upstream OpenClaw fix **#66083** (*"stop unresolved next-run refire loops"*) into the fork's consolidated cron service. Closes #2702.

**Root cause.** When `computeJobNextRunAtMs` cannot resolve a recurring **cron** job's next run (returns `undefined`, or throws → caught), `applyJobResult` synthesized a *phantom* `nextRunAtMs`:
- success path → `endedAt + MIN_REFIRE_GAP_MS` (the 2 s spin-loop guard)
- error path → `endedAt + backoff` (the error backoff delay)

A synthesized time looks **due** on the next tick, so the job refires forever even though its schedule never actually resolved.

**Fix.** Add `resolveCronNextRunWithLowerBound` (cron-kind only): when the natural next run is unresolved, **clear** the schedule (`undefined`) instead of synthesizing a time. `every` jobs keep the arithmetic backoff fallback unchanged. The fork *already* has the recovery half — `armTimer` keeps a maintenance recheck armed while enabled jobs exist, and `recomputeNextRunsForMaintenance` always repairs a missing `nextRunAtMs` — so once the masking phantom time is gone, an initially-unresolved job is correctly re-armed and fires on a later tick once its next run becomes resolvable, instead of silently stalling.

## Scope note (the "entangled refactor" the issue warns about)

The issue's referenced commit `e1fe71872c3` and follow-up `#66113` are written against upstream's **post-SQLite-migration** cron service; their test-case-3 backoff-floor semantics depend on that larger timer refactor (which "does not apply cleanly to the fork"). This PR ports `#66083` — the coherent, minimal fix that satisfies both acceptance criteria — and intentionally does not drag in the SQLite-era evolution.

## Changes

- `src/cron/service/timer.ts` — add `resolveCronNextRunWithLowerBound`; apply it in both branches of `applyJobResult` for cron-kind jobs.
- `src/cron/service.issue-66019-unresolved-next-run.test.ts` *(new)* — `onTimer` integration coverage: no spurious refire (success + errored), **and** reschedule-and-fire on a later tick once the next run resolves.
- `src/cron/service.issue-regressions.test.ts` — reconcile the two `#30905` throw-path tests to the new clear-on-unresolved behavior (matching upstream verbatim), and add the unit-level `#66019` `applyJobResult` regression cases.

## Acceptance criteria

- [x] A cron job whose next run is initially unresolved is correctly rescheduled and fires on a subsequent tick (positive integration test).
- [x] A regression test asserts the refire behavior and passes in isolation (verified: all 3 new integration tests **fail** without the fix, pass with it).

## Verification

- `src/cron/` unit suite: **452 passed** (49 files).
- `pnpm check` (format + tsgo typecheck + oxlint type-aware + fork lint gates): clean.
- Fork-integrity gates (throwing-stub-callers, stub-debt, rebrand): clean.
- Touches `src/cron/`, not `src/middleware/`, so the LIVE smoke-test gate does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)