### PR TITLE
fix(update-cli): port restart-helper failure-surfacing hardening (#2705)

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -1,11 +1,19 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { prepareRestartScript, runRestartScript } from "./restart-helper.js";
 
-vi.mock("node:child_process", () => ({
-  spawn: vi.fn(),
-}));
+vi.mock("node:child_process", async () => {
+  const { mockNodeBuiltinModule } = await import("../../../test/helpers/node-builtin-mocks.js");
+  return mockNodeBuiltinModule(
+    () => vi.importActual<typeof import("node:child_process")>("node:child_process"),
+    {
+      spawn: vi.fn(),
+    },
+  );
+});
 
 describe("restart-helper", () => {
   const originalPlatform = process.platform;
@@ -19,7 +27,45 @@ describe("restart-helper", () => {
   }
 
   async function cleanupScript(scriptPath: string) {
-    await fs.unlink(scriptPath);
+    await fs.unlink(scriptPath).catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    });
+  }
+
+  async function makeTempDir(prefix: string) {
+    return await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  }
+
+  async function writeFakeLaunchctl(
+    fakeBinDir: string,
+    content = `#!/bin/sh
+echo "launchctl $*" >&2
+case "$1" in
+  kickstart) exit 0 ;;
+  enable|bootstrap) exit 0 ;;
+esac
+exit 0
+`,
+  ) {
+    const launchctlPath = path.join(fakeBinDir, "launchctl");
+    await fs.writeFile(launchctlPath, content, { mode: 0o755 });
+  }
+
+  async function executeScript(scriptPath: string, env: Record<string, string>) {
+    return await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve) => {
+      execFile(
+        "/bin/sh",
+        [scriptPath],
+        { env: { ...process.env, ...env } },
+        (error, stdout, stderr) => {
+          const execError = error as (Error & { code?: number | string }) | null;
+          const code = typeof execError?.code === "number" ? execError.code : null;
+          resolve({ code, stdout, stderr });
+        },
+      );
+    });
   }
 
   function expectWindowsRestartWaitOrdering(content: string, port = 18789) {
@@ -29,7 +75,7 @@ describe("restart-helper", () => {
     const pollAttemptIncrement = "set /a attempts+=1";
     const pollNetstatCheck = `netstat -ano | findstr /R /C:":${port} .*LISTENING" >nul`;
     const forceKillLabel = ":force_kill_listener";
-    const forceKillCommand = "taskkill /F /PID %%P >nul 2>&1";
+    const forceKillCommand = "taskkill /F /PID %%P >>";
     const portReleasedLabel = ":port_released";
     const runCommand = 'schtasks /Run /TN "';
     const endIndex = content.indexOf(endCommand);
@@ -105,6 +151,143 @@ describe("restart-helper", () => {
       await cleanupScript(scriptPath);
     });
 
+    it("captures macOS launchctl stderr to ~/.remoteclaw/logs/gateway-restart.log (#68486)", async () => {
+      // Silent failure in macOS update restart helper: previously every
+      // launchctl call redirected stderr to /dev/null and the final kickstart
+      // was chained with `|| true`, so bootstrap/kickstart failures were
+      // invisible and the gateway stayed offline while the updater reported
+      // success. The script should now route stderr to a durable log file and
+      // stop swallowing the final exit code.
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      process.getuid = () => 501;
+
+      const { scriptPath, content } = await prepareAndReadScript({
+        REMOTECLAW_PROFILE: "default",
+        HOME: "/Users/testuser",
+      });
+      expect(content).toContain(
+        "exec >>'/Users/testuser/.remoteclaw/logs/gateway-restart.log' 2>&1",
+      );
+      // Every launchctl call should allow output through now (no `2>/dev/null`)
+      // and the final kickstart must not swallow its exit code.
+      expect(content).not.toMatch(/launchctl[^\n]*2>\/dev\/null/);
+      expect(content).not.toMatch(/launchctl kickstart[^\n]*\|\| true/);
+      await cleanupScript(scriptPath);
+    });
+
+    it("uses REMOTECLAW_STATE_DIR for the macOS update restart log", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      process.getuid = () => 501;
+
+      const { scriptPath, content } = await prepareAndReadScript({
+        REMOTECLAW_PROFILE: "default",
+        HOME: "/Users/testuser",
+        REMOTECLAW_STATE_DIR: "/tmp/remoteclaw-state",
+      });
+
+      expect(content).toContain(
+        "if mkdir -p '/tmp/remoteclaw-state/logs' 2>/dev/null && : >>'/tmp/remoteclaw-state/logs/gateway-restart.log' 2>/dev/null; then",
+      );
+      expect(content).toContain("exec >>'/tmp/remoteclaw-state/logs/gateway-restart.log' 2>&1");
+      await cleanupScript(scriptPath);
+    });
+
+    it("returns the final macOS launchctl kickstart failure after logging cleanup", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      process.getuid = () => 501;
+      const tmpDir = await makeTempDir("remoteclaw-restart-helper-");
+      const fakeBinDir = path.join(tmpDir, "bin");
+      const stateDir = path.join(tmpDir, "state");
+      await fs.mkdir(fakeBinDir, { recursive: true });
+      await writeFakeLaunchctl(
+        fakeBinDir,
+        `#!/bin/sh
+echo "launchctl $*" >&2
+case "$1" in
+  kickstart) exit 42 ;;
+  enable|bootstrap) exit 0 ;;
+esac
+exit 0
+`,
+      );
+
+      const { scriptPath } = await prepareAndReadScript({
+        REMOTECLAW_PROFILE: "default",
+        HOME: path.join(tmpDir, "home"),
+        REMOTECLAW_STATE_DIR: stateDir,
+      });
+
+      const result = await executeScript(scriptPath, {
+        PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+      });
+      const log = await fs.readFile(path.join(stateDir, "logs", "gateway-restart.log"), "utf-8");
+
+      expect(result.code).toBe(42);
+      expect(log).toContain(
+        "remoteclaw restart attempt source=update target=org.remoteclaw.gateway",
+      );
+      expect(log).toContain("launchctl kickstart -k gui/501/org.remoteclaw.gateway");
+      expect(log).toContain("remoteclaw restart failed source=update status=42");
+      expect(log).not.toContain("remoteclaw restart done source=update");
+    });
+
+    it("continues the macOS restart path when log setup fails", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      process.getuid = () => 501;
+      const tmpDir = await makeTempDir("remoteclaw-restart-helper-");
+      const fakeBinDir = path.join(tmpDir, "bin");
+      const stateFile = path.join(tmpDir, "state-file");
+      const markerPath = path.join(tmpDir, "launchctl-ran");
+      await fs.mkdir(fakeBinDir, { recursive: true });
+      await fs.writeFile(stateFile, "not a directory");
+      await writeFakeLaunchctl(
+        fakeBinDir,
+        `#!/bin/sh
+printf ran > "$LAUNCHCTL_MARKER"
+exit 0
+`,
+      );
+
+      const { scriptPath } = await prepareAndReadScript({
+        REMOTECLAW_PROFILE: "default",
+        HOME: path.join(tmpDir, "home"),
+        REMOTECLAW_STATE_DIR: stateFile,
+      });
+
+      const result = await executeScript(scriptPath, {
+        LAUNCHCTL_MARKER: markerPath,
+        PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+      });
+
+      expect(result.code).toBeNull();
+      await expect(fs.readFile(markerPath, "utf-8")).resolves.toBe("ran");
+    });
+
+    it("logs custom macOS launchd labels without shell expansion", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      process.getuid = () => 501;
+      const tmpDir = await makeTempDir("remoteclaw-restart-helper-");
+      const fakeBinDir = path.join(tmpDir, "bin");
+      const stateDir = path.join(tmpDir, "state");
+      await fs.mkdir(fakeBinDir, { recursive: true });
+      await writeFakeLaunchctl(fakeBinDir);
+
+      const { scriptPath } = await prepareAndReadScript({
+        REMOTECLAW_LAUNCHD_LABEL: "org.remoteclaw.$(echo injected)",
+        HOME: path.join(tmpDir, "home"),
+        REMOTECLAW_STATE_DIR: stateDir,
+      });
+
+      const result = await executeScript(scriptPath, {
+        PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+      });
+      const log = await fs.readFile(path.join(stateDir, "logs", "gateway-restart.log"), "utf-8");
+
+      expect(result.code).toBeNull();
+      expect(log).toContain("target=org.remoteclaw.$(echo injected)");
+      expect(log).not.toContain("target=org.remoteclaw.injected");
+    });
+
     it("uses REMOTECLAW_LAUNCHD_LABEL override on macOS", async () => {
       Object.defineProperty(process, "platform", { value: "darwin" });
       process.getuid = () => 501;
@@ -125,8 +308,12 @@ describe("restart-helper", () => {
       });
       expect(scriptPath.endsWith(".bat")).toBe(true);
       expect(content).toContain("@echo off");
+      expect(content).toContain("gateway-restart.log");
+      expect(content).toContain(
+        "remoteclaw restart attempt source=update target=RemoteClaw Gateway",
+      );
       expect(content).toContain('schtasks /End /TN "RemoteClaw Gateway"');
-      expect(content).toContain('schtasks /Run /TN "RemoteClaw Gateway"');
+      expect(content).toContain('schtasks /Run /TN "RemoteClaw Gateway" >>');
       expectWindowsRestartWaitOrdering(content);
       // Batch self-cleanup
       expect(content).toContain('del "%~f0"');

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -9,6 +9,12 @@ import {
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
 } from "../../daemon/constants.js";
+import {
+  renderCmdRestartLogSetup,
+  renderPosixRestartLogSetup,
+  shellEscapeRestartLogValue,
+} from "../../daemon/restart-logs.js";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
 
 /**
  * Shell-escape a string for embedding in single-quoted shell arguments.
@@ -26,7 +32,7 @@ function isBatchSafe(value: string): boolean {
 }
 
 function resolveSystemdUnit(env: NodeJS.ProcessEnv): string {
-  const override = env.REMOTECLAW_SYSTEMD_UNIT?.trim();
+  const override = normalizeOptionalString(env.REMOTECLAW_SYSTEMD_UNIT);
   if (override) {
     return override.endsWith(".service") ? override : `${override}.service`;
   }
@@ -34,7 +40,7 @@ function resolveSystemdUnit(env: NodeJS.ProcessEnv): string {
 }
 
 function resolveLaunchdLabel(env: NodeJS.ProcessEnv): string {
-  const override = env.REMOTECLAW_LAUNCHD_LABEL?.trim();
+  const override = normalizeOptionalString(env.REMOTECLAW_LAUNCHD_LABEL);
   if (override) {
     return override;
   }
@@ -70,14 +76,24 @@ export async function prepareRestartScript(
     if (platform === "linux") {
       const unitName = resolveSystemdUnit(env);
       const escaped = shellEscape(unitName);
+      const logSetup = renderPosixRestartLogSetup({ ...process.env, ...env });
       filename = `remoteclaw-restart-${timestamp}.sh`;
       scriptContent = `#!/bin/sh
 # Standalone restart script — survives parent process termination.
 # Wait briefly to ensure file locks are released after update.
 sleep 1
-systemctl --user restart '${escaped}'
+${logSetup}
+printf '[%s] remoteclaw restart attempt source=update target=%s\\n' "$(date -u +%FT%TZ)" '${escaped}' >&2
+if systemctl --user restart '${escaped}'; then
+  status=0
+  printf '[%s] remoteclaw restart done source=update\\n' "$(date -u +%FT%TZ)" >&2
+else
+  status=$?
+  printf '[%s] remoteclaw restart failed source=update status=%s\\n' "$(date -u +%FT%TZ)" "$status" >&2
+fi
 # Self-cleanup
 rm -f "$0"
+exit "$status"
 `;
     } else if (platform === "darwin") {
       const label = resolveLaunchdLabel(env);
@@ -86,24 +102,39 @@ rm -f "$0"
       const uid = process.getuid ? process.getuid() : 501;
       // Resolve HOME at generation time via env/process.env to match launchd.ts,
       // and shell-escape the label in the plist filename to prevent injection.
-      const home = env.HOME?.trim() || process.env.HOME || os.homedir();
+      const home = normalizeOptionalString(env.HOME) || process.env.HOME || os.homedir();
       const plistPath = path.join(home, "Library", "LaunchAgents", `${label}.plist`);
       const escapedPlistPath = shellEscape(plistPath);
+      const logSetup = renderPosixRestartLogSetup({ ...process.env, ...env });
       filename = `remoteclaw-restart-${timestamp}.sh`;
       scriptContent = `#!/bin/sh
 # Standalone restart script — survives parent process termination.
 # Wait briefly to ensure file locks are released after update.
 sleep 1
+# Capture launchctl output so bootstrap/kickstart failures leave a durable
+# audit trail. Log setup is best-effort: restart must still run if the log path
+# is temporarily unavailable.
+${logSetup}
+printf '[%s] remoteclaw restart attempt source=update target=%s\\n' "$(date -u +%FT%TZ)" '${shellEscapeRestartLogValue(label)}' >&2
 # Try kickstart first (works when the service is still registered).
 # If it fails (e.g. after bootout), clear any persisted disabled state,
-# then re-register via bootstrap and kickstart.
-if ! launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null; then
-  launchctl enable 'gui/${uid}/${escaped}' 2>/dev/null
-  launchctl bootstrap 'gui/${uid}' '${escapedPlistPath}' 2>/dev/null
-  launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null || true
+# then re-register via bootstrap and kickstart. The final status is captured
+# before self-cleanup so a genuine failure remains observable.
+status=0
+if ! launchctl kickstart -k 'gui/${uid}/${escaped}'; then
+  launchctl enable 'gui/${uid}/${escaped}'
+  launchctl bootstrap 'gui/${uid}' '${escapedPlistPath}'
+  launchctl kickstart -k 'gui/${uid}/${escaped}'
+  status=$?
 fi
-# Self-cleanup
+if [ "$status" -eq 0 ]; then
+  printf '[%s] remoteclaw restart done source=update\\n' "$(date -u +%FT%TZ)" >&2
+else
+  printf '[%s] remoteclaw restart failed source=update status=%s\\n' "$(date -u +%FT%TZ)" "$status" >&2
+fi
+# Self-cleanup (log is retained under the RemoteClaw state logs directory).
 rm -f "$0"
+exit "$status"
 `;
     } else if (platform === "win32") {
       const taskName = resolveWindowsTaskName(env);
@@ -112,12 +143,15 @@ rm -f "$0"
       }
       const port =
         Number.isFinite(gatewayPort) && gatewayPort > 0 ? gatewayPort : DEFAULT_GATEWAY_PORT;
+      const restartLog = renderCmdRestartLogSetup({ ...process.env, ...env });
       filename = `remoteclaw-restart-${timestamp}.bat`;
       scriptContent = `@echo off
 REM Standalone restart script — survives parent process termination.
 REM Wait briefly to ensure file locks are released after update.
 timeout /t 2 /nobreak >nul
-schtasks /End /TN "${taskName}"
+${restartLog.lines.join("\r\n")}
+>> ${restartLog.quotedLogPath} 2>&1 echo [%DATE% %TIME%] remoteclaw restart attempt source=update target=${taskName}
+schtasks /End /TN "${taskName}" >> ${restartLog.quotedLogPath} 2>&1
 REM Poll for gateway port release before rerun; force-kill listener if stuck.
 set /a attempts=0
 :wait_for_port_release
@@ -129,13 +163,20 @@ timeout /t 1 /nobreak >nul
 goto wait_for_port_release
 :force_kill_listener
 for /f "tokens=5" %%P in ('netstat -ano ^| findstr /R /C:":${port} .*LISTENING"') do (
-  taskkill /F /PID %%P >nul 2>&1
+  taskkill /F /PID %%P >> ${restartLog.quotedLogPath} 2>&1
   goto port_released
 )
 :port_released
-schtasks /Run /TN "${taskName}"
+schtasks /Run /TN "${taskName}" >> ${restartLog.quotedLogPath} 2>&1
+set "status=%ERRORLEVEL%"
+if not "%status%"=="0" (
+  >> ${restartLog.quotedLogPath} 2>&1 echo [%DATE% %TIME%] remoteclaw restart failed source=update status=%status%
+) else (
+  >> ${restartLog.quotedLogPath} 2>&1 echo [%DATE% %TIME%] remoteclaw restart done source=update
+)
 REM Self-cleanup
 del "%~f0"
+exit /b %status%
 `;
     } else {
       return null;


### PR DESCRIPTION
## Summary

Closes #2705.

RemoteClaw bumped `upstreamVersion` to `2026.4.20`, but
`src/cli/update-cli/restart-helper.ts` (+ its test) was **missed during that sync** — it still carried the pre-`#68486` macOS branch that redirected every `launchctl` call to `/dev/null` and chained the fallback `kickstart` with `|| true`. Bootstrap/kickstart failures were therefore invisible and the gateway could stay offline while `update` reported success (the ~25-minute production outage upstream describes in OpenClaw #68486).

This ports upstream's hardened version (OpenClaw #68486 / #68492, `v2026.4.20`) — the lone straggler, since the supporting infra (`restart-logs.ts` helpers, `normalizeOptionalString`, `test/helpers/node-builtin-mocks.ts`) and the sibling files (`launchd-restart-handoff.ts`, `windows-task-restart.ts`) were already hardened in the `2026.4.20` sweep.

## What changed

**`restart-helper.ts`** — across all three platforms (systemd / launchd / schtasks):
- Route restart output to the shared `gateway-restart.log` via the already-present `renderPosixRestartLogSetup` / `renderCmdRestartLogSetup` / `shellEscapeRestartLogValue` helpers (best-effort: restart still runs if the log path is unavailable).
- Drop `2>/dev/null` on every `launchctl` call; remove the `|| true` swallow on the fallback `kickstart`.
- Capture the final `status` and `exit "$status"` so a genuine failure exits non-zero and is observable.

Diff vs upstream `v2026.4.20` is **rebrand-only** (`REMOTECLAW_*` env vars, `org.remoteclaw.*` labels, `RemoteClaw Gateway` task, `remoteclaw restart …` log strings, `~/.remoteclaw` state dir). Structural code is byte-identical to upstream to keep future syncs clean.

**`restart-helper.test.ts`** — the "execFile mock":
- Switch the `node:child_process` mock from a total replacement (which wiped `execFile`) to `mockNodeBuiltinModule(…importActual…, { spawn: vi.fn() })`, keeping `execFile` **real**.
- Add `executeScript` + fake-`launchctl` helpers that actually *run* generated scripts end-to-end, plus 5 new macOS tests: stderr capture (`#68486`), `REMOTECLAW_STATE_DIR` log path, exit-code propagation on kickstart failure (`status=42`), graceful continuation when log setup fails, and label-injection safety.

## Testing
- `restart-helper.test.ts`: **25 passed** (incl. the 5 new macOS tests).
- `update-cli.test.ts` (sole caller; mocks restart-helper): **26 passed** — no regression. `prepareRestartScript` / `runRestartScript` signatures unchanged.
- `pnpm check` (format + tsgo + oxlint + extra lints): green.
- Fork-integrity gates: rebrand-leakage, zombie-import, stub-debt, throwing-stub-callers, obsolescence-audit — all pass.

**LIVE smoke tests not required**: change is in `src/cli/update-cli/`, not `src/middleware/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)