### PR TITLE
fix(mattermost): harden slash-callback token validation (#2818)

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -428,7 +428,6 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
 
         activateSlashCommands({
           account,
-          commandTokens: allRegistered.map((cmd) => cmd.token).filter(Boolean),
           registeredCommands: allRegistered,
           triggerMap,
           api: { cfg, runtime },

--- a/extensions/mattermost/src/mattermost/slash-commands.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-commands.test.ts
@@ -234,6 +234,20 @@ describe("slash-command token authorization", () => {
   it("fails closed when no commands are registered", () => {
     expect(isAuthorizedSlashCommandToken([], payload())).toBe(false);
   });
+
+  it("matches the trigger case-insensitively (MM lowercases registered triggers)", () => {
+    const mixed: MattermostRegisteredCommand = {
+      ...baseCmd,
+      trigger: "oc_MySkill",
+      token: "skill-token",
+    };
+    expect(
+      isAuthorizedSlashCommandToken(
+        [mixed],
+        payload({ command: "/oc_myskill", token: "skill-token" }),
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("sanitizeSlashLogValue", () => {

--- a/extensions/mattermost/src/mattermost/slash-commands.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-commands.test.ts
@@ -2,11 +2,18 @@ import { describe, expect, it, vi } from "vitest";
 import type { MattermostClient } from "./client.js";
 import {
   DEFAULT_COMMAND_SPECS,
+  findRegisteredCommandForPayload,
+  isAuthorizedSlashCommandToken,
   parseSlashCommandPayload,
   registerSlashCommands,
   resolveCallbackUrl,
   resolveCommandText,
   resolveSlashCommandConfig,
+  sanitizeSlashLogValue,
+} from "./slash-commands.js";
+import type {
+  MattermostRegisteredCommand,
+  MattermostSlashCommandPayload,
 } from "./slash-commands.js";
 
 describe("slash-commands", () => {
@@ -153,5 +160,94 @@ describe("slash-commands", () => {
 
     expect(result).toHaveLength(0);
     expect(request).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("slash-command token authorization", () => {
+  const baseCmd: MattermostRegisteredCommand = {
+    id: "cmd-1",
+    trigger: "oc_status",
+    teamId: "t1",
+    token: "known-token",
+    url: "https://chat.example.com/callback",
+    managed: true,
+  };
+  const payload = (
+    over: Partial<MattermostSlashCommandPayload> = {},
+  ): MattermostSlashCommandPayload => ({
+    token: "known-token",
+    team_id: "t1",
+    channel_id: "c1",
+    user_id: "u1",
+    command: "/oc_status",
+    text: "",
+    ...over,
+  });
+
+  it("finds the registered command by normalized trigger and team", () => {
+    const found = findRegisteredCommandForPayload([baseCmd], payload({ command: "/oc_status" }));
+    expect(found?.id).toBe("cmd-1");
+  });
+
+  it("returns null when the trigger is unknown or the team mismatches", () => {
+    expect(
+      findRegisteredCommandForPayload([baseCmd], payload({ command: "/oc_unknown" })),
+    ).toBeNull();
+    expect(findRegisteredCommandForPayload([baseCmd], payload({ team_id: "other" }))).toBeNull();
+  });
+
+  it("accepts the exact token for the matching command (constant-time gate)", () => {
+    expect(isAuthorizedSlashCommandToken([baseCmd], payload({ token: "known-token" }))).toBe(true);
+  });
+
+  it("rejects a wrong-value token", () => {
+    expect(isAuthorizedSlashCommandToken([baseCmd], payload({ token: "wrong-token" }))).toBe(false);
+  });
+
+  it("rejects a length-mismatch token (exercises the length guard)", () => {
+    expect(isAuthorizedSlashCommandToken([baseCmd], payload({ token: "known-tokenX" }))).toBe(
+      false,
+    );
+  });
+
+  it("scopes tokens per command — a token valid for A is rejected on B", () => {
+    const a: MattermostRegisteredCommand = {
+      ...baseCmd,
+      id: "a",
+      trigger: "oc_a",
+      token: "token-a",
+    };
+    const b: MattermostRegisteredCommand = {
+      ...baseCmd,
+      id: "b",
+      trigger: "oc_b",
+      token: "token-b",
+    };
+    expect(
+      isAuthorizedSlashCommandToken([a, b], payload({ command: "/oc_b", token: "token-a" })),
+    ).toBe(false);
+    expect(
+      isAuthorizedSlashCommandToken([a, b], payload({ command: "/oc_b", token: "token-b" })),
+    ).toBe(true);
+  });
+
+  it("fails closed when no commands are registered", () => {
+    expect(isAuthorizedSlashCommandToken([], payload())).toBe(false);
+  });
+});
+
+describe("sanitizeSlashLogValue", () => {
+  it("collapses CR/LF/tab to spaces to prevent log injection", () => {
+    expect(sanitizeSlashLogValue("line1\r\nline2\tend")).toBe("line1 line2 end");
+  });
+
+  it("truncates values beyond the length cap", () => {
+    const out = sanitizeSlashLogValue("x".repeat(300), 200);
+    expect(out.length).toBe(201); // 200 chars + ellipsis
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("passes short plain values through unchanged", () => {
+    expect(sanitizeSlashLogValue("channel-abc")).toBe("channel-abc");
   });
 });

--- a/extensions/mattermost/src/mattermost/slash-commands.ts
+++ b/extensions/mattermost/src/mattermost/slash-commands.ts
@@ -12,6 +12,7 @@
  * - On shutdown, cleans up registered commands via DELETE /api/v4/commands/{id}
  */
 
+import { safeEqualSecret } from "remoteclaw/plugin-sdk/mattermost";
 import { normalizeOptionalString } from "remoteclaw/plugin-sdk/text-runtime";
 import type { MattermostClient } from "./client.js";
 
@@ -524,6 +525,51 @@ export function resolveCommandText(
 
 export function normalizeSlashCommandTrigger(command: string): string {
   return command.replace(/^\//, "").trim();
+}
+
+/**
+ * Locate the registered command a callback payload targets, matched by the
+ * normalized trigger word and team. Returns null when nothing matches — which
+ * the token gate treats as fail-closed.
+ */
+export function findRegisteredCommandForPayload(
+  registeredCommands: readonly MattermostRegisteredCommand[],
+  payload: Pick<MattermostSlashCommandPayload, "command" | "team_id">,
+): MattermostRegisteredCommand | null {
+  const trigger = normalizeSlashCommandTrigger(payload.command);
+  if (!trigger) {
+    return null;
+  }
+  for (const command of registeredCommands) {
+    if (command.trigger === trigger && command.teamId === payload.team_id) {
+      return command;
+    }
+  }
+  return null;
+}
+
+/**
+ * Validate a slash callback token against the registered command it claims to
+ * invoke. Scopes the token to that specific command (a token issued for command
+ * A is not accepted for command B) and compares in constant time to avoid a
+ * timing side-channel. Fails closed when no command matches.
+ */
+export function isAuthorizedSlashCommandToken(
+  registeredCommands: readonly MattermostRegisteredCommand[],
+  payload: Pick<MattermostSlashCommandPayload, "command" | "team_id" | "token">,
+): boolean {
+  const command = findRegisteredCommandForPayload(registeredCommands, payload);
+  return command !== null && safeEqualSecret(payload.token, command.token);
+}
+
+/**
+ * Sanitize a value before interpolating it into a log line: collapse CR/LF/tab
+ * (prevents log injection/forging via attacker-controlled fields such as sender
+ * name or channel id) and cap the length (bounds log flooding).
+ */
+export function sanitizeSlashLogValue(value: string, maxLength = 200): string {
+  const collapsed = value.replace(/[\r\n\t]+/g, " ").trim();
+  return collapsed.length > maxLength ? `${collapsed.slice(0, maxLength)}…` : collapsed;
 }
 
 // ─── Config resolution ───────────────────────────────────────────────────────

--- a/extensions/mattermost/src/mattermost/slash-commands.ts
+++ b/extensions/mattermost/src/mattermost/slash-commands.ts
@@ -536,12 +536,16 @@ export function findRegisteredCommandForPayload(
   registeredCommands: readonly MattermostRegisteredCommand[],
   payload: Pick<MattermostSlashCommandPayload, "command" | "team_id">,
 ): MattermostRegisteredCommand | null {
-  const trigger = normalizeSlashCommandTrigger(payload.command);
+  // Mattermost lowercases trigger words at registration and echoes the
+  // lowercased form in callbacks, so match case-insensitively to avoid
+  // rejecting a legitimate call for a mixed-case registered trigger. The token
+  // (compared constant-time by the caller) remains the actual auth gate.
+  const trigger = normalizeSlashCommandTrigger(payload.command).toLowerCase();
   if (!trigger) {
     return null;
   }
   for (const command of registeredCommands) {
-    if (command.trigger === trigger && command.teamId === payload.team_id) {
+    if (command.trigger.toLowerCase() === trigger && command.teamId === payload.team_id) {
       return command;
     }
   }

--- a/extensions/mattermost/src/mattermost/slash-http.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.test.ts
@@ -3,12 +3,14 @@ import { PassThrough } from "node:stream";
 import type { RemoteClawConfig, RuntimeEnv } from "remoteclaw/plugin-sdk/mattermost";
 import { describe, expect, it } from "vitest";
 import type { ResolvedMattermostAccount } from "./accounts.js";
+import type { MattermostRegisteredCommand } from "./slash-commands.js";
 import { createSlashCommandHttpHandler } from "./slash-http.js";
 
 function createRequest(params: {
   method?: string;
   body?: string;
   contentType?: string;
+  keepOpen?: boolean;
 }): IncomingMessage {
   const req = new PassThrough();
   const incoming = req as unknown as IncomingMessage;
@@ -20,7 +22,9 @@ function createRequest(params: {
     if (params.body) {
       req.write(params.body);
     }
-    req.end();
+    if (!params.keepOpen) {
+      req.end();
+    }
   });
   return incoming;
 }
@@ -58,18 +62,37 @@ const accountFixture: ResolvedMattermostAccount = {
   config: {},
 };
 
+function cmd(overrides: Partial<MattermostRegisteredCommand> = {}): MattermostRegisteredCommand {
+  return {
+    id: "cmd-1",
+    trigger: "oc_status",
+    teamId: "t1",
+    token: "known-token",
+    url: "https://chat.example.com/callback",
+    managed: true,
+    ...overrides,
+  };
+}
+
 async function runSlashRequest(params: {
-  commandTokens: Set<string>;
+  registeredCommands: MattermostRegisteredCommand[];
   body: string;
   method?: string;
+  bodyTimeoutMs?: number;
+  keepOpen?: boolean;
 }) {
   const handler = createSlashCommandHttpHandler({
     account: accountFixture,
     cfg: {} as RemoteClawConfig,
     runtime: {} as RuntimeEnv,
-    commandTokens: params.commandTokens,
+    registeredCommands: params.registeredCommands,
+    bodyTimeoutMs: params.bodyTimeoutMs,
   });
-  const req = createRequest({ method: params.method, body: params.body });
+  const req = createRequest({
+    method: params.method,
+    body: params.body,
+    keepOpen: params.keepOpen,
+  });
   const response = createResponse();
   await handler(req, response.res);
   return response;
@@ -77,16 +100,11 @@ async function runSlashRequest(params: {
 
 describe("slash-http", () => {
   it("rejects non-POST methods", async () => {
-    const handler = createSlashCommandHttpHandler({
-      account: accountFixture,
-      cfg: {} as RemoteClawConfig,
-      runtime: {} as RuntimeEnv,
-      commandTokens: new Set(["valid-token"]),
+    const response = await runSlashRequest({
+      registeredCommands: [cmd()],
+      method: "GET",
+      body: "",
     });
-    const req = createRequest({ method: "GET", body: "" });
-    const response = createResponse();
-
-    await handler(req, response.res);
 
     expect(response.res.statusCode).toBe(405);
     expect(response.getBody()).toBe("Method Not Allowed");
@@ -94,24 +112,18 @@ describe("slash-http", () => {
   });
 
   it("rejects malformed payloads", async () => {
-    const handler = createSlashCommandHttpHandler({
-      account: accountFixture,
-      cfg: {} as RemoteClawConfig,
-      runtime: {} as RuntimeEnv,
-      commandTokens: new Set(["valid-token"]),
+    const response = await runSlashRequest({
+      registeredCommands: [cmd()],
+      body: "token=abc&command=%2Foc_status",
     });
-    const req = createRequest({ body: "token=abc&command=%2Foc_status" });
-    const response = createResponse();
-
-    await handler(req, response.res);
 
     expect(response.res.statusCode).toBe(400);
     expect(response.getBody()).toContain("Invalid slash command payload");
   });
 
-  it("fails closed when no command tokens are registered", async () => {
+  it("fails closed when no commands are registered", async () => {
     const response = await runSlashRequest({
-      commandTokens: new Set<string>(),
+      registeredCommands: [],
       body: "token=tok1&team_id=t1&channel_id=c1&user_id=u1&command=%2Foc_status&text=",
     });
 
@@ -121,11 +133,44 @@ describe("slash-http", () => {
 
   it("rejects unknown command tokens", async () => {
     const response = await runSlashRequest({
-      commandTokens: new Set(["known-token"]),
+      registeredCommands: [cmd({ token: "known-token" })],
       body: "token=unknown&team_id=t1&channel_id=c1&user_id=u1&command=%2Foc_status&text=",
     });
 
     expect(response.res.statusCode).toBe(401);
     expect(response.getBody()).toContain("Unauthorized: invalid command token.");
+  });
+
+  it("rejects a token registered for a different command (per-command scoping)", async () => {
+    const response = await runSlashRequest({
+      registeredCommands: [
+        cmd({ id: "a", trigger: "oc_a", token: "token-a" }),
+        cmd({ id: "b", trigger: "oc_b", token: "token-b" }),
+      ],
+      body: "token=token-a&team_id=t1&channel_id=c1&user_id=u1&command=%2Foc_b&text=",
+    });
+
+    expect(response.res.statusCode).toBe(401);
+    expect(response.getBody()).toContain("Unauthorized: invalid command token.");
+  });
+
+  it("returns 413 when the body exceeds the size limit", async () => {
+    const response = await runSlashRequest({
+      registeredCommands: [cmd()],
+      body: `token=${"x".repeat(70 * 1024)}`,
+    });
+
+    expect(response.res.statusCode).toBe(413);
+  });
+
+  it("returns 408 when the body read times out", async () => {
+    const response = await runSlashRequest({
+      registeredCommands: [cmd()],
+      body: "token=par",
+      keepOpen: true,
+      bodyTimeoutMs: 50,
+    });
+
+    expect(response.res.statusCode).toBe(408);
   });
 });

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -9,9 +9,13 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   createReplyPrefixOptions,
   createTypingCallbacks,
+  isRequestBodyLimitError,
   logTypingFailure,
+  readRequestBodyWithLimit,
+  redactSensitiveText,
   type RemoteClawConfig,
   type ReplyPayload,
+  requestBodyErrorToText,
   type RuntimeEnv,
 } from "remoteclaw/plugin-sdk/mattermost";
 import type { ResolvedMattermostAccount } from "../mattermost/accounts.js";
@@ -30,43 +34,26 @@ import {
 import { deliverMattermostReplyPayload } from "./reply-delivery.js";
 import { sendMessageMattermost } from "./send.js";
 import {
+  isAuthorizedSlashCommandToken,
+  type MattermostRegisteredCommand,
+  type MattermostSlashCommandResponse,
+  normalizeSlashCommandTrigger,
   parseSlashCommandPayload,
   resolveCommandText,
-  type MattermostSlashCommandResponse,
+  sanitizeSlashLogValue,
 } from "./slash-commands.js";
 
 type SlashHttpHandlerParams = {
   account: ResolvedMattermostAccount;
   cfg: RemoteClawConfig;
   runtime: RuntimeEnv;
-  /** Expected token from registered commands (for validation). */
-  commandTokens: Set<string>;
+  /** Registered commands for this account (token validation is scoped per command). */
+  registeredCommands: readonly MattermostRegisteredCommand[];
   /** Map from trigger to original command name (for skill commands that start with oc_). */
   triggerMap?: ReadonlyMap<string, string>;
   log?: (msg: string) => void;
   bodyTimeoutMs?: number;
 };
-
-/**
- * Read the full request body as a string.
- */
-function readBody(req: IncomingMessage, maxBytes: number): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    let size = 0;
-    req.on("data", (chunk: Buffer) => {
-      size += chunk.length;
-      if (size > maxBytes) {
-        req.destroy();
-        reject(new Error("Request body too large"));
-        return;
-      }
-      chunks.push(chunk);
-    });
-    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
-    req.on("error", reject);
-  });
-}
 
 function sendJsonResponse(
   res: ServerResponse,
@@ -108,7 +95,9 @@ async function authorizeSlashInvocation(params: {
   try {
     channelInfo = await fetchMattermostChannel(client, channelId);
   } catch (err) {
-    log?.(`mattermost: slash channel lookup failed for ${channelId}: ${String(err)}`);
+    log?.(
+      `mattermost: slash channel lookup failed for ${sanitizeSlashLogValue(channelId)}: ${sanitizeSlashLogValue(redactSensitiveText(String(err)))}`,
+    );
   }
 
   if (!channelInfo) {
@@ -206,7 +195,7 @@ async function authorizeSlashInvocation(params: {
  * from the Mattermost server when a user invokes a registered slash command.
  */
 export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
-  const { account, cfg, runtime, commandTokens, triggerMap, log, bodyTimeoutMs } = params;
+  const { account, cfg, runtime, registeredCommands, triggerMap, log, bodyTimeoutMs } = params;
 
   const MAX_BODY_BYTES = 64 * 1024; // 64KB
 
@@ -220,10 +209,18 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
 
     let body: string;
     try {
-      body = await readBody(req, MAX_BODY_BYTES);
-    } catch {
-      res.statusCode = 413;
-      res.end("Payload Too Large");
+      body = await readRequestBodyWithLimit(req, {
+        maxBytes: MAX_BODY_BYTES,
+        timeoutMs: bodyTimeoutMs ?? 5_000,
+      });
+    } catch (err) {
+      if (isRequestBodyLimitError(err)) {
+        res.statusCode = err.statusCode;
+        res.end(requestBodyErrorToText(err.code));
+      } else {
+        res.statusCode = 400;
+        res.end("Bad Request");
+      }
       return;
     }
 
@@ -237,9 +234,10 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
       return;
     }
 
-    // Validate token — fail closed: reject when no tokens are registered
-    // (e.g. registration failed or startup was partial)
-    if (commandTokens.size === 0 || !commandTokens.has(payload.token)) {
+    // Validate the token against the specific command it claims to invoke.
+    // Scoped per command + constant-time compare; fails closed when no command
+    // matches (e.g. registration failed or startup was partial).
+    if (!isAuthorizedSlashCommandToken(registeredCommands, payload)) {
       sendJsonResponse(res, 401, {
         response_type: "ephemeral",
         text: "Unauthorized: invalid command token.",
@@ -247,8 +245,8 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
       return;
     }
 
-    // Extract command info
-    const trigger = payload.command.replace(/^\//, "").trim();
+    // Extract command info (same normalization the token gate matched on).
+    const trigger = normalizeSlashCommandTrigger(payload.command);
     const commandText = resolveCommandText(trigger, payload.text, triggerMap);
     const channelId = payload.channel_id;
     const senderId = payload.user_id;
@@ -279,7 +277,9 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
       return;
     }
 
-    log?.(`mattermost: slash command /${trigger} from ${senderName} in ${channelId}`);
+    log?.(
+      `mattermost: slash command /${sanitizeSlashLogValue(trigger)} from ${sanitizeSlashLogValue(senderName)} in ${sanitizeSlashLogValue(channelId)}`,
+    );
 
     // Acknowledge immediately — we'll send the actual reply asynchronously
     sendJsonResponse(res, 200, {
@@ -309,7 +309,9 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
         log,
       });
     } catch (err) {
-      log?.(`mattermost: slash command handler error: ${String(err)}`);
+      log?.(
+        `mattermost: slash command handler error: ${sanitizeSlashLogValue(redactSensitiveText(String(err)))}`,
+      );
       try {
         const to = `channel:${channelId}`;
         await sendMessageMattermost(to, "Sorry, something went wrong processing that command.", {

--- a/extensions/mattermost/src/mattermost/slash-state.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.test.ts
@@ -1,17 +1,32 @@
 import { describe, expect, it } from "vitest";
+import type { MattermostRegisteredCommand } from "./slash-commands.js";
 import {
   activateSlashCommands,
   deactivateSlashCommands,
   resolveSlashHandlerForToken,
 } from "./slash-state.js";
 
+function registered(
+  token: string,
+  overrides: Partial<MattermostRegisteredCommand> = {},
+): MattermostRegisteredCommand {
+  return {
+    id: `cmd-${token}`,
+    trigger: "oc_status",
+    teamId: "t1",
+    token,
+    url: "https://chat.example.com/callback",
+    managed: true,
+    ...overrides,
+  };
+}
+
 describe("slash-state token routing", () => {
   it("returns single match when token belongs to one account", () => {
     deactivateSlashCommands();
     activateSlashCommands({
       account: { accountId: "a1" } as any,
-      commandTokens: ["tok-a"],
-      registeredCommands: [],
+      registeredCommands: [registered("tok-a")],
       api: { cfg: {} as any, runtime: {} as any },
     });
 
@@ -24,14 +39,12 @@ describe("slash-state token routing", () => {
     deactivateSlashCommands();
     activateSlashCommands({
       account: { accountId: "a1" } as any,
-      commandTokens: ["tok-shared"],
-      registeredCommands: [],
+      registeredCommands: [registered("tok-shared", { id: "c1", teamId: "t1" })],
       api: { cfg: {} as any, runtime: {} as any },
     });
     activateSlashCommands({
       account: { accountId: "a2" } as any,
-      commandTokens: ["tok-shared"],
-      registeredCommands: [],
+      registeredCommands: [registered("tok-shared", { id: "c2", teamId: "t2" })],
       api: { cfg: {} as any, runtime: {} as any },
     });
 

--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -10,7 +10,13 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { RemoteClawPluginApi } from "remoteclaw/plugin-sdk/mattermost";
+import {
+  isRequestBodyLimitError,
+  readRequestBodyWithLimit,
+  type RemoteClawPluginApi,
+  requestBodyErrorToText,
+  safeEqualSecret,
+} from "remoteclaw/plugin-sdk/mattermost";
 import type { ResolvedMattermostAccount } from "./accounts.js";
 import { resolveSlashCommandConfig, type MattermostRegisteredCommand } from "./slash-commands.js";
 import { createSlashCommandHttpHandler } from "./slash-http.js";
@@ -18,9 +24,7 @@ import { createSlashCommandHttpHandler } from "./slash-http.js";
 // ─── Per-account state ───────────────────────────────────────────────────────
 
 export type SlashCommandAccountState = {
-  /** Tokens from registered commands, used for validation. */
-  commandTokens: Set<string>;
-  /** Registered command IDs for cleanup on shutdown. */
+  /** Registered commands, used for per-command token validation and cleanup. */
   registeredCommands: MattermostRegisteredCommand[];
   /** Current HTTP handler for this account. */
   handler: ((req: IncomingMessage, res: ServerResponse) => Promise<void>) | null;
@@ -44,7 +48,10 @@ export function resolveSlashHandlerForToken(token: string): {
   }> = [];
 
   for (const [accountId, state] of accountStates) {
-    if (state.commandTokens.has(token) && state.handler) {
+    const matchesToken = state.registeredCommands.some((command) =>
+      safeEqualSecret(token, command.token),
+    );
+    if (matchesToken && state.handler) {
       matches.push({ accountId, handler: state.handler });
     }
   }
@@ -82,7 +89,6 @@ export function getAllSlashCommandStates(): ReadonlyMap<string, SlashCommandAcco
  */
 export function activateSlashCommands(params: {
   account: ResolvedMattermostAccount;
-  commandTokens: string[];
   registeredCommands: MattermostRegisteredCommand[];
   triggerMap?: Map<string, string>;
   api: {
@@ -91,22 +97,19 @@ export function activateSlashCommands(params: {
   };
   log?: (msg: string) => void;
 }) {
-  const { account, commandTokens, registeredCommands, triggerMap, api, log } = params;
+  const { account, registeredCommands, triggerMap, api, log } = params;
   const accountId = account.accountId;
-
-  const tokenSet = new Set(commandTokens);
 
   const handler = createSlashCommandHttpHandler({
     account,
     cfg: api.cfg,
     runtime: api.runtime,
-    commandTokens: tokenSet,
+    registeredCommands,
     triggerMap,
     log,
   });
 
   accountStates.set(accountId, {
-    commandTokens: tokenSet,
     registeredCommands,
     handler,
     account,
@@ -125,7 +128,6 @@ export function deactivateSlashCommands(accountId?: string) {
   if (accountId) {
     const state = accountStates.get(accountId);
     if (state) {
-      state.commandTokens.clear();
       state.registeredCommands = [];
       state.handler = null;
       accountStates.delete(accountId);
@@ -133,7 +135,6 @@ export function deactivateSlashCommands(accountId?: string) {
   } else {
     // Deactivate all accounts (full shutdown)
     for (const [, state] of accountStates) {
-      state.commandTokens.clear();
       state.registeredCommands = [];
       state.handler = null;
     }
@@ -225,20 +226,24 @@ export function registerSlashCommandRoute(api: RemoteClawPluginApi) {
     }
 
     // Multi-account: buffer the body, find the matching account by token,
-    // then replay the request to the correct handler.
-    const chunks: Buffer[] = [];
-    const MAX_BODY = 64 * 1024;
-    let size = 0;
-    for await (const chunk of req) {
-      size += (chunk as Buffer).length;
-      if (size > MAX_BODY) {
-        res.statusCode = 413;
-        res.end("Payload Too Large");
-        return;
+    // then replay the request to the correct handler. Bound the read by size
+    // AND time (the timeout guards against Slowloris-style slow-drip clients).
+    let bodyStr: string;
+    try {
+      bodyStr = await readRequestBodyWithLimit(req, {
+        maxBytes: 64 * 1024,
+        timeoutMs: 5_000,
+      });
+    } catch (err) {
+      if (isRequestBodyLimitError(err)) {
+        res.statusCode = err.statusCode;
+        res.end(requestBodyErrorToText(err.code));
+      } else {
+        res.statusCode = 400;
+        res.end("Bad Request");
       }
-      chunks.push(chunk as Buffer);
+      return;
     }
-    const bodyStr = Buffer.concat(chunks).toString("utf8");
 
     // Parse just the token to find the right account
     let token: string | null = null;

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -73,8 +73,15 @@ export {
   requireOpenAllowFrom,
 } from "../config/zod-schema.core.js";
 export { createDedupeCache } from "../infra/dedupe.js";
+export {
+  isRequestBodyLimitError,
+  readRequestBodyWithLimit,
+  requestBodyErrorToText,
+} from "../infra/http-body.js";
 export { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 export { rawDataToString } from "../infra/ws.js";
+export { redactSensitiveText } from "../logging/redact.js";
+export { safeEqualSecret } from "../security/secret-equal.js";
 export { isLoopbackHost, isTrustedProxyAddress, resolveClientIp } from "../gateway/net.js";
 export { registerPluginHttpRoute } from "../plugins/http-registry.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";


### PR DESCRIPTION
## What

Hardens the Mattermost native slash-command HTTP callback by porting the security-relevant changes from upstream OpenClaw commit `9c0975c1c20`.

## Why

The slash-callback token gate compared the inbound token with `Set.has(payload.token)`, which:

- short-circuits on the first differing byte → **timing side-channel** usable to recover a valid token byte-by-byte and forge callbacks;
- accepts **any** registered token for **any** command (no per-command scoping).

The body reader had a size cap but **no timeout** (Slowloris), and log lines interpolated attacker-influenced values (sender name, channel id, error strings) verbatim (log injection / secret leakage).

## Changes

- **Constant-time, per-command-scoped token check.** The gate looks up the registered command by normalized trigger + team and compares its token with a length-guarded constant-time comparison (`safeEqualSecret`). Fails closed when no command matches. A token issued for `/a` is no longer accepted on `/b`.
- **Request-body read timeout.** Both the single- and multi-account callback paths use the shared `readRequestBodyWithLimit` (64 KB + 5 s): `413` for oversized, `408` for slow-drip bodies.
- **Log sanitization.** Interpolated values are stripped of CR/LF/tab and run through secret redaction before logging.
- Adopts the already-populated `registeredCommands` model end-to-end and removes the now-vestigial per-account token `Set`; multi-account routing also compares tokens in constant time.

## Tests

- Token-gate unit tests: exact-accept, wrong-value reject, length-mismatch reject, per-command scoping, fail-closed-on-empty.
- Handler tests: unknown / cross-command token → 401, oversized → 413, slow body → 408.
- Log-sanitizer unit tests (CR/LF/tab collapse + truncation).
- `pnpm check` clean; full mattermost extension suite (197 tests) green.

## Deferred (not in this PR)

Upstream `9c0975c1c20` also adds a **live per-invocation token re-validation** layer — a Mattermost API call on every callback to re-fetch the command's current token, backed by an in-flight dedupe map, a bounded failure cache with TTL/sweep, and a token-bucket rate limiter. Its sole purpose is to honor **server-side token revocation without a restart** (admin rotates/deletes a command mid-process). Deferred because:

- it imposes 1–2 synchronous MM API calls on every slash invocation plus ~200 lines of stateful module-global cache/limiter code on a live adapter;
- it has a hard co-dependency on private-network opt-in — on a self-hosted Mattermost at a private IP the live lookup would be SSRF-blocked, fail closed, and poison the per-command failure cache (DoS of legitimate commands);
- native slash commands are opt-in and default off today, so restart-scoped revocation is an acceptable trade.

**Falsifier — revisit and ship the live layer if** native slash commands become a first-class, actively-used feature where admin-initiated token rotation / command deletion is the expected revocation path **and** deployments are long-lived enough that "restart to refresh the token cache" is an unacceptable revocation latency. If shipped, private-network opt-in becomes a required co-dependency.

Partially addresses #2818 — this ships **Layer 1** (constant-time token compare, per-command token scoping, request-body / Slowloris timeout, secret-log redaction). The **rate-limiter + bounded-cache + live-rotation-revalidation layer** described under *Deferred* is **not** included, so **#2818 stays open** to track that remaining hardening (see the Falsifier for the revisit trigger). Intentionally not using a closing keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
