### PR TITLE
fix(session): record auto-reply token/context usage — surface + normalize run.usage (#2801)

### DIFF
--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -22,6 +22,9 @@ export type UsageLike = {
   // Common alternates across providers/SDKs.
   inputTokens?: number;
   outputTokens?: number;
+  // CLI-runtime AgentUsage camelCase cache fields (middleware/types.ts AgentUsage).
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
   promptTokens?: number;
   completionTokens?: number;
   input_tokens?: number;
@@ -117,6 +120,7 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
 
   const cacheRead = normalizeTokenCount(
     raw.cacheRead ??
+      raw.cacheReadTokens ??
       raw.cache_read ??
       raw.cache_read_input_tokens ??
       raw.cached_tokens ??
@@ -159,7 +163,7 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
       raw.timings?.predicted_n,
   );
   const cacheWrite = normalizeTokenCount(
-    raw.cacheWrite ?? raw.cache_write ?? raw.cache_creation_input_tokens,
+    raw.cacheWrite ?? raw.cacheWriteTokens ?? raw.cache_write ?? raw.cache_creation_input_tokens,
   );
   const total = normalizeTokenCount(raw.total ?? raw.totalTokens ?? raw.total_tokens);
 

--- a/src/auto-reply/reply/agent-runner-execution.session-meta.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.session-meta.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { NormalizedUsage } from "../../agents/usage.js";
 import type { AgentDeliveryResult } from "../../middleware/types.js";
 import { surfaceCliSessionMeta } from "./agent-runner-execution.js";
 
@@ -54,5 +55,37 @@ describe("surfaceCliSessionMeta — auto-reply CLI session persistence (#2786 va
     expect(out.meta?.durationMs).toBe(42);
     expect(out.meta?.aborted).toBe(true);
     expect(out.meta?.agentMeta?.sessionId).toBe("892f0aa8-cli-session");
+  });
+});
+
+describe("surfaceCliSessionMeta — usage normalization (#2801)", () => {
+  it("surfaces run.usage normalized to NormalizedUsage (inputTokens→input, outputTokens→output)", () => {
+    // The persistence layer reads meta.agentMeta.usage and treats it as
+    // NormalizedUsage (input/output). run.usage is AgentUsage (inputTokens/…);
+    // without normalization the field-name mismatch made every persisted count 0.
+    const out = surfaceCliSessionMeta(makeBridgeDelivery());
+    const usage = out.meta?.agentMeta?.usage as NormalizedUsage | undefined;
+    expect(usage?.input).toBe(10);
+    expect(usage?.output).toBe(5);
+  });
+
+  it("normalizes AgentUsage cache fields (cacheReadTokens→cacheRead, cacheWriteTokens→cacheWrite)", () => {
+    // These camelCase cache aliases were the specific gap: normalizeUsage did not
+    // recognize them, so cache counts persisted as zero even after usage surfaced.
+    const out = surfaceCliSessionMeta(
+      makeBridgeDelivery({
+        usage: { inputTokens: 100, outputTokens: 50, cacheReadTokens: 900, cacheWriteTokens: 20 },
+      }),
+    );
+    const usage = out.meta?.agentMeta?.usage as NormalizedUsage | undefined;
+    expect(usage?.input).toBe(100);
+    expect(usage?.output).toBe(50);
+    expect(usage?.cacheRead).toBe(900);
+    expect(usage?.cacheWrite).toBe(20);
+  });
+
+  it("leaves agentMeta.usage undefined when the run reported no usage", () => {
+    const out = surfaceCliSessionMeta(makeBridgeDelivery({ usage: undefined }));
+    expect(out.meta?.agentMeta?.usage).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -16,6 +16,7 @@ import {
 } from "../../agents/agent-scope.js";
 import { resolveChannelMessageToolHints } from "../../agents/channel-tools.js";
 import { resolveUserTimezone } from "../../agents/date-time.js";
+import { normalizeUsage } from "../../agents/usage.js";
 import { resolveGatewayPort } from "../../config/paths.js";
 import {
   resolveSessionTranscriptPath,
@@ -96,10 +97,10 @@ function createSessionMapAdapter(params: { getSessionId: () => string | undefine
  * value was always undefined on this path, so no session was ever stored under
  * any key. Mirror the /agent path so the runtime-keyed persistence has a value.
  *
- * Only `sessionId` is surfaced: `run.usage` (AgentUsage: inputTokens/…) has a
- * different shape than the NormalizedUsage (input/…) the persistence layer
- * casts it to, so surfacing it here would be a no-op — auto-reply token
- * accounting is a separate concern. See #2786 / #2105.
+ * `run.usage` is surfaced too, normalized from AgentUsage (inputTokens/…) to the
+ * NormalizedUsage (input/…) shape the persistence layer expects. Without the
+ * normalization the field-name mismatch made auto-reply token/context accounting
+ * a silent no-op (persisted counts stayed zero). See #2801 / #2795 / #2786 / #2105.
  */
 export function surfaceCliSessionMeta(delivery: AgentDeliveryResult): AgentDeliveryResult {
   return {
@@ -109,6 +110,7 @@ export function surfaceCliSessionMeta(delivery: AgentDeliveryResult): AgentDeliv
       agentMeta: {
         ...delivery.meta?.agentMeta,
         sessionId: delivery.run.sessionId,
+        usage: normalizeUsage(delivery.run.usage),
       },
     },
   };


### PR DESCRIPTION
## Summary

Closes #2801 — auto-reply token/context accounting persisted as **zero** for every messaging channel (Slack, Telegram, etc.), so context-window utilization tracking was broken. Sibling of #2795 (which surfaced `run.sessionId`; usage was explicitly scoped to this issue).

## Root cause

The auto-reply persistence path reads usage from `runResult.meta?.agentMeta?.usage` (`agent-runner.ts:386`) and treats it as `NormalizedUsage` (`{ input, output, cacheRead, cacheWrite }`). But:

1. **`meta.agentMeta.usage` was never populated** on the ChannelBridge path — the CLI usage lives on `run.usage` (`AgentRunResult`). Same shape gap #2795 fixed for `sessionId`.
2. **Field-name mismatch**: `run.usage` is `AgentUsage` (`{ inputTokens, outputTokens, cacheReadTokens?, cacheWriteTokens? }`, `middleware/types.ts:154`) vs `NormalizedUsage` (`{ input, output, cacheRead, cacheWrite }`, `agents/usage.ts:53`). So even surfacing it raw would read `undefined`.

Net: `hasNonzeroUsage()` was always false → `inputTokens` / `outputTokens` / `totalTokens` / cache counters persisted as `0` or stale.

## Fix

1. **Surface `run.usage` in `surfaceCliSessionMeta()`** (`agent-runner-execution.ts`), normalized via the existing `normalizeUsage()` so `agentMeta.usage` is a real `NormalizedUsage` (the `as NormalizedUsage` cast at the read site is now truthful).
2. **Teach `normalizeUsage()` the `AgentUsage` camelCase cache aliases** — `cacheReadTokens → cacheRead`, `cacheWriteTokens → cacheWrite`. It already handled `inputTokens`/`outputTokens` but not the cache fields, so cache counts would still have normalized to zero. Reuses the existing normalizer rather than adding a parallel one; purely additive (more input aliases recognized).

## Tests

- Extends the **CI-gated `test-auto-reply`** suite (#2779) `agent-runner-execution.session-meta.test.ts` — asserts `run.usage` is surfaced + normalized (`inputTokens→input`, `outputTokens→output`) and the cache aliases (`cacheReadTokens→cacheRead`, `cacheWriteTokens→cacheWrite`), plus undefined-usage passthrough. **7 tests** (4 from #2795 + 3 new).
- No regressions: `usage.normalization` (10), `usage` + `session-usage` (29) green.
- `pnpm check` (format + typecheck + lint + fork gates) clean.

## Scope

Does not touch `src/middleware/` → no LIVE smoke required. `lastCallUsage` remains `undefined` on this path (the CLI reports no per-call snapshot); context sizing correctly falls back to the cumulative `usage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
