### PR TITLE
fix(heartbeat): honor agents.defaults.heartbeat + stop zero-config heartbeats

### DIFF
--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -412,7 +412,7 @@ describe("getHealthSnapshot", () => {
     expect(exceptionTelegram.probe?.error).toMatch(/network down/i);
   });
 
-  it("disables heartbeat for agents without heartbeat blocks", async () => {
+  it("lets agents without their own heartbeat block inherit defaults.heartbeat (#623)", async () => {
     testConfig = {
       agents: {
         defaults: {
@@ -434,9 +434,33 @@ describe("getHealthSnapshot", () => {
     const main = byAgent.get("main");
     const ops = byAgent.get("ops");
 
-    expect(main?.heartbeat.everyMs).toBeNull();
-    expect(main?.heartbeat.every).toBe("disabled");
+    // #623: `main` has no per-agent heartbeat block, so it inherits
+    // agents.defaults.heartbeat instead of being silently disabled just because
+    // a different agent (ops) set its own override.
+    expect(main?.heartbeat.everyMs).toBe(30 * 60_000);
+    expect(main?.heartbeat.every).toBe("30m");
+    // `ops` keeps its own per-agent override.
     expect(ops?.heartbeat.everyMs).toBeTruthy();
     expect(ops?.heartbeat.every).toBe("1h");
+  });
+
+  it("reports heartbeat disabled when nothing configures it (#623)", async () => {
+    testConfig = {
+      agents: {
+        // No agents.defaults.heartbeat and no per-agent heartbeat: heartbeat is
+        // disabled for every agent, not silently enabled at the 30m default.
+        list: [{ id: "main", default: true }, { id: "ops" }],
+      },
+    };
+    testStore = {};
+
+    const snap = await getHealthSnapshot({ timeoutMs: 10, probe: false });
+    const byAgent = new Map(snap.agents.map((agent) => [agent.agentId, agent] as const));
+
+    for (const agentId of ["main", "ops"]) {
+      const agent = byAgent.get(agentId);
+      expect(agent?.heartbeat.everyMs).toBeNull();
+      expect(agent?.heartbeat.every).toBe("disabled");
+    }
   });
 });

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -184,14 +184,42 @@ describe("resolveHeartbeatPrompt", () => {
 });
 
 describe("isHeartbeatEnabledForAgent", () => {
-  it("enables only explicit heartbeat agents when configured", () => {
+  it("disables every agent when no heartbeat is configured anywhere (#623)", () => {
+    // Regression (#623): a bare config that lists agents but sets NO heartbeat —
+    // neither agents.defaults.heartbeat nor any per-agent heartbeat — must leave
+    // heartbeat disabled. Previously the fallback silently enabled it for all
+    // listed agents at the 30m default, so agents heartbeat-ed without anyone
+    // asking.
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "alpha" }, { id: "ops" }],
+      },
+    };
+    expect(isHeartbeatEnabledForAgent(cfg, "alpha")).toBe(false);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(false);
+  });
+
+  it("enables only agents with a per-agent heartbeat when no defaults are set", () => {
+    const cfg: RemoteClawConfig = {
+      agents: {
+        list: [{ id: "alpha" }, { id: "ops", heartbeat: { every: "1h" } }],
+      },
+    };
+    expect(isHeartbeatEnabledForAgent(cfg, "alpha")).toBe(false);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
+  });
+
+  it("lets agents without a per-agent heartbeat inherit agents.defaults.heartbeat (#623)", () => {
+    // Regression (#623): a per-agent heartbeat on ONE agent must not flip the
+    // OTHER agents off the defaults they would otherwise inherit. Both axes are
+    // independent — `ops` uses its override, `alpha` inherits the defaults.
     const cfg: RemoteClawConfig = {
       agents: {
         defaults: { heartbeat: { every: "30m" } },
         list: [{ id: "alpha" }, { id: "ops", heartbeat: { every: "1h" } }],
       },
     };
-    expect(isHeartbeatEnabledForAgent(cfg, "alpha")).toBe(false);
+    expect(isHeartbeatEnabledForAgent(cfg, "alpha")).toBe(true);
     expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
   });
 
@@ -483,7 +511,10 @@ describe("runHeartbeatOnce", () => {
   it("skips when agent heartbeat is not enabled", async () => {
     const cfg: RemoteClawConfig = {
       agents: {
-        defaults: { heartbeat: { every: "30m" } },
+        // No agents.defaults.heartbeat: alpha has no per-agent heartbeat either,
+        // so it is genuinely disabled (#623). ops opts in via its own config, so
+        // the "some agents configured" path is still exercised — alpha is the
+        // one that must skip.
         list: [{ id: "alpha" }, { id: "ops", heartbeat: { every: "1h" } }],
       },
     };

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -117,22 +117,31 @@ export type HeartbeatRunner = {
   updateConfig: (cfg: RemoteClawConfig) => void;
 };
 
-function hasExplicitHeartbeatAgents(cfg: RemoteClawConfig) {
-  const list = cfg.agents?.list ?? [];
-  return list.some((entry) => Boolean(entry?.heartbeat));
+/**
+ * Whether heartbeat is enabled for a specific, already-resolved agent.
+ *
+ * Enabled when the agent has its OWN heartbeat config, OR when
+ * `agents.defaults.heartbeat` is set — every listed agent inherits the
+ * defaults. When neither is configured, heartbeat is disabled: a bare config
+ * that lists agents but sets no heartbeat anywhere must NOT silently start
+ * heartbeats for them (#623). Per-agent config and defaults are independent
+ * axes, so a per-agent override on ONE agent no longer flips the OTHER agents
+ * off the defaults they would otherwise inherit.
+ */
+function isAgentHeartbeatEnabled(cfg: RemoteClawConfig, agentId: string): boolean {
+  if (resolveAgentConfig(cfg, agentId)?.heartbeat !== undefined) {
+    return true;
+  }
+  return cfg.agents?.defaults?.heartbeat !== undefined;
 }
 
 export function isHeartbeatEnabledForAgent(cfg: RemoteClawConfig, agentId?: string): boolean {
   const fallbackId = resolveSoleAgentId(cfg) ?? listAgentIds(cfg)[0];
   const resolvedAgentId = normalizeAgentId(agentId ?? fallbackId);
-  const list = cfg.agents?.list ?? [];
-  const hasExplicit = hasExplicitHeartbeatAgents(cfg);
-  if (hasExplicit) {
-    return list.some(
-      (entry) => Boolean(entry?.heartbeat) && normalizeAgentId(entry?.id) === resolvedAgentId,
-    );
+  if (!resolvedAgentId || !listAgentIds(cfg).includes(resolvedAgentId)) {
+    return false;
   }
-  return listAgentIds(cfg).includes(resolvedAgentId);
+  return isAgentHeartbeatEnabled(cfg, resolvedAgentId);
 }
 
 function resolveHeartbeatConfig(
@@ -196,20 +205,12 @@ export async function resolveHeartbeatSummaryForAgent(
 }
 
 function resolveHeartbeatAgents(cfg: RemoteClawConfig): HeartbeatAgent[] {
-  const list = cfg.agents?.list ?? [];
-  if (hasExplicitHeartbeatAgents(cfg)) {
-    return list
-      .filter((entry) => entry?.heartbeat)
-      .map((entry) => {
-        const id = normalizeAgentId(entry.id);
-        return { agentId: id, heartbeat: resolveHeartbeatConfig(cfg, id) };
-      })
-      .filter((entry) => entry.agentId);
-  }
-  return listAgentIds(cfg).map((agentId) => ({
-    agentId,
-    heartbeat: resolveHeartbeatConfig(cfg, agentId),
-  }));
+  return listAgentIds(cfg)
+    .filter((agentId) => isAgentHeartbeatEnabled(cfg, agentId))
+    .map((agentId) => ({
+      agentId,
+      heartbeat: resolveHeartbeatConfig(cfg, agentId),
+    }));
 }
 
 export function resolveHeartbeatIntervalMs(


### PR DESCRIPTION
## Problem

`isHeartbeatEnabledForAgent` / `resolveHeartbeatAgents` (`src/infra/heartbeat-runner.ts`) decided enablement from a **global** `hasExplicitHeartbeatAgents(cfg)` mode-switch (does *any* agent have a per-agent `heartbeat`?). That produced two defects (#623):

1. **Zero config enables heartbeat for everyone.** With no `agents.defaults.heartbeat` and no per-agent `heartbeat`, the fallback returned `true` for every listed agent, and the interval resolver falls back to `DEFAULT_HEARTBEAT_EVERY` (`30m`) — so agents heartbeat every 30m even though nobody configured it. The production runner (`server.impl.ts:597`) starts unconditionally, so this fires. The #2310 refactor that deleted `resolveDefaultAgentId` broadened this from "default agent only" to "all agents" (`=== resolveDefaultAgentId(cfg)` → `listAgentIds().includes()`).

2. **A per-agent override disables everyone else's inherited defaults.** With `agents.defaults.heartbeat` set, as soon as *one* agent added its own `heartbeat`, `hasExplicitHeartbeatAgents()` became `true` and every agent *without* a per-agent block was evaluated only on its own (absent) config — silently dropping the defaults it should inherit.

## Fix

Replace the global switch with a per-agent predicate:

```ts
enabled(agent) = perAgentHeartbeat !== undefined || agents.defaults.heartbeat !== undefined
```

The two axes (per-agent vs defaults) are now independent. `isHeartbeatEnabledForAgent` and `resolveHeartbeatAgents` share the predicate, so the enable-check and the scheduler agree. (Per-agent `heartbeat` is typed `heartbeat?: {…}` with no `| false`, so there is no opt-out case to special-case.)

Behavior now matches the #623 table:

| Configuration | Before | After (= expected) |
|---|---|---|
| No heartbeat anywhere | all enabled @30m | **all disabled** |
| `defaults` set, no per-agent | all enabled | all enabled |
| per-agent on some, no `defaults` | only those | only those |
| `defaults` + per-agent on some | others **disabled** | others **inherit defaults** |

## Tests

- `heartbeat-runner.returns-default-unset.test.ts`: the `isHeartbeatEnabledForAgent` block now covers all four rows (added zero-config-disabled and defaults-inheritance; the old assertion that an agent with defaults-but-no-per-agent was `false` encoded bug #2). Fixed the `runHeartbeatOnce` "skips when not enabled" case to use a genuinely-disabled config (no defaults) instead of the row-4 config it previously mis-asserted.
- `health.snapshot.test.ts`: split the old "disables heartbeat for agents without heartbeat blocks" test (which asserted the bug) into an inheritance test and a genuinely-disabled test.

Full `heartbeat-runner*` suite (8 files, 57 tests) + `system-events` + `health.snapshot` pass; `tsgo` clean. (`status.summary.test.ts` fails in isolation on an unrelated pre-existing `DEFAULT_ACCOUNT_ID` mock gap — identical on `main`, not touched here.)

Fixes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
