### PR TITLE
fix(security): re-port webchat compaction + conversation-hook access guards (#2764)

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -74,7 +74,7 @@ function resolveGatewaySessionTargetFromKey(key: string) {
 }
 
 function rejectWebchatSessionMutation(params: {
-  action: "patch" | "delete";
+  action: "patch" | "delete" | "compact";
   client: GatewayClient | null;
   isWebchatConnect: (params: GatewayClient["connect"] | null | undefined) => boolean;
   respond: RespondFn;
@@ -625,13 +625,16 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const messages = limit < allMessages.length ? allMessages.slice(-limit) : allMessages;
     respond(true, { messages }, undefined);
   },
-  "sessions.compact": async ({ params, respond }) => {
+  "sessions.compact": async ({ params, respond, client, isWebchatConnect }) => {
     if (!assertValidParams(params, validateSessionsCompactParams, "sessions.compact", respond)) {
       return;
     }
     const p = params;
     const key = requireSessionKey(p.key, respond);
     if (!key) {
+      return;
+    }
+    if (rejectWebchatSessionMutation({ action: "compact", client, isWebchatConnect, respond })) {
       return;
     }
 

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1037,7 +1037,7 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
-  test("webchat clients cannot patch or delete sessions", async () => {
+  test("webchat clients cannot patch, delete, or compact sessions", async () => {
     await createSessionStoreDir();
 
     await writeSessionStore({
@@ -1080,6 +1080,12 @@ describe("gateway server sessions", () => {
     });
     expect(deleted.ok).toBe(false);
     expect(deleted.error?.message ?? "").toMatch(/webchat clients cannot delete sessions/i);
+
+    const compacted = await rpcReq(ws, "sessions.compact", {
+      key: "agent:main:discord:group:dev",
+    });
+    expect(compacted.ok).toBe(false);
+    expect(compacted.error?.message ?? "").toMatch(/webchat clients cannot compact sessions/i);
 
     ws.close();
   });

--- a/src/plugins/dead-hooks.test.ts
+++ b/src/plugins/dead-hooks.test.ts
@@ -58,3 +58,84 @@ describe("hook registration (post-gut)", () => {
     expect(registry.diagnostics).toHaveLength(0);
   });
 });
+
+describe("conversation hook access gate", () => {
+  it("blocks conversation typed hooks for non-bundled plugins unless explicitly allowed", () => {
+    const { registry, createApi } = createPluginRegistry(makeRegistryParams());
+    const record = makeRecord({ origin: "config" });
+    const api = createApi(record, { config: EMPTY_CONFIG });
+
+    api.on("llm_input", vi.fn());
+    api.on("llm_output", vi.fn());
+    api.on("agent_end", vi.fn());
+
+    expect(registry.typedHooks).toHaveLength(0);
+    const blocked = registry.diagnostics.filter((diag) =>
+      diag.message.includes(
+        "non-bundled plugins must set plugins.entries.test-plugin.hooks.allowConversationAccess=true",
+      ),
+    );
+    expect(blocked).toHaveLength(3);
+  });
+
+  it("allows conversation typed hooks for non-bundled plugins when explicitly enabled", () => {
+    const { registry, createApi } = createPluginRegistry(makeRegistryParams());
+    const record = makeRecord({ origin: "config" });
+    const api = createApi(record, {
+      config: EMPTY_CONFIG,
+      hookPolicy: { allowConversationAccess: true },
+    });
+
+    api.on("llm_input", vi.fn());
+    api.on("llm_output", vi.fn());
+    api.on("agent_end", vi.fn());
+
+    expect(registry.typedHooks.map((entry) => entry.hookName)).toEqual([
+      "llm_input",
+      "llm_output",
+      "agent_end",
+    ]);
+    expect(registry.diagnostics).toHaveLength(0);
+  });
+
+  it("allows conversation typed hooks for bundled plugins by default", () => {
+    const { registry, createApi } = createPluginRegistry(makeRegistryParams());
+    const record = makeRecord({ origin: "bundled" });
+    const api = createApi(record, { config: EMPTY_CONFIG });
+
+    api.on("llm_output", vi.fn());
+
+    expect(registry.typedHooks).toHaveLength(1);
+    expect(registry.diagnostics).toHaveLength(0);
+  });
+
+  it("blocks conversation typed hooks for bundled plugins that explicitly opt out", () => {
+    const { registry, createApi } = createPluginRegistry(makeRegistryParams());
+    const record = makeRecord({ origin: "bundled" });
+    const api = createApi(record, {
+      config: EMPTY_CONFIG,
+      hookPolicy: { allowConversationAccess: false },
+    });
+
+    api.on("agent_end", vi.fn());
+
+    expect(registry.typedHooks).toHaveLength(0);
+    const blocked = registry.diagnostics.filter((diag) =>
+      diag.message.includes(
+        "blocked by plugins.entries.test-plugin.hooks.allowConversationAccess=false",
+      ),
+    );
+    expect(blocked).toHaveLength(1);
+  });
+
+  it("does not gate non-conversation typed hooks for non-bundled plugins", () => {
+    const { registry, createApi } = createPluginRegistry(makeRegistryParams());
+    const record = makeRecord({ origin: "config" });
+    const api = createApi(record, { config: EMPTY_CONFIG });
+
+    api.on("message_received", vi.fn());
+
+    expect(registry.typedHooks).toHaveLength(1);
+    expect(registry.diagnostics).toHaveLength(0);
+  });
+});

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -15,6 +15,7 @@ import { normalizePluginHttpPath } from "./http-path.js";
 import { findOverlappingPluginHttpRoute } from "./http-route-overlap.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import {
+  isConversationHookName,
   isPluginHookName,
   isPromptInjectionHookName,
   stripPromptMutationFieldsFromLegacyHookResult,
@@ -150,6 +151,7 @@ export type PluginRegistryParams = {
 
 type PluginTypedHookPolicy = {
   allowPromptInjection?: boolean;
+  allowConversationAccess?: boolean;
 };
 
 const constrainLegacyPromptInjectionHook = (
@@ -554,6 +556,29 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         effectiveHandler = constrainLegacyPromptInjectionHook(
           handler as PluginHookHandlerMap["before_agent_start"],
         ) as PluginHookHandlerMap[K];
+      }
+    }
+    if (isConversationHookName(hookName)) {
+      const explicitConversationAccess = policy?.allowConversationAccess;
+      if (record.origin !== "bundled" && explicitConversationAccess !== true) {
+        pushDiagnostic({
+          level: "warn",
+          pluginId: record.id,
+          source: record.source,
+          message:
+            `typed hook "${hookName}" blocked because non-bundled plugins must set ` +
+            `plugins.entries.${record.id}.hooks.allowConversationAccess=true`,
+        });
+        return;
+      }
+      if (record.origin === "bundled" && explicitConversationAccess === false) {
+        pushDiagnostic({
+          level: "warn",
+          pluginId: record.id,
+          source: record.source,
+          message: `typed hook "${hookName}" blocked by plugins.entries.${record.id}.hooks.allowConversationAccess=false`,
+        });
+        return;
       }
     }
     record.hookCount += 1;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -401,6 +401,19 @@ const promptInjectionHookNameSet = new Set<PluginHookName>(PROMPT_INJECTION_HOOK
 export const isPromptInjectionHookName = (hookName: PluginHookName): boolean =>
   promptInjectionHookNameSet.has(hookName);
 
+export const CONVERSATION_HOOK_NAMES = [
+  "llm_input",
+  "llm_output",
+  "agent_end",
+] as const satisfies readonly PluginHookName[];
+
+export type ConversationHookName = (typeof CONVERSATION_HOOK_NAMES)[number];
+
+const conversationHookNameSet = new Set<PluginHookName>(CONVERSATION_HOOK_NAMES);
+
+export const isConversationHookName = (hookName: PluginHookName): boolean =>
+  conversationHookNameSet.has(hookName);
+
 // Agent context shared across agent hooks
 export type PluginHookAgentContext = {
   /** Correlation id for this agent run, propagated into hook events. */


### PR DESCRIPTION
## Summary

Re-ports the **two Priority-1 Medium** security fixes identified in #2764 — advertised/expected controls that were absent on live fork paths after the v2026.4.24 content-only sync. Both apply to kept fork layers (gateway, plugins).

Scope: **medium items only**. The Priority-2 Low items in #2764 are intentionally out of scope, so this PR uses **Refs**, not Closes — #2764 stays open for the low-priority drift.

## Item 1 — `sessions.compact` webchat session-mutation guard

**File:** `src/gateway/server-methods/sessions.ts` · **Upstream:** `873dce178de` (PR #70716)

`sessions.patch`/`sessions.delete` call `rejectWebchatSessionMutation`; `sessions.compact` did not, letting an admin-scoped webchat client (e.g. an XSS'd control-UI session) compact/mutate session transcripts even though the same client class is blocked from patch/delete.

- Extended the `rejectWebchatSessionMutation` action union with `"compact"`.
- Gave `sessions.compact` the `client` + `isWebchatConnect` handler params and call the guard before mutating (mirrors patch/delete).
- **Scope note:** the fork has no `sessions.restore` handler (upstream added `"restore"` too), so only `"compact"` is ported — no dead union member.

## Item 2 — enforce `plugins.entries.*.hooks.allowConversationAccess`

**Files:** `src/plugins/types.ts`, `src/plugins/registry.ts` · **Upstream:** `51f9f94cc36` (PR #70786, registry/hooks portion)

The `allowConversationAccess` opt-in was fully plumbed and advertised (config schema, normalization, and `loader.ts` passes it into `hookPolicy`) but **inert** — `registerTypedHook` never gated on it, so an operator-allowed non-bundled plugin got ungated access to conversation transcripts and the control did nothing.

- Added `CONVERSATION_HOOK_NAMES` (`llm_input`, `llm_output`, `agent_end`) + `isConversationHookName` to `types.ts` (the fork's equivalent of upstream's `hook-types.ts`).
- Added `allowConversationAccess` to `PluginTypedHookPolicy` and enforced it in `registerTypedHook`: non-bundled plugins are blocked unless they set it `true`; bundled plugins stay allowed unless they set it `false` — a diagnostic is pushed on block.
- **Scope note:** the upstream `status.ts` hunk is excluded — the fork's `status.ts` has diverged and surfaces neither `allowPromptInjection` nor the policy block, so porting only `allowConversationAccess` there would be inconsistent and is outside the stated fix. The `cli-runner` transcript-loading portion of the upstream commit is not part of #2764's identified gap.

## Verification

Both fixes re-verified against #2764's own "verify the gap" steps (gaps confirmed closed):

- `sessions.compact` now calls `rejectWebchatSessionMutation({ action: "compact", … })`.
- `isConversationHookName` now exists and is used; `registerTypedHook` gates on `policy?.allowConversationAccess`.

Tests (added/extended):
- `src/gateway/server.sessions.gateway-server-sessions-a.test.ts` — webchat-mutation test now also asserts `sessions.compact` is rejected (18/18 pass).
- `src/plugins/dead-hooks.test.ts` — new `conversation hook access gate` suite: non-bundled block, opt-in allow, bundled default-allow, bundled explicit opt-out, non-conversation-hook not gated (7/7 pass).

Gates: `pnpm check` green (format, tsgo, oxlint 0/0, all fork linters); standalone fork-integrity gates clean (zombie-imports, stub-debt baseline 140==140, throwing-stub-callers 0, no openclaw/lobster leaks).

> ⚠️ **Security change — do not auto-merge.** Please review before merging (auto-merge intentionally not enabled).

Refs #2764

🤖 Generated with [Claude Code](https://claude.com/claude-code)