### PR TITLE
fix(gateway): surface error-only agent runs in webchat (restore lost fix)

### DIFF
--- a/src/gateway/server-methods/chat.error-propagation.test.ts
+++ b/src/gateway/server-methods/chat.error-propagation.test.ts
@@ -184,6 +184,25 @@ describe("chat error propagation separates error and non-error reply parts", () 
     expect(errorBroadcasts.length).toBe(0);
   });
 
+  it("broadcasts error when agent run produces only error payloads", async () => {
+    createTranscriptFixture("remoteclaw-chat-err-only-");
+    mockState.payloads = [{ text: "auth failed: invalid credentials", isError: true }];
+    const context = createChatContext();
+
+    const broadcasts = await runChatSendAndWaitForBroadcast({
+      context,
+      idempotencyKey: "idem-err-only",
+    });
+
+    // Error-only agent run (no assistant text) must surface the error to the
+    // webchat UI rather than silently completing as success.
+    const errorBroadcasts = broadcasts.filter((b) => b.state === "error");
+    expect(errorBroadcasts.length).toBe(1);
+    expect(errorBroadcasts[0]?.errorMessage).toContain("auth failed: invalid credentials");
+    const finalBroadcasts = broadcasts.filter((b) => b.state === "final");
+    expect(finalBroadcasts.length).toBe(0);
+  });
+
   it("does not broadcast error when only non-error payloads with no agent run", async () => {
     createTranscriptFixture("remoteclaw-chat-no-agent-");
     mockState.triggerAgentRunStart = false;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1104,6 +1104,8 @@ export const chatHandlers: GatewayRequestHandlers = {
         channel: INTERNAL_MESSAGE_CHANNEL,
       });
       const finalReplyParts: string[] = [];
+      const errorReplyParts: string[] = [];
+      let hasErrorPayload = false;
       const dispatcher = createReplyDispatcher({
         ...prefixOptions,
         onError: (err) => {
@@ -1113,11 +1115,22 @@ export const chatHandlers: GatewayRequestHandlers = {
           if (info.kind !== "final") {
             return;
           }
+          // Set the flag before the empty-text early return so text-less
+          // error payloads still mark the run as having errored.
+          if (payload.isError) {
+            hasErrorPayload = true;
+          }
           const text = payload.text?.trim() ?? "";
           if (!text) {
             return;
           }
-          finalReplyParts.push(text);
+          // Keep error text in a dedicated array so a mixed run (error +
+          // assistant text) is not misclassified as an error.
+          if (payload.isError) {
+            errorReplyParts.push(text);
+          } else {
+            finalReplyParts.push(text);
+          }
         },
       });
 
@@ -1195,6 +1208,28 @@ export const chatHandlers: GatewayRequestHandlers = {
               sessionKey: rawSessionKey,
               message,
             });
+          } else if (
+            hasErrorPayload &&
+            finalReplyParts.length === 0 &&
+            errorReplyParts.length > 0
+          ) {
+            // Agent run started but produced only error payloads (e.g. auth
+            // failure, CLI crash) — the lifecycle events carry no assistant
+            // text, so the normal agent-run broadcast surfaces nothing. Emit
+            // the error to the webchat UI explicitly instead of dropping it.
+            const combinedError = errorReplyParts
+              .map((part) => part.trim())
+              .filter(Boolean)
+              .join("\n\n")
+              .trim();
+            if (combinedError) {
+              broadcastChatError({
+                context,
+                runId: clientRunId,
+                sessionKey: rawSessionKey,
+                errorMessage: combinedError,
+              });
+            }
           }
           setGatewayDedupeEntry({
             dedupe: context.dedupe,


### PR DESCRIPTION
## Problem

In the webchat chat handler, when an agent run produced **only error payloads** (e.g. auth failure, CLI crash) emitted as `final`-kind dispatcher replies, the error was silently dropped:

- the `deliver` collector pushed all final text into `finalReplyParts` without distinguishing `payload.isError`;
- the post-run `.then()` calls `broadcastChatFinal` only on the **non-agent-run** path (`if (!agentRunStarted)`);
- `broadcastChatError` fired solely from `.catch()` (promise *rejection*), never for in-band error payloads.

So an error-only agent run resolved normally, marked the run `ok`, and surfaced nothing to the webchat UI.

## Fix (`src/gateway/server-methods/chat.ts`)

- Collect error text in a dedicated `errorReplyParts` array (kept out of `finalReplyParts`), and set `hasErrorPayload` **before** the empty-text early return so text-less error payloads still mark the run as errored.
- In the post-run handler, when an agent run produced only error payloads (`finalReplyParts` empty, `errorReplyParts` non-empty), broadcast the combined error to the webchat UI. A **mixed** run (error + assistant text) is not misclassified — the assistant text still flows via the agent run's own stream.

## Provenance / regression context

This fix was previously merged and then **silently reverted by a later upstream sync** that overwrote `chat.ts` (upstream never carried it). The accompanying `chat.error-propagation.test.ts` was left behind and had been passing **vacuously** — its assertions held trivially against the broken code.

## Tests (`chat.error-propagation.test.ts`)

- **New** — *"broadcasts error when agent run produces only error payloads"*: asserts exactly one `error`-state broadcast carrying the error text, and no `final` broadcast. **Verified it fails on the unfixed code** (1 failed / 3 passed) and passes with the fix (4/4) — a real regression guard, not vacuous.
- The 3 pre-existing assertions now hold meaningfully (mixed run → no error broadcast; empty-text error → flag set, no broadcast; non-agent run → final broadcast).

`pnpm check` (format + `tsgo` typecheck + lint + fork guards) passes.

> Note: like the rest of the gateway suite, this file is gated out of the default `test` CI job behind `REMOTECLAW_TEST_INCLUDE_GATEWAY=1` (orthogonal pre-existing failures — see the `test-gateway-preauth` comment in `ci.yml`), so the assertions run in the gateway lane / locally. Because this fix was lost once to a sync overwrite, the hardened test is the regression signal whenever the gateway suite runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
