### PR TITLE
fix(cron): preserve defaults.auth in isolated agent runner merge

### DIFF
--- a/src/cron/isolated-agent/run.auth-retry.test.ts
+++ b/src/cron/isolated-agent/run.auth-retry.test.ts
@@ -41,8 +41,9 @@ vi.mock("../../agents/channel-tools.js", () => ({
 }));
 
 const resolveAgentRuntimeEnvMock = vi.fn();
+const resolveAgentConfigMock = vi.fn().mockReturnValue(undefined);
 vi.mock("../../agents/agent-scope.js", () => ({
-  resolveAgentConfig: vi.fn().mockReturnValue(undefined),
+  resolveAgentConfig: resolveAgentConfigMock,
   resolveAgentDir: vi.fn().mockReturnValue("/tmp/agent-dir"),
   resolveAgentRuntime: vi.fn().mockReturnValue("claude"),
   resolveAgentRuntimeArgs: vi.fn().mockReturnValue(undefined),
@@ -247,6 +248,7 @@ describe("runCronIsolatedAgentTurn — auth key retry wiring", () => {
     delete process.env.REMOTECLAW_TEST_FAST;
     resolveCronSessionMock.mockReturnValue(makeFreshSession());
     resolveAgentRuntimeEnvMock.mockReturnValue(undefined);
+    resolveAgentConfigMock.mockReturnValue(undefined);
 
     // Default: withAuthKeyRetry passes through to the execute callback
     withAuthKeyRetryMock.mockImplementation(
@@ -348,5 +350,24 @@ describe("runCronIsolatedAgentTurn — auth key retry wiring", () => {
 
     expect(result.status).toBe("error");
     expect(result.error).toContain("all auth keys exhausted");
+  });
+
+  it("#2083: preserves defaults.auth when the agent inherits auth (no explicit auth field)", async () => {
+    // An agent without an explicit `auth` yields { auth: undefined } from resolveAgentConfig.
+    resolveAgentConfigMock.mockReturnValue({ auth: undefined });
+
+    await runCronIsolatedAgentTurn(
+      makeParams({
+        agentId: "inheriting-agent",
+        cfg: {
+          agents: { defaults: { runtime: "claude" as const, auth: "claude:default-profile" } },
+        },
+      }),
+    );
+
+    // The merged cfg handed to withAuthKeyRetry must still carry the default auth profile —
+    // Object.assign must not clobber it with the override's `auth: undefined`.
+    const options = withAuthKeyRetryMock.mock.calls[0][0];
+    expect(options.cfg.agents.defaults.auth).toBe("claude:default-profile");
   });
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -178,10 +178,17 @@ export async function runCronIsolatedAgentTurn(params: {
         "cron isolated run: cannot resolve agent id — no agent specified and no sole agent configured",
     };
   }
+  // #2083: strip undefined-valued keys from the agent override before merging. An agent
+  // without an explicit `auth` (etc.) yields { auth: undefined } from resolveAgentConfig,
+  // and Object.assign would otherwise overwrite the configured `defaults.auth` with
+  // undefined — breaking auth env injection for cron runs that inherit the default profile.
+  const definedAgentOverride = Object.fromEntries(
+    Object.entries(agentConfigOverride ?? {}).filter(([, value]) => value !== undefined),
+  ) as Partial<AgentDefaultsConfig>;
   const agentCfg: AgentDefaultsConfig = Object.assign(
     {},
     params.cfg.agents?.defaults,
-    (agentConfigOverride ?? {}) as Partial<AgentDefaultsConfig>,
+    definedAgentOverride,
   );
   const cfgWithAgentDefaults: RemoteClawConfig = {
     ...params.cfg,


### PR DESCRIPTION
## Problem

An isolated cron job for an agent that **inherits** its auth profile (no explicit `auth` field) fails with `[CLI_ERROR] Not logged in · Please run /login`, even though `agents.defaults.auth` is configured. Interactive messages for the same agent work.

## Root cause

`src/cron/isolated-agent/run.ts` builds the effective agent config by merging the per-agent override onto `agents.defaults` with `Object.assign`:

```ts
Object.assign({}, params.cfg.agents?.defaults, agentConfigOverride ?? {})
```

`resolveAgentConfig` returns `{ auth: undefined }` for an agent without an explicit `auth`, and `Object.assign` copies that `undefined` over the configured `defaults.auth`. The clobbered `cfgWithAgentDefaults` is what the cron path passes to `withAuthKeyRetry` (#2079/#2081), so auth env injection sees no profile. The interactive path is unaffected because it passes the original `cfg`.

## Fix

Strip `undefined`-valued keys from the override before merging, so inherited fields fall through to the defaults:

```ts
const definedAgentOverride = Object.fromEntries(
  Object.entries(agentConfigOverride ?? {}).filter(([, value]) => value !== undefined),
);
Object.assign({}, params.cfg.agents?.defaults, definedAgentOverride);
```

## Tests

Adds a regression test in `run.auth-retry.test.ts`: with an agent whose `resolveAgentConfig` yields `{ auth: undefined }` and `defaults.auth` set, the merged cfg handed to `withAuthKeyRetry` still carries `defaults.auth`. Verified failing before the fix (`expected undefined to be 'claude:default-profile'`), passing after. This file runs in the unit CI lane.

## Upstream

The `Object.assign` merge originates from upstream OpenClaw (`bcbfb357be`, `d0ca02e963`, `d3f08884db`); the latent clobber applies to any inherited default field. Worth forwarding upstream separately.

Fixes #2083

🤖 Generated with [Claude Code](https://claude.com/claude-code)
