### PR TITLE
fix(feishu): guard un-catch'd WSClient message handler against gateway crash

### DIFF
--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -16,6 +16,7 @@ import {
   recordWebhookStatus,
   wsClients,
 } from "./monitor.state.js";
+import { registerFeishuWsUnhandledRejectionGuard } from "./monitor.unhandled-rejection.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 export type MonitorTransportParams = {
@@ -40,6 +41,12 @@ export async function monitorWebSocket({
   const wsClient = await createFeishuWSClient(account);
   wsClients.set(accountId, wsClient);
 
+  // The vendored Lark SDK's WSClient 'message' handler runs an un-`.catch()`'d
+  // async path (decode / control JSON.parse), so a single malformed inbound frame
+  // rejects uncaught and the central handler crashes the WHOLE gateway. Guard it
+  // for the lifetime of this connection (unregistered in cleanup below).
+  const unregisterUnhandledRejection = registerFeishuWsUnhandledRejectionGuard(accountId, error);
+
   return new Promise((resolve, reject) => {
     let cleanedUp = false;
 
@@ -48,6 +55,7 @@ export async function monitorWebSocket({
         return;
       }
       cleanedUp = true;
+      unregisterUnhandledRejection();
       abortSignal?.removeEventListener("abort", handleAbort);
       try {
         wsClient.close();

--- a/extensions/feishu/src/monitor.unhandled-rejection.test.ts
+++ b/extensions/feishu/src/monitor.unhandled-rejection.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { isUnhandledRejectionHandled } from "../../../src/infra/unhandled-rejections.js";
+import {
+  isFeishuSdkUnhandledRejection,
+  registerFeishuWsUnhandledRejectionGuard,
+} from "./monitor.unhandled-rejection.js";
+
+// A representative stack for the malformed-frame crash class: a protobuf decode
+// failure thrown inside the vendored Lark SDK's bundled index.js.
+const SDK_STACK = [
+  "RangeError: index out of range: 42 + 8 > 40",
+  "    at Reader.uint32 (/repo/node_modules/@larksuiteoapi/node-sdk/lib/index.js:1:1)",
+  "    at Frame.decode (/repo/node_modules/@larksuiteoapi/node-sdk/lib/index.js:84871:1)",
+  "    at decode (/repo/node_modules/@larksuiteoapi/node-sdk/lib/index.js:85150:1)",
+].join("\n");
+
+function sdkError(): Error {
+  const err = new Error("index out of range");
+  err.stack = SDK_STACK;
+  return err;
+}
+
+function foreignError(): Error {
+  const err = new Error("genuine bug");
+  err.stack = "Error: genuine bug\n    at handler (/repo/src/gateway/server.js:2:2)";
+  return err;
+}
+
+describe("isFeishuSdkUnhandledRejection", () => {
+  it("matches an error thrown inside the Lark SDK", () => {
+    expect(isFeishuSdkUnhandledRejection(sdkError())).toBe(true);
+  });
+
+  it("ignores an error thrown outside the Lark SDK", () => {
+    expect(isFeishuSdkUnhandledRejection(foreignError())).toBe(false);
+  });
+
+  it("ignores non-Error reasons and stackless errors", () => {
+    expect(isFeishuSdkUnhandledRejection("not an error")).toBe(false);
+    expect(isFeishuSdkUnhandledRejection(undefined)).toBe(false);
+    expect(isFeishuSdkUnhandledRejection(null)).toBe(false);
+    const stackless = new Error("no stack");
+    stackless.stack = undefined;
+    expect(isFeishuSdkUnhandledRejection(stackless)).toBe(false);
+  });
+});
+
+describe("registerFeishuWsUnhandledRejectionGuard", () => {
+  it("suppresses SDK-origin rejections through the central handler only while registered", () => {
+    const log = vi.fn();
+
+    // Nothing suppresses the SDK error before the guard is registered.
+    expect(isUnhandledRejectionHandled(sdkError())).toBe(false);
+
+    const unregister = registerFeishuWsUnhandledRejectionGuard("acct-1", log);
+    try {
+      // A malformed-frame rejection is now handled — it won't reach process.exit(1).
+      expect(isUnhandledRejectionHandled(sdkError())).toBe(true);
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(log.mock.calls[0]?.[0]).toContain("feishu[acct-1]");
+      // A genuine unrelated rejection is still NOT suppressed — it must crash as before.
+      expect(isUnhandledRejectionHandled(foreignError())).toBe(false);
+    } finally {
+      unregister();
+    }
+
+    // After unregister the guard no longer suppresses anything.
+    expect(isUnhandledRejectionHandled(sdkError())).toBe(false);
+  });
+});

--- a/extensions/feishu/src/monitor.unhandled-rejection.ts
+++ b/extensions/feishu/src/monitor.unhandled-rejection.ts
@@ -1,0 +1,50 @@
+import { registerUnhandledRejectionHandler } from "remoteclaw/plugin-sdk/feishu";
+
+/**
+ * True when an unhandled rejection originated inside the vendored Lark SDK
+ * (`@larksuiteoapi/node-sdk`).
+ *
+ * The SDK's `WSClient` message handler (`communicate()` registers
+ * `wsInstance.on("message", async …)`) runs three un-`.catch()`'d async steps —
+ * `decode(buffer)` (protobuf frame decode), `handleControlData` (`JSON.parse` of
+ * a pong payload) and `handleEventData` — before the only SDK-guarded call
+ * (`eventDispatcher.invoke`). A malformed inbound frame therefore rejects
+ * uncaught; the central handler classifies the resulting `RangeError` /
+ * `SyntaxError` as non-transient and calls `process.exit(1)`, taking down every
+ * channel — not just Feishu.
+ *
+ * A synchronous throw inside the SDK's bundled `index.js` always carries the
+ * package path in its V8 stack, so matching that path scopes suppression to
+ * SDK-origin rejections while a Feishu WebSocket connection is active. Any
+ * non-SDK rejection still reaches the fatal path unchanged.
+ */
+export function isFeishuSdkUnhandledRejection(reason: unknown): boolean {
+  return (
+    reason instanceof Error &&
+    typeof reason.stack === "string" &&
+    reason.stack.includes("@larksuiteoapi/node-sdk")
+  );
+}
+
+/**
+ * Register a process-level guard that turns an SDK-origin unhandled rejection (a
+ * malformed Feishu WebSocket frame) into a logged, dropped frame instead of a
+ * gateway crash. The reject site lives inside the vendored SDK's `'message'`
+ * listener and cannot be `.catch()`'d directly, so this mirrors the
+ * channel-scoped guards used by Slack/Discord/Telegram/WhatsApp.
+ *
+ * Returns an unregister function; call it when the connection is torn down so the
+ * guard's lifetime matches an active WebSocket connection.
+ */
+export function registerFeishuWsUnhandledRejectionGuard(
+  accountId: string,
+  error: (message: string) => void,
+): () => void {
+  return registerUnhandledRejectionHandler((reason) => {
+    if (!isFeishuSdkUnhandledRejection(reason)) {
+      return false;
+    }
+    error(`feishu[${accountId}]: dropped malformed WebSocket frame (non-fatal): ${String(reason)}`);
+    return true;
+  });
+}

--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -53,6 +53,7 @@ export { buildSecretInputSchema } from "./secret-input-schema.js";
 export { createDedupeCache } from "../infra/dedupe.js";
 export { installRequestBodyLimitGuard } from "../infra/http-body.js";
 export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+export { registerUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export type { PluginRuntime } from "../plugins/runtime/types.js";
 export type { AnyAgentTool, RemoteClawPluginApi } from "../plugins/types.js";


### PR DESCRIPTION
## What

Closes #2693 — a latent **whole-gateway** crash in the Feishu adapter.

The vendored `@larksuiteoapi/node-sdk` `WSClient` registers an async `'message'` handler (`communicate()`) that runs three un-`.catch()`'d steps — `decode(buffer)` (protobuf frame decode), `handleControlData` (`JSON.parse` of a pong payload) and `handleEventData` — before its only guarded call (`eventDispatcher.invoke`). A **malformed inbound frame** therefore rejects uncaught; the central unhandled-rejection handler classifies the resulting `RangeError` / `SyntaxError` as non-transient and calls `process.exit(1)`, crashing **every channel**, not just Feishu.

## Fix

The reject site lives inside the vendored SDK and can't be `.catch()`'d directly, so this mirrors the channel-scoped guards already used by Slack / Discord / Telegram / WhatsApp: a process-level unhandled-rejection guard, alive only for the lifetime of each WS connection, that drops (logs) rejections originating in the Lark SDK and lets every other rejection reach the fatal path unchanged.

| File | Change |
|------|--------|
| `extensions/feishu/src/monitor.unhandled-rejection.ts` (new) | `isFeishuSdkUnhandledRejection` discriminator (matches `@larksuiteoapi/node-sdk` in the V8 stack) + `registerFeishuWsUnhandledRejectionGuard` |
| `extensions/feishu/src/monitor.transport.ts` | register the guard in `monitorWebSocket`, unregister in `cleanup` |
| `src/plugin-sdk/feishu.ts` | re-export `registerUnhandledRejectionHandler` on the feishu plugin-sdk surface (boundary-clean subpath import for the bundled plugin) |

## Why the discrimination is conservative

- The guard is registered **only while a Feishu WS connection is active** (registered at start, unregistered in `cleanup`).
- It suppresses only rejections whose stack originates in the Lark SDK — a synchronous throw inside the SDK's bundled `index.js` always carries the package path in its V8 stack.
- A genuine unrelated rejection (or any rejection once no Feishu WS is active) still reaches `process.exit(1)` exactly as before.

## Tests

`extensions/feishu/src/monitor.unhandled-rejection.test.ts`:
- **discriminator** — SDK-origin → suppress; foreign / non-`Error` / stackless → pass through.
- **integration** — the registered guard suppresses an SDK-origin rejection through the **real** `isUnhandledRejectionHandled` (and logs it), a genuine unrelated rejection is still not suppressed, and after unregister nothing is suppressed.

Full feishu suite green (202 tests). Local pre-commit gate (tsgo + oxfmt + oxlint + css-drift audit) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
