### PR TITLE
fix(command-auth): honor owner enforcement for commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Breaking
+
+- **Security — honor owner enforcement for commands
+  ([remoteclaw#2821](https://github.com/remoteclaw/remoteclaw/issues/2821)):**
+  When owner enforcement is on (the WhatsApp default) but no owner is resolvable,
+  command authorization now **denies** non-owner senders instead of authorizing
+  them. Previously, silently-insecure configurations — `channels.whatsapp.allowFrom:
+["*"]`, an empty/unset allowFrom, or `commands.allowFrom` opened to `"*"` — let any
+  sender run privileged commands (session reset, subagent spawn, TTS, status,
+  directives). This flips those setups from accepted to rejected. To keep public
+  command access, configure `commands.ownerAllowFrom: ["*"]` (or an explicit owner
+  list); an internal `operator.admin` session is still authorized. Restores upstream
+  OpenClaw #78864, dropped by a content-only sync when this fork's resolver had
+  structurally diverged.
+
 ## 0.1.0
 
 First RemoteClaw release. Forked from [OpenClaw v2026.2.25](https://github.com/openclaw/openclaw/releases/tag/v2026.2.25)

--- a/src/auto-reply/command-auth.owner-default.test.ts
+++ b/src/auto-reply/command-auth.owner-default.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { RemoteClawConfig } from "../config/config.js";
 import { resolveCommandAuthorization } from "./command-auth.js";
 import type { MsgContext } from "./templating.js";
@@ -184,5 +184,187 @@ describe("senderIsOwner only reflects explicit owner authorization", () => {
     });
 
     expect(auth.senderIsOwner).toBe(true);
+  });
+});
+
+// Owner enforcement (WhatsApp default enforceOwnerForCommands) must deny a
+// non-owner regardless of how permissive the allow-lists are. Restores the
+// guarantee from upstream OpenClaw #78864, whose literal diff a content-only
+// sync dropped because this fork's resolver is inlined rather than split into
+// upstream's resolveCommandSenderAuthorization helper. See remoteclaw#2821.
+describe("owner enforcement denies non-owner senders under WhatsApp (remoteclaw#2821)", () => {
+  it('denies a non-owner WhatsApp sender when channels.whatsapp.allowFrom is ["*"] (the CVE)', () => {
+    const cfg = {
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as RemoteClawConfig;
+
+    const ctx = {
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "direct",
+      From: "whatsapp:+14155559999",
+      SenderId: "+14155559999",
+      SenderE164: "+14155559999",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+    expect(auth.isAuthorizedSender).toBe(false);
+    expect(auth.senderIsOwner).toBe(false);
+  });
+
+  it("denies a non-owner WhatsApp sender when no allowFrom is configured at all", () => {
+    const cfg = {
+      channels: { whatsapp: {} },
+    } as RemoteClawConfig;
+
+    const ctx = {
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "direct",
+      From: "whatsapp:+14155559999",
+      SenderId: "+14155559999",
+      SenderE164: "+14155559999",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+    expect(auth.isAuthorizedSender).toBe(false);
+    expect(auth.senderIsOwner).toBe(false);
+  });
+
+  it('authorizes any WhatsApp sender when commands.ownerAllowFrom is ["*"]', () => {
+    // The discriminator a naive `!senderIsOwnerByIdentity` gate would fail: the
+    // sender is not an identity-matched owner, but ownerAllowFrom: ["*"] makes
+    // everyone an owner, so isOwnerForCommands is true and the gate must NOT deny.
+    const cfg = {
+      channels: { whatsapp: {} },
+      commands: { ownerAllowFrom: ["*"] },
+    } as RemoteClawConfig;
+
+    const ctx = {
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "direct",
+      From: "whatsapp:+14155559999",
+      SenderId: "+14155559999",
+      SenderE164: "+14155559999",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+    expect(auth.isAuthorizedSender).toBe(true);
+    expect(auth.senderIsOwner).toBe(true);
+  });
+
+  it("authorizes an internal operator.admin session even when an owner allowlist excludes it", () => {
+    // operator.admin scope is inherently an internal-provider path, so the
+    // whatsapp-only enforceOwner default is false here; owner enforcement is
+    // active via the configured allowlist. The scope must still pass — a naive
+    // `!senderIsOwnerByIdentity` gate (no identity match here) would wrongly deny.
+    const cfg = {
+      commands: { ownerAllowFrom: ["nonmatching-owner"] },
+    } as RemoteClawConfig;
+
+    const ctx = {
+      Provider: "webchat",
+      Surface: "webchat",
+      GatewayClientScopes: ["operator.admin"],
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+    expect(auth.isAuthorizedSender).toBe(true);
+    expect(auth.senderIsOwner).toBe(true);
+  });
+
+  it("denies an arbitrary WhatsApp sender when neither allowFrom nor ownerAllowFrom is set, but authorizes an identity-listed one", () => {
+    const arbitraryCtx = {
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "direct",
+      From: "whatsapp:+14155559999",
+      SenderId: "+14155559999",
+      SenderE164: "+14155559999",
+    } as MsgContext;
+
+    const failClosed = resolveCommandAuthorization({
+      ctx: arbitraryCtx,
+      cfg: { channels: { whatsapp: {} } } as RemoteClawConfig,
+      commandAuthorized: true,
+    });
+    expect(failClosed.isAuthorizedSender).toBe(false);
+
+    // Contrast: the same sender listed in channels.whatsapp.allowFrom is an owner
+    // by identity (matchedCommandOwner), so enforcement authorizes it.
+    const ownerCtx = {
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "direct",
+      From: "whatsapp:+14155550123",
+      SenderId: "+14155550123",
+      SenderE164: "+14155550123",
+    } as MsgContext;
+
+    const identityOwner = resolveCommandAuthorization({
+      ctx: ownerCtx,
+      cfg: { channels: { whatsapp: { allowFrom: ["+14155550123"] } } } as RemoteClawConfig,
+      commandAuthorized: true,
+    });
+    expect(identityOwner.isAuthorizedSender).toBe(true);
+  });
+
+  it('denies a non-owner even when commands.allowFrom opens commands to all ("*")', () => {
+    // Both-paths fidelity: enforcement must override commands.allowFrom too, not
+    // only the channel-allowFrom fallback path. Without the top-of-branch gate,
+    // commandsAllowAll would authorize this non-owner.
+    const cfg = {
+      channels: { whatsapp: {} },
+      commands: { allowFrom: { "*": ["*"] } },
+    } as RemoteClawConfig;
+
+    const ctx = {
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "direct",
+      From: "whatsapp:+14155559999",
+      SenderId: "+14155559999",
+      SenderE164: "+14155559999",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+    expect(auth.isAuthorizedSender).toBe(false);
+  });
+
+  it("warns operators to configure commands.ownerAllowFrom when enforcement locks everyone out", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const cfg = {
+        channels: { whatsapp: { allowFrom: ["*"] } },
+      } as RemoteClawConfig;
+
+      const ctx = {
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+        ChatType: "direct",
+        // Unique AccountId so the module-level dedup key does not collide with the
+        // other WhatsApp cliff cases in this file.
+        AccountId: "owner-enforcement-cliff-warn-fixture",
+        From: "whatsapp:+14155559999",
+        SenderId: "+14155559999",
+        SenderE164: "+14155559999",
+      } as MsgContext;
+
+      const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+      expect(auth.isAuthorizedSender).toBe(false);
+      expect(warnSpy).toHaveBeenCalled();
+      expect(
+        warnSpy.mock.calls.some((call) => String(call[0]).includes("commands.ownerAllowFrom")),
+      ).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -462,6 +462,26 @@ function resolveFallbackCommandOptions(providerId?: ChannelId): {
   };
 }
 
+// Deduplicates the fail-closed-cliff warning so a per-message denial does not spam
+// the logs. Keyed by provider + account: one warning per misconfigured shape.
+const ownerEnforcementCliffWarned = new Set<string>();
+
+function warnOwnerEnforcementCliff(
+  providerId: ChannelId | undefined,
+  accountId?: string | null,
+): void {
+  const key = `${providerId ?? ""}:${normalizeOptionalLowercaseString(accountId) ?? ""}`;
+  if (ownerEnforcementCliffWarned.has(key)) {
+    return;
+  }
+  ownerEnforcementCliffWarned.add(key);
+  console.warn(
+    `[command-auth] Owner enforcement is enabled for provider "${providerId ?? "unknown"}" but no ` +
+      `command owner is resolvable, so all commands are denied. Configure commands.ownerAllowFrom ` +
+      `(e.g. ["*"] for public command access, or an explicit owner list) to authorize senders.`,
+  );
+}
+
 export function resolveCommandAuthorization(params: {
   ctx: MsgContext;
   cfg: RemoteClawConfig;
@@ -590,12 +610,30 @@ export function resolveCommandAuthorization(params: {
       ? true
       : ownerAllowlistConfigured
         ? senderIsOwner
-        : allowAll || ownerCandidatesForCommands.length === 0 || Boolean(matchedCommandOwner);
+        : senderIsOwnerByScope || Boolean(matchedCommandOwner);
 
   // If commands.allowFrom is configured, use it for command authorization
   // Otherwise, fall back to existing behavior (channel allowFrom + owner checks)
   let isAuthorizedSender: boolean;
-  if (commandsAllowFromList !== null || (providerResolutionError && commandsAllowFromConfigured)) {
+  if (enforceOwner && !isOwnerForCommands) {
+    // Owner enforcement is on (e.g. the WhatsApp default) but the sender is not a
+    // resolved owner. Deny ahead of BOTH authorization paths so enforcement
+    // overrides even commands.allowFrom: ["*"] — a non-owner cannot escalate to
+    // privileged commands (session reset, subagent spawn, TTS, status, directives)
+    // via a permissive allowFrom. Restores upstream OpenClaw #78864 (owner
+    // enforcement for native commands), whose literal diff a content-only sync
+    // dropped because this fork's inlined resolver diverged from upstream's shape.
+    isAuthorizedSender = false;
+    if (ownerList.length === 0 && !senderIsOwnerByScope && !ownerAllowAll) {
+      // Fail-closed cliff: enforcement is on but no owner is configured at all, so
+      // every sender is denied. Point the operator at the remediation once per
+      // provider+account so a silently-locked-out deployment is diagnosable.
+      warnOwnerEnforcementCliff(providerId, ctx.AccountId);
+    }
+  } else if (
+    commandsAllowFromList !== null ||
+    (providerResolutionError && commandsAllowFromConfigured)
+  ) {
     // commands.allowFrom is configured - use it for authorization
     const commandsAllowAll =
       !providerResolutionError &&

--- a/src/auto-reply/reply/commands-subagents-spawn.test.ts
+++ b/src/auto-reply/reply/commands-subagents-spawn.test.ts
@@ -43,8 +43,15 @@ function forbiddenResult(error: string): SpawnSubagentResult {
   };
 }
 
+// ownerAllowFrom: ["*"] authorizes the fixture sender so these spawn-mechanics
+// tests run under the WhatsApp owner-enforcement default (enforceOwner). Without a
+// resolvable owner, the remoteclaw#2821 owner-enforcement gate denies the sender and
+// the command is silently ignored. This fixture is NOT testing authorization —
+// command-auth denial coverage lives in command-auth.owner-default.test.ts and the
+// "ignores unauthorized sender" test below. Do not drop this without re-homing that.
 const baseCfg = {
   session: { mainKey: "main", scope: "per-sender" },
+  commands: { ownerAllowFrom: ["*"] },
 } satisfies RemoteClawConfig;
 
 describe("/subagents spawn command", () => {


### PR DESCRIPTION
## Summary

Restores the owner-enforcement guarantee for commands: when owner enforcement is active (the WhatsApp default), only a **resolved owner** may run commands. A non-owner is now denied on **both** authorization paths — the channel-`allowFrom` fallback and the `commands.allowFrom` path.

This closes a command owner-enforcement bypass (OWASP A01). Upstream OpenClaw shipped the equivalent fix in [`cd070c2a49`](https://github.com/openclaw/openclaw/commit/cd070c2a49) ("Honor owner enforcement for native commands", OpenClaw #78864), but a content-only sync dropped its literal diff: this fork's authorization resolver is inlined and had structurally diverged from upstream's `resolveCommandSenderAuthorization` split, so the diff no longer applied and the fix silently regressed.

## The bug

Under owner enforcement, several silently-insecure configurations authorized **any** sender to run privileged commands (session reset, subagent spawn, TTS, status, directives):

- `channels.whatsapp.allowFrom: ["*"]`
- an empty or unset `allowFrom`
- `commands.allowFrom` opened to `"*"`

The fail-open lived in two places: a final authorization check that treated "no owner configured" as authorization, and the absence of any enforcement gate ahead of the `commands.allowFrom` path.

## The fix

Two-part gate in `resolveCommandAuthorization` (`src/auto-reply/command-auth.ts`):

1. **Close the fail-open owner check** — `isOwnerForCommands` no longer treats "no owner configured" as ownership; it requires an identity match, the `operator.admin` scope, or `ownerAllowFrom`.
2. **Deny ahead of both paths** — when `enforceOwner` is on and the sender is not an owner, authorization is denied before either the `commands.allowFrom` path or the channel-`allowFrom` fallback, so a permissive `commands.allowFrom: ["*"]` can no longer escalate a non-owner to privileged commands.

An **owner** is a sender matched by identity (`channels.<provider>.allowFrom`), by the `operator.admin` scope on the internal channel, or by `commands.ownerAllowFrom` (including `["*"]` for public command access). `operator.admin` sessions remain authorized.

## Breaking change + remediation

This flips previously-working owner-enforced deployments that have **no resolvable owner** from accepted to **rejected**. To restore command access, choose one of:

- `commands.ownerAllowFrom: ["*"]` — public command access, **or**
- an explicit owner list in `commands.ownerAllowFrom`, **or**
- add the operator's identity to `channels.<provider>.allowFrom`.

A deduped runtime warning (one per provider + account) points operators at `commands.ownerAllowFrom` when enforcement locks everyone out, and `CHANGELOG.md` carries a matching `Breaking` entry.

## Tests

- New owner-enforcement coverage in `command-auth.owner-default.test.ts`: bypass regression (the CVE), `ownerAllowFrom: ["*"]` pass-through, `operator.admin` scope pass-through, no-owner fail-closed + identity-owner contrast, and `commands.allowFrom: ["*"]` does **not** bypass enforcement.
- Mutation-verified: reverting the source makes exactly the new security assertions fail, and no others.
- Re-authorized the subagent-spawn mechanics fixture, which had relied on the insecure WhatsApp default (subagent spawn is one of the privileged commands the bypass exposed). Its command-auth denial path stays covered by the dedicated resolver tests and the existing "ignores unauthorized sender" test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #2821
