### PR TITLE
fix(build): emit all source-backed plugin-sdk subpaths so published plugins load (#2772)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,36 @@ jobs:
       - name: Validate release artifact (early signal — runs again in publish-next)
         run: pnpm release:check
 
+  packaged-boot-smoke:
+    # Installs the packed npm tarball into an isolated consumer OUTSIDE the repo
+    # checkout and boots `remoteclaw plugins doctor`, failing if any bundled
+    # plugin fails to load. Guards the sync #2762 regression class: the build
+    # emitted the plugin-sdk root alias (dist/plugin-sdk/root-alias.cjs) but not
+    # the concrete per-subpath dist files it resolves against, so the published
+    # package booted with ZERO plugins (`Cannot find module
+    # '.../root-alias.cjs/text-runtime'`). Neither `pnpm build` nor
+    # `pnpm release:check` exercises the installed package's runtime plugin
+    # loader, so this is a distinct required gate. The consumer must be isolated
+    # OUTSIDE the checkout or Node resolution climbs into the repo's own built
+    # dist and masks a broken tarball (see the script header).
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Build
+        run: pnpm build
+
+      - name: Packaged plugin-boot smoke test
+        run: bash scripts/ci/check-packaged-plugin-boot.sh
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -274,6 +304,7 @@ jobs:
         obsolescence-audit-gate,
         lint,
         build,
+        packaged-boot-smoke,
         test,
         test-gateway,
         test-ui-smoke,
@@ -282,14 +313,18 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.rebrand-gate.result }}" != "success" || "${{ needs.zombie-import-gate.result }}" != "success" || "${{ needs.stub-debt-gate.result }}" != "success" || "${{ needs.throwing-stub-callers-gate.result }}" != "success" || "${{ needs.obsolescence-audit-gate.result }}" != "success" || "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.test.result }}" != "success" || "${{ needs.test-gateway.result }}" != "success" || "${{ needs.test-ui-smoke.result }}" != "success" ]]; then
+          if [[ "${{ needs.rebrand-gate.result }}" != "success" || "${{ needs.zombie-import-gate.result }}" != "success" || "${{ needs.stub-debt-gate.result }}" != "success" || "${{ needs.throwing-stub-callers-gate.result }}" != "success" || "${{ needs.obsolescence-audit-gate.result }}" != "success" || "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.packaged-boot-smoke.result }}" != "success" || "${{ needs.test.result }}" != "success" || "${{ needs.test-gateway.result }}" != "success" || "${{ needs.test-ui-smoke.result }}" != "success" ]]; then
             echo "::error::One or more required jobs failed"
             exit 1
           fi
 
   publish-next:
     if: github.event_name == 'push'
-    needs: [lint, build, test]
+    # packaged-boot-smoke gates publish directly (not only via the CI rollup):
+    # this job runs in parallel with CI on push, so without the dependency a
+    # broken canary could ship even as the rollup fails. It is the exact failure
+    # mode #2762 hit — a published package that boots zero plugins.
+    needs: [lint, build, packaged-boot-smoke, test]
     runs-on: ubuntu-latest
     environment: npm-publish
     permissions:
@@ -333,7 +368,9 @@ jobs:
 
   publish-latest:
     if: github.event_name == 'release'
-    needs: [lint, build, test]
+    # See publish-next: gate the published artifact on the packaged plugin-boot
+    # smoke test so a package that boots zero plugins can never be released.
+    needs: [lint, build, packaged-boot-smoke, test]
     runs-on: ubuntu-latest
     environment: npm-publish
     permissions:

--- a/scripts/ci/check-packaged-plugin-boot.sh
+++ b/scripts/ci/check-packaged-plugin-boot.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Packaged plugin-boot smoke gate.
+#
+# Packs the built npm artifact, installs it into an ISOLATED consumer OUTSIDE
+# the repo checkout, and boots `remoteclaw plugins doctor`, failing if any
+# bundled plugin fails to load from the packaged artifact.
+#
+# Defends the sync #2762+ regression: the build emitted the plugin-sdk root
+# alias (`dist/plugin-sdk/root-alias.cjs`) but not the concrete per-subpath
+# `dist/plugin-sdk/<subpath>.js` files it resolves against. In the published
+# package that made every bundled extension importing such a subpath (e.g.
+# `text-runtime`) fail at load with
+# `Cannot find module '.../dist/plugin-sdk/root-alias.cjs/<subpath>'`, so the
+# gateway booted with ZERO plugins. `pnpm build` + `pnpm release:check` did not
+# catch it because neither exercises the installed package's runtime plugin
+# loader.
+#
+# Two non-obvious properties this gate depends on:
+#
+#   * ISOLATION (out-of-repo consumer). Node resolves the bare `remoteclaw`
+#     specifier — and the plugin-sdk root-alias subpaths the bundled extensions
+#     import — from the nearest `node_modules`, climbing parent directories. A
+#     consumer nested inside the repo climbs into the repo's own freshly-built
+#     dist and masks a broken PACKAGED artifact. The regression only reproduces
+#     when the tarball is the sole resolution source, so the consumer MUST live
+#     outside the repo tree.
+#
+#   * GREP, not exit code. `plugins doctor` exits 0 even when plugins fail to
+#     load; the failure is only visible in its printed report.
+#
+# Requires `pnpm build` to have run first (mirrors the `build` job, which runs
+# `pnpm build` then `pnpm release:check`).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ ! -f dist/plugin-sdk/root-alias.cjs ]]; then
+  echo "::error::dist not built (dist/plugin-sdk/root-alias.cjs missing). Run 'pnpm build' before this gate." >&2
+  exit 1
+fi
+
+PACK_DIR="$(mktemp -d)"
+CONSUMER="$(mktemp -d)"
+cleanup() { rm -rf "$PACK_DIR" "$CONSUMER"; }
+trap cleanup EXIT
+
+# The consumer must live OUTSIDE the repo tree, or module resolution leaks into
+# the repo's built dist and the gate stops discriminating a broken tarball.
+case "$CONSUMER/" in
+  "$REPO_ROOT"/*)
+    echo "::error::isolated consumer $CONSUMER is inside the repo checkout — isolation broken" >&2
+    exit 1
+    ;;
+esac
+
+# Pack the freshly-built dist. --ignore-scripts skips the prepack rebuild: the
+# build step already produced dist, and prepack's `pnpm build` is identical.
+TARBALL_NAME="$(npm pack --ignore-scripts --pack-destination "$PACK_DIR" 2>/dev/null | tail -1)"
+TARBALL="$PACK_DIR/$TARBALL_NAME"
+echo "Packed: $TARBALL"
+
+cd "$CONSUMER"
+npm init -y >/dev/null 2>&1
+echo "Installing packaged tarball into isolated consumer: $CONSUMER"
+if ! npm install "$TARBALL" --ignore-scripts --no-audit --no-fund >install.log 2>&1; then
+  echo "::error::tarball install failed" >&2
+  cat install.log >&2
+  exit 1
+fi
+
+PKG="node_modules/remoteclaw"
+
+# Explicit regression tripwire: the concrete subpath file that was missing in
+# #2762 must be present in the INSTALLED package.
+if [[ ! -f "$PKG/dist/plugin-sdk/text-runtime.js" ]]; then
+  echo "::error::packaged artifact is missing dist/plugin-sdk/text-runtime.js (the #2762 regression)" >&2
+  exit 1
+fi
+
+# Degenerate-pass guard: a clean doctor report is only meaningful if the artifact
+# actually ships plugins for it to load. Zero bundled extensions would make the
+# smoke test vacuous.
+EXT_COUNT="$(find "$PKG/extensions" -maxdepth 2 -name remoteclaw.plugin.json 2>/dev/null | wc -l | tr -d ' ' || true)"
+if [[ "${EXT_COUNT:-0}" -eq 0 ]]; then
+  echo "::error::no bundled extensions found in packaged artifact — smoke test would be vacuous" >&2
+  exit 1
+fi
+echo "Bundled extensions present in packaged artifact: $EXT_COUNT"
+
+mkdir -p home
+echo "Booting 'remoteclaw plugins doctor' (non-interactive)…"
+set +e
+DOCTOR_OUT="$(REMOTECLAW_HOME="$PWD/home" NODE_ENV=production \
+  node "$PKG/remoteclaw.mjs" plugins doctor </dev/null 2>&1)"
+DOCTOR_RC=$?
+set -e
+echo "----- plugins doctor output -----"
+echo "$DOCTOR_OUT"
+echo "---------------------------------"
+
+# A non-zero exit is a boot crash (distinct from a plugin load failure, which
+# doctor reports while still exiting 0).
+if [[ $DOCTOR_RC -ne 0 ]]; then
+  echo "::error::'remoteclaw plugins doctor' exited $DOCTOR_RC (boot crash)" >&2
+  exit 1
+fi
+
+# doctor exits 0 even on plugin load failures — detect them in the report text.
+if printf '%s\n' "$DOCTOR_OUT" | grep -qiE 'failed to load plugin|^Plugin errors:'; then
+  echo "::error::one or more plugins failed to load from the packaged artifact" >&2
+  exit 1
+fi
+
+# Positive confirmation the health path actually ran and evaluated cleanly.
+if ! printf '%s\n' "$DOCTOR_OUT" | grep -q 'No plugin issues detected.'; then
+  echo "::error::unexpected 'plugins doctor' output — missing clean-health confirmation" >&2
+  exit 1
+fi
+
+echo "Packaged plugin-boot smoke test passed: all bundled plugins loaded cleanly."

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from "node:fs";
 import { defineConfig } from "tsdown";
 
 const env = {
@@ -40,51 +41,33 @@ function nodeBuildConfig(config: Record<string, unknown>) {
   };
 }
 
-const pluginSdkEntrypoints = [
-  "index",
-  "core",
-  "channel-config-helpers",
-  "group-access",
-  "reply-payload",
-  "runtime-store",
-  "compat",
-  "telegram",
-  "discord",
-  "slack",
-  "signal",
-  "imessage",
-  "whatsapp",
-  "line",
-  "msteams",
-  "acpx",
-  "bluebubbles",
-  "copilot-proxy",
-  "device-pair",
-  "diagnostics-otel",
-  "diffs",
-  "feishu",
-  "googlechat",
-  "irc",
-  "llm-task",
-  "lobster",
-  "matrix",
-  "mattermost",
-  "nextcloud-talk",
-  "nostr",
-  "open-prose",
-  "phone-control",
-  "synology-chat",
-  "talk-voice",
-  "test-utils",
-  "thread-ownership",
-  "tlon",
-  "twitch",
-  "voice-call",
-  "zalo",
-  "zalouser",
-  "account-id",
-  "keyed-async-queue",
-] as const;
+// Single source of truth for the plugin-sdk build set: the package.json `exports`
+// map. `src/plugin-sdk/root-alias.cjs` (buildPluginSdkAliasMap → useDist) resolves
+// each advertised `./plugin-sdk/<subpath>` against `dist/plugin-sdk/<subpath>.js`;
+// when that file is missing the alias is silently dropped and the plugin import
+// falls through to the bare root alias, failing at runtime as
+// `Cannot find module '.../dist/plugin-sdk/root-alias.cjs/<subpath>'`. Deriving the
+// build set from the same `exports` map root-alias reads (with the same subpath
+// regex) keeps build ⇄ exports ⇄ root-alias from silently diverging, so every
+// source-backed subpath export is guaranteed a concrete dist file.
+//
+// The `existsSync` filter drops phantom exports that have no `src/plugin-sdk/*.ts`
+// source (so tsdown is never asked to build a nonexistent input). `index` is always
+// built as the bare `./plugin-sdk` entry. Paths resolve against the build cwd (repo
+// root), matching the relative-path convention used by the entries below.
+const rootPackageExports = (
+  JSON.parse(readFileSync("package.json", "utf8")) as {
+    exports?: Record<string, unknown>;
+  }
+).exports;
+
+const exportedPluginSdkEntrypoints = Object.keys(rootPackageExports ?? {})
+  .filter((key) => key.startsWith("./plugin-sdk/"))
+  .map((key) => key.slice("./plugin-sdk/".length))
+  .filter((subpath) => /^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(subpath))
+  .filter((subpath) => existsSync(`src/plugin-sdk/${subpath}.ts`));
+
+const pluginSdkEntrypoints = [...new Set(["index", ...exportedPluginSdkEntrypoints])];
 
 export default defineConfig([
   nodeBuildConfig({


### PR DESCRIPTION
## Summary

Fixes #2772 — the published `-next` package booted with **zero plugins** because `dist/plugin-sdk/text-runtime.js` was never emitted.

**Root cause:** the tsdown build's plugin-sdk entrypoint list was a hardcoded 43-entry array that had drifted from the `package.json` `exports` map that `src/plugin-sdk/root-alias.cjs` resolves against. `text-runtime` (and other source-backed subpaths) were advertised as exports + aliased by root-alias but never built, so bundled extensions importing them failed at load with `Cannot find module '.../dist/plugin-sdk/root-alias.cjs/text-runtime'`. In source-mode (all CI) they resolve against `src/`, which is why every gate stayed green while the shipped artifact was broken.

**Blast radius:** `-next` canaries from the v2026.4.24 sync onward. `latest`/v0.7.0 predates it and is unaffected.

## Changes

- **`tsdown.config.ts`** — derive the plugin-sdk build set from the same `exports` map root-alias reads (same subpath regex), filtered to entrypoints with an existing `src/plugin-sdk/*.ts` source. Build ⇄ exports ⇄ root-alias now share one source and can no longer silently diverge. Build set 43 → 48 (+`text-runtime`, `group-activation`, `media-store`, `telegram-command-ui`, `tool-send`; **0 dropped**).
- **`scripts/ci/check-packaged-plugin-boot.sh`** (new) + **`.github/workflows/ci.yml`** — a `packaged-boot-smoke` gate that packs the tarball, installs it into an isolated out-of-repo consumer, and boots `remoteclaw plugins doctor`, failing on any plugin load error. Wired into the required-gates rollup **and** `publish-next` / `publish-latest` (so a broken canary can't ship in parallel — the exact failure mode this bug hit). This is the artifact-level check no existing job performed.

## Verification (against the packaged artifact)

Identical isolated out-of-repo harness, before vs after this change:

| | Before | After |
|---|---|---|
| `dist/plugin-sdk/text-runtime.js` | missing | present (457 KB) |
| `plugins doctor` | `device-pair / phone-control / talk-voice: Cannot find module .../root-alias.cjs/text-runtime` | `No plugin issues detected.` |
| `plugins list` | 0 loaded | **3/27 loaded** (device-pair + phone-control, previously failing, now load) |

All existing gates green locally (`pnpm build`, `pnpm check`, `pnpm lint`, `release:check`, rebrand / zombie-import / stub-debt).

## Follow-ups (out of scope, non-blocking)

- The `.d.ts` shim lists (`scripts/write-plugin-sdk-entry-dts.ts`, `tsconfig.plugin-sdk.dts.json`) still exclude the 5 newly-built entries, so their published `types` 404 for external TS consumers. Types-only — does not affect runtime plugin loading; deferred to avoid `tsc` churn on a P0.
- `text-autolink-runtime` is a phantom export (no source, no importers) — a harmless dangling export to remove or back with source later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
