### PR TITLE
docs(gateway): reconcile RPC surface + local SecretRef resolution (#2724)

### DIFF
--- a/docs/cli/qr.md
+++ b/docs/cli/qr.md
@@ -41,12 +41,11 @@ remoteclaw qr --url wss://gateway.example/ws
 - Mobile pairing fails closed for Tailscale/public `ws://` gateway URLs. Private LAN `ws://` remains supported, but Tailscale/public mobile routes should use Tailscale Serve/Funnel or a `wss://` gateway URL.
 - With `--remote`, RemoteClaw requires either `gateway.remote.url` or
   `gateway.tailscale.mode=serve|funnel`.
-- With `--remote`, if effectively active remote credentials are configured as SecretRefs and you do not pass `--token` or `--password`, the command resolves them from the active gateway snapshot. If gateway is unavailable, the command fails fast.
+- With `--remote`, if effectively active remote credentials are configured as SecretRefs and you do not pass `--token` or `--password`, the command resolves them locally from the configured `env` / `file` / `exec` providers, in-process (`exec` providers are run locally). It does not query a running gateway. If a required SecretRef cannot be resolved, the command fails fast.
 - Without `--remote`, local gateway auth SecretRefs are resolved when no CLI auth override is passed:
   - `gateway.auth.token` resolves when token auth can win (explicit `gateway.auth.mode="token"` or inferred mode where no password source wins).
   - `gateway.auth.password` resolves when password auth can win (explicit `gateway.auth.mode="password"` or inferred mode with no winning token from auth/env).
 - If both `gateway.auth.token` and `gateway.auth.password` are configured (including SecretRefs) and `gateway.auth.mode` is unset, setup-code resolution fails until mode is set explicitly.
-- Gateway version skew note: this command path requires a gateway that supports `secrets.resolve`; older gateways return an unknown-method error.
 - After scanning, approve device pairing with:
   - `remoteclaw devices list`
   - `remoteclaw devices approve <requestId>`

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -265,16 +265,12 @@ implemented in `src/gateway/server-methods/*.ts`.
 - `last-heartbeat` returns the latest persisted heartbeat event.
 - `set-heartbeats` toggles heartbeat processing on the gateway.
 
-### Models and usage
+### Usage
 
-- `models.list` returns the runtime-allowed model catalog.
 - `usage.status` returns provider usage windows/remaining quota summaries.
 - `usage.cost` returns aggregated cost usage summaries for a date range.
 - `doctor.memory.status` returns vector-memory / embedding readiness for the
   active default agent workspace.
-- `sessions.usage` returns per-session usage summaries.
-- `sessions.usage.timeseries` returns timeseries usage for one session.
-- `sessions.usage.logs` returns usage log entries for one session.
 
 ### Channels and login helpers
 
@@ -406,18 +402,14 @@ implemented in `src/gateway/server-methods/*.ts`.
 
 #### Approval families
 
-- `exec.approval.request`, `exec.approval.get`, `exec.approval.list`, and
-  `exec.approval.resolve` cover one-shot exec approval requests plus pending
-  approval lookup/replay.
+- `exec.approval.request` and `exec.approval.resolve` cover one-shot exec
+  approval requests and resolution.
 - `exec.approval.waitDecision` waits on one pending exec approval and returns
   the final decision (or `null` on timeout).
 - `exec.approvals.get` and `exec.approvals.set` manage gateway exec approval
   policy snapshots.
 - `exec.approvals.node.get` and `exec.approvals.node.set` manage node-local exec
   approval policy via node relay commands.
-- `plugin.approval.request`, `plugin.approval.list`,
-  `plugin.approval.waitDecision`, and `plugin.approval.resolve` cover
-  plugin-defined approval flows.
 
 #### Other major families
 
@@ -425,7 +417,7 @@ implemented in `src/gateway/server-methods/*.ts`.
   - `wake` schedules an immediate or next-heartbeat wake text injection
   - `cron.list`, `cron.status`, `cron.add`, `cron.update`, `cron.remove`,
     `cron.run`, `cron.runs`
-- skills/tools: `commands.list`, `skills.*`, `tools.catalog`, `tools.effective`
+- skills/tools: `skills.*`, `tools.catalog`, `tools.effective`
 
 ### Common event families
 
@@ -449,25 +441,8 @@ implemented in `src/gateway/server-methods/*.ts`.
 - `plugin.approval.requested` / `plugin.approval.resolved`: plugin approval
   lifecycle.
 
-### Node helper methods
-
-- Nodes may call `skills.bins` to fetch the current list of skill executables
-  for auto-allow checks.
-
 ### Operator helper methods
 
-- Operators may call `commands.list` (`operator.read`) to fetch the runtime
-  command inventory for an agent.
-  - `agentId` is optional; omit it to read the default agent workspace.
-  - `scope` controls which surface the primary `name` targets:
-    - `text` returns the primary text command token without the leading `/`
-    - `native` and the default `both` path return provider-aware native names
-      when available
-  - `textAliases` carries exact slash aliases such as `/model` and `/m`.
-  - `nativeName` carries the provider-aware native command name when one exists.
-  - `provider` is optional and only affects native naming plus native plugin
-    command availability.
-  - `includeArgs=false` omits serialized argument metadata from the response.
 - Operators may call `tools.catalog` (`operator.read`) to fetch the runtime tool catalog for an
   agent. The response includes grouped tools and provenance metadata:
   - `source`: `core` or `plugin`
@@ -485,8 +460,6 @@ implemented in `src/gateway/server-methods/*.ts`.
   - `agentId` is optional; omit it to read the default agent workspace.
   - The response includes eligibility, missing requirements, config checks, and
     sanitized install options without exposing raw secret values.
-- Operators may call `skills.search` and `skills.detail` (`operator.read`) for
-  ClawHub discovery metadata.
 - Operators may call `skills.install` (`operator.admin`) in two modes:
   - ClawHub mode: `{ source: "clawhub", slug, version?, force? }` installs a
     skill folder into the default agent workspace `skills/` directory.
@@ -655,6 +628,6 @@ Migration target:
 
 ## Scope
 
-This protocol exposes the **full gateway API** (status, channels, models, chat,
+This protocol exposes the **full gateway API** (status, channels, chat,
 agent, sessions, nodes, approvals, etc.). The exact surface is defined by the
 TypeBox schemas in `src/gateway/protocol/schema.ts`.

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -413,24 +413,25 @@ Behavior:
 
 ## Command-path resolution
 
-Command paths can opt into supported SecretRef resolution via gateway snapshot RPC.
+Command paths resolve supported SecretRefs locally and in-process. Each CLI
+invocation reads the configured `env` / `file` / `exec` providers directly; it
+does not query a running gateway, and there is no `secrets.resolve` gateway RPC.
+This keeps command-path resolution independent of gateway availability.
 
 There are two broad behaviors:
 
-- Strict command paths (for example `remoteclaw memory` remote-memory paths and `remoteclaw qr --remote` when it needs remote shared-secret refs) read from the active snapshot and fail fast when a required SecretRef is unavailable.
-- Read-only command paths (for example `remoteclaw status`, `remoteclaw status --all`, `remoteclaw channels status`, `remoteclaw channels resolve`, `remoteclaw security audit`, and read-only doctor/config repair flows) also prefer the active snapshot, but degrade instead of aborting when a targeted SecretRef is unavailable in that command path.
+- Strict command paths (for example `remoteclaw memory` remote-memory paths and `remoteclaw qr --remote` when it needs remote shared-secret refs) fail fast when a required SecretRef cannot be resolved locally.
+- Read-only command paths (for example `remoteclaw status`, `remoteclaw status --all`, `remoteclaw channels status`, `remoteclaw channels resolve`, `remoteclaw security audit`, and read-only doctor/config repair flows) degrade instead of aborting when a targeted SecretRef cannot be resolved in that command path.
 
 Read-only behavior:
 
-- When the gateway is running, these commands read from the active snapshot first.
-- If gateway resolution is incomplete or the gateway is unavailable, they attempt targeted local fallback for the specific command surface.
+- These commands resolve the targeted SecretRef locally for the specific command surface.
 - If a targeted SecretRef is still unavailable, the command continues with degraded read-only output and explicit diagnostics such as “configured but unavailable in this command path”.
 - This degraded behavior is command-local only. It does not weaken runtime startup, reload, or send/auth paths.
 
 Other notes:
 
-- Snapshot refresh after backend secret rotation is handled by `remoteclaw secrets reload`.
-- Gateway RPC method used by these command paths: `secrets.resolve`.
+- After a backend secret rotation, the long-running gateway refreshes its own in-memory snapshot via `remoteclaw secrets reload`; command paths re-resolve from the configured providers on each invocation, so they pick up rotated values directly.
 
 ## Audit and configure workflow
 


### PR DESCRIPTION
Part of #2724 (gateway-suite remediation — docs accuracy). One slice of a multi-part tracker — this PR intentionally leaves #2724 open for the remaining parts.

Reconciles the gateway docs to the fork's **actual** RPC surface and **local** SecretRef resolution. Every changed line was verified against the live fork code (`BASE_METHODS`, `GATEWAY_EVENTS`, the real handlers, and the resolver modules) — not a mechanical find-replace.

## (a) Local SecretRef resolution — `docs/cli/qr.md`, `docs/gateway/secrets.md`

The fork resolves SecretRefs **locally and in-process** via `src/secrets/resolve.ts` (env/file/exec) and `src/gateway/resolve-configured-secret-input-string.ts`. The gateway `secrets.resolve` snapshot RPC was dropped in #2728 (it had no handler) — there is no RPC path anymore.

- **`secrets.md` § Command-path resolution**: rewritten to describe local, in-process resolution; removed the "gateway snapshot RPC", the "read from the active snapshot / gateway-unavailable fallback" framing, and the `Gateway RPC method used by these command paths: secrets.resolve` line. The strict (fail-fast) vs read-only (degrade) distinction is kept — both verified: `qr --remote` fails fast (`resolveRequiredConfiguredSecretRefInputString` throws); the `configured but unavailable in this command path` degrade diagnostics are real (`commands/channels/status.ts`, `commands/status-all/channels.ts`, `commands/doctor-config-flow.ts`, `gateway/credentials.ts`).
- **`qr.md`**: line 44 rewritten to local resolution (`qr` resolves all refs in-process via `qr-cli.ts` + `pairing/setup-code.ts`, running `exec` providers locally; no gateway client); removed the obsolete `secrets.resolve` gateway-version-skew note.

> #2728's own commit body explicitly deferred this as follow-up gap **(A)**: "secrets.md/qr.md command-path SecretRef-resolution docs still name secrets.resolve as the gateway snapshot RPC, but the fork resolves locally."

## (b) RPC method families — `docs/gateway/protocol.md`

Removed the methods #2720 dropped from `BASE_METHODS` (confirmed absent from `BASE_METHODS` **and** with no handler in `coreGatewayHandlers`):

| Removed (method) | Evidence |
|---|---|
| `models.list` | not in BASE_METHODS; no handler (only in `server-startup-unavailable-methods.ts`) |
| `skills.search`, `skills.detail`, `skills.bins` | not in BASE_METHODS; no handler |
| `plugin.approval.request` / `.list` / `.waitDecision` / `.resolve` (methods) | not in BASE_METHODS; no handler |
| `commands.list` | not in BASE_METHODS; no handler |

**Methods-vs-events distinction preserved**: the `plugin.approval.requested` / `plugin.approval.resolved` **events** are in `GATEWAY_EVENTS` (`server-methods-list.ts:139-140`) and remain documented under "Common event families".

Verified ambiguous families (the handlers do **not** confirm them → corrected):
- `sessions.usage` / `sessions.usage.timeseries` / `sessions.usage.logs`: not in BASE_METHODS, **no handler anywhere repo-wide** — only an orphan classification in `method-scopes.ts:76-78`. Removed.
- `exec.approval.get` / `exec.approval.list`: not in BASE_METHODS, not in method-scopes, no handler. Removed from the exec-approval line (kept `exec.approval.request` / `resolve` + `waitDecision`, all in BASE_METHODS).

Also dropped the now-empty "Node helper methods" subsection (it only documented `skills.bins`) and the stray `models` token in the "## Scope" capability list.

> Note: this fork's `BASE_METHODS` deliberately still advertises some declared-but-unhandled methods (e.g. `sessions.create`/`send`/`abort`, `exec.approval.request`) while the execution engine is mid-gutting. Those are the **advertised** surface and are intentionally left documented — out of scope here.

## Verification
- `astro build` of the docs site passes (319 pages, exit 0).
- rebrand-gate passes (no `openclaw` leakage introduced).
- oxfmt `0.38.0 --check`: all three files correctly formatted.

## Out-of-scope findings (flagged, NOT changed — surgical 3-file scope)
These reference removed methods but live outside the three named files; flagging for a future #2724 pass (or confirm if they should be folded in):
- `docs/web/control-ui.md:113` — lists `models.list` as a manual debug RPC call.
- `docs/tools/exec-approvals.md:261` — describes `skills.bins` over the Gateway RPC.
- `docs/gateway/bridge-protocol.md:52` — lists `skills.bins` in the scoped gateway RPC set.
- `docs/gateway/secrets.md` § Activation triggers (~lines 387, 396) — reference bare `secrets.reload` (also not in BASE_METHODS); likely the CLI `remoteclaw secrets reload` command rather than the gutted RPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
