### PR TITLE
fix(agents): never trash the user-owned workspace on agent delete

### DIFF
--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -242,7 +242,7 @@ ${formatHelpExamples([
 
   agents
     .command("delete <id>")
-    .description("Delete an agent and prune workspace/state")
+    .description("Delete an agent and prune agent state")
     .option("--force", "Skip confirmation", false)
     .option("--json", "Output JSON summary", false)
     .action(async (id, opts) => {

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -1,66 +1,14 @@
-import fs from "node:fs";
-import path from "node:path";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
-import { writeConfigFile, type RemoteClawConfig } from "../config/config.js";
+import { writeConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
-import { lowercasePreservingWhitespace } from "../shared/string-coerce.js";
 import { createClackPrompter } from "../wizard/clack-prompter.js";
 import { createQuietRuntime, requireValidConfig } from "./agents.command-shared.js";
 import { findAgentEntryIndex, listAgentEntries, pruneAgentConfig } from "./agents.config.js";
 import { moveToTrash } from "./onboard-helpers.js";
-
-function normalizeWorkspacePathForComparison(input: string): string {
-  const resolved = path.resolve(input.replaceAll("\0", ""));
-  let normalized = resolved;
-  try {
-    normalized = fs.realpathSync.native(resolved);
-  } catch {
-    // Keep lexical path for non-existent directories.
-  }
-  if (process.platform === "win32") {
-    return lowercasePreservingWhitespace(normalized);
-  }
-  return normalized;
-}
-
-function isPathWithinRoot(candidatePath: string, rootPath: string): boolean {
-  const relative = path.relative(rootPath, candidatePath);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-}
-
-function workspacePathsOverlap(left: string, right: string): boolean {
-  const normalizedLeft = normalizeWorkspacePathForComparison(left);
-  const normalizedRight = normalizeWorkspacePathForComparison(right);
-  return (
-    isPathWithinRoot(normalizedLeft, normalizedRight) ||
-    isPathWithinRoot(normalizedRight, normalizedLeft)
-  );
-}
-
-function findOverlappingWorkspaceAgentIds(
-  cfg: RemoteClawConfig,
-  agentId: string,
-  workspaceDir: string,
-): string[] {
-  const entries = listAgentEntries(cfg);
-  const normalizedAgentId = normalizeAgentId(agentId);
-  const overlappingAgentIds: string[] = [];
-  for (const entry of entries) {
-    const otherAgentId = normalizeAgentId(entry.id);
-    if (otherAgentId === normalizedAgentId) {
-      continue;
-    }
-    const otherWorkspace = resolveAgentWorkspaceDir(cfg, otherAgentId);
-    if (workspacePathsOverlap(workspaceDir, otherWorkspace)) {
-      overlappingAgentIds.push(otherAgentId);
-    }
-  }
-  return overlappingAgentIds;
-}
 
 type AgentsDeleteOptions = {
   id: string;
@@ -103,7 +51,7 @@ export async function agentsDeleteCommand(
     }
     const prompter = createClackPrompter();
     const confirmed = await prompter.confirm({
-      message: `Delete agent "${agentId}" and prune workspace/state?`,
+      message: `Delete agent "${agentId}" and prune agent state?`,
       initialValue: false,
     });
     if (!confirmed) {
@@ -123,16 +71,9 @@ export async function agentsDeleteCommand(
   }
 
   const quietRuntime = opts.json ? createQuietRuntime(runtime) : runtime;
-  // Only trash the workspace if no other agent can depend on that path.
-  const workspaceSharedWith = findOverlappingWorkspaceAgentIds(cfg, agentId, workspaceDir);
-  const workspaceRetained = workspaceSharedWith.length > 0;
-  if (workspaceRetained) {
-    quietRuntime.log(
-      `Skipped workspace removal (shared with other agents: ${workspaceSharedWith.join(", ")}): ${workspaceDir}`,
-    );
-  } else {
-    await moveToTrash(workspaceDir, quietRuntime);
-  }
+  // The workspace directory is user-owned — a project/git dir the user points
+  // RemoteClaw at, which RemoteClaw never created. Deleting an agent must NOT
+  // trash it. Only remove RemoteClaw-owned state (agent dir + session transcripts).
   await moveToTrash(agentDir, quietRuntime);
   await moveToTrash(sessionsDir, quietRuntime);
 
@@ -142,9 +83,7 @@ export async function agentsDeleteCommand(
         {
           agentId,
           workspace: workspaceDir,
-          workspaceRetained: workspaceRetained || undefined,
-          workspaceRetainedReason: workspaceRetained ? "shared" : undefined,
-          workspaceSharedWith: workspaceRetained ? workspaceSharedWith : undefined,
+          workspacePreserved: true,
           agentDir,
           sessionsDir,
           removedBindings: result.removedBindings,

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -185,174 +185,8 @@ describe("agents delete command", () => {
     });
   });
 
-  it("skips workspace removal when another agent shares the same workspace (#70890)", async () => {
-    await withStateDirEnv("remoteclaw-agents-delete-shared-workspace-", async ({ stateDir }) => {
-      const sharedWorkspace = path.join(stateDir, "workspace-shared");
-      await fs.mkdir(sharedWorkspace, { recursive: true });
-
-      const now = Date.now();
-      const cfg: RemoteClawConfig = {
-        agents: {
-          list: [
-            { id: "main", workspace: sharedWorkspace },
-            { id: "ops", workspace: sharedWorkspace },
-          ],
-        },
-      } satisfies RemoteClawConfig;
-      await arrangeAgentsDeleteTest({
-        stateDir,
-        cfg,
-        deletedAgentId: "ops",
-        sessions: {
-          "agent:ops:main": { sessionId: "sess-ops-main", updatedAt: now + 1 },
-          "agent:main:main": { sessionId: "sess-main", updatedAt: now + 2 },
-        },
-      });
-
-      await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
-
-      // Workspace should still exist — it was shared
-      const stat = await fs.stat(sharedWorkspace).catch(() => null);
-      expect(stat).not.toBeNull();
-
-      // The JSON output should report why the workspace was retained.
-      const jsonOutput = readJsonLogs();
-      expect(jsonOutput).toHaveLength(1);
-      expect(jsonOutput[0]).toMatchObject({
-        workspaceRetained: true,
-        workspaceRetainedReason: "shared",
-        workspaceSharedWith: ["main"],
-      });
-      expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalledWith(
-        ["trash", sharedWorkspace],
-        { timeoutMs: 5000 },
-      );
-    });
-  });
-
-  it("skips workspace removal when another agent workspace overlaps a child path (#70890)", async () => {
-    await withStateDirEnv(
-      "remoteclaw-agents-delete-overlapping-workspace-",
-      async ({ stateDir }) => {
-        const sharedWorkspace = path.join(stateDir, "workspace-shared");
-        const childWorkspace = path.join(sharedWorkspace, "ops-child");
-        await fs.mkdir(childWorkspace, { recursive: true });
-
-        const now = Date.now();
-        const cfg: RemoteClawConfig = {
-          agents: {
-            list: [
-              { id: "main", workspace: sharedWorkspace },
-              { id: "ops", workspace: childWorkspace },
-            ],
-          },
-        } satisfies RemoteClawConfig;
-        await arrangeAgentsDeleteTest({
-          stateDir,
-          cfg,
-          deletedAgentId: "ops",
-          sessions: {
-            "agent:ops:main": { sessionId: "sess-ops-main", updatedAt: now + 1 },
-            "agent:main:main": { sessionId: "sess-main", updatedAt: now + 2 },
-          },
-        });
-
-        await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
-
-        expect(readJsonLogs()[0]).toMatchObject({
-          workspaceRetained: true,
-          workspaceSharedWith: ["main"],
-        });
-        expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalledWith(
-          ["trash", childWorkspace],
-          { timeoutMs: 5000 },
-        );
-      },
-    );
-  });
-
-  it("skips workspace removal when deleting a parent workspace that contains another agent workspace (#70890)", async () => {
-    await withStateDirEnv("remoteclaw-agents-delete-parent-workspace-", async ({ stateDir }) => {
-      const sharedWorkspace = path.join(stateDir, "workspace-shared");
-      const childWorkspace = path.join(sharedWorkspace, "main-child");
-      await fs.mkdir(childWorkspace, { recursive: true });
-
-      const now = Date.now();
-      const cfg: RemoteClawConfig = {
-        agents: {
-          list: [
-            { id: "main", workspace: childWorkspace },
-            { id: "ops", workspace: sharedWorkspace },
-          ],
-        },
-      } satisfies RemoteClawConfig;
-      await arrangeAgentsDeleteTest({
-        stateDir,
-        cfg,
-        deletedAgentId: "ops",
-        sessions: {
-          "agent:ops:main": { sessionId: "sess-ops-main", updatedAt: now + 1 },
-          "agent:main:main": { sessionId: "sess-main", updatedAt: now + 2 },
-        },
-      });
-
-      await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
-
-      expect(readJsonLogs()[0]).toMatchObject({
-        workspaceRetained: true,
-        workspaceSharedWith: ["main"],
-      });
-      expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalledWith(
-        ["trash", sharedWorkspace],
-        { timeoutMs: 5000 },
-      );
-    });
-  });
-
-  it.runIf(process.platform !== "win32")(
-    "skips workspace removal when another agent reaches the same directory through a symlink (#70890)",
-    async () => {
-      await withStateDirEnv("remoteclaw-agents-delete-symlink-workspace-", async ({ stateDir }) => {
-        const realWorkspace = path.join(stateDir, "workspace-real");
-        const aliasWorkspace = path.join(stateDir, "workspace-alias");
-        await fs.mkdir(realWorkspace, { recursive: true });
-        await fs.symlink(realWorkspace, aliasWorkspace, "dir");
-
-        const now = Date.now();
-        const cfg: RemoteClawConfig = {
-          agents: {
-            list: [
-              { id: "main", workspace: realWorkspace },
-              { id: "ops", workspace: aliasWorkspace },
-            ],
-          },
-        } satisfies RemoteClawConfig;
-        await arrangeAgentsDeleteTest({
-          stateDir,
-          cfg,
-          deletedAgentId: "ops",
-          sessions: {
-            "agent:ops:main": { sessionId: "sess-ops-main", updatedAt: now + 1 },
-            "agent:main:main": { sessionId: "sess-main", updatedAt: now + 2 },
-          },
-        });
-
-        await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
-
-        expect(readJsonLogs()[0]).toMatchObject({
-          workspaceRetained: true,
-          workspaceSharedWith: ["main"],
-        });
-        expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalledWith(
-          ["trash", aliasWorkspace],
-          { timeoutMs: 5000 },
-        );
-      });
-    },
-  );
-
-  it("trashes workspace when no other agent shares it", async () => {
-    await withStateDirEnv("remoteclaw-agents-delete-unique-workspace-", async ({ stateDir }) => {
+  it("never trashes the user-owned workspace, even when no other agent shares it (#587)", async () => {
+    await withStateDirEnv("remoteclaw-agents-delete-preserve-workspace-", async ({ stateDir }) => {
       const opsWorkspace = path.join(stateDir, "workspace-ops");
       const mainWorkspace = path.join(stateDir, "workspace-main");
       await fs.mkdir(opsWorkspace, { recursive: true });
@@ -379,10 +213,61 @@ describe("agents delete command", () => {
 
       await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
 
-      // trash command should have been called for the workspace
-      expect(processMocks.runCommandWithTimeout).toHaveBeenCalledWith(["trash", opsWorkspace], {
+      // The workspace is user-owned — never trash it, even though "ops" is the
+      // only agent using it (the pre-#587 behavior trashed the unique workspace).
+      expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalledWith(["trash", opsWorkspace], {
         timeoutMs: 5000,
       });
+
+      // JSON output signals the workspace was preserved rather than deleted.
+      const jsonOutput = readJsonLogs();
+      expect(jsonOutput).toHaveLength(1);
+      expect(jsonOutput[0]).toMatchObject({
+        workspace: opsWorkspace,
+        workspacePreserved: true,
+      });
+    });
+  });
+
+  it("still trashes RemoteClaw-owned state and never the workspace (#587)", async () => {
+    await withStateDirEnv("remoteclaw-agents-delete-owned-state-", async ({ stateDir }) => {
+      const opsWorkspace = path.join(stateDir, "workspace-ops");
+      const mainWorkspace = path.join(stateDir, "workspace-main");
+      await fs.mkdir(opsWorkspace, { recursive: true });
+      await fs.mkdir(mainWorkspace, { recursive: true });
+
+      const now = Date.now();
+      const cfg: RemoteClawConfig = {
+        agents: {
+          list: [
+            { id: "main", workspace: mainWorkspace },
+            { id: "ops", workspace: opsWorkspace },
+          ],
+        },
+      } satisfies RemoteClawConfig;
+      await arrangeAgentsDeleteTest({
+        stateDir,
+        cfg,
+        deletedAgentId: "ops",
+        sessions: {
+          "agent:ops:main": { sessionId: "sess-ops-main", updatedAt: now + 1 },
+          "agent:main:main": { sessionId: "sess-main", updatedAt: now + 2 },
+        },
+      });
+
+      await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
+
+      const trashCalls = processMocks.runCommandWithTimeout.mock.calls as unknown as Array<
+        [string[], unknown]
+      >;
+      const trashedPaths = trashCalls
+        .map((call) => call[0])
+        .filter((argv) => argv[0] === "trash")
+        .map((argv) => argv[1]);
+      // Delete still cleans up RemoteClaw-owned state (it is not a no-op)...
+      expect(trashedPaths.length).toBeGreaterThan(0);
+      // ...but the user-owned workspace is never among the trashed paths.
+      expect(trashedPaths).not.toContain(opsWorkspace);
     });
   });
 });

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -437,6 +437,13 @@ describe("agents.delete", () => {
     expect(mocks.writeConfigFile).toHaveBeenCalled();
     // moveToTrashBestEffort calls fs.access then movePathToTrash for each dir
     expect(mocks.movePathToTrash).toHaveBeenCalled();
+    // #587: the user-owned workspace must NOT be trashed — only RemoteClaw-owned dirs.
+    const trashedPaths = (mocks.movePathToTrash.mock.calls as unknown as Array<[string]>).map(
+      (call) => call[0],
+    );
+    expect(trashedPaths).toContain("/agents/test-agent");
+    expect(trashedPaths).toContain("/transcripts/test-agent");
+    expect(trashedPaths).not.toContain("/workspace/test-agent");
   });
 
   it("skips file deletion when deleteFiles is false", async () => {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -570,7 +570,6 @@ export const agentsHandlers: GatewayRequestHandlers = {
     }
 
     const deleteFiles = typeof params.deleteFiles === "boolean" ? params.deleteFiles : true;
-    const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
     const agentDir = resolveAgentDir(cfg, agentId);
     const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
 
@@ -578,11 +577,10 @@ export const agentsHandlers: GatewayRequestHandlers = {
     await writeConfigFile(result.config);
 
     if (deleteFiles) {
-      await Promise.all([
-        moveToTrashBestEffort(workspaceDir),
-        moveToTrashBestEffort(agentDir),
-        moveToTrashBestEffort(sessionsDir),
-      ]);
+      // The workspace is user-owned (a project/git dir the user points RemoteClaw
+      // at) — never trash it on delete. Only remove RemoteClaw-owned state
+      // (agent dir + session transcripts).
+      await Promise.all([moveToTrashBestEffort(agentDir), moveToTrashBestEffort(sessionsDir)]);
     }
 
     respond(true, { ok: true, agentId, removedBindings: result.removedBindings }, undefined);


### PR DESCRIPTION
## Problem

`agents delete` (CLI) and the gateway `agents.delete` handler moved the agent's **workspace** directory to trash whenever no other agent shared it. But the workspace is **user-owned** — a project/git directory the user points RemoteClaw at, which RemoteClaw never created — so trashing it on delete destroys the user's own files.

## Fix

Remove workspace trashing entirely from both delete paths. Only RemoteClaw-owned state is pruned now:

- the agent state directory
- session transcripts

This also drops the now-dead shared-workspace overlap detection (workspace-path normalization / containment / overlap helpers), which only existed to decide whether trashing the workspace was safe — moot once we never trash it.

JSON output now reports `workspace` plus `workspacePreserved: true`.

## Tests

- **Gateway** (`agents-mutate.test.ts`, runs in the `test-gateway` CI lane): asserts the workspace is never among the trashed paths — 29/29 pass.
- **CLI** (`agents.delete.test.ts`): two new `#587` tests assert the workspace is preserved even when it is unique to the deleted agent — both pass.

> Note: `src/commands/**` is excluded from the unit CI lane (`vitest.unit.config.ts`), so this CLI test file is not CI-gated. Three unrelated, **pre-existing** session-store tests in the same file already fail on `main` due to schema drift (`default:` deprecation / `writeConfigFile` migration) — untouched by this PR.

Fixes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)
