### PR TITLE
fix(onboarding): reject duplicate account id when adding a new account

### DIFF
--- a/src/plugin-sdk/onboarding.test.ts
+++ b/src/plugin-sdk/onboarding.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RemoteClawConfig } from "../config/config.js";
+import type { WizardPrompter, WizardTextParams } from "../wizard/prompts.js";
+import { promptAccountId } from "./onboarding.js";
+
+const cfg = {} as RemoteClawConfig;
+const listAccountIds = () => ["default", "pelykh"];
+
+function makePrompter(overrides: Record<string, unknown>): WizardPrompter {
+  return {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    note: vi.fn(async () => {}),
+    select: vi.fn(),
+    multiselect: vi.fn(),
+    text: vi.fn(),
+    confirm: vi.fn(),
+    progress: vi.fn(),
+    ...overrides,
+  } as unknown as WizardPrompter;
+}
+
+describe("promptAccountId — duplicate account id guard (#586)", () => {
+  it("rejects a new account id that collides with an existing one (normalized)", async () => {
+    let validate: WizardTextParams["validate"];
+    const prompter = makePrompter({
+      select: vi.fn(async () => "__new__"),
+      text: vi.fn(async (params: WizardTextParams) => {
+        validate = params.validate;
+        return "unique-new-id";
+      }),
+    });
+
+    await promptAccountId({
+      cfg,
+      prompter,
+      label: "Slack",
+      listAccountIds,
+      defaultAccountId: "default",
+    });
+
+    expect(validate).toBeDefined();
+    // Exact and case/format variants of an existing id are rejected — the
+    // pre-#586 validate only checked for non-empty input, so these leaked through
+    // and silently overwrote the existing account.
+    expect(validate?.("pelykh")).toMatch(/already exists/);
+    expect(validate?.("Pelykh")).toMatch(/already exists/);
+    expect(validate?.("default")).toMatch(/already exists/);
+    // Empty input is still "Required".
+    expect(validate?.("")).toBe("Required");
+    // A genuinely new id passes validation.
+    expect(validate?.("brand-new")).toBeUndefined();
+  });
+
+  it("returns the normalized id for a unique new account", async () => {
+    const prompter = makePrompter({
+      select: vi.fn(async () => "__new__"),
+      text: vi.fn(async () => "BrandNew"),
+    });
+
+    const result = await promptAccountId({
+      cfg,
+      prompter,
+      label: "Slack",
+      listAccountIds,
+      defaultAccountId: "default",
+    });
+
+    expect(result).toBe("brandnew");
+  });
+
+  it("returns an existing id directly without prompting for a new one", async () => {
+    const textMock = vi.fn();
+    const prompter = makePrompter({
+      select: vi.fn(async () => "pelykh"),
+      text: textMock,
+    });
+
+    const result = await promptAccountId({
+      cfg,
+      prompter,
+      label: "Slack",
+      listAccountIds,
+      defaultAccountId: "default",
+    });
+
+    expect(result).toBe("pelykh");
+    expect(textMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/plugin-sdk/onboarding.ts
+++ b/src/plugin-sdk/onboarding.ts
@@ -13,6 +13,7 @@ export type PromptAccountIdParams = {
 
 export async function promptAccountId(params: PromptAccountIdParams): Promise<string> {
   const existingIds = params.listAccountIds(params.cfg);
+  const existingNormalized = new Set(existingIds.map((id) => normalizeAccountId(id)));
   const initial = params.currentId?.trim() || params.defaultAccountId || DEFAULT_ACCOUNT_ID;
   const choice = await params.prompter.select({
     message: `${params.label} account`,
@@ -32,7 +33,18 @@ export async function promptAccountId(params: PromptAccountIdParams): Promise<st
 
   const entered = await params.prompter.text({
     message: `New ${params.label} account id`,
-    validate: (value) => (value?.trim() ? undefined : "Required"),
+    validate: (value) => {
+      if (!value?.trim()) {
+        return "Required";
+      }
+      // #586: reject ids that collide with an existing account — normalized, so
+      // "Pelykh" is caught against an existing "pelykh". Otherwise the new tokens
+      // silently overwrite the existing account's configuration.
+      if (existingNormalized.has(normalizeAccountId(value))) {
+        return `Account "${value.trim()}" already exists — pick a different id`;
+      }
+      return undefined;
+    },
   });
   const normalized = normalizeAccountId(String(entered));
   if (String(entered).trim() !== normalized) {


### PR DESCRIPTION
## Problem

During channel/agent onboarding, "Add a new account" let the user enter an account id that **already exists**. The prompt's `validate` only checked for non-empty input, so a duplicate id passed — and the new tokens **silently overwrote** the existing account's configuration (the previous channel app setup was lost, with no warning).

## Root cause

`src/plugin-sdk/onboarding.ts` — the text prompt's `validate` callback checked only `value?.trim()`. `existingIds` was in scope but never consulted against the entered value.

## Fix

Reject ids that collide with an existing account. The comparison normalizes **both sides** via `normalizeAccountId`, so `Pelykh` is caught against an existing `pelykh` — otherwise it would pass validation and then normalize into a silent overwrite afterward.

## Tests

New `src/plugin-sdk/onboarding.test.ts` (CI-gated — `src/plugin-sdk/**` is not excluded from the unit lane):

- duplicate id (exact + case variant + `default`) → validation error
- empty input → still `"Required"`
- unique id → passes and returns the normalized id
- selecting an existing id returns it without prompting for a new one

Fixes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)
