### PR TITLE
chore(gateway): drop dead allowGatewaySubagentBinding runtime option (#2724)

### DIFF
--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -67,5 +67,4 @@ export type PluginRuntime = PluginRuntimeCore & {
 
 export type CreatePluginRuntimeOptions = {
   subagent?: PluginRuntime["subagent"];
-  allowGatewaySubagentBinding?: boolean;
 };


### PR DESCRIPTION
## What

Removes the dead `allowGatewaySubagentBinding?: boolean` field from
`CreatePluginRuntimeOptions` in `src/plugins/runtime/types.ts`.

## Why it's dead (zero live consumers)

A whole-repo grep (including ignored/hidden files, excluding
`node_modules`/`dist`) found the identifier `allowGatewaySubagentBinding`
in **exactly one place** — its own declaration. Tracing the type confirms
nothing reads or writes it:

- **The declaring type is an orphaned duplicate.** There are two
  `CreatePluginRuntimeOptions` declarations: the live one in
  `runtime/index.ts` (no such field) and this duplicate in `runtime/types.ts`.
  Only the `index.ts` version is ever imported — `src/plugins/loader.ts`
  imports `CreatePluginRuntimeOptions` from `./runtime/index.js`, never from
  `./runtime/types.js`.
- **The factory never reads it.** `createPluginRuntime(_options)`
  (`runtime/index.ts`) reads only `_options.subagent`.
- **The sole construction site never sets it.** The gateway builds
  `runtimeOptions` in `src/gateway/server-plugins.ts` with only
  `subagent: createGatewaySubagentRuntime()`.
- No dynamic string-key, destructuring, or spread access exists either.

## Scope

Surgical: one line removed. Out of scope (noted, not addressed here): after
this removal the `runtime/types.ts` `CreatePluginRuntimeOptions` is byte-for-byte
identical to the live `runtime/index.ts` one and remains an un-imported
duplicate — a separate dead-code cleanup candidate.

## Verification

- `pnpm check` (format + typecheck + lint + fork-integrity guards): **pass**
  (also re-run green by the pre-commit hook).
- Post-removal grep for the identifier: **zero references remain**.

Part of #2724.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
