### PR TITLE
fix(hooks): re-port dropped upstream thread-ownership routing fixes (#2749)

### DIFF
--- a/extensions/thread-ownership/index.test.ts
+++ b/extensions/thread-ownership/index.test.ts
@@ -175,4 +175,166 @@ describe("thread-ownership plugin", () => {
       expect(globalThis.fetch).not.toHaveBeenCalled();
     });
   });
+
+  describe("routing canonicalization", () => {
+    beforeEach(() => {
+      api.pluginConfig = {};
+      register(api as any);
+    });
+
+    it("tracks agent-name mentions case-insensitively", async () => {
+      await hooks.message_received(
+        { content: "hey @testbot help", metadata: { threadId: "5101.0001", channelId: "C501" } },
+        { channelId: "slack", conversationId: "C501" },
+      );
+
+      const result = await hooks.message_sending(
+        { content: "On it!", metadata: { threadTs: "5101.0001" }, to: "C501" },
+        { channelId: "slack", conversationId: "C501" },
+      );
+
+      expect(result).toBeUndefined();
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it("does not treat superset handles (@testbot2) as an agent mention", async () => {
+      await hooks.message_received(
+        { content: "hey @testbot2 help", metadata: { threadId: "5102.0001", channelId: "C502" } },
+        { channelId: "slack", conversationId: "C502" },
+      );
+
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ owner: "test-agent" }), { status: 200 }),
+      );
+
+      await hooks.message_sending(
+        { content: "On it!", metadata: { threadTs: "5102.0001" }, to: "C502" },
+        { channelId: "slack", conversationId: "C502" },
+      );
+
+      expect(globalThis.fetch).toHaveBeenCalled();
+    });
+
+    it("does not treat email-like text as an agent mention", async () => {
+      await hooks.message_received(
+        {
+          content: "send mail to foo@testbot.com",
+          metadata: { threadId: "5103.0001", channelId: "C503" },
+        },
+        { channelId: "slack", conversationId: "C503" },
+      );
+
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ owner: "test-agent" }), { status: 200 }),
+      );
+
+      await hooks.message_sending(
+        { content: "On it!", metadata: { threadTs: "5103.0001" }, to: "C503" },
+        { channelId: "slack", conversationId: "C503" },
+      );
+
+      expect(globalThis.fetch).toHaveBeenCalled();
+    });
+
+    it("tracks inbound mentions keyed off metadata.threadId (not just threadTs)", async () => {
+      // The inbound mapper supplies the thread anchor as metadata.threadId (often numeric);
+      // ensure it is honored so mention tracking is not silently skipped.
+      await hooks.message_received(
+        { content: "Hey @TestBot help", metadata: { threadId: 5104, channelId: "C504" } },
+        { channelId: "slack", conversationId: "C504" },
+      );
+
+      const result = await hooks.message_sending(
+        { content: "Sure!", metadata: { threadTs: "5104" }, to: "C504" },
+        { channelId: "slack", conversationId: "C504" },
+      );
+
+      expect(result).toBeUndefined();
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it("canonicalizes non-canonical Slack send targets (channel: prefix + casing)", async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ owner: "test-agent" }), { status: 200 }),
+      );
+
+      const result = await hooks.message_sending(
+        { content: "hello", metadata: { threadTs: "5105.0001" }, to: "channel:c505" },
+        { channelId: "slack", conversationId: "" },
+      );
+
+      expect(result).toBeUndefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "http://localhost:8750/api/v1/ownership/C505/5105.0001",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ agent_id: "test-agent" }),
+        }),
+      );
+    });
+
+    it("prefers the shared conversationId over a non-canonical send target", async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ owner: "test-agent" }), { status: 200 }),
+      );
+
+      const result = await hooks.message_sending(
+        { content: "hello", metadata: { threadTs: "5106.0001" }, to: "channel:c506" },
+        { channelId: "slack", conversationId: "C506" },
+      );
+
+      expect(result).toBeUndefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "http://localhost:8750/api/v1/ownership/C506/5106.0001",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    it("matches inbound and outbound under canonicalized ids despite prefix/casing skew", async () => {
+      await hooks.message_received(
+        {
+          content: "Hey @TestBot",
+          metadata: { threadId: "5107.0001", channelId: "channel:c507" },
+        },
+        { channelId: "slack", conversationId: "" },
+      );
+
+      const result = await hooks.message_sending(
+        { content: "Sure!", metadata: { threadTs: "5107.0001" }, to: "channel:C507" },
+        { channelId: "slack", conversationId: "" },
+      );
+
+      expect(result).toBeUndefined();
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it("fails open when no canonical conversation id can be resolved", async () => {
+      const result = await hooks.message_sending(
+        { content: "hello", metadata: { threadTs: "5108.0001" }, to: "" },
+        { channelId: "slack", conversationId: "" },
+      );
+
+      expect(result).toBeUndefined();
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it("canonicalizes configured ab-test channel allowlists before matching", async () => {
+      api.pluginConfig = { abTestChannels: ["channel:c509"] };
+      register(api as any);
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ owner: "test-agent" }), { status: 200 }),
+      );
+
+      const result = await hooks.message_sending(
+        { content: "hello", metadata: { threadTs: "5109.0001" }, to: "channel:c509" },
+        { channelId: "slack", conversationId: "" },
+      );
+
+      expect(result).toBeUndefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "http://localhost:8750/api/v1/ownership/C509/5109.0001",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+  });
 });

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -18,6 +18,40 @@ type AgentEntry = NonNullable<NonNullable<RemoteClawConfig["agents"]>["list"]>[n
 const mentionedThreads = new Map<string, number>();
 const MENTION_TTL_MS = 5 * 60 * 1000;
 
+// Coerce a thread token (string | number | unknown) to a string key; "" when absent.
+function resolveThreadToken(value: unknown): string {
+  return typeof value === "string" || typeof value === "number" ? String(value) : "";
+}
+
+// Canonicalize a Slack conversation id: strip an optional "slack:"/"channel:" prefix and
+// upper-case canonical Slack id shapes ([CDGUW]...), so inbound and outbound routing keys
+// match regardless of the prefix or casing supplied by the channel adapter.
+function resolveSlackConversationId(value: unknown): string {
+  const raw = normalizeOptionalString(value) ?? "";
+  if (!raw) {
+    return "";
+  }
+  const trimmed = raw.trim();
+  const match = /^(?:slack:)?channel:(.+)$/i.exec(trimmed);
+  const resolved = match?.[1]?.trim() || trimmed;
+  return /^[CDGUW][A-Z0-9]+$/i.test(resolved) ? resolved.toUpperCase() : resolved;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Match a standalone @name mention (word-boundary, case-insensitive) so that superset
+// handles (e.g. @testbot2) and email-like text (e.g. foo@testbot.com) are not mistaken
+// for a mention of the agent.
+function containsAgentNameMention(text: string, agentName: string): boolean {
+  const trimmedName = agentName.trim();
+  if (!trimmedName) {
+    return false;
+  }
+  return new RegExp(`(^|[^\\w])@${escapeRegExp(trimmedName)}(?=$|[^\\w])`, "i").test(text);
+}
+
 function cleanExpiredMentions(): void {
   const now = Date.now();
   for (const [key, ts] of mentionedThreads) {
@@ -52,9 +86,13 @@ export default function register(api: RemoteClawPluginApi) {
   ).replace(/\/$/, "");
 
   const abTestChannels = new Set(
-    pluginCfg.abTestChannels ??
+    (
+      pluginCfg.abTestChannels ??
       process.env.THREAD_OWNERSHIP_CHANNELS?.split(",").filter(Boolean) ??
-      [],
+      []
+    )
+      .map((entry) => resolveSlackConversationId(entry))
+      .filter(Boolean),
   );
 
   const { id: agentId, name: agentName } = resolveOwnershipAgent(api.config);
@@ -68,15 +106,20 @@ export default function register(api: RemoteClawPluginApi) {
     if (ctx.channelId !== "slack") return;
 
     const text = event.content ?? "";
-    const threadTs = (event.metadata?.threadTs as string) ?? "";
-    const channelId = (event.metadata?.channelId as string) ?? ctx.conversationId ?? "";
+    // The inbound mapper carries the thread anchor in metadata.threadId (not threadTs),
+    // so read both to track mentions across channel-adapter metadata shapes.
+    const threadTs =
+      resolveThreadToken(event.metadata?.threadId) || resolveThreadToken(event.metadata?.threadTs);
+    const channelId =
+      resolveSlackConversationId(ctx.conversationId) ||
+      resolveSlackConversationId(event.metadata?.channelId) ||
+      "";
 
     if (!threadTs || !channelId) return;
 
-    // Check if this agent was @-mentioned.
+    // Check if this agent was @-mentioned (case-insensitive, word-boundary).
     const mentioned =
-      (agentName && text.includes(`@${agentName}`)) ||
-      (botUserId && text.includes(`<@${botUserId}>`));
+      containsAgentNameMention(text, agentName) || (botUserId && text.includes(`<@${botUserId}>`));
 
     if (mentioned) {
       cleanExpiredMentions();
@@ -91,11 +134,19 @@ export default function register(api: RemoteClawPluginApi) {
   api.on("message_sending", async (event, ctx) => {
     if (ctx.channelId !== "slack") return;
 
-    const threadTs = (event.metadata?.threadTs as string) ?? "";
-    const channelId = (event.metadata?.channelId as string) ?? event.to;
+    // Slack threading anchors arrive via metadata; replyToId is the canonical reply target.
+    const threadTs =
+      resolveThreadToken(event.metadata?.replyToId) ||
+      resolveThreadToken(event.metadata?.threadId) ||
+      resolveThreadToken(event.metadata?.threadTs);
+    const channelId =
+      resolveSlackConversationId(ctx.conversationId) ||
+      resolveSlackConversationId(event.metadata?.channelId) ||
+      resolveSlackConversationId(event.to) ||
+      "";
 
-    // Top-level messages (no thread) are always allowed.
-    if (!threadTs) return;
+    // Top-level messages (no thread) or an unresolved channel are always allowed (fail open).
+    if (!threadTs || !channelId) return;
 
     // Only enforce in A/B test channels (if set is empty, skip entirely).
     if (abTestChannels.size > 0 && !abTestChannels.has(channelId)) return;


### PR DESCRIPTION
## Summary

Opportunistic re-port of the upstream routing-correctness refinements dropped when the **v2026.4.22** sync held two heavily-diverged keep-layer files at their fork version. Per the issue, each dropped fix was checked against the fork's current shape; applicable ones are ported, the rest annotated with a one-line reason.

**Net change**: 8 thread-ownership routing fixes ported (adapted to the fork's `register()` + metadata transport) with restored unit coverage. All 4 `src/config/io.ts` fixes are **skipped** — the fork's config layer has diverged past applicability (each justified below).

Closes #2749

## Thread-ownership routing — `extensions/thread-ownership/index.ts` (8 ported ✅)

The fork holds this file at the pre-`definePluginEntry` `register(api)` shape, and its plugin event types (`PluginHookMessage{Received,Sending}Event`) carry only `metadata?: Record<string, unknown>` — no top-level `threadId`/`replyToId`. So thread anchors travel through `metadata`, and each upstream hunk was hand-translated rather than applied.

| Upstream commit | Subject | Ported as |
|---|---|---|
| `e593122465` | standardize outbound routing metadata | ✅ multi-source thread token via `resolveThreadToken` (inbound `metadata.threadId \|\| threadTs`; outbound `metadata.replyToId \|\| threadId \|\| threadTs`) |
| `5fbafa7e47` | prefer shared outbound conversation context | ✅ `channelId` prefers `ctx.conversationId`, then `metadata.channelId`, then `event.to` |
| `f4bbbcbfb3` | canonicalize thread ownership conversation ids | ✅ inbound `channelId` prefers `ctx.conversationId`, then `metadata.channelId` |
| `4663e7394b` | canonicalize slack thread ownership ids | ✅ `resolveSlackConversationId` strips `slack:`/`channel:` prefix |
| `f9f836eba4` | normalize thread ownership slack id casing | ✅ `resolveSlackConversationId` upper-cases canonical `[CDGUW][A-Z0-9]+` ids |
| `ec75545a82` | normalize thread ownership channel allowlists | ✅ `abTestChannels` mapped through `resolveSlackConversationId` + `filter(Boolean)` |
| `7d088f198f` | fail open without thread ownership routing | ✅ outbound guard `if (!threadTs \|\| !channelId) return` |
| `4ed2ea5035` | tighten thread ownership mention matching | ✅ `containsAgentNameMention` word-boundary regex + `escapeRegExp` (subsumes `dbba830417`) |

**Notable correctness gain**: the inbound mapper (`toPluginMessageReceivedEvent`) carries the thread anchor as `metadata.threadId`, but the handler previously read only `metadata.threadTs` (which the mapper never sets) — so inbound mention tracking silently never fired. The multi-source read (`e593122465`) restores it.

### Excluded (with reason)
- **Live-config cluster** — `834e50f83c`, `db5895fd2a`, `aad1be102d`, `65ae1e54de`, `d5c0f70e95`: re-read config per hook via `api.runtime.config.loadConfig()` + `resolveLivePluginConfigObject()`. The fork has neither surface (no `config-runtime` plugin-sdk export). Config-freshness feature, not routing-correctness — out of scope.
- **SSRF guard** — `213c36cf51`: already present in the fork (`fetchWithSsrFGuard` + `ssrfPolicyFromAllowPrivateNetwork(true)` + DNS-pin), per the issue note.

## Config-io recovery — `src/config/io.ts` (4 skipped — fork shape handles)

| Upstream commit | Subject | Disposition |
|---|---|---|
| `5d50b0c48f` | recover prefixed config JSON | **Skip** — fork removed the recovery subsystem entirely (`recoverConfigFromLastKnownGood`, `persistClobberedConfigSnapshot`, `resolveLegacyConfigForRead` all absent; no startup recovery wiring) and fails closed on invalid config by design (`io.ts:877-879`). The auto-recovery has no subsystem to integrate with and would contradict the fail-closed posture. |
| `860cc1b3fe` | preserve source config during recovery | **Skip** — the fork's per-failure early-returns (parse/include/validation, `io.ts:924-1000`) already preserve `raw`/`parsed`/`resolved`/`config`; upstream's progressive fallback was needed only because upstream had a single catch-all. The residual final-catch (unexpected post-read throw) has no recovery-clobber consumer in the fork. |
| `f437d96ae2` | avoid false reload restarts | **Skip** — the patched machinery (`notifyRuntimeConfigWriteListeners`, `finalizeRuntimeSnapshotWrite`, `persistedConfig` return) doesn't exist in the fork. The fork re-reads the persisted file (`io.loadConfig()`, `io.ts:1551`) into the runtime snapshot and the reload loop diffs disk-derived configs (`diffConfigPaths`), so no pre-stamp/persisted mismatch reaches the reload decision. Porting stamp-propagation would risk the fork's secret-preservation merge-patch invariant. |
| `2c45879120` | render warning newlines | **Skip** — the fork **deliberately** escapes newlines in config log messages: `io.invalid-config.ts` `formatInvalidConfigLogMessage` returns `\\n` (test-locked: *"formats the logger message with the escaped newline separator"*), with a real newline only in the thrown error (`createInvalidConfigError`). Upstream's real-newline change conflicts with that convention. *(Aside: `io.ts:1131` is a pre-existing fork inconsistency using a real newline; reconciling it is out of scope for this upstream re-port.)* |

## Tests

Restored unit coverage in `extensions/thread-ownership/index.test.ts` (9 new cases): case-insensitive mention, superset-handle & email-like false-positive rejection, `metadata.threadId` inbound tracking, Slack-id prefix+casing canonicalization, shared-`conversationId` preference, allowlist canonicalization, and fail-open. All 9 existing cases remain green.

## Verification (local)

- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/thread-ownership/index.test.ts` → **18 passed (18)**
- `pnpm tsgo` → clean (0 diagnostics)
- `pnpm check` → green (format, lint type-aware 0/0, no-random-messaging, no-remoteclaw-ai, no-lobster-leak, css-drift 0 orphans)
- No gutted-subsystem import introduced (zero new imports).

## Acceptance criteria

- [x] Each config-recovery commit ported or annotated "already handled by fork shape" with a one-line reason
- [x] Thread-ownership id-canonicalization / case-insensitive mention / Slack-id-casing fixes ported with unit coverage
- [x] `pnpm tsgo` + `pnpm check` + the touched unit tests are green
- [x] No import of a removed/gutted subsystem is introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
