### PR TITLE
chore(gateway): drop dead secrets.resolve method + reconcile stale talk.speak/secrets docs (#2724)

### DIFF
--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -302,7 +302,8 @@ implemented in `src/gateway/server-methods/*.ts`.
   requires `operator.talk.secrets` (or `operator.admin`).
 - `talk.mode` sets/broadcasts the current Talk mode state for WebChat/Control UI
   clients.
-- `talk.speak` synthesizes speech through the active Talk speech provider.
+- Talk-mode speech is synthesized client-side by the native apps (ElevenLabs
+  direct, system-TTS fallback — see `docs/nodes/talk.md`), not via a gateway RPC.
 - `tts.status` returns TTS enabled state, active provider, fallback providers,
   and provider config state.
 - `tts.providers` returns the visible TTS provider inventory.
@@ -310,12 +311,8 @@ implemented in `src/gateway/server-methods/*.ts`.
 - `tts.setProvider` updates the preferred TTS provider.
 - `tts.convert` runs one-shot text-to-speech conversion.
 
-### Secrets, config, update, and wizard
+### Config, update, and wizard
 
-- `secrets.reload` re-resolves active SecretRefs and swaps runtime secret state
-  only on full success.
-- `secrets.resolve` resolves command-target secret assignments for a specific
-  command/target set.
 - `config.get` returns the current config snapshot and hash.
 - `config.set` writes a validated config payload.
 - `config.patch` merges a partial config update.

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -13,7 +13,7 @@ Talk mode is a continuous voice conversation loop:
 1. Listen for speech
 2. Send transcript to the model (main session, chat.send)
 3. Wait for the response
-4. Speak it via the configured Talk provider (`talk.speak`)
+4. Speak it via the configured Talk provider — synthesized on-device (ElevenLabs direct, with system-TTS fallback)
 
 ## Behavior (macOS)
 
@@ -86,7 +86,7 @@ Defaults:
 
 - Requires Speech + Microphone permissions.
 - Uses `chat.send` against session key `main`.
-- The gateway resolves Talk playback through `talk.speak` using the active Talk provider. Android falls back to local system TTS only when that RPC is unavailable.
+- Talk playback is synthesized on-device, not by the gateway: each native app calls the ElevenLabs API directly using the active Talk config, and falls back to the platform's system TTS (AVSpeechSynthesizer on macOS/iOS, `TextToSpeech` on Android) when no ElevenLabs API key is configured. The gateway supplies Talk config (`talk.config`) and mode state (`talk.mode`) only — it performs no speech synthesis.
 - `stability` for `eleven_v3` is validated to `0.0`, `0.5`, or `1.0`; other models accept `0..1`.
 - `latency_tier` is validated to `0..4` when set.
 - Android supports `pcm_16000`, `pcm_22050`, `pcm_24000`, and `pcm_44100` output formats for low-latency AudioTrack streaming.

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -122,7 +122,6 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "agents.delete",
     "skills.install",
     "skills.update",
-    "secrets.resolve",
     "cron.add",
     "cron.update",
     "cron.remove",

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -51,7 +51,6 @@ const BASE_METHODS = [
   "update.run",
   "voicewake.get",
   "voicewake.set",
-  "secrets.resolve",
   "sessions.list",
   "sessions.subscribe",
   "sessions.unsubscribe",


### PR DESCRIPTION
## Summary

Resolves two cleanup items tracked on #2724, both gateway method-surface hygiene:

1. **Remove the dead `secrets.resolve` gateway method.** It was advertised in `BASE_METHODS` (`server-methods-list.ts`) and classified in `method-scopes.ts` (ADMIN_SCOPE), but has **no handler** (`server-methods/secrets.ts` was gutted) and **zero production callers** (grep finds only the two registry/scope sites). #2720 removed the sibling `secrets.reload` but deliberately kept `secrets.resolve`, deferring the decision to a dedicated evaluation — this is that evaluation, and the answer is **remove**.

   Advertising a handler-less method is strictly worse than honest non-advertisement: the `requiredMethods` pre-check (`call.ts`) would *pass*, then dispatch hard-errors `unknown method`. The fork's SecretRef resolution is **local** (`src/secrets/resolve.ts`, `gateway/resolve-configured-secret-input-string.ts`), wholly independent of this RPC. Mirrors the `talk.speak` cleanup (#2727).

2. **Reconcile stale `talk.speak` docs to the fork's real Talk-mode playback story.** `docs/nodes/talk.md` and `docs/gateway/protocol.md` described the gateway resolving Talk playback through a `talk.speak` RPC — but that RPC was gutted (#2727), and the native apps (macOS / iOS / Android) all synthesize **on-device**: each calls the ElevenLabs API directly using the active Talk config, falling back to the platform's system TTS (AVSpeechSynthesizer / Android `TextToSpeech`) when no ElevenLabs key is configured. The gateway is config/state only (`talk.config`, `talk.mode`), never synthesis. Also dropped the gutted `secrets.reload` + `secrets.resolve` bullets from protocol.md's method-families reference.

## Changes

| File | Change |
|------|--------|
| `src/gateway/server-methods-list.ts` | Remove `secrets.resolve` from `BASE_METHODS` |
| `src/gateway/method-scopes.ts` | Remove `secrets.resolve` from `ADMIN_SCOPE` |
| `docs/nodes/talk.md` | Rewrite the 2 `talk.speak` refs → on-device synthesis (ElevenLabs direct, system-TTS fallback) |
| `docs/gateway/protocol.md` | Drop the `talk.speak` bullet (→ client-side note); drop the gutted `secrets.reload`/`secrets.resolve` bullets; retitle the subsection |

## Validation

- Gateway suites `method-scopes` + `call`: **80/80** pass — the method-list ↔ scope-map consistency invariant holds with `secrets.resolve` removed.
- `pnpm check` (format + tsgo + lint + custom lints) clean (pre-commit hook).
- No rebrand-gate trip (no `openclaw` refs added).
- `src/commands/message.test.ts` has 3 pre-existing local failures unrelated to this change — identical on clean `main`, and the test only references `secrets.resolve` as fixture strings (never imports the method list). The `test` lane is green on `main` in CI.

## Follow-ups (tracked on #2724)

These need subsystem-accurate rewrites, not mechanical edits, so they're deferred:

- **(A)** `docs/gateway/secrets.md` (Command-path resolution) + `docs/cli/qr.md` still name `secrets.resolve` as the gateway snapshot RPC, but the fork resolves SecretRefs locally — needs an accurate rewrite of the command-path-resolution story.
- **(B)** `docs/gateway/protocol.md`'s "Common RPC method families" still documents other methods #2720 removed from `BASE_METHODS` (`models.list`, `skills.search`/`detail`/`bins`, `plugin.approval.*` methods) — a full method-list reconciliation pass with per-method handler verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
