### PR TITLE
fix(cron): surface job status/error from `cron run` result

### DIFF
--- a/src/cron/service.delivery-plan.test.ts
+++ b/src/cron/service.delivery-plan.test.ts
@@ -79,7 +79,7 @@ describe("CronService delivery plan consistency", () => {
       });
 
       const result = await cron.run(job.id, "force");
-      expect(result).toEqual({ ok: true, ran: true });
+      expect(result).toMatchObject({ ok: true, ran: true });
       expect(enqueueSystemEvent).not.toHaveBeenCalled();
     });
   });
@@ -93,7 +93,7 @@ describe("CronService delivery plan consistency", () => {
       });
 
       const result = await cron.run(job.id, "force");
-      expect(result).toEqual({ ok: true, ran: true });
+      expect(result).toMatchObject({ ok: true, ran: true });
       expect(enqueueSystemEvent).toHaveBeenCalledWith(
         "Cron: done",
         expect.objectContaining({ agentId: undefined }),
@@ -118,7 +118,7 @@ describe("CronService delivery plan consistency", () => {
         });
 
         const result = await cron.run(job.id, "force");
-        expect(result).toEqual({ ok: true, ran: true });
+        expect(result).toMatchObject({ ok: true, ran: true });
         expect(enqueueSystemEvent).not.toHaveBeenCalled();
         expect(requestHeartbeatNow).not.toHaveBeenCalled();
       },

--- a/src/cron/service.every-jobs-fire.test.ts
+++ b/src/cron/service.every-jobs-fire.test.ts
@@ -163,13 +163,13 @@ describe("CronService interval/cron jobs fire on time", () => {
     for (let minute = 1; minute <= 3; minute++) {
       vi.setSystemTime(new Date(nowMs + minute * 60_000));
       const minuteRun = await cron.run("minute-cron", "force");
-      expect(minuteRun).toEqual({ ok: true, ran: true });
+      expect(minuteRun).toMatchObject({ ok: true, ran: true });
     }
 
     // "every" cadence is 2m; verify it stays due at the 6-minute boundary.
     vi.setSystemTime(new Date(nowMs + 6 * 60_000));
     const sfRun = await cron.run("legacy-every", "due");
-    expect(sfRun).toEqual({ ok: true, ran: true });
+    expect(sfRun).toMatchObject({ ok: true, ran: true });
 
     const sfRuns = enqueueSystemEvent.mock.calls.filter((args) => args[0] === "sf-tick").length;
     const minuteRuns = enqueueSystemEvent.mock.calls.filter(

--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -93,4 +93,37 @@ describe("CronService failure alerts", () => {
     cron.stop();
     await store.cleanup();
   });
+
+  it("#2084: surfaces the failed job's status and error in the run result", async () => {
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "cron announce delivery failed",
+    }));
+
+    const cron = createFailureAlertCron({
+      storePath: store.storePath,
+      runIsolatedAgentJob,
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "failing job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+    });
+
+    const result = await cron.run(job.id, "force");
+
+    expect(result).toMatchObject({ ok: true, ran: true, status: "error" });
+    expect((result as { error?: string }).error).toContain("cron announce delivery failed");
+
+    cron.stop();
+    await store.cleanup();
+  });
 });

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -288,7 +288,7 @@ describe("Cron issue regressions", () => {
     });
 
     const result = await cron.run("missing-enabled-due", "due");
-    expect(result).toEqual({ ok: true, ran: true });
+    expect(result).toMatchObject({ ok: true, ran: true });
     expect(enqueueSystemEvent).toHaveBeenCalledWith(
       "missing-enabled-due",
       expect.objectContaining({ agentId: undefined }),
@@ -508,7 +508,7 @@ describe("Cron issue regressions", () => {
     });
 
     const runResult = await cron.run("manual-target", "force");
-    expect(runResult).toEqual({ ok: true, ran: true });
+    expect(runResult).toMatchObject({ ok: true, ran: true });
 
     const jobs = await cron.list({ includeDisabled: true });
     const unrelated = jobs.find((entry) => entry.id === "unrelated-due");
@@ -556,7 +556,7 @@ describe("Cron issue regressions", () => {
     });
 
     const result = await cron.run(job.id, "force");
-    expect(result).toEqual({ ok: true, ran: true });
+    expect(result).toMatchObject({ ok: true, ran: true });
 
     const persisted = await loadCronStore(store.storePath);
     const persistedJob = persisted.jobs.find((entry) => entry.id === job.id);
@@ -1238,7 +1238,7 @@ describe("Cron issue regressions", () => {
     });
 
     const result = await cron.run(job.id, "force");
-    expect(result).toEqual({ ok: true, ran: true });
+    expect(result).toMatchObject({ ok: true, ran: true });
     expect(abortAwareRunner.getObservedAbortSignal()).toBeDefined();
     expect(abortAwareRunner.getObservedAbortSignal()?.aborted).toBe(true);
 
@@ -1506,7 +1506,7 @@ describe("Cron issue regressions", () => {
     });
 
     const result = await run(state, "stale-running", "force");
-    expect(result).toEqual({ ok: true, ran: true });
+    expect(result).toMatchObject({ ok: true, ran: true });
     expect(enqueueSystemEvent).toHaveBeenCalledWith(
       "stale-running",
       expect.objectContaining({ agentId: undefined }),

--- a/src/cron/service.read-ops-nonblocking.test.ts
+++ b/src/cron/service.read-ops-nonblocking.test.ts
@@ -203,7 +203,7 @@ describe("CronService read ops while job is running", () => {
       );
 
       isolatedRun.completeRun({ status: "ok", summary: "manual done" });
-      await expect(runPromise).resolves.toEqual({ ok: true, ran: true });
+      await expect(runPromise).resolves.toMatchObject({ ok: true, ran: true });
 
       const completed = await cron.list({ includeDisabled: true });
       expect(completed[0]?.state.lastStatus).toBe("ok");

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -1,7 +1,7 @@
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { assertSafeCronSessionTargetId } from "../session-target.js";
-import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
+import type { CronJob, CronJobCreate, CronJobPatch, CronRunStatus } from "../types.js";
 import { normalizeCronCreateDeliveryInput } from "./initial-delivery.js";
 import {
   applyJobPatch,
@@ -476,7 +476,7 @@ async function finishPreparedManualRun(
   state: CronServiceState,
   prepared: Extract<PreparedManualRun, { ran: true }>,
   mode?: "due" | "force",
-): Promise<void> {
+): Promise<{ status: CronRunStatus; error?: string }> {
   const executionJob = prepared.executionJob;
   const startedAt = prepared.startedAt;
   const jobId = prepared.jobId;
@@ -557,6 +557,8 @@ async function finishPreparedManualRun(
     await persist(state);
     armTimer(state);
   });
+
+  return { status: coreResult.status, error: coreResult.error };
 }
 
 export async function run(state: CronServiceState, id: string, mode?: "due" | "force") {
@@ -564,8 +566,10 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
   if (!prepared.ok || !prepared.ran) {
     return prepared;
   }
-  await finishPreparedManualRun(state, prepared, mode);
-  return { ok: true, ran: true } as const;
+  const outcome = await finishPreparedManualRun(state, prepared, mode);
+  // #2084: surface the job's execution outcome so callers can distinguish a run
+  // that executed-and-failed from one that succeeded (previously always { ok, ran }).
+  return { ok: true, ran: true, status: outcome.status, error: outcome.error } as const;
 }
 
 export async function enqueueRun(state: CronServiceState, id: string, mode?: "due" | "force") {

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -167,7 +167,7 @@ export type CronStatusSummary = {
 };
 
 export type CronRunResult =
-  | { ok: true; ran: true }
+  | { ok: true; ran: true; status: CronRunStatus; error?: string }
   | { ok: true; enqueued: true; runId: string }
   | { ok: true; ran: false; reason: "not-due" }
   | { ok: true; ran: false; reason: "already-running" }


### PR DESCRIPTION
## Problem

`cron run` (`CronService.run` → `ops.run`) always returned `{ ok: true, ran: true }`, regardless of whether the job's execution succeeded or failed. A job that **ran and errored** (e.g. an announce delivery failure, or an isolated agent turn that returned `status: "error"`) was indistinguishable from a clean success. Callers — notably the gateway `cron.run` handler (`src/gateway/server-methods/cron.ts`), which passes the result verbatim to its API clients — had no way to detect the failure.

## Fix

`finishPreparedManualRun` already computes the job's `coreResult` (`{ status, error, ... }`) but discarded it (returned `Promise<void>`). Thread that outcome out and include it in the run result:

```ts
// ops.run
const outcome = await finishPreparedManualRun(state, prepared, mode);
return { ok: true, ran: true, status: outcome.status, error: outcome.error } as const;
```

- `CronRunResult`'s `{ ok: true; ran: true }` variant is extended to `{ ok: true; ran: true; status: CronRunStatus; error?: string }`.
- `status` is the `CronRunStatus` (`"ok" | "error" | "skipped"`); `error` carries the failure message when present.
- **`ok: true` is retained** — the run *mechanically* completed; `status` carries the *job* outcome. This matches the existing `ok: true` skip returns (`ran: false, reason: ...`) and keeps RPC-success (the call returned) cleanly separate from job-outcome (what happened). The gateway passes the result verbatim, so API callers now see `status: "error"` + `error` without further changes.

This is the primary shape the issue requested: `{ ok: true, ran: true, status: "error", error: "..." }`.

## Tests

Adds a regression test in `service.failure-alert.test.ts`: a failing isolated job (`runIsolatedAgentJob → { status: "error", error }`) driven through `cron.run(job.id, "force")` now returns `status: "error"` and the error message. The assertion checks `status: "error"` — a field the old `{ ok: true, ran: true }` return never carried, so it fails on pre-fix code. `service.failure-alert.test.ts` runs in the CI unit lane. `tsgo` passes (the extended union has no other unguarded constructor).

Fixes #2084

🤖 Generated with [Claude Code](https://claude.com/claude-code)
