### PR TITLE
fix(slack): log silently-swallowed thread starter/history fetch errors

### DIFF
--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logVerbose } from "../../../../src/globals.js";
 import * as ssrf from "../../../../src/infra/net/ssrf.js";
 import * as mediaFetch from "../../../../src/media/fetch.js";
 import type { SavedMedia } from "../../../../src/media/store.js";
@@ -10,10 +11,17 @@ import {
 } from "../../../../test/helpers/extensions/fetch-mock.js";
 import {
   fetchWithSlackAuth,
+  resetSlackThreadStarterCacheForTest,
   resolveSlackAttachmentContent,
   resolveSlackMedia,
   resolveSlackThreadHistory,
+  resolveSlackThreadStarter,
 } from "./media.js";
+
+vi.mock("../../../../src/globals.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../../src/globals.js")>()),
+  logVerbose: vi.fn(),
+}));
 
 // Store original fetch
 const originalFetch = globalThis.fetch;
@@ -766,7 +774,8 @@ describe("resolveSlackThreadHistory", () => {
     expect(replies).not.toHaveBeenCalled();
   });
 
-  it("returns empty when Slack API throws", async () => {
+  it("returns empty and logs the reason when Slack API throws (#2104)", async () => {
+    vi.mocked(logVerbose).mockClear();
     const replies = vi.fn().mockRejectedValueOnce(new Error("slack down"));
     const client = {
       conversations: { replies },
@@ -780,5 +789,37 @@ describe("resolveSlackThreadHistory", () => {
     });
 
     expect(result).toEqual([]);
+    // #2104: the failure must be visible (not silently swallowed), and must
+    // carry the error detail so operators can diagnose it.
+    expect(vi.mocked(logVerbose)).toHaveBeenCalledWith(
+      expect.stringContaining("thread history fetch failed"),
+    );
+    expect(vi.mocked(logVerbose)).toHaveBeenCalledWith(expect.stringContaining("slack down"));
+  });
+});
+
+describe("resolveSlackThreadStarter", () => {
+  afterEach(() => {
+    resetSlackThreadStarterCacheForTest();
+  });
+
+  it("returns null and logs the reason when Slack API throws (#2104)", async () => {
+    vi.mocked(logVerbose).mockClear();
+    const replies = vi.fn().mockRejectedValueOnce(new Error("scope missing"));
+    const client = {
+      conversations: { replies },
+    } as unknown as Parameters<typeof resolveSlackThreadStarter>[0]["client"];
+
+    const result = await resolveSlackThreadStarter({
+      channelId: "C1",
+      threadTs: "1.000",
+      client,
+    });
+
+    expect(result).toBeNull();
+    expect(vi.mocked(logVerbose)).toHaveBeenCalledWith(
+      expect.stringContaining("thread starter fetch failed"),
+    );
+    expect(vi.mocked(logVerbose)).toHaveBeenCalledWith(expect.stringContaining("scope missing"));
   });
 });

--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -3,6 +3,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "remoteclaw/plugin-sdk/text-runtime";
+import { logVerbose } from "../../../../src/globals.js";
 import { normalizeHostname } from "../../../../src/infra/net/hostname.js";
 import type { FetchLike } from "../../../../src/media/fetch.js";
 import { fetchRemoteMedia } from "../../../../src/media/fetch.js";
@@ -429,7 +430,14 @@ export async function resolveSlackThreadStarter(params: {
     });
     evictThreadStarterCache();
     return starter;
-  } catch {
+  } catch (err) {
+    // Best-effort: thread context is optional, so we still fall back to null.
+    // But surface WHY (permissions, rate limit, token expiry, network) instead
+    // of swallowing it silently — otherwise a blank-context session is
+    // impossible to diagnose (#2104).
+    logVerbose(
+      `slack: thread starter fetch failed for channel ${params.channelId} thread ${params.threadTs}: ${String(err)}`,
+    );
     return null;
   }
 }
@@ -521,7 +529,13 @@ export async function resolveSlackThreadHistory(params: {
       ts: msg.ts,
       files: msg.files,
     }));
-  } catch {
+  } catch (err) {
+    // Best-effort: still fall back to empty history, but log WHY so a
+    // missing-thread-context session can be diagnosed instead of silently
+    // swallowing the Slack API failure (#2104).
+    logVerbose(
+      `slack: thread history fetch failed for channel ${params.channelId} thread ${params.threadTs}: ${String(err)}`,
+    );
     return [];
   }
 }


### PR DESCRIPTION
## Problem

`resolveSlackThreadStarter()` and `resolveSlackThreadHistory()` (`extensions/slack/src/monitor/media.ts`) wrapped their `conversations.replies()` calls in `catch { return null }` / `catch { return [] }` — no log, no warning, no metric. When the Slack API fails (missing `im:history` / `channels:history` scope, rate limit, token expiry, network error), thread context silently disappears and the agent starts a blank-context session. Nothing in the logs explains why, which the issue notes "makes debugging impossible."

## Fix

Bind the error and `logVerbose(...)` it — with the channel ID, thread ts, and error string — before the best-effort `null` / `[]` fallback. `logVerbose` matches the established convention for best-effort Slack operations in the same directory (`context.ts:295` logs `slack status update failed for channel …` the same way), and the issue explicitly sanctions it ("Add logWarn or logVerbose"). Return behavior is unchanged; the failure is just no longer invisible.

## Tests

`media.test.ts`: extended the existing `resolveSlackThreadHistory` "throws" test and added a `resolveSlackThreadStarter` error-path test — both assert the fallback value AND that `logVerbose` fired with the failure context plus the error detail. `media.test.ts` + `monitor.media.test.ts` pass (33 tests); `tsgo` clean.

Note: upstream OpenClaw has the same silent-catch pattern in `extensions/slack/src/monitor/media.ts` — this fix is RemoteClaw-local; any upstream contribution is out of scope here.

Fixes #2104

🤖 Generated with [Claude Code](https://claude.com/claude-code)
