### PR TITLE
fix(gateway): enforce chat.abort owner-authorization — reject non-owner aborts (#2721)

### DIFF
--- a/src/gateway/server-methods/chat.abort-authorization.test.ts
+++ b/src/gateway/server-methods/chat.abort-authorization.test.ts
@@ -42,16 +42,12 @@ function createSingleAbortContext() {
 }
 
 describe("chat.abort authorization", () => {
-  // DEFERRED (hardening follow-up): chat.abort owner-authorization is gutted in this fork. The
-  // handler never reads client identity, so any operator can abort another device's in-flight run
-  // (the ChatAbortControllerEntry owner fields exist but are never populated on chat.send nor
-  // checked on chat.abort). Upstream ships the control: resolveChatAbortRequester +
-  // canRequesterAbortChatRun + resolveAuthorizedRunIdsForSession (admin-bypass / owner-by-deviceId /
-  // owner-by-connId). Restoring it flips previously-accepted non-owner aborts to "unauthorized"
-  // (a security-semantics tightening), so it is tracked as a separate HIGH hardening issue rather
-  // than bundled into this make-CI-green pass. See security-architect adjudication. The two
-  // remaining cases below pass under the current permissive behavior (requester == owner/admin).
-  it.skip("rejects explicit run aborts from other clients", async () => {
+  // chat.abort owner-authorization (restored in #2721): the handler resolves the requesting
+  // client's identity (resolveChatAbortRequester) and authorizes it against the run's recorded
+  // owner (canRequesterAbortChatRun) — admin-bypass / owner-by-deviceId / owner-by-connId, with
+  // unowned runs left abortable by any authenticated client. Run ownership is populated at
+  // chat.send run-start, so a non-owner explicit or session abort is now rejected as "unauthorized".
+  it("rejects explicit run aborts from other clients", async () => {
     const context = createSingleAbortContext();
 
     const respond = await invokeSingleRunAbort({
@@ -91,8 +87,7 @@ describe("chat.abort authorization", () => {
     expect(context.chatAbortControllers.has("run-1")).toBe(false);
   });
 
-  // DEFERRED with the explicit-run authz case above (same gutted owner-authorization control).
-  it.skip("only aborts session-scoped runs owned by the requester", async () => {
+  it("only aborts session-scoped runs owned by the requester", async () => {
     const context = createChatAbortContext({
       chatAbortControllers: new Map([
         ["run-mine", createActiveRun("main", { owner: { deviceId: "dev-1" } })],

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -32,6 +32,7 @@ import {
 } from "../chat-abort.js";
 import { type ChatImageContent, parseMessageWithAttachments } from "../chat-attachments.js";
 import { stripEnvelopeFromMessage, stripEnvelopeFromMessages } from "../chat-sanitize.js";
+import { ADMIN_SCOPE } from "../method-scopes.js";
 import {
   GATEWAY_CLIENT_CAPS,
   GATEWAY_CLIENT_MODES,
@@ -702,6 +703,124 @@ function abortChatRunsForSessionKeyWithPartials(params: {
   return res;
 }
 
+type ChatAbortRequester = {
+  connId?: string;
+  deviceId?: string;
+  isAdmin: boolean;
+};
+
+function resolveChatAbortRequester(
+  client: GatewayRequestHandlerOptions["client"],
+): ChatAbortRequester {
+  const connId = typeof client?.connId === "string" ? client.connId : undefined;
+  const deviceId =
+    typeof client?.connect?.device?.id === "string" ? client.connect.device.id : undefined;
+  const scopes = client?.connect?.scopes;
+  const isAdmin = Array.isArray(scopes) && scopes.includes(ADMIN_SCOPE);
+  return { connId, deviceId, isAdmin };
+}
+
+/**
+ * Authorize a requester against a run's recorded owner.
+ *
+ * - `operator.admin` callers bypass owner checks.
+ * - Runs with no recorded owner stay abortable by any authenticated client, so
+ *   restoring ownership enforcement never strands legacy runs or runs started by
+ *   clients that carry no connId/deviceId identity.
+ * - Otherwise the requester must match the run owner by deviceId (a paired device
+ *   keeps abort rights across reconnects) or by connId (the originating
+ *   connection).
+ */
+function canRequesterAbortChatRun(
+  requester: ChatAbortRequester,
+  entry: Pick<ChatAbortControllerEntry, "ownerConnId" | "ownerDeviceId">,
+): boolean {
+  if (requester.isAdmin) {
+    return true;
+  }
+  if (entry.ownerConnId === undefined && entry.ownerDeviceId === undefined) {
+    return true;
+  }
+  if (
+    entry.ownerDeviceId !== undefined &&
+    requester.deviceId !== undefined &&
+    entry.ownerDeviceId === requester.deviceId
+  ) {
+    return true;
+  }
+  if (
+    entry.ownerConnId !== undefined &&
+    requester.connId !== undefined &&
+    entry.ownerConnId === requester.connId
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function resolveAuthorizedRunIdsForSession(params: {
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>;
+  sessionKey: string;
+  requester: ChatAbortRequester;
+}): string[] {
+  const out: string[] = [];
+  for (const [runId, active] of params.chatAbortControllers) {
+    if (active.sessionKey !== params.sessionKey) {
+      continue;
+    }
+    if (canRequesterAbortChatRun(params.requester, active)) {
+      out.push(runId);
+    }
+  }
+  return out;
+}
+
+function abortAuthorizedSessionRunsWithPartials(params: {
+  context: GatewayRequestContext;
+  ops: ChatAbortOps;
+  sessionKey: string;
+  requester: ChatAbortRequester;
+  abortOrigin: AbortOrigin;
+  stopReason?: string;
+}): { aborted: boolean; runIds: string[] } {
+  const authorizedRunIds = new Set(
+    resolveAuthorizedRunIdsForSession({
+      chatAbortControllers: params.context.chatAbortControllers,
+      sessionKey: params.sessionKey,
+      requester: params.requester,
+    }),
+  );
+  if (authorizedRunIds.size === 0) {
+    return { aborted: false, runIds: [] };
+  }
+  const snapshots = collectSessionAbortPartials({
+    chatAbortControllers: params.context.chatAbortControllers,
+    chatRunBuffers: params.context.chatRunBuffers,
+    sessionKey: params.sessionKey,
+    abortOrigin: params.abortOrigin,
+  }).filter((snapshot) => authorizedRunIds.has(snapshot.runId));
+  const runIds: string[] = [];
+  for (const runId of authorizedRunIds) {
+    const res = abortChatRunById(params.ops, {
+      runId,
+      sessionKey: params.sessionKey,
+      stopReason: params.stopReason,
+    });
+    if (res.aborted) {
+      runIds.push(runId);
+    }
+  }
+  if (runIds.length > 0) {
+    const abortedRunIds = new Set(runIds);
+    persistAbortedPartials({
+      context: params.context,
+      sessionKey: params.sessionKey,
+      snapshots: snapshots.filter((snapshot) => abortedRunIds.has(snapshot.runId)),
+    });
+  }
+  return { aborted: runIds.length > 0, runIds };
+}
+
 function nextChatSeq(context: { agentRunSeq: Map<string, number> }, runId: string) {
   const next = (context.agentRunSeq.get(runId) ?? 0) + 1;
   context.agentRunSeq.set(runId, next);
@@ -812,7 +931,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       verboseLevel,
     });
   },
-  "chat.abort": ({ params, respond, context }) => {
+  "chat.abort": ({ params, respond, context, client }) => {
     if (!validateChatAbortParams(params)) {
       respond(
         false,
@@ -830,12 +949,14 @@ export const chatHandlers: GatewayRequestHandlers = {
     };
 
     const ops = createChatAbortOps(context);
+    const requester = resolveChatAbortRequester(client);
 
     if (!runId) {
-      const res = abortChatRunsForSessionKeyWithPartials({
+      const res = abortAuthorizedSessionRunsWithPartials({
         context,
         ops,
         sessionKey: rawSessionKey,
+        requester,
         abortOrigin: "rpc",
         stopReason: "rpc",
       });
@@ -854,6 +975,10 @@ export const chatHandlers: GatewayRequestHandlers = {
         undefined,
         errorShape(ErrorCodes.INVALID_REQUEST, "runId does not match sessionKey"),
       );
+      return;
+    }
+    if (!canRequesterAbortChatRun(requester, active)) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unauthorized"));
       return;
     }
 
@@ -1033,12 +1158,17 @@ export const chatHandlers: GatewayRequestHandlers = {
 
     try {
       const abortController = new AbortController();
+      const ownerConnId = typeof client?.connId === "string" ? client.connId : undefined;
+      const ownerDeviceId =
+        typeof client?.connect?.device?.id === "string" ? client.connect.device.id : undefined;
       context.chatAbortControllers.set(clientRunId, {
         controller: abortController,
         sessionId: entry?.sessionId ?? clientRunId,
         sessionKey: rawSessionKey,
         startedAtMs: now,
         expiresAtMs: resolveChatRunExpiresAtMs({ now, timeoutMs }),
+        ownerConnId,
+        ownerDeviceId,
       });
       const ackPayload = {
         runId: clientRunId,


### PR DESCRIPTION
## Summary

`chat.abort` never read client identity, so **any authenticated client could abort another client's in-flight chat run** — cross-client denial of in-flight work (HIGH). This restores the owner-authorization control, self-contained to `src/gateway/server-methods/chat.ts` (no shared-core edits).

Closes #2721.

## What changed

- **`resolveChatAbortRequester`** — identifies the requesting client: `connId`, `deviceId` (`connect.device.id`), and `operator.admin` scope.
- **`canRequesterAbortChatRun`** — authorizes a requester against the run's recorded owner:
  - `operator.admin` → bypass;
  - **unowned run** (no `ownerConnId`/`ownerDeviceId`) → abortable by any authenticated client (no regression for legacy / no-identity runs);
  - owner-by-`deviceId` (a paired device keeps abort rights across reconnects) or owner-by-`connId` (originating connection).
- **Explicit-run abort** from a non-owner → rejected `{ code: "INVALID_REQUEST", message: "unauthorized" }`; the run is left untouched.
- **Session-scoped abort** → cancels only requester-owned runs (`resolveAuthorizedRunIdsForSession` + `abortAuthorizedSessionRunsWithPartials`, preserving partial-transcript persistence).
- **`chat.send`** populates `ownerConnId` / `ownerDeviceId` at run-start so the check has data in production.
- Un-skips the two covering tests in `chat.abort-authorization.test.ts`.

## Behavior change (intended tightening)

Previously-accepted non-owner aborts now return `unauthorized`. The owner (same connection, or same paired device after reconnect) and `operator.admin` retain full abort capability; unowned runs are unaffected.

## Test plan

- ✅ `chat.abort-authorization.test.ts` — **4/4** (the 2 previously `it.skip` cases un-skipped and passing).
- ✅ Full `pnpm test:gateway` — **1554 passed / 0 failed** (140 files), incl. `chat.abort` persistence (`client: null` + unowned runs) and both `server.chat.gateway-server-chat*` e2e suites (same-`ws` send → abort).
- ✅ `acp/translator.cancel-scoping.test.ts` — 7/7.
- ✅ `pnpm check` (oxfmt + tsgo + oxlint + css-class-drift) clean; throwing-stub-callers gate 0 violations.

## Merge

Per the dispatch directive, **this PR is intentionally not merged** — merging is handled by the orchestrator once CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)