### PR TITLE
fix(gateway): derive senderIsOwner from gateway auth on OpenAI-compat HTTP (#2735)

### DIFF
--- a/scripts/check-openai-http-owner-derivation.mjs
+++ b/scripts/check-openai-http-owner-derivation.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+/**
+ * #2735 CI-assert guard — keeps "green CI" a FAITHFUL proxy for "the IDOR hole
+ * is closed".
+ *
+ * The fix derives `senderIsOwner` from the satisfying gateway auth method so an
+ * UNAUTHENTICATED, header-less caller on an `auth:"none"` gateway is NOT treated
+ * as owner (src/gateway/http-utils.ts `resolveTrustedHttpOperatorScopes`, the
+ * fork divergence). The regression anchor is the un-skipped test
+ *   it("derives senderIsOwner from request auth on the OpenAI-compat endpoint")
+ * in src/gateway/openai-http.test.ts, which posts with NO bearer and NO
+ * x-remoteclaw-scopes header and asserts `senderIsOwner === false`.
+ *
+ * This gate FAILS if that anchor is missing, is skipped (`it.skip` / `xit` /
+ * `it.only` siblings), or no longer asserts `senderIsOwner ... toBe(false)`.
+ * Without it, the anchor could be silently re-skipped (e.g. on an upstream
+ * sync) and CI would stay green while the hole re-opens.
+ *
+ * Reference: issue #2735.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const TEST_FILE = "src/gateway/openai-http.test.ts";
+const ANCHOR_NAME = "derives senderIsOwner from request auth on the OpenAI-compat endpoint";
+
+/**
+ * @returns {Promise<{ ok: boolean; violations: string[] }>}
+ */
+export async function checkOpenAiHttpOwnerDerivationGuard() {
+  const violations = [];
+  const abs = path.join(REPO_ROOT, TEST_FILE);
+
+  let content;
+  try {
+    content = await fs.readFile(abs, "utf-8");
+  } catch {
+    return { ok: false, violations: [`${TEST_FILE}: file not found (anchor test removed?)`] };
+  }
+
+  // Locate the actual test DECLARATION: the anchor name preceded by an opening
+  // quote and an it()/describe() call form. Requiring the quote means a bare
+  // mention of the name in a comment cannot satisfy the gate, and it lets us
+  // read the call form (skip / only / todo / xit / fit) in one match.
+  const escapedName = ANCHOR_NAME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const declMatch = new RegExp(
+    `\\b(x?it|fit|describe)(?:\\s*\\.\\s*(skip|only|todo))?\\s*\\(\\s*["'\`]${escapedName}`,
+  ).exec(content);
+  if (!declMatch) {
+    return {
+      ok: false,
+      violations: [`${TEST_FILE}: missing anchor test "${ANCHOR_NAME}" (#2735 regression anchor)`],
+    };
+  }
+
+  const callForm = declMatch[1]; // it | xit | fit | describe
+  const modifier = declMatch[2]; // skip | only | todo | undefined
+  if (callForm === "xit" || modifier === "skip" || modifier === "todo") {
+    const form = modifier ? `${callForm}.${modifier}` : callForm;
+    violations.push(
+      `${TEST_FILE}: anchor test is SKIPPED (\`${form}\`) — it must run in CI (#2735)`,
+    );
+  }
+  if (callForm === "fit" || modifier === "only") {
+    const form = callForm === "fit" ? "fit" : "it.only";
+    violations.push(
+      `${TEST_FILE}: anchor test uses \`${form}\` — the exclusive form skips siblings, masking coverage (#2735)`,
+    );
+  }
+
+  // Extract the anchor test body: from the declaration to the next top-level
+  // (2-space-indented) it(/describe( declaration, or EOF.
+  const afterDecl = content.slice(declMatch.index);
+  const nextBoundary = afterDecl.slice(1).search(/\n {2}(?:x?it|fit|describe)[\s.(]/);
+  const body = nextBoundary === -1 ? afterDecl : afterDecl.slice(0, nextBoundary + 1);
+
+  const assertsNotOwner = /senderIsOwner/.test(body) && /\.toBe\(\s*false\s*\)/.test(body);
+  if (!assertsNotOwner) {
+    violations.push(
+      `${TEST_FILE}: anchor test no longer asserts \`senderIsOwner ... toBe(false)\` (#2735 invariant lost)`,
+    );
+  }
+
+  return { ok: violations.length === 0, violations };
+}
+
+// CLI entry (also runnable standalone: `node scripts/check-openai-http-owner-derivation.mjs`).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const { ok, violations } = await checkOpenAiHttpOwnerDerivationGuard();
+  if (!ok) {
+    console.error("✗ #2735 owner-derivation guard FAILED:");
+    for (const v of violations) {
+      console.error(`  - ${v}`);
+    }
+    process.exit(1);
+  }
+  console.log(
+    "✓ #2735 owner-derivation guard: anchor test present, un-skipped, asserts not-owner.",
+  );
+}

--- a/src/gateway/http-auth-helpers.ts
+++ b/src/gateway/http-auth-helpers.ts
@@ -2,7 +2,13 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import { authorizeHttpGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
 import { sendGatewayAuthFailure } from "./http-common.js";
-import { getBearerToken, getHeader, resolveHttpBrowserOriginPolicy } from "./http-utils.js";
+import {
+  type AuthorizedGatewayHttpRequest,
+  getBearerToken,
+  getHeader,
+  resolveHttpBrowserOriginPolicy,
+  usesSharedSecretGatewayMethod,
+} from "./http-utils.js";
 import { CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
 
 const OPERATOR_SCOPES_HEADER = "x-remoteclaw-scopes";
@@ -31,6 +37,51 @@ export async function authorizeGatewayBearerRequestOrReply(params: {
     return false;
   }
   return true;
+}
+
+/**
+ * Like `authorizeGatewayBearerRequestOrReply`, but surfaces the satisfying auth
+ * context instead of a bare boolean (#2735). Endpoints that derive per-request
+ * authority — operator scopes / owner — from the auth method (e.g. the
+ * OpenAI-compatible surface) need this; `authorizeGatewayBearerRequestOrReply`
+ * is retained for callers that only need allow/deny (e.g. `tools-invoke-http`).
+ *
+ * Returns `null` (and writes the auth-failure response) when unauthorized, so
+ * callers branch on truthiness exactly as before.
+ */
+export async function authorizeGatewayHttpRequestOrReply(params: {
+  req: IncomingMessage;
+  res: ServerResponse;
+  auth: ResolvedGatewayAuth;
+  trustedProxies?: string[];
+  allowRealIpFallback?: boolean;
+  rateLimiter?: AuthRateLimiter;
+}): Promise<AuthorizedGatewayHttpRequest | null> {
+  const token = getBearerToken(params.req);
+  const browserOriginPolicy = resolveHttpBrowserOriginPolicy(params.req);
+  const authResult = await authorizeHttpGatewayConnect({
+    auth: params.auth,
+    connectAuth: token ? { token, password: token } : null,
+    req: params.req,
+    trustedProxies: params.trustedProxies,
+    allowRealIpFallback: params.allowRealIpFallback,
+    rateLimiter: params.rateLimiter,
+    browserOriginPolicy,
+  });
+  if (!authResult.ok) {
+    sendGatewayAuthFailure(params.res, authResult);
+    return null;
+  }
+  return {
+    authMethod: authResult.method,
+    // Shared-secret bearer auth proves possession of the gateway secret, not a
+    // narrower per-request operator identity, so its DECLARED scopes are NOT
+    // trusted (owner is granted via the compat short-circuit instead). Non-
+    // shared-secret callers (none / trusted-proxy) may have their declared
+    // scopes honored — but a missing or non-admin declaration is NOT owner
+    // (#2735; see resolveTrustedHttpOperatorScopes for the fork divergence).
+    trustDeclaredOperatorScopes: !usesSharedSecretGatewayMethod(authResult.method),
+  };
 }
 
 export function resolveGatewayRequestedOperatorScopes(req: IncomingMessage): string[] {

--- a/src/gateway/http-endpoint-helpers.test.ts
+++ b/src/gateway/http-endpoint-helpers.test.ts
@@ -2,10 +2,14 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
+import type { AuthorizedGatewayHttpRequest } from "./http-utils.js";
 
 vi.mock("./http-auth-helpers.js", () => {
   return {
-    authorizeGatewayBearerRequestOrReply: vi.fn(),
+    // #2735: the endpoint now authorizes via authorizeGatewayHttpRequestOrReply,
+    // which surfaces the satisfying auth method (AuthorizedGatewayHttpRequest)
+    // instead of a bare boolean so downstream owner-derivation can run.
+    authorizeGatewayHttpRequestOrReply: vi.fn(),
     resolveGatewayRequestedOperatorScopes: vi.fn(),
   };
 });
@@ -24,10 +28,18 @@ vi.mock("./method-scopes.js", () => {
   };
 });
 
-const { authorizeGatewayBearerRequestOrReply } = await import("./http-auth-helpers.js");
+const { authorizeGatewayHttpRequestOrReply } = await import("./http-auth-helpers.js");
 const { resolveGatewayRequestedOperatorScopes } = await import("./http-auth-helpers.js");
 const { readJsonBodyOrError, sendJson, sendMethodNotAllowed } = await import("./http-common.js");
 const { authorizeOperatorScopesForMethod } = await import("./method-scopes.js");
+
+// Stand-in for a successful authorization: the concrete shape is irrelevant to
+// these tests (operator scopes are resolved via the mocked resolver), only that
+// it is a non-null AuthorizedGatewayHttpRequest threaded back as `requestAuth`.
+const fakeRequestAuth: AuthorizedGatewayHttpRequest = {
+  authMethod: "token",
+  trustDeclaredOperatorScopes: false,
+};
 
 describe("handleGatewayPostJsonEndpoint", () => {
   it("returns false when path does not match", async () => {
@@ -60,7 +72,7 @@ describe("handleGatewayPostJsonEndpoint", () => {
   });
 
   it("returns undefined when auth fails", async () => {
-    vi.mocked(authorizeGatewayBearerRequestOrReply).mockResolvedValue(false);
+    vi.mocked(authorizeGatewayHttpRequestOrReply).mockResolvedValue(null);
     const result = await handleGatewayPostJsonEndpoint(
       {
         url: "/v1/ok",
@@ -73,8 +85,8 @@ describe("handleGatewayPostJsonEndpoint", () => {
     expect(result).toBeUndefined();
   });
 
-  it("returns body when auth succeeds and JSON parsing succeeds", async () => {
-    vi.mocked(authorizeGatewayBearerRequestOrReply).mockResolvedValue(true);
+  it("returns body and requestAuth when auth succeeds and JSON parsing succeeds", async () => {
+    vi.mocked(authorizeGatewayHttpRequestOrReply).mockResolvedValue(fakeRequestAuth);
     vi.mocked(readJsonBodyOrError).mockResolvedValue({ hello: "world" });
     const result = await handleGatewayPostJsonEndpoint(
       {
@@ -85,11 +97,11 @@ describe("handleGatewayPostJsonEndpoint", () => {
       {} as unknown as ServerResponse,
       { pathname: "/v1/ok", auth: {} as unknown as ResolvedGatewayAuth, maxBodyBytes: 123 },
     );
-    expect(result).toEqual({ body: { hello: "world" } });
+    expect(result).toEqual({ body: { hello: "world" }, requestAuth: fakeRequestAuth });
   });
 
   it("returns undefined and replies when required operator scope is missing", async () => {
-    vi.mocked(authorizeGatewayBearerRequestOrReply).mockResolvedValue(true);
+    vi.mocked(authorizeGatewayHttpRequestOrReply).mockResolvedValue(fakeRequestAuth);
     vi.mocked(resolveGatewayRequestedOperatorScopes).mockReturnValue(["operator.approvals"]);
     vi.mocked(authorizeOperatorScopesForMethod).mockReturnValue({
       allowed: false,

--- a/src/gateway/http-endpoint-helpers.ts
+++ b/src/gateway/http-endpoint-helpers.ts
@@ -2,10 +2,11 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import {
-  authorizeGatewayBearerRequestOrReply,
+  authorizeGatewayHttpRequestOrReply,
   resolveGatewayRequestedOperatorScopes,
 } from "./http-auth-helpers.js";
 import { readJsonBodyOrError, sendJson, sendMethodNotAllowed } from "./http-common.js";
+import type { AuthorizedGatewayHttpRequest } from "./http-utils.js";
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 
 export async function handleGatewayPostJsonEndpoint(
@@ -19,8 +20,18 @@ export async function handleGatewayPostJsonEndpoint(
     allowRealIpFallback?: boolean;
     rateLimiter?: AuthRateLimiter;
     requiredOperatorMethod?: "chat.send" | (string & Record<never, never>);
+    /**
+     * Resolver for the method-scope gate's operator scopes. The compat surface
+     * passes `resolveOpenAiCompatibleHttpOperatorScopes` so shared-secret bearer
+     * auth maps to full operator access while a header-less `auth:"none"` caller
+     * still chats (#2735). Defaults to the header-only resolver.
+     */
+    resolveOperatorScopes?: (
+      req: IncomingMessage,
+      requestAuth: AuthorizedGatewayHttpRequest,
+    ) => string[];
   },
-): Promise<false | { body: unknown } | undefined> {
+): Promise<false | { body: unknown; requestAuth: AuthorizedGatewayHttpRequest } | undefined> {
   const url = new URL(req.url ?? "/", `http://${req.headers.host || "localhost"}`);
   if (url.pathname !== opts.pathname) {
     return false;
@@ -31,7 +42,7 @@ export async function handleGatewayPostJsonEndpoint(
     return undefined;
   }
 
-  const authorized = await authorizeGatewayBearerRequestOrReply({
+  const requestAuth = await authorizeGatewayHttpRequestOrReply({
     req,
     res,
     auth: opts.auth,
@@ -39,12 +50,13 @@ export async function handleGatewayPostJsonEndpoint(
     allowRealIpFallback: opts.allowRealIpFallback,
     rateLimiter: opts.rateLimiter,
   });
-  if (!authorized) {
+  if (!requestAuth) {
     return undefined;
   }
 
   if (opts.requiredOperatorMethod) {
-    const requestedScopes = resolveGatewayRequestedOperatorScopes(req);
+    const requestedScopes =
+      opts.resolveOperatorScopes?.(req, requestAuth) ?? resolveGatewayRequestedOperatorScopes(req);
     const scopeAuth = authorizeOperatorScopesForMethod(
       opts.requiredOperatorMethod,
       requestedScopes,
@@ -66,5 +78,5 @@ export async function handleGatewayPostJsonEndpoint(
     return undefined;
   }
 
-  return { body };
+  return { body, requestAuth };
 }

--- a/src/gateway/http-utils.owner-derivation.test.ts
+++ b/src/gateway/http-utils.owner-derivation.test.ts
@@ -1,0 +1,156 @@
+import type { IncomingMessage } from "node:http";
+import { describe, expect, it } from "vitest";
+import {
+  resolveHttpSenderIsOwner,
+  resolveOpenAiCompatibleHttpOperatorScopes,
+  resolveOpenAiCompatibleHttpSenderIsOwner,
+  resolveTrustedHttpOperatorScopes,
+  usesSharedSecretGatewayMethod,
+} from "./http-utils.js";
+import { ADMIN_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
+
+// #2735: HTTP auth → operator-scope / owner derivation for the gateway HTTP
+// surface. The load-bearing fork divergence from upstream is asserted in
+// "resolveTrustedHttpOperatorScopes" → "no-header non-shared-secret → []".
+function createReq(headers: Record<string, string> = {}): IncomingMessage {
+  return { headers } as IncomingMessage;
+}
+
+const tokenAuth = { mode: "token" as const };
+const noneAuth = { mode: "none" as const };
+
+describe("usesSharedSecretGatewayMethod", () => {
+  it("is true only for token/password methods", () => {
+    expect(usesSharedSecretGatewayMethod("token")).toBe(true);
+    expect(usesSharedSecretGatewayMethod("password")).toBe(true);
+    expect(usesSharedSecretGatewayMethod("none")).toBe(false);
+    expect(usesSharedSecretGatewayMethod("trusted-proxy")).toBe(false);
+    expect(usesSharedSecretGatewayMethod(undefined)).toBe(false);
+  });
+});
+
+describe("resolveTrustedHttpOperatorScopes (owner feed)", () => {
+  it("keeps an explicitly declared scope set for a non-shared-secret request", () => {
+    expect(
+      resolveTrustedHttpOperatorScopes(
+        createReq({ "x-remoteclaw-scopes": "operator.admin, operator.write" }),
+        noneAuth,
+      ),
+    ).toEqual(["operator.admin", "operator.write"]);
+  });
+
+  it("FORK #2735 divergence: non-shared-secret + NO header → [] (NOT CLI defaults)", () => {
+    // Upstream returns [...CLI_DEFAULT_OPERATOR_SCOPES] (incl operator.admin) here;
+    // the fork must return [] so a header-less auth:"none" caller is NOT owner.
+    expect(resolveTrustedHttpOperatorScopes(createReq(), noneAuth)).toEqual([]);
+    // Same divergence via the explicit AuthorizedGatewayHttpRequest input shape
+    // (trustDeclaredOperatorScopes:true ⇒ non-shared-secret ⇒ honor declared,
+    // but there is none, so []).
+    expect(
+      resolveTrustedHttpOperatorScopes(createReq(), { trustDeclaredOperatorScopes: true }),
+    ).toEqual([]);
+  });
+
+  it("returns [] for a present-but-empty header", () => {
+    expect(
+      resolveTrustedHttpOperatorScopes(createReq({ "x-remoteclaw-scopes": "" }), noneAuth),
+    ).toEqual([]);
+  });
+
+  it("drops self-asserted scopes for shared-secret bearer requests", () => {
+    expect(
+      resolveTrustedHttpOperatorScopes(
+        createReq({ authorization: "Bearer secret", "x-remoteclaw-scopes": "operator.admin" }),
+        tokenAuth,
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("resolveHttpSenderIsOwner", () => {
+  it("requires an explicitly declared operator.admin on a non-shared-secret request", () => {
+    expect(
+      resolveHttpSenderIsOwner(createReq({ "x-remoteclaw-scopes": "operator.admin" }), noneAuth),
+    ).toBe(true);
+    expect(
+      resolveHttpSenderIsOwner(createReq({ "x-remoteclaw-scopes": "operator.write" }), noneAuth),
+    ).toBe(false);
+  });
+
+  it("is false for a header-less non-shared-secret request (#2735)", () => {
+    expect(resolveHttpSenderIsOwner(createReq(), noneAuth)).toBe(false);
+  });
+});
+
+describe("resolveOpenAiCompatibleHttpOperatorScopes (chat.send gate)", () => {
+  it("restores CLI defaults for shared-secret bearer auth", () => {
+    const scopes = resolveOpenAiCompatibleHttpOperatorScopes(
+      createReq({ authorization: "Bearer secret", "x-remoteclaw-scopes": "operator.approvals" }),
+      { authMethod: "token", trustDeclaredOperatorScopes: false },
+    );
+    expect(scopes).toContain(ADMIN_SCOPE);
+    expect(scopes).toContain(WRITE_SCOPE);
+  });
+
+  it("stays permissive (CLI defaults) on a missing header so chat.send still passes (B1, not 403)", () => {
+    const scopes = resolveOpenAiCompatibleHttpOperatorScopes(createReq(), {
+      authMethod: "none",
+      trustDeclaredOperatorScopes: true,
+    });
+    // Method-authz only (never owner): includes WRITE so chat.send is allowed.
+    expect(scopes).toContain(WRITE_SCOPE);
+  });
+
+  it("honors an explicitly declared narrower scope set verbatim", () => {
+    expect(
+      resolveOpenAiCompatibleHttpOperatorScopes(
+        createReq({ "x-remoteclaw-scopes": "operator.write" }),
+        { authMethod: "none", trustDeclaredOperatorScopes: true },
+      ),
+    ).toEqual(["operator.write"]);
+  });
+});
+
+describe("resolveOpenAiCompatibleHttpSenderIsOwner", () => {
+  it("treats shared-secret bearer auth as owner BEFORE consulting scopes", () => {
+    expect(
+      resolveOpenAiCompatibleHttpSenderIsOwner(
+        createReq({ authorization: "Bearer secret", "x-remoteclaw-scopes": "operator.approvals" }),
+        { authMethod: "token", trustDeclaredOperatorScopes: false },
+      ),
+    ).toBe(true);
+  });
+
+  it("is FALSE for an unauthenticated no-header caller (the #2735 hole)", () => {
+    expect(
+      resolveOpenAiCompatibleHttpSenderIsOwner(createReq(), {
+        authMethod: "none",
+        trustDeclaredOperatorScopes: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("is FALSE for a non-admin declared scope, TRUE for an explicit operator.admin", () => {
+    expect(
+      resolveOpenAiCompatibleHttpSenderIsOwner(
+        createReq({ "x-remoteclaw-scopes": "operator.write" }),
+        { authMethod: "trusted-proxy", trustDeclaredOperatorScopes: true },
+      ),
+    ).toBe(false);
+    expect(
+      resolveOpenAiCompatibleHttpSenderIsOwner(
+        createReq({ "x-remoteclaw-scopes": "operator.admin" }),
+        { authMethod: "trusted-proxy", trustDeclaredOperatorScopes: true },
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT auto-grant owner to a header-less trusted-proxy caller", () => {
+    expect(
+      resolveOpenAiCompatibleHttpSenderIsOwner(createReq(), {
+        authMethod: "trusted-proxy",
+        trustDeclaredOperatorScopes: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -8,6 +8,11 @@ import {
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
+import type { GatewayAuthResult, ResolvedGatewayAuth } from "./auth.js";
+import { ADMIN_SCOPE, CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
+
+/** Header by which a non-shared-secret HTTP caller may declare its operator scopes. */
+const OPERATOR_SCOPES_HEADER = "x-remoteclaw-scopes";
 
 /** Brand model id that routes to the configured default agent. */
 export const REMOTECLAW_MODEL_ID = "remoteclaw";
@@ -133,4 +138,173 @@ export function resolveHttpBrowserOriginPolicy(
   _req: IncomingMessage,
 ): { origin?: string; allowed?: boolean } | undefined {
   return undefined;
+}
+
+// --- HTTP auth → operator-scope / owner derivation (#2735) -------------------
+//
+// Restores the dropped owner-authorization control on the OpenAI-compatible HTTP
+// surface. `senderIsOwner` was hardcoded `true`, so an UNAUTHENTICATED caller on
+// an `auth:"none"` gateway was handed owner-level MCP tool authority. These
+// helpers derive operator scopes / owner from the *satisfying* gateway auth
+// method instead. See `resolveTrustedHttpOperatorScopes` for the load-bearing
+// fork-specific divergence from upstream.
+
+/** Minimal auth shape used to detect shared-secret (token/password) HTTP auth. */
+type SharedSecretGatewayAuth = Pick<ResolvedGatewayAuth, "mode">;
+
+/**
+ * The auth context that survives `handleGatewayPostJsonEndpoint`'s success path.
+ * `authMethod` is the method that satisfied the gateway connect check;
+ * `trustDeclaredOperatorScopes` is whether the caller's declared per-request
+ * scopes (the `x-remoteclaw-scopes` header) may be honored — false for
+ * shared-secret bearer auth, which proves possession of the gateway secret but
+ * not a narrower per-request operator identity.
+ */
+export type AuthorizedGatewayHttpRequest = {
+  authMethod?: GatewayAuthResult["method"];
+  trustDeclaredOperatorScopes: boolean;
+};
+
+/** Shared-secret gateway methods (token / password bearer). */
+export function usesSharedSecretGatewayMethod(
+  method: GatewayAuthResult["method"] | undefined,
+): boolean {
+  return method === "token" || method === "password";
+}
+
+function usesSharedSecretHttpAuth(auth: SharedSecretGatewayAuth | undefined): boolean {
+  return auth?.mode === "token" || auth?.mode === "password";
+}
+
+/** A bearer-token request against a shared-secret-configured gateway. */
+export function isGatewayBearerHttpRequest(
+  req: IncomingMessage,
+  auth?: SharedSecretGatewayAuth,
+): boolean {
+  return usesSharedSecretHttpAuth(auth) && Boolean(getBearerToken(req));
+}
+
+function shouldTrustDeclaredHttpOperatorScopes(
+  req: IncomingMessage,
+  authOrRequest:
+    | SharedSecretGatewayAuth
+    | Pick<AuthorizedGatewayHttpRequest, "trustDeclaredOperatorScopes">
+    | undefined,
+): boolean {
+  if (authOrRequest && "trustDeclaredOperatorScopes" in authOrRequest) {
+    return authOrRequest.trustDeclaredOperatorScopes;
+  }
+  return !isGatewayBearerHttpRequest(req, authOrRequest);
+}
+
+/**
+ * Parse the caller's explicitly declared operator scopes from the
+ * `x-remoteclaw-scopes` header. Returns `undefined` when the header is absent
+ * (no declaration), `[]` when present-but-empty (caller declared "no scopes"),
+ * or the parsed list otherwise.
+ */
+function parseDeclaredHttpOperatorScopes(req: IncomingMessage): string[] | undefined {
+  const headerValue = getHeader(req, OPERATOR_SCOPES_HEADER);
+  if (headerValue === undefined) {
+    return undefined;
+  }
+  const raw = headerValue.trim();
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0);
+}
+
+/**
+ * Operator scopes used to derive OWNER authority for an HTTP caller.
+ *
+ * FORK-INTRODUCED SECURITY DIVERGENCE (#2735) — DO NOT "sync back" to upstream
+ * here. Upstream OpenClaw returns `[...CLI_DEFAULT_OPERATOR_SCOPES]` for a
+ * *trusted* (non-shared-secret) request that sends NO `x-*-scopes` header
+ * ("trusted clients without an explicit header get the default operator scopes,
+ * matching pre-#57783 behavior"). Those CLI defaults INCLUDE `operator.admin`,
+ * so upstream INTENTIONALLY grants OWNER to a header-less caller on an
+ * `auth:"none"` gateway — acceptable under upstream's local-trusted CLI model,
+ * but NOT for RemoteClaw, which runs gateways network-exposed over messaging
+ * channels where `auth:"none"` + no-header is the realistic attacker. The fork
+ * therefore returns `[]` (→ NOT owner) on that branch. A future DIFF-SYNC MUST
+ * NOT re-adopt the upstream `CLI_DEFAULT_OPERATOR_SCOPES` fallback on this branch
+ * — doing so silently re-opens the #2735 IDOR. (Parallel to the #2733
+ * re-introduction guard; ADR-0011.)
+ */
+export function resolveTrustedHttpOperatorScopes(
+  req: IncomingMessage,
+  authOrRequest?:
+    | SharedSecretGatewayAuth
+    | Pick<AuthorizedGatewayHttpRequest, "trustDeclaredOperatorScopes">,
+): string[] {
+  if (!shouldTrustDeclaredHttpOperatorScopes(req, authOrRequest)) {
+    // Shared-secret bearer auth proves possession of the gateway secret, not a
+    // narrower per-request operator identity. Don't let those callers self-assert
+    // operator scopes via request headers.
+    return [];
+  }
+  const declared = parseDeclaredHttpOperatorScopes(req);
+  if (declared === undefined) {
+    // #2735 divergence (see fn-level comment): no declared scopes ⇒ NOT owner.
+    return [];
+  }
+  return declared;
+}
+
+/** True when the request's TRUSTED operator scopes include `operator.admin`. */
+export function resolveHttpSenderIsOwner(
+  req: IncomingMessage,
+  authOrRequest?:
+    | SharedSecretGatewayAuth
+    | Pick<AuthorizedGatewayHttpRequest, "trustDeclaredOperatorScopes">,
+): boolean {
+  return resolveTrustedHttpOperatorScopes(req, authOrRequest).includes(ADMIN_SCOPE);
+}
+
+/**
+ * Operator scopes for the OpenAI-compatible surface's METHOD-scope gate
+ * (e.g. `chat.send`). This is method-authorization ONLY — it is NEVER used to
+ * derive owner authority (that is `resolveOpenAiCompatibleHttpSenderIsOwner`).
+ *
+ * It stays permissive on a missing header so a plain OpenAI-SDK chat still works
+ * under `auth:"none"` (the #2735 fix downscopes OWNER, it does NOT reject the
+ * request — that would be the rejected "B2" behavior). Shared-secret bearer auth
+ * is the documented trusted-operator surface for the compat API, so it restores
+ * the CLI defaults. A caller may still voluntarily restrict itself by declaring
+ * a narrower (or empty) `x-remoteclaw-scopes` header.
+ */
+export function resolveOpenAiCompatibleHttpOperatorScopes(
+  req: IncomingMessage,
+  requestAuth: AuthorizedGatewayHttpRequest,
+): string[] {
+  if (usesSharedSecretGatewayMethod(requestAuth.authMethod)) {
+    return [...CLI_DEFAULT_OPERATOR_SCOPES];
+  }
+  const declared = parseDeclaredHttpOperatorScopes(req);
+  return declared === undefined ? [...CLI_DEFAULT_OPERATOR_SCOPES] : declared;
+}
+
+/**
+ * Owner authority for the OpenAI-compatible surface.
+ *
+ * Shared-secret bearer auth also carries owner semantics here: there is no
+ * separate per-request owner primitive on that path, so owner-only tool policy
+ * follows the documented trusted-operator contract. The short-circuit happens
+ * BEFORE consulting declared scopes (so a shared-secret bearer is owner even
+ * when it declares a narrower scope). For non-shared-secret callers (`none` /
+ * `trusted-proxy`), owner requires an explicitly declared `operator.admin`
+ * scope — a header-less or non-admin caller is NOT owner (#2735).
+ */
+export function resolveOpenAiCompatibleHttpSenderIsOwner(
+  req: IncomingMessage,
+  requestAuth: AuthorizedGatewayHttpRequest,
+): boolean {
+  if (usesSharedSecretGatewayMethod(requestAuth.authMethod)) {
+    return true;
+  }
+  return resolveHttpSenderIsOwner(req, requestAuth);
 }

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -167,11 +167,10 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         messages: [{ role: "user", content: message }],
       });
       expect(res.status).toBe(200);
-      // NOTE: the unauthenticated-caller ownership assertion that used to live here
-      // (expecting senderIsOwner === false) is tracked separately in the skipped test
-      // "derives senderIsOwner from request auth on the OpenAI-compat endpoint" below.
-      // The fork currently hardcodes senderIsOwner: true (a dropped authorization
-      // control); this helper now only exercises response-shape behavior.
+      // #2735: the default request carries a non-admin `x-remoteclaw-scopes:
+      // operator.write` header against an `auth:"none"` server, so the caller is
+      // NOT an owner. (Owner derivation is exercised exhaustively below.)
+      expect(getFirstAgentCall()?.senderIsOwner).toBe(false);
       return (await res.json()) as Record<string, unknown>;
     };
 
@@ -611,39 +610,89 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     }
   });
 
-  // SKIPPED — tracks a dropped authorization control on the KEPT OpenAI-compat endpoint.
-  // Upstream derives senderIsOwner from request auth (resolveOpenAiCompatibleHttpSenderIsOwner,
-  // upstream's src/gateway/http-utils.ts:177-189): shared-secret bearer -> owner, otherwise
-  // resolveHttpSenderIsOwner keyed on ADMIN_SCOPE. The fork hardcodes senderIsOwner: true
-  // (src/gateway/openai-http.ts:124), so an unauthenticated caller against an auth:"none"
-  // gateway (a config-reachable posture, src/gateway/auth-resolve.ts:79-81) receives
-  // owner-level tool policy. Restoring this is a HIGH-severity hardening change deferred to a
-  // dedicated PR: it requires (1) surfacing the auth result from the SHARED
-  // handleGatewayPostJsonEndpoint (src/gateway/http-endpoint-helpers.ts:69 currently discards
-  // `authorized`), (2) porting resolveOpenAiCompatibleHttpSenderIsOwner + resolveHttpSenderIsOwner
-  // + usesSharedSecretGatewayMethod + the AuthorizedGatewayHttpRequest type (all absent from the
-  // fork), (3) wiring senderIsOwner into buildAgentCommandInput. Un-skip when that lands.
-  // The shared-secret-bearer -> owner arm is already covered by
-  // "treats shared-secret bearer callers as owner operators" below.
-  it.skip("derives senderIsOwner from request auth on the OpenAI-compat endpoint", async () => {
+  // #2735: owner authority is DERIVED from the satisfying gateway auth method
+  // (resolveOpenAiCompatibleHttpSenderIsOwner), not hardcoded. An unauthenticated
+  // caller on an auth:"none" gateway must NOT be treated as owner. The
+  // shared-secret-bearer -> owner arm is covered by "treats shared-secret bearer
+  // callers as owner operators" below.
+  //
+  // CI-ASSERT ANCHOR — scripts/check-openai-http-owner-derivation.mjs verifies the
+  // test immediately below is present, un-skipped, and still asserts
+  // senderIsOwner === false for the unauthenticated no-header caller. That guard
+  // is what makes green CI a faithful proxy for "the #2735 hole is closed". Do NOT
+  // re-skip it or remove the senderIsOwner === false assertion.
+  it("derives senderIsOwner from request auth on the OpenAI-compat endpoint", async () => {
     const port = await getFreePort();
     const server = await startServer(port);
     try {
       agentCommand.mockClear();
       agentCommand.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
-      const res = await postChatCompletions(port, {
-        model: "remoteclaw",
-        messages: [{ role: "user", content: "hi" }],
+      // Literal unauthenticated caller: auth:"none" server, NO bearer, NO
+      // x-remoteclaw-scopes header — the realistic attack. A faithful upstream
+      // port would MIS-GRANT owner here (no-header -> CLI_DEFAULT_OPERATOR_SCOPES,
+      // which includes operator.admin); the fork diverges to return [] (#2735).
+      const res = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "remoteclaw",
+          messages: [{ role: "user", content: "hi" }],
+        }),
       });
+      // The request must still CHAT (200, not 403): the fix downscopes owner, it
+      // does NOT reject the caller.
       expect(res.status).toBe(200);
       const firstCall = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0] as
         | { senderIsOwner?: boolean }
         | undefined;
-      // Unauthenticated caller (auth:"none" server, no bearer) must NOT be treated as owner.
       expect(firstCall?.senderIsOwner).toBe(false);
       await res.text();
     } finally {
       await server.close({ reason: "openai senderIsOwner auth-derivation test done" });
+    }
+  });
+
+  it("does not treat a non-admin declared scope as owner on an auth:none gateway", async () => {
+    const port = await getFreePort();
+    const server = await startServer(port);
+    try {
+      agentCommand.mockClear();
+      agentCommand.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
+      const res = await postChatCompletions(
+        port,
+        { model: "remoteclaw", messages: [{ role: "user", content: "hi" }] },
+        { "x-remoteclaw-scopes": "operator.write" },
+      );
+      expect(res.status).toBe(200);
+      const firstCall = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0] as
+        | { senderIsOwner?: boolean }
+        | undefined;
+      expect(firstCall?.senderIsOwner).toBe(false);
+      await res.text();
+    } finally {
+      await server.close({ reason: "openai senderIsOwner non-admin scope test done" });
+    }
+  });
+
+  it("treats an explicit operator.admin declared scope as owner on an auth:none gateway", async () => {
+    const port = await getFreePort();
+    const server = await startServer(port);
+    try {
+      agentCommand.mockClear();
+      agentCommand.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
+      const res = await postChatCompletions(
+        port,
+        { model: "remoteclaw", messages: [{ role: "user", content: "hi" }] },
+        { "x-remoteclaw-scopes": "operator.admin" },
+      );
+      expect(res.status).toBe(200);
+      const firstCall = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0] as
+        | { senderIsOwner?: boolean }
+        | undefined;
+      expect(firstCall?.senderIsOwner).toBe(true);
+      await res.text();
+    } finally {
+      await server.close({ reason: "openai senderIsOwner admin scope test done" });
     }
   });
 

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -31,7 +31,11 @@ import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
-import { resolveGatewayRequestContext } from "./http-utils.js";
+import {
+  resolveGatewayRequestContext,
+  resolveOpenAiCompatibleHttpOperatorScopes,
+  resolveOpenAiCompatibleHttpSenderIsOwner,
+} from "./http-utils.js";
 import { normalizeInputHostnameAllowlist } from "./input-allowlist.js";
 
 type OpenAiHttpOptions = {
@@ -109,6 +113,7 @@ function buildAgentCommandInput(params: {
   sessionKey: string;
   runId: string;
   messageChannel: string;
+  senderIsOwner: boolean;
 }) {
   return {
     message: params.prompt.message,
@@ -119,8 +124,13 @@ function buildAgentCommandInput(params: {
     deliver: false as const,
     messageChannel: params.messageChannel,
     bestEffortDeliver: false as const,
-    // HTTP API callers are authenticated operator clients for this gateway context.
-    senderIsOwner: true as const,
+    // #2735: owner authority is DERIVED from the satisfying gateway auth method
+    // (resolveOpenAiCompatibleHttpSenderIsOwner), never hardcoded. Previously
+    // pinned to `true`, which handed owner-only MCP tool families to an
+    // UNAUTHENTICATED caller on an `auth:"none"` gateway. This is a
+    // fork-introduced control (RemoteClaw runs gateways network-exposed); a
+    // future upstream DIFF-SYNC MUST keep this threaded, not re-pin it to true.
+    senderIsOwner: params.senderIsOwner,
   };
 }
 
@@ -419,6 +429,12 @@ export async function handleOpenAiHttpRequest(
   const limits = resolveOpenAiChatCompletionsLimits(opts.config);
   const handled = await handleGatewayPostJsonEndpoint(req, res, {
     pathname: "/v1/chat/completions",
+    requiredOperatorMethod: "chat.send",
+    // Compat HTTP uses a different scope model from the generic HTTP helpers:
+    // shared-secret bearer auth is treated as full operator access, while a
+    // header-less `auth:"none"` caller still passes the method-scope gate (and
+    // chats) — it just isn't an owner (#2735).
+    resolveOperatorScopes: resolveOpenAiCompatibleHttpOperatorScopes,
     auth: opts.auth,
     trustedProxies: opts.trustedProxies,
     allowRealIpFallback: opts.allowRealIpFallback,
@@ -431,6 +447,12 @@ export async function handleOpenAiHttpRequest(
   if (!handled) {
     return true;
   }
+
+  // #2735: derive owner authority from the satisfying gateway auth method rather
+  // than hardcoding it. Shared-secret bearer → owner; otherwise owner only when
+  // the caller explicitly declares operator.admin (unauthenticated `auth:"none"`
+  // callers are NOT owner).
+  const senderIsOwner = resolveOpenAiCompatibleHttpSenderIsOwner(req, handled.requestAuth);
 
   const payload = coerceRequest(handled.body);
   const stream = Boolean(payload.stream);
@@ -482,6 +504,7 @@ export async function handleOpenAiHttpRequest(
     sessionKey,
     runId,
     messageChannel,
+    senderIsOwner,
   });
 
   if (!stream) {

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1,0 +1,98 @@
+import type { IncomingMessage } from "node:http";
+import { beforeAll, describe, expect, it } from "vitest";
+import { resolveOpenAiCompatibleHttpSenderIsOwner } from "./http-utils.js";
+import { agentCommand, getFreePort, installGatewayTestHooks } from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+let startGatewayServer: typeof import("./server.js").startGatewayServer;
+
+beforeAll(async () => {
+  ({ startGatewayServer } = await import("./server.js"));
+});
+
+function createReq(headers: Record<string, string> = {}): IncomingMessage {
+  return { headers } as IncomingMessage;
+}
+
+// #2735: the OpenResponses (/v1/responses) surface threads the SAME auth-derived
+// `senderIsOwner` (resolveOpenAiCompatibleHttpSenderIsOwner) into
+// runResponsesAgentCommand that the chat-completions surface uses. It was
+// previously hardcoded `true`, which would hand owner-only MCP tool families to
+// an unauthenticated caller on an `auth:"none"` gateway.
+//
+// NOTE: the fork's `buildAgentPrompt` (openresponses-prompt.ts) is GUTTED — it
+// returns an empty message — so `/v1/responses` 400s ("Missing user message")
+// BEFORE reaching runResponsesAgentCommand. The owner hardcode was therefore
+// unreachable in the fork today; threading the derived value is correctness +
+// future-proofing for when the prompt builder is restored. Because the e2e path
+// cannot reach the agent dispatch, the owner derivation is asserted here at the
+// unit level (the comprehensive table lives in http-utils.owner-derivation.test.ts).
+describe("OpenResponses HTTP senderIsOwner derivation (#2735)", () => {
+  it("does NOT treat an unauthenticated no-header caller as owner (none)", () => {
+    expect(
+      resolveOpenAiCompatibleHttpSenderIsOwner(createReq(), {
+        authMethod: "none",
+        trustDeclaredOperatorScopes: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does NOT treat a non-admin declared scope as owner (none)", () => {
+    expect(
+      resolveOpenAiCompatibleHttpSenderIsOwner(
+        createReq({ "x-remoteclaw-scopes": "operator.write" }),
+        { authMethod: "none", trustDeclaredOperatorScopes: true },
+      ),
+    ).toBe(false);
+  });
+
+  it("treats an explicit operator.admin declared scope as owner (none)", () => {
+    expect(
+      resolveOpenAiCompatibleHttpSenderIsOwner(
+        createReq({ "x-remoteclaw-scopes": "operator.admin" }),
+        { authMethod: "none", trustDeclaredOperatorScopes: true },
+      ),
+    ).toBe(true);
+  });
+
+  it("treats shared-secret bearer callers as owner regardless of declared scope", () => {
+    expect(
+      resolveOpenAiCompatibleHttpSenderIsOwner(
+        createReq({ "x-remoteclaw-scopes": "operator.approvals" }),
+        { authMethod: "token", trustDeclaredOperatorScopes: false },
+      ),
+    ).toBe(true);
+  });
+
+  // Tripwire: documents the current gutted-endpoint contract. An unauthenticated
+  // caller on an `auth:"none"` gateway never reaches the agent (400), so there is
+  // no owner-tool exposure via /v1/responses today. If `buildAgentPrompt` is
+  // restored (200 path enabled), this test fails loudly — at which point add an
+  // e2e senderIsOwner===false assertion mirroring openai-http.test.ts.
+  it("does not dispatch an unauthenticated /v1/responses caller to the agent (gutted prompt builder)", async () => {
+    const port = await getFreePort();
+    const server = await startGatewayServer(port, {
+      host: "127.0.0.1",
+      auth: { mode: "none" },
+      controlUiEnabled: false,
+      openResponsesEnabled: true,
+    });
+    try {
+      agentCommand.mockClear();
+      const res = await fetch(`http://127.0.0.1:${port}/v1/responses`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "remoteclaw",
+          input: [{ type: "message", role: "user", content: "hi" }],
+        }),
+      });
+      expect(res.status).toBe(400);
+      expect(agentCommand).toHaveBeenCalledTimes(0);
+      await res.text();
+    } finally {
+      await server.close({ reason: "openresponses gutted-endpoint contract test done" });
+    }
+  });
+});

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -35,7 +35,10 @@ import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
-import { resolveGatewayRequestContext } from "./http-utils.js";
+import {
+  resolveGatewayRequestContext,
+  resolveOpenAiCompatibleHttpSenderIsOwner,
+} from "./http-utils.js";
 import { normalizeInputHostnameAllowlist } from "./input-allowlist.js";
 import {
   CreateResponseBodySchema,
@@ -244,6 +247,7 @@ async function runResponsesAgentCommand(params: {
   sessionKey: string;
   runId: string;
   messageChannel: string;
+  senderIsOwner: boolean;
   deps: ReturnType<typeof createDefaultDeps>;
 }) {
   return agentCommandFromIngress(
@@ -258,8 +262,12 @@ async function runResponsesAgentCommand(params: {
       deliver: false,
       messageChannel: params.messageChannel,
       bestEffortDeliver: false,
-      // HTTP API callers are authenticated operator clients for this gateway context.
-      senderIsOwner: true,
+      // #2735: owner authority is DERIVED from the satisfying gateway auth method
+      // (resolveOpenAiCompatibleHttpSenderIsOwner), never hardcoded. Previously
+      // pinned to `true`, handing owner-only MCP tool families to an
+      // UNAUTHENTICATED caller on an `auth:"none"` gateway. Fork-introduced
+      // control — a future upstream DIFF-SYNC MUST keep this threaded.
+      senderIsOwner: params.senderIsOwner,
     },
     defaultRuntime,
     params.deps,
@@ -291,6 +299,12 @@ export async function handleOpenResponsesHttpRequest(
   if (!handled) {
     return true;
   }
+
+  // #2735: derive owner authority from the satisfying gateway auth method rather
+  // than hardcoding it (see runResponsesAgentCommand). Shared-secret bearer →
+  // owner; otherwise owner only when the caller explicitly declares
+  // operator.admin (unauthenticated `auth:"none"` callers are NOT owner).
+  const senderIsOwner = resolveOpenAiCompatibleHttpSenderIsOwner(req, handled.requestAuth);
 
   // Validate request body with Zod
   const parseResult = CreateResponseBodySchema.safeParse(handled.body);
@@ -479,6 +493,7 @@ export async function handleOpenResponsesHttpRequest(
         sessionKey,
         runId: responseId,
         messageChannel,
+        senderIsOwner,
         deps,
       });
 
@@ -711,6 +726,7 @@ export async function handleOpenResponsesHttpRequest(
         sessionKey,
         runId: responseId,
         messageChannel,
+        senderIsOwner,
         deps,
       });
 

--- a/src/gateway/owner-derivation-guard.test.ts
+++ b/src/gateway/owner-derivation-guard.test.ts
@@ -1,0 +1,30 @@
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #2735 CI-assert meta-guard. Runs the standalone owner-derivation gate
+// (scripts/check-openai-http-owner-derivation.mjs) inside the gateway test lane
+// so "green test-gateway" stays a FAITHFUL proxy for "the
+// unauthenticated-none-no-header senderIsOwner:false invariant is still
+// asserted". If the openai-http.test.ts anchor is removed, skipped, or stops
+// asserting not-owner, the gate exits non-zero, execFileSync throws, and this
+// fails loudly — the IDOR hole could otherwise silently re-open (e.g. on an
+// upstream sync) with CI staying green. Running the real script (vs duplicating
+// its logic here) keeps the gate single-sourced.
+const guardScript = fileURLToPath(
+  new URL("../../scripts/check-openai-http-owner-derivation.mjs", import.meta.url),
+);
+
+describe("#2735 owner-derivation guard", () => {
+  it("openai-http anchor test is present, un-skipped, and asserts senderIsOwner:false", () => {
+    let stdout = "";
+    try {
+      stdout = execFileSync(process.execPath, [guardScript], { stdio: "pipe", encoding: "utf8" });
+    } catch (caught) {
+      const err = caught as { stderr?: string; message?: string };
+      const detail = err.stderr?.trim() || err.message || "guard subprocess failed";
+      throw new Error(`#2735 owner-derivation guard failed:\n${detail}`, { cause: caught });
+    }
+    expect(stdout).toContain("#2735 owner-derivation guard");
+  });
+});

--- a/src/gateway/server.plugin-gateway-auth-tripwire.test.ts
+++ b/src/gateway/server.plugin-gateway-auth-tripwire.test.ts
@@ -233,34 +233,47 @@ function callsSymbol(sf: ts.SourceFile, name: string): boolean {
 }
 
 /**
- * True when an `authorizeHttpGatewayConnect({ ... })` call in the module forwards
- * a `rateLimiter` property — the wiring that actually feeds the per-origin
- * limiter into the bearer-auth path. A sync that kept the call but dropped this
- * property would disable per-origin brute-force protection while every
- * call-presence assertion below still passed green.
+ * True when EVERY `authorizeHttpGatewayConnect({ ... })` call in the module
+ * forwards a `rateLimiter` property — the wiring that actually feeds the
+ * per-origin limiter into the bearer-auth path. A sync that kept a call but
+ * dropped this property would disable per-origin brute-force protection while
+ * every call-presence assertion below still passed green.
+ *
+ * #2735 split the chokepoint into two wrappers in this module
+ * (authorizeGatewayBearerRequestOrReply + authorizeGatewayHttpRequestOrReply);
+ * requiring ALL calls to forward the limiter (not merely one) keeps the check
+ * honest now that more than one such call exists — otherwise one wrapper could
+ * silently lose its limiter while the other masks it.
  */
 function authConnectForwardsRateLimiter(sf: ts.SourceFile): boolean {
-  let forwarded = false;
+  let callCount = 0;
+  let allForward = true;
   const visit = (node: ts.Node) => {
     if (
       ts.isCallExpression(node) &&
       ts.isIdentifier(node.expression) &&
       node.expression.text === "authorizeHttpGatewayConnect"
     ) {
+      callCount += 1;
       const arg = node.arguments[0];
-      if (arg && ts.isObjectLiteralExpression(arg)) {
-        forwarded ||= arg.properties.some(
+      const forwards =
+        arg !== undefined &&
+        ts.isObjectLiteralExpression(arg) &&
+        arg.properties.some(
           (p) =>
             (ts.isPropertyAssignment(p) || ts.isShorthandPropertyAssignment(p)) &&
             ts.isIdentifier(p.name) &&
             p.name.text === "rateLimiter",
         );
+      if (!forwards) {
+        allForward = false;
       }
     }
     ts.forEachChild(node, visit);
   };
   visit(sf);
-  return forwarded;
+  // Non-degenerate: at least one chokepoint call must exist AND all forward it.
+  return callCount > 0 && allForward;
 }
 
 type ControlWiring = {
@@ -296,11 +309,29 @@ const WIRED_GATEWAY_AUTH_CONTROLS: ControlWiring[] = [
     callSiteImportsSymbol: true,
   },
   {
-    control: "per-origin rate-limit + bearer-auth chokepoint",
-    symbol: "authorizeGatewayBearerRequestOrReply",
+    // #2735: the JSON-POST endpoints (OpenAI-compat /v1/chat/completions and
+    // /v1/responses) authorize via authorizeGatewayHttpRequestOrReply, which
+    // surfaces the satisfying auth method for owner-derivation while preserving
+    // the SAME per-origin rate-limit + bearer-auth (it forwards `rateLimiter`
+    // into authorizeHttpGatewayConnect, asserted below). It REPLACED
+    // authorizeGatewayBearerRequestOrReply at this call site under the approved
+    // #2735 design + security review; per this file's header the row is
+    // RE-POINTED to the new chokepoint, never deleted.
+    control: "per-origin rate-limit + bearer-auth chokepoint (JSON POST endpoints)",
+    symbol: "authorizeGatewayHttpRequestOrReply",
     defModule: "http-auth-helpers.ts",
     defExported: true,
     callSiteModule: "http-endpoint-helpers.ts",
+    callSiteImportsSymbol: true,
+  },
+  {
+    // The boolean bearer chokepoint stays the live control for the tools-invoke
+    // HTTP endpoint, which needs only an allow/deny decision (no owner-derivation).
+    control: "per-origin rate-limit + bearer-auth chokepoint (tools-invoke endpoint)",
+    symbol: "authorizeGatewayBearerRequestOrReply",
+    defModule: "http-auth-helpers.ts",
+    defExported: true,
+    callSiteModule: "tools-invoke-http.ts",
     callSiteImportsSymbol: true,
   },
   {
@@ -337,15 +368,18 @@ describe("gateway-auth control wiring guard (#2724, positive-presence-AND-wiring
   it("pins the control COUNT so a silently dropped row fails loudly (degenerate-subject gate)", () => {
     // If a future edit deletes a row to "make the suite green" after a de-wire,
     // this fails instead. Bump it ONLY when intentionally adding/removing a
-    // guarded control — never to silence a real de-wiring.
-    expect(WIRED_GATEWAY_AUTH_CONTROLS).toHaveLength(4);
+    // guarded control — never to silence a real de-wiring. (#2735 took this 4→5:
+    // the JSON-endpoint chokepoint split into authorizeGatewayHttpRequestOrReply
+    // (compat endpoints) + authorizeGatewayBearerRequestOrReply (tools-invoke).)
+    expect(WIRED_GATEWAY_AUTH_CONTROLS).toHaveLength(5);
   });
 
-  it("keeps the per-origin rate limiter threaded through the bearer-auth chokepoint", () => {
-    // authorizeGatewayBearerRequestOrReply is the single HTTP auth chokepoint;
-    // it must forward `rateLimiter` into authorizeHttpGatewayConnect. The
-    // call-presence row above proves the chokepoint stays wired; this proves the
-    // limiter is still fed INTO it.
+  it("keeps the per-origin rate limiter threaded through every bearer-auth chokepoint", () => {
+    // http-auth-helpers.ts hosts the HTTP auth chokepoint wrappers
+    // (authorizeGatewayBearerRequestOrReply + authorizeGatewayHttpRequestOrReply
+    // since #2735); each must forward `rateLimiter` into authorizeHttpGatewayConnect.
+    // The call-presence rows above prove the chokepoints stay wired; this proves
+    // the limiter is still fed INTO every one of them.
     expect(authConnectForwardsRateLimiter(parseGatewayModule("http-auth-helpers.ts"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

`buildAgentCommandInput` (`openai-http.ts`) and `runResponsesAgentCommand`
(`openresponses-http.ts`) hardcoded `senderIsOwner: true`, granting **owner-level
MCP tool authority to UNAUTHENTICATED callers** on an `auth:"none"` gateway — an
IDOR-class authorization gap. Owner authority is now **derived** from the gateway
auth method that satisfied the connect check.

Closes #2735

### Resulting derivation

| Auth on the OpenAI-compat surface | `senderIsOwner` |
|---|---|
| `token` / `password` (shared-secret bearer) | **true** (short-circuit, before consulting declared scopes) |
| `none` / `trusted-proxy` + explicit `x-remoteclaw-scopes: operator.admin` | **true** |
| `none` / `trusted-proxy` + **no** `x-remoteclaw-scopes` header | **false** ⬅ the fix |
| `none` / `trusted-proxy` + non-admin declared scopes | **false** |

A header-less `auth:"none"` chat call still **works** (200, not 403): the
`chat.send` method-scope gate stays permissive — the fix downscopes *owner*, it
does not reject the caller.

## ⚠️ This owner-derivation is a FORK-INTRODUCED divergence — do NOT "sync back"

Upstream OpenClaw, for a *trusted* (non-shared-secret) request that sends **no**
`x-*-scopes` header, returns `CLI_DEFAULT_OPERATOR_SCOPES` (which **includes**
`operator.admin`) — i.e. upstream **intentionally grants owner** to a header-less
caller on `auth:"none"` (matching pre-#57783 "trusted local CLI" behavior).

RemoteClaw runs gateways **network-exposed over messaging channels**, where
`auth:"none"` + no-header is the realistic attacker, not a trusted local CLI.
The fork therefore **deliberately returns `[]` (→ NOT owner)** on the
non-shared-secret no-header path, in `resolveTrustedHttpOperatorScopes`
(`http-utils.ts`).

**This is a deliberate hardening divergence, NOT a restored upstream control.**
A future DIFF-SYNC **MUST NOT** re-adopt upstream's
no-header → `CLI_DEFAULT_OPERATOR_SCOPES` branch — doing so silently re-opens
this IDOR. The divergence is guarded three ways (parallel to the #2733
re-introduction guard; ADR-0011):

1. A function-level `FORK-INTRODUCED SECURITY DIVERGENCE (#2735)` comment in
   `http-utils.ts` documenting the upstream posture and why the fork differs.
2. A unit table (`http-utils.owner-derivation.test.ts`) pinning the
   `no-header → []` branch and the gate-vs-owner split.
3. A **CI-assert guard** (`scripts/check-openai-http-owner-derivation.mjs` + a
   gateway meta-test `owner-derivation-guard.test.ts`) that fails if the
   literal unauthenticated-no-header `senderIsOwner:false` anchor test is
   removed, skipped, or stops asserting not-owner — so green CI stays a faithful
   proxy for "the hole is closed".

## Changes

- **`http-utils.ts`**: ported trust-gate machinery into the fork's consolidated
  layout — `resolveTrustedHttpOperatorScopes` (the divergence),
  `resolveHttpSenderIsOwner`, and the OpenAI-compat resolvers
  (`resolveOpenAiCompatibleHttpOperatorScopes` = method-scope gate, stays
  permissive on no-header; `resolveOpenAiCompatibleHttpSenderIsOwner` = owner,
  strict). `usesSharedSecretGatewayMethod` distinguishes the bearer short-circuit.
- **`http-auth-helpers.ts`**: new `authorizeGatewayHttpRequestOrReply` surfaces
  the satisfying auth method (`AuthorizedGatewayHttpRequest`) so owner-derivation
  can run; the boolean `authorizeGatewayBearerRequestOrReply` is **retained** for
  `tools-invoke-http` (allow/deny only).
- **`http-endpoint-helpers.ts`**: threads `requestAuth` back to callers and
  accepts a `resolveOperatorScopes` override for the compat scope model.
- **`openai-http.ts` / `openresponses-http.ts`**: derive `senderIsOwner` from
  `requestAuth` and thread it into the agent command (no more hardcoded `true`).
  `tools-invoke-http.ts` is **unchanged**.
- **#2724 auth-wiring tripwire** (`server.plugin-gateway-auth-tripwire.test.ts`):
  re-pointed the JSON-endpoint chokepoint row to the new
  `authorizeGatewayHttpRequestOrReply` and **added** a row for the bearer
  chokepoint's remaining `tools-invoke-http` call site (count 4 → 5);
  strengthened the rate-limiter-threading check to require *every* chokepoint
  wrapper forward the limiter.

## Validation

- Full gateway lane green: **146 files, 1605 passed, 6 skipped, 0 failed**
  (`vitest run --config vitest.gateway.config.ts --pool=forks`).
- `pnpm check` (oxfmt + tsgo + oxlint + custom lints) green.
- Fork-integrity gates green: rebrand, zombie-import, stub-debt
  (zero `@ts-expect-error`), throwing-stub-callers.
- The CI-assert guard was negative-tested against skip / `xit` / `it.only` /
  renamed-anchor / flipped-assertion mutations — all correctly fail the gate.
- No `src/middleware/` changes, so the LIVE smoke lane is not required.

> **Do NOT merge from here.** Per the orchestration plan, the orchestrator
> verifies the no-header hole is closed + the literal-no-header test + the
> CI-assert guard, then merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
