### PR TITLE
fix(gateway): reject delivery to unconfigured plugin channels in agent handler

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -6,6 +6,7 @@ import {
   resolveIngressWorkspaceOverrideForSpawnedRun,
 } from "../../agents/spawned-context.js";
 import { buildBareSessionResetPrompt } from "../../auto-reply/reply/session-reset-prompt.js";
+import { CHANNEL_IDS, type ChatChannelId } from "../../channels/registry.js";
 import { agentCommandFromIngress } from "../../commands/agent.js";
 import { loadConfig } from "../../config/config.js";
 import {
@@ -21,7 +22,10 @@ import {
   resolveAgentDeliveryPlan,
   resolveAgentOutboundTarget,
 } from "../../infra/outbound/agent-delivery.js";
-import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
+import {
+  listConfiguredMessageChannels,
+  resolveMessageChannelSelection,
+} from "../../infra/outbound/channel-selection.js";
 import { classifySessionKeyShape, normalizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
@@ -606,6 +610,25 @@ export const agentHandlers: GatewayRequestHandlers = {
     let resolvedAccountId = deliveryPlan.resolvedAccountId;
     let resolvedTo = deliveryPlan.resolvedTo;
     let effectivePlan = deliveryPlan;
+
+    // A plugin channel may be registered but have no configured accounts,
+    // making it unusable for delivery. Fall back to INTERNAL_MESSAGE_CHANNEL
+    // so channel-selection can surface a proper error. Built-in channels
+    // (in CHANNEL_IDS) are always considered available.
+    if (
+      wantsDelivery &&
+      resolvedChannel !== INTERNAL_MESSAGE_CHANNEL &&
+      isDeliverableMessageChannel(resolvedChannel) &&
+      !CHANNEL_IDS.includes(resolvedChannel as ChatChannelId)
+    ) {
+      const cfgResolved = cfgForAgent ?? cfg;
+      const configured = await listConfiguredMessageChannels(cfgResolved);
+      if (!configured.includes(resolvedChannel)) {
+        resolvedChannel = INTERNAL_MESSAGE_CHANNEL;
+        resolvedTo = undefined;
+        resolvedAccountId = undefined;
+      }
+    }
 
     if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
       const cfgResolved = cfgForAgent ?? cfg;

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -41,7 +41,10 @@ afterAll(async () => {
   await server.close();
 });
 
-const createMSTeamsPlugin = (params?: { aliases?: string[] }): ChannelPlugin => ({
+const createMSTeamsPlugin = (params?: {
+  aliases?: string[];
+  accountIds?: string[];
+}): ChannelPlugin => ({
   id: "msteams",
   meta: {
     id: "msteams",
@@ -53,7 +56,7 @@ const createMSTeamsPlugin = (params?: { aliases?: string[] }): ChannelPlugin => 
   },
   capabilities: { chatTypes: ["direct"] },
   config: {
-    listAccountIds: () => [],
+    listAccountIds: () => params?.accountIds ?? [],
     resolveAccount: () => ({}),
   },
 });
@@ -193,12 +196,12 @@ describe("gateway server agent", () => {
     setRegistry(emptyRegistry);
   });
 
-  test("agent reuses the last plugin delivery route when channel=last", async () => {
+  test("agent reuses the last plugin delivery route when channel=last and the plugin is configured", async () => {
     const registry = createRegistry([
       {
         pluginId: "msteams",
         source: "test",
-        plugin: createMSTeamsPlugin(),
+        plugin: createMSTeamsPlugin({ accountIds: ["default"] }),
       },
     ]);
     setRegistry(registry);
@@ -221,6 +224,34 @@ describe("gateway server agent", () => {
       to: "conversation:teams-123",
       fromEnd: 1,
     });
+  });
+
+  test("agent falls back to internal delivery when the last channel is an unconfigured plugin channel", async () => {
+    const registry = createRegistry([
+      {
+        pluginId: "msteams",
+        source: "test",
+        plugin: createMSTeamsPlugin(),
+      },
+    ]);
+    setRegistry(registry);
+    await writeMainSessionEntry({
+      sessionId: "sess-teams-unconfigured",
+      lastChannel: "msteams",
+      lastTo: "conversation:teams-123",
+    });
+    const res = await rpcReq(ws, "agent", {
+      message: "hi",
+      sessionKey: "main",
+      channel: "last",
+      deliver: true,
+      bestEffortDeliver: false,
+      idempotencyKey: "idem-agent-last-msteams-unconfigured",
+    });
+    expect(res.ok).toBe(false);
+    expect(res.error?.code).toBe("INVALID_REQUEST");
+    expect(res.error?.message).toMatch(/Channel is required|delivery channel is required/);
+    expect(vi.mocked(agentCommand)).not.toHaveBeenCalled();
   });
 
   test("agent accepts built-in channel alias (imsg)", async () => {


### PR DESCRIPTION
## Problem

When an agent run requests delivery (`deliver: true`) and the resolved channel is a **plugin channel with no configured accounts** (e.g. `msteams` registered but no accounts set up), the agent handler silently accepted the delivery request. `isDeliverableMessageChannel()` only checks plugin-registry *presence*, not whether the plugin has configured accounts, and the configured-accounts check (`listConfiguredMessageChannels()`) was consulted only on the `INTERNAL_MESSAGE_CHANNEL` fallback path — never for an explicitly-resolved plugin channel. The run was then dispatched to an unusable channel instead of surfacing a proper error.

## Fix

`src/gateway/server-methods/agent.ts`: before internal-channel resolution, if delivery is wanted and the resolved channel is a registered **plugin** channel (not a built-in `CHANNEL_IDS` channel, not internal) that has no configured accounts, fall back to `INTERNAL_MESSAGE_CHANNEL`. The existing channel-selection logic then surfaces the proper "Channel is required" error instead of dispatching to an unusable channel. Built-in channels skip the check (always considered available).

## Tests

`src/gateway/server.agent.gateway-server-agent-b.test.ts`:
- **New** — *"agent falls back to internal delivery when the last channel is an unconfigured plugin channel"*: asserts `res.ok === false`, `INVALID_REQUEST`, and that no agent dispatch occurs.
- **Updated** — *"agent reuses the last plugin delivery route when channel=last"* now registers a **configured** msteams plugin (`accountIds: ["default"]`). It previously registered an *unconfigured* plugin yet asserted delivery succeeded — i.e. it encoded the bug.
- `createMSTeamsPlugin` gains an optional `accountIds` parameter to express configured vs. unconfigured.

`pnpm check` (format + `tsgo` typecheck + lint + fork guards) passes.

> Note: the full gateway suite (including this file) is gated out of the `test` CI job behind `REMOTECLAW_TEST_INCLUDE_GATEWAY=1` due to orthogonal pre-existing failures (see `.github/workflows/ci.yml` `test-gateway-preauth` comment), so these assertions run in the gateway lane / locally rather than the default `test` job. Verified locally: the two new/updated assertions pass; the 2 pre-existing best-effort-downgrade failures are unrelated and present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
