### PR TITLE
test(cron): regression-guard the cron run 10-minute gateway timeout (#2086)

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -236,6 +236,25 @@ describe("cron cli", () => {
     expect(exitSpy).toHaveBeenCalledWith(expectedExitCode);
   });
 
+  it("defaults the cron run gateway timeout to the 10-minute job timeout (#2086)", async () => {
+    // Isolated cron jobs can run for minutes (DEFAULT_JOB_TIMEOUT_MS = 10m), so
+    // `cron run` must not give up at the generic 30s gateway-client default —
+    // otherwise the CLI reports "gateway timeout after 30000ms" while the job is
+    // still running. When --timeout is not supplied, the timeout is bumped to
+    // 600000ms. This guards the fix against a silent regression from an upstream
+    // sync (it arrived via one and has no other test coverage).
+    const { runOpts } = await runCronRunAndCaptureExit({ ran: true });
+    expect(runOpts.timeout).toBe("600000");
+  });
+
+  it("honors an explicit --timeout for cron run (#2086)", async () => {
+    const { runOpts } = await runCronRunAndCaptureExit({
+      ran: true,
+      args: ["cron", "run", "job-1", "--timeout", "5000"],
+    });
+    expect(runOpts.timeout).toBe("5000");
+  });
+
   it("trims model on cron add", { timeout: CRON_CLI_TEST_TIMEOUT_MS }, async () => {
     await runCronCommand([
       "cron",


### PR DESCRIPTION
## Already fixed — this adds the missing regression guard

`remoteclaw cron run <id>` used to fail with `Error: gateway timeout after 30000ms` on jobs longer than 30s, even though the job kept running in the gateway. That is **already fixed** on `main`: `cron run` overrides the generic 30s gateway-client timeout to `600000ms` (the 10-minute `DEFAULT_JOB_TIMEOUT_MS`) when `--timeout` is not supplied, and `--timeout <ms>` lets the user override it.

- `src/cli/cron-cli/register.cron-simple.ts:94-95` — bumps `opts.timeout` to `"600000"` when it's at the default.
- `src/cli/gateway-rpc.runtime.ts:26` — `timeoutMs: Number(opts.timeout ?? 10_000)` threads it into the RPC.
- `src/cli/gateway-rpc.ts:18` — the `--timeout <ms>` option.

The fix arrived via the upstream sync to **v2026.3.2** (#2172, 2026-04-09) — three days after this issue was filed (2026-04-06) — and had **no test coverage**: the `cron-cli` harness captured the run opts but never asserted the timeout. So a future upstream sync could silently revert it.

## Change

Add two regression tests to `cron-cli.test.ts`:
- `cron run` defaults the gateway timeout to `"600000"`.
- an explicit `--timeout 5000` is honored.

Test-only; no production change. `cron-cli.test.ts` passes (37 tests).

Fixes #2086

🤖 Generated with [Claude Code](https://claude.com/claude-code)
