### PR TITLE
ci(test): run extensions/** + src/auto-reply/** suites as required lanes (#2779)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,69 @@ jobs:
         env:
           REMOTECLAW_TEST_INCLUDE_GATEWAY: "1"
 
+  test-extensions:
+    # Full extensions suite — extensions/**/*.test.ts: every channel adapter
+    # (BlueBubbles, Discord, Telegram, Slack, WhatsApp, iMessage, …) plus
+    # extension-side auto-reply handlers. Runs on its own runner, in parallel
+    # with `test`, and is aggregated through the `CI` rollup so a channel-adapter
+    # regression blocks merge (#2779 — the coverage gap that let #2775 ship
+    # broken). `pnpm test` (unit config) explicitly excludes extensions/**, so
+    # without this lane the whole tree merges unseen. Currently-failing files are
+    # quarantined in vitest.quarantine.ts so the lane is required-and-green; NEW
+    # breakage in any non-quarantined (or newly-added) file still fails here.
+    runs-on: ubuntu-latest
+    # Large suite; a hung adapter suite must fail fast, not hold the runner.
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Build canvas bundle
+        run: pnpm canvas:a2ui:bundle
+
+      - name: Run extensions suite
+        run: pnpm exec vitest run --config vitest.extensions.config.ts
+        env:
+          REMOTECLAW_TEST_INCLUDE_EXTENSIONS: "1"
+          NODE_OPTIONS: "--max-old-space-size=4096"
+
+  test-auto-reply:
+    # Repo-root auto-reply suite — src/auto-reply/**/*.test.ts. Runs on its own
+    # runner, aggregated through the `CI` rollup so an auto-reply regression
+    # blocks merge (#2779). `pnpm test` (unit config) explicitly excludes
+    # src/auto-reply/**, so without this lane it merges unseen. Extension-side
+    # auto-reply handlers live under extensions/** and are covered by the
+    # `test-extensions` lane, keeping the two lanes non-overlapping. Currently-
+    # failing files are quarantined in vitest.quarantine.ts so the lane is
+    # required-and-green.
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Build canvas bundle
+        run: pnpm canvas:a2ui:bundle
+
+      - name: Run auto-reply suite
+        run: pnpm exec vitest run --config vitest.auto-reply.config.ts
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
+
   test-ui-smoke:
     # Browser-mode smoke lane for the RemoteClawApp host class. Scoped to
     # the two sync-regression defense-in-depth suites — class-instance
@@ -307,13 +370,15 @@ jobs:
         packaged-boot-smoke,
         test,
         test-gateway,
+        test-extensions,
+        test-auto-reply,
         test-ui-smoke,
       ]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.rebrand-gate.result }}" != "success" || "${{ needs.zombie-import-gate.result }}" != "success" || "${{ needs.stub-debt-gate.result }}" != "success" || "${{ needs.throwing-stub-callers-gate.result }}" != "success" || "${{ needs.obsolescence-audit-gate.result }}" != "success" || "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.packaged-boot-smoke.result }}" != "success" || "${{ needs.test.result }}" != "success" || "${{ needs.test-gateway.result }}" != "success" || "${{ needs.test-ui-smoke.result }}" != "success" ]]; then
+          if [[ "${{ needs.rebrand-gate.result }}" != "success" || "${{ needs.zombie-import-gate.result }}" != "success" || "${{ needs.stub-debt-gate.result }}" != "success" || "${{ needs.throwing-stub-callers-gate.result }}" != "success" || "${{ needs.obsolescence-audit-gate.result }}" != "success" || "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.packaged-boot-smoke.result }}" != "success" || "${{ needs.test.result }}" != "success" || "${{ needs.test-gateway.result }}" != "success" || "${{ needs.test-extensions.result }}" != "success" || "${{ needs.test-auto-reply.result }}" != "success" || "${{ needs.test-ui-smoke.result }}" != "success" ]]; then
             echo "::error::One or more required jobs failed"
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,8 @@ type(scope): imperative description (#issue)
 - **Test naming**: `*.test.ts` (unit), `*.e2e.test.ts` (e2e), `*.live.test.ts` (live)
 - **Configs**: `vitest.config.ts` (base), `vitest.unit.config.ts`,
   `vitest.e2e.config.ts`, `vitest.extensions.config.ts`,
-  `vitest.gateway.config.ts`, `vitest.live.config.ts`
+  `vitest.auto-reply.config.ts`, `vitest.gateway.config.ts`,
+  `vitest.live.config.ts`
 - **CI env vars**: `REMOTECLAW_TEST_WORKERS=2`, `REMOTECLAW_TEST_MAX_OLD_SPACE_SIZE_MB=4096`
 
 ### Browser-mode smoke tests
@@ -132,6 +133,27 @@ catching "production renders but layout is broken" regressions like #2517.
   (the broader UI lane) is not in CI and has pre-existing failures
   unrelated to the sync-regression class
 
+### Extensions & auto-reply coverage lanes
+
+`extensions/**` (every channel adapter + extension-side auto-reply) and
+`src/auto-reply/**` are **excluded** from `vitest.unit.config.ts`, so `pnpm test`
+never ran them — a regression in any adapter or the reply path merged green (the
+gap that shipped #2775). Two required CI lanes close it (#2779):
+`test-extensions` (`vitest.extensions.config.ts`) and `test-auto-reply`
+(`vitest.auto-reply.config.ts`), both aggregated into the `CI` rollup like
+`test-gateway`.
+
+- **Run locally**: `pnpm test:extensions` / `pnpm test:auto-reply`
+- **Quarantine**: enabling the lanes surfaced a large volume of pre-existing
+  failures. Rather than block the gate on fixing all of them, currently-failing
+  test **files** are listed in `vitest.quarantine.ts` and excluded per lane, so
+  each lane is required-and-green and still fails on NEW breakage in any
+  non-quarantined (or newly-added) file. The list is a debt ledger — shrink it
+  by fixing (or CI-self-skipping) files and deleting their lines; un-quarantining
+  is tracked separately. Never quarantine fresh product breakage to green a red PR.
+- **Non-overlap**: the extensions lane owns `extensions/*/src/auto-reply/**`; the
+  auto-reply lane is scoped to repo-root `src/auto-reply/**` only.
+
 ## CI
 
 GitHub Actions (`.github/workflows/ci.yml`):
@@ -139,6 +161,10 @@ GitHub Actions (`.github/workflows/ci.yml`):
 - **test** job: checkout, setup Node env, canvas bundle, `pnpm test`
 - **test-ui-smoke** job: browser-mode RemoteClawApp smoke lane (see
   § Testing → Browser-mode smoke tests)
+- **test-extensions** / **test-auto-reply** jobs: run the `extensions/**` and
+  repo-root `src/auto-reply/**` suites that `pnpm test` excludes; aggregated into
+  the `CI` rollup so adapter / auto-reply regressions block merge (#2779). See
+  § Testing → Extensions & auto-reply coverage lanes
 - Jobs run on `ubuntu-latest` with Node 22 and pnpm 10.23.0
 - Branch protection requires `build`, `test`, `lint`, and `docs` to pass
 

--- a/package.json
+++ b/package.json
@@ -318,6 +318,7 @@
     "start": "node scripts/run-node.mjs",
     "test": "node scripts/test-parallel.mjs",
     "test:all": "pnpm lint && pnpm build && pnpm test && pnpm test:e2e && pnpm test:live && pnpm test:docker:all",
+    "test:auto-reply": "vitest run --config vitest.auto-reply.config.ts",
     "test:channels": "vitest run --config vitest.channels.config.ts",
     "test:coverage": "vitest run --config vitest.unit.config.ts --coverage",
     "test:docker:all": "pnpm test:docker:onboard && pnpm test:docker:gateway-network && pnpm test:docker:qr && pnpm test:docker:doctor-switch && pnpm test:docker:plugins",

--- a/vitest.auto-reply.config.ts
+++ b/vitest.auto-reply.config.ts
@@ -1,0 +1,9 @@
+import { AUTO_REPLY_QUARANTINE } from "./vitest.quarantine.ts";
+import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
+
+// Repo-root auto-reply path only: `src/auto-reply/**/*.test.ts`. Extension-side
+// auto-reply handlers (extensions/*/src/auto-reply/**) are covered by the
+// `test-extensions` lane, so scoping here to `src/auto-reply` keeps the two
+// lanes non-overlapping. Run by the CI `test-auto-reply` lane (#2779).
+// Currently-failing files are quarantined in vitest.quarantine.ts.
+export default createScopedVitestConfig(["src/auto-reply/**/*.test.ts"], AUTO_REPLY_QUARANTINE);

--- a/vitest.extensions.config.ts
+++ b/vitest.extensions.config.ts
@@ -1,3 +1,8 @@
+import { EXTENSIONS_QUARANTINE } from "./vitest.quarantine.ts";
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
-export default createScopedVitestConfig(["extensions/**/*.test.ts"]);
+// `extensions/**/*.test.ts` covers every channel adapter AND extension-side
+// auto-reply handlers (extensions/*/src/auto-reply/**). Run by the CI
+// `test-extensions` lane (#2779). Currently-failing files are quarantined in
+// vitest.quarantine.ts so the lane is required-and-green.
+export default createScopedVitestConfig(["extensions/**/*.test.ts"], EXTENSIONS_QUARANTINE);

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -1,0 +1,187 @@
+// CI test quarantine ledger — a DEBT LEDGER, not an escape hatch.
+//
+// Context (#2779): the `extensions/**` and `src/auto-reply/**` test suites exist
+// but were run by NO CI job, so regressions in any channel adapter or the
+// auto-reply path shipped green (this gap let #2775 ship broken). The fix wires
+// two required lanes — `test-extensions` (vitest.extensions.config.ts) and
+// `test-auto-reply` (vitest.auto-reply.config.ts) — into the `CI` rollup.
+//
+// Enabling those lanes surfaces a large volume of PRE-EXISTING failures that
+// were previously masked. Fixing all of them is a separate, unbounded effort;
+// blocking this coverage gate on that effort would leave the gate permanently
+// red and un-mergeable. Instead, the currently-failing test FILES are listed
+// here and excluded from their lane, so each lane is a REQUIRED, GREEN gate that
+// still fails CI on any NEW breakage in every non-quarantined file (and on any
+// newly-added test file).
+//
+// Semantics:
+//   - Entries are exact repo-relative test-file paths, passed to the lane's
+//     vitest `exclude`. A quarantined file does NOT run in CI.
+//   - This is FILE-level quarantine: a passing test inside a quarantined file is
+//     also skipped. That lost coverage is the debt tracked below.
+//   - A quarantined file is already red, so excluding it loses no regression
+//     signal; a broken test in any OTHER (non-quarantined or new) file still
+//     fails CI. That is exactly the #2779 acceptance criteria.
+//
+// This list is the UPPER bound observed locally (Node 26 + dev env); the CI
+// runner (Node 22, clean ubuntu, no creds/native deps) has a different failure
+// set. The list is reconciled against actual CI output until the lanes are green.
+//
+// TO REMOVE AN ENTRY (the goal — shrink this list to zero over time):
+//   1. Run the file: `pnpm exec vitest run --config vitest.extensions.config.ts <path>`
+//      (or vitest.auto-reply.config.ts). Fix the underlying failure, OR, if it is
+//      environment-dependent (creds/network/native deps), make it self-skip in CI
+//      via the test's own guard rather than living here.
+//   2. Delete the line. CI will run it on the next PR.
+//
+// Un-quarantining / per-file triage (real-regression vs env-dependent vs flaky)
+// is tracked in: #2782
+//
+// DO NOT add entries without that tracking issue — this is a ledger, not a dumping ground.
+// New product breakage must be FIXED, never quarantined to make a red PR go green.
+
+/** Currently-failing test files under `extensions/**` (run by the `test-extensions` lane). */
+export const EXTENSIONS_QUARANTINE: string[] = [
+  "extensions/acpx/src/manifest.test.ts",
+  "extensions/bluebubbles/src/account-resolve.test.ts",
+  "extensions/bluebubbles/src/attachments.test.ts",
+  "extensions/bluebubbles/src/monitor-normalize.test.ts",
+  "extensions/diagnostics-otel/src/service.test.ts",
+  "extensions/discord/src/accounts.test.ts",
+  "extensions/discord/src/gateway-logging.test.ts",
+  "extensions/discord/src/monitor.test.ts",
+  "extensions/discord/src/monitor.tool-result.sends-status-replies-responseprefix.test.ts",
+  "extensions/discord/src/monitor/auto-presence.test.ts",
+  "extensions/discord/src/monitor/listeners.test.ts",
+  "extensions/discord/src/monitor/message-handler.preflight.test.ts",
+  "extensions/discord/src/monitor/message-handler.process.test.ts",
+  "extensions/discord/src/monitor/message-handler.queue.test.ts",
+  "extensions/discord/src/monitor/message-utils.test.ts",
+  "extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts",
+  "extensions/discord/src/monitor/provider.proxy.test.ts",
+  "extensions/discord/src/monitor/provider.rest-proxy.test.ts",
+  "extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts",
+  "extensions/discord/src/monitor/threading.starter.test.ts",
+  "extensions/discord/src/voice-message.test.ts",
+  "extensions/feishu/src/bot.test.ts",
+  "extensions/feishu/src/client.test.ts",
+  "extensions/feishu/src/media.test.ts",
+  "extensions/feishu/src/monitor.reaction.test.ts",
+  "extensions/feishu/src/monitor.startup.test.ts",
+  "extensions/feishu/src/monitor.webhook-security.test.ts",
+  "extensions/feishu/src/outbound.test.ts",
+  "extensions/feishu/src/probe.test.ts",
+  "extensions/feishu/src/send.reply-fallback.test.ts",
+  "extensions/googlechat/src/monitor.webhook-routing.test.ts",
+  "extensions/imessage/src/accounts.test.ts",
+  "extensions/imessage/src/monitor/deliver.test.ts",
+  "extensions/imessage/src/monitor/inbound-processing.test.ts",
+  "extensions/imessage/src/monitor/parse-notification.test.ts",
+  "extensions/irc/src/send.test.ts",
+  "extensions/line/src/channel.sendPayload.test.ts",
+  "extensions/matrix/src/channel.directory.test.ts",
+  "extensions/matrix/src/manifest.test.ts",
+  "extensions/matrix/src/matrix/format.test.ts",
+  "extensions/matrix/src/matrix/monitor/allowlist.test.ts",
+  "extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts",
+  "extensions/matrix/src/matrix/monitor/index.test.ts",
+  "extensions/mattermost/channel-plugin-api.test.ts",
+  "extensions/mattermost/src/mattermost/interactions.test.ts",
+  "extensions/mattermost/src/mattermost/monitor-auth.test.ts",
+  "extensions/mattermost/src/mattermost/reply-delivery.test.ts",
+  "extensions/msteams/src/attachments.test.ts",
+  "extensions/msteams/src/attachments/shared.test.ts",
+  "extensions/msteams/src/channel.directory.test.ts",
+  "extensions/msteams/src/file-consent.test.ts",
+  "extensions/msteams/src/monitor-handler.file-consent.test.ts",
+  "extensions/msteams/src/monitor-handler/message-handler.authz.test.ts",
+  "extensions/msteams/src/monitor-handler/message-handler.thread-session.test.ts",
+  "extensions/msteams/src/probe.test.ts",
+  "extensions/nextcloud-talk/src/channel.core.test.ts",
+  "extensions/nextcloud-talk/src/monitor.replay.test.ts",
+  "extensions/nextcloud-talk/src/room-info.test.ts",
+  "extensions/nextcloud-talk/src/send.cfg-threading.test.ts",
+  "extensions/nostr/src/channel.outbound.test.ts",
+  "extensions/signal/src/accounts.test.ts",
+  "extensions/signal/src/client.test.ts",
+  "extensions/slack/src/accounts.test.ts",
+  "extensions/slack/src/client.test.ts",
+  "extensions/slack/src/interactive-replies.test.ts",
+  "extensions/slack/src/message-actions.test.ts",
+  "extensions/slack/src/monitor.tool-result.test.ts",
+  "extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts",
+  "extensions/slack/src/monitor/message-handler/prepare.test.ts",
+  "extensions/slack/src/monitor/slash.test.ts",
+  "extensions/slack/src/probe.test.ts",
+  "extensions/slack/src/send.identity-fallback.test.ts",
+  "extensions/synology-chat/src/channel.test.ts",
+  "extensions/telegram/src/bot-message-context.audio-transcript.test.ts",
+  "extensions/telegram/src/bot-message-context.body.test.ts",
+  "extensions/telegram/src/bot-message-context.dm-threads.test.ts",
+  "extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts",
+  "extensions/telegram/src/bot-message-context.group-body.test.ts",
+  "extensions/telegram/src/bot-message-context.named-account-dm.test.ts",
+  "extensions/telegram/src/bot-message-context.silent-ingest.test.ts",
+  "extensions/telegram/src/bot-message-context.thread-binding.test.ts",
+  "extensions/telegram/src/bot-message-context.topic-agentid.test.ts",
+  "extensions/telegram/src/bot-message-dispatch.test.ts",
+  "extensions/telegram/src/bot-native-commands.session-meta.test.ts",
+  "extensions/telegram/src/bot-native-commands.test.ts",
+  "extensions/telegram/src/bot.create-telegram-bot.test.ts",
+  "extensions/telegram/src/bot.test.ts",
+  "extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts",
+  "extensions/telegram/src/bot/delivery.test.ts",
+  "extensions/telegram/src/format.wrap-md.test.ts",
+  "extensions/telegram/src/network-config.test.ts",
+  "extensions/telegram/src/sequential-key.test.ts",
+  "extensions/twitch/src/config.test.ts",
+  "extensions/twitch/src/token.test.ts",
+  "extensions/voice-call/src/manager.inbound-allowlist.test.ts",
+  "extensions/voice-call/src/manager/events.test.ts",
+  "extensions/voice-call/src/providers/plivo.test.ts",
+  "extensions/voice-call/src/providers/telnyx.test.ts",
+  "extensions/voice-call/src/providers/twilio.test.ts",
+  "extensions/voice-call/src/runtime.test.ts",
+  "extensions/voice-call/src/webhook-security.test.ts",
+  "extensions/voice-call/src/webhook.test.ts",
+  "extensions/whatsapp/src/auto-reply.broadcast-groups.combined.test.ts",
+  "extensions/whatsapp/src/auto-reply/monitor/last-route.test.ts",
+  "extensions/whatsapp/src/auto-reply/monitor/on-message.audio-preflight.test.ts",
+  "extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts",
+  "extensions/whatsapp/src/group-session-key.test.ts",
+  "extensions/whatsapp/src/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test.ts",
+  "extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts",
+  "extensions/whatsapp/src/session-contract.test.ts",
+  "extensions/whatsapp/src/session.test.ts",
+  "extensions/zalo/runtime-api.test.ts",
+  "extensions/zalo/src/monitor.webhook.test.ts",
+  "extensions/zalo/src/token.test.ts",
+  "extensions/zalouser/src/channel.directory.test.ts",
+  "extensions/zalouser/src/channel.sendpayload.test.ts",
+  "extensions/zalouser/src/channel.test.ts",
+  "extensions/zalouser/src/monitor.group-gating.test.ts",
+  "extensions/zalouser/src/security-audit.test.ts",
+];
+
+/** Currently-failing test files under `src/auto-reply/**` (run by the `test-auto-reply` lane). */
+export const AUTO_REPLY_QUARANTINE: string[] = [
+  "src/auto-reply/command-control.test.ts",
+  "src/auto-reply/heartbeat-filter.test.ts",
+  "src/auto-reply/inbound.test.ts",
+  "src/auto-reply/reply/abort.test.ts",
+  "src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts",
+  "src/auto-reply/reply/commands-core.test.ts",
+  "src/auto-reply/reply/commands-session-lifecycle.test.ts",
+  "src/auto-reply/reply/commands-subagents-focus.test.ts",
+  "src/auto-reply/reply/commands.test.ts",
+  "src/auto-reply/reply/dispatch-from-config.test.ts",
+  "src/auto-reply/reply/followup-runner.channel-bridge.test.ts",
+  "src/auto-reply/reply/reply-flow.test.ts",
+  "src/auto-reply/reply/reply-media-paths.test.ts",
+  "src/auto-reply/reply/reply-plumbing.test.ts",
+  "src/auto-reply/reply/route-reply.test.ts",
+  "src/auto-reply/reply/session-reset-prompt.test.ts",
+  "src/auto-reply/reply/session.test.ts",
+  "src/auto-reply/reply/strip-inbound-meta.test.ts",
+  "src/auto-reply/status.test.ts",
+];

--- a/vitest.scoped-config.ts
+++ b/vitest.scoped-config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vitest/config";
 import baseConfig from "./vitest.config.ts";
 
-export function createScopedVitestConfig(include: string[]) {
+export function createScopedVitestConfig(include: string[], extraExclude: string[] = []) {
   const base = baseConfig as unknown as Record<string, unknown>;
   const baseTest = (baseConfig as { test?: { exclude?: string[] } }).test ?? {};
   const exclude = baseTest.exclude ?? [];
@@ -11,7 +11,10 @@ export function createScopedVitestConfig(include: string[]) {
     test: {
       ...baseTest,
       include,
-      exclude,
+      // `extraExclude` is the per-lane quarantine denylist (see vitest.quarantine.ts):
+      // currently-failing test files excluded so the lane can be a required, green gate
+      // that still catches NEW regressions in every non-quarantined file.
+      exclude: [...exclude, ...extraExclude],
     },
   });
 }


### PR DESCRIPTION
Closes #2779.

## Problem

`extensions/**` (every channel adapter) and `src/auto-reply/**` test suites exist but run in **no CI job** — `pnpm test` uses `vitest.unit.config.ts`, which explicitly excludes both trees. Regressions in any adapter or the reply path merge green. This is the gap that let #2775 ship broken (its `extensions/bluebubbles` + `extensions/discord` changes were validated only by manual local runs).

## Change

Two new lanes, mirroring the existing `test-gateway` pattern (separate runner, own scoped config, aggregated into the required `CI` rollup):

| Lane | Config | Scope |
|------|--------|-------|
| `test-extensions` | `vitest.extensions.config.ts` | `extensions/**/*.test.ts` (adapters + extension-side auto-reply handlers) |
| `test-auto-reply` | `vitest.auto-reply.config.ts` (new) | repo-root `src/auto-reply/**/*.test.ts` (non-overlapping) |

Both added to the `CI` job's `needs:` + `Check results` condition, so a failure in either blocks merge.

## The quarantine (why this is green)

Enabling the lanes surfaces a large volume of **pre-existing** failures (locally: 119 extension files / 19 repo-root auto-reply files). Fixing them is a separate, unbounded effort — blocking this coverage gate on it would leave the gate permanently red.

Instead, currently-failing test **files** are listed in `vitest.quarantine.ts` and excluded per lane. Each lane is therefore **required-and-green** while still failing CI on any NEW breakage in every non-quarantined (or newly-added) file — exactly the regression class #2779 targets. The ledger is a debt list to shrink to zero; **un-quarantining is tracked in #2782.**

## Acceptance criteria

- ✅ **A broken test in `extensions/**` fails CI** — verified locally with a temporary probe: the lane picked it up (337 = 336 green + 1 probe) and failed (exit 1).
- ✅ **A broken test in `src/auto-reply/**` fails CI** — same, `src/auto-reply/` probe → 43 = 42 + 1, exit 1. (Probes removed, never committed.)
- ✅ **CI rollup depends on the lanes** — both in `CI.needs` + the `Check results` gate.
- ⏳ **`main` green with lanes enabled** — the quarantine was seeded from a local run (**Node 26 + dev env**); the CI runner (**Node 22, clean ubuntu**) has a different failure set, so the ledger is being reconciled against this PR's own CI until both lanes are green.

## Scope

Bounded first slice — **wire the lanes + quarantine** — per the issue's "fix **or** quarantine" call-out and the operator inventory comment ("scope step 1 as its own task"). Explicitly **not** in scope:
- Fixing/triaging the quarantined files → #2782.
- The 2 `pi-embedded`-mock test files → already tracked in #2781.
- `src/commands/**` (also CI-excluded, but outside this issue's scope).

> A parallel `test/vitest/` project system exists but is **local-only** tooling (used by `scripts/bench-test-changed.mjs`, wired into no workflow), so it does not close this gap.

_Merge is deferred to the maintainer/orchestrator; this PR is driven to CI-green first._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
