### PR TITLE
fix(auth): surface configured-but-failed auth resolution instead of masking it

### DIFF
--- a/src/auth/env-injection.test.ts
+++ b/src/auth/env-injection.test.ts
@@ -167,7 +167,7 @@ describe("resolveAuthEnv", () => {
     expect(result).toEqual({ OPENAI_API_KEY: "sk-openai-test" });
   });
 
-  it("returns undefined for missing profile and logs warning", async () => {
+  it("throws for a configured-but-missing profile (#2085)", async () => {
     const cfg: RemoteClawConfig = {
       agents: {
         list: [{ id: "test-agent", workspace: "~/w", auth: "anthropic:nonexistent" }],
@@ -175,11 +175,12 @@ describe("resolveAuthEnv", () => {
     };
     const store = makeStore({});
 
-    const result = await resolveAuthEnv({ cfg, agentId: "test-agent", store });
-    expect(result).toBeUndefined();
+    await expect(resolveAuthEnv({ cfg, agentId: "test-agent", store })).rejects.toThrow(
+      /not found or has no key/,
+    );
   });
 
-  it("returns undefined for profile with unknown provider", async () => {
+  it("throws for a configured profile with an unknown provider (#2085)", async () => {
     const cfg: RemoteClawConfig = {
       agents: {
         list: [{ id: "test-agent", workspace: "~/w", auth: "exotic:p1" }],
@@ -189,8 +190,9 @@ describe("resolveAuthEnv", () => {
       "exotic:p1": { provider: "exotic", key: "exotic-key" },
     });
 
-    const result = await resolveAuthEnv({ cfg, agentId: "test-agent", store });
-    expect(result).toBeUndefined();
+    await expect(resolveAuthEnv({ cfg, agentId: "test-agent", store })).rejects.toThrow(
+      /No env var mapping for provider "exotic"/,
+    );
   });
 
   it("inherits auth from defaults", async () => {

--- a/src/auth/env-injection.ts
+++ b/src/auth/env-injection.ts
@@ -8,7 +8,6 @@
 import { resolveAgentAuth } from "../agents/agent-scope.js";
 import { normalizeProviderId } from "../agents/provider-utils.js";
 import type { RemoteClawConfig } from "../config/config.js";
-import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveApiKeyForProfile } from "./oauth.js";
 import { ensureAuthProfileStore } from "./store.js";
 import type { AuthProfileStore } from "./types.js";
@@ -18,8 +17,6 @@ import {
   markAuthProfileUsed,
   resolveProfileUnusableUntil,
 } from "./usage.js";
-
-const log = createSubsystemLogger("auth-env");
 
 /**
  * Map a provider ID to the primary environment variable name used by CLI agents.
@@ -152,8 +149,12 @@ export function resolveAuthProfileCount(cfg: RemoteClawConfig, agentId: string):
  * - `auth: ["id1", "id2"]` -> persistent cooldown-aware round-robin, inject selected profile
  * - `auth: undefined` -> no injection (returns `undefined`)
  *
- * Missing or invalid profiles log a warning and return `undefined`
- * (fall-through to next credential precedence level).
+ * When auth is NOT configured (`false` / `undefined`, or an empty profile
+ * list), returns `undefined` so the caller falls through to the next credential
+ * precedence level. When auth IS configured but resolution fails (profile
+ * missing, no key, unknown provider, or a resolver error), THROWS — so the
+ * failure surfaces as the agent/job error instead of silently running
+ * credential-less and failing later with a cryptic "Not logged in" (#2085).
  */
 export async function resolveAuthEnv(params: {
   cfg: RemoteClawConfig;
@@ -181,22 +182,25 @@ export async function resolveAuthEnv(params: {
       store,
       profileId,
     });
-  } catch {
-    log.warn(`Failed to resolve auth profile "${profileId}" — skipping env injection`);
-    return undefined;
+  } catch (err) {
+    // #2085: auth IS configured but the resolver threw — surface it instead of
+    // silently returning undefined (which the caller treats as "no auth" and
+    // proceeds credential-less, failing later with a cryptic "Not logged in").
+    throw new Error(
+      `Failed to resolve auth profile "${profileId}": ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
   }
 
   if (!resolved) {
-    log.warn(`Auth profile "${profileId}" not found or has no key — skipping env injection`);
-    return undefined;
+    throw new Error(`Auth profile "${profileId}" not found or has no key`);
   }
 
   const envVarName = resolveProviderEnvVarName(resolved.provider);
   if (!envVarName) {
-    log.warn(
-      `No env var mapping for provider "${resolved.provider}" (profile "${profileId}") — skipping env injection`,
+    throw new Error(
+      `No env var mapping for provider "${resolved.provider}" (auth profile "${profileId}")`,
     );
-    return undefined;
   }
 
   // Token credentials for anthropic must be injected as CLAUDE_CODE_OAUTH_TOKEN,


### PR DESCRIPTION
## Problem

`resolveAuthEnv` (`src/auth/env-injection.ts`) returned `undefined` on three **runtime-failure** paths:

1. `resolveApiKeyForProfile` threw (caught → `log.warn` → `undefined`)
2. profile not found / has no key (`log.warn` → `undefined`)
3. no env-var mapping for the provider (`log.warn` → `undefined`)

In all three, auth **is** configured (the agent has `auth` or inherits `defaults.auth`) but resolution fails for a runtime reason. The single caller, `withAuthKeyRetry`, treats `undefined` as "no auth configured" and proceeds **credential-less** — so the real failure only surfaces later as a cryptic `[CLI_ERROR] Not logged in` from the CLI subprocess, indistinguishable from an agent that genuinely has no auth. The `log.warn` goes to the `auth-env` subsystem logger, which may not be visible at default log levels.

## Fix

Throw on the three configured-but-failed paths, while still returning `undefined` for the genuinely-not-configured cases (`auth: false` / `undefined` / empty profile list). The thrown error propagates through `withAuthKeyRetry` (which already throws on exhausted retries, so its callers handle throws) and is recorded as the agent/job error — e.g. a cron run's `coreResult.error`, which `cron run` now surfaces (#2084). So the operator sees `Auth profile "x" not found or has no key` instead of `Not logged in`.

### Why multi-profile rotation is unaffected

`isAuthRotatableError` matches rate-limit / 401 / unauthorized / invalid-key — **not** "Not logged in". So today a bad profile → `undefined` → credential-less execute → "Not logged in" → **not** rotatable → returned as the error (no self-heal). Throwing removes no rotation that was happening; it replaces a cryptic terminal error with a clear one.

## Tests

Updates the two `env-injection.test.ts` cases that asserted `undefined` on failure (missing profile, unknown provider) to assert the throw. The genuinely-not-configured cases (no config, `auth: false`, empty array) keep returning `undefined`. `resolveAuthEnv`'s only real caller, `withAuthKeyRetry`, is covered by `auth-key-retry.test.ts` (valid profiles, success path) and is unaffected; `run.auth-retry.test.ts` / `run.channel-bridge.test.ts` mock the retry layer. Full `src/auth` suite (112 tests) + `tsgo` pass.

Discovered while investigating #2083.

Fixes #2085

🤖 Generated with [Claude Code](https://claude.com/claude-code)
