### PR TITLE
test(media): cover outbound attachment filename preservation (#2707)

### DIFF
--- a/src/media/outbound-attachment.test.ts
+++ b/src/media/outbound-attachment.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveOutboundAttachmentFromUrl } from "./outbound-attachment.js";
+
+const loadWebMedia = vi.hoisted(() => vi.fn());
+const saveMediaBuffer = vi.hoisted(() => vi.fn());
+
+vi.mock("../../extensions/whatsapp/src/media.js", () => ({
+  loadWebMedia,
+}));
+
+vi.mock("./store.js", () => ({
+  saveMediaBuffer,
+}));
+
+describe("resolveOutboundAttachmentFromUrl", () => {
+  it("preserves the loaded file name when staging outbound media", async () => {
+    const buffer = Buffer.from("pdf");
+    loadWebMedia.mockResolvedValueOnce({
+      buffer,
+      contentType: "application/pdf",
+      fileName: "report.pdf",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/media/outbound/report---uuid.pdf",
+      contentType: "application/pdf",
+    });
+
+    await resolveOutboundAttachmentFromUrl("./report.pdf", 1024);
+
+    expect(saveMediaBuffer).toHaveBeenCalledWith(
+      buffer,
+      "application/pdf",
+      "outbound",
+      1024,
+      "report.pdf",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Resolves the evaluation in #2707 ("evaluate porting upstream outbound web-media abstraction").

**Decision: no functional/runtime delta to port; port only the missing regression test.**

The fork already has the substantive payload (outbound filename preservation). The one genuine, in-scope delta is the upstream regression test that guards it — which the fork was missing. This PR ports that test, adapted to the fork's module layout. **No runtime change.**

## Evaluation (upstream `v2026.4.15..v2026.4.20`)

Traced from the orientation commit `6e18f0e59ed` (`test: share web media document loader`):

| Upstream change in window | Type | Fork status |
|---|---|---|
| `src/media/web-media.ts` runtime | — | **Unchanged across the window** (predates it). Fork's equivalent lives in `extensions/whatsapp/src/media.ts` and already preserves filenames. |
| `6e18f0e59ed` *share web media document loader* | test-only DRY refactor | N/A — fork has no `web-media.test.ts`; zero new coverage. |
| `79840c9fdf1` *preserve outbound attachment filenames* — runtime arg | runtime fix | **Already present** in fork (`src/media/outbound-attachment.ts:22` passes `media.fileName`; `saveMediaBuffer` accepts `originalFilename`). |
| `79840c9fdf1` — new `outbound-attachment.test.ts` | regression test | **Missing in fork** — `resolveOutboundAttachmentFromUrl` was untested despite 2 production callers (imessage, signal). |

Content-disposition filename parsing in `src/media/fetch.ts` is identical to upstream v2026.4.20; store-level filename preservation is already unit-tested in `store.test.ts`. The only untested seam was the `resolveOutboundAttachmentFromUrl` wiring — now covered.

## Change

- Add `src/media/outbound-attachment.test.ts`: asserts `resolveOutboundAttachmentFromUrl` threads the loaded `media.fileName` through to `saveMediaBuffer` as the 5th argument.
- Adapted from upstream by mocking `loadWebMedia` at the fork import path (`../../extensions/whatsapp/src/media.js`) instead of upstream's `./web-media.js`; follows the fork's sibling convention in `src/plugin-sdk/outbound-media.test.ts`.

## Out of scope (noted, not ported)

The fork's outbound loader omits `hostReadCapability` (a pre-window v2026.4.15 feature, a deliberate divergence) — a separate concern that would need its own evaluation, not part of this issue's delta.

## Verification

- `pnpm exec vitest run --config vitest.unit.config.ts src/media/outbound-attachment.test.ts` → 1 passed.
- `pnpm check` (format + typecheck + lint + fork-integrity gates) → green.

Closes #2707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)