### PR TITLE
fix(agents): log subagent-announce direct-send error even when queue recovers (#2117)

### DIFF
--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultRuntime } from "../runtime.js";
 import { createSubagentAnnounceDeliveryRuntimeMock } from "./subagent-announce.test-support.js";
 
 type GatewayCall = {
@@ -543,5 +544,31 @@ describe("subagent announce timeout config", () => {
     expect(internalEvents[0]?.result).toContain(
       "A longer partial summary that should stay silent.",
     );
+  });
+
+  it("logs the direct-send error before falling back to the queue (#2117)", async () => {
+    const logSpy = vi.spyOn(defaultRuntime, "log");
+    try {
+      callGatewayImpl = async (request) => {
+        if (request.method === "chat.history") {
+          return { messages: [] };
+        }
+        throw new Error("direct-send-boom");
+      };
+
+      await runAnnounceFlowForTest("run-2117-direct-fail-log", {
+        requesterOrigin: { channel: "discord", to: "12345" },
+        expectsCompletionMessage: true,
+      });
+
+      const warned = logSpy.mock.calls.some(
+        ([message]) =>
+          typeof message === "string" &&
+          message.includes("direct send failed, attempting queue fallback"),
+      );
+      expect(warned).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 });

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -982,6 +982,16 @@ async function deliverSubagentAnnouncement(params: {
     return direct;
   }
 
+  // Direct completion delivery failed. Surface the direct-send error now, before the
+  // queue fallback below: a successful fallback returns path:"queued" and would
+  // otherwise discard this error, leaving operators unable to tell a clean direct
+  // send from one that failed and was silently rescued by the queue (#2117).
+  if (direct.error) {
+    defaultRuntime.log(
+      `[warn] Subagent announce direct send failed, attempting queue fallback: ${direct.error}`,
+    );
+  }
+
   // If completion path failed direct delivery, try queueing as a fallback so the
   // report can still be delivered once the requester session is idle.
   const queueOutcome = await maybeQueueSubagentAnnounce({


### PR DESCRIPTION
## Problem

In `deliverSubagentAnnouncement` (`src/agents/subagent-announce.ts`), completion-mode delivery tries a direct send first and falls back to the queue on failure. When the direct send fails **but the queue fallback recovers**, the function returns `{delivered: true, path: "queued"}` and the direct-send error is silently discarded.

`runSubagentAnnounceFlow` only logs when the **overall** delivery failed (`!delivered && path === "direct"`), so on queue recovery the direct-send error is never logged. A cron job with isolation + announce that hits a transient direct-send failure (after retry exhaustion) falls back to the queue with **no diagnostic trace** — operators can't distinguish "direct send worked" from "direct send failed but the queue recovered."

## Fix

Log the direct-send error at warn level immediately after direct delivery fails, **before** the queue fallback — so the failure is always traced, independent of whether the fallback recovers. Guarded by `direct.error` so a direct-failure without an error string stays quiet. Uses the file's established warn seam (`defaultRuntime.log(`[warn] …`)`).

Purely additive: no change to return values or delivery control flow.

## Not fixed upstream

Confirmed against current `openclaw/main`: the same silent-swallow exists there and no fix has landed past our sync cursor (#2118 tracks reporting it upstream). So this is a fork-local observability fix.

## Tests

`subagent-announce.timeout.test.ts` (+1): drives a completion-mode direct-send failure and asserts the warn fires. Because the log sits **before** the queue branch, this covers the queue-recovery case by construction. Passes in isolation; `tsgo` + `oxfmt` clean.

Note: this test file carries **11 pre-existing isolation failures** — its mocks reference upstream's split `subagent-announce-delivery.js`, which this fork consolidated into `subagent-announce.ts` (content-only sync posture); they pass in CI's full `test` lane. Verified against a clean-`main` baseline of this file: my change is **+1 passing test, 0 new failures** (baseline `11 failed | 3 passed` → `11 failed | 4 passed`).

Fixes #2117

🤖 Generated with [Claude Code](https://claude.com/claude-code)
