### PR TITLE
fix(session): key cliSessionIds by CLI runtime, not messaging channel (#2786)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -219,7 +219,6 @@ export async function runAgentTurnWithFallback(params: {
       };
       const blockReplyPipeline = params.blockReplyPipeline;
       const onToolResult = params.opts?.onToolResult;
-      const provider = params.followupRun.run.provider;
 
       // Model fallback gutted in RemoteClaw — CLI agents handle their own model
       // selection and fallback. Run the agent directly with the configured model.
@@ -237,13 +236,17 @@ export async function runAgentTurnWithFallback(params: {
 
       let lifecycleTerminalEmitted = false;
       try {
-        // Session adapter: reads the CLI session ID from the auto-reply session entry.
-        const sessionMap = createSessionMapAdapter({
-          getSessionId: () => params.getActiveSessionEntry()?.cliSessionIds?.[provider],
-        });
-
         const cfg = params.followupRun.run.config;
         const agentId = params.followupRun.run.agentId;
+        // CLI session IDs are keyed by the resolved CLI runtime (e.g. "claude"),
+        // NOT the messaging channel (run.provider, e.g. "slack"). Keying by the
+        // channel dropped every session ID → no --resume → fresh session each
+        // message. See #2786 / #2105.
+        const cliRuntime = resolveAgentRuntimeOrThrow(cfg, agentId);
+        // Session adapter: reads the CLI session ID from the auto-reply session entry.
+        const sessionMap = createSessionMapAdapter({
+          getSessionId: () => params.getActiveSessionEntry()?.cliSessionIds?.[cliRuntime],
+        });
         const baseRuntimeEnv = resolveAgentRuntimeEnv(cfg, agentId);
 
         const messageToolHints = resolveChannelMessageToolHints({
@@ -338,7 +341,7 @@ export async function runAgentTurnWithFallback(params: {
           },
           async (runtimeEnv) => {
             const bridge = new ChannelBridge({
-              provider: resolveAgentRuntimeOrThrow(cfg, agentId),
+              provider: cliRuntime,
               sessionMap,
               gatewayUrl: resolveGatewayUrlFromConfig(cfg),
               gatewayToken: resolveGatewayTokenFromConfig(cfg),

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { resolveAgentRuntimeOrThrow } from "../../agents/agent-scope.js";
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
@@ -426,7 +427,12 @@ export async function runReplyAgent(params: {
         });
       }
     }
-    const cliSessionId = isCliProvider(providerUsed, cfg)
+    // CLI session IDs are keyed by the resolved CLI runtime (e.g. "claude"), NOT
+    // the messaging channel carried in `providerUsed` (e.g. "slack"). Keying by the
+    // channel made isCliProvider() false and dropped every session ID, so no
+    // --resume was ever passed and each message started fresh. See #2786 / #2105.
+    const cliRuntime = resolveAgentRuntimeOrThrow(cfg, followupRun.run.agentId);
+    const cliSessionId = isCliProvider(cliRuntime, cfg)
       ? (runResult.meta?.agentMeta?.sessionId as string | undefined)?.trim()
       : undefined;
     const contextTokensUsed =
@@ -443,6 +449,7 @@ export async function runReplyAgent(params: {
       promptTokens,
       modelUsed,
       providerUsed,
+      cliSessionProvider: cliRuntime,
       systemPromptReport: (runResult.meta as Record<string, unknown> | undefined)
         ?.systemPromptReport as
         | import("../../config/sessions.js").SessionSystemPromptReport

--- a/src/auto-reply/reply/session-usage.test.ts
+++ b/src/auto-reply/reply/session-usage.test.ts
@@ -55,6 +55,32 @@ describe("persistSessionUsageUpdate — CLI session ID persistence", () => {
     expect(patch.cliSessionIds?.["claude"]).toBe("sess-abc-123");
   });
 
+  it("keys cliSessionIds by cliSessionProvider (runtime), not providerUsed (channel) — #2786", async () => {
+    // Regression: the messaging channel ("slack") flows through providerUsed, but
+    // CLI session IDs must be keyed by the resolved runtime ("claude"). Keying by
+    // the channel produced cliSessionIds["slack"], which no reader ever resolves,
+    // so --resume never fired and every message started a fresh session.
+    const entry = makeEntry({ modelProvider: "slack" });
+    hoisted.updateSessionStoreEntryMock.mockImplementation(
+      async (params: { update: (e: SessionEntry) => Promise<Partial<SessionEntry>> }) => {
+        return params.update(entry);
+      },
+    );
+
+    await persistSessionUsageUpdate({
+      storePath: "/tmp/store.json",
+      sessionKey: "test-key",
+      usage: { input: 100, output: 50 },
+      providerUsed: "slack",
+      cliSessionProvider: "claude",
+      cliSessionId: "sess-runtime-keyed",
+    });
+
+    const patch = await hoisted.updateSessionStoreEntryMock.mock.results[0].value;
+    expect(patch.cliSessionIds?.["claude"]).toBe("sess-runtime-keyed");
+    expect(patch.cliSessionIds?.["slack"]).toBeUndefined();
+  });
+
   it("uses entry.modelProvider when providerUsed is absent", async () => {
     const entry = makeEntry({ modelProvider: "gemini" });
     hoisted.updateSessionStoreEntryMock.mockImplementation(

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -14,12 +14,17 @@ import { logVerbose } from "../../globals.js";
 function applyCliSessionIdToSessionPatch(
   params: {
     providerUsed?: string;
+    cliSessionProvider?: string;
     cliSessionId?: string;
   },
   entry: SessionEntry,
   patch: Partial<SessionEntry>,
 ): Partial<SessionEntry> {
-  const cliProvider = params.providerUsed ?? entry.modelProvider;
+  // Key CLI session IDs by the resolved CLI runtime (cliSessionProvider, e.g.
+  // "claude") when provided — NOT the messaging channel carried in providerUsed
+  // (e.g. "slack"), which is never a CLI runtime name and dropped every session
+  // ID. Falls back to providerUsed/modelProvider for non-channel callers. See #2786.
+  const cliProvider = params.cliSessionProvider ?? params.providerUsed ?? entry.modelProvider;
   if (params.cliSessionId && cliProvider) {
     const nextEntry = { ...entry, ...patch };
     setCliSessionId(nextEntry, cliProvider, params.cliSessionId);
@@ -45,6 +50,9 @@ export async function persistSessionUsageUpdate(params: {
   lastCallUsage?: NormalizedUsage;
   modelUsed?: string;
   providerUsed?: string;
+  /** Resolved CLI runtime (e.g. "claude") used to key `cliSessionIds` — distinct
+   *  from `providerUsed`, which carries the messaging channel (e.g. "slack"). See #2786. */
+  cliSessionProvider?: string;
   promptTokens?: number;
   systemPromptReport?: SessionSystemPromptReport;
   cliSessionId?: string;


### PR DESCRIPTION
## Summary

Fixes #2786 — channel conversations (Slack observed; **all** messaging channels affected) never resumed the Claude CLI session. Every inbound message spawned a fresh Claude process with no `--resume`, so the agent had zero prior context.

## Root cause

`cliSessionIds` was keyed by `run.provider` — the **messaging channel** (e.g. `"slack"`, from `ctx.Provider ?? ctx.Surface`) — instead of the **CLI runtime** (`resolveAgentRuntimeOrThrow` → `"claude"`, which the bridge already uses). A channel name is never a CLI runtime name, so:

- **Write**: `isCliProvider("slack")` is `false` → the CLI session ID was dropped and never persisted.
- **Read**: the session-map adapter looked up `cliSessionIds["slack"]` → always `undefined` → no `--resume`.

Re-manifestation of the #2105 class (`"unknown"` vs `"claude"`), now `"slack"` vs `"claude"`.

## Fix

Key `cliSessionIds` by `resolveAgentRuntimeOrThrow(cfg, agentId)` on both sides:

- **Read** — `agent-runner-execution.ts`: the session-map adapter reads `cliSessionIds[cliRuntime]`, and the bridge reuses the same resolved runtime (it recomputed it redundantly before).
- **Write** — `agent-runner.ts` gates capture on the runtime and passes a new `cliSessionProvider` field to `persistSessionUsageUpdate`; `session-usage.ts` keys `setCliSessionId` by it. `providerUsed`/`modelProvider` keep the channel for display.

## Tests

- New write-side regression in `session-usage.test.ts`: `providerUsed:"slack"` + `cliSessionProvider:"claude"` ⇒ `cliSessionIds["claude"]` is set and `["slack"]` is absent.
- Full `test-auto-reply` lane green (388 tests); `pnpm check` (format + typecheck + lint) clean.
- The read path's dedicated harness (`followup-runner.channel-bridge.test.ts`) is pre-quarantined (#2782) with unrelated failures, so the read change is covered by typecheck + the symmetric write-side test rather than adding a red test to a quarantined file.

## Scope / follow-ups

- **cron** (`isolated-agent/run.ts`) verified self-consistent (read and write use the same runtime-derived `provider`) — not affected.
- `commands/agent.ts` shows the same read-key-vs-runtime divergence pattern (`params.provider` at :185 vs `resolveAgentRuntimeOrThrow` at :189) — flagged for a follow-up audit, out of scope here.
- Separate low-severity cleanup (to be filed): make `providerUsed` resolve to the CLI runtime instead of falling back to the channel — the root conflation; this PR fixes the only consumer where it caused an outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
