### PR TITLE
fix(agent): resume CLI sessions on the /agent path — key by runtime, not model provider (#2790)

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -170,7 +170,6 @@ function isSessionExpiredBridgeError(error: string | undefined): boolean {
 async function runAgentAttempt(params: {
   cfg: ReturnType<typeof loadConfig>;
   sessionAgentId: string;
-  provider: string;
   runtimeEnv: Record<string, string>;
   message: ChannelMessage;
   abortSignal: AbortSignal | undefined;
@@ -181,12 +180,16 @@ async function runAgentAttempt(params: {
   sessionStore: Record<string, SessionEntry> | undefined;
   storePath: string;
 }): Promise<AgentDeliveryResult> {
+  // Key CLI sessions by the resolved CLI runtime (e.g. "claude") — the same value
+  // the bridge dispatches under — NOT the model provider (e.g. "unknown"), which
+  // isCliProvider() rejects, so no session ever resumed. See #2790 / #2786.
+  const cliRuntime = resolveAgentRuntimeOrThrow(params.cfg, params.sessionAgentId);
   const sessionMap = createSessionMapAdapter({
-    getSessionId: () => getCliSessionId(params.sessionEntryRef.current, params.provider),
+    getSessionId: () => getCliSessionId(params.sessionEntryRef.current, cliRuntime),
   });
 
   const bridge = new ChannelBridge({
-    provider: resolveAgentRuntimeOrThrow(params.cfg, params.sessionAgentId),
+    provider: cliRuntime,
     sessionMap,
     gatewayUrl: resolveGatewayUrlFromConfig(params.cfg),
     gatewayToken: resolveGatewayTokenFromConfig(params.cfg),
@@ -203,19 +206,19 @@ async function runAgentAttempt(params: {
   // Handle CLI session expired: clear stale session and retry once.
   if (
     isSessionExpiredBridgeError(bridgeResult.error) &&
-    getCliSessionId(params.sessionEntryRef.current, params.provider) &&
+    getCliSessionId(params.sessionEntryRef.current, cliRuntime) &&
     params.sessionKey &&
     params.sessionStore &&
     params.storePath
   ) {
     log.warn(
-      `CLI session expired, clearing from session store: provider=${params.provider} sessionKey=${params.sessionKey}`,
+      `CLI session expired, clearing from session store: provider=${cliRuntime} sessionKey=${params.sessionKey}`,
     );
 
     const entry = params.sessionStore[params.sessionKey];
     if (entry) {
       const updatedEntry = { ...entry };
-      const normalizedProvider = normalizeProviderId(params.provider);
+      const normalizedProvider = normalizeProviderId(cliRuntime);
       if (updatedEntry.cliSessionIds) {
         const newIds = { ...updatedEntry.cliSessionIds };
         delete newIds[normalizedProvider];
@@ -438,7 +441,6 @@ export async function agentCommand(
           runAgentAttempt({
             cfg,
             sessionAgentId,
-            provider,
             runtimeEnv,
             message,
             abortSignal: opts.abortSignal,
@@ -486,6 +488,7 @@ export async function agentCommand(
         sessionStore,
         defaultProvider: provider,
         defaultModel: model,
+        cliSessionProvider: resolveAgentRuntimeOrThrow(cfg, sessionAgentId),
         result,
       });
     }

--- a/src/commands/agent/session-store.test.ts
+++ b/src/commands/agent/session-store.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RemoteClawConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
+
+const hoisted = vi.hoisted(() => ({
+  updateSessionStoreMock: vi.fn(),
+}));
+
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions.js")>();
+  return {
+    ...actual,
+    updateSessionStore: (...args: unknown[]) => hoisted.updateSessionStoreMock(...args),
+  };
+});
+
+const { updateSessionStoreAfterAgentRun } = await import("./session-store.js");
+
+type MergeCb = (store: Record<string, SessionEntry>) => SessionEntry;
+
+async function runWith(params: { defaultProvider: string; cliSessionProvider?: string }) {
+  let merged: SessionEntry | undefined;
+  hoisted.updateSessionStoreMock.mockImplementation(async (_storePath: string, update: MergeCb) => {
+    merged = update({});
+    return merged;
+  });
+  await updateSessionStoreAfterAgentRun({
+    cfg: {} as RemoteClawConfig,
+    sessionId: "sess-1",
+    sessionKey: "key-1",
+    storePath: "/tmp/store.json",
+    sessionStore: {},
+    defaultProvider: params.defaultProvider,
+    defaultModel: "unknown",
+    cliSessionProvider: params.cliSessionProvider,
+    result: { meta: { agentMeta: { sessionId: "cli-sess-xyz" } } } as never,
+  });
+  return merged;
+}
+
+describe("updateSessionStoreAfterAgentRun — CLI session key (#2790)", () => {
+  beforeEach(() => {
+    hoisted.updateSessionStoreMock.mockReset();
+  });
+
+  it("keys cliSessionIds by cliSessionProvider (runtime), not the model provider", async () => {
+    // The /agent command resolves defaultProvider to the model provider ("unknown"),
+    // but CLI session IDs must be keyed by the resolved runtime ("claude") — the same
+    // key the bridge reads with. Keying by "unknown" is the #2790 no-resume bug.
+    const merged = await runWith({ defaultProvider: "unknown", cliSessionProvider: "claude" });
+    expect(merged?.cliSessionIds?.["claude"]).toBe("cli-sess-xyz");
+    expect(merged?.cliSessionIds?.["unknown"]).toBeUndefined();
+  });
+
+  it("drops the CLI session when keyed by a non-runtime provider (the pre-fix bug)", async () => {
+    // Without a runtime key, the key falls back to providerUsed ("unknown"), which
+    // isCliProvider() rejects — so nothing is persisted and --resume never fires.
+    const merged = await runWith({ defaultProvider: "unknown", cliSessionProvider: undefined });
+    expect(merged?.cliSessionIds).toBeUndefined();
+  });
+});

--- a/src/commands/agent/session-store.ts
+++ b/src/commands/agent/session-store.ts
@@ -25,6 +25,9 @@ export async function updateSessionStoreAfterAgentRun(params: {
   defaultModel: string;
   fallbackProvider?: string;
   fallbackModel?: string;
+  /** Resolved CLI runtime (e.g. "claude") used to key cliSessionIds — NOT the
+   *  model provider carried in defaultProvider/providerUsed. See #2790 / #2786. */
+  cliSessionProvider?: string;
   result: RunResult;
 }) {
   const {
@@ -37,6 +40,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
     defaultModel,
     fallbackProvider,
     fallbackModel,
+    cliSessionProvider,
     result,
   } = params;
 
@@ -68,10 +72,15 @@ export async function updateSessionStoreAfterAgentRun(params: {
     provider: providerUsed,
     model: modelUsed,
   });
-  if (isCliProvider(providerUsed, cfg)) {
+  // Key CLI session IDs by the resolved CLI runtime (cliSessionProvider, e.g.
+  // "claude"), NOT the model provider in providerUsed (e.g. "unknown"). Keying by
+  // "unknown" made isCliProvider() false and dropped the session ID, so the /agent
+  // command never passed --resume. providerUsed stays for display. See #2790 / #2786.
+  const cliSessionKey = cliSessionProvider ?? providerUsed;
+  if (isCliProvider(cliSessionKey, cfg)) {
     const cliSessionId = result.meta.agentMeta?.sessionId?.trim();
     if (cliSessionId) {
-      setCliSessionId(next, providerUsed, cliSessionId);
+      setCliSessionId(next, cliSessionKey, cliSessionId);
     }
   }
   next.abortedLastRun = result.meta.aborted ?? false;


### PR DESCRIPTION
## Summary

Closes #2790 — the `/agent` command path never resumed CLI sessions (each run started fresh, losing context) — the same #2105 / #2786 class in a different path. Surfaced by the audit for #2788.

## Root cause

`runAgentAttempt` (read) and `updateSessionStoreAfterAgentRun` (write) keyed CLI sessions by a **model provider** — default `"unknown"` (from `normalizeModelRef("unknown","unknown")`), or a stored `providerOverride` — while the `ChannelBridge` dispatched under the resolved **runtime** (`resolveAgentRuntimeOrThrow` → `"claude"`).

- **Write**: `isCliProvider("unknown")` is `false` → the CLI session ID was dropped (never persisted).
- **Read**: `getCliSessionId(entry, "unknown")` → always `undefined` → no `--resume`.

## Fix

Key both sides by `resolveAgentRuntimeOrThrow(cfg, sessionAgentId)` — the same value the bridge uses:

- **Read** (`agent.ts`): resolve the runtime once (`cliRuntime`); use it for the bridge provider, the session read, the session-expired check, and the stale-session clear. Removed the now-unused, misleading `provider` param from `runAgentAttempt`.
- **Write** (`session-store.ts`): added a `cliSessionProvider` param (the runtime, passed by the caller) and key `setCliSessionId` by it. `providerUsed` / `modelProvider` keep the model provider for display — mirrors #2786's `session-usage.ts` split.

## Tests

- `pnpm check` (format + typecheck + lint) clean.
- New regression test `src/commands/agent/session-store.test.ts` (2 tests) — asserts `cliSessionIds` is keyed by `cliSessionProvider` (`"claude"`), not the model provider, and that a non-runtime key drops the session (the pre-fix bug).
- ⚠️ **CI coverage gap**: `src/commands/**` is excluded from the unit lane (`vitest.unit.config.ts:24`) and has **no CI job**, so this test does **not** gate CI. Verified green locally: `pnpm exec vitest run src/commands/agent/session-store.test.ts --config vitest.config.ts` → 2 passed. (The missing `src/commands` lane is the same class of gap #2779 closed for `extensions/**` + `src/auto-reply/**`.)

## Verification note

Confirmed by code-symmetry (read + write keyed by model-provider vs bridge-by-runtime) and the regression test, rather than a live production repro like #2786 had. The both-sides key mismatch is unambiguous in the code.

## Related
- #2786 — the auto-reply manifestation (merged).
- #2788 — the auto-reply `providerUsed` cleanup (this audit's origin; PR #2791).
- #2105 — original CLI session key mismatch (`"unknown"` vs runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
