### PR TITLE
fix(whatsapp): keep QR login state in sync

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -424,8 +424,12 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
         timeoutMs,
         verbose,
       }),
-    loginWithQrWait: async ({ accountId, timeoutMs }) =>
-      await getWhatsAppRuntime().channel.whatsapp.waitForWebLogin({ accountId, timeoutMs }),
+    loginWithQrWait: async ({ accountId, timeoutMs, currentQrDataUrl }) =>
+      await getWhatsAppRuntime().channel.whatsapp.waitForWebLogin({
+        accountId,
+        timeoutMs,
+        currentQrDataUrl,
+      }),
     logoutAccount: async ({ account, runtime }) => {
       const cleared = await getWhatsAppRuntime().channel.whatsapp.logoutWeb({
         authDir: account.authDir,

--- a/extensions/whatsapp/src/login-qr.test.ts
+++ b/extensions/whatsapp/src/login-qr.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../../../src/runtime.js";
+
+vi.mock("./qr-image.js", () => ({
+  renderQrPngBase64: vi.fn(async (input: string) => `encoded:${input}`),
+}));
+
+vi.mock("./session.js", async () => {
+  const actual = await vi.importActual<typeof import("./session.js")>("./session.js");
+  return {
+    ...actual,
+    createWaSocket: vi.fn(),
+    waitForWaConnection: vi.fn(),
+    webAuthExists: vi.fn(async () => false),
+    readWebSelfId: vi.fn(() => ({ e164: null, jid: null })),
+    logoutWeb: vi.fn(async () => true),
+  };
+});
+
+vi.mock("./accounts.js", async () => {
+  const actual = await vi.importActual<typeof import("./accounts.js")>("./accounts.js");
+  return {
+    ...actual,
+    resolveWhatsAppAccount: vi.fn((params: { accountId?: string }) => ({
+      accountId: params.accountId ?? "default",
+      enabled: true,
+      sendReadReceipts: true,
+      authDir: `/tmp/wa-login-qr-test/${params.accountId ?? "default"}`,
+      isLegacyAuthDir: false,
+    })),
+  };
+});
+
+vi.mock("../../../src/config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../../src/config/config.js")>(
+    "../../../src/config/config.js",
+  );
+  return {
+    ...actual,
+    loadConfig: vi.fn(() => ({})),
+  };
+});
+
+import { startWebLoginWithQr, waitForWebLogin } from "./login-qr.js";
+import { createWaSocket, waitForWaConnection } from "./session.js";
+
+const createWaSocketMock = vi.mocked(createWaSocket);
+const waitForWaConnectionMock = vi.mocked(waitForWaConnection);
+
+// Silence the runtime logger so tests do not spam stdout.
+const runtime: RuntimeEnv = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+const RENDERED_QR = "data:image/png;base64,encoded:qr-data";
+
+async function flushTasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("waitForWebLogin QR sync guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createWaSocketMock
+      .mockReset()
+      .mockImplementation(
+        async (
+          _printQr: boolean,
+          _verbose: boolean,
+          opts?: { authDir?: string; onQr?: (qr: string) => void },
+        ) => {
+          const sock = { ws: { close: vi.fn() } };
+          if (opts?.onQr) {
+            setImmediate(() => opts.onQr?.("qr-data"));
+          }
+          return sock as never;
+        },
+      );
+    waitForWaConnectionMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports the connection when the caller's current QR matches the active QR", async () => {
+    const accountId = "qr-matches";
+    waitForWaConnectionMock.mockImplementationOnce(
+      () => new Promise((resolve) => setTimeout(() => resolve(undefined), 10)),
+    );
+
+    const start = await startWebLoginWithQr({ timeoutMs: 5000, accountId, runtime });
+    expect(start.qrDataUrl).toBe(RENDERED_QR);
+
+    await expect(
+      waitForWebLogin({
+        timeoutMs: 5000,
+        accountId,
+        currentQrDataUrl: start.qrDataUrl,
+        runtime,
+      }),
+    ).resolves.toEqual({
+      connected: true,
+      message: "✅ Linked! WhatsApp is ready.",
+    });
+  });
+
+  it("does not short-circuit when the waiter has no current QR image", async () => {
+    const accountId = "wait-without-current-qr";
+    waitForWaConnectionMock.mockImplementationOnce(
+      () => new Promise((resolve) => setTimeout(() => resolve(undefined), 10)),
+    );
+
+    const start = await startWebLoginWithQr({ timeoutMs: 5000, accountId, runtime });
+    expect(start.qrDataUrl).toBe(RENDERED_QR);
+
+    await expect(waitForWebLogin({ timeoutMs: 5000, accountId, runtime })).resolves.toEqual({
+      connected: true,
+      message: "✅ Linked! WhatsApp is ready.",
+    });
+  });
+
+  it("returns a QR-refresh result when the caller's current QR is stale", async () => {
+    const accountId = "stale-current-qr";
+    // Keep the connection pending so the login stays in the QR-wait state.
+    waitForWaConnectionMock.mockImplementationOnce(() => new Promise<void>(() => {}));
+
+    const start = await startWebLoginWithQr({ timeoutMs: 5000, accountId, runtime });
+    expect(start.qrDataUrl).toBe(RENDERED_QR);
+
+    await expect(
+      waitForWebLogin({
+        timeoutMs: 5000,
+        accountId,
+        currentQrDataUrl: "data:image/png;base64,stale-qr",
+        runtime,
+      }),
+    ).resolves.toEqual({
+      connected: false,
+      message: "QR refreshed. Scan the latest code in WhatsApp → Linked Devices.",
+      qrDataUrl: RENDERED_QR,
+    });
+  });
+
+  it("returns a terminal login result before a stale QR refresh", async () => {
+    const accountId = "connected-before-refresh";
+    waitForWaConnectionMock.mockResolvedValueOnce(undefined);
+
+    const start = await startWebLoginWithQr({ timeoutMs: 5000, accountId, runtime });
+    expect(start.qrDataUrl).toBe(RENDERED_QR);
+
+    // Let the login waiter resolve so the login is connected before we wait.
+    await flushTasks();
+
+    await expect(
+      waitForWebLogin({
+        timeoutMs: 5000,
+        accountId,
+        currentQrDataUrl: "data:image/png;base64,stale-qr",
+        runtime,
+      }),
+    ).resolves.toEqual({
+      connected: true,
+      message: "✅ Linked! WhatsApp is ready.",
+    });
+  });
+});

--- a/extensions/whatsapp/src/login-qr.ts
+++ b/extensions/whatsapp/src/login-qr.ts
@@ -216,8 +216,13 @@ export async function startWebLoginWithQr(
 }
 
 export async function waitForWebLogin(
-  opts: { timeoutMs?: number; runtime?: RuntimeEnv; accountId?: string } = {},
-): Promise<{ connected: boolean; message: string }> {
+  opts: {
+    timeoutMs?: number;
+    runtime?: RuntimeEnv;
+    accountId?: string;
+    currentQrDataUrl?: string;
+  } = {},
+): Promise<{ connected: boolean; message: string; qrDataUrl?: string }> {
   const runtime = opts.runtime ?? defaultRuntime;
   const cfg = loadConfig();
   const account = resolveWhatsAppAccount({ cfg, accountId: opts.accountId });
@@ -239,8 +244,26 @@ export async function waitForWebLogin(
   }
   const timeoutMs = Math.max(opts.timeoutMs ?? 120_000, 1000);
   const deadline = Date.now() + timeoutMs;
+  const currentQrDataUrl = opts.currentQrDataUrl;
 
   while (true) {
+    // Bound the wait to the caller's current QR: if the active login now holds a
+    // different QR image than the one the caller is displaying, tell them to
+    // re-scan the latest code instead of racing a stale QR. Terminal states
+    // (connected/error) are handled below and take priority over this refresh.
+    if (
+      !login.connected &&
+      !login.error &&
+      login.qrDataUrl &&
+      currentQrDataUrl &&
+      login.qrDataUrl !== currentQrDataUrl
+    ) {
+      return {
+        connected: false,
+        message: "QR refreshed. Scan the latest code in WhatsApp → Linked Devices.",
+        qrDataUrl: login.qrDataUrl,
+      };
+    }
     const remaining = deadline - Date.now();
     if (remaining <= 0) {
       return {

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -264,6 +264,7 @@ export type ChannelLoginWithQrStartResult = {
 export type ChannelLoginWithQrWaitResult = {
   connected: boolean;
   message: string;
+  qrDataUrl?: string;
 };
 
 export type ChannelLogoutContext<ResolvedAccount = unknown> = {


### PR DESCRIPTION
## Summary

Bounds the WhatsApp QR login-wait flow to the caller's *current* QR so a stale QR can no longer race the login state. If the active login has rotated to a different QR image than the one the caller is displaying, `waitForWebLogin` now returns a **"QR refreshed"** result (carrying the fresh `qrDataUrl`) instead of completing against the stale code — the caller is told to re-scan the latest QR. Terminal states (`connected` / `error`) are evaluated first and take priority over the refresh.

This is the WhatsApp-side portion of upstream `245451b6a9c` ("fix(whatsapp): keep QR login state in sync"). The heartbeat-ack UI portion of that fix landed separately in #2771.

## What changed

- **`extensions/whatsapp/src/login-qr.ts`** — `waitForWebLogin` accepts an optional `currentQrDataUrl` and, at the top of its wait loop, returns a "QR refreshed" result when the active login's `qrDataUrl` differs from the caller's. Terminal states are checked first. Return type gains `qrDataUrl?`.
- **`extensions/whatsapp/src/channel.ts`** — the `loginWithQrWait` adapter threads `currentQrDataUrl` through to `waitForWebLogin`.
- **`src/channels/plugins/types.adapters.ts`** — `ChannelLoginWithQrWaitResult` gains `qrDataUrl?` so the refreshed code flows type-cleanly to the clients that display it.
- **`extensions/whatsapp/src/login-qr.test.ts`** *(new)* — 4 tests: matching QR → connects; no current QR → connects; stale QR → "QR refreshed"; terminal connect wins over a stale-QR refresh.

## Scope note

Upstream's in-session QR-rotation / connection-controller machinery is not present in this codebase (no in-session rotation; no connection-controller or agent-tools-login call sites). This PR ports the behavioral guard that preserves the anti-stale-QR security property without that absent infrastructure.

## Verification

- `pnpm check` (format + typecheck + lint + custom lints): clean
- New `login-qr.test.ts`: 4/4 pass
- Sibling `login.test.ts` / `channel.test.ts`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #2770
