### PR TITLE
fix(mattermost): per-source rate limiting on the slash callback route

### DIFF
--- a/extensions/mattermost/src/mattermost/slash-state.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.test.ts
@@ -1,10 +1,33 @@
-import { describe, expect, it } from "vitest";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { PassThrough } from "node:stream";
+import {
+  type RemoteClawPluginApi,
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
+} from "remoteclaw/plugin-sdk/mattermost";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setMattermostRuntime } from "../runtime.js";
+import type { ResolvedMattermostAccount } from "./accounts.js";
 import type { MattermostRegisteredCommand } from "./slash-commands.js";
 import {
   activateSlashCommands,
   deactivateSlashCommands,
+  registerSlashCommandRoute,
   resolveSlashHandlerForToken,
 } from "./slash-state.js";
+
+const clientMocks = vi.hoisted(() => ({
+  fetchMattermostChannel: vi.fn(),
+}));
+
+// Mock only the network-touching channel lookup; keep the rest of client.js real
+// (createMattermostClient just builds an object — no network at construction).
+vi.mock("./client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client.js")>();
+  return {
+    ...actual,
+    fetchMattermostChannel: clientMocks.fetchMattermostChannel,
+  };
+});
 
 function registered(
   token: string,
@@ -51,5 +74,315 @@ describe("slash-state token routing", () => {
     const match = resolveSlashHandlerForToken("tok-shared");
     expect(match.kind).toBe("ambiguous");
     expect(match.accountIds?.toSorted()).toEqual(["a1", "a2"]);
+  });
+});
+
+// ── Per-source endpoint rate limiting on the slash callback route ─────────────
+
+const RATE_LIMIT = WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests;
+const CALLBACK_PATH = "/mm/slash";
+
+type RouteHandler = (req: IncomingMessage, res: ServerResponse) => Promise<void> | void;
+
+/**
+ * Build a minimal plugin API that captures the handler(s) registered by
+ * registerSlashCommandRoute so a test can drive them directly (no HTTP server —
+ * mirrors how slash-http.test.ts exercises the per-account handler).
+ */
+function createRouteApi(overrides?: { gateway?: unknown }): {
+  api: RemoteClawPluginApi;
+  getHandler: (path?: string) => RouteHandler;
+} {
+  const handlers = new Map<string, RouteHandler>();
+  const api = {
+    id: "mattermost",
+    name: "mattermost",
+    source: "test",
+    config: {
+      channels: { mattermost: { commands: { callbackPath: CALLBACK_PATH } } },
+      gateway: overrides?.gateway,
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    registerHttpRoute: (params: { path: string; handler: RouteHandler }) => {
+      handlers.set(params.path, params.handler);
+    },
+  } as unknown as RemoteClawPluginApi;
+  return {
+    api,
+    getHandler: (path = CALLBACK_PATH) => {
+      const handler = handlers.get(path);
+      if (!handler) {
+        throw new Error(`no handler registered for ${path}`);
+      }
+      return handler;
+    },
+  };
+}
+
+function createReq(params: {
+  method?: string;
+  body?: string;
+  contentType?: string;
+  remoteAddress?: string;
+}): IncomingMessage {
+  const stream = new PassThrough();
+  const req = stream as unknown as IncomingMessage;
+  req.method = params.method ?? "POST";
+  req.url = CALLBACK_PATH;
+  req.headers = {
+    "content-type": params.contentType ?? "application/x-www-form-urlencoded",
+  };
+  (req as unknown as { socket: { remoteAddress?: string } }).socket = {
+    remoteAddress: params.remoteAddress ?? "10.0.0.1",
+  };
+  process.nextTick(() => {
+    if (params.body) {
+      stream.write(params.body);
+    }
+    stream.end();
+  });
+  return req;
+}
+
+function createRes(): {
+  res: ServerResponse;
+  status: () => number;
+  body: () => string;
+  headers: Map<string, string>;
+} {
+  const headers = new Map<string, string>();
+  let body = "";
+  const res = {
+    statusCode: 200,
+    setHeader(name: string, value: string) {
+      headers.set(name.toLowerCase(), value);
+    },
+    end(chunk?: string | Buffer) {
+      body = chunk != null ? String(chunk) : "";
+    },
+  } as unknown as ServerResponse;
+  return { res, status: () => res.statusCode, body: () => body, headers };
+}
+
+function slashBody(token: string): string {
+  return new URLSearchParams({
+    token,
+    team_id: "t1",
+    channel_id: "c1",
+    user_id: "u1",
+    command: "/oc_status",
+    text: "",
+  }).toString();
+}
+
+function activate(accountId: string, tokens: string[]): void {
+  activateSlashCommands({
+    account: {
+      accountId,
+      baseUrl: "https://chat.example.com",
+      botToken: "bot-token",
+    } as unknown as ResolvedMattermostAccount,
+    registeredCommands: tokens.map((token, index) =>
+      registered(token, { id: `${accountId}-${index}` }),
+    ),
+    api: { cfg: {} as any, runtime: {} as any },
+  });
+}
+
+describe("slash callback rate limiting", () => {
+  beforeEach(() => {
+    deactivateSlashCommands();
+    clientMocks.fetchMattermostChannel.mockReset();
+    clientMocks.fetchMattermostChannel.mockResolvedValue(null);
+    // A non-throwing runtime is enough: with fetchMattermostChannel → null the
+    // authorization flow returns before it dereferences the runtime.
+    setMattermostRuntime({} as never);
+  });
+
+  afterEach(() => {
+    deactivateSlashCommands();
+  });
+
+  it("(a) bounds a pre-auth flood from one source with 429, not 401", async () => {
+    activate("a1", ["known-token"]);
+    const { api, getHandler } = createRouteApi();
+    registerSlashCommandRoute(api);
+    const handler = getHandler();
+
+    let saw401 = false;
+    let saw429 = false;
+    for (let i = 0; i < RATE_LIMIT + 10; i += 1) {
+      const res = createRes();
+      await handler(createReq({ body: slashBody(`bad-${i}`), remoteAddress: "10.0.0.1" }), res.res);
+      if (res.status() === 429) {
+        saw429 = true;
+        expect(res.body()).toBe("Too Many Requests");
+        break;
+      }
+      // Under the limit an invalid token is rejected by auth (401) — proving the
+      // 429 above is the rate gate firing *before* auth, not the auth path.
+      expect(res.status()).toBe(401);
+      saw401 = true;
+    }
+
+    expect(saw401).toBe(true);
+    expect(saw429).toBe(true);
+  });
+
+  it("(b) keys the budget by source, not by token", async () => {
+    const { api, getHandler } = createRouteApi();
+    registerSlashCommandRoute(api);
+    const handler = getHandler();
+
+    // Exhaust source A's budget using a different garbage token every request.
+    let exhausted = false;
+    for (let i = 0; i < RATE_LIMIT + 5; i += 1) {
+      const res = createRes();
+      await handler(
+        createReq({ body: slashBody(`tokenA-${i}`), remoteAddress: "10.0.0.1" }),
+        res.res,
+      );
+      if (res.status() === 429) {
+        exhausted = true;
+        break;
+      }
+    }
+    expect(exhausted).toBe(true);
+
+    // A brand-new token from the SAME source is still limited (token-agnostic key).
+    const sameSource = createRes();
+    await handler(
+      createReq({ body: slashBody("a-different-token"), remoteAddress: "10.0.0.1" }),
+      sameSource.res,
+    );
+    expect(sameSource.status()).toBe(429);
+
+    // A DIFFERENT source has an independent budget.
+    const otherSource = createRes();
+    await handler(
+      createReq({ body: slashBody("whatever"), remoteAddress: "10.9.9.9" }),
+      otherSource.res,
+    );
+    expect(otherSource.status()).not.toBe(429);
+  });
+
+  it("(c) returns a neutral 429 that is byte-identical for valid and invalid tokens", async () => {
+    activate("a1", ["valid-token"]);
+    const { api, getHandler } = createRouteApi();
+    registerSlashCommandRoute(api);
+    const handler = getHandler();
+
+    for (let i = 0; i < RATE_LIMIT + 1; i += 1) {
+      const res = createRes();
+      await handler(createReq({ body: slashBody(`bad-${i}`), remoteAddress: "10.0.0.1" }), res.res);
+    }
+
+    const validRes = createRes();
+    await handler(
+      createReq({ body: slashBody("valid-token"), remoteAddress: "10.0.0.1" }),
+      validRes.res,
+    );
+    const invalidRes = createRes();
+    await handler(
+      createReq({ body: slashBody("nope"), remoteAddress: "10.0.0.1" }),
+      invalidRes.res,
+    );
+
+    expect(validRes.status()).toBe(429);
+    expect(invalidRes.status()).toBe(429);
+    expect(validRes.body()).toBe("Too Many Requests");
+    expect(validRes.body()).toBe(invalidRes.body());
+    // The rate gate precedes auth, so the valid token never reached the API.
+    expect(clientMocks.fetchMattermostChannel).not.toHaveBeenCalled();
+  });
+
+  it("(d) spends no rate budget on non-POST requests (method pre-gate)", async () => {
+    const { api, getHandler } = createRouteApi();
+    registerSlashCommandRoute(api);
+    const handler = getHandler();
+
+    for (let i = 0; i < 20; i += 1) {
+      const res = createRes();
+      await handler(createReq({ method: "GET", remoteAddress: "10.0.0.1" }), res.res);
+      expect(res.status()).toBe(405);
+      expect(res.headers.get("allow")).toBe("POST");
+    }
+
+    // A full burst of exactly maxRequests POSTs from the same source still all
+    // pass the rate gate — impossible if the 20 GETs had consumed any budget.
+    let saw429 = false;
+    for (let i = 0; i < RATE_LIMIT; i += 1) {
+      const res = createRes();
+      await handler(createReq({ body: slashBody(`x-${i}`), remoteAddress: "10.0.0.1" }), res.res);
+      if (res.status() === 429) {
+        saw429 = true;
+      }
+    }
+    expect(saw429).toBe(false);
+  });
+
+  it("(e) increments the source budget exactly once per multi-account replay", async () => {
+    activate("a1", ["token-a"]);
+    activate("a2", ["token-b"]); // ≥2 accounts → the buffer/replay path is used
+    const { api, getHandler } = createRouteApi();
+    registerSlashCommandRoute(api);
+    const handler = getHandler();
+
+    // maxRequests valid requests (token matches account B) from ONE source. If
+    // the buffer/replay double-counted, a 429 would appear before request #max.
+    for (let i = 0; i < RATE_LIMIT; i += 1) {
+      const res = createRes();
+      await handler(createReq({ body: slashBody("token-b"), remoteAddress: "10.0.0.1" }), res.res);
+      expect(res.status()).not.toBe(429);
+    }
+    // The (maxRequests + 1)-th request is the first to exceed the budget → 429.
+    const overflow = createRes();
+    await handler(
+      createReq({ body: slashBody("token-b"), remoteAddress: "10.0.0.1" }),
+      overflow.res,
+    );
+    expect(overflow.status()).toBe(429);
+
+    // The replay actually reached account B's handler on the routed requests.
+    expect(clientMocks.fetchMattermostChannel).toHaveBeenCalled();
+  });
+
+  it("(f) does not drop legitimate volume at or below the limit", async () => {
+    const { api, getHandler } = createRouteApi();
+    registerSlashCommandRoute(api);
+    const handler = getHandler();
+
+    for (let i = 0; i < RATE_LIMIT; i += 1) {
+      const res = createRes();
+      await handler(createReq({ body: slashBody(`ok-${i}`), remoteAddress: "10.0.0.1" }), res.res);
+      expect(res.status()).not.toBe(429);
+    }
+  });
+
+  it("(g) preserves Layer-1: invalid token → 401 with no API call; valid token routes", async () => {
+    activate("a1", ["valid-token"]);
+    const { api, getHandler } = createRouteApi();
+    registerSlashCommandRoute(api);
+    const handler = getHandler();
+
+    // Invalid token, under the limit → 401 with no Mattermost channel lookup.
+    const invalid = createRes();
+    await handler(
+      createReq({ body: slashBody("wrong-token"), remoteAddress: "10.0.0.1" }),
+      invalid.res,
+    );
+    expect(invalid.status()).toBe(401);
+    expect(clientMocks.fetchMattermostChannel).not.toHaveBeenCalled();
+
+    // Valid token → routes past the token gate into the authorization flow
+    // (reaches the channel lookup). It is neither auth-rejected nor rate-limited.
+    const valid = createRes();
+    await handler(
+      createReq({ body: slashBody("valid-token"), remoteAddress: "10.0.0.1" }),
+      valid.res,
+    );
+    expect(valid.status()).not.toBe(401);
+    expect(valid.status()).not.toBe(429);
+    expect(clientMocks.fetchMattermostChannel).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -11,11 +11,16 @@
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
+  applyBasicWebhookRequestGuards,
+  createFixedWindowRateLimiter,
   isRequestBodyLimitError,
   readRequestBodyWithLimit,
+  type RemoteClawConfig,
   type RemoteClawPluginApi,
   requestBodyErrorToText,
+  resolveRequestClientIp,
   safeEqualSecret,
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
 } from "remoteclaw/plugin-sdk/mattermost";
 import type { ResolvedMattermostAccount } from "./accounts.js";
 import { resolveSlashCommandConfig, type MattermostRegisteredCommand } from "./slash-commands.js";
@@ -143,6 +148,28 @@ export function deactivateSlashCommands(accountId?: string) {
 }
 
 /**
+ * Resolve the per-source rate-limit key for a slash callback request.
+ *
+ * Keyed by `${callbackPath}:${clientIp}` so each registered callback path gets
+ * an isolated budget per client IP. When trusted proxies are configured the
+ * forwarded client IP is used; otherwise the socket peer address. Falls back to
+ * "unknown" when no address can be resolved (still bounded — a shared bucket).
+ */
+function resolveSlashCallbackRateLimitKey(
+  req: IncomingMessage,
+  callbackPath: string,
+  config?: RemoteClawConfig,
+): string {
+  const clientIp =
+    resolveRequestClientIp(
+      req,
+      config?.gateway?.trustedProxies,
+      config?.gateway?.allowRealIpFallback === true,
+    ) ?? "unknown";
+  return `${callbackPath}:${clientIp}`;
+}
+
+/**
  * Register the HTTP route for slash command callbacks.
  * Called during plugin registration.
  *
@@ -190,7 +217,38 @@ export function registerSlashCommandRoute(api: RemoteClawPluginApi) {
     addCallbackPaths(accountCommandsRaw);
   }
 
-  const routeHandler = async (req: IncomingMessage, res: ServerResponse) => {
+  // One per-source fixed-window limiter shared across every registered callback
+  // path. Keying by `${callbackPath}:${clientIp}` isolates each path's budget
+  // per source while a single instance bounds total tracked keys.
+  const slashCallbackRateLimiter = createFixedWindowRateLimiter({
+    windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs,
+    maxRequests: WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests,
+    maxTrackedKeys: WEBHOOK_RATE_LIMIT_DEFAULTS.maxTrackedKeys,
+  });
+
+  const handleSlashCallback = async (
+    req: IncomingMessage,
+    res: ServerResponse,
+    callbackPath: string,
+  ) => {
+    // Bound the externally reachable callback route per source before any body
+    // read or token routing. The method pre-check (405) runs before the rate
+    // check, so non-POST probes spend no budget; invalid-token floods and
+    // slow-drip clients are counted in the same window as any later request
+    // from that source. Mirrors the telegram/feishu/zalo/googlechat guards.
+    // No content-type gate: Mattermost callbacks are form-urlencoded or JSON.
+    if (
+      !applyBasicWebhookRequestGuards({
+        req,
+        res,
+        allowMethods: ["POST"],
+        rateLimiter: slashCallbackRateLimiter,
+        rateLimitKey: resolveSlashCallbackRateLimitKey(req, callbackPath, api.config),
+      })
+    ) {
+      return;
+    }
+
     if (accountStates.size === 0) {
       res.statusCode = 503;
       res.setHeader("Content-Type", "application/json; charset=utf-8");
@@ -311,7 +369,7 @@ export function registerSlashCommandRoute(api: RemoteClawPluginApi) {
     api.registerHttpRoute({
       path: callbackPath,
       auth: "plugin",
-      handler: routeHandler,
+      handler: (req, res) => handleSlashCallback(req, res, callbackPath),
     });
   }
 }

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -78,11 +78,21 @@ export {
   readRequestBodyWithLimit,
   requestBodyErrorToText,
 } from "../infra/http-body.js";
+export {
+  createFixedWindowRateLimiter,
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
+} from "./webhook-memory-guards.js";
+export { applyBasicWebhookRequestGuards } from "./webhook-request-guards.js";
 export { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 export { rawDataToString } from "../infra/ws.js";
 export { redactSensitiveText } from "../logging/redact.js";
 export { safeEqualSecret } from "../security/secret-equal.js";
-export { isLoopbackHost, isTrustedProxyAddress, resolveClientIp } from "../gateway/net.js";
+export {
+  isLoopbackHost,
+  isTrustedProxyAddress,
+  resolveClientIp,
+  resolveRequestClientIp,
+} from "../gateway/net.js";
 export { registerPluginHttpRoute } from "../plugins/http-registry.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export type { PluginRuntime } from "../plugins/runtime/types.js";


### PR DESCRIPTION
## Summary

Adds per-source endpoint rate limiting to the externally reachable Mattermost slash-command callback route, closing the last request-frequency gap left by the earlier hardening in #2819.

The slash callback validates command tokens **synchronously and locally** — a constant-time compare against the in-memory `registeredCommands` set, with **zero network** per validation. #2819 already added per-command constant-time token comparison, body size/time limits, and log redaction. What remained unbounded was request **frequency**: a single source could flood the endpoint with token guesses or hold slow-drip connections with no per-source cap.

## What this changes

`registerSlashCommandRoute` now wires the callback route into the shared webhook-guard toolkit — the exact per-source fixed-window limiter that `telegram` / `feishu` / `zalo` / `googlechat` already use:

- One `createFixedWindowRateLimiter` (from the webhook-memory-guards toolkit) shared across all registered callback paths.
- `applyBasicWebhookRequestGuards({ allowMethods: ["POST"], rateLimiter, rateLimitKey })` applied at the **single route entrypoint**, before any body read or token routing.
- Rate-limit key = `` `${callbackPath}:${clientIp}` `` (client IP resolved with trusted-proxy awareness), so the budget is **per source**, independent of the token presented.
- No content-type gate — Mattermost callbacks are form-urlencoded **or** JSON.

### Guard invariants

- **Pre-auth:** the rate check runs before token validation, so invalid-token floods and slow-drip clients are bounded in the same window as any later request from that source.
- **Method pre-gate:** the `405` method check runs before the rate check, so non-POST probes spend no budget.
- **Single-count:** the guard lives only in the route entrypoint, never in the per-account handler, so the multi-account buffer/replay path counts each inbound request exactly once.
- **Neutral 429:** a rate-limited response is a bare `429 Too Many Requests`, byte-identical for valid and invalid tokens (no validity oracle).

## Relationship to upstream

Upstream OpenClaw #72923 (commit `9c0975c1c20`) hardened the analogous slash path with a **validation failure cache**, **live-API token re-validation**, and **lookup rate limiting**.

The failure-cache and live-API-re-validation pieces are **architecturally moot** here: this project validates slash tokens **locally** against the in-memory `registeredCommands` (constant-time, no network), whereas upstream **re-fetches per validation** and so needs to cache failures and throttle the lookup path. The only piece that applies to a local-validation design is **request-frequency limiting on the externally reachable route**, which this PR adds via the shared toolkit above.

## Not included (possible follow-up)

The in-flight **concurrency** limiter (`beginWebhookRequestPipelineOrReject`) is not adopted here. Bounding concurrent in-flight callbacks per source would be a reasonable defense-in-depth follow-up, but is out of scope for this focused change.

## Tests

Adds 7 rate-limiting tests driven through the registered route handler (mirroring the telegram webhook tests' within-window flood approach — real timers, `maxRequests + N` burst):

- Pre-auth flood from one source -> `429` (not `401`)
- Budget keyed by source, not token (differing tokens share the bucket; a different source has its own)
- Neutral `429` byte-identical for valid vs invalid token, with no Mattermost API call
- Non-POST requests spend no budget (method pre-gate)
- Multi-account buffer/replay increments the source budget exactly once per request
- Legitimate volume at/below the limit is never dropped
- Layer-1 non-regression: invalid token -> `401` with no API call; valid token still routes

Closes #2818