### PR TITLE
chore(gateway): remove talk.speak orphan method declarations (#2724)

### DIFF
--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -98,7 +98,6 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "agent.wait",
     "wake",
     "talk.mode",
-    "talk.speak",
     "tts.enable",
     "tts.disable",
     "tts.convert",

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -35,7 +35,6 @@ const BASE_METHODS = [
   "wizard.cancel",
   "wizard.status",
   "talk.config",
-  "talk.speak",
   "talk.mode",
   "tools.catalog",
   "tools.effective",


### PR DESCRIPTION
## What

Removes the two orphan `talk.speak` registry declarations — `BASE_METHODS` in `src/gateway/server-methods-list.ts` and `WRITE_SCOPE` in `src/gateway/method-scopes.ts`. No other changes (2 deletions).

## Why

`talk.speak` is declared as a gateway method but has **no handler**: `talkHandlers` (`src/gateway/server-methods/talk.ts`, spread into `coreGatewayHandlers`) defines only `talk.config` and `talk.mode`. The speak capability was gutted at the fork, so these two declarations advertised a method that always failed to dispatch.

## Safety

- `src/gateway/method-scopes.test.ts` — **23/23 pass**. Its *"classifies every listed gateway method name"* check is the consistency invariant (every advertised method must carry a scope mapping); removing `talk.speak` from **both** sites keeps it balanced. Its *"classifies every exposed core gateway handler method"* check confirms no real handler was de-classified by the scope-map removal — i.e. it empirically re-confirms `talk.speak` had no handler.
- `pnpm check` clean (format + tsgo typecheck + lint).

## Scope note

`talk.speak` is still referenced in `docs/` (the Talk-mode playback flow in `docs/nodes/talk.md` + the protocol method list in `docs/gateway/protocol.md`). Those describe the gutted gateway-side synthesis mechanism and need an informed reconciliation of how Talk-mode playback works post-gut — deferred to a separate change, not bundled into this registry cleanup.

One item from #2724.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
