### PR TITLE
fix(gateway): disconnect WS sessions authed against a rotated shared secret (#2722)

### DIFF
--- a/src/gateway/server-methods/config.shared-auth.test.ts
+++ b/src/gateway/server-methods/config.shared-auth.test.ts
@@ -90,14 +90,7 @@ describe("config shared auth disconnects", () => {
     expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
   });
 
-  // DEFERRED (hardening follow-up): the config-write -> shared-auth-disconnect control is gutted
-  // in this fork. config.ts no longer computes didSharedGatewayAuthChange / queueSharedGatewayAuthDisconnect,
-  // and the live disconnect driver (context.disconnectClientsUsingSharedGatewayAuth) is absent from every
-  // owned file (it lives in the cross-cutting core src/gateway/server.impl.ts). Restoring only the config.ts
-  // caller would make this unit test pass while the integration path stays broken, so this defers together
-  // with the session-rotation integration test as one HIGH credential-revocation hardening issue. See
-  // security-architect adjudication.
-  it.skip("disconnects shared-auth clients after config.patch rotates the active token", async () => {
+  it("disconnects shared-auth clients after config.patch rotates the active token", async () => {
     const prevConfig: RemoteClawConfig = {
       gateway: {
         auth: {

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -33,6 +33,7 @@ import {
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { loadRemoteClawPlugins } from "../../plugins/loader.js";
+import { resolveEffectiveSharedGatewayAuth } from "../auth.js";
 import { diffConfigPaths } from "../config-reload.js";
 import {
   formatControlPlaneActor,
@@ -53,7 +54,7 @@ import {
 } from "../protocol/index.js";
 import { resolveBaseHashParam } from "./base-hash.js";
 import { parseRestartRequestParams } from "./restart-request.js";
-import type { GatewayRequestHandlers, RespondFn } from "./types.js";
+import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 const MAX_CONFIG_ISSUES_IN_ERROR_MESSAGE = 3;
@@ -169,6 +170,48 @@ function parseValidateConfigFromRawOrRespond(
     return null;
   }
   return { config: validated.config, schema };
+}
+
+// Compare the EFFECTIVE shared gateway secret (the active auth mode's secret)
+// between two configs. Only a change to the currently-active credential counts —
+// editing the inactive password while mode is "token" must not evict live sessions.
+function didSharedGatewayAuthChange(prev: RemoteClawConfig, next: RemoteClawConfig): boolean {
+  const prevAuth = resolveEffectiveSharedGatewayAuth({
+    authConfig: prev.gateway?.auth,
+    env: process.env,
+    tailscaleMode: prev.gateway?.tailscale?.mode,
+  });
+  const nextAuth = resolveEffectiveSharedGatewayAuth({
+    authConfig: next.gateway?.auth,
+    env: process.env,
+    tailscaleMode: next.gateway?.tailscale?.mode,
+  });
+  if (prevAuth === null || nextAuth === null) {
+    return prevAuth !== nextAuth;
+  }
+  return prevAuth.mode !== nextAuth.mode || prevAuth.secret !== nextAuth.secret;
+}
+
+// A `reload.mode: "off"` config write is never picked up by the live-reload
+// watcher, so without an explicit disconnect the stale-secret sessions would
+// survive until the next manual restart. Other modes restart/hot-reload the
+// gateway, which drops the connections on their own.
+function isReloadDisabled(config: RemoteClawConfig): boolean {
+  return config.gateway?.reload?.mode === "off";
+}
+
+function queueSharedGatewayAuthDisconnect(
+  shouldDisconnect: boolean,
+  context?: GatewayRequestContext,
+): void {
+  if (!shouldDisconnect) {
+    return;
+  }
+  // Defer past the success response so the caller observes the write result
+  // before its socket (if shared-auth) is closed.
+  queueMicrotask(() => {
+    context?.disconnectClientsUsingSharedGatewayAuth?.();
+  });
 }
 
 function summarizeConfigValidationIssues(issues: ReadonlyArray<ConfigValidationIssue>): string {
@@ -325,7 +368,7 @@ export const configHandlers: GatewayRequestHandlers = {
     }
     respond(true, result, undefined);
   },
-  "config.set": async ({ params, respond }) => {
+  "config.set": async ({ params, respond, context }) => {
     if (!assertValidParams(params, validateConfigSetParams, "config.set", respond)) {
       return;
     }
@@ -337,6 +380,12 @@ export const configHandlers: GatewayRequestHandlers = {
     if (!parsed) {
       return;
     }
+    // config.set is a plain write that schedules no restart of its own. When
+    // reload is disabled, a secret rotation must explicitly evict shared-auth
+    // sessions here — otherwise they survive until the next manual restart.
+    // Compare before the write so we use the prior on-disk secret as the baseline.
+    const disconnectSharedAuthClients =
+      isReloadDisabled(parsed.config) && didSharedGatewayAuthChange(snapshot.config, parsed.config);
     await writeConfigFile(parsed.config, writeOptions);
     respond(
       true,
@@ -347,6 +396,7 @@ export const configHandlers: GatewayRequestHandlers = {
       },
       undefined,
     );
+    queueSharedGatewayAuthDisconnect(disconnectSharedAuthClients, context);
   },
   "config.patch": async ({ params, respond, client, context }) => {
     if (!assertValidParams(params, validateConfigPatchParams, "config.patch", respond)) {
@@ -449,6 +499,13 @@ export const configHandlers: GatewayRequestHandlers = {
     context?.logGateway?.info(
       `config.patch write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.patch`,
     );
+    // config.patch always schedules a (delayed) restart. Evict shared-auth
+    // sessions immediately on an effective secret rotation so a revoked
+    // credential cannot keep working during the restart-delay window.
+    const disconnectSharedAuthClients = didSharedGatewayAuthChange(
+      snapshot.config,
+      validated.config,
+    );
     await writeConfigFile(validated.config, writeOptions);
 
     const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
@@ -491,6 +548,7 @@ export const configHandlers: GatewayRequestHandlers = {
       },
       undefined,
     );
+    queueSharedGatewayAuthDisconnect(disconnectSharedAuthClients, context);
   },
   "config.apply": async ({ params, respond, client, context }) => {
     if (!assertValidParams(params, validateConfigApplyParams, "config.apply", respond)) {
@@ -509,6 +567,9 @@ export const configHandlers: GatewayRequestHandlers = {
     context?.logGateway?.info(
       `config.apply write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.apply`,
     );
+    // config.apply mirrors config.patch: restart-capable write, so evict
+    // shared-auth sessions immediately on an effective secret rotation.
+    const disconnectSharedAuthClients = didSharedGatewayAuthChange(snapshot.config, parsed.config);
     await writeConfigFile(parsed.config, writeOptions);
 
     const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
@@ -551,6 +612,7 @@ export const configHandlers: GatewayRequestHandlers = {
       },
       undefined,
     );
+    queueSharedGatewayAuthDisconnect(disconnectSharedAuthClients, context);
   },
   "config.openFile": ({ params, respond }) => {
     if (!assertValidParams(params, validateConfigGetParams, "config.openFile", respond)) {

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -48,6 +48,7 @@ export type GatewayRequestContext = {
   nodeUnsubscribeAll: (nodeId: string) => void;
   hasConnectedMobileNode: () => boolean;
   hasExecApprovalClients?: () => boolean;
+  disconnectClientsUsingSharedGatewayAuth?: () => void;
   nodeRegistry: NodeRegistry;
   agentRunSeq: Map<string, number>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -654,6 +654,21 @@ export async function startGatewayServer(
       }
       return false;
     },
+    disconnectClientsUsingSharedGatewayAuth: () => {
+      // Evict every live socket that authenticated with a shared gateway secret
+      // (token/password). Called when a config write rotates the active shared
+      // secret so a revoked credential cannot survive on an existing connection.
+      for (const gatewayClient of clients) {
+        if (!gatewayClient.usesSharedGatewayAuth) {
+          continue;
+        }
+        try {
+          gatewayClient.socket.close(4001, "gateway auth changed");
+        } catch {
+          /* ignore close failures on already-terminated sockets */
+        }
+      }
+    },
     nodeRegistry,
     agentRunSeq,
     chatAbortControllers,

--- a/src/gateway/server.shared-token-session-rotation.test.ts
+++ b/src/gateway/server.shared-token-session-rotation.test.ts
@@ -74,14 +74,7 @@ function buildConfigSetWithRotatedToken(config: Record<string, unknown>): Record
 }
 
 describe("gateway shared token session rotation", () => {
-  // DEFERRED (hardening follow-up): the shared-secret-rotation -> WS-disconnect control is
-  // gutted in this fork. config.set/patch/apply no longer compute didSharedGatewayAuthChange,
-  // and GatewayRequestContext has no disconnectClientsUsingSharedGatewayAuth (upstream wires it
-  // in src/gateway/server.impl.ts, a cross-cutting core file outside this CI-green pass's scope).
-  // Restoring it is a security-semantics change (sessions authenticated against a revoked secret
-  // currently survive until the next restart) and requires shared-core edits, so it is tracked as
-  // a separate HIGH hardening issue rather than bundled here. See security-architect adjudication.
-  it.skip("invalidates shared-token websocket sessions after config.set rotation even with reload mode off", async () => {
+  it("invalidates shared-token websocket sessions after config.set rotation even with reload mode off", async () => {
     const ws = await openAuthenticatedGatewayWs(port, OLD_TOKEN);
     try {
       const current = await loadGatewayConfig(ws);


### PR DESCRIPTION
## Summary

Closes #2722. Rotating the shared gateway auth secret via `config.set` / `config.patch` / `config.apply` left WebSocket sessions that authenticated against the **old** secret connected until the next gateway restart — credential revocation was ineffective for live connections (HIGH).

This wires the shared-core disconnect driver **together with** its config-write caller. They must land together: the unit-level caller is inert without the integration path in `server.impl.ts`, which is why the two covering tests were `it.skip`-ped as one deferred hardening item.

## Changes

- **`src/gateway/server.impl.ts`** — `gatewayRequestContext.disconnectClientsUsingSharedGatewayAuth()` iterates the connected-client set and closes every `usesSharedGatewayAuth` socket with code `4001 "gateway auth changed"`.
- **`src/gateway/server-methods/types.ts`** — declares the optional `disconnectClientsUsingSharedGatewayAuth?: () => void` on `GatewayRequestContext`.
- **`src/gateway/server-methods/config.ts`** — detects an **effective** shared-auth change (active mode's secret only, via the existing `resolveEffectiveSharedGatewayAuth`) and queues the disconnect after the success response:
  - `config.set` — when reload is **off** (no watcher restart would otherwise drop the stale sessions).
  - `config.patch` / `config.apply` — unconditionally on an effective rotation (revoke immediately rather than wait out the delayed SIGUSR1 restart).
- **Un-skipped** the two acceptance-gate tests: `server.shared-token-session-rotation.test.ts` and `server-methods/config.shared-auth.test.ts`.

The connection-side flag (`GatewayWsClient.usesSharedGatewayAuth`, set in `message-handler.ts`) was already present in the fork; only the driver, the context-type field, and the caller wiring were missing.

Device-token and other non-shared sessions are preserved by the `usesSharedGatewayAuth` guard.

## Acceptance criteria

- [x] Both previously-skipped tests pass.
- [x] After a shared-secret rotation, WS sessions authed against the prior secret are disconnected without requiring a restart. (The integration test starts a real server with `reload.mode: "off"` — no restart path — and asserts the old-token socket closes `4001`.)

## Testing

- `pnpm test:gateway` (full suite): **141 files, 1559 passed, 7 skipped** (the 7 are unrelated pre-existing deferrals). No regressions.
- `pnpm check`: format ✓, typecheck ✓, lint 0/0 ✓, css-class-drift 0 orphans ✓.
- Fork-integrity gates: throwing-stub-callers, stub-debt, zombie-imports all green.
- A fresh-context adversarial security review (security-architect) probed five residual revocation surfaces and found no blocking holes; it independently confirmed that the new-connection path is closed by the existing config-cache flush in the IO write path.

## Follow-up (out of scope — not bundled)

The security review noted an **orphaned dead-code module** `src/gateway/server-shared-auth-generation.ts` (plus the unused `sharedGatewaySessionGeneration?` field in `ws-types.ts`) — an upstream-sync artifact implementing a parallel generation-based revocation mechanism with **zero live callers**. It is inert (not a credential hole) but worth a separate `gut`/cleanup pass to avoid future confusion. Intentionally not addressed here to keep this fix scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
