### PR TITLE
fix(control-ui): hide heartbeat-ack turns from chat history via browser-safe helper (#2770 part 2)

### DIFF
--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -1,4 +1,4 @@
-import { stripHeartbeatToken } from "./heartbeat.js";
+import { stripHeartbeatToken } from "./heartbeat-token.js";
 
 const HEARTBEAT_TASK_PROMPT_PREFIX =
   "Run the following periodic tasks (only those due based on their intervals):";

--- a/src/auto-reply/heartbeat-token.ts
+++ b/src/auto-reply/heartbeat-token.ts
@@ -1,0 +1,132 @@
+// Browser-safe heartbeat token stripping.
+//
+// This module deliberately has NO node:* imports and no node-coupled transitive
+// deps (it does not import ../utils.js or ./heartbeat.js), so the Control UI
+// bundle can import it — directly or via ./heartbeat-filter.js — without pulling
+// node:fs/node:path into the browser build. `heartbeat.ts` re-exports these
+// symbols so existing server-side callers keep importing them from
+// `./heartbeat.js` unchanged. See #2770.
+
+/** The acknowledgement token emitted by heartbeat-only replies. */
+export const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
+
+export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
+
+export type StripHeartbeatMode = "heartbeat" | "message";
+
+// Local copy of escapeRegExp — the shared `../utils.js` home imports node:fs and
+// would poison the browser bundle, so a browser-safe module cannot depend on it.
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function stripTokenAtEdges(raw: string): { text: string; didStrip: boolean } {
+  let text = raw.trim();
+  if (!text) {
+    return { text: "", didStrip: false };
+  }
+
+  const token = HEARTBEAT_TOKEN;
+  const tokenAtEndWithOptionalTrailingPunctuation = new RegExp(
+    `${escapeRegExp(token)}[^\\w]{0,4}$`,
+  );
+  if (!text.includes(token)) {
+    return { text, didStrip: false };
+  }
+
+  let didStrip = false;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const next = text.trim();
+    if (next.startsWith(token)) {
+      const after = next.slice(token.length).trimStart();
+      text = after;
+      didStrip = true;
+      changed = true;
+      continue;
+    }
+    // Strip the token when it appears at the end of the text.
+    // Also strip up to 4 trailing non-word characters the model may have appended
+    // (e.g. ".", "!!!", "---"). Keep trailing punctuation only when real
+    // sentence text exists before the token.
+    if (tokenAtEndWithOptionalTrailingPunctuation.test(next)) {
+      const idx = next.lastIndexOf(token);
+      const before = next.slice(0, idx).trimEnd();
+      if (!before) {
+        text = "";
+      } else {
+        const after = next.slice(idx + token.length).trimStart();
+        text = `${before}${after}`.trimEnd();
+      }
+      didStrip = true;
+      changed = true;
+    }
+  }
+
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  return { text: collapsed, didStrip };
+}
+
+export function stripHeartbeatToken(
+  raw?: string,
+  opts: { mode?: StripHeartbeatMode; maxAckChars?: number } = {},
+) {
+  if (!raw) {
+    return { shouldSkip: true, text: "", didStrip: false };
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { shouldSkip: true, text: "", didStrip: false };
+  }
+
+  const mode: StripHeartbeatMode = opts.mode ?? "message";
+  const maxAckCharsRaw = opts.maxAckChars;
+  const parsedAckChars =
+    typeof maxAckCharsRaw === "string" ? Number(maxAckCharsRaw) : maxAckCharsRaw;
+  const maxAckChars = Math.max(
+    0,
+    typeof parsedAckChars === "number" && Number.isFinite(parsedAckChars)
+      ? parsedAckChars
+      : DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+  );
+
+  // Normalize lightweight markup so HEARTBEAT_OK wrapped in HTML/Markdown
+  // (e.g., <b>HEARTBEAT_OK</b> or **HEARTBEAT_OK**) still strips.
+  const stripMarkup = (text: string) =>
+    text
+      // Drop HTML tags.
+      .replace(/<[^>]*>/g, " ")
+      // Decode common nbsp variant.
+      .replace(/&nbsp;/gi, " ")
+      // Remove markdown-ish wrappers at the edges.
+      .replace(/^[*`~_]+/, "")
+      .replace(/[*`~_]+$/, "");
+
+  const trimmedNormalized = stripMarkup(trimmed);
+  const hasToken = trimmed.includes(HEARTBEAT_TOKEN) || trimmedNormalized.includes(HEARTBEAT_TOKEN);
+  if (!hasToken) {
+    return { shouldSkip: false, text: trimmed, didStrip: false };
+  }
+
+  const strippedOriginal = stripTokenAtEdges(trimmed);
+  const strippedNormalized = stripTokenAtEdges(trimmedNormalized);
+  const picked =
+    strippedOriginal.didStrip && strippedOriginal.text ? strippedOriginal : strippedNormalized;
+  if (!picked.didStrip) {
+    return { shouldSkip: false, text: trimmed, didStrip: false };
+  }
+
+  if (!picked.text) {
+    return { shouldSkip: true, text: "", didStrip: true };
+  }
+
+  const rest = picked.text.trim();
+  if (mode === "heartbeat") {
+    if (rest.length <= maxAckChars) {
+      return { shouldSkip: true, text: "", didStrip: true };
+    }
+  }
+
+  return { shouldSkip: false, text: rest, didStrip: true };
+}

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -1,13 +1,20 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { escapeRegExp } from "../utils.js";
-import { HEARTBEAT_TOKEN } from "./tokens.js";
+
+// Browser-safe token-stripping primitives live in ./heartbeat-token.js (no
+// node:fs/node:path, no node-coupled transitive deps) so the Control UI bundle
+// can import them via ./heartbeat-filter.js. Re-exported here to preserve the
+// historical ./heartbeat.js import surface for server-side callers. See #2770.
+export {
+  DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+  stripHeartbeatToken,
+  type StripHeartbeatMode,
+} from "./heartbeat-token.js";
 
 /** Non-configurable suffix appended by the middleware to every heartbeat prompt. */
 export const HEARTBEAT_TOOL_SUFFIX = " Report the result using the heartbeat_report tool.";
 
 export const DEFAULT_HEARTBEAT_EVERY = "30m";
-export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
 
 /**
  * Resolve the heartbeat prompt from config.
@@ -45,119 +52,6 @@ export async function resolveHeartbeatPrompt(opts: {
   }
 
   return "";
-}
-
-export type StripHeartbeatMode = "heartbeat" | "message";
-
-function stripTokenAtEdges(raw: string): { text: string; didStrip: boolean } {
-  let text = raw.trim();
-  if (!text) {
-    return { text: "", didStrip: false };
-  }
-
-  const token = HEARTBEAT_TOKEN;
-  const tokenAtEndWithOptionalTrailingPunctuation = new RegExp(
-    `${escapeRegExp(token)}[^\\w]{0,4}$`,
-  );
-  if (!text.includes(token)) {
-    return { text, didStrip: false };
-  }
-
-  let didStrip = false;
-  let changed = true;
-  while (changed) {
-    changed = false;
-    const next = text.trim();
-    if (next.startsWith(token)) {
-      const after = next.slice(token.length).trimStart();
-      text = after;
-      didStrip = true;
-      changed = true;
-      continue;
-    }
-    // Strip the token when it appears at the end of the text.
-    // Also strip up to 4 trailing non-word characters the model may have appended
-    // (e.g. ".", "!!!", "---"). Keep trailing punctuation only when real
-    // sentence text exists before the token.
-    if (tokenAtEndWithOptionalTrailingPunctuation.test(next)) {
-      const idx = next.lastIndexOf(token);
-      const before = next.slice(0, idx).trimEnd();
-      if (!before) {
-        text = "";
-      } else {
-        const after = next.slice(idx + token.length).trimStart();
-        text = `${before}${after}`.trimEnd();
-      }
-      didStrip = true;
-      changed = true;
-    }
-  }
-
-  const collapsed = text.replace(/\s+/g, " ").trim();
-  return { text: collapsed, didStrip };
-}
-
-export function stripHeartbeatToken(
-  raw?: string,
-  opts: { mode?: StripHeartbeatMode; maxAckChars?: number } = {},
-) {
-  if (!raw) {
-    return { shouldSkip: true, text: "", didStrip: false };
-  }
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return { shouldSkip: true, text: "", didStrip: false };
-  }
-
-  const mode: StripHeartbeatMode = opts.mode ?? "message";
-  const maxAckCharsRaw = opts.maxAckChars;
-  const parsedAckChars =
-    typeof maxAckCharsRaw === "string" ? Number(maxAckCharsRaw) : maxAckCharsRaw;
-  const maxAckChars = Math.max(
-    0,
-    typeof parsedAckChars === "number" && Number.isFinite(parsedAckChars)
-      ? parsedAckChars
-      : DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
-  );
-
-  // Normalize lightweight markup so HEARTBEAT_OK wrapped in HTML/Markdown
-  // (e.g., <b>HEARTBEAT_OK</b> or **HEARTBEAT_OK**) still strips.
-  const stripMarkup = (text: string) =>
-    text
-      // Drop HTML tags.
-      .replace(/<[^>]*>/g, " ")
-      // Decode common nbsp variant.
-      .replace(/&nbsp;/gi, " ")
-      // Remove markdown-ish wrappers at the edges.
-      .replace(/^[*`~_]+/, "")
-      .replace(/[*`~_]+$/, "");
-
-  const trimmedNormalized = stripMarkup(trimmed);
-  const hasToken = trimmed.includes(HEARTBEAT_TOKEN) || trimmedNormalized.includes(HEARTBEAT_TOKEN);
-  if (!hasToken) {
-    return { shouldSkip: false, text: trimmed, didStrip: false };
-  }
-
-  const strippedOriginal = stripTokenAtEdges(trimmed);
-  const strippedNormalized = stripTokenAtEdges(trimmedNormalized);
-  const picked =
-    strippedOriginal.didStrip && strippedOriginal.text ? strippedOriginal : strippedNormalized;
-  if (!picked.didStrip) {
-    return { shouldSkip: false, text: trimmed, didStrip: false };
-  }
-
-  if (!picked.text) {
-    return { shouldSkip: true, text: "", didStrip: true };
-  }
-
-  const rest = picked.text.trim();
-  if (mode === "heartbeat") {
-    if (rest.length <= maxAckChars) {
-      return { shouldSkip: true, text: "", didStrip: true };
-    }
-  }
-
-  return { shouldSkip: false, text: rest, didStrip: true };
 }
 
 /**

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -1,6 +1,7 @@
 import { escapeRegExp } from "../utils.js";
 
-export const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
+// Single source of truth lives in the browser-safe ./heartbeat-token.js module.
+export { HEARTBEAT_TOKEN } from "./heartbeat-token.js";
 export const SILENT_REPLY_TOKEN = "NO_REPLY";
 
 const silentExactRegexByToken = new Map<string, RegExp>();

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -517,6 +517,26 @@ describe("loadChatHistory", () => {
     expect(state.chatLoading).toBe(false);
   });
 
+  it("filters assistant HEARTBEAT_OK acknowledgements from history", async () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "Are you there?" }] },
+      { role: "assistant", content: [{ type: "text", text: "HEARTBEAT_OK" }] },
+      { role: "assistant", content: [{ type: "text", text: "Real answer" }] },
+    ];
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+
+    // The HEARTBEAT_OK ack is hidden; the user prompt and real answer remain.
+    expect(state.chatMessages).toEqual([messages[0], messages[2]]);
+  });
+
   it("keeps assistant message when text field has real content but content is NO_REPLY", async () => {
     const messages = [{ role: "assistant", text: "real reply", content: "NO_REPLY" }];
     const mockClient = {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1,3 +1,4 @@
+import { isHeartbeatOkResponse } from "../../../../src/auto-reply/heartbeat-filter.js";
 import { resetToolStream } from "../app-tool-stream.ts";
 import { extractText } from "../chat/message-extract.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
@@ -73,15 +74,33 @@ function isEmptyUserTextOnlyMessage(message: unknown): boolean {
   return (extractText(message)?.trim() ?? "") === "";
 }
 
-// NOTE: upstream also hides assistant heartbeat-ack messages here via
-// isHeartbeatOkResponse from src/auto-reply/heartbeat-filter. That helper is
-// not browser-importable in this fork — its transitive deps (heartbeat.ts →
-// utils.ts) pull in node:fs/node:path, which breaks the webchat browser
-// bundle. Skipped until a browser-safe heartbeat-ack helper exists (tracked
-// in #2764 remainder). No regression: neither this nor the server-side
-// history strip (upstream 3f63ba8fd80 session-history-state.ts) is on main.
+// Hide assistant heartbeat-ack turns (HEARTBEAT_OK) from visible chat history,
+// mirroring the empty-user hiding above. isHeartbeatOkResponse comes from the
+// browser-safe src/auto-reply/heartbeat-filter helper — its token-stripping
+// deps now live in src/auto-reply/heartbeat-token (no node:fs/node:path, no
+// node-coupled transitive imports), so it is safe in the webchat browser
+// bundle. See #2770. The fork has no server-side session-history strip
+// (upstream 3f63ba8fd80 session-history-state.ts is not on main), so this UI
+// filter is the single hiding point, as it already is for silent/empty-user turns.
+function isAssistantHeartbeatAck(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  const role = normalizeLowercaseStringOrEmpty(entry.role);
+  if (role !== "assistant") {
+    return false;
+  }
+  const content = entry.content ?? entry.text;
+  return isHeartbeatOkResponse({ role, content });
+}
+
 function shouldHideHistoryMessage(message: unknown): boolean {
-  return isAssistantSilentReply(message) || isEmptyUserTextOnlyMessage(message);
+  return (
+    isAssistantSilentReply(message) ||
+    isAssistantHeartbeatAck(message) ||
+    isEmptyUserTextOnlyMessage(message)
+  );
 }
 
 function hasTranscriptMeta(message: unknown): boolean {


### PR DESCRIPTION
## Summary

Re-ports **one of the two** deferred LOW upstream fixes tracked by #2770.

- ✅ **Part 2 — Heartbeat-ack UI history hiding** (upstream `3f63ba8fd80`): **landed here.**
- ⏸️ **Part 1 — WhatsApp QR-login state sync** (upstream `245451b6a9c`): **deferred** — not cleanly portable (rationale below). #2770 stays open for it.

Refs #2770 (does **not** close it — Part 1 remains).

## Part 2 — what changed

The fork's Control-UI already hides silent-reply and empty-user turns on history reload, but skipped assistant heartbeat-ack (`HEARTBEAT_OK`) turns because the natural helper `isHeartbeatOkResponse` lived behind `heartbeat.ts`, whose transitive deps (`node:fs`/`node:path` and `../utils.js`) poison the Control-UI browser bundle — `test-ui-smoke` catches this. (A `chat.ts` NOTE documented the deferral.)

Fix — extract the pure token-stripping logic into a **browser-safe module** and re-point the filter helper at it:

| File | Change |
|------|--------|
| `src/auto-reply/heartbeat-token.ts` **(new)** | Browser-safe: no `node:*` imports, no node-coupled transitive deps (inline `escapeRegExp`). Holds `HEARTBEAT_TOKEN`, `DEFAULT_HEARTBEAT_ACK_MAX_CHARS`, `StripHeartbeatMode`, `stripTokenAtEdges`, `stripHeartbeatToken`. |
| `src/auto-reply/heartbeat.ts` | Drops the moved code + node-coupled imports; **re-exports** the 3 public symbols from `heartbeat-token.js` so every server-side caller (`heartbeat-runner`, `server-chat`, `normalize-reply`, `agent-runner-payloads`, `heartbeat-policy`) is unchanged. Keeps `resolveHeartbeatPrompt` (node:fs). |
| `src/auto-reply/tokens.ts` | Re-exports `HEARTBEAT_TOKEN` from `heartbeat-token.js` (single source of truth). |
| `src/auto-reply/heartbeat-filter.ts` | Imports `stripHeartbeatToken` from `heartbeat-token.js` → now browser-importable. |
| `ui/src/ui/controllers/chat.ts` | New `isAssistantHeartbeatAck` (uses the now-browser-safe `isHeartbeatOkResponse`); wired into `shouldHideHistoryMessage`; NOTE updated. |
| `ui/src/ui/controllers/chat.test.ts` | +1 test: `HEARTBEAT_OK` ack filtered from history on reload. |

The fork has no server-side session-history strip (upstream's `session-history-state.ts` is not on `main`), so this UI-side filter is the single hiding point — consistent with how the fork already handles silent/empty-user turns.

## Part 1 — why deferred

The `currentQrDataUrl` **plumbing already exists** in the fork (gateway schema, `web.ts`, adapter type, UI controller all carry it). The only structural gap is that the fork's `login-qr.ts` lacks the QR-rotation infrastructure the upstream fix hangs off: upstream catches rotating QR codes via `waitForWhatsAppLoginResult({ onQr, onSocketReplaced })`, **which the fork does not have** (its `attachLoginWaiter` uses `waitForWaConnection`, no QR hook; its render helper is `renderQrPngBase64`, not upstream's `renderQrPngDataUrl`).

Making `currentQrDataUrl` non-inert therefore requires re-architecting the concurrency-sensitive QR versioning + background-render chase + update-signaling onto a different socket-wiring pattern — the "all-or-nothing" adaptation the issue calls out — with **zero fork `login-qr` test coverage**. For a LOW-severity, re-scan-recoverable issue, forcing that into the live WhatsApp login path is poor risk/reward. Left for a focused follow-up that ports the full machinery + tests together.

## Verification

- `pnpm test:ui:smoke` → **12/12 passed** — browser bundle builds and runs with the new `heartbeat-filter` import: **`node:fs` does not reach the Control-UI bundle.**
- `pnpm tsgo` → 0 errors (re-export refactor resolves across all server callers).
- `pnpm check` → green (format, oxlint 0/0, no-lobster-leak, css-class-drift 0 orphans, no-remoteclaw-ai, no-models-write).
- Fork-integrity gates: zombie-imports clean · obsolescence 46==46 · throwing-stub-callers 0 · stub-debt 140==140.
- `ui/.../chat.test.ts` → 26/26 (incl. new heartbeat-ack test).
- `src/auto-reply/{heartbeat-filter,heartbeat,tokens}.test.ts` → 38 passed. **2 pre-existing failures** in `filterHeartbeatPairs` (they depend on a non-empty `HEARTBEAT_PROMPT`, which the fork gutted to `""`) — proven identical on the pre-change baseline, unrelated to this change, and this suite runs in no CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
