### PR TITLE
fix: restore scripts/lib/arg-utils.mjs and reconcile stale CI/test docs (#2711)

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,6 +1,6 @@
 ---
 title: CI Pipeline
-summary: "CI job graph, scope gates, and local command equivalents"
+summary: "CI job graph and local command equivalents for the RemoteClaw fork"
 read_when:
   - You need to understand why a CI job did or did not run
   - You are debugging failing GitHub Actions checks
@@ -8,75 +8,58 @@ read_when:
 
 # CI Pipeline
 
-The CI runs on every push to `main` and every pull request. It uses smart scoping to skip expensive jobs when only unrelated areas changed.
+CI runs on every pull request, every push to `main`, and on published releases. The workflow is defined in `.github/workflows/ci.yml`.
 
-## Job Overview
+RemoteClaw is a fork of OpenClaw with the execution engine gutted (CLI-based agent runtimes replace in-process model providers). Its CI is correspondingly leaner than upstream's lane-based pipeline: a flat set of correctness jobs plus fork-integrity gates, with no changed-scope lane routing — every job runs on every PR.
 
-| Job                              | Purpose                                                                                      | When it runs                        |
-| -------------------------------- | -------------------------------------------------------------------------------------------- | ----------------------------------- |
-| `preflight`                      | Detect docs-only changes, changed scopes, changed extensions, and build the CI manifest      | Always on non-draft pushes and PRs  |
-| `security-scm-fast`              | Private key detection and workflow audit via `zizmor`                                        | Always on non-draft pushes and PRs  |
-| `security-dependency-audit`      | Dependency-free production lockfile audit against npm advisories                             | Always on non-draft pushes and PRs  |
-| `security-fast`                  | Required aggregate for the fast security jobs                                                | Always on non-draft pushes and PRs  |
-| `build-artifacts`                | Build `dist/` and the Control UI once, upload reusable artifacts for downstream jobs         | Node-relevant changes               |
-| `checks-fast-core`               | Fast Linux correctness lanes such as bundled/plugin-contract/protocol checks                 | Node-relevant changes               |
-| `checks-fast-contracts-channels` | Sharded channel contract checks with a stable aggregate check result                         | Node-relevant changes               |
-| `checks-node-extensions`         | Full bundled-plugin test shards across the extension suite                                   | Node-relevant changes               |
-| `checks-node-core-test`          | Core Node test shards, excluding channel, bundled, contract, and extension lanes             | Node-relevant changes               |
-| `extension-fast`                 | Focused tests for only the changed bundled plugins                                           | When extension changes are detected |
-| `check`                          | Sharded main local gate equivalent: prod types, lint, guards, test types, and strict smoke   | Node-relevant changes               |
-| `check-additional`               | Architecture, boundary, extension-surface guards, package-boundary, and gateway-watch shards | Node-relevant changes               |
-| `build-smoke`                    | Built-CLI smoke tests and startup-memory smoke                                               | Node-relevant changes               |
-| `checks`                         | Remaining Linux Node lanes: channel tests and push-only Node 22 compatibility                | Node-relevant changes               |
-| `check-docs`                     | Docs formatting, lint, and broken-link checks                                                | Docs changed                        |
-| `skills-python`                  | Ruff + pytest for Python-backed skills                                                       | Python-skill-relevant changes       |
-| `checks-windows`                 | Windows-specific test lanes                                                                  | Windows-relevant changes            |
-| `macos-node`                     | macOS TypeScript test lane using the shared built artifacts                                  | macOS-relevant changes              |
-| `macos-swift`                    | Swift lint, build, and tests for the macOS app                                               | macOS-relevant changes              |
-| `android`                        | Android build and test matrix                                                                | Android-relevant changes            |
+## Jobs
 
-## Fail-Fast Order
+| Job                          | Purpose                                                                           | When it runs         |
+| ---------------------------- | --------------------------------------------------------------------------------- | -------------------- |
+| `rebrand-gate`               | Detect `openclaw`/`OpenClaw` leakage that should have been rebranded              | Always               |
+| `zombie-import-gate`         | Catch imports from gutted modules                                                 | Always               |
+| `stub-debt-gate`             | Bound the number of gutted stubs against the committed baseline                   | Always               |
+| `throwing-stub-callers-gate` | Reject live callers of throwing stubs (self-tested against a fixture first)       | Always               |
+| `attestation-gate`           | Verify module attestation blocks are present and current (self-tested first)      | Always               |
+| `obsolescence-audit-gate`    | Retrospective audit sentinels for gut waves                                       | Always               |
+| `lint`                       | `pnpm check` — format check, prod typecheck (`tsgo`), lint, and fork guards       | Always               |
+| `build`                      | `pnpm build`, then `pnpm release:check` as an early release-artifact signal       | Always               |
+| `test`                       | `pnpm test` — the full Vitest suite (after building the canvas bundle)            | Always               |
+| `test-gateway-preauth`       | Scoped gateway pre-auth hardening suite (#2644)                                   | Always               |
+| `test-ui-smoke`              | Browser-mode smoke for the Control UI sync-regression suites (#2495/#2496, #2519) | Always               |
+| `CI`                         | Required aggregate — fails if any job above did not succeed                       | Always               |
+| `publish-next`               | Publish a `next`-tagged prerelease to npm (OIDC provenance)                       | Push to `main`       |
+| `publish-latest`             | Publish the release version to npm (OIDC provenance)                              | On published release |
 
-Jobs are ordered so cheap checks fail before expensive ones run:
+The six `*-gate` jobs are fork-specific integrity checks that enforce the gut/keep boundary (the Middleware Boundary Principle). They have no upstream equivalent — they guard against an upstream sync silently re-introducing gutted code, leaking the `openclaw` brand, or growing stub debt.
 
-1. `preflight` decides which lanes exist at all. The `docs-scope` and `changed-scope` logic are steps inside this job, not standalone jobs.
-2. `security-scm-fast`, `security-dependency-audit`, `security-fast`, `check`, `check-additional`, `check-docs`, and `skills-python` fail quickly without waiting on the heavier artifact and platform matrix jobs.
-3. `build-artifacts` overlaps with the fast Linux lanes so downstream consumers can start as soon as the shared build is ready.
-4. Heavier platform and runtime lanes fan out after that: `checks-fast-core`, `checks-fast-contracts-channels`, `checks-node-extensions`, `checks-node-core-test`, `extension-fast`, `checks`, `checks-windows`, `macos-node`, `macos-swift`, and `android`.
+## Local equivalents
 
-Scope logic lives in `scripts/ci-changed-scope.mjs` and is covered by unit tests in `src/scripts/ci-changed-scope.test.ts`.
-The separate `install-smoke` workflow reuses the same scope script through its own `preflight` job. It computes `run_install_smoke` from the narrower changed-smoke signal, so Docker/install smoke only runs for install, packaging, and container-relevant changes.
+```bash
+pnpm check         # format check + prod tsgo + lint + fork guards (the `lint` job)
+pnpm build         # build dist/ (the `build` job)
+pnpm release:check # validate the release artifact (also runs inside build / publish)
+pnpm test          # full Vitest suite (the `test` job)
+pnpm check:docs    # docs format + lint + broken-link check
+```
 
-Local changed-lane logic lives in `scripts/changed-lanes.mjs` and is executed by `scripts/check-changed.mjs`. That local gate is stricter about architecture boundaries than the broad CI platform scope: core production changes run core prod typecheck plus core tests, core test-only changes run only core test typecheck/tests, extension production changes run extension prod typecheck plus extension tests, and extension test-only changes run only extension test typecheck/tests. Public Plugin SDK or plugin-contract changes expand to extension validation because extensions depend on those core contracts. Unknown root/config changes fail safe to all lanes.
+The fork-integrity gates run as standalone scripts:
 
-On pushes, the `checks` matrix adds the push-only `compat-node22` lane. On pull requests, that lane is skipped and the matrix stays focused on the normal test/channel lanes.
-
-The slowest Node test families are split into include-file shards so each job stays small: channel contracts split registry and core coverage into eight weighted shards each, auto-reply reply command tests split into four include-pattern shards, and the other large auto-reply reply prefix groups split into two shards each. `check-additional` also separates package-boundary compile/canary work from runtime topology gateway/architecture work.
-
-GitHub may mark superseded jobs as `cancelled` when a newer push lands on the same PR or `main` ref. Treat that as CI noise unless the newest run for the same ref is also failing. The aggregate shard checks call out this cancellation case explicitly so it is easier to distinguish from a test failure.
+```bash
+bash scripts/ci/check-rebrand-leakage.sh        # rebrand-gate
+node scripts/check-no-zombie-imports.mjs         # zombie-import-gate
+node scripts/check-stub-debt.mjs                 # stub-debt-gate
+node scripts/check-throwing-stub-callers.mjs     # throwing-stub-callers-gate
+node scripts/check-attestations.mjs              # attestation-gate
+node scripts/check-obsolescence-audit.mjs        # obsolescence-audit-gate
+```
 
 ## Runners
 
-| Runner                           | Jobs                                                                                                                                                   |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `blacksmith-16vcpu-ubuntu-2404`  | `preflight`, `security-scm-fast`, `security-dependency-audit`, `security-fast`, `build-artifacts`, Linux checks, docs checks, Python skills, `android` |
-| `blacksmith-32vcpu-windows-2025` | `checks-windows`                                                                                                                                       |
-| `macos-latest`                   | `macos-node`, `macos-swift`                                                                                                                            |
+All jobs run on GitHub-hosted `ubuntu-latest` runners.
 
-## Local Equivalents
+## Notes
 
-```bash
-pnpm changed:lanes   # inspect the local changed-lane classifier for origin/main...HEAD
-pnpm check:changed   # smart local gate: changed typecheck/lint/tests by boundary lane
-pnpm check          # fast local gate: production tsgo + sharded lint + parallel fast guards
-pnpm check:test-types
-pnpm check:timed    # same gate with per-stage timings
-pnpm build:strict-smoke
-pnpm check:architecture
-pnpm test:gateway:watch-regression
-pnpm test           # vitest tests
-pnpm test:channels
-pnpm test:contracts:channels
-pnpm check:docs     # docs format + lint + broken links
-pnpm build          # build dist when CI artifact/build-smoke lanes matter
-```
+- On a pull request, a newer push cancels in-progress runs for the same PR (`concurrency` with `cancel-in-progress`). On `main`, runs are not cancelled — treat a `cancelled` job as CI noise unless the newest run for the same ref is also failing.
+- `publish-next` and `publish-latest` use the `npm-publish` environment with OIDC provenance and run only on push / release, never on PRs.
+- Separate workflows cover other concerns: CodeQL security scanning (`codeql.yml`), documentation build and deploy (`docs.yml`), and sync-PR auditing (`sync-pr-audit.yml`).

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -22,13 +22,10 @@ This doc is a “how we test” guide:
 
 Most days:
 
-- Full gate (expected before push): `pnpm build && pnpm check && pnpm check:test-types && pnpm test`
-- Faster local full-suite run on a roomy machine: `pnpm test:max`
+- Full gate (expected before push): `pnpm build && pnpm check && pnpm test`
 - Direct Vitest watch loop: `pnpm test:watch`
-- Direct file targeting now routes extension/channel paths too: `pnpm test extensions/discord/src/monitor/message-handler.preflight.test.ts`
+- Direct file targeting routes extension/channel paths too: `pnpm test extensions/discord/src/monitor/message-handler.preflight.test.ts`
 - Prefer targeted runs first when you are iterating on a single failure.
-- Docker-backed QA site: `pnpm qa:lab:up`
-- Linux VM-backed QA lane: `pnpm openclaw qa suite --runner multipass --scenario channel-chat-baseline`
 
 When you touch tests or want extra confidence:
 
@@ -269,8 +266,7 @@ Think of the suites as “increasing realism” (and increasing flakiness/cost):
 - Projects note:
   - Untargeted `pnpm test` now runs eleven smaller shard configs (`core-unit-src`, `core-unit-security`, `core-unit-ui`, `core-unit-support`, `core-support-boundary`, `core-contracts`, `core-bundled`, `core-runtime`, `agentic`, `auto-reply`, `extensions`) instead of one giant native root-project process. This cuts peak RSS on loaded machines and avoids auto-reply/extension work starving unrelated suites.
   - `pnpm test --watch` still uses the native root `vitest.config.ts` project graph, because a multi-shard watch loop is not practical.
-  - `pnpm test`, `pnpm test:watch`, and `pnpm test:perf:imports` route explicit file/directory targets through scoped lanes first, so `pnpm test extensions/discord/src/monitor/message-handler.preflight.test.ts` avoids paying the full root project startup tax.
-  - `pnpm test:changed` expands changed git paths into the same scoped lanes when the diff only touches routable source/test files; config/setup edits still fall back to the broad root-project rerun.
+  - `pnpm test` and `pnpm test:watch` route explicit file/directory targets through scoped lanes first, so `pnpm test extensions/discord/src/monitor/message-handler.preflight.test.ts` avoids paying the full root project startup tax.
   - Import-light unit tests from agents, commands, plugins, auto-reply helpers, `plugin-sdk`, and similar pure utility areas route through the `unit-fast` lane, which skips `test/setup-openclaw-runtime.ts`; stateful/runtime-heavy files stay on the existing lanes.
   - Selected `plugin-sdk` and `commands` helper source files also map changed-mode runs to explicit sibling tests in those light lanes, so helper edits avoid rerunning the full heavy suite for that directory.
   - `auto-reply` now has three dedicated buckets: top-level core helpers, top-level `reply.*` integration tests, and the `src/auto-reply/reply/**` subtree. This keeps the heaviest reply harness work off the cheap status/chunk/token tests.
@@ -291,21 +287,6 @@ Think of the suites as “increasing realism” (and increasing flakiness/cost):
   - The root UI lane keeps its `jsdom` setup and optimizer, but now runs on the shared non-isolated runner too.
   - Each `pnpm test` shard inherits the same `threads` + `isolate: false` defaults from the shared Vitest config.
   - The shared `scripts/run-vitest.mjs` launcher now also adds `--no-maglev` for Vitest child Node processes by default to reduce V8 compile churn during big local runs. Set `OPENCLAW_VITEST_ENABLE_MAGLEV=1` if you need to compare against stock V8 behavior.
-- Fast-local iteration note:
-  - `pnpm changed:lanes` shows which architectural lanes a diff triggers.
-  - The pre-commit hook runs `pnpm check:changed --staged` after staged formatting/linting, so core-only commits do not pay extension test cost unless they touch public extension-facing contracts.
-  - `pnpm test:changed` routes through scoped lanes when the changed paths map cleanly to a smaller suite.
-  - `pnpm test:max` and `pnpm test:changed:max` keep the same routing behavior, just with a higher worker cap.
-  - Local worker auto-scaling is intentionally conservative now and also backs off when the host load average is already high, so multiple concurrent Vitest runs do less damage by default.
-  - The base Vitest config marks the projects/config files as `forceRerunTriggers` so changed-mode reruns stay correct when test wiring changes.
-  - The config keeps `OPENCLAW_VITEST_FS_MODULE_CACHE` enabled on supported hosts; set `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/abs/path` if you want one explicit cache location for direct profiling.
-- Perf-debug note:
-  - `pnpm test:perf:imports` enables Vitest import-duration reporting plus import-breakdown output.
-  - `pnpm test:perf:imports:changed` scopes the same profiling view to files changed since `origin/main`.
-- `pnpm test:perf:changed:bench -- --ref <git-ref>` compares routed `test:changed` against the native root-project path for that committed diff and prints wall time plus macOS max RSS.
-- `pnpm test:perf:changed:bench -- --worktree` benchmarks the current dirty tree by routing the changed file list through `scripts/test-projects.mjs` and the root Vitest config.
-  - `pnpm test:perf:profile:main` writes a main-thread CPU profile for Vitest/Vite startup and transform overhead.
-  - `pnpm test:perf:profile:runner` writes runner CPU+heap profiles for the unit suite with file parallelism disabled.
 
 ### E2E (gateway smoke)
 

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -9,55 +9,28 @@ title: "Tests"
 
 - Full testing kit (suites, live, Docker): [Testing](/help/testing)
 
+- `pnpm test`: runs the native Vitest root projects config directly. File filters work natively across the configured projects.
 - `pnpm test:force`: Kills any lingering gateway process holding the default control port, then runs the full Vitest suite with an isolated gateway port so server tests don’t collide with a running instance. Use this when a prior gateway run left port 18789 occupied.
 - `pnpm test:coverage`: Runs the unit suite with V8 coverage (via `vitest.unit.config.ts`). This is a loaded-file unit coverage gate, not whole-repo all-file coverage. Thresholds are 70% lines/functions/statements and 55% branches. Because `coverage.all` is false, the gate measures files loaded by the unit coverage suite instead of treating every split-lane source file as uncovered.
-- `pnpm test:coverage:changed`: Runs unit coverage only for files changed since `origin/main`.
-- `pnpm test:changed`: runs the native Vitest projects config with `--changed origin/main`. The base config treats the projects/config files as `forceRerunTriggers` so wiring changes still rerun broadly when needed.
-- `pnpm test`: runs the native Vitest root projects config directly. File filters work natively across the configured projects.
-- Base Vitest config now defaults to `pool: "threads"` and `isolate: false`, with the shared non-isolated runner enabled across the repo configs.
-- `pnpm test:channels` runs `vitest.channels.config.ts`.
-- `pnpm test:extensions` runs `vitest.extensions.config.ts`.
-- `pnpm test:extensions`: runs extension/plugin suites.
-- `pnpm test:perf:imports`: enables Vitest import-duration + import-breakdown reporting for the native root projects run.
-- `pnpm test:perf:imports:changed`: same import profiling, but only for files changed since `origin/main`.
-- `pnpm test:perf:profile:main`: writes a CPU profile for the Vitest main thread (`.artifacts/vitest-main-profile`).
-- `pnpm test:perf:profile:runner`: writes CPU + heap profiles for the unit runner (`.artifacts/vitest-runner-profile`).
+- Base Vitest config defaults to `pool: "threads"` and `isolate: false`, with the shared non-isolated runner enabled across the repo configs.
+- `pnpm test:channels`: runs `vitest.channels.config.ts`.
+- `pnpm test:extensions`: runs the extension/plugin suites (`vitest.extensions.config.ts`).
 - Gateway integration: opt-in via `REMOTECLAW_TEST_INCLUDE_GATEWAY=1 pnpm test` or `pnpm test:gateway`.
 - `pnpm test:e2e`: Runs gateway end-to-end smoke tests (multi-instance WS/HTTP/node pairing). Defaults to `threads` + `isolate: false` with adaptive workers in `vitest.e2e.config.ts`; tune with `REMOTECLAW_E2E_WORKERS=<n>` and set `REMOTECLAW_E2E_VERBOSE=1` for verbose logs.
-- `pnpm test:live`: Runs provider live tests (minimax/zai). Requires API keys and `LIVE=1` (or provider-specific `*_LIVE_TEST=1`) to unskip.
-- `pnpm test:docker:openwebui`: Starts Dockerized RemoteClaw + Open WebUI, signs in through Open WebUI, checks `/api/models`, then runs a real proxied chat through `/api/chat/completions`. Requires a usable live model key (for example OpenAI in `~/.profile`), pulls an external Open WebUI image, and is not expected to be CI-stable like the normal unit/e2e suites.
-- `pnpm test:docker:mcp-channels`: Starts a seeded Gateway container and a second client container that spawns `remoteclaw mcp serve`, then verifies routed conversation discovery, transcript reads, attachment metadata, live event queue behavior, outbound send routing, and Claude-style channel + permission notifications over the real stdio bridge. The Claude notification assertion reads the raw stdio MCP frames directly so the smoke reflects what the bridge actually emits.
+- `pnpm test:live`: Runs provider live tests. Requires API keys and `REMOTECLAW_LIVE_TEST=1` (or provider-specific `*_LIVE_TEST=1`) to unskip.
 
 ## Local PR gate
 
 For local PR land/gate checks, run:
 
-- `pnpm check:changed`
 - `pnpm check`
-- `pnpm check:test-types`
 - `pnpm build`
 - `pnpm test`
 - `pnpm check:docs`
 
 If `pnpm test` flakes on a loaded host, rerun once before treating it as a regression, then isolate with `pnpm test <path/to/test>`. For memory-constrained hosts, use:
 
-- `REMOTECLAW_VITEST_MAX_WORKERS=1 pnpm test`
-- `REMOTECLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/remoteclaw-vitest-cache pnpm test:changed`
-
-## Model latency bench (local keys)
-
-Script: [`scripts/bench-model.ts`](https://github.com/remoteclaw/remoteclaw/blob/main/scripts/bench-model.ts)
-
-Usage:
-
-- `source ~/.profile && pnpm tsx scripts/bench-model.ts --runs 10`
-- Optional env: `MINIMAX_API_KEY`, `MINIMAX_BASE_URL`, `MINIMAX_MODEL`, `ANTHROPIC_API_KEY`
-- Default prompt: “Reply with a single word: ok. No punctuation or extra text.”
-
-Last run (2025-12-31, 20 runs):
-
-- minimax median 1279ms (min 1114, max 2431)
-- opus median 2454ms (min 1224, max 3170)
+- `REMOTECLAW_TEST_WORKERS=1 pnpm test`
 
 ## CLI startup bench
 
@@ -65,18 +38,12 @@ Script: [`scripts/bench-cli-startup.ts`](https://github.com/remoteclaw/remotecla
 
 Usage:
 
-- `pnpm test:startup:bench`
-- `pnpm test:startup:bench:smoke`
-- `pnpm test:startup:bench:save`
-- `pnpm test:startup:bench:update`
-- `pnpm test:startup:bench:check`
 - `pnpm tsx scripts/bench-cli-startup.ts`
 - `pnpm tsx scripts/bench-cli-startup.ts --runs 12`
 - `pnpm tsx scripts/bench-cli-startup.ts --preset real`
 - `pnpm tsx scripts/bench-cli-startup.ts --preset real --case status --case gatewayStatus --runs 3`
 - `pnpm tsx scripts/bench-cli-startup.ts --entry remoteclaw.mjs --entry-secondary dist/entry.js --preset all`
 - `pnpm tsx scripts/bench-cli-startup.ts --preset all --output .artifacts/cli-startup-bench-all.json`
-- `pnpm tsx scripts/bench-cli-startup.ts --preset real --case gatewayStatusJson --output .artifacts/cli-startup-bench-smoke.json`
 - `pnpm tsx scripts/bench-cli-startup.ts --preset real --cpu-prof-dir .artifacts/cli-cpu`
 - `pnpm tsx scripts/bench-cli-startup.ts --json`
 
@@ -87,18 +54,6 @@ Presets:
 - `all`: both presets
 
 Output includes `sampleCount`, avg, p50, p95, min/max, exit-code/signal distribution, and max RSS summaries for each command. Optional `--cpu-prof-dir` / `--heap-prof-dir` writes V8 profiles per run so timing and profile capture use the same harness.
-
-Saved output conventions:
-
-- `pnpm test:startup:bench:smoke` writes the targeted smoke artifact at `.artifacts/cli-startup-bench-smoke.json`
-- `pnpm test:startup:bench:save` writes the full-suite artifact at `.artifacts/cli-startup-bench-all.json` using `runs=5` and `warmup=1`
-- `pnpm test:startup:bench:update` refreshes the checked-in baseline fixture at `test/fixtures/cli-startup-bench.json` using `runs=5` and `warmup=1`
-
-Checked-in fixture:
-
-- `test/fixtures/cli-startup-bench.json`
-- Refresh with `pnpm test:startup:bench:update`
-- Compare current results against the fixture with `pnpm test:startup:bench:check`
 
 ## Onboarding E2E (Docker)
 

--- a/scripts/lib/arg-utils.mjs
+++ b/scripts/lib/arg-utils.mjs
@@ -1,0 +1,169 @@
+export function readEnvNumber(name, env = process.env) {
+  const raw = env[name]?.trim();
+  if (!raw) {
+    return null;
+  }
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function consumeStringFlag(argv, index, flag, currentValue) {
+  if (argv[index] !== flag) {
+    return null;
+  }
+  return {
+    nextIndex: index + 1,
+    value: argv[index + 1] ?? currentValue,
+  };
+}
+
+export function consumeStringListFlag(argv, index, flag) {
+  if (argv[index] !== flag) {
+    return null;
+  }
+  const value = argv[index + 1];
+  return {
+    nextIndex: index + 1,
+    value: typeof value === "string" && value.length > 0 ? value : null,
+  };
+}
+
+export function consumeIntFlag(argv, index, flag, currentValue, options = {}) {
+  if (argv[index] !== flag) {
+    return null;
+  }
+  const parsed = Number.parseInt(argv[index + 1] ?? "", 10);
+  const min = options.min ?? Number.NEGATIVE_INFINITY;
+  return {
+    nextIndex: index + 1,
+    value: Number.isFinite(parsed) && parsed >= min ? parsed : currentValue,
+  };
+}
+
+export function consumeFloatFlag(argv, index, flag, currentValue, options = {}) {
+  if (argv[index] !== flag) {
+    return null;
+  }
+  const parsed = Number.parseFloat(argv[index + 1] ?? "");
+  const min = options.min ?? Number.NEGATIVE_INFINITY;
+  const includeMin = options.includeMin ?? true;
+  const isValid = Number.isFinite(parsed) && (includeMin ? parsed >= min : parsed > min);
+  return {
+    nextIndex: index + 1,
+    value: isValid ? parsed : currentValue,
+  };
+}
+
+export function stringFlag(flag, key) {
+  return {
+    consume(argv, index, args) {
+      const option = consumeStringFlag(argv, index, flag, args[key]);
+      if (!option) {
+        return null;
+      }
+      return {
+        nextIndex: option.nextIndex,
+        apply(target) {
+          target[key] = option.value;
+        },
+      };
+    },
+  };
+}
+
+export function stringListFlag(flag, key) {
+  return {
+    consume(argv, index) {
+      const option = consumeStringListFlag(argv, index, flag);
+      if (!option) {
+        return null;
+      }
+      return {
+        nextIndex: option.nextIndex,
+        apply(target) {
+          if (option.value) {
+            target[key].push(option.value);
+          }
+        },
+      };
+    },
+  };
+}
+
+function createAssignedValueFlag(consumeOption) {
+  return {
+    consume(argv, index, args) {
+      const option = consumeOption(argv, index, args);
+      if (!option) {
+        return null;
+      }
+      return {
+        nextIndex: option.nextIndex,
+        apply(target) {
+          target[option.key] = option.value;
+        },
+      };
+    },
+  };
+}
+
+export function intFlag(flag, key, options) {
+  return createAssignedValueFlag((argv, index, args) => {
+    const option = consumeIntFlag(argv, index, flag, args[key], options);
+    return option ? { ...option, key } : null;
+  });
+}
+
+export function floatFlag(flag, key, options) {
+  return createAssignedValueFlag((argv, index, args) => {
+    const option = consumeFloatFlag(argv, index, flag, args[key], options);
+    return option ? { ...option, key } : null;
+  });
+}
+
+export function booleanFlag(flag, key, value = true) {
+  return {
+    consume(argv, index) {
+      if (argv[index] !== flag) {
+        return null;
+      }
+      return {
+        nextIndex: index,
+        apply(target) {
+          target[key] = value;
+        },
+      };
+    },
+  };
+}
+
+export function parseFlagArgs(argv, args, specs, options = {}) {
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--" && options.ignoreDoubleDash) {
+      continue;
+    }
+    let handled = false;
+    for (const spec of specs) {
+      const option = spec.consume(argv, i, args);
+      if (!option) {
+        continue;
+      }
+      option.apply(args);
+      i = option.nextIndex;
+      handled = true;
+      break;
+    }
+    if (handled) {
+      continue;
+    }
+    const fallbackResult = options.onUnhandledArg?.(arg, args);
+    if (fallbackResult === "handled") {
+      continue;
+    }
+    if (!options.allowUnknownOptions && arg.startsWith("-")) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return args;
+}


### PR DESCRIPTION
## Summary

Resolves #2711 — a regression from the v2026.4.20 sync (#2700).

**Part 1 — restore `scripts/lib/arg-utils.mjs`.** Sync #2700 dropped this utility (mis-classified `EXCLUDE-GUT` "upstream-only") while keeping/adopting six scripts that import it, breaking them at module load — including the `test:force` chain (`test-force.ts → test-projects.mjs → test-projects.test-support.mjs → changed-lanes.mjs → arg-utils.mjs`). Restored from upstream (no rebrand needed — zero `openclaw` refs; all six required exports present).

**Part 2 — reconcile stale CI/test docs.** The three docs described upstream's lane-based CI and referenced commands absent from `package.json`:
- `docs/ci.md`: rewrote the job graph, runners, and local equivalents to match `.github/workflows/ci.yml` (fork integrity gates + `lint`/`build`/`test`/`test-gateway-preauth`/`test-ui-smoke`).
- `docs/reference/test.md`: dropped `test:changed` / `test:coverage:changed` / `test:perf:*` / `test:docker:{openwebui,mcp-channels}` / `check:changed` / `check:test-types`; removed the model-latency-bench section (`scripts/bench-model.ts` absent); kept CLI-startup-bench via direct `pnpm tsx` (the `test:startup:bench*` aliases don't exist).
- `docs/help/testing.md`: fixed the full-gate command and removed the upstream lane/perf note blocks (`changed:lanes`, `check:changed`, `test:max`, `test:perf:*`).

## Acceptance criteria

- [x] arg-utils.mjs import gap resolved — `changed-lanes.mjs` imports cleanly; all six required exports present; `test:force` chain links.
- [x] The three docs reflect the fork's actual CI/test commands (named lane-based commands fixed/removed).

## Evidence

- `node -e "import('./scripts/changed-lanes.mjs')"` → loads OK (arg-utils link resolves).
- `pnpm check` → 0 warnings / 0 errors (format + tsgo + lint + guards).
- `oxfmt --check` clean on all four files.

## Out of scope (tracked in #2716)

The broader gutted-model-provider doc drift in `docs/help/testing.md` (Docker `live-*` runners, model-provider live-testing sections, `OPENCLAW_*` env-var leakage, `pi-embedded-runner` test refs) is a separate concern beyond #2711's enumerated scope.

Closes #2711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)