### PR TITLE
fix(outbound): preserve Slack scope details in delivery-queue errors

### DIFF
--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -40,6 +40,7 @@ import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { throwIfAborted } from "./abort.js";
 import { ackDelivery, enqueueDelivery, failDelivery } from "./delivery-queue.js";
+import { describeDeliveryError } from "./describe-delivery-error.js";
 import type { OutboundIdentity } from "./identity.js";
 import type { NormalizedOutboundPayload } from "./payloads.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
@@ -521,9 +522,7 @@ export async function deliverOutboundPayloads(
       if (isAbortError(err)) {
         await ackDelivery(queueId).catch(() => {});
       } else {
-        await failDelivery(queueId, err instanceof Error ? err.message : String(err)).catch(
-          () => {},
-        );
+        await failDelivery(queueId, describeDeliveryError(err)).catch(() => {});
       }
     }
     throw err;
@@ -805,7 +804,7 @@ async function deliverOutboundPayloadsCore(
       emitMessageSent({
         success: false,
         content: payloadSummary.text,
-        error: err instanceof Error ? err.message : String(err),
+        error: describeDeliveryError(err),
       });
       if (!params.bestEffort) {
         throw err;

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -4,6 +4,7 @@ import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import { resolveStateDir } from "../../config/paths.js";
 import { generateSecureUuid } from "../secure-random.js";
+import { describeDeliveryError } from "./describe-delivery-error.js";
 import type { OutboundChannel } from "./targets.js";
 
 const QUEUE_DIRNAME = "delivery-queue";
@@ -393,7 +394,7 @@ export async function recoverPendingDeliveries(opts: {
       recovered += 1;
       opts.log.info(`Recovered delivery ${entry.id} to ${entry.channel}:${entry.to}`);
     } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err);
+      const errMsg = describeDeliveryError(err);
       if (isPermanentDeliveryError(errMsg)) {
         opts.log.warn(`Delivery ${entry.id} hit permanent error — moving to failed/: ${errMsg}`);
         try {
@@ -432,6 +433,9 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+  // Slack: a required OAuth scope is missing from the app — cannot self-resolve
+  // without app reconfiguration, so retries only waste attempts (#2098).
+  /missing_scope/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {

--- a/src/infra/outbound/describe-delivery-error.test.ts
+++ b/src/infra/outbound/describe-delivery-error.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { isPermanentDeliveryError } from "./delivery-queue.js";
+import { describeDeliveryError } from "./describe-delivery-error.js";
+
+describe("describeDeliveryError", () => {
+  it("returns the message for a plain Error", () => {
+    expect(describeDeliveryError(new Error("boom"))).toBe("boom");
+  });
+
+  it("stringifies a non-Error value", () => {
+    expect(describeDeliveryError("nope")).toBe("nope");
+    expect(describeDeliveryError(undefined)).toBe("undefined");
+  });
+
+  it("enriches a Slack missing_scope CodedError with the needed and granted scopes (#2098)", () => {
+    const err = Object.assign(new Error("An API error occurred: missing_scope"), {
+      code: "slack_webapi_platform_error",
+      data: {
+        ok: false,
+        error: "missing_scope",
+        needed: "channels:history",
+        provided: "chat:write",
+        response_metadata: { scopes: ["chat:write", "channels:read"] },
+      },
+    });
+    expect(describeDeliveryError(err)).toBe(
+      "An API error occurred: missing_scope (missing scope: channels:history; granted: chat:write, channels:read)",
+    );
+  });
+
+  it("falls back to the base message when structured scope fields are absent", () => {
+    const err = Object.assign(new Error("An API error occurred: channel_not_found"), {
+      data: { ok: false, error: "channel_not_found" },
+    });
+    expect(describeDeliveryError(err)).toBe("An API error occurred: channel_not_found");
+  });
+
+  it("emits only the missing scope when granted scopes are unavailable", () => {
+    const err = Object.assign(new Error("missing_scope"), {
+      data: { needed: "files:write" },
+    });
+    expect(describeDeliveryError(err)).toBe("missing_scope (missing scope: files:write)");
+  });
+});
+
+describe("isPermanentDeliveryError (#2098)", () => {
+  it("treats missing_scope as permanent so recovery stops retrying it", () => {
+    expect(isPermanentDeliveryError("An API error occurred: missing_scope")).toBe(true);
+    // The enriched form still classifies as permanent (the base code survives).
+    const enriched = describeDeliveryError(
+      Object.assign(new Error("An API error occurred: missing_scope"), {
+        data: { needed: "channels:history" },
+      }),
+    );
+    expect(isPermanentDeliveryError(enriched)).toBe(true);
+  });
+
+  it("keeps a transient error retryable", () => {
+    expect(isPermanentDeliveryError("socket hang up")).toBe(false);
+  });
+});

--- a/src/infra/outbound/describe-delivery-error.ts
+++ b/src/infra/outbound/describe-delivery-error.ts
@@ -1,0 +1,45 @@
+/**
+ * Stringify a delivery error for the queue's `lastError` record and failed-entry
+ * moves. Falls back to `err.message` (or `String(err)`), but when the error
+ * carries the structured scope metadata Slack's `@slack/web-api` `CodedError`
+ * attaches on a `missing_scope` failure — `data.needed` (the missing scope) and
+ * `data.response_metadata.scopes` (the granted scopes) — append it so a stuck
+ * queue entry names the scope to add instead of the opaque
+ * "An API error occurred: missing_scope" (#2098).
+ *
+ * Duck-typed on the field shape, so the generic outbound layer stays
+ * channel-agnostic: any error exposing those fields is enriched, and errors
+ * without them are returned unchanged.
+ */
+export function describeDeliveryError(err: unknown): string {
+  const base = err instanceof Error ? err.message : String(err);
+  const detail = extractScopeDetail(err);
+  return detail ? `${base} (${detail})` : base;
+}
+
+function extractScopeDetail(err: unknown): string | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const data = (err as { data?: unknown }).data;
+  if (!data || typeof data !== "object") {
+    return undefined;
+  }
+  const parts: string[] = [];
+  const needed = (data as { needed?: unknown }).needed;
+  if (typeof needed === "string" && needed.trim()) {
+    parts.push(`missing scope: ${needed.trim()}`);
+  }
+  const responseMetadata = (data as { response_metadata?: unknown }).response_metadata;
+  const scopes =
+    responseMetadata && typeof responseMetadata === "object"
+      ? (responseMetadata as { scopes?: unknown }).scopes
+      : undefined;
+  if (Array.isArray(scopes)) {
+    const granted = scopes.filter((scope): scope is string => typeof scope === "string");
+    if (granted.length > 0) {
+      parts.push(`granted: ${granted.join(", ")}`);
+    }
+  }
+  return parts.length > 0 ? parts.join("; ") : undefined;
+}


### PR DESCRIPTION
## Problem

Delivery-queue recovery (and the enqueue-time failure record) stringify errors with `err.message`, discarding the structured fields Slack's `@slack/web-api` `CodedError` attaches on a `missing_scope` failure — `data.needed` (the missing scope) and `data.response_metadata.scopes` (the granted scopes). Stuck queue entries showed only:

```
"lastError": "An API error occurred: missing_scope"
```

with no indication of which scope to add. Observed impact: 59 queue entries accumulated over ~4 weeks, all with that identical unhelpful message.

Secondary: `missing_scope` was not in `PERMANENT_ERROR_PATTERNS`, so these entries retried up to `MAX_RETRIES` before giving up — but a missing OAuth scope never self-resolves without app reconfiguration.

## Fix

1. New `describeDeliveryError(err)` helper (`src/infra/outbound/describe-delivery-error.ts`): returns `err.message` (or `String(err)`), and when the error carries `data.needed` / `data.response_metadata.scopes`, appends `(missing scope: <needed>; granted: <scopes>)`. Duck-typed on the field shape, so the generic outbound layer stays channel-agnostic — the Slack extension already extracts the same fields in its own send path (`extensions/slack/src/send.ts`), but the generic queue path never preserved them.
2. Applied at the three `err.message` stringify sites: `delivery-queue.ts` recovery, `deliver.ts` enqueue-failure record, and the message-sent failure event.
3. Added `/missing_scope/i` to `PERMANENT_ERROR_PATTERNS` so a missing-scope failure is moved to `failed/` immediately instead of burning retries. The enriched message still contains the base `missing_scope` token, so classification still matches.

## Tests

New `describe-delivery-error.test.ts` (7 cases): the helper enriches a Slack `missing_scope` `CodedError` with the needed + granted scopes, falls back to the base message for plain errors and for errors lacking the fields, and emits only the missing scope when granted scopes are unavailable; `isPermanentDeliveryError` now classifies both the raw and enriched `missing_scope` message as permanent while keeping transient errors retryable. `src/infra/outbound/` runs in the CI unit lane; `tsgo` passes.

## Layering note

The fix lives in the generic `src/infra/outbound/` path (per the issue) rather than the Slack channel, because that path is where the structured error is lost. The helper stays channel-agnostic (duck-typed), so it enriches any error exposing those fields without coupling the queue to Slack.

Fixes #2098

🤖 Generated with [Claude Code](https://claude.com/claude-code)
