### PR TITLE
feat(security): port read-only channel resolution for security audit (#2703)

### DIFF
--- a/src/channels/read-only-account-inspect.test.ts
+++ b/src/channels/read-only-account-inspect.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RemoteClawConfig } from "../config/config.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import type { ChannelId, ChannelPlugin } from "./plugins/types.js";
+import { inspectReadOnlyChannelAccount } from "./read-only-account-inspect.js";
+
+const emptyRegistry = createTestRegistry([]);
+
+function registerChannelPlugin(plugin: ChannelPlugin): void {
+  setActivePluginRegistry(
+    createTestRegistry([{ pluginId: String(plugin.id), source: "test", plugin }]),
+  );
+}
+
+function buildPlugin(params: {
+  id: ChannelId;
+  config?: Partial<ChannelPlugin["config"]>;
+}): ChannelPlugin {
+  return createChannelTestPluginBase({ id: params.id, config: params.config }) as ChannelPlugin;
+}
+
+describe("inspectReadOnlyChannelAccount", () => {
+  afterEach(() => {
+    setActivePluginRegistry(emptyRegistry);
+  });
+
+  it("resolves account information via the channel plugin inspector", async () => {
+    const inspectAccount = vi.fn((_cfg: RemoteClawConfig, accountId?: string | null) => ({
+      accountId,
+      enabled: true,
+      configured: true,
+    }));
+    registerChannelPlugin(buildPlugin({ id: "discord", config: { inspectAccount } }));
+
+    const cfg = { channels: {} } as RemoteClawConfig;
+    const result = await inspectReadOnlyChannelAccount({
+      channelId: "discord",
+      cfg,
+      accountId: "default",
+    });
+
+    expect(result).toEqual({ accountId: "default", enabled: true, configured: true });
+    expect(inspectAccount).toHaveBeenCalledTimes(1);
+    expect(inspectAccount).toHaveBeenCalledWith(cfg, "default");
+  });
+
+  it("returns null when the channel plugin is not registered", async () => {
+    const result = await inspectReadOnlyChannelAccount({
+      channelId: "discord",
+      cfg: {} as RemoteClawConfig,
+      accountId: "default",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the registered plugin exposes no inspector", async () => {
+    registerChannelPlugin(buildPlugin({ id: "discord" }));
+    const result = await inspectReadOnlyChannelAccount({
+      channelId: "discord",
+      cfg: {} as RemoteClawConfig,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("awaits asynchronous inspectors", async () => {
+    const inspectAccount = vi.fn(async () => ({ enabled: false }));
+    registerChannelPlugin(buildPlugin({ id: "slack", config: { inspectAccount } }));
+    const result = await inspectReadOnlyChannelAccount({
+      channelId: "slack",
+      cfg: {} as RemoteClawConfig,
+    });
+    expect(result).toEqual({ enabled: false });
+  });
+
+  it("is side-effect-free: never invokes resolvers/mutators and never mutates config", async () => {
+    const inspectAccount = vi.fn((_cfg: RemoteClawConfig, accountId?: string | null) => ({
+      accountId,
+    }));
+    const resolveAccount = vi.fn(() => ({}));
+    const setAccountEnabled = vi.fn((params: { cfg: RemoteClawConfig }) => params.cfg);
+    registerChannelPlugin(
+      buildPlugin({
+        id: "discord",
+        config: { inspectAccount, resolveAccount, setAccountEnabled },
+      }),
+    );
+
+    const cfg = {
+      channels: { discord: { enabled: true, accounts: { default: {} } } },
+    } as RemoteClawConfig;
+    const before = JSON.stringify(cfg);
+
+    await inspectReadOnlyChannelAccount({ channelId: "discord", cfg, accountId: "default" });
+
+    expect(resolveAccount).not.toHaveBeenCalled();
+    expect(setAccountEnabled).not.toHaveBeenCalled();
+    expect(JSON.stringify(cfg)).toBe(before);
+  });
+});

--- a/src/channels/read-only-account-inspect.ts
+++ b/src/channels/read-only-account-inspect.ts
@@ -1,0 +1,32 @@
+import type { RemoteClawConfig } from "../config/config.js";
+import { getChannelPlugin } from "./plugins/registry.js";
+import type { ChannelId } from "./plugins/types.js";
+
+export type ReadOnlyInspectedAccount = Record<string, unknown>;
+
+/**
+ * Resolve a channel's account information for inspection without side effects.
+ *
+ * Read-only by construction: it only invokes the channel plugin's
+ * `config.inspectAccount` reader — never a mutator (`setAccountEnabled`,
+ * `resolveAccount`, etc.) — and performs no writes or state mutation. Returns
+ * `null` when the channel is not registered or exposes no inspector.
+ *
+ * Adapted for the RemoteClaw fork: channel plugins are resolved through the
+ * active registry via `getChannelPlugin`. Upstream additionally falls back to a
+ * bundled channel lazy-loader; the fork gutted that loader, so the active
+ * registry is the single resolution seam.
+ */
+export async function inspectReadOnlyChannelAccount(params: {
+  channelId: ChannelId;
+  cfg: RemoteClawConfig;
+  accountId?: string | null;
+}): Promise<ReadOnlyInspectedAccount | null> {
+  const inspectAccount = getChannelPlugin(params.channelId)?.config.inspectAccount;
+  if (!inspectAccount) {
+    return null;
+  }
+  return (await Promise.resolve(
+    inspectAccount(params.cfg, params.accountId),
+  )) as ReadOnlyInspectedAccount | null;
+}

--- a/src/security/audit-channel-read-only-inspect.test.ts
+++ b/src/security/audit-channel-read-only-inspect.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPlugin } from "../channels/plugins/types.js";
+import type { RemoteClawConfig } from "../config/config.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { collectChannelSecurityFindings } from "./audit-channel.js";
+
+const emptyRegistry = createTestRegistry([]);
+
+describe("security audit read-only channel resolution", () => {
+  afterEach(() => {
+    setActivePluginRegistry(emptyRegistry);
+  });
+
+  it("resolves channel account info via the read-only inspect path when the audited plugin exposes no inspector", async () => {
+    const inspectAccount = vi.fn((_cfg: RemoteClawConfig, accountId?: string | null) => ({
+      accountId,
+      enabled: true,
+      configured: true,
+      config: { dangerouslyAllowNameMatching: true },
+    }));
+
+    // The registry-resolved plugin exposes the read-only inspector...
+    const registeredPlugin = {
+      ...createChannelTestPluginBase({
+        id: "discord",
+        config: { listAccountIds: () => ["default"], inspectAccount },
+      }),
+      security: {},
+    } as ChannelPlugin;
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "discord", source: "test", plugin: registeredPlugin }]),
+    );
+
+    // ...but the plugin handed to the audit does NOT, forcing it through the
+    // read-only resolution path (inspectReadOnlyChannelAccount -> getChannelPlugin).
+    const auditedPlugin = {
+      ...createChannelTestPluginBase({
+        id: "discord",
+        config: { listAccountIds: () => ["default"] },
+      }),
+      security: {},
+    } as ChannelPlugin;
+
+    const cfg: RemoteClawConfig = {
+      channels: { discord: { enabled: true, token: "t" } },
+    };
+
+    const findings = await collectChannelSecurityFindings({
+      cfg,
+      plugins: [auditedPlugin],
+    });
+
+    expect(inspectAccount).toHaveBeenCalled();
+    const finding = findings.find(
+      (entry) => entry.checkId === "channels.discord.allowFrom.dangerous_name_matching_enabled",
+    );
+    expect(finding).toBeDefined();
+  });
+});

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -5,6 +5,7 @@ import {
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import type { listChannelPlugins } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.js";
+import { inspectReadOnlyChannelAccount } from "../channels/read-only-account-inspect.js";
 import {
   isNumericTelegramUserId,
   normalizeTelegramAllowFromEntry,
@@ -123,11 +124,20 @@ export async function collectChannelSecurityFindings(params: {
   const findings: SecurityAuditFinding[] = [];
   const sourceConfig = params.sourceConfig ?? params.cfg;
 
-  const inspectChannelAccount = (
+  const inspectChannelAccount = async (
     plugin: (typeof params.plugins)[number],
     cfg: RemoteClawConfig,
     accountId: string,
-  ) => plugin.config.inspectAccount?.(cfg, accountId) ?? undefined;
+  ) => {
+    if (plugin.config.inspectAccount) {
+      return await plugin.config.inspectAccount(cfg, accountId);
+    }
+    return await inspectReadOnlyChannelAccount({
+      channelId: plugin.id,
+      cfg,
+      accountId,
+    });
+  };
 
   const asAccountRecord = (value: unknown): Record<string, unknown> | null =>
     value && typeof value === "object" && !Array.isArray(value)
@@ -138,8 +148,8 @@ export async function collectChannelSecurityFindings(params: {
     plugin: (typeof params.plugins)[number],
     accountId: string,
   ) => {
-    const sourceInspectedAccount = inspectChannelAccount(plugin, sourceConfig, accountId);
-    const resolvedInspectedAccount = inspectChannelAccount(plugin, params.cfg, accountId);
+    const sourceInspectedAccount = await inspectChannelAccount(plugin, sourceConfig, accountId);
+    const resolvedInspectedAccount = await inspectChannelAccount(plugin, params.cfg, accountId);
     const sourceInspection = sourceInspectedAccount as {
       enabled?: boolean;
       configured?: boolean;


### PR DESCRIPTION
## Summary

Ports the upstream read-only channel-resolution capability into the fork's channel security audit, adapted to the fork's account-resolution seam. Closes #2703.

- **New module** `src/channels/read-only-account-inspect.ts` — `inspectReadOnlyChannelAccount({ channelId, cfg, accountId })` resolves a channel plugin's `config.inspectAccount` through the active registry (`getChannelPlugin`) and returns its read-only result or `null`. It invokes only the read-only inspector — never a mutator — so it performs no writes or state mutation.
- **Wiring** `src/security/audit-channel.ts` — the `inspectChannelAccount` helper inside `collectChannelSecurityFindings` now falls back to the new module when a plugin exposes no direct inspector; the helper is now `async` and both call sites are awaited.

### Fork adaptation

Upstream resolves via `getLoadedChannelPlugin` + a bundled lazy-loader (`getBundledChannelAccountInspector`). The fork gutted the bundled loader, so the active plugin registry (`getChannelPlugin`) is the single resolution seam. The `null`-vs-`undefined` return delta is inert across all downstream audit consumers (verified line-by-line).

## Acceptance criteria

- [x] The security audit can resolve channel/account information read-only via the new inspect path.
- [x] No writes or state mutation occur on the inspect path.
- [x] Tests cover the read-only resolution.

## Tests

- `src/channels/read-only-account-inspect.test.ts` (5): resolves via inspector, `null` when channel unregistered, `null` when no inspector, awaits async inspectors, side-effect-free (no mutators invoked, config unchanged).
- `src/security/audit-channel-read-only-inspect.test.ts` (1): the audit resolves account info via the read-only fallback path end-to-end (a registered inspector drives a finding even when the audited plugin has none).
- Regression: full `src/security/` suite (24 files / 430 tests) green; `pnpm check` (format + tsgo + type-aware lint + fork-integrity lint gates) green.

## Notes

- Touches `src/security/` + `src/channels/`, not `src/middleware/`, so the LIVE smoke-test PR directive does not apply.
- Scoped to the read-only inspect path; upstream's related `account-inspection.ts` (status/summary helper) and `audit-plugins-trust.ts` are out of scope for this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
