### PR TITLE
test(gateway): guard auth-control wiring + audit canvasHost internal authz (#2724)

### DIFF
--- a/src/canvas-host/server.test.ts
+++ b/src/canvas-host/server.test.ts
@@ -391,4 +391,61 @@ describe("canvas host", () => {
       }
     }
   });
+
+  // Audited under #2724: handleHttpRequest's internal authorization model is the
+  // HTTP-pass / WS-reject asymmetry. It is UNAUTHENTICATED by design — no bearer,
+  // no capability challenge — and relies entirely on METHOD confinement (GET/HEAD)
+  // and PATH confinement (no `..`, no symlink escape) for safety. This pins that
+  // intended posture against a future change that silently broadens it.
+  it("internal authorization: serves unauthenticated but method- and path-confined (HTTP-pass / WS-reject)", async () => {
+    const dir = await createCaseDir();
+    await fs.writeFile(
+      path.join(dir, "index.html"),
+      "<html><body>canvas-shell</body></html>",
+      "utf8",
+    );
+    // A symlink inside the root that points OUT of the root must not be followed.
+    const escapeLinkName = `escape-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`;
+    await fs.symlink(path.join(process.cwd(), "package.json"), path.join(dir, escapeLinkName));
+
+    let server: Awaited<ReturnType<typeof startFixtureCanvasHost>>;
+    try {
+      server = await startFixtureCanvasHost(dir);
+    } catch (error) {
+      if (isLoopbackBindDenied(error)) {
+        return;
+      }
+      throw error;
+    }
+
+    try {
+      const base = `http://127.0.0.1:${server.port}${CANVAS_HOST_PATH}`;
+
+      // HTTP PASSES with no auth header at all — the unauthenticated half.
+      const served = await realFetch(`${base}/`);
+      expect(served.status).toBe(200);
+      expect(await served.text()).toContain("canvas-shell");
+
+      // Method-confined: a write method is refused (405), so the unauthenticated
+      // surface is read-only.
+      const post = await realFetch(`${base}/`, { method: "POST" });
+      expect(post.status).toBe(405);
+
+      // Path-confined: `..` traversal cannot escape the canvas root.
+      const traversal = await realFetch(`${base}/%2e%2e%2f%2e%2e%2fpackage.json`);
+      expect(traversal.status).toBe(404);
+
+      // Path-confined: a symlink escaping the root is not followed.
+      const symlink = await realFetch(`${base}/${escapeLinkName}`);
+      expect(symlink.status).toBe(404);
+
+      // WS-reject half: the live-reload WS path is refused over plain HTTP
+      // (426 upgrade-required while live reload is on) — it is never served as a
+      // file, and the WS UPGRADE itself is rejected at the gateway perimeter.
+      const wsOverHttp = await realFetch(`http://127.0.0.1:${server.port}${CANVAS_WS_PATH}`);
+      expect(wsOverHttp.status).toBe(426);
+    } finally {
+      await server.close();
+    }
+  });
 });

--- a/src/canvas-host/server.ts
+++ b/src/canvas-host/server.ts
@@ -340,6 +340,27 @@ export async function createCanvasHostHandler(
     return true;
   };
 
+  // Internal authorization model — audited under #2724 (HTTP-pass / WS-reject
+  // asymmetry). This handler performs NO caller authentication by design: the
+  // gateway perimeter's canvas-auth stage is gutted to always-skip
+  // (`gateway/server-http.ts`), and the standalone host binds loopback-only.
+  // Its authorization is therefore entirely (a) METHOD confinement — GET/HEAD
+  // only (405 otherwise) — and (b) PATH confinement — `resolveFileWithinRoot`
+  // rejects `..` traversal, refuses symlinks, and opens with O_NOFOLLOW inside
+  // the canvas root, so only non-sensitive files genuinely under the root are
+  // served. The asymmetry is intentional and fail-secure on the higher-authority
+  // channel: HTTP serves static files, while the live-reload WS path is refused
+  // over HTTP here (426/404) and the WS UPGRADE is rejected outright at the
+  // gateway.
+  //
+  // This unauthenticated-but-confined posture is SAFE only while the canvas root
+  // holds non-sensitive static content. The writer that would place sensitive
+  // agent-rendered documents here (`gateway/canvas-documents.ts`
+  // `createCanvasDocument`) is fork-orphaned (no live callers). If it is ever
+  // re-wired, canvas HTTP must be re-authorized first (the capability-token
+  // scheme in `gateway/canvas-capability.ts` exists for exactly this). That
+  // precondition is mechanized by the re-wire tripwire in
+  // `gateway/server.canvas-auth.test.ts`.
   const handleHttpRequest = async (req: IncomingMessage, res: ServerResponse) => {
     const urlRaw = req.url;
     if (!urlRaw) {

--- a/src/gateway/server.canvas-auth.test.ts
+++ b/src/gateway/server.canvas-auth.test.ts
@@ -1,3 +1,7 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
 import { describe, expect, test } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
 import { CANVAS_HOST_PATH, CANVAS_WS_PATH } from "../canvas-host/a2ui.js";
@@ -178,9 +182,14 @@ async function withCanvasGatewayHarness(params: {
 // This tripwire replaces them: it documents the CURRENT gutted posture and
 // fails loudly if a future upstream sync silently re-introduces (or further
 // changes) canvas gateway auth, so the gut stays a conscious decision.
-// Follow-up (filed on remoteclaw/remoteclaw): audit `canvasHost.handleHttpRequest`
-// internal authz now that the gateway perimeter no longer challenges it, and
-// add a DIFF-SYNC re-introduction guard (ADR-0010 pattern).
+// Follow-up RESOLVED (#2724 sub-part b): `canvasHost.handleHttpRequest` internal
+// authz has been audited (verdict: INTENTIONAL_SAFE). The handler is
+// unauthenticated by design but METHOD- and PATH-confined; the posture and its
+// emergent-from-dead-code precondition are documented at the handler in
+// `../canvas-host/server.ts` and pinned by the internal-authz asymmetry test in
+// `../canvas-host/server.test.ts`. The DIFF-SYNC re-introduction guard for the
+// precondition is the "canvas document pipeline re-wire tripwire" at the bottom
+// of this file.
 describe("gateway canvas host auth (gutted-posture tripwire)", () => {
   const tokenResolvedAuth: ResolvedGatewayAuth = {
     mode: "token",
@@ -240,4 +249,92 @@ describe("gateway canvas host auth (gutted-posture tripwire)", () => {
       },
     });
   }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// Canvas document pipeline re-wire tripwire (#2724 sub-part b).
+//
+// Canvas HTTP is served UNAUTHENTICATED (the gateway canvas-auth perimeter is
+// gutted to always-skip — see `server-http.ts`). The audit concluded that is
+// SAFE only because the served canvas root holds a static shell, NOT sensitive
+// agent-rendered content. The single writer that would place such content in the
+// root is `createCanvasDocument` (`canvas-documents.ts`), and it is fork-orphaned
+// — no production caller. THAT dead-code fact is the load-bearing precondition of
+// the "unauthenticated is safe" verdict.
+//
+// This tripwire mechanizes the precondition: it fails the instant any production
+// (non-test) module under `src/` imports or calls `createCanvasDocument`. If it
+// fails, the document pipeline was re-wired while canvas HTTP is still
+// unauthenticated → an unauthenticated-disclosure regression. The fix is to
+// RE-AUTHORIZE canvas HTTP (the capability-token scheme in `canvas-capability.ts`
+// exists for exactly this), NOT to delete this test. Re-enabling document
+// publishing is an architecture decision needing its own ADR + security review.
+//
+// Mechanism is AST-confirmed (not raw grep): a cheap substring scan narrows the
+// candidate files, then the TypeScript compiler API confirms a real import/call
+// — so a mention of the symbol in a comment or string (e.g. the audit note in
+// `canvas-host/server.ts`) is not a false positive.
+
+const CANVAS_AUDIT_SRC_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const CANVAS_DOCUMENTS_MODULE = path.join(CANVAS_AUDIT_SRC_DIR, "gateway", "canvas-documents.ts");
+
+function collectProductionTsFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "__tests__") {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectProductionTsFiles(full, acc);
+    } else if (
+      entry.isFile() &&
+      entry.name.endsWith(".ts") &&
+      !entry.name.endsWith(".d.ts") &&
+      !entry.name.endsWith(".test.ts") &&
+      !entry.name.endsWith(".spec.ts") &&
+      full !== CANVAS_DOCUMENTS_MODULE
+    ) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+function importsOrCallsCreateCanvasDocument(file: string): boolean {
+  const text = readFileSync(file, "utf8");
+  if (!text.includes("createCanvasDocument")) {
+    return false; // cheap narrow — skip the AST parse for the vast majority
+  }
+  const sf = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, /* setParentNodes */ true);
+  let referenced = false;
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isImportDeclaration(node) &&
+      node.importClause?.namedBindings !== undefined &&
+      ts.isNamedImports(node.importClause.namedBindings) &&
+      node.importClause.namedBindings.elements.some((el) => el.name.text === "createCanvasDocument")
+    ) {
+      referenced = true;
+    }
+    if (
+      ts.isCallExpression(node) &&
+      ((ts.isIdentifier(node.expression) && node.expression.text === "createCanvasDocument") ||
+        (ts.isPropertyAccessExpression(node.expression) &&
+          node.expression.name.text === "createCanvasDocument"))
+    ) {
+      referenced = true;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return referenced;
+}
+
+describe("canvas document pipeline re-wire tripwire (#2724)", () => {
+  test("keeps createCanvasDocument fork-orphaned — no production caller of the canvas-document writer", () => {
+    const offenders = collectProductionTsFiles(CANVAS_AUDIT_SRC_DIR)
+      .filter(importsOrCallsCreateCanvasDocument)
+      .map((f) => path.relative(CANVAS_AUDIT_SRC_DIR, f));
+    expect(offenders).toEqual([]);
+  });
 });

--- a/src/gateway/server.plugin-gateway-auth-tripwire.test.ts
+++ b/src/gateway/server.plugin-gateway-auth-tripwire.test.ts
@@ -1,4 +1,8 @@
+import { readFileSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
 import { describe, expect, it, vi } from "vitest";
 import { AUTH_NONE, sendRequest, withGatewayServer } from "./server-http.test-harness.js";
 import { createTestRegistry } from "./server/__tests__/test-utils.js";
@@ -138,5 +142,210 @@ describe("plugin auth:'gateway' route gutted-posture tripwire (#2724)", () => {
         expect(gatewayRouteHandler).toHaveBeenCalledTimes(1);
       },
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sub-part (b) of the #2724 gutted-posture guard: positive-presence-AND-WIRING.
+//
+// The behavioral tripwire above (sub-part a, PR #2726) drives the real pipeline
+// and asserts the EMERGENT block still happens. This complementary guard is
+// STRUCTURAL: it asserts the gateway-auth CONTROLS the fork relies on stay
+// *wired at their call sites* — not merely present as defined symbols. It
+// catches the orthogonal de-wiring failure mode an upstream sync can introduce:
+// the control's definition survives (so "symbol exists" / a raw grep still
+// passes green) while its sole invocation is deleted, silently disabling it.
+//
+// Mechanism is AST, NOT text-grep: the repo runs oxfmt (identifier-level
+// reformatting) and a substring match cannot distinguish a real call from the
+// symbol appearing in a comment or string. We parse each module with the
+// TypeScript compiler API and assert an actual CallExpression resolves to the
+// control. Each assertion is kept non-degenerate (degenerate-subject gate): a
+// cross-module call site must IMPORT the symbol AND CALL it, and the control
+// COUNT is pinned so a silently dropped row fails the suite instead of passing
+// vacuously.
+//
+// IF A ROW FAILS AFTER AN UPSTREAM SYNC: a security control was de-wired —
+// restore the call, do NOT delete the row. If a control was intentionally
+// replaced, that is an architecture decision needing its own ADR + security
+// review (hq-internal ADR 0010 / ADR 0011 DIFF-SYNC re-introduction family).
+
+const GATEWAY_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+function parseGatewayModule(relPath: string): ts.SourceFile {
+  const absPath = path.join(GATEWAY_DIR, relPath);
+  return ts.createSourceFile(
+    absPath,
+    readFileSync(absPath, "utf8"),
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+  );
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  const modifiers = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined;
+  return modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) ?? false;
+}
+
+/** True when `name` is declared at module top level (function or `const`). */
+function declaresSymbol(sf: ts.SourceFile, name: string, opts: { exported: boolean }): boolean {
+  for (const stmt of sf.statements) {
+    if (ts.isFunctionDeclaration(stmt) && stmt.name?.text === name) {
+      return opts.exported ? hasExportModifier(stmt) : true;
+    }
+    if (
+      ts.isVariableStatement(stmt) &&
+      stmt.declarationList.declarations.some((d) => ts.isIdentifier(d.name) && d.name.text === name)
+    ) {
+      return opts.exported ? hasExportModifier(stmt) : true;
+    }
+  }
+  return false;
+}
+
+/** True when the module has a named-import binding for `name`. */
+function importsSymbol(sf: ts.SourceFile, name: string): boolean {
+  return sf.statements.some(
+    (stmt) =>
+      ts.isImportDeclaration(stmt) &&
+      stmt.importClause?.namedBindings !== undefined &&
+      ts.isNamedImports(stmt.importClause.namedBindings) &&
+      stmt.importClause.namedBindings.elements.some((el) => el.name.text === name),
+  );
+}
+
+/** True when the module contains a CallExpression invoking `name(...)`. */
+function callsSymbol(sf: ts.SourceFile, name: string): boolean {
+  let found = false;
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      if (ts.isIdentifier(callee) && callee.text === name) {
+        found = true;
+      } else if (ts.isPropertyAccessExpression(callee) && callee.name.text === name) {
+        found = true;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return found;
+}
+
+/**
+ * True when an `authorizeHttpGatewayConnect({ ... })` call in the module forwards
+ * a `rateLimiter` property — the wiring that actually feeds the per-origin
+ * limiter into the bearer-auth path. A sync that kept the call but dropped this
+ * property would disable per-origin brute-force protection while every
+ * call-presence assertion below still passed green.
+ */
+function authConnectForwardsRateLimiter(sf: ts.SourceFile): boolean {
+  let forwarded = false;
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "authorizeHttpGatewayConnect"
+    ) {
+      const arg = node.arguments[0];
+      if (arg && ts.isObjectLiteralExpression(arg)) {
+        forwarded ||= arg.properties.some(
+          (p) =>
+            (ts.isPropertyAssignment(p) || ts.isShorthandPropertyAssignment(p)) &&
+            ts.isIdentifier(p.name) &&
+            p.name.text === "rateLimiter",
+        );
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return forwarded;
+}
+
+type ControlWiring = {
+  /** Human-readable control name (shows up in the test title). */
+  control: string;
+  symbol: string;
+  defModule: string;
+  defExported: boolean;
+  callSiteModule: string;
+  /** Cross-module call sites must import the symbol; same-module calls need not. */
+  callSiteImportsSymbol: boolean;
+};
+
+// The scope-confinement + per-origin rate-limit controls this fork relies on,
+// with the module that DEFINES each and the module that must CALL it. These are
+// the controls whose de-wiring (call-site deletion) would be a privilege /
+// authentication / rate-limit regression — not ceremony helpers.
+const WIRED_GATEWAY_AUTH_CONTROLS: ControlWiring[] = [
+  {
+    control: "scope-confinement: per-request operator scopes (CVE-2026-32919/28473 boundary)",
+    symbol: "resolveGatewayRequestedOperatorScopes",
+    defModule: "http-auth-helpers.ts",
+    defExported: true,
+    callSiteModule: "http-endpoint-helpers.ts",
+    callSiteImportsSymbol: true,
+  },
+  {
+    control: "scope-confinement: per-method scope authorization (deny decision)",
+    symbol: "authorizeOperatorScopesForMethod",
+    defModule: "method-scopes.ts",
+    defExported: true,
+    callSiteModule: "http-endpoint-helpers.ts",
+    callSiteImportsSymbol: true,
+  },
+  {
+    control: "per-origin rate-limit + bearer-auth chokepoint",
+    symbol: "authorizeGatewayBearerRequestOrReply",
+    defModule: "http-auth-helpers.ts",
+    defExported: true,
+    callSiteModule: "http-endpoint-helpers.ts",
+    callSiteImportsSymbol: true,
+  },
+  {
+    control: "scope-confinement: plugin-route runtime client (confined to propagated scopes)",
+    symbol: "createPluginRouteRuntimeClient",
+    defModule: "server/plugins-http.ts",
+    defExported: false, // module-local helper
+    callSiteModule: "server/plugins-http.ts", // invoked in the same module
+    callSiteImportsSymbol: false,
+  },
+];
+
+describe("gateway-auth control wiring guard (#2724, positive-presence-AND-wiring)", () => {
+  it.each(WIRED_GATEWAY_AUTH_CONTROLS)(
+    "keeps wired — $control: $symbol is defined AND invoked at its call site",
+    ({ symbol, defModule, defExported, callSiteModule, callSiteImportsSymbol }) => {
+      const defSource = parseGatewayModule(defModule);
+      // Presence half: the control is still defined where we expect it.
+      expect(declaresSymbol(defSource, symbol, { exported: defExported })).toBe(true);
+
+      const callSiteSource =
+        callSiteModule === defModule ? defSource : parseGatewayModule(callSiteModule);
+      // Non-degeneracy: a cross-module call site must import the symbol, so a
+      // "no call found" result can never be a false alarm from parsing the
+      // wrong file.
+      if (callSiteImportsSymbol) {
+        expect(importsSymbol(callSiteSource, symbol)).toBe(true);
+      }
+      // Wiring half: the control is actually CALLED, not merely defined.
+      expect(callsSymbol(callSiteSource, symbol)).toBe(true);
+    },
+  );
+
+  it("pins the control COUNT so a silently dropped row fails loudly (degenerate-subject gate)", () => {
+    // If a future edit deletes a row to "make the suite green" after a de-wire,
+    // this fails instead. Bump it ONLY when intentionally adding/removing a
+    // guarded control — never to silence a real de-wiring.
+    expect(WIRED_GATEWAY_AUTH_CONTROLS).toHaveLength(4);
+  });
+
+  it("keeps the per-origin rate limiter threaded through the bearer-auth chokepoint", () => {
+    // authorizeGatewayBearerRequestOrReply is the single HTTP auth chokepoint;
+    // it must forward `rateLimiter` into authorizeHttpGatewayConnect. The
+    // call-presence row above proves the chokepoint stays wired; this proves the
+    // limiter is still fed INTO it.
+    expect(authConnectForwardsRateLimiter(parseGatewayModule("http-auth-helpers.ts"))).toBe(true);
   });
 });


### PR DESCRIPTION
## What

Closes out the **Plugin gutted-posture regression guard** item of the #2724
tracker — specifically the still-open **sub-part (b)** plus the deferred
**`canvasHost.handleHttpRequest` internal-authorization audit**. Sub-part (a)
landed in #2726.

No production behavior change — the only non-test edit is a documentation
comment.

### (1) Positive-presence-AND-WIRING guard (sub-part b)

Extends `src/gateway/server.plugin-gateway-auth-tripwire.test.ts` with a
**structural** guard complementary to (a)'s **behavioral** tripwire. It asserts
the scope-confinement and per-origin rate-limit controls the fork relies on stay
**wired at their call sites** — not merely present as defined symbols — catching
the orthogonal de-wiring failure mode an upstream sync can introduce: a control's
definition survives (so "symbol exists" / a raw grep still passes green) while
its sole invocation is deleted.

Controls pinned (de-wiring any is a privilege / authentication / rate-limit
regression):

| Control | Symbol | Defined | Called at |
|---|---|---|---|
| scope-confinement (per-request operator scopes, CVE-2026-32919/28473 boundary) | `resolveGatewayRequestedOperatorScopes` | `http-auth-helpers.ts` | `http-endpoint-helpers.ts` |
| scope-confinement (per-method scope authorization / deny decision) | `authorizeOperatorScopesForMethod` | `method-scopes.ts` | `http-endpoint-helpers.ts` |
| per-origin rate-limit + bearer-auth chokepoint | `authorizeGatewayBearerRequestOrReply` | `http-auth-helpers.ts` | `http-endpoint-helpers.ts` |
| scope-confinement (plugin-route runtime client) | `createPluginRouteRuntimeClient` | `server/plugins-http.ts` | (same module) |

Plus an assertion that `authorizeGatewayBearerRequestOrReply` keeps forwarding
`rateLimiter` into `authorizeHttpGatewayConnect` (the per-origin limiter could be
dropped while the chokepoint call survived), and a pinned control **count** so a
silently-dropped row fails loudly (degenerate-subject gate).

**Mechanism is the TypeScript compiler API (AST), not raw grep** — oxfmt
reformatting plus comment/string false positives make substring matching
fragile. Each row requires the call-site module to both *import* and *call* the
symbol (non-degeneracy). **Proven non-vacuous**: de-wiring one control (replacing
its call with a literal) made exactly that row fail (`1 failed | 5 passed`), then
reverted.

### (2) `canvasHost.handleHttpRequest` internal-authz audit

The gateway *perimeter* asymmetry (canvas HTTP `canvas-auth` stage gutted to
always-skip vs canvas WS upgrade gutted to always-reject) was already settled and
tested in `server.canvas-auth.test.ts`, which explicitly **deferred** auditing the
handler's *internal* authorization. This does that audit.

**Verdict: INTENTIONAL_SAFE** (no present authorization gap). `handleHttpRequest`
is unauthenticated by design but **method-confined** (GET/HEAD only; 405
otherwise) and **path-confined** (`resolveFileWithinRoot` rejects `..` traversal,
refuses symlinks, opens `O_NOFOLLOW` inside the canvas root). The HTTP-pass /
WS-reject asymmetry is intentional and fail-secure on the higher-authority WS
channel.

Resolution (per the "document if intentional" path):
- **In-code comment** at the handler documenting the audited posture +
  precondition.
- **Internal-authz asymmetry test** (`canvas-host/server.test.ts`): unauthenticated
  GET serves a root file, `..` traversal → 404, symlink escape → 404, non-GET →
  405, WS-path-over-HTTP → 426.
- **Re-wire tripwire** (`server.canvas-auth.test.ts`): AST-confirmed assertion that
  `createCanvasDocument` stays fork-orphaned (no production caller). Proven
  non-vacuous with a probe caller.

## ⚠️ Security note for reviewers — latent (NOT present) risk

The audit verdict is *safe in the current fork state*, but the safety is
**emergent from dead code**, not from an authorization decision. Surfacing this
for human awareness (no fix applied — a security behavior change is out of scope
for this guard PR):

- The unauthenticated canvas HTTP surface is safe **only because** the canvas root
  holds a static shell. The writer that would place sensitive agent-rendered
  documents there, `createCanvasDocument` (`gateway/canvas-documents.ts`), is
  fork-orphaned today (verified: zero non-test callers across
  `src/`/`extensions/`/`packages/`/`ui/`/`apps/`).
- The gateway can bind **beyond loopback** (a supported, warned configuration —
  `server-runtime-state.ts`), and the canvas host is on by default.
- The capability-token scheme (`gateway/canvas-capability.ts`) exists but is **not
  validated** for canvas HTTP in the gutted posture.

→ **If `createCanvasDocument` is ever re-wired to an agent surface, canvas HTTP
must be re-authorized first.** The re-wire tripwire fails the build the instant a
production caller is added, forcing that decision rather than letting an
unauthenticated-disclosure regression land silently. No change to security
behavior is proposed here.

## Test plan

- `vitest run --config vitest.gateway.config.ts src/gateway/server.plugin-gateway-auth-tripwire.test.ts` → 8 passed
- `vitest run --config vitest.gateway.config.ts src/gateway/server.canvas-auth.test.ts` → 3 passed
- `vitest run --config vitest.unit.config.ts src/canvas-host/server.test.ts` → 7 passed
- `oxfmt --check`, `tsgo --noEmit` (0 `src/` errors), `oxlint --type-aware` → clean
- Both new guards verified **non-vacuous** via falsification probes.

Part of #2724.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
