### PR TITLE
test(gateway): remote-pairing harness + un-skip trusted-proxy control-ui scope test (#2732)

### DIFF
--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -90,6 +90,17 @@ export class GatewayClientRequestError extends Error {
 
 export type GatewayClientOptions = {
   url?: string; // ws://127.0.0.1:18789
+  /**
+   * Extra HTTP headers to attach to the WS upgrade request.
+   *
+   * Test-only seam: lets a harness present forwarding headers (e.g.
+   * `x-forwarded-for`) so the server classifies the connect as remote
+   * (non-local-direct) via `isLocalDirectRequest`. Production callers never set
+   * this — real clients connect over loopback/SSH-tunnel/Tailscale without
+   * synthesizing proxy headers — so it does not alter the production auto-pair
+   * posture; it only routes test connects through the existing remote codepath.
+   */
+  headers?: Record<string, string>;
   connectChallengeTimeoutMs?: number;
   tickWatchMinIntervalMs?: number;
   requestTimeoutMs?: number;
@@ -214,6 +225,9 @@ export class GatewayClient {
     const wsOptions: ClientOptions = {
       maxPayload: 25 * 1024 * 1024,
     };
+    if (this.opts.headers && Object.keys(this.opts.headers).length > 0) {
+      wsOptions.headers = this.opts.headers;
+    }
     if (url.startsWith("wss://") && this.opts.tlsFingerprint) {
       wsOptions.rejectUnauthorized = false;
       wsOptions.checkServerIdentity = ((_host: string, cert: CertMeta) => {

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -17,11 +17,13 @@ import {
   readConnectChallengeNonce,
   restoreGatewayToken,
   rpcReq,
+  setTestUpgradeRemoteAddressOverride,
   startRateLimitedTokenServerWithPairedDeviceToken,
   startServerWithClient,
   TEST_OPERATOR_CLIENT,
   testState,
   TRUSTED_PROXY_CONTROL_UI_HEADERS,
+  TRUSTED_PROXY_CONTROL_UI_REMOTE_IP,
   withGatewayServer,
   writeTrustedProxyControlUiConfig,
 } from "./server.auth.shared.js";
@@ -262,18 +264,21 @@ export function registerControlUiAndPairingSuite(): void {
     });
   }
 
-  // SKIPPED: this asserts scope-confinement for a *successfully connected*
-  // device-less trusted-proxy operator, but the gateway test harness only ever
-  // connects from a loopback socket (`ws://127.0.0.1`), and `authorizeTrustedProxy`
-  // rejects loopback trusted-proxy sources unconditionally (matching current
-  // upstream — there is no `allowLoopback` escape hatch in either tree). So the
-  // connect never succeeds and the scope-clearing path under test is unreachable
-  // from this harness. The rejection is the *stricter* outcome (fails closed, not
-  // open), so skipping is safe. Re-enable if/when the harness can originate a
-  // non-loopback trusted-proxy connection. The scope-clearing wiring it would
-  // exercise (`shouldClearUnboundScopesForMissingDeviceIdentity`) is itself
-  // separately covered by the browser-hardening suite's trusted-proxy case.
-  test.skip("clears self-declared scopes for trusted-proxy control ui without device identity", async () => {
+  // This asserts scope-confinement for a *successfully connected* device-less
+  // trusted-proxy operator. `authorizeTrustedProxy` (src/gateway/auth.ts) rejects
+  // loopback trusted-proxy sources unconditionally (`trusted_proxy_loopback_source`)
+  // — the correct production posture (a real proxy fronts the gateway from a
+  // non-loopback address). The gateway test transport only connects over
+  // `ws://127.0.0.1`, so without a seam this successful path is unreachable.
+  //
+  // The TEST-ONLY harness seam `setTestUpgradeRemoteAddressOverride` makes the
+  // server observe a non-loopback peer (the TEST-NET-3 IP, which is listed in
+  // `trustedProxies`) for this connection — exactly the network condition that
+  // holds in production behind a real proxy — WITHOUT relaxing the loopback
+  // rejection. The production rejection branch in auth.ts is untouched; any
+  // genuine loopback trusted-proxy connection is still rejected. See
+  // server/ws-connection/test-remote-address-seam.ts § production-safe.
+  test("clears self-declared scopes for trusted-proxy control ui without device identity", async () => {
     await configureTrustedProxyControlUiAuth();
     const { publicKeyRawBase64UrlFromPem } = await import("../infra/device-identity.js");
     const { rejectDevicePairing, requestDevicePairing } =
@@ -289,27 +294,36 @@ export function registerControlUiAndPairingSuite(): void {
       clientId: CONTROL_UI_CLIENT.id,
       clientMode: CONTROL_UI_CLIENT.mode,
     });
-    await withGatewayServer(async ({ port }) => {
-      const ws = await openWs(port, TRUSTED_PROXY_CONTROL_UI_HEADERS);
-      try {
-        const res = await connectReq(ws, {
-          skipDefaultAuth: true,
-          scopes: ["operator.admin"],
-          device: null,
-          client: { ...CONTROL_UI_CLIENT },
-        });
-        expect(res.ok).toBe(true);
-        expect((res.payload as { auth?: unknown } | undefined)?.auth).toBeUndefined();
+    // Simulate a non-loopback reverse-proxy peer so authorizeTrustedProxy accepts
+    // the (configured, trusted) source instead of rejecting it as loopback. The
+    // override is process-global — always reset it in `finally` so it cannot leak
+    // into sibling tests sharing this worker.
+    setTestUpgradeRemoteAddressOverride(TRUSTED_PROXY_CONTROL_UI_REMOTE_IP);
+    try {
+      await withGatewayServer(async ({ port }) => {
+        const ws = await openWs(port, TRUSTED_PROXY_CONTROL_UI_HEADERS);
+        try {
+          const res = await connectReq(ws, {
+            skipDefaultAuth: true,
+            scopes: ["operator.admin"],
+            device: null,
+            client: { ...CONTROL_UI_CLIENT },
+          });
+          expect(res.ok).toBe(true);
+          expect((res.payload as { auth?: unknown } | undefined)?.auth).toBeUndefined();
 
-        await expectStatusMissingScopeButHealthOk(ws);
-        await expectAdminRpcDenied(ws);
-        await expectTalkSecretsDenied(ws);
-        await expectDevicePairApproveDenied(ws, pendingRequest.request.requestId);
-      } finally {
-        ws.close();
-        await rejectDevicePairing(pendingRequest.request.requestId);
-      }
-    });
+          await expectStatusMissingScopeButHealthOk(ws);
+          await expectAdminRpcDenied(ws);
+          await expectTalkSecretsDenied(ws);
+          await expectDevicePairApproveDenied(ws, pendingRequest.request.requestId);
+        } finally {
+          ws.close();
+          await rejectDevicePairing(pendingRequest.request.requestId);
+        }
+      });
+    } finally {
+      setTestUpgradeRemoteAddressOverride(undefined);
+    }
   });
 
   test("allows localhost control ui without device identity when insecure auth is enabled", async () => {

--- a/src/gateway/server.auth.shared.ts
+++ b/src/gateway/server.auth.shared.ts
@@ -119,9 +119,18 @@ const CONTROL_UI_CLIENT = {
   mode: GATEWAY_CLIENT_MODES.WEBCHAT,
 };
 
+// Single source of truth for the simulated reverse-proxy peer IP used by the
+// trusted-proxy control-UI tests. RFC 5737 TEST-NET-3 documentation range — a
+// non-loopback address that is never a real peer. The trusted-proxy harness
+// seam (setTestUpgradeRemoteAddressOverride) makes the server observe this as
+// the socket remoteAddress, and it is listed in `trustedProxies` so
+// `authorizeTrustedProxy` treats it as a legitimate proxy (and, being
+// non-loopback, does NOT hit the loopback rejection).
+const TRUSTED_PROXY_CONTROL_UI_REMOTE_IP = "203.0.113.10";
+
 const TRUSTED_PROXY_CONTROL_UI_HEADERS = {
   origin: "https://localhost",
-  "x-forwarded-for": "203.0.113.10",
+  "x-forwarded-for": TRUSTED_PROXY_CONTROL_UI_REMOTE_IP,
   "x-forwarded-proto": "https",
   "x-forwarded-user": "peter@example.com",
 } as const;
@@ -231,7 +240,12 @@ async function writeTrustedProxyControlUiConfig(params?: { allowInsecureAuth?: b
   const { writeConfigFile } = await import("../config/config.js");
   await writeConfigFile({
     gateway: {
-      trustedProxies: ["127.0.0.1"],
+      // 127.0.0.1 keeps the loopback-source rejection cases meaningful; the
+      // TEST-NET-3 IP lets the harness simulate a legitimate non-loopback proxy
+      // for the successful-path case (L276). Adding it does not change the
+      // loopback-rejection cases — a loopback socket is rejected regardless of
+      // trustedProxies membership.
+      trustedProxies: ["127.0.0.1", TRUSTED_PROXY_CONTROL_UI_REMOTE_IP],
       controlUi: {
         allowedOrigins: ["https://localhost"],
         ...(params?.allowInsecureAuth ? { allowInsecureAuth: true } : {}),
@@ -382,6 +396,7 @@ export {
   TEST_OPERATOR_CLIENT,
   trackConnectChallengeNonce,
   TRUSTED_PROXY_CONTROL_UI_HEADERS,
+  TRUSTED_PROXY_CONTROL_UI_REMOTE_IP,
   testState,
   testTailscaleWhois,
   waitForWsClose,
@@ -390,6 +405,10 @@ export {
   writeTrustedProxyControlUiConfig,
 };
 export { ConnectErrorDetailCodes } from "./protocol/connect-error-details.js";
+// TEST-ONLY harness seam (no production callers). Lets a suite simulate a
+// non-loopback peer so the trusted-proxy auth path is reachable over the
+// loopback-only test transport. See test-remote-address-seam.ts § production-safe.
+export { setTestUpgradeRemoteAddressOverride } from "./server/ws-connection/test-remote-address-seam.js";
 export { getHandshakeTimeoutMs } from "./server-constants.js";
 export { PROTOCOL_VERSION } from "./protocol/index.js";
 export { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";

--- a/src/gateway/server.roles-allowlist-update.test.ts
+++ b/src/gateway/server.roles-allowlist-update.test.ts
@@ -35,6 +35,16 @@ installConnectedControlUiServerSuite((started) => {
   port = started.port;
 });
 
+// Forwarding header that makes the gateway classify a loopback test connect as
+// REMOTE (non-local-direct) via `isLocalDirectRequest` (src/gateway/auth.ts).
+// A remote node connect requires EXPLICIT pairing approval instead of the
+// secure-on-loopback silent auto-pair — which is exactly the path the
+// pairing-required tests below need. This is a TEST-ONLY harness lever: it only
+// passes the header through the existing WS upgrade; production classification
+// and the loopback auto-pair posture are unchanged. 203.0.113.0/24 is the
+// RFC 5737 TEST-NET-3 documentation range (never a real peer).
+const REMOTE_PEER_HEADERS = { "x-forwarded-for": "203.0.113.10" } as const;
+
 const connectNodeClient = async (params: {
   port: number;
   commands: string[];
@@ -44,6 +54,7 @@ const connectNodeClient = async (params: {
   instanceId?: string;
   displayName?: string;
   onEvent?: (evt: { event?: string; payload?: unknown }) => void;
+  headers?: Record<string, string>;
 }) => {
   const token = process.env.REMOTECLAW_GATEWAY_TOKEN;
   if (!token) {
@@ -64,6 +75,7 @@ const connectNodeClient = async (params: {
     commands: params.commands,
     deviceIdentity: params.deviceIdentity,
     onEvent: params.onEvent,
+    headers: params.headers,
     timeoutMessage: "timeout waiting for node to connect",
   });
 };
@@ -382,21 +394,23 @@ describe("gateway node command allowlist", () => {
     }
   });
 
-  // SKIPPED: this asserts that a node's declared commands appear in the
-  // `node.pair.list` PENDING set before approval. On this test harness every
-  // client connects from a loopback socket (`ws://127.0.0.1`), and
-  // `shouldAllowSilentLocalPairing` (message-handler.ts) silently auto-pairs a
-  // local non-browser node on first connect (reason "not-paired") — so the node
-  // is never parked in the pending set and `node.pair.list.pending` is empty.
-  // Production DOES record allowlist-filtered declared commands into the pending
-  // entry (reconcileNodePairingOnConnect → resolveNodeCommandAllowlist +
-  // normalizeDeclaredNodeCommands → requestPairing), and the connect-time
-  // allowlist filtering is covered by "filters system.run for confusable iOS
-  // metadata at connect time" (which reads node.list, observable on loopback).
-  // Re-enable when the harness can originate a remote (non-local-direct) node
-  // connect that requires explicit pairing approval. Silent local auto-pairing
-  // is the secure-on-loopback behavior (no fail-open). Same harness limitation
-  // as the trusted-proxy/pending-pairing cases elsewhere in this cluster.
+  // SKIPPED — blocked by gutted PRODUCTION wiring, not a harness gap (see
+  // remoteclaw/remoteclaw#2744). This asserts a node's allowlist-filtered
+  // declared commands appear in the `node.pair.list` PENDING set (the
+  // NODE-pairing system, distinct from device pairing) on connect. Upstream
+  // OpenClaw runs `reconcileNodePairingOnConnect` at connect time to park that
+  // node-pairing pending entry; the RemoteClaw fork gutted that wiring —
+  // `reconcileNodePairingOnConnect` has no call site (only its definition
+  // remains), and `node.pair.list.pending` is written ONLY by the explicit
+  // `node.pair.request` RPC, never on connect. So the pending entry is empty
+  // regardless of local-vs-remote classification: a remote connect
+  // (REMOTE_PEER_HEADERS) parks only a DEVICE-pairing entry — proven by
+  // "requires explicit pairing approval for a remote (non-local-direct) node
+  // connect" above, which exercises the harness's new remote-connect lever. The
+  // connect-time allowlist FILTERING this checks is still covered by "filters
+  // system.run for confusable iOS metadata at connect time" (reads node.list).
+  // Re-enabling needs restoring the gutted connect→node-pairing reconciliation
+  // (a production port, out of this PR's harness-only scope): #2744.
   test.skip("keeps allowlisted declared commands available before node pairing exists", async () => {
     const findConnectedNode = async (displayName: string) => {
       const listRes = await rpcReq<{
@@ -452,12 +466,13 @@ describe("gateway node command allowlist", () => {
     }
   });
 
-  // SKIPPED (same loopback silent-pairing limitation as the sibling above): the
-  // pending node-pairing entry this asserts on is never created for a loopback
-  // node (silent local auto-pairing fires first). The allowlist-filtering it
-  // checks (İOS confusable → only `canvas.snapshot` survives, `system.run`
-  // filtered) is exercised at connect time by the confusable-metadata test via
-  // node.list. No fail-open; re-enable with a remote-node harness capability.
+  // SKIPPED — same gutted-wiring blocker as the sibling above, not a harness gap
+  // (remoteclaw/remoteclaw#2744): the `node.pair.list` PENDING entry this asserts
+  // on is never created on connect because `reconcileNodePairingOnConnect` is
+  // unwired in the fork. The İOS-confusable allowlist filtering it checks (only
+  // `canvas.snapshot` survives, `system.run` filtered) is exercised at connect
+  // time by "filters system.run for confusable iOS metadata at connect time" via
+  // node.list. Re-enabling needs the production port tracked in #2744.
   test.skip("records only allowlisted commands in pending node pairing requests", async () => {
     const { loadOrCreateDeviceIdentity } = await import("../infra/device-identity.js");
     const deviceIdentityPath = path.join(
@@ -506,6 +521,67 @@ describe("gateway node command allowlist", () => {
       );
     } finally {
       await nodeClient?.stopAndWait();
+    }
+  });
+
+  // AC#1 (remoteclaw#2732): the harness can now originate a node connect that the
+  // gateway classifies as REMOTE (non-local-direct) by attaching a forwarding
+  // header (REMOTE_PEER_HEADERS) that flips `isLocalDirectRequest`
+  // (src/gateway/auth.ts) to false. A remote node connect must NOT take the
+  // secure-on-loopback silent auto-pair shortcut: it is rejected with
+  // PAIRING_REQUIRED and parks a pending DEVICE-pairing entry for explicit
+  // approval. Every other node connect in this suite uses loopback (no header)
+  // and silently auto-pairs — this test is the contrasting remote path. The
+  // header is a TEST-ONLY harness lever; production classification and the
+  // loopback auto-pair posture are unchanged.
+  test("requires explicit pairing approval for a remote (non-local-direct) node connect", async () => {
+    const { listDevicePairing, rejectDevicePairing } = await import("../infra/device-pairing.js");
+    const { loadOrCreateDeviceIdentity } = await import("../infra/device-identity.js");
+    const deviceIdentity = loadOrCreateDeviceIdentity(
+      path.join(
+        os.tmpdir(),
+        `remoteclaw-remote-node-pairing-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+      ),
+    );
+    const displayName = "node-remote-pairing-required";
+
+    let connectError: unknown;
+    try {
+      await connectNodeClient({
+        port,
+        commands: ["canvas.snapshot"],
+        platform: "darwin",
+        instanceId: displayName,
+        displayName,
+        deviceIdentity,
+        headers: REMOTE_PEER_HEADERS,
+      });
+      throw new Error("expected remote node connect to require explicit pairing");
+    } catch (err) {
+      connectError = err;
+    }
+
+    // Assert the structured PAIRING_REQUIRED code rather than the rendered
+    // message so the contract is robust to wording (same convention as the
+    // spoof test below).
+    const detailCode = (connectError as { details?: { code?: string } } | undefined)?.details?.code;
+    expect(detailCode).toBe(ConnectErrorDetailCodes.PAIRING_REQUIRED);
+
+    // The explicit-pairing path parked exactly one pending DEVICE-pairing entry
+    // for this node's device identity (the loopback silent auto-pair did NOT
+    // fire), recording the "node" role it connected with.
+    const pending = (await listDevicePairing()).pending.filter(
+      (entry) => entry.deviceId === deviceIdentity.deviceId,
+    );
+    expect(pending).toHaveLength(1);
+    const pendingRoles = pending[0]?.roles ?? (pending[0]?.role ? [pending[0]?.role] : []);
+    expect(pendingRoles).toContain("node");
+
+    // Clean up the pending entry so it cannot leak into sibling tests (the suite
+    // shares device-pairing state — there is no per-test reset).
+    const requestId = pending[0]?.requestId;
+    if (requestId) {
+      await rejectDevicePairing(requestId);
     }
   });
 

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -20,6 +20,7 @@ import {
   attachGatewayWsMessageHandler,
   type WsOriginCheckMetrics,
 } from "./ws-connection/message-handler.js";
+import { applyTestUpgradeRemoteAddressOverride } from "./ws-connection/test-remote-address-seam.js";
 import type { GatewayWsClient } from "./ws-types.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
@@ -114,6 +115,12 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
   const originCheckMetrics: WsOriginCheckMetrics = { hostHeaderFallbackAccepted: 0 };
 
   wss.on("connection", (socket, upgradeReq) => {
+    // TEST-ONLY: let the harness simulate a non-loopback peer so the
+    // trusted-proxy auth path is reachable over the loopback-only test
+    // transport. No-op in production (override unset + Vitest-gated); the
+    // production loopback rejection in authorizeTrustedProxy is untouched.
+    // See ./ws-connection/test-remote-address-seam.ts for the safety rationale.
+    applyTestUpgradeRemoteAddressOverride(upgradeReq);
     let client: GatewayWsClient | null = null;
     let closed = false;
     const openedAt = Date.now();

--- a/src/gateway/server/ws-connection/test-remote-address-seam.ts
+++ b/src/gateway/server/ws-connection/test-remote-address-seam.ts
@@ -1,0 +1,85 @@
+import type { IncomingMessage } from "node:http";
+
+/**
+ * TEST-ONLY seam: simulate a non-loopback peer address on the gateway WS
+ * upgrade socket so the harness can exercise the *successful* trusted-proxy
+ * auth path.
+ *
+ * ## Why this exists
+ *
+ * `authorizeTrustedProxy` (src/gateway/auth.ts) rejects trusted-proxy auth from
+ * a loopback source unconditionally (`trusted_proxy_loopback_source`). That is
+ * the correct production posture: a real reverse proxy fronts the gateway from a
+ * non-loopback address, so a "trusted proxy" arriving over loopback is almost
+ * certainly a local process spoofing forwarding headers. The gateway test
+ * harness, however, can only connect over `ws://127.0.0.1`, so without a seam it
+ * can ONLY ever observe the loopback *rejection* — never the post-auth behavior
+ * (e.g. self-declared scope clearing for a device-less trusted-proxy control-UI
+ * operator, covered by `server.auth.control-ui.suite.ts`).
+ *
+ * This seam lets a test make the server observe a non-loopback `remoteAddress`
+ * for the connection it is about to open — exactly the network condition that
+ * holds in production behind a real proxy — WITHOUT relaxing the loopback
+ * rejection itself.
+ *
+ * ## Why it is production-safe (read before changing)
+ *
+ * 1. **Off by default.** `override` is `undefined` until a test sets it, and
+ *    {@link applyTestUpgradeRemoteAddressOverride} is a strict no-op while unset.
+ *    Production reads the real socket address — behavior is byte-for-byte
+ *    unchanged.
+ * 2. **No production caller.** {@link setTestUpgradeRemoteAddressOverride} is
+ *    only ever called from test code. Grep `setTestUpgradeRemoteAddressOverride`
+ *    across `src/`: the sole non-test references are this definition and the
+ *    test-helper re-export. Production connect/auth code never imports it. (This
+ *    is the same "no live non-test caller" property the fork's
+ *    throwing-stub-callers-gate enforces.)
+ * 3. **Belt-and-suspenders runtime guard.** The apply path additionally bails
+ *    unless the process is a Vitest run (`process.env.VITEST` is `"true"`/`"1"`,
+ *    set by `test/setup.ts` and never by production). So even an accidental
+ *    production call to the setter cannot alter a real connection.
+ * 4. **It does NOT weaken `authorizeTrustedProxy`.** The loopback-rejection
+ *    branch in auth.ts is untouched. This only changes WHICH address a *test*
+ *    connection appears to originate from — equivalent to running the test on a
+ *    host with a non-loopback NIC behind a proxy. Any genuine loopback
+ *    trusted-proxy connection in production is still rejected.
+ */
+let override: string | undefined;
+
+function isVitestRuntime(): boolean {
+  const value = process.env.VITEST;
+  return value === "true" || value === "1";
+}
+
+/**
+ * TEST-ONLY. Set (or clear, with `undefined`) the simulated non-loopback peer
+ * address applied to subsequent WS upgrades. Tests MUST reset to `undefined`
+ * after use (the override is process-global). Never call from production code.
+ */
+export function setTestUpgradeRemoteAddressOverride(addr: string | undefined): void {
+  override = addr;
+}
+
+/**
+ * Apply the test override (if any) to the upgrade request's socket so that all
+ * downstream reads of `req.socket.remoteAddress` — including
+ * `authorizeTrustedProxy` — observe the simulated peer. No-op in production
+ * (override unset and/or not a Vitest run). See module doc for safety rationale.
+ */
+export function applyTestUpgradeRemoteAddressOverride(req: IncomingMessage): void {
+  if (!override || !isVitestRuntime()) {
+    return;
+  }
+  const socket = req.socket;
+  if (!socket) {
+    return;
+  }
+  // Shadow the real getter/own-property with a configurable own value so every
+  // downstream read (the connection handler's `remoteAddr`, and the auth layer's
+  // `req.socket.remoteAddress`) sees the simulated address consistently.
+  Object.defineProperty(socket, "remoteAddress", {
+    configurable: true,
+    enumerable: true,
+    value: override,
+  });
+}

--- a/src/gateway/test-helpers.e2e.ts
+++ b/src/gateway/test-helpers.e2e.ts
@@ -48,6 +48,13 @@ export async function connectGatewayClient(params: {
   connectChallengeTimeoutMs?: number;
   timeoutMs?: number;
   timeoutMessage?: string;
+  /**
+   * Test-only: extra WS upgrade headers. Forwarding headers (e.g.
+   * `x-forwarded-for`) make the server classify the connect as remote
+   * (non-local-direct) so it requires explicit pairing instead of loopback
+   * auto-pair. See `GatewayClientOptions.headers`.
+   */
+  headers?: Record<string, string>;
 }) {
   const role = params.role ?? "operator";
   const scopes = params.scopes ?? (role === "node" ? [] : undefined);
@@ -84,6 +91,7 @@ export async function connectGatewayClient(params: {
       url: params.url,
       token: params.token,
       deviceToken: params.deviceToken,
+      headers: params.headers,
       connectChallengeTimeoutMs: params.connectChallengeTimeoutMs ?? 0,
       clientName: params.clientName ?? GATEWAY_CLIENT_NAMES.TEST,
       clientDisplayName: params.clientDisplayName ?? "vitest",


### PR DESCRIPTION
Addresses #2732. Adds a test-only harness capability to originate a **remote
(non-local-direct)** gateway connect requiring explicit pairing approval, and
un-skips the trusted-proxy control-UI scope-clearing test — **with no change to
production classification, the loopback auto-pair posture, or the trusted-proxy
loopback rejection.** `src/gateway/auth.ts` is **unchanged** (0 lines).

---

## ⚠️ Operator decision: "Addresses" vs "Closes" #2732

The brief specified the body say **"Closes #2732"**, assuming the issue was fully
resolvable as a harness-only change. Investigation found that is **not** possible
without an out-of-scope production change, so this PR delivers the doable part and
flags the rest rather than auto-closing an issue with unmet ACs:

- ✅ **AC#1** (harness can simulate a remote node connect requiring pairing,
  distinct from local-direct auto-pair) — **delivered** (Part A).
- ✅ **Trusted-proxy control-UI scope test** (L276) — **un-skipped & passing** (Part B).
- ⛔ **The two `node.pair.list` pending-on-connect tests** — **blocked by gutted
  production wiring** (`reconcileNodePairingOnConnect` is unwired in the fork),
  tracked in **#2744**. Kept skipped with corrected comments. Restoring is a
  production port, out of this harness-only scope.

I used **"Addresses #2732"** so merging does not auto-close the issue while AC#2/#3
are unmet. **If you prefer, change to "Closes #2732"** and let #2744 carry the
remaining work — your call before merge.

---

## Part B — trusted-proxy control-UI test seam (security-sensitive; please review)

`authorizeTrustedProxy` (`src/gateway/auth.ts`) rejects trusted-proxy auth from a
**loopback** source unconditionally (`trusted_proxy_loopback_source`) — the correct
production posture (a real reverse proxy fronts the gateway from a non-loopback
address). The gateway test transport only connects over `ws://127.0.0.1`, so the
**successful** trusted-proxy path (scope-clearing for a device-less control-UI
operator) was previously unreachable and the test was skipped.

This PR adds a **TEST-ONLY seam** —
`src/gateway/server/ws-connection/test-remote-address-seam.ts` — that lets a suite
make the server observe a **non-loopback** peer for a single test connect (exactly
the network condition that holds in production behind a real proxy), then un-skips
*"clears self-declared scopes for trusted-proxy control ui without device identity"*.

**Why it is production-safe** (full rationale in the module doc):

1. **`auth.ts` is unchanged.** The loopback-rejection branch is untouched. Any
   genuine loopback trusted-proxy connection in production is still rejected.
2. **Off by default.** The override is `undefined` until a test sets it;
   `applyTestUpgradeRemoteAddressOverride` is a strict no-op while unset, so
   production reads the real socket address byte-for-byte unchanged.
3. **No production caller.** `setTestUpgradeRemoteAddressOverride` is called only
   from test code (`grep` shows the only non-test references are the definition
   and a test-helper re-export) — the same "no live non-test caller" property the
   fork's throwing-stub-callers gate enforces.
4. **Belt-and-suspenders runtime guard.** The apply path additionally bails unless
   the process is a Vitest run (`process.env.VITEST`), so even an accidental
   production call to the setter cannot alter a real connection.
5. **The test resets the process-global override in `finally`** so it cannot leak
   into sibling tests.

**Regression check:** the three loopback-rejection tests
(*rejects trusted-proxy control ui operator / node-role / unpaired-device from a
loopback source*) still pass — adding the TEST-NET-3 IP to `trustedProxies` does
not change them (a loopback socket is rejected regardless of `trustedProxies`
membership).

The other two control-UI skips (`*-lockout`, ~L568/L597, rate-limit) are **out of
scope** and remain skipped.

## Part A — remote-connect harness lever (no production behavior change)

- `GatewayClientOptions.headers` (`client.ts`) forwards extra WS upgrade headers;
  `connectGatewayClient` (`test-helpers.e2e.ts`) threads them through. Production
  clients never set this (they connect over loopback/SSH-tunnel/Tailscale without
  synthesizing proxy headers).
- `REMOTE_PEER_HEADERS` (`x-forwarded-for`, RFC 5737 TEST-NET-3) flips
  `isLocalDirectRequest` to *remote*, routing a test connect through the existing
  remote codepath — no change to the classifier or auto-pair posture.
- New test **"requires explicit pairing approval for a remote (non-local-direct)
  node connect"** proves a remote node connect is rejected with `PAIRING_REQUIRED`
  and parks a pending **device**-pairing entry — the contrast to the loopback
  silent auto-pair every other node test in the suite relies on. This delivers
  **AC#1** and gives the lever a live consumer.

## Why the two node tests stay skipped (#2744)

They assert allowlist-filtered declared commands appear in the **`node.pair.list`
pending set** (the *node*-pairing system, distinct from device pairing) **on
connect**. In upstream OpenClaw, `reconcileNodePairingOnConnect` runs at connect
time to park that entry; the RemoteClaw fork gutted that wiring —
`reconcileNodePairingOnConnect` has **no call site**, and `node.pair.list.pending`
is written **only** by the explicit `node.pair.request` RPC, never on connect. So
the pending set is empty on connect regardless of local-vs-remote classification
(a remote connect parks only a *device*-pairing entry, as the new Part-A test
shows). Re-enabling requires restoring the gutted connect→node-pairing
reconciliation — a production port pulling in the reapproval coordinator, pairing
rate limiting, caps/permissions reconciliation, and broadcast plumbing — which is
out of this PR's harness-only scope. Tracked in **#2744**; skip comments updated to
cite the real cause. The connect-time allowlist *filtering* these tests check is
still covered by *"filters system.run for confusable iOS metadata at connect
time"* (reads `node.list`).

## Validation

- Full gateway lane green: **1583 passed | 6 skipped** (143 files) via
  `pnpm test:gateway`. The 6 skips = 2 blocked node tests (#2744) + 2 out-of-scope
  control-UI rate-limit + 2 pre-existing.
- `pnpm tsgo`, `pnpm lint` (oxlint type-aware), `pnpm format` (oxfmt) all clean.
- Fork-integrity gates pass: rebrand-leakage, zombie-import, stub-debt,
  throwing-stub-callers, obsolescence-audit.
- `src/gateway/auth.ts` diff: **empty**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
