### PR TITLE
fix(slack): reject ids whose prefix contradicts the declared target kind (#2087)

### DIFF
--- a/extensions/slack/src/targets.test.ts
+++ b/extensions/slack/src/targets.test.ts
@@ -46,6 +46,53 @@ describe("parseSlackTarget", () => {
       );
     }
   });
+
+  it("rejects ids whose prefix contradicts the declared kind (#2087)", () => {
+    const cases = [
+      {
+        input: "user:D0AKUMPAKMF",
+        expectedMessage:
+          'Slack ID "D0AKUMPAKMF" looks like a DM channel (D-prefix), but was specified as user:. Use channel:D0AKUMPAKMF instead.',
+      },
+      {
+        input: "channel:U0AKUMPAKMF",
+        expectedMessage:
+          /looks like a user \(U-prefix\), but was specified as channel:\. Use user:U0AKUMPAKMF instead\./,
+      },
+      {
+        input: "slack:C0PUBLIC00",
+        expectedMessage:
+          /looks like a public channel \(C-prefix\), but was specified as slack:\. Use channel:C0PUBLIC00 instead\./,
+      },
+      {
+        input: "#U0AKUMPAKMF",
+        expectedMessage:
+          /looks like a user \(U-prefix\), but was specified as #\. Use user:U0AKUMPAKMF instead\./,
+      },
+    ] as const;
+    for (const testCase of cases) {
+      expect(() => parseSlackTarget(testCase.input), testCase.input).toThrow(
+        testCase.expectedMessage,
+      );
+    }
+  });
+
+  it("accepts ids whose prefix matches the declared kind (#2087)", () => {
+    const cases = [
+      // The documented fix from the issue: a DM channel id belongs to `channel:`.
+      { input: "channel:D0AKUMPAKMF", kind: "channel", id: "D0AKUMPAKMF" },
+      { input: "user:W012ENTERPRISE", kind: "user", id: "W012ENTERPRISE" },
+      { input: "user:B0BOTUSER00", kind: "user", id: "B0BOTUSER00" },
+      { input: "channel:G0PRIVATE00", kind: "channel", id: "G0PRIVATE00" },
+      { input: "#D0AKUMPAKMF", kind: "channel", id: "D0AKUMPAKMF" },
+    ] as const;
+    for (const testCase of cases) {
+      expect(parseSlackTarget(testCase.input), testCase.input).toMatchObject({
+        kind: testCase.kind,
+        id: testCase.id,
+      });
+    }
+  });
 });
 
 describe("resolveSlackChannelId", () => {

--- a/extensions/slack/src/targets.ts
+++ b/extensions/slack/src/targets.ts
@@ -14,6 +14,46 @@ export type SlackTarget = MessagingTarget;
 
 type SlackTargetParseOptions = MessagingTargetParseOptions;
 
+// Slack object-id leading characters: user-like ids start with U (member),
+// W (Enterprise Grid member) or B (bot); channel-like ids start with C (public
+// channel), G (private channel/group) or D (DM). https://api.slack.com/methods/conversations.info
+const SLACK_USER_ID_PREFIXES = "UWB";
+const SLACK_CHANNEL_ID_PREFIXES = "CGD";
+const SLACK_ID_KIND_LABELS: Record<string, string> = {
+  U: "user",
+  W: "user",
+  B: "bot user",
+  C: "public channel",
+  G: "private channel",
+  D: "DM channel",
+};
+
+// Explicit kind-declaring target syntaxes: `user:`/`channel:` prefixes, the legacy
+// `slack:` user alias, and the `#` channel sigil. A bare id, `<@mention>` or `@user`
+// carries no user-chosen kind declaration and is left lenient.
+const SLACK_KIND_DECLARING_PREFIXES = ["user:", "channel:", "slack:"] as const;
+
+// Reject a target whose explicit kind declaration contradicts the Slack id's leading
+// character — e.g. `user:D…` (a DM channel id) or `channel:U…` (a user id). These parse
+// "successfully" today but fail silently at delivery time, so surface a clear error
+// pointing at the correct prefix instead of misconfiguring the target.
+function validateSlackIdKind(declaredKind: SlackTargetKind, id: string, declaredAs: string): void {
+  const firstChar = id.charAt(0).toUpperCase();
+  const actualKind: SlackTargetKind | undefined = SLACK_USER_ID_PREFIXES.includes(firstChar)
+    ? "user"
+    : SLACK_CHANNEL_ID_PREFIXES.includes(firstChar)
+      ? "channel"
+      : undefined;
+  if (!actualKind || actualKind === declaredKind) {
+    return;
+  }
+  const label = SLACK_ID_KIND_LABELS[firstChar] ?? actualKind;
+  throw new Error(
+    `Slack ID "${id}" looks like a ${label} (${firstChar}-prefix), ` +
+      `but was specified as ${declaredAs}. Use ${actualKind}:${id} instead.`,
+  );
+}
+
 export function parseSlackTarget(
   raw: string,
   options: SlackTargetParseOptions = {},
@@ -34,6 +74,10 @@ export function parseSlackTarget(
     atUserErrorMessage: "Slack DMs require a user id (use user:<id> or <@id>)",
   });
   if (userTarget) {
+    const declaredAs = SLACK_KIND_DECLARING_PREFIXES.find((prefix) => trimmed.startsWith(prefix));
+    if (declaredAs) {
+      validateSlackIdKind(userTarget.kind, userTarget.id, declaredAs);
+    }
     return userTarget;
   }
   if (trimmed.startsWith("#")) {
@@ -43,6 +87,7 @@ export function parseSlackTarget(
       pattern: /^[A-Z0-9]+$/i,
       errorMessage: "Slack channels require a channel id (use channel:<id>)",
     });
+    validateSlackIdKind("channel", id, "#");
     return buildMessagingTarget("channel", id, trimmed);
   }
   if (options.defaultKind) {


### PR DESCRIPTION
## Problem

`parseSlackTarget` trusted the explicit `user:` / `channel:` prefix without validating that the Slack id's format matched the declared kind. Slack ids carry well-known single-letter type prefixes:

| id prefix | Slack type | valid kind |
|-----------|-----------|------------|
| `U` / `W` / `B` | member / Enterprise member / bot | `user` |
| `C` / `G` / `D` | public channel / private group / DM | `channel` |

So `user:D0AKUMPAKMF` (a DM **channel** id) parsed as `kind: "user"` and was accepted. It then fails silently at delivery time — e.g. cron announce delivery fails with no indication that the id/kind mismatch is the cause. Surfaced while debugging #2083: after fixing auth, delivery still failed because the target was `user:D…` instead of `channel:D…`.

## Fix

Validate the id's first character against the declared kind in `parseSlackTarget` (Slack-only, at parse time — not the generic `channels/targets.ts`), and throw a helpful error suggesting the correct prefix instead of silently misconfiguring the target:

```
Slack ID "D0AKUMPAKMF" looks like a DM channel (D-prefix), but was specified as user:. Use channel:D0AKUMPAKMF instead.
```

The check covers **every kind-declaring syntax** — `user:`, `channel:`, the legacy `slack:` user alias, and the `#` channel sigil — echoing the exact syntax the caller typed so the message stays accurate (`slack:C…` and `#U…` are the identical silent-misconfiguration bug). Bare ids, `<@mentions>` and `@user` carry no user-chosen kind declaration and stay lenient.

Valid targets are unaffected: `channel:D…` (a DM channel — the documented fix from the issue), `user:W…` / `user:B…`, and `channel:G…` all pass. **Every newly-rejected input was already broken** (silent delivery failure), so no working configuration changes behavior.

## Tests

`targets.test.ts` (+2 cases):
- **mismatch throws** — the exact issue-documented message for `user:D0AKUMPAKMF`, plus `channel:U…`, legacy `slack:C…`, and `#U…`.
- **match accepted** — `channel:D…` (DM channel), `user:W…`, `user:B…`, `channel:G…`, `#D…`.

8/8 pass; `tsgo` clean; `oxfmt` clean.

**Broad-consumer verification** (`parseSlackTarget` feeds send → normalize → gateway delivery → auto-reply routing): ran the full Slack extension suite plus every `slack:`-target consumer across gateway / auto-reply / delivery against a clean-`main` baseline — **+2 passes, 0 new failures**. (The 47 pre-existing failures are cross-file isolation artifacts, identical on untouched `main`; they pass in CI's sharded `test` / `test-extensions` lanes.) Confirmed no path passes a platform-qualified `slack:C…` address into `parseSlackTarget` — the new error appears in zero failures.

Fixes #2087

🤖 Generated with [Claude Code](https://claude.com/claude-code)
