### PR TITLE
test(doctor): adapt stale opencode-go assertion to live opencode-zen warning (#2708)

### DIFF
--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -48,9 +48,9 @@ describe("doctor command", () => {
               api: "openai-completions",
               baseUrl: "https://opencode.ai/zen/v1",
             },
-            "opencode-go": {
+            "opencode-zen": {
               api: "openai-completions",
-              baseUrl: "https://opencode.ai/zen/go/v1",
+              baseUrl: "https://opencode.ai/zen/custom/v1",
             },
           },
         },
@@ -64,9 +64,9 @@ describe("doctor command", () => {
 
     const warned = terminalNoteMock.mock.calls.some(
       ([message, title]) =>
-        title === "OpenCode" &&
-        String(message).includes("models.providers.opencode") &&
-        String(message).includes("models.providers.opencode-go"),
+        title === "OpenCode Zen" &&
+        String(message).includes("models.providers.opencode is set") &&
+        String(message).includes("models.providers.opencode-zen is set"),
     );
     expect(warned).toBe(true);
   });


### PR DESCRIPTION
## Summary

Adapts the stale `"warns about opencode provider overrides"` case in
`src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts` so it reflects the
fork's **actual** `doctor` output. Closes #2708.

## Problem

The case asserted a `note` titled `"OpenCode"` whose message contained a
`models.providers.opencode-go` line. The fork's live `noteOpencodeProviderOverrides`
(`src/commands/doctor-config-flow.ts:148`, wired at `:2100`) instead:

- warns on the `opencode` and `opencode-zen` provider keys (not `opencode-go`), and
- emits the note under the title `"OpenCode Zen"`.

So the assertion was stale on both the title and the provider key, and failed when the
e2e suite was run directly:

```
× warns about opencode provider overrides
  → expected false to be true
```

It was **latent** rather than a CI failure: this is an `*.e2e.test.ts`, and the CI `test`
job runs `vitest.unit.config.ts`, which excludes e2e files.

## Fix

Point the test at the real override warning:

- config provider key `opencode-go` → `opencode-zen` (the key the impl checks);
- assertion title `"OpenCode"` → `"OpenCode Zen"`;
- assertion substrings → `"models.providers.opencode is set"` + `"models.providers.opencode-zen is set"`
  (the ` is set` suffix disambiguates the `opencode` ⊂ `opencode-zen` substring overlap, so the
  check genuinely verifies **both** override lines).

The namesake state-directory-missing case and the gateway-auth cases are untouched.

### Adapt vs. remove

The issue sanctioned either. I **adapted** rather than removed because
`noteOpencodeProviderOverrides` is live code with **no other test coverage** — deleting the
case would drop all coverage of a real, user-facing warning. (Note: the issue's *background*
states the model-provider warning subsystem was removed; in practice this OpenCode Zen
override warning survived, which is why "adapt to match real behavior" is the better fit.)

## Test evidence

```
src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
 ✓ warns when the state directory is missing
 ✓ warns about opencode provider overrides
 ✓ skips gateway auth warning when REMOTECLAW_GATEWAY_TOKEN is set
 ✓ warns when token and password are both configured and gateway.auth.mode is unset
 ✓ keeps doctor read-only when gateway token is SecretRef-managed but unresolved
 Test Files  1 passed (1)   Tests  5 passed (5)
```

Also verified locally on the changed file: `oxfmt --check` clean, `oxlint --type-aware`
0 warnings/0 errors, `tsgo --noEmit` 0 errors in `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
