### PR TITLE
fix(gateway): pre-validate SecretRef id shape on the config path

### DIFF
--- a/src/gateway/resolve-configured-secret-input-string.test.ts
+++ b/src/gateway/resolve-configured-secret-input-string.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RemoteClawConfig } from "../config/types.remoteclaw.js";
+import {
+  resolveConfiguredSecretInputString,
+  resolveRequiredConfiguredSecretRefInputString,
+} from "./resolve-configured-secret-input-string.js";
+
+const resolveSecretRefValuesMock = vi.hoisted(() => vi.fn());
+vi.mock("../secrets/resolve.js", () => ({
+  resolveSecretRefValues: resolveSecretRefValuesMock,
+}));
+
+const config = {} as RemoteClawConfig;
+
+describe("resolveConfiguredSecretInputString — SecretRef shape pre-validation", () => {
+  beforeEach(() => {
+    resolveSecretRefValuesMock.mockReset();
+  });
+
+  it("rejects a malformed exec id (path traversal) before attempting resolution", async () => {
+    const result = await resolveConfiguredSecretInputString({
+      config,
+      env: {},
+      value: { source: "exec", provider: "vault", id: "vault/../secret" },
+      path: "gateway.auth.token",
+      unresolvedReasonStyle: "detailed",
+    });
+
+    expect(result.value).toBeUndefined();
+    expect(result.unresolvedRefReason).toContain("malformed");
+    expect(result.unresolvedRefReason).toContain("exec:vault:vault/../secret");
+    // The hardening guarantee: a malformed ref is never handed to the resolver.
+    expect(resolveSecretRefValuesMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed env id without leaking specifics in generic style", async () => {
+    const result = await resolveConfiguredSecretInputString({
+      config,
+      env: {},
+      value: { source: "env", provider: "default", id: "lower_bad" },
+      path: "gateway.auth.token",
+    });
+
+    expect(result.value).toBeUndefined();
+    expect(result.unresolvedRefReason).toBe(
+      "gateway.auth.token SecretRef is malformed (env:default:lower_bad).",
+    );
+    expect(resolveSecretRefValuesMock).not.toHaveBeenCalled();
+  });
+
+  it("does not reject on a non-kebab provider alias (provider is a free-form lookup key)", async () => {
+    resolveSecretRefValuesMock.mockResolvedValue(
+      new Map([["exec:customProvider:OPENAI_API_KEY", "secret-value"]]),
+    );
+
+    const result = await resolveConfiguredSecretInputString({
+      config,
+      env: {},
+      value: { source: "exec", provider: "customProvider", id: "OPENAI_API_KEY" },
+      path: "gateway.auth.token",
+    });
+
+    expect(result.value).toBe("secret-value");
+    expect(result.unresolvedRefReason).toBeUndefined();
+    expect(resolveSecretRefValuesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a clear error for a malformed ref via the required variant", async () => {
+    await expect(
+      resolveRequiredConfiguredSecretRefInputString({
+        config,
+        env: {},
+        value: { source: "env", provider: "default", id: "lower_bad" },
+        path: "gateway.auth.password",
+      }),
+    ).rejects.toThrow(/malformed/);
+    expect(resolveSecretRefValuesMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves a well-formed ref normally (no false rejection)", async () => {
+    resolveSecretRefValuesMock.mockResolvedValue(
+      new Map([["env:default:GW_TOKEN", "secret-value"]]),
+    );
+
+    const result = await resolveConfiguredSecretInputString({
+      config,
+      env: { GW_TOKEN: "secret-value" },
+      value: { source: "env", provider: "default", id: "GW_TOKEN" },
+      path: "gateway.auth.token",
+    });
+
+    expect(result.value).toBe("secret-value");
+    expect(result.unresolvedRefReason).toBeUndefined();
+    expect(resolveSecretRefValuesMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/gateway/resolve-configured-secret-input-string.ts
+++ b/src/gateway/resolve-configured-secret-input-string.ts
@@ -1,6 +1,6 @@
 import type { RemoteClawConfig } from "../config/types.remoteclaw.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
-import { secretRefKey } from "../secrets/ref-contract.js";
+import { secretRefKey, validateSecretRefShape } from "../secrets/ref-contract.js";
 import { resolveSecretRefValues } from "../secrets/resolve.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 
@@ -13,9 +13,16 @@ export type ConfiguredSecretInputSource =
 function buildUnresolvedReason(params: {
   path: string;
   style: SecretInputUnresolvedReasonStyle;
-  kind: "unresolved" | "non-string" | "empty";
+  kind: "unresolved" | "non-string" | "empty" | "malformed";
   refLabel: string;
+  detail?: string;
 }): string {
+  if (params.kind === "malformed") {
+    if (params.style === "generic" || !params.detail) {
+      return `${params.path} SecretRef is malformed (${params.refLabel}).`;
+    }
+    return `${params.path} SecretRef is malformed (${params.refLabel}): ${params.detail}`;
+  }
   if (params.style === "generic") {
     return `${params.path} SecretRef is unresolved (${params.refLabel}).`;
   }
@@ -45,6 +52,25 @@ export async function resolveConfiguredSecretInputString(params: {
   }
 
   const refLabel = `${ref.source}:${ref.provider}:${ref.id}`;
+
+  // Pre-validate the SecretRef id shape before using it. `coerceSecretRef`
+  // only guarantees a non-empty `id` string; a ref that bypassed the config
+  // schema (inline coercion, legacy form, programmatic construction) can still
+  // carry a malformed id that would otherwise be passed straight to a provider
+  // (exec stdin, file/JSON navigation, env lookup).
+  const shape = validateSecretRefShape(ref);
+  if (!shape.ok) {
+    return {
+      unresolvedRefReason: buildUnresolvedReason({
+        path: params.path,
+        style,
+        kind: "malformed",
+        refLabel,
+        detail: shape.message,
+      }),
+    };
+  }
+
   try {
     const resolved = await resolveSecretRefValues([ref], {
       config: params.config,

--- a/src/secrets/ref-contract.test.ts
+++ b/src/secrets/ref-contract.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { SecretRef } from "../config/types.secrets.js";
+import { validateSecretRefShape } from "./ref-contract.js";
+
+describe("validateSecretRefShape", () => {
+  it("accepts well-formed refs for every source", () => {
+    const valid: SecretRef[] = [
+      { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+      { source: "file", provider: "mounted-json", id: "/providers/openai/apiKey" },
+      { source: "file", provider: "default", id: "value" },
+      { source: "exec", provider: "vault", id: "openai/api-key" },
+    ];
+    for (const ref of valid) {
+      expect(validateSecretRefShape(ref)).toEqual({ ok: true });
+    }
+  });
+
+  it("does not reject on the provider alias (it is only a lookup key, not a use-surface)", () => {
+    // A non-kebab provider name is a free-form lookup key for the resolution
+    // engine; only the id is validated here.
+    expect(
+      validateSecretRefShape({ source: "exec", provider: "customProvider", id: "openai/api-key" }),
+    ).toEqual({ ok: true });
+  });
+
+  it("rejects an env id that is not SCREAMING_SNAKE_CASE", () => {
+    expect(
+      validateSecretRefShape({ source: "env", provider: "default", id: "lower_bad" }),
+    ).toMatchObject({ ok: false, reason: "env-id" });
+    expect(
+      validateSecretRefShape({ source: "env", provider: "default", id: "WITH-DASH" }),
+    ).toMatchObject({ ok: false, reason: "env-id" });
+  });
+
+  it('rejects a file id that is neither an absolute JSON pointer nor "value"', () => {
+    expect(
+      validateSecretRefShape({ source: "file", provider: "default", id: "relative/path" }),
+    ).toMatchObject({ ok: false, reason: "file-id" });
+  });
+
+  it("rejects an exec id that fails the character pattern", () => {
+    expect(
+      validateSecretRefShape({ source: "exec", provider: "vault", id: "-leading-dash" }),
+    ).toMatchObject({ ok: false, reason: "exec-id-pattern" });
+  });
+
+  it("rejects an exec id containing a path-traversal segment", () => {
+    // Passes the character pattern but resolves a "../" segment — the case the
+    // raw pattern check alone would miss.
+    expect(
+      validateSecretRefShape({ source: "exec", provider: "vault", id: "vault/../secret" }),
+    ).toMatchObject({ ok: false, reason: "exec-id-traversal-segment" });
+  });
+
+  it("carries a human-readable message on failure", () => {
+    const result = validateSecretRefShape({ source: "env", provider: "default", id: "lower_bad" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/A-Z/);
+    }
+  });
+});

--- a/src/secrets/ref-contract.ts
+++ b/src/secrets/ref-contract.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SECRET_PROVIDER_ALIAS,
+  isValidEnvSecretRefId,
   type SecretRef,
   type SecretRefSource,
 } from "../config/types.secrets.js";
@@ -105,4 +106,75 @@ export function formatExecSecretRefIdValidationMessage(): string {
     'and must not include "." or ".." path segments',
     '(example: "vault/openai/api-key").',
   ].join(" ");
+}
+
+export type SecretRefShapeValidationReason =
+  | "env-id"
+  | "file-id"
+  | "exec-id-pattern"
+  | "exec-id-traversal-segment";
+
+export type SecretRefShapeValidationResult =
+  | { ok: true }
+  | { ok: false; reason: SecretRefShapeValidationReason; message: string };
+
+/**
+ * Validate that a structurally-coerced {@link SecretRef} carries a well-formed
+ * per-source `id` before it is used to resolve a secret.
+ *
+ * `coerceSecretRef`/`isSecretRef` only guarantee that `source` is valid and
+ * `provider`/`id` are non-empty strings — they do NOT apply the per-source id
+ * patterns the config Zod schema enforces at load time (see
+ * `src/config/zod-schema.core.ts`). A ref that bypasses schema validation
+ * (inline-object coercion, legacy provider-less form, programmatic
+ * construction) can therefore reach resolution with a malformed id that is
+ * then handed straight to a provider: an exec id is written to the provider's
+ * stdin payload, a file id navigates a JSON pointer / path, an env id is used
+ * as an env-var name. This guard applies the same id validators the schema
+ * uses, so a schema-valid ref always passes (zero drift, no false rejections)
+ * while a malformed id — most importantly an exec id with a "." / ".."
+ * traversal segment — is rejected before use.
+ *
+ * The `provider` alias is intentionally not validated here: it is only a
+ * lookup key into the configured providers map (a malformed alias simply finds
+ * no provider), never an input handed to a provider, and the resolution engine
+ * treats it as a free-form key.
+ */
+export function validateSecretRefShape(ref: SecretRef): SecretRefShapeValidationResult {
+  switch (ref.source) {
+    case "env":
+      if (!isValidEnvSecretRefId(ref.id)) {
+        return {
+          ok: false,
+          reason: "env-id",
+          message:
+            'Env secret reference id must match /^[A-Z][A-Z0-9_]{0,127}$/ (example: "OPENAI_API_KEY").',
+        };
+      }
+      return { ok: true };
+    case "file":
+      if (!isValidFileSecretRefId(ref.id)) {
+        return {
+          ok: false,
+          reason: "file-id",
+          message:
+            'File secret reference id must be an absolute JSON pointer (example: "/providers/openai/apiKey"), or "value" for singleValue mode.',
+        };
+      }
+      return { ok: true };
+    case "exec": {
+      const execResult = validateExecSecretRefId(ref.id);
+      if (!execResult.ok) {
+        return {
+          ok: false,
+          reason:
+            execResult.reason === "traversal-segment"
+              ? "exec-id-traversal-segment"
+              : "exec-id-pattern",
+          message: formatExecSecretRefIdValidationMessage(),
+        };
+      }
+      return { ok: true };
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Hardening for the gateway config-path SecretRef resolver. Part of the
gateway-suite remediation tracker (#2724) — the **`SecretRef` pre-validation
(LOW)** item.

`resolveConfiguredSecretInputString` coerces a `SecretRef` via
`coerceSecretRef`/`isSecretRef`, which only guarantee a valid `source` and
non-empty `provider`/`id` strings — they do **not** re-apply the per-source
`id` patterns the config Zod schema (`src/config/zod-schema.core.ts`) enforces
at load time. A ref that bypasses schema validation (inline-object coercion,
the legacy provider-less form, or programmatic construction) could therefore
reach resolution with a malformed `id` that is handed straight to a provider:

- an **exec** id is written to the provider's stdin payload,
- a **file** id navigates a JSON pointer / path,
- an **env** id is read as an env-var name.

## Change

- Add `validateSecretRefShape` to `src/secrets/ref-contract.ts` — a runtime
  mirror of the schema's per-source id validators:
  - **env**: `/^[A-Z][A-Z0-9_]{0,127}$/`
  - **file**: absolute JSON pointer, or `"value"` for singleValue mode
  - **exec**: character pattern **and** no `"."` / `".."` path-traversal segments
- Call it in `resolveConfiguredSecretInputString` **before**
  `resolveSecretRefValues`. A malformed id now fails with a clear
  `"... SecretRef is malformed ..."` reason (the required-input variant throws
  it) instead of being resolved.

A schema-valid ref always passes — the validators are identical to the
schema's, so there is **zero drift and no false rejection** of legitimately
configured refs (production refs on this path originate from schema-validated
config). The `provider` alias is intentionally **not** validated: it is only a
lookup key into the providers map (a malformed alias simply finds no
provider), never an input handed to a provider, and the resolution engine
treats it as a free-form key.

## Test plan

- New `src/secrets/ref-contract.test.ts` — `validateSecretRefShape` per source
  (valid cases, env/file/exec malformed, exec path-traversal segment,
  provider-not-validated).
- New `src/gateway/resolve-configured-secret-input-string.test.ts` —
  config-path wiring: malformed id rejected **before** the resolver is invoked
  (asserts the resolver mock is never called), clear error surfaced, throwing
  required-variant, and no false rejection of a valid ref.
- Full gateway behavioral suite green the CI way
  (`vitest --config vitest.gateway.config.ts --pool=forks --no-file-parallelism`):
  **142 files, 1564 passed | 7 skipped**.
- `pnpm check` (format + typecheck + oxlint) clean; rebrand / zombie-import /
  stub-debt / throwing-stub-callers / attestations / obsolescence gates pass.

Part of #2724. Does not close the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
