### PR TITLE
fix(sync): v2026.5.2 D.7 follow-up — 6 MED dropped-fix ports (+2 escalated)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ ARG REMOTECLAW_NODE_BOOKWORM_IMAGE="node:22-bookworm@sha256:b501c082306a4f528bc4
 ARG REMOTECLAW_NODE_BOOKWORM_DIGEST="sha256:b501c082306a4f528bc4038cbf2fbb58095d583d0419a259b2114b5ac53d12e9"
 ARG REMOTECLAW_NODE_BOOKWORM_SLIM_IMAGE="node:22-bookworm-slim@sha256:9c2c405e3ff9b9afb2873232d24bb06367d649aa3e6259cbe314da59578e81e9"
 ARG REMOTECLAW_NODE_BOOKWORM_SLIM_DIGEST="sha256:9c2c405e3ff9b9afb2873232d24bb06367d649aa3e6259cbe314da59578e81e9"
+# Pinned Bun image for the build stage — replaces the unpinned `curl | bash`
+# Bun install (supply-chain hardening). Keep the version in sync with
+# .github/actions/setup-node-env/action.yml bun-version (1.3.13). To update:
+# docker buildx imagetools inspect oven/bun:<version> and use the manifest-list digest.
+ARG REMOTECLAW_BUN_IMAGE="oven/bun:1.3.13@sha256:87416c977a612a204eb54ab9f3927023c2a3c971f4f345a01da08ea6262ae30e"
 
 # Base images are pinned to SHA256 digests for reproducible builds.
 # Trade-off: digests must be updated manually when upstream tags move.
@@ -35,11 +40,12 @@ RUN --mount=type=bind,source=extensions,target=/tmp/extensions,readonly \
     done
 
 # ── Stage 2: Build ──────────────────────────────────────────────
+FROM ${REMOTECLAW_BUN_IMAGE} AS bun-binary
 FROM ${REMOTECLAW_NODE_BOOKWORM_IMAGE} AS build
 
-# Install Bun (required for build scripts)
-RUN curl -fsSL https://bun.sh/install | bash
-ENV PATH="/root/.bun/bin:${PATH}"
+# Copy the pinned Bun binary from the official image instead of fetching it
+# via `curl | bash` (removes an unverified network-fetched install script).
+COPY --from=bun-binary /usr/local/bin/bun /usr/local/bin/bun
 
 RUN corepack enable
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.com/package/remoteclaw"><img src="https://img.shields.io/npm/v/remoteclaw?style=for-the-badge" alt="npm version"></a>
   <a href="https://github.com/remoteclaw/remoteclaw/releases"><img src="https://img.shields.io/github/v/release/remoteclaw/remoteclaw?include_prereleases&display_name=release&style=for-the-badge&label=GITHUB" alt="GitHub release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0--only-blue.svg?style=for-the-badge" alt="AGPL-3.0-only License"></a>
-  <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.4.29"><img src="https://img.shields.io/badge/upstream-OpenClaw_v2026.4.29-teal?style=for-the-badge" alt="Upstream: OpenClaw v2026.4.29"></a>
+  <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.5.2"><img src="https://img.shields.io/badge/upstream-OpenClaw_v2026.5.2-teal?style=for-the-badge" alt="Upstream: OpenClaw v2026.5.2"></a>
 </p>
 
 **RemoteClaw** is AI agent middleware. It connects agent CLIs you already run — Claude Code, Gemini CLI, Codex, OpenCode — to the messaging channels you already use, so you can reach your agents from anywhere: your phone, your team Slack, your WhatsApp, anywhere.

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -14,6 +14,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { RateLimitError, type RequestClient } from "@buape/carbon";
+import { fetchWithSsrFGuard } from "remoteclaw/plugin-sdk/discord";
 import { normalizeLowercaseStringOrEmpty } from "remoteclaw/plugin-sdk/text-runtime";
 import { formatErrorMessage } from "../../../src/infra/errors.js";
 import type { RetryRunner } from "../../../src/infra/retry-policy.js";
@@ -267,40 +268,51 @@ export async function sendDiscordVoiceMessage(
   }
   const uploadUrlResponse = await request(async () => {
     const url = `${rest.options?.baseUrl ?? "https://discord.com/api"}/channels/${channelId}/attachments`;
-    const res = await fetch(url, {
-      method: "POST",
-      headers: {
-        Authorization: `Bot ${botToken}`,
-        "Content-Type": "application/json",
+    // Route through the SSRF guard: the request URL honors a config-overridable baseUrl.
+    const { response: res, release } = await fetchWithSsrFGuard({
+      url,
+      init: {
+        method: "POST",
+        headers: {
+          Authorization: `Bot ${botToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          files: [{ filename, file_size: fileSize, id: "0" }],
+        }),
       },
-      body: JSON.stringify({
-        files: [{ filename, file_size: fileSize, id: "0" }],
-      }),
+      auditContext: "discord.voice.upload-url",
     });
-    if (!res.ok) {
-      if (res.status === 429) {
-        const retryData = (await res.json().catch(() => ({}))) as {
+    try {
+      if (!res.ok) {
+        if (res.status === 429) {
+          const retryData = (await res.json().catch(() => ({}))) as {
+            message?: string;
+            retry_after?: number;
+            global?: boolean;
+          };
+          throw new RateLimitError(res, {
+            message: retryData.message ?? "You are being rate limited.",
+            retry_after: retryData.retry_after ?? 1,
+            global: retryData.global ?? false,
+          });
+        }
+        const errorBody = (await res.json().catch(() => null)) as {
+          code?: number;
           message?: string;
-          retry_after?: number;
-          global?: boolean;
-        };
-        throw new RateLimitError(res, {
-          message: retryData.message ?? "You are being rate limited.",
-          retry_after: retryData.retry_after ?? 1,
-          global: retryData.global ?? false,
-        });
+        } | null;
+        const err = new Error(
+          `Upload URL request failed: ${res.status} ${errorBody?.message ?? ""}`,
+        );
+        if (errorBody?.code !== undefined) {
+          (err as Error & { code: number }).code = errorBody.code;
+        }
+        throw err;
       }
-      const errorBody = (await res.json().catch(() => null)) as {
-        code?: number;
-        message?: string;
-      } | null;
-      const err = new Error(`Upload URL request failed: ${res.status} ${errorBody?.message ?? ""}`);
-      if (errorBody?.code !== undefined) {
-        (err as Error & { code: number }).code = errorBody.code;
-      }
-      throw err;
+      return (await res.json()) as UploadUrlResponse;
+    } finally {
+      await release();
     }
-    return (await res.json()) as UploadUrlResponse;
   }, "voice-upload-url");
 
   if (!uploadUrlResponse.attachments?.[0]) {
@@ -310,17 +322,27 @@ export async function sendDiscordVoiceMessage(
   const { upload_url, upload_filename } = uploadUrlResponse.attachments[0];
 
   // Step 2: Upload the file to Discord's CDN
-  // Note: Not wrapped in retry runner - upload URLs are single-use and CDN behavior differs
-  const uploadResponse = await fetch(upload_url, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "audio/ogg",
+  // Note: Not wrapped in retry runner - upload URLs are single-use and CDN behavior differs.
+  // The upload_url comes from Discord's /attachments response, so route the PUT through the
+  // SSRF guard as defense-in-depth against a redirected/attacker-influenced upload target.
+  const { response: uploadResponse, release: releaseUpload } = await fetchWithSsrFGuard({
+    url: upload_url,
+    init: {
+      method: "PUT",
+      headers: {
+        "Content-Type": "audio/ogg",
+      },
+      body: new Uint8Array(audioBuffer),
     },
-    body: new Uint8Array(audioBuffer),
+    auditContext: "discord.voice.attachment-upload",
   });
 
-  if (!uploadResponse.ok) {
-    throw new Error(`Failed to upload voice message: ${uploadResponse.status}`);
+  try {
+    if (!uploadResponse.ok) {
+      throw new Error(`Failed to upload voice message: ${uploadResponse.status}`);
+    }
+  } finally {
+    await releaseUpload();
   }
 
   // Step 3: Send the message with voice message flag and metadata

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -16,6 +16,7 @@ import {
   type RuntimeLogger,
 } from "remoteclaw/plugin-sdk/matrix";
 import { normalizeOptionalString } from "remoteclaw/plugin-sdk/text-runtime";
+import { resolvePinnedMainDmOwnerFromAllowlist } from "../../../../../src/security/dm-policy-shared.js";
 import type { CoreConfig, MatrixRoomConfig, ReplyToMode } from "../../types.js";
 import { fetchEventSummary } from "../actions/summary.js";
 import {
@@ -28,6 +29,7 @@ import { reactMatrixMessage, sendMessageMatrix, sendTypingMatrix } from "../send
 import { enforceMatrixDirectMessageAccess, resolveMatrixAccessState } from "./access-policy.js";
 import {
   normalizeMatrixAllowList,
+  normalizeMatrixUserId,
   resolveMatrixAllowListMatch,
   resolveMatrixAllowListMatches,
 } from "./allowlist.js";
@@ -621,6 +623,14 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         ParentSessionKey: parentSessionKey,
       });
 
+      const pinnedMainDmOwner = isDirectMessage
+        ? resolvePinnedMainDmOwnerFromAllowlist({
+            dmScope: cfg.session?.dmScope,
+            allowFrom: effectiveAllowFrom,
+            normalizeEntry: normalizeMatrixUserId,
+          })
+        : null;
+
       await core.channel.session.recordInboundSession({
         storePath,
         sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
@@ -631,6 +641,17 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
               channel: "matrix",
               to: `room:${roomId}`,
               accountId: route.accountId,
+              mainDmOwnerPin: pinnedMainDmOwner
+                ? {
+                    ownerRecipient: pinnedMainDmOwner,
+                    senderRecipient: normalizeMatrixUserId(senderId),
+                    onSkip: ({ ownerRecipient, senderRecipient }) => {
+                      logVerboseMessage(
+                        `matrix: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
+                      );
+                    },
+                  }
+                : undefined,
             }
           : undefined,
         onRecordError: (err) => {

--- a/extensions/matrix/src/types.ts
+++ b/extensions/matrix/src/types.ts
@@ -109,6 +109,8 @@ export type CoreConfig = {
   };
   session?: {
     store?: string;
+    /** Mirrors the canonical DmScope union in src/config/types.base.ts. */
+    dmScope?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
   };
   messages?: {
     ackReaction?: string;

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -29,6 +29,7 @@ import {
   warnMissingProviderGroupPolicyFallbackOnce,
   type HistoryEntry,
 } from "remoteclaw/plugin-sdk/mattermost";
+import { resolvePinnedMainDmOwnerFromAllowlist } from "../../../../src/security/dm-policy-shared.js";
 import { getMattermostRuntime } from "../runtime.js";
 import { resolveMattermostAccount } from "./accounts.js";
 import {
@@ -53,7 +54,11 @@ import {
   setInteractionCallbackUrl,
   setInteractionSecret,
 } from "./interactions.js";
-import { isMattermostSenderAllowed, normalizeMattermostAllowList } from "./monitor-auth.js";
+import {
+  isMattermostSenderAllowed,
+  normalizeMattermostAllowEntry,
+  normalizeMattermostAllowList,
+} from "./monitor-auth.js";
 import {
   createDedupeCache,
   formatInboundFromLabel,
@@ -1140,19 +1145,36 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     });
 
     if (kind === "direct") {
-      const sessionCfg = cfg.session;
-      const storePath = core.channel.session.resolveStorePath(sessionCfg?.store, {
-        agentId: route.agentId,
+      // Owner-pin: a non-owner DMing the bot must not repoint the main session's
+      // last route. This path uses the low-level updateLastRoute (which bypasses the
+      // central shouldSkipPinnedMainDmRouteUpdate gate in recordInboundSession), so
+      // replicate that gate inline. resolvePinnedMainDmOwnerFromAllowlist returns null
+      // (pin inactive) unless dmScope is "main" and the allowlist names exactly one owner.
+      const pinnedMainDmOwner = resolvePinnedMainDmOwnerFromAllowlist({
+        dmScope: cfg.session?.dmScope,
+        allowFrom: account.config.allowFrom,
+        normalizeEntry: normalizeMattermostAllowEntry,
       });
-      await core.channel.session.updateLastRoute({
-        storePath,
-        sessionKey: route.mainSessionKey,
-        deliveryContext: {
-          channel: "mattermost",
-          to,
-          accountId: route.accountId,
-        },
-      });
+      const normalizedSender = normalizeMattermostAllowEntry(senderId);
+      if (pinnedMainDmOwner && normalizedSender && pinnedMainDmOwner !== normalizedSender) {
+        logVerboseMessage(
+          `mattermost: skip main-session last route for ${normalizedSender} (pinned owner ${pinnedMainDmOwner})`,
+        );
+      } else {
+        const sessionCfg = cfg.session;
+        const storePath = core.channel.session.resolveStorePath(sessionCfg?.store, {
+          agentId: route.agentId,
+        });
+        await core.channel.session.updateLastRoute({
+          storePath,
+          sessionKey: route.mainSessionKey,
+          deliveryContext: {
+            channel: "mattermost",
+            to,
+            accountId: route.accountId,
+          },
+        });
+      }
     }
 
     const previewLine = bodyText.slice(0, 200).replace(/\n/g, "\\n");

--- a/extensions/slack/src/monitor/auth.ts
+++ b/extensions/slack/src/monitor/auth.ts
@@ -1,8 +1,11 @@
+import { logVerbose } from "remoteclaw/plugin-sdk/runtime-env";
+import { formatErrorMessage } from "../../../../src/infra/errors.js";
 import { readStoreAllowFromForDmPolicy } from "../../../../src/security/dm-policy-shared.js";
 import {
   allowListMatches,
   normalizeAllowList,
   normalizeAllowListLower,
+  normalizeSlackAllowOwnerEntry,
   resolveSlackUserAllowed,
 } from "./allow-list.js";
 import { resolveSlackChannelConfig } from "./channel-config.js";
@@ -22,8 +25,20 @@ type SlackAllowFromCacheState = {
   pairingPending?: Promise<ResolvedAllowFromLists>;
 };
 
+type SlackChannelMembersCacheEntry = {
+  expiresAtMs: number;
+  members?: Set<string>;
+  pending?: Promise<Set<string>>;
+};
+
 let slackAllowFromCache = new WeakMap<SlackMonitorContext, SlackAllowFromCacheState>();
+let slackChannelMembersCache = new WeakMap<
+  SlackMonitorContext,
+  Map<string, SlackChannelMembersCacheEntry>
+>();
 const DEFAULT_PAIRING_ALLOW_FROM_CACHE_TTL_MS = 5000;
+const DEFAULT_CHANNEL_MEMBERS_CACHE_TTL_MS = 60_000;
+const CHANNEL_MEMBERS_CACHE_MAX = 512;
 
 function getPairingAllowFromCacheTtlMs(): number {
   const raw = process.env.REMOTECLAW_SLACK_PAIRING_ALLOWFROM_CACHE_TTL_MS?.trim();
@@ -37,6 +52,18 @@ function getPairingAllowFromCacheTtlMs(): number {
   return Math.max(0, Math.floor(parsed));
 }
 
+function getChannelMembersCacheTtlMs(): number {
+  const raw = process.env.REMOTECLAW_SLACK_CHANNEL_MEMBERS_CACHE_TTL_MS?.trim();
+  if (!raw) {
+    return DEFAULT_CHANNEL_MEMBERS_CACHE_TTL_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_CHANNEL_MEMBERS_CACHE_TTL_MS;
+  }
+  return Math.max(0, Math.floor(parsed));
+}
+
 function getAllowFromCacheState(ctx: SlackMonitorContext): SlackAllowFromCacheState {
   const existing = slackAllowFromCache.get(ctx);
   if (existing) {
@@ -45,6 +72,28 @@ function getAllowFromCacheState(ctx: SlackMonitorContext): SlackAllowFromCacheSt
   const next: SlackAllowFromCacheState = {};
   slackAllowFromCache.set(ctx, next);
   return next;
+}
+
+function getChannelMembersCache(
+  ctx: SlackMonitorContext,
+): Map<string, SlackChannelMembersCacheEntry> {
+  const existing = slackChannelMembersCache.get(ctx);
+  if (existing) {
+    return existing;
+  }
+  const next = new Map<string, SlackChannelMembersCacheEntry>();
+  slackChannelMembersCache.set(ctx, next);
+  return next;
+}
+
+function pruneChannelMembersCache(cache: Map<string, SlackChannelMembersCacheEntry>): void {
+  while (cache.size > CHANNEL_MEMBERS_CACHE_MAX) {
+    const oldest = cache.keys().next();
+    if (oldest.done) {
+      return;
+    }
+    cache.delete(oldest.value);
+  }
 }
 
 function buildBaseAllowFrom(ctx: SlackMonitorContext): ResolvedAllowFromLists {
@@ -129,6 +178,10 @@ export async function resolveSlackEffectiveAllowFrom(
 
 export function clearSlackAllowFromCacheForTest(): void {
   slackAllowFromCache = new WeakMap<SlackMonitorContext, SlackAllowFromCacheState>();
+  slackChannelMembersCache = new WeakMap<
+    SlackMonitorContext,
+    Map<string, SlackChannelMembersCacheEntry>
+  >();
 }
 
 export function isSlackSenderAllowListed(params: {
@@ -147,6 +200,128 @@ export function isSlackSenderAllowListed(params: {
       allowNameMatching,
     })
   );
+}
+
+async function fetchSlackChannelMemberIds(
+  ctx: SlackMonitorContext,
+  channelId: string,
+): Promise<Set<string>> {
+  const members = new Set<string>();
+  let cursor: string | undefined;
+  do {
+    const response = await ctx.app.client.conversations.members({
+      token: ctx.botToken,
+      channel: channelId,
+      limit: 999,
+      ...(cursor ? { cursor } : {}),
+    });
+    for (const member of normalizeAllowListLower(response.members)) {
+      members.add(member);
+    }
+    const nextCursor = response.response_metadata?.next_cursor?.trim();
+    cursor = nextCursor ? nextCursor : undefined;
+  } while (cursor);
+  return members;
+}
+
+async function resolveSlackChannelMemberIds(
+  ctx: SlackMonitorContext,
+  channelId: string,
+): Promise<Set<string>> {
+  const cache = getChannelMembersCache(ctx);
+  const key = `${ctx.accountId}:${channelId}`;
+  const ttlMs = getChannelMembersCacheTtlMs();
+  const nowMs = Date.now();
+  const cached = cache.get(key);
+  if (ttlMs > 0 && cached?.members && cached.expiresAtMs >= nowMs) {
+    return cached.members;
+  }
+  if (cached?.pending) {
+    return await cached.pending;
+  }
+
+  const pending = fetchSlackChannelMemberIds(ctx, channelId);
+  cache.set(key, {
+    expiresAtMs: ttlMs > 0 ? nowMs + ttlMs : 0,
+    pending,
+  });
+  pruneChannelMembersCache(cache);
+  try {
+    const members = await pending;
+    if (ttlMs > 0) {
+      cache.set(key, {
+        expiresAtMs: Date.now() + ttlMs,
+        members,
+      });
+      pruneChannelMembersCache(cache);
+    } else {
+      cache.delete(key);
+    }
+    return members;
+  } finally {
+    const latest = cache.get(key);
+    if (latest?.pending === pending) {
+      cache.delete(key);
+    }
+  }
+}
+
+function resolveExplicitSlackOwnerIds(allowFromLower: string[]): string[] {
+  const ownerIds = new Set<string>();
+  for (const entry of allowFromLower) {
+    const ownerId = normalizeSlackAllowOwnerEntry(entry);
+    if (ownerId) {
+      ownerIds.add(ownerId);
+    }
+  }
+  return [...ownerIds];
+}
+
+export async function authorizeSlackBotRoomMessage(params: {
+  ctx: SlackMonitorContext;
+  channelId: string;
+  senderId: string;
+  senderName?: string;
+  channelUsers?: Array<string | number>;
+  allowFromLower: string[];
+}): Promise<boolean> {
+  const channelUserAllowList = normalizeAllowListLower(params.channelUsers).filter(
+    (entry) => entry !== "*",
+  );
+  if (
+    channelUserAllowList.length > 0 &&
+    allowListMatches({
+      allowList: channelUserAllowList,
+      id: params.senderId,
+      name: params.senderName,
+      allowNameMatching: params.ctx.allowNameMatching,
+    })
+  ) {
+    return true;
+  }
+
+  const explicitOwnerIds = resolveExplicitSlackOwnerIds(params.allowFromLower);
+  if (explicitOwnerIds.length === 0) {
+    logVerbose(
+      `slack: drop bot message ${params.senderId} in ${params.channelId} (no explicit owner id for presence check)`,
+    );
+    return false;
+  }
+
+  try {
+    const channelMemberIds = await resolveSlackChannelMemberIds(params.ctx, params.channelId);
+    if (explicitOwnerIds.some((ownerId) => channelMemberIds.has(ownerId))) {
+      return true;
+    }
+    logVerbose(
+      `slack: drop bot message ${params.senderId} in ${params.channelId} (no owner present)`,
+    );
+  } catch (error) {
+    logVerbose(
+      `slack: drop bot message ${params.senderId} in ${params.channelId} (owner presence lookup failed: ${formatErrorMessage(error)})`,
+    );
+  }
+  return false;
 }
 
 export type SlackSystemEventAuthResult = {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -50,7 +50,7 @@ import {
   resolveSlackAllowListMatch,
   resolveSlackUserAllowed,
 } from "../allow-list.js";
-import { resolveSlackEffectiveAllowFrom } from "../auth.js";
+import { authorizeSlackBotRoomMessage, resolveSlackEffectiveAllowFrom } from "../auth.js";
 import { resolveSlackChannelConfig } from "../channel-config.js";
 import { stripSlackMentionsForCommandDetection } from "../commands.js";
 import { normalizeSlackChannelType, type SlackMonitorContext } from "../context.js";
@@ -183,8 +183,15 @@ async function authorizeSlackInboundMessage(params: {
   conversation: SlackConversationContext;
 }): Promise<SlackAuthorizationContext | null> {
   const { ctx, account, message, conversation } = params;
-  const { isDirectMessage, channelName, resolvedChannelType, isBotMessage, allowBots } =
-    conversation;
+  const {
+    isDirectMessage,
+    channelName,
+    resolvedChannelType,
+    isRoom,
+    isBotMessage,
+    allowBots,
+    channelConfig,
+  } = conversation;
 
   if (isBotMessage) {
     if (message.user && ctx.botUserId && message.user === ctx.botUserId) {
@@ -254,6 +261,21 @@ async function authorizeSlackInboundMessage(params: {
     if (!allowed) {
       return null;
     }
+  }
+
+  if (
+    isRoom &&
+    isBotMessage &&
+    allowBots &&
+    !(await authorizeSlackBotRoomMessage({
+      ctx,
+      channelId: message.channel,
+      senderId,
+      channelUsers: channelConfig?.users,
+      allowFromLower,
+    }))
+  ) {
+    return null;
   }
 
   return {

--- a/package.json
+++ b/package.json
@@ -473,5 +473,5 @@
     ]
   },
   "upstreamRepo": "openclaw/openclaw",
-  "upstreamVersion": "2026.4.29"
+  "upstreamVersion": "2026.5.2"
 }

--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -146,4 +146,92 @@ describe("redactSensitiveText", () => {
     });
     expect(output).toBe(input);
   });
+
+  it("masks hook-token CLI flags", () => {
+    const input = "remoteclaw --hook-token abcdef1234567890ghij start";
+    const output = redactSensitiveText(input, {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(output).toBe("remoteclaw --hook-token abcdef…ghij start");
+  });
+
+  it("masks payment credential JSON fields without redacting unrelated amounts", () => {
+    const input =
+      '{"card_number":"4242424242424242","cvc":"123","sharedPaymentToken":"spt_abcdefghijklmnopqrstuvwxyz","payment_credential":"paycred_abcdefghijklmnopqrstuvwxyz","amount":"4200"}';
+    const output = redactSensitiveText(input, {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(output).toBe(
+      '{"card_number":"***","cvc":"***","sharedPaymentToken":"spt_ab…wxyz","payment_credential":"paycre…wxyz","amount":"4200"}',
+    );
+  });
+
+  it("masks payment credential assignments and flags", () => {
+    const input = [
+      "LINK_CARD_NUMBER=4242424242424242",
+      "LINK_CVC=123",
+      "shared_payment_token=spt_abcdefghijklmnopqrstuvwxyz",
+      "--payment-credential paycred_abcdefghijklmnopqrstuvwxyz",
+      "--card-number 4000056655665556",
+    ].join("\n");
+    const output = redactSensitiveText(input, {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(output).toContain("LINK_CARD_NUMBER=***");
+    expect(output).toContain("LINK_CVC=***");
+    expect(output).toContain("shared_payment_token=spt_ab…wxyz");
+    expect(output).toContain("--payment-credential paycre…wxyz");
+    expect(output).toContain("--card-number ***");
+  });
+
+  it("masks payment credential URL query parameters", () => {
+    const input =
+      "POST /authorize?shared_payment_token=spt_abcdefghijklmnopqrstuvwxyz&card_number=4242424242424242&amount=4200";
+    const output = redactSensitiveText(input, {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(output).toBe(
+      "POST /authorize?shared_payment_token=spt_ab…wxyz&card_number=***&amount=4200",
+    );
+  });
+
+  it("masks Tencent Cloud SecretId (AKID prefix)", () => {
+    const input = "SecretId is AKIDZ8EXAMPLEFAKE01KEY99TEST";
+    const output = redactSensitiveText(input, {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(output).toBe("SecretId is AKIDZ8…TEST");
+  });
+
+  it("masks Alibaba Cloud AccessKey ID (LTAI prefix)", () => {
+    const input = "AccessKeyId=LTAI5tExampleFakeKeyXyz9";
+    const output = redactSensitiveText(input, {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(output).toBe("AccessKeyId=LTAI5t…Xyz9");
+  });
+
+  it("masks HuggingFace tokens (hf_ prefix)", () => {
+    const input = "hf_ABCDEFghijklmnopqrstuv";
+    const output = redactSensitiveText(input, {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(output).toBe("hf_ABC…stuv");
+  });
+
+  it("masks Replicate tokens (r8_ prefix)", () => {
+    const input = "r8_ABCDEFghijklmnopqrstuv";
+    const output = redactSensitiveText(input, {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(output).toBe("r8_ABC…stuv");
+  });
 });

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -12,19 +12,27 @@ const DEFAULT_REDACT_MIN_LENGTH = 18;
 const DEFAULT_REDACT_KEEP_START = 6;
 const DEFAULT_REDACT_KEEP_END = 4;
 
+// Payment-credential key fragments woven into the ENV/URL/JSON/CLI/standalone
+// patterns below so card numbers, CVV/CVC codes, and payment tokens are redacted
+// alongside API keys/secrets. (Ported from upstream #75230; the structured
+// field-value helper it also added has no fork consumer and is omitted.)
+const PAYMENT_CREDENTIAL_ENV_KEYS = String.raw`CARD[_-]?NUMBER|CARD[_-]?CVC|CARD[_-]?CVV|CVC|CVV|SECURITY[_-]?CODE|PAYMENT[_-]?CREDENTIAL|SHARED[_-]?PAYMENT[_-]?TOKEN`;
+const PAYMENT_CREDENTIAL_QUERY_KEYS = String.raw`card[-_]?number|card[-_]?cvc|card[-_]?cvv|cvc|cvv|security[-_]?code|payment[-_]?credential|shared[-_]?payment[-_]?token`;
+const PAYMENT_CREDENTIAL_JSON_KEYS = String.raw`cardNumber|card_number|cardCvc|card_cvc|cardCvv|card_cvv|cvc|cvv|securityCode|security_code|paymentCredential|payment_credential|sharedPaymentToken|shared_payment_token`;
+
 const DEFAULT_REDACT_PATTERNS: string[] = [
   // ENV-style assignments. Keep this case-sensitive so diagnostics like
   // `Unrecognized key: "llm"` do not lose the actual config key.
-  String.raw`/\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD)\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1/g`,
+  String.raw`/\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|${PAYMENT_CREDENTIAL_ENV_KEYS})\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1/g`,
   // URL query parameters. Kept separate from ENV-style assignments so lower-case URL
   // secrets (e.g. `?access_token=…`) stay redacted without hiding config-key diagnostics.
-  String.raw`[?&](?:access[-_]?token|auth[-_]?token|hook[-_]?token|refresh[-_]?token|api[-_]?key|client[-_]?secret|token|key|secret|password|pass|passwd|auth|signature)=([^&\s"'<>]+)`,
+  String.raw`[?&](?:access[-_]?token|auth[-_]?token|hook[-_]?token|refresh[-_]?token|api[-_]?key|client[-_]?secret|token|key|secret|password|pass|passwd|auth|signature|${PAYMENT_CREDENTIAL_QUERY_KEYS})=([^&\s"'<>]+)`,
   // Standalone credential assignments outside URLs (e.g. `token=…` in a log line).
-  String.raw`(^|[\s,;])(?:access_token|refresh_token|api[-_]?key|token|secret|password|passwd)=([^\s&#]+)`,
+  String.raw`(^|[\s,;])(?:access_token|refresh_token|api[-_]?key|token|secret|password|passwd|${PAYMENT_CREDENTIAL_QUERY_KEYS})=([^\s&#]+)`,
   // JSON fields.
-  String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|refreshToken)"\s*:\s*"([^"]+)"`,
+  String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|refreshToken|${PAYMENT_CREDENTIAL_JSON_KEYS})"\s*:\s*"([^"]+)"`,
   // CLI flags.
-  String.raw`--(?:api[-_]?key|token|secret|password|passwd)\s+(["']?)([^\s"']+)\1`,
+  String.raw`--(?:api[-_]?key|hook[-_]?token|token|secret|password|passwd|${PAYMENT_CREDENTIAL_QUERY_KEYS})\s+(["']?)([^\s"']+)\1`,
   // Authorization headers.
   String.raw`Authorization\s*[:=]\s*Bearer\s+([A-Za-z0-9._\-+=]+)`,
   String.raw`\bBearer\s+([A-Za-z0-9._\-+=]{18,})\b`,
@@ -40,6 +48,12 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
   String.raw`\b(AIza[0-9A-Za-z\-_]{20,})\b`,
   String.raw`\b(pplx-[A-Za-z0-9_-]{10,})\b`,
   String.raw`\b(npm_[A-Za-z0-9]{10,})\b`,
+  // Additional access-key and token-style prefixes (Tencent AKID, Alibaba LTAI,
+  // HuggingFace hf_, Replicate r8_). Ported from upstream #58162.
+  String.raw`\b(AKID[A-Za-z0-9]{10,})\b`,
+  String.raw`\b(LTAI[A-Za-z0-9]{10,})\b`,
+  String.raw`\b(hf_[A-Za-z0-9]{10,})\b`,
+  String.raw`\b(r8_[A-Za-z0-9]{10,})\b`,
   // Telegram Bot API URLs embed the token as `/bot<token>/...` (no word-boundary before digits).
   String.raw`\bbot(\d{6,}:[A-Za-z0-9_-]{20,})\b`,
   String.raw`\b(\d{6,}:[A-Za-z0-9_-]{20,})\b`,

--- a/src/plugin-sdk/discord.ts
+++ b/src/plugin-sdk/discord.ts
@@ -47,3 +47,5 @@ export {
   buildComputedAccountStatusSnapshot,
   buildTokenChannelStatusSummary,
 } from "./status-helpers.js";
+
+export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";


### PR DESCRIPTION
## Summary

D.7 §0 revert-fidelity found 8 MEDIUM upstream security fixes that the content-only
RECONCILE hold silently dropped from live KEPT paths during the v2026.4.29 → v2026.5.2
sync (#2816). This follow-up restores the **6** that are clean wire-ins of security
helpers the fork already retains (and already applies to peer adapters), and **escalates
the 2** that are not cleanly portable to a dedicated baseline PR.

Version indicators bumped 2026.4.29 → 2026.5.2 (`package.json` `upstreamVersion`, README badge).

## Ports restored (6)

| # | Upstream fix | Area | What was restored |
|---|---|---|---|
| 1 | `f6a1d700809` | matrix `monitor/handler.ts` (+ `types.ts`) | Main-DM owner-pin: skip the last-route update when a pinned main-DM owner ≠ sender (`resolvePinnedMainDmOwnerFromAllowlist` + `mainDmOwnerPin`), mirroring peer adapters |
| 2 | `f6a1d700809` | mattermost `monitor.ts` | Same DM owner-pin gate, inline-replicated on the direct-message `updateLastRoute` path |
| 5 | `8b665e0d706` | slack `monitor/auth.ts` + `message-handler/prepare.ts` | Bot-room owner-presence gate: bot messages in rooms are authorized only when an explicit owner is present (`authorizeSlackBotRoomMessage`, cached `conversations.members`) |
| 6 | `bd20f8e07e9` | discord `voice-message.ts` (+ `plugin-sdk/discord.ts` re-export) | SSRF guard (`fetchWithSsrFGuard`) on both the voice upload-url POST and the attachment PUT, preserving carbon `RateLimitError` handling |
| 7 | `84920fad4e6`, `0260903f7f7` | `src/logging/redact.ts` (+ tests) | Payment-credential + cloud-key (AKID / LTAI / hf_ / r8_) redaction across ENV / query / JSON / CLI-flag surfaces; `hook-token` added to the CLI-flag pattern (WATCH) |
| 8 | `10ebcbdb998` | `Dockerfile` | Digest-pinned multi-stage Bun binary `COPY` (replaces `curl \| bash` install) |

## Escalated to baseline — NOT cleanly portable (ports 3 + 4)

**Mattermost slash-callback command validation** (`9c0975c1c20`).

CRVM against this worktree shows this is not a wire-in like the others — it is a **1481-line**
commit (398 slash-http + 169 slash-state + ~900 test lines) that **entangles a structural
refactor with the hardening**, onto a fork base that has structurally diverged from upstream:

- Drags in helpers **absent** from the fork's mattermost extension: `safeEqualSecret`,
  `isPrivateNetworkOptInEnabled`, `readRequestBodyWithLimit` / `isRequestBodyLimitError`
  (the last from a separate refactor-branch commit `1d22578c6cd`, not in the fork).
- Requires a `commandTokens: Set<string>` → `registeredCommands: MattermostRegisteredCommand[]`
  refactor; upstream's `./runtime-api.js` module does not exist in the fork (split into
  `./client.js` + `remoteclaw/plugin-sdk/mattermost`); the fork's live token check is a plain
  `commandTokens.has()`.
- The value is ~400 lines of concurrency-sensitive security code (in-flight dedup, token-bucket
  rate-limit, bounded-cache sweeps, abort/timeout) that cannot be verified without adapting the
  ~900-line upstream test suite. Hand-porting unverified auth-path code risks a **security
  regression** — worse than a tracked deferral. Current fork exposure is bounded (base
  fail-closed token validation still holds); the gap is the token-rotation window + DoS +
  log-redaction.

Full CRVM evidence + baseline-PR checklist: `hq/.tmp/sync/v2026.5.2/ports-3-4-escalation.md`.

**Not ported (record-only, per task scope)**: slack channel-config LOW, gateway SecretRef-rotation
LOW-WATCH, 9 LOW non-security drops, install.ts fail-open scanner.

## Verification

- `pnpm check` (format + typecheck + lint incl. lobster-leak, css-class-drift): ✅ exit 0
- Extensions lane (`pnpm test:extensions`): ✅ 347 files / 3060 tests
- redact unit tests: ✅ 23 / 23
- Unit lane (`pnpm test`): 8335 passed; **2 pre-existing environmental** failures unrelated to
  this PR (`bundled-runtime-deps` sandbox `/tmp` EACCES; `local-heavy-check-runtime` tsgo-arg
  env) — neither file is touched here, and no import path connects the changes to those subjects
- semantic-invariants: ✅ 0 violations / 12
- rebrand + throwing-stub-callers gates: ✅

No `src/middleware/` changes → LIVE smoke tests N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
