### PR TITLE
fix(gateway): remap legacy agent:main:main alias onto live default agent (#2733)

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import {
   listAgentIds,
   resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
   resolveSessionKeyAgentId,
   resolveSoleAgentId,
 } from "../agents/agent-scope.js";
@@ -241,6 +242,105 @@ export function resolveDeletedAgentIdFromSessionKey(
     return null;
   }
   return agentId;
+}
+
+/**
+ * The historical OpenClaw default-agent id. Legacy single-store deployments
+ * serialized the default agent's main session under `agent:main:main`. After a
+ * rebrand/rename the configured default agent is no longer `main`, so that
+ * on-disk entry now encodes a "deleted" agent. See sessions-resolve.ts ADR-NOTE.
+ */
+const LEGACY_DEFAULT_AGENT_ID = "main";
+
+/**
+ * True when sessions are backed by a single configured non-template store
+ * (`cfg.session.store` is set and is NOT an `{agentId}` template). This is the
+ * provenance signal that gates the legacy main-alias remap on the explicit-key
+ * lookup path, and it mirrors the single-store branch of
+ * `loadCombinedSessionStoreForGateway` (which surfaces the same signal as
+ * `fromSingleStore` for the sessionId/label paths). One predicate, no drift.
+ */
+export function isSingleConfiguredSessionStore(cfg: RemoteClawConfig): boolean {
+  const storeConfig = cfg.session?.store;
+  return Boolean(storeConfig) && !isStorePathTemplate(storeConfig);
+}
+
+/**
+ * Narrow remap of the legacy default-agent main-session alias `agent:main:main`
+ * onto the live default agent's main session, restoring continuity for an old
+ * default-agent "main" thread after the default agent was renamed (or the
+ * no-config default became `default`). Returns the remapped session key when
+ * ALL FOUR conjuncts hold, or null to leave the caller's reject/pass behavior
+ * unchanged.
+ *
+ * Conjuncts (full rationale + fork provenance: sessions-resolve.ts ADR-NOTE):
+ *   1. The encoded agent-id segment is the literal historical default-agent id
+ *      `main`, AND the key is the main-SESSION alias (`agent:main:main`). A
+ *      concrete non-alias session under the deleted `main` agent
+ *      (e.g. `agent:main:guildchat:direct:u1`) is NOT remapped — it stays
+ *      rejected.
+ *   2. `main` is NOT a currently-configured agent. If a live `main` agent
+ *      exists, `resolveDeletedAgentIdFromSessionKey` already returns null and
+ *      the key resolves normally, so no remap is needed.
+ *   3. A live DEFAULT agent exists: `resolveDefaultAgentId` resolves to a
+ *      CONFIGURED agent, not the no-config `DEFAULT_AGENT_ID` ("default")
+ *      fallback.
+ *   4. LEGACY SINGLE-STORE PROVENANCE: the matched entry came from the single
+ *      configured (non-template) store (`fromSingleStore`), NOT a discovered
+ *      per-agent store. LOAD-BEARING — a discovered per-agent deleted-agent
+ *      store MUST stay rejected to preserve the #65524 deleted-agent
+ *      send/steer guard; ignoring provenance would re-open that hole.
+ */
+export function resolveLegacyDefaultMainRemap(
+  cfg: RemoteClawConfig,
+  key: string,
+  fromSingleStore: boolean,
+): string | null {
+  // Conjunct 4 — provenance. Only the single configured store may remap;
+  // discovered per-agent stores never do.
+  if (!fromSingleStore) {
+    return null;
+  }
+  const parsed = parseAgentSessionKey(key);
+  if (!parsed) {
+    return null;
+  }
+  // Conjunct 1a — the encoded agent-id is the historical default-agent id.
+  if (normalizeAgentId(parsed.agentId) !== LEGACY_DEFAULT_AGENT_ID) {
+    return null;
+  }
+  // Conjunct 1b — restrict to the legacy main-SESSION alias (`agent:main:main`);
+  // concrete sessions under the deleted `main` agent stay rejected.
+  const legacyMainAliasKey = resolveAgentMainSessionKey({
+    cfg,
+    agentId: LEGACY_DEFAULT_AGENT_ID,
+  });
+  const canonicalUnderLegacyMain = canonicalizeMainSessionAlias({
+    cfg,
+    agentId: LEGACY_DEFAULT_AGENT_ID,
+    sessionKey: key,
+  });
+  if (canonicalUnderLegacyMain !== legacyMainAliasKey) {
+    return null;
+  }
+  // Conjunct 2 — `main` is not a live, configured agent.
+  if (listAgentIds(cfg).includes(LEGACY_DEFAULT_AGENT_ID)) {
+    return null;
+  }
+  // Conjunct 3 — a configured live default agent exists (not the no-config
+  // "default" fallback).
+  const liveDefaultAgentId = resolveDefaultAgentId(cfg);
+  if (!listAgentIds(cfg).includes(liveDefaultAgentId)) {
+    return null;
+  }
+  // Remap agent:main:<rest> -> agent:<live-default>:<rest>, then re-canonicalize
+  // the remainder so the returned key matches how the live default agent's main
+  // session is stored.
+  return canonicalizeMainSessionAlias({
+    cfg,
+    agentId: liveDefaultAgentId,
+    sessionKey: `agent:${liveDefaultAgentId}:${parsed.rest}`,
+  });
 }
 
 /**
@@ -738,9 +838,15 @@ function mergeSessionEntryIntoCombined(params: {
 export function loadCombinedSessionStoreForGateway(cfg: RemoteClawConfig): {
   storePath: string;
   store: Record<string, SessionEntry>;
+  /**
+   * True when the combined store was loaded from the single configured
+   * (non-template) store rather than discovered per-agent stores. Threaded to
+   * `resolveLegacyDefaultMainRemap` as the conjunct-4 provenance gate.
+   */
+  fromSingleStore: boolean;
 } {
   const storeConfig = cfg.session?.store;
-  if (storeConfig && !isStorePathTemplate(storeConfig)) {
+  if (isSingleConfiguredSessionStore(cfg)) {
     const storePath = resolveStorePath(storeConfig);
     const defaultAgentId = resolveSoleAgentId(cfg) ?? listAgentIds(cfg)[0];
     const store = loadSessionStore(storePath);
@@ -755,7 +861,7 @@ export function loadCombinedSessionStoreForGateway(cfg: RemoteClawConfig): {
         canonicalKey,
       });
     }
-    return { storePath, store: combined };
+    return { storePath, store: combined, fromSingleStore: true };
   }
 
   const targets = resolveAllAgentSessionStoreTargetsSync(cfg);
@@ -778,7 +884,7 @@ export function loadCombinedSessionStoreForGateway(cfg: RemoteClawConfig): {
 
   const storePath =
     typeof storeConfig === "string" && storeConfig.trim() ? storeConfig.trim() : "(multiple)";
-  return { storePath, store: combined };
+  return { storePath, store: combined, fromSingleStore: false };
 }
 
 export function getSessionDefaults(cfg: RemoteClawConfig): GatewaySessionsDefaults {

--- a/src/gateway/sessions-resolve-store.test.ts
+++ b/src/gateway/sessions-resolve-store.test.ts
@@ -9,12 +9,12 @@ import { resolveSessionKeyFromResolveParams } from "./sessions-resolve.js";
 describe("resolveSessionKeyFromResolveParams store canonicalization", () => {
   const freshUpdatedAt = () => Date.now();
 
-  // TODO(#NNNN): legacy main-alias remap — separate hardening PR. The
-  // deleted-agent reject parity (T2/T3/T4 below) landed without inventing the
-  // remap-to-live-default behavior this case requires; sessions-resolve.ts
-  // currently rejects `agent:main:main` rather than remapping it onto the live
-  // default agent. Un-skip once the remap boundary is designed + reviewed.
-  it.skip("resolves legacy main-alias matches by sessionId and label for the configured default agent", async () => {
+  // #2733: legacy main-alias remap. A legacy single-store `agent:main:main`
+  // entry (default agent renamed away from `main`) remaps onto the live default
+  // agent's main session via the narrow 4-conjunct gate in sessions-resolve.ts.
+  // The reject falsifiers below (discovered per-agent store, explicit key) prove
+  // the boundary stays narrow and the #65524 deleted-agent guard is preserved.
+  it("resolves legacy main-alias matches by sessionId and label for the configured default agent", async () => {
     await withStateDirEnv("remoteclaw-sessions-resolve-alias-", async ({ stateDir }) => {
       const storePath = path.join(stateDir, "sessions.json");
       const cfg = {

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -8,42 +8,104 @@ import {
   type SessionsResolveParams,
 } from "./protocol/index.js";
 import {
+  isSingleConfiguredSessionStore,
   listSessionsFromStore,
   loadCombinedSessionStoreForGateway,
   pruneLegacyStoreKeys,
   resolveDeletedAgentIdFromSessionKey,
   resolveGatewaySessionStoreTarget,
+  resolveLegacyDefaultMainRemap,
 } from "./session-utils.js";
 
 export type SessionsResolveResult = { ok: true; key: string } | { ok: false; error: ErrorShape };
 
 /**
- * Reject a resolved session key whose owning agent was deleted from
- * configuration, mirroring the send-path guard in
- * `server-methods/chat.ts` (#65524). Returns a rejection result when the
- * key encodes a deleted agent, or null when the key is safe to return.
+ * Three-state resolution for a session key whose encoded agent is no longer in
+ * configuration:
+ *   - `pass`   — the key's agent is still live; return the key unchanged.
+ *   - `reject` — the agent was deleted; ship the deleted-agent error (mirrors
+ *                the send-path guard in `server-methods/chat.ts`, #65524).
+ *   - `remap`  — the key is the legacy default-agent main-session alias
+ *                `agent:main:main` and the narrow 4-conjunct gate holds, so it
+ *                resolves onto the live default agent's main session instead.
  *
- * NOTE: legacy `main`-alias entries surfaced via sessionId/label that should
- * be remapped onto the live default agent are NOT yet handled here; that
- * remap is deferred to a separate hardening change so the reject parity can
- * land without inventing new authorization behavior. See the skipped
- * "resolves legacy main-alias matches" case in sessions-resolve-store.test.ts.
+ * ADR-NOTE — legacy `agent:main:main` remap boundary (#2720 / #2733)
+ * -----------------------------------------------------------------
+ * WHY: a legacy single-store deployment serialized the default agent's main
+ * session under `agent:main:main`. After the default agent was renamed (e.g. to
+ * `ops`) — or the no-config default became `default` — that on-disk entry
+ * encodes a now-deleted agent and was rejected with `Agent "main" no longer
+ * exists`, breaking continuity for the user's old default-agent main thread.
+ * This remaps it onto the live default agent's main session. The boundary is
+ * deliberately NARROW: it fires iff ALL FOUR conjuncts hold (see
+ * `resolveLegacyDefaultMainRemap` for the per-conjunct guard):
+ *   1. encoded agent-id is the literal historical default id `main`, AND the
+ *      key is the main-SESSION alias `agent:main:main` (not a concrete
+ *      `agent:main:<peer>` session, which stays rejected);
+ *   2. `main` is NOT a currently-configured agent;
+ *   3. a live DEFAULT agent exists (a CONFIGURED agent, not the no-config
+ *      `default` fallback);
+ *   4. LEGACY SINGLE-STORE PROVENANCE — the matched entry came from the single
+ *      configured (non-template) store, NOT a discovered per-agent store.
+ *      Conjunct 4 is LOAD-BEARING FOR SECURITY: it keeps a discovered per-agent
+ *      deleted-agent store REJECTED, preserving the #65524 deleted-agent
+ *      send/steer guard. A remap that ignored provenance would re-open that
+ *      hole (regressing the discovered-store and explicit-key reject tests in
+ *      sessions-resolve-store.test.ts).
+ *
+ * FORK PROVENANCE (do NOT delete on upstream diff-sync): this deleted-agent
+ * reject guard AND its main-alias remap are FORK-INTRODUCED. Upstream
+ * OpenClaw's `sessions-resolve.ts` has NEITHER the guard NOR the skipped/now-
+ * unskipped test — it returns matched keys without a deleted-agent check. A
+ * future diff-sync that "restores" upstream's no-guard shape would silently
+ * delete this hardening and re-open #65524. Treat this block as a
+ * re-introduction-guarded divergence (ADR-0011 pattern): keep it across syncs.
  */
-function rejectDeletedAgentSessionKey(
+type DeletedAgentKeyResolution =
+  | { kind: "pass" }
+  | { kind: "remap"; key: string }
+  | { kind: "reject"; result: SessionsResolveResult };
+
+function resolveDeletedAgentSessionKey(
   cfg: RemoteClawConfig,
   key: string,
-): SessionsResolveResult | null {
+  fromSingleStore: boolean,
+): DeletedAgentKeyResolution {
   const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, key);
   if (deletedAgentId === null) {
-    return null;
+    return { kind: "pass" };
+  }
+  const remappedKey = resolveLegacyDefaultMainRemap(cfg, key, fromSingleStore);
+  if (remappedKey !== null) {
+    return { kind: "remap", key: remappedKey };
   }
   return {
-    ok: false,
-    error: errorShape(
-      ErrorCodes.INVALID_REQUEST,
-      `Agent "${deletedAgentId}" no longer exists in configuration`,
-    ),
+    kind: "reject",
+    result: {
+      ok: false,
+      error: errorShape(
+        ErrorCodes.INVALID_REQUEST,
+        `Agent "${deletedAgentId}" no longer exists in configuration`,
+      ),
+    },
   };
+}
+
+/**
+ * Apply a {@link DeletedAgentKeyResolution} to a freshly matched key: reject
+ * surfaces the error, remap swaps in the live-default key, pass returns the
+ * original. Shared by all four resolution paths (key / sessionId / label).
+ */
+function applyDeletedAgentResolution(
+  cfg: RemoteClawConfig,
+  matchKey: string,
+  fromSingleStore: boolean,
+): SessionsResolveResult {
+  const resolution = resolveDeletedAgentSessionKey(cfg, matchKey, fromSingleStore);
+  if (resolution.kind === "reject") {
+    return resolution.result;
+  }
+  return { ok: true, key: resolution.kind === "remap" ? resolution.key : matchKey };
 }
 
 export async function resolveSessionKeyFromResolveParams(params: {
@@ -97,11 +159,11 @@ export async function resolveSessionKeyFromResolveParams(params: {
           };
         }
       }
-      const deletedRejection = rejectDeletedAgentSessionKey(cfg, target.canonicalKey);
-      if (deletedRejection) {
-        return deletedRejection;
-      }
-      return { ok: true, key: target.canonicalKey };
+      return applyDeletedAgentResolution(
+        cfg,
+        target.canonicalKey,
+        isSingleConfiguredSessionStore(cfg),
+      );
     }
     const legacyKey = target.storeKeys.find((candidate) => store[candidate]);
     if (!legacyKey) {
@@ -138,15 +200,15 @@ export async function resolveSessionKeyFromResolveParams(params: {
         };
       }
     }
-    const deletedRejection = rejectDeletedAgentSessionKey(cfg, target.canonicalKey);
-    if (deletedRejection) {
-      return deletedRejection;
-    }
-    return { ok: true, key: target.canonicalKey };
+    return applyDeletedAgentResolution(
+      cfg,
+      target.canonicalKey,
+      isSingleConfiguredSessionStore(cfg),
+    );
   }
 
   if (hasSessionId) {
-    const { storePath, store } = loadCombinedSessionStoreForGateway(cfg);
+    const { storePath, store, fromSingleStore } = loadCombinedSessionStoreForGateway(cfg);
     const list = listSessionsFromStore({
       cfg,
       storePath,
@@ -178,11 +240,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
       };
     }
     const matchKey = String(matches[0]?.key ?? "");
-    const deletedRejection = rejectDeletedAgentSessionKey(cfg, matchKey);
-    if (deletedRejection) {
-      return deletedRejection;
-    }
-    return { ok: true, key: matchKey };
+    return applyDeletedAgentResolution(cfg, matchKey, fromSingleStore);
   }
 
   const parsedLabel = parseSessionLabel(p.label);
@@ -193,7 +251,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
     };
   }
 
-  const { storePath, store } = loadCombinedSessionStoreForGateway(cfg);
+  const { storePath, store, fromSingleStore } = loadCombinedSessionStoreForGateway(cfg);
   const list = listSessionsFromStore({
     cfg,
     storePath,
@@ -228,9 +286,5 @@ export async function resolveSessionKeyFromResolveParams(params: {
   }
 
   const labelKey = String(list.sessions[0]?.key ?? "");
-  const deletedRejection = rejectDeletedAgentSessionKey(cfg, labelKey);
-  if (deletedRejection) {
-    return deletedRejection;
-  }
-  return { ok: true, key: labelKey };
+  return applyDeletedAgentResolution(cfg, labelKey, fromSingleStore);
 }


### PR DESCRIPTION
## Problem

A legacy default-agent **main session** serialized as `agent:main:main` in a single (non-per-agent) store. After the default agent was renamed (e.g. to `ops`) — or the no-config default became `default` — `src/gateway/sessions-resolve.ts` started **rejecting** that on-disk entry with `Agent "main" no longer exists in configuration`, breaking continuity for the user's old default-agent main thread.

## Approach — NARROW 4-conjunct remap

The legacy `agent:main:main` alias is remapped onto the live default agent's main session **iff ALL FOUR conjuncts hold**; otherwise the current reject/pass behavior is **unchanged**:

1. The encoded agent-id segment is the literal historical default id `main`, **AND** the key is the main-SESSION alias `agent:main:main` (a concrete `agent:main:<peer>` session under the deleted `main` agent stays rejected).
2. `main` is **not** a currently-configured agent.
3. A live **default** agent exists — `resolveDefaultAgentId(cfg)` resolves to a *configured* agent, not the no-config `default` fallback.
4. **Legacy single-store provenance** — the matched entry came from the single configured (non-template) store, **not** a discovered per-agent store.

**Conjunct 4 is load-bearing for security.** It keeps a *discovered per-agent* deleted-agent store **rejected**, preserving the #65524 deleted-agent send/steer guard. A remap that ignored provenance would re-open that hole.

When all four hold: `agent:main:<rest>` → `agent:<live-default>:<rest>`, then re-canonicalized via `canonicalizeMainSessionAlias`.

## Changes

- **`session-utils.ts`** — `resolveLegacyDefaultMainRemap` (the 4-conjunct gate) + `isSingleConfiguredSessionStore`; `loadCombinedSessionStoreForGateway` now returns `fromSingleStore` provenance so the sessionId/label paths can distinguish single-store from discovered-store.
- **`sessions-resolve.ts`** — the 2-state `rejectDeletedAgentSessionKey` (reject \| pass) becomes the 3-state `resolveDeletedAgentSessionKey` (**remap** \| reject \| pass), applied at all four resolution sites (key / sessionId / label). Key-path sites pass single-store provenance directly; combined-loader paths thread `fromSingleStore`.
- **In-code ADR-NOTE** — documents the boundary + rationale, and records that this reject-guard **and** its remap are **fork-introduced** (#2720 / #2733). Upstream has *neither* the guard nor the test, so a future diff-sync must **not** "restore" upstream's no-guard form and silently delete this hardening (ADR-0011 re-introduction-guard pattern).
- **`sessions-resolve-store.test.ts`** — un-skipped the legacy main-alias remap case (refs #2733).

## Test evidence

`vitest run --config vitest.gateway.config.ts --pool=forks src/gateway/sessions-resolve-store.test.ts` → **4 passed, 0 skipped**:

- ✓ resolves legacy main-alias matches by sessionId **and** label for the configured default agent (`agent:main:main` → `agent:ops:main`) — *the un-skipped case*
- ✓ still rejects non-alias `agent:main` matches when main is no longer configured — *falsifier*
- ✓ does not adopt legacy main aliases from discovered deleted-agent stores — *falsifier (conjunct 4)*
- ✓ rejects an explicit listed deleted main key instead of remapping — *falsifier*

Broader gateway lane: **143 files / 1582 passed, 6 skipped (pre-existing), 0 failed**. `pnpm check` (format + typecheck + type-aware lint + css-drift) green; rebrand-gate, zombie-import, stub-debt, throwing-stub-callers gates green.

Closes #2733

🤖 Generated with [Claude Code](https://claude.com/claude-code)