### PR TITLE
fix(gateway): re-check allowedSessionKeyPrefixes after /hooks agent-rebind (#2723)

### DIFF
--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -7,6 +7,7 @@ import {
   extractHookToken,
   isHookAgentAllowed,
   normalizeHookDispatchSessionKey,
+  resolveHookDispatchSessionKey,
   resolveHookSessionKey,
   resolveHookTargetAgentId,
   normalizeAgentPayload,
@@ -320,6 +321,42 @@ describe("gateway hooks helpers", () => {
         targetAgentId: "hooks",
       }),
     ).toBe("agent:hooks:slack:channel:c123");
+  });
+
+  test("resolveHookDispatchSessionKey re-checks the rebound key against allowed prefixes", () => {
+    const cfg = {
+      hooks: {
+        enabled: true,
+        token: "secret",
+        allowRequestSessionKey: true,
+        allowedSessionKeyPrefixes: ["hook:", "agent:main:"],
+      },
+    } as RemoteClawConfig;
+    const resolved = resolveHooksConfig(cfg);
+    expect(resolved).not.toBeNull();
+    if (!resolved) {
+      return;
+    }
+
+    // Rebinding an allowlisted agent:main:* request onto the hooks agent yields agent:hooks:*,
+    // which is not allowlisted -> rejected even though the requested key passed the pre-rebind check.
+    const blocked = resolveHookDispatchSessionKey({
+      hooksConfig: resolved,
+      sessionKey: "agent:main:slack:channel:c123",
+      targetAgentId: "hooks",
+    });
+    expect(blocked.ok).toBe(false);
+    if (!blocked.ok) {
+      expect(blocked.error).toContain("sessionKey must start with one of");
+    }
+
+    // Rebinding onto the main agent keeps agent:main:*, which stays allowlisted.
+    const allowed = resolveHookDispatchSessionKey({
+      hooksConfig: resolved,
+      sessionKey: "agent:main:slack:channel:c123",
+      targetAgentId: "main",
+    });
+    expect(allowed).toEqual({ ok: true, value: "agent:main:slack:channel:c123" });
   });
 
   test("resolveHooksConfig validates defaultSessionKey and generated fallback against prefixes", () => {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -375,6 +375,29 @@ export function normalizeHookDispatchSessionKey(params: {
   return `agent:${targetAgentId}:${parsed.rest}`;
 }
 
+/**
+ * Rebind the session key to the target agent, then re-validate the rebound key against
+ * hooks.allowedSessionKeyPrefixes. The pre-rebind allowlist check on the requested key does not
+ * authorize the namespace the rebind lands in (e.g. an allowlisted `agent:main:*` request rebound
+ * to a target `hooks` agent becomes `agent:hooks:*`, which the allowlist may not permit), so the
+ * dispatch key must be re-checked here before it leaves the ingress boundary.
+ */
+export function resolveHookDispatchSessionKey(params: {
+  hooksConfig: HooksConfigResolved;
+  sessionKey: string;
+  targetAgentId: string | undefined;
+}): { ok: true; value: string } | { ok: false; error: string } {
+  const dispatchSessionKey = normalizeHookDispatchSessionKey({
+    sessionKey: params.sessionKey,
+    targetAgentId: params.targetAgentId,
+  });
+  const allowedPrefixes = params.hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
+  if (allowedPrefixes && !isSessionKeyAllowedByPrefix(dispatchSessionKey, allowedPrefixes)) {
+    return { ok: false, error: getHookSessionKeyPrefixError(allowedPrefixes) };
+  }
+  return { ok: true, value: dispatchSessionKey };
+}
+
 export function normalizeAgentPayload(payload: Record<string, unknown>):
   | {
       ok: true;

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -45,7 +45,7 @@ import {
   normalizeHookHeaders,
   normalizeWakePayload,
   readJsonBody,
-  normalizeHookDispatchSessionKey,
+  resolveHookDispatchSessionKey,
   resolveHookSessionKey,
   resolveHookTargetAgentId,
   resolveHookChannel,
@@ -485,12 +485,18 @@ export function createHooksRequestHandler(
         return true;
       }
       const targetAgentId = resolveHookTargetAgentId(hooksConfig, normalized.value.agentId);
+      const dispatchSessionKey = resolveHookDispatchSessionKey({
+        hooksConfig,
+        sessionKey: sessionKey.value,
+        targetAgentId,
+      });
+      if (!dispatchSessionKey.ok) {
+        sendJson(res, 400, { ok: false, error: dispatchSessionKey.error });
+        return true;
+      }
       const runId = dispatchAgentHook({
         ...normalized.value,
-        sessionKey: normalizeHookDispatchSessionKey({
-          sessionKey: sessionKey.value,
-          targetAgentId,
-        }),
+        sessionKey: dispatchSessionKey.value,
         agentId: targetAgentId,
       });
       sendJson(res, 200, { ok: true, runId });
@@ -542,15 +548,21 @@ export function createHooksRequestHandler(
             return true;
           }
           const targetAgentId = resolveHookTargetAgentId(hooksConfig, mapped.action.agentId);
+          const dispatchSessionKey = resolveHookDispatchSessionKey({
+            hooksConfig,
+            sessionKey: sessionKey.value,
+            targetAgentId,
+          });
+          if (!dispatchSessionKey.ok) {
+            sendJson(res, 400, { ok: false, error: dispatchSessionKey.error });
+            return true;
+          }
           const runId = dispatchAgentHook({
             message: mapped.action.message,
             name: mapped.action.name ?? "Hook",
             agentId: targetAgentId,
             wakeMode: mapped.action.wakeMode,
-            sessionKey: normalizeHookDispatchSessionKey({
-              sessionKey: sessionKey.value,
-              targetAgentId,
-            }),
+            sessionKey: dispatchSessionKey.value,
             deliver: resolveHookDeliver(mapped.action.deliver),
             channel,
             to: mapped.action.to,

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -350,20 +350,58 @@ describe("gateway server hooks", () => {
     });
   });
 
-  // SECURITY FOLLOW-UP (tracked separately, NOT in this CI-green test-remediation pass):
-  // Two tests removed here asserted a post-rebind session-namespace authorization re-check
-  // ("rejects rebinding into a session namespace that is not allowlisted" + the mapped variant).
-  // Upstream re-checks the agent-rebound sessionKey against hooks.allowedSessionKeyPrefixes after
-  // normalizeHookDispatchSessionKey (server-http.ts agent path + mapping path); the fork's
-  // server-http.ts has NEVER carried that re-check (git -S isSessionKeyAllowedByPrefix /
-  // getHookSessionKeyPrefixError in server-http.ts → 0 commits). This is a genuine kept-middleware
-  // authz-confinement gap (an authenticated hook caller can rebind a turn into a non-allowlisted
-  // namespace), but restoring it flips previously-accepted requests to 400 — a security-semantics
-  // change that must land in its own threat-modeled hardening PR, not a test-fix commit. See the
-  // security-architect ruling for this branch (file a tracked issue: restore the re-check of
-  // normalizeHookDispatchSessionKey output against allowedSessionKeyPrefixes on both /hooks/agent
-  // and /hooks/<mapping> paths). Deleting the failing assertions does NOT lower shipped posture —
-  // the control is already absent in the fork (which is why these tests fail).
+  // Post-rebind session-key-prefix re-check (remoteclaw#2723): after normalizeHookDispatchSessionKey
+  // rebinds the requested key to the target agent (e.g. agent:main:* -> agent:hooks:*), the rebound
+  // key is re-validated against hooks.allowedSessionKeyPrefixes on both /hooks/agent and
+  // /hooks/<mapping> paths. The requested key passing the pre-rebind check does not authorize the
+  // namespace the rebind lands in.
+  test("rejects rebinding into a session namespace that is not allowlisted", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:", "agent:main:"],
+    };
+    setMainAndHooksAgents();
+    await withGatewayServer(async ({ port }) => {
+      const denied = await postHook(port, "/hooks/agent", {
+        message: "Do it",
+        name: "Email",
+        agentId: "hooks",
+        sessionKey: "agent:main:slack:channel:c123",
+      });
+      expect(denied.status).toBe(400);
+      const body = (await denied.json()) as { error?: string };
+      expect(body.error).toContain("sessionKey must start with one of");
+      expect(cronIsolatedRun).not.toHaveBeenCalled();
+    });
+  });
+
+  test("rejects mapped hook session rebinding into a disallowed target-agent prefix", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:", "agent:main:"],
+      mappings: [
+        {
+          match: { path: "mapped-rebind-denied" },
+          action: "agent",
+          agentId: "hooks",
+          messageTemplate: "Mapped: {{payload.subject}}",
+          sessionKey: "agent:main:slack:channel:c123",
+        },
+      ],
+    };
+    setMainAndHooksAgents();
+    await withGatewayServer(async ({ port }) => {
+      const denied = await postHook(port, "/hooks/mapped-rebind-denied", { subject: "hello" });
+      expect(denied.status).toBe(400);
+      const body = (await denied.json()) as { error?: string };
+      expect(body.error).toContain("sessionKey must start with one of");
+      expect(cronIsolatedRun).not.toHaveBeenCalled();
+    });
+  });
 
   // BACKLOG (low-priority webhook hardening, NOT a regression): removed four tests here asserted
   // an idempotency replay-dedupe cache for /hooks/agent (same Idempotency-Key → same runId, single


### PR DESCRIPTION
## Summary

Fixes #2723 — a gateway authz-confinement gap. The `/hooks/agent` and
`/hooks/<mapping>` paths validated the **requested** session key against
`hooks.allowedSessionKeyPrefixes`, then rebound it to the target agent
(`agent:main:*` → `agent:hooks:*`) via `normalizeHookDispatchSessionKey` and
dispatched **without re-checking** the rebound key. An authenticated hook caller
could therefore rebind a turn into a session namespace it was never authorized
for: e.g. with allowlist `["hook:", "agent:main:"]`, a request for
`sessionKey: "agent:main:..."` + `agentId: hooks` passed the pre-rebind check,
then rebound to `agent:hooks:...` (which matches neither prefix) and dispatched.

## Fix

- Add `resolveHookDispatchSessionKey` (`src/gateway/hooks.ts`): rebinds the
  session key to the target agent, then re-validates the **rebound** key against
  `allowedSessionKeyPrefixes`. Returns the existing `{ok,value}|{ok,error}`
  result shape used by `resolveHookSessionKey`.
- Gate both ingress paths in `createHooksRequestHandler`
  (`src/gateway/server-http.ts`) on it — reject `400` with the existing
  `getHookSessionKeyPrefixError` message when the rebound key violates the
  allowlist. Single security chokepoint; `dispatchAgentHook` has no other
  production invoker.

## Behavior change

This **tightens** behavior: post-rebind requests whose rebound key violates the
prefix allowlist now return `400` instead of being accepted. Requests are
unaffected when no allowlist is configured, or when the rebound key still
matches an allowed prefix.

## Tests

- Restored the two covering integration tests that were removed during the
  CI-green test-remediation pass (the documented deferral lived in
  `src/gateway/server.hooks.test.ts`, not `hooks.test.ts` as the issue text
  states): agent-path + mapping-path "rejects rebinding into a disallowed
  namespace" — both assert `400` + `"sessionKey must start with one of"` +
  `cronIsolatedRun` not called. Confirmed RED before the fix, GREEN after.
- Added a unit test for `resolveHookDispatchSessionKey` in `hooks.test.ts`
  (blocked + allowed cases).
- The idempotency replay-cache tests in the same removed hunk are intentionally
  **out of scope** (net-new feature, separate BACKLOG item) and left unrestored;
  the BACKLOG comment documenting them is preserved.

## Verification

- `pnpm test:gateway` — 1557 pass / 9 skip / 0 fail (full gateway suite, no regressions)
- `pnpm check` — format + typecheck + lint + css-drift all clean
- Fork-integrity gates (throwing-stub-callers, zombie-imports, stub-debt, obsolescence) all pass

## Acceptance criteria

- [x] Post-rebind requests whose rebound session key violates the prefix allowlist are rejected.
- [x] The documented `server.hooks.test.ts` cases are restored and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
