### PR TITLE
chore: bump upstream version indicators to v2026.5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.com/package/remoteclaw"><img src="https://img.shields.io/npm/v/remoteclaw?style=for-the-badge" alt="npm version"></a>
   <a href="https://github.com/remoteclaw/remoteclaw/releases"><img src="https://img.shields.io/github/v/release/remoteclaw/remoteclaw?include_prereleases&display_name=release&style=for-the-badge&label=GITHUB" alt="GitHub release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0--only-blue.svg?style=for-the-badge" alt="AGPL-3.0-only License"></a>
-  <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.5.2"><img src="https://img.shields.io/badge/upstream-OpenClaw_v2026.5.2-teal?style=for-the-badge" alt="Upstream: OpenClaw v2026.5.2"></a>
+  <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.5.7"><img src="https://img.shields.io/badge/upstream-OpenClaw_v2026.5.7-teal?style=for-the-badge" alt="Upstream: OpenClaw v2026.5.7"></a>
 </p>
 
 **RemoteClaw** is AI agent middleware. It connects agent CLIs you already run — Claude Code, Gemini CLI, Codex, OpenCode — to the messaging channels you already use, so you can reach your agents from anywhere: your phone, your team Slack, your WhatsApp, anywhere.

--- a/package.json
+++ b/package.json
@@ -473,5 +473,5 @@
     ]
   },
   "upstreamRepo": "openclaw/openclaw",
-  "upstreamVersion": "2026.5.2"
+  "upstreamVersion": "2026.5.7"
 }


### PR DESCRIPTION
Bumps the upstream version indicators to **v2026.5.7**, following the upstream sync merge in #2820:

- `README.md` upstream badge — release-tag URL, badge text, and alt text → `v2026.5.7`
- `package.json` `upstreamVersion` → `2026.5.7`

The #2820 sync squash didn't update these in-merge; this restores them to match the merged upstream boundary. Docs/metadata only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)