### PR TITLE
fix(session): resolve providerUsed to the CLI runtime, not the messaging channel (#2788)

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -387,10 +387,13 @@ export async function runReplyAgent(params: {
     const promptTokens = runResult.meta?.agentMeta?.promptTokens as number | undefined;
     const modelUsed =
       (runResult.meta?.agentMeta?.model as string | undefined) ?? fallbackModel ?? defaultModel;
+    // The CLI runtime of record for this run (e.g. "claude"). run.provider carries
+    // the messaging channel (e.g. "slack") — NOT a provider of record — so falling
+    // back to it mislabelled modelProvider and misresolved auth mode. Fall back to
+    // the resolved runtime instead; it also keys cliSessionIds below. See #2788 / #2786.
+    const cliRuntime = resolveAgentRuntimeOrThrow(cfg, followupRun.run.agentId);
     const providerUsed =
-      (runResult.meta?.agentMeta?.provider as string | undefined) ??
-      fallbackProvider ??
-      followupRun.run.provider;
+      (runResult.meta?.agentMeta?.provider as string | undefined) ?? fallbackProvider ?? cliRuntime;
     const verboseEnabled = resolvedVerboseLevel !== "off";
     const selectedProvider = followupRun.run.provider;
     const selectedModel = followupRun.run.model;
@@ -427,11 +430,10 @@ export async function runReplyAgent(params: {
         });
       }
     }
-    // CLI session IDs are keyed by the resolved CLI runtime (e.g. "claude"), NOT
-    // the messaging channel carried in `providerUsed` (e.g. "slack"). Keying by the
-    // channel made isCliProvider() false and dropped every session ID, so no
+    // CLI session IDs are keyed by the resolved CLI runtime `cliRuntime` (e.g.
+    // "claude"), NOT the messaging channel (run.provider, e.g. "slack"). Keying by
+    // the channel made isCliProvider() false and dropped every session ID, so no
     // --resume was ever passed and each message started fresh. See #2786 / #2105.
-    const cliRuntime = resolveAgentRuntimeOrThrow(cfg, followupRun.run.agentId);
     const cliSessionId = isCliProvider(cliRuntime, cfg)
       ? (runResult.meta?.agentMeta?.sessionId as string | undefined)?.trim()
       : undefined;


### PR DESCRIPTION
## Summary

Closes #2788 — the low-severity follow-up to #2786 (merged). In the auto-reply run path, `providerUsed` fell back to `run.provider` — the messaging channel (e.g. `"slack"`) — instead of the CLI runtime (e.g. `"claude"`), because the runtime emits no `agentMeta.provider` and model-fallback is gutted. This was the root conflation behind #2786.

## Change

`src/auto-reply/reply/agent-runner.ts` — the final `providerUsed` fallback is now the resolved CLI runtime (`resolveAgentRuntimeOrThrow(cfg, followupRun.run.agentId)`) instead of `run.provider`. The runtime is resolved once and reused as the `cliSessionIds` key, removing #2786's duplicate resolution.

`run.provider` still carries the channel for `ChannelMessage.provider` — only the *provider of record for the model run* changes.

## Blast radius (verified)

Every consumer of `providerUsed` is either dead or wants the runtime:
- **Fallback-notice consumers** (`resolveFallbackTransition` at :402; `buildFallbackNotice` / `buildFallbackClearedNotice` at :529/:539/:601–640) are all **gutted stubs** — `fallback-state.ts` returns `{}` / `undefined`, so the block is dead code and the provider value is irrelevant.
- **Live consumers** — `modelProvider` persistence and `resolveModelAuthMode` / usage-line — are *provider-of-record* fields that should be the runtime. No consumer of `providerUsed` legitimately wants the channel; that leak was the defect.

## Tests

- `pnpm check` (format + typecheck + lint) clean.
- `test-auto-reply` lane green (42 files / 388 tests).
- No new unit test: the `providerUsed` computation lives in the `agent-runner` reply path whose dedicated harness (`agent-runner.misc.runreplyagent.test.ts`) is pre-quarantined (#2782). Covered by typecheck + the verified-dead blast radius + the auto-reply lane — same constraint as #2786's symmetric read-side.

## Follow-up filed separately — #2790

Auditing the `commands/agent.ts` divergence noted in #2788 confirmed a **separate, real #2105-class bug** in the `/agent` command path: `runAgentAttempt` reads/writes CLI sessions keyed by a model-provider (`"unknown"`, from `normalizeModelRef`) while the bridge uses the runtime — a both-sides fix needing `agentId` threading into `session-store.ts`. Different path and shape from this PR, so filed as **#2790** rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
