### PR TITLE
chore(config): remove inert isModelsWriteEnabled helper, keep modelsWrite schema

### DIFF
--- a/src/config/commands.flags.ts
+++ b/src/config/commands.flags.ts
@@ -23,10 +23,6 @@ export function isCommandFlagEnabled(
   return getOwnCommandFlagValue(config, key) === true;
 }
 
-export function isModelsWriteEnabled(config?: { commands?: unknown }): boolean {
-  return getOwnCommandFlagValue(config, "modelsWrite") !== false;
-}
-
 export function isRestartEnabled(config?: { commands?: unknown }): boolean {
   return getOwnCommandFlagValue(config, "restart") !== false;
 }

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -196,6 +196,10 @@ export const CommandsSchema = z
     native: NativeCommandsSettingSchema.optional().default("auto"),
     nativeSkills: NativeCommandsSettingSchema.optional().default("auto"),
     text: z.boolean().optional(),
+    // Config-compat only: accepted for upstream/shared-config parity. The fork delegates model
+    // selection to the CLI runtime (Middleware Boundary Principle) and ships no /models write —
+    // intentionally inert, no enforcement helper. If a fork /models write is ever added, gate it
+    // FAIL-CLOSED (=== true, false default), not the upstream fail-open default. See #2752.
     modelsWrite: z.boolean().optional().default(true),
     bash: z.boolean().optional(),
     bashForegroundMs: z.number().int().min(0).max(30_000).optional(),


### PR DESCRIPTION
## Summary

Resolves the #2752 decision. **Council** (entrepreneur + technical-architect + security-architect),
**CONVERGENT verdict**: model/provider selection is delegated to the external CLI runtimes — a
chat-driven `/models` write does not route through RemoteClaw infrastructure (**Middleware Boundary
Principle**). The fork retains the upstream `commands.modelsWrite` schema flag for config-compat but
ships no write command; the orphan `isModelsWriteEnabled` helper (0 callers, fail-open default, not
on the live import path) is deleted to remove the misleading enforcement seam.

**Falsifier (recorded)**: if a fork-side `/models` write surface is ever added, port the gate
**FAIL-CLOSED** (`=== true`, `false` default), not the upstream fail-open default.

## Changes

- **Delete** `isModelsWriteEnabled` from `src/config/commands.flags.ts` — zero callers (repo-wide
  `git grep`), fail-open default, never re-exported via `commands.ts`. Its sibling `isRestartEnabled`
  IS re-exported and imported by `src/agents/tools/gateway-tool.ts`; that asymmetry is expected —
  `modelsWrite` enforcement was carried as inert schema surface, never connected. The helper was a
  misleading enforcement seam gating a command that does not exist.
- **Keep** the `commands.modelsWrite` schema flag (zod default, labels, help text, message type) for
  upstream/shared-config parity — this is a content-only-sync fork, and removing an upstream-shipped
  flag creates reconcile churn every sync. Added a one-line provenance comment at the zod-schema
  field documenting the intentional inertness and the FAIL-CLOSED falsifier.

## Verification

- `pnpm tsgo` → 0 errors
- `pnpm check` → green (format, oxlint type-aware 0 warnings/0 errors, no-remoteclaw-ai,
  no-lobster-leak, css-class-drift 0 orphans)
- `src/config/` unit tests → 854 passed (7 skipped)
- Fork-integrity gates (run locally): zombie-imports, stub-debt, throwing-stub-callers (+ self-test),
  obsolescence-audit, rebrand-leakage — all green

Closes #2752
