### PR TITLE
refactor(gateway): route default-agent id through resolveDefaultAgentId (#2724)

### DIFF
--- a/src/gateway/assistant-identity.test.ts
+++ b/src/gateway/assistant-identity.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import { DEFAULT_ASSISTANT_IDENTITY, resolveAssistantIdentity } from "./assistant-identity.js";
 
@@ -43,5 +44,58 @@ describe("resolveAssistantIdentity avatar normalization", () => {
     expect(resolveAssistantIdentity({ cfg, workspaceDir: "/tmp/remoteclaw-test" }).avatar).toBe(
       "avatars/remoteclaw.png",
     );
+  });
+});
+
+describe("resolveAssistantIdentity canonical default-agent id (#2724)", () => {
+  it("DEFAULT_ASSISTANT_IDENTITY.agentId derives from the single canonical source", () => {
+    // Pins the fallback identity's agent id to resolveDefaultAgentId's no-config
+    // result ("default") — not a hardcoded literal — and guards against the
+    // eliminated phantom "main" agent ever being reintroduced here.
+    expect(DEFAULT_ASSISTANT_IDENTITY.agentId).toBe(resolveDefaultAgentId({}));
+    expect(DEFAULT_ASSISTANT_IDENTITY.agentId).toBe("default");
+    expect(DEFAULT_ASSISTANT_IDENTITY.agentId).not.toBe("main");
+  });
+
+  it("resolves to the canonical default when no agents are configured", () => {
+    const cfg: RemoteClawConfig = {};
+    expect(resolveAssistantIdentity({ cfg }).agentId).toBe(resolveDefaultAgentId(cfg));
+    expect(resolveAssistantIdentity({ cfg }).agentId).toBe("default");
+  });
+
+  it("uses the first listed agent when none is marked default", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "alpha", workspace: "~/alpha" },
+          { id: "beta", workspace: "~/beta" },
+        ],
+      },
+    };
+    expect(resolveAssistantIdentity({ cfg }).agentId).toBe("alpha");
+    expect(resolveAssistantIdentity({ cfg }).agentId).toBe(resolveDefaultAgentId(cfg));
+  });
+
+  it("honors a non-first agent marked default:true (routes through resolveDefaultAgentId)", () => {
+    // The previous inline `listAgentEntries(cfg)[0]?.id` fallback returned the
+    // FIRST listed agent and ignored the `default` flag. Routing through the
+    // canonical resolver now correctly selects the default-marked agent.
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [
+          { id: "first", workspace: "~/first" },
+          { id: "second", workspace: "~/second", default: true },
+        ],
+      },
+    };
+    expect(resolveAssistantIdentity({ cfg }).agentId).toBe("second");
+    expect(resolveAssistantIdentity({ cfg }).agentId).toBe(resolveDefaultAgentId(cfg));
+  });
+
+  it("an explicit agentId param still wins and is normalized", () => {
+    const cfg: RemoteClawConfig = {
+      agents: { list: [{ id: "configured", workspace: "~/c", default: true }] },
+    };
+    expect(resolveAssistantIdentity({ cfg, agentId: "Override" }).agentId).toBe("override");
   });
 });

--- a/src/gateway/assistant-identity.ts
+++ b/src/gateway/assistant-identity.ts
@@ -1,4 +1,4 @@
-import { listAgentEntries, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveAgentIdentity } from "../agents/identity.js";
 // Gutted in RemoteClaw fork (Middleware Boundary Principle)
 const loadAgentIdentity = (
@@ -18,7 +18,11 @@ const MAX_ASSISTANT_AVATAR = 200;
 const MAX_ASSISTANT_EMOJI = 16;
 
 export const DEFAULT_ASSISTANT_IDENTITY: AssistantIdentity = {
-  agentId: "main",
+  // Derive the agent id from the single canonical source. With no config there
+  // are no agents, so resolveDefaultAgentId returns the canonical fallback
+  // ("default") — not a hardcoded literal, and never the eliminated phantom
+  // "main" agent. (#2724)
+  agentId: resolveDefaultAgentId({}),
   name: "Assistant",
   avatar: "A",
 };
@@ -86,9 +90,11 @@ export function resolveAssistantIdentity(params: {
   agentId?: string | null;
   workspaceDir?: string | null;
 }): AssistantIdentity {
-  const agentId = normalizeAgentId(
-    params.agentId ?? listAgentEntries(params.cfg)[0]?.id ?? "default",
-  );
+  // Route the default through the single canonical source (resolveDefaultAgentId)
+  // instead of re-implementing "first listed agent, else 'default'" inline. This
+  // also honors an agent marked `default: true` that is not first in the list,
+  // which the previous `[0]?.id` fallback ignored. (#2724)
+  const agentId = normalizeAgentId(params.agentId ?? resolveDefaultAgentId(params.cfg));
   const workspaceDir = params.workspaceDir ?? resolveAgentWorkspaceDir(params.cfg, agentId);
   const configAssistant = params.cfg.ui?.assistant;
   const agentIdentity = resolveAgentIdentity(params.cfg, agentId);

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -59,6 +59,10 @@ vi.mock("../../config/config.js", async () => {
 
 vi.mock("../../agents/agent-scope.js", () => ({
   listAgentIds: () => ["main"],
+  // assistant-identity.ts (imported transitively via agent.ts) now resolves the
+  // default agent id through resolveDefaultAgentId at module-init (#2724); the
+  // wholesale mock must export it. Mirror this mock's single-agent "main" fiction.
+  resolveDefaultAgentId: () => "main",
 }));
 
 vi.mock("../../infra/agent-events.js", () => ({


### PR DESCRIPTION
## Summary

Make gateway default-agent-id resolution derive from a **single canonical source** —
`resolveDefaultAgentId` (`src/agents/agent-scope.ts`). `src/gateway/assistant-identity.ts`
was re-implementing default-agent resolution inline with two divergent hardcoded literals;
both now route through the canonical resolver.

Part of #2724 (does **not** close it — multi-part tracker, this is one item).

## ⚠️ Stale-premise correction (please read before reviewing the delta)

The tracker item describes the inconsistency as *"`assistant-identity.ts` resolves `'default'`
while `http-utils.ts` uses `'main'`."* Against the **current** code this is **stale**:

- **`http-utils.ts` is already canonical** — it calls `resolveDefaultAgentId(cfg)` at lines 59 & 84;
  there is **no `'main'` agent-id literal** in it (only a comment mentions the word "default").
  It was already routed through the resolver (during the #2720 re-greening) and the tracker text
  wasn't updated. **→ `http-utils.ts` is unchanged in this PR.**
- The actual remaining `'main'` literal lived in **`assistant-identity.ts`** itself
  (`DEFAULT_ASSISTANT_IDENTITY.agentId`). So **both** divergent literals were in that one file.

## Behavior delta (auditable)

Canonical value is `"default"`: `resolveDefaultAgentId` falls back to the module-local
`DEFAULT_AGENT_ID = "default"` — deliberately **not** exported, per the phantom-`"main"`-agent
elimination guard (`test/default-agent-elimination.test.ts`).

| Site | Old | New | Effect |
|------|-----|-----|--------|
| `DEFAULT_ASSISTANT_IDENTITY.agentId` (line 21) | `"main"` | `resolveDefaultAgentId({})` → `"default"` | **Behaviorally inert.** Its only consumer is the no-config Control-UI bootstrap branch (`control-ui.ts`), which passes it to `resolveAssistantAvatarUrl`. The default avatar is `"A"` (not a path), so the agent id is **never rendered** into the avatar URL (`control-ui-shared.ts` embeds the id only when the avatar `looksLikeAvatarPath`). Value corrected to canonical; no observable change. |
| `resolveAssistantIdentity` fallback (line 90) | `listAgentEntries(cfg)[0]?.id ?? "default"` | `resolveDefaultAgentId(cfg)` | **Common path unchanged** (`"default"` when no agents; first listed agent otherwise — pinned by existing `control-ui.http.test.ts` `/avatar/default` assertions). **Edge-case fix:** an agent marked `default: true` that is **not first** in the list is now honored — the old `[0]?.id` fallback silently ignored the flag. The `??` short-circuit semantics are preserved exactly (only the fallback *expression* changed). |

**Why `"default"` is the correct canonical value:** `"main"` is the *eliminated phantom agent*;
the canonical default-agent id is whatever `resolveDefaultAgentId` returns, whose no-agents fallback
is `DEFAULT_AGENT_ID = "default"`. Routing both sites through that one function is the "single source"
the tracker asks for.

## Tests

Adds 5 tests in `assistant-identity.test.ts` pinning canonical resolution at **each** affected site:

- `DEFAULT_ASSISTANT_IDENTITY.agentId === resolveDefaultAgentId({}) === "default"` (and `!== "main"`)
- no-config → `"default"`; first-listed agent; **`default:true` non-first agent honored**;
  explicit `agentId` param still wins (and is normalized).

Local verification:

- `assistant-identity.test.ts` + all `control-ui*` consumer suites — **58 passed**
- `test/default-agent-elimination.test.ts` (phantom-`"main"` guards) — **24 passed**
- `pnpm check` (oxfmt + tsgo + oxlint + fork-integrity gates) — **green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
