### PR TITLE
fix(command-auth): make silent non-owner command denials diagnosable

### DIFF
--- a/src/auto-reply/command-auth.owner-default.test.ts
+++ b/src/auto-reply/command-auth.owner-default.test.ts
@@ -1,8 +1,33 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RemoteClawConfig } from "../config/config.js";
 import { resolveCommandAuthorization } from "./command-auth.js";
 import type { MsgContext } from "./templating.js";
 import { installDiscordRegistryHooks } from "./test-helpers/command-auth-registry-fixture.js";
+
+// Replaces the subsystem logger so the silent-denial debug diagnostic
+// (remoteclaw#2825) is observable regardless of the ambient console/file log
+// level — `debug` is off by default, so asserting against the real logger's
+// console/file output would require raising the level just to observe the call.
+// Mirrors the established pattern in src/agents/tool-images.log.test.ts.
+const { debugMock } = vi.hoisted(() => ({
+  debugMock: vi.fn(),
+}));
+
+vi.mock("../logging/subsystem.js", () => {
+  const makeLogger = () => ({
+    subsystem: "command-auth",
+    isEnabled: () => true,
+    trace: vi.fn(),
+    debug: debugMock,
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: () => makeLogger(),
+  });
+  return { createSubsystemLogger: () => makeLogger() };
+});
 
 installDiscordRegistryHooks();
 
@@ -365,6 +390,188 @@ describe("owner enforcement denies non-owner senders under WhatsApp (remoteclaw#
       ).toBe(true);
     } finally {
       warnSpy.mockRestore();
+    }
+  });
+});
+
+describe("silent-denial diagnostic (remoteclaw#2825)", () => {
+  beforeEach(() => {
+    debugMock.mockClear();
+  });
+
+  it("emits a rate-limited debug diagnostic naming provider + denied sender when an owner IS configured", () => {
+    const cfg = {
+      channels: { whatsapp: {} },
+      commands: { ownerAllowFrom: ["+14155550042"] },
+    } as RemoteClawConfig;
+
+    const ctx = {
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "direct",
+      AccountId: "silent-denial-diagnostic-fixture",
+      From: "whatsapp:+14155559999",
+      SenderId: "+14155559999",
+      SenderE164: "+14155559999",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+    expect(auth.isAuthorizedSender).toBe(false);
+    expect(auth.senderIsOwner).toBe(false);
+    expect(debugMock).toHaveBeenCalledTimes(1);
+    const [message, meta] = debugMock.mock.calls[0];
+    expect(String(message)).toContain("whatsapp");
+    expect(String(message)).toContain("+14155559999");
+    expect(meta).toMatchObject({ providerId: "whatsapp", senderId: "+14155559999" });
+  });
+
+  it("still fires the fail-closed cliff console.warn exactly once for the no-owner case, and never the new diagnostic", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const cfg = {
+        channels: { whatsapp: { allowFrom: ["*"] } },
+      } as RemoteClawConfig;
+
+      const ctx = {
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+        ChatType: "direct",
+        // Unique AccountId so the module-level dedup key does not collide with the
+        // other WhatsApp cliff cases in this file.
+        AccountId: "silent-denial-diagnostic-cliff-unchanged-fixture",
+        From: "whatsapp:+14155559999",
+        SenderId: "+14155559999",
+        SenderE164: "+14155559999",
+      } as MsgContext;
+
+      // Call twice: the cliff console.warn dedups per-key (process-lifetime), so
+      // this also demonstrates the "exactly once" behavior is unchanged by the
+      // new diagnostic code path.
+      resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+      const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+      expect(auth.isAuthorizedSender).toBe(false);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0][0])).toContain("commands.ownerAllowFrom");
+      expect(debugMock).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("does not emit the denial diagnostic for an authorized owner (identity, operator.admin scope, or wildcard ownerAllowFrom)", () => {
+    // identity match: sender IS the configured owner.
+    const identityCfg = {
+      channels: { whatsapp: {} },
+      commands: { ownerAllowFrom: ["+14155550042"] },
+    } as RemoteClawConfig;
+
+    const identityCtx = {
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "direct",
+      AccountId: "silent-denial-diagnostic-identity-owner-fixture",
+      From: "whatsapp:+14155550042",
+      SenderId: "+14155550042",
+      SenderE164: "+14155550042",
+    } as MsgContext;
+
+    const identityAuth = resolveCommandAuthorization({
+      ctx: identityCtx,
+      cfg: identityCfg,
+      commandAuthorized: true,
+    });
+
+    expect(identityAuth.isAuthorizedSender).toBe(true);
+    expect(debugMock).not.toHaveBeenCalled();
+
+    // operator.admin scope: internal channel sender authorized via GatewayClientScopes.
+    const scopeCfg = {
+      commands: { ownerAllowFrom: ["nonmatching-owner"] },
+    } as RemoteClawConfig;
+
+    const scopeCtx = {
+      Provider: "webchat",
+      Surface: "webchat",
+      GatewayClientScopes: ["operator.admin"],
+    } as MsgContext;
+
+    const scopeAuth = resolveCommandAuthorization({
+      ctx: scopeCtx,
+      cfg: scopeCfg,
+      commandAuthorized: true,
+    });
+
+    expect(scopeAuth.isAuthorizedSender).toBe(true);
+    expect(debugMock).not.toHaveBeenCalled();
+
+    // wildcard ownerAllowFrom: every sender is authorized as owner.
+    const wildcardCfg = {
+      channels: { whatsapp: {} },
+      commands: { ownerAllowFrom: ["*"] },
+    } as RemoteClawConfig;
+
+    const wildcardCtx = {
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "direct",
+      AccountId: "silent-denial-diagnostic-wildcard-owner-fixture",
+      From: "whatsapp:+14155559999",
+      SenderId: "+14155559999",
+      SenderE164: "+14155559999",
+    } as MsgContext;
+
+    const wildcardAuth = resolveCommandAuthorization({
+      ctx: wildcardCtx,
+      cfg: wildcardCfg,
+      commandAuthorized: true,
+    });
+
+    expect(wildcardAuth.isAuthorizedSender).toBe(true);
+    expect(debugMock).not.toHaveBeenCalled();
+  });
+
+  it("rate-limits repeated denials from the same provider+account within the window to at most one diagnostic", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+      const cfg = {
+        channels: { whatsapp: {} },
+        commands: { ownerAllowFrom: ["+14155550042"] },
+      } as RemoteClawConfig;
+
+      const ctx = {
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+        ChatType: "direct",
+        AccountId: "silent-denial-diagnostic-ratelimit-fixture",
+        From: "whatsapp:+14155559999",
+        SenderId: "+14155559999",
+        SenderE164: "+14155559999",
+      } as MsgContext;
+
+      resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+      resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+      resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+      expect(debugMock).toHaveBeenCalledTimes(1);
+
+      // Still inside the same 60s window: no additional diagnostic.
+      vi.setSystemTime(new Date("2026-01-01T00:00:59.000Z"));
+      resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+      expect(debugMock).toHaveBeenCalledTimes(1);
+
+      // Past the window: the throttle rolls over and the still-ongoing denial is
+      // diagnosable again.
+      vi.setSystemTime(new Date("2026-01-01T00:01:01.000Z"));
+      resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+      expect(debugMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
     }
   });
 });

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -470,13 +470,15 @@ function resolveFallbackCommandOptions(providerId?: ChannelId): {
 // Deduplicates the fail-closed-cliff warning so a per-message denial does not spam
 // the logs. Keyed by provider + account: one warning per misconfigured shape.
 //
-// This dedup is process-lifetime by design and never reset or pruned: the fork has
-// no runtime config hot-reload path (no watchConfig/reloadConfig/onConfigChange —
-// config is loaded once at startup), so a fail-closed cliff for a given key cannot
-// be newly *created* mid-process — the misconfigured shape (owner enforcement on,
-// no resolvable owner) that caused it is fixed for the lifetime of the process. The
-// only way the misconfiguration changes is a process restart, which also clears
-// this Set, so a still-misconfigured restarted process correctly warns again.
+// This dedup is process-lifetime by design and never reset or pruned. It gates only
+// log emission — never authorization — so a stale entry can at worst suppress a
+// repeat warning, never change an authz outcome. The fork DOES support runtime config
+// hot-reload (startGatewayConfigReloader, wired in gateway/server.impl.ts via
+// onHotReload; default gateway.reload.mode "hybrid"), so the cliff shape (owner
+// enforcement on, no resolvable owner) CAN arise mid-process. That is still handled
+// correctly: the first cliff denial for an as-yet-unwarned key always warns (this Set
+// only suppresses repeats). Accepted gap: a config fix -> re-break cycle for the SAME
+// key within one process will not re-warn until a restart (which also clears this Set).
 const ownerEnforcementCliffWarned = new Set<string>();
 
 function warnOwnerEnforcementCliff(

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -3,6 +3,11 @@ import type { ChannelId, ChannelPlugin } from "../channels/plugins/types.js";
 import { normalizeAnyChannelId } from "../channels/registry.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import {
+  createFixedWindowRateLimiter,
+  type FixedWindowRateLimiter,
+} from "../infra/fixed-window-rate-limit.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -464,6 +469,14 @@ function resolveFallbackCommandOptions(providerId?: ChannelId): {
 
 // Deduplicates the fail-closed-cliff warning so a per-message denial does not spam
 // the logs. Keyed by provider + account: one warning per misconfigured shape.
+//
+// This dedup is process-lifetime by design and never reset or pruned: the fork has
+// no runtime config hot-reload path (no watchConfig/reloadConfig/onConfigChange —
+// config is loaded once at startup), so a fail-closed cliff for a given key cannot
+// be newly *created* mid-process — the misconfigured shape (owner enforcement on,
+// no resolvable owner) that caused it is fixed for the lifetime of the process. The
+// only way the misconfiguration changes is a process restart, which also clears
+// this Set, so a still-misconfigured restarted process correctly warns again.
 const ownerEnforcementCliffWarned = new Set<string>();
 
 function warnOwnerEnforcementCliff(
@@ -479,6 +492,46 @@ function warnOwnerEnforcementCliff(
     `[command-auth] Owner enforcement is enabled for provider "${providerId ?? "unknown"}" but no ` +
       `command owner is resolvable, so all commands are denied. Configure commands.ownerAllowFrom ` +
       `(e.g. ["*"] for public command access, or an explicit owner list) to authorize senders.`,
+  );
+}
+
+const log = createSubsystemLogger("command-auth");
+
+// Rate-limits the silent-denial diagnostic below (logDeniedNonOwnerSender) so a
+// spraying sender cannot flood the logs once an operator turns debug logging on.
+// `debug` is level-gated off by default (see SubsystemLogger), so production is
+// quiet already; this throttle only bounds the opt-in case where debug is enabled
+// to investigate a denial. Keyed by provider + account — the same small, bounded
+// cardinality as the cliff dedup key above — rather than by sender: a sender
+// identifier is attacker-influenced, so a per-sender Set/Map would let a spraying
+// sender grow it without bound. Unlike the cliff dedup, this is a genuine
+// time-windowed throttle, not a permanent one: at most one diagnostic per key per
+// window, then the window rolls over so a later, still-ongoing denial for that key
+// is diagnosable again.
+const DENIED_SENDER_LOG_WINDOW_MS = 60_000;
+const deniedSenderLogLimiters = new Map<string, FixedWindowRateLimiter>();
+
+function logDeniedNonOwnerSender(params: {
+  providerId: ChannelId | undefined;
+  accountId?: string | null;
+  senderId?: string;
+}): void {
+  const key = `${params.providerId ?? ""}:${normalizeOptionalLowercaseString(params.accountId) ?? ""}`;
+  let limiter = deniedSenderLogLimiters.get(key);
+  if (!limiter) {
+    limiter = createFixedWindowRateLimiter({
+      maxRequests: 1,
+      windowMs: DENIED_SENDER_LOG_WINDOW_MS,
+    });
+    deniedSenderLogLimiters.set(key, limiter);
+  }
+  if (!limiter.consume().allowed) {
+    return;
+  }
+  log.debug(
+    `Denied command from non-owner sender "${params.senderId ?? "unknown"}" for provider ` +
+      `"${params.providerId ?? "unknown"}"`,
+    { providerId: params.providerId, accountId: params.accountId, senderId: params.senderId },
   );
 }
 
@@ -629,6 +682,12 @@ export function resolveCommandAuthorization(params: {
       // every sender is denied. Point the operator at the remediation once per
       // provider+account so a silently-locked-out deployment is diagnosable.
       warnOwnerEnforcementCliff(providerId, ctx.AccountId);
+    } else {
+      // An owner IS configured — this is normal enforcement correctly denying a
+      // non-owner sender, not a misconfiguration, so this is a debug diagnostic
+      // rather than the warn-level cliff above. Rate-limited so a spraying sender
+      // cannot flood the logs when debug is enabled (see logDeniedNonOwnerSender).
+      logDeniedNonOwnerSender({ providerId, accountId: ctx.AccountId, senderId });
     }
   } else if (
     commandsAllowFromList !== null ||


### PR DESCRIPTION
## Summary

Observability-only follow-up to #2824, resolving #2825.

#2824 restored owner enforcement for native commands: when `enforceOwner` is on (the WhatsApp default) and the sender isn't a resolved owner, the resolver denies the command. Today that denial logs a `console.warn` in exactly one case — the fail-closed cliff, where **no owner is configured at all** and every sender is denied. The far more common case — an owner **is** configured, and a **non-owner** sender's command is silently dropped — logs nothing. An operator asking "why is the bot ignoring commands from user X?" gets zero signal.

This PR makes that silent path diagnosable without changing what gets authorized.

## What changed

`src/auto-reply/command-auth.ts`:

- Added a module-scope subsystem logger (`createSubsystemLogger("command-auth")`), matching the pattern used elsewhere in `auto-reply`/`infra`/`middleware`.
- Added an `else` branch alongside the existing fail-closed-cliff check, in the `enforceOwner && !isOwnerForCommands` denial path:
  - Cliff case (`ownerList.length === 0 && !senderIsOwnerByScope && !ownerAllowAll`, unchanged): still logs via `console.warn`, exactly as #2824 left it.
  - New case (an owner **is** configured, this sender just isn't it): emits a `debug`-level diagnostic naming the provider and the denied sender candidate. `debug` sits below `warn` because this is normal enforcement working as intended, not a misconfiguration.
  - The new diagnostic is rate-limited to one log per `provider:account` key per 60-second window (same key shape as the existing cliff dedup), so a spraying sender can't flood logs once an operator turns debug logging on. `debug` is disabled by default, so production log volume is unaffected unless debug is explicitly enabled to investigate a denial.
- Extended the comment above the cliff-warning dedup (`ownerEnforcementCliffWarned`) to document its lifetime decision: it is process-lifetime by design, never reset or pruned. This is safe because the dedup gates **log emission only, never authorization** — a stale entry can at worst suppress a repeat warning, never change an authz outcome. The fork does support runtime config hot-reload (`startGatewayConfigReloader`), so the cliff shape can arise mid-process; that is handled correctly because the first cliff denial for an as-yet-unwarned key always warns (the set only suppresses repeats). Accepted gap: a config fix → re-break cycle for the same key within one process won't re-warn until a restart.

`src/auto-reply/command-auth.owner-default.test.ts`: added a `describe("silent-denial diagnostic (#2825)", ...)` block covering the acceptance criteria below.

## No authorization-outcome change

Every branch condition that decides `isAuthorizedSender` is byte-for-byte unchanged — this PR only adds a logging call inside the pre-existing `else` of the pre-existing `if`. The 3 pre-existing `console.warn` calls from #2824 are untouched (not migrated to the new logger); that's a deliberate boundary so this PR can't be read as touching #2824's warning behavior.

## Acceptance criteria (from #2825)

- [x] A non-owner command denial under `enforceOwner` **with an owner configured** emits a diagnosable, rate-limited log (below `warn`) identifying provider + denied sender candidate.
- [x] The existing fail-closed cliff `console.warn` (no owner configured at all) is unchanged — still fires once for that case.
- [x] The cliff-warning dedup behavior is decided and documented: kept intentionally process-lifetime, with a code comment stating that intent (the third of the three options #2825 offered).
- [x] Tests: (a) non-owner denial with a configured owner produces the diagnostic log; (b) the cliff warning still fires exactly once for the no-owner case, and the new diagnostic never fires in that case; (c) an authorized owner — by identity, by `operator.admin` scope, and by wildcard `commands.ownerAllowFrom: ["*"]` — produces no denial log; (d) repeated denials from the same provider+account within the 60s window emit the diagnostic at most once, and a later denial after the window rolls over is diagnosed again.

## Testing

- `pnpm tsgo` — clean, no errors.
- `pnpm vitest run src/auto-reply/command-auth` — 19 passed (19), including the 4 new cases above.
- `pnpm oxlint --type-aware` on both touched files — 0 warnings, 0 errors.
- `pnpm oxfmt --write` applied to both touched files.
