### PR TITLE
fix(reply-directives): re-apply rc:reply rename clobbered by sync #2634 (#2775)

### DIFF
--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -90,7 +90,7 @@ export function buildMessagePlaceholder(message: NormalizedWebhookMessage): stri
   return "";
 }
 
-// Returns inline reply tag like "[[reply_to:4]]" for prepending to message body
+// Returns inline reply tag like "[[rc:reply:4]]" for prepending to message body
 export function formatReplyTag(message: {
   replyToId?: string;
   replyToShortId?: string;
@@ -100,7 +100,7 @@ export function formatReplyTag(message: {
   if (!rawId) {
     return null;
   }
-  return `[[reply_to:${rawId}]]`;
+  return `[[rc:reply:${rawId}]]`;
 }
 
 function extractReplyMetadata(message: Record<string, unknown>): {

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -21,6 +21,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
+  stripInlineDirectiveTagsForDelivery,
 } from "remoteclaw/plugin-sdk/text-runtime";
 import { downloadBlueBubblesAttachment } from "./attachments.js";
 import { markBlueBubblesChatRead, sendBlueBubblesTyping } from "./chat.js";
@@ -56,7 +57,6 @@ import { formatBlueBubblesChatTarget, isAllowedBlueBubblesSender } from "./targe
 
 const DEFAULT_TEXT_LIMIT = 4000;
 const invalidAckReactions = new Set<string>();
-const REPLY_DIRECTIVE_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]/gi;
 const PENDING_OUTBOUND_MESSAGE_ID_TTL_MS = 2 * 60 * 1000;
 
 type PendingOutboundMessageId = {
@@ -439,7 +439,7 @@ export async function processMessage(
   const attachments = message.attachments ?? [];
   const placeholder = buildMessagePlaceholder(message);
   // Check if text is a tapback pattern (e.g., 'Loved "hello"') and transform to emoji format
-  // For tapbacks, we'll append [[reply_to:N]] at the end; for regular messages, prepend it
+  // For tapbacks, we'll append [[rc:reply:N]] at the end; for regular messages, prepend it
   const tapbackContext = resolveTapbackContext(message);
   const tapbackParsed = parseTapbackText({
     text,
@@ -827,9 +827,9 @@ export async function processMessage(
     replyToShortId = getShortIdForUuid(replyToId);
   }
 
-  // Use inline [[reply_to:N]] tag format
-  // For tapbacks/reactions: append at end (e.g., "reacted with ❤️ [[reply_to:4]]")
-  // For regular replies: prepend at start (e.g., "[[reply_to:4]] Awesome")
+  // Use inline [[rc:reply:N]] tag format
+  // For tapbacks/reactions: append at end (e.g., "reacted with ❤️ [[rc:reply:4]]")
+  // For regular replies: prepend at start (e.g., "[[rc:reply:4]] Awesome")
   const replyTag = formatReplyTag({ replyToId, replyToShortId });
   const baseBody = replyTag
     ? isTapbackMessage
@@ -987,10 +987,7 @@ export async function processMessage(
     if (privateApiEnabled) {
       return value;
     }
-    return value
-      .replace(REPLY_DIRECTIVE_TAG_RE, " ")
-      .replace(/[ \t]+/g, " ")
-      .trim();
+    return stripInlineDirectiveTagsForDelivery(value).text;
   };
 
   // History: in-memory rolling map with bounded API backfill retries
@@ -1447,11 +1444,11 @@ export async function processReaction(
   const chatLabel = reaction.isGroup ? ` in group:${peerId}` : "";
   // Use short ID for token savings
   const messageDisplayId = getShortIdForUuid(reaction.messageId) || reaction.messageId;
-  // Format: "Tyler reacted with ❤️ [[reply_to:5]]" or "Tyler removed ❤️ reaction [[reply_to:5]]"
+  // Format: "Tyler reacted with ❤️ [[rc:reply:5]]" or "Tyler removed ❤️ reaction [[rc:reply:5]]"
   const text =
     reaction.action === "removed"
-      ? `${senderLabel} removed ${reaction.emoji} reaction [[reply_to:${messageDisplayId}]]${chatLabel}`
-      : `${senderLabel} reacted with ${reaction.emoji} [[reply_to:${messageDisplayId}]]${chatLabel}`;
+      ? `${senderLabel} removed ${reaction.emoji} reaction [[rc:reply:${messageDisplayId}]]${chatLabel}`
+      : `${senderLabel} reacted with ${reaction.emoji} [[rc:reply:${messageDisplayId}]]${chatLabel}`;
   core.system.enqueueSystemEvent(text, {
     sessionKey: route.sessionKey,
     contextKey: `bluebubbles:reaction:${reaction.action}:${peerId}:${reaction.messageId}:${reaction.senderId}:${reaction.emoji}`,

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -1224,8 +1224,8 @@ describe("BlueBubbles webhook monitor", () => {
       expect(callArgs.ctx.ReplyToId).toBe("msg-0");
       expect(callArgs.ctx.ReplyToBody).toBe("original message");
       expect(callArgs.ctx.ReplyToSender).toBe("+15550000000");
-      // Body uses inline [[reply_to:N]] tag format
-      expect(callArgs.ctx.Body).toContain("[[reply_to:msg-0]]");
+      // Body uses inline [[rc:reply:N]] tag format
+      expect(callArgs.ctx.Body).toContain("[[rc:reply:msg-0]]");
     });
 
     it("preserves part index prefixes in reply tags when short IDs are unavailable", async () => {
@@ -1270,7 +1270,7 @@ describe("BlueBubbles webhook monitor", () => {
       const callArgs = getFirstDispatchCall();
       expect(callArgs.ctx.ReplyToId).toBe("p:1/msg-0");
       expect(callArgs.ctx.ReplyToIdFull).toBe("p:1/msg-0");
-      expect(callArgs.ctx.Body).toContain("[[reply_to:p:1/msg-0]]");
+      expect(callArgs.ctx.Body).toContain("[[rc:reply:p:1/msg-0]]");
     });
 
     it("hydrates missing reply sender/body from the recent-message cache", async () => {
@@ -1339,8 +1339,8 @@ describe("BlueBubbles webhook monitor", () => {
       expect(callArgs.ctx.ReplyToIdFull).toBe("cache-msg-0");
       expect(callArgs.ctx.ReplyToBody).toBe("original message (cached)");
       expect(callArgs.ctx.ReplyToSender).toBe("+15550000000");
-      // Body uses inline [[reply_to:N]] tag format with short ID
-      expect(callArgs.ctx.Body).toContain("[[reply_to:1]]");
+      // Body uses inline [[rc:reply:N]] tag format with short ID
+      expect(callArgs.ctx.Body).toContain("[[rc:reply:1]]");
     });
 
     it("falls back to threadOriginatorGuid when reply metadata is absent", async () => {
@@ -1461,7 +1461,7 @@ describe("BlueBubbles webhook monitor", () => {
       const callArgs = getFirstDispatchCall();
       expect(callArgs.ctx.RawBody).toBe("reacted with 😅");
       expect(callArgs.ctx.Body).toContain("reacted with 😅");
-      expect(callArgs.ctx.Body).not.toContain("[[reply_to:");
+      expect(callArgs.ctx.Body).not.toContain("[[rc:reply:");
     });
   });
 
@@ -2151,7 +2151,7 @@ describe("BlueBubbles webhook monitor", () => {
       await flushAsync();
 
       expect(mockEnqueueSystemEvent).toHaveBeenCalledWith(
-        expect.stringContaining("reacted with ❤️ [[reply_to:"),
+        expect.stringContaining("reacted with ❤️ [[rc:reply:"),
         expect.any(Object),
       );
     });
@@ -2191,7 +2191,7 @@ describe("BlueBubbles webhook monitor", () => {
       await flushAsync();
 
       expect(mockEnqueueSystemEvent).toHaveBeenCalledWith(
-        expect.stringContaining("removed ❤️ reaction [[reply_to:"),
+        expect.stringContaining("removed ❤️ reaction [[rc:reply:"),
         expect.any(Object),
       );
     });

--- a/extensions/discord/src/voice/sanitize.test.ts
+++ b/extensions/discord/src/voice/sanitize.test.ts
@@ -3,7 +3,7 @@ import { sanitizeVoiceReplyTextForSpeech } from "./sanitize.js";
 
 describe("sanitizeVoiceReplyTextForSpeech", () => {
   it("strips reply tags before speech", () => {
-    expect(sanitizeVoiceReplyTextForSpeech("[[reply_to_current]] hello there")).toBe("hello there");
+    expect(sanitizeVoiceReplyTextForSpeech("[[rc:reply]] hello there")).toBe("hello there");
   });
 
   it("strips the current speaker label prefix before speech", () => {
@@ -20,7 +20,7 @@ describe("sanitizeVoiceReplyTextForSpeech", () => {
 
   it("handles reply tags and speaker prefixes together", () => {
     expect(
-      sanitizeVoiceReplyTextForSpeech("[[reply_to_current]] speaker-1: hello there", "speaker-1"),
+      sanitizeVoiceReplyTextForSpeech("[[rc:reply]] speaker-1: hello there", "speaker-1"),
     ).toBe("hello there");
   });
 

--- a/src/auto-reply/reply/reply-plumbing.test.ts
+++ b/src/auto-reply/reply/reply-plumbing.test.ts
@@ -93,11 +93,11 @@ describe("applyReplyThreading auto-threading", () => {
     expect(result[0].replyToTag).toBe(true);
   });
 
-  it("resolves [[reply_to_current]] to currentMessageId when replyToMode is 'all'", () => {
-    // Mattermost-style scenario: agent responds with [[reply_to_current]] and replyToMode
+  it("resolves [[rc:reply]] to currentMessageId when replyToMode is 'all'", () => {
+    // Mattermost-style scenario: agent responds with [[rc:reply]] and replyToMode
     // is "all". The tag should resolve to the inbound message id.
     const result = applyReplyThreading({
-      payloads: [{ text: "[[reply_to_current]] some reply text" }],
+      payloads: [{ text: "[[rc:reply]] some reply text" }],
       replyToMode: "all",
       currentMessageId: "mm-post-abc123",
     });
@@ -108,9 +108,9 @@ describe("applyReplyThreading auto-threading", () => {
     expect(result[0].text).toBe("some reply text");
   });
 
-  it("resolves [[reply_to:<id>]] to explicit id when replyToMode is 'all'", () => {
+  it("resolves [[rc:reply:<id>]] to explicit id when replyToMode is 'all'", () => {
     const result = applyReplyThreading({
-      payloads: [{ text: "[[reply_to:mm-post-xyz789]] threaded reply" }],
+      payloads: [{ text: "[[rc:reply:mm-post-xyz789]] threaded reply" }],
       replyToMode: "all",
       currentMessageId: "mm-post-abc123",
     });

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -177,7 +177,7 @@ describe("agent event handler", () => {
   it("strips inline directives from assistant chat events", () => {
     const { broadcast, nodeSendToSession, nowSpy } = emitRun1AssistantText(
       createHarness({ now: 1_000 }),
-      "Hello [[reply_to_current]] world [[audio_as_voice]]",
+      "Hello [[rc:reply]] world [[audio_as_voice]]",
     );
     const chatCalls = chatBroadcastCalls(broadcast);
     expect(chatCalls).toHaveLength(1);

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -13,7 +13,7 @@ const mockState = vi.hoisted(() => ({
   transcriptPath: "",
   sessionId: "sess-1",
   mainSessionKey: "main",
-  finalText: "[[reply_to_current]]",
+  finalText: "[[rc:reply]]",
   triggerAgentRunStart: false,
   agentRunId: "run-agent-1",
   sessionEntry: {} as Record<string, unknown>,
@@ -225,7 +225,7 @@ async function runNonStreamingChatSend(params: {
 
 describe("chat directive tag stripping for non-streaming final payloads", () => {
   afterEach(() => {
-    mockState.finalText = "[[reply_to_current]]";
+    mockState.finalText = "[[rc:reply]]";
     mockState.mainSessionKey = "main";
     mockState.triggerAgentRunStart = false;
     mockState.agentRunId = "run-agent-1";
@@ -301,7 +301,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     const context = createChatContext();
 
     await chatHandlers["chat.inject"]({
-      params: { sessionKey: "main", message: "[[reply_to_current]]" },
+      params: { sessionKey: "main", message: "[[rc:reply]]" },
       respond,
       req: {} as never,
       client: null as never,
@@ -326,7 +326,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("chat.send non-streaming final keeps message defined for directive-only assistant text", async () => {
     createTranscriptFixture("remoteclaw-chat-send-directive-only-");
-    mockState.finalText = "[[reply_to_current]]";
+    mockState.finalText = "[[rc:reply]]";
     const respond = vi.fn();
     const context = createChatContext();
 

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -347,23 +347,21 @@ describe("gateway server chat", () => {
         JSON.stringify({
           message: {
             role: "assistant",
-            content: [
-              { type: "text", text: "Hello [[reply_to_current]] world [[audio_as_voice]]" },
-            ],
+            content: [{ type: "text", text: "Hello [[rc:reply]] world [[audio_as_voice]]" }],
             timestamp: Date.now(),
           },
         }),
         JSON.stringify({
           message: {
             role: "assistant",
-            content: "A [[reply_to:abc-123]] B",
+            content: "A [[rc:reply:abc-123]] B",
             timestamp: Date.now() + 1,
           },
         }),
         JSON.stringify({
           message: {
             role: "assistant",
-            text: "[[ reply_to : 456 ]] C",
+            text: "[[ rc:reply : 456 ]] C",
             timestamp: Date.now() + 2,
           },
         }),
@@ -380,7 +378,7 @@ describe("gateway server chat", () => {
       expect(messages.length).toBe(4);
 
       const serialized = JSON.stringify(messages);
-      expect(serialized.includes("[[reply_to")).toBe(false);
+      expect(serialized.includes("[[rc:reply")).toBe(false);
       expect(serialized.includes("[[audio_as_voice]]")).toBe(false);
 
       const first = messages[0] as { content?: Array<{ text?: string }> };

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -335,7 +335,7 @@ describe("readLastMessagePreviewFromTranscript", () => {
       JSON.stringify({
         message: {
           role: "assistant",
-          content: "Hello [[reply_to_current]] world [[audio_as_voice]]",
+          content: "Hello [[rc:reply]] world [[audio_as_voice]]",
         },
       }),
     ];
@@ -618,7 +618,7 @@ describe("readSessionPreviewItemsFromTranscript", () => {
       JSON.stringify({
         message: {
           role: "assistant",
-          content: "A [[reply_to:abc-123]] B [[audio_as_voice]]",
+          content: "A [[rc:reply:abc-123]] B [[audio_as_voice]]",
         },
       }),
     ];

--- a/src/utils/directive-tags.system-prompt-contract.test.ts
+++ b/src/utils/directive-tags.system-prompt-contract.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { buildSystemPrompt } from "../middleware/system-prompt.js";
+import {
+  parseInlineDirectives,
+  stripInlineDirectiveTagsForDelivery,
+  stripInlineDirectiveTagsForDisplay,
+} from "./directive-tags.js";
+
+/**
+ * Cross-file emit↔parse contract for the reply directive.
+ *
+ * `src/middleware/system-prompt.ts` tells the model which reply tag to EMIT;
+ * `src/utils/directive-tags.ts` PARSES and STRIPS it. These two vocabularies
+ * must never drift: when upstream sync #2634 reverted PR #2210's `rc:reply`
+ * rename in the parser (but not in the system prompt), the advertised
+ * `[[rc:reply]]` tag was neither parsed (no threading) nor stripped (leaked
+ * literally into delivered messages) — issue #2775 — while every same-file
+ * parser test stayed green because they were reverted in lockstep.
+ *
+ * This suite reads the tags the system prompt actually advertises and asserts
+ * the parser handles each one, so a future re-drift fails here immediately.
+ */
+describe("reply directive emit↔parse contract (system-prompt ↔ directive-tags)", () => {
+  const prompt = buildSystemPrompt({ channelName: "contract-test" });
+
+  // The only double-bracket markers the default prompt emits are reply-directive
+  // tags (the sole other marker, `[System Message]`, is single-bracket).
+  const advertisedTags = prompt.match(/\[\[[^\]]*\]\]/g) ?? [];
+
+  it("advertises reply tags (guards against a vacuous per-tag loop)", () => {
+    // Degenerate-subject guard: if extraction found nothing, the loop below
+    // would pass vacuously. Require a non-empty, correctly-shaped corpus.
+    expect(advertisedTags.length).toBeGreaterThanOrEqual(3);
+    expect(advertisedTags.some((tag) => /\[\[\s*rc:reply\s*\]\]/i.test(tag))).toBe(true);
+    expect(advertisedTags.some((tag) => /\[\[\s*rc:reply\s*:/i.test(tag))).toBe(true);
+  });
+
+  it("recognizes and strips every advertised reply tag variant", () => {
+    for (const tag of advertisedTags) {
+      const parsed = parseInlineDirectives(`${tag} hello`, { currentMessageId: "msg-1" });
+      expect(parsed.hasReplyTag, `parser must recognize advertised tag: ${tag}`).toBe(true);
+      expect(parsed.text, `advertised tag must be stripped from parsed text: ${tag}`).not.toContain(
+        "[[",
+      );
+      expect(parsed.text).toBe("hello");
+
+      expect(
+        stripInlineDirectiveTagsForDisplay(tag).text.includes("[["),
+        `display strip must remove advertised tag: ${tag}`,
+      ).toBe(false);
+      expect(
+        stripInlineDirectiveTagsForDelivery(`${tag} hello`).text,
+        `delivery strip must remove advertised tag: ${tag}`,
+      ).toBe("hello");
+    }
+  });
+
+  it("threads [[rc:reply]] to the triggering message and delivers only the prose (issue #2775)", () => {
+    const agentOutput = "[[rc:reply]] Yes, I exist. Here and ready.";
+    const parsed = parseInlineDirectives(agentOutput, { currentMessageId: "trigger-42" });
+
+    expect(parsed.hasReplyTag).toBe(true);
+    expect(parsed.replyToCurrent).toBe(true);
+    expect(parsed.replyToId).toBe("trigger-42");
+    expect(parsed.text).toBe("Yes, I exist. Here and ready.");
+
+    // The delivery strip is what channels apply before sending — no literal leak.
+    expect(stripInlineDirectiveTagsForDelivery(agentOutput).text).toBe(
+      "Yes, I exist. Here and ready.",
+    );
+  });
+
+  it("threads [[rc:reply:<id>]] to the explicitly provided id", () => {
+    const parsed = parseInlineDirectives("[[rc:reply:abc-123]] on it", {
+      currentMessageId: "trigger-42",
+    });
+
+    expect(parsed.hasReplyTag).toBe(true);
+    expect(parsed.replyToExplicitId).toBe("abc-123");
+    expect(parsed.replyToId).toBe("abc-123");
+    expect(parsed.text).toBe("on it");
+  });
+});

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -8,14 +8,14 @@ import {
 
 describe("stripInlineDirectiveTagsForDisplay", () => {
   test("removes reply and audio directives", () => {
-    const input = "hello [[reply_to_current]] world [[reply_to:abc-123]] [[audio_as_voice]]";
+    const input = "hello [[rc:reply]] world [[rc:reply:abc-123]] [[audio_as_voice]]";
     const result = stripInlineDirectiveTagsForDisplay(input);
     expect(result.changed).toBe(true);
     expect(result.text).toBe("hello  world  ");
   });
 
   test("supports whitespace variants", () => {
-    const input = "[[ reply_to : 123 ]]ok[[ audio_as_voice ]]";
+    const input = "[[ rc:reply : 123 ]]ok[[ audio_as_voice ]]";
     const result = stripInlineDirectiveTagsForDisplay(input);
     expect(result.changed).toBe(true);
     expect(result.text).toBe("ok");
@@ -31,14 +31,14 @@ describe("stripInlineDirectiveTagsForDisplay", () => {
 
 describe("stripInlineDirectiveTagsForDelivery", () => {
   test("removes directives and surrounding whitespace for outbound text", () => {
-    const input = "hello [[reply_to_current]] world [[audio_as_voice]]";
+    const input = "hello [[rc:reply]] world [[audio_as_voice]]";
     const result = stripInlineDirectiveTagsForDelivery(input);
     expect(result.changed).toBe(true);
     expect(result.text).toBe("hello world");
   });
 
   test("preserves intentional multi-space formatting away from directives", () => {
-    const input = "a  b [[reply_to:123]] c   d";
+    const input = "a  b [[rc:reply:123]] c   d";
     const result = stripInlineDirectiveTagsForDelivery(input);
     expect(result.changed).toBe(true);
     expect(result.text).toBe("a  b c   d");
@@ -54,20 +54,16 @@ describe("stripInlineDirectiveTagsForDelivery", () => {
 
 describe("parseInlineDirectives", () => {
   test("preserves leading spaces after stripping a reply tag", () => {
-    const input = "[[reply_to_current]]    keep this indent\n        and this one";
+    const input = "[[rc:reply]]    keep this indent\n        and this one";
     const result = parseInlineDirectives(input);
     expect(result.hasReplyTag).toBe(true);
     expect(result.text).toBe("    keep this indent\n        and this one");
   });
 
   test("preserves fenced code block indentation after stripping a reply tag", () => {
-    const input = [
-      "[[reply_to_current]]",
-      "```python",
-      "    if True:",
-      "        print('ok')",
-      "```",
-    ].join("\n");
+    const input = ["[[rc:reply]]", "```python", "    if True:", "        print('ok')", "```"].join(
+      "\n",
+    );
     const result = parseInlineDirectives(input);
     expect(result.hasReplyTag).toBe(true);
     expect(result.text).toBe(
@@ -76,14 +72,14 @@ describe("parseInlineDirectives", () => {
   });
 
   test("preserves word boundaries when a reply tag is adjacent to text", () => {
-    const input = "see[[reply_to_current]]now";
+    const input = "see[[rc:reply]]now";
     const result = parseInlineDirectives(input);
     expect(result.hasReplyTag).toBe(true);
     expect(result.text).toBe("see now");
   });
 
   test("drops all leading blank lines introduced by a stripped reply tag", () => {
-    const input = "[[reply_to_current]]\n\ntext";
+    const input = "[[rc:reply]]\n\ntext";
     const result = parseInlineDirectives(input);
     expect(result.hasReplyTag).toBe(true);
     expect(result.text).toBe("text");
@@ -93,7 +89,7 @@ describe("parseInlineDirectives", () => {
 
   test("preserves indented code block (4-space) inside a fenced block after stripping a directive", () => {
     const input = [
-      "[[reply_to_current]]",
+      "[[rc:reply]]",
       "```js",
       "function foo() {",
       "    return 42;",
@@ -117,7 +113,7 @@ describe("parseInlineDirectives", () => {
 
   test("preserves tab-indented lines inside a fenced code block", () => {
     const input = [
-      "[[reply_to_current]]",
+      "[[rc:reply]]",
       "```go",
       "func main() {",
       '\tfmt.Println("hello")',
@@ -142,7 +138,7 @@ describe("parseInlineDirectives", () => {
   });
 
   test("preserves indent-code-block lines (4-space prefix) outside a fenced block", () => {
-    const input = "[[reply_to_current]]\nHere is some code:\n\n    const x = 1;\n    const y = 2;";
+    const input = "[[rc:reply]]\nHere is some code:\n\n    const x = 1;\n    const y = 2;";
     const result = parseInlineDirectives(input);
     expect(result.hasReplyTag).toBe(true);
     expect(result.text).toBe("Here is some code:\n\n    const x = 1;\n    const y = 2;");
@@ -150,7 +146,7 @@ describe("parseInlineDirectives", () => {
 
   test("collapses multiple spaces on normal prose lines but not inside code blocks", () => {
     const input = [
-      "[[reply_to_current]]",
+      "[[rc:reply]]",
       "prose  with  extra  spaces",
       "```",
       "  preserved   spacing  inside",
@@ -164,13 +160,7 @@ describe("parseInlineDirectives", () => {
   });
 
   test("handles tilde fenced blocks (~~~) the same as backtick blocks", () => {
-    const input = [
-      "[[reply_to_current]]",
-      "~~~python",
-      "    x  =  1",
-      "        y  =  2",
-      "~~~",
-    ].join("\n");
+    const input = ["[[rc:reply]]", "~~~python", "    x  =  1", "        y  =  2", "~~~"].join("\n");
     const result = parseInlineDirectives(input);
     expect(result.hasReplyTag).toBe(true);
     expect(result.text).toBe(["~~~python", "    x  =  1", "        y  =  2", "~~~"].join("\n"));
@@ -195,7 +185,7 @@ describe("parseInlineDirectives", () => {
   test("preserves literal sentinel-like text while restoring masked code blocks", () => {
     const sentinelLikeText = "\uE0000\uE000";
     const input = [
-      "[[reply_to_current]]",
+      "[[rc:reply]]",
       `literal ${sentinelLikeText} text`,
       "```ts",
       "    const value = 1;",
@@ -213,7 +203,7 @@ describe("stripInlineDirectiveTagsFromMessageForDisplay", () => {
   test("strips inline directives from text content blocks", () => {
     const input = {
       role: "assistant",
-      content: [{ type: "text", text: "hello [[reply_to_current]] world [[audio_as_voice]]" }],
+      content: [{ type: "text", text: "hello [[rc:reply]] world [[audio_as_voice]]" }],
     };
     const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
     expect(result).toBeDefined();
@@ -223,7 +213,7 @@ describe("stripInlineDirectiveTagsFromMessageForDisplay", () => {
   test("preserves empty-string text when directives are entire content", () => {
     const input = {
       role: "assistant",
-      content: [{ type: "text", text: "[[reply_to_current]]" }],
+      content: [{ type: "text", text: "[[rc:reply]]" }],
     };
     const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
     expect(result).toBeDefined();

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -17,9 +17,9 @@ type InlineDirectiveParseOptions = {
 };
 
 const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
-const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
+const REPLY_TAG_RE = /\[\[\s*(?:rc:reply|rc:reply\s*:\s*([^\]\n]+))\s*\]\]/gi;
 const INLINE_DIRECTIVE_TAG_WITH_PADDING_RE =
-  /\s*(?:\[\[\s*audio_as_voice\s*\]\]|\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\])\s*/gi;
+  /\s*(?:\[\[\s*audio_as_voice\s*\]\]|\[\[\s*(?:rc:reply|rc:reply\s*:\s*[^\]\n]+)\s*\]\])\s*/gi;
 const MAX_REPLY_DIRECTIVE_ID_LENGTH = 256;
 
 function replacementPreservesWordBoundary(source: string, offset: number, length: number): string {


### PR DESCRIPTION
Fixes #2775

## Summary
`[[rc:reply]]` was leaking literally into delivered messages and replies weren't being threaded, because the directive parser was stuck on the legacy `reply_to` vocabulary. Upstream sync #2634 overwrote `src/utils/directive-tags.ts` with upstream's `reply_to_current` / `reply_to:` regexes, silently reverting PR #2210's `rc:reply` rename — while `src/middleware/system-prompt.ts` still tells the model to emit `[[rc:reply]]`. Because `rc:reply` never matched the regex, the tag was **neither parsed** (no `replyToId`, no threading) **nor stripped** (leaked into the delivered text, and spoken aloud on Discord voice).

Affected every shared-path channel: Slack, Telegram, Matrix, Discord text + voice, WhatsApp, Signal, Mattermost, gateway/web chat — plus BlueBubbles, which carried an independent copy of the bug.

## Changes (bakes in the two ratified decisions)
- **D1 — hard-cut to `rc:reply` only.** Restored `rc:reply` / `rc:reply:<id>` in `REPLY_TAG_RE` and `INLINE_DIRECTIVE_TAG_WITH_PADDING_RE` (`src/utils/directive-tags.ts`), re-applying PR #2210's rename. No legacy `reply_to` alternation.
- **D2 — migrate BlueBubbles fully to the `rc:reply` namespace.** The outbound sanitizer now reuses the shared `stripInlineDirectiveTagsForDelivery` (imported from `remoteclaw/plugin-sdk/text-runtime`, same pattern Discord voice already uses) instead of a duplicated local regex — so it **can't drift on the next sync**. The inbound reply-annotation generator (`formatReplyTag`) and reaction lines now emit `[[rc:reply:N]]`. Wire-protocol field names (`message["reply_to"]`, etc.) are correctly left untouched.
- **New cross-file contract test** (`src/utils/directive-tags.system-prompt-contract.test.ts`): reads the exact reply-tag literals `buildSystemPrompt()` advertises and asserts the parser recognizes + strips each. This is the missing emit↔parse guard that let the regression ship — it **fails on origin/main and passes after the fix**. Lives in the CI-covered `src/utils/` path so it guards future syncs.
- **Re-migrated the 8 test files** that were reverted alongside the parser back to `rc:reply` vocabulary.

## Testing
All directive-related suites pass locally. ⚠️ **Note:** the `extensions` and `auto-reply` suites do **not** run in any CI job (the unit config excludes them and there's no dedicated job) — so CI green does **not** cover those; I verified them locally. The `gateway` suite *does* run in CI via the dedicated `test-gateway` job.

| Suite | Result | In CI? |
|---|---|---|
| `directive-tags` + new contract test (unit) | 25 passed | ✅ yes (`test`) |
| `system-prompt` (unit) | 14 passed | ✅ yes (`test`) |
| gateway (4 migrated files) | 107 passed | ✅ yes (`test-gateway`) |
| extensions (discord voice + bluebubbles monitor) | 59 passed | ❌ no — ran locally |
| auto-reply `reply-plumbing` (2 migrated tests) | passed | ❌ no — ran locally |
| auto-reply `reply.directive.parse` + `reply-utils` | 47 passed | ❌ no — ran locally |

- Contract test verified failing on `origin/main` (3 failed) → passing after fix (4 passed).
- `pnpm check` (format + typecheck + lint + rebrand/lobster/css/models-write gates): **green**.
- Bonus: the two `auto-reply` parser suites already used `rc:reply` and were silently failing on `origin/main` against the reverted parser (they aren't in CI); this fix repairs them.

### Not run
- **Pre-existing, unrelated failure:** `reply-plumbing.test.ts` › `formatRunLabel` "sanitizes leaked internal runtime context" fails on `origin/main` too — a non-CI `src/auto-reply/` drift unrelated to reply directives. Left untouched (out of scope for #2775).
- **LIVE smoke tests** (`LIVE=1 pnpm test:live`): not run — these exercise CLI-agent dispatch (claude/gemini/codex/opencode runtimes) requiring live credentials, and this PR modifies `src/utils/` + `extensions/` (not `src/middleware/`). The reply-directive runtime path is covered by the suites above. Happy to run if you'd like it during review.

## Acceptance criteria
- ✅ `[[rc:reply]] <text>` → delivered `<text>` (tag removed) **and** threaded to the triggering message
- ✅ `[[rc:reply:<id>]]` → threaded reply to `<id>`
- ✅ Discord voice no longer speaks the literal tag
- ✅ BlueBubbles (non-private-API path) no longer leaks `[[rc:reply]]` (now via the shared, contract-guarded delivery strip)
- ✅ New contract test fails on current HEAD and passes after the fix
- ✅ Re-migrated test files use `rc:reply` vocabulary

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
