### PR TITLE
fix(session): surface run.sessionId onto agentMeta so channels resume CLI sessions (#2795)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.session-meta.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.session-meta.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { AgentDeliveryResult } from "../../middleware/types.js";
+import { surfaceCliSessionMeta } from "./agent-runner-execution.js";
+
+// The ChannelBridge returns the CLI session ID only on `run.sessionId` and does
+// NOT populate `meta.agentMeta` — the shape the auto-reply persistence path
+// (agent-runner.ts → session-usage.ts) reads. Before surfaceCliSessionMeta the
+// mapping was missing, so `cliSessionId` was always undefined, `cliSessionIds`
+// stayed empty, and `--resume` never fired — every Slack message started a fresh
+// CLI session. This is the value half of the #2786 fix (which keyed the map by
+// the runtime but had no value to store). See #2786 / #2105.
+function makeBridgeDelivery(
+  runOverrides?: Partial<AgentDeliveryResult["run"]>,
+  deliveryOverrides?: Partial<AgentDeliveryResult>,
+): AgentDeliveryResult {
+  return {
+    payloads: [{ text: "hello" }],
+    run: {
+      text: "hello",
+      sessionId: "892f0aa8-cli-session",
+      durationMs: 1200,
+      usage: { inputTokens: 10, outputTokens: 5 },
+      aborted: false,
+      ...runOverrides,
+    },
+    mcp: { sentTexts: [], sentMediaUrls: [], cronAdds: 0 },
+    error: undefined,
+    ...deliveryOverrides,
+  } as AgentDeliveryResult;
+}
+
+describe("surfaceCliSessionMeta — auto-reply CLI session persistence (#2786 value half)", () => {
+  it("surfaces run.sessionId as meta.agentMeta.sessionId (what the persist layer reads)", () => {
+    const out = surfaceCliSessionMeta(makeBridgeDelivery());
+    expect(out.meta?.agentMeta?.sessionId).toBe("892f0aa8-cli-session");
+  });
+
+  it("passes an undefined session ID through unchanged (new session, nothing to resume)", () => {
+    const out = surfaceCliSessionMeta(makeBridgeDelivery({ sessionId: undefined }));
+    expect(out.meta?.agentMeta?.sessionId).toBeUndefined();
+  });
+
+  it("does not disturb payloads, run, or error", () => {
+    const out = surfaceCliSessionMeta(makeBridgeDelivery());
+    expect(out.payloads).toHaveLength(1);
+    expect(out.run.sessionId).toBe("892f0aa8-cli-session");
+    expect(out.error).toBeUndefined();
+  });
+
+  it("preserves any pre-existing meta fields", () => {
+    const out = surfaceCliSessionMeta(
+      makeBridgeDelivery(undefined, { meta: { durationMs: 42, aborted: true } }),
+    );
+    expect(out.meta?.durationMs).toBe(42);
+    expect(out.meta?.aborted).toBe(true);
+    expect(out.meta?.agentMeta?.sessionId).toBe("892f0aa8-cli-session");
+  });
+});

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -82,6 +82,38 @@ function createSessionMapAdapter(params: { getSessionId: () => string | undefine
   } as unknown as SessionMap;
 }
 
+/**
+ * Surface the CLI session ID onto `meta.agentMeta` for the persistence layer.
+ *
+ * The ChannelBridge returns the CLI session ID only on `run.sessionId`, but the
+ * auto-reply persistence path (agent-runner.ts → session-usage.ts) reads it from
+ * `meta.agentMeta.sessionId` — the shape the /agent path builds in
+ * commands/agent/delivery.ts. On the bridge path that field is undefined, so
+ * `cliSessionId` resolves to undefined, `setCliSessionId` never fires,
+ * `cliSessionIds` stays empty, and `--resume` is never passed — every message
+ * starts a fresh CLI session with no prior context. This is the value half of
+ * the #2786 fix: #2786 keyed `cliSessionIds` by the resolved runtime, but the
+ * value was always undefined on this path, so no session was ever stored under
+ * any key. Mirror the /agent path so the runtime-keyed persistence has a value.
+ *
+ * Only `sessionId` is surfaced: `run.usage` (AgentUsage: inputTokens/…) has a
+ * different shape than the NormalizedUsage (input/…) the persistence layer
+ * casts it to, so surfacing it here would be a no-op — auto-reply token
+ * accounting is a separate concern. See #2786 / #2105.
+ */
+export function surfaceCliSessionMeta(delivery: AgentDeliveryResult): AgentDeliveryResult {
+  return {
+    ...delivery,
+    meta: {
+      ...delivery.meta,
+      agentMeta: {
+        ...delivery.meta?.agentMeta,
+        sessionId: delivery.run.sessionId,
+      },
+    },
+  };
+}
+
 /** Resolve gateway URL from config for local gateway. */
 function resolveGatewayUrlFromConfig(cfg: FollowupRun["run"]["config"]): string {
   const port = resolveGatewayPort(cfg ?? undefined);
@@ -384,7 +416,9 @@ export async function runAgentTurnWithFallback(params: {
         });
         lifecycleTerminalEmitted = true;
 
-        runResult = delivery;
+        // Surface run.sessionId onto meta.agentMeta so the persistence layer
+        // can store the CLI session ID and pass --resume next turn. See #2786.
+        runResult = surfaceCliSessionMeta(delivery);
       } catch (err) {
         if (!lifecycleTerminalEmitted) {
           emitAgentEvent({


### PR DESCRIPTION
## Summary

Closes #2795 — messaging channels (Slack, etc.) still started a **fresh Claude CLI session every message** despite #2786/#2788. Those fixed the session-map **key**; this supplies the missing **value**.

## Root cause

`ChannelBridge.handle()` carries the CLI session ID only on `run.sessionId`; it does **not** populate `meta.agentMeta` (`channel-bridge.ts:342` returns `{ payloads, run, mcp, error }`). The auto-reply persistence path reads `runResult.meta?.agentMeta?.sessionId` (`agent-runner.ts:438`) → always `undefined` → `applyCliSessionIdToSessionPatch` (`session-usage.ts:28`) never sets `cliSessionIds` → the SessionMap adapter `get()` returns `undefined` → no `--resume`.

The `/agent` path works because `commands/agent/delivery.ts:77-84` maps `run.sessionId → meta.agentMeta.sessionId`; the auto-reply path had no equivalent.

### Why #2786 / #2788 were necessary but insufficient
- **#2786** keyed `cliSessionIds` by the runtime (`"claude"`) not the channel (`"slack"`) — required for the *read* side, but the value was always `undefined`, so nothing was stored under **any** key.
- **#2788** changed `providerUsed`'s fallback to the runtime — a display / provider-of-record fix (there is no `agentMeta.provider` because there is no `agentMeta` at all on this path).

## Fix

`surfaceCliSessionMeta()` maps `run.sessionId → meta.agentMeta.sessionId` before the run result is returned, mirroring the `/agent` path. Now `cliSessionId` is defined → the `modelUsed` persist gate passes (`resolveDefaultModel` returns `"default"`) → `setCliSessionId(entry, "claude", id)` → next turn reads `cliSessionIds["claude"]` → `--resume`.

Scoped to `sessionId` only — `run.usage` (`AgentUsage`: `inputTokens/…`) has a different shape than the `NormalizedUsage` (`input/…`) the persistence layer casts it to, so surfacing it would be a no-op (separate pre-existing token-accounting gap, not fixed here).

## Tests

- New regression test `agent-runner-execution.session-meta.test.ts` (4 tests) in the **CI-gated `test-auto-reply` lane** (#2779) — asserts `run.sessionId` is surfaced onto `meta.agentMeta`, an undefined id passes through, and `payloads`/`run`/`error`/pre-existing-`meta` are preserved.
- `pnpm check` (format + typecheck + lint) clean.
- #2786's `session-usage.test.ts` still green (no regression).

## Verification

Traced the full read→write→resume chain in code and reconciled it against the production evidence from #2786 (real `session_id` per turn — `892f0aa8…`, `0e111d53…` — discarded; no `--resume`; stable key set-then-miss). Unlike #2790's `src/commands` path, this fix lands in a lane that **actually gates CI**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
