### PR TITLE
feat(gateway): reject ambiguous cron announce delivery at create/update (#2750)

### DIFF
--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -1,3 +1,4 @@
+import { loadConfig } from "../../config/config.js";
 import { normalizeCronJobCreate, normalizeCronJobPatch } from "../../cron/normalize.js";
 import {
   readCronRunLogEntriesPage,
@@ -5,9 +6,10 @@ import {
   resolveCronRunLogPath,
 } from "../../cron/run-log.js";
 import { isInvalidCronSessionTargetIdError } from "../../cron/session-target.js";
-import type { CronJobCreate, CronJobPatch } from "../../cron/types.js";
+import type { CronDelivery, CronJobCreate, CronJobPatch } from "../../cron/types.js";
 import { validateScheduleTimestamp } from "../../cron/validate-timestamp.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { listConfiguredAnnounceChannelIds } from "../../infra/outbound/channel-selection.js";
 import {
   ErrorCodes,
   errorShape,
@@ -21,6 +23,12 @@ import {
   validateCronUpdateParams,
   validateWakeParams,
 } from "../protocol/index.js";
+import {
+  assertValidCronCreateDelivery,
+  assertValidCronUpdateDelivery,
+  type CronDeliveryValidationInput,
+  isCronDeliveryValidationError,
+} from "./cron.validation.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 export const cronHandlers: GatewayRequestHandlers = {
@@ -133,6 +141,20 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    try {
+      const configuredAnnounceChannelIds = await listConfiguredAnnounceChannelIds(loadConfig());
+      assertValidCronCreateDelivery(jobCreate, configuredAnnounceChannelIds);
+    } catch (err) {
+      if (isCronDeliveryValidationError(err)) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, `invalid cron.add params: ${err.message}`),
+        );
+        return;
+      }
+      throw err;
+    }
     const job = await context.cron.add(jobCreate);
     context.logGateway.info("cron: job created", { jobId: job.id, schedule: jobCreate.schedule });
     respond(true, job, undefined);
@@ -191,6 +213,33 @@ export const cronHandlers: GatewayRequestHandlers = {
           errorShape(ErrorCodes.INVALID_REQUEST, timestampValidation.message),
         );
         return;
+      }
+    }
+    if (patch.delivery !== undefined) {
+      const existing = context.cron.getJob(jobId);
+      if (existing) {
+        // Validate the effective delivery the patch will persist (shallow merge
+        // over the existing delivery), so a partial patch that keeps an existing
+        // explicit channel is not flagged as ambiguous.
+        const effectiveJob: CronDeliveryValidationInput = {
+          sessionTarget: patch.sessionTarget ?? existing.sessionTarget,
+          payload: existing.payload,
+          delivery: { ...existing.delivery, ...patch.delivery } as CronDelivery,
+        };
+        try {
+          const configuredAnnounceChannelIds = await listConfiguredAnnounceChannelIds(loadConfig());
+          assertValidCronUpdateDelivery(effectiveJob, configuredAnnounceChannelIds);
+        } catch (err) {
+          if (isCronDeliveryValidationError(err)) {
+            respond(
+              false,
+              undefined,
+              errorShape(ErrorCodes.INVALID_REQUEST, `invalid cron.update params: ${err.message}`),
+            );
+            return;
+          }
+          throw err;
+        }
       }
     }
     const job = await context.cron.update(jobId, patch);

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import type { CronDelivery, CronPayload, CronSessionTarget } from "../../cron/types.js";
+import {
+  assertValidCronAnnounceDelivery,
+  assertValidCronCreateDelivery,
+  assertValidCronUpdateDelivery,
+  CronDeliveryValidationError,
+  type CronDeliveryValidationInput,
+  isCronDeliveryValidationError,
+} from "./cron.validation.js";
+
+const AGENT_TURN: CronPayload = { kind: "agentTurn", message: "hello" };
+const SYSTEM_EVENT: CronPayload = { kind: "systemEvent", text: "hello" };
+
+function job(params: {
+  sessionTarget?: CronSessionTarget;
+  payload?: CronPayload;
+  delivery?: CronDelivery;
+}): CronDeliveryValidationInput {
+  return {
+    sessionTarget: params.sessionTarget ?? "isolated",
+    payload: params.payload ?? AGENT_TURN,
+    delivery: params.delivery,
+  };
+}
+
+const TWO_CHANNELS = ["telegram", "slack"];
+const ONE_CHANNEL = ["telegram"];
+const NO_CHANNELS: string[] = [];
+
+describe("assertValidCronCreateDelivery", () => {
+  describe("ambiguous announce delivery is rejected when multiple channels are configured", () => {
+    it("rejects an explicit announce delivery without a channel", () => {
+      expect(() =>
+        assertValidCronCreateDelivery(job({ delivery: { mode: "announce" } }), TWO_CHANNELS),
+      ).toThrow(CronDeliveryValidationError);
+    });
+
+    it('rejects an announce delivery whose channel is "last"', () => {
+      expect(() =>
+        assertValidCronCreateDelivery(
+          job({ delivery: { mode: "announce", channel: "last" } }),
+          TWO_CHANNELS,
+        ),
+      ).toThrow(/delivery\.channel is ambiguous/);
+    });
+
+    it("rejects an implicit announce delivery (isolated agentTurn, no delivery)", () => {
+      expect(() =>
+        assertValidCronCreateDelivery(
+          job({ sessionTarget: "isolated", payload: AGENT_TURN }),
+          TWO_CHANNELS,
+        ),
+      ).toThrow(CronDeliveryValidationError);
+    });
+
+    it("rejects an ambiguous failure destination", () => {
+      expect(() =>
+        assertValidCronCreateDelivery(
+          job({
+            delivery: {
+              mode: "announce",
+              channel: "telegram",
+              to: "123",
+              failureDestination: { mode: "announce" },
+            },
+          }),
+          TWO_CHANNELS,
+        ),
+      ).toThrow(/delivery\.failureDestination\.channel is ambiguous/);
+    });
+
+    it("lists the configured channels (sorted) in the error message", () => {
+      try {
+        assertValidCronCreateDelivery(job({ delivery: { mode: "announce" } }), [
+          "slack",
+          "telegram",
+        ]);
+        throw new Error("expected validation to throw");
+      } catch (err) {
+        expect(isCronDeliveryValidationError(err)).toBe(true);
+        expect((err as CronDeliveryValidationError).message).toContain("slack, telegram");
+      }
+    });
+  });
+
+  describe("unambiguous or single-channel deliveries are accepted", () => {
+    it("accepts a named channel even with multiple channels configured", () => {
+      expect(() =>
+        assertValidCronCreateDelivery(
+          job({ delivery: { mode: "announce", channel: "telegram", to: "123" } }),
+          TWO_CHANNELS,
+        ),
+      ).not.toThrow();
+    });
+
+    it("accepts an absent channel when only one channel is configured", () => {
+      expect(() =>
+        assertValidCronCreateDelivery(job({ delivery: { mode: "announce" } }), ONE_CHANNEL),
+      ).not.toThrow();
+    });
+
+    it("accepts an absent channel when no channels are configured", () => {
+      expect(() =>
+        assertValidCronCreateDelivery(job({ delivery: { mode: "announce" } }), NO_CHANNELS),
+      ).not.toThrow();
+    });
+
+    it("accepts a named failure destination channel", () => {
+      expect(() =>
+        assertValidCronCreateDelivery(
+          job({
+            delivery: {
+              mode: "announce",
+              channel: "telegram",
+              to: "123",
+              failureDestination: { mode: "announce", channel: "slack", to: "456" },
+            },
+          }),
+          TWO_CHANNELS,
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  describe("non-announce deliveries carry no announce channel", () => {
+    it("accepts webhook delivery regardless of configured channels", () => {
+      expect(() =>
+        assertValidCronCreateDelivery(
+          job({ delivery: { mode: "webhook", to: "https://example.invalid/hook" } }),
+          TWO_CHANNELS,
+        ),
+      ).not.toThrow();
+    });
+
+    it("accepts a webhook failure destination without a channel", () => {
+      expect(() =>
+        assertValidCronCreateDelivery(
+          job({
+            delivery: {
+              mode: "announce",
+              channel: "telegram",
+              to: "123",
+              failureDestination: { mode: "webhook", to: "https://example.invalid/fail" },
+            },
+          }),
+          TWO_CHANNELS,
+        ),
+      ).not.toThrow();
+    });
+
+    it('accepts delivery mode "none"', () => {
+      expect(() =>
+        assertValidCronCreateDelivery(job({ delivery: { mode: "none" } }), TWO_CHANNELS),
+      ).not.toThrow();
+    });
+  });
+
+  describe("announce delivery is only validated for isolated-like session targets", () => {
+    it("skips main session targets (announce delivery is rejected/stripped elsewhere)", () => {
+      expect(() =>
+        assertValidCronCreateDelivery(
+          job({ sessionTarget: "main", payload: SYSTEM_EVENT, delivery: { mode: "announce" } }),
+          TWO_CHANNELS,
+        ),
+      ).not.toThrow();
+    });
+
+    it("validates current session targets", () => {
+      expect(() =>
+        assertValidCronCreateDelivery(
+          job({ sessionTarget: "current", delivery: { mode: "announce" } }),
+          TWO_CHANNELS,
+        ),
+      ).toThrow(CronDeliveryValidationError);
+    });
+
+    it("validates session:<id> targets", () => {
+      expect(() =>
+        assertValidCronCreateDelivery(
+          job({ sessionTarget: "session:project-alpha", delivery: { mode: "announce" } }),
+          TWO_CHANNELS,
+        ),
+      ).toThrow(CronDeliveryValidationError);
+    });
+
+    it("does not treat a main systemEvent job (no delivery) as implicit announce", () => {
+      expect(() =>
+        assertValidCronCreateDelivery(
+          job({ sessionTarget: "main", payload: SYSTEM_EVENT, delivery: undefined }),
+          TWO_CHANNELS,
+        ),
+      ).not.toThrow();
+    });
+  });
+});
+
+describe("assertValidCronUpdateDelivery", () => {
+  it("rejects an ambiguous announce delivery in the merged patch", () => {
+    expect(() =>
+      assertValidCronUpdateDelivery(
+        job({ delivery: { mode: "announce", channel: "last" } }),
+        TWO_CHANNELS,
+      ),
+    ).toThrow(CronDeliveryValidationError);
+  });
+
+  it("accepts a named channel in the merged patch", () => {
+    expect(() =>
+      assertValidCronUpdateDelivery(
+        job({ delivery: { mode: "announce", channel: "telegram", to: "123" } }),
+        TWO_CHANNELS,
+      ),
+    ).not.toThrow();
+  });
+
+  it("does not infer implicit announce for updates (no delivery object)", () => {
+    expect(() =>
+      assertValidCronUpdateDelivery(
+        job({ sessionTarget: "isolated", payload: AGENT_TURN, delivery: undefined }),
+        TWO_CHANNELS,
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("assertValidCronAnnounceDelivery", () => {
+  it("honors the includeImplicit flag", () => {
+    const isolatedNoDelivery = job({ sessionTarget: "isolated", payload: AGENT_TURN });
+    expect(() =>
+      assertValidCronAnnounceDelivery(isolatedNoDelivery, TWO_CHANNELS, { includeImplicit: false }),
+    ).not.toThrow();
+    expect(() =>
+      assertValidCronAnnounceDelivery(isolatedNoDelivery, TWO_CHANNELS, { includeImplicit: true }),
+    ).toThrow(CronDeliveryValidationError);
+  });
+});
+
+describe("isCronDeliveryValidationError", () => {
+  it("identifies CronDeliveryValidationError instances", () => {
+    expect(isCronDeliveryValidationError(new CronDeliveryValidationError("x"))).toBe(true);
+  });
+
+  it("rejects other error types", () => {
+    expect(isCronDeliveryValidationError(new Error("x"))).toBe(false);
+    expect(isCronDeliveryValidationError(null)).toBe(false);
+  });
+});

--- a/src/gateway/server-methods/cron.validation.ts
+++ b/src/gateway/server-methods/cron.validation.ts
@@ -1,0 +1,202 @@
+import type {
+  CronDelivery,
+  CronFailureDestination,
+  CronMessageChannel,
+  CronPayload,
+  CronSessionTarget,
+} from "../../cron/types.js";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "../../shared/string-coerce.js";
+
+/**
+ * Thrown when a cron job's announce delivery target cannot be resolved
+ * unambiguously at create/update time. The gateway cron handlers translate this
+ * into an INVALID_REQUEST response so the caller learns immediately instead of
+ * the job failing (or delivering to the wrong place) at fire time. See #2750.
+ */
+export class CronDeliveryValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CronDeliveryValidationError";
+  }
+}
+
+export function isCronDeliveryValidationError(
+  value: unknown,
+): value is CronDeliveryValidationError {
+  return value instanceof CronDeliveryValidationError;
+}
+
+/**
+ * An absent or `"last"` announce channel is an ambiguous reference: at fire time
+ * it resolves to the single configured channel, but with more than one channel
+ * configured there is no unambiguous target (mirrors
+ * `infra/outbound/channel-selection.ts`).
+ */
+const AMBIGUOUS_CHANNEL = "last";
+
+/** The minimal job shape the announce-delivery validator inspects. */
+export type CronDeliveryValidationInput = {
+  sessionTarget: CronSessionTarget;
+  payload?: CronPayload | undefined;
+  delivery?: CronDelivery | undefined;
+};
+
+type AnnounceTarget = {
+  /** Field path used in the validation error message. */
+  label: string;
+  /** Effective announce channel (`"last"` when absent/unspecified). */
+  channel: CronMessageChannel;
+};
+
+function normalizeChannel(value: unknown): CronMessageChannel | undefined {
+  const normalized = normalizeOptionalLowercaseString(value);
+  return normalized ? (normalized as CronMessageChannel) : undefined;
+}
+
+/**
+ * Announce channel delivery is only honored for isolated-like session targets;
+ * `main` jobs reject it at create (`assertDeliverySupport`) and strip it at
+ * update (`applyJobPatch`), so there is no announce channel to validate there.
+ */
+function isIsolatedLikeSessionTarget(sessionTarget: CronSessionTarget): boolean {
+  return (
+    sessionTarget === "isolated" ||
+    sessionTarget === "current" ||
+    sessionTarget.startsWith("session:")
+  );
+}
+
+function failureDestinationHasMeaningfulFields(
+  failureDestination: CronFailureDestination,
+): boolean {
+  return Boolean(
+    normalizeChannel(failureDestination.channel) ||
+    normalizeOptionalString(failureDestination.to) ||
+    normalizeOptionalString(failureDestination.accountId) ||
+    normalizeOptionalLowercaseString(failureDestination.mode),
+  );
+}
+
+/**
+ * Collect the announce delivery targets (primary delivery + failure
+ * destination) whose channel must resolve unambiguously.
+ *
+ * Mirrors the fork's runtime delivery resolution (`src/cron/delivery.ts`
+ * `resolveCronDeliveryPlan` / `resolveFailureDestination`) and persistence rules
+ * (`src/cron/service/jobs.ts`): an absent announce channel resolves to `"last"`,
+ * a `webhook`/`none` target carries no announce channel, and announce delivery
+ * applies only to isolated-like session targets.
+ */
+function collectAnnounceTargets(
+  job: CronDeliveryValidationInput,
+  options: { includeImplicit: boolean },
+): AnnounceTarget[] {
+  const targets: AnnounceTarget[] = [];
+  const delivery = job.delivery;
+  const hasDelivery = Boolean(delivery && typeof delivery === "object");
+
+  if (!hasDelivery) {
+    // Implicit announce: an isolated agentTurn with no delivery config defaults
+    // to announce delivery at create time (`resolveInitialCronDelivery`).
+    if (
+      options.includeImplicit &&
+      job.sessionTarget === "isolated" &&
+      job.payload?.kind === "agentTurn"
+    ) {
+      targets.push({ label: "delivery.channel", channel: AMBIGUOUS_CHANNEL });
+    }
+    return targets;
+  }
+
+  if (!isIsolatedLikeSessionTarget(job.sessionTarget)) {
+    return targets;
+  }
+
+  const resolved = delivery as CronDelivery;
+  const mode = normalizeOptionalLowercaseString(resolved.mode);
+  if (mode !== "none" && mode !== "webhook") {
+    // "announce", "deliver", or unspecified — all resolve to announce delivery.
+    targets.push({
+      label: "delivery.channel",
+      channel: normalizeChannel(resolved.channel) ?? AMBIGUOUS_CHANNEL,
+    });
+  }
+
+  const failureDestination = resolved.failureDestination;
+  if (
+    failureDestination &&
+    typeof failureDestination === "object" &&
+    failureDestinationHasMeaningfulFields(failureDestination)
+  ) {
+    const failureMode = normalizeOptionalLowercaseString(failureDestination.mode);
+    if (failureMode !== "webhook") {
+      targets.push({
+        label: "delivery.failureDestination.channel",
+        channel: normalizeChannel(failureDestination.channel) ?? AMBIGUOUS_CHANNEL,
+      });
+    }
+  }
+
+  return targets;
+}
+
+function assertAnnounceTargetsUnambiguous(
+  targets: readonly AnnounceTarget[],
+  configuredAnnounceChannelIds: readonly string[],
+): void {
+  if (configuredAnnounceChannelIds.length <= 1) {
+    // Zero or one configured channel always resolves unambiguously.
+    return;
+  }
+  for (const target of targets) {
+    if (target.channel === AMBIGUOUS_CHANNEL) {
+      const sorted = [...configuredAnnounceChannelIds].toSorted();
+      throw new CronDeliveryValidationError(
+        `${target.label} is ambiguous because multiple channels are configured ` +
+          `(${sorted.join(", ")}). Set ${target.label} explicitly to one of them.`,
+      );
+    }
+  }
+}
+
+/**
+ * Throw a {@link CronDeliveryValidationError} when a job's announce delivery (or
+ * failure destination) channel is absent/`"last"` while more than one channel is
+ * configured. Named channels and single/zero-channel setups are always accepted.
+ *
+ * @param options.includeImplicit when true, an isolated agentTurn with no
+ *   delivery config is treated as an implicit announce delivery (matching create
+ *   time). Updates pass `false` because they validate the explicit merged
+ *   delivery only.
+ */
+export function assertValidCronAnnounceDelivery(
+  job: CronDeliveryValidationInput,
+  configuredAnnounceChannelIds: readonly string[],
+  options: { includeImplicit: boolean },
+): void {
+  const targets = collectAnnounceTargets(job, options);
+  assertAnnounceTargetsUnambiguous(targets, configuredAnnounceChannelIds);
+}
+
+/** `cron.add` guard: validates the normalized job being created. */
+export function assertValidCronCreateDelivery(
+  job: CronDeliveryValidationInput,
+  configuredAnnounceChannelIds: readonly string[],
+): void {
+  assertValidCronAnnounceDelivery(job, configuredAnnounceChannelIds, {
+    includeImplicit: true,
+  });
+}
+
+/** `cron.update` guard: validates the effective delivery after the patch merge. */
+export function assertValidCronUpdateDelivery(
+  job: CronDeliveryValidationInput,
+  configuredAnnounceChannelIds: readonly string[],
+): void {
+  assertValidCronAnnounceDelivery(job, configuredAnnounceChannelIds, {
+    includeImplicit: false,
+  });
+}

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -627,6 +627,74 @@ describe("gateway server cron", () => {
     }
   });
 
+  test("rejects ambiguous announce delivery when multiple channels are configured", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "remoteclaw-gw-cron-announce-ambiguity-",
+      cronEnabled: false,
+    });
+
+    await writeCronConfig({
+      session: {
+        mainKey: "main",
+      },
+      channels: {
+        telegram: {
+          botToken: "telegram-token",
+        },
+        slack: {
+          botToken: "xoxb-slack-token",
+          appToken: "xapp-slack-token",
+        },
+      },
+    });
+
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      // Absent announce channel with two configured channels is ambiguous.
+      const ambiguousAddRes = await rpcReq(ws, "cron.add", {
+        name: "ambiguous announce",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "hello" },
+        delivery: { mode: "announce" },
+      });
+      expect(ambiguousAddRes.ok).toBe(false);
+      expect(ambiguousAddRes.error?.message).toContain("ambiguous");
+
+      // A named channel is unambiguous and still accepted.
+      const namedAddRes = await rpcReq(ws, "cron.add", {
+        name: "named announce",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "hello" },
+        delivery: { mode: "announce", channel: "telegram", to: "19098680" },
+      });
+      if (!namedAddRes.ok) {
+        throw new Error(namedAddRes.error?.message ?? "cron.add failed");
+      }
+      expect(namedAddRes.ok).toBe(true);
+      const namedJobIdValue = (namedAddRes.payload as { id?: unknown } | null)?.id;
+      const namedJobId = typeof namedJobIdValue === "string" ? namedJobIdValue : "";
+      expect(namedJobId.length > 0).toBe(true);
+
+      // Updating the accepted job back to an ambiguous channel is rejected.
+      const ambiguousUpdateRes = await rpcReq(ws, "cron.update", {
+        id: namedJobId,
+        patch: { delivery: { mode: "announce", channel: "last" } },
+      });
+      expect(ambiguousUpdateRes.ok).toBe(false);
+      expect(ambiguousUpdateRes.error?.message).toContain("ambiguous");
+    } finally {
+      await cleanupCronTestRun({ ws, server, prevSkipCron, clearSessionConfig: true });
+    }
+  });
+
   test("keeps delivery updates valid after gateway config changes the default agent", async () => {
     const { prevSkipCron } = await setupCronTestRun({
       tempPrefix: "remoteclaw-gw-cron-main-default-agent-drift-",

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -143,6 +143,26 @@ export async function listConfiguredMessageChannels(
   return channels;
 }
 
+/**
+ * Configured channels that can receive an announce delivery.
+ *
+ * This is the fork's equivalent of the upstream channel-presence-policy
+ * `listConfiguredAnnounceChannelIds` helper (RemoteClaw never imported that
+ * module). Announce delivery resolves over the same enabled-and-configured
+ * deliverable message channels that {@link resolveMessageChannelSelection}
+ * uses at fire time, so this delegates to {@link listConfiguredMessageChannels}.
+ *
+ * Used by the gateway `cron.add` / `cron.update` handlers to detect an
+ * ambiguous announce `delivery.channel` (absent / `"last"` with more than one
+ * channel configured) at create/update time instead of letting it fail at fire
+ * time. Disabled accounts are excluded, matching fire-time selection. See #2750.
+ */
+export async function listConfiguredAnnounceChannelIds(
+  cfg: RemoteClawConfig,
+): Promise<MessageChannelId[]> {
+  return await listConfiguredMessageChannels(cfg);
+}
+
 export async function resolveMessageChannelSelection(params: {
   cfg: RemoteClawConfig;
   channel?: string | null;


### PR DESCRIPTION
## Summary

Cron jobs whose **announce** delivery channel is absent or `"last"` resolve to
the single configured channel at fire time. With **more than one** channel
configured, that reference is ambiguous — today the job is accepted at
`cron.add` / `cron.update` and only fails (or delivers to the wrong place) when
it fires. This PR moves that validation to create/update time so the caller
learns immediately.

Closes #2750

## What changed

- **`infra/outbound/channel-selection.ts`** — add `listConfiguredAnnounceChannelIds`,
  the fork's equivalent of the upstream channel-presence-policy helper (RemoteClaw
  never imported that module). It delegates to `listConfiguredMessageChannels`, the
  same **enabled-and-configured** enumerator used at fire time, so disabled
  accounts are excluded and the count matches runtime resolution.
- **`gateway/server-methods/cron.validation.ts`** (new) — a self-contained
  announce-delivery validator. Throws `CronDeliveryValidationError` for an
  ambiguous channel (absent / `"last"`) when **>1** channel is configured.
  Named channels and single-/zero-channel setups are always accepted; `webhook`,
  `none`, and non-isolated (`main`) targets carry no announce channel and are
  skipped. `failureDestination.channel` is validated by the same rule. Create
  validation treats an isolated `agentTurn` with no delivery as an implicit
  announce (matching `resolveInitialCronDelivery`); update validation checks only
  the **effective merged delivery**.
- **`gateway/server-methods/cron.ts`** — wire create/update validation into the
  handlers, returning `INVALID_REQUEST` with the ambiguity reason. Only the typed
  `CronDeliveryValidationError` is translated; any other error re-throws.
- **Tests** — `cron.validation.test.ts` (unit, 22 cases) plus a gateway
  integration test in `server.cron.test.ts` (telegram+slack configured:
  ambiguous-add rejected, named-add accepted, update-to-`"last"` rejected).

## Acceptance criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `cron.add`/`cron.update` reject absent/ambiguous announce `delivery.channel` + `failureDestination.channel` when multiple channels configured | ✅ |
| 2 | Unambiguous / single-channel delivery still accepted | ✅ |
| 3 | `listConfiguredAnnounceChannelIds` resolves over configured channels | ✅ |
| 4 | Test coverage for ambiguous-reject and valid-accept | ✅ |
| 5 | `pnpm tsgo` + `pnpm check` + gateway tests green | ✅ |

## Test evidence (local)

- `pnpm check` (format + tsgo + lint + brand/lobster/css-drift gates): **exit 0**
- Full gateway suite (`vitest.gateway.config.ts`): **1647 passed, 4 skipped** (exit 0)
- Full `infra/outbound` unit suite: **373 passed** (exit 0)
- Fork-integrity gates: rebrand, zombie-import, stub-debt (140 == baseline),
  throwing-stub-callers (**0 violations** — the new conditional `assertValidCron*`
  throwers are correctly not classified as stubs), obsolescence, attestations — all pass

## Implementation note

The issue suggested upstream's validation could be read from a tagged upstream
tree. In this worktree the `upstream/v2026.4.22` tag points at the fork's own
content-only sync commit (package name `remoteclaw`) and does not contain the
upstream channel-presence-policy symbols. Per the issue's explicit authorization
to "implement the equivalent over the fork's existing channel-presence/binding
APIs," the validator is built on the fork's fire-time channel enumerator rather
than ported verbatim.
